### PR TITLE
Fix OSLogOptimization for complete lifetimes in SIL

### DIFF
--- a/test/SILOptimizer/OSLogMandatoryOptTestWithAsserts.swift
+++ b/test/SILOptimizer/OSLogMandatoryOptTestWithAsserts.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -emit-sil -primary-file %s -sil-verify-all 
+
+// REQUIRES: VENDOR=apple
+
+import OSLogTestHelper
+
+// Ensure no SIL verifier error
+public class ActivityHeartbeat {
+  private var lastActivity: Int
+
+  init(now: @escaping () -> Int) {
+    self.lastActivity = now()
+    _osLogTestHelper("ActivityHeartbeat: initialized \(self.lastActivity)")
+  }
+}
+


### PR DESCRIPTION
Complete lifetimes was recently enabled in SIL which requires values to have lifetime ending uses in dead end blocks as well. OSLogOptimization creates copy_value instructions without inserting destroy_value on dead-end paths which triggers a SIL verifier error. 

Resolves rdar://169568625 