### PR TITLE
[windows] add required steps to enable Swift lldb tests

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2379,7 +2379,8 @@ function Test-Compilers([Hashtable] $Platform, [string] $Variant, [switch] $Test
         # Check for required Python modules in CMake
         LLDB_ENFORCE_STRICT_TEST_REQUIREMENTS = "YES";
         # No watchpoint support on windows: https://github.com/llvm/llvm-project/issues/24820
-        LLDB_TEST_USER_ARGS = "--skip-category=watchpoint";
+        LLDB_TEST_USER_ARGS = "--skip-category=watchpoint;--sysroot=$(Get-SwiftSDK -OS $Platform.OS -Identifier $Platform.DefaultSDK)";
+        LLDB_TEST_SWIFT_DRIVER_EXTRA_FLAGS = "-sdk $(Get-SwiftSDK -OS $Platform.OS -Identifier $Platform.DefaultSDK)"
         # gtest sharding breaks llvm-lit's --xfail and LIT_XFAIL inputs: https://github.com/llvm/llvm-project/issues/102264
         LLVM_LIT_ARGS = "-v --no-gtest-sharding --time-tests";
         # LLDB Unit tests link against this library


### PR DESCRIPTION
This patch adds the steps needed to enable the lldb Swift tests.

The `@swiftTest` decorator in lldb tests currently skips tests on Windows. Enabling the tests on Windows requires passing the SDKROOT to `swiftc`. This will be done in https://github.com/swiftlang/llvm-project/pull/12127.

This PR is related to:
- https://github.com/swiftlang/llvm-project/pull/11785

rdar://168441485