### PR TITLE
[SE-0474] Enable yielding accessors by default

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -503,12 +503,7 @@ EXPERIMENTAL_FEATURE(AssumeResilientCxxTypes, true)
 EXPERIMENTAL_FEATURE(ImportNonPublicCxxMembers, true)
 
 /// `yielding borrow`/`yielding mutate` single-yield coroutine accessors
-// TODO: When this is turned on by default, take care of:
-// * "TODO" around line 8100 of lib/Parse/ParseDecl.cpp
-//   (Don't diagnose bare "read"/"modify" in accessors in source files.)
-// * "TODO" around line 12475 of lib/AST/Decl.cpp
-//   (Don't use "read"/"modify" in swiftinterface files.)
-SUPPRESSIBLE_EXPERIMENTAL_FEATURE(CoroutineAccessors, true)
+SUPPRESSIBLE_LANGUAGE_FEATURE(CoroutineAccessors, SE-0474, "Yielding accessors")
 
 /// `yielding borrow` and `yielding mutate` coroutine
 /// accessors always execute the second half of the

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -12490,15 +12490,10 @@ StringRef swift::getAccessorLabel(AccessorKind kind) {
 #define ACCESSOR(ID, KEYWORD)
 #include "swift/AST/AccessorKinds.def"
 
-    // Transitional terminology.  Let's use this for a little
-    // while to ease the transition.  (Both forms are parsed
-    // correctly, this just changes what gets written into
-    // .swiftinterface files.)
-    case AccessorKind::YieldingBorrow: return "read";
-    case AccessorKind::YieldingMutate: return "modify";
-    // TODO: Switch to the final terminology before shipping...
-    // case AccessorKind::YieldingBorrow: return "yielding borrow";
-    // case AccessorKind::YieldingMutate: return "yielding mutate";
+    case AccessorKind::YieldingBorrow:
+      return "yielding borrow";
+    case AccessorKind::YieldingMutate:
+      return "yielding mutate";
   }
   llvm_unreachable("bad accessor kind");
 }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -8092,27 +8092,21 @@ static ParserStatus parseAccessorIntroducer(Parser &P,
 
   // Support the old `read` and `modify` spellings used before SE-0474 was
   // finalized:
-  // * Support them in interface files, to avoid breaking .swiftinterface
+  // * Support reading them in interface files, to avoid breaking .swiftinterface
   //   while we transition to the new spellings.  (The compiler continued
   //   to write `read`/`modify` to interfaces while we transitioned.)
-  // * Support them in Swift code ONLY IF the user has explicitly opted
-  //   into the CoroutineAccessors flag.
-  // TODO: After CoroutineAccessors gets turned on by default, we should
-  // ONLY accept these in interface files.
   // TODO: Someday in the future (after 2026), we can stop accepting these
   // entirely.  Accepting them in interface files is a temporary
   // compatibility bridge to avoid immediate breakage during the switch
   // to the new terminology.
   else if (P.Tok.getRawText() == "read"
-	   && (P.SF.Kind == SourceFileKind::Interface
-	       || P.Context.LangOpts.hasFeature(Feature::CoroutineAccessors))) {
+	   && P.SF.Kind == SourceFileKind::Interface) {
     P.diagnose(P.Tok.getLoc(), diag::old_coroutine_accessor,
 	       "borrow", "read");
     Kind = AccessorKind::YieldingBorrow;
   }
   else if (P.Tok.getRawText() == "modify"
-	   && (P.SF.Kind == SourceFileKind::Interface
-	       || P.Context.LangOpts.hasFeature(Feature::CoroutineAccessors))) {
+	   && P.SF.Kind == SourceFileKind::Interface) {
     P.diagnose(P.Tok.getLoc(), diag::old_coroutine_accessor,
 	       "mutate", "modify");
     Kind = AccessorKind::YieldingMutate;


### PR DESCRIPTION
This enables the `CoroutineAccessors` feature flag by default, which is the final step in completing SE-0474.
