### PR TITLE
[6.3, SE-0485, stdlib] Array functions with OutputSpan

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1563,7 +1563,7 @@ extension Array {
     try unsafe initializer(&buffer, &initializedCount)
   }
 
-  /// Creates an array with the specified capacity, then calls the given
+  /// Creates an array with the specified capacity, and then calls the given
   /// closure with a buffer covering the array's uninitialized memory.
   ///
   /// Inside the closure, set the `initializedCount` parameter to the number of
@@ -1623,8 +1623,8 @@ extension Array {
     self._buffer.mutableCount = unsafe span.finalize(for: buffer)
   }
 
-  /// Creates an array with the specified capacity, then calls the given
-  /// closure with an OutputSpan covering the array's uninitialized memory.
+  /// Creates an array with the specified capacity, and then calls the given
+  /// closure with an output span covering the array's uninitialized memory.
   ///
   /// Inside the closure, initialize elements by appending to the `OutputSpan`.
   /// The `OutputSpan` keeps track of memory's initialization state, ensuring

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1623,6 +1623,39 @@ extension Array {
     self._buffer.mutableCount = unsafe span.finalize(for: buffer)
   }
 
+  /// Creates an array with the specified capacity, then calls the given
+  /// closure with an OutputSpan covering the array's uninitialized memory.
+  ///
+  /// Inside the closure, initialize elements by appending to the `OutputSpan`.
+  /// The `OutputSpan` keeps track of memory's initialization state, ensuring
+  /// safety. Its `count` at the end of the closure will become the `count` of
+  /// the newly-initialized array.
+  ///
+  /// - Note: While the resulting array may have a capacity larger than the
+  ///   requested amount, the `OutputSpan` passed to the closure will cover
+  ///   exactly the number of elements requested.
+  ///
+  /// - Parameters:
+  ///   - capacity: The number of elements to allocate
+  ///     space for in the new array.
+  ///   - initializer: A closure that initializes elements and sets the count
+  ///     of the new array.
+  ///     - Parameters:
+  ///       - span: An `OutputSpan` covering uninitialized memory with
+  ///         space for the specified number of elements.
+  @_alwaysEmitIntoClient
+  @available(SwiftCompatibilitySpan 5.0, *)
+  public init<E: Error>(
+    capacity: Int,
+    initializingWith initializer: (
+      _ span: inout OutputSpan<Element>
+    ) throws(E) -> Void
+  ) throws(E) {
+    try self.init(
+      _uninitializedCapacity: capacity, initializingWith: initializer
+    )
+  }
+
   // Superseded by the typed-throws version of this function, but retained
   // for ABI reasons.
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1678,7 +1678,7 @@ extension Array {
     var initializedCount = 0
     defer {
       // Update mutableCount even when `initializer` throws an error.
-      self._buffer.mutableCount += initializedCount
+      _buffer.mutableCount += initializedCount
       _endMutation()
     }
 
@@ -1687,6 +1687,8 @@ extension Array {
     )
     var span = unsafe OutputSpan(buffer: buffer, initializedCount: 0)
     try initializer(&span)
+    // no need to finalize in the `defer` block: if `initializer` throws,
+    // the elements will be deinitialized by the `OutputSpan`'s deinit.
     initializedCount = unsafe span.finalize(for: buffer)
   }
 }

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1601,9 +1601,12 @@ extension Array {
       initializingWithTypedThrowsInitializer: initializer
     )
   }
+}
 
+@available(SwiftCompatibilitySpan 5.0, *)
+@_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
+extension Array {
   @_alwaysEmitIntoClient
-  @available(SwiftCompatibilitySpan 5.0, *)
   internal init<E: Error>(
     _uninitializedCapacity capacity: Int,
     initializingWith initializer: (
@@ -1644,7 +1647,6 @@ extension Array {
   ///       - span: An `OutputSpan` covering uninitialized memory with
   ///         space for the specified number of elements.
   @_alwaysEmitIntoClient
-  @available(SwiftCompatibilitySpan 5.0, *)
   public init<E: Error>(
     capacity: Int,
     initializingWith initializer: (
@@ -1676,7 +1678,6 @@ extension Array {
   ///       - span: An `OutputSpan` covering uninitialized memory with
   ///         space for the specified number of additional elements.
   @_alwaysEmitIntoClient
-  @available(SwiftCompatibilitySpan 5.0, *)
   public mutating func append<E: Error>(
     addingCapacity uninitializedCount: Int,
     initializingWith initializer: (
@@ -1704,7 +1705,9 @@ extension Array {
     try initializer(&span)
     initializedCount = unsafe span.finalize(for: buffer)
   }
+}
 
+extension Array {
   // Superseded by the typed-throws version of this function, but retained
   // for ABI reasons.
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1651,8 +1651,8 @@ extension Array {
   /// At the end of the closure, `span`'s `count` elements will have been
   /// appended to the array.
   ///
-  /// If the closure throws an error, the array will be reverted to its initial
-  /// state.
+  /// If the closure throws an error, the items appended until that point
+  /// will remain in the array.
   ///
   /// - Parameters:
   ///   - uninitializedCount: The number of new elements the array should have
@@ -1679,12 +1679,8 @@ extension Array {
     )
     var span = unsafe OutputSpan(buffer: buffer, initializedCount: 0)
 
-    var initializedCount = 0
     defer {
-      if initializedCount == 0 {
-        span.removeAll()
-      }
-      _ = unsafe span.finalize(for: buffer)
+      let initializedCount = unsafe span.finalize(for: buffer)
       span = OutputSpan()
 
       // Update mutableCount even when `initializer` throws an error.
@@ -1693,7 +1689,6 @@ extension Array {
     }
 
     try initializer(&span)
-    initializedCount = span.count
   }
 }
 

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -1116,6 +1116,39 @@ extension ContiguousArray {
       initializingWithTypedThrowsInitializer: initializer))
   }
 
+  /// Creates an array with the specified capacity, then calls the given
+  /// closure with an OutputSpan covering the array's uninitialized memory.
+  ///
+  /// Inside the closure, initialize elements by appending to the `OutputSpan`.
+  /// The `OutputSpan` keeps track of memory's initialization state, ensuring
+  /// safety. Its `count` at the end of the closure will become the `count` of
+  /// the newly-initialized array.
+  ///
+  /// - Note: While the resulting array may have a capacity larger than the
+  ///   requested amount, the `OutputSpan` passed to the closure will cover
+  ///   exactly the number of elements requested.
+  ///
+  /// - Parameters:
+  ///   - capacity: The number of elements to allocate
+  ///     space for in the new array.
+  ///   - initializer: A closure that initializes elements and sets the count
+  ///     of the new array.
+  ///     - Parameters:
+  ///       - span: An `OutputSpan` covering uninitialized memory with
+  ///         space for the specified number of elements.
+  @_alwaysEmitIntoClient
+  @available(SwiftCompatibilitySpan 5.0, *)
+  public init<E: Error>(
+    capacity: Int,
+    initializingWith initializer: (
+      _ span: inout OutputSpan<Element>
+    ) throws(E) -> Void
+  ) throws(E) {
+    self = try ContiguousArray(Array(
+      _uninitializedCapacity: capacity, initializingWith: initializer
+    ))
+  }
+
   // Superseded by the typed-throws version of this function, but retained
   // for ABI reasons.
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -1115,7 +1115,11 @@ extension ContiguousArray {
       _unsafeUninitializedCapacity: unsafeUninitializedCapacity,
       initializingWithTypedThrowsInitializer: initializer))
   }
+}
 
+@available(SwiftCompatibilitySpan 5.0, *)
+@_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
+extension ContiguousArray {
   /// Creates an array with the specified capacity, and then calls the given
   /// closure with an output span covering the array's uninitialized memory.
   ///
@@ -1137,7 +1141,6 @@ extension ContiguousArray {
   ///       - span: An `OutputSpan` covering uninitialized memory with
   ///         space for the specified number of elements.
   @_alwaysEmitIntoClient
-  @available(SwiftCompatibilitySpan 5.0, *)
   public init<E: Error>(
     capacity: Int,
     initializingWith initializer: (
@@ -1169,7 +1172,6 @@ extension ContiguousArray {
   ///       - span: An `OutputSpan` covering uninitialized memory with
   ///         space for the specified number of additional elements.
   @_alwaysEmitIntoClient
-  @available(SwiftCompatibilitySpan 5.0, *)
   public mutating func append<E: Error>(
     addingCapacity uninitializedCount: Int,
     initializingWith initializer: (
@@ -1197,7 +1199,9 @@ extension ContiguousArray {
     try initializer(&span)
     initializedCount = unsafe span.finalize(for: buffer)
   }
+}
 
+extension ContiguousArray {
   // Superseded by the typed-throws version of this function, but retained
   // for ABI reasons.
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -1166,8 +1166,6 @@ extension ContiguousArray {
     ) throws(E) -> Void
   ) throws(E) {
     self = ContiguousArray(_uninitializedCount: capacity)
-    defer { _endMutation() }
-
     var initializedCount = 0
     defer {
       // Update self.count even if initializer throws an error,
@@ -1175,6 +1173,7 @@ extension ContiguousArray {
       if capacity > 0 {
         _buffer.mutableCount = initializedCount
       }
+      _endMutation()
     }
 
     let buffer = unsafe UnsafeMutableBufferPointer<Element>(

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -1149,6 +1149,55 @@ extension ContiguousArray {
     ))
   }
 
+  /// Grows the array to have enough capacity for the specified number of
+  /// elements, then calls the closure with an OutputSpan covering the array's
+  /// uninitialized memory.
+  ///
+  /// Inside the closure, initialize elements by appending to `span`. It
+  /// ensures safety by keeping track of the initialization state of the memory
+  /// At the end of the closure, `span`'s `count` elements will have been
+  /// appended to the array.
+  ///
+  /// If the closure throws an error, the array will be reverted to its initial
+  /// state.
+  ///
+  /// - Parameters:
+  ///   - uninitializedCount: The number of new elements the array should have
+  ///     space for.
+  ///   - initializer: A closure that initializes new elements.
+  ///     - Parameters:
+  ///       - span: An `OutputSpan` covering uninitialized memory with
+  ///         space for the specified number of additional elements.
+  @_alwaysEmitIntoClient
+  @available(SwiftCompatibilitySpan 5.0, *)
+  public mutating func append<E: Error>(
+    addingCapacity uninitializedCount: Int,
+    initializingWith initializer: (
+      _ span: inout OutputSpan<Element>
+    ) throws(E) -> Void
+  ) throws(E) {
+    // Ensure uniqueness, mutability, and sufficient storage.
+    _reserveCapacityImpl(
+      minimumCapacity: self.count + uninitializedCount, growForAppend: true
+    )
+    let pointer = unsafe _buffer.mutableFirstElementAddress
+    let uninitializedPointer = unsafe pointer.advanced(by: count)
+
+    var initializedCount = 0
+    defer {
+      // Update mutableCount even when `initializer` throws an error.
+      self._buffer.mutableCount += initializedCount
+      _endMutation()
+    }
+
+    let buffer = unsafe UnsafeMutableBufferPointer(
+      start: uninitializedPointer, count: uninitializedCount
+    )
+    var span = unsafe OutputSpan(buffer: buffer, initializedCount: 0)
+    try initializer(&span)
+    initializedCount = unsafe span.finalize(for: buffer)
+  }
+
   // Superseded by the typed-throws version of this function, but retained
   // for ABI reasons.
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -1079,7 +1079,7 @@ extension ContiguousArray {
 }
 
 extension ContiguousArray {
-  /// Creates an array with the specified capacity, then calls the given
+  /// Creates an array with the specified capacity, and then calls the given
   /// closure with a buffer covering the array's uninitialized memory.
   ///
   /// Inside the closure, set the `initializedCount` parameter to the number of
@@ -1116,8 +1116,8 @@ extension ContiguousArray {
       initializingWithTypedThrowsInitializer: initializer))
   }
 
-  /// Creates an array with the specified capacity, then calls the given
-  /// closure with an OutputSpan covering the array's uninitialized memory.
+  /// Creates an array with the specified capacity, and then calls the given
+  /// closure with an output span covering the array's uninitialized memory.
   ///
   /// Inside the closure, initialize elements by appending to the `OutputSpan`.
   /// The `OutputSpan` keeps track of memory's initialization state, ensuring

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -1181,8 +1181,8 @@ extension ContiguousArray {
     )
     var span = unsafe OutputSpan<Element>(buffer: buffer, initializedCount: 0)
     try initializer(&span)
-    // no need to finalize in a `defer` block: if `initializer` throws,
-    // the elements will be deinitialized when the output span is deinited.
+    // no need to finalize in the `defer` block: if `initializer` throws,
+    // the elements will be deinitialized by the `OutputSpan`'s deinit.
     initializedCount = unsafe span.finalize(for: buffer)
   }
 
@@ -1222,7 +1222,7 @@ extension ContiguousArray {
     var initializedCount = 0
     defer {
       // Update mutableCount even when `initializer` throws an error.
-      self._buffer.mutableCount += initializedCount
+      _buffer.mutableCount += initializedCount
       _endMutation()
     }
 
@@ -1231,6 +1231,8 @@ extension ContiguousArray {
     )
     var span = unsafe OutputSpan(buffer: buffer, initializedCount: 0)
     try initializer(&span)
+    // no need to finalize in the `defer` block: if `initializer` throws,
+    // the elements will be deinitialized by the `OutputSpan`'s deinit.
     initializedCount = unsafe span.finalize(for: buffer)
   }
 }

--- a/stdlib/public/core/InlineArray.swift
+++ b/stdlib/public/core/InlineArray.swift
@@ -358,6 +358,8 @@ extension InlineArray where Element: ~Copyable {
       let buffer = unsafe Self._initializationBuffer(start: rawPtr)
       _internalInvariant(Self.count == buffer.count)
       var output = unsafe OutputSpan(buffer: buffer, initializedCount: 0)
+      // no need to finalize in a `defer` block, since throwing will cause
+      // changes to be deinitialized when the output span is deinited.
       try initializer(&output)
       let initialized = unsafe output.finalize(for: buffer)
       _precondition(count == initialized, "InlineArray initialization underflow")

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -688,6 +688,9 @@ func r23641896() {
 
 }
 
+extension Array {
+  fileprivate mutating func appendLocal(_ newElement: Element) {}
+}
 
 // <rdar://problem/23718859> QoI: Incorrectly flattening ((Int,Int)) argument list to (Int,Int) when printing note
 func test17875634() {
@@ -695,7 +698,7 @@ func test17875634() {
   var row = 1
   var col = 2
   
-  match.append(row, col)  // expected-error {{instance method 'append' expects a single parameter of type '(Int, Int)'}} {{16-16=(}} {{24-24=)}}
+  match.appendLocal(row, col)  // expected-error {{instance method 'appendLocal' expects a single parameter of type '(Int, Int)'}} {{21-21=(}} {{29-29=)}}
 }
 
 // <https://github.com/apple/swift/pull/1205> Improved diagnostics for enums with associated values

--- a/test/Misc/misc_diagnostics.swift
+++ b/test/Misc/misc_diagnostics.swift
@@ -109,6 +109,10 @@ func insertA<T>(array : inout [T], elt : T) {
   array.append(T); // expected-error {{cannot convert value of type 'T.Type' to expected argument type 'T'}}
 }
 
+extension Array {
+  fileprivate mutating func appendLocal(_ newElement: Element) {}
+}
+
 // <rdar://problem/17875634> can't append to array of tuples
 func test17875634() {
   var match: [(Int, Int)] = []
@@ -122,12 +126,12 @@ func test17875634() {
 
   match += coord // expected-error{{binary operator '+=' cannot be applied to operands of type '[(Int, Int)]' and '(Int, Int)'}}
 
-  match.append(row, col) // expected-error {{instance method 'append' expects a single parameter of type '(Int, Int)'}} {{16-16=(}} {{24-24=)}}
+  match.appendLocal(row, col) // expected-error {{instance method 'appendLocal' expects a single parameter of type '(Int, Int)'}} {{21-21=(}} {{29-29=)}}
 
-  match.append(1, 2) // expected-error {{instance method 'append' expects a single parameter of type '(Int, Int)'}} {{16-16=(}} {{20-20=)}}
+  match.appendLocal(1, 2) // expected-error {{instance method 'appendLocal' expects a single parameter of type '(Int, Int)'}} {{21-21=(}} {{25-25=)}}
 
-  match.append(coord)
-  match.append((1, 2))
+  match.appendLocal(coord)
+  match.appendLocal((1, 2))
 
   // Make sure the behavior matches the non-generic case.
   struct FakeNonGenericArray {

--- a/test/stdlib/Span/OutputSpanTests.swift
+++ b/test/stdlib/Span/OutputSpanTests.swift
@@ -386,19 +386,20 @@ suite.test("Array append throws")
   do throws(MyTestError) {
     try a.append(addingCapacity: 8) {
       span throws(MyTestError) in
-      span.append(I())
-      span.append(I())
-      expectEqual(I.count, 6)
-      throw MyTestError.error
+      for i in 1..<100 {
+        span.append(I())
+        expectEqual(I.count, 4+i)
+        if I.count >= 6 { throw MyTestError.error }
+      }
     }
     expectUnreachable("Array initializer should have thrown.")
   } catch {
     expectEqual(error, MyTestError.error)
   }
 
-  // thrown errors revert the changes
-  expectEqual(a.count, 4)
-  expectEqual(I.count, 4)
+  // changes are preserved up to a thrown error
+  expectEqual(a.count, 6)
+  expectEqual(I.count, 6)
 }
 
 suite.test("Array append overflow")
@@ -515,19 +516,20 @@ suite.test("ContiguousArray append throws")
   do throws(MyTestError) {
     try a.append(addingCapacity: 8) {
       span throws(MyTestError) in
-      span.append(I())
-      span.append(I())
-      expectEqual(I.count, 6)
-      throw MyTestError.error
+      for i in 1..<100 {
+        span.append(I())
+        expectEqual(I.count, 4+i)
+        if I.count >= 6 { throw MyTestError.error }
+      }
     }
     expectUnreachable("Array initializer should have thrown.")
   } catch {
     expectEqual(error, MyTestError.error)
-
-    // thrown errors revert the changes
-    expectEqual(a.count, 4)
-    expectEqual(I.count, 4)
   }
+
+  // changes are preserved up to a thrown error
+  expectEqual(a.count, 6)
+  expectEqual(I.count, 6)
 }
 
 suite.test("ContiguousArray append overflow")

--- a/test/stdlib/Span/OutputSpanTests.swift
+++ b/test/stdlib/Span/OutputSpanTests.swift
@@ -65,7 +65,7 @@ struct Allocation<T>: ~Copyable {
   }
 }
 
-enum MyTestError: Error { case error }
+enum MyTestError: Error, Equatable { case error }
 
 suite.test("Create OutputSpan")
 .require(.stdlib_6_2).code {
@@ -232,13 +232,12 @@ suite.test("InlineArray initialization underflow")
   _ = InlineArray<4, Int> {
     $0.append(1)
   }
+  expectUnreachable("InlineArray initializer should have trapped.")
 }
 
 suite.test("InlineArray initialization throws")
 .require(.stdlib_6_2).code {
   guard #available(SwiftStdlib 6.2, *) else { return }
-
-  enum LocalError: Error { case error }
 
   class I {
     static var count = 0
@@ -247,15 +246,14 @@ suite.test("InlineArray initialization throws")
   }
 
   let a: InlineArray<4, I>
-  do throws(LocalError) {
+  do throws(MyTestError) {
     a = try InlineArray {
-      o throws(LocalError) in
+      o throws(MyTestError) in
       o.append(I())
       o.append(I())
       o.append(I())
-      o.append(I())
-      expectEqual(I.count, 4)
-      throw LocalError.error
+      expectEqual(I.count, 3)
+      throw MyTestError.error
     }
     _ = a
   } catch {
@@ -274,4 +272,276 @@ suite.test("OutputSpan Sendability")
 
   let span = OutputSpan(buffer: buffer, initializedCount: 0)
   send(span)
+}
+
+suite.test("Array initialization")
+.require(.stdlib_6_2).code {
+
+  var a: Array<Int>
+
+  a = Array(capacity: 8) {
+    span in
+    span.append(0)
+  }
+  expectEqual(a.count, 1)
+  expectGE(a.capacity, 8)
+
+  a = Array(capacity: 8) {
+    span in
+    for i in 0..<8 {
+      span.append(i)
+    }
+  }
+  expectEqual(a.count, 8)
+  expectGE(a.capacity, 8)
+  expectTrue(a.elementsEqual(0..<8))
+}
+
+suite.test("Array initialization throws")
+.require(.stdlib_6_2).code {
+  class I {
+    static var count = 0
+    init() { Self.count += 1 }
+    deinit { Self.count -= 1 }
+  }
+
+  var a: [I] = []
+  do throws(MyTestError) {
+    a = try Array(capacity: 4) {
+      o throws(MyTestError) in
+      o.append(I())
+      expectEqual(I.count, 1)
+      throw MyTestError.error
+    }
+    expectUnreachable("Array initializer should have thrown.")
+  } catch {
+    expectEqual(I.count, 0)
+    expectEqual(a.count, 0)
+  }
+
+  a = []
+  do throws(MyTestError) {
+    a = try Array(capacity: 0) {
+      o throws(MyTestError) in
+      expectEqual(I.count, 0)
+      throw MyTestError.error
+    }
+    expectUnreachable("Array initializer should have thrown.")
+  } catch {
+    expectEqual(I.count, 0)
+    expectEqual(a.count, 0)
+  }
+}
+
+
+suite.test("Array initialization overflow")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.require(.stdlib_6_2).code {
+
+  expectCrashLater()
+  _ = Array<Int>(capacity: 1) {
+    span in
+    span.append(1)
+    span.append(2)
+  }
+  expectUnreachable("Array initializer should have trapped.")
+}
+
+suite.test("Array append")
+.require(.stdlib_6_2).code {
+
+  let base = [0, 1, 2, 3]
+  var a = base
+
+  a.append(addingCapacity: 8) {
+    span in
+    span.append(0)
+  }
+  expectEqual(a.count, base.count+1)
+  expectGE(a.capacity, base.count+8)
+
+  a = base
+  a.append(addingCapacity: 8) {
+    span in
+    while !span.isFull {
+      span.append(span.count+base.count)
+    }
+  }
+  expectEqual(a.count, base.count+8)
+  expectGE(a.capacity, base.count+8)
+  expectTrue(a.elementsEqual(0..<a.count))
+}
+
+suite.test("Array append throws")
+.require(.stdlib_6_2).code {
+  class I {
+    static var count = 0
+    init() { Self.count += 1 }
+    deinit { Self.count -= 1 }
+  }
+
+  var a = [I(), I(), I(), I()]
+  expectEqual(a.count, 4)
+  expectEqual(I.count, 4)
+  do throws(MyTestError) {
+    try a.append(addingCapacity: 8) {
+      span throws(MyTestError) in
+      span.append(I())
+      span.append(I())
+      expectEqual(I.count, 6)
+      throw MyTestError.error
+    }
+    expectUnreachable("Array initializer should have thrown.")
+  } catch {
+    print(error)
+    expectEqual(error, MyTestError.error)
+
+    // thrown errors revert the changes
+    expectEqual(a.count, 4)
+    expectEqual(I.count, 4)
+  }
+}
+
+suite.test("Array append overflow")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.require(.stdlib_6_2).code {
+
+  expectCrashLater()
+  var a: [Int] = []
+  a.append(addingCapacity: 1) {
+    span in
+    span.append(1)
+    span.append(2)
+  }
+  expectUnreachable("Array initializer should have trapped.")
+}
+
+suite.test("ContiguousArray initialization")
+.require(.stdlib_6_2).code {
+
+  var a: ContiguousArray<Int>
+
+  a = ContiguousArray(capacity: 8) {
+    span in
+    span.append(0)
+  }
+  expectEqual(a.count, 1)
+  expectGE(a.capacity, 8)
+
+  a = ContiguousArray(capacity: 8) {
+    span in
+    for i in 0..<8 {
+      span.append(i)
+    }
+  }
+  expectEqual(a.count, 8)
+  expectGE(a.capacity, 8)
+  expectTrue(a.elementsEqual(0..<8))
+
+  a = []
+  do throws(MyTestError) {
+    a = try ContiguousArray(capacity: 8) {
+      span throws(MyTestError) in
+      span.append(0)
+      throw MyTestError.error
+    }
+    expectUnreachable("ContiguousArray initializer should have thrown.")
+  } catch {
+    expectEqual(error, MyTestError.error)
+    expectTrue(a.isEmpty)
+  }
+
+  a = []
+  do throws(MyTestError) {
+    a = try ContiguousArray(capacity: 0) {
+      _ throws(MyTestError) in
+      throw MyTestError.error
+    }
+    expectUnreachable("ContiguousArray initializer should have thrown.")
+  } catch {
+    expectEqual(error, MyTestError.error)
+    expectTrue(a.isEmpty)
+  }
+}
+
+suite.test("ContiguousArray initialization overflow")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.require(.stdlib_6_2).code {
+
+  expectCrashLater()
+  _ = ContiguousArray<Int>(capacity: 1) {
+    span in
+    span.append(1)
+    span.append(2)
+  }
+  expectUnreachable("ContiguousArray initializer should have trapped.")
+}
+
+suite.test("ContiguousArray append")
+.require(.stdlib_6_2).code {
+
+  let base = [0, 1, 2, 3]
+  var a = base
+
+  a.append(addingCapacity: 8) {
+    span in
+    span.append(0)
+  }
+  expectEqual(a.count, base.count+1)
+  expectGE(a.capacity, base.count+8)
+
+  a = base
+  a.append(addingCapacity: 8) {
+    span in
+    while !span.isFull {
+      span.append(span.count+base.count)
+    }
+  }
+  expectEqual(a.count, base.count+8)
+  expectGE(a.capacity, base.count+8)
+  expectTrue(a.elementsEqual(0..<a.count))
+}
+
+suite.test("ContiguousArray append throws")
+.require(.stdlib_6_2).code {
+  class I {
+    static var count = 0
+    init() { Self.count += 1 }
+    deinit { Self.count -= 1 }
+  }
+
+  var a: ContiguousArray = [I(), I(), I(), I()]
+  expectEqual(a.count, 4)
+  expectEqual(I.count, 4)
+  do throws(MyTestError) {
+    try a.append(addingCapacity: 8) {
+      span throws(MyTestError) in
+      span.append(I())
+      span.append(I())
+      expectEqual(I.count, 6)
+      throw MyTestError.error
+    }
+    expectUnreachable("Array initializer should have thrown.")
+  } catch {
+    print(error)
+    expectEqual(error, MyTestError.error)
+
+    // thrown errors revert the changes
+    expectEqual(a.count, 4)
+    expectEqual(I.count, 4)
+  }
+}
+
+suite.test("ContiguousArray append overflow")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.require(.stdlib_6_2).code {
+
+  expectCrashLater()
+  var a: [Int] = []
+  a.append(addingCapacity: 1) {
+    span in
+    span.append(1)
+    span.append(2)
+  }
+  expectUnreachable("ContiguousArray initializer should have trapped.")
 }

--- a/test/stdlib/Span/OutputSpanTests.swift
+++ b/test/stdlib/Span/OutputSpanTests.swift
@@ -393,13 +393,12 @@ suite.test("Array append throws")
     }
     expectUnreachable("Array initializer should have thrown.")
   } catch {
-    print(error)
     expectEqual(error, MyTestError.error)
-
-    // thrown errors revert the changes
-    expectEqual(a.count, 4)
-    expectEqual(I.count, 4)
   }
+
+  // thrown errors revert the changes
+  expectEqual(a.count, 4)
+  expectEqual(I.count, 4)
 }
 
 suite.test("Array append overflow")
@@ -523,7 +522,6 @@ suite.test("ContiguousArray append throws")
     }
     expectUnreachable("Array initializer should have thrown.")
   } catch {
-    print(error)
     expectEqual(error, MyTestError.error)
 
     // thrown errors revert the changes


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift/pull/83657

**Explanation**:
Adds Array and ContiguousArray initializers and functions deferred from "[SE-0485 OutputSpan](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0485-outputspan.md)".

For both `Array` and `ContiguousArray`, this adds:
```
public init<E>(capacity: Int, initializingWith: (inout OutputSpan<Element>) throws(E) -> Void) throws(E)
public func append<E>(addingCapacity: Int, initializingWith: (inout OutputSpan<Element>) throws(E) -> Void) throws(E)
```

**Scope**: addition
**Risk**: low. These are additions with distinct argument labels.
**Testing**: new tests
**Issue**: rdar://155660454
**Reviewer**: @lorentey 