### PR TITLE
Runtime: Mark demangling test as requiring the runtime_module

### DIFF
--- a/test/Concurrency/Runtime/RuntimeDemangle.swift
+++ b/test/Concurrency/Runtime/RuntimeDemangle.swift
@@ -7,6 +7,7 @@
 // UNSUPPORTED: back_deployment_runtime
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: runtime_module
 
 import Swift
 import Runtime

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -606,6 +606,10 @@ backtracing = lit_config.params.get('backtracing', None)
 if backtracing is not None:
     config.available_features.add('backtracing')
 
+runtime_module = lit_config.params.get('runtime_module', None)
+if runtime_module is not None:
+    config.available_features.add('runtime_module')
+
 backtrace_on_crash = lit_config.params.get('backtrace_on_crash', None)
 if backtrace_on_crash is not None:
     config.environment['SWIFT_BACKTRACE'] = 'enable=on,warnings=suppressed'
@@ -1410,7 +1414,7 @@ if run_vendor == 'apple':
                      "swiftSwiftPrivateLibcExtras", "swiftSwiftPrivate",
                      "swiftDarwin", "swiftSwiftPrivateThreadExtras",
                      "swiftSwiftOnoneSupport", "swift_Concurrency"]
-        if backtracing is not None:
+        if backtracing is not None or runtime_module is not None:
             libraries.append('swiftRuntime')
         for library in libraries:
             swift_execution_tests_extra_flags += ' -Xlinker -l%s'% library


### PR DESCRIPTION
Otherwise the test will try to execute in configurations that do not build the runtime module, and will fail to pass.
