### PR TITLE
[Caching] Support -const-gather-protocols-file correctly

### DIFF
--- a/include/swift/ConstExtract/ConstExtract.h
+++ b/include/swift/ConstExtract/ConstExtract.h
@@ -22,7 +22,10 @@
 namespace llvm {
 class StringRef;
 class raw_fd_ostream;
-}
+namespace vfs{
+  class FileSystem;
+} // namespace vfs
+} // namespace llvm
 
 namespace swift {
 class SourceFile;
@@ -36,6 +39,7 @@ namespace swift {
 bool
 parseProtocolListFromFile(llvm::StringRef protocolListFilePath,
                           DiagnosticEngine &diags,
+                          llvm::vfs::FileSystem &fs,
                           std::unordered_set<std::string> &protocols);
 
 /// Gather compile-time-known values of properties in nominal type declarations

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -113,6 +113,11 @@ def block_list_file
     Flags<[FrontendOption, NoDriverOption, ArgumentIsPath]>,
     HelpText<"The path to a blocklist configuration file">;
 
+def const_gather_protocols_file
+  : Separate<["-"], "const-gather-protocols-file">, MetaVarName<"<path>">,
+    Flags<[FrontendOption, NoDriverOption, ArgumentIsPath]>,
+    HelpText<"Specify a list of protocols for extraction of conformances 'const values'">;
+
 let Flags = [FrontendOption, NoDriverOption] in {
 
 def triple : Separate<["-"], "triple">, Alias<target>;
@@ -272,10 +277,6 @@ def disable_cross_import_overlay_search: Flag<["-"], "disable-cross-import-overl
 def explicit_swift_module_map
   : Separate<["-"], "explicit-swift-module-map-file">, MetaVarName<"<path>">,
     HelpText<"Specify a JSON file containing information of explicit Swift modules">;
-
-def const_gather_protocols_file
-  : Separate<["-"], "const-gather-protocols-file">, MetaVarName<"<path>">,
-    HelpText<"Specify a list of protocols for extraction of conformances' const values'">;
 
 def import_prescan : Flag<["-"], "import-prescan">,
    HelpText<"When performing a dependency scan, only identify all imports of the main Swift module sources">;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -2023,6 +2023,11 @@ def protocol_requirement_allow_list: Separate<["-", "--"], "protocol-requirement
   HelpText<"File containing a new-line separated list of protocol names">,
   MetaVarName<"<path>">;
 
+def const_gather_protocols_list
+  : Separate<["-"], "const-gather-protocols-list">, MetaVarName<"<path>">,
+    Flags<[NewDriverOnlyOption, ArgumentIsPath]>,
+    HelpText<"Specify a list of protocols for extraction of conformances 'const values'">;
+
 def input_paths: Separate<["-", "--"], "input-paths">,
   Flags<[NoDriverOption, SwiftAPIDigesterOption, ArgumentIsPath]>,
   HelpText<"The SDK contents under comparison">,

--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -28,6 +28,7 @@
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/JSON.h"
+#include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Support/YAMLParser.h"
 #include "llvm/Support/YAMLTraits.h"
 
@@ -123,10 +124,10 @@ namespace swift {
 bool
 parseProtocolListFromFile(StringRef protocolListFilePath,
                           DiagnosticEngine &diags,
+                          llvm::vfs::FileSystem &fs,
                           std::unordered_set<std::string> &protocols) {
   // Load the input file.
-  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> FileBufOrErr =
-      llvm::MemoryBuffer::getFile(protocolListFilePath);
+  auto FileBufOrErr = fs.getBufferForFile(protocolListFilePath);
   if (!FileBufOrErr) {
     diags.diagnose(SourceLoc(),
                    diag::const_extract_protocol_list_input_file_missing,

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -483,6 +483,11 @@ SwiftDependencyTracker::SwiftDependencyTracker(
   StringRef AccessNotePath = CI.getLangOptions().AccessNotesPath;
   if (!AccessNotePath.empty())
     addCommonFile(AccessNotePath);
+
+  // const-gather-protocols-file
+  StringRef ConstProtocolFile = SearchPathOpts.ConstGatherProtocolListFilePath;
+  if (!ConstProtocolFile.empty())
+    addCommonFile(ConstProtocolFile);
 }
 
 void SwiftDependencyTracker::startTracking(bool includeCommonDeps) {

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -615,8 +615,9 @@ static bool emitConstValuesForWholeModuleIfNeeded(
   // List of protocols whose conforming nominal types
   // we should extract compile-time-known values from
   std::unordered_set<std::string> Protocols;
-  bool inputParseSuccess = parseProtocolListFromFile(constExtractProtocolListPath,
-                                                     Instance.getDiags(), Protocols);
+  bool inputParseSuccess = parseProtocolListFromFile(
+      constExtractProtocolListPath, Instance.getDiags(),
+      Instance.getFileSystem(), Protocols);
   if (!inputParseSuccess)
     return true;
   auto ConstValues = gatherConstValuesForModule(Protocols,
@@ -640,8 +641,9 @@ static void emitConstValuesForAllPrimaryInputsIfNeeded(
   // List of protocols whose conforming nominal types
   // we should extract compile-time-known values from
   std::unordered_set<std::string> Protocols;
-  bool inputParseSuccess = parseProtocolListFromFile(constExtractProtocolListPath,
-                                                     Instance.getDiags(), Protocols);
+  bool inputParseSuccess = parseProtocolListFromFile(
+      constExtractProtocolListPath, Instance.getDiags(),
+      Instance.getFileSystem(), Protocols);
   if (!inputParseSuccess)
     return;
   for (auto *SF : Instance.getPrimarySourceFiles()) {

--- a/test/CAS/const-protocol-values.swift
+++ b/test/CAS/const-protocol-values.swift
@@ -1,0 +1,22 @@
+// UNSUPPORTED: OS=windows-msvc
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   %t/main.swift -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas -const-gather-protocols-file %t/protocols.json \
+// RUN:   -scanner-prefix-map-paths %t /^tmp
+
+// RUN: %{python} %S/../../utils/swift-build-modules.py --cas %t/cas %swift_frontend_plain %t/deps.json -o %t/MyApp.cmd
+
+// RUN: %target-swift-frontend \
+// RUN:   -typecheck -cache-compile-job -cas-path %t/cas \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   -module-name Test -cache-replay-prefix-map /^tmp %t -const-gather-protocols-file /^tmp/protocols.json \
+// RUN:   /^tmp/main.swift @%t/MyApp.cmd -emit-const-values-path %t/main.module.swiftconstvalues
+
+//--- main.swift
+print("Hello")
+
+//--- protocols.json
+["Foo"]


### PR DESCRIPTION
Previously, const-values output is not supported correctly as it is not captured correctly as a dependency. The load of the input JSON file is loaded via file system directly, that can cause issues like:
* False cache hit when the file is changed
* Cannot be prefix mapped to allow distributed caching

Try to support the input file by:
* Correctly capture the input
* Create a new driver flag `-const-gather-protocols-list` that can do path remapping correctly in swift-driver

rdar://169109358

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
