### PR TITLE
[ScanDependency] Fix canImport when versioned checks all eval to false

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2844,15 +2844,19 @@ bool ASTContext::canImportModule(ImportPath::Module moduleName, SourceLoc loc,
                                  bool underlyingVersion) {
   llvm::VersionTuple versionInfo;
   llvm::VersionTuple underlyingVersionInfo;
-  if (!canImportModuleImpl(moduleName, loc, version, underlyingVersion, true,
-                           versionInfo, underlyingVersionInfo))
-    return false;
+  bool canImport =
+      canImportModuleImpl(moduleName, loc, version, underlyingVersion, true,
+                          versionInfo, underlyingVersionInfo);
 
-  SmallString<64> fullModuleName;
-  moduleName.getString(fullModuleName);
-  
-  addSucceededCanImportModule(fullModuleName, versionInfo, underlyingVersionInfo);
-  return true;
+  // If found an import or resolved an version, recorded the module.
+  if (canImport || !versionInfo.empty() || !underlyingVersionInfo.empty()) {
+    SmallString<64> fullModuleName;
+    moduleName.getString(fullModuleName);
+
+    addSucceededCanImportModule(fullModuleName, versionInfo,
+                                underlyingVersionInfo);
+  }
+  return canImport;;
 }
 
 bool ASTContext::testImportModule(ImportPath::Module ModuleName,

--- a/test/CAS/can-import.swift
+++ b/test/CAS/can-import.swift
@@ -37,6 +37,25 @@
 // RUN:   -module-name Test -explicit-swift-module-map-file @%t/map.casid \
 // RUN:   %t/main.swift @%t/MyApp.cmd
 
+/// Check that a single canImport check eval to false is behaving correctly.
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   %t/single.swift -o %t/deps2.json -swift-version 5 -cache-compile-job -cas-path %t/cas -I %t/include -F %t/frameworks
+
+// RUN: %{python} %S/../../utils/swift-build-modules.py --cas %t/cas %swift_frontend_plain %t/deps2.json -o %t/Test.cmd
+// RUN: %FileCheck %s --check-prefix=SINGLE --input-file=%t/Test.cmd
+// SINGLE:      "-module-can-import-version"
+// SINGLE-NEXT: "Simple"
+// SINGLE-NEXT: "0"
+// SINGLE-NEXT: "1000.0.0"
+
+// RUN: %target-swift-frontend-plain \
+// RUN:   -typecheck -cache-compile-job -cas-path %t/cas \
+// RUN:   -swift-version 5 \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   -module-name Test \
+// RUN:   %t/single.swift @%t/Test.cmd
+
 //--- main.swift
 #if canImport(A.Sub)
 func a() {}
@@ -84,6 +103,13 @@ func useA() {
   simple()
 }
 
+//--- single.swift
+import Simple
+
+#if canImport(Simple, _underlyingVersion: 3000)
+#error("wrong version")
+#endif
+
 //--- include/module.modulemap
 module A {
   module Sub {
@@ -116,6 +142,7 @@ public func d() { }
 //--- include/Simple.swiftinterface
 // swift-interface-format-version: 1.0
 // swift-module-flags: -module-name Simple -O -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib
+@_exported import Simple
 public func simple() { }
 
 //--- frameworks/Simple.framework/Modules/module.modulemap


### PR DESCRIPTION
Fix a corner case when following conditions are met in a single module:
* Module A is imported in the current module
* There exists a versioned `canImport` check for a module A
* All `canImport` check within the module evaluated to false

If all above conditions are met, swift-frontend will not received the version number from scanner, and it will be confused if version is either not available (thus a warning, and treat as true), or condition is not met (eval to false).

Now make sure if when scanner tries to resolve `canImport`, it will record all instances that a module can be imported, or a version of the module is found.

rdar://167784812

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
