### PR TITLE
Prepare for strict enforcement of conditionally Escapable

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8460,9 +8460,7 @@ ERROR(lifetime_dependence_function_type, none,
 ERROR(lifetime_dependence_immortal_alone, none,
       "cannot specify any other dependence source along with immortal", ())
 ERROR(lifetime_dependence_invalid_inherit_escapable_type, none,
-      "cannot copy the lifetime of an Escapable type, use "
-      "'@_lifetime(%0%1)' instead",
-      (StringRef, StringRef))
+      "cannot copy the lifetime of an Escapable type", ())
 ERROR(lifetime_dependence_parsed_borrow_with_ownership, none,
       "invalid use of %0 dependence with %1 ownership",
       (StringRef, StringRef))
@@ -8481,6 +8479,8 @@ ERROR(lifetime_parameter_requires_inout, none,
       "lifetime-dependent parameter '%0' must be 'inout'", (StringRef))
 ERROR(lifetime_target_requires_nonescapable, none,
       "invalid lifetime dependence on an Escapable %0", (StringRef))
+NOTE(lifetime_escapable_source_requires_escapable_note, none,
+     "use '@_lifetime(%0%1)' instead", (StringRef, StringRef))
 
 //------------------------------------------------------------------------------
 // MARK: Lifetime Dependence Requirements

--- a/test/Sema/lifetime_attr.swift
+++ b/test/Sema/lifetime_attr.swift
@@ -104,17 +104,20 @@ func inoutLifetimeDependence(_ ne: inout NE) -> NE {
   ne
 }
 
-@_lifetime(copy k) // expected-error{{cannot copy the lifetime of an Escapable type, use '@_lifetime(&k)' instead}}
+@_lifetime(copy k) // expected-error{{cannot copy the lifetime of an Escapable type}}
+                   // expected-note@-1{{use '@_lifetime(&k)' instead}}
 func dependOnEscapable(_ k: inout Klass) -> NE {
   NE()
 }
 
-@_lifetime(copy k) // expected-error{{cannot copy the lifetime of an Escapable type, use '@_lifetime(borrow k)' instead}}
+@_lifetime(copy k) // expected-error{{cannot copy the lifetime of an Escapable type}}
+                   // expected-note@-1{{use '@_lifetime(borrow k)' instead}}
 func dependOnEscapable(_ k: borrowing Klass) -> NE { 
   NE()
 }
 
-@_lifetime(copy k) // expected-error{{invalid lifetime dependence on an Escapable value with consuming ownership}}
+@_lifetime(copy k) // expected-error{{cannot copy the lifetime of an Escapable type}}
+                   // expected-note@-1{{use '@_lifetime(borrow k)' instead}}
 func dependOnEscapable(_ k: consuming Klass) -> NE { 
   NE()
 }

--- a/test/Sema/lifetime_depend_infer.swift
+++ b/test/Sema/lifetime_depend_infer.swift
@@ -233,7 +233,8 @@ struct EscapableNonTrivialSelf {
   @_lifetime(self)
   func noParamLifetime_NEResult() -> NEImmortal { NEImmortal() }
 
-  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@_lifetime(borrow self)' instead}}
+  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type}}
+                        // expected-note@-1{{use '@_lifetime(borrow self)' instead}}
   func noParamCopy_NEResult() -> NEImmortal { NEImmortal() }
 
   @_lifetime(borrow self)
@@ -246,7 +247,8 @@ struct EscapableNonTrivialSelf {
   @_lifetime(self)
   mutating func mutating_noParamLifetime_NEResult() -> NEImmortal { NEImmortal() }
 
-  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@_lifetime(&self)' instead}}
+  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type}}
+                        // expected-note@-1{{use '@_lifetime(&self)' instead}}
   mutating func mutating_noParamCopy_NEResult() -> NEImmortal { NEImmortal() }
 
   @_lifetime(&self)
@@ -257,7 +259,8 @@ struct EscapableNonTrivialSelf {
   @_lifetime(self)
   func oneParamLifetime_NEResult(_: Int) -> NEImmortal { NEImmortal() }
 
-  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@_lifetime(borrow self)' instead}}
+  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type}}
+                        // expected-note@-1{{use '@_lifetime(borrow self)' instead}}
   func oneParamCopy_NEResult(_: Int) -> NEImmortal { NEImmortal() }
 
   @_lifetime(borrow self)
@@ -269,7 +272,8 @@ struct EscapableNonTrivialSelf {
   @_lifetime(self)
   mutating func mutating_oneParamLifetime_NEResult(_: Int) -> NEImmortal { NEImmortal() }
 
-  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@_lifetime(&self)' instead}}
+  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type}}
+                        // expected-note@-1{{use '@_lifetime(&self)' instead}}
   mutating func mutating_oneParamCopy_NEResult(_: Int) -> NEImmortal { NEImmortal() }
 
   @_lifetime(&self)
@@ -283,7 +287,8 @@ struct EscapableTrivialSelf {
   @_lifetime(self) // OK
   func noParamLifetime_NEResult() -> NEImmortal { NEImmortal() }
 
-  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@_lifetime(borrow self)' instead}}
+  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type}}
+                        // expected-note@-1{{use '@_lifetime(borrow self)' instead}}
   func noParamCopy_NEResult() -> NEImmortal { NEImmortal() }
 
   @_lifetime(borrow self) // OK
@@ -295,7 +300,8 @@ struct EscapableTrivialSelf {
   @_lifetime(self) // OK
   mutating func mutatingMethodNoParamLifetime_NEResult() -> NEImmortal { NEImmortal() }
 
-  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@_lifetime(&self)' instead}}
+  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type}}
+                        // expected-note@-1{{use '@_lifetime(&self)' instead}}
   mutating func mutatingMethodNoParamCopy_NEResult() -> NEImmortal { NEImmortal() }
 
   @_lifetime(&self)
@@ -307,7 +313,8 @@ struct EscapableTrivialSelf {
   @_lifetime(self)
   func oneParamLifetime_NEResult(_: Int) -> NEImmortal { NEImmortal() }
 
-  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@_lifetime(borrow self)' instead}}
+  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type}}
+                        // expected-note@-1{{use '@_lifetime(borrow self)' instead}}
   func oneParamCopy_NEResult(_: Int) -> NEImmortal { NEImmortal() }
 
   @_lifetime(borrow self)
@@ -319,7 +326,8 @@ struct EscapableTrivialSelf {
   @_lifetime(self)
   mutating func mutating_oneParamLifetime_NEResult(_: Int) -> NEImmortal { NEImmortal() }
 
-  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@_lifetime(&self)' instead}}
+  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type}}
+                        // expected-note@-1{{use '@_lifetime(&self)' instead}}
   mutating func mutating_oneParamCopy_NEResult(_: Int) -> NEImmortal { NEImmortal() }
 
   @_lifetime(&self)


### PR DESCRIPTION
- **Prepare for strict enforcement of conditionally Escapable**
  The only intended functional change is that a diagnostic message is split into
  an error and a note:
  
      error: cannot copy the lifetime of an Escapable type
      note: use '@_lifetime(borrow arg)' instead
  
  Reorganize the LifetimeDependenceChecker to support adding the functionality
  required for strict enforcement.
  
  Adds parameter index to ParamInfo.
  
  Adds a few (temporarily unused) helper methods.
  

- **Updates tests for lifetime diagnostic:**
      error: cannot copy the lifetime of an Escapable type
      note: use '@_lifetime(borrow arg)' instead
  