### PR TITLE
[6.3] SIL: assume a read-effect for unused indirect arguments

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Effects.swift
+++ b/SwiftCompilerSources/Sources/SIL/Effects.swift
@@ -101,6 +101,14 @@ extension Function {
         //     %2 = ref_element_addr %1   // class projection
         return getSideEffects()
       }
+      if convention.isIndirectIn && !argument.path.hasClassProjection {
+        // Even if an indirect argument is unused, pretend that the function reads from it. If the unused
+        // argument is passed to another generic function and that function is specialized, the argument
+        // may be re-abstracted and the specializer inserts a load from the indirect argument.
+        // Therefore we must be prepared that unused indirect argument might get loaded from -
+        // even if it's not the case right now.
+        result.memory.read = true
+      }
     } else {
       // Direct arguments:
       if argument.path.mayHaveTwoClassProjections {

--- a/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
+++ b/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
@@ -930,7 +930,7 @@ void MemoryLifetimeVerifier::checkFuncArgument(Bits &bits, Operand &argumentOp,
   switch (argumentConvention) {
     case SILArgumentConvention::Indirect_In_CXX:
     case SILArgumentConvention::Indirect_In:
-      requireBitsSetForArgument(bits, &argumentOp);
+      requireBitsSet(bits, argumentOp.get(), applyInst);
       locations.clearBits(bits, argumentOp.get());
       break;
     case SILArgumentConvention::Indirect_Out:
@@ -939,6 +939,8 @@ void MemoryLifetimeVerifier::checkFuncArgument(Bits &bits, Operand &argumentOp,
       locations.setBits(bits, argumentOp.get());
       break;
     case SILArgumentConvention::Indirect_In_Guaranteed:
+      requireBitsSet(bits, argumentOp.get(), applyInst);
+      break;
     case SILArgumentConvention::Indirect_Inout:
       requireBitsSetForArgument(bits, &argumentOp);
       break;

--- a/test/SIL/Serialization/shared_function_serialization.sil
+++ b/test/SIL/Serialization/shared_function_serialization.sil
@@ -5,7 +5,7 @@
 // CHECK: sil private @top_level_code
 // CHECK: sil public_external [serialized] [ossa] @$ss1XVABycfC{{.*}}
 // CHECK: sil public_external [serialized] [ossa] @$ss17the_thing_it_does1xys1XV_tF{{.*}}
-// CHECK: sil shared [serialized] [noinline] [ossa] @$ss9the_thing1tyx_tlFs1XV_Ttgq5{{.*}}
+// CHECK: sil shared [serialized] [noinline] [ossa] @$ss9the_thing1tyx_tlFs1XV_Tgq5{{.*}}
 
 sil_stage canonical
 

--- a/test/SIL/memory_lifetime.sil
+++ b/test/SIL/memory_lifetime.sil
@@ -520,18 +520,6 @@ bb0(%0 :  $*T):
   return %res : $()
 }
 
-sil [ossa] @test_non_escaping_closure_with_mark_dependence : $@convention(thin) () -> () {
-bb0:
-  %0 = alloc_stack $T
-  %func = function_ref @closure : $@convention(thin) (@in_guaranteed T) -> ()
-  %pa = partial_apply [callee_guaranteed] [on_stack] %func(%0) : $@convention(thin) (@in_guaranteed T) -> ()
-  %pa1 = mark_dependence %pa on %0
-  destroy_value %pa1 : $@noescape @callee_guaranteed () -> () 
-  dealloc_stack %0
-  %res = tuple ()
-  return %res : $()
-}
-
 sil [ossa] @test_store_borrow : $@convention(thin) (@guaranteed T) -> () {
 bb0(%0 :  @guaranteed $T):
   %s = alloc_stack $T
@@ -747,22 +735,6 @@ entry:
   end_apply %token as $()
   %retval = tuple ()
   return %retval : $()
-}
-
-sil @read_inner_b : $@convention(thin) (@in_guaranteed Inner) -> () {
-[%0: read s1]
-}
-
-sil [ossa] @test_partial_read_in_argument : $@convention(thin) (@in Inner) -> () {
-bb0(%0: $*Inner):
-  %1 = struct_element_addr %0 : $*Inner, #Inner.a
-  destroy_addr %1 : $*T
-  %3 = function_ref @read_inner_b : $@convention(thin) (@in_guaranteed Inner) -> ()
-  %4 = apply %3(%0) : $@convention(thin) (@in_guaranteed Inner) -> ()
-  %5 = struct_element_addr %0 : $*Inner, #Inner.b
-  destroy_addr %5 : $*T
-  %r = tuple ()
-  return %r : $()
 }
 
 sil [ossa] @test : $@convention(thin) (@guaranteed KlassOrBool) -> () {

--- a/test/SIL/memory_lifetime_failures.sil
+++ b/test/SIL/memory_lifetime_failures.sil
@@ -291,6 +291,19 @@ bb0(%0 :  $*T):
   return %res : $()
 }
 
+// CHECK: SIL memory lifetime failure in @test_non_escaping_closure_with_mark_dependence: memory is not initialized, but should be
+sil [ossa] @test_non_escaping_closure_with_mark_dependence : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $T
+  %func = function_ref @closure : $@convention(thin) (@in_guaranteed T) -> ()
+  %pa = partial_apply [callee_guaranteed] [on_stack] %func(%0) : $@convention(thin) (@in_guaranteed T) -> ()
+  %pa1 = mark_dependence %pa on %0
+  destroy_value %pa1 : $@noescape @callee_guaranteed () -> () 
+  dealloc_stack %0
+  %res = tuple ()
+  return %res : $()
+}
+
 // CHECK: SIL memory lifetime failure in @test_store_borrow_destroy1: store-borrow location cannot be written 
 sil [ossa] @test_store_borrow_destroy1 : $@convention(thin) (@guaranteed T) -> () {
 bb0(%0 :  @guaranteed $T):

--- a/test/SILOptimizer/closure_specialization_simple.sil
+++ b/test/SILOptimizer/closure_specialization_simple.sil
@@ -322,12 +322,17 @@ bb0(%0 : $Builtin.Int1, %1 : $Builtin.Int1):
   %8 = apply %7(%6) : $@convention(thin) (@owned @callee_owned (Builtin.Int1) -> Builtin.Int1) -> Builtin.Int1
 
   %9 = alloc_stack $Builtin.Int1
+  %9a = alloc_stack $Builtin.Int1
 
   %10 = function_ref @indirect_parameter_partial_apply_fun : $@convention(thin) (@in Builtin.Int1, Builtin.Int1, @in Builtin.Int1) -> @out Builtin.Int1
   %11 = partial_apply %10() : $@convention(thin) (@in Builtin.Int1, Builtin.Int1, @in Builtin.Int1) -> @out Builtin.Int1
+  store %0 to [trivial] %9
   %12 = partial_apply %10(%9) : $@convention(thin) (@in Builtin.Int1, Builtin.Int1, @in Builtin.Int1) -> @out Builtin.Int1
+  store %0 to [trivial] %9
   %13 = partial_apply %10(%1, %9) : $@convention(thin) (@in Builtin.Int1, Builtin.Int1, @in Builtin.Int1) -> @out Builtin.Int1
-  %14 = partial_apply %10(%9, %1, %9) : $@convention(thin) (@in Builtin.Int1, Builtin.Int1, @in Builtin.Int1) -> @out Builtin.Int1
+  store %0 to [trivial] %9
+  store %0 to [trivial] %9a
+  %14 = partial_apply %10(%9, %1, %9a) : $@convention(thin) (@in Builtin.Int1, Builtin.Int1, @in Builtin.Int1) -> @out Builtin.Int1
 
   %16 = function_ref @indirect_parameter_partial_apply_caller1 : $@convention(thin) (@owned @callee_owned (@in Builtin.Int1, Builtin.Int1, @in Builtin.Int1) -> @out Builtin.Int1) -> ()
   %17 = function_ref @indirect_parameter_partial_apply_caller2 : $@convention(thin) (@owned @callee_owned (@in Builtin.Int1, Builtin.Int1) -> @out Builtin.Int1) -> ()
@@ -344,12 +349,18 @@ bb0(%0 : $Builtin.Int1, %1 : $Builtin.Int1):
   %21 = alloc_stack $(Builtin.Int1, Builtin.Int1)
   %22 = function_ref @indirect_parameter_partial_apply_caller6 : $@convention(thin) (@owned @callee_owned () -> @out Builtin.Int1) -> @out Builtin.Int1
   %23 = function_ref @indirect_parameter_partial_apply_caller7 : $@convention(thin) (@owned @callee_owned () -> @out Builtin.Int1) -> @out (Builtin.Int1, Builtin.Int1)
-  %24 = partial_apply %10(%9, %1, %9) : $@convention(thin) (@in Builtin.Int1, Builtin.Int1, @in Builtin.Int1) -> @out Builtin.Int1
-  %25 = partial_apply %10(%9, %1, %9) : $@convention(thin) (@in Builtin.Int1, Builtin.Int1, @in Builtin.Int1) -> @out Builtin.Int1
+  store %0 to [trivial] %9
+  store %0 to [trivial] %9a
+  %24 = partial_apply %10(%9, %1, %9a) : $@convention(thin) (@in Builtin.Int1, Builtin.Int1, @in Builtin.Int1) -> @out Builtin.Int1
+  store %0 to [trivial] %9
+  store %0 to [trivial] %9a
+  %25 = partial_apply %10(%9, %1, %9a) : $@convention(thin) (@in Builtin.Int1, Builtin.Int1, @in Builtin.Int1) -> @out Builtin.Int1
+  store %0 to [trivial] %9
   apply %22(%9, %24) : $@convention(thin) (@owned @callee_owned () -> @out Builtin.Int1) -> @out Builtin.Int1
   apply %23(%21, %25) : $@convention(thin) (@owned @callee_owned () -> @out Builtin.Int1) -> @out (Builtin.Int1, Builtin.Int1)
 
   dealloc_stack %21 : $*(Builtin.Int1, Builtin.Int1)
+  dealloc_stack %9a
   dealloc_stack %9 : $*Builtin.Int1
 
   %26 = partial_apply %2(%0) : $@convention(thin) (Builtin.Int1, Builtin.Int1) -> Builtin.Int1

--- a/test/SILOptimizer/cross-module-optimization.swift
+++ b/test/SILOptimizer/cross-module-optimization.swift
@@ -80,14 +80,14 @@ class DerivedFromOpen<T> : OpenClass<T> { }
 
 func testProtocolsAndClasses() {
   // CHECK-OUTPUT: false
-  // CHECK-SIL-DAG: sil shared [noinline] @$s4Test20checkIfClassConformsyyxlFSi_Ttg5
+  // CHECK-SIL-DAG: sil shared [noinline] @$s4Test20checkIfClassConformsyyxlFSi_Tg5
   checkIfClassConforms(27)
   // CHECK-OUTPUT: false
   // CHECK-SIL-DAG: sil public_external {{.*}} @$s4Test24checkIfClassConforms_genyyxlF
   checkIfClassConforms_gen(27)
   // CHECK-OUTPUT: 123
   // CHECK-OUTPUT: 1234
-  // CHECK-SIL-DAG: sil shared [noinline] @$s4Test7callFooyyxlFSi_Ttg5
+  // CHECK-SIL-DAG: sil shared [noinline] @$s4Test7callFooyyxlFSi_Tg5
   // CHECK-SIL-DAG: sil [{{.*}}] @$s4Test19printFooExistential33_{{.*}} : $@convention(thin)
   callFoo(27)
   // CHECK-OUTPUT: 123

--- a/test/SILOptimizer/devirt_witness_cross_module.swift
+++ b/test/SILOptimizer/devirt_witness_cross_module.swift
@@ -48,7 +48,7 @@ public struct Local: P {
 
 // CHECK-LABEL: sil @$s4Main24testGenericInOtherModuleyyF
 // CHECK-NOCMO:   [[F:%[0-9]+]] = witness_method $S, #P.foo
-// CHECK-CMO:     [[F:%[0-9]+]] = function_ref @$s6Module1SV3foo1xyx_tSkRzSi7ElementRtzlFSaySiG_Ttg{{.*}}
+// CHECK-CMO:     [[F:%[0-9]+]] = function_ref @$s6Module1SV3foo1xyx_tSkRzSi7ElementRtzlFSaySiG_Tg{{.*}}
 // CHECK:         apply [[F]]
 // CHECK:       } // end sil function '$s4Main24testGenericInOtherModuleyyF'
 public func testGenericInOtherModule() {
@@ -75,7 +75,7 @@ public func testGenericRequirementInOtherModule() {
 }
 
 // CHECK-LABEL: sil @$s4Main23testGenericInSameModuleyyF
-// CHECK:         [[F:%[0-9]+]] = function_ref @$s4Main5LocalV3foo1xyx_tSkRzSi7ElementRtzlFSaySiG_Ttg5
+// CHECK:         [[F:%[0-9]+]] = function_ref @$s4Main5LocalV3foo1xyx_tSkRzSi7ElementRtzlFSaySiG_Tg5
 // CHECK:         apply [[F]]
 // CHECK:       } // end sil function '$s4Main23testGenericInSameModuleyyF'
 public func testGenericInSameModule() {

--- a/test/SILOptimizer/mem-behavior.sil
+++ b/test/SILOptimizer/mem-behavior.sil
@@ -2002,3 +2002,37 @@ bb0(%0 : $*UInt64):
   return %99 : $()
 }
 
+sil @unused_indirect_arg : $@convention(thin) (@in_guaranteed Int32) -> () {
+[global: ]
+}
+
+sil @unused_inout_arg : $@convention(thin) (@inout Int32) -> () {
+[global: ]
+}
+
+// CHECK-LABEL: @unused_indirect_arg_should_be_treated_as_read
+// CHECK:       PAIR #0.
+// CHECK-NEXT:     %2 = apply %1(%0)
+// CHECK-NEXT:     %0 = argument of bb0 : $*Int32
+// CHECK-NEXT:     r=1,w=0
+sil [ossa] @unused_indirect_arg_should_be_treated_as_read : $@convention(thin) (@in_guaranteed Int32) -> () {
+bb0(%0 : $*Int32):
+  %1 = function_ref @unused_indirect_arg : $@convention(thin) (@in_guaranteed Int32) -> ()
+  %2 = apply %1(%0) : $@convention(thin) (@in_guaranteed Int32) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: @unused_inout_arg_is_readnone
+// CHECK:       PAIR #0.
+// CHECK-NEXT:     %2 = apply %1(%0)
+// CHECK-NEXT:     %0 = argument of bb0 : $*Int32
+// CHECK-NEXT:     r=0,w=0
+sil [ossa] @unused_inout_arg_is_readnone : $@convention(thin) (@inout Int32) -> () {
+bb0(%0 : $*Int32):
+  %1 = function_ref @unused_inout_arg : $@convention(thin) (@inout Int32) -> ()
+  %2 = apply %1(%0) : $@convention(thin) (@inout Int32) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+

--- a/test/SILOptimizer/pre_specialize_layouts.swift
+++ b/test/SILOptimizer/pre_specialize_layouts.swift
@@ -187,8 +187,9 @@ public func usePrespecializedEntryPoints(wrapperStruct: ReferenceWrapperStruct, 
 // OPT:   [[A1:%.*]] = unchecked_ref_cast [[P1]] : $SomeClass to $AnyObject
 // OPT:   [[R3:%.*]] = apply [[F1]]([[A1]]) : $@convention(thin) (@guaranteed AnyObject) -> @owned AnyObject
 // OPT:   store [[R3]] to [[R2]] : $*AnyObject
-// OPT:   [[F2:%.*]] = function_ref @$s22pre_specialize_layouts7consumeyyxlF0a20_specialized_module_C09SomeClassC_Ttg5 : $@convention(thin) () -> ()
-// OPT:   apply [[F2]]() : $@convention(thin) () -> ()
+// OPT:   [[F2:%.*]] = function_ref @$s22pre_specialize_layouts7consumeyyxlF0a20_specialized_module_C09SomeClassC_Tg5 : $@convention(thin) (@guaranteed SomeClass) -> ()
+// OPT:   [[L1:%.*]] = load [[R1]]
+// OPT:   apply [[F2]]([[L1]]) : $@convention(thin) (@guaranteed SomeClass) -> ()
 // OPT:   dealloc_stack [[R1]] : $*SomeClass
 // OPT: } // end sil function '$s22pre_specialize_layouts46usePrespecializedEntryPointsWithMarkerProtocol1ty0a20_specialized_module_C09SomeClassC_tF'
 public func usePrespecializedEntryPointsWithMarkerProtocol(t: SomeClass) {

--- a/test/SILOptimizer/spec_archetype_method.swift
+++ b/test/SILOptimizer/spec_archetype_method.swift
@@ -32,7 +32,7 @@ func useFoo<T>(x x: T) {
 //CHECK-LABEL: sil @$s21spec_archetype_method21interesting_code_hereyyF
 //CHECK: function_ref @$s21spec_archetype_method12generic_call{{[_0-9a-zA-Z]*}}FAA3ABCC_Tg5
 //CHECK-NEXT: apply
-//CHECK:  function_ref @$s21spec_archetype_method6useFoo{{[_0-9a-zA-Z]*}}FAA3ABCC_Ttg5 : $@convention(thin) () -> ()
+//CHECK:  function_ref @$s21spec_archetype_method6useFoo{{[_0-9a-zA-Z]*}}FAA3ABCC_Tg5 : $@convention(thin) (@guaranteed ABC) -> ()
 //CHECK-NEXT: apply
 //CHECK: return
 public

--- a/test/SILOptimizer/spec_conf1.swift
+++ b/test/SILOptimizer/spec_conf1.swift
@@ -19,8 +19,8 @@ func inner_function<T : P>(In In : T) { }
 @inline(never)
 func outer_function<T : P>(In In : T) { inner_function(In: In) }
 
-//CHECK: sil shared [noinline] {{.*}}@$s10spec_conf114outer_function2Inyx_tAA1PRzlFAA3FooC_Ttg5
-//CHECK: $s10spec_conf114inner_function2Inyx_tAA1PRzlFAA3FooC_Ttg5
+//CHECK: sil shared [noinline] {{.*}}@$s10spec_conf114outer_function2Inyx_tAA1PRzlFAA3FooC_Tg5
+//CHECK: $s10spec_conf114inner_function2Inyx_tAA1PRzlFAA3FooC_Tg5
 //CHECK-NEXT: apply
 //CHECK: return
 

--- a/test/SILOptimizer/spec_conf2.swift
+++ b/test/SILOptimizer/spec_conf2.swift
@@ -18,8 +18,8 @@ func inner_function<T : P & Q>(In In : T) { }
 @inline(never)
 func outer_function<T : P & Q>(In In : T) { inner_function(In: In) }
 
-//CHECK: sil shared [noinline] {{.*}}@$s10spec_conf214outer_function2Inyx_tAA1PRzAA1QRzlFAA3FooC_Ttg5
-//CHECK: function_ref @$s10spec_conf214inner_function2Inyx_tAA1PRzAA1QRzlFAA3FooC_Ttg5
+//CHECK: sil shared [noinline] {{.*}}@$s10spec_conf214outer_function2Inyx_tAA1PRzAA1QRzlFAA3FooC_Tg5
+//CHECK: function_ref @$s10spec_conf214inner_function2Inyx_tAA1PRzAA1QRzlFAA3FooC_Tg5
 //CHECK-NEXT: apply
 //CHECK: return
 

--- a/test/SILOptimizer/specialize_checked_cast_branch.swift
+++ b/test/SILOptimizer/specialize_checked_cast_branch.swift
@@ -25,8 +25,8 @@ public func ArchetypeToArchetypeCast<T1, T2>(t1 : T1, t2 : T2) -> T2 {
   preconditionFailure("??? Profit?")
 }
 
-// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AA1DCTt1g5 : $@convention(thin) (@guaranteed C) -> @owned D
-// CHECK: bb0([[ARG:%.*]] : $C):
+// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AA1DCTg5 : $@convention(thin) (@guaranteed C, @guaranteed D) -> @owned D
+// CHECK: bb0([[ARG:%.*]] : $C, [[ARG2:%.*]] : $D):
 // CHECK:  checked_cast_br C in [[ARG]] : $C to D, bb1, bb2
 //
 // CHECK: bb1([[T0:%.*]] : $D):
@@ -36,16 +36,16 @@ public func ArchetypeToArchetypeCast<T1, T2>(t1 : T1, t2 : T2) -> T2 {
 // CHECK: bb2
 // CHECK:   cond_fail {{%.*}}, "precondition failure"
 // CHECK:   unreachable
-// CHECK: } // end sil function '$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AA1DCTt1g5'
+// CHECK: } // end sil function '$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AA1DCTg5'
 _ = ArchetypeToArchetypeCast(t1: c, t2: d)
 
 // x -> x where x is a class.
-// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AFTt1g5 : $@convention(thin) (@guaranteed C) -> @owned C {
+// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AFTg5 : $@convention(thin) (@guaranteed C, @guaranteed C) -> @owned C {
 // CHECK: bb0
 // CHECK-NOT: bb1
 // CHECK: strong_retain %0 : $C
 // CHECK: return %0 : $C
-// CHECK: } // end sil function '$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AFTt1g5'
+// CHECK: } // end sil function '$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AFTg5'
 _ = ArchetypeToArchetypeCast(t1: c, t2: c)
 
 // TODO: x -> x where x is not a class.
@@ -55,38 +55,38 @@ _ = ArchetypeToArchetypeCast(t1: b, t2: b)
 _ = ArchetypeToArchetypeCast(t1: b, t2: f)
 
 // x -> y where x is not a class but y is.
-// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA8NotUInt8V_AA1CCTt1g5 : $@convention(thin) (NotUInt8) -> @owned C {
+// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA8NotUInt8V_AA1CCTg5 : $@convention(thin) (NotUInt8, @guaranteed C) -> @owned C {
 // CHECK: bb0
 // CHECK-NOT: bb1
 // CHECK: cond_fail {{%.*}}, "precondition failure"
 // CHECK: unreachable
-// CHECK: } // end sil function '$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA8NotUInt8V_AA1CCTt1g5'
+// CHECK: } // end sil function '$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA8NotUInt8V_AA1CCTg5'
 _ = ArchetypeToArchetypeCast(t1: b, t2: c)
 
 // y -> x where x is a class but y is not.
-// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AA8NotUInt8VTt1g5 : $@convention(thin) (@guaranteed C) -> NotUInt8 {
+// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AA8NotUInt8VTg5 : $@convention(thin) (@guaranteed C, NotUInt8) -> NotUInt8 {
 // CHECK: bb0
 // CHECK-NOT: bb1
 // CHECK: cond_fail {{%.*}}, "precondition failure"
 // CHECK: unreachable
-// CHECK: } // end sil function '$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AA8NotUInt8VTt1g5'
+// CHECK: } // end sil function '$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AA8NotUInt8VTg5'
 _ = ArchetypeToArchetypeCast(t1: c, t2: b)
 
 // y -> x where x is a super class of y.
-// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1DC_AA1CCTt1g5 : $@convention(thin) (@guaranteed D) -> @owned C {
+// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1DC_AA1CCTg5 : $@convention(thin) (@guaranteed D, @guaranteed C) -> @owned C {
 // CHECK: [[T1:%.*]] = upcast %0 : $D to $C
 // CHECK: strong_retain [[T1]]
 // CHECK: return [[T1]] : $C
-// CHECK: } // end sil function '$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1DC_AA1CCTt1g5'
+// CHECK: } // end sil function '$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1DC_AA1CCTg5'
 _ = ArchetypeToArchetypeCast(t1: d, t2: c)
 
 // x -> y where x and y are unrelated.
-// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AA1ECTt1g5 : $@convention(thin) (@guaranteed C) -> @owned E {
+// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AA1ECTg5 : $@convention(thin) (@guaranteed C, @guaranteed E) -> @owned E {
 // CHECK: bb0
 // CHECK-NOT: bb1
 // CHECK: cond_fail {{%.*}}, "precondition failure"
 // CHECK: unreachable
-// CHECK: } // end sil function '$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AA1ECTt1g5'
+// CHECK: } // end sil function '$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AA1ECTg5'
 _ = ArchetypeToArchetypeCast(t1: c, t2: e)
 
 ///////////////////////////
@@ -218,48 +218,48 @@ func ConcreteToArchetypeCastD<T>(t: D, t2: T) -> T {
 }
 
 // x -> x where x is not a class.
-// CHECK-LABEL: sil shared @$s30specialize_checked_cast_branch28ConcreteToArchetypeCastUInt81t2t2xAA03NotI0V_xtlFAF_Tt1g5 : $@convention(thin) (NotUInt8) -> NotUInt8 {
+// CHECK-LABEL: sil shared @$s30specialize_checked_cast_branch28ConcreteToArchetypeCastUInt81t2t2xAA03NotI0V_xtlFAF_Tg5 : $@convention(thin) (NotUInt8, NotUInt8) -> NotUInt8 {
 // CHECK: bb0
 // CHECK-NOT: bb1
 // CHECK: return %0 : $NotUInt8
-// CHECK: } // end sil function '$s30specialize_checked_cast_branch28ConcreteToArchetypeCastUInt81t2t2xAA03NotI0V_xtlFAF_Tt1g5'
+// CHECK: } // end sil function '$s30specialize_checked_cast_branch28ConcreteToArchetypeCastUInt81t2t2xAA03NotI0V_xtlFAF_Tg5'
 _ = ConcreteToArchetypeCastUInt8(t: b, t2: b)
 
 // x -> y where x,y are not classes and x is a different type from y.
-// CHECK-LABEL: sil shared @$s30specialize_checked_cast_branch28ConcreteToArchetypeCastUInt81t2t2xAA03NotI0V_xtlFAA0K6UInt64V_Tt1g5 : $@convention(thin) (NotUInt8) -> NotUInt64 {
+// CHECK-LABEL: sil shared @$s30specialize_checked_cast_branch28ConcreteToArchetypeCastUInt81t2t2xAA03NotI0V_xtlFAA0K6UInt64V_Tg5 : $@convention(thin) (NotUInt8, NotUInt64) -> NotUInt64 {
 // CHECK: bb0
 // CHECK-NOT: bb1
 // CHECK: unreachable
-// CHECK: } // end sil function '$s30specialize_checked_cast_branch28ConcreteToArchetypeCastUInt81t2t2xAA03NotI0V_xtlFAA0K6UInt64V_Tt1g5
+// CHECK: } // end sil function '$s30specialize_checked_cast_branch28ConcreteToArchetypeCastUInt81t2t2xAA03NotI0V_xtlFAA0K6UInt64V_Tg5
 _ = ConcreteToArchetypeCastUInt8(t: b, t2: f)
 
-// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch28ConcreteToArchetypeCastUInt81t2t2xAA03NotI0V_xtlFAA1CC_Tt1g5 : $@convention(thin) (NotUInt8) -> @owned C
+// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch28ConcreteToArchetypeCastUInt81t2t2xAA03NotI0V_xtlFAA1CC_Tg5 : $@convention(thin) (NotUInt8, @guaranteed C) -> @owned C
 // CHECK: bb0
 // CHECK: unreachable
 _ = ConcreteToArchetypeCastUInt8(t: b, t2: c)
 
-// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch24ConcreteToArchetypeCastC1t2t2xAA1CC_xtlFAF_Tt1g5 : $@convention(thin) (@guaranteed C) -> @owned C
+// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch24ConcreteToArchetypeCastC1t2t2xAA1CC_xtlFAF_Tg5 : $@convention(thin) (@guaranteed C, @guaranteed C) -> @owned C
 // CHECK: bb0
 // CHECK: return %0
 _ = ConcreteToArchetypeCastC(t: c, t2: c)
 
-// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch24ConcreteToArchetypeCastC1t2t2xAA1CC_xtlFAA8NotUInt8V_Tt1g5 : $@convention(thin) (@guaranteed C) -> NotUInt8
+// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch24ConcreteToArchetypeCastC1t2t2xAA1CC_xtlFAA8NotUInt8V_Tg5 : $@convention(thin) (@guaranteed C, NotUInt8) -> NotUInt8
 // CHECK: bb0
 // CHECK: unreachable
 _ = ConcreteToArchetypeCastC(t: c, t2: b)
 
-// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch24ConcreteToArchetypeCastC1t2t2xAA1CC_xtlFAA1DC_Tt1g5 : $@convention(thin) (@guaranteed C) -> @owned D
+// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch24ConcreteToArchetypeCastC1t2t2xAA1CC_xtlFAA1DC_Tg5 : $@convention(thin) (@guaranteed C, @guaranteed D) -> @owned D
 // CHECK: bb0
 // CHECK:  checked_cast_br C in %0 : $C to D
 // CHECK: bb1
 _ = ConcreteToArchetypeCastC(t: c, t2: d)
 
-// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch24ConcreteToArchetypeCastC1t2t2xAA1CC_xtlFAA1EC_Tt1g5 : $@convention(thin) (@guaranteed C) -> @owned E
+// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch24ConcreteToArchetypeCastC1t2t2xAA1CC_xtlFAA1EC_Tg5 : $@convention(thin) (@guaranteed C, @guaranteed E) -> @owned E
 // CHECK: bb0
 // CHECK: unreachable
 _ = ConcreteToArchetypeCastC(t: c, t2: e)
 
-// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch24ConcreteToArchetypeCastD1t2t2xAA1DC_xtlFAA1CC_Tt1g5 : $@convention(thin) (@guaranteed D) -> @owned C
+// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch24ConcreteToArchetypeCastD1t2t2xAA1DC_xtlFAA1CC_Tg5 : $@convention(thin) (@guaranteed D, @guaranteed C) -> @owned C
 // CHECK: bb0
 // CHECK:  [[T0:%.*]] = upcast %0 : $D to $C
 // CHECK:  return [[T0]]
@@ -283,29 +283,29 @@ func SuperToArchetypeCastD<T>(d : D, t : T) -> T {
   preconditionFailure("??? Profit?")
 }
 
-// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch21SuperToArchetypeCastC1c1txAA1CC_xtlFAF_Tt1g5 : $@convention(thin) (@guaranteed C) -> @owned C
+// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch21SuperToArchetypeCastC1c1txAA1CC_xtlFAF_Tg5 : $@convention(thin) (@guaranteed C, @guaranteed C) -> @owned C
 // CHECK: bb0
 // CHECK: return %0 : $C
 _ = SuperToArchetypeCastC(c: c, t: c)
 
-// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch21SuperToArchetypeCastC1c1txAA1CC_xtlFAA1DC_Tt1g5 : $@convention(thin) (@guaranteed C) -> @owned D
+// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch21SuperToArchetypeCastC1c1txAA1CC_xtlFAA1DC_Tg5 : $@convention(thin) (@guaranteed C, @guaranteed D) -> @owned D
 // CHECK: bb0
 // CHECK:  checked_cast_br C in %0 : $C to D
 // CHECK: bb1
 _ = SuperToArchetypeCastC(c: c, t: d)
 
-// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch21SuperToArchetypeCastC1c1txAA1CC_xtlFAA8NotUInt8V_Tt1g5 : $@convention(thin) (@guaranteed C) -> NotUInt8
+// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch21SuperToArchetypeCastC1c1txAA1CC_xtlFAA8NotUInt8V_Tg5 : $@convention(thin) (@guaranteed C, NotUInt8) -> NotUInt8
 // CHECK: bb0
 // CHECK: unreachable
 _ = SuperToArchetypeCastC(c: c, t: b)
 
-// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch21SuperToArchetypeCastD1d1txAA1DC_xtlFAA1CC_Tt1g5 : $@convention(thin) (@guaranteed D) -> @owned C
+// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch21SuperToArchetypeCastD1d1txAA1DC_xtlFAA1CC_Tg5 : $@convention(thin) (@guaranteed D, @guaranteed C) -> @owned C
 // CHECK: bb0
 // CHECK:  [[T0:%.*]] = upcast %0 : $D to $C
 // CHECK:  return [[T0]]
 _ = SuperToArchetypeCastD(d: d, t: c)
 
-// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch21SuperToArchetypeCastD1d1txAA1DC_xtlFAF_Tt1g5 : $@convention(thin) (@guaranteed D) -> @owned D
+// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch21SuperToArchetypeCastD1d1txAA1DC_xtlFAF_Tg5 : $@convention(thin) (@guaranteed D, @guaranteed D) -> @owned D
 // CHECK: bb0
 // CHECK: return %0 : $D
 _ = SuperToArchetypeCastD(d: d, t: d)
@@ -321,22 +321,22 @@ func ExistentialToArchetypeCast<T>(o : AnyObject, t : T) -> T {
   preconditionFailure("??? Profit?")
 }
 
-// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch26ExistentialToArchetypeCast1o1txyXl_xtlFAA1CC_Tt1g5 : $@convention(thin) (@guaranteed AnyObject) -> @owned C
+// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch26ExistentialToArchetypeCast1o1txyXl_xtlFAA1CC_Tg5 : $@convention(thin) (@guaranteed AnyObject, @guaranteed C) -> @owned C
 // CHECK: bb0
 // CHECK:  checked_cast_br AnyObject in %0 : $AnyObject to C
 // CHECK: bb1
 _ = ExistentialToArchetypeCast(o: o, t: c)
 
-// CHECK-LABEL: sil shared @$s30specialize_checked_cast_branch26ExistentialToArchetypeCast1o1txyXl_xtlFAA8NotUInt8V_Tt1g5 : $@convention(thin) (@guaranteed AnyObject) -> NotUInt8
+// CHECK-LABEL: sil shared @$s30specialize_checked_cast_branch26ExistentialToArchetypeCast1o1txyXl_xtlFAA8NotUInt8V_Tg5 : $@convention(thin) (@guaranteed AnyObject, NotUInt8) -> NotUInt8
 // CHECK: bb0
 // CHECK:  checked_cast_addr_br take_always AnyObject in {{%.*}} : $*AnyObject to NotUInt8 in {{%.*}} : $*NotUInt8,
 // CHECK: bb1
 _ = ExistentialToArchetypeCast(o: o, t: b)
 
-// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch26ExistentialToArchetypeCast1o1txyXl_xtlFyXl_Tt1g5 : $@convention(thin) (@guaranteed AnyObject) -> @owned AnyObject
+// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch26ExistentialToArchetypeCast1o1txyXl_xtlFyXl_Tg5 : $@convention(thin) (@guaranteed AnyObject, @guaranteed AnyObject) -> @owned AnyObject
 // CHECK: bb0
 // CHECK-NOT: checked_cast_br %
 // CHECK: return %0 : $AnyObject
 // CHECK-NOT: checked_cast_br %
-// CHECK: } // end sil function '$s30specialize_checked_cast_branch26ExistentialToArchetypeCast1o1txyXl_xtlFyXl_Tt1g5'
+// CHECK: } // end sil function '$s30specialize_checked_cast_branch26ExistentialToArchetypeCast1o1txyXl_xtlFyXl_Tg5'
 _ = ExistentialToArchetypeCast(o: o, t: o)

--- a/test/SILOptimizer/specialize_class_inherits_base_inherits_protocol.swift
+++ b/test/SILOptimizer/specialize_class_inherits_base_inherits_protocol.swift
@@ -12,7 +12,7 @@ class Bar<T>: Foo<T> {}
 
 // CHECK-LABEL: sil @$s031specialize_class_inherits_base_C9_protocol3fooyyF
 public func foo() {
-  // CHECK: function_ref @$s031specialize_class_inherits_base_C9_protocol4sinkyyxlFypXp_Ttg5
+  // CHECK: function_ref @$s031specialize_class_inherits_base_C9_protocol4sinkyyxlFypXp_Tg5
   p(Bar<Int>())
 }
 

--- a/test/SILOptimizer/specialize_ossa.sil
+++ b/test/SILOptimizer/specialize_ossa.sil
@@ -1621,14 +1621,17 @@ bb0(%0 : $*T):
 
 // CHECK-LABEL: sil [ossa] @call_generic_func_with_no_arg_read :
 // CHECK-NOT:     load
-// CHECK:           = apply {{%[0-9]+}}() :
-// CHECK-NOT:     end_borrow
+// CHECK:           [[L:%.*]] = load_borrow %1
+// CHECK:           = apply {{%[0-9]+}}([[L]]) :
+// CHECK:           end_borrow [[L]]
 // CHECK:       } // end sil function 'call_generic_func_with_no_arg_read'
-sil [ossa] @call_generic_func_with_no_arg_read : $@convention(thin) () -> () {
-bb0:
+sil [ossa] @call_generic_func_with_no_arg_read : $@convention(thin) (@owned Klass) -> () {
+bb0(%0 : @owned $Klass):
   %1 = alloc_stack $Klass
+  store %0 to [init] %1
   %2 = function_ref @unused_argument : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   %3 = apply %2<Klass>(%1) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  destroy_addr %1
   dealloc_stack %1 : $*Klass
   %5 = tuple ()
   return %5 : $()

--- a/test/SILOptimizer/specialize_unconditional_checked_cast.swift
+++ b/test/SILOptimizer/specialize_unconditional_checked_cast.swift
@@ -38,15 +38,15 @@ ArchetypeToArchetype(t: c, t2: e)
 ArchetypeToArchetype(t: b, t2: f)
 
 // x -> x where x is not a class.
-// CHECK-LABEL: sil shared [noinline] @$s37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA8NotUInt8V{{.*}}Tt1g5 : $@convention(thin) (NotUInt8) -> NotUInt8 {
+// CHECK-LABEL: sil shared [noinline] @$s37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA8NotUInt8V{{.*}}Tg5 : $@convention(thin) (NotUInt8, NotUInt8) -> NotUInt8 {
 // CHECK-NOT: unconditional_checked_cast archetype_to_archetype
 
 // x -> x where x is a class.
-// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA1CC{{.*}}Tt1g5 : $@convention(thin) (@guaranteed C) -> @owned C {
+// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA1CC{{.*}}Tg5 : $@convention(thin) (@guaranteed C, @guaranteed C) -> @owned C {
 // CHECK-NOT: unconditional_checked_cast archetype_to_archetype
 
 // x -> y where x is not a class but y is.
-// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA8NotUInt8V_AA1CCTt1g5 : $@convention(thin) (NotUInt8) -> @owned C {
+// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA8NotUInt8V_AA1CCTg5 : $@convention(thin) (NotUInt8, @guaranteed C) -> @owned C {
 // CHECK-NOT: unconditional_checked_cast_addr
 // CHECK-NOT: unconditional_checked_cast_addr
 // CHECK: [[ONE:%[0-9]+]] = integer_literal $Builtin.Int1, -1
@@ -54,33 +54,33 @@ ArchetypeToArchetype(t: b, t2: f)
 // CHECK-NOT: unconditional_checked_cast_addr
 
 // y -> x where x is not a class but y is.
-// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA1CC_AA8NotUInt8VTt1g5 : $@convention(thin) (@guaranteed C) -> NotUInt8 {
+// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA1CC_AA8NotUInt8VTg5 : $@convention(thin) (@guaranteed C, NotUInt8) -> NotUInt8 {
 // CHECK-NOT: unconditional_checked_cast archetype_to_archetype
 // CHECK: [[ONE:%[0-9]+]] = integer_literal $Builtin.Int1, -1
 // CHECK: cond_fail [[ONE]] : $Builtin.Int1, "failed cast"
 // CHECK-NOT: unconditional_checked_cast archetype_to_archetype
 
 // x -> y where x is a super class of y.
-// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA1CC_AA1DCTt1g5 : $@convention(thin) (@guaranteed C) -> @owned D {
+// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA1CC_AA1DCTg5 : $@convention(thin) (@guaranteed C, @guaranteed D) -> @owned D {
 // CHECK: [[STACK:%[0-9]+]] = alloc_stack $C
 // TODO: This should be optimized to an unconditional_checked_cast without the need of alloc_stack: rdar://problem/24775038
 // CHECK: unconditional_checked_cast_addr C in [[STACK]] : $*C to D in
 
 // y -> x where x is a super class of y.
-// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA1DC_AA1CCTt1g5 : $@convention(thin) (@guaranteed D) -> @owned C {
+// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA1DC_AA1CCTg5 : $@convention(thin) (@guaranteed D, @guaranteed C) -> @owned C {
 // CHECK-NOT: unconditional_checked_cast archetype_to_archetype
 // CHECK: upcast {{%[0-9]+}} : $D to $C
 // CHECK-NOT: unconditional_checked_cast archetype_to_archetype
 
 // x -> y where x and y are unrelated classes.
-// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA1CC_AA1ECTt1g5 : $@convention(thin) (@guaranteed C) -> @owned E {
+// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA1CC_AA1ECTg5 : $@convention(thin) (@guaranteed C, @guaranteed E) -> @owned E {
 // CHECK-NOT: unconditional_checked_cast archetype_to_archetype
 // CHECK: [[ONE:%[0-9]+]] = integer_literal $Builtin.Int1, -1
 // CHECK: cond_fail [[ONE]] : $Builtin.Int1, "failed cast"
 // CHECK-NOT: unconditional_checked_cast archetype_to_archetype
 
 // x -> y where x and y are unrelated non classes.
-// CHECK-LABEL: sil shared [noinline] @$s37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA8NotUInt8V_AA0H6UInt64VTt1g5 : $@convention(thin) (NotUInt8) -> NotUInt64 {
+// CHECK-LABEL: sil shared [noinline] @$s37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA8NotUInt8V_AA0H6UInt64VTg5 : $@convention(thin) (NotUInt8, NotUInt64) -> NotUInt64 {
 // CHECK-NOT: unconditional_checked_cast archetype_to_archetype
 // CHECK-NOT: unconditional_checked_cast archetype_to_archetype
 // CHECK: [[ONE:%[0-9]+]] = integer_literal $Builtin.Int1, -1
@@ -213,13 +213,13 @@ ConcreteToArchetypeConvertUInt8(t: b, t2: c)
 ConcreteToArchetypeConvertUInt8(t: b, t2: f)
 
 // x -> x where x is not a class.
-// CHECK-LABEL: sil shared [noinline] @$s37specialize_unconditional_checked_cast31ConcreteToArchetypeConvertUInt8{{[_0-9a-zA-Z]*}}3Not{{.*}}Tt1g5 : $@convention(thin) (NotUInt8) -> NotUInt8 {
-// CHECK: bb0(%0 : $NotUInt8):
+// CHECK-LABEL: sil shared [noinline] @$s37specialize_unconditional_checked_cast31ConcreteToArchetypeConvertUInt8{{[_0-9a-zA-Z]*}}3Not{{.*}}Tg5 : $@convention(thin) (NotUInt8, NotUInt8) -> NotUInt8 {
+// CHECK: bb0(%0 : $NotUInt8, %1 : $NotUInt8):
 // CHECK: debug_value %0
 // CHECK: return %0
 
 // x -> y where x is not a class but y is a class.
-// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast31ConcreteToArchetypeConvertUInt8{{[_0-9a-zA-Z]*}}FAA1CC_Tt1g5 : $@convention(thin) (NotUInt8) -> @owned C {
+// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast31ConcreteToArchetypeConvertUInt8{{[_0-9a-zA-Z]*}}FAA1CC_Tg5 : $@convention(thin) (NotUInt8, @guaranteed C) -> @owned C {
 // CHECK: bb0
 // CHECK: [[ONE:%[0-9]+]] = integer_literal $Builtin.Int1, -1
 // CHECK: cond_fail [[ONE]] : $Builtin.Int1, "failed cast"
@@ -227,7 +227,7 @@ ConcreteToArchetypeConvertUInt8(t: b, t2: f)
 // CHECK-NEXT: }
 
 // x -> y where x,y are different non class types.
-// CHECK-LABEL: sil shared [noinline] @$s37specialize_unconditional_checked_cast31ConcreteToArchetypeConvertUInt8{{[_0-9a-zA-Z]*}}Not{{.*}}Tt1g5 : $@convention(thin) (NotUInt8) -> NotUInt64 {
+// CHECK-LABEL: sil shared [noinline] @$s37specialize_unconditional_checked_cast31ConcreteToArchetypeConvertUInt8{{[_0-9a-zA-Z]*}}Not{{.*}}Tg5 : $@convention(thin) (NotUInt8, NotUInt64) -> NotUInt64 {
 // CHECK: bb0
 // CHECK: [[ONE:%[0-9]+]] = integer_literal $Builtin.Int1, -1
 // CHECK: cond_fail [[ONE]] : $Builtin.Int1, "failed cast"
@@ -246,12 +246,12 @@ ConcreteToArchetypeConvertC(t: c, t2: e)
 
 
 // x -> x where x is a class.
-// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast27ConcreteToArchetypeConvertC{{[_0-9a-zA-Z]*}}Tt1g5 : $@convention(thin) (@guaranteed C) -> @owned C {
-// CHECK: bb0(%0 : $C):
+// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast27ConcreteToArchetypeConvertC{{[_0-9a-zA-Z]*}}Tg5 : $@convention(thin) (@guaranteed C, @guaranteed C) -> @owned C {
+// CHECK: bb0(%0 : $C, %1 : $C):
 // CHECK: return %0
 
 // x -> y where x is a class but y is not.
-// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast27ConcreteToArchetypeConvertC{{[_0-9a-zA-Z]*}}Not{{.*}}Tt1g5 : $@convention(thin) (@guaranteed C) -> NotUInt8 {
+// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast27ConcreteToArchetypeConvertC{{[_0-9a-zA-Z]*}}Not{{.*}}Tg5 : $@convention(thin) (@guaranteed C, NotUInt8) -> NotUInt8 {
 // CHECK: bb0
 // CHECK: [[ONE:%[0-9]+]] = integer_literal $Builtin.Int1, -1
 // CHECK: cond_fail [[ONE]] : $Builtin.Int1, "failed cast"
@@ -259,8 +259,8 @@ ConcreteToArchetypeConvertC(t: c, t2: e)
 // CHECK-NEXT: }
 
 // x -> y where x is a super class of y.
-// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast27ConcreteToArchetypeConvertC{{[_0-9a-zA-Z]*}}FAA1DC_Tt1g5 : $@convention(thin) (@guaranteed C) -> @owned D {
-// CHECK: bb0(%0 : $C):
+// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast27ConcreteToArchetypeConvertC{{[_0-9a-zA-Z]*}}FAA1DC_Tg5 : $@convention(thin) (@guaranteed C, @guaranteed D) -> @owned D {
+// CHECK: bb0(%0 : $C, %1 : $D):
 // CHECK-DAG: [[STACK_C:%[0-9]+]] = alloc_stack $C
 // CHECK-DAG: store %0 to [[STACK_C]]
 // CHECK-DAG: [[STACK_D:%[0-9]+]] = alloc_stack $D
@@ -270,8 +270,8 @@ ConcreteToArchetypeConvertC(t: c, t2: e)
 // CHECK: return [[LOAD]]
 
 // x -> y where x and y are unrelated classes.
-// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast27ConcreteToArchetypeConvertC{{[_0-9a-zA-Z]*}}FAA1EC_Tt1g5 : $@convention(thin) (@guaranteed C) -> @owned E {
-// CHECK: bb0(%0 : $C):
+// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast27ConcreteToArchetypeConvertC{{[_0-9a-zA-Z]*}}FAA1EC_Tg5 : $@convention(thin) (@guaranteed C, @guaranteed E) -> @owned E {
+// CHECK: bb0(%0 : $C, %1 : $E):
 // CHECK: [[ONE:%[0-9]+]] = integer_literal $Builtin.Int1, -1
 // CHECK: cond_fail [[ONE]] : $Builtin.Int1, "failed cast"
 // CHECK-NEXT: unreachable
@@ -285,8 +285,8 @@ public func ConcreteToArchetypeConvertD<T>(t t: D, t2: T) -> T {
 ConcreteToArchetypeConvertD(t: d, t2: c)
 
 // x -> y where x is a subclass of y.
-// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast27ConcreteToArchetypeConvertD{{[_0-9a-zA-Z]*}}FAA1CC_Tt1g5 : $@convention(thin) (@guaranteed D) -> @owned C {
-// CHECK: bb0(%0 : $D):
+// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast27ConcreteToArchetypeConvertD{{[_0-9a-zA-Z]*}}FAA1CC_Tg5 : $@convention(thin) (@guaranteed D, @guaranteed C) -> @owned C {
+// CHECK: bb0(%0 : $D, %1 : $C):
 // CHECK-DAG: [[UC:%[0-9]+]] = upcast %0
 // CHECK: return [[UC]]
 
@@ -306,17 +306,17 @@ SuperToArchetypeC(c: c, t: b)
 
 
 // x -> x where x is a class.
-// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast17SuperToArchetypeC{{[_0-9a-zA-Z]*}}Tt1g5 : $@convention(thin) (@guaranteed C) -> @owned C {
-// CHECK: bb0(%0 : $C):
+// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast17SuperToArchetypeC{{[_0-9a-zA-Z]*}}Tg5 : $@convention(thin) (@guaranteed C, @guaranteed C) -> @owned C {
+// CHECK: bb0(%0 : $C, %1 : $C):
 // CHECK: return %0
 
 // x -> y where x is a super class of y.
-// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast17SuperToArchetypeC{{[_0-9a-zA-Z]*}}FAA1DC_Tt1g5 : $@convention(thin) (@guaranteed C) -> @owned D {
+// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast17SuperToArchetypeC{{[_0-9a-zA-Z]*}}FAA1DC_Tg5 : $@convention(thin) (@guaranteed C, @guaranteed D) -> @owned D {
 // CHECK: bb0
 // CHECK: unconditional_checked_cast_addr C in
 
 // x -> y where x is a class and y is not.
-// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast17SuperToArchetypeC{{[_0-9a-zA-Z]*}}FAA8NotUInt8V_Tt1g5 : $@convention(thin) (@guaranteed C) -> NotUInt8 {
+// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast17SuperToArchetypeC{{[_0-9a-zA-Z]*}}FAA8NotUInt8V_Tg5 : $@convention(thin) (@guaranteed C, NotUInt8) -> NotUInt8 {
 // CHECK: bb0
 // CHECK: [[ONE:%[0-9]+]] = integer_literal $Builtin.Int1, -1
 // CHECK: cond_fail [[ONE]] : $Builtin.Int1, "failed cast"
@@ -333,13 +333,13 @@ SuperToArchetypeD(d: d, t: d)
 
 // *NOTE* The frontend is smart enough to turn this into an upcast. When this
 // test is converted to SIL, this should be fixed appropriately.
-// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast17SuperToArchetypeD{{[_0-9a-zA-Z]*}}FAA1CC_Tt1g5 : $@convention(thin) (@guaranteed D) -> @owned C {
+// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast17SuperToArchetypeD{{[_0-9a-zA-Z]*}}FAA1CC_Tg5 : $@convention(thin) (@guaranteed D, @guaranteed C) -> @owned C {
 // CHECK-NOT: unconditional_checked_cast super_to_archetype
 // CHECK: upcast
 // CHECK-NOT: unconditional_checked_cast super_to_archetype
 
-// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast17SuperToArchetypeD{{[_0-9a-zA-Z]*}}Tt1g5 : $@convention(thin) (@guaranteed D) -> @owned D {
-// CHECK: bb0(%0 : $D):
+// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast17SuperToArchetypeD{{[_0-9a-zA-Z]*}}Tg5 : $@convention(thin) (@guaranteed D, @guaranteed D) -> @owned D {
+// CHECK: bb0(%0 : $D, %1 : $D):
 // CHECK: return %0
 
 //////////////////////////////
@@ -352,18 +352,18 @@ public func ExistentialToArchetype<T>(o o : AnyObject, t : T) -> T {
 }
 
 // AnyObject -> Class.
-// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast22ExistentialToArchetype{{[_0-9a-zA-Z]*}}FAA1CC_Tt1g5 : $@convention(thin) (@guaranteed AnyObject) -> @owned C {
+// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast22ExistentialToArchetype{{[_0-9a-zA-Z]*}}FAA1CC_Tg5 : $@convention(thin) (@guaranteed AnyObject, @guaranteed C) -> @owned C {
 // CHECK: unconditional_checked_cast_addr AnyObject in {{%.*}} : $*AnyObject to C
 
 // AnyObject -> Non Class (should always fail)
-// CHECK-LABEL: sil shared [noinline] @$s37specialize_unconditional_checked_cast22ExistentialToArchetype{{[_0-9a-zA-Z]*}}FAA8NotUInt8V_Tt1g5 : $@convention(thin) (@guaranteed AnyObject) -> NotUInt8 {
+// CHECK-LABEL: sil shared [noinline] @$s37specialize_unconditional_checked_cast22ExistentialToArchetype{{[_0-9a-zA-Z]*}}FAA8NotUInt8V_Tg5 : $@convention(thin) (@guaranteed AnyObject, NotUInt8) -> NotUInt8 {
 // CHECK-NOT: cond_fail
 // CHECK-NOT: unreachable
 // CHECK: return
 
 // AnyObject -> AnyObject
-// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast22ExistentialToArchetype{{[_0-9a-zA-Z]*}}yXl{{.*}}Tt1g5 : $@convention(thin) (@guaranteed AnyObject) -> @owned AnyObject {
-// CHECK: bb0(%0 : $AnyObject):
+// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast22ExistentialToArchetype{{[_0-9a-zA-Z]*}}yXl{{.*}}Tg5 : $@convention(thin) (@guaranteed AnyObject, @guaranteed AnyObject) -> @owned AnyObject {
+// CHECK: bb0(%0 : $AnyObject, %1 : $AnyObject):
 // CHECK: return %0
 
 ExistentialToArchetype(o: o, t: c)

--- a/test/SILOptimizer/templvalueopt_ossa.sil
+++ b/test/SILOptimizer/templvalueopt_ossa.sil
@@ -418,11 +418,8 @@ bb0(%0 : $*TwoFields, %1 : $*TwoFields):
 }
 
 // CHECK-LABEL: sil [ossa] @guaranteed_argument_aliasing :
-// CHECK-NOT:     alloc_stack
-// CHECK:         [[A:%.*]] = struct_element_addr %0 : $*TwoFields, #TwoFields.a
-// CHECK-NEXT:    destroy_addr [[A]]
-// CHECK:         apply %{{[0-9]+}}([[A]], %0)
-// CHECK-NOT:     copy_addr
+// CHECK:         alloc_stack
+// CHECK:         copy_addr
 // CHECK-LABEL: } // end sil function 'guaranteed_argument_aliasing'
 sil [ossa] @guaranteed_argument_aliasing : $@convention(thin) (@inout TwoFields, @owned Child) -> () {
 bb0(%0 : $*TwoFields, %1 : @owned $Child):

--- a/test/embedded/value-type-deinits.swift
+++ b/test/embedded/value-type-deinits.swift
@@ -31,6 +31,6 @@ public func test() {
   createFoo(x: 1)
 }
 
-// CHECK-LABEL: sil shared @$e8MyModule9createFoo1xyx_ts17FixedWidthIntegerRzlFSi_Ttg5 :
+// CHECK-LABEL: sil shared @$e8MyModule9createFoo1xyx_ts17FixedWidthIntegerRzlFSi_Tg5 :
 // CHECK-NOT:     release
-// CHECK:       } // end sil function '$e8MyModule9createFoo1xyx_ts17FixedWidthIntegerRzlFSi_Ttg5'
+// CHECK:       } // end sil function '$e8MyModule9createFoo1xyx_ts17FixedWidthIntegerRzlFSi_Tg5'


### PR DESCRIPTION
* **Explanation**:  Fixes a compiler crash caused interprocedural side effect analysis. If an unused indirect argument is passed to another generic function and that function is specialized, the argument may be re-abstracted and the specializer inserts a load from the indirect argument. Therefore stores to unused indirect arguments must not be deleted. The fix is simply to assume that indirect arguments are always read.
* **Risk**: Low. It's a simple change which makes alias analysis more conservative when dealing with indirect function arguments.
* **Testing**: Tested by a lit test.
* **Issue**: rdar://168623362
* **Reviewer**:  @meg-gupta
* **Main branch PR**: https://github.com/swiftlang/swift/pull/86741
