### PR TITLE
[CSBindings] Correctness fixes for literal coverage and Double/CGFloat coalescing

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1382,7 +1382,7 @@ LiteralRequirement::isCoveredBy(const PotentialBinding &binding, bool canBeNil,
       return std::make_pair(false, Type());
 
     if (isCoveredBy(type, CS)) {
-      return std::make_pair(true, requiresUnwrap ? type : binding.BindingType);
+      return std::make_pair(true, requiresUnwrap ? type : Type());
     }
 
     // Can't unwrap optionals if there is `ExpressibleByNilLiteral`

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -959,8 +959,9 @@ void BindingSet::addBinding(PotentialBinding binding) {
           });
 
       if (inferredCGFloat != Bindings.end()) {
-        Bindings.erase(inferredCGFloat);
-        Bindings.insert(inferredCGFloat->withType(type));
+        auto newBinding = inferredCGFloat->withType(type);
+        (void)Bindings.erase(inferredCGFloat);
+        Bindings.insert(newBinding);
         return;
       }
     }
@@ -1048,8 +1049,9 @@ void BindingSet::determineLiteralCoverage() {
       literal.setCoveredBy(binding->getSource());
 
       if (adjustedTy) {
-        Bindings.erase(binding);
-        Bindings.insert(binding->withType(adjustedTy));
+        auto newBinding = binding->withType(adjustedTy);
+        (void)Bindings.erase(binding);
+        Bindings.insert(newBinding);
       }
 
       break;

--- a/test/Constraints/casts_swift6.swift
+++ b/test/Constraints/casts_swift6.swift
@@ -25,9 +25,9 @@ func test_compatibility_coercions(_ arr: [Int], _ optArr: [Int]?, _ dict: [Strin
 
   // Make sure we error on the following in Swift 6 mode.
   _ = id(arr) as [String] // expected-error {{conflicting arguments to generic parameter 'T' ('[Int]' vs. '[String]')}}
-  _ = (arr ?? []) as [String] // expected-error {{conflicting arguments to generic parameter 'T' ('[Int]' vs. '[String]')}}
-  _ = (arr ?? [] ?? []) as [String] // expected-error {{conflicting arguments to generic parameter 'T' ('[Int]' vs. '[String]')}}
-  // expected-error@-1{{conflicting arguments to generic parameter 'T' ('[Int]' vs. '[String]')}}
+  _ = (arr ?? []) as [String] // expected-error {{conflicting arguments to generic parameter 'T' ('[String]' vs. '[Int]')}}
+  _ = (arr ?? [] ?? []) as [String] // expected-error {{conflicting arguments to generic parameter 'T' ('[String]' vs. '[Int]')}}
+  // expected-error@-1{{conflicting arguments to generic parameter 'T' ('[String]' vs. '[Int]')}}
   _ = (optArr ?? []) as [String] // expected-error {{conflicting arguments to generic parameter 'T' ('[Int]' vs. '[String]'}}
 
   _ = (arr ?? []) as [String]? // expected-error {{'[Int]' is not convertible to '[String]?'}}

--- a/test/Constraints/ternary_expr.swift
+++ b/test/Constraints/ternary_expr.swift
@@ -92,3 +92,19 @@ struct ShellTask {
 let delegate = Delegate(shellTasks: [])
 _ = delegate.shellTasks[safe: 0]?.commandLine.compactMap({ $0.asString.hasPrefix("") ? $0 : nil }).count ?? 0
 // expected-error@-1 {{value of type 'String' has no member 'asString'}}
+
+// A test-case for a problem where ternary didn't get a correct binding due to a bug in `determineLiteralCoverage`
+// which results in the solver preferring an overload of `??` that returns an optional.
+do {
+  struct Data {
+    init(value: Int) {}
+  }
+
+  func test(_n: Int?) {
+    let n = _n.flatMap {
+      ($0 != -1) ? $0 : 0
+    } ?? 0
+
+    _ = Data(value: n) // Ok
+  }
+}


### PR DESCRIPTION
- Don't use iterator after calling `erase`

   There are few places where the binding is found, removed
   and then re-inserted with a different type. The new
   binding should be formed before `erase` is called and
   iterator is mutated otherwise using the old iterator
   point could lead to corruption.

   In the added test-case `determineLiteralCoverage`
   would find a "supertypes of" binding and attempt to
   remove + re-insert it but it ends up as "subtypes of"
   after that because calling `.erase` moves the iterator.

- Fix `LiteralRequirement::isCoveredBy` to not produce a type if it wasn't adjusted

    Otherwise `determineLiteralCoverage` is going to re-introduce
    the same binding if the type didn't actually change.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
