### PR TITLE
[update-checkout] force cloning with 'core.autoclrf=false' and 'core.symlinks=true'

### DIFF
--- a/utils/update_checkout/tests/test_clone.py
+++ b/utils/update_checkout/tests/test_clone.py
@@ -11,6 +11,7 @@
 # ===----------------------------------------------------------------------===#
 
 import os
+import subprocess
 import sys
 import shutil
 from unittest.mock import patch
@@ -94,6 +95,68 @@ class CloneTestCase(scheme_mock.SchemeMockTestCase):
             "You don't have all swift sources. Call this script with --clone to get them.",
             output,
         )
+
+    def test_clone_with_git_config(self):
+        """
+        Test that git is cloning with the following settings:
+         - core.symlinks = true
+         - core.autocrlf = false
+        """
+        self.call(
+            [
+                self.update_checkout_path,
+                "--config",
+                self.config_path,
+                "--source-root",
+                self.source_root,
+                "--clone",
+            ]
+        )
+
+        for repo in self.get_all_repos():
+            repo_path = os.path.join(self.source_root, repo)
+            output = subprocess.check_output(
+                ["git", "-C", repo_path, "config", "--get", "core.symlinks"], text=True
+            )
+            self.assertIn("true", output)
+            output = subprocess.check_output(
+                ["git", "-C", repo_path, "config", "--get", "core.autocrlf"], text=True
+            )
+            self.assertIn("false", output)
+
+    @patch("update_checkout.update_checkout.obtain_all_additional_swift_sources")
+    @patch("sys.exit", return_value=None)
+    def test_clone_with_incorrect_git_config(self, mock_exit, mock_obtain):
+        repo = self.get_all_repos()[0]
+
+        def side_effect(*args, **kwargs):
+            result = obtain_all_additional_swift_sources(*args, **kwargs)
+            repo_path = os.path.join(self.source_root, repo)
+            subprocess.run(["git", "-C", repo_path, "config", "core.symlinks", "false"])
+            subprocess.run(["git", "-C", repo_path, "config", "core.autocrlf", "true"])
+            return result
+
+        mock_obtain.side_effect = side_effect
+
+        sys.argv = [
+            "update-checkout",
+            "--config",
+            self.config_path,
+            "--source-root",
+            self.source_root,
+            "--clone",
+        ]
+        with contextlib.redirect_stdout(StringIO()) as stdout:
+            main()
+            output = stdout.getvalue()
+            self.assertIn(
+                f"[WARNING] '{repo}' was not cloned with 'core.symlinks=true'. This can cause build/tests failures.",
+                output,
+            )
+            self.assertIn(
+                f"[WARNING] '{repo}' was not cloned with 'core.autocrlf=false'. This can cause build/tests failures.",
+                output,
+            )
 
     @patch("update_checkout.update_checkout.obtain_all_additional_swift_sources")
     @patch("sys.exit", return_value=None)

--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -13,6 +13,7 @@ import os
 from pathlib import Path
 import platform
 import re
+import subprocess
 import sys
 import traceback
 from typing import Any, Dict, Hashable, Optional, List, Tuple, Union
@@ -371,25 +372,72 @@ def _check_missing_clones(
     Returns:
         Prints a warning if any required repository is missing.
     """
-
-    directory_contents = {path.name for path in args.source_root.iterdir()}
-    current_platform = platform.system()
-
     for repo in scheme_map:
-        repo_config = config["repos"].get(repo, {})
-
-        if (
-            "platforms" in repo_config
-            and current_platform not in repo_config["platforms"]
-        ):
+        if _should_skip_repo(args, config, repo):
             continue
 
-        if repo not in directory_contents and repo not in args.skip_repository_list:
+        if not args.source_root.joinpath(repo).exists():
             print(
                 "You don't have all swift sources. "
                 "Call this script with --clone to get them."
             )
             return
+
+
+def _check_git_config(
+    args: CliArguments, config: Dict[str, Any], scheme_map: Dict[str, Any]
+):
+    """
+    Verify git configuration for all cloned repositories.
+    Warns if core.symlinks or core.autocrlf are not set correctly.
+
+    Args:
+        args (CliArguments): Parsed CLI arguments.
+        config (Dict[str, Any]): deserialized `update-checkout-config.json`.
+        scheme_map (Dict[str, str] | None): map of repo names to branches to check out.
+
+    Returns:
+        Prints a warning if any required repository is missing.
+    """
+    git_configs = {
+        "core.symlinks": "true",
+        "core.autocrlf": "false",
+    }
+
+    for repo in scheme_map:
+        if _should_skip_repo(args, config, repo):
+            continue
+
+        repo_path = args.source_root.joinpath(repo)
+        if not repo_path.exists():
+            continue
+
+        for config_key, expected_value in git_configs.items():
+            output = subprocess.check_output(
+                ["git", "-C", str(repo_path), "config", "--get", config_key],
+                text=True,
+                stderr=subprocess.DEVNULL,
+            )
+            if expected_value not in output:
+                print(
+                    f"[WARNING] '{repo}' was not cloned with "
+                    f"'{config_key}={expected_value}'. "
+                    "This can cause build/tests failures."
+                )
+
+
+def _should_skip_repo(args: CliArguments, config: Dict[str, Any], repo: str) -> bool:
+    """Check if a repository should be skipped based on platform or skip list."""
+    if repo in args.skip_repository_list:
+        return True
+
+    repo_config = config["repos"].get(repo, {})
+    if "platforms" in repo_config:
+        current_platform = platform.system()
+        if current_platform not in repo_config["platforms"]:
+            return True
+
+    return False
 
 
 def _move_llvm_project_to_first_index(
@@ -485,6 +533,10 @@ def obtain_additional_swift_sources(pool_args: AdditionalSwiftSourcesArguments):
             args.source_root,
             [
                 "clone",
+                "--config",
+                "core.symlinks=true",
+                "--config",
+                "core.autocrlf=false",
                 "--recursive",
                 "--depth",
                 "1",
@@ -508,7 +560,16 @@ def obtain_additional_swift_sources(pool_args: AdditionalSwiftSourcesArguments):
     else:
         Git.run(
             args.source_root,
-            ["clone", "--recursive", remote, repo_name]
+            [
+                "clone",
+                "--config",
+                "core.symlinks=true",
+                "--config",
+                "core.autocrlf=false",
+                "--recursive",
+                remote,
+                repo_name,
+            ]
             + (["--no-tags"] if skip_tags else []),
             env=env,
             echo=verbose,
@@ -848,6 +909,8 @@ def main() -> int:
             skipped_repositories, clone_results = obtain_all_additional_swift_sources(
                 args, config, scheme_name, skip_repo_list
             )
+            _check_git_config(args, config, scheme_map)
+
             SkippedReason.print_skipped_repositories(skipped_repositories, "clone")
 
         swift_repo_path = args.source_root.joinpath("swift")


### PR DESCRIPTION
This patch forces cloning with `core.autoclrf=false` and `core.symlinks=true` in update-checkout.

When cloning, `update-checkout` will ensure that `core.autoclrf=false` and `core.symlinks=true` are set. It will print a warning if those values are not set after the clone: on Windows, these settings can get overwritten if symlinks are not enabled.

Some tests (mostly in SourceKit) require specific line endings. `core.autoclrf=true` will cause tests failures.

rdar://168500181