### PR TITLE
[cxx-interop] Import record members lazily

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -504,6 +504,9 @@ EXPERIMENTAL_FEATURE(AssumeResilientCxxTypes, true)
 /// Import inherited non-public members when importing C++ classes.
 EXPERIMENTAL_FEATURE(ImportNonPublicCxxMembers, true)
 
+/// Do not import non-field C++ record members until requested from Swift.
+EXPERIMENTAL_FEATURE(ImportCxxMembersLazily, true)
+
 /// `yielding borrow`/`yielding mutate` single-yield coroutine accessors
 // TODO: When this is turned on by default, take care of:
 // * "TODO" around line 8100 of lib/Parse/ParseDecl.cpp

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -425,6 +425,7 @@ UNINTERESTING_FEATURE(LibraryEvolution)
 UNINTERESTING_FEATURE(SafeInteropWrappers)
 UNINTERESTING_FEATURE(AssumeResilientCxxTypes)
 UNINTERESTING_FEATURE(ImportNonPublicCxxMembers)
+UNINTERESTING_FEATURE(ImportCxxMembersLazily)
 UNINTERESTING_FEATURE(CoroutineAccessorsUnwindOnCallerError)
 UNINTERESTING_FEATURE(AllowRuntimeSymbolDeclarations)
 

--- a/lib/ClangImporter/ClangLookup.cpp
+++ b/lib/ClangImporter/ClangLookup.cpp
@@ -64,6 +64,8 @@ using namespace swift;
 namespace {
 /// Collects name lookup results into the given tiny vector, for use in the
 /// various ClangImporter lookup routines.
+///
+/// Validates that the name we looked up matches the resulting imported name.
 class CollectLookupResults {
   DeclName name;
   TinyPtrVector<ValueDecl *> &result;
@@ -73,7 +75,10 @@ public:
       : name(name), result(result) {}
 
   void add(ValueDecl *imported) {
-    result.push_back(imported);
+    // Match by base name, since that is what MemberLookupTable is keyed on for
+    // laziness (i.e., see type of MemberLookupTable::isLazilyComplete).
+    if (imported->getBaseName() == name.getBaseName())
+      result.push_back(imported);
 
     // Expand any macros introduced by the Clang importer.
     imported->visitAuxiliaryDecls([&](Decl *decl) {

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -1964,6 +1964,26 @@ void importer::addEntryToLookupTable(SwiftLookupTable &table,
     }
   }
 
+  if (auto methodDecl = dyn_cast<clang::CXXMethodDecl>(named)) {
+    // If the return type is a template instantiation, it is not possible to
+    // determine safety/unsafety of the method without instantiating the
+    // template. Let's add both safe and unsafe versions of the name to the
+    // lookup table.
+    if (auto returnTy = desugarIfElaborated(methodDecl->getReturnType());
+        isa<clang::TemplateSpecializationType>(returnTy)) {
+      auto importedName = nameImporter.importName(methodDecl, currentVersion);
+      if (importedName && importedName.getDeclName().isSpecial()) {
+        if (StringRef id = importedName.getDeclName().getBaseIdentifier().str();
+            id.starts_with("__") && id.ends_with("Unsafe")) {
+          StringRef safeId = id.drop_front(2).drop_back(6);
+          table.addEntry(
+              DeclBaseName(nameImporter.getContext().getIdentifier(safeId)),
+              named, importedName.getEffectiveContext());
+        }
+      }
+    }
+  }
+
   // Class template instantiations are imported lazily, however, the lookup
   // table must include their mangled name (__CxxTemplateInst...) to make it
   // possible to find these decls during deserialization. For any C++ typedef

--- a/lib/ClangImporter/SwiftLookupTable.h
+++ b/lib/ClangImporter/SwiftLookupTable.h
@@ -283,7 +283,7 @@ const uint16_t SWIFT_LOOKUP_TABLE_VERSION_MAJOR = 1;
 /// Lookup table minor version number.
 ///
 /// When the format changes IN ANY WAY, this number should be incremented.
-const uint16_t SWIFT_LOOKUP_TABLE_VERSION_MINOR = 20; // 64-bit clang serialization IDs
+const uint16_t SWIFT_LOOKUP_TABLE_VERSION_MINOR = 21; // add both safe and unsafe names of C++ methods
 
 /// A lookup table that maps Swift names to the set of Clang
 /// declarations with that particular name.

--- a/test/Interop/Cxx/class/bad-type-members.swift
+++ b/test/Interop/Cxx/class/bad-type-members.swift
@@ -1,0 +1,259 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-clang -c -o /dev/null -Xclang -verify -I %t/Inputs %t/ok.cpp
+// RUN: %target-clang -c -o /dev/null -Xclang -verify=cxx-instantiation -I %t/Inputs %t/err.cpp
+// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}type.h %t%{fs-sep}ok.swift
+// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}type.h %t%{fs-sep}err.swift -verify-additional-prefix swift-
+
+// RUN: %target-swift-ide-test -print-module -module-to-print=Type -I %t/Inputs -source-filename=x -cxx-interoperability-mode=default | %FileCheck %s
+
+//--- Inputs/module.modulemap
+module Type {
+    header "type.h"
+    requires cplusplus
+}
+
+//--- Inputs/type.h
+#pragma once
+
+// cxx-instantiation-note@+3 {{template is declared here}}
+// cxx-instantiation-note@+2 {{template is declared here}}
+// cxx-instantiation-note@+1 {{template is declared here}}
+template <typename T> struct NeedsBool;
+
+template <> struct NeedsBool<bool> {};
+// CHECK:      struct NeedsBool<CBool> {
+// CHECK-NEXT:   init()
+// CHECK-NEXT: }
+
+struct Foo { using foo = int; };
+struct Bar {};
+struct Baz {};
+
+// expected-swift-note@+1 {{'NeedsFoo<Bar>' requested here}}
+template <typename T> struct NeedsFoo {
+  typename T::foo x;
+  // cxx-instantiation-error@-1 {{no type named 'foo' in 'Bar'}}
+  // expected-swift-error@-2 {{no type named 'foo' in 'Bar'}}
+  // cxx-instantiation-error@-3 {{no type named 'foo' in 'Baz'}}
+};
+// CHECK:      struct NeedsFoo<Foo> {
+// CHECK-NEXT:   init(x: Foo.foo)
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   var x: Foo.foo
+// CHECK-NEXT: }
+
+// expected-swift-note@+2 {{declared here}}
+// expected-swift-note@+1 {{declared here}}
+struct UseMe {
+  using GoodBool = NeedsBool<bool>;
+  using GoodFoo = NeedsFoo<Foo>;
+
+  using BadBool = NeedsBool<int>;
+  using BadFoo = NeedsFoo<Bar>;
+  using BadFoo2 = NeedsFoo<Baz>;
+};
+// CHECK:      struct UseMe {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   typealias GoodBool = NeedsBool<CBool>
+// CHECK-NEXT:   typealias GoodFoo = NeedsFoo<Foo>
+// CHECK-NEXT: }
+
+// Test using shadow decls with type aliases
+// expected-swift-note@+2 {{declared here}}
+// expected-swift-note@+1 {{declared here}}
+struct Derived : UseMe {
+  using UseMe::GoodBool;
+  using UseMe::GoodFoo;
+  using UseMe::BadBool;
+  using UseMe::BadFoo2;
+};
+// CHECK:      struct Derived {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   typealias GoodBool = UseMe.GoodBool
+// CHECK-NEXT:   typealias GoodFoo = UseMe.GoodFoo
+// CHECK-NEXT: }
+
+// expected-swift-note@+1 {{declared here}}
+struct FwdContainer {
+  struct Forward;
+  using ForwardAlias = Forward;
+
+  // cxx-instantiation-note@+1 {{forward declaration of}}
+  struct NeverDefined;
+  using UndefinedAlias = NeverDefined;
+};
+struct FwdContainer::Forward {
+  int value;
+};
+// CHECK:      struct FwdContainer {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   typealias ForwardAlias = FwdContainer.Forward
+// CHECK-NEXT:   struct Forward {
+// CHECK-NEXT:     init(value: Int32)
+// CHECK-NEXT:     init()
+// CHECK-NEXT:     var value: Int32
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+
+// expected-swift-note@+2 {{declared here}}
+template <typename T, typename U>
+struct TemplateContainer {
+  using GoodAlias = NeedsBool<T>;
+  using BadAlias = NeedsBool<U>;
+};
+
+using TemplateContainerInst = TemplateContainer<bool, int>;
+// CHECK:      struct TemplateContainer<CBool, CInt> {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   typealias GoodAlias = NeedsBool<CBool>
+// CHECK-NEXT: }
+// CHECK-NEXT: typealias TemplateContainerInst = TemplateContainer<CBool, CInt>
+
+// cxx-instantiation-note@+2 {{forward declaration of}}
+// expected-swift-note@+1 {{forward declaration of}}
+struct IncompleteType;
+
+// Test type alias to template with invalid instantiation
+// expected-swift-note@+2 {{requested here}}
+template <typename T>
+struct RequiresComplete {
+  T value;
+  // cxx-instantiation-error@-1 {{field has incomplete type 'IncompleteType'}}
+  // expected-swift-error@-2 {{field has incomplete type 'IncompleteType'}}
+};
+
+// expected-swift-note@+1 {{declared here}}
+struct UsesInvalidTemplate {
+  using BadTemplate = RequiresComplete<IncompleteType>;
+};
+// CHECK:      struct UsesInvalidTemplate {
+// CHECK-NEXT:   init()
+// CHECK-NEXT: }
+
+// Test type alias to abstract class
+// expected-swift-note@+1 {{'init()' has been explicitly marked unavailable here}}
+struct Abstract {
+  // cxx-instantiation-note@+1 {{unimplemented pure virtual method}}
+  virtual void pureVirtual() = 0;
+};
+// CHECK:      struct Abstract {
+// CHECK-NEXT:   @available(*, unavailable, message: "constructors of abstract C++ classes are unavailable in Swift")
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   @available(*, unavailable, message: "virtual function is not available in Swift because it is pure")
+// CHECK-NEXT:   mutating func pureVirtual()
+// CHECK-NEXT: }
+
+struct UsesAbstract {
+  using AbstractAlias = Abstract;
+};
+// CHECK:      struct UsesAbstract {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   typealias AbstractAlias = Abstract
+// CHECK-NEXT: }
+
+//--- ok.cpp
+// expected-no-diagnostics
+#include <type.h>
+
+void ok(void) {
+  UseMe um;
+  UseMe::GoodBool gb;
+  UseMe::GoodFoo gf;
+
+  Derived dum;
+  Derived::GoodBool dgb;
+  Derived::GoodFoo dgf;
+
+  FwdContainer fc;
+  FwdContainer::ForwardAlias fa;
+
+  TemplateContainerInst tci;
+  TemplateContainerInst::GoodAlias tga;
+
+  UsesInvalidTemplate uit;
+  UsesAbstract ua;
+}
+
+//--- err.cpp
+#include <type.h>
+
+void err(void) {
+  UseMe um;
+  UseMe::GoodBool gb;
+  UseMe::GoodFoo gf;
+  UseMe::BadBool bb; // cxx-instantiation-error {{implicit instantiation of undefined template}}
+  UseMe::BadFoo bf;  // cxx-instantiation-note {{requested here}}
+
+  Derived dum;
+  Derived::GoodBool dgb;
+  Derived::GoodFoo dgf;
+  Derived::BadBool dbb; // cxx-instantiation-error {{implicit instantiation of undefined template}}
+  Derived::BadFoo2 dbf; // cxx-instantiation-note {{requested here}}
+
+  FwdContainer fc;
+  FwdContainer::ForwardAlias fa;
+  FwdContainer::UndefinedAlias fu; // cxx-instantiation-error {{variable has incomplete type}}
+
+  TemplateContainerInst tci;
+  TemplateContainerInst::GoodAlias tga;
+  TemplateContainerInst::BadAlias tba; // cxx-instantiation-error {{implicit instantiation of undefined template}}
+
+  UsesInvalidTemplate uit;
+  UsesInvalidTemplate::BadTemplate ubt; // cxx-instantiation-note {{requested here}}
+
+  UsesAbstract ua;
+  UsesAbstract::AbstractAlias uaa; // cxx-instantiation-error {{is an abstract class}}
+}
+
+//--- ok.swift
+import Type
+
+func ok() {
+  let _: UseMe = UseMe()
+  let _: UseMe.GoodBool = .init()
+  let _: UseMe.GoodFoo = .init()
+
+  let _: Derived = .init()
+  let _: Derived.GoodBool = .init()
+  let _: Derived.GoodFoo = .init()
+
+  let _: FwdContainer = .init()
+  let _: FwdContainer.ForwardAlias = .init()
+
+  let _: TemplateContainerInst = .init()
+  let _: TemplateContainerInst.GoodAlias = .init()
+
+  let _: UsesInvalidTemplate = .init()
+  let _: UsesAbstract = .init()
+}
+
+//--- err.swift
+import Type
+
+func err() {
+  let _: UseMe = UseMe()
+  let _: UseMe.GoodBool = .init()
+  let _: UseMe.GoodFoo = .init()
+  let _: UseMe.BadBool = .init() // expected-swift-error {{not a member type of struct}}
+  let _: UseMe.BadFoo = .init()  // expected-swift-error {{not a member type of struct}}
+
+  let _: Derived = .init()
+  let _: Derived.GoodBool = .init()
+  let _: Derived.GoodFoo = .init()
+  let _: Derived.BadBool = .init() // expected-swift-error {{not a member type of struct}}
+  let _: Derived.BadFoo = .init()  // expected-swift-error {{not a member type of struct}}
+
+  let _: FwdContainer = .init()
+  let _: FwdContainer.ForwardAlias = .init()
+  let _: FwdContainer.UndefinedAlias = .init() // expected-swift-error {{not a member type of struct}}
+
+  let _: TemplateContainerInst = .init()
+  let _: TemplateContainerInst.GoodAlias = .init()
+  let _: TemplateContainerInst.BadAlias = .init() // expected-swift-error {{not a member type of struct}}
+
+  let _: UsesInvalidTemplate = .init()
+  let _: UsesInvalidTemplate.BadTemplate = .init() // expected-swift-error {{not a member type of struct}}
+  let _: UsesAbstract = .init()
+  let _: UsesAbstract.AbstractAlias = .init() // expected-swift-error {{constructors of abstract C++ classes are unavailable}}
+}

--- a/test/Interop/Cxx/class/bad-type-members.swift
+++ b/test/Interop/Cxx/class/bad-type-members.swift
@@ -1,11 +1,27 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
+//
+// Validate usability of type.h in C++ with clang
 // RUN: %target-clang -c -o /dev/null -Xclang -verify -I %t/Inputs %t/ok.cpp
 // RUN: %target-clang -c -o /dev/null -Xclang -verify=cxx-instantiation -I %t/Inputs %t/err.cpp
-// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}type.h %t%{fs-sep}ok.swift
-// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}type.h %t%{fs-sep}err.swift -verify-additional-prefix swift-
+//
+// Compare usability of type.h in Swift with swift-frontend
+// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default \
+// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
+// RUN:   -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}type.h \
+// RUN:   %t%{fs-sep}ok.swift
+// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default \
+// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
+// RUN:   -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}type.h \
+// RUN:   %t%{fs-sep}err.swift -verify-additional-prefix swift-
+//
+// Check module interface of type.h
+// RUN: %target-swift-ide-test -print-module -source-filename=x \
+// RUN:   -cxx-interoperability-mode=default -I %t/Inputs \
+// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
+// RUN:   -module-to-print=Type | %FileCheck %s
 
-// RUN: %target-swift-ide-test -print-module -module-to-print=Type -I %t/Inputs -source-filename=x -cxx-interoperability-mode=default | %FileCheck %s
+// REQUIRES: swift_feature_ImportCxxMembersLazily
 
 //--- Inputs/module.modulemap
 module Type {

--- a/test/Interop/Cxx/class/function-members-with-incomplete-types.swift
+++ b/test/Interop/Cxx/class/function-members-with-incomplete-types.swift
@@ -1,0 +1,218 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+//
+// Validate usability of function.h in C++ with clang
+// RUN: %target-clang -c -o /dev/null -Xclang -verify -I %t/Inputs %t/ok.cpp
+// RUN: %target-clang -c -o /dev/null -Xclang -verify=cxx -I %t/Inputs %t/err.cpp
+//
+// Compare usability of function.h in Swift with swift-frontend
+// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}function.h %t%{fs-sep}ok.swift
+// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}function.h %t%{fs-sep}err.swift -verify-additional-prefix swift-
+//
+// Check module interface of function.h
+// RUN: %target-swift-ide-test -print-module -module-to-print=Function -I %t/Inputs -source-filename=x -cxx-interoperability-mode=default | %FileCheck %s
+
+//--- Inputs/module.modulemap
+module Function {
+  header "function.h"
+  requires cplusplus
+}
+
+//--- Inputs/function.h
+#pragma once
+
+struct Incomplete;
+// cxx-note@-1 {{forward declaration of}}
+// cxx-note@-2 {{forward declaration of}}
+// cxx-note@-3 {{forward declaration of}}
+
+// None of GoodStruct's members should prevent it from being imported sans error
+struct GoodStruct {
+  GoodStruct() = default;
+  GoodStruct(Incomplete);
+
+  // expected-swift-note@+3 {{explicitly marked unavailable here}}
+  // expected-swift-note@+2 {{explicitly marked unavailable here}}
+  // expected-swift-note@+1 {{explicitly marked unavailable here}}
+  Incomplete badReturn() const;
+  // cxx-note@-1 {{declared here}}
+  // cxx-note@-2 {{declared here}}
+  // cxx-note@-3 {{declared here}}
+
+  // expected-swift-note@+2 {{unavailable (cannot import)}}
+  // expected-swift-note@+1 {{unavailable (cannot import)}}
+  void badArg(Incomplete) const;
+
+  // expected-swift-note@+2 {{unavailable (cannot import)}}
+  // expected-swift-note@+1 {{unavailable (cannot import)}}
+  static Incomplete badStatic(Incomplete);
+
+  void overloadsSameNumArgs(int) const;
+  void overloadsSameNumArgs(Incomplete) const;
+
+  // expected-swift-note@+1 {{declared here}}
+  void overloadsDiffNumArgs(int, int) const;
+  void overloadsDiffNumArgs(Incomplete) const;
+
+  int operator+(Incomplete) const;
+
+  Incomplete begin() const;
+  Incomplete end() const;
+};
+// CHECK:      struct GoodStruct {
+// CHECK-NEXT:   init()
+//
+// CHECK-NEXT:   @available(*, unavailable, message: "return type is unavailable in Swift")
+// CHECK-NEXT:   func badReturn() -> Never
+//
+// NOTE-MISSING: func badArg(_: Never)
+//
+// NOTE-MISSING: func badStatic(_: Never) -> Never
+//
+// CHECK-NEXT:   func overloadsSameNumArgs(_: Int32)
+// NOTE-MISSING: func overloadsSameNumArgs(_: Never)
+//
+// CHECK-NEXT:   func overloadsDiffNumArgs(_: Int32, _: Int32)
+// NOTE-MISSING: func overloadsDiffNumArgs(_: Never)
+//
+// NOTE-MISSING: static func +(lhs: GoodStruct, rhs: Never) -> Int32
+//
+// CHECK-NEXT:   @available(*, unavailable, message: "return type is unavailable in Swift")
+// CHECK-NEXT:   func __beginUnsafe() -> Never
+// CHECK-NEXT:   @available(*, unavailable, message: "return type is unavailable in Swift")
+// CHECK-NEXT:   func __endUnsafe() -> Never
+// CHECK-NEXT: }
+
+
+struct DerivedGoodStruct : GoodStruct {};
+// CHECK:      struct DerivedGoodStruct {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   func badReturn() -> Never
+// CHECK-NEXT:   func overloadsSameNumArgs(_: Int32)
+// CHECK-NEXT:   func overloadsDiffNumArgs(_: Int32, _: Int32)
+// CHECK-NEXT:   func __beginUnsafe() -> Never
+// CHECK-NEXT:   func __endUnsafe() -> Never
+// CHECK-NEXT: }
+
+struct UsingGoodStruct : GoodStruct {
+  using GoodStruct::badReturn;
+  using GoodStruct::badArg;
+  using GoodStruct::badStatic;
+};
+
+// CHECK:      struct UsingGoodStruct {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   func badReturn() -> Never
+// CHECK-NEXT:   func overloadsSameNumArgs(_: Int32)
+// CHECK-NEXT:   func overloadsDiffNumArgs(_: Int32, _: Int32)
+// CHECK-NEXT:   func __beginUnsafe() -> Never
+// CHECK-NEXT:   func __endUnsafe() -> Never
+// CHECK-NEXT: }
+
+
+struct UsesGoodStruct {
+  GoodStruct field;
+  GoodStruct returns() const;
+  void takes(GoodStruct) const;
+};
+// CHECK:      struct UsesGoodStruct {
+// CHECK-NEXT:   init(field: GoodStruct)
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   var field: GoodStruct
+// CHECK-NEXT:   func returns() -> GoodStruct
+// CHECK-NEXT:   func takes(_: GoodStruct)
+// CHECK-NEXT: }
+
+//--- ok.cpp
+// expected-no-diagnostics
+#include <function.h>
+
+void ok(void) {
+  GoodStruct gs;
+  DerivedGoodStruct dgs;
+  UsingGoodStruct ugs;
+
+  UsesGoodStruct usgs;
+  auto f = usgs.field;
+  f = usgs.returns();
+  usgs.takes(f);
+}
+
+//--- err.cpp
+#include <function.h>
+
+void err(void) {
+  GoodStruct gs;
+  auto inc = gs.badReturn(); // cxx-error {{with incomplete return type}}
+  gs.badArg(inc);
+  GoodStruct::badStatic(inc);
+
+  DerivedGoodStruct dgs;
+  auto dinc = dgs.badReturn(); // cxx-error {{with incomplete return type}}
+  dgs.badArg(dinc);
+  DerivedGoodStruct::badStatic(dinc);
+
+  UsingGoodStruct ugs;
+  auto uinc = ugs.badReturn(); // cxx-error {{with incomplete return type}}
+  ugs.badArg(uinc);
+  UsingGoodStruct::badStatic(uinc);
+}
+
+//--- ok.swift
+import Function
+
+func ok() {
+  let gs = GoodStruct()
+  gs.overloadsSameNumArgs(42)
+  gs.overloadsDiffNumArgs(42, 24)
+
+  let _ = DerivedGoodStruct()
+  let _ = UsingGoodStruct()
+
+  let usgs = UsesGoodStruct()
+  var f = usgs.field
+  f = usgs.returns()
+  usgs.takes(f)
+}
+
+//--- err.swift
+import Function
+
+func err() {
+  let gs = GoodStruct()
+  let inc = gs.badReturn()  // expected-swift-error {{is unavailable}}
+                            // expected-swift-warning@-1 {{an enum with no cases}}
+                            // expected-swift-note@-2 {{add an explicit type annotation}}
+  gs.badArg(inc)            // expected-swift-error {{has no member}}
+  GoodStruct.badStatic(inc) // expected-swift-error {{has no member}}
+
+  let _ = GoodStruct(inc) // expected-swift-error {{call that takes no arguments}}
+
+  gs.overloadsSameNumArgs(42)
+  gs.overloadsSameNumArgs(inc) // expected-swift-error {{cannot convert value of type 'Never'}}
+
+  gs.overloadsDiffNumArgs(42, 24)
+  gs.overloadsDiffNumArgs(inc) // expected-swift-error {{cannot convert value of type 'Never'}}
+                               // expected-swift-error@-1 {{missing argument for parameter #2 in call}}
+
+  let _ = gs + inc    // expected-swift-error {{binary operator '+' cannot be applied}}
+
+  let _ = gs.begin()  // expected-swift-error {{has no member}}
+                      // expected-swift-note@-1 {{is unavailable}}
+                      // expected-swift-note@-2 {{try using Swift collection APIs instead}}
+  let _ = gs.end()    // expected-swift-error {{has no member}}
+                      // expected-swift-note@-1 {{is unavailable}}
+                      // expected-swift-note@-2 {{try using Swift collection APIs instead}}
+
+  let dgs = DerivedGoodStruct()
+  let dinc = dgs.badReturn()  // expected-swift-error {{is unavailable}}
+                              // expected-swift-warning@-1 {{an enum with no cases}}
+                              // expected-swift-note@-2 {{add an explicit type annotation}}
+  dgs.badArg(dinc)            // expected-swift-error {{has no member}}
+
+  let ugs = UsingGoodStruct()
+  let uinc = ugs.badReturn() // expected-swift-error {{is unavailable}}
+                             // expected-swift-warning@-1 {{an enum with no cases}}
+                             // expected-swift-note@-2 {{add an explicit type annotation}}
+  ugs.badArg(uinc)           // expected-swift-error {{has no member}}
+}

--- a/test/Interop/Cxx/class/function-members-with-invalid-types.swift
+++ b/test/Interop/Cxx/class/function-members-with-invalid-types.swift
@@ -1,0 +1,226 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+//
+// Validate usability of function.h in C++ with clang
+// RUN: %target-clang -c -o /dev/null -Xclang -verify -I %t/Inputs %t/ok.cpp
+// RUN: %target-clang -c -o /dev/null -Xclang -verify=cxx -I %t/Inputs %t/err.cpp
+//
+// Compare usability of function.h in Swift with swift-frontend
+// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}function.h %t%{fs-sep}ok.swift
+// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}function.h %t%{fs-sep}err.swift -verify-additional-prefix swift-
+//
+// Check module interface of function.h
+// RUN: %target-swift-ide-test -print-module -module-to-print=Function -I %t/Inputs -source-filename=x -cxx-interoperability-mode=default | %FileCheck %s
+
+//--- Inputs/module.modulemap
+module Function {
+  header "function.h"
+  requires cplusplus
+}
+
+//--- Inputs/function.h
+#pragma once
+
+// NOTE: Bro<Ken> is an invalid type and will produce an error when instantiated
+
+template <typename K>
+struct Bro {
+  typename K::enough iAm; // cxx-error {{no type named 'enough'}}
+                          // expected-swift-error@-1 {{no type named 'enough'}}
+};
+
+struct Ken {};
+
+// None of GoodStruct's members should prevent it from being imported sans error
+struct GoodStruct {
+  GoodStruct() = default;
+
+  // FIXME: constructors are imported eagerly, so having this member would make GoodStruct unusable
+  // GoodStruct(Bro<Ken>, Bro<Ken>);
+  // NOTE: if the above has only one argument, Bro<Ken> will get instantiated
+  // while considering the copy constructor overload candidate.
+
+  // expected-swift-note@+3 {{explicitly marked unavailable here}}
+  // expected-swift-note@+2 {{explicitly marked unavailable here}}
+  // expected-swift-note@+1 {{explicitly marked unavailable here}}
+  Bro<Ken> badReturn() const;
+  // expected-swift-note@-1 {{requested here}}
+
+  // expected-swift-note@+2 {{unavailable (cannot import)}}
+  // expected-swift-note@+1 {{unavailable (cannot import)}}
+  void badArg(Bro<Ken>) const;
+
+  // expected-swift-note@+2 {{unavailable (cannot import)}}
+  // expected-swift-note@+1 {{unavailable (cannot import)}}
+  static Bro<Ken> badStatic(Bro<Ken>);
+
+  void overloadsSameNumArgs(int) const;
+  void overloadsSameNumArgs(Bro<Ken>) const;
+
+  // expected-swift-note@+1 {{declared here}}
+  void overloadsDiffNumArgs(int, int) const;
+  void overloadsDiffNumArgs(Bro<Ken>) const;
+
+  // FIXME: operators are imported eagerly, so having this member would make GoodStruct unusable
+  // int operator+(Bro<Ken>) const;
+
+  // FIXME: begin()/end() are imported eagerly, so having this member would make GoodStruct unusable
+  // Bro<Ken> begin() const;
+  // Bro<Ken> end() const;
+};
+// CHECK:      struct GoodStruct {
+// CHECK-NEXT:   init()
+//
+// CHECK-NEXT:   func badReturn() -> Never
+//
+// NOTE-MISSING: func badArg(_: Never)
+//
+// NOTE-MISSING: func badStatic(_: Never) -> Never
+//
+// CHECK-NEXT:   func overloadsSameNumArgs(_: Int32)
+// NOTE-MISSING: func overloadsSameNumArgs(_: Never)
+//
+// CHECK-NEXT:   func overloadsDiffNumArgs(_: Int32, _: Int32)
+// NOTE-MISSING: func overloadsDiffNumArgs(_: Never)
+//
+// CHECK-NEXT: }
+
+
+struct DerivedGoodStruct : GoodStruct {};
+// CHECK:      struct DerivedGoodStruct {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   func badReturn() -> Never
+// CHECK-NEXT:   func overloadsSameNumArgs(_: Int32)
+// CHECK-NEXT:   func overloadsDiffNumArgs(_: Int32, _: Int32)
+// CHECK-NEXT: }
+
+struct UsingGoodStruct : GoodStruct {
+  using GoodStruct::badReturn;
+  using GoodStruct::badArg;
+  using GoodStruct::badStatic;
+};
+
+// CHECK:      struct UsingGoodStruct {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   func badReturn() -> Never
+// CHECK-NEXT:   func overloadsSameNumArgs(_: Int32)
+// CHECK-NEXT:   func overloadsDiffNumArgs(_: Int32, _: Int32)
+// CHECK-NEXT: }
+
+
+struct UsesGoodStruct {
+  GoodStruct field;
+  GoodStruct returns() const;
+  void takes(GoodStruct) const;
+};
+// CHECK:      struct UsesGoodStruct {
+// CHECK-NEXT:   init(field: GoodStruct)
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   var field: GoodStruct
+// CHECK-NEXT:   func returns() -> GoodStruct
+// CHECK-NEXT:   func takes(_: GoodStruct)
+// CHECK-NEXT: }
+
+//--- ok.cpp
+// expected-no-diagnostics
+#include <function.h>
+
+void ok(void) {
+  GoodStruct gs;
+  gs.overloadsDiffNumArgs(42, 24);
+  DerivedGoodStruct dgs;
+  UsingGoodStruct ugs;
+
+  UsesGoodStruct usgs;
+  auto f = usgs.field;
+  f = usgs.returns();
+  usgs.takes(f);
+}
+
+//--- err.cpp
+#include <function.h>
+
+void err(void) {
+  GoodStruct gs;
+  gs.overloadsSameNumArgs(42); // cxx-note {{requested here}}
+  // The Bro<Ken> type is instantiated while considering overloads candidates
+  // for GoodStruct::overloadsSameNumArgs(_).
+
+  // It is only instantiated once and thus no longer triggers diagnostics in
+  // its following uses:
+  auto inc = gs.badReturn();
+  gs.badArg(inc);
+  GoodStruct::badStatic(inc);
+
+  DerivedGoodStruct dgs;
+  auto dinc = dgs.badReturn();
+  dgs.badArg(dinc);
+  DerivedGoodStruct::badStatic(dinc);
+
+  UsingGoodStruct ugs;
+  auto uinc = ugs.badReturn();
+  ugs.badArg(uinc);
+  UsingGoodStruct::badStatic(uinc);
+}
+
+//--- ok.swift
+import Function
+
+
+func ok() {
+  let _: UnsafePointer<GoodStruct>
+  let _: UnsafePointer<DerivedGoodStruct>
+  let _: UnsafePointer<UsingGoodStruct>
+  let _: UnsafePointer<UsesGoodStruct>
+
+  let gs = GoodStruct() // expected-warning {{never used}}
+  // TODO: calling overloadsDiffNumArgs(_:_) should work since we should never
+  //       need to import the (invalid) single-argument overload. The following
+  //       call is commented out so that ok.swift compiles without C++ errors,
+  //       but should be added back when this behavior is fixed.
+  // gs.overloadsDiffNumArgs(42, 24)
+
+  let _ = DerivedGoodStruct()
+  let _ = UsingGoodStruct()
+
+  let usgs = UsesGoodStruct()
+  var f = usgs.field
+  f = usgs.returns()
+  usgs.takes(f)
+}
+
+//--- err.swift
+import Function
+
+func err() {
+  let gs = GoodStruct()
+  let inc = gs.badReturn()  // expected-swift-error {{is unavailable}}
+                            // expected-swift-warning@-1 {{an enum with no cases}}
+                            // expected-swift-note@-2 {{add an explicit type annotation}}
+  gs.badArg(inc)            // expected-swift-error {{has no member}}
+  GoodStruct.badStatic(inc) // expected-swift-error {{has no member}}
+
+  let _ = GoodStruct(inc) // expected-swift-error {{call that takes no arguments}}
+
+  // TODO: overload sets are looked up and imported as a group, so even the
+  //       valid overloads of the following methods are missing due to invalid
+  //       members in the overload set
+  gs.overloadsSameNumArgs(42)
+  gs.overloadsSameNumArgs(inc) // expected-swift-error {{cannot convert value of type 'Never'}}
+
+  gs.overloadsDiffNumArgs(42, 24)
+  gs.overloadsDiffNumArgs(inc) // expected-swift-error {{cannot convert value of type 'Never'}}
+                               // expected-swift-error@-1 {{missing argument for parameter #2 in call}}
+
+  let dgs = DerivedGoodStruct()
+  let dinc = dgs.badReturn()  // expected-swift-error {{is unavailable}}
+                              // expected-swift-warning@-1 {{an enum with no cases}}
+                              // expected-swift-note@-2 {{add an explicit type annotation}}
+  dgs.badArg(dinc)            // expected-swift-error {{has no member}}
+
+  let ugs = UsingGoodStruct()
+  let uinc = ugs.badReturn() // expected-swift-error {{is unavailable}}
+                             // expected-swift-warning@-1 {{an enum with no cases}}
+                             // expected-swift-note@-2 {{add an explicit type annotation}}
+  ugs.badArg(uinc)           // expected-swift-error {{has no member}}
+}

--- a/test/Interop/Cxx/class/function-members-with-invalid-types.swift
+++ b/test/Interop/Cxx/class/function-members-with-invalid-types.swift
@@ -6,11 +6,22 @@
 // RUN: %target-clang -c -o /dev/null -Xclang -verify=cxx -I %t/Inputs %t/err.cpp
 //
 // Compare usability of function.h in Swift with swift-frontend
-// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}function.h %t%{fs-sep}ok.swift
-// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}function.h %t%{fs-sep}err.swift -verify-additional-prefix swift-
+// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default \
+// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
+// RUN:   -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}function.h \
+// RUN:   %t%{fs-sep}ok.swift
+// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default \
+// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
+// RUN:   -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}function.h \
+// RUN:   %t%{fs-sep}err.swift -verify-additional-prefix swift-
 //
 // Check module interface of function.h
-// RUN: %target-swift-ide-test -print-module -module-to-print=Function -I %t/Inputs -source-filename=x -cxx-interoperability-mode=default | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -source-filename=x \
+// RUN:   -cxx-interoperability-mode=default -I %t/Inputs \
+// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
+// RUN:   -module-to-print=Function | %FileCheck %s
+//
+// REQUIRES: swift_feature_ImportCxxMembersLazily
 
 //--- Inputs/module.modulemap
 module Function {

--- a/test/Interop/Cxx/stdlib/libstdcxx-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/libstdcxx-module-interface.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -print-module -module-to-print=CxxStdlib -source-filename=x -enable-experimental-cxx-interop -module-cache-path %t > %t/interface.swift
+// RUN: %target-swift-ide-test -print-module -module-to-print=CxxStdlib -source-filename=x -enable-experimental-cxx-interop -module-cache-path %t -enable-experimental-feature ImportCxxMembersLazily > %t/interface.swift
 // RUN: %FileCheck %s -check-prefix=CHECK-STD < %t/interface.swift
 // RUN: %FileCheck %s -check-prefix=CHECK-SIZE-T < %t/interface.swift
 // RUN: %FileCheck %s -check-prefix=CHECK-TO-STRING < %t/interface.swift
@@ -9,6 +9,10 @@
 
 // This test is specific to libstdc++ and only runs on platforms where libstdc++ is used.
 // REQUIRES: OS=linux-gnu
+//
+// The RHS of basic_string's typealias value_type depends on how eagerly/lazily
+// we import type members
+// REQUIRES: swift_feature_ImportCxxMembersLazily
 
 // CHECK-STD: enum std {
 // CHECK-STRING:   struct basic_string<CChar, std{{(.__cxx11)?}}.char_traits<CChar>, std{{(.__cxx11)?}}.allocator<CChar>> : CxxMutableRandomAccessCollection {

--- a/test/Interop/Cxx/stdlib/libstdcxx-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/libstdcxx-module-interface.swift
@@ -12,10 +12,10 @@
 
 // CHECK-STD: enum std {
 // CHECK-STRING:   struct basic_string<CChar, std{{(.__cxx11)?}}.char_traits<CChar>, std{{(.__cxx11)?}}.allocator<CChar>> : CxxMutableRandomAccessCollection {
-// CHECK-STRING:     typealias value_type = std.char_traits<CChar>.char_type
+// CHECK-STRING:     typealias value_type = CChar
 // CHECK-STRING:   }
 // CHECK-STRING:   struct basic_string<CWideChar, std{{(.__cxx11)?}}.char_traits<CWideChar>, std{{(.__cxx11)?}}.allocator<CWideChar>> : CxxMutableRandomAccessCollection {
-// CHECK-STRING:     typealias value_type = std.char_traits<CWideChar>.char_type
+// CHECK-STRING:     typealias value_type = CWideChar
 // CHECK-STRING:   }
 
 // CHECK-TO-STRING:   static func to_string(_ __val: Int32) -> std{{(.__cxx11)?}}.string

--- a/test/Interop/Cxx/templates/invalid-return-type.swift
+++ b/test/Interop/Cxx/templates/invalid-return-type.swift
@@ -1,8 +1,21 @@
 // RUN: split-file %s %t
 // RUN: %target-clang -c -o /dev/null -Xclang -verify -I %t/Inputs %t/cxx.cpp
-// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}CxxHeader.h %t%{fs-sep}ok.swift
-// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}CxxHeader.h %t%{fs-sep}err.swift -verify-additional-prefix err-
-// RUN: %target-swift-ide-test -print-module -module-to-print=CxxModule -I %t/Inputs -source-filename=x -cxx-interoperability-mode=default | %FileCheck %t/Inputs/CxxHeader.h
+// RUN: %target-swift-frontend -typecheck -verify \
+// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
+// RUN:   -cxx-interoperability-mode=default -I %t%{fs-sep}Inputs \
+// RUN:   -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}CxxHeader.h \
+// RUN:   %t%{fs-sep}ok.swift
+// RUN: %target-swift-frontend -typecheck -verify \
+// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
+// RUN:   -cxx-interoperability-mode=default -I %t%{fs-sep}Inputs \
+// RUN:   -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}CxxHeader.h \
+// RUN:   %t%{fs-sep}err.swift -verify-additional-prefix err-
+// RUN: %target-swift-ide-test -print-module -source-filename=x \
+// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
+// RUN:   -cxx-interoperability-mode=default -I %t/Inputs \
+// RUN:   -module-to-print=CxxModule | %FileCheck %t/Inputs/CxxHeader.h
+//
+// REQUIRES: swift_feature_ImportCxxMembersLazily
 
 //--- Inputs/module.modulemap
 module CxxModule {

--- a/test/Interop/Cxx/templates/invalid-return-type.swift
+++ b/test/Interop/Cxx/templates/invalid-return-type.swift
@@ -1,0 +1,56 @@
+// RUN: split-file %s %t
+// RUN: %target-clang -c -o /dev/null -Xclang -verify -I %t/Inputs %t/cxx.cpp
+// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}CxxHeader.h %t%{fs-sep}ok.swift
+// RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}CxxHeader.h %t%{fs-sep}err.swift -verify-additional-prefix err-
+// RUN: %target-swift-ide-test -print-module -module-to-print=CxxModule -I %t/Inputs -source-filename=x -cxx-interoperability-mode=default | %FileCheck %t/Inputs/CxxHeader.h
+
+//--- Inputs/module.modulemap
+module CxxModule {
+    requires cplusplus
+    header "CxxHeader.h"
+}
+
+//--- Inputs/CxxHeader.h
+#pragma once
+
+
+template <class T> struct OnlyChar;
+template <> struct OnlyChar<char> {};
+
+struct S {
+  S() = default;
+
+  OnlyChar<int> Err() const; // cannot be called (incomplete return type)
+  // expected-err-note@-1 {{explicitly marked unavailable here}}
+
+  OnlyChar<char> Ok() const;
+};
+
+// CHECK:      struct S {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   func Err() -> Never
+// CHECK-NEXT:   func Ok()
+// CHECK:      }
+
+//--- cxx.cpp
+// expected-no-diagnostics
+#include <CxxHeader.h>
+void IsOk(void) {
+  S Is;
+  Is.Ok();
+}
+
+//--- ok.swift
+import CxxModule
+func IsOk() {
+  let Is = S()  // We can instantiate it
+  Is.Ok()       // We can call it
+}
+
+//--- err.swift
+import CxxModule
+func IsErr() {
+  let Is = S()  // We can instantiate it
+  Is.Err()      // expected-error {{return type is unavailable in Swift}}
+  Is.Ok()       // We can still call it
+}

--- a/test/Interop/Cxx/templates/using-return-type.swift
+++ b/test/Interop/Cxx/templates/using-return-type.swift
@@ -1,0 +1,120 @@
+// C++ methods that return iterators are imported with an unsafe name mangling,
+// i.e., '__{{METHOD_NAME}}Unsafe'.
+//
+// In this test, we ensure that the iterator-detection logic does not depend on
+// whether the iterator type happens to be instantiated at the time we determine
+// the imported name of the C++ method.
+
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -typecheck -verify %t%{fs-sep}main.swift \
+// RUN:   -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}CxxHeader.h \
+// RUN:   -suppress-notes \
+// RUN:   -cxx-interoperability-mode=default
+
+//--- Inputs/module.modulemap
+module CxxModule {
+    requires cplusplus
+    header "CxxHeader.h"
+}
+
+//--- Inputs/CxxHeader.h
+#pragma once
+
+#include <iterator>
+
+template <typename T> struct IteratorT {
+  // Having this makes (each instance of) IteratorT considered an iterator
+  using iterator_category = std::input_iterator_tag;
+};
+
+template <typename T> struct IdentityT {
+  T t;
+};
+
+// Some types to instantiate IteratorT with
+struct A {};
+struct B {};
+struct C {};
+struct D {};
+
+struct AA {
+  IteratorT<A> getIter() const;
+  IdentityT<A> getValue() const;
+};
+
+struct BB {
+  using iter = IteratorT<B>;
+  using value = IdentityT<B>;
+  iter getIter() const;
+  value getValue() const;
+};
+
+struct CC {
+  using iter = IteratorT<C>;
+  using value = IdentityT<C>;
+  IteratorT<C> getIter() const;
+  IdentityT<C> getValue() const;
+};
+
+struct DD {
+  IteratorT<D> getIter() const;
+  IdentityT<D> getValue() const;
+  using iter = IteratorT<D>;
+  using value = IdentityT<D>;
+};
+
+struct AAA : AA {};
+struct BBB : BB {};
+struct CCC : CC {};
+struct DDD : DD {};
+
+//--- main.swift
+import CxxModule
+
+let aa = AA()
+aa.getIter() // expected-error {{has no member 'getIter'}}
+aa.__getIterUnsafe()
+aa.getValue()
+aa.__getValueUnsafe() // expected-error {{has no member '__getValueUnsafe'}}
+
+let bb = BB()
+bb.getIter() // expected-error {{has no member 'getIter'}}
+bb.__getIterUnsafe()
+bb.getValue()
+bb.__getValueUnsafe() // expected-error {{has no member '__getValueUnsafe'}}
+
+let cc = CC()
+cc.getIter() // expected-error {{has no member 'getIter'}}
+cc.__getIterUnsafe()
+cc.getValue()
+cc.__getValueUnsafe() // expected-error {{has no member '__getValueUnsafe'}}
+
+let dd = DD()
+dd.getIter() // expected-error {{has no member 'getIter'}}
+dd.__getIterUnsafe()
+dd.getValue()
+dd.__getValueUnsafe() // expected-error {{has no member '__getValueUnsafe'}}
+
+let aaa = AAA()
+aaa.getIter() // expected-error {{has no member 'getIter'}}
+aaa.__getIterUnsafe()
+aaa.getValue()
+aaa.__getValueUnsafe() // expected-error {{has no member '__getValueUnsafe'}}
+
+let bbb = BBB()
+bbb.getIter() // expected-error {{has no member 'getIter'}}
+bbb.__getIterUnsafe()
+bbb.getValue()
+bbb.__getValueUnsafe() // expected-error {{has no member '__getValueUnsafe'}}
+
+let ccc = CCC()
+ccc.getIter() // expected-error {{has no member 'getIter'}}
+ccc.__getIterUnsafe()
+ccc.getValue()
+ccc.__getValueUnsafe() // expected-error {{has no member '__getValueUnsafe'}}
+
+let ddd = DDD()
+ddd.getIter() // expected-error {{has no member 'getIter'}}
+ddd.__getIterUnsafe()
+ddd.getValue()
+ddd.__getValueUnsafe() // expected-error {{has no member '__getValueUnsafe'}}

--- a/test/Interop/Cxx/templates/using-return-type.swift
+++ b/test/Interop/Cxx/templates/using-return-type.swift
@@ -7,9 +7,12 @@
 
 // RUN: split-file %s %t
 // RUN: %target-swift-frontend -typecheck -verify %t%{fs-sep}main.swift \
+// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
 // RUN:   -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}CxxHeader.h \
 // RUN:   -suppress-notes \
 // RUN:   -cxx-interoperability-mode=default
+//
+// REQUIRES: swift_feature_ImportCxxMembersLazily
 
 //--- Inputs/module.modulemap
 module CxxModule {


### PR DESCRIPTION
In theory, we only need to import record fields eagerly (to compute
record layout); other members can be imported lazily, i.e., only when
they are used in Swift.

Currently, ClangImporter still relies on eagerly importing all members,
so we need to ease into lazy member imports gradually. In this patch set
we import start to type members and most member functions lazily. This
allows us to avoid over-eagerly instantiating the templated class types
in those decls.

rdar://156949141

Stacked on top of, and supersedes, #86686 and #86699.