### PR TITLE
[basic] Add llvm::reportFatal{Internal,Usage}Error that use a llvm::raw_ostream closure based API so normal C++ dumpers can be used ergonomically.

### DIFF
--- a/include/swift/Basic/LLVMExtras.h
+++ b/include/swift/Basic/LLVMExtras.h
@@ -19,7 +19,10 @@
 
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/raw_ostream.h"
 
 namespace swift {
 
@@ -30,6 +33,35 @@ namespace swift {
 template <typename T, unsigned N>
 using SmallSetVector = llvm::SetVector<T, llvm::SmallVector<T, N>,
       llvm::SmallDenseSet<T, N, llvm::DenseMapInfo<T>>>;
+
+using llvm::reportFatalInternalError;
+using llvm::reportFatalUsageError;
+
+/// A helper for reportFatalInternalError that allows for a raw_ostream to be
+/// used so that normal ostream printing constructs can be used with
+/// reportFatalInternalError.
+static inline void reportFatalInternalError(
+    llvm::function_ref<void(llvm::raw_ostream &)> callback) {
+  llvm::SmallString<64> result;
+  {
+    llvm::raw_svector_ostream os(result);
+    callback(os);
+  }
+  reportFatalInternalError(result.str());
+}
+
+/// A helper for reportFatalInternalError that allows for a raw_ostream to be
+/// used so that normal ostream printing constructs can be used with
+/// reportFatalInternalError.
+static inline void
+reportFatalUsageError(llvm::function_ref<void(llvm::raw_ostream &)> callback) {
+  llvm::SmallString<64> result;
+  {
+    llvm::raw_svector_ostream os(result);
+    callback(os);
+  }
+  reportFatalUsageError(result.str());
+}
 
 } // namespace swift
 


### PR DESCRIPTION
LLVM is switching to use these APIs instead of report_fatal_error. One unfortunate characteristic of these APIs is that they take Twines and StringRefs so if one wants to use a type that uses raw_ostream based print APIs, one has to by hand create a SmallString, create an ostream to put the value into the SmallString and then call the API. These helpers just perform that initial bit of work of creating the SmallString and ostream and pass in the ostream to the callback. After the callback returns, we pass the SmallString to reportFatal{Internal,Usage}Error.

I also imported the llvm APIs into the swift namespace as well.
