### PR TITLE
[Sema] Reject global actor annotations on class inheritance clauses

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6204,6 +6204,9 @@ ERROR(unsafe_global_actor,none,
 ERROR(global_actor_arg,none,
       "global actor attribute %0 cannot have arguments",
       (Type))
+ERROR(global_actor_on_inheritance_clause,none,
+      "global actor %0 cannot be applied to type in inheritance clause",
+      (TypeRepr *))
 ERROR(global_actor_non_final_class,none,
       "non-final class %0 cannot be a global actor", (DeclName))
 ERROR(global_actor_top_level_var,none,

--- a/test/Concurrency/global_actor_inheritance_clause.swift
+++ b/test/Concurrency/global_actor_inheritance_clause.swift
@@ -1,0 +1,33 @@
+// RUN: %target-typecheck-verify-swift
+// REQUIRES: concurrency
+
+actor SomeActor { }
+
+@globalActor
+struct SomeGlobalActor {
+  static let shared = SomeActor()
+}
+
+class Base {}
+class GenericBase<T> {}
+
+class Derived1: @MainActor Base {} // expected-error {{global actor 'MainActor' cannot be applied to type in inheritance clause}} {{18-27=}}
+class Derived2: @SomeGlobalActor Base {} // expected-error {{global actor 'SomeGlobalActor' cannot be applied to type in inheritance clause}} {{18-33=}}
+
+protocol SomeProtocol {}
+class Derived3: @MainActor SomeProtocol {}
+struct SomeStruct: @MainActor SomeProtocol {}
+enum SomeEnum: @MainActor SomeProtocol {}
+
+class Derived4: @MainActor Base, @MainActor SomeProtocol {} // expected-error {{global actor 'MainActor' cannot be applied to type in inheritance clause}} {{18-27=}}
+
+typealias BaseAlias = Base
+class DerivedFromAlias: @MainActor BaseAlias {} // expected-error {{global actor 'MainActor' cannot be applied to type in inheritance clause}} {{26-35=}}
+
+class DerivedFromGeneric: @MainActor GenericBase<Int> {} // expected-error {{global actor 'MainActor' cannot be applied to type in inheritance clause}} {{28-37=}}
+
+protocol ClassBoundProtocol: AnyObject {}
+class DerivedClassBound: @MainActor Base, ClassBoundProtocol {} // expected-error {{global actor 'MainActor' cannot be applied to type in inheritance clause}} {{27-36=}}
+
+typealias ComposedType = Base & SomeProtocol
+class DerivedFromComposition: @MainActor ComposedType {} // expected-error {{global actor 'MainActor' cannot be applied to type in inheritance clause}} {{32-41=}}


### PR DESCRIPTION
Global actor annotations like `@MainActor` were being accepted on class inheritance clauses even though they have no semantic meaning there. This adds validation to reject them with a clear error.

The fix only rejects global actors on class inheritance, protocol conformances still allow them since thats part of the isolated conformances feature.

Resolves #86693