### PR TITLE
Typed Throws Adoption for Several Dictionary APIs

### DIFF
--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -1171,15 +1171,35 @@ extension Dictionary {
   ///     dictionary.
   /// - Returns: A new dictionary with the combined keys and values of this
   ///   dictionary and `other`.
-  @inlinable
-  public __consuming func merging<S: Sequence>(
+  @_alwaysEmitIntoClient
+  public __consuming func merging<S: Sequence, E: Error>(
     _ other: __owned S,
-    uniquingKeysWith combine: (Value, Value) throws -> Value
-  ) rethrows -> [Key: Value] where S.Element == (Key, Value) {
+    uniquingKeysWith combine: (Value, Value) throws(E) -> Value
+  ) throws(E) -> [Key: Value] where S.Element == (Key, Value) {
     var result = self
     try result._variant.merge(other, uniquingKeysWith: combine)
     return result
   }
+
+#if !$Embedded
+  // ABI-only entrypoint for the rethrows version of merging, which has been
+  // superseded by the typed-throws version. Expressed as "throws", which is
+  // ABI-compatible with "rethrows".
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @usableFromInline
+  @abi(
+    __consuming func merging<S: Sequence>(
+      _ other: __owned S,
+      uniquingKeysWith combine: (Value, Value) throws -> Value
+    ) rethrows -> [Key: Value] where S.Element == (Key, Value)
+  )
+  internal __consuming func __rethrows_merging<S: Sequence>(
+    _ other: __owned S,
+    uniquingKeysWith combine: (Value, Value) throws -> Value
+  ) throws -> [Key: Value] where S.Element == (Key, Value) {
+    try merging(other, uniquingKeysWith: combine)
+  }
+#endif
 
   /// Creates a dictionary by merging the given dictionary into this
   /// dictionary, using a combining closure to determine the value for
@@ -1211,15 +1231,35 @@ extension Dictionary {
   ///     dictionary.
   /// - Returns: A new dictionary with the combined keys and values of this
   ///   dictionary and `other`.
-  @inlinable
-  public __consuming func merging(
+  @_alwaysEmitIntoClient
+  public __consuming func merging<E: Error>(
     _ other: __owned [Key: Value],
-    uniquingKeysWith combine: (Value, Value) throws -> Value
-  ) rethrows -> [Key: Value] {
+    uniquingKeysWith combine: (Value, Value) throws(E) -> Value
+  ) throws(E) -> [Key: Value] {
     var result = self
     try result.merge(other, uniquingKeysWith: combine)
     return result
   }
+
+#if !$Embedded
+  // ABI-only entrypoint for the rethrows version of merging, which has been
+  // superseded by the typed-throws version. Expressed as "throws", which is
+  // ABI-compatible with "rethrows".
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @usableFromInline
+  @abi(
+    __consuming func merging(
+      _ other: __owned [Key: Value],
+      uniquingKeysWith combine: (Value, Value) throws -> Value
+    ) rethrows -> [Key: Value]
+  )
+  internal __consuming func __rethrows_merging_dictionary(
+    _ other: __owned [Key: Value],
+    uniquingKeysWith combine: (Value, Value) throws -> Value
+  ) throws -> [Key: Value] {
+    try merging(other, uniquingKeysWith: combine)
+  }
+#endif
 
   /// Removes and returns the key-value pair at the specified index.
   ///

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -926,12 +926,30 @@ extension Dictionary {
   ///   this dictionary.
   ///
   /// - Complexity: O(*n*), where *n* is the length of the dictionary.
-  @inlinable
-  public func mapValues<T>(
-    _ transform: (Value) throws -> T
-  ) rethrows -> Dictionary<Key, T> {
+  @_alwaysEmitIntoClient
+  public func mapValues<T, E: Error>(
+    _ transform: (Value) throws(E) -> T
+  ) throws(E) -> Dictionary<Key, T> {
     return try Dictionary<Key, T>(_native: _variant.mapValues(transform))
   }
+
+#if !$Embedded
+  // ABI-only entrypoint for the rethrows version of mapValues, which has been
+  // superseded by the typed-throws version. Expressed as "throws", which is
+  // ABI-compatible with "rethrows".
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @usableFromInline
+  @abi(
+    func mapValues<T>(
+      _ transform: (Value) throws -> T
+    ) rethrows -> Dictionary<Key, T>
+  )
+  internal func __rethrows_mapValues<T>(
+    _ transform: (Value) throws -> T
+  ) throws -> Dictionary<Key, T> {
+    try mapValues(transform)
+  }
+#endif
 
   /// Returns a new dictionary containing only the key-value pairs that have
   /// non-`nil` values as the result of transformation by the given closure.

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -531,13 +531,13 @@ public struct Dictionary<Key: Hashable, Value> {
   // superseded by the typed-throws version. Expressed as "throws", which is
   // ABI-compatible with "rethrows".
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-  @usableFromInline
   @abi(
     init<S: Sequence>(
       _ keysAndValues: __owned S,
       uniquingKeysWith combine: (Value, Value) throws -> Value
-    ) rethrows where S.Element == (Key, Value)
+    ) throws where S.Element == (Key, Value)
   )
+  @usableFromInline
   internal init<S: Sequence>(
     __rethrows_keysAndValues keysAndValues: __owned S,
     uniquingKeysWith combine: (Value, Value) throws -> Value
@@ -581,13 +581,13 @@ public struct Dictionary<Key: Hashable, Value> {
   // superseded by the typed-throws version. Expressed as "throws", which is
   // ABI-compatible with "rethrows".
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-  @usableFromInline
   @abi(
     init<S: Sequence>(
       grouping values: __owned S,
       by keyForValue: (S.Element) throws -> Key
-    ) rethrows where Value == [S.Element]
+    ) throws where Value == [S.Element]
   )
+  @usableFromInline
   internal init<S: Sequence>(
     __rethrows_grouping values: __owned S,
     by keyForValue: (S.Element) throws -> Key
@@ -960,12 +960,12 @@ extension Dictionary {
   // superseded by the typed-throws version. Expressed as "throws", which is
   // ABI-compatible with "rethrows".
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-  @usableFromInline
   @abi(
     func mapValues<T>(
       _ transform: (Value) throws -> T
-    ) rethrows -> Dictionary<Key, T>
+    ) throws -> Dictionary<Key, T>
   )
+  @usableFromInline
   internal func __rethrows_mapValues<T>(
     _ transform: (Value) throws -> T
   ) throws -> Dictionary<Key, T> {
@@ -1094,13 +1094,13 @@ extension Dictionary {
   // superseded by the typed-throws version. Expressed as "throws", which is
   // ABI-compatible with "rethrows".
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-  @usableFromInline
   @abi(
     mutating func merge<S: Sequence>(
       _ other: __owned S,
       uniquingKeysWith combine: (Value, Value) throws -> Value
-    ) rethrows where S.Element == (Key, Value)
+    ) throws where S.Element == (Key, Value)
   )
+  @usableFromInline
   internal mutating func __rethrows_merge<S: Sequence>(
     _ other: __owned S,
     uniquingKeysWith combine: (Value, Value) throws -> Value
@@ -1150,13 +1150,13 @@ extension Dictionary {
   // superseded by the typed-throws version. Expressed as "throws", which is
   // ABI-compatible with "rethrows".
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-  @usableFromInline
   @abi(
     mutating func merge(
       _ other: __owned [Key: Value],
       uniquingKeysWith combine: (Value, Value) throws -> Value
-    ) rethrows
+    ) throws
   )
+  @usableFromInline
   internal mutating func __rethrows_merge_dictionary(
     _ other: __owned [Key: Value],
     uniquingKeysWith combine: (Value, Value) throws -> Value
@@ -1208,13 +1208,13 @@ extension Dictionary {
   // superseded by the typed-throws version. Expressed as "throws", which is
   // ABI-compatible with "rethrows".
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-  @usableFromInline
   @abi(
     __consuming func merging<S: Sequence>(
       _ other: __owned S,
       uniquingKeysWith combine: (Value, Value) throws -> Value
-    ) rethrows -> [Key: Value] where S.Element == (Key, Value)
+    ) throws -> [Key: Value] where S.Element == (Key, Value)
   )
+  @usableFromInline
   internal __consuming func __rethrows_merging<S: Sequence>(
     _ other: __owned S,
     uniquingKeysWith combine: (Value, Value) throws -> Value
@@ -1268,13 +1268,13 @@ extension Dictionary {
   // superseded by the typed-throws version. Expressed as "throws", which is
   // ABI-compatible with "rethrows".
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-  @usableFromInline
   @abi(
     __consuming func merging(
       _ other: __owned [Key: Value],
       uniquingKeysWith combine: (Value, Value) throws -> Value
-    ) rethrows -> [Key: Value]
+    ) throws -> [Key: Value]
   )
+  @usableFromInline
   internal __consuming func __rethrows_merging_dictionary(
     _ other: __owned [Key: Value],
     uniquingKeysWith combine: (Value, Value) throws -> Value

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -481,15 +481,7 @@ public struct Dictionary<Key: Hashable, Value> {
     }
     var native = _NativeDictionary<Key, Value>(
       capacity: keysAndValues.underestimatedCount)
-    // '_MergeError.keyCollision' is caught and handled with an appropriate
-    // error message one level down, inside native.merge(_:...). We throw an
-    // error instead of calling fatalError() directly because we want the
-    // message to include the duplicate key, and the closure only has access to
-    // the conflicting values.
-    try! native.merge(
-      keysAndValues,
-      isUnique: true,
-      uniquingKeysWith: { _, _ in throw _MergeError.keyCollision })
+    native.merge(trappingOnDuplicates: keysAndValues)
     self.init(_native: native)
   }
 

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -1059,13 +1059,33 @@ extension Dictionary {
   ///   - combine: A closure that takes the current and new values for any
   ///     duplicate keys. The closure returns the desired value for the final
   ///     dictionary.
-  @inlinable
-  public mutating func merge<S: Sequence>(
+  @_alwaysEmitIntoClient
+  public mutating func merge<S: Sequence, E: Error>(
     _ other: __owned S,
-    uniquingKeysWith combine: (Value, Value) throws -> Value
-  ) rethrows where S.Element == (Key, Value) {
+    uniquingKeysWith combine: (Value, Value) throws(E) -> Value
+  ) throws(E) where S.Element == (Key, Value) {
     try _variant.merge(other, uniquingKeysWith: combine)
   }
+
+#if !$Embedded
+  // ABI-only entrypoint for the rethrows version of merge, which has been
+  // superseded by the typed-throws version. Expressed as "throws", which is
+  // ABI-compatible with "rethrows".
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @usableFromInline
+  @abi(
+    mutating func merge<S: Sequence>(
+      _ other: __owned S,
+      uniquingKeysWith combine: (Value, Value) throws -> Value
+    ) rethrows where S.Element == (Key, Value)
+  )
+  internal mutating func __rethrows_merge<S: Sequence>(
+    _ other: __owned S,
+    uniquingKeysWith combine: (Value, Value) throws -> Value
+  ) throws where S.Element == (Key, Value) {
+    try merge(other, uniquingKeysWith: combine)
+  }
+#endif
 
   /// Merges the given dictionary into this dictionary, using a combining
   /// closure to determine the value for any duplicate keys.
@@ -1094,14 +1114,34 @@ extension Dictionary {
   ///   - combine: A closure that takes the current and new values for any
   ///     duplicate keys. The closure returns the desired value for the final
   ///     dictionary.
-  @inlinable
-  public mutating func merge(
+  @_alwaysEmitIntoClient
+  public mutating func merge<E: Error>(
     _ other: __owned [Key: Value],
-    uniquingKeysWith combine: (Value, Value) throws -> Value
-  ) rethrows {
+    uniquingKeysWith combine: (Value, Value) throws(E) -> Value
+  ) throws(E) {
     try _variant.merge(
       other.lazy.map { ($0, $1) }, uniquingKeysWith: combine)
   }
+
+#if !$Embedded
+  // ABI-only entrypoint for the rethrows version of merge, which has been
+  // superseded by the typed-throws version. Expressed as "throws", which is
+  // ABI-compatible with "rethrows".
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @usableFromInline
+  @abi(
+    mutating func merge(
+      _ other: __owned [Key: Value],
+      uniquingKeysWith combine: (Value, Value) throws -> Value
+    ) rethrows
+  )
+  internal mutating func __rethrows_merge_dictionary(
+    _ other: __owned [Key: Value],
+    uniquingKeysWith combine: (Value, Value) throws -> Value
+  ) throws {
+    try merge(other, uniquingKeysWith: combine)
+  }
+#endif
 
   /// Creates a dictionary by merging key-value pairs in a sequence into the
   /// dictionary, using a combining closure to determine the value for

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -486,20 +486,10 @@ public struct Dictionary<Key: Hashable, Value> {
     // error instead of calling fatalError() directly because we want the
     // message to include the duplicate key, and the closure only has access to
     // the conflicting values.
-    #if !$Embedded
     try! native.merge(
       keysAndValues,
       isUnique: true,
       uniquingKeysWith: { _, _ in throw _MergeError.keyCollision })
-    #else
-    native.merge(
-      keysAndValues,
-      isUnique: true,
-      uniquingKeysWith: { _, _ throws(_MergeError) in
-        throw _MergeError.keyCollision
-      }
-    )
-    #endif
     self.init(_native: native)
   }
 

--- a/stdlib/public/core/DictionaryBridging.swift
+++ b/stdlib/public/core/DictionaryBridging.swift
@@ -572,21 +572,23 @@ extension __CocoaDictionary {
     return result
   }
 
+#if !$Embedded
   // ABI-only entrypoint for the rethrows version of mapValues, which has been
   // superseded by the typed-throws version. Expressed as "throws", which is
   // ABI-compatible with "rethrows".
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-  @usableFromInline
   @abi(
     func mapValues<Key: Hashable, Value, T>(
       _ transform: (Value) throws -> T
-    ) rethrows -> _NativeDictionary<Key, T>
+    ) throws -> _NativeDictionary<Key, T>
   )
+  @usableFromInline
   internal func __rethrows_mapValues<Key: Hashable, Value, T>(
     _ transform: (Value) throws -> T
   ) throws -> _NativeDictionary<Key, T> {
     try mapValues(transform)
   }
+#endif
 }
 
 extension __CocoaDictionary {

--- a/stdlib/public/core/DictionaryBridging.swift
+++ b/stdlib/public/core/DictionaryBridging.swift
@@ -559,10 +559,10 @@ extension __CocoaDictionary: _DictionaryBuffer {
 }
 
 extension __CocoaDictionary {
-  @inlinable
-  internal func mapValues<Key: Hashable, Value, T>(
-    _ transform: (Value) throws -> T
-  ) rethrows -> _NativeDictionary<Key, T> {
+  @_alwaysEmitIntoClient
+  internal func mapValues<Key: Hashable, Value, T, E: Error>(
+    _ transform: (Value) throws(E) -> T
+  ) throws(E) -> _NativeDictionary<Key, T> {
     var result = _NativeDictionary<Key, T>(capacity: self.count)
     for (cocoaKey, cocoaValue) in self {
       let key = _forceBridgeFromObjectiveC(cocoaKey, Key.self)
@@ -570,6 +570,22 @@ extension __CocoaDictionary {
       try result.insertNew(key: key, value: transform(value))
     }
     return result
+  }
+
+  // ABI-only entrypoint for the rethrows version of mapValues, which has been
+  // superseded by the typed-throws version. Expressed as "throws", which is
+  // ABI-compatible with "rethrows".
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @usableFromInline
+  @abi(
+    func mapValues<Key: Hashable, Value, T>(
+      _ transform: (Value) throws -> T
+    ) rethrows -> _NativeDictionary<Key, T>
+  )
+  internal func __rethrows_mapValues<Key: Hashable, Value, T>(
+    _ transform: (Value) throws -> T
+  ) throws -> _NativeDictionary<Key, T> {
+    try mapValues(transform)
   }
 }
 

--- a/stdlib/public/core/DictionaryBridging.swift
+++ b/stdlib/public/core/DictionaryBridging.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/DictionaryVariant.swift
+++ b/stdlib/public/core/DictionaryVariant.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/DictionaryVariant.swift
+++ b/stdlib/public/core/DictionaryVariant.swift
@@ -469,12 +469,12 @@ extension Dictionary._Variant {
   // superseded by the typed-throws version. Expressed as "throws", which is
   // ABI-compatible with "rethrows".
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-  @usableFromInline
   @abi(
     func mapValues<T>(
       _ transform: (Value) throws -> T
-    ) rethrows -> _NativeDictionary<Key, T>
+    ) throws -> _NativeDictionary<Key, T>
   )
+  @usableFromInline
   internal func __rethrows_mapValues<T>(
     _ transform: (Value) throws -> T
   ) throws -> _NativeDictionary<Key, T> {
@@ -510,13 +510,13 @@ extension Dictionary._Variant {
   // superseded by the typed-throws version. Expressed as "throws", which is
   // ABI-compatible with "rethrows".
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-  @usableFromInline
   @abi(
     mutating func merge<S: Sequence>(
       _ keysAndValues: __owned S,
       uniquingKeysWith combine: (Value, Value) throws -> Value
-    ) rethrows where S.Element == (Key, Value)
+    ) throws where S.Element == (Key, Value)
   )
+  @usableFromInline
   internal mutating func __rethrows_merge<S: Sequence>(
     _ keysAndValues: __owned S,
     uniquingKeysWith combine: (Value, Value) throws -> Value

--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -843,35 +843,6 @@ extension _NativeDictionary { // High-level operations
   }
 #endif
 
-  #if $Embedded
-  @inlinable
-  internal mutating func merge<S: Sequence>(
-    _ keysAndValues: __owned S,
-    isUnique: Bool,
-    uniquingKeysWith combine: (Value, Value) throws(_MergeError) -> Value
-  ) where S.Element == (Key, Value) {
-    var isUnique = isUnique
-    for (key, value) in keysAndValues {
-      let (bucket, found) = mutatingFind(key, isUnique: isUnique)
-      isUnique = true
-      if found {
-        do throws(_MergeError) {
-          let newValue = try combine(unsafe uncheckedValue(at: bucket), value)
-          unsafe _values[bucket.offset] = newValue
-        } catch {
-          #if !$Embedded
-          fatalError("Duplicate values for key: '\(key)'")
-          #else
-          fatalError("Duplicate values for a key in a Dictionary")
-          #endif
-        }
-      } else {
-        _insert(at: bucket, key: key, value: value)
-      }
-    }
-  }
-  #endif
-
   @_alwaysEmitIntoClient
   @inline(__always)
   internal init<S: Sequence, E: Error>(

--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -778,12 +778,12 @@ extension _NativeDictionary { // High-level operations
   // superseded by the typed-throws version. Expressed as "throws", which is
   // ABI-compatible with "rethrows".
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-  @usableFromInline
   @abi(
     func mapValues<T>(
       _ transform: (Value) throws -> T
-    ) rethrows -> _NativeDictionary<Key, T>
+    ) throws -> _NativeDictionary<Key, T>
   )
+  @usableFromInline
   internal func __rethrows_mapValues<T>(
     _ transform: (Value) throws -> T
   ) throws -> _NativeDictionary<Key, T> {
@@ -835,14 +835,14 @@ extension _NativeDictionary { // High-level operations
   // superseded by the typed-throws version. Expressed as "throws", which is
   // ABI-compatible with "rethrows".
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-  @usableFromInline
   @abi(
     mutating func merge<S: Sequence>(
       _ keysAndValues: __owned S,
       isUnique: Bool,
       uniquingKeysWith combine: (Value, Value) throws -> Value
-    ) rethrows where S.Element == (Key, Value)
+    ) throws where S.Element == (Key, Value)
   )
+  @usableFromInline
   internal mutating func __rethrows_merge<S: Sequence>(
     _ keysAndValues: __owned S,
     isUnique: Bool,
@@ -875,13 +875,13 @@ extension _NativeDictionary { // High-level operations
   // superseded by the typed-throws version. Expressed as "throws", which is
   // ABI-compatible with "rethrows".
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-  @usableFromInline
   @abi(
     init<S: Sequence>(
       grouping values: __owned S,
       by keyForValue: (S.Element) throws -> Key
-    ) rethrows where Value == [S.Element]
+    ) throws where Value == [S.Element]
   )
+  @usableFromInline
   internal init<S: Sequence>(
     __rethrows_grouping values: __owned S,
     by keyForValue: (S.Element) throws -> Key

--- a/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
@@ -366,6 +366,9 @@ Func Dictionary.mapValues(_:) is now without rethrows
 Func Dictionary.merge(_:uniquingKeysWith:) has generic signature change from <Key, Value where Key : Swift.Hashable> to <Key, Value, E where Key : Swift.Hashable, E : Swift.Error>
 Func Dictionary.merge(_:uniquingKeysWith:) has generic signature change from <Key, Value, S where Key : Swift.Hashable, S : Swift.Sequence, S.Element == (Key, Value)> to <Key, Value, S, E where Key : Swift.Hashable, S : Swift.Sequence, E : Swift.Error, S.Element == (Key, Value)>
 Func Dictionary.merge(_:uniquingKeysWith:) is now without rethrows
+Func Dictionary.merging(_:uniquingKeysWith:) has generic signature change from <Key, Value where Key : Swift.Hashable> to <Key, Value, E where Key : Swift.Hashable, E : Swift.Error>
+Func Dictionary.merging(_:uniquingKeysWith:) has generic signature change from <Key, Value, S where Key : Swift.Hashable, S : Swift.Sequence, S.Element == (Key, Value)> to <Key, Value, S, E where Key : Swift.Hashable, S : Swift.Sequence, E : Swift.Error, S.Element == (Key, Value)>
+Func Dictionary.merging(_:uniquingKeysWith:) is now without rethrows
 
 // Adoption of @_addressableForDependencies
 Struct CollectionOfOne is now with @_addressableForDependencies

--- a/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
@@ -361,6 +361,8 @@ Func ContiguousArray.withUnsafeBufferPointer(_:) is now without rethrows
 Func ContiguousArray.withUnsafeMutableBufferPointer(_:) has generic signature change from <Element, R> to <Element, R, E where E : Swift.Error>
 Func ContiguousArray.withUnsafeMutableBufferPointer(_:) has parameter 0 type change from (inout Swift.UnsafeMutableBufferPointer<Element>) throws -> R to (inout Swift.UnsafeMutableBufferPointer<Element>) throws(E) -> R
 Func ContiguousArray.withUnsafeMutableBufferPointer(_:) is now without rethrows
+Func Dictionary.mapValues(_:) has generic signature change from <Key, Value, T where Key : Swift.Hashable> to <Key, Value, T, E where Key : Swift.Hashable, E : Swift.Error>
+Func Dictionary.mapValues(_:) is now without rethrows
 
 // Adoption of @_addressableForDependencies
 Struct CollectionOfOne is now with @_addressableForDependencies

--- a/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
@@ -369,6 +369,10 @@ Func Dictionary.merge(_:uniquingKeysWith:) is now without rethrows
 Func Dictionary.merging(_:uniquingKeysWith:) has generic signature change from <Key, Value where Key : Swift.Hashable> to <Key, Value, E where Key : Swift.Hashable, E : Swift.Error>
 Func Dictionary.merging(_:uniquingKeysWith:) has generic signature change from <Key, Value, S where Key : Swift.Hashable, S : Swift.Sequence, S.Element == (Key, Value)> to <Key, Value, S, E where Key : Swift.Hashable, S : Swift.Sequence, E : Swift.Error, S.Element == (Key, Value)>
 Func Dictionary.merging(_:uniquingKeysWith:) is now without rethrows
+Constructor Dictionary.init(_:uniquingKeysWith:) has generic signature change from <Key, Value, S where Key : Swift.Hashable, S : Swift.Sequence, S.Element == (Key, Value)> to <Key, Value, S, E where Key : Swift.Hashable, S : Swift.Sequence, E : Swift.Error, S.Element == (Key, Value)>
+Constructor Dictionary.init(_:uniquingKeysWith:) is now without rethrows
+Constructor Dictionary.init(grouping:by:) has generic signature change from <Key, Value, S where Key : Swift.Hashable, Value == [S.Element], S : Swift.Sequence> to <Key, Value, S, E where Key : Swift.Hashable, Value == [S.Element], S : Swift.Sequence, E : Swift.Error>
+Constructor Dictionary.init(grouping:by:) is now without rethrows
 
 // Adoption of @_addressableForDependencies
 Struct CollectionOfOne is now with @_addressableForDependencies

--- a/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
@@ -363,6 +363,9 @@ Func ContiguousArray.withUnsafeMutableBufferPointer(_:) has parameter 0 type cha
 Func ContiguousArray.withUnsafeMutableBufferPointer(_:) is now without rethrows
 Func Dictionary.mapValues(_:) has generic signature change from <Key, Value, T where Key : Swift.Hashable> to <Key, Value, T, E where Key : Swift.Hashable, E : Swift.Error>
 Func Dictionary.mapValues(_:) is now without rethrows
+Func Dictionary.merge(_:uniquingKeysWith:) has generic signature change from <Key, Value where Key : Swift.Hashable> to <Key, Value, E where Key : Swift.Hashable, E : Swift.Error>
+Func Dictionary.merge(_:uniquingKeysWith:) has generic signature change from <Key, Value, S where Key : Swift.Hashable, S : Swift.Sequence, S.Element == (Key, Value)> to <Key, Value, S, E where Key : Swift.Hashable, S : Swift.Sequence, E : Swift.Error, S.Element == (Key, Value)>
+Func Dictionary.merge(_:uniquingKeysWith:) is now without rethrows
 
 // Adoption of @_addressableForDependencies
 Struct CollectionOfOne is now with @_addressableForDependencies

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -819,6 +819,9 @@ Func _SliceBuffer.withUnsafeMutableBufferPointer(_:) has mangled name changing f
 
 // Functions changed for typed throws
 Constructor Array.init(_unsafeUninitializedCapacity:initializingWith:) has been removed
+Constructor Dictionary.init(_:uniquingKeysWith:) has been removed
+Constructor Dictionary.init(grouping:by:) has been removed
+Constructor _NativeDictionary.init(grouping:by:) has been removed
 Func Array.withUnsafeBufferPointer(_:) has been removed
 Func ArraySlice.withUnsafeBufferPointer(_:) has been removed
 Func ContiguousArray.withUnsafeBufferPointer(_:) has been removed

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -822,6 +822,11 @@ Constructor Array.init(_unsafeUninitializedCapacity:initializingWith:) has been 
 Func Array.withUnsafeBufferPointer(_:) has been removed
 Func ArraySlice.withUnsafeBufferPointer(_:) has been removed
 Func ContiguousArray.withUnsafeBufferPointer(_:) has been removed
+Func Dictionary._Variant.mapValues(_:) has been removed
+Func Dictionary.mapValues(_:) has been removed
+Func _NativeDictionary.mapValues(_:) has been removed
+Func __CocoaDictionary.mapValues(_:) has been removed
+
 
 Struct String.Index has added a conformance to an existing protocol CustomDebugStringConvertible
 

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -826,6 +826,7 @@ Func Dictionary._Variant.mapValues(_:) has been removed
 Func Dictionary._Variant.merge(_:uniquingKeysWith:) has been removed
 Func Dictionary.mapValues(_:) has been removed
 Func Dictionary.merge(_:uniquingKeysWith:) has been removed
+Func Dictionary.merging(_:uniquingKeysWith:) has been removed
 Func _NativeDictionary.mapValues(_:) has been removed
 Func _NativeDictionary.merge(_:isUnique:uniquingKeysWith:) has been removed
 Func __CocoaDictionary.mapValues(_:) has been removed

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -823,8 +823,11 @@ Func Array.withUnsafeBufferPointer(_:) has been removed
 Func ArraySlice.withUnsafeBufferPointer(_:) has been removed
 Func ContiguousArray.withUnsafeBufferPointer(_:) has been removed
 Func Dictionary._Variant.mapValues(_:) has been removed
+Func Dictionary._Variant.merge(_:uniquingKeysWith:) has been removed
 Func Dictionary.mapValues(_:) has been removed
+Func Dictionary.merge(_:uniquingKeysWith:) has been removed
 Func _NativeDictionary.mapValues(_:) has been removed
+Func _NativeDictionary.merge(_:isUnique:uniquingKeysWith:) has been removed
 Func __CocoaDictionary.mapValues(_:) has been removed
 
 


### PR DESCRIPTION
Adopts typed throws for several Dictionary APIs: mapValues, merge, merging and init.