### PR TITLE
[Serialization][cxx-interop] Fix a deserialization failure

### DIFF
--- a/lib/ClangImporter/Serializability.cpp
+++ b/lib/ClangImporter/Serializability.cpp
@@ -308,16 +308,14 @@ namespace {
         IsSerializable = false;
     }
     void writeDeclRef(const clang::Decl *decl) {
-      if (!decl) {
-        IsSerializable = false;
+      if (!decl)
         return;
-      }
       auto path = Impl.findStableSerializationPath(decl);
       if (!path) {
         IsSerializable = false;
         return;
       }
-      if (path.isSwiftDecl())
+      if (Impl.SwiftContext.getSwiftDeclForExportedClangDecl(decl))
         HasSwiftDecl = true;
     }
     void writeSourceLocation(clang::SourceLocation loc) {


### PR DESCRIPTION
The deserialization failure is due to missing Clang type when an entity is being deserialized. This is a regression introduced by #86517. It turns out the logic to filter out clang types that were synthesized by the Swift compiler was incorrect and we also filtered out imported types. Also, the logic was different when the decl was a null pointer.

This PR fixes the logic for the first problem and restores the previous behavior for null declarations.

Unfortunately, I was not able to come up with a minimal reproducer.

rdar://168932071