### PR TITLE
tests: disable more autodiff tests on linux which sometimes fail due to a linker crash

### DIFF
--- a/test/AutoDiff/compiler_crashers_fixed/issue-54992-siloptimizer-rewrite-partial-apply-convention-method.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/issue-54992-siloptimizer-rewrite-partial-apply-convention-method.swift
@@ -4,6 +4,10 @@
 // SIL verification error regarding `CapturePropagation::rewritePartialApply`
 // for `partial_apply` with `@convention(method)` callee
 
+// On linux this test sometimes fails with a linker crash
+// rdar://143988849
+// REQUIRES: OS=macosx
+
 import _Differentiation
 
 protocol Protocol: Differentiable {

--- a/test/AutoDiff/compiler_crashers_fixed/issue-70819-try-apply-adjoint.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/issue-70819-try-apply-adjoint.swift
@@ -4,6 +4,10 @@
 // Fixes "note: do not know how to handle this incoming bb argument" assertion
 // Here try_apply is produced so the result value is available in the successor BB
 
+// On linux this test sometimes fails with a linker crash
+// rdar://167564410
+// REQUIRES: OS=macosx
+
 import _Differentiation
 
 @differentiable(reverse)

--- a/test/AutoDiff/compiler_crashers_fixed/rdar84716758-differentiable-protocol-witness-missing-requirements.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/rdar84716758-differentiable-protocol-witness-missing-requirements.swift
@@ -1,5 +1,9 @@
 // RUN: %target-build-swift %s
 
+// On linux this test sometimes fails with a linker crash
+// rdar://147769717
+// REQUIRES: OS=macosx
+
 import _Differentiation
 
 public protocol Layer: Differentiable {


### PR DESCRIPTION
rdar://143988849
rdar://167564410
rdar://147769717
