### PR TITLE
[rbi] Make SILIsolationInfo::isNonSendableType assert that a type is not an interface type.

### DIFF
--- a/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
+++ b/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
@@ -574,6 +574,12 @@ public:
   /// E.x.: Builtin.RawPointer and Builtin.NativeObject
   ///
   /// TODO: Fix the type checker.
+  ///
+  /// NOTE: It is assumed that type is /not/ an interface type. We assert inside
+  /// as such.
+  ///
+  /// NOTE: We assume that if type is a generic environment, it is the one
+  /// associated with \p fn. It cannot just be a random function.
   static bool isNonSendableType(SILType type, SILFunction *fn);
 
   static bool isSendableType(SILType type, SILFunction *fn) {

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -1585,6 +1585,9 @@ void SILIsolationInfo::printForOneLineLogging(SILFunction *fn,
 // NOTE: We special case RawPointer and NativeObject to ensure they are
 // treated as non-Sendable and strict checking is applied to it.
 bool SILIsolationInfo::isNonSendableType(SILType type, SILFunction *fn) {
+  assert(!type.hasTypeParameter() &&
+         "We assume that type is not an interface type");
+
   // Treat Builtin.NativeObject, Builtin.RawPointer, and Builtin.BridgeObject as
   // non-Sendable.
   if (type.getASTType()->is<BuiltinNativeObjectType>() ||


### PR DESCRIPTION
I was going to make isNonSendableType just map the type into an interface type... but I decided not to since it would make the way of using the API more confusing. Better to just make it an invariant that the caller has to obey.
