### PR TITLE
Sema: Narrow down cycle-breaking hack in TypeChecker::lookupMemberType()

### DIFF
--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -1341,8 +1341,10 @@ public:
 
     // If we already have an interface type, don't bother trying to
     // avoid a cycle.
-    if (witness->hasInterfaceType())
+    if (witness->hasInterfaceType()) {
+      LLVM_DEBUG(llvm::errs() << "Already has an interface type\n");
       return false;
+    }
 
     // We call checkForPotentailCycle() multiple times with
     // different witnesses.
@@ -4011,6 +4013,8 @@ auto AssociatedTypeInference::solve() -> std::optional<InferredTypeWitnesses> {
     case ResolveWitnessResult::Missing:
       // We did not find the witness via name lookup. Try to derive
       // it below.
+      LLVM_DEBUG(llvm::dbgs() << "Associated type " << assocType->getName()
+                              << " will be inferred\n";);
       break;
     }
 

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -561,11 +561,13 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
       auto *concrete = conformance.getConcrete();
       auto *normal = concrete->getRootNormalConformance();
 
-      // This is the only case where NormalProtocolConformance::
-      // getTypeWitnessAndDecl() returns a null type.
-      if (dc->getASTContext().evaluator.hasActiveRequest(
-            ResolveTypeWitnessesRequest{normal})) {
-        continue;
+      if (!concrete->hasTypeWitness(assocType)) {
+        // This is the only case where NormalProtocolConformance::
+        // getTypeWitnessAndDecl() returns a null type.
+        if (dc->getASTContext().evaluator.hasActiveRequest(
+              ResolveTypeWitnessesRequest{normal})) {
+          continue;
+        }
       }
 
       auto *typeDecl =

--- a/test/AssociatedTypeInference/rdar167849997.swift
+++ b/test/AssociatedTypeInference/rdar167849997.swift
@@ -1,0 +1,35 @@
+// RUN: %target-typecheck-verify-swift
+
+// This was reduced from rdar://167849997. The original code is actually
+// incorrect, because the user wrote 'Self.B' instead of 'B' in the
+// implementation of G, and a qualified lookup there will find the type
+// alias in the protocol extension, and not the generic parameter of
+// 'G' named 'B'.
+//
+// Thus, we would infer the type witness for 'B' to be '()' in the
+// 'G: P' conformance, and not the generic parameter
+// as was probably intended.
+
+let x = G<Int, String>.A.self
+let y = G<Int, String>.B.self
+
+let xx: Int.Type = x
+let yy: ().Type = y
+
+public protocol P {
+  associatedtype A
+  associatedtype B
+
+  func f(_: A, _: B)
+}
+
+public extension P {
+    typealias B = Void
+}
+
+public struct G<A, B>: P {
+  // Note: Self.B
+  public func f(_: A, _: Self.B) {
+    fatalError()
+  }
+}

--- a/test/AssociatedTypeInference/rdar167849997_fixed.swift
+++ b/test/AssociatedTypeInference/rdar167849997_fixed.swift
@@ -1,0 +1,30 @@
+// RUN: %target-typecheck-verify-swift
+
+// This is the "corrected" version of the test case from
+// rdar167849997.swift.
+
+let x = G<Int, String>.A.self
+let y = G<Int, String>.B.self
+
+let xx: Int.Type = x
+let yy: String.Type = y
+
+public protocol P {
+  associatedtype A
+  associatedtype B
+
+  func f(_: A, _: B)
+}
+
+public extension P {
+    typealias B = Void
+}
+
+public struct G<A, B>: P {
+  // FIXME: This should not be necessary
+  public typealias B = B
+
+  public func f(_: A, _: B) {
+    fatalError()
+  }
+}


### PR DESCRIPTION
It's okay if we're in the middle of associated type inference, as long as we've already recorded the type witness we're looking for!

This fixes a regression from 62e4979691570df8e66452eed5be71ce69c7aa54, but what's notable is the cycle breaking hack has been there this whole time. The fact that it was overly broad was only exposed now.

The specific code example in the test case is intentionally wrong. It was reduced from a piece of code that attempted to refer to a generic parameter named `Output` by writing `Self.Output`, and this picked up a protocol type alias instead, so the original project needed to be fixed anyway. But, the regressed behavior was bogus too, because we started to emit a diagnostic that didn't make sense, so let's fix it anyway.

Fixes rdar://problem/167849997.