### PR TITLE
ASTMangler: Fix incorrect mangling of retroactive conformances to marker protocols

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2112,6 +2112,7 @@ static bool isRetroactiveConformance(const RootProtocolConformance *root) {
 
 template<typename Fn>
 static bool forEachConditionalConformance(const ProtocolConformance *conformance,
+                                          bool allowMarkerProtocols,
                                           Fn fn) {
   auto *rootConformance = conformance->getRootConformance();
 
@@ -2139,6 +2140,10 @@ static bool forEachConditionalConformance(const ProtocolConformance *conformance
       continue;
 
     ProtocolDecl *proto = req.getProtocolDecl();
+
+    if (!allowMarkerProtocols && proto->isMarkerProtocol())
+      continue;
+
     auto conformance = subMap.lookupConformance(
         req.getFirstType()->getCanonicalType(), proto);
     if (fn(req.getFirstType().subst(subMap), conformance))
@@ -2175,7 +2180,8 @@ static bool containsRetroactiveConformance(
 
   // If the conformance is conditional and any of the substitutions used to
   // satisfy the conditions are retroactive, it's retroactive.
-  return forEachConditionalConformance(conformance,
+  return forEachConditionalConformance(
+    conformance, /*allowMarkerProtocols=*/false,
     [&](Type substType, ProtocolConformanceRef substConf) -> bool {
       return containsRetroactiveConformance(substConf);
     });
@@ -4587,10 +4593,10 @@ void ASTMangler::appendAnyProtocolConformance(
                                            CanType conformingType,
                                            ProtocolConformanceRef conformance) {
   // If we have a conformance to a marker protocol but we aren't allowed to
-  // emit marker protocols, skip it.
-  if (!AllowMarkerProtocols &&
-      conformance.getProtocol()->isMarkerProtocol())
-    return;
+  // emit marker protocols, it's too late. The caller should have handled this,
+  // because otherwise they don't know if they should emit a list separator or
+  // not.
+  ASSERT(AllowMarkerProtocols || !conformance.getProtocol()->isMarkerProtocol());
 
   // While all invertible protocols are marker protocols, do not mangle them
   // as a dependent conformance. See `conformanceRequirementIndex` which skips
@@ -4651,7 +4657,7 @@ void ASTMangler::appendConcreteProtocolConformance(
 
   // Conditional conformance requirements.
   bool firstRequirement = true;
-  forEachConditionalConformance(conformance,
+  forEachConditionalConformance(conformance, AllowMarkerProtocols,
     [&](Type substType, ProtocolConformanceRef substConf) -> bool {
       if (substType->hasArchetype())
         substType = substType->mapTypeOutOfEnvironment();

--- a/test/IRGen/Inputs/retroactive_conformance_other.swift
+++ b/test/IRGen/Inputs/retroactive_conformance_other.swift
@@ -4,3 +4,5 @@ public enum E<First, Second> {
   case left(First)
   case right(Second)
 }
+
+public struct X {}

--- a/test/IRGen/retroactive_conformance.swift
+++ b/test/IRGen/retroactive_conformance.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module-path %t/retroactive_conformance_other.swiftmodule %S/Inputs/retroactive_conformance_other.swift
-// RUN: %target-swift-frontend -emit-ir %s -I %t
+// RUN: %target-swift-frontend -emit-ir %s -I %t | %FileCheck %s
 
 import retroactive_conformance_other
 
@@ -10,12 +10,33 @@ public enum MyError : Error {
   case a
 }
 
-extension E: P where First: P {
-}
+extension E: @retroactive P where First: P {}
 
 public enum Bar<T: P> {
   case x(Foo<E<T, MyError>>)
   case y
 }
 
+// rdar://168023786
+public struct G<B: Equatable> {}
 
+extension X: @retroactive Equatable {
+  public static func ==(_: Self, _: Self) -> Bool { return false }
+}
+
+public func blackHole<T>(_: T) {}
+
+// CHECK-LABEL: @"symbolic _____y_____SgACSQHPABSQ23retroactive_conformanceyHC_HCg_Gm 23retroactive_conformance1GV 0a1_B6_other1XV" = {{.*}}"SgACSQHPABSQ23retroactive_conformanceyHC_HCg_Gm"
+blackHole(G<Optional<X>>.self)
+
+
+// Note that the next symbol name is still wrong, because it mentions
+// 'Copyable' and 'Escapable', even though the type signature of
+// brokenMangling() does not involve any inverse generics.
+//
+// Swift 6.3 produced the following mangling:
+//
+// s23retroactive_conformance14brokenManglingyyAA1GVy0a1_B6_other1XVSgAHSQHPAGSQAAyHC_HCg_GF
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s23retroactive_conformance14brokenManglingyyAA1GVy0a1_B6_other1XVSgAHSQHPAGs8CopyableHPyHC_AGSQAAyHCAGs9EscapableHPyHCHCg_GF"()
+public func brokenMangling(_: G<Optional<X>>) {}

--- a/test/Interpreter/Inputs/demangle_retroactive_equatable_other.swift
+++ b/test/Interpreter/Inputs/demangle_retroactive_equatable_other.swift
@@ -1,0 +1,1 @@
+public struct X {}

--- a/test/Interpreter/demangle_retroactive_equatable.swift
+++ b/test/Interpreter/demangle_retroactive_equatable.swift
@@ -1,0 +1,28 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-build-swift-dylib(%t/%target-library-name(demangle_retroactive_equatable_other)) -enable-library-evolution %S/Inputs/demangle_retroactive_equatable_other.swift -emit-module -emit-module-path %t/demangle_retroactive_equatable_other.swiftmodule -module-name demangle_retroactive_equatable_other
+// RUN: %target-codesign %t/%target-library-name(demangle_retroactive_equatable_other)
+
+// RUN: %target-build-swift %s -ldemangle_retroactive_equatable_other -I %t -L %t -o %t/main %target-rpath(%t)
+// RUN: %target-codesign %t/main
+
+// RUN: %target-run %t/main %t/%target-library-name(demangle_retroactive_equatable_other)
+
+import demangle_retroactive_equatable_other
+
+// rdar://168023786
+
+// When the stdlib's Equatable protocol was changed to suppress ~Copyable
+// and ~Escapable on Self, it exposed a mangler bug, and as a result we
+// would incorrectly mangle the type 'G<Optional<X>>' below, and crash at
+// runtime when attempting to realize its metadata. Make sure that works
+// properly.
+
+public struct G<T: Equatable> {}
+
+extension X: @retroactive Equatable {
+  public static func ==(_: Self, _: Self) -> Bool { return false }
+}
+
+// CHECK: main.G<Swift.Optional<main.X>>
+print(G<Optional<X>>.self)


### PR DESCRIPTION
We turn off the AllowMarkerProtocols mangler flag when mangling the types that are passed into the runtime demangler.

The logic in appendAnyProtocolConformance() was wrong when this flag was set; we would early exit from this function, but then appendRetroactiveConformances() would still call appendListSeparator(). The would result in an invalid mangled string which could not be parsed by the demangler.

In particular, this meant that the recent changes to generalize Equatable to allow non-Copyable and non-Escapable conformers could introduce runtime crashes, because a mangled string for a retroactive conformance to Equatable could be incorrect.

The fix is to handle AllowMarkerProtocols further up in forEachConditionalConformance().

Note that this change should not directly change ABI, because AllowMarkerProtocols is on for symbol names.

When AllowMarkerProtocols is on, we still always mangle conformances to Copyable and Escapable in this code path.

This means that even with this change, mangling a symbol name that contains a retroactive conformance to Equatable can output a different string than in Swift 6.3, which means we have an ABI break. That problem requires a separate fix.

- Fixes rdar://problem/168023786.