### PR TITLE
Fixes for printing borrow/mutate accessors in swiftinterface files

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2590,8 +2590,11 @@ void PrintAST::printAccessors(const AbstractStorageDecl *ASD) {
     Printer << " {";
     if (mutatingGetter) printWithSpace("mutating");
 
-    // TODO: Print borrow/yielding borrow here?
-    printWithSpace("get");
+    if (ASD->getParsedAccessor(AccessorKind::Borrow)) {
+      printWithSpace("borrow");
+    } else {
+      printWithSpace("get");
+    }
 
     if (asyncGet) printWithSpace("async");
 
@@ -2603,8 +2606,11 @@ void PrintAST::printAccessors(const AbstractStorageDecl *ASD) {
     if (settable) {
       if (nonmutatingSetter) printWithSpace("nonmutating");
 
-      // TODO: Print mutate/yielding mutate here?
-      printWithSpace("set");
+      if (ASD->getParsedAccessor(AccessorKind::Mutate)) {
+        printWithSpace("mutate");
+      } else {
+        printWithSpace("set");
+      }
     }
     Printer << " }";
     return;

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -481,8 +481,27 @@ UNINTERESTING_FEATURE(BuiltinInterleave)
 UNINTERESTING_FEATURE(BuiltinVectorsExternC)
 UNINTERESTING_FEATURE(AddressOfProperty2)
 UNINTERESTING_FEATURE(ImmutableWeakCaptures)
-// Ignore borrow and mutate accessors until it is used in the standard library.
-UNINTERESTING_FEATURE(BorrowAndMutateAccessors)
+
+static bool usesFeatureBorrowAndMutateAccessors(Decl *decl) {
+  auto accessorDeclUsesFeatureBorrowAndMutateAccessors =
+      [](AccessorDecl *accessor) {
+        return requiresFeatureBorrowAndMutateAccessors(
+            accessor->getAccessorKind());
+      };
+  switch (decl->getKind()) {
+  case DeclKind::Var: {
+    auto *var = cast<VarDecl>(decl);
+    return llvm::any_of(var->getAllAccessors(),
+                        accessorDeclUsesFeatureBorrowAndMutateAccessors);
+  }
+  case DeclKind::Accessor: {
+    auto *accessor = cast<AccessorDecl>(decl);
+    return accessorDeclUsesFeatureBorrowAndMutateAccessors(accessor);
+  }
+  default:
+    return false;
+  }
+}
 
 static bool usesFeatureInlineAlways(Decl *decl) {
   if (auto *inlineAttr = decl->getAttrs().getAttribute<InlineAttr>()) {

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -2981,7 +2981,8 @@ forwardFunctionArguments(SILGenFunction &SGF, SILLocation loc,
     if (isGuaranteedParameterInCallee(argTy.getConvention())) {
       auto forwardedArg =
           SGF.emitManagedBeginBorrow(loc, arg.getValue()).getValue();
-      if (fTy->hasGuaranteedResult(/*loweredAddresses*/ true)) {
+      if (forwardedArg->getType().isObject() &&
+          fTy->hasGuaranteedResult(/*loweredAddresses*/ true)) {
         forwardedArg = SGF.B.createUncheckedOwnership(loc, forwardedArg);
       }
       forwardedArgs.push_back(forwardedArg);

--- a/test/ModuleInterface/Inputs/borrow_accessors.swift
+++ b/test/ModuleInterface/Inputs/borrow_accessors.swift
@@ -1,0 +1,17 @@
+public class Klass {}
+
+public protocol P {
+  var k : Klass { borrow mutate }
+}
+
+public struct Wrapper : P {
+   var _k : Klass
+   public var k : Klass {
+     borrow {
+       return _k
+     }
+     mutate {
+       return &_k
+     }
+   }
+}

--- a/test/ModuleInterface/borrow_accessor_test.swift
+++ b/test/ModuleInterface/borrow_accessor_test.swift
@@ -25,7 +25,7 @@ import borrow_accessors
 
 // CHECK: public protocol P {
 // CHECK:   #if compiler(>=5.3) && $BorrowAndMutateAccessors
-// TODO-CHECK:   var k: borrow_accessors.Klass { borrow mutate }
+// CHECK:   var k: borrow_accessors.Klass { borrow mutate }
 // CHECK:   #endif
 // CHECK: }
 // CHECK: public struct Wrapper : borrow_accessors.P {

--- a/test/ModuleInterface/borrow_accessor_test.swift
+++ b/test/ModuleInterface/borrow_accessor_test.swift
@@ -1,0 +1,39 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution -emit-module \
+// RUN:     -enable-experimental-feature BorrowAndMutateAccessors \
+// RUN:     -o %t/borrow_accessors.swiftmodule \
+// RUN:     -emit-module-interface-path %t/borrow_accessors.swiftinterface \
+// RUN:     %S/Inputs/borrow_accessors.swift
+
+// Check the interfaces
+
+// RUN: %FileCheck %s < %t/borrow_accessors.swiftinterface
+
+// See if we can compile a module through just the interface and typecheck using it.
+
+// RUN: %target-swift-frontend -compile-module-from-interface \
+// RUN:    -enable-experimental-feature BorrowAndMutateAccessors \
+// RUN:    %t/borrow_accessors.swiftinterface -o %t/borrow_accessors.swiftmodule
+
+// RUN: %target-swift-frontend -typecheck -I %t %s \
+// RUN:    -enable-experimental-feature BorrowAndMutateAccessors
+
+// REQUIRES: swift_feature_BorrowAndMutateAccessors
+
+import borrow_accessors
+
+// CHECK: public protocol P {
+// CHECK:   #if compiler(>=5.3) && $BorrowAndMutateAccessors
+// TODO-CHECK:   var k: borrow_accessors.Klass { borrow mutate }
+// CHECK:   #endif
+// CHECK: }
+// CHECK: public struct Wrapper : borrow_accessors.P {
+// CHECK:   #if compiler(>=5.3) && $BorrowAndMutateAccessors
+// CHECK:   public var k: borrow_accessors.Klass {
+// CHECK:     borrow
+// CHECK:     mutate
+// CHECK:   }
+// CHECK:   #endif
+// CHECK: }
+

--- a/test/SILGen/borrow_accessor_protocol.swift
+++ b/test/SILGen/borrow_accessor_protocol.swift
@@ -17,6 +17,7 @@ public struct NonTrivial {
 // Protocol requirements witnessed via borrow/mutate accessors
 public struct S1 : P {
   var _id: NonTrivial
+  var _k: Klass
 
   public var id: NonTrivial {
     borrow {
@@ -142,6 +143,28 @@ public struct S5 : P {
   public var id: NonTrivial
 }
 
+public protocol Q {
+  var id: FrozenNonTrivial { borrow mutate }
+}
+
+@frozen
+public struct FrozenNonTrivial {
+  public var k: Klass
+}
+
+public struct S6 : Q {
+  var _id: FrozenNonTrivial
+
+  public var id: FrozenNonTrivial {
+    borrow {
+      return _id
+    }
+    mutate {
+      return &_id
+    }
+  }
+}
+
 // CHECK: sil shared [transparent] [serialized] [thunk] [ossa] @$s24borrow_accessor_protocol2S5VAA1PA2aDP2idAA10NonTrivialVvbTW : $@convention(witness_method: P) (@in_guaranteed S5) -> @guaranteed NonTrivial {
 // CHECK: bb0([[REG0:%.*]] : $*S5):
 // CHECK:   [[REG1:%.*]] = load_borrow [[REG0]]
@@ -164,6 +187,13 @@ public struct S5 : P {
 // CHECK-EVO: bb0([[REG0:%.*]] : $*S5):
 // CHECK-EVO:   [[REG1:%.*]] = function_ref @$s24borrow_accessor_protocol2S5V2idAA10NonTrivialVvb : $@convention(method) (@in_guaranteed S5) -> @guaranteed_address NonTrivial
 // CHECK-EVO:   [[REG2:%.*]] = apply [[REG1]]([[REG0]]) : $@convention(method) (@in_guaranteed S5) -> @guaranteed_address NonTrivial
+// CHECK-EVO:   return [[REG2]]
+// CHECK-EVO: }
+
+// CHECK-EVO: sil private [transparent] [thunk] [ossa] @$s24borrow_accessor_protocol2S6VAA1QA2aDP2idAA16FrozenNonTrivialVvbTW : $@convention(witness_method: Q) (@in_guaranteed S6) -> @guaranteed FrozenNonTrivial {
+// CHECK-EVO: bb0([[REG0:%.*]] : $*S6):
+// CHECK-EVO:   [[REG1:%.*]] = function_ref @$s24borrow_accessor_protocol2S6V2idAA16FrozenNonTrivialVvb : $@convention(method) (@in_guaranteed S6) -> @guaranteed FrozenNonTrivial
+// CHECK-EVO:   [[REG2:%.*]] = apply [[REG1]]([[REG0]]) : $@convention(method) (@in_guaranteed S6) -> @guaranteed FrozenNonTrivial
 // CHECK-EVO:   return [[REG2]]
 // CHECK-EVO: }
 


### PR DESCRIPTION
This PR ensures we guard borrow/mutate accessors with feature flags in swiftinterface files. Also fixes ASTPrinter to print borrow/mutate in the protocol requirement instead of get/set. 