### PR TITLE
[6.3] Remove assert that isn't fully established

### DIFF
--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -443,7 +443,6 @@ bool SILFunction::hasForeignBody() const {
 }
 
 void SILFunction::setAsmName(StringRef value) {
-  ASSERT((AsmName.empty() || value == AsmName) && "Cannot change asmname");
   AsmName = value;
 
   if (!value.empty()) {


### PR DESCRIPTION
- **Explanation**: Removes an assertion that is not strictly necessary and is triggering in some complex cases we have yet to isolate.
- **Scope**: Limited to one area of SILGen that is used to set the `asmname` of SIL functions for C entrypoints.
- **Issues**: rdar://164495210
- **Original PRs**: https://github.com/swiftlang/swift/pull/86668
- **Risk**: Very low, just removes an assert.
- **Testing**: CI
- **Reviewers**: @slavapestov , @compnerd 
