### PR TITLE
[cxx-interop] Fix crash trying to expose Swift existentials to C++

### DIFF
--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -21,6 +21,7 @@
 #include "swift/ABI/MetadataValues.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/GenericParamList.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/ParameterList.h"
@@ -290,7 +291,12 @@ public:
   visitExistentialType(ExistentialType *ty,
                        std::optional<OptionalTypeKind> optionalKind,
                        bool isInOutParam) {
-    if (ty->isObjCExistentialType()) {
+    bool hasSwiftSuperClass = false;
+    if (auto superClass = ty->getExistentialLayout().getSuperclass()) {
+      auto *CD = superClass->getClassOrBoundGenericClass();
+      hasSwiftSuperClass = !CD->isObjC();
+    }
+    if (ty->isObjCExistentialType() && !hasSwiftSuperClass) {
       declPrinter.withOutputStream(os).print(ty, optionalKind);
       if (isInOutParam) {
         os << " __strong";

--- a/test/Interop/SwiftToCxx/unsupported/unsupported-existentials-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/unsupported/unsupported-existentials-in-cxx.swift
@@ -1,0 +1,15 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name Existentials -verify -clang-header-expose-decls=all-public -disable-availability-checking -typecheck -verify -emit-clang-header-path %t/existentials.h
+// RUN: %FileCheck %s < %t/existentials.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/existentials.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -std=c++17)
+
+public struct Foo {
+    var x: CInt
+    var y: CInt
+};
+
+public func useExistential(_ x: KeyPath<Foo, CInt> & Sendable) {
+}
+
+// CHECK: Unavailable in C++: Swift global function 'useExistential(_:)'.


### PR DESCRIPTION
Confusingly, isObjCExistentialType does not check if the super class is actually ObjC. Make the check stricter to avoid a crash down the line.

rdar://169210092
