### PR TITLE
ASTPrinter: skip printing incompatible attributes in swiftinterface

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1475,6 +1475,12 @@ void PrintAST::printAttributes(const Decl *D) {
     }
   }
 
+  // Attributes that are not permitted to appear should not be printed
+  for (auto *attr : attrs) {
+    if (!attr->canAppearOnDecl(D))
+      scope.Options.ExcludeAttrList.push_back(attr->getKind());
+  }
+
   attrs.print(Printer, Options, D);
 }
 

--- a/test/Concurrency/deinit_isolation_import/test.swift
+++ b/test/Concurrency/deinit_isolation_import/test.swift
@@ -259,7 +259,7 @@ class ProbeDefault_BaseIsolatedClass: BaseIsolatedClass {
 }
 
 // CHECK-LABEL: @objc @_inheritsConvenienceInitializers @MainActor @preconcurrency class ProbeIsolated_BaseIsolatedClass : BaseIsolatedClass {
-// CHECK: @objc @preconcurrency isolated deinit
+// CHECK: @objc isolated deinit
 // CHECK: }
 // CHECK-SYMB: ProbeIsolated_BaseIsolatedClass.__isolated_deallocating_deinit
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: MainActor
@@ -319,7 +319,7 @@ class ProbeDefault_DerivedIsolatedClass: DerivedIsolatedClass {
 }
 
 // CHECK-LABEL: @objc @_inheritsConvenienceInitializers @MainActor @preconcurrency class ProbeIsolated_DerivedIsolatedClass : DerivedIsolatedClass {
-// CHECK: @objc @preconcurrency isolated deinit
+// CHECK: @objc isolated deinit
 // CHECK: }
 // CHECK-SYMB: ProbeIsolated_DerivedIsolatedClass.__isolated_deallocating_deinit
 // CHECK-SYMB-NEXT: // Isolation: global_actor. type: MainActor

--- a/test/ModuleInterface/preconcurrency-deinit.swift
+++ b/test/ModuleInterface/preconcurrency-deinit.swift
@@ -1,0 +1,30 @@
+// REQUIRES: objc_interop
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -module-name SwiftLibrary %t/SwiftLibrary.swift -emit-module -emit-module-interface-path %t/SwiftLibrary.swiftinterface -swift-version 6 -I %t/ObjCLibrary -experimental-allow-module-with-compiler-errors
+// Added experimental-allow-module-with-compiler-errors flag to avoid crashes on the assert in serialization
+// RUN: %FileCheck %s < %t/SwiftLibrary.swiftinterface
+
+//--- SwiftLibrary.swift
+import ObjCLibrary
+
+// CHECK: {{^ @objc isolated deinit$}}
+public class SwiftSubclass: ObjCBaseClass {
+    isolated deinit {}
+}
+
+//--- ObjCLibrary/module.modulemap
+module ObjCLibrary {
+  header "ObjCBaseClass.h"
+  export *
+}
+
+//--- ObjCLibrary/ObjCBaseClass.h
+
+#import <Foundation/Foundation.h>
+
+__attribute__((__swift_attr__("@MainActor")))
+@interface ObjCBaseClass : NSObject
+@end


### PR DESCRIPTION
Attributes that are not allowed to appear on declaration should not be printed in textual interface.

Resolves issue #85564 and rdar://164975727

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
