### PR TITLE
RedundantLoadElimination: fix a complexity problem when replacing a huge amount of `load`s with a common value

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/RedundantLoadElimination.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/RedundantLoadElimination.swift
@@ -103,9 +103,9 @@ func eliminateRedundantLoads(in function: Function,
 
     // We cannot use for-in iteration here because if the load is split, the new
     // individual loads are inserted right before and they would be ignored by a for-in iteration.
-    var inst = block.instructions.reversed().first
-    while let i = inst {
-      defer { inst = i.previous }
+    // Also the `load` might be moved to another location instead of being deleted.
+    var iter = block.instructions.reversed().first
+    while let succ = iter, let inst = succ.previous {
 
       if let load = inst as? LoadingInstruction {
         if !context.continueWithNextSubpassRun(for: load) {
@@ -114,11 +114,16 @@ func eliminateRedundantLoads(in function: Function,
         if complexityBudget < 20 {
           complexityBudget = 20
         }
-        if !load.isEligibleForElimination(in: variant, context) {
-          continue;
+        if load.isEligibleForElimination(in: variant, context) {
+          if tryEliminate(load: load, complexityBudget: &complexityBudget, context) {
+            changed = true
+            // The `load` has been deleted: do not advance `iter`, because the next instruction to process is
+            // now its new predecessor.
+            continue
+          }
         }
-        changed = tryEliminate(load: load, complexityBudget: &complexityBudget, context) || changed
       }
+      iter = succ.previous
     }
   }
   return changed
@@ -141,6 +146,24 @@ extension LoadInst : LoadingInstruction {
 
   // Nothing to materialize, because this is already a `load`.
   func materializeLoadForReplacement(_ context: FunctionPassContext) -> LoadInst { return self }
+
+  func replaceEfficiently(with newValue: Value, _ context: FunctionPassContext) {
+    if let existingLoad = newValue as? LoadInst {
+      // As we are processing the loads in reverse control flow order, the replaced loads might accumulate
+      // quite a lot of users. This happens if the are many loads from the same location in a row.
+      // To avoid quadratic complexity in `uses.replaceAll`, we swap both load instructions and move the uses
+      // from the `existingLoad` (which usually has a small number of uses) to this load - and delete the
+      // `existingLoad`.
+      existingLoad.uses.replaceAll(with: self, context)
+      self.operand.set(to: existingLoad.address, context)
+      self.set(ownership: existingLoad.loadOwnership, context)
+      self.set(location: existingLoad.location, context)
+      self.move(before: existingLoad, context)
+      context.erase(instruction: existingLoad)
+    } else {
+      replace(with: newValue, context)
+    }
+  }
 }
 
 extension CopyAddrInst : LoadingInstruction {
@@ -357,7 +380,7 @@ private func replace(load: LoadingInstruction, with availableValues: [AvailableV
   // Make sure to keep dependencies valid after replacing the load
   insertMarkDependencies(for: originalLoad, context)
 
-  originalLoad.replace(with: newValue, context)
+  originalLoad.replaceEfficiently(with: newValue, context)
 }
 
 private func provideValue(

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -92,6 +92,11 @@ public class Instruction : CustomStringConvertible, Hashable {
     return Location(bridged: bridged.getLocation())
   }
 
+  final public func set(location: Location, _ context: some MutatingContext) {
+    bridged.setLocation(location.bridged)
+    context.notifyInstructionsChanged()
+  }
+
   public final func move(before otherInstruction: Instruction, _ context: some MutatingContext) {
     BridgedContext.moveInstructionBefore(bridged, otherInstruction.bridged)
     context.notifyInstructionsChanged()

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -731,6 +731,7 @@ struct BridgedInstruction {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedOperandArray getTypeDependentOperands() const;
   BRIDGED_INLINE void setOperand(SwiftInt index, BridgedValue value) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedLocation getLocation() const;
+  BRIDGED_INLINE void setLocation(BridgedLocation loc) const;
   BRIDGED_INLINE BridgedMemoryBehavior getMemBehavior() const;
   BRIDGED_INLINE bool mayRelease() const;
   BRIDGED_INLINE bool mayHaveSideEffects() const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -1157,6 +1157,10 @@ BridgedLocation BridgedInstruction::getLocation() const {
   return unbridged()->getDebugLocation();
 }
 
+void BridgedInstruction::setLocation(BridgedLocation loc) const {
+  return unbridged()->setDebugLocation(loc.getLoc());
+}
+
 BridgedMemoryBehavior BridgedInstruction::getMemBehavior() const {
   return (BridgedMemoryBehavior)unbridged()->getMemoryBehavior();
 }

--- a/test/Sema/large_int_array.swift.gyb
+++ b/test/Sema/large_int_array.swift.gyb
@@ -1,14 +1,17 @@
 // RUN: %empty-directory(%t)
 // RUN: %gyb %s -o %t/large_int_array.swift
-// RUN: %target-swift-frontend -typecheck -verify %t/large_int_array.swift
 
-// verification is disabled because the ownership verifier takes too long: rdar://162566682
-// RUN: %target-swift-frontend -sil-verify-none %t/large_int_array.swift -emit-sil -o %t
+// The compiler should finish in less than 10 seconds. To give some slack,
+// specify a timeout of 1 minute.
+
+// RUN: %{python} %S/../../test/Inputs/timeout.py 60 %target-swift-frontend -typecheck -verify %t/large_int_array.swift
+// RUN: %{python} %S/../../test/Inputs/timeout.py 60 %target-swift-frontend -O %t/large_int_array.swift -emit-sil -o /dev/null
+// RUN: %{python} %S/../../test/Inputs/timeout.py 60 %target-swift-frontend -parse-as-library -O %t/large_int_array.swift -emit-sil -o /dev/null
 
 % num_elements = 65537
 
 let v = 0
-let _ : [Int] = [
+let x : [Int] = [
 % for i in range(num_elements):
   v,
 % end


### PR DESCRIPTION
As RedundantLoadElimination processing the loads in reverse control flow order, the replaced loads might accumulate quite a lot of users. This happens if the are many loads from the same location in a row. To void quadratic complexity in `uses.replaceAll`, we swap both load instructions and move the uses from the previous (which usually has a small number of uses) to the replaced load.

This came up in the Sema/large_int_array.swift.gyb test, which tests a 64k large Int array. With this fix, the compile time gets down from 3 minutes to 5 seconds. I also changed the test:
* run the compiler with the timeout script to detect build time regressions
* re-enabled the SIL verifier because the problem there is already fixed (https://github.com/swiftlang/swift/pull/86781)
* run the compiler with -O to also test the whole optimizer pipeline and not only the mandatory pipeline
* assigned the array to a real variable (instead of `_`) to not let the optimizer remove the whole array too early
* run the compiler with and without `-parse-as-library` because this makes a huge difference how the global array is being generated
