### PR TITLE
[stdlib] Generalize the `filter(_:)` functions for typed throws

### DIFF
--- a/stdlib/public/core/ArrayType.swift
+++ b/stdlib/public/core/ArrayType.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -70,10 +70,23 @@ extension _ArrayProtocol {
   // Since RangeReplaceableCollection now has a version of filter that is less
   // efficient, we should make the default implementation coming from Sequence
   // preferred.
-  @inlinable
-  public __consuming func filter(
+  @_alwaysEmitIntoClient
+  public consuming func filter<E: Error>(
+    _ isIncluded: (Element) throws(E) -> Bool
+  ) throws(E) -> [Element] {
+    try _filter(isIncluded)
+  }
+
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @abi(
+    __consuming func filter(
+      _ isIncluded: (Element) throws -> Bool
+    ) throws -> [Element]
+  )
+  @usableFromInline
+  internal __consuming func __legacyABI_filter(
     _ isIncluded: (Element) throws -> Bool
-  ) rethrows -> [Element] {
-    return try _filter(isIncluded)
+  ) throws -> [Element] {
+    try filter(isIncluded)
   }
 }

--- a/stdlib/public/core/ArrayType.swift
+++ b/stdlib/public/core/ArrayType.swift
@@ -77,6 +77,10 @@ extension _ArrayProtocol {
     try _filter(isIncluded)
   }
 
+#if !hasFeature(Embedded)
+  // ABI-only entrypoint for the rethrows version of filter, which has been
+  // superseded by the typed-throws version. Expressed as "throws", which is
+  // ABI-compatible with "rethrows".
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
   @abi(
     __consuming func filter(
@@ -89,4 +93,5 @@ extension _ArrayProtocol {
   ) throws -> [Element] {
     try filter(isIncluded)
   }
+#endif // !hasFeature(Embedded)
 }

--- a/stdlib/public/core/Bitset.swift
+++ b/stdlib/public/core/Bitset.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -354,13 +354,13 @@ extension _UnsafeBitset.Word: @unsafe Sequence, @unsafe IteratorProtocol {
 extension _UnsafeBitset {
   @_alwaysEmitIntoClient
   @inline(__always)
-  internal static func _withTemporaryUninitializedBitset<R>(
+  internal static func _withTemporaryUninitializedBitset<R, E: Error>(
     wordCount: Int,
-    body: (_UnsafeBitset) throws -> R
-  ) rethrows -> R {
+    body: (_UnsafeBitset) throws(E) -> R
+  ) throws(E) -> R {
     try unsafe withUnsafeTemporaryAllocation(
       of: _UnsafeBitset.Word.self, capacity: wordCount
-    ) { buffer in
+    ) { (buffer: UnsafeMutableBufferPointer<_UnsafeBitset.Word>) throws(E) -> R in
       let bitset = unsafe _UnsafeBitset(
         words: buffer.baseAddress!, wordCount: buffer.count)
       return try unsafe body(bitset)
@@ -369,14 +369,14 @@ extension _UnsafeBitset {
 
   @_alwaysEmitIntoClient
   @inline(__always)
-  internal static func withTemporaryBitset<R>(
+  internal static func withTemporaryBitset<R, E: Error>(
     capacity: Int,
-    body: (_UnsafeBitset) throws -> R
-  ) rethrows -> R {
+    body: (_UnsafeBitset) throws(E) -> R
+  ) throws(E) -> R {
     let wordCount = unsafe Swift.max(1, Self.wordCount(forCapacity: capacity))
     return try unsafe _withTemporaryUninitializedBitset(
       wordCount: wordCount
-    ) { bitset in
+    ) { (bitset: _UnsafeBitset) throws(E) -> R in
       unsafe bitset.clear()
       return try unsafe body(bitset)
     }
@@ -386,13 +386,13 @@ extension _UnsafeBitset {
 extension _UnsafeBitset {
   @_alwaysEmitIntoClient
   @inline(__always)
-  internal static func withTemporaryCopy<R>(
+  internal static func withTemporaryCopy<R, E: Error>(
     of original: _UnsafeBitset,
-    body: (_UnsafeBitset) throws -> R
-  ) rethrows -> R {
+    body: (_UnsafeBitset) throws(E) -> R
+  ) throws(E) -> R {
     try unsafe _withTemporaryUninitializedBitset(
       wordCount: original.wordCount
-    ) { bitset in
+    ) { (bitset: _UnsafeBitset) throws(E) -> R in
       unsafe bitset.words.initialize(from: original.words, count: original.wordCount)
       return try unsafe body(bitset)
     }

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -643,7 +643,7 @@ extension Dictionary {
   @abi(
     __consuming func filter(
       _ isIncluded: (Element) throws -> Bool
-    ) rethrows -> [Key: Value]
+    ) throws -> [Key: Value]
   )
   internal __consuming func __rethrows_filter(
     _ isIncluded: (Element) throws -> Bool

--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -848,12 +848,12 @@ extension _NativeDictionary { // High-level operations
   }
 
   @_alwaysEmitIntoClient
-  internal func filter(
-    _ isIncluded: (Element) throws -> Bool
-  ) rethrows -> _NativeDictionary<Key, Value> {
+  internal func filter<E: Error>(
+    _ isIncluded: (Element) throws(E) -> Bool
+  ) throws(E) -> _NativeDictionary<Key, Value> {
     try unsafe _UnsafeBitset.withTemporaryBitset(
       capacity: _storage._bucketCount
-    ) { bitset in
+    ) { (bitset: _UnsafeBitset) throws(E) -> _NativeDictionary<Key, Value> in
       var count = 0
       for unsafe bucket in unsafe hashTable {
         if try unsafe isIncluded(

--- a/stdlib/public/core/NativeSet.swift
+++ b/stdlib/public/core/NativeSet.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -748,18 +748,19 @@ extension _NativeSet {
   }
 
   @_alwaysEmitIntoClient
-  internal __consuming func filter(
-    _ isIncluded: (Element) throws -> Bool
-  ) rethrows -> _NativeSet<Element> {
-    try unsafe _UnsafeBitset.withTemporaryBitset(capacity: bucketCount) { bitset in
+  internal consuming func filter<E: Error>(
+    _ isIncluded: (Element) throws(E) -> Bool
+  ) throws(E) -> _NativeSet<Element> {
+    try unsafe _UnsafeBitset.withTemporaryBitset(capacity: bucketCount) {
+      [s = consume self] bitset throws(E) -> _NativeSet<Element> in
       var count = 0
-      for unsafe bucket in unsafe hashTable {
-        if try isIncluded(unsafe uncheckedElement(at: bucket)) {
+      for unsafe bucket in unsafe s.hashTable {
+        if try isIncluded(unsafe s.uncheckedElement(at: bucket)) {
           unsafe bitset.uncheckedInsert(bucket.offset)
           count += 1
         }
       }
-      return unsafe extractSubset(using: bitset, count: count)
+      return unsafe s.extractSubset(using: bitset, count: count)
     }
   }
 

--- a/stdlib/public/core/RangeReplaceableCollection.swift
+++ b/stdlib/public/core/RangeReplaceableCollection.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -1111,17 +1111,35 @@ extension RangeReplaceableCollection {
   /// - Returns: A collection of the elements that `isIncluded` allowed.
   ///
   /// - Complexity: O(*n*), where *n* is the length of the collection.
-  @inlinable
+  @_alwaysEmitIntoClient
   @available(swift, introduced: 4.0)
-  public __consuming func filter(
-    _ isIncluded: (Element) throws -> Bool
-  ) rethrows -> Self {
+  public consuming func filter<E: Error>(
+    _ isIncluded: (Element) throws(E) -> Bool
+  ) throws(E) -> Self {
     var result = Self()
     for element in self where try isIncluded(element) {
       result.append(element)
     }
     return result
   }
+
+#if !$Embedded
+  // ABI-only entrypoint for the rethrows version of filter, which has been
+  // superseded by the typed-throws version. Expressed as "throws", which is
+  // ABI-compatible with "rethrows".
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @abi(
+    __consuming func filter(
+      _ isIncluded: (Element) throws -> Bool
+    ) throws -> Self
+  )
+  @usableFromInline
+  internal __consuming func __legacyABI_filter(
+    _ isIncluded: (Element) throws -> Bool
+  ) throws -> Self {
+    try filter(isIncluded)
+  }
+#endif // !$Embedded
 }
 
 extension RangeReplaceableCollection where Self: MutableCollection {

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -743,6 +743,10 @@ extension Sequence {
     return try _filter(isIncluded)
   }
 
+#if !hasFeature(Embedded)
+  // ABI-only entrypoint for the rethrows version of filter, which has been
+  // superseded by the typed-throws version. Expressed as "throws", which is
+  // ABI-compatible with "rethrows".
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
   @abi(
     __consuming func filter(
@@ -755,6 +759,7 @@ extension Sequence {
   ) throws -> [Element] {
     try filter(isIncluded)
   }
+#endif // !hasFeature(Embedded)
 
   @_alwaysEmitIntoClient  @inline(__always)
   public func _filter<E: Error>(
@@ -774,6 +779,10 @@ extension Sequence {
     return Array(result)
   }
 
+#if !hasFeature(Embedded)
+  // ABI-only entrypoint for the rethrows version of _filter, which has been
+  // superseded by the typed-throws version. Expressed as "throws", which is
+  // ABI-compatible with "rethrows".
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
   @abi(
     __consuming func _filter(
@@ -786,6 +795,7 @@ extension Sequence {
   ) throws -> [Element] {
     try _filter(isIncluded)
   }
+#endif // !hasFeature(Embedded)
 
   /// A value less than or equal to the number of elements in the sequence,
   /// calculated nondestructively.

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -736,17 +736,30 @@ extension Sequence {
   /// - Returns: An array of the elements that `isIncluded` allowed.
   ///
   /// - Complexity: O(*n*), where *n* is the length of the sequence.
-  @inlinable
-  public __consuming func filter(
-    _ isIncluded: (Element) throws -> Bool
-  ) rethrows -> [Element] {
+  @_alwaysEmitIntoClient
+  public __consuming func filter<E: Error>(
+    _ isIncluded: (Element) throws(E) -> Bool
+  ) throws(E) -> [Element] {
     return try _filter(isIncluded)
   }
 
-  @_transparent
-  public func _filter(
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @abi(
+    __consuming func filter(
+      _ isIncluded: (Element) throws -> Bool
+    ) throws -> [Element]
+  )
+  @usableFromInline
+  internal __consuming func __legacyABI_filter(
     _ isIncluded: (Element) throws -> Bool
-  ) rethrows -> [Element] {
+  ) throws -> [Element] {
+    try filter(isIncluded)
+  }
+
+  @_alwaysEmitIntoClient  @inline(__always)
+  public func _filter<E: Error>(
+    _ isIncluded: (Element) throws(E) -> Bool
+  ) throws(E) -> [Element] {
 
     var result = ContiguousArray<Element>()
 
@@ -759,6 +772,19 @@ extension Sequence {
     }
 
     return Array(result)
+  }
+
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @abi(
+    __consuming func _filter(
+      _ isIncluded: (Element) throws -> Bool
+    ) throws -> [Element]
+  )
+  @usableFromInline
+  internal __consuming func __legacyABI_underscore_filter(
+    _ isIncluded: (Element) throws -> Bool
+  ) throws -> [Element] {
+    try _filter(isIncluded)
   }
 
   /// A value less than or equal to the number of elements in the sequence,

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -761,7 +761,7 @@ extension Sequence {
   }
 #endif // !hasFeature(Embedded)
 
-  @_alwaysEmitIntoClient  @inline(__always)
+  @_alwaysEmitIntoClient  @_transparent
   public func _filter<E: Error>(
     _ isIncluded: (Element) throws(E) -> Bool
   ) throws(E) -> [Element] {

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -297,13 +297,31 @@ extension Set {
   ///   and returns a Boolean value indicating whether the element should be
   ///   included in the returned set.
   /// - Returns: A set of the elements that `isIncluded` allows.
-  @inlinable
+  @_alwaysEmitIntoClient
   @available(swift, introduced: 4.0)
-  public __consuming func filter(
-    _ isIncluded: (Element) throws -> Bool
-  ) rethrows -> Set {
-    return try Set(_native: _variant.filter(isIncluded))
+  public consuming func filter<E: Error>(
+    _ isIncluded: (Element) throws(E) -> Bool
+  ) throws(E) -> Set {
+    try Set(_native: _variant.filter(isIncluded))
   }
+
+#if !$Embedded
+  // ABI-only entrypoint for the rethrows version of filter, which has been
+  // superseded by the typed-throws version. Expressed as "throws", which is
+  // ABI-compatible with "rethrows".
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @abi(
+    __consuming func filter(
+      _ isIncluded: (Element) throws -> Bool
+    ) throws -> Set
+  )
+  @usableFromInline
+  internal __consuming func __legacyABI_filter(
+    _ isIncluded: (Element) throws -> Bool
+  ) throws -> Set {
+    try filter(isIncluded)
+  }
+#endif // !$Embedded
 }
 
 extension Set: Collection {

--- a/stdlib/public/core/SetVariant.swift
+++ b/stdlib/public/core/SetVariant.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -381,9 +381,9 @@ extension Set._Variant {
 
 extension Set._Variant {
   @_alwaysEmitIntoClient
-  internal __consuming func filter(
-    _ isIncluded: (Element) throws -> Bool
-  ) rethrows -> _NativeSet<Element> {
+  internal consuming func filter<E: Error>(
+    _ isIncluded: (Element) throws(E) -> Bool
+  ) throws(E) -> _NativeSet<Element> {
 #if _runtime(_ObjC)
     guard isNative else {
       var result = _NativeSet<Element>()

--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -1353,11 +1353,26 @@ extension Substring {
     return String(self).uppercased()
   }
 
-  public func filter(
-    _ isIncluded: (Element) throws -> Bool
-  ) rethrows -> String {
-    return try String(self.lazy.filter(isIncluded))
+  @_alwaysEmitIntoClient
+  public func filter<E: Error>(
+    _ isIncluded: (Element) throws(E) -> Bool
+  ) throws(E) -> String {
+    try String(self.lazy.filter(isIncluded))
   }
+
+#if !$Embedded
+  // ABI-only entrypoint for the rethrows version of filter, which has been
+  // superseded by the typed-throws version. Expressed as "throws", which is
+  // ABI-compatible with "rethrows".
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @abi(func filter(_ isIncluded: (Element) throws -> Bool) throws -> String)
+  @usableFromInline
+  internal func __legacyABI_filter(
+    _ isIncluded: (Element) throws -> Bool
+  ) throws -> String {
+    try filter(isIncluded)
+  }
+#endif // !$Embedded
 }
 
 extension Substring: TextOutputStream {

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -900,7 +900,7 @@ func rdar78623338() {
 // rdar://78781552 - crash in `getFunctionArgApplyInfo`
 func rdar78781552() {
   struct Test<Data, Content> where Data : RandomAccessCollection {
-    // expected-note@-1 {{where 'Data' = '(((Int) throws -> Bool) throws -> [Int])?'}}
+    // expected-note@-1 {{where 'Data' = '(((Int) throws(E) -> Bool) throws(E) -> [Int])?'}}
     // expected-note@-2 {{'init(data:filter:)' declared here}}
     // expected-note@-3 {{'Content' declared as parameter to type 'Test'}}
     var data: [Data]
@@ -909,11 +909,12 @@ func rdar78781552() {
 
   func test(data: [Int]?) {
     Test(data?.filter)
-    // expected-error@-1 {{generic struct 'Test' requires that '(((Int) throws -> Bool) throws -> [Int])?' conform to 'RandomAccessCollection'}}
+    // expected-error@-1 {{generic struct 'Test' requires that '(((Int) throws(E) -> Bool) throws(E) -> [Int])?' conform to 'RandomAccessCollection'}}
     // expected-error@-2 {{generic parameter 'Content' could not be inferred}} expected-note@-2 {{explicitly specify the generic arguments to fix this issue}}
-    // expected-error@-3 {{cannot convert value of type '(((Int) throws -> Bool) throws -> [Int])?' to expected argument type '[(((Int) throws -> Bool) throws -> [Int])?]'}}
+    // expected-error@-3 {{cannot convert value of type '(((Int) throws(E) -> Bool) throws(E) -> [Int])?' to expected argument type '[(((Int) throws(E) -> Bool) throws(E) -> [Int])?]'}}
     // expected-error@-4 {{missing argument label 'data:' in call}}
     // expected-error@-5 {{missing argument for parameter 'filter' in call}}
+    // expected-error@-6 {{generic parameter 'E' could not be inferred}}
   }
 }
 

--- a/test/Sema/fixed_ambiguities/rdar33142386.swift
+++ b/test/Sema/fixed_ambiguities/rdar33142386.swift
@@ -2,5 +2,5 @@
 // RUN: %target-swift-frontend -emit-sil -verify %s -swift-version 4 | %FileCheck %s
 
 let x: String = "ultimate question"
-// CHECK: function_ref @$sSmsE6filteryxSb7ElementQzKXEKF
+// CHECK: function_ref @$sSmsE6filteryxSb7ElementQzqd__YKXEqd__YKs5ErrorRd__lF
 _ = x.filter({ $0 == " " }).count < 3

--- a/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
@@ -52,6 +52,19 @@ Constructor Array.init(unsafeUninitializedCapacity:initializingWith:) is now wit
 Constructor ContiguousArray.init(unsafeUninitializedCapacity:initializingWith:) has generic signature change from <Element> to <Element, E where E : Swift.Error>
 Constructor ContiguousArray.init(unsafeUninitializedCapacity:initializingWith:) has parameter 1 type change from (inout Swift.UnsafeMutableBufferPointer<Element>, inout Swift.Int) throws -> Swift.Void to (inout Swift.UnsafeMutableBufferPointer<Element>, inout Swift.Int) throws(E) -> Swift.Void
 Constructor ContiguousArray.init(unsafeUninitializedCapacity:initializingWith:) is now without rethrows
+Func RangeReplaceableCollection.filter(_:) has generic signature change from <Self where Self : Swift.RangeReplaceableCollection> to <Self, E where Self : Swift.RangeReplaceableCollection, E : Swift.Error>
+Func RangeReplaceableCollection.filter(_:) has self access kind changing from __Consuming to Consuming
+Func RangeReplaceableCollection.filter(_:) is now without rethrows
+Func Dictionary.filter(_:) has generic signature change from <Key, Value where Key : Swift.Hashable> to <Key, Value, E where Key : Swift.Hashable, E : Swift.Error>
+Func Dictionary.filter(_:) has self access kind changing from __Consuming to Consuming
+Func Dictionary.filter(_:) is now without rethrows
+Func Sequence.filter(_:) has generic signature change from <Self where Self : Swift.Sequence> to <Self, E where Self : Swift.Sequence, E : Swift.Error>
+Func Sequence.filter(_:) is now without rethrows
+Func Set.filter(_:) has generic signature change from <Element where Element : Swift.Hashable> to <Element, E where Element : Swift.Hashable, E : Swift.Error>
+Func Set.filter(_:) has self access kind changing from __Consuming to Consuming
+Func Set.filter(_:) is now without rethrows
+Func Substring.filter(_:) has generic signature change from to <E where E : Swift.Error>
+Func Substring.filter(_:) is now without rethrows
 
 Protocol SIMDScalar has generic signature change from <Self == Self.SIMD16Storage.Scalar, Self.SIMD16Storage : Swift.SIMDStorage, Self.SIMD2Storage : Swift.SIMDStorage, Self.SIMD32Storage : Swift.SIMDStorage, Self.SIMD4Storage : Swift.SIMDStorage, Self.SIMD64Storage : Swift.SIMDStorage, Self.SIMD8Storage : Swift.SIMDStorage, Self.SIMDMaskScalar : Swift.FixedWidthInteger, Self.SIMDMaskScalar : Swift.SIMDScalar, Self.SIMDMaskScalar : Swift.SignedInteger, Self.SIMD16Storage.Scalar == Self.SIMD2Storage.Scalar, Self.SIMD2Storage.Scalar == Self.SIMD32Storage.Scalar, Self.SIMD32Storage.Scalar == Self.SIMD4Storage.Scalar, Self.SIMD4Storage.Scalar == Self.SIMD64Storage.Scalar, Self.SIMD64Storage.Scalar == Self.SIMD8Storage.Scalar> to <Self : Swift.BitwiseCopyable, Self == Self.SIMD16Storage.Scalar, Self.SIMD16Storage : Swift.SIMDStorage, Self.SIMD2Storage : Swift.SIMDStorage, Self.SIMD32Storage : Swift.SIMDStorage, Self.SIMD4Storage : Swift.SIMDStorage, Self.SIMD64Storage : Swift.SIMDStorage, Self.SIMD8Storage : Swift.SIMDStorage, Self.SIMDMaskScalar : Swift.FixedWidthInteger, Self.SIMDMaskScalar : Swift.SIMDScalar, Self.SIMDMaskScalar : Swift.SignedInteger, Self.SIMDMaskScalar == Self.SIMDMaskScalar.SIMDMaskScalar, Self.SIMD16Storage.Scalar == Self.SIMD2Storage.Scalar, Self.SIMD2Storage.Scalar == Self.SIMD32Storage.Scalar, Self.SIMD32Storage.Scalar == Self.SIMD4Storage.Scalar, Self.SIMD4Storage.Scalar == Self.SIMD64Storage.Scalar, Self.SIMD64Storage.Scalar == Self.SIMD8Storage.Scalar>
 

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -90,7 +90,14 @@ Func AnyCollection.map(_:) has been removed
 Func AnyRandomAccessCollection.map(_:) has been removed
 Func AnySequence.map(_:) has been removed
 Func Collection.map(_:) has been removed
+Func RangeReplaceableCollection.filter(_:) has been removed
+Func Sequence._filter(_:) has been removed
+Func Sequence.filter(_:) has been removed
 Func Sequence.map(_:) has been removed
+Func Dictionary.filter(_:) has been removed
+Func Set.filter(_:) has been removed
+Func Substring.filter(_:) has been removed
+Func _ArrayProtocol.filter(_:) has been removed
 Constructor Result.init(catching:) has been removed
 Func withoutActuallyEscaping(_:do:) has been renamed to Func __abi_withoutActuallyEscaping(_:do:)
 Func withoutActuallyEscaping(_:do:) has mangled name changing from 'Swift.withoutActuallyEscaping<A, B>(_: A, do: (A) throws -> B) throws -> B' to 'Swift.__abi_withoutActuallyEscaping<A, B>(_: A, do: (A) throws -> B) throws -> B'

--- a/validation-test/Sema/type_checker_perf/fast/rdar36838495.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar36838495.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-scope-threshold=2000
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=2400
 // REQUIRES: tools-release,no_asan
 // REQUIRES: OS=macosx
 


### PR DESCRIPTION
Generalizes the `filter(_:)` functions of most standard library types to support typed throws.