### PR TITLE
[6.3] Fix DefiniteInititalization diagnostics for empty types

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -222,7 +222,7 @@ ERROR(ivar_not_initialized_at_implicit_superinit,none,
       (StringRef, bool))
 ERROR(ivar_not_initialized_by_init_accessor,none,
       "property %0 not initialized by init accessor",
-      (DeclName))
+      (StringRef))
 
 ERROR(noncopyable_dynamic_lifetime_unsupported,none,
       "conditional initialization or destruction of noncopyable types is not "

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -390,6 +390,10 @@ public:
   /// struct containing only empty types.
   bool isEmpty(const SILFunction &F) const;
 
+  /// True if the type is an empty tuple or a tuple containing only empty
+  /// tuples.
+  bool isEmptyTuple(const SILFunction &F) const;
+
   /// True if the type, or the referenced type of an address type, is known to
   /// be a scalar reference-counted type such as a class, box, or thick function
   /// type. Returns false for non-trivial aggregates.

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -213,6 +213,20 @@ bool SILType::isEmpty(const SILFunction &F) const {
   return false;
 }
 
+bool SILType::isEmptyTuple(const SILFunction &F) const {
+  if (auto tupleTy = getAs<TupleType>()) {
+    // A tuple is empty if it either has no elements or if all elements are
+    // empty.
+    for (unsigned idx = 0, num = tupleTy->getNumElements(); idx < num; ++idx) {
+      if (!getTupleElementType(idx).isEmptyTuple(F))
+        return false;
+    }
+    return true;
+  }
+
+  return false;
+}
+
 bool SILType::isReferenceCounted(SILModule &M) const {
   return M.Types.getTypeLowering(*this,
                                  TypeExpansionContext::minimal())

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -1197,13 +1197,14 @@ void LifetimeChecker::doIt() {
 
   // All of the indirect results marked as "out" have to be fully initialized
   // before their lifetime ends.
-  if (TheMemory.isOut()) {
+  if (TheMemory.isOut() &&
+      !TheMemory.getType().isEmptyTuple(TheMemory.getFunction())) {
     auto diagnoseMissingInit = [&]() {
       std::string propertyName;
-      auto *property = TheMemory.getPathStringToElement(0, propertyName);
+      TheMemory.getPathStringToElement(0, propertyName);
       diagnose(Module, F.getLocation(),
                diag::ivar_not_initialized_by_init_accessor,
-               property->getName());
+               StringRef("'" + propertyName + "'"));
       EmittedErrorLocs.push_back(TheMemory.getLoc());
     };
 

--- a/test/SILOptimizer/definite_init_crashes.sil
+++ b/test/SILOptimizer/definite_init_crashes.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all %s -definite-init -raw-sil-inst-lowering | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -definite-init -raw-sil-inst-lowering -verify | %FileCheck %s
 
 // These are all regression tests to ensure that the memory promotion pass
 // doesn't crash.
@@ -129,5 +129,38 @@ bb5(%40 : @owned $Error):
   destroy_addr %4 : $*AStruct
   dealloc_stack %3 : $*AStruct
   throw %40 : $Error
+}
+
+struct Empty {}
+
+sil hidden [ossa] @empty_tuple_di1 : $@convention(thin) () -> @out () {
+bb0(%0 : $*()):
+  %2 = mark_uninitialized [out] %0
+  %3 = tuple ()
+  %5 = begin_access [modify] [static] %2
+  end_access %5
+  %7 = tuple ()
+  return %7
+}
+
+sil hidden [ossa] @empty_tuple_di2 : $@convention(thin) () -> @out ((), ()) {
+bb0(%0 : $*((), ())):
+  %2 = mark_uninitialized [out] %0
+  %3 = tuple ()
+  %5 = begin_access [modify] [static] %2
+  end_access %5
+  %7 = tuple ()
+  return %7
+}
+
+// Ensure no crash while emitting a diagnostic
+sil hidden [ossa] @empty_struct_di : $@convention(thin) () -> @out Empty { // expected-error{{}}
+bb0(%0 : $*Empty):
+  %2 = mark_uninitialized [out] %0
+  %3 = tuple ()
+  %5 = begin_access [modify] [static] %2
+  end_access %5
+  %7 = tuple ()
+  return %7
 }
 

--- a/test/SILOptimizer/definite_init_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_diagnostics.swift
@@ -1667,3 +1667,4 @@ final class HasInitAccessors {
     ints.append(0)
   }
 }
+

--- a/test/SILOptimizer/init_accessor_definite_init_diagnostics.swift
+++ b/test/SILOptimizer/init_accessor_definite_init_diagnostics.swift
@@ -349,3 +349,27 @@ do {
     }
   }
 }
+
+struct Empty {}
+
+final class Wrapper {
+  var empty1 : Void?
+  var empty2 : Void
+  var empty3 : (Void, Void)
+  var empty4 : Empty
+  var empty5 : (Empty, Empty)
+  var storage: Bool {
+    @storageRestrictions(initializes: empty1, empty2, empty3, empty4, empty5)
+    init(initialValue) { // expected-error {{property 'empty1' not initialized by init accessor}} // expected-error {{property 'empty4' not initialized by init accessor}} // expected-error {{property 'empty5.0' not initialized by init accessor}}
+
+    }
+    get {return true}
+  }
+
+  init() {
+    empty1 = nil
+    empty4 = Empty()
+    empty5 = (Empty(), Empty())
+  }
+}
+


### PR DESCRIPTION
Explanation : This PR does the following:

- getPathStringToElementRec crashes on tuples with 0 elements, add an early return
- Disable raising diagnostics for empty tuples (tuples with 0 elements or tuples containing other tuples of 0 elements) in init accessors
- Don't crash while emitting diagnostic for empty structs

Risk: Low

Testing: lit test

Reviewer: @slavapestov 

Main PR: https://github.com/swiftlang/swift/pull/86296 

