### PR TITLE
[update-checkout] fix error when running --skip-history with commit hash

### DIFF
--- a/utils/update_checkout/tests/scheme_mock.py
+++ b/utils/update_checkout/tests/scheme_mock.py
@@ -219,7 +219,8 @@ class SchemeMockTestCase(unittest.TestCase):
         teardown_mock_remote(self.workspace)
 
     def call(self, *args, **kwargs):
-        kwargs["cwd"] = self.source_root
+        if "cwd" not in kwargs:
+            kwargs["cwd"] = self.source_root
         return call_quietly(*args, **kwargs)
 
     def get_all_repos(self):

--- a/utils/update_checkout/update_checkout/git_command.py
+++ b/utils/update_checkout/update_checkout/git_command.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import re
 import shlex
 import subprocess
 import sys
@@ -162,3 +163,7 @@ def is_any_repository_locked(pool_args: List[RunnerArguments]) -> Set[str]:
             if file.suffix == ".lock":
                 locked_repositories.add(repo_name)
     return locked_repositories
+
+def is_commit_hash(ref: str):
+    """Check if ref looks like a commit hash"""
+    return bool(re.match(r'^[0-9a-f]{7,40}$', ref, re.IGNORECASE))


### PR DESCRIPTION
Cloning with `--skip-history` fails if one the repo in the scheme uses a commit hash. This patch fixes this error.