### PR TITLE
[update-checkout] account for non-zero exit codes in git configuration checks

### DIFF
--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -413,11 +413,12 @@ def _check_git_config(
             continue
 
         for config_key, expected_value in git_configs.items():
-            output = subprocess.check_output(
+            output = subprocess.run(
                 ["git", "-C", str(repo_path), "config", "--get", config_key],
                 text=True,
+                stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL,
-            )
+            ).stdout
             if expected_value not in output:
                 print(
                     f"[WARNING] '{repo}' was not cloned with "


### PR DESCRIPTION
`check_output` will throw if the call to `git -C <repo_path> config --get <config_key>` returns non-zero

However we don't want to throw, we just want to check the stdout for a value if it exists. 

Right now update-checkout is exploding due to this check