### PR TITLE
[demangling] Handle malformed AutoDiffSubsetParametersThunk

### DIFF
--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -2287,6 +2287,10 @@ NodePointer NodePrinter::print(NodePointer Node, unsigned depth,
   }
   case Node::Kind::AutoDiffSubsetParametersThunk: {
     Printer << "autodiff subset parameters thunk for ";
+    if (Node->getNumChildren() < 5) {
+      setInvalid();
+      return nullptr;
+    }
     auto currentIndex = Node->getNumChildren() - 1;
     auto toParamIndices = Node->getChild(currentIndex--);
     auto resultIndices = Node->getChild(currentIndex--);

--- a/test/Demangle/validate-auto-diff-subset-params.test
+++ b/test/Demangle/validate-auto-diff-subset-params.test
@@ -1,0 +1,3 @@
+# Test that a malformed AutoDiffSubsetParametersThunk is handled gracefully
+RUN: %swift-demangle '$STJSdSSSSSSSSSSSSSpSrSSP' | %FileCheck %s --check-prefix=PASSTHROUGH
+PASSTHROUGH: $STJSdSSSSSSSSSSSSSpSrSSP ---> $STJSdSSSSSSSSSSSSSpSrSSP


### PR DESCRIPTION
## Summary
Add a check to make sure there are enough node children present to process an `AutoDiffSubsetParametersThunk`.

## Details
This prevents an integer underflow when calculating indices that could lead to very large and invalid indices causing high CPU and memory usage for an indefinite amount of time -- generally until an OOM.

## Example behavior without a fix
When running the included test without the fix:
```bash
% ps aux | head -n1 && ps aux | grep swift-demangle
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
erahm    2403955  100  8.6 58213672 21451488 pts/10 R 18:42   0:15 swift-project/build/Ninja-RelWithDebInfoAssert/swift-linux-x86_64/bin/swift-demangle $STJSdSSSSSSSSSSSSSpSrSSP
```
The test itself will not complete in a reasonable amount of time and will potentially OOM.
## Example behavior with a fix
```bash
 % swift-project/build/Ninja-RelWithDebInfoAssert/swift-linux-x86_64/bin/swift-demangle '$STJSdSSSSSSSSSSSSSpSrSSP'
$STJSdSSSSSSSSSSSSSpSrSSP ---> $STJSdSSSSSSSSSSSSSpSrSSP
```
The malformed symbol is simply returned as-is.
