### PR TITLE
[6.3] [embedded] Link newly created specialized functions to bring in witness tables

### DIFF
--- a/lib/SILOptimizer/Transforms/GenericSpecializer.cpp
+++ b/lib/SILOptimizer/Transforms/GenericSpecializer.cpp
@@ -173,6 +173,19 @@ bool swift::specializeAppliesInFunction(SILFunction &F,
         recursivelyDeleteTriviallyDeadInstructions(AI, true);
         Changed = true;
       }
+      // Specialization might create new references to conformances.
+      // A specialized init_existential_ref might now refer to a concrete
+      // conformance.
+      // In Embedded swift protocol witness tables are emitted lazily. Therefore
+      // deserialization of the sil_witness_table becomes mandatory if it is
+      // referenced because we can't rely on it being defined in the originating
+      // module.
+      if (isMandatory &&
+          FunctionBuilder.getModule().getASTContext().LangOpts.hasFeature(Feature::Embedded)) {
+        for (SILFunction *NewF : reverse(NewFunctions)) {
+          FunctionBuilder.getModule().linkFunction(NewF, SILModule::LinkingMode::LinkNormal);
+        }
+      }
 
       if (auto *sft = dyn_cast<SILFunctionTransform>(transform)) {
         // If calling the specialization utility resulted in new functions

--- a/test/embedded/existential-class-bound8.swift
+++ b/test/embedded/existential-class-bound8.swift
@@ -2,10 +2,18 @@
 // RUN: %{python} %utils/split_file.py -o %t %s
 
 // RUN: %target-swift-frontend -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded -parse-as-library
+// RUN: %target-swift-frontend -c -o %t/MyModule.o %t/MyModule.swift -enable-experimental-feature Embedded -parse-as-library
 // RUN: %target-swift-frontend -c -I %t %t/Main.swift -enable-experimental-feature Embedded -o %t/a.o
+
+// RUN: %llvm-nm -a %t/MyModule.o | %FileCheck --check-prefix=ORIGINBINARY %s
+// RUN: %llvm-nm -a %t/a.o | %FileCheck --check-prefix=CLIENTBINARY %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_Embedded
+
+
+// ORIGINBINARY-NOT: e8MyModule0A5ClassCAA08InternalC5BoundAAWP
+// CLIENTBINARY: {{(S|V|W)}} {{(_)?}}$e8MyModule0A5ClassCAA08InternalC5BoundAAWP
 
 // BEGIN MyModule.swift
 
@@ -15,6 +23,30 @@ public protocol Base: AnyObject {
 
 public protocol ClassBound: Base {
     func foo()
+}
+
+
+public protocol InternalClassBound : AnyObject {
+  func foo()
+}
+
+public class CaptureExistential : ClassBound {
+  let c : InternalClassBound
+
+  init(_ e: InternalClassBound) {
+    self.c = e
+  }
+
+  public func foo() {
+    c.foo()
+  }
+
+  public func bar() { print("bar") }
+}
+
+public class MyClass : InternalClassBound {
+  public init() {}
+  public func foo() { print("MyClass.foo()") }
 }
 
 class MyGenericClass<T> {
@@ -30,11 +62,23 @@ public func factory() -> any ClassBound {
     return MyGenericClass<String>(typ: "String")
 }
 
+
+@inline(never)
+func genericCreate<T: InternalClassBound>(_ t: T) -> CaptureExistential {
+    let exist : InternalClassBound = t
+    return CaptureExistential(exist)
+}
+
+@inline(never)
+public func genericFactory<T: InternalClassBound>(_ t: T) -> CaptureExistential? {
+    return genericCreate(t)
+}
+
 // BEGIN Main.swift
 
 import MyModule
 
-var arr: [any ClassBound] = [factory()]
+var arr: [any ClassBound] = [factory(), genericFactory(MyClass())!]
 arr[0].foo()
 // CHECK: MyGenericClass<String>.foo()
 arr[0].foo()


### PR DESCRIPTION
Issue:
Specialization might create new references to conformances. A specialized init_existential_ref might now refer to a concrete conformance.
In Embedded swift protocol witness tables are emitted lazily. Therefore deserialization of the sil_witness_table becomes mandatory if it is referenced because we can't rely on it being defined in the originating module.
Failure leads to missing symbols.

Risk: Medium, we link in new code in the middle of the manditory optimization pipeline. Downstream effects possible.

Testing: A unit test was added.

Reviewed by: @eeckstein, @DougGregor

Main PR: https://github.com/swiftlang/swift/pull/86491

rdar://167843592