### PR TITLE
[Concurrency] Diagnose more places where isolation on `main` is invalid

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6339,12 +6339,12 @@ static InferredActorIsolation computeActorIsolation(Evaluator &evaluator,
     std::optional<ActorIsolation> mainIsolation =
         getActorIsolationForMainFuncDecl(fd);
     if (mainIsolation) {
-      if (isolationFromAttr && isolationFromAttr->isGlobalActor()) {
-        if (!areTypesEqual(isolationFromAttr->getGlobalActor(),
-                           mainIsolation->getGlobalActor())) {
-          fd->getASTContext().Diags.diagnose(
-              fd->getLoc(), diag::main_function_must_be_mainActor);
-        }
+      // If an explicit attribute is anything other than `@MainActor`, complain.
+      if (isolationFromAttr &&
+          !(isolationFromAttr->isGlobalActor() &&
+            areTypesEqual(isolationFromAttr->getGlobalActor(),
+                          mainIsolation->getGlobalActor()))) {
+        fd->diagnose(diag::main_function_must_be_mainActor);
       }
       return {
         *mainIsolation,

--- a/test/Concurrency/async_main_invalid_isolation.swift
+++ b/test/Concurrency/async_main_invalid_isolation.swift
@@ -1,0 +1,26 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -parse-as-library %t/test1.swift -emit-sil -o /dev/null -verify
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -parse-as-library %t/test2.swift -emit-sil -o /dev/null -verify
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -parse-as-library %t/test3.swift -emit-sil -o /dev/null -verify
+
+// REQUIRES: concurrency
+
+//--- test1.swift
+@main
+struct TestNonisolated1 {
+  nonisolated static func main() async {} // expected-error{{main() must be '@MainActor'}}
+}
+
+//--- test2.swift
+@main
+struct TestNonisolated2 {
+  @concurrent static func main() async {} // expected-error{{main() must be '@MainActor'}}
+}
+
+//--- test3.swift
+@main
+struct TestNonisolated1 {
+  nonisolated(nonsending) static func main() async {} // expected-error{{main() must be '@MainActor'}}
+}


### PR DESCRIPTION
Previously only the use a global actor different from
`MainActor` was diagnosed, now any attempt to use an
explicit isolation attribute that differs from `@MainActor`
would be as well.


Resolves: https://github.com/swiftlang/swift/issues/83790
Resolves: rdar://158608620

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
