### PR TITLE
[test] Disable newly failing DebugInfo async-args test case and two other unmodified regressions on 32-bit platforms

### DIFF
--- a/test/DebugInfo/async-args.swift
+++ b/test/DebugInfo/async-args.swift
@@ -3,6 +3,7 @@
 // RUN:    -parse-as-library | %FileCheck %s
 
 // REQUIRES: concurrency
+// REQUIRES: PTRSIZE=64
 
 func use<T>(_ t: T) {}
 func forceSplit() async {

--- a/test/DebugInfo/async-lifetime-extension.swift
+++ b/test/DebugInfo/async-lifetime-extension.swift
@@ -2,6 +2,7 @@
 // RUN:    -module-name a  -target %target-swift-5.1-abi-triple \
 // RUN:    | %FileCheck %s --check-prefix=CHECK
 // REQUIRES: concurrency
+// REQUIRES: PTRSIZE=64
 
 // Test that lifetime extension preserves a dbg.declare for "n" in the resume
 // funclet.

--- a/test/DebugInfo/async-task-alloc.swift
+++ b/test/DebugInfo/async-task-alloc.swift
@@ -2,6 +2,7 @@
 // RUN:    -module-name a  -target %target-swift-5.1-abi-triple \
 // RUN:    | %FileCheck %s --check-prefix=CHECK
 // REQUIRES: concurrency
+// REQUIRES: PTRSIZE=64
 
 // Test dynamically allocated local variables in async functions.
 


### PR DESCRIPTION
@shahmishal and @MaxDesiatov, these [just started failing today](https://ci.swift.org/job/oss-swift-package-swift-sdk-for-android/203/console), so this should finally get the Android CI green again.