### PR TITLE
[Concurrency] Add more info to tracing calls.

### DIFF
--- a/include/swift/Runtime/EnvironmentVariables.h
+++ b/include/swift/Runtime/EnvironmentVariables.h
@@ -70,6 +70,10 @@ SWIFT_RUNTIME_STDLIB_SPI const char *concurrencyIsCurrentExecutorLegacyModeOverr
 // library can call.
 SWIFT_RUNTIME_STDLIB_SPI bool concurrencyEnableTaskSlabAllocator();
 
+// Wrapper around SWIFT_CONCURRENCY_TRACING_SUBSYSTEM that the Concurrency
+// library can call.
+SWIFT_RUNTIME_STDLIB_SPI const char *concurrencyTracingSubsystem();
+
 } // end namespace environment
 } // end namespace runtime
 } // end namespace swift

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -211,7 +211,9 @@ ExecutorTrackingInfo::ActiveInfoInThread;
 
 } // end anonymous namespace
 
-void swift::runJobInEstablishedExecutorContext(Job *job) {
+void swift::runJobInEstablishedExecutorContext(Job *job,
+                                               SerialExecutorRef serialExecutor,
+                                               TaskExecutorRef taskExecutor) {
   _swift_tsan_acquire(job);
   SWIFT_TASK_DEBUG_LOG("Run job in established context %p", job);
 
@@ -230,7 +232,8 @@ void swift::runJobInEstablishedExecutorContext(Job *job) {
     [[maybe_unused]]
     uint32_t dispatchOpaquePriority = task->flagAsRunning();
 
-    auto traceHandle = concurrency::trace::job_run_begin(job);
+    auto traceHandle =
+        concurrency::trace::job_run_begin(job, serialExecutor, taskExecutor);
     task->runInFullyEstablishedContext();
     concurrency::trace::job_run_end(traceHandle);
 
@@ -1851,14 +1854,18 @@ static void defaultActorDrain(DefaultActorImpl *actor) {
         break;
       }
     } else {
+      auto taskExecutor = TaskExecutorRef::undefined();
       if (AsyncTask *task = dyn_cast<AsyncTask>(job)) {
-        auto taskExecutor = task->getPreferredTaskExecutor();
+        taskExecutor = task->getPreferredTaskExecutor();
         trackingInfo.setTaskExecutor(taskExecutor);
       }
 
       // This thread is now going to follow the task on this actor.
       // It may hop off the actor
-      runJobInEstablishedExecutorContext(job);
+      runJobInEstablishedExecutorContext(
+          job,
+          SerialExecutorRef::forDefaultActor(asAbstract(currentActor)),
+          taskExecutor);
 
       // We could have come back from the job on a generic executor and not as
       // part of a default actor. If so, there is no more work left for us to do
@@ -2217,7 +2224,7 @@ static void swift_job_runImpl(Job *job, SerialExecutorRef executor) {
   trackingInfo.enterAndShadow(executor, taskExecutor);
 
   SWIFT_TASK_DEBUG_LOG("job %p", job);
-  runJobInEstablishedExecutorContext(job);
+  runJobInEstablishedExecutorContext(job, executor, taskExecutor);
 
   trackingInfo.leave();
 
@@ -2243,7 +2250,7 @@ static void swift_job_run_on_serial_and_task_executorImpl(Job *job,
   trackingInfo.enterAndShadow(serialExecutor, taskExecutor);
 
   SWIFT_TASK_DEBUG_LOG("job %p", job);
-  runJobInEstablishedExecutorContext(job);
+  runJobInEstablishedExecutorContext(job, serialExecutor, taskExecutor);
 
   trackingInfo.leave();
 
@@ -2744,6 +2751,8 @@ static void swift_task_enqueueImpl(Job *job, SerialExecutorRef serialExecutorRef
   auto serialExecutorIdentity = serialExecutorRef.getIdentity();
   auto serialExecutorType = swift_getObjectType(serialExecutorIdentity);
   auto serialExecutorWtable = serialExecutorRef.getSerialExecutorWitnessTable();
+  concurrency::trace::job_enqueue_executor(job, serialExecutorRef,
+                                           TaskExecutorRef::undefined());
   _swift_task_enqueueOnExecutor(job, serialExecutorIdentity, serialExecutorType,
                                 serialExecutorWtable);
 #endif // SWIFT_CONCURRENCY_EMBEDDED

--- a/stdlib/public/Concurrency/ConcurrencyHooks.cpp
+++ b/stdlib/public/Concurrency/ConcurrencyHooks.cpp
@@ -172,7 +172,8 @@ swift_task_enqueueMainExecutorOrig(Job *job) {
 
 void
 swift::swift_task_enqueueMainExecutor(Job *job) {
-  concurrency::trace::job_enqueue_main_executor(job);
+  concurrency::trace::job_enqueue_executor(
+      job, swift_task_getMainExecutor(), TaskExecutorRef::undefined());
   if (SWIFT_UNLIKELY(swift_task_enqueueMainExecutor_hook))
     swift_task_enqueueMainExecutor_hook(job, swift_task_enqueueMainExecutorOrig);
   else

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -70,8 +70,11 @@ void _swift_task_dealloc_specific(AsyncTask *task, void *ptr);
 
 /// Given that we've already set the right executor as the active
 /// executor, run the given job.  This does additional bookkeeping
-/// related to the active task.
-void runJobInEstablishedExecutorContext(Job *job);
+/// related to the active task. actor and executorIdentity are used for emitting
+/// tracing around the run.
+void runJobInEstablishedExecutorContext(Job *job,
+                                        SerialExecutorRef serialExecutor,
+                                        TaskExecutorRef taskExecutor);
 
 /// Adopt the voucher stored in `task`. This removes the voucher from the task
 /// and adopts it on the current thread.
@@ -751,11 +754,25 @@ public:
     return record_iterator::rangeBeginning(getInnermostRecord());
   }
 
-  void traceStatusChanged(AsyncTask *task, bool isStarting, bool wasRunning) {
-    concurrency::trace::task_status_changed(
-        task, static_cast<uint8_t>(getStoredPriority()), isCancelled(),
-        isStoredPriorityEscalated(), isStarting, isRunning(), isEnqueued(),
-        wasRunning);
+  void traceStatusChanged(AsyncTask *task, ActiveTaskStatus oldStatus,
+                          bool isStarting) {
+    uint8_t maxPriority = static_cast<uint8_t>(getStoredPriority());
+    bool cancelled = isCancelled();
+    bool escalated = isStoredPriorityEscalated();
+    bool running = isRunning();
+    bool enqueued = isEnqueued();
+    bool wasRunning = oldStatus.isRunning();
+
+    if (!isStarting &&
+        maxPriority == static_cast<uint8_t>(oldStatus.getStoredPriority()) &&
+        cancelled == oldStatus.isCancelled() &&
+        escalated == oldStatus.isStoredPriorityEscalated() &&
+        running == wasRunning && enqueued == oldStatus.isEnqueued())
+      return;
+
+    concurrency::trace::task_status_changed(task, maxPriority, cancelled,
+                                            escalated, isStarting, running,
+                                            enqueued, wasRunning);
   }
 };
 
@@ -1037,7 +1054,7 @@ inline uint32_t AsyncTask::flagAsRunning() {
       if (_private()._status().compare_exchange_weak(oldStatus, newStatus,
                /* success */ std::memory_order_relaxed,
                /* failure */ std::memory_order_relaxed)) {
-        newStatus.traceStatusChanged(this, true, oldStatus.isRunning());
+        newStatus.traceStatusChanged(this, oldStatus, true);
         adoptTaskVoucher(this);
         swift_task_enterThreadLocalContext(
             (char *)&_private().ExclusivityAccessSet[0]);

--- a/stdlib/public/Concurrency/TaskStatus.cpp
+++ b/stdlib/public/Concurrency/TaskStatus.cpp
@@ -94,9 +94,8 @@ static void withStatusRecordLock(
               status, newStatus,
               /*success*/ SWIFT_MEMORY_ORDER_CONSUME,
               /*failure*/ std::memory_order_relaxed)) {
-        bool wasRunning = status.isRunning();
+        newStatus.traceStatusChanged(task, status, false);
         status = newStatus;
-        status.traceStatusChanged(task, false, wasRunning);
         break;
       }
     }
@@ -131,7 +130,7 @@ static void withStatusRecordLock(
             status, newStatus,
             /*success*/ std::memory_order_relaxed,
             /*failure*/ std::memory_order_relaxed)) {
-      newStatus.traceStatusChanged(task, false, status.isRunning());
+      newStatus.traceStatusChanged(task, status, false);
       break;
     }
   }
@@ -197,7 +196,7 @@ bool swift::addStatusRecord(AsyncTask *task, TaskStatusRecord *newRecord,
       if (task->_private()._status().compare_exchange_weak(oldStatus, newStatus,
               /*success*/ std::memory_order_release,
               /*failure*/ std::memory_order_relaxed)) {
-        newStatus.traceStatusChanged(task, false, oldStatus.isRunning());
+        newStatus.traceStatusChanged(task, oldStatus, false);
         return true;
       } else {
         // Retry
@@ -303,7 +302,7 @@ void swift::removeStatusRecord(AsyncTask *task, TaskStatusRecord *record,
             oldStatus, newStatus,
             /*success*/ std::memory_order_relaxed,
             /*failure*/ std::memory_order_relaxed)) {
-      newStatus.traceStatusChanged(task, false, oldStatus.isRunning());
+      newStatus.traceStatusChanged(task, oldStatus, false);
       return;
     }
 
@@ -911,7 +910,7 @@ static void swift_task_cancelImpl(AsyncTask *task) {
     }
   }
 
-  newStatus.traceStatusChanged(task, false, oldStatus.isRunning());
+  newStatus.traceStatusChanged(task, oldStatus, false);
   if (newStatus.getInnermostRecord() == nullptr) {
     // No records, nothing to propagate
     return;

--- a/stdlib/public/Concurrency/Tracing.h
+++ b/stdlib/public/Concurrency/Tracing.h
@@ -23,9 +23,10 @@ namespace swift {
 class AsyncLet;
 class AsyncTask;
 class ContinuationAsyncContext;
-class SerialExecutorRef;
 struct HeapObject;
 class Job;
+class SerialExecutorRef;
+class TaskExecutorRef;
 class TaskGroup;
 class TaskStatusRecord;
 
@@ -35,8 +36,6 @@ namespace trace {
 // Actor trace calls.
 
 void actor_create(HeapObject *actor);
-
-void actor_destroy(HeapObject *actor);
 
 void actor_deallocate(HeapObject *actor);
 
@@ -58,7 +57,9 @@ void actor_note_job_queue(HeapObject *actor, Job *first,
 
 void task_create(AsyncTask *task, AsyncTask *parent, TaskGroup *group,
                  AsyncLet *asyncLet, uint8_t jobPriority, bool isChildTask,
-                 bool isFuture, bool isGroupChildTask, bool isAsyncLetTask);
+                 bool isFuture, bool isGroupChildTask, bool isAsyncLetTask,
+                 bool isDiscardingTask, bool hasInitialTaskExecutorPreference,
+                 const char *taskName);
 
 void task_destroy(AsyncTask *task);
 
@@ -89,7 +90,16 @@ void job_enqueue_global(Job *job);
 
 void job_enqueue_global_with_delay(unsigned long long delay, Job *job);
 
-void job_enqueue_main_executor(Job *job);
+void job_enqueue_executor(Job *job, SerialExecutorRef serialExecutor,
+                          TaskExecutorRef taskExecutor);
+
+enum class TracingExecutorKind : uint8_t {
+  GlobalConcurrent,
+  DefaultActor,
+  MainActor,
+  CustomSerialExecutor,
+  TaskExecutor,
+};
 
 struct job_run_info {
   /// The ID of the task that started running.
@@ -104,7 +114,8 @@ struct job_run_info {
 // call to task_run_end.  Any information we want to log must be
 // extracted from the job when we start to run it because execution
 // will invalidate the job.
-job_run_info job_run_begin(Job *job);
+job_run_info job_run_begin(Job *job, SerialExecutorRef serialExecutor,
+                           TaskExecutorRef taskExecutor);
 
 void job_run_end(job_run_info info);
 

--- a/stdlib/public/Concurrency/TracingSignpost.cpp
+++ b/stdlib/public/Concurrency/TracingSignpost.cpp
@@ -17,6 +17,7 @@
 #if SWIFT_STDLIB_TRACING
 
 #include "TracingSignpost.h"
+#include "swift/Runtime/EnvironmentVariables.h"
 #include <stdio.h>
 
 #define SWIFT_LOG_CONCURRENCY_SUBSYSTEM "com.apple.swift.concurrency"
@@ -39,10 +40,15 @@ void setupLogs(void *unused) {
   }
 
   TracingEnabled = true;
-  ActorLog = os_log_create(SWIFT_LOG_CONCURRENCY_SUBSYSTEM,
-                           SWIFT_LOG_ACTOR_CATEGORY);
-  TaskLog = os_log_create(SWIFT_LOG_CONCURRENCY_SUBSYSTEM,
-                          SWIFT_LOG_TASK_CATEGORY);
+
+  const char *subsystem = SWIFT_LOG_CONCURRENCY_SUBSYSTEM;
+  const char *envSubsystem =
+      runtime::environment::concurrencyTracingSubsystem();
+  if (envSubsystem && envSubsystem[0] != '\0')
+    subsystem = envSubsystem;
+
+  ActorLog = os_log_create(subsystem, SWIFT_LOG_ACTOR_CATEGORY);
+  TaskLog = os_log_create(subsystem, SWIFT_LOG_TASK_CATEGORY);
 }
 
 } // namespace trace

--- a/stdlib/public/Concurrency/TracingSignpost.h
+++ b/stdlib/public/Concurrency/TracingSignpost.h
@@ -65,7 +65,7 @@
 #define SWIFT_LOG_JOB_ENQUEUE_GLOBAL_NAME "job_enqueue_global"
 #define SWIFT_LOG_JOB_ENQUEUE_GLOBAL_WITH_DELAY_NAME                           \
   "job_enqueue_global_with_delay"
-#define SWIFT_LOG_JOB_ENQUEUE_MAIN_EXECUTOR_NAME "job_enqueue_main_executor"
+#define SWIFT_LOG_JOB_ENQUEUE_EXECUTOR_NAME "job_enqueue_executor"
 #define SWIFT_LOG_JOB_RUN_NAME "job_run"
 
 namespace swift {
@@ -111,20 +111,15 @@ inline void actor_create(HeapObject *actor) {
 
   auto id = os_signpost_id_make_with_pointer(ActorLog, actor);
   os_signpost_interval_begin(ActorLog, id, SWIFT_LOG_ACTOR_LIFETIME_NAME,
-                             "actor=%p typeName:%.*s", actor,
+                             "actor=%p typeName=%.*s", actor,
                              (int)typeName.length, typeName.data);
-}
-
-inline void actor_destroy(HeapObject *actor) {
-  ENSURE_LOGS();
-  auto id = os_signpost_id_make_with_pointer(ActorLog, actor);
-  os_signpost_interval_end(ActorLog, id, SWIFT_LOG_ACTOR_LIFETIME_NAME,
-                           "actor=%p", actor);
 }
 
 inline void actor_deallocate(HeapObject *actor) {
   ENSURE_LOGS();
   auto id = os_signpost_id_make_with_pointer(ActorLog, actor);
+  os_signpost_interval_end(ActorLog, id, SWIFT_LOG_ACTOR_LIFETIME_NAME,
+                           "actor=%p", actor);
   os_signpost_event_emit(ActorLog, id, SWIFT_LOG_ACTOR_DEALLOCATE_NAME,
                          "actor=%p", actor);
 }
@@ -132,18 +127,26 @@ inline void actor_deallocate(HeapObject *actor) {
 inline void actor_enqueue(HeapObject *actor, Job *job) {
   if (AsyncTask *task = dyn_cast<AsyncTask>(job)) {
     ENSURE_LOGS();
+    auto metadata = swift_getObjectType(actor);
+    auto descriptor = (const void *)metadata->getTypeContextDescriptor();
     auto id = os_signpost_id_make_with_pointer(ActorLog, actor);
-    os_signpost_event_emit(ActorLog, id, SWIFT_LOG_ACTOR_ENQUEUE_NAME,
-                           "actor=%p task=%" PRId64, actor, task->getTaskId());
+    os_signpost_event_emit(
+        ActorLog, id, SWIFT_LOG_ACTOR_ENQUEUE_NAME,
+        "actor=%p task=%" PRId64 " taskPointer=%p metadata=%p descriptor=%p",
+        actor, task->getTaskId(), task, metadata, descriptor);
   }
 }
 
 inline void actor_dequeue(HeapObject *actor, Job *job) {
   if (AsyncTask *task = dyn_cast_or_null<AsyncTask>(job)) {
     ENSURE_LOGS();
+    auto metadata = swift_getObjectType(actor);
+    auto descriptor = (const void *)metadata->getTypeContextDescriptor();
     auto id = os_signpost_id_make_with_pointer(ActorLog, actor);
-    os_signpost_event_emit(ActorLog, id, SWIFT_LOG_ACTOR_DEQUEUE_NAME,
-                           "actor=%p task=%" PRId64, actor, task->getTaskId());
+    os_signpost_event_emit(
+        ActorLog, id, SWIFT_LOG_ACTOR_DEQUEUE_NAME,
+        "actor=%p task=%" PRId64 " taskPointer=%p metadata=%p descriptor=%p",
+        actor, task->getTaskId(), task, metadata, descriptor);
   }
 }
 
@@ -199,17 +202,19 @@ inline void task_create(AsyncTask *task, AsyncTask *parent, TaskGroup *group,
       "isGroupChildTask=%{bool}d isAsyncLetTask=%{bool}d parent=%" PRId64
       " group=%p asyncLet=%p "
       "isDiscardingTask=%{bool}d hasInitialTaskExecutorPreference=%{bool}d "
-      "taskName=%{public}s",
+      "taskName=%{public}s taskPointer=%p",
       task->getTaskId(), task->getResumeFunctionForLogging(true), jobPriority,
       isChildTask, isFuture, isGroupChildTask, isAsyncLetTask, parentID, group,
-      asyncLet, isDiscardingTask, hasInitialTaskExecutorPreference, taskName);
+      asyncLet, isDiscardingTask, hasInitialTaskExecutorPreference, taskName,
+      task);
 }
 
 inline void task_destroy(AsyncTask *task) {
   ENSURE_LOGS();
   auto id = os_signpost_id_make_with_pointer(TaskLog, task);
   os_signpost_interval_end(TaskLog, id, SWIFT_LOG_TASK_LIFETIME_NAME,
-                           "task=%" PRId64 "", task->getTaskId());
+                           "task=%" PRId64 " taskPointer=%p",
+                           task->getTaskId(), task);
 }
 
 inline void task_status_changed(AsyncTask *task, uint8_t maxPriority,
@@ -234,13 +239,16 @@ inline void task_status_changed(AsyncTask *task, uint8_t maxPriority,
 #endif // !TARGET_OS_SIMULATOR
   ENSURE_LOGS();
   auto id = os_signpost_id_make_with_pointer(TaskLog, task);
+  const char *taskName = task->getTaskName();
   os_signpost_event_emit(
       TaskLog, id, SWIFT_LOG_TASK_STATUS_CHANGED_NAME,
       "task=%" PRId64 " resumefn=%p "
       "maxPriority=%u, isCancelled=%{bool}d "
-      "isEscalated=%{bool}d, isRunning=%{bool}d, isEnqueued=%{bool}d",
-      task->getTaskId(), task->getResumeFunctionForLogging(isStarting), maxPriority,
-      isCancelled, isEscalated, isRunning, isEnqueued);
+      "isEscalated=%{bool}d, isRunning=%{bool}d, isEnqueued=%{bool}d "
+      "taskName=%{public}s taskPointer=%p",
+      task->getTaskId(), task->getResumeFunctionForLogging(isStarting),
+      maxPriority, isCancelled, isEscalated, isRunning, isEnqueued, taskName,
+      task);
 }
 
 inline void task_flags_changed(AsyncTask *task, uint8_t jobPriority,
@@ -250,10 +258,11 @@ inline void task_flags_changed(AsyncTask *task, uint8_t jobPriority,
   auto id = os_signpost_id_make_with_pointer(TaskLog, task);
   os_signpost_event_emit(
       TaskLog, id, SWIFT_LOG_TASK_FLAGS_CHANGED_NAME,
-      "task=%" PRId64 " jobPriority=%u isChildTask=%{bool}d, isFuture=%{bool}d "
-                      "isGroupChildTask=%{bool}d isAsyncLetTask=%{bool}d",
-      task->getTaskId(), jobPriority, isChildTask, isFuture, isGroupChildTask,
-      isAsyncLetTask);
+      "task=%" PRId64
+      " jobPriority=%u isChildTask=%{bool}d, isFuture=%{bool}d "
+      "isGroupChildTask=%{bool}d isAsyncLetTask=%{bool}d taskPointer=%p",
+      task->getTaskId(), jobPriority, isChildTask, isFuture,
+      isGroupChildTask, isAsyncLetTask, task);
 }
 
 inline void task_wait(AsyncTask *task, AsyncTask *waitingOn, uintptr_t status) {
@@ -262,14 +271,15 @@ inline void task_wait(AsyncTask *task, AsyncTask *waitingOn, uintptr_t status) {
   auto waitingID = waitingOn ? waitingOn->getTaskId() : 0;
   os_signpost_interval_begin(TaskLog, id, SWIFT_LOG_TASK_WAIT_NAME,
                              "task=%" PRId64 " waitingOnTask=%" PRId64
-                             " status=0x%" PRIxPTR,
-                             task->getTaskId(), waitingID, status);
+                             " status=0x%" PRIxPTR " taskPointer=%p",
+                             task->getTaskId(), waitingID, status, task);
 }
 
 inline void task_resume(AsyncTask *task) {
   auto id = os_signpost_id_make_with_pointer(TaskLog, task);
   os_signpost_interval_end(TaskLog, id, SWIFT_LOG_TASK_WAIT_NAME,
-                           "task=%" PRId64, task->getTaskId());
+                           "task=%" PRId64 " taskPointer=%p",
+                           task->getTaskId(), task);
 }
 
 inline void task_continuation_init(AsyncTask *task,
@@ -277,8 +287,8 @@ inline void task_continuation_init(AsyncTask *task,
   ENSURE_LOGS();
   auto id = os_signpost_id_make_with_pointer(TaskLog, context);
   os_signpost_interval_begin(TaskLog, id, SWIFT_LOG_TASK_CONTINUATION,
-                             "task=%" PRId64 " context=%p", task->getTaskId(),
-                             context);
+                             "task=%" PRId64 " context=%p taskPointer=%p",
+                             task->getTaskId(), context, task);
 }
 
 inline void task_continuation_await(ContinuationAsyncContext *context) {
@@ -301,7 +311,8 @@ inline void job_enqueue_global(Job *job) {
     ENSURE_LOGS();
     auto id = os_signpost_id_make_with_pointer(TaskLog, job);
     os_signpost_event_emit(TaskLog, id, SWIFT_LOG_JOB_ENQUEUE_GLOBAL_NAME,
-                           "task=%" PRId64, task->getTaskId());
+                           "task=%" PRId64 " taskPointer=%p",
+                           task->getTaskId(), task);
   }
 }
 
@@ -311,21 +322,47 @@ inline void job_enqueue_global_with_delay(unsigned long long delay, Job *job) {
     auto id = os_signpost_id_make_with_pointer(TaskLog, job);
     os_signpost_event_emit(
         TaskLog, id, SWIFT_LOG_JOB_ENQUEUE_GLOBAL_WITH_DELAY_NAME,
-        "task=%" PRId64 " delay=%llu", task->getTaskId(), delay);
+        "task=%" PRId64 " delay=%llu taskPointer=%p",
+        task->getTaskId(), delay, task);
   }
 }
 
-inline void job_enqueue_main_executor(Job *job) {
+inline TracingExecutorKind classifyExecutor(SerialExecutorRef serialExecutor,
+                                            TaskExecutorRef taskExecutor) {
+  if (serialExecutor.isMainExecutor())
+    return TracingExecutorKind::MainActor;
+  if (serialExecutor.isDefaultActor())
+    return TracingExecutorKind::DefaultActor;
+  if (!serialExecutor.isGeneric())
+    return TracingExecutorKind::CustomSerialExecutor;
+  if (taskExecutor.isDefined())
+    return TracingExecutorKind::TaskExecutor;
+  return TracingExecutorKind::GlobalConcurrent;
+}
+
+inline void job_enqueue_executor(Job *job, SerialExecutorRef serialExecutor,
+                                  TaskExecutorRef taskExecutor) {
   if (AsyncTask *task = dyn_cast<AsyncTask>(job)) {
     ENSURE_LOGS();
+    HeapObject *executorIdentity =
+        serialExecutor.isGeneric() ? nullptr : serialExecutor.getIdentity();
+    auto metadata =
+        executorIdentity ? swift_getObjectType(executorIdentity) : nullptr;
+    auto descriptor = metadata
+        ? (const void *)metadata->getTypeContextDescriptor() : nullptr;
+    auto executorKind = classifyExecutor(serialExecutor, taskExecutor);
     auto id = os_signpost_id_make_with_pointer(TaskLog, job);
-    os_signpost_event_emit(TaskLog, id,
-                           SWIFT_LOG_JOB_ENQUEUE_MAIN_EXECUTOR_NAME,
-                           "task=%" PRId64, task->getTaskId());
+    os_signpost_event_emit(TaskLog, id, SWIFT_LOG_JOB_ENQUEUE_EXECUTOR_NAME,
+                           "task=%" PRId64 " taskPointer=%p"
+                           " executor=%p metadata=%p descriptor=%p"
+                           " executorKind=%u",
+                           task->getTaskId(), task, executorIdentity, metadata,
+                           descriptor, (unsigned)executorKind);
   }
 }
 
-inline job_run_info job_run_begin(Job *job) {
+inline job_run_info job_run_begin(Job *job, SerialExecutorRef serialExecutor,
+                                  TaskExecutorRef taskExecutor) {
   auto invalidInfo = []{
     return job_run_info{ 0, OS_SIGNPOST_ID_INVALID };
   };
@@ -334,8 +371,26 @@ inline job_run_info job_run_begin(Job *job) {
     ENSURE_LOGS(invalidInfo());
     auto handle = os_signpost_id_generate(TaskLog);
     auto taskId = task->getTaskId();
-    os_signpost_interval_begin(TaskLog, handle, SWIFT_LOG_JOB_RUN_NAME,
-                               "task=%" PRId64, taskId);
+    const char *taskName = task->getTaskName();
+
+    HeapObject *actor = serialExecutor.isDefaultActor()
+                            ? serialExecutor.getDefaultActor()
+                            : nullptr;
+    HeapObject *executorIdentity =
+        serialExecutor.isGeneric() ? nullptr : serialExecutor.getIdentity();
+    auto metadata =
+        executorIdentity ? swift_getObjectType(executorIdentity) : nullptr;
+    auto descriptor = metadata
+        ? (const void *)metadata->getTypeContextDescriptor() : nullptr;
+    auto executorKind = classifyExecutor(serialExecutor, taskExecutor);
+
+    os_signpost_interval_begin(
+        TaskLog, handle, SWIFT_LOG_JOB_RUN_NAME,
+        "task=%" PRId64 " taskPointer=%p"
+        " actor=%p executor=%p metadata=%p descriptor=%p "
+        "taskName=%{public}s executorKind=%u",
+        taskId, task, actor, executorIdentity, metadata, descriptor, taskName,
+        (unsigned)executorKind);
     return { taskId, handle };
   }
   return invalidInfo();

--- a/stdlib/public/Concurrency/TracingStubs.h
+++ b/stdlib/public/Concurrency/TracingStubs.h
@@ -18,14 +18,13 @@
 #define SWIFT_CONCURRENCY_TRACINGSIGNPOST_H
 
 #include "Tracing.h"
+#include "swift/ABI/Executor.h"
 
 namespace swift {
 namespace concurrency {
 namespace trace {
 
 inline void actor_create(HeapObject *actor) {}
-
-inline void actor_destroy(HeapObject *actor) {}
 
 inline void actor_deallocate(HeapObject *actor) {}
 
@@ -75,9 +74,13 @@ inline void job_enqueue_global(Job *job) {}
 
 inline void job_enqueue_global_with_delay(unsigned long long delay, Job *job) {}
 
-inline void job_enqueue_main_executor(Job *job) {}
+inline void job_enqueue_executor(Job *job, SerialExecutorRef serialExecutor,
+                                  TaskExecutorRef taskExecutor) {}
 
-inline job_run_info job_run_begin(Job *job) { return {}; }
+inline job_run_info job_run_begin(Job *job, SerialExecutorRef serialExecutor,
+                                  TaskExecutorRef taskExecutor) {
+  return {};
+}
 
 inline void job_run_end(job_run_info info) {}
 

--- a/stdlib/public/runtime/EnvironmentVariables.cpp
+++ b/stdlib/public/runtime/EnvironmentVariables.cpp
@@ -323,3 +323,7 @@ SWIFT_RUNTIME_STDLIB_SPI const char *concurrencyIsCurrentExecutorLegacyModeOverr
 SWIFT_RUNTIME_STDLIB_SPI bool concurrencyEnableTaskSlabAllocator() {
   return runtime::environment::SWIFT_DEBUG_ENABLE_TASK_SLAB_ALLOCATOR();
 }
+
+SWIFT_RUNTIME_STDLIB_SPI const char *concurrencyTracingSubsystem() {
+  return runtime::environment::SWIFT_CONCURRENCY_TRACING_SUBSYSTEM();
+}

--- a/stdlib/public/runtime/EnvironmentVariables.def
+++ b/stdlib/public/runtime/EnvironmentVariables.def
@@ -155,4 +155,10 @@ VARIABLE(SWIFT_DEBUG_ENABLE_TASK_SLAB_ALLOCATOR, bool, true,
          "call malloc/free. Direct use of malloc/free enables use of memory "
          "debugging tools for async stack allocations.")
 
+VARIABLE(SWIFT_CONCURRENCY_TRACING_SUBSYSTEM, string, "",
+         "Override the os_signpost subsystem used for concurrency tracing. "
+         "When set, signposts are emitted under this subsystem instead of "
+         "com.apple.swift.concurrency. Useful for testing, since the default "
+         "subsystem has signposts disabled by system logging preferences.")
+
 #undef VARIABLE

--- a/test/Concurrency/Runtime/signpost_tracing_test.swift
+++ b/test/Concurrency/Runtime/signpost_tracing_test.swift
@@ -1,0 +1,541 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -g %s -o %t/a.out -target %target-swift-6.2-abi-triple -Onone
+// RUN: %target-codesign %t/a.out
+// RUN: env %env-SWIFT_CONCURRENCY_TRACING_SUBSYSTEM=org.swift.concurrency.test.tracing %target-run %t/a.out
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+// REQUIRES: OS=macosx
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+// Verify signposts emitted by the Concurrency runtime. Built at -Onone to avoid
+// the optimizer eliminating unnecessary Concurrency-related operations.
+
+import Foundation
+import os
+import StdlibUnittest
+
+// MARK: - Signpost JSON Model
+
+/// Represents one NDJSON record from `log stream --style ndjson`.
+struct LogStreamRecord: Decodable {
+  var signpostName: String?
+  var signpostType: SignpostType?
+  var eventMessage: String?
+
+  enum SignpostType: String, Decodable {
+    case begin
+    case end
+    case event
+  }
+}
+
+// MARK: - Signpost Event
+
+struct SignpostEvent: CustomStringConvertible {
+  var name: String
+  var type: LogStreamRecord.SignpostType
+  var message: String
+
+  var description: String { "\(name) (\(type.rawValue)): \(message)" }
+}
+
+// MARK: - Expected Signpost
+
+/// An expected signpost. If `type` is nil, matches any event type with that
+/// name. If `messageContains` is non-nil, the event message must contain
+/// that substring.
+struct ExpectedSignpost: CustomStringConvertible {
+  var name: String
+  var type: LogStreamRecord.SignpostType?
+  var messageContains: String?
+
+  var description: String {
+    var result = name
+    if let type { result += " (\(type.rawValue))" }
+    if let messageContains { result += " [contains: \(messageContains)]" }
+    return result
+  }
+
+  func matches(_ event: SignpostEvent) -> Bool {
+    if name != event.name { return false }
+    if let type, type != event.type { return false }
+    if let messageContains, !event.message.contains(messageContains) {
+      return false
+    }
+    return true
+  }
+}
+
+func beginEnd(_ name: String) -> [ExpectedSignpost] {
+  [
+    ExpectedSignpost(name: name, type: .begin),
+    ExpectedSignpost(name: name, type: .end),
+  ]
+}
+
+// MARK: - Errors
+
+struct TimeoutError: Error, CustomStringConvertible {
+  var description: String { "Timed out waiting for signpost events" }
+}
+
+// MARK: - Signpost Monitor
+
+/// Monitors signpost events from this process using `log stream`.
+///
+/// Usage:
+///   let monitor = try await SignpostMonitor.start(expected: [...])
+///   // ... do async work that triggers signposts ...
+///   await monitor.expectAllSignpostsReceived()
+class SignpostMonitor {
+  private let process: Process
+  private let events: AsyncThrowingStream<SignpostEvent, Error>
+  private let eventsContinuation: AsyncThrowingStream<SignpostEvent, Error>.Continuation
+
+  static let subsystem = "org.swift.concurrency.test.tracing"
+  private static let canaryName = "signpost_monitor_canary"
+  private static let canarySignposter = OSSignposter(
+    subsystem: SignpostMonitor.subsystem, category: "TestCanary")
+
+  private let decoder = JSONDecoder()
+
+  private init(process: Process,
+               events: AsyncThrowingStream<SignpostEvent, Error>,
+               continuation: AsyncThrowingStream<SignpostEvent, Error>.Continuation) {
+    self.process = process
+    self.events = events
+    self.eventsContinuation = continuation
+  }
+
+  /// Launches `log stream`, waits for it to be fully connected (via a canary
+  /// signpost), and returns a monitor ready to receive events.
+  static func start() async -> SignpostMonitor {
+    let pid = ProcessInfo.processInfo.processIdentifier
+
+    let (events, continuation) = AsyncThrowingStream<SignpostEvent, Error>.makeStream()
+
+    let process = Process()
+    let pipe = Pipe()
+
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/log")
+    process.arguments = [
+      "stream",
+      "--signpost",
+      "--predicate",
+      "subsystem == \"\(subsystem)\" AND processIdentifier == \(pid)",
+      "--style", "ndjson",
+    ]
+    process.standardOutput = pipe
+    process.standardError = FileHandle.nullDevice
+
+    let monitor = SignpostMonitor(
+      process: process, events: events, continuation: continuation)
+
+    // readabilityHandler is not called concurrently, so no locking needed.
+    // Use nonisolated(unsafe) to tell the compiler we know what we're doing.
+    nonisolated(unsafe) var buffer = Data()
+    let headerReady = AsyncThrowingStream<Void, Error>.makeStream()
+
+    pipe.fileHandleForReading.readabilityHandler = { handle in
+      let data = handle.availableData
+      guard !data.isEmpty else { return }
+
+      buffer.append(data)
+
+      while let newlineIndex = buffer.firstIndex(of: UInt8(ascii: "\n")) {
+        let lineData = buffer[buffer.startIndex..<newlineIndex]
+        buffer = buffer[(buffer.index(after: newlineIndex))...]
+
+        guard let line = String(data: lineData, encoding: .utf8) else {
+          continue
+        }
+
+        // The first line from `log stream` is a header like "Filtering the
+        // log data using ...". Use it as the readiness signal.
+        if line.hasPrefix("Filtering") || line.hasPrefix("Timestamp") {
+          headerReady.1.finish()
+          continue
+        }
+
+        monitor.processLine(line)
+      }
+    }
+
+    do {
+      try process.run()
+    } catch {
+      fatalError("Failed to launch log stream: \(error)")
+    }
+
+    // Wait for the header line, with timeout.
+    do {
+      try await withThrowingTaskGroup(of: Void.self) { group in
+        group.addTask {
+          for try await _ in headerReady.0 {}
+        }
+        group.addTask {
+          try await Task.sleep(for: .seconds(20))
+          throw TimeoutError()
+        }
+        try await group.next()
+        group.cancelAll()
+      }
+    } catch {
+      fatalError("log stream failed to become ready: \(error)")
+    }
+
+    // The header line appears before the stream is fully connected to logd.
+    // Emit canary signposts until we see one come back, confirming the stream
+    // is truly live.
+    let canaryStream = AsyncThrowingStream<Void, Error>.makeStream()
+    monitor.canaryReady = canaryStream.1
+
+    do {
+      try await withThrowingTaskGroup(of: Void.self) { group in
+        group.addTask {
+          for try await _ in canaryStream.0 {}
+        }
+        group.addTask {
+          while !Task.isCancelled {
+            canarySignposter.emitEvent("signpost_monitor_canary")
+            try await Task.sleep(for: .milliseconds(100))
+          }
+        }
+        group.addTask {
+          try await Task.sleep(for: .seconds(20))
+          throw TimeoutError()
+        }
+        try await group.next()
+        group.cancelAll()
+      }
+    } catch {
+      fatalError("log stream canary failed: \(error)")
+    }
+    monitor.canaryReady = nil
+
+    return monitor
+  }
+
+  private var canaryReady: AsyncThrowingStream<Void, Error>.Continuation?
+
+  private func processLine(_ line: String) {
+    guard let data = line.data(using: .utf8),
+          let record = try? decoder.decode(LogStreamRecord.self, from: data),
+          let name = record.signpostName
+    else {
+      return
+    }
+
+    // Canary signpost — used to confirm log stream is fully connected.
+    if name == SignpostMonitor.canaryName {
+      canaryReady?.finish()
+      return
+    }
+
+    let event = SignpostEvent(
+      name: name,
+      type: record.signpostType ?? .event,
+      message: record.eventMessage ?? ""
+    )
+    eventsContinuation.yield(event)
+  }
+
+  /// Wait for all expected signposts to arrive. On timeout, reports which
+  /// signposts were missing and what was observed.
+  func expectAllSignpostsReceived(
+    _ expected: [ExpectedSignpost],
+    timeout: Duration = .seconds(20)
+  ) async {
+    var remaining = expected
+    var observed: [SignpostEvent] = []
+
+    let timeoutTask = Task.detached { [eventsContinuation] in
+      try await Task.sleep(for: timeout)
+      eventsContinuation.finish(throwing: TimeoutError())
+    }
+
+    do {
+      for try await event in events {
+        observed.append(event)
+        if let idx = remaining.firstIndex(where: { $0.matches(event) }) {
+          remaining.remove(at: idx)
+          if remaining.isEmpty {
+            break
+          }
+        }
+      }
+    } catch is TimeoutError {
+      print("Timed out waiting for signposts. Observed so far:")
+      for event in observed {
+        print("  \(event)")
+      }
+      // Fall through to report missing signposts below.
+    } catch {
+      expectTrue(false, "Unexpected error: \(error)")
+    }
+
+    timeoutTask.cancel()
+    process.terminate()
+    process.waitUntilExit()
+
+    if !remaining.isEmpty {
+      var msg = "Missing signposts:\n"
+      for m in remaining {
+        msg += "  - \(m)\n"
+      }
+      expectTrue(false, msg)
+    }
+  }
+}
+
+// MARK: - Tests
+
+var tests = TestSuite("SignpostTracing")
+
+tests.test("BasicTaskLifecycle") {
+  let monitor = await SignpostMonitor.start()
+
+  let value = await Task { return 42 }.value
+  precondition(value == 42)
+
+  await monitor.expectAllSignpostsReceived(
+    beginEnd("task_lifetime")
+    + [ExpectedSignpost(name: "job_run", type: .begin,
+                        messageContains: "executorKind=0"),
+       ExpectedSignpost(name: "job_run", type: .end),
+       ExpectedSignpost(name: "job_enqueue_global", type: .event),
+       ExpectedSignpost(name: "task_status_changed", type: .event)]
+  )
+}
+
+tests.test("TaskWait") {
+  let monitor = await SignpostMonitor.start()
+
+  async let result = { () async -> Int in
+    try? await Task.sleep(for: .milliseconds(10))
+    return 42
+  }()
+  let _ = await result
+
+  await monitor.expectAllSignpostsReceived(
+    beginEnd("task_wait")
+  )
+}
+
+tests.test("Continuation") {
+  let monitor = await SignpostMonitor.start()
+
+  await withCheckedContinuation {
+    (continuation: CheckedContinuation<Void, Never>) in
+    DispatchQueue.global().async {
+      continuation.resume()
+    }
+  }
+
+  await monitor.expectAllSignpostsReceived(
+    beginEnd("task_continuation")
+    + [ExpectedSignpost(name: "task_continuation_await", type: .event)]
+  )
+}
+
+tests.test("ThrowingContinuationWithError") {
+  struct TestError: Error {}
+
+  let monitor = await SignpostMonitor.start()
+
+  do {
+    try await withCheckedThrowingContinuation {
+      (continuation: CheckedContinuation<Void, Error>) in
+      DispatchQueue.global().async {
+        continuation.resume(throwing: TestError())
+      }
+    }
+  } catch {}
+
+  await monitor.expectAllSignpostsReceived(
+    beginEnd("task_continuation")
+    + [ExpectedSignpost(name: "task_continuation_await", type: .event)]
+  )
+}
+
+// Tests the throwing continuation path where resume succeeds (no error thrown).
+// This exercises swift_continuation_throwingResumeImpl (a different call site
+// from the non-throwing and error paths).
+tests.test("ThrowingContinuationWithoutError") {
+  let monitor = await SignpostMonitor.start()
+
+  let value = try! await withCheckedThrowingContinuation {
+    (continuation: CheckedContinuation<Int, Error>) in
+    DispatchQueue.global().async {
+      continuation.resume(returning: 42)
+    }
+  }
+  precondition(value == 42)
+
+  await monitor.expectAllSignpostsReceived(
+    beginEnd("task_continuation")
+    + [ExpectedSignpost(name: "task_continuation_await", type: .event)]
+  )
+}
+
+// Note: job_enqueue_global_with_delay is not tested because Task.sleep now
+// routes through the scheduling executor's enqueue(after:clock:) method
+// rather than swift_task_enqueueGlobalWithDelay.
+
+tests.test("MainExecutorEnqueue") {
+  @MainActor func onMain() -> Int { return 1 }
+
+  let monitor = await SignpostMonitor.start()
+
+  let _ = await Task.detached {
+    return await onMain()
+  }.value
+
+  // Hopping to @MainActor goes through swift_task_enqueueImpl, which emits
+  // job_enqueue_executor. executorKind=2 is MainActor.
+  await monitor.expectAllSignpostsReceived(
+    [ExpectedSignpost(name: "job_enqueue_executor", type: .event,
+                      messageContains: "executorKind=2"),
+     ExpectedSignpost(name: "job_run", type: .begin,
+                      messageContains: "executorKind=2")]
+  )
+}
+
+tests.test("ActorInteraction") {
+  actor WorkActor {
+    func work() {}
+  }
+
+  let monitor = await SignpostMonitor.start()
+
+  let a = WorkActor()
+  await a.work()
+  withExtendedLifetime(a) {}
+
+  await monitor.expectAllSignpostsReceived(
+    [ExpectedSignpost(name: "actor_lifetime", type: .begin),
+     ExpectedSignpost(name: "actor_state_changed", type: .event),
+     ExpectedSignpost(name: "actor_enqueue", type: .event),
+     ExpectedSignpost(name: "actor_dequeue", type: .event),
+     ExpectedSignpost(name: "actor_job_queue", type: .event),
+     // The job runs on the default actor. executorKind=1 is DefaultActor.
+     ExpectedSignpost(name: "job_run", type: .begin,
+                      messageContains: "executorKind=1")]
+  )
+}
+
+tests.test("ActorDeallocation") {
+  actor ShortLivedActor {
+    func ping() {}
+  }
+
+  let monitor = await SignpostMonitor.start()
+
+  // Create and destroy inside a helper so the actor goes out of scope.
+  func createAndDestroy() async {
+    let a = ShortLivedActor()
+    await a.ping()
+  }
+  await createAndDestroy()
+
+  await monitor.expectAllSignpostsReceived(
+    beginEnd("actor_lifetime")
+    + [ExpectedSignpost(name: "actor_deallocate", type: .event)]
+  )
+}
+
+tests.test("TaskGroup") {
+  let monitor = await SignpostMonitor.start()
+
+  await withTaskGroup(of: Int.self) { group in
+    group.addTask { 1 }
+    group.addTask { 2 }
+    var sum = 0
+    for await val in group { sum += val }
+    precondition(sum == 3)
+  }
+
+  await monitor.expectAllSignpostsReceived(
+    // At least two child task lifecycles.
+    beginEnd("task_lifetime")
+    + beginEnd("task_lifetime")
+    + [ExpectedSignpost(name: "job_enqueue_global", type: .event),
+       ExpectedSignpost(name: "job_enqueue_global", type: .event)]
+  )
+}
+
+tests.test("AsyncLet") {
+  let monitor = await SignpostMonitor.start()
+
+  @Sendable func compute() async -> Int {
+    try? await Task.sleep(for: .milliseconds(10))
+    return 7
+  }
+  async let result = compute()
+  let _ = await result
+
+  await monitor.expectAllSignpostsReceived(
+    beginEnd("task_lifetime")
+    + beginEnd("task_wait")
+    + [ExpectedSignpost(name: "task_flags_changed", type: .event)]
+  )
+}
+
+// Test executorKind for a custom serial executor (executorKind=3).
+tests.test("CustomSerialExecutorKind") {
+  final class MyExecutor: SerialExecutor {
+    func enqueue(_ job: consuming ExecutorJob) {
+      job.runSynchronously(on: asUnownedSerialExecutor())
+    }
+  }
+
+  actor CustomExecutorActor {
+    let executor: MyExecutor
+    nonisolated var unownedExecutor: UnownedSerialExecutor {
+      executor.asUnownedSerialExecutor()
+    }
+    init(executor: MyExecutor) { self.executor = executor }
+    func work() -> Int { return 1 }
+  }
+
+  let monitor = await SignpostMonitor.start()
+  let executor = MyExecutor()
+  let actor = CustomExecutorActor(executor: executor)
+
+  let _ = await actor.work()
+
+  // executorKind=3 is CustomSerialExecutor.
+  await monitor.expectAllSignpostsReceived(
+    [ExpectedSignpost(name: "job_enqueue_executor", type: .event,
+                      messageContains: "executorKind=3"),
+     ExpectedSignpost(name: "job_run", type: .begin,
+                      messageContains: "executorKind=3")]
+  )
+}
+
+// Test executorKind for a task executor (executorKind=4).
+tests.test("TaskExecutorKind") {
+  final class MyTaskExecutor: TaskExecutor {
+    func enqueue(_ job: consuming ExecutorJob) {
+      job.runSynchronously(on: asUnownedTaskExecutor())
+    }
+  }
+
+  let monitor = await SignpostMonitor.start()
+  let executor = MyTaskExecutor()
+
+  let _ = await Task(executorPreference: executor) {
+    return 1
+  }.value
+
+  // executorKind=4 is TaskExecutor.
+  await monitor.expectAllSignpostsReceived(
+    [ExpectedSignpost(name: "job_run", type: .begin,
+                      messageContains: "executorKind=4")]
+  )
+}
+
+await runAllTestsAsync()

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -1280,3 +1280,6 @@ Added: _$ss15CollectionOfOneVyxGSQsSQRzlMc
 Added: _$ss15EmptyCollectionV9hashValueSivpMV
 Added: _$ss15EmptyCollectionVyxGSHsMc
 Added: _$ss15EmptyCollectionVyxGSHsWP
+
+// Wrapper for SWIFT_CONCURRENCY_TRACING_SUBSYSTEM environment variable
+Added: _concurrencyTracingSubsystem

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -1275,3 +1275,6 @@ Added: _$ss15CollectionOfOneVyxGSQsSQRzlMc
 Added: _$ss15EmptyCollectionV9hashValueSivpMV
 Added: _$ss15EmptyCollectionVyxGSHsMc
 Added: _$ss15EmptyCollectionVyxGSHsWP
+
+// Wrapper for SWIFT_CONCURRENCY_TRACING_SUBSYSTEM environment variable
+Added: _concurrencyTracingSubsystem


### PR DESCRIPTION
* Have job_run include the actor, executor, and task name.
* Make task_status_changed only trace if one of the tracked values actually changed.
* Add a job_enqueue_executor that covers enqueueing jobs on serial executors (default actors, custom executors, main actor, etc.).
* Actually end the actor lifetime signpost interval.
* Include the actor metadata and context descriptor pointers in actor enqueue/dequeue so the type can be identified.
* Add the task pointer to all task-related signpost messages.
* Emit job_enqueue_main_executor from the swift_task_enqueueImpl path so main actor enqueues appear in traces.
* Add TracingExecutorKind enum and log executorKind in job_enqueue_executor and job_run to distinguish global, default actor, main actor, custom serial executor, and task executor contexts.

While we're here, finally add a test for Concurrency signposts. This is difficult because the signposts are disabled by default and there isn't a good way to turn them on in an automated fashion. Resolve this by adding an environment variable, SWIFT_CONCURRENCY_TRACING_SUBSYSTEM, which overrides the subsystem used by the Concurrency signpost code. The test can use this to set a subsystem that isn't disabled by default, which then allows `log stream` to capture the signposts.

rdar://169727270