### PR TITLE
[CS] Add `for` loop compatibility hack for `makeIterator`/`next` ranking

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -1555,6 +1555,13 @@ public:
     return LangOpts.isLanguageModeAtLeast(major, minor);
   }
 
+  /// Whether the "next major" language mode is being used. This isn't a real
+  /// language mode, it only exists to signal clients that expect to be
+  /// included in the next language mode when it becomes available.
+  bool isAtLeastFutureMajorLanguageMode() const {
+    return LangOpts.isAtLeastFutureMajorLanguageMode();
+  }
+
   /// Check whether it's important to respect access control restrictions
   /// in current context.
   bool isAccessControlDisabled() const {

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -749,6 +749,14 @@ namespace swift {
       return EffectiveLanguageVersion.isVersionAtLeast(major, minor);
     }
 
+    /// Whether the "next major" language mode is being used. This isn't a real
+    /// language mode, it only exists to signal clients that expect to be
+    /// included in the next language mode when it becomes available.
+    bool isAtLeastFutureMajorLanguageMode() const {
+      using namespace version;
+      return isLanguageModeAtLeast(Version::getFutureMajorLanguageVersion());
+    }
+
     /// Sets the "_hasAtomicBitWidth" conditional.
     void setHasAtomicBitWidth(llvm::Triple triple);
 

--- a/include/swift/Sema/ConstraintLocatorPathElts.def
+++ b/include/swift/Sema/ConstraintLocatorPathElts.def
@@ -284,6 +284,9 @@ SIMPLE_LOCATOR_PATH_ELT(CoercionOperand)
 /// A fallback type for some AST location (i.e. key path literal).
 SIMPLE_LOCATOR_PATH_ELT(FallbackType)
 
+/// Locator for a fake 'makeIterator' or 'next' for a 'for' loop.
+SIMPLE_LOCATOR_PATH_ELT(ImplicitForEachCompatMember)
+
 /// An implicit conversion (upcast) associated with an existential member access
 /// performed to abstract the member reference type away from context-specific
 /// types like `Self` that are not well-formed in the access context.

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -2454,6 +2454,12 @@ public:
   llvm::DenseMap<ConstraintLocator *, ProtocolDecl *>
       SynthesizedConformances;
 
+  /// A mapping between an input expr and a custom simulated initial depth for
+  /// the constraint system's depth map.
+  /// FIXME: This only exists for a narrow compatibility hack and should be
+  /// removed.
+  llvm::DenseMap<Expr *, unsigned> InputExprSimulatedDepths;
+
 private:
   /// Describes the current solver state.
   struct SolverState {
@@ -4911,7 +4917,8 @@ private:
   /// failure.
   Type lookupDependentMember(Type base, AssociatedTypeDecl *assocTy,
                              bool openExistential,
-                             ConstraintLocatorBuilder locator);
+                             ConstraintLocatorBuilder locator,
+                             ProtocolConformanceRef *conformanceOut = nullptr);
 
   /// Attempt to simplify the ForEachElement constraint.
   SolutionKind

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -5304,8 +5304,7 @@ getConcurrencyDiagnosticBehaviorLimitRec(
   // Metatypes that aren't Sendable were introduced in Swift 6.2, so downgrade
   // them to warnings prior to Swift 7.
   if (type->is<AnyMetatypeType>()) {
-    if (!type->getASTContext().isLanguageModeAtLeast(
-            version::Version::getFutureMajorLanguageVersion()))
+    if (!declCtx->getASTContext().isAtLeastFutureMajorLanguageMode())
       return DiagnosticBehavior::Warning;
   }
 

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -1588,8 +1588,7 @@ public:
              ->getType()
              .getASTType()
              ->getASTContext()
-             .isLanguageModeAtLeast(
-                 version::Version::getFutureMajorLanguageVersion()))
+             .isAtLeastFutureMajorLanguageMode())
       return DiagnosticBehavior::Warning;
 
     return sendingOperand->get()->getType().getConcurrencyDiagnosticBehavior(

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5796,8 +5796,7 @@ Expr *ExprRewriter::coerceTupleToTuple(Expr *expr,
     SmallString<16> toLabelStr;
     concatLabels(labels, toLabelStr);
 
-    using namespace version;
-    if (ctx.isLanguageModeAtLeast(Version::getFutureMajorLanguageVersion())) {
+    if (ctx.isAtLeastFutureMajorLanguageMode()) {
       ctx.Diags.diagnose(expr->getLoc(), diag::reordering_tuple_shuffle,
                          fromLabelStr, toLabelStr);
     } else {

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -295,8 +295,7 @@ getConcurrencyFixBehavior(ConstraintSystem &cs, ConstraintKind constraintKind,
     // Passing a static member reference as an argument needs to be downgraded
     // to a warning until future major mode to maintain source compatibility for
     // code with non-Sendable metatypes.
-    if (!cs.getASTContext().isLanguageModeAtLeast(
-            version::Version::getFutureMajorLanguageVersion())) {
+    if (!cs.getASTContext().isAtLeastFutureMajorLanguageMode()) {
       auto *argLoc = cs.getConstraintLocator(locator);
       if (auto *argument = getAsExpr(simplifyLocatorToAnchor(argLoc))) {
         if (auto overload = cs.findSelectedOverloadFor(

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3887,6 +3887,12 @@ static bool generateForEachStmtConstraints(ConstraintSystem &cs,
   auto seqExprTarget =
       SyntacticElementTarget(sequenceExpr, dc, contextInfo, false);
 
+  // Pretend the sequence expression still has a depth that matches when it
+  // was previously within a 'makeIterator()' call.
+  // FIXME: Remove this
+  if (!cs.getASTContext().isAtLeastFutureMajorLanguageMode())
+    cs.InputExprSimulatedDepths[sequenceExpr] = 2;
+
   if (cs.generateConstraints(seqExprTarget))
     return true;
 

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -1083,6 +1083,11 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
 
   auto getWeight = [&](ConstraintLocator *locator) -> unsigned {
     if (auto *anchor = locator->getAnchor().dyn_cast<Expr *>()) {
+      // FIXME: Hack to maintain ranking behavior for 'makeIterator' and 'next'
+      // in a 'for' loop. See the comment in `simplifyForEachElementConstraint`.
+      if (locator->isLastElement<LocatorPathElt::ImplicitForEachCompatMember>())
+        return 2;
+
       auto weight = cs.getExprDepth(anchor);
       if (weight)
         return *weight + 1;

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1479,8 +1479,7 @@ bool HasMemberwiseInitRequest::evaluate(Evaluator &evaluator, StructDecl *decl,
 
     // In the next language mode we should stop creating the compatibility
     // initializer.
-    using namespace version;
-    if (ctx.isLanguageModeAtLeast(Version::getFutureMajorLanguageVersion()))
+    if (ctx.isAtLeastFutureMajorLanguageMode())
       return false;
 
     // If there are no extra properties present for the compatibility

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -111,6 +111,7 @@ unsigned LocatorPathElt::getNewSummaryFlags() const {
   case ConstraintLocator::ThrownErrorType:
   case ConstraintLocator::FallbackType:
   case ConstraintLocator::KeyPathSubscriptIndex:
+  case ConstraintLocator::ImplicitForEachCompatMember:
   case ConstraintLocator::ExistentialMemberAccessConversion:
     return 0;
 
@@ -521,6 +522,10 @@ void LocatorPathElt::dump(raw_ostream &out) const {
   }
   case ConstraintLocator::FallbackType: {
     out << "fallback type";
+    break;
+
+  case ConstraintLocator::ImplicitForEachCompatMember:
+    out << "implicit 'for' loop 'makeIterator'/'next' compatibility member";
     break;
 
   case ConstraintLocator::KeyPathSubscriptIndex:

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -679,8 +679,7 @@ Type TypeChecker::typeCheckParameterDefault(Expr *&defaultValue,
 
       // In Swift 6.2 and below we incorrectly missed checking this rule for
       // methods, downgrade to a warning until the next language mode.
-      auto futureVersion = version::Version::getFutureMajorLanguageVersion();
-      if (!anchor->hasCurriedSelf() || ctx.isLanguageModeAtLeast(futureVersion))
+      if (!anchor->hasCurriedSelf() || ctx.isAtLeastFutureMajorLanguageMode())
         return Type();
 
       diag.warnUntilFutureLanguageMode();

--- a/test/Constraints/foreach_makeiterator_compat.swift
+++ b/test/Constraints/foreach_makeiterator_compat.swift
@@ -1,0 +1,35 @@
+// RUN: %target-typecheck-verify-swift -swift-version 6 -verify-additional-prefix swift6-
+// RUN: %target-typecheck-verify-swift -swift-version 7 -verify-additional-prefix swift7-
+
+// REQUIRES: swift7
+
+struct WrapperSequence<Base: Collection>: Sequence {
+  struct Iterator: IteratorProtocol {
+    mutating func next() -> Base.Element? {}
+  }
+  func makeIterator() -> Iterator {}
+}
+struct WrapperCollection<Base: Collection> : Collection {
+  typealias Element = Base.Element
+  typealias Index = Base.Index
+
+  var startIndex: Index {}
+  var endIndex: Index {}
+
+  func index(after i: Index) -> Index {}
+  subscript(idx: Index) -> Element {}
+}
+
+extension Collection {
+  func foo() -> WrapperSequence<Self> {} // expected-swift7-note {{found this candidate}}
+  func foo() -> WrapperCollection<Self> {} // expected-swift7-note {{found this candidate}}
+}
+
+func foo(_ x: some Collection) {
+  // This should be ambiguous since WrapperSequence & WrapperCollection are
+  // unrelated types, but was previously unambiguous purely because Collection's
+  // default 'makeIterator' was considered "less specialized" than WrapperSequence's
+  // concrete implementation.
+  for _ in x.foo() {}
+  // expected-swift7-error@-1 {{ambiguous use of 'foo()'}}
+}

--- a/test/Constraints/ranking.swift
+++ b/test/Constraints/ranking.swift
@@ -475,3 +475,18 @@ func testForLoops() {
   // CHECK: function_ref @$s7ranking12testForLoopsyyF3fooL1_SaySiGyF : $@convention(thin) () -> @owned Array<Int>
   for _ in foo() {}
 }
+
+extension Collection {
+  // CHECK-LABEL: sil hidden [ossa] @$sSl7rankingE13testDropFirstyySiF
+  func testDropFirst(_ i: Int) {
+    // These should refer to the default Collection implementation of 'dropFirst'.
+    for _ in self.dropFirst(i) {}
+    // CHECK: function_ref @$sSlsE9dropFirsty11SubSequenceQzSiF : $@convention(method) <τ_0_0 where τ_0_0 : Collection> (Int, @in τ_0_0) -> @out τ_0_0.SubSequence
+
+    // CHECK-LABEL: sil private [ossa] @$sSl7rankingE13testDropFirstyySiFyycfU_
+    _ = {
+      for _ in self.dropFirst(i) {}
+      // CHECK: function_ref @$sSlsE9dropFirsty11SubSequenceQzSiF : $@convention(method) <τ_0_0 where τ_0_0 : Collection> (Int, @in τ_0_0) -> @out τ_0_0.SubSequence
+    }
+  }
+}


### PR DESCRIPTION
Still record overload choices for `makeIterator` and `next` when solving a `ForEachElement` constraint. This maintains compatibility with the previous behavior where we would solve these in the constraint system, since the choices can affect ranking if e.g Collection's default `makeIterator` is compared with a concrete `makeIterator` overload. This is a complete hack though and we ought to rip this out as soon as we can.

rdar://168840696