### PR TITLE
Clean up type_checker_perf tests

### DIFF
--- a/validation-test/Sema/type_checker_perf/fast/array_literal_with_operators_and_double_literals.swift
+++ b/validation-test/Sema/type_checker_perf/fast/array_literal_with_operators_and_double_literals.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck -solver-expression-time-threshold=1
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck -solver-scope-threshold=2000
 
 // REQUIRES: objc_interop
 

--- a/validation-test/Sema/type_checker_perf/fast/cgfloat_with_unary_operators.swift
+++ b/validation-test/Sema/type_checker_perf/fast/cgfloat_with_unary_operators.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 
 // REQUIRES: OS=macosx,no_asan
 // REQUIRES: objc_interop

--- a/validation-test/Sema/type_checker_perf/fast/expression_too_complex_4.swift
+++ b/validation-test/Sema/type_checker_perf/fast/expression_too_complex_4.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 4 -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -swift-version 4 -solver-scope-threshold=1000
 // REQUIRES: tools-release,no_asan
 
 func test(_ i: Int, _ j: Int) -> Int {

--- a/validation-test/Sema/type_checker_perf/fast/fast-operator-typechecking.swift
+++ b/validation-test/Sema/type_checker_perf/fast/fast-operator-typechecking.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 5 -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -swift-version 5 -solver-scope-threshold=1000
 
 // rdar://problem/32998180
 func checksum(value: UInt16) -> UInt16 {

--- a/validation-test/Sema/type_checker_perf/fast/issue-42761.swift
+++ b/validation-test/Sema/type_checker_perf/fast/issue-42761.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 // REQUIRES: tools-release,no_asan
 
 // https://github.com/apple/swift/issues/42761

--- a/validation-test/Sema/type_checker_perf/fast/issue-43386_array_of_ranges.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/issue-43386_array_of_ranges.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 1 --end 15 --step 1 --select NumLeafScopes %s -Xfrontend=-solver-expression-time-threshold=1 -Xfrontend=-verify
+// RUN: %scale-test --begin 1 --end 15 --step 1 --select NumLeafScopes %s -Xfrontend=-solver-scope-threshold=1000 -Xfrontend=-verify
 // REQUIRES: asserts, no_asan
 
 // https://github.com/apple/swift/issues/43386

--- a/validation-test/Sema/type_checker_perf/fast/issue-62390.swift
+++ b/validation-test/Sema/type_checker_perf/fast/issue-62390.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 // REQUIRES: tools-release,no_asan
 
 // https://github.com/apple/swift/issues/62390

--- a/validation-test/Sema/type_checker_perf/fast/member_chains_and_operators_with_iou_base_types.swift
+++ b/validation-test/Sema/type_checker_perf/fast/member_chains_and_operators_with_iou_base_types.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck -solver-expression-time-threshold=1
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck -solver-scope-threshold=1000
 
 // REQUIRES: OS=macosx,no_asan
 // REQUIRES: objc_interop

--- a/validation-test/Sema/type_checker_perf/fast/mixed_string_array_addition.swift
+++ b/validation-test/Sema/type_checker_perf/fast/mixed_string_array_addition.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 5 -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -swift-version 5 -solver-scope-threshold=1000
 
 func method(_ arg: String, body: () -> [String]) {}
 

--- a/validation-test/Sema/type_checker_perf/fast/multi_statement_closure_with_simd_variable.swift
+++ b/validation-test/Sema/type_checker_perf/fast/multi_statement_closure_with_simd_variable.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 // REQUIRES: objc_interop,no_asan
 
 // REQUIRES: OS=macosx

--- a/validation-test/Sema/type_checker_perf/fast/operator_chain_with_hetergeneous_arguments.swift
+++ b/validation-test/Sema/type_checker_perf/fast/operator_chain_with_hetergeneous_arguments.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 // REQUIRES: tools-release,no_asan
 
 // TODO(performance): This should be converted in a scale test once performance issue is fixed

--- a/validation-test/Sema/type_checker_perf/fast/property_vs_unapplied_func.swift
+++ b/validation-test/Sema/type_checker_perf/fast/property_vs_unapplied_func.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 // REQUIRES: tools-release,no_asan
 
 struct Date {

--- a/validation-test/Sema/type_checker_perf/fast/rdar133340307.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar133340307.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 // REQUIRES: tools-release,no_asan
 
 public protocol Applicative {}

--- a/validation-test/Sema/type_checker_perf/fast/rdar17024694.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar17024694.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 // REQUIRES: tools-release,no_asan
 
 _ = (2...100).reversed().filter({ $0 % 11 == 0 }).map {

--- a/validation-test/Sema/type_checker_perf/fast/rdar17077404.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar17077404.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 // REQUIRES: tools-release,no_asan
 
 func memoize<A: Hashable, R>(

--- a/validation-test/Sema/type_checker_perf/fast/rdar18522024.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar18522024.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 // REQUIRES: tools-release,no_asan
 
 func test(a: [String], b: String, c: String) -> [String] {

--- a/validation-test/Sema/type_checker_perf/fast/rdar19029974.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19029974.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 // REQUIRES: tools-release,no_asan
 
 infix operator <*> : AdditionPrecedence

--- a/validation-test/Sema/type_checker_perf/fast/rdar19157118.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19157118.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 // REQUIRES: tools-release,no_asan
 
 public func expectEqualMethodsForDomain<

--- a/validation-test/Sema/type_checker_perf/fast/rdar19357292.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19357292.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 // REQUIRES: tools-release,no_asan
 
 func test(strings: [String]) {

--- a/validation-test/Sema/type_checker_perf/fast/rdar19738292.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19738292.swift.gyb
@@ -1,6 +1,5 @@
-// RUN: %scale-test --begin 7 --end 12 --step 1 --select NumLeafScopes %s
+// RUN: %scale-test --begin 3 --end 12 --step 1 --select NumLeafScopes %s
 // REQUIRES: asserts,no_asan
-// REQUIRES: rdar42650365,no_asan
 
 let a = [[0]]
 _ = a[0][0]

--- a/validation-test/Sema/type_checker_perf/fast/rdar19836070.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19836070.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 // REQUIRES: tools-release,no_asan
 
 let _: (Character) -> Bool = { c in

--- a/validation-test/Sema/type_checker_perf/fast/rdar20875936.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar20875936.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 // REQUIRES: tools-release,no_asan
 
 let _ = Array([0].lazy.reversed().filter { $0 % 2 == 0 }.map { $0 / 2 })

--- a/validation-test/Sema/type_checker_perf/fast/rdar21374729.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar21374729.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 // REQUIRES: tools-release,no_asan
 
 protocol P {

--- a/validation-test/Sema/type_checker_perf/fast/rdar21398466.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar21398466.swift
@@ -1,7 +1,6 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=50000
 // REQUIRES: OS=macosx,no_asan
 // REQUIRES: asserts,no_asan
-// REQUIRES: rdar48061151,no_asan
 
 // This problem is related to renaming,
 // as soon as `init(truncatingBitPattern:)` is changed
@@ -11,38 +10,38 @@ func getUInt8(u: UInt) -> [UInt8]
   let values: [UInt8]
 
   values = [
-    UInt8(truncatingBitPattern: (u >> 1) & 0xf), // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
-    UInt8(truncatingBitPattern: (u >> 2) & 0xf), // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
-    UInt8(truncatingBitPattern: (u >> 3) & 0xf), // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
-    UInt8(truncatingBitPattern: (u >> 4) & 0xf), // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
-    UInt8(truncatingBitPattern: (u >> 1) & 0xf), // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
-    UInt8(truncatingBitPattern: (u >> 2) & 0xf), // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
-    UInt8(truncatingBitPattern: (u >> 3) & 0xf), // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
-    UInt8(truncatingBitPattern: (u >> 4) & 0xf), // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
-    UInt8(truncatingBitPattern: (u >> 1) & 0xf), // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
-    UInt8(truncatingBitPattern: (u >> 2) & 0xf), // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
-    UInt8(truncatingBitPattern: (u >> 3) & 0xf), // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
-    UInt8(truncatingBitPattern: (u >> 4) & 0xf), // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
-    UInt8(truncatingBitPattern: (u >> 1) & 0xf), // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
-    UInt8(truncatingBitPattern: (u >> 2) & 0xf), // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
-    UInt8(truncatingBitPattern: (u >> 3) & 0xf), // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
-    UInt8(truncatingBitPattern: (u >> 4) & 0xf), // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
-    UInt8(truncatingBitPattern: (u >> 1) & 0xf), // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
-    UInt8(truncatingBitPattern: (u >> 2) & 0xf), // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
-    UInt8(truncatingBitPattern: (u >> 3) & 0xf), // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
-    UInt8(truncatingBitPattern: (u >> 4) & 0xf), // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
-    UInt8(truncatingBitPattern: (u >> 1) & 0xf), // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
-    UInt8(truncatingBitPattern: (u >> 2) & 0xf), // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
-    UInt8(truncatingBitPattern: (u >> 3) & 0xf), // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
-    UInt8(truncatingBitPattern: (u >> 4) & 0xf), // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
-    UInt8(truncatingBitPattern: (u >> 1) & 0xf), // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
-    UInt8(truncatingBitPattern: (u >> 2) & 0xf), // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
-    UInt8(truncatingBitPattern: (u >> 3) & 0xf), // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
-    UInt8(truncatingBitPattern: (u >> 4) & 0xf), // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
-    UInt8(truncatingBitPattern: (u >> 1) & 0xf), // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
-    UInt8(truncatingBitPattern: (u >> 2) & 0xf), // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
-    UInt8(truncatingBitPattern: (u >> 3) & 0xf), // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
-    UInt8(truncatingBitPattern: (u >> 4) & 0xf), // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
+    UInt8(truncatingBitPattern: (u >> 1) & 0xf), // expected-error {{extraneous argument label 'truncatingBitPattern:' in call}}
+    UInt8(truncatingBitPattern: (u >> 2) & 0xf), // expected-error {{extraneous argument label 'truncatingBitPattern:' in call}}
+    UInt8(truncatingBitPattern: (u >> 3) & 0xf), // expected-error {{extraneous argument label 'truncatingBitPattern:' in call}}
+    UInt8(truncatingBitPattern: (u >> 4) & 0xf), // expected-error {{extraneous argument label 'truncatingBitPattern:' in call}}
+    UInt8(truncatingBitPattern: (u >> 1) & 0xf), // expected-error {{extraneous argument label 'truncatingBitPattern:' in call}}
+    UInt8(truncatingBitPattern: (u >> 2) & 0xf), // expected-error {{extraneous argument label 'truncatingBitPattern:' in call}}
+    UInt8(truncatingBitPattern: (u >> 3) & 0xf), // expected-error {{extraneous argument label 'truncatingBitPattern:' in call}}
+    UInt8(truncatingBitPattern: (u >> 4) & 0xf), // expected-error {{extraneous argument label 'truncatingBitPattern:' in call}}
+    UInt8(truncatingBitPattern: (u >> 1) & 0xf), // expected-error {{extraneous argument label 'truncatingBitPattern:' in call}}
+    UInt8(truncatingBitPattern: (u >> 2) & 0xf), // expected-error {{extraneous argument label 'truncatingBitPattern:' in call}}
+    UInt8(truncatingBitPattern: (u >> 3) & 0xf), // expected-error {{extraneous argument label 'truncatingBitPattern:' in call}}
+    UInt8(truncatingBitPattern: (u >> 4) & 0xf), // expected-error {{extraneous argument label 'truncatingBitPattern:' in call}}
+    UInt8(truncatingBitPattern: (u >> 1) & 0xf), // expected-error {{extraneous argument label 'truncatingBitPattern:' in call}}
+    UInt8(truncatingBitPattern: (u >> 2) & 0xf), // expected-error {{extraneous argument label 'truncatingBitPattern:' in call}}
+    UInt8(truncatingBitPattern: (u >> 3) & 0xf), // expected-error {{extraneous argument label 'truncatingBitPattern:' in call}}
+    UInt8(truncatingBitPattern: (u >> 4) & 0xf), // expected-error {{extraneous argument label 'truncatingBitPattern:' in call}}
+    UInt8(truncatingBitPattern: (u >> 1) & 0xf), // expected-error {{extraneous argument label 'truncatingBitPattern:' in call}}
+    UInt8(truncatingBitPattern: (u >> 2) & 0xf), // expected-error {{extraneous argument label 'truncatingBitPattern:' in call}}
+    UInt8(truncatingBitPattern: (u >> 3) & 0xf), // expected-error {{extraneous argument label 'truncatingBitPattern:' in call}}
+    UInt8(truncatingBitPattern: (u >> 4) & 0xf), // expected-error {{extraneous argument label 'truncatingBitPattern:' in call}}
+    UInt8(truncatingBitPattern: (u >> 1) & 0xf), // expected-error {{extraneous argument label 'truncatingBitPattern:' in call}}
+    UInt8(truncatingBitPattern: (u >> 2) & 0xf), // expected-error {{extraneous argument label 'truncatingBitPattern:' in call}}
+    UInt8(truncatingBitPattern: (u >> 3) & 0xf), // expected-error {{extraneous argument label 'truncatingBitPattern:' in call}}
+    UInt8(truncatingBitPattern: (u >> 4) & 0xf), // expected-error {{extraneous argument label 'truncatingBitPattern:' in call}}
+    UInt8(truncatingBitPattern: (u >> 1) & 0xf), // expected-error {{extraneous argument label 'truncatingBitPattern:' in call}}
+    UInt8(truncatingBitPattern: (u >> 2) & 0xf), // expected-error {{extraneous argument label 'truncatingBitPattern:' in call}}
+    UInt8(truncatingBitPattern: (u >> 3) & 0xf), // expected-error {{extraneous argument label 'truncatingBitPattern:' in call}}
+    UInt8(truncatingBitPattern: (u >> 4) & 0xf), // expected-error {{extraneous argument label 'truncatingBitPattern:' in call}}
+    UInt8(truncatingBitPattern: (u >> 1) & 0xf), // expected-error {{extraneous argument label 'truncatingBitPattern:' in call}}
+    UInt8(truncatingBitPattern: (u >> 2) & 0xf), // expected-error {{extraneous argument label 'truncatingBitPattern:' in call}}
+    UInt8(truncatingBitPattern: (u >> 3) & 0xf), // expected-error {{extraneous argument label 'truncatingBitPattern:' in call}}
+    UInt8(truncatingBitPattern: (u >> 4) & 0xf), // expected-error {{extraneous argument label 'truncatingBitPattern:' in call}}
   ]
 
   return values

--- a/validation-test/Sema/type_checker_perf/fast/rdar22022980.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar22022980.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-scope-threshold=4000 -swift-version 5
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=5000 -swift-version 5
 // REQUIRES: tools-release,no_asan
 
 _ = [1, 3, 5, 7, 11].filter{ $0 == 1 || $0 == 3 || $0 == 11 || $0 == 1 || $0 == 3 || $0 == 11 } == [ 1, 3, 11 ]

--- a/validation-test/Sema/type_checker_perf/fast/rdar22022980.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar22022980.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=4000 -swift-version 5
 // REQUIRES: tools-release,no_asan
 
 _ = [1, 3, 5, 7, 11].filter{ $0 == 1 || $0 == 3 || $0 == 11 || $0 == 1 || $0 == 3 || $0 == 11 } == [ 1, 3, 11 ]

--- a/validation-test/Sema/type_checker_perf/fast/rdar22249571.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar22249571.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 // REQUIRES: tools-release,no_asan
 
 func rdar22249571() -> [UInt8] {

--- a/validation-test/Sema/type_checker_perf/fast/rdar22282851.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar22282851.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 // REQUIRES: tools-release,no_asan
 
 struct S {

--- a/validation-test/Sema/type_checker_perf/fast/rdar22466245.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar22466245.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=2000
 // REQUIRES: tools-release,no_asan
 
 _ = (1...10).map(String.init) + [": hi"]

--- a/validation-test/Sema/type_checker_perf/fast/rdar22466245.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar22466245.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 // REQUIRES: tools-release,no_asan
 
 _ = (1...10).map(String.init) + [": hi"]

--- a/validation-test/Sema/type_checker_perf/fast/rdar22770433.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar22770433.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 // REQUIRES: tools-release,no_asan
 
 func test(n: Int) -> Int {

--- a/validation-test/Sema/type_checker_perf/fast/rdar23429943.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar23429943.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 // REQUIRES: tools-release,no_asan
 
 let _ = [0].reduce([Int]()) {

--- a/validation-test/Sema/type_checker_perf/fast/rdar23620262.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar23620262.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 // REQUIRES: tools-release,no_asan
 
 // UNSUPPORTED: OS=linux-gnu

--- a/validation-test/Sema/type_checker_perf/fast/rdar23861629.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar23861629.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 // REQUIRES: tools-release,no_asan
 
 struct S { var s: String? }

--- a/validation-test/Sema/type_checker_perf/fast/rdar28018866.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar28018866.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 // REQUIRES: tools-release,no_asan
 
 struct P {

--- a/validation-test/Sema/type_checker_perf/fast/rdar31439825.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar31439825.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 // REQUIRES: tools-release,no_asan
 
 let a = 1

--- a/validation-test/Sema/type_checker_perf/fast/rdar32221800.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar32221800.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 // REQUIRES: tools-release,no_asan
 
 func test(header_field_mark: Bool?, header_value_mark: Bool?,

--- a/validation-test/Sema/type_checker_perf/fast/rdar32998180.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar32998180.swift
@@ -1,9 +1,9 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=12000
 // REQUIRES: tools-release,no_asan
 // REQUIRES: OS=macosx
 
 func rdar32998180(value: UInt16) -> UInt16 {
   let result = ((((value >> 1) ^ (value >> 1) ^ (value >> 1) ^ (value >> 1)) & 1) << 1)
-  | (((((value >> 1) ^ (value >> 1) ^ (value >> 1) ^ (value >> 1)) & 1) << 1) << 1)
+             | (((((value >> 1) ^ (value >> 1) ^ (value >> 1) ^ (value >> 1)) & 1) << 1) << 1)
   return result
 }

--- a/validation-test/Sema/type_checker_perf/fast/rdar32999041.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar32999041.swift.gyb
@@ -1,7 +1,5 @@
-// RUN: %scale-test --begin 3 --end 8 --step 1 --select NumLeafScopes %s
+// RUN: %scale-test --begin 3 --end 10 --step 1 --select NumLeafScopes %s
 // REQUIRES: asserts,no_asan
-// FIXME: https://github.com/apple/swift/issues/49545
-// REQUIRES: SR6997,no_asan
 
 _ = MemoryLayout<Int>.size
 %for i in range(0, N):

--- a/validation-test/Sema/type_checker_perf/fast/rdar33289839.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar33289839.swift.gyb
@@ -1,6 +1,5 @@
-// RUN: %scale-test --invert-result --begin 2 --end 7 --step 1 --select NumLeafScopes %s
+// RUN: %scale-test --begin 2 --end 7 --step 1 --select NumLeafScopes %s
 // REQUIRES: asserts,no_asan
-// REQUIRES: rdar42969824,no_asan
 
 func rdar33289839(s: String) -> String {
   return "test" + String(s)

--- a/validation-test/Sema/type_checker_perf/fast/rdar33806601.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar33806601.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 // REQUIRES: tools-release,no_asan
 
 class P {

--- a/validation-test/Sema/type_checker_perf/fast/rdar35213699.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar35213699.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 // REQUIRES: tools-release,no_asan
 
 func test() {

--- a/validation-test/Sema/type_checker_perf/fast/rdar36838495.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar36838495.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=2000
 // REQUIRES: tools-release,no_asan
 // REQUIRES: OS=macosx
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar42672946.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar42672946.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 func f(tail: UInt64, byteCount: UInt64) {
   if tail & ~(1 << ((byteCount & 7) << 3) - 1) == 0 { }
 }

--- a/validation-test/Sema/type_checker_perf/fast/rdar46541800.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar46541800.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 // REQUIRES: OS=macosx,no_asan
 
 import simd

--- a/validation-test/Sema/type_checker_perf/fast/rdar46687985.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar46687985.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 
 func test(_ d: Double) -> Double {
   return d + d - d - (d / 2) + (d / 2) + (d / 2.0)

--- a/validation-test/Sema/type_checker_perf/fast/rdar46713933_concrete_args.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar46713933_concrete_args.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 // REQUIRES: tools-release,no_asan
 
 func wrap<T>(_ key: String, _ value: T) -> T { return value }

--- a/validation-test/Sema/type_checker_perf/fast/rdar46713933_literal_arg.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar46713933_literal_arg.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 // REQUIRES: tools-release,no_asan
 
 func wrap<T>(_ key: String, _ value: T) -> T { return value }

--- a/validation-test/Sema/type_checker_perf/fast/rdar46939892.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar46939892.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 
 struct S {
   let a: Int

--- a/validation-test/Sema/type_checker_perf/fast/rdar47492691.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar47492691.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 // REQUIRES: objc_interop,no_asan
 
 import CoreGraphics

--- a/validation-test/Sema/type_checker_perf/fast/rdar54580427.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar54580427.swift
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 1 --end 20 --step 1 --select NumLeafScopes %s -Xfrontend=-solver-expression-time-threshold=1
+// RUN: %scale-test --begin 1 --end 20 --step 1 --select NumLeafScopes %s -Xfrontend=-solver-scope-threshold=1000
 // REQUIRES: asserts,no_asan
 
 // UNSUPPORTED: OS=linux-gnu

--- a/validation-test/Sema/type_checker_perf/fast/rdar54926602.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar54926602.swift
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 1 --end 10 --step 1 --select NumLeafScopes %s --expected-exit-code 1 -Xfrontend=-solver-expression-time-threshold=1
+// RUN: %scale-test --begin 1 --end 10 --step 1 --select NumLeafScopes %s --expected-exit-code 1 -Xfrontend=-solver-scope-threshold=1000
 // REQUIRES: asserts,no_asan
 
 class God {

--- a/validation-test/Sema/type_checker_perf/fast/rdar74035425.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar74035425.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 // REQUIRES: tools-release,no_asan
 // REQUIRES: OS=macosx
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar74853403.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar74853403.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 // REQUIRES: tools-release,no_asan
 
 func makeString(_ strings: [String]) -> String { "" }

--- a/validation-test/Sema/type_checker_perf/fast/rdar75476311.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar75476311.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.15 -solver-expression-time-threshold=1 -swift-version 5
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.15 -solver-scope-threshold=1000 -swift-version 5
 // REQUIRES: tools-release,no_asan,objc_interop
 // REQUIRES: OS=macosx
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar91310777.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar91310777.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 // REQUIRES: tools-release,no_asan
 
 func compute(_ cont: () -> Void) {}

--- a/validation-test/Sema/type_checker_perf/fast/swift_package_index_2.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/swift_package_index_2.swift.gyb
@@ -1,8 +1,6 @@
 // RUN: %scale-test --begin 1 --end 10 --step 1 --select NumConstraintScopes %s
 // REQUIRES: tools-release,no_asan,asserts
 
-// REQUIRES: rdar135382075
-
 var v: [String] = []
 var vv: [String]? = nil
 

--- a/validation-test/Sema/type_checker_perf/slow/array_count_property_vs_method.swift
+++ b/validation-test/Sema/type_checker_perf/slow/array_count_property_vs_method.swift
@@ -1,6 +1,7 @@
 // RUN: %target-typecheck-verify-swift -solver-scope-threshold=5000
 // REQUIRES: tools-release,no_asan
-// REQUIRES: OS=macosx
+
+// Valid expression, type checks with default limits but slow
 
 // FIXME: Array literals are considered "speculative" bindings at the moment but they cannot actually
 // assume different types unlike integer and floating-pointer literals.

--- a/validation-test/Sema/type_checker_perf/slow/borderline_flat_map_operator_mix.swift
+++ b/validation-test/Sema/type_checker_perf/slow/borderline_flat_map_operator_mix.swift
@@ -1,6 +1,8 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=10000
 
 // REQUIRES: no_asan
+
+// Valid expression, type checks with default limits but slow
 
 struct S {
     var t: Double

--- a/validation-test/Sema/type_checker_perf/slow/issue-43369.swift
+++ b/validation-test/Sema/type_checker_perf/slow/issue-43369.swift
@@ -1,7 +1,8 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=5
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=50000
 // REQUIRES: tools-release,no_asan
 
-// Hits the default memory threshold
+// Invalid expression, because there is no (A, Int) overload of /
+
 // https://github.com/apple/swift/issues/43369
 
 struct A {}

--- a/validation-test/Sema/type_checker_perf/slow/issue-49476.swift
+++ b/validation-test/Sema/type_checker_perf/slow/issue-49476.swift
@@ -2,7 +2,7 @@
 
 // https://github.com/swiftlang/swift/issues/49476
 
-// This is invalid, because offset and index have mismatched types
+// Invalid expression, because offset and index have mismatched types
 
 func slow() {
   let offset: Double = 5.0

--- a/validation-test/Sema/type_checker_perf/slow/issue-53523.swift
+++ b/validation-test/Sema/type_checker_perf/slow/issue-53523.swift
@@ -2,7 +2,7 @@
 
 // https://github.com/swiftlang/swift/issues/53523
 
-// This is invalid: we're mixing Double and Int.
+// Invalid expression, there is no (Double, Int) overload of /
 
 public func slow(d: Double, n: Int) {
   return d * 1.0 + 1.0 / n + d / d

--- a/validation-test/Sema/type_checker_perf/slow/issue-54143-1.swift
+++ b/validation-test/Sema/type_checker_perf/slow/issue-54143-1.swift
@@ -21,7 +21,7 @@ class UIView {
   init() { fatalError() }
 }
 
-// This is invalid, because there is no one-argument form of reduce()
+// Invalid expression, because there is no one-argument form of reduce()
 
 class SomeViewController: UIViewController {
     private func updatePreferredContentSize() {

--- a/validation-test/Sema/type_checker_perf/slow/issue-60320.swift
+++ b/validation-test/Sema/type_checker_perf/slow/issue-60320.swift
@@ -8,6 +8,8 @@ func *(_: Double, _: MyType) -> MyType {}
 // func *(_: MyType, _: Double) -> MyType {}
 func +(_: MyType, _: MyType) -> MyType {}
 
+// Invalid expression, because there is no (MyType, Double) overload of /
+
 func slow() {
   let d: Double
   let state: MyType
@@ -16,7 +18,6 @@ func slow() {
   let k3: MyType
   let k4: MyType
 
-  // This is invalid because of the missing overload commented out above
   let result = state + (1.0/6) * (k1 + 2*k2 + 2*k3 + k4) * d
   // expected-error@-1 {{reasonable}}
 }

--- a/validation-test/Sema/type_checker_perf/slow/issue-62778.swift
+++ b/validation-test/Sema/type_checker_perf/slow/issue-62778.swift
@@ -3,7 +3,7 @@
 
 // https://github.com/swiftlang/swift/issues/62778
 
-// This is invalid; we're applying | to UInt vs Int.
+// Invalid expression, because there is no (UInt, Int) overload of |.
 
 func slow() {
   let pieces = [1, 2, 3, 4]

--- a/validation-test/Sema/type_checker_perf/slow/issue-73885.swift
+++ b/validation-test/Sema/type_checker_perf/slow/issue-73885.swift
@@ -47,6 +47,8 @@ struct Bar {
 
 extension Event {
     static func test1(foo: Foo) -> Event {
+        // Invalid expression, because the dictionary literal has the
+        // wrong type.
         .init(properties: [  // expected-error {{reasonable time}}
             .dim1: foo.bar?.bar,
             .dim2: foo.bar?.baz,

--- a/validation-test/Sema/type_checker_perf/slow/rdar17170728.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar17170728.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 // REQUIRES: tools-release,no_asan
 
 let i: Int? = 1

--- a/validation-test/Sema/type_checker_perf/slow/rdar18800950.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar18800950.swift
@@ -1,7 +1,7 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=50000
 // REQUIRES: tools-release,no_asan
 
-// Mixed Float and Double arithmetic
+// Invalid expression: mixed Float and Double arithmetic
 func rdar18800950(v: Float) -> Double {
   let c1: Float = 1.0
   let c2 = 2.0

--- a/validation-test/Sema/type_checker_perf/slow/rdar18994321.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar18994321.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=50000
 // REQUIRES: tools-release,no_asan
 
 precedencegroup ExponentiationPrecedence {
@@ -17,7 +17,7 @@ func test(f: Float) {
   let v2 = 2.2
   let v3 = 3.3
 
-  // NOTE: This is using mixed types, and would result in a type checking error if it completed.
+  // Invalid expression: Mixed Float and Double arithmetic
   let _ = v2*7.1**(1.97276*(1-v1/f)-7.02202*v3+1.70373*1e-3*(1.0-10**(-2.29692*(f/v1-1.0)))+0.32273*1e-3*(10**(3.76977*(1.0-v1/f))-1)-2.2195923)
   // expected-error@-1 {{the compiler is unable to type-check this expression in reasonable time; try breaking up the expression into distinct sub-expressions}}
 }

--- a/validation-test/Sema/type_checker_perf/slow/rdar19368383.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar19368383.swift
@@ -1,7 +1,7 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=50000
 // REQUIRES: tools-release,no_asan
 
-// Missing force of optional result of dictionary lookup.
+// Invalid expression: Missing force of optional result of dictionary lookup.
 func rdar19368383(d: [String : String]) -> [String] {
   var r = [String]()
   r += [ // expected-error {{reasonable time}}

--- a/validation-test/Sema/type_checker_perf/slow/rdar19612086.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar19612086.swift
@@ -1,5 +1,8 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=50000
 // REQUIRES: tools-release,no_asan
+
+// Invalid expression: There is no + overload for Stringly
+
 struct Stringly {
   init(string: String) {}
   init(format: String, _ args: Any...) {}

--- a/validation-test/Sema/type_checker_perf/slow/rdar19737632.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar19737632.swift
@@ -1,5 +1,7 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=50000
 // REQUIRES: tools-release,no_asan
+
+// Invalid expression: Non-existent overloads of +
 
 let a = "a"
 let b = "b"

--- a/validation-test/Sema/type_checker_perf/slow/rdar19915443.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar19915443.swift
@@ -1,7 +1,9 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=50000
 // REQUIRES: tools-release,no_asan
 
 var counts = [ 0, 0, 0, 0 ]
-// NOTE: This is using mixed types, and would result in a type checking error if it completed.
+
+// Invalid expression: Missing (Int, Array<Int>) overload of +
+
 let d = counts[0] * 1000 + counts[1] * 100 + counts[2] * 10 + counts
 // expected-error@-1 {{the compiler is unable to type-check this expression in reasonable time; try breaking up the expression into distinct sub-expressions}}

--- a/validation-test/Sema/type_checker_perf/slow/rdar20859567.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar20859567.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=50000
 // REQUIRES: tools-release,no_asan
 
 struct Stringly {
@@ -6,6 +6,8 @@ struct Stringly {
   init(format: String, _ args: Any...) {}
   init(stringly: Stringly) {}
 }
+
+// Invalid expression: Missing overloads of +
 
 [Int](0..<1).map {
   // expected-error@-1 {{reasonable time}}

--- a/validation-test/Sema/type_checker_perf/slow/rdar22079400.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar22079400.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 // REQUIRES: tools-release,no_asan
 
 let _ = (0...1).lazy.flatMap { // expected-error {{reasonable time}}

--- a/validation-test/Sema/type_checker_perf/slow/rdar22877285.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar22877285.swift
@@ -1,5 +1,7 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=50000
 // REQUIRES: tools-release,no_asan
+
+// Invalid expression: Missing overloads of +
 
 let j = 1
 

--- a/validation-test/Sema/type_checker_perf/slow/rdar22949523.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar22949523.swift
@@ -1,5 +1,7 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=50000
 // REQUIRES: tools-release,no_asan
+
+// Invalid expression: Missing (String, Int) overload of <
 
 _ = [0,1,2,3].lazy.map { String($0)+"hi" }.sorted(by: { $0 > $1 && $1 < $0 && ($1 + $0) < 1000 })
 // expected-error@-1 {{reasonable time}}

--- a/validation-test/Sema/type_checker_perf/slow/rdar23224583.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar23224583.swift
@@ -1,7 +1,8 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=50000
 // REQUIRES: tools-release,no_asan
 
-// Mixed UInt32 and Double
+// Invalid expression: Missing (UInt32, Double) overload of >
+
 let x: UInt32 = 1
 let _ = x > (33 + 55 + 6 + 55 + 6 + 55 + 6 + 55 + 6 + 27.5)
 // expected-error@-1 {{reasonable time}}

--- a/validation-test/Sema/type_checker_perf/slow/rdar23682605.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar23682605.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
 // REQUIRES: tools-release,no_asan
 
 func memoize<T: Hashable, U>( body: @escaping ((T)->U, T)->U ) -> (T)->U {

--- a/validation-test/Sema/type_checker_perf/slow/rdar26564101.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar26564101.swift
@@ -1,6 +1,8 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=50000
 // REQUIRES: tools-release,no_asan
 // UNSUPPORTED: swift_test_mode_optimize_none && OS=linux-gnu
+
+// Invalid expression: Missing (Int, Double) overload of -
 
 func rdar26564101(a: [Double], m: Double) -> Double {
   // expected-error@+1 {{unable to type-check this expression in reasonable time}}

--- a/validation-test/Sema/type_checker_perf/slow/rdar30631148.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar30631148.swift
@@ -1,5 +1,7 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=50000
 // REQUIRES: tools-release,no_asan
+
+// Invalid expression: Missing (Double, Float) overload of /
 
 func fun(_ x: Double) -> Double { fatalError() }
 

--- a/validation-test/Sema/type_checker_perf/slow/rdar32034560.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar32034560.swift
@@ -1,15 +1,16 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
-// REQUIRES: rdar42744631,no_asan
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=10000
 // REQUIRES: tools-release,no_asan
+
+// Valid expression, type checks with default limits but slow
 
 struct S {
   var A: [[UInt32]]
 
   func rdar32034560(x: UInt32) -> UInt32 {
+    // expected-error@+1 {{reasonable time}}
     return ((self.A[0][Int(x >> 24) & 0xFF] &+ self.A[1][Int(x >> 16) & 0xFF]) ^ self.A[2][Int(x >> 8) & 0xFF]) &+ self.A[3][Int(x & 0xFF)]
          | ((self.A[0][Int(x >> 24) & 0xFF] &+ self.A[1][Int(x >> 16) & 0xFF]) ^ self.A[2][Int(x >> 8) & 0xFF]) &+ self.A[3][Int(x & 0xFF)]
          | ((self.A[0][Int(x >> 24) & 0xFF] &+ self.A[1][Int(x >> 16) & 0xFF]) ^ self.A[2][Int(x >> 8) & 0xFF]) &+ self.A[3][Int(x & 0xFF)]
          | ((self.A[0][Int(x >> 24) & 0xFF] &+ self.A[1][Int(x >> 16) & 0xFF]) ^ self.A[2][Int(x >> 8) & 0xFF]) &+ self.A[3][Int(x & 0xFF)]
-   // expected-error@-1 {{reasonable time}}
   }
 }

--- a/validation-test/Sema/type_checker_perf/slow/rdar33476240.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar33476240.swift
@@ -1,7 +1,8 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=50000
 // REQUIRES: tools-release,no_asan
 
-// Mixed Int/Double slow to emit diagnostics
+// Invalid expression: Missing (Int, Double) overload of - or *
+
 func rdar33476240(col: Int, row: Int, maxCol: Int, maxRow: Int) {
   let _ = (-(maxCol - 1) + (col * 2)) * 0.1 * 0.2 * 0.3
   // expected-error@-1 {{reasonable time}}

--- a/validation-test/Sema/type_checker_perf/slow/rdar33935430.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar33935430.swift
@@ -1,7 +1,8 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=50000
 // REQUIRES: tools-release,no_asan
 
-// Mixed Int/Float arithmetic
+// Invalid expression: Missing (Int, Float) overload of +
+
 func rdar33935430(a: Int, b: Int, c: Float, d: Float, n: Int) {
   let _ = ((a * c) + ((b * d - a * c) / (b - a)) * (n - a)) / n
   // expected-error@-1 {{reasonable time}}

--- a/validation-test/Sema/type_checker_perf/slow/rdar53589951.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar53589951.swift
@@ -1,11 +1,12 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=5000
 // REQUIRES: tools-release,no_asan
-// REQUIRES: rdar36854536
 
 class Color {
   init(hue: Double, saturation: Double, brightness: Double, alpha: Double) {}
   init(red: Double, green: Double, blue: Double, alpha: Double) {}
 }
+
+// Invalid expression: Argument label mismatch in Color.init()
 
 // expected-error@+1 {{reasonable time}}
 let _: [Color] = [

--- a/validation-test/Sema/type_checker_perf/slow/swift_package_index_3.swift
+++ b/validation-test/Sema/type_checker_perf/slow/swift_package_index_3.swift
@@ -1,6 +1,8 @@
 // RUN: %target-typecheck-verify-swift %s -solver-scope-threshold=50000
 // REQUIRES: tools-release,no_asan
 
+// Valid expression, type checks with default limits but slow
+
 extension String {
   func replacingOccurrences(of: String, with: String) -> String { return "" }
   func components(separatedBy: String) -> [String] { return [] }


### PR DESCRIPTION
- Use -solver-scope-threshold instead of -solver-expression-time-threshold to make them deterministic
- Out of the slow tests, annotate which ones are invalid, for easy grepping
- Re-enable some tests that were "temporarily" disabled years ago and never re-enabled