### PR TITLE
Use strict class check for _SwiftValue box

### DIFF
--- a/stdlib/public/runtime/SwiftValue.mm
+++ b/stdlib/public/runtime/SwiftValue.mm
@@ -409,7 +409,7 @@ swift::findSwiftValueConformances(const ExistentialTypeMetadata *existentialType
   }
 
   // `other` must also be a _SwiftValue box
-  if (![other isKindOfClass:getSwiftValueClass()]) {
+  if (object_getClass(other) != getSwiftValueClass()) {
     return NO;
   }
 


### PR DESCRIPTION
Replaces isKindOfClass with object_getClass to ensure 'other' is exactly a _SwiftValue box, not a subclass. This works because other has no subclasses/proxies.