### PR TITLE
[cxx-interop] Import macro-declared `CF_OPTIONS` enums correctly

### DIFF
--- a/test/Interop/Cxx/enum/Inputs/c-enums-withOptions-omit.h
+++ b/test/Interop/Cxx/enum/Inputs/c-enums-withOptions-omit.h
@@ -52,6 +52,14 @@ typedef CF_OPTIONS(NSUInteger, UITableViewScrollPosition) {
   UITableViewScrollPosition1,
   UITableViewScrollPosition2
 };
+
+#define TEST(X) MacroPrefix##X
+
+typedef CF_OPTIONS(NSUInteger, TEST(Enum)) {
+  MacroPrefixEnumFoo = (1 << 0),
+  MacroPrefixEnumBar = (1 << 1),
+};
+
 @interface NSIndexPath
 @end
 

--- a/test/Interop/Cxx/enum/c-enums-withOptions-omit.swift
+++ b/test/Interop/Cxx/enum/c-enums-withOptions-omit.swift
@@ -8,6 +8,9 @@ import CenumsWithOptionsOmit
 // CHECK-NEXT: func enumerateObjects(options
 // CHECK-NEXT: @available(swift, obsoleted: 3, renamed: "enumerateObjects(options:)")
 
+// CHECK-NOT: typealias MacroPrefixEnum
+// CHECK: struct MacroPrefixEnum : OptionSet
+
 // CHECK: class TestsForEnhancedOmitNeedlessWords {
 
 // Tests for withOptions -> 'with options'


### PR DESCRIPTION
This makes sure that Swift correctly imports `CF_OPTIONS`/`NS_OPTIONS` types in C++ interop mode, such as:
```
typedef CF_OPTIONS(NSUInteger, TEST(Enum))
```

`CF_OPTIONS`/`NS_OPTIONS` macros have different expansions in C++ language mode, which forces us to have extra logic to handle them correctly with C++ interop enabled.

rdar://166528719

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
