### PR TITLE
6.3 [Concurrency] Avoid @export on withTaskPriorityEscalationHandler #86504

### DIFF
--- a/stdlib/public/Concurrency/Task+PriorityEscalation.swift
+++ b/stdlib/public/Concurrency/Task+PriorityEscalation.swift
@@ -106,7 +106,7 @@ extension UnsafeCurrentTask {
 ///              and the second argument is the new escalated priority.
 /// - Returns: the value returned by `operation`
 /// - Throws: when the `operation` throws an error
-@export(implementation)
+@_alwaysEmitIntoClient
 @available(SwiftStdlib 6.2, *)
 public nonisolated(nonsending) func withTaskPriorityEscalationHandler<T, E>(
   operation: nonisolated(nonsending)  () async throws(E) -> T,


### PR DESCRIPTION
**Description**: We can't use the `@export` yet in stdlib yet, so stick to _alwaysEmitIntoClient.
**Scope/Impact**: Prevent condfail style failure in stdlib build
**Risk:** Low, AEIC has the same semantics
**Testing**: CI testing
**Reviewed by**: @hborla

**Original PR:** https://github.com/swiftlang/swift/pull/86504
**Radar:** rdar://168020930
