### PR TITLE
[cxx-interop] Fix confusion between multiply and dereference operators

### DIFF
--- a/test/Interop/Cxx/operators/Inputs/member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/member-inline.h
@@ -431,6 +431,24 @@ public:
   int operator*() const { return value; }
 };
 
+class AllStar {
+private:
+  long L = 111;
+
+public:
+  // The unary variant (i.e., dereference) should be accessible
+  // via the synthesized .pointee member
+  long &operator*() { return L; }
+
+  // The binary variant (i.e., multiply) should be accessible
+  // via the synthesized static func *(lhs, rhs) operator
+  AllStar operator*(const AllStar &rhs) const {
+    AllStar a;
+    a.L = this->L * rhs.L;
+    return a;
+  }
+};
+
 struct AmbiguousOperatorStar {
 private:
   int value = 567;

--- a/test/Interop/Cxx/operators/Inputs/non-member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/non-member-inline.h
@@ -121,6 +121,14 @@ LValueAndRValueArithmetic operator+(const LValueAndRValueArithmetic &lhs,
   return {lhs.value + rhs.value};
 }
 
+struct AllStar { long L = 111; };
+inline long &operator*(AllStar &a) { return a.L; }
+inline AllStar operator*(const AllStar &lhs, const AllStar &rhs) {
+  AllStar a;
+  a.L = lhs.L * rhs.L;
+  return a;
+}
+
 // Make sure that we don't crash on templated operators
 template<typename T> struct S {};
 template<typename T> S<T> operator+(S<T> lhs, S<T> rhs);

--- a/test/Interop/Cxx/operators/member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/member-inline-module-interface.swift
@@ -252,12 +252,12 @@
 // CHECK: struct AllStar {
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   @available(*, unavailable, message: "use .pointee property")
-// CHECK-NEXT:   mutating func __operatorStar() -> UnsafeMutablePointer<Int>
+// CHECK-NEXT:   mutating func __operatorStar() -> UnsafeMutablePointer<Int{{(32|64)?}}>
 // CHECK-NEXT:   static func * (lhs: AllStar, rhs: AllStar) -> AllStar
 // CHECK-NEXT:   @available(*, unavailable, message: "use * instead")
 // CHECK-NEXT:   func __operatorStar(_ rhs: AllStar) -> AllStar
-// CHECK-NEXT:   var L: Int
-// CHECK-NEXT:   var pointee: Int { mutating get set }
+// CHECK-NEXT:   var L: Int{{(32|64)?}}
+// CHECK-NEXT:   var pointee: Int{{(32|64)?}} { mutating get set }
 // CHECK-NEXT: }
 
 // CHECK: struct AmbiguousOperatorStar {

--- a/test/Interop/Cxx/operators/member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/member-inline-module-interface.swift
@@ -249,6 +249,17 @@
 // CHECK:   var pointee: Int32 { get }
 // CHECK: }
 
+// CHECK: struct AllStar {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   @available(*, unavailable, message: "use .pointee property")
+// CHECK-NEXT:   mutating func __operatorStar() -> UnsafeMutablePointer<Int>
+// CHECK-NEXT:   static func * (lhs: AllStar, rhs: AllStar) -> AllStar
+// CHECK-NEXT:   @available(*, unavailable, message: "use * instead")
+// CHECK-NEXT:   func __operatorStar(_ rhs: AllStar) -> AllStar
+// CHECK-NEXT:   var L: Int
+// CHECK-NEXT:   var pointee: Int { mutating get set }
+// CHECK-NEXT: }
+
 // CHECK: struct AmbiguousOperatorStar {
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   @available(*, unavailable, message: "use .pointee property")

--- a/test/Interop/Cxx/operators/member-inline-typechecker.swift
+++ b/test/Interop/Cxx/operators/member-inline-typechecker.swift
@@ -84,6 +84,13 @@ let _ = classWithSuccessorAvailable.successor();
 let classWithSuccessorUnavailable = ClassWithSuccessorUnavailable()
 let _ = classWithSuccessorUnavailable.successor(); // expected-error {{'successor()' is unavailable in Swift}}
 
+let allStar = AllStar() // expected-note {{change 'let' to 'var' to make it mutable}}
+let _ = allStar.pointee // expected-error {{cannot use mutating getter on immutable value}}
+var mutAllStar = AllStar()
+let _ = mutAllStar.pointee
+var _: AllStar  = mutAllStar * allStar
+var _: AllStar = allStar * mutAllStar
+
 var classWithOperatorStarAvailable = ClassWithOperatorStarAvailable()
 let _ = classWithOperatorStarAvailable.pointee
 let derivedClassWithOperatorStarAvailable = DerivedClassWithOperatorStarAvailable()

--- a/test/Interop/Cxx/operators/member-inline.swift
+++ b/test/Interop/Cxx/operators/member-inline.swift
@@ -385,6 +385,22 @@ OperatorsTestSuite.test("ConstIteratorByVal.pointee") {
   expectEqual(456, res)
 }
 
+OperatorsTestSuite.test("AllStar.*") {
+  var a = AllStar()
+  var b = a
+  b.pointee = 9
+
+  expectEqual(111, a.pointee)
+  expectEqual(9, b.pointee)
+
+  var c = a * b
+  c.pointee += 1000
+
+  expectEqual(111, a.pointee)
+  expectEqual(9, b.pointee)
+  expectEqual(1999, c.pointee)
+}
+
 OperatorsTestSuite.test("AmbiguousOperatorStar.pointee") {
   let stars = AmbiguousOperatorStar()
   let res = stars.pointee

--- a/test/Interop/Cxx/operators/non-member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/non-member-inline-module-interface.swift
@@ -24,3 +24,7 @@
 // CHECK-NOT:  func + (lhs: RValueArithmetic
 
 // CHECK:      func + (lhs: LValueAndRValueArithmetic, rhs: LValueAndRValueArithmetic) -> LValueAndRValueArithmetic
+
+// FIXME: this is currently imported due to quirks of NameImporter
+// FIXME-NOT: func * ({{.*}}: inout AllStar)
+// CHECK: func * (lhs: AllStar, rhs: AllStar) -> AllStar

--- a/test/Interop/Cxx/operators/non-member-inline-typechecker.swift
+++ b/test/Interop/Cxx/operators/non-member-inline-typechecker.swift
@@ -45,3 +45,12 @@ let resultRValue = lhsRValue + rhsRValue // expected-error {{binary operator '+'
 let lhsLRValue = LValueAndRValueArithmetic(value: 123)
 let rhsLRValue = LValueAndRValueArithmetic(value: 146)
 let resultLRValue = lhsLRValue + rhsLRValue
+
+// FIXME: out-of-line operator*() is not imported as .pointee
+var mutAllStar = AllStar()
+let _ = mutAllStar.pointee  // expected-error {{no member 'pointee'}}
+let allStar = AllStar()     // FIXME-note {{change 'let' to 'var' to make it mutable}}
+let _ = allStar.pointee     // FIXME-error {{cannot use mutating getter on immutable value}}
+                            // expected-error@-1 {{no member 'pointee'}}
+var _: AllStar  = mutAllStar * allStar
+var _: AllStar = allStar * mutAllStar

--- a/test/Interop/Cxx/operators/non-member-inline.swift
+++ b/test/Interop/Cxx/operators/non-member-inline.swift
@@ -208,4 +208,13 @@ OperatorsTestSuite.test("LValueAndRValueArithmetic.+") {
   expectEqual(269, (lhs + rhs).value)
 }
 
+OperatorsTestSuite.test("AllStar (unary vs binary *)") {
+  let a = AllStar()
+  let b = AllStar()
+  var c = a * b
+  // FIXME: unary non-member operator*() not imported as .pointee
+  // expectEqual(111 * 111, c.pointee)
+  expectEqual(111 * 111, c.L)
+}
+
 runAllTests()


### PR DESCRIPTION
c2952b7 mistakenly treated the binary C++ operator*() ("multiply") as the unary operator*() ("dereference"), preventing ClangImporter from synthesizing the Swift func *(_:_) operator. This patch fixes the issue and adds some tests to exercise the scenario.

rdar://169448888