### PR TITLE
[SILGen]: some fixes for throws(Never) properties & subscripts

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -2106,10 +2106,18 @@ static void emitRawApply(SILGenFunction &SGF,
     else
       errorAddrOrType = substFnConv.getSILErrorType(SGF.getTypeExpansionContext());
 
-    SILBasicBlock *errorBB =
-      SGF.getTryApplyErrorDest(loc, substFnType, prevExecutor,
-                                *errorAddrOrType,
-                               options.contains(ApplyFlags::DoesNotThrow));
+    bool suppressErrorPath = options.contains(ApplyFlags::DoesNotThrow);
+
+    // If we're constructing a no-throw function and emitting a throws(Never)
+    // try_apply, we also want to emit the error branch as unreachable.
+    if (!suppressErrorPath &&
+        !SGF.F.getLoweredFunctionType()->hasErrorResult() &&
+        substFnType->getErrorResult().getInterfaceType()->isNever()) {
+      suppressErrorPath = true;
+    }
+
+    SILBasicBlock *errorBB = SGF.getTryApplyErrorDest(
+        loc, substFnType, prevExecutor, *errorAddrOrType, suppressErrorPath);
 
     options -= ApplyFlags::DoesNotThrow;
     SGF.B.createTryApply(loc, fnValue, subs, argValues, normalBB, errorBB,

--- a/test/SILGen/typed_throws.swift
+++ b/test/SILGen/typed_throws.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-emit-silgen -Xllvm -sil-print-types %s | %FileCheck %s
+// RUN: %target-swift-emit-sil -sil-verify-all %s
 
 enum MyError: Error {
   case fail
@@ -296,6 +297,83 @@ func formerReabstractionCrash() {
   let _: MyResult<String, Error>? = {
     return MyResult{"hello"}
   }()
+}
+
+// https://github.com/swiftlang/swift/issues/74273
+
+// Accessors & subscripts with typed throws getters where the error type is
+// substituted with Never should have unreachable error paths when called.
+
+struct GenericErrorAccessors<E: Error> {
+  var prop: Int {
+    get throws(E) { 42 }
+  }
+
+  subscript(key: Int) -> Int {
+    get throws(E) { key }
+  }
+}
+
+// CHECK-LABEL: sil {{.*}} @{{.*}}accessNeverThrowingProp{{[^:]*}}F :
+// CHECK:         try_apply {{%.*}}<Never>{{.*}}, error [[ERROR:bb[0-9]+]]
+// CHECK:       [[ERROR]]:
+// CHECK-NEXT:    unreachable
+func accessNeverThrowingProp(_ s: GenericErrorAccessors<Never>) {
+  _ = s.prop
+}
+
+// CHECK-LABEL: sil {{.*}} @{{.*}}accessNeverThrowingSubscript{{[^:]*}}F :
+// CHECK:         try_apply {{%.*}}<Never>{{.*}}, error [[ERROR:bb[0-9]+]]
+// CHECK:       [[ERROR]]:
+// CHECK-NEXT:    unreachable
+func accessNeverThrowingSubscript(_ s: GenericErrorAccessors<Never>) {
+  _ = s[0]
+}
+
+extension GenericErrorAccessors where E == Never {
+  // CHECK-LABEL: sil {{.*}} @{{.*}}Never{{.*}}readProp{{.*}}F :
+  // CHECK:         try_apply {{%.*}}<Never>{{.*}}, error [[ERROR:bb[0-9]+]]
+  // CHECK:       [[ERROR]]:
+  // CHECK-NEXT:    unreachable
+  func readProp() {
+    _ = self.prop
+  }
+
+  // CHECK-LABEL: sil {{.*}} @{{.*}}Never{{.*}}readSubscript{{.*}}F :
+  // CHECK:         try_apply {{%.*}}<Never>{{.*}}, error [[ERROR:bb[0-9]+]]
+  // CHECK:       [[ERROR]]:
+  // CHECK-NEXT:    unreachable
+  func readSubscript() {
+    _ = self[0]
+  }
+}
+
+protocol TypedThrowsProto {
+  associatedtype Err: Error
+
+  var throwingProp: Int { get throws(Err) }
+
+  subscript (key: Int) -> Int {
+    get throws(Err)
+  }
+}
+
+extension TypedThrowsProto where Err == Never {
+  // CHECK-LABEL: sil {{.*}} @{{.*}}TypedThrowsProto{{.*}}Never{{.*}}testProp{{.*}}F :
+  // CHECK:         try_apply {{.*}}, error [[ERROR:bb[0-9]+]]
+  // CHECK:       [[ERROR]]:
+  // CHECK-NEXT:    unreachable
+  func testProp() {
+    _ = self.throwingProp
+  }
+
+  // CHECK-LABEL: sil {{.*}} @{{.*}}TypedThrowsProto{{.*}}Never{{.*}}testSubscript{{.*}}F :
+  // CHECK:         try_apply {{.*}}, error [[ERROR:bb[0-9]+]]
+  // CHECK:       [[ERROR]]:
+  // CHECK-NEXT:    unreachable
+  func testSubscript() {
+    _ = self[0]
+  }
 }
 
 // CHECK-LABEL:      sil_vtable MySubclass {


### PR DESCRIPTION
Accessors and subscripts that used typed throws but were then specialized with `Never` would crash the compiler when not called within a (redundant) `try` expression. This appeared to be due to logic in SILGen that did not suppress the generated error path in these instances. This change adds code to detect this scenario and produce an unreachable error.

Resolves: https://github.com/swiftlang/swift/issues/74273
Resolves: https://github.com/swiftlang/swift/issues/87036