### PR TITLE
[SILOptimizer] Update the inliner to account for different result ownerships

### DIFF
--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -617,9 +617,17 @@ void SILInlineCloner::cloneInline(ArrayRef<SILValue> AppliedArgs) {
         callerBlock->split(std::next(Apply.getInstruction()->getIterator()));
     endBorrowInsertPts.push_back(&*ReturnToBB->begin());
 
+    auto resultOwnership = OwnershipKind::Owned;
+
+    if (AI->hasGuaranteedResult()) {
+      resultOwnership = OwnershipKind::Guaranteed;
+    } else if (AI->hasAddressResult()) {
+      resultOwnership = OwnershipKind::None;
+    }
+
     // Create an argument on the return-to BB representing the returned value.
     auto *retArg =
-        ReturnToBB->createPhiArgument(AI->getType(), OwnershipKind::Owned);
+        ReturnToBB->createPhiArgument(AI->getType(), resultOwnership);
     // Replace all uses of the ApplyInst with the new argument.
     AI->replaceAllUsesWith(retArg);
     break;


### PR DESCRIPTION
Now that we have `@guaranteed`, `@guaranteed_address`, and `@inout` result conventions, account for that when making the phi argument for the result before we merge the basic blocks.