### PR TITLE
[Diagnostics] Avoid unnecessary fully qualified type names in diagnostic output

### DIFF
--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -991,7 +991,7 @@ static void formatDiagnosticArgument(StringRef Modifier,
       if (type->getASTContext().TypeCheckerOpts.PrintFullConvention)
         printOptions.PrintFunctionRepresentationAttrs =
             PrintOptions::FunctionRepresentationMode::Full;
-      needsQualification = true;
+      needsQualification = typeSpellingIsAmbiguous(type, Args, printOptions);
     } else {
       assert(Arg.getKind() == DiagnosticArgumentKind::WitnessType);
       type = Arg.getAsWitnessType().getType();


### PR DESCRIPTION
- **Explanation**:
  
  Avoid printing fully qualified type names in diagnostics when they’re not needed by using existing ambiguity detection for `FullyQualifiedType`.

- **Scope**:
  
  Diagnostic output only. No semantic/compiler behavior changes.

- **Issues**:
  
  Fixes swiftlang/swift#86617.

- **Original PRs**:
  
  N/A.

- **Risk**:
  
  Low. Uses the same ambiguity logic as other diagnostic type arguments.

- **Testing**:
  
  N/A.

- **Reviewers**:
  
  N/A.