### PR TITLE
test/DebugInfo: enable all available tests for Wasm

### DIFF
--- a/test/DebugInfo/advanced.swift
+++ b/test/DebugInfo/advanced.swift
@@ -63,7 +63,7 @@ func foo(_ a: Int64, _ b: Int64) -> Int64 {
 
 // CHECK-DAG: ![[MAINFILE:[0-9]+]] = !DIFile(filename: "{{.*}}DebugInfo/advanced.swift", directory: "{{.*}}")
 // CHECK-DAG: !DICompileUnit(language: DW_LANG_Swift, file: ![[MAINFILE]],{{.*}} producer: "{{.*}}Swift version{{.*}},{{.*}}
-// CHECK-DAG: !DISubprogram(name: "main", {{.*}}file: ![[MAINFILE]],
+// CHECK-DAG: !DISubprogram(name: "{{(__)?}}main{{(_argc_argv)?}}", {{.*}}file: ![[MAINFILE]],
 
 // Function type for foo.
 // CHECK-DAG: ![[FOOTYPE]] = !DISubroutineType(types: ![[PARAMTYPES:[0-9]+]])

--- a/test/DebugInfo/method-declaration.swift
+++ b/test/DebugInfo/method-declaration.swift
@@ -3,6 +3,8 @@
 
 // RUN: %target-swift-frontend -primary-file %t/a.swift -import-objc-header %t/objc.h -enable-objc-interop -emit-ir -gdwarf-types -o - | %FileCheck %s
 
+// REQUIRES: objc_interop
+
 // Verify that we added a declaration for a method.
 
 // CHECK: define{{.*}}foo_static_method{{.*}} !dbg ![[FOO_STATIC_METHOD_DEF_DBG:[0-9]+]]

--- a/test/DebugInfo/modulecache.swift
+++ b/test/DebugInfo/modulecache.swift
@@ -8,7 +8,7 @@ import ClangModule
 // 1. Test that swift-ide-test creates a thin module without debug info.
 
 // RUN: %empty-directory(%t)
-// RUN: %swift-ide-test_plain -print-usrs -target %target-triple -module-cache-path %t  -I %S/Inputs -source-filename %s
+// RUN: %swift-ide-test -print-usrs -target %target-triple -module-cache-path %t  -I %S/Inputs -source-filename %s
 // RUN: dd bs=1 count=4 < %t/*/ClangModule-*.pcm 2>/dev/null | grep -q CPCH
 
 // 2. Test that swift is creating clang modules with debug info.
@@ -20,4 +20,4 @@ import ClangModule
 
 // 3. Test that swift-ide-check will not share swiftc's module cache.
 
-// RUN: %swift-ide-test_plain -print-usrs -target %target-triple -module-cache-path %t  -I %S/Inputs -source-filename %s
+// RUN: %swift-ide-test -print-usrs -target %target-triple -module-cache-path %t  -I %S/Inputs -source-filename %s

--- a/test/DebugInfo/top_level_code.swift
+++ b/test/DebugInfo/top_level_code.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend %s -S -g -o - | %FileCheck %s
 
 func markUsed<T>(_ t: T) {}
-// CHECK: {{_?}}main:
+// CHECK: {{_?_?}}main{{(_argc_argv)?}}:
 // CHECK: Lfunc_begin0:
 // Verify that the top-level function (main) begins at line 0 and then
 // proceeds to the first line.

--- a/test/DebugInfo/top_level_var.swift
+++ b/test/DebugInfo/top_level_var.swift
@@ -8,6 +8,6 @@ markUsed(a)
 // CHECK: !DIGlobalVariable(name: "a",
 // CHECK-SAME:              scope: ![[MOD:[0-9]+]]
 // CHECK: ![[MOD]] = !DIModule(scope: null, name: "top_level_var"
-// CHECK: ![[MAIN:.*]] = distinct !DISubprogram(name: "main",
+// CHECK: ![[MAIN:.*]] = distinct !DISubprogram(name: "{{(__)?}}main{{(_argc_argv)?}}",
 // CHECK-SAME:                                  line: 1
 // CHECK-SAME:                                  DISPFlagDefinition

--- a/test/DebugInfo/variables.swift
+++ b/test/DebugInfo/variables.swift
@@ -5,6 +5,7 @@
 // ASM-macho: .section __DWARF,__debug_info
 // ASM-elf: .section .debug_info,"",{{[@%]}}progbits
 // ASM-coff: .section .debug_info,"dr"
+// ASM-wasm: .section .debug_info,"",@
 
 // Test variables-interpreter.swift runs this code with `swift -g -i`.
 // Test variables-repl.swift runs this code with `swift -g < variables.swift`.

--- a/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
@@ -194,7 +194,7 @@ class WasmStdlib(cmake_product.CMakeProduct):
         self.cmake_options.define('SWIFT_INCLUDE_TESTS:BOOL', 'TRUE')
         self.cmake_options.define('SWIFT_ENABLE_SOURCEKIT_TESTS:BOOL', 'FALSE')
         lit_test_paths = [
-            'IRGen', 'stdlib', 'Concurrency/Runtime', 'embedded', 'AutoDiff',
+            'IRGen', 'stdlib', 'Concurrency/Runtime', 'embedded', 'AutoDiff', 'DebugInfo',
             # TODO(katei): Enable all interpreter tests
             'Interpreter/enum.swift',
         ]


### PR DESCRIPTION
Wasm is the only 32-bit platform regularly tested on Swift CI, let's enable existing `DebugInfo` tests for it.
