### PR TITLE
Added starter documentation and a script for profiling the Swift compiler on Windows

### DIFF
--- a/docs/WindowsProfilingCompiler.md
+++ b/docs/WindowsProfilingCompiler.md
@@ -1,4 +1,4 @@
-# Windows Profiling Tools
+# Profiling the Swift Compiler on Windows
 
 This document describes Windows profiling tools from the angle of **profiling the Swift compiler itself**. The information is mostly general purpose, but specifics relevant to other applications aren't considered.
 

--- a/docs/WindowsProfilingTools.md
+++ b/docs/WindowsProfilingTools.md
@@ -1,10 +1,77 @@
 # Windows Profiling Tools
 
-This document describes Windows profiling tools from the angle of profiling the Swift compiler. The information is mostly general purpose, but specifics relevant to other applications aren’t considered.
+This document describes Windows profiling tools from the angle of **profiling the Swift compiler itself**. The information is mostly general purpose, but specifics relevant to other applications aren't considered.
 
-# Survey of Windows profiling tools
+The recommended approach when you need detailed function and I/O operation-level profiling of the Swift compiler on Windows is to use **Event Tracing for Windows (ETW)**. This includes using **Windows Performance Recorder (WPR)** to collect profiling data in ETL format and then **Windows Performance Analyzer (WPA)** to analyze it. For specific analyses not available in WPA, you will also be able to use `xperf.exe` to convert a binary ETL file to a text format for analysis by another program. We also discuss a couple of alternatives which may in certain cases be easier to use or provide specific data of interest: **Visual Studio** (the full IDE, not VS Code) and **Intel VTune**.
 
-This section lists desribes some major Windows profiling tools that can be used with the Swift compiler and the relationships between them.
+The document is organized as follows:
+
+1. [Recommended: Using Event Tracing for Windows (ETW) to profile Swift compiler runs](#recommended-using-event-tracing-for-windows-etw-to-profile-swift-compiler-runs)
+2. [Alternative: Using Visual Studio to profile Swift compiler runs](#alternative-using-visual-studio-to-profile-swift-compiler-runs)
+3. [Alternative: Using VTune to profile Swift compiler runs](#alternative-using-vtune-to-profile-swift-compiler-runs)
+4. [Reference: Survey of Windows profiling tools](#reference-survey-of-windows-profiling-tools)
+5. [Reference: Building the Swift toolchain for Windows with debugging symbols](#building-the-swift-toolchain-for-windows-with-debugging-symbols)
+
+# Recommended: Using Event Tracing for Windows (ETW) to profile Swift compiler runs
+
+1. Make sure you have a build of the Swift toolchain with PDB format debug symbols. One approach is to follow [Building the Swift toolchain for Windows with debugging symbols](#building-the-swift-toolchain-for-windows-with-debugging-symbols).
+2. Use `wpr` (Windows Performance Recorder) or a wrapper script like [utils/windows-profiling-tools/RunProfiler.ps1](../utils/windows-profiling-tools/RunProfiler.ps1) to collect a `.etl` file (event trace log).
+    1. If you are using a custom-built Swift toolchain, set environment variables as instructed in [WindowsQuickStart.md](https://github.com/compnerd/swift-build/blob/main/docs/WindowsQuickStart.md).
+    2. Example usage of `RunProfiler.ps1`: `...\RunProfiler.ps1 -TracePath C:\Temp\program.etl -Target swiftc program.swift`. Here `program.swift` just serves as a workload for running the compiler. Different parts of the compiler will naturally be exercised more or less depending on the program.
+    3. Instead of running `swiftc` directly, you can instead call a build system like `swift build` or `cmake` to build a larger program. Longer compilations will result in larger `.etl` files. Try a small program first, to see
+    what the `.etl` file collection and analysis process is like (including the size of `.etl` files).
+1. Run `wpa.exe <path\to\trace.etl>` to load the `.etl` file into WPA and analyze it.
+    1. On the left, double click on the view you're interested in. Some useful ones include "Computation > CPU Usage (Sampled)," "System Activity > Processes," and "Storage > File I/O > Activity by Process, Thead, Type."
+    2. Sort by Process name and select other related processes you may be interested in like `swift.exe`. Then right click on the selected processes and choose "Filter To Selection" to hide all other processes. Alternatively, right click on the table header, select "Edit Filters," and enter "Process Name" constraints.
+    3. Go to Trace > Configure Symbol Paths. It will open a Configure Symbols dialog. Add `S:\Program Files\Swift\Runtimes\0.0.0\usr\bin` and `S:\Program Files\Swift\Toolchains\0.0.0+Asserts\usr\bin` the list in the Paths tab. This enables WPA to find PDB files for our EXEs and DLLs. You shouldn't have to reconfigure this every time you run WPA.
+    4. Make sure Trace > Load Symbols is selected. If it's unselected, it will likely take some time to load symbols once you select it.
+    5. The Stack column of the process list should now show function symbols as you drill down into execution times for various parts of the call stack. If you're in a view that doesn't include Stack or another column you want, right click on the table header and select "More Columns..." > the column view you want or right click the table header and select "Open View Editor..." for more detailed configuration.
+
+# Alternative: Using Visual Studio to profile Swift compiler runs
+
+Visual Studio (the full IDE, not VS Code) has a built-in profiler that can profile arbitrary executables without requiring a Visual Studio solution or project. This includes the Swift compiler, provided it is built with PDB format debug symbols. By default, Visual Studio's profiler only records profiling data for the directly invoked process, not child processes. This makes it a less than ideal choice for top level Swift builds that invoke many child processes, but can still be useful if you have a specific `swift-frontend.exe` command you would like to profile.
+
+Assuming you want to profile `swiftc.exe`'s call to `swift-frontend.exe` run on an input source file `S:\Temp\hello.swift`:
+
+1. On the command line, run `swiftc.exe -v hello.swift` (for example). This will give you a `swift-frontend.exe` command that `swiftc.exe` calls.
+2. Open Visual Studio without any files/project.
+3. Debug > Performance Profiler...
+4. Change Target > Executable
+    1. Path to executable: `S:\Program Files\Swift\Toolchains\0.0.0+Asserts\usr\bin\swift-frontend.exe`
+    2. Command line options: (as output in step (1) above).
+    3. Working directory: `S:\Temp`
+    4. Environment Variables: see "Using the Toolchain" in [WindowsQuickStart.md](https://github.com/compnerd/swift-build/blob/main/docs/WindowsQuickStart.md).
+5. Click Ok, select "CPU Usage," click Start.
+6. When the run is done, Visual Studio will present you with a GUI with lists of the functions that take the most time as well as hot traces, which you can explore further.
+
+# Alternative: Using VTune to profile Swift compiler runs
+
+Intel VTune supports profiling using Intel processors' Performance Monitoring Unit (PMU), which provides hardware-level performance counters. It's available as an integrated GUI application as well as a standalone command line executable (`vtune.exe`) that can collect performance logs to be analyzed in the GUI. We'll discuss the GUI workflow here.
+
+1. Download VTune for Windows from Intel and install it on a Windows computer with an Intel processor. The first time you launch VTune, a helpful walkthrough tutorial is available. After that:
+2. On the Welcome tab, click "Configure Analysis..." and configure it as follows:
+    1. Where: Local Host (default)
+    2. What: Launch Application (default)
+    3. Application: for example, `S:\Program Files\Swift\Toolchains\0.0.0+Asserts\usr\bin\swiftc.exe`
+    4. Application parameters: for example, `hello.swift`
+    5. Uncheck "Use application directory as working directory"
+    6. Working directory: for example, `S:\Temp`
+    7. Advanced >
+        1. User-defined environment variables: see "Using the Toolchain" in [WindowsQuickStart.md](https://github.com/compnerd/swift-build/blob/main/docs/WindowsQuickStart.md).
+        2. Make sure "Analyze child processes" is checked (it is by default)
+        3. Duration time estimate: Under 1 minute
+        4. Store result in (and create link file to) another directory: `C:\Users\%USER%\Documents\VTune\Projects\swift_hello` (note: manually fill in your `%USER%`)
+    8. How: Select what you would like to profile. Hotspots will tell you where most of the time is spent in the code.
+    9. Click the "Search Sources/Binaries" button (folder with a magnifying glass) and add the following search directories:
+        - `S:\Program Files\Swift\Runtimes\0.0.0\usr\bin`
+        - `S:\Program Files\Swift\Toolchains\0.0.0+Asserts\usr\bin`
+
+    10. Click the "Start" button ("play" button style triangle above). If you would prefer to run `vtune.exe` from the command line, click the ">_" button seen above to get the command to run.
+3. After profiling `swiftc.exe hello.swift` exits, you will be taken to an analysis tab to view the results, which include hot traces and time consuming functions.
+
+# Reference: Survey of Windows profiling tools
+
+This section describes Windows profiling tools that can be used with the Swift compiler and the relationships between them.
 
 - **WPT** = Windows Performance Toolkit is a collection of tools & infrastructure for profiling from Microsoft. Includes the WP* and XPerf* tools below.
 - **ETW** = Event Tracing for Windows is the OS-level feature for collecting application and kernel performance event traces. Microsoft/Windows Profiler tools drive ETW to collect events.
@@ -18,7 +85,7 @@ This section lists desribes some major Windows profiling tools that can be used 
     - `.etl` is the output binary event log file format produced by tools like WPR and XPerf. There are also a command line tools including `xperf.exe` and `tracerpt.exe` that can be used to convert an ETL file into multiple text-based formats.
     - `.wprp` is an XML configuration file format used to configure WPR’s operation. For example, [utils/windows-profiling-tools/CpuAndWaitsWithLargeBuffers.wprp](../utils/windows-profiling-tools/CpuAndWaitsWithLargeBuffers.wprp) increases the in-memory buffer size that WPR configures ETW to use so as not to drop events during recording.
 - Analysis GUIs:
-    - **WPA** = Windows Performance Analyzer is a GUI that lets you analyze various aspects of the performance trace data found in `.etl` files. It can be invoked on the command line by running `wpa.exe` with the `.etl` file as an argument. See below for how to view program profiles with symbols.
+    - **WPA** = Windows Performance Analyzer is a GUI that lets you analyze various aspects of the performance trace data found in `.etl` files. It can be invoked on the command line by running `wpa.exe` with the `.etl` file as an argument. See [Using Event Tracing for Windows (ETW) to profile Swift compiler runs](#recommended-using-event-tracing-for-windows-etw-to-profile-swift-compiler-runs) for how to view program profiles with symbols.
     - **XPerfView** is an older GUI for analyzing `.etl` files that has been replaced by WPA.
     - **Visual Studio** directly displays profile results after recording a profile data from a run of a program. By default, it only shows profiles for the directly invoked program, not for subprocesses.
     - **Intel VTune** can either directly display profile results after recording them or display profile results from a command line run of `vtune.exe` (possibly run on a different host).
@@ -33,57 +100,6 @@ This section lists desribes some major Windows profiling tools that can be used 
 
 To build the Swift compiler with PDB format debug symbols that are used by profile analysis tools like WPA or Visual Studio, follow the https://github.com/compnerd/swift-build/blob/main/docs/WindowsQuickStart.md instructions, using the following `build.cmd` command line (or a variant on it based on your exact needs):
 
-`S:\SourceCache\swift\utils\build.cmd -Windows -DebugInfo -SkipPackaging -WindowsSDKArchitectures x64 -CDebugFormat codeview -SwiftDebugFormat codeview` 
+`S:\SourceCache\swift\utils\build.cmd -Windows -DebugInfo -SkipPackaging -WindowsSDKArchitectures x64 -CDebugFormat codeview -SwiftDebugFormat codeview`
 
-If you need to build a package that you can install on a separate Windows host, either remove `-SkipPackaging` in the above command, or if you’ve already run the above build, substitute `-SkipBuild` in place of `-SkipPackaging`:
-
-`S:\SourceCache\swift\utils\build.cmd -Windows -DebugInfo -SkipBuild -WindowsSDKArchitectures x64 -CDebugFormat codeview -SwiftDebugFormat codeview` 
-
-# Configuring Visual Studio for profiling the Swift compiler
-
-Assuming you want to profile `swiftc.exe` run on an input source file `S:\Temp\hello.swift`:
-
-1. Open Visual Studio without any files/project.
-2. Debug > Performance Profiler...
-3. Change Target > Executable
-    1. Path to executable: `S:\Program Files\Swift\Toolchains\0.0.0+Asserts\usr\bin\swiftc.exe`
-    2. Command line options: `hello.swift`
-    3. Working directory: `S:\Temp` 
-    4. Environment Variables: see "Using the Toolchain" in [WindowsQuickStart.md](https://github.com/compnerd/swift-build/blob/main/docs/WindowsQuickStart.md).
-4. Click Ok, select "CPU Usage," click Start.
-5. When the run is done, use the GUI to examine functions that take most of the time and hot traces.
-
-# Configuring WPA for analyzing `.etl` profiles of the Swift compiler
-
-1. Use `wpr` or a wrapper like [utils/windows-profiling-tools/RunProfiler.ps1](../utils/windows-profiling-tools/RunProfiler.ps1) to collect a `.etl` file.
-    1. `$env:SDKROOT = "S:\Program Files\Swift\Platforms\Windows.platform\Developer\SDKs\Windows.sdk"`
-    2. The location of the Swift compiler to run should be `S:\Program Files\Swift\Toolchains\0.0.0+Asserts\usr\bin\swift.exe`
-2. Run `wpa.exe <path\to\trace.etl>` to load the `.etl` file into WPA.
-3. On the left, double click on the view you're interested in. Some useful ones include "Computation > CPU Usage (Sampled)," "System Activity > Processes," and "Storage > File I/O > Activity by Process, Thead, Type."
-4. Sort by Process name and select other related processes you may be interested in like `swift.exe`. Then right click on the selected processes and choose “Filter To Selection” to hide all other processes. Alternatively, right click on the table header, select "Edit Filters," and enter "Process Name" constraints.
-5. Go to Trace > Configure Symbol Paths. It will open a Configure Symbols dialog. Add `S:\Program Files\Swift\Runtimes\0.0.0\usr\bin` and `S:\Program Files\Swift\Toolchains\0.0.0+Asserts\usr\bin` the list in the Paths tab. This enables WPA to find PDB files for our EXEs and DLLs. You shouldn’t have to reconfigure this every time you run WPA.
-6. Make sure Trace > Load Symbols is selected. If it’s unselected, it will likely take some time to load symbols once select it.
-7. The Stack column of the process list should now show function symbols as you drill down into execution times for various parts of the call stack. If you're in a view that doesn't include Stack or another column you want, right click on the table header and select "More Columns..." > the column view you want or right click the table header and select "Open View Editor..." for more detailed configuration.
-
-# Configuring VTune  for profiling the Swift compiler
-
-1. Download VTune for Windows from Intel and install it. The first time you launch it, a helpful walkthrough tutorial is available. After that:
-2. On the Welcome tab, click “Configure Analysis...” and configure it as follows:
-    1. Where: Local Host (default)
-    2. What: Launch Application (default)
-    3. Application: for example, `S:\Program Files\Swift\Toolchains\0.0.0+Asserts\usr\bin\swiftc.exe`
-    4. Application parameters: for example, `hello.swift`
-    5. Uncheck “Use application directory as working directory”
-    6. Working directory: for example, `S:\Temp`
-    7. Advanced >
-        1. User-defined environment variables: see "Using the Toolchain" in [WindowsQuickStart.md](https://github.com/compnerd/swift-build/blob/main/docs/WindowsQuickStart.md).
-        2. Make sure “Analyze child processes” is checked (it is by default)
-        3. Duration time estimate: Under 1 minute
-        4. Store result in (and create link file to) another directory: `C:\Users\%USER%\Documents\VTune\Projects\swift_hello` (note: manually fill in your `%USER%`)
-    8. How: Select what you would like to profile. Hotspots will tell you where most of the time is spent in the code.
-    9. Click the “Search Sources/Binaries” button (folder with a magnifying glass) and add the following search directories:
-        - `S:\Program Files\Swift\Runtimes\0.0.0\usr\bin`
-        - `S:\Program Files\Swift\Toolchains\0.0.0+Asserts\usr\bin`
-            
-    10. Click the “Start” button (”play” button style triangle above). If you would prefer to run `vtune.exe` from the command line, click the “>_” button seen above to get the command to run.
-3. After profiling `swiftc.exe hello.swift` exits, you will be taken to an analysis tab to view the results.
+If you need to build a package that you can install on a separate Windows host, either remove `-SkipPackaging` in the above command, or if you've already run the above build, substitute `-SkipBuild` in place of `-SkipPackaging`.

--- a/docs/WindowsProfilingTools.md
+++ b/docs/WindowsProfilingTools.md
@@ -49,9 +49,7 @@ Assuming you want to profile `swiftc.exe` run on an input source file `S:\Temp\h
     1. Path to executable: `S:\Program Files\Swift\Toolchains\0.0.0+Asserts\usr\bin\swiftc.exe`
     2. Command line options: `hello.swift`
     3. Working directory: `S:\Temp` 
-    4. Environment Variables (these enable VS to find PDB files for our EXEs and DLLs):
-        - `Path`: `S:\Program Files\Swift\Runtimes\0.0.0\usr\bin;S:\Program Files\Swift\Toolchains\0.0.0+Asserts\usr\bin;%PATH%`
-        - `SDKROOT`: `S:\Program Files\Swift\Platforms\Windows.platform\Developer\SDKs\Windows.sdk`
+    4. Environment Variables: see "Using the Toolchain" in [WindowsQuickStart.md](https://github.com/compnerd/swift-build/blob/main/docs/WindowsQuickStart.md).
 4. Click Ok, select "CPU Usage," click Start.
 5. When the run is done, use the GUI to examine functions that take most of the time and hot traces.
 
@@ -78,9 +76,7 @@ Assuming you want to profile `swiftc.exe` run on an input source file `S:\Temp\h
     5. Uncheck “Use application directory as working directory”
     6. Working directory: for example, `S:\Temp`
     7. Advanced >
-        1. User-defined environment variables:
-            - `Path`: `S:\Program Files\Swift\Runtimes\0.0.0\usr\bin;S:\Program Files\Swift\Toolchains\0.0.0+Asserts\usr\bin;%PATH%`
-            - `SDKROOT`: `S:\Program Files\Swift\Platforms\Windows.platform\Developer\SDKs\Windows.sdk`
+        1. User-defined environment variables: see "Using the Toolchain" in [WindowsQuickStart.md](https://github.com/compnerd/swift-build/blob/main/docs/WindowsQuickStart.md).
         2. Make sure “Analyze child processes” is checked (it is by default)
         3. Duration time estimate: Under 1 minute
         4. Store result in (and create link file to) another directory: `C:\Users\%USER%\Documents\VTune\Projects\swift_hello` (note: manually fill in your `%USER%`)

--- a/docs/WindowsProfilingTools.md
+++ b/docs/WindowsProfilingTools.md
@@ -1,0 +1,93 @@
+# Windows Profiling Tools
+
+This document describes Windows profiling tools from the angle of profiling the Swift compiler. The information is mostly general purpose, but specifics relevant to other applications aren’t considered.
+
+# Survey of Windows profiling tools
+
+This section lists desribes some major Windows profiling tools that can be used with the Swift compiler and the relationships between them.
+
+- **WPT** = Windows Performance Toolkit is a collection of tools & infrastructure for profiling from Microsoft. Includes the WP* and XPerf* tools below.
+- **ETW** = Event Tracing for Windows is the OS-level feature for collecting application and kernel performance event traces. Microsoft/Windows Profiler tools drive ETW to collect events.
+- Performance event recorders:
+    - **WPR** = Windows Performance Recorder lets you start and stop an ETW session by running `wpr.exe`. Collects profiling data for all running processes and saves it to a `.etl` file. See [utils/windows-profiling-tools/RunProfiler.ps1](../utils/windows-profiling-tools/RunProfiler.ps1) for a PowerShell script that runs WPR for the duration of a specified command invocation.
+    - **XPerf** is an older, lower level equivalent of WPR. It supports a few obscure ETW settings not exposed by WPR, but WPR is recommended if meets your needs.
+    - **Visual Studio** also supports profiling `.exe`s that don’t have to be part of a Visual Studio solution/project, starting by opening VS without any files/project, then going to Debug > Performance Profiler... By default, it only profiles the initial process
+    launched from the `.exe`, not child processes.
+    - **Intel VTune** supports profiling using Intel processors’ Performance Monitoring Unit (PMU) rather than ETW. It’s available as an integrated GUI application as well as a standalone command line executable that can collect performance logs to be analyzed in the GUI.
+- File formats:
+    - `.etl` is the output binary event log file format produced by tools like WPR and XPerf. There are also a command line tools including `xperf.exe` and `tracerpt.exe` that can be used to convert an ETL file into multiple text-based formats.
+    - `.wprp` is an XML configuration file format used to configure WPR’s operation. For example, [utils/windows-profiling-tools/CpuAndWaitsWithLargeBuffers.wprp](../utils/windows-profiling-tools/CpuAndWaitsWithLargeBuffers.wprp) increases the in-memory buffer size that WPR configures ETW to use so as not to drop events during recording.
+- Analysis GUIs:
+    - **WPA** = Windows Performance Analyzer is a GUI that lets you analyze various aspects of the performance trace data found in `.etl` files. It can be invoked on the command line by running `wpa.exe` with the `.etl` file as an argument. See below for how to view program profiles with symbols.
+    - **XPerfView** is an older GUI for analyzing `.etl` files that has been replaced by WPA.
+    - **Visual Studio** directly displays profile results after recording a profile data from a run of a program. By default, it only shows profiles for the directly invoked program, not for subprocesses.
+    - **Intel VTune** can either directly display profile results after recording them or display profile results from a command line run of `vtune.exe` (possibly run on a different host).
+- Analysis CLIs:
+    - `wpaexport.exe` takes a profile built in the WPA GUI and exports data from a `.etl` file according to that profile. Note that profiles that include hierarchical lists in the GUI may only export the top levels of the hierarchy. In this case, you can reconfigure the WPA GUI view to make the list flat and then export a new profile.
+    - `xperf.exe` can be used to operate on `.etl` files recorded with either `wpr.exe` or `xperf.exe` itself. Examples:
+        - Dump all events from a `.etl` file in text format: `xperf -i <INPUT>.etl -o <OUTPUT>.txt -symbols -target machine -a dumper -stacktimeshifting` where `<INPUT>` and `<OUTPUT>` are files of your choice with `_NT_SYMBOL_PATH` set in the environment to point to directories containing PDB files, e.g. in PowerShell:
+            - `$env:_NT_SYMBOL_PATH="S:\b\5\bin\bin"` (list all directories containing relevant PDB files, separated by semicolons)
+        - List execution times per function from a `.etl` file, *not including  the time taken by calls to other functions*: `xperf -i <INPUT>.etl -o <OUTPUT>.txt -symbols -a profile -detail`
+
+# Building the Swift toolchain for Windows with debugging symbols
+
+To build the Swift compiler with PDB format debug symbols that are used by profile analysis tools like WPA or Visual Studio, follow the https://github.com/compnerd/swift-build/blob/main/docs/WindowsQuickStart.md instructions, using the following `build.cmd` command line (or a variant on it based on your exact needs):
+
+`S:\SourceCache\swift\utils\build.cmd -Windows -DebugInfo -SkipPackaging -WindowsSDKArchitectures x64 -CDebugFormat codeview -SwiftDebugFormat codeview` 
+
+If you need to build a package that you can install on a separate Windows host, either remove `-SkipPackaging` in the above command, or if you’ve already run the above build, substitute `-SkipBuild` in place of `-SkipPackaging`:
+
+`S:\SourceCache\swift\utils\build.cmd -Windows -DebugInfo -SkipBuild -WindowsSDKArchitectures x64 -CDebugFormat codeview -SwiftDebugFormat codeview` 
+
+# Configuring Visual Studio for profiling the Swift compiler
+
+Assuming you want to profile `swiftc.exe` run on an input source file `S:\Temp\hello.swift`:
+
+1. Open Visual Studio without any files/project.
+2. Debug > Performance Profiler...
+3. Change Target > Executable
+    1. Path to executable: `S:\Program Files\Swift\Toolchains\0.0.0+Asserts\usr\bin\swiftc.exe`
+    2. Command line options: `hello.swift`
+    3. Working directory: `S:\Temp` 
+    4. Environment Variables (these enable VS to find PDB files for our EXEs and DLLs):
+        - `Path`: `S:\Program Files\Swift\Runtimes\0.0.0\usr\bin;S:\Program Files\Swift\Toolchains\0.0.0+Asserts\usr\bin;%PATH%`
+        - `SDKROOT`: `S:\Program Files\Swift\Platforms\Windows.platform\Developer\SDKs\Windows.sdk`
+4. Click Ok, select "CPU Usage," click Start.
+5. When the run is done, use the GUI to examine functions that take most of the time and hot traces.
+
+# Configuring WPA for analyzing `.etl` profiles of the Swift compiler
+
+1. Use `wpr` or a wrapper like [utils/windows-profiling-tools/RunProfiler.ps1](../utils/windows-profiling-tools/RunProfiler.ps1) to collect a `.etl` file.
+    1. `$env:SDKROOT = "S:\Program Files\Swift\Platforms\Windows.platform\Developer\SDKs\Windows.sdk"`
+    2. The location of the Swift compiler to run should be `S:\Program Files\Swift\Toolchains\0.0.0+Asserts\usr\bin\swift.exe`
+2. Run `wpa.exe <path\to\trace.etl>` to load the `.etl` file into WPA.
+3. On the left, double click on the view you're interested in. Some useful ones include "Computation > CPU Usage (Sampled)," "System Activity > Processes," and "Storage > File I/O > Activity by Process, Thead, Type."
+4. Sort by Process name and select other related processes you may be interested in like `swift.exe`. Then right click on the selected processes and choose “Filter To Selection” to hide all other processes. Alternatively, right click on the table header, select "Edit Filters," and enter "Process Name" constraints.
+5. Go to Trace > Configure Symbol Paths. It will open a Configure Symbols dialog. Add `S:\Program Files\Swift\Runtimes\0.0.0\usr\bin` and `S:\Program Files\Swift\Toolchains\0.0.0+Asserts\usr\bin` the list in the Paths tab. This enables WPA to find PDB files for our EXEs and DLLs. You shouldn’t have to reconfigure this every time you run WPA.
+6. Make sure Trace > Load Symbols is selected. If it’s unselected, it will likely take some time to load symbols once select it.
+7. The Stack column of the process list should now show function symbols as you drill down into execution times for various parts of the call stack. If you're in a view that doesn't include Stack or another column you want, right click on the table header and select "More Columns..." > the column view you want or right click the table header and select "Open View Editor..." for more detailed configuration.
+
+# Configuring VTune  for profiling the Swift compiler
+
+1. Download VTune for Windows from Intel and install it. The first time you launch it, a helpful walkthrough tutorial is available. After that:
+2. On the Welcome tab, click “Configure Analysis...” and configure it as follows:
+    1. Where: Local Host (default)
+    2. What: Launch Application (default)
+    3. Application: for example, `S:\Program Files\Swift\Toolchains\0.0.0+Asserts\usr\bin\swiftc.exe`
+    4. Application parameters: for example, `hello.swift`
+    5. Uncheck “Use application directory as working directory”
+    6. Working directory: for example, `S:\Temp`
+    7. Advanced >
+        1. User-defined environment variables:
+            - `Path`: `S:\Program Files\Swift\Runtimes\0.0.0\usr\bin;S:\Program Files\Swift\Toolchains\0.0.0+Asserts\usr\bin;%PATH%`
+            - `SDKROOT`: `S:\Program Files\Swift\Platforms\Windows.platform\Developer\SDKs\Windows.sdk`
+        2. Make sure “Analyze child processes” is checked (it is by default)
+        3. Duration time estimate: Under 1 minute
+        4. Store result in (and create link file to) another directory: `C:\Users\%USER%\Documents\VTune\Projects\swift_hello` (note: manually fill in your `%USER%`)
+    8. How: Select what you would like to profile. Hotspots will tell you where most of the time is spent in the code.
+    9. Click the “Search Sources/Binaries” button (folder with a magnifying glass) and add the following search directories:
+        - `S:\Program Files\Swift\Runtimes\0.0.0\usr\bin`
+        - `S:\Program Files\Swift\Toolchains\0.0.0+Asserts\usr\bin`
+            
+    10. Click the “Start” button (”play” button style triangle above). If you would prefer to run `vtune.exe` from the command line, click the “>_” button seen above to get the command to run.
+3. After profiling `swiftc.exe hello.swift` exits, you will be taken to an analysis tab to view the results.

--- a/utils/windows-profiling-tools/CpuAndWaitsWithLargeBuffers.wprp
+++ b/utils/windows-profiling-tools/CpuAndWaitsWithLargeBuffers.wprp
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<WindowsPerformanceRecorder
+    Author="Custom"
+    Company="Custom"
+    Copyright="(c) 2025"
+    Comments="High-buffer CPU sampling profile with wait and I/O analysis"
+    Version="1.0">
+
+  <Profiles>
+
+    <!-- Kernel session with big buffers (512 MB total) -->
+    <SystemCollector
+      Id="CpuWithLargeBuffers_SystemCollector"
+      Name="NT Kernel Logger">
+      <BufferSize Value="1024"/>
+      <Buffers Value="512"/>
+    </SystemCollector>
+
+    <!-- System provider for CPU sampling + context switches + thread activity + I/O -->
+    <SystemProvider
+      Id="CpuWithLargeBuffers_SystemProvider">
+      <Keywords>
+        <!-- CPU / scheduling / loader keywords -->
+        <Keyword Value="CpuConfig"/>
+        <Keyword Value="SampledProfile"/>
+        <Keyword Value="ProcessThread"/>
+        <Keyword Value="CSwitch"/>
+        <Keyword Value="Loader"/>
+        <!-- ADDED: Required for wait analysis -->
+        <Keyword Value="ReadyThread"/>
+        <!-- ADDED: File and Disk I/O -->
+        <Keyword Value="DiskIO"/>
+        <Keyword Value="FileIO"/>
+        <Keyword Value="FileIOInit"/>
+        <Keyword Value="HardFaults"/>
+      </Keywords>
+      <Stacks>
+        <!-- CPU and scheduling stacks -->
+        <Stack Value="CSwitch"/>
+        <Stack Value="SampledProfile"/>
+        <Stack Value="ReadyThread"/>
+        <!-- ADDED: I/O stacks -->
+        <Stack Value="DiskReadInit"/>
+        <Stack Value="DiskWriteInit"/>
+        <Stack Value="DiskFlushInit"/>
+        <Stack Value="FileCreate"/>
+        <Stack Value="FileRead"/>
+        <Stack Value="FileWrite"/>
+        <Stack Value="FileQueryInformation"/>
+      </Stacks>
+    </SystemProvider>
+
+    <!-- File-logging profile -->
+    <Profile
+      Id="CpuWithLargeBuffers.Verbose.File"
+      Name="CpuWithLargeBuffers"
+      DetailLevel="Verbose"
+      LoggingMode="File"
+      Description="CPU sampling with large kernel buffers, wait analysis, and I/O (file logging)">
+      <ProblemCategories>
+        <ProblemCategory Value="CPU"/>
+        <ProblemCategory Value="IO"/>
+      </ProblemCategories>
+      <Collectors>
+        <SystemCollectorId Value="CpuWithLargeBuffers_SystemCollector">
+          <SystemProviderId Value="CpuWithLargeBuffers_SystemProvider"/>
+        </SystemCollectorId>
+      </Collectors>
+    </Profile>
+
+    <!-- Required Memory variant -->
+    <Profile
+      Id="CpuWithLargeBuffers.Verbose.Memory"
+      Name="CpuWithLargeBuffers"
+      DetailLevel="Verbose"
+      LoggingMode="Memory"
+      Description="CPU sampling with large kernel buffers, wait analysis, and I/O (memory logging)">
+      <ProblemCategories>
+        <ProblemCategory Value="CPU"/>
+        <ProblemCategory Value="IO"/>
+      </ProblemCategories>
+      <Collectors>
+        <SystemCollectorId Value="CpuWithLargeBuffers_SystemCollector">
+          <SystemProviderId Value="CpuWithLargeBuffers_SystemProvider"/>
+        </SystemCollectorId>
+      </Collectors>
+    </Profile>
+
+  </Profiles>
+</WindowsPerformanceRecorder>

--- a/utils/windows-profiling-tools/RunProfiler.ps1
+++ b/utils/windows-profiling-tools/RunProfiler.ps1
@@ -1,0 +1,171 @@
+#
+# RunProfiler.ps1 - runs a user-specified command while recording a system wide profile .etl file
+#
+# Example usage: .\RunProfiler.ps1 -Target S:\Path\To\example.exe -TracePath $env:USERPROFILE\example.etl <args to program>
+#
+# Also see docs/WindowsProfilingTools.md
+#
+
+param(
+    [string]$Target = ".\example.exe",
+    [string]$TracePath = "example_trace.etl",
+    [string]$SignalFile = "",
+    [switch]$ElevatedHelper,
+
+    [Parameter(Position = 4, ValueFromRemainingArguments = $true)]
+    [string[]]$TargetArgs
+)
+
+# Resolve script path (so we can re-invoke ourselves elevated and find CpuWithLargeBuffers.wprp)
+$scriptPath = $MyInvocation.MyCommand.Path
+if (-not $scriptPath) {
+    Write-Error "Cannot determine script path. Save this script to a .ps1 file first."
+    exit 1
+}
+
+function Wait-ForFile {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    $full = [System.IO.Path]::GetFullPath($Path)
+    $dir  = [System.IO.Path]::GetDirectoryName($full)
+    $file = [System.IO.Path]::GetFileName($full)
+
+    $fsw = New-Object System.IO.FileSystemWatcher
+    $fsw.Path = $dir
+    $fsw.Filter = $file
+    $fsw.NotifyFilter = [System.IO.NotifyFilters]'FileName'
+    $fsw.EnableRaisingEvents = $true
+
+    # Unique SourceIdentifier so multiple calls don't collide
+    $src = "FileCreated_$([guid]::NewGuid().ToString())"
+    $evt = Register-ObjectEvent -InputObject $fsw -EventName Created -SourceIdentifier $src
+
+    try {
+        if (Test-Path -LiteralPath $full) {
+            return
+        }
+
+        Wait-Event -SourceIdentifier $src | Out-Null
+    } finally {
+        Unregister-Event -SourceIdentifier $src -ErrorAction SilentlyContinue
+        $fsw.Dispose()
+    }
+}
+
+if ($ElevatedHelper) {
+    try {
+        # === Elevated helper branch (runs as Administrator) ===
+        Write-Host "[Elevated] Starting WPR collection..."
+
+        $wprp_file_path = Join-Path ([System.IO.Path]::GetDirectoryName($scriptPath)) "CpuAndWaitsWithLargeBuffers.wprp"
+        wpr -start "$wprp_file_path!CpuWithLargeBuffers" -filemode
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "[Elevated] Failed to start WPR. Exit code: $LASTEXITCODE"
+            exit $LASTEXITCODE
+        }
+
+        if (-not $SignalFile) {
+            Write-Error "[Elevated] No signal file specified; aborting."
+            exit 1
+        }
+
+        Write-Host "[Elevated] Waiting for signal file: $SignalFile"
+        Wait-ForFile -Path $SignalFile
+
+        # Clean up signal file (optional)
+        Remove-Item -LiteralPath $SignalFile -ErrorAction SilentlyContinue
+
+        Write-Host "[Elevated] Stopping WPR. Saving trace to: $TracePath"
+        wpr -stop "$TracePath"
+        $stopCode = $LASTEXITCODE
+        if ($stopCode -ne 0) {
+            Write-Error "[Elevated] wpr -stop failed with code: $stopCode"
+        } else {
+            Write-Host "[Elevated] Trace successfully saved to: $TracePath"
+        }
+
+        exit $stopCode
+    } finally {
+        Read-Host "Press Enter to close this window..."
+    }
+}
+
+# === Normal controller branch (runs as your user) ===
+
+# Make a unique signal file in %TEMP%
+if (-not $SignalFile) {
+    $SignalFile = Join-Path $env:TEMP ("wpr_stop_" + [guid]::NewGuid().ToString() + ".signal")
+}
+
+# Get an absolute path for the trace file
+$callerDir = (Get-Location -PSProvider FileSystem).ProviderPath
+$fullTracePath = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($callerDir, $TracePath))
+
+Write-Host "Trace will be saved to: $fullTracePath"
+Write-Host "Signal file: $SignalFile"
+Write-Host ""
+
+# Function to start elevated helper (one UAC prompt)
+function Start-ElevatedHelper {
+    param(
+        [string]$ScriptPath,
+        [string]$TracePath,
+        [string]$SignalFile
+    )
+
+    $escapedScript = $ScriptPath.Replace('"', '""')
+    $escapedTrace  = $TracePath.Replace('"', '""')
+    $escapedSignal = $SignalFile.Replace('"', '""')
+
+    $args = @(
+        "-NoProfile"
+        "-File"
+        "`"$escapedScript`""
+        "-ElevatedHelper"
+        "-TracePath"
+        "`"$escapedTrace`""
+        "-SignalFile"
+        "`"$escapedSignal`""
+    ) -join " "
+
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName = "powershell.exe"
+    $psi.Arguments = $args
+    $psi.Verb = "RunAs"          # <-- single UAC prompt here
+    $psi.UseShellExecute = $true
+
+    Write-Host "Requesting elevation for WPR helper..."
+    $p = [System.Diagnostics.Process]::Start($psi)
+    return $p
+}
+
+# 1. Start elevated helper (this will UAC-prompt once)
+$elevatedProc = Start-ElevatedHelper -ScriptPath $scriptPath -TracePath $fullTracePath -SignalFile $SignalFile
+if (-not $elevatedProc) {
+    Write-Error "Failed to start elevated helper process (user may have cancelled UAC)."
+    exit 1
+}
+
+# Optional: give WPR a moment to start
+Start-Sleep -Seconds 2
+
+# 2. Run target as normal user
+Write-Host "Running target: $Target"
+& $Target @TargetArgs
+$targetExit = $LASTEXITCODE
+Write-Host "Target exited with code: $targetExit"
+
+# 3. Signal elevated helper to stop WPR
+Write-Host "Signalling elevated helper to stop WPR..."
+New-Item -ItemType File -Path $SignalFile -Force | Out-Null
+
+# 4. Wait for helper to finish
+$elevatedProc.WaitForExit()
+Write-Host "Elevated helper exited with code: $($elevatedProc.ExitCode)"
+
+Write-Host ""
+Write-Host "Done. ETL trace should be at: $fullTracePath"
+exit $targetExit


### PR DESCRIPTION
Added starter documentation and a script for profiling the Swift compiler on Windows. Includes a comparison of different common Windows profiling tools and modes of usage, to give the reader options relevant to their circumstances. The included script simplifies profiling a compilation to a single command that logs traces of all processes involved.

This PR does not make any changes to Swift itself, its build tooling, etc.