### PR TITLE
[SILGen]: fix thunk emission for nothrow to throws(Never) 

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -6356,8 +6356,15 @@ SILValue SILGenFunction::emitApplyWithRethrow(SILLocation loc, SILValue fn,
   SILBasicBlock *normalBB = createBasicBlock();
   B.createTryApply(loc, fn, subs, args, normalBB, errorBB);
 
-  // Emit the rethrow logic.
-  {
+  if (!F.getLoweredFunctionType()->hasErrorResult()) {
+    // Thunks to convert from throws(Never) to non-throwing functions
+    // can end up here. Since the callee cannot actually throw, emit
+    // an unreachable in the error branch.
+    ASSERT(silFnType->getErrorResult().getInterfaceType()->isNever());
+    B.emitBlock(errorBB);
+    B.createUnreachable(loc);
+  } else {
+    // Emit the rethrow logic.
     B.emitBlock(errorBB);
 
     Scope scope(Cleanups, CleanupLocation(loc));


### PR DESCRIPTION
Previously attempting to emit a thunk to wrap a throws(Never) function within a non-throwing function would crash during SILGen because it was unconditionally assumed the outer function had an error result. Change this so that such cases instead create a try_apply and error branch as they did before, but replace the rethrowing logic in the error branch with an unreachable instruction.

[Discussion](https://forums.swift.org/t/possible-fix-for-typed-throws-re-abstraction-thunk-crash/84211)
Resolves: https://github.com/swiftlang/swift/issues/77123