### PR TITLE
[Test][stdlib] Remove REQUIRES shell directive from MirrorWithPacks

### DIFF
--- a/test/stdlib/MirrorWithPacks.swift
+++ b/test/stdlib/MirrorWithPacks.swift
@@ -16,7 +16,6 @@
 // RUN: %target-run %t/Mirror
 
 // REQUIRES: executable_test
-// REQUIRES: shell
 // REQUIRES: reflection
 
 // rdar://96439408


### PR DESCRIPTION
Partially address #84407 

```
#86882 fixed test/stdlib/MirrorWithPacks.swift
```