### PR TITLE
[windows] lower the number of parallel link jobs when building with DebugInfo

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2164,7 +2164,14 @@ function Get-CompilersDefines([Hashtable] $Platform, [string] $Variant, [switch]
   }
 
   # If DebugInfo is enabled limit the number of parallel links to avoid OOM.
-  $DebugDefines = if ($DebugInfo) { @{ SWIFT_PARALLEL_LINK_JOBS = "4"; } } else { @{} }
+  $DebugDefines = if ($DebugInfo) {
+    @{
+      SWIFT_PARALLEL_LINK_JOBS = "2";
+      LLVM_PARALLEL_LINK_JOBS = "2";
+    }
+  } else {
+    @{}
+  }
 
   # In the latest versions of VS, STL typically requires a newer version of
   # Clang than released Swift toolchains include. Relax this requirement when


### PR DESCRIPTION
Lower the number of parallel link jobs to 2 by setting `SWIFT_PARALLEL_LINK_JOBS` and `LLVM_PARALLEL_LINK_JOBS`. This is to avoid OOM errors in CI and might have to be adjusted manually when building at desk.