### PR TITLE
[cxx-interop] Reapply adoption of ~Copyable on UnsafeCxxInputIterator

### DIFF
--- a/stdlib/public/Cxx/UnsafeCxxIterators.swift
+++ b/stdlib/public/Cxx/UnsafeCxxIterators.swift
@@ -18,7 +18,7 @@
 ///
 /// - SeeAlso: https://en.cppreference.com/w/cpp/named_req/InputIterator
 public protocol UnsafeCxxInputIterator: Equatable {
-  associatedtype Pointee
+  associatedtype Pointee: ~Copyable
 
   /// Returns the unwrapped result of C++ `operator*()`.
   ///
@@ -34,19 +34,23 @@ public protocol UnsafeCxxInputIterator: Equatable {
   func successor() -> Self
 }
 
-extension UnsafePointer: @unsafe UnsafeCxxInputIterator {}
+extension UnsafePointer: @unsafe UnsafeCxxInputIterator
+where Pointee: ~Copyable {}
 
-extension UnsafeMutablePointer: @unsafe UnsafeCxxInputIterator {}
+extension UnsafeMutablePointer: @unsafe UnsafeCxxInputIterator
+where Pointee: ~Copyable {}
 
 extension Optional: UnsafeCxxInputIterator where Wrapped: UnsafeCxxInputIterator {
   public typealias Pointee = Wrapped.Pointee
 
   @inlinable
   public var pointee: Pointee {
-    if let value = self {
-      return value.pointee
+    _read {
+      guard let value = self else {
+        fatalError("Could not dereference nullptr")
+      }
+      yield value.pointee
     }
-    fatalError("Could not dereference nullptr")
   }
 
   @inlinable
@@ -63,7 +67,8 @@ public protocol UnsafeCxxMutableInputIterator: UnsafeCxxInputIterator {
   override var pointee: Pointee { get set }
 }
 
-extension UnsafeMutablePointer: UnsafeCxxMutableInputIterator {}
+extension UnsafeMutablePointer: UnsafeCxxMutableInputIterator
+where Pointee: ~Copyable {}
 
 /// Bridged C++ iterator that allows computing the distance between two of its
 /// instances, and advancing an instance by a given number of elements.
@@ -79,14 +84,17 @@ public protocol UnsafeCxxRandomAccessIterator: UnsafeCxxInputIterator {
   static func +=(lhs: inout Self, rhs: Distance)
 }
 
-extension UnsafePointer: @unsafe UnsafeCxxRandomAccessIterator {}
+extension UnsafePointer: @unsafe UnsafeCxxRandomAccessIterator
+where Pointee: ~Copyable {}
 
-extension UnsafeMutablePointer: @unsafe UnsafeCxxRandomAccessIterator {}
+extension UnsafeMutablePointer: @unsafe UnsafeCxxRandomAccessIterator
+where Pointee: ~Copyable {}
 
 public protocol UnsafeCxxMutableRandomAccessIterator:
 UnsafeCxxRandomAccessIterator, UnsafeCxxMutableInputIterator {}
 
-extension UnsafeMutablePointer: UnsafeCxxMutableRandomAccessIterator {}
+extension UnsafeMutablePointer: UnsafeCxxMutableRandomAccessIterator
+where Pointee: ~Copyable {}
 
 /// Bridged C++ iterator that allows traversing elements of a random access
 /// collection that are stored in contiguous memory segments.


### PR DESCRIPTION
This reverts https://github.com/swiftlang/swift/pull/72537 - we tried to make `UnsafeCxxInputIterator` accept a `~Copyable` Pointee, but that caused bootstrapping problems and so these changes got reverted.

Now, we need `Pointee` in `UnsafeCxxInputIterator` to be `~Copyable` so that we can reuse this protocol when we adopt the `BorrowingSequence` protocol in the C++ stdlib overlay. 