### PR TITLE
utils: fix the check-incremental script by adding new IR saving options

### DIFF
--- a/docs/DebuggingTheCompiler.md
+++ b/docs/DebuggingTheCompiler.md
@@ -134,9 +134,11 @@ The output of all these dump options (except `-dump-ast`) can be redirected
 with an additional `-o <file>` option.
 Compilation stops at the phase where you print the output.
 
-If you want to print the SIL or LLVM IR in addition to producing the regular
-output file (e.g an object file), use the `-sil-output-path <file>`, or
-`-ir-output-path <file>` options (prefixed with `-Xfrontend`).
+If you want to print the SIL or IR in addition to producing the regular output
+file (e.g an object file), use the `-save-sil`, `save-irgen` or `save-ir`
+options.
+Those options take a file argument and save the SIL or LLVM-IR before or after
+LLVM optimization, respectively.
 
 ## Debugging Diagnostic Emission
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -89,6 +89,7 @@
 #include "llvm/IRReader/IRReader.h"
 #include "llvm/Option/OptTable.h"
 #include "llvm/Option/Option.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Compression.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -110,6 +111,10 @@
 #include <utility>
 
 using namespace swift;
+
+static llvm::cl::opt<std::string> SaveSIL(
+    "save-sil", llvm::cl::Hidden,
+    llvm::cl::desc("Save SIL to a file after SIL optimizations"));
 
 static std::vector<std::string>
 collectSupplementaryOutputPaths(ArrayRef<const char *> Args,
@@ -2156,6 +2161,12 @@ static bool performCompileStepsPostSILGen(
     if (writeSIL(*SM, Instance.getMainModule(), Invocation.getSILOptions(),
                  PSPs.SupplementaryOutputs.SILOutputPath,
                  Instance.getOutputBackend()))
+      return true;
+  }
+
+  if (!SaveSIL.empty()) {
+    if (writeSIL(*SM, Instance.getMainModule(), Invocation.getSILOptions(),
+                 SaveSIL, Instance.getOutputBackend()))
       return true;
   }
 

--- a/utils/check-incremental
+++ b/utils/check-incremental
@@ -52,9 +52,11 @@ def print_diff(output_file, suffix):
 
 def print_ir_diffs(output_file):
     if EMIT_IR and VERBOSE:
-        print("\n## SIL differences:")
+        print("\n## SIL differences:", flush=True)
         print_diff(output_file, ".sil")
-        print("\n## IR differences:")
+        print("\n## IRGen differences:", flush=True)
+        print_diff(output_file, ".irgen.ll")
+        print("\n## IR differences:", flush=True)
         print_diff(output_file, ".ll")
 
 def main():
@@ -85,8 +87,9 @@ def main():
 
     if EMIT_IR:
       new_args += [
-        '-Xfrontend', '-sil-output-path', '-Xfrontend', output_file + '.sil',
-        '-Xfrontend', '-ir-output-path', '-Xfrontend', output_file + '.ll']
+        '-Xllvm', '-save-sil', '-Xllvm', output_file + '.sil',
+        '-Xllvm', '-save-irgen', '-Xllvm', output_file + '.irgen.ll',
+        '-Xllvm', '-save-ir', '-Xllvm', output_file + '.ll']
 
     if VERBOSE:
         print("Reference compilation of " + output_file + ":")
@@ -102,6 +105,8 @@ def main():
     if EMIT_IR:
         subprocess.check_call(
             ["cp", output_file + ".sil", output_file + ".ref.sil"])
+        subprocess.check_call(
+            ["cp", output_file + ".irgen.ll", output_file + ".ref.irgen.ll"])
         subprocess.check_call(
             ["cp", output_file + ".ll", output_file + ".ref.ll"])
 


### PR DESCRIPTION
Instead of `-sil-output-path`/`-ir-output-path` use the new `-save-sil`/`-save-irgen`/`-save-ir` options, because the former options are not compatible with `-supplementary-output-file-map`.
Also, write the LLVM IR directly after IRGen to catch potential non-determinisms in IRGen.

rdar://168012861