### PR TITLE
[Sema] Error when metadata is needed on non_runtime_protocol ObjC protocol

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7190,6 +7190,11 @@ ERROR(availability_variadic_type_only_version_newer, none,
       "parameter packs in generic types are only available in %0 %1 or newer",
       (AvailabilityDomain, AvailabilityRange))
 
+ERROR(non_runtime_protocol_requires_metadata, none,
+      "protocol '%0' has the 'objc_non_runtime_protocol' attribute and cannot "
+      "be used in a context that requires runtime protocol metadata",
+      (StringRef))
+
 NOTE(availability_guard_with_version_check, none,
      "add 'if #available' version check", ())
 

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -48,6 +48,7 @@
 #include "swift/Parse/Lexer.h"
 #include "swift/Parse/ParseDeclName.h"
 #include "swift/Sema/IDETypeChecking.h"
+#include "clang/AST/DeclObjC.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/SaveAndRestore.h"
@@ -2006,6 +2007,48 @@ static bool checkInverseGenericsCastingAvailability(Type srcType,
   return false;
 }
 
+/// Check if a protocol declaration is a non-runtime ObjC protocol.
+/// Returns the protocol name if it is, empty string otherwise.
+static StringRef getNonRuntimeProtocolName(const ProtocolDecl *proto) {
+  if (!proto)
+    return StringRef();
+  auto *clangDecl = proto->getClangDecl();
+  if (!clangDecl)
+    return StringRef();
+  auto *objcProto = dyn_cast<clang::ObjCProtocolDecl>(clangDecl);
+  if (!objcProto)
+    return StringRef();
+  if (!objcProto->isNonRuntimeProtocol())
+    return StringRef();
+  return proto->getName().str();
+}
+
+/// Diagnose the use of a non-runtime protocol in a context where metadata
+/// is required (e.g., dynamic casts, extended existential types).
+static bool diagnoseNonRuntimeProtocolMetadataUsage(CanType type,
+                                                    SourceRange refLoc,
+                                                    const DeclContext *refDC) {
+  ASTContext &ctx = refDC->getASTContext();
+
+  // findIf() walks into protocol compositions and existential types,
+  // so we only need to check for ProtocolType directly.
+  bool diagnosed = false;
+  type.findIf([&](CanType componentType) {
+    if (auto proto = dyn_cast<ProtocolType>(componentType)) {
+      StringRef protoName = getNonRuntimeProtocolName(proto->getDecl());
+      if (!protoName.empty()) {
+        ctx.Diags.diagnose(refLoc.Start,
+                           diag::non_runtime_protocol_requires_metadata,
+                           protoName);
+        diagnosed = true;
+        return true;
+      }
+    }
+    return false;
+  });
+  return diagnosed;
+}
+
 static bool checkTypeMetadataAvailabilityInternal(CanType type,
                                                   SourceRange refLoc,
                                                   const DeclContext *refDC) {
@@ -2467,6 +2510,9 @@ public:
                                       Where.getDeclContext());
         checkTypeMetadataAvailabilityForConverted(CE->getSubExpr()->getType(),
                                                   loc, Where.getDeclContext());
+        // Check for non-runtime protocol usage in dynamic casts
+        diagnoseNonRuntimeProtocolMetadataUsage(
+            CE->getCastType()->getCanonicalType(), loc, Where.getDeclContext());
       }
 
       diagnoseTypeAvailability(CE->getCastTypeRepr(), CE->getCastType(),

--- a/test/ClangImporter/Inputs/non_runtime_protocol.h
+++ b/test/ClangImporter/Inputs/non_runtime_protocol.h
@@ -1,0 +1,14 @@
+// This file is meant to be used with the mock SDK.
+#import <Foundation.h>
+
+__attribute__((objc_non_runtime_protocol))
+@protocol NonRuntimeBridging
+@end
+
+@protocol RegularProtocol
+@end
+
+// A second non-runtime protocol for testing compositions
+__attribute__((objc_non_runtime_protocol))
+@protocol AnotherNonRuntimeProtocol
+@end

--- a/test/ClangImporter/non_runtime_protocol.swift
+++ b/test/ClangImporter/non_runtime_protocol.swift
@@ -1,0 +1,67 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -import-objc-header %S/Inputs/non_runtime_protocol.h %s
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+// === ALLOWED CASES ===
+// Using non-runtime protocol in function signatures should be allowed
+// These usages don't require runtime protocol metadata
+
+@objc class AllowedUsages : NSObject {
+  // Using protocol in array type - allowed (no metadata needed for static type)
+  @objc public func runMutations(_ mutations: [NonRuntimeBridging]) {
+    for _ in mutations {
+    }
+  }
+
+  // Using protocol as parameter type - allowed
+  @objc public func processMutation(_ mutation: NonRuntimeBridging) {
+  }
+
+  // Using protocol as return type - allowed
+  @objc public func getMutation() -> NonRuntimeBridging? {
+    return nil
+  }
+}
+
+// Conforming to non-runtime protocol should be allowed
+class MyConformer : NonRuntimeBridging {
+}
+
+// Using protocol as generic constraint - allowed
+func genericFunc<T: NonRuntimeBridging>(_ value: T) {
+}
+
+// === DISALLOWED CASES ===
+// Using non-runtime protocol in contexts requiring runtime metadata should error
+
+func testDynamicCasts(_ obj: AnyObject) {
+  // Dynamic cast to non-runtime protocol - should error
+  let _ = obj as? NonRuntimeBridging // expected-error {{protocol 'NonRuntimeBridging' has the 'objc_non_runtime_protocol' attribute and cannot be used in a context that requires runtime protocol metadata}}
+
+  let _ = obj is NonRuntimeBridging // expected-error {{protocol 'NonRuntimeBridging' has the 'objc_non_runtime_protocol' attribute and cannot be used in a context that requires runtime protocol metadata}}
+
+  let _ = obj as! NonRuntimeBridging // expected-error {{protocol 'NonRuntimeBridging' has the 'objc_non_runtime_protocol' attribute and cannot be used in a context that requires runtime protocol metadata}}
+}
+
+// Test protocol composition with non-runtime protocol
+func testProtocolCompositionCasts(_ obj: AnyObject) {
+  // Composition containing non-runtime protocol should error
+  let _ = obj as? (NonRuntimeBridging & RegularProtocol) // expected-error {{protocol 'NonRuntimeBridging' has the 'objc_non_runtime_protocol' attribute and cannot be used in a context that requires runtime protocol metadata}}
+
+  let _ = obj is (NonRuntimeBridging & RegularProtocol) // expected-error {{protocol 'NonRuntimeBridging' has the 'objc_non_runtime_protocol' attribute and cannot be used in a context that requires runtime protocol metadata}}
+}
+
+// Test with multiple non-runtime protocols in composition
+func testMultipleNonRuntimeProtocols(_ obj: AnyObject) {
+  // Note: The order of protocols in composition may vary, so we check for either
+  let _ = obj as? (NonRuntimeBridging & AnotherNonRuntimeProtocol) // expected-error {{protocol 'AnotherNonRuntimeProtocol' has the 'objc_non_runtime_protocol' attribute and cannot be used in a context that requires runtime protocol metadata}}
+}
+
+// Regular protocols should still work fine with dynamic casts
+func testRegularProtocolCasts(_ obj: AnyObject) {
+  let _ = obj as? RegularProtocol
+  let _ = obj is RegularProtocol
+  let _ = obj as! RegularProtocol
+}


### PR DESCRIPTION

ObjC protocols with the non_runtime_protocol attribute could cause issues when used in Swift contexts that require runtime metadata.

This change adds diagnostics that error when the protocol's runtime metadata is actually needed (e.g., dynamic casts like as?, as!, is). By contrast, function signatures, for loops, and generic instantiations will not trigger errors since they don't require runtime protocol metadata.

