### PR TITLE
Sema: Remove disjunction ordering heuristic for logical operators

### DIFF
--- a/lib/Sema/CSOptimizer.cpp
+++ b/lib/Sema/CSOptimizer.cpp
@@ -254,14 +254,6 @@ static bool isStandardComparisonOperator(Constraint *disjunction) {
   return false;
 }
 
-static bool isStandardInfixLogicalOperator(Constraint *disjunction) {
-  auto *choice = disjunction->getNestedConstraints()[0];
-  if (auto *decl = getOverloadChoiceDecl(choice))
-    return decl->isOperator() &&
-           decl->getBaseIdentifier().isStandardInfixLogicalOperator();
-  return false;
-}
-
 static bool isNilCoalescingOperator(Constraint *disjunction) {
   auto *choice = disjunction->getNestedConstraints()[0];
   if (auto *decl = getOverloadChoiceDecl(choice))
@@ -1954,16 +1946,6 @@ ConstraintSystem::selectDisjunction() {
 
     bool isFirstOperator = isOperatorDisjunction(first);
     bool isSecondOperator = isOperatorDisjunction(second);
-
-    // Infix logical operators are usually not overloaded and don't
-    // form disjunctions, but when they do, let's prefer them over
-    // other operators when they have fewer choices because it helps
-    // to split operator chains.
-    if (isFirstOperator && isSecondOperator) {
-      if (isStandardInfixLogicalOperator(first) !=
-          isStandardInfixLogicalOperator(second))
-        return firstActive < secondActive;
-    }
 
     // Not all of the non-operator disjunctions are supported by the
     // ranking algorithm, so to prevent eager selection of operators


### PR DESCRIPTION
This doesn't seem to be covered by tests.