### PR TITLE
[rbi] Fix logic around tracking of Sendable/non-Sendable field projections from Sendable/non-Sendable values

### DIFF
--- a/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
@@ -49,6 +49,10 @@ getApplyIsolationCrossing(SILInstruction *inst);
 // the computation.
 class PartitionOpTranslator;
 
+//===----------------------------------------------------------------------===//
+//                         MARK: BlockPartitionState
+//===----------------------------------------------------------------------===//
+
 class BlockPartitionState {
   friend RegionAnalysisFunctionInfo;
 
@@ -101,8 +105,8 @@ private:
   /// Recomputes the exit partition from the entry partition, and returns
   /// whether this changed the exit partition.
   ///
-  /// NOTE: This method ignored errors that arise. We process separately later
-  /// to discover if an error occured.
+  /// NOTE: This method ignores errors that arise. We process separately later
+  /// to discover if an error occurred.
   bool recomputeExitFromEntry(PartitionOpTranslator &translator);
 };
 
@@ -338,7 +342,7 @@ private:
     SILValue value;
 
     /// The actual base value that we found if we were looking for an address
-    /// equivilance class and had a non-Sendable base. If we have an object or
+    /// equivalence class and had a non-Sendable base. If we have an object or
     /// we do not have a separate base, this is SILValue().
     SILValue base;
 

--- a/test/Concurrency/regionanalysis_trackable_value.sil
+++ b/test/Concurrency/regionanalysis_trackable_value.sil
@@ -62,6 +62,40 @@ enum MyEnum<T> {
     case some2(T)
 }
 
+enum MyEnum2 {
+    case none
+    case sendable(SendableKlass)
+    case nonsendable(NonSendableKlass)
+}
+
+enum SendableEnum : @unchecked Sendable {
+    case none
+    case value(NonSendableKlass)
+}
+
+struct TupleMixed {
+  var tuple: (NonSendableKlass, SendableKlass)
+}
+
+struct TupleNonSendable {
+  var tuple: (NonSendableKlass, NonSendableKlass)
+}
+
+struct TupleSendable : @unchecked Sendable {
+  var tuple: (SendableKlass, SendableKlass)
+}
+
+struct TupleNestedMixed {
+  var tuple: ((NonSendableKlass, SendableKlass), SendableKlass)
+}
+
+@MainActor
+struct MainActorStruct : @unchecked Sendable {
+  var ns: NonSendableKlass
+  var s: SendableKlass
+  var nested: Struct2
+}
+
 sil @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
 sil @useNonSendableKlass : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
 sil @constructNonSendableKlass : $@convention(thin) () -> @owned NonSendableKlass
@@ -722,4 +756,500 @@ bb0(%arg : @owned $NonSendableKlass):
 
   %7 = tuple ()
   return %7 : $()
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// MARK: tuple_element_addr Tests - Testing projection through tuple elements //
+////////////////////////////////////////////////////////////////////////////////
+
+// Test: NonSendable tuple, extract NonSendable element
+// Expected: Look through both (operand and result are both non-Sendable)
+// CHECK-LABEL: begin running test 1 of 1 on tuple_nonsendable_extract_nonsendable_0: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %2 = alloc_stack $(NonSendableKlass, NonSendableKlass)
+// CHECK: end running test 1 of 1 on tuple_nonsendable_extract_nonsendable_0: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @tuple_nonsendable_extract_nonsendable_0 : $@convention(thin) (@owned NonSendableKlass, @owned NonSendableKlass) -> () {
+bb0(%0 : @owned $NonSendableKlass, %1 : @owned $NonSendableKlass):
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %tuple_addr = alloc_stack $(NonSendableKlass, NonSendableKlass)
+  %tuple_val = tuple (%0 : $NonSendableKlass, %1 : $NonSendableKlass)
+  store %tuple_val to [init] %tuple_addr : $*(NonSendableKlass, NonSendableKlass)
+
+  %elem = tuple_element_addr %tuple_addr : $*(NonSendableKlass, NonSendableKlass), 0
+  debug_value [trace] %elem : $*NonSendableKlass
+
+  destroy_addr %tuple_addr : $*(NonSendableKlass, NonSendableKlass)
+  dealloc_stack %tuple_addr : $*(NonSendableKlass, NonSendableKlass)
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test: NonSendable tuple, extract NonSendable element (index 1)
+// Expected: Look through both
+// CHECK-LABEL: begin running test 1 of 1 on tuple_nonsendable_extract_nonsendable_1: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %2 = alloc_stack $(NonSendableKlass, NonSendableKlass)
+// CHECK: end running test 1 of 1 on tuple_nonsendable_extract_nonsendable_1: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @tuple_nonsendable_extract_nonsendable_1 : $@convention(thin) (@owned NonSendableKlass, @owned NonSendableKlass) -> () {
+bb0(%0 : @owned $NonSendableKlass, %1 : @owned $NonSendableKlass):
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %tuple_addr = alloc_stack $(NonSendableKlass, NonSendableKlass)
+  %tuple_val = tuple (%0 : $NonSendableKlass, %1 : $NonSendableKlass)
+  store %tuple_val to [init] %tuple_addr : $*(NonSendableKlass, NonSendableKlass)
+
+  %elem = tuple_element_addr %tuple_addr : $*(NonSendableKlass, NonSendableKlass), 1
+  debug_value [trace] %elem : $*NonSendableKlass
+
+  destroy_addr %tuple_addr : $*(NonSendableKlass, NonSendableKlass)
+  dealloc_stack %tuple_addr : $*(NonSendableKlass, NonSendableKlass)
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test: Mixed tuple (NonSendable, Sendable), extract NonSendable element
+// Expected: Look through both (both are non-Sendable)
+// CHECK-LABEL: begin running test 1 of 1 on tuple_mixed_extract_nonsendable: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %2 = alloc_stack $(NonSendableKlass, SendableKlass)
+// CHECK: end running test 1 of 1 on tuple_mixed_extract_nonsendable: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @tuple_mixed_extract_nonsendable : $@convention(thin) (@owned NonSendableKlass, @owned SendableKlass) -> () {
+bb0(%0 : @owned $NonSendableKlass, %1 : @owned $SendableKlass):
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %tuple_addr = alloc_stack $(NonSendableKlass, SendableKlass)
+  %tuple_val = tuple (%0 : $NonSendableKlass, %1 : $SendableKlass)
+  store %tuple_val to [init] %tuple_addr : $*(NonSendableKlass, SendableKlass)
+
+  %elem = tuple_element_addr %tuple_addr : $*(NonSendableKlass, SendableKlass), 0
+  debug_value [trace] %elem : $*NonSendableKlass
+
+  destroy_addr %tuple_addr : $*(NonSendableKlass, SendableKlass)
+  dealloc_stack %tuple_addr : $*(NonSendableKlass, SendableKlass)
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test: Mixed tuple (NonSendable, Sendable), extract Sendable element
+// Expected: Stop at projection (operand is non-Sendable, result is Sendable)
+// CHECK-LABEL: begin running test 1 of 1 on tuple_mixed_extract_sendable: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: Value:
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %5 = tuple_element_addr %2 : $*(NonSendableKlass, SendableKlass), 1
+// CHECK: Base:
+// CHECK: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %2 = alloc_stack $(NonSendableKlass, SendableKlass)
+// CHECK: end running test 1 of 1 on tuple_mixed_extract_sendable: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @tuple_mixed_extract_sendable : $@convention(thin) (@owned NonSendableKlass, @owned SendableKlass) -> () {
+bb0(%0 : @owned $NonSendableKlass, %1 : @owned $SendableKlass):
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %tuple_addr = alloc_stack $(NonSendableKlass, SendableKlass)
+  %tuple_val = tuple (%0 : $NonSendableKlass, %1 : $SendableKlass)
+  store %tuple_val to [init] %tuple_addr : $*(NonSendableKlass, SendableKlass)
+
+  %elem = tuple_element_addr %tuple_addr : $*(NonSendableKlass, SendableKlass), 1
+  debug_value [trace] %elem : $*SendableKlass
+
+  destroy_addr %tuple_addr : $*(NonSendableKlass, SendableKlass)
+  dealloc_stack %tuple_addr : $*(NonSendableKlass, SendableKlass)
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test: Sendable tuple, extract Sendable element
+// CHECK-LABEL: begin running test 1 of 1 on tuple_sendable_extract_sendable: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: Value:
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %5 = tuple_element_addr %2 : $*(SendableKlass, SendableKlass), 0
+// CHECK: Base:
+// CHECK: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %2 = alloc_stack $(SendableKlass, SendableKlass)
+// CHECK: end running test 1 of 1 on tuple_sendable_extract_sendable: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @tuple_sendable_extract_sendable : $@convention(thin) (@owned SendableKlass, @owned SendableKlass) -> () {
+bb0(%0 : @owned $SendableKlass, %1 : @owned $SendableKlass):
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %tuple_addr = alloc_stack $(SendableKlass, SendableKlass)
+  %tuple_val = tuple (%0 : $SendableKlass, %1 : $SendableKlass)
+  store %tuple_val to [init] %tuple_addr : $*(SendableKlass, SendableKlass)
+
+  %elem = tuple_element_addr %tuple_addr : $*(SendableKlass, SendableKlass), 0
+  debug_value [trace] %elem : $*SendableKlass
+
+  destroy_addr %tuple_addr : $*(SendableKlass, SendableKlass)
+  dealloc_stack %tuple_addr : $*(SendableKlass, SendableKlass)
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test: Nested tuple ((NonSendable, Sendable), Sendable), extract outer element 0
+// Expected: Look through (both tuple types are non-Sendable)
+// CHECK-LABEL: begin running test 1 of 1 on tuple_nested_extract_tuple: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %5 = alloc_stack $((NonSendableKlass, SendableKlass), SendableKlass)
+// CHECK: end running test 1 of 1 on tuple_nested_extract_tuple: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @tuple_nested_extract_tuple : $@convention(thin) (@owned NonSendableKlass, @owned SendableKlass, @owned SendableKlass) -> () {
+bb0(%0 : @owned $NonSendableKlass, %1 : @owned $SendableKlass, %2 : @owned $SendableKlass):
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %inner = tuple (%0 : $NonSendableKlass, %1 : $SendableKlass)
+  %outer = tuple (%inner : $(NonSendableKlass, SendableKlass), %2 : $SendableKlass)
+  %tuple_addr = alloc_stack $((NonSendableKlass, SendableKlass), SendableKlass)
+  store %outer to [init] %tuple_addr : $*((NonSendableKlass, SendableKlass), SendableKlass)
+
+  %elem0 = tuple_element_addr %tuple_addr : $*((NonSendableKlass, SendableKlass), SendableKlass), 0
+  debug_value [trace] %elem0 : $*(NonSendableKlass, SendableKlass)
+
+  destroy_addr %tuple_addr : $*((NonSendableKlass, SendableKlass), SendableKlass)
+  dealloc_stack %tuple_addr : $*((NonSendableKlass, SendableKlass), SendableKlass)
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test: Nested tuple, extract through two levels to NonSendable
+// Expected: Look through all levels
+// CHECK-LABEL: begin running test 1 of 1 on tuple_nested_double_extract_nonsendable: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %5 = alloc_stack $((NonSendableKlass, SendableKlass), SendableKlass)
+// CHECK: end running test 1 of 1 on tuple_nested_double_extract_nonsendable: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @tuple_nested_double_extract_nonsendable : $@convention(thin) (@owned NonSendableKlass, @owned SendableKlass, @owned SendableKlass) -> () {
+bb0(%0 : @owned $NonSendableKlass, %1 : @owned $SendableKlass, %2 : @owned $SendableKlass):
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %inner = tuple (%0 : $NonSendableKlass, %1 : $SendableKlass)
+  %outer = tuple (%inner : $(NonSendableKlass, SendableKlass), %2 : $SendableKlass)
+  %tuple_addr = alloc_stack $((NonSendableKlass, SendableKlass), SendableKlass)
+  store %outer to [init] %tuple_addr : $*((NonSendableKlass, SendableKlass), SendableKlass)
+
+  %elem0 = tuple_element_addr %tuple_addr : $*((NonSendableKlass, SendableKlass), SendableKlass), 0
+  %elem0_0 = tuple_element_addr %elem0 : $*(NonSendableKlass, SendableKlass), 0
+  debug_value [trace] %elem0_0 : $*NonSendableKlass
+
+  destroy_addr %tuple_addr : $*((NonSendableKlass, SendableKlass), SendableKlass)
+  dealloc_stack %tuple_addr : $*((NonSendableKlass, SendableKlass), SendableKlass)
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test: Nested tuple, extract through two levels to Sendable
+// Expected: Stop at second projection (inner tuple is non-Sendable, extracted Sendable)
+// CHECK-LABEL: begin running test 1 of 1 on tuple_nested_double_extract_sendable: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: Value:
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %8 = tuple_element_addr %7 : $*(NonSendableKlass, SendableKlass), 1
+// CHECK: Base:
+// CHECK: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %5 = alloc_stack $((NonSendableKlass, SendableKlass), SendableKlass)
+// CHECK: end running test 1 of 1 on tuple_nested_double_extract_sendable: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @tuple_nested_double_extract_sendable : $@convention(thin) (@owned NonSendableKlass, @owned SendableKlass, @owned SendableKlass) -> () {
+bb0(%0 : @owned $NonSendableKlass, %1 : @owned $SendableKlass, %2 : @owned $SendableKlass):
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %inner = tuple (%0 : $NonSendableKlass, %1 : $SendableKlass)
+  %outer = tuple (%inner : $(NonSendableKlass, SendableKlass), %2 : $SendableKlass)
+  %tuple_addr = alloc_stack $((NonSendableKlass, SendableKlass), SendableKlass)
+  store %outer to [init] %tuple_addr : $*((NonSendableKlass, SendableKlass), SendableKlass)
+
+  %elem0 = tuple_element_addr %tuple_addr : $*((NonSendableKlass, SendableKlass), SendableKlass), 0
+  %elem0_1 = tuple_element_addr %elem0 : $*(NonSendableKlass, SendableKlass), 1
+  debug_value [trace] %elem0_1 : $*SendableKlass
+
+  destroy_addr %tuple_addr : $*((NonSendableKlass, SendableKlass), SendableKlass)
+  dealloc_stack %tuple_addr : $*((NonSendableKlass, SendableKlass), SendableKlass)
+  %r = tuple ()
+  return %r : $()
+}
+
+////////////////////////////////////////////////////////////////////////////
+// MARK: unchecked_enum_data_addr Tests - Testing enum payload extraction //
+////////////////////////////////////////////////////////////////////////////
+
+// Test: NonSendable enum, extract NonSendable payload
+// Expected: Look through (both non-Sendable)
+// CHECK-LABEL: begin running test 1 of 1 on enum_nonsendable_extract_nonsendable: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %1 = alloc_stack $MyEnum2
+// CHECK: end running test 1 of 1 on enum_nonsendable_extract_nonsendable: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @enum_nonsendable_extract_nonsendable : $@convention(thin) (@owned NonSendableKlass) -> () {
+bb0(%0 : @owned $NonSendableKlass):
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %enum_addr = alloc_stack $MyEnum2
+  %enum_val = enum $MyEnum2, #MyEnum2.nonsendable!enumelt, %0 : $NonSendableKlass
+  store %enum_val to [init] %enum_addr : $*MyEnum2
+
+  %payload = unchecked_take_enum_data_addr %enum_addr : $*MyEnum2, #MyEnum2.nonsendable!enumelt
+  debug_value [trace] %payload : $*NonSendableKlass
+
+  destroy_addr %payload : $*NonSendableKlass
+  dealloc_stack %enum_addr : $*MyEnum2
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test: NonSendable enum, extract Sendable payload
+// Expected: Stop at projection (operand non-Sendable, result Sendable)
+// CHECK-LABEL: begin running test 1 of 1 on enum_nonsendable_extract_sendable: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: Value:
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %4 = unchecked_take_enum_data_addr %1 : $*MyEnum2, #MyEnum2.sendable!enumelt
+// CHECK: Base:
+// CHECK: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %1 = alloc_stack $MyEnum2
+// CHECK: end running test 1 of 1 on enum_nonsendable_extract_sendable: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @enum_nonsendable_extract_sendable : $@convention(thin) (@owned SendableKlass) -> () {
+bb0(%0 : @owned $SendableKlass):
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %enum_addr = alloc_stack $MyEnum2
+  %enum_val = enum $MyEnum2, #MyEnum2.sendable!enumelt, %0 : $SendableKlass
+  store %enum_val to [init] %enum_addr : $*MyEnum2
+
+  %payload = unchecked_take_enum_data_addr %enum_addr : $*MyEnum2, #MyEnum2.sendable!enumelt
+  debug_value [trace] %payload : $*SendableKlass
+
+  destroy_addr %payload : $*SendableKlass
+  dealloc_stack %enum_addr : $*MyEnum2
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test: Sendable enum (wrapping NonSendable), extract NonSendable payload
+// Expected: Stop at projection and mark as non-Sendable value (Sendable operand, non-Sendable result)
+// CHECK-LABEL: begin running test 1 of 1 on enum_sendable_extract_nonsendable: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: Value:
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %4 = unchecked_take_enum_data_addr %1 : $*SendableEnum, #SendableEnum.value!enumelt
+// CHECK: Base:
+// CHECK: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %1 = alloc_stack $SendableEnum
+// CHECK: end running test 1 of 1 on enum_sendable_extract_nonsendable: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @enum_sendable_extract_nonsendable : $@convention(thin) (@owned NonSendableKlass) -> () {
+bb0(%0 : @owned $NonSendableKlass):
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %enum_addr = alloc_stack $SendableEnum
+  %enum_val = enum $SendableEnum, #SendableEnum.value!enumelt, %0 : $NonSendableKlass
+  store %enum_val to [init] %enum_addr : $*SendableEnum
+
+  %payload = unchecked_take_enum_data_addr %enum_addr : $*SendableEnum, #SendableEnum.value!enumelt
+  debug_value [trace] %payload : $*NonSendableKlass
+
+  destroy_addr %payload : $*NonSendableKlass
+  dealloc_stack %enum_addr : $*SendableEnum
+  %r = tuple ()
+  return %r : $()
+}
+
+///////////////////////////////////////////////////////////////////
+// MARK: Combined struct_element_addr + tuple_element_addr Tests //
+///////////////////////////////////////////////////////////////////
+
+// Test: Struct with tuple field, extract tuple then NonSendable element
+// Expected: Look through all (all non-Sendable)
+// CHECK-LABEL: begin running test 1 of 1 on struct_tuple_extract_nonsendable: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %2 = alloc_stack $TupleMixed
+// CHECK: end running test 1 of 1 on struct_tuple_extract_nonsendable: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @struct_tuple_extract_nonsendable : $@convention(thin) (@owned NonSendableKlass, @owned SendableKlass) -> () {
+bb0(%0 : @owned $NonSendableKlass, %1 : @owned $SendableKlass):
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %struct_addr = alloc_stack $TupleMixed
+  %tuple_val = tuple (%0 : $NonSendableKlass, %1 : $SendableKlass)
+  %struct_val = struct $TupleMixed (%tuple_val : $(NonSendableKlass, SendableKlass))
+  store %struct_val to [init] %struct_addr : $*TupleMixed
+
+  %tuple_addr = struct_element_addr %struct_addr : $*TupleMixed, #TupleMixed.tuple
+  %elem = tuple_element_addr %tuple_addr : $*(NonSendableKlass, SendableKlass), 0
+  debug_value [trace] %elem : $*NonSendableKlass
+
+  destroy_addr %struct_addr : $*TupleMixed
+  dealloc_stack %struct_addr : $*TupleMixed
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test: Struct with tuple field, extract tuple then Sendable element
+// Expected: Stop at tuple_element_addr (tuple is non-Sendable, element is Sendable)
+// CHECK-LABEL: begin running test 1 of 1 on struct_tuple_extract_sendable: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: Value:
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %7 = tuple_element_addr %6 : $*(NonSendableKlass, SendableKlass), 1
+// CHECK: Base:
+// CHECK: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %2 = alloc_stack $TupleMixed
+// CHECK: end running test 1 of 1 on struct_tuple_extract_sendable: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @struct_tuple_extract_sendable : $@convention(thin) (@owned NonSendableKlass, @owned SendableKlass) -> () {
+bb0(%0 : @owned $NonSendableKlass, %1 : @owned $SendableKlass):
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %struct_addr = alloc_stack $TupleMixed
+  %tuple_val = tuple (%0 : $NonSendableKlass, %1 : $SendableKlass)
+  %struct_val = struct $TupleMixed (%tuple_val : $(NonSendableKlass, SendableKlass))
+  store %struct_val to [init] %struct_addr : $*TupleMixed
+
+  %tuple_addr = struct_element_addr %struct_addr : $*TupleMixed, #TupleMixed.tuple
+  %elem = tuple_element_addr %tuple_addr : $*(NonSendableKlass, SendableKlass), 1
+  debug_value [trace] %elem : $*SendableKlass
+
+  destroy_addr %struct_addr : $*TupleMixed
+  dealloc_stack %struct_addr : $*TupleMixed
+  %r = tuple ()
+  return %r : $()
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+// MARK: Deep Nesting Tests - Multiple levels of projections                     //
+////////////////////////////////////////////////////////////////////////////////////
+
+// Test: Struct -> Struct -> Struct, all NonSendable fields
+// Expected: Look through all levels
+// CHECK-LABEL: begin running test 1 of 1 on deep_struct_triple_nonsendable: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %1 = alloc_stack $Struct
+// CHECK: end running test 1 of 1 on deep_struct_triple_nonsendable: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @deep_struct_triple_nonsendable : $@convention(thin) (@owned Struct) -> () {
+bb0(%0 : @owned $Struct):
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %struct_addr = alloc_stack $Struct
+  store %0 to [init] %struct_addr : $*Struct
+
+  %l1 = struct_element_addr %struct_addr : $*Struct, #Struct.struct2Let
+  %l2 = struct_element_addr %l1 : $*Struct2, #Struct2.nsLet
+  debug_value [trace] %l2 : $*NonSendableKlass
+
+  destroy_addr %struct_addr : $*Struct
+  dealloc_stack %struct_addr : $*Struct
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test: Struct -> Struct -> Sendable field (deep projection ending in Sendable)
+// Expected: Stop at first projection.
+// CHECK-LABEL: begin running test 1 of 1 on deep_struct_triple_to_sendable: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: Value:
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %4 = struct_element_addr %3 : $*Struct2, #Struct2.sLet
+// CHECK: Base:
+// CHECK: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %1 = alloc_stack $Struct
+// CHECK: end running test 1 of 1 on deep_struct_triple_to_sendable: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @deep_struct_triple_to_sendable : $@convention(thin) (@owned Struct) -> () {
+bb0(%0 : @owned $Struct):
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %struct_addr = alloc_stack $Struct
+  store %0 to [init] %struct_addr : $*Struct
+
+  %l1 = struct_element_addr %struct_addr : $*Struct, #Struct.struct2Let
+  %l2 = struct_element_addr %l1 : $*Struct2, #Struct2.sLet
+  debug_value [trace] %l2 : $*SendableKlass
+
+  destroy_addr %struct_addr : $*Struct
+  dealloc_stack %struct_addr : $*Struct
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test: Struct -> Tuple -> Struct (mixed projections)
+// Expected: Look through all (all non-Sendable)
+// CHECK-LABEL: begin running test 1 of 1 on mixed_struct_tuple_struct_nonsendable: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %6 = alloc_stack $TupleNestedMixed
+// CHECK: end running test 1 of 1 on mixed_struct_tuple_struct_nonsendable: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @mixed_struct_tuple_struct_nonsendable : $@convention(thin) (@owned NonSendableKlass, @owned SendableKlass, @owned SendableKlass) -> () {
+bb0(%0 : @owned $NonSendableKlass, %1 : @owned $SendableKlass, %2 : @owned $SendableKlass):
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %inner = tuple (%0 : $NonSendableKlass, %1 : $SendableKlass)
+  %outer = tuple (%inner : $(NonSendableKlass, SendableKlass), %2 : $SendableKlass)
+  %struct_val = struct $TupleNestedMixed (%outer : $((NonSendableKlass, SendableKlass), SendableKlass))
+  %struct_addr = alloc_stack $TupleNestedMixed
+  store %struct_val to [init] %struct_addr : $*TupleNestedMixed
+
+  %tuple_addr = struct_element_addr %struct_addr : $*TupleNestedMixed, #TupleNestedMixed.tuple
+  %inner_tuple = tuple_element_addr %tuple_addr : $*((NonSendableKlass, SendableKlass), SendableKlass), 0
+  %elem = tuple_element_addr %inner_tuple : $*(NonSendableKlass, SendableKlass), 0
+  debug_value [trace] %elem : $*NonSendableKlass
+
+  destroy_addr %struct_addr : $*TupleNestedMixed
+  dealloc_stack %struct_addr : $*TupleNestedMixed
+  %r = tuple ()
+  return %r : $()
+}
+
+////////////////////////////////////
+// MARK: MainActor Isolated Tests //
+////////////////////////////////////
+
+// Test: MainActor struct as parameter, extract NonSendable field
+//
+// Should have MainActor as a base and non sendable field should be main actor
+// isolated.
+//
+// CHECK-LABEL: begin running test 1 of 1 on mainactor_struct_extract_nonsendable: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: Value:
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: main actor-isolated].
+// CHECK:     Rep Value:   %1 = struct_element_addr %0 : $*MainActorStruct, #MainActorStruct.ns
+// CHECK: Base:
+// CHECK: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK:     Rep Value: %0 = argument of bb0 : $*MainActorStruct
+// CHECK: end running test 1 of 1 on mainactor_struct_extract_nonsendable: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @mainactor_struct_extract_nonsendable : $@convention(thin) @async (@in_guaranteed MainActorStruct) -> () {
+bb0(%0 : $*MainActorStruct):
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %field = struct_element_addr %0 : $*MainActorStruct, #MainActorStruct.ns
+  debug_value [trace] %field : $*NonSendableKlass
+
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test: MainActor struct as parameter, extract Sendable field
+// Expected: Sendable field, should have base pointing to MainActor struct
+// CHECK-LABEL: begin running test 1 of 1 on mainactor_struct_extract_sendable: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: Value:
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %1 = struct_element_addr %0 : $*MainActorStruct, #MainActorStruct.s
+// CHECK: Base:
+// CHECK: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK:     Rep Value: %0 = argument of bb0 : $*MainActorStruct
+// CHECK: end running test 1 of 1 on mainactor_struct_extract_sendable: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @mainactor_struct_extract_sendable : $@convention(thin) @async (@in_guaranteed MainActorStruct) -> () {
+bb0(%0 : $*MainActorStruct):
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %field = struct_element_addr %0 : $*MainActorStruct, #MainActorStruct.s
+  debug_value [trace] %field : $*SendableKlass
+
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test: MainActor struct, extract nested struct then NonSendable field
+// Expected: We should stop at nested and mark that as main actor-isolated.
+// CHECK-LABEL: begin running test 1 of 1 on mainactor_struct_nested_extract_nonsendable: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: Value:
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: main actor-isolated].
+// CHECK:     Rep Value:   %1 = struct_element_addr %0 : $*MainActorStruct, #MainActorStruct.nested
+// CHECK: Base:
+// CHECK: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK:     Rep Value: %0 = argument of bb0 : $*MainActorStruct
+// CHECK: end running test 1 of 1 on mainactor_struct_nested_extract_nonsendable: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @mainactor_struct_nested_extract_nonsendable : $@convention(thin) @async (@in_guaranteed MainActorStruct) -> () {
+bb0(%0 : $*MainActorStruct):
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %nested = struct_element_addr %0 : $*MainActorStruct, #MainActorStruct.nested
+  %field = struct_element_addr %nested : $*Struct2, #Struct2.nsLet
+  debug_value [trace] %field : $*NonSendableKlass
+
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test: MainActor struct, extract nested struct then Sendable field
+// CHECK-LABEL: begin running test 1 of 1 on mainactor_struct_nested_extract_sendable: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: Value:
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %2 = struct_element_addr %1 : $*Struct2, #Struct2.sLet
+// CHECK: Base:
+// CHECK: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK:     Rep Value: %0 = argument of bb0 : $*MainActorStruct
+// CHECK: end running test 1 of 1 on mainactor_struct_nested_extract_sendable: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @mainactor_struct_nested_extract_sendable : $@convention(thin) @async (@in_guaranteed MainActorStruct) -> () {
+bb0(%0 : $*MainActorStruct):
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %nested = struct_element_addr %0 : $*MainActorStruct, #MainActorStruct.nested
+  %field = struct_element_addr %nested : $*Struct2, #Struct2.sLet
+  debug_value [trace] %field : $*SendableKlass
+
+  %r = tuple ()
+  return %r : $()
 }

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -2234,9 +2234,8 @@ struct IndirectAssignTests {
     mutating func take() -> sending NonSendableKlass {
       if let value {
         self.value = nil
-        // TODO: Why are we not erroring on this. We should be.
-        return value // xpected-warning {{sending 'value' risks causing data races}}
-        // xpected-note @-1 {{main actor-isolated 'value' cannot be a 'sending' result. main actor-isolated uses may race with caller uses}}
+        return value // expected-warning {{sending 'value' risks causing data races}}
+        // expected-note @-1 {{main actor-isolated 'value' cannot be a 'sending' result. main actor-isolated uses may race with caller uses}}
       } else {
         preconditionFailure("Consumed twice")
       }

--- a/test/Concurrency/transfernonsendable_partitionop_translation.sil
+++ b/test/Concurrency/transfernonsendable_partitionop_translation.sil
@@ -24,6 +24,9 @@ class NonSendableKlass : NonSendableProtocol {
 class NonSendableKlassSubKlass : NonSendableKlass {
 }
 
+class SendableKlass : @unchecked Sendable {
+}
+
 struct SingleFieldStruct {
   var field: NonSendableKlass
 }
@@ -33,9 +36,31 @@ struct TwoFieldStruct {
   var second: NonSendableKlass
 }
 
+struct MixedFieldStruct {
+  let nsLet: NonSendableKlass
+  let sLet: SendableKlass
+  var nsVar: NonSendableKlass
+  var sVar: SendableKlass
+}
+
+struct SendableStruct : @unchecked Sendable {
+  let nsLet: NonSendableKlass
+}
+
 enum NonSendableEnum {
   case none
   case some(NonSendableKlass)
+}
+
+enum MixedEnum {
+  case none
+  case nonsendable(NonSendableKlass)
+  case sendable(SendableKlass)
+}
+
+enum SendableEnum : @unchecked Sendable {
+  case none
+  case value(NonSendableKlass)
 }
 
 protocol NonSendableProtocol {
@@ -766,6 +791,58 @@ bb0:
 }
 
 
+// Test: NonSendable operand → Sendable let result (should be ignored - no partition ops)
+// CHECK-LABEL: begin running test {{.*}} on test_struct_element_addr_nonsendable_to_sendable_let: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: end running test {{.*}} on test_struct_element_addr_nonsendable_to_sendable_let: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_struct_element_addr_nonsendable_to_sendable_let : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $MixedFieldStruct
+  %1 = struct_element_addr %0 : $*MixedFieldStruct, #MixedFieldStruct.sLet
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  dealloc_stack %0
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// Test: NonSendable operand → Sendable var result (should require the operand)
+// CHECK-LABEL: begin running test {{.*}} on test_struct_element_addr_nonsendable_to_sendable_var: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: %1 = struct_element_addr %0 : $*MixedFieldStruct, #MixedFieldStruct.sVar
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: %0 = alloc_stack $MixedFieldStruct
+// CHECK-NEXT: require [mutable_base_of_sendable_val] %%1:   %1 = struct_element_addr %0 : $*MixedFieldStruct, #MixedFieldStruct.sVar
+// CHECK-NEXT: end running test {{.*}} on test_struct_element_addr_nonsendable_to_sendable_var: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_struct_element_addr_nonsendable_to_sendable_var : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $MixedFieldStruct
+  %1 = struct_element_addr %0 : $*MixedFieldStruct, #MixedFieldStruct.sVar
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  dealloc_stack %0
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// Test: Sendable operand → NonSendable result (should assign fresh)
+// CHECK-LABEL: begin running test {{.*}} on test_struct_element_addr_sendable_to_nonsendable: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = struct_element_addr %0 : $*SendableStruct, #SendableStruct.nsLet
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %0 = alloc_stack $SendableStruct
+// CHECK-NEXT: assign_fresh %%0:   %1 = struct_element_addr %0 : $*SendableStruct, #SendableStruct.nsLet
+// CHECK-NEXT: end running test {{.*}} on test_struct_element_addr_sendable_to_nonsendable: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_struct_element_addr_sendable_to_nonsendable : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $SendableStruct
+  %1 = struct_element_addr %0 : $*SendableStruct, #SendableStruct.nsLet
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  dealloc_stack %0
+  %r = tuple ()
+  return %r : $()
+}
+
+
 // CHECK-LABEL: begin running test {{.*}} on test_tuple_element_addr: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
 // CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
 // CHECK-NEXT:     Rep Value:   %0 = alloc_stack $(NonSendableKlass, NonSendableKlass)
@@ -774,6 +851,43 @@ sil [ossa] @test_tuple_element_addr : $@convention(thin) () -> () {
 bb0:
   %0 = alloc_stack $(NonSendableKlass, NonSendableKlass)
   %1 = tuple_element_addr %0 : $*(NonSendableKlass, NonSendableKlass), 0
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  dealloc_stack %0
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// Test: NonSendable tuple → Sendable element (should require operand)
+// CHECK-LABEL: begin running test {{.*}} on test_tuple_element_addr_nonsendable_to_sendable: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: %1 = tuple_element_addr %0 : $*(NonSendableKlass, SendableKlass), 1
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: %0 = alloc_stack $(NonSendableKlass, SendableKlass)
+// CHECK-NEXT: require [mutable_base_of_sendable_val] %%1:   %1 = tuple_element_addr %0 : $*(NonSendableKlass, SendableKlass), 1
+// CHECK-NEXT: end running test {{.*}} on test_tuple_element_addr_nonsendable_to_sendable: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_tuple_element_addr_nonsendable_to_sendable : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $(NonSendableKlass, SendableKlass)
+  %1 = tuple_element_addr %0 : $*(NonSendableKlass, SendableKlass), 1
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  dealloc_stack %0
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// Test: Sendable tuple → Sendable element (both sendable - lookthrough)
+// CHECK-LABEL: begin running test {{.*}} on test_tuple_element_addr_sendable_to_sendable: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = tuple_element_addr %0 : $*(SendableKlass, SendableKlass), 0
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %0 = alloc_stack $(SendableKlass, SendableKlass)
+// CHECK-NEXT: end running test {{.*}} on test_tuple_element_addr_sendable_to_sendable: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_tuple_element_addr_sendable_to_sendable : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $(SendableKlass, SendableKlass)
+  %1 = tuple_element_addr %0 : $*(SendableKlass, SendableKlass), 0
   specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
   dealloc_stack %0
   %r = tuple ()
@@ -2171,6 +2285,42 @@ bb0(%0 : $*NonSendableEnum):
   %r = tuple ()
   return %r : $()
 }
+
+
+// Test: NonSendable enum → Sendable payload (should require operand)
+// CHECK-LABEL: begin running test {{.*}} on test_unchecked_take_enum_data_addr_nonsendable_to_sendable: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $*MixedEnum
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: %1 = unchecked_take_enum_data_addr %0 : $*MixedEnum, #MixedEnum.sendable!enumelt
+// CHECK-NEXT: require %%0:   %1 = unchecked_take_enum_data_addr %0 : $*MixedEnum, #MixedEnum.sendable!enumelt
+// CHECK-NEXT: end running test {{.*}} on test_unchecked_take_enum_data_addr_nonsendable_to_sendable: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_unchecked_take_enum_data_addr_nonsendable_to_sendable : $@convention(thin) (@in MixedEnum) -> () {
+bb0(%0 : $*MixedEnum):
+  %payload_addr = unchecked_take_enum_data_addr %0 : $*MixedEnum, #MixedEnum.sendable!enumelt
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_addr %payload_addr
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test: Sendable enum → NonSendable payload (should assign fresh)
+// CHECK-LABEL: begin running test {{.*}} on test_unchecked_take_enum_data_addr_sendable_to_nonsendable: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $*SendableEnum
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = unchecked_take_enum_data_addr %0 : $*SendableEnum, #SendableEnum.value!enumelt
+// CHECK-NEXT: assign_fresh %%1:   %1 = unchecked_take_enum_data_addr %0 : $*SendableEnum, #SendableEnum.value!enumelt
+// CHECK-NEXT: end running test {{.*}} on test_unchecked_take_enum_data_addr_sendable_to_nonsendable: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_unchecked_take_enum_data_addr_sendable_to_nonsendable : $@convention(thin) (@in SendableEnum) -> () {
+bb0(%0 : $*SendableEnum):
+  %payload_addr = unchecked_take_enum_data_addr %0 : $*SendableEnum, #SendableEnum.value!enumelt
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_addr %payload_addr
+  %r = tuple ()
+  return %r : $()
+}
+
 
 //===----------------------------------------------------------------------===//
 // MARK: Address-Only Existential Operations


### PR DESCRIPTION
Previously, region-based isolation was not diagnosing cases where a non-Sendable value projected from a Sendable base that was MainActor isolated. For example:

```swift
@MainActor
struct MainActorBox {
  var value: NonSendableKlass?

  mutating func take() -> sending NonSendableKlass {
    if let value {
      self.value = nil
      return value // Should warn: main actor-isolated value cannot be 'sending'
    } else {
      preconditionFailure("Consumed twice")
    }
  }
}
```

This was caused by two issues:

1. A logic bug in `AddressBaseComputingVisitor::visitAll` where we overwrote an already-found Sendable value when recursing. The visitor should only record the first Sendable value found, not subsequent ones. This caused us to incorrectly return the `@MainActor` `MainActorBox` as the base instead of emitting a require for the projected value.

2. struct_element_addr being transparent unconditionally causing us to not even emit a require at all.

This commit has two parts:

1. I fixed the first two issues by fixing the logic bug and by making struct_element_addr only transparent if its operand and result are non-Sendable. I added logic that we have used in other such cases to handle non-Sendable operand/Sendable result as well as Sendable operand and non-Sendable result. I then added the same support for tuple_element_addr and unchecked_take_enum_data_addr since they suffered from a similar problem.

2. Adding the logic to handle variants where the operand was non-Sendable and the result was Sendable, caused a bunch of tests to break so I had to fix that.

To fix the broken test cases, I had to make the compiler smarter about how it was inserting this require. To do this:

1. I checked if the access base of the projection was actually immutable or if we are an alloc_stack that there was a prefix path in the projection path of immutable projections that end in the alloc_stack. In such a case, we know that we do not need to require that the operand is available in the current isolation domain since we will never write to that piece of memory and once we have loaded the result from memory, we know that the value is Sendable so nothing bad can happen.

2. If the access base of the projection was mutable, I used the same logic that we used for alloc_box that were non-Sendable that stored a Sendable thing by changing operand to be a `require [mutable_base_of_sending]` on the result of the projection instead of requiring the projection's operand. This ensures that we handled important flow sensitive cases.

rdar://169626088
