### PR TITLE
[cxx-interop] Import type members lazily

### DIFF
--- a/lib/ClangImporter/ClangLookup.cpp
+++ b/lib/ClangImporter/ClangLookup.cpp
@@ -64,6 +64,8 @@ using namespace swift;
 namespace {
 /// Collects name lookup results into the given tiny vector, for use in the
 /// various ClangImporter lookup routines.
+///
+/// Validates that the name we looked up matches the resulting imported name.
 class CollectLookupResults {
   DeclName name;
   TinyPtrVector<ValueDecl *> &result;
@@ -73,7 +75,8 @@ public:
       : name(name), result(result) {}
 
   void add(ValueDecl *imported) {
-    result.push_back(imported);
+    if (imported->getName().matchesRef(name))
+      result.push_back(imported);
 
     // Expand any macros introduced by the Clang importer.
     imported->visitAuxiliaryDecls([&](Decl *decl) {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -888,6 +888,38 @@ static bool areRecordFieldsComplete(const clang::CXXRecordDecl *decl) {
   return true;
 }
 
+/// Whether to import a member decl when importing its parent record.
+///
+/// In theory this should just be isa<clang::FieldDecl>(decl), but currently
+/// various parts of ClangImporter still relies on eagerly importing non-field
+/// members (e.g., for deriving protocol conformances, etc.). This helper
+/// function encapsulates those edge cases.
+static bool shouldEagerlyImportClangRecordMember(const clang::NamedDecl *decl) {
+  // Look through using decls to determine whether to import decl
+  while (auto *usd = dyn_cast<clang::UsingShadowDecl>(decl)) {
+    // VisitUsingShadowDecl() only imports types and non-constructor methods,
+    // so we mirror that logic here.
+    if (!isa<clang::TypeDecl, clang::CXXMethodDecl>(usd->getTargetDecl()))
+      break;
+    if (isa<clang::CXXConstructorDecl>(usd->getTargetDecl()))
+      break;
+    decl = usd->getTargetDecl();
+  }
+
+  if (auto *td = dyn_cast<clang::TagDecl>(decl);
+      td && !td->hasNameForLinkage()) {
+    // Need to import unnamed types eagerly, otherwise we cannot look them up
+    return true;
+  }
+
+  if (isa<clang::TypeDecl>(decl)) {
+    return false;
+  }
+
+  return true;
+}
+
+
 namespace {
   /// Search the member tables for this class and its superclasses and try to
   /// identify the nearest VarDecl that serves as a base for an override.  We
@@ -2480,6 +2512,9 @@ namespace {
             continue;
           }
         }
+
+        if (!shouldEagerlyImportClangRecordMember(nd))
+          continue;
 
         Decl *member = Impl.importDecl(nd, getActiveSwiftVersion());
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4465,6 +4465,27 @@ namespace {
     }
 
     Decl *VisitCXXMethodDecl(const clang::CXXMethodDecl *decl) {
+      // If the return type is a templated class, instantiate it. This must
+      // happen before we import the name of the method, as the name is affected
+      // by safety/unsafety of the return type. The safety detection logic
+      // (`IsSafeUseOfCxxDecl`) relies on the class being instantiated.
+      if (auto *returnedTmpl =
+              dyn_cast_or_null<clang::ClassTemplateSpecializationDecl>(
+                  desugarIfElaborated(decl->getReturnType())->getAsTagDecl());
+          returnedTmpl && !returnedTmpl->getDefinition()) {
+        Impl.getClangSema().InstantiateClassTemplateSpecialization(
+            decl->getLocation(),
+            const_cast<clang::ClassTemplateSpecializationDecl *>(returnedTmpl),
+            clang::TemplateSpecializationKind::TSK_ImplicitInstantiation,
+            /*Complain*/ false, /*PrimaryStrictPackMatch*/ false);
+        // N.B. InstantiateClassTemplateSpecialization() returns true if it
+        //      encountered an error while instantiating the returned template.
+        //      Even if it does, we don't bail out here, and defer error
+        //      handling to later. This is because that handler may involve
+        //      things like import a method and mark it as unavailable, rather
+        //      than simply not import it at all.
+      }
+
       // The static `operator ()` introduced in C++ 23 is still callable as an
       // instance operator in C++, and we want to preserve the ability to call
       // it as an instance method in Swift as well for source compatibility.

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -1964,6 +1964,26 @@ void importer::addEntryToLookupTable(SwiftLookupTable &table,
     }
   }
 
+  if (auto methodDecl = dyn_cast<clang::CXXMethodDecl>(named)) {
+    // If the return type is a template instantiation, it is not possible to
+    // determine safety/unsafety of the method without instantiating the
+    // template. Let's add both safe and unsafe versions of the name to the
+    // lookup table.
+    if (auto returnTy = desugarIfElaborated(methodDecl->getReturnType());
+        isa<clang::TemplateSpecializationType>(returnTy)) {
+      auto importedName = nameImporter.importName(methodDecl, currentVersion);
+      if (importedName && importedName.getDeclName().isSpecial()) {
+        if (StringRef id = importedName.getDeclName().getBaseIdentifier().str();
+            id.starts_with("__") && id.ends_with("Unsafe")) {
+          StringRef safeId = id.drop_front(2).drop_back(6);
+          table.addEntry(
+              DeclBaseName(nameImporter.getContext().getIdentifier(safeId)),
+              named, importedName.getEffectiveContext());
+        }
+      }
+    }
+  }
+
   // Class template instantiations are imported lazily, however, the lookup
   // table must include their mangled name (__CxxTemplateInst...) to make it
   // possible to find these decls during deserialization. For any C++ typedef

--- a/lib/ClangImporter/SwiftLookupTable.h
+++ b/lib/ClangImporter/SwiftLookupTable.h
@@ -283,7 +283,7 @@ const uint16_t SWIFT_LOOKUP_TABLE_VERSION_MAJOR = 1;
 /// Lookup table minor version number.
 ///
 /// When the format changes IN ANY WAY, this number should be incremented.
-const uint16_t SWIFT_LOOKUP_TABLE_VERSION_MINOR = 20; // 64-bit clang serialization IDs
+const uint16_t SWIFT_LOOKUP_TABLE_VERSION_MINOR = 21; // add both safe and unsafe names of C++ methods
 
 /// A lookup table that maps Swift names to the set of Clang
 /// declarations with that particular name.

--- a/test/Interop/Cxx/class/bad-type-members.swift
+++ b/test/Interop/Cxx/class/bad-type-members.swift
@@ -1,0 +1,259 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-clang -c -o /dev/null -Xclang -verify -I %t/Inputs %t/ok.cpp
+// RUN: %target-clang -c -o /dev/null -Xclang -verify=cxx-instantiation -I %t/Inputs %t/err.cpp
+// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}type.h %t%{fs-sep}ok.swift
+// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}type.h %t%{fs-sep}err.swift -verify-additional-prefix swift-
+
+// RUN: %target-swift-ide-test -print-module -module-to-print=Type -I %t/Inputs -source-filename=x -cxx-interoperability-mode=default | %FileCheck %s
+
+//--- Inputs/module.modulemap
+module Type {
+    header "type.h"
+    requires cplusplus
+}
+
+//--- Inputs/type.h
+#pragma once
+
+// cxx-instantiation-note@+3 {{template is declared here}}
+// cxx-instantiation-note@+2 {{template is declared here}}
+// cxx-instantiation-note@+1 {{template is declared here}}
+template <typename T> struct NeedsBool;
+
+template <> struct NeedsBool<bool> {};
+// CHECK:      struct NeedsBool<CBool> {
+// CHECK-NEXT:   init()
+// CHECK-NEXT: }
+
+struct Foo { using foo = int; };
+struct Bar {};
+struct Baz {};
+
+// expected-swift-note@+1 {{'NeedsFoo<Bar>' requested here}}
+template <typename T> struct NeedsFoo {
+  typename T::foo x;
+  // cxx-instantiation-error@-1 {{no type named 'foo' in 'Bar'}}
+  // expected-swift-error@-2 {{no type named 'foo' in 'Bar'}}
+  // cxx-instantiation-error@-3 {{no type named 'foo' in 'Baz'}}
+};
+// CHECK:      struct NeedsFoo<Foo> {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   init(x: Foo.foo)
+// CHECK-NEXT:   var x: Foo.foo
+// CHECK-NEXT: }
+
+// expected-swift-note@+2 {{declared here}}
+// expected-swift-note@+1 {{declared here}}
+struct UseMe {
+  using GoodBool = NeedsBool<bool>;
+  using GoodFoo = NeedsFoo<Foo>;
+
+  using BadBool = NeedsBool<int>;
+  using BadFoo = NeedsFoo<Bar>;
+  using BadFoo2 = NeedsFoo<Baz>;
+};
+// CHECK:      struct UseMe {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   typealias GoodBool = NeedsBool<CBool>
+// CHECK-NEXT:   typealias GoodFoo = NeedsFoo<Foo>
+// CHECK-NEXT: }
+
+// Test using shadow decls with type aliases
+// expected-swift-note@+2 {{declared here}}
+// expected-swift-note@+1 {{declared here}}
+struct Derived : UseMe {
+  using UseMe::GoodBool;
+  using UseMe::GoodFoo;
+  using UseMe::BadBool;
+  using UseMe::BadFoo2;
+};
+// CHECK:      struct Derived {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   typealias GoodBool = UseMe.GoodBool
+// CHECK-NEXT:   typealias GoodFoo = UseMe.GoodFoo
+// CHECK-NEXT: }
+
+// expected-swift-note@+1 {{declared here}}
+struct FwdContainer {
+  struct Forward;
+  using ForwardAlias = Forward;
+
+  // cxx-instantiation-note@+1 {{forward declaration of}}
+  struct NeverDefined;
+  using UndefinedAlias = NeverDefined;
+};
+struct FwdContainer::Forward {
+  int value;
+};
+// CHECK:      struct FwdContainer {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   struct Forward {
+// CHECK-NEXT:     init()
+// CHECK-NEXT:     init(value: Int32)
+// CHECK-NEXT:     var value: Int32
+// CHECK-NEXT:   }
+// CHECK-NEXT:   typealias ForwardAlias = FwdContainer.Forward
+// CHECK-NEXT: }
+
+// expected-swift-note@+2 {{declared here}}
+template <typename T, typename U>
+struct TemplateContainer {
+  using GoodAlias = NeedsBool<T>;
+  using BadAlias = NeedsBool<U>;
+};
+
+using TemplateContainerInst = TemplateContainer<bool, int>;
+// CHECK:      struct TemplateContainer<CBool, CInt> {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   typealias GoodAlias = NeedsBool<CBool>
+// CHECK-NEXT: }
+// CHECK-NEXT: typealias TemplateContainerInst = TemplateContainer<CBool, CInt>
+
+// cxx-instantiation-note@+2 {{forward declaration of}}
+// expected-swift-note@+1 {{forward declaration of}}
+struct IncompleteType;
+
+// Test type alias to template with invalid instantiation
+// expected-swift-note@+2 {{requested here}}
+template <typename T>
+struct RequiresComplete {
+  T value;
+  // cxx-instantiation-error@-1 {{field has incomplete type 'IncompleteType'}}
+  // expected-swift-error@-2 {{field has incomplete type 'IncompleteType'}}
+};
+
+// expected-swift-note@+1 {{declared here}}
+struct UsesInvalidTemplate {
+  using BadTemplate = RequiresComplete<IncompleteType>;
+};
+// CHECK:      struct UsesInvalidTemplate {
+// CHECK-NEXT:   init()
+// CHECK-NEXT: }
+
+// Test type alias to abstract class
+// expected-swift-note@+1 {{'init()' has been explicitly marked unavailable here}}
+struct Abstract {
+  // cxx-instantiation-note@+1 {{unimplemented pure virtual method}}
+  virtual void pureVirtual() = 0;
+};
+// CHECK:      struct Abstract {
+// CHECK-NEXT:   @available(*, unavailable, message: "constructors of abstract C++ classes are unavailable in Swift")
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   @available(*, unavailable, message: "virtual function is not available in Swift because it is pure")
+// CHECK-NEXT:   mutating func pureVirtual()
+// CHECK-NEXT: }
+
+struct UsesAbstract {
+  using AbstractAlias = Abstract;
+};
+// CHECK:      struct UsesAbstract {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   typealias AbstractAlias = Abstract
+// CHECK-NEXT: }
+
+//--- ok.cpp
+// expected-no-diagnostics
+#include <type.h>
+
+void ok(void) {
+  UseMe um;
+  UseMe::GoodBool gb;
+  UseMe::GoodFoo gf;
+
+  Derived dum;
+  Derived::GoodBool dgb;
+  Derived::GoodFoo dgf;
+
+  FwdContainer fc;
+  FwdContainer::ForwardAlias fa;
+
+  TemplateContainerInst tci;
+  TemplateContainerInst::GoodAlias tga;
+
+  UsesInvalidTemplate uit;
+  UsesAbstract ua;
+}
+
+//--- err.cpp
+#include <type.h>
+
+void err(void) {
+  UseMe um;
+  UseMe::GoodBool gb;
+  UseMe::GoodFoo gf;
+  UseMe::BadBool bb; // cxx-instantiation-error {{implicit instantiation of undefined template}}
+  UseMe::BadFoo bf;  // cxx-instantiation-note {{requested here}}
+
+  Derived dum;
+  Derived::GoodBool dgb;
+  Derived::GoodFoo dgf;
+  Derived::BadBool dbb; // cxx-instantiation-error {{implicit instantiation of undefined template}}
+  Derived::BadFoo2 dbf; // cxx-instantiation-note {{requested here}}
+
+  FwdContainer fc;
+  FwdContainer::ForwardAlias fa;
+  FwdContainer::UndefinedAlias fu; // cxx-instantiation-error {{variable has incomplete type}}
+
+  TemplateContainerInst tci;
+  TemplateContainerInst::GoodAlias tga;
+  TemplateContainerInst::BadAlias tba; // cxx-instantiation-error {{implicit instantiation of undefined template}}
+
+  UsesInvalidTemplate uit;
+  UsesInvalidTemplate::BadTemplate ubt; // cxx-instantiation-note {{requested here}}
+
+  UsesAbstract ua;
+  UsesAbstract::AbstractAlias uaa; // cxx-instantiation-error {{is an abstract class}}
+}
+
+//--- ok.swift
+import Type
+
+func ok() {
+  let _: UseMe = UseMe()
+  let _: UseMe.GoodBool = .init()
+  let _: UseMe.GoodFoo = .init()
+
+  let _: Derived = .init()
+  let _: Derived.GoodBool = .init()
+  let _: Derived.GoodFoo = .init()
+
+  let _: FwdContainer = .init()
+  let _: FwdContainer.ForwardAlias = .init()
+
+  let _: TemplateContainerInst = .init()
+  let _: TemplateContainerInst.GoodAlias = .init()
+
+  let _: UsesInvalidTemplate = .init()
+  let _: UsesAbstract = .init()
+}
+
+//--- err.swift
+import Type
+
+func err() {
+  let _: UseMe = UseMe()
+  let _: UseMe.GoodBool = .init()
+  let _: UseMe.GoodFoo = .init()
+  let _: UseMe.BadBool = .init() // expected-swift-error {{not a member type of struct}}
+  let _: UseMe.BadFoo = .init()  // expected-swift-error {{not a member type of struct}}
+
+  let _: Derived = .init()
+  let _: Derived.GoodBool = .init()
+  let _: Derived.GoodFoo = .init()
+  let _: Derived.BadBool = .init() // expected-swift-error {{not a member type of struct}}
+  let _: Derived.BadFoo = .init()  // expected-swift-error {{not a member type of struct}}
+
+  let _: FwdContainer = .init()
+  let _: FwdContainer.ForwardAlias = .init()
+  let _: FwdContainer.UndefinedAlias = .init() // expected-swift-error {{not a member type of struct}}
+
+  let _: TemplateContainerInst = .init()
+  let _: TemplateContainerInst.GoodAlias = .init()
+  let _: TemplateContainerInst.BadAlias = .init() // expected-swift-error {{not a member type of struct}}
+
+  let _: UsesInvalidTemplate = .init()
+  let _: UsesInvalidTemplate.BadTemplate = .init() // expected-swift-error {{not a member type of struct}}
+  let _: UsesAbstract = .init()
+  let _: UsesAbstract.AbstractAlias = .init() // expected-swift-error {{constructors of abstract C++ classes are unavailable}}
+}

--- a/test/Interop/Cxx/stdlib/libstdcxx-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/libstdcxx-module-interface.swift
@@ -12,10 +12,10 @@
 
 // CHECK-STD: enum std {
 // CHECK-STRING:   struct basic_string<CChar, std{{(.__cxx11)?}}.char_traits<CChar>, std{{(.__cxx11)?}}.allocator<CChar>> : CxxMutableRandomAccessCollection {
-// CHECK-STRING:     typealias value_type = std.char_traits<CChar>.char_type
+// CHECK-STRING:     typealias value_type = CChar
 // CHECK-STRING:   }
 // CHECK-STRING:   struct basic_string<CWideChar, std{{(.__cxx11)?}}.char_traits<CWideChar>, std{{(.__cxx11)?}}.allocator<CWideChar>> : CxxMutableRandomAccessCollection {
-// CHECK-STRING:     typealias value_type = std.char_traits<CWideChar>.char_type
+// CHECK-STRING:     typealias value_type = CWideChar
 // CHECK-STRING:   }
 
 // CHECK-TO-STRING:   static func to_string(_ __val: Int32) -> std{{(.__cxx11)?}}.string

--- a/test/Interop/Cxx/templates/invalid-return-type.swift
+++ b/test/Interop/Cxx/templates/invalid-return-type.swift
@@ -1,0 +1,56 @@
+// RUN: split-file %s %t
+// RUN: %target-clang -c -o /dev/null -Xclang -verify -I %t/Inputs %t/cxx.cpp
+// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}CxxHeader.h %t%{fs-sep}ok.swift
+// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}CxxHeader.h %t%{fs-sep}err.swift -verify-additional-prefix err-
+// RUN: %target-swift-ide-test -print-module -module-to-print=CxxModule -I %t/Inputs -source-filename=x -cxx-interoperability-mode=default | %FileCheck %t/Inputs/CxxHeader.h
+
+//--- Inputs/module.modulemap
+module CxxModule {
+    requires cplusplus
+    header "CxxHeader.h"
+}
+
+//--- Inputs/CxxHeader.h
+#pragma once
+
+
+template <class T> struct OnlyChar;
+template <> struct OnlyChar<char> {};
+
+struct S {
+  S() = default;
+
+  OnlyChar<int> Err() const; // cannot be called (incomplete return type)
+  // expected-err-note@-1 {{explicitly marked unavailable here}}
+
+  OnlyChar<char> Ok() const;
+};
+
+// CHECK:      struct S {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   func Err() -> Never
+// CHECK-NEXT:   func Ok()
+// CHECK:      }
+
+//--- cxx.cpp
+// expected-no-diagnostics
+#include <CxxHeader.h>
+void IsOk(void) {
+  S Is;
+  Is.Ok();
+}
+
+//--- ok.swift
+import CxxModule
+func IsOk() {
+  let Is = S()  // We can instantiate it
+  Is.Ok()       // We can call it
+}
+
+//--- err.swift
+import CxxModule
+func IsErr() {
+  let Is = S()  // We can instantiate it
+  Is.Err()      // expected-error {{return type is unavailable in Swift}}
+  Is.Ok()       // We can still call it
+}

--- a/test/Interop/Cxx/templates/using-return-type.swift
+++ b/test/Interop/Cxx/templates/using-return-type.swift
@@ -1,0 +1,120 @@
+// C++ methods that return iterators are imported with an unsafe name mangling,
+// i.e., '__{{METHOD_NAME}}Unsafe'.
+//
+// In this test, we ensure that the iterator-detection logic does not depend on
+// whether the iterator type happens to be instantiated at the time we determine
+// the imported name of the C++ method.
+
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -typecheck -verify %t%{fs-sep}main.swift \
+// RUN:   -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}CxxHeader.h \
+// RUN:   -suppress-notes \
+// RUN:   -cxx-interoperability-mode=default
+
+//--- Inputs/module.modulemap
+module CxxModule {
+    requires cplusplus
+    header "CxxHeader.h"
+}
+
+//--- Inputs/CxxHeader.h
+#pragma once
+
+#include <iterator>
+
+template <typename T> struct IteratorT {
+  // Having this makes (each instance of) IteratorT considered an iterator
+  using iterator_category = std::input_iterator_tag;
+};
+
+template <typename T> struct IdentityT {
+  T t;
+};
+
+// Some types to instantiate IteratorT with
+struct A {};
+struct B {};
+struct C {};
+struct D {};
+
+struct AA {
+  IteratorT<A> getIter() const;
+  IdentityT<A> getValue() const;
+};
+
+struct BB {
+  using iter = IteratorT<B>;
+  using value = IdentityT<B>;
+  iter getIter() const;
+  value getValue() const;
+};
+
+struct CC {
+  using iter = IteratorT<C>;
+  using value = IdentityT<C>;
+  IteratorT<C> getIter() const;
+  IdentityT<C> getValue() const;
+};
+
+struct DD {
+  IteratorT<D> getIter() const;
+  IdentityT<D> getValue() const;
+  using iter = IteratorT<D>;
+  using value = IdentityT<D>;
+};
+
+struct AAA : AA {};
+struct BBB : BB {};
+struct CCC : CC {};
+struct DDD : DD {};
+
+//--- main.swift
+import CxxModule
+
+let aa = AA()
+aa.getIter() // expected-error {{has no member 'getIter'}}
+aa.__getIterUnsafe()
+aa.getValue()
+aa.__getValueUnsafe() // expected-error {{has no member '__getValueUnsafe'}}
+
+let bb = BB()
+bb.getIter() // expected-error {{has no member 'getIter'}}
+bb.__getIterUnsafe()
+bb.getValue()
+bb.__getValueUnsafe() // expected-error {{has no member '__getValueUnsafe'}}
+
+let cc = CC()
+cc.getIter() // expected-error {{has no member 'getIter'}}
+cc.__getIterUnsafe()
+cc.getValue()
+cc.__getValueUnsafe() // expected-error {{has no member '__getValueUnsafe'}}
+
+let dd = DD()
+dd.getIter() // expected-error {{has no member 'getIter'}}
+dd.__getIterUnsafe()
+dd.getValue()
+dd.__getValueUnsafe() // expected-error {{has no member '__getValueUnsafe'}}
+
+let aaa = AAA()
+aaa.getIter() // expected-error {{has no member 'getIter'}}
+aaa.__getIterUnsafe()
+aaa.getValue()
+aaa.__getValueUnsafe() // expected-error {{has no member '__getValueUnsafe'}}
+
+let bbb = BBB()
+bbb.getIter() // expected-error {{has no member 'getIter'}}
+bbb.__getIterUnsafe()
+bbb.getValue()
+bbb.__getValueUnsafe() // expected-error {{has no member '__getValueUnsafe'}}
+
+let ccc = CCC()
+ccc.getIter() // expected-error {{has no member 'getIter'}}
+ccc.__getIterUnsafe()
+ccc.getValue()
+ccc.__getValueUnsafe() // expected-error {{has no member '__getValueUnsafe'}}
+
+let ddd = DDD()
+ddd.getIter() // expected-error {{has no member 'getIter'}}
+ddd.__getIterUnsafe()
+ddd.getValue()
+ddd.__getValueUnsafe() // expected-error {{has no member '__getValueUnsafe'}}


### PR DESCRIPTION
In theory, we only need to import record fields eagerly (to compute record layout); other members can be imported lazily, i.e., only when they are used in Swift.

Currently, ClangImporter still relies on eagerly importing all members, so we need to ease into lazy member imports gradually. For now, only make type decls lazy.

rdar://156949141