### PR TITLE
ABIChecker: add -ignore-spi-group-new-api flag

### DIFF
--- a/include/swift/APIDigester/ModuleAnalyzerNodes.h
+++ b/include/swift/APIDigester/ModuleAnalyzerNodes.h
@@ -158,6 +158,7 @@ struct CheckerOptions {
   StringRef LocationFilter;
   std::vector<std::string> ToolArgs;
   llvm::StringSet<> SPIGroupNamesToIgnore;
+  llvm::StringSet<> SPIGroupNamesToIgnoreNewAPI;
 };
 
 class SDKContext {

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -2012,6 +2012,12 @@ def ignore_spi_groups : Separate<["-", "--"], "ignore-spi-group">,
   Flags<[NoDriverOption, SwiftAPIDigesterOption]>,
   HelpText<"SPI group name to not diagnose about">;
 
+def ignore_spi_groups_new_api
+    : Separate<["-", "--"], "ignore-spi-group-new-api">,
+      Flags<[NoDriverOption, SwiftAPIDigesterOption]>,
+      HelpText<"Suppress “new API without '@available’ diagnostic for given "
+               "SPI group name">;
+
 def protocol_requirement_allow_list: Separate<["-", "--"], "protocol-requirement-allow-list">,
   Flags<[NoDriverOption, SwiftAPIDigesterOption, ArgumentIsPath]>,
   HelpText<"File containing a new-line separated list of protocol names">,

--- a/test/api-digester/ignore-spi-group-new-api.swift
+++ b/test/api-digester/ignore-spi-group-new-api.swift
@@ -1,0 +1,39 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-module -o %t/Foo.swiftmodule -emit-abi-descriptor-path %t/abi-before.json %s -enable-library-evolution -DBASELINE -emit-tbd-path %t/abi-before.tbd -tbd-install_name Foo
+// RUN: %target-swift-frontend -emit-module -o %t/Foo.swiftmodule -emit-abi-descriptor-path %t/abi-after.json %s -enable-library-evolution -emit-tbd-path %t/abi-after.tbd -tbd-install_name Foo
+// RUN: %api-digester -diagnose-sdk --input-paths %t/abi-before.json -input-paths %t/abi-after.json -abi -o %t/include-result.txt
+// RUN: %FileCheck %s -check-prefix CHECK_INCLUDE_SPI < %t/include-result.txt
+
+// RUN: %api-digester -diagnose-sdk --input-paths %t/abi-before.json -input-paths %t/abi-after.json -abi -o %t/exclude-all-result.txt -ignore-spi-group secret
+// RUN: %FileCheck -check-prefix CHECK_EXCLUDE_ALL_SPI %s < %t/exclude-all-result.txt
+
+// RUN: %api-digester -diagnose-sdk --input-paths %t/abi-before.json -input-paths %t/abi-after.json -abi -o %t/exclude-new-api-result.txt -ignore-spi-group-new-api secret
+// RUN: %FileCheck -check-prefix CHECK_EXCLUDE_NEW_API %s < %t/exclude-new-api-result.txt
+
+#if BASELINE
+
+@_spi(secret)
+public func foo() {}
+
+#else
+
+public func bar() {}
+
+@_spi(secret)
+public func baz() {}
+
+#endif
+
+// CHECK_INCLUDE_SPI: Func foo() has been removed
+// CHECK_EXCLUDE_ALL_SPI-NOT: foo()
+// CHECK_EXCLUDE_NEW_API: Func foo() has been removed
+
+// CHECK_INCLUDE_SPI: Func bar() is a new API without '@available'
+// CHECK_EXCLUDE_ALL_SPI: Func bar() is a new API without '@available'
+// CHECK_EXCLUDE_NEW_API: Func bar() is a new API without '@available'
+
+// CHECK_INCLUDE_SPI: Func baz() is a new API without '@available'
+// CHECK_EXCLUDE_ALL_SPI-NOT: baz()
+// CHECK_EXCLUDE_NEW_API-NOT: baz()
+


### PR DESCRIPTION
Add a new -ignore-spi-group-new-api flag that selectively suppresses "new API without '@available'" diagnostics for specified SPI groups while still reporting ABI-breaking changes.

rdar://167702700

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
