### PR TITLE
[CSBindings] Don't propagate defaults up the supertype chain

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -622,12 +622,6 @@ void BindingSet::inferTransitiveSupertypeBindings() {
     ASSERT(inserted);
   }
 
-  llvm::SmallDenseSet<Type> seenDefaults;
-  for (auto *constraint : Defaults) {
-    bool inserted = seenDefaults.insert(constraint->getSecondType()).second;
-    ASSERT(inserted);
-  }
-
   for (const auto &entry : Info.SupertypeOf) {
     auto &node = CS.getConstraintGraph()[entry.first];
     if (!node.hasBindingSet())
@@ -665,17 +659,6 @@ void BindingSet::inferTransitiveSupertypeBindings() {
 
       literal.setDirectRequirement(false);
       Literals.push_back(literal);
-    }
-
-    // Infer transitive defaults.
-    for (auto *def : bindings.Defaults) {
-      if (def->getKind() == ConstraintKind::FallbackType)
-        continue;
-
-      if (!seenDefaults.insert(def->getSecondType()).second)
-        continue;
-
-      addDefault(def);
     }
 
     // TODO: We shouldn't need this in the future.

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -187,7 +187,8 @@ func r22162441(_ lines: [String]) {
 
 func testMap() {
   let a = 42
-  [1,a].map { $0 + 1.0 } // expected-error {{cannot convert value of type 'Int' to expected element type 'Double'}}
+  [1,a].map { $0 + 1.0 } // expected-error {{binary operator '+' cannot be applied to operands of type 'Int' and 'Double'}}
+  // expected-note@-1 {{overloads for '+' exist with these partially matching parameter lists: (Double, Double), (Int, Int)}}
 }
 
 // <rdar://problem/22414757> "UnresolvedDot" "in wrong phase" assertion from verifier


### PR DESCRIPTION
Default bindings are local and shouldn't be moved because that could lead to incorrect diagnostics.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
