### PR TITLE
[6.3] MemoryLifetimeVerifier: fix a false alarm for function calls reading from an argument location

### DIFF
--- a/include/swift/SIL/MemoryLocations.h
+++ b/include/swift/SIL/MemoryLocations.h
@@ -145,6 +145,10 @@ public:
       return idx < subLocations.size() && subLocations.test(idx);
     }
 
+    bool selfBitRepresentsUnknownSubFields() const {
+      return numFieldsNotCoveredBySubfields > 0;
+    }
+
   private:
     friend class MemoryLocations;
 

--- a/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
+++ b/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
@@ -295,16 +295,25 @@ void MemoryLifetimeVerifier::requireBitsSet(const Bits &bits, SILValue addr,
 }
 
 void MemoryLifetimeVerifier::requireBitsSetForArgument(const Bits &bits, Operand *argOp) {
-  if (auto *loc = locations.getLocation(argOp->get())) {
-    Bits missingBits = ~bits & loc->subLocations;
-    for (int errorLocIdx = missingBits.find_first(); errorLocIdx >= 0;
-         errorLocIdx = missingBits.find_next(errorLocIdx)) {
-      auto *errorLoc = locations.getLocation(errorLocIdx);
+  int locIdx = locations.getLocationIdx(argOp->get());
+  if (locIdx < 0)
+    return;
 
-      if (applyMayRead(argOp, errorLoc->representativeValue)) {
-        reportError("memory is not initialized, but should be",
-                    errorLocIdx, argOp->getUser());
-      }
+  auto *loc = locations.getLocation(locIdx);
+  Bits missingBits = ~bits & loc->subLocations;
+  for (int errorLocIdx = missingBits.find_first(); errorLocIdx >= 0;
+       errorLocIdx = missingBits.find_next(errorLocIdx)) {
+    auto *errorLoc = locations.getLocation(errorLocIdx);
+
+    // We only have a valid address if this is not the "self" bit which represents
+    // unknown sub-fields.
+    SILValue addr;
+    if (errorLocIdx != locIdx || !errorLoc->selfBitRepresentsUnknownSubFields())
+      addr = errorLoc->representativeValue;
+
+    if (applyMayRead(argOp, addr)) {
+      reportError("memory is not initialized, but should be",
+                  errorLocIdx, argOp->getUser());
     }
   }
 }
@@ -327,8 +336,16 @@ bool MemoryLifetimeVerifier::applyMayRead(Operand *argOp, SILValue addr) {
   }
 
   for (SILFunction *callee : callees) {
-    if (callee->argumentMayRead(argOp, addr))
-      return true;
+    if (addr) {
+      if (callee->argumentMayRead(argOp, addr))
+        return true;
+    } else {
+      // We don't know which unknown sub-fields the argument effects refer to.
+      // Only if there are no argument effects at all, we know that the function
+      // may read from an unknown sub-field.
+      if (!callee->hasArgumentEffects())
+        return true;
+    }
   }
   return false;
 }

--- a/test/SIL/memory_lifetime.sil
+++ b/test/SIL/memory_lifetime.sil
@@ -35,6 +35,11 @@ enum KlassOrBool {
   case bool(Bool)
 }
 
+struct IntPair {
+  var a: Int
+  var b: Int
+}
+
 
 sil [ossa] @test_struct : $@convention(thin) (@in Outer) -> @owned T {
 bb0(%0 : $*Outer):
@@ -893,3 +898,33 @@ sil [ossa] @storage_leaked_into_dead_ends : $@convention(thin) () -> () {
   dealloc_stack %t_addr
   unreachable
 }
+
+sil [ossa] @read_a : $@convention(thin) (@inout IntPair) -> () {
+[%0: read s0.v**]
+}
+
+sil [ossa] @callee_reads_unknown_subfield : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %1 = alloc_stack $IntPair
+  %2 = struct_element_addr %1, #IntPair.a
+  store %0 to [trivial] %2
+  %4 = function_ref @read_a : $@convention(thin) (@inout IntPair) -> ()
+  %5 = apply %4(%1) : $@convention(thin) (@inout IntPair) -> ()
+  dealloc_stack %1
+  %7 = tuple ()
+  return %7
+}
+
+sil [ossa] @callee_reads_known_subfield : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %1 = alloc_stack $IntPair
+  %2 = struct_element_addr %1, #IntPair.a
+  %3 = struct_element_addr %1, #IntPair.b
+  store %0 to [trivial] %2
+  %4 = function_ref @read_a : $@convention(thin) (@inout IntPair) -> ()
+  %5 = apply %4(%1) : $@convention(thin) (@inout IntPair) -> ()
+  dealloc_stack %1
+  %7 = tuple ()
+  return %7
+}
+


### PR DESCRIPTION
* **Explanation**:  Fixes a false SIL verifier crash. If a struct field is not referenced in a function and that field is not read from a called function's argument, the verifier complained that the field must be initialized.
* **Risk**: Low. It makes the memory lifetime verifier more conservative. No changes in code generation
* **Testing**: Tested by a lit test.
* **Issue**: rdar://168051370
* **Reviewer**:  @meg-gupta
* **Main branch PR**: https://github.com/swiftlang/swift/pull/86562
