### PR TITLE
Drop unnecessary -fptrauth-calls Clang option

### DIFF
--- a/test/embedded/ptr-auth-irgen-verify-no-stdlib.swift
+++ b/test/embedded/ptr-auth-irgen-verify-no-stdlib.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none -Xcc -fptrauth-calls -module-name Swift | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none -module-name Swift | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_Embedded


### PR DESCRIPTION
It causes issues in some configurations, and has nothing to do with what this test is testing. Fixes rdar://166922694.
