### PR TITLE
DependencyScan: avoid re-tokenising the command line in the scanner

### DIFF
--- a/lib/DependencyScan/DependencyScanningTool.cpp
+++ b/lib/DependencyScan/DependencyScanningTool.cpp
@@ -26,6 +26,40 @@
 
 #include <sstream>
 
+namespace {
+llvm::ErrorOr<swift::CompilerInvocation>
+ConstructInvocation(llvm::ArrayRef<const char *> CommandArgs,
+                    llvm::StringRef executable, llvm::StringRef pwd,
+                    swift::DiagnosticEngine &DE) {
+  auto unescape =
+#if LLVM_ON_WIN32
+      llvm::cl::TokenizeWindowsCommandLine;
+#else
+      llvm::cl::TokenizeGNUCommandLine;
+#endif
+
+  llvm::BumpPtrAllocator Alloc;
+  llvm::SmallVector<std::string, 16> Args;
+  for (llvm::StringRef Arg : CommandArgs) {
+    llvm::StringSaver Saver(Alloc);
+    llvm::SmallVector<const char *, 4> Tokens;
+    // Unescape any arguments
+    unescape(Arg, Saver, Tokens, /*MarkEOLs=*/false);
+    Args.push_back(llvm::join(Tokens, " "));
+  }
+
+  std::vector<const char *> arguments;
+  arguments.reserve(Args.size());
+  std::transform(std::begin(Args), std::end(Args), std::back_inserter(arguments),
+                 [](const std::string &S) { return S.data(); });
+
+  swift::CompilerInvocation Invocation;
+  if (Invocation.parseArgs(arguments, DE, nullptr, pwd, executable))
+    return std::make_error_code(std::errc::invalid_argument);
+  return Invocation;
+}
+}
+
 namespace swift {
 namespace dependencies {
 
@@ -36,32 +70,17 @@ llvm::ErrorOr<swiftscan_string_ref_t> getTargetInfo(ArrayRef<const char *> Comma
                                                     const char *main_executable_path) {
   llvm::sys::SmartScopedLock<true> Lock(TargetInfoMutex);
 
-  // Parse arguments.
-  std::string CommandString;
-  for (const auto *c : Command) {
-    CommandString.append(c);
-    CommandString.append(" ");
-  }
-  SmallVector<const char *, 4> Args;
-  llvm::BumpPtrAllocator Alloc;
-  llvm::StringSaver Saver(Alloc);
-  // Ensure that we use the Windows command line parsing on Windows as we need
-  // to ensure that we properly handle paths.
-  if (llvm::Triple(llvm::sys::getProcessTriple()).isOSWindows()) 
-    llvm::cl::TokenizeWindowsCommandLine(CommandString, Saver, Args);
-  else
-    llvm::cl::TokenizeGNUCommandLine(CommandString, Saver, Args);
   SourceManager dummySM;
   DiagnosticEngine DE(dummySM);
-  CompilerInvocation Invocation;
-  if (Invocation.parseArgs(Args, DE, nullptr, {}, main_executable_path)) {
-    return std::make_error_code(std::errc::invalid_argument);
-  }
+  llvm::ErrorOr<CompilerInvocation> Invocation =
+      ConstructInvocation(Command, main_executable_path, {}, DE);
+  if (std::error_code EC = Invocation.getError())
+    return EC;
 
   // Store the result to a string.
   std::string ResultStr;
   llvm::raw_string_ostream StrOS(ResultStr);
-  swift::targetinfo::printTargetInfo(Invocation, StrOS);
+  swift::targetinfo::printTargetInfo(*Invocation, StrOS);
   return c_string_utils::create_clone(ResultStr.c_str());
 }
 
@@ -363,38 +382,22 @@ llvm::ErrorOr<ScanQueryContext> DependencyScanningTool::createScanQueryContext(
       return std::make_error_code(std::errc::invalid_argument);
     }
 
-    CompilerInvocation Invocation;
     SmallString<128> WorkingDirectory(WorkingDir);
     if (WorkingDirectory.empty())
       llvm::sys::fs::current_path(WorkingDirectory);
 
-    // Parse/tokenize arguments.
-    std::string CommandString;
-    for (const auto *c : CommandArgs) {
-      CommandString.append(c);
-      CommandString.append(" ");
-    }
-    SmallVector<const char *, 4> Args;
-    llvm::BumpPtrAllocator Alloc;
-    llvm::StringSaver Saver(Alloc);
-    // Ensure that we use the Windows command line parsing on Windows as we need
-    // to ensure that we properly handle paths.
-    if (llvm::Triple(llvm::sys::getProcessTriple()).isOSWindows())
-      llvm::cl::TokenizeWindowsCommandLine(CommandString, Saver, Args);
-    else
-      llvm::cl::TokenizeGNUCommandLine(CommandString, Saver, Args);
-
-    if (Invocation.parseArgs(Args, Instance->getDiags(),
-                             nullptr, WorkingDirectory, "/tmp/foo")) {
-      return std::make_error_code(std::errc::invalid_argument);
-    }
+    llvm::ErrorOr<CompilerInvocation> Invocation =
+        ConstructInvocation(CommandArgs, "swiftc", WorkingDirectory,
+                            Instance->getDiags());
+    if (std::error_code EC = Invocation.getError())
+      return EC;
 
     // Setup the instance
     std::string InstanceSetupError;
-    if (Instance->setup(Invocation, InstanceSetupError))
+    if (Instance->setup(*Invocation, InstanceSetupError))
       return std::make_error_code(std::errc::not_supported);
 
-    Invocation.getFrontendOptions().LLVMArgs.clear();
+    Invocation->getFrontendOptions().LLVMArgs.clear();
 
     // Setup the caching service after the instance finishes setup.
     if (ScanningService->setupCachingDependencyScanningService(*Instance))


### PR DESCRIPTION
We would concatenate and re-tokenise the command line even though we receive the command line pre-tokenised. This behaviour was introduced in cfde1fb693bb71f107ec09dfe92bb87ca15e990a in order to deal with paths which may be escaped. Rather than joining the arguments and re-tokenising to unescape the parameters, prefer instead to process each argument individually to unescape any parameter. By doing this, we are no longer required to ensure that the parameters are properly shell quoted prior to passing them to the scanner, but any escaped parameter will be unescaped.

This repairs some of the test failures in the swift-driver test suite on Windows.