### PR TITLE
build: split compiler-rt from WASI sysroot install

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2086,7 +2086,7 @@ elif kIsWASI:
     config.target_sdk_name = "wasi"
     config.target_runtime = "native"
     config.target_not_crash = "not"
-    config.target_clang_resource_dir_opt = f"-resource-dir {test_resource_dir}/../../../wasi-sysroot/wasm32-wasip1"
+    config.target_clang_resource_dir_opt = f"-resource-dir {test_resource_dir}/../../../wasi-sysroot/wasm32-wasip1/resource-dir"
     config.target_swift_default_executor_opt = ''
 
     config.target_swift_autolink_extract = inferSwiftBinary("swift-autolink-extract")

--- a/utils/swift_build_support/swift_build_support/products/wasisysroot.py
+++ b/utils/swift_build_support/swift_build_support/products/wasisysroot.py
@@ -111,7 +111,14 @@ class WASILibc(product.Product):
         Returns the path to the sysroot install directory, which contains artifacts
         of wasi-libc and LLVM runtimes.
         """
-        return os.path.join(build_root, 'wasi-sysroot', target_triple)
+        return os.path.join(build_root, 'wasi-sysroot', target_triple, 'sysroot')
+
+    @classmethod
+    def resource_dir_install_path(cls, build_root, target_triple):
+        """
+        Returns the path to the compiler resource directory install location.
+        """
+        return os.path.join(build_root, 'wasi-sysroot', target_triple, 'resource-dir')
 
 
 class WasmLLVMRuntimeLibs(cmake_product.CMakeProduct):
@@ -145,12 +152,8 @@ class WasmLLVMRuntimeLibs(cmake_product.CMakeProduct):
                     compiler_rt_os_dir='wasip1', target_triple='wasm32-wasip1-threads')
 
     def _build(self, host_target, enable_wasi_threads, compiler_rt_os_dir, target_triple):
-        cmake = cmake_product.CMakeProduct(
-            args=self.args,
-            toolchain=self.toolchain,
-            source_dir=self.source_dir,
-            build_dir=os.path.join(self.build_dir, target_triple))
-
+        target_build_dir = os.path.join(self.build_dir, target_triple)
+        runtimes_build_dir = os.path.join(target_build_dir, 'runtimes')
         build_root = os.path.dirname(self.build_dir)
 
         if self.args.build_runtime_with_host_compiler:
@@ -166,8 +169,10 @@ class WasmLLVMRuntimeLibs(cmake_product.CMakeProduct):
         else:
             llvm_build_bin_dir = os.path.join(
                 '..', build_root, '%s-%s' % ('llvm', host_target), 'bin')
-            llvm_tools_path = cmake.args.native_llvm_tools_path or llvm_build_bin_dir
-            clang_tools_path = cmake.args.native_clang_tools_path or llvm_build_bin_dir
+            native_llvm_tools_path = self.args.native_llvm_tools_path
+            native_clang_tools_path = self.args.native_clang_tools_path
+            llvm_tools_path = native_llvm_tools_path or llvm_build_bin_dir
+            clang_tools_path = native_clang_tools_path or llvm_build_bin_dir
             ar_path = os.path.join(llvm_tools_path, 'llvm-ar')
             ranlib_path = os.path.join(llvm_tools_path, 'llvm-ranlib')
             cc_path = os.path.join(clang_tools_path, 'clang')
@@ -175,37 +180,8 @@ class WasmLLVMRuntimeLibs(cmake_product.CMakeProduct):
 
         cmake_has_threads = 'TRUE' if enable_wasi_threads else 'FALSE'
 
-        cmake.cmake_options.define(
-            'CMAKE_SYSROOT:PATH',
-            WASILibc.sysroot_build_path(build_root, host_target, target_triple))
-        enable_runtimes = ['libcxx', 'libcxxabi', 'compiler-rt']
-        cmake.cmake_options.define('LLVM_ENABLE_RUNTIMES:STRING',
-                                   ';'.join(enable_runtimes))
-
-        libdir_suffix = '/' + target_triple
-        cmake.cmake_options.define('LIBCXX_LIBDIR_SUFFIX:STRING', libdir_suffix)
-        cmake.cmake_options.define('LIBCXXABI_LIBDIR_SUFFIX:STRING', libdir_suffix)
-        cmake.cmake_options.define('CMAKE_STAGING_PREFIX:PATH', '/')
-
-        cmake.cmake_options.define('COMPILER_RT_DEFAULT_TARGET_ARCH:STRING', 'wasm32')
-        cmake.cmake_options.define('COMPILER_RT_DEFAULT_TARGET_ONLY:BOOL', 'TRUE')
-        cmake.cmake_options.define('COMPILER_RT_BAREMETAL_BUILD:BOOL', 'TRUE')
-        cmake.cmake_options.define('COMPILER_RT_BUILD_XRAY:BOOL', 'FALSE')
-        cmake.cmake_options.define('COMPILER_RT_BUILD_PROFILE:BOOL', 'TRUE')
-        cmake.cmake_options.define('COMPILER_RT_INCLUDE_TESTS:BOOL', 'FALSE')
-        cmake.cmake_options.define('COMPILER_RT_HAS_FPIC_FLAG:BOOL', 'FALSE')
-        cmake.cmake_options.define('COMPILER_RT_EXCLUDE_ATOMIC_BUILTIN:BOOL', 'FALSE')
-        cmake.cmake_options.define('COMPILER_RT_OS_DIR:STRING', compiler_rt_os_dir)
-
-        cmake.cmake_options.define('CMAKE_C_COMPILER_WORKS:BOOL', 'TRUE')
-        cmake.cmake_options.define('CMAKE_CXX_COMPILER_WORKS:BOOL', 'TRUE')
-
-        cmake.cmake_options.define('CMAKE_SYSTEM_NAME:STRING', 'WASI')
-        cmake.cmake_options.define('CMAKE_SYSTEM_PROCESSOR:STRING', 'wasm32')
-        cmake.cmake_options.define('CMAKE_AR:FILEPATH', ar_path)
-        cmake.cmake_options.define('CMAKE_RANLIB:FILEPATH', ranlib_path)
-        cmake.cmake_options.define('CMAKE_C_COMPILER:FILEPATH', cc_path)
-        cmake.cmake_options.define('CMAKE_CXX_COMPILER:STRING', cxx_path)
+        sysroot_build_path = WASILibc.sysroot_build_path(
+            build_root, host_target, target_triple)
 
         c_flags = []
         # Explicitly disable exceptions even though it's usually implicitly disabled by
@@ -216,12 +192,54 @@ class WasmLLVMRuntimeLibs(cmake_product.CMakeProduct):
         if enable_wasi_threads:
             c_flags.append('-pthread')
             cxx_flags.append('-pthread')
-        cmake.cmake_options.define('CMAKE_C_FLAGS:STRING', ' '.join(c_flags))
-        cmake.cmake_options.define('CMAKE_CXX_FLAGS:STRING', ' '.join(cxx_flags))
+        c_flags_str = ' '.join(c_flags)
+        cxx_flags_str = ' '.join(cxx_flags)
 
-        cmake.cmake_options.define('CMAKE_C_COMPILER_TARGET:STRING', target_triple)
-        cmake.cmake_options.define('CMAKE_CXX_COMPILER_TARGET:STRING', target_triple)
+        self._build_runtimes(
+            runtimes_build_dir=runtimes_build_dir,
+            target_triple=target_triple,
+            sysroot_build_path=sysroot_build_path,
+            build_root=build_root,
+            cc_path=cc_path,
+            cxx_path=cxx_path,
+            ar_path=ar_path,
+            ranlib_path=ranlib_path,
+            cmake_has_threads=cmake_has_threads,
+            c_flags=c_flags_str,
+            cxx_flags=cxx_flags_str)
 
+        self._build_compiler_rt(
+            target_build_dir=target_build_dir,
+            target_triple=target_triple,
+            compiler_rt_os_dir=compiler_rt_os_dir,
+            build_root=build_root,
+            sysroot_build_path=sysroot_build_path,
+            cc_path=cc_path,
+            cxx_path=cxx_path,
+            ar_path=ar_path,
+            ranlib_path=ranlib_path,
+            c_flags=c_flags_str,
+            cxx_flags=cxx_flags_str)
+
+    def _build_runtimes(self, runtimes_build_dir, target_triple, sysroot_build_path,
+                        build_root, cc_path, cxx_path, ar_path, ranlib_path,
+                        cmake_has_threads, c_flags, cxx_flags):
+        cmake = cmake_product.CMakeProduct(
+            args=self.args,
+            toolchain=self.toolchain,
+            source_dir=self.source_dir,
+            build_dir=runtimes_build_dir)
+
+        self._apply_wasi_toolchain_options(
+            cmake.cmake_options, sysroot_build_path, target_triple,
+            cc_path, cxx_path, ar_path, ranlib_path, c_flags, cxx_flags)
+        enable_runtimes = ['libcxx', 'libcxxabi']
+        cmake.cmake_options.define('LLVM_ENABLE_RUNTIMES:STRING',
+                                   ';'.join(enable_runtimes))
+
+        libdir_suffix = '/' + target_triple
+        cmake.cmake_options.define('LIBCXX_LIBDIR_SUFFIX:STRING', libdir_suffix)
+        cmake.cmake_options.define('LIBCXXABI_LIBDIR_SUFFIX:STRING', libdir_suffix)
         cmake.cmake_options.define('CXX_SUPPORTS_CXX11:BOOL', 'TRUE')
 
         cmake.cmake_options.define('LIBCXX_ENABLE_THREADS:BOOL', cmake_has_threads)
@@ -255,6 +273,59 @@ class WasmLLVMRuntimeLibs(cmake_product.CMakeProduct):
                                ignore_extra_cmake_options=True)
         cmake.install_with_cmake(
             ["install"], WASILibc.sysroot_install_path(build_root, target_triple))
+
+    def _build_compiler_rt(self, target_build_dir, target_triple, compiler_rt_os_dir,
+                           build_root, sysroot_build_path,
+                           cc_path, cxx_path, ar_path, ranlib_path,
+                           c_flags, cxx_flags):
+        compiler_rt_source_dir = os.path.join(
+            os.path.dirname(self.source_dir), 'compiler-rt')
+        compiler_rt_build_dir = os.path.join(target_build_dir, 'compiler-rt')
+        compiler_rt = cmake_product.CMakeProduct(
+            args=self.args,
+            toolchain=self.toolchain,
+            source_dir=compiler_rt_source_dir,
+            build_dir=compiler_rt_build_dir)
+
+        self._apply_wasi_toolchain_options(
+            compiler_rt.cmake_options, sysroot_build_path, target_triple,
+            cc_path, cxx_path, ar_path, ranlib_path, c_flags, cxx_flags)
+
+        compiler_rt.cmake_options.define('COMPILER_RT_DEFAULT_TARGET_ARCH:STRING', 'wasm32')
+        compiler_rt.cmake_options.define('COMPILER_RT_DEFAULT_TARGET_ONLY:BOOL', 'TRUE')
+        compiler_rt.cmake_options.define('COMPILER_RT_BAREMETAL_BUILD:BOOL', 'TRUE')
+        compiler_rt.cmake_options.define('COMPILER_RT_BUILD_XRAY:BOOL', 'FALSE')
+        compiler_rt.cmake_options.define('COMPILER_RT_BUILD_PROFILE:BOOL', 'TRUE')
+        compiler_rt.cmake_options.define('COMPILER_RT_INCLUDE_TESTS:BOOL', 'FALSE')
+        compiler_rt.cmake_options.define('COMPILER_RT_HAS_FPIC_FLAG:BOOL', 'FALSE')
+        compiler_rt.cmake_options.define('COMPILER_RT_EXCLUDE_ATOMIC_BUILTIN:BOOL', 'FALSE')
+        compiler_rt.cmake_options.define('COMPILER_RT_OS_DIR:STRING', compiler_rt_os_dir)
+
+        compiler_rt.build_with_cmake([], compiler_rt.args.build_variant, [],
+                                     prefer_native_toolchain=not self.args.build_runtime_with_host_compiler,
+                                     ignore_extra_cmake_options=True)
+        compiler_rt.install_with_cmake(
+            ["install"],
+            WASILibc.resource_dir_install_path(build_root, target_triple))
+
+    def _apply_wasi_toolchain_options(self, cmake_options, sysroot_build_path,
+                                      target_triple, cc_path, cxx_path,
+                                      ar_path, ranlib_path, c_flags, cxx_flags):
+        cmake_options.define('CMAKE_SYSROOT:PATH', sysroot_build_path)
+        cmake_options.define('CMAKE_STAGING_PREFIX:PATH', '/')
+        cmake_options.define('CMAKE_SYSTEM_NAME:STRING', 'WASI')
+        cmake_options.define('CMAKE_SYSTEM_PROCESSOR:STRING', 'wasm32')
+        cmake_options.define('UNIX:BOOL', 'TRUE')
+        cmake_options.define('CMAKE_AR:FILEPATH', ar_path)
+        cmake_options.define('CMAKE_RANLIB:FILEPATH', ranlib_path)
+        cmake_options.define('CMAKE_C_COMPILER:FILEPATH', cc_path)
+        cmake_options.define('CMAKE_CXX_COMPILER:STRING', cxx_path)
+        cmake_options.define('CMAKE_C_FLAGS:STRING', c_flags)
+        cmake_options.define('CMAKE_CXX_FLAGS:STRING', cxx_flags)
+        cmake_options.define('CMAKE_C_COMPILER_TARGET:STRING', target_triple)
+        cmake_options.define('CMAKE_CXX_COMPILER_TARGET:STRING', target_triple)
+        cmake_options.define('CMAKE_C_COMPILER_WORKS:BOOL', 'TRUE')
+        cmake_options.define('CMAKE_CXX_COMPILER_WORKS:BOOL', 'TRUE')
 
     @classmethod
     def get_dependencies(cls):

--- a/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
@@ -204,7 +204,7 @@ class WasmStdlib(cmake_product.CMakeProduct):
         test_driver_options = [
             # compiler-rt is not installed in the final toolchain, so use one
             # in build dir
-            '-Xclang-linker', '-resource-dir=' + self._wasi_sysroot_path(target_triple),
+            '-Xclang-linker', '-resource-dir=' + self._wasi_resource_dir_path(target_triple),
         ]
         # Leading space is needed to separate from other options
         self.cmake_options.define('SWIFT_DRIVER_TEST_OPTIONS:STRING',
@@ -269,6 +269,10 @@ class WasmStdlib(cmake_product.CMakeProduct):
     def _wasi_sysroot_path(self, target_triple):
         build_root = os.path.dirname(self.build_dir)
         return wasisysroot.WASILibc.sysroot_install_path(build_root, target_triple)
+
+    def _wasi_resource_dir_path(self, target_triple):
+        build_root = os.path.dirname(self.build_dir)
+        return wasisysroot.WASILibc.resource_dir_install_path(build_root, target_triple)
 
     def should_install(self, host_target):
         return False

--- a/utils/swift_build_support/swift_build_support/products/wasmswiftsdk.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmswiftsdk.py
@@ -224,7 +224,7 @@ class WasmSwiftSDK(product.Product):
 
     def _build_target_package(self, swift_host_triple, clang_multiarch_triple, has_pthread,
                               stdlib_build_path, llvm_runtime_libs_build_path,
-                              wasi_sysroot):
+                              wasi_sysroot, wasi_resource_dir):
 
         dest_dir = self._target_package_path(swift_host_triple)
         shell.rmtree(dest_dir)
@@ -235,13 +235,15 @@ class WasmSwiftSDK(product.Product):
             shell.call([self.toolchain.cmake, '--install', '.'],
                        env={'DESTDIR': dest_dir})
 
-        # Copy clang builtin libraries
-        with shell.pushd(llvm_runtime_libs_build_path):
-            for dirname in ['clang', 'swift/clang', 'swift_static/clang']:
-                clang_dir = os.path.join(dest_dir, f'usr/lib/{dirname}')
-                shell.call([self.toolchain.cmake, '--install', '.',
-                            '--component', 'clang_rt.builtins-wasm32'],
-                           env={'DESTDIR': clang_dir})
+        # Copy clang resource dir
+        for dirname in ['clang', 'swift/clang', 'swift_static/clang']:
+            dest_clang_resource_dir = os.path.join(
+                dest_dir, 'usr', 'lib', dirname)
+            shell.makedirs(dest_clang_resource_dir)
+            resource_lib_dir = os.path.join(dest_clang_resource_dir, 'lib')
+            # Remove existing (empty) lib directory, which is created by stdlib CMake install step
+            shell.rmtree(resource_lib_dir)
+            shell.copytree(os.path.join(wasi_resource_dir, 'lib'), resource_lib_dir)
 
         self._build_libxml2(swift_host_triple, clang_multiarch_triple, has_pthread, wasi_sysroot)
         self._build_foundation(swift_host_triple, clang_multiarch_triple, has_pthread, wasi_sysroot)
@@ -270,12 +272,14 @@ class WasmSwiftSDK(product.Product):
                 build_root, '%s-%s' % (build_basename, host_target))
             wasi_sysroot = wasisysroot.WASILibc.sysroot_install_path(
                 build_root, clang_multiarch_triple)
+            wasi_resource_dir = wasisysroot.WASILibc.resource_dir_install_path(
+                build_root, clang_multiarch_triple)
             llvm_runtime_libs_build_path = os.path.join(
                 build_root, '%s-%s' % ('wasmllvmruntimelibs', host_target),
                 clang_multiarch_triple)
             package_path = self._build_target_package(
                 swift_host_triple, clang_multiarch_triple, has_pthread, stdlib_build_path,
-                llvm_runtime_libs_build_path, wasi_sysroot)
+                llvm_runtime_libs_build_path, wasi_sysroot, wasi_resource_dir)
             if build_sdk:
                 target_packages.append((swift_host_triple, wasi_sysroot, package_path))
 


### PR DESCRIPTION
WASI sysroots installed libc++ and compiler-rt via the same runtimes mono build, leaving compiler-rt artifacts in the sysroot even though compiler-rt should belong under the compiler resource directory. That layout made it hard to package the WASI SDK correctly.

This patch modifies the WASI sysroot build to install compiler-rt under a separate resource directory so that we can copy the entire resource-dir's lib directory into the Swift resource dir.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
