### PR TITLE
Basic: Introduce a safe, structured representation for language modes

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -1546,16 +1546,6 @@ public:
       const ValueDecl *base, const ValueDecl *derived,
       const OverrideGenericSignatureReqCheck direction);
 
-  /// Whether our effective Swift version is at least 'major'.
-  ///
-  /// This is usually the check you want; for example, when introducing
-  /// a new language feature which is only visible in Swift 5, you would
-  /// check for isLanguageModeAtLeast(5).
-  [[deprecated("use e.g. isLanguageModeAtLeast(LanguageMode::v6)")]]
-  bool isLanguageModeAtLeast(unsigned major, unsigned minor = 0) const {
-    return LangOpts.isLanguageModeAtLeast(major, minor);
-  }
-
   /// Returns a boolean value indicating whether the language mode is at least
   /// `mode`.
   ///

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -1554,6 +1554,9 @@ public:
   bool isLanguageModeAtLeast(unsigned major, unsigned minor = 0) const {
     return LangOpts.isLanguageModeAtLeast(major, minor);
   }
+  bool isLanguageModeAtLeast(LanguageMode mode) const {
+    return LangOpts.isLanguageModeAtLeast(mode);
+  }
 
   /// Whether the "next major" language mode is being used. This isn't a real
   /// language mode, it only exists to signal clients that expect to be

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -1551,18 +1551,19 @@ public:
   /// This is usually the check you want; for example, when introducing
   /// a new language feature which is only visible in Swift 5, you would
   /// check for isLanguageModeAtLeast(5).
+  [[deprecated("use e.g. isLanguageModeAtLeast(LanguageMode::v6)")]]
   bool isLanguageModeAtLeast(unsigned major, unsigned minor = 0) const {
     return LangOpts.isLanguageModeAtLeast(major, minor);
   }
+
+  /// Returns a boolean value indicating whether the language mode is at least
+  /// `mode`.
+  ///
+  /// This is very likely the check you want; for example, when introducing
+  /// a new language feature which is only visible in Swift 5, you would
+  /// check for `isLanguageModeAtLeast(LanguageMode::v5)`.
   bool isLanguageModeAtLeast(LanguageMode mode) const {
     return LangOpts.isLanguageModeAtLeast(mode);
-  }
-
-  /// Whether the "next major" language mode is being used. This isn't a real
-  /// language mode, it only exists to signal clients that expect to be
-  /// included in the next language mode when it becomes available.
-  bool isAtLeastFutureMajorLanguageMode() const {
-    return LangOpts.isAtLeastFutureMajorLanguageMode();
   }
 
   /// Check whether it's important to respect access control restrictions

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -400,10 +400,6 @@ namespace swift {
     ///
     /// This helps stage in fixes for stricter diagnostics as warnings
     /// until the next major language version.
-    [[deprecated(
-        "use e.g. limitBehaviorUntilLanguageMode(limit, LanguageMode::v6)")]]
-    InFlightDiagnostic &limitBehaviorUntilLanguageMode(DiagnosticBehavior limit,
-                                                       unsigned majorVersion);
     InFlightDiagnostic &limitBehaviorUntilLanguageMode(DiagnosticBehavior limit,
                                                        LanguageMode mode);
 
@@ -436,8 +432,6 @@ namespace swift {
     ///
     /// This helps stage in fixes for stricter diagnostics as warnings
     /// until the next major language version.
-    [[deprecated("use e.g. warnUntilLanguageMode(LanguageMode::v6)")]]
-    InFlightDiagnostic &warnUntilLanguageMode(unsigned majorVersion);
     InFlightDiagnostic &warnUntilLanguageMode(LanguageMode mode);
 
     /// Limit the diagnostic behavior to warning if the context is a

--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -405,7 +405,7 @@ WARNING(module_interface_scoped_import_unsupported,none,
         "scoped imports are not yet supported in module interfaces",
         ())
 WARNING(warn_unsupported_module_interface_swift_version,none,
-        "module interfaces are only supported with Swift language version 5 "
+        "module interfaces are only supported with the Swift 5 language mode "
         "or later (currently using -swift-version %0)",
         (StringRef))
 WARNING(warn_unsupported_module_interface_library_evolution,none,

--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -40,8 +40,9 @@ ERROR(error_unsupported_target_arch, none,
       "unsupported target architecture: '%0'", (StringRef))
 
 WARNING(warning_upcoming_feature_on_by_default, none,
-        "upcoming feature '%0' is already enabled as of Swift version %1",
-        (StringRef, unsigned))
+        "upcoming feature '%0' already enabled as of the Swift %1 "
+        "language mode",
+        (StringRef, StringRef))
 
 GROUPED_WARNING(unrecognized_feature, UnrecognizedStrictLanguageFeatures, none,
                 "'%0' is not a recognized "

--- a/include/swift/Basic/Feature.h
+++ b/include/swift/Basic/Feature.h
@@ -14,6 +14,7 @@
 #define SWIFT_BASIC_FEATURE_H
 
 #include "swift/Basic/LLVM.h"
+#include "swift/Basic/LanguageMode.h"
 
 #include "llvm/ADT/StringRef.h"
 #include <optional>
@@ -80,9 +81,10 @@ struct Feature {
   /// one.
   static std::optional<Feature> getExperimentalFeature(StringRef name);
 
-  /// Get the major language version in which this feature was introduced, or
-  /// \c None if it does not have such a version.
-  std::optional<unsigned> getLanguageMode() const;
+  /// Get the earliest language mode that includes this feature, or
+  /// `std::nullopt` if the feature is not associated with a language mode
+  /// (i.e., not an upcoming feature).
+  std::optional<LanguageMode> getLanguageMode() const;
 };
 
 #define LANGUAGE_FEATURE(FeatureName, SENumber, Description)                   \

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -285,33 +285,41 @@ BASELINE_LANGUAGE_FEATURE(ExcludePrivateFromMemberwiseInit, 502, "Exclude privat
 // suppression of @c in Swift interfaces as a temporary measure.
 SUPPRESSIBLE_LANGUAGE_FEATURE(CAttribute, 495, "@c attribute")
 
-// Swift 6
-UPCOMING_FEATURE(ConciseMagicFile, 274, 6)
-UPCOMING_FEATURE(ForwardTrailingClosures, 286, 6)
-UPCOMING_FEATURE(StrictConcurrency, 0337, 6)
-UPCOMING_FEATURE(BareSlashRegexLiterals, 354, 6)
-UPCOMING_FEATURE(DeprecateApplicationMain, 383, 6)
-UPCOMING_FEATURE(ImportObjcForwardDeclarations, 384, 6)
-UPCOMING_FEATURE(DisableOutwardActorInference, 401, 6)
-UPCOMING_FEATURE(IsolatedDefaultValues, 411, 6)
-UPCOMING_FEATURE(GlobalConcurrency, 412, 6)
-UPCOMING_FEATURE(InferSendableFromCaptures, 418, 6)
-UPCOMING_FEATURE(ImplicitOpenExistentials, 352, 6)
-UPCOMING_FEATURE(RegionBasedIsolation, 414, 6)
-UPCOMING_FEATURE(DynamicActorIsolation, 423, 6)
-UPCOMING_FEATURE(NonfrozenEnumExhaustivity, 192, 6)
-UPCOMING_FEATURE(GlobalActorIsolatedTypesUsability, 0434, 6)
+//===----------------------------------------------------------------------===//
+// MARK: - Swift 6 features
+//===----------------------------------------------------------------------===//
 
-// Swift 7
-MIGRATABLE_UPCOMING_FEATURE(ExistentialAny, 335, 7)
-UPCOMING_FEATURE(InternalImportsByDefault, 409, 7)
-MIGRATABLE_UPCOMING_FEATURE(MemberImportVisibility, 444, 7)
-MIGRATABLE_UPCOMING_FEATURE(InferIsolatedConformances, 470, 7)
-MIGRATABLE_UPCOMING_FEATURE(NonisolatedNonsendingByDefault, 461, 7)
-UPCOMING_FEATURE(ImmutableWeakCaptures, 481, 7)
-UPCOMING_FEATURE(StrictAccessControl, 0, 7)
+UPCOMING_FEATURE(ConciseMagicFile, 274, LanguageMode::v6)
+UPCOMING_FEATURE(ForwardTrailingClosures, 286, LanguageMode::v6)
+UPCOMING_FEATURE(StrictConcurrency, 0337, LanguageMode::v6)
+UPCOMING_FEATURE(BareSlashRegexLiterals, 354, LanguageMode::v6)
+UPCOMING_FEATURE(DeprecateApplicationMain, 383, LanguageMode::v6)
+UPCOMING_FEATURE(ImportObjcForwardDeclarations, 384, LanguageMode::v6)
+UPCOMING_FEATURE(DisableOutwardActorInference, 401, LanguageMode::v6)
+UPCOMING_FEATURE(IsolatedDefaultValues, 411, LanguageMode::v6)
+UPCOMING_FEATURE(GlobalConcurrency, 412, LanguageMode::v6)
+UPCOMING_FEATURE(InferSendableFromCaptures, 418, LanguageMode::v6)
+UPCOMING_FEATURE(ImplicitOpenExistentials, 352, LanguageMode::v6)
+UPCOMING_FEATURE(RegionBasedIsolation, 414, LanguageMode::v6)
+UPCOMING_FEATURE(DynamicActorIsolation, 423, LanguageMode::v6)
+UPCOMING_FEATURE(NonfrozenEnumExhaustivity, 192, LanguageMode::v6)
+UPCOMING_FEATURE(GlobalActorIsolatedTypesUsability, 0434, LanguageMode::v6)
 
-// Optional language features / modes
+//===----------------------------------------------------------------------===//
+// MARK: - Future Swift features
+//===----------------------------------------------------------------------===//
+
+MIGRATABLE_UPCOMING_FEATURE(ExistentialAny, 335, LanguageMode::future)
+UPCOMING_FEATURE(InternalImportsByDefault, 409, LanguageMode::future)
+MIGRATABLE_UPCOMING_FEATURE(MemberImportVisibility, 444, LanguageMode::future)
+MIGRATABLE_UPCOMING_FEATURE(InferIsolatedConformances, 470, LanguageMode::future)
+MIGRATABLE_UPCOMING_FEATURE(NonisolatedNonsendingByDefault, 461, LanguageMode::future)
+UPCOMING_FEATURE(ImmutableWeakCaptures, 481, LanguageMode::future)
+UPCOMING_FEATURE(StrictAccessControl, 0, LanguageMode::future)
+
+//===----------------------------------------------------------------------===//
+// MARK: - Optional features
+//===----------------------------------------------------------------------===//
 
 /// Diagnose uses of language constructs and APIs that can violate memory
 /// safety.
@@ -319,7 +327,9 @@ MIGRATABLE_OPTIONAL_LANGUAGE_FEATURE(StrictMemorySafety, 458, "Strict memory saf
 
 OPTIONAL_LANGUAGE_FEATURE(LibraryEvolution, 0, "Library evolution")
 
-// Experimental features
+//===----------------------------------------------------------------------===//
+// MARK: - Experimental features
+//===----------------------------------------------------------------------===//
 
 EXPERIMENTAL_FEATURE(StaticAssert, false)
 EXPERIMENTAL_FEATURE(NamedOpaqueTypes, false)

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -746,19 +746,19 @@ namespace swift {
     /// This is usually the check you want; for example, when introducing
     /// a new language feature which is only visible in Swift 5, you would
     /// check for isLanguageModeAtLeast(5).
+    [[deprecated("use e.g. isLanguageModeAtLeast(LanguageMode::v6)")]]
     bool isLanguageModeAtLeast(unsigned major, unsigned minor = 0) const {
       return EffectiveLanguageVersion.isVersionAtLeast(major, minor);
     }
+
+    /// Returns a boolean value indicating whether the language mode is at least
+    /// `mode`.
+    ///
+    /// This is very likely the check you want; for example, when introducing
+    /// a new language feature which is only visible in Swift 5, you would
+    /// check for `isLanguageModeAtLeast(LanguageMode::v5)`.
     bool isLanguageModeAtLeast(LanguageMode mode) const {
       return mode.isEffectiveIn(EffectiveLanguageVersion);
-    }
-
-    /// Whether the "next major" language mode is being used. This isn't a real
-    /// language mode, it only exists to signal clients that expect to be
-    /// included in the next language mode when it becomes available.
-    bool isAtLeastFutureMajorLanguageMode() const {
-      using namespace version;
-      return isLanguageModeAtLeast(Version::getFutureMajorLanguageVersion());
     }
 
     /// Sets the "_hasAtomicBitWidth" conditional.

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -741,16 +741,6 @@ namespace swift {
       return CustomConditionalCompilationFlags;
     }
 
-    /// Whether our effective Swift version is at least 'major'.
-    ///
-    /// This is usually the check you want; for example, when introducing
-    /// a new language feature which is only visible in Swift 5, you would
-    /// check for isLanguageModeAtLeast(5).
-    [[deprecated("use e.g. isLanguageModeAtLeast(LanguageMode::v6)")]]
-    bool isLanguageModeAtLeast(unsigned major, unsigned minor = 0) const {
-      return EffectiveLanguageVersion.isVersionAtLeast(major, minor);
-    }
-
     /// Returns a boolean value indicating whether the language mode is at least
     /// `mode`.
     ///

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -22,6 +22,7 @@
 #include "swift/Basic/Feature.h"
 #include "swift/Basic/FunctionBodySkipping.h"
 #include "swift/Basic/LLVM.h"
+#include "swift/Basic/LanguageMode.h"
 #include "swift/Basic/Platform.h"
 #include "swift/Basic/PlaygroundOption.h"
 #include "swift/Basic/Version.h"
@@ -747,6 +748,9 @@ namespace swift {
     /// check for isLanguageModeAtLeast(5).
     bool isLanguageModeAtLeast(unsigned major, unsigned minor = 0) const {
       return EffectiveLanguageVersion.isVersionAtLeast(major, minor);
+    }
+    bool isLanguageModeAtLeast(LanguageMode mode) const {
+      return mode.isEffectiveIn(EffectiveLanguageVersion);
     }
 
     /// Whether the "next major" language mode is being used. This isn't a real

--- a/include/swift/Basic/LanguageMode.h
+++ b/include/swift/Basic/LanguageMode.h
@@ -1,0 +1,90 @@
+//===--- Basic/LanguageMode.h -----------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// A representation for Swift language modes, aka Swift compatibility versions.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BASIC_LANGUAGE_MODE_H
+#define SWIFT_BASIC_LANGUAGE_MODE_H
+
+#include "swift/Basic/Debug.h"
+#include "swift/Basic/Version.h"
+#include "llvm/ADT/StringRef.h"
+#include <array>
+#include <utility>
+
+namespace swift {
+
+struct LanguageMode {
+  enum class AnyLanguageMode : unsigned {
+#define LANGUAGE_MODE(NAME, ...) NAME,
+#include "swift/Basic/LanguageModes.def"
+
+    // The abstract future language mode.
+    future,
+  };
+
+private:
+  AnyLanguageMode mode;
+
+  constexpr LanguageMode(AnyLanguageMode mode) : mode(mode) {}
+
+public:
+  /// Implicit conversion to faciliate switching over objects of this type.
+  constexpr operator AnyLanguageMode() const { return mode; }
+
+  /// Declare a static constant per language mode for convenience:
+  /// `LanguageMode::v6` vs. `LanguageMode(LanguageMode::v6)`.
+#define LANGUAGE_MODE(NAME, ...) static const LanguageMode NAME;
+#include "swift/Basic/LanguageModes.def"
+  static const LanguageMode future;
+
+  /// Returns a boolean value indicating whether this language mode is the
+  /// abstract future mode.
+  bool isFuture() const;
+
+  /// Returns a boolean value indicating whether this language mode is effective
+  /// (enabled) according to the given effective language version.
+  bool isEffectiveIn(version::Version effectiveLanguageVersion) const;
+
+  /// Returns the array of supported language modes. This does not include the
+  /// abstract future language mode.
+  static auto allSupportedModes() {
+    return std::array{
+#define LANGUAGE_MODE(NAME, ...) LanguageMode::NAME,
+#include "swift/Basic/LanguageModes.def"
+    };
+  }
+
+  /// Returns a pair containing the major and minor version associated with
+  /// this language mode.
+  std::pair<unsigned, unsigned> version() const;
+
+  /// Returns a string representation of this language mode that can be used
+  /// with `-swift-version`.
+  std::string versionString() const;
+
+  SWIFT_DEBUG_DUMP;
+};
+
+#define LANGUAGE_MODE(NAME, ...)                                               \
+  constexpr inline LanguageMode LanguageMode::NAME =                           \
+      LanguageMode::AnyLanguageMode::NAME;
+#include "swift/Basic/LanguageModes.def"
+constexpr inline LanguageMode LanguageMode::future =
+    LanguageMode::AnyLanguageMode::future;
+
+} // end namespace swift
+
+#endif // SWIFT_BASIC_LANGUAGE_MODE_H

--- a/include/swift/Basic/LanguageModes.def
+++ b/include/swift/Basic/LanguageModes.def
@@ -1,0 +1,45 @@
+//===--- Basic/LanguageModes.def --------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This definition file describes all language modes for meta-programming
+/// purposes.
+///
+/// `LANGUAGE_MODE(NAME, MAJOR_VERSION, MINOR_VERSION)`
+///
+/// To define a major language mode, use `MAJOR_LANGUAGE_MODE`.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LANGUAGE_MODE
+#error "define LANGUAGE_MODE before including this file"
+#endif
+
+#ifndef MAJOR_LANGUAGE_MODE
+  #define MAJOR_LANGUAGE_MODE(NAME, MAJOR_VERSION)                             \
+    LANGUAGE_MODE(NAME, MAJOR_VERSION, 0)
+#endif
+
+#ifndef LAST_REAL_LANGUAGE_MODE
+  #define LAST_REAL_LANGUAGE_MODE(ID)
+#endif
+
+MAJOR_LANGUAGE_MODE(v4, 4)
+LANGUAGE_MODE(v4_2, 4, 2)
+MAJOR_LANGUAGE_MODE(v5, 5)
+MAJOR_LANGUAGE_MODE(v6, 6)
+
+LAST_REAL_LANGUAGE_MODE(v6)
+
+#undef LANGUAGE_MODE
+#undef MAJOR_LANGUAGE_MODE
+#undef LAST_REAL_LANGUAGE_MODE

--- a/include/swift/Basic/Version.h
+++ b/include/swift/Basic/Version.h
@@ -137,12 +137,6 @@ public:
   static constexpr unsigned getFutureMajorLanguageVersion() {
     return 7;
   }
-
-  // List of backward-compatibility versions that we permit passing as
-  // -swift-version <vers>
-  static std::array<StringRef, 4> getValidEffectiveVersions() {
-    return {{"4", "4.2", "5", "6"}};
-  };
 };
 
 bool operator>=(const Version &lhs, const Version &rhs);

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -4218,7 +4218,7 @@ AnyFunctionType::Param swift::computeSelfParam(AbstractFunctionDecl *AFD,
     // NOTE: it's important that we check if it's a convenience init only after
     // confirming it's not semantically final, or else there can be a request
     // evaluator cycle to determine the init kind for actors, which are final.
-    if (Ctx.isLanguageModeAtLeast(5)) {
+    if (Ctx.isLanguageModeAtLeast(LanguageMode::v5)) {
       if (wantDynamicSelf)
         if (auto *classDecl = selfTy->getClassOrBoundGenericClass())
           if (!classDecl->isSemanticallyFinal() && CD->isConvenienceInit())

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2199,7 +2199,7 @@ public:
     void verifyChecked(OptionalTryExpr *E) {
       PrettyStackTraceExpr debugStack(Ctx, "verifying OptionalTryExpr", E);
 
-      if (Ctx.isLanguageModeAtLeast(5)) {
+      if (Ctx.isLanguageModeAtLeast(LanguageMode::v5)) {
         checkSameType(E->getType(), E->getSubExpr()->getType(),
                       "OptionalTryExpr and sub-expression");
       }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1233,7 +1233,7 @@ bool Decl::preconcurrency() const {
 
   // Variables declared in top-level code are @_predatesConcurrency
   if (const VarDecl *var = dyn_cast<VarDecl>(this)) {
-    return !getASTContext().isLanguageModeAtLeast(6) &&
+    return !getASTContext().isLanguageModeAtLeast(LanguageMode::v6) &&
            var->isTopLevelGlobal() && var->getDeclContext()->isAsyncContext();
   }
 
@@ -2870,7 +2870,7 @@ static bool isDefaultInitializable(const TypeRepr *typeRepr, ASTContext &ctx) {
     return true;
 
   // Also support the desugared 'Optional<T>' spelling.
-  if (!ctx.isLanguageModeAtLeast(5)) {
+  if (!ctx.isLanguageModeAtLeast(LanguageMode::v5)) {
     if (typeRepr->isSimpleUnqualifiedIdentifier(ctx.Id_Void)) {
       return true;
     }
@@ -3051,7 +3051,7 @@ static bool deferMatchesEnclosingAccess(const FuncDecl *defer) {
   assert(defer->isDeferBody());
 
   // In Swift 6+, then yes.
-  if (defer->getASTContext().isLanguageModeAtLeast(6))
+  if (defer->getASTContext().isLanguageModeAtLeast(LanguageMode::v6))
     return true;
 
   // If the defer is part of a function that is a member of an actor or
@@ -3125,7 +3125,7 @@ static bool isDirectToStorageAccess(const DeclContext *UseDC,
     // In Swift 5 and later, the access must also be a member access on 'self'.
     if (!isAccessOnSelf &&
         var->getDeclContext()->isTypeContext() &&
-        var->getASTContext().isLanguageModeAtLeast(5))
+        var->getASTContext().isLanguageModeAtLeast(LanguageMode::v5))
       return false;
 
     // As a special case, 'read' and 'modify' coroutines with forced static
@@ -4123,7 +4123,7 @@ bool swift::conflicting(ASTContext &ctx,
     // Prior to Swift 5, we permitted redeclarations of variables as different
     // declarations if the variable was declared in an extension of a generic
     // type. Make sure we maintain this behaviour in versions < 5.
-    if (!ctx.isLanguageModeAtLeast(5)) {
+    if (!ctx.isLanguageModeAtLeast(LanguageMode::v5)) {
       if ((sig1.IsVariable && sig1.InExtensionOfGenericType) ||
           (sig2.IsVariable && sig2.InExtensionOfGenericType)) {
         if (wouldConflictInSwift5)
@@ -4147,7 +4147,7 @@ bool swift::conflicting(ASTContext &ctx,
   // Swift 5, a variable not in an extension of a generic type got a null
   // overload type instead of a function type as it does now, so we really
   // follow that behaviour and warn if there's going to be a conflict in future.
-  if (!ctx.isLanguageModeAtLeast(5)) {
+  if (!ctx.isLanguageModeAtLeast(LanguageMode::v5)) {
     auto swift4Sig1Type = sig1.IsVariable && !sig1.InExtensionOfGenericType
                               ? CanType()
                               : sig1Type;
@@ -12319,7 +12319,7 @@ ActorIsolation swift::getActorIsolationOfContext(
         ctx.LangOpts.StrictConcurrencyLevel >= StrictConcurrency::Complete) {
       if (Type mainActor = ctx.getMainActorType())
         return ActorIsolation::forGlobalActor(mainActor).withPreconcurrency(
-            !ctx.isLanguageModeAtLeast(6));
+            !ctx.isLanguageModeAtLeast(LanguageMode::v6));
     }
   }
 

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -494,15 +494,21 @@ InFlightDiagnostic::limitBehaviorUntilLanguageMode(DiagnosticBehavior limit,
   return *this;
 }
 
-InFlightDiagnostic &InFlightDiagnostic::warnUntilFutureLanguageMode() {
-  using namespace version;
-  return warnUntilLanguageMode(Version::getFutureMajorLanguageVersion());
+InFlightDiagnostic &
+InFlightDiagnostic::limitBehaviorUntilLanguageMode(DiagnosticBehavior limit,
+                                                   LanguageMode mode) {
+  return limitBehaviorUntilLanguageMode(limit, mode.version().first);
 }
 
 InFlightDiagnostic &
 InFlightDiagnostic::warnUntilLanguageMode(unsigned majorVersion) {
   return limitBehaviorUntilLanguageMode(DiagnosticBehavior::Warning,
                                         majorVersion);
+}
+
+InFlightDiagnostic &
+InFlightDiagnostic::warnUntilLanguageMode(LanguageMode mode) {
+  return limitBehaviorUntilLanguageMode(DiagnosticBehavior::Warning, mode);
 }
 
 InFlightDiagnostic &

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -626,7 +626,8 @@ static void recordShadowedDeclsAfterTypeMatch(
       // This is due to the fact that in Swift 4, we only gave custom overload
       // types to properties in extensions of generic types, otherwise we
       // used the null type.
-      if (!ctx.isLanguageModeAtLeast(5) && isa<ValueDecl>(firstDecl)) {
+      if (!ctx.isLanguageModeAtLeast(LanguageMode::v5) &&
+          isa<ValueDecl>(firstDecl)) {
         auto secondSig = cast<ValueDecl>(secondDecl)->getOverloadSignature();
         auto firstSig = cast<ValueDecl>(firstDecl)->getOverloadSignature();
         if (firstSig.IsVariable && secondSig.IsVariable)

--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -1048,13 +1048,13 @@ InferredGenericSignatureRequest::evaluate(
           ctx.Diags
               .diagnose(loc, diag::requires_generic_params_made_equal,
                         genericParam, result->getSugaredType(reduced))
-              .warnUntilLanguageMode(6);
+              .warnUntilLanguageMode(LanguageMode::v6);
         } else {
           ctx.Diags
               .diagnose(loc,
                         diag::requires_generic_param_made_equal_to_concrete,
                         genericParam)
-              .warnUntilLanguageMode(6);
+              .warnUntilLanguageMode(LanguageMode::v6);
         }
       }
     }

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -5338,7 +5338,7 @@ getConcurrencyDiagnosticBehaviorLimitRec(
   // Metatypes that aren't Sendable were introduced in Swift 6.2, so downgrade
   // them to warnings prior to Swift 7.
   if (type->is<AnyMetatypeType>()) {
-    if (!declCtx->getASTContext().isAtLeastFutureMajorLanguageMode())
+    if (!declCtx->getASTContext().isLanguageModeAtLeast(LanguageMode::future))
       return DiagnosticBehavior::Warning;
   }
 

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -379,7 +379,7 @@ ValueDecl *UnqualifiedLookupFactory::lookupBaseDecl(const DeclContext *baseDC) c
 
   // Previously we didn't perform the lookup of 'self' for anything outside
   // of a '[weak self]' closure, maintain that behavior until Swift 6 mode.
-  if (!Ctx.isLanguageModeAtLeast(6) && !capturesSelfWeakly)
+  if (!Ctx.isLanguageModeAtLeast(LanguageMode::v6) && !capturesSelfWeakly)
     return nullptr;
 
   auto selfDecl = ASTScope::lookupSingleLocalDecl(DC->getParentSourceFile(),
@@ -413,7 +413,7 @@ ValueDecl *UnqualifiedLookupFactory::lookupBaseDecl(const DeclContext *baseDC) c
   // In these cases, using the Swift 6 lookup behavior doesn't affect
   // how the body is type-checked, so it can be used in Swift 5 mode
   // without breaking source compatibility for non-escaping closures.
-  if (!Ctx.isLanguageModeAtLeast(6) &&
+  if (!Ctx.isLanguageModeAtLeast(LanguageMode::v6) &&
       !implicitSelfReferenceIsUnwrapped(selfDecl)) {
     return nullptr;
   }

--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -60,6 +60,7 @@ add_swift_host_library(swiftBasic STATIC
   JSONSerialization.cpp
   LangOptions.cpp
   LangOptionsBridging.cpp
+  LanguageMode.cpp
   LoadDynamicLibrary.cpp
   Located.cpp
   Mangler.cpp

--- a/lib/Basic/Feature.cpp
+++ b/lib/Basic/Feature.cpp
@@ -57,7 +57,7 @@ std::optional<Feature> Feature::getExperimentalFeature(llvm::StringRef name) {
       .Default(std::nullopt);
 }
 
-std::optional<unsigned> Feature::getLanguageMode() const {
+std::optional<LanguageMode> Feature::getLanguageMode() const {
   switch (kind) {
 #define LANGUAGE_FEATURE(FeatureName, SENumber, Description)
 #define UPCOMING_FEATURE(FeatureName, SENumber, LanguageMode)                  \

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -335,8 +335,8 @@ LangOptions::FeatureState LangOptions::getFeatureState(Feature feature) const {
   if (state.isEnabled())
     return state;
 
-  if (auto version = feature.getLanguageMode()) {
-    if (isLanguageModeAtLeast(*version)) {
+  if (auto languageMode = feature.getLanguageMode()) {
+    if (isLanguageModeAtLeast(languageMode.value())) {
       return FeatureState(feature, FeatureState::Kind::Enabled);
     }
   }
@@ -349,8 +349,8 @@ bool LangOptions::hasFeature(Feature feature, bool allowMigration) const {
   if (state.isEnabled())
     return true;
 
-  if (auto version = feature.getLanguageMode()) {
-    if (isLanguageModeAtLeast(*version))
+  if (auto languageMode = feature.getLanguageMode()) {
+    if (isLanguageModeAtLeast(languageMode.value()))
       return true;
   }
 

--- a/lib/Basic/LanguageMode.cpp
+++ b/lib/Basic/LanguageMode.cpp
@@ -1,0 +1,52 @@
+//===--- Basic/LanguageMode.cpp ---------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Basic/LanguageMode.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace swift;
+
+bool LanguageMode::isFuture() const { return mode == AnyLanguageMode::future; }
+
+bool LanguageMode::isEffectiveIn(
+    version::Version effectiveLanguageVersion) const {
+  auto majorAndMinor = version();
+  return effectiveLanguageVersion.isVersionAtLeast(majorAndMinor.first,
+                                                   majorAndMinor.second);
+}
+
+std::pair<unsigned, unsigned> LanguageMode::version() const {
+  switch (mode) {
+#define LANGUAGE_MODE(NAME, MAJOR, MINOR)                                      \
+  case AnyLanguageMode::NAME:                                                  \
+    return {MAJOR, MINOR};
+  case AnyLanguageMode::future:
+    return {version::Version::getFutureMajorLanguageVersion(), 0};
+#include "swift/Basic/LanguageModes.def"
+  }
+}
+
+std::string LanguageMode::versionString() const {
+  switch (mode) {
+#define MAJOR_LANGUAGE_MODE(NAME, MAJOR)                                       \
+  case AnyLanguageMode::NAME:                                                  \
+    return #MAJOR;
+#define LANGUAGE_MODE(NAME, MAJOR, MINOR)                                      \
+  case AnyLanguageMode::NAME:                                                  \
+    return #MAJOR "." #MINOR;
+#include "swift/Basic/LanguageModes.def"
+  case AnyLanguageMode::future:
+    return std::to_string(version::Version::getFutureMajorLanguageVersion());
+  }
+}
+
+void LanguageMode::dump() const { llvm::errs() << versionString(); }

--- a/lib/Basic/SupportedFeatures.cpp
+++ b/lib/Basic/SupportedFeatures.cpp
@@ -114,8 +114,8 @@ void printSupportedFeatures(llvm::raw_ostream &out) {
       });
       out << "]";
     }
-    if (auto version = feature.getLanguageMode()) {
-      out << ", \"enabled_in\": \"" << *version << "\"";
+    if (auto languageMode = feature.getLanguageMode()) {
+      out << ", \"enabled_in\": \"" << languageMode->versionString() << "\"";
     }
 
     if (auto flagName = optionalFlagName(feature)) {

--- a/lib/Basic/Version.cpp
+++ b/lib/Basic/Version.cpp
@@ -189,7 +189,7 @@ std::optional<Version> Version::getEffectiveLanguageVersion() const {
     // Allow the future language mode version in asserts compilers *only* so
     // that we can start testing changes planned for after the current latest
     // language mode. Note that it'll not be listed in
-    // `Version::getValidEffectiveVersions()`.
+    // `LanguageMode::allSupportedModes()`.
 #ifdef NDEBUG
     LLVM_FALLTHROUGH;
 #else

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -6128,7 +6128,7 @@ namespace {
 
       auto access = AccessLevel::Open;
       if (decl->hasAttr<clang::ObjCSubclassingRestrictedAttr>() &&
-          Impl.SwiftContext.isLanguageModeAtLeast(5)) {
+          Impl.SwiftContext.isLanguageModeAtLeast(LanguageMode::v5)) {
         access = AccessLevel::Public;
       }
 

--- a/lib/DriverTool/sil_llvm_gen_main.cpp
+++ b/lib/DriverTool/sil_llvm_gen_main.cpp
@@ -354,11 +354,12 @@ int sil_llvm_gen_main(ArrayRef<const char *> argv, void *MainAddr) {
       exit(-1);
     }
 
-    if (auto firstVersion = feature->getLanguageMode()) {
-      if (Invocation.getLangOptions().isLanguageModeAtLeast(*firstVersion)) {
+    if (auto languageMode = feature->getLanguageMode()) {
+      if (Invocation.getLangOptions().isLanguageModeAtLeast(
+              languageMode.value())) {
         llvm::errs() << "error: upcoming feature " << QuotedString(featureName)
-                     << " is already enabled as of Swift version "
-                     << *firstVersion << '\n';
+                     << " already enabled as of the Swift "
+                     << languageMode->versionString() << " language mode\n";
         exit(-1);
       }
     }

--- a/lib/DriverTool/sil_opt_main.cpp
+++ b/lib/DriverTool/sil_opt_main.cpp
@@ -763,11 +763,12 @@ int sil_opt_main(ArrayRef<const char *> argv, void *MainAddr) {
       exit(-1);
     }
 
-    if (auto firstVersion = feature->getLanguageMode()) {
-      if (Invocation.getLangOptions().isLanguageModeAtLeast(*firstVersion)) {
+    if (auto languageMode = feature->getLanguageMode()) {
+      if (Invocation.getLangOptions().isLanguageModeAtLeast(
+              languageMode.value())) {
         llvm::errs() << "error: upcoming feature " << QuotedString(featureName)
-                     << " is already enabled as of Swift version "
-                     << *firstVersion << '\n';
+                     << " already enabled as of the Swift "
+                     << languageMode->versionString() << " language mode\n";
         exit(-1);
       }
     }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -940,11 +940,11 @@ static bool ParseEnabledFeatureArgs(LangOptions &Opts, ArgList &Args,
 
     // If the current language mode enables the feature by default then
     // diagnose and skip it.
-    if (auto firstVersion = feature->getLanguageMode()) {
-      if (Opts.isLanguageModeAtLeast(*firstVersion)) {
+    if (auto languageMode = feature->getLanguageMode()) {
+      if (Opts.isLanguageModeAtLeast(languageMode.value())) {
         Diags.diagnose(SourceLoc(),
                        diag::warning_upcoming_feature_on_by_default,
-                       feature->getName(), *firstVersion);
+                       feature->getName(), languageMode->versionString());
         continue;
       }
     }
@@ -1346,8 +1346,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   // Add a future feature if it is not already implied by the language version.
   auto addFutureFeatureIfNotImplied = [&](Feature feature) {
     // Check if this feature was introduced already in this language version.
-    if (auto firstVersion = feature.getLanguageMode()) {
-      if (Opts.isLanguageModeAtLeast(*firstVersion))
+    if (auto languageMode = feature.getLanguageMode()) {
+      if (Opts.isLanguageModeAtLeast(languageMode.value()))
         return;
     }
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1524,7 +1524,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   if (Args.hasFlag(OPT_enable_nonfrozen_enum_exhaustivity_diagnostics,
                    OPT_disable_nonfrozen_enum_exhaustivity_diagnostics,
-                   Opts.isLanguageModeAtLeast(5))) {
+                   Opts.isLanguageModeAtLeast(LanguageMode::v5))) {
     Opts.enableFeature(Feature::NonfrozenEnumExhaustivity);
   }
 
@@ -1945,7 +1945,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
                      A->getAsString(Args), A->getValue());
       HadError = true;
     }
-  } else if (Opts.isLanguageModeAtLeast(6)) {
+  } else if (Opts.isLanguageModeAtLeast(LanguageMode::v6)) {
     Opts.UseCheckedAsyncObjCBridging = true;
   }
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -19,6 +19,7 @@
 #include "swift/AST/DiagnosticsFrontend.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/Feature.h"
+#include "swift/Basic/LanguageMode.h"
 #include "swift/Basic/Platform.h"
 #include "swift/Basic/Version.h"
 #include "swift/Option/Options.h"
@@ -510,10 +511,16 @@ static void diagnoseSwiftVersion(std::optional<version::Version> &vers,
   diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
                  verArg->getAsString(Args), verArg->getValue());
 
-  // Note valid versions.
-  auto validVers = version::Version::getValidEffectiveVersions();
-  auto versStr = "'" + llvm::join(validVers, "', '") + "'";
-  diags.diagnose(SourceLoc(), diag::note_valid_swift_versions, versStr);
+  // Enumerate the valid language modes.
+  std::string modesStr;
+  {
+    llvm::raw_string_ostream os(modesStr);
+    llvm::interleaveComma(
+        LanguageMode::allSupportedModes(), os,
+        [&](LanguageMode mode) { os << "'" << mode.versionString() << "'"; });
+  }
+
+  diags.diagnose(SourceLoc(), diag::note_valid_swift_versions, modesStr);
 }
 
 /// Create a new Regex instance out of the string value in \p RpassArg.

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1521,7 +1521,7 @@ ModuleDecl *CompilerInstance::getMainModule() const {
     }
     if (Invocation.getLangOptions().hasFeature(Feature::LibraryEvolution))
       MainModule->setResilienceStrategy(ResilienceStrategy::Resilient);
-    if (Invocation.getLangOptions().isLanguageModeAtLeast(6))
+    if (Invocation.getLangOptions().isLanguageModeAtLeast(LanguageMode::v6))
       MainModule->setIsConcurrencyChecked(true);
     if (Invocation.getLangOptions().EnableCXXInterop &&
         Invocation.getLangOptions()

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -204,11 +204,11 @@ printModuleInterfaceIfNeeded(llvm::vfs::OutputBackend &outputBackend,
     return false;
 
   DiagnosticEngine &diags = M->getDiags();
-  if (!LangOpts.isLanguageModeAtLeast(5)) {
-    assert(LangOpts.isLanguageModeAtLeast(4));
-    diags.diagnose(SourceLoc(),
-                   diag::warn_unsupported_module_interface_swift_version,
-                   LangOpts.isLanguageModeAtLeast(4, 2) ? "4.2" : "4");
+  if (!LangOpts.isLanguageModeAtLeast(LanguageMode::v5)) {
+    assert(LangOpts.isLanguageModeAtLeast(LanguageMode::v4));
+    diags.diagnose(
+        SourceLoc(), diag::warn_unsupported_module_interface_swift_version,
+        LangOpts.isLanguageModeAtLeast(LanguageMode::v4_2) ? "4.2" : "4");
   }
   if (M->getResilienceStrategy() != ResilienceStrategy::Resilient) {
     diags.diagnose(SourceLoc(),

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4438,12 +4438,12 @@ ParserStatus Parser::parseDeclAttribute(DeclAttributes &Attributes,
 
   // In Swift 5 and above, these become hard errors. In Swift 4.2, emit a
   // warning for compatibility. Otherwise, don't diagnose at all.
-  if (Context.isLanguageModeAtLeast(5)) {
+  if (Context.isLanguageModeAtLeast(LanguageMode::v5)) {
     checkInvalidAttrName("_versioned", "usableFromInline",
                          DeclAttrKind::UsableFromInline, diag::attr_renamed);
     checkInvalidAttrName("_inlineable", "inlinable", DeclAttrKind::Inlinable,
                          diag::attr_renamed);
-  } else if (Context.isLanguageModeAtLeast(4, 2)) {
+  } else if (Context.isLanguageModeAtLeast(LanguageMode::v4_2)) {
     checkInvalidAttrName("_versioned", "usableFromInline",
                          DeclAttrKind::UsableFromInline,
                          diag::attr_renamed_warning);

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4237,7 +4237,7 @@ bool Parser::parseVersionTuple(llvm::VersionTuple &Version,
     consumeToken();
     if (Version.empty()) {
       // Versions cannot be empty (e.g. "0").
-      diagnose(Range.Start, D).warnUntilLanguageMode(6);
+      diagnose(Range.Start, D).warnUntilLanguageMode(LanguageMode::v6);
       return true;
     }
     return false;
@@ -4278,7 +4278,7 @@ bool Parser::parseVersionTuple(llvm::VersionTuple &Version,
 
   if (Version.empty()) {
     // Versions cannot be empty (e.g. "0.0").
-    diagnose(Range.Start, D).warnUntilLanguageMode(6);
+    diagnose(Range.Start, D).warnUntilLanguageMode(LanguageMode::v6);
     return true;
   }
 
@@ -4316,7 +4316,7 @@ ParserResult<CustomAttr> Parser::parseCustomAttribute(SourceLoc atLoc) {
   if (isAtAttributeLParen(/*isCustomAttribute=*/true)) {
     if (getEndOfPreviousLoc() != Tok.getLoc()) {
       diagnose(getEndOfPreviousLoc(), diag::attr_extra_whitespace_before_lparen)
-          .warnUntilLanguageMode(6);
+          .warnUntilLanguageMode(LanguageMode::v6);
     }
     // If we have no local context to parse the initial value into, create
     // one for the attribute.
@@ -4375,7 +4375,7 @@ ParserStatus Parser::parseDeclAttribute(DeclAttributes &Attributes,
                                         bool isFromClangAttribute) {
   if (AtEndLoc != Tok.getLoc()) {
     diagnose(AtEndLoc, diag::attr_extra_whitespace_after_at)
-        .warnUntilLanguageMode(6);
+        .warnUntilLanguageMode(LanguageMode::v6);
   }
 
   bool hasModuleSelector = peekToken().is(tok::colon_colon);
@@ -4794,7 +4794,7 @@ ParserStatus Parser::parseTypeAttribute(TypeOrCustomAttr &result,
                                         bool justChecking) {
   if (AtEndLoc != Tok.getLoc()) {
     diagnose(AtEndLoc, diag::attr_extra_whitespace_after_at)
-        .warnUntilLanguageMode(6);
+        .warnUntilLanguageMode(LanguageMode::v6);
   }
 
   // If this not an identifier, the attribute is malformed.

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -180,7 +180,7 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
     // Per SE-0155, enum elements may not have empty parameter lists.
     if (paramContext == ParameterContextKind::EnumElement) {
       decltype(diag::enum_element_empty_arglist) diagnostic;
-      if (Context.isLanguageModeAtLeast(5)) {
+      if (Context.isLanguageModeAtLeast(LanguageMode::v5)) {
         diagnostic = diag::enum_element_empty_arglist;
       } else {
         diagnostic = diag::enum_element_empty_arglist_swift4;

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -249,7 +249,7 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
         if (Tok.isContextualKeyword("isolated")) {
           diagnose(Tok, diag::parameter_specifier_as_attr_disallowed,
                    Tok.getText())
-              .warnUntilLanguageMode(6);
+              .warnUntilLanguageMode(LanguageMode::v6);
           // did we already find an 'isolated' type modifier?
           if (param.IsolatedLoc.isValid()) {
             diagnose(Tok, diag::parameter_specifier_repeated)
@@ -266,7 +266,7 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
         if (Tok.isContextualKeyword("_const")) {
           diagnose(Tok, diag::parameter_specifier_as_attr_disallowed,
                    Tok.getText())
-              .warnUntilLanguageMode(6);
+              .warnUntilLanguageMode(LanguageMode::v6);
           param.CompileConstLoc = consumeToken();
           continue;
         }
@@ -275,7 +275,7 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
             Tok.isContextualKeyword("sending")) {
           diagnose(Tok, diag::parameter_specifier_as_attr_disallowed,
                    Tok.getText())
-              .warnUntilLanguageMode(6);
+              .warnUntilLanguageMode(LanguageMode::v6);
           if (param.SendingLoc.isValid()) {
             diagnose(Tok, diag::parameter_specifier_repeated)
                 .fixItRemove(Tok.getLoc());
@@ -459,7 +459,7 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
                     .fixItInsert(typeStartLoc, "_: ");
             } else {
               diagnose(typeStartLoc, diag::parameter_unnamed)
-                  .warnUntilLanguageMode(6)
+                  .warnUntilLanguageMode(LanguageMode::v6)
                   .fixItInsert(typeStartLoc, "_: ");
             }
           }

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -602,7 +602,7 @@ SourceLoc Parser::consumeAttributeLParen() {
   SourceLoc LastTokenEndLoc = getEndOfPreviousLoc();
   if (LastTokenEndLoc != Tok.getLoc() && !isInSILMode()) {
     diagnose(LastTokenEndLoc, diag::attr_extra_whitespace_before_lparen)
-        .warnUntilLanguageMode(6);
+        .warnUntilLanguageMode(LanguageMode::v6);
   }
   return consumeToken(tok::l_paren);
 }

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -618,7 +618,7 @@ bool Parser::isAtAttributeLParen(bool isCustomAttr) {
   if (!Tok.isFollowingLParen())
     return false;
 
-  if (Context.isLanguageModeAtLeast(6)) {
+  if (Context.isLanguageModeAtLeast(LanguageMode::v6)) {
     // No-space '(' are always arguments.
     if (getEndOfPreviousLoc() == Tok.getLoc())
       return true;

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -1423,7 +1423,7 @@ private:
       // because it's a diagnostic inflicted on /clients/, but it's close
       // enough. It really is invalid to call +new when -init is unavailable.
       StringRef annotationName = "SWIFT_UNAVAILABLE_MSG";
-      if (!getASTContext().isLanguageModeAtLeast(5))
+      if (!getASTContext().isLanguageModeAtLeast(LanguageMode::v5))
         annotationName = "SWIFT_DEPRECATED_MSG";
       os << "+ (nonnull instancetype)new " << annotationName
          << "(\"-init is unavailable\");\n";

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -663,7 +663,7 @@ void SILGenFunction::emitValueConstructor(ConstructorDecl *ctor) {
   MarkUninitializedInst::Kind MUIKind;
   if (isDelegating) {
     MUIKind = MarkUninitializedInst::DelegatingSelf;
-  } else if (getASTContext().isLanguageModeAtLeast(5)) {
+  } else if (getASTContext().isLanguageModeAtLeast(LanguageMode::v5)) {
     MUIKind = MarkUninitializedInst::RootSelf;
   } else {
     auto *dc = ctor->getParent();

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1300,8 +1300,9 @@ RValue RValueEmitter::visitOptionalTryExpr(OptionalTryExpr *E, SGFContext C) {
   // FIXME: Much of this was copied from visitOptionalEvaluationExpr.
 
   // Prior to Swift 5, an optional try's subexpression is always wrapped in an additional optional
-  bool shouldWrapInOptional = !(SGF.getASTContext().isLanguageModeAtLeast(5));
-  
+  bool shouldWrapInOptional =
+      !(SGF.getASTContext().isLanguageModeAtLeast(LanguageMode::v5));
+
   auto &optTL = SGF.getTypeLowering(E->getType());
 
   Initialization *optInit = C.getEmitInto();

--- a/lib/SILOptimizer/Mandatory/FlowIsolation.cpp
+++ b/lib/SILOptimizer/Mandatory/FlowIsolation.cpp
@@ -474,7 +474,7 @@ void Info::diagnoseAll(AnalysisInfo &info, bool forDeinit,
       diag.diagnose(illegalLoc.getSourceLoc(),
                     diag::isolated_property_mutation_in_nonisolated_context,
                     accessor->getStorage(), accessor->isSetter())
-          .warnUntilLanguageMode(6);
+          .warnUntilLanguageMode(LanguageMode::v6);
       continue;
     }
 
@@ -486,7 +486,7 @@ void Info::diagnoseAll(AnalysisInfo &info, bool forDeinit,
     diag.diagnose(illegalLoc.getSourceLoc(), diag::isolated_after_nonisolated,
                   forDeinit, var)
         .highlight(illegalLoc.getSourceRange())
-        .warnUntilLanguageMode(6);
+        .warnUntilLanguageMode(LanguageMode::v6);
 
     // after <verb><adjective> <subject>, ... can't use self anymore, etc ...
     //   example:

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -367,7 +367,7 @@ template <typename... T, typename... U>
 static InFlightDiagnostic diagnoseError(ASTContext &context, SourceLoc loc,
                                         Diag<T...> diag, U &&...args) {
   return std::move(context.Diags.diagnose(loc, diag, std::forward<U>(args)...)
-                       .warnUntilLanguageMode(6));
+                       .warnUntilLanguageMode(LanguageMode::v6));
 }
 
 template <typename... T, typename... U>
@@ -1150,7 +1150,7 @@ private:
     emittedErrorDiagnostic = true;
     return std::move(getASTContext()
                          .Diags.diagnose(loc, diag, std::forward<U>(args)...)
-                         .warnUntilLanguageMode(6));
+                         .warnUntilLanguageMode(LanguageMode::v6));
   }
 
   template <typename... T, typename... U>
@@ -1936,7 +1936,7 @@ private:
     emittedErrorDiagnostic = true;
     return std::move(getASTContext()
                          .Diags.diagnose(loc, diag, std::forward<U>(args)...)
-                         .warnUntilLanguageMode(6));
+                         .warnUntilLanguageMode(LanguageMode::v6));
   }
 
   template <typename... T, typename... U>
@@ -2559,7 +2559,7 @@ public:
     emittedErrorDiagnostic = true;
     return std::move(getASTContext()
                          .Diags.diagnose(loc, diag, std::forward<U>(args)...)
-                         .warnUntilLanguageMode(6));
+                         .warnUntilLanguageMode(LanguageMode::v6));
   }
 
   template <typename... T, typename... U>
@@ -3076,7 +3076,7 @@ public:
     emittedErrorDiagnostic = true;
     return std::move(getASTContext()
                          .Diags.diagnose(loc, diag, std::forward<U>(args)...)
-                         .warnUntilLanguageMode(6));
+                         .warnUntilLanguageMode(LanguageMode::v6));
   }
 
   template <typename... T, typename... U>
@@ -3202,7 +3202,7 @@ public:
     emittedErrorDiagnostic = true;
     return std::move(getASTContext()
                          .Diags.diagnose(loc, diag, std::forward<U>(args)...)
-                         .warnUntilLanguageMode(6));
+                         .warnUntilLanguageMode(LanguageMode::v6));
   }
 
   template <typename... T, typename... U>
@@ -3412,7 +3412,7 @@ struct NonSendableIsolationCrossingResultDiagnosticEmitter {
     emittedErrorDiagnostic = true;
     return std::move(getASTContext()
                          .Diags.diagnose(loc, diag, std::forward<U>(args)...)
-                         .warnUntilLanguageMode(6));
+                         .warnUntilLanguageMode(LanguageMode::v6));
   }
 
   template <typename... T, typename... U>
@@ -3634,7 +3634,7 @@ public:
     emittedErrorDiagnostic = true;
     return std::move(getASTContext()
                          .Diags.diagnose(loc, diag, std::forward<U>(args)...)
-                         .warnUntilLanguageMode(6));
+                         .warnUntilLanguageMode(LanguageMode::v6));
   }
 
   template <typename... T, typename... U>

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -1617,7 +1617,7 @@ public:
              ->getType()
              .getASTType()
              ->getASTContext()
-             .isAtLeastFutureMajorLanguageMode())
+             .isLanguageModeAtLeast(LanguageMode::future))
       return DiagnosticBehavior::Warning;
 
     return sendingOperand->get()->getType().getConcurrencyDiagnosticBehavior(

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -361,7 +361,7 @@ static void recordTypeWitness(NormalProtocolConformance *conformance,
         ctx.evaluator, ConformanceAccessScopeRequest{dc, proto},
         std::make_pair(AccessScope::getPublic(), false));
 
-    if (!ctx.isLanguageModeAtLeast(5) &&
+    if (!ctx.isLanguageModeAtLeast(LanguageMode::v5) &&
         !dc->getParentModule()->isResilient()) {
       // HACK: In pre-Swift-5, these typealiases were synthesized with the
       // same access level as the conforming type, which might be more
@@ -593,7 +593,7 @@ static ResolveWitnessResult resolveTypeWitnessViaLookup(
     // AsyncSequence.Failure. We'll infer it from the AsyncIterator.Failure
     // instead.
     if (isAsyncSequenceFailure(assocType) &&
-        !ctx.isLanguageModeAtLeast(6) &&
+        !ctx.isLanguageModeAtLeast(LanguageMode::v6) &&
         assocType->getName() == genericDecl->getName())
       continue;
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3755,8 +3755,8 @@ namespace {
       //  - Equal to T? if T is not optional
       //
       // The result is that in Swift 5, 'try?' avoids producing nested optionals.
-      
-      if (!ctx.isLanguageModeAtLeast(5)) {
+
+      if (!ctx.isLanguageModeAtLeast(LanguageMode::v5)) {
         // Nothing to do for Swift 4 and earlier!
         return simplifyExprType(expr);
       }
@@ -4323,7 +4323,7 @@ namespace {
       // be an optional type, leave any extra optionals on the source in place.
       // Only apply the latter condition in Swift 5 mode to best preserve
       // compatibility with Swift 4.1's casting behaviour.
-      if (isBridgeToAnyObject || (ctx.isLanguageModeAtLeast(5) &&
+      if (isBridgeToAnyObject || (ctx.isLanguageModeAtLeast(LanguageMode::v5) &&
                                   destValueType->canDynamicallyBeOptionalType(
                                       /*includeExistential*/ false))) {
         auto destOptionalsCount = destOptionals.size() - destExtraOptionals;
@@ -5801,7 +5801,7 @@ Expr *ExprRewriter::coerceTupleToTuple(Expr *expr,
     SmallString<16> toLabelStr;
     concatLabels(labels, toLabelStr);
 
-    if (ctx.isAtLeastFutureMajorLanguageMode()) {
+    if (ctx.isLanguageModeAtLeast(LanguageMode::future)) {
       ctx.Diags.diagnose(expr->getLoc(), diag::reordering_tuple_shuffle,
                          fromLabelStr, toLabelStr);
     } else {
@@ -6168,7 +6168,7 @@ ArgumentList *ExprRewriter::coerceCallArguments(
 
     // Both the caller and the allee are in the same module.
     if (dc->getParentModule() == decl->getModuleContext()) {
-      return !dc->getASTContext().isLanguageModeAtLeast(6);
+      return !dc->getASTContext().isLanguageModeAtLeast(LanguageMode::v6);
     }
 
     // If we cannot figure out where the callee came from, let's conservatively
@@ -6345,7 +6345,7 @@ ArgumentList *ExprRewriter::coerceCallArguments(
         // to be used by value if parameter would return a function
         // type (it just needs to get wrapped into autoclosure expr),
         // otherwise argument must always form a call.
-        return ctx.isLanguageModeAtLeast(5);
+        return ctx.isLanguageModeAtLeast(LanguageMode::v5);
       }
 
       return true;
@@ -7099,8 +7099,8 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
       // ```
       //
       // See also: https://github.com/apple/swift/issues/49345
-      if (ctx.isLanguageModeAtLeast(4) &&
-          !ctx.isLanguageModeAtLeast(5)) {
+      if (ctx.isLanguageModeAtLeast(LanguageMode::v4) &&
+          !ctx.isLanguageModeAtLeast(LanguageMode::v5)) {
         auto obj1 = fromType->getOptionalObjectType();
         auto obj2 = toType->getOptionalObjectType();
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1789,7 +1789,8 @@ bool MissingOptionalUnwrapFailure::diagnoseAsError() {
   auto *unwrappedExpr = anchor->getValueProvidingExpr();
 
   if (auto *tryExpr = dyn_cast<OptionalTryExpr>(unwrappedExpr)) {
-    bool isSwift5OrGreater = getASTContext().isLanguageModeAtLeast(5);
+    bool isSwift5OrGreater =
+        getASTContext().isLanguageModeAtLeast(LanguageMode::v5);
     auto subExprType = getType(tryExpr->getSubExpr());
     bool subExpressionIsOptional = (bool)subExprType->getOptionalObjectType();
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -8182,7 +8182,7 @@ bool SendingMismatchFailure::diagnoseAsError() {
 bool SendingMismatchFailure::diagnoseArgFailure() {
   emitDiagnostic(diag::sending_function_wrong_sending, getFromType(),
                  getToType())
-      .warnUntilLanguageMode(6);
+      .warnUntilLanguageMode(LanguageMode::v6);
   emitDiagnostic(diag::sending_function_param_with_sending_param_note);
   return true;
 }
@@ -8190,7 +8190,7 @@ bool SendingMismatchFailure::diagnoseArgFailure() {
 bool SendingMismatchFailure::diagnoseResultFailure() {
   emitDiagnostic(diag::sending_function_wrong_sending, getFromType(),
                  getToType())
-      .warnUntilLanguageMode(6);
+      .warnUntilLanguageMode(LanguageMode::v6);
   emitDiagnostic(diag::sending_function_result_with_sending_param_note);
   return true;
 }
@@ -9445,7 +9445,7 @@ bool InvalidWeakAttributeUse::diagnoseAsError() {
 bool TupleLabelMismatchWarning::diagnoseAsError() {
   emitDiagnostic(diag::tuple_label_mismatch, getFromType(), getToType())
       .highlight(getSourceRange())
-      .warnUntilFutureLanguageMode();
+      .warnUntilLanguageMode(LanguageMode::future);
   return true;
 }
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -296,7 +296,7 @@ getConcurrencyFixBehavior(ConstraintSystem &cs, ConstraintKind constraintKind,
     // Passing a static member reference as an argument needs to be downgraded
     // to a warning until future major mode to maintain source compatibility for
     // code with non-Sendable metatypes.
-    if (!cs.getASTContext().isAtLeastFutureMajorLanguageMode()) {
+    if (!cs.getASTContext().isLanguageModeAtLeast(LanguageMode::future)) {
       auto *argLoc = cs.getConstraintLocator(locator);
       if (auto *argument = getAsExpr(simplifyLocatorToAnchor(argLoc))) {
         if (auto overload = cs.findSelectedOverloadFor(
@@ -331,7 +331,7 @@ getConcurrencyFixBehavior(ConstraintSystem &cs, ConstraintKind constraintKind,
   }
 
   // Otherwise, warn until Swift 6.
-  if (!cs.getASTContext().isLanguageModeAtLeast(6))
+  if (!cs.getASTContext().isLanguageModeAtLeast(LanguageMode::v6))
     return FixBehavior::DowngradeToWarning;
 
   return FixBehavior::Error;
@@ -2002,7 +2002,7 @@ bool AllowSendingMismatch::diagnose(const Solution &solution,
 AllowSendingMismatch *AllowSendingMismatch::create(ConstraintSystem &cs,
                                                    Type srcType, Type dstType,
                                                    ConstraintLocator *locator) {
-  auto fixBehavior = cs.getASTContext().isLanguageModeAtLeast(6)
+  auto fixBehavior = cs.getASTContext().isLanguageModeAtLeast(LanguageMode::v6)
                          ? FixBehavior::Error
                          : FixBehavior::DowngradeToWarning;
   return new (cs.getAllocator())
@@ -2784,7 +2784,7 @@ bool AllowFunctionSpecialization::diagnose(const Solution &solution,
 AllowFunctionSpecialization *
 AllowFunctionSpecialization::create(ConstraintSystem &cs, ValueDecl *decl,
                                     ConstraintLocator *locator) {
-  auto fixBehavior = cs.getASTContext().isLanguageModeAtLeast(6)
+  auto fixBehavior = cs.getASTContext().isLanguageModeAtLeast(LanguageMode::v6)
                          ? FixBehavior::Error
                          : FixBehavior::DowngradeToWarning;
   return new (cs.getAllocator())

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1342,7 +1342,7 @@ namespace {
         // rdar://85263844, as it can affect the prioritization of bindings,
         // which can affect behavior for tuple matching as tuple subtyping is
         // currently a *weaker* constraint than tuple conversion.
-        if (!CS.getASTContext().isLanguageModeAtLeast(6)) {
+        if (!CS.getASTContext().isLanguageModeAtLeast(LanguageMode::v6)) {
           auto paramTypeVar = CS.createTypeVariable(
               CS.getConstraintLocator(expr, ConstraintLocator::ApplyArgument),
               TVO_CanBindToLValue | TVO_CanBindToInOut | TVO_CanBindToNoEscape |
@@ -1527,7 +1527,7 @@ namespace {
       // NB Keep adding the additional layer in Swift 5 and on if this 'try?'
       // applies to a delegation to an 'Optional' initializer, or else we won't
       // discern the difference between a failure and a constructed value.
-      if (CS.getASTContext().isLanguageModeAtLeast(5) &&
+      if (CS.getASTContext().isLanguageModeAtLeast(LanguageMode::v5) &&
           !isDelegationToOptionalInit) {
         CS.addConstraint(ConstraintKind::Conversion,
                          CS.getType(expr->getSubExpr()), optTy,

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -627,7 +627,8 @@ bool CompareDeclSpecializationRequest::evaluate(
   //      x.i // ensure ambiguous.
   //    }
   //
-  if (C.isLanguageModeAtLeast(5) && !isDynamicOverloadComparison) {
+  if (C.isLanguageModeAtLeast(LanguageMode::v5) &&
+      !isDynamicOverloadComparison) {
     auto inProto1 = isa<ProtocolDecl>(outerDC1);
     auto inProto2 = isa<ProtocolDecl>(outerDC2);
     if (inProto1 != inProto2)
@@ -1423,7 +1424,7 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
     // compatibility under Swift 4 mode by ensuring we don't introduce any new
     // ambiguities. This will become a more general "is more specialised" rule
     // in Swift 5 mode.
-    if (!cs.getASTContext().isLanguageModeAtLeast(5) &&
+    if (!cs.getASTContext().isLanguageModeAtLeast(LanguageMode::v5) &&
         choice1.getKind() != OverloadChoiceKind::DeclViaDynamic &&
         choice2.getKind() != OverloadChoiceKind::DeclViaDynamic &&
         isa<VarDecl>(decl1) && isa<VarDecl>(decl2)) {
@@ -1633,7 +1634,8 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
   // All other things being equal, apply the Swift 4.1 compatibility hack for
   // preferring var members in concrete types over a protocol requirement
   // (see the comment above for the rationale of this hack).
-  if (!cs.getASTContext().isLanguageModeAtLeast(5) && score1 == score2) {
+  if (!cs.getASTContext().isLanguageModeAtLeast(LanguageMode::v5) &&
+      score1 == score2) {
     score1 += isVarAndNotProtocol1;
     score2 += isVarAndNotProtocol2;
   }

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -407,7 +407,7 @@ createImplicitConstructor(NominalTypeDecl *decl, ImplicitConstructorKind ICK,
                             ICK == ImplicitConstructorKind::Memberwise,
                             decl->getDeclaredType(), existingIsolation,
                             isolation)
-                  .warnUntilLanguageMode(6);
+                  .warnUntilLanguageMode(LanguageMode::v6);
               if (previousVar) {
                 previousVar->diagnose(diag::property_requires_actor,
                                       previousVar, existingIsolation);
@@ -952,7 +952,7 @@ static void diagnoseMissingRequiredInitializer(
       .diagnose(insertionLoc, diag::required_initializer_missing,
                 superInitializer->getName(),
                 superInitializer->getDeclContext()->getDeclaredInterfaceType())
-      .warnUntilLanguageModeIf(downgradeToWarning, 6)
+      .warnUntilLanguageModeIf(downgradeToWarning, LanguageMode::v6)
       .fixItInsert(insertionLoc, initializerText);
 
   ctx.Diags.diagnose(findNonImplicitRequiredInit(superInitializer),

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1481,7 +1481,7 @@ bool HasMemberwiseInitRequest::evaluate(Evaluator &evaluator, StructDecl *decl,
     // In the next language mode we should stop creating the compatibility
     // initializer if 'DeprecateCompatMemberwiseInit' is enabled.
     if (ctx.LangOpts.hasFeature(Feature::DeprecateCompatMemberwiseInit) &&
-        ctx.isAtLeastFutureMajorLanguageMode()) {
+        ctx.isLanguageModeAtLeast(LanguageMode::future)) {
       return false;
     }
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4976,7 +4976,7 @@ bool ConstraintSystem::isReadOnlyKeyPathComponent(
   // get any special power from being formed in certain contexts, such
   // as the ability to assign to `let`s in initialization contexts, so
   // we pass null for the DC to `isSettable` here.)
-  if (!getASTContext().isLanguageModeAtLeast(5)) {
+  if (!getASTContext().isLanguageModeAtLeast(LanguageMode::v5)) {
     // As a source-compatibility measure, continue to allow
     // WritableKeyPaths to be formed in the same conditions we did
     // in previous releases even if we should not be able to set

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -748,7 +748,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
       // - member type expressions rooted on non-identifier types, e.g.
       //   '[X].Y' since they used to be accepted without the '.self'.
       bool downgradeToWarningUntil6 = false;
-      if (!Ctx.isLanguageModeAtLeast(6)) {
+      if (!Ctx.isLanguageModeAtLeast(LanguageMode::v6)) {
         if (ParentExpr && (isa<SubscriptExpr>(ParentExpr) ||
                            isa<DynamicSubscriptExpr>(ParentExpr) ||
                            isa<ObjectLiteralExpr>(ParentExpr))) {
@@ -1895,7 +1895,7 @@ public:
 
     // Prior to Swift 6, use the old validation logic.
     auto &ctx = inClosure->getASTContext();
-    if (!ctx.isLanguageModeAtLeast(6))
+    if (!ctx.isLanguageModeAtLeast(LanguageMode::v6))
       return selfDeclAllowsImplicitSelf510(DRE, ty, inClosure);
 
     return selfDeclAllowsImplicitSelf(DRE->getDecl(), ty, inClosure,
@@ -2280,7 +2280,7 @@ public:
 
   bool shouldRecordClosure(const AbstractClosureExpr *E) {
     // Record all closures in Swift 6 mode.
-    if (Ctx.isLanguageModeAtLeast(6))
+    if (Ctx.isLanguageModeAtLeast(LanguageMode::v6))
       return true;
 
     // Only record closures requiring self qualification prior to Swift 6
@@ -2367,7 +2367,8 @@ public:
 
     if (memberLoc.isValid()) {
       const AbstractClosureExpr *parentDisallowingImplicitSelf = nullptr;
-      if (Ctx.isLanguageModeAtLeast(6) && selfDRE && selfDRE->getDecl()) {
+      if (Ctx.isLanguageModeAtLeast(LanguageMode::v6) && selfDRE &&
+          selfDRE->getDecl()) {
         parentDisallowingImplicitSelf = parentClosureDisallowingImplicitSelf(
             selfDRE->getDecl(), selfDRE->getType(), ACE);
       }
@@ -5696,7 +5697,7 @@ static void diagnoseUnintendedOptionalBehavior(const Expr *E,
 
       // Do not warn on coercions from implicitly unwrapped optionals
       // for Swift versions less than 5.
-      if (!Ctx.isLanguageModeAtLeast(5) &&
+      if (!Ctx.isLanguageModeAtLeast(LanguageMode::v5) &&
           hasImplicitlyUnwrappedResult(subExpr))
         return;
 
@@ -6702,7 +6703,7 @@ void swift::performSyntacticExprDiagnostics(const Expr *E,
   maybeDiagnoseCallToKeyValueObserveMethod(E, DC);
   diagnoseExplicitUseOfLazyVariableStorage(E, DC);
   diagnoseComparisonWithNaN(E, DC);
-  if (!ctx.isLanguageModeAtLeast(5))
+  if (!ctx.isLanguageModeAtLeast(LanguageMode::v5))
     diagnoseDeprecatedWritableKeyPath(E, DC);
   if (!ctx.LangOpts.DisableAvailabilityChecking)
     diagnoseExprAvailability(E, const_cast<DeclContext*>(DC));

--- a/lib/Sema/PreCheckTarget.cpp
+++ b/lib/Sema/PreCheckTarget.cpp
@@ -2045,7 +2045,7 @@ bool PreCheckTarget::canSimplifyDiscardAssignmentExpr(
 bool PreCheckTarget::correctInterpolationIfStrange(
     InterpolatedStringLiteralExpr *ISLE) {
   // These expressions are valid in Swift 5+.
-  if (getASTContext().isLanguageModeAtLeast(5))
+  if (getASTContext().isLanguageModeAtLeast(LanguageMode::v5))
     return true;
 
   /// Diagnoses appendInterpolation(...) calls with multiple
@@ -2732,7 +2732,7 @@ void PreCheckTarget::resolveKeyPathExpr(KeyPathExpr *KPE) {
 Expr *PreCheckTarget::simplifyTypeConstructionWithLiteralArg(Expr *E) {
   // If constructor call is expected to produce an optional let's not attempt
   // this optimization because literal initializers aren't failable.
-  if (!getASTContext().isLanguageModeAtLeast(5)) {
+  if (!getASTContext().isLanguageModeAtLeast(LanguageMode::v5)) {
     if (!ExprStack.empty()) {
       auto *parent = ExprStack.back();
       if (isa<BindOptionalExpr>(parent) || isa<ForceValueExpr>(parent))

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -93,8 +93,9 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
           Context.Diags
               .diagnose(loc, diagID, D, accessor->getFormalAccess(),
                         fragileKind.getSelector())
-              .warnUntilFutureLanguageModeIf(
-                  !Context.LangOpts.hasFeature(Feature::StrictAccessControl));
+              .warnUntilLanguageModeIf(
+                  !Context.LangOpts.hasFeature(Feature::StrictAccessControl),
+                  LanguageMode::future);
           Context.Diags.diagnose(D, diag::resilience_decl_declared_here, D);
         }
       }
@@ -214,7 +215,7 @@ static bool diagnoseTypeAliasDeclRefExportability(SourceLoc loc,
                   TAD, definingModule->getNameStr(), D->getNameStr(),
                   static_cast<unsigned>(*reason), definingModule->getName(),
                   static_cast<unsigned>(originKind))
-        .warnUntilLanguageModeIf(warnPreSwift6, 6)
+        .warnUntilLanguageModeIf(warnPreSwift6, LanguageMode::v6)
         .limitBehaviorIfMorePermissive(commonBehavior);
   } else {
     ctx.Diags
@@ -223,7 +224,7 @@ static bool diagnoseTypeAliasDeclRefExportability(SourceLoc loc,
                   TAD, definingModule->getNameStr(), D->getNameStr(),
                   fragileKind.getSelector(), definingModule->getName(),
                   static_cast<unsigned>(originKind))
-        .warnUntilLanguageModeIf(warnPreSwift6, 6)
+        .warnUntilLanguageModeIf(warnPreSwift6, LanguageMode::v6)
         .limitBehaviorIfMorePermissive(commonBehavior);
   }
   D->diagnose(diag::kind_declared_here, DescriptiveDeclKind::Type);
@@ -399,7 +400,7 @@ static bool diagnoseValueDeclRefExportability(SourceLoc loc, const ValueDecl *D,
                        fragileKind.getSelector(), definingModule->getName(),
                        static_cast<unsigned>(originKind))
         .warnUntilLanguageModeIf(downgradeToWarning == DowngradeToWarning::Yes,
-                                 6)
+                                 LanguageMode::v6)
         .limitBehaviorIfMorePermissive(commonBehavior);
 
     if (originKind == DisallowedOriginKind::MissingImport &&
@@ -489,8 +490,8 @@ TypeChecker::diagnoseConformanceExportability(SourceLoc loc,
           (warnIfConformanceUnavailablePreSwift6 &&
            originKind != DisallowedOriginKind::SPIOnly &&
            originKind != DisallowedOriginKind::NonPublicImport) ||
-          originKind == DisallowedOriginKind::MissingImport,
-          6)
+              originKind == DisallowedOriginKind::MissingImport,
+          LanguageMode::v6)
       .limitBehaviorIfMorePermissive(commonBehavior);
 
   if (!ctx.LangOpts.hasFeature(Feature::StrictAccessControl) &&

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -109,7 +109,8 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
   // Dynamic declarations were mistakenly not checked in Swift 4.2.
   // Do enforce the restriction even in pre-Swift-5 modes if the module we're
   // building is resilient, though.
-  if (D->shouldUseObjCDispatch() && !Context.isLanguageModeAtLeast(5) &&
+  if (D->shouldUseObjCDispatch() &&
+      !Context.isLanguageModeAtLeast(LanguageMode::v5) &&
       !DC->getParentModule()->isResilient()) {
     return false;
   }
@@ -123,22 +124,23 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
 
   // Swift 4.2 did not perform any checks for type aliases.
   if (isa<TypeAliasDecl>(D)) {
-    if (!Context.isLanguageModeAtLeast(4, 2))
+    if (!Context.isLanguageModeAtLeast(LanguageMode::v4_2))
       return false;
-    if (!Context.isLanguageModeAtLeast(5))
+    if (!Context.isLanguageModeAtLeast(LanguageMode::v5))
       downgradeToWarning = DowngradeToWarning::Yes;
   }
 
   // Swift 4.2 did not check accessor accessibility.
   if (auto accessor = dyn_cast<AccessorDecl>(D)) {
-    if (!accessor->isInitAccessor() && !Context.isLanguageModeAtLeast(5))
+    if (!accessor->isInitAccessor() &&
+        !Context.isLanguageModeAtLeast(LanguageMode::v5))
       downgradeToWarning = DowngradeToWarning::Yes;
   }
 
   // Swift 5.0 did not check the underlying types of local typealiases.
   if (isa<TypeAliasDecl>(DC) &&
       !Context.LangOpts.hasFeature(Feature::StrictAccessControl) &&
-      !Context.isLanguageModeAtLeast(6))
+      !Context.isLanguageModeAtLeast(LanguageMode::v6))
     downgradeToWarning = DowngradeToWarning::Yes;
 
   auto diagID = diag::resilience_decl_unavailable;
@@ -231,7 +233,7 @@ static bool diagnoseTypeAliasDeclRefExportability(SourceLoc loc,
 
   if (!ctx.LangOpts.hasFeature(Feature::StrictAccessControl) &&
       originKind == DisallowedOriginKind::MissingImport &&
-      !ctx.isLanguageModeAtLeast(6))
+      !ctx.isLanguageModeAtLeast(LanguageMode::v6))
     addMissingImport(loc, D, where);
 
   // If limited by an import, note which one.
@@ -496,7 +498,7 @@ TypeChecker::diagnoseConformanceExportability(SourceLoc loc,
 
   if (!ctx.LangOpts.hasFeature(Feature::StrictAccessControl) &&
       originKind == DisallowedOriginKind::MissingImport &&
-      !ctx.isLanguageModeAtLeast(6))
+      !ctx.isLanguageModeAtLeast(LanguageMode::v6))
     addMissingImport(loc, ext, where);
 
   // If limited by an import, note which one.

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -334,7 +334,7 @@ void AccessControlCheckerBase::checkTypeAccessImpl(
     // TypeRepr into account).
 
     if (typeRepr && mayBeInferred &&
-        !Context.isLanguageModeAtLeast(5) &&
+        !Context.isLanguageModeAtLeast(LanguageMode::v5) &&
         !useDC->getParentModule()->isResilient()) {
       // Swift 4.2 and earlier didn't check the Type when a TypeRepr was
       // present. However, this is a major hole when generic parameters are
@@ -557,7 +557,7 @@ void AccessControlCheckerBase::checkGenericParamAccess(
     downgradeToWarning = DowngradeToWarning::Yes;
 
   if (checkUsableFromInline) {
-    if (!Context.isLanguageModeAtLeast(5))
+    if (!Context.isLanguageModeAtLeast(LanguageMode::v5))
       downgradeToWarning = DowngradeToWarning::Yes;
 
     auto diagID = diag::generic_param_usable_from_inline;
@@ -956,7 +956,7 @@ public:
 
         // Swift versions before 5.0 did not check requirements on the
         // protocol's where clause, so emit a warning.
-        if (!assocType->getASTContext().isLanguageModeAtLeast(5))
+        if (!assocType->getASTContext().isLanguageModeAtLeast(LanguageMode::v5))
           downgradeToWarning = DowngradeToWarning::Yes;
       }
     });
@@ -1040,7 +1040,7 @@ public:
 
       auto outerDowngradeToWarning = DowngradeToWarning::No;
       if (superclassDecl->isGenericContext() &&
-          !CD->getASTContext().isLanguageModeAtLeast(5)) {
+          !CD->getASTContext().isLanguageModeAtLeast(LanguageMode::v5)) {
         // Swift 4 failed to properly check this if the superclass was generic,
         // because the above loop was too strict.
         outerDowngradeToWarning = DowngradeToWarning::Yes;
@@ -1141,7 +1141,8 @@ public:
               declKind = declKindForType(type);
               // Swift versions before 5.0 did not check requirements on the
               // protocol's where clause, so emit a warning.
-              if (!proto->getASTContext().isLanguageModeAtLeast(5))
+              if (!proto->getASTContext().isLanguageModeAtLeast(
+                      LanguageMode::v5))
                 downgradeToWarning = DowngradeToWarning::Yes;
             }
           });
@@ -1442,7 +1443,7 @@ public:
       : AccessControlCheckerBase(/*checkUsableFromInline=*/true) {}
 
   void visit(Decl *D) {
-    if (!D->getASTContext().isLanguageModeAtLeast(4, 2))
+    if (!D->getASTContext().isLanguageModeAtLeast(LanguageMode::v4_2))
       return;
 
     if (D->isInvalid() || D->isImplicit())
@@ -1529,7 +1530,7 @@ public:
           auto diagID = diag::pattern_type_not_usable_from_inline_inferred;
           if (fixedLayoutStructContext) {
             diagID = diag::pattern_type_not_usable_from_inline_inferred_frozen;
-          } else if (!Ctx.isLanguageModeAtLeast(5)) {
+          } else if (!Ctx.isLanguageModeAtLeast(LanguageMode::v5)) {
             diagID = diag::pattern_type_not_usable_from_inline_inferred_warn;
           }
           Ctx.Diags.diagnose(NP->getLoc(), diagID, theVar->isLet(),
@@ -1568,7 +1569,7 @@ public:
           auto diagID = diag::pattern_type_not_usable_from_inline;
           if (fixedLayoutStructContext)
             diagID = diag::pattern_type_not_usable_from_inline_frozen;
-          else if (!Ctx.isLanguageModeAtLeast(5))
+          else if (!Ctx.isLanguageModeAtLeast(LanguageMode::v5))
             diagID = diag::pattern_type_not_usable_from_inline_warn;
           auto diag = Ctx.Diags.diagnose(TP->getLoc(), diagID, anyVar->isLet(),
                                          isTypeContext);
@@ -1624,7 +1625,7 @@ public:
                         DowngradeToWarning downgradeToWarning,
                         ImportAccessLevel importLimit) {
       auto diagID = diag::type_alias_underlying_type_not_usable_from_inline;
-      if (!TAD->getASTContext().isLanguageModeAtLeast(5))
+      if (!TAD->getASTContext().isLanguageModeAtLeast(LanguageMode::v5))
         diagID = diag::type_alias_underlying_type_not_usable_from_inline_warn;
       auto diag = TAD->diagnose(diagID);
       highlightOffendingType(diag, complainRepr);
@@ -1646,7 +1647,7 @@ public:
             DowngradeToWarning downgradeDiag,
                           ImportAccessLevel importLimit) {
         auto diagID = diag::associated_type_not_usable_from_inline;
-        if (!assocType->getASTContext().isLanguageModeAtLeast(5))
+        if (!assocType->getASTContext().isLanguageModeAtLeast(LanguageMode::v5))
           diagID = diag::associated_type_not_usable_from_inline_warn;
         auto diag = assocType->diagnose(diagID, ACEK_Requirement);
         highlightOffendingType(diag, complainRepr);
@@ -1661,7 +1662,7 @@ public:
                         DowngradeToWarning downgradeDiag,
                         ImportAccessLevel importLimit) {
       auto diagID = diag::associated_type_not_usable_from_inline;
-      if (!assocType->getASTContext().isLanguageModeAtLeast(5))
+      if (!assocType->getASTContext().isLanguageModeAtLeast(LanguageMode::v5))
         diagID = diag::associated_type_not_usable_from_inline_warn;
       auto diag = assocType->diagnose(diagID, ACEK_DefaultDefinition);
       highlightOffendingType(diag, complainRepr);
@@ -1679,7 +1680,7 @@ public:
                                  DowngradeToWarning downgradeDiag,
                                  ImportAccessLevel importLimit) {
         auto diagID = diag::associated_type_not_usable_from_inline;
-        if (!assocType->getASTContext().isLanguageModeAtLeast(5))
+        if (!assocType->getASTContext().isLanguageModeAtLeast(LanguageMode::v5))
           diagID = diag::associated_type_not_usable_from_inline_warn;
         auto diag = assocType->diagnose(diagID, ACEK_Requirement);
         highlightOffendingType(diag, complainRepr);
@@ -1710,7 +1711,7 @@ public:
                           DowngradeToWarning downgradeToWarning,
                           ImportAccessLevel importLimit) {
         auto diagID = diag::enum_raw_type_not_usable_from_inline;
-        if (!ED->getASTContext().isLanguageModeAtLeast(5))
+        if (!ED->getASTContext().isLanguageModeAtLeast(LanguageMode::v5))
           diagID = diag::enum_raw_type_not_usable_from_inline_warn;
         auto diag = ED->diagnose(diagID);
         highlightOffendingType(diag, complainRepr);
@@ -1755,7 +1756,7 @@ public:
                           DowngradeToWarning downgradeToWarning,
                           ImportAccessLevel importLimit) {
         auto diagID = diag::class_super_not_usable_from_inline;
-        if (!CD->getASTContext().isLanguageModeAtLeast(5))
+        if (!CD->getASTContext().isLanguageModeAtLeast(LanguageMode::v5))
           diagID = diag::class_super_not_usable_from_inline_warn;
         auto diag = CD->diagnose(diagID, superclassLocIter->getTypeRepr() !=
                                              complainRepr);
@@ -1779,7 +1780,7 @@ public:
                           DowngradeToWarning downgradeDiag,
                           ImportAccessLevel importLimit) {
         auto diagID = diag::protocol_usable_from_inline;
-        if (!proto->getASTContext().isLanguageModeAtLeast(5))
+        if (!proto->getASTContext().isLanguageModeAtLeast(LanguageMode::v5))
           diagID = diag::protocol_usable_from_inline_warn;
         auto diag = proto->diagnose(diagID, PCEK_Refine);
         highlightOffendingType(diag, complainRepr);
@@ -1798,7 +1799,7 @@ public:
                                  DowngradeToWarning downgradeDiag,
                                  ImportAccessLevel importLimit) {
         auto diagID = diag::protocol_usable_from_inline;
-        if (!proto->getASTContext().isLanguageModeAtLeast(5))
+        if (!proto->getASTContext().isLanguageModeAtLeast(LanguageMode::v5))
           diagID = diag::protocol_usable_from_inline_warn;
         auto diag = proto->diagnose(diagID, PCEK_Requirement);
         highlightOffendingType(diag, complainRepr);
@@ -1817,7 +1818,7 @@ public:
               DowngradeToWarning downgradeDiag,
               ImportAccessLevel importLimit) {
             auto diagID = diag::subscript_type_usable_from_inline;
-            if (!SD->getASTContext().isLanguageModeAtLeast(5))
+            if (!SD->getASTContext().isLanguageModeAtLeast(LanguageMode::v5))
               diagID = diag::subscript_type_usable_from_inline_warn;
             auto diag = SD->diagnose(diagID, /*problemIsElement=*/false);
             highlightOffendingType(diag, complainRepr);
@@ -1832,7 +1833,7 @@ public:
                         DowngradeToWarning downgradeDiag,
                         ImportAccessLevel importLimit) {
       auto diagID = diag::subscript_type_usable_from_inline;
-      if (!SD->getASTContext().isLanguageModeAtLeast(5))
+      if (!SD->getASTContext().isLanguageModeAtLeast(LanguageMode::v5))
         diagID = diag::subscript_type_usable_from_inline_warn;
       auto diag = SD->diagnose(diagID, /*problemIsElement=*/true);
       highlightOffendingType(diag, complainRepr);
@@ -1868,7 +1869,8 @@ public:
                   DowngradeToWarning downgradeDiag,
                   ImportAccessLevel importLimit) {
                 auto diagID = diag::function_type_usable_from_inline;
-                if (!fn->getASTContext().isLanguageModeAtLeast(5))
+                if (!fn->getASTContext().isLanguageModeAtLeast(
+                        LanguageMode::v5))
                   diagID = diag::function_type_usable_from_inline_warn;
                 auto diag = fn->diagnose(diagID, functionKind,
                                          /*problemIsResult=*/false,
@@ -1885,7 +1887,7 @@ public:
               DowngradeToWarning downgradeDiag,
               ImportAccessLevel importLimit) {
             auto diagID = diag::function_type_usable_from_inline;
-            if (!fn->getASTContext().isLanguageModeAtLeast(5))
+            if (!fn->getASTContext().isLanguageModeAtLeast(LanguageMode::v5))
               diagID = diag::function_type_usable_from_inline_warn;
             auto diag = fn->diagnose(diagID, functionKind,
                                      /*problemIsResult=*/false,
@@ -1903,7 +1905,7 @@ public:
                           DowngradeToWarning downgradeDiag,
                           ImportAccessLevel importLimit) {
         auto diagID = diag::function_type_usable_from_inline;
-        if (!fn->getASTContext().isLanguageModeAtLeast(5))
+        if (!fn->getASTContext().isLanguageModeAtLeast(LanguageMode::v5))
           diagID = diag::function_type_usable_from_inline_warn;
         auto diag = fn->diagnose(diagID, functionKind,
                                  /*problemIsResult=*/true,
@@ -1928,7 +1930,7 @@ public:
               DowngradeToWarning downgradeToWarning,
               ImportAccessLevel importLimit) {
             auto diagID = diag::enum_case_usable_from_inline;
-            if (!EED->getASTContext().isLanguageModeAtLeast(5))
+            if (!EED->getASTContext().isLanguageModeAtLeast(LanguageMode::v5))
               diagID = diag::enum_case_usable_from_inline_warn;
             auto diag = EED->diagnose(diagID);
             highlightOffendingType(diag, complainRepr);
@@ -2063,7 +2065,7 @@ swift::getDisallowedOriginKind(const Decl *decl,
     // just in this case.
     if (!Context.LangOpts.hasFeature(Feature::StrictAccessControl) &&
         howImported == RestrictedImportKind::MissingImport &&
-        !Context.isLanguageModeAtLeast(6) &&
+        !Context.isLanguageModeAtLeast(LanguageMode::v6) &&
         !SF->hasImportsWithFlag(ImportFlags::ImplementationOnly)) {
       downgradeToWarning = DowngradeToWarning::Yes;
     }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1334,7 +1334,7 @@ void AttributeChecker::visitAccessControlAttr(AccessControlAttr *attr) {
             diagnose(attr->getLocation(),
                      diag::access_control_non_objc_open_member, VD)
                 .fixItReplace(attr->getRange(), "public")
-                .warnUntilFutureLanguageMode();
+                .warnUntilLanguageMode(LanguageMode::future);
           }
         }
       }
@@ -2225,8 +2225,8 @@ visitDynamicMemberLookupAttr(DynamicMemberLookupAttr *attr) {
     });
 
     if (candidates.empty()) {
-      auto futureVersion = version::Version::getFutureMajorLanguageVersion();
-      bool shouldError = ctx.isLanguageModeAtLeast(futureVersion);
+      const auto languageModeForError = LanguageMode::future;
+      bool shouldError = ctx.isLanguageModeAtLeast(languageModeForError);
 
       // Diagnose as an error in resilient modules regardless of language
       // version since this will break the swiftinterface. Don't diagnose
@@ -2241,7 +2241,7 @@ visitDynamicMemberLookupAttr(DynamicMemberLookupAttr *attr) {
                   requiredAccessScope.requiredAccessForDiagnostics(),
                   /*isForSetter=*/false, /*useDefaultAccess=*/false,
                   /*updateAttr=*/false);
-      diag.warnUntilLanguageModeIf(!shouldError, futureVersion);
+      diag.warnUntilLanguageModeIf(!shouldError, languageModeForError);
 
       if (shouldError) {
         attr->setInvalid();
@@ -3059,7 +3059,7 @@ void AttributeChecker::checkApplicationMainAttribute(DeclAttribute *attr,
     diagnose(attr->getLocation(),
              diag::attr_ApplicationMain_deprecated,
              applicationMainKind)
-        .warnUntilLanguageMode(6);
+        .warnUntilLanguageMode(LanguageMode::v6);
 
     diagnose(attr->getLocation(),
              diag::attr_ApplicationMain_deprecated_use_attr_main)
@@ -5662,7 +5662,7 @@ Type TypeChecker::checkReferenceOwnershipAttr(VarDecl *var, Type type,
     // properties of Objective-C protocols.
     auto D = diag::ownership_invalid_in_protocols;
     Diags.diagnose(attr->getLocation(), D, ownershipKind)
-        .warnUntilLanguageMode(5)
+        .warnUntilLanguageMode(LanguageMode::v5)
         .fixItRemove(attr->getRange());
     attr->setInvalid();
   }
@@ -7946,7 +7946,7 @@ void AttributeChecker::visitSendableAttr(SendableAttr *attr) {
     if (isolation.isActorIsolated()) {
       diagnoseAndRemoveAttr(attr, diag::sendable_isolated_sync_function,
                             isolation, value)
-          .warnUntilLanguageMode(6);
+          .warnUntilLanguageMode(LanguageMode::v6);
     }
   }
   // Prevent Sendable Attr from being added to methods of non-sendable types
@@ -8030,12 +8030,12 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
         if (var->supportsMutation() && !attr->isUnsafe() && !canBeNonisolated) {
           if (var->hasAttachedPropertyWrapper()) {
             diagnoseAndRemoveAttr(attr, diag::nonisolated_mutable_storage)
-                .warnUntilLanguageModeIf(attr->isImplicit(), 6)
+                .warnUntilLanguageModeIf(attr->isImplicit(), LanguageMode::v6)
                 .fixItInsertAfter(attr->getRange().End, "(unsafe)");
             return;
           } else if (var->getAttrs().hasAttribute<LazyAttr>()) {
             diagnoseAndRemoveAttr(attr, diag::nonisolated_mutable_storage)
-                .warnUntilLanguageMode(6)
+                .warnUntilLanguageMode(LanguageMode::v6)
                 .fixItInsertAfter(attr->getRange().End, "(unsafe)");
             return;
           } else {
@@ -8116,7 +8116,7 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
         if (!ctor->hasAsync()) {
           // the isolation for a synchronous init cannot be `nonisolated`.
           diagnoseAndRemoveAttr(attr, diag::nonisolated_actor_sync_init)
-              .warnUntilLanguageMode(6);
+              .warnUntilLanguageMode(LanguageMode::v6);
           return;
         }
       }
@@ -8242,7 +8242,7 @@ void AttributeChecker::visitInheritActorContextAttr(
     diagnose(attr->getLocation(),
              diag::inherit_actor_context_only_on_sending_or_Sendable_params,
              attr)
-        .warnUntilFutureLanguageMode();
+        .warnUntilLanguageMode(LanguageMode::future);
   }
 
   // Either `async` or `@isolated(any)`.
@@ -8251,7 +8251,7 @@ void AttributeChecker::visitInheritActorContextAttr(
         attr,
         diag::inherit_actor_context_only_on_async_or_isolation_erased_params,
         attr)
-        .warnUntilFutureLanguageMode();
+        .warnUntilLanguageMode(LanguageMode::future);
   }
 }
 
@@ -8335,7 +8335,7 @@ void AttributeChecker::visitUnsafeInheritExecutorAttr(
     bool inConcurrencyModule = D->getDeclContext()->getParentModule()->getName()
         .str() == "_Concurrency";
     auto diag = fn->diagnose(diag::unsafe_inherits_executor_deprecated);
-    diag.warnUntilLanguageMode(6);
+    diag.warnUntilLanguageMode(LanguageMode::v6);
     diag.limitBehaviorIf(inConcurrencyModule, DiagnosticBehavior::Warning);
     replaceUnsafeInheritExecutorWithDefaultedIsolationParam(fn, diag);
   }
@@ -8718,7 +8718,7 @@ public:
                    diag::isolated_parameter_closure_combined_global_actor_attr,
                    param->getName())
               .fixItRemove(attr->getRangeWithAt())
-              .warnUntilLanguageMode(6);
+              .warnUntilLanguageMode(LanguageMode::v6);
           attr->setInvalid();
           break; // don't need to complain about this more than once.
         }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3740,7 +3740,7 @@ void AttributeChecker::visitUsableFromInlineAttr(UsableFromInlineAttr *attr) {
 
   // On internal declarations, @inlinable implies @usableFromInline.
   if (VD->getAttrs().hasAttribute<InlinableAttr>()) {
-    if (Ctx.isLanguageModeAtLeast(4, 2))
+    if (Ctx.isLanguageModeAtLeast(LanguageMode::v4_2))
       diagnoseAndRemoveAttr(attr, diag::inlinable_implies_usable_from_inline,
                             VD);
     return;

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -271,7 +271,7 @@ const {
   if (getExportedLevel() == ExportedLevel::ImplicitlyExported &&
       originKind != DisallowedOriginKind::ImplementationOnlyMemoryLayout &&
       !ctx.LangOpts.hasFeature(Feature::CheckImplementationOnly) &&
-      !ctx.isLanguageModeAtLeast(7))
+      !ctx.isLanguageModeAtLeast(LanguageMode::future))
     return DiagnosticBehavior::Warning;
 
   return DiagnosticBehavior::Error;

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1098,7 +1098,7 @@ static bool diagnosePotentialUnavailability(
     } else if (behaviorLimit >= DiagnosticBehavior::Warning) {
       err.limitBehavior(behaviorLimit);
     } else if (!ctx.LangOpts.hasFeature(Feature::StrictAccessControl)) {
-      err.warnUntilLanguageMode(6);
+      err.warnUntilLanguageMode(LanguageMode::v6);
     }
 
     // Direct a fixit to the error if an existing guard is nearly-correct
@@ -1797,7 +1797,8 @@ bool diagnoseExplicitUnavailability(SourceLoc loc,
                 shouldHideDomainNameForConstraintDiagnostic(constraint),
                 domainAndRange.getDomain(), EncodedMessage.Message)
       .limitBehaviorWithPreconcurrency(behavior, preconcurrency)
-      .warnUntilLanguageModeIf(warnIfConformanceUnavailablePreSwift6, 6);
+      .warnUntilLanguageModeIf(warnIfConformanceUnavailablePreSwift6,
+                               LanguageMode::v6);
 
   switch (constraint.getReason()) {
   case AvailabilityConstraint::Reason::UnavailableUnconditionally:
@@ -2981,9 +2982,9 @@ diagnoseDeclAsyncAvailability(const ValueDecl *D, SourceRange R,
       diag.limitBehavior(DiagnosticBehavior::Warning);
     } else if (!ctx.LangOpts.hasFeature(Feature::StrictAccessControl)) {
       if (shouldWarnUntilFutureVersion()) {
-        diag.warnUntilFutureLanguageMode();
+        diag.warnUntilLanguageMode(LanguageMode::future);
       } else {
-        diag.warnUntilLanguageMode(6);
+        diag.warnUntilLanguageMode(LanguageMode::v6);
       }
     }
 
@@ -3007,9 +3008,9 @@ diagnoseDeclAsyncAvailability(const ValueDecl *D, SourceRange R,
                                    attr->Message);
     if (!ctx.LangOpts.hasFeature(Feature::StrictAccessControl)) {
       if (shouldWarnUntilFutureVersion()) {
-        diag.warnUntilFutureLanguageMode();
+        diag.warnUntilLanguageMode(LanguageMode::future);
       } else {
-        diag.warnUntilLanguageMode(6);
+        diag.warnUntilLanguageMode(LanguageMode::v6);
       }
     }
   }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -484,7 +484,7 @@ GlobalActorAttributeRequest::evaluate(
         }
 
         // In Swift 6, once the diag above is an error, it is disallowed.
-        if (ctx.isLanguageModeAtLeast(6))
+        if (ctx.isLanguageModeAtLeast(LanguageMode::v6))
           return std::nullopt;
       }
     }
@@ -953,7 +953,7 @@ bool swift::diagnoseSendabilityErrorBasedOn(
 
         ctx.Diags
             .diagnose(importLoc, diag::add_predates_concurrency_import,
-                      ctx.isLanguageModeAtLeast(6),
+                      ctx.isLanguageModeAtLeast(LanguageMode::v6),
                       nominal->getParentModule()->getName())
             .fixItInsert(importLoc, "@preconcurrency ");
 
@@ -1949,7 +1949,7 @@ static bool memberAccessHasSpecialPermissionInSwift5(
     ValueDecl const *member, SourceLoc memberLoc,
     std::optional<VarRefUseEnv> useKind) {
   // no need for this in Swift 6+
-  if (refCxt->getASTContext().isLanguageModeAtLeast(6))
+  if (refCxt->getASTContext().isLanguageModeAtLeast(LanguageMode::v6))
     return false;
 
   // must be an access to an instance member.
@@ -6162,7 +6162,8 @@ computeDefaultInferredActorIsolation(ValueDecl *value) {
               // having to explicitly state `@MainActor`.
               auto isolation =
                   ActorIsolation::forGlobalActor(globalActor)
-                      .withPreconcurrency(!ctx.isLanguageModeAtLeast(6));
+                      .withPreconcurrency(
+                          !ctx.isLanguageModeAtLeast(LanguageMode::v6));
               return {{{isolation, {}}, nullptr, {}}};
             }
 
@@ -6195,9 +6196,9 @@ computeDefaultInferredActorIsolation(ValueDecl *value) {
           // Preconcurrency here is used to stage the diagnostics
           // when users select `@MainActor` default isolation with
           // non-strict concurrency modes (pre Swift 6).
-          auto isolation =
-              ActorIsolation::forGlobalActor(globalActor)
-                  .withPreconcurrency(!ctx.isLanguageModeAtLeast(6));
+          auto isolation = ActorIsolation::forGlobalActor(globalActor)
+                               .withPreconcurrency(!ctx.isLanguageModeAtLeast(
+                                   LanguageMode::v6));
           return {{{isolation, {}}, nullptr, {}}};
       }
 

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -557,7 +557,7 @@ bool diagnoseIfAnyNonSendableTypes(
 
         if (!diagnosed) {
           ctx.Diags.diagnose(diagnoseLoc, diag, type, diagArgs...)
-              .limitBehaviorUntilLanguageMode(behavior, 6)
+              .limitBehaviorUntilLanguageMode(behavior, LanguageMode::v6)
               .limitBehaviorIf(preconcurrency);
           diagnosed = true;
         }

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -520,7 +520,7 @@ Type TypeChecker::typeCheckParameterDefault(Expr *&defaultValue,
       if (!anchor->hasCurriedSelf() || ctx.isAtLeastFutureMajorLanguageMode())
         return Type();
 
-      diag.warnUntilFutureLanguageMode();
+      diag.warnUntilLanguageMode(LanguageMode::future);
     }
   }
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -517,7 +517,8 @@ Type TypeChecker::typeCheckParameterDefault(Expr *&defaultValue,
 
       // In Swift 6.2 and below we incorrectly missed checking this rule for
       // methods, downgrade to a warning until the next language mode.
-      if (!anchor->hasCurriedSelf() || ctx.isAtLeastFutureMajorLanguageMode())
+      if (!anchor->hasCurriedSelf() ||
+          ctx.isLanguageModeAtLeast(LanguageMode::future))
         return Type();
 
       diag.warnUntilLanguageMode(LanguageMode::future);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -413,7 +413,7 @@ InitKindRequest::evaluate(Evaluator &evaluator, ConstructorDecl *decl) const {
                         "actors")
               .fixItRemove(convenAttr->getLocation())
               .warnInSwiftInterface(dc)
-              .warnUntilLanguageMode(6);
+              .warnUntilLanguageMode(LanguageMode::v6);
 
         } else { // not an actor
           // Forbid convenience inits on Foreign CF types, as Swift does not yet

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -314,7 +314,7 @@ static bool inferFinalAndDiagnoseIfNeeded(ValueDecl *D, ClassDecl *cls,
   if (D->getFormalAccess() == AccessLevel::Open) {
     auto &context = D->getASTContext();
     auto diagID = diag::implicitly_final_cannot_be_open;
-    if (!context.isLanguageModeAtLeast(5))
+    if (!context.isLanguageModeAtLeast(LanguageMode::v5))
       diagID = diag::implicitly_final_cannot_be_open_swift4;
     auto inFlightDiag = context.Diags.diagnose(D, diagID,
                                     static_cast<unsigned>(reason.value()));
@@ -641,7 +641,7 @@ BodyInitKindRequest::evaluate(Evaluator &evaluator,
       // be delegating because, well, we don't know the layout.
       // A dynamic replacement is permitted to be non-delegating.
       if (NTD->isResilient() ||
-          (ctx.isLanguageModeAtLeast(5) &&
+          (ctx.isLanguageModeAtLeast(LanguageMode::v5) &&
            !decl->getAttrs().getAttribute<DynamicReplacementAttr>())) {
         if (decl->getParentModule() != NTD->getParentModule())
           Kind = BodyInitKind::Delegating;
@@ -843,7 +843,7 @@ IsFinalRequest::evaluate(Evaluator &evaluator, ValueDecl *decl) const {
           if (VD->getFormalAccess() == AccessLevel::Open) {
             auto &context = decl->getASTContext();
             auto diagID = diag::implicitly_final_cannot_be_open;
-            if (!context.isLanguageModeAtLeast(5))
+            if (!context.isLanguageModeAtLeast(LanguageMode::v5))
               diagID = diag::implicitly_final_cannot_be_open_swift4;
             auto inFlightDiag =
               context.Diags.diagnose(decl, diagID,

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -2882,11 +2882,11 @@ bool swift::diagnoseObjCMethodConflicts(SourceFile &sf) {
       // conflict checking and have to be diagnosed as warnings in Swift 5:
 
       // * Selectors for imported methods with async variants.
-      bool breakingInSwift5 = originalIsImportedAsync;
-      
+      bool breakingPreSwift6 = originalIsImportedAsync;
+
       // * Protocol requirements
       if (!isa<ClassDecl>(conflict.typeDecl))
-        breakingInSwift5 = true;
+        breakingPreSwift6 = true;
 
       bool redeclSame = (diagInfo == origDiagInfo);
       auto diag = Ctx.Diags.diagnose(conflictingDecl,
@@ -2895,7 +2895,7 @@ bool swift::diagnoseObjCMethodConflicts(SourceFile &sf) {
                                      diagInfo.first, diagInfo.second,
                                      origDiagInfo.first, origDiagInfo.second,
                                      conflict.selector);
-      diag.warnUntilLanguageModeIf(breakingInSwift5, 6);
+      diag.warnUntilLanguageModeIf(breakingPreSwift6, LanguageMode::v6);
 
       // Temporarily soften selector conflicts in objcImpl extensions; we're
       // seeing some that are caused by ObjCImplementationChecker improvements.
@@ -3058,7 +3058,7 @@ bool swift::diagnoseObjCCategoryConflicts(SourceFile &sf) {
             .diagnose(catToCheck, diag::objc_redecl_category_name,
                       catToCheck->hasClangNode(), bestCat->hasClangNode(),
                       catName)
-            .warnUntilLanguageMode(6);
+            .warnUntilLanguageMode(LanguageMode::v6);
 
         Ctx.Diags.diagnose(bestCat, diag::invalid_redecl_prev_name, catName);
       }

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -581,7 +581,7 @@ static void diagnoseGeneralOverrideFailure(ValueDecl *decl,
             diags
                 .diagnose(decl, diag::override_sendability_mismatch,
                           decl->getName())
-                .limitBehaviorUntilLanguageMode(limit, 6)
+                .limitBehaviorUntilLanguageMode(limit, LanguageMode::v6)
                 .limitBehaviorIf(
                     fromContext.preconcurrencyBehavior(baseDeclClass));
             return false;
@@ -599,7 +599,7 @@ static void diagnoseGeneralOverrideFailure(ValueDecl *decl,
       diags
           .diagnose(decl, diag::override_global_actor_isolation_mismatch,
                     decl->getName())
-          .limitBehaviorUntilLanguageMode(DiagnosticBehavior::Warning, 6)
+          .warnUntilLanguageMode(LanguageMode::v6)
           .limitBehaviorIf(fromContext.preconcurrencyBehavior(baseDeclClass));
     }
     break;

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1218,7 +1218,7 @@ bool OverrideMatcher::checkOverride(ValueDecl *baseDecl,
   // is helpful in several cases - just not this one.
   auto dc = decl->getDeclContext();
   auto classDecl = dc->getSelfClassDecl();
-  if (decl->getASTContext().isLanguageModeAtLeast(5) &&
+  if (decl->getASTContext().isLanguageModeAtLeast(LanguageMode::v5) &&
       baseDecl->getInterfaceType()->hasDynamicSelfType() &&
       !decl->getInterfaceType()->hasDynamicSelfType() &&
       !classDecl->isSemanticallyFinal()) {
@@ -1929,7 +1929,7 @@ static bool checkSingleOverride(ValueDecl *override, ValueDecl *base) {
          overrideASD->getAttrs().hasAttribute<LazyAttr>()) &&
         !overrideASD->hasObservers()) {
       bool downgradeToWarning = false;
-      if (!ctx.isLanguageModeAtLeast(5) &&
+      if (!ctx.isLanguageModeAtLeast(LanguageMode::v5) &&
           overrideASD->getAttrs().hasAttribute<LazyAttr>()) {
         // Swift 4.0 had a bug where lazy properties were considered
         // computed by the time of this check. Downgrade this diagnostic to

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -321,7 +321,7 @@ static void checkInheritanceClause(
           isa<ProtocolDecl>(decl) &&
           Lexer::getTokenAtLocation(ctx.SourceMgr, sourceRange.Start)
               .is(tok::kw_class);
-      if (ctx.isLanguageModeAtLeast(5) && isWrittenAsClass) {
+      if (ctx.isLanguageModeAtLeast(LanguageMode::v5) && isWrittenAsClass) {
         diags
             .diagnose(sourceRange.Start,
                       diag::anyobject_class_inheritance_deprecated)
@@ -335,7 +335,7 @@ static void checkInheritanceClause(
         auto knownIndex = inheritedAnyObject->first;
         auto knownRange = inheritedAnyObject->second;
         SourceRange removeRange = inheritedTypes.getRemovalRange(knownIndex);
-        if (!ctx.isLanguageModeAtLeast(5) &&
+        if (!ctx.isLanguageModeAtLeast(LanguageMode::v5) &&
             isa<ProtocolDecl>(decl) &&
             Lexer::getTokenAtLocation(ctx.SourceMgr, knownRange.Start)
               .is(tok::kw_class)) {

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -150,8 +150,8 @@ public:
                         ctx.getProtocol(*kp))
             // Downgrade to a warning for `~BitwiseCopyable` because it was
             // accepted in some incorrect positions before.
-            .warnUntilFutureLanguageModeIf(kp ==
-                                           KnownProtocolKind::BitwiseCopyable);
+            .warnUntilLanguageModeIf(kp == KnownProtocolKind::BitwiseCopyable,
+                                     LanguageMode::future);
         return Type();
       }
     }
@@ -1896,7 +1896,7 @@ static void diagnoseRetroactiveConformances(
             diags
                 .diagnose(loc, diag::retroactive_attr_does_not_apply, declForDiag,
                           isSameModule)
-                .warnUntilLanguageMode(6)
+                .warnUntilLanguageMode(LanguageMode::v6)
                 .fixItRemove(SourceRange(loc, loc.getAdvancedLoc(1)));
             return TypeWalker::Action::Stop;
           }
@@ -4137,7 +4137,7 @@ void TypeChecker::checkParameterList(ParameterList *params,
           // cannot have more than one isolated parameter (SE-0313)
           param->diagnose(diag::isolated_parameter_duplicate)
               .highlight(param->getSourceRange())
-              .warnUntilLanguageMode(6);
+              .warnUntilLanguageMode(LanguageMode::v6);
           // I'd love to describe the context in which there is an isolated parameter,
           // we had a DescriptiveDeclContextKind, but that only
           // exists for Decls.

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -3218,7 +3218,8 @@ public:
 
     Diags.diagnose(loc, message)
         .highlight(highlight)
-        .warnUntilLanguageModeIf(classification.shouldDowngradeToWarning(), 6);
+        .warnUntilLanguageModeIf(classification.shouldDowngradeToWarning(),
+                                 LanguageMode::v6);
     maybeAddRethrowsNote(Diags, loc, reason);
 
     // If this is a call without expected 'try[?|!]', like this:
@@ -4795,7 +4796,7 @@ private:
       return;
 
     Ctx.Diags.diagnose(anchor->getStartLoc(), diag::async_expr_without_await)
-        .warnUntilLanguageModeIf(downgradeToWarning, 6)
+        .warnUntilLanguageModeIf(downgradeToWarning, LanguageMode::v6)
         .fixItInsert(loc, insertText)
         .highlight(anchor->getSourceRange());
 
@@ -4898,7 +4899,8 @@ private:
       Ctx.Diags
           .diagnose(loc, diag::actor_isolated_access_outside_of_actor_context,
                     declIsolation, declRef.getDecl(), isCall)
-          .warnUntilLanguageModeIf(errorInfo.downgradeToWarning, 6)
+          .warnUntilLanguageModeIf(errorInfo.downgradeToWarning,
+                                   LanguageMode::v6)
           .fixItInsert(fixItLoc, insertText)
           .highlight(anchor->getSourceRange());
       return true;

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -375,7 +375,7 @@ static bool checkProtocolSelfRequirementsImpl(
                        secondType.getString())
         // FIXME: This should become an unconditional error since violating
         // this invariant can introduce compiler and run time crashes.
-        .warnUntilFutureLanguageModeIf(downgrade);
+        .warnUntilLanguageModeIf(downgrade, LanguageMode::future);
     return true;
   }
 
@@ -717,7 +717,7 @@ void TypeChecker::checkShadowedGenericParams(GenericContext *dc) {
       } else {
         genericParamDecl
             ->diagnose(diag::shadowed_generic_param, genericParamDecl)
-            .warnUntilLanguageMode(6);
+            .warnUntilLanguageMode(LanguageMode::v6);
       }
 
       if (existingParamDecl->getLoc()) {

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -700,7 +700,7 @@ static void validateMacroExpansion(SourceFile *expansionBuffer,
       auto *var = dyn_cast<VarDecl>(attachedTo);
       if (var && var->isLet()) {
         ctx.Diags.diagnose(var->getLoc(), diag::let_accessor_expansion)
-            .warnUntilLanguageMode(6);
+            .warnUntilLanguageMode(LanguageMode::v6);
       }
 
       continue;

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1087,7 +1087,7 @@ NullablePtr<Pattern> TypeChecker::trySimplifyExprPattern(ExprPattern *EP,
                     patternTy)
           .warnUntilLanguageMode(LanguageMode::v6);
 
-      if (ctx.isLanguageModeAtLeast(6))
+      if (ctx.isLanguageModeAtLeast(LanguageMode::v6))
         return nullptr;
     }
   }

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1085,7 +1085,7 @@ NullablePtr<Pattern> TypeChecker::trySimplifyExprPattern(ExprPattern *EP,
       ctx.Diags
           .diagnose(NLE->getLoc(), diag::value_type_comparison_with_nil_illegal,
                     patternTy)
-          .warnUntilLanguageMode(6);
+          .warnUntilLanguageMode(LanguageMode::v6);
 
       if (ctx.isLanguageModeAtLeast(6))
         return nullptr;

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -790,7 +790,7 @@ RequirementMatch swift::matchWitness(
       // If our requirement says that it has a sending result, then our witness
       // must also have a sending result since otherwise, in generic contexts,
       // we would be returning non-disconnected values as disconnected.
-      if (dc->getASTContext().isLanguageModeAtLeast(6)) {
+      if (dc->getASTContext().isLanguageModeAtLeast(LanguageMode::v6)) {
         if (reqFnType->hasExtInfo() && reqFnType->hasSendingResult() &&
             (!witnessFnType->hasExtInfo() || !witnessFnType->hasSendingResult()))
           return RequirementMatch(witness, MatchKind::TypeConflict, witnessType);
@@ -830,7 +830,7 @@ RequirementMatch swift::matchWitness(
 
       // If we have a requirement without sending and our witness expects a
       // sending parameter, error.
-      if (dc->getASTContext().isLanguageModeAtLeast(6)) {
+      if (dc->getASTContext().isLanguageModeAtLeast(LanguageMode::v6)) {
         if (!reqParams[i].getParameterFlags().isSending() &&
             witnessParams[i].getParameterFlags().isSending())
           return RequirementMatch(witness, MatchKind::TypeConflict, witnessType);
@@ -2591,7 +2591,7 @@ checkIndividualConformance(NormalProtocolConformance *conformance) {
   if (Proto->isSpecificProtocol(KnownProtocolKind::Sendable)) {
     // In -swift-version 5 mode, a conditional conformance to a protocol can imply
     // a Sendable conformance.
-    if (!Context.isLanguageModeAtLeast(6))
+    if (!Context.isLanguageModeAtLeast(LanguageMode::v6))
       allowImpliedConditionalConformance = true;
   } else if (Proto->isMarkerProtocol()) {
     allowImpliedConditionalConformance = true;
@@ -3054,9 +3054,9 @@ diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
     break;
 
   case MatchKind::RequiresNonSendable:
-    diags.diagnose(match.Witness, diag::protocol_witness_non_sendable,
-                   withAssocTypes,
-                   module->getASTContext().isLanguageModeAtLeast(6));
+    diags.diagnose(
+        match.Witness, diag::protocol_witness_non_sendable, withAssocTypes,
+        module->getASTContext().isLanguageModeAtLeast(LanguageMode::v6));
     break;
 
   case MatchKind::RenamedMatch: {
@@ -4477,7 +4477,7 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
       //
       // Work around this by discarding the witness if its not sufficiently
       // visible.
-      if (!getASTContext().isLanguageModeAtLeast(5))
+      if (!getASTContext().isLanguageModeAtLeast(LanguageMode::v5))
         if (requirement->getAttrs().hasAttribute<OptionalAttr>())
           return ResolveWitnessResult::Missing;
 

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -1167,20 +1167,20 @@ namespace {
             DE.diagnose(startLoc, diag::non_exhaustive_switch_unknown_only,
                         subjectType, shouldIncludeFutureVersionComment);
 
-        auto shouldWarnUntilVersion = [&theEnum]() -> unsigned {
+        auto languageModeForError = [&theEnum]() -> LanguageMode {
           if (theEnum) {
             // Presence of `@nonexhaustive(warn)` pushes the warning farther,
             // into the future.
             if (auto *nonexhaustive =
                     theEnum->getAttrs().getAttribute<NonexhaustiveAttr>()) {
               if (nonexhaustive->getMode() == NonexhaustiveMode::Warning)
-                return swift::version::Version::getFutureMajorLanguageVersion();
+                return LanguageMode::future;
             }
           }
-          return 6;
+          return LanguageMode::v6;
         };
 
-        diag.warnUntilLanguageMode(shouldWarnUntilVersion());
+        diag.warnUntilLanguageMode(languageModeForError());
 
         mainDiagType = std::nullopt;
       }

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4318,7 +4318,7 @@ NeverNullType TypeResolver::resolveASTFunctionType(
   unsigned numIsolatedParams = countIsolatedParamsUpTo(repr, 2);
   if (!repr->isWarnedAbout() && numIsolatedParams > 1) {
     diagnose(repr->getLoc(), diag::isolated_parameter_duplicate_type)
-        .warnUntilLanguageMode(6);
+        .warnUntilLanguageMode(LanguageMode::v6);
 
     if (ctx.isLanguageModeAtLeast(6))
       return ErrorType::get(ctx);
@@ -4333,7 +4333,7 @@ NeverNullType TypeResolver::resolveASTFunctionType(
     if (globalActor && !globalActor->hasError() && !globalActorAttr->isInvalid()) {
       if (numIsolatedParams != 0) {
         diagnose(repr->getLoc(), diag::isolated_parameter_global_actor_type)
-            .warnUntilLanguageMode(6);
+            .warnUntilLanguageMode(LanguageMode::v6);
         globalActorAttr->setInvalid();
       } else if (isolatedAttr) {
         diagnose(repr->getLoc(), diag::isolated_attr_global_actor_type,
@@ -5871,6 +5871,7 @@ NeverNullType TypeResolver::resolveImplicitlyUnwrappedOptionalType(
     // In language modes up to Swift 5, we allow `T!` in invalid position for
     // compatibility and downgrade the error to a warning.
     const unsigned swiftLangModeForError = 5;
+    const auto languageModeForError = LanguageMode::v5;
 
     // If we are about to error, mark this node as invalid.
     // This is the only way to indicate that something went wrong without
@@ -5894,7 +5895,7 @@ NeverNullType TypeResolver::resolveImplicitlyUnwrappedOptionalType(
     }
 
     diagnose(repr->getExclamationLoc(), diagID)
-        .warnUntilLanguageMode(swiftLangModeForError);
+        .warnUntilLanguageMode(languageModeForError);
 
     // Suggest a regular optional, but not when `T!` is the right-hand side of
     // a cast expression.

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4320,7 +4320,7 @@ NeverNullType TypeResolver::resolveASTFunctionType(
     diagnose(repr->getLoc(), diag::isolated_parameter_duplicate_type)
         .warnUntilLanguageMode(LanguageMode::v6);
 
-    if (ctx.isLanguageModeAtLeast(6))
+    if (ctx.isLanguageModeAtLeast(LanguageMode::v6))
       return ErrorType::get(ctx);
     else
       repr->setWarned();
@@ -5870,7 +5870,6 @@ NeverNullType TypeResolver::resolveImplicitlyUnwrappedOptionalType(
   if (doDiag && !options.contains(TypeResolutionFlags::SilenceErrors)) {
     // In language modes up to Swift 5, we allow `T!` in invalid position for
     // compatibility and downgrade the error to a warning.
-    const unsigned swiftLangModeForError = 5;
     const auto languageModeForError = LanguageMode::v5;
 
     // If we are about to error, mark this node as invalid.
@@ -5885,12 +5884,12 @@ NeverNullType TypeResolver::resolveImplicitlyUnwrappedOptionalType(
     // Compiler should diagnose both `Int!` and `String!` as invalid,
     // but returning `ErrorType` from here would stop type resolution
     // after `Int!`.
-    if (ctx.isLanguageModeAtLeast(swiftLangModeForError)) {
+    if (ctx.isLanguageModeAtLeast(languageModeForError)) {
       repr->setInvalid();
     }
 
     Diag<> diagID = diag::iuo_deprecated_here;
-    if (ctx.isLanguageModeAtLeast(swiftLangModeForError)) {
+    if (ctx.isLanguageModeAtLeast(languageModeForError)) {
       diagID = diag::iuo_invalid_here;
     }
 

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -3150,7 +3150,8 @@ void ConstraintSystem::resolveOverload(OverloadChoice choice, DeclContext *useDC
           // method without any applications at all, which would get
           // miscompiled into a function with undefined behavior. Warn for
           // source compatibility.
-          bool isWarning = !getASTContext().isLanguageModeAtLeast(5);
+          bool isWarning =
+              !getASTContext().isLanguageModeAtLeast(LanguageMode::v5);
           (void)recordFix(
               AllowInvalidPartialApplication::create(isWarning, *this, locator));
         } else if (level == 1) {

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -296,7 +296,7 @@ Status ModuleFile::associateWithFileContext(FileUnit *file, SourceLoc diagLoc,
 
   StringRef SDKPath = ctx.SearchPathOpts.getSDKPath();
   // In Swift 6 mode, we do not inherit search paths from loaded non-SDK modules.
-  if (!ctx.isLanguageModeAtLeast(6) &&
+  if (!ctx.isLanguageModeAtLeast(LanguageMode::v6) &&
       (SDKPath.empty() ||
        !Core->ModuleInputBuffer->getBufferIdentifier().starts_with(SDKPath))) {
     for (const auto &searchPath : Core->SearchPaths) {

--- a/test/Frontend/features/adoption_mode.swift
+++ b/test/Frontend/features/adoption_mode.swift
@@ -51,7 +51,7 @@
 // CHECK-SWIFT-5-NOT: warning:
 
 // CHECK-SWIFT-6-NOT: warning:
-// CHECK-SWIFT-6-COUNT-8: warning: upcoming feature 'DynamicActorIsolation' is already enabled as of Swift version 6{{$}}
+// CHECK-SWIFT-6-COUNT-8: warning: upcoming feature 'DynamicActorIsolation' already enabled as of the Swift 6 language mode{{$}}
 // CHECK-SWIFT-6-NOT: warning:
 
 // CHECK-NOT: error:

--- a/test/Frontend/features/adoption_mode_adoptable_feature.swift
+++ b/test/Frontend/features/adoption_mode_adoptable_feature.swift
@@ -32,7 +32,7 @@
 // CHECK-SWIFT-5-NOT: warning:
 
 // CHECK-SWIFT-7-NOT: warning:
-// CHECK-SWIFT-7-COUNT-6: warning: upcoming feature 'ExistentialAny' is already enabled as of Swift version 7{{$}}
+// CHECK-SWIFT-7-COUNT-6: warning: upcoming feature 'ExistentialAny' already enabled as of the Swift 7 language mode{{$}}
 // CHECK-SWIFT-7-NOT: warning:
 
 // CHECK-NOT: error:

--- a/test/Frontend/features/upcoming_feature.swift
+++ b/test/Frontend/features/upcoming_feature.swift
@@ -38,7 +38,7 @@
 
 // REQUIRES: swift_feature_ConciseMagicFile
 
-// CHECK: warning: upcoming feature 'ConciseMagicFile' is already enabled as of Swift version 6
+// CHECK: warning: upcoming feature 'ConciseMagicFile' already enabled as of the Swift 6 language mode
 
 #if hasFeature(ConciseMagicFile)
 let x = 0

--- a/test/ModuleInterface/unsupported-configurations.swift
+++ b/test/ModuleInterface/unsupported-configurations.swift
@@ -18,11 +18,11 @@
 // RUN: %target-swift-frontend -typecheck -emit-module-interface-path %t/empty.swiftinterface %s -swift-version 5 -enable-library-evolution 2>&1 | %FileCheck -check-prefix=NEGATIVE -allow-empty %s
 // RUN: ls %t/empty.swiftinterface
 
-// CHECK-DAG: warning: module interfaces are only supported with Swift language version 5 or later (currently using -swift-version [[VERSION]])
+// CHECK-DAG: warning: module interfaces are only supported with the Swift 5 language mode or later (currently using -swift-version [[VERSION]])
 // CHECK-DAG: warning: module interfaces are only supported with -enable-library-evolution
 
 // CHECK-VERSION-ONLY-NOT: warning:
-// CHECK-VERSION-ONLY: warning: module interfaces are only supported with Swift language version 5 or later (currently using -swift-version [[VERSION]])
+// CHECK-VERSION-ONLY: warning: module interfaces are only supported with the Swift 5 language mode or later (currently using -swift-version [[VERSION]])
 // CHECK-VERSION-ONLY-NOT: warning:
 
 // CHECK-EVOLUTION-ONLY-NOT: warning:

--- a/test/sil-opt/upcoming-feature.sil
+++ b/test/sil-opt/upcoming-feature.sil
@@ -5,4 +5,4 @@
 // READ THIS: This test makes sure that we error if an upcoming feature is
 // enabled in a language mode where it is enabled by default.
 
-// CHECK: error: upcoming feature "RegionBasedIsolation" is already enabled as of Swift version 6
+// CHECK: error: upcoming feature "RegionBasedIsolation" already enabled as of the Swift 6 language mode

--- a/unittests/AST/DiagnosticBehaviorTests.cpp
+++ b/unittests/AST/DiagnosticBehaviorTests.cpp
@@ -58,7 +58,7 @@ TEST(DiagnosticBehavior, WarnUntilSwiftLangMode) {
       [](DiagnosticEngine &diags) {
         diags.setLanguageVersion(version::Version({5}));
         diags.diagnose(SourceLoc(), diag::error_immediate_mode_missing_stdlib)
-            .warnUntilLanguageMode(4);
+            .warnUntilLanguageMode(LanguageMode::v4);
       },
       [](DiagnosticEngine &diags, const DiagnosticInfo &info) {
         EXPECT_EQ(info.Kind, DiagnosticKind::Error);
@@ -72,7 +72,7 @@ TEST(DiagnosticBehavior, WarnUntilSwiftLangMode) {
       [](DiagnosticEngine &diags) {
         diags.setLanguageVersion(version::Version({4}));
         diags.diagnose(SourceLoc(), diag::error_immediate_mode_missing_stdlib)
-            .warnUntilLanguageMode(5);
+            .warnUntilLanguageMode(LanguageMode::v5);
       },
       [](DiagnosticEngine &diags, const DiagnosticInfo &info) {
         EXPECT_EQ(info.Kind, DiagnosticKind::Warning);
@@ -90,7 +90,7 @@ TEST(DiagnosticBehavior, WarnUntilSwiftLangMode) {
       [](DiagnosticEngine &diags) {
         diags.setLanguageVersion(version::Version({4}));
         diags.diagnose(SourceLoc(), diag::error_immediate_mode_missing_stdlib)
-            .warnUntilLanguageMode(99);
+            .warnUntilLanguageMode(LanguageMode::future);
       },
       [](DiagnosticEngine &diags, const DiagnosticInfo &info) {
         EXPECT_EQ(info.Kind, DiagnosticKind::Warning);

--- a/unittests/AST/DiagnosticGroupsTests.cpp
+++ b/unittests/AST/DiagnosticGroupsTests.cpp
@@ -107,7 +107,8 @@ TEST(DiagnosticGroups, OverrideBehaviorLimitations) {
 
           diags.diagnose(SourceLoc(), diagnostic);
           diags.diagnose(SourceLoc(), diagnostic)
-              .limitBehaviorUntilLanguageMode(DiagnosticBehavior::Warning, 99);
+              .limitBehaviorUntilLanguageMode(DiagnosticBehavior::Warning,
+                                              LanguageMode::future);
         },
         [](const DiagnosticInfo &info) {
           EXPECT_EQ(info.Kind, DiagnosticKind::Error);
@@ -140,7 +141,8 @@ TEST(DiagnosticGroups, OverrideBehaviorLimitations) {
           diags.setWarningGroupControlRules(rules);
 
           diags.diagnose(SourceLoc(), diagnostic)
-              .limitBehaviorUntilLanguageMode(DiagnosticBehavior::Warning, 99);
+              .limitBehaviorUntilLanguageMode(DiagnosticBehavior::Warning,
+                                              LanguageMode::future);
         },
         [](const DiagnosticInfo &info) {
           EXPECT_EQ(info.Kind, DiagnosticKind::Error);

--- a/unittests/AST/DiagnosticInfoTests.cpp
+++ b/unittests/AST/DiagnosticInfoTests.cpp
@@ -103,7 +103,8 @@ TEST(DiagnosticInfo, PrintDiagnosticNamesMode_Identifier_WrappedDiag) {
         diags.setPrintDiagnosticNamesMode(PrintDiagnosticNamesMode::Identifier);
 
         diags.diagnose(SourceLoc(), diag::error_immediate_mode_missing_stdlib)
-            .limitBehaviorUntilLanguageMode(DiagnosticBehavior::Warning, 99);
+            .limitBehaviorUntilLanguageMode(DiagnosticBehavior::Warning,
+                                            LanguageMode::future);
       },
       [](DiagnosticEngine &diags, const DiagnosticInfo &info) {
         EXPECT_EQ(info.ID, diag::error_in_a_future_swift_lang_mode.ID);
@@ -159,7 +160,8 @@ TEST(DiagnosticInfo, PrintDiagnosticNamesMode_Group_WrappedDiag) {
         TestDiagnostic diagnostic(diag::error_immediate_mode_missing_stdlib.ID,
                                   DiagGroupID::DeprecatedDeclaration);
         diags.diagnose(SourceLoc(), diagnostic)
-            .limitBehaviorUntilLanguageMode(DiagnosticBehavior::Warning, 99);
+            .limitBehaviorUntilLanguageMode(DiagnosticBehavior::Warning,
+                                            LanguageMode::future);
       },
       [](DiagnosticEngine &, const DiagnosticInfo &info) {
         EXPECT_EQ(info.ID, diag::error_in_a_future_swift_lang_mode.ID);
@@ -180,8 +182,10 @@ TEST(DiagnosticInfo, CategoryDeprecation) {
         EXPECT_TRUE(diags.isDeprecationDiagnostic(diag.ID));
 
         diags.diagnose(SourceLoc(), diag);
-        diags.diagnose(SourceLoc(), diag).warnUntilLanguageMode(6);
-        diags.diagnose(SourceLoc(), diag).warnUntilLanguageMode(99);
+        diags.diagnose(SourceLoc(), diag)
+            .warnUntilLanguageMode(LanguageMode::v6);
+        diags.diagnose(SourceLoc(), diag)
+            .warnUntilLanguageMode(LanguageMode::future);
       },
       [](DiagnosticEngine &, const DiagnosticInfo &info) {
         EXPECT_EQ(info.Category, "deprecation");
@@ -197,8 +201,10 @@ TEST(DiagnosticInfo, CategoryNoUsage) {
         EXPECT_TRUE(diags.isNoUsageDiagnostic(diag.ID));
 
         diags.diagnose(SourceLoc(), diag);
-        diags.diagnose(SourceLoc(), diag).warnUntilLanguageMode(6);
-        diags.diagnose(SourceLoc(), diag).warnUntilLanguageMode(99);
+        diags.diagnose(SourceLoc(), diag)
+            .warnUntilLanguageMode(LanguageMode::v6);
+        diags.diagnose(SourceLoc(), diag)
+            .warnUntilLanguageMode(LanguageMode::future);
       },
       [](DiagnosticEngine &, const DiagnosticInfo &info) {
         EXPECT_EQ(info.Category, "no-usage");
@@ -214,9 +220,10 @@ TEST(DiagnosticInfo, CategoryAPIDigesterBreakage) {
         EXPECT_TRUE(diags.isAPIDigesterBreakageDiagnostic(diag.ID));
 
         diags.diagnose(SourceLoc(), diag, StringRef());
-        diags.diagnose(SourceLoc(), diag, StringRef()).warnUntilLanguageMode(6);
         diags.diagnose(SourceLoc(), diag, StringRef())
-            .warnUntilLanguageMode(99);
+            .warnUntilLanguageMode(LanguageMode::v6);
+        diags.diagnose(SourceLoc(), diag, StringRef())
+            .warnUntilLanguageMode(LanguageMode::future);
       },
       [](DiagnosticEngine &, const DiagnosticInfo &info) {
         EXPECT_EQ(info.Category, "api-digester-breaking-change");

--- a/unittests/Basic/CMakeLists.txt
+++ b/unittests/Basic/CMakeLists.txt
@@ -23,6 +23,7 @@ add_swift_unittest(SwiftBasicTests
   FrozenMultiMapTest.cpp
   ImmutablePointerSetTest.cpp
   JSONSerialization.cpp
+  LanguageModeTest.cpp
   OptionSetTest.cpp
   Options.cpp
   OwnedStringTest.cpp

--- a/unittests/Basic/LanguageModeTest.cpp
+++ b/unittests/Basic/LanguageModeTest.cpp
@@ -1,0 +1,83 @@
+//===--- Basic/LanguageModeTest.cpp -----------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Basic/LanguageMode.h"
+#include "gtest/gtest.h"
+
+using namespace swift;
+
+TEST(LanguageMode, isFuture) {
+  EXPECT_FALSE(LanguageMode::v4.isFuture());
+  EXPECT_FALSE(LanguageMode::v4_2.isFuture());
+  EXPECT_FALSE(LanguageMode::v5.isFuture());
+  EXPECT_FALSE(LanguageMode::v6.isFuture());
+  EXPECT_TRUE(LanguageMode::future.isFuture());
+}
+
+TEST(LanguageMode, versionString) {
+  EXPECT_EQ(LanguageMode::v4.versionString(), "4");
+  EXPECT_EQ(LanguageMode::v4_2.versionString(), "4.2");
+  EXPECT_EQ(LanguageMode::v5.versionString(), "5");
+  EXPECT_EQ(LanguageMode::v6.versionString(), "6");
+  EXPECT_EQ(LanguageMode::future.versionString(), "7");
+}
+
+TEST(LanguageMode, allSupportedModes) {
+  const auto modes = LanguageMode::allSupportedModes();
+  EXPECT_EQ(modes[0], LanguageMode::v4);
+  EXPECT_EQ(modes[1], LanguageMode::v4_2);
+  EXPECT_EQ(modes[2], LanguageMode::v5);
+  EXPECT_EQ(modes[3], LanguageMode::v6);
+}
+
+TEST(LanguageMode, version) {
+  EXPECT_EQ(LanguageMode::v4.version(), (std::pair<unsigned, unsigned>(4, 0)));
+  EXPECT_EQ(LanguageMode::v4_2.version(),
+            (std::pair<unsigned, unsigned>(4, 2)));
+  EXPECT_EQ(LanguageMode::v5.version(), (std::pair<unsigned, unsigned>(5, 0)));
+  EXPECT_EQ(LanguageMode::v6.version(), (std::pair<unsigned, unsigned>(6, 0)));
+}
+
+TEST(LanguageMode, isEffectiveIn) {
+  EXPECT_FALSE(LanguageMode::v4.isEffectiveIn({}));
+  EXPECT_FALSE(LanguageMode::v4.isEffectiveIn({1}));
+  EXPECT_FALSE(LanguageMode::v4.isEffectiveIn({3, 0}));
+  EXPECT_TRUE(LanguageMode::v4.isEffectiveIn({4, 0}));
+  EXPECT_TRUE(LanguageMode::v4.isEffectiveIn({4, 50, 1}));
+  EXPECT_TRUE(LanguageMode::v4.isEffectiveIn({9, 4}));
+
+  EXPECT_FALSE(LanguageMode::v4_2.isEffectiveIn({}));
+  EXPECT_FALSE(LanguageMode::v4_2.isEffectiveIn({3, 999}));
+  EXPECT_FALSE(LanguageMode::v4_2.isEffectiveIn({4, 0}));
+  EXPECT_TRUE(LanguageMode::v4_2.isEffectiveIn({4, 2, 0}));
+  EXPECT_TRUE(LanguageMode::v4_2.isEffectiveIn({4, 2, 3}));
+  EXPECT_TRUE(LanguageMode::v4_2.isEffectiveIn({9, 4}));
+
+  EXPECT_FALSE(LanguageMode::v5.isEffectiveIn({}));
+  EXPECT_FALSE(LanguageMode::v5.isEffectiveIn({2}));
+  EXPECT_FALSE(LanguageMode::v5.isEffectiveIn({4, 0}));
+  EXPECT_TRUE(LanguageMode::v5.isEffectiveIn({5}));
+  EXPECT_TRUE(LanguageMode::v5.isEffectiveIn({5, 10}));
+  EXPECT_TRUE(LanguageMode::v5.isEffectiveIn({6, 1}));
+
+  EXPECT_FALSE(LanguageMode::v6.isEffectiveIn({4}));
+  EXPECT_FALSE(LanguageMode::v6.isEffectiveIn({5, 999}));
+  EXPECT_TRUE(LanguageMode::v6.isEffectiveIn({6, 0, 0, 0}));
+  EXPECT_TRUE(LanguageMode::v6.isEffectiveIn({9, 9, 9, 9}));
+
+  EXPECT_FALSE(LanguageMode::future.isEffectiveIn({}));
+  EXPECT_FALSE(LanguageMode::future.isEffectiveIn({4, 0}));
+
+  // These two must be false once 'future' is untied from Swift 7.
+  EXPECT_TRUE(LanguageMode::future.isEffectiveIn({8, 0}));
+  EXPECT_TRUE(LanguageMode::future.isEffectiveIn({999}));
+}

--- a/unittests/Frontend/ArgParsingTest.cpp
+++ b/unittests/Frontend/ArgParsingTest.cpp
@@ -19,10 +19,10 @@ ArgParsingTest::ArgParsingTest() : diags(sourceMgr) {}
 void ArgParsingTest::parseArgs(const Args &args) {
   std::vector<const char *> adjustedArgs;
 
-  if (this->langMode) {
+  if (this->languageMode) {
     adjustedArgs.reserve(args.size() + 2);
     adjustedArgs.push_back("-swift-version");
-    adjustedArgs.push_back(this->langMode->data());
+    adjustedArgs.push_back(this->languageMode->data());
   } else {
     adjustedArgs.reserve(args.size());
   }

--- a/unittests/Frontend/ArgParsingTest.h
+++ b/unittests/Frontend/ArgParsingTest.h
@@ -24,7 +24,7 @@ class ArgParsingTest : public ::testing::Test {
   swift::DiagnosticEngine diags;
 
 protected:
-  std::optional<std::string> langMode;
+  std::optional<std::string> languageMode;
 
 public:
   ArgParsingTest();

--- a/unittests/Frontend/FeatureParsingTest.cpp
+++ b/unittests/Frontend/FeatureParsingTest.cpp
@@ -14,18 +14,15 @@
 
 using namespace swift;
 
-const std::string FeatureParsingTest::defaultLangMode = "5";
+const swift::LanguageMode FeatureParsingTest::defaultLanguageMode =
+    LanguageMode::v5;
 
 FeatureParsingTest::FeatureParsingTest() : ArgParsingTest() {
-  this->langMode = defaultLangMode;
+  this->languageMode = defaultLanguageMode.versionString();
 }
 
-FeatureWrapper::FeatureWrapper(Feature id) : id(id), name(id.getName().data()) {
-  auto langMode = id.getLanguageMode();
-  if (langMode) {
-    this->langMode = std::to_string(*langMode);
-  }
-}
+FeatureWrapper::FeatureWrapper(Feature feature)
+    : Feature(feature), name(getName().str()) {}
 
 void swift::PrintTo(const StrictConcurrency &value, std::ostream *os) {
   switch (value) {

--- a/unittests/Frontend/FeatureParsingTest.h
+++ b/unittests/Frontend/FeatureParsingTest.h
@@ -17,19 +17,15 @@
 #include "swift/Basic/Feature.h"
 
 struct FeatureParsingTest : public ArgParsingTest {
-  static const std::string defaultLangMode;
+  static const swift::LanguageMode defaultLanguageMode;
 
   FeatureParsingTest();
 };
 
-struct FeatureWrapper final {
-  swift::Feature id;
+struct FeatureWrapper final : swift::Feature {
   std::string name;
-  std::string langMode;
 
-  FeatureWrapper(swift::Feature id);
-
-  operator swift::Feature() const { return id; }
+  FeatureWrapper(swift::Feature feature);
 };
 
 // MARK: - Printers

--- a/unittests/Frontend/IsFeatureEnabledTests.cpp
+++ b/unittests/Frontend/IsFeatureEnabledTests.cpp
@@ -38,37 +38,37 @@ TEST_F(IsFeatureEnabledTest, VerifyTestedFeatures) {
   {
     ASSERT_FALSE(Feature::getUpcomingFeature(feature.name));
     ASSERT_FALSE(Feature::getExperimentalFeature(feature.name));
-    ASSERT_FALSE(feature.id.isMigratable());
+    ASSERT_FALSE(feature.isMigratable());
   }
 
   feature = upcomingF;
   {
     ASSERT_TRUE(Feature::getUpcomingFeature(feature.name));
-    ASSERT_FALSE(feature.id.isMigratable());
-    ASSERT_LT(defaultLangMode, feature.langMode);
+    ASSERT_FALSE(feature.isMigratable());
+    ASSERT_LT(defaultLanguageMode, feature.getLanguageMode().value());
   }
 
   feature = adoptableUpcomingF;
   {
     ASSERT_TRUE(Feature::getUpcomingFeature(feature.name));
-    ASSERT_TRUE(feature.id.isMigratable());
-    ASSERT_LT(defaultLangMode, feature.langMode);
+    ASSERT_TRUE(feature.isMigratable());
+    ASSERT_LT(defaultLanguageMode, feature.getLanguageMode().value());
   }
 
   feature = strictConcurrencyF;
   {
     ASSERT_TRUE(Feature::getUpcomingFeature(feature.name));
-    ASSERT_FALSE(feature.id.isMigratable());
-    ASSERT_LT(defaultLangMode, feature.langMode);
+    ASSERT_FALSE(feature.isMigratable());
+    ASSERT_LT(defaultLanguageMode, feature.getLanguageMode().value());
   }
 
   feature = experimentalF;
   {
     // If these tests start failing because `experimentalF` was promoted, swap
     // it for another experimental feature one that is available in production.
-    ASSERT_TRUE(feature.id.isAvailableInProduction());
+    ASSERT_TRUE(feature.isAvailableInProduction());
     ASSERT_TRUE(Feature::getExperimentalFeature(feature.name));
-    ASSERT_FALSE(feature.id.isMigratable());
+    ASSERT_FALSE(feature.isMigratable());
   }
 }
 
@@ -98,10 +98,10 @@ static const IsFeatureEnabledTestCase defaultStateTestCases[] = {
         {experimentalF, FeatureState::Off},
       }),
   IsFeatureEnabledTestCase(
-      {"-swift-version", upcomingF.langMode},
+      {"-swift-version", upcomingF.getLanguageMode()->versionString()},
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase(
-      {"-swift-version", strictConcurrencyF.langMode},
+      {"-swift-version", strictConcurrencyF.getLanguageMode()->versionString()},
       {{strictConcurrencyF, FeatureState::Enabled}}),
 };
 // clang-format on
@@ -163,7 +163,7 @@ static const IsFeatureEnabledTestCase singleEnableTestCases[] = {
 #ifndef NDEBUG
   // Requesting migration mode in target language mode has no effect.
   IsFeatureEnabledTestCase({
-        "-swift-version", adoptableUpcomingF.langMode,
+        "-swift-version", adoptableUpcomingF.getLanguageMode()->versionString(),
         "-enable-upcoming-feature", adoptableUpcomingF.name + ":migrate",
       },
       {{adoptableUpcomingF, FeatureState::Enabled}}),
@@ -181,7 +181,7 @@ static const IsFeatureEnabledTestCase singleEnableTestCases[] = {
 #ifndef NDEBUG
   // Requesting migration mode in target language mode has no effect.
   IsFeatureEnabledTestCase({
-        "-swift-version", adoptableUpcomingF.langMode,
+        "-swift-version", adoptableUpcomingF.getLanguageMode()->versionString(),
         "-enable-experimental-feature", adoptableUpcomingF.name + ":migrate",
       },
       {{adoptableUpcomingF, FeatureState::Enabled}}),
@@ -247,12 +247,12 @@ static const IsFeatureEnabledTestCase singleDisableTestCases[] = {
 
   // Disabling in target language mode has no effect.
   IsFeatureEnabledTestCase({
-        "-swift-version", upcomingF.langMode,
+        "-swift-version", upcomingF.getLanguageMode()->versionString(),
         "-disable-upcoming-feature", upcomingF.name,
       },
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
-        "-swift-version", upcomingF.langMode,
+        "-swift-version", upcomingF.getLanguageMode()->versionString(),
         "-disable-experimental-feature", upcomingF.name,
       },
       {{upcomingF, FeatureState::Enabled}}),
@@ -267,12 +267,12 @@ static const IsFeatureEnabledTestCase singleDisableTestCases[] = {
   // Disabling in target language mode has no effect.
   IsFeatureEnabledTestCase({
         "-disable-upcoming-feature", strictConcurrencyF.name,
-        "-swift-version", strictConcurrencyF.langMode,
+        "-swift-version", strictConcurrencyF.getLanguageMode()->versionString(),
       },
       {{strictConcurrencyF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
         "-disable-experimental-feature", strictConcurrencyF.name,
-        "-swift-version", strictConcurrencyF.langMode,
+        "-swift-version", strictConcurrencyF.getLanguageMode()->versionString(),
       },
       {{strictConcurrencyF, FeatureState::Enabled}}),
 

--- a/unittests/Frontend/StrictConcurrencyTests.cpp
+++ b/unittests/Frontend/StrictConcurrencyTests.cpp
@@ -36,7 +36,7 @@ static const StrictConcurrencyTestCase strictConcurrencyTestCases[] = {
       {},
       StrictConcurrency::Minimal),
   StrictConcurrencyTestCase(
-      {"-swift-version", strictConcurrencyF.langMode},
+      {"-swift-version", strictConcurrencyF.getLanguageMode()->versionString()},
       StrictConcurrency::Complete),
   StrictConcurrencyTestCase(
       {"-enable-upcoming-feature", strictConcurrencyF.name},


### PR DESCRIPTION
Future directions:
* Support `LanguageMode` as a diagnostic argument to unify the wording we use for it in diagnostics.
* Store a language mode alongside the "effective language version".
* Store a language mode instead of a version in the diagnostic engine.
* Allow `-swift-version future` vs. `-swift-version <whatever we *think* the next one will be>` with asserts compilers.

I chose to stick to an abstract future language mode instead of encouraging the use of relative language modes as in  `LanguageMode::v6.next()` because we still have to audit these uses for the purpose of considering which new features or behavior to include in a new language mode. A condition based on a relative language mode would express an early decision that will continue working as _initially_ expected after the introduction of said language mode. However, it seems wiser to defer such decisions until a new language mode is available than to future-proof this interface at the cost of increasing the odds of accidentally including gated behaviours.