### PR TITLE
Prevent invalid attributes from being added to DeclAttributeList

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -3779,9 +3779,13 @@ public:
   };
 
   /// Add a constructed DeclAttribute to this list.
-  void add(DeclAttribute *Attr) {
-    Attr->Next = DeclAttrs;
-    DeclAttrs = Attr;
+  void add(DeclAttribute *Attr, const Decl *D = nullptr) {
+    if (D && !Attr->canAppearOnDecl(D)) {
+      Attr->setInvalid();
+    } else {
+      Attr->Next = DeclAttrs;
+      DeclAttrs = Attr;
+    }
   }
 
   /// Add multiple constructed DeclAttributes to this list.

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -3780,12 +3780,11 @@ public:
 
   /// Add a constructed DeclAttribute to this list.
   void add(DeclAttribute *Attr, const Decl *D = nullptr) {
-    if (D && !Attr->canAppearOnDecl(D)) {
-      Attr->setInvalid();
-    } else {
-      Attr->Next = DeclAttrs;
-      DeclAttrs = Attr;
+    if (D) {
+      ASSERT(Attr->canAppearOnDecl(D));
     }
+    Attr->Next = DeclAttrs;
+    DeclAttrs = Attr;
   }
 
   /// Add multiple constructed DeclAttributes to this list.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1066,7 +1066,7 @@ public:
   /// \c getAttrs().add(...) since it also attaches the attribute if necessary.
   void addAttribute(DeclAttribute *attr) {
     attr->attachToDecl(this);
-    getAttrs().add(attr);
+    getAttrs().add(attr, this);
   }
 
   /// Returns the attributes that were directly attached to this declaration

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -512,9 +512,12 @@ void ClangImporter::Implementation::addSynthesizedProtocolAttrs(
     // This is unfortunately not an error because some test use mock protocols.
     // If those tests were updated, we could assert that
     // ctx.getProtocol(kind) != nulltpr which would be nice.
-    if (auto proto = ctx.getProtocol(kind))
-      nominal->addAttribute(
-        new (ctx) SynthesizedProtocolAttr(proto, this, isUnchecked, isSuppressed));
+    if (auto proto = ctx.getProtocol(kind)) {
+      auto synthAttr = new (ctx)
+          SynthesizedProtocolAttr(proto, this, isUnchecked, isSuppressed);
+      if (synthAttr->canAppearOnDecl(nominal))
+        nominal->addAttribute(synthAttr);
+    }
   }
 }
 
@@ -4143,9 +4146,11 @@ namespace {
             // Currently, addressable parameters and opaque values are at odds.
             if (!dc->getDeclaredInterfaceType()->hasReferenceSemantics() &&
                 !importedName.importAsMember() &&
-                !Impl.SwiftContext.SILOpts.EnableSILOpaqueValues)
-              func->addAttribute(new (Impl.SwiftContext)
-                                     AddressableSelfAttr(true));
+                !Impl.SwiftContext.SILOpts.EnableSILOpaqueValues) {
+              auto funcAttr = new (Impl.SwiftContext) AddressableSelfAttr(true);
+              if (funcAttr->canAppearOnDecl(func))
+                func->addAttribute(funcAttr);
+            }
           } else {
             func->setStatic();
             func->setImportAsStaticMember();
@@ -4164,10 +4169,13 @@ namespace {
       Impl.recordImplicitUnwrapForDecl(result,
                                        resultType.isImplicitlyUnwrapped());
 
-      if (dc->getSelfClassDecl())
+      if (dc->getSelfClassDecl()) {
         // FIXME: only if the class itself is not marked final
-        result->addAttribute(new (Impl.SwiftContext)
-                                 FinalAttr(/*IsImplicit=*/true));
+        auto resultAttr =
+            new (Impl.SwiftContext) FinalAttr(/*IsImplicit=*/true);
+        if (resultAttr->canAppearOnDecl(result))
+          result->addAttribute(resultAttr);
+      }
 
       finishFuncDecl(decl, result);
 
@@ -8970,8 +8978,11 @@ void ClangImporter::Implementation::importNontrivialAttribute(
     for (auto decl : topLevelDecls) {
       SmallVector<DeclAttribute *, 2> attrs(decl->getAttrs().begin(),
                                             decl->getAttrs().end());
-      for (auto attr : attrs)
-        MappedDecl->addAttribute(cached ? attr->clone(SwiftContext) : attr);
+      for (auto attr : attrs) {
+        auto attrToAdd = cached ? attr->clone(SwiftContext) : attr;
+        if (attrToAdd->canAppearOnDecl(MappedDecl))
+          MappedDecl->addAttribute(attrToAdd);
+      }
     }
     break;
   }
@@ -9424,7 +9435,8 @@ void ClangImporter::Implementation::importAttributes(
     if (auto unavailable = dyn_cast<clang::UnavailableAttr>(*AI)) {
       auto Message = unavailable->getMessage();
       auto attr = AvailableAttr::createUniversallyUnavailable(C, Message);
-      MappedDecl->addAttribute(attr);
+      if (attr->canAppearOnDecl(MappedDecl))
+        MappedDecl->addAttribute(attr);
       AnyUnavailable = true;
       continue;
     }
@@ -9437,7 +9449,8 @@ void ClangImporter::Implementation::importAttributes(
     if (auto unavailable_annot = dyn_cast<clang::AnnotateAttr>(*AI))
       if (unavailable_annot->getAnnotation() == "swift1_unavailable") {
         auto attr = AvailableAttr::createUnavailableInSwift(C, "", "");
-        MappedDecl->addAttribute(attr);
+        if (attr->canAppearOnDecl(MappedDecl))
+          MappedDecl->addAttribute(attr);
         AnyUnavailable = true;
         continue;
       }
@@ -9450,7 +9463,8 @@ void ClangImporter::Implementation::importAttributes(
     if (auto deprecated = dyn_cast<clang::DeprecatedAttr>(*AI)) {
       auto Message = deprecated->getMessage();
       auto attr = AvailableAttr::createUniversallyDeprecated(C, Message, "");
-      MappedDecl->addAttribute(attr);
+      if (attr->canAppearOnDecl(MappedDecl))
+        MappedDecl->addAttribute(attr);
       continue;
     }
 
@@ -9473,7 +9487,8 @@ void ClangImporter::Implementation::importAttributes(
 
         auto attr = AvailableAttr::createUnavailableInSwift(
             C, avail->getMessage(), swiftReplacement);
-        MappedDecl->addAttribute(attr);
+        if (attr->canAppearOnDecl(MappedDecl))
+          MappedDecl->addAttribute(attr);
         AnyUnavailable = true;
         continue;
       }
@@ -9555,7 +9570,8 @@ void ClangImporter::Implementation::importAttributes(
           SourceRange(), obsoleted, SourceRange(),
           /*Implicit=*/false, EnableClangSPI && IsSPI);
 
-      MappedDecl->addAttribute(AvAttr);
+      if (AvAttr->canAppearOnDecl(MappedDecl))
+        MappedDecl->addAttribute(AvAttr);
     }
 
     // __attribute__((availability(domain:)))
@@ -9582,7 +9598,8 @@ void ClangImporter::Implementation::importAttributes(
             /*Deprecated=*/{}, SourceRange(), /*Obsoleted=*/{}, SourceRange(),
             /*Implicit=*/false, /*IsSPI=*/false);
 
-        MappedDecl->addAttribute(avAttr);
+        if (avAttr->canAppearOnDecl(MappedDecl))
+          MappedDecl->addAttribute(avAttr);
       }
     }
 
@@ -9594,10 +9611,12 @@ void ClangImporter::Implementation::importAttributes(
     if (method->isDirectMethod() && !AnyUnavailable) {
       assert(isa<AbstractFunctionDecl>(MappedDecl) &&
              "objc_direct declarations are expected to be an AbstractFunctionDecl");
-      MappedDecl->addAttribute(new (C) FinalAttr(/*IsImplicit=*/true));
+      auto attr = new (C) FinalAttr(/*isImplicit=*/true);
+      if (attr->canAppearOnDecl(MappedDecl))
+        MappedDecl->addAttribute(attr);
       if (auto accessorDecl = dyn_cast<AccessorDecl>(MappedDecl)) {
-        auto attr = new (C) FinalAttr(/*isImplicit=*/true);
-        accessorDecl->getStorage()->addAttribute(attr);
+        if (attr->canAppearOnDecl(accessorDecl->getStorage()))
+          accessorDecl->getStorage()->addAttribute(attr);
       }
     }
   }
@@ -9610,7 +9629,8 @@ void ClangImporter::Implementation::importAttributes(
     // Ban NSInvocation.
     if (ID->getName() == "NSInvocation") {
       auto attr = AvailableAttr::createUniversallyUnavailable(C, "");
-      MappedDecl->addAttribute(attr);
+      if (attr->canAppearOnDecl(MappedDecl))
+        MappedDecl->addAttribute(attr);
       return;
     }
 
@@ -9619,7 +9639,8 @@ void ClangImporter::Implementation::importAttributes(
         isa<ClassDecl>(MappedDecl)) {
       if (!MappedDecl->getAttrs().hasAttribute<ObjCMembersAttr>()) {
         auto attr = new (C) ObjCMembersAttr(/*IsImplicit=*/true);
-        MappedDecl->addAttribute(attr);
+        if (attr->canAppearOnDecl(MappedDecl))
+          MappedDecl->addAttribute(attr);
       }
     }
 
@@ -9627,7 +9648,8 @@ void ClangImporter::Implementation::importAttributes(
     if (ID->getName() == "XCTestCase") {
       if (!MappedDecl->getAttrs().hasAttribute<ObjCMembersAttr>()) {
         auto attr = new (C) ObjCMembersAttr(/*IsImplicit=*/true);
-        MappedDecl->addAttribute(attr);
+        if (attr->canAppearOnDecl(MappedDecl))
+          MappedDecl->addAttribute(attr);
       }
     }
   }
@@ -9644,7 +9666,8 @@ void ClangImporter::Implementation::importAttributes(
         if (isCFTypeDecl(t->getDecl())) {
           auto attr = AvailableAttr::createUniversallyUnavailable(
               C, "Core Foundation objects are automatically memory managed");
-          MappedDecl->addAttribute(attr);
+          if (attr->canAppearOnDecl(MappedDecl))
+            MappedDecl->addAttribute(attr);
           return;
         }
       }
@@ -9657,7 +9680,9 @@ void ClangImporter::Implementation::importAttributes(
     if (isPrintLikeMethod(MD->getName(), MD->getDeclContext())) {
       // Use a non-implicit attribute so it shows up in the generated
       // interface.
-      MD->addAttribute(new (C) WarnUnqualifiedAccessAttr(/*implicit*/ false));
+      auto attr = new (C) WarnUnqualifiedAccessAttr(/*implicit*/ false);
+      if (attr->canAppearOnDecl(MD))
+        MD->addAttribute(attr);
     }
   }
 
@@ -9675,17 +9700,24 @@ void ClangImporter::Implementation::importAttributes(
       // async function, eagerly load the result type and check.
       if (MD->hasAsync())
         hasVoidReturnType = MD->getResultInterfaceType()->isVoid();
-      if (!hasVoidReturnType)
-        MD->addAttribute(new (C) DiscardableResultAttr(/*implicit*/ true));
+      if (!hasVoidReturnType) {
+        auto attr = new (C) DiscardableResultAttr(/*implicit*/ true);
+        if (attr->canAppearOnDecl(MD))
+          MD->addAttribute(attr);
+      }
     }
   }
   // Map __attribute__((const)).
   if (ClangDecl->hasAttr<clang::ConstAttr>()) {
-    MappedDecl->addAttribute(new (C) EffectsAttr(EffectsKind::ReadNone));
+    auto attr = new (C) EffectsAttr(EffectsKind::ReadNone);
+    if (attr->canAppearOnDecl(MappedDecl))
+      MappedDecl->addAttribute(attr);
   }
   // Map __attribute__((pure)).
   if (ClangDecl->hasAttr<clang::PureAttr>()) {
-    MappedDecl->addAttribute(new (C) EffectsAttr(EffectsKind::ReadOnly));
+    auto attr = new (C) EffectsAttr(EffectsKind::ReadOnly);
+    if (attr->canAppearOnDecl(MappedDecl))
+      MappedDecl->addAttribute(attr);
   }
 }
 

--- a/lib/Sema/TypeCheckAccessNotes.cpp
+++ b/lib/Sema/TypeCheckAccessNotes.cpp
@@ -83,7 +83,8 @@ static void addOrRemoveAttr(ValueDecl *VD, const AccessNotesFile &notes,
   if (*expected) {
     attr = willCreate();
     attr->setAddedByAccessNote();
-    VD->addAttribute(attr);
+    if (attr->canAppearOnDecl(VD))
+      VD->addAttribute(attr);
 
     // Arrange for us to emit a remark about this attribute after type checking
     // has ensured it's valid.

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5972,29 +5972,35 @@ static void addAttributesForActorIsolation(ValueDecl *value,
                                            ActorIsolation isolation) {
   ASTContext &ctx = value->getASTContext();
   switch (isolation) {
-  case ActorIsolation::CallerIsolationInheriting:
-    value->addAttribute(new (ctx) NonisolatedAttr(
+  case ActorIsolation::CallerIsolationInheriting: {
+    auto attr = new (ctx) NonisolatedAttr(
         /*atLoc=*/{}, /*range=*/{}, NonIsolatedModifier::NonSending,
-        /*implicit=*/true));
-    break;
+        /*implicit=*/true);
+    if (attr->canAppearOnDecl(value))
+      value->addAttribute(attr);
+  } break;
   case ActorIsolation::Nonisolated:
   case ActorIsolation::NonisolatedUnsafe: {
-    value->addAttribute(NonisolatedAttr::createImplicit(
+    auto attr = NonisolatedAttr::createImplicit(
         ctx, isolation == ActorIsolation::NonisolatedUnsafe
                  ? NonIsolatedModifier::Unsafe
-                 : NonIsolatedModifier::None));
+                 : NonIsolatedModifier::None);
+    if (attr->canAppearOnDecl(value))
+      value->addAttribute(attr);
     break;
   }
   case ActorIsolation::GlobalActor: {
     auto typeExpr = TypeExpr::createImplicit(isolation.getGlobalActor(), ctx);
     auto attr = CustomAttr::create(ctx, SourceLoc(), typeExpr, /*owner*/ value,
                                    /*implicit=*/true);
-    value->addAttribute(attr);
+    if (attr->canAppearOnDecl(value))
+      value->addAttribute(attr);
 
     if (isolation.preconcurrency() &&
         !value->getAttrs().hasAttribute<PreconcurrencyAttr>()) {
       auto preconcurrency = new (ctx) PreconcurrencyAttr(/*isImplicit*/ true);
-      value->addAttribute(preconcurrency);
+      if (preconcurrency->canAppearOnDecl(value))
+        value->addAttribute(preconcurrency);
     }
     break;
   }
@@ -6313,7 +6319,8 @@ static InferredActorIsolation computeActorIsolation(Evaluator &evaluator,
       !value->getAttrs().hasAttribute<PreconcurrencyAttr>()) {
     auto preconcurrency =
         new (ctx) PreconcurrencyAttr(/*isImplicit*/true);
-    value->addAttribute(preconcurrency);
+    if (preconcurrency->canAppearOnDecl(value))
+      value->addAttribute(preconcurrency);
   }
 
   // Check if we inferred CallerIsolationInheriting from our isolation attr, but
@@ -6328,8 +6335,10 @@ static InferredActorIsolation computeActorIsolation(Evaluator &evaluator,
     // Replace `nonisolated` with `nonisolated(nonsending)`
     if (!nonisolated || !nonisolated->isNonSending()) {
       value->getAttrs().removeAttribute(nonisolated);
-      value->addAttribute(NonisolatedAttr::createImplicit(
-          ctx, NonIsolatedModifier::NonSending));
+      auto attr =
+          NonisolatedAttr::createImplicit(ctx, NonIsolatedModifier::NonSending);
+      if (attr->canAppearOnDecl(value))
+        value->addAttribute(attr);
     }
   }
 

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -612,11 +612,17 @@ void ModuleFile::getImportDecls(SmallVectorImpl<Decl *> &Results) {
       auto *ID = ImportDecl::create(Ctx, FileContext, SourceLoc(), Kind,
                                     SourceLoc(), importPath.get());
       ID->setModule(M);
-      if (Dep.isExported())
-        ID->addAttribute(new (Ctx) ExportedAttr(/*IsImplicit=*/false));
-      if (Dep.isImplementationOnly())
-        ID->addAttribute(new (Ctx)
-                             ImplementationOnlyAttr(/*IsImplicit=*/false));
+      if (Dep.isExported()) {
+        auto expAttr = new (Ctx) ExportedAttr(/*IsImplicit=*/false);
+        if (expAttr->canAppearOnDecl(ID))
+          ID->addAttribute(expAttr);
+      }
+      if (Dep.isImplementationOnly()) {
+        auto implOnlyAttr =
+            new (Ctx) ImplementationOnlyAttr(/*IsImplicit=*/false);
+        if (implOnlyAttr->canAppearOnDecl(ID))
+          ID->addAttribute(implOnlyAttr);
+      }
 
       ImportDecls.push_back(ID);
     }


### PR DESCRIPTION
Modified DeclAttributeList::add() to validate whether the attribute can appear on the given declaration before adding it to the list.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
