### PR TITLE
[rbi] Treat `alloc_box { let TYPE }` where TYPE is Sendable as Sendable

### DIFF
--- a/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
+++ b/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
@@ -569,12 +569,11 @@ public:
   static SILIsolationInfo getFunctionIsolation(SILFunction *fn);
 
 private:
-  /// A helper that is used to ensure that we treat certain builtin values as
-  /// non-Sendable that the AST level otherwise thinks are non-Sendable.
+  /// A helper that defines at the SIL level what we considered Sendable.
   ///
-  /// E.x.: Builtin.RawPointer and Builtin.NativeObject
-  ///
-  /// TODO: Fix the type checker.
+  /// NOTE: This can differ from the AST in certain cases since we treat certain
+  /// builtin values such as Builtin.RawPointer and Builtin.NativeObject as
+  /// non-Sendable even though they are considered Sendable by the AST today.
   static bool isNonSendableType(SILType type, SILFunction *fn);
 
   static bool isSendableType(SILType type, SILFunction *fn) {
@@ -582,8 +581,16 @@ private:
   }
 
 public:
+  /// Returns true if \p value is a Sendable value.
+  ///
+  /// NOTE: This can use value based information to determine sendable for
+  /// values that are from a type perspective non-SEndable. E.x.: a
+  /// non-payloaded case of a non-Sendable enum.
   static bool isSendable(SILValue value);
 
+  /// Returns true if \p value is a non-Sendable value.
+  ///
+  /// NOTE: This just invokes isSendable and inverts the results.
   static bool isNonSendable(SILValue value) { return !isSendable(value); }
 
   static bool boxContainsOnlySendableFields(AllocBoxInst *abi) {

--- a/test/Concurrency/silisolationinfo_inference.sil
+++ b/test/Concurrency/silisolationinfo_inference.sil
@@ -1898,3 +1898,115 @@ bb0:
   %9999 = tuple ()
   return %9999 : $()
 }
+
+// CHECK-LABEL: begin running test 1 of 1 on var_box_with_sendable_type_is_nonsendable: sil_isolation_info_is_sendable with: @trace[0]
+// CHECK: Input Value:   %0 = alloc_box ${ var MyActor }
+// CHECK: IsSendable: no
+// CHECK: end running test 1 of 1 on var_box_with_sendable_type_is_nonsendable: sil_isolation_info_is_sendable with: @trace[0]
+sil [ossa] @var_box_with_sendable_type_is_nonsendable : $@convention(thin) () -> () {
+bb0:
+  specify_test "sil_isolation_info_is_sendable @trace[0]"
+  %0 = alloc_box ${ var MyActor }
+  debug_value [trace] %0
+  destroy_value %0
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on var_box_with_sendable_type_is_nonsendable_isolationinfo: sil_isolation_info_inference with: @trace[0]
+// CHECK: Input Value:   %0 = alloc_box ${ var MyActor }                 // user: %1
+// CHECK: Isolation: unknown
+// CHECK: end running test 1 of 1 on var_box_with_sendable_type_is_nonsendable_isolationinfo: sil_isolation_info_inference with: @trace[0]
+sil [ossa] @var_box_with_sendable_type_is_nonsendable_isolationinfo : $@convention(thin) () -> () {
+bb0:
+  specify_test "sil_isolation_info_inference @trace[0]"
+  %0 = alloc_box ${ var MyActor }
+  debug_value [trace] %0
+  destroy_value %0
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on let_box_with_sendable_type_is_sendable: sil_isolation_info_is_sendable with: @trace[0]
+// CHECK: Input Value:   %0 = alloc_box ${ let MyActor }
+// CHECK: IsSendable: yes
+// CHECK: end running test 1 of 1 on let_box_with_sendable_type_is_sendable: sil_isolation_info_is_sendable with: @trace[0]
+sil [ossa] @let_box_with_sendable_type_is_sendable : $@convention(thin) () -> () {
+bb0:
+  specify_test "sil_isolation_info_is_sendable @trace[0]"
+  %0 = alloc_box ${ let MyActor }
+  debug_value [trace] %0
+  destroy_value %0
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on let_box_with_sendable_type_is_sendable_isolationinfo_inference: sil_isolation_info_inference with: @trace[0]
+// CHECK: Input Value:   %0 = alloc_box ${ let MyActor }                 // user: %1
+// CHECK: Isolation: unknown
+// CHECK: end running test 1 of 1 on let_box_with_sendable_type_is_sendable_isolationinfo_inference: sil_isolation_info_inference with: @trace[0]
+sil [ossa] @let_box_with_sendable_type_is_sendable_isolationinfo_inference : $@convention(thin) () -> () {
+bb0:
+  specify_test "sil_isolation_info_inference @trace[0]"
+  %0 = alloc_box ${ let MyActor }
+  debug_value [trace] %0
+  destroy_value %0
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on var_box_with_nonsendable_type_is_nonsendable: sil_isolation_info_is_sendable with: @trace[0]
+// CHECK: Input Value:   %0 = alloc_box ${ var NonSendableKlass }
+// CHECK: IsSendable: no
+// CHECK: end running test 1 of 1 on var_box_with_nonsendable_type_is_nonsendable: sil_isolation_info_is_sendable with: @trace[0]
+sil [ossa] @var_box_with_nonsendable_type_is_nonsendable : $@convention(thin) () -> () {
+bb0:
+  specify_test "sil_isolation_info_is_sendable @trace[0]"
+  %0 = alloc_box ${ var NonSendableKlass }
+  debug_value [trace] %0
+  destroy_value %0
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on var_box_with_nonsendable_type_is_nonsendable_isolationinfo_inference: sil_isolation_info_inference with: @trace[0]
+// CHECK: Input Value:   %0 = alloc_box ${ var NonSendableKlass }        // user: %1
+// CHECK: Isolation: unknown
+// CHECK: end running test 1 of 1 on var_box_with_nonsendable_type_is_nonsendable_isolationinfo_inference: sil_isolation_info_inference with: @trace[0]
+sil [ossa] @var_box_with_nonsendable_type_is_nonsendable_isolationinfo_inference : $@convention(thin) () -> () {
+bb0:
+  specify_test "sil_isolation_info_inference @trace[0]"
+  %0 = alloc_box ${ var NonSendableKlass }
+  debug_value [trace] %0
+  destroy_value %0
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on let_box_with_nonsendable_type_is_nonsendable: sil_isolation_info_is_sendable with: @trace[0]
+// CHECK: Input Value:   %0 = alloc_box ${ let NonSendableKlass }
+// CHECK: IsSendable: no
+// CHECK: end running test 1 of 1 on let_box_with_nonsendable_type_is_nonsendable: sil_isolation_info_is_sendable with: @trace[0]
+sil [ossa] @let_box_with_nonsendable_type_is_nonsendable : $@convention(thin) () -> () {
+bb0:
+  specify_test "sil_isolation_info_is_sendable @trace[0]"
+  %0 = alloc_box ${ let NonSendableKlass }
+  debug_value [trace] %0
+  destroy_value %0
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on let_box_with_nonsendable_type_is_nonsendable_isolationinfo_inference: sil_isolation_info_inference with: @trace[0]
+// CHECK: Input Value:   %0 = alloc_box ${ let NonSendableKlass }        // user: %1
+// CHECK: Isolation: unknown
+// CHECK: end running test 1 of 1 on let_box_with_nonsendable_type_is_nonsendable_isolationinfo_inference: sil_isolation_info_inference with: @trace[0]
+sil [ossa] @let_box_with_nonsendable_type_is_nonsendable_isolationinfo_inference : $@convention(thin) () -> () {
+bb0:
+  specify_test "sil_isolation_info_inference @trace[0]"
+  %0 = alloc_box ${ let NonSendableKlass }
+  debug_value [trace] %0
+  destroy_value %0
+  %9999 = tuple ()
+  return %9999 : $()
+}

--- a/test/Concurrency/transfernonsendable_closure_captures.swift
+++ b/test/Concurrency/transfernonsendable_closure_captures.swift
@@ -127,8 +127,7 @@ func testNoncopyableSendableStructWithEscapingMainActorAsync() {
   let x = NoncopyableStructSendable()
   let _ = {
     escapingAsyncUse { @MainActor in
-      useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      useValue(x)
     }
   }
 }
@@ -253,8 +252,7 @@ func testNoncopyableSendableStructWithEscapingMainActorAsyncNormalCapture() {
   let x = NoncopyableStructSendable()
   let _ = { [x] in
     escapingAsyncUse { @MainActor in
-      useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      useValue(x)
     }
   }
 }
@@ -264,8 +262,7 @@ func testMutableNoncopyableSendableStructWithEscapingMainActorAsyncNormalCapture
   x = NoncopyableStructSendable()
   let _ = { [x] in
     escapingAsyncUse { @MainActor in
-      useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      useValue(x)
     }
   }
 }
@@ -1241,6 +1238,127 @@ func testMutableGenericNonsendableWithNonescapingMainActorAsync<T : ~Copyable>(
     nonescapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
       // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+    }
+  }
+}
+
+/////////////////////////////////////////////////
+// MARK: Generic Noncopyable Sendable Let Tests //
+/////////////////////////////////////////////////
+
+// These tests verify that generic noncopyable Sendable types in let bindings
+// work correctly. The key insight is that noncopyable types must be boxed when
+// captured, and immutable boxes with Sendable contents are treated as Sendable.
+
+func testGenericNoncopyableSendableLetWithEscapingMainActorAsync<T: ~Copyable & Sendable>(
+  _ value: consuming T) {
+  let x = value
+  let _ = {
+    escapingAsyncUse { @MainActor in
+      useValue(x) // OK: let binding + Sendable contents = Sendable box
+    }
+  }
+}
+
+func testGenericNoncopyableSendableLetWithNonescapingMainActorAsync<T: ~Copyable & Sendable>(
+  _ value: consuming T) {
+  let x = value
+  let _ = {
+    nonescapingAsyncUse { @MainActor in
+      useValue(x) // OK: let binding + Sendable contents = Sendable box
+    }
+  }
+}
+
+// Test generic noncopyable Sendable in capture list
+func testGenericNoncopyableSendableCaptureListWithEscapingMainActorAsync<T: ~Copyable & Sendable>(
+  _ value: consuming T) {
+  let x = value
+  let _ = { [x] in
+    escapingAsyncUse { @MainActor in
+      useValue(x) // OK: capture list creates let box + Sendable contents
+    }
+  }
+}
+
+// Verify that generic noncopyable non-Sendable still errors (negative test)
+func testGenericNoncopyableNonsendableLetWithEscapingMainActorAsync<T: ~Copyable>(
+  _ value: consuming T) {
+  let x = value
+  let _ = {
+    escapingAsyncUse { @MainActor in
+      useValue(x) // expected-error {{sending 'x' risks causing data races}}
+      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+    }
+  }
+}
+
+///////////////////////////////////////////////
+// MARK: Nested Closure with Let Box Tests   //
+///////////////////////////////////////////////
+
+// These tests verify that noncopyable Sendable types work correctly in deeply
+// nested closure scenarios.
+
+func testNestedClosuresNoncopyableSendable() {
+  let x = NoncopyableStructSendable()
+  let _ = {
+    let _ = {
+      escapingAsyncUse { @MainActor in
+        useValue(x) // OK: let box with Sendable contents
+      }
+    }
+  }
+}
+
+func testNestedClosuresNoncopyableSendableWithCaptureList() {
+  let x = NoncopyableStructSendable()
+  let _ = { [x] in
+    let _ = {
+      escapingAsyncUse { @MainActor in
+        useValue(x) // OK: let box with Sendable contents
+      }
+    }
+  }
+}
+
+func testDeeplyNestedClosuresNoncopyableSendable() {
+  let x = NoncopyableStructSendable()
+  let _ = {
+    let _ = {
+      let _ = {
+        escapingAsyncUse { @MainActor in
+          useValue(x) // OK: let box with Sendable contents
+        }
+      }
+    }
+  }
+}
+
+// Verify nested closure with noncopyable non-Sendable still errors
+func testNestedClosuresNoncopyableNonsendable() {
+  let x = NoncopyableStructNonsendable()
+  let _ = {
+    let _ = {
+      escapingAsyncUse { @MainActor in
+        useValue(x) // expected-error {{sending 'x' risks causing data races}}
+        // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      }
+    }
+  }
+}
+
+// Test nested closures with mixed Sendable/non-Sendable captures
+func testNestedClosuresMixedSendability() {
+  let sendable = NoncopyableStructSendable()
+  let nonsendable = NoncopyableStructNonsendable()
+  let _ = {
+    let _ = {
+      escapingAsyncUse { @MainActor in
+        useValue(sendable) // OK
+        useValue(nonsendable) // expected-error {{sending 'nonsendable' risks causing data races}}
+        // expected-note @-1 {{task-isolated 'nonsendable' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      }
     }
   }
 }


### PR DESCRIPTION
[rbi] Treat `alloc_box { let TYPE }` where TYPE is Sendable as Sendable

This is safe because:

1. The box can never be written to after initialization due to
definite initialization, and that initialization must occur before the box
escapes to another isolation domain.

2. We restrict this to immutable boxes containing Sendable types since otherwise
we could load a non-Sendable value from the box and produce a fresh value that
could escape into multiple isolation domains, potentially allowing unsafe
concurrent writes.

The important use case that this fixes are as follows:

1. Sendable noncopyable nominal types. Since the type is noncopyable, we must
   store it into a let box it to capture it in an escaping closure causing us to
   previously error:

   ```swift
   func testNoncopyableSendableStructWithEscapingMainActorAsync() {
     let x = NoncopyableStructSendable()
     let _ = {
       escapingAsyncUse { @MainActor in
         useValue(x) // Error!
       }
     }
   }
   ```

2. Simple capture lists of Sendable noncopyable nominal types. When we put the
   value into the capture list, we create a new let binding for the value which
   would be a let box since the underlying type is noncopyable:

   ```swift
   func testNoncopyableSendableStructWithEscapingMainActorAsyncNormalCapture() {
     let x = NoncopyableStructSendable()
     let _ = { [x] in
       escapingAsyncUse { @MainActor in
         useValue(x)
       }
     }
   }
   ```

Originally developed as part of rdar://166081666, though it turned out to be
independent of that fix.

