### PR TITLE
[Concurrency] Turn off custom executors for 6.2 targets.

### DIFF
--- a/include/swift/AST/FeatureAvailability.def
+++ b/include/swift/AST/FeatureAvailability.def
@@ -80,10 +80,10 @@ FEATURE(IsolatedDeinit,                                 (6, 1))
 
 FEATURE(ValueGenericType,                               (6, 2))
 FEATURE(InitRawStructMetadata2,                         (6, 2))
-FEATURE(CustomGlobalExecutors,                          (6, 2))
 FEATURE(TaskExecutor,                                   (6, 2))
 FEATURE(TypedCoroAlloc,                                 (6, 2))
 
+FEATURE(CustomGlobalExecutors,                          FUTURE)
 FEATURE(Differentiation,                                FUTURE)
 FEATURE(ClearSensitive,                                 FUTURE)
 FEATURE(UpdatePureObjCClassMetadata,                    FUTURE)


### PR DESCRIPTION
While I'd already updated the availability of the APIs, I hadn't fixed the feature availability, so the compiler might have tried to use the custom executors entry point when building async main.

rdar://168507128
