### PR TITLE
Mark failing Android tests as unsupported

### DIFF
--- a/test/Interop/Cxx/class/noncopyable-irgen.swift
+++ b/test/Interop/Cxx/class/noncopyable-irgen.swift
@@ -8,6 +8,8 @@
 // RUN: %target-swift-frontend -cxx-interoperability-mode=default -emit-ir -I %swift_src_root/lib/ClangImporter/SwiftBridging -I %t%{fs-sep}Inputs %t%{fs-sep}test.swift -Xcc -fignore-exceptions -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}noncopyable.h -verify-additional-prefix TEST6- -D TEST6
 // RUN: %target-swift-frontend -cxx-interoperability-mode=default -emit-ir -I %swift_src_root/lib/ClangImporter/SwiftBridging -I %t%{fs-sep}Inputs %t%{fs-sep}test.swift -Xcc -fignore-exceptions -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}noncopyable.h -verify-additional-prefix TEST7-%target-os-family- -verify-additional-prefix TEST7-%target-os- -D TEST7 -Xcc -DTEST7 -Xcc -std=c++20 -verify-ignore-unrelated
 
+// UNSUPPORTED: OS=linux-android, OS=linux-androideabi
+
 //--- Inputs/module.modulemap
 module Test {
     header "noncopyable.h"

--- a/test/Interop/Cxx/stdlib/use-std-optional-lib.swift
+++ b/test/Interop/Cxx/stdlib/use-std-optional-lib.swift
@@ -1,5 +1,7 @@
 // RUN: %target-build-swift %s -emit-module -emit-library -cxx-interoperability-mode=default -module-name OptionalLib -emit-module-path %t/artifacts/OptionalLib.swiftmodule -I %S/Inputs -O
 
+// UNSUPPORTED: OS=linux-android, OS=linux-androideabi
+
 import StdOptional
 import CxxStdlib
 


### PR DESCRIPTION
Unblocking nightly toolchain snapshots due to failing Android builds https://ci.swift.org/job/oss-swift-package-swift-sdk-for-android/202/