### PR TITLE
Reapply: Runtime: expose demangle() in Runtime module (#84788)

### DIFF
--- a/Runtimes/Supplemental/Runtime/CMakeLists.txt
+++ b/Runtimes/Supplemental/Runtime/CMakeLists.txt
@@ -139,6 +139,7 @@ add_library(swiftRuntime
   ImageSource.swift
   Libc.swift
   LimitSequence.swift
+  Mangling.swift
   MemoryReader.swift
   OSReleaseScanner.swift
   ProcMapsScanner.swift

--- a/include/swift/Runtime/Runtime.h
+++ b/include/swift/Runtime/Runtime.h
@@ -1,0 +1,60 @@
+//===--- Runtime.cpp - Runtime functions exposed in Runtime module ---- ===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Definitions relating to public runtime module.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_RUNTIME_MANGLING_H
+#define SWIFT_RUNTIME_MANGLING_H
+
+#ifdef __linux__
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#include <signal.h>
+#endif // defined(__linux__)
+
+#include "swift/Runtime/Config.h"
+#include "swift/Runtime/CrashInfo.h"
+
+#include "swift/shims/Visibility.h"
+
+#include <inttypes.h>
+
+#ifdef __cplusplus
+namespace swift {
+namespace runtime {
+namespace mangling {
+#endif
+
+SWIFT_RUNTIME_STDLIB_SPI
+size_t _swift_runtime_demangle(
+  const char *mangledName, size_t mangledNameLength,
+  char *outputBuffer, size_t *outputBufferSize,
+  size_t flags
+);
+
+SWIFT_RUNTIME_STDLIB_SPI
+char *_swift_runtime_demangle_allocate(
+  const char *mangledName, size_t mangledNameLength,
+  size_t *outputBufferSize,
+  size_t flags
+);
+
+#ifdef __cplusplus
+} // namespace mangling
+} // namespace runtime
+} // namespace swift
+#endif
+
+#endif // SWIFT_RUNTIME_MANGLING_H

--- a/stdlib/public/RuntimeModule/CMakeLists.txt
+++ b/stdlib/public/RuntimeModule/CMakeLists.txt
@@ -58,6 +58,7 @@ set(RUNTIME_SOURCES
   ImageSource.swift
   Libc.swift
   LimitSequence.swift
+  Mangling.swift
   MemoryReader.swift
   OSReleaseScanner.swift
   ProcMapsScanner.swift

--- a/stdlib/public/RuntimeModule/Mangling.swift
+++ b/stdlib/public/RuntimeModule/Mangling.swift
@@ -1,0 +1,128 @@
+//===--- Mangling.swift --------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  Defines functions and types allowing to handle Swift's mangling scheme.
+//
+//===----------------------------------------------------------------------===//
+
+import Swift
+
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+internal import Darwin
+#elseif os(Windows)
+internal import ucrt
+#elseif canImport(Glibc)
+internal import Glibc
+#elseif canImport(Musl)
+internal import Musl
+#endif
+internal import BacktracingImpl.Runtime
+
+// - MARK: Demangling
+
+/// Given a mangled Swift symbol, demangle it into a human readable format.
+///
+/// If the provided string is not a valid mangled swift identifier this function will throw.
+/// If mangling succeeds the returned string will contain a demangled human-readable representation of the identifier.
+///
+/// - Parameters:
+///   - mangledName: A mangled Swift symbol.
+/// - Returns: A human readable demangled Swift symbol.
+/// - Throws: When the demangling fails for any reason.
+/// - Warning: The demangled output is lossy is not not guaranteed to be stable across Swift versions.
+///            Future versions of Swift may choose to print more (or less) information in the demangled format.
+@available(StdlibDeploymentTarget 6.3, *)
+public func demangle(_ mangledName: String) throws(DemanglingError) -> String {
+  var demangledLength: size_t = 0
+
+  let demangled: UnsafeMutablePointer<CChar>? = _swift_runtime_demangle_allocate(
+    mangledName, mangledName.utf8.count,
+    &demangledLength,
+    /*flags=*/0
+  )
+
+  guard demangledLength > 0 else {
+    assert(demangled == nil)
+    throw .invalidSymbol
+  }
+  defer { free(demangled) }
+
+  return try UnsafeBufferPointer(start: demangled, count: demangledLength)
+    .withMemoryRebound(to: UTF8.CodeUnit.self) { (buffer: UnsafeBufferPointer<UTF8.CodeUnit>) throws(DemanglingError) -> String in
+      guard let demangledSpan = try? UTF8Span(validating: buffer.span) else {
+        throw DemanglingError.invalidSymbol
+      }
+      return String(copying: demangledSpan)
+    }
+}
+
+/// Given a mangled Swift symbol, demangle it into a human readable format into the prepared output span.
+///
+/// If the provided bytes are not a valid mangled swift name, the output span will be initialized with zero elements.
+/// If mangling succeeds the output span will contain the resulting demangled string.
+/// A successfully demangled string is _not_ null terminated, and its length is communicated by the `initializedCount`
+/// of the output span.
+/// 
+/// The demangled output may be _truncated_ if the output span's capacity is insufficient for the
+/// demangled output string! You can detect this situation by inspecting the returned ``DemanglingResult``,
+/// for the ``DemanglingResult/truncated`` case.
+/// 
+/// - Parameters:
+///   - mangledName: A mangled Swift symbol.
+///   - output: A pre-allocated span to demangle the Swift symbol into.
+/// - Throws: When the demangling failed entirely, and the output span will not have been written to.
+/// - Warning: The demangled output is lossy is not not guaranteed to be stable across Swift versions.
+///            Future versions of Swift may choose to print more (or less) information in the demangled format.
+@available(StdlibDeploymentTarget 6.3, *)
+public func demangle(
+  _ mangledName: borrowing UTF8Span,
+  into output: inout OutputSpan<UTF8.CodeUnit>
+) throws(DemanglingError) {
+  var outputCapacity = output.capacity
+
+  let requiredBufferSize = output.withUnsafeMutableBufferPointer { outputBufferUInt8, initializedOutputLength in
+    outputBufferUInt8.withMemoryRebound(to: Int8.self) { outputBuffer in
+      mangledName.span.withUnsafeBytes { mangledNamePtr in
+        let requiredBufferSize = _swift_runtime_demangle(
+          mangledNamePtr.baseAddress, mangledName.count,
+          outputBuffer.baseAddress, &outputCapacity,
+          /*flags=*/0)
+
+        initializedOutputLength = outputCapacity
+        return requiredBufferSize
+      }
+    }
+  }
+
+  guard requiredBufferSize > 0 else {
+    throw DemanglingError.invalidSymbol
+  }
+
+  // If the buffer size is still equal to the buffer count, the demangle was
+  // successful.
+  guard requiredBufferSize <= output.capacity else {
+    throw DemanglingError.truncated(requiredBufferSize: requiredBufferSize)
+  }
+
+  return // OK!
+}
+
+/// Error thrown to indicate failure to demangle a Swift symbol.
+@available(StdlibDeploymentTarget 6.3, *)
+public enum DemanglingError: Error {
+  /// Demangling resulted in truncating the result. The payload value is the
+  /// number of bytes necessary for a full demangle.
+  case truncated(requiredBufferSize: Int)
+
+  /// The passed Swift mangled symbol was invalid.
+  case invalidSymbol
+}

--- a/stdlib/public/RuntimeModule/Mangling.swift
+++ b/stdlib/public/RuntimeModule/Mangling.swift
@@ -40,7 +40,7 @@ internal import BacktracingImpl.Runtime
 /// - Throws: When the demangling fails for any reason.
 /// - Warning: The demangled output is lossy is not not guaranteed to be stable across Swift versions.
 ///            Future versions of Swift may choose to print more (or less) information in the demangled format.
-@available(StdlibDeploymentTarget 6.3, *)
+@available(SwiftStdlib 6.3, *)
 public func demangle(_ mangledName: String) throws(DemanglingError) -> String {
   var demangledLength: size_t = 0
 
@@ -82,7 +82,7 @@ public func demangle(_ mangledName: String) throws(DemanglingError) -> String {
 /// - Throws: When the demangling failed entirely, and the output span will not have been written to.
 /// - Warning: The demangled output is lossy is not not guaranteed to be stable across Swift versions.
 ///            Future versions of Swift may choose to print more (or less) information in the demangled format.
-@available(StdlibDeploymentTarget 6.3, *)
+@available(SwiftStdlib 6.3, *)
 public func demangle(
   _ mangledName: borrowing UTF8Span,
   into output: inout OutputSpan<UTF8.CodeUnit>
@@ -117,7 +117,7 @@ public func demangle(
 }
 
 /// Error thrown to indicate failure to demangle a Swift symbol.
-@available(StdlibDeploymentTarget 6.3, *)
+@available(SwiftStdlib 6.3, *)
 public enum DemanglingError: Error {
   /// Demangling resulted in truncating the result. The payload value is the
   /// number of bytes necessary for a full demangle.

--- a/stdlib/public/RuntimeModule/modules/Runtime/Runtime.h
+++ b/stdlib/public/RuntimeModule/modules/Runtime/Runtime.h
@@ -38,6 +38,36 @@ char *_swift_backtrace_demangle(const char *rawName,
                                 char *outputBuffer,
                                 size_t *outputBufferSize);
 
+// Demangle the given Swift mangled identifier.
+// 
+// An output buffer must be passed into which the demangled string will be written.
+//
+// The demangled result string is NOT null-terminated. 
+// The demangled string length is indicated through the outputBufferSize parameter.
+//
+// If the demangled result is truncated, the returned number will be greater than the
+// initialized count written into the outputBufferSize.
+// 
+// Introduced in Swift 6.3.
+size_t _swift_runtime_demangle(
+  const char *rawName, size_t rawNameLength,
+  char *outputBuffer, size_t *outputBufferSize,
+  size_t flags
+);
+
+// Demangle the given Swift mangled identifier.
+// This function always allocates a new buffer for the result to be returned.
+
+// The demangled result string is NOT null-terminated.
+// The demangled string length is indicated through the outputBufferSize parameter.
+//
+// Introduced in Swift 6.3.
+char *_swift_runtime_demangle_allocate(
+  const char *rawName, size_t rawNameLength,
+  size_t *outputBufferSize,
+  size_t flags
+);
+
 #ifdef __cplusplus
 }
 #endif

--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -24,6 +24,12 @@
 #include <objc/runtime.h>
 #endif
 
+#ifdef _WIN32
+// We'll probably want dbghelp.h here
+#else
+#include <cxxabi.h>
+#endif
+
 using namespace swift;
 
 Demangle::NodePointer
@@ -1033,3 +1039,113 @@ char *swift_demangle(const char *mangledName,
   return outputBuffer;
 #endif
 }
+
+namespace swift {
+  namespace runtime {
+
+    static bool isUTF8CodePointContinuationByte(unsigned char byte) {
+      return (byte & 0b11000000) == 0b10000000;
+    }
+
+    // Demangle entry point for backtrace and public demangle() Swift API.
+    SWIFT_RUNTIME_STDLIB_SPI size_t
+    _swift_runtime_demangle(const char *mangledName,
+                            size_t mangledNameLength,
+                            char *outputBuffer,
+                            size_t *outputBufferSize,
+                            size_t flags) {
+      assert(outputBuffer != nullptr);
+      assert(outputBufferSize != nullptr);
+
+      if (!mangledName || mangledNameLength == 0) {
+        *outputBufferSize = 0;
+        return 0;
+      }
+      if (flags > 0) {
+        *outputBufferSize = 0;
+        return 0; // ignore not supported flags
+      }
+
+      llvm::StringRef name = llvm::StringRef(mangledName, mangledNameLength);
+      if (Demangle::isSwiftSymbol(name)) {
+        // Determine demangling/formatting options:
+        auto options = DemangleOptions();
+
+        auto result = Demangle::demangleSymbolAsString(name, options);
+        size_t toCopy = std::min(*outputBufferSize, result.length());
+
+        // Are we accidentally cutting of an UTF8 codepoint in the middle?
+        // there may be up to 4 continuations of a codepoint so we need to see if we're cutting off in the middle,
+        // and if so, back out until we find the actual non-continuation byte.
+        while (toCopy > 0 &&
+               toCopy < result.length() &&
+               isUTF8CodePointContinuationByte(result.data()[toCopy])) {
+          // we're in the middle of an utf8 scalar, and would overwrite it with a null terminator resulting in a truncated UTF8-scalar.
+          // don't do that, and instead truncate further back
+          toCopy -= 1;
+        }
+
+        ::memcpy(outputBuffer, result.data(), toCopy);
+        *outputBufferSize = toCopy; // indicate how many bytes were written
+
+        // we return the total size of the result, even if we wrote less'
+        // this is how we can detect truncation
+        return result.length();
+      }
+
+      // We could attempt to demangle C++ symbols here, but we choose not to support this in Runtime.demangle(...)
+
+      *outputBufferSize = 0; // indicate we did not write to buffer
+      return 0; // we don't know how many bytes we'd need, the symbol was invalid to begin with
+    }
+
+    SWIFT_RUNTIME_STDLIB_SPI char *
+    _swift_runtime_demangle_allocate(const char *mangledName,
+                            size_t mangledNameLength,
+                            size_t *outputSize,
+                            size_t flags) {
+      if (!mangledName)
+        return nullptr;
+      if (flags > 0)
+        return nullptr; // ignore not supported flags
+
+      llvm::StringRef name = llvm::StringRef(mangledName, mangledNameLength);
+      if (Demangle::isSwiftSymbol(name)) {
+        // Determine demangling/formatting options:
+        auto options = DemangleOptions();
+
+        auto result = Demangle::demangleSymbolAsString(name, options);
+
+        // we allocate the buffer for the result; truncation cannot happen in this case.
+        auto totalLength = result.length();
+        auto outputBuffer = (char *)::malloc(totalLength);
+        if (!outputBuffer) {
+          // malloc could have failed, let's handle it gracefully
+          *outputSize = 0;
+          return nullptr;
+        }
+        size_t bufferSize = result.length();
+
+        size_t toCopy = std::min(bufferSize, result.length());
+
+        // Are we accidentally cutting of an UTF8 codepoint in the middle?
+        // There may be up to 4 continuations of a codepoint so we need to see if we're cutting off in the middle,
+        // and if so, back out until we find the actual non-continuation byte.
+        while (toCopy > 0 &&
+               toCopy + 1 < result.length() && isUTF8CodePointContinuationByte(result.data()[toCopy + 1])) {
+          // we're in the middle of an utf8 scalar, a truncated UTF8-scalar.
+          // don't do that, and instead truncate further back
+          toCopy -= 1;
+        }
+
+        ::memcpy(outputBuffer, result.data(), toCopy);
+        *outputSize = toCopy;
+        return outputBuffer;
+      }
+
+      // We could attempt to demangle C++ symbols here, but we choose not to support this in Runtime.demangle(...)
+      return nullptr;
+    }
+
+  } // namespace runtime
+} // namespace swift

--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -1101,9 +1101,9 @@ namespace swift {
 
     SWIFT_RUNTIME_STDLIB_SPI char *
     _swift_runtime_demangle_allocate(const char *mangledName,
-                            size_t mangledNameLength,
-                            size_t *outputSize,
-                            size_t flags) {
+                                    size_t mangledNameLength,
+                                    size_t *outputSize,
+                                    size_t flags) {
       if (!mangledName || !outputSize)
         return nullptr;
       if (flags > 0)
@@ -1113,7 +1113,6 @@ namespace swift {
       if (Demangle::isSwiftSymbol(name)) {
         // Determine demangling/formatting options:
         auto options = DemangleOptions();
-
         auto result = Demangle::demangleSymbolAsString(name, options);
 
         // we allocate the buffer for the result; truncation cannot happen in this case.
@@ -1124,22 +1123,9 @@ namespace swift {
           *outputSize = 0;
           return nullptr;
         }
-        size_t bufferSize = result.length();
 
-        size_t toCopy = std::min(bufferSize, result.length());
-
-        // Are we accidentally cutting of an UTF8 codepoint in the middle?
-        // There may be up to 4 continuations of a codepoint so we need to see if we're cutting off in the middle,
-        // and if so, back out until we find the actual non-continuation byte.
-        while (toCopy > 0 &&
-               toCopy + 1 < result.length() && isUTF8CodePointContinuationByte(result.data()[toCopy + 1])) {
-          // we're in the middle of an utf8 scalar, a truncated UTF8-scalar.
-          // don't do that, and instead truncate further back
-          toCopy -= 1;
-        }
-
-        ::memcpy(outputBuffer, result.data(), toCopy);
-        *outputSize = toCopy;
+        ::memcpy(outputBuffer, result.data(), totalLength);
+        *outputSize = totalLength;
         return outputBuffer;
       }
 

--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -1104,7 +1104,7 @@ namespace swift {
                             size_t mangledNameLength,
                             size_t *outputSize,
                             size_t flags) {
-      if (!mangledName)
+      if (!mangledName || !outputSize)
         return nullptr;
       if (flags > 0)
         return nullptr; // ignore not supported flags

--- a/test/Concurrency/Runtime/RuntimeDemangle.swift
+++ b/test/Concurrency/Runtime/RuntimeDemangle.swift
@@ -1,0 +1,222 @@
+// RUN: %target-run-simple-swift
+
+
+// REQUIRES: executable_test
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+import Swift
+import Runtime
+import StdlibUnittest
+
+var DemangleTests = TestSuite("Demangle")
+
+if #available(SwiftStdlib 6.3, *) {
+  DemangleTests.test("basic string return API") {
+    // First, test that we get back 'nil' with invalid input.
+    expectEqual(try? demangle("abc123"), nil)
+    expectEqual(try? demangle("Si"), nil)
+    expectEqual(try? demangle("Swift is super cool!"), nil)
+
+    // Test that correct symbols are demangled. (Test all documented prefixes)
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) // legacy mangling is not supported on Linux
+    expectEqual(try? demangle("_TSb"), "Swift.Bool")
+    expectEqual(try? demangle("_T0Si"), "Swift.Int")
+    #endif
+    expectEqual(try? demangle("$SSdXSaXSq"), "[Swift.Double]?")
+    expectEqual(try? demangle("_$S8Demangle4main4argc4argvs5Int32VAF_SpySpys4Int8VGSgGtF"), "Demangle.main(argc: Swift.Int32, argv: Swift.UnsafeMutablePointer<Swift.Optional<Swift.UnsafeMutablePointer<Swift.Int8>>>) -> Swift.Int32")
+    expectEqual(try? demangle("$sSG"), "Swift.RandomNumberGenerator")
+    expectEqual(try? demangle("_$sSS7cStringSSSPys4Int8VG_tcfC"), "Swift.String.init(cString: Swift.UnsafePointer<Swift.Int8>) -> Swift.String")
+  }
+
+  func test(body: (inout OutputSpan<UTF8.CodeUnit>) -> ()) {
+    let buffer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: 140)
+    var outputSpan = OutputSpan<UTF8.CodeUnit>(buffer: buffer, initializedCount: 0)
+
+    defer { buffer.deallocate() }
+
+    body(&outputSpan)
+  }
+
+  DemangleTests.test("Span API") {
+    // First, test that the buffer is still empty after failed demanglings.
+    test { outputSpan in
+      do {
+        try demangle("abc123".utf8Span, into: &outputSpan)
+        expectTrue(false, "Expected demangle to throw")
+      } catch DemanglingError.invalidSymbol {
+        expectEqual(outputSpan.count, 0)
+        let demangled = String(copying: try! UTF8Span(validating: outputSpan.span))
+        expectEqual(demangled, "")
+      } catch {
+        expectTrue(false, "Got unexpected error: \(error)")
+      }
+    }
+
+    test { outputSpan in
+      do {
+        try demangle("Si".utf8Span, into: &outputSpan)
+        expectTrue(false, "Expected demangle to throw")
+      } catch DemanglingError.invalidSymbol {
+        let demangled = String(copying: try! UTF8Span(validating: outputSpan.span))
+        expectEqual(demangled, "")
+      } catch {
+        expectTrue(false, "Got unexpected error: \(error)")
+      }
+    }
+
+    test { outputSpan in
+      do {
+        try demangle("Swift is super cool!".utf8Span, into: &outputSpan)
+        expectTrue(false, "Expected demangle to throw")
+      } catch DemanglingError.invalidSymbol {
+        let demangled = String(copying: try! UTF8Span(validating: outputSpan.span))
+        expectEqual(demangled, "")
+      } catch {
+        expectTrue(false, "Got unexpected error: \(error)")
+      }
+    }
+
+    // Test that correct symbols are demangled. (Test all documented prefixes)
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) // legacy mangling is not supported on Linux
+    test { outputSpan in
+      do {
+        try demangle("_TSb".utf8Span, into: &outputSpan)
+        let demangled = String(copying: try! UTF8Span(validating: outputSpan.span))
+        expectEqual(demangled, "Swift.Bool")
+      } catch {
+        expectTrue(false, "Got unexpected error: \(error)")
+      }
+    }
+    #endif
+
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) // legacy mangling is not supported on Linux
+    test { outputSpan in
+      do {
+        try demangle("_T0Si".utf8Span, into: &outputSpan)
+        let demangled = String(copying: try! UTF8Span(validating: outputSpan.span))
+        expectEqual(demangled, "Swift.Int")
+      } catch {
+        expectTrue(false, "Got unexpected error: \(error)")
+      }
+    }
+    #endif
+
+    test { outputSpan in
+      do {
+        try demangle("$SSdXSaXSq".utf8Span, into: &outputSpan)
+        let demangled = String(copying: try! UTF8Span(validating: outputSpan.span))
+        expectEqual(demangled, "[Swift.Double]?")
+      } catch {
+        expectTrue(false, "Got unexpected error: \(error)")
+      }
+    }
+
+    test { outputSpan in
+      do {
+        try demangle("_$S8Demangle4main4argc4argvs5Int32VAF_SpySpys4Int8VGSgGtF".utf8Span, into: &outputSpan)
+        let demangled = String(copying: try! UTF8Span(validating: outputSpan.span))
+        expectEqual(demangled, "Demangle.main(argc: Swift.Int32, argv: Swift.UnsafeMutablePointer<Swift.Optional<Swift.UnsafeMutablePointer<Swift.Int8>>>) -> Swift.Int32")
+      } catch {
+        expectTrue(false, "Got unexpected error: \(error)")
+      }
+    }
+
+    test { outputSpan in
+      do {
+        try demangle("$sSG".utf8Span, into: &outputSpan)
+        let demangled = String(copying: try! UTF8Span(validating: outputSpan.span))
+        expectEqual(demangled, "Swift.RandomNumberGenerator")
+      } catch {
+        expectTrue(false, "Got unexpected error: \(error)")
+      }
+    }
+
+    test { outputSpan in
+      do {
+        try demangle("_$sSS7cStringSSSPys4Int8VG_tcfC".utf8Span, into: &outputSpan)
+        let demangled = String(copying: try! UTF8Span(validating: outputSpan.span))
+        expectEqual(demangled, "Swift.String.init(cString: Swift.UnsafePointer<Swift.Int8>) -> Swift.String")
+      } catch {
+        expectTrue(false, "Got unexpected error: \(error)")
+      }
+    }
+  }
+
+  DemangleTests.test("Span API - too small buffer") {
+    // Test the return of demangle into with a smaller buffer.
+    // Swift.Int requires 9 bytes, give this 8
+    let smolBuffer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: 8)
+    var smolOutputSpan = OutputSpan<UTF8.CodeUnit>(buffer: smolBuffer, initializedCount: 0)
+    defer { smolBuffer.deallocate() }
+
+    do {
+      try demangle("$sSi".utf8Span, into: &smolOutputSpan)
+      expectTrue(false, "Expected demangle to throw")
+    } catch DemanglingError.truncated(let requiredBufferSize) {
+      expectEqual(requiredBufferSize, 9)
+      expectEqual(String(copying: try! UTF8Span(validating: smolOutputSpan.span)), "Swift.In")
+    } catch {
+      expectTrue(false, "Got unexpected error: \(error)")
+    }
+  }
+
+  DemangleTests.test("Span API - small buffer, success") {
+    let smolBuffer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: 9)
+    var smolOutputSpan = OutputSpan<UTF8.CodeUnit>(buffer: smolBuffer, initializedCount: 0)
+    defer { smolBuffer.deallocate() }
+
+    do {
+      try demangle("$s4Smol3IntV".utf8Span, into: &smolOutputSpan)
+      expectEqual(String(copying: try! UTF8Span(validating: smolOutputSpan.span)), "Smol.Int")
+    } catch {
+      expectTrue(false, "Got unexpected error: \(error)")
+    }
+  }
+
+  DemangleTests.test("Span API - don't cut off an UTF8 codepoint in the middle (length 3)") {
+    let smolBuffer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: 3)
+    var smolOutputSpan = OutputSpan<UTF8.CodeUnit>(buffer: smolBuffer, initializedCount: 0)
+    defer { smolBuffer.deallocate() }
+
+    // Test nil return on successful demangle.
+    do {
+      try demangle("$s4ąą3IntV".utf8Span, into: &smolOutputSpan)
+      expectTrue(false, "Expected demangle to throw")
+    } catch DemanglingError.truncated(let requiredBufferSize) {
+      expectEqual(requiredBufferSize, 8)
+      // ą is two bytes, so the 3 bytes won't wit the "ąą" but only "ą" and half of the "ą"
+      // therefore, the output must properly truncate to just a single "ą"
+      //
+      // 2 bytes - "ą"
+      expectEqual(String(copying: try! UTF8Span(validating: smolOutputSpan.span)), "ą")
+    } catch {
+      expectTrue(false, "Got unexpected error: \(error)")
+    }
+  }
+
+  DemangleTests.test("Span API - don't cut off an UTF8 codepoint in the middle (length 4)") {
+    let smolBuffer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: 4)
+    var smolOutputSpan = OutputSpan<UTF8.CodeUnit>(buffer: smolBuffer, initializedCount: 0)
+    defer { smolBuffer.deallocate() }
+
+    // Test nil return on successful demangle.
+    do {
+      try demangle("$s4ąą3IntV".utf8Span, into: &smolOutputSpan)
+      expectTrue(false, "Expected demangle to throw")
+    } catch DemanglingError.truncated(let requiredBufferSize) {
+      expectEqual(requiredBufferSize, 8)
+      // 2 bytes - "ą"
+      // 2 bytes - "ą"
+      expectEqual(String(copying: try! UTF8Span(validating: smolOutputSpan.span)), "ąą")
+    } catch {
+      expectTrue(false, "Got unexpected error: \(error)")
+    }
+  }
+
+}
+
+runAllTests()

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -1172,3 +1172,7 @@ Added: _$sSS9UTF16ViewV20isTriviallyIdentical2toSbAB_tF
 Added: _$sSs17UnicodeScalarViewV20isTriviallyIdentical2toSbAB_tF
 Added: _$sSs8UTF8ViewV20isTriviallyIdentical2toSbAB_tF
 Added: _$sSs9UTF16ViewV20isTriviallyIdentical2toSbAB_tF
+
+// SE-0498: Add Runtime.demangle function
+Added: __swift_runtime_demangle
+Added: __swift_runtime_demangle_allocate

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -1167,3 +1167,7 @@ Added: _$sSS9UTF16ViewV20isTriviallyIdentical2toSbAB_tF
 Added: _$sSs17UnicodeScalarViewV20isTriviallyIdentical2toSbAB_tF
 Added: _$sSs8UTF8ViewV20isTriviallyIdentical2toSbAB_tF
 Added: _$sSs9UTF16ViewV20isTriviallyIdentical2toSbAB_tF
+
+// SE-0498: Add Runtime.demangle function
+Added: __swift_runtime_demangle
+Added: __swift_runtime_demangle_allocate


### PR DESCRIPTION
Re-applies https://github.com/swiftlang/swift/pull/84788 after the revert https://github.com/swiftlang/swift/pull/86470

Adjusts some availability annotations which were the reason the the revert

resolves rdar://168004804