### PR TITLE
Fix crash compiling bridging header with SWIFT_SHARED_REFERENCE and C++ interop

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -768,6 +768,12 @@ bool isCxxConstReferenceType(const clang::Type *type);
 /// attributes that makes it import as a reference types.
 bool hasImportAsRefAttr(const clang::RecordDecl *decl);
 
+/// Determine whether the given Clang record declaration or any of its base
+/// classes has the import_reference attribute. This is a lightweight check
+/// that only examines attributes without triggering CxxRecordSemantics
+/// evaluation, making it safe to use during name importing.
+bool hasImportAsRefAttrInHierarchy(const clang::RecordDecl *decl);
+
 /// Determine whether this typedef is a CF type.
 bool isCFTypeDecl(const clang::TypedefNameDecl *Decl);
 

--- a/lib/ClangImporter/ClangClassTemplateNamePrinter.cpp
+++ b/lib/ClangImporter/ClangClassTemplateNamePrinter.cpp
@@ -132,10 +132,14 @@ struct TemplateInstantiationNamePrinter
     // If this is a pointer to foreign reference type, we should not wrap
     // it in Unsafe(Mutable)?Pointer, since it will be imported as a class
     // in Swift.
+    // Note: We use hasImportAsRefAttrInHierarchy instead of
+    // recordHasReferenceSemantics here because this code runs during name
+    // importing, and CxxRecordSemantics should not be evaluated at that time
+    // (Clang sema has not yet defined implicit special members).
     bool isReferenceType = false;
     if (auto tagDecl = pointee->getAsTagDecl()) {
       if (auto *rd = dyn_cast<clang::RecordDecl>(tagDecl))
-        isReferenceType = recordHasReferenceSemantics(rd, importerImpl);
+        isReferenceType = hasImportAsRefAttrInHierarchy(rd);
     }
 
     llvm::SmallString<128> storage;


### PR DESCRIPTION
## Summary
Fix a compiler crash that occurs when compiling a bridging header with C++ interoperability enabled and `SWIFT_SHARED_REFERENCE` annotations on C++ class hierarchies.

## Problem
The `ClangClassTemplateNamePrinter::VisitPointerType` function was calling `recordHasReferenceSemantics()` during name importing for template specializations. This triggered the `CxxRecordSemantics` request evaluation, which violates the documented constraint that this request should not be evaluated during name importing (because Clang sema has not yet defined implicit special members at that point).

## Solution
Introduced a new helper function `hasImportAsRefAttrInHierarchy()` that performs a lightweight attribute only check. It examines the record and its base classes for the `import_reference` attribute without triggering `CxxRecordSemantics` evaluation, making it safe to use during name importing.

## Test plan
- [ ] Verify the fix resolves the crash reported in #86907
- [ ] Run existing C++ interop tests to ensure no regressions

Fixes #86907