### PR TITLE
windows: always let cmake know the swift host compiler

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2137,7 +2137,7 @@ function Build-BuildTools([Hashtable] $Platform) {
     -Bin (Get-ProjectBinaryCache $Platform BuildTools) `
     -Platform $Platform `
     -UseMSVCCompilers $(if ($UseHostToolchain) { @("ASM_MASM", "C", "CXX") } else { @("") }) `
-    -UsePinnedCompilers $(if ($UseHostToolchain) { @("") } else { @("ASM", "C", "CXX") }) `
+    -UsePinnedCompilers $(if ($UseHostToolchain) { @("") } else { @("ASM", "C", "CXX", "Swift") }) `
     -BuildTargets llvm-tblgen,clang-tblgen,clang-tidy-confusable-chars-gen,lldb-tblgen,llvm-config,swift-def-to-strings-converter,swift-serialize-diagnostics,swift-compatibility-symbols `
     -Defines @{
       CMAKE_CROSSCOMPILING = "NO";


### PR DESCRIPTION
So that we can require this in the main cmake file

This is needed for https://github.com/swiftlang/swift/pull/86711