### PR TITLE
[SE-0474] Force unwind off for new yielding accessors

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -5153,15 +5153,17 @@ enum class SILCoroutineKind : uint8_t {
   /// results and may not have yield results.
   None,
 
-  /// This function is a yield-once coroutine (used by e.g. accessors).
-  /// It must not have normal results and may have arbitrary yield results.
+  /// This function is a yield-once coroutine (used by legacy
+  /// `_read` and `_modify` accessors).
+  /// It must not have normal results and may have arbitrary
+  /// yield results.
   YieldOnce,
 
-  /// This function is a yield-once coroutine (used by read and modify
-  /// accessors).  It has the following differences from YieldOnce:
-  /// - it does not observe errors thrown by its caller (unless the feature
-  /// CoroutineAccessorsUnwindOnCallerError is enabled)
-  /// - it uses the callee-allocated ABI
+  /// This function is a yield-once coroutine (used by `yielding borrow`
+  /// and `yielding mutate` accessors).
+  /// Unlike YieldOnce, the second half of the coroutine is _always_
+  /// run, even if an error is thrown within the access scope.
+  /// It also uses a more efficient callee-allocated ABI.
   YieldOnce2,
 
   /// This function is a yield-many coroutine (used by e.g. generators).

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -510,7 +510,11 @@ EXPERIMENTAL_FEATURE(ImportNonPublicCxxMembers, true)
 //   (Don't use "read"/"modify" in swiftinterface files.)
 SUPPRESSIBLE_EXPERIMENTAL_FEATURE(CoroutineAccessors, true)
 
-/// modify/read single-yield coroutines always execute code post-yield code
+/// `yielding borrow` and `yielding mutate` coroutine
+/// accessors always execute the second half of the
+/// coroutine, even after a thrown error.  This flag
+/// used to disable running the second half after an
+/// error, but no longer has any effect.
 EXPERIMENTAL_FEATURE(CoroutineAccessorsUnwindOnCallerError, false)
 
 EXPERIMENTAL_FEATURE(AddressableParameters, true)

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -2377,9 +2377,9 @@ public:
             "operand of abort_apply must be a begin_apply");
     auto *mvi = getAsResultOf<BeginApplyInst>(AI->getOperand());
     auto *bai = cast<BeginApplyInst>(mvi->getParent());
-    require(!bai->getSubstCalleeType()->isCalleeAllocatedCoroutine() ||
-                AI->getFunction()->getASTContext().LangOpts.hasFeature(
-                    Feature::CoroutineAccessorsUnwindOnCallerError),
+    // `abort_apply` is valid for legacy `_read`/`_modify` accessors
+    // It is never valid for `yielding borrow`/`yielding mutate`
+    require(!bai->getSubstCalleeType()->isCalleeAllocatedCoroutine(),
             "abort_apply of callee-allocated yield-once coroutine!?");
   }
 

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -2084,7 +2084,7 @@ public:
                                         bool isOnSelfParameter);
 
   ManagedValue applyBorrowMutateAccessor(SILLocation loc, ManagedValue fn,
-                                         bool canUnwind, SubstitutionMap subs,
+                                         SubstitutionMap subs,
                                          ArrayRef<ManagedValue> args,
                                          CanSILFunctionType substFnType,
                                          ApplyOptions options);

--- a/test/SIL/verifier_failures.sil
+++ b/test/SIL/verifier_failures.sil
@@ -75,7 +75,7 @@ failure(%error : @owned $any Error):
 }
 
 // CHECK-LABEL: Begin Error in function abort_apply_callee_allocated_coro_2
-// CHECK: SIL verification failed: abort_apply of callee-allocated yield-once coroutine!?: !bai->getSubstCalleeType()->isCalleeAllocatedCoroutine() || AI->getFunction()->getASTContext().LangOpts.hasFeature( Feature::CoroutineAccessorsUnwindOnCallerError)
+// CHECK: SIL verification failed: abort_apply of callee-allocated yield-once coroutine!?: !bai->getSubstCalleeType()->isCalleeAllocatedCoroutine()
 // CHECK: End Error in function abort_apply_callee_allocated_coro_2
 sil [ossa] @abort_apply_callee_allocated_coro_2 : $@convention(thin) () -> (@error any Error) {
 entry:

--- a/test/SILGen/coroutine_accessors.swift
+++ b/test/SILGen/coroutine_accessors.swift
@@ -3,15 +3,15 @@
 // RUN:     -enable-callee-allocated-coro-abi               \
 // RUN:     -enable-library-evolution                       \
 // RUN:     -enable-experimental-feature CoroutineAccessors \
-// RUN: | %FileCheck %s --check-prefixes=CHECK,CHECK-NOUNWIND
+// RUN: | %FileCheck %s
 
-// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types                      \
-// RUN:     %s                                                                 \
-// RUN:     -enable-callee-allocated-coro-abi                                  \
-// RUN:     -enable-library-evolution                                          \
-// RUN:     -enable-experimental-feature CoroutineAccessors                    \
+// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types   \
+// RUN:     %s                                              \
+// RUN:     -enable-callee-allocated-coro-abi               \
+// RUN:     -enable-library-evolution                       \
+// RUN:     -enable-experimental-feature CoroutineAccessors \
 // RUN:     -enable-experimental-feature CoroutineAccessorsUnwindOnCallerError \
-// RUN: | %FileCheck %s --check-prefixes=CHECK,CHECK-UNWIND
+// RUN: | %FileCheck %s
 
 // REQUIRES: swift_feature_CoroutineAccessors
 // REQUIRES: swift_feature_CoroutineAccessorsUnwindOnCallerError
@@ -148,8 +148,7 @@ public var irm: Int {
 // CHECK:      dealloc_stack [[OLD_VALUE_ADDR]]
 // CHECK:      return [[OLD_VALUE]]
 // CHECK:    bb2([[ERROR:%[^,]+]] : @owned $any Error):
-// CHECK-NOUNWIND: end_apply [[TOKEN]]
-// CHECK-UNWIND: abort_apply [[TOKEN]]
+// CHECK:      end_apply [[TOKEN]]
 // CHECK:      dealloc_stack [[ALLOCATION]]
 // CHECK:      end_access [[SELF_ACCESS]]
 // CHECK:      dealloc_stack [[NEW_VALUE_ADDR]]

--- a/test/SILGen/coroutine_accessors_skip.swift
+++ b/test/SILGen/coroutine_accessors_skip.swift
@@ -4,7 +4,7 @@
 // RUN:     -experimental-skip-non-inlinable-function-bodies \
 // RUN:     -enable-library-evolution                        \
 // RUN:     -enable-experimental-feature CoroutineAccessors  \
-// RUN: | %FileCheck %s --check-prefixes=CHECK,CHECK-NOUNWIND
+// RUN: | %FileCheck %s
 
 // RUN: %target-swift-emit-silgen                                              \
 // RUN:     %s                                                                 \
@@ -13,7 +13,7 @@
 // RUN:     -enable-library-evolution                                          \
 // RUN:     -enable-experimental-feature CoroutineAccessors                    \
 // RUN:     -enable-experimental-feature CoroutineAccessorsUnwindOnCallerError \
-// RUN: | %FileCheck %s --check-prefixes=CHECK,CHECK-UNWIND
+// RUN: | %FileCheck %s
 
 // REQUIRES: swift_feature_CoroutineAccessors
 // REQUIRES: swift_feature_CoroutineAccessorsUnwindOnCallerError

--- a/test/SILGen/read_requirements.swift
+++ b/test/SILGen/read_requirements.swift
@@ -3,7 +3,7 @@
 // RUN:     -enable-callee-allocated-coro-abi               \
 // RUN:     -enable-library-evolution                       \
 // RUN:     -enable-experimental-feature CoroutineAccessors \
-// RUN: | %FileCheck %s --check-prefixes=CHECK,CHECK-NORMAL,CHECK-%target-abi-stability
+// RUN: | %FileCheck %s --check-prefixes=CHECK,CHECK-%target-abi-stability
 
 // RUN: %target-swift-emit-silgen -Xllvm -sil-print-types                      \
 // RUN:     %s                                                                 \
@@ -11,7 +11,7 @@
 // RUN:     -enable-library-evolution                                          \
 // RUN:     -enable-experimental-feature CoroutineAccessors                    \
 // RUN:     -enable-experimental-feature CoroutineAccessorsUnwindOnCallerError \
-// RUN: | %FileCheck %s --check-prefixes=CHECK,CHECK-UNWIND,CHECK-%target-abi-stability
+// RUN: | %FileCheck %s --check-prefixes=CHECK,CHECK-%target-abi-stability
 
 // REQUIRES: swift_feature_CoroutineAccessors
 // REQUIRES: swift_feature_CoroutineAccessorsUnwindOnCallerError
@@ -19,7 +19,7 @@
 // A read requirement may be satisfied by
 // - a stored property
 // - a _read accessor
-// - a read accessor
+// - a yielding borrow accessor
 // - a get accessor
 // - an unsafeAddress accessor
 
@@ -80,7 +80,7 @@ public protocol P1 : ~Copyable {
 }
 @available(SwiftStdlib 9999, *)
 public protocol P2 : ~Copyable {
-  var urs: U { read set }
+  var urs: U { yielding borrow set }
 }
 @available(SwiftStdlib 6.0, *)
 public protocol P3 : ~Copyable {
@@ -107,7 +107,7 @@ public protocol P3 : ~Copyable {
 // CHECK:         end_apply [[TOKEN]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements2P3P2urAA1UVvy'
-  var ur: U { read }
+  var ur: U { yielding borrow }
 }
 
 @frozen
@@ -190,8 +190,7 @@ public struct ImplAStored : ~Copyable & P1 {
 // CHECK:         end_borrow [[SELF]]
 // CHECK:         return
 // CHECK:       bb2:
-// CHECK-NORMAL:  end_apply [[TOKEN]]
-// CHECK-UNWIND:  abort_apply [[TOKEN]]
+// CHECK:         end_apply [[TOKEN]]
 // CHECK:         dealloc_stack [[ALLOCATION]]
 // CHECK:         end_borrow [[SELF]]
 // CHECK:         unwind
@@ -241,8 +240,7 @@ public struct ImplBStored : ~Copyable & P2 {
 // CHECK:         end_borrow [[SELF]]
 // CHECK:         return
 // CHECK:       [[FAILURE]]:
-// CHECK-NORMAL:  end_apply [[TOKEN]]
-// CHECK-UNWIND:  abort_apply [[TOKEN]]
+// CHECK:         end_apply [[TOKEN]]
 // CHECK:         dealloc_stack [[ALLOCATION]]
 // CHECK:         end_borrow [[SELF]]
 // CHECK:         unwind
@@ -331,8 +329,7 @@ public struct ImplCStored : ~Copyable & P3 {
 // CHECK:         end_borrow [[SELF]]
 // CHECK:         return
 // CHECK:       [[FAILURE]]:
-// CHECK-NORMAL:  end_apply [[TOKEN]]
-// CHECK-UNWIND:  abort_apply [[TOKEN]]
+// CHECK:         end_apply [[TOKEN]]
 // CHECK:         dealloc_stack [[ALLOCATION]]
 // CHECK:         end_borrow [[SELF]]
 // CHECK:         unwind
@@ -436,8 +433,7 @@ public struct ImplAUnderscoredCoroutineAccessors : ~Copyable & P1 {
 // CHECK:         end_borrow [[SELF]]
 // CHECK:         return
 // CHECK:       [[FAILURE]]:
-// CHECK-NORMAL:  end_apply [[TOKEN]]
-// CHECK-UNWIND:  abort_apply [[TOKEN]]
+// CHECK:         end_apply [[TOKEN]]
 // CHECK:         dealloc_stack [[ALLOCATION]]
 // CHECK:         end_borrow [[SELF]]
 // CHECK:         unwind
@@ -523,8 +519,7 @@ public struct ImplBUnderscoredCoroutineAccessors : ~Copyable & P2 {
 // CHECK:         end_borrow [[SELF]]
 // CHECK:         return
 // CHECK:       [[FAILURE]]:
-// CHECK-NORMAL:  end_apply [[TOKEN]]
-// CHECK-UNWIND:  abort_apply [[TOKEN]]
+// CHECK:         end_apply [[TOKEN]]
 // CHECK:         dealloc_stack [[ALLOCATION]]
 // CHECK:         end_borrow [[SELF]]
 // CHECK:         unwind
@@ -626,8 +621,7 @@ public struct ImplCUnderscoredCoroutineAccessors : ~Copyable & P3 {
 // CHECK:         end_borrow [[SELF]]
 // CHECK:         return
 // CHECK:       [[FAILURE]]:
-// CHECK-NORMAL:  end_apply [[TOKEN]]
-// CHECK-UNWIND:  abort_apply [[TOKEN]]
+// CHECK:         end_apply [[TOKEN]]
 // CHECK:         dealloc_stack [[ALLOCATION]]
 // CHECK:         end_borrow [[SELF]]
 // CHECK:         unwind
@@ -637,10 +631,10 @@ public struct ImplCUnderscoredCoroutineAccessors : ~Copyable & P3 {
 struct ImplACoroutineAccessors : ~Copyable & P1 {
   var _i: U
   var ubgs: U {
-    read {
+    yielding borrow {
       yield _i
     }
-    modify {
+    yielding mutate {
       yield &_i
     }
   }
@@ -732,8 +726,7 @@ struct ImplACoroutineAccessors : ~Copyable & P1 {
 // CHECK:         end_borrow [[SELF]]
 // CHECK:         return
 // CHECK:       [[FAILURE]]:
-// CHECK-NORMAL:  end_apply [[TOKEN]]
-// CHECK-UNWIND:  abort_apply [[TOKEN]]
+// CHECK:         end_apply [[TOKEN]]
 // CHECK:         dealloc_stack [[ALLOCATION]]
 // CHECK:         end_borrow [[SELF]]
 // CHECK:         unwind
@@ -745,10 +738,10 @@ struct ImplACoroutineAccessors : ~Copyable & P1 {
 public struct ImplBCoroutineAccessors : ~Copyable & P2 {
   var _i: U
   public var urs: U {
-    read {
+    yielding borrow {
       yield _i
     }
-    modify {
+    yielding mutate {
       yield &_i
     }
   }
@@ -789,8 +782,7 @@ public struct ImplBCoroutineAccessors : ~Copyable & P2 {
 // CHECK:         end_borrow [[SELF]]
 // CHECK:         return
 // CHECK:       [[FAILURE]]:
-// CHECK-NORMAL:  end_apply [[TOKEN]]
-// CHECK-UNWIND:  abort_apply [[TOKEN]]
+// CHECK:         end_apply [[TOKEN]]
 // CHECK:         dealloc_stack [[ALLOCATION]]
 // CHECK:         end_borrow [[SELF]]
 // CHECK:         unwind
@@ -802,7 +794,7 @@ public struct ImplBCoroutineAccessors : ~Copyable & P2 {
 public struct ImplCCoroutineAccessors : ~Copyable & P3 {
   var _i: U
   public var ur: U {
-    read {
+    yielding borrow {
       yield _i
     }
   }
@@ -894,8 +886,7 @@ public struct ImplCCoroutineAccessors : ~Copyable & P3 {
 // CHECK:         end_borrow [[SELF]]
 // CHECK:         return
 // CHECK:       [[FAILURE]]:
-// CHECK-NORMAL:  end_apply [[TOKEN]]
-// CHECK-UNWIND:  abort_apply [[TOKEN]]
+// CHECK:         end_apply [[TOKEN]]
 // CHECK:         dealloc_stack [[ALLOCATION]]
 // CHECK:         end_borrow [[SELF]]
 // CHECK:         unwind
@@ -994,8 +985,7 @@ public struct ImplAGetSet : P1 {
 // CHECK:         dealloc_stack [[ALLOCATION]]
 // CHECK:         return
 // CHECK:       [[FAILURE]]:
-// CHECK-NORMAL:  end_apply [[TOKEN]]
-// CHECK-UNWIND:  abort_apply [[TOKEN]]
+// CHECK:         end_apply [[TOKEN]]
 // CHECK:         dealloc_stack [[ALLOCATION]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements11ImplAGetSetVAA2P1A2aDP4ubgsAA1UVvyTW'
@@ -1058,8 +1048,7 @@ public struct ImplBGetSet : P2 {
 // CHECK:         dealloc_stack [[ALLOCATION]]
 // CHECK:         return
 // CHECK:       [[FAILURE]]:
-// CHECK-NORMAL:  end_apply [[TOKEN]]
-// CHECK-UNWIND:  abort_apply [[TOKEN]]
+// CHECK:         end_apply [[TOKEN]]
 // CHECK:         dealloc_stack [[ALLOCATION]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements11ImplBGetSetVAA2P2A2aDP3ursAA1UVvyTW'
@@ -1155,8 +1144,7 @@ public struct ImplCGetSet : P3 {
 // CHECK:         dealloc_stack [[ALLOCATION]]
 // CHECK:         return
 // CHECK:       [[FAILURE]]:
-// CHECK-NORMAL:  end_apply [[TOKEN]]
-// CHECK-UNWIND:  abort_apply [[TOKEN]]
+// CHECK:         end_apply [[TOKEN]]
 // CHECK:         dealloc_stack [[ALLOCATION]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements11ImplCGetSetVAA2P3A2aDP2urAA1UVvyTW'
@@ -1264,8 +1252,7 @@ public struct ImplAUnsafeAddressors : P1 {
 // CHECK:         dealloc_stack [[ALLOCATION]]
 // CHECK:         return
 // CHECK:       [[FAILURE]]:
-// CHECK-NORMAL:  end_apply [[TOKEN]]
-// CHECK-UNWIND:  abort_apply [[TOKEN]]
+// CHECK:         end_apply [[TOKEN]]
 // CHECK:         dealloc_stack [[ALLOCATION]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements21ImplAUnsafeAddressorsVAA2P1A2aDP4ubgsAA1UVvyTW'
@@ -1334,8 +1321,7 @@ public struct ImplBUnsafeAddressors : P2 {
 // CHECK:         dealloc_stack [[ALLOCATION]]
 // CHECK:         return
 // CHECK:       [[FAILURE]]:
-// CHECK-NORMAL:  end_apply [[TOKEN]]
-// CHECK-UNWIND:  abort_apply [[TOKEN]]
+// CHECK:         end_apply [[TOKEN]]
 // CHECK:         dealloc_stack [[ALLOCATION]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements21ImplBUnsafeAddressorsVAA2P2A2aDP3ursAA1UVvyTW'
@@ -1446,8 +1432,7 @@ public struct ImplCUnsafeAddressors : P3 {
 // CHECK:         dealloc_stack [[ALLOCATION]]
 // CHECK:         return
 // CHECK:       [[FAILURE]]:
-// CHECK-NORMAL:  end_apply [[TOKEN]]
-// CHECK-UNWIND:  abort_apply [[TOKEN]]
+// CHECK:         end_apply [[TOKEN]]
 // CHECK:         dealloc_stack [[ALLOCATION]]
 // CHECK:         unwind
 // CHECK-LABEL: } // end sil function '$s17read_requirements21ImplCUnsafeAddressorsVAA2P3A2aDP2urAA1UVvyTW'


### PR DESCRIPTION
In the context of coroutine/yielding accessors, "unwind" means that the second half of the coroutine (code _after_ the `yield` statement) will not run if an exception is thrown during the access.

Unwinding was the default behavor for legacy `_read`/`_modify` coroutine accessors.
For the new `yielding borrow`/`yielding mutate` accessors, unwinding was optional behind a separate feature flag.
But the final SE-0474 dictates that unwinding is always _disabled_ for the new yielding accessors.  That is, the new yielding accessors always run to completion, regardless of whether there are thrown exceptions within the access scope.  This was deemed essential to ensure that authors of data structures could guarantee consistency.

This PR permanently disables unwinding behavior for the new accessors. The feature flag still exists but has no effect.
A handful of tests that verified the unwinding behavior have been edited to ensure that unwinding does _not_ happen even when the feature flag is specified.
