### PR TITLE
build-script: use the overall build variant to find early swift driver

### DIFF
--- a/utils/swift_build_support/swift_build_support/build_script_invocation.py
+++ b/utils/swift_build_support/swift_build_support/build_script_invocation.py
@@ -258,7 +258,7 @@ class BuildScriptInvocation(object):
                     '-DSWIFTSYNTAX_ENABLE_ASSERTIONS:BOOL=TRUE')
 
         if args.build_early_swift_driver:
-            configuration = 'release' if str(args.swift_build_variant) in [
+            configuration = 'release' if str(args.build_variant) in [
                 'Release',
                 'RelWithDebInfo'
             ] else 'debug'


### PR DESCRIPTION
The path in which the early SwiftDriver is installed depends on the `build_variant` argument (set with `--release`, `--release-debuginfo` and `--debug`), but build-script calculates it based off `swift_build_variant`, which can be different from the former (e.g. when we want to build only the compiler in debug configuration).