### PR TITLE
[update-checkout] add a --max-retries flag

### DIFF
--- a/utils/update_checkout/update_checkout/cli_arguments.py
+++ b/utils/update_checkout/update_checkout/cli_arguments.py
@@ -27,6 +27,7 @@ class CliArguments(argparse.Namespace):
     use_submodules: bool
     verbose: bool
     command: Optional[Any]
+    max_retries: int
 
     @staticmethod
     def parse_args() -> "CliArguments":
@@ -128,6 +129,14 @@ repositories.
             help="Check out adjacent repositories to match timestamp of "
             " current swift checkout.",
             action="store_true",
+        )
+        parser.add_argument(
+            "--max-retries",
+            help="Maximum number of times update-checkout will retry if the"
+            " cloning of any repository failed. 0 for no retries, -1 for"
+            " unlimited retries.",
+            type=int,
+            default=0,
         )
         parser.add_argument(
             "-j",

--- a/utils/update_checkout/update_checkout/retry.py
+++ b/utils/update_checkout/update_checkout/retry.py
@@ -1,0 +1,49 @@
+import time
+import functools
+from typing import Callable, TypeVar, Any
+
+T = TypeVar('T')
+
+def exponential_retry(
+    max_retries: int = 3,
+    base_delay: float = 10.0,
+    max_delay: float = 600.0,
+):
+    """
+    Retries with exponential backoff if the method returns a value > 0.
+    
+    Args:
+        max_retries (int): Maximum number of retry attempts. 0 is for no
+                           retries, -1 is for an unlimited amount.
+        base_delay (float): Initial delay in seconds.
+        max_delay (float): Maximum delay between retries in seconds.
+    """
+    def decorator(func: Callable[..., T]) -> Callable[..., T]:
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> T:
+            retries = 0
+            
+            while max_retries == -1 or retries <= max_retries:
+                fail_count = func(*args, **kwargs)
+                
+                if fail_count <= 0:
+                    return fail_count
+                
+                if retries == max_retries:
+                    return fail_count
+                
+                delay = min(base_delay * (4 ** retries), max_delay)
+                
+                print(f"Retry {retries + 1}/{max_retries}: There were {fail_count} failure", end="")
+                if fail_count > 1:
+                    print("s", end="")
+                print(".")
+                print(f"Waiting {delay:.2f}s before retrying...")
+                
+                time.sleep(delay)
+                retries += 1
+            
+            return fail_count
+        
+        return wrapper
+    return decorator


### PR DESCRIPTION
This patch adds exponential retry capabilities to `update-checkout` through the `--max-retries` flag.

This patch will allow CI scripts to retry cloning the repositories automatically in case of temporary network failures.

rdar://168064930