### PR TITLE
[stdlib] mark `OutputRawSpan.storeBytes()` with `@unsafe`

### DIFF
--- a/stdlib/public/core/Span/OutputRawSpan.swift
+++ b/stdlib/public/core/Span/OutputRawSpan.swift
@@ -208,6 +208,7 @@ extension OutputRawSpan {
 extension OutputRawSpan {
   /// Appends the given value's bytes to this span's bytes.
   @_alwaysEmitIntoClient
+  @unsafe
   @lifetime(self: copy self)
   public mutating func append<T: BitwiseCopyable>(_ value: T, as type: T.Type) {
     _precondition(
@@ -219,6 +220,7 @@ extension OutputRawSpan {
 
   /// Appends the given value's bytes repeatedly to this span's bytes.
   @_alwaysEmitIntoClient
+  @unsafe
   @lifetime(self: copy self)
   public mutating func append<T: BitwiseCopyable>(
     repeating repeatedValue: T, count: Int, as type: T.Type


### PR DESCRIPTION
When storing a value of a type with internal padding in its representation, the padding bytes could be left uninitialized. This is contrary to the stated precondition of `RawSpan` that all its bytes are initialized.

The current `storeBytes(_:as:)` and `storeBytes(repeating:as:) functions must be marked `@unsafe`.
(We'll work on safe replacements separately.)

Addresses rdar://168561707