### PR TITLE
Add -assert-config DisableReplacement to the private oslog library

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -1765,6 +1765,7 @@ endfunction()
 #     [INSTALL]
 #     [IS_STDLIB]
 #     [IS_STDLIB_CORE]
+#     [IS_OSLOG]
 #     [ONLY_SWIFTMODULE]
 #     [NO_SWIFTMODULE]
 #     [INSTALL_WITH_SHARED]
@@ -1875,6 +1876,9 @@ endfunction()
 # IS_STDLIB_CORE
 #   Compile as the Swift standard library core.
 #
+# IS_OSLOG
+#   Treat the library as OSLog library.
+#
 # ONLY_SWIFTMODULE
 #   Do not build either static or shared, build just the .swiftmodule.
 #
@@ -1964,6 +1968,7 @@ function(add_swift_target_library name)
         IS_SDK_OVERLAY
         IS_STDLIB
         IS_STDLIB_CORE
+        IS_OSLOG
         IS_SWIFT_ONLY
         NOSWIFTRT
         ONLY_SWIFTMODULE
@@ -2135,6 +2140,10 @@ function(add_swift_target_library name)
   if (SWIFTLIB_IS_STDLIB)
     list(APPEND SWIFTLIB_SWIFT_COMPILE_FLAGS "-warn-implicit-overrides")
     list(APPEND SWIFTLIB_SWIFT_COMPILE_FLAGS "-Xfrontend;-enable-lexical-lifetimes=false")
+  endif()
+
+  if (SWIFTLIB_IS_OSLOG)
+    list(APPEND SWIFTLIB_SWIFT_COMPILE_FLAGS "-Xfrontend;-assert-config;-Xfrontend;DisableReplacement")
   endif()
 
   if(NOT DEFINED SWIFTLIB_INSTALL_BINARY_SWIFTMODULE)

--- a/stdlib/private/OSLog/CMakeLists.txt
+++ b/stdlib/private/OSLog/CMakeLists.txt
@@ -15,6 +15,7 @@ if((SWIFT_BUILD_CLANG_OVERLAYS
 endif()
 
 add_swift_target_library(swiftOSLogTestHelper
+  IS_OSLOG
   IS_SDK_OVERLAY
   SHARED
 

--- a/stdlib/private/OSLog/OSLogTestHelper.swift
+++ b/stdlib/private/OSLog/OSLogTestHelper.swift
@@ -41,6 +41,7 @@ public let _noopClosure = { (x : String, y : UnsafeBufferPointer<UInt8>) in retu
 ///     byte buffer and asserts a condition.
 @_semantics("oslog.requires_constant_arguments")
 @_transparent
+@_alwaysEmitIntoClient
 @_optimize(none)
 public // @testable
 func _osLogTestHelper(


### PR DESCRIPTION
We have a private oslog library to test optimizations specific for oslog.
Add -assert-config DisableReplacement to this library to be consistent with the real implementation.
This prevents surprising optimizer regressions.