### PR TITLE
[6.3] TempRValueElimination: fix a problem with `load`-`store` copy elimination

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/TempRValueElimination.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/TempRValueElimination.swift
@@ -426,10 +426,15 @@ private func getLastUseWhileSourceIsNotModified(of copy: CopyLikeInstruction,
                                                 uses: InstructionSetWithCount,
                                                 _ context: FunctionPassContext) -> Instruction?
 {
-  if uses.isEmpty {
+  var numUsesFound = 0
+  if copy == copy.loadingInstruction {
+    // As we are starting the iteration at the next instruction after the copy's load instruction
+    // we pretend to having seen the copy instruction already.
+    numUsesFound += 1
+  }
+  if uses.count == numUsesFound {
     return copy
   }
-  var numUsesFound = 0
   let aliasAnalysis = context.aliasAnalysis
 
   // We already checked that the useful lifetime of the `alloc_stack` ends in the same block as the `copy`.
@@ -480,7 +485,7 @@ private struct UseCollector : AddressDefUseWalker {
     for use in allocStack.uses {
       switch use.instruction {
       case copy:
-        break
+        uses.insert(copy)
       case is DeallocStackInst:
         // Deallocations are allowed to be in a different block.
         break

--- a/test/SILOptimizer/temp_rvalue_opt_ossa.sil
+++ b/test/SILOptimizer/temp_rvalue_opt_ossa.sil
@@ -1790,3 +1790,22 @@ bb2:
   return %9
 }
 
+// CHECK-LABEL: sil [ossa] @dealloc_stack_between_load_and_store :
+// CHECK:         %4 = load [take] %2
+// CHECK-NEXT:    dealloc_stack %2
+// CHECK-NEXT:    store %4 to [init] %1
+// CHECK-LABEL: } // end sil function 'dealloc_stack_between_load_and_store'
+sil [ossa] @dealloc_stack_between_load_and_store : $@convention(thin) (@owned AnyObject) -> () {
+bb0(%0 : @owned $AnyObject):
+  %1 = alloc_stack $AnyObject
+  %2 = alloc_stack [lexical] $AnyObject
+  store %0 to [init] %2
+  %4 = load [take] %2
+  dealloc_stack %2
+  store %4 to [init] %1
+  destroy_addr %1
+  dealloc_stack %1
+  %9 = tuple ()
+  return %9
+}
+


### PR DESCRIPTION
* **Explanation**:  Fixes a compiler crash caused by the TempRValueElimination. If a value is "copied" to the stack location via a `load` and `store` instruction pair and the source location is written or de-allocated between both instructions, the optimization generated wrong SIL. The fix is to make sure that writes to the source locations are always checked between the `load` and `store`.
* **Risk**: Low. It's a simple change in TempRValueElimination which is tested very well by lit tests
* **Testing**: Tested by a lit test.
* **Issue**: rdar://168595700
* **Reviewer**:  @Azoy
* **Main branch PR**: https://github.com/swiftlang/swift/pull/86708
