### PR TITLE
Add brotli support to FoundationNetworking (release 6.2)

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/curl.py
+++ b/utils/swift_build_support/swift_build_support/products/curl.py
@@ -110,6 +110,7 @@ class LibCurl(cmake_product.CMakeProduct):
         self.cmake_options.define('CURL_DISABLE_SMTP', 'YES')
         self.cmake_options.define('CURL_DISABLE_GOPHER', 'YES')
         self.cmake_options.define('CURL_ZLIB', 'YES')
+        self.cmake_options.define('CURL_BROTLI', 'YES')
         self.cmake_options.define('ENABLE_CURL_MANUAL', 'NO')
         self.cmake_options.define('ENABLE_UNIX_SOCKETS', 'NO')
         self.cmake_options.define('ENABLE_THREADED_RESOLVER', 'NO')

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -118,6 +118,9 @@
         "zlib": {
           "remote": { "id": "madler/zlib" }
         },
+        "brotli": {
+          "remote": { "id": "google/brotli" }
+        },
         "mimalloc": {
           "remote": { "id": "microsoft/mimalloc" },
           "platforms": [ "Windows" ]
@@ -177,7 +180,8 @@
                 "curl": "curl-8_9_1",
                 "libxml2": "v2.11.5",
                 "zlib": "v1.3.1",
-                "mimalloc": "v3.0.1"
+                "mimalloc": "v3.0.1",
+                "brotli": "v1.1.0"
             }
         },
         "release/6.2": {
@@ -232,6 +236,7 @@
                 "curl": "curl-8_9_1",
                 "libxml2": "v2.11.5",
                 "zlib": "v1.3.1",
+                "brotli": "v1.1.0",
                 "mimalloc": "v3.0.1"
             }
         },
@@ -441,7 +446,8 @@
                 "curl": "curl-8_9_1",
                 "libxml2": "v2.11.5",
                 "zlib": "v1.3.1",
-                "mimalloc": "v3.0.1"
+                "mimalloc": "v3.0.1",
+                "brotli": "v1.1.0"
             }
         },
         "next" : {
@@ -491,7 +497,8 @@
                 "curl": "curl-8_9_1",
                 "libxml2": "v2.11.5",
                 "zlib": "v1.3.1",
-                "mimalloc": "v3.0.1"
+                "mimalloc": "v3.0.1",
+                "brotli": "v1.1.0"
             }
         }
     }


### PR DESCRIPTION
(this is the 6.2 back port of https://github.com/swiftlang/swift/pull/83441)
(previous draft PR: https://github.com/swiftlang/swift/pull/83836)

Add brotli as a dependency to enable brotli decoding for curl.

brotli is a general purpose compression algorithm used extensively on web. (https://datatracker.ietf.org/doc/html/rfc7932)

brotli support for curl is enabled by integrating the brotli compression library (https://github.com/google/brotli). I've also added some tests for FoundationNetworking in https://github.com/swiftlang/swift-corelibs-foundation/pull/5251 which exercises this feature by

looking at the accept-encoding http header
decoding a brotli encoded payload