### PR TITLE
[ASTMangler] Restore `stripConcurrency` behavior for `@preconcurrency…

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -1519,7 +1519,12 @@ public:
   ///
   /// \param dropGlobalActor Whether to drop a global actor from a function
   /// type.
-  Type stripConcurrency(bool recurse, bool dropGlobalActor);
+  /// \param dropIsolation Whether to drop the isolation from a function type.
+  /// This should almost always be `false` except to one use in ASTMangler to
+  /// maintain old behavior where setting `dropGlobalActor` to `true` dropped
+  /// isolation for `@preconcurrency` declarations.
+  Type stripConcurrency(bool recurse, bool dropGlobalActor,
+                        bool dropIsolation = false);
 
   /// Whether this is the AnyObject type.
   bool isAnyObject();

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -4232,8 +4232,12 @@ CanType ASTMangler::getDeclTypeForMangling(
   // If this declaration predates concurrency, adjust its type to not
   // contain type features that were not available pre-concurrency. This
   // cannot alter the ABI in any way.
+  //
+  // `dropIsolation` is set here as a workaround because `dropGlobalActor`
+  // used to call `withoutIsolation` unconditionally before.
   if (decl->preconcurrency()) {
-    ty = ty->stripConcurrency(/*recurse=*/true, /*dropGlobalActor=*/true);
+    ty = ty->stripConcurrency(/*recurse=*/true, /*dropGlobalActor=*/true,
+                              /*dropIsolation=*/true);
   }
 
   // Map any local archetypes out of context.

--- a/test/Concurrency/preconcurrency_isolation_erasure.swift
+++ b/test/Concurrency/preconcurrency_isolation_erasure.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-emit-silgen %s -verify -swift-version 5 | %FileCheck %s
+
+// REQUIRES: concurrency
+
+// Check that isolation is erased from `@preconcurrency` declarations.
+
+@preconcurrency public let nestedTypes: () -> @isolated(any) () -> Void = { { } }
+// CHECK-LABEL: sil_global [let] @$s32preconcurrency_isolation_erasure11nestedTypesyycycvp
+
+@preconcurrency func testGlobalActorErasure(_: @MainActor () -> Void) {}
+// CHECK-LABEL: sil hidden [ossa] @$s32preconcurrency_isolation_erasure22testGlobalActorErasureyyyyXEF
+
+@preconcurrency func testIsolatedAnyErasure(_: @isolated(any) () -> Void) {}
+// CHECK-LABEL: sil hidden [ossa] @$s32preconcurrency_isolation_erasure22testIsolatedAnyErasureyyyyXEF
+
+struct Data<T> {
+}
+
+struct S {
+  @preconcurrency
+  init(_: [Data<nonisolated(nonsending) @Sendable () async -> Void>]? = nil) {}
+  // CHECK-LABEL: sil hidden [ossa] @$s32preconcurrency_isolation_erasure1SVyACSayAA4DataVyyyYacGGSgcfC
+}


### PR DESCRIPTION
…` declarations

This is a follow-up to https://github.com/swiftlang/swift/pull/86557

When mangling a `@preconcurrency` declaration, `dropGlobalActor` is set to `true`, and the original condition behind that used to remove isolation from function types regardless of whether the function type was actually global-actor isolated or not. We need to maintain this behavior for mangling or risk breaking ABI for the existing declarations that had isolation like `@isolated(any)`.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
