### PR TITLE
[Literal Expressions] Add support for literal expressions in enum raw values

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -8948,9 +8948,9 @@ class EnumElementDecl : public DeclContext, public ValueDecl {
   ParameterList *Params;
   
   SourceLoc EqualsLoc;
-  
-  /// The raw value literal for the enum element, or null.
-  LiteralExpr *RawValueExpr;
+
+  /// The raw value expression for the enum element, or null.
+  Expr *RawValueExpr;
 
 protected:
   struct {
@@ -8961,7 +8961,7 @@ public:
   EnumElementDecl(SourceLoc IdentifierLoc, DeclName Name,
                   ParameterList *Params,
                   SourceLoc EqualsLoc,
-                  LiteralExpr *RawValueExpr,
+                  Expr *RawValueExpr,
                   DeclContext *DC);
 
   /// Returns the string for the base name, or "_" if this is unnamed.
@@ -8981,20 +8981,17 @@ public:
   void setParameterList(ParameterList *params);
   ParameterList *getParameterList() const { return Params; }
 
-  /// Retrieves a fully typechecked raw value expression associated
-  /// with this enum element, if it exists.
+  /// Retrieves a raw value expression associated with this enum element, if it
+  /// exists, as it was written in the source.
+  Expr *getOriginalRawValueExpr() const;
+
+  /// Retrieves a fully-typechecked and (if LiteralExpressions experimental
+  /// feature is enabled) constant-folded raw value expression associated with
+  /// this enum element, if it exists.
   LiteralExpr *getRawValueExpr() const;
-  
-  /// Retrieves a "structurally" checked raw value expression associated
-  /// with this enum element, if it exists.
-  ///
-  /// The structural raw value may or may not have a type set, but it is
-  /// guaranteed to be suitable for retrieving any non-semantic information
-  /// like digit text for an integral raw value or user text for a string raw value.
-  LiteralExpr *getStructuralRawValueExpr() const;
-  
+
   /// Reset the raw value expression.
-  void setRawValueExpr(LiteralExpr *e);
+  void setRawValueExpr(Expr *e);
 
   /// Return the containing EnumDecl.
   EnumDecl *getParentEnum() const {
@@ -9020,7 +9017,7 @@ public:
 
   /// Do not call this!
   /// It exists to let the AST walkers get the raw value without forcing a request.
-  LiteralExpr *getRawValueUnchecked() const { return RawValueExpr; }
+  Expr *getRawValueUnchecked() const { return RawValueExpr; }
 
   static bool classof(const Decl *D) {
     return D->getKind() == DeclKind::EnumElement;

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -888,6 +888,8 @@ ERROR(expected_expr_enum_case_raw_value,PointsToFirstBadToken,
       "expected expression after '=' in 'case'", ())
 ERROR(nonliteral_enum_case_raw_value,PointsToFirstBadToken,
       "raw value for enum case must be a literal", ())
+ERROR(nonliteral_int_expr_enum_case_raw_value,PointsToFirstBadToken,
+      "raw value for enum case must be an integer literal expression", ())
 
 // Collection Types
 ERROR(new_array_syntax,none,

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -2406,8 +2406,8 @@ public:
 /// Computes the raw values for an enum type.
 class EnumRawValuesRequest :
     public SimpleRequest<EnumRawValuesRequest,
-                         evaluator::SideEffect (EnumDecl *, TypeResolutionStage),
-                         RequestFlags::SeparatelyCached> {
+                         evaluator::SideEffect (EnumDecl *),
+                         RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
   
@@ -2416,17 +2416,15 @@ private:
   
   // Evaluation.
   evaluator::SideEffect
-  evaluate(Evaluator &evaluator, EnumDecl *ED, TypeResolutionStage stage) const;
+  evaluate(Evaluator &evaluator, EnumDecl *ED) const;
   
 public:
   // Cycle handling.
   void diagnoseCycle(DiagnosticEngine &diags) const;
   void noteCycleStep(DiagnosticEngine &diags) const;
                            
-  // Separate caching.
-  bool isCached() const;
-  std::optional<evaluator::SideEffect> getCachedResult() const;
-  void cacheResult(evaluator::SideEffect value) const;
+  // Caching.
+  bool isCached() const { return true; }
 };
 
 /// Determines if an override is ABI compatible with its base method.

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -99,7 +99,7 @@ SWIFT_REQUEST(TypeChecker, SpecializeAttrTargetDeclRequest,
               ValueDecl *(const ValueDecl *, AbstractSpecializeAttr *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, EnumRawValuesRequest,
-              evaluator::SideEffect (EnumDecl *, TypeResolutionStage),
+              evaluator::SideEffect (EnumDecl *),
               SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, EnumRawTypeRequest,
               Type(EnumDecl *), Cached, NoLocationInfo)

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4739,7 +4739,7 @@ void PrintAST::printEnumElement(EnumElementDecl *elt) {
     break;
   }
 
-  auto *raw = elt->getStructuralRawValueExpr();
+  auto *raw = elt->getRawValueExpr();
   if (!raw || raw->isImplicit())
     return;
 

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -589,10 +589,9 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
         return true;
     }
 
-    if (auto *rawLiteralExpr = ED->getRawValueUnchecked()) {
-      if (Expr *newRawExpr = doIt(rawLiteralExpr)) {
-        auto *newLiteralRawExpr = cast<LiteralExpr>(newRawExpr);
-        ED->setRawValueExpr(newLiteralRawExpr);
+    if (auto *rawExpr = ED->getRawValueUnchecked()) {
+      if (Expr *newRawExpr = doIt(rawExpr)) {
+        ED->setRawValueExpr(newRawExpr);
       } else {
         return true;
       }

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1028,24 +1028,6 @@ void StructuralTypeRequest::diagnoseCycle(DiagnosticEngine &diags) const {
 // EnumRawValuesRequest computation.
 //----------------------------------------------------------------------------//
 
-bool EnumRawValuesRequest::isCached() const {
-  return std::get<1>(getStorage()) == TypeResolutionStage::Interface;
-}
-
-std::optional<evaluator::SideEffect>
-EnumRawValuesRequest::getCachedResult() const {
-  auto *ED = std::get<0>(getStorage());
-  if (ED->SemanticFlags.contains(EnumDecl::HasFixedRawValuesAndTypes))
-    return std::make_tuple<>();
-  return std::nullopt;
-}
-
-void EnumRawValuesRequest::cacheResult(evaluator::SideEffect) const {
-  auto *ED = std::get<0>(getStorage());
-  ED->SemanticFlags |= OptionSet<EnumDecl::SemanticInfoFlags>{
-      EnumDecl::HasFixedRawValues | EnumDecl::HasFixedRawValuesAndTypes};
-}
-
 void EnumRawValuesRequest::diagnoseCycle(DiagnosticEngine &diags) const {
   // This request computes the raw type, and so participates in cycles involving
   // it. For now, the raw type provides a rich enough circularity diagnostic

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -1398,12 +1398,12 @@ synthesizeEnumRawValueConstructorBody(AbstractFunctionDecl *afd,
     SmallVector<CaseLabelItem, 8> validCaseLabels;
     for (auto *elt : enumDecl->getAllElements()) {
       // Get the raw value literal for this element
-      auto rawValueExpr = elt->getStructuralRawValueExpr();
+      auto rawValueExpr = elt->getRawValueExpr();
       if (!rawValueExpr)
         continue;
 
       // Clone the raw value expression for pattern matching
-      auto *litExpr = cloneRawLiteralExpr(ctx, cast<LiteralExpr>(rawValueExpr));
+      auto *litExpr = cloneRawLiteralExpr(ctx, rawValueExpr);
       auto *litPat = ExprPattern::createImplicit(ctx, litExpr, ctorDecl);
 
       // Add to the list of valid case labels

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -980,7 +980,7 @@ private:
       }
 
       // Print the raw values, even the ones that we synthesize.
-      auto *ILE = cast<IntegerLiteralExpr>(Elt->getStructuralRawValueExpr());
+      auto *ILE = cast<IntegerLiteralExpr>(Elt->getRawValueExpr());
       os << " = ";
       if (ILE->isNegative())
         os << "-";

--- a/lib/Sema/LiteralExpressionFolding.cpp
+++ b/lib/Sema/LiteralExpressionFolding.cpp
@@ -223,7 +223,6 @@ private:
     ASTContext &Ctx;
     llvm::DenseMap<Expr *, FoldingErrorOr<ConstantValuePtr>>
         ConstValuesOrErrors;
-
   public:
     ConstantWalker(ASTContext &ctx) : Ctx(ctx) {}
 

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -3683,7 +3683,7 @@ public:
     }
 
     // Force the raw value expr then yell if our parent doesn't have a raw type.
-    Expr *RVE = EED->getRawValueExpr();
+    Expr *RVE = EED->getOriginalRawValueExpr();
     if (RVE && !ED->hasRawType()) {
       DE.diagnose(RVE->getLoc(), diag::enum_raw_value_without_raw_type);
       EED->setInvalid();

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -5091,7 +5091,7 @@ public:
     if (elem->getParentEnum()->isObjC()) {
       // Currently ObjC enums always have integer raw values.
       rawValueKind = EnumElementRawValueKind::IntegerLiteral;
-      auto ILE = cast<IntegerLiteralExpr>(elem->getStructuralRawValueExpr());
+      auto ILE = cast<IntegerLiteralExpr>(elem->getRawValueExpr());
       RawValueText = ILE->getDigitsText();
       isNegative = ILE->isNegative();
       isRawValueImplicit = ILE->isImplicit();

--- a/test/LiteralExpressions/EnumRawValue.swift
+++ b/test/LiteralExpressions/EnumRawValue.swift
@@ -1,0 +1,36 @@
+// Enum case raw value expressions
+// REQUIRES: swift_feature_LiteralExpressions
+// RUN: %target-swift-frontend -typecheck -dump-ast %s -enable-experimental-feature LiteralExpressions -verify | %FileCheck %s
+
+enum E1: Int {
+    case a = 2 + 2
+    case b
+    case c
+}
+// CHECK-LABEL: (enum_element_decl {{.*}} "a" interface_type="(E1.Type) -> E1"
+// CHECK: (original_raw_value_expr=binary_expr type="Int" {{.*}} nothrow isolation_crossing="none"
+// CHECK: (folded_raw_value_expr=integer_literal_expr implicit type="Int" {{.*}} value="4" builtin_initializer="Swift.(file).Int.init(_builtinIntegerLiteral:)"
+
+// CHECK-LABEL: (enum_element_decl {{.*}} "b" interface_type="(E1.Type) -> E1"
+// CHECK: (raw_value_expr=integer_literal_expr implicit type="Int" {{.*}} value="5" builtin_initializer="Swift.(file).Int.init(_builtinIntegerLiteral:)"
+
+// CHECK-LABEL: (enum_element_decl {{.*}} "c" interface_type="(E1.Type) -> E1"
+// CHECK: (raw_value_expr=integer_literal_expr implicit type="Int" {{.*}} value="6" builtin_initializer="Swift.(file).Int.init(_builtinIntegerLiteral:)"
+
+@section("mysection") let sectionInt = 42
+let someOtherInt = 42
+enum E2: Int {
+    case life = sectionInt
+    case universe = someOtherInt << 1
+    case everything
+}
+// CHECK-LABEL: (enum_element_decl {{.*}} "life" interface_type="(E2.Type) -> E2"
+// CHECK: (original_raw_value_expr=declref_expr type="Int" {{.*}} decl="EnumRawValue.(file).sectionInt@{{.*}}EnumRawValue.swift:{{[0-9]+}}:{{[0-9]+}}" function_ref=unapplied)
+// CHECK: (folded_raw_value_expr=integer_literal_expr implicit type="Int" {{.*}} value="42" builtin_initializer="Swift.(file).Int.init(_builtinIntegerLiteral:)"
+
+// CHECK-LABEL: (enum_element_decl {{.*}} "universe" interface_type="(E2.Type) -> E2"
+// CHECK: (original_raw_value_expr=binary_expr type="Int" {{.*}} nothrow isolation_crossing="none"
+// CHECK: (folded_raw_value_expr=integer_literal_expr implicit type="Int" {{.*}} value="84" builtin_initializer="Swift.(file).Int.init(_builtinIntegerLiteral:)"
+
+// CHECK-LABEL: (enum_element_decl {{.*}} "everything" interface_type="(E2.Type) -> E2"
+// CHECK: (raw_value_expr=integer_literal_expr implicit type="Int" {{.*}} value="85" builtin_initializer="Swift.(file).Int.init(_builtinIntegerLiteral:)"

--- a/test/LiteralExpressions/EnumRawValueFail.swift
+++ b/test/LiteralExpressions/EnumRawValueFail.swift
@@ -1,0 +1,26 @@
+// Enum case raw value expressions
+// REQUIRES: swift_feature_LiteralExpressions
+// RUN: %target-swift-frontend -typecheck %s -enable-experimental-feature LiteralExpressions -verify -verify-ignore-unrelated
+
+enum E1: Int {
+    case a = 2 + Int.random(in: 0 ..< 10)
+    // expected-error@-1 {{not supported in a literal expression}}
+    // expected-error@-2 {{raw value for enum case must be an integer literal expression}}
+    case b
+    case c
+}
+
+enum E2: Int {
+    case a = 2.0
+    // expected-error@-1 {{cannot convert value of type 'Double' to raw type 'Int'}}
+    // expected-error@-3 {{'E2' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized}}
+    // expected-note@-4 {{add stubs for conformance}}
+}
+
+enum E3: Int {
+    case a = 2 + 2.0
+    // expected-error@-1 {{cannot convert value of type 'Double' to raw type 'Int'}}
+    // expected-error@-2 {{raw value for enum case must be an integer literal expression}}
+    case b
+    case c
+}

--- a/test/LiteralExpressions/EnumRawValueInterface.swift
+++ b/test/LiteralExpressions/EnumRawValueInterface.swift
@@ -1,0 +1,19 @@
+// Enum case raw value expressions
+// REQUIRES: swift_feature_LiteralExpressions
+// RUN: %target-swift-frontend -emit-module -module-name EnumRawValueInterface -emit-module-interface-path %t/EnumRawValueInterface.swiftinterface -enable-library-evolution -swift-version 5 %s -enable-experimental-feature LiteralExpressions
+// RUN: %FileCheck %s < %t/EnumRawValueInterface.swiftinterface
+
+// CHECK-LABEL: public enum E1 : Swift.Int {
+public enum E1: Int {
+    // CHECK-NEXT: case a
+    // CHECK-NEXT: case b
+    // CHECK-NEXT: case c
+    case a = 2 + 2
+    case b
+    case c
+  // CHECK-DAG: public typealias RawValue = Swift.Int
+  // CHECK-DAG: public init?(rawValue: Swift.Int)
+  // CHECK-DAG: public var rawValue: Swift.Int {
+  // CHECK-DAG:   get{{$}}
+  // CHECK-DAG: }    
+} // CHECK: {{^}$}}

--- a/test/LiteralExpressions/EnumRawValueRun.swift
+++ b/test/LiteralExpressions/EnumRawValueRun.swift
@@ -1,0 +1,34 @@
+// Enum case raw value expressions
+// REQUIRES: swift_feature_LiteralExpressions
+// RUN: %target-run-simple-swift(-enable-experimental-feature LiteralExpressions) | %FileCheck %s --dump-input=always
+
+// CHECK: 1
+// CHECK-NEXT: 2
+// CHECK-NEXT: 4
+// CHECK-NEXT: 8
+// CHECK-NEXT: 16
+// CHECK-NEXT: 32
+// CHECK-NEXT: 4
+// CHECK-NEXT: 5
+// CHECK-NEXT: 6
+
+enum Powers: Int, CaseIterable {
+    case zero = 1 << 0
+    case one = 1 << 1
+    case two = 1 << 2
+    case three = 1 << 3
+    case four = 1 << 4
+    case five = 1 << 5
+}
+enum E1: Int, CaseIterable {
+    case a = 2 + 2
+    case b
+    case c
+}
+
+for c in Powers.allCases {
+    print(c.rawValue)
+}
+for c in E1.allCases {
+    print(c.rawValue)
+}

--- a/test/expr/unary/async_await.swift
+++ b/test/expr/unary/async_await.swift
@@ -37,7 +37,7 @@ func test5<T>(_ f : () async throws -> T)  rethrows->T { // expected-note{{add '
 }
 
 enum SomeEnum: Int {
-case foo = await 5 // expected-error{{raw value for enum case must be a literal}}
+  case foo = await 5 // expected-error{{raw value for enum case must be a literal}}
 }
 
 struct SomeStruct {


### PR DESCRIPTION
Modify relevant portions of the type-checker and parser to allow, when the `LiteralExpressions` experimental feature is enabled, for arbitrary integer-typed expressions in enum raw value specifiers. These expressions will be type-checked and constant-folded into an integer literal expression, keeping the current interface of `EnumElementDecl` consistent for clients.

Previously, `EnumRawValuesRequest` had two different "modes" which were discerned based on type-checking stage (`structural` | `interface`), where the former had the request compute all raw values, both user-specified literal expressions and computing increment-derived values as well; the latter would also type-check the user-specified expressions and compute their types.
    - With the need to have enum case raw values support arbitrary integer expressions, the request (`EnumRawValuesRequest`) has been refactored and simplified to *always* both compute all case raw values and perform type-checking of user-specified raw value expressions. This is done in order to allow the AST-based constant-folding infrastructure (`ConstantFoldExpression` request) to run on the expressions. Constant folding is invoked during the evaluation of `EnumRawValuesRequest` on all user-specified raw value expressions, in order to be able to compute subsequent increment values and ensure the expressions are foldable. If they are not, i.e. if constant folding fails, a relevant diagnostic will be emitted.
    - `EnumElementDecl` continues to store the raw value expression, which is no longer a `LiteralExpr` but rather an `Expr`; however, the getter (`getRawValueExpr`) continues to return a `LiteralExpr` by invoking the constant-folding request on the stored value, which is guaranteed to return a cached result from a prior invocation in `EnumRawValuesRequest`, assuming it succeeded.
    - Furthermore, the 'structural' request kind was previously not cached, whereas now because the request must always do the complete type-checking work, it is always cached.

Resolves rdar://168005520