### PR TITLE
Sema: Fix regression from floating point removal

### DIFF
--- a/lib/Sema/CSOptimizer.cpp
+++ b/lib/Sema/CSOptimizer.cpp
@@ -814,7 +814,7 @@ static std::optional<DisjunctionInfo> preserveFavoringOfUnlabeledUnaryArgument(
         }
       });
 
-  return DisjunctionInfoBuilder(/*score=*/favoredChoices.empty() ? 0 : 1,
+  return DisjunctionInfoBuilder(/*score=*/favoredChoices.empty() ? 0 : 100,
                                 favoredChoices)
       .build();
 }

--- a/test/Constraints/ranking.swift
+++ b/test/Constraints/ranking.swift
@@ -450,3 +450,14 @@ struct HasIntInit {
 func compare_solutions_with_bindings(x: UInt8, y: UInt8) -> HasIntInit {
   return .init(Int(x / numericCast(y)))
 }
+
+// This should pick UnicodeScalar.init(Int) and not one of the other
+// random overloads
+
+// CHECK-LABEL: sil hidden [ossa] @$s7ranking19unicode_scalar_init1sys7UnicodeO6ScalarV_tF : $@convention(thin) (Unicode.Scalar) -> () {
+// CHECK: function_ref @$ss7UnicodeO6ScalarVyADSgSicfC : $@convention(method) (Int, @thin Unicode.Scalar.Type) -> Optional<Unicode.Scalar>
+// CHECK: return
+
+func unicode_scalar_init(s: UnicodeScalar) {
+  if s == UnicodeScalar(0xfe0e) {}
+}


### PR DESCRIPTION
In https://github.com/swiftlang/swift/commit/7bcbe1b3f05d425864aa99f05465162fc0a88e1b, I forgot to scale the value by 100 in one place. This wasn't caught by our test suite, but it regressed the new test case I'm adding. We would select the UnicodeScalar.init() overload taking an UInt8, and complain that the scalar doesn't fit.