### PR TITLE
[stdlib, 6.3] mark some `Span` members with `@_transparent`

### DIFF
--- a/stdlib/public/core/Span/MutableRawSpan.swift
+++ b/stdlib/public/core/Span/MutableRawSpan.swift
@@ -135,7 +135,7 @@ extension MutableRawSpan {
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableRawSpan {
   @_alwaysEmitIntoClient
-  @_transparent
+  @_semantics("fixed_storage.get_count")
   public var byteCount: Int { _assumeNonNegative(_count) }
 
   @_alwaysEmitIntoClient

--- a/stdlib/public/core/Span/MutableRawSpan.swift
+++ b/stdlib/public/core/Span/MutableRawSpan.swift
@@ -136,7 +136,7 @@ extension MutableRawSpan {
 extension MutableRawSpan {
   @_alwaysEmitIntoClient
   @_transparent
-  public var byteCount: Int { _count }
+  public var byteCount: Int { _assumeNonNegative(_count) }
 
   @_alwaysEmitIntoClient
   @_transparent

--- a/stdlib/public/core/Span/MutableRawSpan.swift
+++ b/stdlib/public/core/Span/MutableRawSpan.swift
@@ -135,9 +135,11 @@ extension MutableRawSpan {
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableRawSpan {
   @_alwaysEmitIntoClient
+  @_transparent
   public var byteCount: Int { _count }
 
   @_alwaysEmitIntoClient
+  @_transparent
   public var isEmpty: Bool { byteCount == 0 }
 
   @_alwaysEmitIntoClient
@@ -151,6 +153,7 @@ extension MutableRawSpan {
 extension MutableRawSpan {
 
   @_alwaysEmitIntoClient
+  @_transparent
   public func withUnsafeBytes<E: Error, Result: ~Copyable>(
     _ body: (_ buffer: UnsafeRawBufferPointer) throws(E) -> Result
   ) throws(E) -> Result {
@@ -158,6 +161,7 @@ extension MutableRawSpan {
   }
 
   @_alwaysEmitIntoClient
+  @_transparent
   @lifetime(self: copy self)
   public mutating func withUnsafeMutableBytes<E: Error, Result: ~Copyable>(
     _ body: (UnsafeMutableRawBufferPointer) throws(E) -> Result
@@ -185,6 +189,7 @@ extension MutableRawSpan {
 
   public var bytes: RawSpan {
     @_alwaysEmitIntoClient
+    @_transparent
     @lifetime(borrow self)
     borrowing get {
       return RawSpan(_mutableRawSpan: self)

--- a/stdlib/public/core/Span/OutputRawSpan.swift
+++ b/stdlib/public/core/Span/OutputRawSpan.swift
@@ -67,18 +67,22 @@ extension OutputRawSpan {
 extension OutputRawSpan {
   /// The number of initialized bytes in this span.
   @_alwaysEmitIntoClient
+  @_transparent
   public var byteCount: Int { _count }
 
   /// The number of additional bytes that can be appended to this span.
   @_alwaysEmitIntoClient
+  @_transparent
   public var freeCapacity: Int { capacity &- _count }
 
   /// A Boolean value indicating whether the span is empty.
   @_alwaysEmitIntoClient
+  @_transparent
   public var isEmpty: Bool { _count == 0 }
 
   /// A Boolean value indicating whether the span is full.
   @_alwaysEmitIntoClient
+  @_transparent
   public var isFull: Bool { _count == capacity }
 }
 
@@ -239,6 +243,7 @@ extension OutputRawSpan {
 extension OutputRawSpan {
   /// Borrow the underlying initialized memory for read-only access.
   @_alwaysEmitIntoClient
+  @_transparent
   public var bytes: RawSpan {
     @lifetime(borrow self)
     borrowing get {
@@ -250,6 +255,7 @@ extension OutputRawSpan {
 
   /// Exclusively borrow the underlying initialized memory for mutation.
   @_alwaysEmitIntoClient
+  @_transparent
   public var mutableBytes: MutableRawSpan {
     @lifetime(&self)
     mutating get {
@@ -288,6 +294,7 @@ extension OutputRawSpan {
   /// this is an unsafe operation. Violating the invariants of `OutputRawSpan`
   /// may result in undefined behavior.
   @_alwaysEmitIntoClient
+  @_transparent
   @lifetime(self: copy self)
   public mutating func withUnsafeMutableBytes<E: Error, R: ~Copyable>(
     _ body: (

--- a/stdlib/public/core/Span/OutputRawSpan.swift
+++ b/stdlib/public/core/Span/OutputRawSpan.swift
@@ -67,7 +67,7 @@ extension OutputRawSpan {
 extension OutputRawSpan {
   /// The number of initialized bytes in this span.
   @_alwaysEmitIntoClient
-  @_transparent
+  @_semantics("fixed_storage.get_count")
   public var byteCount: Int { _assumeNonNegative(_count) }
 
   /// The number of additional bytes that can be appended to this span.

--- a/stdlib/public/core/Span/OutputRawSpan.swift
+++ b/stdlib/public/core/Span/OutputRawSpan.swift
@@ -68,7 +68,7 @@ extension OutputRawSpan {
   /// The number of initialized bytes in this span.
   @_alwaysEmitIntoClient
   @_transparent
-  public var byteCount: Int { _count }
+  public var byteCount: Int { _assumeNonNegative(_count) }
 
   /// The number of additional bytes that can be appended to this span.
   @_alwaysEmitIntoClient

--- a/stdlib/public/core/Span/OutputSpan.swift
+++ b/stdlib/public/core/Span/OutputSpan.swift
@@ -82,7 +82,6 @@ extension OutputSpan where Element: ~Copyable {
 extension OutputSpan where Element: ~Copyable {
   /// The number of initialized elements in this span.
   @_alwaysEmitIntoClient
-  @_transparent
   @_semantics("fixed_storage.get_count")
   public var count: Int { _assumeNonNegative(_count) }
 

--- a/stdlib/public/core/Span/OutputSpan.swift
+++ b/stdlib/public/core/Span/OutputSpan.swift
@@ -82,19 +82,23 @@ extension OutputSpan where Element: ~Copyable {
 extension OutputSpan where Element: ~Copyable {
   /// The number of initialized elements in this span.
   @_alwaysEmitIntoClient
+  @_transparent
   @_semantics("fixed_storage.get_count")
   public var count: Int { _assumeNonNegative(_count) }
 
   /// The number of additional elements that can be added to this span.
   @_alwaysEmitIntoClient
+  @_transparent
   public var freeCapacity: Int { capacity &- _count }
 
   /// A Boolean value indicating whether the span is empty.
   @_alwaysEmitIntoClient
+  @_transparent
   public var isEmpty: Bool { _count == 0 }
 
   /// A Boolean value indicating whether the span is full.
   @_alwaysEmitIntoClient
+  @_transparent
   public var isFull: Bool { _count == capacity }
 }
 
@@ -354,6 +358,7 @@ extension OutputSpan {
 extension OutputSpan where Element: ~Copyable {
   /// Borrow the underlying initialized memory for read-only access.
   @_alwaysEmitIntoClient
+  @_transparent
   public var span: Span<Element> {
     @lifetime(borrow self)
     borrowing get {
@@ -366,6 +371,7 @@ extension OutputSpan where Element: ~Copyable {
 
   /// Exclusively borrow the underlying initialized memory for mutation.
   @_alwaysEmitIntoClient
+  @_transparent
   public var mutableSpan: MutableSpan<Element> {
     @lifetime(&self)
     mutating get {
@@ -404,6 +410,7 @@ extension OutputSpan where Element: ~Copyable {
   /// this is an unsafe operation. Violating the invariants of `OutputSpan`
   /// may result in undefined behavior.
   @_alwaysEmitIntoClient
+  @_transparent
   @lifetime(self: copy self)
   public mutating func withUnsafeMutableBufferPointer<E: Error, R: ~Copyable>(
     _ body: (

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -340,12 +340,14 @@ extension RawSpan {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
+  @_transparent
   public var byteCount: Int { _count }
 
   /// A Boolean value indicating whether the span is empty.
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
+  @_transparent
   public var isEmpty: Bool { byteCount == 0 }
 
   /// The indices that are valid for subscripting the span, in ascending
@@ -531,6 +533,7 @@ extension RawSpan {
   ///   its execution.
   /// - Returns: The return value of the `body` closure parameter.
   @_alwaysEmitIntoClient
+  @_transparent
   public func withUnsafeBytes<E: Error, Result: ~Copyable>(
     _ body: (_ buffer: UnsafeRawBufferPointer) throws(E) -> Result
   ) throws(E) -> Result {

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -341,7 +341,7 @@ extension RawSpan {
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @_transparent
-  public var byteCount: Int { _count }
+  public var byteCount: Int { _assumeNonNegative(_count) }
 
   /// A Boolean value indicating whether the span is empty.
   ///

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -340,7 +340,7 @@ extension RawSpan {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @_transparent
+  @_semantics("fixed_storage.get_count")
   public var byteCount: Int { _assumeNonNegative(_count) }
 
   /// A Boolean value indicating whether the span is empty.


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift/pull/84312

**Explanation**: This PR adds @_transparent to a number of members of Span, RawSpan, MutableSpan, MutableRawSpan, OutputSpan and OutputRawSpan. The affected members are the closure-taking functions, the span-returning accessors, and some simple computed properties.

**Scope**: performance fix
**Risk**: low.
**Testing**: covered by existing tests
**Issue**: rdar://159802216
**Reviewer**: @Azoy 