### PR TITLE
tests: xfail -> unsupported `Reflection/capture_descriptors.sil` on freebsd

### DIFF
--- a/test/Reflection/capture_descriptors.sil
+++ b/test/Reflection/capture_descriptors.sil
@@ -13,7 +13,7 @@
 // offsets in section headers, breaking the Swift reflection data ELF parser
 // resulting in missing metadata.
 // rdar://159139154
-// XFAIL: OS=freebsd
+// UNSUPPORTED: OS=freebsd
 
 sil_stage canonical
 


### PR DESCRIPTION
This test started to pass. Let's just disable it for freebsd to remove the flakiness rdar://168080107
