### PR TITLE
[Literal Expressions] Add support for simple constant-folded literal expressions

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2709,9 +2709,8 @@ public:
   Expr *getInit(unsigned i) const {
     return getPatternList()[i].getInit();
   }
-  Expr *getExecutableInit(unsigned i) const {
-    return getPatternList()[i].getExecutableInit();
-  }
+  bool hasSingleVarConstantFoldedInit() const;
+  Expr *getExecutableInit(unsigned i) const;
   Expr *getOriginalInit(unsigned i) const {
     return getPatternList()[i].getOriginalInit();
   }

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -823,31 +823,37 @@ ERROR(expect_compile_time_literal,none,
       "expect a compile-time constant literal", ())
 
 ERROR(const_unsupported_enum_associated_value,none,
-      "enums with associated values not supported in a constant expression", ())
+      "enums with associated values not supported in a literal expression", ())
 ERROR(const_unsupported_operator,none,
-      "unsupported operator in a constant expression", ())
+      "unsupported operator in a literal expression", ())
 ERROR(const_unsupported_type,none,
-      "unsupported type in a constant expression", ())
+      "unsupported type in a literal expression", ())
 ERROR(const_unsupported_type_expr,none,
-      "type expressions not supported in a constant expression", ())
+      "type expressions not supported in a literal expression", ())
 ERROR(const_unsupported_closure,none,
-      "closures not supported in a constant expression", ())
+      "closures not supported in a literal expression", ())
 ERROR(const_unsupported_closure_with_captures,none,
-      "closures with captures not supported in a constant expression", ())
+      "closures with captures not supported in a literal expression", ())
 ERROR(const_unsupported_keypath,none,
-      "keypaths not supported in a constant expression", ())
+      "keypaths not supported in a literal expression", ())
 ERROR(const_opaque_decl_ref,none,
-      "unable to resolve variable reference in a constant expression", ())
+      "unable to resolve variable reference in a literal expression", ())
 ERROR(const_opaque_func_decl_ref,none,
-      "unable to resolve function reference in a constant expression", ())
+      "unable to resolve function reference in a literal expression", ())
 ERROR(const_non_convention_c_conversion,none,
-      "only 'convention(c)' function values are supported in a constant expression", ())
+      "only 'convention(c)' function values are supported in a literal expression", ())
 ERROR(const_opaque_callee,none,
-      "unable to resolve callee in a constant expression", ())
+      "unable to resolve callee in a literal expression", ())
 ERROR(const_non_const_param,none,
-      "reference to a non-'@const' parameter in a constant expression", ())
+      "reference to a non-'@const' parameter in a literal expression", ())
+ERROR(const_integer_overflow,none,
+      "operation results in integer overflow", ())
+ERROR(const_divide_by_zero,none,
+      "division by zero", ())
 ERROR(const_unknown_default,none,
-      "not supported in a constant expression", ())
+      "not supported in a literal expression", ())
+NOTE(const_failed_fold_declref_init,none,
+     "requested from reference in a literal expression", ())
 
 //------------------------------------------------------------------------------
 // MARK: Import Resolution

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -5020,6 +5020,24 @@ public:
 bool isCached() const { return true; }
 };
 
+/// A request to constant-fold an expression node
+class ConstantFoldExpression
+: public SimpleRequest<ConstantFoldExpression,
+                       Expr *(const Expr *, ASTContext *),
+                       RequestFlags::Cached> {
+public:
+using SimpleRequest::SimpleRequest;
+
+private:
+friend SimpleRequest;
+
+Expr *
+evaluate(Evaluator &evaluator, const Expr *expr, ASTContext *ctx) const;
+
+public:
+bool isCached() const { return true; }
+};
+
 /// Check @c enums for compatibility with C.
 class TypeCheckCDeclEnumRequest
     : public SimpleRequest<TypeCheckCDeclEnumRequest,

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -674,3 +674,7 @@ SWIFT_REQUEST(TypeChecker, EmitPerformanceHints,
 SWIFT_REQUEST(TypeChecker, DesugarForEachStmtRequest,
               BraceStmt *(ForEachStmt *),
               SeparatelyCached, NoLocationInfo)
+
+SWIFT_REQUEST(TypeChecker, ConstantFoldExpression,
+              Expr *(const Expr *, ASTContext *),
+              Cached, NoLocationInfo)

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -1114,6 +1114,12 @@ public:
   /// on macOS or Foundation on Linux.
   bool isCGFloat();
 
+  /// Check if this is an integer type coming from the Swift module
+  bool isStdlibInteger();
+
+  /// Check if this is a floating-point type coming from the Swift module
+  bool isStdlibFloat();
+
   /// Check if this is a ObjCBool type from the Objective-C module.
   bool isObjCBool();
 

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -529,8 +529,12 @@ EXPERIMENTAL_FEATURE(ConcurrencySyntaxSugar, true)
 /// Allow declaration of compile-time values
 EXPERIMENTAL_FEATURE(CompileTimeValues, true)
 
-/// Allow declaration of compile-time values
+/// Allow declaration of compile-time values bypassing
+/// syntactic legality checking
 EXPERIMENTAL_FEATURE(CompileTimeValuesPreview, false)
+
+/// Allow use of literal expressions as literals
+EXPERIMENTAL_FEATURE(LiteralExpressions, true)
 
 /// Allow function body macros applied to closures.
 EXPERIMENTAL_FEATURE(ClosureBodyMacro, true)

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2793,9 +2793,12 @@ namespace {
                     printRec(PBD->getOriginalInit(idx),
                              Label::always("original_init"));
                   }
-                  if (PBD->getInit(idx)) {
+                  if (auto initExpr = PBD->getInit(idx)) {
                     printRec(PBD->getInit(idx),
                              Label::always("processed_init"));
+                    if (PBD->hasSingleVarConstantFoldedInit())
+                      printRec(PBD->getExecutableInit(idx),
+                               Label::always("processed_constant_folded_init"));
                   }
 
                   printFoot();

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2785,6 +2785,20 @@ VarDecl *PatternBindingDecl::getAnchoringVarDecl(unsigned i) const {
   return getPatternList()[i].getAnchoringVarDecl();
 }
 
+bool PatternBindingDecl::hasSingleVarConstantFoldedInit() const {
+  auto *singleVar = getSingleVar();
+  return singleVar && singleVar->isConstValue() &&
+         getASTContext().LangOpts.hasFeature(Feature::LiteralExpressions);
+}
+
+Expr *PatternBindingDecl::getExecutableInit(unsigned i) const {
+  auto idxInit = getPatternList()[i].getExecutableInit();
+  if (auto &ctx = getASTContext(); idxInit && hasSingleVarConstantFoldedInit())
+    return evaluateOrDefault(ctx.evaluator,
+                             ConstantFoldExpression{idxInit, &ctx}, {});
+  return idxInit;
+}
+
 bool VarDecl::isInitExposedToClients() const {
   // 'lazy' initializers are emitted inside the getter, which is never
   // @inlinable.

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -360,10 +360,6 @@ static bool usesFeatureCompileTimeValues(Decl *decl) {
          decl->getAttrs().hasAttribute<ConstInitializedAttr>();
 }
 
-static bool usesFeatureCompileTimeValuesPreview(Decl *decl) {
-  return false;
-}
-
 static bool usesFeatureClosureBodyMacro(Decl *decl) {
   return false;
 }
@@ -372,6 +368,8 @@ static bool usesFeatureBuiltinConcurrencyStackNesting(Decl *decl) {
   return false;
 }
 
+UNINTERESTING_FEATURE(CompileTimeValuesPreview)
+UNINTERESTING_FEATURE(LiteralExpressions)
 UNINTERESTING_FEATURE(StrictMemorySafety)
 UNINTERESTING_FEATURE(LibraryEvolution)
 UNINTERESTING_FEATURE(SafeInteropWrappers)

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1300,6 +1300,15 @@ bool TypeBase::isCGFloat() {
          NTD->getName().is("CGFloat");
 }
 
+bool TypeBase::isStdlibInteger() {
+  return isInt() || isInt8() || isInt16() || isInt32() || isInt64() ||
+         isUInt() || isUInt8() || isUInt16() || isUInt32() || isUInt64();
+}
+
+bool TypeBase::isStdlibFloat() {
+  return isFloat() || isDouble() || isFloat80();
+}
+
 bool TypeBase::isObjCBool() {
   auto *NTD = getAnyNominal();
   if (!NTD)

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -25,6 +25,7 @@
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/PropertyWrappers.h"
 #include "swift/AST/ProtocolConformance.h"
+#include "swift/AST/TypeCheckRequests.h"
 #include "swift/Basic/Platform.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/ProfileCounter.h"

--- a/lib/Sema/CMakeLists.txt
+++ b/lib/Sema/CMakeLists.txt
@@ -40,7 +40,8 @@ add_swift_host_library(swiftSema STATIC
   DerivedConformance/DerivedConformanceRawRepresentable.cpp
   ImportResolution.cpp
   InstrumenterSupport.cpp
-  LegalConstExprVerifier.cpp
+  LegalLiteralExprVerifier.cpp
+  LiteralExpressionFolding.cpp
   LookupVisibleDecls.cpp
   MiscDiagnostics.cpp
   OpenedExistentials.cpp

--- a/lib/Sema/ConstantnessSemaDiagnostics.cpp
+++ b/lib/Sema/ConstantnessSemaDiagnostics.cpp
@@ -26,6 +26,7 @@
 
 #include "MiscDiagnostics.h"
 #include "TypeChecker.h"
+#include "LiteralExpressionFolding.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/ParameterList.h"
@@ -207,19 +208,6 @@ static Expr *checkConstantness(Expr *expr) {
   return nullptr;
 }
 
-/// Return true iff the given \p type is a Stdlib integer type.
-static bool isIntegerType(Type type) {
-  return type->isInt() || type->isInt8() || type->isInt16() ||
-         type->isInt32() || type->isInt64() || type->isUInt() ||
-         type->isUInt8() || type->isUInt16() || type->isUInt32() ||
-         type->isUInt64();
-}
-
-/// Return true iff the given \p type is a Float type.
-static bool isFloatType(Type type) {
-  return type->isFloat() || type->isDouble() || type->isFloat80();
-}
-
 /// Given an error expression \p errorExpr, diagnose the error based on the type
 /// of the expression. For instance, if the expression's type is expressible by
 /// a literal e.g. integer, boolean etc. report that it must be a literal.
@@ -256,11 +244,11 @@ static void diagnoseError(Expr *errorExpr, const ASTContext &astContext,
     diags.diagnose(errorLoc, diag::oslog_arg_must_be_string_literal);
     return;
   }
-  if (isIntegerType(exprType)) {
+  if (exprType->isStdlibInteger()) {
     diags.diagnose(errorLoc, diag::oslog_arg_must_be_integer_literal);
     return;
   }
-  if (isFloatType(exprType)) {
+  if (exprType->isStdlibFloat()) {
     diags.diagnose(errorLoc, diag::oslog_arg_must_be_float_literal);
     return;
   }

--- a/lib/Sema/LiteralExpressionFolding.cpp
+++ b/lib/Sema/LiteralExpressionFolding.cpp
@@ -1,0 +1,523 @@
+//===--- LiteralExpressionFolding.cpp - -------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  Simple AST-based evaluator of supported literal expressions
+//
+//===----------------------------------------------------------------------===//
+
+#include "LiteralExpressionFolding.h"
+#include "MiscDiagnostics.h"
+#include "TypeChecker.h"
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/ASTWalker.h"
+#include "swift/AST/TypeCheckRequests.h"
+#include "swift/Basic/Unreachable.h"
+
+using namespace swift;
+using namespace LiteralExprFolding;
+
+namespace {
+
+class FoldingError : public llvm::ErrorInfo<FoldingError> {
+public:
+  static char ID;
+  IllegalConstError code;
+  SourceLoc sourceLocation;
+  FoldingError(IllegalConstError code) : code(code), sourceLocation() {}
+  FoldingError(IllegalConstError code, SourceLoc loc)
+      : code(code), sourceLocation(loc) {}
+  void log(llvm::raw_ostream &OS) const override {
+    OS << "Const Folding Error: "
+       << static_cast<std::underlying_type<IllegalConstError>::type>(code);
+  }
+  std::error_code convertToErrorCode() const override {
+    return llvm::inconvertibleErrorCode();
+  }
+};
+char FoldingError::ID = 0;
+
+static unsigned getTargetPointerBitWidth(ASTContext &ctx) {
+  // Matching the compiler's determination of the
+  // `#if _pointerBitWidth` value.
+  if (ctx.LangOpts.Target.isArch16Bit())
+    return 16;
+  else if (ctx.LangOpts.Target.isArch32Bit())
+    return 32;
+  else if (ctx.LangOpts.Target.isArch64Bit())
+    return 64;
+  swift_unreachable("Unsupported platform kind.");
+}
+
+/// Get the bitwidth for a Swift integer type for constant folding.
+/// Returns 0 if the type is not a known integer type.
+static unsigned getIntegerBitWidth(Type type, ASTContext &ctx) {
+  assert(type->isStdlibInteger());
+  // Map stdlib integer types to their bitwidths
+  if (type->isInt())
+    return getTargetPointerBitWidth(ctx);
+  if (type->isInt64())
+    return 64;
+  if (type->isInt32())
+    return 32;
+  if (type->isInt16())
+    return 16;
+  if (type->isInt8())
+    return 8;
+
+  if (type->isUInt())
+    return getTargetPointerBitWidth(ctx);
+  if (type->isUInt64())
+    return 64;
+  if (type->isUInt32())
+    return 32;
+  if (type->isUInt16())
+    return 16;
+  if (type->isUInt8())
+    return 8;
+
+  swift_unreachable("Unsupported integer type.");
+}
+
+static ConcreteDeclRef getIntTypeBuiltinInit(Type type, ASTContext &ctx) {
+  assert(type->isStdlibInteger());
+  // Map stdlib integer types to their bitwidths
+  if (type->isInt())
+    return ctx.getIntBuiltinInitDecl(ctx.getIntDecl());
+  if (type->isInt64())
+    return ctx.getIntBuiltinInitDecl(ctx.getInt64Decl());
+  if (type->isInt32())
+    return ctx.getIntBuiltinInitDecl(ctx.getInt32Decl());
+  if (type->isInt16())
+    return ctx.getIntBuiltinInitDecl(ctx.getInt16Decl());
+  if (type->isInt8())
+    return ctx.getIntBuiltinInitDecl(ctx.getInt8Decl());
+
+  if (type->isUInt())
+    return ctx.getIntBuiltinInitDecl(ctx.getUIntDecl());
+  if (type->isUInt64())
+    return ctx.getIntBuiltinInitDecl(ctx.getUInt64Decl());
+  if (type->isUInt32())
+    return ctx.getIntBuiltinInitDecl(ctx.getUInt32Decl());
+  if (type->isUInt16())
+    return ctx.getIntBuiltinInitDecl(ctx.getUInt16Decl());
+  if (type->isUInt8())
+    return ctx.getIntBuiltinInitDecl(ctx.getUInt8Decl());
+
+  swift_unreachable("Unsupported integer type.");
+}
+
+/// Check if the type is a signed integer type
+static bool isSignedIntegerType(Type type) {
+  return type->isInt() || type->isInt64() || type->isInt32() ||
+         type->isInt16() || type->isInt8();
+}
+
+/// A move-only value that's either a `FoldingError` or some parameterized type
+/// value `T`. A convenience wrapper around `TaggedUnion<T, FoldingError>`.
+template <typename T>
+class FoldingErrorOr {
+  TaggedUnion<T, FoldingError> Value;
+
+public:
+  FoldingErrorOr() : Value(FoldingError(IllegalConstError::Default)) {}
+  FoldingErrorOr(T &&t) : Value(std::move(t)) {}
+  FoldingErrorOr(const FoldingError &fe) : Value(fe) {}
+
+  FoldingErrorOr(FoldingErrorOr &&other) : Value(std::move(other.Value)) {}
+  FoldingErrorOr &operator=(FoldingErrorOr &&other) noexcept {
+    if (this != &other)
+      Value = std::move(other.Value);
+    return *this;
+  }
+
+  FoldingErrorOr(const FoldingErrorOr &) = delete;
+  FoldingErrorOr &operator=(const FoldingErrorOr &) = delete;
+
+  const T *operator->() const { return Value.template dyn_cast<T>(); }
+  FoldingError getError() const {
+    return *Value.template dyn_cast<FoldingError>();
+  }
+  bool isError() const {
+    return Value.template dyn_cast<FoldingError>() != nullptr;
+  }
+
+  /// Return false if there is an error.
+  explicit operator bool() const { return !isError(); }
+};
+
+class ConstantValue {
+public:
+  enum class ConstantValueKind : int8_t {
+    FirstKind,
+    Integer = FirstKind,
+    FloatingPoint,
+    LastKind = FloatingPoint + 1
+  };
+
+  const ConstantValueKind kind;
+  ConstantValue(ConstantValueKind kind) : kind(kind) {}
+  virtual ~ConstantValue() = default;
+  ConstantValueKind getKind() const { return kind; }
+};
+using ConstantValuePtr = std::unique_ptr<ConstantValue>;
+
+class IntegerValue : public ConstantValue {
+  APInt value;
+  bool isSigned;
+
+public:
+  IntegerValue(APInt value, bool isSigned)
+      : ConstantValue(ConstantValueKind::Integer), value(value),
+        isSigned(isSigned) {}
+
+  APInt getValue() const { return value; }
+  bool getIsSigned() const { return isSigned; }
+
+  static bool classof(const ConstantValue *base) {
+    return base->getKind() == ConstantValueKind::Integer;
+  }
+};
+
+/// A simple constant expression folder to simplify
+/// binary expressions of integer type consisting of literal
+/// value operands.
+class ConstantFolder {
+  ASTContext &Ctx;
+
+public:
+  ConstantFolder(ASTContext &ctx) : Ctx(ctx) {}
+  Expr *fold(const Expr *expr) {
+    // If this expression failed to type-check, no need to attempt to
+    // fold it since we likely won't be able to do anything meaningful
+    // here.
+    if (!expr->getType() || expr->getType()->getAs<ErrorType>()) {
+      emitFoldingErrorDiagnostic(
+          FoldingError(IllegalConstError::UpstreamError, expr->getStartLoc()));
+      return nullptr;
+    }
+
+    ConstantWalker walker(Ctx);
+    const_cast<Expr *>(expr)->walk(walker);
+    ASSERT(walker.hasConstantValueFor(expr) &&
+           "No value or error computed by constant-folding AST walker");
+    const auto &result = walker.getConstantValueOrErrorFor(expr);
+    if (result)
+      return createIntegerLiteralExpr(expr, result->get());
+    else {
+      emitFoldingErrorDiagnostic(result.getError());
+      return nullptr;
+    }
+  }
+
+private:
+  class ConstantWalker : public ASTWalker {
+    ASTContext &Ctx;
+    llvm::DenseMap<Expr *, FoldingErrorOr<ConstantValuePtr>>
+        ConstValuesOrErrors;
+
+  public:
+    ConstantWalker(ASTContext &ctx) : Ctx(ctx) {}
+
+    PostWalkResult<Expr *> walkToExprPost(Expr *expr) override {
+      ConstValuesOrErrors.insert({expr, tryFoldExpression(expr)});
+      return Action::Continue(expr);
+    }
+
+    bool hasConstantValueFor(const Expr *expr) {
+      return ConstValuesOrErrors.contains(expr);
+    }
+
+    const FoldingErrorOr<ConstantValuePtr> &
+    getConstantValueOrErrorFor(const Expr *expr) {
+      ASSERT(ConstValuesOrErrors.contains(expr) &&
+             "Querying constant value for an unfolded expression.");
+      return ConstValuesOrErrors.at(expr);
+    }
+
+  private:
+    FoldingErrorOr<ConstantValuePtr> tryFoldExpression(const Expr *expr) {
+      if (auto *literalExpr = dyn_cast<LiteralExpr>(expr))
+        return tryFoldLiteralExpression(literalExpr);
+      else if (auto *binaryExpr = dyn_cast<BinaryExpr>(expr))
+        return tryFoldBinaryExpr(binaryExpr);
+      else if (auto *unaryExpr = dyn_cast<PrefixUnaryExpr>(expr))
+        return tryFoldUnaryExpr(unaryExpr);
+      else if (auto *parenExpr = dyn_cast<ParenExpr>(expr))
+        return tryFoldParenExpr(parenExpr);
+      else if (auto *declRefExpr = dyn_cast<DeclRefExpr>(expr))
+        return foldDeclRefExpr(declRefExpr);
+      else
+        return FoldingError(IllegalConstError::Default, expr->getLoc());
+    }
+
+    FoldingErrorOr<ConstantValuePtr>
+    tryFoldLiteralExpression(const LiteralExpr *expr) {
+      if (auto *intLiteralExpr = dyn_cast<IntegerLiteralExpr>(expr))
+        return foldIntegerLiteralExpr(intLiteralExpr);
+      else
+        return FoldingError(IllegalConstError::Default, expr->getLoc());
+    }
+
+    ConstantValuePtr foldIntegerLiteralExpr(const IntegerLiteralExpr *expr) {
+      auto exprType = expr->getType();
+      auto value = expr->getValue();
+      auto resultBitWidth = getIntegerBitWidth(exprType, Ctx);
+      if (isSignedIntegerType(exprType))
+        return std::make_unique<IntegerValue>(value.sextOrTrunc(resultBitWidth),
+                                              true);
+      else
+        return std::make_unique<IntegerValue>(value.zextOrTrunc(resultBitWidth),
+                                              false);
+    }
+
+    FoldingErrorOr<ConstantValuePtr> tryFoldBinaryExpr(const BinaryExpr *expr) {
+      if (!expr->getType()->isStdlibInteger())
+        return FoldingError(IllegalConstError::TypeNotSupported,
+                            expr->getStartLoc());
+      if (!supportedOperator(expr))
+        return FoldingError(IllegalConstError::UnsupportedBinaryOperator,
+                            expr->getStartLoc());
+
+      if (const auto &lhsOrErr = getConstantValueOrErrorFor(expr->getLHS())) {
+        if (const auto &rhsOrErr = getConstantValueOrErrorFor(expr->getRHS())) {
+          auto lhsIntPtr = cast<IntegerValue>(lhsOrErr->get());
+          auto rhsIntPtr = cast<IntegerValue>(rhsOrErr->get());
+          auto operatorDecl = expr->getCalledValue();
+          auto operatorIdentifier = operatorDecl->getBaseName().getIdentifier();
+          if (operatorIdentifier.isArithmeticOperator())
+            return tryFoldIntegerBinaryArithmeticOperator(
+                operatorIdentifier, expr->getLoc(), lhsIntPtr, rhsIntPtr);
+          else if (operatorIdentifier.isBitwiseOperator() ||
+                   operatorIdentifier.isShiftOperator())
+            return tryFoldIntegerBinaryBitwiseOperator(
+                operatorIdentifier, expr->getLoc(), lhsIntPtr, rhsIntPtr);
+          else
+            llvm_unreachable("Unsupported operator");
+        } else
+          return rhsOrErr.getError();
+      } else
+        return lhsOrErr.getError();
+    }
+
+    FoldingErrorOr<ConstantValuePtr>
+    tryFoldUnaryExpr(const PrefixUnaryExpr *expr) {
+      if (!expr->getType()->isStdlibInteger())
+        return FoldingError(IllegalConstError::TypeNotSupported,
+                            expr->getLoc());
+      if (!supportedOperator(expr))
+        return FoldingError(IllegalConstError::UnsupportedBinaryOperator,
+                            expr->getLoc());
+
+      const auto &operandOrErr = getConstantValueOrErrorFor(expr->getOperand());
+      if (operandOrErr) {
+        auto operatorIdentifier =
+            expr->getCalledValue()->getBaseName().getIdentifier();
+        return tryFoldIntegerUnaryArithmeticOperator(
+            operatorIdentifier, expr->getLoc(),
+            cast<IntegerValue>(operandOrErr->get()));
+      } else
+        return operandOrErr.getError();
+    }
+
+    FoldingErrorOr<ConstantValuePtr> tryFoldParenExpr(const ParenExpr *expr) {
+      const auto &operandOrErr = getConstantValueOrErrorFor(expr->getSubExpr());
+      if (operandOrErr) {
+        auto *intValue = cast<IntegerValue>(operandOrErr->get());
+        return ConstantValuePtr(std::make_unique<IntegerValue>(
+            intValue->getValue(), intValue->getIsSigned()));
+      } else
+        return operandOrErr.getError();
+    }
+
+    FoldingErrorOr<ConstantValuePtr> foldDeclRefExpr(const DeclRefExpr *expr) {
+      if (const VarDecl *varDecl = dyn_cast<VarDecl>(expr->getDecl())) {
+        // For other `@const` or `@section` values, we expect
+        // their initializer to be foldable. For other values which
+        // have a default value, we attempt to fold the
+        // corresponding initializer expression.
+        if (varDecl->isConstValue() || varDecl->hasInitialValue())
+          if (auto initExpr = varDecl->getParentInitializer())
+            return tryFoldDeclRefInitializerExpr(initExpr, expr->getLoc());
+
+        // Clang constants are imported as a ValueDecl
+        // with simple getter returning a literal value.
+        if (varDecl->hasClangNode() && !varDecl->isDynamic() &&
+            !varDecl->isObjC() &&
+            varDecl->getImplInfo().getReadImpl() == ReadImplKind::Get)
+          if (auto accessor = varDecl->getAccessor(AccessorKind::Get))
+            if (auto singleRetStmt = dyn_cast<ReturnStmt>(
+                    accessor->getBody()->getSingleActiveStatement()))
+              return tryFoldDeclRefInitializerExpr(singleRetStmt->getResult(),
+                                                   expr->getLoc());
+      }
+
+      return FoldingError(IllegalConstError::OpaqueDeclRef, expr->getLoc());
+    }
+
+    FoldingErrorOr<ConstantValuePtr>
+    tryFoldDeclRefInitializerExpr(const Expr *expr, SourceLoc referenceLoc) {
+      bool previouslyFolded =
+          Ctx.evaluator.hasCachedResult(ConstantFoldExpression{expr, &Ctx});
+      // Request the init expression of this declaration to be
+      // constant-folded.
+      if (auto foldedLiteralExpr =
+              dyn_cast<LiteralExpr>(swift::foldLiteralExpression(expr, &Ctx)))
+        return tryFoldLiteralExpression(foldedLiteralExpr);
+      // If this is the first time we have requested to constant-fold this
+      // declaration's initializer and have failed to do so, emit a note
+      // with a location of the declRef from which we initiated this query.
+      else if (!previouslyFolded)
+        return FoldingError(IllegalConstError::NonConstDeclRef, referenceLoc);
+      return FoldingError(IllegalConstError::OpaqueDeclRef, referenceLoc);
+    }
+
+    FoldingErrorOr<ConstantValuePtr> tryFoldIntegerBinaryArithmeticOperator(
+        Identifier operatorIdentifier, SourceLoc sourceLocation,
+        const IntegerValue *lhsVal, const IntegerValue *rhsVal) {
+      assert((lhsVal->getIsSigned() && rhsVal->getIsSigned()) ||
+             (!lhsVal->getIsSigned() && !rhsVal->getIsSigned()));
+      bool isSigned = lhsVal->getIsSigned();
+      auto lhsInt = lhsVal->getValue();
+      auto rhsInt = rhsVal->getValue();
+      APInt result;
+      bool overflow = false;
+      if (operatorIdentifier.is("+"))
+        result = isSigned ? lhsInt.sadd_ov(rhsInt, overflow)
+                          : lhsInt.uadd_ov(rhsInt, overflow);
+      else if (operatorIdentifier.is("-"))
+        result = isSigned ? lhsInt.ssub_ov(rhsInt, overflow)
+                          : lhsInt.usub_ov(rhsInt, overflow);
+      else if (operatorIdentifier.is("*"))
+        result = isSigned ? lhsInt.smul_ov(rhsInt, overflow)
+                          : lhsInt.umul_ov(rhsInt, overflow);
+      else if (operatorIdentifier.is("/")) {
+        if (rhsInt == 0)
+          return FoldingError(IllegalConstError::DivideByZero, sourceLocation);
+        result =
+            isSigned ? lhsInt.sdiv_ov(rhsInt, overflow) : lhsInt.udiv(rhsInt);
+      } else if (operatorIdentifier.is("%")) {
+        if (rhsInt == 0)
+          return FoldingError(IllegalConstError::DivideByZero, sourceLocation);
+        if (isSigned) // Check for overflow
+          auto divResult = lhsInt.sdiv_ov(rhsInt, overflow);
+        result = isSigned ? lhsInt.srem(rhsInt) : lhsInt.urem(rhsInt);
+      } else
+        return FoldingError(IllegalConstError::UnsupportedBinaryOperator,
+                            sourceLocation);
+
+      if (overflow)
+        return FoldingError(IllegalConstError::IntegerOverflow, sourceLocation);
+
+      return ConstantValuePtr(std::make_unique<IntegerValue>(result, isSigned));
+    }
+
+    FoldingErrorOr<ConstantValuePtr> tryFoldIntegerBinaryBitwiseOperator(
+        Identifier operatorIdentifier, SourceLoc sourceLocation,
+        const IntegerValue *lhsVal, const IntegerValue *rhsVal) {
+      assert((lhsVal->getIsSigned() && rhsVal->getIsSigned()) ||
+             (!lhsVal->getIsSigned() && !rhsVal->getIsSigned()));
+      bool isSigned = lhsVal->getIsSigned();
+      auto lhsInt = lhsVal->getValue();
+      auto rhsInt = rhsVal->getValue();
+      APInt result;
+      if (operatorIdentifier.is("&"))
+        result = lhsInt & rhsInt;
+      else if (operatorIdentifier.is("|"))
+        result = lhsInt | rhsInt;
+      else if (operatorIdentifier.is("^"))
+        result = lhsInt ^ rhsInt;
+      else if (operatorIdentifier.is("<<"))
+        result = lhsInt << rhsInt;
+      else if (operatorIdentifier.is(">>"))
+        result = lhsInt.lshr(rhsInt);
+      else
+        return FoldingError(IllegalConstError::UnsupportedBinaryOperator,
+                            sourceLocation);
+
+      return ConstantValuePtr(std::make_unique<IntegerValue>(result, isSigned));
+    }
+
+    FoldingErrorOr<ConstantValuePtr>
+    tryFoldIntegerUnaryArithmeticOperator(Identifier operatorIdentifier,
+                                          SourceLoc sourceLocation,
+                                          const IntegerValue *operandVal) {
+      APInt result;
+      auto operand = operandVal->getValue();
+      bool overflow = false;
+      if (operatorIdentifier.is("-")) {
+        APInt zero = APInt(operand.getBitWidth(), 0);
+        result = operandVal->getIsSigned() ? zero.ssub_ov(operand, overflow)
+                                           : zero.usub_ov(operand, overflow);
+      } else if (operatorIdentifier.is("+"))
+        result = operand;
+      else if (operatorIdentifier.is("~"))
+        result = ~operand;
+      else
+        return FoldingError(IllegalConstError::UnsupportedUnaryOperator,
+                            sourceLocation);
+
+      if (overflow)
+        return FoldingError(IllegalConstError::IntegerOverflow, sourceLocation);
+
+      return ConstantValuePtr(
+          std::make_unique<IntegerValue>(result, operandVal->getIsSigned()));
+    }
+  };
+
+  Expr *createIntegerLiteralExpr(const Expr *foldedExpr,
+                                 const ConstantValue *result) {
+    assert(isa<IntegerValue>(result));
+    auto intResult = cast<IntegerValue>(result)->getValue();
+    auto resultType = foldedExpr->getType();
+    assert(resultType->isStdlibInteger());
+    bool isSigned = isSignedIntegerType(resultType);
+
+    SmallString<32> resultStr;
+    // Get the absolute value for a signed integer
+    // because it is represented as a 'negative value' on the resulting
+    // `IntegerLiteralExpr`.
+    if (isSigned)
+      intResult.abs().toString(resultStr, 10, true);
+    else
+      intResult.toString(resultStr, 10, false);
+
+    auto *newLit = new (Ctx) IntegerLiteralExpr(
+        Ctx.getIdentifier(resultStr).str(), foldedExpr->getLoc(),
+        /*implicit*/ true);
+    newLit->setType(resultType);
+    newLit->setImplicit();
+    newLit->setBuiltinInitializer(getIntTypeBuiltinInit(resultType, Ctx));
+    if (isSigned && intResult.slt(0))
+      newLit->setNegative(foldedExpr->getLoc());
+    return newLit;
+  }
+
+  void emitFoldingErrorDiagnostic(const FoldingError &foldingError) {
+    diagnoseError(foldingError.sourceLocation, foldingError.code, Ctx.Diags);
+  }
+};
+} // anonymous namespace
+
+Expr *swift::foldLiteralExpression(const Expr *expr, ASTContext *ctx) {
+  return evaluateOrDefault(ctx->evaluator, ConstantFoldExpression{expr, ctx},
+                           {});
+}
+
+Expr *ConstantFoldExpression::evaluate(Evaluator &evaluator, const Expr *expr,
+                                       ASTContext *ctx) const {
+  if (ctx->LangOpts.hasFeature(Feature::LiteralExpressions)) {
+    ConstantFolder folder(*ctx);
+    if (auto result = folder.fold(expr))
+      return result;
+  }
+  return const_cast<Expr *>(expr);
+}

--- a/lib/Sema/LiteralExpressionFolding.h
+++ b/lib/Sema/LiteralExpressionFolding.h
@@ -1,0 +1,64 @@
+//===--- LiteralExpressionFolding.h - ---------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  Simple AST-based evaluator of supported literal expressions
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SEMA_LITERAL_EXPR_FOLD_H
+#define SWIFT_SEMA_LITERAL_EXPR_FOLD_H
+
+#include "swift/AST/Decl.h"
+#include "swift/AST/Expr.h"
+#include "swift/AST/Stmt.h"
+
+namespace swift {
+namespace LiteralExprFolding {
+
+/// Kinds of failures which can be encountered when
+/// constant-folding or literal/const expression
+enum class IllegalConstError : int8_t {
+  TypeNotSupported,
+  AssociatedValue,
+  UnsupportedBinaryOperator,
+  UnsupportedUnaryOperator,
+  TypeExpression,
+  KeyPath,
+  Closure,
+  ClosureWithCaptures,
+  OpaqueDeclRef,
+  NonConstDeclRef,
+  OpaqueFuncDeclRef,
+  NonConventionCFunc,
+  OpaqueCalleeRef,
+  NonConstParameter,
+  DivideByZero,
+  IntegerOverflow,
+  UpstreamError,
+  Default
+};
+
+bool supportedOperator(const ApplyExpr *operatorApplyExpr);
+void diagnoseError(SourceLoc errorLoc, IllegalConstError reason,
+                   DiagnosticEngine &diags);
+
+} // namespace LiteralExprFolding
+
+/// Attempt to constant-fold an expression down to a
+/// constant of integer or floating-point type.
+/// Returns a `IntegerLiteralExpr` if successful,
+/// `nullptr` otherwise.
+Expr *foldLiteralExpression(const Expr *expr, ASTContext *ctx);
+
+} // namespace swift
+
+#endif // SWIFT_SEMA_LITERAL_EXPR_FOLD_H

--- a/test/ConstValues/DiagModulesSyntactic.swift
+++ b/test/ConstValues/DiagModulesSyntactic.swift
@@ -17,4 +17,4 @@ public func foo() -> Int {
 import MyModule
 
 @const let constGlobal1: Int = foo()
-// expected-error@-1 {{not supported in a constant expression}}
+// expected-error@-1 {{not supported in a literal expression}}

--- a/test/ConstValues/DiagNotConstSyntactic.swift
+++ b/test/ConstValues/DiagNotConstSyntactic.swift
@@ -3,11 +3,11 @@
 // RUN: %target-swift-frontend -emit-ir -primary-file %s -parse-as-library -verify -enable-experimental-feature CompileTimeValues
 
 @const let a: Bool = Bool.random()
-// expected-error@-1 {{not supported in a constant expression}}
+// expected-error@-1 {{not supported in a literal expression}}
 
 func foo() -> Int {
 	return 42 * Int.random(in: 0 ..< 10)
 }
 
 @const let b: Int = foo()
-// expected-error@-1 {{not supported in a constant expression}}
+// expected-error@-1 {{not supported in a literal expression}}

--- a/test/ConstValues/FunctionTypesSyntactic.swift
+++ b/test/ConstValues/FunctionTypesSyntactic.swift
@@ -6,25 +6,25 @@ func foo_void_to_void() {}
 func foo_int_to_int(x: Int) -> Int { return 42 }
 
 @const let constGlobalA1: ()->() = { }
-// expected-error@-1{{closures not supported in a constant expression}}
+// expected-error@-1{{closures not supported in a literal expression}}
 @const let constGlobalA2: @convention(c) ()->() = { }
-// expected-error@-1{{closures not supported in a constant expression}}
+// expected-error@-1{{closures not supported in a literal expression}}
 @const let constGlobalA3: @convention(thin) ()->() = { }
-// expected-error@-1{{only 'convention(c)' function values are supported in a constant expression}}
+// expected-error@-1{{only 'convention(c)' function values are supported in a literal expression}}
 
 @const let constGlobalB1: ()->() = foo_void_to_void // TODO: Diagnose the type of the variable as not eligigle for '@const' (not the init expression)
 @const let constGlobalB2: @convention(c) ()->() = foo_void_to_void
 @const let constGlobalB3: @convention(thin) ()->() = foo_void_to_void
-// expected-error@-1{{only 'convention(c)' function values are supported in a constant expression}}
+// expected-error@-1{{only 'convention(c)' function values are supported in a literal expression}}
 
 @const let constGlobalC1: (Int)->(Int) = { _ in return 42 }
-// expected-error@-1{{closures not supported in a constant expression}}
+// expected-error@-1{{closures not supported in a literal expression}}
 @const let constGlobalC2: @convention(c) (Int)->(Int) = { _ in return 42 }
-// expected-error@-1{{closures not supported in a constant expression}}
+// expected-error@-1{{closures not supported in a literal expression}}
 @const let constGlobalC3: @convention(thin) (Int)->(Int) = { _ in return 42 }
-// expected-error@-1{{only 'convention(c)' function values are supported in a constant expression}}
+// expected-error@-1{{only 'convention(c)' function values are supported in a literal expression}}
 
 @const let constGlobalD1: (Int)->(Int) = foo_int_to_int
 @const let constGlobalD2: @convention(c) (Int)->(Int) = foo_int_to_int
 @const let constGlobalD3: @convention(thin) (Int)->(Int) = foo_int_to_int
-// expected-error@-1{{only 'convention(c)' function values are supported in a constant expression}}
+// expected-error@-1{{only 'convention(c)' function values are supported in a literal expression}}

--- a/test/ConstValues/IntegerBinaryExpressions.swift
+++ b/test/ConstValues/IntegerBinaryExpressions.swift
@@ -1,0 +1,14 @@
+// Constant globals on simple integer literals
+// REQUIRES: swift_feature_CompileTimeValues
+// REQUIRES: swift_feature_CompileTimeValuesPreview
+// RUN: %target-swift-frontend -emit-ir -primary-file %s -parse-as-library -verify -enable-experimental-feature CompileTimeValues -enable-experimental-feature CompileTimeValuesPreview
+// RUN: %target-swift-frontend -emit-ir -primary-file %s -parse-as-library -verify -enable-experimental-feature CompileTimeValues
+
+@const let constGlobal1: Int = 42 + 1
+@const let constGlobal2: UInt = 2*2
+@const let constGlobal3: UInt = 0xf000f000
+#if _pointerBitWidth(_64)
+@const let constGlobal4: UInt = 0xf000f000_f000f000
+#endif
+@const let constGlobal5: UInt8 = 255
+@const let constGlobal6: UInt32 = 0xffff_ffff

--- a/test/ConstValues/IntegerExpressionsSyntactic.swift
+++ b/test/ConstValues/IntegerExpressionsSyntactic.swift
@@ -5,7 +5,7 @@
 
 @const let constGlobal1: Int = (42 + 42 + 42) / 3
 @const let constGlobal2: Int = MemoryLayout<UInt32>.size + 4
-// expected-error@-1{{in a constant expression}}
+// expected-error@-1{{in a literal expression}}
 @const let constGlobal3: Int = Int(17.0 / 3.5)
 @const let constGlobal4: Int = constGlobal1 + 1
 @const let constGlobal5: Int = -constGlobal1 + 1

--- a/test/ConstValues/ParametersSyntactic.swift
+++ b/test/ConstValues/ParametersSyntactic.swift
@@ -14,5 +14,5 @@ func foo() {
     #endif
     let _ = bar(UInt.random(in: 0..<10))
     // expected-error@-1 {{expected a compile-time value argument for a '@const' parameter}}
-    // expected-error@-2 {{not supported in a constant expression}}
+    // expected-error@-2 {{not supported in a literal expression}}
 }

--- a/test/ConstValues/SectionSyntactic.swift
+++ b/test/ConstValues/SectionSyntactic.swift
@@ -26,19 +26,19 @@
 
 // operators (should be rejected)
 @section("mysection") let invalidOperator1 = 1 + 1
-// expected-error@-1{{unsupported operator in a constant expression}}
+// expected-error@-1{{unsupported operator in a literal expression}}
 @section("mysection") let invalidOperator2 = 3.14 * 2.0
-// expected-error@-1{{unsupported operator in a constant expression}}
+// expected-error@-1{{unsupported operator in a literal expression}}
 @section("mysection") let invalidOperator3: Int = -(1)
-// expected-error@-1{{unsupported operator in a constant expression}}
+// expected-error@-1{{unsupported operator in a literal expression}}
 
 // non-literal expressions (should be rejected)
 @section("mysection") let invalidNonLiteral1 = Int.max
-// expected-error@-1{{not supported in a constant expression}}
+// expected-error@-1{{not supported in a literal expression}}
 @section("mysection") let invalidNonLiteral2 = UInt64(42)
-// expected-error@-1{{unsupported type in a constant expression}}
+// expected-error@-1{{unsupported type in a literal expression}}
 @section("mysection") let invalidNonLiteral3 = true.hashValue
-// expected-error@-1{{not supported in a constant expression}}
+// expected-error@-1{{not supported in a literal expression}}
 
 func foo() -> Int { return 42 }
 func bar(x: Int) -> String { return "test" }
@@ -63,25 +63,25 @@ extension Q { @section("mysection") static let staticFuncRef2 = staticFunc } // 
 
 // invalid function references (should be rejected)
 @section("mysection") let invalidFuncRef1 = foo()
-// expected-error@-1{{not supported in a constant expression}}
+// expected-error@-1{{not supported in a literal expression}}
 @section("mysection") let invalidFuncRef2 = Bool.self.random
-// expected-error@-1{{not supported in a constant expression}}
+// expected-error@-1{{not supported in a literal expression}}
 @section("mysection") let invalidFuncRef3 = (Bool.self as Bool.Type).random
-// expected-error@-1{{not supported in a constant expression}}
+// expected-error@-1{{not supported in a literal expression}}
 @section("mysection") let invalidFuncRef4 = Q.memberFunc
-// expected-error@-1{{not supported in a constant expression}}
+// expected-error@-1{{not supported in a literal expression}}
 extension Q { @section("mysection") static let invalidFuncRef5 = memberFunc }
-// expected-error@-1{{not supported in a constant expression}}
+// expected-error@-1{{not supported in a literal expression}}
 extension Q { @section("mysection") static let invalidFuncRef6: (Int)->() = genericFunc(Q()) }
-// expected-error@-1{{not supported in a constant expression}}
+// expected-error@-1{{not supported in a literal expression}}
 extension Q { @section("mysection") static let invalidFuncRef7: (Q) -> (Int) -> () = genericFunc }
-// expected-error@-1{{not supported in a constant expression}}
+// expected-error@-1{{not supported in a literal expression}}
 extension Q { @section("mysection") static let invalidFuncRef8: (Int)->() = staticGenericFunc }
-// expected-error@-1{{not supported in a constant expression}}
+// expected-error@-1{{not supported in a literal expression}}
 
 // generic function references (should be rejected)
 @section("mysection") let invalidGenericFunc = [Int].randomElement
-// expected-error@-1{{not supported in a constant expression}}
+// expected-error@-1{{not supported in a literal expression}}
 
 // closures
 @section("mysection") let closure1 = { } // ok
@@ -108,21 +108,21 @@ var capturedMutableVar = TestClass()
 
 // closures with captures (should be rejected)
 @section("mysection") let invalidClosure1 = { capturedVar }
-// expected-error@-1{{closures with captures not supported in a constant expression}}
+// expected-error@-1{{closures with captures not supported in a literal expression}}
 @section("mysection") let invalidClosure2 = { return capturedVar + 1 }
-// expected-error@-1{{closures with captures not supported in a constant expression}}
+// expected-error@-1{{closures with captures not supported in a literal expression}}
 @section("mysection") let invalidClosure3 = { [capturedVar] in return capturedVar }
-// expected-error@-1{{not supported in a constant expression}}
+// expected-error@-1{{not supported in a literal expression}}
 @section("mysection") let invalidClosure4 = { [weak capturedMutableVar] in return capturedMutableVar }
-// expected-error@-1{{not supported in a constant expression}}
+// expected-error@-1{{not supported in a literal expression}}
 @section("mysection") let invalidClosure5 = { [unowned capturedMutableVar] in return capturedMutableVar }
-// expected-error@-1{{not supported in a constant expression}}
+// expected-error@-1{{not supported in a literal expression}}
 @section("mysection") let invalidClosure6 = { [capturedVar, capturedMutableVar] in return 42 }
-// expected-error@-1{{not supported in a constant expression}}
+// expected-error@-1{{not supported in a literal expression}}
 @section("mysection") let invalidClosure7 = { [renamed = capturedVar] in return renamed * 2 }
-// expected-error@-1{{not supported in a constant expression}}
+// expected-error@-1{{not supported in a literal expression}}
 @section("mysection") let invalidClosure8 = { [computed = capturedVar + 5] in return computed }
-// expected-error@-1{{not supported in a constant expression}}
+// expected-error@-1{{not supported in a literal expression}}
 
 struct S { }
 enum E { case a }
@@ -132,13 +132,13 @@ enum E { case a }
 
 // invalid metatype references
 @section("mysection") let invalidMetatype1 = Int.self.self
-// expected-error@-1{{type expressions not supported in a constant expression}}
+// expected-error@-1{{type expressions not supported in a literal expression}}
 @section("mysection") let invalidMetatype2 = (1 == 1 ? Int.self : Int.self).self
-// expected-error@-1{{type expressions not supported in a constant expression}}
+// expected-error@-1{{type expressions not supported in a literal expression}}
 @section("mysection") let invalidMetatype3 = Array<Int>.self // generic
-// expected-error@-1{{type expressions not supported in a constant expression}}
+// expected-error@-1{{type expressions not supported in a literal expression}}
 @section("mysection") let invalidMetatype4 = Mirror.self // resilient
-// expected-error@-1{{type expressions not supported in a constant expression}}
+// expected-error@-1{{type expressions not supported in a literal expression}}
 
 // tuples
 @section("mysection") let tuple1 = (1, 2, 3, 2.718, true) // ok
@@ -148,15 +148,15 @@ enum E { case a }
 
 // invalid tuples (should be rejected)
 @section("mysection") let invalidTuple1 = (1, 2, Int.max)
-// expected-error@-1{{not supported in a constant expression}}
+// expected-error@-1{{not supported in a literal expression}}
 @section("mysection") let invalidTuple2 = (1 + 1, 2)
-// expected-error@-1{{unsupported operator in a constant expression}}
+// expected-error@-1{{unsupported operator in a literal expression}}
 
 let someVar = 42
 
 // variables (should be rejected)
 @section("mysection") let invalidVarRef = someVar
-// expected-error@-1{{unable to resolve variable reference in a constant expression}}
+// expected-error@-1{{unable to resolve variable reference in a literal expression}}
 
 struct MyCustomExpressibleByIntegerLiteral: ExpressibleByIntegerLiteral {
     init(integerLiteral value: Int) {}
@@ -164,19 +164,19 @@ struct MyCustomExpressibleByIntegerLiteral: ExpressibleByIntegerLiteral {
 
 // custom types (should be rejected)
 @section("mysection") let invalidCustomType1: MyCustomExpressibleByIntegerLiteral = 42
-// expected-error@-1{{unsupported type in a constant expression}}
+// expected-error@-1{{unsupported type in a literal expression}}
 @section("mysection") let invalidCustomType2: E = E.a
-// expected-error@-1{{not supported in a constant expression}}
+// expected-error@-1{{not supported in a literal expression}}
 @section("mysection") let invalidCustomType3: S = S()
-// expected-error@-1{{not supported in a constant expression}}
+// expected-error@-1{{not supported in a literal expression}}
 
 // other standard types (should be rejected)
 @section("mysection") let invalidString = "hello"
-// expected-error@-1{{unsupported type in a constant expression}}
+// expected-error@-1{{unsupported type in a literal expression}}
 @section("mysection") let invalidArray = [1, 2, 3]
-// expected-error@-1{{unsupported type in a constant expression}}
+// expected-error@-1{{unsupported type in a literal expression}}
 @section("mysection") let invalidDict = ["key": "value"]
-// expected-error@-1{{not supported in a constant expression}}
+// expected-error@-1{{not supported in a literal expression}}
 
 // inline array
 @available(SwiftStdlib 6.2, *)
@@ -185,20 +185,20 @@ struct MyCustomExpressibleByIntegerLiteral: ExpressibleByIntegerLiteral {
 // invalid inline array (should be rejected)
 @available(SwiftStdlib 6.2, *)
 @section("mysection") let invalidInlineArray: InlineArray = [1, 2, 3, Int.max]
-// expected-error@-1{{not supported in a constant expression}}
+// expected-error@-1{{not supported in a literal expression}}
 
 // optionals (should be rejected)
 @section("mysection") let optional1: Int? = 42
-// expected-error@-1{{unsupported type in a constant expression}}
+// expected-error@-1{{unsupported type in a literal expression}}
 @section("mysection") let optional2: Int? = nil
-// expected-error@-1{{unsupported type in a constant expression}}
+// expected-error@-1{{unsupported type in a literal expression}}
 @section("mysection") let optional3: Double? = 3.14
-// expected-error@-1{{unsupported type in a constant expression}}
+// expected-error@-1{{unsupported type in a literal expression}}
 @section("mysection") let optional4: Bool? = true
-// expected-error@-1{{unsupported type in a constant expression}}
+// expected-error@-1{{unsupported type in a literal expression}}
 @section("mysection") let optional5: Bool? = false
-// expected-error@-1{{unsupported type in a constant expression}}
+// expected-error@-1{{unsupported type in a literal expression}}
 @section("mysection") let optional6: Int? = 1 + 1
-// expected-error@-1{{unsupported type in a constant expression}}
+// expected-error@-1{{unsupported type in a literal expression}}
 @section("mysection") let optional7: Int? = Int.max
-// expected-error@-1{{unsupported type in a constant expression}}
+// expected-error@-1{{unsupported type in a literal expression}}

--- a/test/ConstValues/Tuples.swift
+++ b/test/ConstValues/Tuples.swift
@@ -11,4 +11,4 @@
 @const let constGlobal5: (Int, Float) = (42, 42.0)
 
 // Closure call not supported in syntactically-validated mode
-@const let constGlobal7: (UInt64, StaticString, @convention(c) ()->Int) = (42, "hi", { return 42 }) // expected-error {{not supported in a constant expression}}
+@const let constGlobal7: (UInt64, StaticString, @convention(c) ()->Int) = (42, "hi", { return 42 }) // expected-error {{not supported in a literal expression}}

--- a/test/LiteralExpressions/ArithmeticErrors.swift
+++ b/test/LiteralExpressions/ArithmeticErrors.swift
@@ -1,0 +1,7 @@
+// Constant globals using @section initialized with literal expressions
+// REQUIRES: swift_feature_LiteralExpressions
+// RUN: %target-swift-frontend -emit-ir -primary-file %s -parse-as-library -enable-experimental-feature LiteralExpressions -verify
+
+@section("mysection") let overflow: UInt8 = 100 * 3 // expected-error {{operation results in integer overflow}}
+@section("mysection") let divideZero1 = 4 / 0 // expected-error {{division by zero}}
+@section("mysection") let divideZero2 = 4 % 0 // expected-error {{division by zero}}

--- a/test/LiteralExpressions/LiteralOperands.swift
+++ b/test/LiteralExpressions/LiteralOperands.swift
@@ -1,0 +1,58 @@
+// Constant globals using @section initialized with literal expressions
+// REQUIRES: swift_feature_LiteralExpressions
+// RUN: %target-swift-frontend -typecheck -dump-ast %s -enable-experimental-feature LiteralExpressions -verify | %FileCheck %s
+
+// Simple arithmetic operators on integers
+@section("mysection") let intBinaryArithOp1 = 1 + 1
+// CHECK-LABEL: (pattern_named type="Int" "intBinaryArithOp1")
+// CHECK: (processed_constant_folded_init=integer_literal_expr implicit type="Int" location={{.*}}LiteralOperands.swift:{{[0-9]+}}:{{[0-9]+}} range=[{{.*}}] value="2"
+
+@section("mysection") let intBinaryArithOp2 = 4 - 1
+// CHECK-LABEL: (pattern_named type="Int" "intBinaryArithOp2")
+// CHECK: (processed_constant_folded_init=integer_literal_expr implicit type="Int" location={{.*}}LiteralOperands.swift:{{[0-9]+}}:{{[0-9]+}} range=[{{.*}}] value="3"
+
+@section("mysection") let intBinaryArithOp3 = 3 * 2
+// CHECK-LABEL: (pattern_named type="Int" "intBinaryArithOp3")
+// CHECK: (processed_constant_folded_init=integer_literal_expr implicit type="Int" location={{.*}}LiteralOperands.swift:{{[0-9]+}}:{{[0-9]+}} range=[{{.*}}] value="6"
+
+@section("mysection") let intBinaryArithOp4 = 4 / 2
+// CHECK-LABEL: (pattern_named type="Int" "intBinaryArithOp4")
+// CHECK: (processed_constant_folded_init=integer_literal_expr implicit type="Int" location={{.*}}LiteralOperands.swift:{{[0-9]+}}:{{[0-9]+}} range=[{{.*}}] value="2"
+
+@section("mysection") let intBinaryArithOp5 = 4 % 2
+// CHECK-LABEL: (pattern_named type="Int" "intBinaryArithOp5")
+// CHECK: (processed_constant_folded_init=integer_literal_expr implicit type="Int" location={{.*}}LiteralOperands.swift:{{[0-9]+}}:{{[0-9]+}} range=[{{.*}}] value="0"
+
+// Bitwise operators on integers
+@section("mysection") let intBinaryBitwiseOp1 = 1 & 2
+// CHECK-LABEL: (pattern_named type="Int" "intBinaryBitwiseOp1")
+// CHECK: (processed_constant_folded_init=integer_literal_expr implicit type="Int" location={{.*}}LiteralOperands.swift:{{[0-9]+}}:{{[0-9]+}} range=[{{.*}}] value="0"
+
+@section("mysection") let intBinaryBitwiseOp2 = 1 | 2
+// CHECK-LABEL: (pattern_named type="Int" "intBinaryBitwiseOp2")
+// CHECK: (processed_constant_folded_init=integer_literal_expr implicit type="Int" location={{.*}}LiteralOperands.swift:{{[0-9]+}}:{{[0-9]+}} range=[{{.*}}] value="3"
+
+@section("mysection") let intBinaryBitwiseOp3 = 1 ^ 2
+// CHECK-LABEL: (pattern_named type="Int" "intBinaryBitwiseOp3")
+// CHECK: (processed_constant_folded_init=integer_literal_expr implicit type="Int" location={{.*}}LiteralOperands.swift:{{[0-9]+}}:{{[0-9]+}} range=[{{.*}}] value="3"
+
+@section("mysection") let intBinaryBitwiseOp4 = 1 << 2
+// CHECK-LABEL: (pattern_named type="Int" "intBinaryBitwiseOp4")
+// CHECK: (processed_constant_folded_init=integer_literal_expr implicit type="Int" location={{.*}}LiteralOperands.swift:{{[0-9]+}}:{{[0-9]+}} range=[{{.*}}] value="4"
+
+@section("mysection") let intBinaryBitwiseOp5 = 4 >> 1
+// CHECK-LABEL: (pattern_named type="Int" "intBinaryBitwiseOp5")
+// CHECK: (processed_constant_folded_init=integer_literal_expr implicit type="Int" location={{.*}}LiteralOperands.swift:{{[0-9]+}}:{{[0-9]+}} range=[{{.*}}] value="2"
+
+// Unary prefix operators on integers
+@section("mysection") let intUnaryOp1: Int = -(1)
+// CHECK-LABEL: (pattern_named type="Int" "intUnaryOp1")
+// CHECK: (processed_constant_folded_init=integer_literal_expr implicit type="Int" location={{.*}}LiteralOperands.swift:{{[0-9]+}}:{{[0-9]+}} range=[{{.*}}] negative value="1"
+
+@section("mysection") let intUnaryOp2: Int = +1
+// CHECK-LABEL: (pattern_named type="Int" "intUnaryOp2")
+// CHECK: (processed_constant_folded_init=integer_literal_expr implicit type="Int" location={{.*}}LiteralOperands.swift:{{[0-9]+}}:{{[0-9]+}} range=[{{.*}}] value="1"
+
+@section("mysection") let intUnaryOp3: UInt8 = ~0b00001111  // equals 0b11110000 (240 in decimal)
+// CHECK-LABEL: (pattern_named type="UInt8" "intUnaryOp3")
+// CHECK: (processed_constant_folded_init=integer_literal_expr implicit type="UInt8" location={{.*}}LiteralOperands.swift:{{[0-9]+}}:{{[0-9]+}} range=[{{.*}}] value="240"

--- a/test/LiteralExpressions/SectionInterface.swift
+++ b/test/LiteralExpressions/SectionInterface.swift
@@ -1,0 +1,10 @@
+// Enum case raw value expressions
+// REQUIRES: swift_feature_LiteralExpressions
+// RUN: %target-swift-frontend -emit-module -module-name SectionLiteralExprInterface -emit-module-interface-path %t/SectionLiteralExprInterface.swiftinterface -enable-library-evolution -swift-version 5 %s -enable-experimental-feature LiteralExpressions
+// RUN: %FileCheck %s < %t/SectionLiteralExprInterface.swiftinterface
+
+// Simple arithmetic operators on integers
+@section("mysection") public let intBinaryArithOp1 = 1 + 1
+
+// As of today, the values do not get printed in the textual interface
+// CHECK: @section("mysection") public let intBinaryArithOp1: Swift.Int

--- a/test/LiteralExpressions/VariableReferenceFail.swift
+++ b/test/LiteralExpressions/VariableReferenceFail.swift
@@ -1,0 +1,20 @@
+// Constant globals using @section initialized with literal expressions with simple variable references
+// REQUIRES: swift_feature_LiteralExpressions
+
+// RUN: %empty-directory(%t/deps)
+// RUN: %target-swift-frontend -typecheck %s -enable-experimental-feature LiteralExpressions -verify
+
+// This declaration is not itself declared to be a constant value
+// but is referenced from one. Upon emitting a failure to constant fold, ensure
+// we emit a note with a location of the declaration reference in a literal expression.
+let foo: Int32 = 42 + Int32.random(in: 0..<10)
+// expected-error@-1 {{not supported in a literal expression}}
+@section("mysection") let bar: Int32 = 1 + foo
+// expected-note@-1 {{requested from reference in a literal expression}}
+
+// Currently, only the first encountered reference to a non-const non-constant-foldable
+// declaration will result in a note, and subsequent encounters will emit a general failure
+// to resolve the reference to a value
+@section("mysection") let baz: Int32 = 1 + foo
+// expected-error@-1 {{unable to resolve variable reference in a literal expression}}
+

--- a/test/LiteralExpressions/VariableReferences.swift
+++ b/test/LiteralExpressions/VariableReferences.swift
@@ -1,0 +1,53 @@
+// Constant globals using @section initialized with literal expressions with simple variable references
+// REQUIRES: swift_feature_LiteralExpressions
+
+// RUN: %empty-directory(%t/deps)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -typecheck -dump-ast %t/client.swift -I %t/deps -enable-experimental-feature LiteralExpressions -verify | %FileCheck %s
+
+//--- deps/foo.h
+#define MACRO_INT 42
+
+const int const_int = 42;
+static const int static_const_int = 42;
+static const char static_const_char = 42;
+static const char static_const_char_with_long_literal = 42ull;
+static const long static_const_long = 42;
+static const char static_const_char_referencing_other_const = 1 + static_const_char;
+
+static const float static_const_float = 42.0;
+static const double static_const_double = 42.0;
+
+static const char *static_const_pointer = 0;
+
+//--- deps/module.modulemap
+module Foo {
+  header "foo.h"
+  export *
+}
+
+//--- client.swift
+import Foo
+@section("mysection") let clangConstantOp1 = 1 + MACRO_INT
+// CHECK-LABEL: (pattern_named type="Int32" "clangConstantOp1")
+// CHECK: (processed_constant_folded_init=integer_literal_expr implicit type="Int32" location={{.*}}client.swift:{{.*}} range=[{{.*}}] value="43"
+
+@section("mysection") let clangConstantOp2 = 2 + const_int
+// CHECK-LABEL: (pattern_named type="Int32" "clangConstantOp2")
+// CHECK: (processed_constant_folded_init=integer_literal_expr implicit type="Int32" location={{.*}}client.swift:{{.*}} range=[{{.*}}] value="44"
+
+@section("mysection") let clangConstantOp4 = 4 + static_const_int
+// CHECK-LABEL: (pattern_named type="Int32" "clangConstantOp4")
+// CHECK: (processed_constant_folded_init=integer_literal_expr implicit type="Int32" location={{.*}}client.swift:{{.*}} range=[{{.*}}] value="46"
+
+@section("mysection") let clangConstantOp5 = 5 + static_const_char
+// CHECK-LABEL: (pattern_named type="Int8" "clangConstantOp5")
+// CHECK: (processed_constant_folded_init=integer_literal_expr implicit type="Int8" location={{.*}}client.swift:{{.*}} range=[{{.*}}] value="47"
+
+@section("mysection") let clangConstantOp6 = 6 + static_const_char_with_long_literal
+// CHECK-LABEL: (pattern_named type="Int8" "clangConstantOp6")
+// CHECK: (processed_constant_folded_init=integer_literal_expr implicit type="Int8" location={{.*}}client.swift:{{.*}} range=[{{.*}}] value="48"
+
+@section("mysection") let swiftConstantOp1 = 1 + clangConstantOp1
+// CHECK-LABEL: (pattern_named type="Int32" "swiftConstantOp1")
+// CHECK: (processed_constant_folded_init=integer_literal_expr implicit type="Int32" location={{.*}}client.swift:{{.*}} range=[{{.*}}] value="44"

--- a/test/Parse/const.swift
+++ b/test/Parse/const.swift
@@ -21,11 +21,11 @@ func takeIntConst(@const _ a: Int) {}
 struct Article {
   let id: String
 }
-@const let keypath = \Article.id // expected-error{{keypaths not supported in a constant expression}}
+@const let keypath = \Article.id // expected-error{{keypaths not supported in a literal expression}}
 
 func LocalConstVarUser() -> Int {
   @const let localConst = 3
   return localConst + 1
 }
 
-@const let a: Bool = Bool.random() // expected-error{{not supported in a constant expression}}
+@const let a: Bool = Bool.random() // expected-error{{not supported in a literal expression}}


### PR DESCRIPTION
This change adds an experimental feature `LiteralExpressions` which allows for use of simple binary expressions of integer type composed of literal value operands.

For now, such literal expressions are only supported in initializers of `@section` values.

Resolves rdar://168005182