### PR TITLE
[cxx-interop] [test] Disable failing executable test for protected special members

### DIFF
--- a/test/Interop/Cxx/class/inheritance/protected-special-member-executable.swift
+++ b/test/Interop/Cxx/class/inheritance/protected-special-member-executable.swift
@@ -2,9 +2,9 @@
 //
 // REQUIRES: executable_test
 //
-// REQUIRES: OS=macosx
-// Fails on Linux:   https://github.com/swiftlang/swift/issues/86426
-// Fails on Windows：https://github.com/swiftlang/swift/issues/67288
+// REQUIRES: rdar168302720
+// Fails on Windows：  https://github.com/swiftlang/swift/issues/67288
+// Fails on non-macOS: https://github.com/swiftlang/swift/issues/86426
 
 import StdlibUnittest
 import ProtectedSpecialMember


### PR DESCRIPTION
This test fails on Linux and some simulator platforms as well. This test was added in a35a0ad696533bc456ffdba5acc6202d181e7bf6 to test the work there but is known to be broken prior to that (see PR testing in #86389).

Disable this test until a forward fix is found. At this time it is not known which platforms it fails on or why.

rdar://168302720