### PR TITLE
MandatoryPerformanceOptimizations: force de-virtualizing value-type deinits

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/DeinitDevirtualizer.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/DeinitDevirtualizer.swift
@@ -24,11 +24,11 @@ let deinitDevirtualizer = FunctionPass(name: "deinit-devirtualizer") {
   for inst in function.instructions {
     switch inst {
     case let destroyValue as DestroyValueInst:
-      _ = devirtualizeDeinits(of: destroyValue, context)
+      _ = devirtualizeDeinits(of: destroyValue, isMandatory: false, context)
     case let destroyAddr as DestroyAddrInst:
-      _ = devirtualizeDeinits(of: destroyAddr, context)
+      _ = devirtualizeDeinits(of: destroyAddr, isMandatory: false, context)
     case let builtin as BuiltinInst:
-      _ = devirtualizeDeinits(of: builtin, context)
+      _ = devirtualizeDeinits(of: builtin, isMandatory: false, context)
     default:
       break
     }

--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
@@ -161,7 +161,7 @@ private func optimize(function: Function, _ context: FunctionPassContext, _ modu
           worklist.addWitnessMethods(of: conformance, moduleContext)
 
         default:
-          if !devirtualizeDeinits(of: bi, simplifyCtxt) {
+          if !devirtualizeDeinits(of: bi, isMandatory: true, simplifyCtxt) {
             // If invoked from SourceKit avoid reporting false positives when WMO is turned off for indexing purposes.
             if moduleContext.enableWMORequiredDiagnostics {
               context.diagnosticEngine.diagnose(.deinit_not_visible, at: bi.location)
@@ -171,14 +171,14 @@ private func optimize(function: Function, _ context: FunctionPassContext, _ modu
 
       // We need to de-virtualize deinits of non-copyable types to be able to specialize the deinitializers.
       case let destroyValue as DestroyValueInst:
-        if !devirtualizeDeinits(of: destroyValue, simplifyCtxt) {
+        if !devirtualizeDeinits(of: destroyValue, isMandatory: true, simplifyCtxt) {
           // If invoked from SourceKit avoid reporting false positives when WMO is turned off for indexing purposes.
           if moduleContext.enableWMORequiredDiagnostics {
             context.diagnosticEngine.diagnose(.deinit_not_visible, at: destroyValue.location)
           }
         }
       case let destroyAddr as DestroyAddrInst:
-        if !devirtualizeDeinits(of: destroyAddr, simplifyCtxt) {
+        if !devirtualizeDeinits(of: destroyAddr, isMandatory: true, simplifyCtxt) {
           // If invoked from SourceKit avoid reporting false positives when WMO is turned off for indexing purposes.
           if moduleContext.enableWMORequiredDiagnostics {
             context.diagnosticEngine.diagnose(.deinit_not_visible, at: destroyAddr.location)

--- a/test/SILOptimizer/mandatory_performance_optimizations.sil
+++ b/test/SILOptimizer/mandatory_performance_optimizations.sil
@@ -13,6 +13,10 @@ struct NonTrivialStruct {
   var s: String
 }
 
+struct S6: ~Copyable {
+  deinit
+}
+
 sil_global [let] @g1 : $Int32
 sil_global [let] @g2 : $Int32
 sil_global [let] @g3 : $Int32
@@ -248,6 +252,25 @@ bb0(%0 : $Int):
   return %12
 }
 
+// CHECK-LABEL: sil [serialized] [no_allocation] [perf_constraint] [ossa] @devirtualze_hidden_deinit :
+// CHECK:         function_ref @s6_deinit
+// CHECK-NEXT:    apply
+// CHECK:       } // end sil function 'devirtualze_hidden_deinit'
+sil [serialized] [no_allocation] [ossa] @devirtualze_hidden_deinit : $@convention(thin) (@owned S6) -> () {
+bb0(%0 : @owned $S6):
+  destroy_value %0
+  %r = tuple()
+  return %r
+}
+
+// CHECK-LABEL: sil [perf_constraint] [ossa] @s6_deinit :
+sil hidden [ossa] @s6_deinit : $@convention(method) (@owned S6) -> () {
+bb0(%0 : @owned $S6):
+  end_lifetime %0
+  %r = tuple ()
+  return %r
+}
+
 // CHECK-LABEL: sil [no_locks] [perf_constraint] [ossa] @remove_metatype_arg :
 // CHECK:         [[F:%.*]] = function_ref @$s12metatype_argTf4ndn_n : $@convention(thin) (Int, @owned Builtin.NativeObject) -> @owned Builtin.NativeObject
 // CHECK:         [[A:%.*]] = apply [[F]](%0, %1) : $@convention(thin) (Int, @owned Builtin.NativeObject) -> @owned Builtin.NativeObject
@@ -382,3 +405,7 @@ bb0(%0 : $Int, %1 : $@thick Int.Type, %2 : @owned $Builtin.NativeObject):
 // CHECK:         return %1 : $Builtin.NativeObject
 // CHECK:       } // end sil function '$s12metatype_argTf4ndn_n'
 
+
+sil_moveonlydeinit S6 {
+  @s6_deinit
+}


### PR DESCRIPTION
Do this even if the function then contains references to other functions with wrong linkage. MandatoryPerformanceOptimization fixes the linkage afterwards. This is similar to what we already do with de-virtualizing class and witness methods: https://github.com/swiftlang/swift/pull/76032

rdar://168171608
