### PR TITLE
[stdlib, 6.3] mark some `bytes: RawSpan` accessors as unsafe

### DIFF
--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -254,7 +254,7 @@ extension MutableSpan where Element: ~Copyable {
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableSpan where Element: BitwiseCopyable {
 
-  /// Construct a RawSpan over the memory represented by this span
+  /// Construct a raw span over the memory represented by this span.
   ///
   /// - Returns: a RawSpan over the memory represented by this span
   @_alwaysEmitIntoClient
@@ -266,7 +266,7 @@ extension MutableSpan where Element: BitwiseCopyable {
     }
   }
 
-  /// Construct a MutableRawSpan over the memory represented by this span
+  /// Construct a mutable raw span over the memory represented by this span.
   ///
   /// Mutating `self` through this property is unsafe because
   /// it is possible to mutate a byte so as to produce an invalid

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -258,6 +258,7 @@ extension MutableSpan where Element: BitwiseCopyable {
   ///
   /// - Returns: a RawSpan over the memory represented by this span
   @_alwaysEmitIntoClient
+  @unsafe
   public var bytes: RawSpan {
     @lifetime(borrow self)
     borrowing get {

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -507,6 +507,9 @@ extension Span where Element: BitwiseCopyable {
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension Span where Element: BitwiseCopyable {
 
+  /// Construct a raw span over the memory represented by this span.
+  ///
+  /// - Returns: a RawSpan over the memory represented by this span
   @_alwaysEmitIntoClient
   @unsafe
   public var bytes: RawSpan {

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -507,9 +507,10 @@ extension Span where Element: BitwiseCopyable {
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension Span where Element: BitwiseCopyable {
 
+  @_alwaysEmitIntoClient
+  @unsafe
   public var bytes: RawSpan {
     @lifetime(copy self)
-    @_alwaysEmitIntoClient
     get {
       let rawSpan = RawSpan(_elements: self)
       return unsafe _overrideLifetime(rawSpan, copying: self)


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift/pull/86684

**Explanation**: We should have marked the `Span`-to-`RawSpan` accessors as unsafe in SE-0447 and SE-0467. Even if the memory is initialized from the point of view of using `Element` instances, it is not necessarily the case that every byte is initialized.

**Scope**: correctness fix
**Risk**: low. Projects that build with "-strict-memory-safety" may get new warnings due to this bug fix.
**Testing**: existing tests pass.
**Issue**: rdar://168547924
**Reviewer**: @Azoy 