### PR TITLE
Add swift-testing build dependency to XCTest

### DIFF
--- a/utils/swift_build_support/swift_build_support/build_script_invocation.py
+++ b/utils/swift_build_support/swift_build_support/build_script_invocation.py
@@ -656,6 +656,15 @@ class BuildScriptInvocation(object):
         builder.add_impl_product(products.LibDispatch,
                                  is_enabled=self.args.build_libdispatch)
 
+        # Begin a new build-script pipeline for Swift Testing only. This is a required
+        # dependency to build XCTest, which is in the next pipeline.
+        # We can't include both in the same pipeline because XCTest is an impl product.
+        builder.begin_pipeline()
+        builder.add_product(products.SwiftTestingMacros,
+                            is_enabled=self.args.build_swift_testing_macros)
+        builder.add_product(products.SwiftTesting,
+                            is_enabled=self.args.build_swift_testing)
+
         # Begin a new build-script-impl pipeline that builds libraries that we
         # build as part of build-script-impl but that we should eventually move
         # onto build-script products.
@@ -675,10 +684,6 @@ class BuildScriptInvocation(object):
         builder.add_product(products.WasmLLVMRuntimeLibs,
                             is_enabled=self.args.build_wasmstdlib)
 
-        builder.add_product(products.SwiftTestingMacros,
-                            is_enabled=self.args.build_swift_testing_macros)
-        builder.add_product(products.SwiftTesting,
-                            is_enabled=self.args.build_swift_testing)
         builder.add_product(products.SwiftPM,
                             is_enabled=self.args.build_swiftpm)
 

--- a/utils/swift_build_support/swift_build_support/build_script_invocation.py
+++ b/utils/swift_build_support/swift_build_support/build_script_invocation.py
@@ -662,8 +662,19 @@ class BuildScriptInvocation(object):
         builder.begin_impl_pipeline(should_run_epilogue_operations=True)
         builder.add_impl_product(products.Foundation,
                                  is_enabled=self.args.build_foundation)
+
+        # Build Swift Testing here because it has to come before XCTest but after Foundation
+        builder.begin_pipeline()
+        builder.add_product(products.SwiftTestingMacros,
+                            is_enabled=self.args.build_swift_testing_macros)
+        builder.add_product(products.SwiftTesting,
+                            is_enabled=self.args.build_swift_testing)
+
+        builder.begin_impl_pipeline(should_run_epilogue_operations=True)
         builder.add_impl_product(products.LLBuild,
                                  is_enabled=self.args.build_llbuild)
+        builder.add_impl_product(products.XCTest,
+                                 is_enabled=self.args.build_xctest)
 
         # Begin the post build-script-impl build phase.
         builder.begin_pipeline()
@@ -673,10 +684,6 @@ class BuildScriptInvocation(object):
         builder.add_product(products.WasmLLVMRuntimeLibs,
                             is_enabled=self.args.build_wasmstdlib)
 
-        builder.add_product(products.SwiftTestingMacros,
-                            is_enabled=self.args.build_swift_testing_macros)
-        builder.add_product(products.SwiftTesting,
-                            is_enabled=self.args.build_swift_testing)
         builder.add_product(products.SwiftPM,
                             is_enabled=self.args.build_swiftpm)
 
@@ -735,12 +742,6 @@ class BuildScriptInvocation(object):
         builder.add_product(products.SwiftDriver,
                             is_enabled=self.args.build_swift_driver
                             or self.args.install_swift_driver)
-
-        # Build XCTest last since it must follow after Swift Testing. It requires a
-        # separate pipeline since it is an impl_product.
-        builder.begin_impl_pipeline(should_run_epilogue_operations=True)
-        builder.add_impl_product(products.XCTest,
-                                 is_enabled=self.args.build_xctest)
 
         # Now that we have constructed our pass pipelines using our builder, get
         # the final schedule and finalize the builder.

--- a/utils/swift_build_support/swift_build_support/build_script_invocation.py
+++ b/utils/swift_build_support/swift_build_support/build_script_invocation.py
@@ -656,23 +656,12 @@ class BuildScriptInvocation(object):
         builder.add_impl_product(products.LibDispatch,
                                  is_enabled=self.args.build_libdispatch)
 
-        # Begin a new build-script pipeline for Swift Testing only. This is a required
-        # dependency to build XCTest, which is in the next pipeline.
-        # We can't include both in the same pipeline because XCTest is an impl product.
-        builder.begin_pipeline()
-        builder.add_product(products.SwiftTestingMacros,
-                            is_enabled=self.args.build_swift_testing_macros)
-        builder.add_product(products.SwiftTesting,
-                            is_enabled=self.args.build_swift_testing)
-
         # Begin a new build-script-impl pipeline that builds libraries that we
         # build as part of build-script-impl but that we should eventually move
         # onto build-script products.
         builder.begin_impl_pipeline(should_run_epilogue_operations=True)
         builder.add_impl_product(products.Foundation,
                                  is_enabled=self.args.build_foundation)
-        builder.add_impl_product(products.XCTest,
-                                 is_enabled=self.args.build_xctest)
         builder.add_impl_product(products.LLBuild,
                                  is_enabled=self.args.build_llbuild)
 
@@ -684,6 +673,10 @@ class BuildScriptInvocation(object):
         builder.add_product(products.WasmLLVMRuntimeLibs,
                             is_enabled=self.args.build_wasmstdlib)
 
+        builder.add_product(products.SwiftTestingMacros,
+                            is_enabled=self.args.build_swift_testing_macros)
+        builder.add_product(products.SwiftTesting,
+                            is_enabled=self.args.build_swift_testing)
         builder.add_product(products.SwiftPM,
                             is_enabled=self.args.build_swiftpm)
 
@@ -742,6 +735,12 @@ class BuildScriptInvocation(object):
         builder.add_product(products.SwiftDriver,
                             is_enabled=self.args.build_swift_driver
                             or self.args.install_swift_driver)
+
+        # Build XCTest last since it must follow after Swift Testing. It requires a
+        # separate pipeline since it is an impl_product.
+        builder.begin_impl_pipeline(should_run_epilogue_operations=True)
+        builder.add_impl_product(products.XCTest,
+                                 is_enabled=self.args.build_xctest)
 
         # Now that we have constructed our pass pipelines using our builder, get
         # the final schedule and finalize the builder.

--- a/utils/swift_build_support/swift_build_support/products/swift_testing.py
+++ b/utils/swift_build_support/swift_build_support/products/swift_testing.py
@@ -15,6 +15,7 @@ import os
 from build_swift.build_swift.versions import Version
 
 from . import cmake_product
+from . import foundation
 from . import product
 from . import swift
 from . import swift_testing_macros
@@ -37,7 +38,8 @@ class SwiftTesting(product.Product):
     @classmethod
     def get_dependencies(cls):
         return [swift.Swift,
-                swift_testing_macros.SwiftTestingMacros]
+                swift_testing_macros.SwiftTestingMacros,
+                foundation.Foundation]
 
     def should_clean(self, host_target):
         # Workaround for 'swift-testing' not detecting compiler/stdlib changes.

--- a/utils/swift_build_support/swift_build_support/products/xctest.py
+++ b/utils/swift_build_support/swift_build_support/products/xctest.py
@@ -17,6 +17,7 @@ from . import libdispatch
 from . import llvm
 from . import product
 from . import swift
+from . import swift_testing
 
 
 class XCTest(product.Product):
@@ -47,7 +48,8 @@ class XCTest(product.Product):
                 libcxx.LibCXX,
                 swift.Swift,
                 libdispatch.LibDispatch,
-                foundation.Foundation]
+                foundation.Foundation,
+                swift_testing.SwiftTesting]
 
     @classmethod
     def is_nondarwin_only_build_product(cls):

--- a/validation-test/BuildSystem/android_cross_compile.test
+++ b/validation-test/BuildSystem/android_cross_compile.test
@@ -7,9 +7,9 @@
 # CHECK-NOT: cmake --build {{.*}}/llvm-android-aarch64 --config
 # CHECK-NOT: cmake --build {{.*}}/llvm-android-aarch64 {{.*}} install-llvm
 # CHECK: cmake {{.*}}-DSWIFT_INCLUDE_TOOLS:BOOL=FALSE{{.*}}/swift
+# CHECK: Skipping building Foundation Macros for android-aarch64, because the host tools are not being built
+# CHECK: Skipping installing Foundation Macros for android-aarch64, because the host tools are not being built
 # CHECK: Skipping building Testing Macros for android-aarch64, because the host tools are not being built
 # CHECK: Skipping installing Testing Macros for android-aarch64, because the host tools are not being built
 # CHECK: cmake {{.*}}-DCMAKE_TOOLCHAIN_FILE:PATH={{.*}}swifttesting-android-aarch64/BuildScriptToolchain.cmake
 # CHECK: -DCMAKE_Swift_FLAGS=-target aarch64-unknown-linux-android{{.*}} -sdk
-# CHECK: Skipping building Foundation Macros for android-aarch64, because the host tools are not being built
-# CHECK: Skipping installing Foundation Macros for android-aarch64, because the host tools are not being built

--- a/validation-test/BuildSystem/android_cross_compile.test
+++ b/validation-test/BuildSystem/android_cross_compile.test
@@ -7,9 +7,9 @@
 # CHECK-NOT: cmake --build {{.*}}/llvm-android-aarch64 --config
 # CHECK-NOT: cmake --build {{.*}}/llvm-android-aarch64 {{.*}} install-llvm
 # CHECK: cmake {{.*}}-DSWIFT_INCLUDE_TOOLS:BOOL=FALSE{{.*}}/swift
-# CHECK: Skipping building Foundation Macros for android-aarch64, because the host tools are not being built
-# CHECK: Skipping installing Foundation Macros for android-aarch64, because the host tools are not being built
 # CHECK: Skipping building Testing Macros for android-aarch64, because the host tools are not being built
 # CHECK: Skipping installing Testing Macros for android-aarch64, because the host tools are not being built
 # CHECK: cmake {{.*}}-DCMAKE_TOOLCHAIN_FILE:PATH={{.*}}swifttesting-android-aarch64/BuildScriptToolchain.cmake
 # CHECK: -DCMAKE_Swift_FLAGS=-target aarch64-unknown-linux-android{{.*}} -sdk
+# CHECK: Skipping building Foundation Macros for android-aarch64, because the host tools are not being built
+# CHECK: Skipping installing Foundation Macros for android-aarch64, because the host tools are not being built


### PR DESCRIPTION
Add SwiftTesting build dependency to XCTest

* The swift-testing project produces the new _TestingInterop library.

  This allows for test assertions in XCTest and Swift Testing to be used
  in tests of the other library, e.g. XCTAssert in an @Test function.

* Build swift-testing ahead of XCTest in the build pipeline in order,
  allowing XCTest to link against _TestingInterop.

  We can't include swift-testing and XCTest in the same pipeline,
  because XCTest is an impl product and Swift Testing is a regular
  product.

* Also explicitly add a Foundation dependency to Swift Testing. This
  dependency already exists in practice when building the toolchain, but
  it wasn't declared in `products/swift_testing.py` yet.

Pipeline Changes:

* Split Foundation into its own pipeline

* Split SwiftTesting and SwiftTestingMacros into their own pipeline

* XCTest and LLBuild remain in the same pipeline

The new pipeline order is:

Foundation -> Swift Testing -> XCTest+LLBuild -> Everything Else
 
