### PR TITLE
Ensure trace CSVs include entry and exit for all events on Windows, with microsecond-level timing

### DIFF
--- a/include/swift/Basic/Statistics.def
+++ b/include/swift/Basic/Statistics.def
@@ -86,6 +86,9 @@ FRONTEND_STATISTIC(Frontend, NumInstructionsExecuted)
 /// Total processor cycles-executed count in each frontend process.
 FRONTEND_STATISTIC(Frontend, NumCyclesExecuted)
 
+/// Elapsed wall clock time in microseconds in each frontend process.
+FRONTEND_STATISTIC(Frontend, WallClockMicroseconds)
+
 /// Maximum number of bytes allocated via malloc.
 FRONTEND_STATISTIC(Frontend, MaxMallocUsage)
 

--- a/include/swift/Basic/Statistics.def
+++ b/include/swift/Basic/Statistics.def
@@ -83,6 +83,9 @@ FRONTEND_STATISTIC(Frontend, NumProcessFailures)
 /// Total instructions-executed count in each frontend process.
 FRONTEND_STATISTIC(Frontend, NumInstructionsExecuted)
 
+/// Total processor cycles-executed count in each frontend process.
+FRONTEND_STATISTIC(Frontend, NumCyclesExecuted)
+
 /// Maximum number of bytes allocated via malloc.
 FRONTEND_STATISTIC(Frontend, MaxMallocUsage)
 

--- a/lib/Basic/Statistic.cpp
+++ b/lib/Basic/Statistic.cpp
@@ -530,7 +530,9 @@ FrontendStatsTracer::~FrontendStatsTracer()
 }
 
 static int64_t getCurrentTimeInMicroseconds() {
-  return std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
+  return std::chrono::duration_cast<std::chrono::microseconds>(
+             std::chrono::steady_clock::now().time_since_epoch())
+      .count();
 }
 
 static const int64_t processStartTimeMicroseconds = getCurrentTimeInMicroseconds();
@@ -550,17 +552,15 @@ void updateProcessWideFrontendCounters(
   }
 #elif defined(_WIN32)
   ULONG64 CycleTime;
-  if (QueryProcessCycleTime(GetCurrentProcess(), &CycleTime)) {
+  if (QueryProcessCycleTime(GetCurrentProcess(), &CycleTime))
     C.NumCyclesExecuted = CycleTime;
-  }
 
   PROCESS_MEMORY_COUNTERS_EX PMC;
   PMC.cb = sizeof(PMC);
   if (GetProcessMemoryInfo(GetCurrentProcess(),
                            reinterpret_cast<PROCESS_MEMORY_COUNTERS *>(&PMC),
-                           sizeof(PMC))) {
+                           sizeof(PMC)))
     C.MaxMallocUsage = PMC.PeakWorkingSetSize;
-  }
   return;
 #endif
 

--- a/lib/Basic/Statistic.cpp
+++ b/lib/Basic/Statistic.cpp
@@ -529,10 +529,18 @@ FrontendStatsTracer::~FrontendStatsTracer()
     Reporter->saveAnyFrontendStatsEvents(*this, false);
 }
 
+static int64_t getCurrentTimeInMicroseconds() {
+  return std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
+}
+
+static const int64_t processStartTimeMicroseconds = getCurrentTimeInMicroseconds();
+
 // Copy any interesting process-wide resource accounting stats to
 // associated fields in the provided AlwaysOnFrontendCounters.
 void updateProcessWideFrontendCounters(
     UnifiedStatsReporter::AlwaysOnFrontendCounters &C) {
+  C.WallClockMicroseconds = getCurrentTimeInMicroseconds() - processStartTimeMicroseconds;
+
 #if defined(HAVE_PROC_PID_RUSAGE) && defined(RUSAGE_INFO_V4)
   struct rusage_info_v4 ru;
   if (proc_pid_rusage(getpid(), RUSAGE_INFO_V4, (rusage_info_t *)&ru) == 0) {

--- a/lib/Basic/Statistic.cpp
+++ b/lib/Basic/Statistic.cpp
@@ -540,9 +540,23 @@ void updateProcessWideFrontendCounters(
     C.MaxMallocUsage = ru.ri_lifetime_max_phys_footprint;
     return;
   }
+#elif defined(_WIN32)
+  ULONG64 CycleTime;
+  if (QueryProcessCycleTime(GetCurrentProcess(), &CycleTime)) {
+    C.NumCyclesExecuted = CycleTime;
+  }
+
+  PROCESS_MEMORY_COUNTERS_EX PMC;
+  PMC.cb = sizeof(PMC);
+  if (GetProcessMemoryInfo(GetCurrentProcess(),
+                           reinterpret_cast<PROCESS_MEMORY_COUNTERS *>(&PMC),
+                           sizeof(PMC))) {
+    C.MaxMallocUsage = PMC.PeakWorkingSetSize;
+  }
+  return;
 #endif
 
-  // FIXME: Do something useful when the above API is not available.
+  // FIXME: Do something useful when the above APIs are not available.
 }
 
 static inline void


### PR DESCRIPTION
Ensure trace CSVs include entry and exit for all events on Windows, with microsecond-level timing. Previously, entry and exit rows were missing for some events because `updateProcessWideFrontendCounters()` was not implemented on Windows, and timing granularity was coarser than one millisecond.

This PR adds or modifies the following counters:
* `WallClockMicroseconds`: added on all platforms. Measures wall clock time from the start time of the process as opposed to CPU time (measured by the `Time` and `Live` columns in trace CSVs), so, for example, it includes time spent waiting on I/O.
* `NumCyclesExecuted`: added as a Windows-specific best available alternative to `NumInstructionsExecuted`.
* `MaxMallocUsage`: now populated on Windows as well as other platforms.

Resolves https://github.com/swiftlang/swift/issues/86586

Swift CI needs to be run by a committer.

Example output:
```
Time,Live,IsEntry,EventName,CounterName,CounterDelta,CounterValue,EntityName,EntityRange
46875,0,"entry","load-stdlib","Frontend.NumCyclesExecuted",145831941,145831941,"",""
46875,0,"entry","load-stdlib","Frontend.WallClockMicroseconds",2951,2951,"",""
46875,0,"entry","load-stdlib","Frontend.MaxMallocUsage",35610624,35610624,"",""
46875,0,"entry","load-stdlib","AST.NumASTBytesAllocated",12825,12825,"",""
78125,31250,"exit","load-stdlib","Frontend.NumCyclesExecuted",102330763,248162704,"",""
78125,31250,"exit","load-stdlib","Frontend.WallClockMicroseconds",34757,37708,"",""
78125,31250,"exit","load-stdlib","Frontend.MaxMallocUsage",11141120,46751744,"",""
78125,31250,"exit","load-stdlib","AST.NumASTBytesAllocated",19904,32729,"",""
78125,31250,"exit","load-stdlib","AST.ImportSetFoldMiss",8,8,"",""
78125,31250,"exit","load-stdlib","AST.ImportSetCacheMiss",8,8,"",""
78125,0,"entry","parse-and-resolve-imports","Frontend.NumCyclesExecuted",1697566,249860270,"",""
78125,0,"entry","parse-and-resolve-imports","Frontend.WallClockMicroseconds",422,38130,"",""
78125,0,"entry","Import resolution","Frontend.NumCyclesExecuted",3917161,253777431,"",""
78125,0,"entry","Import resolution","Frontend.WallClockMicroseconds",1338,39468,"",""
78125,0,"entry","Import resolution","Frontend.MaxMallocUsage",69632,46821376,"",""
78125,0,"entry","Import resolution","AST.NumASTBytesAllocated",3544,36273,"",""
125000,46875,"exit","Import resolution","Frontend.NumCyclesExecuted",130969849,384747280,"",""
125000,46875,"exit","Import resolution","Frontend.WallClockMicroseconds",44631,84099,"",""
125000,46875,"exit","Import resolution","Frontend.MaxMallocUsage",24305664,71127040,"",""
125000,46875,"exit","Import resolution","AST.NumASTBytesAllocated",58096,94369,"",""
125000,46875,"exit","Import resolution","AST.ImportSetFoldMiss",14,22,"",""
125000,46875,"exit","Import resolution","AST.ImportSetCacheMiss",14,22,"",""
125000,46875,"exit","parse-and-resolve-imports","Frontend.NumCyclesExecuted",775106,385522386,"",""
125000,46875,"exit","parse-and-resolve-imports","Frontend.WallClockMicroseconds",243,84342,"",""
125000,46875,"exit","parse-and-resolve-imports","Frontend.MaxMallocUsage",57344,71184384,"",""
125000,0,"entry","perform-sema","Frontend.NumCyclesExecuted",630148,386152534,"",""
125000,0,"entry","perform-sema","Frontend.WallClockMicroseconds",216,84558,"",""
...
```
Notice how:
1. Every event with an exit row block has an entry row block with events nested in terms of entry/exit.
2. `Frontend.NumCyclesExecuted` (Windows-specific) `Frontend.WallClockMicroseconds` (cross-platform) are in every entry and exit row block.
3. `Frontend.WallClockMicroseconds` row `CounterValue`s roughly match up with the `Time` column, but have finer granularity (e.g., we can see 422microseconds elapsed between `load-stdlib` exit and `parse-and-resolve-imports` entry).
4. Wall clock times for leaf level events match wall cock times in `stats-*.json` files. For example, in this run, we see 34757 microseconds for `load-stdlib` and 44631 microseconds for `Import Resolution`. In the corresponding `stats-*.json` file, we have very close to the same numbers, in units of seconds:
```
{
	...
	"time.swift.Import resolution.wall": 4.4628858566284180e-02,
	...
	"time.swift.load-stdlib.wall": 3.4754514694213867e-02,
	...
}
```