### PR TITLE
[test] Fix building Android tests on Windows toolchain CI

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2811,6 +2811,13 @@ function Test-Runtime([Hashtable] $Platform) {
     throw "LIT test utilities not found in $CompilersBinaryCache\bin"
   }
 
+  $PlatformDefines = @{}
+  if ($Platform.OS -eq [OS]::Android) {
+    $PlatformDefines += @{
+      SWIFT_ANDROID_API_LEVEL = "$AndroidAPILevel";
+    }
+  }
+
   Invoke-IsolatingEnvVars {
     # Filter known issues when testing on Windows
     Load-LitTestOverrides $PSScriptRoot/windows-swift-android-lit-test-overrides.txt
@@ -2822,13 +2829,13 @@ function Test-Runtime([Hashtable] $Platform) {
       -UseBuiltCompilers C,CXX,Swift `
       -SwiftSDK $null `
       -BuildTargets check-swift-validation-only_non_executable `
-      -Defines @{
+      -Defines ($PlatformDefines + @{
         SWIFT_INCLUDE_TESTS = "YES";
         SWIFT_INCLUDE_TEST_BINARIES = "YES";
         SWIFT_BUILD_TEST_SUPPORT_MODULES = "YES";
         SWIFT_NATIVE_LLVM_TOOLS_PATH = Join-Path -Path $CompilersBinaryCache -ChildPath "bin";
         LLVM_LIT_ARGS = "-vv";
-      }
+      })
   }
 }
 


### PR DESCRIPTION
Ever since #84574 added Android availability versioning, the Reflection test stopped building for Android unless the API level was in the target triple, so [we hacked that into CMake in that pull](https://github.com/swiftlang/swift/pull/84574/files#diff-e2e2a250882f66d531f2a42c201e013fa2d8be892b2880a32d6596710761f470R2549), but the Windows CI does not pass in `SWIFT_ANDROID_API_LEVEL`, [like `build-script` does](https://github.com/swiftlang/swift/blob/9143271dfdc92053a7b9d95000d9fd60e42413c3/utils/build-script-impl#L1632), so pass it in here.

I don't see a way to run [the failing build of the Android tests from the Windows toolchain CI](https://ci-external.swift.org/job/swift-main-windows-toolchain/1830/console) in this pull, so will just need review from Windows people like @compnerd or @jeffdav before merging.