### PR TITLE
[stdlib] Typed Throws Adoption for Sequence & Dictionary `.filter(_:)`

### DIFF
--- a/stdlib/public/core/Bitset.swift
+++ b/stdlib/public/core/Bitset.swift
@@ -354,13 +354,13 @@ extension _UnsafeBitset.Word: @unsafe Sequence, @unsafe IteratorProtocol {
 extension _UnsafeBitset {
   @_alwaysEmitIntoClient
   @inline(__always)
-  internal static func _withTemporaryUninitializedBitset<R>(
+  internal static func _withTemporaryUninitializedBitset<R, E: Error>(
     wordCount: Int,
-    body: (_UnsafeBitset) throws -> R
-  ) rethrows -> R {
+    body: (_UnsafeBitset) throws(E) -> R
+  ) throws(E) -> R {
     try unsafe withUnsafeTemporaryAllocation(
       of: _UnsafeBitset.Word.self, capacity: wordCount
-    ) { buffer in
+    ) { (buffer: UnsafeMutableBufferPointer<_UnsafeBitset.Word>) throws(E) -> R in
       let bitset = unsafe _UnsafeBitset(
         words: buffer.baseAddress!, wordCount: buffer.count)
       return try unsafe body(bitset)
@@ -369,14 +369,14 @@ extension _UnsafeBitset {
 
   @_alwaysEmitIntoClient
   @inline(__always)
-  internal static func withTemporaryBitset<R>(
+  internal static func withTemporaryBitset<R, E: Error>(
     capacity: Int,
-    body: (_UnsafeBitset) throws -> R
-  ) rethrows -> R {
+    body: (_UnsafeBitset) throws(E) -> R
+  ) throws(E) -> R {
     let wordCount = unsafe Swift.max(1, Self.wordCount(forCapacity: capacity))
     return try unsafe _withTemporaryUninitializedBitset(
       wordCount: wordCount
-    ) { bitset in
+    ) { (bitset: _UnsafeBitset) throws(E) -> R in
       unsafe bitset.clear()
       return try unsafe body(bitset)
     }
@@ -386,13 +386,13 @@ extension _UnsafeBitset {
 extension _UnsafeBitset {
   @_alwaysEmitIntoClient
   @inline(__always)
-  internal static func withTemporaryCopy<R>(
+  internal static func withTemporaryCopy<R, E: Error>(
     of original: _UnsafeBitset,
-    body: (_UnsafeBitset) throws -> R
-  ) rethrows -> R {
+    body: (_UnsafeBitset) throws(E) -> R
+  ) throws(E) -> R {
     try unsafe _withTemporaryUninitializedBitset(
       wordCount: original.wordCount
-    ) { bitset in
+    ) { (bitset: _UnsafeBitset) throws(E) -> R in
       unsafe bitset.words.initialize(from: original.words, count: original.wordCount)
       return try unsafe body(bitset)
     }

--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -848,12 +848,12 @@ extension _NativeDictionary { // High-level operations
   }
 
   @_alwaysEmitIntoClient
-  internal func filter(
-    _ isIncluded: (Element) throws -> Bool
-  ) rethrows -> _NativeDictionary<Key, Value> {
+  internal func filter<E: Error>(
+    _ isIncluded: (Element) throws(E) -> Bool
+  ) throws(E) -> _NativeDictionary<Key, Value> {
     try unsafe _UnsafeBitset.withTemporaryBitset(
       capacity: _storage._bucketCount
-    ) { bitset in
+    ) { (bitset: _UnsafeBitset) throws(E) -> _NativeDictionary<Key, Value> in
       var count = 0
       for unsafe bucket in unsafe hashTable {
         if try unsafe isIncluded(

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -736,17 +736,30 @@ extension Sequence {
   /// - Returns: An array of the elements that `isIncluded` allowed.
   ///
   /// - Complexity: O(*n*), where *n* is the length of the sequence.
-  @inlinable
-  public __consuming func filter(
-    _ isIncluded: (Element) throws -> Bool
-  ) rethrows -> [Element] {
+  @_alwaysEmitIntoClient
+  public __consuming func filter<E>(
+    _ isIncluded: (Element) throws(E) -> Bool
+  ) throws(E) -> [Element] {
     return try _filter(isIncluded)
   }
 
-  @_transparent
-  public func _filter(
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @abi(
+    __consuming func filter(
+      _ isIncluded: (Element) throws -> Bool
+    ) throws -> [Element]
+  )
+  @usableFromInline
+  internal __consuming func __legacyABI_filter(
     _ isIncluded: (Element) throws -> Bool
-  ) rethrows -> [Element] {
+  ) throws -> [Element] {
+    try filter(isIncluded)
+  }
+
+  @_alwaysEmitIntoClient  @inline(__always)
+  public func _filter<E>(
+    _ isIncluded: (Element) throws(E) -> Bool
+  ) throws(E) -> [Element] {
 
     var result = ContiguousArray<Element>()
 
@@ -759,6 +772,19 @@ extension Sequence {
     }
 
     return Array(result)
+  }
+
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @abi(
+    __consuming func _filter(
+      _ isIncluded: (Element) throws -> Bool
+    ) throws -> [Element]
+  )
+  @usableFromInline
+  internal __consuming func __legacyABI_underscore_filter(
+    _ isIncluded: (Element) throws -> Bool
+  ) throws -> [Element] {
+    try _filter(isIncluded)
   }
 
   /// A value less than or equal to the number of elements in the sequence,

--- a/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
@@ -363,6 +363,8 @@ Func ContiguousArray.withUnsafeBufferPointer(_:) is now without rethrows
 Func ContiguousArray.withUnsafeMutableBufferPointer(_:) has generic signature change from <Element, R> to <Element, R, E where E : Swift.Error>
 Func ContiguousArray.withUnsafeMutableBufferPointer(_:) has parameter 0 type change from (inout Swift.UnsafeMutableBufferPointer<Element>) throws -> R to (inout Swift.UnsafeMutableBufferPointer<Element>) throws(E) -> R
 Func ContiguousArray.withUnsafeMutableBufferPointer(_:) is now without rethrows
+Func Dictionary.filter(_:) has generic signature change from <Key, Value where Key : Swift.Hashable> to <Key, Value, E where Key : Swift.Hashable, E : Swift.Error>
+Func Dictionary.filter(_:) is now without rethrows
 
 // Adoption of @_addressableForDependencies
 Struct CollectionOfOne is now with @_addressableForDependencies

--- a/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
@@ -38,6 +38,8 @@ Func AnySequence.map(_:) has generic signature change from <Element, T> to <Elem
 Func AnySequence.map(_:) is now without rethrows
 Func Collection.map(_:) has generic signature change from <Self, T where Self : Swift.Collection> to <Self, T, E where Self : Swift.Collection, E : Swift.Error>
 Func Collection.map(_:) is now without rethrows
+Func Sequence.filter(_:) has generic signature change from <Self where Self : Swift.Sequence> to <Self, E where Self : Swift.Sequence, E : Swift.Error>
+Func Sequence.filter(_:) is now without rethrows
 Func Sequence.map(_:) has generic signature change from <Self, T where Self : Swift.Sequence> to <Self, T, E where Self : Swift.Sequence, E : Swift.Error>
 Func Sequence.map(_:) is now without rethrows
 Func withUnsafeMutablePointer(to:_:) is now without rethrows

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -90,6 +90,8 @@ Func AnyCollection.map(_:) has been removed
 Func AnyRandomAccessCollection.map(_:) has been removed
 Func AnySequence.map(_:) has been removed
 Func Collection.map(_:) has been removed
+Func Sequence._filter(_:) has been removed
+Func Sequence.filter(_:) has been removed
 Func Sequence.map(_:) has been removed
 Constructor Result.init(catching:) has been removed
 Func withoutActuallyEscaping(_:do:) has been renamed to Func __abi_withoutActuallyEscaping(_:do:)

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -824,6 +824,7 @@ Constructor Array.init(_unsafeUninitializedCapacity:initializingWith:) has been 
 Func Array.withUnsafeBufferPointer(_:) has been removed
 Func ArraySlice.withUnsafeBufferPointer(_:) has been removed
 Func ContiguousArray.withUnsafeBufferPointer(_:) has been removed
+Func Dictionary.filter(_:) has been removed
 
 Struct String.Index has added a conformance to an existing protocol CustomDebugStringConvertible
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar36838495.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar36838495.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-scope-threshold=2000
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=2010
 // REQUIRES: tools-release,no_asan
 // REQUIRES: OS=macosx
 

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -2026,6 +2026,26 @@ DictionaryTestSuite.test("filter(_:)") {
   expectNil(d2[5])
 }
 
+DictionaryTestSuite.test("filter(_:) pt. 2") {
+  let d1 = [1: 1, 2: 2, 3: 100, 4: 4, 5: 100, 6: 6]
+
+  struct AnError: Error, Equatable {}
+
+  do throws(AnError) {
+    let d2 = try d1.filter() {
+      key, value throws(AnError) -> Bool in
+      if key.isMultiple(of: 3) {
+        throw AnError()
+      }
+      return key == value
+    }
+    expectUnreachable()
+    _ = d2
+  } catch {
+    expectEqual(error, AnError())
+  }
+}
+
 DictionaryTestSuite.test("capacity/init(minimumCapacity:)") {
   let d0 = Dictionary<String, Int>(minimumCapacity: 0)
   expectGE(d0.capacity, 0)


### PR DESCRIPTION
Adopts typed throws for `Sequence.filter(_:)` and `Dictionary.filter(_:)`.