### PR TITLE
[cxx-interop] Fix printing suppressible conformances for imported types

### DIFF
--- a/test/Interop/Cxx/class/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/Inputs/module.modulemap
@@ -172,3 +172,9 @@ module Mirror {
   requires cplusplus
   export *
 }
+
+module SuppressibleProtocols {
+  header "suppressible-protocols.h"
+  requires cplusplus
+  export *
+}

--- a/test/Interop/Cxx/class/Inputs/suppressible-protocols.h
+++ b/test/Interop/Cxx/class/Inputs/suppressible-protocols.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "swift/bridging"
+
+struct SWIFT_NONESCAPABLE View {};
+
+struct SWIFT_NONCOPYABLE Noncopyable {};

--- a/test/Interop/Cxx/class/inheritance/protected-special-member-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/protected-special-member-module-interface.swift
@@ -32,13 +32,13 @@
 // CHECK-NEXT:   init()
 // CHECK-NEXT: }
 
-// CHECK:      struct InheritsProtectedMove {
+// CHECK:      struct InheritsProtectedMove : ~Copyable {
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   func getFromBase() -> Int32
 // CHECK-NEXT:   mutating func setFromBase(_ x: Int32)
 // CHECK-NEXT: }
 
-// CHECK:      struct ProtectedCopyWithMove {
+// CHECK:      struct ProtectedCopyWithMove : ~Copyable {
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   var fromBase: Int32
 // CHECK-NEXT: }

--- a/test/Interop/Cxx/class/suppressible-module-interface.swift
+++ b/test/Interop/Cxx/class/suppressible-module-interface.swift
@@ -1,0 +1,4 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=SuppressibleProtocols -I %swift_src_root/lib/ClangImporter/SwiftBridging -I %S/Inputs -source-filename=x -cxx-interoperability-mode=default | %FileCheck %s
+
+// CHECK: struct View : ~Escapable {
+// CHECK: struct Noncopyable : ~Copyable {

--- a/test/Interop/Cxx/templates/uninstantiatable-special-members-module-interface.swift
+++ b/test/Interop/Cxx/templates/uninstantiatable-special-members-module-interface.swift
@@ -1,9 +1,9 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=UninstantiatableSpecialMembers -I %S/Inputs -source-filename=x -cxx-interoperability-mode=upcoming-swift | %FileCheck %s
 
-// CHECK: struct HasUninstantiatableCopyConstructor<CInt> {
+// CHECK: struct HasUninstantiatableCopyConstructor<CInt> : ~Copyable {
 // CHECK: }
 // CHECK: typealias NonCopyableInst = HasUninstantiatableCopyConstructor<CInt>
 
-// CHECK: struct DerivedUninstantiatableCopyConstructor<CInt> {
+// CHECK: struct DerivedUninstantiatableCopyConstructor<CInt> : ~Copyable {
 // CHECK: }
 // CHECK: typealias DerivedNonCopyableInst = DerivedUninstantiatableCopyConstructor<CInt>


### PR DESCRIPTION
We only added the old attributes but those are not picked up by ASTPrinter. This PR adds inherited entries which is the correct representation of these conformances.

rdar://157868143
