### PR TITLE
[6.3 🍒][AutoDiff] Add throwing versions of differential operators (#86393)

### DIFF
--- a/stdlib/public/Differentiation/DifferentialOperators.swift
+++ b/stdlib/public/Differentiation/DifferentialOperators.swift
@@ -42,6 +42,30 @@ public func valueWithDifferential<T, U, V, R>(
   return Builtin.applyDerivative_jvp_arity3(f, x, y, z)
 }
 
+@inlinable
+public func valueWithDifferential<T, R, E: Error>(
+  at x: T, of f: @differentiable(reverse) (T) throws(E) -> R
+) throws(E) -> (value: R, differential: (T.TangentVector) -> R.TangentVector) {
+  return try Builtin.applyDerivative_jvp_throws(f, x)
+}
+
+@inlinable
+public func valueWithDifferential<T, U, R, E: Error>(
+  at x: T, _ y: U, of f: @differentiable(reverse) (T, U) throws(E) -> R
+) throws(E) -> (value: R,
+      differential: (T.TangentVector, U.TangentVector) -> R.TangentVector) {
+  return try Builtin.applyDerivative_jvp_arity2_throws(f, x, y)
+}
+
+@inlinable
+public func valueWithDifferential<T, U, V, R, E: Error>(
+  at x: T, _ y: U, _ z: V, of f: @differentiable(reverse) (T, U, V) throws(E) -> R
+) throws(E) -> (value: R,
+      differential: (T.TangentVector, U.TangentVector, V.TangentVector)
+        -> (R.TangentVector)) {
+  return try Builtin.applyDerivative_jvp_arity3_throws(f, x, y, z)
+}
+
 // Value with pullback
 
 @inlinable
@@ -68,6 +92,30 @@ public func valueWithPullback<T, U, V, R>(
   return Builtin.applyDerivative_vjp_arity3(f, x, y, z)
 }
 
+@inlinable
+public func valueWithPullback<T, R, E: Error>(
+  at x: T, of f: @differentiable(reverse) (T) throws(E) -> R
+) throws(E) -> (value: R, pullback: (R.TangentVector) -> T.TangentVector) {
+  return try Builtin.applyDerivative_vjp_throws(f, x)
+}
+
+@inlinable
+public func valueWithPullback<T, U, R, E: Error>(
+  at x: T, _ y: U, of f: @differentiable(reverse) (T, U) throws(E) -> R
+) throws(E) -> (value: R,
+      pullback: (R.TangentVector) -> (T.TangentVector, U.TangentVector)) {
+  return try Builtin.applyDerivative_vjp_arity2_throws(f, x, y)
+}
+
+@inlinable
+public func valueWithPullback<T, U, V, R, E: Error>(
+  at x: T, _ y: U, _ z: V, of f: @differentiable(reverse) (T, U, V) throws(E) -> R
+) throws(E) -> (value: R,
+      pullback: (R.TangentVector)
+        -> (T.TangentVector, U.TangentVector, V.TangentVector)) {
+  return try Builtin.applyDerivative_vjp_arity3_throws(f, x, y, z)
+}
+
 // Differential
 
 @inlinable
@@ -89,6 +137,27 @@ public func differential<T, U, V, R>(
   at x: T, _ y: U, _ z: V, of f: @differentiable(reverse) (T, U, V) -> R
 ) -> (T.TangentVector, U.TangentVector, V.TangentVector) -> (R.TangentVector) {
   return valueWithDifferential(at: x, y, z, of: f).1
+}
+
+@inlinable
+public func differential<T, R, E: Error>(
+  at x: T, of f: @differentiable(reverse) (T) throws(E) -> R
+) throws(E) -> (T.TangentVector) -> R.TangentVector {
+  return try valueWithDifferential(at: x, of: f).1
+}
+
+@inlinable
+public func differential<T, U, R, E: Error>(
+  at x: T, _ y: U, of f: @differentiable(reverse) (T, U) throws(E) -> R
+) throws(E) -> (T.TangentVector, U.TangentVector) -> R.TangentVector {
+  return try valueWithDifferential(at: x, y, of: f).1
+}
+
+@inlinable
+public func differential<T, U, V, R, E: Error>(
+  at x: T, _ y: U, _ z: V, of f: @differentiable(reverse) (T, U, V) throws(E) -> R
+) throws(E) -> (T.TangentVector, U.TangentVector, V.TangentVector) -> (R.TangentVector) {
+  return try valueWithDifferential(at: x, y, z, of: f).1
 }
 
 
@@ -114,6 +183,28 @@ public func pullback<T, U, V, R>(
 ) -> (R.TangentVector)
     -> (T.TangentVector, U.TangentVector, V.TangentVector) {
   return Builtin.applyDerivative_vjp_arity3(f, x, y, z).1
+}
+
+@inlinable
+public func pullback<T, R, E: Error>(
+  at x: T, of f: @differentiable(reverse) (T) throws(E) -> R
+) throws(E) -> (R.TangentVector) -> T.TangentVector {
+  return try Builtin.applyDerivative_vjp_throws(f, x).1
+}
+
+@inlinable
+public func pullback<T, U, R, E: Error>(
+  at x: T, _ y: U, of f: @differentiable(reverse) (T, U) throws(E) -> R
+) throws(E) -> (R.TangentVector) -> (T.TangentVector, U.TangentVector) {
+  return try Builtin.applyDerivative_vjp_arity2_throws(f, x, y).1
+}
+
+@inlinable
+public func pullback<T, U, V, R, E: Error>(
+  at x: T, _ y: U, _ z: V, of f: @differentiable(reverse) (T, U, V) throws(E) -> R
+) throws(E) -> (R.TangentVector)
+    -> (T.TangentVector, U.TangentVector, V.TangentVector) {
+  return try Builtin.applyDerivative_vjp_arity3_throws(f, x, y, z).1
 }
 
 // Derivative
@@ -145,6 +236,33 @@ public func derivative<T: FloatingPoint, U: FloatingPoint, V: FloatingPoint, R>(
   return differential(at: x, y, z, of: f)(T(1), U(1), V(1))
 }
 
+@inlinable
+public func derivative<T: FloatingPoint, R, E: Error>(
+  at x: T, of f: @differentiable(reverse) (T) throws(E) -> R
+) throws(E) ->  R.TangentVector
+  where T.TangentVector == T {
+  return try differential(at: x, of: f)(T(1))
+}
+
+@inlinable
+public func derivative<T: FloatingPoint, U: FloatingPoint, R, E: Error>(
+  at x: T, _ y: U, of f: @differentiable(reverse) (T, U) throws(E) -> R
+) throws(E) -> R.TangentVector
+  where T.TangentVector == T,
+        U.TangentVector == U {
+  return try differential(at: x, y, of: f)(T(1), U(1))
+}
+
+@inlinable
+public func derivative<T: FloatingPoint, U: FloatingPoint, V: FloatingPoint, R, E: Error>(
+  at x: T, _ y: U, _ z: V, of f: @differentiable(reverse) (T, U, V) throws(E) -> R
+) throws(E) -> R.TangentVector
+  where T.TangentVector == T,
+        U.TangentVector == U,
+        V.TangentVector == V {
+  return try differential(at: x, y, z, of: f)(T(1), U(1), V(1))
+}
+
 // Gradient
 
 @inlinable
@@ -169,6 +287,30 @@ public func gradient<T, U, V, R>(
 ) -> (T.TangentVector, U.TangentVector, V.TangentVector)
   where R : FloatingPoint, R.TangentVector == R {
   return pullback(at: x, y, z, of: f)(R(1))
+}
+
+@inlinable
+public func gradient<T, R, E: Error>(
+  at x: T, of f: @differentiable(reverse) (T) throws(E) -> R
+) throws(E) -> T.TangentVector
+  where R : FloatingPoint, R.TangentVector == R {
+  return try pullback(at: x, of: f)(R(1))
+}
+
+@inlinable
+public func gradient<T, U, R, E: Error>(
+  at x: T, _ y: U, of f: @differentiable(reverse) (T, U) throws(E) -> R
+) throws(E) -> (T.TangentVector, U.TangentVector)
+  where R : FloatingPoint, R.TangentVector == R {
+  return try pullback(at: x, y, of: f)(R(1))
+}
+
+@inlinable
+public func gradient<T, U, V, R, E: Error>(
+  at x: T, _ y: U, _ z: V, of f: @differentiable(reverse) (T, U, V) throws(E) -> R
+) throws(E) -> (T.TangentVector, U.TangentVector, V.TangentVector)
+  where R : FloatingPoint, R.TangentVector == R {
+  return try pullback(at: x, y, z, of: f)(R(1))
 }
 
 // Value with derivative
@@ -204,6 +346,37 @@ public func valueWithDerivative<
   return (y, differential(T(1), U(1), V(1)))
 }
 
+@inlinable
+public func valueWithDerivative<T: FloatingPoint, R, E: Error>(
+  at x: T, of f: @escaping @differentiable(reverse) (T) throws(E) -> R
+) throws(E) -> (value: R, derivative: R.TangentVector)
+  where T.TangentVector == T {
+  let (y, differential) = try valueWithDifferential(at: x, of: f)
+  return (y, differential(T(1)))
+}
+
+@inlinable
+public func valueWithDerivative<T: FloatingPoint, U: FloatingPoint, R, E: Error>(
+  at x: T, _ y: U, of f: @escaping @differentiable(reverse) (T, U) throws(E) -> R
+) throws(E) -> (value: R, derivative: R.TangentVector)
+  where T.TangentVector == T,
+        U.TangentVector == U {
+  let (y, differential) = try valueWithDifferential(at: x, y, of: f)
+  return (y, differential(T(1), U(1)))
+}
+
+@inlinable
+public func valueWithDerivative<
+  T: FloatingPoint, U: FloatingPoint, V: FloatingPoint, R, E: Error>(
+  at x: T, _ y: U, _ z: V, of f: @escaping @differentiable(reverse) (T, U, V) throws(E) -> R
+) throws(E) -> (value: R, derivative: R.TangentVector)
+  where T.TangentVector == T,
+        U.TangentVector == U,
+        V.TangentVector == V {
+  let (y, differential) = try valueWithDifferential(at: x, y, z, of: f)
+  return (y, differential(T(1), U(1), V(1)))
+}
+
 // Value with gradient
 
 @inlinable
@@ -231,6 +404,34 @@ public func valueWithGradient<T, U, V, R>(
       gradient: (T.TangentVector, U.TangentVector, V.TangentVector))
   where R : FloatingPoint, R.TangentVector == R {
   let (y, pullback) = valueWithPullback(at: x, y, z, of: f)
+  return (y, pullback(R(1)))
+}
+
+@inlinable
+public func valueWithGradient<T, R, E: Error>(
+  at x: T, of f: @differentiable(reverse) (T) throws(E) -> R
+) throws(E) -> (value: R, gradient: T.TangentVector)
+  where R : FloatingPoint, R.TangentVector == R {
+  let (y, pullback) = try valueWithPullback(at: x, of: f)
+  return (y, pullback(R(1)))
+}
+
+@inlinable
+public func valueWithGradient<T, U, R, E: Error>(
+  at x: T, _ y: U, of f: @differentiable(reverse) (T, U) throws(E) -> R
+) throws(E) -> (value: R, gradient: (T.TangentVector, U.TangentVector))
+  where R : FloatingPoint, R.TangentVector == R {
+  let (y, pullback) = try valueWithPullback(at: x, y, of: f)
+  return (y, pullback(R(1)))
+}
+
+@inlinable
+public func valueWithGradient<T, U, V, R, E: Error>(
+  at x: T, _ y: U, _ z: V, of f: @differentiable(reverse) (T, U, V) throws(E) -> R
+) throws(E) -> (value: R,
+      gradient: (T.TangentVector, U.TangentVector, V.TangentVector))
+  where R : FloatingPoint, R.TangentVector == R {
+  let (y, pullback) = try valueWithPullback(at: x, y, z, of: f)
   return (y, pullback(R(1)))
 }
 
@@ -263,6 +464,33 @@ public func derivative<T: FloatingPoint, U: FloatingPoint, V: FloatingPoint, R>(
   return { (x, y, z) in derivative(at: x, y, z, of: f) }
 }
 
+@inlinable 
+public func derivative<T: FloatingPoint, R, E: Error>(
+  of f: @escaping @differentiable(reverse) (T) throws(E) -> R
+) -> (T) throws(E) -> R.TangentVector
+  where T.TangentVector == T {
+  return { x in try derivative(at: x, of: f) }
+}
+
+@inlinable 
+public func derivative<T: FloatingPoint, U: FloatingPoint, R, E: Error>(
+  of f: @escaping @differentiable(reverse) (T, U) throws(E) -> R
+) -> (T, U) throws(E) -> R.TangentVector
+  where T.TangentVector == T,
+        U.TangentVector == U {
+  return { (x, y) in try derivative(at: x, y, of: f) }
+}
+
+@inlinable
+public func derivative<T: FloatingPoint, U: FloatingPoint, V: FloatingPoint, R, E: Error>(
+  of f: @escaping @differentiable(reverse) (T, U, V) throws(E) -> R
+) -> (T, U, V) throws(E) -> R.TangentVector
+  where T.TangentVector == T,
+        U.TangentVector == U,
+        V.TangentVector == V {
+  return { (x, y, z) in try derivative(at: x, y, z, of: f) }
+}
+
 // Gradient (curried)
 
 @inlinable
@@ -287,4 +515,28 @@ public func gradient<T, U, V, R>(
 ) -> (T, U, V) -> (T.TangentVector, U.TangentVector, V.TangentVector)
   where R : FloatingPoint, R.TangentVector == R {
   return { x, y, z in gradient(at: x, y, z, of: f) }
+}
+
+@inlinable
+public func gradient<T, R, E: Error>(
+  of f: @escaping @differentiable(reverse) (T) throws(E) -> R
+) -> (T) throws(E) -> T.TangentVector
+  where R : FloatingPoint, R.TangentVector == R {
+  return { x in try gradient(at: x, of: f) }
+}
+
+@inlinable
+public func gradient<T, U, R, E: Error>(
+  of f: @escaping @differentiable(reverse) (T, U) throws(E) -> R
+) -> (T, U) throws(E) -> (T.TangentVector, U.TangentVector)
+  where R : FloatingPoint, R.TangentVector == R {
+  return { x, y in try gradient(at: x, y, of: f) }
+}
+
+@inlinable
+public func gradient<T, U, V, R, E: Error>(
+  of f: @escaping @differentiable(reverse) (T, U, V) throws(E) -> R
+) -> (T, U, V) throws(E) -> (T.TangentVector, U.TangentVector, V.TangentVector)
+  where R : FloatingPoint, R.TangentVector == R {
+  return { x, y, z in try gradient(at: x, y, z, of: f) }
 }

--- a/test/AutoDiff/stdlib/differential_operators.swift.gyb
+++ b/test/AutoDiff/stdlib/differential_operators.swift.gyb
@@ -26,6 +26,17 @@ func exampleVJP_${arity}(${params}) -> (value: Float, pullback: (Float) -> ${pb_
   )
 }
 
+func exampleDiffFunc_${arity}_throws(${params}) throws -> Float {
+  fatalError()
+}
+@derivative(of: exampleDiffFunc_${arity}_throws)
+func exampleVJP_${arity}_throws(${params}) throws -> (value: Float, pullback: (Float) -> ${pb_return_type}) {
+  (
+    ${' + '.join(['x%d * x%d' % (i, i) for i in range(arity)])},
+    { (${', '.join(['2 * x%d * $0' % i for i in range(arity)])}) }
+  )
+}
+
 % argValues = [i * 10 for i in range(1, arity + 1)]
 % args = ', '.join([str(v) for v in argValues])
 % expectedValue = sum([v * v for v in argValues])
@@ -38,13 +49,29 @@ DifferentialOperatorTestSuite.test("valueWithPullback_${arity}") {
   expectEqual(${expectedGradients}, pb(1))
 }
 
+DifferentialOperatorTestSuite.test("valueWithPullback_${arity}_throws") {
+  let (value, pb) = try! valueWithPullback(at: ${args}, of: exampleDiffFunc_${arity}_throws)
+  expectEqual(${expectedValue}, value)
+  expectEqual(${expectedGradients}, pb(1))
+}
+
 DifferentialOperatorTestSuite.test("pullback_${arity}") {
   let pb = pullback(at: ${args}, of: exampleDiffFunc_${arity})
   expectEqual(${expectedGradients}, pb(1))
 }
 
+DifferentialOperatorTestSuite.test("pullback_${arity}_throws") {
+  let pb = try! pullback(at: ${args}, of: exampleDiffFunc_${arity}_throws)
+  expectEqual(${expectedGradients}, pb(1))
+}
+
 DifferentialOperatorTestSuite.test("gradient_${arity}") {
   let grad = gradient(at: ${args}, of: exampleDiffFunc_${arity})
+  expectEqual(${expectedGradients}, grad)
+}
+
+DifferentialOperatorTestSuite.test("gradient_${arity}_throws") {
+  let grad = try! gradient(at: ${args}, of: exampleDiffFunc_${arity}_throws)
   expectEqual(${expectedGradients}, grad)
 }
 
@@ -54,9 +81,20 @@ DifferentialOperatorTestSuite.test("valueWithGradient_${arity}") {
   expectEqual(${expectedGradients}, grad)
 }
 
+DifferentialOperatorTestSuite.test("valueWithGradient_${arity}_throws") {
+  let (value, grad) = try! valueWithGradient(at: ${args}, of: exampleDiffFunc_${arity}_throws)
+  expectEqual(${expectedValue}, value)
+  expectEqual(${expectedGradients}, grad)
+}
+
 DifferentialOperatorTestSuite.test("gradient_curried_${arity}") {
   let gradF = gradient(of: exampleDiffFunc_${arity})
   expectEqual(${expectedGradients}, gradF(${args}))
+}
+
+DifferentialOperatorTestSuite.test("gradient_curried_${arity}_throws") {
+  let gradF = gradient(of: exampleDiffFunc_${arity}_throws)
+  expectEqual(${expectedGradients}, try! gradF(${args}))
 }
 
 % end


### PR DESCRIPTION
- **Explanation**:
Updates the AutoDiff related Builtins to accept typed throws, and adds throwing versions of differential operators, e.g. `valueWithPullback<T, R, E: Error>`.

We can now automatically differentiate through throwing functions. But we cannot call the gradients of said functions using `valueWithPullback(at: x, of: throwingFunction)`, as this is only merged on main. This makes the throwing functionality very limiting unfortunately as we also cannot define functional operators like:
```swift
import _Differentiation

extension Array where Element: Differentiable {
    @differentiable(reverse, wrt: self)
    public func differentiableThrowingMap<Result: Differentiable, E: Error>(
        _ body: @differentiable(reverse) (Element) throws(E) -> Result
    ) throws(E) -> [Result] {
        try map(body)
    }

    @derivative(of: differentiableThrowingMap)
    public func _vjpDifferentiableThrowingMap<Result: Differentiable, E: Error>(
        _ body: @differentiable(reverse) (Element) throws(E) -> Result
    ) throws(E) -> ( // succeeds when turned into throws(E)
        value: [Result],
        pullback: (Array<Result>.TangentVector) -> Array.TangentVector
    ) {
        let count = self.count
        var values: [Result] = []
        var pullbacks: [(Result.TangentVector) -> Element.TangentVector] = []
        values.reserveCapacity(count)
        pullbacks.reserveCapacity(count)
        for x in self {
            let (y, pb) = try valueWithPullback(at: x, of: body)
            values.append(y)
            pullbacks.append(pb)
        }
        func pullback(_ tans: Array<Result>.TangentVector) -> Array.TangentVector {
            .init(zip(tans.base, pullbacks).map { tan, pb in pb(tan) })
        }
        return (value: values, pullback: pullback)
    }
}
```

https://github.com/swiftlang/swift/pull/82653 laid the groundwork to enable differentiating through throwing functions. This cherrypick now enables the use of that groundwork, adding the overloads of `valueWithPullback` where we could pass a throwing closure.

- **Scope**: Limited to AutoDiff functionality.

- **Issues**: https://github.com/swiftlang/swift/issues/87090 rdar://169976256

- **Original PRs**: https://github.com/swiftlang/swift/pull/86393

- **Risk**:
While this does touch some general files like `lib/AST/Builtins.ccp`, the changes are specific to AutoDiff functions. No changes expected to general functionality, with low risk overall.

- **Testing**:
New cases added to existing AutoDiff tests.

- **Reviewers**:
@asl
@kovdan01