### PR TITLE
[6.3][Concurrency] Narrow fix to break cycles in implicit Sendable inference

### DIFF
--- a/test/Concurrency/sendable_checking_with_recursive_types.swift
+++ b/test/Concurrency/sendable_checking_with_recursive_types.swift
@@ -1,0 +1,56 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -verify -language-mode 6 -emit-sil -c %t/use.swift -primary-file %t/types.swift
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -verify -language-mode 6 -emit-sil -c %t/types.swift -primary-file %t/use.swift
+
+// REQUIRES: concurrency
+
+//--- types.swift
+
+// https://github.com/swiftlang/swift/issues/62060
+// Test1 references Test2 that references itself
+enum Test1 {
+  case a(i: Int, b: Test2)
+}
+indirect enum Test2 {
+  case b(i: Int, b: Test2)
+  case c
+}
+
+// https://github.com/swiftlang/swift/issues/82628
+// Multi-step recursion
+enum Test3 {
+  case v1(data: S1)
+  case v2
+  case v3
+}
+
+struct S1 {
+  let s2: [S2]
+}
+
+struct S2 {
+  let t4: Test4
+}
+
+enum Test4 {
+  case v1(a: S1)
+  case v2
+  case v3
+}
+
+// Recrusion through a typealias (Sendable check here is triggered by SIL at use)
+enum RecWithAliases {
+    typealias RecursiveArray = [RecWithAliases]
+    typealias RecursiveDictionary = [(String, RecWithAliases)]
+
+    case array(RecursiveArray)
+    case entity(RecursiveDictionary)
+}
+
+//--- use.swift
+func testAlias() -> RecWithAliases {
+  let v = RecWithAliases.RecursiveDictionary()
+  return .entity(v)
+}


### PR DESCRIPTION
- Explanation:

  Fixes some cases of extraneous "circular reference" issue with Sendable inference.

  An internal type is inferred to be Sendable when it's instance storage as Sendable. This complicates conformance lookup because all of the additional checking has to happen there. `lookupConformance` already has a check that breaks cycles with implicit known protocols, this was defeated by tuple types at the moment because they are split later by recursively calling `lookupConformance`.

  One idea was to split storage checking out of lookup and do that as part of availability checking but that won't help when check is requested from SILGen or type is a in different file from its use.

  As a narrow fix the change checks individual elements of tuple types in `diagnoseNonSendableTypes` that helps to detect cycles early.

- Resolves: https://github.com/swiftlang/swift/issues/62060, https://github.com/swiftlang/swift/issues/82628, rdar://168238300, rdar://91780682

- Main Branch PR: https://github.com/swiftlang/swift/pull/86874

- Risk: Low. The change doesn't make any semantic difference, it makes it easier to diagnose request cycles.

- Reviewed By: @slavapestov 

- Testing: Added new test-cases to the suite.

(cherry picked from commit bbb078ccde37abeed7d8b5f5c13a4da2d6ae08f1)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
