### PR TITLE
[swift] Fix DebugInfo tests to account for CoroSplit changes

### DIFF
--- a/test/DebugInfo/async-args.swift
+++ b/test/DebugInfo/async-args.swift
@@ -10,9 +10,15 @@ func forceSplit() async {
 func withGenericArg<T>(_ msg: T) async {
   // This odd debug info is part of a contract with CoroSplit/CoroFrame to fix
   // this up after coroutine splitting.
-  // CHECK-LABEL: {{^define .*}} @"$s1M14withGenericArgyyxYalF"(ptr swiftasync %0
-  // CHECK-DAG: #dbg_declare(ptr %0, ![[MSG:[0-9]+]], !DIExpression({{.*}}DW_OP_plus_uconst, {{.*}}DW_OP_deref),
-  // CHECK-DAG: #dbg_declare(ptr %0, ![[TAU:[0-9]+]], !DIExpression({{.*}}DW_OP_plus_uconst,
+  // CHECK-LABEL: {{^define .*}} @"$s1M14withGenericArgyyxYalF"(
+  // CHECK-SAME: ptr swiftasync %[[frame_ptr:.*]], ptr {{.*}}, ptr %[[tau:.*]])
+  // CHECK-NEXT: entry:
+  // CHECK-NEXT: %[[frame_ptr_alloca:.*]] = alloca ptr,
+  // CHECK:      #dbg_declare(ptr %[[frame_ptr_alloca]], ![[MSG:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_plus_uconst, 24, DW_OP_deref)
+  // CHECK:      store ptr %[[frame_ptr]], ptr %[[frame_ptr_alloca]]
+  // CHECK:      %[[tau_alloca:.*]] = alloca ptr,
+  // CHECK-NEXT: #dbg_declare(ptr %[[tau_alloca]], ![[TAU:[0-9]+]], !DIExpression(DW_OP_deref)
+  // CHECK-NEXT: store ptr %[[tau]], ptr %[[tau_alloca]]
 
   await forceSplit()
   // CHECK-LABEL: {{^define .*}} @"$s1M14withGenericArgyyxYalFTQ0_"(ptr swiftasync %0)

--- a/test/DebugInfo/move_function_dbginfo_async.swift
+++ b/test/DebugInfo/move_function_dbginfo_async.swift
@@ -43,9 +43,12 @@ public func forceSplit5() async {}
 // Tests //
 ///////////
 
-// CHECK-LABEL: define swifttailcc void @"$s27move_function_dbginfo_async13letSimpleTestyyxnYalF"(ptr swiftasync %0, ptr noalias %1, ptr %T)
+// CHECK-LABEL: define swifttailcc void @"$s27move_function_dbginfo_async13letSimpleTestyyxnYalF"(
+// CHECK-SAME:     ptr swiftasync %[[frame_ptr:.*]], ptr noalias %1, ptr %T)
 // CHECK: entry:
-// CHECK:   #dbg_value(ptr %{{[0-9]+}}, ![[SIMPLE_TEST_METADATA:[0-9]+]], !DIExpression(DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_deref), ![[ADDR_LOC:[0-9]+]]
+// CHECK:   %[[frame_ptr_alloca:.*]] = alloca ptr,
+// CHECK:   store ptr %[[frame_ptr]], ptr %[[frame_ptr_alloca]]
+// CHECK:   #dbg_value(ptr %[[frame_ptr_alloca]], ![[SIMPLE_TEST_METADATA:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_deref), ![[ADDR_LOC:[0-9]+]]
 // CHECK:   musttail call swifttailcc void
 // CHECK-NEXT: ret void
 
@@ -89,8 +92,11 @@ public func letSimpleTest<T>(_ msg: __owned T) async {
     use(consume msg)
 }
 
-// CHECK-LABEL: define swifttailcc void @"$s27move_function_dbginfo_async13varSimpleTestyyxz_xtYalF"(ptr swiftasync %0, ptr %1, ptr noalias %2, ptr %T)
-// CHECK:   #dbg_value(ptr %{{[0-9]+}}, !{{[0-9]+}}, !DIExpression(DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_deref)
+// CHECK-LABEL: define swifttailcc void @"$s27move_function_dbginfo_async13varSimpleTestyyxz_xtYalF"(
+// CHECK-SAME:     ptr swiftasync %[[frame_ptr:.*]], ptr %1, ptr noalias %2, ptr %T)
+// CHECK:   %[[frame_ptr_alloca:.*]] = alloca ptr,
+// CHECK:   store ptr %[[frame_ptr]], ptr %[[frame_ptr_alloca]]
+// CHECK:   #dbg_value(ptr %[[frame_ptr_alloca]], !{{[0-9]+}}, !DIExpression(DW_OP_deref, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_deref)
 // CHECK:   musttail call swifttailcc void @"$s27move_function_dbginfo_async10forceSplityyYaF"(ptr swiftasync %{{[0-9]+}})
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
@@ -440,7 +446,10 @@ public func letArgCCFlowTrueTest<T>(_ msg: __owned T) async {
 // SIL: } // end sil function '$s27move_function_dbginfo_async20varArgCCFlowTrueTestyyxzYaAA1PRzlF'
 
 // CHECK-LABEL: define swifttailcc void @"$s27move_function_dbginfo_async20varArgCCFlowTrueTestyyxzYaAA1PRzlF"(
-// CHECK: #dbg_value(ptr %{{[0-9]+}}, !{{[0-9]+}}, !DIExpression(DW_OP_plus_uconst, 64, DW_OP_deref, DW_OP_deref),
+// CHECK-SAME:     ptr swiftasync %[[frame_ptr:[0-9]+]],
+// CHECK:   %[[frame_ptr_alloca:.*]] = alloca ptr,
+// CHECK:   store ptr %[[frame_ptr]], ptr %[[frame_ptr_alloca]]
+// CHECK: #dbg_value(ptr %[[frame_ptr_alloca]], !{{[0-9]+}}, !DIExpression(DW_OP_deref, DW_OP_plus_uconst, 64, DW_OP_deref, DW_OP_deref),
 // CHECK: musttail call swifttailcc void @"$s27move_function_dbginfo_async11forceSplit1yyYaF"(
 
 // CHECK-LABEL: define internal swifttailcc void @"$s27move_function_dbginfo_async20varArgCCFlowTrueTestyyxzYaAA1PRzlFTQ0_"(


### PR DESCRIPTION
After 9ff29a89020e in llvm-project, the async frame ptr is stored in an alloca in entry funclets.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
