### PR TITLE
[StrictExhaustiveSwitches] suggest @unknown default for resilient enums

### DIFF
--- a/include/swift/AST/DiagnosticGroups.def
+++ b/include/swift/AST/DiagnosticGroups.def
@@ -88,6 +88,7 @@ GROUP(TemporaryPointers,none,"temporary-pointers")
 GROUP(TrailingClosureMatching,none,"trailing-closure-matching")
 GROUP(UnknownWarningGroup,none,"unknown-warning-group")
 GROUP(WeakMutability,none,"weak-mutability")
+GROUP(StrictExhaustiveSwitches,DefaultIgnoreWarnings,"strict-exhaustive-switches")
 
 GROUP_LINK(PerformanceHints,ExistentialType)
 GROUP_LINK(PerformanceHints,ReturnTypeImplicitCopy)

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7603,6 +7603,13 @@ ERROR(non_exhaustive_switch_unknown_only,none,
       "switch covers known cases, but %0 may have additional unknown values"
       "%select{|, possibly added in future versions}1", (Type, bool))
 
+GROUPED_ERROR(exhaustive_switch_replace_default_with_unknown,StrictExhaustiveSwitches,none,
+      "switch covers known cases, but %0 may have additional unknown values,"
+      "%select{| possibly added in future versions,}1 "
+      "'default' [or 'case _'] will only be executed for unknown values "
+      "[possibly added in future versions]; replace with \"@unknown default\"",
+      (Type, bool))
+
 ERROR(override_nsobject_hashvalue_error,none,
       "'NSObject.hashValue' is not overridable; "
       "did you mean to override 'NSObject.hash'?", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7580,6 +7580,12 @@ NOTE(missing_several_cases,none,
 NOTE(missing_unknown_case,none,
      "handle unknown values using \"@unknown default\"", ())
 
+GROUPED_WARNING(decompose_default_case,StrictExhaustiveSwitches,none,
+  "switch can be made exhaustive without use of 'default'; replace with known cases", ())
+
+GROUPED_WARNING(default_after_catchall,StrictExhaustiveSwitches,none,
+                "a 'default' case is equivalent to a catch-all case; remove one", ())
+
 NOTE(non_exhaustive_switch_drop_unknown,none,
      "remove '@unknown' to handle remaining values", ())
 

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -1408,6 +1408,9 @@ public:
 
   bool isDefault() { return getCaseLabelItems()[0].isDefault(); }
 
+  /// True if this case matches any pattern ('case _:' or 'case(_, _):')
+  bool isCatchAll();
+
   bool hasUnknownAttr() const {
     // Note: This representation doesn't allow for synthesized @unknown cases.
     // However, that's probably sensible; the purpose of @unknown is for

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -1235,9 +1235,18 @@ namespace {
           return 6;
         };
 
-        DE.diagnose(startLoc, diag::non_exhaustive_switch_unknown_only,
-                    subjectType, shouldIncludeFutureVersionComment)
-            .warnUntilLanguageMode(shouldWarnUntilVersion());
+        if (defaultCase) {
+          hasEmittedUnnecessaryDefaultDiagnostic = true;
+          DE.diagnose(startLoc,
+                      diag::exhaustive_switch_replace_default_with_unknown,
+                      subjectType, shouldIncludeFutureVersionComment)
+              .fixItInsert(defaultCase->getStartLoc(), "@unknown ")
+              .warnUntilLanguageMode(shouldWarnUntilVersion());
+        } else {
+          DE.diagnose(startLoc, diag::non_exhaustive_switch_unknown_only,
+                      subjectType, shouldIncludeFutureVersionComment)
+              .warnUntilLanguageMode(shouldWarnUntilVersion());
+        }
 
         mainDiagType.reset();
         break;

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -16,6 +16,7 @@
 
 #include "TypeChecker.h"
 #include "swift/AST/ASTPrinter.h"
+#include "swift/AST/DiagnosticGroups.h"
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/Pattern.h"
 #include "swift/Basic/Assertions.h"
@@ -973,6 +974,11 @@ namespace {
       }
     }
 
+    bool hasStrictExhaustiveChecksEnabled() {
+      auto SF = DC->getParentSourceFile();
+      return Context.Diags.isDiagnosticGroupEnabled(SF, DiagGroupID::StrictExhaustiveSwitches);
+    }
+
     void checkExhaustiveness(bool limitedChecking) {
       // If the type of the scrutinee is uninhabited, we're already dead.
       // Allow any well-typed patterns through.
@@ -985,11 +991,14 @@ namespace {
       if (limitedChecking) {
         // Reject switch statements with empty blocks.
         if (Switch->getCases().empty())
-          diagnoseMissingCases(RequiresDefault::EmptySwitchBody, Space());
+          diagnoseMissingCases(RequiresDefault::EmptySwitchBody, Space(),
+                               nullptr /* unknown default */,
+                               nullptr /* default */);
         return;
       }
 
       const CaseStmt *unknownCase = nullptr;
+      const CaseStmt *defaultCase = nullptr;
       SmallVector<Space, 4> spaces;
       auto &DE = Context.Diags;
       for (auto *caseBlock : Switch->getCases()) {
@@ -1006,8 +1015,14 @@ namespace {
             continue;
 
           // Space is trivially covered with a default clause.
-          if (caseItem.isDefault())
+          if (caseItem.isDefault()) {
+            if (!hasStrictExhaustiveChecksEnabled()) {
             return;
+            }
+            assert(defaultCase == nullptr && "multiple default cases");
+            defaultCase = caseBlock;
+            continue;
+          }
 
           Space projection = projectPattern(caseItem.getPattern());
           bool isRedundant = !projection.isEmpty() &&
@@ -1046,7 +1061,7 @@ namespace {
       auto diff = totalSpace.minus(coveredSpace, DC, &minusCount);
       if (!diff) {
         diagnoseMissingCases(RequiresDefault::SpaceTooLarge, Space(),
-                             unknownCase);
+                             unknownCase, defaultCase);
         return;
       }
 
@@ -1060,32 +1075,55 @@ namespace {
       // uncovered space is empty because we trust that if the developer went to
       // the trouble of writing @unknown that it was for a good reason, like
       // addressing diagnostics in another build configuration where there are
-      // potentially unknown cases.
+      // potentially unknown cases, like a dependency built with resilience.
       uncovered = *uncovered.minus(Space::forUnknown(unknownCase == nullptr),
                                    DC, /*&minusCount*/ nullptr);
 
-      if (uncovered.isEmpty())
+      if (uncovered.isEmpty()) {
+        // Here diagnose the case where a catch-all masks the default case
+        if (hasStrictExhaustiveChecksEnabled() && defaultCase) {
+          for (auto *caseBlock : Switch->getCases()) {
+            if (caseBlock->isCatchAll()) {
+              DE.diagnose(caseBlock->getLoc(), diag::default_after_catchall)
+                  .fixItRemoveChars(caseBlock->getStartLoc(),
+                                    caseBlock->getLoc())
+                  .fixItRemoveChars(defaultCase->getStartLoc(),
+                                    defaultCase->getLoc());
+            }
+          }
+        }
+
         return;
+      }
 
       // If the entire space is left uncovered we have two choices: We can
       // decompose the type space and offer them as fixits, or simply offer
       // to insert a `default` clause.
+      //
+      // If a strictly exhaustive switch is requested
+      // (see hasStrictExhaustiveChecksEnabled), a default case will be
+      // suggested to be decomposed into the remaining cases if they are
+      // statically possible to determine.
+      //
+      // As well, if the type space is resilient, the default case may also
+      // be converted to an unknown default to exhaust known and future cases
       if (uncovered.getKind() == SpaceKind::Type) {
         if (Space::canDecompose(uncovered.getType())) {
           SmallVector<Space, 4> spaces;
           Space::decomposeDisjuncts(DC, uncovered.getType(), {}, spaces);
           diagnoseMissingCases(RequiresDefault::No, Space::forDisjunct(spaces),
-                               unknownCase);
-        } else {
+                               unknownCase, defaultCase);
+        } else if (!defaultCase) {
           diagnoseMissingCases(Switch->getCases().empty()
                                  ? RequiresDefault::EmptySwitchBody
                                  : RequiresDefault::UncoveredSwitch,
-                               uncovered, unknownCase);
+                               uncovered, unknownCase, nullptr /*defaultCase*/);
         }
         return;
       }
 
-      diagnoseMissingCases(RequiresDefault::No, uncovered, unknownCase);
+      diagnoseMissingCases(RequiresDefault::No, uncovered, unknownCase,
+                           defaultCase);
     }
     
     enum class RequiresDefault {
@@ -1096,14 +1134,40 @@ namespace {
     };
 
     void diagnoseMissingCases(RequiresDefault defaultReason, Space uncovered,
-                              const CaseStmt *unknownCase = nullptr) {
+                              const CaseStmt *unknownCase,
+                              const CaseStmt *defaultCase) {
+      assert(!(unknownCase && defaultCase) &&
+             "both @unknown default and default should be caught earlier");
       if (!Switch->getLBraceLoc().isValid()) {
         // There is no '{' in the switch statement, which we already diagnosed
         // in the parser. So there's no real body to speak of and it doesn't
         // make sense to emit diagnostics about missing cases.
         return;
       }
+
+      std::optional<decltype(diag::non_exhaustive_switch)> mainDiagType =
+          diag::non_exhaustive_switch;
+
+      // Decide whether we want an error or a warning.
+      bool downgrade = false;
+
+      // We either replace default with unknown default or known cases
+      // based on resilience and StrictExhaustiveSwitches
+      bool hasEmittedUnnecessaryDefaultDiagnostic = false;
+
       auto &DE = Context.Diags;
+      if (defaultCase) {
+        if (defaultReason != RequiresDefault::No) {
+          // We actually do need the default,
+          // so it does handle the space, do not emit diagnostics
+          return;
+        }
+
+        // Switch actually is exhaustive with known cases,
+        // so don't emit exhaustive diagnostic
+        mainDiagType.reset();
+      }
+
       SourceLoc startLoc = Switch->getStartLoc();
       SourceLoc insertLoc;
       if (unknownCase)
@@ -1114,10 +1178,6 @@ namespace {
       llvm::SmallString<128> buffer;
       llvm::raw_svector_ostream OS(buffer);
 
-      // Decide whether we want an error or a warning.
-      std::optional<decltype(diag::non_exhaustive_switch)> mainDiagType =
-          diag::non_exhaustive_switch;
-      bool downgrade = false;
       if (unknownCase) {
         switch (defaultReason) {
         case RequiresDefault::EmptySwitchBody:
@@ -1155,17 +1215,12 @@ namespace {
         Type subjectType = Switch->getSubjectExpr()->getType();
         bool shouldIncludeFutureVersionComment = false;
         auto *theEnum = subjectType->getEnumOrBoundGenericEnum();
-
         if (theEnum) {
           auto *enumModule = theEnum->getParentModule();
           shouldIncludeFutureVersionComment =
               enumModule->isSystemModule() ||
               theEnum->getAttrs().hasAttribute<NonexhaustiveAttr>();
         }
-
-        auto diag =
-            DE.diagnose(startLoc, diag::non_exhaustive_switch_unknown_only,
-                        subjectType, shouldIncludeFutureVersionComment);
 
         auto shouldWarnUntilVersion = [&theEnum]() -> unsigned {
           if (theEnum) {
@@ -1180,11 +1235,22 @@ namespace {
           return 6;
         };
 
-        diag.warnUntilLanguageMode(shouldWarnUntilVersion());
+        DE.diagnose(startLoc, diag::non_exhaustive_switch_unknown_only,
+                    subjectType, shouldIncludeFutureVersionComment)
+            .warnUntilLanguageMode(shouldWarnUntilVersion());
 
-        mainDiagType = std::nullopt;
-      }
+        mainDiagType.reset();
         break;
+      }
+      }
+
+      if (defaultCase && !hasEmittedUnnecessaryDefaultDiagnostic) {
+        // Warn that the default case is not needed, remove the
+        // default case and enumerate the cases below
+        hasEmittedUnnecessaryDefaultDiagnostic = true;
+        DE.diagnose(defaultCase->getStartLoc(), diag::decompose_default_case)
+            .fixItRemoveChars(defaultCase->getStartLoc(),
+                              defaultCase->getEndLoc());
       }
 
       switch (defaultReason) {
@@ -1224,9 +1290,7 @@ namespace {
 
       // Add notes to explain what's missing.
       auto processUncoveredSpaces =
-          [&](llvm::function_ref<void(const Space &space,
-                                      bool onlyOneUncoveredSpace)> process) {
-
+          [&](llvm::function_ref<void(const Space &space)> process) {
         // Flatten away all disjunctions.
         SmallVector<Space, 4> flats;
         flatten(uncovered, flats);
@@ -1255,8 +1319,8 @@ namespace {
           flatsToEmit.insert(space);
         }
 
-        // Finally we can iterate over the flat spaces in their original order,
-        // but only emit the interesting ones.
+            // Finally we can iterate over the flat spaces in their original
+            // order, but only emit the interesting ones.
         for (const Space &flat : flats) {
           if (!flatsToEmit.count(&flat))
             continue;
@@ -1264,22 +1328,23 @@ namespace {
           if (flat.getKind() == SpaceKind::UnknownCase) {
             assert(&flat == &flats.back() && "unknown case must be last");
             if (unknownCase) {
-              // This can occur if the /only/ case in the switch is 'unknown'.
-              // In that case we won't do any analysis on the input space, but
-              // will later decompose the space into cases.
+                  // This can occur if the /only/ case in the switch is
+                  // 'unknown'. In that case we won't do any analysis on the
+                  // input space, but will later decompose the space into cases.
               continue;
             }
-            if (!Context.LangOpts.hasFeature(Feature::NonfrozenEnumExhaustivity))
+                if (!Context.LangOpts.hasFeature(
+                        Feature::NonfrozenEnumExhaustivity))
               continue;
 
-            // This can occur if the switch is empty and the subject type is an
-            // enum. If decomposing the enum type yields an unknown space that
-            // is not required, don't suggest adding it in the fix-it.
+                // This can occur if the switch is empty and the subject type is
+                // an enum. If decomposing the enum type yields an unknown space
+                // that is not required, don't suggest adding it in the fix-it.
             if (flat.isAllowedButNotRequired())
               continue;
           }
 
-          process(flat, flats.size() == 1);
+              process(flat);
         }
       };
 
@@ -1300,14 +1365,16 @@ namespace {
       SmallString<128> missingSeveralCasesFixIt;
       int diagnosedCases = 0;
 
-      processUncoveredSpaces([&](const Space &space,
-                                 bool onlyOneUncoveredSpace) {
+      processUncoveredSpaces([&](const Space &space) {
         llvm::SmallString<64> fixItBuffer;
         llvm::raw_svector_ostream fixItOS(fixItBuffer);
         if (space.getKind() == SpaceKind::UnknownCase) {
-          fixItOS << "@unknown " << tok::kw_default << ":\n<#fatalError()#>\n";
+          if (!hasEmittedUnnecessaryDefaultDiagnostic) {
+            fixItOS << "@unknown " << tok::kw_default
+                    << ":\n<#fatalError()#>\n";
           DE.diagnose(startLoc, diag::missing_unknown_case)
               .fixItInsert(insertLoc, fixItBuffer.str());
+          }
         } else {
           llvm::SmallString<64> spaceBuffer;
           llvm::raw_svector_ostream spaceOS(spaceBuffer);

--- a/test/stmt/strict_exhaustive_switches.swift
+++ b/test/stmt/strict_exhaustive_switches.swift
@@ -1,0 +1,175 @@
+// RUN: split-file %s %t
+
+// Use fragile enums
+// RUN: %target-swift-frontend %t/Enums.swift -emit-module -module-name enums -o %t/enums.swiftmodule
+// RUN: %target-swift-frontend    -I %t %t/NewDiagnostics.swift %t/PreventRegressions.swift %t/WithError.swift -swift-version 6 -Wwarning StrictExhaustiveSwitches -verify -typecheck
+// RUN: %target-swift-emit-silgen -I %t %t/NewDiagnostics.swift %t/PreventRegressions.swift %t/SILVerify.swift -swift-version 6 -Wwarning StrictExhaustiveSwitches -verify -o /dev/null
+
+//--- Enums.swift
+
+public enum ReasonableEnum {
+  case zero
+  case one
+}
+
+public enum OverlyLargeSpaceEnum {
+  case case0
+  case case1
+  case case2
+  case case3
+  case case4
+  case case5
+  case case6
+  case case7
+  case case8
+  case case9
+  case case10
+  case case11
+}
+
+//--- NewDiagnostics.swift
+
+import enums
+
+func testMissingKnownCases(enum o: OverlyLargeSpaceEnum) -> Bool {
+  switch o {
+    // expected-note@-1 {{add missing cases}}
+    // expected-note@-2 11 {{add missing case}}
+    case .case0: return true
+    default: return false // expected-warning {{switch can be made exhaustive without use of 'default'; replace with known cases}}
+  }
+}
+
+func testMissingWildcards(e1: ReasonableEnum, e2: ReasonableEnum) -> Bool {
+  switch (e1, e2) { // expected-note {{add missing cases}}
+    // expected-note@-1 {{add missing case: '(.one, _)'}}
+    // expected-note@-2 {{add missing case: '(_, .one)'}}
+    case (.zero, .zero): return true
+    default: return false // expected-warning {{switch can be made exhaustive without use of 'default'; replace with known cases}}
+  }
+}
+
+func testMissingWildcards(o1: OverlyLargeSpaceEnum, o2: OverlyLargeSpaceEnum) -> Bool {
+  switch (o1, o2) { // expected-note {{add missing case: '(.case11, _)'}}
+  case (.case0, _): return true
+  case (.case1, _): return true
+  case (.case2, _): return true
+  case (.case3, _): return true
+  case (.case4, _): return true
+  case (.case5, _): return true
+  case (.case6, _): return true
+  case (.case7, _): return true
+  case (.case8, _): return true
+  case (.case9, _): return true
+  case (.case10, _): return true
+  default: return false // expected-warning {{switch can be made exhaustive without use of 'default'; replace with known cases}}
+  }
+}
+
+//--- SILVerify.swift
+
+import enums
+
+func testExhaustiveWithDefault(enum e: ReasonableEnum) -> Bool {
+  switch e {
+    case .zero, .one: return true
+    default: return false // expected-warning {{default will never be executed}}
+  }
+}
+
+func testWildcardWithDefault(enum e: ReasonableEnum) -> Bool {
+  switch e {
+    case _: // expected-warning {{a 'default' case is equivalent to a catch-all case; remove one}}
+      return true
+    default: // expected-warning {{default will never be executed}}
+      return false
+  }
+}
+
+func testTupleWildcardWithDefault(e1: ReasonableEnum, e2: ReasonableEnum) -> Bool {
+  switch (e1, e2) {
+  case (_, _): // expected-warning {{a 'default' case is equivalent to a catch-all case; remove one}}
+    return true
+  default: // expected-warning {{default will never be executed}}
+    return false
+  }
+}
+
+func testParensWildcardWithDefault(e1: ReasonableEnum) -> Bool {
+  switch (e1) {
+  case ((_)): // expected-warning {{a 'default' case is equivalent to a catch-all case; remove one}}
+      return true
+    default: // expected-warning {{default will never be executed}}
+      return false
+  }
+}
+
+func testGuardedWildcardWithDefault(enum e: ReasonableEnum) -> Bool {
+  switch e {
+    case .zero, .one:
+      return true
+    case _ where e == .one:
+      return true
+    default:
+      return false
+  }
+}
+
+//--- PreventRegressions.swift
+
+import enums
+
+func testWellFormedExhaustive(enum e: ReasonableEnum) -> Bool {
+  switch e {
+    case .zero, .one: return true
+  }
+}
+
+func testExhaustiveOpen(value: Int) -> Bool {
+  switch value {
+  case 1: return true
+  case 2...10: return true
+  default: return false
+  }
+}
+
+func testExhaustiveWithUnknownDefault(e: ReasonableEnum) -> Bool {
+  switch e {
+  case .zero, .one: return true
+  @unknown default: return false
+  }
+}
+
+func testNonExhaustiveWithUnknownDefault(e: ReasonableEnum) -> Bool {
+  switch ReasonableEnum.zero { // expected-warning {{switch must be exhaustive}}
+  // expected-note@-1 {{add missing case: '.one'}}
+  case .zero: return true
+  @unknown default: return false
+  }
+}
+
+func testExhaustiveTupleWithUnknownDefault(e1: ReasonableEnum, e2: ReasonableEnum) -> Bool {
+  switch (ReasonableEnum.zero, ReasonableEnum.one) {
+  case (.zero, _), (.one, _): return true
+  @unknown default: return false
+  }
+}
+
+func nonExhaustiveTupleWithUnknownDeafult(e1: ReasonableEnum, e2: ReasonableEnum) -> Bool {
+  switch (ReasonableEnum.zero, ReasonableEnum.one) { // expected-warning {{switch must be exhaustive}}
+  // expected-note@-1 {{add missing case: '(.one, _)'}}
+  case (.zero, _): return true
+  @unknown default: return false
+  }
+}
+
+//--- WithError.swift
+
+// split file to verify type-checking but can't get to sil with error
+func testNonExhaustiveOpen(value: Int) -> Bool {
+  switch value { // expected-error {{switch must be exhaustive}}
+  // expected-note@-1 {{add a default clause}}
+  case 1: return true
+  case 2...10: return true
+  }
+}

--- a/test/stmt/strict_exhaustive_switches.swift
+++ b/test/stmt/strict_exhaustive_switches.swift
@@ -5,6 +5,11 @@
 // RUN: %target-swift-frontend    -I %t %t/NewDiagnostics.swift %t/PreventRegressions.swift %t/WithError.swift -swift-version 6 -Wwarning StrictExhaustiveSwitches -verify -typecheck
 // RUN: %target-swift-emit-silgen -I %t %t/NewDiagnostics.swift %t/PreventRegressions.swift %t/SILVerify.swift -swift-version 6 -Wwarning StrictExhaustiveSwitches -verify -o /dev/null
 
+// Repeat with resilient enums
+// RUN: %target-swift-frontend %t/Enums.swift -emit-module -module-name enums -o %t/enums.swiftmodule -enable-library-evolution
+// RUN: %target-swift-frontend    -I %t %t/NewWithResilience.swift %t/PreventRegsResilience.swift %t/ErrResilience.swift -swift-version 6 -Wwarning StrictExhaustiveSwitches -verify -typecheck
+// RUN: %target-swift-emit-silgen -I %t %t/NewWithResilience.swift %t/PreventRegsResilience.swift %t/SILResilience.swift -swift-version 6 -Wwarning StrictExhaustiveSwitches -verify -o /dev/null
+
 //--- Enums.swift
 
 public enum ReasonableEnum {
@@ -51,6 +56,49 @@ func testMissingWildcards(e1: ReasonableEnum, e2: ReasonableEnum) -> Bool {
 
 func testMissingWildcards(o1: OverlyLargeSpaceEnum, o2: OverlyLargeSpaceEnum) -> Bool {
   switch (o1, o2) { // expected-note {{add missing case: '(.case11, _)'}}
+  case (.case0, _): return true
+  case (.case1, _): return true
+  case (.case2, _): return true
+  case (.case3, _): return true
+  case (.case4, _): return true
+  case (.case5, _): return true
+  case (.case6, _): return true
+  case (.case7, _): return true
+  case (.case8, _): return true
+  case (.case9, _): return true
+  case (.case10, _): return true
+  default: return false // expected-warning {{switch can be made exhaustive without use of 'default'; replace with known cases}}
+  }
+}
+
+
+//--- NewWithResilience.swift
+
+import enums
+
+func testMissingKnownCases(enum o: OverlyLargeSpaceEnum) -> Bool {
+  switch o {
+    // expected-note@-1 {{add missing cases}}
+    // expected-note@-2 11 {{add missing case}}
+    case .case0: return true
+    default: return false // expected-warning {{switch can be made exhaustive without use of 'default'; replace with known cases}}
+  }
+}
+
+func testMissingWildcards(e1: ReasonableEnum, e2: ReasonableEnum) -> Bool {
+  switch (e1, e2) { // expected-note {{add missing cases}}
+    // expected-note@-1 {{add missing case: '(.one, _)'}}
+    // expected-note@-2 {{add missing case: '(_, .one)'}}
+    // expected-note@-3 2 {{add missing case: '(_, _)'}}
+    case (.zero, .zero): return true
+    default: return false // expected-warning {{switch can be made exhaustive without use of 'default'; replace with known cases}}
+  }
+}
+
+func testMissingWildcards(o1: OverlyLargeSpaceEnum, o2: OverlyLargeSpaceEnum) -> Bool {
+  switch (o1, o2) { // expected-note {{add missing cases}}
+  // expected-note@-1 {{add missing case: '(.case11, _)'}}
+  // expected-note@-2 {{add missing case: '(_, _)'}}
   case (.case0, _): return true
   case (.case1, _): return true
   case (.case2, _): return true
@@ -115,6 +163,55 @@ func testGuardedWildcardWithDefault(enum e: ReasonableEnum) -> Bool {
   }
 }
 
+//--- SILResilience.swift
+
+import enums
+
+func testExhaustiveWithDefault(enum e: ReasonableEnum) -> Bool {
+  switch e { // expected-error {{switch covers known cases, but 'ReasonableEnum' may have additional unknown values, 'default' [or 'case _'] will only be executed for unknown values [possibly added in future versions]; replace with "@unknown default"}} {{7:3-3=@unknown }}
+  case .zero, .one: return true
+  default: return false
+  }
+}
+
+func testWildcardWithDefault(enum e: ReasonableEnum) -> Bool {
+  switch e {
+  case _: // expected-warning {{a 'default' case is equivalent to a catch-all case; remove one}}
+    return true
+  default:
+    return false
+  }
+}
+
+func testGuardedWildcardWithDefault(enum e: ReasonableEnum) -> Bool {
+  switch e { // expected-error {{switch covers known cases, but 'ReasonableEnum' may have additional unknown values, 'default' [or 'case _'] will only be executed for unknown values [possibly added in future versions]; replace with "@unknown default"}}
+    case .zero, .one:
+      return true
+    case _ where e == .one:
+      return true
+    default:
+      return false
+  }
+}
+
+func testTupleWildcardWithDefault(e1: ReasonableEnum, e2: ReasonableEnum) -> Bool {
+  switch (e1, e2) {
+  case (_, _): // expected-warning {{a 'default' case is equivalent to a catch-all case; remove one}}
+    return true
+  default:
+    return false
+  }
+}
+
+func testParensWildcardWithDefault(e1: ReasonableEnum) -> Bool {
+  switch (e1) {
+  case ((_)): // expected-warning {{a 'default' case is equivalent to a catch-all case; remove one}}
+    return true
+  default:
+    return false
+  }
+}
+
 //--- PreventRegressions.swift
 
 import enums
@@ -122,6 +219,56 @@ import enums
 func testWellFormedExhaustive(enum e: ReasonableEnum) -> Bool {
   switch e {
     case .zero, .one: return true
+  }
+}
+
+func testExhaustiveOpen(value: Int) -> Bool {
+  switch value {
+  case 1: return true
+  case 2...10: return true
+  default: return false
+  }
+}
+
+func testExhaustiveWithUnknownDefault(e: ReasonableEnum) -> Bool {
+  switch e {
+  case .zero, .one: return true
+  @unknown default: return false
+  }
+}
+
+func testNonExhaustiveWithUnknownDefault(e: ReasonableEnum) -> Bool {
+  switch ReasonableEnum.zero { // expected-warning {{switch must be exhaustive}}
+  // expected-note@-1 {{add missing case: '.one'}}
+  case .zero: return true
+  @unknown default: return false
+  }
+}
+
+func testExhaustiveTupleWithUnknownDefault(e1: ReasonableEnum, e2: ReasonableEnum) -> Bool {
+  switch (ReasonableEnum.zero, ReasonableEnum.one) {
+  case (.zero, _), (.one, _): return true
+  @unknown default: return false
+  }
+}
+
+func nonExhaustiveTupleWithUnknownDeafult(e1: ReasonableEnum, e2: ReasonableEnum) -> Bool {
+  switch (ReasonableEnum.zero, ReasonableEnum.one) { // expected-warning {{switch must be exhaustive}}
+  // expected-note@-1 {{add missing case: '(.one, _)'}}
+  case (.zero, _): return true
+  @unknown default: return false
+  }
+}
+
+
+//--- PreventRegsResilience.swift
+
+import enums
+
+func testSuggestUnkonwnDefaultForResilientEnum(enum e: ReasonableEnum) -> Bool {
+  switch e { // expected-error {{switch covers known cases, but 'ReasonableEnum' may have additional unknown values}}
+  // expected-note@-1 {{handle unknown values using "@unknown default"}}
+  case .zero, .one: return true
   }
 }
 
@@ -171,5 +318,20 @@ func testNonExhaustiveOpen(value: Int) -> Bool {
   // expected-note@-1 {{add a default clause}}
   case 1: return true
   case 2...10: return true
+  }
+}
+
+
+//--- ErrResilience.swift
+
+import enums
+
+func testMissingWildcardsNoDefault(e1: ReasonableEnum, e2: ReasonableEnum) -> Bool {
+  switch (e1, e2) { // expected-error {{switch must be exhaustive}}
+    // expected-note@-1 {{add missing cases}}
+    // expected-note@-2 {{add missing case: '(.one, _)'}}
+    // expected-note@-3 {{add missing case: '(_, .one)'}}
+    // expected-note@-4 2 {{add missing case: '(_, _)'}}
+    case (.zero, .zero): return true
   }
 }


### PR DESCRIPTION
Improving on #85168, when a strictly-exhausted-and-resilient enum is already covered by known cases, replace the 'default' case with an '@unknown default' case.

The new diagnostic should be an error as explained [here](https://github.com/swiftlang/swift/pull/85168#discussion_r2488493012): 
> What I was trying to avoid was one diagnostic (a warning) that encouraged the user to remove the default and then once removed, another (now an error) that told them to add an unknown default. While this is preferable to keeping the diagnostics succinct I think it's a bad developer experience to apply a warning fix-it and then get an error.

This will be demoted to a warning in Swift 5 LM, which is consistent with the current diagnostics in both language modes.