### PR TITLE
DeinitDevirtualizer: don't devirtualize `destroy_value [dead_end]`

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/Devirtualization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/Devirtualization.swift
@@ -17,6 +17,12 @@ import SIL
 /// This may be a no-op if the destroy doesn't call any deinitializers.
 /// Returns true if all deinitializers could be devirtualized.
 func devirtualizeDeinits(of destroy: DestroyValueInst, isMandatory: Bool, _ context: some MutatingContext) -> Bool {
+  if destroy.isDeadEnd {
+    // It doesn't make sense to de-virtualize `destroy_value [dead_end]` because such operations
+    // are no-ops anyway. This is especially important for Embedded Swift, because introducing
+    // calls to generic deinit functions after the mandatory pipeline can result in IRGen crashes.
+    return true
+  }
   return devirtualize(destroy: destroy, isMandatory: isMandatory, context)
 }
 

--- a/test/SILOptimizer/devirt_deinits.sil
+++ b/test/SILOptimizer/devirt_deinits.sil
@@ -68,6 +68,16 @@ bb0(%0 : @owned $S1):
   return %r : $()
 }
 
+// CHECK-LABEL: sil [ossa] @dont_devirtualize_deadend_destroys :
+// CHECK:         destroy_value [dead_end] %0
+// CHECK-NEXT:    unreachable
+// CHECK:       } // end sil function 'dont_devirtualize_deadend_destroys'
+sil [ossa] @dont_devirtualize_deadend_destroys : $@convention(thin) (@owned S1) -> () {
+bb0(%0 : @owned $S1):
+  destroy_value [dead_end] %0
+  unreachable
+}
+
 // CHECK-LABEL: sil [ossa] @test_two_field_deinits :
 // CHECK:         ([[S1:%.*]], [[S2:%.*]], %{{[0-9]*}}) = destructure_struct %0
 // CHECK:         [[D1:%.*]] = function_ref @s1_deinit


### PR DESCRIPTION
It doesn't make sense to de-virtualize `destroy_value [dead_end]` because such operations are no-ops anyway. This is especially important for Embedded Swift, because introducing calls to generic deinit functions after the mandatory pipeline can result in IRGen crashes.

rdar://168171608
