### PR TITLE
[cxx-interop] Methods that return references to FRT are safe

### DIFF
--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -423,8 +423,10 @@ private:
 
 struct SafeUseOfCxxDeclDescriptor final {
   const clang::Decl *decl;
+  ASTContext& ctx;
 
-  SafeUseOfCxxDeclDescriptor(const clang::Decl *decl) : decl(decl) {}
+  SafeUseOfCxxDeclDescriptor(const clang::Decl *decl, ASTContext &ctx)
+      : decl(decl), ctx(ctx) {}
 
   friend llvm::hash_code hash_value(const SafeUseOfCxxDeclDescriptor &desc) {
     return llvm::hash_combine(desc.decl);

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -9131,7 +9131,7 @@ ClangImporter::Implementation::importSwiftAttrAttributes(Decl *MappedDecl) {
     bool importUnsafeHeuristic =
         isa<clang::CXXMethodDecl>(ClangDecl) &&
         !evaluateOrDefault(SwiftContext.evaluator,
-                           IsSafeUseOfCxxDecl({ClangDecl}), {});
+                           IsSafeUseOfCxxDecl({ClangDecl, SwiftContext}), {});
     if (seenUnsafe || importUnsafeHeuristic) {
       auto attr = new (SwiftContext) UnsafeAttr(/*implicit=*/!seenUnsafe);
       MappedDecl->addAttribute(attr);

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1502,7 +1502,7 @@ static StringRef renameUnsafeMethod(ASTContext &ctx,
                                     const clang::NamedDecl *decl,
                                     StringRef name) {
   if (isa<clang::CXXMethodDecl>(decl) &&
-      !evaluateOrDefault(ctx.evaluator, IsSafeUseOfCxxDecl({decl}), {})) {
+      !evaluateOrDefault(ctx.evaluator, IsSafeUseOfCxxDecl({decl, ctx}), {})) {
     return ctx.getIdentifier(("__" + name + "Unsafe").str()).str();
   }
 

--- a/test/Interop/Cxx/foreign-reference/Inputs/frt-reference-returns.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/frt-reference-returns.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#define IMMORTAL_FRT                                                           \
+  __attribute__((swift_attr("import_reference")))                              \
+  __attribute__((swift_attr("retain:immortal")))                               \
+  __attribute__((swift_attr("release:immortal")))
+
 namespace NoAnnotations {
 
 struct RefCountedType {
@@ -69,3 +74,19 @@ RefCountedType& getByRef();
 
 void retainBothRefCounted(BothAnnotations::RefCountedType* obj);
 void releaseBothRefCounted(BothAnnotations::RefCountedType* obj);
+
+struct ImmortalIntBox {
+  int value;
+
+  ImmortalIntBox(const ImmortalIntBox &) = delete;
+
+  ImmortalIntBox &builderPattern() { return *this; }
+} IMMORTAL_FRT;
+
+static ImmortalIntBox globalImmortalIntBox = {123};
+ImmortalIntBox &createImmortalIntBox() { return globalImmortalIntBox; }
+
+struct DerivedImmortalIntBox : ImmortalIntBox {};
+
+static DerivedImmortalIntBox globalDerivedImmortalIntBox = {456};
+DerivedImmortalIntBox &createDerivedImmortalIntBox() { return globalDerivedImmortalIntBox; }

--- a/test/Interop/Cxx/foreign-reference/frt-reference-returns-diagnostics.swift
+++ b/test/Interop/Cxx/foreign-reference/frt-reference-returns-diagnostics.swift
@@ -28,3 +28,11 @@ func testBothAnnotations() {
   let _ = BothAnnotations.createByRef() 
   let _ = BothAnnotations.getByRef()
 }
+
+func testImmortal() {
+  let i = createImmortalIntBox()
+  let _ = i.builderPattern()
+
+  let d = createDerivedImmortalIntBox()
+  let _ = d.builderPattern()
+}


### PR DESCRIPTION
If a C++ method returns a foreign reference type as a pointer (`MyImmortal*`), Swift correctly treats the method as safe. However, if the method returns a foreign reference type as a reference (`MyImmortal&`), Swift assumed that the method is unsafe.

This change adjusts the heuristic to treat such methods as safe. It also addresses a FIXME comment: previously, if the returned foreign reference type has inherited its `import_reference` attribute from a base class, the safety heuristic did not correctly detect the type as an FRT.

rdar://168057355

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
