### PR TITLE
utils: disable building DocC on Windows

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -4466,7 +4466,7 @@ if (-not $SkipBuild -and $IncludeNoAsserts) {
   Build-NoAssertsToolchain
 }
 
-if (-not $SkipBuild -and -not $IsCrossCompiling) {
+if ($False -and -not $SkipBuild -and -not $IsCrossCompiling) {
   Invoke-BuildStep Build-DocC $HostPlatform
 }
 


### PR DESCRIPTION
DocC was stripped from the Windows build as the CMake build was reverted. This removes the build entirely to save some build time on CI. Enabling the distribution of DocC is currently waiting on GHA based testing on DocC.