### PR TITLE
[6.3] Optimizer: fix a few problems where destroys are illegally hoisted across deinit barriers

### DIFF
--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -75,6 +75,16 @@ enum class MandatoryInlining_t {
   inlineAlways
 };
 
+static bool isLexicalPartialApply(PartialApplyInst *pai) {
+  for (Operand *use : pai->getUses()) {
+    if (auto *mv = dyn_cast<MoveValueInst>(use->getUser())) {
+      if (mv->isLexical())
+        return true;
+    }
+  }
+  return false;
+}
+
 /// Fixup reference counts after inlining a function call (which is a no-op
 /// unless the function is a thick function).
 ///
@@ -92,6 +102,8 @@ static  bool fixupReferenceCounts(
   // We assume that we were passed a slice of our actual argument array. So we
   // can use this to copy if we need to.
   assert(captureArgConventions.size() == capturedArgs.size());
+
+  bool isLexical = isLexicalPartialApply(pai);
 
   // FIXME: Can we cache this in between inlining invocations?
   DeadEndBlocks deadEndBlocks(pai->getFunction());
@@ -160,6 +172,24 @@ static  bool fixupReferenceCounts(
     }
 
     case ParameterConvention::Direct_Guaranteed: {
+      if (isLexical && v->getOwnershipKind() == OwnershipKind::Owned) {
+        // If the result of the `partial_apply` is lexical we must make sure
+        // to make its captured arguments lexical. Otherwise the argument
+        // lifetimes may be shortened after inlining because the (lexical)
+        //`partial_apply` is not there anymore to keep the arguments alive.
+        auto *mv = SILBuilderWithScope(pai).createMoveValue(loc, v, IsLexical);
+        for (Operand *use : v->getUses()) {
+          if (use->getUser() == pai) {
+            ASSERT(use->isLifetimeEnding() &&
+                   "an escaping partial_apply must consume its arguments");
+            use->set(mv);
+            v = mv;
+            break;
+          }
+        }
+        ASSERT(v == mv && "partial_apply doesn't use its captured argument");
+      }
+
       // If we have a direct_guaranteed value, the value is being taken by the
       // partial_apply at +1, but we are going to invoke the value at +0. So we
       // need to copy/borrow the value before the pai and then

--- a/lib/SILOptimizer/Utils/CanonicalizeInstruction.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeInstruction.cpp
@@ -443,49 +443,6 @@ broadenSingleElementStores(StoreInst *storeInst,
 //                            Simple ARC Peepholes
 //===----------------------------------------------------------------------===//
 
-/// "dead" copies are removed in OSSA, but this may shorten object lifetimes,
-/// changing program semantics in unexpected ways by releasing weak references
-/// and running deinitializers early. This copy may be the only thing keeping a
-/// variable's reference alive. But just because the copy's current SSA value
-/// contains no other uses does not mean that there aren't other uses that still
-/// correspond to the original variable whose lifetime is protected by this
-/// copy. The only way to guarantee the lifetime of a variable is to use a
-/// borrow scope--copy/destroy is insufficient by itself.
-///
-/// FIXME: This removes debug_value instructions aggressively as part of
-/// SILGenCleanup. Instead, debug_values should be canonicalized before copy
-/// elimination so that we never see the pattern:
-///   %b = begin_borrow
-///   %c = copy %b
-///   end_borrow %b
-///   debug_value %c
-///
-/// FIXME: Technically this should be guarded by a compiler flag like
-/// -enable-copy-propagation until SILGen protects scoped variables by
-/// borrow scopes.
-static SILBasicBlock::iterator
-eliminateSimpleCopies(CopyValueInst *cvi, CanonicalizeInstruction &pass) {
-  auto next = std::next(cvi->getIterator());
-
-  // Eliminate copies that only have destroy_value uses.
-  SmallVector<DestroyValueInst *, 8> destroys;
-  for (Operand *use : cvi->getUses()) {
-    if (auto *dvi = dyn_cast<DestroyValueInst>(use->getUser())) {
-      destroys.push_back(dvi);
-      continue;
-    }
-    if (!pass.preserveDebugInfo && isa<DebugValueInst>(use->getUser())) {
-      continue;
-    }
-    return next;
-  }
-
-  while (!destroys.empty()) {
-    next = killInstruction(destroys.pop_back_val(), next, pass);
-  }
-  return killInstAndIncidentalUses(cvi, next, pass);
-}
-
 /// Unlike dead copy elimination, dead borrows can be safely removed because the
 /// semantics of a borrow scope
 static SILBasicBlock::iterator
@@ -599,9 +556,6 @@ CanonicalizeInstruction::canonicalize(SILInstruction *inst) {
   if (auto *storeInst = dyn_cast<StoreInst>(inst)) {
     return broadenSingleElementStores(storeInst, *this);
   }
-
-  if (auto *cvi = dyn_cast<CopyValueInst>(inst))
-    return eliminateSimpleCopies(cvi, *this);
 
   if (auto *bbi = dyn_cast<BeginBorrowInst>(inst))
     return eliminateSimpleBorrows(bbi, *this);

--- a/lib/SILOptimizer/Utils/OSSACanonicalizeOwned.cpp
+++ b/lib/SILOptimizer/Utils/OSSACanonicalizeOwned.cpp
@@ -398,8 +398,6 @@ void OSSACanonicalizeOwned::extendLivenessToDeinitBarriers() {
         });
   } else {
     for (auto destroy : destroys) {
-      if (destroy->getOperand(0) != getCurrentDef())
-        continue;
       ends.push_back(destroy);
     }
   }

--- a/test/SILOptimizer/copy_propagation.sil
+++ b/test/SILOptimizer/copy_propagation.sil
@@ -33,7 +33,9 @@ sil [ossa] @takeOwnedCTwice : $@convention(thin) (@owned C, @owned C) -> ()
 sil [ossa] @takeOwnedCAndGuaranteedC : $@convention(thin) (@owned C, @guaranteed C) -> ()
 sil [ossa] @takeGuaranteedC : $@convention(thin) (@guaranteed C) -> ()
 sil [ossa] @borrowB : $@convention(thin) (@guaranteed B) -> ()
-sil [ossa] @takeGuaranteedAnyObject : $@convention(thin) (@guaranteed AnyObject) -> ()
+sil [ossa] @takeGuaranteedAnyObject : $@convention(thin) (@guaranteed AnyObject) -> () {
+[global:]
+}
 sil [ossa] @getMOS : $() -> (@owned MOS)
 
 // -O hoists the destroy
@@ -1010,10 +1012,8 @@ bb0:
 // CHECK:         [[BARRIER:%[^,]+]] = function_ref @barrier
 // CHECK:         [[BORROW:%[^,]+]] = function_ref @takeGuaranteedC
 // CHECK:         apply [[BORROW]]([[INSTANCE]])
-// The destroy of the copy should be hoisted over the deinit barrier, and then
-// canonicalization of the lexical value should remove the copy.
-// CHECK:         destroy_value [[INSTANCE]]
 // CHECK:         apply [[BARRIER]]()
+// CHECK:         destroy_value [[INSTANCE]]
 // CHECK-LABEL: } // end sil function 'hoist_destroy_of_copy_of_lexical_over_deinit_barrier'
 sil [ossa] @hoist_destroy_of_copy_of_lexical_over_deinit_barrier : $(@owned C) -> () {
 entry(%instance : @owned $C):

--- a/test/SILOptimizer/lexical_closure_lifetime.swift
+++ b/test/SILOptimizer/lexical_closure_lifetime.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift | %FileCheck %s
+// RUN: %target-run-simple-swift(-O) | %FileCheck %s
 
 // REQUIRES: executable_test
 

--- a/test/SILOptimizer/lexical_closure_lifetime.swift
+++ b/test/SILOptimizer/lexical_closure_lifetime.swift
@@ -1,0 +1,35 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+
+// REQUIRES: executable_test
+
+class C {}
+
+func runit<T>(_ c: () -> T) -> T {
+  return c()
+}
+
+func testit() -> C? {
+    weak var weakRef: C? = nil
+
+    let resultsHandler = runit {
+        let c = C()
+        weakRef = c
+
+        let x: () -> () = {
+            _ = c
+        }
+        return x
+    }
+
+    resultsHandler()
+
+    return weakRef
+}
+
+if testit() == nil {
+  fatalError()
+}
+
+// CHECK: success
+print("success")
+

--- a/test/SILOptimizer/mandatory_inlining_ownership.sil
+++ b/test/SILOptimizer/mandatory_inlining_ownership.sil
@@ -655,6 +655,26 @@ bb0(%0 : $Int):
   return %r
 }
 
+// CHECK-LABEL: sil [ossa] @lexical_partial_apply :
+// CHECK:         %1 = move_value [lexical] %0
+// CHECK:       } // end sil function 'lexical_partial_apply'
+sil [ossa] @lexical_partial_apply : $@convention(thin) (@owned String) -> () {
+bb0(%0 : @owned $String):
+  %1 = function_ref @closure : $@convention(thin) (@guaranteed String) -> ()
+  %2 = partial_apply [callee_guaranteed] %1(%0) : $@convention(thin) (@guaranteed String) -> ()
+  %3 = move_value [lexical] %2
+  %4 = apply %3() : $@callee_guaranteed () -> ()
+  destroy_value %3
+  %6 = tuple ()
+  return %6
+}
+
+sil [transparent] [ossa] @closure : $@convention(thin) (@guaranteed String) -> () {
+bb0(%0 : @guaranteed $String):
+  %1 = tuple ()
+  return %1
+}
+
 sil_vtable C2 {
   #C2.i!modify: (C2) -> () -> () : @devirt_callee
 }

--- a/test/SILOptimizer/sil_combine_ossa.sil
+++ b/test/SILOptimizer/sil_combine_ossa.sil
@@ -39,6 +39,10 @@ struct PointerStorage {
 class B { }
 class E : B { }
 
+class D {
+  @_hasStorage weak var c: B?
+}
+
 sil @use_b_guaranteed : $@convention(thin) (@guaranteed B) -> ()
 sil @usearray_error : $@convention(thin) (@guaranteed Array<Error>) -> ()
 
@@ -5596,5 +5600,17 @@ bb1:
   return %9
 }
 
-
+// CHECK-LABEL: sil [ossa] @dont_hoist_destroy_over_deinit_barrier :
+// CHECK:         load_weak
+// CHECK-NEXT:    destroy_value %0
+// CHECK:       } // end sil function 'dont_hoist_destroy_over_deinit_barrier'
+sil [ossa] @dont_hoist_destroy_over_deinit_barrier : $@convention(thin) (@owned B, @guaranteed D) -> @owned Optional<B> {
+bb0(%0 : @owned $B, %1 : @guaranteed $D):
+  %2 = copy_value %0
+  destroy_value %0
+  %4 = ref_element_addr %1, #D.c
+  %5 = load_weak %4
+  destroy_value %2
+  return %5
+}
 

--- a/test/SILOptimizer/silgen_cleanup.sil
+++ b/test/SILOptimizer/silgen_cleanup.sil
@@ -341,28 +341,6 @@ bb0(%0 : @guaranteed $Builtin.NativeObject):
   return %1 : $Builtin.NativeObject
 }
 
-// Test SemanticARCOpts eliminateSimpleCopies. At -O, remove the
-// debug_value with the copy to avoid a lifetime violation. -Onone, do nothing.
-//
-// CHECK-LABEL: sil [ossa] @testSimpleCopyWithDebug : $@convention(thin) (@owned Klass) -> Builtin.Int64 {
-// CHECKOPT-NOT: copy_value
-// CHECKOPT-NOT: debug_value
-// CHECKDEB: copy_value
-// CHECKDEB: debug_value
-// CHECK-LABEL: } // end sil function 'testSimpleCopyWithDebug'
-sil [ossa] @testSimpleCopyWithDebug : $@convention(thin) (@owned Klass) -> Builtin.Int64 {
-bb9(%0 : @owned $Klass):
-  %borrow = begin_borrow %0 : $Klass
-  %p = ref_element_addr %borrow : $Klass, #Klass.property
-  %v = load [trivial] %p : $*Builtin.Int64
-  %copy = copy_value %borrow : $Klass
-  end_borrow %borrow : $Klass
-  debug_value %copy : $Klass, let, name "c"
-  destroy_value %copy : $Klass
-  destroy_value %0 : $Klass
-  return %v : $Builtin.Int64
-}
-
 struct Outer {
   var middle: Middle
 }

--- a/test/stdlib/move_function.swift
+++ b/test/stdlib/move_function.swift
@@ -75,7 +75,9 @@ extension Class {
         }
         switch (x)[userHandle] {
         case .foo:
-            expectTrue(self.array._buffer.isUniquelyReferenced())
+          // The array buffer is not unique because the lexical lifetime of x spans
+          // over the switch statement.
+          expectFalse(self.array._buffer.isUniquelyReferenced())
         }
     }
 }


### PR DESCRIPTION
* **Explanation**:  Fixes a mis-compile which let destroys of values be hoisted over deinit-barriers. The effect is e.g. that a weak reference is nil although the owning variable is still in scope. There are several places in the optimizer which need to be fixed. For details see the commit messages.
* **Risk**: Relatively low. The fixes are mostly simple changes in the optimizer.
* **Testing**: Tested by lit tests.
* **Issue**: rdar://168337959
* **Reviewer**:  @meg-gupta
* **Main branch PR**: https://github.com/swiftlang/swift/pull/86702
