### PR TITLE
[Concurrency] Avoid @export on withTaskPriorityEscalationHandler

### DIFF
--- a/stdlib/public/Concurrency/Task+PriorityEscalation.swift
+++ b/stdlib/public/Concurrency/Task+PriorityEscalation.swift
@@ -106,7 +106,7 @@ extension UnsafeCurrentTask {
 ///              and the second argument is the new escalated priority.
 /// - Returns: the value returned by `operation`
 /// - Throws: when the `operation` throws an error
-@export(implementation)
+@_alwaysEmitIntoClient
 @available(SwiftStdlib 6.2, *)
 public nonisolated(nonsending) func withTaskPriorityEscalationHandler<T, E>(
   operation: nonisolated(nonsending)  () async throws(E) -> T,


### PR DESCRIPTION
This is to avoid a condfail, we can't use this yet so widely. Stick to `@_alwaysEmitIntoClient`

resolves rdar://168020930