### PR TITLE
[test] adjust test for watchOS compatibility

### DIFF
--- a/test/stdlib/UTF8SpanQueriesComparisons.swift
+++ b/test/stdlib/UTF8SpanQueriesComparisons.swift
@@ -203,7 +203,11 @@ if #available(SwiftStdlib 6.2, *) {
     }
 
     let a = Span<UInt8>()
-    let b: Span<UInt8> = "isTriviallyIdentical(to:)".utf8.span
+
+    var s = "isTriviallyIdentical(to:)"
+    s.makeContiguousUTF8()
+    guard let b = expectNotNil(s.utf8._span) else { return }
+
     let c = b.extracting(first: 20)
     let d = b.extracting(last: 23)
     let e = c.extracting(last: 18)


### PR DESCRIPTION
This test was written to use `String.UTF8View`'s `span` property, which is unavailable on 32-bit watchOS. This PR adjusts the test so that it can run successfully on 32-bit watchOS.

Addresses rdar://166692988