### PR TITLE
[stdlib, 6.3] mark `OutputRawSpan.storeBytes()` with `@unsafe`

### DIFF
--- a/stdlib/public/core/Span/OutputRawSpan.swift
+++ b/stdlib/public/core/Span/OutputRawSpan.swift
@@ -208,6 +208,7 @@ extension OutputRawSpan {
 extension OutputRawSpan {
   /// Appends the given value's bytes to this span's bytes.
   @_alwaysEmitIntoClient
+  @unsafe
   @lifetime(self: copy self)
   public mutating func append<T: BitwiseCopyable>(_ value: T, as type: T.Type) {
     _precondition(
@@ -219,6 +220,7 @@ extension OutputRawSpan {
 
   /// Appends the given value's bytes repeatedly to this span's bytes.
   @_alwaysEmitIntoClient
+  @unsafe
   @lifetime(self: copy self)
   public mutating func append<T: BitwiseCopyable>(
     repeating repeatedValue: T, count: Int, as type: T.Type


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift/pull/86718

**Explanation**: When storing a value of a type with internal padding in its representation, the padding bytes could be left uninitialized. This is contrary to the stated precondition of `RawSpan` that all its bytes are initialized. This marks the current `append(_:as:)` and `append(repeating:as:)` functions as `@unsafe`.

**Scope**: correctness fix
**Risk**: low. Projects that build with "-strict-memory-safety" may get new warnings due to this bug fix.
**Testing**: existing tests slightly changed
**Issue**: Addresses rdar://168561707
**Reviewer**: @stephentyrone 