### PR TITLE
DefiniteInitialization: handle inout-self uses when analyzing closures

### DIFF
--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
@@ -1239,6 +1239,7 @@ bool ElementUseCollector::addClosureElementUses(PartialApplyInst *pai,
       case DIUseKind::Load:
       case DIUseKind::Escape:
       case DIUseKind::InOutArgument:
+      case DIUseKind::InOutSelfArgument:
         break;
       default:
         return false;

--- a/test/SILOptimizer/definite_init_closures.swift
+++ b/test/SILOptimizer/definite_init_closures.swift
@@ -45,6 +45,15 @@ func forward(_ b: inout Bool) -> Bool {
   return b
 }
 
+struct T {
+  var i: Int
+
+  mutating func foo() -> Bool {
+    i == 0
+  }
+}
+
+
 struct InoutUse {
   var x: Bool
   var y: Bool
@@ -52,6 +61,18 @@ struct InoutUse {
   init() {
     x = false
     y = false || forward(&x)
+  }
+}
+
+struct InoutSelfUse {
+  var a: T
+  var b: T
+
+  init(_ x: T) {
+    a = x
+    if a.foo() || a.foo() {
+    }
+    b = x
   }
 }
 


### PR DESCRIPTION
Fixes a false "used before being initialized" error when using self-mutating functions inside conditional operators (`&&`, `||`) in initializers. This is a follow-up on https://github.com/swiftlang/swift/pull/35276.

rdar://168784050
