### PR TITLE
Downgrade StrictAccessControl errors to warnings

### DIFF
--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -90,14 +90,11 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
         auto storage = accessor->getStorage();
         if (accessor->getFormalAccess() < storage->getFormalAccess()) {
           auto diagID = diag::resilience_decl_unavailable;
-          if (Context.LangOpts.hasFeature(Feature::StrictAccessControl))
-            Context.Diags.diagnose(loc, diagID, D, accessor->getFormalAccess(),
-                                   fragileKind.getSelector());
-          else
-            Context.Diags
-                .diagnose(loc, diagID, D, accessor->getFormalAccess(),
-                          fragileKind.getSelector())
-                .limitBehavior(DiagnosticBehavior::Warning);
+          Context.Diags
+              .diagnose(loc, diagID, D, accessor->getFormalAccess(),
+                        fragileKind.getSelector())
+              .warnUntilFutureLanguageModeIf(
+                  !Context.LangOpts.hasFeature(Feature::StrictAccessControl));
           Context.Diags.diagnose(D, diag::resilience_decl_declared_here, D);
         }
       }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4453,20 +4453,26 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
         auto diagKind = protoForcesAccess
                           ? diag::witness_not_accessible_proto
                           : diag::witness_not_accessible_type;
-        if (check.getKind() == CheckKind::AccessStrict) {
-          if (witness->getASTContext().LangOpts.hasFeature(
-                  Feature::StrictAccessControl))
-            diagKind = diag::witness_not_accessible_strict_check;
-          else
-            diagKind = diag::witness_not_accessible_strict_check_warn;
-        }
         bool isSetter = check.isForSetterAccess();
 
         auto &diags = DC->getASTContext().Diags;
-        diags.diagnose(getLocForDiagnosingWitness(conformance, witness),
-                       diagKind, getProtocolRequirementKind(requirement),
-                       witness, isSetter, requiredAccess,
-                       protoAccessScope.accessLevelForDiagnostics(), proto);
+        if (check.getKind() == CheckKind::AccessStrict) {
+          // Strict Access Control violation requires a different diagnostics
+          diagKind = diag::witness_not_accessible_strict_check;
+          diags
+              .diagnose(getLocForDiagnosingWitness(conformance, witness),
+                        diagKind, getProtocolRequirementKind(requirement),
+                        witness, isSetter, requiredAccess,
+                        protoAccessScope.accessLevelForDiagnostics(), proto)
+              .warnUntilFutureLanguageModeIf(
+                  !DC->getASTContext().LangOpts.hasFeature(
+                      Feature::StrictAccessControl));
+        } else {
+          diags.diagnose(getLocForDiagnosingWitness(conformance, witness),
+                         diagKind, getProtocolRequirementKind(requirement),
+                         witness, isSetter, requiredAccess,
+                         protoAccessScope.accessLevelForDiagnostics(), proto);
+        }
 
         auto *decl = dyn_cast<AbstractFunctionDecl>(witness);
         if (decl && decl->isSynthesized())


### PR DESCRIPTION
Refactors access check diagnostic to automatically downgrade errors to
warnings based on feature flag and/or swift version

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
