### PR TITLE
[CSBindings] PotentialBindings: De-duplicate defaults based on type

### DIFF
--- a/test/Constraints/array_literal.swift
+++ b/test/Constraints/array_literal.swift
@@ -425,3 +425,16 @@ do {
     let _: [(String, String)] = f { return Array(v) } + v // Ok
   }
 }
+
+// Make sure that sbutyping works with empty literals.
+do {
+  class A {}
+
+  class B: A {}
+
+  func takesSequence<S>(_: S, _: S) where S: Sequence, S.Element: Sequence, S.Element.Element == A.Type {}
+
+  func test() {
+    takesSequence([[B.self]], [])
+  }
+}


### PR DESCRIPTION
It's possible to infer the same default type from multiple different default constraints, especially via transitive inference. Let's de-duplicate direct and transitive default bindings based on a type to avoid effects on type variable selection.

Resolves: rdar://168624965

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
