### PR TITLE
[Embedded] Put dynamic exclusivity behind a second experimental feature 

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -587,7 +587,8 @@ ERROR(min_ptr_value_without_embedded,none,
       "-min-valid-pointer-value is only applicable with embedded Swift.", ())
 ERROR(no_swift_sources_with_embedded,none,
       "embedded swift cannot be enabled in a compiler built without Swift sources", ())
-
+WARNING(embedded_dynamic_exclusivity_staging,none,
+        "'-enforce-exclusivity=checked' is ignored in Embedded Swift unless also enabled by '-enable-experimental-feature EmbeddedDynamicExclusivity'", ())
 ERROR(package_cmo_requires_library_evolution, none,
         "Library evolution must be enabled for Package CMO", ())
 

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -562,6 +562,9 @@ SUPPRESSIBLE_EXPERIMENTAL_FEATURE(TildeSendable, false)
 /// Allow use of protocol typed values in Embedded mode (`Any` and friends)
 EXPERIMENTAL_FEATURE(EmbeddedExistentials, true)
 
+/// Allow enabling dynamic exclusivity in Embedded Swift.
+EXPERIMENTAL_FEATURE(EmbeddedDynamicExclusivity, true)
+
 /// Allow use of the 'anyAppleOS' availability domain.
 EXPERIMENTAL_FEATURE(AnyAppleOSAvailability, true)
 

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -130,6 +130,7 @@ UNINTERESTING_FEATURE(KeyPathWithMethodMembers)
 UNINTERESTING_FEATURE(ImportMacroAliases)
 UNINTERESTING_FEATURE(NoExplicitNonIsolated)
 UNINTERESTING_FEATURE(EmbeddedExistentials)
+UNINTERESTING_FEATURE(EmbeddedDynamicExclusivity)
 
 static bool usesFeatureUnderscoreOwned(Decl *D) {
   return D->getAttrs().hasAttribute<OwnedAttr>();

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3345,6 +3345,15 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
 
   if (const Arg *A = Args.getLastArg(options::OPT_enforce_exclusivity_EQ)) {
     parseExclusivityEnforcementOptions(A, Opts, Diags);
+
+    // In the short term, we ignore -enforce-exclusivity=checked unless
+    // in Embedded Swift unless EmbeddedDynamicExclusivity is also enabled.
+    if (LangOpts.hasFeature(Feature::Embedded) &&
+        Opts.EnforceExclusivityDynamic &&
+        !LangOpts.hasFeature(Feature::EmbeddedDynamicExclusivity)) {
+      Diags.diagnose(SourceLoc(), diag::embedded_dynamic_exclusivity_staging);
+      Opts.EnforceExclusivityDynamic = false;
+    }
   } else if (!Opts.RemoveRuntimeAsserts &&
              LangOpts.hasFeature(Feature::Embedded)) {
     // Embedded Swift defaults to -enforce-exclusivity=unchecked for now.

--- a/test/embedded/exclusivity.swift
+++ b/test/embedded/exclusivity.swift
@@ -1,9 +1,11 @@
-// RUN: %target-swift-frontend -emit-ir %s -enforce-exclusivity=checked -enable-experimental-feature Embedded -parse-as-library | %FileCheck -check-prefix DYNAMIC %s
+// RUN: %target-swift-frontend -emit-ir %s -enforce-exclusivity=checked -enable-experimental-feature Embedded -enable-experimental-feature EmbeddedDynamicExclusivity -parse-as-library | %FileCheck -check-prefix DYNAMIC %s
 // RUN: %target-swift-frontend -parse-as-library -emit-ir %s -enforce-exclusivity=unchecked -enable-experimental-feature Embedded | %FileCheck -check-prefix STATIC-ONLY %s
+// RUN: %target-swift-frontend -parse-as-library -emit-ir %s -enforce-exclusivity=checked -enable-experimental-feature Embedded | %FileCheck -check-prefix STATIC-ONLY %s
 // RUN: %target-swift-frontend -parse-as-library -emit-ir %s -enable-experimental-feature Embedded | %FileCheck -check-prefix STATIC-ONLY %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_Embedded
+// REQUIRES: swift_feature_EmbeddedDynamicExclusivity
 
 func f() -> Bool? { return nil }
 

--- a/test/embedded/exclusivity_experimental.swift
+++ b/test/embedded/exclusivity_experimental.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -typecheck -verify -enforce-exclusivity=checked 2>&1 | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_Embedded
+
+// CHECK: warning: '-enforce-exclusivity=checked' is ignored in Embedded Swift unless also enabled by '-enable-experimental-feature EmbeddedDynamicExclusivity'
+

--- a/test/embedded/exclusivity_runtime.swift
+++ b/test/embedded/exclusivity_runtime.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o -enforce-exclusivity=checked
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o -enforce-exclusivity=checked -enable-experimental-feature EmbeddedDynamicExclusivity
 
 // Single-threaded exclusivity checking implementation
 // RUN: %target-clang %t/a.o -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip -lswiftExclusivitySingleThreaded
@@ -9,6 +9,7 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_feature_Embedded
+// REQUIRES: swift_feature_EmbeddedDynamicExclusivity
 
 struct NC: ~Copyable {
   var i: Int = 1

--- a/test/embedded/exclusivity_runtime_multi.swift
+++ b/test/embedded/exclusivity_runtime_multi.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o -enforce-exclusivity=checked
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o -enforce-exclusivity=checked -enable-experimental-feature EmbeddedDynamicExclusivity
 
 // Multi-threaded exclusivity checking implementation (that uses C11 thread_local).
 // RUN: %target-clang %t/a.o -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip -lswiftExclusivityC11ThreadLocal
@@ -9,6 +9,7 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_feature_Embedded
+// REQUIRES: swift_feature_EmbeddedDynamicExclusivity
 
 // UNSUPPORTED: OS=wasip1
 


### PR DESCRIPTION
We need to stage in the behavior change to enable dynamic exclusivity
checking for Embedded Swift. For now, ignore
`-enforce-exclusivity=checked` in Embedded Swift unless the
experimental feature `EmbeddedDynamicExclusivity` is also enabled.

Addresses rdar://168618037, a regression in Embedded Swift code that
is passing `-enforce-exclusivity=checked` explicitly.