### PR TITLE
Use a separate DIRefMap cache for existential typealiases (#86368)

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -161,6 +161,7 @@ class IRGenDebugInfoImpl : public IRGenDebugInfo {
   llvm::StringSet<> OriginallyDefinedInTypes;
   TrackingDIRefMap DIRefMap;
   TrackingDIRefMap InnerTypeCache;
+  TrackingDIRefMap ExistentialTypeAliasMap;
   /// \}
 
   /// A list of replaceable fwddecls that need to be RAUWed at the end.
@@ -2684,6 +2685,16 @@ private:
     return Scope;
   }
 
+  static bool isExistentialTypeAlias(DebugTypeInfo DbgTy) {
+    TypeBase *BaseTy = DbgTy.getType();
+    auto *ExistentialTy = BaseTy->getAs<ExistentialType>();
+    if (!ExistentialTy)
+      return false;
+    Type ConstraintTy = ExistentialTy->getConstraintType();
+    TypeBase *TyPtr = ConstraintTy.getPointer();
+    return isa<TypeAliasType>(TyPtr);
+  }
+
   llvm::DIType *getOrCreateType(DebugTypeInfo DbgTy,
                                 llvm::DIScope *Scope = nullptr) {
     // Is this an empty type?
@@ -2697,6 +2708,22 @@ private:
       return DITy;
     }
 
+    // Use a separate DIRefMap cache for existential typealiases
+    // because they have identical mangled names as their inner
+    // protocol types and cause conflicts in the cache. For example,
+    // protocol P<Value> {
+    //    associatedtype Value
+    // }
+    // actor A<Value> {
+    //    public typealias T = P<Value>
+    //    let t: any T
+    //    ...
+    // }
+    // "any T" (existential type) and "P<Value>" (parameterized protocol type)
+    // have the same mangled name but distinct DI types.
+    TrackingDIRefMap &RefMap =
+        isExistentialTypeAlias(DbgTy) ? ExistentialTypeAliasMap : DIRefMap;
+
     // Second line of defense: Look up the mangled name. TypeBase*'s are
     // not necessarily unique, but name mangling is too expensive to do
     // every time.
@@ -2706,7 +2733,7 @@ private:
       Mangled = getMangledName(DbgTy);
       if (!Mangled.Sugared.empty()) {
         UID = llvm::MDString::get(IGM.getLLVMContext(), Mangled.Sugared);
-        if (llvm::Metadata *CachedTy = DIRefMap.lookup(UID))
+        if (llvm::Metadata *CachedTy = RefMap.lookup(UID))
           return cast<llvm::DIType>(CachedTy);
 
         if (DbgTy.getType()->getKind() != swift::TypeKind::TypeAlias) {
@@ -2718,7 +2745,7 @@ private:
           // recursively that appears iniside itself. To deal with the latter we
           // directly emit a type alias to the canonical type.
           UID = llvm::MDString::get(IGM.getLLVMContext(), Mangled.Canonical);
-          if (llvm::Metadata *CachedTy = DIRefMap.lookup(UID)) {
+          if (llvm::Metadata *CachedTy = RefMap.lookup(UID)) {
             Scope = updateScope(Scope, DbgTy);
             llvm::DIType *DITy = cast<llvm::DIType>(CachedTy);
             llvm::DIType *TypeDef = DBuilder.createTypedef(
@@ -2741,13 +2768,13 @@ private:
           return DBuilder.createTypedef(Desugared, Name, MainFile, 0,
                                         updateScope(Scope, DbgTy));
         return Desugared;
-      } else if (llvm::Metadata *CachedTy = DIRefMap.lookup(UID)) {
+      } else if (llvm::Metadata *CachedTy = RefMap.lookup(UID)) {
         auto *DITy = cast<llvm::DIType>(CachedTy);
         assert(sanityCheckCachedType(DbgTy, DITy));
         return DITy;
       } else {
         UID = llvm::MDString::get(IGM.getLLVMContext(), Mangled.Canonical);
-        if (llvm::Metadata *CachedTy = DIRefMap.lookup(UID))
+        if (llvm::Metadata *CachedTy = RefMap.lookup(UID))
           return cast<llvm::DIType>(CachedTy);
       }
     }
@@ -2789,7 +2816,7 @@ private:
     if (auto *CTy = dyn_cast<llvm::DICompositeType>(DITy)) {
 #ifndef NDEBUG
       // Soundness check.
-      if (llvm::Metadata *V = DIRefMap.lookup(UID)) {
+      if (llvm::Metadata *V = RefMap.lookup(UID)) {
         auto *CachedTy = cast<llvm::DIType>(V);
         assert(CachedTy == DITy && "conflicting types for one UID");
       }
@@ -2798,7 +2825,7 @@ private:
       if (auto UID = CTy->getRawIdentifier()) {
         assert(UID->getString() == MangledName &&
                "Unique identifier is different from mangled name ");
-        DIRefMap[UID] = llvm::TrackingMDNodeRef(DITy);
+        RefMap[UID] = llvm::TrackingMDNodeRef(DITy);
       }
     }
 

--- a/test/DebugInfo/existential-typealias-cache-conflict.swift
+++ b/test/DebugInfo/existential-typealias-cache-conflict.swift
@@ -1,0 +1,23 @@
+// RUN: %target-build-swift -emit-ir -module-name LayeredCache -g %s -o - | %FileCheck %s
+
+protocol P<Value> {
+    associatedtype Value
+}
+
+actor A<Value> {
+    public typealias T = P<Value>
+    let t: any T
+    init(i: Int, t: any T) {
+        self.init(t: t)
+    }
+    init(t: any T) {
+        self.t = t
+    }
+}
+
+// CHECK-DAG: !DIDerivedType(tag: DW_TAG_member, name: "t", {{.*}}, baseType: ![[EXIST_TY:[0-9]+]]
+// CHECK-DAG: ![[EXIST_TY]] = !DICompositeType(tag: DW_TAG_structure_type, name: "P", {{.*}}, elements: ![[ELTS:[0-9]+]], {{.*}}, identifier: "$s12LayeredCache1P_px5ValueAaBPRts_XPD")
+// CHECK-DAG: ![[ELTS]] = !{![[INNER:[0-9]+]]}
+// CHECK-DAG: ![[INNER]] = !DIDerivedType(tag: DW_TAG_member, name: "$swift.constraint", {{.*}}, baseType: ![[TYPEDEF:[0-9]+]]
+// CHECK-DAG: ![[TYPEDEF]] = !DIDerivedType(tag: DW_TAG_typedef, name: "$s12LayeredCache1AC1Tayx_GD", {{.*}}, baseType: ![[PROTO_TY:[0-9]+]])
+// CHECK-DAG: ![[PROTO_TY]] = !DICompositeType(tag: DW_TAG_structure_type, name: "$s12LayeredCache1P_px5ValueAaBPRts_XPD", {{.*}}, identifier: "$s12LayeredCache1P_px5ValueAaBPRts_XPD")


### PR DESCRIPTION
After https://github.com/swiftlang/swift/pull/85655, DI types for existential typealiases and their inner protocol types are created, which may encounter conflicts in the DIRefMap cache and assert failures because they can have identical mangled names. This change fixes this issue by using a separate cache for existential typealiases to avoid such conflicts.

Issue https://github.com/swiftlang/swift/issues/86313

(cherry picked commit from 6f60adf009c078183e418698baa52acae45b941b)
