### PR TITLE
support noescape analysis for packs

### DIFF
--- a/include/swift/SIL/NodeDatastructures.h
+++ b/include/swift/SIL/NodeDatastructures.h
@@ -18,6 +18,7 @@
 #define SWIFT_SIL_NODEDATASTRUCTURES_H
 
 #include "swift/SIL/NodeBits.h"
+#include "swift/SIL/SILValue.h"
 #include "swift/SIL/StackList.h"
 
 namespace swift {
@@ -140,6 +141,18 @@ public:
       return true;
     }
     return false;
+  }
+
+  /// Pushes each instruction in \p instructions onto the worklist if that
+  /// instruction has never been pushed before. Returns true if any instruction
+  /// was added.
+  template <typename Collection>
+  bool pushInstructionsIfNotVisited(Collection &&instructions) {
+    bool visited = false;
+    for (auto *instruction : instructions) {
+      visited |= pushIfNotVisited(instruction);
+    }
+    return visited;
   }
 
   /// Like `pushIfNotVisited`, but requires that \p instruction has never been

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4431,6 +4431,9 @@ bool TypeBase::isNoEscape() const {
   if (auto funcTy = dyn_cast<FunctionType>(type))
     return funcTy->isNoEscape();
 
+  if (auto packExpansionTy = dyn_cast<PackExpansionType>(type))
+    return packExpansionTy.getPatternType()->isNoEscape();
+
   if (auto tupleTy = dyn_cast<TupleType>(type)) {
     for (auto eltTy : tupleTy.getElementTypes())
       if (eltTy->isNoEscape())

--- a/lib/SILOptimizer/Mandatory/DiagnoseInvalidEscapingCaptures.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseInvalidEscapingCaptures.cpp
@@ -551,7 +551,14 @@ static void diagnoseCaptureLoc(ASTContext &Context, DeclContext *DC,
     // Look through indirect pack references. A function with a pack parameter
     // will get the address, set the pack, and later get and load the pack. We
     // want to follow this indirection until the load, so we can diagnose where
-    // the pack is used, like `repeat each x`
+    // the pack is used, like `repeat each x`.
+    //
+    // %12 = tuple_pack_element_addr %10 of %1 // user: %13
+    // pack_element_set %12 into %10 of %2 // id: %13
+    // ^ find the users of that pack
+    // %26 = pack_element_get %24 of %2 // user: %27
+    // %27 = load [copy] %26 // users: %29, %28
+    // ^ diagnose at this instruction
     if (auto *svi = dyn_cast<SingleValueInstruction>(user)) {
       if (isa<TuplePackElementAddrInst>(user) ||
           isa<PackElementGetInst>(user)) {

--- a/lib/SILOptimizer/Mandatory/DiagnoseInvalidEscapingCaptures.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseInvalidEscapingCaptures.cpp
@@ -365,11 +365,11 @@ static void diagnoseCaptureLoc(ASTContext &Context, DeclContext *DC,
 
     // Look through indirect pack references. A function with a pack parameter
     // will get the address, set the pack, and later get and load the pack. We
-    // want to follow this indirection to diagnose where the pack value is
-    // actually used.
+    // want to follow this indirection until the load, so we can diagnose where
+    // the pack is used, like `repeat each x`
     if (auto *svi = dyn_cast<SingleValueInstruction>(user)) {
       if (isa<TuplePackElementAddrInst>(user) ||
-          isa<PackElementGetInst>(user) || isa<LoadInst>(user)) {
+          isa<PackElementGetInst>(user)) {
         for (auto *use : svi->getUses())
           uselistInsert(use);
         continue;

--- a/lib/SILOptimizer/Mandatory/DiagnoseInvalidEscapingCaptures.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseInvalidEscapingCaptures.cpp
@@ -314,21 +314,23 @@ static const SILValue tryGetPackFromIntermediaryInstruction(SILInstruction *inst
 
     // Follow the source of copy addr.
     if (auto *copyAddr = dyn_cast<CopyAddrInst>(inst)) {
-      worklist.pushIfNotVisited(copyAddr->getSrc()->getDefiningInstruction());
+      if (auto *src = copyAddr->getSrc()->getDefiningInstruction())
+        worklist.pushIfNotVisited(src);
       continue;
     }
 
     // Follow the source of load inst.
     if (auto *load = dyn_cast<LoadInst>(inst)) {
-      worklist.pushIfNotVisited(load->getOperand()->getDefiningInstruction());
+      if (auto *src = load->getOperand()->getDefiningInstruction())
+        worklist.pushIfNotVisited(src);
       continue;
     }
 
     // Follow the value of a pack set, ideally to a tuple pack element addr
     // inst.
     if (auto *packElemSet = dyn_cast<PackElementSetInst>(inst)) {
-      worklist.pushIfNotVisited(
-          packElemSet->getValue()->getDefiningInstruction());
+      if (auto *valueDef = packElemSet->getValue()->getDefiningInstruction())
+        worklist.pushIfNotVisited(valueDef);
       continue;
     }
 
@@ -348,8 +350,8 @@ static const SILValue tryGetPackFromIntermediaryInstruction(SILInstruction *inst
       if (auto *arg = dyn_cast<SILArgument>(packElemGet->getPack())) {
         return arg;
       }
-      worklist.pushIfNotVisited(
-          packElemGet->getPack()->getDefiningInstruction());
+      if (auto *packDef = packElemGet->getPack()->getDefiningInstruction())
+        worklist.pushIfNotVisited(packDef);
       continue;
     }
   }

--- a/lib/SILOptimizer/Mandatory/DiagnoseInvalidEscapingCaptures.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseInvalidEscapingCaptures.cpp
@@ -568,21 +568,25 @@ static void diagnoseCaptureLoc(ASTContext &Context, DeclContext *DC,
       continue;
     }
 
-    // Follow indirection for defer
+    // Follow indirection for defer.
     if (auto *copyAddrInst = dyn_cast<CopyAddrInst>(user)) {
       // We came from the source, follow it to where its copied to
       if (oper->getOperandNumber() == CopyAddrInst::Src) {
         SILValue dest = copyAddrInst->getDest();
 
-        // Walk through address projections to find the base
+        // Walk through address projections to find the base.
         while (true) {
           if (auto *tuplePackInst = dyn_cast<TuplePackElementAddrInst>(dest)) {
             dest = tuplePackInst->getTuple();
-          } else if (auto *packInst = dyn_cast<PackElementGetInst>(dest)) {
-            dest = packInst->getPack();
-          } else {
-            break;
+            continue;
           }
+
+          if (auto *packInst = dyn_cast<PackElementGetInst>(dest)) {
+            dest = packInst->getPack();
+            continue;
+          }
+
+          break;
         }
 
         for (auto *use : dest->getUses())

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -445,8 +445,9 @@ Type ConstraintSystem::openPackExpansionType(PackExpansionType *expansion,
   auto *expansionLoc = getConstraintLocator(locator.withPathElement(
       LocatorPathElt::PackExpansionType(openedPackExpansion)));
 
-  auto *expansionVar = createTypeVariable(expansionLoc, TVO_PackExpansion,
-                                          preparedOverload);
+  auto *expansionVar = createTypeVariable(
+      expansionLoc, TVO_PackExpansion | TVO_CanBindToNoEscape,
+      preparedOverload);
 
   // This constraint is important to make sure that pack expansion always
   // has a binding and connect pack expansion var to any type variables

--- a/test/SILOptimizer/invalid_escaping_captures.swift
+++ b/test/SILOptimizer/invalid_escaping_captures.swift
@@ -309,6 +309,26 @@ func badNoEscapeCaptureFromDeferedPackIteration<each T>(_ fn: repeat () -> each 
   }
 }
 
+func badNoEscapeCaptureFromDeferredEscapingPack<each T>(_ fn: repeat () -> each T) { // expected-note@:59 {{parameter 'fn' is implicitly non-escaping}}
+  defer {
+    takesEscaping { // expected-error {{escaping closure captures non-escaping parameter 'fn'}}
+      let _ = (repeat (each fn)()) // expected-note@:24 {{captured here}}
+    }
+  }
+  let _ = 5
+}
+
+func badNoEscapeCaptureFromDeferedEscapingPackIteration<each T>(_ fn: repeat () -> each T) { // expected-note@:67 {{parameter 'fn' is implicitly non-escaping}}
+  defer {
+    takesEscaping { // expected-error {{escaping closure captures non-escaping parameter 'fn'}}
+      for f in repeat each fn { // expected-note@:23 {{captured here}}
+        let _ = f()
+      }
+    }
+  }
+  let _ = 42
+}
+
 func badNoEscapeCaptureAfterPackExpansion<each T>(_ fn: repeat () -> each T) {
   let tup = (repeat each fn)
 

--- a/test/SILOptimizer/invalid_escaping_captures.swift
+++ b/test/SILOptimizer/invalid_escaping_captures.swift
@@ -275,22 +275,22 @@ struct TestInoutEscapeInClosure {
   }
 }
 
-func badNoEscapeCaptureFromPack<each T>(_ fn: repeat () -> each T) {
-  takesEscaping { // expected-error {{escaping closure captures non-escaping value}}
+func badNoEscapeCaptureFromPack<each T>(_ fn: repeat () -> each T) { // expected-note@:43 {{parameter 'fn' is implicitly non-escaping}}
+  takesEscaping { // expected-error {{escaping closure captures non-escaping parameter 'fn'}}
     let _ = (repeat (each fn)()) // expected-note@:22 {{captured here}}
   }
 }
 
-func badNoEscapeCaptureFromPackIteration<each T>(_ fn: repeat () -> each T) {
-  takesEscaping { // expected-error {{escaping closure captures non-escaping value}}
+func badNoEscapeCaptureFromPackIteration<each T>(_ fn: repeat () -> each T) { // expected-note@:52 {{parameter 'fn' is implicitly non-escaping}}
+  takesEscaping { // expected-error {{escaping closure captures non-escaping parameter 'fn'}}
     for f in repeat each fn {
       let _ = f() // expected-note@:15 {{captured here}}
     }
   }
 }
 
-func badNoEscapeCaptureFromDeferPack<each T>(_ fn: repeat () -> each T) {
-  takesEscaping { // expected-error {{escaping closure captures non-escaping value}}
+func badNoEscapeCaptureFromDeferPack<each T>(_ fn: repeat () -> each T) { // expected-note@:48 {{parameter 'fn' is implicitly non-escaping}}
+  takesEscaping { // expected-error {{escaping closure captures non-escaping parameter 'fn'}}
     defer { // expected-note {{captured indirectly by this call}}
       let _ = (repeat (each fn)()) // expected-note@:24 {{captured here}}
     }

--- a/test/SILOptimizer/invalid_escaping_captures.swift
+++ b/test/SILOptimizer/invalid_escaping_captures.swift
@@ -274,3 +274,9 @@ struct TestInoutEscapeInClosure {
     }
   }
 }
+
+func badNoEscapeCaptureFromPack<each T>(_ fn: repeat () -> each T) { // expected-note {{captured here}}
+  takesEscaping { // expected-error {{escaping closure captures non-escaping value}}
+    let _ = (repeat (each fn)())
+  }
+}

--- a/test/SILOptimizer/invalid_escaping_captures.swift
+++ b/test/SILOptimizer/invalid_escaping_captures.swift
@@ -275,8 +275,16 @@ struct TestInoutEscapeInClosure {
   }
 }
 
-func badNoEscapeCaptureFromPack<each T>(_ fn: repeat () -> each T) { // expected-note {{captured here}}
+func badNoEscapeCaptureFromPack<each T>(_ fn: repeat () -> each T) {
   takesEscaping { // expected-error {{escaping closure captures non-escaping value}}
-    let _ = (repeat (each fn)())
+    let _ = (repeat (each fn)()) // expected-note@:22 {{captured here}}
+  }
+}
+
+func badNoEscapeCaptureFromPackIteration<each T>(_ fn: repeat () -> each T) {
+  takesEscaping { // expected-error {{escaping closure captures non-escaping value}}
+    for f in repeat each fn {
+      let _ = f() // expected-note@:15 {{captured here}}
+    }
   }
 }

--- a/test/SILOptimizer/invalid_escaping_captures.swift
+++ b/test/SILOptimizer/invalid_escaping_captures.swift
@@ -283,8 +283,8 @@ func badNoEscapeCaptureFromPack<each T>(_ fn: repeat () -> each T) { // expected
 
 func badNoEscapeCaptureFromPackIteration<each T>(_ fn: repeat () -> each T) { // expected-note@:52 {{parameter 'fn' is implicitly non-escaping}}
   takesEscaping { // expected-error {{escaping closure captures non-escaping parameter 'fn'}}
-    for f in repeat each fn {
-      let _ = f() // expected-note@:15 {{captured here}}
+    for f in repeat each fn { // expected-note@:21 {{captured here}}
+      let _ = f()
     }
   }
 }
@@ -295,6 +295,17 @@ func badNoEscapeCaptureFromDeferPack<each T>(_ fn: repeat () -> each T) { // exp
       let _ = (repeat (each fn)()) // expected-note@:24 {{captured here}}
     }
     let _ = 5
+  }
+}
+
+func badNoEscapeCaptureFromDeferedPackIteration<each T>(_ fn: repeat () -> each T) { // expected-note@:59 {{parameter 'fn' is implicitly non-escaping}}
+  takesEscaping { // expected-error {{escaping closure captures non-escaping parameter 'fn'}}
+    defer { // expected-note {{captured indirectly by this call}}
+      for f in repeat each fn { // expected-note@:23 {{captured here}}
+        let _ = f()
+      }
+    }
+    let _ = 42
   }
 }
 

--- a/test/SILOptimizer/invalid_escaping_captures.swift
+++ b/test/SILOptimizer/invalid_escaping_captures.swift
@@ -329,6 +329,24 @@ func badNoEscapeCaptureFromDeferedEscapingPackIteration<each T>(_ fn: repeat () 
   let _ = 42
 }
 
+func badRepeatedNoEscapeCaptureFromPackIteration<each T>(_ fn: repeat () -> each T) { // expected-note {{parameter 'fn' is implicitly non-escaping}}
+  repeat takesEscaping { // expected-error {{escaping closure captures non-escaping parameter 'fn'}}
+    _ = (each fn)() // expected-note {{captured here}}
+  }
+}
+
+// TODO: test this case when we can compile repeat ... { defer { ... } }
+// https://github.com/swiftlang/swift/issues/87206
+// 
+// func badRepeatedDeferedNoEscapeCaptureFromPackIteration<each T>(_ fn: repeat () -> each T) { // expected note {{parameter 'fn' is implicitly non-escaping}}
+//   repeat takesEscaping { // expected error {{escaping closure captures non-escaping parameter 'fn'}}
+//     defer {
+//       _ = (each fn)() // expected note {{captured here}}
+//     }
+//   }
+// }
+
+
 func badNoEscapeCaptureAfterPackExpansion<each T>(_ fn: repeat () -> each T) {
   let tup = (repeat each fn)
 

--- a/test/SILOptimizer/invalid_escaping_captures.swift
+++ b/test/SILOptimizer/invalid_escaping_captures.swift
@@ -288,3 +288,20 @@ func badNoEscapeCaptureFromPackIteration<each T>(_ fn: repeat () -> each T) {
     }
   }
 }
+
+func badNoEscapeCaptureFromDeferPack<each T>(_ fn: repeat () -> each T) {
+  takesEscaping { // expected-error {{escaping closure captures non-escaping value}}
+    defer { // expected-note {{captured indirectly by this call}}
+      let _ = (repeat (each fn)()) // expected-note@:24 {{captured here}}
+    }
+    let _ = 5
+  }
+}
+
+func badNoEscapeCaptureAfterPackExpansion<each T>(_ fn: repeat () -> each T) {
+  let tup = (repeat each fn)
+
+  takesEscaping { // expected-error {{escaping closure captures non-escaping value}}
+    let _ = tup
+  }
+}

--- a/test/type/pack_expansion.swift
+++ b/test/type/pack_expansion.swift
@@ -108,3 +108,13 @@ typealias First<T, U> = T
 
 func unusedParameterPack2<each T>(_: repeat First<Int, each T>) {}
 // expected-error@-1 {{generic parameter 'T' is not used in function signature}}
+
+// ensure that packs aren't considered implicitly escaping
+func capturePackClosureWithoutEscape<each T>(_ t: repeat () -> each T) {
+  _ = {
+    _ = (repeat (each t)())
+  }
+}
+
+capturePackClosureWithoutEscape({ 1 }, { 2 })
+


### PR DESCRIPTION
Resolves #86399.

`isNoEscape` in `TypeBase` wasn't checking for `PackExpansionType` to check `isNoEscape` and discover no escape functions in the pack expansion, which this PR fixes in 9f58221. Updating `isNoEscape` required setting `TVO_CanBindToNoEscape` on expansion variables, otherwise passing closures would fail. My hunch is that this wasn't necessary when `isNoEscape` didn't inspect pack expansions.

Now, the use of non escaping functions in a pack expansion will be detected and reported.

Also updates `diagnoseCaptureLoc` to be able to follow pack indirection to put the `[value_captured_here]` annotation on the usage of the pack, and `getParamDeclFromOperand` to be able to find the parameter from `AllocStackInst` indirection that happens when using packs.

```swift
func escapes<T>(_: @escaping () -> T) {}

func foo<each T>(_ t: repeat () -> each T) {
  escapes {
    let _ = (repeat (each t)())
  }
}
```

```
error: escaping closure captures non-escaping parameter 't'
 1 | func escapes<T>(_: @escaping () -> T) {}
 2 |
 3 | func foo<each T>(_ t: repeat () -> each T) {
   |                    `- note: parameter 't' is implicitly non-escaping
 4 |   escapes {
   |           `- error: escaping closure captures non-escaping parameter 't'
 5 |     let _ = (repeat (each t)())
   |                      `- note: captured here
 6 |   }
 7 | }
 ```
 
