### PR TITLE
[6.3][wasm] Enable aggressive reg2mem optimization

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -4329,11 +4329,6 @@ bool CompilerInvocation::parseArgs(
                        OPT_disable_aggressive_reg2mem,
                        SILOpts.UseAggressiveReg2MemForCodeSize);
 
-  // We ran into an LLVM backend instruction selection failure.
-  // This is a workaround.
-  if (LangOpts.Target.isWasm())
-    SILOpts.UseAggressiveReg2MemForCodeSize = false;
-
   // With Swift 6, enable @_spiOnly by default. This also enables proper error
   // reporting of ioi references from spi decls.
   if (LangOpts.EffectiveLanguageVersion.isVersionAtLeast(6)) {

--- a/test/IRGen/loadable_by_address_address_assignment.swift
+++ b/test/IRGen/loadable_by_address_address_assignment.swift
@@ -2,9 +2,6 @@
 
 // REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 
-// wasm currently disables aggressive reg2mem
-// UNSUPPORTED: CPU=wasm32
-
 public struct LargeThing {
     var  s0 : String = ""
     var  s1 : String = ""

--- a/test/IRGen/loadable_by_address_reg2mem_fixed_array.sil
+++ b/test/IRGen/loadable_by_address_reg2mem_fixed_array.sil
@@ -4,9 +4,6 @@
 
 // REQUIRES: swift_feature_BuiltinModule
 
-// wasm currently disables aggressive reg2mem
-// UNSUPPORTED: CPU=wasm32
-
 import Builtin
 import Swift
 


### PR DESCRIPTION
Cherry-pick https://github.com/swiftlang/swift/pull/86624

**Explanation**: We had been seeing compilation-time and code size regression introduced between https://github.com/swiftlang/swift/compare/swift-DEVELOPMENT-SNAPSHOT-2025-11-03-a...swift-DEVELOPMENT-SNAPSHOT-2025-11-20-a without the aggressive reg2mem optimization enabled. It seems like the 6.3 branch has cut off after that, so I assume it should have the same regression.
**Scope**: Isolated to Wasm Swift SDK.
**Risk**: Low due to isolated scope.
**Testing**: Enabled a few tests to run against wasm
**Issue**: rdar://169104260
**Reviewer**: @MaxDesiatov  
