### PR TITLE
[6.3] [🍒] Fix runtime crash due to miscompile when using result builder via synthesized initializer in non-generic struct

### DIFF
--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -399,6 +399,22 @@ static void emitImplicitValueConstructor(SILGenFunction &SGF,
 
   auto subs = getSubstitutionsForPropertyInitializer(decl, decl);
 
+  /// If the stored property has an attached result builder and its
+  /// type is not a function type, the argument is a noescape closure
+  /// that needs to be called.
+  auto emitResultBuilderCallIfNeeded = [&](VarDecl *field, RValue &&arg) -> RValue {
+    if (field->getResultBuilderType()) {
+      if (!field->getValueInterfaceType()
+              ->lookThroughAllOptionalTypes()->is<AnyFunctionType>()) {
+        auto resultTy = cast<FunctionType>(arg.getType()).getResult();
+        arg = SGF.emitMonomorphicApply(
+            Loc, std::move(arg).getAsSingleValue(SGF, Loc), {}, resultTy,
+            resultTy, ApplyOptions(), std::nullopt, std::nullopt);
+      }
+    }
+    return std::move(arg);
+  };
+
   // If we have an indirect return slot, initialize it in-place.
   if (resultSlot) {
     auto elti = elements.begin(), eltEnd = elements.end();
@@ -457,19 +473,7 @@ static void emitImplicitValueConstructor(SILGenFunction &SGF,
         FullExpr scope(SGF.Cleanups, field->getParentPatternBinding());
 
         RValue arg = std::move(*elti);
-
-        // If the stored property has an attached result builder and its
-        // type is not a function type, the argument is a noescape closure
-        // that needs to be called.
-        if (field->getResultBuilderType()) {
-          if (!field->getValueInterfaceType()
-                  ->lookThroughAllOptionalTypes()->is<AnyFunctionType>()) {
-            auto resultTy = cast<FunctionType>(arg.getType()).getResult();
-            arg = SGF.emitMonomorphicApply(
-                Loc, std::move(arg).getAsSingleValue(SGF, Loc), {}, resultTy,
-                resultTy, ApplyOptions(), std::nullopt, std::nullopt);
-          }
-        }
+        arg = emitResultBuilderCallIfNeeded(field, std::move(arg));
 
         maybeEmitPropertyWrapperInitFromValue(SGF, Loc, field, subs,
                                               std::move(arg))
@@ -544,21 +548,8 @@ static void emitImplicitValueConstructor(SILGenFunction &SGF,
       assert(elti != eltEnd && "number of args does not match number of fields");
       (void)eltEnd;
       value = std::move(*elti);
+      value = emitResultBuilderCallIfNeeded(field, std::move(value));
       ++elti;
-
-      // If the stored property has an attached result builder and its
-      // type is not a function type, the argument is a noescape closure
-      // that needs to be called.
-      if (field->getResultBuilderType()) {
-        if (!field->getValueInterfaceType()
-                 ->lookThroughAllOptionalTypes()
-                 ->is<AnyFunctionType>()) {
-          auto resultTy = cast<FunctionType>(value.getType()).getResult();
-          value = SGF.emitMonomorphicApply(
-              Loc, std::move(value).getAsSingleValue(SGF, Loc), {}, resultTy,
-              resultTy, ApplyOptions(), std::nullopt, std::nullopt);
-        }
-      }
     } else {
       // Otherwise, use its initializer.
       // TODO: This doesn't correctly take into account destructuring

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -545,6 +545,20 @@ static void emitImplicitValueConstructor(SILGenFunction &SGF,
       (void)eltEnd;
       value = std::move(*elti);
       ++elti;
+
+      // If the stored property has an attached result builder and its
+      // type is not a function type, the argument is a noescape closure
+      // that needs to be called.
+      if (field->getResultBuilderType()) {
+        if (!field->getValueInterfaceType()
+                 ->lookThroughAllOptionalTypes()
+                 ->is<AnyFunctionType>()) {
+          auto resultTy = cast<FunctionType>(value.getType()).getResult();
+          value = SGF.emitMonomorphicApply(
+              Loc, std::move(value).getAsSingleValue(SGF, Loc), {}, resultTy,
+              resultTy, ApplyOptions(), std::nullopt, std::nullopt);
+        }
+      }
     } else {
       // Otherwise, use its initializer.
       // TODO: This doesn't correctly take into account destructuring

--- a/test/Constraints/result_builder.swift
+++ b/test/Constraints/result_builder.swift
@@ -869,6 +869,24 @@ let ts1 = MyTupleStruct {
 // CHECK: MyTupleStruct<(Int, String, Optional<String>), (Double, String)>(first: (Function), second: (3.14159, "blah"))
 print(ts1)
 
+// CHECK: testStoredProperties
+struct MyTupleStruct2 {
+  @ArrayBuilder<String> let first: () -> [String]
+  @ArrayBuilder<String> let second: [String]
+}
+
+print("testStoredProperties")
+let ts2 = MyTupleStruct2 {
+  "foo"
+  "bar"
+} second: {
+  "baaz"
+  "quux"
+}
+
+// CHECK: MyTupleStruct2(first: (Function), second: ["baaz", "quux"])
+print(ts2)
+
 // Make sure that `weakV` is `Test?` and not `Test??`
 func test_weak_optionality_stays_the_same() {
   class Test {


### PR DESCRIPTION
- **Explanation**:

In this sample code, the synthesized memberwise initializer does not properly initialize `value.array`, causing a runtime crash when it is later accessed.

```swift
@resultBuilder
struct StringArrayBuilder {
  static func buildBlock(_ elements: String...) -> [String] {
    elements
  }
}

struct MyValue {
  @StringArrayBuilder let array: [String]
}

let value = MyValue(array: {
  "foo"
  "bar"
})

print("Value?")
print(value.array.count) // Crashes because value.array is uninitialized
```

- **Scope**:

This PR fixes a runtime crash for non-generic structs with a synthesized init and a memberwise initialized property with a result builder attribute. Considering this currently crashes at runtime, there are probably no examples of this in practice yet.

- **Issues**:

https://github.com/swiftlang/swift/issues/86205

- **Original PRs**:

https://github.com/swiftlang/swift/pull/86272

- **Risk**:

Low. Fixes a miscompile.

- **Testing**:

New unit tests.

- **Reviewers**:

@xedin, what do you think about including this fix in 6.3?

@hborla (release manager)
