### PR TITLE
[Parse] treat <> as a potential generic

### DIFF
--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -1600,7 +1600,8 @@ static bool isGenericTypeDisambiguatingToken(Parser &P) {
 }
 
 bool Parser::canParseAsGenericArgumentList() {
-  if (!Tok.isAnyOperator() || Tok.getText() != "<")
+  // Expressions of the form T<>() will produce a single <> token, not < and >
+  if (!Tok.isAnyOperator() || (Tok.getText() != "<" && Tok.getText() != "<>"))
     return false;
 
   BacktrackingScope backtrack(*this);

--- a/test/Parse/generic_disambiguation.swift
+++ b/test/Parse/generic_disambiguation.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift -verify-additional-prefix swift5-
 // RUN: %target-typecheck-verify-swift -swift-version 6 -verify-additional-prefix swift6-
 
-struct A<B> { // expected-note{{generic struct 'A' declared here}}
+struct A<B> { // expected-note 2 {{generic struct 'A' declared here}}
   init(x:Int) {}
   static func c() {}
 
@@ -76,8 +76,7 @@ meta(A<B>.C<D>.self)
 meta2(A<B>.C<D>.self, 0)
  */
 
-// TODO: parse empty <> list
-//A<>.c() // e/xpected-error{{xxx}}
+A<>.c() // expected-error{{generic type 'A' specialized with too few type parameters (got 0, but expected 1}}
 
 A<B, D>.c() // expected-error{{generic type 'A' specialized with too many type parameters (got 2, but expected 1)}}
 

--- a/test/Parse/type_parameter_packs.swift
+++ b/test/Parse/type_parameter_packs.swift
@@ -41,3 +41,9 @@ func ellipsis<T...>(_ x: repeat each T) {}
 func eachEllipsis<each T...>(_ x: repeat each T) {}
 // expected-error@-1 {{ellipsis operator cannot be used with a type parameter pack}}{{25-28=}}
 // expected-error@-2 {{cannot find type 'T' in scope}}
+
+let _ = S1< >()
+foo< >()
+
+let _ = S1<>()
+foo<>()


### PR DESCRIPTION
This commit changes canParseAsGenericArgumentList such that the guard no longer returns early for '<>' which is a single token when the brackets aren't seperated by a space, which fixes #68290.

Also adds a test case for this behavior and enables a generic disambiguation test with no params, since this affects all use of generics in expressions.

With this PR, code like this works:
```swift
struct T<each U> {}
let _ = T<>()
T<>.self
```

There is some cause for concern about interacting with infix and postfix `<>` operators; I think *this* change doesn't pose an issue for that since my read of the surrounding code is that the token is only treated like a generic if it has a disambiguating token after it, but in a future where `.self` is dropped a decision might need to be made about which to prefer in some cases, and allowing `T<>.self` now would make it especially surprising to not allow `T<>` in that future.

SwiftParser [explicitly excludes this case](https://github.com/swiftlang/swift-syntax/blob/5266ebb28783a81dee835cafa273696e210f1695/Sources/SwiftParser/Types.swift#L1065-L1075) and will need to be updated if allowing this is the direction to go in.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
