### PR TITLE
[CoroutineAccessors] [SILGen] Fix emitBackDeployForwardApplyAndReturnOrThrow for yield_once_2 coroutines

### DIFF
--- a/test/SILGen/back_deployed_attr_accessor_coroutine.swift
+++ b/test/SILGen/back_deployed_attr_accessor_coroutine.swift
@@ -1,6 +1,10 @@
 // RUN: %target-swift-emit-sil -Xllvm -sil-print-types -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.50 -verify
 // RUN: %target-swift-emit-silgen -Xllvm -sil-print-types -parse-as-library -module-name back_deploy %s | %FileCheck %s
 // RUN: %target-swift-emit-silgen -Xllvm -sil-print-types -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.50 | %FileCheck %s
+// Dont crash:
+// RUN: %target-swift-emit-silgen -enable-library-evolution -enable-experimental-feature CoroutineAccessors -Xllvm -sil-print-types -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx99.99
+
+// REQUIRES: swift_feature_CoroutineAccessors
 
 // REQUIRES: OS=macosx
 


### PR DESCRIPTION
They have an stack allocation result and the token result is at a different index.

rdar://168937038
