### PR TITLE
OptimizeDeadAlloc: Handle MarkDependenceAddrInst

### DIFF
--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -1956,7 +1956,7 @@ private:
 
   /// Return true if a mark_dependence can be promoted. If so, this initializes
   /// the available values in promotions.
-  bool canPromoteMarkDepBase(MarkDependenceInst *md);
+  bool canPromoteMarkDepBase(MarkDependenceInstruction md);
 
   /// Return true if a load [take] or destroy_addr can be promoted. If so, this
   /// initializes the available values in promotions.
@@ -2032,7 +2032,9 @@ bool OptimizeDeadAlloc::canRemoveDeadAllocation() {
   }
 
   for (auto *md : promotions.markDepBases.instructions()) {
-    if (!canPromoteMarkDepBase(cast<MarkDependenceInst>(md)))
+    MarkDependenceInstruction mdInstruction(md);
+    assert(mdInstruction && "md is a MarkDependenceInst or MarkDependenceAddrInst");
+    if (!canPromoteMarkDepBase(mdInstruction))
       return false;
   }
   if (isTrivial()) {
@@ -2149,16 +2151,16 @@ SILInstruction *OptimizeDeadAlloc::collectUsesForPromotion() {
   return nullptr;
 }
 
-bool OptimizeDeadAlloc::canPromoteMarkDepBase(MarkDependenceInst *md) {
-  SILValue srcAddr = md->getBase();
+bool OptimizeDeadAlloc::canPromoteMarkDepBase(MarkDependenceInstruction md) {
+  SILValue srcAddr = md.getBase();
   SmallVector<AvailableValue, 8> availableValues;
   auto loadInfo =
-      DataflowContext.computeAvailableValues(srcAddr, md, availableValues);
+      DataflowContext.computeAvailableValues(srcAddr, *md, availableValues);
   if (!loadInfo.has_value())
     return false;
 
   unsigned index = promotions.markDepBases.initializeAvailableValues(
-      md, std::move(availableValues));
+      *md, std::move(availableValues));
 
   SILType baseTy = loadInfo->loadType;
   if (auto *abi = dyn_cast<AllocBoxInst>(TheMemory)) {

--- a/test/SILOptimizer/predictable_memopt_dependence.sil
+++ b/test/SILOptimizer/predictable_memopt_dependence.sil
@@ -73,6 +73,33 @@ bb0(%0 : @owned $SomeClass, %1 : $UnsafeMutablePointer<Int>):
   return %ld : $SomeClass
 }
 
+// Test mark_dependence_addr base: stack promotion
+//
+// Eliminate the allocation, store, and load.
+// Update the mark_dependence_addr base to the available value.
+//
+// CHECK-LABEL: sil [ossa] @markdep_addr_base_promote_stack : $@convention(thin) (@owned SomeClass, UnsafeMutablePointer<Int>) -> @owned SomeClass {
+// CHECK: [[ST:%.*]] = copy_value %0 : $SomeClass
+// CHECK: mark_dependence_addr %1 : $UnsafeMutablePointer<Int> on %0 : $SomeClass
+// CHECK: struct_extract %1 : $UnsafeMutablePointer<Int>, #UnsafeMutablePointer._rawValue
+// CHECK: return [[ST]] : $SomeClass
+// CHECK-LABEL: } // end sil function 'markdep_addr_base_promote_stack'
+sil [ossa] @markdep_addr_base_promote_stack : $@convention(thin) (@owned SomeClass, UnsafeMutablePointer<Int>) -> @owned SomeClass {
+bb0(%0 : @owned $SomeClass, %1 : $UnsafeMutablePointer<Int>):
+  %2 = alloc_stack $SomeClass
+  store %0 to [init] %2 : $*SomeClass
+  mark_dependence_addr %1 : $UnsafeMutablePointer<Int> on %2 : $*SomeClass
+  %ld = load [copy] %2 : $*SomeClass
+  %rawp = struct_extract %1 : $UnsafeMutablePointer<Int>, #UnsafeMutablePointer._rawValue
+  %addr = pointer_to_address %rawp : $Builtin.RawPointer to [strict] $*Int
+  %acc = begin_access [read] [unsafe] %addr : $*Int
+  %ldp = load [trivial] %acc : $*Int
+  end_access %acc : $*Int
+  destroy_addr %2 : $*SomeClass
+  dealloc_stack %2 : $*SomeClass
+  return %ld : $SomeClass
+}
+
 // Test mark_dependence base: stack promotion on trivial allocation
 //
 // CHECK-LABEL: sil [ossa] @markdep_trivial_base_promote_stack : $@convention(thin) (Int, UnsafeMutablePointer<Int>) -> Int {
@@ -214,6 +241,34 @@ bb0(%0 : @owned $SomeClass, %1 : $UnsafeMutablePointer<Int>):
   store %0 to [init] %2 : $*SomeClass
   %md = mark_dependence %1 : $UnsafeMutablePointer<Int> on %2 : $*SomeClass
   %rawp = struct_extract %md : $UnsafeMutablePointer<Int>, #UnsafeMutablePointer._rawValue
+  %addr = pointer_to_address %rawp : $Builtin.RawPointer to [strict] $*Int
+  %acc = begin_access [read] [unsafe] %addr : $*Int
+  %ldp = load [trivial] %acc : $*Int
+  end_access %acc : $*Int
+  destroy_addr %2 : $*SomeClass
+  dealloc_stack %2: $*SomeClass
+  return %ldp : $Int
+}
+
+// Test mark_dependence_addr base: dead stack
+//
+// Eliminate the allocation and store.
+// Update the mark_dependence_addr to the stored value.
+// The stored value must not be destroyed until after the end_access
+//
+// CHECK-LABEL: sil [ossa] @markdep_addr_base_dead_stack : $@convention(thin) (@owned SomeClass, UnsafeMutablePointer<Int>) -> Int {
+// CHECK-NOT: alloc_stack
+// CHECK-NOT: store
+// CHECK: mark_dependence_addr %1 : $UnsafeMutablePointer<Int> on %0 : $SomeClass
+// CHECK: end_access %{{.*}} : $*Int
+// CHECK: destroy_value %0 : $SomeClass
+// CHECK-LABEL: } // end sil function 'markdep_addr_base_dead_stack'
+sil [ossa] @markdep_addr_base_dead_stack : $@convention(thin) (@owned SomeClass, UnsafeMutablePointer<Int>) -> Int {
+bb0(%0 : @owned $SomeClass, %1 : $UnsafeMutablePointer<Int>):
+  %2 = alloc_stack $SomeClass
+  store %0 to [init] %2 : $*SomeClass
+  mark_dependence_addr %1 : $UnsafeMutablePointer<Int> on %2 : $*SomeClass
+  %rawp = struct_extract %1 : $UnsafeMutablePointer<Int>, #UnsafeMutablePointer._rawValue
   %addr = pointer_to_address %rawp : $Builtin.RawPointer to [strict] $*Int
   %acc = begin_access [read] [unsafe] %addr : $*Int
   %ldp = load [trivial] %acc : $*Int


### PR DESCRIPTION
This case appears to have been overlooked. There was a natural abstraction to use, so the change was simple.

I've added a couple of tests that are adapted from existing dead allocation `mark_dependence` tests.
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
