### PR TITLE
[Test][remote-run] Migrate remote-run files compatible with lit shell

### DIFF
--- a/test/remote-run/dry-run.test-sh
+++ b/test/remote-run/dry-run.test-sh
@@ -1,19 +1,27 @@
 REQUIRES: rsync
-REQUIRES: shell
 
 RUN: %empty-directory(%t)
-RUN: %debug-remote-run -n --input-prefix %S/Inputs/ ls %S/Inputs/upload/1.txt %S/Inputs/upload/2.txt 2>&1 >/dev/null | %FileCheck -check-prefix CHECK-INPUT %s
-RUN: test -z "`ls %t`"
+RUN: mkdir -p %t/log
+RUN: %debug-remote-run -n --input-prefix %S/Inputs/ ls %S/Inputs/upload/1.txt %S/Inputs/upload/2.txt 1>/dev/null 2>%t/log/input-log.txt
+RUN: %FileCheck -check-prefix CHECK-INPUT %s < %t/log/input-log.txt
+RUN: ls %t > %t/log/top.txt
+RUN: %FileCheck -check-prefix CHECK-TOP-ONLY-LOG %s < %t/log/top.txt
 RUN: test ! -e %t-REMOTE
 
+CHECK-TOP-ONLY-LOG: log
+CHECK-TOP-ONLY-LOG-NOT: {{.}}
+
 CHECK-INPUT: /usr/bin/env /bin/mkdir -p {{.+}}-REMOTE/input
-CHECK-INPUT-NEXT: rsync
+CHECK-INPUT: rsync
 CHECK-INPUT: /usr/bin/env {{.*}}ls
 
 RUN: %empty-directory(%t)
+RUN: mkdir -p %t/log
 RUN: %empty-directory(%t/nested)
 RUN: touch %t/nested/input %t/nested/BAD
-RUN: %debug-remote-run -n --output-prefix %t cp %t/nested/input %t/nested/output 2>&1 >/dev/null | %FileCheck -check-prefix CHECK-OUTPUT %s
+RUN: %debug-remote-run -n --output-prefix %t cp %t/nested/input %t/nested/output 1>/dev/null 2>%t/log/output-log.txt
+RUN: %FileCheck -check-prefix CHECK-OUTPUT %s < %t/log/output-log.txt
+RUN: test ! -e %t/nested/output
 RUN: test ! -e %t-REMOTE
 
 CHECK-OUTPUT: /usr/bin/env /bin/mkdir -p {{.+}}-REMOTE/output/nested

--- a/test/remote-run/dry-run.test-sh
+++ b/test/remote-run/dry-run.test-sh
@@ -1,27 +1,19 @@
 REQUIRES: rsync
+UNSUPPORTED: OS=windows-msvc
 
 RUN: %empty-directory(%t)
-RUN: mkdir -p %t/log
-RUN: %debug-remote-run -n --input-prefix %S/Inputs/ ls %S/Inputs/upload/1.txt %S/Inputs/upload/2.txt 1>/dev/null 2>%t/log/input-log.txt
-RUN: %FileCheck -check-prefix CHECK-INPUT %s < %t/log/input-log.txt
-RUN: ls %t > %t/log/top.txt
-RUN: %FileCheck -check-prefix CHECK-TOP-ONLY-LOG %s < %t/log/top.txt
+RUN: %debug-remote-run -n --input-prefix %S/Inputs/ ls %S/Inputs/upload/1.txt %S/Inputs/upload/2.txt 2>&1 >/dev/null | %FileCheck -check-prefix CHECK-INPUT %s
+RUN: test -z "`ls %t`"
 RUN: test ! -e %t-REMOTE
 
-CHECK-TOP-ONLY-LOG: log
-CHECK-TOP-ONLY-LOG-NOT: {{.}}
-
 CHECK-INPUT: /usr/bin/env /bin/mkdir -p {{.+}}-REMOTE/input
-CHECK-INPUT: rsync
+CHECK-INPUT-NEXT: rsync
 CHECK-INPUT: /usr/bin/env {{.*}}ls
 
 RUN: %empty-directory(%t)
-RUN: mkdir -p %t/log
 RUN: %empty-directory(%t/nested)
 RUN: touch %t/nested/input %t/nested/BAD
-RUN: %debug-remote-run -n --output-prefix %t cp %t/nested/input %t/nested/output 1>/dev/null 2>%t/log/output-log.txt
-RUN: %FileCheck -check-prefix CHECK-OUTPUT %s < %t/log/output-log.txt
-RUN: test ! -e %t/nested/output
+RUN: %debug-remote-run -n --output-prefix %t cp %t/nested/input %t/nested/output 2>&1 >/dev/null | %FileCheck -check-prefix CHECK-OUTPUT %s
 RUN: test ! -e %t-REMOTE
 
 CHECK-OUTPUT: /usr/bin/env /bin/mkdir -p {{.+}}-REMOTE/output/nested

--- a/test/remote-run/env.test-sh
+++ b/test/remote-run/env.test-sh
@@ -1,5 +1,5 @@
 REQUIRES: rsync
-REQUIRES: shell
+UNSUPPORTED: OS=windows-msvc
 
 RUN: env REMOTE_RUN_CHILD_FOO=foo REMOTE_RUN_CHILD_BAR=bar %debug-remote-run sh -c 'echo ":${FOO}:" ":${BAR}:"' | %FileCheck %s
 RUN: env REMOTE_RUN_CHILD_FOO=foo REMOTE_RUN_CHILD_BAR=bar %debug-remote-run -v sh -c 'echo ":${FOO}:" ":${BAR}:"' 2>&1 >/dev/null | %FileCheck -check-prefix VERBOSE %s

--- a/test/remote-run/exit-code.test-sh
+++ b/test/remote-run/exit-code.test-sh
@@ -1,5 +1,5 @@
 REQUIRES: rsync
-REQUIRES: shell
+UNSUPPORTED: OS=windows-msvc
 
 RUN: export SWIFT_BACKTRACE=
 RUN: not %debug-remote-run false >%t.txt 2>%t.errs.txt

--- a/test/remote-run/run-only.test-sh
+++ b/test/remote-run/run-only.test-sh
@@ -1,5 +1,5 @@
 REQUIRES: rsync
-REQUIRES: shell
+UNSUPPORTED: OS=windows-msvc
 
 RUN: %debug-remote-run echo hello | %FileCheck %s
 RUN: %debug-remote-run -v echo hello 2>&1 >/dev/null | %FileCheck -check-prefix VERBOSE %s

--- a/test/remote-run/stderr.test-sh
+++ b/test/remote-run/stderr.test-sh
@@ -1,5 +1,5 @@
 REQUIRES: rsync
-REQUIRES: shell
+UNSUPPORTED: OS=windows-msvc
 
 RUN: %debug-remote-run sh -c "echo hello; echo goodbye >&2" > %t.stdout.txt 2> %t.stderr.txt
 RUN: %FileCheck -check-prefix CHECK-STDOUT %s < %t.stdout.txt


### PR DESCRIPTION
Partially addresses: https://github.com/swiftlang/swift/issues/84407

Files included in this PR:
```
test/remote-run/dry-run.test-sh
test/remote-run/stderr.test-sh
test/remote-run/exit-code.test-sh
test/remote-run/run-only.test-sh
test/remote-run/env.test-sh
```