### PR TITLE
Bailout of ForEachLoopUnroll pass when sources of element stores cannot be extended

### DIFF
--- a/test/SILOptimizer/for_each_loop_unroll_test.swift
+++ b/test/SILOptimizer/for_each_loop_unroll_test.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -sil-print-types -emit-sil -primary-file %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-print-types -emit-sil -primary-file %s -sil-verify-all | %FileCheck %s
 
 // Tests for the ForEachLoopUnroll mandatory optimization pass that unrolls
 // Sequence.forEach calls over array literals.
@@ -108,4 +108,17 @@ func unrollMultipleLoops(x: Int64, y: Int64, z: Bool) {
   }
     // CHECK-NOT: forEach
     // CHECK-LABEL: end sil function '$s25for_each_loop_unroll_test0D13MultipleLoops1x1y1zys5Int64V_AGSbtF'
+}
+
+// Ensure no verifier crash
+func testNonDominatingElementStores() {
+  let string : String? = String("http://domain")
+  let validURLs : [String?] = [
+      string!, string!,
+      string!, string!,
+  ]
+
+  validURLs.forEach { url in
+    print(url)
+  }
 }


### PR DESCRIPTION
`ForEachLoopUnroll` pass inserts copies for all element store sources and then inserts destroys at the lifetime end of the array. This is problematic if the stores do not dominate the lifetime end of the array. I am adding an early bailout to the pass when the element store is not in the parent block of the array to avoid this issue. 

Resolves rdar://169438266 
