### PR TITLE
[DebugInfo] Relax check-next in yielding_mutate.swift

### DIFF
--- a/test/DebugInfo/yielding_mutate.swift
+++ b/test/DebugInfo/yielding_mutate.swift
@@ -22,7 +22,7 @@ var state = S()
 // CHECK: %[[call_result:.*]] = call swiftcc { ptr, ptr } %[[coro]]
 // CHECK: %[[continuation_ptr:.*]] = extractvalue  { ptr, ptr } %[[call_result]]
 // CHECK: call {{.*}} @{{.*}}USE{{.*}}, !dbg ![[DBG:.*]]
-// CHECK-NEXT: call swiftcc void %[[continuation_ptr]]{{.*}}, !dbg ![[DBG]]
+// CHECK: call swiftcc void %[[continuation_ptr]]{{.*}}, !dbg ![[DBG]]
 USE(&state.computed_property)
 FINISH()
 // CHECK: call swiftcc void @"{{.*}}FINISH


### PR DESCRIPTION
This is too strict for targets that generate authentication instructions.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
