### PR TITLE
[Concurrency] Fix thunk emission for function types with isolated par…

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1248,6 +1248,10 @@ namespace {
         auto *param = thunkParamList->get(idx);
         auto arg = thunkTy->getParams()[idx];
 
+        // Propagate isolation from function type to the parameter declaration,
+        // this is important for subsequent verification.
+        param->setIsolated(arg.isIsolated());
+
         param->setInterfaceType(arg.getParameterType()->mapTypeOutOfEnvironment());
         param->setSpecifier(ParamDecl::getParameterSpecifierForValueOwnership(
             arg.getValueOwnership()));
@@ -1389,6 +1393,10 @@ namespace {
           ParamDecl::getParameterSpecifierForValueOwnership(
               selfThunkParam.getValueOwnership()));
       selfParamDecl->setImplicit();
+
+      // Propagate isolation from function type to the parameter declaration,
+      // this is important for subsequent verification.
+      selfParamDecl->setIsolated(selfThunkParam.isIsolated());
 
       // Build a reference to the 'self' parameter.
       Expr *selfParamRef = new (ctx) DeclRefExpr(selfParamDecl, DeclNameLoc(),

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -1031,6 +1031,13 @@ FunctionType *ConstraintSystem::adjustFunctionTypeForConcurrency(
           // For example, `(C) -> () -> Void` where `C` should be Sendable
           // for the inner function type to be Sendable as well.
           sendableDepTy = sendableDepTy->getMetatypeInstanceType();
+
+          // Partially applied actor instance methods cannot cross isolation
+          // boundary unless they are asynchronous otherwise it would be
+          // possible to escape the actor context and access actor-isolated
+          // storage from different isolation.
+          if (sendableDepTy->isAnyActorType() && !decl->isAsync())
+            sendableDepTy = Type();
         }
 
         auto referenceTy = adjustedTy->getResult()->castTo<FunctionType>();

--- a/test/Concurrency/actor_isolation_swift6.swift
+++ b/test/Concurrency/actor_isolation_swift6.swift
@@ -122,7 +122,7 @@ struct ReferenceSelfDotMethods {
 }
 
 actor UserDefinedActorSelfDotMethod {
-  func actorAffinedFunc() {} // expected-note {{calls to instance method 'actorAffinedFunc()' from outside of its actor context are implicitly asynchronous}}
+  func actorAffinedFunc() {}
 
   // Unfortunately we can't express the desired isolation of this returned closure statically to
   // be able to call it on the desired actor. This may be possible with the acceptance of
@@ -130,7 +130,43 @@ actor UserDefinedActorSelfDotMethod {
   // in the type system to express this sort of curry.
   nonisolated
   private func testCurry() -> (UserDefinedActorSelfDotMethod) -> (@isolated(any) () -> Void) {
-    let functionRef = Self.actorAffinedFunc // expected-error {{call to actor-isolated instance method 'actorAffinedFunc()' in a synchronous nonisolated context}}
-    return functionRef // expected-error {{cannot convert return expression of type '@Sendable (isolated Self) -> @Sendable () -> ()' to return type '(UserDefinedActorSelfDotMethod) -> @isolated(any) () -> Void'}}
+    let functionRef = Self.actorAffinedFunc
+    return functionRef // expected-error {{cannot convert return expression of type '@Sendable (isolated Self) -> () -> ()' to return type '(UserDefinedActorSelfDotMethod) -> @isolated(any) () -> Void'}}
+  }
+}
+
+actor PartialApplyTest {
+  func compute(_: Int) {}
+  func expensiveCompute() async {}
+
+  func test() {
+    _ = Self.compute // Ok
+    _ = Self.compute(_:) // Ok
+
+    _ = Self.expensiveCompute // Ok
+    _ = self.expensiveCompute // Ok (this is okay because method is async)
+  }
+
+  nonisolated static func test(a: PartialApplyTest) {
+    _ = PartialApplyTest.compute // Ok
+    _ = PartialApplyTest.compute(_:) // Ok
+
+    _ = a.compute // expected-error {{actor-isolated instance method 'compute' can not be partially applied}}
+    _ = a.compute(_:) // expected-error {{actor-isolated instance method 'compute' can not be partially applied}}
+
+    _ = Self.expensiveCompute // Ok
+    _ = a.expensiveCompute // Ok (this is okay because method is async)
+  }
+}
+
+func testPartialApplyWithIsolatedParameters() {
+  func isolatedFn(v: Int, _: isolated PartialApplyTest) {
+  }
+
+  let fn = isolatedFn(v:_:) // expected-note {{calls to let 'fn' from outside of its actor context are implicitly asynchronous}}
+  let _: (Int, isolated PartialApplyTest) -> Void = fn // Ok
+
+  func apply(a: PartialApplyTest) {
+    fn(42, a) //expected-error {{call to actor-isolated let 'fn' in a synchronous nonisolated context}}
   }
 }

--- a/test/Concurrency/isolated_any.swift
+++ b/test/Concurrency/isolated_any.swift
@@ -105,7 +105,7 @@ func extractFunctionIsolationExpr(
 
   // Only `@isolated(any)` functions have `.isolation`
   let myActor = A()
-  let _: (any Actor)? = myActor.actorFunction.isolation // expected-error {{value of type '@Sendable () -> ()' has no member 'isolation'}}
+  let _: (any Actor)? = myActor.actorFunction.isolation // expected-error {{value of type '() -> ()' has no member 'isolation'}}
   let _: (any Actor)? = myActor.asyncActorFunction.isolation // expected-error {{value of type '@Sendable () async -> ()' has no member 'isolation'}}
   let _: (any Actor)? = myActor.asyncThrowsActorFunction.isolation // expected-error {{value of type '@Sendable () async throws -> ()' has no member 'isolation'}}
   let _: (any Actor)? = myActor.actorFunctionWithArgs.isolation // expected-error {{value of type '@Sendable (Int) async -> String' has no member 'isolation'}}


### PR DESCRIPTION
…ameters

This is important for things like instance methods of actors in particular because otherwise it won't be possible to compute a correct isolation for the thunk.

This fix enables fully unapplied references to actor-isolated instance methods and other functions with isolated parameters.

Resolves: rdar://148395744
Resolves: https://github.com/swiftlang/swift/issues/80454

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
