### PR TITLE
RequirementMachine: Better diagnostics for recursive same-type requirements

### DIFF
--- a/lib/AST/RequirementMachine/Diagnostics.h
+++ b/lib/AST/RequirementMachine/Diagnostics.h
@@ -49,8 +49,6 @@ struct RequirementError {
     /// An inverse requirement that conflicts with the computed requirements of
     /// a generic parameter, e.g., T : Copyable, T : ~Copyable
     ConflictingInverseRequirement,
-    /// A recursive requirement, e.g. T == G<T.A>.
-    RecursiveRequirement,
     /// A not-yet-supported same-element requirement, e.g. each T == Int.
     UnsupportedSameElement,
     /// A not-yet-supported same-type requirement involving packs and concrete
@@ -154,11 +152,6 @@ public:
                                                     Requirement second,
                                                     SourceLoc loc) {
     return {Kind::ConflictingRequirement, first, second, loc};
-  }
-
-  static RequirementError forRecursiveRequirement(Requirement req,
-                                                  SourceLoc loc) {
-    return {Kind::RecursiveRequirement, req, loc};
   }
 
   static RequirementError forSameElement(Requirement req, SourceLoc loc) {

--- a/lib/AST/RequirementMachine/HomotopyReduction.cpp
+++ b/lib/AST/RequirementMachine/HomotopyReduction.cpp
@@ -121,41 +121,6 @@ void RewriteSystem::propagateExplicitBits() {
   }
 }
 
-/// Find concrete type or superclass rules where the right hand side occurs as a
-/// proper prefix of one of its substitutions.
-///
-/// eg, (T.[concrete: G<T.[P:A]>] => T).
-void RewriteSystem::computeRecursiveRules() {
-  for (unsigned ruleID = FirstLocalRule, e = Rules.size();
-       ruleID < e; ++ruleID) {
-    auto &rule = getRule(ruleID);
-
-    if (rule.isPermanent() ||
-        rule.isRedundant())
-      continue;
-
-    auto optSymbol = rule.isPropertyRule();
-    if (!optSymbol)
-      continue;
-
-    auto kind = optSymbol->getKind();
-    if (kind != Symbol::Kind::ConcreteType &&
-        kind != Symbol::Kind::Superclass) {
-      continue;
-    }
-
-    auto rhs = rule.getRHS();
-    for (auto term : optSymbol->getSubstitutions()) {
-      if (term.size() > rhs.size() &&
-          std::equal(rhs.begin(), rhs.end(), term.begin())) {
-        RecursiveRules.push_back(ruleID);
-        rule.markRecursive();
-        break;
-      }
-    }
-  }
-}
-
 /// Find a rule to delete by looking through all loops for rewrite rules appearing
 /// once in empty context. Returns a pair consisting of a loop ID and a rule ID,
 /// otherwise returns None.
@@ -554,8 +519,6 @@ void RewriteSystem::minimizeRewriteSystem(const PropertyMap &map) {
 
     return false;
   });
-
-  computeRecursiveRules();
 
   // Check invariants after homotopy reduction.
   verifyRewriteLoops();

--- a/lib/AST/RequirementMachine/RequirementMachine.h
+++ b/lib/AST/RequirementMachine/RequirementMachine.h
@@ -121,10 +121,16 @@ class RequirementMachine final {
     return Complete;
   }
 
+  std::optional<unsigned> checkForRecursiveRule() const;
+
   std::pair<CompletionResult, unsigned>
   computeCompletion(RewriteSystem::ValidityPolicy policy);
 
   void freeze();
+
+  void diagnoseRecursiveRequirement(SourceLoc signatureLoc,
+                                    const ProtocolDecl *proto,
+                                    unsigned ruleID) const;
 
   void computeRequirementDiagnostics(
                             SmallVectorImpl<RequirementError> &errors,

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -57,6 +57,9 @@ enum class CompletionResult {
 
   /// Maximum type difference count exceeded.
   MaxTypeDifferences,
+
+  /// Recursive same-type or superclass requirement detected.
+  RecursiveRule,
 };
 
 /// A term rewrite system for working with types in a generic signature.
@@ -246,12 +249,13 @@ public:
   void computeConflictingRequirementDiagnostics(SmallVectorImpl<RequirementError> &errors,
                                                 SourceLoc signatureLoc,
                                                 const PropertyMap &map,
-                                                ArrayRef<GenericTypeParamType *> genericParams);
+                                                ArrayRef<GenericTypeParamType *> genericParams) const;
 
-  void computeRecursiveRequirementDiagnostics(SmallVectorImpl<RequirementError> &errors,
-                                              SourceLoc signatureLoc,
-                                              const PropertyMap &map,
-                                              ArrayRef<GenericTypeParamType *> genericParams);
+  void diagnoseRecursiveRequirement(SourceLoc signatureLoc,
+                                    const PropertyMap &propertyMap,
+                                    ArrayRef<GenericTypeParamType *> genericParams,
+                                    const ProtocolDecl *proto,
+                                    unsigned ruleID) const;
 
 private:
   struct CriticalPair {
@@ -388,8 +392,6 @@ private:
   void propagateExplicitBits();
 
   void propagateRedundantRequirementIDs();
-
-  void computeRecursiveRules();
 
   using EliminationPredicate = llvm::function_ref<bool(unsigned loopID,
                                                        unsigned ruleID)>;

--- a/lib/AST/RequirementMachine/Rule.h
+++ b/lib/AST/RequirementMachine/Rule.h
@@ -226,6 +226,8 @@ public:
 
   std::pair<unsigned, unsigned> getNestingAndSize() const;
 
+  bool isRecursiveRule() const;
+
   std::optional<int> compare(const Rule &other, RewriteContext &ctx) const;
 
   void dump(llvm::raw_ostream &out) const;

--- a/test/Constraints/same_types.swift
+++ b/test/Constraints/same_types.swift
@@ -284,8 +284,7 @@ protocol P2 {
 // CHECK-LABEL: same_types.(file).structuralSameTypeRecursive1@
 // CHECK-NEXT: Generic signature: <T, U where T == <<error type>>, U == <<error type>>>
 
-// expected-error@+2 {{cannot build rewrite system for generic signature; concrete type nesting limit exceeded}}
-// expected-note@+1 {{τ_0_0.[P2:Assoc1].[concrete: ((((((((((((((((((((((((((((((((τ_0_0.[P2:Assoc1], τ_0_1), τ_0_1), τ_0_1), τ_0_1), τ_0_1), τ_0_1), τ_0_1), τ_0_1), τ_0_1), τ_0_1), τ_0_1), τ_0_1), τ_0_1), τ_0_1), τ_0_1), τ_0_1), τ_0_1), τ_0_1), τ_0_1), τ_0_1), τ_0_1), τ_0_1), τ_0_1), τ_0_1), τ_0_1), τ_0_1), τ_0_1), τ_0_1), τ_0_1), τ_0_1), τ_0_1), τ_0_1)] => τ_0_0.[P2:Assoc1]}}
+// expected-error@+1 {{same-type constraint 'T.Assoc1' == '((T.Assoc1, U), U)' is recursive}}
 func structuralSameTypeRecursive1<T: P2, U>(_: T, _: U) where T.Assoc1 == Tuple2<T.Assoc1, U> {}
 
 protocol P3 {

--- a/test/Generics/abstract_type_witnesses_in_protocols.swift
+++ b/test/Generics/abstract_type_witnesses_in_protocols.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -typecheck -verify %s -debug-generic-signatures 2>&1 | %FileCheck %s
-// RUN: %target-swift-frontend -typecheck -verify %s -debug-generic-signatures -disable-requirement-machine-concrete-contraction 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -disable-requirement-machine-concrete-contraction
 
 protocol P {
   associatedtype T
@@ -14,61 +14,50 @@ protocol Q {
 
 protocol R {}
 
-// CHECK-LABEL: abstract_type_witnesses_in_protocols.(file).Q1@
-// CHECK-NEXT: Requirement signature: <Self where Self : Q, Self.[Q]A == G<<<error type>>>, Self.[Q1]B : P, Self.[Q]A.[P]T == Self.[Q1]B.[P]T>
-
 // GSB: Non-canonical requirement
 // expected-error@+1 {{same-type constraint 'Self.A' == 'G<Self.A.T>' is recursive}}
 protocol Q1 : Q {
   associatedtype B : P where A == G<B.T>
+  // expected-error@-1 {{'T' is not a member type of type 'Self.B'}}
 }
 
 // This used to crash
 func useQ1<T : Q1>(_: T) -> T.A.T.Type {
+  // expected-error@-1 {{'A' is not a member type of type 'T'}}
   return T.A.T.Type
 }
-
-// CHECK-LABEL: abstract_type_witnesses_in_protocols.(file).Q1a@
-// CHECK-NEXT: Requirement signature: <Self where Self : Q, Self.[Q]A == G<<<error type>>>, Self.[Q1a]B : P, Self.[Q]A.[P]T : R, Self.[Q]A.[P]T == Self.[Q1a]B.[P]T>
 
 // GSB: Missing requirement
 // expected-error@+1 {{same-type constraint 'Self.A' == 'G<Self.A.T>' is recursive}}
 protocol Q1a : Q {
   associatedtype B : P where A.T : R, A == G<B.T>
+  // expected-error@-1 {{'T' is not a member type of type 'Self.B'}}
 }
-
-// CHECK-LABEL: abstract_type_witnesses_in_protocols.(file).Q1b@
-// CHECK-NEXT: Requirement signature: <Self where Self : Q, Self.[Q]A == G<<<error type>>>, Self.[Q1b]B : P, Self.[Q]A.[P]T : R, Self.[Q]A.[P]T == Self.[Q1b]B.[P]T>
 
 // GSB: Non-canonical requirement
 // expected-error@+1 {{same-type constraint 'Self.A' == 'G<Self.A.T>' is recursive}}
 protocol Q1b : Q {
   associatedtype B : P where B.T : R, A == G<B.T>
+  // expected-error@-1 2{{'T' is not a member type of type 'Self.B'}}
 }
-
-// CHECK-LABEL: abstract_type_witnesses_in_protocols.(file).Q2@
-// CHECK-NEXT: Requirement signature: <Self where Self : Q, Self.[Q]A == G<<<error type>>>, Self.[Q2]B : P, Self.[Q]A.[P]T == Self.[Q2]B.[P]T>
 
 // GSB: Missing requirement
 // expected-error@+1 {{same-type constraint 'Self.A' == 'G<Self.A.T>' is recursive}}
 protocol Q2 : Q {
   associatedtype B : P where A.T == B.T, A == G<B.T>
+  // expected-error@-1 2{{'T' is not a member type of type 'Self.B'}}
 }
-
-// CHECK-LABEL: abstract_type_witnesses_in_protocols.(file).Q3@
-// CHECK-NEXT: Requirement signature: <Self where Self : Q, Self.[Q]A == G<<<error type>>>, Self.[Q3]B : P, Self.[Q]A.[P]T == Self.[Q3]B.[P]T>
 
 // GSB: Unsupported recursive requirement
 // expected-error@+1 {{same-type constraint 'Self.A' == 'G<Self.A.T>' is recursive}}
 protocol Q3 : Q {
   associatedtype B : P where A == G<A.T>, A.T == B.T
+  // expected-error@-1 {{'T' is not a member type of type 'Self.B'}}
 }
-
-// CHECK-LABEL: abstract_type_witnesses_in_protocols.(file).Q4@
-// CHECK-NEXT: Requirement signature: <Self where Self : Q, Self.[Q]A == G<<<error type>>>, Self.[Q4]B : P, Self.[Q]A.[P]T == Self.[Q4]B.[P]T>
 
 // GSB: Unsupported recursive requirement
 // expected-error@+1 {{same-type constraint 'Self.A' == 'G<Self.A.T>' is recursive}}
 protocol Q4 : Q {
   associatedtype B : P where A.T == B.T, A == G<A.T>
+  // expected-error@-1 {{'T' is not a member type of type 'Self.B'}}
 }

--- a/test/Generics/infinite_concrete_type.swift
+++ b/test/Generics/infinite_concrete_type.swift
@@ -49,8 +49,7 @@ class Base<T> {}
 class Derived<T, U> : Base<(T, U)> {}
 
 protocol TooManyDifferences {
-// expected-error@-1 {{cannot build rewrite system for protocol; concrete type difference limit exceeded}}
-// expected-note@-2 {{failed rewrite rule is }}
+// expected-error@-1 {{same-type constraint 'Self.B' == '(Self.B, Self.C)' is recursive}}
   associatedtype A1 where A1: Derived<B, C>, A2: Base<B>, A1 == A2
   associatedtype A2
   associatedtype B
@@ -59,9 +58,8 @@ protocol TooManyDifferences {
 
 struct G2<T> {
     func f2<each A>()
-// expected-error@-1 {{cannot build rewrite system for generic signature; concrete type nesting limit exceeded}}
-// expected-note@-2 {{failed rewrite rule is }}
-// expected-error@-3 {{generic parameter 'A' is not used in function signature}}
+// expected-error@-1 {{same-type constraint 'T' == '(repeat each A, (repeat each A, T))' is recursive}}
+// expected-error@-2 {{generic parameter 'A' is not used in function signature}}
   where (repeat each A, T) == T {}
 // expected-error@-1 {{tuple with noncopyable element type 'repeat each A' is not supported}}
 

--- a/test/Generics/rdar90402519.swift
+++ b/test/Generics/rdar90402519.swift
@@ -23,5 +23,4 @@ protocol P1 : P0 where C == G1<I> {
 }
 
 protocol P2 : P1 where C == G2<I> {}
-// expected-error@-1 {{cannot build rewrite system for protocol; concrete type nesting limit exceeded}}
-// expected-note@-2 {{failed rewrite rule is [P2:I].[concrete: G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<[P2:I]>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>] => [P2:I]}}
+// expected-error@-1 {{same-type constraint 'Self.I' == 'G<Self.I>' is recursive}}

--- a/test/attr/attr_specialize.swift
+++ b/test/attr/attr_specialize.swift
@@ -53,8 +53,7 @@ class G<T> {
   @_specialize(where T == T) // expected-error{{too few generic parameters are specified in '_specialize' attribute (got 0, but expected 1)}}
   // expected-note@-1 {{missing constraint for 'T' in '_specialize' attribute}}
   @_specialize(where T == S<T>)
-  // expected-error@-1 {{cannot build rewrite system for generic signature; concrete type nesting limit exceeded}}
-  // expected-note@-2 {{failed rewrite rule is τ_0_0.[concrete: S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<τ_0_0>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>] => τ_0_0}}
+  // expected-error@-1 {{same-type constraint 'T' == 'S<S<T>>' is recursive}}
   @_specialize(where T == Int, U == Int) // expected-error{{cannot find type 'U' in scope}}
 
   func noGenericParams() {}

--- a/test/decl/protocol/req/recursion.swift
+++ b/test/decl/protocol/req/recursion.swift
@@ -5,8 +5,7 @@ protocol SomeProtocol {
 }
 
 extension SomeProtocol where T == Optional<T> { }
-// expected-error@-1 {{cannot build rewrite system for generic signature; concrete type nesting limit exceeded}}
-// expected-note@-2 {{failed rewrite rule is τ_0_0.[SomeProtocol:T].[concrete: Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<τ_0_0.[SomeProtocol:T]>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>] => τ_0_0.[SomeProtocol:T]}}
+// expected-error@-1 {{same-type constraint 'Self.T' == 'Optional<Optional<Self.T>>' is recursive}}
 
 // rdar://problem/19840527
 

--- a/validation-test/compiler_crashers_fixed/issue-52031.swift
+++ b/validation-test/compiler_crashers_fixed/issue-52031.swift
@@ -11,8 +11,7 @@ protocol P {
 
 extension S: P where N: P {
   static func f<X: P>(_ x: X) -> S<X.A> where A == X, X.A == N {
-  // expected-error@-1 {{cannot build rewrite system for generic signature; rule length limit exceeded}}
-  // expected-note@-2 {{τ_0_0.[P:A].[P:A].[P:A].[P:A].[P:A].[concrete: S<S<S<S<S<S<τ_0_0>>>>>>] => τ_0_0.[P:A].[P:A].[P:A].[P:A].[P:A] [subst↓]}}
+  // expected-error@-1 {{same-type constraint 'N' == 'S<S<N>>' is recursive}}
     return S<X.A>()
   }
 }

--- a/validation-test/compiler_crashers_fixed/issue-63997.swift
+++ b/validation-test/compiler_crashers_fixed/issue-63997.swift
@@ -6,8 +6,7 @@ protocol P {
 
 struct J<A> { }
 
-// expected-error@+2 {{same-type constraint 'Self' == 'J<Self.A>' is recursive}}
-// expected-error@+1 {{no type for 'Self' can satisfy both 'Self == J<Self.A>' and 'Self : P'}}
+// expected-error@+1 {{same-type constraint 'Self' == 'J<Self.A>' is recursive}}
 extension P where Self == J<A> {
   static func just(_: A) { }
 }


### PR DESCRIPTION
We would emit a custom diagnostic for something like `[T == G<T.A>]`, because we would check for this in homotopy reduction. However, something like `[T == G<T>]` would blow up in completion, so we would emit a "scary" diagnostic about completion failing.

Instead, move the occurs check so that it happens earlier, and fail completion right away with a special error that uses the same diagnostic we use for the other kind of recursion as well.

Fixes https://github.com/swiftlang/swift/issues/70875.