### PR TITLE
[cxx-interop] Import the locations of ObjC methods

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -5440,10 +5440,11 @@ namespace {
         }
       }
 
-      auto result = createFuncOrAccessor(Impl,
-                                         /*funcLoc*/ SourceLoc(), accessorInfo,
-                                         importedName.getDeclName(),
-                                         /*nameLoc*/ SourceLoc(),
+      auto loc = Impl.importSourceLoc(decl->getLocation());
+      // FIXME: more precise source location.
+      auto nameLoc = loc;
+      auto result = createFuncOrAccessor(Impl, loc, accessorInfo,
+                                         importedName.getDeclName(), nameLoc,
                                          /*genericParams=*/nullptr, bodyParams,
                                          resultTy, async, throws, dc, decl);
 

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -6459,17 +6459,11 @@ static void diagnoseCxxFunctionCalls(const Expr *E, const DeclContext *DC) {
         return Action::Continue(E);
 
       if (shouldDiagnoseMissingReturnsRetained(ND, retType, Ctx)) {
-        SourceLoc diagnosticLoc = func->getLoc();
-        if (diagnosticLoc.isInvalid() && func->getClangDecl()) {
-          // FIXME: Remove the diagnosticLoc once the source locations of the
-          // objc method declarations are imported correctly.
-          diagnosticLoc = Ctx.getClangModuleLoader()->importSourceLocation(
-              ND->getLocation());
-        }
-
         Ctx.Diags.diagnose(CE->getLoc(),
                            diag::warn_unannotated_cxx_func_returning_frt, func);
 
+        SourceLoc diagnosticLoc = func->getLoc();
+        ASSERT(diagnosticLoc.isValid());
         Ctx.Diags.diagnose(diagnosticLoc,
                            diag::note_unannotated_cxx_func_returning_frt, func);
       }

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -73,13 +73,13 @@ typedef void (^NonsendableCompletionHandler)(NSString * _Nullable, NSString * _N
 
 -(void)customizedWithString:(NSString *)operation completionHandler:(void (^)(NSInteger))handler __attribute__((swift_name("customize(with:completionHandler:)"))) __attribute__((swift_async_name("customize(_:)")));
 
--(void)unavailableMethod __attribute__((__swift_attr__("@_unavailableFromAsync")));
--(void)unavailableMethodWithMessage __attribute__((__swift_attr__("@_unavailableFromAsync(message: \"Blarpy!\")")));
+-(void)unavailableMethod __attribute__((__swift_attr__("@_unavailableFromAsync"))); // expected-note {{'unavailableMethod()' declared here}}
+-(void)unavailableMethodWithMessage __attribute__((__swift_attr__("@_unavailableFromAsync(message: \"Blarpy!\")"))); // expected-note {{'unavailableMethodWithMessage()' declared here}}
 
 -(void)dance:(NSString *)step andThen:(void (^)(NSString *))doSomething __attribute__((swift_async(not_swift_private,2)));
 -(void)leap:(NSInteger)height andThen:(void (^)(NSString *))doSomething __attribute__((swift_async(swift_private,2)));
 
--(void)repeatTrick:(NSString *)trick completionHandler:(void (^)(NSInteger))handler __attribute__((swift_async(none)));
+-(void)repeatTrick:(NSString *)trick completionHandler:(void (^)(NSInteger))handler __attribute__((swift_async(none))); // expected-note {{'repeatTrick(_:completionHandler:)' declared here}}
 
 -(void)doSomethingSlowNullably:(NSString *)operation completionHandler:(void (^ _Nullable)(NSInteger))handler;
 -(void)findAnswerNullably:(NSString *)operation completionHandler:(void (^ _Nullable)(NSString *))handler;
@@ -208,7 +208,8 @@ __attribute__((__swift_attr__("@MainActor")))
 @end
 
 @interface NXButton: NXView
--(void)onButtonPress;
+-(void)onButtonPress; // expected-note {{calls to instance method 'onButtonPress()' from outside of its actor context are implicitly asynchronous}}
+                      // expected-note @-1 {{main actor isolation inferred from inheritance from class 'NXView'}}
 @end
 
 // Do something concurrently, but without escaping.

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift
@@ -50,7 +50,7 @@ var x: FooClassBase
 // RUN:      == -req=cursor -pos=210:15 | %FileCheck -check-prefix=CHECK2 %s
 // The cursor points inside the interface, see 'gen_clang_module.swift.response'
 
-// CHECK2: source.lang.swift.decl.function.method.instance ({{.*}}Foo.framework/Headers/Foo.h:170:10-170:27)
+// CHECK2: source.lang.swift.decl.function.method.instance ({{.*}}Foo.framework/Headers/Foo.h:170:1-170:2)
 // CHECK2: fooInstanceFunc0
 // CHECK2: c:objc(cs)FooClassDerived(im)fooInstanceFunc0
 // CHECK2: Foo{{$}}

--- a/test/SourceKit/Mixed/cursor_mixed.swift
+++ b/test/SourceKit/Mixed/cursor_mixed.swift
@@ -6,7 +6,7 @@ func test(_ b : Base) {
 // REQUIRES: objc_interop
 // RUN: %sourcekitd-test -req=cursor -pos=3:7 %s -- %s -F %S/Inputs -module-name Mixed -import-underlying-module | %FileCheck %s
 
-// CHECK: source.lang.swift.ref.function.method.instance ({{.*}}Mixed.framework/Headers/Mixed.h:5:9-5:23)
+// CHECK: source.lang.swift.ref.function.method.instance ({{.*}}Mixed.framework/Headers/Mixed.h:5:1-5:22)
 // CHECK: doIt(_:)
 // CHECK: c:objc(cs)Base(im)doIt:
 // CHECK: (Base) -> (Int32) -> ()

--- a/test/SourceKit/Mixed/cursor_mixed_header.swift
+++ b/test/SourceKit/Mixed/cursor_mixed_header.swift
@@ -14,7 +14,7 @@ func test(_ b : BaseInHead) {
 // RUN: %sourcekitd-test -req=cursor -pos=3:7 %s -- %s -module-name Mixed -pch-output-dir %t -import-objc-header %S/Inputs/header.h | %FileCheck %s
 // RUN: stat %t/*.pch
 
-// CHECK: source.lang.swift.ref.function.method.instance ({{.*}}Inputs/header.h:4:9-4:23)
+// CHECK: source.lang.swift.ref.function.method.instance ({{.*}}Inputs/header.h:4:1-4:22)
 // CHECK: doIt(_:)
 // CHECK: c:objc(cs)BaseInHead(im)doIt:
 // CHECK: (BaseInHead) -> (Int32) -> ()


### PR DESCRIPTION
We did not import the source locations for ObjC methods properly but had some workarounds in place for diagnostics.

rdar://158977633
