### PR TITLE
[cxx-interop] Do not emit invalid C++ operator declarations

### DIFF
--- a/test/Interop/SwiftToCxx/functions/swift-operators.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-operators.swift
@@ -58,3 +58,19 @@ public func ==(lhs: IntBox, rhs: IntBox) -> Bool {
 // CHECK-NEXT:   return Operators::_impl::$s9Operators2eeoiySbAA6IntBoxV_ADtF(Operators::_impl::swift_interop_passDirect_Operators_uint32_t_0_4(Operators::_impl::_impl_IntBox::getOpaquePointer(lhs)), Operators::_impl::swift_interop_passDirect_Operators_uint32_t_0_4(Operators::_impl::_impl_IntBox::getOpaquePointer(rhs)));
 // CHECK-NEXT: }
 
+public func ===(lhs: IntBox, rhs: IntBox) -> Bool {
+  return lhs.x == rhs.x
+}
+// CHECK-NOT: operator===
+
+infix operator +>
+func +> (lhs: IntBox, rhs: Int) -> IntBox {
+  return IntBox(x: lhs.x + CInt(rhs))
+}
+// CHECK-NOT: operator+>
+
+infix operator !
+func ! (lhs: IntBox, rhs: IntBox) -> Bool {
+  return lhs.x == rhs.x
+}
+// CHECK-NOT: operator!


### PR DESCRIPTION
When generating a reverse interop header for a Swift module that declares `func ===` for a Swift type, we were printing `operator===`, which isn't valid in C++.

This teaches reverse interop to only print operators that are valid in C++.

rdar://169474185

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
