### PR TITLE
Optimizer: Improve TempRValueOptimization and SimplifyAllocStack

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/TempRValueElimination.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/TempRValueElimination.swift
@@ -68,80 +68,22 @@ private func removeTempRValues(in function: Function, keepDebugInfo: Bool, _ con
 
 private func tryEliminate(copy: CopyLikeInstruction, keepDebugInfo: Bool, _ context: FunctionPassContext) {
 
-  guard let (allocStack, lastUseOfAllocStack) =
-          getRemovableAllocStackDestination(of: copy, keepDebugInfo: keepDebugInfo, context),
-        let needHoistDestroys = needHoistDestroys(of: allocStack, after: lastUseOfAllocStack, copy: copy, context)
-  else {
-    return
-  }
-
-  guard extendAccessScopes(beyond: lastUseOfAllocStack, copy: copy, context) else {
-    return
-  }
-
-  if needHoistDestroys {
-    // Hoist destroy_addrs after the last use, because between the last use and the original destroy
-    // the source is modified.
-    hoistDestroy(of: allocStack, after: lastUseOfAllocStack, context)
-  } else if !copy.isTakeOfSource {
-    removeDestroys(of: allocStack, context)
-  }
-
-  allocStack.uses.ignore(usersOfType: DeallocStackInst.self).replaceAll(with: copy.sourceAddress, context)
-
-  if keepDebugInfo {
-    Builder(before: copy, context).createDebugStep()
-  }
-  context.erase(instructionIncludingAllUsers: copy.loadingInstruction)
-  context.erase(instructionIncludingAllUsers: allocStack)
-}
-
-/// Checks if the `copy` is copying into an `alloc_stack` which is removable:
-/// ```
-///   %allocStack = alloc_stack $T
-///   copy_addr %src to [init] %allocStack
-///   ...
-///   %lastUseOfAllocStack = load %allocStack
-/// ```
-private func getRemovableAllocStackDestination(
-  of copy: CopyLikeInstruction, keepDebugInfo: Bool, _ context: FunctionPassContext
-) -> (allocStack: AllocStackInst, lastUseOfAllocStack: Instruction)? {
   guard copy.isInitializationOfDestination,
         let allocStack = copy.destinationAddress as? AllocStackInst
   else {
-    return nil
+    return
   }
 
-  if keepDebugInfo {
-    if allocStack.isFromVarDecl || allocStack.isLexical {
-      return nil
-    }
-  } else {
-    // If the `allocStack` is lexical we can eliminate it if the source of the copy is lexical and
-    // it is live for longer than the `allocStack`.
-    if allocStack.isLexical && !copy.sourceAddress.accessBase.storageIsLexical {
-      return nil
-    }
+  if keepDebugInfo, allocStack.isFromVarDecl || allocStack.isLexical {
+    return
   }
 
   var allocStackUses = UseCollector(copy: copy, context)
   defer { allocStackUses.deinitialize() }
 
-  // Scan all uses of the `allocStack` to verify only the `copy` is writing to it and that all uses
-  // (except `destroy_addr` and `dealloc_stack`) are in the same basic block.
+  // Scan all uses of the `allocStack` to verify only the `copy` is writing to it.
   guard allocStackUses.collectUses(of: allocStack) else {
-    return nil
-  }
-
-  // Check that there are no uses of the `allocStack` that precede the copyInst. This can happen with projections.
-  // TODO: We can enable this case if we clone the projections at "load" uses.
-  if allocStack.hasUses(before: copy, context) {
-    return nil
-  }
-
-  // Check if the source is modified within the lifetime of the 'alloc_stack'.
-  guard let lastUseOfAllocStack = getLastUseWhileSourceIsNotModified(of: copy, uses: allocStackUses.uses, context) else {
-    return nil
+    return
   }
 
   // Bail if in non-OSSA the `allocStack` is destroyed in a non-obvious way, e.g. by
@@ -154,145 +96,47 @@ private func getRemovableAllocStackDestination(
         // We can easily remove a dead alloc_stack
         allocStack.uses.ignore(user: copy).ignore(usersOfType: DeallocStackInst.self).isEmpty
   else {
-    return nil
-  }
-
-  return (allocStack, lastUseOfAllocStack)
-}
-
-/// Returns true if the final `destroy_addr`s need to be hoisted to the last use of the `allocStack`.
-/// This is required if the copy-source is re-initialized inbetween, e.g.
-/// ```
-///   copy_addr %source, %allocStack
-///   ...
-///   last_use(%allocStack)
-///   ...                                <- the destroy_addr needs to be moved here
-///   store %newValue to [init] %source
-///   ...
-///   destroy_addr %allocStack
-/// ```
-/// Returns nil if hoisting is needed but not possible.
-private func needHoistDestroys(of allocStack: AllocStackInst,
-                               after lastUseOfAllocStack: Instruction,
-                               copy: CopyLikeInstruction,
-                               _ context: FunctionPassContext
-) -> Bool? {
-  guard copy.isTakeOfSource else {
-    return false
-  }
-  if lastUseOfAllocStack is DestroyAddrInst {
-    assert(!copy.parentFunction.hasOwnership, "should not treat destroy_addr as uses in OSSA")
-    return false
-  }
-
-  // We cannot insert the destroy of `copy.source` after `lastUseOfAllocStack` if `copy.source` is
-  // re-initialized by exactly this instruction.
-  // This is a corner case, but can happen if `lastUseOfAllocStack` is a `copy_addr`. Example:
-  // ```
-  //   copy_addr [take] %src to [init] %allocStack   // `copy`
-  //   copy_addr [take] %allocStack to [init] %src   // `lastUseOfAllocStack`
-  // ```
-  if lastUseOfAllocStack != copy, lastUseOfAllocStack.mayWrite(toAddress: copy.sourceAddress, context.aliasAnalysis) {
-    return nil
-  }
-
-  if mayWrite(to: copy.sourceAddress, after: lastUseOfAllocStack, beforeDestroysOf: allocStack, context) {
-    if hasDestroyBarrier(after: lastUseOfAllocStack, beforeDestroysOf: allocStack, context) {
-      return nil
-    }
-    return true
-  }
-  return false
-}
-
-private func mayWrite(to source: Value,
-                      after lastUse: Instruction,
-                      beforeDestroysOf allocStack: AllocStackInst,
-                      _ context: FunctionPassContext
-) -> Bool {
-  return visitInstructions(after: lastUse, beforeDestroysOf: allocStack, context) { inst in
-    inst.mayWrite(toAddress: source, context.aliasAnalysis)
-  }
-}
-
-private func hasDestroyBarrier(after lastUse: Instruction,
-                              beforeDestroysOf allocStack: AllocStackInst,
-                               _ context: FunctionPassContext
-) -> Bool {
-  return visitInstructions(after: lastUse, beforeDestroysOf: allocStack, context) { inst in
-    inst.isBarrierForDestroy(of: allocStack.type, context)
-  }
-}
-
-private func visitInstructions(after lastUse: Instruction,
-                               beforeDestroysOf allocStack: AllocStackInst,
-                               _ context: FunctionPassContext,
-                               _ predicate: (Instruction) -> Bool
-) -> Bool {
-  var worklist = InstructionWorklist(context)
-  defer { worklist.deinitialize() }
-
-  for destroy in allocStack.uses.users(ofType: DestroyAddrInst.self) {
-    worklist.pushPredecessors(of: destroy, ignoring: lastUse)
-  }
-
-  while let inst = worklist.pop() {
-    if predicate(inst) {
-      return true
-    }
-    worklist.pushPredecessors(of: inst, ignoring: lastUse)
-  }
-  return false
-}
-
-// We need to hoist the destroy of the stack location up to its last use because the source of the copy
-// could be re-initialized between the last use and the destroy.
-private func hoistDestroy(of allocStack: AllocStackInst, after lastUse: Instruction, _ context: FunctionPassContext) {
-  // Check if the last use already takes the stack location,
-  switch lastUse {
-  case let cai as CopyAddrInst where cai.source == allocStack && cai.isTakeOfSource:
-    return
-  case let li as LoadInst where li.loadOwnership == .take:
-    assert(li.address == allocStack, "load must be not take a projected address")
-    return
-  case let apply as ApplyInst where apply.consumes(address: allocStack):
-    if allocStack.uses.contains(where: { $0.instruction == apply && apply.convention(of: $0)!.isGuaranteed }) {
-      return
-    }
-  default:
-    break
-  }
-  if allocStack.uses.users(ofType: DestroyAddrInst.self).isEmpty {
-    // The stack location is not destroyed at all! This can happen if it contains a non-copyable
-    // value which has only trivial fields.
     return
   }
 
-  // Note that there can be multiple destroy_addr because they don't need to be in the same block
-  // as the alloc_stack, e.g.
-  //   %1 = alloc_stack
-  //   cond_br %c, bb1, bb2
-  // bb1:
-  //   destroy_addr %1
-  // bb2:
-  //   destroy_addr %1
-  context.erase(instructions: allocStack.uses.users(ofType: DestroyAddrInst.self))
+  var liverange = Liverange(context)
+  defer { liverange.deinitialize() }
 
-  Builder.insert(after: lastUse, context) { builder in
-    builder.createDestroyAddr(address: allocStack)
+  guard liverange.compute(for: copy, users: allocStackUses.users),
+        liverange.areAllUsersInLiverange(of: allocStack),
+        liverange.canExtendAccessScopes()
+  else {
+    return
   }
+
+  liverange.moveDebugValuesIntoLiverange(of: allocStack, after: copy.loadingInstruction)
+  liverange.extendAccessScopes()
+
+  if !copy.isTakeOfSource {
+    removeDestroys(users: allocStackUses.users, context)
+  }
+
+  allocStack.uses.ignore(usersOfType: DeallocStackInst.self).replaceAll(with: copy.sourceAddress, context)
+
+  if keepDebugInfo {
+    Builder(before: copy, context).createDebugStep()
+  }
+  if let debugVar = allocStack.debugVariable {
+    let builder = Builder(after: copy.loadingInstruction, location: allocStack.location, context)
+    builder.createDebugValue(value: copy.sourceAddress, debugVariable: debugVar)
+  }
+  context.erase(instructionIncludingAllUsers: copy.loadingInstruction)
+  context.erase(instructionIncludingAllUsers: allocStack)
 }
 
-private func removeDestroys(of allocStack: AllocStackInst, _ context: FunctionPassContext) {
-  for use in allocStack.uses {
-    switch use.instruction {
+private func removeDestroys(users: Stack<Instruction>, _ context: FunctionPassContext) {
+  for user in users {
+    switch user {
     case is DestroyAddrInst:
-      context.erase(instruction: use.instruction)
+      context.erase(instruction: user)
     case let cai as CopyAddrInst where cai.isTakeOfSource:
-      assert(cai.source == allocStack, "partial takes of the stack location are not supported")
       cai.set(isTakeOfSource: false, context)
     case let load as LoadInst where load.loadOwnership == .take:
-      assert(load.address == allocStack, "partial takes of the stack location are not supported")
       load.set(ownership: .copy, context)
     default:
       // Note that no operations other than the cases above can destroy the `allocStack` (we checked
@@ -302,28 +146,7 @@ private func removeDestroys(of allocStack: AllocStackInst, _ context: FunctionPa
   }
 }
 
-
 private extension AllocStackInst {
-  func hasUses(before instruction: Instruction, _ context: FunctionPassContext) -> Bool {
-    var useSet = InstructionSet(context)
-    defer { useSet.deinitialize() }
-
-    useSet.insert(contentsOf: self.users)
-
-    var worklist = InstructionWorklist(context)
-    defer { worklist.deinitialize() }
-
-    worklist.pushPredecessors(of: instruction, ignoring: self)
-
-    while let inst = worklist.pop() {
-      if useSet.contains(inst) {
-        return true
-      }
-      worklist.pushPredecessors(of: inst, ignoring: self)
-    }
-    return false
-  }
-
   /// In non-OSSA, check if the `alloc_stack` destroyed in an obvious way and not e.g. implicitly by
   /// ```
   ///   %x = load %allocStack   // looks like a load, but is a `load [take]`
@@ -352,203 +175,43 @@ private extension AllocStackInst {
   }
 }
 
-private extension ApplySite {
-  func consumes(address: Value) -> Bool {
-    argumentOperands.contains { argOp in
-      argOp.value == address && convention(of: argOp)!.isConsumed
-    }
-  }
-}
-
-/// Tries to move an `end_access` down to extend the access scope over all uses of the `alloc_stack`.
-/// For example:
-/// ```
-///   %a = begin_access %src
-///   copy_addr %a to [init] %temp : $*T
-///   end_access %a
-///   use %temp
-/// ```
-/// We must not replace %temp with %a after the `end_access`. Instead we try to move the `end_access`
-/// after the last use.
-private func extendAccessScopes(beyond lastUse: Instruction, copy: CopyLikeInstruction,
-                                _ context: FunctionPassContext) -> Bool
-{
-  var endAccessToMove: EndAccessInst? = nil
-
-  for inst in InstructionList(first: copy.next) {
-    if let endAccess = inst as? EndAccessInst {
-      // To keep things simple, we can just move a single `end_access`. Also, we cannot move an
-      // `end_access` over a (non-aliasing) other `end_access`.
-      if endAccessToMove != nil {
-        return false
-      }
-      if context.aliasAnalysis.mayAlias(copy.sourceAddress, endAccess.beginAccess.address),
-         // There cannot be any aliasing modifying accesses within the liverange of the `alloc_stack`,
-         // because we would have cought this in `getLastUseWhileSourceIsNotModified`.
-         // But there are cases where `aliasAnalysis.mayAlias` is less precise than `Instruction.mayWrite`.
-         // Therefore, just ignore any non-read accesses.
-         endAccess.beginAccess.accessKind == .read
-      {
-        // We cannot move instructions beyond the block's terminator.
-        if lastUse is TermInst {
-          return false
-        }
-        endAccessToMove = endAccess
-      }
-    } else if let endAccessToMove {
-      // We cannot move an `end_access` over a `begin_access`. This would destroy the proper nesting of accesses.
-      if inst is BeginAccessInst || inst is BeginUnpairedAccessInst {
-        return false
-      }
-      // Don't extend a read-access scope over a (potential) write.
-      // Note that `inst` can be a function call containing other access scopes. But doing the `inst.mayWrite`
-      // check, we know that the function can only contain read accesses (to the same memory location).
-      // So it's fine to move `endAccessToMove` even over such a function call.
-      if inst.mayWrite(toAddress: endAccessToMove.beginAccess.address, context.aliasAnalysis) {
-        return false
-      }
-    }
-    if inst == lastUse {
-      break
-    }
-  }
-  if let endAccessToMove {
-    endAccessToMove.move(before: lastUse.next!, context)
-  }
-
-  return true
-}
-
-/// Checks if the source of `copy` is not modified within the `alloc_stack`'s lifetime, i.e. is not modified
-/// before the last use of `uses`.
-///
-/// If there are no source modifications with the lifetime, returns the last user. Otherwise returns nil.
-///
-/// Unfortunately, we cannot simply use the destroy points as the lifetime end, because they can be in a
-/// different basic block. Instead we look for the last non-destroy, non-dealloc use.
-private func getLastUseWhileSourceIsNotModified(of copy: CopyLikeInstruction,
-                                                uses: InstructionSetWithCount,
-                                                _ context: FunctionPassContext) -> Instruction?
-{
-  var numUsesFound = 0
-  if copy == copy.loadingInstruction {
-    // As we are starting the iteration at the next instruction after the copy's load instruction
-    // we pretend to having seen the copy instruction already.
-    numUsesFound += 1
-  }
-  if uses.count == numUsesFound {
-    return copy
-  }
-  let aliasAnalysis = context.aliasAnalysis
-
-  // We already checked that the useful lifetime of the `alloc_stack` ends in the same block as the `copy`.
-  // Therefore we can limit our search to the instructions of this block.
-  for inst in InstructionList(first: copy.loadingInstruction.next) {
-    if uses.contains(inst) {
-      numUsesFound += 1
-    }
-
-    // If this is the last use of the `alloc_stack` we are okay. After this point, modifications to the source
-    // don't matter anymore.
-    // Note that we are assuming here that if an instruction reads and writes to the source at the same time
-    // (like a `copy_addr` could do), the write takes effect after the read.
-    if numUsesFound == uses.count {
-      // Function calls are an exception: in a called function a potential modification of `copy.source`
-      // could occur _before_ the read of the `alloc_stack`.
-      switch inst {
-      case is FullApplySite, is YieldInst:
-        if inst.mayWrite(toAddress: copy.sourceAddress, aliasAnalysis) {
-          return nil
-        }
-        return inst
-      default:
-        return inst
-      }
-    }
-
-    if inst.mayWrite(toAddress: copy.sourceAddress, aliasAnalysis) {
-      return nil
-    }
-  }
-  // For some reason, not all normal uses have been seen between the copy and the end of the initialization
-  // block. We should never reach here.
-  return nil
-}
-
 /// Collects all uses of the `alloc_stack`.
 private struct UseCollector : AddressDefUseWalker {
-  private(set) var uses: InstructionSetWithCount
+  private(set) var users: Stack<Instruction>
   private let copy: CopyLikeInstruction
 
   init(copy: CopyLikeInstruction, _ context: FunctionPassContext) {
-    self.uses = InstructionSetWithCount(context)
+    self.users = Stack(context)
     self.copy = copy
   }
 
   mutating func collectUses(of allocStack: AllocStackInst) -> Bool {
-    for use in allocStack.uses {
-      switch use.instruction {
-      case copy:
-        uses.insert(copy)
-      case is DeallocStackInst:
-        // Deallocations are allowed to be in a different block.
-        break
-      case let destroyAddr as DestroyAddrInst:
-        if !destroyAddr.parentFunction.hasOwnership && copy.isTakeOfSource {
-          // In non-OSSA mode, for the purpose of inserting the destroy of `copy.source`, we have to be
-          // conservative and assume that the lifetime of `allocStack` goes beyond it's last use - until
-          // the final `destroy_addr`. Otherwise we would risk inserting the destroy too early. Therefore we
-          // treat the `destroy_addr` as any other use of `allocStack` and require it to be in the same block.
-          if destroyAddr.parentBlock != copy.parentBlock {
-            return false
-          }
-          uses.insert(destroyAddr)
-        }
-      default:
-        if walkDown(address: use, path: UnusedWalkingPath()) == .abortWalk {
-          return false
-        }
-      }
+    if walkDownUses(ofAddress: allocStack, path: UnusedWalkingPath()) == .abortWalk {
+      return false
     }
     return true
   }
 
   public mutating func walkDown(address operand: Operand, path: UnusedWalkingPath) -> WalkResult {
-    if operand.instruction.parentBlock != copy.parentBlock {
-      // All normal uses (except destroys and `dealloc_stack`) must be in the initialization block.
-      return .abortWalk
-    }
     switch operand.instruction {
     case let openExistential as OpenExistentialAddrInst:
       if !openExistential.isImmutable {
         return.abortWalk
       }
     case let takeEnum as UncheckedTakeEnumDataAddrInst:
-      // In certain cases, `unchecked_take_enum_data_addr` invalidates the underlying memory. Therefore,
-      // by default` we can not look through it... but this is not true in the case of `Optional`.
-      // This is an important case for us to handle, so handle it here.
-      if !takeEnum.enum.type.isOptional {
+      // In certain cases, `unchecked_take_enum_data_addr` invalidates the underlying memory.
+      if takeEnum.mayBeDestructive {
         return .abortWalk
       }
     case let beginAccess as BeginAccessInst:
       if beginAccess.accessKind != .read {
         return .abortWalk
       }
-      // We don't have to walk down the `beginAccess` result, because the access kind "read" already
-      // guarantees that there are no writes to the `beginAccess` result address. But we have to register
-      // the `end_access`es as uses to correctly mark the end-of-lifetime of the `alloc_stack`.
-      // ```
-      //   %addr = begin_access [read]
-      //      ... // there can be no writes to %addr here
-      //   end_access %addr   // <- This is where the use actually ends.
-      // ```
-      for endAccess in beginAccess.endAccessInstructions {
-        if endAccess.parentBlock != copy.parentBlock {
-          return .abortWalk
-        }
-        uses.insert(endAccess)
-      }
-      return .continueWalk
+      users.append(contentsOf: beginAccess.scopeEndingOperands.users)
+    case let dropDeinit as DropDeinitInst:
+      // `drop_deinit` is a side-effect instruction can can meaningfully exist without any users.
+      // Therefore we have to explicitly add it to `users`.
+      users.append(dropDeinit)
     default:
       break
     }
@@ -560,20 +223,21 @@ private struct UseCollector : AddressDefUseWalker {
       return .continueWalk
     }
 
+    if address.instruction == copy {
+      return .continueWalk
+    }
+
     // Only allow uses that cannot destroy their operand. We need to be sure that replacing all the uses
     // with the copy source doesn't destroy the source.
     switch address.instruction {
     case let beginApply as BeginApplyInst:
+      users.append(beginApply)
       // Extend the lifetime of the `alloc_stack` to the 'end_apply'/'abort_apply'.
-      for tokenUse in beginApply.token.uses {
-        if tokenUse.instruction.parentBlock != copy.parentBlock {
-          return .abortWalk
-        }
-        uses.insert(tokenUse.instruction)
-      }
+      users.append(contentsOf: beginApply.token.uses.users)
       return visitApply(address: address, apply: beginApply)
 
     case let partialApply as PartialApplyInst:
+      users.append(partialApply)
       if !partialApply.isOnStack {
         return .abortWalk
       }
@@ -581,56 +245,41 @@ private struct UseCollector : AddressDefUseWalker {
 
     case let apply as ApplySite:
       // Remaining applies: `apply` and `try_apply`
+      users.append(apply)
       return visitApply(address: address, apply: apply)
 
     case let yield as YieldInst:
+      users.append(yield)
       if !yield.convention(of: address).isGuaranteed {
         return .abortWalk
       }
-      uses.insert(yield)
       return .continueWalk
 
     case let addrCast as UncheckedAddrCastInst:
       return walkDownUses(ofAddress: addrCast, path: UnusedWalkingPath())
 
-    case let load as LoadInst:
-      if load.loadOwnership == .take,
-          // Only accept `load [take]` if it takes the whole `alloc_stack`. A `load [take]` from
-          // a projection would destroy only a part of the `alloc_stack` and we don't handle this.
-          load.address != copy.destinationAddress
-      {
-        return .abortWalk
-      }
-      uses.insert(load)
-      return .continueWalk
-
     case let loadBorrow as LoadBorrowInst:
-      uses.insert(loadBorrow)
+      users.append(loadBorrow)
       for end in loadBorrow.uses.endingLifetime.users {
-        if end.parentBlock != copy.parentBlock || end is BranchInst {
+        if end is BranchInst {
           return .abortWalk
         }
-        uses.insert(end)
+        users.append(end)
       }
-      return .continueWalk
-
-    case let fixLifetime as FixLifetimeInst:
-      // After removing the `alloc_stack` the `fix_lifetime` will apply for the `copy.source`.
-      uses.insert(fixLifetime)
       return .continueWalk
 
     case let copyFromStack as CopyAddrInst:
+      users.append(copyFromStack)
       if copyFromStack.destinationOperand == address {
         return .abortWalk
       }
-      // As with `load [take]`, only accept `copy_addr [take]` if it takes the whole `alloc_stack`.
-      if copyFromStack.isTakeOfSource && copyFromStack.source != copy.destinationAddress {
-        return .abortWalk
-      }
-      uses.insert(copyFromStack)
       return .continueWalk
 
-    case is DebugValueInst:
+    case is LoadInst, is FixLifetimeInst, is DestroyAddrInst, is SwitchEnumAddrInst:
+      users.append(address.instruction)
+      return .continueWalk
+
+    case is DebugValueInst, is DeallocStackInst:
       return .continueWalk
 
     default:
@@ -641,13 +290,10 @@ private struct UseCollector : AddressDefUseWalker {
   private mutating func visitApply(address: Operand, apply: ApplySite) -> WalkResult {
     let argConvention = apply.convention(of: address)!
     guard argConvention.isGuaranteed ||
-          // Only accept consuming-in arguments if it consumes the whole `alloc_stack`. A consume from
-          // a projection would destroy only a part of the `alloc_stack` and we don't handle this.
-          (argConvention == .indirectIn && (copy.isTakeOfSource && address.value == copy.destinationAddress))
+          (argConvention == .indirectIn && copy.isTakeOfSource)
     else {
       return .abortWalk
     }
-    uses.insert(apply)
     return .continueWalk
   }
 
@@ -656,6 +302,187 @@ private struct UseCollector : AddressDefUseWalker {
   }
 
   mutating func deinitialize() {
-    uses.deinitialize()
+    users.deinitialize()
   }
+}
+
+/// Represents the liverange of the `alloc_stack` - from the `copy` instruction until its last uses:
+/// ```
+///   %1 = alloc_stack $T
+///   copy_addr %src to %1                  -+
+///   ...                                    |
+///   %3 = load %1                           |  liverange
+///   ...                                    |
+///   %4 = load %1   // last use of %1      -+
+///   ...
+///   dealloc_stack %1
+/// ```
+/// If the copy is a `load`-`store` pair, the liverange starts at the `load`.
+private struct Liverange {
+  var liverange: InstructionWorklist
+
+  // The found `end_access` instructions of the source value, within the liverange.
+  var endAccesses: Stack<EndAccessInst>
+
+  let context: FunctionPassContext
+
+  init(_ context: FunctionPassContext) {
+    liverange = InstructionWorklist(context)
+    endAccesses = Stack(context)
+    self.context = context
+  }
+
+  mutating func deinitialize() {
+    endAccesses.deinitialize()
+    liverange.deinitialize()
+  }
+
+  /// Computes the liverange and returns true if there are no writes to the copy source within the liverange.
+  /// Also, collects all `end_access` instructions of the copy source in `endAccesses`.
+  mutating func compute(for copy: CopyLikeInstruction, users: Stack<Instruction>) -> Bool {
+    let loadFromSource = copy.loadingInstruction
+
+    // For now, let the liverange go _until_, but not _including_ the users. If a user both reads from the
+    // `alloc_stack` and writes to the source, the read happens before the write and we can accept such an
+    // instruction, e.g. `copy_addr %stack to %source`.
+    for user in users {
+      switch user {
+      case let apply as FullApplySite:
+        // Function calls are an exception: in a called function a potential modification of source could
+        // occur _before_ the read of the `alloc_stack` (which is passed as an indirect argument).
+        liverange.pushIfNotVisited(apply)
+      case let destroy as DestroyAddrInst:
+        // If `copy` actually _copies_ the source, all of `alloc_stack`s destroys are removed and we don't
+        // need to add them to the liverange.
+        if copy.isTakeOfSource {
+          liverange.pushPredecessors(of: destroy, ignoring: loadFromSource)
+        }
+      default:
+        liverange.pushPredecessors(of: user, ignoring: loadFromSource)
+      }
+    }
+
+    let aliasAnalysis = context.aliasAnalysis
+
+    while let inst = liverange.pop() {
+      if inst.mayWrite(toAddress: copy.sourceAddress, aliasAnalysis) {
+        return false
+      }
+      if let endAccess = inst as? EndAccessInst,
+         aliasAnalysis.mayAlias(copy.sourceAddress, endAccess.beginAccess.address),
+         // There cannot be any aliasing modifying accesses within the liverange of the `alloc_stack`,
+         // because we would have cought this with `inst.mayWrite` above.
+         // However, there are cases where `aliasAnalysis.mayAlias` is less precise than `Instruction.mayWrite`.
+         // Therefore, just ignore any non-read accesses.
+         endAccess.beginAccess.accessKind == .read
+      {
+        endAccesses.append(endAccess)
+      }
+      liverange.pushPredecessors(of: inst, ignoring: loadFromSource)
+    }
+
+    if liverange.hasBeenPushed(copy.parentFunction.entryBlock.instructions.first!) {
+      // Liverange computation should never go beyond the copy instruction, because the copy is the only
+      // write to the `alloc_stack` and therefore must dominate all users.
+      // If we reach the function entry instruction, something must have gone wrong.
+      // To be on the safe side, let's check this and abort in this case.
+      return false
+    }
+
+    // Finally push the user instructions themselves (which we excluded in the first place).
+    liverange.pushIfNotVisited(contentsOf: users.lazy.filter{ !($0 is DestroyAddrInst)})
+    return true
+  }
+
+  /// Returns true if all users of `alloc_stack` are in the computed liverange.
+  /// This might not be the case if there are any users before the copy instruction.
+  /// Ignore `debug_value` because we can move this instruction easily.
+  func areAllUsersInLiverange(of allocStack: AllocStackInst) -> Bool {
+    for user in allocStack.users {
+      if !liverange.hasBeenPushed(user) {
+        switch user {
+        // Ignore instructions which are not added to `UseCollector.users`, but are not relevant,
+        // because the will be deleted or can be moved.
+        case is DeallocStackInst, is DestroyAddrInst, is CopyAddrInst, is DebugValueInst:
+          break
+        default:
+          return false
+        }
+      }
+    }
+    return true
+  }
+
+  /// Move `debug_value` instructions, which are located _before_ the copy instruction, after the copy instruction.
+  func moveDebugValuesIntoLiverange(of allocStack: AllocStackInst, after: Instruction) {
+    for user in allocStack.users {
+      if !liverange.hasBeenPushed(user) {
+        switch user {
+        case let debugValue as DebugValueInst:
+          debugValue.move(before: after.next!, context)
+        case is DeallocStackInst, is DestroyAddrInst, is CopyAddrInst:
+          break
+        default:
+          fatalError("moving this kind of instruction is currently not supported")
+        }
+      }
+    }
+  }
+
+  /// Check if we can move `end_access`es down to extend access scopes over all uses of the `alloc_stack`.
+  /// For example:
+  /// ```
+  ///   %a = begin_access %src
+  ///   copy_addr %a to [init] %temp : $*T
+  ///   end_access %a
+  ///   use %temp
+  /// ```
+  /// We must not replace %temp with %a after the `end_access`. Instead we try to move the `end_access`
+  /// after the last use.
+  func canExtendAccessScopes() -> Bool {
+    let aliasAnalysis = context.aliasAnalysis
+    var endAccessBlocks = BasicBlockSet(context)
+    defer { endAccessBlocks.deinitialize() }
+
+    for endAccess in endAccesses {
+      guard endAccessBlocks.insert(endAccess.parentBlock) else {
+        // For simplicity, only handle a single `end_access` per block (which is usually the case).
+        return false
+      }
+      let accessAddr = endAccess.beginAccess.address
+      for inst in InstructionList(first: endAccess.next) {
+        if !liverange.hasBeenPushed(inst) {
+          break
+        }
+        switch inst {
+        case is BeginAccessInst, is BeginUnpairedAccessInst, is EndAccessInst,
+             is TermInst:
+          // We cannot move an `end_access` over a `begin_access`. This would destroy the proper nesting of accesses.
+          return false
+        default:
+          // Don't extend a read-access scope over a (potential) write.
+          // Note that `inst` can be a function call containing other access scopes. But doing the `inst.mayWrite`
+          // check, we know that the function can only contain read accesses (to the same memory location).
+          // So it's fine to move `endAccessToMove` even over such a function call.
+          if inst.mayWrite(toAddress: accessAddr, aliasAnalysis) {
+            return false
+          }
+        }
+      }
+    }
+    return true
+  }
+
+  func extendAccessScopes() {
+    for endAccess in endAccesses {
+      for inst in InstructionList(first: endAccess.next) {
+        if !liverange.hasBeenPushed(inst) {
+          endAccess.move(before: inst, context)
+          break
+        }
+        assert(!(inst is TermInst), "no place found to move end_access")
+      }
+    }
+  }
+
 }

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -1129,6 +1129,17 @@ final public class InitEnumDataAddrInst : SingleValueInstruction, UnaryInstructi
 final public class UncheckedTakeEnumDataAddrInst : SingleValueInstruction, UnaryInstruction, EnumInstruction {
   public var `enum`: Value { operand.value }
   public var caseIndex: Int { bridged.UncheckedTakeEnumDataAddrInst_caseIndex() }
+
+  /// True, if this instruction invalidates the operand memory value.
+  /// This happens for certain enum kinds because the enum tag must be cleared before the payload may be used.
+  public var isDestructive: Bool { bridged.UncheckedTakeEnumDataAddrInst_isDestructive() }
+
+  /// True, if this instruction may invalidate the operand memory value.
+  public var mayBeDestructive: Bool {
+    return isDestructive ||
+           // We don't know the layout of resilient enums. So be conservative and assume they are destructive.
+           self.enum.type.nominal!.isResilient(in: parentFunction)
+  }
 }
 
 final public class SelectEnumInst : SingleValueInstruction {

--- a/SwiftCompilerSources/Sources/SIL/Utilities/Test.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/Test.swift
@@ -144,6 +144,7 @@ public func registerTests() {
     parseTestSpecificationTest,
     basicBlockTest,
     instructionIterationTest,
+    instructionWorklistTest,
     smallProjectionPathTest,
     getAccessBaseTest,
     accessPathTest,

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -841,6 +841,7 @@ struct BridgedInstruction {
   BRIDGED_INLINE SwiftInt UncheckedEnumDataInst_caseIndex() const;
   BRIDGED_INLINE SwiftInt InitEnumDataAddrInst_caseIndex() const;
   BRIDGED_INLINE SwiftInt UncheckedTakeEnumDataAddrInst_caseIndex() const;
+  BRIDGED_INLINE bool UncheckedTakeEnumDataAddrInst_isDestructive() const;
   BRIDGED_INLINE SwiftInt InjectEnumAddrInst_caseIndex() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedDeclObj InjectEnumAddrInst_element() const;
   BRIDGED_INLINE SwiftInt RefElementAddrInst_fieldIndex() const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -1411,6 +1411,10 @@ SwiftInt BridgedInstruction::UncheckedTakeEnumDataAddrInst_caseIndex() const {
   return getAs<swift::UncheckedTakeEnumDataAddrInst>()->getCaseIndex();
 }
 
+bool BridgedInstruction::UncheckedTakeEnumDataAddrInst_isDestructive() const {
+  return getAs<swift::UncheckedTakeEnumDataAddrInst>()->isDestructive();
+}
+
 SwiftInt BridgedInstruction::InjectEnumAddrInst_caseIndex() const {
   return getAs<swift::InjectEnumAddrInst>()->getCaseIndex();
 }

--- a/test/Interpreter/reference_bindings.swift
+++ b/test/Interpreter/reference_bindings.swift
@@ -8,6 +8,11 @@ import StdlibUnittest
 
 defer { runAllTests() }
 
+@inline(never)
+func useit(s: inout String) {
+  _blackHole(s)
+}
+
 var tests = TestSuite("reference bindings")
 
 var global: String = "globalName"
@@ -28,6 +33,7 @@ tests.test("multiple global access exclusivity error")
     @inline(never)
     func test(_ x: inout String) {
       inout x = global
+      useit(s: &x)
     }
     test(&global)
   }

--- a/test/SILOptimizer/assemblyvision_remark/cast_remarks.swift
+++ b/test/SILOptimizer/assemblyvision_remark/cast_remarks.swift
@@ -17,21 +17,18 @@ public func forcedCast<NS, T>(_ ns: NS) -> T {
 public func forcedCast2<NS, T>(_ ns: NS) -> T {
   // Make sure the colon info is right so that the arrow is under the a.
   //
-  // Today, we seem to completely eliminate 'x' here in the debug info. TODO:
-  // Maybe we can recover this info somehow.
-  let x = ns
+  let x = ns      // expected-note        {{of 'x'}}
   return x as! T  // expected-remark @:12 {{unconditional runtime cast of value with type 'NS' to 'T'}}
-                  // expected-note @-7:34 {{of 'ns'}}
+                  // expected-note @-5:34 {{of 'ns'}}
 }
 
 public func forcedCast3<NS, T>(_ ns: NS) -> T {
   // Make sure the colon info is right so that the arrow is under the a.
   //
-  // Today, we seem to completely eliminate 'x' here in the debug info. TODO:
-  // Maybe we can recover this info somehow.
   var x = ns // expected-warning {{variable 'x' was never mutated}}
+             // expected-note @-1 {{of 'x'}}
   return x as! T  // expected-remark @:12 {{unconditional runtime cast of value with type 'NS' to 'T'}}
-                  // expected-note @-7:34 {{of 'ns'}}
+                  // expected-note @-6:34 {{of 'ns'}}
 }
 
 public func forcedCast4<NS, T>(_ ns: NS, _ ns2: NS) -> T {
@@ -50,21 +47,18 @@ public func condCast<NS, T>(_ ns: NS) -> T? {
 public func condCast2<NS, T>(_ ns: NS) -> T? {
   // Make sure the colon info is right so that the arrow is under the a.
   //
-  // Today, we seem to completely eliminate 'x' here in the debug info. TODO:
-  // Maybe we can recover this info somehow.
-  let x = ns
+  let x = ns      // expected-note        {{of 'x'}}
   return x as? T  // expected-remark @:12 {{conditional runtime cast of value with type 'NS' to 'T'}}
-                  // expected-note @-7:32 {{of 'ns'}}
+                  // expected-note @-5:32 {{of 'ns'}}
 }
 
 public func condCast3<NS, T>(_ ns: NS) -> T? {
   // Make sure the colon info is right so that the arrow is under the a.
   //
-  // Today, we seem to completely eliminate 'x' here in the debug info. TODO:
-  // Maybe we can recover this info somehow.
   var x = ns // expected-warning {{variable 'x' was never mutated}}
+             // expected-note @-1 {{of 'x'}}
   return x as? T  // expected-remark @:12 {{conditional runtime cast of value with type 'NS' to 'T'}}
-                  // expected-note @-7:32 {{of 'ns'}}
+                  // expected-note @-6:32 {{of 'ns'}}
 }
 
 public func condCast4<NS, T>(_ ns: NS, _ ns2: NS) -> T? {
@@ -219,21 +213,18 @@ public func forcedCast(_ ns: Existential1) -> Existential2 {
 public func forcedCast2(_ ns: Existential1) -> Existential2 {
   // Make sure the colon info is right so that the arrow is under the a.
   //
-  // Today, we seem to completely eliminate 'x' here in the debug info. TODO:
-  // Maybe we can recover this info somehow. We should also note the retain as being on 'ns'
-  let x = ns
+  let x = ns      // expected-note        {{of 'x'}}
   return x as! Existential2  // expected-remark @:12 {{unconditional runtime cast of value with type 'any Existential1' to 'any Existential2'}}
-                  // expected-note @-7:27 {{of 'ns'}}
+                  // expected-note @-5:27 {{of 'ns'}}
 }
 
 public func forcedCast3(_ ns: Existential1) -> Existential2 {
   // Make sure the colon info is right so that the arrow is under the a.
   //
-  // Today, we seem to completely eliminate 'x' here in the debug info. TODO:
-  // Maybe we can recover this info somehow.
   var x = ns // expected-warning {{variable 'x' was never mutated}}
+             // expected-note @-1 {{of 'x'}}
   return x as! Existential2  // expected-remark @:12 {{unconditional runtime cast of value with type 'any Existential1' to 'any Existential2'}}
-                  // expected-note @-7:27 {{of 'ns'}}
+                  // expected-note @-6:27 {{of 'ns'}}
 }
 
 // TODO: We should be able to identify NS2 in this case with opaque values.
@@ -253,21 +244,18 @@ public func condCast(_ ns: Existential1) -> Existential2? {
 public func condCast2(_ ns: Existential1) -> Existential2? {
   // Make sure the colon info is right so that the arrow is under the a.
   //
-  // Today, we seem to completely eliminate 'x' here in the debug info. TODO:
-  // Maybe we can recover this info somehow.
-  let x = ns
+  let x = ns      // expected-note        {{of 'x'}}
   return x as? Existential2  // expected-remark @:12 {{conditional runtime cast of value with type 'any Existential1' to 'any Existential2'}}
-                  // expected-note @-7:25 {{of 'ns'}}
+                  // expected-note @-5:25 {{of 'ns'}}
 }
 
 public func condCast3(_ ns: Existential1) -> Existential2? {
   // Make sure the colon info is right so that the arrow is under the a.
   //
-  // Today, we seem to completely eliminate 'x' here in the debug info. TODO:
-  // Maybe we can recover this info somehow.
   var x = ns // expected-warning {{variable 'x' was never mutated}}
+             // expected-note @-1 {{of 'x'}}
   return x as? Existential2  // expected-remark @:12 {{conditional runtime cast of value with type 'any Existential1' to 'any Existential2'}}
-                  // expected-note @-7:25 {{of 'ns'}}
+                  // expected-note @-6:25 {{of 'ns'}}
 }
 
 // TODO: We should be able to identify NS2 here!

--- a/test/SILOptimizer/assemblyvision_remark/cast_remarks_objc.swift
+++ b/test/SILOptimizer/assemblyvision_remark/cast_remarks_objc.swift
@@ -18,7 +18,7 @@ public func forcedCast<NS, T>(_ ns: NS) -> T {
 
 public func forcedCast2<NS, T>(_ ns: NS) -> T {
   // Make sure the colon info is right so that the arrow is under the a.
-  let x = ns
+  let x = ns      // expected-note        {{of 'x'}}
   return x as! T  // expected-remark @:12 {{unconditional runtime cast of value with type 'NS' to 'T'}}
                   // expected-note @-4:34 {{of 'ns'}}
 }
@@ -26,8 +26,9 @@ public func forcedCast2<NS, T>(_ ns: NS) -> T {
 public func forcedCast3<NS, T>(_ ns: NS) -> T {
   // Make sure the colon info is right so that the arrow is under the a.
   var x = ns // expected-warning {{variable 'x' was never mutated}}
+             // expected-note @-1 {{of 'x'}}
   return x as! T  // expected-remark @:12 {{unconditional runtime cast of value with type 'NS' to 'T'}}
-                  // expected-note @-4:34 {{of 'ns'}}
+                  // expected-note @-5:34 {{of 'ns'}}
 }
 
 public func forcedCast4<NS, T>(_ ns: NS, _ ns2: NS) -> T {
@@ -45,7 +46,7 @@ public func condCast<NS, T>(_ ns: NS) -> T? {
 
 public func condCast2<NS, T>(_ ns: NS) -> T? {
   // Make sure the colon info is right so that the arrow is under the a.
-  let x = ns
+  let x = ns      // expected-note        {{of 'x'}}
   return x as? T  // expected-remark @:12 {{conditional runtime cast of value with type 'NS' to 'T'}}
                   // expected-note @-4:32 {{of 'ns'}}
 }
@@ -53,8 +54,9 @@ public func condCast2<NS, T>(_ ns: NS) -> T? {
 public func condCast3<NS, T>(_ ns: NS) -> T? {
   // Make sure the colon info is right so that the arrow is under the a.
   var x = ns // expected-warning {{variable 'x' was never mutated}}
+             // expected-note @-1 {{of 'x'}}
   return x as? T  // expected-remark @:12 {{conditional runtime cast of value with type 'NS' to 'T'}}
-                  // expected-note @-4:32 {{of 'ns'}}
+                  // expected-note @-5:32 {{of 'ns'}}
 }
 
 public func condCast4<NS, T>(_ ns: NS, _ ns2: NS) -> T? {

--- a/test/SILOptimizer/capture_promotion_generic_context.sil
+++ b/test/SILOptimizer/capture_promotion_generic_context.sil
@@ -110,9 +110,9 @@ exit:
 // CHECK-LABEL: sil {{.*}}@call_generic_promotable_box_from_different_generic2 :
 // CHECK:       bb0(%0 : $*R<T>, %1 : $*E<(R<U>) -> Builtin.Int32>, %2 : $*Builtin.Int32):
 // CHECK:         [[F:%.*]] = function_ref @$s23generic_promotable_box2Tf2nnni_n : $@convention(thin) <τ_0_0> (@in_guaranteed R<τ_0_0>, @in_guaranteed Builtin.Int32, @guaranteed E<(R<τ_0_0>) -> Builtin.Int32>) -> @out Builtin.Int32
-// CHECK:         %4 = load %1 : $*E<(R<U>) -> Builtin.Int32>
-// CHECK-NEXT:    [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[F]]<U>(%2, %4)
-// CHECK-NEXT:    retain_value %4
+// CHECK:         [[L:%.*]] = load %1 : $*E<(R<U>) -> Builtin.Int32>
+// CHECK-NEXT:    [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[F]]<U>(%2, [[L]])
+// CHECK-NEXT:    retain_value [[L]]
 // CHECK-NEXT:    return [[CLOSURE]]
 // CHECK: } // end sil function 'call_generic_promotable_box_from_different_generic2'
 sil [ossa] @call_generic_promotable_box_from_different_generic2 : $@convention(thin) <T, U: P> (@in_guaranteed R<T>, @in_guaranteed E<(R<U>)->Int>, @in Int) -> @owned @callee_guaranteed (@in_guaranteed R<U>) -> @out Int {

--- a/test/SILOptimizer/cast_optimizer_conditional_conformance.sil
+++ b/test/SILOptimizer/cast_optimizer_conditional_conformance.sil
@@ -94,12 +94,10 @@ bb6:
 // CHECK: [[EXIS:%.*]] = alloc_stack $any HasFoo
 // CHECK: [[VAL:%.*]] = alloc_stack $S1<Int8>
 // CHECK: store %0 to [[VAL]] : $*S1<Int8>
-// CHECK: [[OPT:%.*]] = alloc_stack $Optional<any HasFoo>
-// CHECK: [[IEDA:%.*]] = init_enum_data_addr [[OPT]] : $*Optional<any HasFoo>, #Optional.some!enumelt
-// CHECK: checked_cast_addr_br take_always S1<Int8> in [[VAL]] : $*S1<Int8> to any HasFoo in [[IEDA]] : $*any HasFoo, bb1, bb2
+// CHECK: [[HF:%.*]] = alloc_stack $any HasFoo
+// CHECK: checked_cast_addr_br take_always S1<Int8> in [[VAL]] : $*S1<Int8> to any HasFoo in [[HF]] : $*any HasFoo, bb1, bb2
 // bbs...
-// CHECK: [[UNWRAP:%.*]] = unchecked_take_enum_data_addr [[OPT]] : $*Optional<any HasFoo>, #Optional.some!enumelt
-// CHECK: copy_addr [take] [[UNWRAP]] to [init] [[EXIS]] : $*any HasFoo
+// CHECK: copy_addr [take] [[HF]] to [init] [[EXIS]] : $*any HasFoo
 // CHECK: [[OPEN:%.*]] = open_existential_addr immutable_access [[EXIS]] : $*any HasFoo to $*@opened("5E16CBC0-FD9F-11E8-A311-D0817AD9F6DD", any HasFoo) Self
 // CHECK: [[WM:%.*]] = witness_method $@opened("5E16CBC0-FD9F-11E8-A311-D0817AD9F6DD", any HasFoo) Self, #HasFoo.foo : <Self where Self : HasFoo> (Self) -> () -> (), [[OPEN]] : $*@opened("5E16CBC0-FD9F-11E8-A311-D0817AD9F6DD", any HasFoo) Self : $@convention(witness_method: HasFoo) <τ_0_0 where τ_0_0 : HasFoo> (@in_guaranteed τ_0_0) -> ()
 // CHECK: apply [[WM]]<@opened("5E16CBC0-FD9F-11E8-A311-D0817AD9F6DD", any HasFoo) Self>([[OPEN]]) : $@convention(witness_method: HasFoo) <τ_0_0 where τ_0_0 : HasFoo> (@in_guaranteed τ_0_0) -> ()

--- a/test/SILOptimizer/merge_exclusivity.swift
+++ b/test/SILOptimizer/merge_exclusivity.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -O -enforce-exclusivity=checked -Xllvm -sil-disable-pass=redundant-load-elimination -Xllvm -sil-print-types -emit-sil  -primary-file %s | %FileCheck %s --check-prefix=TESTSIL
+// RUN: %target-swift-frontend -O -enforce-exclusivity=checked -Xllvm -sil-print-types -emit-sil  -primary-file %s | %FileCheck %s --check-prefix=TESTSIL
 // REQUIRES: optimized_stdlib,asserts
 // REQUIRES: swift_stdlib_no_asserts
 // REQUIRES: PTRSIZE=64
@@ -20,23 +20,14 @@ func sum(_ x: UInt64, _ y: UInt64) -> UInt64 {
 // TESTSIL: [[B1:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBALVAR]]
 // TESTSIL: end_access [[B1]]
 // TESTSIL: bb4{{.*}}:
-// TESTSIL: [[B2a:%.*]] = begin_access [read] [static] [no_nested_conflict] [[GLOBALVAR]]
-// TESTSIL-NEXT: load [[B2a]]
-// TESTSIL: end_access [[B2a]]
 // TESTSIL: [[B2b:%.*]] = begin_access [modify] [static] [no_nested_conflict] [[GLOBALVAR]]
 // TESTSIL: store {{.*}} to [[B2b]]
 // TESTSIL: end_access [[B2b]]
 // TESTSIL: bb5:
-// TESTSIL: [[B3a:%.*]] = begin_access [read] [static] [no_nested_conflict] [[GLOBALVAR]]
-// TESTSIL-NEXT: load [[B3a]]
-// TESTSIL: end_access [[B3a]]
 // TESTSIL: [[B3b:%.*]] = begin_access [modify] [static] [no_nested_conflict] [[GLOBALVAR]]
 // TESTSIL: store {{.*}} to [[B3b]]
 // TESTSIL: end_access [[B3b]]
-// TESTSIL: bb6:
-// TESTSIL: [[B4a:%.*]] = begin_access [read] [static] [no_nested_conflict] [[GLOBALVAR]]
-// TESTSIL-NEXT: load [[B4a]]
-// TESTSIL: end_access [[B4a]]
+// TESTSIL: bb8:
 // TESTSIL: [[B4b:%.*]] = begin_access [modify] [static] [no_nested_conflict] [[GLOBALVAR]]
 // TESTSIL: store {{.*}} to [[B4b]]
 // TESTSIL: end_access [[B4b]]
@@ -68,17 +59,11 @@ public func MergeTest1(_ N: Int) {
 // TESTSIL: [[GLOBALVAR:%.*]] = global_addr @$s17merge_exclusivity5checks6UInt64Vvp
 // TESTSIL: [[B1:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBALVAR]]
 // TESTSIL: end_access [[B1]]
-// TESTSIL: bb6
-// TESTSIL: [[B2a:%.*]] = begin_access [read] [static] [no_nested_conflict] [[GLOBALVAR]]
-// TESTSIL-NEXT: load [[B2a]]
-// TESTSIL: end_access [[B2a]]
+// TESTSIL: bb5
 // TESTSIL: [[B2b:%.*]] = begin_access [modify] [static] [no_nested_conflict] [[GLOBALVAR]]
 // TESTSIL: store {{.*}} to [[B2b]]
 // TESTSIL: end_access [[B2b]]
-// TESTSIL: bb7
-// TESTSIL: [[B3a:%.*]] = begin_access [read] [static] [no_nested_conflict] [[GLOBALVAR]]
-// TESTSIL-NEXT: load [[B3a]]
-// TESTSIL: end_access [[B3a]]
+// TESTSIL: bb8
 // TESTSIL: [[B3b:%.*]] = begin_access [modify] [static] [no_nested_conflict] [[GLOBALVAR]]
 // TESTSIL: store {{.*}} to [[B3b]]
 // TESTSIL: end_access [[B3b]]

--- a/test/SILOptimizer/sil_combine_enum_addr.sil
+++ b/test/SILOptimizer/sil_combine_enum_addr.sil
@@ -91,7 +91,6 @@ bb3:
 // CHECK: store
 // CHECK-NOT: checked_cast_addr_br
 // CHECK-NOT: bb1
-// CHECK: inject_enum_addr %{{.*}} : $*Optional<any CustomStringConvertible>, #Optional.some!enumelt
 // CHECK: dealloc_stack
 // CHECK: return
 sil @convert_checked_cast_addr_br_into_unconditional_checked_cast_addr_cond_br : $@convention(thin) (@in Int, @inout _Stdout) -> () {
@@ -144,10 +143,8 @@ private class D : C {
 //
 // CHECK-LABEL: sil @convert_checked_cast_addr_br_with_internal_type : $@convention(thin) (@in A, @inout _Stdout) -> ()
 // CHECK: checked_cast_addr_br
-// CHECK: inject_enum_addr %{{.*}} : $*Optional<any CustomStringConvertible>, #Optional.some!enumelt
 // CHECK: dealloc_stack
 // CHECK: return
-// CHECK: inject_enum_addr %{{.*}} : $*Optional<any CustomStringConvertible>, #Optional.none!enumelt
 // CHECK: }
 sil @convert_checked_cast_addr_br_with_internal_type : $@convention(thin) (@in A, @inout _Stdout) -> () {
 bb0(%0 : $*A, %1 : $*_Stdout):
@@ -186,7 +183,6 @@ bb22:
 // CHECK: store
 // CHECK-NOT: checked_cast_addr_br
 // CHECK-NOT: bb1
-// CHECK: inject_enum_addr %{{.*}} : $*Optional<any CustomStringConvertible>, #Optional.none!enumelt
 // CHECK: dealloc_stack
 // CHECK: return
 sil @convert_checked_cast_addr_br_with_private_type : $@convention(thin) (@in B, @inout _Stdout) -> () {
@@ -224,10 +220,8 @@ bb22:
 //
 // CHECK-LABEL: sil @convert_checked_cast_addr_br_with_non_private_superclass : $@convention(thin) (@in D, @inout _Stdout) -> ()
 // CHECK: checked_cast_addr_br
-// CHECK: inject_enum_addr %{{.*}} : $*Optional<any CustomStringConvertible>, #Optional.some!enumelt
 // CHECK: dealloc_stack
 // CHECK: return
-// CHECK: inject_enum_addr %{{.*}} : $*Optional<any CustomStringConvertible>, #Optional.none!enumelt
 // CHECK: }
 sil @convert_checked_cast_addr_br_with_non_private_superclass : $@convention(thin) (@in D, @inout _Stdout) -> () {
 bb0(%0 : $*D, %1 : $*_Stdout):

--- a/test/SILOptimizer/sil_combine_enums.sil
+++ b/test/SILOptimizer/sil_combine_enums.sil
@@ -605,10 +605,10 @@ bb3:
   return %11 : $()
 }
 
-// CHECK-LABEL: sil @dont_expand_alloc_stack_of_enum_multiple_cases
-// CHECK:   alloc_stack $MP
-// CHECK: } // end sil function 'dont_expand_alloc_stack_of_enum_multiple_cases'
-sil @dont_expand_alloc_stack_of_enum_multiple_cases : $@convention(method) (S) -> () {
+// CHECK-LABEL: sil @expand_alloc_stack_of_enum_multiple_cases2
+// CHECK:   alloc_stack $S
+// CHECK: } // end sil function 'expand_alloc_stack_of_enum_multiple_cases2'
+sil @expand_alloc_stack_of_enum_multiple_cases2 : $@convention(method) (S) -> () {
 bb0(%0 : $S):
   %1 = alloc_stack $MP
   cond_br undef, bb1, bb2

--- a/test/SILOptimizer/sil_combine_enums_ossa.sil
+++ b/test/SILOptimizer/sil_combine_enums_ossa.sil
@@ -591,10 +591,10 @@ bb3:
   return %11 : $()
 }
 
-// CHECK-LABEL: sil [ossa] @dont_expand_alloc_stack_of_enum_multiple_cases
-// CHECK:   alloc_stack $MP
-// CHECK: } // end sil function 'dont_expand_alloc_stack_of_enum_multiple_cases'
-sil [ossa] @dont_expand_alloc_stack_of_enum_multiple_cases : $@convention(method) (S) -> () {
+// CHECK-LABEL: sil [ossa] @expand_alloc_stack_of_enum_multiple_cases2
+// CHECK:   alloc_stack $S
+// CHECK: } // end sil function 'expand_alloc_stack_of_enum_multiple_cases2'
+sil [ossa] @expand_alloc_stack_of_enum_multiple_cases2 : $@convention(method) (S) -> () {
 bb0(%0 : $S):
   %1 = alloc_stack $MP
   cond_br undef, bb1, bb2

--- a/test/SILOptimizer/simplify_alloc_stack.sil
+++ b/test/SILOptimizer/simplify_alloc_stack.sil
@@ -44,6 +44,12 @@ public struct T2: P {
 enum MP {
   case A(S)
   case B(S)
+  case C(T1)
+}
+
+enum MP2 {
+  case A(T1)
+  case B(T)
 }
 
 public enum X {
@@ -160,10 +166,38 @@ bb3:
   return %11 : $()
 }
 
-// CHECK-LABEL: sil [ossa] @dont_expand_alloc_stack_of_enum_multiple_cases :
-// CHECK:         alloc_stack $MP
-// CHECK:       } // end sil function 'dont_expand_alloc_stack_of_enum_multiple_cases'
-sil [ossa] @dont_expand_alloc_stack_of_enum_multiple_cases : $@convention(method) (S) -> () {
+// CHECK-LABEL: sil [ossa] @expand_alloc_stack_of_enum_multiple_cases2 :
+// CHECK:         [[A:%[0-9]+]] = alloc_stack $Optional<T>
+// CHECK:       } // end sil function 'expand_alloc_stack_of_enum_multiple_cases2'
+sil [ossa] @expand_alloc_stack_of_enum_multiple_cases2 : $@convention(method) (@owned T) -> () {
+bb0(%0 : @owned $T):
+  %1 = alloc_stack $Optional<T>
+  cond_br undef, bb1, bb2
+
+bb1:
+  %2 = init_enum_data_addr %1, #Optional.some!enumelt
+  store %0 to [init] %2
+  inject_enum_addr %1, #Optional.some!enumelt
+  %7 = unchecked_take_enum_data_addr %1, #Optional.some!enumelt
+  %9 = apply undef(%7) : $@convention(thin) (@in_guaranteed T) -> ()
+  br bb3
+
+bb2:
+  inject_enum_addr %1, #Optional.none!enumelt
+  destroy_value %0
+  br bb3
+
+bb3:
+  destroy_addr %1
+  dealloc_stack %1
+  %11 = tuple ()
+  return %11 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @different_cases_same_payload_type :
+// CHECK:         alloc_stack $S
+// CHECK:       } // end sil function 'different_cases_same_payload_type'
+sil [ossa] @different_cases_same_payload_type : $@convention(method) (S) -> () {
 bb0(%0 : $S):
   %1 = alloc_stack $MP
   cond_br undef, bb1, bb2
@@ -183,6 +217,33 @@ bb2:
 bb3:
   destroy_addr %1 : $*MP
   dealloc_stack %1 : $*MP
+  %11 = tuple ()
+  return %11 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @different_case_different_payload_type :
+// CHECK:         alloc_stack $MP
+// CHECK:       } // end sil function 'different_case_different_payload_type'
+sil [ossa] @different_case_different_payload_type : $@convention(method) (S, T1) -> () {
+bb0(%0 : $S, %t : $T1):
+  %1 = alloc_stack $MP
+  cond_br undef, bb1, bb2
+
+bb1:
+  %2 = init_enum_data_addr %1 : $*MP, #MP.A!enumelt
+  store %0 to [trivial] %2
+  inject_enum_addr %1, #MP.A!enumelt
+  br bb3
+
+bb2:
+  %3 = init_enum_data_addr %1 : $*MP, #MP.C!enumelt
+  store %t to [trivial] %3
+  inject_enum_addr %1, #MP.C!enumelt
+  br bb3
+
+bb3:
+  destroy_addr %1
+  dealloc_stack %1
   %11 = tuple ()
   return %11 : $()
 }
@@ -229,6 +290,321 @@ bb0(%0 : $S):
   %11 = tuple ()
   return %11 : $()
 }
+
+// CHECK-LABEL: sil [ossa] @enum_with_store :
+// CHECK:         %1 = alloc_stack $C
+// CHECK:         %2 = unchecked_enum_data %0, #Optional.some
+// CHECK:         store %2 to [init] %1
+// CHECK:         load [take] %1
+// CHECK:       } // end sil function 'enum_with_store'
+sil [ossa] @enum_with_store : $@convention(thin) (@owned Optional<C>) -> @owned C {
+bb0(%0 : @owned $Optional<C>):
+  %1 = alloc_stack $Optional<C>
+  store %0 to [init] %1
+  %3 = unchecked_take_enum_data_addr %1, #Optional.some!enumelt
+  %4 = load [take] %3
+  dealloc_stack %1
+  return %4
+}
+
+// CHECK-LABEL: sil [ossa] @store_and_overlapping_inject :
+// CHECK:         %1 = alloc_stack $Optional<C>
+// CHECK:       } // end sil function 'store_and_overlapping_inject'
+sil [ossa] @store_and_overlapping_inject : $@convention(thin) (@guaranteed Optional<C>) -> () {
+bb0(%0 : @guaranteed $Optional<C>):
+  %1 = alloc_stack $Optional<C>
+  cond_br undef, bb1, bb2
+
+bb1:
+  %2 = copy_value %0
+  store %2 to [init] %1
+  %3 = unchecked_take_enum_data_addr %1, #Optional.some!enumelt
+  %4 = load [copy] %3
+  destroy_value %4
+  br bb3
+
+bb2:
+  inject_enum_addr %1, #Optional.none!enumelt
+  br bb3
+
+bb3:
+  destroy_addr %1
+  dealloc_stack %1
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil [ossa] @inject_diamond :
+// CHECK:         %1 = alloc_stack $Optional<C>
+// CHECK:       } // end sil function 'inject_diamond'
+sil [ossa] @inject_diamond : $@convention(thin) () -> @out C {
+bb0(%0 : $*C):
+  %1 = alloc_stack $Optional<C>
+  cond_br undef, bb1, bb3
+
+bb1:
+  inject_enum_addr %1, #Optional.none!enumelt
+  %4 = integer_literal $Builtin.Int32, 0
+  %5 = integer_literal $Builtin.Int32, 1
+  switch_value %5, case %4: bb2, case %5: bb5
+
+bb2:
+  br bb4
+
+bb3:
+  %8 = init_enum_data_addr %1, #Optional.some!enumelt
+  %9 = apply undef(%8) : $@convention(thin) () -> @out C
+  inject_enum_addr %1, #Optional.some!enumelt
+  br bb4
+
+bb4:
+  %12 = unchecked_take_enum_data_addr %1, #Optional.some!enumelt
+  copy_addr [take] %12 to [init] %0
+  br bb6
+
+bb5:
+  %15 = apply undef(%0) : $@convention(thin) () -> @out C
+  destroy_addr %1
+  br bb6
+
+bb6:
+  dealloc_stack %1
+  %19 = tuple ()
+  return %19
+}
+
+// CHECK-LABEL: sil [ossa] @trivial_case_of_nontrivial_enum :
+// CHECK:         %1 = alloc_stack $T1
+// CHECK:         %2 = unchecked_enum_data %0, #MP2.A
+// CHECK:         store %2 to [trivial] %1
+// CHECK:         load [trivial] %1
+// CHECK:       } // end sil function 'trivial_case_of_nontrivial_enum'
+sil [ossa] @trivial_case_of_nontrivial_enum : $@convention(thin) (@owned MP2) -> T1 {
+bb0(%0 : @owned $MP2):
+  %1 = alloc_stack $MP2
+  store %0 to [init] %1
+  %3 = unchecked_take_enum_data_addr %1, #MP2.A!enumelt
+  %4 = load [trivial] %3
+  dealloc_stack %1
+  return %4
+}
+
+// CHECK-LABEL: sil [ossa] @store_doesnt_dominate_all_loads :
+// CHECK:         %1 = alloc_stack $Optional<C>
+// CHECK:         unchecked_take_enum_data_addr
+// CHECK:       } // end sil function 'store_doesnt_dominate_all_loads'
+sil [ossa] @store_doesnt_dominate_all_loads : $@convention(thin) (@owned Optional<C>) -> () {
+bb0(%0 : @owned $Optional<C>):
+  %1 = alloc_stack $Optional<C>
+  store %0 to [init] %1
+  %3 = unchecked_take_enum_data_addr %1, #Optional.some!enumelt
+  cond_br undef, bb1, bb2
+bb1:
+  %4 = load [take] %3
+  destroy_value %4
+  br bb3
+bb2:
+  destroy_addr %1
+  br bb3
+bb3:
+  dealloc_stack %1
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil [ossa] @store_dominates_multiple_case_blocks :
+// CHECK:         %1 = alloc_stack $C
+// CHECK:       bb1:
+// CHECK-NEXT:    [[P:%.*]] = unchecked_enum_data %0, #Optional.some
+// CHECK-NEXT:    store [[P]] to [init] %1
+// CHECK:       bb2:
+// CHECK-NEXT:    destroy_value %0
+// CHECK-NEXT:    br bb3
+// CHECK:       } // end sil function 'store_dominates_multiple_case_blocks'
+sil [ossa] @store_dominates_multiple_case_blocks : $@convention(thin) (@owned Optional<C>) -> () {
+bb0(%0 : @owned $Optional<C>):
+  %1 = alloc_stack $Optional<C>
+  store %0 to [init] %1
+  cond_br undef, bb1, bb2
+
+bb1:
+  %3 = unchecked_take_enum_data_addr %1, #Optional.some!enumelt
+  %4 = load [copy] %3
+  destroy_value %4
+  destroy_addr %1
+  br bb3
+
+bb2:
+  destroy_addr %1
+  inject_enum_addr %1, #Optional.none!enumelt
+  br bb3
+
+bb3:
+  dealloc_stack %1
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil [ossa] @store_dominates_multiple_case_blocks_trivial :
+// CHECK:         %1 = alloc_stack $Int
+// CHECK:       bb1:
+// CHECK-NEXT:    [[P:%.*]] = unchecked_enum_data %0, #Optional.some
+// CHECK-NEXT:    store [[P]] to [trivial] %1
+// CHECK:       bb2:
+// CHECK-NEXT:    br bb3
+// CHECK:       } // end sil function 'store_dominates_multiple_case_blocks_trivial'
+sil [ossa] @store_dominates_multiple_case_blocks_trivial : $@convention(thin) (Optional<Int>) -> () {
+bb0(%0 : $Optional<Int>):
+  %1 = alloc_stack $Optional<Int>
+  store %0 to [trivial] %1
+  cond_br undef, bb1, bb2
+
+bb1:
+  %3 = unchecked_take_enum_data_addr %1, #Optional.some!enumelt
+  %4 = load [trivial] %3
+  fix_lifetime %4
+  br bb3
+
+bb2:
+  inject_enum_addr %1, #Optional.none!enumelt
+  br bb3
+
+bb3:
+  dealloc_stack %1
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil [ossa] @store_in_loop :
+// CHECK:         %0 = alloc_stack $C
+// CHECK:       bb1:
+// CHECK-NEXT:    %2 = apply
+// CHECK:       bb2:
+// CHECK-NEXT:    destroy_value %2
+// CHECK-NEXT:    br bb1
+// CHECK:       bb3:
+// CHECK-NEXT:    [[P:%.*]] = unchecked_enum_data %2
+// CHECK-NEXT:    store [[P]] to [init] %0
+// CHECK:       } // end sil function 'store_in_loop'
+sil [ossa] @store_in_loop : $@convention(thin) () -> () {
+bb0:
+  %1 = alloc_stack $Optional<C>
+  br bb1
+
+bb1:
+  %3 = apply undef() : $@convention(thin) () -> @owned Optional<C>
+  store %3 to [init] %1
+  cond_br undef, bb2, bb3
+
+bb2:
+  destroy_addr %1
+  br bb1
+
+bb3:
+  %8 = unchecked_take_enum_data_addr %1, #Optional.some!enumelt
+  %9 = load [copy] %8
+  destroy_value %9
+  destroy_addr %1
+  dealloc_stack %1
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil [ossa] @store_not_in_pred_block :
+// CHECK:         %1 = alloc_stack $Optional<C>
+// CHECK:       } // end sil function 'store_not_in_pred_block'
+sil [ossa] @store_not_in_pred_block : $@convention(thin) (@owned Optional<C>) -> () {
+bb0(%0 : @owned $Optional<C>):
+  %1 = alloc_stack $Optional<C>
+  store %0 to [init] %1
+  cond_br undef, bb1, bb4
+
+bb1:
+  cond_br undef, bb2, bb3
+
+bb2:
+  %3 = unchecked_take_enum_data_addr %1, #Optional.some!enumelt
+  %4 = load [copy] %3
+  destroy_value %4
+  destroy_addr %1
+  br bb5
+
+bb3:
+  destroy_addr %1
+  br bb5
+
+bb4:
+  destroy_addr %1
+  br bb5
+
+bb5:
+  dealloc_stack %1
+  %r = tuple ()
+  return %r
+}
+
+
+
+// CHECK-LABEL: sil [ossa] @not_a_single_store :
+// CHECK:         %2 = alloc_stack $Optional<C>
+// CHECK:         unchecked_take_enum_data_addr
+// CHECK:       } // end sil function 'not_a_single_store'
+sil [ossa] @not_a_single_store : $@convention(thin) (@owned Optional<C>, @owned Optional<C>) -> @owned C {
+bb0(%0 : @owned $Optional<C>, %1 : @owned $Optional<C>):
+  %2 = alloc_stack $Optional<C>
+  store %0 to [init] %2
+  destroy_addr %2
+  store %1 to [init] %2
+  %3 = unchecked_take_enum_data_addr %2, #Optional.some!enumelt
+  %4 = load [take] %3
+  dealloc_stack %2
+  return %4
+}
+
+// CHECK-LABEL: sil [ossa] @store_and_init :
+// CHECK:         %2 = alloc_stack $Optional<C>
+// CHECK:         unchecked_take_enum_data_addr
+// CHECK:       } // end sil function 'store_and_init'
+sil [ossa] @store_and_init : $@convention(thin) (@owned Optional<C>, @owned C) -> @owned C {
+bb0(%0 : @owned $Optional<C>, %1 : @owned $C):
+  %2 = alloc_stack $Optional<C>
+  store %0 to [init] %2
+  destroy_addr %2
+  %5 = init_enum_data_addr %2, #Optional.some!enumelt
+  store %1 to [init] %5
+  inject_enum_addr %2, #Optional.some!enumelt
+  %8 = unchecked_take_enum_data_addr %2, #Optional.some!enumelt
+  %9 = load [take] %8
+  dealloc_stack %2
+  return %9
+}
+
+// CHECK-LABEL: sil [ossa] @mismatching_case :
+// CHECK:         %1 = alloc_stack $MP
+// CHECK:         unchecked_take_enum_data_addr
+// CHECK:         unchecked_take_enum_data_addr
+// CHECK:       } // end sil function 'mismatching_case'
+sil [ossa] @mismatching_case : $@convention(thin) (MP) -> () {
+bb0(%0 : $MP):
+  %1 = alloc_stack $MP
+  store %0 to [trivial] %1
+  cond_br undef, bb1, bb2
+bb1:
+  %3 = unchecked_take_enum_data_addr %1, #MP.A!enumelt
+  %4 = load [trivial] %3
+  fix_lifetime %4
+  br bb3
+bb2:
+  %7 = unchecked_take_enum_data_addr %1, #MP.B!enumelt
+  %8 = load [trivial] %7
+  fix_lifetime %8
+  br bb3
+bb3:
+  dealloc_stack %1
+  %r = tuple ()
+  return %r
+}
+
 
 // CHECK-LABEL: sil [ossa] @replace_archetype :
 // CHECK:         [[S:%.*]] = alloc_stack [lexical] $T

--- a/test/SILOptimizer/temp-rvalue-elimination.swift
+++ b/test/SILOptimizer/temp-rvalue-elimination.swift
@@ -1,0 +1,201 @@
+// RUN: %target-swift-frontend %s -O -module-name=test -disable-availability-checking -emit-sil | %FileCheck %s
+
+public struct S {
+    var i: Int
+    var obj: AnyObject
+    var existential: Any
+}
+
+public struct S2 {
+    var optionalInt: Int?
+    var obj: AnyObject?
+    var existential: Any?
+}
+
+// CHECK-LABEL: sil @$s4test6getInt4fromSiSgAA1SVSg_tF :
+// CHECK-NOT:     alloc_stack
+// CHECK-NOT:     copy_addr
+// CHECK:       } // end sil function '$s4test6getInt4fromSiSgAA1SVSg_tF'
+public func getInt(from optionalStruct: S?) -> Int? {
+  return optionalStruct?.i
+}
+
+// CHECK-LABEL: sil @$s4test6getObj4fromyXlSgAA1SVSg_tF :
+// CHECK-NOT:     alloc_stack
+// CHECK-NOT:     copy_addr
+// CHECK:       } // end sil function '$s4test6getObj4fromyXlSgAA1SVSg_tF'
+public func getObj(from optionalStruct: S?) -> AnyObject? {
+  return optionalStruct?.obj
+}
+
+// CHECK-LABEL: sil @$s4test14getExistential4fromypSgAA1SVSg_tF :
+// CHECK-NOT:     alloc_stack
+// CHECK:       } // end sil function '$s4test14getExistential4fromypSgAA1SVSg_tF'
+public func getExistential(from optionalStruct: S?) -> Any? {
+  return optionalStruct?.existential
+}
+
+// CHECK-LABEL: sil @$s4test12getIntSwitch4fromSiSgAA1SVSg_tF  :
+// CHECK-NOT:     alloc_stack
+// CHECK:       } // end sil function '$s4test12getIntSwitch4fromSiSgAA1SVSg_tF'
+public func getIntSwitch(from optionalStruct: S?) -> Int? {
+    switch optionalStruct {
+        case .some(let myStruct): myStruct.i
+        case .none: nil
+    }
+}
+
+// CHECK-LABEL: sil @$s4test11getIntIfLet4fromSiSgAA1SVSg_tF :
+// CHECK-NOT:     alloc_stack
+// CHECK:       } // end sil function '$s4test11getIntIfLet4fromSiSgAA1SVSg_tF'
+public func getIntIfLet(from optionalStruct: S?) -> Int? {
+    if let s = optionalStruct {
+        s.i
+    } else {
+        nil
+    }
+}
+
+// CHECK-LABEL: sil @$s4test14getIntGuardLet4fromSiSgAA1SVSg_tF :
+// CHECK-NOT:     alloc_stack
+// CHECK:       } // end sil function '$s4test14getIntGuardLet4fromSiSgAA1SVSg_tF'
+public func getIntGuardLet(from optionalStruct: S?) -> Int? {
+    guard let s = optionalStruct else {
+        return nil
+    }
+    return s.i
+}
+
+// CHECK-LABEL: sil @$s4test15getIntIfCaseLet4fromSiSgAA1SVSg_tF :
+// CHECK-NOT:     alloc_stack
+// CHECK:       } // end sil function '$s4test15getIntIfCaseLet4fromSiSgAA1SVSg_tF'
+public func getIntIfCaseLet(from optionalStruct: S?) -> Int? {
+    if case .some(let s) = optionalStruct {
+        return s.i
+    }
+    return nil
+}
+
+// CHECK-LABEL: sil @$s4test9getIntMap4fromSiSgAA1SVSg_tF :
+// CHECK-NOT:     alloc_stack
+// CHECK:       } // end sil function '$s4test9getIntMap4fromSiSgAA1SVSg_tF'
+public func getIntMap(from optionalStruct: S?) -> Int? {
+    optionalStruct.map { $0.i }
+}
+
+// CHECK-LABEL: sil @$s4test36getIntConditionallyUnsafelyUnwrapped4fromSiSgAA1SVSg_tF :
+// CHECK-NOT:     alloc_stack
+// CHECK:       } // end sil function '$s4test36getIntConditionallyUnsafelyUnwrapped4fromSiSgAA1SVSg_tF'
+public func getIntConditionallyUnsafelyUnwrapped(from optionalStruct: S?) -> Int? {
+    optionalStruct == nil ? nil :optionalStruct.unsafelyUnwrapped.i
+}
+
+// CHECK-LABEL: sil @$s4test33getIntConditionallyForceUnwrapped4fromSiSgAA1SVSg_tF :
+// CHECK-NOT:     alloc_stack
+// CHECK:       } // end sil function '$s4test33getIntConditionallyForceUnwrapped4fromSiSgAA1SVSg_tF'
+public func getIntConditionallyForceUnwrapped(from optionalStruct: S?) -> Int? {
+    optionalStruct == nil ? nil :optionalStruct!.i
+}
+
+// CHECK-LABEL: sil @$s4test20getIntForceUnwrapped4fromSiSgAA1SVSg_tF :
+// CHECK-NOT:     alloc_stack
+// CHECK:       } // end sil function '$s4test20getIntForceUnwrapped4fromSiSgAA1SVSg_tF'
+public func getIntForceUnwrapped(from optionalStruct: S?) -> Int? {
+    optionalStruct!.i
+}
+
+// CHECK-LABEL: sil @$s4test23getIntUnsafelyUnwrapped4fromSiSgAA1SVSg_tF :
+// CHECK-NOT:     alloc_stack
+// CHECK:       } // end sil function '$s4test23getIntUnsafelyUnwrapped4fromSiSgAA1SVSg_tF'
+public func getIntUnsafelyUnwrapped(from optionalStruct: S?) -> Int? {
+    optionalStruct.unsafelyUnwrapped.i
+}
+
+// CHECK-LABEL: sil @$s4test22getIntOptionalChaining4fromSiSgAA2S2VSg_tF :
+// CHECK-NOT:     alloc_stack
+// CHECK:       } // end sil function '$s4test22getIntOptionalChaining4fromSiSgAA2S2VSg_tF'
+public func getIntOptionalChaining(from optionalStruct: S2?) -> Int? {
+    optionalStruct?.optionalInt
+}
+
+// CHECK-LABEL: sil @$s4test12getIntSwitch4fromSiSgAA2S2VSg_tF :
+// CHECK-NOT:     alloc_stack
+// CHECK:       } // end sil function '$s4test12getIntSwitch4fromSiSgAA2S2VSg_tF'
+public func getIntSwitch(from optionalStruct: S2?) -> Int? {
+    switch optionalStruct {
+        case .some(let myStruct):
+        switch myStruct.optionalInt {
+        case .some(let i): i
+        case .none: nil
+        }
+        case .none: nil
+    }
+}
+
+// CHECK-LABEL: sil @$s4test11getIntIfLet4fromSiSgAA2S2VSg_tF :
+// CHECK-NOT:     alloc_stack
+// CHECK:       } // end sil function '$s4test11getIntIfLet4fromSiSgAA2S2VSg_tF'
+public func getIntIfLet(from optionalStruct: S2?) -> Int? {
+    if let s = optionalStruct, let i = s.optionalInt {
+        i
+    } else {
+        nil
+    }
+}
+
+// CHECK-LABEL: sil @$s4test14getIntGuardLet4fromSiSgAA2S2VSg_tF :
+// CHECK-NOT:     alloc_stack
+// CHECK:       } // end sil function '$s4test14getIntGuardLet4fromSiSgAA2S2VSg_tF'
+public func getIntGuardLet(from optionalStruct: S2?) -> Int? {
+    guard let s = optionalStruct, let i = s.optionalInt else {
+        return nil
+    }
+    return i
+}
+
+// CHECK-LABEL: sil @$s4test15getIntIfCaseLet4fromSiSgAA2S2VSg_tF :
+// CHECK-NOT:     alloc_stack
+// CHECK:       } // end sil function '$s4test15getIntIfCaseLet4fromSiSgAA2S2VSg_tF'
+public func getIntIfCaseLet(from optionalStruct: S2?) -> Int? {
+    if case .some(let s) = optionalStruct, case .some(let i) = s.optionalInt {
+        return i
+    }
+    return nil
+}
+
+// CHECK-LABEL: sil @$s4test13getIntFlatMap4fromSiSgAA2S2VSg_tF :
+// CHECK-NOT:     alloc_stack
+// CHECK:       } // end sil function '$s4test13getIntFlatMap4fromSiSgAA2S2VSg_tF'
+public func getIntFlatMap(from optionalStruct: S2?) -> Int? {
+    optionalStruct.flatMap { $0.optionalInt }
+}
+
+// CHECK-LABEL: sil @$s4test23getIntUnsafelyUnwrapped4fromSiSgAA2S2VSg_tF :
+// CHECK-NOT:     alloc_stack
+// CHECK:       } // end sil function '$s4test23getIntUnsafelyUnwrapped4fromSiSgAA2S2VSg_tF'
+public func getIntUnsafelyUnwrapped(from optionalStruct: S2?) -> Int? {
+    optionalStruct.unsafelyUnwrapped.optionalInt.unsafelyUnwrapped
+}
+
+// CHECK-LABEL: sil @$s4test20getIntForceUnwrapped4fromSiSgAA2S2VSg_tF :
+// CHECK-NOT:     alloc_stack
+// CHECK:       } // end sil function '$s4test20getIntForceUnwrapped4fromSiSgAA2S2VSg_tF'
+public func getIntForceUnwrapped(from optionalStruct: S2?) -> Int? {
+    optionalStruct!.optionalInt!
+}
+
+func getValue5<Value>(from array: UnsafeBufferPointer<Any>, as: Value.Type) -> Value {
+  @_transparent func project<T>( t: T) -> Value {
+    unsafeBitCast(t, to: Value.self)
+  }
+  return _openExistential(array[0], do: project)
+}
+
+// CHECK-LABEL: sil {{.*}}@$s4test14getInlineArray4froms0cD0Vy$3_yXlGSRyypG_tF :
+// CHECK-NOT:     alloc_stack
+// CHECK-NOT:     copy_addr
+// CHECK:       } // end sil function '$s4test14getInlineArray4froms0cD0Vy$3_yXlGSRyypG_tF'
+public func getInlineArray(from array: UnsafeBufferPointer<Any>) -> InlineArray<4, AnyObject> {
+  getValue5(from: array, as: InlineArray<4, AnyObject>.self)
+}
+

--- a/test/SILOptimizer/temp_rvalue_opt.sil
+++ b/test/SILOptimizer/temp_rvalue_opt.sil
@@ -168,14 +168,14 @@ bb0(%0 : $*Str):
   dealloc_stack %1 : $*Str
   return %3 : $Str
 }
-// CHECK-LABEL: sil @load_in_wrong_block
-// CHECK:      bb0(%0 : $*GS<B>):
-// CHECK-NEXT:   alloc_stack
-// CHECK-NEXT:   copy_addr
-// CHECK-NEXT:   struct_element_addr
-// CHECK-NEXT:   br bb1
-// CHECK:        return
-sil @load_in_wrong_block : $@convention(thin) <B> (@in GS<B>) -> () {
+// CHECK-LABEL: sil @load_in_different_block
+// CHECK-NOT:      alloc_stack
+// CHECK-NOT:      copy_addr
+// CHECK:          [[S:%.*]] = struct_element_addr %0
+// CHECK:        bb1:
+// CHECK-NEXT:        = load [[S]]
+// CHECK:       } // end sil function 'load_in_different_block'
+sil @load_in_different_block : $@convention(thin) <B> (@in GS<B>) -> () {
 bb0(%0 : $*GS<B>):
   %4 = alloc_stack $GS<B>
   copy_addr %0 to [init] %4 : $*GS<B>
@@ -191,13 +191,11 @@ bb1:
   return %9999 : $()
 }
 
-// CHECK-LABEL: sil @projection_in_wrong_block
-// CHECK:      bb0(%0 : $*GS<B>):
-// CHECK-NEXT:   alloc_stack
-// CHECK-NEXT:   copy_addr
-// CHECK-NEXT:   br bb1
-// CHECK:        return
-sil @projection_in_wrong_block : $@convention(thin) <B> (@in GS<B>) -> () {
+// CHECK-LABEL: sil @projection_in_different_block
+// CHECK-NOT:     alloc_stack
+// CHECK-NOT:     copy_addr
+// CHECK:       } // end sil function 'projection_in_different_block'
+sil @projection_in_different_block : $@convention(thin) <B> (@in GS<B>) -> () {
 bb0(%0 : $*GS<B>):
   %4 = alloc_stack $GS<B>
   copy_addr %0 to [init] %4 : $*GS<B>
@@ -858,24 +856,3 @@ bb0(%0 : $*NC):
   return %r
 }
 
-
-// Test that the operand of the debug value dominates its use.
-// CHECK-LABEL: sil [ossa] @copy_and_consuming_arg :
-// CHECK:  %1 = alloc_stack $Klass
-// CHECK:  debug_value %1 : $*Klass, let, name "x"
-// CHECK-LABEL: } // end sil function 'copy_and_consuming_arg'
-sil [ossa] @copy_and_consuming_arg : $@convention(thin) (@inout Str) -> () {
-bb0(%0 : $*Str):
-  %1 = alloc_stack $Klass
-  br bb1
-
-bb1:
-  debug_value %1, let, name "x"
-  %3 = struct_element_addr %0, #Str.kl
-  copy_addr %3 to [init] %1
-  %4 = apply undef(%1) : $@convention(thin) (@in_guaranteed Klass) -> ()
-  destroy_addr %1
-  dealloc_stack %1
-  %9 = tuple ()
-  return %9 : $()
-}

--- a/test/SILOptimizer/temp_rvalue_opt_ossa.sil
+++ b/test/SILOptimizer/temp_rvalue_opt_ossa.sil
@@ -35,6 +35,14 @@ struct NonTrivialStruct {
   var val:Klass
 }
 
+struct S {
+  var i: Int
+}
+
+struct S2 {
+  var ntv: NonTrivialStruct
+}
+
 public enum FakeOptional<T> {
   case none
   case some(T)
@@ -188,11 +196,9 @@ bb0(%0 : $*GS<B>, %1 : $*GS<B>):
 
 // CHECK-LABEL: sil [ossa] @take_from_temp
 // CHECK:      bb0(%0 : $*B, %1 : $*GS<B>):
-// CHECK-NEXT:   [[STK:%.*]] = alloc_stack
-// CHECK-NEXT:   copy_addr %1 to [init] [[STK]]
-// CHECK-NEXT:   [[INNER:%.*]] = struct_element_addr
-// CHECK-NEXT:   copy_addr [take] [[INNER]]
-// CHECK-NEXT:   dealloc_stack
+// CHECK-ONONE:  debug_step
+// CHECK-NEXT:   [[S:%.*]] = struct_element_addr %1
+// CHECK-NEXT:   copy_addr [[S]] to %0
 // CHECK-NEXT:   tuple
 // CHECK-NEXT:   return
 sil [ossa] @take_from_temp : $@convention(thin) <B> (@inout B, @inout GS<B>) -> () {
@@ -223,15 +229,12 @@ bb0(%0 : $*Builtin.NativeObject, %1 : @owned $Builtin.NativeObject):
   return %obj : $Builtin.NativeObject
 }
 
-// CHECK-LABEL: sil [ossa] @copy_with_take_and_copy_from_src
+// CHECK-LABEL: sil [ossa] @copy_with_take_and_copy_from_src1
 // CHECK:       bb0({{.*}}):
-// CHECK-ONONE-NEXT:   debug_step
-// CHECK-NEXT:    destroy_addr %0
-// CHECK-NEXT:    copy_addr [take] %1 to [init] %0
-// CHECK-NEXT:    tuple
-// CHECK-NEXT:    return
-// CHECK:       } // end sil function 'copy_with_take_and_copy_from_src'
-sil [ossa] @copy_with_take_and_copy_from_src : $@convention(thin) (@inout Builtin.NativeObject, @in Builtin.NativeObject) -> () {
+// CHECK:         copy_addr
+// CHECK:         copy_addr
+// CHECK:       } // end sil function 'copy_with_take_and_copy_from_src1'
+sil [ossa] @copy_with_take_and_copy_from_src1 : $@convention(thin) (@inout Builtin.NativeObject, @in Builtin.NativeObject) -> () {
 bb0(%0 : $*Builtin.NativeObject, %1 : $*Builtin.NativeObject):
   %stk = alloc_stack $Builtin.NativeObject
   copy_addr [take] %0 to [init] %stk : $*Builtin.NativeObject
@@ -242,14 +245,30 @@ bb0(%0 : $*Builtin.NativeObject, %1 : $*Builtin.NativeObject):
   return %v : $()
 }
 
+// CHECK-LABEL: sil [ossa] @copy_with_take_and_copy_from_src2
+// CHECK:       bb0({{.*}}):
+// CHECK-ONONE-NEXT:   debug_step
+// CHECK-NEXT:    destroy_addr %0
+// CHECK-NEXT:    copy_addr [take] %1 to [init] %0
+// CHECK-NEXT:    tuple
+// CHECK-NEXT:    return
+// CHECK:       } // end sil function 'copy_with_take_and_copy_from_src2'
+sil [ossa] @copy_with_take_and_copy_from_src2 : $@convention(thin) (@inout Builtin.NativeObject, @in Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject, %1 : $*Builtin.NativeObject):
+  %stk = alloc_stack $Builtin.NativeObject
+  copy_addr [take] %0 to [init] %stk : $*Builtin.NativeObject
+  destroy_addr %stk : $*Builtin.NativeObject
+  copy_addr [take] %1 to [init] %0 : $*Builtin.NativeObject
+  dealloc_stack %stk : $*Builtin.NativeObject
+  %v = tuple ()
+  return %v : $()
+}
+
 // CHECK-LABEL: sil [ossa] @copy_take_and_try_apply
 // CHECK-NOT: copy_addr
 // CHECK:   try_apply {{%[0-9]+}}(%0)
-// CHECK: bb1({{.*}}):
-// CHECK:   destroy_addr %0
-// CHECK: bb2({{.*}}):
-// CHECK:   destroy_addr %0
 // CHECK: bb3:
+// CHECK:   destroy_addr %0
 // CHECK:   store %1 to [init] %0
 // CHECK: } // end sil function 'copy_take_and_try_apply'
 sil [ossa] @copy_take_and_try_apply : $@convention(thin) (@inout Klass, @owned Klass) -> () {
@@ -263,20 +282,15 @@ bb1(%r : $()):
 bb2(%e : $Error):
   br bb3
 bb3:
-  store %1 to [init] %0 : $*Klass
   destroy_addr %2 : $*Klass
+  store %1 to [init] %0 : $*Klass
   dealloc_stack %2 : $*Klass
   %9 = tuple ()
   return %9 : $()
 }
 
-// Currently we cannot optimize this. But in theory it's possible to eliminate
-// both copies.
-//
 // CHECK-LABEL: sil [ossa] @copy_and_copy_back
-// CHECK:   [[STK:%[0-9]+]] = alloc_stack
-// CHECK:   copy_addr [take] %0 to [init] [[STK]]
-// CHECK:   copy_addr [take] [[STK]] to [init] %0
+// CHECK-NOT:     copy_addr
 // CHECK: } // end sil function 'copy_and_copy_back'
 sil [ossa] @copy_and_copy_back : $@convention(thin) (@inout Builtin.NativeObject) -> () {
 bb0(%0 : $*Builtin.NativeObject):
@@ -288,11 +302,10 @@ bb0(%0 : $*Builtin.NativeObject):
   return %v : $()
 }
 
-// CHECK-LABEL: sil [ossa] @dont_allow_copy_take_from_projection
-// CHECK:   [[STK:%[0-9]+]] = alloc_stack
-// CHECK:   copy_addr [take] %1 to [init] [[STK]]
-// CHECK: } // end sil function 'dont_allow_copy_take_from_projection'
-sil [ossa] @dont_allow_copy_take_from_projection : $@convention(thin) (@in Two) -> @out Two {
+// CHECK-LABEL: sil [ossa] @copy_take_from_projection
+// CHECK-NOT:     alloc_stack
+// CHECK: } // end sil function 'copy_take_from_projection'
+sil [ossa] @copy_take_from_projection : $@convention(thin) (@in Two) -> @out Two {
 bb0(%0 : $*Two, %1 : $*Two):
   %a0 = struct_element_addr %0 : $*Two, #Two.a
   %b0 = struct_element_addr %0 : $*Two, #Two.b
@@ -307,14 +320,14 @@ bb0(%0 : $*Two, %1 : $*Two):
   return %r : $()
 }
 
-// CHECK-LABEL: sil [ossa] @load_in_wrong_block
-// CHECK:      bb0(%0 : $*GS<B>):
-// CHECK-NEXT:   alloc_stack
-// CHECK-NEXT:   copy_addr
-// CHECK-NEXT:   struct_element_addr
-// CHECK-NEXT:   br bb1
-// CHECK:        return
-sil [ossa] @load_in_wrong_block : $@convention(thin) <B> (@in_guaranteed GS<B>) -> () {
+// CHECK-LABEL: sil [ossa] @load_in_different_block
+// CHECK-NOT:      alloc_stack
+// CHECK-NOT:      copy_addr
+// CHECK:          [[S:%.*]] = struct_element_addr %0
+// CHECK:        bb1:
+// CHECK-NEXT:        = load [trivial] [[S]]
+// CHECK:       } // end sil function 'load_in_different_block'
+sil [ossa] @load_in_different_block : $@convention(thin) <B> (@in_guaranteed GS<B>) -> () {
 bb0(%0 : $*GS<B>):
   %4 = alloc_stack $GS<B>
   copy_addr %0 to [init] %4 : $*GS<B>
@@ -330,13 +343,11 @@ bb1:
   return %9999 : $()
 }
 
-// CHECK-LABEL: sil [ossa] @projection_in_wrong_block
-// CHECK:      bb0(%0 : $*GS<B>):
-// CHECK-NEXT:   alloc_stack
-// CHECK-NEXT:   copy_addr
-// CHECK-NEXT:   br bb1
-// CHECK:        return
-sil [ossa] @projection_in_wrong_block : $@convention(thin) <B> (@in_guaranteed GS<B>) -> () {
+// CHECK-LABEL: sil [ossa] @projection_in_different_block
+// CHECK-NOT:     alloc_stack
+// CHECK-NOT:     copy_addr
+// CHECK:       } // end sil function 'projection_in_different_block'
+sil [ossa] @projection_in_different_block : $@convention(thin) <B> (@in_guaranteed GS<B>) -> () {
 bb0(%0 : $*GS<B>):
   %4 = alloc_stack $GS<B>
   copy_addr %0 to [init] %4 : $*GS<B>
@@ -835,12 +846,10 @@ bb0(%0 : $*Builtin.NativeObject):
   return %v : $()
 }
 
-// Do not remove a copy that is released via a load of a projection. This is not
-// the pattern from SILGen that we are targeting, so we reduce the state space by banning the pattern.
-//
 // CHECK-LABEL: sil [ossa] @takeWithLoadReleaseOfProjection : $@convention(thin) (@in GS<Builtin.NativeObject>) -> () {
-// CHECK: alloc_stack
-// CHECK: } // end sil function 'takeWithLoadReleaseOfProjection'
+// CHECK-NOT:     alloc_stack
+// CHECK-NOT:     copy_addr
+// CHECK:       } // end sil function 'takeWithLoadReleaseOfProjection'
 sil [ossa] @takeWithLoadReleaseOfProjection : $@convention(thin) (@in GS<Builtin.NativeObject>) -> () {
 bb0(%0 : $*GS<Builtin.NativeObject>):
   %stk = alloc_stack $GS<Builtin.NativeObject>
@@ -1701,14 +1710,11 @@ bb2:
   return %9
 }
 
-// CHECK-LABEL:    sil [ossa] @hoist_destroy :
-// CHECK:          bb0(%0 : $*Klass, %1 : @owned $Klass):
-// CHECK-OPT-NEXT:   destroy_addr %0
-// CHECK-OPT-NOT:    alloc_stack
-// CHECK-OPT-NOT:    copy_addr
-// CHECK-OPT-NOT:    destroy_addr
-// CHECK-LABEL:    } // end sil function 'hoist_destroy'
-sil [ossa] @hoist_destroy : $@convention(thin) (@inout Klass, @owned Klass) -> () {
+// CHECK-LABEL:    sil [ossa] @store_to_src_before_destroy :
+// CHECK:            alloc_stack
+// CHECK:            copy_addr
+// CHECK-LABEL:    } // end sil function 'store_to_src_before_destroy'
+sil [ossa] @store_to_src_before_destroy : $@convention(thin) (@inout Klass, @owned Klass) -> () {
 bb0(%0 : $*Klass, %1 : @owned $Klass):
   %2 = alloc_stack [lexical] [var_decl] $Klass
   copy_addr [take] %0 to [init] %2
@@ -1723,14 +1729,11 @@ bb2:
   return %9
 }
 
-// CHECK-LABEL:    sil [ossa] @hoist_destroy2 :
-// CHECK:          bb0(%0 : $*Klass, %1 : @owned $Klass, %2 : $*Int, %3 : $Int):
-// CHECK-OPT-NEXT:   destroy_addr %0
-// CHECK-OPT-NOT:    alloc_stack
-// CHECK-OPT-NOT:    copy_addr
-// CHECK-OPT-NOT:    destroy_addr
-// CHECK-LABEL:    } // end sil function 'hoist_destroy2'
-sil [ossa] @hoist_destroy2 : $@convention(thin) (@inout Klass, @owned Klass, @inout_aliasable Int, Int) -> () {
+// CHECK-LABEL:    sil [ossa] @store_to_src_before_destroy2 :
+// CHECK:            alloc_stack
+// CHECK:            copy_addr
+// CHECK-LABEL:    } // end sil function 'store_to_src_before_destroy2'
+sil [ossa] @store_to_src_before_destroy2 : $@convention(thin) (@inout Klass, @owned Klass, @inout_aliasable Int, Int) -> () {
 bb0(%0 : $*Klass, %1 : @owned $Klass, %2 : $*Int, %3 : $Int):
   %4 = alloc_stack [lexical] [var_decl] $Klass
   copy_addr [take] %0 to [init] %4
@@ -1810,3 +1813,87 @@ bb0(%0 : @owned $AnyObject):
   return %9
 }
 
+// CHECK-LABEL: sil [ossa] @optional_chaining :
+// CHECK-NOT:     alloc_stack
+// CHECK-NOT:     destroy_addr
+// CHECK-LABEL: } // end sil function 'optional_chaining'
+sil [ossa] @optional_chaining : $@convention(thin) (@in_guaranteed Optional<S>, Int) -> Optional<Int> {
+bb0(%0 : $*Optional<S>, %1 : $Int):
+  %2 = alloc_stack $Optional<S>
+  copy_addr %0 to [init] %2
+  switch_enum_addr %2, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb3
+
+bb1:
+  %5 = unchecked_take_enum_data_addr %2, #Optional.some!enumelt
+  %6 = struct_element_addr %5, #S.i
+  %7 = load [trivial] %6
+  destroy_addr %5
+  %9 = enum $Optional<Int>, #Optional.some!enumelt, %7
+  br bb2(%9)
+
+bb2(%11 : $Optional<Int>):
+  dealloc_stack %2
+  return %11
+
+bb3:
+  destroy_addr %2
+  %15 = enum $Optional<Int>, #Optional.none!enumelt
+  br bb2(%15)
+}
+
+// CHECK-LABEL: sil [ossa] @preserve_debug_var :
+// CHECK:         %1 = struct_element_addr %0
+// CHECK:         debug_value %1 : $*Klass, let, name "x"
+// CHECK-LABEL: } // end sil function 'preserve_debug_var'
+sil [ossa] @preserve_debug_var : $@convention(thin) (@inout NonTrivialStruct) -> () {
+bb0(%0 : $*NonTrivialStruct):
+  %1 = alloc_stack $Klass, let, name "x"
+  %3 = struct_element_addr %0, #NonTrivialStruct.val
+  copy_addr %3 to [init] %1
+  %4 = apply undef(%1) : $@convention(thin) (@in_guaranteed Klass) -> ()
+  destroy_addr %1
+  dealloc_stack %1
+  %9 = tuple ()
+  return %9 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @move_debug_value :
+// CHECK-NOT:     alloc_stack
+// CHECK:         %2 = struct_element_addr
+// CHECK:         debug_value %2 : $*Klass, let, name "x"
+// CHECK-LABEL: } // end sil function 'move_debug_value'
+sil [ossa] @move_debug_value : $@convention(thin) (@inout NonTrivialStruct) -> () {
+bb0(%0 : $*NonTrivialStruct):
+  %1 = alloc_stack $Klass
+  br bb1
+
+bb1:
+  debug_value %1, let, name "x"
+  %3 = struct_element_addr %0, #NonTrivialStruct.val
+  copy_addr %3 to [init] %1
+  %4 = apply undef(%1) : $@convention(thin) (@in_guaranteed Klass) -> ()
+  destroy_addr %1
+  dealloc_stack %1
+  %9 = tuple ()
+  return %9 : $()
+}
+
+// TODO: this is optimizable, we just don't support it currently
+// CHECK-LABEL: sil [ossa] @unmovable_user :
+// CHECK:         alloc_stack
+// CHECK-LABEL: } // end sil function 'unmovable_user'
+sil [ossa] @unmovable_user : $@convention(thin) (@inout S2) -> () {
+bb0(%0 : $*S2):
+  %1 = alloc_stack $NonTrivialStruct
+  br bb1
+
+bb1:
+  %2 = struct_element_addr %1, #NonTrivialStruct.val
+  %3 = struct_element_addr %0, #S2.ntv
+  copy_addr %3 to [init] %1
+  %4 = apply undef(%2) : $@convention(thin) (@in_guaranteed Klass) -> ()
+  destroy_addr %1
+  dealloc_stack %1
+  %9 = tuple ()
+  return %9 : $()
+}

--- a/test/SILOptimizer/unavailable_enum_element_mandatory.swift
+++ b/test/SILOptimizer/unavailable_enum_element_mandatory.swift
@@ -45,7 +45,7 @@ public func testFullyCoveredSwitchResilient(_ e: ResilientEnumWithUnavailableCas
 }
 
 // CHECK-LABEL: sil @$s4Test37testUnknownDefaultCaseSwitchResilientyy14resilient_enum0g19EnumWithUnavailableE0OF : $@convention(thin) (@in_guaranteed ResilientEnumWithUnavailableCase) -> () {
-// CHECK:         switch_enum_addr %2 : $*ResilientEnumWithUnavailableCase, case #ResilientEnumWithUnavailableCase.available!enumelt: [[AVAILBB:bb[0-9]+]], default [[DEFAULTBB:bb[0-9]+]]
+// CHECK:         switch_enum_addr %0 : $*ResilientEnumWithUnavailableCase, case #ResilientEnumWithUnavailableCase.available!enumelt: [[AVAILBB:bb[0-9]+]], default [[DEFAULTBB:bb[0-9]+]]
 // CHECK:       [[DEFAULTBB]]:
 // CHECK:         function_ref @$s4Test3fooyyF
 // CHECK-NEXT:    apply
@@ -113,7 +113,7 @@ public func testAvailableElementIfCase(_ e: HasUnavailableElement) {
 }
 
 // CHECK-LABEL: sil @$s4Test35testAvailableElementIfCaseResilientyy14resilient_enum0g19EnumWithUnavailableF0OF : $@convention(thin) (@in_guaranteed ResilientEnumWithUnavailableCase) -> () {
-// CHECK:         switch_enum_addr %2 : $*ResilientEnumWithUnavailableCase, case #ResilientEnumWithUnavailableCase.available!enumelt: [[AVAILBB:bb[0-9]+]], default [[DEFAULTBB:bb[0-9]+]]
+// CHECK:         switch_enum_addr %0 : $*ResilientEnumWithUnavailableCase, case #ResilientEnumWithUnavailableCase.available!enumelt: [[AVAILBB:bb[0-9]+]], default [[DEFAULTBB:bb[0-9]+]]
 // CHECK:       [[DEFAULTBB]]:
 // CHECK-NOT:     unreachable
 // CHECK:       } // end sil function '$s4Test35testAvailableElementIfCaseResilientyy14resilient_enum0g19EnumWithUnavailableF0OF'
@@ -137,7 +137,7 @@ public func testUnavailableElementIfCase(_ e: HasUnavailableElement) {
 }
 
 // CHECK-LABEL: sil @$s4Test37testUnavailableElementIfCaseResilientyy14resilient_enum0g8EnumWithcF0OF : $@convention(thin) (@in_guaranteed ResilientEnumWithUnavailableCase) -> () {
-// CHECK:         switch_enum_addr %2 : $*ResilientEnumWithUnavailableCase, default [[DEFAULTBB:bb[0-9]+]]
+// CHECK:         switch_enum_addr %0 : $*ResilientEnumWithUnavailableCase, default [[DEFAULTBB:bb[0-9]+]]
 // CHECK:       [[DEFAULTBB]]:
 // CHECK-NOT:     unreachable
 // CHECK:       } // end sil function '$s4Test37testUnavailableElementIfCaseResilientyy14resilient_enum0g8EnumWithcF0OF'

--- a/test/SILOptimizer/worklist_unit.sil
+++ b/test/SILOptimizer/worklist_unit.sil
@@ -1,0 +1,87 @@
+// RUN: %target-sil-opt -test-runner %s -o /dev/null 2>&1 | %FileCheck %s
+
+sil_stage canonical
+
+// CHECK-LABEL: begin running test 1 of 1 on forward: instruction_worklist with: false
+// CHECK-NEXT:    string_literal utf8 "begin"
+// CHECK-NEXT:    br bb1
+// CHECK-NEXT:    string_literal utf8 "b"
+// CHECK-NEXT:    cond_br undef, bb2, bb3
+// CHECK-NEXT:    br bb4
+// CHECK-NEXT:    string_literal utf8 "f"
+// CHECK-NEXT:    cond_br undef, bb5, bb6
+// CHECK-NEXT:    string_literal utf8 "g"
+// CHECK-NEXT:    br bb1
+// CHECK-NEXT:    string_literal utf8 "c"
+// CHECK-NEXT:    string_literal utf8 "d"
+// CHECK-NEXT:    br bb4
+// CHECK-NEXT:  end running test 1 of 1 on forward: instruction_worklist with: false
+sil [ossa] @forward : $@convention(thin) () -> () {
+bb0:
+  specify_test "instruction_worklist false"
+  %0 = string_literal utf8 "a"
+  %1 = string_literal utf8 "begin"
+  br bb1
+
+bb1:
+  %3 = string_literal utf8 "b"
+  cond_br undef, bb2, bb3
+
+bb2:
+  %4 = string_literal utf8 "c"
+  %5 = string_literal utf8 "d"
+  br bb4
+
+bb3:
+  %6 = string_literal utf8 "transparent"
+  %7 = string_literal utf8 "e"
+  br bb4
+
+bb4:
+  %9 = string_literal utf8 "f"
+  cond_br undef, bb5, bb6
+
+bb5:
+  br bb1
+
+bb6:
+  %10 = string_literal utf8 "g"
+  %11 = string_literal utf8 "end"
+  %12 = tuple ()
+  return %12
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on backward: instruction_worklist with: true
+// CHECK-NEXT:    string_literal utf8 "begin"
+// CHECK-NEXT:    string_literal utf8 "transparent"
+// CHECK-NEXT:    cond_br undef, bb1, bb2
+// CHECK-NEXT:    string_literal utf8 "begin"
+// CHECK-NEXT:    string_literal utf8 "b"
+// CHECK-NEXT:  end running test 1 of 1 on backward: instruction_worklist with: true
+sil [ossa] @backward : $@convention(thin) () -> () {
+bb0:
+  specify_test "instruction_worklist true"
+  %0 = string_literal utf8 "a"
+  %1 = string_literal utf8 "end"
+  cond_br undef, bb1, bb2
+
+bb1:
+  %3 = string_literal utf8 "b"
+  %4 = string_literal utf8 "begin"
+  %5 = string_literal utf8 "c"
+  br bb4
+
+bb2:
+  %7 = string_literal utf8 "transparent"
+  %8 = string_literal utf8 "d"
+  br bb3
+
+bb3:
+  %10 = string_literal utf8 "begin"
+  br bb4
+
+bb4:
+  %12 = tuple ()
+  return %12
+}
+


### PR DESCRIPTION
So far TempRValueOptimization just handled the case where all uses of the `alloc_stack` are in the same basic block.
Now we can handle arbitrary liveranges of the `alloc_stack`.
Also, improve the enum-to-non-enum `alloc_stack` simplification. First, handle non-destructive `unchecked_take_enum_data_addr` correctly. Second, improve the algorithm to handle more cases.
These optimization improvements lead to significantly more removed and simplified `alloc_stack`s.

rdar://168845882
