### PR TITLE
[stdlib] fix a pessimized bound

### DIFF
--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -399,7 +399,7 @@ extension MutableSpan where Element: ~Copyable {
     _ body: (UnsafeMutableBufferPointer<Element>) throws(E) -> Result
   ) throws(E) -> Result {
     let bytes = unsafe UnsafeMutableRawBufferPointer(
-      start: _pointer, count: _count
+      start: _pointer, count: _count &* MemoryLayout<Element>.stride
     )
     return try unsafe bytes.withMemoryRebound(to: Element.self) {
       buffer throws(E) -> Result in

--- a/stdlib/public/core/Span/OutputSpan.swift
+++ b/stdlib/public/core/Span/OutputSpan.swift
@@ -418,7 +418,7 @@ extension OutputSpan where Element: ~Copyable {
     ) throws(E) -> R
   ) throws(E) -> R {
     let bytes = unsafe UnsafeMutableRawBufferPointer(
-      start: _pointer, count: capacity
+      start: _pointer, count: capacity &* MemoryLayout<Element>.stride
     )
     var initializedCount = _count
     defer {

--- a/test/stdlib/Span/OutputRawSpanTests.swift
+++ b/test/stdlib/Span/OutputRawSpanTests.swift
@@ -19,7 +19,6 @@ import StdlibUnittest
 var suite = TestSuite("OutputRawSpan Tests")
 defer { runAllTests() }
 
-@available(SwiftStdlib 6.2, *)
 @safe
 private struct Allocation: ~Copyable {
   let allocation: UnsafeMutableRawBufferPointer
@@ -160,6 +159,27 @@ suite.test("deinitialize buffer")
   }
   catch {
     expectTrue(false)
+  }
+}
+
+suite.test("OutputRawSpan.withUnsafeBytes")
+.require(.stdlib_6_2).code {
+  let c = 49
+  var a = Allocation(byteCount: c)
+  a.initialize {
+    $0.withUnsafeMutableBytes {
+      expectEqual($0.count, c)
+      for i in $0.indices {
+        $0.storeBytes(of: UInt8(i), toByteOffset: i, as: UInt8.self)
+        $1 += 1
+      }
+    }
+  }
+  a.withSpan {
+    expectEqual($0.byteCount, c)
+    for i in $0.byteOffsets {
+      expectEqual($0.unsafeLoad(fromByteOffset: i, as: UInt8.self), UInt8(i))
+    }
   }
 }
 

--- a/test/stdlib/Span/OutputSpanTests.swift
+++ b/test/stdlib/Span/OutputSpanTests.swift
@@ -19,7 +19,6 @@ import StdlibUnittest
 var suite = TestSuite("OutputSpan Tests")
 defer { runAllTests() }
 
-@available(SwiftStdlib 6.2, *)
 struct Allocation<T>: ~Copyable {
   let allocation: UnsafeMutableBufferPointer<T>
   var count: Int? = nil
@@ -258,6 +257,27 @@ suite.test("InlineArray initialization throws")
     _ = a
   } catch {
     expectEqual(I.count, 0)
+  }
+}
+
+suite.test("OutputSpan.withUnsafeMutableBufferPointer")
+.require(.stdlib_6_2).code {
+  let c = 10
+  var a = Allocation(of: c, [Int].self)
+  a.initialize {
+    $0.withUnsafeMutableBufferPointer {
+      expectEqual($0.count, c)
+      for i in $0.indices {
+        $0.initializeElement(at: i, to: .init(repeating: i, count: i))
+        $1 += 1
+      }
+    }
+  }
+  a.withSpan {
+    expectEqual($0.count, c)
+    for i in $0.indices {
+      expectEqual($0[i], Array(repeating: i, count: i))
+    }
   }
 }
 

--- a/test/stdlib/Span/SpanTests.swift
+++ b/test/stdlib/Span/SpanTests.swift
@@ -440,29 +440,23 @@ suite.test("suffix extracting() functions")
 }
 
 suite.test("withUnsafeBufferPointer")
-.skip(.custom(
-  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
-  reason: "Requires Swift 6.2's standard library"
-))
-.code {
-  guard #available(SwiftStdlib 6.2, *) else { return }
-
-  let capacity: UInt8 = 64
-  let a = Array(0..<capacity)
-  a.withUnsafeBufferPointer {
-    ub in
-    let span = Span(_unsafeElements: ub)
+.require(.stdlib_6_2).code {
+  let capacity = 10
+  var a = ContiguousArray(0..<10)
+  a.withUnsafeMutableBufferPointer {
+    let span = Span(_unsafeElements: $0)
     span.withUnsafeBufferPointer {
-      let i = Int.random(in: 0..<$0.count)
-      expectEqual($0[i], ub[i])
+      expectEqual($0.count, capacity)
+      for i in $0.indices {
+        expectEqual($0[i], i)
+      }
     }
 
-    let emptyBuffer = UnsafeBufferPointer(rebasing: ub[0..<0])
-    expectEqual(emptyBuffer.baseAddress, ub.baseAddress)
-
+    let emptyBuffer = UnsafeBufferPointer(rebasing: $0[0..<0])
+    expectEqual(emptyBuffer.baseAddress, $0.baseAddress)
     let emptySpan = Span(_unsafeElements: emptyBuffer)
     emptySpan.withUnsafeBufferPointer {
-      expectTrue($0.isEmpty)
+      expectEqual($0.count, 0)
       expectNotNil($0.baseAddress)
     }
   }


### PR DESCRIPTION
In a [previous change](https://github.com/swiftlang/swift/pull/86435), the size of the buffers passed to the mutating closures was too small, while a test was missing and another used an inappropriate element type. This fixes those tests and fixes the bug.

Addresses rdar://169036911