### PR TITLE
BridgingHeader: Don't warn on using the internal bridging header without library-evolution

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -591,9 +591,6 @@ ERROR(no_swift_sources_with_embedded,none,
 ERROR(package_cmo_requires_library_evolution, none,
         "Library evolution must be enabled for Package CMO", ())
 
-WARNING(internal_bridging_header_without_library_evolution,none,
-        "using internal bridging headers without library evolution can cause instability", ())
-
 ERROR(error_invalid_clang_header_access_level, none,
       "invalid minimum clang header access level '%0'; chose from "
       "'public'|'package'|'internal'",

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2239,14 +2239,6 @@ static bool ParseClangImporterArgs(ClangImporterOptions &Opts, ArgList &Args,
     Opts.BridgingHeaderIsInternal = importAsInternal;
   }
 
-  // Until we have some checking in place, internal bridging headers are a
-  // bit unsafe without library evolution.
-  if (Opts.BridgingHeaderIsInternal &&
-      !LangOpts.hasFeature(Feature::LibraryEvolution)) {
-    Diags.diagnose(SourceLoc(),
-                   diag::internal_bridging_header_without_library_evolution);
-  }
-
   Opts.DisableSwiftBridgeAttr |= Args.hasArg(OPT_disable_swift_bridge_attr);
 
   Opts.DisableOverlayModules |= Args.hasArg(OPT_emit_imported_modules);

--- a/test/ClangImporter/InternalBridgingHeader/implementation_only_checking.swift
+++ b/test/ClangImporter/InternalBridgingHeader/implementation_only_checking.swift
@@ -2,14 +2,16 @@
 // RUN: mkdir -p %t/tmp
 
 // Test with the normal bridging header.
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -internal-import-bridging-header %S/../Inputs/c-bridging-header.h -sdk %clang-importer-sdk -verify-ignore-unknown -swift-version 5
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -internal-import-bridging-header %S/../Inputs/c-bridging-header.h -sdk %clang-importer-sdk -verify-ignore-unknown -swift-version 5 -verify-additional-prefix non-library-evolution-
 
 // RUN: not %target-swift-frontend -typecheck -internal-import-bridging-header %S/../Inputs/c-bridging-header.h -sdk %clang-importer-sdk %s 2>&1 | %FileCheck %s
 
 // Test with a precompiled bridging header.
 // RUN: %target-swift-frontend -emit-pch -o %t/c-bridging-header.pch %S/../Inputs/c-bridging-header.h -sdk %clang-importer-sdk -swift-version 5
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -internal-import-bridging-header %t/c-bridging-header.pch -sdk %clang-importer-sdk -verify-ignore-unknown -swift-version 5
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -internal-import-bridging-header %t/c-bridging-header.pch -sdk %clang-importer-sdk -verify-ignore-unknown -swift-version 5 -verify-additional-prefix non-library-evolution-
 
+// Test library-evolution differences.
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -internal-import-bridging-header %S/../Inputs/c-bridging-header.h -sdk %clang-importer-sdk -verify-ignore-unknown -swift-version 5 -enable-library-evolution
 
 @inlinable
 public func f() -> Any {
@@ -27,9 +29,9 @@ public struct FrozenStruct {
 }
 
 public struct PublicStruct {
-    var p: MyPoint // expected-error {{cannot use struct 'MyPoint' in a property declaration member of a type not marked '@_implementationOnly'; it was imported via the internal bridging header}}
+    var p: MyPoint // expected-non-library-evolution-error {{cannot use struct 'MyPoint' in a property declaration member of a type not marked '@_implementationOnly'; it was imported via the internal bridging header}}
 }
 
 internal struct InternalStruct {
-    var p: MyPoint // expected-error {{cannot use struct 'MyPoint' in a property declaration member of a type not marked '@_implementationOnly'; it was imported via the internal bridging header}}
+    var p: MyPoint // expected-non-library-evolution-error {{cannot use struct 'MyPoint' in a property declaration member of a type not marked '@_implementationOnly'; it was imported via the internal bridging header}}
 }

--- a/test/ClangImporter/InternalBridgingHeader/library_evolution.swift
+++ b/test/ClangImporter/InternalBridgingHeader/library_evolution.swift
@@ -1,10 +1,8 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -internal-import-bridging-header %S/../Inputs/c-bridging-header.h -sdk %clang-importer-sdk %s 2>&1 | %FileCheck -check-prefix NONRESILIENT %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -internal-import-bridging-header %S/../Inputs/c-bridging-header.h -sdk %clang-importer-sdk %s 2>&1 | %FileCheck %s
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -internal-import-bridging-header %S/../Inputs/c-bridging-header.h -sdk %clang-importer-sdk %s -enable-library-evolution 2>&1 | %FileCheck -check-prefix EVOLUTION %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -internal-import-bridging-header %S/../Inputs/c-bridging-header.h -sdk %clang-importer-sdk %s -enable-library-evolution 2>&1 | %FileCheck %s
 
-// NONRESILIENT: warning: using internal bridging headers without library evolution can cause instability
-
-// EVOLUTION-NOT: internal bridging head
+// CHECK-NOT: internal bridging head
 
 @available(*, deprecated)
 func f() { }


### PR DESCRIPTION
Since #86565 we check internal bridging headers for all known issues when hiding dependencies without library-evolution. Let's lift the warning against it as it should now be safe.

We removed the equivalent warning on `@_implementationOnly` imports in #86335.

As a bonus, add a few tests comparing the internal bridging header behavior with and without library-evolution.