### PR TITLE
[6.3][Serialization][cxx-interop] Fix a deserialization failure

### DIFF
--- a/lib/ClangImporter/Serializability.cpp
+++ b/lib/ClangImporter/Serializability.cpp
@@ -308,16 +308,14 @@ namespace {
         IsSerializable = false;
     }
     void writeDeclRef(const clang::Decl *decl) {
-      if (!decl) {
-        IsSerializable = false;
+      if (!decl)
         return;
-      }
       auto path = Impl.findStableSerializationPath(decl);
       if (!path) {
         IsSerializable = false;
         return;
       }
-      if (path.isSwiftDecl())
+      if (Impl.SwiftContext.getSwiftDeclForExportedClangDecl(decl))
         HasSwiftDecl = true;
     }
     void writeSourceLocation(clang::SourceLocation loc) {


### PR DESCRIPTION
Explanation: The deserialization failure is due to missing Clang type when an entity is being deserialized. This is a regression introduced by #86517. It turns out the logic to filter out clang types that were synthesized by the Swift compiler was incorrect and we also filtered out imported types.
Issues: rdar://168932071
Original PRs: #86897
Risk: Low. This patch makes the logic more similar to what we had before the change that introduced the regression.
Testing: Could not recreate a minimal reproducer, verified the fix with the project that triggered the failure manually.
Reviewers:
