### PR TITLE
build.ps1: Build the Android SDKs for API 24 instead

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -79,8 +79,8 @@ Format: r{number}[{letter}] (e.g., r28c)
 Default: "r28c"
 
 .PARAMETER AndroidAPILevel
-The API Level to target when building the Android SDKs. Must be between 1 and 36.
-Default: 28
+The API Level to target when building the Android SDKs. Must be between 21 and 36.
+Default: 24
 
 .PARAMETER AndroidSDKVersions
 An array of SDKs to build for the Android OS.
@@ -187,8 +187,8 @@ param
   [switch] $Android = $false,
   [ValidatePattern("^r(?:[1-9]|[1-9][0-9])(?:[a-z])?$")]
   [string] $AndroidNDKVersion = "r28c",
-  [ValidateRange(1, 36)]
-  [int] $AndroidAPILevel = 28,
+  [ValidateRange(21, 36)]
+  [int] $AndroidAPILevel = 24,
   [string[]] $AndroidSDKArchitectures = @("aarch64", "armv7", "i686", "x86_64"),
   [ValidateSet("dynamic", "static")]
   [string[]] $AndroidSDKLinkModes = @("dynamic", "static"),


### PR DESCRIPTION
Let's see if this passes all Windows CI. I'm putting together a pull next for the official Android CI that generates the SDK bundles, which runs on linux, but @marcprux already tested this out there months ago, swiftlang/swift-docker#509, and we've since added the `posix_spawn` changes that he was stubbing out back then.

This is based on [@compnerd and other workgroup members' go-ahead in the latest Android workgroup meeting](https://forums.swift.org/t/swift-android-workgroup-meeting-notes-january-28th-2026/84429) and the work @madsodgaard has been doing to drive this minimum API down to 24 and below.