### PR TITLE
[Backtracing] Allow symbolication across platforms

### DIFF
--- a/stdlib/public/RuntimeModule/Backtrace.swift
+++ b/stdlib/public/RuntimeModule/Backtrace.swift
@@ -361,9 +361,38 @@ public struct Backtrace: CustomStringConvertible, Sendable {
   public func symbolicated(with images: ImageMap? = nil,
                            options: SymbolicationOptions = .default)
     -> SymbolicatedBacktrace? {
+    return symbolicated(with: images,
+                        platform: .default,
+                        alternativeSymbolFilePaths: [],
+                        options: options)
+  }
+
+  @_spi(Internal)
+  public enum SymbolicationPlatform {
+    case Darwin
+    case Linux
+    case Windows
+
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    static public let `default` = SymbolicationPlatform.Darwin
+    #elseif os(Linux)
+    static public let `default` = SymbolicationPlatform.Linux
+    #elseif os(Windows)
+    static public let `default` = SymbolicationPlatform.Windows
+    #endif
+  }
+
+  @_spi(Internal)
+  public func symbolicated(with images: ImageMap? = nil,
+                           platform: SymbolicationPlatform,
+                           alternativeSymbolFilePaths: [String],
+                           options: SymbolicationOptions = .default)
+    -> SymbolicatedBacktrace? {
     return SymbolicatedBacktrace.symbolicate(
       backtrace: self,
       images: images,
+      platform: platform,
+      alternativeSymbolFilePaths: alternativeSymbolFilePaths,
       options: options
     )
   }

--- a/stdlib/public/RuntimeModule/Context.swift
+++ b/stdlib/public/RuntimeModule/Context.swift
@@ -723,7 +723,7 @@ extension arm_gprs {
           }
         }
 
-	to[31] = UInt64(mctx.sp)
+        to[31] = UInt64(mctx.sp)
       }
     }
     gprs.pc = UInt64(mctx.pc)

--- a/stdlib/public/RuntimeModule/CrashLog.swift
+++ b/stdlib/public/RuntimeModule/CrashLog.swift
@@ -391,7 +391,11 @@ public extension CrashLog.Thread {
         return Backtrace(architecture: architecture, frames: frames, images: images)
     }
 
-    func symbolicatedBacktrace(architecture: String, images: ImageMap?) -> SymbolicatedBacktrace? {
+    func symbolicatedBacktrace(
+        architecture: String,
+        images: ImageMap?,
+        platform: Backtrace.SymbolicationPlatform) 
+    -> SymbolicatedBacktrace? {
         guard let images else { return nil }
         let backtrace = backtrace(architecture: architecture, images: images)
         let frames = self.frames.compactMap { frame in
@@ -437,6 +441,8 @@ extension CrashLog {
 
     public mutating func symbolicate(
         allThreads: Bool = false,
+        platform: Backtrace.SymbolicationPlatform,
+        alternativeSymbolFilePaths: [String],
         options: Backtrace.SymbolicationOptions = .default) {
 
         let images = imageMap()
@@ -446,7 +452,10 @@ extension CrashLog {
             let backtrace: Backtrace = thread.backtrace(architecture: architecture, images: images)
 
             if let symbolicatedBacktrace = backtrace.symbolicated(
-                with: images, options: options) {
+                with: images,
+                platform: platform,
+                alternativeSymbolFilePaths: alternativeSymbolFilePaths,
+                options: options) {
 
                 thread.updateWithBacktrace(symbolicatedBacktrace: symbolicatedBacktrace)
             }

--- a/stdlib/public/RuntimeModule/ElfImageCache.swift
+++ b/stdlib/public/RuntimeModule/ElfImageCache.swift
@@ -44,7 +44,7 @@ final class ElfImageCache {
     case elf32Image(Elf32Image)
     case elf64Image(Elf64Image)
   }
-  func lookup(path: String?) -> Result? {
+  func lookup(path: String?, alternativePaths: [String] = []) -> Result? {
     guard let path = path else {
       return nil
     }
@@ -54,7 +54,7 @@ final class ElfImageCache {
     if let image = elf64[path] {
       return .elf64Image(image)
     }
-    if let source = try? ImageSource(path: path) {
+    if let source = try? ImageSource(path: path, alternativePaths: alternativePaths) {
       if let elfImage = try? Elf32Image(source: source) {
         elf32[path] = elfImage
         return .elf32Image(elfImage)

--- a/stdlib/public/RuntimeModule/ImageSource.swift
+++ b/stdlib/public/RuntimeModule/ImageSource.swift
@@ -183,7 +183,7 @@ struct ImageSource: CustomStringConvertible {
       self.init(mapped: UnsafeRawBufferPointer(
                   start: base, count: size))
       #else
-      let fd = _swift_open(path, O_RDONLY, 0)
+      var fd = _swift_open(path, O_RDONLY, 0)
 
       if fd < 0 {
         let filePathCharacter: Character = "/" // non windows path separator


### PR DESCRIPTION
Allow for example symbolication of Linux backtraces on a macOS platform.

The primary work is instead of the symbolication path being decided by what platform the symbolication code is running on, it's decided by a parameter passed to the symbolication function.

This parameter is defaulted to a value based on the current parameter for backward compatibility. This should mean that existing code, in particular 'online' / just in time symbolication attempted in swift-backtrace during the initial crash dump should work exactly as before (and all unit tests should be unaffected).

However it adds a key feature for the upcoming offline symbolicator project, to give some ability to symbolicate crash dumps produced by swift running on a different platform (with some constraints and limitations likely).

rdar://168769519

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
