### PR TITLE
[SwiftToCxx] don't include <cstdbool>

### DIFF
--- a/lib/PrintAsClang/PrintAsClang.cpp
+++ b/lib/PrintAsClang/PrintAsClang.cpp
@@ -131,7 +131,6 @@ static void writePrologue(raw_ostream &out, ASTContext &ctx,
       [&] {
         out << "#include <cstdint>\n"
                "#include <cstddef>\n"
-               "#include <cstdbool>\n"
                "#include <cstring>\n";
         out << "#include <stdlib.h>\n";
         out << "#include <new>\n";

--- a/test/PrintAsCxx/empty.swift
+++ b/test/PrintAsCxx/empty.swift
@@ -27,7 +27,6 @@
 // CHECK-NEXT:  #if defined(__cplusplus)
 // CHECK-NEXT:  #include <cstdint>
 // CHECK-NEXT:  #include <cstddef>
-// CHECK-NEXT:  #include <cstdbool>
 // CHECK-NEXT:  #include <cstring>
 // CHECK-NEXT:  #include <stdlib.h>
 // CHECK-NEXT:  #include <new>


### PR DESCRIPTION
This header is deprecated in C++17 onwards, and including it triggers a warning in Fedora 43. Since C++ has native support for bool, it doesn't actually define anything other than macros confirming that bool is defined.

Resolves #86769
rdar://168833492