### PR TITLE
test/DebugInfo/LoadableByAddress.swift: require `PTRSIZE=64`

### DIFF
--- a/test/DebugInfo/LoadableByAddress.swift
+++ b/test/DebugInfo/LoadableByAddress.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend %s -module-name A -emit-ir -g -o - | %FileCheck %s
+// REQUIRES: PTRSIZE=64
 
 public struct Continuation<A> {
    private let magicToken = "Hello World"


### PR DESCRIPTION
This test in its current form does not pass on 32-bit platforms.
