### PR TITLE
[Swiftify] properly support initializers

### DIFF
--- a/test/Interop/C/swiftify-import/availability.swift
+++ b/test/Interop/C/swiftify-import/availability.swift
@@ -62,9 +62,10 @@ public func bufferPointer(_ _bufferPointer_param0: UnsafeMutableBufferPointer<In
 @available(iOS 2.0, *) @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 public func span(_ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
-    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
-      return unsafe span(_pPtr.baseAddress!, len)
+    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+        unsafe $0
     }
+    return unsafe span(_pPtr.baseAddress!, len)
 }
 ------------------------------
 //--- watchos-expansions.expected
@@ -83,9 +84,10 @@ public func bufferPointer(_ _bufferPointer_param0: UnsafeMutableBufferPointer<In
 @available(watchOS 2.0, *) @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 public func span(_ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
-    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
-      return unsafe span(_pPtr.baseAddress!, len)
+    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+        unsafe $0
     }
+    return unsafe span(_pPtr.baseAddress!, len)
 }
 ------------------------------
 //--- xros-expansions.expected
@@ -104,9 +106,10 @@ public func bufferPointer(_ _bufferPointer_param0: UnsafeMutableBufferPointer<In
 @available(visionOS 1.0, *) @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 public func span(_ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
-    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
-      return unsafe span(_pPtr.baseAddress!, len)
+    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+        unsafe $0
     }
+    return unsafe span(_pPtr.baseAddress!, len)
 }
 ------------------------------
 //--- tvos-expansions.expected
@@ -123,9 +126,10 @@ public func span(_ p: inout MutableSpan<Int32>) {
 /// This is an auto-generated wrapper for safer interop
 @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public func span(_ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
-    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
-      return unsafe span(_pPtr.baseAddress!, len)
+    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+        unsafe $0
     }
+    return unsafe span(_pPtr.baseAddress!, len)
 }
 ------------------------------
 //--- other-expansions.expected
@@ -142,9 +146,10 @@ public func span(_ p: inout MutableSpan<Int32>) {
 /// This is an auto-generated wrapper for safer interop
 @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public func span(_ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
-    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
-      return unsafe span(_pPtr.baseAddress!, len)
+    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+        unsafe $0
     }
+    return unsafe span(_pPtr.baseAddress!, len)
 }
 ------------------------------
 //--- test.swift

--- a/test/Interop/C/swiftify-import/availability.swift
+++ b/test/Interop/C/swiftify-import/availability.swift
@@ -40,9 +40,10 @@ public func bufferPointer(_ _bufferPointer_param0: UnsafeMutableBufferPointer<In
 @available(macOS 10.5, *) @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 public func span(_ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
-    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
-      return unsafe span(_pPtr.baseAddress!, len)
+    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+        unsafe $0
     }
+    return unsafe span(_pPtr.baseAddress!, len)
 }
 ------------------------------
 //--- ios-expansions.expected

--- a/test/Interop/C/swiftify-import/bridging-header-from-module.swift
+++ b/test/Interop/C/swiftify-import/bridging-header-from-module.swift
@@ -32,9 +32,10 @@ imports for @__swiftmacro_So3foo15_SwiftifyImportfMp_.swift:
 /// This is an auto-generated wrapper for safer interop
 @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_disfavoredOverload public func foo(_ p: Span<Int32>, _ x: UnsafeMutablePointer<no_module_record_t>!) {
     let len = Int32(exactly: p.count)!
-    return unsafe p.withUnsafeBufferPointer { _pPtr in
-      return unsafe foo(len, _pPtr.baseAddress!, x)
+    let _pPtr = unsafe p.withUnsafeBufferPointer {
+        unsafe $0
     }
+    return unsafe foo(len, _pPtr.baseAddress!, x)
 }
 ------------------------------
 

--- a/test/Interop/C/swiftify-import/bridging-header-nontrivial.swift
+++ b/test/Interop/C/swiftify-import/bridging-header-nontrivial.swift
@@ -36,9 +36,10 @@ imports for @__swiftmacro_So3bar15_SwiftifyImportfMp_.swift:
 /// This is an auto-generated wrapper for safer interop
 @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_disfavoredOverload public func foo(_ p: Span<Int32>) {
     let len = Int32(exactly: p.count)!
-    return unsafe p.withUnsafeBufferPointer { _pPtr in
-      return unsafe foo(len, _pPtr.baseAddress!)
+    let _pPtr = unsafe p.withUnsafeBufferPointer {
+        unsafe $0
     }
+    return unsafe foo(len, _pPtr.baseAddress!)
 }
 ------------------------------
 @__swiftmacro_So3bar15_SwiftifyImportfMp_.swift
@@ -46,9 +47,10 @@ imports for @__swiftmacro_So3bar15_SwiftifyImportfMp_.swift:
 /// This is an auto-generated wrapper for safer interop
 @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_disfavoredOverload public func bar(_ p: Span<Int32>) {
     let len = Int32(exactly: p.count)!
-    return unsafe p.withUnsafeBufferPointer { _pPtr in
-      return unsafe bar(len, _pPtr.baseAddress!)
+    let _pPtr = unsafe p.withUnsafeBufferPointer {
+        unsafe $0
     }
+    return unsafe bar(len, _pPtr.baseAddress!)
 }
 ------------------------------
 

--- a/test/Interop/C/swiftify-import/bridging-header.swift
+++ b/test/Interop/C/swiftify-import/bridging-header.swift
@@ -30,9 +30,10 @@ imports for @__swiftmacro_So3foo15_SwiftifyImportfMp_.swift:
 /// This is an auto-generated wrapper for safer interop
 @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_disfavoredOverload public func foo(_ p: Span<a_t>, _ x: UnsafeMutablePointer<no_module_record_t>!) {
     let len = no_module_t(exactly: p.count)!
-    return unsafe p.withUnsafeBufferPointer { _pPtr in
-      return unsafe foo(len, _pPtr.baseAddress!, x)
+    let _pPtr = unsafe p.withUnsafeBufferPointer {
+        unsafe $0
     }
+    return unsafe foo(len, _pPtr.baseAddress!, x)
 }
 ------------------------------
 

--- a/test/Interop/C/swiftify-import/import-as-instance-method.swift
+++ b/test/Interop/C/swiftify-import/import-as-instance-method.swift
@@ -325,7 +325,7 @@ public func createA2(_ p: inout MutableSpan<Int32>) -> UnsafeMutablePointer<A>! 
 ------------------------------
 /// This is an auto-generated wrapper for safer interop
 @_alwaysEmitIntoClient @_disfavoredOverload
-public /*not inherited*/ init!(pointerC p: UnsafeMutableBufferPointer<Int32>) {
+public /*not inherited*/ convenience init!(pointerC p: UnsafeMutableBufferPointer<Int32>) {
     let len = Int32(exactly: p.count)!
     unsafe self.init(countC: len, pointerC: p.baseAddress!)
 }

--- a/test/Interop/C/swiftify-import/import-as-instance-method.swift
+++ b/test/Interop/C/swiftify-import/import-as-instance-method.swift
@@ -11,19 +11,38 @@
 import Instance
 
 @available(SwiftStdlib 5.8, *)
-func foo(_ p: inout MutableSpan<CInt>, a: A, aa: inout A, c: C, b: B, bb: inout B) {
+func foo(_ p: inout MutableSpan<CInt>, a: A, aa: inout A, c: C, b: B, bb: inout B, d: D) {
   aa.basic(&p)
   aa.bar(&p)
   a.constSelf(&p)
   a.valSelf(&p)
   let _: MutableSpan<CInt> = a.lifetimeBoundSelf(3)
   c.refSelf(&p)
+  d.refSelf(&p)
   b.nonescaping(&p)
   let _: MutableSpan<CInt> = bb.nonescapingLifetimebound(73)
 
 #if VERIFY
   aa.countedSelf(&p)
   a.basic(&p) // expected-error{{cannot use mutating member on immutable value: 'a' is a 'let' constant}}
+#endif
+}
+
+@available(SwiftStdlib 5.8, *)
+func testInit(_ p: UnsafeMutablePointer<CInt>, _ len: CInt, _ s: inout MutableSpan<CInt>, _ bp: inout UnsafeMutableBufferPointer<CInt>) {
+  let _ = unsafe A(countA: len, pointerA: p)
+  let _ = unsafe A(pointerA: bp)
+  let _ = A(pointerA2: &s)
+  // let _ = unsafe B(len, p)
+  // let _ = B(&s)
+  let _ = unsafe C(countC: len, pointerC: p)
+  let _ = unsafe C(pointerC: bp)
+  let _ = unsafe D(countD: len, pointerD: p)
+
+#if VERIFY
+  // expected-error@+2{{cannot convert value of type 'UnsafeMutableBufferPointer<CInt>' (aka 'UnsafeMutableBufferPointer<Int32>') to expected argument type 'UnsafeMutablePointer<Int32>'}}
+  // expected-error@+1{{missing argument for parameter 'countD' in call}}
+  let _ = unsafe D(pointerD: bp)
 #endif
 }
 
@@ -35,6 +54,7 @@ func foo(_ p: inout MutableSpan<CInt>, a: A, aa: inout A, c: C, b: B, bb: inout 
 struct A {};
 struct SWIFT_NONESCAPABLE B {};
 struct SWIFT_IMMORTAL_REFERENCE C {};
+typedef struct __attribute__((objc_bridge(id))) D *DRef;
 
 void basic(struct A *a, int * __counted_by(len) p __noescape, int len) __attribute__((swift_name("A.basic(self:_:_:)")));
 
@@ -53,11 +73,25 @@ void valSelf(struct A a, int * __counted_by(len) p __noescape, int len) __attrib
 
 void refSelf(struct C *c, int * __counted_by(len) p __noescape, int len) __attribute__((swift_name("C.refSelf(self:_:_:)")));
 
+void refSelfCF(DRef d, int * __counted_by(len) p __noescape, int len) __attribute__((swift_name("D.refSelf(self:_:_:)")));
+
 int * __counted_by(len) lifetimeBoundSelf(struct A a __lifetimebound, int len) __attribute__((swift_name("A.lifetimeBoundSelf(self:_:)")));
 
 void nonescaping(const struct B *d, int * __counted_by(len) p __noescape, int len) __attribute__((swift_name("B.nonescaping(self:_:_:)")));
 
 int * __counted_by(len) nonescapingLifetimebound(struct B *d __lifetimebound, int len) __attribute__((swift_name("B.nonescapingLifetimebound(self:_:)")));
+
+struct A * createA(int len, int * __counted_by(len) p) __attribute__((swift_name("A.init(countA:pointerA:)")));
+struct A * createA2(int len, int * __counted_by(len) p __noescape) __attribute__((swift_name("A.init(countA2:pointerA2:)")));
+
+// This crashes the compiler rdar://169580475
+// struct B * createB(int len, int * __counted_by(len) p __lifetimebound) __attribute__((swift_name("B.init(_:_:)")));
+
+struct C * createC(int len, int * __counted_by(len) p) __attribute__((swift_name("C.init(countC:pointerC:)")));
+
+// This should not generate an overload, because Swift does not allow user-defined initiailizers for CF-style foreign references
+// expected-note@+1{{'init(countD:pointerD:)' declared here}}
+DRef createD(int len, int * __counted_by(len) p) __attribute__((swift_name("D.init(countD:pointerD:)")));
 
 //--- Inputs/module.modulemap
 module Instance {
@@ -71,9 +105,10 @@ module Instance {
 @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 public mutating func basic(_ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
-    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
-      return unsafe basic(_pPtr.baseAddress!, len)
+    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+        unsafe $0
     }
+    return unsafe basic(_pPtr.baseAddress!, len)
 }
 ------------------------------
 @__swiftmacro_So5basic15_SwiftifyImportfMp_.swift
@@ -82,9 +117,10 @@ public mutating func basic(_ p: inout MutableSpan<Int32>) {
 @available(swift, obsoleted: 3, renamed: "A.basic(self:_:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 public func basic(_ a: UnsafeMutablePointer<A>!, _ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
-    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
-      return unsafe basic(a, _pPtr.baseAddress!, len)
+    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+        unsafe $0
     }
+    return unsafe basic(a, _pPtr.baseAddress!, len)
 }
 ------------------------------
 @__swiftmacro_So1AV3bar15_SwiftifyImportfMp_.swift
@@ -93,9 +129,10 @@ public func basic(_ a: UnsafeMutablePointer<A>!, _ p: inout MutableSpan<Int32>) 
 @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 public mutating func bar(_ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
-    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
-      return unsafe bar(_pPtr.baseAddress!, len)
+    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+        unsafe $0
     }
+    return unsafe bar(_pPtr.baseAddress!, len)
 }
 ------------------------------
 @__swiftmacro_So7renamed15_SwiftifyImportfMp_.swift
@@ -104,9 +141,10 @@ public mutating func bar(_ p: inout MutableSpan<Int32>) {
 @available(swift, obsoleted: 3, renamed: "A.bar(self:_:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 public func renamed(_ a: UnsafeMutablePointer<A>!, _ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
-    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
-      return unsafe renamed(a, _pPtr.baseAddress!, len)
+    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+        unsafe $0
     }
+    return unsafe renamed(a, _pPtr.baseAddress!, len)
 }
 ------------------------------
 @__swiftmacro_So1AV9constSelf15_SwiftifyImportfMp_.swift
@@ -115,9 +153,10 @@ public func renamed(_ a: UnsafeMutablePointer<A>!, _ p: inout MutableSpan<Int32>
 @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 public func constSelf(_ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
-    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
-      return unsafe constSelf(_pPtr.baseAddress!, len)
+    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+        unsafe $0
     }
+    return unsafe constSelf(_pPtr.baseAddress!, len)
 }
 ------------------------------
 @__swiftmacro_So9constSelf15_SwiftifyImportfMp_.swift
@@ -126,9 +165,10 @@ public func constSelf(_ p: inout MutableSpan<Int32>) {
 @available(swift, obsoleted: 3, renamed: "A.constSelf(self:_:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 public func constSelf(_ a: UnsafePointer<A>!, _ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
-    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
-      return unsafe constSelf(a, _pPtr.baseAddress!, len)
+    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+        unsafe $0
     }
+    return unsafe constSelf(a, _pPtr.baseAddress!, len)
 }
 ------------------------------
 @__swiftmacro_So1AV7valSelf15_SwiftifyImportfMp_.swift
@@ -137,9 +177,10 @@ public func constSelf(_ a: UnsafePointer<A>!, _ p: inout MutableSpan<Int32>) {
 @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 public func valSelf(_ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
-    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
-      return unsafe valSelf(_pPtr.baseAddress!, len)
+    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+        unsafe $0
     }
+    return unsafe valSelf(_pPtr.baseAddress!, len)
 }
 ------------------------------
 @__swiftmacro_So7valSelf15_SwiftifyImportfMp_.swift
@@ -148,9 +189,10 @@ public func valSelf(_ p: inout MutableSpan<Int32>) {
 @available(swift, obsoleted: 3, renamed: "A.valSelf(self:_:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 public func valSelf(_ a: A, _ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
-    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
-      return unsafe valSelf(a, _pPtr.baseAddress!, len)
+    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+        unsafe $0
     }
+    return unsafe valSelf(a, _pPtr.baseAddress!, len)
 }
 ------------------------------
 @__swiftmacro_So1AV17lifetimeBoundSelf15_SwiftifyImportfMp_.swift
@@ -175,9 +217,10 @@ public func lifetimeBoundSelf(_ a: A, _ len: Int32) -> MutableSpan<Int32> {
 @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 public func refSelf(_ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
-    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
-      return unsafe refSelf(_pPtr.baseAddress!, len)
+    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+        unsafe $0
     }
+    return unsafe refSelf(_pPtr.baseAddress!, len)
 }
 ------------------------------
 @__swiftmacro_So7refSelf15_SwiftifyImportfMp_.swift
@@ -186,9 +229,34 @@ public func refSelf(_ p: inout MutableSpan<Int32>) {
 @available(swift, obsoleted: 3, renamed: "C.refSelf(self:_:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 public func refSelf(_ c: C!, _ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
-    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
-      return unsafe refSelf(c, _pPtr.baseAddress!, len)
+    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+        unsafe $0
     }
+    return unsafe refSelf(c, _pPtr.baseAddress!, len)
+}
+------------------------------
+@__swiftmacro_So4DRefa7refSelf15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
+public func refSelf(_ p: inout MutableSpan<Int32>) {
+    let len = Int32(exactly: p.count)!
+    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+        unsafe $0
+    }
+    return unsafe refSelf(_pPtr.baseAddress!, len)
+}
+------------------------------
+@__swiftmacro_So9refSelfCF15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@available(swift, obsoleted: 3, renamed: "D.refSelf(self:_:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
+public func refSelfCF(_ d: D!, _ p: inout MutableSpan<Int32>) {
+    let len = Int32(exactly: p.count)!
+    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+        unsafe $0
+    }
+    return unsafe refSelfCF(d, _pPtr.baseAddress!, len)
 }
 ------------------------------
 @__swiftmacro_So1BV11nonescaping15_SwiftifyImportfMp_.swift
@@ -197,9 +265,10 @@ public func refSelf(_ c: C!, _ p: inout MutableSpan<Int32>) {
 @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 public func nonescaping(_ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
-    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
-      return unsafe nonescaping(_pPtr.baseAddress!, len)
+    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+        unsafe $0
     }
+    return unsafe nonescaping(_pPtr.baseAddress!, len)
 }
 ------------------------------
 @__swiftmacro_So1BV24nonescapingLifetimebound15_SwiftifyImportfMp_.swift
@@ -208,5 +277,74 @@ public func nonescaping(_ p: inout MutableSpan<Int32>) {
 @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy self) @_disfavoredOverload
 public mutating func nonescapingLifetimebound(_ len: Int32) -> MutableSpan<Int32> {
     return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: unsafe nonescapingLifetimebound(len), count: Int(len)), copying: ())
+}
+------------------------------
+@__swiftmacro_So1AV4init15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public /*not inherited*/ init!(pointerA p: UnsafeMutableBufferPointer<Int32>) {
+    let len = Int32(exactly: p.count)!
+    unsafe self.init(countA: len, pointerA: p.baseAddress!)
+}
+------------------------------
+@__swiftmacro_So7createA15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@available(swift, obsoleted: 3, renamed: "A.init(countA:pointerA:)") @_alwaysEmitIntoClient @_disfavoredOverload
+public func createA(_ p: UnsafeMutableBufferPointer<Int32>) -> UnsafeMutablePointer<A>! {
+    let len = Int32(exactly: p.count)!
+    return unsafe createA(len, p.baseAddress!)
+}
+------------------------------
+@__swiftmacro_So1AV4init15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
+public /*not inherited*/ init!(pointerA2 p: inout MutableSpan<Int32>) {
+    let len = Int32(exactly: p.count)!
+    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+        unsafe $0
+    }
+    unsafe self.init(countA2: len, pointerA2: _pPtr.baseAddress!)
+}
+------------------------------
+@__swiftmacro_So8createA215_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@available(swift, obsoleted: 3, renamed: "A.init(countA2:pointerA2:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
+public func createA2(_ p: inout MutableSpan<Int32>) -> UnsafeMutablePointer<A>! {
+    let len = Int32(exactly: p.count)!
+    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+        unsafe $0
+    }
+    return unsafe createA2(len, _pPtr.baseAddress!)
+}
+------------------------------
+@__swiftmacro_So1CV4init15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public /*not inherited*/ init!(pointerC p: UnsafeMutableBufferPointer<Int32>) {
+    let len = Int32(exactly: p.count)!
+    unsafe self.init(countC: len, pointerC: p.baseAddress!)
+}
+------------------------------
+@__swiftmacro_So7createC15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@available(swift, obsoleted: 3, renamed: "C.init(countC:pointerC:)") @_alwaysEmitIntoClient @_disfavoredOverload
+public func createC(_ p: UnsafeMutableBufferPointer<Int32>) -> C! {
+    let len = Int32(exactly: p.count)!
+    return unsafe createC(len, p.baseAddress!)
+}
+------------------------------
+@__swiftmacro_So7createD15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@available(swift, obsoleted: 3, renamed: "D.init(countD:pointerD:)") @_alwaysEmitIntoClient @_disfavoredOverload
+public func createD(_ p: UnsafeMutableBufferPointer<Int32>) -> Unmanaged<D>! {
+    let len = Int32(exactly: p.count)!
+    return unsafe createD(len, p.baseAddress!)
 }
 ------------------------------

--- a/test/Interop/Cxx/swiftify-import/parameter-type-from-namespace.swift
+++ b/test/Interop/Cxx/swiftify-import/parameter-type-from-namespace.swift
@@ -78,32 +78,34 @@ namespace foo {
 //   expected-note@1 5{{in expansion of macro '_SwiftifyImport' on global function 'bar' here}}
 // }}
 __attribute__((swift_attr("@_SwiftifyImport(.countedBy(pointer: .param(1), count: \"len\"))"))) void bar(float *p, int len, foo::foo_t extra);
-// expected-expansion@+12:94{{
+// expected-expansion@+13:94{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_disfavoredOverload public func bar2(_ p: Span<foo.foo_t>, _ extra: foo.foo_t) {|}}
 //   expected-remark@3{{macro content: |    let len = foo.foo_t(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    return unsafe p.withUnsafeBufferPointer { _pPtr in|}}
-//   expected-remark@5{{macro content: |      return unsafe bar2(_pPtr.baseAddress!, len, extra)|}}
+//   expected-remark@4{{macro content: |    let _pPtr = unsafe p.withUnsafeBufferPointer {|}}
+//   expected-remark@5{{macro content: |        unsafe $0|}}
 //   expected-remark@6{{macro content: |    }|}}
-//   expected-remark@7{{macro content: |}|}}
+//   expected-remark@7{{macro content: |    return unsafe bar2(_pPtr.baseAddress!, len, extra)|}}
+//   expected-remark@8{{macro content: |}|}}
 // }}
 // expected-expansion@+3:6{{
-//   expected-note@1 7{{in expansion of macro '_SwiftifyImport' on global function 'bar2' here}}
+//   expected-note@1 8{{in expansion of macro '_SwiftifyImport' on global function 'bar2' here}}
 // }}
 void bar2(const foo::foo_t * __counted_by(len) p __noescape, foo::foo_t len, foo::foo_t extra);
 namespace baz {
-  // expected-expansion@+13:100{{
+  // expected-expansion@+14:100{{
   //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
   //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_disfavoredOverload|}}
   //   expected-remark@3{{macro content: |public static func baz_func(_ p: Span<foo.foo_t>, _ extra: foo.foo_t) {|}}
   //   expected-remark@4{{macro content: |    let len = foo.foo_t(exactly: p.count)!|}}
-  //   expected-remark@5{{macro content: |    return unsafe p.withUnsafeBufferPointer { _pPtr in|}}
-  //   expected-remark@6{{macro content: |      return unsafe baz_func(_pPtr.baseAddress!, len, extra)|}}
+  //   expected-remark@5{{macro content: |    let _pPtr = unsafe p.withUnsafeBufferPointer {|}}
+  //   expected-remark@6{{macro content: |        unsafe $0|}}
   //   expected-remark@7{{macro content: |    }|}}
-  //   expected-remark@8{{macro content: |}|}}
+  //   expected-remark@8{{macro content: |    return unsafe baz_func(_pPtr.baseAddress!, len, extra)|}}
+  //   expected-remark@9{{macro content: |}|}}
   // }}
   // expected-expansion@+3:8{{
-  //   expected-note@1 8{{in expansion of macro '_SwiftifyImport' on static method 'baz_func' here}}
+  //   expected-note@1 9{{in expansion of macro '_SwiftifyImport' on static method 'baz_func' here}}
   // }}
   void baz_func(const foo::foo_t * __counted_by(len) p __noescape, foo::foo_t len, foo::foo_t extra);
 }

--- a/test/Macros/SwiftifyImport/CountedBy/Anonymous.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Anonymous.swift
@@ -1,7 +1,13 @@
 // REQUIRES: swift_swift_parser
 
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -typecheck -plugin-path %swift-plugin-dir -strict-memory-safety -warnings-as-errors -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
 
+// RUN: %target-swift-frontend %t/test.swift -emit-module -plugin-path %swift-plugin-dir -strict-memory-safety -verify
+// RUN: env SWIFT_BACKTRACE="" %target-swift-frontend %t/test.swift -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2> %t/expansions.out
+// RUN: %diff %t/expansions.out %t/expansions.expected
+
+//--- test.swift
 @_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"))
 public func myFunc(_: UnsafePointer<CInt>, _ len: CInt) {
 }
@@ -18,30 +24,44 @@ public func myFunc3(_: UnsafePointer<CInt>, _ len: CInt) {
 public func myFunc4(_: UnsafeMutablePointer<CInt>, _ len: CInt) {
 }
 
-// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: public func myFunc(_ _myFunc_param0: UnsafeBufferPointer<CInt>) {
-// CHECK-NEXT:     let _myFunc_param1 = CInt(exactly: _myFunc_param0.count)!
-// CHECK-NEXT:     return unsafe myFunc(_myFunc_param0.baseAddress!, _myFunc_param1)
-// CHECK-NEXT: }
-
-// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: public func myFunc2(_ _myFunc2_param0: UnsafeBufferPointer<CInt>, _ _myFunc2_param2: CInt) {
-// CHECK-NEXT:     let _myFunc2_param1 = CInt(exactly: _myFunc2_param0.count)!
-// CHECK-NEXT:     return unsafe myFunc2(_myFunc2_param0.baseAddress!, _myFunc2_param1, _myFunc2_param2)
-// CHECK-NEXT: }
-
-// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: public func myFunc3(_ _myFunc3_param0: Span<CInt>) {
-// CHECK-NEXT:     let _myFunc3_param1 = CInt(exactly: _myFunc3_param0.count)!
-// CHECK-NEXT:     return unsafe _myFunc3_param0.withUnsafeBufferPointer { __myFunc3_param0Ptr in
-// CHECK-NEXT:       return unsafe myFunc3(__myFunc3_param0Ptr.baseAddress!, _myFunc3_param1)
-// CHECK-NEXT:     }
-// CHECK-NEXT: }
-
-// CHECK:      @_alwaysEmitIntoClient @_lifetime(_myFunc4_param0: copy _myFunc4_param0) @_disfavoredOverload
-// CHECK-NEXT: public func myFunc4(_ _myFunc4_param0: inout MutableSpan<CInt>) {
-// CHECK-NEXT:     let _myFunc4_param1 = CInt(exactly: _myFunc4_param0.count)!
-// CHECK-NEXT:     return unsafe _myFunc4_param0.withUnsafeMutableBufferPointer { __myFunc4_param0Ptr in
-// CHECK-NEXT:       return unsafe myFunc4(__myFunc4_param0Ptr.baseAddress!, _myFunc4_param1)
-// CHECK-NEXT:     }
-// CHECK-NEXT: }
+//--- expansions.expected
+@__swiftmacro_4test6myFunc15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func myFunc(_ _myFunc_param0: UnsafeBufferPointer<CInt>) {
+    let _myFunc_param1 = CInt(exactly: _myFunc_param0.count)!
+    return unsafe myFunc(_myFunc_param0.baseAddress!, _myFunc_param1)
+}
+------------------------------
+@__swiftmacro_4test7myFunc215_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func myFunc2(_ _myFunc2_param0: UnsafeBufferPointer<CInt>, _ _myFunc2_param2: CInt) {
+    let _myFunc2_param1 = CInt(exactly: _myFunc2_param0.count)!
+    return unsafe myFunc2(_myFunc2_param0.baseAddress!, _myFunc2_param1, _myFunc2_param2)
+}
+------------------------------
+@__swiftmacro_4test7myFunc315_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func myFunc3(_ _myFunc3_param0: Span<CInt>) {
+    let _myFunc3_param1 = CInt(exactly: _myFunc3_param0.count)!
+    return unsafe _myFunc3_param0.withUnsafeBufferPointer { __myFunc3_param0Ptr in
+      return unsafe myFunc3(__myFunc3_param0Ptr.baseAddress!, _myFunc3_param1)
+    }
+}
+------------------------------
+@__swiftmacro_4test7myFunc415_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_lifetime(_myFunc4_param0: copy _myFunc4_param0) @_disfavoredOverload
+public func myFunc4(_ _myFunc4_param0: inout MutableSpan<CInt>) {
+    let _myFunc4_param1 = CInt(exactly: _myFunc4_param0.count)!
+    return unsafe _myFunc4_param0.withUnsafeMutableBufferPointer { __myFunc4_param0Ptr in
+      return unsafe myFunc4(__myFunc4_param0Ptr.baseAddress!, _myFunc4_param1)
+    }
+}
+------------------------------

--- a/test/Macros/SwiftifyImport/CountedBy/Anonymous.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Anonymous.swift
@@ -49,9 +49,10 @@ public func myFunc2(_ _myFunc2_param0: UnsafeBufferPointer<CInt>, _ _myFunc2_par
 @_alwaysEmitIntoClient @_disfavoredOverload
 public func myFunc3(_ _myFunc3_param0: Span<CInt>) {
     let _myFunc3_param1 = CInt(exactly: _myFunc3_param0.count)!
-    return unsafe _myFunc3_param0.withUnsafeBufferPointer { __myFunc3_param0Ptr in
-      return unsafe myFunc3(__myFunc3_param0Ptr.baseAddress!, _myFunc3_param1)
+    let __myFunc3_param0Ptr = unsafe _myFunc3_param0.withUnsafeBufferPointer {
+        unsafe $0
     }
+    return unsafe myFunc3(__myFunc3_param0Ptr.baseAddress!, _myFunc3_param1)
 }
 ------------------------------
 @__swiftmacro_4test7myFunc415_SwiftifyImportfMp_.swift
@@ -60,8 +61,9 @@ public func myFunc3(_ _myFunc3_param0: Span<CInt>) {
 @_alwaysEmitIntoClient @_lifetime(_myFunc4_param0: copy _myFunc4_param0) @_disfavoredOverload
 public func myFunc4(_ _myFunc4_param0: inout MutableSpan<CInt>) {
     let _myFunc4_param1 = CInt(exactly: _myFunc4_param0.count)!
-    return unsafe _myFunc4_param0.withUnsafeMutableBufferPointer { __myFunc4_param0Ptr in
-      return unsafe myFunc4(__myFunc4_param0Ptr.baseAddress!, _myFunc4_param1)
+    let __myFunc4_param0Ptr = unsafe _myFunc4_param0.withUnsafeMutableBufferPointer {
+        unsafe $0
     }
+    return unsafe myFunc4(__myFunc4_param0Ptr.baseAddress!, _myFunc4_param1)
 }
 ------------------------------

--- a/test/Macros/SwiftifyImport/CountedBy/ConstantCount.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/ConstantCount.swift
@@ -117,9 +117,10 @@ public func noescape(_ ptr: Span<CInt>) {
     if _ptrCount != 37 {
       fatalError("bounds check failure in noescape: expected \(37) but got \(_ptrCount)")
     }
-    return unsafe ptr.withUnsafeBufferPointer { _ptrPtr in
-      return unsafe noescape(_ptrPtr.baseAddress!)
+    let _ptrPtr = unsafe ptr.withUnsafeBufferPointer {
+        unsafe $0
     }
+    return unsafe noescape(_ptrPtr.baseAddress!)
 }
 ------------------------------
 @__swiftmacro_4test11noescapeOpt15_SwiftifyImportfMp_.swift
@@ -131,15 +132,10 @@ public func noescapeOpt(_ ptr: Span<CInt>?) {
     if _ptrCount != 37 {
       fatalError("bounds check failure in noescapeOpt: expected \(37) but got \(_ptrCount)")
     }
-    return { () in
-        return if ptr == nil {
-            unsafe noescapeOpt(nil)
-          } else {
-            unsafe ptr!.withUnsafeBufferPointer { _ptrPtr in
-              return unsafe noescapeOpt(_ptrPtr.baseAddress)
-            }
-          }
-    }()
+    let _ptrPtr = unsafe ptr?.withUnsafeBufferPointer {
+        unsafe $0
+    }
+    return unsafe noescapeOpt(_ptrPtr?.baseAddress)
 }
 ------------------------------
 @__swiftmacro_4test11noescapeMut15_SwiftifyImportfMp_.swift
@@ -151,9 +147,10 @@ public func noescapeMut(_ ptr: inout MutableSpan<CInt>) {
     if _ptrCount != 37 {
       fatalError("bounds check failure in noescapeMut: expected \(37) but got \(_ptrCount)")
     }
-    return unsafe ptr.withUnsafeMutableBufferPointer { _ptrPtr in
-      return unsafe noescapeMut(_ptrPtr.baseAddress!)
+    let _ptrPtr = unsafe ptr.withUnsafeMutableBufferPointer {
+        unsafe $0
     }
+    return unsafe noescapeMut(_ptrPtr.baseAddress!)
 }
 ------------------------------
 @__swiftmacro_4test14noescapeMutOpt15_SwiftifyImportfMp_.swift
@@ -165,15 +162,10 @@ public func noescapeMutOpt(_ ptr: inout MutableSpan<CInt>?) {
     if _ptrCount != 37 {
       fatalError("bounds check failure in noescapeMutOpt: expected \(37) but got \(_ptrCount)")
     }
-    return { () in
-        return if ptr == nil {
-            unsafe noescapeMutOpt(nil)
-          } else {
-            unsafe ptr!.withUnsafeMutableBufferPointer { _ptrPtr in
-              return unsafe noescapeMutOpt(_ptrPtr.baseAddress)
-            }
-          }
-    }()
+    let _ptrPtr = unsafe ptr?.withUnsafeMutableBufferPointer {
+        unsafe $0
+    }
+    return unsafe noescapeMutOpt(_ptrPtr?.baseAddress)
 }
 ------------------------------
 @__swiftmacro_4test11plainReturn15_SwiftifyImportfMp_.swift

--- a/test/Macros/SwiftifyImport/CountedBy/CountExpr.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/CountExpr.swift
@@ -1,16 +1,27 @@
 // REQUIRES: swift_swift_parser
 
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -strict-memory-safety -warnings-as-errors -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
 
+// RUN: %target-swift-frontend %t/test.swift -emit-module -plugin-path %swift-plugin-dir -strict-memory-safety -verify
+// RUN: env SWIFT_BACKTRACE="" %target-swift-frontend %t/test.swift -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2> %t/expansions.out
+// RUN: %diff %t/expansions.out %t/expansions.expected
+
+//--- test.swift
 @_SwiftifyImport(.countedBy(pointer: .param(1), count: "size * count"))
-func myFunc(_ ptr: UnsafePointer<CInt>, _ size: CInt, _ count: CInt) {
+public func myFunc(_ ptr: UnsafePointer<CInt>, _ size: CInt, _ count: CInt) {
 }
 
-// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func myFunc(_ ptr: UnsafeBufferPointer<CInt>, _ size: CInt, _ count: CInt) {
-// CHECK-NEXT:     let _ptrCount = ptr.count
-// CHECK-NEXT:     if _ptrCount != size * count {
-// CHECK-NEXT:       fatalError("bounds check failure in myFunc: expected \(size * count) but got \(_ptrCount)")
-// CHECK-NEXT:     }
-// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, size, count)
-// CHECK-NEXT: }
+//--- expansions.expected
+@__swiftmacro_4test6myFunc15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func myFunc(_ ptr: UnsafeBufferPointer<CInt>, _ size: CInt, _ count: CInt) {
+    let _ptrCount = ptr.count
+    if _ptrCount != size * count {
+      fatalError("bounds check failure in myFunc: expected \(size * count) but got \(_ptrCount)")
+    }
+    return unsafe myFunc(ptr.baseAddress!, size, count)
+}
+------------------------------

--- a/test/Macros/SwiftifyImport/CountedBy/Mutable.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Mutable.swift
@@ -1,13 +1,24 @@
 // REQUIRES: swift_swift_parser
 
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -strict-memory-safety -warnings-as-errors -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
 
+// RUN: %target-swift-frontend %t/test.swift -emit-module -plugin-path %swift-plugin-dir -strict-memory-safety -verify
+// RUN: env SWIFT_BACKTRACE="" %target-swift-frontend %t/test.swift -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2> %t/expansions.out
+// RUN: %diff %t/expansions.out %t/expansions.expected
+
+//--- test.swift
 @_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"))
-func myFunc(_ ptr: UnsafeMutablePointer<CInt>, _ len: CInt) {
+public func myFunc(_ ptr: UnsafeMutablePointer<CInt>, _ len: CInt) {
 }
 
-// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func myFunc(_ ptr: UnsafeMutableBufferPointer<CInt>) {
-// CHECK-NEXT:     let len = CInt(exactly: ptr.count)!
-// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, len)
-// CHECK-NEXT: }
+//--- expansions.expected
+@__swiftmacro_4test6myFunc15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func myFunc(_ ptr: UnsafeMutableBufferPointer<CInt>) {
+    let len = CInt(exactly: ptr.count)!
+    return unsafe myFunc(ptr.baseAddress!, len)
+}
+------------------------------

--- a/test/Macros/SwiftifyImport/CountedBy/MutableSpan.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/MutableSpan.swift
@@ -1,16 +1,26 @@
 // REQUIRES: swift_swift_parser
 
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -strict-memory-safety -warnings-as-errors -dump-macro-expansions > %t.log 2>&1
-// RUN: %FileCheck --match-full-lines %s < %t.log
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
 
+// RUN: %target-swift-frontend %t/test.swift -emit-module -plugin-path %swift-plugin-dir -strict-memory-safety -verify
+// RUN: env SWIFT_BACKTRACE="" %target-swift-frontend %t/test.swift -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2> %t/expansions.out
+// RUN: %diff %t/expansions.out %t/expansions.expected
+
+//--- test.swift
 @_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"), .nonescaping(pointer: .param(1)))
-func myFunc(_ ptr: UnsafeMutablePointer<CInt>, _ len: CInt) {
+public func myFunc(_ ptr: UnsafeMutablePointer<CInt>, _ len: CInt) {
 }
 
-// CHECK:      @_alwaysEmitIntoClient @_lifetime(ptr: copy ptr) @_disfavoredOverload
-// CHECK-NEXT: func myFunc(_ ptr: inout MutableSpan<CInt>) {
-// CHECK-NEXT:     let len = CInt(exactly: ptr.count)!
-// CHECK-NEXT:     return unsafe ptr.withUnsafeMutableBufferPointer { _ptrPtr in
-// CHECK-NEXT:       return unsafe myFunc(_ptrPtr.baseAddress!, len)
-// CHECK-NEXT:     }
-// CHECK-NEXT: }
+//--- expansions.expected
+@__swiftmacro_4test6myFunc15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_lifetime(ptr: copy ptr) @_disfavoredOverload
+public func myFunc(_ ptr: inout MutableSpan<CInt>) {
+    let len = CInt(exactly: ptr.count)!
+    return unsafe ptr.withUnsafeMutableBufferPointer { _ptrPtr in
+      return unsafe myFunc(_ptrPtr.baseAddress!, len)
+    }
+}
+------------------------------

--- a/test/Macros/SwiftifyImport/CountedBy/MutableSpan.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/MutableSpan.swift
@@ -19,8 +19,9 @@ public func myFunc(_ ptr: UnsafeMutablePointer<CInt>, _ len: CInt) {
 @_alwaysEmitIntoClient @_lifetime(ptr: copy ptr) @_disfavoredOverload
 public func myFunc(_ ptr: inout MutableSpan<CInt>) {
     let len = CInt(exactly: ptr.count)!
-    return unsafe ptr.withUnsafeMutableBufferPointer { _ptrPtr in
-      return unsafe myFunc(_ptrPtr.baseAddress!, len)
+    let _ptrPtr = unsafe ptr.withUnsafeMutableBufferPointer {
+        unsafe $0
     }
+    return unsafe myFunc(_ptrPtr.baseAddress!, len)
 }
 ------------------------------

--- a/test/Macros/SwiftifyImport/CountedBy/NamedParams.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/NamedParams.swift
@@ -1,63 +1,89 @@
 // REQUIRES: swift_swift_parser
 
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -strict-memory-safety -warnings-as-errors -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
 
+// RUN: %target-swift-frontend %t/test.swift -emit-module -plugin-path %swift-plugin-dir -strict-memory-safety -verify
+// RUN: env SWIFT_BACKTRACE="" %target-swift-frontend %t/test.swift -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2> %t/expansions.out
+// RUN: %diff %t/expansions.out %t/expansions.expected
+
+//--- test.swift
 @_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"))
-func ptrNamed(ptr: UnsafePointer<CInt>, _ len: CInt) {
+public func ptrNamed(ptr: UnsafePointer<CInt>, _ len: CInt) {
 }
 
 @_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"))
-func ptrNamedOther(buf ptr: UnsafePointer<CInt>, _ len: CInt) {
+public func ptrNamedOther(buf ptr: UnsafePointer<CInt>, _ len: CInt) {
 }
 
 @_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"))
-func lenNamed(_ ptr: UnsafePointer<CInt>, len: CInt) {
+public func lenNamed(_ ptr: UnsafePointer<CInt>, len: CInt) {
 }
 
 @_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"))
-func lenNamedOther(_ ptr: UnsafePointer<CInt>, count len: CInt) {
+public func lenNamedOther(_ ptr: UnsafePointer<CInt>, count len: CInt) {
 }
 
 @_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"))
-func allNamed(ptr: UnsafePointer<CInt>, len: CInt) {
+public func allNamed(ptr: UnsafePointer<CInt>, len: CInt) {
 }
 
 @_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"))
-func allNamedOther(buf ptr: UnsafePointer<CInt>, count len: CInt) {
+public func allNamedOther(buf ptr: UnsafePointer<CInt>, count len: CInt) {
 }
 
-// CHECK: @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func ptrNamed(ptr: UnsafeBufferPointer<CInt>) {
-// CHECK-NEXT:     let len = CInt(exactly: ptr.count)!
-// CHECK-NEXT:     return unsafe ptrNamed(ptr: ptr.baseAddress!, len)
-// CHECK-NEXT: }
-
-// CHECK: @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func ptrNamedOther(buf ptr: UnsafeBufferPointer<CInt>) {
-// CHECK-NEXT:     let len = CInt(exactly: ptr.count)!
-// CHECK-NEXT:     return unsafe ptrNamedOther(buf: ptr.baseAddress!, len)
-// CHECK-NEXT: }
-
-// CHECK: @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func lenNamed(_ ptr: UnsafeBufferPointer<CInt>) {
-// CHECK-NEXT:     let len = CInt(exactly: ptr.count)!
-// CHECK-NEXT:     return unsafe lenNamed(ptr.baseAddress!, len: len)
-// CHECK-NEXT: }
-
-// CHECK: @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func lenNamedOther(_ ptr: UnsafeBufferPointer<CInt>) {
-// CHECK-NEXT:     let len = CInt(exactly: ptr.count)!
-// CHECK-NEXT:     return unsafe lenNamedOther(ptr.baseAddress!, count: len)
-// CHECK-NEXT: }
-
-// CHECK: @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func allNamed(ptr: UnsafeBufferPointer<CInt>) {
-// CHECK-NEXT:     let len = CInt(exactly: ptr.count)!
-// CHECK-NEXT:     return unsafe allNamed(ptr: ptr.baseAddress!, len: len)
-// CHECK-NEXT: }
-
-// CHECK: @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func allNamedOther(buf ptr: UnsafeBufferPointer<CInt>) {
-// CHECK-NEXT:     let len = CInt(exactly: ptr.count)!
-// CHECK-NEXT:     return unsafe allNamedOther(buf: ptr.baseAddress!, count: len)
-// CHECK-NEXT: }
+//--- expansions.expected
+@__swiftmacro_4test8ptrNamed15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func ptrNamed(ptr: UnsafeBufferPointer<CInt>) {
+    let len = CInt(exactly: ptr.count)!
+    return unsafe ptrNamed(ptr: ptr.baseAddress!, len)
+}
+------------------------------
+@__swiftmacro_4test13ptrNamedOther15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func ptrNamedOther(buf ptr: UnsafeBufferPointer<CInt>) {
+    let len = CInt(exactly: ptr.count)!
+    return unsafe ptrNamedOther(buf: ptr.baseAddress!, len)
+}
+------------------------------
+@__swiftmacro_4test8lenNamed15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func lenNamed(_ ptr: UnsafeBufferPointer<CInt>) {
+    let len = CInt(exactly: ptr.count)!
+    return unsafe lenNamed(ptr.baseAddress!, len: len)
+}
+------------------------------
+@__swiftmacro_4test13lenNamedOther15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func lenNamedOther(_ ptr: UnsafeBufferPointer<CInt>) {
+    let len = CInt(exactly: ptr.count)!
+    return unsafe lenNamedOther(ptr.baseAddress!, count: len)
+}
+------------------------------
+@__swiftmacro_4test8allNamed15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func allNamed(ptr: UnsafeBufferPointer<CInt>) {
+    let len = CInt(exactly: ptr.count)!
+    return unsafe allNamed(ptr: ptr.baseAddress!, len: len)
+}
+------------------------------
+@__swiftmacro_4test13allNamedOther15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func allNamedOther(buf ptr: UnsafeBufferPointer<CInt>) {
+    let len = CInt(exactly: ptr.count)!
+    return unsafe allNamedOther(buf: ptr.baseAddress!, count: len)
+}
+------------------------------

--- a/test/Macros/SwiftifyImport/CountedBy/Nullable.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Nullable.swift
@@ -41,15 +41,10 @@ public func myFunc(_ ptr: UnsafeBufferPointer<CInt>?) {
 @_alwaysEmitIntoClient @_lifetime(ptr: copy ptr) @_disfavoredOverload
 public func myFunc2(_ ptr: inout MutableSpan<CInt>?) {
     let len = CInt(exactly: ptr?.count ?? 0)!
-    return { () in
-        return if ptr == nil {
-            unsafe myFunc2(nil, len)
-          } else {
-            unsafe ptr!.withUnsafeMutableBufferPointer { _ptrPtr in
-              return unsafe myFunc2(_ptrPtr.baseAddress, len)
-            }
-          }
-    }()
+    let _ptrPtr = unsafe ptr?.withUnsafeMutableBufferPointer {
+        unsafe $0
+    }
+    return unsafe myFunc2(_ptrPtr?.baseAddress, len)
 }
 ------------------------------
 @__swiftmacro_4test7myFunc315_SwiftifyImportfMp_.swift
@@ -59,31 +54,13 @@ public func myFunc2(_ ptr: inout MutableSpan<CInt>?) {
 public func myFunc3(_ ptr: inout MutableSpan<CInt>?, _ ptr2: inout MutableSpan<CInt>?) {
     let len = CInt(exactly: ptr?.count ?? 0)!
     let len2 = CInt(exactly: ptr2?.count ?? 0)!
-    return { () in
-        return if ptr2 == nil {
-            { () in
-                return if ptr == nil {
-                        unsafe myFunc3(nil, len, nil, len2)
-                      } else {
-                        unsafe ptr!.withUnsafeMutableBufferPointer { _ptrPtr in
-                          return unsafe myFunc3(_ptrPtr.baseAddress, len, nil, len2)
-                        }
-                      }
-            }()
-          } else {
-            unsafe ptr2!.withUnsafeMutableBufferPointer { _ptr2Ptr in
-              return { () in
-                  return if ptr == nil {
-                          unsafe myFunc3(nil, len, _ptr2Ptr.baseAddress, len2)
-                        } else {
-                          unsafe ptr!.withUnsafeMutableBufferPointer { _ptrPtr in
-                            return unsafe myFunc3(_ptrPtr.baseAddress, len, _ptr2Ptr.baseAddress, len2)
-                          }
-                        }
-              }()
-            }
-          }
-    }()
+    let _ptrPtr = unsafe ptr?.withUnsafeMutableBufferPointer {
+        unsafe $0
+    }
+    let _ptr2Ptr = unsafe ptr2?.withUnsafeMutableBufferPointer {
+        unsafe $0
+    }
+    return unsafe myFunc3(_ptrPtr?.baseAddress, len, _ptr2Ptr?.baseAddress, len2)
 }
 ------------------------------
 @__swiftmacro_4test7myFunc415_SwiftifyImportfMp_.swift
@@ -92,16 +69,11 @@ public func myFunc3(_ ptr: inout MutableSpan<CInt>?, _ ptr2: inout MutableSpan<C
 @_alwaysEmitIntoClient @_lifetime(copy ptr) @_lifetime(ptr: copy ptr) @_disfavoredOverload
 public func myFunc4(_ ptr: inout MutableSpan<CInt>?) -> MutableSpan<CInt>? {
     let len = CInt(exactly: ptr?.count ?? 0)!
+    let _ptrPtr = unsafe ptr?.withUnsafeMutableBufferPointer {
+        unsafe $0
+    }
     return unsafe _swiftifyOverrideLifetime({ () in
-      let _resultValue = { () in
-              return if ptr == nil {
-                  unsafe myFunc4(nil, len)
-                } else {
-                  unsafe ptr!.withUnsafeMutableBufferPointer { _ptrPtr in
-                    return unsafe myFunc4(_ptrPtr.baseAddress, len)
-                  }
-                }
-          }()
+      let _resultValue = unsafe myFunc4(_ptrPtr?.baseAddress, len)
       if unsafe _resultValue == nil {
         return nil
       } else {

--- a/test/Macros/SwiftifyImport/CountedBy/Nullable.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Nullable.swift
@@ -1,91 +1,112 @@
 // REQUIRES: swift_swift_parser
 
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -strict-memory-safety -warnings-as-errors -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
 
+// RUN: %target-swift-frontend %t/test.swift -emit-module -plugin-path %swift-plugin-dir -strict-memory-safety -verify
+// RUN: env SWIFT_BACKTRACE="" %target-swift-frontend %t/test.swift -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2> %t/expansions.out
+// RUN: %diff %t/expansions.out %t/expansions.expected
+
+//--- test.swift
 @_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"))
-func myFunc(_ ptr: UnsafePointer<CInt>?, _ len: CInt) {
+public func myFunc(_ ptr: UnsafePointer<CInt>?, _ len: CInt) {
 }
 
 @_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"), .nonescaping(pointer: .param(1)))
-func myFunc2(_ ptr: UnsafeMutablePointer<CInt>?, _ len: CInt) {
+public func myFunc2(_ ptr: UnsafeMutablePointer<CInt>?, _ len: CInt) {
 }
 
 @_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"), .nonescaping(pointer: .param(1)), .countedBy(pointer: .param(3), count: "len2"), .nonescaping(pointer: .param(3)))
-func myFunc3(_ ptr: UnsafeMutablePointer<CInt>?, _ len: CInt, _ ptr2: UnsafeMutablePointer<CInt>?, _ len2: CInt) {
+public func myFunc3(_ ptr: UnsafeMutablePointer<CInt>?, _ len: CInt, _ ptr2: UnsafeMutablePointer<CInt>?, _ len2: CInt) {
 }
 
 @_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"), .countedBy(pointer: .return, count: "len"), .lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .copy))
-func myFunc4(_ ptr: UnsafeMutablePointer<CInt>?, _ len: CInt) -> UnsafeMutablePointer<CInt>? {
+public func myFunc4(_ ptr: UnsafeMutablePointer<CInt>?, _ len: CInt) -> UnsafeMutablePointer<CInt>? {
+// expected-error@+1{{missing return in global function expected to return 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>')}}
 }
 
-// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func myFunc(_ ptr: UnsafeBufferPointer<CInt>?) {
-// CHECK-NEXT:     let len = CInt(exactly: unsafe ptr?.count ?? 0)!
-// CHECK-NEXT:     return unsafe myFunc(ptr?.baseAddress, len)
-// CHECK-NEXT: }
-
-// CHECK:      @_alwaysEmitIntoClient @_lifetime(ptr: copy ptr) @_disfavoredOverload
-// CHECK-NEXT: func myFunc2(_ ptr: inout MutableSpan<CInt>?) {
-// CHECK-NEXT:     let len = CInt(exactly: ptr?.count ?? 0)!
-// CHECK-NEXT:     return { () in
-// CHECK-NEXT:         return if ptr == nil {
-// CHECK-NEXT:             unsafe myFunc2(nil, len)
-// CHECK-NEXT:         } else {
-// CHECK-NEXT:             unsafe ptr!.withUnsafeMutableBufferPointer { _ptrPtr in
-// CHECK-NEXT:                 return unsafe myFunc2(_ptrPtr.baseAddress, len)
-// CHECK-NEXT:             }
-// CHECK-NEXT:         }
-// CHECK-NEXT:     }()
-// CHECK-NEXT: }
-
-// CHECK:      @_alwaysEmitIntoClient @_lifetime(ptr: copy ptr) @_lifetime(ptr2: copy ptr2) @_disfavoredOverload
-// CHECK-NEXT: func myFunc3(_ ptr: inout MutableSpan<CInt>?, _ ptr2: inout MutableSpan<CInt>?) {
-// CHECK-NEXT:     let len = CInt(exactly: ptr?.count ?? 0)!
-// CHECK-NEXT:     let len2 = CInt(exactly: ptr2?.count ?? 0)!
-// CHECK-NEXT:     return { () in
-// CHECK-NEXT:         return if ptr2 == nil {
-// CHECK-NEXT:             { () in
-// CHECK-NEXT:                 return  if ptr == nil {
-// CHECK-NEXT:                     unsafe myFunc3(nil, len, nil, len2)
-// CHECK-NEXT:                 } else {
-// CHECK-NEXT:                     unsafe ptr!.withUnsafeMutableBufferPointer { _ptrPtr in
-// CHECK-NEXT:                         return unsafe myFunc3(_ptrPtr.baseAddress, len, nil, len2)
-// CHECK-NEXT:                     }
-// CHECK-NEXT:                 }
-// CHECK-NEXT:             }()
-// CHECK-NEXT:         } else {
-// CHECK-NEXT:             unsafe ptr2!.withUnsafeMutableBufferPointer { _ptr2Ptr in
-// CHECK-NEXT:                 return { () in
-// CHECK-NEXT:                     return if ptr == nil {
-// CHECK-NEXT:                         unsafe myFunc3(nil, len, _ptr2Ptr.baseAddress, len2)
-// CHECK-NEXT:                     } else {
-// CHECK-NEXT:                         unsafe ptr!.withUnsafeMutableBufferPointer { _ptrPtr in
-// CHECK-NEXT:                             return unsafe myFunc3(_ptrPtr.baseAddress, len, _ptr2Ptr.baseAddress, len2)
-// CHECK-NEXT:                         }
-// CHECK-NEXT:                     }
-// CHECK-NEXT:                 }()
-// CHECK-NEXT:             }
-// CHECK-NEXT:         }
-// CHECK-NEXT:     }()
-// CHECK-NEXT: }
-
-// CHECK:      @_alwaysEmitIntoClient @_lifetime(copy ptr) @_lifetime(ptr: copy ptr) @_disfavoredOverload
-// CHECK-NEXT: func myFunc4(_ ptr: inout MutableSpan<CInt>?) -> MutableSpan<CInt>? {
-// CHECK-NEXT:     let len = CInt(exactly: ptr?.count ?? 0)!
-// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime({ () in
-// CHECK-NEXT:         let _resultValue = { () in
-// CHECK-NEXT:             return if ptr == nil {
-// CHECK-NEXT:                 unsafe myFunc4(nil, len)
-// CHECK-NEXT:             } else {
-// CHECK-NEXT:                 unsafe ptr!.withUnsafeMutableBufferPointer { _ptrPtr in
-// CHECK-NEXT:                     return unsafe myFunc4(_ptrPtr.baseAddress, len)
-// CHECK-NEXT:                 }
-// CHECK-NEXT:             }
-// CHECK-NEXT:         }()
-// CHECK-NEXT:         if unsafe _resultValue == nil {
-// CHECK-NEXT:             return nil
-// CHECK-NEXT:         } else {
-// CHECK-NEXT:             return unsafe _swiftifyOverrideLifetime(MutableSpan<CInt>(_unsafeStart: _resultValue!, count: Int(len)), copying: ())
-// CHECK-NEXT:         }
-// CHECK-NEXT:     }(), copying: ())
-// CHECK-NEXT: }
+//--- expansions.expected
+@__swiftmacro_4test6myFunc15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func myFunc(_ ptr: UnsafeBufferPointer<CInt>?) {
+    let len = CInt(exactly: unsafe ptr?.count ?? 0)!
+    return unsafe myFunc(ptr?.baseAddress, len)
+}
+------------------------------
+@__swiftmacro_4test7myFunc215_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_lifetime(ptr: copy ptr) @_disfavoredOverload
+public func myFunc2(_ ptr: inout MutableSpan<CInt>?) {
+    let len = CInt(exactly: ptr?.count ?? 0)!
+    return { () in
+        return if ptr == nil {
+            unsafe myFunc2(nil, len)
+          } else {
+            unsafe ptr!.withUnsafeMutableBufferPointer { _ptrPtr in
+              return unsafe myFunc2(_ptrPtr.baseAddress, len)
+            }
+          }
+    }()
+}
+------------------------------
+@__swiftmacro_4test7myFunc315_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_lifetime(ptr: copy ptr) @_lifetime(ptr2: copy ptr2) @_disfavoredOverload
+public func myFunc3(_ ptr: inout MutableSpan<CInt>?, _ ptr2: inout MutableSpan<CInt>?) {
+    let len = CInt(exactly: ptr?.count ?? 0)!
+    let len2 = CInt(exactly: ptr2?.count ?? 0)!
+    return { () in
+        return if ptr2 == nil {
+            { () in
+                return if ptr == nil {
+                        unsafe myFunc3(nil, len, nil, len2)
+                      } else {
+                        unsafe ptr!.withUnsafeMutableBufferPointer { _ptrPtr in
+                          return unsafe myFunc3(_ptrPtr.baseAddress, len, nil, len2)
+                        }
+                      }
+            }()
+          } else {
+            unsafe ptr2!.withUnsafeMutableBufferPointer { _ptr2Ptr in
+              return { () in
+                  return if ptr == nil {
+                          unsafe myFunc3(nil, len, _ptr2Ptr.baseAddress, len2)
+                        } else {
+                          unsafe ptr!.withUnsafeMutableBufferPointer { _ptrPtr in
+                            return unsafe myFunc3(_ptrPtr.baseAddress, len, _ptr2Ptr.baseAddress, len2)
+                          }
+                        }
+              }()
+            }
+          }
+    }()
+}
+------------------------------
+@__swiftmacro_4test7myFunc415_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_lifetime(copy ptr) @_lifetime(ptr: copy ptr) @_disfavoredOverload
+public func myFunc4(_ ptr: inout MutableSpan<CInt>?) -> MutableSpan<CInt>? {
+    let len = CInt(exactly: ptr?.count ?? 0)!
+    return unsafe _swiftifyOverrideLifetime({ () in
+      let _resultValue = { () in
+              return if ptr == nil {
+                  unsafe myFunc4(nil, len)
+                } else {
+                  unsafe ptr!.withUnsafeMutableBufferPointer { _ptrPtr in
+                    return unsafe myFunc4(_ptrPtr.baseAddress, len)
+                  }
+                }
+          }()
+      if unsafe _resultValue == nil {
+        return nil
+      } else {
+        return unsafe _swiftifyOverrideLifetime(MutableSpan<CInt>(_unsafeStart: _resultValue!, count: Int(len)), copying: ())
+      }
+        }(), copying: ())
+}
+------------------------------

--- a/test/Macros/SwiftifyImport/CountedBy/PointerReturn.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/PointerReturn.swift
@@ -52,9 +52,10 @@ public func nonEscaping(_ len: CInt) -> UnsafeBufferPointer<CInt> {
 @_alwaysEmitIntoClient @_lifetime(copy p) @_disfavoredOverload
 public func lifetimeDependentCopy(_ p: Span<CInt>, _ len2: CInt) -> Span<CInt> {
     let len1 = CInt(exactly: p.count)!
-    return unsafe _swiftifyOverrideLifetime(Span<CInt> (_unsafeStart: unsafe p.withUnsafeBufferPointer { _pPtr in
-      return unsafe lifetimeDependentCopy(_pPtr.baseAddress!, len1, len2)
-            }, count: Int(len2)), copying: ())
+    let _pPtr = unsafe p.withUnsafeBufferPointer {
+        unsafe $0
+    }
+    return unsafe _swiftifyOverrideLifetime(Span<CInt> (_unsafeStart: unsafe lifetimeDependentCopy(_pPtr.baseAddress!, len1, len2), count: Int(len2)), copying: ())
 }
 ------------------------------
 @__swiftmacro_4test23lifetimeDependentBorrow15_SwiftifyImportfMp_.swift

--- a/test/Macros/SwiftifyImport/CountedBy/PointerReturn.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/PointerReturn.swift
@@ -1,43 +1,68 @@
 // REQUIRES: swift_swift_parser
 // REQUIRES: swift_feature_Lifetimes
 
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -enable-experimental-feature Lifetimes -strict-memory-safety -warnings-as-errors -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
 
+// RUN: %target-swift-frontend %t/test.swift -emit-module -plugin-path %swift-plugin-dir -strict-memory-safety -enable-experimental-feature Lifetimes -verify
+// RUN: env SWIFT_BACKTRACE="" %target-swift-frontend %t/test.swift -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions -enable-experimental-feature Lifetimes 2> %t/expansions.out
+// RUN: %diff %t/expansions.out %t/expansions.expected
+
+//--- test.swift
 @_SwiftifyImport(.countedBy(pointer: .return, count: "len"))
-func myFunc(_ len: CInt) -> UnsafeMutablePointer<CInt> {
+public func myFunc(_ len: CInt) -> UnsafeMutablePointer<CInt> {
+// expected-error@+1{{missing return in global function expected to return 'UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>')}}
 }
 
 @_SwiftifyImport(.countedBy(pointer: .return, count: "len"), .nonescaping(pointer: .return))
-func nonEscaping(_ len: CInt) -> UnsafePointer<CInt> {
+public func nonEscaping(_ len: CInt) -> UnsafePointer<CInt> {
+// expected-error@+1{{missing return in global function expected to return 'UnsafePointer<CInt>' (aka 'UnsafePointer<Int32>')}}
 }
 
 @_SwiftifyImport(.countedBy(pointer: .return, count: "len2"), .countedBy(pointer: .param(1), count: "len1"), .lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .copy))
-func lifetimeDependentCopy(_ p: UnsafePointer<CInt>, _ len1: CInt, _ len2: CInt) -> UnsafePointer<CInt> {
+public func lifetimeDependentCopy(_ p: UnsafePointer<CInt>, _ len1: CInt, _ len2: CInt) -> UnsafePointer<CInt> {
+// expected-error@+1{{missing return in global function expected to return 'UnsafePointer<CInt>' (aka 'UnsafePointer<Int32>')}}
 }
 
 @_SwiftifyImport(.countedBy(pointer: .return, count: "len2"), .countedBy(pointer: .param(1), count: "len1"), .lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .borrow))
-func lifetimeDependentBorrow(_ p: borrowing UnsafePointer<CInt>, _ len1: CInt, _ len2: CInt) -> UnsafePointer<CInt> {
+public func lifetimeDependentBorrow(_ p: borrowing UnsafePointer<CInt>, _ len1: CInt, _ len2: CInt) -> UnsafePointer<CInt> {
+// expected-error@+1{{missing return in global function expected to return 'UnsafePointer<CInt>' (aka 'UnsafePointer<Int32>')}}
 }
 
-// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func myFunc(_ len: CInt) -> UnsafeMutableBufferPointer<CInt> {
-// CHECK-NEXT:     return unsafe UnsafeMutableBufferPointer<CInt> (start: unsafe myFunc(len), count: Int(len))
-// CHECK-NEXT: }
-
-// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func nonEscaping(_ len: CInt) -> UnsafeBufferPointer<CInt> {
-// CHECK-NEXT:     return unsafe UnsafeBufferPointer<CInt> (start: unsafe nonEscaping(len), count: Int(len))
-
-// CHECK:      @_alwaysEmitIntoClient @_lifetime(copy p) @_disfavoredOverload
-// CHECK-NEXT: func lifetimeDependentCopy(_ p: Span<CInt>, _ len2: CInt) -> Span<CInt> {
-// CHECK-NEXT:     let len1 = CInt(exactly: p.count)!
-// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(Span<CInt> (_unsafeStart: unsafe p.withUnsafeBufferPointer { _pPtr in
-// CHECK-NEXT:       return unsafe lifetimeDependentCopy(_pPtr.baseAddress!, len1, len2)
-// CHECK-NEXT:             }, count: Int(len2)), copying: ())
-// CHECK-NEXT: }
-
-// CHECK:      @_alwaysEmitIntoClient @_lifetime(borrow p) @_disfavoredOverload
-// CHECK-NEXT: func lifetimeDependentBorrow(_ p: borrowing UnsafeBufferPointer<CInt>, _ len2: CInt) -> Span<CInt> {
-// CHECK-NEXT:     let len1 = CInt(exactly: p.count)!
-// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(Span<CInt> (_unsafeStart: unsafe lifetimeDependentBorrow(p.baseAddress!, len1, len2), count: Int(len2)), copying: ())
-// CHECK-NEXT: }
+//--- expansions.expected
+@__swiftmacro_4test6myFunc15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func myFunc(_ len: CInt) -> UnsafeMutableBufferPointer<CInt> {
+    return unsafe UnsafeMutableBufferPointer<CInt> (start: unsafe myFunc(len), count: Int(len))
+}
+------------------------------
+@__swiftmacro_4test11nonEscaping15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func nonEscaping(_ len: CInt) -> UnsafeBufferPointer<CInt> {
+    return unsafe UnsafeBufferPointer<CInt> (start: unsafe nonEscaping(len), count: Int(len))
+}
+------------------------------
+@__swiftmacro_4test21lifetimeDependentCopy15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_lifetime(copy p) @_disfavoredOverload
+public func lifetimeDependentCopy(_ p: Span<CInt>, _ len2: CInt) -> Span<CInt> {
+    let len1 = CInt(exactly: p.count)!
+    return unsafe _swiftifyOverrideLifetime(Span<CInt> (_unsafeStart: unsafe p.withUnsafeBufferPointer { _pPtr in
+      return unsafe lifetimeDependentCopy(_pPtr.baseAddress!, len1, len2)
+            }, count: Int(len2)), copying: ())
+}
+------------------------------
+@__swiftmacro_4test23lifetimeDependentBorrow15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_lifetime(borrow p) @_disfavoredOverload
+public func lifetimeDependentBorrow(_ p: borrowing UnsafeBufferPointer<CInt>, _ len2: CInt) -> Span<CInt> {
+    let len1 = CInt(exactly: p.count)!
+    return unsafe _swiftifyOverrideLifetime(Span<CInt> (_unsafeStart: unsafe lifetimeDependentBorrow(p.baseAddress!, len1, len2), count: Int(len2)), copying: ())
+}
+------------------------------

--- a/test/Macros/SwiftifyImport/CountedBy/Protocol.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Protocol.swift
@@ -56,9 +56,10 @@ extension SpanProtocol {
 @_alwaysEmitIntoClient @_disfavoredOverload public
       func foo(_ ptr: Span<CInt>) {
         let len = CInt(exactly: ptr.count)!
-        return unsafe ptr.withUnsafeBufferPointer { _ptrPtr in
-          return unsafe foo(_ptrPtr.baseAddress!, len)
+        let _ptrPtr = unsafe ptr.withUnsafeBufferPointer {
+            unsafe $0
         }
+        return unsafe foo(_ptrPtr.baseAddress!, len)
     }
     /// This is an auto-generated wrapper for safer interop
 @_alwaysEmitIntoClient @_lifetime(borrow self) @_disfavoredOverload public
@@ -75,9 +76,10 @@ extension MixedProtocol {
       /// Some doc comment
       func foo(_ ptr: Span<CInt>) {
         let len = CInt(exactly: ptr.count)!
-        return unsafe ptr.withUnsafeBufferPointer { _ptrPtr in
-          return unsafe foo(_ptrPtr.baseAddress!, len)
+        let _ptrPtr = unsafe ptr.withUnsafeBufferPointer {
+            unsafe $0
         }
+        return unsafe foo(_ptrPtr.baseAddress!, len)
     }
     /// This is an auto-generated wrapper for safer interop
 @_alwaysEmitIntoClient @_disfavoredOverload public

--- a/test/Macros/SwiftifyImport/CountedBy/Return.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Return.swift
@@ -1,13 +1,25 @@
 // REQUIRES: swift_swift_parser
 
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -strict-memory-safety -warnings-as-errors -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
 
+// RUN: %target-swift-frontend %t/test.swift -emit-module -plugin-path %swift-plugin-dir -strict-memory-safety -verify
+// RUN: env SWIFT_BACKTRACE="" %target-swift-frontend %t/test.swift -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2> %t/expansions.out
+// RUN: %diff %t/expansions.out %t/expansions.expected
+
+//--- test.swift
 @_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"))
-func myFunc(_ ptr: UnsafePointer<CInt>, _ len: CInt) -> CInt {
+public func myFunc(_ ptr: UnsafePointer<CInt>, _ len: CInt) -> CInt {
+// expected-error@+1{{missing return in global function expected to return 'CInt' (aka 'Int32')}}
 }
 
-// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func myFunc(_ ptr: UnsafeBufferPointer<CInt>) -> CInt {
-// CHECK-NEXT:     let len = CInt(exactly: ptr.count)!
-// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, len)
-// CHECK-NEXT: }
+//--- expansions.expected
+@__swiftmacro_4test6myFunc15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func myFunc(_ ptr: UnsafeBufferPointer<CInt>) -> CInt {
+    let len = CInt(exactly: ptr.count)!
+    return unsafe myFunc(ptr.baseAddress!, len)
+}
+------------------------------

--- a/test/Macros/SwiftifyImport/CountedBy/SharedCount.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/SharedCount.swift
@@ -1,75 +1,98 @@
 // REQUIRES: swift_swift_parser
 
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -strict-memory-safety -warnings-as-errors -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
 
+// RUN: %target-swift-frontend %t/test.swift -emit-module -plugin-path %swift-plugin-dir -strict-memory-safety -verify
+// RUN: env SWIFT_BACKTRACE="" %target-swift-frontend %t/test.swift -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2> %t/expansions.out
+// RUN: %diff %t/expansions.out %t/expansions.expected
+
+//--- test.swift
 @_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"), .countedBy(pointer: .param(2), count: "len"))
-func myFunc(_ ptr: UnsafePointer<CInt>, _ ptr2: UnsafePointer<CInt>, _ len: CInt) {
+public func myFunc(_ ptr: UnsafePointer<CInt>, _ ptr2: UnsafePointer<CInt>, _ len: CInt) {
 }
 
 @_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"), .countedBy(pointer: .param(2), count: "len * size"))
-func myFunc2(_ ptr: UnsafePointer<CInt>, _ ptr2: UnsafePointer<CInt>, _ len: CInt, _ size: CInt) {
+public func myFunc2(_ ptr: UnsafePointer<CInt>, _ ptr2: UnsafePointer<CInt>, _ len: CInt, _ size: CInt) {
 }
 
 @_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"), .countedBy(pointer: .param(2), count: "size"), .countedBy(pointer: .param(3), count: "len * size"))
-func myFunc3(_ ptr: UnsafePointer<CInt>, _ ptr2: UnsafePointer<CInt>, _ ptr3: UnsafePointer<CInt>, _ len: CInt, _ size: CInt) {
+public func myFunc3(_ ptr: UnsafePointer<CInt>, _ ptr2: UnsafePointer<CInt>, _ ptr3: UnsafePointer<CInt>, _ len: CInt, _ size: CInt) {
 }
 
 @_SwiftifyImport(.countedBy(pointer: .param(3), count: "len"), .countedBy(pointer: .param(2), count: "size"), .countedBy(pointer: .param(1), count: "len * size"))
-func myFunc4(_ ptr: UnsafePointer<CInt>, _ ptr2: UnsafePointer<CInt>, _ ptr3: UnsafePointer<CInt>, _ len: CInt, _ size: CInt) {
+public func myFunc4(_ ptr: UnsafePointer<CInt>, _ ptr2: UnsafePointer<CInt>, _ ptr3: UnsafePointer<CInt>, _ len: CInt, _ size: CInt) {
 }
 
 @_SwiftifyImport(.countedBy(pointer: .param(1), count: "len * size"), .countedBy(pointer: .param(3), count: "len"), .countedBy(pointer: .param(2), count: "size"))
-func myFunc5(_ ptr: UnsafePointer<CInt>, _ ptr2: UnsafePointer<CInt>, _ ptr3: UnsafePointer<CInt>, _ len: CInt, _ size: CInt) {
+public func myFunc5(_ ptr: UnsafePointer<CInt>, _ ptr2: UnsafePointer<CInt>, _ ptr3: UnsafePointer<CInt>, _ len: CInt, _ size: CInt) {
 }
 
-// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func myFunc(_ ptr: UnsafeBufferPointer<CInt>, _ ptr2: UnsafeBufferPointer<CInt>) {
-// CHECK-NEXT:     let len = CInt(exactly: ptr.count)!
-// CHECK-NEXT:     if ptr2.count != len {
-// CHECK-NEXT:       fatalError("bounds check failure in myFunc: expected \(len) but got \(ptr2.count)")
-// CHECK-NEXT:     }
-// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, ptr2.baseAddress!, len)
-// CHECK-NEXT: }
-
-// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func myFunc2(_ ptr: UnsafeBufferPointer<CInt>, _ ptr2: UnsafeBufferPointer<CInt>, _ size: CInt) {
-// CHECK-NEXT:     let len = CInt(exactly: ptr.count)!
-// CHECK-NEXT:     let _ptr2Count = ptr2.count
-// CHECK-NEXT:     if _ptr2Count != len * size {
-// CHECK-NEXT:       fatalError("bounds check failure in myFunc2: expected \(len * size) but got \(_ptr2Count)")
-// CHECK-NEXT:     }
-// CHECK-NEXT:     return unsafe myFunc2(ptr.baseAddress!, ptr2.baseAddress!, len, size)
-// CHECK-NEXT: }
-
-// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func myFunc3(_ ptr: UnsafeBufferPointer<CInt>, _ ptr2: UnsafeBufferPointer<CInt>, _ ptr3: UnsafeBufferPointer<CInt>) {
-// CHECK-NEXT:     let len = CInt(exactly: ptr.count)!
-// CHECK-NEXT:     let size = CInt(exactly: ptr2.count)!
-// CHECK-NEXT:     let _ptr3Count = ptr3.count
-// CHECK-NEXT:     if _ptr3Count != len * size {
-// CHECK-NEXT:       fatalError("bounds check failure in myFunc3: expected \(len * size) but got \(_ptr3Count)")
-// CHECK-NEXT:     }
-// CHECK-NEXT:     return unsafe myFunc3(ptr.baseAddress!, ptr2.baseAddress!, ptr3.baseAddress!, len, size)
-// CHECK-NEXT: }
-
-// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func myFunc4(_ ptr: UnsafeBufferPointer<CInt>, _ ptr2: UnsafeBufferPointer<CInt>, _ ptr3: UnsafeBufferPointer<CInt>) {
-// CHECK-NEXT:     let size = CInt(exactly: ptr2.count)!
-// CHECK-NEXT:     let len = CInt(exactly: ptr3.count)!
-// CHECK-NEXT:     let _ptrCount = ptr.count
-// CHECK-NEXT:     if _ptrCount != len * size {
-// CHECK-NEXT:       fatalError("bounds check failure in myFunc4: expected \(len * size) but got \(_ptrCount)")
-// CHECK-NEXT:     }
-// CHECK-NEXT:     return unsafe myFunc4(ptr.baseAddress!, ptr2.baseAddress!, ptr3.baseAddress!, len, size)
-// CHECK-NEXT: }
-
-// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func myFunc5(_ ptr: UnsafeBufferPointer<CInt>, _ ptr2: UnsafeBufferPointer<CInt>, _ ptr3: UnsafeBufferPointer<CInt>) {
-// CHECK-NEXT:     let size = CInt(exactly: ptr2.count)!
-// CHECK-NEXT:     let len = CInt(exactly: ptr3.count)!
-// CHECK-NEXT:     let _ptrCount = ptr.count
-// CHECK-NEXT:     if _ptrCount != len * size {
-// CHECK-NEXT:       fatalError("bounds check failure in myFunc5: expected \(len * size) but got \(_ptrCount)")
-// CHECK-NEXT:     }
-// CHECK-NEXT:     return unsafe myFunc5(ptr.baseAddress!, ptr2.baseAddress!, ptr3.baseAddress!, len, size)
-// CHECK-NEXT: }
+//--- expansions.expected
+@__swiftmacro_4test6myFunc15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func myFunc(_ ptr: UnsafeBufferPointer<CInt>, _ ptr2: UnsafeBufferPointer<CInt>) {
+    let len = CInt(exactly: ptr.count)!
+    if ptr2.count != len {
+      fatalError("bounds check failure in myFunc: expected \(len) but got \(ptr2.count)")
+    }
+    return unsafe myFunc(ptr.baseAddress!, ptr2.baseAddress!, len)
+}
+------------------------------
+@__swiftmacro_4test7myFunc215_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func myFunc2(_ ptr: UnsafeBufferPointer<CInt>, _ ptr2: UnsafeBufferPointer<CInt>, _ size: CInt) {
+    let len = CInt(exactly: ptr.count)!
+    let _ptr2Count = ptr2.count
+    if _ptr2Count != len * size {
+      fatalError("bounds check failure in myFunc2: expected \(len * size) but got \(_ptr2Count)")
+    }
+    return unsafe myFunc2(ptr.baseAddress!, ptr2.baseAddress!, len, size)
+}
+------------------------------
+@__swiftmacro_4test7myFunc315_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func myFunc3(_ ptr: UnsafeBufferPointer<CInt>, _ ptr2: UnsafeBufferPointer<CInt>, _ ptr3: UnsafeBufferPointer<CInt>) {
+    let len = CInt(exactly: ptr.count)!
+    let size = CInt(exactly: ptr2.count)!
+    let _ptr3Count = ptr3.count
+    if _ptr3Count != len * size {
+      fatalError("bounds check failure in myFunc3: expected \(len * size) but got \(_ptr3Count)")
+    }
+    return unsafe myFunc3(ptr.baseAddress!, ptr2.baseAddress!, ptr3.baseAddress!, len, size)
+}
+------------------------------
+@__swiftmacro_4test7myFunc415_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func myFunc4(_ ptr: UnsafeBufferPointer<CInt>, _ ptr2: UnsafeBufferPointer<CInt>, _ ptr3: UnsafeBufferPointer<CInt>) {
+    let size = CInt(exactly: ptr2.count)!
+    let len = CInt(exactly: ptr3.count)!
+    let _ptrCount = ptr.count
+    if _ptrCount != len * size {
+      fatalError("bounds check failure in myFunc4: expected \(len * size) but got \(_ptrCount)")
+    }
+    return unsafe myFunc4(ptr.baseAddress!, ptr2.baseAddress!, ptr3.baseAddress!, len, size)
+}
+------------------------------
+@__swiftmacro_4test7myFunc515_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func myFunc5(_ ptr: UnsafeBufferPointer<CInt>, _ ptr2: UnsafeBufferPointer<CInt>, _ ptr3: UnsafeBufferPointer<CInt>) {
+    let size = CInt(exactly: ptr2.count)!
+    let len = CInt(exactly: ptr3.count)!
+    let _ptrCount = ptr.count
+    if _ptrCount != len * size {
+      fatalError("bounds check failure in myFunc5: expected \(len * size) but got \(_ptrCount)")
+    }
+    return unsafe myFunc5(ptr.baseAddress!, ptr2.baseAddress!, ptr3.baseAddress!, len, size)
+}
+------------------------------

--- a/test/Macros/SwiftifyImport/CountedBy/SimpleCount.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/SimpleCount.swift
@@ -1,13 +1,24 @@
 // REQUIRES: swift_swift_parser
 
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -strict-memory-safety -warnings-as-errors -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
 
+// RUN: %target-swift-frontend %t/test.swift -emit-module -plugin-path %swift-plugin-dir -strict-memory-safety -verify
+// RUN: env SWIFT_BACKTRACE="" %target-swift-frontend %t/test.swift -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2> %t/expansions.out
+// RUN: %diff %t/expansions.out %t/expansions.expected
+
+//--- test.swift
 @_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"))
-func myFunc(_ ptr: UnsafePointer<CInt>, _ len: CInt) {
+public func myFunc(_ ptr: UnsafePointer<CInt>, _ len: CInt) {
 }
 
-// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func myFunc(_ ptr: UnsafeBufferPointer<CInt>) {
-// CHECK-NEXT:     let len = CInt(exactly: ptr.count)!
-// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, len)
-// CHECK-NEXT: }
+//--- expansions.expected
+@__swiftmacro_4test6myFunc15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func myFunc(_ ptr: UnsafeBufferPointer<CInt>) {
+    let len = CInt(exactly: ptr.count)!
+    return unsafe myFunc(ptr.baseAddress!, len)
+}
+------------------------------

--- a/test/Macros/SwiftifyImport/CountedBy/SimpleSpan.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/SimpleSpan.swift
@@ -1,16 +1,26 @@
 // REQUIRES: swift_swift_parser
 
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -strict-memory-safety -warnings-as-errors
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
 
+// RUN: %target-swift-frontend %t/test.swift -emit-module -plugin-path %swift-plugin-dir -strict-memory-safety -verify
+// RUN: env SWIFT_BACKTRACE="" %target-swift-frontend %t/test.swift -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2> %t/expansions.out
+// RUN: %diff %t/expansions.out %t/expansions.expected
+
+//--- test.swift
 @_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"), .nonescaping(pointer: .param(1)))
-func myFunc(_ ptr: UnsafePointer<CInt>, _ len: CInt) {
+public func myFunc(_ ptr: UnsafePointer<CInt>, _ len: CInt) {
 }
 
-// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func myFunc(_ ptr: Span<CInt>) {
-// CHECK-NEXT:     let len = CInt(exactly: ptr.count)!
-// CHECK-NEXT:     return unsafe ptr.withUnsafeBufferPointer { _ptrPtr in
-// CHECK-NEXT:       return unsafe myFunc(_ptrPtr.baseAddress!, len)
-// CHECK-NEXT:     }
-// CHECK-NEXT: }
+//--- expansions.expected
+@__swiftmacro_4test6myFunc15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func myFunc(_ ptr: Span<CInt>) {
+    let len = CInt(exactly: ptr.count)!
+    return unsafe ptr.withUnsafeBufferPointer { _ptrPtr in
+      return unsafe myFunc(_ptrPtr.baseAddress!, len)
+    }
+}
+------------------------------

--- a/test/Macros/SwiftifyImport/CountedBy/SimpleSpan.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/SimpleSpan.swift
@@ -19,8 +19,9 @@ public func myFunc(_ ptr: UnsafePointer<CInt>, _ len: CInt) {
 @_alwaysEmitIntoClient @_disfavoredOverload
 public func myFunc(_ ptr: Span<CInt>) {
     let len = CInt(exactly: ptr.count)!
-    return unsafe ptr.withUnsafeBufferPointer { _ptrPtr in
-      return unsafe myFunc(_ptrPtr.baseAddress!, len)
+    let _ptrPtr = unsafe ptr.withUnsafeBufferPointer {
+        unsafe $0
     }
+    return unsafe myFunc(_ptrPtr.baseAddress!, len)
 }
 ------------------------------

--- a/test/Macros/SwiftifyImport/CountedBy/SimpleSpanWithReturn.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/SimpleSpanWithReturn.swift
@@ -20,8 +20,9 @@ public func myFunc(_ ptr: UnsafePointer<CInt>, _ len: CInt) -> CInt {
 @_alwaysEmitIntoClient @_disfavoredOverload
 public func myFunc(_ ptr: Span<CInt>) -> CInt {
     let len = CInt(exactly: ptr.count)!
-    return unsafe ptr.withUnsafeBufferPointer { _ptrPtr in
-      return unsafe myFunc(_ptrPtr.baseAddress!, len)
+    let _ptrPtr = unsafe ptr.withUnsafeBufferPointer {
+        unsafe $0
     }
+    return unsafe myFunc(_ptrPtr.baseAddress!, len)
 }
 ------------------------------

--- a/test/Macros/SwiftifyImport/CountedBy/SimpleSpanWithReturn.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/SimpleSpanWithReturn.swift
@@ -1,16 +1,27 @@
 // REQUIRES: swift_swift_parser
 
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -strict-memory-safety -warnings-as-errors
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
 
+// RUN: %target-swift-frontend %t/test.swift -emit-module -plugin-path %swift-plugin-dir -strict-memory-safety -verify
+// RUN: env SWIFT_BACKTRACE="" %target-swift-frontend %t/test.swift -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2> %t/expansions.out
+// RUN: %diff %t/expansions.out %t/expansions.expected
+
+//--- test.swift
 @_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"), .nonescaping(pointer: .param(1)))
-func myFunc(_ ptr: UnsafePointer<CInt>, _ len: CInt) -> CInt {
+public func myFunc(_ ptr: UnsafePointer<CInt>, _ len: CInt) -> CInt {
+// expected-error@+1{{missing return in global function expected to return 'CInt' (aka 'Int32')}}
 }
 
-// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func myFunc(_ ptr: Span<CInt>) -> CInt {
-// CHECK-NEXT:     let len = CInt(exactly: ptr.count)!
-// CHECK-NEXT:     return unsafe ptr.withUnsafeBufferPointer { _ptrPtr in
-// CHECK-NEXT:       return unsafe myFunc(_ptrPtr.baseAddress!, len)
-// CHECK-NEXT:     }
-// CHECK-NEXT: }
+//--- expansions.expected
+@__swiftmacro_4test6myFunc15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func myFunc(_ ptr: Span<CInt>) -> CInt {
+    let len = CInt(exactly: ptr.count)!
+    return unsafe ptr.withUnsafeBufferPointer { _ptrPtr in
+      return unsafe myFunc(_ptrPtr.baseAddress!, len)
+    }
+}
+------------------------------

--- a/test/Macros/SwiftifyImport/CountedBy/SpanAndUnsafeBuffer.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/SpanAndUnsafeBuffer.swift
@@ -20,8 +20,9 @@ public func myFunc(_ ptr1: UnsafePointer<CInt>, _ len1: CInt, _ ptr2: UnsafePoin
 public func myFunc(_ ptr1: Span<CInt>, _ ptr2: UnsafeBufferPointer<CInt>) {
     let len1 = CInt(exactly: ptr1.count)!
     let len2 = CInt(exactly: ptr2.count)!
-    return unsafe ptr1.withUnsafeBufferPointer { _ptr1Ptr in
-      return unsafe myFunc(_ptr1Ptr.baseAddress!, len1, ptr2.baseAddress!, len2)
+    let _ptr1Ptr = unsafe ptr1.withUnsafeBufferPointer {
+        unsafe $0
     }
+    return unsafe myFunc(_ptr1Ptr.baseAddress!, len1, ptr2.baseAddress!, len2)
 }
 ------------------------------

--- a/test/Macros/SwiftifyImport/CountedBy/SpanAndUnsafeBuffer.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/SpanAndUnsafeBuffer.swift
@@ -1,18 +1,27 @@
 // REQUIRES: swift_swift_parser
 
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
 
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -strict-memory-safety -warnings-as-errors
+// RUN: %target-swift-frontend %t/test.swift -emit-module -plugin-path %swift-plugin-dir -strict-memory-safety -verify
+// RUN: env SWIFT_BACKTRACE="" %target-swift-frontend %t/test.swift -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2> %t/expansions.out
+// RUN: %diff %t/expansions.out %t/expansions.expected
 
+//--- test.swift
 @_SwiftifyImport(.countedBy(pointer: .param(1), count: "len1"), .countedBy(pointer: .param(3), count: "len2"), .nonescaping(pointer: .param(1)))
-func myFunc(_ ptr1: UnsafePointer<CInt>, _ len1: CInt, _ ptr2: UnsafePointer<CInt>, _ len2: CInt) {
+public func myFunc(_ ptr1: UnsafePointer<CInt>, _ len1: CInt, _ ptr2: UnsafePointer<CInt>, _ len2: CInt) {
 }
 
-// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func myFunc(_ ptr1: Span<CInt>, _ ptr2: UnsafeBufferPointer<CInt>) {
-// CHECK-NEXT:     let len1 = CInt(exactly: ptr1.count)!
-// CHECK-NEXT:     let len2 = CInt(exactly: ptr2.count)!
-// CHECK-NEXT:     return unsafe ptr1.withUnsafeBufferPointer { _ptr1Ptr in
-// CHECK-NEXT:       return unsafe myFunc(_ptr1Ptr.baseAddress!, len1, ptr2.baseAddress!, len2)
-// CHECK-NEXT:     }
-// CHECK-NEXT: }
+//--- expansions.expected
+@__swiftmacro_4test6myFunc15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func myFunc(_ ptr1: Span<CInt>, _ ptr2: UnsafeBufferPointer<CInt>) {
+    let len1 = CInt(exactly: ptr1.count)!
+    let len2 = CInt(exactly: ptr2.count)!
+    return unsafe ptr1.withUnsafeBufferPointer { _ptr1Ptr in
+      return unsafe myFunc(_ptr1Ptr.baseAddress!, len1, ptr2.baseAddress!, len2)
+    }
+}
+------------------------------

--- a/test/Macros/SwiftifyImport/CountedBy/Unwrapped.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Unwrapped.swift
@@ -1,13 +1,24 @@
 // REQUIRES: swift_swift_parser
 
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -strict-memory-safety -warnings-as-errors -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
 
+// RUN: %target-swift-frontend %t/test.swift -emit-module -plugin-path %swift-plugin-dir -strict-memory-safety -verify
+// RUN: env SWIFT_BACKTRACE="" %target-swift-frontend %t/test.swift -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2> %t/expansions.out
+// RUN: %diff %t/expansions.out %t/expansions.expected
+
+//--- test.swift
 @_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"))
-func myFunc(_ ptr: UnsafePointer<CInt>!, _ len: CInt) {
+public func myFunc(_ ptr: UnsafePointer<CInt>!, _ len: CInt) {
 }
 
-// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func myFunc(_ ptr: UnsafeBufferPointer<CInt>) {
-// CHECK-NEXT:     let len = CInt(exactly: ptr.count)!
-// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, len)
-// CHECK-NEXT: }
+//--- expansions.expected
+@__swiftmacro_4test6myFunc15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func myFunc(_ ptr: UnsafeBufferPointer<CInt>) {
+    let len = CInt(exactly: ptr.count)!
+    return unsafe myFunc(ptr.baseAddress!, len)
+}
+------------------------------

--- a/test/Macros/SwiftifyImport/CountedBy/Whitespace.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Whitespace.swift
@@ -1,49 +1,57 @@
-@_SwiftifyImport(.countedBy(pointer: .return, count: "len"), .lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .copy), .countedBy(pointer: .param(1), count: "len"), .nonescaping(pointer: .param(1)), .countedBy(pointer: .param(3), count: "len2"), .nonescaping(pointer: .param(3)))
-func myFunc(_ ptr: UnsafeMutablePointer<CInt>?, _ len: CInt, _ ptr2: UnsafeMutablePointer<CInt>?, _ len2: CInt) -> UnsafeMutablePointer<CInt>? {}
-
 // REQUIRES: swift_swift_parser
+// REQUIRES: swift_feature_Lifetimes
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
 
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -strict-memory-safety -warnings-as-errors -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines --strict-whitespace %s
+// RUN: %target-swift-frontend %t/test.swift -emit-module -plugin-path %swift-plugin-dir -strict-memory-safety -enable-experimental-feature Lifetimes -verify
+// RUN: env SWIFT_BACKTRACE="" %target-swift-frontend %t/test.swift -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions -enable-experimental-feature Lifetimes 2> %t/expansions.out
+// RUN: %diff %t/expansions.out %t/expansions.expected
 
 // This test is meant to act as an alarm bell to unintended changes in whitespace
 
-// CHECK:------------------------------
-// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
-// CHECK-NEXT:@_alwaysEmitIntoClient @_lifetime(copy ptr) @_lifetime(ptr: copy ptr) @_lifetime(ptr2: copy ptr2) @_disfavoredOverload
-// CHECK-NEXT:func myFunc(_ ptr: inout MutableSpan<CInt>?, _ ptr2: inout MutableSpan<CInt>?) -> MutableSpan<CInt>? {
-// CHECK-NEXT:    let len = CInt(exactly: ptr?.count ?? 0)!
-// CHECK-NEXT:    let len2 = CInt(exactly: ptr2?.count ?? 0)!
-// CHECK-NEXT:    return unsafe _swiftifyOverrideLifetime({ () in
-// CHECK-NEXT:      let _resultValue = { () in
-// CHECK-NEXT:              return if ptr2 == nil {
-// CHECK-NEXT:                  { () in
-// CHECK-NEXT:                      return if ptr == nil {
-// CHECK-NEXT:                              unsafe myFunc(nil, len, nil, len2)
-// CHECK-NEXT:                            } else {
-// CHECK-NEXT:                              unsafe ptr!.withUnsafeMutableBufferPointer { _ptrPtr in
-// CHECK-NEXT:                                return unsafe myFunc(_ptrPtr.baseAddress, len, nil, len2)
-// CHECK-NEXT:                              }
-// CHECK-NEXT:                            }
-// CHECK-NEXT:                  }()
-// CHECK-NEXT:                } else {
-// CHECK-NEXT:                  unsafe ptr2!.withUnsafeMutableBufferPointer { _ptr2Ptr in
-// CHECK-NEXT:                    return { () in
-// CHECK-NEXT:                        return if ptr == nil {
-// CHECK-NEXT:                                unsafe myFunc(nil, len, _ptr2Ptr.baseAddress, len2)
-// CHECK-NEXT:                              } else {
-// CHECK-NEXT:                                unsafe ptr!.withUnsafeMutableBufferPointer { _ptrPtr in
-// CHECK-NEXT:                                  return unsafe myFunc(_ptrPtr.baseAddress, len, _ptr2Ptr.baseAddress, len2)
-// CHECK-NEXT:                                }
-// CHECK-NEXT:                              }
-// CHECK-NEXT:                    }()
-// CHECK-NEXT:                  }
-// CHECK-NEXT:                }
-// CHECK-NEXT:          }()
-// CHECK-NEXT:      if unsafe _resultValue == nil {
-// CHECK-NEXT:        return nil
-// CHECK-NEXT:      } else {
-// CHECK-NEXT:        return unsafe _swiftifyOverrideLifetime(MutableSpan<CInt>(_unsafeStart: _resultValue!, count: Int(len)), copying: ())
-// CHECK-NEXT:      }
-// CHECK-NEXT:        }(), copying: ())
-// CHECK-NEXT:}
-// CHECK-NEXT:------------------------------
+//--- test.swift
+@_SwiftifyImport(.countedBy(pointer: .return, count: "len"), .lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .copy), .countedBy(pointer: .param(1), count: "len"), .nonescaping(pointer: .param(1)), .countedBy(pointer: .param(3), count: "len2"), .nonescaping(pointer: .param(3)))
+public func myFunc(_ ptr: UnsafeMutablePointer<CInt>?, _ len: CInt, _ ptr2: UnsafeMutablePointer<CInt>?, _ len2: CInt) -> UnsafeMutablePointer<CInt>? { nil }
+
+//--- expansions.expected
+@__swiftmacro_4test6myFunc15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_lifetime(copy ptr) @_lifetime(ptr: copy ptr) @_lifetime(ptr2: copy ptr2) @_disfavoredOverload
+public func myFunc(_ ptr: inout MutableSpan<CInt>?, _ ptr2: inout MutableSpan<CInt>?) -> MutableSpan<CInt>? {
+    let len = CInt(exactly: ptr?.count ?? 0)!
+    let len2 = CInt(exactly: ptr2?.count ?? 0)!
+    return unsafe _swiftifyOverrideLifetime({ () in
+      let _resultValue = { () in
+              return if ptr2 == nil {
+                  { () in
+                      return if ptr == nil {
+                              unsafe myFunc(nil, len, nil, len2)
+                            } else {
+                              unsafe ptr!.withUnsafeMutableBufferPointer { _ptrPtr in
+                                return unsafe myFunc(_ptrPtr.baseAddress, len, nil, len2)
+                              }
+                            }
+                  }()
+                } else {
+                  unsafe ptr2!.withUnsafeMutableBufferPointer { _ptr2Ptr in
+                    return { () in
+                        return if ptr == nil {
+                                unsafe myFunc(nil, len, _ptr2Ptr.baseAddress, len2)
+                              } else {
+                                unsafe ptr!.withUnsafeMutableBufferPointer { _ptrPtr in
+                                  return unsafe myFunc(_ptrPtr.baseAddress, len, _ptr2Ptr.baseAddress, len2)
+                                }
+                              }
+                    }()
+                  }
+                }
+          }()
+      if unsafe _resultValue == nil {
+        return nil
+      } else {
+        return unsafe _swiftifyOverrideLifetime(MutableSpan<CInt>(_unsafeStart: _resultValue!, count: Int(len)), copying: ())
+      }
+        }(), copying: ())
+}
+------------------------------

--- a/test/Macros/SwiftifyImport/CountedBy/Whitespace.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Whitespace.swift
@@ -21,32 +21,14 @@ public func myFunc(_ ptr: UnsafeMutablePointer<CInt>?, _ len: CInt, _ ptr2: Unsa
 public func myFunc(_ ptr: inout MutableSpan<CInt>?, _ ptr2: inout MutableSpan<CInt>?) -> MutableSpan<CInt>? {
     let len = CInt(exactly: ptr?.count ?? 0)!
     let len2 = CInt(exactly: ptr2?.count ?? 0)!
+    let _ptrPtr = unsafe ptr?.withUnsafeMutableBufferPointer {
+        unsafe $0
+    }
+    let _ptr2Ptr = unsafe ptr2?.withUnsafeMutableBufferPointer {
+        unsafe $0
+    }
     return unsafe _swiftifyOverrideLifetime({ () in
-      let _resultValue = { () in
-              return if ptr2 == nil {
-                  { () in
-                      return if ptr == nil {
-                              unsafe myFunc(nil, len, nil, len2)
-                            } else {
-                              unsafe ptr!.withUnsafeMutableBufferPointer { _ptrPtr in
-                                return unsafe myFunc(_ptrPtr.baseAddress, len, nil, len2)
-                              }
-                            }
-                  }()
-                } else {
-                  unsafe ptr2!.withUnsafeMutableBufferPointer { _ptr2Ptr in
-                    return { () in
-                        return if ptr == nil {
-                                unsafe myFunc(nil, len, _ptr2Ptr.baseAddress, len2)
-                              } else {
-                                unsafe ptr!.withUnsafeMutableBufferPointer { _ptrPtr in
-                                  return unsafe myFunc(_ptrPtr.baseAddress, len, _ptr2Ptr.baseAddress, len2)
-                                }
-                              }
-                    }()
-                  }
-                }
-          }()
+      let _resultValue = unsafe myFunc(_ptrPtr?.baseAddress, len, _ptr2Ptr?.baseAddress, len2)
       if unsafe _resultValue == nil {
         return nil
       } else {

--- a/test/Macros/SwiftifyImport/CxxSpan/LifetimeboundSpan.swift
+++ b/test/Macros/SwiftifyImport/CxxSpan/LifetimeboundSpan.swift
@@ -123,9 +123,10 @@ public func myFunc6(_ span: Span<CInt>, _ ptr: RawSpan, _ count: CInt, _ size: C
     if _ptrCount != count * size {
       fatalError("bounds check failure in myFunc6: expected \(count * size) but got \(_ptrCount)")
     }
-    return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe ptr.withUnsafeBytes { _ptrPtr in
-      return unsafe myFunc6(SpanOfInt(span), _ptrPtr.baseAddress!, count, size)
-            }), copying: ())
+    let _ptrPtr = unsafe ptr.withUnsafeBytes {
+        unsafe $0
+    }
+    return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe myFunc6(SpanOfInt(span), _ptrPtr.baseAddress!, count, size)), copying: ())
 }
 ------------------------------
 @__swiftmacro_4test7myFunc715_SwiftifyImportfMp_.swift
@@ -137,9 +138,10 @@ public func myFunc7(_ span: Span<CInt>, _ ptr: RawSpan, _ count: CInt, _ size: C
     if _ptrCount != count * size {
       fatalError("bounds check failure in myFunc7: expected \(count * size) but got \(_ptrCount)")
     }
-    return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe ptr.withUnsafeBytes { _ptrPtr in
-      return unsafe myFunc7(SpanOfInt(span), _ptrPtr.baseAddress!, count, size)
-            }), copying: ())
+    let _ptrPtr = unsafe ptr.withUnsafeBytes {
+        unsafe $0
+    }
+    return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe myFunc7(SpanOfInt(span), _ptrPtr.baseAddress!, count, size)), copying: ())
 }
 ------------------------------
 @__swiftmacro_4test7myFunc815_SwiftifyImportfMp_.swift
@@ -151,9 +153,10 @@ public func myFunc8(_ ptr: RawSpan, _ span: Span<CInt>, _ count: CInt, _ size: C
     if _ptrCount != count * size {
       fatalError("bounds check failure in myFunc8: expected \(count * size) but got \(_ptrCount)")
     }
-    return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe ptr.withUnsafeBytes { _ptrPtr in
-      return unsafe myFunc8(_ptrPtr.baseAddress!, SpanOfInt(span), count, size)
-            }), copying: ())
+    let _ptrPtr = unsafe ptr.withUnsafeBytes {
+        unsafe $0
+    }
+    return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe myFunc8(_ptrPtr.baseAddress!, SpanOfInt(span), count, size)), copying: ())
 }
 ------------------------------
 @__swiftmacro_4test7myFunc915_SwiftifyImportfMp_.swift

--- a/test/Macros/SwiftifyImport/CxxSpan/LifetimeboundSpan.swift
+++ b/test/Macros/SwiftifyImport/CxxSpan/LifetimeboundSpan.swift
@@ -1,133 +1,178 @@
-
 // REQUIRES: swift_swift_parser
-
-// RUN: %target-swift-frontend %s -enable-experimental-cxx-interop -I %S/Inputs -Xcc -std=c++20 -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions -verify -strict-memory-safety 2>&1 | %FileCheck --match-full-lines %s
-
 // REQUIRES: std_span
 
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend %t/test.swift -cxx-interoperability-mode=default -I %S/Inputs -Xcc -std=c++20 -emit-module -plugin-path %swift-plugin-dir -strict-memory-safety -verify
+// RUN: env SWIFT_BACKTRACE="" %target-swift-frontend %t/test.swift -cxx-interoperability-mode=default -I %S/Inputs -Xcc -std=c++20 -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2> %t/expansions.out
+// RUN: %diff %t/expansions.out %t/expansions.expected
+
+//--- test.swift
 import CxxStdlib
 import StdSpan
 
 public struct VecOfInt {}
 
 @_SwiftifyImport(.lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .copy), typeMappings: ["SpanOfInt" : "std.span<__cxxConst<CInt>>"])
-func myFunc(_ span: SpanOfInt) -> SpanOfInt {
+public func myFunc(_ span: SpanOfInt) -> SpanOfInt {
+  unsafe SpanOfInt()
 }
 
 @_SwiftifyImport(.lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .borrow), typeMappings: ["SpanOfInt" : "std.__1.span<__cxxConst<CInt>, _CUnsignedLong_18446744073709551615>"])
-func myFunc2(_ vec: borrowing VecOfInt) -> SpanOfInt {
+public func myFunc2(_ vec: borrowing VecOfInt) -> SpanOfInt {
+  unsafe SpanOfInt()
 }
 
 @_SwiftifyImport(.lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .copy), .lifetimeDependence(dependsOn: .param(2), pointer: .return, type: .copy), typeMappings: ["SpanOfInt" : "std.__1.span<__cxxConst<CInt>, _CUnsignedLong_18446744073709551615>"])
-func myFunc3(_ span1: SpanOfInt, _ span2: SpanOfInt) -> SpanOfInt {
+public func myFunc3(_ span1: SpanOfInt, _ span2: SpanOfInt) -> SpanOfInt {
+  unsafe SpanOfInt()
 }
 
 @_SwiftifyImport(.lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .borrow), .lifetimeDependence(dependsOn: .param(2), pointer: .return, type: .copy), typeMappings: ["SpanOfInt" : "std.__1.span<__cxxConst<CInt>, _CUnsignedLong_18446744073709551615>"])
-func myFunc4(_ vec: borrowing VecOfInt, _ span: SpanOfInt) -> SpanOfInt {
+public func myFunc4(_ vec: borrowing VecOfInt, _ span: SpanOfInt) -> SpanOfInt {
+  unsafe SpanOfInt()
 }
 
 struct X {
   @_SwiftifyImport(.lifetimeDependence(dependsOn: .self, pointer: .return, type: .borrow), typeMappings: ["SpanOfInt" : "std.__1.span<__cxxConst<CInt>, _CUnsignedLong_18446744073709551615>"])
-  func myFunc5() -> SpanOfInt {}
+  public func myFunc5() -> SpanOfInt { unsafe SpanOfInt() }
 }
 
 @_SwiftifyImport(.lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .copy),
                  .sizedBy(pointer: .param(2), size: "count * size"),
                  .nonescaping(pointer: .param(2)),
                  typeMappings: ["SpanOfInt" : "std.__1.span<__cxxConst<CInt>, _CUnsignedLong_18446744073709551615>"])
-func myFunc6(_ span: SpanOfInt, _ ptr: UnsafeRawPointer, _ count: CInt, _ size: CInt) -> SpanOfInt {
+public func myFunc6(_ span: SpanOfInt, _ ptr: UnsafeRawPointer, _ count: CInt, _ size: CInt) -> SpanOfInt {
+  unsafe SpanOfInt()
 }
 
 @_SwiftifyImport(.sizedBy(pointer: .param(2), size: "count * size"),
                  .lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .copy),
                  .nonescaping(pointer: .param(2)),
                  typeMappings: ["SpanOfInt" : "std.__1.span<__cxxConst<CInt>, _CUnsignedLong_18446744073709551615>"])
-func myFunc7(_ span: SpanOfInt, _ ptr: UnsafeRawPointer, _ count: CInt, _ size: CInt) -> SpanOfInt {
+public func myFunc7(_ span: SpanOfInt, _ ptr: UnsafeRawPointer, _ count: CInt, _ size: CInt) -> SpanOfInt {
+  unsafe SpanOfInt()
 }
 
 @_SwiftifyImport(.sizedBy(pointer: .param(1), size: "count * size"),
                  .nonescaping(pointer: .param(1)),
                  .lifetimeDependence(dependsOn: .param(2), pointer: .return, type: .copy),
                  typeMappings: ["SpanOfInt" : "std.__1.span<__cxxConst<CInt>, _CUnsignedLong_18446744073709551615>"])
-func myFunc8(_ ptr: UnsafeRawPointer, _ span: SpanOfInt, _ count: CInt, _ size: CInt) -> SpanOfInt {
+public func myFunc8(_ ptr: UnsafeRawPointer, _ span: SpanOfInt, _ count: CInt, _ size: CInt) -> SpanOfInt {
+  unsafe SpanOfInt()
 }
 
 @_SwiftifyImport(.lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .copy), typeMappings: ["MutableSpanOfInt" : "std.span<CInt>"])
-func myFunc9(_ span: MutableSpanOfInt) -> MutableSpanOfInt {
+public func myFunc9(_ span: MutableSpanOfInt) -> MutableSpanOfInt {
+  unsafe MutableSpanOfInt()
 }
 
 @_SwiftifyImport(.lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .copy), typeMappings: ["MutableSpanOfInt" : "std.span<CInt>"])
-func myFunc10(_ self: MutableSpanOfInt) -> MutableSpanOfInt {
+public func myFunc10(_ self: MutableSpanOfInt) -> MutableSpanOfInt {
+  unsafe MutableSpanOfInt()
 }
 
-// CHECK:      @_alwaysEmitIntoClient @_lifetime(copy span) @_disfavoredOverload
-// CHECK-NEXT: func myFunc(_ span: Span<CInt>) -> Span<CInt> {
-// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe myFunc(SpanOfInt(span))), copying: ())
-// CHECK-NEXT: }
-
-// CHECK:      @_alwaysEmitIntoClient @_lifetime(borrow vec) @_disfavoredOverload
-// CHECK-NEXT: func myFunc2(_ vec: borrowing VecOfInt) -> Span<CInt> {
-// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe myFunc2(vec)), copying: ())
-// CHECK-NEXT: }
-
-// CHECK:      @_alwaysEmitIntoClient @_lifetime(copy span1, copy span2) @_disfavoredOverload
-// CHECK-NEXT: func myFunc3(_ span1: Span<CInt>, _ span2: Span<CInt>) -> Span<CInt> {
-// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe myFunc3(SpanOfInt(span1), SpanOfInt(span2))), copying: ())
-// CHECK-NEXT: }
-
-// CHECK:      @_alwaysEmitIntoClient @_lifetime(borrow vec, copy span) @_disfavoredOverload
-// CHECK-NEXT: func myFunc4(_ vec: borrowing VecOfInt, _ span: Span<CInt>) -> Span<CInt> {
-// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe myFunc4(vec, SpanOfInt(span))), copying: ())
-// CHECK-NEXT: }
-
-// CHECK:      @_alwaysEmitIntoClient @_lifetime(borrow self) @_disfavoredOverload
-// CHECK-NEXT: func myFunc5() -> Span<CInt> {
-// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe myFunc5()), copying: ())
-// CHECK-NEXT: }
-
-// CHECK:      @_alwaysEmitIntoClient @_lifetime(copy span) @_disfavoredOverload
-// CHECK-NEXT: func myFunc6(_ span: Span<CInt>, _ ptr: RawSpan, _ count: CInt, _ size: CInt) -> Span<CInt> {
-// CHECK-NEXT:     let _ptrCount = ptr.byteCount
-// CHECK-NEXT:     if _ptrCount != count * size {
-// CHECK-NEXT:       fatalError("bounds check failure in myFunc6: expected \(count * size) but got \(_ptrCount)")
-// CHECK-NEXT:     }
-// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe ptr.withUnsafeBytes { _ptrPtr in
-// CHECK-NEXT:       return unsafe myFunc6(SpanOfInt(span), _ptrPtr.baseAddress!, count, size)
-// CHECK-NEXT:             }), copying: ())
-// CHECK-NEXT: }
-
-// CHECK:      @_alwaysEmitIntoClient @_lifetime(copy span) @_disfavoredOverload
-// CHECK-NEXT: func myFunc7(_ span: Span<CInt>, _ ptr: RawSpan, _ count: CInt, _ size: CInt) -> Span<CInt> {
-// CHECK-NEXT:     let _ptrCount = ptr.byteCount
-// CHECK-NEXT:     if _ptrCount != count * size {
-// CHECK-NEXT:       fatalError("bounds check failure in myFunc7: expected \(count * size) but got \(_ptrCount)")
-// CHECK-NEXT:     }
-// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe ptr.withUnsafeBytes { _ptrPtr in
-// CHECK-NEXT:       return unsafe myFunc7(SpanOfInt(span), _ptrPtr.baseAddress!, count, size)
-// CHECK-NEXT:             }), copying: ())
-// CHECK-NEXT: }
-
-// CHECK:      @_alwaysEmitIntoClient @_lifetime(copy span) @_disfavoredOverload
-// CHECK-NEXT: func myFunc8(_ ptr: RawSpan, _ span: Span<CInt>, _ count: CInt, _ size: CInt) -> Span<CInt> {
-// CHECK-NEXT:     let _ptrCount = ptr.byteCount
-// CHECK-NEXT:     if _ptrCount != count * size {
-// CHECK-NEXT:       fatalError("bounds check failure in myFunc8: expected \(count * size) but got \(_ptrCount)")
-// CHECK-NEXT:     }
-// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe ptr.withUnsafeBytes { _ptrPtr in
-// CHECK-NEXT:       return unsafe myFunc8(_ptrPtr.baseAddress!, SpanOfInt(span), count, size)
-// CHECK-NEXT:             }), copying: ())
-// CHECK-NEXT: }
-
-// CHECK:      @_alwaysEmitIntoClient @_lifetime(copy span) @_lifetime(span: copy span) @_disfavoredOverload
-// CHECK-NEXT: func myFunc9(_ span: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
-// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(MutableSpan(_unsafeCxxSpan: unsafe span.withUnsafeMutableBufferPointer { _spanPtr in
-// CHECK-NEXT:       return unsafe myFunc9(MutableSpanOfInt(_spanPtr))
-// CHECK-NEXT:             }), copying: ())
-// CHECK-NEXT: }
-
-// CHECK:      @_alwaysEmitIntoClient @_lifetime(copy `self`) @_lifetime(`self`: copy `self`) @_disfavoredOverload
-// CHECK-NEXT: func myFunc10(_ `self`: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
-// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(MutableSpan(_unsafeCxxSpan: unsafe `self`.withUnsafeMutableBufferPointer { _selfPtr in
-// CHECK-NEXT:         return unsafe myFunc10(MutableSpanOfInt(_selfPtr))
-// CHECK-NEXT:    }), copying: ())
-// CHECK-NEXT: }
+//--- expansions.expected
+@__swiftmacro_4test6myFunc15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_lifetime(copy span) @_disfavoredOverload
+public func myFunc(_ span: Span<CInt>) -> Span<CInt> {
+    return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe myFunc(SpanOfInt(span))), copying: ())
+}
+------------------------------
+@__swiftmacro_4test7myFunc215_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_lifetime(borrow vec) @_disfavoredOverload
+public func myFunc2(_ vec: borrowing VecOfInt) -> Span<CInt> {
+    return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe myFunc2(vec)), copying: ())
+}
+------------------------------
+@__swiftmacro_4test7myFunc315_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_lifetime(copy span1, copy span2) @_disfavoredOverload
+public func myFunc3(_ span1: Span<CInt>, _ span2: Span<CInt>) -> Span<CInt> {
+    return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe myFunc3(SpanOfInt(span1), SpanOfInt(span2))), copying: ())
+}
+------------------------------
+@__swiftmacro_4test7myFunc415_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_lifetime(borrow vec, copy span) @_disfavoredOverload
+public func myFunc4(_ vec: borrowing VecOfInt, _ span: Span<CInt>) -> Span<CInt> {
+    return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe myFunc4(vec, SpanOfInt(span))), copying: ())
+}
+------------------------------
+@__swiftmacro_4test1XV7myFunc515_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+  @_alwaysEmitIntoClient @_lifetime(borrow self) @_disfavoredOverload
+  public func myFunc5() -> Span<CInt> {
+    return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe myFunc5()), copying: ())
+}
+------------------------------
+@__swiftmacro_4test7myFunc615_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_lifetime(copy span) @_disfavoredOverload
+public func myFunc6(_ span: Span<CInt>, _ ptr: RawSpan, _ count: CInt, _ size: CInt) -> Span<CInt> {
+    let _ptrCount = ptr.byteCount
+    if _ptrCount != count * size {
+      fatalError("bounds check failure in myFunc6: expected \(count * size) but got \(_ptrCount)")
+    }
+    return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe ptr.withUnsafeBytes { _ptrPtr in
+      return unsafe myFunc6(SpanOfInt(span), _ptrPtr.baseAddress!, count, size)
+            }), copying: ())
+}
+------------------------------
+@__swiftmacro_4test7myFunc715_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_lifetime(copy span) @_disfavoredOverload
+public func myFunc7(_ span: Span<CInt>, _ ptr: RawSpan, _ count: CInt, _ size: CInt) -> Span<CInt> {
+    let _ptrCount = ptr.byteCount
+    if _ptrCount != count * size {
+      fatalError("bounds check failure in myFunc7: expected \(count * size) but got \(_ptrCount)")
+    }
+    return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe ptr.withUnsafeBytes { _ptrPtr in
+      return unsafe myFunc7(SpanOfInt(span), _ptrPtr.baseAddress!, count, size)
+            }), copying: ())
+}
+------------------------------
+@__swiftmacro_4test7myFunc815_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_lifetime(copy span) @_disfavoredOverload
+public func myFunc8(_ ptr: RawSpan, _ span: Span<CInt>, _ count: CInt, _ size: CInt) -> Span<CInt> {
+    let _ptrCount = ptr.byteCount
+    if _ptrCount != count * size {
+      fatalError("bounds check failure in myFunc8: expected \(count * size) but got \(_ptrCount)")
+    }
+    return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe ptr.withUnsafeBytes { _ptrPtr in
+      return unsafe myFunc8(_ptrPtr.baseAddress!, SpanOfInt(span), count, size)
+            }), copying: ())
+}
+------------------------------
+@__swiftmacro_4test7myFunc915_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_lifetime(copy span) @_lifetime(span: copy span) @_disfavoredOverload
+public func myFunc9(_ span: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
+    return unsafe _swiftifyOverrideLifetime(MutableSpan(_unsafeCxxSpan: unsafe span.withUnsafeMutableBufferPointer { _spanPtr in
+      return unsafe myFunc9(MutableSpanOfInt(_spanPtr))
+            }), copying: ())
+}
+------------------------------
+@__swiftmacro_4test8myFunc1015_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_lifetime(copy `self`) @_lifetime(`self`: copy `self`) @_disfavoredOverload
+public func myFunc10(_ `self`: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
+    return unsafe _swiftifyOverrideLifetime(MutableSpan(_unsafeCxxSpan: unsafe `self`.withUnsafeMutableBufferPointer { _selfPtr in
+      return unsafe myFunc10(MutableSpanOfInt(_selfPtr))
+            }), copying: ())
+}
+------------------------------

--- a/test/Macros/SwiftifyImport/CxxSpan/NoEscapeSpan.swift
+++ b/test/Macros/SwiftifyImport/CxxSpan/NoEscapeSpan.swift
@@ -1,53 +1,72 @@
 // REQUIRES: swift_swift_parser
 // REQUIRES: swift_feature_Lifetimes
-
-// RUN: %target-swift-frontend %s -cxx-interoperability-mode=default -I %S/Inputs -Xcc -std=c++20 -swift-version 5 -module-name main -disable-availability-checking -typecheck -enable-experimental-feature Lifetimes -plugin-path %swift-plugin-dir -strict-memory-safety -warnings-as-errors -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
-
 // REQUIRES: std_span
 
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend %t/test.swift -cxx-interoperability-mode=default -I %S/Inputs -Xcc -std=c++20 -emit-module -plugin-path %swift-plugin-dir -strict-memory-safety -enable-experimental-feature Lifetimes -verify
+// RUN: env SWIFT_BACKTRACE="" %target-swift-frontend %t/test.swift -cxx-interoperability-mode=default -I %S/Inputs -Xcc -std=c++20 -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions -enable-experimental-feature Lifetimes 2> %t/expansions.out
+// RUN: %diff %t/expansions.out %t/expansions.expected
+
+//--- test.swift
 import CxxStdlib
 import StdSpan
 
 @_SwiftifyImport(.nonescaping(pointer: .param(1)), typeMappings: ["SpanOfInt" : "std.span<__cxxConst<CInt>>"])
-func myFunc(_ span: SpanOfInt, _ secondSpan: SpanOfInt) {
+public func myFunc(_ span: SpanOfInt, _ secondSpan: SpanOfInt) {
 }
 
 @_SwiftifyImport(.nonescaping(pointer: .param(1)), typeMappings: ["MutableSpanOfInt" : "std.span<CInt>"])
-func myFunc2(_ span: MutableSpanOfInt, _ secondSpan: MutableSpanOfInt) {
+public func myFunc2(_ span: MutableSpanOfInt, _ secondSpan: MutableSpanOfInt) {
 }
 
 @_SwiftifyImport(.nonescaping(pointer: .param(1)), .nonescaping(pointer: .param(2)), typeMappings: ["MutableSpanOfInt" : "std.span<CInt>", "SpanOfInt" : "std.span<__cxxConst<CInt>>"])
-func myFunc3(_ span: MutableSpanOfInt, _ secondSpan: SpanOfInt) {
+public func myFunc3(_ span: MutableSpanOfInt, _ secondSpan: SpanOfInt) {
 }
 
 @_SwiftifyImport(.nonescaping(pointer: .param(1)), .nonescaping(pointer: .param(2)), typeMappings: ["MutableSpanOfInt" : "std.span<CInt>"])
-func myFunc4(_ span: MutableSpanOfInt, _ secondSpan: MutableSpanOfInt) {
+public func myFunc4(_ span: MutableSpanOfInt, _ secondSpan: MutableSpanOfInt) {
 }
 
-// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func myFunc(_ span: Span<CInt>, _ secondSpan: SpanOfInt) {
-// CHECK-NEXT:     return unsafe myFunc(SpanOfInt(span), secondSpan)
-// CHECK-NEXT: }
-
-// CHECK:      @_alwaysEmitIntoClient @_lifetime(span: copy span) @_disfavoredOverload
-// CHECK-NEXT: func myFunc2(_ span: inout MutableSpan<CInt>, _ secondSpan: MutableSpanOfInt) {
-// CHECK-NEXT:     return unsafe span.withUnsafeMutableBufferPointer { _spanPtr in
-// CHECK-NEXT:         return unsafe myFunc2(MutableSpanOfInt(_spanPtr), secondSpan)
-// CHECK-NEXT:     }
-// CHECK-NEXT: }
-
-// CHECK:      @_alwaysEmitIntoClient @_lifetime(span: copy span) @_disfavoredOverload
-// CHECK-NEXT: func myFunc3(_ span: inout MutableSpan<CInt>, _ secondSpan: Span<CInt>) {
-// CHECK-NEXT:     return unsafe span.withUnsafeMutableBufferPointer { _spanPtr in
-// CHECK-NEXT:         return unsafe myFunc3(MutableSpanOfInt(_spanPtr), SpanOfInt(secondSpan))
-// CHECK-NEXT:     }
-// CHECK-NEXT: }
-
-// CHECK:      @_alwaysEmitIntoClient @_lifetime(span: copy span) @_lifetime(secondSpan: copy secondSpan) @_disfavoredOverload
-// CHECK-NEXT: func myFunc4(_ span: inout MutableSpan<CInt>, _ secondSpan: inout MutableSpan<CInt>) {
-// CHECK-NEXT:     return unsafe secondSpan.withUnsafeMutableBufferPointer { _secondSpanPtr in
-// CHECK-NEXT:         return unsafe span.withUnsafeMutableBufferPointer { _spanPtr in
-// CHECK-NEXT:             return unsafe myFunc4(MutableSpanOfInt(_spanPtr), MutableSpanOfInt(_secondSpanPtr))
-// CHECK-NEXT:         }
-// CHECK-NEXT:     }
-// CHECK-NEXT: }
+//--- expansions.expected
+@__swiftmacro_4test6myFunc15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func myFunc(_ span: Span<CInt>, _ secondSpan: SpanOfInt) {
+    return unsafe myFunc(SpanOfInt(span), secondSpan)
+}
+------------------------------
+@__swiftmacro_4test7myFunc215_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_lifetime(span: copy span) @_disfavoredOverload
+public func myFunc2(_ span: inout MutableSpan<CInt>, _ secondSpan: MutableSpanOfInt) {
+    return unsafe span.withUnsafeMutableBufferPointer { _spanPtr in
+      return unsafe myFunc2(MutableSpanOfInt(_spanPtr), secondSpan)
+    }
+}
+------------------------------
+@__swiftmacro_4test7myFunc315_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_lifetime(span: copy span) @_disfavoredOverload
+public func myFunc3(_ span: inout MutableSpan<CInt>, _ secondSpan: Span<CInt>) {
+    return unsafe span.withUnsafeMutableBufferPointer { _spanPtr in
+      return unsafe myFunc3(MutableSpanOfInt(_spanPtr), SpanOfInt(secondSpan))
+    }
+}
+------------------------------
+@__swiftmacro_4test7myFunc415_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_lifetime(span: copy span) @_lifetime(secondSpan: copy secondSpan) @_disfavoredOverload
+public func myFunc4(_ span: inout MutableSpan<CInt>, _ secondSpan: inout MutableSpan<CInt>) {
+    return unsafe secondSpan.withUnsafeMutableBufferPointer { _secondSpanPtr in
+      return unsafe span.withUnsafeMutableBufferPointer { _spanPtr in
+      return unsafe myFunc4(MutableSpanOfInt(_spanPtr), MutableSpanOfInt(_secondSpanPtr))
+      }
+    }
+}
+------------------------------

--- a/test/Macros/SwiftifyImport/SizedBy/MultipleParams.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/MultipleParams.swift
@@ -1,14 +1,25 @@
 // REQUIRES: swift_swift_parser
 
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions -strict-memory-safety -warnings-as-errors 2>&1 | %FileCheck --match-full-lines %s
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
 
+// RUN: %target-swift-frontend %t/test.swift -emit-module -plugin-path %swift-plugin-dir -strict-memory-safety -verify
+// RUN: env SWIFT_BACKTRACE="" %target-swift-frontend %t/test.swift -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2> %t/expansions.out
+// RUN: %diff %t/expansions.out %t/expansions.expected
+
+//--- test.swift
 @_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size"), .sizedBy(pointer: .param(3), size: "size2"))
-func myFunc(_ ptr: UnsafeRawPointer, _ size: CInt, _ ptr2: UnsafeRawPointer, _ size2: CInt) {
+public func myFunc(_ ptr: UnsafeRawPointer, _ size: CInt, _ ptr2: UnsafeRawPointer, _ size2: CInt) {
 }
 
-// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func myFunc(_ ptr: UnsafeRawBufferPointer, _ ptr2: UnsafeRawBufferPointer) {
-// CHECK-NEXT:     let size = CInt(exactly: ptr.count)!
-// CHECK-NEXT:     let size2 = CInt(exactly: ptr2.count)!
-// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, size, ptr2.baseAddress!, size2)
-// CHECK-NEXT: }
+//--- expansions.expected
+@__swiftmacro_4test6myFunc15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func myFunc(_ ptr: UnsafeRawBufferPointer, _ ptr2: UnsafeRawBufferPointer) {
+    let size = CInt(exactly: ptr.count)!
+    let size2 = CInt(exactly: ptr2.count)!
+    return unsafe myFunc(ptr.baseAddress!, size, ptr2.baseAddress!, size2)
+}
+------------------------------

--- a/test/Macros/SwiftifyImport/SizedBy/Mutable.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/Mutable.swift
@@ -1,13 +1,24 @@
 // REQUIRES: swift_swift_parser
 
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -strict-memory-safety -warnings-as-errors -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
 
+// RUN: %target-swift-frontend %t/test.swift -emit-module -plugin-path %swift-plugin-dir -strict-memory-safety -verify
+// RUN: env SWIFT_BACKTRACE="" %target-swift-frontend %t/test.swift -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2> %t/expansions.out
+// RUN: %diff %t/expansions.out %t/expansions.expected
+
+//--- test.swift
 @_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size"))
-func myFunc(_ ptr: UnsafeMutableRawPointer, _ size: CInt) {
+public func myFunc(_ ptr: UnsafeMutableRawPointer, _ size: CInt) {
 }
 
-// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func myFunc(_ ptr: UnsafeMutableRawBufferPointer) {
-// CHECK-NEXT:     let size = CInt(exactly: ptr.count)!
-// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, size)
-// CHECK-NEXT: }
+//--- expansions.expected
+@__swiftmacro_4test6myFunc15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func myFunc(_ ptr: UnsafeMutableRawBufferPointer) {
+    let size = CInt(exactly: ptr.count)!
+    return unsafe myFunc(ptr.baseAddress!, size)
+}
+------------------------------

--- a/test/Macros/SwiftifyImport/SizedBy/MutableRawSpan.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/MutableRawSpan.swift
@@ -1,16 +1,26 @@
 // REQUIRES: swift_swift_parser
 
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -strict-memory-safety -warnings-as-errors -dump-macro-expansions > %t.log 2>&1
-// RUN: %FileCheck --match-full-lines %s < %t.log
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
 
+// RUN: %target-swift-frontend %t/test.swift -emit-module -plugin-path %swift-plugin-dir -strict-memory-safety -verify
+// RUN: env SWIFT_BACKTRACE="" %target-swift-frontend %t/test.swift -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2> %t/expansions.out
+// RUN: %diff %t/expansions.out %t/expansions.expected
+
+//--- test.swift
 @_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size"), .nonescaping(pointer: .param(1)))
-func myFunc(_ ptr: UnsafeMutableRawPointer, _ size: CInt) {
+public func myFunc(_ ptr: UnsafeMutableRawPointer, _ size: CInt) {
 }
 
-// CHECK:      @_alwaysEmitIntoClient @_lifetime(ptr: copy ptr) @_disfavoredOverload
-// CHECK-NEXT: func myFunc(_ ptr: inout MutableRawSpan) {
-// CHECK-NEXT:     let size = CInt(exactly: ptr.byteCount)!
-// CHECK-NEXT:     return unsafe ptr.withUnsafeMutableBytes { _ptrPtr in
-// CHECK-NEXT:       return unsafe myFunc(_ptrPtr.baseAddress!, size)
-// CHECK-NEXT:     }
-// CHECK-NEXT: }
+//--- expansions.expected
+@__swiftmacro_4test6myFunc15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_lifetime(ptr: copy ptr) @_disfavoredOverload
+public func myFunc(_ ptr: inout MutableRawSpan) {
+    let size = CInt(exactly: ptr.byteCount)!
+    return unsafe ptr.withUnsafeMutableBytes { _ptrPtr in
+      return unsafe myFunc(_ptrPtr.baseAddress!, size)
+    }
+}
+------------------------------

--- a/test/Macros/SwiftifyImport/SizedBy/MutableRawSpan.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/MutableRawSpan.swift
@@ -19,8 +19,9 @@ public func myFunc(_ ptr: UnsafeMutableRawPointer, _ size: CInt) {
 @_alwaysEmitIntoClient @_lifetime(ptr: copy ptr) @_disfavoredOverload
 public func myFunc(_ ptr: inout MutableRawSpan) {
     let size = CInt(exactly: ptr.byteCount)!
-    return unsafe ptr.withUnsafeMutableBytes { _ptrPtr in
-      return unsafe myFunc(_ptrPtr.baseAddress!, size)
+    let _ptrPtr = unsafe ptr.withUnsafeMutableBytes {
+        unsafe $0
     }
+    return unsafe myFunc(_ptrPtr.baseAddress!, size)
 }
 ------------------------------

--- a/test/Macros/SwiftifyImport/SizedBy/Nullable.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/Nullable.swift
@@ -41,15 +41,10 @@ public func myFunc(_ ptr: UnsafeRawBufferPointer?) {
 @_alwaysEmitIntoClient @_lifetime(ptr: copy ptr) @_disfavoredOverload
 public func myFunc2(_ ptr: inout MutableRawSpan?) {
     let len = CInt(exactly: ptr?.byteCount ?? 0)!
-    return { () in
-        return if ptr == nil {
-            unsafe myFunc2(nil, len)
-          } else {
-            unsafe ptr!.withUnsafeMutableBytes { _ptrPtr in
-              return unsafe myFunc2(_ptrPtr.baseAddress, len)
-            }
-          }
-    }()
+    let _ptrPtr = unsafe ptr?.withUnsafeMutableBytes {
+        unsafe $0
+    }
+    return unsafe myFunc2(_ptrPtr?.baseAddress, len)
 }
 ------------------------------
 @__swiftmacro_4test7myFunc315_SwiftifyImportfMp_.swift
@@ -59,31 +54,13 @@ public func myFunc2(_ ptr: inout MutableRawSpan?) {
 public func myFunc3(_ ptr: inout MutableRawSpan?, _ ptr2: inout MutableRawSpan?) {
     let len = CInt(exactly: ptr?.byteCount ?? 0)!
     let len2 = CInt(exactly: ptr2?.byteCount ?? 0)!
-    return { () in
-        return if ptr2 == nil {
-            { () in
-                return if ptr == nil {
-                        unsafe myFunc3(nil, len, nil, len2)
-                      } else {
-                        unsafe ptr!.withUnsafeMutableBytes { _ptrPtr in
-                          return unsafe myFunc3(_ptrPtr.baseAddress, len, nil, len2)
-                        }
-                      }
-            }()
-          } else {
-            unsafe ptr2!.withUnsafeMutableBytes { _ptr2Ptr in
-              return { () in
-                  return if ptr == nil {
-                          unsafe myFunc3(nil, len, _ptr2Ptr.baseAddress, len2)
-                        } else {
-                          unsafe ptr!.withUnsafeMutableBytes { _ptrPtr in
-                            return unsafe myFunc3(_ptrPtr.baseAddress, len, _ptr2Ptr.baseAddress, len2)
-                          }
-                        }
-              }()
-            }
-          }
-    }()
+    let _ptrPtr = unsafe ptr?.withUnsafeMutableBytes {
+        unsafe $0
+    }
+    let _ptr2Ptr = unsafe ptr2?.withUnsafeMutableBytes {
+        unsafe $0
+    }
+    return unsafe myFunc3(_ptrPtr?.baseAddress, len, _ptr2Ptr?.baseAddress, len2)
 }
 ------------------------------
 @__swiftmacro_4test7myFunc415_SwiftifyImportfMp_.swift
@@ -92,16 +69,11 @@ public func myFunc3(_ ptr: inout MutableRawSpan?, _ ptr2: inout MutableRawSpan?)
 @_alwaysEmitIntoClient @_lifetime(copy ptr) @_lifetime(ptr: copy ptr) @_disfavoredOverload
 public func myFunc4(_ ptr: inout MutableRawSpan?) -> MutableRawSpan? {
     let len = CInt(exactly: ptr?.byteCount ?? 0)!
+    let _ptrPtr = unsafe ptr?.withUnsafeMutableBytes {
+        unsafe $0
+    }
     return unsafe _swiftifyOverrideLifetime({ () in
-      let _resultValue = { () in
-              return if ptr == nil {
-                  unsafe myFunc4(nil, len)
-                } else {
-                  unsafe ptr!.withUnsafeMutableBytes { _ptrPtr in
-                    return unsafe myFunc4(_ptrPtr.baseAddress, len)
-                  }
-                }
-          }()
+      let _resultValue = unsafe myFunc4(_ptrPtr?.baseAddress, len)
       if unsafe _resultValue == nil {
         return nil
       } else {

--- a/test/Macros/SwiftifyImport/SizedBy/Nullable.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/Nullable.swift
@@ -1,91 +1,112 @@
 // REQUIRES: swift_swift_parser
 
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -strict-memory-safety -warnings-as-errors -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
 
+// RUN: %target-swift-frontend %t/test.swift -emit-module -plugin-path %swift-plugin-dir -strict-memory-safety -verify
+// RUN: env SWIFT_BACKTRACE="" %target-swift-frontend %t/test.swift -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2> %t/expansions.out
+// RUN: %diff %t/expansions.out %t/expansions.expected
+
+//--- test.swift
 @_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size"))
-func myFunc(_ ptr: UnsafeRawPointer?, _ size: CInt) {
+public func myFunc(_ ptr: UnsafeRawPointer?, _ size: CInt) {
 }
 
 @_SwiftifyImport(.sizedBy(pointer: .param(1), size: "len"), .nonescaping(pointer: .param(1)))
-func myFunc2(_ ptr: UnsafeMutableRawPointer?, _ len: CInt) {
+public func myFunc2(_ ptr: UnsafeMutableRawPointer?, _ len: CInt) {
 }
 
 @_SwiftifyImport(.sizedBy(pointer: .param(1), size: "len"), .nonescaping(pointer: .param(1)), .sizedBy(pointer: .param(3), size: "len2"), .nonescaping(pointer: .param(3)))
-func myFunc3(_ ptr: UnsafeMutableRawPointer?, _ len: CInt, _ ptr2: UnsafeMutableRawPointer?, _ len2: CInt) {
+public func myFunc3(_ ptr: UnsafeMutableRawPointer?, _ len: CInt, _ ptr2: UnsafeMutableRawPointer?, _ len2: CInt) {
 }
 
 @_SwiftifyImport(.sizedBy(pointer: .param(1), size: "len"), .sizedBy(pointer: .return, size: "len"), .lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .copy))
-func myFunc4(_ ptr: UnsafeMutableRawPointer?, _ len: CInt) -> UnsafeMutableRawPointer? {
+public func myFunc4(_ ptr: UnsafeMutableRawPointer?, _ len: CInt) -> UnsafeMutableRawPointer? {
+// expected-error@+1{{missing return in global function expected to return 'UnsafeMutableRawPointer?'}}
 }
 
-// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func myFunc(_ ptr: UnsafeRawBufferPointer?) {
-// CHECK-NEXT:     let size = CInt(exactly: unsafe ptr?.count ?? 0)!
-// CHECK-NEXT:     return unsafe myFunc(ptr?.baseAddress, size)
-// CHECK-NEXT: }
-
-// CHECK:      @_alwaysEmitIntoClient @_lifetime(ptr: copy ptr) @_disfavoredOverload
-// CHECK-NEXT: func myFunc2(_ ptr: inout MutableRawSpan?) {
-// CHECK-NEXT:     let len = CInt(exactly: ptr?.byteCount ?? 0)!
-// CHECK-NEXT:     return { () in
-// CHECK-NEXT:         return if ptr == nil {
-// CHECK-NEXT:             unsafe myFunc2(nil, len)
-// CHECK-NEXT:           } else {
-// CHECK-NEXT:             unsafe ptr!.withUnsafeMutableBytes { _ptrPtr in
-// CHECK-NEXT:               return unsafe myFunc2(_ptrPtr.baseAddress, len)
-// CHECK-NEXT:             }
-// CHECK-NEXT:           }
-// CHECK-NEXT:     }()
-// CHECK-NEXT: }
-
-// CHECK:      @_alwaysEmitIntoClient @_lifetime(ptr: copy ptr) @_lifetime(ptr2: copy ptr2) @_disfavoredOverload
-// CHECK-NEXT: func myFunc3(_ ptr: inout MutableRawSpan?, _ ptr2: inout MutableRawSpan?) {
-// CHECK-NEXT:     let len = CInt(exactly: ptr?.byteCount ?? 0)!
-// CHECK-NEXT:     let len2 = CInt(exactly: ptr2?.byteCount ?? 0)!
-// CHECK-NEXT:     return { () in
-// CHECK-NEXT:         return if ptr2 == nil {
-// CHECK-NEXT:             { () in
-// CHECK-NEXT:                 return if ptr == nil {
-// CHECK-NEXT:                         unsafe myFunc3(nil, len, nil, len2)
-// CHECK-NEXT:                       } else {
-// CHECK-NEXT:                         unsafe ptr!.withUnsafeMutableBytes { _ptrPtr in
-// CHECK-NEXT:                           return unsafe myFunc3(_ptrPtr.baseAddress, len, nil, len2)
-// CHECK-NEXT:                         }
-// CHECK-NEXT:                       }
-// CHECK-NEXT:             }()
-// CHECK-NEXT:           } else {
-// CHECK-NEXT:             unsafe ptr2!.withUnsafeMutableBytes { _ptr2Ptr in
-// CHECK-NEXT:               return { () in
-// CHECK-NEXT:                   return if ptr == nil {
-// CHECK-NEXT:                           unsafe myFunc3(nil, len, _ptr2Ptr.baseAddress, len2)
-// CHECK-NEXT:                         } else {
-// CHECK-NEXT:                           unsafe ptr!.withUnsafeMutableBytes { _ptrPtr in
-// CHECK-NEXT:                             return unsafe myFunc3(_ptrPtr.baseAddress, len, _ptr2Ptr.baseAddress, len2)
-// CHECK-NEXT:                           }
-// CHECK-NEXT:                         }
-// CHECK-NEXT:               }()
-// CHECK-NEXT:             }
-// CHECK-NEXT:           }
-// CHECK-NEXT:     }()
-// CHECK-NEXT: }
-
-// CHECK:      @_alwaysEmitIntoClient @_lifetime(copy ptr) @_lifetime(ptr: copy ptr) @_disfavoredOverload
-// CHECK-NEXT: func myFunc4(_ ptr: inout MutableRawSpan?) -> MutableRawSpan? {
-// CHECK-NEXT:     let len = CInt(exactly: ptr?.byteCount ?? 0)!
-// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime({ () in
-// CHECK-NEXT:       let _resultValue = { () in
-// CHECK-NEXT:               return if ptr == nil {
-// CHECK-NEXT:                   unsafe myFunc4(nil, len)
-// CHECK-NEXT:                 } else {
-// CHECK-NEXT:                   unsafe ptr!.withUnsafeMutableBytes { _ptrPtr in
-// CHECK-NEXT:                     return unsafe myFunc4(_ptrPtr.baseAddress, len)
-// CHECK-NEXT:                   }
-// CHECK-NEXT:                 }
-// CHECK-NEXT:           }()
-// CHECK-NEXT:       if unsafe _resultValue == nil {
-// CHECK-NEXT:         return nil
-// CHECK-NEXT:       } else {
-// CHECK-NEXT:         return unsafe _swiftifyOverrideLifetime(MutableRawSpan(_unsafeStart: _resultValue!, byteCount: Int(len)), copying: ())
-// CHECK-NEXT:       }
-// CHECK-NEXT:         }(), copying: ())
-// CHECK-NEXT: }
+//--- expansions.expected
+@__swiftmacro_4test6myFunc15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func myFunc(_ ptr: UnsafeRawBufferPointer?) {
+    let size = CInt(exactly: unsafe ptr?.count ?? 0)!
+    return unsafe myFunc(ptr?.baseAddress, size)
+}
+------------------------------
+@__swiftmacro_4test7myFunc215_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_lifetime(ptr: copy ptr) @_disfavoredOverload
+public func myFunc2(_ ptr: inout MutableRawSpan?) {
+    let len = CInt(exactly: ptr?.byteCount ?? 0)!
+    return { () in
+        return if ptr == nil {
+            unsafe myFunc2(nil, len)
+          } else {
+            unsafe ptr!.withUnsafeMutableBytes { _ptrPtr in
+              return unsafe myFunc2(_ptrPtr.baseAddress, len)
+            }
+          }
+    }()
+}
+------------------------------
+@__swiftmacro_4test7myFunc315_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_lifetime(ptr: copy ptr) @_lifetime(ptr2: copy ptr2) @_disfavoredOverload
+public func myFunc3(_ ptr: inout MutableRawSpan?, _ ptr2: inout MutableRawSpan?) {
+    let len = CInt(exactly: ptr?.byteCount ?? 0)!
+    let len2 = CInt(exactly: ptr2?.byteCount ?? 0)!
+    return { () in
+        return if ptr2 == nil {
+            { () in
+                return if ptr == nil {
+                        unsafe myFunc3(nil, len, nil, len2)
+                      } else {
+                        unsafe ptr!.withUnsafeMutableBytes { _ptrPtr in
+                          return unsafe myFunc3(_ptrPtr.baseAddress, len, nil, len2)
+                        }
+                      }
+            }()
+          } else {
+            unsafe ptr2!.withUnsafeMutableBytes { _ptr2Ptr in
+              return { () in
+                  return if ptr == nil {
+                          unsafe myFunc3(nil, len, _ptr2Ptr.baseAddress, len2)
+                        } else {
+                          unsafe ptr!.withUnsafeMutableBytes { _ptrPtr in
+                            return unsafe myFunc3(_ptrPtr.baseAddress, len, _ptr2Ptr.baseAddress, len2)
+                          }
+                        }
+              }()
+            }
+          }
+    }()
+}
+------------------------------
+@__swiftmacro_4test7myFunc415_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_lifetime(copy ptr) @_lifetime(ptr: copy ptr) @_disfavoredOverload
+public func myFunc4(_ ptr: inout MutableRawSpan?) -> MutableRawSpan? {
+    let len = CInt(exactly: ptr?.byteCount ?? 0)!
+    return unsafe _swiftifyOverrideLifetime({ () in
+      let _resultValue = { () in
+              return if ptr == nil {
+                  unsafe myFunc4(nil, len)
+                } else {
+                  unsafe ptr!.withUnsafeMutableBytes { _ptrPtr in
+                    return unsafe myFunc4(_ptrPtr.baseAddress, len)
+                  }
+                }
+          }()
+      if unsafe _resultValue == nil {
+        return nil
+      } else {
+        return unsafe _swiftifyOverrideLifetime(MutableRawSpan(_unsafeStart: _resultValue!, byteCount: Int(len)), copying: ())
+      }
+        }(), copying: ())
+}
+------------------------------

--- a/test/Macros/SwiftifyImport/SizedBy/Opaque.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/Opaque.swift
@@ -1,74 +1,101 @@
 // REQUIRES: swift_swift_parser
 
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -strict-memory-safety -warnings-as-errors -dump-macro-expansions -verify 2>&1 | %FileCheck --match-full-lines %s
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
 
+// RUN: %target-swift-frontend %t/test.swift -emit-module -plugin-path %swift-plugin-dir -strict-memory-safety -verify
+// RUN: env SWIFT_BACKTRACE="" %target-swift-frontend %t/test.swift -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2> %t/expansions.out
+// RUN: %diff %t/expansions.out %t/expansions.expected
+
+//--- test.swift
 @_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size"))
-func nonnullUnsafeRawBufferPointer(_ ptr: OpaquePointer, _ size: CInt) {
+public func nonnullUnsafeRawBufferPointer(_ ptr: OpaquePointer, _ size: CInt) {
 }
 
 @_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size"))
-func nullableUnsafeRawBufferPointer(_ ptr: OpaquePointer?, _ size: CInt) {
+public func nullableUnsafeRawBufferPointer(_ ptr: OpaquePointer?, _ size: CInt) {
 }
 
 @_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size"))
-func impNullableUnsafeRawBufferPointer(_ ptr: OpaquePointer!, _ size: CInt) {
+public func impNullableUnsafeRawBufferPointer(_ ptr: OpaquePointer!, _ size: CInt) {
 }
 
 @_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size"), .nonescaping(pointer: .param(1)))
-func nonnullSpan(_ ptr: OpaquePointer, _ size: CInt) {
+public func nonnullSpan(_ ptr: OpaquePointer, _ size: CInt) {
 }
 
 @_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size"), .nonescaping(pointer: .param(1)))
-func nullableSpan(_ ptr: OpaquePointer?, _ size: CInt) {
+public func nullableSpan(_ ptr: OpaquePointer?, _ size: CInt) {
 }
 
 @_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size"), .nonescaping(pointer: .param(1)))
-func impNullableSpan(_ ptr: OpaquePointer!, _ size: CInt) {
+public func impNullableSpan(_ ptr: OpaquePointer!, _ size: CInt) {
 }
 
-// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func nonnullUnsafeRawBufferPointer(_ ptr: UnsafeRawBufferPointer) {
-// CHECK-NEXT:     let size = CInt(exactly: ptr.count)!
-// CHECK-NEXT:     return unsafe nonnullUnsafeRawBufferPointer(OpaquePointer(ptr.baseAddress!), size)
-
-// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func nullableUnsafeRawBufferPointer(_ ptr: UnsafeRawBufferPointer?) {
-// CHECK-NEXT:     let size = CInt(exactly: unsafe ptr?.count ?? 0)!
-// CHECK-NEXT:     return unsafe nullableUnsafeRawBufferPointer(OpaquePointer(ptr?.baseAddress), size)
-// CHECK-NEXT: }
-
-// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func impNullableUnsafeRawBufferPointer(_ ptr: UnsafeRawBufferPointer) {
-// CHECK-NEXT:     let size = CInt(exactly: ptr.count)!
-// CHECK-NEXT:     return unsafe impNullableUnsafeRawBufferPointer(OpaquePointer(ptr.baseAddress!), size)
-// CHECK-NEXT: }
-
-// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func nonnullSpan(_ ptr: RawSpan) {
-// CHECK-NEXT:     let size = CInt(exactly: ptr.byteCount)!
-// CHECK-NEXT:     return unsafe ptr.withUnsafeBytes { _ptrPtr in
-// CHECK-NEXT:       return unsafe nonnullSpan(OpaquePointer(_ptrPtr.baseAddress!), size)
-// CHECK-NEXT:     }
-// CHECK-NEXT: }
-
-// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func nullableSpan(_ ptr: RawSpan?) {
-// CHECK-NEXT:     let size = CInt(exactly: ptr?.byteCount ?? 0)!
-// CHECK-NEXT:     return { () in
-// CHECK-NEXT:         return if ptr == nil {
-// CHECK-NEXT:             unsafe nullableSpan(nil, size)
-// CHECK-NEXT:           } else {
-// CHECK-NEXT:             unsafe ptr!.withUnsafeBytes { _ptrPtr in
-// CHECK-NEXT:               return unsafe nullableSpan(OpaquePointer(_ptrPtr.baseAddress), size)
-// CHECK-NEXT:             }
-// CHECK-NEXT:           }
-// CHECK-NEXT:     }()
-// CHECK-NEXT: }
-
-// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func impNullableSpan(_ ptr: RawSpan) {
-// CHECK-NEXT:     let size = CInt(exactly: ptr.byteCount)!
-// CHECK-NEXT:     return unsafe ptr.withUnsafeBytes { _ptrPtr in
-// CHECK-NEXT:       return unsafe impNullableSpan(OpaquePointer(_ptrPtr.baseAddress!), size)
-// CHECK-NEXT:     }
-// CHECK-NEXT: }
+//--- expansions.expected
+@__swiftmacro_4test29nonnullUnsafeRawBufferPointer15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func nonnullUnsafeRawBufferPointer(_ ptr: UnsafeRawBufferPointer) {
+    let size = CInt(exactly: ptr.count)!
+    return unsafe nonnullUnsafeRawBufferPointer(OpaquePointer(ptr.baseAddress!), size)
+}
+------------------------------
+@__swiftmacro_4test30nullableUnsafeRawBufferPointer15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func nullableUnsafeRawBufferPointer(_ ptr: UnsafeRawBufferPointer?) {
+    let size = CInt(exactly: unsafe ptr?.count ?? 0)!
+    return unsafe nullableUnsafeRawBufferPointer(OpaquePointer(ptr?.baseAddress), size)
+}
+------------------------------
+@__swiftmacro_4test33impNullableUnsafeRawBufferPointer15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func impNullableUnsafeRawBufferPointer(_ ptr: UnsafeRawBufferPointer) {
+    let size = CInt(exactly: ptr.count)!
+    return unsafe impNullableUnsafeRawBufferPointer(OpaquePointer(ptr.baseAddress!), size)
+}
+------------------------------
+@__swiftmacro_4test11nonnullSpan15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func nonnullSpan(_ ptr: RawSpan) {
+    let size = CInt(exactly: ptr.byteCount)!
+    return unsafe ptr.withUnsafeBytes { _ptrPtr in
+      return unsafe nonnullSpan(OpaquePointer(_ptrPtr.baseAddress!), size)
+    }
+}
+------------------------------
+@__swiftmacro_4test12nullableSpan15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func nullableSpan(_ ptr: RawSpan?) {
+    let size = CInt(exactly: ptr?.byteCount ?? 0)!
+    return { () in
+        return if ptr == nil {
+            unsafe nullableSpan(nil, size)
+          } else {
+            unsafe ptr!.withUnsafeBytes { _ptrPtr in
+              return unsafe nullableSpan(OpaquePointer(_ptrPtr.baseAddress), size)
+            }
+          }
+    }()
+}
+------------------------------
+@__swiftmacro_4test15impNullableSpan15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func impNullableSpan(_ ptr: RawSpan) {
+    let size = CInt(exactly: ptr.byteCount)!
+    return unsafe ptr.withUnsafeBytes { _ptrPtr in
+      return unsafe impNullableSpan(OpaquePointer(_ptrPtr.baseAddress!), size)
+    }
+}
+------------------------------

--- a/test/Macros/SwiftifyImport/SizedBy/Opaque.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/Opaque.swift
@@ -66,9 +66,10 @@ public func impNullableUnsafeRawBufferPointer(_ ptr: UnsafeRawBufferPointer) {
 @_alwaysEmitIntoClient @_disfavoredOverload
 public func nonnullSpan(_ ptr: RawSpan) {
     let size = CInt(exactly: ptr.byteCount)!
-    return unsafe ptr.withUnsafeBytes { _ptrPtr in
-      return unsafe nonnullSpan(OpaquePointer(_ptrPtr.baseAddress!), size)
+    let _ptrPtr = unsafe ptr.withUnsafeBytes {
+        unsafe $0
     }
+    return unsafe nonnullSpan(OpaquePointer(_ptrPtr.baseAddress!), size)
 }
 ------------------------------
 @__swiftmacro_4test12nullableSpan15_SwiftifyImportfMp_.swift
@@ -77,15 +78,10 @@ public func nonnullSpan(_ ptr: RawSpan) {
 @_alwaysEmitIntoClient @_disfavoredOverload
 public func nullableSpan(_ ptr: RawSpan?) {
     let size = CInt(exactly: ptr?.byteCount ?? 0)!
-    return { () in
-        return if ptr == nil {
-            unsafe nullableSpan(nil, size)
-          } else {
-            unsafe ptr!.withUnsafeBytes { _ptrPtr in
-              return unsafe nullableSpan(OpaquePointer(_ptrPtr.baseAddress), size)
-            }
-          }
-    }()
+    let _ptrPtr = unsafe ptr?.withUnsafeBytes {
+        unsafe $0
+    }
+    return unsafe nullableSpan(OpaquePointer(_ptrPtr?.baseAddress), size)
 }
 ------------------------------
 @__swiftmacro_4test15impNullableSpan15_SwiftifyImportfMp_.swift
@@ -94,8 +90,9 @@ public func nullableSpan(_ ptr: RawSpan?) {
 @_alwaysEmitIntoClient @_disfavoredOverload
 public func impNullableSpan(_ ptr: RawSpan) {
     let size = CInt(exactly: ptr.byteCount)!
-    return unsafe ptr.withUnsafeBytes { _ptrPtr in
-      return unsafe impNullableSpan(OpaquePointer(_ptrPtr.baseAddress!), size)
+    let _ptrPtr = unsafe ptr.withUnsafeBytes {
+        unsafe $0
     }
+    return unsafe impNullableSpan(OpaquePointer(_ptrPtr.baseAddress!), size)
 }
 ------------------------------

--- a/test/Macros/SwiftifyImport/SizedBy/OpaqueReturn.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/OpaqueReturn.swift
@@ -64,9 +64,10 @@ public func impNullableUnsafeRawBufferPointer(_ size: CInt) -> UnsafeRawBufferPo
 @_alwaysEmitIntoClient @_lifetime(copy p) @_disfavoredOverload
 public func nonnullSpan(p: RawSpan) -> RawSpan {
     let size = CInt(exactly: p.byteCount)!
-    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe UnsafeRawPointer(unsafe p.withUnsafeBytes { _pPtr in
-      return unsafe nonnullSpan(p: OpaquePointer(_pPtr.baseAddress!), size: size)
-                }), byteCount: Int(size)), copying: ())
+    let _pPtr = unsafe p.withUnsafeBytes {
+        unsafe $0
+    }
+    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe UnsafeRawPointer(unsafe nonnullSpan(p: OpaquePointer(_pPtr.baseAddress!), size: size)), byteCount: Int(size)), copying: ())
 }
 ------------------------------
 @__swiftmacro_4test12nullableSpan15_SwiftifyImportfMp_.swift
@@ -75,16 +76,11 @@ public func nonnullSpan(p: RawSpan) -> RawSpan {
 @_alwaysEmitIntoClient @_lifetime(copy p) @_disfavoredOverload
 public func nullableSpan(p: RawSpan?) -> RawSpan? {
     let size = CInt(exactly: p?.byteCount ?? 0)!
+    let _pPtr = unsafe p?.withUnsafeBytes {
+        unsafe $0
+    }
     return unsafe _swiftifyOverrideLifetime({ () in
-      let _resultValue = { () in
-              return if p == nil {
-                  unsafe nullableSpan(p: nil, size)
-                } else {
-                  unsafe p!.withUnsafeBytes { _pPtr in
-                    return unsafe nullableSpan(p: OpaquePointer(_pPtr.baseAddress), size)
-                  }
-                }
-          }()
+      let _resultValue = unsafe nullableSpan(p: OpaquePointer(_pPtr?.baseAddress), size)
       if unsafe _resultValue == nil {
         return nil
       } else {
@@ -99,9 +95,10 @@ public func nullableSpan(p: RawSpan?) -> RawSpan? {
 @_alwaysEmitIntoClient @_lifetime(copy p) @_disfavoredOverload
 public func impNullableSpan(p: RawSpan) -> RawSpan {
     let size = CInt(exactly: p.byteCount)!
-    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe UnsafeRawPointer(unsafe p.withUnsafeBytes { _pPtr in
-      return unsafe impNullableSpan(p: OpaquePointer(_pPtr.baseAddress!), size)
-                }), byteCount: Int(size)), copying: ())
+    let _pPtr = unsafe p.withUnsafeBytes {
+        unsafe $0
+    }
+    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe UnsafeRawPointer(unsafe impNullableSpan(p: OpaquePointer(_pPtr.baseAddress!), size)), byteCount: Int(size)), copying: ())
 }
 ------------------------------
 

--- a/test/Macros/SwiftifyImport/SizedBy/PointerReturn.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/PointerReturn.swift
@@ -1,66 +1,97 @@
 // REQUIRES: swift_swift_parser
-// REQUIRES: swift_feature_Lifetimes
 
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -enable-experimental-feature Lifetimes -strict-memory-safety -warnings-as-errors -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
 
+// RUN: %target-swift-frontend %t/test.swift -emit-module -plugin-path %swift-plugin-dir -strict-memory-safety -verify
+// RUN: env SWIFT_BACKTRACE="" %target-swift-frontend %t/test.swift -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2> %t/expansions.out
+// RUN: %diff %t/expansions.out %t/expansions.expected
+
+//--- test.swift
 @_SwiftifyImport(.sizedBy(pointer: .return, size: "len"))
-func myFunc(_ len: CInt) -> UnsafeMutableRawPointer {
+public func myFunc(_ len: CInt) -> UnsafeMutableRawPointer {
+// expected-error@+1{{missing return in global function expected to return 'UnsafeMutableRawPointer'}}
 }
 
 @_SwiftifyImport(.sizedBy(pointer: .return, size: "len"), .nonescaping(pointer: .return))
-func nonEscaping(_ len: CInt) -> UnsafeRawPointer {
+public func nonEscaping(_ len: CInt) -> UnsafeRawPointer {
+// expected-error@+1{{missing return in global function expected to return 'UnsafeRawPointer'}}
 }
 
 @_SwiftifyImport(.sizedBy(pointer: .return, size: "len2"), .sizedBy(pointer: .param(1), size: "len1"), .lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .copy))
-func lifetimeDependentCopy(_ p: UnsafeRawPointer, _ len1: CInt, _ len2: CInt) -> UnsafeRawPointer {
+public func lifetimeDependentCopy(_ p: UnsafeRawPointer, _ len1: CInt, _ len2: CInt) -> UnsafeRawPointer {
+// expected-error@+1{{missing return in global function expected to return 'UnsafeRawPointer'}}
 }
 
 @_SwiftifyImport(.sizedBy(pointer: .return, size: "len2"), .sizedBy(pointer: .param(1), size: "len1"), .lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .borrow))
-func lifetimeDependentBorrow(_ p: borrowing UnsafeRawPointer, _ len1: CInt, _ len2: CInt) -> UnsafeRawPointer {
+public func lifetimeDependentBorrow(_ p: borrowing UnsafeRawPointer, _ len1: CInt, _ len2: CInt) -> UnsafeRawPointer {
+// expected-error@+1{{missing return in global function expected to return 'UnsafeRawPointer'}}
 }
 
 @_SwiftifyImport(.sizedBy(pointer: .return, size: "len2"), .sizedBy(pointer: .param(1), size: "len1"), .lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .copy))
-func lifetimeDependentCopyMut(_ p: UnsafeMutableRawPointer, _ len1: CInt, _ len2: CInt) -> UnsafeMutableRawPointer {
+public func lifetimeDependentCopyMut(_ p: UnsafeMutableRawPointer, _ len1: CInt, _ len2: CInt) -> UnsafeMutableRawPointer {
+// expected-error@+1{{missing return in global function expected to return 'UnsafeMutableRawPointer'}}
 }
 
 @_SwiftifyImport(.sizedBy(pointer: .return, size: "len2"), .sizedBy(pointer: .param(1), size: "len1"), .lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .borrow))
-func lifetimeDependentBorrowMut(_ p: borrowing UnsafeMutableRawPointer, _ len1: CInt, _ len2: CInt) -> UnsafeMutableRawPointer {
+public func lifetimeDependentBorrowMut(_ p: borrowing UnsafeMutableRawPointer, _ len1: CInt, _ len2: CInt) -> UnsafeMutableRawPointer {
+// expected-error@+1{{missing return in global function expected to return 'UnsafeMutableRawPointer'}}
 }
 
-// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func myFunc(_ len: CInt) -> UnsafeMutableRawBufferPointer {
-// CHECK-NEXT:     return unsafe UnsafeMutableRawBufferPointer(start: unsafe myFunc(len), count: Int(len))
-// CHECK-NEXT: }
-
-// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func nonEscaping(_ len: CInt) -> UnsafeRawBufferPointer {
-// CHECK-NEXT:     return unsafe UnsafeRawBufferPointer(start: unsafe nonEscaping(len), count: Int(len))
-// CHECK-NEXT: }
-
-// CHECK:      @_alwaysEmitIntoClient @_lifetime(copy p) @_disfavoredOverload
-// CHECK-NEXT: func lifetimeDependentCopy(_ p: RawSpan, _ len2: CInt) -> RawSpan {
-// CHECK-NEXT:     let len1 = CInt(exactly: p.byteCount)!
-// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe p.withUnsafeBytes { _pPtr in
-// CHECK-NEXT:       return unsafe lifetimeDependentCopy(_pPtr.baseAddress!, len1, len2)
-// CHECK-NEXT:             }, byteCount: Int(len2)), copying: ())
-// CHECK-NEXT: }
-
-// CHECK:      @_alwaysEmitIntoClient @_lifetime(borrow p) @_disfavoredOverload
-// CHECK-NEXT: func lifetimeDependentBorrow(_ p: borrowing UnsafeRawBufferPointer, _ len2: CInt) -> RawSpan {
-// CHECK-NEXT:     let len1 = CInt(exactly: p.count)!
-// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe lifetimeDependentBorrow(p.baseAddress!, len1, len2), byteCount: Int(len2)), copying: ())
-// CHECK-NEXT: }
-
-// CHECK:      @_alwaysEmitIntoClient @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload
-// CHECK-NEXT: func lifetimeDependentCopyMut(_ p: inout MutableRawSpan, _ len2: CInt) -> MutableRawSpan {
-// CHECK-NEXT:     let len1 = CInt(exactly: p.byteCount)!
-// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(MutableRawSpan(_unsafeStart: unsafe p.withUnsafeMutableBytes { _pPtr in
-// CHECK-NEXT:       return unsafe lifetimeDependentCopyMut(_pPtr.baseAddress!, len1, len2)
-// CHECK-NEXT:             }, byteCount: Int(len2)), copying: ())
-// CHECK-NEXT: }
-
-// CHECK:      @_alwaysEmitIntoClient @_lifetime(borrow p) @_disfavoredOverload
-// CHECK-NEXT: func lifetimeDependentBorrowMut(_ p: borrowing UnsafeMutableRawBufferPointer, _ len2: CInt) -> MutableRawSpan {
-// CHECK-NEXT:     let len1 = CInt(exactly: p.count)!
-// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(MutableRawSpan(_unsafeStart: unsafe lifetimeDependentBorrowMut(p.baseAddress!, len1, len2), byteCount: Int(len2)), copying: ())
-// CHECK-NEXT: }
+//--- expansions.expected
+@__swiftmacro_4test6myFunc15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func myFunc(_ len: CInt) -> UnsafeMutableRawBufferPointer {
+    return unsafe UnsafeMutableRawBufferPointer(start: unsafe myFunc(len), count: Int(len))
+}
+------------------------------
+@__swiftmacro_4test11nonEscaping15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func nonEscaping(_ len: CInt) -> UnsafeRawBufferPointer {
+    return unsafe UnsafeRawBufferPointer(start: unsafe nonEscaping(len), count: Int(len))
+}
+------------------------------
+@__swiftmacro_4test21lifetimeDependentCopy15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_lifetime(copy p) @_disfavoredOverload
+public func lifetimeDependentCopy(_ p: RawSpan, _ len2: CInt) -> RawSpan {
+    let len1 = CInt(exactly: p.byteCount)!
+    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe p.withUnsafeBytes { _pPtr in
+      return unsafe lifetimeDependentCopy(_pPtr.baseAddress!, len1, len2)
+            }, byteCount: Int(len2)), copying: ())
+}
+------------------------------
+@__swiftmacro_4test23lifetimeDependentBorrow15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_lifetime(borrow p) @_disfavoredOverload
+public func lifetimeDependentBorrow(_ p: borrowing UnsafeRawBufferPointer, _ len2: CInt) -> RawSpan {
+    let len1 = CInt(exactly: p.count)!
+    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe lifetimeDependentBorrow(p.baseAddress!, len1, len2), byteCount: Int(len2)), copying: ())
+}
+------------------------------
+@__swiftmacro_4test24lifetimeDependentCopyMut15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload
+public func lifetimeDependentCopyMut(_ p: inout MutableRawSpan, _ len2: CInt) -> MutableRawSpan {
+    let len1 = CInt(exactly: p.byteCount)!
+    return unsafe _swiftifyOverrideLifetime(MutableRawSpan(_unsafeStart: unsafe p.withUnsafeMutableBytes { _pPtr in
+      return unsafe lifetimeDependentCopyMut(_pPtr.baseAddress!, len1, len2)
+            }, byteCount: Int(len2)), copying: ())
+}
+------------------------------
+@__swiftmacro_4test26lifetimeDependentBorrowMut15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_lifetime(borrow p) @_disfavoredOverload
+public func lifetimeDependentBorrowMut(_ p: borrowing UnsafeMutableRawBufferPointer, _ len2: CInt) -> MutableRawSpan {
+    let len1 = CInt(exactly: p.count)!
+    return unsafe _swiftifyOverrideLifetime(MutableRawSpan(_unsafeStart: unsafe lifetimeDependentBorrowMut(p.baseAddress!, len1, len2), byteCount: Int(len2)), copying: ())
+}
+------------------------------

--- a/test/Macros/SwiftifyImport/SizedBy/PointerReturn.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/PointerReturn.swift
@@ -61,9 +61,10 @@ public func nonEscaping(_ len: CInt) -> UnsafeRawBufferPointer {
 @_alwaysEmitIntoClient @_lifetime(copy p) @_disfavoredOverload
 public func lifetimeDependentCopy(_ p: RawSpan, _ len2: CInt) -> RawSpan {
     let len1 = CInt(exactly: p.byteCount)!
-    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe p.withUnsafeBytes { _pPtr in
-      return unsafe lifetimeDependentCopy(_pPtr.baseAddress!, len1, len2)
-            }, byteCount: Int(len2)), copying: ())
+    let _pPtr = unsafe p.withUnsafeBytes {
+        unsafe $0
+    }
+    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe lifetimeDependentCopy(_pPtr.baseAddress!, len1, len2), byteCount: Int(len2)), copying: ())
 }
 ------------------------------
 @__swiftmacro_4test23lifetimeDependentBorrow15_SwiftifyImportfMp_.swift
@@ -81,9 +82,10 @@ public func lifetimeDependentBorrow(_ p: borrowing UnsafeRawBufferPointer, _ len
 @_alwaysEmitIntoClient @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload
 public func lifetimeDependentCopyMut(_ p: inout MutableRawSpan, _ len2: CInt) -> MutableRawSpan {
     let len1 = CInt(exactly: p.byteCount)!
-    return unsafe _swiftifyOverrideLifetime(MutableRawSpan(_unsafeStart: unsafe p.withUnsafeMutableBytes { _pPtr in
-      return unsafe lifetimeDependentCopyMut(_pPtr.baseAddress!, len1, len2)
-            }, byteCount: Int(len2)), copying: ())
+    let _pPtr = unsafe p.withUnsafeMutableBytes {
+        unsafe $0
+    }
+    return unsafe _swiftifyOverrideLifetime(MutableRawSpan(_unsafeStart: unsafe lifetimeDependentCopyMut(_pPtr.baseAddress!, len1, len2), byteCount: Int(len2)), copying: ())
 }
 ------------------------------
 @__swiftmacro_4test26lifetimeDependentBorrowMut15_SwiftifyImportfMp_.swift

--- a/test/Macros/SwiftifyImport/SizedBy/Return.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/Return.swift
@@ -1,13 +1,25 @@
 // REQUIRES: swift_swift_parser
 
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -strict-memory-safety -warnings-as-errors -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
 
+// RUN: %target-swift-frontend %t/test.swift -emit-module -plugin-path %swift-plugin-dir -strict-memory-safety -verify
+// RUN: env SWIFT_BACKTRACE="" %target-swift-frontend %t/test.swift -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2> %t/expansions.out
+// RUN: %diff %t/expansions.out %t/expansions.expected
+
+//--- test.swift
 @_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size"))
-func myFunc(_ ptr: UnsafeRawPointer, _ size: CInt) -> CInt {
+public func myFunc(_ ptr: UnsafeRawPointer, _ size: CInt) -> CInt {
+// expected-error@+1{{missing return in global function expected to return 'CInt' (aka 'Int32')}}
 }
 
-// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func myFunc(_ ptr: UnsafeRawBufferPointer) -> CInt {
-// CHECK-NEXT:     let size = CInt(exactly: ptr.count)!
-// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, size)
-// CHECK-NEXT: }
+//--- expansions.expected
+@__swiftmacro_4test6myFunc15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func myFunc(_ ptr: UnsafeRawBufferPointer) -> CInt {
+    let size = CInt(exactly: ptr.count)!
+    return unsafe myFunc(ptr.baseAddress!, size)
+}
+------------------------------

--- a/test/Macros/SwiftifyImport/SizedBy/SharedCount.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/SharedCount.swift
@@ -1,16 +1,27 @@
 // REQUIRES: swift_swift_parser
 
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions -strict-memory-safety -warnings-as-errors 2>&1 | %FileCheck --match-full-lines %s
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
 
+// RUN: %target-swift-frontend %t/test.swift -emit-module -plugin-path %swift-plugin-dir -strict-memory-safety -verify
+// RUN: env SWIFT_BACKTRACE="" %target-swift-frontend %t/test.swift -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2> %t/expansions.out
+// RUN: %diff %t/expansions.out %t/expansions.expected
+
+//--- test.swift
 @_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size"), .sizedBy(pointer: .param(2), size: "size"))
-func myFunc(_ ptr: UnsafeRawPointer, _ ptr2: UnsafeRawPointer, _ size: CInt) {
+public func myFunc(_ ptr: UnsafeRawPointer, _ ptr2: UnsafeRawPointer, _ size: CInt) {
 }
 
-// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func myFunc(_ ptr: UnsafeRawBufferPointer, _ ptr2: UnsafeRawBufferPointer) {
-// CHECK-NEXT:     let size = CInt(exactly: ptr.count)!
-// CHECK-NEXT:     if ptr2.count != size {
-// CHECK-NEXT:       fatalError("bounds check failure in myFunc: expected \(size) but got \(ptr2.count)")
-// CHECK-NEXT:     }
-// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, ptr2.baseAddress!, size)
-// CHECK-NEXT: }
+//--- expansions.expected
+@__swiftmacro_4test6myFunc15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func myFunc(_ ptr: UnsafeRawBufferPointer, _ ptr2: UnsafeRawBufferPointer) {
+    let size = CInt(exactly: ptr.count)!
+    if ptr2.count != size {
+      fatalError("bounds check failure in myFunc: expected \(size) but got \(ptr2.count)")
+    }
+    return unsafe myFunc(ptr.baseAddress!, ptr2.baseAddress!, size)
+}
+------------------------------

--- a/test/Macros/SwiftifyImport/SizedBy/SimpleRawSpan.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/SimpleRawSpan.swift
@@ -1,16 +1,26 @@
 // REQUIRES: swift_swift_parser
 
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -strict-memory-safety -warnings-as-errors
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
 
+// RUN: %target-swift-frontend %t/test.swift -emit-module -plugin-path %swift-plugin-dir -strict-memory-safety -verify
+// RUN: env SWIFT_BACKTRACE="" %target-swift-frontend %t/test.swift -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2> %t/expansions.out
+// RUN: %diff %t/expansions.out %t/expansions.expected
+
+//--- test.swift
 @_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size"), .nonescaping(pointer: .param(1)))
-func myFunc(_ ptr: UnsafeRawPointer, _ size: CInt) {
+public func myFunc(_ ptr: UnsafeRawPointer, _ size: CInt) {
 }
 
-// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func myFunc(_ ptr: RawSpan) {
-// CHECK-NEXT:     let size = CInt(exactly: ptr.byteCount)!
-// CHECK-NEXT:     return unsafe ptr.withUnsafeBytes { _ptrPtr in
-// CHECK-NEXT:       return unsafe myFunc(_ptrPtr.baseAddress!, size)
-// CHECK-NEXT:     }
-// CHECK-NEXT: }
+//--- expansions.expected
+@__swiftmacro_4test6myFunc15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func myFunc(_ ptr: RawSpan) {
+    let size = CInt(exactly: ptr.byteCount)!
+    return unsafe ptr.withUnsafeBytes { _ptrPtr in
+      return unsafe myFunc(_ptrPtr.baseAddress!, size)
+    }
+}
+------------------------------

--- a/test/Macros/SwiftifyImport/SizedBy/SimpleRawSpan.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/SimpleRawSpan.swift
@@ -19,8 +19,9 @@ public func myFunc(_ ptr: UnsafeRawPointer, _ size: CInt) {
 @_alwaysEmitIntoClient @_disfavoredOverload
 public func myFunc(_ ptr: RawSpan) {
     let size = CInt(exactly: ptr.byteCount)!
-    return unsafe ptr.withUnsafeBytes { _ptrPtr in
-      return unsafe myFunc(_ptrPtr.baseAddress!, size)
+    let _ptrPtr = unsafe ptr.withUnsafeBytes {
+        unsafe $0
     }
+    return unsafe myFunc(_ptrPtr.baseAddress!, size)
 }
 ------------------------------

--- a/test/Macros/SwiftifyImport/SizedBy/SimpleRawSpanWithReturn.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/SimpleRawSpanWithReturn.swift
@@ -20,8 +20,9 @@ public func myFunc(_ ptr: UnsafeRawPointer, _ size: CInt) -> CInt {
 @_alwaysEmitIntoClient @_disfavoredOverload
 public func myFunc(_ ptr: RawSpan) -> CInt {
     let size = CInt(exactly: ptr.byteCount)!
-    return unsafe ptr.withUnsafeBytes { _ptrPtr in
-      return unsafe myFunc(_ptrPtr.baseAddress!, size)
+    let _ptrPtr = unsafe ptr.withUnsafeBytes {
+        unsafe $0
     }
+    return unsafe myFunc(_ptrPtr.baseAddress!, size)
 }
 ------------------------------

--- a/test/Macros/SwiftifyImport/SizedBy/SimpleRawSpanWithReturn.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/SimpleRawSpanWithReturn.swift
@@ -1,16 +1,27 @@
 // REQUIRES: swift_swift_parser
 
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -strict-memory-safety -warnings-as-errors
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
 
+// RUN: %target-swift-frontend %t/test.swift -emit-module -plugin-path %swift-plugin-dir -strict-memory-safety -verify
+// RUN: env SWIFT_BACKTRACE="" %target-swift-frontend %t/test.swift -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2> %t/expansions.out
+// RUN: %diff %t/expansions.out %t/expansions.expected
+
+//--- test.swift
 @_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size"), .nonescaping(pointer: .param(1)))
-func myFunc(_ ptr: UnsafeRawPointer, _ size: CInt) -> CInt {
+public func myFunc(_ ptr: UnsafeRawPointer, _ size: CInt) -> CInt {
+// expected-error@+1{{missing return in global function expected to return 'CInt' (aka 'Int32')}}
 }
 
-// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func myFunc(_ ptr: RawSpan) -> CInt {
-// CHECK-NEXT:     let size = CInt(exactly: ptr.byteCount)!
-// CHECK-NEXT:     return unsafe ptr.withUnsafeBytes { _ptrPtr in
-// CHECK-NEXT:       return unsafe myFunc(_ptrPtr.baseAddress!, size)
-// CHECK-NEXT:     }
-// CHECK-NEXT: }
+//--- expansions.expected
+@__swiftmacro_4test6myFunc15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func myFunc(_ ptr: RawSpan) -> CInt {
+    let size = CInt(exactly: ptr.byteCount)!
+    return unsafe ptr.withUnsafeBytes { _ptrPtr in
+      return unsafe myFunc(_ptrPtr.baseAddress!, size)
+    }
+}
+------------------------------

--- a/test/Macros/SwiftifyImport/SizedBy/SizeExpr.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/SizeExpr.swift
@@ -1,16 +1,27 @@
 // REQUIRES: swift_swift_parser
 
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -strict-memory-safety -warnings-as-errors -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
 
+// RUN: %target-swift-frontend %t/test.swift -emit-module -plugin-path %swift-plugin-dir -strict-memory-safety -verify
+// RUN: env SWIFT_BACKTRACE="" %target-swift-frontend %t/test.swift -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2> %t/expansions.out
+// RUN: %diff %t/expansions.out %t/expansions.expected
+
+//--- test.swift
 @_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size * count"))
-func myFunc(_ ptr: UnsafeRawPointer, _ size: CInt, _ count: CInt) {
+public func myFunc(_ ptr: UnsafeRawPointer, _ size: CInt, _ count: CInt) {
 }
 
-// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func myFunc(_ ptr: UnsafeRawBufferPointer, _ size: CInt, _ count: CInt) {
-// CHECK-NEXT:     let _ptrCount = ptr.count
-// CHECK-NEXT:     if _ptrCount != size * count {
-// CHECK-NEXT:       fatalError("bounds check failure in myFunc: expected \(size * count) but got \(_ptrCount)")
-// CHECK-NEXT:     }
-// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, size, count)
-// CHECK-NEXT: }
+//--- expansions.expected
+@__swiftmacro_4test6myFunc15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func myFunc(_ ptr: UnsafeRawBufferPointer, _ size: CInt, _ count: CInt) {
+    let _ptrCount = ptr.count
+    if _ptrCount != size * count {
+      fatalError("bounds check failure in myFunc: expected \(size * count) but got \(_ptrCount)")
+    }
+    return unsafe myFunc(ptr.baseAddress!, size, count)
+}
+------------------------------

--- a/test/Macros/SwiftifyImport/SizedBy/TypedPointer.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/TypedPointer.swift
@@ -106,9 +106,10 @@ public func exprReturn(_ size: CInt, _ count: CInt) -> UnsafeMutableRawBufferPoi
 @_alwaysEmitIntoClient @_disfavoredOverload
 public func constParamNoreturn(_ ptr: RawSpan) {
     let size = CInt(exactly: ptr.byteCount)!
-    return unsafe ptr.withUnsafeBytes { _ptrPtr in
-      return unsafe constParamNoreturn(_ptrPtr.baseAddress!.assumingMemoryBound(to: CChar.self), size)
+    let _ptrPtr = unsafe ptr.withUnsafeBytes {
+        unsafe $0
     }
+    return unsafe constParamNoreturn(_ptrPtr.baseAddress!.assumingMemoryBound(to: CChar.self), size)
 }
 ------------------------------
 @__swiftmacro_4test16mutParamNoreturn15_SwiftifyImportfMp_.swift
@@ -117,9 +118,10 @@ public func constParamNoreturn(_ ptr: RawSpan) {
 @_alwaysEmitIntoClient @_lifetime(ptr: copy ptr) @_disfavoredOverload
 public func mutParamNoreturn(_ ptr: inout MutableRawSpan) {
     let size = CInt(exactly: ptr.byteCount)!
-    return unsafe ptr.withUnsafeMutableBytes { _ptrPtr in
-      return unsafe mutParamNoreturn(_ptrPtr.baseAddress!.assumingMemoryBound(to: UInt8.self), size)
+    let _ptrPtr = unsafe ptr.withUnsafeMutableBytes {
+        unsafe $0
     }
+    return unsafe mutParamNoreturn(_ptrPtr.baseAddress!.assumingMemoryBound(to: UInt8.self), size)
 }
 ------------------------------
 @__swiftmacro_4test21constReturnDependence15_SwiftifyImportfMp_.swift
@@ -128,9 +130,10 @@ public func mutParamNoreturn(_ ptr: inout MutableRawSpan) {
 @_alwaysEmitIntoClient @_lifetime(copy ptr) @_disfavoredOverload
 public func constReturnDependence(_ ptr: RawSpan) -> RawSpan {
     let size = CInt(exactly: ptr.byteCount)!
-    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe ptr.withUnsafeBytes { _ptrPtr in
-      return unsafe constReturnDependence(size, _ptrPtr.baseAddress!.assumingMemoryBound(to: UInt8.self))
-            }, byteCount: Int(size)), copying: ())
+    let _ptrPtr = unsafe ptr.withUnsafeBytes {
+        unsafe $0
+    }
+    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe constReturnDependence(size, _ptrPtr.baseAddress!.assumingMemoryBound(to: UInt8.self)), byteCount: Int(size)), copying: ())
 }
 ------------------------------
 @__swiftmacro_4test19mutReturnDependence15_SwiftifyImportfMp_.swift
@@ -139,8 +142,9 @@ public func constReturnDependence(_ ptr: RawSpan) -> RawSpan {
 @_alwaysEmitIntoClient @_lifetime(copy ptr) @_lifetime(ptr: copy ptr) @_disfavoredOverload
 public func mutReturnDependence(_ ptr: inout MutableRawSpan) -> MutableRawSpan {
     let size = CInt(exactly: ptr.byteCount)!
-    return unsafe _swiftifyOverrideLifetime(MutableRawSpan(_unsafeStart: unsafe ptr.withUnsafeMutableBytes { _ptrPtr in
-      return unsafe mutReturnDependence(size, _ptrPtr.baseAddress!.assumingMemoryBound(to: UInt8.self))
-            }, byteCount: Int(size)), copying: ())
+    let _ptrPtr = unsafe ptr.withUnsafeMutableBytes {
+        unsafe $0
+    }
+    return unsafe _swiftifyOverrideLifetime(MutableRawSpan(_unsafeStart: unsafe mutReturnDependence(size, _ptrPtr.baseAddress!.assumingMemoryBound(to: UInt8.self)), byteCount: Int(size)), copying: ())
 }
 ------------------------------

--- a/test/Macros/SwiftifyImport/SizedBy/Unwrapped.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/Unwrapped.swift
@@ -1,13 +1,24 @@
 // REQUIRES: swift_swift_parser
 
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -strict-memory-safety -warnings-as-errors -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
 
+// RUN: %target-swift-frontend %t/test.swift -emit-module -plugin-path %swift-plugin-dir -strict-memory-safety -verify
+// RUN: env SWIFT_BACKTRACE="" %target-swift-frontend %t/test.swift -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions 2> %t/expansions.out
+// RUN: %diff %t/expansions.out %t/expansions.expected
+
+//--- test.swift
 @_SwiftifyImport(.sizedBy(pointer: .param(1), size: "len"))
-func myFunc(_ ptr: UnsafeRawPointer!, _ len: CInt) {
+public func myFunc(_ ptr: UnsafeRawPointer!, _ len: CInt) {
 }
 
-// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func myFunc(_ ptr: UnsafeRawBufferPointer) {
-// CHECK-NEXT:     let len = CInt(exactly: ptr.count)!
-// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, len)
-// CHECK-NEXT: }
+//--- expansions.expected
+@__swiftmacro_4test6myFunc15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload
+public func myFunc(_ ptr: UnsafeRawBufferPointer) {
+    let len = CInt(exactly: ptr.count)!
+    return unsafe myFunc(ptr.baseAddress!, len)
+}
+------------------------------


### PR DESCRIPTION
Main commit:
```
[Swiftify] properly support initializers

This linearizes the macro expansions by leaking the internal buffer
pointer in [Mutable][Raw]Span parameters. This avoids the closure-based
nesting, simplifying the function body, but more importantly avoids an
error when the function is an intializer: Swift does not allow calls to
delegated initializers inside other expressions or closures.

Initializers for CoreFoundation-style references are not allowed at all
(other than the ones imported from C), so safe wrappers on those are
avoided entirely.

rdar://169661706
```

To simplify updating all the test cases, this also contains:
```
[Swiftify] modernize test cases (NFC)

This updates test cases in test/Macros/SwiftifyImport to use -verify
instead of -warnings-as-errors, diff instead of FileCheck, and removes
-disableAvailabilityChecking, which silences more errors than just
availability. This requires making functions public, since
@_alwaysEmitIntoClient functions cannot refer to non-public functions.

This will make it easier to update the macro in the next commit, since
the tests are now compatible with --update-tests.
```

The changes are tested in test/Interop/C/swiftify-import/import-as-instance-method.swift, the rest is mostly noise. I recommend reviewing the commits one by one.