### PR TITLE
[Test][Interpreter] Remove unnecessary REQUIRES: shell from convenience_init_per_delegation

### DIFF
--- a/test/Interpreter/convenience_init_peer_delegation.swift
+++ b/test/Interpreter/convenience_init_peer_delegation.swift
@@ -29,9 +29,6 @@
 // REQUIRES: foundation
 // XFAIL: CPU=arm64e
 
-// Because of the use of 'sed' in this test.
-// REQUIRES: shell
-
 import Darwin
 import Foundation
 


### PR DESCRIPTION
Partially address #84407

```
#86925 fixed test/Interpreter/convenience_init_peer_delegation.swift
```

The test already has `REQUIRES: objc_interop`, so `sed` can be invoked by the internal shell externally.