### PR TITLE
[stdlib] mark some `bytes: RawSpan` accessors as unsafe

### DIFF
--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -262,6 +262,7 @@ extension MutableSpan where Element: BitwiseCopyable {
   /// - Returns: a RawSpan over the memory represented by this span
   @_alwaysEmitIntoClient
   @_transparent
+  @unsafe
   public var bytes: RawSpan {
     @lifetime(borrow self)
     borrowing get {

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -257,7 +257,7 @@ extension MutableSpan where Element: ~Copyable {
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableSpan where Element: BitwiseCopyable {
 
-  /// Construct a RawSpan over the memory represented by this span
+  /// Construct a raw span over the memory represented by this span.
   ///
   /// - Returns: a RawSpan over the memory represented by this span
   @_alwaysEmitIntoClient
@@ -270,7 +270,7 @@ extension MutableSpan where Element: BitwiseCopyable {
     }
   }
 
-  /// Construct a MutableRawSpan over the memory represented by this span
+  /// Construct a mutable raw span over the memory represented by this span.
   ///
   /// Mutating `self` through this property is unsafe because
   /// it is possible to mutate a byte so as to produce an invalid

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -508,9 +508,10 @@ extension Span where Element: BitwiseCopyable {
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension Span where Element: BitwiseCopyable {
 
+  @_alwaysEmitIntoClient
+  @_transparent
+  @unsafe
   public var bytes: RawSpan {
-    @_alwaysEmitIntoClient
-    @_transparent
     @lifetime(copy self)
     get {
       let rawSpan = RawSpan(_elements: self)

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -508,6 +508,9 @@ extension Span where Element: BitwiseCopyable {
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension Span where Element: BitwiseCopyable {
 
+  /// Construct a raw span over the memory represented by this span.
+  ///
+  /// - Returns: a RawSpan over the memory represented by this span
   @_alwaysEmitIntoClient
   @_transparent
   @unsafe


### PR DESCRIPTION
We should have marked these as unsafe in SE-0447 and SE-0467. Even if the memory is initialized from the point of view of using `Element` instances, it is not necessarily the case that every byte is initialized.

Addresses rdar://168547924