### PR TITLE
Optimizer: fix two problems related to value-type deinits

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/Devirtualization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/Devirtualization.swift
@@ -58,6 +58,11 @@ private func devirtualize(destroy: some DevirtualizableDestroy, _ context: some 
     guard let deinitFunc = context.lookupDeinit(ofNominal: nominal) else {
       return false
     }
+    let serialized = destroy.parentFunction.serializedKind
+    guard serialized == .notSerialized || deinitFunc.hasValidLinkageForFragileRef(serialized) else {
+      return false
+    }
+
     if deinitFunc.linkage == .shared && !deinitFunc.isDefinition {
       // Make sure to not have an external shared function, which is illegal in SIL.
       _ = context.loadFunction(function: deinitFunc, loadCalleesRecursively: false)

--- a/lib/SILOptimizer/Transforms/SILSROA.cpp
+++ b/lib/SILOptimizer/Transforms/SILSROA.cpp
@@ -357,13 +357,15 @@ static bool runSROAOnFunction(SILFunction &Fn, bool splitSemanticTypes) {
         if (!splitSemanticTypes && isSemanticType(ctxt, AI->getElementType()))
           continue;
 
-        if (shouldExpand(Fn.getModule(), AI->getElementType()))
-          Worklist.push_back(AI);
+        Worklist.push_back(AI);
       }
 
   while (!Worklist.empty()) {
     AllocStackInst *AI = Worklist.back();
     Worklist.pop_back();
+
+    if (!shouldExpand(Fn.getModule(), AI->getElementType()))
+      continue;
 
     SROAMemoryUseAnalyzer Analyzer(AI);
 

--- a/test/SILOptimizer/devirt_deinits.sil
+++ b/test/SILOptimizer/devirt_deinits.sil
@@ -53,6 +53,10 @@ struct S5: ~Copyable {
   @_hasStorage let b: AnyObject
 }
 
+struct S6: ~Copyable {
+  deinit
+}
+
 // CHECK-LABEL: sil [ossa] @test_simple_struct :
 // CHECK:         [[D:%.*]] = function_ref @s1_deinit
 // CHECK:         apply [[D]](%0) : $@convention(method) (@owned S1) -> ()
@@ -331,11 +335,30 @@ bb0(%0 : $Builtin.RawPointer, %1 : $Builtin.Word):
   return %r
 }
 
+// CHECK-LABEL: sil [serialized] [ossa] @dont_create_non_public_function_ref_in_serialized_func :
+// CHECK-NOT:     function_ref
+// CHECK-NOT:     apply
+// CHECK:       } // end sil function 'dont_create_non_public_function_ref_in_serialized_func'
+sil [serialized] [ossa] @dont_create_non_public_function_ref_in_serialized_func : $@convention(thin) (@owned S6) -> () {
+bb0(%0 : @owned $S6):
+  destroy_value %0
+  %r = tuple()
+  return %r
+}
+
 
 sil @s1_deinit : $@convention(method) (@owned S1) -> ()
 sil @s2_deinit : $@convention(method) (@owned S2) -> ()
 sil @s3_deinit : $@convention(method) <T> (@in S3<T>) -> ()
 sil @s4_deinit : $@convention(method) (@owned S4) -> ()
+
+sil hidden [ossa] @s6_deinit : $@convention(method) (@owned S6) -> () {
+bb0(%0 : @owned $S6):
+  %1 = drop_deinit %0
+  () = destructure_struct %1
+  %r = tuple ()
+  return %r
+}
 
 sil_moveonlydeinit S1 {
   @s1_deinit
@@ -351,4 +374,8 @@ sil_moveonlydeinit S3 {
 
 sil_moveonlydeinit S4 {
   @s4_deinit
+}
+
+sil_moveonlydeinit S6 {
+  @s6_deinit
 }

--- a/test/SILOptimizer/sroa_ossa.sil
+++ b/test/SILOptimizer/sroa_ossa.sil
@@ -15,6 +15,20 @@ struct S1 {
   var z : Builtin.Int64
 }
 
+struct NC: ~Copyable {
+  var t: NCWithDeinit
+}
+
+struct NCWithDeinit: ~Copyable {
+  var i: NCInner
+
+  deinit
+}
+
+struct NCInner: ~Copyable {
+  var i: Int
+}
+
 sil [ossa] @use_int32 : $@convention(thin) (Builtin.Int32) -> ()
 
 // CHECK-LABEL: sil [ossa] @struct_with_scalar_fields : $@convention(thin) (S1) -> ()
@@ -583,3 +597,29 @@ bb6:
   %res = tuple ()
   return %res : $()
 }
+
+// CHECK-LABEL: sil [ossa] @dont_expand_non_copyable_with_deinit :
+// CHECK:         %1 = alloc_stack $NCWithDeinit
+// CHECK:         [[N:%.*]] = struct $NC (
+// CHECK-NEXT:    [[D:%.*]] = destructure_struct [[N]]
+// CHECK-NEXT:    store [[D]] to [init] %1
+// CHECK-LABEL: } // end sil function 'dont_expand_non_copyable_with_deinit'
+sil [ossa] @dont_expand_non_copyable_with_deinit : $@convention(thin) (Int) -> @owned NC {
+bb0(%0 : $Int):
+  %1 = alloc_stack $NC
+  %i = struct $NCInner (%0)
+  %2 = struct $NCWithDeinit (%i)
+  %3 = struct $NC (%2)
+  store %3 to [init] %1
+
+  %5 = struct_element_addr %1, #NC.t
+  %6 = struct_element_addr %5, #NCWithDeinit.i
+  %7 = struct_element_addr %6, #NCInner.i
+  %8 = load [trivial] %7
+  fix_lifetime %8
+
+  %10 = load [take] %1
+  dealloc_stack %1
+  return %10
+}
+


### PR DESCRIPTION
* DeinitDevirtualizer: don't create an invalid function_ref in a serialized function. Serialized functions may not reference non-public functions.

* SROA: don't try to destructure a non-copyable type with a deinit. This check was only done for the top-level alloc_stack, but not for any nested types.

rdar://169022052