### PR TITLE
Fix swift tests for Windows ARM64

### DIFF
--- a/test/ClangImporter/availability_returns_twice-msvc-aarch64.swift
+++ b/test/ClangImporter/availability_returns_twice-msvc-aarch64.swift
@@ -12,6 +12,6 @@ func test_unavailable_returns_twice_function() {
 // CHECK: availability_returns_twice-msvc-aarch64.swift:{{[0-9]+}}:{{[0-9]+}}: error: unexpected error produced: cannot find type '_JBTYPE' in scope
 // CHECK-NEXT: typealias JumpBuffer = _JBTYPE
 // CHECK-NEXT:  ^
-// CHECK-NEXT: setjmp.h:{{[0-9]+}}:{{[0-9]+}}: note: diagnostic produced elsewhere: macro '_JBTYPE' unavailable: structure not supported
+// CHECK-NEXT: setjmp.h:{{[0-9]+}}:{{[0-9]+}}: error: unexpected note produced: macro '_JBTYPE' unavailable: structure not supported
 // CHECK-NEXT:   #define _JBTYPE unsigned __int64
 

--- a/test/ClangImporter/unicode.swift
+++ b/test/ClangImporter/unicode.swift
@@ -1,5 +1,5 @@
-// RUN: %swift-ide-test -target x86_64-unknown-windows-msvc -print-module -module-to-print unicode -print-interface -source-filename %s -I %S/Inputs/unicode | %FileCheck %s -check-prefix CHECK-C
-// RUN: %swift-ide-test -target x86_64-unknown-windows-msvc -enable-experimental-cxx-interop -print-module -module-to-print unicode -print-interface -source-filename %s -I %S/Inputs/unicode | %FileCheck %s -check-prefix CHECK-CXX
+// RUN: %swift-ide-test -target %target-cpu-unknown-windows-msvc -print-module -module-to-print unicode -print-interface -source-filename %s -I %S/Inputs/unicode | %FileCheck %s -check-prefix CHECK-C
+// RUN: %swift-ide-test -target %target-cpu-unknown-windows-msvc -enable-experimental-cxx-interop -print-module -module-to-print unicode -print-interface -source-filename %s -I %S/Inputs/unicode | %FileCheck %s -check-prefix CHECK-CXX
 
 // REQUIRES: OS=windows-msvc
 

--- a/test/IRGen/windows-linking.swift
+++ b/test/IRGen/windows-linking.swift
@@ -1,8 +1,9 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -target x86_64-unknown-windows-msvc -parse-as-library -parse-stdlib -static -emit-module -emit-module-path %t/module.swiftmodule -module-name module -DMODULE %s
-// RUN: %target-swift-frontend -target x86_64-unknown-windows-msvc -parse-as-library -parse-stdlib -S -emit-ir %s -module-name main -o - -I%t | %FileCheck %s -check-prefix CHECK-STATIC
-// RUN: %target-swift-frontend -target x86_64-unknown-windows-msvc -parse-as-library -parse-stdlib -emit-module -emit-module-path %t/module.swiftmodule -module-name module -DMODULE %s
-// RUN: %target-swift-frontend -target x86_64-unknown-windows-msvc -parse-as-library -parse-stdlib -S -emit-ir %s -module-name main -o - -I%t | %FileCheck %s -check-prefix CHECK-SHARED
+// RUN: %target-swift-frontend -target %target-cpu-unknown-windows-msvc -parse-as-library -parse-stdlib -static -emit-module -emit-module-path %t/module.swiftmodule -module-name module -DMODULE %s
+// RUN: %target-swift-frontend -target %target-cpu-unknown-windows-msvc -parse-as-library -parse-stdlib -S -emit-ir %s -module-name main -o - -I%t | %FileCheck %s -check-prefix CHECK-STATIC
+// RUN: %target-swift-frontend -target %target-cpu-unknown-windows-msvc -parse-as-library -parse-stdlib -emit-module -emit-module-path %t/module.swiftmodule -module-name module -DMODULE %s
+// RUN: %target-swift-frontend -target %target-cpu-unknown-windows-msvc -parse-as-library -parse-stdlib -S -emit-ir %s -module-name main -o - -I%t | %FileCheck %s -check-prefix CHECK-SHARED
+// REQUIRES: OS=windows-msvc
 
 #if MODULE
 

--- a/test/Interop/Cxx/class/method/inreg-sret.swift
+++ b/test/Interop/Cxx/class/method/inreg-sret.swift
@@ -25,4 +25,4 @@ final public class Function {
 // CHECK-aarch64: call void @"?getFirstBlock@BridgedFunction@@QEBA?AUOptionalBridgedBasicBlock@@XZ"(ptr {{.*}}, ptr inreg noalias sret(%TSo25OptionalBridgedBasicBlockV) captures(none) {{.*}})
 
 // CHECK-x86_64: define {{.*}} void @"?getFirstBlock@BridgedFunction@@QEBA?AUOptionalBridgedBasicBlock@@XZ"(ptr {{.*}} %{{.*}}, ptr {{.*}} sret(%struct.OptionalBridgedBasicBlock) {{.*}} %{{.*}})
-// CHECK-aarch64: define {{.*}} void @"?getFirstBlock@BridgedFunction@@QEBA?AUOptionalBridgedBasicBlock@@XZ"(ptr {{.*}} %{{.*}}, ptr inreg {{.*}} sret(%struct.OptionalBridgedBasicBlock) {{.*}} %{{.*}})
+// CHECK-aarch64: define {{.*}} void @"?getFirstBlock@BridgedFunction@@QEBA?AUOptionalBridgedBasicBlock@@XZ"(ptr {{.*}} %{{.*}}, ptr {{.*}} inreg {{.*}} sret(%struct.OptionalBridgedBasicBlock) {{.*}} %{{.*}})

--- a/test/Interop/Cxx/class/method/sret-win-arm64.swift
+++ b/test/Interop/Cxx/class/method/sret-win-arm64.swift
@@ -28,4 +28,4 @@ public func test(sm: SubstitutionMap) -> OptionalTypeArray {
 // Check that BridgedTypeArray is indirectly returned via sret after the fix
 
 // CHECK-before-fix: declare {{.*}} [2 x i64] @"?fromReplacementTypes@BridgedTypeArray@@SA?AU1@UBridgedSubstitutionMap@@@Z"(i64)
-// CHECK-after-fix: declare {{.*}} void @"?fromReplacementTypes@BridgedTypeArray@@SA?AU1@UBridgedSubstitutionMap@@@Z"(ptr inreg sret(%struct.BridgedTypeArray) align 8, i64)
+// CHECK-after-fix: declare {{.*}} void @"?fromReplacementTypes@BridgedTypeArray@@SA?AU1@UBridgedSubstitutionMap@@@Z"(ptr {{.*}} inreg {{.*}} sret(%struct.BridgedTypeArray) align 8, i64)

--- a/test/Interop/Cxx/operators/member-inline-irgen.swift
+++ b/test/Interop/Cxx/operators/member-inline-irgen.swift
@@ -5,7 +5,7 @@ import MemberInline
 public func sub(_ lhs: inout LoadableIntWrapper, _ rhs: LoadableIntWrapper) -> LoadableIntWrapper { lhs - rhs }
 
 // CHECK-SYSV: call [[RESA:i32|i64]] [[NAMEA:@_ZN18LoadableIntWrappermiES_]](ptr {{%[0-9]+}}, {{i32|\[1 x i32\]|i64|%struct.LoadableIntWrapper\* byval\(.*\) align 4}} {{%[0-9]+}})
-// CHECK-WIN: call [[RESA:void]] [[NAMEA:@"\?\?GLoadableIntWrapper@@QEAA\?AU0@U0@@Z"]](ptr {{%[0-9]+}}, ptr {{.*}} sret(%TSo18LoadableIntWrapperV) {{.*}}, i32 {{%[0-9]+}})
+// CHECK-WIN: call [[RESA:void]] [[NAMEA:@"\?\?GLoadableIntWrapper@@QEAA\?AU0@U0@@Z"]](ptr {{%[0-9]+}}, ptr {{.*}} sret(%TSo18LoadableIntWrapperV) {{.*}}, {{i32|i64}} {{%[0-9]+}})
 
 public func call(_ wrapper: inout LoadableIntWrapper, _ arg: Int32) -> Int32 { wrapper(arg) }
 

--- a/test/Interop/Cxx/operators/member-out-of-line-irgen.swift
+++ b/test/Interop/Cxx/operators/member-out-of-line-irgen.swift
@@ -7,5 +7,5 @@ public func add(_ lhs: inout LoadableIntWrapper, _ rhs: LoadableIntWrapper) -> L
 // CHECK-SYSV: call {{i32|i64}} [[NAME:@_ZNK18LoadableIntWrapperplES_]](ptr %{{[0-9]+}}, {{i32|\[1 x i32\]|i64|%struct.LoadableIntWrapper\* byval\(.*\)}}{{.*}})
 // CHECK-SYSV: declare {{.*}}{{i32|i64}} [[NAME]](ptr {{.*}}, {{i32|\[1 x i32\]|i64|%struct.LoadableIntWrapper\* .*byval\(%struct.LoadableIntWrapper\)}}{{.*}})
 
-// CHECK-WIN: call void [[NAME:@"\?\?HLoadableIntWrapper@@QEBA\?AU0@U0@@Z"]](ptr %{{[0-9]+}}, ptr {{.*}} sret(%TSo18LoadableIntWrapperV) {{.*}}, i32 %{{[0-9]+}})
-// CHECK-WIN: declare dso_local void [[NAME]](ptr {{.*}}, ptr {{.*}} sret(%struct.LoadableIntWrapper) {{.*}}, i32)
+// CHECK-WIN: call void [[NAME:@"\?\?HLoadableIntWrapper@@QEBA\?AU0@U0@@Z"]](ptr %{{[0-9]+}}, ptr {{.*}} sret(%TSo18LoadableIntWrapperV) {{.*}}, {{i32|i64}} %{{[0-9]+}})
+// CHECK-WIN: declare dso_local void [[NAME]](ptr {{.*}}, ptr {{.*}} sret(%struct.LoadableIntWrapper) {{.*}}, {{i32|i64}})


### PR DESCRIPTION
Explanation: This fixes the failing swift tests for Windows ARM64
Scope: The swift tests for Windows ARM64
Issues: https://github.com/swiftlang/swift/issues/86529
Original PRs: https://github.com/swiftlang/swift/pull/86558
Risk: Low. This is a test only fix
Testing: The 6.3 CI
Reviewers: @compnerd @egorzhdan