### PR TITLE
[StrictMemorySafety] Add unsafe annotations to OpenBSDImpl.

### DIFF
--- a/stdlib/public/Synchronization/Mutex/OpenBSDImpl.swift
+++ b/stdlib/public/Synchronization/Mutex/OpenBSDImpl.swift
@@ -12,47 +12,70 @@
 
 import Glibc
 
+@usableFromInline
+@_transparent
+func errstr(_ no: Int32) -> String {
+  let a: [CChar] = unsafe Array(unsafeUninitializedCapacity: Int(NL_TEXTMAX)) {
+    unsafe strerror_r(no, $0.baseAddress, $1)
+  }
+  return String(validatingUTF8: a) ?? ""
+}
+
 @available(SwiftStdlib 6.0, *)
 @frozen
 @_staticExclusiveOnly
+@safe
 public struct _MutexHandle: ~Copyable {
   @usableFromInline
+  @safe
   let value: _Cell<pthread_mutex_t?>
 
   @available(SwiftStdlib 6.0, *)
   @_alwaysEmitIntoClient
   @_transparent
   public init() {
-    var mx = pthread_mutex_t(bitPattern: 0)
-    pthread_mutex_init(&mx, nil)
-    value = _Cell(mx)
+    var mx = unsafe pthread_mutex_t(bitPattern: 0)
+    let r = unsafe pthread_mutex_init(&mx, nil)
+    if r != 0 {
+      fatalError("couldn't initialize mutex: \(errstr(errno))")
+    }
+    value = unsafe _Cell(mx)
   }
 
   @available(SwiftStdlib 6.0, *)
   @_alwaysEmitIntoClient
   @_transparent
   internal borrowing func _lock() {
-    pthread_mutex_lock(value._address)
+    let r = unsafe pthread_mutex_lock(value._address)
+    if r != 0 {
+      fatalError("couldn't lock mutex: \(errstr(errno))")
+    }
   }
 
   @available(SwiftStdlib 6.0, *)
   @_alwaysEmitIntoClient
   @_transparent
   internal borrowing func _tryLock() -> Bool {
-    pthread_mutex_trylock(value._address) == 0
+    unsafe pthread_mutex_trylock(value._address) == 0
   }
 
   @available(SwiftStdlib 6.0, *)
   @_alwaysEmitIntoClient
   @_transparent
   internal borrowing func _unlock() {
-    pthread_mutex_unlock(value._address)
+    let r = unsafe pthread_mutex_unlock(value._address)
+    if r != 0 {
+      fatalError("couldn't unlock mutex: \(errstr(errno))")
+    }
   }
 
   @available(SwiftStdlib 6.0, *)
   @_alwaysEmitIntoClient
   @_transparent
   deinit {
-    pthread_mutex_destroy(value._address)
+    let r = unsafe pthread_mutex_destroy(value._address)
+    if r != 0 {
+      fatalError("couldn't destroy mutex: \(errstr(errno))")
+    }
   }
 }

--- a/stdlib/public/Synchronization/Mutex/OpenBSDImpl.swift
+++ b/stdlib/public/Synchronization/Mutex/OpenBSDImpl.swift
@@ -15,10 +15,11 @@ import Glibc
 @usableFromInline
 @_transparent
 func errstr(_ no: Int32) -> String {
-  let a: [CChar] = unsafe Array(unsafeUninitializedCapacity: Int(NL_TEXTMAX)) {
-    unsafe strerror_r(no, $0.baseAddress, $1)
+  unsafe withUnsafeTemporaryAllocation(of: CChar.self, capacity: Int(NL_TEXTMAX)) { buf in
+    unsafe strerror_r(no, buf.baseAddress, buf.count)
+    return String(validatingCString: buf.baseAddress)
+      ?? "An unknown error occurred (\(no))."
   }
-  return String(validatingUTF8: a) ?? ""
 }
 
 @available(SwiftStdlib 6.0, *)

--- a/stdlib/public/Synchronization/Mutex/OpenBSDImpl.swift
+++ b/stdlib/public/Synchronization/Mutex/OpenBSDImpl.swift
@@ -16,8 +16,8 @@ import Glibc
 @_transparent
 func errstr(_ no: Int32) -> String {
   unsafe withUnsafeTemporaryAllocation(of: CChar.self, capacity: Int(NL_TEXTMAX)) { buf in
-    unsafe strerror_r(no, buf.baseAddress, buf.count)
-    return String(validatingCString: buf.baseAddress)
+    unsafe strerror_r(no, buf.baseAddress!, buf.count)
+    return unsafe String(validatingCString: buf.baseAddress!)
       ?? "An unknown error occurred (\(no))."
   }
 }


### PR DESCRIPTION
In #86276 strict memory safety becomes an error, necessitating adding the following annotations and changes:

* in init(): check the return value of `pthread_mutex_init`; since this isn't a failable initializer, `fatalError` if this fails, to avoid silently leaving a zero-valued pointer,

* similarly check return values in `pthread_mutex_lock`, `pthread_mutex_unlock`, and `pthread_mutex_destroy`,

* the message in `fatalError` should use `strerror`, which necessitates `unsafe` markings since despite `strerror` never returning a null pointer.

* marking the `value` as `@safe` since the underlying mutex type is an `OpaquePointer` and is unsafe and all access to value occur through a safe interface,

* thus, marking `_MutexHandle` `@safe`.