### PR TITLE
tests: disable `AutoDiff/compiler_crashers_fixed/issue-56649-missing-debug-scopes-in-pullback-trampoline.swift` on linux

### DIFF
--- a/test/AutoDiff/compiler_crashers_fixed/issue-56649-missing-debug-scopes-in-pullback-trampoline.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/issue-56649-missing-debug-scopes-in-pullback-trampoline.swift
@@ -5,6 +5,10 @@
 // https://github.com/apple/swift/issues/56649
 // SIL verification fails when differentiating a function of `[[Double]]`
 
+// On linux this test sometimes fails with a linker crash
+// rdar://168025835
+// REQUIRES: OS=macosx
+
 import _Differentiation
 
 let values: [[Double]] = [[0, 0], [0, 0]]


### PR DESCRIPTION
On linux this test sometimes fails with a linker crash.
rdar://168025835
