### PR TITLE
[CMake] MSVC does not support -fno-lto, so skip it

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -61,13 +61,18 @@ function(_is_lto_enabled option out_var)
   endif()
 endfunction()
 
+# Not every compiler supports -fno-lto (MSVC, for example).
+check_cxx_compiler_flag("-fno-lto" CXX_COMPILER_SUPPORTS_FNO_LTO)
+
 function(_compute_lto_flag option out_var)
   _is_lto_enabled("${option}" _lto_enabled)
   if (_lto_enabled)
     string(TOLOWER "${option}" lowercase_option)
     set(${out_var} "-flto=${lowercase_option}" PARENT_SCOPE)
-  else()
+  elseif (CXX_COMPILER_SUPPORTS_FNO_LTO)
     set(${out_var} "-fno-lto" PARENT_SCOPE)
+  else()
+    set(${out_var} "" PARENT_SCOPE)
   endif()
 endfunction()
 


### PR DESCRIPTION
Sadly MSVC doesn't seem to have a equivalent to `-fno-lto` and it does not like `-fno-lto`, printing a warning. Pointed out after landing in the comments of #86187.

In order to avoid the warning, skip the `-fno-lto` flag for MSVC compilers. This means that MSVC will still suffer the problem described in #86187 (enabling LTO in a LLVM unified build will force enabling LTO on Swift/Swift stdlib, even if disabled explicitly with\ `SWIFT_STDLIB_ENABLE_LTO`). This was the result even after #86187, since MSVC was ignoring the `-fno-lto` anyway.

It cannot be done with a generator expression because the resulting string seems to be used in some context that does not support generator expressions.