### PR TITLE
[Test][Driver] Replace REQUIRES: shell with UNSUPPORTED: OS=windows-msvc in subcommands

### DIFF
--- a/test/Driver/subcommands.swift
+++ b/test/Driver/subcommands.swift
@@ -1,4 +1,4 @@
-// REQUIRES: shell
+// UNSUPPORTED: OS=windows-msvc
 // Check that 'swift' and 'swift repl' invoke the REPL.
 
 // RUN: rm -rf %t.dir


### PR DESCRIPTION
Partially address #84407

```
#86929 fixed test/Driver/subcommands.swift
```