### PR TITLE
[rbi] Use indirect assignment for stores to no-alias destinations to fix a common data race hole

### DIFF
--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -1683,8 +1683,6 @@ public:
       handleAssignNonDisconnectedIntoSendingResult(op);
 
       // Create extra region for our dest and merge it into dest's region.
-      //
-      // We use an optional in case our evaluator does not support doing this.
       p.trackNewElement(op.getOpArg3());
       p.merge(op.getOpArg1(), op.getOpArg3());
 

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -148,7 +148,8 @@ public:
     }
 
     if (auto *op = value.dyn_cast<Operand *>()) {
-      os << "Value from Overwritten Memory : " << *op;
+      os << "Value from Overwritten Memory. Op Num: " << op->getOperandNumber()
+         << ". User: " << *op->getUser();
       return;
     }
 
@@ -1674,9 +1675,6 @@ public:
              "Assign PartitionOp's dest argument should be already tracked");
       assert(p.isTrackingElement(op.getOpArg2()) &&
              "Assign PartitionOp's source argument should be already tracked");
-      assert(
-          p.isTrackingElement(op.getOpArg3()) &&
-          "Assign PartitionOp's dest value argument should be already tracked");
 
       // First emit any errors if we are assigning a non-disconnected thing into
       // a sending result.

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -1671,17 +1671,23 @@ struct PartitionOpBuilder {
         PartitionOp::AssignFresh(id, currentInst));
   }
 
-  void addAssignFresh(ArrayRef<TrackableValue> values) {
-    if (values.empty())
+  /// Assign fresh an entire range of values to the same region.
+  template <typename ValueRangeTy>
+  void addAssignFresh(ValueRangeTy values) {
+    auto iter = values.begin();
+    auto end = values.end();
+    if (iter == end)
       return;
 
-    auto first = values.front();
+    TrackableValue first = *iter;
+    ++iter;
     currentInstPartitionOps->emplace_back(
         PartitionOp::AssignFresh(first.getID(), currentInst));
 
-    for (auto value : values.drop_front()) {
+    while (iter != end) {
       currentInstPartitionOps->emplace_back(PartitionOp::AssignFreshAssign(
-          value.getID(), first.getID(), currentInst));
+          (*iter).getID(), first.getID(), currentInst));
+      ++iter;
     }
   }
 

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -2648,10 +2648,12 @@ public:
       return translateIsolatedPartialApply(pai, isolationRegionInfo);
     }
 
-    SmallVector<SILValue, 8> applyResults;
-    getApplyResults(pai, applyResults);
-    translateSILMultiAssign(applyResults,
-                            makeOperandRefRange(pai->getAllOperands()));
+    SmallVector<SILValue, 8> directResults;
+    getApplyResults(pai, directResults);
+    translateSILMultiAssign(
+        directResults,
+        ArrayRef<Operand *>(), // No indirect results for a partial_apply.
+        makeOperandRefRange(pai->getAllOperands()));
   }
 
   void translateCreateAsyncTask(BuiltinInst *bi) {

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -3154,7 +3154,7 @@ public:
       if (destResult.value().value.isNoAlias() &&
           !resultIsolationInfoOverride &&
           !isProjectedFromAggregate(destValue))
-        return translateSILAssignDirect(destValue, src);
+        return translateSILAssignIndirect(dest, src);
 
       // Stores to possibly aliased storage must be treated as merges.
       return translateSILMerge(destValue, src, /*requireOperand*/true,

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -2973,6 +2973,25 @@ public:
     }
   }
 
+  /// Perform an assign for dest that is an indirect parameter. It should be a
+  /// parameter of the current inst we are processing.
+  template <typename SourceOperandsTy>
+  void translateSILAssignIndirect(Operand *dest,
+                                  SourceOperandsTy sourceOperands) {
+    return translateSILMultiAssign(
+        ArrayRef<SILValue>(), TinyPtrVector<Operand *>(dest), sourceOperands);
+  }
+
+  /// Perform an assign for dest that is an indirect parameter. It should be a
+  /// parameter of the current inst we are processing.
+  template <>
+  void translateSILAssignIndirect<Operand *>(Operand *dest,
+                                             Operand *srcOperand) {
+    return translateSILMultiAssign(ArrayRef<SILValue>(),
+                                   TinyPtrVector<Operand *>(dest),
+                                   TinyPtrVector<Operand *>(srcOperand));
+  }
+
   /// Perform an assign for dest that is a direct parameter. It should be a
   /// parameter of the current inst we are processing.
   template <typename Collection>

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -3611,6 +3611,8 @@ CONSTANT_TRANSLATION(ExistentialMetatypeInst, AssignDirect)
 CONSTANT_TRANSLATION(ObjectInst, AssignDirect)
 CONSTANT_TRANSLATION(StructInst, AssignDirect)
 CONSTANT_TRANSLATION(TupleInst, AssignDirect)
+CONSTANT_TRANSLATION(SelectEnumAddrInst, AssignDirect)
+CONSTANT_TRANSLATION(SelectEnumInst, AssignDirect)
 
 //===---
 // Look Through
@@ -4242,18 +4244,6 @@ TranslationSemantics PartitionOpTranslator::visitEnumInst(EnumInst *ei) {
   if (ei->getNumOperands() == 0)
     return TranslationSemantics::AssignFresh;
   return TranslationSemantics::AssignDirect;
-}
-
-TranslationSemantics
-PartitionOpTranslator::visitSelectEnumAddrInst(SelectEnumAddrInst *inst) {
-  translateSILSelectEnum(inst);
-  return TranslationSemantics::Special;
-}
-
-TranslationSemantics
-PartitionOpTranslator::visitSelectEnumInst(SelectEnumInst *inst) {
-  translateSILSelectEnum(inst);
-  return TranslationSemantics::Special;
 }
 
 TranslationSemantics

--- a/test/Concurrency/transfernonsendable_partitionop_translation.sil
+++ b/test/Concurrency/transfernonsendable_partitionop_translation.sil
@@ -120,8 +120,10 @@ sil @coro_multiple_params : $@yield_once @convention(thin) (@owned NonSendableKl
 // CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
 // CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
 // CHECK-NEXT:     Rep Value:   %1 = alloc_stack $NonSendableKlass
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: Value from Overwritten Memory. Op Num: 1. User:   store %2 to [init] %1 : $*NonSendableKlass
 // CHECK-NEXT: require %%0:   store %2 to [init] %1 : $*NonSendableKlass
-// CHECK-NEXT: assign_direct %%1 = %%0:   store %2 to [init] %1 : $*NonSendableKlass
+// CHECK-NEXT: assign_indirect %%1 = %%0.   Overwritten Value: 2:   store %2 to [init] %1 : $*NonSendableKlass
 // CHECK-NEXT: end running test {{.*}} on test_store_init: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
 sil [ossa] @test_store_init : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
 bb0(%0 : @guaranteed $NonSendableKlass):
@@ -176,8 +178,10 @@ bb0(%0 : @guaranteed $NonSendableKlass, %arg1 : @guaranteed $NonSendableKlass):
 // CHECK-NEXT:     Rep Value: %1 = argument of bb0 : $NonSendableKlass
 // CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
 // CHECK-NEXT:     Rep Value:   %2 = alloc_stack $NonSendableKlass
+// CHECK-NEXT: %%3: TrackableValue. State: TrackableValueState[id: 3][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: Value from Overwritten Memory. Op Num: 1. User:   store %5 to [assign] %2 : $*NonSendableKlass
 // CHECK-NEXT: require %%1:   store %5 to [assign] %2 : $*NonSendableKlass
-// CHECK-NEXT: assign_direct %%2 = %%1:   store %5 to [assign] %2 : $*NonSendableKlass
+// CHECK-NEXT: assign_indirect %%2 = %%1.   Overwritten Value: 3:   store %5 to [assign] %2 : $*NonSendableKlass
 // CHECK-NEXT: end running test {{.*}} on test_store_assign_unaliased: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
 sil [ossa] @test_store_assign_unaliased : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> () {
 bb0(%0 : @guaranteed $NonSendableKlass, %1 : @guaranteed $NonSendableKlass):
@@ -236,8 +240,10 @@ bb0(%0 : @guaranteed $NonSendableKlass, %1 : @guaranteed $NonSendableKlass, %arg
 // CHECK-NEXT:     Rep Value:   %2 = alloc_stack $NonSendableKlass
 // CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
 // CHECK-NEXT:     Rep Value:   %1 = alloc_stack $NonSendableKlass
+// CHECK-NEXT: %%3: TrackableValue. State: TrackableValueState[id: 3][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: Value from Overwritten Memory. Op Num: 1. User:   copy_addr %1 to [init] %2 : $*NonSendableKlass
 // CHECK-NEXT: require %%2:   copy_addr %1 to [init] %2 : $*NonSendableKlass
-// CHECK-NEXT: assign_direct %%1 = %%2:   copy_addr %1 to [init] %2 : $*NonSendableKlass
+// CHECK-NEXT: assign_indirect %%1 = %%2.   Overwritten Value: 3:   copy_addr %1 to [init] %2 : $*NonSendableKlass
 // CHECK-NEXT: end running test {{.*}} on test_copy_addr_to_init: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
 sil [ossa] @test_copy_addr_to_init : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
 bb0(%0 : @guaranteed $NonSendableKlass):
@@ -263,8 +269,10 @@ bb0(%0 : @guaranteed $NonSendableKlass):
 // CHECK-NEXT:     Rep Value:   %2 = alloc_stack $NonSendableKlass
 // CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
 // CHECK-NEXT:     Rep Value:   %1 = alloc_stack $NonSendableKlass
+// CHECK-NEXT: %%3: TrackableValue. State: TrackableValueState[id: 3][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: Value from Overwritten Memory. Op Num: 1. User:   copy_addr [take] %1 to [init] %2 : $*NonSendableKlass
 // CHECK-NEXT: require %%2:   copy_addr [take] %1 to [init] %2 : $*NonSendableKlass
-// CHECK-NEXT: assign_direct %%1 = %%2:   copy_addr [take] %1 to [init] %2 : $*NonSendableKlass
+// CHECK-NEXT: assign_indirect %%1 = %%2.   Overwritten Value: 3:   copy_addr [take] %1 to [init] %2 : $*NonSendableKlass
 // CHECK-NEXT: end running test {{.*}} on test_copy_addr_take_to_init: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
 sil [ossa] @test_copy_addr_take_to_init : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
 bb0(%0 : @guaranteed $NonSendableKlass):
@@ -291,8 +299,10 @@ bb0(%0 : @guaranteed $NonSendableKlass):
 // CHECK-NEXT:     Rep Value:   %3 = alloc_stack $NonSendableKlass
 // CHECK-NEXT: %%3: TrackableValue. State: TrackableValueState[id: 3][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
 // CHECK-NEXT:     Rep Value:   %2 = alloc_stack $NonSendableKlass
+// CHECK-NEXT: %%4: TrackableValue. State: TrackableValueState[id: 4][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: Value from Overwritten Memory. Op Num: 1. User:   copy_addr %2 to %3 : $*NonSendableKlass
 // CHECK-NEXT: require %%3:   copy_addr %2 to %3 : $*NonSendableKlass
-// CHECK-NEXT: assign_direct %%2 = %%3:   copy_addr %2 to %3 : $*NonSendableKlass
+// CHECK-NEXT: assign_indirect %%2 = %%3.   Overwritten Value: 4:   copy_addr %2 to %3 : $*NonSendableKlass
 // CHECK-NEXT: end running test {{.*}} on test_copy_addr_to_initialized: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
 sil [ossa] @test_copy_addr_to_initialized : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> () {
 bb0(%0 : @guaranteed $NonSendableKlass, %1 : @guaranteed $NonSendableKlass):
@@ -320,8 +330,10 @@ bb0(%0 : @guaranteed $NonSendableKlass, %1 : @guaranteed $NonSendableKlass):
 // CHECK-NEXT:     Rep Value:   %2 = alloc_stack $NonSendableKlass
 // CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
 // CHECK-NEXT:     Rep Value:   %1 = alloc_stack $NonSendableKlass
+// CHECK-NEXT: %%3: TrackableValue. State: TrackableValueState[id: 3][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: Value from Overwritten Memory. Op Num: 1. User:   explicit_copy_addr %1 to [init] %2 : $*NonSendableKlass
 // CHECK-NEXT: require %%2:   explicit_copy_addr %1 to [init] %2 : $*NonSendableKlass
-// CHECK-NEXT: assign_direct %%1 = %%2:   explicit_copy_addr %1 to [init] %2 : $*NonSendableKlass
+// CHECK-NEXT: assign_indirect %%1 = %%2.   Overwritten Value: 3:   explicit_copy_addr %1 to [init] %2 : $*NonSendableKlass
 // CHECK-NEXT: end running test {{.*}} on test_explicit_copy_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
 sil [ossa] @test_explicit_copy_addr : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
 bb0(%0 : @guaranteed $NonSendableKlass):
@@ -2712,8 +2724,10 @@ bb0(%0 : $*@sil_weak Optional<NonSendableKlass>):
 // CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $Optional<NonSendableKlass>
 // CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: yes][is_sendable: no][region_value_kind: task-isolated].
 // CHECK-NEXT:     Rep Value: %1 = argument of bb0 : $*@sil_weak Optional<NonSendableKlass>
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: yes][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: Value from Overwritten Memory. Op Num: 1. User:   store_weak %0 to %1 : $*@sil_weak Optional<NonSendableKlass>
 // CHECK-NEXT: require %%0:   store_weak %0 to %1 : $*@sil_weak Optional<NonSendableKlass>
-// CHECK-NEXT: assign_direct %%1 = %%0:   store_weak %0 to %1 : $*@sil_weak Optional<NonSendableKlass>
+// CHECK-NEXT: assign_indirect %%1 = %%0.   Overwritten Value: 2:   store_weak %0 to %1 : $*@sil_weak Optional<NonSendableKlass>
 // CHECK-NEXT: end running test {{.*}} on test_store_weak: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
 sil [ossa] @test_store_weak : $@convention(thin) (@owned Optional<NonSendableKlass>, @inout @sil_weak Optional<NonSendableKlass>) -> () {
 bb0(%0 : @owned $Optional<NonSendableKlass>, %1 : $*@sil_weak Optional<NonSendableKlass>):
@@ -2751,8 +2765,10 @@ bb0(%0 : $*@sil_unowned NonSendableKlass):
 // CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
 // CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: yes][is_sendable: no][region_value_kind: task-isolated].
 // CHECK-NEXT:     Rep Value: %1 = argument of bb0 : $*@sil_unowned NonSendableKlass
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: yes][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: Value from Overwritten Memory. Op Num: 1. User:   store_unowned %0 to %1 : $*@sil_unowned NonSendableKlass
 // CHECK-NEXT: require %%0:   store_unowned %0 to %1 : $*@sil_unowned NonSendableKlass
-// CHECK-NEXT: assign_direct %%1 = %%0:   store_unowned %0 to %1 : $*@sil_unowned NonSendableKlass
+// CHECK-NEXT: assign_indirect %%1 = %%0.   Overwritten Value: 2:   store_unowned %0 to %1 : $*@sil_unowned NonSendableKlass
 // CHECK-NEXT: end running test {{.*}} on test_store_unowned: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
 sil [ossa] @test_store_unowned : $@convention(thin) (@guaranteed NonSendableKlass, @inout @sil_unowned NonSendableKlass) -> () {
 bb0(%0 : @guaranteed $NonSendableKlass, %1 : $*@sil_unowned NonSendableKlass):
@@ -3428,3 +3444,118 @@ bb0:
 //  %r = tuple ()
 //  return %r : $()
 //}
+
+//===----------------------------------------------------------------------===//
+// MARK: mark_unresolved_move_addr, unchecked_ref_cast_addr, unconditional_checked_cast_addr
+//===----------------------------------------------------------------------===//
+
+// These instructions use Store semantics with translateSILAssignIndirect.
+
+// CHECK-LABEL: begin running test {{.*}} on test_mark_unresolved_move_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %2 = alloc_stack $NonSendableKlass
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = alloc_stack $NonSendableKlass
+// CHECK-NEXT: %%3: TrackableValue. State: TrackableValueState[id: 3][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: Value from Overwritten Memory. Op Num: 1. User:   mark_unresolved_move_addr %1 to %2 : $*NonSendableKlass
+// CHECK-NEXT: require %%2:   mark_unresolved_move_addr %1 to %2 : $*NonSendableKlass
+// CHECK-NEXT: assign_indirect %%1 = %%2.   Overwritten Value: 3:   mark_unresolved_move_addr %1 to %2 : $*NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_mark_unresolved_move_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_mark_unresolved_move_addr : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %1 = alloc_stack $NonSendableKlass
+  %2 = alloc_stack $NonSendableKlass
+  %3 = copy_value %0
+  store %3 to [init] %1
+  mark_unresolved_move_addr %1 to %2 : $*NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_addr %1
+  destroy_addr %2
+  dealloc_stack %2
+  dealloc_stack %1
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: begin running test {{.*}} on test_unchecked_ref_cast_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %2 = alloc_stack $NonSendableKlassSubKlass
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = alloc_stack $NonSendableKlass
+// CHECK-NEXT: %%3: TrackableValue. State: TrackableValueState[id: 3][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: Value from Overwritten Memory. Op Num: 1. User:   unchecked_ref_cast_addr NonSendableKlass in %1 : $*NonSendableKlass to NonSendableKlassSubKlass in %2 : $*NonSendableKlassSubKlass
+// CHECK-NEXT: require %%2:   unchecked_ref_cast_addr NonSendableKlass in %1 : $*NonSendableKlass to NonSendableKlassSubKlass in %2 : $*NonSendableKlassSubKlass
+// CHECK-NEXT: assign_indirect %%1 = %%2.   Overwritten Value: 3:   unchecked_ref_cast_addr NonSendableKlass in %1 : $*NonSendableKlass to NonSendableKlassSubKlass in %2 : $*NonSendableKlassSubKlass
+// CHECK-NEXT: end running test {{.*}} on test_unchecked_ref_cast_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_unchecked_ref_cast_addr : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %1 = alloc_stack $NonSendableKlass
+  %2 = alloc_stack $NonSendableKlassSubKlass
+  %3 = copy_value %0
+  store %3 to [init] %1
+  unchecked_ref_cast_addr NonSendableKlass in %1 : $*NonSendableKlass to NonSendableKlassSubKlass in %2 : $*NonSendableKlassSubKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_addr %2
+  dealloc_stack %2
+  dealloc_stack %1
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: begin running test {{.*}} on test_unconditional_checked_cast_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %2 = alloc_stack $NonSendableKlassSubKlass
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = alloc_stack $NonSendableKlass
+// CHECK-NEXT: %%3: TrackableValue. State: TrackableValueState[id: 3][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: Value from Overwritten Memory. Op Num: 1. User:   unconditional_checked_cast_addr NonSendableKlass in %1 : $*NonSendableKlass to NonSendableKlassSubKlass in %2 : $*NonSendableKlassSubKlass
+// CHECK-NEXT: require %%2:   unconditional_checked_cast_addr NonSendableKlass in %1 : $*NonSendableKlass to NonSendableKlassSubKlass in %2 : $*NonSendableKlassSubKlass
+// CHECK-NEXT: assign_indirect %%1 = %%2.   Overwritten Value: 3:   unconditional_checked_cast_addr NonSendableKlass in %1 : $*NonSendableKlass to NonSendableKlassSubKlass in %2 : $*NonSendableKlassSubKlass
+// CHECK-NEXT: end running test {{.*}} on test_unconditional_checked_cast_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_unconditional_checked_cast_addr : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %1 = alloc_stack $NonSendableKlass
+  %2 = alloc_stack $NonSendableKlassSubKlass
+  %3 = copy_value %0
+  store %3 to [init] %1
+  unconditional_checked_cast_addr NonSendableKlass in %1 : $*NonSendableKlass to NonSendableKlassSubKlass in %2 : $*NonSendableKlassSubKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_addr %2
+  dealloc_stack %2
+  dealloc_stack %1
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: begin running test {{.*}} on test_pack_element_set: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = alloc_pack $Pack{NonSendableKlass}
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %2 = alloc_stack $NonSendableKlass
+// CHECK-NEXT: require %%1:   pack_element_set %2 : $*NonSendableKlass into %5 of %1 : $*Pack{NonSendableKlass}
+// CHECK-NEXT: require %%2:   pack_element_set %2 : $*NonSendableKlass into %5 of %1 : $*Pack{NonSendableKlass}
+// CHECK-NEXT: merge %%1 with %%2:   pack_element_set %2 : $*NonSendableKlass into %5 of %1 : $*Pack{NonSendableKlass}
+// CHECK-NEXT: end running test {{.*}} on test_pack_element_set: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_pack_element_set : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %1 = alloc_pack $Pack{NonSendableKlass}
+  %2 = alloc_stack $NonSendableKlass
+  %3 = copy_value %0
+  store %3 to [init] %2
+  %index = scalar_pack_index 0 of $Pack{NonSendableKlass}
+  pack_element_set %2 : $*NonSendableKlass into %index of %1 : $*Pack{NonSendableKlass}
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_addr %2
+  dealloc_stack %2
+  dealloc_pack %1
+  %r = tuple ()
+  return %r : $()
+}

--- a/test/Concurrency/transfernonsendable_partitionop_translation.sil
+++ b/test/Concurrency/transfernonsendable_partitionop_translation.sil
@@ -2564,6 +2564,7 @@ bb0:
 // CHECK-NEXT:     Rep Value:   %2 = integer_literal $Builtin.Int32, 0
 // CHECK-NEXT: %%3: TrackableValue. State: TrackableValueState[id: 3][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
 // CHECK-NEXT:     Rep Value:   %3 = select_enum %0 : $NonSendableEnum, case #NonSendableEnum.some!enumelt: %1, case #NonSendableEnum.none!enumelt: %2 : $Builtin.Int32
+// CHECK-NEXT: require %%0:   %3 = select_enum %0 : $NonSendableEnum, case #NonSendableEnum.some!enumelt: %1, case #NonSendableEnum.none!enumelt: %2 : $Builtin.Int32
 // CHECK-NEXT: end running test {{.*}} on test_select_enum: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
 sil [ossa] @test_select_enum : $@convention(thin) (@guaranteed NonSendableEnum) -> Builtin.Int32 {
 bb0(%0 : @guaranteed $NonSendableEnum):
@@ -2584,6 +2585,7 @@ bb0(%0 : @guaranteed $NonSendableEnum):
 // CHECK-NEXT:     Rep Value:   %2 = integer_literal $Builtin.Int32, 0
 // CHECK-NEXT: %%3: TrackableValue. State: TrackableValueState[id: 3][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
 // CHECK-NEXT:     Rep Value:   %3 = select_enum_addr %0 : $*NonSendableEnum, case #NonSendableEnum.some!enumelt: %1, case #NonSendableEnum.none!enumelt: %2 : $Builtin.Int32
+// CHECK-NEXT: require %%0:   %3 = select_enum_addr %0 : $*NonSendableEnum, case #NonSendableEnum.some!enumelt: %1, case #NonSendableEnum.none!enumelt: %2 : $Builtin.Int32
 // CHECK-NEXT: end running test {{.*}} on test_select_enum_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
 sil [ossa] @test_select_enum_addr : $@convention(thin) (@in_guaranteed NonSendableEnum) -> Builtin.Int32 {
 bb0(%0 : $*NonSendableEnum):


### PR DESCRIPTION
## Overview

This PR is the first in a series of changes migrating instructions to indirect assignment. It handles the most important case: stores to nonaliased, non-aggregated-projected destinations. By using indirect assignment, rbi is able to model that when a piece of memory is written to, the value that was originally in the memory is still valid in the old region. This previously caused us to lose that task isolated values remained in regions causing data holes in cases like the following where we would not emit that we were returning a task-isolated value:

```swift
extension Optional where Wrapped: ~Copyable {
  mutating func takeSending() -> sending Self {
    let result = self
    self = nil
    return result // expected-warning {{returning task-isolated 'result' as a 'sending' result risks causing data races}}
    // expected-note @-1 {{returning task-isolated 'result' risks causing data races since the caller assumes that 'result' can be safely sent to other isolation domains}}
  }
}
```

## Implementation Details

The PR includes preparatory refactoring to support this change:

- Renamed `translateSILAssign` → `translateSILAssignDirect` and `TranslationSemantics::Assign` → `AssignDirect` for clarity
- Added new helpers like `translateSILAssignIndirect` helpers for single-destination indirect parameter assigns
- Extended `translateSILMultiAssign` to handle indirect result addresses with explicit indirect results parameter. I also added an overload for older code that had the old `translateSILMultiAssign` signature but just passed everything as direct assigns. All code that used translateSILMultiAssign was refactored to use the overload for older code.
- Updated all instructions besides stores were updated to use the new signature. This again just involved them passing everything as direct assigns. I validated that this was correct.

Once that was complete, I wired up the store handling to use the indirect assign form of translateSILMultiAssign.

NOTE: I discovered an additional bug that I am fixing in the test case for `@MainActor`. It is more interesting and is a sizable enough fix that I need to do it in a different PR. I am leaving in the test case in this PR for now with the expected lines marked as expected lines. The example is:

```
  @MainActor
  struct MainActorBox {
    var value: NonSendableKlass?

    mutating func take() -> sending NonSendableKlass {
      if let value {
        self.value = nil
        // TODO: Why are we not erroring on this. We should be.
        return value // xpected-warning {{sending 'value' risks causing data races}}
        // xpected-note @-1 {{main actor-isolated 'value' cannot be a 'sending' result. main actor-isolated uses may race with caller uses}}
      } else {
        preconditionFailure("Consumed twice")
      }
    }
  }
```

the problem is related to the way we represent GEPs as transparent or not when one has a sendable operand a non-Sendable result. It also showed me a different error in this general area with non-Sendable operands and sendable results. I am going to fix all of that together.

rdar://156024613
https://github.com/swiftlang/swift/issues/83121
