### PR TITLE
[Sema] 61733 error message improvement

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1754,18 +1754,22 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
           // ignore Any
           if (unwrapped->isAny())
             return std::nullopt;
-          if (unwrapped->isAnyExistentialType()) {
-            auto layout = unwrapped->getExistentialLayout();
-            if (!layout.requiresClass()) {
-              auto openedAfterPeel = shouldOpenExistentialCallArgument(
-                  callee, paramIdx, paramTy, unwrapped, argExpr, cs);
-              if (openedAfterPeel) {
-                cs.recordFix(ForceOptional::create(
-                    cs, argTy, unwrapped, cs.getConstraintLocator(loc)));
-                return openedAfterPeel;
-              }
-            }
-          }
+
+          if (!unwrapped->isAnyExistentialType())
+            return std::nullopt;
+
+          auto layout = unwrapped->getExistentialLayout();
+          if (layout.requiresClass())
+            return std::nullopt;
+
+          auto openedAfterPeel = shouldOpenExistentialCallArgument(
+              callee, paramIdx, paramTy, unwrapped, argExpr, cs);
+          if (!openedAfterPeel || !paramTy->getOptionalObjectType())
+            return std::nullopt;
+
+          cs.recordFix(ForceOptional::create(cs, argTy, unwrapped,
+                                             cs.getConstraintLocator(loc)));
+          return openedAfterPeel;
         }
         return std::nullopt;
       };

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1750,19 +1750,21 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
           return std::nullopt;
 
         if (Type optObject = argTy->getOptionalObjectType()) {
-          Type unwrapped = optObject->lookThroughAllOptionalTypes();
-          if (unwrapped->isAnyExistentialType()) {
-            auto layout = unwrapped->getExistentialLayout();
-            if (!layout.requiresClass()) {
+          if (paramTy->getOptionalObjectType()) {
+            Type unwrapped = optObject->lookThroughAllOptionalTypes();
+            if (unwrapped->isAnyExistentialType()) {
+              auto layout = unwrapped->getExistentialLayout();
+              if (!layout.requiresClass()) {
 
-              auto openedAfterPeel = shouldOpenExistentialCallArgument(
-                  callee, paramIdx, paramTy, unwrapped, argExpr, cs);
+                auto openedAfterPeel = shouldOpenExistentialCallArgument(
+                    callee, paramIdx, paramTy, unwrapped, argExpr, cs);
 
-              if (openedAfterPeel) {
-                cs.recordFix(ForceOptional::create(
-                    cs, argTy, unwrapped, cs.getConstraintLocator(loc)));
+                if (openedAfterPeel) {
+                  cs.recordFix(ForceOptional::create(
+                      cs, argTy, unwrapped, cs.getConstraintLocator(loc)));
 
-                return openedAfterPeel;
+                  return openedAfterPeel;
+                }
               }
             }
           }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1385,38 +1385,6 @@ shouldOpenExistentialCallArgument(ValueDecl *callee, unsigned paramIdx,
   return result;
 }
 
-// Identifies Swift language runtime and standard library implementation
-// modules.
-//
-// Certain diagnostics (e.g. ForceOptional for optional existentials passed
-// to generic parameters) are only appropriate in user code. This helper is
-// used to suppress those fixes while compiling the standard library and its
-// supporting runtime modules, where such patterns are intentional.
-
-static bool isLanguageRuntimeModule(ModuleDecl *module) {
-
-  if (!module)
-    return false;
-
-  auto &ctx = module->getASTContext();
-
-  if (module == ctx.getStdlibModule())
-    return true;
-
-  if (module == ctx.TheBuiltinModule)
-    return true;
-
-  auto name = module->getName();
-
-  return name.is("Distributed") ||
-    name.is("Foundation") ||
-    name.is("Observation") ||
-    name.is("StdlibUnittest") ||
-    name.is("_Concurrency") ||
-    name.is("_Differentiation") ||
-    name.is("_StringProcessing");
-}
-
 // Match the argument of a call to the parameter.
 static ConstraintSystem::TypeMatchResult matchCallArguments(
     ConstraintSystem &cs, FunctionType *contextualType, ArgumentList *argList,
@@ -1770,7 +1738,7 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
         Type argTypeForOpening = argTy;
 
         auto *module = cs.DC->getParentModule();
-        if (!module || isLanguageRuntimeModule(module)) {
+        if (!module) {
           return shouldOpenExistentialCallArgument(
               callee, paramIdx, paramTy, argTypeForOpening, argExpr, cs);
         }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1736,14 +1736,8 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
         [&]() -> std::optional<std::pair<TypeVariableType *, Type>> {
 
         Type argTypeForOpening = argTy;
-
-        auto *module = cs.DC->getParentModule();
-        if (!module) {
-          return shouldOpenExistentialCallArgument(
-              callee, paramIdx, paramTy, argTypeForOpening, argExpr, cs);
-        }
         // 1) First try: the normal path.
-        auto opened = ::shouldOpenExistentialCallArgument(
+        auto opened = shouldOpenExistentialCallArgument(
             callee, paramIdx, paramTy, argTypeForOpening, argExpr, cs);
 
         if (opened)

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1733,8 +1733,7 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
       }
 
       auto shouldOpenExistentialArgument =
-        [&]() -> std::optional<std::pair<TypeVariableType *, Type>> {
-
+          [&]() -> std::optional<std::pair<TypeVariableType *, Type>> {
         Type argTypeForOpening = argTy;
         // 1) First try: the normal path.
         auto opened = shouldOpenExistentialCallArgument(
@@ -1743,9 +1742,10 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
         if (opened)
           return opened;
 
-        // 2) If opening failed, consider ForceOptional ONLY if fixes are enabled
-        //    and arg is Optional whose object is an existential any ... with protocols
-        //    and not class-constrained.
+        // 2) If opening failed, consider ForceOptional ONLY if fixes are
+        // enabled
+        //    and arg is Optional whose object is an existential any ... with
+        //    protocols and not class-constrained.
         if (!cs.shouldAttemptFixes())
           return std::nullopt;
 
@@ -1759,10 +1759,8 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
                   callee, paramIdx, paramTy, unwrapped, argExpr, cs);
 
               if (openedAfterPeel) {
-                cs.recordFix(ForceOptional::create(cs,
-                                                   argTy,
-                                                   unwrapped,
-                                                   cs.getConstraintLocator(loc)));
+                cs.recordFix(ForceOptional::create(
+                    cs, argTy, unwrapped, cs.getConstraintLocator(loc)));
 
                 return openedAfterPeel;
               }
@@ -1786,7 +1784,7 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
 
           Type openedTy;
           std::tie(openedTy, openedArchetype) =
-            cs.openAnyExistentialType(t, cs.getConstraintLocator(loc));
+              cs.openAnyExistentialType(t, cs.getConstraintLocator(loc));
 
           return openedTy;
         });

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1750,21 +1750,19 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
           return std::nullopt;
 
         if (Type optObject = argTy->getOptionalObjectType()) {
-          if (paramTy->getOptionalObjectType()) {
-            Type unwrapped = optObject->lookThroughAllOptionalTypes();
-            if (unwrapped->isAnyExistentialType()) {
-              auto layout = unwrapped->getExistentialLayout();
-              if (!layout.requiresClass()) {
-
-                auto openedAfterPeel = shouldOpenExistentialCallArgument(
-                    callee, paramIdx, paramTy, unwrapped, argExpr, cs);
-
-                if (openedAfterPeel) {
-                  cs.recordFix(ForceOptional::create(
-                      cs, argTy, unwrapped, cs.getConstraintLocator(loc)));
-
-                  return openedAfterPeel;
-                }
+          Type unwrapped = optObject->lookThroughAllOptionalTypes();
+          // ignore Any
+          if (unwrapped->isAny())
+            return std::nullopt;
+          if (unwrapped->isAnyExistentialType()) {
+            auto layout = unwrapped->getExistentialLayout();
+            if (!layout.requiresClass()) {
+              auto openedAfterPeel = shouldOpenExistentialCallArgument(
+                  callee, paramIdx, paramTy, unwrapped, argExpr, cs);
+              if (openedAfterPeel) {
+                cs.recordFix(ForceOptional::create(
+                    cs, argTy, unwrapped, cs.getConstraintLocator(loc)));
+                return openedAfterPeel;
               }
             }
           }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1385,6 +1385,38 @@ shouldOpenExistentialCallArgument(ValueDecl *callee, unsigned paramIdx,
   return result;
 }
 
+// Identifies Swift language runtime and standard library implementation
+// modules.
+//
+// Certain diagnostics (e.g. ForceOptional for optional existentials passed
+// to generic parameters) are only appropriate in user code. This helper is
+// used to suppress those fixes while compiling the standard library and its
+// supporting runtime modules, where such patterns are intentional.
+
+static bool isLanguageRuntimeModule(ModuleDecl *module) {
+
+  if (!module)
+    return false;
+
+  auto &ctx = module->getASTContext();
+
+  if (module == ctx.getStdlibModule())
+    return true;
+
+  if (module == ctx.TheBuiltinModule)
+    return true;
+
+  auto name = module->getName();
+
+  return name.is("Distributed") ||
+    name.is("Foundation") ||
+    name.is("Observation") ||
+    name.is("StdlibUnittest") ||
+    name.is("_Concurrency") ||
+    name.is("_Differentiation") ||
+    name.is("_StringProcessing");
+}
+
 // Match the argument of a call to the parameter.
 static ConstraintSystem::TypeMatchResult matchCallArguments(
     ConstraintSystem &cs, FunctionType *contextualType, ArgumentList *argList,
@@ -1732,28 +1764,68 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
         }
       }
 
-      // If the argument is an existential type and the parameter is generic,
-      // consider opening the existential type.
-      if (auto typeVarAndBindingTy = shouldOpenExistentialCallArgument(
-              callee, paramIdx, paramTy, argTy, argExpr, cs)) {
-        // My kingdom for a decent "if let" in C++.
+      auto shouldOpenExistentialArgument =
+      [&]() -> std::optional<std::pair<TypeVariableType *, Type>> {
+
+        Type argTypeForOpening = argTy;
+
+        auto *module = cs.DC ? cs.DC->getParentModule() : nullptr;
+        if (!module || isLanguageRuntimeModule(module)) {
+          return shouldOpenExistentialCallArgument(
+              callee, paramIdx, paramTy, argTypeForOpening, argExpr, cs);
+        }
+        // 1) First try: the normal path.
+        auto opened = ::shouldOpenExistentialCallArgument(
+            callee, paramIdx, paramTy, argTypeForOpening, argExpr, cs);
+
+        if (opened)
+          return opened;
+
+        // 2) If opening failed, consider ForceOptional ONLY if fixes are enabled
+        //    and arg is Optional whose object is an existential any ... with protocols
+        //    and not class-constrained.
+        if (!cs.shouldAttemptFixes())
+          return std::nullopt;
+
+        if (Type optObject = argTy->getOptionalObjectType()) {
+          Type unwrapped = optObject->lookThroughAllOptionalTypes();
+          if (unwrapped->isAnyExistentialType()) {
+            auto layout = unwrapped->getExistentialLayout();
+            if (!layout.getProtocols().empty() && !layout.requiresClass()) {
+
+              auto openedAfterPeel = shouldOpenExistentialCallArgument(
+                  callee, paramIdx, paramTy, unwrapped, argExpr, cs);
+
+              if (openedAfterPeel) {
+                cs.recordFix(ForceOptional::create(cs,
+                                                   argTy,
+                                                   unwrapped,
+                                                   cs.getConstraintLocator(loc)));
+
+                return openedAfterPeel;
+              }
+            }
+          }
+        }
+        return std::nullopt;
+      };
+
+      if (auto typeVarAndBindingTy = shouldOpenExistentialArgument()) {
         TypeVariableType *typeVar;
         Type bindingTy;
         std::tie(typeVar, bindingTy) = *typeVarAndBindingTy;
 
-        ExistentialArchetypeType *openedArchetype;
+        ExistentialArchetypeType *openedArchetype = nullptr;
 
-        // Open the argument type.
-        argTy = argTy.transformRec([&](TypeBase *t) -> std::optional<Type> {
-          if (t->isAnyExistentialType()) {
+        argTy = argTy.transformRec([&](TypeBase *t)-> std::optional<Type> {
+            if (!t->isAnyExistentialType())
+                return std::nullopt;
+
             Type openedTy;
             std::tie(openedTy, openedArchetype) =
                 cs.openAnyExistentialType(t, cs.getConstraintLocator(loc));
 
             return openedTy;
-          }
-
-          return std::nullopt;
         });
 
         openedExistentials.push_back({typeVar, openedArchetype});

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1787,14 +1787,14 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
 
         // Open the argument type.
         argTy = argTy.transformRec([&](TypeBase *t) -> std::optional<Type> {
-            if (!t->isAnyExistentialType())
-                return std::nullopt;
+          if (!t->isAnyExistentialType())
+            return std::nullopt;
 
-            Type openedTy;
-            std::tie(openedTy, openedArchetype) =
-                cs.openAnyExistentialType(t, cs.getConstraintLocator(loc));
+          Type openedTy;
+          std::tie(openedTy, openedArchetype) =
+            cs.openAnyExistentialType(t, cs.getConstraintLocator(loc));
 
-            return openedTy;
+          return openedTy;
         });
 
         openedExistentials.push_back({typeVar, openedArchetype});

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1765,11 +1765,11 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
       }
 
       auto shouldOpenExistentialArgument =
-      [&]() -> std::optional<std::pair<TypeVariableType *, Type>> {
+        [&]() -> std::optional<std::pair<TypeVariableType *, Type>> {
 
         Type argTypeForOpening = argTy;
 
-        auto *module = cs.DC ? cs.DC->getParentModule() : nullptr;
+        auto *module = cs.DC->getParentModule();
         if (!module || isLanguageRuntimeModule(module)) {
           return shouldOpenExistentialCallArgument(
               callee, paramIdx, paramTy, argTypeForOpening, argExpr, cs);
@@ -1791,7 +1791,7 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
           Type unwrapped = optObject->lookThroughAllOptionalTypes();
           if (unwrapped->isAnyExistentialType()) {
             auto layout = unwrapped->getExistentialLayout();
-            if (!layout.getProtocols().empty() && !layout.requiresClass()) {
+            if (!layout.requiresClass()) {
 
               auto openedAfterPeel = shouldOpenExistentialCallArgument(
                   callee, paramIdx, paramTy, unwrapped, argExpr, cs);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1785,7 +1785,8 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
 
         ExistentialArchetypeType *openedArchetype = nullptr;
 
-        argTy = argTy.transformRec([&](TypeBase *t)-> std::optional<Type> {
+        // Open the argument type.
+        argTy = argTy.transformRec([&](TypeBase *t) -> std::optional<Type> {
             if (!t->isAnyExistentialType())
                 return std::nullopt;
 

--- a/test/Constraints/ImplicitOpenExistentials/Inputs/opened_existentials.swift
+++ b/test/Constraints/ImplicitOpenExistentials/Inputs/opened_existentials.swift
@@ -201,13 +201,13 @@ func passesInOut(i: Int) {
 }
 
 func takesOptional<T: P>(_ value: T?) { }
-// expected-note@-1{{required by global function 'takesOptional' where 'T' = 'any P'}}
 
 func passesToOptional(p: any P, pOpt: (any P)?) {
   // SWIFT-5-AND-6: open_existential_expr {{.*}} location={{.*}}:[[@LINE+1]]:{{[0-9]+}} range=
   takesOptional(p) // okay
-  takesOptional(pOpt) // expected-error{{type 'any P' cannot conform to 'P'}}
-  // expected-note@-1{{only concrete types such as structs, enums and classes can conform to protocols}}
+  takesOptional(pOpt) // expected-error{{value of optional type '(any P)?' must be unwrapped to a value of type 'any P'}}
+  // expected-note@-1{{coalesce using '??' to provide a default when the optional value contains 'nil'}}
+  // expected-note@-2{{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
 }
 
 

--- a/test/Constraints/issue-61733.swift
+++ b/test/Constraints/issue-61733.swift
@@ -1,0 +1,16 @@
+// RUN: %target-typecheck-verify-swift
+// REQUIRES: asserts
+// Issue: https://github.com/swiftlang/swift/issues/61733
+// Verifies SE-0375 fix for (any P)? → (some P) conversion via ForceOptional
+
+protocol P {}
+struct S: P {}
+
+func takesOptionalP(_: (some P)?) {}
+
+func passOptional(foo: (any P)?) {
+    takesOptionalP(foo)
+    // expected-error @-1 {{value of optional type '(any P)?' must be unwrapped to a value of type 'any P'}}
+    // expected-note @-2 {{coalesce using '??' to provide a default when the optional value contains 'nil'}}
+    // expected-note @-3 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+}


### PR DESCRIPTION
### Supercedes
[PR86370](https://github.com/swiftlang/swift/pull/86370)
Replaces previous PR on this issue.  Based on reviewer feedback from @xedin the original approach was not correct, so there was no point in preserving any of the commit history.

### Resolves
[Issue 61733](https://github.com/swiftlang/swift/issues/61733)

### Problem Statement
If you try to pass a value of type (any P)? to an argument of type (some P)?, the compiler tells you that any P cannot conform to P, which is confusing and not actionable. With [SE-0375](https://github.com/apple/swift-evolution/blob/main/proposals/0375-opening-existential-optional.md), existential opening/unboxing is supported with optionals, but only if the argument is not an optional because it's possible that the (any P)? is nil (and thus does not have a dynamic type to bind to some P). With [SE-0375](https://swiftlang.github.io/swift-evolution/#?proposal=SE-0375), the fix is to unwrap the optional or provide a default value. So, the error message should tell you that!

#### Reproducer code

````
protocol P {}

struct S: P {}

func takesOptionalP(_: (some P)?) {}

func passOptional(value: (any P)?) {
  takesOptionalP(value) // error: type 'any P' cannot conform to 'P'

  takesOptionalP(value ?? S()) // okay under SE-0375
  takesOptionalP(value!) // okay under SE-0375
}
````
The constraint system currently applies the MissingConformance fix when solving for the takesOptionalP(value) expression. Instead, it should identify that the wrapped type of the argument matches the parameter type, and apply the ForceOptional fix.

### Cause
During constraint solving for takesOptionalP(value), the constraint system records a viable ForceOptional fix at the call site, but during salvage it still applies MissingConformance, producing a misleading protocol conformance diagnostic.

### Changes
+ Adds a check in matchCallArguments() to detect the case where an optional existential is being passed to a generic parameter. If the existential’s layout is valid and non-class-bound, we now record a ForceOptional fix.
+ A regression test was added under test/Constraints/issue-61733.swift.
+ An existing test case was updated (as the output changed and it would not have worked)

## Before
````
$ cat 61733.swift 
protocol P {}
struct S: P {}

func takesOptionalP(_: (some P)?) {}

// Test Case 01
func passOptional(foo: (any P)?) {
    takesOptionalP(foo)
}

$ swiftc 61733.swift 
61733.swift:8:5: error: type 'any P' cannot conform to 'P'
 2 | struct S: P {}
 3 | 
 4 | func takesOptionalP(_: (some P)?) {}
   |      `- note: required by global function 'takesOptionalP' where 'some P' = 'any P'
 5 | 
 6 | // Test Case 01
 7 | func passOptional(foo: (any P)?) {
 8 |     takesOptionalP(foo)
   |     |- error: type 'any P' cannot conform to 'P'
   |     `- note: only concrete types such as structs, enums and classes can conform to protocols
 9 | }
10 | 
````

## After
````
$ cat 61733.swift 
protocol P {}
struct S: P {}

func takesOptionalP(_: (some P)?) {}

// Test Case 01
func passOptional(foo: (any P)?) {
    takesOptionalP(foo)
}

$ swiftc 61733.swift 
61733.swift:8:20: error: value of optional type '(any P)?' must be unwrapped to a value of type 'any P'
 6 | // Test Case 01
 7 | func passOptional(foo: (any P)?) {
 8 |     takesOptionalP(foo)
   |                    |- error: value of optional type '(any P)?' must be unwrapped to a value of type 'any P'
   |                    |- note: coalesce using '??' to provide a default when the optional value contains 'nil'
   |                    `- note: force-unwrap using '!' to abort execution if the optional value contains 'nil'
 9 | }
10 | 
````