### PR TITLE
[Backtracing][Test] Fix CrashWithThreads test again

### DIFF
--- a/test/Backtracing/CrashWithThreads.swift
+++ b/test/Backtracing/CrashWithThreads.swift
@@ -1,4 +1,3 @@
-// REQUIRES: rdar168895001
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -Onone -g -o %t/CrashWithThreads
 // RUN: %target-codesign %t/CrashWithThreads
@@ -113,6 +112,3 @@ while (true) {
 
 // CHECK: Thread {{[0-9]*( ".*")?}}:
 // CHECK: {{0x[0-9a-f]+.*main.* CrashWithThreads}}
-
-// CHECK: Thread {{[0-9]*( ".*")?}}:
-// CHECK: {{0x[0-9a-f]+.*pthread_start}}

--- a/test/Backtracing/CrashWithThreads.swift
+++ b/test/Backtracing/CrashWithThreads.swift
@@ -112,3 +112,5 @@ while (true) {
 
 // CHECK: Thread {{[0-9]*( ".*")?}}:
 // CHECK: {{0x[0-9a-f]+.*main.* CrashWithThreads}}
+
+// CHECK: Thread {{[0-9]*( ".*")?}}:


### PR DESCRIPTION
Once again unfortunately this test has proved a bit unstable at scale, with flaky failures. I think it's best not to assume anything about the actual backtrace for the "other" threads in this test (that is the threads that aren't either the crashing background thread or the main thread).

rdar://168895001

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
