### PR TITLE
[cxx-interop] Reenable disabled test

### DIFF
--- a/test/Interop/Cxx/stdlib/use-std-span.swift
+++ b/test/Interop/Cxx/stdlib/use-std-span.swift
@@ -4,9 +4,6 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20 -Xcc -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG -enable-experimental-feature BorrowingForLoop)
 
 
-// TODO: test failed in macOS PR testing but passes locally: rdar://163049442
-// UNSUPPORTED: OS_FAMILY=darwin && !CPU=arm64
-
 // REQUIRES: executable_test
 // REQUIRES: std_span
 // REQUIRES: swift_feature_BorrowingForLoop


### PR DESCRIPTION
The rdar seems to be a duplicate of another one that is already resolved. Let's see if this passes now.
