### PR TITLE
check_incremental: better diagnostics for non-determinism checks

### DIFF
--- a/include/swift/AST/ASTPrinter.h
+++ b/include/swift/AST/ASTPrinter.h
@@ -238,6 +238,9 @@ public:
   ASTPrinter &operator<<(QuotedString s);
 
   ASTPrinter &operator<<(unsigned long long N);
+
+  static void getUUIDStringForPrinting(UUID uuid, llvm::SmallVectorImpl<char> &out);
+
   ASTPrinter &operator<<(UUID UU);
 
   ASTPrinter &operator<<(Identifier name);

--- a/include/swift/SILOptimizer/PassManager/PassManager.h
+++ b/include/swift/SILOptimizer/PassManager/PassManager.h
@@ -454,11 +454,11 @@ private:
 
   /// Dumps information about the pass with index \p TransIdx to llvm::dbgs().
   void dumpPassInfo(const char *Title, SILTransform *Tr, SILFunction *F,
-                    int passIdx = -1);
+                    int passIdx = -1, bool skipNewline = false);
 
   /// Dumps information about the pass with index \p TransIdx to llvm::dbgs().
   void dumpPassInfo(const char *Title, unsigned TransIdx,
-                    SILFunction *F = nullptr);
+                    SILFunction *F = nullptr, bool skipNewline = false);
 
   /// Displays the call graph in an external dot-viewer.
   /// This function is meant for use from the debugger.

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -85,6 +85,10 @@ static llvm::cl::opt<bool> NumberSuppressionChecks(
     llvm::cl::init(false), llvm::cl::Hidden);
 #endif
 
+llvm::cl::opt<bool>
+PrintNoUUIDS("print-no-uuids", llvm::cl::init(false),
+                   llvm::cl::desc("don't print UUIDs to make the output better diffable"));
+
 // Defined here to avoid repeatedly paying the price of template instantiation.
 const std::function<bool(const ExtensionDecl *)>
     PrintOptions::defaultPrintExtensionContentAsMembers
@@ -580,9 +584,17 @@ ASTPrinter &ASTPrinter::operator<<(unsigned long long N) {
   return *this;
 }
 
+void ASTPrinter::getUUIDStringForPrinting(UUID uuid, llvm::SmallVectorImpl<char> &out) {
+  if (PrintNoUUIDS) {
+    out.clear();
+    return;
+  }
+  uuid.toString(out);
+}
+
 ASTPrinter &ASTPrinter::operator<<(UUID UU) {
   llvm::SmallString<UUID::StringBufferSize> Str;
-  UU.toString(Str);
+  getUUIDStringForPrinting(UU, Str);
   printTextImpl(Str);
   return *this;
 }

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -16,6 +16,7 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "swift/AST/ASTPrinter.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/Module.h"
@@ -764,10 +765,16 @@ class SILPrinter : public SILInstructionVisitor<SILPrinter> {
   SIMPLE_PRINTER(SILDeclRef)
   SIMPLE_PRINTER(APInt)
   SIMPLE_PRINTER(ValueOwnershipKind)
-  SIMPLE_PRINTER(UUID)
   SIMPLE_PRINTER(GenericSignature)
   SIMPLE_PRINTER(ActorIsolation)
 #undef SIMPLE_PRINTER
+
+  SILPrinter &operator<<(UUID value) {
+    llvm::SmallString<UUID::StringBufferSize> str;
+    ASTPrinter::getUUIDStringForPrinting(value, str);
+    PrintState.OS << str;
+    return *this;
+  }
 
   SILPrinter &operator<<(SILValuePrinterInfo i) {
     SILColor C(PrintState.OS, SC_Type);

--- a/test/SIL/dont_print_uuids.sil
+++ b/test/SIL/dont_print_uuids.sil
@@ -1,0 +1,18 @@
+// RUN: %target-sil-opt -print-no-uuids %s | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+protocol P {}
+
+sil [ossa] @testit : $@convention(thin) (@in_guaranteed P) -> () {
+bb0(%0 :  $*P):
+  // CHECK: %1 = open_existential_addr immutable_access %0 to $*@opened("", any P) Self 
+  %1 = open_existential_addr immutable_access %0 to $*@opened("8D8C5442-F841-11F0-91F8-0EA13E3AABB4", any P) Self 
+  %r = tuple ()
+  return %r
+}
+

--- a/test/SILOptimizer/pass_printer.swift
+++ b/test/SILOptimizer/pass_printer.swift
@@ -1,8 +1,13 @@
 // RUN: %target-swift-frontend -Xllvm -sil-print-before=definite-init -emit-sil %s -o /dev/null 2>&1 | %FileCheck --check-prefix=BEFORE %s
 // RUN: %target-swift-frontend -Xllvm -sil-print-after=definite-init -emit-sil %s -o /dev/null 2>&1 | %FileCheck --check-prefix=AFTER %s
 // RUN: %target-swift-frontend -Xllvm -sil-disable-pass=definite-init -Xllvm -sil-print-pass-name -emit-sil %s -o /dev/null 2>&1 | %FileCheck --check-prefix=DISABLE %s
+// RUN: %target-swift-frontend -Xllvm -sil-print-pass-md5 -emit-sil %s -o /dev/null 2>&1 | %FileCheck --check-prefix=MD5 %s
 
 // BEFORE: SIL function before #{{[0-9]+}}, stage  Mandatory Diagnostic Passes + Enabling Optimization Passes, pass {{[0-9]+}}: DefiniteInitialization (definite-init)
 // AFTER: SIL function after #{{[0-9]+}}, stage  Mandatory Diagnostic Passes + Enabling Optimization Passes, pass {{[0-9]+}}: DefiniteInitialization  (definite-init)
 // DISABLE: (Disabled) #{{[0-9]+}}, stage  Mandatory Diagnostic Passes + Enabling Optimization Passes, pass {{[0-9]+}}: DefiniteInitialization (definite-init)
+
+// MD5: Initial SILGen Passes MD5 =
+// MD5:   {{MD5 #[0-9]+, stage .*, pass [0-9]+:.* = }}
+
 func foo() {}

--- a/utils/check-incremental
+++ b/utils/check-incremental
@@ -34,7 +34,12 @@ def compile_and_stat(compile_args, output_file):
     (md5sum, last modified time) for ``output_file`` after the
     compilation has finished.
     """
-    subprocess.check_call(compile_args)
+
+    logFile = open(output_file + ".log", "w")
+
+    subprocess.check_call(compile_args, stderr=logFile)
+
+    logFile.close()
 
     md5 = subprocess.check_output(["md5", "-q", output_file],
                                   universal_newlines=True)
@@ -50,7 +55,10 @@ def print_diff(output_file, suffix):
     subprocess.run(
         ["diff", output_file + suffix, output_file + ".ref" + suffix])
 
-def print_ir_diffs(output_file):
+def print_diffs(output_file):
+    print("\n## MD5 differences:", flush=True)
+    print_diff(output_file, ".log")
+
     if EMIT_IR and VERBOSE:
         print("\n## SIL differences:", flush=True)
         print_diff(output_file, ".sil")
@@ -85,6 +93,10 @@ def main():
         subprocess.check_call(new_args)
         return
 
+    new_args += [
+      '-Xllvm', '-print-no-uuids',
+      '-Xllvm', '-sil-print-pass-md5']
+
     if EMIT_IR:
       new_args += [
         '-Xllvm', '-save-sil', '-Xllvm', output_file + '.sil',
@@ -102,6 +114,7 @@ def main():
     reference_md5, reference_time = compile_and_stat(new_args, output_file)
 
     subprocess.check_call(["cp", output_file, output_file + ".ref.o"])
+    subprocess.check_call(["cp", output_file + ".log", output_file + ".ref.log"])
     if EMIT_IR:
         subprocess.check_call(
             ["cp", output_file + ".sil", output_file + ".ref.sil"])
@@ -120,7 +133,7 @@ def main():
         # This is the most important check: is the output file exactly the
         # same.
         if reference_md5 != second_md5:
-            print_ir_diffs(output_file)
+            print_diffs(output_file)
             sys.exit("ERROR: non-determinism when generating: " + output_file +
                      "\ncommand line:\n" + " ".join(new_args))
 
@@ -128,7 +141,7 @@ def main():
         # file. (For compilations < 1sec this check may succeed even if the
         # file was overwritten).
         if compare_time and reference_time != second_time:
-            print_ir_diffs(output_file)
+            print_diffs(output_file)
             sys.exit("ERROR: file timestamp was re-written: " + output_file)
 
 


### PR DESCRIPTION
It now prints the MD5 hashes of SIL after each SIL pass to find a non-deterministic pass

This is a follow-up of https://github.com/swiftlang/swift/pull/86471 and https://github.com/swiftlang/swift/pull/86512