### PR TITLE
Cleanup: Remove SmallVector hacks

### DIFF
--- a/include/swift/Basic/LLVM.h
+++ b/include/swift/Basic/LLVM.h
@@ -23,15 +23,6 @@
 // Casting.h has complex templates that cannot be easily forward declared.
 #include "llvm/Support/Casting.h"
 
-#if defined(__clang_major__) && __clang_major__ < 6
-// Add this header as a workaround to prevent `too few template arguments for
-// class template 'SmallVector'` on the buggy Clang 5 compiler (it doesn't
-// merge template arguments correctly). Remove once the CentOS 7 job is
-// replaced.
-// rdar://98218902
-#include "llvm/ADT/SmallVector.h"
-#endif
-
 // Don't pre-declare certain LLVM types in the runtime, which must
 // not put things in namespace llvm for ODR reasons.
 #if defined(SWIFT_RUNTIME)


### PR DESCRIPTION
We no longer support any platform that uses clang 5. This was a workaround for older clang versions where template arguments weren't merged between forward declarations and definitions correctly.

Since we don't support anything this old anymore, we can drop this workaround.

Fixes: rdar://98218902