### PR TITLE
Move MigrationSupport.swift to the end of the list

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -114,7 +114,6 @@ split_embedded_sources(
   EMBEDDED ManagedBuffer.swift
   EMBEDDED Map.swift
   EMBEDDED MemoryLayout.swift
-  EMBEDDED MigrationSupport.swift
   EMBEDDED Mirror.swift
     NORMAL Mirrors.swift
   EMBEDDED Misc.swift
@@ -246,6 +245,7 @@ split_embedded_sources(
   EMBEDDED WriteBackMutableSlice.swift
   EMBEDDED Zip.swift
   EMBEDDED _InlineArray.swift
+  EMBEDDED MigrationSupport.swift # TODO: Out of order due to a solver issue
     NORMAL "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
   )
 


### PR DESCRIPTION
Alphabetizing all of the sources in the standard library uncovered one issue in the solver. Moving MigrationSupport.swift to the end works around the issue in the short term. rdar://168618780
