### PR TITLE
Optimizer: don't remove unused `destructure_struct` of a non-copyable value

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -441,6 +441,14 @@ extension Instruction {
       // An extend_lifetime can only be removed if the operand is also removed.
       // If its operand is trivial, it will be removed by MandatorySimplification.
       return false
+    case let dsi as DestructureStructInst:
+      // A dead `destructure_struct` with an owned argument can appear for a non-copyable or
+      // non-escapable struct which has only trivial elements. The instruction is not trivially
+      // dead because it ends the lifetime of its operand.
+      if dsi.struct.ownership == .owned {
+        return false
+      }
+      return true
     default:
       break
     }

--- a/test/SILOptimizer/sil_combine_inst_passes.sil
+++ b/test/SILOptimizer/sil_combine_inst_passes.sil
@@ -8,6 +8,11 @@ import SwiftShims
 
 class Buffer {}
 
+struct NCWithoutDeinit: ~Copyable {
+  var a: Bool
+  var b: Int
+}
+
 sil_global @_swiftEmptyArrayStorage : $_SwiftEmptyArrayStorage
 
 // CHECK-LABEL: sil [ossa] @remove_end_begin_cow_pair
@@ -166,3 +171,14 @@ bb3(%9 : @guaranteed $Buffer):
   %r = tuple ()
   return %r : $()
 }
+
+// CHECK-LABEL: sil [ossa] @dont_remove_non_copyable_destructure
+// CHECK:         (%1, %2) = destructure_struct %0
+// CHECK:       } // end sil function 'dont_remove_non_copyable_destructure'
+sil [ossa] @dont_remove_non_copyable_destructure : $@convention(thin) (@owned NCWithoutDeinit) -> () {
+bb0(%0 : @owned $NCWithoutDeinit):
+  (%1, %2) = destructure_struct %0
+  %r = tuple ()
+  return %r
+}
+


### PR DESCRIPTION
Because `destructure_struct` acts as lifetime-ending use. Removing this instruction results in an ownership error. This can happen if a non-copyable struct only has trivial fields.

Fixes a verifier crash
https://github.com/swiftlang/swift/issues/86901
rdar://169285436
