### PR TITLE
[Serialization] Fix serialization of init_borrow_addr instruction

### DIFF
--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -3089,9 +3089,11 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   case SILInstructionKind::InitBorrowAddrInst: {
     auto Ty = MF->getType(TyID);
     SILType addrType = getSILType(Ty, (SILValueCategory)TyCategory, Fn);
-    ResultInst = Builder.createInitBorrowAddr(
-        Loc, getLocalValue(Builder.maybeGetFunction(), ValID, addrType),
-        getLocalValue(Builder.maybeGetFunction(), ValID2, addrType));
+    auto refType = SILType::getPrimitiveAddressType(
+      addrType.castTo<BuiltinBorrowType>()->getReferentType());
+    auto referent = getLocalValue(Builder.maybeGetFunction(), ValID, refType);
+    auto borrow = getLocalValue(Builder.maybeGetFunction(), ValID2, addrType);
+    ResultInst = Builder.createInitBorrowAddr(Loc, borrow, referent);
     break;
   }
   case SILInstructionKind::CopyAddrInst: {

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -2519,8 +2519,8 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
       operand = SBI->getDest();
       value = SBI->getSrc();
     } else if (auto *IBA = dyn_cast<InitBorrowAddrInst>(&SI)) {
-      operand = IBA->getReferent();
-      value = IBA->getDest();
+      operand = IBA->getDest();
+      value = IBA->getReferent();
     } else {
       llvm_unreachable("switch out of sync");
     }

--- a/test/SIL/Serialization/basic2.sil
+++ b/test/SIL/Serialization/basic2.sil
@@ -133,6 +133,43 @@ bb0(%0 : @owned $Builtin.NativeObject):
   return %9999 : $()
 }
 
+// CHECK-LABEL: sil [serialized] [ossa] @test_dereference_addr_borrow : $@convention(thin) (Builtin.Borrow<Any>) -> @out Any {
+// CHECK:       bb0([[DEST:%.*]] : $*Any, [[BORROW:%.*]] : $Builtin.Borrow<Any>):
+// CHECK:         [[ANY_PTR:%.*]] = dereference_addr_borrow [[BORROW]] : $Builtin.Borrow<Any>
+// CHECK:         copy_addr [[ANY_PTR]] to [init] [[DEST]] : $*Any
+// CHECK-LABEL: } // end sil function 'test_dereference_addr_borrow'
+sil [serialized] [ossa] @test_dereference_addr_borrow : $@convention(thin) (Builtin.Borrow<Any>) -> @out Any {
+bb0(%0 : $*Any, %1 : $Builtin.Borrow<Any>):
+  %any_ptr = dereference_addr_borrow %1 : $Builtin.Borrow<Any>
+  copy_addr %any_ptr to [init] %0 : $*Any
+  %t = tuple ()
+  return %t
+}
+
+// CHECK-LABEL: sil [serialized] [ossa] @test_dereference_borrow : $@convention(thin) (Builtin.Borrow<Int>) -> Int {
+// CHECK:       bb0([[BORROW:%.*]] : $Builtin.Borrow<Int>):
+// CHECK:         [[INT:%.*]] = dereference_borrow [[BORROW]] : $Builtin.Borrow<Int>
+// CHECK:         return [[INT]] : $Int
+// CHECK-LABEL: } // end sil function 'test_dereference_borrow'
+sil [serialized] [ossa] @test_dereference_borrow : $@convention(thin) (Builtin.Borrow<Int>) -> Int {
+bb0(%0 : $Builtin.Borrow<Int>):
+  %int = dereference_borrow %0 : $Builtin.Borrow<Int>
+  return %int : $Int
+}
+
+// CHECK-LABEL: sil [serialized] [ossa] @test_dereference_borrow_addr : $@convention(thin) <T> (@in_guaranteed Builtin.Borrow<T>) -> @out T {
+// CHECK:       bb0([[DEST:%.*]] : $*T, [[BORROW:%.*]] : $*Builtin.Borrow<T>):
+// CHECK:         [[T_PTR:%.*]] = dereference_borrow_addr [[BORROW]] : $*Builtin.Borrow<T>
+// CHECK:         copy_addr [[T_PTR]] to [init] [[DEST]] : $*T
+// CHECK-LABEL: } // end sil function 'test_dereference_borrow_addr'
+sil [serialized] [ossa] @test_dereference_borrow_addr : $@convention(thin) <T> (@in_guaranteed Builtin.Borrow<T>) -> @out T {
+bb0(%0 : $*T, %1 : $*Builtin.Borrow<T>):
+  %t_ptr = dereference_borrow_addr %1 : $*Builtin.Borrow<T>
+  copy_addr %t_ptr to [init] %0 : $*T
+  %t = tuple ()
+  return %t
+}
+
 // CHECK-LABEL: sil [ossa] @test_destroy_value : {{.*}} {
 // CHECK:         cond_br undef, [[GOOD:bb[0-9]+]], [[BAD:bb[0-9]+]]
 // CHECK:       [[BAD]]:
@@ -232,6 +269,37 @@ bb1:
 bb2:
   destroy_value [dead_end] %k
   unreachable
+}
+
+// CHECK-LABEL: sil [serialized] [ossa] @test_init_borrow_addr : $@convention(thin) <T> (@in_guaranteed T) -> @out Builtin.Borrow<T> {
+// CHECK:       bb0([[DEST:%.*]] : $*Builtin.Borrow<T>, [[SRC:%.*]] : $*T):
+// CHECK:         init_borrow_addr [[DEST]] : $*Builtin.Borrow<T> with [[SRC]] : $*T
+// CHECK-LABEL: } // end sil function 'test_init_borrow_addr'
+sil [serialized] [ossa] @test_init_borrow_addr : $@convention(thin) <T> (@in_guaranteed T) -> @out Builtin.Borrow<T> {
+bb0(%0 : $*Builtin.Borrow<T>, %1 : $*T):
+  init_borrow_addr %0 : $*Builtin.Borrow<T> with %1 : $*T
+  %t = tuple ()
+  return %t : $()
+}
+
+// CHECK-LABEL: sil [serialized] [ossa] @test_make_addr_borrow : $@convention(thin) (@in_guaranteed Any) -> Builtin.Borrow<Any> {
+// CHECK:       bb0([[ANY:%.*]] : $*Any):
+// CHECK:         [[BORROW:%.*]] = make_addr_borrow [[ANY]] : $*Any
+// CHECK-LABEL: } // end sil function 'test_make_addr_borrow'
+sil [serialized] [ossa] @test_make_addr_borrow : $@convention(thin) (@in_guaranteed Any) -> Builtin.Borrow<Any> {
+bb0(%0 : $*Any):
+  %borrow = make_addr_borrow %0 : $*Any
+  return %borrow : $Builtin.Borrow<Any>
+}
+
+// CHECK-LABEL: sil [serialized] [ossa] @test_make_borrow : $@convention(thin) (Int) -> Builtin.Borrow<Int> {
+// CHECK:       bb0([[INT:%.*]] : $Int):
+// CHECK:         [[BORROW:%.*]] = make_borrow [[INT]] : $Int
+// CHECK-LABEL: } // end sil function 'test_make_borrow'
+sil [serialized] [ossa] @test_make_borrow : $@convention(thin) (Int) -> Builtin.Borrow<Int> {
+bb0(%0 : $Int):
+  %borrow = make_borrow %0 : $Int
+  return %borrow : $Builtin.Borrow<Int>
 }
 
 // CHECK-LABEL: sil [ossa] @test_mark_dependence : $@convention(thin) (@owned Builtin.NativeObject, @owned Builtin.NativeObject) -> () {


### PR DESCRIPTION
Resolves using `init_borrow_addr` across module boundaries. 