### PR TITLE
[6.3] wasmstdlib.py: add SWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING

### DIFF
--- a/test/AutoDiff/SIL/Parse/sildeclref.sil
+++ b/test/AutoDiff/SIL/Parse/sildeclref.sil
@@ -1,6 +1,8 @@
 // RUN: %target-sil-opt -sil-print-types %s -module-name=sildeclref_parse | %target-sil-opt -sil-print-types -module-name=sildeclref_parse | %FileCheck %s
 // Parse AutoDiff derivative SILDeclRefs via `witness_method` and `class_method` instructions.
 
+// UNSUPPORTED: OS=wasip1
+
 import Swift
 import _Differentiation
 

--- a/test/AutoDiff/SIL/Serialization/differentiable_function_type.swift
+++ b/test/AutoDiff/SIL/Serialization/differentiable_function_type.swift
@@ -11,6 +11,8 @@
 // https://github.com/apple/swift/issues/54526 workaround.
 // REQUIRES: shell
 
+// UNSUPPORTED: OS=wasip1
+
 sil_stage raw
 
 import Swift

--- a/test/AutoDiff/SIL/differentiability_witness_function_inst.sil
+++ b/test/AutoDiff/SIL/differentiability_witness_function_inst.sil
@@ -22,6 +22,8 @@
 // https://github.com/apple/swift/issues/54526 workaround.
 // REQUIRES: shell
 
+// UNSUPPORTED: OS=wasip1
+
 sil_stage raw
 
 import Swift

--- a/test/AutoDiff/SIL/differentiability_witness_function_inst_transpose.sil
+++ b/test/AutoDiff/SIL/differentiability_witness_function_inst_transpose.sil
@@ -20,6 +20,8 @@
 // https://github.com/apple/swift/issues/54526 workaround.
 // REQUIRES: shell
 
+// UNSUPPORTED: OS=wasip1
+
 sil_stage raw
 
 import Swift

--- a/test/AutoDiff/SIL/differentiable_function_inst.sil
+++ b/test/AutoDiff/SIL/differentiable_function_inst.sil
@@ -23,6 +23,7 @@
 
 // Would need to update for arm64e.
 // UNSUPPORTED: CPU=arm64e
+// UNSUPPORTED: OS=wasip1
 
 sil_stage raw
 

--- a/test/AutoDiff/SIL/linear_function_inst.sil
+++ b/test/AutoDiff/SIL/linear_function_inst.sil
@@ -13,6 +13,7 @@
 // RUN: sed -e 's/import Swift$/import Swift; import _Differentiation/' %t/tmp.sil > %t/tmp_fixed.sil
 // RUN: %target-sil-opt -sil-print-types %t/tmp_fixed.sil -module-name main -emit-sorted-sil | %FileCheck %s --check-prefix=CHECK-SIL
 
+// UNSUPPORTED: OS=wasip1
 
 sil_stage raw
 

--- a/test/AutoDiff/SIL/sil_differentiability_witness.sil
+++ b/test/AutoDiff/SIL/sil_differentiability_witness.sil
@@ -21,6 +21,8 @@
 // https://github.com/apple/swift/issues/54526 workaround.
 // REQUIRES: shell
 
+// UNSUPPORTED: OS=wasip1
+
 sil_stage raw
 
 import Builtin

--- a/test/AutoDiff/SILGen/sil_differentiability_witness.swift
+++ b/test/AutoDiff/SILGen/sil_differentiability_witness.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-frontend -emit-silgen %s | %target-sil-opt | %FileCheck %s
 
+// UNSUPPORTED: OS=wasip1
+
 // Test SIL differentiability witness SIL generation.
 
 import _Differentiation

--- a/test/AutoDiff/SILOptimizer/closure_specialization/multi_bb_bte.sil
+++ b/test/AutoDiff/SILOptimizer/closure_specialization/multi_bb_bte.sil
@@ -4,6 +4,8 @@
 
 // REQUIRES: swift_in_compiler
 
+// UNSUPPORTED: OS=wasip1
+
 sil_stage canonical
 
 import Builtin

--- a/test/AutoDiff/SILOptimizer/closure_specialization/multi_bb_no_bte1.sil
+++ b/test/AutoDiff/SILOptimizer/closure_specialization/multi_bb_no_bte1.sil
@@ -4,6 +4,8 @@
 
 // REQUIRES: swift_in_compiler
 
+// UNSUPPORTED: OS=wasip1
+
 sil_stage canonical
 
 import Builtin

--- a/test/AutoDiff/SILOptimizer/closure_specialization/single_bb.sil
+++ b/test/AutoDiff/SILOptimizer/closure_specialization/single_bb.sil
@@ -2,6 +2,8 @@
 
 // REQUIRES: swift_in_compiler
 
+// UNSUPPORTED: OS=wasip1
+
 sil_stage canonical
 
 import Builtin

--- a/test/AutoDiff/SILOptimizer/differentiability_witness_inlining.sil
+++ b/test/AutoDiff/SILOptimizer/differentiability_witness_inlining.sil
@@ -1,5 +1,7 @@
 // RUN: %target-sil-opt -differentiability-witness-devirtualizer %s -enable-sil-verify-all | %FileCheck %s
 
+// UNSUPPORTED: OS=wasip1
+
 sil_stage raw
 
 import _Differentiation

--- a/test/AutoDiff/SILOptimizer/differentiation_function_canonicalization.sil
+++ b/test/AutoDiff/SILOptimizer/differentiation_function_canonicalization.sil
@@ -1,5 +1,7 @@
 // RUN: %target-sil-opt -sil-print-types -differentiation %s | %FileCheck %s
 
+// UNSUPPORTED: OS=wasip1
+
 sil_stage raw
 
 import _Differentiation

--- a/test/AutoDiff/SILOptimizer/linear_function_canonicalization.sil
+++ b/test/AutoDiff/SILOptimizer/linear_function_canonicalization.sil
@@ -1,5 +1,7 @@
 // RUN: %target-sil-opt -sil-print-types -differentiation -enable-experimental-linear-map-transposition %s | %FileCheck %s
 
+// UNSUPPORTED: OS=wasip1
+
 sil_stage raw
 
 import Swift

--- a/test/AutoDiff/SILOptimizer/pullback_generation.sil
+++ b/test/AutoDiff/SILOptimizer/pullback_generation.sil
@@ -1,12 +1,14 @@
-// Pullback generation tests written in SIL for features 
+// Pullback generation tests written in SIL for features
 // that may not be directly supported by the Swift frontend
 
 // RUN: %target-sil-opt -sil-print-types --differentiation -emit-sorted-sil %s 2>&1 | %FileCheck %s
 
+// UNSUPPORTED: OS=wasip1
+
 //===----------------------------------------------------------------------===//
 // Pullback generation - `struct_extract`
 // - Input to pullback has non-owned ownership semantics which requires copying
-// this value to stack before lifetime-ending uses. 
+// this value to stack before lifetime-ending uses.
 //===----------------------------------------------------------------------===//
 
 sil_stage raw
@@ -52,35 +54,35 @@ sil_differentiability_witness hidden [reverse] [parameters 0] [results 0] @$func
 
 sil hidden [ossa] @$function_with_struct_extract_1 : $@convention(thin) (@guaranteed Y) -> @owned X {
 bb0(%0 : @guaranteed $Y):
-  %1 = struct_extract %0 : $Y, #Y.a               
-  %2 = copy_value %1 : $X                         
-  return %2 : $X                                  
+  %1 = struct_extract %0 : $Y, #Y.a
+  %2 = copy_value %1 : $X
+  return %2 : $X
 }
 
 // CHECK-LABEL: sil private [ossa] @$function_with_struct_extract_1TJpSpSr : $@convention(thin) (@guaranteed X) -> @owned Y {
 // CHECK: bb0(%0 : @guaranteed $X):
-// CHECK:   %1 = alloc_stack $Y                             
-// CHECK:   %2 = witness_method $Y, #AdditiveArithmetic.zero!getter : <Self where Self : AdditiveArithmetic> (Self.Type) -> () -> Self : $@convention(witness_method: AdditiveArithmetic) <τ_0_0 where τ_0_0 : AdditiveArithmetic> (@thick τ_0_0.Type) -> @out τ_0_0 
-// CHECK:   %3 = metatype $@thick Y.Type                    
+// CHECK:   %1 = alloc_stack $Y
+// CHECK:   %2 = witness_method $Y, #AdditiveArithmetic.zero!getter : <Self where Self : AdditiveArithmetic> (Self.Type) -> () -> Self : $@convention(witness_method: AdditiveArithmetic) <τ_0_0 where τ_0_0 : AdditiveArithmetic> (@thick τ_0_0.Type) -> @out τ_0_0
+// CHECK:   %3 = metatype $@thick Y.Type
 // CHECK:   %4 = apply %2<Y>(%1, %3) : $@convention(witness_method: AdditiveArithmetic) <τ_0_0 where τ_0_0 : AdditiveArithmetic> (@thick τ_0_0.Type) -> @out τ_0_0
-// CHECK:   %5 = struct_element_addr %1 : $*Y, #Y.a         
+// CHECK:   %5 = struct_element_addr %1 : $*Y, #Y.a
 
-// Since input parameter $0 has non-owned ownership semantics, it 
+// Since input parameter $0 has non-owned ownership semantics, it
 // needs to be copied before a lifetime-ending use.
-// CHECK:   %6 = copy_value %0 : $X                         
+// CHECK:   %6 = copy_value %0 : $X
 
-// CHECK:   %7 = alloc_stack $X                             
-// CHECK:   store %6 to [init] %7 : $*X                     
-// CHECK:   %9 = witness_method $X, #AdditiveArithmetic."+=" : <Self where Self : AdditiveArithmetic> (Self.Type) -> (inout Self, Self) -> () : $@convention(witness_method: AdditiveArithmetic) <τ_0_0 where τ_0_0 : AdditiveArithmetic> (@inout τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> () 
-// CHECK:   %10 = metatype $@thick X.Type                   
+// CHECK:   %7 = alloc_stack $X
+// CHECK:   store %6 to [init] %7 : $*X
+// CHECK:   %9 = witness_method $X, #AdditiveArithmetic."+=" : <Self where Self : AdditiveArithmetic> (Self.Type) -> (inout Self, Self) -> () : $@convention(witness_method: AdditiveArithmetic) <τ_0_0 where τ_0_0 : AdditiveArithmetic> (@inout τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> ()
+// CHECK:   %10 = metatype $@thick X.Type
 // CHECK:   %11 = apply %9<X>(%5, %7, %10) : $@convention(witness_method: AdditiveArithmetic) <τ_0_0 where τ_0_0 : AdditiveArithmetic> (@inout τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> ()
-// CHECK:   destroy_addr %7 : $*X                           
-// CHECK:   dealloc_stack %7 : $*X                          
-// CHECK:   %14 = load [take] %1 : $*Y                      
-// CHECK:   dealloc_stack %1 : $*Y                          
-// CHECK:   %16 = copy_value %14 : $Y                       
-// CHECK:   destroy_value %14 : $Y                          
-// CHECK:   return %16 : $Y                                 
+// CHECK:   destroy_addr %7 : $*X
+// CHECK:   dealloc_stack %7 : $*X
+// CHECK:   %14 = load [take] %1 : $*Y
+// CHECK:   dealloc_stack %1 : $*Y
+// CHECK:   %16 = copy_value %14 : $Y
+// CHECK:   destroy_value %14 : $Y
+// CHECK:   return %16 : $Y
 // CHECK: } // end sil function '$function_with_struct_extract_1TJpSpSr'
 
 //===----------------------------------------------------------------------===//
@@ -101,35 +103,35 @@ bb0(%0 : $(Float, Float)):
 
 // CHECK-LABEL: sil private [ossa] @function_with_tuple_extract_1TJpSpSr : $@convention(thin) (Float) -> (Float, Float) {
 // CHECK: bb0(%0 : $Float):
-// CHECK:   %1 = alloc_stack $(Float, Float)                
-// CHECK:   %2 = tuple_element_addr %1 : $*(Float, Float), 0 
-// CHECK:   %3 = witness_method $Float, #AdditiveArithmetic.zero!getter : <Self where Self : AdditiveArithmetic> (Self.Type) -> () -> Self : $@convention(witness_method: AdditiveArithmetic) <τ_0_0 where τ_0_0 : AdditiveArithmetic> (@thick τ_0_0.Type) -> @out τ_0_0 
-// CHECK:   %4 = metatype $@thick Float.Type                
+// CHECK:   %1 = alloc_stack $(Float, Float)
+// CHECK:   %2 = tuple_element_addr %1 : $*(Float, Float), 0
+// CHECK:   %3 = witness_method $Float, #AdditiveArithmetic.zero!getter : <Self where Self : AdditiveArithmetic> (Self.Type) -> () -> Self : $@convention(witness_method: AdditiveArithmetic) <τ_0_0 where τ_0_0 : AdditiveArithmetic> (@thick τ_0_0.Type) -> @out τ_0_0
+// CHECK:   %4 = metatype $@thick Float.Type
 // CHECK:   %5 = apply %3<Float>(%2, %4) : $@convention(witness_method: AdditiveArithmetic) <τ_0_0 where τ_0_0 : AdditiveArithmetic> (@thick τ_0_0.Type) -> @out τ_0_0
-// CHECK:   %6 = tuple_element_addr %1 : $*(Float, Float), 1 
-// CHECK:   %7 = witness_method $Float, #AdditiveArithmetic.zero!getter : <Self where Self : AdditiveArithmetic> (Self.Type) -> () -> Self : $@convention(witness_method: AdditiveArithmetic) <τ_0_0 where τ_0_0 : AdditiveArithmetic> (@thick τ_0_0.Type) -> @out τ_0_0 
-// CHECK:   %8 = metatype $@thick Float.Type                
+// CHECK:   %6 = tuple_element_addr %1 : $*(Float, Float), 1
+// CHECK:   %7 = witness_method $Float, #AdditiveArithmetic.zero!getter : <Self where Self : AdditiveArithmetic> (Self.Type) -> () -> Self : $@convention(witness_method: AdditiveArithmetic) <τ_0_0 where τ_0_0 : AdditiveArithmetic> (@thick τ_0_0.Type) -> @out τ_0_0
+// CHECK:   %8 = metatype $@thick Float.Type
 // CHECK:   %9 = apply %7<Float>(%6, %8) : $@convention(witness_method: AdditiveArithmetic) <τ_0_0 where τ_0_0 : AdditiveArithmetic> (@thick τ_0_0.Type) -> @out τ_0_0
-// CHECK:   %10 = tuple_element_addr %1 : $*(Float, Float), 0 
-// CHECK:   %11 = alloc_stack $Float                        
-// CHECK:   store %0 to [trivial] %11 : $*Float             
-// CHECK:   %13 = witness_method $Float, #AdditiveArithmetic."+=" : <Self where Self : AdditiveArithmetic> (Self.Type) -> (inout Self, Self) -> () : $@convention(witness_method: AdditiveArithmetic) <τ_0_0 where τ_0_0 : AdditiveArithmetic> (@inout τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> () 
-// CHECK:   %14 = metatype $@thick Float.Type               
+// CHECK:   %10 = tuple_element_addr %1 : $*(Float, Float), 0
+// CHECK:   %11 = alloc_stack $Float
+// CHECK:   store %0 to [trivial] %11 : $*Float
+// CHECK:   %13 = witness_method $Float, #AdditiveArithmetic."+=" : <Self where Self : AdditiveArithmetic> (Self.Type) -> (inout Self, Self) -> () : $@convention(witness_method: AdditiveArithmetic) <τ_0_0 where τ_0_0 : AdditiveArithmetic> (@inout τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> ()
+// CHECK:   %14 = metatype $@thick Float.Type
 // CHECK:   %15 = apply %13<Float>(%10, %11, %14) : $@convention(witness_method: AdditiveArithmetic) <τ_0_0 where τ_0_0 : AdditiveArithmetic> (@inout τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> ()
-// CHECK:   destroy_addr %11 : $*Float                      
-// CHECK:   dealloc_stack %11 : $*Float                     
-// CHECK:   %18 = load [trivial] %1 : $*(Float, Float)      
-// CHECK:   dealloc_stack %1 : $*(Float, Float)             
-// CHECK:   return %18 : $(Float, Float)                    
+// CHECK:   destroy_addr %11 : $*Float
+// CHECK:   dealloc_stack %11 : $*Float
+// CHECK:   %18 = load [trivial] %1 : $*(Float, Float)
+// CHECK:   dealloc_stack %1 : $*(Float, Float)
+// CHECK:   return %18 : $(Float, Float)
 // CHECK: } // end sil function 'function_with_tuple_extract_1TJpSpSr'
 
 //===----------------------------------------------------------------------===//
-// Pullback generation - Inner values of concrete adjoints must be copied 
-// during direct materialization. 
-// - If the input to pullback BB has non-owned ownership semantics we cannot 
+// Pullback generation - Inner values of concrete adjoints must be copied
+// during direct materialization.
+// - If the input to pullback BB has non-owned ownership semantics we cannot
 // perform a lifetime-ending operation on it.
-// - If the input to the pullback BB is an owned, non-trivial value we must 
-// copy it or there will be a double consume when all owned parameters are 
+// - If the input to the pullback BB is an owned, non-trivial value we must
+// copy it or there will be a double consume when all owned parameters are
 // destroyed at the end of the basic block.
 //===----------------------------------------------------------------------===//
 sil_differentiability_witness hidden [reverse] [parameters 0] [results 0] @function_with_tuple_extract_2: $@convention(thin) (@guaranteed (X, X)) -> @owned X {
@@ -144,29 +146,29 @@ bb0(%0 : @guaranteed $(X, X)):
 
 // CHECK-LABEL: sil private [ossa] @function_with_tuple_extract_2TJpSpSr : $@convention(thin) (@guaranteed X) -> @owned (X, X) {
 // CHECK: bb0(%0 : @guaranteed $X):
-// CHECK:   %1 = alloc_stack $(X, X)                        
-// CHECK:   %2 = tuple_element_addr %1 : $*(X, X), 0        
-// CHECK:   %3 = witness_method $X, #AdditiveArithmetic.zero!getter : <Self where Self : AdditiveArithmetic> (Self.Type) -> () -> Self : $@convention(witness_method: AdditiveArithmetic) <τ_0_0 where τ_0_0 : AdditiveArithmetic> (@thick τ_0_0.Type) -> @out τ_0_0 
-// CHECK:   %4 = metatype $@thick X.Type                    
+// CHECK:   %1 = alloc_stack $(X, X)
+// CHECK:   %2 = tuple_element_addr %1 : $*(X, X), 0
+// CHECK:   %3 = witness_method $X, #AdditiveArithmetic.zero!getter : <Self where Self : AdditiveArithmetic> (Self.Type) -> () -> Self : $@convention(witness_method: AdditiveArithmetic) <τ_0_0 where τ_0_0 : AdditiveArithmetic> (@thick τ_0_0.Type) -> @out τ_0_0
+// CHECK:   %4 = metatype $@thick X.Type
 // CHECK:   %5 = apply %3<X>(%2, %4) : $@convention(witness_method: AdditiveArithmetic) <τ_0_0 where τ_0_0 : AdditiveArithmetic> (@thick τ_0_0.Type) -> @out τ_0_0
-// CHECK:   %6 = tuple_element_addr %1 : $*(X, X), 1        
-// CHECK:   %7 = witness_method $X, #AdditiveArithmetic.zero!getter : <Self where Self : AdditiveArithmetic> (Self.Type) -> () -> Self : $@convention(witness_method: AdditiveArithmetic) <τ_0_0 where τ_0_0 : AdditiveArithmetic> (@thick τ_0_0.Type) -> @out τ_0_0 
-// CHECK:   %8 = metatype $@thick X.Type                    
+// CHECK:   %6 = tuple_element_addr %1 : $*(X, X), 1
+// CHECK:   %7 = witness_method $X, #AdditiveArithmetic.zero!getter : <Self where Self : AdditiveArithmetic> (Self.Type) -> () -> Self : $@convention(witness_method: AdditiveArithmetic) <τ_0_0 where τ_0_0 : AdditiveArithmetic> (@thick τ_0_0.Type) -> @out τ_0_0
+// CHECK:   %8 = metatype $@thick X.Type
 // CHECK:   %9 = apply %7<X>(%6, %8) : $@convention(witness_method: AdditiveArithmetic) <τ_0_0 where τ_0_0 : AdditiveArithmetic> (@thick τ_0_0.Type) -> @out τ_0_0
-// CHECK:   %10 = tuple_element_addr %1 : $*(X, X), 0       
-// CHECK:   %11 = copy_value %0 : $X                        
-// CHECK:   %12 = alloc_stack $X                            
-// CHECK:   store %11 to [init] %12 : $*X                   
-// CHECK:   %14 = witness_method $X, #AdditiveArithmetic."+=" : <Self where Self : AdditiveArithmetic> (Self.Type) -> (inout Self, Self) -> () : $@convention(witness_method: AdditiveArithmetic) <τ_0_0 where τ_0_0 : AdditiveArithmetic> (@inout τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> () 
-// CHECK:   %15 = metatype $@thick X.Type                   
+// CHECK:   %10 = tuple_element_addr %1 : $*(X, X), 0
+// CHECK:   %11 = copy_value %0 : $X
+// CHECK:   %12 = alloc_stack $X
+// CHECK:   store %11 to [init] %12 : $*X
+// CHECK:   %14 = witness_method $X, #AdditiveArithmetic."+=" : <Self where Self : AdditiveArithmetic> (Self.Type) -> (inout Self, Self) -> () : $@convention(witness_method: AdditiveArithmetic) <τ_0_0 where τ_0_0 : AdditiveArithmetic> (@inout τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> ()
+// CHECK:   %15 = metatype $@thick X.Type
 // CHECK:   %16 = apply %14<X>(%10, %12, %15) : $@convention(witness_method: AdditiveArithmetic) <τ_0_0 where τ_0_0 : AdditiveArithmetic> (@inout τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> ()
-// CHECK:   destroy_addr %12 : $*X                          
-// CHECK:   dealloc_stack %12 : $*X                         
-// CHECK:   %19 = load [take] %1 : $*(X, X)                 
-// CHECK:   dealloc_stack %1 : $*(X, X)                     
-// CHECK:   %21 = copy_value %19 : $(X, X)                  
-// CHECK:   destroy_value %19 : $(X, X)                     
-// CHECK:   return %21 : $(X, X)                            
+// CHECK:   destroy_addr %12 : $*X
+// CHECK:   dealloc_stack %12 : $*X
+// CHECK:   %19 = load [take] %1 : $*(X, X)
+// CHECK:   dealloc_stack %1 : $*(X, X)
+// CHECK:   %21 = copy_value %19 : $(X, X)
+// CHECK:   destroy_value %19 : $(X, X)
+// CHECK:   return %21 : $(X, X)
 // CHECK: } // end sil function 'function_with_tuple_extract_2TJpSpSr'
 
 //===----------------------------------------------------------------------===//

--- a/test/AutoDiff/Serialization/derivative_attr.swift
+++ b/test/AutoDiff/Serialization/derivative_attr.swift
@@ -5,6 +5,8 @@
 
 // BCANALYZER-NOT: UnknownCode
 
+// UNSUPPORTED: OS=wasip1
+
 import _Differentiation
 
 // Dummy `Differentiable`-conforming type.

--- a/test/AutoDiff/Serialization/differentiable_attr.swift
+++ b/test/AutoDiff/Serialization/differentiable_attr.swift
@@ -3,6 +3,8 @@
 // RUN: llvm-bcanalyzer %t/differentiable_attr.swiftmodule | %FileCheck %s -check-prefix=BCANALYZER
 // RUN: %target-sil-opt -enable-sil-verify-all %t/differentiable_attr.swiftmodule -o - | %FileCheck %s
 
+// UNSUPPORTED: OS=wasip1
+
 // BCANALYZER-NOT: UnknownCode
 
 import _Differentiation

--- a/test/AutoDiff/Serialization/differentiable_function.swift
+++ b/test/AutoDiff/Serialization/differentiable_function.swift
@@ -5,6 +5,8 @@
 
 // BCANALYZER-NOT: UnknownCode
 
+// UNSUPPORTED: OS=wasip1
+
 import _Differentiation
 
 func a(_ f: @differentiable(reverse) (Float) -> Float) {}

--- a/test/AutoDiff/Serialization/transpose_attr.swift
+++ b/test/AutoDiff/Serialization/transpose_attr.swift
@@ -5,6 +5,8 @@
 
 // BCANALYZER-NOT: UnknownCode
 
+// UNSUPPORTED: OS=wasip1
+
 import _Differentiation
 
 // Dummy `Differentiable`-conforming type.

--- a/test/AutoDiff/sil_combine.sil
+++ b/test/AutoDiff/sil_combine.sil
@@ -1,5 +1,7 @@
 // RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all %s -sil-combine | %FileCheck %s
 
+// UNSUPPORTED: OS=wasip1
+
 // SILCombine tests for differentiation-related instructions.
 
 sil_stage canonical
@@ -58,7 +60,7 @@ bb0(%orig : $@callee_guaranteed (Float) -> Float):
 // CHECK:   [[DIFF_FN:%.*]] = differentiable_function [parameters 0] [results 0] [[ORIG_FN]] : $@callee_guaranteed (Float) -> Float
 // CHECK:   [[EXTRACTED_VJP:%.*]] = differentiable_function_extract [vjp] [[DIFF_FN]] : $@differentiable(reverse) @callee_guaranteed (Float) -> Float
 // CHECK:   return [[EXTRACTED_VJP]] : $@callee_guaranteed (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
-// CHECK-LABEL: } // end sil function 'differentiable_function_extract_vjp_undefined' 
+// CHECK-LABEL: } // end sil function 'differentiable_function_extract_vjp_undefined'
 
 // MARK: `convert_function` hoisting
 

--- a/test/AutoDiff/stdlib/tgmath_derivatives.swift.gyb
+++ b/test/AutoDiff/stdlib/tgmath_derivatives.swift.gyb
@@ -11,6 +11,8 @@
   import Android
 #elseif os(Windows)
   import CRT
+#elseif canImport(WASILibc)
+  import WASILibc
 #else
 #error("Unsupported platform")
 #endif

--- a/test/AutoDiff/validation-test/always_emit_into_client/multi_module_struct_no_jvp.swift
+++ b/test/AutoDiff/validation-test/always_emit_into_client/multi_module_struct_no_jvp.swift
@@ -17,6 +17,8 @@
 
 // RUN: %target-build-swift -I%t %s -emit-ir | %FileCheck %s
 
+// UNSUPPORTED: OS=wasip1
+
 import MultiModuleStruct1
 import MultiModuleStruct2NoJVP
 import StdlibUnittest

--- a/test/AutoDiff/validation-test/closure_specialization/single_bb1.swift
+++ b/test/AutoDiff/validation-test/closure_specialization/single_bb1.swift
@@ -23,8 +23,10 @@ import StdlibUnittest
 import Glibc
 #elseif canImport(Android)
 import Android
+#elseif canImport(WASILibc)
+import WASILibc
 #else
-import Foundation
+#error("Unsupported platform")
 #endif
 
 var AutoDiffClosureSpecSingleBBTests = TestSuite("AutoDiffClosureSpecSingleBB")

--- a/test/AutoDiff/validation-test/closure_specialization/single_bb1.swift
+++ b/test/AutoDiff/validation-test/closure_specialization/single_bb1.swift
@@ -25,6 +25,8 @@ import Glibc
 import Android
 #elseif canImport(WASILibc)
 import WASILibc
+#elseif canImport(Foundation)
+import Foundation
 #else
 #error("Unsupported platform")
 #endif

--- a/test/AutoDiff/validation-test/custom_derivatives.swift
+++ b/test/AutoDiff/validation-test/custom_derivatives.swift
@@ -10,6 +10,8 @@ import StdlibUnittest
   import Android
 #elseif os(Windows)
   import CRT
+#elseif canImport(WASILibc)
+  import WASILibc
 #else
 #error("Unsupported platform")
 #endif

--- a/test/AutoDiff/validation-test/reflection.swift
+++ b/test/AutoDiff/validation-test/reflection.swift
@@ -1,5 +1,5 @@
 // REQUIRES: no_asan
-// UNSUPPORTED: OS=linux-android, OS=linux-androideabi
+// UNSUPPORTED: OS=linux-android, OS=linux-androideabi, OS=wasip1
 // RUN: %empty-directory(%t)
 import _Differentiation
 

--- a/test/AutoDiff/validation-test/separate_tangent_type.swift
+++ b/test/AutoDiff/validation-test/separate_tangent_type.swift
@@ -10,6 +10,8 @@ import StdlibUnittest
   import Android
 #elseif os(Windows)
   import CRT
+#elseif canImport(WASILibc)
+  import WASILibc
 #else
 #error("Unsupported platform")
 #endif

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -416,7 +416,10 @@ else:
 # Allow using using same condition in WASI test suites.
 kIsWASI = run_os.startswith('wasi')
 if kIsWASI:
-  run_os = f"{run_os}{run_vers}"
+    run_os = f"{run_os}{run_vers}"
+    if run_os == 'wasip1-threads':
+        run_os = 'wasip1'
+        run_environment = 'threads'
 
 # Parse the host triple
 (host_cpu, host_vendor, host_os, host_vers) = re.match('([^-]+)-([^-]+)-([^0-9-]+)(.*)', config.host_triple).groups()

--- a/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
@@ -175,6 +175,7 @@ class WasmStdlib(cmake_product.CMakeProduct):
         self.cmake_options.define('SWIFT_ENABLE_SYNCHRONIZATION:BOOL', 'TRUE')
         self.cmake_options.define('SWIFT_ENABLE_VOLATILE:BOOL', 'TRUE')
         self.cmake_options.define('SWIFT_ENABLE_EXPERIMENTAL_OBSERVATION:BOOL', 'TRUE')
+        self.cmake_options.define('SWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING', 'TRUE')
 
         self.cmake_options.define('SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB:BOOL', 'TRUE')
         self.cmake_options.define(

--- a/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
@@ -193,7 +193,7 @@ class WasmStdlib(cmake_product.CMakeProduct):
         self.cmake_options.define('SWIFT_INCLUDE_TESTS:BOOL', 'TRUE')
         self.cmake_options.define('SWIFT_ENABLE_SOURCEKIT_TESTS:BOOL', 'FALSE')
         lit_test_paths = [
-            'IRGen', 'stdlib', 'Concurrency/Runtime', 'embedded',
+            'IRGen', 'stdlib', 'Concurrency/Runtime', 'embedded', 'AutoDiff',
             # TODO(katei): Enable all interpreter tests
             'Interpreter/enum.swift',
         ]


### PR DESCRIPTION
Cherry-pick of #86552 and https://github.com/swiftlang/swift/pull/86657, merged as 7847de0095d013f6dfb1d6aacc59f0b8018681dd

**Explanation**: The feature is already enabled on other platforms in swift.org toolchains, this change brings feature parity to the Swift SDK for Wasm.
**Scope**: Isolated to Wasm Swift SDK.
**Risk**: Low due to isolated scope and test suite coverage.
**Testing**: Existing autodiff tests in the toolchain repository.
**Issue**: rdar://168501720
**Reviewer**: @kateinoigakukun 
