### PR TITLE
[CMake] Introduce swift-syntax-dev component

### DIFF
--- a/cmake/modules/SwiftComponents.cmake
+++ b/cmake/modules/SwiftComponents.cmake
@@ -67,11 +67,12 @@
 # * testsuite-tools -- extra tools required to run the Swift testsuite.
 # * static-mirror-lib -- Build the static mirror library used by SwiftStaticMirror.
 # * swift-syntax-lib -- install swift-syntax libraries
+# * swift-syntax-dev -- '.swiftmodule' and support libraries to use swift-syntax-lib libraries.
 # * toolchain-dev-tools -- install development tools useful in a shared toolchain
 # * llvm-toolchain-dev-tools -- install LLVM development tools useful in a shared toolchain
 # * dev -- headers and libraries required to use Swift compiler as a library.
 set(_SWIFT_DEFINED_COMPONENTS
-  "autolink-driver;back-deployment;compiler;compiler-swift-syntax-lib;clang-builtin-headers;clang-resource-dir-symlink;clang-builtin-headers-in-clang-resource-dir;libexec;stdlib;stdlib-experimental;sdk-overlay;static-mirror-lib;swift-syntax-lib;editor-integration;tools;testsuite-tools;toolchain-tools;toolchain-dev-tools;llvm-toolchain-dev-tools;dev;license;sourcekit-xpc-service;sourcekit-inproc;swift-remote-mirror;swift-remote-mirror-headers")
+  "autolink-driver;back-deployment;compiler;compiler-swift-syntax-lib;clang-builtin-headers;clang-resource-dir-symlink;clang-builtin-headers-in-clang-resource-dir;libexec;stdlib;stdlib-experimental;sdk-overlay;static-mirror-lib;swift-syntax-lib;swift-syntax-dev;editor-integration;tools;testsuite-tools;toolchain-tools;toolchain-dev-tools;llvm-toolchain-dev-tools;dev;license;sourcekit-xpc-service;sourcekit-inproc;swift-remote-mirror;swift-remote-mirror-headers")
 
 # The default install components include all of the defined components, except
 # for the following exceptions.

--- a/lib/SwiftSyntax/CMakeLists.txt
+++ b/lib/SwiftSyntax/CMakeLists.txt
@@ -54,21 +54,25 @@ set(SWIFT_SYNTAX_MODULES
   SwiftLibraryPluginProvider
 )
 
+set(SWIFT_SYNTAX_TEST_MODULES
+  # For macro plugin testing.
+  _SwiftSyntaxGenericTestSupport
+  SwiftSyntaxMacrosGenericTestSupport
+)
+
 # Install shared runtime libraries
 if(CMAKE_SYSTEM_NAME MATCHES Windows)
   swift_install_in_component(TARGETS ${SWIFT_SYNTAX_MODULES}
                              RUNTIME
                              DESTINATION "bin"
                              COMPONENT swift-syntax-lib)
-else()
-  swift_install_in_component(TARGETS ${SWIFT_SYNTAX_MODULES}
-                             LIBRARY
-                             DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/host"
-                             COMPONENT swift-syntax-lib)
-endif()
 
-# Install import libraries in Windows.
-if(CMAKE_SYSTEM_NAME MATCHES Windows)
+  swift_install_in_component(TARGETS ${SWIFT_SYNTAX_TEST_MODULES}
+                             RUNTIME
+                             DESTINATION "bin"
+                             COMPONENT swift-syntax-dev)
+
+  # Install import libraries.
   list(TRANSFORM SWIFT_SYNTAX_MODULES
        PREPEND "${CMAKE_IMPORT_LIBRARY_PREFIX}"
        OUTPUT_VARIABLE SWIFT_SYNTAX_IMPORT_LIBRARIES)
@@ -80,26 +84,38 @@ if(CMAKE_SYSTEM_NAME MATCHES Windows)
        OUTPUT_VARIABLE SWIFT_SYNTAX_IMPORT_LIBRARIES)
   swift_install_in_component(PROGRAMS "${SWIFT_SYNTAX_IMPORT_LIBRARIES}"
                              DESTINATION lib
+                             COMPONENT swift-syntax-dev)
+else()
+  swift_install_in_component(TARGETS ${SWIFT_SYNTAX_MODULES}
+                             LIBRARY
+                             DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/host"
                              COMPONENT swift-syntax-lib)
+  swift_install_in_component(TARGETS ${SWIFT_SYNTAX_TEST_MODULES}
+                             LIBRARY
+                             DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/host"
+                             COMPONENT swift-syntax-dev)
 endif()
 
 add_dependencies(swift-syntax-lib
   ${SWIFT_SYNTAX_MODULES})
+add_dependencies(swift-syntax-dev
+  ${SWIFT_SYNTAX_MODULES} ${SWIFT_SYNTAX_TEST_MODULES})
 
 if(BOOTSTRAPPING_MODE STREQUAL "CROSSCOMPILE")
     add_dependencies(swift-syntax-lib swift-stdlib-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH})
+    add_dependencies(swift-syntax-dev swift-stdlib-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH})
 endif()
 
 # Install Swift module interface files.
-foreach(module ${SWIFT_SYNTAX_MODULES})
+foreach(module ${SWIFT_SYNTAX_MODULES} ${SWIFT_SYNTAX_TEST_MODULES})
   set(module_dir "${module}.swiftmodule")
   set(module_file "${SWIFT_HOST_LIBRARIES_DEST_DIR}/${module_dir}/${SWIFT_HOST_MODULE_TRIPLE}")
   swift_install_in_component(FILES "${module_file}.swiftinterface" "${module_file}.private.swiftinterface"
                              DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/host/${module_dir}"
-                             COMPONENT swift-syntax-lib)
+                             COMPONENT swift-syntax-dev)
 endforeach()
 
-export(TARGETS ${SWIFT_SYNTAX_MODULES}
+export(TARGETS ${SWIFT_SYNTAX_MODULES} ${SWIFT_SYNTAX_TEST_MODULES}
        NAMESPACE SwiftSyntax::
        FILE ${CMAKE_BINARY_DIR}/cmake/modules/SwiftSyntaxConfig.cmake
        EXPORT_LINK_INTERFACE_LIBRARIES)


### PR DESCRIPTION
* Separate `.swiftmodule` from `swift-syntax-lib` component
* Include `SwiftSyntaxMacrosGenericTestSupport` libraries and modules in `swift-syntax-dev` component

rdar://122209853
rdar://114280017
