### PR TITLE
Sema: Disjunction pruning optimization

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -1012,6 +1012,10 @@ namespace swift {
 
     /// Enable the experimental "prepared overloads" optimization.
     bool SolverEnablePreparedOverloads = true;
+
+    /// Enable experimental optimization to disable contradictory disjunction
+    /// choices.
+    bool SolverPruneDisjunctions = false;
   };
 
   /// Options for controlling the behavior of the Clang importer.

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -922,6 +922,12 @@ def solver_disable_prepared_overloads : Flag<["-"], "solver-disable-prepared-ove
 def solver_enable_prepared_overloads : Flag<["-"], "solver-enable-prepared-overloads">,
   HelpText<"Enable experimental prepared overloads optimization">;
 
+def solver_disable_prune_disjunctions : Flag<["-"], "solver-disable-prune-disjunctions">,
+  HelpText<"Disable experimental disjunction pruning algorithm for lookahead in the solver">;
+
+def solver_enable_prune_disjunctions : Flag<["-"], "solver-enable-prune-disjunctions">,
+  HelpText<"Enable experimental disjunction pruning algorithm for lookahead in the solver">;
+
 def solver_disable_splitter : Flag<["-"], "solver-disable-splitter">,
   HelpText<"Disable the component splitter phase of expression type checking">;
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5164,8 +5164,7 @@ public:
 
   /// Determine whether given type variable with its set of bindings is viable
   /// to be attempted on the next step of the solver.
-  const BindingSet *determineBestBindings(
-      llvm::function_ref<void(const BindingSet &)> onCandidate);
+  const BindingSet *determineBestBindings();
 
   /// Get bindings for the given type variable based on current
   /// state of the constraint system.

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5249,6 +5249,9 @@ private:
   std::optional<std::pair<Constraint *, llvm::TinyPtrVector<Constraint *>>>
   selectDisjunction();
 
+  void pruneDisjunction(Constraint *disjunction,
+                        Constraint *applicableFn);
+
   /// Pick a conjunction from the InactiveConstraints list.
   ///
   /// \returns The selected conjunction.

--- a/lib/AST/Requirement.cpp
+++ b/lib/AST/Requirement.cpp
@@ -265,7 +265,7 @@ int Requirement::compare(const Requirement &other) const {
 
   int compareProtos =
     TypeDecl::compare(getProtocolDecl(), other.getProtocolDecl());
-  assert(compareProtos != 0 && "Duplicate conformance requirements");
+  ASSERT(compareProtos != 0 && "Duplicate conformance requirements");
 
   return compareProtos;
 }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2116,6 +2116,10 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
       Args.hasArg(OPT_solver_disable_prepared_overloads))
     Opts.SolverEnablePreparedOverloads = Args.hasArg(OPT_solver_enable_prepared_overloads);
 
+  if (Args.hasArg(OPT_solver_enable_prune_disjunctions) ||
+      Args.hasArg(OPT_solver_disable_prune_disjunctions))
+    Opts.SolverPruneDisjunctions = Args.hasArg(OPT_solver_enable_prune_disjunctions);
+
   if (FrontendOpts.RequestedAction == FrontendOptions::ActionType::Immediate)
     Opts.DeferToRuntime = true;
 

--- a/lib/Sema/CMakeLists.txt
+++ b/lib/Sema/CMakeLists.txt
@@ -8,6 +8,7 @@ add_swift_host_library(swiftSema STATIC
   CSBindings.cpp
   CSSyntacticElement.cpp
   CSGen.cpp
+  CSLookahead.cpp
   CSRanking.cpp
   CSSimplify.cpp
   CSSolver.cpp

--- a/lib/Sema/CSLookahead.cpp
+++ b/lib/Sema/CSLookahead.cpp
@@ -1,0 +1,483 @@
+//===--- CSLookahead.cpp - Experimental Optimization ----------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements FOO.
+//
+//===----------------------------------------------------------------------===//
+
+#include "OpenedExistentials.h"
+#include "TypeChecker.h"
+#include "swift/AST/ConformanceLookup.h"
+#include "swift/AST/Decl.h"
+#include "swift/AST/ExistentialLayout.h"
+#include "swift/AST/Expr.h"
+#include "swift/AST/GenericSignature.h"
+#include "swift/Basic/OptionSet.h"
+#include "swift/Sema/ConstraintGraph.h"
+#include "swift/Sema/ConstraintSystem.h"
+#include "swift/Sema/CSBindings.h"
+#include "llvm/ADT/BitVector.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/PointerIntPair.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/TinyPtrVector.h"
+#include "llvm/Support/raw_ostream.h"
+#include <cstddef>
+#include <functional>
+
+using namespace swift;
+using namespace constraints;
+
+enum ConflictFlag : unsigned {
+  Category = 1 << 0,
+  Exact = 1 << 1,
+  Nominal = 1 << 2,
+  Class = 1 << 3,
+  Structural = 1 << 4,
+  Array = 1 << 5,
+  Dictionary = 1 << 6,
+  Set = 1 << 7,
+  Optional = 1 << 8,
+  Double = 1 << 9,
+  Conformance = 1 << 10,
+  Mutability = 1 << 11
+};
+using ConflictReason = OptionSet<ConflictFlag>;
+
+static bool shouldBeConservativeWithProto(ProtocolDecl *proto) {
+  if (proto->isMarkerProtocol())
+    return true;
+
+  if (proto->isObjC())
+    return true;
+
+  return false;
+}
+
+static ConflictReason canPossiblyConvertTo(
+    ConstraintSystem &cs,
+    Type lhs, Type rhs,
+    GenericSignature sig) {
+  auto lhsKind = inference::getConversionBehavior(lhs);
+  auto rhsKind = inference::getConversionBehavior(rhs);
+
+  // Conversion between two types with the same conversion behavior.
+  if (lhsKind == rhsKind) {
+    switch (lhsKind) {
+    case inference::ConversionBehavior::None:
+      if (!lhs->hasTypeVariable() && !lhs->hasTypeParameter() &&
+          !rhs->hasTypeVariable() && !rhs->hasTypeParameter()) {
+        if (!lhs->isEqual(rhs))
+          return ConflictFlag::Exact;
+      }
+
+      if (lhs->getAnyNominal() != rhs->getAnyNominal())
+        return ConflictFlag::Nominal;
+      break;
+
+    case inference::ConversionBehavior::Class: {
+      auto *lhsDecl = lhs->getClassOrBoundGenericClass();
+      auto *rhsDecl = rhs->getClassOrBoundGenericClass();
+      if (!rhsDecl->isSuperclassOf(lhsDecl))
+        return ConflictFlag::Class;
+
+      break;
+    }
+
+    case inference::ConversionBehavior::Double:
+      // There are only two types with this behavior, and they convert
+      // to each other.
+      break;
+
+    case inference::ConversionBehavior::AnyHashable:
+      // AnyHashable converts to AnyHashable.
+      break;
+
+    case inference::ConversionBehavior::Pointer:
+      // FIXME: Implement
+      break;
+
+    case inference::ConversionBehavior::Array: {
+      auto subResult = canPossiblyConvertTo(
+          cs,
+          lhs->getArrayElementType(),
+          rhs->getArrayElementType(), sig);
+      if (subResult)
+        return subResult | ConflictFlag::Array;
+
+      break;
+    }
+    case inference::ConversionBehavior::Dictionary: {
+      // FIXME: Implement
+      break;
+    }
+    case inference::ConversionBehavior::Set: {
+      // FIXME: Implement
+      break;
+    }
+    case inference::ConversionBehavior::Optional: {
+      // Optional-to-optional conversion.
+      auto argObjectType = lhs->getOptionalObjectType();
+      auto objectType = rhs->getOptionalObjectType();
+      auto optionalToOptional = canPossiblyConvertTo(
+          cs, argObjectType, objectType, sig);
+
+      if (optionalToOptional)
+        return optionalToOptional | ConflictFlag::Optional;
+      break;
+    }
+    case inference::ConversionBehavior::Structural:
+      if (lhs->getCanonicalType()->getKind()
+          != rhs->getCanonicalType()->getKind())
+        return ConflictFlag::Structural;
+      break;
+    case inference::ConversionBehavior::Unknown:
+      break;
+    }
+
+  // Handle case where the kinds don't match, and we're not converting
+  // from an unknown type.
+  } else if (lhsKind != inference::ConversionBehavior::Unknown) {
+    switch (rhsKind) {
+    case inference::ConversionBehavior::Class: {
+      // Archetypes can convert to classes.
+      if (lhs->is<ArchetypeType>()) {
+        auto superclassType = lhs->getSuperclass();
+        if (!superclassType)
+          return ConflictFlag::Class;
+
+        return canPossiblyConvertTo(cs, superclassType, rhs, sig);
+      }
+
+      // Protocol metatypes can convert to instances of the Protocol class
+      // on Objective-C interop platforms.
+      if (lhs->is<MetatypeType>())
+        break;
+
+      // Nothing else converts to a class except for existentials
+      // (which are 'ConversionBehavior::Unknown').
+      return ConflictFlag::Category;
+    }
+
+    case inference::ConversionBehavior::AnyHashable:
+      // FIXME: Check if lhs definitely not Hashable
+      break;
+
+    case inference::ConversionBehavior::Pointer:
+      // FIXME: Array, String, InOutType convert to pointers
+      break;
+
+    case inference::ConversionBehavior::Optional: {
+      // We have a non-optional on the left. Try value-to-optional.
+      auto objectType = rhs->getOptionalObjectType();
+      auto valueToOptional = canPossiblyConvertTo(
+          cs, lhs, objectType, sig);
+      if (valueToOptional)
+        return valueToOptional | ConflictFlag::Optional;
+
+      break;
+    }
+
+    case inference::ConversionBehavior::None:
+    case inference::ConversionBehavior::Double:
+    case inference::ConversionBehavior::Array:
+    case inference::ConversionBehavior::Dictionary:
+    case inference::ConversionBehavior::Set:
+    case inference::ConversionBehavior::Structural:
+      return ConflictFlag::Category;
+
+    case inference::ConversionBehavior::Unknown:
+      break;
+    }
+  }
+
+  if (sig) {
+    // If '$LHS conv $RHS' and '$LHS conforms P', does it follow
+    // that '$RHS conforms P'?
+    auto isConformanceTransitiveOnLHS = [lhsKind, lhs]() -> bool {
+      // FIXME: String converts to UnsafePointer<UInt8> which
+      // can satisfy a conformance to P that String does not
+      // satisfy. Encode this more thoroughly.
+      if (lhsKind == inference::ConversionBehavior::None)
+        return !lhs->isString();
+
+      return false;
+    };
+
+    if (rhs->isTypeParameter() &&
+        isConformanceTransitiveOnLHS()) {
+      bool failed = llvm::any_of(
+          sig->getRequiredProtocols(rhs),
+          [&](ProtocolDecl *proto) {
+            if (shouldBeConservativeWithProto(proto))
+              return false;
+            return !lookupConformance(lhs, proto);
+          });
+      if (failed)
+        return ConflictFlag::Conformance;
+    }
+
+    // If '$LHS conv $RHS' and '$RHS conforms P', does it follow
+    // that '$LHS conforms P'?
+    auto isConformanceTransitiveOnRHS = [rhsKind]() -> bool {
+      if (rhsKind == inference::ConversionBehavior::None ||
+          rhsKind == inference::ConversionBehavior::Array ||
+          rhsKind == inference::ConversionBehavior::Dictionary ||
+          rhsKind == inference::ConversionBehavior::Set)
+        return true;
+
+      return false;
+    };
+
+    if (lhs->isTypeParameter() &&
+        isConformanceTransitiveOnRHS()) {
+      bool failed = llvm::any_of(
+          sig->getRequiredProtocols(lhs),
+          [&](ProtocolDecl *proto) {
+            if (shouldBeConservativeWithProto(proto))
+              return false;
+            return !lookupConformance(rhs, proto);
+          });
+      if (failed)
+        return ConflictFlag::Conformance;
+    }
+  }
+
+  /*llvm::errs() << "unknown conversion:\n";
+  lhs->dump(llvm::errs());
+  rhs->dump(llvm::errs());*/
+  return std::nullopt;
+}
+
+static void forEachDisjunctionChoice(
+    ConstraintSystem &cs, Constraint *disjunction,
+    llvm::function_ref<void(Constraint *, ValueDecl *decl, FunctionType *)>
+        callback) {
+  for (auto constraint : disjunction->getNestedConstraints()) {
+    if (constraint->isDisabled())
+      continue;
+
+    if (constraint->getKind() != ConstraintKind::BindOverload)
+      continue;
+
+    auto choice = constraint->getOverloadChoice();
+    auto *decl = choice.getDeclOrNull();
+    if (!decl)
+      continue;
+
+    Type overloadType = cs.getEffectiveOverloadType(
+        disjunction->getLocator(), choice,
+        /*allowMembers=*/true, constraint->getDeclContext());
+
+    if (!overloadType || !overloadType->is<FunctionType>())
+      continue;
+
+    callback(constraint, decl, overloadType->castTo<FunctionType>());
+  }
+}
+
+static void pruneDisjunctionImpl(
+    ConstraintSystem &cs, Constraint *disjunction,
+    Constraint *applicableFn) {
+  if (!cs.getASTContext().TypeCheckerOpts.SolverPruneDisjunctions)
+    return;
+
+  if (cs.shouldAttemptFixes())
+    return;
+
+  if (!applicableFn)
+    return;
+
+  auto argFuncType =
+      applicableFn->getFirstType()->castTo<FunctionType>();
+
+  auto argumentList = cs.getArgumentList(applicableFn->getLocator());
+  ASSERT(argumentList);
+
+  for (const auto &argument : *argumentList) {
+    if (auto *expr = argument.getExpr()) {
+      // Directly `<#...#>` or has one inside.
+      if (isa<CodeCompletionExpr>(expr) ||
+          cs.containsIDEInspectionTarget(expr))
+        return;
+    }
+  }
+
+  SmallVector<FunctionType::Param, 8> argsWithLabels;
+  {
+    argsWithLabels.append(argFuncType->getParams().begin(),
+                          argFuncType->getParams().end());
+    FunctionType::relabelParams(argsWithLabels, argumentList);
+  }
+
+  SmallVector<Type, 2> argTypes;
+  argTypes.resize(argFuncType->getNumParams());
+
+  for (unsigned i = 0, n = argFuncType->getNumParams(); i != n; ++i) {
+    const auto &param = argFuncType->getParams()[i];
+    auto argType = cs.simplifyType(param.getPlainType());
+    // FIXME: This is gross, I know. The purpose is just to wrap the type
+    // with something that will give it ConversionBehavior::Unknown.
+    if (param.isInOut())
+      argType = InOutType::get(argType);
+    argTypes[i] = argType;
+  }
+
+  auto resultType = cs.simplifyType(argFuncType->getResult());
+
+  auto matchArguments = [&](OverloadChoice choice, FunctionType *overloadType)
+    -> std::optional<MatchCallArgumentResult> {
+        auto *decl = choice.getDeclOrNull();
+    assert(decl);
+
+    auto hasAppliedSelf =
+        decl->hasCurriedSelf() &&
+        doesMemberRefApplyCurriedSelf(choice.getBaseType(), decl);
+
+    ParameterListInfo paramListInfo(overloadType->getParams(), decl,
+                                    hasAppliedSelf);
+
+    MatchCallArgumentListener listener;
+    return matchCallArguments(argsWithLabels, overloadType->getParams(),
+                              paramListInfo,
+                              argumentList->getFirstTrailingClosureIndex(),
+                              /*allow fixes*/ false, listener, std::nullopt);
+  };
+
+  forEachDisjunctionChoice(
+    cs, disjunction,
+    [&](Constraint *choice, ValueDecl *decl, FunctionType *overloadType) {
+      GenericSignature genericSig;
+      {
+        if (auto *GF = dyn_cast<AbstractFunctionDecl>(decl)) {
+          genericSig = GF->getGenericSignature();
+        } else if (auto *SD = dyn_cast<SubscriptDecl>(decl)) {
+          genericSig = SD->getGenericSignature();
+        }
+      }
+
+      auto matchings =
+          matchArguments(choice->getOverloadChoice(), overloadType);
+      if (!matchings) {
+        if (cs.isDebugMode()) {
+          llvm::errs().indent(cs.solverState->getCurrentIndent())
+              << "<<< Matching failed with ";
+          choice->print(llvm::errs(),
+                        &cs.getASTContext().SourceMgr,
+                        cs.solverState->getCurrentIndent());
+          llvm::errs() << "\n";
+        }
+        return;
+      }
+
+      // This is important for SIMD operators in particular because
+      // a lot of their overloads have same-type requires to a concrete
+      // type:  `<Scalar == (U)Int*>(_: SIMD*<Scalar>, ...) -> ...`.
+      if (genericSig) {
+        overloadType = overloadType->getReducedType(genericSig)
+                           ->castTo<FunctionType>();
+      }
+
+      ConflictReason reason;
+      for (unsigned paramIdx = 0, n = overloadType->getNumParams();
+           paramIdx != n; ++paramIdx) {
+        const auto &param = overloadType->getParams()[paramIdx];
+
+        auto argIndices = matchings->parameterBindings[paramIdx];
+        switch (argIndices.size()) {
+        case 0:
+          // Current parameter is defaulted, mark and continue.
+          continue;
+
+        case 1:
+          // One-to-one match between argument and parameter.
+          break;
+
+        default:
+          // Cannot deal with multiple possible matchings at the moment.
+          continue;
+        }
+
+        auto argIdx = argIndices.front();
+        ASSERT(argIdx < argFuncType->getNumParams());
+        auto argType = argTypes[argIdx];
+        ASSERT(argType);
+
+        const auto paramFlags = param.getParameterFlags();
+
+        // If parameter is variadic we cannot compare because we don't know
+        // real arity.
+        if (paramFlags.isVariadic())
+          continue;
+
+        auto paramType = param.getPlainType();
+
+        if (paramFlags.isAutoClosure())
+          paramType = paramType->castTo<AnyFunctionType>()->getResult();
+
+        // `inout` parameter accepts only l-value argument.
+        if (paramFlags.isInOut() && !argType->is<LValueType>()) {
+          // reason |= ConflictReason::Mutability;
+        }
+
+        reason |= canPossiblyConvertTo(cs, argType, paramType, genericSig);
+      }
+
+      auto overloadResultType = overloadType->getResult();
+      reason |= canPossiblyConvertTo(cs, overloadResultType, resultType, genericSig);
+
+      if (reason) {
+        if (cs.isDebugMode()) {
+          llvm::errs().indent(cs.solverState->getCurrentIndent() + 4)
+              << "(disabled choice ";
+          choice->print(llvm::errs(),
+                        &cs.getASTContext().SourceMgr,
+                        cs.solverState->getCurrentIndent());
+          llvm::errs() << " because";
+          if (reason.contains(ConflictFlag::Category))
+            llvm::errs() << " category";
+          if (reason.contains(ConflictFlag::Exact))
+            llvm::errs() << " exact";
+          if (reason.contains(ConflictFlag::Nominal))
+            llvm::errs() << " nominal";
+          if (reason.contains(ConflictFlag::Class))
+            llvm::errs() << " class";
+          if (reason.contains(ConflictFlag::Structural))
+            llvm::errs() << " structural";
+          if (reason.contains(ConflictFlag::Array))
+            llvm::errs() << " array";
+          if (reason.contains(ConflictFlag::Dictionary))
+            llvm::errs() << " dictionary";
+          if (reason.contains(ConflictFlag::Set))
+            llvm::errs() << " set";
+          if (reason.contains(ConflictFlag::Optional))
+            llvm::errs() << " optional";
+          if (reason.contains(ConflictFlag::Structural))
+            llvm::errs() << " structural";
+          if (reason.contains(ConflictFlag::Conformance))
+            llvm::errs() << " conformance";
+          if (reason.contains(ConflictFlag::Mutability))
+            llvm::errs() << " mutability";
+          llvm::errs() << ")\n";
+        }
+
+        if (cs.solverState)
+          cs.solverState->disableConstraint(choice);
+        else
+          choice->setDisabled();
+      }
+    });
+}
+
+void ConstraintSystem::pruneDisjunction(Constraint *disjunction, Constraint *applicableFn) {
+  pruneDisjunctionImpl(*this, disjunction, applicableFn);
+}

--- a/lib/Sema/CSOptimizer.cpp
+++ b/lib/Sema/CSOptimizer.cpp
@@ -1912,6 +1912,7 @@ ConstraintSystem::selectDisjunction() {
         applicableFn.get()->getFirstType()->getAs<FunctionType>();
     }
 
+    pruneDisjunction(disjunction, applicableFn.getPtrOrNull());
     auto info = computeDisjunctionInfo(*this, disjunctions, index, favorings);
     favorings.try_emplace(disjunction, info);
 

--- a/lib/Sema/CSOptimizer.cpp
+++ b/lib/Sema/CSOptimizer.cpp
@@ -1960,8 +1960,11 @@ ConstraintSystem::selectDisjunction() {
     unsigned firstActive = first->countActiveNestedConstraints();
     unsigned secondActive = second->countActiveNestedConstraints();
 
-    if (firstActive == 1 || secondActive == 1)
-      return secondActive != 1;
+    // A disjunction where all choices have been disabled allows us
+    // to immediately fail. A disjunction with one choice is a
+    // forced move.
+    if ((firstActive <= 1) || (secondActive <= 1))
+      return firstActive < secondActive;
 
     if (auto preference = isPreferable(*this, first, second))
       return preference.value();

--- a/lib/Sema/CSOptimizer.cpp
+++ b/lib/Sema/CSOptimizer.cpp
@@ -1790,14 +1790,6 @@ static DisjunctionInfo computeDisjunctionInfo(
         }
       });
 
-  if (cs.isDebugMode()) {
-    llvm::errs().indent(cs.solverState->getCurrentIndent())
-        << "<<< Disjunction "
-        << disjunction->getNestedConstraints()[0]->getFirstType()->getString(
-               PrintOptions::forDebugging())
-        << " with score " << bestScore << "\n";
-  }
-
   // Determine if the score and favoring decisions here are
   // based only on "speculative" sources i.e. inference from
   // literals.
@@ -1819,83 +1811,6 @@ static DisjunctionInfo computeDisjunctionInfo(
   }
 
   return info.build();
-}
-
-/// Given a set of disjunctions, attempt to determine
-/// favored choices in the current context.
-static void determineBestChoicesInContext(
-    ConstraintSystem &cs, SmallVectorImpl<Constraint *> &disjunctions,
-    llvm::DenseMap<Constraint *, DisjunctionInfo> &result) {
-  unsigned bestOverallScore = 0;
-
-  for (auto index : indices(disjunctions)) {
-    auto info = computeDisjunctionInfo(cs, disjunctions, index, result);
-    bestOverallScore = std::max(bestOverallScore, info.Score.value_or(0));
-    result.try_emplace(disjunctions[index], info);
-  }
-
-  if (cs.isDebugMode() && bestOverallScore > 0) {
-    PrintOptions PO = PrintOptions::forDebugging();
-
-    auto getLogger = [&](unsigned extraIndent = 0) -> llvm::raw_ostream & {
-      return llvm::errs().indent(cs.solverState->getCurrentIndent() +
-                                 extraIndent);
-    };
-
-    {
-      auto &log = getLogger();
-      log << "(Optimizing disjunctions: [";
-
-      interleave(
-          disjunctions,
-          [&](const auto *disjunction) {
-            log << disjunction->getNestedConstraints()[0]
-                       ->getFirstType()
-                       ->getString(PO);
-          },
-          [&]() { log << ", "; });
-
-      log << "]\n";
-    }
-
-    getLogger(/*extraIndent=*/4)
-        << "Best overall score = " << bestOverallScore << '\n';
-
-    for (auto *disjunction : disjunctions) {
-      auto found = result.find(disjunction);
-
-      getLogger(/*extraIndent=*/4)
-          << "[Disjunction '"
-          << disjunction->getNestedConstraints()[0]->getFirstType()->getString(
-                 PO);
-
-      if (found != result.end()) {
-        auto &entry = found->second;
-        if (entry.Score.has_value()) {
-          getLogger(/*extraIndent=*/4)
-              << "' with score = " << entry.Score.value_or(0) << '\n';
-        } else {
-          getLogger(/*extraIndent=*/4)
-              << "' without score\n";
-        }
-
-        for (const auto *choice : entry.FavoredChoices) {
-          auto &log = getLogger(/*extraIndent=*/6);
-
-          log << "- ";
-          choice->print(log, &cs.getASTContext().SourceMgr);
-          log << '\n';
-        }
-      } else {
-        getLogger(/*extraIndent=*/4)
-            << "' unsupported\n";
-      }
-
-      getLogger(/*extraIdent=*/4) << "]\n";
-    }
-
-    getLogger() << ")\n";
-  }
 }
 
 static std::optional<bool> isPreferable(ConstraintSystem &cs,
@@ -1924,22 +1839,119 @@ static std::optional<bool> isPreferable(ConstraintSystem &cs,
   return std::nullopt;
 }
 
+namespace {
+
+struct DisjunctionStats {
+  unsigned FavoredChoices = 0;
+  unsigned ActiveChoices = 0;
+  unsigned DisabledChoices = 0;
+
+  explicit DisjunctionStats(Constraint *disjunction) {
+    for (auto constraint : disjunction->getNestedConstraints()) {
+      if (constraint->isDisabled()) {
+        ++DisabledChoices;
+        continue;
+      }
+
+      ++ActiveChoices;
+    }
+  }
+
+  void print(llvm::raw_ostream &out) {
+    out << "active=" << ActiveChoices << " disabled=" << DisabledChoices;
+  }
+};
+
+}
+
 std::optional<std::pair<Constraint *, llvm::TinyPtrVector<Constraint *>>>
 ConstraintSystem::selectDisjunction() {
   SmallVector<Constraint *, 4> disjunctions;
 
   collectDisjunctions(disjunctions);
 
+  if (disjunctions.empty())
+    return std::nullopt;
+
+  auto getLogger = [&](unsigned extraIndent = 0) -> llvm::raw_ostream & {
+    return llvm::errs().indent(solverState->getCurrentIndent() +
+                               extraIndent);
+  };
+  PrintOptions PO = PrintOptions::forDebugging();
+
+  if (isDebugMode()) {
+    auto &log = getLogger();
+    log << "(disjunctions: (";
+    interleave(
+          disjunctions,
+          [&](const auto *disjunction) {
+            log << disjunction->getNestedConstraints()[0]
+                       ->getFirstType()
+                       ->getString(PO);
+          },
+          [&]() { log << " "; });
+
+      log << ")\n";
+  }
+
   if (unsigned seed = getASTContext().TypeCheckerOpts.ShuffleDisjunctionSeed) {
     std::mt19937 g(seed);
     std::shuffle(disjunctions.begin(), disjunctions.end(), g);
   }
 
-  if (disjunctions.empty())
-    return std::nullopt;
-
   llvm::DenseMap<Constraint *, DisjunctionInfo> favorings;
-  determineBestChoicesInContext(*this, disjunctions, favorings);
+
+  for (auto index : indices(disjunctions)) {
+    auto *disjunction = disjunctions[index];
+
+    auto applicableFn =
+        getApplicableFnConstraint(getConstraintGraph(), disjunction);
+    FunctionType *argFuncType = nullptr;
+    if (applicableFn) {
+      argFuncType =
+        applicableFn.get()->getFirstType()->getAs<FunctionType>();
+    }
+
+    auto info = computeDisjunctionInfo(*this, disjunctions, index, favorings);
+    favorings.try_emplace(disjunction, info);
+
+    if (isDebugMode()) {
+      auto &log = getLogger(/*extraIndent=*/2);
+      log << "(disjunction '"
+          << disjunction->getNestedConstraints()[0]->getFirstType()->getString(
+                 PO) << "': ";
+
+      DisjunctionStats(disjunction).print(log);
+
+      if (argFuncType)
+        log << " type=" << simplifyType(argFuncType)->getString(PO);
+
+      if (info.Score.has_value()) {
+        log << " score=" << info.Score.value_or(0);
+      } else {
+        log << " unsupported";
+      }
+
+      if (info.FavoredChoices.empty()) {
+        log << ")\n";
+      } else {
+        log << "\n";
+        for (const auto *choice : info.FavoredChoices) {
+          auto &log = getLogger(/*extraIndent=*/4);
+
+          log << "- ";
+          choice->print(log, &getASTContext().SourceMgr);
+          log << "\n";
+        }
+
+        getLogger(/*extraIndent=*/2) << ")\n";
+      }
+    }
+  }
+
+  if (isDebugMode()) {
+    getLogger() << ")\n";
+  }
 
   // Pick the disjunction with the smallest number of favored, then active
   // choices.

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -293,14 +293,6 @@ StepResult ComponentStep::take(bool prevFailed) {
       log << potentialBindings;
     }
 
-    if (!overloadDisjunctions.empty()) {
-      auto &log = getDebugLogger();
-      log.indent(CS.solverState->getCurrentIndent() + 2);
-      log << "Disjunction(s) = [";
-      interleave(overloadDisjunctions, log, ", ");
-      log << "]\n";
-    }
-
     if (!potentialBindings.empty() || !overloadDisjunctions.empty()) {
       auto &log = getDebugLogger();
       log << ")\n";

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -326,9 +326,9 @@ StepResult ComponentStep::take(bool prevFailed) {
 
   auto printConstraints = [&](const ConstraintList &constraints) {
     for (auto &constraint : constraints) {
-      constraint.print(
-          getDebugLogger().indent(CS.solverState->getCurrentIndent()),
-          &CS.getASTContext().SourceMgr, CS.solverState->getCurrentIndent());
+      constraint.print(getDebugLogger(),
+                       &CS.getASTContext().SourceMgr,
+                       CS.solverState->getCurrentIndent());
       getDebugLogger() << "\n";
     }
   };

--- a/test/Constraints/result_builder_conjunction_selection.swift
+++ b/test/Constraints/result_builder_conjunction_selection.swift
@@ -71,7 +71,7 @@ do {
   // CHECK: (pattern_named implicit "$__builder{{.*}}")
   // CHECK: (applying conjunction result to outer context
   // CHECK: (attempting type variable {{.*}} := (Int?) -> {{.*}}
-  // CHECK: (attempting disjunction choice {{.*}} bound to decl {{.*}}.Int.init(_:)
+  // CHECK: (attempting disjunction choice {{.*}} bound to decl Swift.(file).SignedInteger extension.init(_:)
   let _ = {
     let x = 42
     test { cond in

--- a/validation-test/Sema/type_checker_perf/fast/issue-55762.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/issue-55762.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --invert-result --begin 1 --end 7 --step 1 --select NumLeafScopes %s -Xfrontend=-typecheck
+// RUN: %scale-test --begin 1 --end 7 --step 1 --select NumLeafScopes %s -Xfrontend=-typecheck -Xfrontend=-solver-enable-prune-disjunctions
 // REQUIRES: asserts, no_asan
 
 // https://github.com/swiftlang/swift/issues/55762

--- a/validation-test/Sema/type_checker_perf/fast/operators_inside_closure.swift
+++ b/validation-test/Sema/type_checker_perf/fast/operators_inside_closure.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -typecheck %s -solver-scope-threshold=10000
+// RUN: %target-swift-frontend -typecheck %s -solver-scope-threshold=1000 -solver-enable-prune-disjunctions
 // REQUIRES: tools-release,no_asan
 
 // Selecting operators from the closure before arguments to `zip` makes this "too complex"

--- a/validation-test/Sema/type_checker_perf/fast/rdar32034560.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar32034560.swift
@@ -1,13 +1,10 @@
-// RUN: %target-typecheck-verify-swift -solver-scope-threshold=10000
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=2000 -solver-enable-prune-disjunctions
 // REQUIRES: tools-release,no_asan
-
-// Valid expression, type checks with default limits but slow
 
 struct S {
   var A: [[UInt32]]
 
   func rdar32034560(x: UInt32) -> UInt32 {
-    // expected-error@+1 {{reasonable time}}
     return ((self.A[0][Int(x >> 24) & 0xFF] &+ self.A[1][Int(x >> 16) & 0xFF]) ^ self.A[2][Int(x >> 8) & 0xFF]) &+ self.A[3][Int(x & 0xFF)]
          | ((self.A[0][Int(x >> 24) & 0xFF] &+ self.A[1][Int(x >> 16) & 0xFF]) ^ self.A[2][Int(x >> 8) & 0xFF]) &+ self.A[3][Int(x & 0xFF)]
          | ((self.A[0][Int(x >> 24) & 0xFF] &+ self.A[1][Int(x >> 16) & 0xFF]) ^ self.A[2][Int(x >> 8) & 0xFF]) &+ self.A[3][Int(x & 0xFF)]

--- a/validation-test/Sema/type_checker_perf/slow/rdar140212559.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/slow/rdar140212559.swift.gyb
@@ -1,0 +1,9 @@
+// RUN: %scale-test --invert-result --begin 1 --end 10 --step 1 --select NumLeafScopes %s
+// REQUIRES: asserts,no_asan
+
+func localType(s: String) -> Any.Type? {
+  return _typeByName(s)
+%for i in range(0, N):
+    ?? _typeByName("\(s)")
+%end
+}

--- a/validation-test/Sema/type_checker_perf/slow/rdar59008707.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar59008707.swift
@@ -1,4 +1,8 @@
-// RUN: %target-typecheck-verify-swift -solver-scope-threshold=10000
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=10000 -solver-enable-prune-disjunctions
+
+// FIXME: -solver-enable-prune-disjunctions just moves the location of the
+// reasonable time diagnostic. It also decreases the number of scopes but
+// not below 10000.
 
 // REQUIRES: objc_interop
 

--- a/validation-test/Sema/type_checker_perf/slow/swift_package_index_3.swift
+++ b/validation-test/Sema/type_checker_perf/slow/swift_package_index_3.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift %s -solver-scope-threshold=50000
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=50000
 // REQUIRES: tools-release,no_asan
 
 // Valid expression, type checks with default limits but slow


### PR DESCRIPTION
This adds a new "lookahead" disjunction processing pass to complement the disjunction selection / favoring done by solver-perf. This pass disables disjunction choices which it can definitely prove, via a conservative match of the argument and parameter types, will not be taken.

The new pass is disabled by default. When / if it is enabled, it will benefit performanace in two cases:
- when the disjunction with the disabled choices is not the immediate next disjunction, but is only considered inside a nested scope, disabling choices now can avoid duplicated work in those nested scopes.
- also, disabling choices can change disjunction ranking, so some disjunction _becomes_ the next disjunction. This may turn out to be beneficial, especially if that disjunction now only has a small number of active choices.

So far this is just an experiment, and I only implemented a couple of heuristics. Also it is not fully correct, pending filling in `shouldBeConservativeWithProto()` in CSLookahead.cpp.

To avoid breaking any existing behaviors, I copy and pasted a bunch of code from CSOptimizer.cpp here, but if we go ahead with this approach I'll merge the new code into CSOptimizer.cpp or extract the common utilities out.

Besides the cleanup, there's an optimization I plan on doing here. Instead of processing every disjunction on every step, we should be able to do this lazily, only when type variables mentioned from an applicable function constraint are changed. (In fact, we should already be able to do this with determineBestChoices(), and make selectDisjunction() essentially constant-time.) I'll investigate this in a follow-up PR.

So far this fixes two slow tests in the suite:
- Fixes https://github.com/swiftlang/swift/issues/55762
- rdar://32034560 from 2017!

Also the expressions from https://github.com/swiftlang/swift/issues/52861 become much faster but still not quite fast enough to pass with the minimal limit set in the test.