### PR TITLE
[DiagnosticVerifier] skip over unrelated diags in expansions

### DIFF
--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -853,6 +853,10 @@ unsigned DiagnosticVerifier::parseExpectedDiagInfo(
             NestedExpected.ExpectedEnd - NestedMatchStart.data();
         assert(NestedMatchEnd > 0);
         PrevMatchEnd = NestedMatch + NestedMatchEnd;
+      } else {
+        // Skip line if this an expected diagnostic with a prefix this invocation ignores,
+        // otherwise its }} will close the expansion.
+        PrevMatchEnd = MatchStart.find("\n", PrevMatchEnd);
       }
 
       size_t NextEnd = MatchStart.find("}}", PrevMatchEnd);

--- a/test/Frontend/DiagnosticVerifier/expansion-remarks.swift
+++ b/test/Frontend/DiagnosticVerifier/expansion-remarks.swift
@@ -16,6 +16,7 @@ func foo() {}
 expected-expansion@-2:14{{
     expected-remark@1{{macro content: |func foo(_ x: Int) {|}}
     expected-remark@2{{macro content: |    let a = 2|}}
+    expected-ignored-error@42{{this diagnostic should not affect the expansion}}
     expected-warning@2{{initialization of immutable value 'a' was never used; consider replacing with assignment to '_' or removing it}}
     expected-remark@3{{macro content: |    let b = x|}}
     expected-warning@3{{initialization of immutable value 'b' was never used; consider replacing with assignment to '_' or removing it}}


### PR DESCRIPTION
This adds support for the following case:
```
expected-expansion@:1:2{{
  expected-warning@3{{foo}}
  expected-sometimes-warning@4{{bar}}
  expected-warning@5{{foobar}}
}}
```
This would work when parsing the additional "sometimes-" prefix, but for invokations that didn't parse that prefix the "}}" on that line would close the expansion, and `expected-warning@5{{foobar}}` would be parsed as a top level statement.