### PR TITLE
[Dependency Scanning] Use clang dependency scanning tool's old by-name lookup API

### DIFF
--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -326,9 +326,10 @@ ModuleDependencyScanningWorker::scanFilesystemForClangModuleDependency(
     const llvm::DenseSet<clang::tooling::dependencies::ModuleID>
         &alreadySeenModules) {
   diagnosticReporter.registerNamedClangModuleQuery();
-  auto clangModuleDependencies =
-      clangScanningTool.computeDependenciesByNameWithContext(
-          moduleName.str(), alreadySeenModules, lookupModuleOutput);
+  auto clangModuleDependencies = clangScanningTool.getModuleDependencies(
+      moduleName.str(), clangScanningModuleCommandLineArgs,
+      clangScanningWorkingDirectoryPath, alreadySeenModules,
+      lookupModuleOutput);
   if (!clangModuleDependencies) {
     llvm::handleAllErrors(
         clangModuleDependencies.takeError(),


### PR DESCRIPTION
https://github.com/swiftlang/swift/pull/85555 taught Swift to use a shared clang compiler instance that is initialized once and reused for multiple by-name lookups. This unfortunately led to a few internal project build failures. 

This PR reverts back to use clang dependency scanning tool's old by-name lookup APIs while we investigate the failures. 

rdar://168709914