### PR TITLE
[TempRValueElimination] Make AllocStackInst.hasUses analysis global

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/TempRValueElimination.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/TempRValueElimination.swift
@@ -309,13 +309,17 @@ private extension AllocStackInst {
     defer { useSet.deinitialize() }
 
     useSet.insert(contentsOf: self.users)
-    for inst in InstructionList(first: self) {
-      if inst == instruction {
-        return false
-      }
+
+    var worklist = InstructionWorklist(context)
+    defer { worklist.deinitialize() }
+
+    worklist.pushPredecessors(of: instruction, ignoring: self)
+
+    while let inst = worklist.pop() {
       if useSet.contains(inst) {
         return true
       }
+      worklist.pushPredecessors(of: inst, ignoring: self)
     }
     return false
   }

--- a/test/SILOptimizer/temp_rvalue_opt.sil
+++ b/test/SILOptimizer/temp_rvalue_opt.sil
@@ -858,3 +858,24 @@ bb0(%0 : $*NC):
   return %r
 }
 
+
+// Test that the operand of the debug value dominates its use.
+// CHECK-LABEL: sil [ossa] @copy_and_consuming_arg :
+// CHECK:  %1 = alloc_stack $Klass
+// CHECK:  debug_value %1 : $*Klass, let, name "x"
+// CHECK-LABEL: } // end sil function 'copy_and_consuming_arg'
+sil [ossa] @copy_and_consuming_arg : $@convention(thin) (@inout Str) -> () {
+bb0(%0 : $*Str):
+  %1 = alloc_stack $Klass
+  br bb1
+
+bb1:
+  debug_value %1, let, name "x"
+  %3 = struct_element_addr %0, #Str.kl
+  copy_addr %3 to [init] %1
+  %4 = apply undef(%1) : $@convention(thin) (@in_guaranteed Klass) -> ()
+  destroy_addr %1
+  dealloc_stack %1
+  %9 = tuple ()
+  return %9 : $()
+}


### PR DESCRIPTION
Wihtout this change an alloc_stack instruction that is defined in a different basic block than its use could result in instructions that are not dominated by its operands. In an asserts build this is caught by the SIL verifier, but in a non-asserts build it can crash the compiler.

Thanks to Erik Eckstein for the actual implementation of the fix!

rdar://168622625
