### PR TITLE
[PrintAsClang] Strip trailing / from search paths

### DIFF
--- a/test/PrintAsObjC/Inputs/custom-modules/header_above_modulemap/header-above-modulemap.h
+++ b/test/PrintAsObjC/Inputs/custom-modules/header_above_modulemap/header-above-modulemap.h
@@ -1,0 +1,5 @@
+#import <Foundation.h>
+
+@interface Parent : NSObject
+- (void)bar;
+@end

--- a/test/PrintAsObjC/Inputs/custom-modules/header_above_modulemap/subdir/module.modulemap
+++ b/test/PrintAsObjC/Inputs/custom-modules/header_above_modulemap/subdir/module.modulemap
@@ -1,0 +1,4 @@
+module EmitClangHeaderWithParentDir {
+  header "../header-above-modulemap.h"
+  export *
+}

--- a/test/PrintAsObjC/emit-clang-header-nonmodular-includes-path-normalization.swift
+++ b/test/PrintAsObjC/emit-clang-header-nonmodular-includes-path-normalization.swift
@@ -1,13 +1,17 @@
 // REQUIRES: objc_interop
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -emit-objc-header-path %t/textual-imports.h -Xcc -fmodule-map-file=%S/Inputs/custom-modules/module.modulemap -Xcc -I%S/Inputs/custom-modules/./header_subdirectory/ -I%S/Inputs/custom-modules/ -emit-clang-header-nonmodular-includes %s
+// RUN: cd %S/Inputs/custom-modules
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -emit-objc-header-path %t/textual-imports.h -Xcc -fmodule-map-file=%S/Inputs/custom-modules/module.modulemap -Xcc -I%S/Inputs/custom-modules/./header_subdirectory/ -Xcc -fmodule-map-file=%S/Inputs/custom-modules/header_above_modulemap/subdir/module.modulemap -Xcc -I. -emit-clang-header-nonmodular-includes %s
 // RUN: %FileCheck %s < %t/textual-imports.h
 
 // The period in the provided include directory above should not break the system.
 import EmitClangHeaderNonmodularIncludesStressTest
+import EmitClangHeaderWithParentDir
 
 public class Bar : Baz {}
+
+public class Sub : Parent {}
 
 // CHECK:      #if __has_feature(objc_modules)
 // CHECK:      #if __has_feature(objc_modules)
@@ -15,8 +19,13 @@ public class Bar : Baz {}
 // CHECK-NEXT: #pragma clang diagnostic ignored "-Watimport-in-framework-header"
 // CHECK-NEXT: #endif
 // CHECK-NEXT: @import EmitClangHeaderNonmodularIncludesStressTest;
+// CHECK-NEXT: @import EmitClangHeaderWithParentDir;
 // CHECK-NEXT: #elif defined(__OBJC__)
 // CHECK-NEXT: #import <header-regular.h>
-// CHECK: #else
+// CHECK-NEXT: #import <header-symlink.h>
+// CHECK-NEXT: #import <header_above_modulemap/header-above-modulemap.h>
+// CHECK-NEXT: #else
 // CHECK-NEXT: #include <header-regular.h>
-// CHECK: #endif
+// CHECK-NEXT: #include <header-symlink.h>
+// CHECK-NEXT: #include <header_above_modulemap/header-above-modulemap.h>
+// CHECK-NEXT: #endif


### PR DESCRIPTION
When emitting ObjC textual imports for Swift headers, we need to strip any trailing / for prefixing to work correctly. We add a trailing / to the prefix in `addHeader` here:

https://github.com/swiftlang/swift/blob/8d4ded8a203b849d3e2e39eda659f2befdbad1f5/lib/PrintAsClang/PrintAsClang.cpp#L322-L323

Without stripping we end up with a double / and the prefix does not match.
