### PR TITLE
🍒 [6.3][cxx-interop] Check for the presence of simple copy constructor

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -8576,8 +8576,11 @@ CxxValueSemantics::evaluate(Evaluator &evaluator,
     bool isCopyable = !isExplicitlyNonCopyable;
     if (!isExplicitlyNonCopyable) {
       auto copyCtor = findCopyConstructor(cxxRecordDecl);
-      isCopyable = copyCtor || cxxRecordDecl->needsImplicitCopyConstructor();
+      isCopyable = copyCtor || 
+                   cxxRecordDecl->hasSimpleCopyConstructor() ||
+                   cxxRecordDecl->needsImplicitCopyConstructor();
       if ((copyCtor && copyCtor->isDefaulted()) ||
+          cxxRecordDecl->hasSimpleCopyConstructor() ||
           cxxRecordDecl->needsImplicitCopyConstructor()) {
         // If the copy constructor is implicit/defaulted, we ask Clang to
         // generate its definition. The implicitly-defined copy constructor


### PR DESCRIPTION
  - **Explanation**: Sometimes, a `CxxRecordDecl` will have an implicitly declared copy constructor that is not found through `findCopyConstructor()`. So, we also explicitly check for the presence of a simple copy constructor.
  - **Original PR**: https://github.com/swiftlang/swift/pull/86380
  - **Risk**: Low. We used to check for the presence of a simple copy constructor in the past but at some point I removed it, thinking it was unnecessary. 
  - **Testing**: Unfortunately I couldn't come up with a small reproducer, but this fixes rdar://167551559
  - **Reviewers**: @Xazax-hun @egorzhdan @j-hui 