### PR TITLE
[Test][BuildSystem] Prepend env to variable assignments for internal …

### DIFF
--- a/validation-test/BuildSystem/android_cross_compile.test
+++ b/validation-test/BuildSystem/android_cross_compile.test
@@ -1,7 +1,7 @@
 # REQUIRES: standalone_build
 
 # RUN: %empty-directory(%t)
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --cmake %cmake --foundation --swift-testing --swift-testing-macros --install-foundation --install-swift-testing-macros --install-llvm --cross-compile-hosts=android-aarch64 --cross-compile-build-swift-tools=False --android --android-ndk %t/ndk/ --android-arch aarch64 2>&1 | %FileCheck %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --cmake %cmake --foundation --swift-testing --swift-testing-macros --install-foundation --install-swift-testing-macros --install-llvm --cross-compile-hosts=android-aarch64 --cross-compile-build-swift-tools=False --android --android-ndk %t/ndk/ --android-arch aarch64 2>&1 | %FileCheck %s
 
 # CHECK: pushd {{.*}}/llvm-android-aarch64
 # CHECK-NOT: cmake --build {{.*}}/llvm-android-aarch64 --config

--- a/validation-test/BuildSystem/build_lld.test
+++ b/validation-test/BuildSystem/build_lld.test
@@ -1,6 +1,6 @@
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --cmake %cmake --build-lld 2>&1 | %FileCheck %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --cmake %cmake --build-lld 2>&1 | %FileCheck %s
 
 # REQUIRES: standalone_build
 

--- a/validation-test/BuildSystem/clean_install_destroot.test
+++ b/validation-test/BuildSystem/clean_install_destroot.test
@@ -3,7 +3,7 @@
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --cmake %cmake --clean-install-destdir --verbose-build 2>&1 | %FileCheck %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --cmake %cmake --clean-install-destdir --verbose-build 2>&1 | %FileCheck %s
 
 # CHECK: Cleaning install destdir!
 # CHECK-NEXT: rm -rf

--- a/validation-test/BuildSystem/cmark_crosscompile_using_toolchain_always.test
+++ b/validation-test/BuildSystem/cmark_crosscompile_using_toolchain_always.test
@@ -4,8 +4,8 @@
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --install-all --cmake %cmake --skip-build-llvm --skip-build-swift 2>&1 | %FileCheck %s
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --install-all --cmake %cmake --skip-build-llvm --skip-build-swift --cross-compile-hosts=android-aarch64 --skip-local-build --android --android-ndk %t/ndk/ 2>&1 | %FileCheck --check-prefix=ANDROID %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --install-all --cmake %cmake --skip-build-llvm --skip-build-swift 2>&1 | %FileCheck %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --install-all --cmake %cmake --skip-build-llvm --skip-build-swift --cross-compile-hosts=android-aarch64 --skip-local-build --android --android-ndk %t/ndk/ 2>&1 | %FileCheck --check-prefix=ANDROID %s
 
 # CHECK: DRY_RUN! Writing Toolchain file to path:{{.*}}BuildScriptToolchain.cmake
 # CHECK: cmake {{.*}}-DCMAKE_TOOLCHAIN_FILE:PATH={{.*}}BuildScriptToolchain.cmake {{.*}}cmark

--- a/validation-test/BuildSystem/core_lipo_and_non_core_epilogue_opts.test
+++ b/validation-test/BuildSystem/core_lipo_and_non_core_epilogue_opts.test
@@ -3,7 +3,7 @@
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --cmake %cmake --infer --swiftpm --verbose-build 2>&1 | %FileCheck %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --cmake %cmake --infer --swiftpm --verbose-build 2>&1 | %FileCheck %s
 
 # Make sure we build swift, llvm, llbuild, then do core lipo, then build
 # swiftpm, and finally finish by running the rest of the epilogue operations.

--- a/validation-test/BuildSystem/default_build_still_performs_epilogue_opts_after_split.test
+++ b/validation-test/BuildSystem/default_build_still_performs_epilogue_opts_after_split.test
@@ -2,9 +2,9 @@
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --verbose-build --dry-run --cmake %cmake 2>&1 | %FileCheck %s
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --verbose-build --dry-run --cmake %cmake --infer 2>&1 | %FileCheck %s
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --verbose-build --dry-run --cmake %cmake --infer --swiftpm 2>&1 | %FileCheck %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --verbose-build --dry-run --cmake %cmake 2>&1 | %FileCheck %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --verbose-build --dry-run --cmake %cmake --infer 2>&1 | %FileCheck %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --verbose-build --dry-run --cmake %cmake --infer --swiftpm 2>&1 | %FileCheck %s
 
 # Make sure we run the merged hosts lipo step regardless of whether or not we
 # are building anything from the 2nd build-script-impl phase with or without

--- a/validation-test/BuildSystem/dsymutil_jobs.test
+++ b/validation-test/BuildSystem/dsymutil_jobs.test
@@ -4,7 +4,7 @@
 # RUN: mkdir -p %t
 # RUN: mkdir -p %t/destdir
 # RUN: mkdir -p %t/symroot/macosx-%target-cpu
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --enable-extract-symbol-dry-run-test=1 --host-target=macosx-%target-cpu --darwin-install-extract-symbols --dsymutil-jobs 5 --cmake %cmake --install-symroot=%t/symroot --install-destdir=%t/destdir --toolchain-prefix= 2>&1 | %FileCheck %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --enable-extract-symbol-dry-run-test=1 --host-target=macosx-%target-cpu --darwin-install-extract-symbols --dsymutil-jobs 5 --cmake %cmake --install-symroot=%t/symroot --install-destdir=%t/destdir --toolchain-prefix= 2>&1 | %FileCheck %s
 
 # CHECK: --- Extracting symbols ---
 # CHECK: { "command": "dsymutil", "start": "

--- a/validation-test/BuildSystem/extra_dsymutil_args.test
+++ b/validation-test/BuildSystem/extra_dsymutil_args.test
@@ -4,9 +4,9 @@
 # RUN: mkdir -p %t
 # RUN: mkdir -p %t/destdir
 # RUN: mkdir -p %t/symroot/macosx-%target-cpu
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --enable-extract-symbol-dry-run-test=1 --host-target=macosx-%target-cpu --darwin-install-extract-symbols --extra-dsymutil-args="--verify-dwarf=auto --verbose"  --cmake %cmake --install-symroot=%t/symroot --install-destdir=%t/destdir --toolchain-prefix= 2>&1 | %FileCheck %s
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --enable-extract-symbol-dry-run-test=1 --host-target=macosx-%target-cpu --darwin-install-extract-symbols --extra-dsymutil-args=--verify-dwarf=auto,--verbose  --cmake %cmake --install-symroot=%t/symroot --install-destdir=%t/destdir --toolchain-prefix= 2>&1 | %FileCheck %s
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --enable-extract-symbol-dry-run-test=1 --host-target=macosx-%target-cpu --darwin-install-extract-symbols --extra-dsymutil-args="--verify-dwarf=auto" --extra-dsymutil-args=--verbose  --cmake %cmake --install-symroot=%t/symroot --install-destdir=%t/destdir --toolchain-prefix= 2>&1 | %FileCheck %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --enable-extract-symbol-dry-run-test=1 --host-target=macosx-%target-cpu --darwin-install-extract-symbols --extra-dsymutil-args="--verify-dwarf=auto --verbose"  --cmake %cmake --install-symroot=%t/symroot --install-destdir=%t/destdir --toolchain-prefix= 2>&1 | %FileCheck %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --enable-extract-symbol-dry-run-test=1 --host-target=macosx-%target-cpu --darwin-install-extract-symbols --extra-dsymutil-args=--verify-dwarf=auto,--verbose  --cmake %cmake --install-symroot=%t/symroot --install-destdir=%t/destdir --toolchain-prefix= 2>&1 | %FileCheck %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --enable-extract-symbol-dry-run-test=1 --host-target=macosx-%target-cpu --darwin-install-extract-symbols --extra-dsymutil-args="--verify-dwarf=auto" --extra-dsymutil-args=--verbose  --cmake %cmake --install-symroot=%t/symroot --install-destdir=%t/destdir --toolchain-prefix= 2>&1 | %FileCheck %s
 
 # CHECK: --- Extracting symbols ---
 # CHECK: { "command": "dsymutil", "start": "

--- a/validation-test/BuildSystem/extra_dsymutil_args_empty.test
+++ b/validation-test/BuildSystem/extra_dsymutil_args_empty.test
@@ -4,10 +4,10 @@
 # RUN: mkdir -p %t
 # RUN: mkdir -p %t/destdir
 # RUN: mkdir -p %t/symroot/macosx-%target-cpu
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --enable-extract-symbol-dry-run-test=1 --host-target=macosx-%target-cpu --darwin-install-extract-symbols --extra-dsymutil-args=""  --cmake %cmake --install-symroot=%t/symroot --install-destdir=%t/destdir --toolchain-prefix= 2>&1 | %FileCheck %s
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --enable-extract-symbol-dry-run-test=1 --host-target=macosx-%target-cpu --darwin-install-extract-symbols --extra-dsymutil-args=  --cmake %cmake --install-symroot=%t/symroot --install-destdir=%t/destdir --toolchain-prefix= 2>&1 | %FileCheck %s
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --enable-extract-symbol-dry-run-test=1 --host-target=macosx-%target-cpu --darwin-install-extract-symbols --extra-dsymutil-args="" --extra-dsymutil-args=""  --cmake %cmake --install-symroot=%t/symroot --install-destdir=%t/destdir --toolchain-prefix= 2>&1 | %FileCheck %s
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --enable-extract-symbol-dry-run-test=1 --host-target=macosx-%target-cpu --darwin-install-extract-symbols --cmake %cmake --install-symroot=%t/symroot --install-destdir=%t/destdir --toolchain-prefix= 2>&1 | %FileCheck %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --enable-extract-symbol-dry-run-test=1 --host-target=macosx-%target-cpu --darwin-install-extract-symbols --extra-dsymutil-args=""  --cmake %cmake --install-symroot=%t/symroot --install-destdir=%t/destdir --toolchain-prefix= 2>&1 | %FileCheck %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --enable-extract-symbol-dry-run-test=1 --host-target=macosx-%target-cpu --darwin-install-extract-symbols --extra-dsymutil-args=  --cmake %cmake --install-symroot=%t/symroot --install-destdir=%t/destdir --toolchain-prefix= 2>&1 | %FileCheck %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --enable-extract-symbol-dry-run-test=1 --host-target=macosx-%target-cpu --darwin-install-extract-symbols --extra-dsymutil-args="" --extra-dsymutil-args=""  --cmake %cmake --install-symroot=%t/symroot --install-destdir=%t/destdir --toolchain-prefix= 2>&1 | %FileCheck %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --enable-extract-symbol-dry-run-test=1 --host-target=macosx-%target-cpu --darwin-install-extract-symbols --cmake %cmake --install-symroot=%t/symroot --install-destdir=%t/destdir --toolchain-prefix= 2>&1 | %FileCheck %s
 
 # CHECK: --- Extracting symbols ---
 # CHECK: { "command": "dsymutil", "start": "

--- a/validation-test/BuildSystem/extractsymbols-darwin-symroot-path-filters.test
+++ b/validation-test/BuildSystem/extractsymbols-darwin-symroot-path-filters.test
@@ -22,21 +22,21 @@
 # RUN: mkdir -p %t/symroot/macosx-%target-cpu
 
 # test build-script-impl on its own
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script-impl --dry-run --enable-extract-symbol-dry-run-test=1 --build-dir=%t/build --workspace=%swift_src_root/.. --cmake %cmake --only-execute macosx-%target-cpu-extractsymbols --host-cc /usr/bin/true --darwin-install-extract-symbols=1 --host-target=macosx-%target-cpu --install-symroot=%t/symroot --install-destdir=%t/destdir --build-jobs=1 --darwin-symroot-path-filters="/lib/ /swift-demangle"  2>&1 | tee %t/build-script-impl-output.txt
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script-impl --dry-run --enable-extract-symbol-dry-run-test=1 --build-dir=%t/build --workspace=%swift_src_root/.. --cmake %cmake --only-execute macosx-%target-cpu-extractsymbols --host-cc /usr/bin/true --darwin-install-extract-symbols=1 --host-target=macosx-%target-cpu --install-symroot=%t/symroot --install-destdir=%t/destdir --build-jobs=1 --darwin-symroot-path-filters="/lib/ /swift-demangle"  2>&1 | tee %t/build-script-impl-output.txt
 # RUN: %FileCheck --input-file=%t/build-script-impl-output.txt %s
 # RUN: %FileCheck --input-file=%t/build-script-impl-output.txt --check-prefixes CHECK-SKIPPED %s
 
 # ensure build-script pass the argument to build-script-impl
 # RUN: %empty-directory(%t/symroot)
 # RUN: mkdir -p %t/symroot/macosx-%target-cpu
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --enable-extract-symbol-dry-run-test=1 --cmake %cmake --darwin-install-extract-symbols=1 --install-destdir=%t/destdir --toolchain-prefix="" --install-symroot=%t/symroot --darwin-symroot-path-filters="/lib/ /swift-demangle" --jobs=1 --host-target=macosx-%target-cpu 2>&1 | tee %t/build-script-output.txt
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --enable-extract-symbol-dry-run-test=1 --cmake %cmake --darwin-install-extract-symbols=1 --install-destdir=%t/destdir --toolchain-prefix="" --install-symroot=%t/symroot --darwin-symroot-path-filters="/lib/ /swift-demangle" --jobs=1 --host-target=macosx-%target-cpu 2>&1 | tee %t/build-script-output.txt
 # RUN: %FileCheck --input-file=%t/build-script-output.txt %s
 # RUN: %FileCheck --input-file=%t/build-script-output.txt --check-prefixes CHECK-SKIPPED %s
 
 # ensure we get all the values if we specify the flag multiple times
 # RUN: %empty-directory(%t/symroot)
 # RUN: mkdir -p %t/symroot/macosx-%target-cpu
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --enable-extract-symbol-dry-run-test=1 --cmake %cmake --darwin-install-extract-symbols=1 --install-destdir=%t/destdir --toolchain-prefix="" --install-symroot=%t/symroot --darwin-symroot-path-filters="/lib/" --darwin-symroot-path-filters="/swift-demangle" --jobs=1 --host-target=macosx-%target-cpu 2>&1 | tee %t/build-script-output.txt
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --enable-extract-symbol-dry-run-test=1 --cmake %cmake --darwin-install-extract-symbols=1 --install-destdir=%t/destdir --toolchain-prefix="" --install-symroot=%t/symroot --darwin-symroot-path-filters="/lib/" --darwin-symroot-path-filters="/swift-demangle" --jobs=1 --host-target=macosx-%target-cpu 2>&1 | tee %t/build-script-output.txt
 # RUN: %FileCheck --input-file=%t/build-script-output.txt %s
 # RUN: %FileCheck --input-file=%t/build-script-output.txt --check-prefixes CHECK-SKIPPED %s
 

--- a/validation-test/BuildSystem/extractsymbols-default-behaviour.test
+++ b/validation-test/BuildSystem/extractsymbols-default-behaviour.test
@@ -21,7 +21,7 @@
 # RUN: chmod a+x %t/destdir/libswiftCompatibility51.a
 # RUN: mkdir -p %t/symroot/macosx-%target-cpu
 
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script-impl --dry-run --enable-extract-symbol-dry-run-test=1 --build-dir=%t/build --workspace=%swift_src_root/.. --cmake %cmake --only-execute macosx-%target-cpu-extractsymbols --host-cc /usr/bin/true --darwin-install-extract-symbols=1 --host-target=macosx-%target-cpu --install-symroot=%t/symroot --install-destdir=%t/destdir --build-jobs=1 > %t/build-script-impl-output.txt 2>&1
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script-impl --dry-run --enable-extract-symbol-dry-run-test=1 --build-dir=%t/build --workspace=%swift_src_root/.. --cmake %cmake --only-execute macosx-%target-cpu-extractsymbols --host-cc /usr/bin/true --darwin-install-extract-symbols=1 --host-target=macosx-%target-cpu --install-symroot=%t/symroot --install-destdir=%t/destdir --build-jobs=1 > %t/build-script-impl-output.txt 2>&1
 # RUN: %FileCheck --input-file=%t/build-script-impl-output.txt %s
 # RUN: %FileCheck --input-file=%t/build-script-impl-output.txt --check-prefixes CHECK-SKIPPED %s
 

--- a/validation-test/BuildSystem/extractsymbols-dry-run-does-not-fail.test
+++ b/validation-test/BuildSystem/extractsymbols-dry-run-does-not-fail.test
@@ -13,7 +13,7 @@
 # RUN: mkdir -p %t
 # RUN: mkdir -p %t/destdir
 # RUN: mkdir -p %t/symroot/macosx-%target-cpu
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script-impl --dry-run --build-dir=%t/build --workspace=%swift_src_root/.. --cmake %cmake --only-execute macosx-%target-cpu-extractsymbols --host-cc /usr/bin/true --darwin-install-extract-symbols=1 --host-target=macosx-%target-cpu --install-symroot=%t/symroot --install-destdir=%t/destdir --build-jobs=1 2>&1 | %FileCheck %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script-impl --dry-run --build-dir=%t/build --workspace=%swift_src_root/.. --cmake %cmake --only-execute macosx-%target-cpu-extractsymbols --host-cc /usr/bin/true --darwin-install-extract-symbols=1 --host-target=macosx-%target-cpu --install-symroot=%t/symroot --install-destdir=%t/destdir --build-jobs=1 2>&1 | %FileCheck %s
 
 # CHECK: --- Extracting symbols ---
 

--- a/validation-test/BuildSystem/infer-cross-compile-hosts-on-darwin-linux.test
+++ b/validation-test/BuildSystem/infer-cross-compile-hosts-on-darwin-linux.test
@@ -2,12 +2,12 @@
 # REQUIRES: OS=linux-gnu
 
 # RUN: %empty-directory(%t)
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --infer-cross-compile-hosts-on-darwin --cmake %cmake  2>&1 | %FileCheck --check-prefix=NO-INFER-CROSS-COMPILE-HOSTS-ON-DARWIN %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --infer-cross-compile-hosts-on-darwin --cmake %cmake  2>&1 | %FileCheck --check-prefix=NO-INFER-CROSS-COMPILE-HOSTS-ON-DARWIN %s
 # RUN: %empty-directory(%t)
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --infer-cross-compile-hosts-on-darwin=1 --cmake %cmake  2>&1 | %FileCheck --check-prefix=NO-INFER-CROSS-COMPILE-HOSTS-ON-DARWIN %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --infer-cross-compile-hosts-on-darwin=1 --cmake %cmake  2>&1 | %FileCheck --check-prefix=NO-INFER-CROSS-COMPILE-HOSTS-ON-DARWIN %s
 # RUN: %empty-directory(%t)
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --cmake %cmake  2>&1 | %FileCheck --check-prefix=NO-INFER-CROSS-COMPILE-HOSTS-ON-DARWIN %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --cmake %cmake  2>&1 | %FileCheck --check-prefix=NO-INFER-CROSS-COMPILE-HOSTS-ON-DARWIN %s
 # RUN: %empty-directory(%t)
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --infer-cross-compile-hosts-on-darwin=0 --cmake %cmake  2>&1 | %FileCheck --check-prefix=NO-INFER-CROSS-COMPILE-HOSTS-ON-DARWIN %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --infer-cross-compile-hosts-on-darwin=0 --cmake %cmake  2>&1 | %FileCheck --check-prefix=NO-INFER-CROSS-COMPILE-HOSTS-ON-DARWIN %s
 
 # NO-INFER-CROSS-COMPILE-HOSTS-ON-DARWIN-NOT: Inferred the following hosts for cross compilations:

--- a/validation-test/BuildSystem/infer-cross-compile-hosts-on-darwin-macosx.test
+++ b/validation-test/BuildSystem/infer-cross-compile-hosts-on-darwin-macosx.test
@@ -2,17 +2,17 @@
 # REQUIRES: OS=macosx
 
 # RUN: %empty-directory(%t)
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t ARCH_FOR_BUILDSYSTEM_TESTS=x86_64 %swift_src_root/utils/build-script --dry-run --infer-cross-compile-hosts-on-darwin --cmake %cmake  2>&1 | %FileCheck --check-prefix=INFER-CROSS-COMPILE-HOSTS-ON-DARWIN-x86_64 %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t ARCH_FOR_BUILDSYSTEM_TESTS=x86_64 %swift_src_root/utils/build-script --dry-run --infer-cross-compile-hosts-on-darwin --cmake %cmake  2>&1 | %FileCheck --check-prefix=INFER-CROSS-COMPILE-HOSTS-ON-DARWIN-x86_64 %s
 # RUN: %empty-directory(%t)
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t ARCH_FOR_BUILDSYSTEM_TESTS=arm64 %swift_src_root/utils/build-script --dry-run --infer-cross-compile-hosts-on-darwin=1 --cmake %cmake  2>&1 | %FileCheck --check-prefix=INFER-CROSS-COMPILE-HOSTS-ON-DARWIN-arm64 %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t ARCH_FOR_BUILDSYSTEM_TESTS=arm64 %swift_src_root/utils/build-script --dry-run --infer-cross-compile-hosts-on-darwin=1 --cmake %cmake  2>&1 | %FileCheck --check-prefix=INFER-CROSS-COMPILE-HOSTS-ON-DARWIN-arm64 %s
 
 # INFER-CROSS-COMPILE-HOSTS-ON-DARWIN-x86_64: Inferred the following hosts for cross compilations: ['macosx-arm64']
 # INFER-CROSS-COMPILE-HOSTS-ON-DARWIN-arm64: Inferred the following hosts for cross compilations: ['macosx-x86_64']
 
 
 # RUN: %empty-directory(%t)
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --cmake %cmake  2>&1 | %FileCheck --check-prefix=NO-INFER-CROSS-COMPILE-HOSTS-ON-DARWIN %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --cmake %cmake  2>&1 | %FileCheck --check-prefix=NO-INFER-CROSS-COMPILE-HOSTS-ON-DARWIN %s
 # RUN: %empty-directory(%t)
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --infer-cross-compile-hosts-on-darwin=0 --cmake %cmake  2>&1 | %FileCheck --check-prefix=NO-INFER-CROSS-COMPILE-HOSTS-ON-DARWIN %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --infer-cross-compile-hosts-on-darwin=0 --cmake %cmake  2>&1 | %FileCheck --check-prefix=NO-INFER-CROSS-COMPILE-HOSTS-ON-DARWIN %s
 
 # NO-INFER-CROSS-COMPILE-HOSTS-ON-DARWIN-NOT: Inferred the following hosts for cross compilations:

--- a/validation-test/BuildSystem/infer_dumps_deps_if_verbose_build.test
+++ b/validation-test/BuildSystem/infer_dumps_deps_if_verbose_build.test
@@ -1,6 +1,6 @@
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --verbose-build --dry-run --infer --swiftpm --cmake %cmake 2>&1 | %FileCheck %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --verbose-build --dry-run --infer --swiftpm --cmake %cmake 2>&1 | %FileCheck %s
 
 # REQUIRES: standalone_build
 

--- a/validation-test/BuildSystem/infer_implies_install_all.test
+++ b/validation-test/BuildSystem/infer_implies_install_all.test
@@ -1,6 +1,6 @@
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --infer --swiftpm --cmake %cmake 2>&1 | %FileCheck %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --infer --swiftpm --cmake %cmake 2>&1 | %FileCheck %s
 
 # REQUIRES: standalone_build
 

--- a/validation-test/BuildSystem/install_all.test
+++ b/validation-test/BuildSystem/install_all.test
@@ -1,6 +1,6 @@
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --install-all --cmake %cmake 2>&1 | %FileCheck %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --install-all --cmake %cmake 2>&1 | %FileCheck %s
 
 # REQUIRES: standalone_build
 

--- a/validation-test/BuildSystem/install_all_linux.test
+++ b/validation-test/BuildSystem/install_all_linux.test
@@ -1,6 +1,6 @@
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --install-all --llbuild --swiftpm --foundation --libdispatch --cmake %cmake 2>&1 | %FileCheck %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --install-all --llbuild --swiftpm --foundation --libdispatch --cmake %cmake 2>&1 | %FileCheck %s
 
 # REQUIRES: standalone_build
 # REQUIRES: OS=linux-gnu

--- a/validation-test/BuildSystem/llvm-build-compiler-rt-on-linux.test
+++ b/validation-test/BuildSystem/llvm-build-compiler-rt-on-linux.test
@@ -2,7 +2,7 @@
 # REQUIRES: OS=linux-gnu
 
 # RUN: %empty-directory(%t)
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --skip-build --cmake %cmake  2>&1 | %FileCheck --check-prefix=LINUX %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --skip-build --cmake %cmake  2>&1 | %FileCheck --check-prefix=LINUX %s
 
 # LINUX: Building llvm
 # LINUX-DAG: cmake -G Ninja

--- a/validation-test/BuildSystem/llvm-build-compiler-rt-on-macosx.test
+++ b/validation-test/BuildSystem/llvm-build-compiler-rt-on-macosx.test
@@ -2,7 +2,7 @@
 # REQUIRES: OS=macosx
 
 # RUN: %empty-directory(%t)
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --skip-build --cmake %cmake  2>&1 | %FileCheck --check-prefix=LLVM-USE-RUNTIMES %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --skip-build --cmake %cmake  2>&1 | %FileCheck --check-prefix=LLVM-USE-RUNTIMES %s
 
 # LLVM-USE-RUNTIMES: Building llvm
 # LLVM-USE-RUNTIMES-DAG: cmake -G Ninja

--- a/validation-test/BuildSystem/llvm-build-compiler-rt-with-use-runtimes.test
+++ b/validation-test/BuildSystem/llvm-build-compiler-rt-with-use-runtimes.test
@@ -1,7 +1,7 @@
 # REQUIRES: standalone_build
 
 # RUN: %empty-directory(%t)
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --skip-build --cmake %cmake  2>&1 | %FileCheck --check-prefix=LLVM-USE-RUNTIMES %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --skip-build --cmake %cmake  2>&1 | %FileCheck --check-prefix=LLVM-USE-RUNTIMES %s
 
 # LLVM-USE-RUNTIMES: Building llvm
 # LLVM-USE-RUNTIMES-DAG: cmake -G Ninja
@@ -11,7 +11,7 @@
 # LLVM-USE-RUNTIMES-SAME: llvm{{$}}
 
 # RUN: %empty-directory(%t)
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --skip-build --skip-build-compiler-rt --cmake %cmake  2>&1 | %FileCheck --check-prefix=DONT-BUILD-COMPILER-RT %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --skip-build --skip-build-compiler-rt --cmake %cmake  2>&1 | %FileCheck --check-prefix=DONT-BUILD-COMPILER-RT %s
 
 # DONT-BUILD-COMPILER-RT: Building llvm
 # DONT-BUILD-COMPILER-RT-DAG: cmake -G Ninja

--- a/validation-test/BuildSystem/llvm-targets-options-for-cross-compile-hosts.test
+++ b/validation-test/BuildSystem/llvm-targets-options-for-cross-compile-hosts.test
@@ -3,7 +3,7 @@
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --llvm-ninja-targets="lib/all clangDependencyScanning" --cross-compile-hosts=iphoneos-arm64e --cmake %cmake  2>&1 | %FileCheck --check-prefix=LLVM-NINJA-TARGETS-APPLY-TO-CROSS-COMPILE-HOSTS-TOO-CHECK %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --llvm-ninja-targets="lib/all clangDependencyScanning" --cross-compile-hosts=iphoneos-arm64e --cmake %cmake  2>&1 | %FileCheck --check-prefix=LLVM-NINJA-TARGETS-APPLY-TO-CROSS-COMPILE-HOSTS-TOO-CHECK %s
 
 # LLVM-NINJA-TARGETS-APPLY-TO-CROSS-COMPILE-HOSTS-TOO-CHECK: cmake --build {{.*}}/llvm-{{[^/]*}} lib/all clangDependencyScanning
 # LLVM-NINJA-TARGETS-APPLY-TO-CROSS-COMPILE-HOSTS-TOO-CHECK: cmake --build {{.*}}/llvm-iphoneos-arm64e {{.*}} lib/all clangDependencyScanning
@@ -11,7 +11,7 @@
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --llvm-ninja-targets="lib/all clangDependencyScanning" --llvm-ninja-targets-for-cross-compile-hosts="bin/clang" --cross-compile-hosts=iphoneos-arm64e --cmake %cmake 2>&1 | %FileCheck --check-prefix=LLVM-NINJA-TARGETS-FOR-CROSS-COMPILE-HOSTS-CHECK %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --llvm-ninja-targets="lib/all clangDependencyScanning" --llvm-ninja-targets-for-cross-compile-hosts="bin/clang" --cross-compile-hosts=iphoneos-arm64e --cmake %cmake 2>&1 | %FileCheck --check-prefix=LLVM-NINJA-TARGETS-FOR-CROSS-COMPILE-HOSTS-CHECK %s
 
 # LLVM-NINJA-TARGETS-FOR-CROSS-COMPILE-HOSTS-CHECK: cmake --build {{.*}}/llvm-{{[^/]*}} lib/all clangDependencyScanning
 # LLVM-NINJA-TARGETS-FOR-CROSS-COMPILE-HOSTS-CHECK: cmake --build {{.*}}/llvm-iphoneos-arm64e {{.*}} bin/clang
@@ -19,7 +19,7 @@
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --llvm-ninja-targets-for-cross-compile-hosts="bin/clang" --cross-compile-hosts=iphoneos-arm64e --cmake %cmake 2>&1 | %FileCheck --check-prefix=ONLY-LLVM-NINJA-TARGETS-FOR-CROSS-COMPILE-HOSTS-CHECK %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --llvm-ninja-targets-for-cross-compile-hosts="bin/clang" --cross-compile-hosts=iphoneos-arm64e --cmake %cmake 2>&1 | %FileCheck --check-prefix=ONLY-LLVM-NINJA-TARGETS-FOR-CROSS-COMPILE-HOSTS-CHECK %s
 
 # ONLY-LLVM-NINJA-TARGETS-FOR-CROSS-COMPILE-HOSTS-CHECK: cmake --build {{.*}}/llvm-{{[^/]*}} all
 # ONLY-LLVM-NINJA-TARGETS-FOR-CROSS-COMPILE-HOSTS-CHECK: cmake --build {{.*}}/llvm-iphoneos-arm64e {{.*}} bin/clang

--- a/validation-test/BuildSystem/llvm-targets-options.test
+++ b/validation-test/BuildSystem/llvm-targets-options.test
@@ -2,30 +2,30 @@
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --build-llvm=0 --cmake %cmake  2>&1 | %FileCheck --check-prefix=BUILD-LLVM-0-CHECK %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --build-llvm=0 --cmake %cmake  2>&1 | %FileCheck --check-prefix=BUILD-LLVM-0-CHECK %s
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --build-llvm=0 --llvm-ninja-targets="lib/all clangDependencyScanning" --cmake %cmake  2>&1 | %FileCheck --check-prefix=BUILD-LLVM-0-CHECK %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --build-llvm=0 --llvm-ninja-targets="lib/all clangDependencyScanning" --cmake %cmake  2>&1 | %FileCheck --check-prefix=BUILD-LLVM-0-CHECK %s
 
 # BUILD-LLVM-0-CHECK-NOT: cmake --build {{.*}}/Ninja-DebugAssert/llvm
 
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --skip-build --cmake %cmake  2>&1 | %FileCheck --check-prefix=SKIP-BUILD-CHECK %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --skip-build --cmake %cmake  2>&1 | %FileCheck --check-prefix=SKIP-BUILD-CHECK %s
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --skip-build --llvm-ninja-targets="lib/all bin/clang" --cmake %cmake  2>&1 | %FileCheck --check-prefix=SKIP-BUILD-CHECK %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --skip-build --llvm-ninja-targets="lib/all bin/clang" --cmake %cmake  2>&1 | %FileCheck --check-prefix=SKIP-BUILD-CHECK %s
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --skip-build-llvm --cmake %cmake  2>&1 | %FileCheck --check-prefix=SKIP-BUILD-CHECK %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --skip-build-llvm --cmake %cmake  2>&1 | %FileCheck --check-prefix=SKIP-BUILD-CHECK %s
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --skip-build-llvm --llvm-ninja-targets="bin/clang clangDependencyScanning" --cmake %cmake  2>&1 | %FileCheck --check-prefix=SKIP-BUILD-CHECK %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --skip-build-llvm --llvm-ninja-targets="bin/clang clangDependencyScanning" --cmake %cmake  2>&1 | %FileCheck --check-prefix=SKIP-BUILD-CHECK %s
 
 # SKIP-BUILD-CHECK: cmake --build {{.*}}/llvm-{{[^/]*}} llvm-tblgen clang-resource-headers intrinsics_gen clang-tablegen-targets
 # SKIP-BUILD-CHECK-SAME: FileCheck not llvm-nm
@@ -33,7 +33,7 @@
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --skip-build-llvm --build-toolchain-only=1 --cmake %cmake  2>&1 | %FileCheck --check-prefix=SKIP-BUILD-LLVM-BUILD-TOOLCHAIN-ONLY-CHECK %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --skip-build-llvm --build-toolchain-only=1 --cmake %cmake  2>&1 | %FileCheck --check-prefix=SKIP-BUILD-LLVM-BUILD-TOOLCHAIN-ONLY-CHECK %s
 
 # SKIP-BUILD-LLVM-BUILD-TOOLCHAIN-ONLY-CHECK: cmake --build {{.*}}/llvm-{{[^/]*}} llvm-tblgen clang-resource-headers intrinsics_gen clang-tablegen-targets
 # SKIP-BUILD-LLVM-BUILD-TOOLCHAIN-ONLY-CHECK-NOT: FileCheck not llvm-nm
@@ -41,7 +41,7 @@
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --llvm-ninja-targets="lib/all clangDependencyScanning" --cmake %cmake  2>&1 | %FileCheck --check-prefix=LLVM-NINJA-TARGETS-CHECK %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --llvm-ninja-targets="lib/all clangDependencyScanning" --cmake %cmake  2>&1 | %FileCheck --check-prefix=LLVM-NINJA-TARGETS-CHECK %s
 
 # LLVM-NINJA-TARGETS-CHECK: cmake --build {{.*}}/llvm-{{[^/]*}} lib/all clangDependencyScanning
 

--- a/validation-test/BuildSystem/reconfigure-passed-to-build-script-impl.test
+++ b/validation-test/BuildSystem/reconfigure-passed-to-build-script-impl.test
@@ -1,6 +1,6 @@
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --reconfigure --verbose --cmake %cmake 2>&1| %FileCheck %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --reconfigure --verbose --cmake %cmake 2>&1| %FileCheck %s
 
 # REQUIRES: standalone_build
 

--- a/validation-test/BuildSystem/relocate_xdg_cache_home_under_build_subdir.test
+++ b/validation-test/BuildSystem/relocate_xdg_cache_home_under_build_subdir.test
@@ -1,6 +1,6 @@
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --install-all --llbuild --swiftpm --foundation --libdispatch --relocate-xdg-cache-home-under-build-subdir --verbose-build --cmake %cmake 2>&1 | %FileCheck %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --install-all --llbuild --swiftpm --foundation --libdispatch --relocate-xdg-cache-home-under-build-subdir --verbose-build --cmake %cmake 2>&1 | %FileCheck %s
 
 # REQUIRES: standalone_build
 # REQUIRES: OS=linux-gnu

--- a/validation-test/BuildSystem/skip-local-build.test-sh
+++ b/validation-test/BuildSystem/skip-local-build.test-sh
@@ -1,10 +1,10 @@
 # REQUIRES: standalone_build
 
 # RUN: %empty-directory(%t)
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --cmake %cmake --dump-config --skip-local-build 2>&1 | %FileCheck %s -check-prefix=CONFIG
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --cmake %cmake --dump-config --skip-local-build 2>&1 | %FileCheck %s -check-prefix=CONFIG
 # CONFIG: "skip_local_build": true
 
 # RUN: %empty-directory(%t)
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --cmake %cmake --dry-run --verbose-build --skip-local-build 2>&1 | %FileCheck %s -check-prefix=DRY
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --cmake %cmake --dry-run --verbose-build --skip-local-build 2>&1 | %FileCheck %s -check-prefix=DRY
 # DRY: build-script-impl
 # DRY-SAME: --skip-local-build

--- a/validation-test/BuildSystem/skip_clean_corelibs.test
+++ b/validation-test/BuildSystem/skip_clean_corelibs.test
@@ -7,11 +7,11 @@
 #
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --xctest --cmake %cmake  2>&1 | %FileCheck --check-prefix=CLEAN-CORELIBS-CHECK %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --xctest --cmake %cmake  2>&1 | %FileCheck --check-prefix=CLEAN-CORELIBS-CHECK %s
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --xctest --skip-clean-libdispatch --skip-clean-foundation --skip-clean-xctest --cmake %cmake  2>&1 | %FileCheck --check-prefix=SKIP-CLEAN-CORELIBS-CHECK %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --xctest --skip-clean-libdispatch --skip-clean-foundation --skip-clean-xctest --cmake %cmake  2>&1 | %FileCheck --check-prefix=SKIP-CLEAN-CORELIBS-CHECK %s
 
 # CLEAN-CORELIBS-CHECK: Cleaning the libdispatch build directory
 # CLEAN-CORELIBS-CHECK-NEXT: rm -rf

--- a/validation-test/BuildSystem/skip_clean_llbuild.test
+++ b/validation-test/BuildSystem/skip_clean_llbuild.test
@@ -2,11 +2,11 @@
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --llbuild --cmake %cmake  2>&1 | %FileCheck --check-prefix=CLEAN-LLBUILD-CHECK %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --llbuild --cmake %cmake  2>&1 | %FileCheck --check-prefix=CLEAN-LLBUILD-CHECK %s
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --llbuild --skip-clean-llbuild --cmake %cmake  2>&1 | %FileCheck --check-prefix=SKIP-CLEAN-LLBUILD-CHECK %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --llbuild --skip-clean-llbuild --cmake %cmake  2>&1 | %FileCheck --check-prefix=SKIP-CLEAN-LLBUILD-CHECK %s
 
 # CLEAN-LLBUILD-CHECK-DAG: Cleaning the llbuild build directory
 # CLEAN-LLBUILD-CHECK: rm -rf

--- a/validation-test/BuildSystem/skip_cmark_swift_llvm.test
+++ b/validation-test/BuildSystem/skip_cmark_swift_llvm.test
@@ -2,15 +2,15 @@
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --install-all --cmake %cmake --skip-build-cmark 2>&1 | %FileCheck --check-prefix=SKIP-CMARK-CHECK %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --install-all --cmake %cmake --skip-build-cmark 2>&1 | %FileCheck --check-prefix=SKIP-CMARK-CHECK %s
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --install-all --cmake %cmake --skip-build-llvm 2>&1 | %FileCheck --check-prefix=SKIP-LLVM-CHECK %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --install-all --cmake %cmake --skip-build-llvm 2>&1 | %FileCheck --check-prefix=SKIP-LLVM-CHECK %s
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --install-all --cmake %cmake --skip-build-swift 2>&1 | %FileCheck --check-prefix=SKIP-SWIFT-CHECK %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --install-all --cmake %cmake --skip-build-swift 2>&1 | %FileCheck --check-prefix=SKIP-SWIFT-CHECK %s
 
 # SKIP-CMARK-CHECK-NOT: cmake --build {{.*}}cmark-
 # SKIP-CMARK-CHECK-NOT: --- Installing cmark ---

--- a/validation-test/BuildSystem/test_early_swift_driver_and_infer.swift
+++ b/validation-test/BuildSystem/test_early_swift_driver_and_infer.swift
@@ -2,6 +2,6 @@
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --swiftpm --infer --cmake %cmake 2>&1 | %FileCheck %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --swiftpm --infer --cmake %cmake 2>&1 | %FileCheck %s
 
 # CHECK: --- Building earlyswiftdriver ---

--- a/validation-test/BuildSystem/test_skip_early_swift_driver.test
+++ b/validation-test/BuildSystem/test_skip_early_swift_driver.test
@@ -2,6 +2,6 @@
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --cmake %cmake --skip-early-swift-driver 2>&1 | %FileCheck %s
+# RUN: env SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --cmake %cmake --skip-early-swift-driver 2>&1 | %FileCheck %s
 
 # CHECK-NOT: --- Building earlyswiftdriver ---


### PR DESCRIPTION
Partially address #84407 

```
#86909 fixed:
- validation-test/BuildSystem/android_cross_compile.test
- validation-test/BuildSystem/build_lld.test
- validation-test/BuildSystem/llvm-build-compiler-rt-on-macosx.test
- validation-test/BuildSystem/cmark_crosscompile_using_toolchain_always.test
- validation-test/BuildSystem/default_build_still_performs_epilogue_opts_after_split.test
- validation-test/BuildSystem/infer_dumps_deps_if_verbose_build.test
- validation-test/BuildSystem/infer_implies_install_all.test
- validation-test/BuildSystem/install_all.test
- validation-test/BuildSystem/llvm-build-compiler-rt-with-use-runtimes.test
- validation-test/BuildSystem/llvm-targets-options.test
- validation-test/BuildSystem/reconfigure-passed-to-build-script-impl.test
- validation-test/BuildSystem/skip-local-build.test-sh
- validation-test/BuildSystem/skip_clean_llbuild.test
- validation-test/BuildSystem/skip_cmark_swift_llvm.test
- validation-test/BuildSystem/test_early_swift_driver_and_infer.swift
- validation-test/BuildSystem/test_skip_early_swift_driver.test
- validation-test/BuildSystem/clean_install_destroot.test
- validation-test/BuildSystem/core_lipo_and_non_core_epilogue_opts.test
- validation-test/BuildSystem/dsymutil_jobs.test
- validation-test/BuildSystem/extra_dsymutil_args_empty.test
- validation-test/BuildSystem/extra_dsymutil_args.test
- validation-test/BuildSystem/extractsymbols-darwin-symroot-path-filters.test
- validation-test/BuildSystem/extractsymbols-default-behaviour.test
- validation-test/BuildSystem/extractsymbols-dry-run-does-not-fail.test
- validation-test/BuildSystem/infer-cross-compile-hosts-on-darwin-macosx.test
- validation-test/BuildSystem/llvm-targets-options-for-cross-compile-hosts.test
```
There are some extra that I prepended env to `SKIP_XCODE_VERSION_CHECK=1`

```
- validation-test/BuildSystem/llvm-build-compiler-rt-on-linux.test
- validation-test/BuildSystem/install_all_linux.test
- validation-test/BuildSystem/infer-cross-compile-hosts-on-darwin-linux.test
- validation-test/BuildSystem/relocate_xdg_cache_home_under_build_subdir.test
- validation-test/BuildSystem/skip_clean_corelibs.test
```