### PR TITLE
SIL: replace some `assert`s with `ASSERT`s

### DIFF
--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -250,7 +250,7 @@ public:
   /// override the implementation via `postProcess`.
   void recordClonedInstruction(SILInstruction *Orig, SILInstruction *Cloned) {
     asImpl().postProcess(Orig, Cloned);
-    assert((!Orig->getDebugScope() || Cloned->getDebugScope() ||
+    ASSERT((!Orig->getDebugScope() || Cloned->getDebugScope() ||
             Builder.isInsertingIntoGlobal())
            && "cloned instruction dropped debug scope");
   }
@@ -272,7 +272,7 @@ public:
            == To->getGenericSignature().getPointer());
 
     auto result = Functor.LocalArchetypeSubs.insert(std::make_pair(From, To));
-    assert(result.second);
+    ASSERT(result.second);
     (void)result;
   }
 
@@ -326,7 +326,7 @@ public:
   /// corresponding structural index in the remapped pack type.
   unsigned getOpStructuralPackIndex(CanPackType origPackType,
                                     unsigned origIndex) {
-    assert(origIndex < origPackType->getNumElements());
+    ASSERT(origIndex < origPackType->getNumElements());
     unsigned newIndex = 0;
     for (unsigned i = 0; i != origIndex; ++i) {
       auto origComponentType = origPackType.getElementType(i);
@@ -397,7 +397,7 @@ public:
     // All of the packs expanded to scalars.  We should've short-circuited
     // if we ever saw a second or labeled scalar, so all we need to test
     // is whether we have exactly one scalar.
-    assert(numScalarElements <= 1);
+    ASSERT(numScalarElements <= 1);
     return numScalarElements == 1;
   }
 
@@ -740,14 +740,14 @@ template <typename ImplClass>
 void SILCloner<ImplClass>::mapValue(SILValue origValue, SILValue mappedValue) {
   auto iterAndInserted = ValueMap.insert({origValue, mappedValue});
   (void)iterAndInserted;
-  assert(iterAndInserted.second && "Original value already mapped.");
+  ASSERT(iterAndInserted.second && "Original value already mapped.");
 }
 
 template<typename ImplClass>
 SILBasicBlock*
 SILCloner<ImplClass>::remapBasicBlock(SILBasicBlock *BB) {
   SILBasicBlock *MappedBB = BBMap[BB];
-  assert(MappedBB && "Unmapped basic block while cloning?");
+  ASSERT(MappedBB && "Unmapped basic block while cloning?");
   return MappedBB;
 }
 
@@ -755,7 +755,7 @@ template<typename ImplClass>
 void
 SILCloner<ImplClass>::postProcess(SILInstruction *orig,
                                   SILInstruction *cloned) {
-  assert((!orig->getDebugScope() || cloned->getDebugScope() ||
+  ASSERT((!orig->getDebugScope() || cloned->getDebugScope() ||
           Builder.isInsertingIntoGlobal()) &&
          "cloned function dropped debug scope");
 
@@ -774,7 +774,7 @@ SILCloner<ImplClass>::postProcess(SILInstruction *orig,
   }
 
   // Otherwise, map the results over one-by-one.
-  assert(origResults.size() == clonedResults.size());
+  ASSERT(origResults.size() == clonedResults.size());
   for (auto i : indices(origResults))
     asImpl().mapValue(origResults[i], clonedResults[i]);
 }
@@ -794,10 +794,10 @@ void SILCloner<ImplClass>::cloneReachableBlocks(
   bool havePrepopulatedFunctionArgs) {
 
   SILFunction *F = startBB->getParent();
-  assert(F == &Builder.getFunction()
+  ASSERT(F == &Builder.getFunction()
          && "cannot clone region across functions.");
-  assert(BBMap.empty() && "This API does not allow clients to map blocks.");
-  assert((havePrepopulatedFunctionArgs || ValueMap.empty()) &&
+  ASSERT(BBMap.empty() && "This API does not allow clients to map blocks.");
+  ASSERT((havePrepopulatedFunctionArgs || ValueMap.empty()) &&
          "Stale ValueMap.");
 
   auto *clonedStartBB = insertAfterBB ? F->createBasicBlockAfter(insertAfterBB)
@@ -825,12 +825,12 @@ void SILCloner<ImplClass>::cloneFunctionBody(SILFunction *F,
                                              ArrayRef<SILValue> entryArgs,
                                              bool replaceOriginalFunctionInPlace) {
 
-  assert((replaceOriginalFunctionInPlace || F != clonedEntryBB->getParent()) &&
+  ASSERT((replaceOriginalFunctionInPlace || F != clonedEntryBB->getParent()) &&
          "Must clone into a new function.");
-  assert(BBMap.empty() && "This API does not allow clients to map blocks.");
-  assert(ValueMap.empty() && "Stale ValueMap.");
+  ASSERT(BBMap.empty() && "This API does not allow clients to map blocks.");
+  ASSERT(ValueMap.empty() && "Stale ValueMap.");
 
-  assert(entryArgs.size() == F->getArguments().size());
+  ASSERT(entryArgs.size() == F->getArguments().size());
   for (unsigned i = 0, e = entryArgs.size(); i != e; ++i)
     ValueMap[F->getArgument(i)] = entryArgs[i];
 
@@ -846,10 +846,10 @@ void SILCloner<ImplClass>::cloneFunctionBody(SILFunction *F,
 
 template <typename ImplClass>
 void SILCloner<ImplClass>::cloneFunctionBody(SILFunction *F) {
-  assert(!Builder.getFunction().empty() && "Expect the entry block to already be created");
+  ASSERT(!Builder.getFunction().empty() && "Expect the entry block to already be created");
 
-  assert(F != &Builder.getFunction() && "Must clone into a new function.");
-  assert(BBMap.empty() && "This API does not allow clients to map blocks.");
+  ASSERT(F != &Builder.getFunction() && "Must clone into a new function.");
+  ASSERT(BBMap.empty() && "This API does not allow clients to map blocks.");
 
   SILBasicBlock *clonedEntryBB = Builder.getFunction().getEntryBlock();
   BBMap.insert(std::make_pair(&*F->begin(), clonedEntryBB));
@@ -892,8 +892,8 @@ template <typename ImplClass>
 void SILCloner<ImplClass>::cloneFunctionBody(
     SILFunction *F, SILBasicBlock *clonedEntryBB, ArrayRef<SILValue> entryArgs,
     llvm::function_ref<SILValue(SILValue)> entryArgIndexToOldArgIndex) {
-  assert(ValueMap.empty() && "Stale ValueMap.");
-  assert(entryArgs.size() == F->getArguments().size());
+  ASSERT(ValueMap.empty() && "Stale ValueMap.");
+  ASSERT(entryArgs.size() == F->getArguments().size());
   for (unsigned i = 0, e = entryArgs.size(); i != e; ++i) {
     ValueMap[entryArgIndexToOldArgIndex(entryArgs[i])] = entryArgs[i];
   }
@@ -921,9 +921,9 @@ template <typename ImplClass>
 void SILCloner<ImplClass>::visitBlocksDepthFirst(SILBasicBlock *startBB) {
   // The caller clones startBB because it may be a function header, which
   // requires special handling.
-  assert(BBMap.count(startBB) && "The caller must map the first BB.");
+  ASSERT(BBMap.count(startBB) && "The caller must map the first BB.");
 
-  assert(preorderBlocks.empty());
+  ASSERT(preorderBlocks.empty());
 
   // First clone the CFG region.
   //
@@ -977,7 +977,7 @@ void SILCloner<ImplClass>::visitBlocksDepthFirst(SILBasicBlock *startBB) {
         // This predecessor has multiple successors, so cloning it without
         // cloning its successors would create a critical edge.
         splitEdge(term, succIdx, DomTree);
-        assert(!BBMap.count(BB->getSuccessors()[succIdx]));
+        ASSERT(!BBMap.count(BB->getSuccessors()[succIdx]));
       }
       // Map the successor to a new BB. Layout the cloned blocks in the order
       // they are visited and cloned.
@@ -1020,7 +1020,7 @@ void SILCloner<ImplClass>::commonFixUp(SILFunction *F) {
       if (auto *CCBI = dyn_cast<CheckedCastBranchInst>(Term)) {
         // Check if we have a default argument.
         auto *FailureBlock = CCBI->getFailureBB();
-        assert(FailureBlock->getNumArguments() <= 1 &&
+        ASSERT(FailureBlock->getNumArguments() <= 1 &&
                "We should either have no args or a single default arg");
         if (0 == FailureBlock->getNumArguments())
           continue;
@@ -1031,7 +1031,7 @@ void SILCloner<ImplClass>::commonFixUp(SILFunction *F) {
 
       if (auto *SEI = dyn_cast<SwitchEnumInst>(Term)) {
         if (auto DefaultBlock = SEI->getDefaultBBOrNull()) {
-          assert(DefaultBlock.get()->getNumArguments() <= 1 &&
+          ASSERT(DefaultBlock.get()->getNumArguments() <= 1 &&
                  "We should either have no args or a single default arg");
           if (0 == DefaultBlock.get()->getNumArguments())
             continue;
@@ -2267,7 +2267,7 @@ void SILCloner<ImplClass>::visitMoveOnlyWrapperToCopyableValueInst(
     cvt = getBuilder().createOwnedMoveOnlyWrapperToCopyableValue(
         getOpLocation(inst->getLoc()), getOpValue(inst->getOperand()));
   } else {
-    assert(inst->getOwnershipKind() == OwnershipKind::Guaranteed);
+    ASSERT(inst->getOwnershipKind() == OwnershipKind::Guaranteed);
     cvt = getBuilder().createGuaranteedMoveOnlyWrapperToCopyableValue(
         getOpLocation(inst->getLoc()), getOpValue(inst->getOperand()));
   }
@@ -2310,7 +2310,7 @@ void SILCloner<ImplClass>::visitCopyableToMoveOnlyWrapperValueInst(
     cvt = getBuilder().createOwnedCopyableToMoveOnlyWrapperValue(
         getOpLocation(inst->getLoc()), getOpValue(inst->getOperand()));
   } else {
-    assert(inst->getOwnershipKind() == OwnershipKind::Guaranteed);
+    ASSERT(inst->getOwnershipKind() == OwnershipKind::Guaranteed);
     cvt = getBuilder().createGuaranteedCopyableToMoveOnlyWrapperValue(
         getOpLocation(inst->getLoc()), getOpValue(inst->getOperand()));
   }
@@ -2783,7 +2783,7 @@ SILCloner<ImplClass>::visitWitnessMethodInst(WitnessMethodInst *Inst) {
     auto conformingType = conformance.getConcrete()->getType()->getCanonicalType();
 
     if (conformingType != lookupType) {
-      assert(
+      ASSERT(
           (conformingType->isExactSuperclassOf(lookupType) ||
            getBuilder().getModule().Types.getLoweredRValueType(
                getBuilder().getTypeExpansionContext(), conformingType) == lookupType) &&

--- a/lib/SILOptimizer/Utils/ValueLifetime.cpp
+++ b/lib/SILOptimizer/Utils/ValueLifetime.cpp
@@ -34,7 +34,7 @@ void ValueLifetimeBoundary::visitInsertionPoints(
         continue;
 #endif
 
-      assert(succ->getSinglePredecessorBlock() == predBB);
+      ASSERT(succ->getSinglePredecessorBlock() == predBB);
       visitor(succ->begin());
     }
   }
@@ -50,8 +50,8 @@ void ValueLifetimeBoundary::visitInsertionPoints(
 
 void ValueLifetimeAnalysis::propagateLiveness() {
   bool defIsInstruction = isa<SILInstruction *>(defValue);
-  assert(liveBlocks.empty() && "frontier computed twice");
-  assert(
+  ASSERT(liveBlocks.empty() && "frontier computed twice");
+  ASSERT(
       (!defIsInstruction || !userSet.count(cast<SILInstruction *>(defValue))) &&
       "definition cannot be its own use");
 
@@ -73,7 +73,7 @@ void ValueLifetimeAnalysis::propagateLiveness() {
     if (defIsInstruction && userBlock == defBB)
       ++numUsersBeforeDef;
   }
-  assert((isa<SILInstruction *>(defValue) || (numUsersBeforeDef == 0)) &&
+  ASSERT((isa<SILInstruction *>(defValue) || (numUsersBeforeDef == 0)) &&
          "Non SILInstruction defValue with users before the def?!");
 
   // Don't count any users in the defBB which are actually located _after_ the
@@ -88,7 +88,7 @@ void ValueLifetimeAnalysis::propagateLiveness() {
 
   // Initialize the hasUsersBeforeDef field.
   hasUsersBeforeDef = numUsersBeforeDef > 0;
-  assert(defIsInstruction || !hasUsersBeforeDef);
+  ASSERT(defIsInstruction || !hasUsersBeforeDef);
 
   // Now propagate liveness backwards until we hit the block that defines the
   // value.
@@ -112,7 +112,7 @@ void ValueLifetimeAnalysis::propagateLiveness() {
 SILInstruction *ValueLifetimeAnalysis::findLastUserInBlock(SILBasicBlock *bb) {
   // Walk backwards in bb looking for last use of the value.
   for (auto &inst : llvm::reverse(*bb)) {
-    assert(defValue.dyn_cast<SILInstruction *>() != &inst &&
+    ASSERT(defValue.dyn_cast<SILInstruction *>() != &inst &&
            "Found def before finding use!");
 
     if (userSet.count(&inst))
@@ -127,7 +127,7 @@ void ValueLifetimeAnalysis::computeLifetime(
     llvm::function_ref<void(SILInstruction *)> visitLastUser,
     llvm::function_ref<void(SILBasicBlock *predBB, SILBasicBlock *succBB)>
         visitBoundaryEdge) {
-  assert(!isAliveAtBeginOfBlock(getFunction()->getEntryBlock()) &&
+  ASSERT(!isAliveAtBeginOfBlock(getFunction()->getEntryBlock()) &&
          "Can't compute frontier for def which does not dominate all uses");
 
   /// The lifetime ends if we have a live block and a not-live successor.
@@ -147,7 +147,7 @@ void ValueLifetimeAnalysis::computeLifetime(
           //
           // This should never happen if we have a SILArgument since the
           // SILArgument can not have any uses before it in a block.
-          assert(isa<SILInstruction *>(defValue) &&
+          ASSERT(isa<SILInstruction *>(defValue) &&
                  "SILArguments dominate all instructions in their defining "
                  "blocks");
           usedAndRedefinedInSucc = true;
@@ -165,7 +165,7 @@ void ValueLifetimeAnalysis::computeLifetime(
           break;
         }
       }
-      assert(ii != bb->rend() &&
+      ASSERT(ii != bb->rend() &&
              "There must be a user in bb before definition");
     }
     if (liveInSucc) {
@@ -237,7 +237,7 @@ bool ValueLifetimeAnalysis::computeFrontier(FrontierImpl &frontier, Mode mode,
     // frontier, add all successor blocks to the frontier.
     auto *termBB = lastUser->getParent();
     for (const SILSuccessor &succ : termBB->getSuccessors()) {
-      assert(!isAliveAtBeginOfBlock(succ)
+      ASSERT(!isAliveAtBeginOfBlock(succ)
              && "out-of-sync with computeLifetime");
 
       if (deBlocks && deBlocks->isDeadEnd(succ))
@@ -270,7 +270,7 @@ bool ValueLifetimeAnalysis::computeFrontier(FrontierImpl &frontier, Mode mode,
   BasicBlockSet unhandledFrontierBlocks(getFunction());
   bool unhandledFrontierBlocksFound = false;
   for (SILBasicBlock *frontierBB : frontierBlocks) {
-    assert(mode != UsersMustPostDomDef);
+    ASSERT(mode != UsersMustPostDomDef);
     bool needSplit = false;
     // If the value is live only in part of the predecessor blocks we have to
     // split those predecessor edges.
@@ -296,7 +296,7 @@ bool ValueLifetimeAnalysis::computeFrontier(FrontierImpl &frontier, Mode mode,
   // Split critical edges from the lifetime region to not yet handled frontier
   // blocks.
   for (SILBasicBlock *frontierPred : liveOutBlocks) {
-    assert(mode != UsersMustPostDomDef);
+    ASSERT(mode != UsersMustPostDomDef);
     auto *term = frontierPred->getTerminator();
     // Cache the successor blocks because splitting critical edges invalidates
     // the successor list iterator of T.
@@ -306,7 +306,7 @@ bool ValueLifetimeAnalysis::computeFrontier(FrontierImpl &frontier, Mode mode,
 
     for (unsigned i = 0, e = succBlocks.size(); i != e; ++i) {
       if (unhandledFrontierBlocks.contains(succBlocks[i])) {
-        assert((isCriticalEdge(term, i) || userSet.count(term)) &&
+        ASSERT((isCriticalEdge(term, i) || userSet.count(term)) &&
                "actually not a critical edge?");
         noCriticalEdges = false;
         if (mode != AllowToModifyCFG) {


### PR DESCRIPTION
To catch those errors also in a non-assert build of the compiler. I recently investigated a compiler crash with a non-assert compiler and would have found the root cause much faster if those asserts would have triggered.
