### PR TITLE
Serialization: Raise a proper error on type members broken by invalid modularization

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1017,18 +1017,18 @@ ERROR(cxx_stdlib_kind_mismatch,none,
       (Identifier, StringRef, StringRef))
 
 ERROR(modularization_issue_decl_moved,Fatal,
-      "reference to %select{top-level declaration|type}0 %1 broken by a context change; "
-      "%1 was expected to be in %2, but now a candidate is found only in %3",
-      (bool, DeclName, const ModuleDecl*, const ModuleDecl*))
+      "reference to %select{declaration|type}0 '%1' broken by a context change; "
+      "'%1' was expected to be in %2, but now a candidate is found only in %3",
+      (bool, StringRef, const ModuleDecl*, const ModuleDecl*))
 ERROR(modularization_issue_decl_type_changed,Fatal,
-      "reference to %select{top-level declaration|type}0 %1 broken by a context change; "
-      "the declaration kind of %1 %select{from %2|}5 changed since building '%3'"
+      "reference to %select{declaration|type}0 '%1' broken by a context change; "
+      "the declaration kind of '%1' %select{from %2|}5 changed since building '%3'"
       "%select{|, it was in %2 and now a candidate is found only in %4}5",
-      (bool, DeclName, const ModuleDecl*, StringRef, const ModuleDecl*, bool))
+      (bool, StringRef, const ModuleDecl*, StringRef, const ModuleDecl*, bool))
 ERROR(modularization_issue_decl_not_found,Fatal,
-      "reference to %select{top-level declaration|type}0 %1 broken by a context change; "
-      "%1 is not found, it was expected to be in %2",
-      (bool, DeclName, const ModuleDecl*))
+      "reference to %select{declaration|type}0 '%1' broken by a context change; "
+      "'%1' is not found, it was expected to be in %2",
+      (bool, StringRef, const ModuleDecl*))
 
 NOTE(modularization_issue_note_expected,none,
      "the %select{declaration|type}0 was expected to be found in module %1 at '%2'",
@@ -1066,9 +1066,9 @@ NOTE(modularization_issue_layering_found_local,none,
      "the local module %1 for a reference from the distributed module %0",
      (const ModuleDecl*, const ModuleDecl*))
 NOTE(modularization_issue_related_modules,none,
-     "the %select{declaration|type}0 %1 moved between related modules; "
+     "the %select{declaration|type}0 '%1' moved between related modules; "
      "clang preprocessor macros may affect headers shared between these modules",
-     (bool, DeclName))
+     (bool, StringRef))
 NOTE(interface_block_listed_broken,none,
      "textual interface for %0 is blocklisted as broken; "
      "interface verification errors are downgraded to warnings", (StringRef))

--- a/test/Serialization/Recovery/module-recovery-remarks-on-type-changed.swift
+++ b/test/Serialization/Recovery/module-recovery-remarks-on-type-changed.swift
@@ -1,10 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-/// Compile two libraries A and LibWithXRef.
+/// Compile the middle Swift library LibWithXRef.
 // RUN: %target-swift-frontend -emit-module %t/LibWithXRef.swift -I %t \
 // RUN:   -module-name LibWithXRef -o %t/LibWithXRef.swiftmodule \
 // RUN:   -swift-version 5
+
+/// Build client fine in the expected behavior.
 // RUN: %target-swift-frontend -c -O %t/Client.swift -I %t \
 // RUN:   -validate-tbd-against-ir=none -swift-version 5
 
@@ -12,8 +14,8 @@
 // RUN: mv %t/A_DifferentAPI.h %t/A.h
 // RUN: not --crash %target-swift-frontend -c -O %t/Client.swift -I %t \
 // RUN:   -validate-tbd-against-ir=none -swift-version 5 2>&1 \
-// RUN:   | %FileCheck %s
-// CHECK: error: reference to top-level declaration 'foo' broken by a context change; the declaration kind of 'foo' from 'A' changed since building 'LibWithXRef'
+// RUN:   -diagnostic-style llvm | %FileCheck %s
+// CHECK: error: reference to declaration 'foo' broken by a context change; the declaration kind of 'foo' from 'A' changed since building 'LibWithXRef'
 // CHECK: note: the declaration was expected to be found in module 'A' at '{{.*}}module.modulemap'
 // CHECK: note: the declaration was actually found in module 'A' at '{{.*}}module.modulemap'
 // CHECK: note: a candidate was filtered out because of a type mismatch; expected: '() -> ()', found: '() -> Float'

--- a/test/Serialization/modularization-error-member.swift
+++ b/test/Serialization/modularization-error-member.swift
@@ -1,0 +1,66 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+/// Compile the middle Swift library LibWithXRef.
+// RUN: %target-swift-frontend -emit-module %t/LibWithXRef.swift -I %t \
+// RUN:   -module-name LibWithXRef -o %t/LibWithXRef.swiftmodule \
+// RUN:   -swift-version 5
+
+/// Build client fine in the expected behavior.
+// RUN: %target-swift-frontend -c -O %t/Client.swift -I %t \
+// RUN:   -validate-tbd-against-ir=none -swift-version 5
+
+// Replace headers, changing the type of `foo`.
+// RUN: cp %t/A_Changed.h %t/A.h
+// RUN: not --crash %target-swift-frontend -c -O %t/Client.swift -I %t \
+// RUN:   -validate-tbd-against-ir=none -swift-version 5 \
+// RUN:   -diagnostic-style llvm 2> %t/out
+// RUN: %FileCheck %t/A_Changed.h --input-file %t/out
+
+// Replace headers, disappearing `foo`.
+// RUN: cp %t/A_Disappeared.h %t/A.h
+// RUN: not --crash %target-swift-frontend -c -O %t/Client.swift -I %t \
+// RUN:   -validate-tbd-against-ir=none -swift-version 5 \
+// RUN:   -diagnostic-style llvm 2> %t/out
+// RUN: %FileCheck %t/A_Disappeared.h --input-file %t/out
+
+//--- module.modulemap
+module A {
+    header "A.h"
+}
+
+//--- A.h
+struct S {};
+struct S *create() __attribute__((swift_name("S.init()")));
+double foo(struct S *data) __attribute__((swift_name("S.foo(self:)")));
+
+//--- A_Disappeared.h
+struct S {};
+struct S *create() __attribute__((swift_name("S.init()")));
+
+// CHECK: error: reference to declaration 'S.foo' broken by a context change; 'S.foo' is not found, it was expected to be in 'A'
+// CHECK: note: the declaration was expected to be found in module 'A' at '{{.*}}module.modulemap'
+// CHECK-NOT: actually found
+
+//--- A_Changed.h
+struct S {};
+struct S *create() __attribute__((swift_name("S.init()")));
+float foo(struct S *data) __attribute__((swift_name("S.foo(self:)")));
+
+// CHECK: error: reference to declaration 'S.foo' broken by a context change; the declaration kind of 'S.foo' from 'A' changed since building 'LibWithXRef'
+// CHECK: note: the declaration was expected to be found in module 'A' at '{{.*}}module.modulemap'
+// CHECK: note: a candidate was filtered out because of a type mismatch; expected: '(inout S) -> () -> Double', found: '(inout S) -> () -> Float'
+
+//--- LibWithXRef.swift
+import A
+
+@inlinable
+public func bar() {
+    var s = S()
+    s.foo()
+}
+
+//--- Client.swift
+import LibWithXRef
+
+bar()


### PR DESCRIPTION
Extend support for proper errors on broken modularization to type members, previously only top-level declarations were reported as error. This change raises errors with relevant context if a type member is referenced from a swiftmodule file but at reading the member is not found or changed shape.

It doesn't report moves between modules like we do for top-level declarations. This is less likely to happen at the member level as the check is already applied at the top-level for the same reference. We may still see such issues when using `SWIFT_NAME` to assign a top-level declaration to a type from a different module.