### PR TITLE
[Test][lit] Fix %enable-cow-checking for internal shell 🐄

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -3189,7 +3189,7 @@ config.substitutions.append(('%import-static-libdispatch', getattr(config, 'impo
 config.environment['SWIFT_DEBUG_ENABLE_COW_CHECKS'] = 'false'
 
 # Add this to the command which runs an executable to enable COW checks in the swift runtime.
-config.substitutions.append(('%enable-cow-checking', 'export ' + config.target_env_prefix + 'SWIFT_DEBUG_ENABLE_COW_CHECKS=true;'))
+config.substitutions.append(('%enable-cow-checking', 'env ' + config.target_env_prefix + 'SWIFT_DEBUG_ENABLE_COW_CHECKS=true;'))
 
 # We add an expansion to ensure that migrator tests can search for the api diff
 # data dir from the host compiler toolchain instead of the resource dir of the

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -3189,7 +3189,7 @@ config.substitutions.append(('%import-static-libdispatch', getattr(config, 'impo
 config.environment['SWIFT_DEBUG_ENABLE_COW_CHECKS'] = 'false'
 
 # Add this to the command which runs an executable to enable COW checks in the swift runtime.
-config.substitutions.append(('%enable-cow-checking', config.target_env_prefix + 'SWIFT_DEBUG_ENABLE_COW_CHECKS=true;'))
+config.substitutions.append(('%enable-cow-checking', 'export ' + config.target_env_prefix + 'SWIFT_DEBUG_ENABLE_COW_CHECKS=true;'))
 
 # We add an expansion to ensure that migrator tests can search for the api diff
 # data dir from the host compiler toolchain instead of the resource dir of the


### PR DESCRIPTION
Partially address #84407


```
#86908 fixed:
- validation-test/stdlib/Array.swift.gyb                                                                                           
- validation-test/stdlib/Array/Array_MutableRandomAccessCollectionRef.swift                                                        
- validation-test/stdlib/Array/Array_MutableRandomAccessCollectionVal.swift                                                        
- validation-test/stdlib/Array/Array_RangeReplaceableRandomAccessCollectionRef.swift                                               
- validation-test/stdlib/Array/Array_RangeReplaceableRandomAccessCollectionVal.swift                                               
- validation-test/stdlib/Array/ArraySlice_MutableRandomAccessCollectionRef.swift                                                   
- validation-test/stdlib/Array/ArraySlice_MutableRandomAccessCollectionVal.swift                                                   
- validation-test/stdlib/Array/ArraySlice_RangeReplaceableRandomAccessCollectionRef.swift                                          
- validation-test/stdlib/Array/ArraySlice_RangeReplaceableRandomAccessCollectionVal.swift                                          
- validation-test/stdlib/Array/ArraySliceWithNonZeroStartIndex_MutableRandomAccessCollectionRef.swift                              
- validation-test/stdlib/Array/ArraySliceWithNonZeroStartIndex_MutableRandomAccessCollectionVal.swift                              
- validation-test/stdlib/Array/ArraySliceWithNonZeroStartIndex_RangeReplaceableRandomAccessCollectionRef.swift                     
- validation-test/stdlib/Array/ArraySliceWithNonZeroStartIndex_RangeReplaceableRandomAccessCollectionVal.swift                     
- validation-test/stdlib/Array/ContiguousArray_MutableRandomAccessCollectionRef.swift                                              
- validation-test/stdlib/Array/ContiguousArray_MutableRandomAccessCollectionVal.swift                                              
- validation-test/stdlib/Array/ContiguousArray_RangeReplaceableRandomAccessCollectionRef.swift                                     
- validation-test/stdlib/Array/ContiguousArray_RangeReplaceableRandomAccessCollectionVal.swift 
```