### PR TITLE
Fixes for borrow accessors 

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -334,6 +334,9 @@ WARNING(old_coroutine_accessor,none,
 ERROR(accessor_requires_borrow_and_mutate_accessors,none,
       "%0 requires '-enable-experimental-feature BorrowAndMutateAccessors'",
       (StringRef))
+ERROR(borrow_mutate_pair_restrict,none,
+      "A '%0' accessor can only be defined along with a '%1' accessor",
+      (StringRef, StringRef))
 
 // Import
 ERROR(decl_expected_module_name,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1818,8 +1818,8 @@ ERROR(functions_mutating_and_not,none,
 ERROR(static_functions_not_mutating,none,
       "static functions must not be declared mutating", ())
 
-ERROR(consuming_invalid_borrow_mutate_accessor, none,
-      "%0 cannot be declared consuming", (StringRef))
+ERROR(modifier_invalid_borrow_mutate_accessor, none,
+      "%0 cannot be declared %1", (StringRef, StringRef))
 
 ERROR(readwriter_mutatingness_differs_from_reader_or_writer_mutatingness,none,
       "%0 cannot be %1 when "

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -8848,6 +8848,20 @@ void Parser::ParsedAccessors::classify(Parser &P, AbstractStorageDecl *storage,
       P.diagnose(Init->getLoc(), diag::init_accessor_is_not_on_property);
     }
   }
+
+  // A 'borrow' can only be paired with 'mutate'
+  if (Borrow) {
+    if (Set || Modify || YieldingMutate || MutableAddress) {
+      P.diagnose(Borrow->getLoc(), diag::borrow_mutate_pair_restrict, "borrow",
+                 "mutate");
+    }
+  }
+  if (Mutate) {
+    if (Get || Read || YieldingBorrow || Address) {
+      P.diagnose(Mutate->getLoc(), diag::borrow_mutate_pair_restrict, "mutate",
+                 "borrow");
+    }
+  }
 }
 
 

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1629,8 +1629,6 @@ public:
       if (substResultTL.getRecursiveProperties()
                        .isAddressableForDependencies()) {
         convention = ResultConvention::GuaranteedAddress;
-      } else if (substResultTL.isTrivial()) {
-        convention = ResultConvention::Unowned;
       } else if (isFormallyReturnedIndirectly(origType, substType,
                                               substResultTLForConvention)) {
         convention = ResultConvention::GuaranteedAddress;

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -787,9 +787,7 @@ bool SILGenFunction::emitBorrowOrMutateAccessorResult(
     auto resultMV = emitRawProjectedLValue(regularLoc, std::move(lvalue));
     SILValue result = resultMV.getValue();
     if (resultMV.getType().isAddress() &&
-        (F.getConventions().hasGuaranteedResult() ||
-         F.getConventions().funcTy->getSingleResult().getConvention() ==
-             ResultConvention::Unowned)) {
+        F.getConventions().hasGuaranteedResult()) {
       result = emitLoadBorrowFromGuaranteedAddress(resultMV);
     }
     directResults.push_back(result);
@@ -829,9 +827,7 @@ bool SILGenFunction::emitBorrowOrMutateAccessorResult(
   SILValue result = resultMV->getValue();
   SILType selfType = F.getSelfArgument()->getType();
 
-  if (F.getConventions().hasGuaranteedResult() ||
-      F.getConventions().funcTy->getSingleResult().getConvention() ==
-          ResultConvention::Unowned) {
+  if (F.getConventions().hasGuaranteedResult()) {
     // If we are returning the result of borrow accessor, strip the
     // unnecessary copy_value + mark_unresolved_non_copyable_value
     // instructions.

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -738,13 +738,23 @@ void AttributeChecker::visitMutationAttr(DeclAttribute *attr) {
     diagnoseAndRemoveAttr(attr, diag::static_functions_not_mutating);
 
   auto *accessor = dyn_cast<AccessorDecl>(FD);
-  if (accessor &&
-      (accessor->isBorrowAccessor() || accessor->isMutateAccessor())) {
-    if (attrModifier == SelfAccessKind::Consuming ||
-        attrModifier == SelfAccessKind::LegacyConsuming) {
-      diagnoseAndRemoveAttr(
-          attr, diag::consuming_invalid_borrow_mutate_accessor,
-          getAccessorNameForDiagnostic(accessor, /*article*/ true));
+  if (accessor) {
+    if (accessor->isBorrowAccessor() || accessor->isMutateAccessor()) {
+      if (attrModifier == SelfAccessKind::Consuming ||
+          attrModifier == SelfAccessKind::LegacyConsuming) {
+        diagnoseAndRemoveAttr(
+            attr, diag::modifier_invalid_borrow_mutate_accessor,
+            getAccessorNameForDiagnostic(accessor, /*article*/ true),
+            "consuming");
+      }
+    }
+    if (accessor->isMutateAccessor()) {
+      if (attrModifier == SelfAccessKind::Borrowing) {
+        diagnoseAndRemoveAttr(
+            attr, diag::modifier_invalid_borrow_mutate_accessor,
+            getAccessorNameForDiagnostic(accessor, /*article*/ true),
+            "borrowing");
+      }
     }
   }
 }

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1123,19 +1123,18 @@ public:
 
     auto *accessor = TheFunc->getAccessorDecl();
     auto *exprToCheck = RS->getResult();
-    InOutExpr *inout = nullptr;
 
     if (accessor && accessor->isMutateAccessor()) {
+      auto *unsafeExpr = dyn_cast<UnsafeExpr>(exprToCheck);
       // Check that the returned expression is a &.
-      if ((inout = dyn_cast<InOutExpr>(exprToCheck))) {
+      if (isa<InOutExpr>(exprToCheck) ||
+          (unsafeExpr && isa<InOutExpr>(unsafeExpr->getSubExpr()))) {
         ResultTy = InOutType::get(ResultTy);
       } else {
         getASTContext()
             .Diags
             .diagnose(exprToCheck->getLoc(), diag::missing_address_of_return)
             .highlight(exprToCheck->getSourceRange());
-        inout = new (getASTContext()) InOutExpr(
-            exprToCheck->getStartLoc(), exprToCheck, Type(), /*implicit*/ true);
       }
     }
     using namespace constraints;

--- a/test/IRGen/borrow_accessor_large.swift
+++ b/test/IRGen/borrow_accessor_large.swift
@@ -24,8 +24,18 @@ func use(_ tuple: (Klass, Klass, Klass, Klass, Klass, Klass, Klass, Klass)) {
 }
 
 @inline(never)
+func use(_ tuple: (Int, Int, Int, Int, Int, Int, Int, Int)) {
+  print(tuple.4)
+}
+
+@inline(never)
 func use(_ ls: LargeProp) { 
   use(ls._largeTuple)
+}
+
+@inline(never)
+func use(_ p: LargeTrivialProp) { 
+  use(p._largeTuple)
 }
 
 @inline(never)
@@ -49,6 +59,10 @@ public struct LargeProp {
   var _largeTuple = (Klass(), Klass(), Klass(), Klass(), Klass(), Klass(), Klass(), Klass())
 }
 
+public struct LargeTrivialProp {
+  var _largeTuple = (0, 0, 0, 0, 0, 0, 0, 0)
+}
+
 public struct LargeNCProp : ~Copyable {
   var nc1 = NC()
   var nc2 = NC()
@@ -70,6 +84,7 @@ public struct LargeStruct {
   var _largeTuple = (Klass(), Klass(), Klass(), Klass(), Klass(), Klass(), Klass(), Klass())
   var _largeProp = LargeProp()
   var _smallStruct = SmallStruct()
+  var _largeTrivialProp = LargeTrivialProp()
 
   var borrowKlass: Klass {
     borrow {
@@ -96,6 +111,11 @@ public struct LargeStruct {
       return largePropBorrow
     }
   }
+  var largeTrivialPropBorrow: LargeTrivialProp {
+    borrow {
+      return _largeTrivialProp
+    }
+  }
 }
 
 func test() {
@@ -107,6 +127,7 @@ func test() {
   use(l.largeTupleBorrow)
   use(l.largePropBorrow)
   use(k)
+  use(l.largeTrivialPropBorrow)
 }
 
 public struct NC : ~Copyable {
@@ -148,21 +169,21 @@ func nctest() {
 // CHECK: }
 
 // IRGen result type is PtrTy because we are returning a class reference 
-// CHECK-IRGEN: define hidden swiftcc ptr @"$s21borrow_accessor_large11LargeStructV0A5KlassAA0F0Cvb"(ptr noalias swiftself captures(none) dereferenceable(208) [[REG0:%.*]]) {{.*}} {
+// CHECK-IRGEN: define hidden swiftcc ptr @"$s21borrow_accessor_large11LargeStructV0A5KlassAA0F0Cvb"(ptr noalias swiftself captures(none) dereferenceable(272) [[REG0:%.*]]) {{.*}} {
 // CHECK-IRGEN: entry:
 // CHECK-IRGEN:   %._k = getelementptr inbounds nuw %T21borrow_accessor_large11LargeStructV, ptr [[REG0]], i32 0, i32 0
 // CHECK-IRGEN:   [[REG1:%.*]] = load ptr, ptr %._k, align 8
 // CHECK-IRGEN:   ret ptr [[REG1]]
 // CHECK-IRGEN: }
 
-// CHECK: sil hidden @$s21borrow_accessor_large11LargeStructV0a5SmallE0AA0fE0Vvb : $@convention(method) (@in_guaranteed LargeStruct) -> SmallStruct {
+// CHECK: sil hidden @$s21borrow_accessor_large11LargeStructV0a5SmallE0AA0fE0Vvb : $@convention(method) (@in_guaranteed LargeStruct) -> @guaranteed SmallStruct {
 // CHECK: bb0([[REG0:%.*]] : $*LargeStruct):
 // CHECK:   [[REG2:%.*]] = struct_element_addr [[REG0]], #LargeStruct._smallStruct
 // CHECK:   [[REG3:%.*]] = load [[REG2]]
 // CHECK:   return [[REG3]]
 // CHECK: }
 
-// CHECK-IRGEN: define hidden swiftcc i64 @"$s21borrow_accessor_large11LargeStructV0a5SmallE0AA0fE0Vvb"(ptr noalias swiftself captures(none) dereferenceable(208) [[REG0:%.*]]) {{.*}} {
+// CHECK-IRGEN: define hidden swiftcc i64 @"$s21borrow_accessor_large11LargeStructV0a5SmallE0AA0fE0Vvb"(ptr noalias swiftself captures(none) dereferenceable(272) [[REG0:%.*]]) {{.*}} {
 // CHECK-IRGEN: entry:
 // CHECK-IRGEN:   %._smallStruct = getelementptr inbounds nuw %T21borrow_accessor_large11LargeStructV, ptr [[REG0]], i32 0, i32 4
 // CHECK-IRGEN:   %._smallStruct.id = getelementptr inbounds nuw %T21borrow_accessor_large11SmallStructV, ptr %._smallStruct, i32 0, i32 0
@@ -177,7 +198,7 @@ func nctest() {
 // CHECK: return [[REG1]]
 // CHECK: }
 
-// CHECK-IRGEN: define hidden swiftcc ptr @"$s21borrow_accessor_large11LargeStructV0C10PropBorrowAA0dF0Vvb"(ptr noalias swiftself dereferenceable(208) [[REG0:%.*]]) {{.*}} {
+// CHECK-IRGEN: define hidden swiftcc ptr @"$s21borrow_accessor_large11LargeStructV0C10PropBorrowAA0dF0Vvb"(ptr noalias swiftself dereferenceable(272) [[REG0:%.*]]) {{.*}} {
 // CHECK-IRGEN: entry:
 // CHECK-IRGEN:   %._largeProp = getelementptr inbounds nuw %T21borrow_accessor_large11LargeStructV, ptr [[REG0]], i32 0, i32 3
 // CHECK-IRGEN:   ret ptr %._largeProp
@@ -191,7 +212,7 @@ func nctest() {
 // CHECK:   return [[REG3]]
 // CHECK: }
 
-// CHECK-IRGEN: define hidden swiftcc void @"$s21borrow_accessor_large11LargeStructV0C11TupleBorrowAA5KlassC_A7Ftvb"(ptr noalias sret(<{ ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr }>) captures(none) [[REG0:%.*]], ptr noalias swiftself captures(none) dereferenceable(208) [[REG1:%.*]]) {{.*}} {
+// CHECK-IRGEN: define hidden swiftcc void @"$s21borrow_accessor_large11LargeStructV0C11TupleBorrowAA5KlassC_A7Ftvb"(ptr noalias sret(<{ ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr }>) captures(none) [[REG0:%.*]], ptr noalias swiftself captures(none) dereferenceable(272) [[REG1:%.*]]) {{.*}} {
 // CHECK-IRGEN: entry:
 // CHECK-IRGEN:   %._largeTuple = getelementptr inbounds nuw %T21borrow_accessor_large11LargeStructV, ptr [[REG1]], i32 0, i32 2
 // CHECK-IRGEN:   %._largeTuple.elt = getelementptr inbounds nuw <{ ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr }>, ptr %._largeTuple, i32 0, i32 0
@@ -236,11 +257,23 @@ func nctest() {
 // CHECK:   return [[REG2]]
 // CHECK: } // end sil function '$s21borrow_accessor_large11LargeStructV06nestedD10PropBorrowAA0dG0Vvb'
 
-// CHECK-IRGEN define hidden swiftcc ptr @"$s21borrow_accessor_large11LargeStructV06nestedD10PropBorrowAA0dG0Vvb"(ptr noalias swiftself dereferenceable(208) [[REG0:%.*]]) {{.*}} {
+// CHECK-IRGEN define hidden swiftcc ptr @"$s21borrow_accessor_large11LargeStructV06nestedD10PropBorrowAA0dG0Vvb"(ptr noalias swiftself dereferenceable(272) [[REG0:%.*]]) {{.*}} {
 // CHECK-IRGEN entry:
-// CHECK-IRGEN   [[REG1:%.*]] = call swiftcc ptr @"$s21borrow_accessor_large11LargeStructV0C10PropBorrowAA0dF0Vvb"(ptr noalias swiftself dereferenceable(208) [[REG0]])
+// CHECK-IRGEN   [[REG1:%.*]] = call swiftcc ptr @"$s21borrow_accessor_large11LargeStructV0C10PropBorrowAA0dF0Vvb"(ptr noalias swiftself dereferenceable(272) [[REG0]])
 // CHECK-IRGEN   ret ptr [[REG1]]
 // CHECK-IRGEN }
+
+// CHECK: sil hidden @$s21borrow_accessor_large11LargeStructV0C17TrivialPropBorrowAA0dfG0Vvb : $@convention(method) (@in_guaranteed LargeStruct) -> @guaranteed_address LargeTrivialProp {
+// CHECK: bb0(%0 : $*LargeStruct):
+// CHECK:   %2 = struct_element_addr %0, #LargeStruct._largeTrivialProp
+// CHECK:   return %2
+// CHECK: }
+
+// CHECK-IRGEN: define hidden swiftcc ptr @"$s21borrow_accessor_large11LargeStructV0C17TrivialPropBorrowAA0dfG0Vvb"(ptr noalias swiftself dereferenceable(272) %0) {{.*}} {
+// CHECK-IRGEN: entry:
+// CHECK-IRGEN:   %._largeTrivialProp = getelementptr inbounds nuw %T21borrow_accessor_large11LargeStructV, ptr %0, i32 0, i32 5
+// CHECK-IRGEN:   ret ptr %._largeTrivialProp
+// CHECK-IRGEN: }
 
 // CHECK: sil hidden @$s21borrow_accessor_large13NCLargeStructV0A2NCAA0F0Vvb : $@convention(method) (@in_guaranteed NCLargeStruct) -> @guaranteed NC {
 // CHECK: bb0([[REG0:%.*]] : $*NCLargeStruct):
@@ -283,3 +316,4 @@ func nctest() {
 // CHECK-IRGEN:   [[REG1:%.*]] = call swiftcc ptr @"$s21borrow_accessor_large13NCLargeStructV0C10PropBorrowAA11LargeNCPropVvb"(ptr noalias swiftself dereferenceable(72) [[REG0]])
 // CHECK-IRGEN:   ret ptr [[REG1]]
 // CHECK-IRGEN: }
+

--- a/test/Parse/borrow_and_mutate_accessors.swift
+++ b/test/Parse/borrow_and_mutate_accessors.swift
@@ -45,7 +45,7 @@ struct Wrapper {
     }
   }
   var k6: Klass {
-    borrow {
+    borrow { // expected-error{{A 'borrow' accessor can only be defined along with a 'mutate' accessor}}
       return _otherK
     }
     mutate { // expected-error{{variable cannot provide both a 'mutate' accessor and a setter}}
@@ -59,7 +59,7 @@ struct Wrapper {
     }
   }
   var k7: Klass {
-    borrow {
+    borrow { // expected-error{{A 'borrow' accessor can only be defined along with a 'mutate' accessor}}
       return _otherK
     }
     mutate { // expected-note{{mutate accessor defined here}}
@@ -73,6 +73,38 @@ struct Wrapper {
       return _otherK
     }
     mutate async throws { // expected-error{{'mutate' accessor cannot have specifier 'async'}} expected-error{{'mutate' accessor cannot have specifier 'throws'}}
+      return &_otherK
+    }
+  }
+  var k9: Klass {
+    borrow { // expected-error{{A 'borrow' accessor can only be defined along with a 'mutate' accessor}}
+      return _otherK
+    }
+    _modify {
+      yield &_otherK
+    }
+  }
+  var k10: Klass {
+    borrow { // expected-error{{A 'borrow' accessor can only be defined along with a 'mutate' accessor}}
+      return _otherK
+    }
+    yielding mutate {
+      yield &_otherK
+    }
+  }
+  var k11: Klass {
+    borrow { // expected-error{{A 'borrow' accessor can only be defined along with a 'mutate' accessor}}
+      return _otherK
+    }
+    set {
+      _otherK = newValue
+    }
+  }
+  var k12: Klass {
+    get {
+      return _otherK
+    }
+    mutate { // expected-error{{A 'mutate' accessor can only be defined along with a 'borrow' accessor}}
       return &_otherK
     }
   }

--- a/test/SILGen/borrow_accessor_container.swift
+++ b/test/SILGen/borrow_accessor_container.swift
@@ -1,7 +1,8 @@
-// RUN:%target-swift-frontend -emit-silgen %s -verify  -enable-experimental-feature BorrowAndMutateAccessors | %FileCheck %s
+// RUN:%target-swift-frontend -emit-silgen %s -verify  -enable-experimental-feature BorrowAndMutateAccessors  -strict-memory-safety | %FileCheck %s
 
 // REQUIRES: swift_feature_BorrowAndMutateAccessors
 
+@safe
 public struct Container<Element: ~Copyable >: ~Copyable {
   var _storage: UnsafeMutableBufferPointer<Element>
   var _count: Int
@@ -9,11 +10,11 @@ public struct Container<Element: ~Copyable >: ~Copyable {
   var first: Element {
     @_unsafeSelfDependentResult
     borrow {
-      return _storage.baseAddress.unsafelyUnwrapped.pointee
+      return unsafe _storage.baseAddress.unsafelyUnwrapped.pointee
     }
     @_unsafeSelfDependentResult
     mutate {
-      return &_storage.baseAddress.unsafelyUnwrapped.pointee
+      return unsafe &_storage.baseAddress.unsafelyUnwrapped.pointee
     }
   }
 
@@ -21,12 +22,12 @@ public struct Container<Element: ~Copyable >: ~Copyable {
     @_unsafeSelfDependentResult
     borrow {
       precondition(index >= 0 && index < _count, "Index out of bounds")
-      return _storage.baseAddress.unsafelyUnwrapped.advanced(by: index).pointee
+      return unsafe _storage.baseAddress.unsafelyUnwrapped.advanced(by: index).pointee
     }
     @_unsafeSelfDependentResult
     mutate {
       precondition(index >= 0 && index < _count, "Index out of bounds")
-      return &_storage.baseAddress.unsafelyUnwrapped.advanced(by: index).pointee
+      return unsafe &_storage.baseAddress.unsafelyUnwrapped.advanced(by: index).pointee
     }
   }
 }
@@ -171,6 +172,7 @@ public struct S {
   var _k: Klass
 }
 
+@safe
 public struct CopyableContainer {
   var _storage: UnsafeMutableBufferPointer<S>
   var _count: Int
@@ -178,7 +180,7 @@ public struct CopyableContainer {
   var first: S {
     @_unsafeSelfDependentResult
     borrow {
-      return _storage.baseAddress.unsafelyUnwrapped.pointee
+      return unsafe _storage.baseAddress.unsafelyUnwrapped.pointee
     }
   }
 
@@ -186,12 +188,12 @@ public struct CopyableContainer {
     @_unsafeSelfDependentResult
     borrow {
       precondition(index >= 0 && index < _count, "Index out of bounds")
-      return _storage.baseAddress.unsafelyUnwrapped.advanced(by: index).pointee._k
+      return unsafe _storage.baseAddress.unsafelyUnwrapped.advanced(by: index).pointee._k
     }
     @_unsafeSelfDependentResult
     mutate {
       precondition(index >= 0 && index < _count, "Index out of bounds")
-      return &_storage.baseAddress.unsafelyUnwrapped.advanced(by: index).pointee._k
+      return unsafe &_storage.baseAddress.unsafelyUnwrapped.advanced(by: index).pointee._k
     }
   }
 }
@@ -270,6 +272,7 @@ public struct CopyableContainer {
 
 public struct NC : ~Copyable {}
 
+@safe
 public struct NonCopyableContainer : ~Copyable {
   var _storage: UnsafeMutableBufferPointer<NC>
   var _count: Int
@@ -277,7 +280,7 @@ public struct NonCopyableContainer : ~Copyable {
   var first: NC {
     @_unsafeSelfDependentResult
     borrow {
-      return _storage.baseAddress.unsafelyUnwrapped.pointee
+      return unsafe _storage.baseAddress.unsafelyUnwrapped.pointee
     }
   }
 
@@ -285,12 +288,12 @@ public struct NonCopyableContainer : ~Copyable {
     @_unsafeSelfDependentResult
     borrow {
       precondition(index >= 0 && index < _count, "Index out of bounds")
-      return _storage.baseAddress.unsafelyUnwrapped.advanced(by: index).pointee
+      return unsafe _storage.baseAddress.unsafelyUnwrapped.advanced(by: index).pointee
     }
     @_unsafeSelfDependentResult
     mutate {
       precondition(index >= 0 && index < _count, "Index out of bounds")
-      return &_storage.baseAddress.unsafelyUnwrapped.advanced(by: index).pointee
+      return unsafe &_storage.baseAddress.unsafelyUnwrapped.advanced(by: index).pointee
     }
   }
 }


### PR DESCRIPTION
- Use @guaranteed to represent trivial results of borrow accessors
- Add diagnostics for invalid ownership modifiers with borrow accessors
- Add diagnostics when borrow/mutate accessors are defined with other accessors
- Handle unsafe expression in mutate accessor return statements