### PR TITLE
[rbi] Preparatory work for splitting indirect and direct assigns.

### DIFF
--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -1237,6 +1237,11 @@ private:
   friend class TrailingOperandsList;
 };
 
+inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, const Operand &op) {
+  op.print(OS);
+  return OS;
+}
+
 /// A class which adapts an array of Operands into an array of Values.
 ///
 /// The intent is that this should basically act exactly like

--- a/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
@@ -151,6 +151,14 @@ public:
 
   bool isNonSendable() const { return !isSendable(); }
 
+  /// Return a copy of this trackable state with the id being \p newID instead
+  /// of whatever is stored in this state.
+  TrackableValueState getWithNewID(unsigned newID) const {
+    auto newVal = *this;
+    newVal.id = newID;
+    return newVal;
+  }
+
   SILIsolationInfo getIsolationRegionInfo() const {
     if (!regionInfo) {
       return SILIsolationInfo::getDisconnected(false);
@@ -408,6 +416,12 @@ public:
   /// exists. Returns nullptr otherwise.
   SILInstruction *maybeGetActorIntroducingInst(Element trackableValueID) const;
 
+  /// Given the value of use \p op that is mapped to memory that will be
+  /// overwritten, produce a new TrackableValue that represents the value that
+  /// was in that memory.
+  TrackableValue
+  getRepresentativeValueForValueFromOverwrittenMemory(Operand *op) const;
+
   SILIsolationInfo getIsolationRegion(Element trackableValueID) const;
   SILIsolationInfo getIsolationRegion(SILValue trackableValueID) const;
 
@@ -440,6 +454,7 @@ private:
   TrackableValue
   getActorIntroducingRepresentative(SILInstruction *introducingInst,
                                     SILIsolationInfo isolation) const;
+
   bool valueHasID(SILValue value, bool dumpIfHasNoID = false);
   Element lookupValueID(SILValue value);
 

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -2188,10 +2188,10 @@ public:
   /// element isolation of disconnected. NOTE: The results will still be in the
   /// region of the non-Sendable arguments so at the region level they will have
   /// the same value.
-  template <typename TargetRange, typename SourceRange>
+  template <typename DirectResultsRangeTy, typename SourceValueRangeTy>
   void
-  translateSILMultiAssign(const TargetRange &directResultValues,
-                          const SourceRange &sourceValues,
+  translateSILMultiAssign(const DirectResultsRangeTy &directResultValues,
+                          const SourceValueRangeTy &sourceValues,
                           SILIsolationInfo resultIsolationInfoOverride = {},
                           bool requireSrcValues = true) {
     SmallVector<std::pair<Operand *, TrackableValue>, 8> assignOperands;

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -2226,8 +2226,6 @@ public:
 
       // Perform our lookup result.
       if (auto lookupResult = tryToTrackValue(src)) {
-        auto value = lookupResult->value;
-
         // If our value is non-Sendable require it and if we have a base and
         // that base is non-Sendable, require that as well.
         //
@@ -2240,6 +2238,8 @@ public:
         if (requireSrcValues) {
           builder.addRequire(*lookupResult);
         }
+
+        auto value = lookupResult->value;
 
         // If our value was actually Sendable, skip it, we do not want to merge
         // anything.

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -4496,8 +4496,6 @@ static FunctionTest PartitionOpsTest(
     [](auto &function, auto &arguments, auto &test) {
       llvm::BumpPtrAllocator allocator;
       IsolationHistory::Factory historyFactory(allocator);
-      SendingOperandSetFactory ptrSetFactory(allocator);
-      SendingOperandToStateMap sendingOperandToStateMap(historyFactory);
       RegionAnalysisValueMap valueMap(&function);
       PartitionOpTranslator translator(
           &function,

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -3520,7 +3520,6 @@ CONSTANT_TRANSLATION(TupleInst, Assign)
 // underlying region.
 CONSTANT_TRANSLATION(BeginAccessInst, LookThrough)
 CONSTANT_TRANSLATION(BorrowedFromInst, LookThrough)
-CONSTANT_TRANSLATION(BeginDeallocRefInst, LookThrough)
 CONSTANT_TRANSLATION(BridgeObjectToRefInst, LookThrough)
 CONSTANT_TRANSLATION(CopyValueInst, LookThrough)
 CONSTANT_TRANSLATION(ExplicitCopyValueInst, LookThrough)
@@ -4042,6 +4041,14 @@ PartitionOpTranslator::visitMarkDependenceInst(MarkDependenceInst *mdi) {
   assert(isStaticallyLookThroughInst(mdi) && "Out of sync");
   translateSILLookThrough(mdi->getResults(), mdi->getValue());
   translateSILRequire(mdi->getBase());
+  return TranslationSemantics::Special;
+}
+
+TranslationSemantics
+PartitionOpTranslator::visitBeginDeallocRefInst(BeginDeallocRefInst *bdr) {
+  assert(isStaticallyLookThroughInst(bdr) && "Out of sync");
+  translateSILLookThrough(SILValue(bdr), bdr->getReference());
+  translateSILRequire(bdr->getAllocation());
   return TranslationSemantics::Special;
 }
 

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -1654,24 +1654,6 @@ struct PartitionOpBuilder {
         PartitionOp::AssignFresh(id, currentInst));
   }
 
-  void addAssignFresh(ArrayRef<SILValue> values) {
-    if (values.empty())
-      return;
-
-    auto first = lookupValueID(values.front());
-    currentInstPartitionOps->emplace_back(
-        PartitionOp::AssignFresh(first, currentInst));
-
-    auto transformedCollection =
-        makeTransformRange(values.drop_front(), [&](SILValue value) {
-          return lookupValueID(value);
-        });
-    for (auto id : transformedCollection) {
-      currentInstPartitionOps->emplace_back(
-          PartitionOp::AssignFreshAssign(id, first, currentInst));
-    }
-  }
-
   void addAssignFresh(ArrayRef<TrackableValue> values) {
     if (values.empty())
       return;
@@ -3819,7 +3801,7 @@ PartitionOpTranslator::visitAllocStackInst(AllocStackInst *asi) {
 
   // NOTE: To prevent an additional reinitialization by the canned AssignFresh
   // code, we do our own assign fresh and return special.
-  builder.addAssignFresh(v->first.getRepresentative().getValue());
+  builder.addAssignFresh(v->first);
   return TranslationSemantics::Special;
 }
 

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -130,11 +130,19 @@ void PartitionOpError::InOutSendingParametersInSameRegionError::print(
 void PartitionOp::print(llvm::raw_ostream &os, bool extraSpace) const {
   constexpr static char extraSpaceLiteral[10] = "     ";
   switch (opKind) {
-  case PartitionOpKind::Assign: {
-    os << "assign ";
+  case PartitionOpKind::AssignDirect: {
+    os << "assign_direct ";
     if (extraSpace)
       os << extraSpaceLiteral;
     os << "%%" << getOpArg1() << " = %%" << getOpArg2();
+    break;
+  }
+  case PartitionOpKind::AssignIndirect: {
+    os << "assign_indirect ";
+    if (extraSpace)
+      os << extraSpaceLiteral;
+    os << "%%" << getOpArg1() << " = %%" << getOpArg2()
+       << ". Overwritten Value: " << getOpArg3();
     break;
   }
   case PartitionOpKind::AssignFresh:

--- a/test/Concurrency/transfernonsendable_partitionop_translation.sil
+++ b/test/Concurrency/transfernonsendable_partitionop_translation.sil
@@ -1,0 +1,3428 @@
+// RUN: %target-sil-opt -module-name partop_translation --test-runner %s 2>&1 | %FileCheck %s
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+// PLEASE READ THIS!
+//
+// This test is specifically meant to test how we transform instructions into
+// PartitionOps using SIL test infrastructure.
+
+sil_stage raw
+
+import Swift
+import Builtin
+import _Concurrency
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+class NonSendableKlass : NonSendableProtocol {
+}
+
+class NonSendableKlassSubKlass : NonSendableKlass {
+}
+
+struct SingleFieldStruct {
+  var field: NonSendableKlass
+}
+
+struct TwoFieldStruct {
+  var first: NonSendableKlass
+  var second: NonSendableKlass
+}
+
+enum NonSendableEnum {
+  case none
+  case some(NonSendableKlass)
+}
+
+protocol NonSendableProtocol {
+}
+
+class DerivedKlass : NonSendableKlass {}
+
+class KlassWithField {
+  var field: NonSendableKlass
+}
+
+class MethodKlass {
+  func instanceMethod()
+}
+
+protocol SomeProtocol {
+  func doSomething()
+}
+
+struct MoveOnlyStruct : ~Copyable {
+  var value: NonSendableKlass
+  deinit
+}
+
+struct NonSendableStruct {
+  var field: NonSendableKlass
+}
+
+enum MyErrorNonSendable : Error {
+case failure
+case failure2(NonSendableKlass)
+}
+
+sil_global @global_nonsendable : $NonSendableKlass
+sil_global @immutable_global : $NonSendableKlass
+
+sil @some_function : $@convention(thin) () -> ()
+sil @callee : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
+sil @takes_two : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> ()
+sil @throwing_callee : $@convention(thin) (@guaranteed NonSendableKlass) -> @error any Error
+sil @coro_callee : $@yield_once @convention(thin) (@guaranteed NonSendableKlass) -> @yields @inout NonSendableKlass
+sil [dynamically_replacable] @dynamic_func : $@convention(thin) () -> ()
+sil @thin_func : $@convention(thin) () -> ()
+sil @nsk_to_nsk : $@convention(thin) (@guaranteed NonSendableKlass) -> @owned NonSendableKlass
+sil @block_invoke : $@convention(c) (@inout_aliasable @block_storage NonSendableKlass) -> ()
+sil @$s4main11MethodKlassC14instanceMethodyyF : $@convention(method) (@guaranteed MethodKlass) -> ()
+
+// Function declarations for comprehensive apply tests
+sil @takes_owned : $@convention(thin) (@owned NonSendableKlass) -> ()
+sil @takes_guaranteed : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
+sil @returns_owned : $@convention(thin) () -> @owned NonSendableKlass
+sil @takes_in : $@convention(thin) (@in NonSendableStruct) -> ()
+sil @takes_in_guaranteed : $@convention(thin) (@in_guaranteed NonSendableStruct) -> ()
+sil @takes_inout : $@convention(thin) (@inout NonSendableStruct) -> ()
+sil @takes_inout_aliasable : $@convention(thin) (@inout_aliasable NonSendableStruct) -> ()
+sil @takes_owned_and_guaranteed : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass) -> ()
+sil @takes_in_and_guaranteed : $@convention(thin) (@in NonSendableStruct, @guaranteed NonSendableKlass) -> ()
+sil @takes_inout_and_guaranteed : $@convention(thin) (@inout NonSendableStruct, @guaranteed NonSendableKlass) -> ()
+sil @takes_three_mixed : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass, @in NonSendableStruct) -> ()
+sil @takes_four_mixed : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass, @inout NonSendableStruct, @in_guaranteed NonSendableStruct) -> ()
+sil @returns_out : $@convention(thin) () -> @out NonSendableStruct
+sil @returns_owned_direct : $@convention(thin) () -> @owned NonSendableKlass
+sil @returns_multiple_out : $@convention(thin) () -> (@out NonSendableStruct, @out NonSendableStruct)
+sil @returns_mixed : $@convention(thin) () -> (@out NonSendableStruct, @owned NonSendableKlass)
+sil @takes_and_returns_out : $@convention(thin) (@guaranteed NonSendableKlass) -> @out NonSendableStruct
+sil @$s18NonSendableKlassC6methodyyF : $@convention(method) (@guaranteed NonSendableKlass) -> ()
+sil @$s18NonSendableKlassC11methodTakesyAA0bC0CF : $@convention(method) (@owned NonSendableKlass, @guaranteed NonSendableKlass) -> ()
+sil @witness_method_impl : $@convention(witness_method: NonSendableProtocol) <Self where Self : NonSendableProtocol> (@in_guaranteed Self) -> ()
+sil @throws_with_owned : $@convention(thin) (@owned NonSendableKlass) -> (@owned NonSendableKlass, @error any Error)
+sil @throws_with_in : $@convention(thin) (@in NonSendableStruct) -> @error any Error
+sil @throws_multiple_params : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass) -> @error any Error
+sil @coro_yields_owned : $@yield_once @convention(thin) (@guaranteed NonSendableKlass) -> @yields @owned NonSendableKlass
+sil @coro_yields_inout : $@yield_once @convention(thin) (@guaranteed NonSendableKlass) -> @yields @inout NonSendableStruct
+sil @coro_multiple_params : $@yield_once @convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass) -> @yields @inout NonSendableStruct
+
+/////////////////
+// MARK: Tests //
+/////////////////
+
+// CHECK-LABEL: begin running test {{.*}} on test_store_init: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = alloc_stack $NonSendableKlass
+// CHECK-NEXT: require %%0:   store %2 to [init] %1 : $*NonSendableKlass
+// CHECK-NEXT: assign_direct %%1 = %%0:   store %2 to [init] %1 : $*NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_store_init: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_store_init : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %1 = alloc_stack $NonSendableKlass
+  %2 = copy_value %0
+  store %2 to [init] %1
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_addr %1
+  dealloc_stack %1
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Store Instructions
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_store_init_projected: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %1 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %2 = alloc_stack $TwoFieldStruct
+// CHECK-NEXT: require %%2:   store %7 to [init] %6 : $*NonSendableKlass
+// CHECK-NEXT: require %%1:   store %7 to [init] %6 : $*NonSendableKlass
+// CHECK-NEXT: merge %%2 with %%1:   store %7 to [init] %6 : $*NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_store_init_projected: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_store_init_projected : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass, %arg1 : @guaranteed $NonSendableKlass):
+  %1 = alloc_stack $TwoFieldStruct
+  // Initialize first field
+  %2 = struct_element_addr %1 : $*TwoFieldStruct, #TwoFieldStruct.first
+  %3 = copy_value %0
+  store %3 to [init] %2
+  // Initialize second field
+  %second = struct_element_addr %1 : $*TwoFieldStruct, #TwoFieldStruct.second
+  %secondVal = copy_value %arg1
+  store %secondVal to [init] %second
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_addr %1
+  dealloc_stack %1
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_store_assign_unaliased: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %1 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %2 = alloc_stack $NonSendableKlass
+// CHECK-NEXT: require %%1:   store %5 to [assign] %2 : $*NonSendableKlass
+// CHECK-NEXT: assign_direct %%2 = %%1:   store %5 to [assign] %2 : $*NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_store_assign_unaliased: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_store_assign_unaliased : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass, %1 : @guaranteed $NonSendableKlass):
+  %2 = alloc_stack $NonSendableKlass
+  %3 = copy_value %0
+  store %3 to [init] %2
+  %4 = copy_value %1
+  store %4 to [assign] %2
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_addr %2
+  dealloc_stack %2
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_store_assign_projected: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %1 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %2 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%3: TrackableValue. State: TrackableValueState[id: 3][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %3 = alloc_stack $TwoFieldStruct
+// CHECK-NEXT: require %%3:   store %10 to [assign] %4 : $*NonSendableKlass
+// CHECK-NEXT: require %%1:   store %10 to [assign] %4 : $*NonSendableKlass
+// CHECK-NEXT: merge %%3 with %%1:   store %10 to [assign] %4 : $*NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_store_assign_projected: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_store_assign_projected : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass, %1 : @guaranteed $NonSendableKlass, %arg2 : @guaranteed $NonSendableKlass):
+  %2 = alloc_stack $TwoFieldStruct
+  // Initialize first field
+  %3 = struct_element_addr %2 : $*TwoFieldStruct, #TwoFieldStruct.first
+  %4 = copy_value %0
+  store %4 to [init] %3
+  // Initialize second field
+  %second = struct_element_addr %2 : $*TwoFieldStruct, #TwoFieldStruct.second
+  %secondVal = copy_value %arg2
+  store %secondVal to [init] %second
+  // Now do an assign to first field
+  %5 = copy_value %1
+  store %5 to [assign] %3
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_addr %2
+  dealloc_stack %2
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_copy_addr_to_init: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %2 = alloc_stack $NonSendableKlass
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = alloc_stack $NonSendableKlass
+// CHECK-NEXT: require %%2:   copy_addr %1 to [init] %2 : $*NonSendableKlass
+// CHECK-NEXT: assign_direct %%1 = %%2:   copy_addr %1 to [init] %2 : $*NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_copy_addr_to_init: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_copy_addr_to_init : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %1 = alloc_stack $NonSendableKlass
+  %2 = alloc_stack $NonSendableKlass
+  %3 = copy_value %0
+  store %3 to [init] %1
+  copy_addr %1 to [init] %2
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_addr %1
+  destroy_addr %2
+  dealloc_stack %2
+  dealloc_stack %1
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_copy_addr_take_to_init: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %2 = alloc_stack $NonSendableKlass
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = alloc_stack $NonSendableKlass
+// CHECK-NEXT: require %%2:   copy_addr [take] %1 to [init] %2 : $*NonSendableKlass
+// CHECK-NEXT: assign_direct %%1 = %%2:   copy_addr [take] %1 to [init] %2 : $*NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_copy_addr_take_to_init: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_copy_addr_take_to_init : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %1 = alloc_stack $NonSendableKlass
+  %2 = alloc_stack $NonSendableKlass
+  %3 = copy_value %0
+  store %3 to [init] %1
+  copy_addr [take] %1 to [init] %2
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_addr %2
+  dealloc_stack %2
+  dealloc_stack %1
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_copy_addr_to_initialized: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %1 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %3 = alloc_stack $NonSendableKlass
+// CHECK-NEXT: %%3: TrackableValue. State: TrackableValueState[id: 3][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %2 = alloc_stack $NonSendableKlass
+// CHECK-NEXT: require %%3:   copy_addr %2 to %3 : $*NonSendableKlass
+// CHECK-NEXT: assign_direct %%2 = %%3:   copy_addr %2 to %3 : $*NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_copy_addr_to_initialized: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_copy_addr_to_initialized : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass, %1 : @guaranteed $NonSendableKlass):
+  %2 = alloc_stack $NonSendableKlass
+  %3 = alloc_stack $NonSendableKlass
+  %4 = copy_value %0
+  store %4 to [init] %2
+  %5 = copy_value %1
+  store %5 to [init] %3
+  copy_addr %2 to %3
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_addr %2
+  destroy_addr %3
+  dealloc_stack %3
+  dealloc_stack %2
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_explicit_copy_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %2 = alloc_stack $NonSendableKlass
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = alloc_stack $NonSendableKlass
+// CHECK-NEXT: require %%2:   explicit_copy_addr %1 to [init] %2 : $*NonSendableKlass
+// CHECK-NEXT: assign_direct %%1 = %%2:   explicit_copy_addr %1 to [init] %2 : $*NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_explicit_copy_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_explicit_copy_addr : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %1 = alloc_stack $NonSendableKlass
+  %2 = alloc_stack $NonSendableKlass
+  %3 = copy_value %0
+  store %3 to [init] %1
+  explicit_copy_addr %1 to [init] %2 : $*NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_addr %1
+  destroy_addr %2
+  dealloc_stack %2
+  dealloc_stack %1
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_store_borrow: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = alloc_stack $NonSendableKlass
+// CHECK-NEXT: merge %%0 with %%1:   %2 = store_borrow %0 to %1 : $*NonSendableKlass
+// CHECK-NEXT: assign_direct %%1 = %%0:   %2 = store_borrow %0 to %1 : $*NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_store_borrow: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_store_borrow : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %1 = alloc_stack $NonSendableKlass
+  %2 = store_borrow %0 to %1 : $*NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  end_borrow %2
+  dealloc_stack %1
+  %r = tuple ()
+  return %r : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: AssignFresh Instructions
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_alloc_ref: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %0 = alloc_ref $NonSendableKlass
+// CHECK-NEXT: assign_fresh %%0:   %0 = alloc_ref $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_alloc_ref: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_alloc_ref : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_ref $NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_value %0
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_alloc_box: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %0 = alloc_box ${ var NonSendableKlass }
+// CHECK-NEXT: assign_fresh %%0:   %0 = alloc_box ${ var NonSendableKlass }
+// CHECK-NEXT: end running test {{.*}} on test_alloc_box: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_alloc_box : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_box ${ var NonSendableKlass }
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  dealloc_box %0 : ${ var NonSendableKlass }
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_alloc_stack: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %0 = alloc_stack $NonSendableKlass
+// CHECK-NEXT: assign_fresh %%0:   %0 = alloc_stack $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_alloc_stack: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_alloc_stack : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  dealloc_stack %0
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_global_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %0 = global_addr @global_nonsendable : $*NonSendableKlass
+// CHECK-NEXT: assign_fresh %%0:   %0 = global_addr @global_nonsendable : $*NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_global_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_global_addr : $@convention(thin) () -> () {
+bb0:
+  %0 = global_addr @global_nonsendable : $*NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_function_ref: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   // function_ref some_function
+// CHECK-NEXT:   %0 = function_ref @some_function : $@convention(thin) () -> ()
+// CHECK-NEXT: end running test {{.*}} on test_function_ref: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_function_ref : $@convention(thin) () -> () {
+bb0:
+  %0 = function_ref @some_function : $@convention(thin) () -> ()
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_metatype: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %0 = metatype $@thick NonSendableKlass.Type
+// CHECK-NEXT: end running test {{.*}} on test_metatype: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_metatype : $@convention(thin) () -> () {
+bb0:
+  %0 = metatype $@thick NonSendableKlass.Type
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_alloc_ref_dynamic: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $@thick NonSendableKlass.Type
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = alloc_ref_dynamic %0 : $@thick NonSendableKlass.Type, $NonSendableKlass
+// CHECK-NEXT: assign_fresh %%1:   %1 = alloc_ref_dynamic %0 : $@thick NonSendableKlass.Type, $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_alloc_ref_dynamic: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_alloc_ref_dynamic : $@convention(thin) (@thick NonSendableKlass.Type) -> () {
+bb0(%0 : $@thick NonSendableKlass.Type):
+  %1 = alloc_ref_dynamic %0 : $@thick NonSendableKlass.Type, $NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_value %1
+  %r = tuple ()
+  return %r : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Assign Direct Instructions
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_struct: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %2 = struct $SingleFieldStruct (%1 : $NonSendableKlass)
+// CHECK-NEXT: require %%0:   %2 = struct $SingleFieldStruct (%1 : $NonSendableKlass)
+// CHECK-NEXT: assign_direct %%1 = %%0:   %2 = struct $SingleFieldStruct (%1 : $NonSendableKlass)
+// CHECK-NEXT: end running test {{.*}} on test_struct: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_struct : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %1 = copy_value %0
+  %2 = struct $SingleFieldStruct (%1)
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_value %2
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_tuple: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %1 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %4 = tuple (%2 : $NonSendableKlass, %3 : $NonSendableKlass)
+// CHECK-NEXT: require %%0:   %4 = tuple (%2 : $NonSendableKlass, %3 : $NonSendableKlass)
+// CHECK-NEXT: require %%1:   %4 = tuple (%2 : $NonSendableKlass, %3 : $NonSendableKlass)
+// CHECK-NEXT: merge %%0 with %%1:   %4 = tuple (%2 : $NonSendableKlass, %3 : $NonSendableKlass)
+// CHECK-NEXT: assign_direct %%2 = %%0:   %4 = tuple (%2 : $NonSendableKlass, %3 : $NonSendableKlass)
+// CHECK-NEXT: end running test {{.*}} on test_tuple: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_tuple : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass, %1 : @guaranteed $NonSendableKlass):
+  %2 = copy_value %0
+  %3 = copy_value %1
+  %4 = tuple (%2 : $NonSendableKlass, %3 : $NonSendableKlass)
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_value %4
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_struct_extract: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $SingleFieldStruct
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = struct_extract %0 : $SingleFieldStruct, #SingleFieldStruct.field
+// CHECK-NEXT: require %%0:   %1 = struct_extract %0 : $SingleFieldStruct, #SingleFieldStruct.field
+// CHECK-NEXT: assign_direct %%1 = %%0:   %1 = struct_extract %0 : $SingleFieldStruct, #SingleFieldStruct.field
+// CHECK-NEXT: end running test {{.*}} on test_struct_extract: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_struct_extract : $@convention(thin) (@guaranteed SingleFieldStruct) -> () {
+bb0(%0 : @guaranteed $SingleFieldStruct):
+  %1 = struct_extract %0 : $SingleFieldStruct, #SingleFieldStruct.field
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_tuple_extract: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $(NonSendableKlass, NonSendableKlass)
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = tuple_extract %0 : $(NonSendableKlass, NonSendableKlass), 0
+// CHECK-NEXT: require %%0:   %1 = tuple_extract %0 : $(NonSendableKlass, NonSendableKlass), 0
+// CHECK-NEXT: assign_direct %%1 = %%0:   %1 = tuple_extract %0 : $(NonSendableKlass, NonSendableKlass), 0
+// CHECK-NEXT: end running test {{.*}} on test_tuple_extract: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_tuple_extract : $@convention(thin) (@guaranteed (NonSendableKlass, NonSendableKlass)) -> () {
+bb0(%0 : @guaranteed $(NonSendableKlass, NonSendableKlass)):
+  %1 = tuple_extract %0 : $(NonSendableKlass, NonSendableKlass), 0
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_init_existential_ref: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %2 = init_existential_ref %1 : $NonSendableKlass : $NonSendableKlass, $AnyObject
+// CHECK-NEXT: require %%0:   %2 = init_existential_ref %1 : $NonSendableKlass : $NonSendableKlass, $AnyObject
+// CHECK-NEXT: assign_direct %%1 = %%0:   %2 = init_existential_ref %1 : $NonSendableKlass : $NonSendableKlass, $AnyObject
+// CHECK-NEXT: end running test {{.*}} on test_init_existential_ref: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_init_existential_ref : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %1 = copy_value %0
+  %2 = init_existential_ref %1 : $NonSendableKlass : $NonSendableKlass, $AnyObject
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_value %2
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_open_existential_ref: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $AnyObject
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = open_existential_ref %0 : $AnyObject to $@opened("00000000-0000-0000-0000-000000000000", AnyObject) Self
+// CHECK-NEXT: require %%0:   %1 = open_existential_ref %0 : $AnyObject to $@opened("00000000-0000-0000-0000-000000000000", AnyObject) Self
+// CHECK-NEXT: assign_direct %%1 = %%0:   %1 = open_existential_ref %0 : $AnyObject to $@opened("00000000-0000-0000-0000-000000000000", AnyObject) Self
+// CHECK-NEXT: end running test {{.*}} on test_open_existential_ref: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_open_existential_ref : $@convention(thin) (@guaranteed AnyObject) -> () {
+bb0(%0 : @guaranteed $AnyObject):
+  %1 = open_existential_ref %0 : $AnyObject to $@opened("00000000-0000-0000-0000-000000000000", AnyObject) Self
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_index_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %0 = alloc_stack $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = integer_literal $Builtin.Word, 0
+// CHECK-NEXT: require %%0:   %2 = index_addr %0 : $*NonSendableKlass, %1 : $Builtin.Word
+// CHECK-NEXT: end running test {{.*}} on test_index_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_index_addr : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $NonSendableKlass
+  %1 = integer_literal $Builtin.Word, 0
+  %2 = index_addr %0 : $*NonSendableKlass, %1 : $Builtin.Word
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  dealloc_stack %0
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_enum: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %2 = enum $NonSendableEnum, #NonSendableEnum.some!enumelt, %1 : $NonSendableKlass
+// CHECK-NEXT: require %%0:   %2 = enum $NonSendableEnum, #NonSendableEnum.some!enumelt, %1 : $NonSendableKlass
+// CHECK-NEXT: assign_direct %%1 = %%0:   %2 = enum $NonSendableEnum, #NonSendableEnum.some!enumelt, %1 : $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_enum: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_enum : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %1 = copy_value %0
+  %2 = enum $NonSendableEnum, #NonSendableEnum.some!enumelt, %1 : $NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_value %2
+  %r = tuple ()
+  return %r : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: LookThrough Instructions
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_copy_value: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_copy_value: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_copy_value : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %1 = copy_value %0
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_value %1
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_begin_borrow: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_begin_borrow: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_begin_borrow : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %1 = copy_value %0
+  %2 = begin_borrow %1
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  end_borrow %2
+  destroy_value %1
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_end_borrow: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_end_borrow: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_end_borrow : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %1 = copy_value %0
+  %2 = begin_borrow %1
+  end_borrow %2
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_value %1
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_move_value: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_move_value: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_move_value : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %1 = copy_value %0
+  %2 = move_value %1
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_value %2
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_begin_access: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = alloc_stack $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_begin_access: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_begin_access : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %1 = alloc_stack $NonSendableKlass
+  %2 = copy_value %0
+  store %2 to [init] %1
+  %3 = begin_access [read] [static] %1 : $*NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  end_access %3
+  destroy_addr %1
+  dealloc_stack %1
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_end_access: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_end_access: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_end_access : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %1 = alloc_stack $NonSendableKlass
+  %2 = copy_value %0
+  store %2 to [init] %1
+  %3 = begin_access [modify] [dynamic] %1 : $*NonSendableKlass
+  end_access %3
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_addr %1
+  dealloc_stack %1
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_project_box: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %0 = alloc_box ${ var NonSendableKlass }
+// CHECK-NEXT: end running test {{.*}} on test_project_box: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_project_box : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_box ${ var NonSendableKlass }
+  %1 = project_box %0 : ${ var NonSendableKlass }, 0
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  dealloc_box %0 : ${ var NonSendableKlass }
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_struct_element_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %0 = alloc_stack $TwoFieldStruct
+// CHECK-NEXT: end running test {{.*}} on test_struct_element_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_struct_element_addr : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $TwoFieldStruct
+  %1 = struct_element_addr %0 : $*TwoFieldStruct, #TwoFieldStruct.first
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  dealloc_stack %0
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_tuple_element_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %0 = alloc_stack $(NonSendableKlass, NonSendableKlass)
+// CHECK-NEXT: end running test {{.*}} on test_tuple_element_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_tuple_element_addr : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $(NonSendableKlass, NonSendableKlass)
+  %1 = tuple_element_addr %0 : $*(NonSendableKlass, NonSendableKlass), 0
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  dealloc_stack %0
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_destructure_tuple: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $(NonSendableKlass, NonSendableKlass)
+// CHECK-NEXT: end running test {{.*}} on test_destructure_tuple: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_destructure_tuple : $@convention(thin) (@owned (NonSendableKlass, NonSendableKlass)) -> () {
+bb0(%0 : @owned $(NonSendableKlass, NonSendableKlass)):
+  (%1, %2) = destructure_tuple %0 : $(NonSendableKlass, NonSendableKlass)
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_value %1
+  destroy_value %2
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_destructure_struct: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $SingleFieldStruct
+// CHECK-NEXT: end running test {{.*}} on test_destructure_struct: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_destructure_struct : $@convention(thin) (@owned SingleFieldStruct) -> () {
+bb0(%0 : @owned $SingleFieldStruct):
+  (%1) = destructure_struct %0 : $SingleFieldStruct
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_value %1
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_upcast: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $DerivedKlass
+// CHECK-NEXT: end running test {{.*}} on test_upcast: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_upcast : $@convention(thin) (@guaranteed DerivedKlass) -> () {
+bb0(%0 : @guaranteed $DerivedKlass):
+  %1 = upcast %0 : $DerivedKlass to $NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_unchecked_ref_cast: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_unchecked_ref_cast: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_unchecked_ref_cast : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %1 = unchecked_ref_cast %0 : $NonSendableKlass to $NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_unchecked_enum_data: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableEnum
+// CHECK-NEXT: end running test {{.*}} on test_unchecked_enum_data: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_unchecked_enum_data : $@convention(thin) (@guaranteed NonSendableEnum) -> () {
+bb0(%0 : @guaranteed $NonSendableEnum):
+  %1 = unchecked_enum_data %0 : $NonSendableEnum, #NonSendableEnum.some!enumelt
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_open_existential_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $*any NonSendableProtocol
+// CHECK-NEXT: end running test {{.*}} on test_open_existential_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_open_existential_addr : $@convention(thin) (@in_guaranteed any NonSendableProtocol) -> () {
+bb0(%0 : $*any NonSendableProtocol):
+  %1 = open_existential_addr immutable_access %0 : $*any NonSendableProtocol to $*@opened("00000000-0000-0000-0000-000000000001", any NonSendableProtocol) Self
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_ref_to_unowned: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_ref_to_unowned: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_ref_to_unowned : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %1 = ref_to_unowned %0 : $NonSendableKlass to $@sil_unowned NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_unowned_to_ref: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_unowned_to_ref: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_unowned_to_ref : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %1 = ref_to_unowned %0 : $NonSendableKlass to $@sil_unowned NonSendableKlass
+  %2 = unowned_to_ref %1 : $@sil_unowned NonSendableKlass to $NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_init_enum_data_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %0 = alloc_stack $NonSendableEnum
+// CHECK-NEXT: end running test {{.*}} on test_init_enum_data_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_init_enum_data_addr : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $NonSendableEnum
+  %1 = init_enum_data_addr %0 : $*NonSendableEnum, #NonSendableEnum.some!enumelt
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  dealloc_stack %0
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_begin_cow_mutation: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: (**%1**, %2) = begin_cow_mutation %0 : $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_begin_cow_mutation: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_begin_cow_mutation : $@convention(thin) (@owned NonSendableKlass) -> () {
+bb0(%0 : @owned $NonSendableKlass):
+  (%1, %2) = begin_cow_mutation %0 : $NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %3 = end_cow_mutation %2 : $NonSendableKlass
+  destroy_value %3
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_end_cow_mutation: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_end_cow_mutation: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_end_cow_mutation : $@convention(thin) (@owned NonSendableKlass) -> () {
+bb0(%0 : @owned $NonSendableKlass):
+  (%1, %2) = begin_cow_mutation %0 : $NonSendableKlass
+  %3 = end_cow_mutation %2 : $NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_value %3
+  %r = tuple ()
+  return %r : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Load Instructions
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_load_copy: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_load_copy: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_load_copy : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %1 = alloc_stack $NonSendableKlass
+  %2 = copy_value %0
+  store %2 to [init] %1
+  %3 = load [copy] %1
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_value %3
+  destroy_addr %1
+  dealloc_stack %1
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_load_take: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_load_take: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_load_take : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %1 = alloc_stack $NonSendableKlass
+  %2 = copy_value %0
+  store %2 to [init] %1
+  %3 = load [take] %1
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_value %3
+  dealloc_stack %1
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_load_borrow: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_load_borrow: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_load_borrow : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %1 = alloc_stack $NonSendableKlass
+  %2 = copy_value %0
+  store %2 to [init] %1
+  %3 = load_borrow %1
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  end_borrow %3
+  destroy_addr %1
+  dealloc_stack %1
+  %r = tuple ()
+  return %r : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Require Instructions
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_fix_lifetime: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: require %%0:   fix_lifetime %0 : $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_fix_lifetime: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_fix_lifetime : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  fix_lifetime %0 : $NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_is_unique: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = alloc_stack $NonSendableKlass
+// CHECK-NEXT: require %%1:   %4 = is_unique %1 : $*NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_is_unique: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_is_unique : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %1 = alloc_stack $NonSendableKlass
+  %2 = copy_value %0
+  store %2 to [init] %1
+  %3 = is_unique %1 : $*NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_addr %1
+  dealloc_stack %1
+  %r = tuple ()
+  return %r : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Apply Instructions
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_apply: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   // function_ref callee
+// CHECK-NEXT:   %1 = function_ref @callee : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %2 = apply %1(%0) : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: require %%0:   %2 = apply %1(%0) : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: end running test {{.*}} on test_apply: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_apply : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %f = function_ref @callee : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
+  %1 = apply %f(%0) : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_partial_apply: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   // function_ref takes_two
+// CHECK-NEXT:   %1 = function_ref @takes_two : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %3 = partial_apply [callee_guaranteed] %1(%2) : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: require %%0:   %3 = partial_apply [callee_guaranteed] %1(%2) : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: assign_direct %%2 = %%0:   %3 = partial_apply [callee_guaranteed] %1(%2) : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: end running test {{.*}} on test_partial_apply: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_partial_apply : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %f = function_ref @takes_two : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> ()
+  %1 = copy_value %0
+  %2 = partial_apply [callee_guaranteed] %f(%1) : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> ()
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_value %2
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_try_apply: sil_regionanalysis_partitionoptranslation with: @instruction
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   // function_ref throwing_callee
+// CHECK-NEXT:   %1 = function_ref @throwing_callee : $@convention(thin) (@guaranteed NonSendableKlass) -> @error any Error
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: %3 = argument of bb1 : $()
+// CHECK-NEXT: %%3: TrackableValue. State: TrackableValueState[id: 3][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: %6 = argument of bb2 : $any Error
+// CHECK-NEXT: require %%0:   try_apply %1(%0) : $@convention(thin) (@guaranteed NonSendableKlass) -> @error any Error, normal bb1, error bb2
+// CHECK-NEXT: end running test {{.*}} on test_try_apply: sil_regionanalysis_partitionoptranslation with: @instruction
+sil [ossa] @test_try_apply : $@convention(thin) (@guaranteed NonSendableKlass) -> @error any Error {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %f = function_ref @throwing_callee : $@convention(thin) (@guaranteed NonSendableKlass) -> @error any Error
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction"
+  try_apply %f(%0) : $@convention(thin) (@guaranteed NonSendableKlass) -> @error any Error, normal bb1, error bb2
+
+bb1(%1 : $()):
+  %r = tuple ()
+  return %r : $()
+
+bb2(%e : @owned $any Error):
+  throw %e : $any Error
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_begin_apply: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   // function_ref coro_callee
+// CHECK-NEXT:   %1 = function_ref @coro_callee : $@yield_once @convention(thin) (@guaranteed NonSendableKlass) -> @yields @inout NonSendableKlass
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: (**%2**, %3) = begin_apply %1(%0) : $@yield_once @convention(thin) (@guaranteed NonSendableKlass) -> @yields @inout NonSendableKlass
+// CHECK-NEXT: %%3: TrackableValue. State: TrackableValueState[id: 3][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: (%2, **%3**) = begin_apply %1(%0) : $@yield_once @convention(thin) (@guaranteed NonSendableKlass) -> @yields @inout NonSendableKlass
+// CHECK-NEXT: require %%0:   (%2, %3) = begin_apply %1(%0) : $@yield_once @convention(thin) (@guaranteed NonSendableKlass) -> @yields @inout NonSendableKlass
+// CHECK-NEXT: assign_direct %%2 = %%0:   (%2, %3) = begin_apply %1(%0) : $@yield_once @convention(thin) (@guaranteed NonSendableKlass) -> @yields @inout NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_begin_apply: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_begin_apply : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %f = function_ref @coro_callee : $@yield_once @convention(thin) (@guaranteed NonSendableKlass) -> @yields @inout NonSendableKlass
+  (%1, %token) = begin_apply %f(%0) : $@yield_once @convention(thin) (@guaranteed NonSendableKlass) -> @yields @inout NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  end_apply %token as $()
+  %r = tuple ()
+  return %r : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Comprehensive Apply Parameter Conventions
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_apply_owned_param: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   // function_ref takes_owned
+// CHECK-NEXT:   %2 = function_ref @takes_owned : $@convention(thin) (@owned NonSendableKlass) -> ()
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %3 = apply %2(%1) : $@convention(thin) (@owned NonSendableKlass) -> ()
+// CHECK-NEXT: require %%0:   %3 = apply %2(%1) : $@convention(thin) (@owned NonSendableKlass) -> ()
+// CHECK-NEXT: end running test {{.*}} on test_apply_owned_param: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_apply_owned_param : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %copy = copy_value %0
+  %f = function_ref @takes_owned : $@convention(thin) (@owned NonSendableKlass) -> ()
+  %result = apply %f(%copy) : $@convention(thin) (@owned NonSendableKlass) -> ()
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_apply_in_param: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   // function_ref takes_in
+// CHECK-NEXT:   %5 = function_ref @takes_in : $@convention(thin) (@in NonSendableStruct) -> ()
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = alloc_stack $NonSendableStruct
+// CHECK-NEXT: %%3: TrackableValue. State: TrackableValueState[id: 3][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %6 = apply %5(%1) : $@convention(thin) (@in NonSendableStruct) -> ()
+// CHECK-NEXT: require %%2:   %6 = apply %5(%1) : $@convention(thin) (@in NonSendableStruct) -> ()
+// CHECK-NEXT: end running test {{.*}} on test_apply_in_param: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_apply_in_param : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %stack = alloc_stack $NonSendableStruct
+  %copy = copy_value %0
+  %field_addr = struct_element_addr %stack : $*NonSendableStruct, #NonSendableStruct.field
+  store %copy to [init] %field_addr : $*NonSendableKlass
+  %f = function_ref @takes_in : $@convention(thin) (@in NonSendableStruct) -> ()
+  %result = apply %f(%stack) : $@convention(thin) (@in NonSendableStruct) -> ()
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  dealloc_stack %stack : $*NonSendableStruct
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_apply_in_guaranteed_param: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   // function_ref takes_in_guaranteed
+// CHECK-NEXT:   %5 = function_ref @takes_in_guaranteed : $@convention(thin) (@in_guaranteed NonSendableStruct) -> ()
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = alloc_stack $NonSendableStruct
+// CHECK-NEXT: %%3: TrackableValue. State: TrackableValueState[id: 3][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %6 = apply %5(%1) : $@convention(thin) (@in_guaranteed NonSendableStruct) -> ()
+// CHECK-NEXT: require %%2:   %6 = apply %5(%1) : $@convention(thin) (@in_guaranteed NonSendableStruct) -> ()
+// CHECK-NEXT: end running test {{.*}} on test_apply_in_guaranteed_param: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_apply_in_guaranteed_param : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %stack = alloc_stack $NonSendableStruct
+  %copy = copy_value %0
+  %field_addr = struct_element_addr %stack : $*NonSendableStruct, #NonSendableStruct.field
+  store %copy to [init] %field_addr : $*NonSendableKlass
+  %f = function_ref @takes_in_guaranteed : $@convention(thin) (@in_guaranteed NonSendableStruct) -> ()
+  %result = apply %f(%stack) : $@convention(thin) (@in_guaranteed NonSendableStruct) -> ()
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_addr %stack : $*NonSendableStruct
+  dealloc_stack %stack : $*NonSendableStruct
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_apply_inout_param: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   // function_ref takes_inout
+// CHECK-NEXT:   %5 = function_ref @takes_inout : $@convention(thin) (@inout NonSendableStruct) -> ()
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = alloc_stack $NonSendableStruct
+// CHECK-NEXT: %%3: TrackableValue. State: TrackableValueState[id: 3][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %6 = apply %5(%1) : $@convention(thin) (@inout NonSendableStruct) -> ()
+// CHECK-NEXT: require %%2:   %6 = apply %5(%1) : $@convention(thin) (@inout NonSendableStruct) -> ()
+// CHECK-NEXT: end running test {{.*}} on test_apply_inout_param: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_apply_inout_param : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %stack = alloc_stack $NonSendableStruct
+  %copy = copy_value %0
+  %field_addr = struct_element_addr %stack : $*NonSendableStruct, #NonSendableStruct.field
+  store %copy to [init] %field_addr : $*NonSendableKlass
+  %f = function_ref @takes_inout : $@convention(thin) (@inout NonSendableStruct) -> ()
+  %result = apply %f(%stack) : $@convention(thin) (@inout NonSendableStruct) -> ()
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_addr %stack : $*NonSendableStruct
+  dealloc_stack %stack : $*NonSendableStruct
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_apply_inout_aliasable_param: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   // function_ref takes_inout_aliasable
+// CHECK-NEXT:   %5 = function_ref @takes_inout_aliasable : $@convention(thin) (@inout_aliasable NonSendableStruct) -> ()
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = alloc_stack $NonSendableStruct
+// CHECK-NEXT: %%3: TrackableValue. State: TrackableValueState[id: 3][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %6 = apply %5(%1) : $@convention(thin) (@inout_aliasable NonSendableStruct) -> ()
+// CHECK-NEXT: require %%2:   %6 = apply %5(%1) : $@convention(thin) (@inout_aliasable NonSendableStruct) -> ()
+// CHECK-NEXT: end running test {{.*}} on test_apply_inout_aliasable_param: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_apply_inout_aliasable_param : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %stack = alloc_stack $NonSendableStruct
+  %copy = copy_value %0
+  %field_addr = struct_element_addr %stack : $*NonSendableStruct, #NonSendableStruct.field
+  store %copy to [init] %field_addr : $*NonSendableKlass
+  %f = function_ref @takes_inout_aliasable : $@convention(thin) (@inout_aliasable NonSendableStruct) -> ()
+  %result = apply %f(%stack) : $@convention(thin) (@inout_aliasable NonSendableStruct) -> ()
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_addr %stack : $*NonSendableStruct
+  dealloc_stack %stack : $*NonSendableStruct
+  %r = tuple ()
+  return %r : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Multiple Parameters with Mixed Conventions
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_apply_owned_and_guaranteed: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %1 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   // function_ref takes_owned_and_guaranteed
+// CHECK-NEXT:   %2 = function_ref @takes_owned_and_guaranteed : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: %%3: TrackableValue. State: TrackableValueState[id: 3][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %3 = apply %2(%1, %0) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: require %%1:   %3 = apply %2(%1, %0) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: require %%0:   %3 = apply %2(%1, %0) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: merge %%1 with %%0:   %3 = apply %2(%1, %0) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: end running test {{.*}} on test_apply_owned_and_guaranteed: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_apply_owned_and_guaranteed : $@convention(thin) (@guaranteed NonSendableKlass, @owned NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass, %1 : @owned $NonSendableKlass):
+  %f = function_ref @takes_owned_and_guaranteed : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass) -> ()
+  %result = apply %f(%1, %0) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass) -> ()
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_apply_in_and_guaranteed: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %1 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   // function_ref takes_in_and_guaranteed
+// CHECK-NEXT:   %5 = function_ref @takes_in_and_guaranteed : $@convention(thin) (@in NonSendableStruct, @guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: %%3: TrackableValue. State: TrackableValueState[id: 3][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %2 = alloc_stack $NonSendableStruct
+// CHECK-NEXT: %%4: TrackableValue. State: TrackableValueState[id: 4][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %6 = apply %5(%2, %0) : $@convention(thin) (@in NonSendableStruct, @guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: require %%3:   %6 = apply %5(%2, %0) : $@convention(thin) (@in NonSendableStruct, @guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: require %%0:   %6 = apply %5(%2, %0) : $@convention(thin) (@in NonSendableStruct, @guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: merge %%3 with %%0:   %6 = apply %5(%2, %0) : $@convention(thin) (@in NonSendableStruct, @guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: end running test {{.*}} on test_apply_in_and_guaranteed: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_apply_in_and_guaranteed : $@convention(thin) (@guaranteed NonSendableKlass, @owned NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass, %1 : @owned $NonSendableKlass):
+  %stack = alloc_stack $NonSendableStruct
+  %field_addr = struct_element_addr %stack : $*NonSendableStruct, #NonSendableStruct.field
+  store %1 to [init] %field_addr : $*NonSendableKlass
+  %f = function_ref @takes_in_and_guaranteed : $@convention(thin) (@in NonSendableStruct, @guaranteed NonSendableKlass) -> ()
+  %result = apply %f(%stack, %0) : $@convention(thin) (@in NonSendableStruct, @guaranteed NonSendableKlass) -> ()
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  dealloc_stack %stack : $*NonSendableStruct
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_apply_inout_and_guaranteed: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %1 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   // function_ref takes_inout_and_guaranteed
+// CHECK-NEXT:   %5 = function_ref @takes_inout_and_guaranteed : $@convention(thin) (@inout NonSendableStruct, @guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: %%3: TrackableValue. State: TrackableValueState[id: 3][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %2 = alloc_stack $NonSendableStruct
+// CHECK-NEXT: %%4: TrackableValue. State: TrackableValueState[id: 4][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %6 = apply %5(%2, %0) : $@convention(thin) (@inout NonSendableStruct, @guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: require %%3:   %6 = apply %5(%2, %0) : $@convention(thin) (@inout NonSendableStruct, @guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: require %%0:   %6 = apply %5(%2, %0) : $@convention(thin) (@inout NonSendableStruct, @guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: merge %%3 with %%0:   %6 = apply %5(%2, %0) : $@convention(thin) (@inout NonSendableStruct, @guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: end running test {{.*}} on test_apply_inout_and_guaranteed: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_apply_inout_and_guaranteed : $@convention(thin) (@guaranteed NonSendableKlass, @owned NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass, %1 : @owned $NonSendableKlass):
+  %stack = alloc_stack $NonSendableStruct
+  %field_addr = struct_element_addr %stack : $*NonSendableStruct, #NonSendableStruct.field
+  store %1 to [init] %field_addr : $*NonSendableKlass
+  %f = function_ref @takes_inout_and_guaranteed : $@convention(thin) (@inout NonSendableStruct, @guaranteed NonSendableKlass) -> ()
+  %result = apply %f(%stack, %0) : $@convention(thin) (@inout NonSendableStruct, @guaranteed NonSendableKlass) -> ()
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_addr %stack : $*NonSendableStruct
+  dealloc_stack %stack : $*NonSendableStruct
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_apply_three_mixed_params: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %1 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %2 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%3: TrackableValue. State: TrackableValueState[id: 3][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   // function_ref takes_three_mixed
+// CHECK-NEXT:   %6 = function_ref @takes_three_mixed : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass, @in NonSendableStruct) -> ()
+// CHECK-NEXT: %%4: TrackableValue. State: TrackableValueState[id: 4][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %3 = alloc_stack $NonSendableStruct
+// CHECK-NEXT: %%5: TrackableValue. State: TrackableValueState[id: 5][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %7 = apply %6(%1, %0, %3) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass, @in NonSendableStruct) -> ()
+// CHECK-NEXT: require %%1:   %7 = apply %6(%1, %0, %3) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass, @in NonSendableStruct) -> ()
+// CHECK-NEXT: require %%0:   %7 = apply %6(%1, %0, %3) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass, @in NonSendableStruct) -> ()
+// CHECK-NEXT: require %%4:   %7 = apply %6(%1, %0, %3) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass, @in NonSendableStruct) -> ()
+// CHECK-NEXT: merge %%1 with %%0:   %7 = apply %6(%1, %0, %3) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass, @in NonSendableStruct) -> ()
+// CHECK-NEXT: merge %%0 with %%4:   %7 = apply %6(%1, %0, %3) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass, @in NonSendableStruct) -> ()
+// CHECK-NEXT: end running test {{.*}} on test_apply_three_mixed_params: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_apply_three_mixed_params : $@convention(thin) (@guaranteed NonSendableKlass, @owned NonSendableKlass, @owned NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass, %1 : @owned $NonSendableKlass, %2 : @owned $NonSendableKlass):
+  %stack = alloc_stack $NonSendableStruct
+  %field_addr = struct_element_addr %stack : $*NonSendableStruct, #NonSendableStruct.field
+  store %2 to [init] %field_addr : $*NonSendableKlass
+  %f = function_ref @takes_three_mixed : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass, @in NonSendableStruct) -> ()
+  %result = apply %f(%1, %0, %stack) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass, @in NonSendableStruct) -> ()
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  dealloc_stack %stack : $*NonSendableStruct
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_apply_four_mixed_params: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %1 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %2 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%3: TrackableValue. State: TrackableValueState[id: 3][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %3 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%4: TrackableValue. State: TrackableValueState[id: 4][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   // function_ref takes_four_mixed
+// CHECK-NEXT:   %10 = function_ref @takes_four_mixed : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass, @inout NonSendableStruct, @in_guaranteed NonSendableStruct) -> ()
+// CHECK-NEXT: %%5: TrackableValue. State: TrackableValueState[id: 5][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %4 = alloc_stack $NonSendableStruct
+// CHECK-NEXT: %%6: TrackableValue. State: TrackableValueState[id: 6][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %7 = alloc_stack $NonSendableStruct
+// CHECK-NEXT: %%7: TrackableValue. State: TrackableValueState[id: 7][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %11 = apply %10(%1, %0, %4, %7) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass, @inout NonSendableStruct, @in_guaranteed NonSendableStruct) -> ()
+// CHECK-NEXT: require %%1:   %11 = apply %10(%1, %0, %4, %7) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass, @inout NonSendableStruct, @in_guaranteed NonSendableStruct) -> ()
+// CHECK-NEXT: require %%0:   %11 = apply %10(%1, %0, %4, %7) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass, @inout NonSendableStruct, @in_guaranteed NonSendableStruct) -> ()
+// CHECK-NEXT: require %%5:   %11 = apply %10(%1, %0, %4, %7) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass, @inout NonSendableStruct, @in_guaranteed NonSendableStruct) -> ()
+// CHECK-NEXT: require %%6:   %11 = apply %10(%1, %0, %4, %7) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass, @inout NonSendableStruct, @in_guaranteed NonSendableStruct) -> ()
+// CHECK-NEXT: merge %%1 with %%0:   %11 = apply %10(%1, %0, %4, %7) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass, @inout NonSendableStruct, @in_guaranteed NonSendableStruct) -> ()
+// CHECK-NEXT: merge %%0 with %%5:   %11 = apply %10(%1, %0, %4, %7) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass, @inout NonSendableStruct, @in_guaranteed NonSendableStruct) -> ()
+// CHECK-NEXT: merge %%5 with %%6:   %11 = apply %10(%1, %0, %4, %7) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass, @inout NonSendableStruct, @in_guaranteed NonSendableStruct) -> ()
+// CHECK-NEXT: end running test {{.*}} on test_apply_four_mixed_params: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_apply_four_mixed_params : $@convention(thin) (@guaranteed NonSendableKlass, @owned NonSendableKlass, @owned NonSendableKlass, @owned NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass, %1 : @owned $NonSendableKlass, %2 : @owned $NonSendableKlass, %3 : @owned $NonSendableKlass):
+  %stack1 = alloc_stack $NonSendableStruct
+  %field_addr1 = struct_element_addr %stack1 : $*NonSendableStruct, #NonSendableStruct.field
+  store %2 to [init] %field_addr1 : $*NonSendableKlass
+  %stack2 = alloc_stack $NonSendableStruct
+  %field_addr2 = struct_element_addr %stack2 : $*NonSendableStruct, #NonSendableStruct.field
+  store %3 to [init] %field_addr2 : $*NonSendableKlass
+  %f = function_ref @takes_four_mixed : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass, @inout NonSendableStruct, @in_guaranteed NonSendableStruct) -> ()
+  %result = apply %f(%1, %0, %stack1, %stack2) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass, @inout NonSendableStruct, @in_guaranteed NonSendableStruct) -> ()
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_addr %stack1 : $*NonSendableStruct
+  destroy_addr %stack2 : $*NonSendableStruct
+  dealloc_stack %stack2 : $*NonSendableStruct
+  dealloc_stack %stack1 : $*NonSendableStruct
+  %r = tuple ()
+  return %r : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Result Conventions
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_apply_owned_result: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   // function_ref returns_owned_direct
+// CHECK-NEXT:   %0 = function_ref @returns_owned_direct : $@convention(thin) () -> @owned NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = apply %0() : $@convention(thin) () -> @owned NonSendableKlass
+// CHECK-NEXT: assign_fresh %%1:   %1 = apply %0() : $@convention(thin) () -> @owned NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_apply_owned_result: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_apply_owned_result : $@convention(thin) () -> () {
+bb0:
+  %f = function_ref @returns_owned_direct : $@convention(thin) () -> @owned NonSendableKlass
+  %result = apply %f() : $@convention(thin) () -> @owned NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_value %result : $NonSendableKlass
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_apply_out_result: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   // function_ref returns_out
+// CHECK-NEXT:   %1 = function_ref @returns_out : $@convention(thin) () -> @out NonSendableStruct
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %0 = alloc_stack $NonSendableStruct
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %2 = apply %1(%0) : $@convention(thin) () -> @out NonSendableStruct
+// CHECK-NEXT: require %%1:   %2 = apply %1(%0) : $@convention(thin) () -> @out NonSendableStruct
+// CHECK-NEXT: end running test {{.*}} on test_apply_out_result: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_apply_out_result : $@convention(thin) () -> () {
+bb0:
+  %out = alloc_stack $NonSendableStruct
+  %f = function_ref @returns_out : $@convention(thin) () -> @out NonSendableStruct
+  %result = apply %f(%out) : $@convention(thin) () -> @out NonSendableStruct
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_addr %out : $*NonSendableStruct
+  dealloc_stack %out : $*NonSendableStruct
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_apply_multiple_out_results: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   // function_ref returns_multiple_out
+// CHECK-NEXT:   %2 = function_ref @returns_multiple_out : $@convention(thin) () -> (@out NonSendableStruct, @out NonSendableStruct)
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %0 = alloc_stack $NonSendableStruct
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = alloc_stack $NonSendableStruct
+// CHECK-NEXT: %%3: TrackableValue. State: TrackableValueState[id: 3][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %3 = apply %2(%0, %1) : $@convention(thin) () -> (@out NonSendableStruct, @out NonSendableStruct)
+// CHECK-NEXT: require %%1:   %3 = apply %2(%0, %1) : $@convention(thin) () -> (@out NonSendableStruct, @out NonSendableStruct)
+// CHECK-NEXT: require %%2:   %3 = apply %2(%0, %1) : $@convention(thin) () -> (@out NonSendableStruct, @out NonSendableStruct)
+// CHECK-NEXT: merge %%1 with %%2:   %3 = apply %2(%0, %1) : $@convention(thin) () -> (@out NonSendableStruct, @out NonSendableStruct)
+// CHECK-NEXT: end running test {{.*}} on test_apply_multiple_out_results: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_apply_multiple_out_results : $@convention(thin) () -> () {
+bb0:
+  %out1 = alloc_stack $NonSendableStruct
+  %out2 = alloc_stack $NonSendableStruct
+  %f = function_ref @returns_multiple_out : $@convention(thin) () -> (@out NonSendableStruct, @out NonSendableStruct)
+  %result = apply %f(%out1, %out2) : $@convention(thin) () -> (@out NonSendableStruct, @out NonSendableStruct)
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_addr %out1 : $*NonSendableStruct
+  destroy_addr %out2 : $*NonSendableStruct
+  dealloc_stack %out2 : $*NonSendableStruct
+  dealloc_stack %out1 : $*NonSendableStruct
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_apply_mixed_results: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   // function_ref returns_mixed
+// CHECK-NEXT:   %1 = function_ref @returns_mixed : $@convention(thin) () -> (@out NonSendableStruct, @owned NonSendableKlass)
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %0 = alloc_stack $NonSendableStruct
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %2 = apply %1(%0) : $@convention(thin) () -> (@out NonSendableStruct, @owned NonSendableKlass)
+// CHECK-NEXT: require %%1:   %2 = apply %1(%0) : $@convention(thin) () -> (@out NonSendableStruct, @owned NonSendableKlass)
+// CHECK-NEXT: assign_direct %%2 = %%1:   %2 = apply %1(%0) : $@convention(thin) () -> (@out NonSendableStruct, @owned NonSendableKlass)
+// CHECK-NEXT: end running test {{.*}} on test_apply_mixed_results: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_apply_mixed_results : $@convention(thin) () -> () {
+bb0:
+  %out = alloc_stack $NonSendableStruct
+  %f = function_ref @returns_mixed : $@convention(thin) () -> (@out NonSendableStruct, @owned NonSendableKlass)
+  %direct_result = apply %f(%out) : $@convention(thin) () -> (@out NonSendableStruct, @owned NonSendableKlass)
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_value %direct_result : $NonSendableKlass
+  destroy_addr %out : $*NonSendableStruct
+  dealloc_stack %out : $*NonSendableStruct
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_apply_param_and_out_result: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   // function_ref takes_and_returns_out
+// CHECK-NEXT:   %2 = function_ref @takes_and_returns_out : $@convention(thin) (@guaranteed NonSendableKlass) -> @out NonSendableStruct
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = alloc_stack $NonSendableStruct
+// CHECK-NEXT: %%3: TrackableValue. State: TrackableValueState[id: 3][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %3 = apply %2(%1, %0) : $@convention(thin) (@guaranteed NonSendableKlass) -> @out NonSendableStruct
+// CHECK-NEXT: require %%2:   %3 = apply %2(%1, %0) : $@convention(thin) (@guaranteed NonSendableKlass) -> @out NonSendableStruct
+// CHECK-NEXT: require %%0:   %3 = apply %2(%1, %0) : $@convention(thin) (@guaranteed NonSendableKlass) -> @out NonSendableStruct
+// CHECK-NEXT: merge %%2 with %%0:   %3 = apply %2(%1, %0) : $@convention(thin) (@guaranteed NonSendableKlass) -> @out NonSendableStruct
+// CHECK-NEXT: end running test {{.*}} on test_apply_param_and_out_result: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_apply_param_and_out_result : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %out = alloc_stack $NonSendableStruct
+  %f = function_ref @takes_and_returns_out : $@convention(thin) (@guaranteed NonSendableKlass) -> @out NonSendableStruct
+  %result = apply %f(%out, %0) : $@convention(thin) (@guaranteed NonSendableKlass) -> @out NonSendableStruct
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_addr %out : $*NonSendableStruct
+  dealloc_stack %out : $*NonSendableStruct
+  %r = tuple ()
+  return %r : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Method and Witness Conventions
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_apply_method_convention: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   // function_ref $s18NonSendableKlassC6methodyyF
+// CHECK-NEXT:   %1 = function_ref @$s18NonSendableKlassC6methodyyF : $@convention(method) (@guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %2 = apply %1(%0) : $@convention(method) (@guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: require %%0:   %2 = apply %1(%0) : $@convention(method) (@guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: end running test {{.*}} on test_apply_method_convention: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_apply_method_convention : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %method = function_ref @$s18NonSendableKlassC6methodyyF : $@convention(method) (@guaranteed NonSendableKlass) -> ()
+  %result = apply %method(%0) : $@convention(method) (@guaranteed NonSendableKlass) -> ()
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_apply_method_multiple_params: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   // function_ref $s18NonSendableKlassC11methodTakesyAA0bC0CF
+// CHECK-NEXT:   %2 = function_ref @$s18NonSendableKlassC11methodTakesyAA0bC0CF : $@convention(method) (@owned NonSendableKlass, @guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %3 = apply %2(%1, %0) : $@convention(method) (@owned NonSendableKlass, @guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: require %%0:   %3 = apply %2(%1, %0) : $@convention(method) (@owned NonSendableKlass, @guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: require %%0:   %3 = apply %2(%1, %0) : $@convention(method) (@owned NonSendableKlass, @guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: end running test {{.*}} on test_apply_method_multiple_params: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_apply_method_multiple_params : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %copy = copy_value %0
+  %method = function_ref @$s18NonSendableKlassC11methodTakesyAA0bC0CF : $@convention(method) (@owned NonSendableKlass, @guaranteed NonSendableKlass) -> ()
+  %result = apply %method(%copy, %0) : $@convention(method) (@owned NonSendableKlass, @guaranteed NonSendableKlass) -> ()
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_apply_witness_method: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   // function_ref witness_method_impl
+// CHECK-NEXT:   %4 = function_ref @witness_method_impl : $@convention(witness_method: NonSendableProtocol) <τ_0_0 where τ_0_0 : NonSendableProtocol> (@in_guaranteed τ_0_0) -> ()
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = alloc_stack $NonSendableKlass
+// CHECK-NEXT: %%3: TrackableValue. State: TrackableValueState[id: 3][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %5 = apply %4<NonSendableKlass>(%1) : $@convention(witness_method: NonSendableProtocol) <τ_0_0 where τ_0_0 : NonSendableProtocol> (@in_guaranteed τ_0_0) -> ()
+// CHECK-NEXT: require %%2:   %5 = apply %4<NonSendableKlass>(%1) : $@convention(witness_method: NonSendableProtocol) <τ_0_0 where τ_0_0 : NonSendableProtocol> (@in_guaranteed τ_0_0) -> ()
+// CHECK-NEXT: end running test {{.*}} on test_apply_witness_method: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_apply_witness_method : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %stack = alloc_stack $NonSendableKlass
+  %copy = copy_value %0
+  store %copy to [init] %stack : $*NonSendableKlass
+  %witness = function_ref @witness_method_impl : $@convention(witness_method: NonSendableProtocol) <Self where Self : NonSendableProtocol> (@in_guaranteed Self) -> ()
+  %result = apply %witness<NonSendableKlass>(%stack) : $@convention(witness_method: NonSendableProtocol) <Self where Self : NonSendableProtocol> (@in_guaranteed Self) -> ()
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_addr %stack : $*NonSendableKlass
+  dealloc_stack %stack : $*NonSendableKlass
+  %r = tuple ()
+  return %r : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: try_apply with Multiple Parameters
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_try_apply_owned_param: sil_regionanalysis_partitionoptranslation with: @instruction
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   // function_ref throws_with_owned
+// CHECK-NEXT:   %1 = function_ref @throws_with_owned : $@convention(thin) (@owned NonSendableKlass) -> (@owned NonSendableKlass, @error any Error)
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: %4 = argument of bb1 : $NonSendableKlass
+// CHECK-NEXT: %%3: TrackableValue. State: TrackableValueState[id: 3][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: %8 = argument of bb2 : $any Error
+// CHECK-NEXT: require %%0:   try_apply %1(%2) : $@convention(thin) (@owned NonSendableKlass) -> (@owned NonSendableKlass, @error any Error), normal bb1, error bb2
+// CHECK-NEXT: assign_direct %%2 = %%0:   try_apply %1(%2) : $@convention(thin) (@owned NonSendableKlass) -> (@owned NonSendableKlass, @error any Error), normal bb1, error bb2
+// CHECK-NEXT: end running test {{.*}} on test_try_apply_owned_param: sil_regionanalysis_partitionoptranslation with: @instruction
+sil [ossa] @test_try_apply_owned_param : $@convention(thin) (@guaranteed NonSendableKlass) -> @error any Error {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %f = function_ref @throws_with_owned : $@convention(thin) (@owned NonSendableKlass) -> (@owned NonSendableKlass, @error any Error)
+  %copy = copy_value %0
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction"
+  try_apply %f(%copy) : $@convention(thin) (@owned NonSendableKlass) -> (@owned NonSendableKlass, @error any Error), normal bb1, error bb2
+
+bb1(%result : @owned $NonSendableKlass):
+  destroy_value %result : $NonSendableKlass
+  %r = tuple ()
+  return %r : $()
+
+bb2(%error : @owned $any Error):
+  throw %error : $any Error
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_try_apply_in_param: sil_regionanalysis_partitionoptranslation with: @instruction
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   // function_ref throws_with_in
+// CHECK-NEXT:   %5 = function_ref @throws_with_in : $@convention(thin) (@in NonSendableStruct) -> @error any Error
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = alloc_stack $NonSendableStruct
+// CHECK-NEXT: %%3: TrackableValue. State: TrackableValueState[id: 3][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: %7 = argument of bb1 : $()
+// CHECK-NEXT: %%4: TrackableValue. State: TrackableValueState[id: 4][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: %11 = argument of bb2 : $any Error
+// CHECK-NEXT: require %%2:   try_apply %5(%1) : $@convention(thin) (@in NonSendableStruct) -> @error any Error, normal bb1, error bb2
+// CHECK-NEXT: end running test {{.*}} on test_try_apply_in_param: sil_regionanalysis_partitionoptranslation with: @instruction
+sil [ossa] @test_try_apply_in_param : $@convention(thin) (@guaranteed NonSendableKlass) -> @error any Error {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %stack = alloc_stack $NonSendableStruct
+  %copy = copy_value %0
+  %field_addr = struct_element_addr %stack : $*NonSendableStruct, #NonSendableStruct.field
+  store %copy to [init] %field_addr : $*NonSendableKlass
+  %f = function_ref @throws_with_in : $@convention(thin) (@in NonSendableStruct) -> @error any Error
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction"
+  try_apply %f(%stack) : $@convention(thin) (@in NonSendableStruct) -> @error any Error, normal bb1, error bb2
+
+bb1(%result : $()):
+  dealloc_stack %stack : $*NonSendableStruct
+  %r = tuple ()
+  return %r : $()
+
+bb2(%error : @owned $any Error):
+  dealloc_stack %stack : $*NonSendableStruct
+  throw %error : $any Error
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_try_apply_multiple_params: sil_regionanalysis_partitionoptranslation with: @instruction
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %1 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   // function_ref throws_multiple_params
+// CHECK-NEXT:   %2 = function_ref @throws_multiple_params : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass) -> @error any Error
+// CHECK-NEXT: %%3: TrackableValue. State: TrackableValueState[id: 3][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: %4 = argument of bb1 : $()
+// CHECK-NEXT: %%4: TrackableValue. State: TrackableValueState[id: 4][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: %7 = argument of bb2 : $any Error
+// CHECK-NEXT: require %%1:   try_apply %2(%1, %0) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass) -> @error any Error, normal bb1, error bb2
+// CHECK-NEXT: require %%0:   try_apply %2(%1, %0) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass) -> @error any Error, normal bb1, error bb2
+// CHECK-NEXT: merge %%1 with %%0:   try_apply %2(%1, %0) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass) -> @error any Error, normal bb1, error bb2
+// CHECK-NEXT: end running test {{.*}} on test_try_apply_multiple_params: sil_regionanalysis_partitionoptranslation with: @instruction
+sil [ossa] @test_try_apply_multiple_params : $@convention(thin) (@guaranteed NonSendableKlass, @owned NonSendableKlass) -> @error any Error {
+bb0(%0 : @guaranteed $NonSendableKlass, %1 : @owned $NonSendableKlass):
+  %f = function_ref @throws_multiple_params : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass) -> @error any Error
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction"
+  try_apply %f(%1, %0) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass) -> @error any Error, normal bb1, error bb2
+
+bb1(%result : $()):
+  %r = tuple ()
+  return %r : $()
+
+bb2(%error : @owned $any Error):
+  throw %error : $any Error
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: begin_apply with Multiple Parameters
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_begin_apply_yields_owned: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   // function_ref coro_yields_owned
+// CHECK-NEXT:   %1 = function_ref @coro_yields_owned : $@yield_once @convention(thin) (@guaranteed NonSendableKlass) -> @yields @owned NonSendableKlass
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: (**%2**, %3) = begin_apply %1(%0) : $@yield_once @convention(thin) (@guaranteed NonSendableKlass) -> @yields @owned NonSendableKlass
+// CHECK-NEXT: %%3: TrackableValue. State: TrackableValueState[id: 3][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: (%2, **%3**) = begin_apply %1(%0) : $@yield_once @convention(thin) (@guaranteed NonSendableKlass) -> @yields @owned NonSendableKlass
+// CHECK-NEXT: require %%0:   (%2, %3) = begin_apply %1(%0) : $@yield_once @convention(thin) (@guaranteed NonSendableKlass) -> @yields @owned NonSendableKlass
+// CHECK-NEXT: assign_direct %%2 = %%0:   (%2, %3) = begin_apply %1(%0) : $@yield_once @convention(thin) (@guaranteed NonSendableKlass) -> @yields @owned NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_begin_apply_yields_owned: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_begin_apply_yields_owned : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %f = function_ref @coro_yields_owned : $@yield_once @convention(thin) (@guaranteed NonSendableKlass) -> @yields @owned NonSendableKlass
+  (%yielded, %token) = begin_apply %f(%0) : $@yield_once @convention(thin) (@guaranteed NonSendableKlass) -> @yields @owned NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_value %yielded : $NonSendableKlass
+  end_apply %token as $()
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_begin_apply_yields_inout: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   // function_ref coro_yields_inout
+// CHECK-NEXT:   %1 = function_ref @coro_yields_inout : $@yield_once @convention(thin) (@guaranteed NonSendableKlass) -> @yields @inout NonSendableStruct
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: (**%2**, %3) = begin_apply %1(%0) : $@yield_once @convention(thin) (@guaranteed NonSendableKlass) -> @yields @inout NonSendableStruct
+// CHECK-NEXT: %%3: TrackableValue. State: TrackableValueState[id: 3][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: (%2, **%3**) = begin_apply %1(%0) : $@yield_once @convention(thin) (@guaranteed NonSendableKlass) -> @yields @inout NonSendableStruct
+// CHECK-NEXT: require %%0:   (%2, %3) = begin_apply %1(%0) : $@yield_once @convention(thin) (@guaranteed NonSendableKlass) -> @yields @inout NonSendableStruct
+// CHECK-NEXT: assign_direct %%2 = %%0:   (%2, %3) = begin_apply %1(%0) : $@yield_once @convention(thin) (@guaranteed NonSendableKlass) -> @yields @inout NonSendableStruct
+// CHECK-NEXT: end running test {{.*}} on test_begin_apply_yields_inout: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_begin_apply_yields_inout : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %f = function_ref @coro_yields_inout : $@yield_once @convention(thin) (@guaranteed NonSendableKlass) -> @yields @inout NonSendableStruct
+  (%yielded, %token) = begin_apply %f(%0) : $@yield_once @convention(thin) (@guaranteed NonSendableKlass) -> @yields @inout NonSendableStruct
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  end_apply %token as $()
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_begin_apply_multiple_params: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %1 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   // function_ref coro_multiple_params
+// CHECK-NEXT:   %2 = function_ref @coro_multiple_params : $@yield_once @convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass) -> @yields @inout NonSendableStruct
+// CHECK-NEXT: %%3: TrackableValue. State: TrackableValueState[id: 3][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: (**%3**, %4) = begin_apply %2(%1, %0) : $@yield_once @convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass) -> @yields @inout NonSendableStruct
+// CHECK-NEXT: %%4: TrackableValue. State: TrackableValueState[id: 4][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: (%3, **%4**) = begin_apply %2(%1, %0) : $@yield_once @convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass) -> @yields @inout NonSendableStruct
+// CHECK-NEXT: require %%1:   (%3, %4) = begin_apply %2(%1, %0) : $@yield_once @convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass) -> @yields @inout NonSendableStruct
+// CHECK-NEXT: require %%0:   (%3, %4) = begin_apply %2(%1, %0) : $@yield_once @convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass) -> @yields @inout NonSendableStruct
+// CHECK-NEXT: merge %%1 with %%0:   (%3, %4) = begin_apply %2(%1, %0) : $@yield_once @convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass) -> @yields @inout NonSendableStruct
+// CHECK-NEXT: assign_direct %%3 = %%1:   (%3, %4) = begin_apply %2(%1, %0) : $@yield_once @convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass) -> @yields @inout NonSendableStruct
+// CHECK-NEXT: end running test {{.*}} on test_begin_apply_multiple_params: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_begin_apply_multiple_params : $@convention(thin) (@guaranteed NonSendableKlass, @owned NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass, %1 : @owned $NonSendableKlass):
+  %f = function_ref @coro_multiple_params : $@yield_once @convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass) -> @yields @inout NonSendableStruct
+  (%yielded, %token) = begin_apply %f(%1, %0) : $@yield_once @convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass) -> @yields @inout NonSendableStruct
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  end_apply %token as $()
+  %r = tuple ()
+  return %r : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: partial_apply with Different Capture Conventions
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_partial_apply_owned_capture: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   // function_ref takes_owned_and_guaranteed
+// CHECK-NEXT:   %1 = function_ref @takes_owned_and_guaranteed : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %3 = partial_apply [callee_guaranteed] %1(%2) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: require %%0:   %3 = partial_apply [callee_guaranteed] %1(%2) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: assign_direct %%2 = %%0:   %3 = partial_apply [callee_guaranteed] %1(%2) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: end running test {{.*}} on test_partial_apply_owned_capture: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_partial_apply_owned_capture : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %f = function_ref @takes_owned_and_guaranteed : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass) -> ()
+  %copy = copy_value %0
+  %closure = partial_apply [callee_guaranteed] %f(%copy) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass) -> ()
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_value %closure : $@callee_guaranteed (@owned NonSendableKlass) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_partial_apply_guaranteed_capture: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   // function_ref takes_two
+// CHECK-NEXT:   %1 = function_ref @takes_two : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %3 = partial_apply [callee_guaranteed] %1(%2) : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: require %%0:   %3 = partial_apply [callee_guaranteed] %1(%2) : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: assign_direct %%2 = %%0:   %3 = partial_apply [callee_guaranteed] %1(%2) : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> ()
+// CHECK-NEXT: end running test {{.*}} on test_partial_apply_guaranteed_capture: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_partial_apply_guaranteed_capture : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %f = function_ref @takes_two : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> ()
+  %copy = copy_value %0
+  %closure = partial_apply [callee_guaranteed] %f(%copy) : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> ()
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_value %closure : $@callee_guaranteed (@guaranteed NonSendableKlass) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Terminator Instructions
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_return: sil_regionanalysis_partitionoptranslation with: @instruction
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: require %%0:   return %1 : $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_return: sil_regionanalysis_partitionoptranslation with: @instruction
+sil [ossa] @test_return : $@convention(thin) (@guaranteed NonSendableKlass) -> @owned NonSendableKlass {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %1 = copy_value %0
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction"
+  return %1 : $NonSendableKlass
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_br_with_arg: sil_regionanalysis_partitionoptranslation with: @instruction
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: %3 = argument of bb1 : $NonSendableKlass
+// CHECK-NEXT: require %%0:   br bb1(%1 : $NonSendableKlass)
+// CHECK-NEXT: assign_direct %%1 = %%0:   br bb1(%1 : $NonSendableKlass)
+// CHECK-NEXT: end running test {{.*}} on test_br_with_arg: sil_regionanalysis_partitionoptranslation with: @instruction
+sil [ossa] @test_br_with_arg : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %1 = copy_value %0
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction"
+  br bb1(%1 : $NonSendableKlass)
+
+bb1(%2 : @owned $NonSendableKlass):
+  destroy_value %2
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_switch_enum: sil_regionanalysis_partitionoptranslation with: @instruction
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableEnum
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: %2 = argument of bb1 : $NonSendableKlass
+// CHECK-NEXT: require %%0:   switch_enum %0 : $NonSendableEnum, case #NonSendableEnum.some!enumelt: bb1, case #NonSendableEnum.none!enumelt: bb2
+// CHECK-NEXT: assign_direct %%1 = %%0:   switch_enum %0 : $NonSendableEnum, case #NonSendableEnum.some!enumelt: bb1, case #NonSendableEnum.none!enumelt: bb2
+// CHECK-NEXT: end running test {{.*}} on test_switch_enum: sil_regionanalysis_partitionoptranslation with: @instruction
+sil [ossa] @test_switch_enum : $@convention(thin) (@owned NonSendableEnum) -> () {
+bb0(%0 : @owned $NonSendableEnum):
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction"
+  switch_enum %0 : $NonSendableEnum, case #NonSendableEnum.some!enumelt: bb1, case #NonSendableEnum.none!enumelt: bb2
+
+bb1(%payload : @owned $NonSendableKlass):
+  destroy_value %payload
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_checked_cast_br: sil_regionanalysis_partitionoptranslation with: @instruction
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $AnyObject
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: %2 = argument of bb1 : $NonSendableKlass
+// CHECK-NEXT: require %%0:   checked_cast_br AnyObject in %0 : $AnyObject to NonSendableKlass, bb1, bb2
+// CHECK-NEXT: assign_direct %%1 = %%0:   checked_cast_br AnyObject in %0 : $AnyObject to NonSendableKlass, bb1, bb2
+// CHECK-NEXT: end running test {{.*}} on test_checked_cast_br: sil_regionanalysis_partitionoptranslation with: @instruction
+sil [ossa] @test_checked_cast_br : $@convention(thin) (@owned AnyObject) -> () {
+bb0(%0 : @owned $AnyObject):
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction"
+  checked_cast_br AnyObject in %0 : $AnyObject to NonSendableKlass, bb1, bb2
+
+bb1(%casted : @owned $NonSendableKlass):
+  destroy_value %casted
+  br bb3
+
+bb2(%original : @owned $AnyObject):
+  destroy_value %original
+  br bb3
+
+bb3:
+  %r = tuple ()
+  return %r : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Additional Instructions
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_pointer_to_address: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = address_to_pointer %0 : $*NonSendableKlass to $Builtin.RawPointer
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %0 = alloc_stack $NonSendableKlass
+// CHECK-NEXT: require %%0:   %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*NonSendableKlass
+// CHECK-NEXT: assign_direct %%1 = %%0:   %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_pointer_to_address: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_pointer_to_address : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $NonSendableKlass
+  %1 = address_to_pointer %0 : $*NonSendableKlass to $Builtin.RawPointer
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  dealloc_stack %0
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_ref_element_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $KlassWithField
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = ref_element_addr %0 : $KlassWithField, #KlassWithField.field
+// CHECK-NEXT: require %%0:   %1 = ref_element_addr %0 : $KlassWithField, #KlassWithField.field
+// CHECK-NEXT: assign_direct %%1 = %%0:   %1 = ref_element_addr %0 : $KlassWithField, #KlassWithField.field
+// CHECK-NEXT: end running test {{.*}} on test_ref_element_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_ref_element_addr : $@convention(thin) (@guaranteed KlassWithField) -> () {
+bb0(%0 : @guaranteed $KlassWithField):
+  %1 = ref_element_addr %0 : $KlassWithField, #KlassWithField.field
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_unconditional_checked_cast: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $AnyObject
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = unconditional_checked_cast %0 : $AnyObject to NonSendableKlass
+// CHECK-NEXT: require %%0:   %1 = unconditional_checked_cast %0 : $AnyObject to NonSendableKlass
+// CHECK-NEXT: assign_direct %%1 = %%0:   %1 = unconditional_checked_cast %0 : $AnyObject to NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_unconditional_checked_cast: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_unconditional_checked_cast : $@convention(thin) (@owned AnyObject) -> () {
+bb0(%0 : @owned $AnyObject):
+  %1 = unconditional_checked_cast %0 : $AnyObject to NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_value %1
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_address_to_pointer: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %0 = alloc_stack $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = address_to_pointer %0 : $*NonSendableKlass to $Builtin.RawPointer
+// CHECK-NEXT: require %%0:   %1 = address_to_pointer %0 : $*NonSendableKlass to $Builtin.RawPointer
+// CHECK-NEXT: assign_direct %%1 = %%0:   %1 = address_to_pointer %0 : $*NonSendableKlass to $Builtin.RawPointer
+// CHECK-NEXT: end running test {{.*}} on test_address_to_pointer: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_address_to_pointer : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $NonSendableKlass
+  %1 = address_to_pointer %0 : $*NonSendableKlass to $Builtin.RawPointer
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  dealloc_stack %0
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_value_metatype: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = value_metatype $@thick NonSendableKlass.Type, %0 : $NonSendableKlass
+// CHECK-NEXT: require %%0:   %1 = value_metatype $@thick NonSendableKlass.Type, %0 : $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_value_metatype: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_value_metatype : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %1 = value_metatype $@thick NonSendableKlass.Type, %0 : $NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_mark_dependence: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %1 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: require %%1:   %3 = mark_dependence %2 : $NonSendableKlass on %1 : $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_mark_dependence: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_mark_dependence : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass, %1 : @guaranteed $NonSendableKlass):
+  %2 = copy_value %0
+  %3 = mark_dependence %2 : $NonSendableKlass on %1 : $NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_value %3
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_builtin: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %0 = integer_literal $Builtin.Int64, 1
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = integer_literal $Builtin.Int64, 2
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %2 = builtin "add_Int64"(%0 : $Builtin.Int64, %1 : $Builtin.Int64) : $Builtin.Int64
+// CHECK-NEXT: end running test {{.*}} on test_builtin: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_builtin : $@convention(thin) () -> () {
+bb0:
+  %0 = integer_literal $Builtin.Int64, 1
+  %1 = integer_literal $Builtin.Int64, 2
+  %2 = builtin "add_Int64"(%0 : $Builtin.Int64, %1 : $Builtin.Int64) : $Builtin.Int64
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Additional Apply Instructions
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_end_apply: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_end_apply: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_end_apply : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %f = function_ref @coro_callee : $@yield_once @convention(thin) (@guaranteed NonSendableKlass) -> @yields @inout NonSendableKlass
+  (%1, %token) = begin_apply %f(%0) : $@yield_once @convention(thin) (@guaranteed NonSendableKlass) -> @yields @inout NonSendableKlass
+  end_apply %token as $()
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_abort_apply: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_abort_apply: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_abort_apply : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %f = function_ref @coro_callee : $@yield_once @convention(thin) (@guaranteed NonSendableKlass) -> @yields @inout NonSendableKlass
+  (%1, %token) = begin_apply %f(%0) : $@yield_once @convention(thin) (@guaranteed NonSendableKlass) -> @yields @inout NonSendableKlass
+  abort_apply %token
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Address-Only Enum Operations
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_switch_enum_addr: sil_regionanalysis_partitionoptranslation with: @instruction
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $*NonSendableEnum
+// CHECK-NEXT: require %%0:   switch_enum_addr %0 : $*NonSendableEnum, case #NonSendableEnum.some!enumelt: bb1, case #NonSendableEnum.none!enumelt: bb2
+// CHECK-NEXT: end running test {{.*}} on test_switch_enum_addr: sil_regionanalysis_partitionoptranslation with: @instruction
+sil [ossa] @test_switch_enum_addr : $@convention(thin) (@in NonSendableEnum) -> () {
+bb0(%0 : $*NonSendableEnum):
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction"
+  switch_enum_addr %0 : $*NonSendableEnum, case #NonSendableEnum.some!enumelt: bb1, case #NonSendableEnum.none!enumelt: bb2
+
+bb1:
+  %payload_addr = unchecked_take_enum_data_addr %0 : $*NonSendableEnum, #NonSendableEnum.some!enumelt
+  destroy_addr %payload_addr
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_inject_enum_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_inject_enum_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_inject_enum_addr : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %enum_addr = alloc_stack $NonSendableEnum
+  %payload_addr = init_enum_data_addr %enum_addr : $*NonSendableEnum, #NonSendableEnum.some!enumelt
+  %copy = copy_value %0
+  store %copy to [init] %payload_addr
+  inject_enum_addr %enum_addr : $*NonSendableEnum, #NonSendableEnum.some!enumelt
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_addr %enum_addr
+  dealloc_stack %enum_addr
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_unchecked_take_enum_data_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $*NonSendableEnum
+// CHECK-NEXT: end running test {{.*}} on test_unchecked_take_enum_data_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_unchecked_take_enum_data_addr : $@convention(thin) (@in NonSendableEnum) -> () {
+bb0(%0 : $*NonSendableEnum):
+  %payload_addr = unchecked_take_enum_data_addr %0 : $*NonSendableEnum, #NonSendableEnum.some!enumelt
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_addr %payload_addr
+  %r = tuple ()
+  return %r : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Address-Only Existential Operations
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_init_existential_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = alloc_stack $Any
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %2 = init_existential_addr %1 : $*Any, $NonSendableKlass
+// CHECK-NEXT: require %%1:   %2 = init_existential_addr %1 : $*Any, $NonSendableKlass
+// CHECK-NEXT: assign_direct %%2 = %%1:   %2 = init_existential_addr %1 : $*Any, $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_init_existential_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_init_existential_addr : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %exist = alloc_stack $Any
+  %addr = init_existential_addr %exist : $*Any, $NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %copy = copy_value %0
+  store %copy to [init] %addr
+  destroy_addr %exist
+  dealloc_stack %exist
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_deinit_existential_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $*Any
+// CHECK-NEXT: end running test {{.*}} on test_deinit_existential_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_deinit_existential_addr : $@convention(thin) (@in Any) -> () {
+bb0(%0 : $*Any):
+  deinit_existential_addr %0 : $*Any
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Boxed Existential Operations
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_alloc_existential_box: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = alloc_existential_box $any Error, $MyErrorNonSendable
+// CHECK-NEXT: end running test {{.*}} on test_alloc_existential_box: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_alloc_existential_box : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %box = alloc_existential_box $any Error, $MyErrorNonSendable
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %addr = project_existential_box $MyErrorNonSendable in %box : $any Error
+  %copy = copy_value %0
+  %addr2 = unchecked_take_enum_data_addr %addr : $*MyErrorNonSendable, #MyErrorNonSendable.failure2
+  store %copy to [init] %addr2
+  destroy_value %box
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_project_existential_box: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = alloc_existential_box $any Error, $MyErrorNonSendable
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %2 = project_existential_box $MyErrorNonSendable in %1 : $any Error
+// CHECK-NEXT: end running test {{.*}} on test_project_existential_box: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_project_existential_box : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %box = alloc_existential_box $any Error, $MyErrorNonSendable
+  %addr = project_existential_box $MyErrorNonSendable in %box : $any Error
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %copy = copy_value %0
+  %addr2 = unchecked_take_enum_data_addr %addr : $*MyErrorNonSendable, #MyErrorNonSendable.failure2
+  store %copy to [init] %addr2
+  destroy_value %box
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_open_existential_box: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $any Error
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = open_existential_box %0 : $any Error to $*@opened("00000000-0000-0000-0000-000000000002", any Error) Self
+// CHECK-NEXT: end running test {{.*}} on test_open_existential_box: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_open_existential_box : $@convention(thin) (@guaranteed any Error) -> () {
+bb0(%0 : @guaranteed $any Error):
+  %opened = open_existential_box %0 : $any Error to $*@opened("00000000-0000-0000-0000-000000000002", any Error) Self
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_open_existential_box_value: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $any Error
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = open_existential_box_value %0 : $any Error to $@opened("00000000-0000-0000-0000-000000000003", any Error) Self
+// CHECK-NEXT: end running test {{.*}} on test_open_existential_box_value: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_open_existential_box_value : $@convention(thin) (@guaranteed any Error) -> () {
+bb0(%0 : @guaranteed $any Error):
+  %opened = open_existential_box_value %0 : $any Error to $@opened("00000000-0000-0000-0000-000000000003", any Error) Self
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Method Dispatch Operations
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_class_method: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $MethodKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = class_method %0 : $MethodKlass, #MethodKlass.instanceMethod : (MethodKlass) -> () -> (), $@convention(method) (@guaranteed MethodKlass) -> ()
+// CHECK-NEXT: require %%0:   %1 = class_method %0 : $MethodKlass, #MethodKlass.instanceMethod : (MethodKlass) -> () -> (), $@convention(method) (@guaranteed MethodKlass) -> ()
+// CHECK-NEXT: assign_direct %%1 = %%0:   %1 = class_method %0 : $MethodKlass, #MethodKlass.instanceMethod : (MethodKlass) -> () -> (), $@convention(method) (@guaranteed MethodKlass) -> ()
+// CHECK-NEXT: end running test {{.*}} on test_class_method: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_class_method : $@convention(thin) (@guaranteed MethodKlass) -> () {
+bb0(%0 : @guaranteed $MethodKlass):
+  %method = class_method %0 : $MethodKlass, #MethodKlass.instanceMethod : (MethodKlass) -> () -> (), $@convention(method) (@guaranteed MethodKlass) -> ()
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %result = apply %method(%0) : $@convention(method) (@guaranteed MethodKlass) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_witness_method: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $*T
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = witness_method $T, #SomeProtocol.doSomething : <Self where Self : SomeProtocol> (Self) -> () -> () : $@convention(witness_method: SomeProtocol) <τ_0_0 where τ_0_0 : SomeProtocol> (@in_guaranteed τ_0_0) -> ()
+// CHECK-NEXT: assign_fresh %%1:   %1 = witness_method $T, #SomeProtocol.doSomething : <Self where Self : SomeProtocol> (Self) -> () -> () : $@convention(witness_method: SomeProtocol) <τ_0_0 where τ_0_0 : SomeProtocol> (@in_guaranteed τ_0_0) -> ()
+// CHECK-NEXT: end running test {{.*}} on test_witness_method: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_witness_method : $@convention(thin) <T where T : SomeProtocol> (@in_guaranteed T) -> () {
+bb0(%0 : $*T):
+  %witness = witness_method $T, #SomeProtocol.doSomething : <Self where Self : SomeProtocol> (Self) -> () -> () : $@convention(witness_method: SomeProtocol) <τ_0_0 where τ_0_0 : SomeProtocol> (@in_guaranteed τ_0_0) -> ()
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %result = apply %witness<T>(%0) : $@convention(witness_method: SomeProtocol) <τ_0_0 where τ_0_0 : SomeProtocol> (@in_guaranteed τ_0_0) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Block Operations
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_project_block_storage: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = alloc_stack $@block_storage NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_project_block_storage: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_project_block_storage : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %storage = alloc_stack $@block_storage NonSendableKlass
+  %payload = project_block_storage %storage : $*@block_storage NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %copy = copy_value %0
+  store %copy to [init] %payload
+  destroy_addr %payload
+  dealloc_stack %storage
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_init_block_storage_header: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = alloc_stack $@block_storage NonSendableKlass
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   // function_ref block_invoke
+// CHECK-NEXT:   %5 = function_ref @block_invoke : $@convention(c) (@inout_aliasable @block_storage NonSendableKlass) -> ()
+// CHECK-NEXT: %%3: TrackableValue. State: TrackableValueState[id: 3][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %6 = init_block_storage_header %1 : $*@block_storage NonSendableKlass, invoke %5 : $@convention(c) (@inout_aliasable @block_storage NonSendableKlass) -> (), type $@convention(block) @noescape () -> ()
+// CHECK-NEXT: require %%1:   %6 = init_block_storage_header %1 : $*@block_storage NonSendableKlass, invoke %5 : $@convention(c) (@inout_aliasable @block_storage NonSendableKlass) -> (), type $@convention(block) @noescape () -> ()
+// CHECK-NEXT: assign_direct %%3 = %%1:   %6 = init_block_storage_header %1 : $*@block_storage NonSendableKlass, invoke %5 : $@convention(c) (@inout_aliasable @block_storage NonSendableKlass) -> (), type $@convention(block) @noescape () -> ()
+// CHECK-NEXT: end running test {{.*}} on test_init_block_storage_header: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_init_block_storage_header : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %storage = alloc_stack $@block_storage NonSendableKlass
+  %payload = project_block_storage %storage : $*@block_storage NonSendableKlass
+  %copy = copy_value %0
+  store %copy to [init] %payload
+  %fn = function_ref @block_invoke : $@convention(c) (@inout_aliasable @block_storage NonSendableKlass) -> ()
+  %block = init_block_storage_header %storage : $*@block_storage NonSendableKlass, invoke %fn : $@convention(c) (@inout_aliasable @block_storage NonSendableKlass) -> (), type $@convention(block) @noescape () -> ()
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  dealloc_stack %storage
+  %r = tuple ()
+  return %r : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Move-Only and Lifetime Operations
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_explicit_copy_value: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_explicit_copy_value: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_explicit_copy_value : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %copy = explicit_copy_value %0 : $NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_value %copy
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_move_value_lexical: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_move_value_lexical: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_move_value_lexical : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %1 = copy_value %0
+  %2 = move_value [lexical] %1 : $NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_value %2
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_end_lifetime: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_end_lifetime: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_end_lifetime : $@convention(thin) (@owned NonSendableKlass) -> () {
+bb0(%0 : @owned $NonSendableKlass):
+  end_lifetime %0 : $NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_extend_lifetime: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_extend_lifetime: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_extend_lifetime : $@convention(thin) (@owned NonSendableKlass) -> () {
+bb0(%0 : @owned $NonSendableKlass):
+  extend_lifetime %0 : $NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_value %0
+  %r = tuple ()
+  return %r : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Type Conversion Operations
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_thin_to_thick_function: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   // function_ref thin_func
+// CHECK-NEXT:   %0 = function_ref @thin_func : $@convention(thin) () -> ()
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = thin_to_thick_function %0 : $@convention(thin) () -> () to $@callee_guaranteed () -> ()
+// CHECK-NEXT: assign_fresh %%1:   %1 = thin_to_thick_function %0 : $@convention(thin) () -> () to $@callee_guaranteed () -> ()
+// CHECK-NEXT: end running test {{.*}} on test_thin_to_thick_function: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_thin_to_thick_function : $@convention(thin) () -> () {
+bb0:
+  %thin = function_ref @thin_func : $@convention(thin) () -> ()
+  %thick = thin_to_thick_function %thin : $@convention(thin) () -> () to $@callee_guaranteed () -> ()
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_value %thick
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_convert_escape_to_noescape: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $@callee_guaranteed () -> ()
+// CHECK-NEXT: end running test {{.*}} on test_convert_escape_to_noescape: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_convert_escape_to_noescape : $@convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> () {
+bb0(%0 : @guaranteed $@callee_guaranteed () -> ()):
+  %noescape = convert_escape_to_noescape %0 : $@callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> ()
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_value %noescape
+  %r = tuple ()
+  return %r : $()
+}
+
+//sil [ossa] @test_convert_function : $@convention(thin) (@owned @callee_guaranteed (@guaranteed NonSendableKlass) -> ()) -> () {
+//bb0(%0 : @owned $@callee_guaranteed (@guaranteed NonSendableKlass) -> ()):
+//  %converted = convert_function %0 : $@callee_guaranteed (@guaranteed NonSendableKlass) -> () to $@callee_guaranteed (@guaranteed Builtin.NativeObject) -> ()
+//  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+//  destroy_value %converted
+//  %r = tuple ()
+//  return %r : $()
+//}
+
+
+//sil [ossa] @test_convert_function : $@convention(thin) (@owned @callee_guaranteed (@guaranteed NonSendableKlass) -> ()) -> () {
+//bb0(%0 : @owned $@callee_guaranteed (@guaranteed NonSendableKlass) -> ()):
+//  %converted = convert_function %0 : $@callee_guaranteed (@guaranteed NonSendableKlass) -> () to $@callee_guaranteed (@guaranteed Builtin.NativeObject) -> ()
+//  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+//  destroy_value %converted
+//  %r = tuple ()
+//  return %r : $()
+//}
+
+// CHECK-LABEL: begin running test {{.*}} on test_unchecked_bitwise_cast: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_unchecked_bitwise_cast: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_unchecked_bitwise_cast : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %casted = unchecked_bitwise_cast %0 : $NonSendableKlass to $Builtin.NativeObject
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_unchecked_addr_cast: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %0 = alloc_stack $Builtin.Word
+// CHECK-NEXT: end running test {{.*}} on test_unchecked_addr_cast: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_unchecked_addr_cast : $@convention(thin) () -> () {
+bb0:
+  %addr = alloc_stack $Builtin.Word
+  %casted = unchecked_addr_cast %addr : $*Builtin.Word to $*Builtin.RawPointer
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  dealloc_stack %addr
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_unchecked_ownership_conversion: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $Builtin.NativeObject
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = unchecked_ownership_conversion %0 : $Builtin.NativeObject, @guaranteed to @owned
+// CHECK-NEXT: require %%0:   %1 = unchecked_ownership_conversion %0 : $Builtin.NativeObject, @guaranteed to @owned
+// CHECK-NEXT: assign_direct %%1 = %%0:   %1 = unchecked_ownership_conversion %0 : $Builtin.NativeObject, @guaranteed to @owned
+// CHECK-NEXT: end running test {{.*}} on test_unchecked_ownership_conversion: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_unchecked_ownership_conversion : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : @guaranteed $Builtin.NativeObject):
+  %owned = unchecked_ownership_conversion %0 : $Builtin.NativeObject, @guaranteed to @owned
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  end_lifetime %owned : $Builtin.NativeObject
+  %r = tuple ()
+  return %r : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Deallocation Operations
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_dealloc_box: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: end running test {{.*}} on test_dealloc_box: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_dealloc_box : $@convention(thin) () -> () {
+bb0:
+  %box = alloc_box ${ var NonSendableKlass }
+  dealloc_box %box : ${ var NonSendableKlass }
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_dealloc_ref: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: end running test {{.*}} on test_dealloc_ref: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_dealloc_ref : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_ref $NonSendableKlassSubKlass
+  %1 = begin_dealloc_ref %0 : $NonSendableKlassSubKlass of %0 : $NonSendableKlassSubKlass
+  dealloc_ref %1 : $NonSendableKlassSubKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Selection Operations
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_select_enum: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableEnum
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = integer_literal $Builtin.Int32, 1
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %2 = integer_literal $Builtin.Int32, 0
+// CHECK-NEXT: %%3: TrackableValue. State: TrackableValueState[id: 3][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %3 = select_enum %0 : $NonSendableEnum, case #NonSendableEnum.some!enumelt: %1, case #NonSendableEnum.none!enumelt: %2 : $Builtin.Int32
+// CHECK-NEXT: end running test {{.*}} on test_select_enum: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_select_enum : $@convention(thin) (@guaranteed NonSendableEnum) -> Builtin.Int32 {
+bb0(%0 : @guaranteed $NonSendableEnum):
+  %some_val = integer_literal $Builtin.Int32, 1
+  %none_val = integer_literal $Builtin.Int32, 0
+  %result = select_enum %0 : $NonSendableEnum, case #NonSendableEnum.some!enumelt: %some_val, case #NonSendableEnum.none!enumelt: %none_val : $Builtin.Int32
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  return %result : $Builtin.Int32
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_select_enum_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $*NonSendableEnum
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = integer_literal $Builtin.Int32, 1
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %2 = integer_literal $Builtin.Int32, 0
+// CHECK-NEXT: %%3: TrackableValue. State: TrackableValueState[id: 3][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %3 = select_enum_addr %0 : $*NonSendableEnum, case #NonSendableEnum.some!enumelt: %1, case #NonSendableEnum.none!enumelt: %2 : $Builtin.Int32
+// CHECK-NEXT: end running test {{.*}} on test_select_enum_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_select_enum_addr : $@convention(thin) (@in_guaranteed NonSendableEnum) -> Builtin.Int32 {
+bb0(%0 : $*NonSendableEnum):
+  %some_val = integer_literal $Builtin.Int32, 1
+  %none_val = integer_literal $Builtin.Int32, 0
+  %result = select_enum_addr %0 : $*NonSendableEnum, case #NonSendableEnum.some!enumelt: %some_val, case #NonSendableEnum.none!enumelt: %none_val : $Builtin.Int32
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  return %result : $Builtin.Int32
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Throw Terminator
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_throw: sil_regionanalysis_partitionoptranslation with: @instruction
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $any Error
+// CHECK-NEXT: end running test {{.*}} on test_throw: sil_regionanalysis_partitionoptranslation with: @instruction
+sil [ossa] @test_throw : $@convention(thin) (@owned any Error) -> @error any Error {
+bb0(%0 : @owned $any Error):
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction"
+  throw %0 : $any Error
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Move-Only Type Wrapper Operations
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_copyable_to_moveonlywrapper: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $Builtin.NativeObject
+// CHECK-NEXT: end running test {{.*}} on test_copyable_to_moveonlywrapper: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_copyable_to_moveonlywrapper : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  %1 = copyable_to_moveonlywrapper [owned] %0 : $Builtin.NativeObject
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_value %1 : $@moveOnly Builtin.NativeObject
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_moveonlywrapper_to_copyable: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $Builtin.NativeObject
+// CHECK-NEXT: end running test {{.*}} on test_moveonlywrapper_to_copyable: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_moveonlywrapper_to_copyable : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  %1 = copyable_to_moveonlywrapper [owned] %0 : $Builtin.NativeObject
+  %2 = moveonlywrapper_to_copyable [owned] %1 : $@moveOnly Builtin.NativeObject
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_value %2 : $Builtin.NativeObject
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_copyable_to_moveonlywrapper_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $*Builtin.NativeObject
+// CHECK-NEXT: end running test {{.*}} on test_copyable_to_moveonlywrapper_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_copyable_to_moveonlywrapper_addr : $@convention(thin) (@in Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject):
+  %1 = copyable_to_moveonlywrapper_addr %0 : $*Builtin.NativeObject
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_addr %1 : $*@moveOnly Builtin.NativeObject
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_moveonlywrapper_to_copyable_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %0 = alloc_stack $@moveOnly Builtin.NativeObject
+// CHECK-NEXT: end running test {{.*}} on test_moveonlywrapper_to_copyable_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_moveonlywrapper_to_copyable_addr : $@convention(thin) () -> () {
+bb0:
+  %1 = alloc_stack $@moveOnly Builtin.NativeObject
+  %2 = moveonlywrapper_to_copyable_addr %1 : $*@moveOnly Builtin.NativeObject
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  dealloc_stack %1
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_drop_deinit: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $MoveOnlyStruct
+// CHECK-NEXT: end running test {{.*}} on test_drop_deinit: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_drop_deinit : $@convention(thin) (@owned MoveOnlyStruct) -> () {
+bb0(%0 : @owned $MoveOnlyStruct):
+  %1 = drop_deinit %0 : $MoveOnlyStruct
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_value %1 : $MoveOnlyStruct
+  %r = tuple ()
+  return %r : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Weak Reference Operations
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_load_weak: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $*@sil_weak Optional<NonSendableKlass>
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = load_weak %0 : $*@sil_weak Optional<NonSendableKlass>
+// CHECK-NEXT: require %%0:   %1 = load_weak %0 : $*@sil_weak Optional<NonSendableKlass>
+// CHECK-NEXT: assign_direct %%1 = %%0:   %1 = load_weak %0 : $*@sil_weak Optional<NonSendableKlass>
+// CHECK-NEXT: end running test {{.*}} on test_load_weak: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_load_weak : $@convention(thin) (@in @sil_weak Optional<NonSendableKlass>) -> () {
+bb0(%0 : $*@sil_weak Optional<NonSendableKlass>):
+  %1 = load_weak %0 : $*@sil_weak Optional<NonSendableKlass>
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_value %1 : $Optional<NonSendableKlass>
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_store_weak: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $Optional<NonSendableKlass>
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: yes][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %1 = argument of bb0 : $*@sil_weak Optional<NonSendableKlass>
+// CHECK-NEXT: require %%0:   store_weak %0 to %1 : $*@sil_weak Optional<NonSendableKlass>
+// CHECK-NEXT: assign_direct %%1 = %%0:   store_weak %0 to %1 : $*@sil_weak Optional<NonSendableKlass>
+// CHECK-NEXT: end running test {{.*}} on test_store_weak: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_store_weak : $@convention(thin) (@owned Optional<NonSendableKlass>, @inout @sil_weak Optional<NonSendableKlass>) -> () {
+bb0(%0 : @owned $Optional<NonSendableKlass>, %1 : $*@sil_weak Optional<NonSendableKlass>):
+  store_weak %0 to %1 : $*@sil_weak Optional<NonSendableKlass>
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_value %0
+  %r = tuple ()
+  return %r : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Unowned Reference Operations
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_load_unowned: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $*@sil_unowned NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = load_unowned %0 : $*@sil_unowned NonSendableKlass
+// CHECK-NEXT: require %%0:   %1 = load_unowned %0 : $*@sil_unowned NonSendableKlass
+// CHECK-NEXT: assign_direct %%1 = %%0:   %1 = load_unowned %0 : $*@sil_unowned NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_load_unowned: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_load_unowned : $@convention(thin) (@in @sil_unowned NonSendableKlass) -> () {
+bb0(%0 : $*@sil_unowned NonSendableKlass):
+  %1 = load_unowned %0 : $*@sil_unowned NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_value %1 : $NonSendableKlass
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_store_unowned: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: yes][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %1 = argument of bb0 : $*@sil_unowned NonSendableKlass
+// CHECK-NEXT: require %%0:   store_unowned %0 to %1 : $*@sil_unowned NonSendableKlass
+// CHECK-NEXT: assign_direct %%1 = %%0:   store_unowned %0 to %1 : $*@sil_unowned NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_store_unowned: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_store_unowned : $@convention(thin) (@guaranteed NonSendableKlass, @inout @sil_unowned NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass, %1 : $*@sil_unowned NonSendableKlass):
+  store_unowned %0 to %1 : $*@sil_unowned NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_strong_copy_unowned_value: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $@sil_unowned NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = strong_copy_unowned_value %0 : $@sil_unowned NonSendableKlass
+// CHECK-NEXT: require %%0:   %1 = strong_copy_unowned_value %0 : $@sil_unowned NonSendableKlass
+// CHECK-NEXT: assign_direct %%1 = %%0:   %1 = strong_copy_unowned_value %0 : $@sil_unowned NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_strong_copy_unowned_value: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_strong_copy_unowned_value : $@convention(thin) (@guaranteed @sil_unowned NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $@sil_unowned NonSendableKlass):
+  %1 = strong_copy_unowned_value %0 : $@sil_unowned NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_value %1 : $NonSendableKlass
+  %r = tuple ()
+  return %r : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Coroutine Suspension Operations
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_yield_terminator: sil_regionanalysis_partitionoptranslation with: @instruction
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = alloc_stack $NonSendableKlass
+// CHECK-NEXT: require %%1:   yield %1 : $*NonSendableKlass, resume bb1, unwind bb2
+// CHECK-NEXT: end running test {{.*}} on test_yield_terminator: sil_regionanalysis_partitionoptranslation with: @instruction
+sil [ossa] @test_yield_terminator : $@yield_once @convention(thin) (@guaranteed NonSendableKlass) -> @yields @inout NonSendableKlass {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %1 = alloc_stack $NonSendableKlass
+  %2 = copy_value %0
+  store %2 to [init] %1
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction"
+  yield %1 : $*NonSendableKlass, resume bb1, unwind bb2
+
+bb1:
+  destroy_addr %1
+  dealloc_stack %1
+  %r = tuple ()
+  return %r : $()
+
+bb2:
+  destroy_addr %1
+  dealloc_stack %1
+  unwind
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_unwind_terminator: sil_regionanalysis_partitionoptranslation with: @instruction
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_unwind_terminator: sil_regionanalysis_partitionoptranslation with: @instruction
+sil [ossa] @test_unwind_terminator : $@yield_once @convention(thin) (@guaranteed NonSendableKlass) -> @yields @inout NonSendableKlass {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %1 = alloc_stack $NonSendableKlass
+  %2 = copy_value %0
+  store %2 to [init] %1
+  yield %1 : $*NonSendableKlass, resume bb1, unwind bb2
+
+bb1:
+  destroy_addr %1
+  dealloc_stack %1
+  %r = tuple ()
+  return %r : $()
+
+bb2:
+  destroy_addr %1
+  dealloc_stack %1
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction"
+  unwind
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Variadic Generics and Pack Operations
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_pack_length: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: end running test {{.*}} on test_pack_length: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_pack_length : $@convention(thin) <each T> () -> Builtin.Word {
+bb0:
+  %len = pack_length $Pack{repeat each T}
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  return %len : $Builtin.Word
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_scalar_pack_index: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: end running test {{.*}} on test_scalar_pack_index: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_scalar_pack_index : $@convention(thin) <each T> () -> () {
+bb0:
+  %index = scalar_pack_index 0 of $Pack{NonSendableKlass, repeat each T, NonSendableKlass}
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_dynamic_pack_index: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $Builtin.Word
+// CHECK-NEXT: end running test {{.*}} on test_dynamic_pack_index: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_dynamic_pack_index : $@convention(thin) <each T> (Builtin.Word) -> () {
+bb0(%word_idx : $Builtin.Word):
+  %index = dynamic_pack_index %word_idx of $Pack{repeat each T}
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_pack_pack_index: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $Builtin.Word
+// CHECK-NEXT: end running test {{.*}} on test_pack_pack_index: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_pack_pack_index : $@convention(thin) <each T> (Builtin.Word) -> () {
+bb0(%slice_idx : $Builtin.Word):
+  %innerIndex = dynamic_pack_index %slice_idx of $Pack{repeat each T}
+  %index = pack_pack_index 0, %innerIndex of $Pack{repeat each T}
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_pack_element_get: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $*Pack{repeat each T}
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: %1 = argument of bb0 : $Builtin.Word
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %4 = pack_element_get %2 of %0 : $*Pack{repeat each T} as $*@pack_element("00000000-0000-0000-0000-000000000010") each T
+// CHECK-NEXT: require %%0:   %4 = pack_element_get %2 of %0 : $*Pack{repeat each T} as $*@pack_element("00000000-0000-0000-0000-000000000010") each T
+// CHECK-NEXT: assign_direct %%2 = %%0:   %4 = pack_element_get %2 of %0 : $*Pack{repeat each T} as $*@pack_element("00000000-0000-0000-0000-000000000010") each T
+// CHECK-NEXT: end running test {{.*}} on test_pack_element_get: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_pack_element_get : $@convention(thin) <each T> (@pack_owned Pack{repeat each T}, Builtin.Word) -> () {
+bb0(%pack : $*Pack{repeat each T}, %idx : $Builtin.Word):
+  %index = dynamic_pack_index %idx of $Pack{repeat each T}
+  open_pack_element %index of <each T> at <Pack{repeat each T}>, shape $T, uuid "00000000-0000-0000-0000-000000000010"
+  %elem_addr = pack_element_get %index of %pack : $*Pack{repeat each T} as $*@pack_element("00000000-0000-0000-0000-000000000010") T
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+//sil [ossa] @test_pack_element_set : $@convention(thin) <each T> (@pack_inout Pack{repeat each T}, @in T, Builtin.Word) -> () {
+//bb0(%pack : $*Pack{repeat each T}, %value : $*T, %idx : $Builtin.Word):
+//  %index = dynamic_pack_index %idx of $Pack{repeat each T}
+//  open_pack_element %index of <each T> at <Pack{repeat each T}>, shape $T, uuid "00000000-0000-0000-0000-000000000011"
+//  pack_element_set %value : $*@pack_element("00000000-0000-0000-0000-000000000011") T into %index of %pack : $*Pack{repeat each T}
+//  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+//  %r = tuple ()
+//  return %r : $()
+//}
+
+
+//sil [ossa] @test_pack_element_set : $@convention(thin) <each T> (@pack_inout Pack{repeat each T}, @in T, Builtin.Word) -> () {
+//bb0(%pack : $*Pack{repeat each T}, %value : $*T, %idx : $Builtin.Word):
+//  %index = dynamic_pack_index %idx of $Pack{repeat each T}
+//  open_pack_element %index of <each T> at <Pack{repeat each T}>, shape $T, uuid "00000000-0000-0000-0000-000000000011"
+//  pack_element_set %value : $*@pack_element("00000000-0000-0000-0000-000000000011") T into %index of %pack : $*Pack{repeat each T}
+//  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+//  %r = tuple ()
+//  return %r : $()
+//}
+
+// CHECK-LABEL: begin running test {{.*}} on test_open_pack_element: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $*Pack{repeat each T}
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: %1 = argument of bb0 : $Builtin.Word
+// CHECK-NEXT: end running test {{.*}} on test_open_pack_element: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_open_pack_element : $@convention(thin) <each T> (@pack_owned Pack{repeat each T}, Builtin.Word) -> () {
+bb0(%pack : $*Pack{repeat each T}, %idx : $Builtin.Word):
+  %index = dynamic_pack_index %idx of $Pack{repeat each T}
+  open_pack_element %index of <each T> at <Pack{repeat each T}>, shape $T, uuid "00000000-0000-0000-0000-000000000012"
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_pack_with_nonsendable: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %1 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %2 = alloc_stack $Pack{NonSendableKlass, NonSendableKlass}
+// CHECK-NEXT: %%3: TrackableValue. State: TrackableValueState[id: 3][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %8 = pack_element_get %7 of %2 : $*Pack{NonSendableKlass, NonSendableKlass} as $*NonSendableKlass
+// CHECK-NEXT: require %%2:   %8 = pack_element_get %7 of %2 : $*Pack{NonSendableKlass, NonSendableKlass} as $*NonSendableKlass
+// CHECK-NEXT: assign_direct %%3 = %%2:   %8 = pack_element_get %7 of %2 : $*Pack{NonSendableKlass, NonSendableKlass} as $*NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_pack_with_nonsendable: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_pack_with_nonsendable : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass, %1 : @guaranteed $NonSendableKlass):
+  %pack_addr = alloc_stack $Pack{NonSendableKlass, NonSendableKlass}
+
+  // Get index for first element
+  %index0 = scalar_pack_index 0 of $Pack{NonSendableKlass, NonSendableKlass}
+
+  // Get address of first element
+  %elem0_addr = pack_element_get %index0 of %pack_addr : $*Pack{NonSendableKlass, NonSendableKlass} as $*NonSendableKlass
+  %copy0 = copy_value %0
+  store %copy0 to [init] %elem0_addr
+
+  // Get index for second element
+  %index1 = scalar_pack_index 1 of $Pack{NonSendableKlass, NonSendableKlass}
+
+  // Get address of second element
+  %elem1_addr = pack_element_get %index1 of %pack_addr : $*Pack{NonSendableKlass, NonSendableKlass} as $*NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %copy1 = copy_value %1
+  store %copy1 to [init] %elem1_addr
+
+  destroy_addr %pack_addr
+  dealloc_stack %pack_addr
+  %r = tuple ()
+  return %r : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Unpaired Access Operations
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_begin_unpaired_access: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = alloc_stack $NonSendableKlass
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %4 = alloc_stack $Builtin.UnsafeValueBuffer
+// CHECK-NEXT: require %%1:   begin_unpaired_access [read] [dynamic] %1 : $*NonSendableKlass, %4 : $*Builtin.UnsafeValueBuffer
+// CHECK-NEXT: end running test {{.*}} on test_begin_unpaired_access: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_begin_unpaired_access : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %stack = alloc_stack $NonSendableKlass
+  %copy = copy_value %0
+  store %copy to [init] %stack
+  %buf = alloc_stack $Builtin.UnsafeValueBuffer
+  begin_unpaired_access [read] [dynamic] %stack : $*NonSendableKlass, %buf : $*Builtin.UnsafeValueBuffer
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  end_unpaired_access [dynamic] %buf : $*Builtin.UnsafeValueBuffer
+  dealloc_stack %buf
+  destroy_addr %stack
+  dealloc_stack %stack
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_end_unpaired_access: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_end_unpaired_access: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_end_unpaired_access : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %stack = alloc_stack $NonSendableKlass
+  %copy = copy_value %0
+  store %copy to [init] %stack
+  %buf = alloc_stack $Builtin.UnsafeValueBuffer
+  begin_unpaired_access [modify] [dynamic] %stack : $*NonSendableKlass, %buf : $*Builtin.UnsafeValueBuffer
+  end_unpaired_access [dynamic] %buf : $*Builtin.UnsafeValueBuffer
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  dealloc_stack %buf
+  destroy_addr %stack
+  dealloc_stack %stack
+  %r = tuple ()
+  return %r : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Memory Binding Operations
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_bind_memory: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $Builtin.RawPointer
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = integer_literal $Builtin.Word, 1
+// CHECK-NEXT: require %%0:   %2 = bind_memory %0 : $Builtin.RawPointer, %1 : $Builtin.Word to $*NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_bind_memory: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_bind_memory : $@convention(thin) (Builtin.RawPointer) -> () {
+bb0(%ptr : $Builtin.RawPointer):
+  %count = integer_literal $Builtin.Word, 1
+  %token = bind_memory %ptr : $Builtin.RawPointer, %count : $Builtin.Word to $*NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_rebind_memory: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $Builtin.RawPointer
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %2 = bind_memory %0 : $Builtin.RawPointer, %1 : $Builtin.Word to $*NonSendableKlass
+// CHECK-NEXT: require %%0:   %3 = rebind_memory %0 : $Builtin.RawPointer to %2 : $Builtin.Word
+// CHECK-NEXT: end running test {{.*}} on test_rebind_memory: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_rebind_memory : $@convention(thin) (Builtin.RawPointer) -> () {
+bb0(%ptr : $Builtin.RawPointer):
+  %count = integer_literal $Builtin.Word, 1
+  %token = bind_memory %ptr : $Builtin.RawPointer, %count : $Builtin.Word to $*NonSendableKlass
+  rebind_memory %ptr : $Builtin.RawPointer to %token : $Builtin.Word
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Tuple Address Operations
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_tuple_addr_constructor_init: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %1 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %2 = alloc_stack $(NonSendableKlass, NonSendableKlass)
+// CHECK-NEXT: require %%2:   tuple_addr_constructor [assign] %2 : $*(NonSendableKlass, NonSendableKlass) with (%3 : $*NonSendableKlass, %4 : $*NonSendableKlass)
+// CHECK-NEXT: require %%2:   tuple_addr_constructor [assign] %2 : $*(NonSendableKlass, NonSendableKlass) with (%3 : $*NonSendableKlass, %4 : $*NonSendableKlass)
+// CHECK-NEXT: end running test {{.*}} on test_tuple_addr_constructor_init: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_tuple_addr_constructor_init : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass, %1 : @guaranteed $NonSendableKlass):
+  %tuple_addr = alloc_stack $(NonSendableKlass, NonSendableKlass)
+  %elem0_addr = tuple_element_addr %tuple_addr : $*(NonSendableKlass, NonSendableKlass), 0
+  %elem1_addr = tuple_element_addr %tuple_addr : $*(NonSendableKlass, NonSendableKlass), 1
+  %copy0 = copy_value %0
+  store %copy0 to [init] %elem0_addr
+  %copy1 = copy_value %1
+  store %copy1 to [init] %elem1_addr
+  tuple_addr_constructor [assign] %tuple_addr : $*(NonSendableKlass, NonSendableKlass) with (%elem0_addr : $*NonSendableKlass, %elem1_addr : $*NonSendableKlass)
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_addr %tuple_addr
+  dealloc_stack %tuple_addr
+  %r = tuple ()
+  return %r : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Tail Allocation Operations
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_tail_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %0 = alloc_stack $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = integer_literal $Builtin.Word, 1
+// CHECK-NEXT: require %%0:   %2 = tail_addr %0 : $*NonSendableKlass, %1 : $Builtin.Word, $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_tail_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_tail_addr : $@convention(thin) () -> () {
+bb0:
+  %addr = alloc_stack $NonSendableKlass
+  %count = integer_literal $Builtin.Word, 1
+  %tail = tail_addr %addr : $*NonSendableKlass, %count : $Builtin.Word, $NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  dealloc_stack %addr
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_ref_tail_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = ref_tail_addr %0 : $NonSendableKlass, $NonSendableKlass
+// CHECK-NEXT: require %%0:   %1 = ref_tail_addr %0 : $NonSendableKlass, $NonSendableKlass
+// CHECK-NEXT: assign_direct %%1 = %%0:   %1 = ref_tail_addr %0 : $NonSendableKlass, $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_ref_tail_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_ref_tail_addr : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %tail = ref_tail_addr %0 : $NonSendableKlass, $NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_ref_tail_addr_immutable: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = ref_tail_addr [immutable] %0 : $NonSendableKlass, $NonSendableKlass
+// CHECK-NEXT: require %%0:   %1 = ref_tail_addr [immutable] %0 : $NonSendableKlass, $NonSendableKlass
+// CHECK-NEXT: assign_direct %%1 = %%0:   %1 = ref_tail_addr [immutable] %0 : $NonSendableKlass, $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_ref_tail_addr_immutable: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_ref_tail_addr_immutable : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %tail = ref_tail_addr [immutable] %0 : $NonSendableKlass, $NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_index_raw_pointer: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $Builtin.RawPointer
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = integer_literal $Builtin.Word, 8
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %2 = index_raw_pointer %0 : $Builtin.RawPointer, %1 : $Builtin.Word
+// CHECK-NEXT: require %%0:   %2 = index_raw_pointer %0 : $Builtin.RawPointer, %1 : $Builtin.Word
+// CHECK-NEXT: assign_direct %%2 = %%0:   %2 = index_raw_pointer %0 : $Builtin.RawPointer, %1 : $Builtin.Word
+// CHECK-NEXT: end running test {{.*}} on test_index_raw_pointer: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_index_raw_pointer : $@convention(thin) (Builtin.RawPointer) -> () {
+bb0(%ptr : $Builtin.RawPointer):
+  %offset = integer_literal $Builtin.Word, 8
+  %new_ptr = index_raw_pointer %ptr : $Builtin.RawPointer, %offset : $Builtin.Word
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Global Value Operations
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_global_value: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %0 = global_value @immutable_global : $NonSendableKlass // ownership: none
+// CHECK-NEXT: assign_fresh %%0:   %0 = global_value @immutable_global : $NonSendableKlass // ownership: none
+// CHECK-NEXT: end running test {{.*}} on test_global_value: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_global_value : $@convention(thin) () -> () {
+bb0:
+  %global = global_value @immutable_global : $NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_global_value_bare: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %0 = global_value [bare] @immutable_global : $NonSendableKlass // ownership: none
+// CHECK-NEXT: assign_fresh %%0:   %0 = global_value [bare] @immutable_global : $NonSendableKlass // ownership: none
+// CHECK-NEXT: end running test {{.*}} on test_global_value_bare: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_global_value_bare : $@convention(thin) () -> () {
+bb0:
+  %global = global_value [bare] @immutable_global : $NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_alloc_global: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: end running test {{.*}} on test_alloc_global: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_alloc_global : $@convention(thin) () -> () {
+bb0:
+  alloc_global @global_nonsendable
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Dynamic Replacement Operations
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_dynamic_function_ref: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   // dynamic_function_ref dynamic_func
+// CHECK-NEXT:   %0 = dynamic_function_ref @dynamic_func : $@convention(thin) () -> ()
+// CHECK-NEXT: assign_fresh %%0:   // dynamic_function_ref dynamic_func
+// CHECK-NEXT:   %0 = dynamic_function_ref @dynamic_func : $@convention(thin) () -> ()
+// CHECK-NEXT: end running test {{.*}} on test_dynamic_function_ref: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_dynamic_function_ref : $@convention(thin) () -> () {
+bb0:
+  %fn = dynamic_function_ref @dynamic_func : $@convention(thin) () -> ()
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+//sil [ossa] @test_prev_dynamic_function_ref : $@convention(thin) () -> () {
+//bb0:
+//  %fn = prev_dynamic_function_ref @dynamic_func : $@convention(thin) () -> ()
+//  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+//  %r = tuple ()
+//  return %r : $()
+//}
+
+
+//sil [ossa] @test_prev_dynamic_function_ref : $@convention(thin) () -> () {
+//bb0:
+//  %fn = prev_dynamic_function_ref @dynamic_func : $@convention(thin) () -> ()
+//  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+//  %r = tuple ()
+//  return %r : $()
+//}
+
+// CHECK-LABEL: begin running test {{.*}} on test_base_addr_for_offset: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %0 = base_addr_for_offset $*NonSendableKlass
+// CHECK-NEXT: assign_fresh %%0:   %0 = base_addr_for_offset $*NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_base_addr_for_offset: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_base_addr_for_offset : $@convention(thin) () -> () {
+bb0:
+  %base = base_addr_for_offset $*NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Assertion and Unreachable Operations
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_cond_fail: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $Builtin.Int1
+// CHECK-NEXT: end running test {{.*}} on test_cond_fail: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_cond_fail : $@convention(thin) (Builtin.Int1) -> () {
+bb0(%cond : $Builtin.Int1):
+  cond_fail %cond : $Builtin.Int1, "test failure"
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_unreachable: sil_regionanalysis_partitionoptranslation with: @instruction
+// CHECK-NEXT: end running test {{.*}} on test_unreachable: sil_regionanalysis_partitionoptranslation with: @instruction
+sil [ossa] @test_unreachable : $@convention(thin) () -> () {
+bb0:
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction"
+  unreachable
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Special Lifecycle Operations
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_begin_dealloc_ref: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %0 = alloc_ref $NonSendableKlass
+// CHECK-NEXT: require %%0:   %1 = begin_dealloc_ref %0 : $NonSendableKlass of %0 : $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_begin_dealloc_ref: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_begin_dealloc_ref : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_ref $NonSendableKlass
+  %1 = begin_dealloc_ref %0 : $NonSendableKlass of %0 : $NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  dealloc_ref %1 : $NonSendableKlass
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_end_init_let_ref: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_end_init_let_ref: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_end_init_let_ref : $@convention(thin) (@owned NonSendableKlass) -> () {
+bb0(%0 : @owned $NonSendableKlass):
+  %1 = end_init_let_ref %0 : $NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_value %1
+  %r = tuple ()
+  return %r : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Additional Dependency Operations
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_mark_dependence_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = alloc_stack $NonSendableKlass
+// CHECK-NEXT: require %%1:   mark_dependence_addr %1 : $*NonSendableKlass on %0 : $NonSendableKlass
+// CHECK-NEXT: require %%0:   mark_dependence_addr %1 : $*NonSendableKlass on %0 : $NonSendableKlass
+// CHECK-NEXT: merge %%1 with %%0:   mark_dependence_addr %1 : $*NonSendableKlass on %0 : $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_mark_dependence_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_mark_dependence_addr : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %stack = alloc_stack $NonSendableKlass
+  %copy = copy_value %0
+  store %copy to [init] %stack
+  mark_dependence_addr %stack : $*NonSendableKlass on %0 : $NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_addr %stack
+  dealloc_stack %stack
+  %r = tuple ()
+  return %r : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Existential Box Deallocation
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_dealloc_existential_box: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: end running test {{.*}} on test_dealloc_existential_box: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_dealloc_existential_box : $@convention(thin) () -> () {
+bb0:
+  %box = alloc_existential_box $any Error, $MyErrorNonSendable
+  %addr = project_existential_box $MyErrorNonSendable in %box : $any Error
+  %val = enum $MyErrorNonSendable, #MyErrorNonSendable.failure
+  store %val to [init] %addr
+  destroy_addr %addr
+  dealloc_existential_box %box : $any Error, $Builtin.Int64
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+//sil [ossa] @test_get_async_continuation : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () {
+//bb0(%0 : @guaranteed $NonSendableKlass):
+//  (%continuation, %result_addr) = get_async_continuation $NonSendableKlass
+//  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+//  %copy = copy_value %0
+//  store %copy to [init] %result_addr
+//  await_async_continuation %continuation : $Builtin.RawUnsafeContinuation, resume bb1
+//
+//bb1(%result : @owned $NonSendableKlass):
+//  destroy_value %result
+//  %r = tuple ()
+//  return %r : $()
+//}
+//
+//sil [ossa] @test_get_async_continuation_addr : $@convention(thin) @async (@in NonSendableKlass) -> () {
+//bb0(%0 : $*NonSendableKlass):
+//  (%continuation, %result_addr) = get_async_continuation_addr $NonSendableKlass
+//  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+//  copy_addr [take] %0 to [init] %result_addr
+//  await_async_continuation %continuation : $Builtin.RawUnsafeContinuation, resume bb1
+//
+//bb1:
+//  %r = tuple ()
+//  return %r : $()
+//}
+//
+//sil [ossa] @test_await_async_continuation : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () {
+//bb0(%0 : @guaranteed $NonSendableKlass):
+//  (%continuation, %result_addr) = get_async_continuation $NonSendableKlass
+//  %copy = copy_value %0
+//  store %copy to [init] %result_addr
+//  specify_test "sil_regionanalysis_partitionoptranslation @instruction"
+//  await_async_continuation %continuation : $Builtin.RawUnsafeContinuation, resume bb1
+//
+//bb1(%result : @owned $NonSendableKlass):
+//  destroy_value %result
+//  %r = tuple ()
+//  return %r : $()
+//}
+//
+//sil [ossa] @test_hop_to_executor : $@convention(thin) @async (Builtin.Executor) -> () {
+//bb0(%executor : $Builtin.Executor):
+//  hop_to_executor %executor : $Builtin.Executor
+//  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+//  %r = tuple ()
+//  return %r : $()
+//}
+//
+//sil [ossa] @test_extract_executor : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+//bb0(%0 : @guaranteed $NonSendableKlass):
+//  %executor = extract_executor %0 : $NonSendableKlass
+//  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+//  %r = tuple ()
+//  return %r : $()
+//}

--- a/test/Concurrency/transfernonsendable_partitionop_translation_objc.sil
+++ b/test/Concurrency/transfernonsendable_partitionop_translation_objc.sil
@@ -1,0 +1,153 @@
+// RUN: %target-sil-opt -enable-objc-interop --test-runner %s 2>&1 | %FileCheck %s
+
+// REQUIRES: objc_interop
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+// This test file contains Objective-C interop instructions that require
+// Objective-C runtime support and are not available on all platforms.
+
+import Builtin
+import Swift
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+// Objective-C class that can be called via objc_method
+@objc class ObjCNonSendableClass {
+  @objc func instanceMethod() -> ObjCNonSendableClass
+  @objc class func classMethod() -> ObjCNonSendableClass
+  @objc func method() -> ()
+}
+
+@objc class ObjCDerivedClass : ObjCNonSendableClass {
+  @objc override func instanceMethod() -> ObjCNonSendableClass
+}
+
+sil @objc_instance_impl : $@convention(method) (@guaranteed ObjCNonSendableClass) -> @owned ObjCNonSendableClass
+sil @objc_class_impl : $@convention(method) (@objc_metatype ObjCNonSendableClass.Type) -> @owned ObjCNonSendableClass
+sil @objc_derived_impl : $@convention(method) (@guaranteed ObjCDerivedClass) -> @owned ObjCNonSendableClass
+
+//===----------------------------------------------------------------------===//
+// MARK: Objective-C Method Dispatch
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_objc_method_instance: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $ObjCNonSendableClass      // users: %2, %1
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = objc_method %0 : $ObjCNonSendableClass, #ObjCNonSendableClass.instanceMethod!foreign : (ObjCNonSendableClass) -> () -> ObjCNonSendableClass, $@convention(objc_method) (ObjCNonSendableClass) -> @autoreleased ObjCNonSendableClass // user: %2
+// CHECK-NEXT: require %%0:   %1 = objc_method %0 : $ObjCNonSendableClass, #ObjCNonSendableClass.instanceMethod!foreign : (ObjCNonSendableClass) -> () -> ObjCNonSendableClass, $@convention(objc_method) (ObjCNonSendableClass) -> @autoreleased ObjCNonSendableClass // user: %2
+// CHECK-NEXT: assign_direct %%1 = %%0:   %1 = objc_method %0 : $ObjCNonSendableClass, #ObjCNonSendableClass.instanceMethod!foreign : (ObjCNonSendableClass) -> () -> ObjCNonSendableClass, $@convention(objc_method) (ObjCNonSendableClass) -> @autoreleased ObjCNonSendableClass // user: %2
+// CHECK-NEXT: end running test 1 of 1 on test_objc_method_instance: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_objc_method_instance : $@convention(thin) (@guaranteed ObjCNonSendableClass) -> () {
+bb0(%0 : @guaranteed $ObjCNonSendableClass):
+  %method = objc_method %0 : $ObjCNonSendableClass, #ObjCNonSendableClass.instanceMethod!foreign : (ObjCNonSendableClass) -> () -> ObjCNonSendableClass, $@convention(objc_method) (ObjCNonSendableClass) -> @autoreleased ObjCNonSendableClass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %result = apply %method(%0) : $@convention(objc_method) (ObjCNonSendableClass) -> @autoreleased ObjCNonSendableClass
+  destroy_value %result : $ObjCNonSendableClass
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: begin running test {{.*}} on test_objc_method_class: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $@thick ObjCNonSendableClass.Type // user: %1
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = thick_to_objc_metatype %0 : $@thick ObjCNonSendableClass.Type to $@objc_metatype ObjCNonSendableClass.Type // users: %3, %2
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %2 = objc_method %1 : $@objc_metatype ObjCNonSendableClass.Type, #ObjCNonSendableClass.classMethod!foreign : (ObjCNonSendableClass.Type) -> () -> ObjCNonSendableClass, $@convention(objc_method) (@objc_metatype ObjCNonSendableClass.Type) -> @autoreleased ObjCNonSendableClass // user: %3
+// CHECK-NEXT: assign_fresh %%2:   %2 = objc_method %1 : $@objc_metatype ObjCNonSendableClass.Type, #ObjCNonSendableClass.classMethod!foreign : (ObjCNonSendableClass.Type) -> () -> ObjCNonSendableClass, $@convention(objc_method) (@objc_metatype ObjCNonSendableClass.Type) -> @autoreleased ObjCNonSendableClass // user: %3
+// CHECK-NEXT: end running test 1 of 1 on test_objc_method_class: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_objc_method_class : $@convention(thin) (@thick ObjCNonSendableClass.Type) -> () {
+bb0(%0 : $@thick ObjCNonSendableClass.Type):
+  %objc_meta = thick_to_objc_metatype %0 : $@thick ObjCNonSendableClass.Type to $@objc_metatype ObjCNonSendableClass.Type
+  %method = objc_method %objc_meta : $@objc_metatype ObjCNonSendableClass.Type, #ObjCNonSendableClass.classMethod!foreign : (ObjCNonSendableClass.Type) -> () -> ObjCNonSendableClass, $@convention(objc_method) (@objc_metatype ObjCNonSendableClass.Type) -> @autoreleased ObjCNonSendableClass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %result = apply %method(%objc_meta) : $@convention(objc_method) (@objc_metatype ObjCNonSendableClass.Type) -> @autoreleased ObjCNonSendableClass
+  destroy_value %result : $ObjCNonSendableClass
+  %r = tuple ()
+  return %r : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Objective-C Super Method Dispatch
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_objc_super_method: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $ObjCDerivedClass          // users: %2, %1
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = objc_super_method %0 : $ObjCDerivedClass, #ObjCNonSendableClass.instanceMethod!foreign : (ObjCNonSendableClass) -> () -> ObjCNonSendableClass, $@convention(objc_method) (ObjCNonSendableClass) -> @autoreleased ObjCNonSendableClass // user: %3
+// CHECK-NEXT: require %%0:   %1 = objc_super_method %0 : $ObjCDerivedClass, #ObjCNonSendableClass.instanceMethod!foreign : (ObjCNonSendableClass) -> () -> ObjCNonSendableClass, $@convention(objc_method) (ObjCNonSendableClass) -> @autoreleased ObjCNonSendableClass // user: %3
+// CHECK-NEXT: assign_direct %%1 = %%0:   %1 = objc_super_method %0 : $ObjCDerivedClass, #ObjCNonSendableClass.instanceMethod!foreign : (ObjCNonSendableClass) -> () -> ObjCNonSendableClass, $@convention(objc_method) (ObjCNonSendableClass) -> @autoreleased ObjCNonSendableClass // user: %3
+// CHECK-NEXT: end running test 1 of 1 on test_objc_super_method: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_objc_super_method : $@convention(thin) (@guaranteed ObjCDerivedClass) -> () {
+bb0(%0 : @guaranteed $ObjCDerivedClass):
+  %method = objc_super_method %0 : $ObjCDerivedClass, #ObjCNonSendableClass.instanceMethod!foreign : (ObjCNonSendableClass) -> () -> ObjCNonSendableClass, $@convention(objc_method) (ObjCNonSendableClass) -> @autoreleased ObjCNonSendableClass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %upcast = upcast %0 : $ObjCDerivedClass to $ObjCNonSendableClass
+  %result = apply %method(%upcast) : $@convention(objc_method) (ObjCNonSendableClass) -> @autoreleased ObjCNonSendableClass
+  destroy_value %result : $ObjCNonSendableClass
+  %r = tuple ()
+  return %r : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Swift Super Method Dispatch
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_super_method: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $ObjCDerivedClass          // users: %2, %1
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = super_method %0 : $ObjCDerivedClass, #ObjCNonSendableClass.method : (ObjCNonSendableClass) -> () -> (), $@convention(method) (@guaranteed ObjCNonSendableClass) -> () // user: %3
+// CHECK-NEXT: require %%0:   %1 = super_method %0 : $ObjCDerivedClass, #ObjCNonSendableClass.method : (ObjCNonSendableClass) -> () -> (), $@convention(method) (@guaranteed ObjCNonSendableClass) -> () // user: %3
+// CHECK-NEXT: assign_direct %%1 = %%0:   %1 = super_method %0 : $ObjCDerivedClass, #ObjCNonSendableClass.method : (ObjCNonSendableClass) -> () -> (), $@convention(method) (@guaranteed ObjCNonSendableClass) -> () // user: %3
+// CHECK-NEXT: end running test 1 of 1 on test_super_method: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_super_method : $@convention(thin) (@guaranteed ObjCDerivedClass) -> () {
+bb0(%0 : @guaranteed $ObjCDerivedClass):
+  %method = super_method %0 : $ObjCDerivedClass, #ObjCNonSendableClass.method : (ObjCNonSendableClass) -> () -> (), $@convention(method) (@guaranteed ObjCNonSendableClass) -> ()
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %upcast = upcast %0 : $ObjCDerivedClass to $ObjCNonSendableClass
+  %result = apply %method(%upcast) : $@convention(method) (@guaranteed ObjCNonSendableClass) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: ObjC Metatype Conversions
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test {{.*}} on test_thick_to_objc_metatype: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $@thick ObjCNonSendableClass.Type // user: %1
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = thick_to_objc_metatype %0 : $@thick ObjCNonSendableClass.Type to $@objc_metatype ObjCNonSendableClass.Type
+// CHECK-NEXT: end running test 1 of 1 on test_thick_to_objc_metatype: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_thick_to_objc_metatype : $@convention(thin) (@thick ObjCNonSendableClass.Type) -> () {
+bb0(%0 : $@thick ObjCNonSendableClass.Type):
+  %objc_meta = thick_to_objc_metatype %0 : $@thick ObjCNonSendableClass.Type to $@objc_metatype ObjCNonSendableClass.Type
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_objc_to_thick_metatype: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $@objc_metatype ObjCNonSendableClass.Type // user: %1
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = objc_to_thick_metatype %0 : $@objc_metatype ObjCNonSendableClass.Type to $@thick ObjCNonSendableClass.Type
+// CHECK-NEXT: end running test 1 of 1 on test_objc_to_thick_metatype: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_objc_to_thick_metatype : $@convention(thin) (@objc_metatype ObjCNonSendableClass.Type) -> () {
+bb0(%0 : $@objc_metatype ObjCNonSendableClass.Type):
+  %thick_meta = objc_to_thick_metatype %0 : $@objc_metatype ObjCNonSendableClass.Type to $@thick ObjCNonSendableClass.Type
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+// Need a declaration for super_method test
+sil [ossa] @$s4main16ObjCNonSendableClassC6methodyyF : $@convention(method) (@guaranteed ObjCNonSendableClass) -> ()

--- a/test/SILOptimizer/specialize_ossa.sil
+++ b/test/SILOptimizer/specialize_ossa.sil
@@ -1712,10 +1712,3 @@ bb0(%0 : @guaranteed $String):
   %13 = tuple ()
   return %13
 }
-
-
-
-
-
-
-

--- a/unittests/SILOptimizer/PartitionUtilsTest.cpp
+++ b/unittests/SILOptimizer/PartitionUtilsTest.cpp
@@ -286,24 +286,24 @@ TEST(PartitionUtilsTest, Join1) {
 
   {
     MockedPartitionOpEvaluator eval(p1, factory, transferringOpToStateMap);
-    eval.apply({PartitionOp::Assign(Element(0), Element(0)),
-                PartitionOp::Assign(Element(1), Element(0)),
-                PartitionOp::Assign(Element(2), Element(2)),
-                PartitionOp::Assign(Element(3), Element(3)),
-                PartitionOp::Assign(Element(4), Element(3)),
-                PartitionOp::Assign(Element(5), Element(2))});
+    eval.apply({PartitionOp::AssignDirect(Element(0), Element(0)),
+                PartitionOp::AssignDirect(Element(1), Element(0)),
+                PartitionOp::AssignDirect(Element(2), Element(2)),
+                PartitionOp::AssignDirect(Element(3), Element(3)),
+                PartitionOp::AssignDirect(Element(4), Element(3)),
+                PartitionOp::AssignDirect(Element(5), Element(2))});
   }
 
   Partition p2 = Partition::separateRegions(fakeLoc, llvm::ArrayRef(data1),
                                             historyFactory.get());
   {
     MockedPartitionOpEvaluator eval(p2, factory, transferringOpToStateMap);
-    eval.apply({PartitionOp::Assign(Element(0), Element(0)),
-                PartitionOp::Assign(Element(1), Element(0)),
-                PartitionOp::Assign(Element(2), Element(2)),
-                PartitionOp::Assign(Element(3), Element(3)),
-                PartitionOp::Assign(Element(4), Element(3)),
-                PartitionOp::Assign(Element(5), Element(5))});
+    eval.apply({PartitionOp::AssignDirect(Element(0), Element(0)),
+                PartitionOp::AssignDirect(Element(1), Element(0)),
+                PartitionOp::AssignDirect(Element(2), Element(2)),
+                PartitionOp::AssignDirect(Element(3), Element(3)),
+                PartitionOp::AssignDirect(Element(4), Element(3)),
+                PartitionOp::AssignDirect(Element(5), Element(5))});
   }
 
   auto result = Partition::join(p1, p2);
@@ -329,12 +329,12 @@ TEST(PartitionUtilsTest, Join2) {
 
   {
     MockedPartitionOpEvaluator eval(p1, factory, transferringOpToStateMap);
-    eval.apply({PartitionOp::Assign(Element(0), Element(0)),
-                PartitionOp::Assign(Element(1), Element(0)),
-                PartitionOp::Assign(Element(2), Element(2)),
-                PartitionOp::Assign(Element(3), Element(3)),
-                PartitionOp::Assign(Element(4), Element(3)),
-                PartitionOp::Assign(Element(5), Element(2))});
+    eval.apply({PartitionOp::AssignDirect(Element(0), Element(0)),
+                PartitionOp::AssignDirect(Element(1), Element(0)),
+                PartitionOp::AssignDirect(Element(2), Element(2)),
+                PartitionOp::AssignDirect(Element(3), Element(3)),
+                PartitionOp::AssignDirect(Element(4), Element(3)),
+                PartitionOp::AssignDirect(Element(5), Element(2))});
   }
 
   Element data2[] = {Element(4), Element(5), Element(6),
@@ -343,12 +343,12 @@ TEST(PartitionUtilsTest, Join2) {
                                             historyFactory.get());
   {
     MockedPartitionOpEvaluator eval(p2, factory, transferringOpToStateMap);
-    eval.apply({PartitionOp::Assign(Element(4), Element(4)),
-                PartitionOp::Assign(Element(5), Element(5)),
-                PartitionOp::Assign(Element(6), Element(4)),
-                PartitionOp::Assign(Element(7), Element(7)),
-                PartitionOp::Assign(Element(8), Element(7)),
-                PartitionOp::Assign(Element(9), Element(4))});
+    eval.apply({PartitionOp::AssignDirect(Element(4), Element(4)),
+                PartitionOp::AssignDirect(Element(5), Element(5)),
+                PartitionOp::AssignDirect(Element(6), Element(4)),
+                PartitionOp::AssignDirect(Element(7), Element(7)),
+                PartitionOp::AssignDirect(Element(8), Element(7)),
+                PartitionOp::AssignDirect(Element(9), Element(4))});
   }
 
   auto result = Partition::join(p1, p2);
@@ -378,12 +378,12 @@ TEST(PartitionUtilsTest, Join2Reversed) {
 
   {
     MockedPartitionOpEvaluator eval(p1, factory, transferringOpToStateMap);
-    eval.apply({PartitionOp::Assign(Element(0), Element(0)),
-                PartitionOp::Assign(Element(1), Element(0)),
-                PartitionOp::Assign(Element(2), Element(2)),
-                PartitionOp::Assign(Element(3), Element(3)),
-                PartitionOp::Assign(Element(4), Element(3)),
-                PartitionOp::Assign(Element(5), Element(2))});
+    eval.apply({PartitionOp::AssignDirect(Element(0), Element(0)),
+                PartitionOp::AssignDirect(Element(1), Element(0)),
+                PartitionOp::AssignDirect(Element(2), Element(2)),
+                PartitionOp::AssignDirect(Element(3), Element(3)),
+                PartitionOp::AssignDirect(Element(4), Element(3)),
+                PartitionOp::AssignDirect(Element(5), Element(2))});
   }
 
   Element data2[] = {Element(4), Element(5), Element(6),
@@ -392,12 +392,12 @@ TEST(PartitionUtilsTest, Join2Reversed) {
                                             historyFactory.get());
   {
     MockedPartitionOpEvaluator eval(p2, factory, transferringOpToStateMap);
-    eval.apply({PartitionOp::Assign(Element(4), Element(4)),
-                PartitionOp::Assign(Element(5), Element(5)),
-                PartitionOp::Assign(Element(6), Element(4)),
-                PartitionOp::Assign(Element(7), Element(7)),
-                PartitionOp::Assign(Element(8), Element(7)),
-                PartitionOp::Assign(Element(9), Element(4))});
+    eval.apply({PartitionOp::AssignDirect(Element(4), Element(4)),
+                PartitionOp::AssignDirect(Element(5), Element(5)),
+                PartitionOp::AssignDirect(Element(6), Element(4)),
+                PartitionOp::AssignDirect(Element(7), Element(7)),
+                PartitionOp::AssignDirect(Element(8), Element(7)),
+                PartitionOp::AssignDirect(Element(9), Element(4))});
   }
 
   auto result = Partition::join(p2, p1);
@@ -431,36 +431,36 @@ TEST(PartitionUtilsTest, JoinLarge) {
                                             historyFactory.get());
   {
     MockedPartitionOpEvaluator eval(p1, factory, transferringOpToStateMap);
-    eval.apply({PartitionOp::Assign(Element(0), Element(29)),
-                PartitionOp::Assign(Element(1), Element(17)),
-                PartitionOp::Assign(Element(2), Element(0)),
-                PartitionOp::Assign(Element(3), Element(12)),
-                PartitionOp::Assign(Element(4), Element(13)),
-                PartitionOp::Assign(Element(5), Element(9)),
-                PartitionOp::Assign(Element(6), Element(15)),
-                PartitionOp::Assign(Element(7), Element(27)),
-                PartitionOp::Assign(Element(8), Element(3)),
-                PartitionOp::Assign(Element(9), Element(3)),
-                PartitionOp::Assign(Element(10), Element(3)),
-                PartitionOp::Assign(Element(11), Element(21)),
-                PartitionOp::Assign(Element(12), Element(14)),
-                PartitionOp::Assign(Element(13), Element(25)),
-                PartitionOp::Assign(Element(14), Element(1)),
-                PartitionOp::Assign(Element(15), Element(25)),
-                PartitionOp::Assign(Element(16), Element(12)),
-                PartitionOp::Assign(Element(17), Element(3)),
-                PartitionOp::Assign(Element(18), Element(25)),
-                PartitionOp::Assign(Element(19), Element(13)),
-                PartitionOp::Assign(Element(20), Element(19)),
-                PartitionOp::Assign(Element(21), Element(7)),
-                PartitionOp::Assign(Element(22), Element(19)),
-                PartitionOp::Assign(Element(23), Element(27)),
-                PartitionOp::Assign(Element(24), Element(1)),
-                PartitionOp::Assign(Element(25), Element(9)),
-                PartitionOp::Assign(Element(26), Element(18)),
-                PartitionOp::Assign(Element(27), Element(29)),
-                PartitionOp::Assign(Element(28), Element(28)),
-                PartitionOp::Assign(Element(29), Element(13))});
+    eval.apply({PartitionOp::AssignDirect(Element(0), Element(29)),
+                PartitionOp::AssignDirect(Element(1), Element(17)),
+                PartitionOp::AssignDirect(Element(2), Element(0)),
+                PartitionOp::AssignDirect(Element(3), Element(12)),
+                PartitionOp::AssignDirect(Element(4), Element(13)),
+                PartitionOp::AssignDirect(Element(5), Element(9)),
+                PartitionOp::AssignDirect(Element(6), Element(15)),
+                PartitionOp::AssignDirect(Element(7), Element(27)),
+                PartitionOp::AssignDirect(Element(8), Element(3)),
+                PartitionOp::AssignDirect(Element(9), Element(3)),
+                PartitionOp::AssignDirect(Element(10), Element(3)),
+                PartitionOp::AssignDirect(Element(11), Element(21)),
+                PartitionOp::AssignDirect(Element(12), Element(14)),
+                PartitionOp::AssignDirect(Element(13), Element(25)),
+                PartitionOp::AssignDirect(Element(14), Element(1)),
+                PartitionOp::AssignDirect(Element(15), Element(25)),
+                PartitionOp::AssignDirect(Element(16), Element(12)),
+                PartitionOp::AssignDirect(Element(17), Element(3)),
+                PartitionOp::AssignDirect(Element(18), Element(25)),
+                PartitionOp::AssignDirect(Element(19), Element(13)),
+                PartitionOp::AssignDirect(Element(20), Element(19)),
+                PartitionOp::AssignDirect(Element(21), Element(7)),
+                PartitionOp::AssignDirect(Element(22), Element(19)),
+                PartitionOp::AssignDirect(Element(23), Element(27)),
+                PartitionOp::AssignDirect(Element(24), Element(1)),
+                PartitionOp::AssignDirect(Element(25), Element(9)),
+                PartitionOp::AssignDirect(Element(26), Element(18)),
+                PartitionOp::AssignDirect(Element(27), Element(29)),
+                PartitionOp::AssignDirect(Element(28), Element(28)),
+                PartitionOp::AssignDirect(Element(29), Element(13))});
   }
 
   Element data2[] = {
@@ -474,35 +474,35 @@ TEST(PartitionUtilsTest, JoinLarge) {
                                             historyFactory.get());
   {
     MockedPartitionOpEvaluator eval(p2, factory, transferringOpToStateMap);
-    eval.apply({PartitionOp::Assign(Element(15), Element(31)),
-                PartitionOp::Assign(Element(16), Element(34)),
-                PartitionOp::Assign(Element(17), Element(35)),
-                PartitionOp::Assign(Element(18), Element(41)),
-                PartitionOp::Assign(Element(19), Element(15)),
-                PartitionOp::Assign(Element(20), Element(32)),
-                PartitionOp::Assign(Element(21), Element(17)),
-                PartitionOp::Assign(Element(22), Element(31)),
-                PartitionOp::Assign(Element(23), Element(21)),
-                PartitionOp::Assign(Element(24), Element(33)),
-                PartitionOp::Assign(Element(25), Element(25)),
-                PartitionOp::Assign(Element(26), Element(31)),
-                PartitionOp::Assign(Element(27), Element(16)),
-                PartitionOp::Assign(Element(28), Element(35)),
-                PartitionOp::Assign(Element(29), Element(40)),
-                PartitionOp::Assign(Element(30), Element(33)),
-                PartitionOp::Assign(Element(31), Element(34)),
-                PartitionOp::Assign(Element(32), Element(22)),
-                PartitionOp::Assign(Element(33), Element(42)),
-                PartitionOp::Assign(Element(34), Element(37)),
-                PartitionOp::Assign(Element(35), Element(34)),
-                PartitionOp::Assign(Element(36), Element(18)),
-                PartitionOp::Assign(Element(37), Element(32)),
-                PartitionOp::Assign(Element(38), Element(22)),
-                PartitionOp::Assign(Element(39), Element(44)),
-                PartitionOp::Assign(Element(40), Element(20)),
-                PartitionOp::Assign(Element(41), Element(37)),
-                PartitionOp::Assign(Element(43), Element(29)),
-                PartitionOp::Assign(Element(44), Element(25))});
+    eval.apply({PartitionOp::AssignDirect(Element(15), Element(31)),
+                PartitionOp::AssignDirect(Element(16), Element(34)),
+                PartitionOp::AssignDirect(Element(17), Element(35)),
+                PartitionOp::AssignDirect(Element(18), Element(41)),
+                PartitionOp::AssignDirect(Element(19), Element(15)),
+                PartitionOp::AssignDirect(Element(20), Element(32)),
+                PartitionOp::AssignDirect(Element(21), Element(17)),
+                PartitionOp::AssignDirect(Element(22), Element(31)),
+                PartitionOp::AssignDirect(Element(23), Element(21)),
+                PartitionOp::AssignDirect(Element(24), Element(33)),
+                PartitionOp::AssignDirect(Element(25), Element(25)),
+                PartitionOp::AssignDirect(Element(26), Element(31)),
+                PartitionOp::AssignDirect(Element(27), Element(16)),
+                PartitionOp::AssignDirect(Element(28), Element(35)),
+                PartitionOp::AssignDirect(Element(29), Element(40)),
+                PartitionOp::AssignDirect(Element(30), Element(33)),
+                PartitionOp::AssignDirect(Element(31), Element(34)),
+                PartitionOp::AssignDirect(Element(32), Element(22)),
+                PartitionOp::AssignDirect(Element(33), Element(42)),
+                PartitionOp::AssignDirect(Element(34), Element(37)),
+                PartitionOp::AssignDirect(Element(35), Element(34)),
+                PartitionOp::AssignDirect(Element(36), Element(18)),
+                PartitionOp::AssignDirect(Element(37), Element(32)),
+                PartitionOp::AssignDirect(Element(38), Element(22)),
+                PartitionOp::AssignDirect(Element(39), Element(44)),
+                PartitionOp::AssignDirect(Element(40), Element(20)),
+                PartitionOp::AssignDirect(Element(41), Element(37)),
+                PartitionOp::AssignDirect(Element(43), Element(29)),
+                PartitionOp::AssignDirect(Element(44), Element(25))});
   }
 
   auto result = Partition::join(p1, p2);
@@ -591,9 +591,9 @@ TEST(PartitionUtilsTest, TestAssign) {
   EXPECT_TRUE(Partition::equals(p2, p3));
   EXPECT_TRUE(Partition::equals(p1, p3));
 
-  evalP1.apply(PartitionOp::Assign(Element(0), Element(1)));
-  evalP2.apply(PartitionOp::Assign(Element(1), Element(0)));
-  evalP3.apply(PartitionOp::Assign(Element(2), Element(1)));
+  evalP1.apply(PartitionOp::AssignDirect(Element(0), Element(1)));
+  evalP2.apply(PartitionOp::AssignDirect(Element(1), Element(0)));
+  evalP3.apply(PartitionOp::AssignDirect(Element(2), Element(1)));
 
   // expected: p1: ((0 1) (Element(2)) (Element(3))), p2: ((0 1) (Element(2))
   // (Element(3))), p3: ((Element(0)) (1 2) (Element(3)))
@@ -602,9 +602,9 @@ TEST(PartitionUtilsTest, TestAssign) {
   EXPECT_FALSE(Partition::equals(p2, p3));
   EXPECT_FALSE(Partition::equals(p1, p3));
 
-  evalP1.apply(PartitionOp::Assign(Element(2), Element(0)));
-  evalP2.apply(PartitionOp::Assign(Element(2), Element(1)));
-  evalP3.apply(PartitionOp::Assign(Element(0), Element(2)));
+  evalP1.apply(PartitionOp::AssignDirect(Element(2), Element(0)));
+  evalP2.apply(PartitionOp::AssignDirect(Element(2), Element(1)));
+  evalP3.apply(PartitionOp::AssignDirect(Element(0), Element(2)));
 
   // expected: p1: ((0 1 2) (Element(3))), p2: ((0 1 2) (Element(3))), p3: ((0 1
   // 2) (Element(3)))
@@ -613,9 +613,9 @@ TEST(PartitionUtilsTest, TestAssign) {
   EXPECT_TRUE(Partition::equals(p2, p3));
   EXPECT_TRUE(Partition::equals(p1, p3));
 
-  evalP1.apply(PartitionOp::Assign(Element(0), Element(3)));
-  evalP2.apply(PartitionOp::Assign(Element(1), Element(3)));
-  evalP3.apply(PartitionOp::Assign(Element(2), Element(3)));
+  evalP1.apply(PartitionOp::AssignDirect(Element(0), Element(3)));
+  evalP2.apply(PartitionOp::AssignDirect(Element(1), Element(3)));
+  evalP3.apply(PartitionOp::AssignDirect(Element(2), Element(3)));
 
   // expected: p1: ((1 2) (0 3)), p2: ((0 2) (1 3)), p3: ((0 1) (2 3))
 
@@ -623,9 +623,9 @@ TEST(PartitionUtilsTest, TestAssign) {
   EXPECT_FALSE(Partition::equals(p2, p3));
   EXPECT_FALSE(Partition::equals(p1, p3));
 
-  evalP1.apply(PartitionOp::Assign(Element(1), Element(0)));
-  evalP2.apply(PartitionOp::Assign(Element(2), Element(1)));
-  evalP3.apply(PartitionOp::Assign(Element(0), Element(2)));
+  evalP1.apply(PartitionOp::AssignDirect(Element(1), Element(0)));
+  evalP2.apply(PartitionOp::AssignDirect(Element(2), Element(1)));
+  evalP3.apply(PartitionOp::AssignDirect(Element(0), Element(2)));
 
   // expected: p1: ((Element(2)) (0 1 3)), p2: ((Element(0)) (1 2 3)), p3:
   // ((Element(1)) (0 2 3))
@@ -634,9 +634,9 @@ TEST(PartitionUtilsTest, TestAssign) {
   EXPECT_FALSE(Partition::equals(p2, p3));
   EXPECT_FALSE(Partition::equals(p1, p3));
 
-  evalP1.apply(PartitionOp::Assign(Element(2), Element(3)));
-  evalP2.apply(PartitionOp::Assign(Element(0), Element(3)));
-  evalP3.apply(PartitionOp::Assign(Element(1), Element(3)));
+  evalP1.apply(PartitionOp::AssignDirect(Element(2), Element(3)));
+  evalP2.apply(PartitionOp::AssignDirect(Element(0), Element(3)));
+  evalP3.apply(PartitionOp::AssignDirect(Element(1), Element(3)));
 
   // expected: p1: ((0 1 2 3)), p2: ((0 1 2 3)), p3: ((0 1 2 3))
 
@@ -669,14 +669,14 @@ TEST(PartitionUtilsTest, TestConsumeAndRequire) {
                 PartitionOp::AssignFresh(Element(10)),
                 PartitionOp::AssignFresh(Element(11)),
 
-                PartitionOp::Assign(Element(1), Element(0)),
-                PartitionOp::Assign(Element(2), Element(1)),
+                PartitionOp::AssignDirect(Element(1), Element(0)),
+                PartitionOp::AssignDirect(Element(2), Element(1)),
 
-                PartitionOp::Assign(Element(4), Element(3)),
-                PartitionOp::Assign(Element(5), Element(4)),
+                PartitionOp::AssignDirect(Element(4), Element(3)),
+                PartitionOp::AssignDirect(Element(5), Element(4)),
 
-                PartitionOp::Assign(Element(7), Element(6)),
-                PartitionOp::Assign(Element(9), Element(8)),
+                PartitionOp::AssignDirect(Element(7), Element(6)),
+                PartitionOp::AssignDirect(Element(9), Element(8)),
 
                 // expected: p: ((0 1 2) (3 4 5) (6 7) (8 9) (Element(10))
                 // (Element(11)))
@@ -827,7 +827,7 @@ TEST(PartitionUtilsTest, TestLastEltInTransferredRegion) {
                 PartitionOp::AssignFresh(Element(1)),
                 PartitionOp::AssignFresh(Element(2)),
                 PartitionOp::Send(Element(0), operandSingletons[0]),
-                PartitionOp::Assign(Element(0), Element(2))});
+                PartitionOp::AssignDirect(Element(0), Element(2))});
   }
   p2.validateRegionToSendingOpMapRegions();
 }
@@ -880,13 +880,13 @@ TEST(PartitionUtilsTest, TestHistory_AssignRegion) {
 
   {
     MockedPartitionOpEvaluator eval(p, factory, transferringOpToStateMap);
-    eval.apply({PartitionOp::Assign(Element(1), Element(2))});
+    eval.apply({PartitionOp::AssignDirect(Element(1), Element(2))});
   }
 
   Partition pSnapshot2 = p;
   {
     MockedPartitionOpEvaluator eval(p, factory, transferringOpToStateMap);
-    eval.apply({PartitionOp::Assign(Element(0), Element(2))});
+    eval.apply({PartitionOp::AssignDirect(Element(0), Element(2))});
   }
 
   p.popHistory(joinedHistories);
@@ -914,8 +914,8 @@ TEST(PartitionUtilsTest, TestHistory_BuildNewRegionRepIsMergee) {
                 PartitionOp::AssignFresh(Element(3)),
                 PartitionOp::AssignFresh(Element(10)),
                 PartitionOp::AssignFresh(Element(0)),
-                PartitionOp::Assign(Element(3), Element(2)),
-                PartitionOp::Assign(Element(10), Element(2)),
+                PartitionOp::AssignDirect(Element(3), Element(2)),
+                PartitionOp::AssignDirect(Element(10), Element(2)),
                 PartitionOp::Merge(Element(2), Element(0))});
   }
 
@@ -923,13 +923,13 @@ TEST(PartitionUtilsTest, TestHistory_BuildNewRegionRepIsMergee) {
 
   {
     MockedPartitionOpEvaluator eval(p, factory, transferringOpToStateMap);
-    eval.apply({PartitionOp::Assign(Element(1), Element(2))});
+    eval.apply({PartitionOp::AssignDirect(Element(1), Element(2))});
   }
 
   Partition pSnapshot2 = p;
   {
     MockedPartitionOpEvaluator eval(p, factory, transferringOpToStateMap);
-    eval.apply({PartitionOp::Assign(Element(0), Element(2))});
+    eval.apply({PartitionOp::AssignDirect(Element(0), Element(2))});
   }
 
   // Even though we pushed a new instruction, nothing changed in our region.


### PR DESCRIPTION
Today in RBI, we associate the value in memory with the memory itself. This is useful for processing but when we assign into the memory this causes a bug. When we assigned into memory, we will in certain situations remove the memory from the original region to the region associated with the new value. This causes us to lose that the value that was originally in the memory is still in the old region.

This is a bit of predatory work that I did for that that I could split off into a separate commit (especially since I had to time box a little so I need to do something else today so it made since to land it.

Some highlights:

**1. Testing Infrastructure** (commit 82c6cf1e5fb)
- Added new `sil_regionanalysis_partitionoptranslation` test to directly verify SIL→PartitionOp translation
- Added extensive test files: `transfernonsendable_partitionop_translation.sil` and `transfernonsendable_partitionop_translation_objc.sil`.
- We have never had this type of testing before and it probably would have caught a bunch of bugs. Before I make the big change of splitting Assign into AssignDirect/AssignIndirect, I wanted this in place so I could catch bugs. I am going to be extending this over time.

**2. TrackableValue API Transition** (commits 5fac5702dad, 910546e0b7b, 6425c18f9c8, 69e9efb6937)
- Refactored `translateSILMultiAssign` and related APIs to work with `TrackableValue` instead of `SILValue`
- Renamed variables for clarity (`assignOperands` → `sourceOperandTVPairs`, `assignResults` → `directResultTVs`)
- Updated `addActorIntroducingInst` and `addAssignFresh` to take `TrackableValue` parameters
- Eliminated unnecessary SILValue-to-TrackableValue conversions ("boomeranging")

**3. Assignment Operation Split** (commit d809d6fd986)
- Split `PartitionOpKind::Assign` into two distinct operations:
  - `AssignDirect`: For new SSA values (objects or freshly-produced addresses)
  - `AssignIndirect`: For storing to memory locations created by different instructions
- `AssignIndirect` now tracks three arguments: destination, source, and the overwritten value
- This distinction preserves isolation information when values in memory are overwritten
- Nothing uses AssignIndirect yet, so we are still preserving the current output.

**4. Overwritten Memory Tracking** (commit d809d6fd986)
- Extended `RepresentativeValue` to support three value kinds: `SILValue`, `SILInstruction*` (actor-introducing), and `Operand*` (overwritten memory). I also used this as an opportunity to improve the comments in this part of the code.
- Added `getRepresentativeValueForValueFromOverwrittenMemory()` to create trackable values for memory contents before assignment
- This ensures actor/task isolation is preserved when memory locations are reassigned
- Again, nothing is using the Operand * form now. This is just in preparation for the later change.