### PR TITLE
utils: do not specify default SSL backend

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2685,7 +2685,7 @@ function Build-CURL([Hashtable] $Platform) {
       CURL_CA_SEARCH_SAFE = "NO";
       CURL_CLANG_TIDY = "NO";
       CURL_CODE_COVERAGE = "NO";
-      CURL_DEFAULT_SSL_BACKEND = "schannel";
+      # CURL_DEFAULT_SSL_BACKEND = if ($Platform.OS -eq [OS]::Windows) { "schannel" } else { "" };
       CURL_DISABLE_ALTSVC = "NO";
       CURL_DISABLE_AWS = "YES";
       CURL_DISABLE_BASIC_AUTH = "NO";


### PR DESCRIPTION
It appears that we currently do not enable any SSL backends in the Android builds! Disable the setting to allow the builds to continue until this is fixed properly by enabling an SSL backend for Android.