### PR TITLE
[lit] always use internal shell unless LIT_USE_INTERNAL_SHELL=0 is set

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -186,10 +186,12 @@ kIsAndroid = 'ANDROID_DATA' in os.environ
 
 # Choose between lit's internal shell pipeline runner and a real shell.  If
 # LIT_USE_INTERNAL_SHELL is in the environment, we use that as an override.
-use_lit_shell = os.environ.get('LIT_USE_INTERNAL_SHELL', kIsWindows or lit_config.update_tests)
+use_lit_shell = os.environ.get('LIT_USE_INTERNAL_SHELL', True)
 if not use_lit_shell:
     if lit_config.update_tests:
         lit_config.fatal('--update-tests cannot be combined with LIT_USE_INTERNAL_SHELL=0')
+    if kIsWindows:
+        lit_config.fatal('LIT_USE_INTERNAL_SHELL=0 is not supported on Windows')
     config.available_features.add('shell')
 
 config.test_format = swift_test.SwiftTest(coverage_mode=config.coverage_mode,


### PR DESCRIPTION
Now that all tests have been updated to be compatible with lit's internal shell (see https://github.com/swiftlang/swift/issues/84407), this flips the switch to enable the internal shell by default, as outlined in https://forums.swift.org/t/rfc-enabling-the-internal-shell-by-default-in-llvm-lit-tests/82148.

TL;DR: this should speed up testing, increase cross-platform compatibility in the test suite, and improve the quality of lit's test result output.

Thanks @ramonasuncion and @emirariemir for volunteering to the months of hard work to make this happen!

Resolves https://github.com/swiftlang/swift/issues/84407