### PR TITLE
[IRGenSIL][DebugInfo] Extend lifetime of variables in coroutines

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -791,6 +791,8 @@ public:
     return LoweredType->isCalleeAllocatedCoroutine();
   }
 
+  bool isCoroutine() const { return LoweredType->isCoroutine(); }
+
   /// Returns the calling convention used by this entry point.
   SILFunctionTypeRepresentation getRepresentation() const {
     return getLoweredFunctionType()->getRepresentation();

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1032,7 +1032,8 @@ public:
 
     // Mark variables in async functions that don't generate a shadow copy for
     // lifetime extension, so they get spilled into the async context.
-    if (!IGM.IRGen.Opts.shouldOptimize() && CurSILFn->isAsync())
+    if (!IGM.IRGen.Opts.shouldOptimize() &&
+        (CurSILFn->isAsync() || CurSILFn->isCoroutine()))
       if (isa<llvm::AllocaInst>(Storage)) {
         if (emitLifetimeExtendingUse(Storage))
           if (ValueVariables.insert(Storage).second)
@@ -1052,7 +1053,8 @@ public:
 
     // Mark variables in async functions for lifetime extension, so they get
     // spilled into the async context.
-    if (!IGM.IRGen.Opts.shouldOptimize() && CurSILFn->isAsync()) {
+    if (!IGM.IRGen.Opts.shouldOptimize() &&
+        (CurSILFn->isAsync() || CurSILFn->isCoroutine())) {
       if (emitLifetimeExtendingUse(shadow)) {
         if (ValueVariables.insert(shadow).second)
           ValueDomPoints.push_back({shadow, getActiveDominancePoint()});
@@ -1088,7 +1090,8 @@ public:
 
       // Mark variables in async functions for lifetime extension, so they get
       // spilled into the async context.
-      if (!IGM.IRGen.Opts.shouldOptimize() && CurSILFn->isAsync())
+      if (!IGM.IRGen.Opts.shouldOptimize() &&
+          (CurSILFn->isAsync() || CurSILFn->isCoroutine()))
         if (vals.begin() != vals.end()) {
           auto Value = vals.front();
           if (isa<llvm::Instruction>(Value) || isa<llvm::Argument>(Value))

--- a/test/DebugInfo/yielding_mutate.swift
+++ b/test/DebugInfo/yielding_mutate.swift
@@ -26,4 +26,18 @@ var state = S()
 USE(&state.computed_property)
 FINISH()
 // CHECK: call swiftcc void @"{{.*}}FINISH
-// CHECK: ![[DBG]] = !DILocation(line: [[@LINE-3]],
+
+
+// CHECK-LABEL: define {{.*}} @{{.*}}computed_property
+// CHECK-SAME:  ptr swiftself {{.*}} %[[self:.*]])
+// CHECK: %[[self_alloca:.*]] = alloca ptr
+// CHECK: #dbg_declare(ptr %[[self_alloca]], ![[SELF_DBG:.*]], !DIExpression(DW_OP_deref)
+// CHECK: call {{.*}} @llvm.coro.begin
+// CHECK: store ptr %[[self]], ptr %[[self_alloca]]
+// CHECK: call void asm sideeffect "", "r"(ptr %[[self_alloca]])
+// CHECK: call {{.*}} @llvm.coro.suspend.retcon
+// CHECK: call void asm sideeffect "", "r"(ptr %[[self_alloca]])
+// CHECK: call {{.*}} @llvm.coro.end
+
+
+// CHECK: ![[DBG]] = !DILocation(line: [[@LINE-17]],


### PR DESCRIPTION
Depends on https://github.com/swiftlang/swift/pull/86810
Please review only the last commit.

Just like in async functions, coroutines will go through the CoroSplit
flow. As such, variables in O0 need to go through the same treatment
they undergo for async functions: an `asm` directive is emitted so to
create a use of the variable after each split point.
