### PR TITLE
[Concurrency] Use Task.immediate for bridged async methods when available

### DIFF
--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -1049,7 +1049,11 @@ extension Task where Failure == Error {
 @usableFromInline
 internal func _runTaskForBridgedAsyncMethod(@_inheritActorContext _ body: __owned @Sendable @escaping () async -> Void) {
 #if compiler(>=5.6)
-  Task(operation: body)
+  if #available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *) {
+    Task.immediate(operation: body)
+  } else {
+    Task(operation: body)
+  }
 #else
   Task<Int, Error> {
     await body()


### PR DESCRIPTION
This is a behaviour change, however a most welcome one -- it attempts to avoid the initial enqueue to global which can cause delays and ordering changes when using bridget async methods.

Open question if this should be using `if #available(SwiftStdlib 6.2, *) {` when `Task.immediate` was introduced or `if #available(SwiftStdlib 6. 3 or 4, *) {` since when we add the behavior change here...
