### PR TITLE
Reject @isolated(any) when we don't have the concurrency library

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6182,8 +6182,8 @@ NOTE(distributed_actor_synchronous_access_distributed_computed_property,none,
 ERROR(concurrency_lib_missing,none,
       "missing '%0' declaration, probably because the '_Concurrency' "
       "module was not imported", (StringRef))
-ERROR(async_main_no_concurrency,none,
-      "'_Concurrency' module not imported, required for async main", ())
+ERROR(no_concurrency_module,none,
+      "'_Concurrency' module not imported, required for %0", (StringRef))
 
 ERROR(multiple_global_actors,none,
       "declaration can not have multiple global actor attributes (%0 and %1)",

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3125,7 +3125,7 @@ synthesizeMainBody(AbstractFunctionDecl *fn, void *arg) {
     auto *concurrencyModule = context.getLoadedModule(context.Id_Concurrency);
     if (!concurrencyModule) {
       context.Diags.diagnose(mainFunction->getAsyncLoc(),
-                             diag::async_main_no_concurrency);
+                             diag::no_concurrency_module, "async main");
       auto result = new (context) ErrorExpr(mainFunction->getSourceRange());
       ASTNode stmts[] = {result};
       auto body = BraceStmt::create(context, SourceLoc(), stmts, SourceLoc(),

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4271,6 +4271,12 @@ NeverNullType TypeResolver::resolveASTFunctionType(
                           diag::isolated_attr_bad_convention,
                           isolatedAttr->getIsolationKindName(),
                           conventionAttr->getConventionName());
+        } else if (!ctx.getLoadedModule(ctx.Id_Concurrency) &&
+                   !ctx.SILOpts.ParseStdlib) {
+          // If the Actor protocol isn't available, we have to reject this.
+          diagnoseInvalid(repr, isolatedAttr->getAtLoc(),
+                          diag::no_concurrency_module,
+                          "@isolated(any)");
         } else {
           isolation = FunctionTypeIsolation::forErased();
         }

--- a/test/Concurrency/isolated_any_without_concurrency.swift
+++ b/test/Concurrency/isolated_any_without_concurrency.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -emit-ir -o - -disable-implicit-concurrency-module-import %s -verify
+
+// REQUIRES: concurrency
+
+final class NC<A> {
+  struct State { }
+
+  // expected-error@+1{{'_Concurrency' module not imported, required for @isolated(any)}}
+  @discardableResult public func doIt(_ handler: (@escaping @Sendable @isolated(any) (_ connection: NC, _ state: State) -> Void)) -> Self {
+    return self
+  }
+}
+
+extension NC {
+  func blah() {
+    doIt { conn, state in
+      
+    }
+  }
+}


### PR DESCRIPTION
IRGen crashes on `@isolated(any)` functions if the Actor protocol isn't available. It's safer to reject in the type checker in these cases.

Fixes rdar://165090740.
