### PR TITLE
[Test][Backtracing] Use not --crash instead of subshells for internal…

### DIFF
--- a/test/Backtracing/CrashAsync.swift
+++ b/test/Backtracing/CrashAsync.swift
@@ -5,8 +5,8 @@
 // Demangling is disabled for now because older macOS can't demangle async
 // function names.  We test demangling elsewhere, so this is no big deal.
 
-// RUN: (env SWIFT_BACKTRACE=enable=yes,demangle=no,cache=no %target-run %t/CrashAsync 2>&1 || true) | %FileCheck %s
-// RUN: (env SWIFT_BACKTRACE=preset=friendly,enable=yes,demangle=no,cache=no %target-run %t/CrashAsync 2>&1 || true) | %FileCheck %s --check-prefix FRIENDLY
+// RUN: not --crash env SWIFT_BACKTRACE=enable=yes,demangle=no,cache=no %target-run %t/CrashAsync 2>&1 | %FileCheck %s
+// RUN: not --crash env SWIFT_BACKTRACE=preset=friendly,enable=yes,demangle=no,cache=no %target-run %t/CrashAsync 2>&1 | %FileCheck %s --check-prefix FRIENDLY
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime

--- a/test/Backtracing/CrashWithThreads.swift
+++ b/test/Backtracing/CrashWithThreads.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -Onone -g -o %t/CrashWithThreads
 // RUN: %target-codesign %t/CrashWithThreads
-// RUN: (env SWIFT_BACKTRACE=enable=yes,cache=no,swift-backtrace=%backtracer %target-run %t/CrashWithThreads 2>&1 || true) | %FileCheck -vv %s -dump-input-filter=all
-// RUN: (env SWIFT_BACKTRACE=enable=yes,cache=no,swift-backtrace=%backtracer,threads=all %target-run %t/CrashWithThreads 2>&1 || true) | %FileCheck -vv %s -dump-input-filter=all
+// RUN: not --crash env SWIFT_BACKTRACE=enable=yes,cache=no,swift-backtrace=%backtracer %target-run %t/CrashWithThreads 2>&1 | %FileCheck -vv %s -dump-input-filter=all
+// RUN: not --crash env SWIFT_BACKTRACE=enable=yes,cache=no,swift-backtrace=%backtracer,threads=all %target-run %t/CrashWithThreads 2>&1 | %FileCheck -vv %s -dump-input-filter=all
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime

--- a/test/Backtracing/NotImportedByDefault.swift
+++ b/test/Backtracing/NotImportedByDefault.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: ( %target-build-swift %s -o %t/NotImportedByDefault || true ) 2>&1 | %FileCheck %s
+// RUN: not %target-build-swift %s -o %t/NotImportedByDefault 2>&1 | %FileCheck %s
 
 // Windows chokes on the parens in the above expression
 // UNSUPPORTED: OS=windows-msvc

--- a/test/Backtracing/TTYDetection.swift
+++ b/test/Backtracing/TTYDetection.swift
@@ -2,9 +2,9 @@
 // RUN: %target-build-swift %s -parse-as-library -Onone -g -o %t/TTYDetection
 // RUN: %target-codesign %t/TTYDetection
 
-// RUN: (env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/TTYDetection 2> %t/default-output || true) && cat %t/default-output | %FileCheck %s
-// RUN: (env SWIFT_BACKTRACE=enable=yes,cache=no,output-to=stderr %target-run %t/TTYDetection 2> %t/stderr-output || true) && cat %t/stderr-output | %FileCheck %s --check-prefix STDERR
-// RUN: (env SWIFT_BACKTRACE=enable=yes,cache=no,output-to=stdout %target-run %t/TTYDetection > %t/stdout-output || true) && cat %t/stdout-output | %FileCheck %s --check-prefix STDOUT
+// RUN: not --crash env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/TTYDetection 2> %t/default-output && cat %t/default-output | %FileCheck %s
+// RUN: not --crash env SWIFT_BACKTRACE=enable=yes,cache=no,output-to=stderr %target-run %t/TTYDetection 2> %t/stderr-output && cat %t/stderr-output | %FileCheck %s --check-prefix STDERR
+// RUN: not --crash env SWIFT_BACKTRACE=enable=yes,cache=no,output-to=stdout %target-run %t/TTYDetection > %t/stdout-output && cat %t/stdout-output | %FileCheck %s --check-prefix STDOUT
 
 
 // UNSUPPORTED: use_os_stdlib

--- a/test/Backtracing/TTYDetectionColourLinux.swift
+++ b/test/Backtracing/TTYDetectionColourLinux.swift
@@ -4,7 +4,7 @@
 
 // RUN: %target-build-swift %s -o %t/crash-host
 
-// RUN: (env SWIFT_BACKTRACE=enable=yes,cache=no,interactive=no %target-run %t/crash-host %t/crash)| %FileCheck %s
+// RUN: env SWIFT_BACKTRACE=enable=yes,cache=no,interactive=no %target-run %t/crash-host %t/crash | %FileCheck %s
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime

--- a/test/Backtracing/TTYDetectionColourMacOS.swift
+++ b/test/Backtracing/TTYDetectionColourMacOS.swift
@@ -2,7 +2,7 @@
 // RUN: %target-build-swift %s -parse-as-library -Onone -g -o %t/TTYDetection
 // RUN: %target-codesign %t/TTYDetection
 
-// RUN: (env SWIFT_BACKTRACE=enable=yes,cache=no,interactive=no %target-run script -reF %t/script-output %t/TTYDetection || true) && cat %t/script-output | %FileCheck %s
+// RUN: not --crash env SWIFT_BACKTRACE=enable=yes,cache=no,interactive=no %target-run script -reF %t/script-output %t/TTYDetection && cat %t/script-output | %FileCheck %s
 
 
 // UNSUPPORTED: use_os_stdlib

--- a/test/Backtracing/TTYDetectionColourMacOS.swift
+++ b/test/Backtracing/TTYDetectionColourMacOS.swift
@@ -2,7 +2,7 @@
 // RUN: %target-build-swift %s -parse-as-library -Onone -g -o %t/TTYDetection
 // RUN: %target-codesign %t/TTYDetection
 
-// RUN: not --crash env SWIFT_BACKTRACE=enable=yes,cache=no,interactive=no %target-run script -reF %t/script-output %t/TTYDetection && cat %t/script-output | %FileCheck %s
+// RUN: not env SWIFT_BACKTRACE=enable=yes,cache=no,interactive=no %target-run script -reF %t/script-output %t/TTYDetection && cat %t/script-output | %FileCheck %s
 
 
 // UNSUPPORTED: use_os_stdlib


### PR DESCRIPTION
Partially address #84407 

```
#86913 fixed:
- test/Backtracing/CrashAsync.swift
- test/Backtracing/CrashWithThreads.swift
- ‎test/Backtracing/NotImportedByDefault.swift
- test/Backtracing/TTYDetection.swift
- test/Backtracing/TTYDetectionColourLinux.swift
- test/Backtracing/TTYDetectionColourMacOS.swift
```