### PR TITLE
[Swiftify] get module from canonical decl

### DIFF
--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -357,10 +357,17 @@ static const clang::Decl *getTemplateInstantiation(const clang::Decl *D) {
 }
 
 static clang::Module *getOwningModule(const clang::Decl *ClangDecl) {
+  std::optional<clang::Module *> M;
   if (const auto *Instance = getTemplateInstantiation(ClangDecl)) {
-    return Instance->getOwningModule();
+    M = importer::getClangSubmoduleForDecl(Instance, true);
+  } else {
+    M = importer::getClangSubmoduleForDecl(ClangDecl, true);
   }
-  return ClangDecl->getOwningModule();
+  if (M) {
+    // the inner value can be null, so flatten it
+    return M.value();
+  }
+  return nullptr;
 }
 
 struct ForwardDeclaredConcreteTypeVisitor : public TypeWalker {

--- a/test/Interop/C/swiftify-import/bridging-header-including-module.swift
+++ b/test/Interop/C/swiftify-import/bridging-header-including-module.swift
@@ -1,0 +1,68 @@
+// REQUIRES: swift_feature_SafeInteropWrappers
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -o %t/test.swiftmodule -I %t -import-bridging-header %t/bridging.h -enable-experimental-feature SafeInteropWrappers -strict-memory-safety %t/test.swift \
+// RUN:   -verify
+
+// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -o %t/test.swiftmodule -I %t -import-bridging-header %t/bridging.h -enable-experimental-feature SafeInteropWrappers -strict-memory-safety %t/test.swift \
+// RUN:   -dump-macro-expansions 2>&1 | %FileCheck --dry-run > %t/macro-expansions.out
+// RUN: %diff %t/macro-expansions.out %t/macro-expansions.expected
+
+// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -o %t/test.swiftmodule -I %t -import-bridging-header %t/bridging.h -enable-experimental-feature SafeInteropWrappers -strict-memory-safety %t/test.swift \
+// RUN:   -dump-source-file-imports 2>&1 | %FileCheck --dry-run > %t/imports.out
+// RUN: %diff %t/imports.out %t/imports.expected
+
+// This is a regression test that previously triggered `ASSERT(OwningModule || IsInBridgingHeader)`
+// in swiftifyImpl. It makes sure that the logic for fetching the owning module alignes with the
+// logic in getClangModuleForDecl().
+
+//--- imports.expected
+imports for TMP_DIR/test.swift:
+	Swift
+	__ObjC
+	_StringProcessing
+	_SwiftConcurrencyShims
+	_Concurrency
+	A
+imports for A.foo:
+imports for @__swiftmacro_So3foo15_SwiftifyImportfMp_.swift:
+	Swift
+	ptrcheck
+	_StringProcessing
+	_SwiftConcurrencyShims
+	_Concurrency
+
+//--- macro-expansions.expected
+@__swiftmacro_So3foo15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload public func foo(_ p: UnsafeMutableBufferPointer<Int32>) {
+    let len = Int32(exactly: p.count)!
+    return unsafe foo(len, p.baseAddress!)
+}
+------------------------------
+
+//--- test.swift
+import A
+
+func test(p: UnsafeMutableBufferPointer<CInt>) {
+  unsafe foo(p)
+}
+
+//--- bridging.h
+#include <ptrcheck.h>
+#include <a.h>
+
+void foo(int len, int * __counted_by(len) p);
+
+//--- a.h
+#include <ptrcheck.h>
+
+void foo(int len, int * __counted_by(len) p);
+
+//--- module.modulemap
+module A {
+  header "a.h"
+}


### PR DESCRIPTION
This aligns the logic in SwiftifyDecl.cpp for fetching the owning module with that of the rest of the compiler. Previously we would fetch the owning module from the clang decl directly associated with the Swift decl, whereas the rest of the compiler looks at the canoncial (first) decl to determine ownership. This mismatch resulted in a state where swiftifyImpl did not think the decl originated in a bridging header (because it was not imported into the __ObjC module), but it also didn't find an owning module on the clang decl. This occured when a bridging header would import a header from a module, and then redeclare a function from that module.

rdar://168703691