### PR TITLE
[ImportDecl] Replace `@Sendable` with synthesized protocol attribute …

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -9191,7 +9191,9 @@ ClangImporter::Implementation::importSwiftAttrAttributes(Decl *MappedDecl) {
   // can see if we should synthesize a Sendable conformance.
   if (auto nominal = dyn_cast<NominalTypeDecl>(MappedDecl)) {
     auto sendability = nominal->getAttrs().getEffectiveSendableAttr();
-    if (isa_and_nonnull<SendableAttr>(sendability)) {
+    if (auto *sendable = dyn_cast_or_null<SendableAttr>(sendability)) {
+      // Remove the original `Sendable` attribute we are about to replace.
+      nominal->getAttrs().removeAttribute(sendable);
       addSynthesizedProtocolAttrs(nominal, {KnownProtocolKind::Sendable},
                                   /*isUnchecked=*/true);
     }

--- a/test/Interop/Cxx/class/Inputs/sendable.h
+++ b/test/Interop/Cxx/class/Inputs/sendable.h
@@ -37,3 +37,9 @@ struct DerivedPrivatelyFromHasPrivatePointerField : private HasPrivatePointerFie
 struct DerivedProtectedFromHasPublicPointerField : protected HasPublicPointerField {};
 struct DerivedProtectedFromHasPublicNonSendableField : protected HasPublicNonSendableField {};
 struct DerivedProtectedFromHasPrivatePointerField : protected HasPrivatePointerField {};
+
+class SendableKlass final {
+public:
+  void test() const {
+  }
+} __attribute__((swift_attr("~Copyable"))) __attribute__((swift_attr("@Sendable")));

--- a/test/Interop/Cxx/class/sendable-typechecker.swift
+++ b/test/Interop/Cxx/class/sendable-typechecker.swift
@@ -3,6 +3,8 @@
 import Sendable // expected-warning {{add '@preconcurrency' to treat 'Sendable'-related errors from module 'Sendable' as warnings}}
 
 func takesSendable<T: Sendable>(_ x: T.Type) {}
+func takesSendable<T>(_: T.Type) where T: Sendable, T: ~Copyable {}
+func takesSendable(_: @Sendable () -> Void) {}
 
 takesSendable(HasPrivatePointerField.self) // expected-error {{type 'HasPrivatePointerField' does not conform to the 'Sendable' protocol}}
 takesSendable(HasProtectedPointerField.self) // expected-error {{type 'HasProtectedPointerField' does not conform to the 'Sendable' protocol}}
@@ -23,3 +25,8 @@ takesSendable(DerivedPrivatelyFromHasPrivatePointerField.self) // expected-error
 takesSendable(DerivedProtectedFromHasPublicPointerField.self) // expected-error {{type 'DerivedProtectedFromHasPublicPointerField' does not conform to the 'Sendable' protocol}}
 takesSendable(DerivedProtectedFromHasPublicNonSendableField.self) // expected-error {{type 'DerivedProtectedFromHasPublicNonSendableField' does not conform to the 'Sendable' protocol}}
 takesSendable(DerivedProtectedFromHasPrivatePointerField.self) // expected-error {{type 'DerivedProtectedFromHasPrivatePointerField' does not conform to the 'Sendable' protocol}}
+
+func checkSendableRef(k: borrowing SendableKlass) {
+  takesSendable(SendableKlass.self) // Ok
+  takesSendable(k.test) // Ok
+}


### PR DESCRIPTION
…on a type

Currently the importer simply adds new "synthesized protocol" attribute for `Sendable` which is problematic during type-checking because the new attribute is supposed to replace `@Sendable` and properly synthesize the conformance.

Resolves: rdar://158224838

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
