### PR TITLE
fix noncopyable-irgen.swift failures

### DIFF
--- a/test/Interop/Cxx/class/noncopyable-irgen.swift
+++ b/test/Interop/Cxx/class/noncopyable-irgen.swift
@@ -174,7 +174,7 @@ func derivedWithDefaultedCopyConstructor() {
     takeCopyable(s)
 }
 
-#elseif TEST7 && (os(macOS) || os(Linux))
+#elseif TEST7 && (canImport(Darwin) || os(Android) || os(Linux))
 func stdUniquePtr() {
     let s = DefaultedCopyConstructorUniquePtr()
     takeCopyable(s)


### PR DESCRIPTION
This test would fail for Android and non-macOS Darwin targets, because -verify was asked to match diagnostics for the entire DARWIN and LINUX OS families, but the call to trigger those diagnostics was guarded behind `#if os(macOS) || os(Linux)`.

rdar://168297106