### PR TITLE
[Sema] Correctly handle properties in nested macros

### DIFF
--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -3253,18 +3253,20 @@ ManglingError Remangler::mangleFreestandingMacroExpansion(
 
 ManglingError Remangler::mangleAttachedMacro(Node *node, unsigned depth,
                                              StringRef mangledChar) {
-  RETURN_IF_ERROR(mangleChildNode(node, 0, depth + 1));
-  RETURN_IF_ERROR(mangleChildNode(node, 1, depth + 1));
-  RETURN_IF_ERROR(mangleChildNode(node, 2, depth + 1));
+  unsigned idx = 0;
+  while (idx + 1 < node->getNumChildren()) {
+    RETURN_IF_ERROR(mangleChildNode(node, idx, depth));
+    idx += 1;
+  }
   Buffer << "fM" << mangledChar;
-  return mangleChildNode(node, 3, depth + 1);
+  return mangleChildNode(node, idx, depth);
 }
 
 #define FREESTANDING_MACRO_ROLE(Name, Description)
 #define ATTACHED_MACRO_ROLE(Name, Description, MangledChar)    \
 ManglingError Remangler::mangle##Name##AttachedMacroExpansion( \
     Node *node, unsigned depth) {                              \
-  return mangleAttachedMacro(node, depth, MangledChar);        \
+  return mangleAttachedMacro(node, depth + 1, MangledChar);    \
 }
 #include "swift/Basic/MacroRoles.def"
 

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -358,6 +358,9 @@ class Remangler : public RemanglerBase {
     return mangleChildNodesReversed(FuncType, depth);
   }
 
+  ManglingError mangleAttachedMacro(Node *node, unsigned depth,
+                                    StringRef mangledChar);
+
   ManglingError mangleGenericSpecializationNode(Node *node,
                                                 char specKind,
                                                 unsigned depth);
@@ -3248,15 +3251,20 @@ ManglingError Remangler::mangleFreestandingMacroExpansion(
   return mangleChildNode(node, 2, depth + 1);
 }
 
+ManglingError Remangler::mangleAttachedMacro(Node *node, unsigned depth,
+                                             StringRef mangledChar) {
+  RETURN_IF_ERROR(mangleChildNode(node, 0, depth + 1));
+  RETURN_IF_ERROR(mangleChildNode(node, 1, depth + 1));
+  RETURN_IF_ERROR(mangleChildNode(node, 2, depth + 1));
+  Buffer << "fM" << mangledChar;
+  return mangleChildNode(node, 3, depth + 1);
+}
+
 #define FREESTANDING_MACRO_ROLE(Name, Description)
 #define ATTACHED_MACRO_ROLE(Name, Description, MangledChar)    \
 ManglingError Remangler::mangle##Name##AttachedMacroExpansion( \
     Node *node, unsigned depth) {                              \
-  RETURN_IF_ERROR(mangleChildNode(node, 0, depth + 1));        \
-  RETURN_IF_ERROR(mangleChildNode(node, 1, depth + 1));        \
-  RETURN_IF_ERROR(mangleChildNode(node, 2, depth + 1));        \
-  Buffer << "fM" MangledChar;                                  \
-  return mangleChildNode(node, 3, depth + 1);                  \
+  return mangleAttachedMacro(node, depth, MangledChar);        \
 }
 #include "swift/Basic/MacroRoles.def"
 

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -210,29 +210,27 @@ static void enumerateStoredPropertiesAndMissing(
         _addStoredProperty(var);
     }
   };
+  std::function<void(Decl *)> visitMember;
+  visitMember = [&](Decl *member) {
+    if (auto *var = dyn_cast<VarDecl>(member))
+      addStoredProperty(var);
+
+    member->visitAuxiliaryDecls(visitMember);
+
+    if (auto missing = dyn_cast<MissingMemberDecl>(member))
+      if (missing->getNumberOfFieldOffsetVectorEntries() > 0)
+        addMissing(missing);
+  };
 
   // If we have a distributed actor, find the id and actorSystem
   // properties. We always want them first, and in a specific
   // order.
   if (auto idVar = decl->getDistributedActorIDProperty())
-    addStoredProperty(idVar);
+    visitMember(idVar);
   if (auto actorSystemVar = decl->getDistributedActorSystemProperty())
-    addStoredProperty(actorSystemVar);
-
-  for (auto *member : implDecl->getMembers()) {
-    if (auto *var = dyn_cast<VarDecl>(member)) {
-      addStoredProperty(var);
-    }
-
-    member->visitAuxiliaryDecls([&](Decl *auxDecl) {
-      if (auto auxVar = dyn_cast<VarDecl>(auxDecl))
-        addStoredProperty(auxVar);
-    });
-
-    if (auto missing = dyn_cast<MissingMemberDecl>(member))
-      if (missing->getNumberOfFieldOffsetVectorEntries() > 0)
-        addMissing(missing);
-  }
+    visitMember(actorSystemVar);
+  for (auto *member : implDecl->getMembers())
+    visitMember(member);
 }
 
 static bool isInSourceFile(IterableDeclContext *idc) {
@@ -345,15 +343,16 @@ InitializablePropertiesRequest::evaluate(Evaluator &evaluator,
     }
   };
 
-  for (auto *member : decl->getMembers()) {
+  std::function<void(Decl *)> visitMember;
+  visitMember = [&](Decl *member) {
     if (auto *var = dyn_cast<VarDecl>(member))
       maybeAddProperty(var);
 
-    member->visitAuxiliaryDecls([&](Decl *auxDecl) {
-      if (auto auxVar = dyn_cast<VarDecl>(auxDecl))
-        maybeAddProperty(auxVar);
-    });
-  }
+    member->visitAuxiliaryDecls(visitMember);
+  };
+
+  for (auto *member : decl->getMembers())
+    visitMember(member);
 
   return decl->getASTContext().AllocateCopy(results);
 }

--- a/test/Macros/macro_nested_property_expand.swift
+++ b/test/Macros/macro_nested_property_expand.swift
@@ -1,0 +1,97 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name MacroDefinition %t/MacroDefinition.swift -g -no-toolchain-stdlib-rpath
+
+// RUN: %target-swift-frontend -emit-sil -load-plugin-library %t/%target-library-name(MacroDefinition) %t/main.swift | %FileCheck --check-prefix SIL %s
+// RUN: %target-swift-frontend -emit-ir -load-plugin-library %t/%target-library-name(MacroDefinition) %t/main.swift | %FileCheck --check-prefix IR %s
+
+// RUN: %target-swift-ide-test -print-ast-typechecked -print-access -source-filename=%t/main.swift -load-plugin-library %t/%target-library-name(MacroDefinition) | %FileCheck %s --check-prefix PRINT
+
+//--- MacroDefinition.swift
+
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+struct StorageMacro: DeclarationMacro {
+  static func expansion(
+    of node: some SwiftSyntax.FreestandingMacroExpansionSyntax,
+    in context: some SwiftSyntaxMacros.MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    ["var _property: T"]
+  }
+}
+
+struct StorageTrampolineMacro: PeerMacro {
+  static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    [#"#_Property()"#]
+  }
+}
+
+//--- main.swift
+
+@freestanding(declaration, names: arbitrary)
+macro _Property() = #externalMacro(module: "MacroDefinition", type: "StorageMacro")
+
+@attached(peer, names: prefixed(_))
+macro PropertyWrap() = #externalMacro(module: "MacroDefinition", type: "StorageTrampolineMacro")
+
+// Make sure we can lower this without crashing.
+public struct S1<T> {
+  @PropertyWrap var property: T {
+    fatalError()
+  }
+  public init(_ x: T) {
+    self._property = x
+  }
+}
+
+public struct S2 {
+  public typealias T = Bool
+  @PropertyWrap var property: Int = 0
+  public init(_ x: T) {
+    self._property = x
+  }
+}
+// IR: %T4main2S2V = type <{ %TSi, %TSb }>
+
+public class C<T> {
+  @PropertyWrap var property: T {
+    fatalError()
+  }
+  public init(_ x: T) {
+    self._property = x
+  }
+}
+// SIL:      sil_vtable C {
+// SIL-NEXT:   #C._property!getter: <T> (C<T>) -> () -> T : @$s4main1CC9_propertyxvg
+// SIL-NEXT:   #C._property!setter: <T> (C<T>) -> (T) -> () : @$s4main1CC9_propertyxvs
+// SIL-NEXT:   #C._property!modify: <T> (C<T>) -> () -> () : @$s4main1CC9_propertyxvM
+
+// PRINT-LABEL: struct TestMemberwise1<T>
+struct TestMemberwise1<T> {
+  @PropertyWrap var property: T
+  // PRINT: internal init(property: T, _property: T)
+
+  func foo() {
+    // Force the memberwise initializer to be emitted.
+    _ = Self.init(property:_property:)
+  }
+}
+
+// PRINT-LABEL: struct TestMemberwise2<T>
+struct TestMemberwise2<T> {
+  @PropertyWrap var property: T { fatalError() }
+  // PRINT: internal init(_property: T)
+
+  func foo() {
+    // Force the memberwise initializer to be emitted.
+    _ = Self.init(_property:)
+  }
+}


### PR DESCRIPTION
We need to ensure that we recurse into the auxiliary decls in `enumerateStoredPropertiesAndMissing` to pick up properties in nested macro expansions. Also do the same in `enumerateCurrentPropertiesAndAuxiliaryVars` and `InitializablePropertiesRequest` to ensure the memberwise initializer correctly handles this case.

This would technically be ABI breaking, but previously we would have just crashed in SILGen.

rdar://166908960