### PR TITLE
[Concurrency] Fix `stripConcurrency` to strip only global actor isola…

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1001,7 +1001,7 @@ Type TypeBase::stripConcurrency(bool recurse, bool dropGlobalActor) {
     ASTExtInfo extInfo =
         fnType->hasExtInfo() ? fnType->getExtInfo() : ASTExtInfo();
     extInfo = extInfo.withSendable(false);
-    if (dropGlobalActor)
+    if (dropGlobalActor && extInfo.getGlobalActor())
       extInfo = extInfo.withoutIsolation();
 
     ArrayRef<AnyFunctionType::Param> params = fnType->getParams();

--- a/test/Interpreter/issue86332.swift
+++ b/test/Interpreter/issue86332.swift
@@ -1,0 +1,29 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -target %target-swift-5.1-abi-triple %s -default-isolation MainActor -enable-upcoming-feature NonisolatedNonsendingByDefault -parse-as-library -module-name main -swift-version 5 -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: concurrency
+// REQUIRES: executable_test
+// REQUIRES: concurrency_runtime
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
+
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: OS=windows-msvc
+
+struct S {
+  var action: (Int) async -> Void
+
+  init(action: @escaping (Int) -> Void) {
+    self.action = action
+  }
+}
+
+@main
+enum App {
+  static func main() async {
+    let s = S { print($0) }
+    await s.action(42)
+    // CHECK: 42
+  }
+}


### PR DESCRIPTION
…tion

The original condition was removing not just global actor isolation but any isolation set on the function type. This leads to incorrect conversions in AST and miscompiles.

Resolves: https://github.com/swiftlang/swift/issues/86332
Resolves: rdar://167712422

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
