### PR TITLE
[stdlib] followup to #83657

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1667,6 +1667,9 @@ extension Array {
       _ span: inout OutputSpan<Element>
     ) throws(E) -> Void
   ) throws(E) {
+    _precondition(
+      uninitializedCount >= 0, "uninitializedCount must not be negative"
+    )
     // Ensure uniqueness, mutability, and sufficient storage.
     _reserveCapacityImpl(
       minimumCapacity: self.count + uninitializedCount, growForAppend: true

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1625,8 +1625,7 @@ extension Array {
   /// - Parameters:
   ///   - capacity: The number of elements to allocate
   ///     space for in the new array.
-  ///   - initializer: A closure that initializes elements and sets the count
-  ///     of the new array.
+  ///   - initializer: A closure that initializes the elements of the new array.
   ///     - Parameters:
   ///       - span: An `OutputSpan` covering uninitialized memory with
   ///         space for the specified number of elements.
@@ -1643,7 +1642,7 @@ extension Array {
   }
 
   /// Grows the array to have enough capacity for the specified number of
-  /// elements, then calls the closure with an OutputSpan covering the array's
+  /// elements, then calls the closure with an output span covering the array's
   /// uninitialized memory.
   ///
   /// Inside the closure, initialize elements by appending to `span`. It

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -1153,8 +1153,7 @@ extension ContiguousArray {
   /// - Parameters:
   ///   - capacity: The number of elements to allocate
   ///     space for in the new array.
-  ///   - initializer: A closure that initializes elements and sets the count
-  ///     of the new array.
+  ///   - initializer: A closure that initializes the elements of the new array.
   ///     - Parameters:
   ///       - span: An `OutputSpan` covering uninitialized memory with
   ///         space for the specified number of elements.
@@ -1187,7 +1186,7 @@ extension ContiguousArray {
   }
 
   /// Grows the array to have enough capacity for the specified number of
-  /// elements, then calls the closure with an OutputSpan covering the array's
+  /// elements, then calls the closure with an output span covering the array's
   /// uninitialized memory.
   ///
   /// Inside the closure, initialize elements by appending to `span`. It

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -1211,6 +1211,9 @@ extension ContiguousArray {
       _ span: inout OutputSpan<Element>
     ) throws(E) -> Void
   ) throws(E) {
+    _precondition(
+      uninitializedCount >= 0, "uninitializedCount must not be negative"
+    )
     // Ensure uniqueness, mutability, and sufficient storage.
     _reserveCapacityImpl(
       minimumCapacity: self.count + uninitializedCount, growForAppend: true

--- a/test/stdlib/Span/OutputSpanTests.swift
+++ b/test/stdlib/Span/OutputSpanTests.swift
@@ -333,7 +333,6 @@ suite.test("Array initialization throws")
   }
 }
 
-
 suite.test("Array initialization overflow")
 .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
 .require(.stdlib_6_2).code {
@@ -343,6 +342,17 @@ suite.test("Array initialization overflow")
     span in
     span.append(1)
     span.append(2)
+  }
+  expectUnreachable("Array initializer should have trapped.")
+}
+
+suite.test("Array initialization underflow")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.require(.stdlib_6_2).code {
+
+  expectCrashLater()
+  _ = Array<Int>(capacity: -1) {
+    $0.removeAll()
   }
   expectUnreachable("Array initializer should have trapped.")
 }
@@ -413,7 +423,19 @@ suite.test("Array append overflow")
     span.append(1)
     span.append(2)
   }
-  expectUnreachable("Array initializer should have trapped.")
+  expectUnreachable("Array.append should have trapped.")
+}
+
+suite.test("Array append underflow")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.require(.stdlib_6_2).code {
+
+  expectCrashLater()
+  var a: [Int] = []
+  a.append(addingCapacity: -1) {
+    $0.removeAll()
+  }
+  expectUnreachable("Array.append should have trapped.")
 }
 
 suite.test("ContiguousArray initialization")
@@ -473,6 +495,17 @@ suite.test("ContiguousArray initialization overflow")
     span in
     span.append(1)
     span.append(2)
+  }
+  expectUnreachable("ContiguousArray initializer should have trapped.")
+}
+
+suite.test("ContiguousArray initialization underflow")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.require(.stdlib_6_2).code {
+
+  expectCrashLater()
+  _ = ContiguousArray<Int>(capacity: -1) {
+    $0.removeAll()
   }
   expectUnreachable("ContiguousArray initializer should have trapped.")
 }
@@ -543,5 +576,17 @@ suite.test("ContiguousArray append overflow")
     span.append(1)
     span.append(2)
   }
-  expectUnreachable("ContiguousArray initializer should have trapped.")
+  expectUnreachable("ContiguousArray append should have trapped.")
+}
+
+suite.test("ContiguousArray.append underflow")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.require(.stdlib_6_2).code {
+
+  expectCrashLater()
+  var a: [Int] = [1, 2, 3]
+  a.append(addingCapacity: -1) {
+    $0.removeAll()
+  }
+  expectUnreachable("ContiguousArray.append should have trapped.")
 }


### PR DESCRIPTION
Following up to review comments in https://github.com/swiftlang/swift/pull/83657

This makes corrections to the doc-comments for the new functions, and adds omitted tests along with some missing preconditions. Thanks to the Linux CI running optimized tests with a no-asserts standard library.