### PR TITLE
Require a host swift host compiler for building the compiler

### DIFF
--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -39,6 +39,10 @@
 #include "llvm/Support/Casting.h"
 #include <fstream>
 
+#ifndef SWIFT_ENABLE_SWIFT_IN_SWIFT
+#error "Building the compiler without Swift sources is not supported anymore"
+#endif
+
 using namespace swift;
 
 llvm::cl::opt<bool> SILPrintAll(


### PR DESCRIPTION
This is the first step to remove the ability for bootstrapping (without a swift host compiler). This change is intended to find any problems in CI before we really drop the support for bootstrapping.
