### PR TITLE
[cxx-interop] Skip over static_assert when importing members

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2442,7 +2442,7 @@ namespace {
       // FIXME: Import anonymous union fields and support field access when
       // it is nested in a struct.
       for (auto m : decl->decls()) {
-        if (isa<clang::AccessSpecDecl>(m)) {
+        if (isa<clang::AccessSpecDecl, clang::StaticAssertDecl>(m)) {
           // The presence of AccessSpecDecls themselves does not influence
           // whether we can generate a member-wise initializer.
           continue;

--- a/test/Interop/Cxx/class/Inputs/memberwise-initializer.h
+++ b/test/Interop/Cxx/class/Inputs/memberwise-initializer.h
@@ -72,4 +72,14 @@ public:
   using MyUsing = TemplatedType<T>;
 };
 
+struct ClassWithStaticAssert {
+  int x, y;
+  static_assert(true);
+};
+
+struct ClassWithStaticAssert2 {
+  static_assert(true);
+  int x, y;
+};
+
 #endif

--- a/test/Interop/Cxx/class/memberwise-initializer-module-interface.swift
+++ b/test/Interop/Cxx/class/memberwise-initializer-module-interface.swift
@@ -52,3 +52,15 @@
 // CHECK-NEXT:   init(varPublic: Int32)
 // CHECK-NEXT:   var varPublic: Int32
 // CHECK-NEXT: }
+// CHECK-NEXT: struct ClassWithStaticAssert {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   init(x: Int32, y: Int32)
+// CHECK-NEXT:   var x: Int32
+// CHECK-NEXT:   var y: Int32
+// CHECK-NEXT: }
+// CHECK-NEXT: struct ClassWithStaticAssert2 {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   init(x: Int32, y: Int32)
+// CHECK-NEXT:   var x: Int32
+// CHECK-NEXT:   var y: Int32
+// CHECK-NEXT: }

--- a/test/Interop/Cxx/class/memberwise-initializer-typechecker.swift
+++ b/test/Interop/Cxx/class/memberwise-initializer-typechecker.swift
@@ -15,3 +15,6 @@ let classEmptyPublicSection = ClassEmptyPublicSection(varPrivate: 42) // expecte
 let classPublicAndPrivate1 = ClassPrivateAndPublic(varPublic: 23)  // expected-error {{argument passed to call that takes no arguments}}
 let classPublicAndPrivate2 = ClassPrivateAndPublic(varPrivate: 42, varPublic: 23)  // expected-error {{argument passed to call that takes no arguments}}
 let classWithUnimportedMemberFunction = ClassWithUnimportedMemberFunction(varPublic: 42)
+
+let _ = ClassWithStaticAssert(x: 6, y: 7)
+let _ = ClassWithStaticAssert2(x: 6, y: 7)


### PR DESCRIPTION
Not doing so prevents member-wise initializers from being synthesized

Fixes #86730

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
