### PR TITLE
Advanced observation tracking

### DIFF
--- a/Runtimes/Supplemental/Observation/CMakeLists.txt
+++ b/Runtimes/Supplemental/Observation/CMakeLists.txt
@@ -97,6 +97,7 @@ add_link_options($<$<PLATFORM_ID:Windows>:LINKER:/WX>)
 add_link_options($<$<PLATFORM_ID:Android,Linux>:LINKER:-z,defs>)
 
 add_library(swiftObservation
+  Sources/Observation/ContinuousObservation.swift
   Sources/Observation/Locking.swift
   Sources/Observation/Observable.swift
   Sources/Observation/ObservationRegistrar.swift

--- a/stdlib/public/Observation/Sources/Observation/CMakeLists.txt
+++ b/stdlib/public/Observation/Sources/Observation/CMakeLists.txt
@@ -13,6 +13,7 @@
 list(APPEND swift_runtime_library_compile_flags -I${SWIFT_SOURCE_DIR}/stdlib/include -I${SWIFT_SOURCE_DIR}/include)
 
 add_swift_target_library(swiftObservation ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
+  ContinuousObservation.swift
   Locking.swift
   Observable.swift
   ObservationRegistrar.swift

--- a/stdlib/public/Observation/Sources/Observation/ContinuousObservation.swift
+++ b/stdlib/public/Observation/Sources/Observation/ContinuousObservation.swift
@@ -1,0 +1,330 @@
+@available(SwiftStdlib 6.4, *)
+public func withContinuousObservation(
+  options: ObservationTracking.Options,
+  @_inheritActorContext apply: @isolated(any) @Sendable @escaping (borrowing ObservationTracking.Event) -> Void
+) -> ObservationTracking.Token {
+  let observation = ContinuousObservation(options: options, apply)
+  return observation.token
+}
+
+extension ObservationTracking {
+  @available(SwiftStdlib 6.4, *)
+  public struct Token: ~Copyable {
+    fileprivate var state: _ManagedCriticalState<ContinuousObservation.State>
+
+    @available(SwiftStdlib 6.4, *)
+    public consuming func cancel() {
+        ContinuousObservation.State.cancel(state)
+    }
+
+    deinit {
+        ContinuousObservation.State.cancel(state)
+    }
+  }
+}
+
+
+struct ContinuousObservation: ~Copyable {
+  // Tracks whether the didSet of the tracking has occurred (kind of).
+  // Whether it has come to the point of suspension after the isolation. "Next suspension on
+  // the isolation after the willSet"
+  struct State: Sendable {
+    // When `true`, this means to keep running because there is more to do (wait for the
+    // next suspension point).
+    var continuation: UnsafeContinuation<Bool, Never>?
+    var isInitial: Bool = true
+    // Tracks whether a change occurred before the cancellation, but has not called the
+    // synchronize closure yet. This allows that `synchronize` to be called for that value still.
+    var dirty = false
+    var cancelled = false
+    var event: (ObservationTracking.Event.Kind, ObservationTracking?)?
+  }
+
+  fileprivate let state = _ManagedCriticalState(State())
+
+  // Initialize with a closure where you access all properties you wish for changes to be tracked.
+  // Inside the closure, you should use the properties and transform them to set on other objects.
+  // This closure will be called continuously whenever any tracked property changes to a new
+  // value.
+  //
+  // - Note: The closure will be called isolated to the same actor this type is initialized on.
+  // - Parameters:
+  //     - synchronize: A closure that will be called whenever any of the tracked properties
+  //     change.
+  //         - `context`: Information as to the current iteration to allow you to change your code.
+  //         For instance, `isInitial` so you can choose to do something difference for the initial
+  //         value rather than when it changes.
+  init(
+    options: ObservationTracking.Options,
+    @_inheritActorContext _ apply: @isolated(any) @Sendable @escaping (borrowing ObservationTracking.Event) -> Void
+  ) {
+    ContinuousObservation.run(state, options: options, apply: apply)
+  }
+
+  var token: ObservationTracking.Token {
+    ObservationTracking.Token(state: state)
+  }
+}
+
+extension ContinuousObservation.State {
+  fileprivate static func emitEvent(
+    _ state: _ManagedCriticalState<ContinuousObservation.State>,
+    _ event: borrowing ObservationTracking.Event
+  ) {
+    let kind = event.kind
+    let tracking = event.tracking
+    let (continuation, terminal) = state.withCriticalRegion {
+      state -> (UnsafeContinuation<Bool, Never>?, Bool) in
+      let continuation = state.continuation
+      state.isInitial = false
+      state.dirty = true
+      state.continuation = nil
+      state.event = (kind, tracking)
+      return (continuation, state.cancelled)
+    }
+    if let continuation {
+      continuation.resume(returning: !terminal)
+    }
+  }
+
+  // If the return value is true, you should continue to listen for the next change. If false,
+  // you should end immediately and not listen to the next change.
+  fileprivate static func populate(
+    _ state: _ManagedCriticalState<ContinuousObservation.State>,
+    continuation: UnsafeContinuation<Bool, Never>
+  ) -> Bool {
+    // Continuation stays suspend until you get the new willSet trigger and the value is whether
+    // you should keep observing.
+    let (continuation, dirty) = state.withCriticalRegion {
+      state -> (UnsafeContinuation<Bool, Never>?, Bool) in
+      assert(state.continuation == nil)
+      let dirty = state.dirty
+      state.dirty = false
+      if state.cancelled {
+        return (continuation, dirty)
+      } else {
+        state.continuation = continuation
+        return (nil, dirty)
+      }
+    }
+    if let continuation {
+      // This is an early resume saying this is cancelled
+      continuation.resume(returning: false)
+      // If something already hit the willSet (dirty == true), then continue with one more
+      // value change.
+      return dirty
+    } else {
+      return true
+    }
+  }
+
+  static func cancel(_ state: _ManagedCriticalState<ContinuousObservation.State>)
+  {
+    state.withCriticalRegion { state in
+      let continuation = state.continuation
+      state.cancelled = true
+      state.continuation = nil
+      return continuation
+    }?.resume(returning: false)
+  }
+
+  // This will sit on an iteration of the loop until a `willSet`
+  // occurs for one of the tracked properties. Then, it will perform
+  // another iteration of the loop.
+  //
+  // Taking in the isolation ensures that we don't hop to another actor.
+  fileprivate static func trackingLoop(
+    isolation: isolated (any Actor)?,
+    _ state: _ManagedCriticalState<ContinuousObservation.State>,
+    options: ObservationTracking.Options,
+    apply:
+      @isolated(any) @escaping @Sendable (
+        borrowing ObservationTracking.Event
+      ) -> Void
+  ) async {
+    while await track(state, options: options, apply: apply) {}
+  }
+
+  fileprivate static func track(
+    _ state: _ManagedCriticalState<ContinuousObservation.State>,
+    options: ObservationTracking.Options,
+    apply:
+      @isolated(any) @escaping @Sendable (
+        borrowing ObservationTracking.Event
+      ) -> Void
+  ) async -> Bool {
+    return await withTaskCancellationHandler(
+      operation: {
+        return await withUnsafeContinuation(isolation: apply.isolation) {
+          continuation in
+          guard
+            ContinuousObservation.State.populate(state, continuation: continuation)
+          else {
+            return
+          }
+          withObservationTracking(options: options) {
+            // This is safe since we have already been isolated to the tracking isolation.
+            // It can be asserted to be isolated by
+            apply.isolation?.assertIsolated()
+            let fn = apply as @Sendable (borrowing ObservationTracking.Event) -> Void
+            // This ends up also being how the `didSet` is called because this will occur
+            // on the next iteration of the while loop from `trackingLoop` after the
+            // onChange.
+            let kindAndTracking = state.withCriticalRegion { state in
+              defer { state.event = nil }
+              return state.event
+            }
+            if let kindAndTracking {
+              fn(.init(kindAndTracking.1, continuousState: state, kind: kindAndTracking.0))
+            } else {
+              fn(.init(nil, continuousState: state, kind: .initial))
+            }
+          } onChange: { event in
+            // This will trigger this whole `track` method to be called again, causing the
+            // `apply` closure to run.
+            ContinuousObservation.State.emitEvent(state, event)
+          }
+        }
+      },
+      onCancel: {
+        ContinuousObservation.State.cancel(state)
+      },
+      isolation: apply.isolation
+    )
+  }
+}
+
+// MARK: - Runner
+
+extension ContinuousObservation {
+  // This is representing the state of the runner, which is spawning the task that's responsible
+  // for suspending (to wait after willSet) and resuming.
+  fileprivate struct RunnerState: @unchecked Sendable {
+    enum RunnerAction {
+      // Start looking at something
+      case startSynchronizing(
+        _ManagedCriticalState<State>,
+        ObservationTracking.Options,
+        @isolated(any) @Sendable (borrowing ObservationTracking.Event) -> Void
+      )
+      // Done looking at something
+      case finishedSynchronization
+    }
+
+    // Set to true when the `Task` is created
+    var running = false
+    var continuation: AsyncStream<RunnerAction>.Continuation
+    var iterator: AsyncStream<RunnerAction>.Iterator?
+
+    init() {
+      let (stream, continuation) = AsyncStream.makeStream(of: RunnerAction.self)
+      self.continuation = continuation
+      self.iterator = stream.makeAsyncIterator()
+    }
+  }
+
+  fileprivate static let runnerState = _ManagedCriticalState(RunnerState())
+}
+
+// This is needed just to make the `iterator` `Sendable`.
+// This is needed for the Coat Check algorithm.
+private struct UnsafeBox<Element>: @unchecked Sendable {
+  var value: Element
+  init(_ value: Element) {
+    self.value = value
+  }
+}
+
+extension ContinuousObservation.RunnerState {
+  // This says I'm waiting for something to do. I'm waiting to perform an action.
+  fileprivate static func dequeue(
+    _ state: _ManagedCriticalState<ContinuousObservation.RunnerState>,
+    isolation: isolated (any Actor)? = #isolation
+  ) async -> RunnerAction? {
+    guard
+      var iteratorBox = state.withCriticalRegion({ state in
+        // Atomic swap checkout algorithm (Coat Check Algorithm)
+        let iteratorBox = state.iterator.map { UnsafeBox($0) }
+        state.iterator = nil
+        return iteratorBox
+      })
+    else {
+      fatalError("Iteration should be fully exclusive")
+    }
+    // At this point, the state.iterator has been set to `nil`
+    // You are handing off where the iteration is being done so only one thing is ever awaiting.
+    let value = await iteratorBox.value.next(isolation: isolation)
+    // iterator is captured to freeze the state of the iteration from being a var
+    state.withCriticalRegion { [iteratorBox] state in
+      // Checks the value back in
+      state.iterator = iteratorBox.value
+    }
+    return value
+  }
+
+  fileprivate static func enqueue(
+    _ state: _ManagedCriticalState<ContinuousObservation.RunnerState>,
+    action: RunnerAction
+  ) {
+    state.withCriticalRegion { state in
+      return state.continuation
+    }.yield(action)
+  }
+}
+
+extension ContinuousObservation {
+  fileprivate static func run(
+    _ state: _ManagedCriticalState<State>,
+    options: ObservationTracking.Options,
+    apply: @isolated(any) @Sendable @escaping (borrowing ObservationTracking.Event) -> Void
+  ) {
+    let shouldStart = runnerState.withCriticalRegion { state in
+      let isRunning = state.running
+      state.running = true
+      return !isRunning
+    }
+
+    // Only the first time anything is ever trying to run
+    if shouldStart {
+      Task.detached(name: "ContinuousObservation") {
+        await withTaskGroup { group in
+          var activeDequeueCount = 0
+          while true {
+            // the active dequeue action should only have 1 active at any point in time
+            if activeDequeueCount < 1 {
+              group.addTask {
+                await RunnerState.dequeue(runnerState)
+              }
+              activeDequeueCount += 1
+            }
+            // ensure that there is precisely 1 active dequeue active
+            assert(activeDequeueCount == 1)
+            // This gets the next action returned from the group `Task`s
+            switch await group.next() {
+            case .finishedSynchronization:  // this is only returned by an iteration of tracking
+              break
+            case .startSynchronizing(let state, let options, let apply):  // this is only emitted by enqueueing an action
+              // Allow for the opportunity for another synchronization task to start
+              activeDequeueCount -= 1
+              group.addTask {
+                // This will sit on an iteration of the loop until a `willSet`
+                // occurs for one of the tracked properties. Then, it will perform
+                // another iteration of the loop.
+                await State.trackingLoop(
+                  isolation: apply.isolation,
+                  state,
+                  options: options,
+                  apply: apply
+                )
+                return .finishedSynchronization
+              }
+            default:
+              return
+            }
+          }
+        }
+      }
+    }
+    RunnerState.enqueue(runnerState, action: .startSynchronizing(state, options, apply))
+  }
+}

--- a/stdlib/public/Observation/Sources/Observation/ContinuousObservation.swift
+++ b/stdlib/public/Observation/Sources/Observation/ContinuousObservation.swift
@@ -20,6 +20,7 @@ public func withContinuousObservation(
   return observation.token
 }
 
+@available(SwiftStdlib 6.4, *)
 extension ObservationTracking {
   @available(SwiftStdlib 6.4, *)
   public struct Token: ~Copyable {
@@ -36,7 +37,7 @@ extension ObservationTracking {
   }
 }
 
-
+@available(SwiftStdlib 6.4, *)
 struct ContinuousObservation: ~Copyable {
   // Tracks whether the didSet of the tracking has occurred (kind of).
   // Whether it has come to the point of suspension after the isolation. "Next suspension on
@@ -79,6 +80,7 @@ struct ContinuousObservation: ~Copyable {
   }
 }
 
+@available(SwiftStdlib 6.4, *)
 extension ContinuousObservation.State {
   fileprivate static func emitEvent(
     _ state: _ManagedCriticalState<ContinuousObservation.State>,
@@ -208,7 +210,7 @@ extension ContinuousObservation.State {
 }
 
 // MARK: - Runner
-
+@available(SwiftStdlib 6.4, *)
 extension ContinuousObservation {
   // This is representing the state of the runner, which is spawning the task that's responsible
   // for suspending (to wait after willSet) and resuming.
@@ -248,6 +250,7 @@ private struct UnsafeBox<Element>: @unchecked Sendable {
   }
 }
 
+@available(SwiftStdlib 6.4, *)
 extension ContinuousObservation.RunnerState {
   // This says I'm waiting for something to do. I'm waiting to perform an action.
   fileprivate static func dequeue(
@@ -285,6 +288,7 @@ extension ContinuousObservation.RunnerState {
   }
 }
 
+@available(SwiftStdlib 6.4, *)
 extension ContinuousObservation {
   fileprivate static func run(
     _ state: _ManagedCriticalState<State>,

--- a/stdlib/public/Observation/Sources/Observation/ContinuousObservation.swift
+++ b/stdlib/public/Observation/Sources/Observation/ContinuousObservation.swift
@@ -1,3 +1,16 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import _Concurrency
+
 @available(SwiftStdlib 6.4, *)
 public func withContinuousObservation(
   options: ObservationTracking.Options,

--- a/stdlib/public/Observation/Sources/Observation/ObservationTracking.swift
+++ b/stdlib/public/Observation/Sources/Observation/ObservationTracking.swift
@@ -10,12 +10,11 @@
 //===----------------------------------------------------------------------===//
 
 @available(SwiftStdlib 5.9, *)
-@_spi(SwiftUI)
 public struct ObservationTracking: Sendable {
-  enum Id {
-    case willSet(Int)
-    case didSet(Int)
-    case full(Int, Int)
+  struct Id {
+    var willSet: Int?
+    var didSet: Int?
+    var `deinit`: Int?
   }
 
   struct Entry: @unchecked Sendable {
@@ -35,6 +34,10 @@ public struct ObservationTracking: Sendable {
     func addDidSetObserver(_ changed: @Sendable @escaping (AnyKeyPath) -> Void) -> Int {
       return context.registerTracking(for: properties, didSet: changed)
     }
+
+    func addDeinitObserver(_ changed: @Sendable @escaping () -> Void) -> Int {
+      return context.registerTracking(deinit: changed)
+    }
     
     func removeObserver(_ token: Int) {
       context.cancel(token)
@@ -45,7 +48,7 @@ public struct ObservationTracking: Sendable {
     }
     
     func union(_ entry: Entry) -> Entry {
-      Entry(context, properties: properties.union(entry.properties))
+      return Entry(context, properties: properties.union(entry.properties))
     }
   }
   
@@ -69,38 +72,43 @@ public struct ObservationTracking: Sendable {
     }
   }
 
+  static func _installTracking(
+    options: ObservationTracking.Options,
+    _ tracking: ObservationTracking,
+    willSet: (@Sendable (ObservationTracking) -> Void)? = nil,
+    didSet: (@Sendable (ObservationTracking) -> Void)? = nil,
+    `deinit`: (@Sendable () -> Void)? = nil
+  ) {
+    let values = tracking.list.entries.mapValues { 
+      var id = Id()
+      if let willSet {
+        id.willSet = $0.addWillSetObserver { property in
+          tracking.state.withCriticalRegion { $0.changed = property }
+          willSet(tracking)
+        }
+      }
+      if let didSet {
+        id.didSet = $0.addDidSetObserver { property in
+          tracking.state.withCriticalRegion { $0.changed = property }
+          didSet(tracking)
+        }
+      }
+      if let `deinit` {
+        id.deinit = $0.addDeinitObserver(`deinit`)
+      }
+      return id
+    }
+    
+    tracking.install(values)
+  }
+
   @_spi(SwiftUI)
   public static func _installTracking(
     _ tracking: ObservationTracking,
     willSet: (@Sendable (ObservationTracking) -> Void)? = nil,
     didSet: (@Sendable (ObservationTracking) -> Void)? = nil
   ) {
-    let values = tracking.list.entries.mapValues { 
-      switch (willSet, didSet) {
-      case (.some(let willSetObserver), .some(let didSetObserver)):
-        return Id.full($0.addWillSetObserver { keyPath in
-          tracking.state.withCriticalRegion { $0.changed = keyPath }
-          willSetObserver(tracking)
-        }, $0.addDidSetObserver { keyPath in
-          tracking.state.withCriticalRegion { $0.changed = keyPath }
-          didSetObserver(tracking)
-        })
-      case (.some(let willSetObserver), .none):
-        return Id.willSet($0.addWillSetObserver { keyPath in
-          tracking.state.withCriticalRegion { $0.changed = keyPath }
-          willSetObserver(tracking)
-        })
-      case (.none, .some(let didSetObserver)):
-        return Id.didSet($0.addDidSetObserver { keyPath in
-          tracking.state.withCriticalRegion { $0.changed = keyPath }
-          didSetObserver(tracking)
-        })
-      case (.none, .none):
-        fatalError()
-      }  
-    }
-    
-    tracking.install(values)
+    _installTracking(options: [], tracking, willSet: willSet, didSet: didSet, deinit: nil)
   }
 
   @_spi(SwiftUI)
@@ -126,7 +134,18 @@ public struct ObservationTracking: Sendable {
   
   @_spi(SwiftUI)
   public init(_ list: _AccessList?) {
+    self.init(list, changed: nil)
+  }
+
+  init(_ list: _AccessList?, changed: AnyKeyPath?) {
     self.list = list ?? _AccessList()
+    if let changed {
+      state.withCriticalRegion { $0.changed = changed }
+    }
+  }
+
+  var isCancelled: Bool {
+    state.withCriticalRegion { $0.cancelled }
   }
 
   internal func install(_ values:  [ObjectIdentifier : ObservationTracking.Id]) {
@@ -137,6 +156,7 @@ public struct ObservationTracking: Sendable {
     }
   }
 
+  @_spi(SwiftUI)
   public func cancel() {
     let values = state.withCriticalRegion {
       $0.cancelled = true
@@ -145,28 +165,212 @@ public struct ObservationTracking: Sendable {
       return values
     }
     for (id, observationId) in values {
-        switch observationId {
-        case .willSet(let token):
+        if let token = observationId.willSet {
           list.entries[id]?.removeObserver(token)
-        case .didSet(let token):
+        }
+        if let token = observationId.didSet {
           list.entries[id]?.removeObserver(token)
-        case .full(let willSetToken, let didSetToken):
-          list.entries[id]?.removeObserver(willSetToken)
-          list.entries[id]?.removeObserver(didSetToken)
+        }
+        if let token = observationId.deinit {
+          list.entries[id]?.removeObserver(token)
         }
       }
   }
 
   @available(SwiftStdlib 6.0, *)
+  @_spi(SwiftUI)
   public var changed: AnyKeyPath? {
       state.withCriticalRegion { $0.changed }
   }
+
+  static func deactivateAccessList(_ ptr: UnsafeMutablePointer<_AccessList?>) -> ObservationRegistrar.Dirty? {
+    var found: ObservationRegistrar.Dirty? = nil
+    if let entries = ptr.pointee?.entries.values {
+      for entry in entries {
+        let dirty = entry.context.clearDirty(ptr)
+        if found == nil {
+          found = dirty
+        }
+      }
+    }
+    return found
+  }
+
+  @available(SwiftStdlib 6.4, *)
+  public struct Options {
+    struct RawValue: OptionSet {
+      var rawValue: Int
+
+      init(rawValue: Int) {
+        self.rawValue = rawValue
+      }
+
+      static var willSet: RawValue { .init(rawValue: 1 << 0) }
+      static var didSet: RawValue { .init(rawValue: 1 << 1) }
+      static var `deinit`: RawValue { .init(rawValue: 1 << 2) }
+      static var continuous: RawValue { .init(rawValue: 1 << 3) }
+      static var updating: RawValue { .init(rawValue: 1 << 4) }
+    }
+    var rawValue: RawValue
+
+    init(rawValue: RawValue) {
+      self.rawValue = rawValue
+    }
+
+    @available(SwiftStdlib 6.4, *)
+    public init() { 
+      rawValue = RawValue()
+    }
+
+    @available(SwiftStdlib 6.4, *)
+    public static var willSet: Options { Options(rawValue: .willSet) }
+
+    @available(SwiftStdlib 6.4, *)
+    public static var didSet: Options { Options(rawValue: .didSet) }
+    
+    @available(SwiftStdlib 6.4, *)
+    public static var `deinit`: Options { Options(rawValue: .deinit) }
+  }
+
+  @available(SwiftStdlib 6.4, *)
+  public struct Event: ~Copyable {
+    @available(SwiftStdlib 6.4, *)
+    public struct Kind: Equatable, Sendable {
+      enum RawValue {
+        case initial
+        case willSet
+        case didSet
+        case `deinit`
+      }
+
+      var rawValue: RawValue
+      
+      @available(SwiftStdlib 6.4, *)
+      public static var initial: Kind { Kind(rawValue: .initial) }
+      
+      @available(SwiftStdlib 6.4, *)
+      public static var willSet: Kind { Kind(rawValue: .willSet) }
+      
+      @available(SwiftStdlib 6.4, *)
+      public static var didSet: Kind { Kind(rawValue: .didSet) }
+      
+      @available(SwiftStdlib 6.4, *)
+      public static var `deinit`: Kind { Kind(rawValue: .deinit) }
+    }
+
+    @available(SwiftStdlib 6.4, *)
+    public private(set) var kind: Kind
+
+    var tracking: ObservationTracking?
+    var continuousState: _ManagedCriticalState<ContinuousObservation.State>?
+
+    init(_ tracking: ObservationTracking?, kind: Kind) {
+      self.kind = kind
+      self.tracking = tracking
+    }
+
+    init(_ tracking: ObservationTracking?, continuousState: _ManagedCriticalState<ContinuousObservation.State>, kind: Kind) {
+      self.kind = kind
+      self.tracking = tracking
+      self.continuousState = continuousState
+    }
+
+    @available(SwiftStdlib 6.4, *)
+    public func matches(_ keyPath: PartialKeyPath<some Observable>) -> Bool {
+      return tracking?.changed == keyPath
+    }
+
+    @available(SwiftStdlib 6.4, *)
+    public func cancel() {
+      tracking?.cancel()
+      if let continuousState {
+        ContinuousObservation.State.cancel(continuousState)
+      }
+    }
+  }
 }
 
-@available(SwiftStdlib 5.9, *)
-fileprivate func generateAccessList<T>(_ apply: () -> T) -> (T, ObservationTracking._AccessList?) {
+@available(SwiftStdlib 6.4, *)
+extension ObservationTracking.Options: SetAlgebra {
+  @available(SwiftStdlib 6.4, *)
+  public init(arrayLiteral elements: ObservationTracking.Options...) {
+    var rawValue = RawValue()
+    for element in elements {
+      rawValue.rawValue |= element.rawValue.rawValue
+    }
+    self.init(rawValue: rawValue)
+  }
+
+  @available(SwiftStdlib 6.4, *)
+  public func union(_ other: Self) -> Self {
+    Self(rawValue: rawValue.union(other.rawValue))
+  }
+
+  @available(SwiftStdlib 6.4, *)
+  public func intersection(_ other: Self) -> Self {
+    Self(rawValue: rawValue.intersection(other.rawValue))
+  }
+
+  @available(SwiftStdlib 6.4, *)
+  public func symmetricDifference(_ other: Self) -> Self {
+    Self(rawValue: rawValue.symmetricDifference(other.rawValue))
+  }
+
+  @available(SwiftStdlib 6.4, *)
+  public mutating func formUnion(_ other: Self) {
+    rawValue.formUnion(other.rawValue)
+  }
+
+  @available(SwiftStdlib 6.4, *)
+  public mutating func formIntersection(_ other: Self) {
+    rawValue.formIntersection(other.rawValue)
+  }
+
+  @available(SwiftStdlib 6.4, *)
+  public mutating func formSymmetricDifference(_ other: Self) {
+    rawValue.formSymmetricDifference(other.rawValue)
+  }
+  
+  @available(SwiftStdlib 6.4, *)
+  public func contains(_ member: Self) -> Bool {
+    rawValue.contains(member.rawValue)
+  }
+
+  @available(SwiftStdlib 6.4, *)
+  @discardableResult
+  public mutating func insert(_ newMember: Self) -> (inserted: Bool, memberAfterInsert: Self) {
+    let (inserted, memberAfterInsert) = rawValue.insert(newMember.rawValue)
+    return (inserted, Self(rawValue: memberAfterInsert))
+  }
+  
+  @available(SwiftStdlib 6.4, *)
+  @discardableResult
+  public mutating func remove(_ member: Self) -> Self? {
+    rawValue.remove(member.rawValue).map { Self(rawValue: $0) }
+  }
+
+  @available(SwiftStdlib 6.4, *)
+  @discardableResult
+  public mutating func update(with newMember: Self) -> Self? {
+    rawValue.update(with: newMember.rawValue).map { Self(rawValue: $0) }
+  }
+}
+
+extension ObservationTracking.Options: Sendable { }
+
+struct AccessListResult<T: ~Copyable>: ~Copyable {
+  var result: T
   var accessList: ObservationTracking._AccessList?
-  let result = withUnsafeMutablePointer(to: &accessList) { ptr in
+  var dirty: ObservationRegistrar.Dirty?
+}
+
+fileprivate func generateAccessList<T: ~Copyable, Failure: Error>(
+  options: ObservationTracking.Options, 
+  _ apply: () throws(Failure) -> T
+) throws(Failure) -> AccessListResult<T> {
+  var accessList: ObservationTracking._AccessList?
+  var dirty: ObservationRegistrar.Dirty? = nil
+  let result = try withUnsafeMutablePointer(to: &accessList) { (ptr: UnsafeMutablePointer<ObservationTracking._AccessList?>) throws(Failure) -> T in
     let previous = _ThreadLocal.value
     _ThreadLocal.value = UnsafeMutableRawPointer(ptr)
     defer {
@@ -180,10 +384,67 @@ fileprivate func generateAccessList<T>(_ apply: () -> T) -> (T, ObservationTrack
       }
       _ThreadLocal.value = previous
     }
-    return apply()
+    let result = try apply()
+    // if options.rawValue.contains(.concurrentMutation) {
+      dirty = ObservationTracking.deactivateAccessList(ptr)
+    // }
+    return result
   }
-  return (result, accessList)
+  return AccessListResult(result: result, accessList: accessList, dirty: dirty)
 }
+
+@available(SwiftStdlib 6.4, *)
+public func withObservationTracking<Result: ~Copyable, Failure: Error>(
+  options: ObservationTracking.Options,
+  _ apply: () throws(Failure) -> Result,
+  onChange: @escaping @Sendable (borrowing ObservationTracking.Event) -> Void
+) throws(Failure) -> Result {
+  let accessListResult = try generateAccessList(options: options, apply)
+  let willSet: (@Sendable (ObservationTracking) -> Void)?
+  if options.contains(.willSet) {
+    willSet = { tracking in
+      onChange(ObservationTracking.Event(tracking, kind: .willSet))
+      if !options.rawValue.contains(.continuous) && !options.contains(.didSet) {
+        tracking.cancel()
+      }
+    }
+  } else {
+    willSet = nil
+  }
+  let didSet: (@Sendable (ObservationTracking) -> Void)?
+  if options.contains(.didSet) {
+    didSet = { tracking in
+      onChange(ObservationTracking.Event(tracking, kind: .didSet))
+      if !options.rawValue.contains(.continuous) {
+        tracking.cancel()
+      }
+    }
+  } else {
+    didSet = nil
+  }
+  let `deinit`: (@Sendable () -> Void)?
+  if options.contains(.deinit) {
+    `deinit` = { 
+      onChange(ObservationTracking.Event(nil, kind: .deinit))
+    }
+  } else {
+    `deinit` = nil
+  }
+  let tracking = ObservationTracking(accessListResult.accessList)
+  ObservationTracking._installTracking(options: options, tracking, willSet: willSet, didSet: didSet, deinit: `deinit`)
+  switch accessListResult.dirty {
+  case .willSet(let keyPath):
+    willSet?(ObservationTracking(accessListResult.accessList, changed: keyPath))
+  case .didSet(let keyPath):
+    didSet?(ObservationTracking(accessListResult.accessList, changed: keyPath))
+  case .deinit:
+    `deinit`?()
+  default:
+    break
+  }
+  return accessListResult.result
+}
+
 
 /// Tracks access to properties.
 ///
@@ -214,11 +475,11 @@ public func withObservationTracking<T>(
   _ apply: () -> T,
   onChange: @autoclosure () -> @Sendable () -> Void
 ) -> T {
-  let (result, accessList) = generateAccessList(apply)
-  if let accessList {
+  let accessListResult = generateAccessList(options: [], apply)
+  if let accessList = accessListResult.accessList {
     ObservationTracking._installTracking(accessList, onChange: onChange())
   }
-  return result
+  return accessListResult.result
 }
 
 @available(SwiftStdlib 5.9, *)
@@ -228,9 +489,9 @@ public func withObservationTracking<T>(
   willSet: @escaping @Sendable (ObservationTracking) -> Void,
   didSet: @escaping @Sendable (ObservationTracking) -> Void
 ) -> T {
-  let (result, accessList) = generateAccessList(apply)
-  ObservationTracking._installTracking(ObservationTracking(accessList), willSet: willSet, didSet: didSet)
-  return result
+  let accessListResult = generateAccessList(options: [], apply)
+  ObservationTracking._installTracking(ObservationTracking(accessListResult.accessList), willSet: willSet, didSet: didSet)
+  return accessListResult.result
 }
 
 @available(SwiftStdlib 5.9, *)
@@ -239,9 +500,9 @@ public func withObservationTracking<T>(
   _ apply: () -> T,
   willSet: @escaping @Sendable (ObservationTracking) -> Void
 ) -> T {
-  let (result, accessList) = generateAccessList(apply)
-  ObservationTracking._installTracking(ObservationTracking(accessList), willSet: willSet, didSet: nil)
-  return result
+  let accessListResult = generateAccessList(options: [], apply)
+  ObservationTracking._installTracking(ObservationTracking(accessListResult.accessList), willSet: willSet, didSet: nil)
+  return accessListResult.result
 }
 
 @available(SwiftStdlib 5.9, *)
@@ -250,7 +511,7 @@ public func withObservationTracking<T>(
   _ apply: () -> T,
   didSet: @escaping @Sendable (ObservationTracking) -> Void
 ) -> T {
-  let (result, accessList) = generateAccessList(apply)
-  ObservationTracking._installTracking(ObservationTracking(accessList), willSet: nil, didSet: didSet)
-  return result
+  let accessListResult = generateAccessList(options: [], apply)
+  ObservationTracking._installTracking(ObservationTracking(accessListResult.accessList), willSet: nil, didSet: didSet)
+  return accessListResult.result
 }

--- a/test/abi/macOS/arm64/observation.swift
+++ b/test/abi/macOS/arm64/observation.swift
@@ -87,3 +87,152 @@ Added: _$s11Observation12ObservationsVyACyxq_GxyYbq_YKYAccfC
 
 // protocol conformance descriptor for Observation.Observations<A, B> : Swift.AsyncSequence in Observation
 Added: _$s11Observation12ObservationsVyxq_GSciAAMc
+
+// static Observation.ObservationTracking.Event.Kind.== infix(Observation.ObservationTracking.Event.Kind, Observation.ObservationTracking.Event.Kind) -> Swift.Bool
+Added: _$s11Observation0A8TrackingV5EventV4KindV2eeoiySbAG_AGtFZ
+
+// static Observation.ObservationTracking.Event.Kind.deinit.getter : Observation.ObservationTracking.Event.Kind
+Added: _$s11Observation0A8TrackingV5EventV4KindV6deinitAGvgZ
+
+// property descriptor for static Observation.ObservationTracking.Event.Kind.deinit : Observation.ObservationTracking.Event.Kind
+Added: _$s11Observation0A8TrackingV5EventV4KindV6deinitAGvpZMV
+
+// static Observation.ObservationTracking.Event.Kind.didSet.getter : Observation.ObservationTracking.Event.Kind
+Added: _$s11Observation0A8TrackingV5EventV4KindV6didSetAGvgZ
+
+// property descriptor for static Observation.ObservationTracking.Event.Kind.didSet : Observation.ObservationTracking.Event.Kind
+Added: _$s11Observation0A8TrackingV5EventV4KindV6didSetAGvpZMV
+
+// static Observation.ObservationTracking.Event.Kind.initial.getter : Observation.ObservationTracking.Event.Kind
+Added: _$s11Observation0A8TrackingV5EventV4KindV7initialAGvgZ
+
+// property descriptor for static Observation.ObservationTracking.Event.Kind.initial : Observation.ObservationTracking.Event.Kind
+Added: _$s11Observation0A8TrackingV5EventV4KindV7initialAGvpZMV
+
+// static Observation.ObservationTracking.Event.Kind.willSet.getter : Observation.ObservationTracking.Event.Kind
+Added: _$s11Observation0A8TrackingV5EventV4KindV7willSetAGvgZ
+
+// property descriptor for static Observation.ObservationTracking.Event.Kind.willSet : Observation.ObservationTracking.Event.Kind
+Added: _$s11Observation0A8TrackingV5EventV4KindV7willSetAGvpZMV
+
+// type metadata accessor for Observation.ObservationTracking.Event.Kind
+Added: _$s11Observation0A8TrackingV5EventV4KindVMa
+
+// nominal type descriptor for Observation.ObservationTracking.Event.Kind
+Added: _$s11Observation0A8TrackingV5EventV4KindVMn
+
+// type metadata for Observation.ObservationTracking.Event.Kind
+Added: _$s11Observation0A8TrackingV5EventV4KindVN
+
+// protocol conformance descriptor for Observation.ObservationTracking.Event.Kind : Swift.Equatable in Observation
+Added: _$s11Observation0A8TrackingV5EventV4KindVSQAAMc
+
+// Observation.ObservationTracking.Event.kind.getter : Observation.ObservationTracking.Event.Kind
+Added: _$s11Observation0A8TrackingV5EventV4kindAE4KindVvg
+
+// Observation.ObservationTracking.Event.cancel() -> ()
+Added: _$s11Observation0A8TrackingV5EventV6cancelyyF
+
+// Observation.ObservationTracking.Event.matches<A where A: Observation.Observable>(Swift.PartialKeyPath<A>) -> Swift.Bool
+Added: _$s11Observation0A8TrackingV5EventV7matchesySbs14PartialKeyPathCyxGAA10ObservableRzlF
+
+// type metadata accessor for Observation.ObservationTracking.Event
+Added: _$s11Observation0A8TrackingV5EventVMa
+
+// nominal type descriptor for Observation.ObservationTracking.Event
+Added: _$s11Observation0A8TrackingV5EventVMn
+
+// type metadata for Observation.ObservationTracking.Event
+Added: _$s11Observation0A8TrackingV5EventVN
+
+// Observation.ObservationTracking.Token.cancel() -> ()
+Added: _$s11Observation0A8TrackingV5TokenV6cancelyyF
+
+// type metadata accessor for Observation.ObservationTracking.Token
+Added: _$s11Observation0A8TrackingV5TokenVMa
+
+// nominal type descriptor for Observation.ObservationTracking.Token
+Added: _$s11Observation0A8TrackingV5TokenVMn
+
+// type metadata for Observation.ObservationTracking.Token
+Added: _$s11Observation0A8TrackingV5TokenVN
+
+// Observation.ObservationTracking.Token.deinit
+Added: _$s11Observation0A8TrackingV5TokenVfD
+
+// Observation.ObservationTracking.Options.init(arrayLiteral: Observation.ObservationTracking.Options...) -> Observation.ObservationTracking.Options
+Added: _$s11Observation0A8TrackingV7OptionsV12arrayLiteralA2Ed_tcfC
+
+// Observation.ObservationTracking.Options.intersection(Observation.ObservationTracking.Options) -> Observation.ObservationTracking.Options
+Added: _$s11Observation0A8TrackingV7OptionsV12intersectionyA2EF
+
+// Observation.ObservationTracking.Options.formIntersection(Observation.ObservationTracking.Options) -> ()
+Added: _$s11Observation0A8TrackingV7OptionsV16formIntersectionyyAEF
+
+// Observation.ObservationTracking.Options.symmetricDifference(Observation.ObservationTracking.Options) -> Observation.ObservationTracking.Options
+Added: _$s11Observation0A8TrackingV7OptionsV19symmetricDifferenceyA2EF
+
+// Observation.ObservationTracking.Options.formSymmetricDifference(Observation.ObservationTracking.Options) -> ()
+Added: _$s11Observation0A8TrackingV7OptionsV23formSymmetricDifferenceyyAEF
+
+// static Observation.ObservationTracking.Options.== infix(Observation.ObservationTracking.Options, Observation.ObservationTracking.Options) -> Swift.Bool
+Added: _$s11Observation0A8TrackingV7OptionsV2eeoiySbAE_AEtFZ
+
+// Observation.ObservationTracking.Options.union(Observation.ObservationTracking.Options) -> Observation.ObservationTracking.Options
+Added: _$s11Observation0A8TrackingV7OptionsV5unionyA2EF
+
+// static Observation.ObservationTracking.Options.deinit.getter : Observation.ObservationTracking.Options
+Added: _$s11Observation0A8TrackingV7OptionsV6deinitAEvgZ
+
+// property descriptor for static Observation.ObservationTracking.Options.deinit : Observation.ObservationTracking.Options
+Added: _$s11Observation0A8TrackingV7OptionsV6deinitAEvpZMV
+
+// static Observation.ObservationTracking.Options.didSet.getter : Observation.ObservationTracking.Options
+Added: _$s11Observation0A8TrackingV7OptionsV6didSetAEvgZ
+
+// property descriptor for static Observation.ObservationTracking.Options.didSet : Observation.ObservationTracking.Options
+Added: _$s11Observation0A8TrackingV7OptionsV6didSetAEvpZMV
+
+// Observation.ObservationTracking.Options.insert(Observation.ObservationTracking.Options) -> (inserted: Swift.Bool, memberAfterInsert: Observation.ObservationTracking.Options)
+Added: _$s11Observation0A8TrackingV7OptionsV6insertySb8inserted_AE17memberAfterInserttAEF
+
+// Observation.ObservationTracking.Options.remove(Observation.ObservationTracking.Options) -> Observation.ObservationTracking.Options?
+Added: _$s11Observation0A8TrackingV7OptionsV6removeyAESgAEF
+
+// Observation.ObservationTracking.Options.update(with: Observation.ObservationTracking.Options) -> Observation.ObservationTracking.Options?
+Added: _$s11Observation0A8TrackingV7OptionsV6update4withAESgAE_tF
+
+// static Observation.ObservationTracking.Options.willSet.getter : Observation.ObservationTracking.Options
+Added: _$s11Observation0A8TrackingV7OptionsV7willSetAEvgZ
+
+// property descriptor for static Observation.ObservationTracking.Options.willSet : Observation.ObservationTracking.Options
+Added: _$s11Observation0A8TrackingV7OptionsV7willSetAEvpZMV
+
+// Observation.ObservationTracking.Options.contains(Observation.ObservationTracking.Options) -> Swift.Bool
+Added: _$s11Observation0A8TrackingV7OptionsV8containsySbAEF
+
+// Observation.ObservationTracking.Options.formUnion(Observation.ObservationTracking.Options) -> ()
+Added: _$s11Observation0A8TrackingV7OptionsV9formUnionyyAEF
+
+// Observation.ObservationTracking.Options.init() -> Observation.ObservationTracking.Options
+Added: _$s11Observation0A8TrackingV7OptionsVAEycfC
+
+// type metadata accessor for Observation.ObservationTracking.Options
+Added: _$s11Observation0A8TrackingV7OptionsVMa
+
+// nominal type descriptor for Observation.ObservationTracking.Options
+Added: _$s11Observation0A8TrackingV7OptionsVMn
+
+// type metadata for Observation.ObservationTracking.Options
+Added: _$s11Observation0A8TrackingV7OptionsVN
+
+// protocol conformance descriptor for Observation.ObservationTracking.Options : Swift.Equatable in Observation
+Added: _$s11Observation0A8TrackingV7OptionsVSQAAMc
+
+// protocol conformance descriptor for Observation.ObservationTracking.Options : Swift.SetAlgebra in Observation
+Added: _$s11Observation0A8TrackingV7OptionsVs10SetAlgebraAAMc
+
+// protocol conformance descriptor for Observation.ObservationTracking.Options : Swift.ExpressibleByArrayLiteral in Observation
+Added: _$s11Observation0A8TrackingV7OptionsVs25ExpressibleByArrayLiteralAAMc
+
+

--- a/test/abi/macOS/arm64/observation.swift
+++ b/test/abi/macOS/arm64/observation.swift
@@ -235,4 +235,8 @@ Added: _$s11Observation0A8TrackingV7OptionsVs10SetAlgebraAAMc
 // protocol conformance descriptor for Observation.ObservationTracking.Options : Swift.ExpressibleByArrayLiteral in Observation
 Added: _$s11Observation0A8TrackingV7OptionsVs25ExpressibleByArrayLiteralAAMc
 
+// Observation.withContinuousObservation(options: Observation.ObservationTracking.Options, apply: @isolated(any) @Sendable (Observation.ObservationTracking.Event) -> ()) -> Observation.ObservationTracking.Token
+Added: _$s11Observation014withContinuousA07options5applyAA0A8TrackingV5TokenVAF7OptionsV_yAF5EventVYbYActF
 
+// Observation.withObservationTracking<A, B where B: Swift.Error, A: ~Swift.Copyable>(options: Observation.ObservationTracking.Options, _: () throws(B) -> A, onChange: @Sendable (Observation.ObservationTracking.Event) -> ()) throws(B) -> A
+Added: _$s11Observation04withA8Tracking7options_8onChangexAA0aC0V7OptionsV_xyq_YKXEyAF5EventVYbctq_YKs5ErrorR_Ri_zr0_lF

--- a/test/abi/macOS/x86_64/observation.swift
+++ b/test/abi/macOS/x86_64/observation.swift
@@ -87,3 +87,152 @@ Added: _$s11Observation12ObservationsVyACyxq_GxyYbq_YKYAccfC
 
 // protocol conformance descriptor for Observation.Observations<A, B> : Swift.AsyncSequence in Observation
 Added: _$s11Observation12ObservationsVyxq_GSciAAMc
+
+// static Observation.ObservationTracking.Event.Kind.== infix(Observation.ObservationTracking.Event.Kind, Observation.ObservationTracking.Event.Kind) -> Swift.Bool
+Added: _$s11Observation0A8TrackingV5EventV4KindV2eeoiySbAG_AGtFZ
+
+// static Observation.ObservationTracking.Event.Kind.deinit.getter : Observation.ObservationTracking.Event.Kind
+Added: _$s11Observation0A8TrackingV5EventV4KindV6deinitAGvgZ
+
+// property descriptor for static Observation.ObservationTracking.Event.Kind.deinit : Observation.ObservationTracking.Event.Kind
+Added: _$s11Observation0A8TrackingV5EventV4KindV6deinitAGvpZMV
+
+// static Observation.ObservationTracking.Event.Kind.didSet.getter : Observation.ObservationTracking.Event.Kind
+Added: _$s11Observation0A8TrackingV5EventV4KindV6didSetAGvgZ
+
+// property descriptor for static Observation.ObservationTracking.Event.Kind.didSet : Observation.ObservationTracking.Event.Kind
+Added: _$s11Observation0A8TrackingV5EventV4KindV6didSetAGvpZMV
+
+// static Observation.ObservationTracking.Event.Kind.initial.getter : Observation.ObservationTracking.Event.Kind
+Added: _$s11Observation0A8TrackingV5EventV4KindV7initialAGvgZ
+
+// property descriptor for static Observation.ObservationTracking.Event.Kind.initial : Observation.ObservationTracking.Event.Kind
+Added: _$s11Observation0A8TrackingV5EventV4KindV7initialAGvpZMV
+
+// static Observation.ObservationTracking.Event.Kind.willSet.getter : Observation.ObservationTracking.Event.Kind
+Added: _$s11Observation0A8TrackingV5EventV4KindV7willSetAGvgZ
+
+// property descriptor for static Observation.ObservationTracking.Event.Kind.willSet : Observation.ObservationTracking.Event.Kind
+Added: _$s11Observation0A8TrackingV5EventV4KindV7willSetAGvpZMV
+
+// type metadata accessor for Observation.ObservationTracking.Event.Kind
+Added: _$s11Observation0A8TrackingV5EventV4KindVMa
+
+// nominal type descriptor for Observation.ObservationTracking.Event.Kind
+Added: _$s11Observation0A8TrackingV5EventV4KindVMn
+
+// type metadata for Observation.ObservationTracking.Event.Kind
+Added: _$s11Observation0A8TrackingV5EventV4KindVN
+
+// protocol conformance descriptor for Observation.ObservationTracking.Event.Kind : Swift.Equatable in Observation
+Added: _$s11Observation0A8TrackingV5EventV4KindVSQAAMc
+
+// Observation.ObservationTracking.Event.kind.getter : Observation.ObservationTracking.Event.Kind
+Added: _$s11Observation0A8TrackingV5EventV4kindAE4KindVvg
+
+// Observation.ObservationTracking.Event.cancel() -> ()
+Added: _$s11Observation0A8TrackingV5EventV6cancelyyF
+
+// Observation.ObservationTracking.Event.matches<A where A: Observation.Observable>(Swift.PartialKeyPath<A>) -> Swift.Bool
+Added: _$s11Observation0A8TrackingV5EventV7matchesySbs14PartialKeyPathCyxGAA10ObservableRzlF
+
+// type metadata accessor for Observation.ObservationTracking.Event
+Added: _$s11Observation0A8TrackingV5EventVMa
+
+// nominal type descriptor for Observation.ObservationTracking.Event
+Added: _$s11Observation0A8TrackingV5EventVMn
+
+// type metadata for Observation.ObservationTracking.Event
+Added: _$s11Observation0A8TrackingV5EventVN
+
+// Observation.ObservationTracking.Token.cancel() -> ()
+Added: _$s11Observation0A8TrackingV5TokenV6cancelyyF
+
+// type metadata accessor for Observation.ObservationTracking.Token
+Added: _$s11Observation0A8TrackingV5TokenVMa
+
+// nominal type descriptor for Observation.ObservationTracking.Token
+Added: _$s11Observation0A8TrackingV5TokenVMn
+
+// type metadata for Observation.ObservationTracking.Token
+Added: _$s11Observation0A8TrackingV5TokenVN
+
+// Observation.ObservationTracking.Token.deinit
+Added: _$s11Observation0A8TrackingV5TokenVfD
+
+// Observation.ObservationTracking.Options.init(arrayLiteral: Observation.ObservationTracking.Options...) -> Observation.ObservationTracking.Options
+Added: _$s11Observation0A8TrackingV7OptionsV12arrayLiteralA2Ed_tcfC
+
+// Observation.ObservationTracking.Options.intersection(Observation.ObservationTracking.Options) -> Observation.ObservationTracking.Options
+Added: _$s11Observation0A8TrackingV7OptionsV12intersectionyA2EF
+
+// Observation.ObservationTracking.Options.formIntersection(Observation.ObservationTracking.Options) -> ()
+Added: _$s11Observation0A8TrackingV7OptionsV16formIntersectionyyAEF
+
+// Observation.ObservationTracking.Options.symmetricDifference(Observation.ObservationTracking.Options) -> Observation.ObservationTracking.Options
+Added: _$s11Observation0A8TrackingV7OptionsV19symmetricDifferenceyA2EF
+
+// Observation.ObservationTracking.Options.formSymmetricDifference(Observation.ObservationTracking.Options) -> ()
+Added: _$s11Observation0A8TrackingV7OptionsV23formSymmetricDifferenceyyAEF
+
+// static Observation.ObservationTracking.Options.== infix(Observation.ObservationTracking.Options, Observation.ObservationTracking.Options) -> Swift.Bool
+Added: _$s11Observation0A8TrackingV7OptionsV2eeoiySbAE_AEtFZ
+
+// Observation.ObservationTracking.Options.union(Observation.ObservationTracking.Options) -> Observation.ObservationTracking.Options
+Added: _$s11Observation0A8TrackingV7OptionsV5unionyA2EF
+
+// static Observation.ObservationTracking.Options.deinit.getter : Observation.ObservationTracking.Options
+Added: _$s11Observation0A8TrackingV7OptionsV6deinitAEvgZ
+
+// property descriptor for static Observation.ObservationTracking.Options.deinit : Observation.ObservationTracking.Options
+Added: _$s11Observation0A8TrackingV7OptionsV6deinitAEvpZMV
+
+// static Observation.ObservationTracking.Options.didSet.getter : Observation.ObservationTracking.Options
+Added: _$s11Observation0A8TrackingV7OptionsV6didSetAEvgZ
+
+// property descriptor for static Observation.ObservationTracking.Options.didSet : Observation.ObservationTracking.Options
+Added: _$s11Observation0A8TrackingV7OptionsV6didSetAEvpZMV
+
+// Observation.ObservationTracking.Options.insert(Observation.ObservationTracking.Options) -> (inserted: Swift.Bool, memberAfterInsert: Observation.ObservationTracking.Options)
+Added: _$s11Observation0A8TrackingV7OptionsV6insertySb8inserted_AE17memberAfterInserttAEF
+
+// Observation.ObservationTracking.Options.remove(Observation.ObservationTracking.Options) -> Observation.ObservationTracking.Options?
+Added: _$s11Observation0A8TrackingV7OptionsV6removeyAESgAEF
+
+// Observation.ObservationTracking.Options.update(with: Observation.ObservationTracking.Options) -> Observation.ObservationTracking.Options?
+Added: _$s11Observation0A8TrackingV7OptionsV6update4withAESgAE_tF
+
+// static Observation.ObservationTracking.Options.willSet.getter : Observation.ObservationTracking.Options
+Added: _$s11Observation0A8TrackingV7OptionsV7willSetAEvgZ
+
+// property descriptor for static Observation.ObservationTracking.Options.willSet : Observation.ObservationTracking.Options
+Added: _$s11Observation0A8TrackingV7OptionsV7willSetAEvpZMV
+
+// Observation.ObservationTracking.Options.contains(Observation.ObservationTracking.Options) -> Swift.Bool
+Added: _$s11Observation0A8TrackingV7OptionsV8containsySbAEF
+
+// Observation.ObservationTracking.Options.formUnion(Observation.ObservationTracking.Options) -> ()
+Added: _$s11Observation0A8TrackingV7OptionsV9formUnionyyAEF
+
+// Observation.ObservationTracking.Options.init() -> Observation.ObservationTracking.Options
+Added: _$s11Observation0A8TrackingV7OptionsVAEycfC
+
+// type metadata accessor for Observation.ObservationTracking.Options
+Added: _$s11Observation0A8TrackingV7OptionsVMa
+
+// nominal type descriptor for Observation.ObservationTracking.Options
+Added: _$s11Observation0A8TrackingV7OptionsVMn
+
+// type metadata for Observation.ObservationTracking.Options
+Added: _$s11Observation0A8TrackingV7OptionsVN
+
+// protocol conformance descriptor for Observation.ObservationTracking.Options : Swift.Equatable in Observation
+Added: _$s11Observation0A8TrackingV7OptionsVSQAAMc
+
+// protocol conformance descriptor for Observation.ObservationTracking.Options : Swift.SetAlgebra in Observation
+Added: _$s11Observation0A8TrackingV7OptionsVs10SetAlgebraAAMc
+
+// protocol conformance descriptor for Observation.ObservationTracking.Options : Swift.ExpressibleByArrayLiteral in Observation
+Added: _$s11Observation0A8TrackingV7OptionsVs25ExpressibleByArrayLiteralAAMc
+
+

--- a/test/abi/macOS/x86_64/observation.swift
+++ b/test/abi/macOS/x86_64/observation.swift
@@ -235,4 +235,8 @@ Added: _$s11Observation0A8TrackingV7OptionsVs10SetAlgebraAAMc
 // protocol conformance descriptor for Observation.ObservationTracking.Options : Swift.ExpressibleByArrayLiteral in Observation
 Added: _$s11Observation0A8TrackingV7OptionsVs25ExpressibleByArrayLiteralAAMc
 
+// Observation.withContinuousObservation(options: Observation.ObservationTracking.Options, apply: @isolated(any) @Sendable (Observation.ObservationTracking.Event) -> ()) -> Observation.ObservationTracking.Token
+Added: _$s11Observation014withContinuousA07options5applyAA0A8TrackingV5TokenVAF7OptionsV_yAF5EventVYbYActF
 
+// Observation.withObservationTracking<A, B where B: Swift.Error, A: ~Swift.Copyable>(options: Observation.ObservationTracking.Options, _: () throws(B) -> A, onChange: @Sendable (Observation.ObservationTracking.Event) -> ()) throws(B) -> A
+Added: _$s11Observation04withA8Tracking7options_8onChangexAA0aC0V7OptionsV_xyq_YKXEyAF5EventVYbctq_YKs5ErrorR_Ri_zr0_lF

--- a/test/stdlib/Observation/Observable.swift
+++ b/test/stdlib/Observation/Observable.swift
@@ -290,7 +290,7 @@ final class CowTest {
 @main
 struct Validator {
   @MainActor
-  static func main() {
+  static func main() async {
 
     
     let suite = TestSuite("Observable")
@@ -532,7 +532,7 @@ struct Validator {
       let changed = CapturedState(state: false)
 
       let test = MiddleNamePerson()
-      withObservationTracking(options: .willSet) {
+      withObservationTracking(options: .didSet) {
         _blackHole(test.firstName)
       } onChange: { _ in
         changed.state = true
@@ -598,9 +598,13 @@ struct Validator {
       try! await Task.sleep(for: .seconds(0.1))
       expectEqual(changed.state, 3)
       token.cancel()
+      try! await Task.sleep(for: .seconds(0.1)) // ensure a small grace w.r.t. cancellation
+      test.firstName = "e"
+      try! await Task.sleep(for: .seconds(0.1))
+      expectEqual(changed.state, 3)
     }
 
-    runAllTests()
+    await runAllTestsAsync()
   }
 }
 

--- a/test/stdlib/Observation/Observable.swift
+++ b/test/stdlib/Observation/Observable.swift
@@ -581,6 +581,25 @@ struct Validator {
         expectEqual(changed.state, true)
     }
 
+    suite.test("continuous tracking") {
+      let changed = CapturedState(state: 0)
+      let test: MiddleNamePerson = MiddleNamePerson()
+      let token = withContinuousObservation(options: .didSet) { _ in
+        _blackHole(test.firstName)
+        changed.state += 1
+      }
+      // the sleeps here are intended to be a simulation of returning to the main run loop
+      try! await Task.sleep(for: .seconds(0.1))
+      expectEqual(changed.state, 1)
+      test.firstName = "c"
+      try! await Task.sleep(for: .seconds(0.1))
+      expectEqual(changed.state, 2)
+      test.firstName = "d"
+      try! await Task.sleep(for: .seconds(0.1))
+      expectEqual(changed.state, 3)
+      token.cancel()
+    }
+
     runAllTests()
   }
 }

--- a/test/stdlib/Observation/Observable.swift
+++ b/test/stdlib/Observation/Observable.swift
@@ -511,6 +511,76 @@ struct Validator {
       expectEqual(subject.container.id, startId)
     }
 
+    suite.test("tracking changes willSet option") {
+      let changed = CapturedState(state: false)
+
+      let test = MiddleNamePerson()
+      withObservationTracking(options: .willSet) {
+        _blackHole(test.firstName)
+      } onChange: { _ in
+        changed.state = true
+      }
+
+      test.firstName = "c"
+      expectEqual(changed.state, true)
+      changed.state = false
+      test.firstName = "c"
+      expectEqual(changed.state, false)
+    }
+
+    suite.test("tracking changes didSet option") {
+      let changed = CapturedState(state: false)
+
+      let test = MiddleNamePerson()
+      withObservationTracking(options: .willSet) {
+        _blackHole(test.firstName)
+      } onChange: { _ in
+        changed.state = true
+      }
+
+      test.firstName = "c"
+      expectEqual(changed.state, true)
+      changed.state = false
+      test.firstName = "c"
+      expectEqual(changed.state, false)
+    }
+
+    suite.test("tracking changes willSet & didSet option") {
+        let changed = CapturedState(state: 0)
+
+        let test = MiddleNamePerson()
+        withObservationTracking(options: [.willSet, .didSet]) {
+          _blackHole(test.firstName)
+        } onChange: { _ in
+          changed.state += 1
+        }
+
+        test.firstName = "c"
+        expectEqual(changed.state, 2) // an event is triggered for both the willSet and the didSet
+        changed.state = 0
+        test.firstName = "c"
+        expectEqual(changed.state, 0)
+    }
+
+    suite.test("tracking changes deinit option") {
+        let changed = CapturedState(state: false)
+
+        var test: MiddleNamePerson? = MiddleNamePerson()
+        withObservationTracking(options: .deinit) {
+          _blackHole(test?.firstName)
+        } onChange: { _ in
+          changed.state = true
+        }
+
+        test?.firstName = "c"
+        expectEqual(changed.state, false)
+        changed.state = false
+        test?.firstName = "c"
+        expectEqual(changed.state, false)
+        test = nil
+        expectEqual(changed.state, true)
+    }
+
     runAllTests()
   }
 }


### PR DESCRIPTION
This is the implementation for https://github.com/swiftlang/swift-evolution/blob/main/proposals/0506-advanced-observation-tracking.md and additionally two bug fixes around termination events.

This adds two new entry points for tracking observations. One new one-shot api that has a new options parameter for controlling events and one new continuous form that is a callback version of Observations.

Bug fixes:

Previously `Observations` had a very small but still present window of opportunity during deinitialization to miss an event and leave the AsyncSequence never emitting a final event but never finishing. Primarily this could occur when a weakly referenced `@Observable` type was deinitialized from another isolation than the observation itself. This current implementation leverages the new options parameter to account for the deinitailization. 

Both `Observations` and `withObservationTracking` where susceptible to a very small race condition where there was a window of opportunity of a secondary isolation to mutate a tracked property while the setup of the observation was being called. Self isolation mutation during the setup cannot be reported since that would distinctly cause recursive failures in both observation based code but also code like SwiftUI using it so the same isolation must be ignored, however external isolation changes have now been addressed by verifying the tracking lists against the potential "dirty-ness" of a property. This fixes https://github.com/swiftlang/swift/issues/83359.