### PR TITLE
Fix the OSSA RAUW utility for unowned phis

### DIFF
--- a/include/swift/SILOptimizer/Utils/ValueLifetime.h
+++ b/include/swift/SILOptimizer/Utils/ValueLifetime.h
@@ -55,6 +55,10 @@ struct ValueLifetimeBoundary {
   /// excluding dead-end blocks. This is only useful when it is known that none
   /// of the lastUsers ends the lifetime, for example when creating a new borrow
   /// scope to enclose all uses.
+  ///
+  /// This requires that none of the lastUsers are phi nodes. Phi nodes that end
+  /// the lifetime are already prohibited, but clients must also check for
+  /// guaranteed forwarding and unowned phis.
   void visitInsertionPoints(
       llvm::function_ref<void(SILBasicBlock::iterator insertPt)> visitor,
       DeadEndBlocks *deBlocks = nullptr);

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -451,6 +451,8 @@ bool swift::findUsesOfSimpleValue(SILValue value,
         return false;
       }
       break;
+    case OperandOwnership::ForwardingUnowned:
+      return false;
     default:
       break;
     }

--- a/test/SILOptimizer/cse_ossa.sil
+++ b/test/SILOptimizer/cse_ossa.sil
@@ -1362,3 +1362,71 @@ bb2:
   return %16
 }
 
+/////////////////////////////////////////////////////////////////////////////
+// rdar168620481: bailout on uwnowed phis
+/////////////////////////////////////////////////////////////////////////////
+
+class Element {
+  @_hasStorage var skip: Optional<Unmanaged<Element>>
+  @_hasStorage var after: Optional<Element>
+}
+
+// The old value:
+//     %24 = unmanaged_to_ref %23 to $Element
+// cannot be replaced by
+//     %16 = copy_value %15
+// because %24 is used by phi node
+//     br bb2(%20, %24)
+//
+// Previously asserted in OwnershipLifetimeExtender::createPlusZeroCopy.
+// CHECK-LABEL: sil [ossa] @testUnownedPhi : {{.*}} {
+// CHECK:  unmanaged_to_ref %{{.*}} to $Element
+// CHECK-LABEL: } // end sil function 'testUnownedPhi'
+sil [ossa] @testUnownedPhi : $@convention(thin) (Optional<Unmanaged<Element>>) -> () {
+bb0(%0 : $Optional<Unmanaged<Element>>):
+  br bb1(%0)
+
+bb1(%2 : $Optional<Unmanaged<Element>>):
+  %3 = unchecked_enum_data %2, #Optional.some!enumelt
+  %4 = struct_extract %3, #Unmanaged._value
+  %5 = unmanaged_to_ref %4 to $Element
+  br bb2(%3, %5)
+
+
+bb2(%7 : $Unmanaged<Element>, %8 : @unowned $Element):
+  %9 = unchecked_ownership_conversion %8, @unowned to @guaranteed
+  %10 = ref_element_addr %9, #Element.after
+  %11 = load [copy] %10
+  %12 = begin_borrow [lexical] %11
+  switch_enum %12, case #Optional.some!enumelt: bb3, case #Optional.none!enumelt: bb6
+
+bb3(%14 : @guaranteed $Element):
+  %15 = unchecked_enum_data %12, #Optional.some!enumelt
+  %16 = copy_value %15
+  end_borrow %12
+  destroy_value %11
+  %19 = ref_to_unmanaged %16 to $@sil_unmanaged Element
+  %20 = struct $Unmanaged<Element> (%19)
+  destroy_value %16
+  end_borrow %9
+  %23 = struct_extract %20, #Unmanaged._value
+  %24 = unmanaged_to_ref %23 to $Element
+  cond_br undef, bb5, bb4
+
+bb4:
+  %26 = unchecked_ownership_conversion %24, @unowned to @guaranteed
+  %27 = ref_element_addr %26, #Element.skip
+  %28 = load [trivial] %27
+  end_borrow %26
+  br bb1(%28)
+
+bb5:
+  br bb2(%20, %24)
+
+bb6:
+  end_borrow %12
+  destroy_value %11
+  end_borrow %9
+  %35 = tuple ()
+  return %35
+}


### PR DESCRIPTION
The OwnershipRAUW utility is called by CSE, SILCombine, etc. whenever OSSA
values are substituted or combined. It handles ownership corner cases by
creating new copies. Destroys need to be insert for those new copies after all
original uses. It is impossible to do that when phis are involved. The utility
already checks for phis involving owned or guaranteed values, but unowned phis
were not anticipated.

Fixes rdar://168620481 swift-frontend crash: While running pass
SILFunctionTransform "GenericSpecializer"
