### PR TITLE
[Draft] Enable safe interop by default

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -324,7 +324,7 @@ EXPERIMENTAL_FEATURE(NamedOpaqueTypes, false)
 EXPERIMENTAL_FEATURE(FlowSensitiveConcurrencyCaptures, false)
 EXPERIMENTAL_FEATURE(CodeItemMacros, false)
 EXPERIMENTAL_FEATURE(PreambleMacros, false)
-EXPERIMENTAL_FEATURE(MacrosOnImports, true)
+LANGUAGE_FEATURE(MacrosOnImports, 0, "allow attaching Swift macros with swift_attr")
 EXPERIMENTAL_FEATURE(TupleConformances, false)
 EXPERIMENTAL_FEATURE(FullTypedThrows, false)
 EXPERIMENTAL_FEATURE(SameElementRequirements, false)
@@ -494,7 +494,7 @@ EXPERIMENTAL_FEATURE(TrailingComma, false)
 
 // Import bounds safety and lifetime attributes from interop headers to
 // generate Swift wrappers with safe pointer types.
-EXPERIMENTAL_FEATURE(SafeInteropWrappers, true)
+LANGUAGE_FEATURE(SafeInteropWrappers, 0, "wrap imported functions with safe interfaces")
 
 /// Ignore resilience errors due to C++ types.
 EXPERIMENTAL_FEATURE(AssumeResilientCxxTypes, true)

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -2347,6 +2347,8 @@ AvailableAttr::AvailableAttr(
       IntroducedRange(IntroducedRange), Deprecated(Deprecated),
       DeprecatedRange(DeprecatedRange), Obsoleted(Obsoleted),
       ObsoletedRange(ObsoletedRange) {
+  ASSERT(!Introduced.empty() || !Deprecated.empty() || !Obsoleted.empty() ||
+      !Message.empty() || !Rename.empty() || Kind != Kind::Default);
   Bits.AvailableAttr.Kind = static_cast<uint8_t>(Kind);
   Bits.AvailableAttr.IsSPI = IsSPI;
   Bits.AvailableAttr.IsGroupMember = false;

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -2347,8 +2347,6 @@ AvailableAttr::AvailableAttr(
       IntroducedRange(IntroducedRange), Deprecated(Deprecated),
       DeprecatedRange(DeprecatedRange), Obsoleted(Obsoleted),
       ObsoletedRange(ObsoletedRange) {
-  ASSERT(!Introduced.empty() || !Deprecated.empty() || !Obsoleted.empty() ||
-      !Message.empty() || !Rename.empty() || Kind != Kind::Default);
   Bits.AvailableAttr.Kind = static_cast<uint8_t>(Kind);
   Bits.AvailableAttr.IsSPI = IsSPI;
   Bits.AvailableAttr.IsGroupMember = false;

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -593,8 +593,10 @@ void importer::getNormalInvocationArguments(
     }
   }
 
-  if (LangOpts.hasFeature(Feature::SafeInteropWrappers))
+  if (LangOpts.hasFeature(Feature::SafeInteropWrappers)) {
     invocationArgStrs.push_back("-fexperimental-bounds-safety-attributes");
+    invocationArgStrs.push_back("-D__LIBC_STAGED_BOUNDS_SAFETY_ATTRIBUTES");
+  }
 
   // Set C language options.
   if (triple.isOSDarwin()) {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -9553,6 +9553,10 @@ void ClangImporter::Implementation::importAttributes(
 
       const auto &replacement = avail->getReplacement();
 
+      if (introduced.empty() && deprecated.empty() && obsoleted.empty() &&
+          message.empty() && replacement.empty())
+        continue;
+
       StringRef swiftReplacement = "";
       if (!replacement.empty())
         swiftReplacement = getSwiftNameFromClangName(replacement);

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -9554,7 +9554,8 @@ void ClangImporter::Implementation::importAttributes(
       const auto &replacement = avail->getReplacement();
 
       if (introduced.empty() && deprecated.empty() && obsoleted.empty() &&
-          message.empty() && replacement.empty())
+          message.empty() && replacement.empty() &&
+          AttrKind == AvailableAttr::Kind::Default)
         continue;
 
       StringRef swiftReplacement = "";

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -738,6 +738,7 @@ void ClangImporter::Implementation::swiftify(AbstractFunctionDecl *MappedDecl) {
 
 void ClangImporter::Implementation::swiftifyProtocol(
     NominalTypeDecl *MappedDecl) {
+  return; // disable for now
   if (!SwiftContext.LangOpts.hasFeature(Feature::SafeInteropWrappers))
     return;
   if (!isa<ProtocolDecl, ClassDecl>(MappedDecl))

--- a/test/Interop/C/swiftify-import/availability.swift
+++ b/test/Interop/C/swiftify-import/availability.swift
@@ -1,0 +1,115 @@
+// REQUIRES: swift_feature_SafeInteropWrappers
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/test.swiftmodule %t/test.swift -I %t -enable-experimental-feature SafeInteropWrappers -strict-memory-safety \
+// RUN:   -verify -verify-additional-file %t%{fs-sep}test.h
+
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/test.swiftmodule %t/test.swift -I %t -enable-experimental-feature SafeInteropWrappers -strict-memory-safety \
+// RUN:   -dump-macro-expansions 2> %t/expansions.out
+
+// RUN: %if OS=macosx %{ \
+// RUN:   %diff %t/macos-expansions.expected %t/expansions.out %} \
+// RUN: %else %{\
+// RUN:   %if OS=ios %{ \
+// RUN:     %diff %t/ios-expansions.expected %t/expansions.out \
+// RUN:   %} %else %{ \
+// RUN:     %diff %t/other-expansions.expected %t/expansions.out \
+// RUN:   %} \
+// RUN: %}
+
+//--- test.h
+#pragma once
+
+#define __counted_by(x) __attribute__((__counted_by__(x)))
+#define __noescape __attribute__((noescape))
+
+void bufferPointer(int *__counted_by(len), int len) __attribute__((availability(ios,introduced=2.0))) __attribute__((availability(macosx,introduced=10.5)));
+void span(int *__counted_by(len) p __noescape, int len) __attribute__((availability(ios,introduced=2.0))) __attribute__((availability(macosx,introduced=10.5)));
+
+//--- macos-expansions.expected
+@__swiftmacro_So13bufferPointer15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@available(macOS 10.5, *) @_alwaysEmitIntoClient @_disfavoredOverload
+public func bufferPointer(_ _bufferPointer_param0: UnsafeMutableBufferPointer<Int32>) {
+    let _bufferPointer_param1 = Int32(exactly: _bufferPointer_param0.count)!
+    return unsafe bufferPointer(_bufferPointer_param0.baseAddress!, _bufferPointer_param1)
+}
+------------------------------
+@__swiftmacro_So4span15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@available(macOS 10.5, *) @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
+public func span(_ p: inout MutableSpan<Int32>) {
+    let len = Int32(exactly: p.count)!
+    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+      return unsafe span(_pPtr.baseAddress!, len)
+    }
+}
+------------------------------
+//--- ios-expansions.expected
+@__swiftmacro_So13bufferPointer15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@available(iOS 2.0, *) @_alwaysEmitIntoClient @_disfavoredOverload
+public func bufferPointer(_ _bufferPointer_param0: UnsafeMutableBufferPointer<Int32>) {
+    let _bufferPointer_param1 = Int32(exactly: _bufferPointer_param0.count)!
+    return unsafe bufferPointer(_bufferPointer_param0.baseAddress!, _bufferPointer_param1)
+}
+------------------------------
+@__swiftmacro_So4span15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@available(iOS 2.0, *) @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
+public func span(_ p: inout MutableSpan<Int32>) {
+    let len = Int32(exactly: p.count)!
+    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+      return unsafe span(_pPtr.baseAddress!, len)
+    }
+}
+------------------------------
+//--- other-expansions.expected
+@__swiftmacro_So13bufferPointer15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload public func bufferPointer(_ _bufferPointer_param0: UnsafeMutableBufferPointer<Int32>) {
+    let _bufferPointer_param1 = Int32(exactly: _bufferPointer_param0.count)!
+    return unsafe bufferPointer(_bufferPointer_param0.baseAddress!, _bufferPointer_param1)
+}
+------------------------------
+@__swiftmacro_So4span15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public func span(_ p: inout MutableSpan<Int32>) {
+    let len = Int32(exactly: p.count)!
+    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+      return unsafe span(_pPtr.baseAddress!, len)
+    }
+}
+------------------------------
+//--- test.swift
+import Test
+
+func callBufferPointer(_ p: UnsafeMutablePointer<CInt>, len: CInt) {
+  unsafe bufferPointer(p, len)
+}
+
+func callBufferPointer(_ p: UnsafeMutableBufferPointer<CInt>) {
+  unsafe bufferPointer(p)
+}
+
+func callSpan(_ p: UnsafeMutablePointer<CInt>, len: CInt) {
+  unsafe span(p, len)
+}
+
+func callSpan(_ p: inout MutableSpan<CInt>) {
+  span(&p)
+}
+
+//--- module.modulemap
+module Test {
+  header "test.h"
+}
+

--- a/test/Interop/C/swiftify-import/availability.swift
+++ b/test/Interop/C/swiftify-import/availability.swift
@@ -6,7 +6,7 @@
 // RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/test.swiftmodule %t/test.swift -I %t -enable-experimental-feature SafeInteropWrappers -strict-memory-safety \
 // RUN:   -verify -verify-additional-file %t%{fs-sep}test.h
 
-// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/test.swiftmodule %t/test.swift -I %t -enable-experimental-feature SafeInteropWrappers -strict-memory-safety \
+// RUN: env SWIFT_BACKTRACE="" %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/test.swiftmodule %t/test.swift -I %t -enable-experimental-feature SafeInteropWrappers -strict-memory-safety \
 // RUN:   -dump-macro-expansions 2> %t/expansions.out
 
 // RUN: %if OS=macosx %{ \


### PR DESCRIPTION
This enables safe interop wrappers by default, and tells clang to enable bounds safety attributes in libc.

Stacked on top of https://github.com/swiftlang/swift/pull/86613.