### PR TITLE
Sema: Prefer immediate binding sets

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5164,8 +5164,7 @@ public:
 
   /// Determine whether given type variable with its set of bindings is viable
   /// to be attempted on the next step of the solver.
-  const BindingSet *determineBestBindings(
-      llvm::function_ref<void(const BindingSet &)> onCandidate);
+  const BindingSet *determineBestBindings();
 
   /// Get bindings for the given type variable based on current
   /// state of the constraint system.

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1230,8 +1230,7 @@ bool BindingSet::operator<(const BindingSet &other) {
   }
 #include "swift/Sema/CSTrail.def"
 
-const BindingSet *ConstraintSystem::determineBestBindings(
-    llvm::function_ref<void(const BindingSet &)> onCandidate) {
+const BindingSet *ConstraintSystem::determineBestBindings() {
   // Look for potential type variable bindings.
   BindingSet *bestBindings = nullptr;
 
@@ -1280,7 +1279,12 @@ const BindingSet *ConstraintSystem::determineBestBindings(
     if (!isViable)
       continue;
 
-    onCandidate(bindings);
+    if (isDebugMode() && bindings.hasViableBindings()) {
+      auto &log = llvm::errs().indent(solverState->getCurrentIndent() + 2);
+      log << "(potential bindings ";
+      bindings.dump(log, solverState->getCurrentIndent() + 2);
+      log << ")\n";
+    }
 
     // If these are the first bindings, or they are better than what
     // we saw before, use them instead.

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -50,7 +50,9 @@ static bool isDirectRequirement(ConstraintSystem &cs,
 
 BindingSet::BindingSet(ConstraintSystem &CS, TypeVariableType *TypeVar,
                        const PotentialBindings &info)
-    : CS(CS), TypeVar(TypeVar), Info(info) {
+    : CS(CS), TypeVar(TypeVar), Info(info),
+      HasTransitiveProtocols(0),
+      HasImmediateBinding(0) {
 
   for (const auto &binding : info.Bindings)
     addBinding(binding);
@@ -390,7 +392,7 @@ bool BindingSet::isPotentiallyIncomplete() const {
 }
 
 void BindingSet::inferTransitiveProtocolRequirements() {
-  if (TransitiveProtocols)
+  if (HasTransitiveProtocols)
     return;
 
   llvm::SmallVector<std::pair<TypeVariableType *, TypeVariableType *>, 4>
@@ -437,12 +439,12 @@ void BindingSet::inferTransitiveProtocolRequirements() {
     // If current variable already has transitive protocol
     // conformances inferred, there is no need to look deeper
     // into subtype/equivalence chain.
-    if (bindings.TransitiveProtocols) {
+    if (bindings.HasTransitiveProtocols) {
       TypeVariableType *parent = nullptr;
       std::tie(parent, currentVar) = workList.pop_back_val();
       assert(parent);
       propagateProtocolsTo(parent, conformanceReqs,
-                            *bindings.TransitiveProtocols);
+                           bindings.TransitiveProtocols);
       continue;
     }
 
@@ -538,15 +540,15 @@ void BindingSet::inferTransitiveProtocolRequirements() {
       auto &node = CS.getConstraintGraph()[equivalence.first];
       if (node.hasBindingSet()) {
         auto &bindings = node.getBindingSet();
-        bindings.TransitiveProtocols.emplace(protocolsForEquivalence.begin(),
-                                             protocolsForEquivalence.end());
+        bindings.TransitiveProtocols = protocolsForEquivalence;
+        bindings.HasTransitiveProtocols = 1;
       }
     }
 
     // Update the bindings associated with current type variable,
     // to avoid repeating this inference process.
-    bindings.TransitiveProtocols.emplace(inferredProtocols.begin(),
-                                         inferredProtocols.end());
+    bindings.TransitiveProtocols = inferredProtocols;
+    bindings.HasTransitiveProtocols = 1;
   } while (!workList.empty());
 }
 
@@ -722,8 +724,8 @@ void BindingSet::inferTransitiveUnresolvedMemberRefBindings() {
         // \endcode
         inferTransitiveProtocolRequirements();
 
-        if (TransitiveProtocols.has_value()) {
-          for (auto *constraint : *TransitiveProtocols) {
+        if (HasTransitiveProtocols) {
+          for (auto *constraint : TransitiveProtocols) {
             Type protocolTy = constraint->getSecondType();
 
             // Compiler-known marker protocols cannot be extended with members,
@@ -1083,6 +1085,57 @@ void BindingSet::coalesceIntegerAndFloatLiteralRequirements() {
   }
 }
 
+static bool isImmediateBinding(PotentialBinding binding) {
+  switch (binding.Kind) {
+  case AllowedBindingKind::Subtypes:
+    // Only alowed if the type in fact has no proper subtypes.
+    return !hasConversions(binding.BindingType);
+  case AllowedBindingKind::Exact:
+    // Always allowed.
+    return true;
+  case AllowedBindingKind::Supertypes:
+    // Never allowed.
+    return false;
+  }
+}
+
+void BindingSet::simplifyImmediateBinding() {
+  // If we already performed this step, skip.
+  if (hasImmediateBinding())
+    return;
+
+  if (isHole())
+    return;
+
+  if (CS.shouldAttemptFixes())
+    return;
+
+  // Result type of subscript could be l-value so we can't bind it early.
+  if (TypeVar->getImpl().isSubscriptResultType() ||
+      llvm::any_of(Info.DelayedBy, [](const Constraint *constraint) {
+        return constraint->getKind() == ConstraintKind::Disjunction ||
+               constraint->getKind() == ConstraintKind::ValueMember;
+      })) {
+    return;
+  }
+
+  std::optional<PotentialBinding> immediateBinding;
+  for (const auto &binding : Bindings) {
+    if (isImmediateBinding(binding)) {
+      immediateBinding = binding;
+      break;
+    }
+  }
+
+  if (immediateBinding.has_value()) {
+    HasImmediateBinding = 1;
+    Bindings.clear();
+    Bindings.insert(*immediateBinding);
+    Literals.clear();
+    Defaults.clear();
+  }
+}
+
 void PotentialBindings::inferFromLiteral(Constraint *constraint) {
   ASSERT(TypeVar);
   ASSERT(isDirectRequirement(CS, TypeVar, constraint));
@@ -1169,8 +1222,11 @@ BindingSet::BindingScore BindingSet::formBindingScore(const BindingSet &b) {
                                    : b.TypeVar->getImpl().isClosureType() ? 1
                                                                           : 0;
 
-  return std::make_tuple(b.isHole(), numNonDefaultableBindings == 0,
-                         b.isDelayed(), b.isSubtypeOfExistentialType(),
+  return std::make_tuple(!b.hasImmediateBinding(),
+                         b.isHole(),
+                         numNonDefaultableBindings == 0,
+                         b.isDelayed(),
+                         b.isSubtypeOfExistentialType(),
                          b.involvesTypeVariables(),
                          static_cast<unsigned char>(b.getLiteralForScore()),
                          -numNonDefaultableBindings);
@@ -1278,6 +1334,8 @@ const BindingSet *ConstraintSystem::determineBestBindings() {
 
     if (!isViable)
       continue;
+
+    bindings.simplifyImmediateBinding();
 
     if (isDebugMode() && bindings.hasViableBindings()) {
       auto &log = llvm::errs().indent(solverState->getCurrentIndent() + 2);
@@ -1629,26 +1687,11 @@ bool BindingSet::isViable(PotentialBinding &binding) {
 }
 
 bool BindingSet::favoredOverDisjunction(Constraint *disjunction) const {
+  if (HasImmediateBinding)
+    return true;
+
   if (isHole())
     return false;
-
-  if (llvm::any_of(Bindings, [&](const PotentialBinding &binding) {
-        if (binding.Kind == AllowedBindingKind::Supertypes)
-          return false;
-
-        if (CS.shouldAttemptFixes())
-          return false;
-
-        return !hasConversions(binding.BindingType);
-      })) {
-    // Result type of subscript could be l-value so we can't bind it early.
-    if (!TypeVar->getImpl().isSubscriptResultType() &&
-        llvm::none_of(Info.DelayedBy, [](const Constraint *constraint) {
-          return constraint->getKind() == ConstraintKind::Disjunction ||
-                 constraint->getKind() == ConstraintKind::ValueMember;
-        }))
-      return true;
-  }
 
   if (isDelayed())
     return false;

--- a/lib/Sema/CSOptimizer.cpp
+++ b/lib/Sema/CSOptimizer.cpp
@@ -1790,14 +1790,6 @@ static DisjunctionInfo computeDisjunctionInfo(
         }
       });
 
-  if (cs.isDebugMode()) {
-    llvm::errs().indent(cs.solverState->getCurrentIndent())
-        << "<<< Disjunction "
-        << disjunction->getNestedConstraints()[0]->getFirstType()->getString(
-               PrintOptions::forDebugging())
-        << " with score " << bestScore << "\n";
-  }
-
   // Determine if the score and favoring decisions here are
   // based only on "speculative" sources i.e. inference from
   // literals.
@@ -1819,83 +1811,6 @@ static DisjunctionInfo computeDisjunctionInfo(
   }
 
   return info.build();
-}
-
-/// Given a set of disjunctions, attempt to determine
-/// favored choices in the current context.
-static void determineBestChoicesInContext(
-    ConstraintSystem &cs, SmallVectorImpl<Constraint *> &disjunctions,
-    llvm::DenseMap<Constraint *, DisjunctionInfo> &result) {
-  unsigned bestOverallScore = 0;
-
-  for (auto index : indices(disjunctions)) {
-    auto info = computeDisjunctionInfo(cs, disjunctions, index, result);
-    bestOverallScore = std::max(bestOverallScore, info.Score.value_or(0));
-    result.try_emplace(disjunctions[index], info);
-  }
-
-  if (cs.isDebugMode() && bestOverallScore > 0) {
-    PrintOptions PO = PrintOptions::forDebugging();
-
-    auto getLogger = [&](unsigned extraIndent = 0) -> llvm::raw_ostream & {
-      return llvm::errs().indent(cs.solverState->getCurrentIndent() +
-                                 extraIndent);
-    };
-
-    {
-      auto &log = getLogger();
-      log << "(Optimizing disjunctions: [";
-
-      interleave(
-          disjunctions,
-          [&](const auto *disjunction) {
-            log << disjunction->getNestedConstraints()[0]
-                       ->getFirstType()
-                       ->getString(PO);
-          },
-          [&]() { log << ", "; });
-
-      log << "]\n";
-    }
-
-    getLogger(/*extraIndent=*/4)
-        << "Best overall score = " << bestOverallScore << '\n';
-
-    for (auto *disjunction : disjunctions) {
-      auto found = result.find(disjunction);
-
-      getLogger(/*extraIndent=*/4)
-          << "[Disjunction '"
-          << disjunction->getNestedConstraints()[0]->getFirstType()->getString(
-                 PO);
-
-      if (found != result.end()) {
-        auto &entry = found->second;
-        if (entry.Score.has_value()) {
-          getLogger(/*extraIndent=*/4)
-              << "' with score = " << entry.Score.value_or(0) << '\n';
-        } else {
-          getLogger(/*extraIndent=*/4)
-              << "' without score\n";
-        }
-
-        for (const auto *choice : entry.FavoredChoices) {
-          auto &log = getLogger(/*extraIndent=*/6);
-
-          log << "- ";
-          choice->print(log, &cs.getASTContext().SourceMgr);
-          log << '\n';
-        }
-      } else {
-        getLogger(/*extraIndent=*/4)
-            << "' unsupported\n";
-      }
-
-      getLogger(/*extraIdent=*/4) << "]\n";
-    }
-
-    getLogger() << ")\n";
-  }
 }
 
 static std::optional<bool> isPreferable(ConstraintSystem &cs,
@@ -1924,22 +1839,118 @@ static std::optional<bool> isPreferable(ConstraintSystem &cs,
   return std::nullopt;
 }
 
+namespace {
+
+struct DisjunctionStats {
+  unsigned FavoredChoices = 0;
+  unsigned ActiveChoices = 0;
+  unsigned DisabledChoices = 0;
+
+  explicit DisjunctionStats(Constraint *disjunction) {
+    for (auto constraint : disjunction->getNestedConstraints()) {
+      if (constraint->isDisabled()) {
+        ++DisabledChoices;
+        continue;
+      }
+
+      ++ActiveChoices;
+    }
+  }
+
+  void print(llvm::raw_ostream &out) {
+    out << "active=" << ActiveChoices << " disabled=" << DisabledChoices;
+  }
+};
+
+}
+
 std::optional<std::pair<Constraint *, llvm::TinyPtrVector<Constraint *>>>
 ConstraintSystem::selectDisjunction() {
   SmallVector<Constraint *, 4> disjunctions;
 
   collectDisjunctions(disjunctions);
 
+  if (disjunctions.empty())
+    return std::nullopt;
+
+  auto getLogger = [&](unsigned extraIndent = 0) -> llvm::raw_ostream & {
+    return llvm::errs().indent(solverState->getCurrentIndent() +
+                               extraIndent);
+  };
+  PrintOptions PO = PrintOptions::forDebugging();
+
+  if (isDebugMode()) {
+    auto &log = getLogger();
+    log << "(select disjunction: (";
+    interleave(
+          disjunctions,
+          [&](const auto *disjunction) {
+            log << disjunction->getNestedConstraints()[0]
+                       ->getFirstType()
+                       ->getString(PO);
+          },
+          [&]() { log << " "; });
+
+      log << ")\n";
+  }
+
   if (unsigned seed = getASTContext().TypeCheckerOpts.ShuffleDisjunctionSeed) {
     std::mt19937 g(seed);
     std::shuffle(disjunctions.begin(), disjunctions.end(), g);
   }
 
-  if (disjunctions.empty())
-    return std::nullopt;
+  for (auto *disjunction : disjunctions)
+    pruneDisjunction(disjunction);
 
   llvm::DenseMap<Constraint *, DisjunctionInfo> favorings;
-  determineBestChoicesInContext(*this, disjunctions, favorings);
+
+  for (auto index : indices(disjunctions)) {
+    auto *disjunction = disjunctions[index];
+
+    auto applicableFn =
+        getApplicableFnConstraint(getConstraintGraph(), disjunction);
+    FunctionType *argFuncType = nullptr;
+    if (applicableFn) {
+      argFuncType =
+        applicableFn.get()->getFirstType()->getAs<FunctionType>();
+    }
+
+    pruneDisjunction(disjunction, applicableFn.getPtrOrNull());
+    auto info = computeDisjunctionInfo(*this, disjunctions, index, favorings);
+    favorings.try_emplace(disjunction, info);
+
+    if (isDebugMode()) {
+      auto &log = getLogger(/*extraIndent=*/4);
+      log << "(disjunction '"
+          << disjunction->getNestedConstraints()[0]->getFirstType()->getString(
+                 PO) << "': ";
+
+      DisjunctionStats(disjunction).print(log);
+
+      if (argFuncType)
+        log << " type=" << simplifyType(argFuncType)->getString(PO);
+
+      if (info.Score.has_value()) {
+        log << " score=" << info.Score.value_or(0) << ")\n";
+      } else {
+        log << " unsupported)\n";
+      }
+
+      for (const auto *choice : info.FavoredChoices) {
+        auto &log = getLogger(/*extraIndent=*/6);
+
+        log << "- ";
+        choice->print(log, &getASTContext().SourceMgr);
+        log << "\n";
+      }
+
+      log << ")\n";
+    }
+  }
+
+  if (isDebugMode()) {
+    getLogger() << ")\n";
+  }
 
   // Pick the disjunction with the smallest number of favored, then active
   // choices.

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -293,14 +293,6 @@ StepResult ComponentStep::take(bool prevFailed) {
       log << potentialBindings;
     }
 
-    if (!overloadDisjunctions.empty()) {
-      auto &log = getDebugLogger();
-      log.indent(CS.solverState->getCurrentIndent() + 2);
-      log << "Disjunction(s) = [";
-      interleave(overloadDisjunctions, log, ", ");
-      log << "]\n";
-    }
-
     if (!potentialBindings.empty() || !overloadDisjunctions.empty()) {
       auto &log = getDebugLogger();
       log << ")\n";


### PR DESCRIPTION
If a BindingSet has a Subtype binding to a type with no proper subtypes, or an Exact binding, we would favor it over a disjunction, however we would not necessarily favor it over other binding sets. Change the order so that we always favor such BindingSets.

Also, we don't have to attempt any supertype, literal, or default bindings for such a type variable. Delete them from the BindingSet before attempting.