### PR TITLE
[IRGen] Fix crash when getting nonisolated(nonsending) function metadata on older runtimes

### DIFF
--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -1565,6 +1565,69 @@ static CanPackType getInducedPackType(AnyFunctionType::CanParamArrayRef params,
   return CanPackType::get(ctx, elts);
 }
 
+static MetadataResponse
+emitExtendedFunctionTypeMetadataBackdeploy(IRGenFunction &IGF,
+                                           ArrayRef<llvm::Value *> arguments,
+                                           FunctionTypeMetadataParamInfo info) {
+  assert(arguments.size() == 8 && "We always expect 8 parameters");
+  std::array<llvm::Type *, 8> types;
+  for (auto pair : llvm::enumerate(arguments)) {
+    types[pair.index()] = pair.value()->getType();
+  }
+  auto *helper = IGF.IGM.getOrCreateHelperFunction(
+      "__swift_getExtendedFunctionTypeMetadata_backDeploy", IGF.IGM.PtrTy,
+      types, [&](auto &subIGF) {
+        llvm::Function *curFn = subIGF.CurFn;
+        std::array<llvm::Value *, 8> arguments;
+        for (auto pair : llvm::enumerate(curFn->args())) {
+          arguments[pair.index()] = &pair.value();
+        }
+        std::array<llvm::Value *, 4> backdeployArgs = {
+            arguments[0],
+            // We skip the second parameter since it is for the differentiable
+            // entry.
+            arguments[2], arguments[3], arguments[4]};
+
+        auto fnPtr = subIGF.IGM.getGetFunctionMetadataExtendedFunctionPointer();
+        auto isNonNull =
+            subIGF.Builder.CreateIsNotNull(fnPtr.getPointer(subIGF));
+        auto *successBlock =
+            subIGF.createBasicBlock("have-get-function-metadata-extended");
+        auto *failBlock = subIGF.createBasicBlock(
+            "do-not-have-get-function-metadata-extended");
+        auto *contBB =
+            subIGF.createBasicBlock("cont-get-function-metadata-extended-call");
+        subIGF.Builder.CreateCondBr(isNonNull, successBlock, failBlock);
+
+        subIGF.Builder.emitBlock(successBlock);
+        auto *successValue = subIGF.Builder.CreateCall(fnPtr, arguments);
+        successValue->setDoesNotThrow();
+        subIGF.Builder.CreateBr(contBB);
+
+        subIGF.Builder.emitBlock(failBlock);
+        auto *failValue = subIGF.Builder.CreateCall(
+            subIGF.IGM.getGetFunctionMetadataFunctionPointer(), backdeployArgs);
+        failValue->setDoesNotThrow();
+        subIGF.Builder.CreateBr(contBB);
+
+        subIGF.Builder.emitBlock(contBB);
+        auto *phi = subIGF.Builder.CreatePHI(failValue->getType(), 2);
+        phi->addIncoming(successValue, successBlock);
+        phi->addIncoming(failValue, failBlock);
+        subIGF.Builder.CreateRet(phi);
+      });
+
+  auto fnType = llvm::FunctionType::get(IGF.IGM.PtrTy, types,
+                                        false /*is var arg*/);
+  auto sig = Signature(fnType, {}, IGF.IGM.DefaultCC);
+  auto fnPtr = FunctionPointer::forDirect(FunctionPointer::Kind::Function,
+                                          helper, nullptr, sig);
+  auto call = IGF.Builder.CreateCall(fnPtr, arguments);
+  call->setDoesNotThrow();
+  cleanupFunctionTypeMetadataParams(IGF, info);
+  return MetadataResponse::forComplete(call);
+}
+
 static MetadataResponse emitFunctionTypeMetadataRef(IRGenFunction &IGF,
                                                     CanFunctionType type,
                                                     DynamicMetadataRequest request) {
@@ -1652,7 +1715,6 @@ static MetadataResponse emitFunctionTypeMetadataRef(IRGenFunction &IGF,
 
   default:
     llvm::SmallVector<llvm::Value *, 8> arguments;
-
     arguments.push_back(flagsVal);
 
     llvm::Value *diffKindVal = nullptr;
@@ -1729,24 +1791,42 @@ static MetadataResponse emitFunctionTypeMetadataRef(IRGenFunction &IGF,
       arguments.push_back(llvm::ConstantPointerNull::get(IGF.IGM.TypeMetadataPtrTy));
     }
 
-    auto getMetadataFn =
-        flags.hasExtendedFlags()
-            ? IGF.IGM.getGetFunctionMetadataExtendedFunctionPointer()
-        : type->getGlobalActor()
-            ? (IGF.IGM.isConcurrencyAvailable()
-                   ? IGF.IGM
-                         .getGetFunctionMetadataGlobalActorFunctionPointer()
-                   : IGF.IGM
-                         .getGetFunctionMetadataGlobalActorBackDeployFunctionPointer())
-        : type->isDifferentiable()
-            ? IGF.IGM.getGetFunctionMetadataDifferentiableFunctionPointer()
-            : IGF.IGM.getGetFunctionMetadataFunctionPointer();
+    // If we have a function that is nonisolated(nonsending) and that is the
+    // only extended flag that it has, allow for the metadata call to backdeploy
+    // by calling GetFunctionMetadata instead of GetFunctionMetadataExtended if
+    // we backdeploy and GetFunctionMetadataExtended is not available.
+    //
+    // SAFETY: This is safe to do as long as we do not attempt to reflect (in a
+    // way that exposes the async bits of the type), cast, or existential erase
+    // these types.
+    if (flags.hasExtendedFlags() &&
+        (extFlags == decltype(extFlags)().withNonIsolatedCaller()) &&
+        !type->isDifferentiable() &&
+        cast<llvm::Function>(IGF.IGM.getGetFunctionMetadataExtendedFn())
+            ->hasExternalWeakLinkage()) {
+      return emitExtendedFunctionTypeMetadataBackdeploy(IGF, arguments, info);
+    }
+
+    auto getMetadataFn = [&]() -> FunctionPointer {
+      if (flags.hasExtendedFlags())
+        return IGF.IGM.getGetFunctionMetadataExtendedFunctionPointer();
+
+      if (type->getGlobalActor()) {
+        if (IGF.IGM.isConcurrencyAvailable())
+          return IGF.IGM.getGetFunctionMetadataGlobalActorFunctionPointer();
+        return IGF.IGM
+            .getGetFunctionMetadataGlobalActorBackDeployFunctionPointer();
+      }
+
+      if (type->isDifferentiable())
+        return IGF.IGM.getGetFunctionMetadataDifferentiableFunctionPointer();
+
+      return IGF.IGM.getGetFunctionMetadataFunctionPointer();
+    }();
 
     auto call = IGF.Builder.CreateCall(getMetadataFn, arguments);
     call->setDoesNotThrow();
-
     cleanupFunctionTypeMetadataParams(IGF, info);
-
     return MetadataResponse::forComplete(call);
   }
 }

--- a/test/IRGen/backward_deploy_nonisolated_nonsending_function_type.swift
+++ b/test/IRGen/backward_deploy_nonisolated_nonsending_function_type.swift
@@ -1,17 +1,103 @@
-// RUN: %target-swift-frontend -target %target-cpu-apple-macos12 -emit-ir -o - -primary-file %s | %FileCheck %s
+// RUN: %target-swift-frontend -module-name nonisolated_nonsending_metadata_backdeploy -target %target-cpu-apple-macosx26 -emit-ir -o - -primary-file %s | %FileCheck --check-prefix=MANGLED %s
+// RUN: %target-swift-frontend -module-name nonisolated_nonsending_metadata_backdeploy -target %target-cpu-apple-macosx26 -emit-ir -o - -disable-concrete-type-metadata-mangled-name-accessors -primary-file %s | %FileCheck --check-prefix=NO-MANGLED %s
+// RUN: %target-swift-frontend -module-name nonisolated_nonsending_metadata_backdeploy -target %target-cpu-apple-macosx14 -emit-ir -o - -primary-file %s | %FileCheck %s --check-prefix=NO-MANGLED-BD
+
 // REQUIRES: concurrency
 // REQUIRES: OS=macosx
 
-func useGenericMetatype(_ type: Any.Type) { }
+func useMetatype(_ type: Any.Type) {}
 
-// CHECK-LABEL: define hidden swiftcc void @"$s52backward_deploy_nonisolated_nonsending_function_type29testNonisolatedNonsendingTypeyyF"()
-func testNonisolatedNonsendingType() {
+func testNonisolatedNonsendingFunctionType() {
   typealias Fn = nonisolated(nonsending) () async throws -> Int
 
-  // CHECK: call swiftcc %swift.metadata_response @"$sSiyYaKYCcMa"
-  // CHECK: call swiftcc void @"$s52backward_deploy_nonisolated_nonsending_function_type18useGenericMetatypeyyypXpF"
-  useGenericMetatype(Fn.self)
+  useMetatype(Fn.self)
 }
 
-// CHECK-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$sSiyYaKYCcMa"
-// CHECK: call ptr @swift_getExtendedFunctionTypeMetadata(i{{32|64}} 2768240640, {{i32|i64}} 0, ptr null, ptr null, ptr @"$sSiN"
+// Check if we are allowed to mangle.
+
+// MANGLED-LABEL: define hidden swiftcc void @"$s42nonisolated_nonsending_metadata_backdeploy37testNonisolatedNonsendingFunctionTypeyyF"()
+// MANGLED-NEXT: entry:
+// MANGLED-NEXT:   call ptr @__swift_instantiateConcreteTypeFromMangledName(ptr @"$sSiyYaKYCcMD")
+// MANGLED-NEXT:   call swiftcc void @"$s42nonisolated_nonsending_metadata_backdeploy11useMetatypeyyypXpF"(ptr
+// MANGLED-NEXT:   ret void
+// MANGLED-NEXT: }
+
+// Check if we are not allowed to mangle, but we are not backdeploying.
+
+// NO-MANGLED-LABEL: define hidden swiftcc void @"$s42nonisolated_nonsending_metadata_backdeploy37testNonisolatedNonsendingFunctionTypeyyF"()
+// NO-MANGLED-NEXT: entry:
+// NO-MANGLED-NEXT:   call swiftcc %swift.metadata_response @"$sSiyYaKYCcMa"(
+// NO-MANGLED-NEXT:   extractvalue
+// NO-MANGLED-NEXT:   call swiftcc void @"$s42nonisolated_nonsending_metadata_backdeploy11useMetatypeyyypXpF"
+// NO-MANGLED-NEXT:   ret void
+// NO-MANGLED-NEXT: }
+
+// NO-MANGLED-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$sSiyYaKYCcMa"(i64 %0)
+// NO-MANGLED: entry:
+// NO-MANGLED: [[LAZY_CACHE_VAR:%.*]] = load ptr, ptr @"$sSiyYaKYCcML"
+// NO-MANGLED: [[LAZY_CACHE_VAR_CMP:%.*]] = icmp eq ptr [[LAZY_CACHE_VAR]], null
+// NO-MANGLED: br i1 [[LAZY_CACHE_VAR_CMP]], label %[[CACHE_IS_NULL_BB:.*]], label %[[CONT_BB:.*]]
+//
+// NO-MANGLED: [[CACHE_IS_NULL_BB]]:
+// NO-MANGLED:   [[HAVE_FUNCTION_METADATA:%.*]] = call ptr @swift_getExtendedFunctionTypeMetadata(
+// NO-MANGLED:   store atomic ptr [[HAVE_FUNCTION_METADATA]], ptr @"$sSiyYaKYCcML" release
+// NO-MANGLED:   br label %[[CONT_BB]]
+//
+// NO-MANGLED: [[CONT_BB]]:
+// NO-MANGLED:   [[RESULT_PHI:%.*]] = phi ptr [ [[LAZY_CACHE_VAR]], %entry ], [ [[HAVE_FUNCTION_METADATA]], %[[CACHE_IS_NULL_BB]] ]
+// NO-MANGLED:   [[RESULT_1:%.*]] = insertvalue %swift.metadata_response undef, ptr [[RESULT_PHI]], 0
+// NO-MANGLED:   [[RESULT_2:%.*]] = insertvalue %swift.metadata_response [[RESULT_1]], i64 0, 1
+// NO-MANGLED:   ret %swift.metadata_response [[RESULT_2]]
+// NO-MANGLED-NEXT: }
+
+// NO-MANGLED: declare ptr @swift_getExtendedFunctionTypeMetadata(i64, i64, ptr, ptr, ptr, ptr, i32, ptr)
+
+
+// Check if we are not allowed to mangle and we backdeploy.
+
+// NO-MANGLED-BD-LABEL: define hidden swiftcc void @"$s42nonisolated_nonsending_metadata_backdeploy37testNonisolatedNonsendingFunctionTypeyyF"()
+// NO-MANGLED-BD-NEXT: entry:
+// NO-MANGLED-BD-NEXT:   call swiftcc %swift.metadata_response @"$sSiyYaKYCcMa"(
+// NO-MANGLED-BD-NEXT:   extractvalue
+// NO-MANGLED-BD-NEXT:   call swiftcc void @"$s42nonisolated_nonsending_metadata_backdeploy11useMetatypeyyypXpF"
+// NO-MANGLED-BD-NEXT:   ret void
+// NO-MANGLED-BD-NEXT: }
+
+// NO-MANGLED-BD-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$sSiyYaKYCcMa"(i64 %0)
+// NO-MANGLED-BD: entry:
+// NO-MANGLED-BD: [[LAZY_CACHE_VAR:%.*]] = load ptr, ptr @"$sSiyYaKYCcML"
+// NO-MANGLED-BD: [[LAZY_CACHE_VAR_CMP:%.*]] = icmp eq ptr [[LAZY_CACHE_VAR]], null
+// NO-MANGLED-BD: br i1 [[LAZY_CACHE_VAR_CMP]], label %[[CACHE_IS_NULL_BB:.*]], label %[[CONT_BB:.*]]
+//
+// NO-MANGLED-BD: [[CACHE_IS_NULL_BB]]:
+// NO-MANGLED-BD:   [[VALUE:%.*]] = call ptr @__swift_getExtendedFunctionTypeMetadata_backDeploy(
+// NO-MANGLED-BD:   store atomic ptr [[VALUE]], ptr @"$sSiyYaKYCcML" release
+// NO-MANGLED-BD:   br label %[[CONT_BB]]
+//
+// NO-MANGLED-BD: [[CONT_BB]]:
+// NO-MANGLED-BD:   [[RESULT_PHI:%.*]] = phi ptr [ [[LAZY_CACHE_VAR]], %entry ], [ [[VALUE]], %[[CACHE_IS_NULL_BB]] ]
+// NO-MANGLED-BD:   [[RESULT_1:%.*]] = insertvalue %swift.metadata_response undef, ptr [[RESULT_PHI]], 0
+// NO-MANGLED-BD:   [[RESULT_2:%.*]] = insertvalue %swift.metadata_response [[RESULT_1]], i64 0, 1
+// NO-MANGLED-BD:   ret %swift.metadata_response [[RESULT_2]]
+// NO-MANGLED-BD-NEXT: }
+
+// NO-MANGLED-BD: declare extern_weak ptr @swift_getExtendedFunctionTypeMetadata(i64, i64, ptr, ptr, ptr, ptr, i32, ptr)
+
+// NO-MANGLED-BD-LABEL: define linkonce_odr hidden ptr @__swift_getExtendedFunctionTypeMetadata_backDeploy(
+// NO-MANGLED-BD:   [[HAVE_EXTENDED_FUNCTION_TYPE_METADATA:%.*]] = icmp ne ptr @swift_getExtendedFunctionTypeMetadata, null
+// NO-MANGLED-BD:   br i1 [[HAVE_EXTENDED_FUNCTION_TYPE_METADATA]], label %[[HAVE_FUNCTION_BB:.*]], label %[[DONOT_HAVE_FUNCTION_BB:.*]]
+//
+// NO-MANGLED-BD  [[HAVE_FUNCTION_BB]]:
+// NO-MANGLED-BD:   [[HAVE_FUNCTION_METADATA:%.*]] = call ptr @swift_getExtendedFunctionTypeMetadata(
+// NO-MANGLED-BD:   br label %[[CONT_BB:.*]]
+//
+// NO-MANGLED-BD: [[DONOT_HAVE_FUNCTION_BB]]:
+// NO-MANGLED-BD:   [[DONOT_HAVE_FUNCTION_METADATA:%.*]] = call ptr @swift_getFunctionTypeMetadata(
+// NO-MANGLED-BD:   br label %[[CONT_BB]]
+//
+// NO-MANGLED-BD: [[CONT_BB]]:
+// NO-MANGLED-BD:   [[PHI:%.*]] = phi ptr [ [[HAVE_FUNCTION_METADATA]], %[[HAVE_FUNCTION_BB]] ], [ [[DONOT_HAVE_FUNCTION_METADATA]], %[[DONOT_HAVE_FUNCTION_BB]] ]
+// NO-MANGLED-BD:   ret ptr [[PHI]]
+// NO-MANGLED-BD-NEXT:  }
+
+// NO-MANGLED-BD: declare ptr @swift_getFunctionTypeMetadata(i64, ptr, ptr, ptr)

--- a/test/Interpreter/nonisolated_nonsending_metadata.swift
+++ b/test/Interpreter/nonisolated_nonsending_metadata.swift
@@ -1,0 +1,15 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+
+func testNonisolatedNonsendingMetadata() {
+  typealias NonisolatedNonsendingFn = nonisolated(nonsending) () async throws -> Int
+
+  let nonisolatedType = NonisolatedNonsendingFn.self
+
+  // CHECK: nonisolated(nonsending) type: {{.*}}() async throws -> Int
+  print("nonisolated(nonsending) type: \(nonisolatedType)")
+}
+
+testNonisolatedNonsendingMetadata()


### PR DESCRIPTION
When compiling for a triple that predates typed throws, `swift_getFunctionMetadataExtended` is conditionally available and emitted as a weak external symbol. Previously, when such code ran on a older runtime where `swift_getFunctionMetadataExtended` was uanvailable, accessing function metadata for a `nonisolated(nonsending)` function would crash by invoking the null `swift_getFunctionMetadataExtended`.

This patch adds a runtime null check when emitting metadata accessors for simple `nonisolated(nonsending)` functions (those without typed throws or other extended flags) in such situations. If `swift_getFunctionMetadataExtended` is unavailable at runtime, we fall back to `swift_getFunctionMetadata`, returning `@concurrent` function metadata instead.

This trade-off is acceptable because:
- Function metadata is not required to call a `nonisolated(nonsending)` function
- This enables use of these functions in frameworks like SwiftUI on older OS versions

Known limitations of the fallback path:
- Dynamic casts between `nonisolated(nonsending)` and `@concurrent` will incorrectly succeed
- Reflection will report `nonisolated(nonsending)` functions as `@concurrent`
- Existential erasure will lose the `nonisolated(nonsending)` attribute

These edge cases will produce obvious crashes during testing if misused, since `nonisolated(nonsending)` expects its first parameter to be an actor while `@concurrent` does not. This makes the increased compatibility worth the trade-off.

rdar://158970802
