### PR TITLE
[cxx-interop] Fix lazy lookup for synthesized successor() method

### DIFF
--- a/lib/ClangImporter/ClangLookup.cpp
+++ b/lib/ClangImporter/ClangLookup.cpp
@@ -384,7 +384,8 @@ TinyPtrVector<ValueDecl *> ClangRecordMemberLookup::evaluate(
     if (name.isSimpleName("pointee")) {
       if (auto *pointee = Importer.Impl.lookupAndImportPointee(inheritingDecl))
         result.push_back(pointee);
-    } else if (name.isSimpleName("successor")) {
+    } else if (name.getBaseName() == "successor" &&
+               name.getArgumentNames().size() == 0) {
       if (auto *succ = Importer.Impl.lookupAndImportSuccessor(inheritingDecl))
         result.push_back(succ);
     }

--- a/test/Interop/Cxx/operators/operator-protocol-requirements-typechecker.swift
+++ b/test/Interop/Cxx/operators/operator-protocol-requirements-typechecker.swift
@@ -1,0 +1,34 @@
+// RUN: %target-typecheck-verify-swift \
+// RUN:   -suppress-warnings -suppress-notes \
+// RUN:   -I %S/Inputs -cxx-interoperability-mode=default
+
+import MemberInline
+
+protocol HasPointee { var pointee: CInt { get } }
+func reqPointee<T: HasPointee>(_ _: T) {}
+
+protocol HasSucc { func successor() -> Self }
+func reqSucc<T: HasSucc>(_ _: T) {}
+
+extension ClassWithOperatorStarAvailable : HasPointee {}
+extension ClassWithOperatorStarAvailable : HasSucc {} // expected-error {{does not conform to protocol}}
+
+extension DerivedClassWithOperatorStarAvailable : HasPointee {}
+extension DerivedClassWithOperatorStarAvailable : HasSucc {} // expected-error {{does not conform to protocol}}
+
+extension ClassWithOperatorStarUnavailable : HasPointee {} // expected-error {{does not conform to protocol}}
+                                                           // expected-error@-1 {{unavailable property}}
+extension ClassWithOperatorStarUnavailable : HasSucc {} // expected-error {{does not conform to protocol}}
+
+// FIXME: The below test should also fail with 'pointee' is unavailable in Swift error,
+// but currently pointee is not hidden in derived classes.
+extension DerivedClassWithOperatorStarUnavailable : HasPointee {} // FIXME-error {{does not conform to protocol}}
+                                                                  // FIXME-error@-1 {{unavailable property}}
+extension DerivedClassWithOperatorStarUnavailable : HasSucc {} // expected-error {{does not conform to protocol}}
+
+extension ClassWithSuccessorAvailable : HasPointee {} // expected-error {{does not conform to protocol}}
+extension ClassWithSuccessorAvailable : HasSucc {}
+
+extension ClassWithSuccessorUnavailable : HasPointee {} // expected-error {{does not conform to protocol}}
+extension ClassWithSuccessorUnavailable : HasSucc {} // expected-error {{does not conform to protocol}}
+                                                     // expected-error@-1 {{unavailable instance method}}


### PR DESCRIPTION
Protocol conformance checking requests a qualified name lookup of "successor()", not "successor", which is a compound name with zero arguments rather than a simple name.

Teach ClangRecordMemberLookup to be aware of this. Without accounting for this, protocol conformances will fail.

rdar://169217941