### PR TITLE
[CMake] Add option for header-only clang resource install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -401,6 +401,10 @@ if(SWIFT_USE_SYMLINKS)
   set(SWIFT_COPY_OR_SYMLINK_DIR "create_symlink")
 endif()
 
+option(SWIFT_STDLIB_INSTALL_ONLY_CLANG_RESOURCE_HEADERS
+  "If enabled, install only Clang builtin headers and modulemaps under lib/swift[/swift_static]/clang instead of the entire resource directory."
+  OFF)
+
 # The following only works with the Ninja generator in CMake >= 3.0.
 set(SWIFT_PARALLEL_LINK_JOBS "" CACHE STRING
   "Define the maximum number of linker jobs for swift.")

--- a/stdlib/public/SwiftShims/swift/shims/CMakeLists.txt
+++ b/stdlib/public/SwiftShims/swift/shims/CMakeLists.txt
@@ -239,15 +239,27 @@ endif()
 
 # Install Clang headers under the Swift library so that an installed Swift's
 # module importer can find the compiler headers corresponding to its Clang.
-swift_install_in_component(DIRECTORY "${clang_headers_location}/"
-                           DESTINATION "lib/swift/clang"
-                           COMPONENT clang-builtin-headers
-                           REGEX "\.(h|modulemap)$")
+if(SWIFT_STDLIB_INSTALL_ONLY_CLANG_RESOURCE_HEADERS)
+  set(clang_headers_source "${clang_headers_location}/include/")
+  set(clang_headers_dest_suffix "/include")
+  set(clang_headers_filter
+      FILES_MATCHING
+      REGEX "\.(h|modulemap)$")
+else()
+  set(clang_headers_source "${clang_headers_location}/")
+  set(clang_headers_dest_suffix "")
+  set(clang_headers_filter)
+endif()
 
-swift_install_in_component(DIRECTORY "${clang_headers_location}/"
-  DESTINATION "lib/swift_static/clang"
+swift_install_in_component(DIRECTORY "${clang_headers_source}"
+                           DESTINATION "lib/swift/clang${clang_headers_dest_suffix}"
+                           COMPONENT clang-builtin-headers
+                           ${clang_headers_filter})
+
+swift_install_in_component(DIRECTORY "${clang_headers_source}"
+  DESTINATION "lib/swift_static/clang${clang_headers_dest_suffix}"
   COMPONENT clang-builtin-headers
-  REGEX "\.(h|modulemap)$")
+  ${clang_headers_filter})
 
 if(SWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER OR SWIFT_PREBUILT_CLANG)
   # This will still link against the Swift-forked clang headers if the Swift

--- a/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
@@ -147,6 +147,8 @@ class WasmStdlib(cmake_product.CMakeProduct):
         self.cmake_options.define('SWIFT_BUILD_STATIC_STDLIB:BOOL', 'TRUE')
         self.cmake_options.define('SWIFT_BUILD_DYNAMIC_STDLIB:BOOL', 'FALSE')
         self.cmake_options.define('SWIFT_BUILD_STATIC_SDK_OVERLAY:BOOL', 'TRUE')
+        # Install clang builtin headers only, not the full clang resource dir including libs
+        self.cmake_options.define('SWIFT_STDLIB_INSTALL_ONLY_CLANG_RESOURCE_HEADERS:BOOL', 'TRUE')
         # TODO: Turn off library evolution once we establish a good way to teach
         # libraries including swift-testing whether to use the stable ABI.
         self.cmake_options.define('SWIFT_STDLIB_STABLE_ABI:BOOL', 'TRUE')


### PR DESCRIPTION
The bare `REGEX` argument to `install(DIRECTORY ...)` actually does not filter out anything unless paired with `FILES_MATCHING` or `EXCLUDE`. PR #34190 added `FILES_MATCHING` so the clang resource-dir install only copies headers, but PR #34241 reverted it to unblock the Source Compat suite even though that meant copying the entire clang resource tree, including lib/.

Add SWIFT_STDLIB_INSTALL_ONLY_CLANG_RESOURCE_HEADERS so we can opt back into header-only installs without breaking toolchains that expect lib/swift/clang/lib.

Leave the flag off by default for compatibility and enable it for the wasm stdlib build so installing that package no longer copies host-side compiler-rt archives into Swift's resource directory.

This change should save 64mb of Wasm SDK size:
```
$ du -hd1 swift-6.2-RELEASE_wasm.artifactbundle/swift-6.2-RELEASE_wasm/wasm32-unknown-wasip1/swift.xctoolchain/usr/lib/swift/clang/lib/linux
64M     swift-6.2-RELEASE_wasm.artifactbundle/swift-6.2-RELEASE_wasm/wasm32-unknown-wasip1/swift.xctoolchain/usr/lib/swift/clang/lib/linux
```
