### PR TITLE
Reinstate public API for `withTaskCancellationHandler(operation:onCancel:isolation:)`

### DIFF
--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -22,7 +22,6 @@ import Swift
 ///   - handler: A closure to execute on cancellation.
 ///     If the task is canceled, this closure is called at most once;
 ///     otherwise, it isn't called.
-///   - isolation: The actor that the operation and cancellation handler are isolated to.
 ///
 /// This differs from the operation cooperatively checking for cancellation
 /// and reacting to it in that the cancellation handler is _always_ and
@@ -88,17 +87,70 @@ public func withTaskCancellationHandler<Return, Failure>(
 }
 
 #if !$Embedded
+/// Execute an operation with a cancellation handler that's immediately
+/// invoked if the current task is canceled.
+///
+/// - Parameters:
+///   - operation: The operation to perform.
+///   - handler: A closure to execute on cancellation.
+///     If the task is canceled, this closure is called at most once;
+///     otherwise, it isn't called.
+///   - isolation: The actor that the operation and cancellation handler are isolated to.
+///
+/// This differs from the operation cooperatively checking for cancellation
+/// and reacting to it in that the cancellation handler is _always_ and
+/// _immediately_ invoked when the task is canceled. For example, even if the
+/// operation is running code that never checks for cancellation, a cancellation
+/// handler still runs and provides a chance to run some cleanup code:
+///
+/// ```
+/// await withTaskCancellationHandler {
+///   var sum = 0
+///   while condition {
+///     sum += 1
+///   }
+///   return sum
+/// } onCancel: {
+///   // This onCancel closure might execute concurrently with the operation.
+///   condition.cancel()
+/// }
+/// ```
+///
+/// ### Execution order and semantics
+/// The `operation` closure is always invoked, even when the
+/// `withTaskCancellationHandler(operation:onCancel:)` method is called from a task
+/// that was already canceled.
+///
+/// When `withTaskCancellationHandler(operation:onCancel:)` is used in a task that has already been
+/// canceled, the cancellation handler will be executed
+/// immediately before the `operation` closure gets to execute.
+///
+/// This allows the cancellation handler to set some external "canceled" flag
+/// that the operation may be *atomically* checking for in order to avoid
+/// performing any actual work once the operation gets to run.
+///
+/// The `operation` closure executes on the calling execution context, and doesn't
+/// suspend or change execution context unless code contained within the closure
+/// does so. In other words, the potential suspension point of the
+/// `withTaskCancellationHandler(operation:onCancel:)` never suspends by itself before
+/// executing the operation.
+///
+/// If cancellation occurs while the operation is running, the cancellation
+/// handler executes *concurrently* with the operation.
+///
+/// ### Cancellation handlers and locks
+///
+/// Cancellation handlers which acquire locks must take care to avoid deadlock.
+/// The cancellation handler may be invoked while holding internal locks
+/// associated with the task or other tasks.  Other operations on the task, such
+/// as resuming a continuation, may acquire these same internal locks.
+/// Therefore, if a cancellation handler must acquire a lock, other code should
+/// not cancel tasks or resume continuations while holding that lock.
 @available(SwiftStdlib 6.0, *)
-@usableFromInline
-@abi(func withTaskCancellationHandler<T>(
-       operation: () async throws -> T,
-       onCancel handler: @Sendable () -> Void,
-       isolation: isolated (any Actor)?,
-     ) async rethrows -> T)
-func __abi_withTaskCancellationHandler<T>(
+public func withTaskCancellationHandler<T>(
   operation: () async throws -> T,
   onCancel handler: @Sendable () -> Void,
-  isolation: isolated (any Actor)? = #isolation
+  isolation: isolated (any Actor)?
 ) async rethrows -> T {
   // unconditionally add the cancellation record to the task.
   // if the task was already cancelled, it will be executed right away.

--- a/test/Concurrency/async_cancellation.swift
+++ b/test/Concurrency/async_cancellation.swift
@@ -52,6 +52,30 @@ func test_cancellation_withTaskCancellationHandler(_ anything: Any) async -> Pic
   return nil
 }
 
+@available(SwiftStdlib 6.0, *)
+func test_cancellation_withTaskCancellationHandler(_ anything: Any, isolation: (any Actor)? = #isolation) async -> PictureData? {
+  let handle: Task<PictureData, Error> = .init {
+    let file = SomeFile()
+
+    do {
+      return try await withTaskCancellationHandler(
+        operation: { () throws in
+          await test_cancellation_guard_isCancelled(file)
+        },
+        onCancel: {
+          file.close()
+        },
+        isolation: isolation
+      )
+    } catch {
+      return PictureData.value("...")
+    }
+  }
+
+  handle.cancel()
+  return nil
+}
+
 @available(SwiftStdlib 5.1, *)
 func test_cancellation_loop() async -> Int {
   struct SampleTask { func process() async {} }

--- a/test/api-digester/stability-concurrency-abi.test
+++ b/test/api-digester/stability-concurrency-abi.test
@@ -89,8 +89,8 @@ Func withCheckedThrowingContinuation(function:_:) has parameter 0 type change fr
 Func withCheckedThrowingContinuation(function:_:) has parameter 1 type change from (_Concurrency.CheckedContinuation<τ_0_0, any Swift.Error>) -> () to Swift.String
 
 // #isolation adoption for cancellation handlers; old APIs are kept ABI compatible
-Func withTaskCancellationHandler(operation:onCancel:) has been renamed to Func __abi_withTaskCancellationHandler(operation:onCancel:isolation:)
-Func withTaskCancellationHandler(operation:onCancel:) has mangled name changing from '_Concurrency.withTaskCancellationHandler<A>(operation: () async throws -> A, onCancel: @Sendable () -> ()) async throws -> A' to '_Concurrency.__abi_withTaskCancellationHandler<A>(operation: () async throws -> A, onCancel: @Sendable () -> (), isolation: isolated Swift.Optional<Swift.Actor>) async throws -> A'
+Func withTaskCancellationHandler(operation:onCancel:) has been renamed to Func withTaskCancellationHandler(operation:onCancel:isolation:)
+Func withTaskCancellationHandler(operation:onCancel:) has mangled name changing from '_Concurrency.withTaskCancellationHandler<A>(operation: () async throws -> A, onCancel: @Sendable () -> ()) async throws -> A' to '_Concurrency.withTaskCancellationHandler<A>(operation: () async throws -> A, onCancel: @Sendable () -> (), isolation: isolated Swift.Optional<Swift.Actor>) async throws -> A'
 
 // #isolated was adopted and the old methods kept: $ss31withCheckedThrowingContinuation8function_xSS_yScCyxs5Error_pGXEtYaKlF
 Func withCheckedContinuation(function:_:) has been renamed to Func withCheckedContinuation(isolation:function:_:)


### PR DESCRIPTION
Some clients are explicitly passing isolation through, so we need to retain this signature. Fixes rdar://168955495.