### PR TITLE
[AutoDiff] Initial support for differentiable curry

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -726,6 +726,11 @@ public:
   /// the given generic signature.
   bool isBitwiseCopyable(GenericSignature sig);
 
+  /// Returns true if this contextual type satisfies a conformance to
+  /// Differentiable. If `tangentVectorEqualsSelf` is true, also check
+  /// whether the given type satisfies `TangentVector == Self`.
+  bool isDifferentiable(bool tangentVectorEqualsSelf = false);
+
   /// Are values of this type essentially just class references,
   /// possibly with some sort of additional information?
   ///
@@ -4030,6 +4035,8 @@ public:
     return containsPackExpansionType(getParams());
   }
 
+  bool isSupportedAsDifferentiableClosure() const;
+
   static bool containsPackExpansionType(ArrayRef<Param> params);
 
   static void printParams(ArrayRef<Param> Params, raw_ostream &OS,
@@ -6221,7 +6228,9 @@ public:
   /// Return the unsubstituted function type equivalent to this type; that is, the type that has the same
   /// argument and result types as `this` type after substitutions, if any.
   CanSILFunctionType getUnsubstitutedType(SILModule &M) const;
-                                    
+
+  bool isSupportedAsDifferentiableClosure() const;
+
   void Profile(llvm::FoldingSetNodeID &ID) {
     Profile(ID, getInvocationGenericSignature(),
             getExtInfo(), getCoroutineKind(), getCalleeConvention(),

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -3272,6 +3272,8 @@ public:
   
   /// Visit the instructions that end the lifetime of an OSSA on-stack closure.
   bool visitOnStackLifetimeEnds(llvm::function_ref<bool (Operand*)> func) const;
+
+  bool isSupportedAsDifferentiableClosure() const;
 };
 
 class EndApplyInst;

--- a/include/swift/SILOptimizer/Differentiation/Common.h
+++ b/include/swift/SILOptimizer/Differentiation/Common.h
@@ -320,6 +320,14 @@ public:
   }
 };
 
+inline bool isApplySiteOfDifferentiableClosure(FullApplySite applySite) {
+  if (applySite.getKind() != FullApplySiteKind::ApplyInst)
+    return false;
+  auto callee = cast<ApplyInst>(applySite.getInstruction())->getCallee();
+  auto silFunctionType = callee->getType().getAs<SILFunctionType>();
+  return silFunctionType->isSupportedAsDifferentiableClosure();
+}
+
 } // end namespace swift
 
 #endif // SWIFT_SILOPTIMIZER_MANDATORY_DIFFERENTIATION_COMMON_H

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -4903,6 +4903,22 @@ void AnyFunctionType::relabelParams(MutableArrayRef<Param> params,
   }
 }
 
+bool AnyFunctionType::isSupportedAsDifferentiableClosure() const {
+  // Right now, we only support closures capturing exactly one argument with the
+  // type equal to the result type. No other arguments except the captured one
+  // are supported.
+  // TODO: support arbitrary captured and non-captured arguments types.
+  if (getNumParams() != 0)
+    return false;
+
+  // TODO: support this
+  if (getResult()->getCanonicalType()->hasTypeParameter())
+    return false;
+
+  return getResult()->getCanonicalType()->isDifferentiable(
+      /*tangentVectorEqualsSelf=*/true);
+}
+
 /// Profile \p params into \p ID. In contrast to \c == on \c Param, the profile
 /// *does* take the internal label into account and *does not* canonicalize
 /// the param's type.

--- a/lib/AST/ConformanceLookup.cpp
+++ b/lib/AST/ConformanceLookup.cpp
@@ -1008,3 +1008,19 @@ bool TypeBase::isBitwiseCopyable(GenericSignature sig) {
   }
   return contextTy->isBitwiseCopyable();
 }
+
+bool TypeBase::isDifferentiable(bool tangentVectorEqualsSelf) {
+  auto &ctx = getASTContext();
+  auto *differentiableProtocol =
+      ctx.getProtocol(KnownProtocolKind::Differentiable);
+  if (!differentiableProtocol) {
+    return false;
+  }
+  auto conf = checkConformance(this, differentiableProtocol);
+  if (conf.isInvalid())
+    return false;
+  if (!tangentVectorEqualsSelf)
+    return true;
+  auto tanType = conf.getTypeWitnessByName(ctx.Id_TangentVector);
+  return this->isEqual(tanType);
+}

--- a/lib/SILOptimizer/Analysis/DifferentiableActivityAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/DifferentiableActivityAnalysis.cpp
@@ -362,6 +362,9 @@ void DifferentiableActivityInfo::propagateUseful(
     // Propagate usefulness through apply site arguments.
     for (auto arg : applySite.getArgumentsWithoutIndirectResults())
       setUsefulAndPropagateToOperands(arg, i);
+
+    if (isApplySiteOfDifferentiableClosure(applySite))
+      setUsefulAndPropagateToOperands(applySite.getCallee(), i);
   }
   // Handle store-like instructions:
   //   `store`, `store_borrow`, `copy_addr`, `unconditional_checked_cast`

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5935,23 +5935,6 @@ SpecializeAttrTargetDeclRequest::evaluate(Evaluator &evaluator,
   }
 
   return nullptr;
-
-}
-/// Returns true if the given type conforms to `Differentiable` in the given
-/// context. If `tangentVectorEqualsSelf` is true, also check whether the given
-/// type satisfies `TangentVector == Self`.
-static bool conformsToDifferentiable(Type type,
-                                     bool tangentVectorEqualsSelf = false) {
-  auto &ctx = type->getASTContext();
-  auto *differentiableProto =
-      ctx.getProtocol(KnownProtocolKind::Differentiable);
-  auto conf = checkConformance(type, differentiableProto);
-  if (conf.isInvalid())
-    return false;
-  if (!tangentVectorEqualsSelf)
-    return true;
-  auto tanType = conf.getTypeWitnessByName(ctx.Id_TangentVector);
-  return type->isEqual(tanType);
 }
 
 IndexSubset *TypeChecker::inferDifferentiabilityParameters(
@@ -5972,6 +5955,14 @@ IndexSubset *TypeChecker::inferDifferentiabilityParameters(
     if (i >= allParamTypes.size())
       return false;
     auto paramType = allParamTypes[i];
+    if (const auto *anyFunctionType = paramType->getAs<AnyFunctionType>()) {
+      if (!anyFunctionType->isSupportedAsDifferentiableClosure())
+        return false;
+      // Right now we assume that for differentiable closures we capture exactly
+      // one argument and its type is equal to the result type.
+      // TODO: handle arbitrary captured arg types and result types.
+      paramType = anyFunctionType->getResult();
+    }
     if (derivativeGenEnv)
       paramType = derivativeGenEnv->mapTypeIntoEnvironment(paramType);
     else
@@ -5980,7 +5971,7 @@ IndexSubset *TypeChecker::inferDifferentiabilityParameters(
     if (paramType->isExistentialType())
       return false;
     // Return true if the type conforms to `Differentiable`.
-    return conformsToDifferentiable(paramType);
+    return paramType->isDifferentiable();
   };
 
   // Get all parameter types.
@@ -6040,7 +6031,7 @@ static IndexSubset *computeDifferentiabilityParameters(
         selfType = derivativeGenEnv->mapTypeIntoEnvironment(selfType);
       else
         selfType = function->mapTypeIntoEnvironment(selfType);
-      if (!conformsToDifferentiable(selfType)) {
+      if (!selfType->isDifferentiable()) {
         diags
             .diagnose(attrLoc, diag::diff_function_no_parameters, function)
             .highlight(function->getSignatureSourceRange());
@@ -7620,8 +7611,8 @@ static bool checkLinearityParameters(
         parsedLinearParams.empty() ? attrLoc : parsedLinearParams[i].getLoc();
     // Parameter must conform to `Differentiable` and satisfy
     // `Self == Self.TangentVector`.
-    if (!conformsToDifferentiable(linearParamType,
-                                  /*tangentVectorEqualsSelf*/ true)) {
+    if (!linearParamType->isDifferentiable(
+            /*tangentVectorEqualsSelf*/ true)) {
       diags.diagnose(loc,
                      diag::transpose_attr_invalid_linearity_parameter_or_result,
                      linearParamType.getString(), /*isParameter*/ true);
@@ -7732,8 +7723,8 @@ void AttributeChecker::visitTransposeAttr(TransposeAttr *attr) {
   if (expectedOriginalResultType->hasTypeParameter())
     expectedOriginalResultType = transpose->mapTypeIntoEnvironment(
         expectedOriginalResultType);
-  if (!conformsToDifferentiable(expectedOriginalResultType,
-                                /*tangentVectorEqualsSelf*/ true)) {
+  if (!expectedOriginalResultType->isDifferentiable(
+          /*tangentVectorEqualsSelf*/ true)) {
     diagnoseAndRemoveAttr(
         attr, diag::transpose_attr_invalid_linearity_parameter_or_result,
         expectedOriginalResultType.getString(), /*isParameter*/ false);

--- a/test/AutoDiff/SILGen/differentiable_curry.swift
+++ b/test/AutoDiff/SILGen/differentiable_curry.swift
@@ -1,0 +1,65 @@
+// RUN: %target-swift-frontend -Xllvm -sil-print-types -emit-sil %s | %FileCheck %s
+
+import _Differentiation
+
+func foo(_ x: Float, _ y: () -> Float) -> Float {
+  if x > 0 {
+    return y()
+  }
+  return x
+}
+
+@differentiable(reverse)
+func bar(_ x: Float, _ y: Float) -> Float {
+  return foo(x, {y})
+}
+
+// CHECK-LABEL: {{^}}// reverse-mode derivative of bar(_:_:)
+// CHECK:       sil hidden @$s20differentiable_curry3baryS2f_SftFTJrSSpSr : $@convention(thin) (Float, Float) -> (Float, @owned @callee_guaranteed (Float) -> (Float, Float)) {
+// CHECK:       bb0(%0 : $Float, %1 : $Float):
+// CHECK:         // function_ref closure #1 in bar(_:_:)
+// CHECK:         %[[#T4:]] = function_ref @$s20differentiable_curry3baryS2f_SftFSfyXEfU_ : $@convention(thin) (Float) -> Float
+// CHECK:         %[[#T5:]] = differentiability_witness_function [jvp] [reverse] [parameters 0] [results 0] @$s20differentiable_curry3baryS2f_SftFSfyXEfU_ : $@convention(thin) (Float) -> Float
+// CHECK:         %[[#T6:]] = differentiability_witness_function [vjp] [reverse] [parameters 0] [results 0] @$s20differentiable_curry3baryS2f_SftFSfyXEfU_ : $@convention(thin) (Float) -> Float
+// CHECK:         %[[#T7:]] = differentiable_function [parameters 0] [results 0] %[[#T4]] : $@convention(thin) (Float) -> Float with_derivative {%[[#T5]] : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float), %[[#T6]] : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)}
+// CHECK:         %[[#T8:]] = differentiable_function_extract [vjp] %[[#T7]] : $@differentiable(reverse) @convention(thin) (Float) -> Float
+// CHECK:         %[[#T9:]] = partial_apply [callee_guaranteed] [on_stack] %[[#T8]](%1) : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// CHECK:         // function_ref foo(_:_:)
+// CHECK:         %[[#T10:]] = function_ref @$s20differentiable_curry3fooyS2f_SfyXEtF : $@convention(thin) (Float, @guaranteed @noescape @callee_guaranteed () -> Float) -> Float
+// CHECK:         %[[#T11:]] = differentiability_witness_function [jvp] [reverse] [parameters 0 1] [results 0] @$s20differentiable_curry3fooyS2f_SfyXEtF : $@convention(thin) (Float, @guaranteed @noescape @callee_guaranteed () -> Float) -> Float
+// CHECK:         %[[#T12:]] = differentiability_witness_function [vjp] [reverse] [parameters 0 1] [results 0] @$s20differentiable_curry3fooyS2f_SfyXEtF : $@convention(thin) (Float, @guaranteed @noescape @callee_guaranteed () -> Float) -> Float
+// CHECK:         %[[#T13:]] = differentiable_function [parameters 0 1] [results 0] %[[#T10]] : $@convention(thin) (Float, @guaranteed @noescape @callee_guaranteed () -> Float) -> Float with_derivative {%[[#T11]] : $@convention(thin) (Float, @guaranteed @noescape @callee_guaranteed () -> (Float, @owned @callee_guaranteed (Float) -> Float)) -> (Float, @owned @callee_guaranteed (Float, @guaranteed Float) -> Float), %[[#T12]] : $@convention(thin) (Float, @guaranteed @noescape @callee_guaranteed () -> (Float, @owned @callee_guaranteed (Float) -> Float)) -> (Float, @owned @callee_guaranteed (Float) -> (Float, Float))}
+// CHECK:         %[[#T14:]] = differentiable_function_extract [vjp] %[[#T13]] : $@differentiable(reverse) @convention(thin) (Float, @guaranteed @noescape @callee_guaranteed () -> Float) -> Float
+// CHECK:         %[[#T15:]] = apply %[[#T14]](%0, %[[#T9]]) : $@convention(thin) (Float, @guaranteed @noescape @callee_guaranteed () -> (Float, @owned @callee_guaranteed (Float) -> Float)) -> (Float, @owned @callee_guaranteed (Float) -> (Float, Float))
+// ...
+
+// CHECK-LABEL: {{^}}// reverse-mode derivative of foo(_:_:)
+// CHECK:       sil private @$s20differentiable_curry3fooyS2f_SfyXEtFTJrSSpSr : $@convention(thin) (Float, @guaranteed @noescape @callee_guaranteed () -> (Float, @owned @callee_guaranteed (Float) -> Float)) -> (Float, @owned @callee_guaranteed (Float) -> (Float, Float)) {
+// CHECK:       bb0(%0 : $Float, %1 : $@noescape @callee_guaranteed () -> (Float, @owned @callee_guaranteed (Float) -> Float)):
+// CHECK:         cond_br %[[#]], bb1, bb2
+// CHECK:       bb1:
+// CHECK:         %[[#T9:]] = enum $_AD__$s20differentiable_curry3fooyS2f_SfyXEtF_bb1__Pred__src_0_wrt_0_1, #_AD__$s20differentiable_curry3fooyS2f_SfyXEtF_bb1__Pred__src_0_wrt_0_1.bb0!enumelt, %[[#]] : $()
+// CHECK:         %[[#T10:]] = apply %1() : $@noescape @callee_guaranteed () -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// CHECK:         %[[#T11:]] = tuple_extract %[[#T10]] : $(Float, @callee_guaranteed (Float) -> Float), 0
+// CHECK:         %[[#T12:]] = tuple_extract %[[#T10]] : $(Float, @callee_guaranteed (Float) -> Float), 1
+// CHECK:         %[[#T13:]] = tuple $(predecessor: _AD__$s20differentiable_curry3fooyS2f_SfyXEtF_bb1__Pred__src_0_wrt_0_1, @callee_guaranteed (Float) -> Float) (%[[#T9]], %[[#T12]])
+// CHECK:         %[[#T14:]] = enum $_AD__$s20differentiable_curry3fooyS2f_SfyXEtF_bb3__Pred__src_0_wrt_0_1, #_AD__$s20differentiable_curry3fooyS2f_SfyXEtF_bb3__Pred__src_0_wrt_0_1.bb1!enumelt, %[[#T13]] : $(predecessor: _AD__$s20differentiable_curry3fooyS2f_SfyXEtF_bb1__Pred__src_0_wrt_0_1, @callee_guaranteed (Float) -> Float)
+// CHECK:         br bb3(%[[#]] : $Float, %[[#]] : $_AD__$s20differentiable_curry3fooyS2f_SfyXEtF_bb3__Pred__src_0_wrt_0_1)
+// CHECK:       bb2:
+// ...
+// CHECK:       bb3(%[[#]] : $Float, %[[#]] : $_AD__$s20differentiable_curry3fooyS2f_SfyXEtF_bb3__Pred__src_0_wrt_0_1):
+// ...
+
+// CHECK-LABEL: {{^}}// pullback of foo(_:_:)
+// CHECK:       sil private @$s20differentiable_curry3fooyS2f_SfyXEtFTJpSSpSr : $@convention(thin) (Float, @owned _AD__$s20differentiable_curry3fooyS2f_SfyXEtF_bb3__Pred__src_0_wrt_0_1) -> (Float, Float) {
+// CHECK:       bb0(%0 : $Float, %1 : $_AD__$s20differentiable_curry3fooyS2f_SfyXEtF_bb3__Pred__src_0_wrt_0_1):
+// CHECK:         switch_enum %1 : $_AD__$s20differentiable_curry3fooyS2f_SfyXEtF_bb3__Pred__src_0_wrt_0_1, case #_AD__$s20differentiable_curry3fooyS2f_SfyXEtF_bb3__Pred__src_0_wrt_0_1.bb2!enumelt: bb1, case #_AD__$s20differentiable_curry3fooyS2f_SfyXEtF_bb3__Pred__src_0_wrt_0_1.bb1!enumelt: bb2
+// CHECK:       bb1(%[[#]] : $(predecessor: _AD__$s20differentiable_curry3fooyS2f_SfyXEtF_bb2__Pred__src_0_wrt_0_1)):
+// ...
+// CHECK:       bb2(%[[#T15:]] : $(predecessor: _AD__$s20differentiable_curry3fooyS2f_SfyXEtF_bb1__Pred__src_0_wrt_0_1, @callee_guaranteed (Float) -> Float)):
+// CHECK:         %[[#T16:]] = tuple_extract %[[#T15]] : $(predecessor: _AD__$s20differentiable_curry3fooyS2f_SfyXEtF_bb1__Pred__src_0_wrt_0_1, @callee_guaranteed (Float) -> Float), 0
+// CHECK:         %[[#T17:]] = tuple_extract %[[#T15]] : $(predecessor: _AD__$s20differentiable_curry3fooyS2f_SfyXEtF_bb1__Pred__src_0_wrt_0_1, @callee_guaranteed (Float) -> Float), 1
+// CHECK:         %[[#T18:]] = apply %[[#T17]](%0) : $@callee_guaranteed (Float) -> Float
+// CHECK:         strong_release %[[#T17]] : $@callee_guaranteed (Float) -> Float
+// CHECK:         %[[#T20:]] = struct_extract %[[#T18]] : $Float, #Float._value
+// ...

--- a/test/AutoDiff/SILOptimizer/differentiable_curry_errors.swift
+++ b/test/AutoDiff/SILOptimizer/differentiable_curry_errors.swift
@@ -1,0 +1,40 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+
+import _Differentiation
+
+// Nil coalescing overload accepting non-throwing autoclosure
+func ??(_ x: Float?, _ y: @autoclosure () -> Float) -> Float {
+  if x == nil {
+    return y()
+  }
+  return x!
+}
+
+// expected-error @+1 {{function is not differentiable}}
+@differentiable(reverse)
+// expected-note @+1 {{when differentiating this function definition}}
+func errorInoutAlias(ff: F) -> Float {
+  var y = ff.i?.first { $0 >= 0.0 } ?? 0.0
+  while 0.0 < y {
+    // As for now, we do not support differentiation here since `y` is passed as `inout_alias`.
+    // Currently we only support arguments with Object value category.
+    // TODO: support captured argument with Address value category.
+    // expected-note @+1 {{expression is not differentiable}}
+    y = ff.g() ?? y
+  }
+  return y
+}
+
+public struct F: Differentiable {
+  @noDerivative var i: [Float]? {return nil}
+  func g() -> Float? {return nil}
+}
+
+// TODO: support closures capturing multiple arguments
+// expected-error @+1 {{function is not differentiable}}
+@differentiable(reverse)
+// expected-note @+1 {{when differentiating this function definition}}
+func errorManyArgs(_ x: Float?, _ a: Float, _ b: Float) -> Float {
+  // expected-note @+1 {{expression is not differentiable}}
+  return x ?? a + b
+}

--- a/test/AutoDiff/SILOptimizer/differentiation_control_flow_diagnostics.swift
+++ b/test/AutoDiff/SILOptimizer/differentiation_control_flow_diagnostics.swift
@@ -107,6 +107,18 @@ func testNilCoalescingActive(_ maybeX: Float?, y: Float) -> Float {
   return maybeX ?? y
 }
 
+func nilCoalescingNonThrowing(_ x: Float?, _ y: @autoclosure () -> Float) -> Float {
+  if x == nil {
+    return y()
+  }
+  return x!
+}
+
+@differentiable(reverse)
+func testNilCoalescingNonThrowingActive(_ maybeX: Float?, y: Float) -> Float {
+  return nilCoalescingNonThrowing(maybeX, y)
+}
+
 // Test unsupported differentiation of active enum values.
 
 // expected-error @+1 {{function is not differentiable}}

--- a/test/AutoDiff/validation-test/differentiable_curry.swift
+++ b/test/AutoDiff/validation-test/differentiable_curry.swift
@@ -1,0 +1,191 @@
+// RUN: %target-run-simple-swift
+
+// REQUIRES: executable_test
+
+import DifferentiationUnittest
+import StdlibUnittest
+
+var NilCoalescingTests = TestSuite("OptionalDifferentiation")
+
+struct S : AdditiveArithmetic, Differentiable {
+  var x : Float
+  typealias TangentVector = Self
+
+  static func + (lhs: Self, rhs: Self) -> Self {
+    return Self(x: lhs.x + rhs.x)
+  }
+
+  static func - (lhs: Self, rhs: Self) -> Self {
+    return Self(x: lhs.x - rhs.x)
+  }
+
+  static func * (lhs: Self, rhs: Self) -> Self {
+    return Self(x: lhs.x * rhs.x)
+  }
+
+  static var zero: Self { Self(x: 0.0) }
+}
+
+// Note: we do not support throwing closures, so use a custom overload accepting a non-throwing closure
+// Test both implicit differentiation and explicit @differentiable(reverse) attr.
+func ??(_ x: Float?, _ y: @autoclosure () -> Float) -> Float {
+  if x == nil {
+    return y()
+  }
+  return x!
+}
+
+@differentiable(reverse)
+func ??(_ x: Double?, _ y: @autoclosure () -> Double) -> Double {
+  if x == nil {
+    return y()
+  }
+  return x!
+}
+
+func ??(_ x: S?, _ y: @autoclosure () -> S) -> S {
+  if x == nil {
+    return y()
+  }
+  return x!
+}
+
+// Also, test regular closures (both with and without @differentiable(reverse) attr).
+func ??(_ x: Float?, _ y: () -> Float) -> Float {
+  if x == nil {
+    return y()
+  }
+  return x!
+}
+
+@differentiable(reverse)
+func ??(_ x: Double?, _ y: () -> Double) -> Double {
+  if x == nil {
+    return y()
+  }
+  return x!
+}
+
+func ??(_ x: S?, _ y: () -> S) -> S {
+  if x == nil {
+    return y()
+  }
+  return x!
+}
+
+// Ensure that results are identical for lazy and non-lazy evaluation
+func nilCoalescingNonLazy(_ x: Float?, _ y: Float) -> Float {
+  if x == nil {
+    return y
+  }
+  return x!
+}
+
+func nilCoalescingNonLazy(_ x: Double?, _ y: Double) -> Double {
+  if x == nil {
+    return y
+  }
+  return x!
+}
+
+func nilCoalescingNonLazy(_ x: S?, _ y: S) -> S {
+  if x == nil {
+    return y
+  }
+  return x!
+}
+
+NilCoalescingTests.test("Float") {
+  @differentiable(reverse)
+  func lazy1(_ x: Float?, _ y: Float) -> Float {
+    return x ?? y * y
+  }
+
+  @differentiable(reverse)
+  func lazy2(_ x: Float?, _ y: Float) -> Float {
+    return x ?? {y * y}
+  }
+
+  @differentiable(reverse)
+  func nonLazy(_ x: Float?, _ y: Float) -> Float {
+    return nilCoalescingNonLazy(x, y * y)
+  }
+
+  let pbLazy1 = pullback(at: Float?(nil), Float(3), of: lazy1)
+  let lazyResult1 = pbLazy1(Float(1))
+
+  let pbLazy2 = pullback(at: Float?(nil), Float(3), of: lazy2)
+  let lazyResult2 = pbLazy2(Float(1))
+
+  let pbNonLazy = pullback(at: Float?(nil), Float(3), of: nonLazy)
+  let nonLazyResult = pbNonLazy(Float(1))
+
+  let expectedResult = (Optional<Float>.TangentVector(0), Float(6))
+  expectEqual(lazyResult1, expectedResult)
+  expectEqual(lazyResult2, expectedResult)
+  expectEqual(nonLazyResult, expectedResult)
+}
+
+NilCoalescingTests.test("Double") {
+  @differentiable(reverse)
+  func lazy1(_ x: Double?, _ y: Double) -> Double {
+    return x ?? y * y * y
+  }
+
+  @differentiable(reverse)
+  func lazy2(_ x: Double?, _ y: Double) -> Double {
+    return x ?? {y * y * y}
+  }
+
+  @differentiable(reverse)
+  func nonLazy(_ x: Double?, _ y: Double) -> Double {
+    return nilCoalescingNonLazy(x, y * y * y)
+  }
+
+  let pbLazy1 = pullback(at: Double?(nil), Double(4), of: lazy1)
+  let lazyResult1 = pbLazy1(Double(1))
+
+  let pbLazy2 = pullback(at: Double?(nil), Double(4), of: lazy2)
+  let lazyResult2 = pbLazy2(Double(1))
+
+  let pbNonLazy = pullback(at: Double?(nil), Double(4), of: nonLazy)
+  let nonLazyResult = pbNonLazy(Double(1))
+
+  let expectedResult = (Optional<Double>.TangentVector(0), Double(48))
+  expectEqual(lazyResult1, expectedResult)
+  expectEqual(lazyResult2, expectedResult)
+  expectEqual(nonLazyResult, expectedResult)
+}
+
+NilCoalescingTests.test("S") {
+  @differentiable(reverse)
+  func lazy1(_ x: S?, _ y: S) -> S {
+    return x ?? y * y
+  }
+
+  @differentiable(reverse)
+  func lazy2(_ x: S?, _ y: S) -> S {
+    return x ?? {y * y}
+  }
+
+  @differentiable(reverse)
+  func nonLazy(_ x: S?, _ y: S) -> S {
+    return nilCoalescingNonLazy(x, y * y)
+  }
+
+  let pbLazy1 = pullback(at: S?(nil), S(x: 3), of: lazy1)
+  let lazyResult1 = pbLazy1(S(x: 1))
+
+  let pbLazy2 = pullback(at: S?(nil), S(x: 3), of: lazy2)
+  let lazyResult2 = pbLazy2(S(x: 1))
+
+  let pbNonLazy = pullback(at: S?(nil), S(x: 3), of: nonLazy)
+  let nonLazyResult = pbNonLazy(S(x: 1))
+
+  let expectedResult = (Optional<S>.TangentVector(S(x: 0)), S(x: 6))
+  expectEqual(lazyResult1, expectedResult)
+  expectEqual(lazyResult2, expectedResult)
+  expectEqual(nonLazyResult, expectedResult)
+}
+
+runAllTests()


### PR DESCRIPTION
Currently, we only support closures (including autoclosures) meeting the following requirements:

1) the function accepts exactly 1 argument;
2) the closure is constructed by capturing this argument;
3) the result type is equal to the arg type;
4) the arg type conforms to Differentiable and is equal to its TangentVector;
5) the closure is non-throwing.

This is enough to support simple use cases with nil coalescing operator. See test/AutoDiff/validation-test/differentiable_curry.swift

Roadmap for future changes:

1) support generics so we do not need to implement several overloads for
   different Differentiable types;
2) support functions accepting and/or capturing more than 1 argument.
