### PR TITLE
Preparation for switching .swiftinterface to `yielding` terminology

### DIFF
--- a/include/swift/AST/AccessorKinds.def
+++ b/include/swift/AST/AccessorKinds.def
@@ -167,7 +167,7 @@ COROUTINE_ACCESSOR(Read, _read)
 ///
 /// If the storage is not implemented with a read accessor then
 /// one can always be synthesized (even if the storage type is move-only).
-YIELDING_ACCESSOR(YieldingBorrow, read, borrow, CoroutineAccessors)
+YIELDING_ACCESSOR(YieldingBorrow, yielding_borrow, borrow, CoroutineAccessors)
 
 /// This is a modify accessor: a yield-once coroutine which is called when a
 /// the storage is modified which works by yielding an inout value
@@ -183,7 +183,7 @@ COROUTINE_ACCESSOR(Modify, _modify)
 ///
 /// If the storage is not implemented with a modify accessor then
 /// one can be synthesized if the storage is mutable at all.
-YIELDING_ACCESSOR(YieldingMutate, modify, mutate, CoroutineAccessors)
+YIELDING_ACCESSOR(YieldingMutate, yielding_mutate, mutate, CoroutineAccessors)
 
 /// This is a willSet observer: a function which "decorates" an
 /// underlying assignment operation by being called prior to the

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -502,7 +502,12 @@ EXPERIMENTAL_FEATURE(AssumeResilientCxxTypes, true)
 /// Import inherited non-public members when importing C++ classes.
 EXPERIMENTAL_FEATURE(ImportNonPublicCxxMembers, true)
 
-/// modify/read single-yield coroutines
+/// `yielding borrow`/`yielding mutate` single-yield coroutine accessors
+// TODO: When this is turned on by default, take care of:
+// * "TODO" around line 8100 of lib/Parse/ParseDecl.cpp
+//   (Don't diagnose bare "read"/"modify" in accessors in source files.)
+// * "TODO" around line 12475 of lib/AST/Decl.cpp
+//   (Don't use "read"/"modify" in swiftinterface files.)
 SUPPRESSIBLE_EXPERIMENTAL_FEATURE(CoroutineAccessors, true)
 
 /// modify/read single-yield coroutines always execute code post-yield code

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -12468,10 +12468,21 @@ void swift::simple_display(llvm::raw_ostream &out, const GenericParamList *GPL) 
 
 StringRef swift::getAccessorLabel(AccessorKind kind) {
   switch (kind) {
+  #define YIELDING_ACCESSOR(ID, KEYWORD, YIELDING_KEYWORD, FEATURE)
   #define SINGLETON_ACCESSOR(ID, KEYWORD) \
     case AccessorKind::ID: return #KEYWORD;
 #define ACCESSOR(ID, KEYWORD)
 #include "swift/AST/AccessorKinds.def"
+
+    // Transitional terminology.  Let's use this for a little
+    // while to ease the transition.  (Both forms are parsed
+    // correctly, this just changes what gets written into
+    // .swiftinterface files.)
+    case AccessorKind::YieldingBorrow: return "read";
+    case AccessorKind::YieldingMutate: return "modify";
+    // TODO: Switch to the final terminology before shipping...
+    // case AccessorKind::YieldingBorrow: return "yielding borrow";
+    // case AccessorKind::YieldingMutate: return "yielding mutate";
   }
   llvm_unreachable("bad accessor kind");
 }

--- a/lib/ASTGen/Sources/ASTGen/Decls.swift
+++ b/lib/ASTGen/Sources/ASTGen/Decls.swift
@@ -402,20 +402,18 @@ extension ASTGenVisitor {
     case .`init`:
       return .Init
     case .read:
-      precondition(ctx.langOpts.hasFeature(.CoroutineAccessors), "(compiler bug) 'read' accessor should only be parsed with 'CoroutineAccessors' feature")
-      return .read
+      return .yielding_borrow
     case .modify:
-      precondition(ctx.langOpts.hasFeature(.CoroutineAccessors), "(compiler bug) 'modify' accessor should only be parsed with 'CoroutineAccessors' feature")
-      return .modify
+      return .yielding_mutate
     case .borrow:
       if modifiers.first(where: { $0.name.text == "yielding" }) != nil {
-        return .read // AKA `yielding borrow`
+        return .yielding_borrow
       }
       precondition(ctx.langOpts.hasFeature(.BorrowAndMutateAccessors), "(compiler bug) 'borrow' accessor should only be parsed with 'BorrowAndMutateAccessors' feature")
       return .borrow
     case .mutate:
       if modifiers.first(where: { $0.name.text == "yielding" }) != nil {
-        return .modify // AKA `yielding mutate`
+        return .yielding_mutate
       }
       precondition(ctx.langOpts.hasFeature(.BorrowAndMutateAccessors), "(compiler bug) 'mutate' accessor should only be parsed with 'BorrowAndMutateAccessors' feature")
       return .mutate

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -8086,31 +8086,41 @@ static ParserStatus parseAccessorIntroducer(Parser &P,
   }
 #define ACCESSOR_KEYWORD(KEYWORD)
 
-// Support the old `read` and `modify` spellings used before SE-0474 was
-// finalized.  Include a warning guiding people to the final spellings.
-// The complicated condition here is to try to deal gracefully with
-// existing code that has a function called `read` or `modify` that
-// takes a closure and invokes it from within a default getter.
-#define YIELDING_ACCESSOR(ID, KEYWORD, YIELDING_KEYWORD, FEATURE)              \
-  else if (P.Tok.getRawText() == #KEYWORD) {                                   \
-    if (!P.Context.LangOpts.hasFeature(Feature::FEATURE)) {                    \
-      if (featureUnavailable)                                                  \
-        *featureUnavailable = true;                                            \
-      if (isFirstAccessor) {                                                   \
-        Status.setIsParseError();                                              \
-        return Status;                                                         \
-      }                                                                        \
-    }                                                                          \
-    P.diagnose(P.Tok.getLoc(), diag::old_coroutine_accessor,                   \
-               #YIELDING_KEYWORD, #KEYWORD);                                   \
-    Kind = AccessorKind::ID;                                                   \
-  }
+#define YIELDING_ACCESSOR(ID, KEYWORD, YIELDING_KEYWORD, FEATURE)
 #define SINGLETON_ACCESSOR(ID, KEYWORD)                                        \
   else if (P.Tok.getRawText() == #KEYWORD) {                                   \
     Kind = AccessorKind::ID;                                                   \
   }
 #include "swift/AST/AccessorKinds.def"
 
+  // Support the old `read` and `modify` spellings used before SE-0474 was
+  // finalized:
+  // * Support them in interface files, to avoid breaking .swiftinterface
+  //   while we transition to the new spellings.  (The compiler continued
+  //   to write `read`/`modify` to interfaces while we transitioned.)
+  // * Support them in Swift code ONLY IF the user has explicitly opted
+  //   into the CoroutineAccessors flag.
+  // TODO: After CoroutineAccessors gets turned on by default, we should
+  // ONLY accept these in interface files.
+  // TODO: Someday in the future (after 2026), we can stop accepting these
+  // entirely.  Accepting them in interface files is a temporary
+  // compatibility bridge to avoid immediate breakage during the switch
+  // to the new terminology.
+  else if (P.Tok.getRawText() == "read"
+	   && (P.SF.Kind == SourceFileKind::Interface
+	       || P.Context.LangOpts.hasFeature(Feature::CoroutineAccessors))) {
+    P.diagnose(P.Tok.getLoc(), diag::old_coroutine_accessor,
+	       "borrow", "read");
+    Kind = AccessorKind::YieldingBorrow;
+  }
+  else if (P.Tok.getRawText() == "modify"
+	   && (P.SF.Kind == SourceFileKind::Interface
+	       || P.Context.LangOpts.hasFeature(Feature::CoroutineAccessors))) {
+    P.diagnose(P.Tok.getLoc(), diag::old_coroutine_accessor,
+	       "mutate", "modify");
+    Kind = AccessorKind::YieldingMutate;
+  }
+  // Support `yielding borrow` and `yielding mutate`
   else if (P.Tok.getRawText() == "yielding") {
     // If there's a "yielding" token, see if this is
     // "yielding mutate" or "yielding borrow"

--- a/test/Parse/coroutine_accessors.swift
+++ b/test/Parse/coroutine_accessors.swift
@@ -50,10 +50,10 @@ var iybr: Int {
   yielding borrow { // expected-disabled-error{{accessor_requires_coroutine_accessors}}
     fatalError()
   }
-  read { // expected-warning{{old_coroutine_accessor}}
-         // expected-error@-1{{duplicate_accessor}}
-         // expected-note@-5{{previous_accessor}}
-         // expected-disabled-error@-3{{accessor_requires_coroutine_accessors}}
+  read { // expected-enabled-warning{{old_coroutine_accessor}}
+         // expected-enabled-error@-1{{duplicate_accessor}}
+         // expected-enabled-note@-5{{previous_accessor}}
+         // expected-disabled-error@-3{{expected_accessor_kw}}
     fatalError()
   }
 }
@@ -93,10 +93,10 @@ var igr: Int {
   get {
     1
   }
-  read { // expected-warning{{old_coroutine_accessor}}
-         // expected-error@-1{{variable cannot provide both a 'yielding borrow' accessor and a getter}}
-         // expected-note@-5{{previous_accessor}}
-         // expected-disabled-error@-3{{'yielding borrow' accessor is only valid when experimental feature coroutine accessors is enabled}}
+  read { // expected-enabled-warning{{old_coroutine_accessor}}
+         // expected-enabled-error@-1{{variable cannot provide both a 'yielding borrow' accessor and a getter}}
+         // expected-enabled-note@-5{{previous_accessor}}
+         // expected-disabled-error@-3{{expected_accessor_kw}}
     yield _i
   }
 }


### PR DESCRIPTION
For now, we write `read`/`modify` to .swiftinterface files so they can be read by the draft implementation in current compilers.  Here are some of the issues:

* We _cannot_ support `read`/`modify` in Swift sources without the user specifying a flag. That's because the idiom below occurs in real code, and would be broken by such support.  So when we enable the `CoroutineAccessors` flag by default, we _must_ not support `read`/`modify` as accessor notations in source.

```
struct XYZ {
  // `read` method that takes a closure
  func read(_ closure: () -> ()) { ... }

  // getter that uses the above closure
  var foo: Type {
    read { ... closure ... }
  }
}
```

* .swiftinterface files don't have the above problem. Accessor bodies aren't stored at all by default, and when inlineable, we always write explicit `get`. So we can continue to accept `read`/`modify` notation in interface files.

So our strategy here is:

* We'll accept both `read`/`modify` and `yielding borrow`/`yielding mutate` in interface files for a lengthy transition period.

* We'll write `read`/`modify` to swiftinterface files for a little longer, then switch to `yielding borrow`/`yielding mutate`.

* We'll disable `read`/`modify` support in source files when we enable `CoroutineAccessors` by default. (We can't even diagnose, due to the above idiom.)

This means that early adopters will have to update their sources to use the new terminology.  However, swiftinterface files will be exchangeable between the new and old compilers for a little while.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
