### PR TITLE
[driver] Implement -debug-module-path in the legacy driver 

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -696,6 +696,21 @@ ToolChain::constructInvocation(const CompileJobAction &job,
     Arguments.push_back("-debug-info-store-invocation");
   }
 
+  if (context.Args.hasArg(options::OPT_g))
+    for (auto Output : context.Output.getAdditionalOutputsForType(
+             file_types::ID::TY_SwiftModuleFile)) {
+      // This communicates the output of an action that depends on this action's
+      // output, which is why we're recomputing the name here.
+      llvm::SmallString<128> Path(Output);
+      assert(!Path.empty());
+      llvm::sys::path::remove_filename(Path);
+      llvm::sys::path::append(Path, context.OI.ModuleName);
+      llvm::sys::path::replace_extension(
+          Path, file_types::getExtension(file_types::ID::TY_SwiftModuleFile));
+      Arguments.push_back("-debug-module-path");
+      Arguments.push_back(context.Args.MakeArgString(Path));
+    }
+
   if (context.Args.hasArg(
                       options::OPT_disable_autolinking_runtime_compatibility)) {
     Arguments.push_back("-disable-autolinking-runtime-compatibility");

--- a/test/Driver/debug-module-path.swift
+++ b/test/Driver/debug-module-path.swift
@@ -1,0 +1,3 @@
+// RUN: %swiftc_driver -module-name a -driver-print-jobs -target x86_64-apple-macosx10.10 -g -o debugmodule-path %s 2>&1 | %FileCheck %s
+
+// CHECK: -debug-module-path {{.*}}{{/|\\\\}}a.swiftmodule

--- a/test/Driver/modulewrap.swift
+++ b/test/Driver/modulewrap.swift
@@ -1,6 +1,6 @@
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-linux-gnu -g %s | %FileCheck %s
 
-// CHECK: bin{{/|\\\\}}swift{{(c|c-legacy-driver|-frontend)?(\.exe)?"?}} -frontend{{.*}}-emit-module-path [[MOD:.*\.swiftmodule]]
+// CHECK: bin{{/|\\\\}}swift{{(c|c-legacy-driver|-frontend)?(\.exe)?"?}} -frontend{{.*}}-emit-module-path [[MOD:.*\.swiftmodule"?]] -emit-module-doc-path
 // CHECK: bin{{/|\\\\}}swift{{(c|c-legacy-driver|-frontend)?(\.exe)?"?}} {{.*}}-emit-module [[MOD]]
 // CHECK-SAME:                                 -o [[MERGED:.*\.swiftmodule]]
 // CHECK: bin{{/|\\\\}}swift{{(c|c-legacy-driver|-frontend)?(\.exe)?"?}} -modulewrap [[MERGED]]{{"?}} -target x86_64-unknown-linux-gnu -o [[OBJ:.*\.o]]


### PR DESCRIPTION
Not having suport for this option causes confusing and non-obvious failures in the LLDB testsuite, and some people build LLDB without also compiling the driver.

rdar://168107340
