### PR TITLE
[Swiftify] don't attach macro if plugin unavailable

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8200,6 +8200,10 @@ NOTE(macro_expand_circular_reference_unnamed_through, none,
 ERROR(accessor_macro_not_single_var, none,
       "accessor macro %0 can only apply to a single variable", (DeclName))
 
+WARNING(macro_on_import_not_loadable, none,
+        "could not load macro '%0'; this may cause errors down the line",
+        (StringRef))
+
 //------------------------------------------------------------------------------
 // MARK: Noncopyable Types Diagnostics
 //------------------------------------------------------------------------------

--- a/include/swift/Frontend/DiagnosticVerifier.h
+++ b/include/swift/Frontend/DiagnosticVerifier.h
@@ -149,6 +149,7 @@ private:
   /// got all of the expected diagnostics and check to see if there were any
   /// unexpected ones.
   Result verifyFile(unsigned BufferID);
+  bool parseTargetBufferName(StringRef &MatchStart, StringRef &Out, size_t &TextStartIdx);
   unsigned parseExpectedDiagInfo(unsigned BufferID, StringRef MatchStart,
                                  unsigned &PrevExpectedContinuationLine,
                                  ExpectedDiagnosticInfo &Expected);

--- a/test/Interop/C/swiftify-import/text-interface.swift
+++ b/test/Interop/C/swiftify-import/text-interface.swift
@@ -14,11 +14,11 @@
 // RUN: rm %t/test.swiftmodule %t/depender.swiftmodule
 
 // Comments are not emitted into the swiftinterface, so add some comments with the right path to depender.swift
-// RUN: echo "// expected-textinterface-error@%t%{fs-sep}test.swiftinterface:14{{cannot convert value of type 'UnsafeMutableBufferPointer<CInt>'}}" >> %t/depender.swift
-// RUN: echo "// expected-textinterface-error@%t%{fs-sep}test.swiftinterface:14{{missing argument for parameter #2 in call}}" >> %t/depender.swift
+// RUN: echo "// expected-textinterface-error@'%t%{fs-sep}test.swiftinterface':14{{cannot convert value of type 'UnsafeMutableBufferPointer<CInt>'}}" >> %t/depender.swift
+// RUN: echo "// expected-textinterface-error@'%t%{fs-sep}test.swiftinterface':14{{missing argument for parameter #2 in call}}" >> %t/depender.swift
 
-// RUN: echo "// expected-textinterface-error@%t%{fs-sep}test.swiftinterface:20{{cannot convert value of type 'UnsafeMutablePointer<MutableSpan<CInt>>'}}" >> %t/depender.swift
-// RUN: echo "// expected-textinterface-error@%t%{fs-sep}test.swiftinterface:20{{missing argument for parameter #2 in call}}" >> %t/depender.swift
+// RUN: echo "// expected-textinterface-error@'%t%{fs-sep}test.swiftinterface':20{{cannot convert value of type 'UnsafeMutablePointer<MutableSpan<CInt>>'}}" >> %t/depender.swift
+// RUN: echo "// expected-textinterface-error@'%t%{fs-sep}test.swiftinterface':20{{missing argument for parameter #2 in call}}" >> %t/depender.swift
 
 // Verify that absence of the macro plugin doesn't break compilation by itself - only if one of the inlinable functions calls the safe wrapper
 // RUN: %target-swift-frontend -swift-version 5 -emit-module -o %t/depender.swiftmodule %t/depender.swift -I %t -enable-experimental-feature SafeInteropWrappers -strict-memory-safety \

--- a/test/Interop/C/swiftify-import/text-interface.swift
+++ b/test/Interop/C/swiftify-import/text-interface.swift
@@ -3,7 +3,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution -emit-module -emit-module-interface-path %t/test.swiftinterface -plugin-path %swift-plugin-dir -o %t/test.swiftmodule %t/test.swift -I %t -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature MacrosOnImports -strict-memory-safety \
+// RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution -emit-module -emit-module-interface-path %t/test.swiftinterface -plugin-path %swift-plugin-dir -o %t/test.swiftmodule %t/test.swift -I %t -enable-experimental-feature SafeInteropWrappers -strict-memory-safety \
 // RUN:   -verify -verify-additional-file %t%{fs-sep}test.h
 
 // Verify that including the binary module works as expected

--- a/test/Interop/C/swiftify-import/text-interface.swift
+++ b/test/Interop/C/swiftify-import/text-interface.swift
@@ -1,0 +1,86 @@
+// REQUIRES: swift_feature_SafeInteropWrappers
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution -emit-module -emit-module-interface-path %t/test.swiftinterface -plugin-path %swift-plugin-dir -o %t/test.swiftmodule %t/test.swift -I %t -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature MacrosOnImports -strict-memory-safety \
+// RUN:   -verify -verify-additional-file %t%{fs-sep}test.h
+
+// Verify that including the binary module works as expected
+// RUN: %target-swift-frontend -swift-version 5 -emit-module -o %t/depender.swiftmodule %t/depender.swift -I %t -enable-experimental-feature SafeInteropWrappers -strict-memory-safety \
+// RUN:   -verify -verify-additional-file %t%{fs-sep}test.h
+
+// Make sure we trigger compilation from text interface
+// RUN: rm %t/test.swiftmodule %t/depender.swiftmodule
+
+// Comments are not emitted into the swiftinterface, so add some comments with the right path to depender.swift
+// RUN: echo "// expected-textinterface-error@%t%{fs-sep}test.swiftinterface:14{{cannot convert value of type 'UnsafeMutableBufferPointer<CInt>'}}" >> %t/depender.swift
+// RUN: echo "// expected-textinterface-error@%t%{fs-sep}test.swiftinterface:14{{missing argument for parameter #2 in call}}" >> %t/depender.swift
+
+// RUN: echo "// expected-textinterface-error@%t%{fs-sep}test.swiftinterface:20{{cannot convert value of type 'UnsafeMutablePointer<MutableSpan<CInt>>'}}" >> %t/depender.swift
+// RUN: echo "// expected-textinterface-error@%t%{fs-sep}test.swiftinterface:20{{missing argument for parameter #2 in call}}" >> %t/depender.swift
+
+// Verify that absence of the macro plugin doesn't break compilation by itself - only if one of the inlinable functions calls the safe wrapper
+// RUN: %target-swift-frontend -swift-version 5 -emit-module -o %t/depender.swiftmodule %t/depender.swift -I %t -enable-experimental-feature SafeInteropWrappers -strict-memory-safety \
+// RUN:   -verify -verify-additional-file %t%{fs-sep}test.h -verify-additional-file %t%{fs-sep}test.swiftinterface -verify-additional-prefix textinterface- -suppress-notes
+
+
+//--- test.h
+#pragma once
+
+#define __counted_by(x) __attribute__((__counted_by__(x)))
+#define __noescape __attribute__((noescape))
+
+// expected-textinterface-warning@+1{{could not load macro '_SwiftifyImport'; this may cause errors down the line}}
+void bufferPointer(int *__counted_by(len), int len);
+// expected-textinterface-warning@+1{{could not load macro '_SwiftifyImport'; this may cause errors down the line}}
+void span(int *__counted_by(len) p __noescape, int len);
+
+//--- test.swift
+import Test
+
+@inlinable
+public func callBufferPointer(_ p: UnsafeMutablePointer<CInt>, _ len: CInt) {
+  unsafe bufferPointer(p, len)
+}
+
+@inlinable
+public func callBufferPointer(_ p: UnsafeMutableBufferPointer<CInt>) {
+  unsafe bufferPointer(p)
+}
+
+@inlinable
+public func callSpan(_ p: UnsafeMutablePointer<CInt>, _ len: CInt) {
+  unsafe span(p, len)
+}
+
+@inlinable
+public func callSpan(_ p: inout MutableSpan<CInt>) {
+  span(&p)
+}
+
+//--- depender.swift
+// expected-textinterface-error@+1{{failed to build module 'test' for importation due to the errors above; the textual interface may be broken by project issues or a compiler bug}}
+import test
+
+func callCallBufferPointer(_ p: UnsafeMutablePointer<CInt>, len: CInt) {
+  unsafe callBufferPointer(p, len)
+}
+
+func callCallBufferPointer(_ p: UnsafeMutableBufferPointer<CInt>) {
+  unsafe callBufferPointer(p)
+}
+
+func callCallSpan(_ p: UnsafeMutablePointer<CInt>, len: CInt) {
+  unsafe callSpan(p, len)
+}
+
+func callCallSpan(_ p: inout MutableSpan<CInt>) {
+  callSpan(&p)
+}
+
+//--- module.modulemap
+module Test {
+  header "test.h"
+}
+


### PR DESCRIPTION
At the moment plugin paths do not get passed along when consuming a textual interface of an imported module. Normally this is not an issue, because all macros have already been expanded at this point, but this is not the case for _SwiftifyImport which belongs to a clang module but is expanded while compiling a dependent Swift module. This would cause an error when trying to expand the macro. Since most textual interfaces don't call any safe wrappers at the moment, this unblocks the compilation by checking whether the macro plugin can be loaded before attaching the macro, and emitting a warning if not. Long term we'll want to pass along the plugin path to swift-api-digester, but this will do for now.

rdar://168967555