### PR TITLE
[6.3] SIL: fix a complexity problem in the ownership verifier

### DIFF
--- a/include/swift/SIL/LinearLifetimeChecker.h
+++ b/include/swift/SIL/LinearLifetimeChecker.h
@@ -15,6 +15,7 @@
 
 #include "swift/Basic/Debug.h"
 #include "swift/Basic/LLVM.h"
+#include "swift/SIL/InstructionUtils.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILBasicBlock.h"
@@ -62,6 +63,11 @@ private:
   // may still be useful for checking memory lifetime for address uses.
   DeadEndBlocks *deadEndBlocks;
 
+  // If not null, `instIndices` are used for efficiently computing dominance
+  // relations between instructions in the same basic block.
+  // If null, the algorithm falls back to linear search.
+  InstructionIndices *instIndices;
+
 public:
   /// \p deadEndBlocks should be provided for lifetimes that do not require
   /// consuming uses on dead-end paths, which end in an unreachable terminator.
@@ -73,8 +79,8 @@ public:
   /// paths. Owned OSSA lifetimes may still be missing destroys on dead-end
   /// paths. Once owned values are fully enforced, the same invariant will hold
   /// for all OSSA values.
-  LinearLifetimeChecker(DeadEndBlocks *deadEndBlocks = nullptr)
-      : deadEndBlocks(deadEndBlocks) {}
+  LinearLifetimeChecker(DeadEndBlocks *deadEndBlocks, InstructionIndices *instIndices)
+      : deadEndBlocks(deadEndBlocks), instIndices(instIndices) {}
 
   /// Returns true that \p value forms a linear lifetime with consuming uses \p
   /// consumingUses, non consuming uses \p nonConsumingUses. Returns false

--- a/include/swift/SIL/SILBitfield.h
+++ b/include/swift/SIL/SILBitfield.h
@@ -109,6 +109,10 @@ public:
     }
     entity->setCustomBits((entity->getCustomBits() & ~clearMask) | (value << startBit));
   }
+
+  bool fits(unsigned value) const {
+    return value < (1u << (endBit - startBit));
+  }
 };
 
 /// A set which knows its size.

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -38,6 +38,7 @@ class DominanceInfo;
 class PostOrderFunctionInfo;
 class ReversePostOrderInfo;
 class Operand;
+class InstructionIndices;
 class SILInstruction;
 class SILArgument;
 class SILLocation;
@@ -728,7 +729,7 @@ public:
   /// Verify that this SILValue and its uses respects ownership invariants.
   ///
   /// \p DEBlocks is nullptr when OSSA lifetimes are complete.
-  void verifyOwnership(DeadEndBlocks *DEBlocks) const;
+  void verifyOwnership(DeadEndBlocks *DEBlocks, InstructionIndices *instIndices) const;
 
   SWIFT_DEBUG_DUMP;
 };

--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -1493,3 +1493,15 @@ bool swift::shouldExpand(SILModule &module, SILType ty) {
   unsigned numFields = module.Types.countNumberOfFields(ty, expansion);
   return (numFields <= 6);
 }
+
+InstructionIndices::InstructionIndices(SILFunction *f)
+    : indices(f, numIndexBits) {
+  for (SILBasicBlock &block : *f) {
+    unsigned idx = 1;
+    for (SILInstruction &inst : block) {
+      indices.set(inst.asSILNode(), idx);
+      if (indices.fits(idx + 1))
+        idx += 1;
+    }
+  }
+}

--- a/lib/SIL/Verifier/GuaranteedPhiVerifier.cpp
+++ b/lib/SIL/Verifier/GuaranteedPhiVerifier.cpp
@@ -34,7 +34,7 @@ bool GuaranteedPhiVerifier::verifyDependentPhiLifetime(SILPhiArgument *phi,
     return false;
 
   SmallVector<Operand *, 4> phiUses(lookThroughBorrowedFromUser(phi)->getUses());
-  LinearLifetimeChecker checker(deadEndBlocks);
+  LinearLifetimeChecker checker(deadEndBlocks, instIndices);
   // newErrorBuilder is consumed at the end of the checkValue function.
   // Copy initial state from errorBuilder everytime
   LinearLifetimeChecker::ErrorBuilder newErrorBuilder = errorBuilder;

--- a/lib/SIL/Verifier/GuaranteedPhiVerifierPrivate.h
+++ b/lib/SIL/Verifier/GuaranteedPhiVerifierPrivate.h
@@ -96,9 +96,16 @@ class GuaranteedPhiVerifier {
       dependentPhiToBaseValueMap;
 
 public:
+  // If not null, `instIndices` are used for efficiently computing dominance
+  // relations between instructions in the same basic block.
+  // If null, the algorithm falls back to linear search.
+  InstructionIndices *instIndices;
+
   GuaranteedPhiVerifier(const SILFunction *func, DeadEndBlocks *deadEndBlocks,
+                        InstructionIndices *instIndices,
                         LinearLifetimeChecker::ErrorBuilder errorBuilder)
-      : deadEndBlocks(deadEndBlocks), errorBuilder(errorBuilder) {}
+      : deadEndBlocks(deadEndBlocks), errorBuilder(errorBuilder),
+        instIndices(instIndices) {}
 
   /// Verify whether all reborrows of \p borrow are within the lifetime of the
   /// borrowed value.

--- a/lib/SIL/Verifier/SILOwnershipVerifier.cpp
+++ b/lib/SIL/Verifier/SILOwnershipVerifier.cpp
@@ -186,7 +186,8 @@ bool SILValueOwnershipChecker::check() {
   llvm::copy(regularUsers, std::back_inserter(allRegularUsers));
   llvm::copy(extendLifetimeUses, std::back_inserter(allRegularUsers));
 
-  LinearLifetimeChecker checker(deadEndBlocks);
+  LinearLifetimeChecker checker(deadEndBlocks,
+                                guaranteedPhiVerifier.instIndices);
   auto linearLifetimeResult = checker.checkValue(value, allLifetimeEndingUsers,
                                                  allRegularUsers, errorBuilder);
   result = !linearLifetimeResult.getFoundError();
@@ -619,7 +620,8 @@ bool SILValueOwnershipChecker::checkYieldWithoutLifetimeEndingUses(
     coroutineEndUses.push_back(use);
   }
 
-  LinearLifetimeChecker checker(deadEndBlocks);
+  LinearLifetimeChecker checker(deadEndBlocks,
+                                guaranteedPhiVerifier.instIndices);
   auto linearLifetimeResult =
       checker.checkValue(yield, coroutineEndUses, regularUses, errorBuilder);
   if (linearLifetimeResult.getFoundError()) {
@@ -962,7 +964,8 @@ verifySILValueHelper(const SILFunction *f, SILValue value,
       .check();
 }
 
-void SILValue::verifyOwnership(DeadEndBlocks *deadEndBlocks) const {
+void SILValue::verifyOwnership(DeadEndBlocks *deadEndBlocks,
+                               InstructionIndices *instIndices) const {
   // Do not validate SILUndef values.
   if (isa<SILUndef>(*this))
     return;
@@ -993,7 +996,8 @@ void SILValue::verifyOwnership(DeadEndBlocks *deadEndBlocks) const {
   using BehaviorKind = LinearLifetimeChecker::ErrorBehaviorKind;
   LinearLifetimeChecker::ErrorBuilder errorBuilder(
       *f, BehaviorKind::PrintMessageAndAssert);
-  GuaranteedPhiVerifier guaranteedPhiVerifier(f, deadEndBlocks, errorBuilder);
+  GuaranteedPhiVerifier guaranteedPhiVerifier(f, deadEndBlocks, instIndices,
+                                              errorBuilder);
   verifySILValueHelper(f, *this, errorBuilder, deadEndBlocks,
                        guaranteedPhiVerifier);
 }
@@ -1040,8 +1044,10 @@ void SILFunction::verifyOwnership(DeadEndBlocks *deadEndBlocks) const {
     errorBuilder.emplace(*this, BehaviorKind::PrintMessageAndAssert);
   }
 
+  InstructionIndices instIndices(const_cast<SILFunction *>(this));
+
   GuaranteedPhiVerifier guaranteedPhiVerifier(this, deadEndBlocks,
-                                              *errorBuilder);
+                                              &instIndices, *errorBuilder);
   for (auto &block : *this) {
     for (auto *arg : block.getArguments()) {
       LinearLifetimeChecker::ErrorBuilder newBuilder = *errorBuilder;

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1350,7 +1350,7 @@ public:
               "Once ownership is gone, all values should have none ownership");
       return;
     }
-    SILValue(V).verifyOwnership(DEBlocks.get());
+    SILValue(V).verifyOwnership(DEBlocks.get(), &instIndices);
   }
 
   void checkSILInstruction(SILInstruction *I) {

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -919,6 +919,7 @@ class SILVerifier : public SILVerifierBase<SILVerifier> {
   CalleeCache *calleeCache;
   SILFunctionConventions fnConv;
   Lowering::TypeConverter &TC;
+  InstructionIndices instIndices;
 
   bool SingleFunction = true;
   bool checkLinearLifetime = false;
@@ -927,9 +928,6 @@ class SILVerifier : public SILVerifierBase<SILVerifier> {
   const SILInstruction *CurInstruction = nullptr;
   const SILArgument *CurArgument = nullptr;
   std::unique_ptr<DominanceInfo> Dominance;
-
-  // Used for dominance checking within a basic block.
-  llvm::DenseMap<const SILInstruction *, unsigned> InstNumbers;
 
   /// TODO: LifetimeCompletion: Remove.
   std::shared_ptr<DeadEndBlocks> DEBlocks;
@@ -1200,35 +1198,24 @@ public:
     return match;
   }
 
-  static unsigned numInstsInFunction(const SILFunction &F) {
-    unsigned numInsts = 0;
-    for (auto &BB : F) {
-      numInsts += std::distance(BB.begin(), BB.end());
-    }
-    return numInsts;
-  }
-
   SILVerifier(const SILFunction &F, CalleeCache *calleeCache,
               bool SingleFunction, bool checkLinearLifetime)
       : M(F.getModule().getSwiftModule()), F(F),
         calleeCache(calleeCache),
         fnConv(F.getConventionsInContext()), TC(F.getModule().Types),
+        instIndices(const_cast<SILFunction *>(&F)),
         SingleFunction(SingleFunction),
         checkLinearLifetime(checkLinearLifetime),
-        Dominance(nullptr),
-        InstNumbers(numInstsInFunction(F)) {
+        Dominance(nullptr) {
     if (F.isExternalDeclaration())
       return;
 
     // Check to make sure that all blocks are well formed.  If not, the
     // SILVerifier object will explode trying to compute dominance info.
-    unsigned InstIdx = 0;
     for (auto &BB : F) {
       require(!BB.empty(), "Basic blocks cannot be empty");
       require(isa<TermInst>(BB.back()),
               "Basic blocks must end with a terminator instruction");
-      for (auto &I : BB)
-        InstNumbers[&I] = InstIdx++;
     }
 
     Dominance.reset(new DominanceInfo(const_cast<SILFunction *>(&F)));
@@ -1252,7 +1239,10 @@ public:
     if (aBlock != bBlock)
       return Dominance->properlyDominates(aBlock, bBlock);
 
-    return InstNumbers[a] < InstNumbers[b];
+    // Note that it might happen that for absurdly large basic blocks, the instruction
+    // indices are "maxed out". In this case we cannot compute the before-after
+    // relation efficiently and we conservatively return true.
+    return a != b && instIndices.get(a) <= instIndices.get(b);
   }
 
   void visitSILPhiArgument(SILPhiArgument *arg) {

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -139,7 +139,7 @@ static  bool fixupReferenceCounts(
       auto *stackLoc = builder.createAllocStack(loc, v->getType().getObjectType());
       builder.createCopyAddr(loc, v, stackLoc, IsNotTake, IsInitialization);
 
-      LinearLifetimeChecker checker(&deadEndBlocks);
+      LinearLifetimeChecker checker(&deadEndBlocks, /*instIndices=*/ nullptr);
       bool consumedInLoop = checker.completeConsumingUseSet(
           pai, applySite.getCalleeOperand(),
           [&](SILBasicBlock::iterator insertPt) {
@@ -182,7 +182,7 @@ static  bool fixupReferenceCounts(
       // just cares about the block the value is in. In a forthcoming commit, I
       // am going to change this to use a different API on the linear lifetime
       // checker that makes this clearer.
-      LinearLifetimeChecker checker(&deadEndBlocks);
+      LinearLifetimeChecker checker(&deadEndBlocks, /*instIndices=*/ nullptr);
       bool consumedInLoop = checker.completeConsumingUseSet(
           pai, applySite.getCalleeOperand(),
           [&](SILBasicBlock::iterator insertPt) {
@@ -229,7 +229,7 @@ static  bool fixupReferenceCounts(
       // just cares about the block the value is in. In a forthcoming commit, I
       // am going to change this to use a different API on the linear lifetime
       // checker that makes this clearer.
-      LinearLifetimeChecker checker(&deadEndBlocks);
+      LinearLifetimeChecker checker(&deadEndBlocks, /*instIndices=*/ nullptr);
       checker.completeConsumingUseSet(
           pai, applySite.getCalleeOperand(),
           [&](SILBasicBlock::iterator insertPt) {
@@ -266,7 +266,7 @@ static  bool fixupReferenceCounts(
       // just cares about the block the value is in. In a forthcoming commit, I
       // am going to change this to use a different API on the linear lifetime
       // checker that makes this clearer.
-      LinearLifetimeChecker checker(&deadEndBlocks);
+      LinearLifetimeChecker checker(&deadEndBlocks, /*instIndices=*/ nullptr);
       checker.completeConsumingUseSet(
           pai, applySite.getCalleeOperand(),
           [&](SILBasicBlock::iterator insertPt) {

--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -541,7 +541,7 @@ void AvailableValueDataflowFixup::verifyOwnership(DeadEndBlocks &deBlocks) {
       continue;
 
     for (auto result : inst->getResults()) {
-      result.verifyOwnership(&deBlocks);
+      result.verifyOwnership(&deBlocks, /*instIndices=*/ nullptr);
     }
   }
   insertedInsts.clear();

--- a/lib/SILOptimizer/SemanticARC/CopyValueOpts.cpp
+++ b/lib/SILOptimizer/SemanticARC/CopyValueOpts.cpp
@@ -813,7 +813,7 @@ bool SemanticARCOptVisitor::tryPerformOwnedCopyValueOptimization(
   // parent owned value's lifetime.
   // Note: we cannot optimistically ignore DeadEndBlocks - unlike for ownership
   //       verification.
-  LinearLifetimeChecker checker(nullptr);
+  LinearLifetimeChecker checker(nullptr, /*instIndices=*/ nullptr);
   if (!checker.validateLifetime(originalValue, parentLifetimeEndingUses,
                                 allCopyUses))
     return false;

--- a/lib/SILOptimizer/SemanticARC/OwnershipConversionElimination.cpp
+++ b/lib/SILOptimizer/SemanticARC/OwnershipConversionElimination.cpp
@@ -56,7 +56,7 @@ bool SemanticARCOptVisitor::visitUncheckedOwnershipConversionInst(
 
   // Ok, now we need to perform our lifetime check.
   SmallVector<Operand *, 8> consumingUses(op->getConsumingUses());
-  LinearLifetimeChecker checker(&ctx.getDeadEndBlocks());
+  LinearLifetimeChecker checker(&ctx.getDeadEndBlocks(),  /*instIndices=*/ nullptr);
   if (!checker.validateLifetime(op, consumingUses, newUses))
     return false;
 

--- a/test/SIL/verifier_failures.sil
+++ b/test/SIL/verifier_failures.sil
@@ -10,6 +10,41 @@ class C {}
 
 protocol Error {}
 
+// CHECK-LABEL: Begin Error in function dominance_violation_in_block
+// CHECK:       SIL verification failed: instruction isn't dominated by its operand
+// CHECK-LABEL: End Error in function dominance_violation_in_block
+sil [ossa] @dominance_violation_in_block : $@convention(thin) () -> () {
+bb0:
+  fix_lifetime %1 : $Builtin.Int32
+  %1 = integer_literal $Builtin.Int32, 0
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: Begin Error in function dominance_violation_in_instruction
+// CHECK:       SIL verification failed: instruction isn't dominated by its operand
+// CHECK-LABEL: End Error in function dominance_violation_in_instruction
+sil [ossa] @dominance_violation_in_instruction : $@convention(thin) () -> () {
+bb0:
+  %1 = apply undef(%1) : $@convention(thin) (Builtin.Int32) -> Builtin.Int32
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: Begin Error in function dominance_violation_multi_bb
+// CHECK:       SIL verification failed: instruction isn't dominated by its operand
+// CHECK-LABEL: End Error in function dominance_violation_multi_bb
+sil [ossa] @dominance_violation_multi_bb : $@convention(thin) () -> () {
+bb0:
+  fix_lifetime %1 : $Builtin.Int32
+  br bb1
+
+bb1:
+  %1 = integer_literal $Builtin.Int32, 0
+  %retval = tuple ()
+  return %retval : $()
+}
+
 // CHECK-LABEL: Begin Error in function end_borrow_1_addr_alloc_stack
 // CHECK:       SIL verification failed: end_borrow of an address not produced by store_borrow
 // CHECK-LABEL: End Error in function end_borrow_1_addr_alloc_stack

--- a/validation-test/SILOptimizer/large_string_array.swift.gyb
+++ b/validation-test/SILOptimizer/large_string_array.swift.gyb
@@ -9,7 +9,7 @@
 // If the compiler needs more than 5 minutes, there is probably a real problem.
 // So please don't just increase the timeout in case this fails.
 
-// RUN: %{python} %S/../../test/Inputs/timeout.py 300 %target-swift-frontend -O -parse-as-library -sil-verify-none -emit-sil %t/main.swift | %FileCheck %s
+// RUN: %{python} %S/../../test/Inputs/timeout.py 300 %target-swift-frontend -O -parse-as-library -emit-sil %t/main.swift | %FileCheck %s
 
 // REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 // REQUIRES: long_test


### PR DESCRIPTION
* **Explanation**:  Fixes a compile time problem with large arrays. In the ownership verifier, computing dominance relation between instructions in the same block was done with linear search, e.g. when checking if a value-use is before its lifetime ending instruction.
This resulted in quadratic complexity and very long compile times for very large basic blocks.
Now we do the dominance check with pre-computed instruction indices, which is O(0) instead of O(n).
* **Risk**: Low. It's only affecting the verifier. No change in code generation.
* **Testing**: Tested by lit tests.
* **Issue**: https://github.com/swiftlang/swift/issues/86663, rdar://168511262
* **Reviewer**:  @meg-gupta, @hjyamauchi 
* **Main branch PR**: https://github.com/swiftlang/swift/pull/86781
