### PR TITLE
[cxx-interop] Fix crash deserializing some Clang function types

### DIFF
--- a/include/swift/AST/ClangModuleLoader.h
+++ b/include/swift/AST/ClangModuleLoader.h
@@ -266,6 +266,11 @@ public:
   virtual const clang::Decl *
   resolveStableSerializationPath(const StableSerializationPath &path) const = 0;
 
+  struct SerializableInfo {
+    bool Serializable;
+    bool HasSwiftDecl;
+  };
+
   /// Determine whether the given type is serializable.
   ///
   /// If \c checkCanonical is true, checks the canonical type,
@@ -288,8 +293,8 @@ public:
   /// least, it's probably best to use conservative predicates
   /// that work both ways so that language behavior doesn't differ
   /// based on subtleties like the target module interface format.
-  virtual bool isSerializable(const clang::Type *type,
-                              bool checkCanonical) const = 0;
+  virtual SerializableInfo isSerializable(const clang::Type *type,
+                                          bool checkCanonical) const = 0;
 
   virtual clang::FunctionDecl *
   instantiateCXXFunctionTemplate(ASTContext &ctx,

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -639,8 +639,8 @@ public:
   resolveStableSerializationPath(
                             const StableSerializationPath &path) const override;
 
-  bool isSerializable(const clang::Type *type,
-                      bool checkCanonical) const override;
+  SerializableInfo isSerializable(const clang::Type *type,
+                                  bool checkCanonical) const override;
 
   clang::FunctionDecl *
   instantiateCXXFunctionTemplate(ASTContext &ctx,

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1351,7 +1351,8 @@ public:
   /// Note that this will only check the requested sugaring of the given
   /// type (depending on \c checkCanonical); the canonical type may be
   /// serializable even if the non-canonical type is not, or vice-versa.
-  bool isSerializable(clang::QualType type, bool checkCanonical);
+  ClangModuleLoader::SerializableInfo isSerializable(clang::QualType type,
+                                                     bool checkCanonical);
 
   /// Try to find a stable Swift serialization path for the given Clang
   /// declaration.

--- a/lib/ClangImporter/Serializability.cpp
+++ b/lib/ClangImporter/Serializability.cpp
@@ -22,6 +22,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "ImporterImpl.h"
+#include "swift/AST/ClangModuleLoader.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/ClangImporter/SwiftAbstractBasicWriter.h"
 
@@ -293,6 +294,7 @@ namespace {
       DataStreamBasicWriter<ClangTypeSerializationChecker> {
     ClangImporter::Implementation &Impl;
     bool IsSerializable = true;
+    bool HasSwiftDecl = false;
 
     ClangTypeSerializationChecker(ClangImporter::Implementation &impl)
       : DataStreamBasicWriter<ClangTypeSerializationChecker>(
@@ -306,8 +308,17 @@ namespace {
         IsSerializable = false;
     }
     void writeDeclRef(const clang::Decl *decl) {
-      if (decl && !Impl.findStableSerializationPath(decl))
+      if (!decl) {
         IsSerializable = false;
+        return;
+      }
+      auto path = Impl.findStableSerializationPath(decl);
+      if (!path) {
+        IsSerializable = false;
+        return;
+      }
+      if (path.isSwiftDecl())
+        HasSwiftDecl = true;
     }
     void writeSourceLocation(clang::SourceLocation loc) {
       // If a source location is written into a type, it's likely to be
@@ -336,13 +347,15 @@ namespace {
   };
 }
 
-bool ClangImporter::isSerializable(const clang::Type *type,
-                                   bool checkCanonical) const {
+ClangModuleLoader::SerializableInfo
+ClangImporter::isSerializable(const clang::Type *type,
+                              bool checkCanonical) const {
   return Impl.isSerializable(clang::QualType(type, 0), checkCanonical);
 }
 
-bool ClangImporter::Implementation::isSerializable(clang::QualType type,
-                                                   bool checkCanonical) {
+ClangModuleLoader::SerializableInfo
+ClangImporter::Implementation::isSerializable(clang::QualType type,
+                                              bool checkCanonical) {
   if (checkCanonical)
     type = getClangASTContext().getCanonicalType(type);
 
@@ -350,5 +363,5 @@ bool ClangImporter::Implementation::isSerializable(clang::QualType type,
   // anything that we can't stably serialize.
   ClangTypeSerializationChecker checker(*this);
   checker.writeQualType(type);
-  return checker.IsSerializable;
+  return {checker.IsSerializable, checker.HasSwiftDecl};
 }

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3477,7 +3477,8 @@ public:
           // Serialization will serialize the sugared type if it can,
           // but we need the canonical type to be serializable or else
           // canonicalization (e.g. in SIL) might break things.
-          if (!loader->isSerializable(clangType, /*check canonical*/ true)) {
+          if (!loader->isSerializable(clangType, /*check canonical*/ true)
+                   .Serializable) {
             ctx.Diags.diagnose(Loc, diag::unexportable_clang_function_type, T);
           }
         }

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -473,7 +473,7 @@ public:
   /// The type will be scheduled for serialization if necessary.,
   ///
   /// \returns The ID for the given type in this module.
-  ClangTypeID addClangTypeRef(const clang::Type *ty);
+  ClangTypeID addClangTypeRef(const clang::Type *ty, bool forFunction = false);
 
   /// Records the use of the given DeclBaseName.
   ///

--- a/test/Serialization/rdar166359524.swift
+++ b/test/Serialization/rdar166359524.swift
@@ -1,0 +1,26 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t --leading-lines
+
+// RUN: %target-swift-frontend -emit-module -o %t -module-name BlockArrayModule %t/BlockArrayModule.swift
+// RUN: %target-swift-frontend -typecheck -I %t %t/Client.swift
+
+// No Foundation on other platforms yet.
+// REQUIRES: objc_interop
+// REQUIRES: VENDOR=apple
+
+//--- BlockArrayModule.swift
+import Foundation
+
+@objc public class MediaContent: NSObject {}
+
+public struct MediaContainer {
+    public var contentProvider: @convention(block) () -> MediaContent
+}
+
+//--- Client.swift
+import Foundation
+import BlockArrayModule
+
+func process(container: MediaContainer) {
+    let _ = container.contentProvider()
+}


### PR DESCRIPTION
When a function type refers to a Swift declaration we get a crash during deserialization. This patch prevents serializing the problematic clang function types to avoid this crash.

rdar://166359524
