### PR TITLE
[Runtime] Remove clang:: from clang::no_unique_address.

### DIFF
--- a/stdlib/public/runtime/StackAllocator.h
+++ b/stdlib/public/runtime/StackAllocator.h
@@ -89,7 +89,7 @@ private:
 #if defined(_MSC_VER)
   [[msvc::no_unique_address]]
 #elif defined(__clang__)
-  [[clang::no_unique_address]]
+  [[no_unique_address]]
 #endif
   SlabAllocatorConfiguration configuration;
 


### PR DESCRIPTION
Clang only recognizes [[no_unique_address]] or [[msvc::no_unique_address]] depending on the target.