### PR TITLE
Fix test trap-on-exception-irgen-msvc.swift with no-assert build

### DIFF
--- a/test/Interop/Cxx/exceptions/trap-on-exception-irgen-msvc.swift
+++ b/test/Interop/Cxx/exceptions/trap-on-exception-irgen-msvc.swift
@@ -19,5 +19,5 @@
 // CHECK: call {{.*}}i32 @"?freeFunctionNoThrow@@YAHH@Z"
 // CHECK: call swiftcc i32 @"$s4test8makeCInts5Int32VyF"()
 // CHECK: call {{.*}}i32 @"?freeFunctionThrows@@YAHH@Z"
-// CHECK: ret i32 %1
+// CHECK: ret i32 {{.*}}
 // CHECK-NEXT: }


### PR DESCRIPTION
The return value differs between %0 and %1 when LLVM_ENABLE_ASSERTIONS is false.
