### PR TITLE
[ClangImporter] Don't import empty availability attributes

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -2347,6 +2347,8 @@ AvailableAttr::AvailableAttr(
       IntroducedRange(IntroducedRange), Deprecated(Deprecated),
       DeprecatedRange(DeprecatedRange), Obsoleted(Obsoleted),
       ObsoletedRange(ObsoletedRange) {
+  ASSERT(!Introduced.empty() || !Deprecated.empty() || !Obsoleted.empty() ||
+      !Message.empty() || !Rename.empty() || Kind != Kind::Default);
   Bits.AvailableAttr.Kind = static_cast<uint8_t>(Kind);
   Bits.AvailableAttr.IsSPI = IsSPI;
   Bits.AvailableAttr.IsGroupMember = false;

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -2347,8 +2347,6 @@ AvailableAttr::AvailableAttr(
       IntroducedRange(IntroducedRange), Deprecated(Deprecated),
       DeprecatedRange(DeprecatedRange), Obsoleted(Obsoleted),
       ObsoletedRange(ObsoletedRange) {
-  ASSERT(!Introduced.empty() || !Deprecated.empty() || !Obsoleted.empty() ||
-      !Message.empty() || !Rename.empty() || Kind != Kind::Default);
   Bits.AvailableAttr.Kind = static_cast<uint8_t>(Kind);
   Bits.AvailableAttr.IsSPI = IsSPI;
   Bits.AvailableAttr.IsGroupMember = false;

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -9553,6 +9553,10 @@ void ClangImporter::Implementation::importAttributes(
 
       const auto &replacement = avail->getReplacement();
 
+      if (introduced.empty() && deprecated.empty() && obsoleted.empty() &&
+          message.empty() && replacement.empty())
+        continue;
+
       StringRef swiftReplacement = "";
       if (!replacement.empty())
         swiftReplacement = getSwiftNameFromClangName(replacement);

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -9554,7 +9554,8 @@ void ClangImporter::Implementation::importAttributes(
       const auto &replacement = avail->getReplacement();
 
       if (introduced.empty() && deprecated.empty() && obsoleted.empty() &&
-          message.empty() && replacement.empty())
+          message.empty() && replacement.empty() &&
+          AttrKind == AvailableAttr::Kind::Default)
         continue;
 
       StringRef swiftReplacement = "";

--- a/test/Interop/C/swiftify-import/availability.swift
+++ b/test/Interop/C/swiftify-import/availability.swift
@@ -1,0 +1,115 @@
+// REQUIRES: swift_feature_SafeInteropWrappers
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/test.swiftmodule %t/test.swift -I %t -enable-experimental-feature SafeInteropWrappers -strict-memory-safety \
+// RUN:   -verify -verify-additional-file %t%{fs-sep}test.h
+
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/test.swiftmodule %t/test.swift -I %t -enable-experimental-feature SafeInteropWrappers -strict-memory-safety \
+// RUN:   -dump-macro-expansions 2> %t/expansions.out
+
+// RUN: %if OS=macosx %{ \
+// RUN:   %diff %t/macos-expansions.expected %t/expansions.out %} \
+// RUN: %else %{\
+// RUN:   %if OS=ios %{ \
+// RUN:     %diff %t/ios-expansions.expected %t/expansions.out \
+// RUN:   %} %else %{ \
+// RUN:     %diff %t/other-expansions.expected %t/expansions.out \
+// RUN:   %} \
+// RUN: %}
+
+//--- test.h
+#pragma once
+
+#define __counted_by(x) __attribute__((__counted_by__(x)))
+#define __noescape __attribute__((noescape))
+
+void bufferPointer(int *__counted_by(len), int len) __attribute__((availability(ios,introduced=2.0))) __attribute__((availability(macosx,introduced=10.5)));
+void span(int *__counted_by(len) p __noescape, int len) __attribute__((availability(ios,introduced=2.0))) __attribute__((availability(macosx,introduced=10.5)));
+
+//--- macos-expansions.expected
+@__swiftmacro_So13bufferPointer15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@available(macOS 10.5, *) @_alwaysEmitIntoClient @_disfavoredOverload
+public func bufferPointer(_ _bufferPointer_param0: UnsafeMutableBufferPointer<Int32>) {
+    let _bufferPointer_param1 = Int32(exactly: _bufferPointer_param0.count)!
+    return unsafe bufferPointer(_bufferPointer_param0.baseAddress!, _bufferPointer_param1)
+}
+------------------------------
+@__swiftmacro_So4span15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@available(macOS 10.5, *) @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
+public func span(_ p: inout MutableSpan<Int32>) {
+    let len = Int32(exactly: p.count)!
+    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+      return unsafe span(_pPtr.baseAddress!, len)
+    }
+}
+------------------------------
+//--- ios-expansions.expected
+@__swiftmacro_So13bufferPointer15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@available(iOS 2.0, *) @_alwaysEmitIntoClient @_disfavoredOverload
+public func bufferPointer(_ _bufferPointer_param0: UnsafeMutableBufferPointer<Int32>) {
+    let _bufferPointer_param1 = Int32(exactly: _bufferPointer_param0.count)!
+    return unsafe bufferPointer(_bufferPointer_param0.baseAddress!, _bufferPointer_param1)
+}
+------------------------------
+@__swiftmacro_So4span15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@available(iOS 2.0, *) @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
+public func span(_ p: inout MutableSpan<Int32>) {
+    let len = Int32(exactly: p.count)!
+    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+      return unsafe span(_pPtr.baseAddress!, len)
+    }
+}
+------------------------------
+//--- other-expansions.expected
+@__swiftmacro_So13bufferPointer15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload public func bufferPointer(_ _bufferPointer_param0: UnsafeMutableBufferPointer<Int32>) {
+    let _bufferPointer_param1 = Int32(exactly: _bufferPointer_param0.count)!
+    return unsafe bufferPointer(_bufferPointer_param0.baseAddress!, _bufferPointer_param1)
+}
+------------------------------
+@__swiftmacro_So4span15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public func span(_ p: inout MutableSpan<Int32>) {
+    let len = Int32(exactly: p.count)!
+    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+      return unsafe span(_pPtr.baseAddress!, len)
+    }
+}
+------------------------------
+//--- test.swift
+import Test
+
+func callBufferPointer(_ p: UnsafeMutablePointer<CInt>, len: CInt) {
+  unsafe bufferPointer(p, len)
+}
+
+func callBufferPointer(_ p: UnsafeMutableBufferPointer<CInt>) {
+  unsafe bufferPointer(p)
+}
+
+func callSpan(_ p: UnsafeMutablePointer<CInt>, len: CInt) {
+  unsafe span(p, len)
+}
+
+func callSpan(_ p: inout MutableSpan<CInt>) {
+  span(&p)
+}
+
+//--- module.modulemap
+module Test {
+  header "test.h"
+}
+

--- a/test/Interop/C/swiftify-import/availability.swift
+++ b/test/Interop/C/swiftify-import/availability.swift
@@ -6,7 +6,7 @@
 // RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/test.swiftmodule %t/test.swift -I %t -enable-experimental-feature SafeInteropWrappers -strict-memory-safety \
 // RUN:   -verify -verify-additional-file %t%{fs-sep}test.h
 
-// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/test.swiftmodule %t/test.swift -I %t -enable-experimental-feature SafeInteropWrappers -strict-memory-safety \
+// RUN: env SWIFT_BACKTRACE="" %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/test.swiftmodule %t/test.swift -I %t -enable-experimental-feature SafeInteropWrappers -strict-memory-safety \
 // RUN:   -dump-macro-expansions 2> %t/expansions.out
 
 // RUN: %if OS=macosx %{ \


### PR DESCRIPTION
When compilng for tvOS, `availability(ios,introduced=2.0)` seems to imply `availability(tvos)`. This gets imported as `@available(tvOS)`, which is invalid Swift syntax. Normally this attribute has no effect, but when attaching a macro to such a function the macro gets invalid Swift syntax as input.

rdar://168272342