### PR TITLE
Serialization: Enable recovery from broken modularization by default

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1081,8 +1081,7 @@ NOTE(modularization_issue_side_effect_type_error,none,
      (DeclName))
 
 NOTE(modularization_issue_worked_around,none,
-     "attempting forced recovery enabled by "
-     "-experimental-force-workaround-broken-modules",
+     "attempting to recover from the previous modularization issue",
      ())
 
 ERROR(modularization_issue_conformance_xref_error,none,

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -455,7 +455,7 @@ namespace swift {
     /// Attempt to recover for imported modules with broken modularization
     /// in an unsafe way. Currently applies only to xrefs where the target
     /// decl moved to a different module that is already loaded.
-    bool ForceWorkaroundBrokenModules = false;
+    bool EnableWorkaroundBrokenModules = true;
 
     /// Whether to enable the new operator decl and precedencegroup lookup
     /// behavior. This is a staging flag, and will be removed in the future.

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -768,9 +768,9 @@ def disable_deserialization_safety :
   Flag<["-"], "disable-deserialization-safety">,
   HelpText<"Don't avoid reading potentially unsafe decls in swiftmodules">;
 
-def force_workaround_broken_modules :
-  Flag<["-"], "experimental-force-workaround-broken-modules">,
-  HelpText<"Attempt unsafe recovery for imported modules with broken modularization">;
+def disable_workaround_broken_modules :
+  Flag<["-"], "disable-workaround-broken-modules">,
+  HelpText<"Disable recovery for imported modules with broken modularization">;
 
 def enable_experimental_string_processing :
   Flag<["-"], "enable-experimental-string-processing">,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1194,8 +1194,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
       = A->getOption().matches(OPT_enable_access_control);
   }
 
-  Opts.ForceWorkaroundBrokenModules
-    |= Args.hasArg(OPT_force_workaround_broken_modules);
+  Opts.EnableWorkaroundBrokenModules
+    &= !Args.hasArg(OPT_disable_workaround_broken_modules);
 
   // Either the env var and the flag has to be set to enable package interface load
   Opts.EnablePackageInterfaceLoad = Args.hasArg(OPT_experimental_package_interface_load) ||

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2489,6 +2489,8 @@ ModuleFile::resolveCrossReference(ModuleID MID, uint32_t pathLen) {
     // signature. Even if we recover, print as a warning the errors we skip.
     if (getContext().LangOpts.EnableWorkaroundBrokenModules &&
         errorKind == ModularizationError::Kind::DeclMoved &&
+        baseModule->findUnderlyingClangModule() &&
+        foundIn->findUnderlyingClangModule() &&
         !values.empty()) {
       // Print the error as a warning and notify of the recovery attempt.
       llvm::handleAllErrors(std::move(error),

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2484,10 +2484,10 @@ ModuleFile::resolveCrossReference(ModuleID MID, uint32_t pathLen) {
                                                        mismatchingTypes);
 
     // If we want to workaround broken modularization, we can keep going if
-    // we found a matching top-level decl in a different module. This is
-    // obviously dangerous as it could just be some other decl that happens to
-    // match.
-    if (getContext().LangOpts.ForceWorkaroundBrokenModules &&
+    // we found a matching top-level decl in a different module. The risk
+    // here would be to pick an unrelated decl that happens to share the same
+    // signature. Even if we recover, print as a warning the errors we skip.
+    if (getContext().LangOpts.EnableWorkaroundBrokenModules &&
         errorKind == ModularizationError::Kind::DeclMoved &&
         !values.empty()) {
       // Print the error as a warning and notify of the recovery attempt.

--- a/test/Serialization/modularization-error.swift
+++ b/test/Serialization/modularization-error.swift
@@ -10,13 +10,13 @@
 /// Move MyType from A to B.
 // RUN: %target-swift-frontend %t/Empty.swift -emit-module-path %t/A.swiftmodule -module-name A
 // RUN: %target-swift-frontend %t/LibOriginal.swift -emit-module-path %t/B.swiftmodule -module-name B
-// RUN: not %target-swift-frontend -emit-sil %t/LibWithXRef.swiftmodule -module-name LibWithXRef -I %t -diagnostic-style llvm 2>&1 \
+// RUN: not %target-swift-frontend -emit-sil %t/LibWithXRef.swiftmodule -module-name LibWithXRef -I %t -diagnostic-style llvm -disable-workaround-broken-modules 2>&1 \
 // RUN:   | %FileCheck --check-prefixes CHECK,CHECK-MOVED %s
 // CHECK-MOVED: LibWithXRef.swiftmodule:1:1: error: reference to type 'MyType' broken by a context change; 'MyType' was expected to be in 'A', but now a candidate is found only in 'B'
 
 /// Force working around the broken modularization to get a result and no errors.
 // RUN: %target-swift-frontend -emit-sil %t/LibWithXRef.swiftmodule -module-name LibWithXRef -I %t \
-// RUN:   -experimental-force-workaround-broken-modules -diagnostic-style llvm 2>&1 \
+// RUN:   -diagnostic-style llvm 2>&1 \
 // RUN:   | %FileCheck --check-prefixes CHECK-WORKAROUND %s
 // CHECK-WORKAROUND: LibWithXRef.swiftmodule:1:1: warning: reference to type 'MyType' broken by a context change; 'MyType' was expected to be in 'A', but now a candidate is found only in 'B'
 // CHECK-WORKAROUND-NEXT: A.MyType
@@ -25,7 +25,7 @@
 // CHECK-WORKAROUND-SAME: A.swiftmodule'
 // CHECK-WORKAROUND: note: the type was actually found in module 'B' at '
 // CHECK-WORKAROUND-SAME: B.swiftmodule'
-// CHECK-WORKAROUND: note: attempting forced recovery enabled by -experimental-force-workaround-broken-modules
+// CHECK-WORKAROUND: note: attempting to recover from the previous modularization issue
 // CHECK-WORKAROUND: func foo() -> some Proto
 
 /// Change MyType into a function.
@@ -45,7 +45,7 @@
 /// Remove MyType from all imported modules.
 // RUN: %target-swift-frontend %t/Empty.swift -emit-module-path %t/A.swiftmodule -module-name A
 // RUN: %target-swift-frontend %t/Empty.swift -emit-module-path %t/B.swiftmodule -module-name B
-// RUN: not %target-swift-frontend -emit-sil %t/LibWithXRef.swiftmodule -module-name LibWithXRef -I %t -diagnostic-style llvm 2>&1 \
+// RUN: not %target-swift-frontend -emit-sil %t/LibWithXRef.swiftmodule -module-name LibWithXRef -I %t -diagnostic-style llvm -disable-workaround-broken-modules 2>&1 \
 // RUN:   | %FileCheck --check-prefixes CHECK,CHECK-NOT-FOUND %s
 // CHECK-NOT-FOUND: LibWithXRef.swiftmodule:1:1: error: reference to type 'MyType' broken by a context change; 'MyType' is not found, it was expected to be in 'A'
 

--- a/test/Serialization/modularization-error.swift
+++ b/test/Serialization/modularization-error.swift
@@ -14,19 +14,10 @@
 // RUN:   | %FileCheck --check-prefixes CHECK,CHECK-MOVED %s
 // CHECK-MOVED: LibWithXRef.swiftmodule:1:1: error: reference to type 'MyType' broken by a context change; 'MyType' was expected to be in 'A', but now a candidate is found only in 'B'
 
-/// Force working around the broken modularization to get a result and no errors.
-// RUN: %target-swift-frontend -emit-sil %t/LibWithXRef.swiftmodule -module-name LibWithXRef -I %t \
+/// The enabled by default workaround doesn't apply (no -disable-workaround-broken-modules)
+// RUN: not %target-swift-frontend -emit-sil %t/LibWithXRef.swiftmodule -module-name LibWithXRef -I %t \
 // RUN:   -diagnostic-style llvm 2>&1 \
-// RUN:   | %FileCheck --check-prefixes CHECK-WORKAROUND %s
-// CHECK-WORKAROUND: LibWithXRef.swiftmodule:1:1: warning: reference to type 'MyType' broken by a context change; 'MyType' was expected to be in 'A', but now a candidate is found only in 'B'
-// CHECK-WORKAROUND-NEXT: A.MyType
-// CHECK-WORKAROUND-NEXT: ^
-// CHECK-WORKAROUND: note: the type was expected to be found in module 'A' at '
-// CHECK-WORKAROUND-SAME: A.swiftmodule'
-// CHECK-WORKAROUND: note: the type was actually found in module 'B' at '
-// CHECK-WORKAROUND-SAME: B.swiftmodule'
-// CHECK-WORKAROUND: note: attempting to recover from the previous modularization issue
-// CHECK-WORKAROUND: func foo() -> some Proto
+// RUN:   | %FileCheck --check-prefixes CHECK-MOVED %s
 
 /// Change MyType into a function.
 // RUN: %target-swift-frontend %t/LibTypeChanged.swift -emit-module-path %t/A.swiftmodule -module-name A
@@ -45,7 +36,7 @@
 /// Remove MyType from all imported modules.
 // RUN: %target-swift-frontend %t/Empty.swift -emit-module-path %t/A.swiftmodule -module-name A
 // RUN: %target-swift-frontend %t/Empty.swift -emit-module-path %t/B.swiftmodule -module-name B
-// RUN: not %target-swift-frontend -emit-sil %t/LibWithXRef.swiftmodule -module-name LibWithXRef -I %t -diagnostic-style llvm -disable-workaround-broken-modules 2>&1 \
+// RUN: not %target-swift-frontend -emit-sil %t/LibWithXRef.swiftmodule -module-name LibWithXRef -I %t -diagnostic-style llvm 2>&1 \
 // RUN:   | %FileCheck --check-prefixes CHECK,CHECK-NOT-FOUND %s
 // CHECK-NOT-FOUND: LibWithXRef.swiftmodule:1:1: error: reference to type 'MyType' broken by a context change; 'MyType' is not found, it was expected to be in 'A'
 

--- a/test/Serialization/modularization-recover.swift
+++ b/test/Serialization/modularization-recover.swift
@@ -1,0 +1,86 @@
+/// Recover from typical modularization issues seen in clang modules.
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+/// Setup two library modules A and B, and a client.
+// RUN: cp %t/LibOriginal.h %t/A.h
+// RUN: cp %t/Empty.h %t/B.h
+// RUN: %target-swift-frontend %t/LibWithXRef.swift -I %t \
+// RUN:   -emit-module-path %t/LibWithXRef.swiftmodule
+
+/// Move MyType from A to B, then error on client.
+// RUN: cp %t/Empty.h %t/A.h
+// RUN: cp %t/LibOriginal.h %t/B.h
+// RUN: not %target-swift-frontend -emit-sil %t/LibWithXRef.swiftmodule -I %t \
+// RUN:   -diagnostic-style llvm \
+// RUN:   -disable-workaround-broken-modules 2>&1 \
+// RUN:   | %FileCheck --check-prefixes CHECK,CHECK-MOVED %s
+// CHECK-MOVED: LibWithXRef.swiftmodule:1:1: error: reference to type 'MyType' broken by a context change; 'MyType' was expected to be in 'A', but now a candidate is found only in 'B'
+
+/// Working around the broken modularization to get a result and no errors.
+// RUN: %target-swift-frontend -emit-sil %t/LibWithXRef.swiftmodule -I %t \
+// RUN:   -diagnostic-style llvm 2>&1 \
+// RUN:   | %FileCheck --check-prefixes CHECK-WORKAROUND %s
+// CHECK-WORKAROUND: LibWithXRef.swiftmodule:1:1: warning: reference to type 'MyType' broken by a context change; 'MyType' was expected to be in 'A', but now a candidate is found only in 'B'
+// CHECK-WORKAROUND-NEXT: A.MyType
+// CHECK-WORKAROUND-NEXT: ^
+// CHECK-WORKAROUND: note: the type was expected to be found in module 'A' at '
+// CHECK-WORKAROUND-SAME: module.modulemap'
+// CHECK-WORKAROUND: note: the type was actually found in module 'B' at '
+// CHECK-WORKAROUND-SAME: module.modulemap'
+// CHECK-WORKAROUND: note: attempting to recover from the previous modularization issue
+// CHECK-WORKAROUND: func foo() -> some Proto
+
+/// Change MyType into a function, then error.
+// RUN: cp %t/LibTypeChanged.h %t/A.h
+// RUN: cp %t/Empty.h %t/B.h
+// RUN: not %target-swift-frontend -emit-sil %t/LibWithXRef.swiftmodule -I %t \
+// RUN:   -diagnostic-style llvm 2>&1 \
+// RUN:   | %FileCheck --check-prefixes CHECK,CHECK-KIND-CHANGED %s
+// CHECK-KIND-CHANGED: LibWithXRef.swiftmodule:1:1: error: reference to type 'MyType' broken by a context change; the declaration kind of 'MyType' from 'A' changed since building 'LibWithXRef'
+
+/// Change MyType into a function, move it and then error.
+// RUN: cp %t/Empty.h %t/A.h
+// RUN: cp %t/LibTypeChanged.h %t/B.h
+// RUN: not %target-swift-frontend -emit-sil %t/LibWithXRef.swiftmodule -I %t \
+// RUN:   -diagnostic-style llvm 2>&1 \
+// RUN:   | %FileCheck --check-prefixes CHECK,CHECK-KIND-CHANGED-AND-MOVED %s
+// CHECK-KIND-CHANGED-AND-MOVED: LibWithXRef.swiftmodule:1:1: error: reference to type 'MyType' broken by a context change; the declaration kind of 'MyType' changed since building 'LibWithXRef', it was in 'A' and now a candidate is found only in 'B'
+
+/// Remove MyType from all imported modules and error.
+// RUN: cp %t/Empty.h %t/A.h
+// RUN: cp %t/Empty.h %t/B.h
+// RUN: not %target-swift-frontend -emit-sil %t/LibWithXRef.swiftmodule -I %t \
+// RUN:   -diagnostic-style llvm 2>&1 \
+// RUN:   | %FileCheck --check-prefixes CHECK,CHECK-NOT-FOUND %s
+// CHECK-NOT-FOUND: LibWithXRef.swiftmodule:1:1: error: reference to type 'MyType' broken by a context change; 'MyType' is not found, it was expected to be in 'A'
+
+// CHECK: LibWithXRef.swiftmodule:1:1: note: could not deserialize extension
+
+//--- module.modulemap
+module A {
+    header "A.h"
+}
+
+module B {
+    header "B.h"
+}
+
+//--- Empty.h
+
+//--- LibOriginal.h
+struct MyType {};
+
+//--- LibTypeChanged.h
+/// Make it a function to fail filtering.
+void MyType() {}
+
+//--- LibWithXRef.swift
+import A
+import B
+
+public protocol Proto {}
+extension MyType : Proto {}
+
+@available(SwiftStdlib 5.1, *)
+public func foo() -> some Proto { return MyType() }


### PR DESCRIPTION
The Swift compiler has been reporting some clang modularization issues as diagnostics for some time now. The most common modularization break would be detected as a declaration moving between two modules, as different compiler invocation would assign it to different modules. This is commonly caused by two clang modules claiming ownership of the same header (or copies of the same header/declaration).

Here we apply the next step, recover from modularization issues and keep going when we can. If the compiler detects that a declaration moved between modules, it should keep working using the declaration at the new location. For this to apply the type must have the same name and signature, as well as moved only between clang modules.

This recovery is noted by diagnostics pointing out the real issue as a warning and followed by a note saying: `attempting to recover from the previous modularization issue`. If needed, this behavior can be disabled using `-disable-workaround-broken-modules`.

There are two main risks with this recovery:
- Possible undetected regressions. In a large system a modularization issue introduced by a library may break indirect clients. The old compiler error or crash would efficiently report this issue. This was however a late failure point and not the role of serialization. Projects should adopt the module verifier to report such issues early.
- Picking an incompatible declaration in the recovery process would push the problem down the road. The matching rules to pick the recovery declarations are very strict and require for the original declaration to have disappeared. The behavior is restricted to C languages where swift-style module namespacing isn't expected, so top-level declarations have distinct names. With these rules in place the recovery is unlikely to pick a different declaration.