### PR TITLE
[SILVerifier] Adjust ownership requirement for `ImplicitActorToOpaque…

### DIFF
--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -3638,7 +3638,8 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
     }
 
     if (B.getFunction().hasOwnership()) {
-      if (Value->getOwnershipKind() != OwnershipKind::Guaranteed) {
+      if (!Value->getOwnershipKind().isCompatibleWith(
+              OwnershipKind::Guaranteed)) {
         P.diagnose(ValueLoc, diag::sil_operand_has_wrong_ownership_kind,
                    Value->getOwnershipKind().asString(),
                    OwnershipKind(OwnershipKind::Guaranteed).asString());

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -3107,11 +3107,13 @@ public:
   void checkImplicitActorToOpaqueIsolationCastInst(
       ImplicitActorToOpaqueIsolationCastInst *igi) {
     if (F.hasOwnership()) {
-      require(igi->getValue()->getOwnershipKind() == OwnershipKind::Guaranteed,
+      require(igi->getValue()->getOwnershipKind().isCompatibleWith(
+                  OwnershipKind::Guaranteed),
               "implicitactor_to_optionalactor_cast's operand should have "
               "guaranteed ownership");
-      require(igi->getOwnershipKind() == OwnershipKind::Guaranteed,
-              "result value should have guaranteed ownership");
+      require(
+          igi->getOwnershipKind().isCompatibleWith(OwnershipKind::Guaranteed),
+          "result value should have guaranteed ownership");
     }
 
     require(igi->getValue()->getType() ==

--- a/test/SIL/Parser/concurrency.sil
+++ b/test/SIL/Parser/concurrency.sil
@@ -40,3 +40,15 @@ bb0(%0 : @guaranteed $Builtin.ImplicitActor):
   %2 = copy_value %1 : $Optional<any Actor>
   return %2 : $Optional<any Actor>
 }
+
+// CHECK-LABEL: sil [ossa] @test_implicitactor_to_opaqueisolation_on_unowned : $@convention(thin) () -> @owned Optional<any Actor> {
+// CHECK: implicitactor_to_opaqueisolation_cast {{%.*}} : $Builtin.ImplicitActor
+// CHECK: } // end sil function 'test_implicitactor_to_opaqueisolation_on_unowned'
+sil [ossa] @test_implicitactor_to_opaqueisolation_on_unowned : $@convention(thin) () -> @owned Optional<any Actor> {
+bb0:
+  %0 = enum $Optional<any Actor>, #Optional.none!enumelt
+  %1 = unchecked_value_cast %0 : $Optional<any Actor> to $Builtin.ImplicitActor
+  %2 = implicitactor_to_opaqueisolation_cast %1 : $Builtin.ImplicitActor
+  %3 = copy_value %2 : $Optional<any Actor>
+  return %3 : $Optional<any Actor>
+}

--- a/test/SIL/Serialization/concurrency.sil
+++ b/test/SIL/Serialization/concurrency.sil
@@ -22,3 +22,15 @@ bb0(%0 : @guaranteed $Builtin.ImplicitActor):
   %2 = copy_value %1 : $Optional<any Actor>
   return %2 : $Optional<any Actor>
 }
+
+// CHECK-LABEL: sil [ossa] @test_implicitactor_to_opaqueisolation_on_unowned : $@convention(thin) () -> @owned Optional<any Actor> {
+// CHECK: implicitactor_to_opaqueisolation_cast {{%.*}} : $Builtin.ImplicitActor
+// CHECK: } // end sil function 'test_implicitactor_to_opaqueisolation_on_unowned'
+sil [ossa] @test_implicitactor_to_opaqueisolation_on_unowned : $@convention(thin) () -> @owned Optional<any Actor> {
+bb0:
+  %0 = enum $Optional<any Actor>, #Optional.none!enumelt
+  %1 = unchecked_value_cast %0 : $Optional<any Actor> to $Builtin.ImplicitActor
+  %2 = implicitactor_to_opaqueisolation_cast %1 : $Builtin.ImplicitActor
+  %3 = copy_value %2 : $Optional<any Actor>
+  return %3 : $Optional<any Actor>
+}

--- a/test/SIL/verifier_concurrency_nofail.sil
+++ b/test/SIL/verifier_concurrency_nofail.sil
@@ -1,0 +1,26 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s
+
+// This file contains a collection of tests that ensure that the verifier does
+// not fail on specific segments of code. The idea is to ensure that changing
+// the verifier does not cause these to start asserting. When one adds a new
+// check to the verifier, add a test case to make sure normal cases do not
+// crash.
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+import _Concurrency
+
+// REQUIRES: asserts
+// REQUIRES: concurrency
+
+sil [ossa] @test_implicitactor_to_opaqueisolation_on_unowned : $@convention(thin) () -> () {
+bb0:
+  %0 = enum $Optional<any Actor>, #Optional.none!enumelt
+  %1 = unchecked_value_cast %0 : $Optional<any Actor> to $Builtin.ImplicitActor
+  %2 = implicitactor_to_opaqueisolation_cast %1 : $Builtin.ImplicitActor
+  %3 = tuple()
+  return %3 : $()
+}


### PR DESCRIPTION
…IsolationCast`

This check should use `isCompatibleWith` because sometimes the operands don't have ownership i.e. when the actor is `nil`.

Resolves: rdar://164993540

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
