### PR TITLE
[NFC-ish] Disable module selectors in CxxStdlib

### DIFF
--- a/Runtimes/Overlay/Cxx/std/CMakeLists.txt
+++ b/Runtimes/Overlay/Cxx/std/CMakeLists.txt
@@ -15,9 +15,10 @@ target_compile_options(swiftCxxStdlib PRIVATE
   "SHELL:-enable-experimental-feature AssumeResilientCxxTypes"
   # The varying modularization of the C++ standard library on different
   # platforms makes it difficult to enable MemberImportVisibility for this
-  # module
+  # module or qualify types with module names
   "SHELL:-disable-upcoming-feature MemberImportVisibility"
-  "SHELL:-Xfrontend -module-interface-preserve-types-as-written")
+  "SHELL:-Xfrontend -module-interface-preserve-types-as-written"
+  "SHELL:-Xfrontend -disable-module-selectors-in-module-interface")
 # NOTE: We need to setup the sysroot here as we need to ensure that we pick up
 # the module.map from the C++ runtime for the `std` (spelt `CxxStdlib`) import.
 target_compile_options(swiftCxxStdlib PRIVATE

--- a/stdlib/public/Cxx/std/CMakeLists.txt
+++ b/stdlib/public/Cxx/std/CMakeLists.txt
@@ -44,6 +44,7 @@ add_swift_target_library(swiftCxxStdlib STATIC NO_LINK_NAME IS_STDLIB IS_SWIFT_O
     SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
     -cxx-interoperability-mode=default
     -Xfrontend -module-interface-preserve-types-as-written
+    -Xfrontend -disable-module-selectors-in-module-interface
 
     # This flag is unnecessary when building with newer compilers that allow
     # using C++ symbols in resilient overlays (see f4204568).


### PR DESCRIPTION
The module interface for this module intentionally does not qualify its names, since the C++ standard library is modularized differently on different platforms. Make sure we don’t add module selectors to it.

This change is a no-op except in configurations where module selectors are on by default. We are currently testing such configurations before making them the default.