### PR TITLE
Sema: Add some scale-tests

### DIFF
--- a/lib/Sema/CSOptimizer.cpp
+++ b/lib/Sema/CSOptimizer.cpp
@@ -1867,19 +1867,33 @@ static void determineBestChoicesInContext(
         << "Best overall score = " << bestOverallScore << '\n';
 
     for (auto *disjunction : disjunctions) {
-      auto &entry = result[disjunction];
+      auto found = result.find(disjunction);
+
       getLogger(/*extraIndent=*/4)
           << "[Disjunction '"
           << disjunction->getNestedConstraints()[0]->getFirstType()->getString(
-                 PO)
-          << "' with score = " << entry.Score.value_or(0) << '\n';
+                 PO);
 
-      for (const auto *choice : entry.FavoredChoices) {
-        auto &log = getLogger(/*extraIndent=*/6);
+      if (found != result.end()) {
+        auto &entry = found->second;
+        if (entry.Score.has_value()) {
+          getLogger(/*extraIndent=*/4)
+              << "' with score = " << entry.Score.value_or(0) << '\n';
+        } else {
+          getLogger(/*extraIndent=*/4)
+              << "' without score\n";
+        }
 
-        log << "- ";
-        choice->print(log, &cs.getASTContext().SourceMgr);
-        log << '\n';
+        for (const auto *choice : entry.FavoredChoices) {
+          auto &log = getLogger(/*extraIndent=*/6);
+
+          log << "- ";
+          choice->print(log, &cs.getASTContext().SourceMgr);
+          log << '\n';
+        }
+      } else {
+        getLogger(/*extraIndent=*/4)
+            << "' unsupported\n";
       }
 
       getLogger(/*extraIdent=*/4) << "]\n";

--- a/validation-test/Sema/type_checker_perf/fast/logical_operator_heuristic_1.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/logical_operator_heuristic_1.swift.gyb
@@ -1,0 +1,42 @@
+// RUN: %scale-test --begin 1 --end 6 --step 1 --select NumLeafScopes %s
+// REQUIRES: tools-release,no_asan,asserts
+
+public struct S1: Equatable {}
+public struct S2: Equatable {}
+public struct S3: Equatable {}
+
+// Here, we have overloads of &&, which usually isn't overloaded.
+// The expression does not actually involve those overloads.
+
+public func && (_: S1, _: S1) -> S2 { S2() }
+public func && (_: S2, _: S3) -> S2 { S2() }
+public func && (_: S3, _: S2) -> S2 { S2() }
+public func && (_: S2, _: S1) -> S2 { S2() }
+public func && (_: S1, _: S2) -> S2 { S2() }
+public func && (_: S3, _: S3) -> S2 { S2() }
+public func && (_: S3, _: S1) -> S2 { S2() }
+public func && (_: S1, _: S3) -> S2 { S2() }
+
+public struct G<T> {}
+
+public func && <T>(_: G<T>, _: G<T>) -> G<T> { G<T>() }
+
+public func == <T, U>(_: U, _: U) -> G<T> where U : Equatable { G<T>() }
+public func == <T, U>(_: KeyPath<T, U>, _: U) -> G<T> where U : Equatable { G<T>() }
+public func == <T, U>(_: U, _: KeyPath<T, U>) -> G<T> where U : Equatable { G<T>() }
+public func == <T, U>(_: KeyPath<T, U>, _: KeyPath<T, U>) -> G<T> where U : Equatable { G<T>() }
+
+public struct S4: Equatable {}
+
+public struct S5: Equatable {
+  public static func == (lhs: S5, rhs: S5) -> Bool {
+    return (lhs.lastEditedBy == rhs.lastEditedBy &&
+%for i in range(0, N):
+            lhs.lastEditedBy == rhs.lastEditedBy &&
+%end
+            lhs.lastEditedBy == rhs.lastEditedBy)
+  }
+
+  var lastEditedBy: S4?
+}
+

--- a/validation-test/Sema/type_checker_perf/fast/not1.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/not1.swift.gyb
@@ -1,0 +1,20 @@
+// RUN: %scale-test --begin 1 --end 10 --step 1 --select NumLeafScopes %s
+// REQUIRES: tools-release,no_asan,asserts
+
+struct T {}
+struct F {}
+
+func not(_: T) -> F { fatalError() }
+func not(_: F) -> T { fatalError() }
+
+func test() {
+  let _ = { x -> T in
+%for i in range(0, N):
+    not(
+%end
+    x
+%for i in range(0, N):
+    )
+%end
+  }
+}

--- a/validation-test/Sema/type_checker_perf/fast/not2.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/not2.swift.gyb
@@ -1,0 +1,20 @@
+// RUN: %scale-test --begin 1 --end 10 --step 1 --select NumLeafScopes %s
+// REQUIRES: tools-release,no_asan,asserts
+
+struct T {}
+struct F {}
+
+func not(_: T) -> F { fatalError() }
+func not(_: F) -> T { fatalError() }
+
+func test() {
+  let _ = { (x: T) in
+%for i in range(0, N):
+    not(
+%end
+    x
+%for i in range(0, N):
+    )
+%end
+  }
+}

--- a/validation-test/Sema/type_checker_perf/slow/rdar30596744_1.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/slow/rdar30596744_1.swift.gyb
@@ -1,6 +1,8 @@
 // RUN: %scale-test --invert-result --begin 1 --end 7 --step 1 --select NumLeafScopes %s --expected-exit-code 1
 // REQUIRES: asserts,no_asan
 
+// Invalid expression: contextual type of .xi is not specified
+
 % enum_cases = N
 % array_elements = 3
 


### PR DESCRIPTION
not1 is only fast on accident -- no disjunction scores are assigned, because we do not consider result type matching when scoring non-operator disjunctions. We should fix this!

not2 is fast because we do consider parameter types, so we score disjunctions and solve the innermost one first.