### PR TITLE
Collect local types from extension macro expansions

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -3929,6 +3929,12 @@ ArrayRef<TypeDecl *> LocalTypeDeclsRequest::evaluate(Evaluator &evaluator,
   SmallVector<TypeDecl *> results;
   LocalTypeDeclCollector collector(results);
   sf->walk(collector);
+
+  // Also walk the synthesized file to collect local types from
+  // extension macro expansions.
+  if (auto *synthesizedFile = sf->getSynthesizedFile())
+    synthesizedFile->walk(collector);
+
   return sf->getASTContext().AllocateCopy(results);
 }
 

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -3016,3 +3016,28 @@ public struct CustomConditionCheckMacro: ExpressionMacro {
     return "\(literal: isSet)"
   }
 }
+
+public struct ExtensionWithLocalTypeMacro: ExtensionMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo decl: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [ExtensionDeclSyntax] {
+    let ext: DeclSyntax =
+      """
+      extension \(raw: type.trimmedDescription) {
+        static func test(_ value: Int) {
+          enum Status {
+            case active
+            case inactive
+          }
+          func checkStatus(value: Int, status: Status?) {}
+          checkStatus(value: value, status: nil)
+        }
+      }
+      """
+    return [ext.cast(ExtensionDeclSyntax.self)]
+  }
+}

--- a/test/Macros/macro_expand_extension_local_type.swift
+++ b/test/Macros/macro_expand_extension_local_type.swift
@@ -1,0 +1,16 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+
+// Verify that emitting IR with debug info does not crash when an extension
+// macro generates a function containing a local type.
+// RUN: %target-swift-frontend -swift-version 5 -emit-ir -load-plugin-library %t/%target-library-name(MacroDefinition) %s -module-name MacroUser -o - -g | %FileCheck %s
+
+@attached(extension, names: named(test))
+macro ExtensionWithLocalType() = #externalMacro(module: "MacroDefinition", type: "ExtensionWithLocalTypeMacro")
+
+@ExtensionWithLocalType
+struct MyStruct {}
+
+// CHECK: define {{.*}}test


### PR DESCRIPTION
Fixes #86809 

### Explanation

The issue seems to be caused by missing local type lookup. 

LocalTypeDeclsRequest only walked the original source file, missing local types declared inside extension macro expansions stored in the synthesized file. This caused a crash when emitting IR with debug info for such expansions. 

An alternative approach could be overriding the `SynthesizedFileUnit::lookupLocalType`, and changing the `ModuleDecl::lookupLocalType` to go through `ModuleDecl::getFiles()` and each file's `getSynthesizedFile()`, when there isn't a local type lookup hit in the source files. 

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
