### PR TITLE
Fix two Wasm test harness issues and re-enable more autodiff tests

### DIFF
--- a/test/AutoDiff/SIL/Parse/sildeclref.sil
+++ b/test/AutoDiff/SIL/Parse/sildeclref.sil
@@ -1,8 +1,5 @@
 // RUN: %target-sil-opt -sil-print-types %s -module-name=sildeclref_parse | %target-sil-opt -sil-print-types -module-name=sildeclref_parse | %FileCheck %s
 // Parse AutoDiff derivative SILDeclRefs via `witness_method` and `class_method` instructions.
-
-// UNSUPPORTED: OS=wasip1
-
 import Swift
 import _Differentiation
 

--- a/test/AutoDiff/SIL/Serialization/differentiable_function_type.swift
+++ b/test/AutoDiff/SIL/Serialization/differentiable_function_type.swift
@@ -9,8 +9,6 @@
 // RUN: %target-sil-opt -sil-print-types %t/tmp_fixed.sil -module-name main -emit-sorted-sil | %FileCheck %s
 
 
-// UNSUPPORTED: OS=wasip1
-
 sil_stage raw
 
 import Swift

--- a/test/AutoDiff/SIL/differentiability_witness_function_inst.sil
+++ b/test/AutoDiff/SIL/differentiability_witness_function_inst.sil
@@ -20,8 +20,6 @@
 // NOTE: `%target-cpu`-specific FileCheck lines exist because lowered function types in LLVM IR differ between architectures.
 
 
-// UNSUPPORTED: OS=wasip1
-
 sil_stage raw
 
 import Swift

--- a/test/AutoDiff/SIL/differentiability_witness_function_inst_transpose.sil
+++ b/test/AutoDiff/SIL/differentiability_witness_function_inst_transpose.sil
@@ -18,8 +18,6 @@
 // RUN: %target-sil-opt %t/tmp_fixed.sil -module-name main -emit-sorted-sil | %FileCheck %s
 
 
-// UNSUPPORTED: OS=wasip1
-
 sil_stage raw
 
 import Swift

--- a/test/AutoDiff/SIL/differentiable_function_inst.sil
+++ b/test/AutoDiff/SIL/differentiable_function_inst.sil
@@ -20,7 +20,6 @@
 
 // Would need to update for arm64e.
 // UNSUPPORTED: CPU=arm64e
-// UNSUPPORTED: OS=wasip1
 
 sil_stage raw
 

--- a/test/AutoDiff/SIL/linear_function_inst.sil
+++ b/test/AutoDiff/SIL/linear_function_inst.sil
@@ -13,8 +13,6 @@
 // RUN: sed -e 's/import Swift$/import Swift; import _Differentiation/' %t/tmp.sil > %t/tmp_fixed.sil
 // RUN: %target-sil-opt -sil-print-types %t/tmp_fixed.sil -module-name main -emit-sorted-sil | %FileCheck %s --check-prefix=CHECK-SIL
 
-// UNSUPPORTED: OS=wasip1
-
 sil_stage raw
 
 import Swift

--- a/test/AutoDiff/SIL/sil_differentiability_witness.sil
+++ b/test/AutoDiff/SIL/sil_differentiability_witness.sil
@@ -19,8 +19,6 @@
 // RUN: %target-swift-frontend -emit-ir %s | %FileCheck --check-prefix=IRGEN %s
 
 
-// UNSUPPORTED: OS=wasip1
-
 sil_stage raw
 
 import Builtin

--- a/test/AutoDiff/SILGen/sil_differentiability_witness.swift
+++ b/test/AutoDiff/SILGen/sil_differentiability_witness.swift
@@ -1,7 +1,5 @@
 // RUN: %target-swift-frontend -emit-silgen %s | %target-sil-opt -sil-verify-none | %FileCheck %s
 
-// UNSUPPORTED: OS=wasip1
-
 // Test SIL differentiability witness SIL generation.
 
 import _Differentiation

--- a/test/AutoDiff/SILOptimizer/closure_specialization/multi_bb_bte.sil
+++ b/test/AutoDiff/SILOptimizer/closure_specialization/multi_bb_bte.sil
@@ -5,8 +5,6 @@
 
 // REQUIRES: swift_in_compiler
 
-// UNSUPPORTED: OS=wasip1
-
 sil_stage canonical
 
 import Builtin

--- a/test/AutoDiff/SILOptimizer/closure_specialization/multi_bb_no_bte1.sil
+++ b/test/AutoDiff/SILOptimizer/closure_specialization/multi_bb_no_bte1.sil
@@ -4,8 +4,6 @@
 
 // REQUIRES: swift_in_compiler
 
-// UNSUPPORTED: OS=wasip1
-
 sil_stage canonical
 
 import Builtin

--- a/test/AutoDiff/SILOptimizer/closure_specialization/single_bb.sil
+++ b/test/AutoDiff/SILOptimizer/closure_specialization/single_bb.sil
@@ -2,8 +2,6 @@
 
 // REQUIRES: swift_in_compiler
 
-// UNSUPPORTED: OS=wasip1
-
 sil_stage canonical
 
 import Builtin

--- a/test/AutoDiff/SILOptimizer/differentiability_witness_inlining.sil
+++ b/test/AutoDiff/SILOptimizer/differentiability_witness_inlining.sil
@@ -1,7 +1,5 @@
 // RUN: %target-sil-opt -differentiability-witness-devirtualizer %s -enable-sil-verify-all | %FileCheck %s
 
-// UNSUPPORTED: OS=wasip1
-
 sil_stage raw
 
 import _Differentiation

--- a/test/AutoDiff/SILOptimizer/differentiation_function_canonicalization.sil
+++ b/test/AutoDiff/SILOptimizer/differentiation_function_canonicalization.sil
@@ -1,7 +1,5 @@
 // RUN: %target-sil-opt -sil-print-types -differentiation %s | %FileCheck %s
 
-// UNSUPPORTED: OS=wasip1
-
 sil_stage raw
 
 import _Differentiation

--- a/test/AutoDiff/SILOptimizer/linear_function_canonicalization.sil
+++ b/test/AutoDiff/SILOptimizer/linear_function_canonicalization.sil
@@ -1,7 +1,5 @@
 // RUN: %target-sil-opt -sil-print-types -differentiation -enable-experimental-linear-map-transposition %s | %FileCheck %s
 
-// UNSUPPORTED: OS=wasip1
-
 sil_stage raw
 
 import Swift

--- a/test/AutoDiff/SILOptimizer/pullback_generation.sil
+++ b/test/AutoDiff/SILOptimizer/pullback_generation.sil
@@ -3,8 +3,6 @@
 
 // RUN: %target-sil-opt -sil-print-types --differentiation -emit-sorted-sil %s 2>&1 | %FileCheck %s
 
-// UNSUPPORTED: OS=wasip1
-
 //===----------------------------------------------------------------------===//
 // Pullback generation - `struct_extract`
 // - Input to pullback has non-owned ownership semantics which requires copying

--- a/test/AutoDiff/Serialization/derivative_attr.swift
+++ b/test/AutoDiff/Serialization/derivative_attr.swift
@@ -5,8 +5,6 @@
 
 // BCANALYZER-NOT: UnknownCode
 
-// UNSUPPORTED: OS=wasip1
-
 import _Differentiation
 
 // Dummy `Differentiable`-conforming type.

--- a/test/AutoDiff/Serialization/differentiable_attr.swift
+++ b/test/AutoDiff/Serialization/differentiable_attr.swift
@@ -3,8 +3,6 @@
 // RUN: llvm-bcanalyzer %t/differentiable_attr.swiftmodule | %FileCheck %s -check-prefix=BCANALYZER
 // RUN: %target-sil-opt -enable-sil-verify-all %t/differentiable_attr.swiftmodule -o - | %FileCheck %s
 
-// UNSUPPORTED: OS=wasip1
-
 // BCANALYZER-NOT: UnknownCode
 
 import _Differentiation

--- a/test/AutoDiff/Serialization/differentiable_function.swift
+++ b/test/AutoDiff/Serialization/differentiable_function.swift
@@ -5,8 +5,6 @@
 
 // BCANALYZER-NOT: UnknownCode
 
-// UNSUPPORTED: OS=wasip1
-
 import _Differentiation
 
 func a(_ f: @differentiable(reverse) (Float) -> Float) {}

--- a/test/AutoDiff/Serialization/transpose_attr.swift
+++ b/test/AutoDiff/Serialization/transpose_attr.swift
@@ -5,8 +5,6 @@
 
 // BCANALYZER-NOT: UnknownCode
 
-// UNSUPPORTED: OS=wasip1
-
 import _Differentiation
 
 // Dummy `Differentiable`-conforming type.

--- a/test/AutoDiff/sil_combine.sil
+++ b/test/AutoDiff/sil_combine.sil
@@ -1,7 +1,5 @@
 // RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all %s -sil-combine | %FileCheck %s
 
-// UNSUPPORTED: OS=wasip1
-
 // SILCombine tests for differentiation-related instructions.
 
 sil_stage canonical

--- a/test/AutoDiff/validation-test/always_emit_into_client/multi_module_struct_no_jvp.swift
+++ b/test/AutoDiff/validation-test/always_emit_into_client/multi_module_struct_no_jvp.swift
@@ -17,6 +17,7 @@
 
 // RUN: %target-build-swift -I%t %s -emit-ir | %FileCheck %s
 
+// Unsupported due to expectCrash() not working
 // UNSUPPORTED: OS=wasip1
 
 import MultiModuleStruct1

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2131,9 +2131,11 @@ elif kIsWASI:
 
     if 'interpret' in lit_config.params:
         use_interpreter_for_simple_runs()
+    # Use SDKROOT instead of -sdk because a couple tests set another -sdk and
+    # sil-opt errors if passed -sdk multiple times.
     config.target_sil_opt = (
-        '%s -target %s %s %s %s' %
-        (config.sil_opt, config.variant_triple, config.resource_dir_opt, mcp_opt, config.sil_test_options))
+        'env SDKROOT=%s %s -target %s %s %s %s' %
+        (shell_quote(config.variant_sdk), config.sil_opt, config.variant_triple, config.resource_dir_opt, mcp_opt, config.sil_test_options))
     subst_target_sil_opt_mock_sdk = config.target_sil_opt
     subst_target_sil_opt_mock_sdk_after = ""
     config.target_swift_symbolgraph_extract = ' '.join([

--- a/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
@@ -44,11 +44,11 @@ class WasmStdlib(cmake_product.CMakeProduct):
         self._build(host_target, 'wasm32-wasip1', 'wasip1-wasm32')
 
     def _build(self, host_target, target_triple, short_triple):
-        llvm_build_dir = self._configure_llvm(target_triple, short_triple)
+        llvm_build_dir = self._configure_llvm(host_target, target_triple, short_triple)
         llvm_cmake_dir = os.path.join(llvm_build_dir, 'lib', 'cmake', 'llvm')
         self._build_stdlib(host_target, target_triple, llvm_cmake_dir)
 
-    def _configure_llvm(self, target_triple, short_triple):
+    def _configure_llvm(self, host_target, target_triple, short_triple):
         # Configure LLVM for WebAssembly target independently
         # from the native LLVM build to turn off zlib and libxml2
         build_root = os.path.dirname(self.build_dir)
@@ -56,7 +56,8 @@ class WasmStdlib(cmake_product.CMakeProduct):
             build_root, 'llvm-%s' % short_triple)
         llvm_source_dir = os.path.join(
             os.path.dirname(self.source_dir), 'llvm-project', 'llvm')
-        cmake_options = cmake.CMakeOptions()
+
+        cmake_options, _, relevant_options = self.host_cmake_options(host_target)
         cmake_options.define('CMAKE_BUILD_TYPE:STRING', self._build_variant)
         # compiler-rt for WebAssembly target is not installed in the host toolchain
         # so skip compiler health checks here.


### PR DESCRIPTION
 - Correctly construct cmake cmdline for wasmstdlib including cmake common host options. This is required in order to include e.g. `CMAKE_OSX_SYSROOT` on macOS, etc.
 - Ensure we're passing path to newly-built SDK to sil-opt

This makes almost every AutoDiff tests passing for Wasm target (the only exception is `AutoDiff/validation-test/always_emit_into_client/multi_module_struct_no_jvp.swift` as `expectCrash()` is not working properly on Wasm.