### PR TITLE
[cxx-interop] fix std-span-interface.swift (NFC)

### DIFF
--- a/test/Interop/Cxx/stdlib/std-span-interface.swift
+++ b/test/Interop/Cxx/stdlib/std-span-interface.swift
@@ -3,13 +3,11 @@
 // RUN: %FileCheck %s --match-full-lines < %t/interface.swift
 
 // Make sure we trigger typechecking and SIL diagnostics
-// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %S/Inputs -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature Lifetimes -cxx-interoperability-mode=default -strict-memory-safety -warnings-as-errors -verify -Xcc -std=c++20 %s
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %S/Inputs -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature Lifetimes -cxx-interoperability-mode=default -strict-memory-safety -module-cache-path %t -verify -Xcc -std=c++20 %s
 
 // REQUIRES: swift_feature_SafeInteropWrappers
 // REQUIRES: swift_feature_Lifetimes
 // REQUIRES: std_span
-
-// REQUIRES: rdar163085444
 
 #if !BRIDGING_HEADER
 import StdSpan


### PR DESCRIPTION
This makes sure that both invocations in std-span-interface.swift use the same module cache, as sharing a module cache with use-std-span.swift may pick up a clang module compiled without bounds attributes. Also removes -warnings-as-errors as it is redundant with -verify.

rdar://163085444

This offers an alternative explanation to https://github.com/swiftlang/swift/pull/86884 for why this test might fail.