### PR TITLE
[test] Fix noncopyable-irgen.swift failure on Android

### DIFF
--- a/test/Interop/Cxx/class/noncopyable-irgen.swift
+++ b/test/Interop/Cxx/class/noncopyable-irgen.swift
@@ -6,7 +6,7 @@
 // RUN: %target-swift-frontend -cxx-interoperability-mode=default -emit-ir -I %swift_src_root/lib/ClangImporter/SwiftBridging -I %t%{fs-sep}Inputs %t%{fs-sep}test.swift -Xcc -fignore-exceptions -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}noncopyable.h -verify-additional-prefix TEST4- -D TEST4 -Xcc -DTEST4 -Xcc -std=c++20
 // RUN: %target-swift-frontend -cxx-interoperability-mode=default -emit-ir -I %swift_src_root/lib/ClangImporter/SwiftBridging -I %t%{fs-sep}Inputs %t%{fs-sep}test.swift -Xcc -fignore-exceptions -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}noncopyable.h -verify-additional-prefix TEST5- -D TEST5
 // RUN: %target-swift-frontend -cxx-interoperability-mode=default -emit-ir -I %swift_src_root/lib/ClangImporter/SwiftBridging -I %t%{fs-sep}Inputs %t%{fs-sep}test.swift -Xcc -fignore-exceptions -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}noncopyable.h -verify-additional-prefix TEST6- -D TEST6
-// RUN: %target-swift-frontend -cxx-interoperability-mode=default -emit-ir -I %swift_src_root/lib/ClangImporter/SwiftBridging -I %t%{fs-sep}Inputs %t%{fs-sep}test.swift -Xcc -fignore-exceptions -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}noncopyable.h -verify-additional-prefix TEST7-%target-os-family- -D TEST7 -Xcc -DTEST7 -Xcc -std=c++20 -verify-ignore-unrelated
+// RUN: %target-swift-frontend -cxx-interoperability-mode=default -emit-ir -I %swift_src_root/lib/ClangImporter/SwiftBridging -I %t%{fs-sep}Inputs %t%{fs-sep}test.swift -Xcc -fignore-exceptions -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}noncopyable.h -verify-additional-prefix TEST7-%target-os-family- -verify-additional-prefix TEST7-%target-os- -D TEST7 -Xcc -DTEST7 -Xcc -std=c++20 -verify-ignore-unrelated
 
 //--- Inputs/module.modulemap
 module Test {
@@ -43,9 +43,10 @@ struct OwnsT {
     // expected-TEST1-note@-4 {{use 'requires' (since C++20) to specify the constraints under which the copy constructor is available}}
     // expected-TEST1-note@-5 {{annotate a type with SWIFT_COPYABLE_IF(<T>) in C++ to specify that the type is Copyable if <T> is Copyable}}
     // expected-TEST7-DARWIN-error@-6 {{call to implicitly-deleted copy constructor of 'std::unique_ptr<int>'}}
-    // expected-TEST7-LINUX-error@-7 {{call to deleted constructor of 'std::unique_ptr<int>'}}
-    // expected-TEST7-DARWIN-note@-8 {{in instantiation of member function 'OwnsT<std::unique_ptr<int>>::OwnsT' requested here}}
-    // expected-TEST7-LINUX-note@-9 {{in instantiation of member function 'OwnsT<std::unique_ptr<int>>::OwnsT' requested here}}
+    // expected-TEST7-linux-android-error@-7 {{call to implicitly-deleted copy constructor of 'std::unique_ptr<int>'}}
+    // expected-TEST7-linux-gnu-error@-8 {{call to deleted constructor of 'std::unique_ptr<int>'}}
+    // expected-TEST7-DARWIN-note@-9 {{in instantiation of member function 'OwnsT<std::unique_ptr<int>>::OwnsT' requested here}}
+    // expected-TEST7-LINUX-note@-10 {{in instantiation of member function 'OwnsT<std::unique_ptr<int>>::OwnsT' requested here}}
     OwnsT(OwnsT&& other) {}
 };
 


### PR DESCRIPTION
Android uses libc++, just like Darwin, so it has the same error message for the constructor, not the one linux has with libstdc++, so check the specific OS also.

Otherwise, we see this error on [the Android CI](https://ci.swift.org/job/oss-swift-package-swift-sdk-for-android/200/console):
```
15:49:14      // expected-TEST7-LINUX-error@-7 {{call to deleted constructor of 'std::unique_ptr<int>'}}
15:49:14                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
15:49:14                                         call to implicitly-deleted copy constructor of 'std::unique_ptr<int>'
```

@susmonteiro and @compnerd, let me know what you think.

Ultimately, the C++ Interop team should probably add a test variable keyed to the specific C++ library used and check that instead, as @egorzhdan has [done a little in another context](https://github.com/swiftlang/swift/blob/a5f9ec1d872a6f298cecdd5f957782fe73302f06/test/Interop/lit.local.cfg#L49), but this should get the Android CI working again by checking the OS for now.