### PR TITLE
Enable dynamic exclusivity checking runtime in Embedded Swift

### DIFF
--- a/stdlib/public/SwiftShims/swift/shims/ThreadLocalStorage.h
+++ b/stdlib/public/SwiftShims/swift/shims/ThreadLocalStorage.h
@@ -18,13 +18,22 @@
 SWIFT_RUNTIME_STDLIB_INTERNAL
 void * _Nonnull _swift_stdlib_threadLocalStorageGet(void);
 
+#if !defined(__swift_embedded__)
 SWIFT_RUNTIME_STDLIB_INTERNAL
 void * _Nullable _swift_getExclusivityTLSImpl();
 
 SWIFT_RUNTIME_STDLIB_INTERNAL
 void _swift_setExclusivityTLSImpl(void * _Nullable newValue);
+#endif
 
-#if defined(__APPLE__) && __arm64__
+#if defined(__swift_embedded__)
+SWIFT_RUNTIME_STDLIB_INTERNAL
+void * _Nullable _swift_getExclusivityTLS();
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+void _swift_setExclusivityTLS(void * _Nullable newValue);
+
+#elif defined(__APPLE__) && __arm64__
 
 // Use a fast path on Apple ARM64, where we have a dedicated TLS key and fast
 // access to read/write it.

--- a/stdlib/public/SwiftShims/swift/shims/ThreadLocalStorage.h
+++ b/stdlib/public/SwiftShims/swift/shims/ThreadLocalStorage.h
@@ -20,7 +20,7 @@ void * _Nonnull _swift_stdlib_threadLocalStorageGet(void);
 
 #if !defined(__swift_embedded__)
 SWIFT_RUNTIME_STDLIB_INTERNAL
-void * _Nullable _swift_getExclusivityTLSImpl();
+void * _Nullable _swift_getExclusivityTLSImpl(void);
 
 SWIFT_RUNTIME_STDLIB_INTERNAL
 void _swift_setExclusivityTLSImpl(void * _Nullable newValue);
@@ -28,7 +28,7 @@ void _swift_setExclusivityTLSImpl(void * _Nullable newValue);
 
 #if defined(__swift_embedded__)
 SWIFT_RUNTIME_STDLIB_INTERNAL
-void * _Nullable _swift_getExclusivityTLS();
+void * _Nullable _swift_getExclusivityTLS(void);
 
 SWIFT_RUNTIME_STDLIB_INTERNAL
 void _swift_setExclusivityTLS(void * _Nullable newValue);
@@ -44,14 +44,14 @@ void _swift_setExclusivityTLS(void * _Nullable newValue);
 
 #define SWIFT_RUNTIME_EXCLUSIVITY_KEY __PTK_FRAMEWORK_SWIFT_KEY7
 
-static inline void * _Nullable * _Nonnull _swift_getExclusivityTLSPointer() {
+static inline void * _Nullable * _Nonnull _swift_getExclusivityTLSPointer(void) {
   unsigned long tsd;
   __asm__ ("mrs %0, TPIDRRO_EL0" : "=r" (tsd));
   void **base = (void **)tsd;
   return &base[SWIFT_RUNTIME_EXCLUSIVITY_KEY];
 }
 
-static inline void * _Nullable _swift_getExclusivityTLS() {
+static inline void * _Nullable _swift_getExclusivityTLS(void) {
   return *_swift_getExclusivityTLSPointer();
 }
 
@@ -61,7 +61,7 @@ static inline void _swift_setExclusivityTLS(void * _Nullable newValue) {
 
 #else
 
-static inline void * _Nullable _swift_getExclusivityTLS() {
+static inline void * _Nullable _swift_getExclusivityTLS(void) {
   return _swift_getExclusivityTLSImpl();
 }
 

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -84,7 +84,7 @@ split_embedded_sources(
   EMBEDDED EnumeratedSequence.swift
   EMBEDDED Equatable.swift
   EMBEDDED ErrorType.swift
-    NORMAL Exclusivity.swift
+  EMBEDDED Exclusivity.swift
   EMBEDDED ExistentialCollection.swift
   EMBEDDED Filter.swift
   EMBEDDED FlatMap.swift

--- a/stdlib/public/core/EmbeddedPrint.swift
+++ b/stdlib/public/core/EmbeddedPrint.swift
@@ -128,7 +128,7 @@ extension BinaryInteger {
     return count
   }
 
-  func writeToStdout() {
+  func writeToStdout(radix: Int = 10) {
     // Avoid withUnsafeTemporaryAllocation which is not typed-throws ready yet
     let byteCount = 64
     let stackBuffer = Builtin.stackAlloc(byteCount._builtinWordValue,
@@ -136,7 +136,7 @@ extension BinaryInteger {
     let buffer = unsafe UnsafeMutableRawBufferPointer(start: .init(stackBuffer),
         count: byteCount).baseAddress!.assumingMemoryBound(to: UInt8.self)
 
-    let count = unsafe _toStringImpl(buffer, 64, 10, false)
+    let count = unsafe _toStringImpl(buffer, 64, radix, false)
 
     unsafe printCharacters(UnsafeBufferPointer(start: buffer, count: count))
 
@@ -145,7 +145,12 @@ extension BinaryInteger {
 }
 
 public func print(_ integer: some BinaryInteger, terminator: StaticString = "\n") {
-  integer.writeToStdout()
+  integer.writeToStdout(radix: 10)
+  print("", terminator: terminator)
+}
+
+internal func printAsHex(_ integer: some BinaryInteger, terminator: StaticString = "\n") {
+  integer.writeToStdout(radix: 16)
   print("", terminator: terminator)
 }
 

--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -720,6 +720,13 @@ func _embeddedReportFatalError(prefix: StaticString, message: StaticString) {
 }
 
 @inline(never)
+func _embeddedReportFatalError(prefix: StaticString, message: UnsafeBufferPointer<UInt8>) {
+  print(prefix, terminator: "")
+  if message.count > 0 { print(": ", terminator: "") }
+  unsafe print(message)
+}
+
+@inline(never)
 func _embeddedReportFatalErrorInFile(prefix: StaticString, message: StaticString, file: StaticString, line: UInt) {
   print(file, terminator: ":")
   print(line, terminator: ": ")
@@ -735,6 +742,38 @@ func _embeddedReportFatalErrorInFile(prefix: StaticString, message: UnsafeBuffer
   print(prefix, terminator: "")
   if message.count > 0 { print(": ", terminator: "") }
   unsafe print(message)
+}
+
+extension Access.Action {
+  func printName() {
+    switch self {
+    case .read:
+      print("read", terminator: "")
+    case .modify:
+      print("modify", terminator: "")
+    }
+  }
+}
+
+@inline(never)
+func _embeddedReportExclusivityViolation(
+  oldAction: Access.Action, oldPC: UnsafeRawPointer?,
+  newAction: Access.Action, newPC: UnsafeRawPointer?,
+  pointer: UnsafeRawPointer
+) {
+  print("Simultaneous access to 0x", terminator: "")
+  printAsHex(Int(bitPattern: pointer), terminator: "")
+  print(", but modification requires exclusive access")
+
+  print("Previous access (a ", terminator: "")
+  oldAction.printName()
+  print(") started at 0x", terminator: "")
+  printAsHex(Int(bitPattern: oldPC))
+
+  print("Current access (a ", terminator: "")
+  newAction.printName()
+  print(") started at 0x", terminator: "")
+  printAsHex(Int(bitPattern: newPC))
 }
 
 // CXX Exception Personality

--- a/stdlib/public/core/Exclusivity.swift
+++ b/stdlib/public/core/Exclusivity.swift
@@ -21,8 +21,8 @@ fileprivate let ValueBufferSize = unsafe 3 * MemoryLayout<UnsafeRawPointer>.stri
 fileprivate let TrackingFlag: UInt = 0x20
 fileprivate let ActionMask: UInt = 0x1
 
-fileprivate typealias AccessPointer = UnsafeMutablePointer<Access>
-@unsafe fileprivate struct Access {
+typealias AccessPointer = UnsafeMutablePointer<Access>
+@unsafe struct Access {
 
   enum Action: UInt {
     case read
@@ -79,12 +79,21 @@ fileprivate typealias AccessPointer = UnsafeMutablePointer<Access>
     while let nextPtr = unsafe cursor {
       if unsafe nextPtr.pointee.location == location {
         if unsafe nextPtr.pointee.action == .modify || action == .modify {
+          #if !$Embedded
           unsafe _swift_reportExclusivityConflict(
             nextPtr.pointee.action.rawValue,
             nextPtr.pointee.pc,
             action.rawValue,
             pc,
             location)
+          #else
+          unsafe _embeddedReportExclusivityViolation(
+            oldAction: nextPtr.pointee.action,
+            oldPC: nextPtr.pointee.pc,
+            newAction: action,
+            newPC: pc,
+            pointer: location)
+          #endif
         }
       }
       unsafe cursor = nextPtr.pointee.next
@@ -174,12 +183,14 @@ internal func swift_beginAccess(
   // eliminate the check when it's true.
   precondition(unsafe MemoryLayout<Access>.size <= ValueBufferSize)
 
+  #if !$Embedded
   // If exclusivity checking is disabled, mark this access as untracked by
   // putting nil into the access buffer's pointer field, and return.
   if _swift_disableExclusivityChecking {
     unsafe Access.from(rawPointer: buffer)?.pointee.location = nil
     return
   }
+  #endif
 
   guard let action = Access.Action(rawValue: flags & ActionMask) else {
     invalidFlags(flags)
@@ -279,10 +290,16 @@ fileprivate func reportExclusivityError(
   prefix.withUTF8Buffer { prefixBuffer in
     var message = message
     message.withUTF8 { messageBuffer in
+      #if !$Embedded
       unsafe _swift_stdlib_reportFatalError(
           prefixBuffer.baseAddress!, CInt(prefixBuffer.count),
           messageBuffer.baseAddress!, CInt(messageBuffer.count),
           0)
+      #else
+      unsafe _embeddedReportFatalError(
+          prefix: prefix,
+          message: messageBuffer)
+      #endif
     }
   }
   Builtin.int_trap()

--- a/stdlib/public/stubs/CMakeLists.txt
+++ b/stdlib/public/stubs/CMakeLists.txt
@@ -51,4 +51,5 @@ if("${SWIFT_PRIMARY_VARIANT_SDK}" IN_LIST SWIFT_DARWIN_PLATFORMS)
                  "-fobjc-arc")
 endif()
 
+add_subdirectory(Exclusivity)
 add_subdirectory(Unicode)

--- a/stdlib/public/stubs/Exclusivity/C11ThreadLocal.cpp
+++ b/stdlib/public/stubs/Exclusivity/C11ThreadLocal.cpp
@@ -18,6 +18,7 @@
 #include "swift/shims/Visibility.h"
 
 #if defined(__has_feature) && __has_feature(cxx_thread_local)
+#if defined(__APPLE__) || defined(__linux__) || defined(_WIN32)
 extern "C" {
 thread_local void * _Nullable _swift_exclusivity_single_threaded;
 
@@ -31,4 +32,5 @@ void _swift_setExclusivityTLS(void * _Nullable newValue) {
   _swift_exclusivity_single_threaded = newValue;
 }
 }
+#endif
 #endif

--- a/stdlib/public/stubs/Exclusivity/C11ThreadLocal.cpp
+++ b/stdlib/public/stubs/Exclusivity/C11ThreadLocal.cpp
@@ -17,6 +17,7 @@
 
 #include "swift/shims/Visibility.h"
 
+#if defined(__has_feature) && __has_feature(cxx_thread_local)
 extern "C" {
 thread_local void * _Nullable _swift_exclusivity_single_threaded;
 
@@ -30,3 +31,4 @@ void _swift_setExclusivityTLS(void * _Nullable newValue) {
   _swift_exclusivity_single_threaded = newValue;
 }
 }
+#endif

--- a/stdlib/public/stubs/Exclusivity/C11ThreadLocal.cpp
+++ b/stdlib/public/stubs/Exclusivity/C11ThreadLocal.cpp
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+// Multi-threaded implementation of dynamic exclusivity checking that relies
+// on C++11. This file
+// should be linked in to single-threaded Embedded Swift applications that
+// require dynamic exclusivity checking.
+//===----------------------------------------------------------------------===//
+
+#include "swift/shims/Visibility.h"
+
+extern "C" {
+thread_local void * _Nullable _swift_exclusivity_single_threaded;
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+void * _Nullable _swift_getExclusivityTLS() {
+  return _swift_exclusivity_single_threaded;
+}
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+void _swift_setExclusivityTLS(void * _Nullable newValue) {
+  _swift_exclusivity_single_threaded = newValue;
+}
+}

--- a/stdlib/public/stubs/Exclusivity/CMakeLists.txt
+++ b/stdlib/public/stubs/Exclusivity/CMakeLists.txt
@@ -1,0 +1,68 @@
+# Embedded Swift dynamic exclusivity mix-in libraries
+if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
+  set(EMBEDDED_SWIFT_EXCLUSIVITY_IMPLEMENTATIONS SingleThreaded C11ThreadLocal)
+  add_custom_target(embedded-exclusivity)
+  add_dependencies(embedded-libraries embedded-exclusivity)
+
+  foreach(entry ${EMBEDDED_STDLIB_TARGET_TRIPLES})
+    string(REGEX REPLACE "[ \t]+" ";" list "${entry}")
+    list(GET list 0 arch)
+    list(GET list 1 mod)
+    list(GET list 2 triple)
+
+    if("${mod}" MATCHES "-windows-msvc$")
+      continue()
+    endif()
+
+    if("${arch}" MATCHES "avr")
+      continue()
+    endif()
+
+    if (SWIFT_HOST_VARIANT STREQUAL "linux")
+      set(extra_c_compile_flags -ffreestanding)
+    elseif (SWIFT_HOST_VARIANT STREQUAL "macosx")
+      set(extra_c_compile_flags -ffreestanding)
+    endif()
+    list(APPEND extra_c_compile_flags -nostdinc++)
+
+    set(SWIFT_SDK_embedded_ARCH_${mod}_MODULE "${mod}")
+    set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
+    set(SWIFT_SDK_embedded_ARCH_${mod}_TRIPLE "${triple}")
+    if(SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES)
+      set(SWIFT_SDK_embedded_ARCH_${mod}_PATH "${EMBEDDED_STDLIB_SDK_FOR_${triple}}")
+    endif()
+
+    foreach(impl ${EMBEDDED_SWIFT_EXCLUSIVITY_IMPLEMENTATIONS})
+      add_swift_target_library_single(
+        embedded-exclusivity-${impl}-${mod}
+        swiftExclusivity${impl}
+        STATIC
+        IS_FRAGILE
+        PARTIAL_SOURCES_INTENDED
+
+        ${impl}.cpp
+
+        C_COMPILE_FLAGS ${extra_c_compile_flags}
+        MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
+        SDK "embedded"
+        ARCHITECTURE "${mod}"
+        DEPENDS embedded-stdlib-${mod}
+        INSTALL_IN_COMPONENT stdlib
+        )
+      swift_install_in_component(
+        TARGETS embedded-exclusivity-${impl}-${mod}
+        DESTINATION "lib/swift/embedded/${mod}"
+        COMPONENT "stdlib"
+        )
+      swift_install_in_component(
+        FILES "${SWIFTLIB_DIR}/embedded/${mod}/libswiftExclusivity${impl}.a"
+        DESTINATION "lib/swift/embedded/${mod}/"
+        COMPONENT "stdlib"
+        PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+        )
+      set_property(TARGET embedded-exclusivity-${impl}-${mod} PROPERTY OSX_ARCHITECTURES "${arch}")
+
+      add_dependencies(embedded-exclusivity embedded-exclusivity-${impl}-${mod})
+    endforeach()
+  endforeach()
+endif()

--- a/stdlib/public/stubs/Exclusivity/CMakeLists.txt
+++ b/stdlib/public/stubs/Exclusivity/CMakeLists.txt
@@ -33,6 +33,13 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     endif()
 
     foreach(impl ${EMBEDDED_SWIFT_EXCLUSIVITY_IMPLEMENTATIONS})
+      # C11 thread-local does not work with -none- triples.
+      if ("${impl}" MATCHES "C11ThreadLocal")
+        if("${triple}" MATCHES "-none-")
+            continue()
+        endif()
+      endif()
+
       add_swift_target_library_single(
         embedded-exclusivity-${impl}-${mod}
         swiftExclusivity${impl}

--- a/stdlib/public/stubs/Exclusivity/SingleThreaded.cpp
+++ b/stdlib/public/stubs/Exclusivity/SingleThreaded.cpp
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+// Single-threaded implementation of dynamic exclusivity checking. This file
+// should be linked in to single-threaded Embedded Swift applications that
+// require dynamic exclusivity checking.
+//===----------------------------------------------------------------------===//
+
+#include "swift/shims/Visibility.h"
+
+extern "C" {
+void * _Nullable _swift_exclusivity_single_threaded;
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+void * _Nullable _swift_getExclusivityTLS() {
+  return _swift_exclusivity_single_threaded;
+}
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+void _swift_setExclusivityTLS(void * _Nullable newValue) {
+  _swift_exclusivity_single_threaded = newValue;
+}
+}

--- a/test/embedded/exclusivity.swift
+++ b/test/embedded/exclusivity.swift
@@ -22,7 +22,7 @@ struct Main {
   // CHECK: 4main
   static func main() {
     // DYNAMIC: call void @swift_beginAccess
-    // STATIC-ONLY-NOT: call void @swift_beginAccess
+    // STATIC-ONLY-NOT: @swift_beginAccess
     o = MyClass()
     o!.handler = { print("no captures") }
     o!.foo() // CHECK: no captures

--- a/test/embedded/exclusivity_runtime.swift
+++ b/test/embedded/exclusivity_runtime.swift
@@ -1,0 +1,61 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o -enforce-exclusivity=checked
+// RUN: %target-clang %t/a.o -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
+// RUN: %target-run %t/a.out 2>&1| %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_in_compiler
+// REQUIRES: optimized_stdlib
+// REQUIRES: swift_feature_Embedded
+
+struct NC: ~Copyable {
+  var i: Int = 1
+
+  mutating func add(_ other: borrowing Self) {
+    i += other.i
+    i += other.i
+    print(self.i)
+    print(other.i)
+  }
+}
+
+class C1 {
+  var nc = NC()
+
+  func foo() {
+    nc.add(nc)
+  }
+}
+
+struct S {
+  var i: Int = 1
+
+  mutating func add(_ c: C2) {
+    let other = c.getS()
+    i += other.i
+    i += other.i
+    print(self.i)
+    print(other.i)
+  }
+}
+
+final class C2 {
+  var s = S()
+
+  @inline(never)
+  func getS() -> S { s }
+
+  func foo() {
+    s.add(self)
+  }
+}
+
+@main
+struct Main {
+  static func main() {
+    // CHECK: Simultaneous access to 0x{{.*}}, but modification requires exclusive access
+    // CHECK: Previous access (a modify) started at 0x{{.*}}
+    // CHECK: Current access (a read) started at 0x{{.*}}
+    C1().foo()
+  }
+}

--- a/test/embedded/exclusivity_runtime.swift
+++ b/test/embedded/exclusivity_runtime.swift
@@ -1,7 +1,14 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o -enforce-exclusivity=checked
-// RUN: %target-clang %t/a.o -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
+
+// Single-threaded exclusivity checking implementation
+// RUN: %target-clang %t/a.o -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip -lswiftExclusivitySingleThreaded
 // RUN: %target-run %t/a.out 2>&1| %FileCheck %s
+
+// Multi-threaded exclusivity checking implementation (that uses C11 thread_local).
+// RUN: %target-clang %t/a.o -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip -lswiftExclusivityC11ThreadLocal
+// RUN: %target-run %t/a.out 2>&1| %FileCheck %s
+
 
 // REQUIRES: executable_test
 // REQUIRES: swift_in_compiler

--- a/test/embedded/exclusivity_runtime_multi.swift
+++ b/test/embedded/exclusivity_runtime_multi.swift
@@ -1,14 +1,16 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o -enforce-exclusivity=checked
 
-// Single-threaded exclusivity checking implementation
-// RUN: %target-clang %t/a.o -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip -lswiftExclusivitySingleThreaded
+// Multi-threaded exclusivity checking implementation (that uses C11 thread_local).
+// RUN: %target-clang %t/a.o -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip -lswiftExclusivityC11ThreadLocal
 // RUN: %target-run %t/a.out 2>&1| %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_feature_Embedded
+
+// UNSUPPORTED: OS=wasip1
 
 struct NC: ~Copyable {
   var i: Int = 1


### PR DESCRIPTION
Start building the dynamic exclusivity checking code in Embedded Swift.
It will be used when dynamic exclusivity checking is enabled (via
`-enforce-exclusivity=checked`), and dead-code-stripped otherwise. Note
that we deliberately avoid linking `swift_(begin|end)Access` in
modules that don't have exclusivity enforcement enabled to aid with
dead-code stripping.

Also note that, unlike in non-Embedded Swift, exclusivity checking
cannot be disabled at runtime by setting
_swift_disableExclusivityChecking to `false`. We need the ability to
constant-initialize global variables to bring that functionality into
Embedded Swift.

Tracked by rdar://159115910.