### PR TITLE
Revert "[CSBindings] PotentialBindings: Track only direct conformance requirements"

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -2181,12 +2181,6 @@ void PotentialBindings::infer(Constraint *constraint) {
 
   case ConstraintKind::NonisolatedConformsTo:
   case ConstraintKind::ConformsTo:
-    // Conformances are applicable only to the types they are
-    // placed on. They could be transferred to supertypes
-    // but that happens separately.
-    if (!isDirectRequirement(CS, TypeVar, constraint))
-      break;
-
     if (constraint->getSecondType()->is<ProtocolType>())
       recordProtocol(constraint);
     break;

--- a/test/Constraints/rdar168932385.swift
+++ b/test/Constraints/rdar168932385.swift
@@ -1,0 +1,61 @@
+// RUN: %target-typecheck-verify-swift
+
+// rdar://168932385 - error: type 'Comparable' has no member 'pi'
+
+protocol FormatStyle<FormatInput, FormatOutput> {
+  associatedtype FormatInput
+  associatedtype FormatOutput
+
+  func format(_ value: Self.FormatInput) -> Self.FormatOutput
+}
+
+protocol ParseStrategy {
+  associatedtype ParseInput
+  associatedtype ParseOutput
+
+  func parse(_ value: Self.ParseInput) throws -> Self.ParseOutput
+}
+
+protocol ParseableFormatStyle : FormatStyle {
+  associatedtype Strategy : ParseStrategy where Self.FormatInput == Self.Strategy.ParseOutput, Self.FormatOutput == Self.Strategy.ParseInput
+
+  var parseStrategy: Self.Strategy { get }
+}
+
+protocol ScalarFormatStyle: ParseableFormatStyle
+  where FormatInput: Hashable, FormatOutput == String {
+}
+
+extension ParseableFormatStyle where Self: ParseStrategy {
+    var parseStrategy: Self { self }
+}
+
+struct AngleFormatStyle<T: BinaryFloatingPoint>: ScalarFormatStyle, ParseStrategy {
+  func format(_ value: T) -> String { "" }
+  func parse(_ str: String) throws -> T { }
+}
+
+extension FormatStyle where Self == AngleFormatStyle<Float> {
+  static var angle: Self { Self() }
+}
+
+protocol CellValue: Hashable {
+}
+
+extension Float: CellValue {}
+
+enum Cell<Value: CellValue>: Hashable {
+}
+
+struct SliderCellField<F: ScalarFormatStyle> where
+   F.FormatInput: CellValue & BinaryFloatingPoint,
+   F.FormatInput.Stride: BinaryFloatingPoint
+{
+  var value: Cell<F.FormatInput>
+  var range: ClosedRange<F.FormatInput>
+  var format: F
+}
+
+func test(cell: Cell<Float>) {
+  _ = SliderCellField(value: cell, range: -.pi ... .pi, format: .angle) // Ok
+}


### PR DESCRIPTION
The change in question is correct but it caused source compatibility regression because
when non-direct requirements are excluded it leads to fewer bindings for leading-dot syntax
"base" type in some cases (even though these bindings are not actually valid) and that
affects type variable selection order.

Resolves: rdar://168932385
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
