### PR TITLE
Optimizer: fix a few problems where destroys are illegally hoisted across deinit barriers

### DIFF
--- a/lib/SILOptimizer/Utils/OSSACanonicalizeOwned.cpp
+++ b/lib/SILOptimizer/Utils/OSSACanonicalizeOwned.cpp
@@ -409,8 +409,6 @@ void OSSACanonicalizeOwned::extendLivenessToDeinitBarriers() {
         });
   } else {
     for (auto destroy : destroys) {
-      if (destroy->getOperand(0) != getCurrentDef())
-        continue;
       ends.push_back(destroy);
     }
   }

--- a/test/SILOptimizer/copy_propagation.sil
+++ b/test/SILOptimizer/copy_propagation.sil
@@ -33,7 +33,9 @@ sil [ossa] @takeOwnedCTwice : $@convention(thin) (@owned C, @owned C) -> ()
 sil [ossa] @takeOwnedCAndGuaranteedC : $@convention(thin) (@owned C, @guaranteed C) -> ()
 sil [ossa] @takeGuaranteedC : $@convention(thin) (@guaranteed C) -> ()
 sil [ossa] @borrowB : $@convention(thin) (@guaranteed B) -> ()
-sil [ossa] @takeGuaranteedAnyObject : $@convention(thin) (@guaranteed AnyObject) -> ()
+sil [ossa] @takeGuaranteedAnyObject : $@convention(thin) (@guaranteed AnyObject) -> () {
+[global:]
+}
 sil [ossa] @getMOS : $() -> (@owned MOS)
 
 // -O hoists the destroy
@@ -1014,10 +1016,8 @@ bb0:
 // CHECK:         [[BARRIER:%[^,]+]] = function_ref @barrier
 // CHECK:         [[BORROW:%[^,]+]] = function_ref @takeGuaranteedC
 // CHECK:         apply [[BORROW]]([[INSTANCE]])
-// The destroy of the copy should be hoisted over the deinit barrier, and then
-// canonicalization of the lexical value should remove the copy.
-// CHECK:         destroy_value [[INSTANCE]]
 // CHECK:         apply [[BARRIER]]()
+// CHECK:         destroy_value [[INSTANCE]]
 // CHECK-LABEL: } // end sil function 'hoist_destroy_of_copy_of_lexical_over_deinit_barrier'
 sil [ossa] @hoist_destroy_of_copy_of_lexical_over_deinit_barrier : $(@owned C) -> () {
 entry(%instance : @owned $C):

--- a/test/SILOptimizer/lexical_closure_lifetime.swift
+++ b/test/SILOptimizer/lexical_closure_lifetime.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift | %FileCheck %s
+// RUN: %target-run-simple-swift(-O) | %FileCheck %s
 
 // REQUIRES: executable_test
 

--- a/test/SILOptimizer/lexical_closure_lifetime.swift
+++ b/test/SILOptimizer/lexical_closure_lifetime.swift
@@ -1,0 +1,35 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+
+// REQUIRES: executable_test
+
+class C {}
+
+func runit<T>(_ c: () -> T) -> T {
+  return c()
+}
+
+func testit() -> C? {
+    weak var weakRef: C? = nil
+
+    let resultsHandler = runit {
+        let c = C()
+        weakRef = c
+
+        let x: () -> () = {
+            _ = c
+        }
+        return x
+    }
+
+    resultsHandler()
+
+    return weakRef
+}
+
+if testit() == nil {
+  fatalError()
+}
+
+// CHECK: success
+print("success")
+

--- a/test/SILOptimizer/mandatory_inlining_ownership.sil
+++ b/test/SILOptimizer/mandatory_inlining_ownership.sil
@@ -655,6 +655,26 @@ bb0(%0 : $Int):
   return %r
 }
 
+// CHECK-LABEL: sil [ossa] @lexical_partial_apply :
+// CHECK:         %1 = move_value [lexical] %0
+// CHECK:       } // end sil function 'lexical_partial_apply'
+sil [ossa] @lexical_partial_apply : $@convention(thin) (@owned String) -> () {
+bb0(%0 : @owned $String):
+  %1 = function_ref @closure : $@convention(thin) (@guaranteed String) -> ()
+  %2 = partial_apply [callee_guaranteed] %1(%0) : $@convention(thin) (@guaranteed String) -> ()
+  %3 = move_value [lexical] %2
+  %4 = apply %3() : $@callee_guaranteed () -> ()
+  destroy_value %3
+  %6 = tuple ()
+  return %6
+}
+
+sil [transparent] [ossa] @closure : $@convention(thin) (@guaranteed String) -> () {
+bb0(%0 : @guaranteed $String):
+  %1 = tuple ()
+  return %1
+}
+
 sil_vtable C2 {
   #C2.i!modify: (C2) -> () -> () : @devirt_callee
 }

--- a/test/SILOptimizer/sil_combine_ossa.sil
+++ b/test/SILOptimizer/sil_combine_ossa.sil
@@ -39,6 +39,10 @@ struct PointerStorage {
 class B { }
 class E : B { }
 
+class D {
+  @_hasStorage weak var c: B?
+}
+
 sil @use_b_guaranteed : $@convention(thin) (@guaranteed B) -> ()
 sil @usearray_error : $@convention(thin) (@guaranteed Array<Error>) -> ()
 
@@ -5582,6 +5586,20 @@ bb1:
   dealloc_stack %2
   %9 = tuple ()
   return %9
+}
+
+// CHECK-LABEL: sil [ossa] @dont_hoist_destroy_over_deinit_barrier :
+// CHECK:         load_weak
+// CHECK-NEXT:    destroy_value %0
+// CHECK:       } // end sil function 'dont_hoist_destroy_over_deinit_barrier'
+sil [ossa] @dont_hoist_destroy_over_deinit_barrier : $@convention(thin) (@owned B, @guaranteed D) -> @owned Optional<B> {
+bb0(%0 : @owned $B, %1 : @guaranteed $D):
+  %2 = copy_value %0
+  destroy_value %0
+  %4 = ref_element_addr %1, #D.c
+  %5 = load_weak %4
+  destroy_value %2
+  return %5
 }
 
 // Just check that this doesn't produce illegal SIL

--- a/test/SILOptimizer/silgen_cleanup.sil
+++ b/test/SILOptimizer/silgen_cleanup.sil
@@ -341,28 +341,6 @@ bb0(%0 : @guaranteed $Builtin.NativeObject):
   return %1 : $Builtin.NativeObject
 }
 
-// Test SemanticARCOpts eliminateSimpleCopies. At -O, remove the
-// debug_value with the copy to avoid a lifetime violation. -Onone, do nothing.
-//
-// CHECK-LABEL: sil [ossa] @testSimpleCopyWithDebug : $@convention(thin) (@owned Klass) -> Builtin.Int64 {
-// CHECKOPT-NOT: copy_value
-// CHECKOPT-NOT: debug_value
-// CHECKDEB: copy_value
-// CHECKDEB: debug_value
-// CHECK-LABEL: } // end sil function 'testSimpleCopyWithDebug'
-sil [ossa] @testSimpleCopyWithDebug : $@convention(thin) (@owned Klass) -> Builtin.Int64 {
-bb9(%0 : @owned $Klass):
-  %borrow = begin_borrow %0 : $Klass
-  %p = ref_element_addr %borrow : $Klass, #Klass.property
-  %v = load [trivial] %p : $*Builtin.Int64
-  %copy = copy_value %borrow : $Klass
-  end_borrow %borrow : $Klass
-  debug_value %copy : $Klass, let, name "c"
-  destroy_value %copy : $Klass
-  destroy_value %0 : $Klass
-  return %v : $Builtin.Int64
-}
-
 struct Outer {
   var middle: Middle
 }

--- a/test/stdlib/move_function.swift
+++ b/test/stdlib/move_function.swift
@@ -75,7 +75,9 @@ extension Class {
         }
         switch (x)[userHandle] {
         case .foo:
-            expectTrue(self.array._buffer.isUniquelyReferenced())
+          // The array buffer is not unique because the lexical lifetime of x spans
+          // over the switch statement.
+          expectFalse(self.array._buffer.isUniquelyReferenced())
         }
     }
 }


### PR DESCRIPTION
* In MandatoryInlining: fix handling of inlined lexical closures
* remove the "eliminateSimpleCopies" peephole optimization from instruction canonicalization
* let OSSA canonicalization always respect deinit barriers

For details see the commit messages

Fixes a mis-compile
rdar://168337959
