### PR TITLE
Tweak export_as behavior with submodules

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3173,8 +3173,7 @@ void ValueDecl::dumpRef(raw_ostream &os) const {
       getName().printPretty(os);
     }
   } else {
-    auto moduleName = cast<ModuleDecl>(this)->getRealName();
-    os << moduleName;
+    cast<ModuleDecl>(this)->getReverseFullModuleName().printForward(os);
   }
 
   if (getAttrs().hasAttribute<KnownToBeLocalAttr>()) {

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -32,6 +32,7 @@
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/GenericParamList.h"
 #include "swift/AST/GenericSignature.h"
+#include "swift/AST/ImportCache.h"
 #include "swift/AST/MacroDefinition.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/NameLookup.h"
@@ -6086,8 +6087,23 @@ class TypePrinter : public TypeVisitor<TypePrinter, void, NonRecursivePrintOptio
     return Options.CurrentModule->getVisibleClangModules(Options.InterfaceContentKind);
   }
 
-  bool shouldUseExportedModuleName(ASTContext &ctx,
+  /// If \p TyDecl belongs to a submodule, return the \c ModuleDecl for that
+  /// submodule; otherwise just return the parent module.
+  ModuleDecl *getParentSubModuleOrModule(GenericTypeDecl *TyDecl) {
+    // Only clang declarations can belong to a submodule
+    if (auto clangNode = TyDecl->getClangNode()) {
+      auto importer = TyDecl->getASTContext().getClangModuleLoader();
+      if (auto clangMod = importer->getClangOwningModule(clangNode)) {
+        return importer->getWrapperForModule(clangMod);
+      }
+    }
+
+    return TyDecl->getParentModule();
+  }
+
+  bool shouldUseExportedModuleName(GenericTypeDecl *TyDecl,
                                    StringRef exportedModuleName) {
+    auto &ctx = TyDecl->getASTContext();
     if (exportedModuleName.empty())
       return false;
 
@@ -6097,7 +6113,18 @@ class TypePrinter : public TypeVisitor<TypePrinter, void, NonRecursivePrintOptio
     case PrintOptions::ExportedModuleNameUsage::Never:
       return false;
     case PrintOptions::ExportedModuleNameUsage::IfLoaded:
-      return ctx.getLoadedModule(ctx.getIdentifier(exportedModuleName));
+      // Has the module we're exporting as been loaded? If not, we might be
+      // in a dependency of the exported-as module, so we can't use its name.
+      auto exportAsModule = ctx.getLoadedModule(
+                                ctx.getIdentifier(exportedModuleName));
+      if (!exportAsModule)
+        return false;
+
+      // Is the specific submodule TyDecl belongs to actually visible through
+      // exportAsModule? There are some subtleties about re-exports from
+      // submodules that are captured by querying the ImportCache.
+      auto tyDeclParent = getParentSubModuleOrModule(TyDecl);
+      return ctx.getImportCache().isImportedBy(tyDeclParent, exportAsModule);
     }
 
     llvm_unreachable("Unrecognized ExportedModuleNameUsage");
@@ -6140,7 +6167,7 @@ class TypePrinter : public TypeVisitor<TypePrinter, void, NonRecursivePrintOptio
     // Should use the module real (binary) name here and everywhere else the
     // module is printed in case module aliasing is used (see -module-alias)
     Identifier Name = Mod->getRealName();
-    if (shouldUseExportedModuleName(Mod->getASTContext(), ExportedModuleName)) {
+    if (shouldUseExportedModuleName(TyDecl, ExportedModuleName)) {
       Name = Mod->getASTContext().getIdentifier(ExportedModuleName);
     }
 

--- a/test/ModuleInterface/export-as-in-swiftinterfaces-submodules.swift
+++ b/test/ModuleInterface/export-as-in-swiftinterfaces-submodules.swift
@@ -1,0 +1,118 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+/// Build a client of the Library lib.
+// RUN: %target-swift-frontend -emit-module %t/LibraryClient.swift \
+// RUN:   -module-name LibraryClient -swift-version 5 -I %t \
+// RUN:   -enable-library-evolution \
+// RUN:   -emit-module-path %t/LibraryClient.swiftmodule \
+// RUN:   -emit-module-interface-path %t/LibraryClient.swiftinterface \
+// RUN:   -emit-private-module-interface-path %t/LibraryClient.private.swiftinterface
+// RUN: %target-swift-typecheck-module-from-interface(%t/LibraryClient.swiftinterface) -I %t
+// RUN: %target-swift-typecheck-module-from-interface(%t/LibraryClient.private.swiftinterface) -module-name LibraryClient -I %t
+// RUN: %FileCheck -input-file=%t/LibraryClient.swiftinterface -check-prefix=PUBLIC %t/LibraryClient.swift
+// RUN: %FileCheck -input-file=%t/LibraryClient.private.swiftinterface -check-prefix=PRIVATE %t/LibraryClient.swift
+
+/// Build a client of the LibraryCore lib. Note that the public interface is not
+/// expected to be usable--a direct client of a module using `export_as` is
+/// eventually folded into the `export_as` module itself.
+// RUN: %target-swift-frontend -emit-module %t/LibraryCoreClient.swift \
+// RUN:   -module-name LibraryCoreClient -swift-version 5 -I %t \
+// RUN:   -enable-library-evolution \
+// RUN:   -emit-module-path %t/LibraryCoreClient.swiftmodule \
+// RUN:   -emit-module-interface-path %t/LibraryCoreClient.swiftinterface \
+// RUN:   -emit-private-module-interface-path %t/LibraryCoreClient.private.swiftinterface
+// RUN: not %target-swift-typecheck-module-from-interface(%t/LibraryCoreClient.swiftinterface) -I %t
+// RUN: %target-swift-typecheck-module-from-interface(%t/LibraryCoreClient.private.swiftinterface) -module-name LibraryCoreClient -I %t
+// RUN: %FileCheck -input-file=%t/LibraryCoreClient.swiftinterface -check-prefix=PUBLIC %t/LibraryCoreClient.swift
+// RUN: %FileCheck -input-file=%t/LibraryCoreClient.private.swiftinterface -check-prefix=PRIVATE %t/LibraryCoreClient.swift
+
+//--- module.modulemap
+module LibraryCore {
+  export_as Library
+
+  umbrella "LibraryCore"
+  header "LibraryCore/LibraryCore.h"
+  export *
+
+  explicit module * { export * }
+}
+
+module Library {
+  umbrella "Library"
+  header "Library/Library.h"
+  export *
+
+  explicit module * { export * }
+}
+
+//--- LibraryCore/LibraryCore.h
+// This file is re-exported by Library
+#pragma once
+struct LibraryCoreType {};
+
+//--- LibraryCore/Submodule.h
+// This file is re-exported by Library.Submodule (which Swift does not respect)
+#pragma once
+struct LibraryCoreSubmoduleType {};
+
+//--- LibraryCore/ReexportedSubmodule.h
+// This file is re-exported by Library
+#pragma once
+struct LibraryCoreReexportedSubmoduleType {};
+
+//--- Library/Library.h
+#include <LibraryCore/LibraryCore.h>
+#include <LibraryCore/ReexportedSubmodule.h>
+#pragma once
+struct LibraryType {};
+
+//--- Library/Submodule.h
+#include <LibraryCore/Submodule.h>
+#pragma once
+struct LibrarySubmoduleType {};
+
+//--- LibraryClient.swift
+
+import Library
+import Library.Submodule
+
+// PUBLIC-LABEL: public func foo
+// PRIVATE-LABEL: public func foo
+public func foo(
+  // PUBLIC-SAME: a: Library.LibraryCoreType
+  // PRIVATE-SAME: a: Library.LibraryCoreType
+  a: LibraryCoreType,
+  // PUBLIC-SAME: b: Library.LibraryCoreSubmoduleType
+  // PRIVATE-SAME: b: LibraryCore.LibraryCoreSubmoduleType
+  b: LibraryCoreSubmoduleType,
+  // PUBLIC-SAME: c: Library.LibraryCoreReexportedSubmoduleType
+  // PRIVATE-SAME: c: LibraryCore.LibraryCoreReexportedSubmoduleType
+  c: LibraryCoreReexportedSubmoduleType,
+  // PUBLIC-SAME: d: Library.LibraryType
+  // PRIVATE-SAME: d: Library.LibraryType
+  d: LibraryType,
+  // PUBLIC-SAME: e: Library.LibrarySubmoduleType
+  // PRIVATE-SAME: e: Library.LibrarySubmoduleType
+  e: LibrarySubmoduleType
+) {}
+
+//--- LibraryCoreClient.swift
+
+import LibraryCore
+import LibraryCore.Submodule
+import LibraryCore.ReexportedSubmodule
+
+// PUBLIC-LABEL: public func foo
+// PRIVATE-LABEL: public func foo
+public func foo(
+  // PUBLIC-SAME: a: Library.LibraryCoreType
+  // PRIVATE-SAME: a: LibraryCore.LibraryCoreType
+  a: LibraryCoreType,
+  // PUBLIC-SAME: b: Library.LibraryCoreSubmoduleType
+  // PRIVATE-SAME: b: LibraryCore.LibraryCoreSubmoduleType
+  b: LibraryCoreSubmoduleType,
+  // PUBLIC-SAME: c: Library.LibraryCoreReexportedSubmoduleType
+  // PRIVATE-SAME: c: LibraryCore.LibraryCoreReexportedSubmoduleType
+  c: LibraryCoreReexportedSubmoduleType
+) {}


### PR DESCRIPTION
In #86859, I modified the way `export_as` names are used in private module interfaces so that the `export_as` name is used when that module has been imported. This turns out to be slightly too aggressive in a specific scenario where a submodule of the export_as module imports a submodule of the real module—the compiler ends up using the export name even though the resulting lookup won’t actually work.

Modify the logic for deciding whether to use an exported module name so that it not only checks whether the export_as module has been loaded, but also whether the specific module or submodule the declaration belongs to is (possibly transitively) imported by that module.

Fixes rdar://167874630 (harder).