### PR TITLE
🍒 [6.3][cxx-interop] Revert bases iteration in CxxValueSemantics

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -8614,8 +8614,6 @@ CxxValueSemantics::evaluate(Evaluator &evaluator,
         // ~Copyable, the type should also be ~Copyable.
         for (auto field : cxxRecordDecl->fields())
           maybePushToStack(field->getType()->getUnqualifiedDesugaredType());
-        for (auto base : cxxRecordDecl->bases())
-          maybePushToStack(base.getType()->getUnqualifiedDesugaredType());
       }
     }
 

--- a/test/Interop/Cxx/class/noncopyable-typechecker.swift
+++ b/test/Interop/Cxx/class/noncopyable-typechecker.swift
@@ -210,10 +210,12 @@ func copyableDisposablePOD(p: DisposablePOD) {
 
 func couldCreateCycleOfCxxValueSemanticsRequests() {
   let d1 = DerivesFromMe()
-  takeCopyable(d1) // expected-error {{global function 'takeCopyable' requires that 'DerivesFromMe' conform to 'Copyable'}}
+  // FIXME expected error {{global function 'takeCopyable' requires that 'DerivesFromMe' conform to 'Copyable'}}
+  takeCopyable(d1)
 
   let d2 = DerivesFromMeToo()
-  takeCopyable(d2) // expected-error {{global function 'takeCopyable' requires that 'DerivesFromMeToo' conform to 'Copyable'}}
+  // FIXME expected error {{global function 'takeCopyable' requires that 'DerivesFromMeToo' conform to 'Copyable'}}
+  takeCopyable(d2)
 
   let d3 = FieldDependsOnMe()
   takeCopyable(d3) // expected-error {{global function 'takeCopyable' requires that 'FieldDependsOnMe' conform to 'Copyable'}}

--- a/test/Interop/Cxx/stdlib/use-std-vector-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-vector-typechecker.swift
@@ -36,4 +36,4 @@ takeCopyable(hasVector)
 
 let baseHasVector = BaseHasVector()
 takeCopyable(baseHasVector)
-// CHECK: error: global function 'takeCopyable' requires that 'BaseHasVector' conform to 'Copyable'
+// FIXME expected error: global function 'takeCopyable' requires that 'BaseHasVector' conform to 'Copyable'


### PR DESCRIPTION
  - **Explanation**: We recently extended the `CxxValueSemantics` request to the bases of the type, but overlooked the case when the base has a protected constructor. This created some regressions so, while we wait for the correct fix (https://github.com/swiftlang/swift/pull/86369), we revert the bases iteration for now. 
  - **Original PR**: https://github.com/swiftlang/swift/pull/86513
  - **Issues**: rdar://167555864
  - **Risk**: Low, we are reverting a small, problematic part of a previous commit.
  - **Reviewers**: @j-hui 