### PR TITLE
[6.3] [Index] Fix incorrect setter references for subscript keys (#86119)

### DIFF
--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -354,6 +354,13 @@ namespace swift {
   llvm::TinyPtrVector<ValueDecl *>
   findWitnessedObjCRequirements(const ValueDecl *witness,
                                 bool anySingleRequirement);
+  /// Returns true if the given subscript method is a valid implementation of
+  /// the `subscript(dynamicMember: {Writable}KeyPath<...>)` requirement for
+  /// @dynamicMemberLookup.
+  /// The method is given to be defined as `subscript(dynamicMember:)` which
+  /// takes a single non-variadic parameter of `{Writable}KeyPath<T, U>` type.
+  bool isValidKeyPathDynamicMemberLookup(SubscriptDecl *decl,
+                                         bool ignoreLabel = false);
 }
 
 #endif

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -25,10 +25,10 @@
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/SourceManager.h"
-#include "swift/Parse/Lexer.h"
-#include "clang/Basic/Module.h"
 #include "swift/IDE/SourceEntityWalker.h"
 #include "swift/IDE/Utils.h"
+#include "swift/Sema/IDETypeChecking.h"
+#include "clang/Basic/Module.h"
 
 using namespace swift;
 
@@ -451,8 +451,33 @@ ASTWalker::PreWalkResult<Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
         return Action::Stop();
     }
 
-    if (!SE->getArgs()->walk(*this))
-      return Action::Stop();
+    // For regular subscripts (not dynamic member lookups), the index expressions
+    // are always read, regardless of how the subscript is being used (read or write).
+    // Do not propagate a write access kind into the subscript arguments.
+    // However, for dynamic member lookup subscripts, the argument represents
+    // a member being accessed, so it should reflect the access kind.
+    bool isKeyPathDynamicMemberLookup = false;
+    if (auto *SD = dyn_cast_or_null<SubscriptDecl>(SubscrD)) {
+      // Check if the base type has @dynamicMemberLookup
+      Type baseType = SE->getBase()->getType();
+      if (baseType) {
+        baseType = baseType->getWithoutSpecifierType();
+        if (baseType->hasDynamicMemberLookupAttribute() &&
+            isValidKeyPathDynamicMemberLookup(SD)) {
+          isKeyPathDynamicMemberLookup = true;
+        }
+      }
+    }
+
+    if (!isKeyPathDynamicMemberLookup) {
+      llvm::SaveAndRestore<std::optional<AccessKind>>
+          C(this->OpAccess, std::nullopt);
+      if (!SE->getArgs()->walk(*this))
+        return Action::Stop();
+    } else {
+      if (!SE->getArgs()->walk(*this))
+        return Action::Stop();
+    }
 
     if (SubscrD) {
       if (!passSubscriptReference(SubscrD, E->getEndLoc(), data, false))

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -66,11 +66,11 @@ namespace constraints {
 enum class DeclTypeCheckingSemantics {
   /// A normal declaration.
   Normal,
-  
+
   /// The type(of:) declaration, which performs a "dynamic type" operation,
   /// with different behavior for existential and non-existential arguments.
   TypeOf,
-  
+
   /// The withoutActuallyEscaping(_:do:) declaration, which makes a nonescaping
   /// closure temporarily escapable.
   WithoutActuallyEscaping,
@@ -294,7 +294,7 @@ public:
         RequirementFailureInfo{Req, SubstReq, { }, IsolatedConformances,
                                IsolatedConformanceProto});
   }
-  
+
   const RequirementFailureInfo &getRequirementFailureInfo() const {
     assert(Kind == CheckRequirementsResult::RequirementFailure);
 
@@ -1342,14 +1342,6 @@ bool isValidStringDynamicMemberLookup(SubscriptDecl *decl,
 BoundGenericType *
 getKeyPathTypeForDynamicMemberLookup(SubscriptDecl *decl,
                                      bool ignoreLabel = false);
-
-/// Returns true if the given subscript method is an valid implementation of
-/// the `subscript(dynamicMember: {Writable}KeyPath<...>)` requirement for
-/// @dynamicMemberLookup.
-/// The method is given to be defined as `subscript(dynamicMember:)` which
-/// takes a single non-variadic parameter of `{Writable}KeyPath<T, U>` type.
-bool isValidKeyPathDynamicMemberLookup(SubscriptDecl *decl,
-                                       bool ignoreLabel = false);
 
 /// Compute the wrapped value type for the given property that has attached
 /// property wrappers, when the backing storage is known to have the given type.

--- a/test/Index/index_subscript_key.swift
+++ b/test/Index/index_subscript_key.swift
@@ -1,0 +1,36 @@
+// RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %s | %FileCheck %s
+
+// Test that properties used as subscript keys are treated as reads (getter), not writes (setter).
+let key = "key"
+var dictionary: [String: Any] = [:]
+// CHECK: [[@LINE+2]]:12 | variable/Swift | key | {{.*}} | Ref,Read | rel: 0
+// CHECK: [[@LINE+1]]:12 | function/acc-get/Swift | getter:key | {{.*}} | Ref,Call,Impl | rel: 0
+dictionary[key] = 42
+
+// Test that chained property accesses used as subscript keys are treated as reads.
+struct Config {
+  var settings: Settings
+}
+struct Settings {
+  var apiKey: String
+}
+let config = Config(settings: Settings(apiKey: "secret"))
+var apiKeyDict: [String: String] = [:]
+// CHECK: [[@LINE+6]]:12 | variable/Swift | config | {{.*}} | Ref,Read | rel: 0
+// CHECK: [[@LINE+5]]:12 | function/acc-get/Swift | getter:config | {{.*}} | Ref,Call,Impl | rel: 0
+// CHECK: [[@LINE+4]]:19 | instance-property/Swift | settings | {{.*}} | Ref,Read | rel: 0
+// CHECK: [[@LINE+3]]:19 | instance-method/acc-get/Swift | getter:settings | {{.*}} | Ref,Call,Impl | rel: 0
+// CHECK: [[@LINE+2]]:28 | instance-property/Swift | apiKey | {{.*}} | Ref,Read | rel: 0
+// CHECK: [[@LINE+1]]:28 | instance-method/acc-get/Swift | getter:apiKey | {{.*}} | Ref,Call,Impl | rel: 0
+apiKeyDict[config.settings.apiKey] = "new-secret"
+
+// Test that keypaths used as subscript keys are also treated as reads.
+struct KeyPathContainer {
+  var value: Int = 0
+}
+let container = KeyPathContainer()
+var keyPathDict: [KeyPath<KeyPathContainer, Int>: Int] = [:]
+// CHECK: [[@LINE+3]]:31 | instance-property/Swift | value | {{.*}} | Ref,Read | rel: 0
+// CHECK: [[@LINE+2]]:31 | instance-method/acc-get/Swift | getter:value | {{.*}} | Ref,Call,Impl | rel: 0
+// CHECK: [[@LINE+1]]:14 | struct/Swift | KeyPathContainer | {{.*}} | Ref | rel: 0
+keyPathDict[\KeyPathContainer.value] = 42


### PR DESCRIPTION
- **Explanation**:
Properties used as subscript keys (e.g., `dictionary[key] = 42`) were incorrectly indexed as writes, referencing setters instead of getters. Fix by forcing subscript arguments to be treated as reads, except for dynamic member lookup subscripts where the argument represents the member being accessed.
- **Scope**:
Purely additive to the index store. Can help tools such as [Periphery](https://github.com/peripheryapp/periphery) be more accurate.
- **Issues**:
#56541
- **Original PRs**:
#86119
- **Risk**:
Very low, perhaps a slight increase in index store size.
- **Testing**:
Passed all tests across all platforms.
- **Reviewers**:
@hamishknight 