### PR TITLE
Ban returning literals from borrow accessors

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -1269,7 +1269,7 @@ ERROR(noncopyable_shared_case_block_unimplemented, none,
 ERROR(invalid_borrow_accessor_return, none,
       "invalid return value from borrow accessor", ())
 NOTE(borrow_accessor_not_a_projection_note, none,
-     "borrow accessors can return either literals, stored properties or computed "
+     "borrow accessors can return either stored properties or computed "
      "properties that have borrow accessors",
      ())
 ERROR(invalid_multiple_return_borrow_accessor, none,

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -726,14 +726,6 @@ bool SILGenFunction::emitBorrowOrMutateAccessorResult(
     return B.createUncheckedOwnership(regularLoc, load);
   };
 
-  // If the return expression is a literal, emit as a regular return
-  // expression.
-  if (isa<LiteralExpr>(ret)) {
-    auto RV = emitRValue(ret);
-    std::move(RV).forwardAll(*this, directResults);
-    return false;
-  }
-
   auto storageRefResult =
       StorageRefResult::findStorageReferenceExprForBorrow(ret);
   auto lvExpr = storageRefResult.getTransitiveRoot();

--- a/test/SILGen/borrow_accessor_failures.swift
+++ b/test/SILGen/borrow_accessor_failures.swift
@@ -60,13 +60,13 @@ public struct Wrapper {
 
   var nested_get1: Klass {
     borrow {
-      return _s.get_k // expected-error{{invalid return value from borrow accessor}} // expected-note{{borrow accessors can return either literals, stored properties or computed properties that have borrow accessors}}
+      return _s.get_k // expected-error{{invalid return value from borrow accessor}} // expected-note{{borrow accessors can return either stored properties or computed properties that have borrow accessors}}
     }
   }
 
   var nested_get2: Klass {
     borrow {
-      return s_get.borrow_k // expected-error{{invalid return value from borrow accessor}} // expected-note{{borrow accessors can return either literals, stored properties or computed properties that have borrow accessors}}
+      return s_get.borrow_k // expected-error{{invalid return value from borrow accessor}} // expected-note{{borrow accessors can return either stored properties or computed properties that have borrow accessors}}
     }
   }
 
@@ -84,26 +84,26 @@ public struct Wrapper {
 
   var nested_read1: Klass {
     borrow {
-      return _s.read_k // expected-error{{invalid return value from borrow accessor}} // expected-note{{borrow accessors can return either literals, stored properties or computed properties that have borrow accessors}}
+      return _s.read_k // expected-error{{invalid return value from borrow accessor}} // expected-note{{borrow accessors can return either stored properties or computed properties that have borrow accessors}}
     }
   }
 
   var nested_read2: Klass {
     borrow {
-      return s_read.read_k // expected-error{{invalid return value from borrow accessor}} // expected-note{{borrow accessors can return either literals, stored properties or computed properties that have borrow accessors}}
+      return s_read.read_k // expected-error{{invalid return value from borrow accessor}} // expected-note{{borrow accessors can return either stored properties or computed properties that have borrow accessors}}
     }
   }
 
   var owned_value_direct: Klass {
     borrow {
-      return get_k() // expected-error{{invalid return value from borrow accessor}} // expected-note{{borrow accessors can return either literals, stored properties or computed properties that have borrow accessors}}
+      return get_k() // expected-error{{invalid return value from borrow accessor}} // expected-note{{borrow accessors can return either stored properties or computed properties that have borrow accessors}}
     }
   }
 
   var owned_value_projected: Klass {
     borrow {
       let w = Wrapper(_k: Klass(), _s: S(_k: Klass()))
-      return w.k // expected-error{{invalid return value from borrow accessor}} // expected-note{{borrow accessors can return either literals, stored properties or computed properties that have borrow accessors}}
+      return w.k // expected-error{{invalid return value from borrow accessor}} // expected-note{{borrow accessors can return either stored properties or computed properties that have borrow accessors}}
     }
   }
 
@@ -118,16 +118,13 @@ public struct Wrapper {
 
   var tuple_klass: (Klass, Klass) {
     borrow {
-      return (_k, _k) // expected-error{{invalid return value from borrow accessor}} // expected-note{{borrow accessors can return either literals, stored properties or computed properties that have borrow accessors}}
+      return (_k, _k) // expected-error{{invalid return value from borrow accessor}} // expected-note{{borrow accessors can return either stored properties or computed properties that have borrow accessors}}
     }
   }
 
   var opt_klass: Klass? {
     borrow {
-      if Int.random(in: 1..<100) == 0 {
-        return nil
-      }
-      return _k // expected-error{{invalid return value from borrow accessor}} // expected-note{{borrow accessors can return either literals, stored properties or computed properties that have borrow accessors}}
+      return _k // expected-error{{invalid return value from borrow accessor}} // expected-note{{borrow accessors can return either stored properties or computed properties that have borrow accessors}}
     }
   }
 }
@@ -166,14 +163,14 @@ public struct GenWrapper<T> {
 
   var get_prop: T {
     borrow {
-      return _w.get_prop // expected-error{{invalid return value from borrow accessor}} // expected-note{{borrow accessors can return either literals, stored properties or computed properties that have borrow accessors}}
+      return _w.get_prop // expected-error{{invalid return value from borrow accessor}} // expected-note{{borrow accessors can return either stored properties or computed properties that have borrow accessors}}
 
     }
   }
 
   var read_prop: T {
     borrow {
-      return _w.read_prop // expected-error{{invalid return value from borrow accessor}} // expected-note{{borrow accessors can return either literals, stored properties or computed properties that have borrow accessors}}
+      return _w.read_prop // expected-error{{invalid return value from borrow accessor}} // expected-note{{borrow accessors can return either stored properties or computed properties that have borrow accessors}}
     }
   }
 
@@ -188,16 +185,13 @@ public struct GenWrapper<T> {
 
   var tuple_prop: (T, T) {
     borrow {
-      return (_prop, _prop) // expected-error{{invalid return value from borrow accessor}} // expected-note{{borrow accessors can return either literals, stored properties or computed properties that have borrow accessors}}
+      return (_prop, _prop) // expected-error{{invalid return value from borrow accessor}} // expected-note{{borrow accessors can return either stored properties or computed properties that have borrow accessors}}
     }
   }
 
   var opt_T: T? {
     borrow {
-      if Int.random(in: 1..<100) == 0 {
-        return nil
-      }
-      return _prop // expected-error{{invalid return value from borrow accessor}} // expected-note{{borrow accessors can return either literals, stored properties or computed properties that have borrow accessors}}
+      return _prop // expected-error{{invalid return value from borrow accessor}} // expected-note{{borrow accessors can return either stored properties or computed properties that have borrow accessors}}
 
     }
   }
@@ -237,14 +231,14 @@ public struct GenNCWrapper<T : ~Copyable> : ~Copyable {
 
   var nested_get: T {
     borrow {
-      return _w.get_prop // expected-error{{invalid return value from borrow accessor}} // expected-note{{borrow accessors can return either literals, stored properties or computed properties that have borrow accessors}}
+      return _w.get_prop // expected-error{{invalid return value from borrow accessor}} // expected-note{{borrow accessors can return either stored properties or computed properties that have borrow accessors}}
 
     }
   }
 
   var nested_read: T {
     borrow {
-      return _w.read_prop // expected-error{{invalid return value from borrow accessor}} // expected-note{{borrow accessors can return either literals, stored properties or computed properties that have borrow accessors}}
+      return _w.read_prop // expected-error{{invalid return value from borrow accessor}} // expected-note{{borrow accessors can return either stored properties or computed properties that have borrow accessors}}
 
     }
   }
@@ -260,10 +254,7 @@ public struct GenNCWrapper<T : ~Copyable> : ~Copyable {
 
   var opt_T: T? {
     borrow {
-      if Int.random(in: 1..<100) == 0 {
-        return nil
-      }
-      return _prop // expected-error{{invalid return value from borrow accessor}} // expected-note{{borrow accessors can return either literals, stored properties or computed properties that have borrow accessors}}
+      return _prop // expected-error{{invalid return value from borrow accessor}} // expected-note{{borrow accessors can return either stored properties or computed properties that have borrow accessors}}
     }
   }
 }


### PR DESCRIPTION
literals are not "stored values" in a general sense and cannot be returned by borrow accessors
