### PR TITLE
[test] Silence output from `doc_stdlib.swift`

### DIFF
--- a/test/SourceKit/DocSupport/doc_stdlib.swift
+++ b/test/SourceKit/DocSupport/doc_stdlib.swift
@@ -1,2 +1,2 @@
 // Make sure we're not crashing.
-// RUN: %sourcekitd-test -req=doc-info -module Swift
+// RUN: %sourcekitd-test -req=doc-info -module Swift > /dev/null


### PR DESCRIPTION
This test produces a very large output (~83MB when run locally), which seems to slow down Windows CI