### PR TITLE
Fix InlineArray protocol conformance with subscript requirements

### DIFF
--- a/stdlib/public/core/InlineArray.swift
+++ b/stdlib/public/core/InlineArray.swift
@@ -381,6 +381,32 @@ extension InlineArray where Element: Copyable {
       unsafe buffer.initialize(repeating: value)
     }
   }
+
+  /// Accesses the element at the specified position.
+  ///
+  /// This subscript provides get and set access for `Copyable` elements,
+  /// enabling conformance to protocols with subscript requirements.
+  ///
+  /// - Parameter i: The position of the element to access. `i` must be a valid
+  ///   index of the array that is not equal to the `endIndex` property.
+  ///
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.2, *)
+  @_addressableSelf
+  @_alwaysEmitIntoClient
+  public subscript(_ i: Index) -> Element {
+    @_transparent
+    get {
+      _checkIndex(i)
+      return unsafe _address[i]
+    }
+
+    @_transparent
+    set {
+      _checkIndex(i)
+      unsafe _mutableAddress[i] = newValue
+    }
+  }
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Fixes #86793

### The Problem
InlineArray currently can't conform to protocols that have a subscript getter requirement. For example, this simple code fails during -emit-module:

```
swift
protocol P {
    associatedtype Element
    subscript(index: Int) -> Element { get }
}
extension InlineArray: P {}  // ❌ Error: 'self.subscript' is borrowed and cannot be consumed
```

The error only appears during module emission, not during parsing, which makes it particularly confusing. The same protocol works fine with C++ Array.

### Root Cause
InlineArray's subscript was designed to support ~Copyable elements, so it only provides unsafeAddress and unsafeMutableAddress accessors (no explicit getter). When a protocol requires a getter, the compiler tries to synthesize one by loading from the borrowed address. However, the move checker flags this as an error because you can't consume (copy) a borrowed value.

### The Fix
I've added an explicit C++ get/ C++ set subscript for C++ Copyable elements that lives alongside the existing address-only subscript:
- For  C++ Copyable elements → uses the new subscript with proper get/set accessors
- For ~Copyable elements → continues using the original address-only subscript

This way, protocol conformances work correctly for copyable types while preserving the non-copyable behavior.

### Testing
The syntax has been verified to parse correctly. Full testing requires a Swift toolchain build.


