### PR TITLE
SILGen: More useful fatal error message from useConformance()

### DIFF
--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -607,18 +607,19 @@ public:
   void emitLazyConformancesForType(NominalTypeDecl *NTD);
 
   /// Mark a protocol conformance as used, so we know we need to emit it if
-  /// it's in our TU.
-  void useConformance(ProtocolConformanceRef conformance);
+  /// it's in our TU. The SILInstruction is printed for debugging purposes if
+  /// the conformance turns out to be invalid.
+  void useConformance(SILInstruction *inst, ProtocolConformanceRef conformance);
 
   /// Mark protocol conformances from the given type as used.
-  void useConformancesFromType(CanType type);
+  void useConformancesFromType(SILInstruction *inst, CanType type);
 
   /// Mark protocol conformances from the given set of substitutions as used.
-  void useConformancesFromSubstitutions(SubstitutionMap subs);
+  void useConformancesFromSubstitutions(SILInstruction *inst, SubstitutionMap subs);
 
   /// Mark _ObjectiveCBridgeable conformances as used for any imported types
   /// mentioned by the given type.
-  void useConformancesFromObjectiveCType(CanType type);
+  void useConformancesFromObjectiveCType(SILInstruction *inst, CanType type);
 
   /// Make a note of a member reference expression, which allows us
   /// to ensure that the conformance above is emitted wherever it

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -2040,7 +2040,7 @@ void SILGenModule::noteMemberRefExpr(MemberRefExpr *e) {
   // for a builtin.
   ASTContext &ctx = var->getASTContext();
   if (isDistributedActorAsLocalActorComputedProperty(var)) {
-    useConformance(getDistributedActorAsActorConformanceRef(ctx));
+    useConformance(nullptr, getDistributedActorAsActorConformanceRef(ctx));
   }
 }
 

--- a/lib/SILGen/SILGenConcurrency.cpp
+++ b/lib/SILGen/SILGenConcurrency.cpp
@@ -537,7 +537,7 @@ SILGenFunction::emitFlowSensitiveSelfIsolation(SILLocation loc,
         getBuiltinName(BuiltinValueKind::FlowSensitiveSelfIsolation));
     conformance = getActorConformance(*this, actorType);
   }
-  SGM.useConformance(conformance);
+  SGM.useConformance(nullptr, conformance);
 
   SubstitutionMap subs = SubstitutionMap::getProtocolSubstitutions(
       conformance.getProtocol(), actorType, conformance);

--- a/lib/SILGen/SILGenConcurrency.cpp
+++ b/lib/SILGen/SILGenConcurrency.cpp
@@ -537,7 +537,6 @@ SILGenFunction::emitFlowSensitiveSelfIsolation(SILLocation loc,
         getBuiltinName(BuiltinValueKind::FlowSensitiveSelfIsolation));
     conformance = getActorConformance(*this, actorType);
   }
-  SGM.useConformance(nullptr, conformance);
 
   SubstitutionMap subs = SubstitutionMap::getProtocolSubstitutions(
       conformance.getProtocol(), actorType, conformance);

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -651,7 +651,7 @@ ManagedValue SILGenFunction::emitExistentialErasure(
                             bool allowEmbeddedNSError) {
   // Mark the needed conformances as used.
   for (auto conformance : conformances)
-    SGM.useConformance(conformance);
+    SGM.useConformance(nullptr, conformance);
 
   // If we're erasing to the 'Error' type, we might be able to get an NSError
   // representation more efficiently.

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -649,10 +649,6 @@ ManagedValue SILGenFunction::emitExistentialErasure(
                             SGFContext C,
                             llvm::function_ref<ManagedValue (SGFContext)> F,
                             bool allowEmbeddedNSError) {
-  // Mark the needed conformances as used.
-  for (auto conformance : conformances)
-    SGM.useConformance(nullptr, conformance);
-
   // If we're erasing to the 'Error' type, we might be able to get an NSError
   // representation more efficiently.
   auto &ctx = getASTContext();

--- a/lib/SILGen/SILGenLazyConformance.cpp
+++ b/lib/SILGen/SILGenLazyConformance.cpp
@@ -30,7 +30,8 @@
 using namespace swift;
 using namespace swift::Lowering;
 
-void SILGenModule::useConformance(ProtocolConformanceRef conformanceRef) {
+void SILGenModule::useConformance(SILInstruction *inst,
+                                  ProtocolConformanceRef conformanceRef) {
   // If the conformance is invalid, crash deterministically even in noassert
   // builds.
   if (conformanceRef.isInvalid()) {
@@ -40,7 +41,20 @@ void SILGenModule::useConformance(ProtocolConformanceRef conformanceRef) {
     if (ctx.TypeCheckerOpts.EnableLazyTypecheck && ctx.hadError())
       return;
 
-    llvm::report_fatal_error("Invalid conformance in type-checked AST");
+    ABORT([&](auto &out) {
+      out << "Found an invalid conformance in SILGen. This may indicate a problem in ";
+      out << "Sema or the ClangImporter.\n";
+
+      if (inst != nullptr) {
+        out << "\n";
+        out << "Emitting lazy conformances for instruction:\n";
+        inst->print(out);
+        out << "\n";
+        out << "In function:\n";
+        inst->getFunction()->print(out);
+        out << "\n";
+      }
+    });
   }
 
   // We don't need to emit dependent conformances.
@@ -52,7 +66,7 @@ void SILGenModule::useConformance(ProtocolConformanceRef conformanceRef) {
     auto *packConformance = conformanceRef.getPack();
 
     for (auto patternConformanceRef : packConformance->getPatternConformances())
-      useConformance(patternConformanceRef);
+      useConformance(inst, patternConformanceRef);
 
     return;
   }
@@ -65,7 +79,7 @@ void SILGenModule::useConformance(ProtocolConformanceRef conformanceRef) {
 
   // Emit any conformances implied by conditional requirements.
   if (auto *specialized = dyn_cast<SpecializedProtocolConformance>(conformance)) {
-    useConformancesFromSubstitutions(specialized->getSubstitutionMap());
+    useConformancesFromSubstitutions(inst, specialized->getSubstitutionMap());
     conformance = specialized->getGenericConformance();
   }
 
@@ -93,12 +107,13 @@ void SILGenModule::useConformance(ProtocolConformanceRef conformanceRef) {
 }
 
 void SILGenModule::useConformancesFromSubstitutions(
+                                                SILInstruction *inst,
                                                 const SubstitutionMap subs) {
   for (auto conf : subs.getConformances())
-    useConformance(conf);
+    useConformance(inst, conf);
 }
 
-void SILGenModule::useConformancesFromType(CanType type) {
+void SILGenModule::useConformancesFromType(SILInstruction *inst, CanType type) {
   if (!usedConformancesFromTypes.insert(type.getPointer()).second)
     return;
 
@@ -122,12 +137,13 @@ void SILGenModule::useConformancesFromType(CanType type) {
       return;
 
     auto subMap = t->getContextSubstitutionMap();
-    useConformancesFromSubstitutions(subMap);
+    useConformancesFromSubstitutions(inst, subMap);
     return;
   });
 }
 
-void SILGenModule::useConformancesFromObjectiveCType(CanType type) {
+void SILGenModule::useConformancesFromObjectiveCType(
+    SILInstruction *inst, CanType type) {
   if (!usedConformancesFromObjectiveCTypes.insert(type.getPointer()).second)
     return;
 
@@ -149,12 +165,12 @@ void SILGenModule::useConformancesFromObjectiveCType(CanType type) {
 
     if (objectiveCBridgeable) {
       if (auto subConformance = lookupConformance(t, objectiveCBridgeable))
-        useConformance(subConformance);
+        useConformance(inst, subConformance);
     }
 
     if (bridgedStoredNSError) {
       if (auto subConformance = lookupConformance(t, bridgedStoredNSError))
-        useConformance(subConformance);
+        useConformance(inst, subConformance);
     }
   });
 }
@@ -173,172 +189,172 @@ public:
   LazyConformanceEmitter(SILGenModule &SGM) : SGM(SGM) {}
 
   void visitAllocExistentialBoxInst(AllocExistentialBoxInst *AEBI) {
-    SGM.useConformancesFromType(AEBI->getFormalConcreteType());
-    SGM.useConformancesFromObjectiveCType(AEBI->getFormalConcreteType());
+    SGM.useConformancesFromType(AEBI, AEBI->getFormalConcreteType());
+    SGM.useConformancesFromObjectiveCType(AEBI, AEBI->getFormalConcreteType());
     for (auto conformance : AEBI->getConformances())
-      SGM.useConformance(conformance);
+      SGM.useConformance(AEBI, conformance);
   }
 
   void visitAllocGlobalInst(AllocGlobalInst *AGI) {
-    SGM.useConformancesFromType(
+    SGM.useConformancesFromType(AGI,
         AGI->getReferencedGlobal()->getLoweredType().getASTType());
   }
 
   void visitAllocRefInst(AllocRefInst *ARI) {
-    SGM.useConformancesFromType(ARI->getType().getASTType());
+    SGM.useConformancesFromType(ARI, ARI->getType().getASTType());
   }
 
   void visitAllocStackInst(AllocStackInst *ASI) {
-    SGM.useConformancesFromType(ASI->getType().getASTType());
+    SGM.useConformancesFromType(ASI, ASI->getType().getASTType());
   }
 
   void visitApplyInst(ApplyInst *AI) {
-    SGM.useConformancesFromObjectiveCType(AI->getSubstCalleeType());
-    SGM.useConformancesFromSubstitutions(AI->getSubstitutionMap());
+    SGM.useConformancesFromObjectiveCType(AI, AI->getSubstCalleeType());
+    SGM.useConformancesFromSubstitutions(AI, AI->getSubstitutionMap());
   }
 
   void visitBeginApplyInst(BeginApplyInst *BAI) {
-    SGM.useConformancesFromObjectiveCType(BAI->getSubstCalleeType());
-    SGM.useConformancesFromSubstitutions(BAI->getSubstitutionMap());
+    SGM.useConformancesFromObjectiveCType(BAI, BAI->getSubstCalleeType());
+    SGM.useConformancesFromSubstitutions(BAI, BAI->getSubstitutionMap());
   }
 
   void visitBuiltinInst(BuiltinInst *BI) {
-    SGM.useConformancesFromSubstitutions(BI->getSubstitutions());
+    SGM.useConformancesFromSubstitutions(BI, BI->getSubstitutions());
   }
 
   void visitCheckedCastBranchInst(CheckedCastBranchInst *CCBI) {
-    SGM.useConformancesFromType(CCBI->getSourceFormalType());
-    SGM.useConformancesFromType(CCBI->getTargetFormalType());
-    SGM.useConformancesFromObjectiveCType(CCBI->getSourceFormalType());
-    SGM.useConformancesFromObjectiveCType(CCBI->getTargetFormalType());
+    SGM.useConformancesFromType(CCBI, CCBI->getSourceFormalType());
+    SGM.useConformancesFromType(CCBI, CCBI->getTargetFormalType());
+    SGM.useConformancesFromObjectiveCType(CCBI, CCBI->getSourceFormalType());
+    SGM.useConformancesFromObjectiveCType(CCBI, CCBI->getTargetFormalType());
   }
 
   void visitCheckedCastAddrBranchInst(CheckedCastAddrBranchInst *CCABI) {
-    SGM.useConformancesFromType(CCABI->getSourceFormalType());
-    SGM.useConformancesFromType(CCABI->getTargetFormalType());
-    SGM.useConformancesFromObjectiveCType(CCABI->getSourceFormalType());
-    SGM.useConformancesFromObjectiveCType(CCABI->getTargetFormalType());
+    SGM.useConformancesFromType(CCABI, CCABI->getSourceFormalType());
+    SGM.useConformancesFromType(CCABI, CCABI->getTargetFormalType());
+    SGM.useConformancesFromObjectiveCType(CCABI, CCABI->getSourceFormalType());
+    SGM.useConformancesFromObjectiveCType(CCABI, CCABI->getTargetFormalType());
   }
 
   void visitCopyAddrInst(CopyAddrInst *CAI) {
-    SGM.useConformancesFromType(CAI->getSrc()->getType().getASTType());
-    SGM.useConformancesFromType(CAI->getDest()->getType().getASTType());
+    SGM.useConformancesFromType(CAI, CAI->getSrc()->getType().getASTType());
+    SGM.useConformancesFromType(CAI, CAI->getDest()->getType().getASTType());
   }
 
   void visitMarkUnresolvedMoveAddrInst(MarkUnresolvedMoveAddrInst *MAI) {
-    SGM.useConformancesFromType(MAI->getSrc()->getType().getASTType());
-    SGM.useConformancesFromType(MAI->getDest()->getType().getASTType());
+    SGM.useConformancesFromType(MAI, MAI->getSrc()->getType().getASTType());
+    SGM.useConformancesFromType(MAI, MAI->getDest()->getType().getASTType());
   }
 
   void visitCopyValueInst(CopyValueInst *CVI) {
-    SGM.useConformancesFromType(CVI->getOperand()->getType().getASTType());
+    SGM.useConformancesFromType(CVI, CVI->getOperand()->getType().getASTType());
   }
 
   void visitDestroyAddrInst(DestroyAddrInst *DAI) {
-    SGM.useConformancesFromType(DAI->getOperand()->getType().getASTType());
+    SGM.useConformancesFromType(DAI, DAI->getOperand()->getType().getASTType());
   }
 
   void visitDestroyValueInst(DestroyValueInst *DVI) {
-    SGM.useConformancesFromType(DVI->getOperand()->getType().getASTType());
+    SGM.useConformancesFromType(DVI, DVI->getOperand()->getType().getASTType());
   }
 
   void visitGlobalAddrInst(GlobalAddrInst *GAI) {
-    SGM.useConformancesFromType(
+    SGM.useConformancesFromType(GAI,
         GAI->getReferencedGlobal()->getLoweredType().getASTType());
   }
 
   void visitGlobalValueInst(GlobalValueInst *GVI) {
-    SGM.useConformancesFromType(
+    SGM.useConformancesFromType(GVI,
         GVI->getReferencedGlobal()->getLoweredType().getASTType());
   }
 
   void visitKeyPathInst(KeyPathInst *KPI) {
-    SGM.useConformancesFromSubstitutions(KPI->getSubstitutions());
+    SGM.useConformancesFromSubstitutions(KPI, KPI->getSubstitutions());
   }
 
   void visitInitEnumDataAddrInst(InitEnumDataAddrInst *IEDAI) {
-    SGM.useConformancesFromType(
+    SGM.useConformancesFromType(IEDAI,
         IEDAI->getOperand()->getType().getASTType());
   }
 
   void visitInjectEnumAddrInst(InjectEnumAddrInst *IEAI) {
-    SGM.useConformancesFromType(IEAI->getOperand()->getType().getASTType());
+    SGM.useConformancesFromType(IEAI, IEAI->getOperand()->getType().getASTType());
   }
 
   void visitInitExistentialAddrInst(InitExistentialAddrInst *IEAI) {
-    SGM.useConformancesFromType(IEAI->getFormalConcreteType());
-    SGM.useConformancesFromObjectiveCType(IEAI->getFormalConcreteType());
+    SGM.useConformancesFromType(IEAI, IEAI->getFormalConcreteType());
+    SGM.useConformancesFromObjectiveCType(IEAI, IEAI->getFormalConcreteType());
     for (auto conformance : IEAI->getConformances())
-      SGM.useConformance(conformance);
+      SGM.useConformance(IEAI, conformance);
   }
 
   void visitInitExistentialMetatypeInst(InitExistentialMetatypeInst *IEMI) {
-    SGM.useConformancesFromType(IEMI->getOperand()->getType().getASTType());
+    SGM.useConformancesFromType(IEMI, IEMI->getOperand()->getType().getASTType());
     for (auto conformance : IEMI->getConformances())
-      SGM.useConformance(conformance);
+      SGM.useConformance(IEMI, conformance);
   }
 
   void visitInitExistentialRefInst(InitExistentialRefInst *IERI) {
-    SGM.useConformancesFromType(IERI->getFormalConcreteType());
-    SGM.useConformancesFromObjectiveCType(IERI->getFormalConcreteType());
+    SGM.useConformancesFromType(IERI, IERI->getFormalConcreteType());
+    SGM.useConformancesFromObjectiveCType(IERI, IERI->getFormalConcreteType());
     for (auto conformance : IERI->getConformances())
-      SGM.useConformance(conformance);
+      SGM.useConformance(IERI, conformance);
   }
 
   void visitInitExistentialValueInst(InitExistentialValueInst *IEVI) {
-    SGM.useConformancesFromType(IEVI->getFormalConcreteType());
-    SGM.useConformancesFromObjectiveCType(IEVI->getFormalConcreteType());
+    SGM.useConformancesFromType(IEVI, IEVI->getFormalConcreteType());
+    SGM.useConformancesFromObjectiveCType(IEVI, IEVI->getFormalConcreteType());
     for (auto conformance : IEVI->getConformances())
-      SGM.useConformance(conformance);
+      SGM.useConformance(IEVI, conformance);
   }
 
   void visitMetatypeInst(MetatypeInst *MI) {
-    SGM.useConformancesFromType(MI->getType().getASTType());
+    SGM.useConformancesFromType(MI, MI->getType().getASTType());
   }
 
   void visitPartialApplyInst(PartialApplyInst *PAI) {
-    SGM.useConformancesFromObjectiveCType(PAI->getSubstCalleeType());
-    SGM.useConformancesFromSubstitutions(PAI->getSubstitutionMap());
+    SGM.useConformancesFromObjectiveCType(PAI, PAI->getSubstCalleeType());
+    SGM.useConformancesFromSubstitutions(PAI, PAI->getSubstitutionMap());
   }
 
   void visitSelectEnumAddrInst(SelectEnumAddrInst *SEAI) {
-    SGM.useConformancesFromType(
+    SGM.useConformancesFromType(SEAI,
         SEAI->getEnumOperand()->getType().getASTType());
   }
 
   void visitStructElementAddrInst(StructElementAddrInst *SEAI) {
-    SGM.useConformancesFromType(SEAI->getOperand()->getType().getASTType());
+    SGM.useConformancesFromType(SEAI, SEAI->getOperand()->getType().getASTType());
   }
 
   void visitTryApplyInst(TryApplyInst *TAI) {
-    SGM.useConformancesFromObjectiveCType(TAI->getSubstCalleeType());
-    SGM.useConformancesFromSubstitutions(TAI->getSubstitutionMap());
+    SGM.useConformancesFromObjectiveCType(TAI, TAI->getSubstCalleeType());
+    SGM.useConformancesFromSubstitutions(TAI, TAI->getSubstitutionMap());
   }
 
   void visitTupleElementAddrInst(TupleElementAddrInst *TEAI) {
-    SGM.useConformancesFromType(TEAI->getOperand()->getType().getASTType());
+    SGM.useConformancesFromType(TEAI, TEAI->getOperand()->getType().getASTType());
   }
 
   void visitUnconditionalCheckedCastInst(UnconditionalCheckedCastInst *UCCI) {
-    SGM.useConformancesFromType(UCCI->getSourceFormalType());
-    SGM.useConformancesFromType(UCCI->getTargetFormalType());
-    SGM.useConformancesFromObjectiveCType(UCCI->getSourceFormalType());
-    SGM.useConformancesFromObjectiveCType(UCCI->getTargetFormalType());
+    SGM.useConformancesFromType(UCCI, UCCI->getSourceFormalType());
+    SGM.useConformancesFromType(UCCI, UCCI->getTargetFormalType());
+    SGM.useConformancesFromObjectiveCType(UCCI, UCCI->getSourceFormalType());
+    SGM.useConformancesFromObjectiveCType(UCCI, UCCI->getTargetFormalType());
   }
 
   void visitUnconditionalCheckedCastAddrInst(UnconditionalCheckedCastAddrInst *UCCAI) {
-    SGM.useConformancesFromType(UCCAI->getSourceFormalType());
-    SGM.useConformancesFromType(UCCAI->getTargetFormalType());
-    SGM.useConformancesFromObjectiveCType(UCCAI->getSourceFormalType());
-    SGM.useConformancesFromObjectiveCType(UCCAI->getTargetFormalType());
+    SGM.useConformancesFromType(UCCAI, UCCAI->getSourceFormalType());
+    SGM.useConformancesFromType(UCCAI, UCCAI->getTargetFormalType());
+    SGM.useConformancesFromObjectiveCType(UCCAI, UCCAI->getSourceFormalType());
+    SGM.useConformancesFromObjectiveCType(UCCAI, UCCAI->getTargetFormalType());
   }
 
   void visitUncheckedTakeEnumDataAddrInst(UncheckedTakeEnumDataAddrInst *UTEDAI) {
-    SGM.useConformancesFromType(UTEDAI->getOperand()->getType().getASTType());
+    SGM.useConformancesFromType(UTEDAI, UTEDAI->getOperand()->getType().getASTType());
   }
 
   void visitWitnessMethodInst(WitnessMethodInst *WMI) {
-    SGM.useConformance(WMI->getConformance());
+    SGM.useConformance(WMI, WMI->getConformance());
   }
 
   void visitSILInstruction(SILInstruction *I) {}
@@ -357,33 +373,33 @@ void SILGenModule::emitLazyConformancesForType(NominalTypeDecl *NTD) {
 
   for (auto reqt : genericSig.getRequirements()) {
     if (reqt.getKind() != RequirementKind::Layout)
-      useConformancesFromType(reqt.getSecondType()->getCanonicalType());
+      useConformancesFromType(nullptr, reqt.getSecondType()->getCanonicalType());
   }
 
   if (auto *ED = dyn_cast<EnumDecl>(NTD)) {
     for (auto *EED : ED->getAllElements()) {
       if (EED->hasAssociatedValues()) {
-        useConformancesFromType(EED->getPayloadInterfaceType()
-                                   ->getReducedType(genericSig));
+        useConformancesFromType(nullptr, EED->getPayloadInterfaceType()
+                                            ->getReducedType(genericSig));
       }
     }
   }
 
   if (isa<StructDecl>(NTD) || isa<ClassDecl>(NTD)) {
     for (auto *VD : NTD->getStoredProperties()) {
-      useConformancesFromType(VD->getValueInterfaceType()
-                                ->getReducedType(genericSig));
+      useConformancesFromType(nullptr, VD->getValueInterfaceType()
+                                          ->getReducedType(genericSig));
     }
   }
 
   if (auto *CD = dyn_cast<ClassDecl>(NTD))
     if (auto superclass = CD->getSuperclass())
-      useConformancesFromType(superclass->getReducedType(genericSig));
+      useConformancesFromType(nullptr, superclass->getReducedType(genericSig));
 
   if (auto *PD = dyn_cast<ProtocolDecl>(NTD)) {
     for (auto reqt : PD->getRequirementSignature().getRequirements()) {
       if (reqt.getKind() != RequirementKind::Layout)
-        useConformancesFromType(reqt.getSecondType()->getCanonicalType());
+        useConformancesFromType(nullptr, reqt.getSecondType()->getCanonicalType());
     }
   }
 }

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -624,7 +624,7 @@ public:
     });
 
     // Emit the witness table for the base conformance if it is shared.
-    SGM.useConformance(ProtocolConformanceRef(conformance));
+    SGM.useConformance(nullptr, ProtocolConformanceRef(conformance));
   }
 
   Witness getWitness(ValueDecl *decl) {
@@ -695,7 +695,7 @@ public:
     auto assocConformance =
       Conformance->getAssociatedConformance(req.getAssociation(),
                                             req.getAssociatedRequirement());
-    SGM.useConformance(assocConformance);
+    SGM.useConformance(nullptr, assocConformance);
     Entries.push_back(SILWitnessTable::AssociatedConformanceWitness{
         req.getAssociation(), assocConformance});
   }


### PR DESCRIPTION
When we find an invalid conformance here, we would print a message with no further information. Change the method to take a SILInstruction as well, since we have one most of the time. If an instruction is provided, we print it out together with the parent SILFunction.