### PR TITLE
[6.3][silgen] Look through conversions that combine a Sendable and nonisolated(nonsending) conversion.

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2016,7 +2016,7 @@ RValueEmitter::emitFunctionCvtToExecutionCaller(FunctionConversionExpr *e,
   // nonisolated(nonsending) or @Sendable in the constraint evaluator.
   //
   // The reason why we need to evaluate this especially is that otherwise we
-  // generate multiple
+  // generate multiple conversion thunks.
 
   bool needsSendableConversion = false;
   if (auto *subCvt = dyn_cast<FunctionConversionExpr>(subExpr)) {
@@ -2037,11 +2037,11 @@ RValueEmitter::emitFunctionCvtToExecutionCaller(FunctionConversionExpr *e,
   }
 
   // Check if the only difference in between our destType and srcType is our
-  // isolation.
+  // isolation and optionally Sendable.
   if (!subExprType->hasExtInfo() || !destType->hasExtInfo() ||
-      destType->withIsolation(subExprType->getIsolation()) != subExprType) {
+      destType->withIsolation(subExprType->getIsolation())
+      ->withSendable(subExprType->isSendable()) != subExprType)
     return RValue();
-  }
 
   // Ok, we know that our underlying types are the same. Lets try to emit.
   auto *declRef = dyn_cast<DeclRefExpr>(subExpr);
@@ -2100,9 +2100,10 @@ RValue RValueEmitter::emitFunctionCvtFromExecutionCallerToGlobalActor(
       cast<FunctionType>(subCvt->getType()->getCanonicalType());
 
   // Src type should be isNonIsolatedCaller and they should only differ in
-  // isolation.
+  // isolation or sendability.
   if (!subCvtType->getIsolation().isNonIsolatedCaller() ||
-      subCvtType->withIsolation(destType->getIsolation()) != destType)
+      subCvtType->withIsolation(destType->getIsolation())
+              ->withSendable(destType->isSendable()) != destType)
     return RValue();
 
   // Grab our decl ref/its decl and make sure that our decl is actually caller


### PR DESCRIPTION

Explanation: We discovered that we were not pattern matching an artificial
conversion inserted by Sema. We were pattern matching if:

1. The conversion was a single conversion that added nonisolated(nonsending).
2. A two level conversion that had a first conversion to Sendable and a second
   to nonisolated(nonsending).

But not a conversion that combined the Sendable and nonisolated(nonsending)
conversion. Without this, we inserted a round trip isolation thunk in the
following:

```swift
nonisolated(nonsending) func globalCallerFunc() {}
nonisolated(nonsending) func localVariableAssignmentConversion() async {
  let c2 = globalCallerFunc
  await c2()
}
```

causing globalCallerFunc to be on the global concurrent queue instead of on the
caller queue.

To be consistent, I also updated the code that involved conversion from
execution caller to global actor as well in case we hit the same case there.

Scope: This can only impact cases where we have these artificial AST nodes since
we are pattern matching them very specifically. We should not be able to impact
any further code.
Issues: rdar://158685169
https://github.com/swiftlang/swift/issues/83812
Original PRs: https://github.com/swiftlang/swift/pull/86585

Risk: Low. We are tightly matching a specific pattern that is only inserted by
Sema in this specific case... so the worst that can happen is that we pattern
match this specific pattern in an additional case that causes the compiler to
crash... but that is pretty unlikely given how specific this is.

Testing: FileCheck compiler test
Reviewers: @xedin
