### PR TITLE
Testing: Resilience testing with `llvm-nm`

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2649,8 +2649,6 @@ rth_flags = ''
 if swift_execution_tests_extra_flags:
     rth_flags = swift_execution_tests_extra_flags + ' -wmo'
 
-rth_coro_flags = rth_flags +  ' -enable-experimental-feature CoroutineAccessors'
-
 relative_platform_module_dir_prefix = ''
 if platform.system() != 'Darwin':
     relative_platform_module_dir_prefix = os.path.join(config.target_sdk_name, run_cpu)
@@ -2858,25 +2856,15 @@ if not getattr(config, 'target_run_simple_swift', None):
 config.target_resilience_test = (
      '%s %s --target-build-swift "%s" --target-run "%s" --t %%t --S %%S '
      '--s %%s --lib-prefix "%s" --lib-suffix "%s" --target-codesign "%s" '
-     '--additional-compile-flags "%s" --triple "%s"'
-     % (shell_quote(sys.executable), config.rth, config.target_build_swift,
-        config.target_run, config.target_shared_library_prefix,
-        config.target_shared_library_suffix, config.target_codesign,
-        rth_flags, config.variant_triple))
-
-
-config.target_resilience_test_coroutine_accessors = (
-     '%s %s --target-build-swift "%s" --target-run "%s" --t %%t --S %%S '
-     '--s %%s --lib-prefix "%s" --lib-suffix "%s" --target-codesign "%s" '
      '--additional-compile-flags "%s" --triple "%s" '
+     '--target-nm "%s"'
      % (shell_quote(sys.executable), config.rth, config.target_build_swift,
         config.target_run, config.target_shared_library_prefix,
         config.target_shared_library_suffix, config.target_codesign,
-        rth_coro_flags, config.variant_triple))
+        rth_flags, config.variant_triple,
+        config.llvm_nm))
 
-# FIXME: Get symbol diffing working with binutils nm as well. The flags are slightly
-# different.
-if platform.system() != 'Darwin' or swift_test_mode == 'optimize_none_with_implicit_dynamic':
+if swift_test_mode == 'optimize_none_with_implicit_dynamic':
     config.target_resilience_test = ('%s --no-symbol-diff' %
                                      config.target_resilience_test)
 
@@ -3131,7 +3119,6 @@ config.substitutions.insert(0, ('%target-static-library-name\(([^)]+)\)',
                                     escape_for_substitute_captures(config.target_static_library_suffix)))))
 config.substitutions.append(('%target-rpath\(([^)]+)\)', config.target_add_rpath))
 
-config.substitutions.append(('%target-resilience-test-coroutine-accessors', config.target_resilience_test_coroutine_accessors))
 config.substitutions.append(('%target-resilience-test', config.target_resilience_test))
 
 config.substitutions.append(('%llvm-profdata', config.llvm_profdata))

--- a/utils/rth
+++ b/utils/rth
@@ -141,7 +141,7 @@ class ResilienceTest(object):
         try:
             subprocess.check_output(diff_cmd)
         except subprocess.CalledProcessError as e:
-            assert len(e.output) == 0, "Removed symbols:\n" + e.output
+            assert len(e.output) == 0, "Removed symbols:\n" + '\n'.join(e.output.decode('utf-8').split('\n'))
 
     def compile_main(self):
         for config in self.config_dir_map:

--- a/validation-test/Evolution/test_coroutine_accessors.swift
+++ b/validation-test/Evolution/test_coroutine_accessors.swift
@@ -1,9 +1,4 @@
-// RUN: %target-resilience-test-coroutine-accessors
-
-// The symbol diffing code does not seem to work on linux:
-//  nm: invalid argument to -U/--unicode
-// AssertionError: ['nm', '-gjU', '/home/../Output/test_coroutine_accessors.swift.tmp/before/libcoroutine_accessors.so'
-// UNSUPPORTED: OS=linux-gnu
+// RUN: %target-resilience-test --additional-compile-flags '-enable-experimental-feature CoroutineAccessors'
 
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_CoroutineAccessors

--- a/validation-test/Evolution/test_coroutine_accessors.swift
+++ b/validation-test/Evolution/test_coroutine_accessors.swift
@@ -3,6 +3,19 @@
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_CoroutineAccessors
 
+// Linux fails with the following removed symbols:
+// Removed Symbols:
+// $s19coroutine_accessors13ResilientEnumO1sSivg
+// $s19coroutine_accessors13ResilientEnumO1sSivpMV
+// $s19coroutine_accessors14ResilientClassC1sSivgTj
+// $s19coroutine_accessors14ResilientClassC1sSivgTq
+// $s19coroutine_accessors14ResilientClassC1sSivpMV
+// $s19coroutine_accessors15ResilientStructV1sSivg
+// $s19coroutine_accessors15ResilientStructV1sSivpMV
+// $s19coroutine_accessors33ResilientStructWithImplicitModifyV1sSivg
+// $s19coroutine_accessors33ResilientStructWithImplicitModifyV1sSivpMV
+// XFAIL: OS=linux-gnu
+
 import StdlibUnittest
 import coroutine_accessors
 


### PR DESCRIPTION
These tests were disabled on everything except macOS because it relies on flags that are specific to llvm-nm. This PR re-enables the tests and uses the llvm-nm from the building toolchain to execute the test instead of hoping that the nm on path is the llvm-nm.

It also removes the extra target-resilience-test-coroutine-accessors expansion, which is only used in one test and instead adds the CoroutineAccessor experimental feature flag to the test that needs it.