### PR TITLE
build.ps1: Revert the Testing portion of #86577

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3198,6 +3198,12 @@ function Test-XCTest {
 }
 
 function Build-Testing([Hashtable] $Platform) {
+  $SwiftFlags = if ($Platform.OS -eq [OS]::Windows) {
+    @();
+  } else {
+    @("-I$(Get-SwiftSDK -OS $Platform.OS -Identifier $Platform.DefaultSDK)\usr\include");
+  }
+
   Build-CMakeProject `
     -Src $SourceCache\swift-testing `
     -Bin (Get-ProjectBinaryCache $Platform Testing) `
@@ -3208,6 +3214,7 @@ function Build-Testing([Hashtable] $Platform) {
     -Defines @{
       BUILD_SHARED_LIBS = "YES";
       CMAKE_INSTALL_BINDIR = $Platform.BinaryDir;
+      CMAKE_Swift_FLAGS = $SwiftFlags;
       SwiftTesting_MACRO = "$(Get-ProjectBinaryCache $BuildPlatform BootstrapTestingMacros)\TestingMacros.dll";
       SwiftTesting_INSTALL_NESTED_SUBDIR = "YES";
     }


### PR DESCRIPTION
This flag appears to be needed to cross-compile Testing for Android, otherwise it can't find Dispatch.

@Steelskin, your recent pull #86577 appears to have [broken the Windows toolchain CI when building the Android SDK](https://ci-external.swift.org/job/swift-main-windows-toolchain/1877/console). I'm guessing this flag is the reason, as [the prior passing run had it](https://ci-external.swift.org/job/swift-main-windows-toolchain/1872/consoleText):
```
-D CMAKE_Swift_FLAGS=\"-IT:/Program Files/Swift/Platforms/Android.platform/Developer/SDKs/Android.sdk/usr/include\" -sdk \"T:/Program Files/Swift/Platforms/Android.platform/Developer/SDKs/Android.sdk\" -sysroot T:/android-ndk-r27c/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -target -Xclang-linker aarch64-unknown-linux-android28 -Xclang-linker --sysroot -Xclang-linker T:/android-ndk-r27c/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -resource-dir -Xclang-linker T:/android-ndk-r27c/toolchains/llvm/prebuilt/windows-x86_64/lib/clang/18 -gnone
```
whereas the failing one above does not:
```
-D CMAKE_Swift_FLAGS=-sdk \"T:/Program Files/Swift/Platforms/Android.platform/Developer/SDKs/Android.sdk\" -sysroot T:/android-ndk-r27c/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -target -Xclang-linker aarch64-unknown-linux-android28 -Xclang-linker --sysroot -Xclang-linker T:/android-ndk-r27c/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Xclang-linker -resource-dir -Xclang-linker T:/android-ndk-r27c/toolchains/llvm/prebuilt/windows-x86_64/lib/clang/18 -gnone
```
However, I don't build Swift on Windows so this is just an informed guess: if you can verify it, that would be great. Otherwise, we will find out when we merge and run this through that toolchain CI again, let me know what you BCNY people think.