### PR TITLE
[cxx-interop] Do not crash when an operator returns an internal type as `auto`

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -10165,7 +10165,7 @@ DeclContext *ClangImporter::Implementation::importDeclContextImpl(
   assert(!dc->isTranslationUnit());
 
   auto decl = dyn_cast<clang::NamedDecl>(dc);
-  if (!decl)
+  if (!decl || !decl->getDeclName().isIdentifier())
     return nullptr;
 
   // Category decls with same name can be merged and using canonical decl always

--- a/test/Interop/Cxx/operators/Inputs/member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/member-inline.h
@@ -590,4 +590,13 @@ struct ClassWithDefaultTemplatedOperatorStar {
   template <typename T = int> T operator*() const { return 42; }
 };
 
+struct HasOperatorReturningAuto {
+  auto operator*() const {
+    struct Inner {
+      int x = 123;
+    };
+    return Inner();
+  }
+};
+
 #endif

--- a/test/Interop/Cxx/operators/member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/member-inline-module-interface.swift
@@ -326,3 +326,8 @@
 // CHECK: struct HasStaticOperatorCallWithUnimportableCxxType {
 // CHECK-NEXT:  init()
 // CHECK-NEXT: }
+
+// CHECK: struct HasOperatorReturningAuto {
+// CHECK-NEXT:  init()
+// CHECK-NEXT: }
+

--- a/test/Interop/Cxx/operators/member-inline-typechecker.swift
+++ b/test/Interop/Cxx/operators/member-inline-typechecker.swift
@@ -104,3 +104,5 @@ let classWithDefaultTemplatedOperatorStar = ClassWithDefaultTemplatedOperatorSta
 let _ = classWithDefaultTemplatedOperatorStar.pointee  // expected-error {{has no member 'pointee'}}
 // ^this could work in theory, but is niche (https://github.com/swiftlang/swift/issues/86478)
 // Same for templated operator++.
+
+let _ = HasOperatorReturningAuto().pointee // expected-error {{value of type 'HasOperatorReturningAuto' has no member 'pointee'}}


### PR DESCRIPTION
If an overloaded operator returns `auto`, and the implementation of it returns an instance of a type declared within the operator, Swift was crashing when trying to import the internal type. Instead of crashing, let's not import those overloads.

rdar://159271202 / resolves https://github.com/swiftlang/swift/issues/83942

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
