### PR TITLE
[Sema]: enable opaque results to be marked sending

### DIFF
--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -225,10 +225,17 @@ OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
     opaqueDecl->setGenericSignature(GenericSignature());
   }
 
+  TypeResolverContext resolverContext = TypeResolverContext::FunctionResult;
+  if (isa<VarDecl>(originatingDecl)) {
+    // Non-opaque result types are resolved against this context, so
+    // replicate that logic here.
+    resolverContext = TypeResolverContext::PatternBindingDecl;
+  }
+
   // Resolving in the context of `opaqueDecl` allows type resolution to create
   // opaque archetypes where needed
   auto interfaceType =
-      TypeResolution::forInterface(opaqueDecl, TypeResolverContext::None,
+      TypeResolution::forInterface(opaqueDecl, resolverContext,
                                    /*unboundTyOpener*/ nullptr,
                                    /*placeholderHandler*/ nullptr,
                                    /*packElementOpener*/ nullptr)

--- a/test/Concurrency/sending_subscript.swift
+++ b/test/Concurrency/sending_subscript.swift
@@ -2,7 +2,9 @@
 
 // REQUIRES: concurrency
 
-class NonSendableKlass {}
+protocol P {}
+
+class NonSendableKlass: P {}
 
 // CHECK-DAG: subscript(_: sending NonSendableKlass) -> sending NonSendableKlass { get }
 
@@ -20,3 +22,18 @@ struct S2 {
   }
 }
 
+// CHECK-DAG: subscript(_: sending NonSendableKlass) -> sending some P { get }
+
+// CHECK-DAG: sil hidden [ossa] @$s17sending_subscript2S3VyQrAA16NonSendableKlassCncig : $@convention(method) (@sil_sending @owned NonSendableKlass, S3) -> @sil_sending @out @_opaqueReturnTypeOf("$s17sending_subscript2S3VyQrAA16NonSendableKlassCncip", 0) __ {
+struct S3 {
+  subscript(_: sending NonSendableKlass) -> sending (some P) { NonSendableKlass() }
+}
+
+// CHECK-DAG: subscript(_: sending NonSendableKlass) -> sending (some P, NonSendableKlass) { get }
+
+// CHECK-DAG: sil hidden [ossa] @$s17sending_subscript2S4VyQr_AA16NonSendableKlassCtAEncig : $@convention(method) (@sil_sending @owned NonSendableKlass, S4) -> (@sil_sending @out @_opaqueReturnTypeOf("$s17sending_subscript2S4VyQr_AA16NonSendableKlassCtAEncip", 0) __, @sil_sending @owned NonSendableKlass) {
+struct S4 {
+  subscript(_: sending NonSendableKlass) -> sending (some P, NonSendableKlass) {
+    (NonSendableKlass(), NonSendableKlass())
+  }
+}

--- a/test/Parse/sending.swift
+++ b/test/Parse/sending.swift
@@ -13,7 +13,18 @@ func testArgResult(_ x: sending String) -> sending String {
 }
 
 func testVarDeclDoesntWork() {
-  var x: sending String // expected-error {{'sending' may only be used on parameter}}
+  var x: sending String // expected-error {{'sending' may only be used on parameters and results}}
+  let y: sending String // expected-error {{'sending' may only be used on parameters and results}}
+
+  struct S {
+    var opaqueStored: sending some Equatable = 0 // expected-error {{'sending' may only be used on parameters and results}}
+    let opaqueStoredImmutable: sending some Equatable = 0 // expected-error {{'sending' may only be used on parameters and results}}
+    var opaqueComputed: sending some Equatable { 0 } // expected-error {{'sending' may only be used on parameters and results}}
+    var opaqueWriteback: sending some Equatable { // expected-error {{'sending' may only be used on parameters and results}}
+      get { 0 }
+      set {}
+    }
+  }
 }
 
 func testVarDeclTupleElt() -> (sending String, String) {} // expected-error {{'sending' cannot be applied to tuple elements}}

--- a/test/Sema/diag_erroneous_iuo.swift
+++ b/test/Sema/diag_erroneous_iuo.swift
@@ -323,9 +323,6 @@ func returnsFunc2Identifier() -> (Int) -> ImplicitlyUnwrappedOptional<Int> { // 
 }
 
 func opaqueResult() -> (some Equatable)! { return 1 }
-// expected-swift4-warning@-1:40 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}{{none}}
-// expected-swift5-error@-2:40 {{'!' is not allowed here}}{{none}}
-// expected-note@-3:40 {{use '?' instead}}{{40-41=?}}
 
 let x0 = 1 as ImplicitlyUnwrappedOptional // expected-error {{'ImplicitlyUnwrappedOptional' has been renamed to 'Optional'}}{{15-42=Optional}}
 

--- a/test/Sema/sending.swift
+++ b/test/Sema/sending.swift
@@ -22,3 +22,8 @@ func test_repeated_sending_mixed(_ x: sending consuming sending inout Int) {}
 // Just until we get the results setup.
 func test_sending_result_in_tuple() -> (sending Int, Int) {}
 // expected-error @-1 {{'sending' cannot be applied to tuple elements}}
+
+// https://github.com/swiftlang/swift/issues/74846
+
+func test_good_returns_sending_opaque() -> sending (some Equatable) { 0 }
+func test_good_returns_sending_opaque_in_tuple() -> sending (some Equatable, Int) { (0, 0) }


### PR DESCRIPTION
`sending` results of functions and subscripts are currently supported _except_ if the result type is opaque, which is confusing and inconsistent. It seems to have possibly been an oversight due to differences in how `OpaqueResultTypeRequest` and `ResultTypeRequest` work. Specifically, the type resolver context for `OpaqueResultTypeRequest` was always set to `None`, which meant the logic to validate that `sending` is used in appropriate contexts did not function analogously to how it works when resolving a non-opaque result type request (which uses the `FunctionResult` resolver context value).

To bring parity to these cases, we now set the resolver context to `FunctionResult` when evaluating an opaque result type request, _unless_ the originating decl was a `VarDecl`, which prevents opaquely-typed variables to be allowed to be marked `sending`. One existing test case was removed which enforced that an opaque result type could not also be marked as an IUO, which started failing after this change. It's not clear to me what that test was trying to enforce, as other similar formulations appear to be accepted.

[Discussion](https://forums.swift.org/t/opaque-return-type-cannot-be-sending/84217)
Resolves: https://github.com/swiftlang/swift/issues/74846