### PR TITLE
[6.3][ScanDependency] Fix canImport when versioned checks all eval to false

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2836,15 +2836,19 @@ bool ASTContext::canImportModule(ImportPath::Module moduleName, SourceLoc loc,
                                  bool underlyingVersion) {
   llvm::VersionTuple versionInfo;
   llvm::VersionTuple underlyingVersionInfo;
-  if (!canImportModuleImpl(moduleName, loc, version, underlyingVersion, true,
-                           versionInfo, underlyingVersionInfo))
-    return false;
+  bool canImport =
+      canImportModuleImpl(moduleName, loc, version, underlyingVersion, true,
+                          versionInfo, underlyingVersionInfo);
 
-  SmallString<64> fullModuleName;
-  moduleName.getString(fullModuleName);
-  
-  addSucceededCanImportModule(fullModuleName, versionInfo, underlyingVersionInfo);
-  return true;
+  // If found an import or resolved an version, recorded the module.
+  if (canImport || !versionInfo.empty() || !underlyingVersionInfo.empty()) {
+    SmallString<64> fullModuleName;
+    moduleName.getString(fullModuleName);
+
+    addSucceededCanImportModule(fullModuleName, versionInfo,
+                                underlyingVersionInfo);
+  }
+  return canImport;;
 }
 
 bool ASTContext::testImportModule(ImportPath::Module ModuleName,

--- a/test/CAS/can-import.swift
+++ b/test/CAS/can-import.swift
@@ -37,6 +37,33 @@
 // RUN:   -module-name Test -explicit-swift-module-map-file @%t/map.casid \
 // RUN:   %t/main.swift @%t/MyApp.cmd
 
+/// Check that a single canImport check eval to false is behaving correctly.
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   %t/single.swift -o %t/deps2.json -swift-version 5 -cache-compile-job -cas-path %t/cas -I %t/include -F %t/frameworks
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps2.json clang:Simple > %t/CSimple.cmd
+// RUN: %swift_frontend_plain @%t/CSimple.cmd
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps2.json Simple > %t/Simple.cmd
+// RUN: %swift_frontend_plain @%t/Simple.cmd
+
+// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps2.json > %t/map2.json
+// RUN: llvm-cas --cas %t/cas --make-blob --data %t/map2.json > %t/map2.casid
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps2.json Test > %t/Test.cmd
+// RUN: %FileCheck %s --check-prefix=SINGLE --input-file=%t/Test.cmd
+// SINGLE:      "-module-can-import-version"
+// SINGLE-NEXT: "Simple"
+// SINGLE-NEXT: "0"
+// SINGLE-NEXT: "1000.0.0"
+
+// RUN: %target-swift-frontend \
+// RUN:   -typecheck -cache-compile-job -cas-path %t/cas \
+// RUN:   -swift-version 5 -disable-implicit-swift-modules \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   -module-name Test -explicit-swift-module-map-file @%t/map2.casid \
+// RUN:   %t/single.swift @%t/Test.cmd
+
 //--- main.swift
 #if canImport(A.Sub)
 func a() {}
@@ -84,6 +111,13 @@ func useA() {
   simple()
 }
 
+//--- single.swift
+import Simple
+
+#if canImport(Simple, _underlyingVersion: 3000)
+#error("wrong version")
+#endif
+
 //--- include/module.modulemap
 module A {
   module Sub {
@@ -116,6 +150,7 @@ public func d() { }
 //--- include/Simple.swiftinterface
 // swift-interface-format-version: 1.0
 // swift-module-flags: -module-name Simple -O -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib
+@_exported import Simple
 public func simple() { }
 
 //--- frameworks/Simple.framework/Modules/module.modulemap


### PR DESCRIPTION
- **Explanation**: Fix a corner case that causes versioned `canImport` to be evaluated to the wrong value when all canImport check are evaluated to false inside a module.
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: This is a corner case that affects some explicit module build and all swift caching build when above conditions are met.
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Issues**: rdar://167784812
  <!--
  References to issues the changes resolve, if any.
  -->
- **Original PRs**: https://github.com/swiftlang/swift/pull/86501
  <!--
  Links to mainline branch pull requests in which the changes originated.
  -->
- **Risk**: Low. Fixing a corner case in the scanner.
  <!--
  The (specific) risk to the release for taking the changes.
  -->
- **Testing**: unit test
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->
- **Reviewers**: @artemcm 
  <!--
  The code owners that GitHub-approved the original changes in the mainline
  branch pull requests. If an original change has not been GitHub-approved by
  a respective code owner, provide a reason. Technical review can be delegated
  by a code owner or otherwise requested as deemed appropriate or useful.
  -->

