### PR TITLE
[cxx-interop] Reenable use-std-span test

### DIFF
--- a/test/Interop/Cxx/stdlib/use-std-span.swift
+++ b/test/Interop/Cxx/stdlib/use-std-span.swift
@@ -1,9 +1,6 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20)
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20 -Xcc -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG)
 
-// TODO: test failed in Windows PR testing: rdar://144384453
-// UNSUPPORTED: OS=windows-msvc
-
 // TODO: test failed in macOS PR testing but passes locally: rdar://163049442
 // UNSUPPORTED: OS_FAMILY=darwin && !CPU=arm64
 


### PR DESCRIPTION
This test was failing due to APINotes not getting applied to MSVC's STL implementation properly. I fixed this in upstream LLVM now so let's reenable this test.

rdar://144384453
