### PR TITLE
[cxx-interop] Instantiate CXXMethodDecl return type before importing

### DIFF
--- a/lib/ClangImporter/ClangLookup.cpp
+++ b/lib/ClangImporter/ClangLookup.cpp
@@ -64,6 +64,8 @@ using namespace swift;
 namespace {
 /// Collects name lookup results into the given tiny vector, for use in the
 /// various ClangImporter lookup routines.
+///
+/// Validates that the name we looked up matches the resulting imported name.
 class CollectLookupResults {
   DeclName name;
   TinyPtrVector<ValueDecl *> &result;
@@ -73,7 +75,8 @@ public:
       : name(name), result(result) {}
 
   void add(ValueDecl *imported) {
-    result.push_back(imported);
+    if (imported->getName().matchesRef(name))
+      result.push_back(imported);
 
     // Expand any macros introduced by the Clang importer.
     imported->visitAuxiliaryDecls([&](Decl *decl) {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4465,6 +4465,27 @@ namespace {
     }
 
     Decl *VisitCXXMethodDecl(const clang::CXXMethodDecl *decl) {
+      // If the return type is a templated class, instantiate it. This must
+      // happen before we import the name of the method, as the name is affected
+      // by safety/unsafety of the return type. The safety detection logic
+      // (`IsSafeUseOfCxxDecl`) relies on the class being instantiated.
+      if (auto *returnedTmpl =
+              dyn_cast_or_null<clang::ClassTemplateSpecializationDecl>(
+                  desugarIfElaborated(decl->getReturnType())->getAsTagDecl());
+          returnedTmpl && !returnedTmpl->getDefinition()) {
+        Impl.getClangSema().InstantiateClassTemplateSpecialization(
+            decl->getLocation(),
+            const_cast<clang::ClassTemplateSpecializationDecl *>(returnedTmpl),
+            clang::TemplateSpecializationKind::TSK_ImplicitInstantiation,
+            /*Complain*/ false, /*PrimaryStrictPackMatch*/ false);
+        // N.B. InstantiateClassTemplateSpecialization() returns true if it
+        //      encountered an error while instantiating the returned template.
+        //      Even if it does, we don't bail out here, and defer error
+        //      handling to later. This is because that handler may involve
+        //      things like import a method and mark it as unavailable, rather
+        //      than simply not import it at all.
+      }
+
       // The static `operator ()` introduced in C++ 23 is still callable as an
       // instance operator in C++, and we want to preserve the ability to call
       // it as an instance method in Swift as well for source compatibility.

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -1964,6 +1964,26 @@ void importer::addEntryToLookupTable(SwiftLookupTable &table,
     }
   }
 
+  if (auto methodDecl = dyn_cast<clang::CXXMethodDecl>(named)) {
+    // If the return type is a template instantiation, it is not possible to
+    // determine safety/unsafety of the method without instantiating the
+    // template. Let's add both safe and unsafe versions of the name to the
+    // lookup table.
+    if (auto returnTy = desugarIfElaborated(methodDecl->getReturnType());
+        isa<clang::TemplateSpecializationType>(returnTy)) {
+      auto importedName = nameImporter.importName(methodDecl, currentVersion);
+      if (importedName && importedName.getDeclName().isSpecial()) {
+        if (StringRef id = importedName.getDeclName().getBaseIdentifier().str();
+            id.starts_with("__") && id.ends_with("Unsafe")) {
+          StringRef safeId = id.drop_front(2).drop_back(6);
+          table.addEntry(
+              DeclBaseName(nameImporter.getContext().getIdentifier(safeId)),
+              named, importedName.getEffectiveContext());
+        }
+      }
+    }
+  }
+
   // Class template instantiations are imported lazily, however, the lookup
   // table must include their mangled name (__CxxTemplateInst...) to make it
   // possible to find these decls during deserialization. For any C++ typedef

--- a/lib/ClangImporter/SwiftLookupTable.h
+++ b/lib/ClangImporter/SwiftLookupTable.h
@@ -283,7 +283,7 @@ const uint16_t SWIFT_LOOKUP_TABLE_VERSION_MAJOR = 1;
 /// Lookup table minor version number.
 ///
 /// When the format changes IN ANY WAY, this number should be incremented.
-const uint16_t SWIFT_LOOKUP_TABLE_VERSION_MINOR = 20; // 64-bit clang serialization IDs
+const uint16_t SWIFT_LOOKUP_TABLE_VERSION_MINOR = 21; // add both safe and unsafe names of C++ methods
 
 /// A lookup table that maps Swift names to the set of Clang
 /// declarations with that particular name.

--- a/test/Interop/Cxx/templates/invalid-return-type.swift
+++ b/test/Interop/Cxx/templates/invalid-return-type.swift
@@ -1,0 +1,56 @@
+// RUN: split-file %s %t
+// RUN: %target-clang -c -o /dev/null -Xclang -verify -I %t/Inputs %t/cxx.cpp
+// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}CxxHeader.h %t%{fs-sep}ok.swift
+// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}CxxHeader.h %t%{fs-sep}err.swift -verify-additional-prefix err-
+// RUN: %target-swift-ide-test -print-module -module-to-print=CxxModule -I %t/Inputs -source-filename=x -cxx-interoperability-mode=default | %FileCheck %t/Inputs/CxxHeader.h
+
+//--- Inputs/module.modulemap
+module CxxModule {
+    requires cplusplus
+    header "CxxHeader.h"
+}
+
+//--- Inputs/CxxHeader.h
+#pragma once
+
+
+template <class T> struct OnlyChar;
+template <> struct OnlyChar<char> {};
+
+struct S {
+  S() = default;
+
+  OnlyChar<int> Err() const; // cannot be called (incomplete return type)
+  // expected-err-note@-1 {{explicitly marked unavailable here}}
+
+  OnlyChar<char> Ok() const;
+};
+
+// CHECK:      struct S {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   func Err() -> Never
+// CHECK-NEXT:   func Ok()
+// CHECK:      }
+
+//--- cxx.cpp
+// expected-no-diagnostics
+#include <CxxHeader.h>
+void IsOk(void) {
+  S Is;
+  Is.Ok();
+}
+
+//--- ok.swift
+import CxxModule
+func IsOk() {
+  let Is = S()  // We can instantiate it
+  Is.Ok()       // We can call it
+}
+
+//--- err.swift
+import CxxModule
+func IsErr() {
+  let Is = S()  // We can instantiate it
+  Is.Err()      // expected-error {{return type is unavailable in Swift}}
+  Is.Ok()       // We can still call it
+}

--- a/test/Interop/Cxx/templates/using-return-type.swift
+++ b/test/Interop/Cxx/templates/using-return-type.swift
@@ -1,0 +1,120 @@
+// C++ methods that return iterators are imported with an unsafe name mangling,
+// i.e., '__{{METHOD_NAME}}Unsafe'.
+//
+// In this test, we ensure that the iterator-detection logic does not depend on
+// whether the iterator type happens to be instantiated at the time we determine
+// the imported name of the C++ method.
+
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -typecheck -verify %t%{fs-sep}main.swift \
+// RUN:   -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}CxxHeader.h \
+// RUN:   -suppress-notes \
+// RUN:   -cxx-interoperability-mode=default
+
+//--- Inputs/module.modulemap
+module CxxModule {
+    requires cplusplus
+    header "CxxHeader.h"
+}
+
+//--- Inputs/CxxHeader.h
+#pragma once
+
+#include <iterator>
+
+template <typename T> struct IteratorT {
+  // Having this makes (each instance of) IteratorT considered an iterator
+  using iterator_category = std::input_iterator_tag;
+};
+
+template <typename T> struct IdentityT {
+  T t;
+};
+
+// Some types to instantiate IteratorT with
+struct A {};
+struct B {};
+struct C {};
+struct D {};
+
+struct AA {
+  IteratorT<A> getIter() const;
+  IdentityT<A> getValue() const;
+};
+
+struct BB {
+  using iter = IteratorT<B>;
+  using value = IdentityT<B>;
+  iter getIter() const;
+  value getValue() const;
+};
+
+struct CC {
+  using iter = IteratorT<C>;
+  using value = IdentityT<C>;
+  IteratorT<C> getIter() const;
+  IdentityT<C> getValue() const;
+};
+
+struct DD {
+  IteratorT<D> getIter() const;
+  IdentityT<D> getValue() const;
+  using iter = IteratorT<D>;
+  using value = IdentityT<D>;
+};
+
+struct AAA : AA {};
+struct BBB : BB {};
+struct CCC : CC {};
+struct DDD : DD {};
+
+//--- main.swift
+import CxxModule
+
+let aa = AA()
+aa.getIter() // expected-error {{has no member 'getIter'}}
+aa.__getIterUnsafe()
+aa.getValue()
+aa.__getValueUnsafe() // expected-error {{has no member '__getValueUnsafe'}}
+
+let bb = BB()
+bb.getIter() // expected-error {{has no member 'getIter'}}
+bb.__getIterUnsafe()
+bb.getValue()
+bb.__getValueUnsafe() // expected-error {{has no member '__getValueUnsafe'}}
+
+let cc = CC()
+cc.getIter() // expected-error {{has no member 'getIter'}}
+cc.__getIterUnsafe()
+cc.getValue()
+cc.__getValueUnsafe() // expected-error {{has no member '__getValueUnsafe'}}
+
+let dd = DD()
+dd.getIter() // expected-error {{has no member 'getIter'}}
+dd.__getIterUnsafe()
+dd.getValue()
+dd.__getValueUnsafe() // expected-error {{has no member '__getValueUnsafe'}}
+
+let aaa = AAA()
+aaa.getIter() // expected-error {{has no member 'getIter'}}
+aaa.__getIterUnsafe()
+aaa.getValue()
+aaa.__getValueUnsafe() // expected-error {{has no member '__getValueUnsafe'}}
+
+let bbb = BBB()
+bbb.getIter() // expected-error {{has no member 'getIter'}}
+bbb.__getIterUnsafe()
+bbb.getValue()
+bbb.__getValueUnsafe() // expected-error {{has no member '__getValueUnsafe'}}
+
+let ccc = CCC()
+ccc.getIter() // expected-error {{has no member 'getIter'}}
+ccc.__getIterUnsafe()
+ccc.getValue()
+ccc.__getValueUnsafe() // expected-error {{has no member '__getValueUnsafe'}}
+
+let ddd = DDD()
+ddd.getIter() // expected-error {{has no member 'getIter'}}
+ddd.__getIterUnsafe()
+ddd.getValue()
+ddd.__getValueUnsafe() // expected-error {{has no member '__getValueUnsafe'}}


### PR DESCRIPTION
This needs to happen because, at this type of commit, IsSafeUseOfCxxDecl (and thus ImportName) depends on the definition of the return type.

By eagerly instantiating the return type, we make the safety checking (and thus the rename logic) more reliable.

rdar://127152954