### PR TITLE
[MiscDiagnostics] Modernize `checkUseOfMetaTypeName`

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5005,8 +5005,7 @@ ERROR(value_of_module_type,none,
       "expected module member name after module name", ())
 
 ERROR(value_of_metatype_type,none,
-      "expected member name or initializer call after type name%select{|; this "
-      "will be an error in Swift 6}0", (bool))
+      "expected member name or initializer call after type name", ())
 
 NOTE(add_parens_to_type,none,
      "add arguments after the type to construct a value of the type", ())

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -735,41 +735,35 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
       if (!AlreadyDiagnosedMetatypes.insert(E).second)
         return;
 
-      DiagnosticBehavior behavior = DiagnosticBehavior::Error;
+      auto *ParentExpr = Parent.getAsExpr();
 
-      if (auto *ParentExpr = Parent.getAsExpr()) {
-        if (ParentExpr->isValidParentOfTypeExpr(E))
-          return;
+      if (ParentExpr && ParentExpr->isValidParentOfTypeExpr(E))
+        return;
 
-        // In Swift < 6 warn about
-        // - plain type name passed as an argument to a subscript, dynamic
-        //   subscript, or ObjC literal since it used to be accepted.
-        // - member type expressions rooted on non-identifier types, e.g.
-        //   '[X].Y' since they used to be accepted without the '.self'.
-        if (!Ctx.isLanguageModeAtLeast(6)) {
-          if (isa<SubscriptExpr>(ParentExpr) ||
-              isa<DynamicSubscriptExpr>(ParentExpr) ||
-              isa<ObjectLiteralExpr>(ParentExpr)) {
-            auto *argList = ParentExpr->getArgs();
-            assert(argList);
-            if (argList->isUnlabeledUnary())
-              behavior = DiagnosticBehavior::Warning;
-          } else if (auto *TE = dyn_cast<TypeExpr>(E)) {
-            if (auto *QualIdentTR = dyn_cast_or_null<QualifiedIdentTypeRepr>(
-                    TE->getTypeRepr())) {
-              if (!isa<UnqualifiedIdentTypeRepr>(QualIdentTR->getRoot())) {
-                behavior = DiagnosticBehavior::Warning;
-              }
-            }
+      // In Swift < 6 warn about
+      // - plain type name passed as an argument to a subscript, dynamic
+      //   subscript, or ObjC literal since it used to be accepted.
+      // - member type expressions rooted on non-identifier types, e.g.
+      //   '[X].Y' since they used to be accepted without the '.self'.
+      bool downgradeToWarningUntil6 = false;
+      if (!Ctx.isLanguageModeAtLeast(6)) {
+        if (ParentExpr && (isa<SubscriptExpr>(ParentExpr) ||
+                           isa<DynamicSubscriptExpr>(ParentExpr) ||
+                           isa<ObjectLiteralExpr>(ParentExpr))) {
+          auto *argList = ParentExpr->getArgs();
+          assert(argList);
+          downgradeToWarningUntil6 = argList->isUnlabeledUnary();
+        } else if (auto *TE = dyn_cast<TypeExpr>(E)) {
+          if (auto *QualIdentTR =
+                  dyn_cast_or_null<QualifiedIdentTypeRepr>(TE->getTypeRepr())) {
+            downgradeToWarningUntil6 =
+                !isa<UnqualifiedIdentTypeRepr>(QualIdentTR->getRoot());
           }
         }
       }
 
-      // Is this a protocol metatype?
-      Ctx.Diags
-          .diagnose(E->getStartLoc(), diag::value_of_metatype_type,
-                    behavior == DiagnosticBehavior::Warning)
-          .limitBehavior(behavior);
+      Ctx.Diags.diagnose(E->getStartLoc(), diag::value_of_metatype_type)
+          .warnUntilLanguageModeIf(downgradeToWarningUntil6, 6);
 
       // Add fix-it to insert '()', only if this is a metatype of
       // non-existential type and has any initializers.

--- a/test/Constraints/dynamic_lookup.swift
+++ b/test/Constraints/dynamic_lookup.swift
@@ -454,11 +454,11 @@ func test_dynamic_subscript_accepts_type_name_argument() {
   }
 
   func test(a: AnyObject, optA: AnyObject?) {
-    let _ = a[A] // expected-warning {{expected member name or initializer call after type name; this will be an error in Swift 6}}
+    let _ = a[A] // expected-warning {{expected member name or initializer call after type name; this is an error in the Swift 6 language mode}}
     // expected-note@-1 {{add arguments after the type to construct a value of the type}} {{16-16=()}}
     // expected-note@-2 {{use '.self' to reference the type object}} {{16-16=.self}}
 
-    let _ = optA?[A] // expected-warning {{expected member name or initializer call after type name; this will be an error in Swift 6}}
+    let _ = optA?[A] // expected-warning {{expected member name or initializer call after type name; this is an error in the Swift 6 language mode}}
     // expected-note@-1 {{add arguments after the type to construct a value of the type}} {{20-20=()}}
     // expected-note@-2 {{use '.self' to reference the type object}} {{20-20=.self}}
   }

--- a/test/Constraints/subscript.swift
+++ b/test/Constraints/subscript.swift
@@ -230,11 +230,11 @@ func test_subscript_accepts_type_name_argument() {
   }
 
   func test(a: A, optA: A?) {
-    let _ = a[A] // expected-warning {{expected member name or initializer call after type name; this will be an error in Swift 6}}
+    let _ = a[A] // expected-warning {{expected member name or initializer call after type name; this is an error in the Swift 6 language mode}}
     // expected-note@-1 {{add arguments after the type to construct a value of the type}} {{16-16=()}}
     // expected-note@-2 {{use '.self' to reference the type object}} {{16-16=.self}}
 
-    let _ = optA?[A] // expected-warning {{expected member name or initializer call after type name; this will be an error in Swift 6}}
+    let _ = optA?[A] // expected-warning {{expected member name or initializer call after type name; this is an error in the Swift 6 language mode}}
     // expected-note@-1 {{add arguments after the type to construct a value of the type}} {{20-20=()}}
     // expected-note@-2 {{use '.self' to reference the type object}} {{20-20=.self}}
   }

--- a/test/type/nested_types.swift
+++ b/test/type/nested_types.swift
@@ -92,20 +92,20 @@ do {
 
     func test() {
       blackHole(Self.E)
-      // expected-warning@-1 {{expected member name or initializer call after type name; this will be an error in Swift 6}}
+      // expected-warning@-1 {{expected member name or initializer call after type name; this is an error in the Swift 6 language mode}}
       // expected-note@-2 {{use '.self' to reference the type object}}
       blackHole((Test).E)
-      // expected-warning@-1 {{expected member name or initializer call after type name; this will be an error in Swift 6}}
+      // expected-warning@-1 {{expected member name or initializer call after type name; this is an error in the Swift 6 language mode}}
       // expected-note@-2 {{use '.self' to reference the type object}}
       blackHole([Test].Element)
-      // expected-warning@-1 {{expected member name or initializer call after type name; this will be an error in Swift 6}}
+      // expected-warning@-1 {{expected member name or initializer call after type name; this is an error in the Swift 6 language mode}}
       // expected-note@-2 {{use '.self' to reference the type object}}
       // expected-note@-3 {{add arguments after the type to construct a value of the type}}
       blackHole([Int : Test].Element)
-      // expected-warning@-1 {{expected member name or initializer call after type name; this will be an error in Swift 6}}
+      // expected-warning@-1 {{expected member name or initializer call after type name; this is an error in the Swift 6 language mode}}
       // expected-note@-2 {{use '.self' to reference the type object}}
       blackHole(Test?.Wrapped)
-      // expected-warning@-1 {{expected member name or initializer call after type name; this will be an error in Swift 6}}
+      // expected-warning@-1 {{expected member name or initializer call after type name; this is an error in the Swift 6 language mode}}
       // expected-note@-2 {{use '.self' to reference the type object}}
       // expected-note@-3 {{add arguments after the type to construct a value of the type}}
     }

--- a/test/type/self.swift
+++ b/test/type/self.swift
@@ -389,12 +389,20 @@ class Container {
     init(value: Int) {}
   }
 
+  func test<T>(_: T.Type) {}
+  
   func someFunc() {
     let _ = [Container.NestedType]()  // ok
     let _ = [Self.NestedType]()  // ok
 
-    _ = Self.NestedType // expected-warning {{expected member name or initializer call after type name; this will be an error in Swift 6}}
+    _ = Self.NestedType // expected-warning {{expected member name or initializer call after type name; this is an error in the Swift 6 language mode}}
     // expected-note@-1 {{add arguments after the type to construct a value of the type}}
     // expected-note@-2 {{use '.self' to reference the type object}} {{24-24=.self}}
+    let _ = Self.NestedType // expected-warning {{expected member name or initializer call after type name; this is an error in the Swift 6 language mode}}
+    // expected-note@-1 {{add arguments after the type to construct a value of the type}}
+    // expected-note@-2 {{use '.self' to reference the type object}} {{28-28=.self}}
+    test(Self.NestedType) // expected-warning {{expected member name or initializer call after type name; this is an error in the Swift 6 language mode}}
+    // expected-note@-1 {{add arguments after the type to construct a value of the type}}
+    // expected-note@-2 {{use '.self' to reference the type object}} {{25-25=.self}}
   }
 }


### PR DESCRIPTION
This is a follow-up to https://github.com/swiftlang/swift/pull/86499.

Make sure that the error is downgraded even when there is no parent expression, this covers pattern binding initializer expressions which started to error after `DynamicSelf` change.

Replace a custom "will be an error in Swift 6" with a modern downgrade API.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
