### PR TITLE
[Diagnostics]: add RBI errors to `RegionIsolation` diagnostic group

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -1134,7 +1134,7 @@ NOTE(regionbasedisolation_isolated_conformance_introduced, none,
 
 // Error that is only used when the send non sendable emitter cannot discover any
 // information to give a better diagnostic.
-ERROR(regionbasedisolation_task_or_actor_isolated_sent, none,
+GROUPED_ERROR(regionbasedisolation_task_or_actor_isolated_sent, RegionIsolation, none,
       "task or actor-isolated value cannot be sent", ())
 
 //===
@@ -1143,19 +1143,19 @@ ERROR(regionbasedisolation_task_or_actor_isolated_sent, none,
 NOTE(regionbasedisolation_inout_sending_must_be_reinitialized, none,
      "'inout sending' parameter must be reinitialized before function exit with a non-actor-isolated value",
      ())
-ERROR(regionbasedisolation_inout_sending_cannot_be_actor_isolated, none,
+GROUPED_ERROR(regionbasedisolation_inout_sending_cannot_be_actor_isolated, RegionIsolation, none,
       "'inout sending' parameter %0 cannot be %1 at end of function",
       (Identifier, StringRef))
 NOTE(regionbasedisolation_inout_sending_cannot_be_actor_isolated_note, none,
       "%1 %0 risks causing races in between %1 uses and caller uses since caller assumes value is not actor isolated",
       (Identifier, StringRef))
-ERROR(regionbasedisolation_inout_sending_cannot_be_returned_param, none,
+GROUPED_ERROR(regionbasedisolation_inout_sending_cannot_be_returned_param, RegionIsolation, none,
       "'inout sending' parameter %0 cannot be returned",
       (Identifier))
-ERROR(regionbasedisolation_inout_sending_cannot_be_returned_value, none,
+GROUPED_ERROR(regionbasedisolation_inout_sending_cannot_be_returned_value, RegionIsolation, none,
       "%0 cannot be returned",
       (Identifier))
-ERROR(regionbasedisolation_inout_sending_cannot_be_returned_value_result, none,
+GROUPED_ERROR(regionbasedisolation_inout_sending_cannot_be_returned_value_result, RegionIsolation, none,
       "result of %kind0 cannot be returned",
       (const ValueDecl *))
 NOTE(regionbasedisolation_inout_sending_cannot_be_returned_note_param, none,
@@ -1179,13 +1179,13 @@ NOTE(regionbasedisolation_inout_sending_cannot_be_returned_note_actor_return_val
 //===
 // Out Sending
 
-ERROR(regionbasedisolation_out_sending_cannot_be_actor_isolated_type, none,
+GROUPED_ERROR(regionbasedisolation_out_sending_cannot_be_actor_isolated_type, RegionIsolation, none,
       "returning a %1 %0 value as a 'sending' result risks causing data races",
       (Type, StringRef))
 NOTE(regionbasedisolation_out_sending_cannot_be_actor_isolated_note_type, none,
       "returning a %1 %0 value risks causing races since the caller assumes the value can be safely sent to other isolation domains",
       (Type, StringRef))
-ERROR(regionbasedisolation_out_sending_cannot_be_actor_isolated_named, none,
+GROUPED_ERROR(regionbasedisolation_out_sending_cannot_be_actor_isolated_named, RegionIsolation, none,
       "returning %1 %0 as a 'sending' result risks causing data races",
       (Identifier, StringRef))
 NOTE(regionbasedisolation_out_sending_cannot_be_actor_isolated_note_named, none,
@@ -1196,10 +1196,10 @@ NOTE(regionbasedisolation_out_sending_cannot_be_actor_isolated_note_named, none,
 // non-Sendable Results
 
 // Example: returning main-actor isolated result to a custom-actor isolated context risks causing data races
-ERROR(rbi_isolation_crossing_result, none,
+GROUPED_ERROR(rbi_isolation_crossing_result, RegionIsolation, none,
       "non-Sendable %0-typed result can not be returned from %1 %kind2 to %3 context",
       (Type, StringRef, const ValueDecl *, StringRef))
-ERROR(rbi_isolation_crossing_result_no_decl, none,
+GROUPED_ERROR(rbi_isolation_crossing_result_no_decl, RegionIsolation, none,
       "non-Sendable %0-typed result can not be returned from %1 function to %2 context",
       (Type, StringRef, StringRef))
 NOTE(rbi_non_sendable_nominal,none,
@@ -1214,7 +1214,7 @@ NOTE(rbi_add_generic_parameter_sendable_conformance,none,
      "consider making generic parameter %0 conform to the 'Sendable' protocol",
      (Type))
 
-ERROR(regionbasedisolation_inout_sending_in_same_region, none,
+GROUPED_ERROR(regionbasedisolation_inout_sending_in_same_region, RegionIsolation, none,
       "'inout sending' parameters %0 and %1 can be potentially accessed from each other at function return risking data races in caller",
       (Identifier, Identifier))
 NOTE(regionbasedisolation_inout_sending_in_same_region_note, none,


### PR DESCRIPTION
Adds the `RegionIsolation` diagnostic group to a number of existing region based isolation errors. This allows them to be more flexibly controlled in the swift 5 language mode by using diagnostic control flags.