### PR TITLE
[Test] Replace REQUIRES: shell with UNSUPPORTED: OS=windows-msvc

### DIFF
--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -1,5 +1,6 @@
 // Must be able to run xcrun-return-self.sh
 // UNSUPPORTED: OS=windows-msvc
+// TODO: Try to make this test work on Windows when reenabling it.
 // REQUIRES: rdar65281056
 // FIXME: When this is turned on, please move the test from linker-library-with-space.swift
 // to this file and remove that file.

--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -1,5 +1,5 @@
 // Must be able to run xcrun-return-self.sh
-// REQUIRES: shell
+// UNSUPPORTED: OS=windows-msvc
 // REQUIRES: rdar65281056
 // FIXME: When this is turned on, please move the test from linker-library-with-space.swift
 // to this file and remove that file.

--- a/test/Index/Store/index_compress.swift
+++ b/test/Index/Store/index_compress.swift
@@ -1,4 +1,4 @@
-// REQUIRES: shell
+// UNSUPPORTED: OS=windows-msvc
 
 // RUN: rm -rf %t
 // RUN: %target-swift-frontend -index-store-path %t/idx -index-store-compress -o %t.o -typecheck %s

--- a/test/Index/Store/index_compress.swift
+++ b/test/Index/Store/index_compress.swift
@@ -1,4 +1,4 @@
-// UNSUPPORTED: OS=windows-msvc
+// REQUIRES: shell
 
 // RUN: rm -rf %t
 // RUN: %target-swift-frontend -index-store-path %t/idx -index-store-compress -o %t.o -typecheck %s

--- a/test/SourceKit/CodeComplete/complete_checkdeps_avoid_check.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_avoid_check.swift
@@ -8,7 +8,7 @@ func foo() {
 }
 
 // Checks that, due to default check delay, a modification will be ignored and fast completion will still activate.
-// REQUIRES: shell
+// UNSUPPORTED: OS=windows-msvc
 
 // RUN: %empty-directory(%t/Frameworks)
 // RUN: %empty-directory(%t/MyProject)

--- a/test/SourceKit/CodeComplete/complete_checkdeps_avoid_check.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_avoid_check.swift
@@ -9,6 +9,7 @@ func foo() {
 
 // Checks that, due to default check delay, a modification will be ignored and fast completion will still activate.
 // UNSUPPORTED: OS=windows-msvc
+// TODO: Try to make this test work on Windows when reenabling it.
 
 // RUN: %empty-directory(%t/Frameworks)
 // RUN: %empty-directory(%t/MyProject)

--- a/test/SourceKit/CodeComplete/complete_checkdeps_avoid_check.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_avoid_check.swift
@@ -13,37 +13,35 @@ func foo() {
 // RUN: %empty-directory(%t/Frameworks)
 // RUN: %empty-directory(%t/MyProject)
 
-// RUN: COMPILER_ARGS=( \
-// RUN:   -target %target-triple \
-// RUN:   -module-name MyProject \
-// RUN:   -F %t/Frameworks \
-// RUN:   -I %t/MyProject \
-// RUN:   -import-objc-header %t/MyProject/Bridging.h \
-// RUN:   %t/MyProject/Library.swift \
-// RUN:   %s \
-// RUN: )
-// RUN: INPUT_DIR=%S/Inputs/checkdeps
+// DEFINE: %{args} = \
+// DEFINE:   -target %target-triple \
+// DEFINE:   -module-name MyProject \
+// DEFINE:   -F %t/Frameworks \
+// DEFINE:   -I %t/MyProject \
+// DEFINE:   -import-objc-header %t/MyProject/Bridging.h \
+// DEFINE:   %t/MyProject/Library.swift \
+// DEFINE:   %s
 
-// RUN: cp -R $INPUT_DIR/MyProject %t/
-// RUN: cp -R $INPUT_DIR/ClangFW.framework %t/Frameworks/
+// RUN: cp -R %S/Inputs/checkdeps/MyProject %t/
+// RUN: cp -R %S/Inputs/checkdeps/ClangFW.framework %t/Frameworks/
 // RUN: touch -t 202001010101 %t/Frameworks/ClangFW.framework/Headers/*
 // RUN: %empty-directory(%t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule)
-// RUN: %target-swift-frontend -emit-module -module-name SwiftFW -o %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name $INPUT_DIR/SwiftFW_src/Funcs.swift
+// RUN: %target-swift-frontend -emit-module -module-name SwiftFW -o %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name %S/Inputs/checkdeps/SwiftFW_src/Funcs.swift
 
 // RUN: %sourcekitd-test \
 // RUN:   -req=global-config == \
 
 // RUN:   -shell -- echo "### Initial" == \
-// RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} == \
+// RUN:   -req=complete -pos=5:3 %s -- %{args} == \
 
 // RUN:   -shell -- echo '### Modify framework (c)' == \
-// RUN:   -shell -- cp -R $INPUT_DIR/ClangFW.framework_mod/* %t/Frameworks/ClangFW.framework/ == \
+// RUN:   -shell -- cp -R %S/Inputs/checkdeps/ClangFW.framework_mod/* %t/Frameworks/ClangFW.framework/ == \
 // RUN:   -shell -- touch -t 210001010101 %t/Frameworks/ClangFW.framework/Headers/*  == \
-// RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} == \
+// RUN:   -req=complete -pos=5:3 %s -- %{args} == \
 
 // RUN:   -req=global-config -req-opts=completion_check_dependency_interval=0 == \
 // RUN:   -shell -- echo '### Checking dependencies' == \
-// RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} \
+// RUN:   -req=complete -pos=5:3 %s -- %{args} \
 
 // RUN:   | %FileCheck %s
 

--- a/test/SourceKit/CodeComplete/complete_checkdeps_clangmodule.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_clangmodule.swift
@@ -8,6 +8,7 @@ func foo() {
 }
 
 // UNSUPPORTED: OS=windows-msvc
+// TODO: Try to make this test work on Windows when reenabling it.
 
 // RUN: %empty-directory(%t/Frameworks)
 // RUN: %empty-directory(%t/MyProject)

--- a/test/SourceKit/CodeComplete/complete_checkdeps_clangmodule.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_clangmodule.swift
@@ -12,37 +12,35 @@ func foo() {
 // RUN: %empty-directory(%t/Frameworks)
 // RUN: %empty-directory(%t/MyProject)
 
-// RUN: COMPILER_ARGS=( \
-// RUN:   -target %target-triple \
-// RUN:   -module-name MyProject \
-// RUN:   -F %t/Frameworks \
-// RUN:   -I %t/MyProject \
-// RUN:   -import-objc-header %t/MyProject/Bridging.h \
-// RUN:   %t/MyProject/Library.swift \
-// RUN:   %s \
-// RUN: )
-// RUN: INPUT_DIR=%S/Inputs/checkdeps
+// DEFINE: %{args} = \
+// DEFINE:   -target %target-triple \
+// DEFINE:   -module-name MyProject \
+// DEFINE:   -F %t/Frameworks \
+// DEFINE:   -I %t/MyProject \
+// DEFINE:   -import-objc-header %t/MyProject/Bridging.h \
+// DEFINE:   %t/MyProject/Library.swift \
+// DEFINE:   %s
 
-// RUN: cp -R $INPUT_DIR/MyProject %t/
-// RUN: cp -R $INPUT_DIR/ClangFW.framework %t/Frameworks/
+// RUN: cp -R %S/Inputs/checkdeps/MyProject %t/
+// RUN: cp -R %S/Inputs/checkdeps/ClangFW.framework %t/Frameworks/
 // RUN: touch -t 202001010101 %t/Frameworks/ClangFW.framework/Headers/*
 // RUN: %empty-directory(%t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule)
-// RUN: %target-swift-frontend -emit-module -module-name SwiftFW -o %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name $INPUT_DIR/SwiftFW_src/Funcs.swift
+// RUN: %target-swift-frontend -emit-module -module-name SwiftFW -o %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name %S/Inputs/checkdeps/SwiftFW_src/Funcs.swift
 
 // RUN: %sourcekitd-test \
 // RUN:   -req=global-config -req-opts=completion_check_dependency_interval=0 == \
 
 // RUN:   -shell -- echo "### Initial" == \
-// RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} == \
+// RUN:   -req=complete -pos=5:3 %s -- %{args} == \
 
 // RUN:   -shell -- echo '### Modify framework (c)' == \
-// RUN:   -shell -- cp -R $INPUT_DIR/ClangFW.framework_mod/* %t/Frameworks/ClangFW.framework/ == \
+// RUN:   -shell -- cp -R %S/Inputs/checkdeps/ClangFW.framework_mod/* %t/Frameworks/ClangFW.framework/ == \
 // RUN:   -shell -- touch -t 210001010101 %t/Frameworks/ClangFW.framework/Headers/* == \
-// RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} == \
+// RUN:   -req=complete -pos=5:3 %s -- %{args} == \
 
 // RUN:   -shell -- echo '### Fast completion' == \
 // RUN:   -shell -- touch -t 202001010101 %t/Frameworks/ClangFW.framework/Headers/* == \
-// RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} \
+// RUN:   -req=complete -pos=5:3 %s -- %{args} \
 
 // RUN:   | %FileCheck %s
 

--- a/test/SourceKit/CodeComplete/complete_checkdeps_clangmodule.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_clangmodule.swift
@@ -7,7 +7,7 @@ func foo() {
   /*HERE*/
 }
 
-// REQUIRES: shell
+// UNSUPPORTED: OS=windows-msvc
 
 // RUN: %empty-directory(%t/Frameworks)
 // RUN: %empty-directory(%t/MyProject)

--- a/test/SourceKit/CodeComplete/complete_checkdeps_notifyupdate.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_notifyupdate.swift
@@ -11,34 +11,32 @@ func foo() {
 // RUN: %empty-directory(%t/Frameworks)
 // RUN: %empty-directory(%t/MyProject)
 
-// RUN: COMPILER_ARGS=( \
-// RUN:   -target %target-triple \
-// RUN:   -module-name MyProject \
-// RUN:   -F %t/Frameworks \
-// RUN:   -I %t/MyProject \
-// RUN:   -import-objc-header %t/MyProject/Bridging.h \
-// RUN:   %t/MyProject/Library.swift \
-// RUN:   %s \
-// RUN: )
-// RUN: INPUT_DIR=%S/Inputs/checkdeps
+// DEFINE: %{args} = \
+// DEFINE:   -target %target-triple \
+// DEFINE:   -module-name MyProject \
+// DEFINE:   -F %t/Frameworks \
+// DEFINE:   -I %t/MyProject \
+// DEFINE:   -import-objc-header %t/MyProject/Bridging.h \
+// DEFINE:   %t/MyProject/Library.swift \
+// DEFINE:   %s
 
-// RUN: cp -R $INPUT_DIR/MyProject %t/
-// RUN: cp -R $INPUT_DIR/ClangFW.framework %t/Frameworks/
+// RUN: cp -R %S/Inputs/checkdeps/MyProject %t/
+// RUN: cp -R %S/Inputs/checkdeps/ClangFW.framework %t/Frameworks/
 // RUN: %empty-directory(%t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule)
-// RUN: %target-swift-frontend -emit-module -module-name SwiftFW -o %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name $INPUT_DIR/SwiftFW_src/Funcs.swift
+// RUN: %target-swift-frontend -emit-module -module-name SwiftFW -o %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name %S/Inputs/checkdeps/SwiftFW_src/Funcs.swift
 
 // RUN: %sourcekitd-test \
 // RUN:   -shell -- echo "### Initial" == \
-// RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} == \
+// RUN:   -req=complete -pos=5:3 %s -- %{args} == \
 
 // RUN:   -shell -- echo '### Modify framework' == \
-// RUN:   -shell -- %target-swift-frontend -emit-module -module-name SwiftFW -o %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name $INPUT_DIR/SwiftFW_src_mod/Funcs.swift == \
-// RUN:   -req=dependency-updated -- ${COMPILER_ARGS[@]} == \
-// RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} == \
+// RUN:   -shell -- %target-swift-frontend -emit-module -module-name SwiftFW -o %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name %S/Inputs/checkdeps/SwiftFW_src_mod/Funcs.swift == \
+// RUN:   -req=dependency-updated -- %{args} == \
+// RUN:   -req=complete -pos=5:3 %s -- %{args} == \
 
 // RUN:   -shell -- echo '### Notify without modifying' == \
-// RUN:   -req=dependency-updated -- ${COMPILER_ARGS[@]} == \
-// RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} \
+// RUN:   -req=dependency-updated -- %{args} == \
+// RUN:   -req=complete -pos=5:3 %s -- %{args} \
 
 // RUN:   | %FileCheck %s
 

--- a/test/SourceKit/CodeComplete/complete_checkdeps_notifyupdate.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_notifyupdate.swift
@@ -6,6 +6,7 @@ func foo() {
 }
 
 // UNSUPPORTED: OS=windows-msvc
+// TODO: Try to make this test work on Windows when reenabling it.
 // REQUIRES: rdar74150023
 
 // RUN: %empty-directory(%t/Frameworks)

--- a/test/SourceKit/CodeComplete/complete_checkdeps_notifyupdate.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_notifyupdate.swift
@@ -5,7 +5,7 @@ func foo() {
   /*HERE*/
 }
 
-// REQUIRES: shell
+// UNSUPPORTED: OS=windows-msvc
 // REQUIRES: rdar74150023
 
 // RUN: %empty-directory(%t/Frameworks)

--- a/test/SourceKit/CodeComplete/complete_checkdeps_swiftmodule.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_swiftmodule.swift
@@ -12,37 +12,35 @@ func foo() {
 // RUN: %empty-directory(%t/Frameworks)
 // RUN: %empty-directory(%t/MyProject)
 
-// RUN: COMPILER_ARGS=( \
-// RUN:   -target %target-triple \
-// RUN:   -module-name MyProject \
-// RUN:   -F %t/Frameworks \
-// RUN:   -I %t/MyProject \
-// RUN:   -import-objc-header %t/MyProject/Bridging.h \
-// RUN:   %t/MyProject/Library.swift \
-// RUN:   %s \
-// RUN: )
-// RUN: INPUT_DIR=%S/Inputs/checkdeps
+// DEFINE: %{args} = \
+// DEFINE:   -target %target-triple \
+// DEFINE:   -module-name MyProject \
+// DEFINE:   -F %t/Frameworks \
+// DEFINE:   -I %t/MyProject \
+// DEFINE:   -import-objc-header %t/MyProject/Bridging.h \
+// DEFINE:   %t/MyProject/Library.swift \
+// DEFINE:   %s
 
-// RUN: cp -R $INPUT_DIR/MyProject %t/
-// RUN: cp -R $INPUT_DIR/ClangFW.framework %t/Frameworks/
+// RUN: cp -R %S/Inputs/checkdeps/MyProject %t/
+// RUN: cp -R %S/Inputs/checkdeps/ClangFW.framework %t/Frameworks/
 // RUN: %empty-directory(%t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule)
-// RUN: %target-swift-frontend -emit-module -module-name SwiftFW -o %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name $INPUT_DIR/SwiftFW_src/Funcs.swift
+// RUN: %target-swift-frontend -emit-module -module-name SwiftFW -o %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name %S/Inputs/checkdeps/SwiftFW_src/Funcs.swift
 // RUN: touch -t 202001010101 %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name
 
 // RUN: %sourcekitd-test \
 // RUN:   -req=global-config -req-opts=completion_check_dependency_interval=0 == \
 
 // RUN:   -shell -- echo "### Initial" == \
-// RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} == \
+// RUN:   -req=complete -pos=5:3 %s -- %{args} == \
 
 // RUN:   -shell -- echo '### Modify framework (s)' == \
-// RUN:   -shell --  %target-swift-frontend -emit-module -module-name SwiftFW -o %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name $INPUT_DIR/SwiftFW_src_mod/Funcs.swift == \
+// RUN:   -shell --  %target-swift-frontend -emit-module -module-name SwiftFW -o %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name %S/Inputs/checkdeps/SwiftFW_src_mod/Funcs.swift == \
 // RUN:    -shell -- touch -t 210001010101 %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name == \
-// RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} == \
+// RUN:   -req=complete -pos=5:3 %s -- %{args} == \
 
 // RUN:   -shell -- echo '### Fast completion' == \
 // RUN:   -shell -- touch -t 202001010101 %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name == \
-// RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} \
+// RUN:   -req=complete -pos=5:3 %s -- %{args} \
 
 // RUN:   | %FileCheck %s
 

--- a/test/SourceKit/CodeComplete/complete_checkdeps_swiftmodule.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_swiftmodule.swift
@@ -8,6 +8,7 @@ func foo() {
 }
 
 // UNSUPPORTED: OS=windows-msvc
+// TODO: Try to make this test work on Windows when reenabling it.
 
 // RUN: %empty-directory(%t/Frameworks)
 // RUN: %empty-directory(%t/MyProject)

--- a/test/SourceKit/CodeComplete/complete_checkdeps_swiftmodule.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_swiftmodule.swift
@@ -7,7 +7,7 @@ func foo() {
   /*HERE*/
 }
 
-// REQUIRES: shell
+// UNSUPPORTED: OS=windows-msvc
 
 // RUN: %empty-directory(%t/Frameworks)
 // RUN: %empty-directory(%t/MyProject)


### PR DESCRIPTION
Partially address #84407

```
#86927 fixed:
- test/SourceKit/CodeComplete/complete_checkdeps_clangmodule.swift                     
- test/SourceKit/CodeComplete/complete_checkdeps_swiftmodule.swift                     
- test/SourceKit/CodeComplete/complete_checkdeps_notifyupdate.swift                    
- test/SourceKit/CodeComplete/complete_checkdeps_avoid_check.swift
- test/Driver/linker.swift
```

Some of the test have radar requirements, but are still blocking: `Test requires the following unavailable features: shell`.
