### PR TITLE
[windows] copy .pdb files as part in the stage directory

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -4147,6 +4147,7 @@ function Build-Installer([Hashtable] $Platform) {
 function Copy-BuildArtifactsToStage([Hashtable] $Platform) {
   Copy-File "$BinaryCache\$($Platform.Triple)\installer\Release\$($Platform.Architecture.VSName)\*.cab" $Stage
   Copy-File "$BinaryCache\$($Platform.Triple)\installer\Release\$($Platform.Architecture.VSName)\*.msi" $Stage
+  Copy-File [IO.Path]::Combine((Get-ProjectBinaryCache $BuildPlatform Compilers), "bin", "*.pdb") $Stage
   foreach ($Build in $WindowsSDKBuilds) {
     Copy-File "$BinaryCache\$($Platform.Triple)\installer\Release\$($Build.Architecture.VSName)\*.msm" $Stage
   }


### PR DESCRIPTION
This patch enables copying the .pdb files emitted when building the compiler to the stage directory.

This will allow to retrieve those files in CI.