### PR TITLE
CHANGELOG: Explain that objc bridging is using Task.immediate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 
 ## Swift (next)
 
+* Calling from Objective-C into into asynchronous Swift APIs will now attempt use `Task.immediate`
+  instead of `Task` when available. This reduces the initial enqueue delay which Task would incur
+  (by enqueueing on the global pool before calling the async target), and can improve performance
+  and ordering predictability of calling async code through these bridged APIs.
+
 * The raw span accessor properties of `Span` and `MutableSpan` (`bytes` and
   `mutableBytes`) as well as the two generic `append()` methods of
   `OutputRawSpan` are newly marked with `@unsafe`. These changes are corrections


### PR DESCRIPTION
Explain the semantic change made in https://github.com/swiftlang/swift/pull/86807

It's good to explain it in the changelog since its a behavior change

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
