### PR TITLE
[Triple] Support the new target triple "os" for firmware

### DIFF
--- a/include/swift/Basic/Platform.h
+++ b/include/swift/Basic/Platform.h
@@ -35,7 +35,8 @@ namespace swift {
     WatchOS,
     WatchOSSimulator,
     VisionOS,
-    VisionOSSimulator
+    VisionOSSimulator,
+    Firmware,
   };
 
   /// Returns true if the given triple represents iOS running in a simulator.

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -77,6 +77,7 @@ static const SupportedConditionalValue SupportedConditionalCompilationOSs[] = {
   "iOS",
   "visionOS",
   "xrOS",
+  "Firmware",
   "Linux",
   "FreeBSD",
   "OpenBSD",
@@ -540,6 +541,9 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
   case llvm::Triple::XROS:
     addPlatformConditionValue(PlatformConditionKind::OS, "xrOS");
     addPlatformConditionValue(PlatformConditionKind::OS, "visionOS");
+    break;
+  case llvm::Triple::Firmware:
+    addPlatformConditionValue(PlatformConditionKind::OS, "Firmware");
     break;
   case llvm::Triple::Linux:
     if (Target.getEnvironment() == llvm::Triple::Android)

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -184,6 +184,8 @@ DarwinPlatformKind swift::getDarwinPlatformKind(const llvm::Triple &triple) {
       return DarwinPlatformKind::VisionOSSimulator;
     return DarwinPlatformKind::VisionOS;
   }
+  if (triple.isAppleFirmware())
+    return DarwinPlatformKind::Firmware;
 
   llvm_unreachable("Unsupported Darwin platform");
 }
@@ -208,6 +210,8 @@ static StringRef getPlatformNameForDarwin(const DarwinPlatformKind platform) {
     return "xros";
   case DarwinPlatformKind::VisionOSSimulator:
     return "xrsimulator";
+  case DarwinPlatformKind::Firmware:
+    return "firmware";
   }
   llvm_unreachable("Unsupported Darwin platform");
 }
@@ -246,6 +250,7 @@ StringRef swift::getPlatformNameForTriple(const llvm::Triple &triple) {
   case llvm::Triple::TvOS:
   case llvm::Triple::WatchOS:
   case llvm::Triple::XROS:
+  case llvm::Triple::Firmware:
     return getPlatformNameForDarwin(getDarwinPlatformKind(triple));
   case llvm::Triple::Linux:
     if (triple.isAndroid())

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -118,6 +118,8 @@ getDarwinLibraryNameSuffixForTriple(const llvm::Triple &triple) {
     return "xros";
   case DarwinPlatformKind::VisionOSSimulator:
     return "xrossim";
+  default:
+    break;
   }
   llvm_unreachable("Unsupported Darwin platform");
 }
@@ -554,6 +556,8 @@ toolchains::Darwin::addDeploymentTargetArgs(ArgStringList &Arguments,
       case DarwinPlatformKind::VisionOSSimulator:
         platformName = "xros-simulator";
         break;
+      case DarwinPlatformKind::Firmware:
+        return;
       }
     }
 
@@ -614,6 +618,13 @@ toolchains::Darwin::addDeploymentTargetArgs(ArgStringList &Arguments,
         }
 
         break;
+      case DarwinPlatformKind::Firmware:
+        osVersion = triple.getOSVersion();
+        // Firmware is not versioned; (always version 1.0.0).
+        if (osVersion.getMajor() == 0) {
+          osVersion = llvm::VersionTuple(/*Major=*/1, /*Minor=*/0);
+        }
+        break;
       }
     }
 
@@ -669,6 +680,8 @@ static unsigned getDWARFVersionForTriple(const llvm::Triple &triple) {
     osVersion = triple.getOSVersion();
     if (osVersion < llvm::VersionTuple(2))
       return 4;
+    return 5;
+  case DarwinPlatformKind::Firmware:
     return 5;
   }
   llvm_unreachable("unsupported platform kind");

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -424,6 +424,7 @@ Driver::buildToolChain(const llvm::opt::InputArgList &ArgList) {
 
   switch (target.getOS()) {
   case llvm::Triple::XROS:
+  case llvm::Triple::Firmware:
   case llvm::Triple::IOS:
   case llvm::Triple::TvOS:
   case llvm::Triple::WatchOS:

--- a/lib/DriverTool/swift_api_digester_main.cpp
+++ b/lib/DriverTool/swift_api_digester_main.cpp
@@ -2198,6 +2198,8 @@ static StringRef getBaselineFilename(llvm::Triple Triple) {
     return "windows.json";
   else if (Triple.isXROS())
     return "xros.json";
+  else if (Triple.isAppleFirmware())
+    return "firmware.json";
   else {
     llvm::errs() << "Unsupported triple target\n";
     exit(1);

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -558,6 +558,8 @@ static AvailabilityRange getObjCClassStubAvailability(ASTContext &ctx) {
     return AvailabilityRange(llvm::VersionTuple(6, 0, 0));
   if (target.isXROS())
     return AvailabilityRange(llvm::VersionTuple(1, 0, 0));
+  if (target.isAppleFirmware())
+    return AvailabilityRange(llvm::VersionTuple(1, 0, 0));
   return AvailabilityRange::alwaysAvailable();
 }
 

--- a/test/Parse/ConditionalCompilation/basicParseErrors.swift
+++ b/test/Parse/ConditionalCompilation/basicParseErrors.swift
@@ -80,6 +80,9 @@ struct S {
 
 #endif
 
+#if os(Firmware)
+#endif
+
 #if arch(arn)
 #endif
 


### PR DESCRIPTION
Add support for the new Firmware llvm::Triple::OSType, and make a swift::DarwinPlatformKind to go with it.

rdar://165361368