### PR TITLE
[Test][SourceKit] Remove REQUIRES: shell from no-driver-outputs

### DIFF
--- a/test/SourceKit/Misc/no-driver-outputs.swift
+++ b/test/SourceKit/Misc/no-driver-outputs.swift
@@ -1,5 +1,3 @@
-// REQUIRES: shell
-
 // RUN: %empty-directory(%t)
 // RUN: env TMPDIR=%t __XPC_TMPDIR=%t %sourcekitd-test -req=syntax-map %s 
 // RUN: ls %t/ | count 0


### PR DESCRIPTION
Partially address #84407 

```
#86876 fixed test/SourceKit/Misc/no-driver-outputs.swift
```