### PR TITLE
[CSBindings] Filter leading-dot base types based on member lookup

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -2181,6 +2181,12 @@ void PotentialBindings::infer(Constraint *constraint) {
 
   case ConstraintKind::NonisolatedConformsTo:
   case ConstraintKind::ConformsTo:
+    // Conformances are applicable only to the types they are
+    // placed on. They could be transferred to supertypes
+    // but that happens separately.
+    if (!isDirectRequirement(CS, TypeVar, constraint))
+      break;
+
     if (constraint->getSecondType()->is<ProtocolType>())
       recordProtocol(constraint);
     break;

--- a/test/expr/delayed-ident/member_chains.swift
+++ b/test/expr/delayed-ident/member_chains.swift
@@ -409,3 +409,22 @@ do {
     }
   }
 }
+
+protocol P {
+  associatedtype X
+}
+protocol Q {}
+
+struct S: P, Q {
+  typealias X = S
+}
+
+extension Q where Self == S {
+  static var value: S { S() }
+}
+
+// Leading-dot syntax used to infer base from non-direct requirements which is incorrect.
+do {
+  func test_indirect<T: P>(_ x: T) where T.X: Q {}
+  test_indirect(.value) // expected-error {{type 'P' has no member 'value'}}
+}


### PR DESCRIPTION
If the transitively inferred protocol base type doesn't have a member
that was referenced via leading-dot syntax, let's filter it out from
the binding set during normal type-checking.

This helps to make sure that we don't attempt more than necessary
during normal type checking and prevents unrelated types from
interfering with type variable selection. These types are going
to be attempted in diagnostic mode still to make sure that any
typos or other user originated errors are properly diagnosed.

The test-case for this was added by c26ef041b8caf994803b2f38f55921e1705cbe71

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
