### PR TITLE
[Diagnostics]: restore unknown warning group behavior

### DIFF
--- a/include/swift/Basic/DiagnosticOptions.h
+++ b/include/swift/Basic/DiagnosticOptions.h
@@ -78,6 +78,10 @@ public:
   /// Rules for escalating warnings to errors
   llvm::SmallVector<WarningGroupBehaviorRule, 4> WarningGroupControlRules;
 
+  /// Unknown warning group names specified via -Werror or -Wwarning.
+  /// These will be diagnosed when the DiagnosticEngine is configured.
+  llvm::SmallVector<std::string, 1> UnknownWarningGroups;
+
   /// When printing diagnostics, include either the diagnostic name
   /// (diag::whatever) at the end or the associated diagnostic group.
   PrintDiagnosticNamesMode PrintDiagnosticNames =

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2774,15 +2774,26 @@ static bool ParseDiagnosticArgs(DiagnosticOptions &Opts, ArgList &Args,
       Opts.WarningGroupControlRules.emplace_back(
           WarningGroupBehavior::AsWarning);
       break;
-    case OPT_Werror:
-      Opts.WarningGroupControlRules.emplace_back(
-          WarningGroupBehavior::AsError, getDiagGroupIDByName(arg->getValue()));
+    case OPT_Werror: {
+      auto groupID = getDiagGroupIDByName(arg->getValue());
+      if (groupID && *groupID != DiagGroupID::no_group) {
+        Opts.WarningGroupControlRules.emplace_back(
+            WarningGroupBehavior::AsError, *groupID);
+      } else {
+        Opts.UnknownWarningGroups.push_back(arg->getValue());
+      }
       break;
-    case OPT_Wwarning:
-      Opts.WarningGroupControlRules.emplace_back(
-          WarningGroupBehavior::AsWarning,
-          getDiagGroupIDByName(arg->getValue()));
+    }
+    case OPT_Wwarning: {
+      auto groupID = getDiagGroupIDByName(arg->getValue());
+      if (groupID && *groupID != DiagGroupID::no_group) {
+        Opts.WarningGroupControlRules.emplace_back(
+            WarningGroupBehavior::AsWarning, *groupID);
+      } else {
+        Opts.UnknownWarningGroups.push_back(arg->getValue());
+      }
       break;
+    }
     default:
       llvm_unreachable("unhandled warning as error option");
     };
@@ -2887,6 +2898,12 @@ static void configureDiagnosticEngine(
 void CompilerInvocation::setUpDiagnosticEngine(DiagnosticEngine &diags) {
   configureDiagnosticEngine(DiagnosticOpts, LangOpts.EffectiveLanguageVersion,
                             FrontendOpts.MainExecutablePath, diags);
+
+  // Once configured, immediately diagnose any unknown warning groups that were
+  // encountered while parsing the diagnostic options.
+  for (const auto &unknownGroup : DiagnosticOpts.UnknownWarningGroups) {
+    diags.diagnose(SourceLoc(), diag::unknown_warning_group, unknownGroup);
+  }
 }
 
 /// Parse -enforce-exclusivity=... options

--- a/test/diagnostics/warnings_as_errors_rules.swift
+++ b/test/diagnostics/warnings_as_errors_rules.swift
@@ -2,8 +2,10 @@
 // RUN: not %target-swift-frontend -typecheck -diagnostic-style llvm -Werror DeprecatedDeclaration %s 2>&1 | %FileCheck %s --check-prefix=CHECK-WE-GROUP
 // RUN: %target-swift-frontend -typecheck -diagnostic-style llvm -warnings-as-errors -no-warnings-as-errors %s 2>&1 | %FileCheck %s --check-prefix=CHECK-WAE-NWAE
 // RUN: %target-swift-frontend -typecheck -diagnostic-style llvm -warnings-as-errors -Wwarning DeprecatedDeclaration %s 2>&1 | %FileCheck %s --check-prefix=CHECK-WAE-WW-GROUP
+// RUN: %target-swift-frontend -typecheck -diagnostic-style llvm -Werror SomeUnknownGroup %s 2>&1 | %FileCheck %s --check-prefix=CHECK-UNKNOWN-WE
+// RUN: %target-swift-frontend -typecheck -diagnostic-style llvm -Wwarning SomeUnknownGroup %s 2>&1 | %FileCheck %s --check-prefix=CHECK-UNKNOWN-WW
 
-// This test verifies that the warning control flags apply with respect to 
+// This test verifies that the warning control flags apply with respect to
 // the order they are specified in the cmd line.
 // Naming:
 // WAE: -warnings-as-errors
@@ -12,6 +14,8 @@
 // WW-xxxx: -Wwarning xxxx
 // GROUP - refers to a narrower group
 // SUPERGROUP - refers to a broader group that includes GROUP
+// UNKNOWN-WE: -Werror <unknown group id>
+// UNKNOWN-WW: -Wwarning <unknown group id>
 
 
 @available(*, deprecated)
@@ -43,3 +47,11 @@ foo()
 // CHECK-WAE-WW-GROUP: warning: 'bar()' is deprecated: renamed to 'bar2'
 // CHECK-WAE-WW-GROUP-NOT: error: 'bar()' is deprecated: renamed to 'bar2'
 bar()
+
+// Unknown warning groups should be appropriately diagnosed
+// CHECK-UNKNOWN-WE: warning: unknown warning group: 'SomeUnknownGroup'
+// CHECK-UNKNOWN-WE: warning: 'foo()' is deprecated
+// CHECK-UNKNOWN-WE-NOT: error: 'foo()' is deprecated
+// CHECK-UNKNOWN-WW: warning: unknown warning group: 'SomeUnknownGroup'
+// CHECK-UNKNOWN-WW: warning: 'foo()' is deprecated
+// CHECK-UNKNOWN-WW-NOT: error: 'foo()' is deprecated


### PR DESCRIPTION
Attempt to fix a likely regression from https://github.com/swiftlang/swift/pull/85036 which removed the functionality that would diagnose unrecognized diagnostic groups.

Resolves: https://github.com/swiftlang/swift/issues/86969