### PR TITLE
[cxx-interop] [NFC] Stabilize interface order of Clang record members

### DIFF
--- a/test/Interop/C/bounds-safety/import-bounds-attributed-struct.swift
+++ b/test/Interop/C/bounds-safety/import-bounds-attributed-struct.swift
@@ -6,60 +6,60 @@
 // rather than being marked unavailable because of an unknown type.
 
 // CHECK:      struct a {
-// CHECK-NEXT:   init()
-// CHECK-NEXT:   init(a: UnsafeMutablePointer<Int{{[0-9]+}}>!, len: Int{{[0-9]+}})
-// CHECK-NEXT:   var a: UnsafeMutablePointer<Int{{[0-9]+}}>!
-// CHECK-NEXT:   var len: Int{{[0-9]+}}
+// CHECK-DAG:   init()
+// CHECK-DAG:   init(a: UnsafeMutablePointer<Int{{[0-9]+}}>!, len: Int{{[0-9]+}})
+// CHECK-NEXT:  var a: UnsafeMutablePointer<Int{{[0-9]+}}>!
+// CHECK-NEXT:  var len: Int{{[0-9]+}}
 // CHECK-NEXT: }
 // CHECK-NEXT: func a(_: a) -> UnsafeMutablePointer<a>!
-// CHECK-NEXT: struct b {
-// CHECK-NEXT:   init()
-// CHECK-NEXT:   init(a: UnsafeMutablePointer<Int{{[0-9]+}}>!, len: Int{{[0-9]+}})
-// CHECK-NEXT:   var a: UnsafeMutablePointer<Int{{[0-9]+}}>!
-// CHECK-NEXT:   var len: Int{{[0-9]+}}
+// CHECK:      struct b {
+// CHECK-DAG:   init()
+// CHECK-DAG:   init(a: UnsafeMutablePointer<Int{{[0-9]+}}>!, len: Int{{[0-9]+}})
+// CHECK-NEXT:  var a: UnsafeMutablePointer<Int{{[0-9]+}}>!
+// CHECK-NEXT:  var len: Int{{[0-9]+}}
 // CHECK-NEXT: }
 // CHECK-NEXT: func b(_: b) -> UnsafeMutablePointer<b>!
-// CHECK-NEXT: struct c {
-// CHECK-NEXT:   init()
-// CHECK-NEXT:   init(a: UnsafeMutablePointer<CChar>!, len: Int{{[0-9]+}})
-// CHECK-NEXT:   var a: UnsafeMutablePointer<CChar>!
-// CHECK-NEXT:   var len: Int{{[0-9]+}}
+// CHECK:      struct c {
+// CHECK-DAG:   init()
+// CHECK-DAG:   init(a: UnsafeMutablePointer<CChar>!, len: Int{{[0-9]+}})
+// CHECK-NEXT:  var a: UnsafeMutablePointer<CChar>!
+// CHECK-NEXT:  var len: Int{{[0-9]+}}
 // CHECK-NEXT: }
 // CHECK-NEXT: func c(_: c) -> UnsafeMutablePointer<c>!
-// CHECK-NEXT: struct d {
-// CHECK-NEXT:   init()
-// CHECK-NEXT:   init(a: UnsafeMutableRawPointer!, len: Int{{[0-9]+}})
-// CHECK-NEXT:   var a: UnsafeMutableRawPointer!
-// CHECK-NEXT:   var len: Int{{[0-9]+}}
+// CHECK:      struct d {
+// CHECK-DAG:   init()
+// CHECK-DAG:   init(a: UnsafeMutableRawPointer!, len: Int{{[0-9]+}})
+// CHECK-NEXT:  var a: UnsafeMutableRawPointer!
+// CHECK-NEXT:  var len: Int{{[0-9]+}}
 // CHECK-NEXT: }
 // CHECK-NEXT: func d(_: d) -> UnsafeMutablePointer<d>!
-// CHECK-NEXT: struct e {
-// CHECK-NEXT:   init()
-// CHECK-NEXT:   init(a: UnsafeMutableRawPointer!, b: UnsafeMutablePointer<Int{{[0-9]+}}>!)
-// CHECK-NEXT:   var a: UnsafeMutableRawPointer!
-// CHECK-NEXT:   var b: UnsafeMutablePointer<Int{{[0-9]+}}>!
+// CHECK:      struct e {
+// CHECK-DAG:   init()
+// CHECK-DAG:   init(a: UnsafeMutableRawPointer!, b: UnsafeMutablePointer<Int{{[0-9]+}}>!)
+// CHECK-NEXT:  var a: UnsafeMutableRawPointer!
+// CHECK-NEXT:  var b: UnsafeMutablePointer<Int{{[0-9]+}}>!
 // CHECK-NEXT: }
 // CHECK-NEXT: func e(_: e) -> UnsafeMutablePointer<e>!
-// CHECK-NEXT: struct f {
-// CHECK-NEXT:   init()
-// CHECK-NEXT:   init(a: UnsafePointer<CChar>!, b: UnsafeMutablePointer<CChar>!)
-// CHECK-NEXT:   var a: UnsafePointer<CChar>!
-// CHECK-NEXT:   var b: UnsafeMutablePointer<CChar>!
+// CHECK:      struct f {
+// CHECK-DAG:   init()
+// CHECK-DAG:   init(a: UnsafePointer<CChar>!, b: UnsafeMutablePointer<CChar>!)
+// CHECK-NEXT:  var a: UnsafePointer<CChar>!
+// CHECK-NEXT:  var b: UnsafeMutablePointer<CChar>!
 // CHECK-NEXT: }
 // CHECK-NEXT: func f(_: f) -> UnsafeMutablePointer<f>!
 
 // BOUNDS-SAFETY-NEXT: struct g {
-// BOUNDS-SAFETY-NEXT:  init()
-// BOUNDS-SAFETY-NEXT:  init(a: UnsafeMutableRawPointer!, b: UnsafeMutablePointer<Int32>!)
-// BOUNDS-SAFETY-NEXT:  var a: UnsafeMutableRawPointer!
-// BOUNDS-SAFETY-NEXT:  var b: UnsafeMutablePointer<Int32>!
+// BOUNDS-SAFETY-DAG:  init()
+// BOUNDS-SAFETY-DAG:  init(a: UnsafeMutableRawPointer!, b: UnsafeMutablePointer<Int32>!)
+// BOUNDS-SAFETY-NEXT: var a: UnsafeMutableRawPointer!
+// BOUNDS-SAFETY-NEXT: var b: UnsafeMutablePointer<Int32>!
 // BOUNDS-SAFETY-NEXT: }
 // BOUNDS-SAFETY-NEXT: func g(_: g) -> UnsafeMutablePointer<g>!
 // BOUNDS-SAFETY-NEXT: struct h {
-// BOUNDS-SAFETY-NEXT:  init()
-// BOUNDS-SAFETY-NEXT:  init(a: UnsafeMutableRawPointer!, b: UnsafeMutablePointer<Int32>!)
-// BOUNDS-SAFETY-NEXT:  var a: UnsafeMutableRawPointer!
-// BOUNDS-SAFETY-NEXT:  var b: UnsafeMutablePointer<Int32>!
+// BOUNDS-SAFETY-DAG:  init()
+// BOUNDS-SAFETY-DAG:  init(a: UnsafeMutableRawPointer!, b: UnsafeMutablePointer<Int32>!)
+// BOUNDS-SAFETY-NEXT: var a: UnsafeMutableRawPointer!
+// BOUNDS-SAFETY-NEXT: var b: UnsafeMutablePointer<Int32>!
 // BOUNDS-SAFETY-NEXT: }
 // BOUNDS-SAFETY-NEXT: func h(_: h) -> UnsafeMutablePointer<h>!
 
@@ -69,19 +69,19 @@
 // CHECK-NEXT: }
 // CHECK-NEXT: func i(_: UnsafeMutablePointer<i>!) -> UnsafeMutablePointer<i>!
 // CHECK-NEXT: var len1: Int{{[0-9]+}} { get }
-// CHECK-NEXT: struct j {
-// CHECK-NEXT:   init()
-// CHECK-NEXT:   init(a: UnsafeMutablePointer<Int{{[0-9]+}}>!, b: UnsafeMutableRawPointer!)
-// CHECK-NEXT:   var a: UnsafeMutablePointer<Int{{[0-9]+}}>!
-// CHECK-NEXT:   var b: UnsafeMutableRawPointer!
+// CHECK:      struct j {
+// CHECK-DAG:   init()
+// CHECK-DAG:   init(a: UnsafeMutablePointer<Int{{[0-9]+}}>!, b: UnsafeMutableRawPointer!)
+// CHECK-NEXT:  var a: UnsafeMutablePointer<Int{{[0-9]+}}>!
+// CHECK-NEXT:  var b: UnsafeMutableRawPointer!
 // CHECK-NEXT: }
 // CHECK-NEXT: func j(_: j) -> UnsafeMutablePointer<j>!
 // CHECK-NEXT: var len2: Int{{[0-9]+}}
-// CHECK-NEXT: struct k {
-// CHECK-NEXT:   init()
-// CHECK-NEXT:   init(a: UnsafeMutablePointer<Int{{[0-9]+}}>!, b: UnsafeMutableRawPointer!)
-// CHECK-NEXT:   var a: UnsafeMutablePointer<Int{{[0-9]+}}>!
-// CHECK-NEXT:   var b: UnsafeMutableRawPointer!
+// CHECK:      struct k {
+// CHECK-DAG:   init()
+// CHECK-DAG:   init(a: UnsafeMutablePointer<Int{{[0-9]+}}>!, b: UnsafeMutableRawPointer!)
+// CHECK-NEXT:  var a: UnsafeMutablePointer<Int{{[0-9]+}}>!
+// CHECK-NEXT:  var b: UnsafeMutableRawPointer!
 // CHECK-NEXT: }
 // CHECK-NEXT: func k(_: k) -> UnsafeMutablePointer<k>!
 

--- a/test/Interop/Cxx/class/access/access-inversion-module-interface.swift
+++ b/test/Interop/Cxx/class/access/access-inversion-module-interface.swift
@@ -6,8 +6,8 @@
 // CHECK:   private typealias PrivateAlias = Bool
 
 // CHECK:   private struct PrivateRec {
-// CHECK:     public init()
 // CHECK:     private init()
+// CHECK:     public init()
 // CHECK:     public func privateRecMethod()
 // CHECK:     public static var PRIVATE_REC_CONST: Bool { get }
 // CHECK:   }
@@ -39,32 +39,32 @@
 // CHECK:   public typealias AliasToPrivateEnumClass = Leaky.PrivateEnumClass
 
 // CHECK:   public struct RecWithPrivateAlias {
-// CHECK:     public init()
 // CHECK:     public init(mem: Leaky.PrivateAlias)
+// CHECK:     public init()
 // CHECK:     public var mem: Leaky.PrivateAlias
 // CHECK:   }
 
 // CHECK:   public struct RecWithPrivateRec {
-// CHECK:     public init()
 // CHECK:     public init(mem: Leaky.PrivateRec)
+// CHECK:     public init()
 // CHECK:     public var mem: Leaky.PrivateRec
 // CHECK:   }
 
 // CHECK:   public struct RecWithPrivateEnum {
-// CHECK:     public init()
 // CHECK:     public init(mem: Leaky.PrivateEnum)
+// CHECK:     public init()
 // CHECK:     public var mem: Leaky.PrivateEnum
 // CHECK:   }
 
 // CHECK:   public struct RecWithPrivateEnumClass {
-// CHECK:     public init()
 // CHECK:     public init(mem: Leaky.PrivateEnumClass)
+// CHECK:     public init()
 // CHECK:     public var mem: Leaky.PrivateEnumClass
 // CHECK:   }
 
 // CHECK:   public struct RecWithPrivateConst {
-// CHECK:     public init()
 // CHECK:     public init(mem: Bool)
+// CHECK:     public init()
 // CHECK:     public var mem: Bool { get }
 // CHECK:   }
 

--- a/test/Interop/Cxx/class/access/access-specifiers-module-interface.swift
+++ b/test/Interop/Cxx/class/access/access-specifiers-module-interface.swift
@@ -7,6 +7,7 @@
 
 // CHECK:      public struct PublicPrivate {
 // CHECK-NEXT:   public init()
+// CHECK-NEXT:   public var PublicMemberVar: Int32
 // CHECK-NEXT:   public static var PublicStaticMemberVar: Int32
 // CHECK-NEXT:   public mutating func publicMemberFunc()
 // CHECK-NEXT:   public typealias PublicTypedef = Int32
@@ -42,6 +43,7 @@
 // CHECK-NEXT:     public typealias Element = PublicPrivate.PublicFlagEnum
 // CHECK-NEXT:     public typealias ArrayLiteralElement = PublicPrivate.PublicFlagEnum
 // CHECK-NEXT:   }
+// CHECK-NEXT:   private var PrivateMemberVar: Int32
 // CHECK-NEXT:   private static var PrivateStaticMemberVar: Int32
 // CHECK-NEXT:   private mutating func privateMemberFunc()
 // CHECK-NEXT:   private typealias PrivateTypedef = Int32
@@ -77,6 +79,4 @@
 // CHECK-NEXT:     private typealias Element = PublicPrivate.PrivateFlagEnum
 // CHECK-NEXT:     private typealias ArrayLiteralElement = PublicPrivate.PrivateFlagEnum
 // CHECK-NEXT:   }
-// CHECK-NEXT:   public var PublicMemberVar: Int32
-// CHECK-NEXT:   private var PrivateMemberVar: Int32
 // CHECK-NEXT: }

--- a/test/Interop/Cxx/class/access/non-public-shadow-module-interface.swift
+++ b/test/Interop/Cxx/class/access/non-public-shadow-module-interface.swift
@@ -4,13 +4,6 @@
 // We only check the module interface of Shadow to keep this test concise
 
 // CHECK:      public struct Shadow {
-// CHECK-NEXT:   public init()
-// CHECK-NEXT:   public func publPublShadowed() -> Return
-// CHECK-NEXT:   public func protPublShadowed() -> Return
-// CHECK-NEXT:   public func privPublShadowed() -> Return
-// CHECK-NEXT:   private func publPrivShadowed() -> Return
-// CHECK-NEXT:   private func protPrivShadowed() -> Return
-// CHECK-NEXT:   private func privPrivShadowed() -> Return
 
 // Currently, ImportDecl.cpp::loadAllMembersOfRecordDecl() does not correctly
 // handle multiple inheritance, so it only loads one of each ambiguous member.
@@ -25,4 +18,17 @@
 
 // TODO:         public func publOrProt() -> Return
 // TODO:         private func publOrProt() -> Return
+
+// CHECK-NEXT:   public init()
+// CHECK-NEXT:   private func publOrProt() -> Return
+// CHECK-NEXT:   @available(*, unavailable, message: "this base member is not accessible because it is private")
+// CHECK-NEXT:   private func publOrPriv() -> Return
+// CHECK-NEXT:   @available(*, unavailable, message: "this base member is not accessible because it is private")
+// CHECK-NEXT:   private func protOrPriv() -> Return
+// CHECK-NEXT:   public func publPublShadowed() -> Return
+// CHECK-NEXT:   public func protPublShadowed() -> Return
+// CHECK-NEXT:   public func privPublShadowed() -> Return
+// CHECK-NEXT:   private func publPrivShadowed() -> Return
+// CHECK-NEXT:   private func protPrivShadowed() -> Return
+// CHECK-NEXT:   private func privPrivShadowed() -> Return
 // CHECK:      }

--- a/test/Interop/Cxx/class/access/using-non-public-module-interface.swift
+++ b/test/Interop/Cxx/class/access/using-non-public-module-interface.swift
@@ -1,54 +1,54 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=UsingNonPublic -print-access -I %S/Inputs -source-filename=x -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=UsingNonPublic -print-access -I %S/Inputs -source-filename=x -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers | tee %s.out | %FileCheck %s
 // REQUIRES: swift_feature_ImportNonPublicCxxMembers
 
 // CHECK:      public struct PublUser {
 // CHECK-NEXT:   public init()
-// CHECK-NEXT:   public func publUsingProt() -> Return
-// CHECK-NEXT:   public func publUsingPubl() -> Return
-// CHECK-NEXT:   private func protUsingProt() -> Return
-// CHECK-NEXT:   private func protUsingPubl() -> Return
 // CHECK-NEXT:   private func omitUsingProt() -> Return
+// CHECK-NEXT:   private func protUsingProt() -> Return
+// CHECK-NEXT:   public func publUsingProt() -> Return
 // CHECK-NEXT:   public func omitUsingPubl() -> Return
+// CHECK-NEXT:   private func protUsingPubl() -> Return
+// CHECK-NEXT:   public func publUsingPubl() -> Return
 // CHECK-NEXT: }
 
 // CHECK:      public struct ProtUser {
 // CHECK-NEXT:   public init()
-// CHECK-NEXT:   public func publUsingProt() -> Return
-// CHECK-NEXT:   public func publUsingPubl() -> Return
-// CHECK-NEXT:   private func protUsingProt() -> Return
-// CHECK-NEXT:   private func protUsingPubl() -> Return
 // CHECK-NEXT:   private func omitUsingProt() -> Return
+// CHECK-NEXT:   private func protUsingProt() -> Return
+// CHECK-NEXT:   public func publUsingProt() -> Return
 // CHECK-NEXT:   private func omitUsingPubl() -> Return
+// CHECK-NEXT:   private func protUsingPubl() -> Return
+// CHECK-NEXT:   public func publUsingPubl() -> Return
 // CHECK-NEXT: }
 
 // CHECK:      public struct PrivUser {
 // CHECK-NEXT:   public init()
-// CHECK-NEXT:   public func publUsingProt() -> Return
-// CHECK-NEXT:   public func publUsingPubl() -> Return
-// CHECK-NEXT:   private func protUsingProt() -> Return
-// CHECK-NEXT:   private func protUsingPubl() -> Return
 // CHECK-NEXT:   private func omitUsingProt() -> Return
+// CHECK-NEXT:   private func protUsingProt() -> Return
+// CHECK-NEXT:   public func publUsingProt() -> Return
 // CHECK-NEXT:   private func omitUsingPubl() -> Return
+// CHECK-NEXT:   private func protUsingPubl() -> Return
+// CHECK-NEXT:   public func publUsingPubl() -> Return
 // CHECK-NEXT: }
 
 // CHECK:      public struct PublPrivUser {
 // CHECK-NEXT:   public init()
-// CHECK-NEXT:   public func publUsingProt() -> Return
-// CHECK-NEXT:   public func publUsingPubl() -> Return
-// CHECK-NEXT:   private func protUsingProt() -> Return
-// CHECK-NEXT:   private func protUsingPubl() -> Return
 // CHECK-NEXT:   @available(*, unavailable, message: "this base member is not accessible because of private inheritance")
 // CHECK-NEXT:   private func omitUsingProt() -> Return
 // CHECK-NEXT:   @available(*, unavailable, message: "this base member is not accessible because of private inheritance")
 // CHECK-NEXT:   private func omitUsingPubl() -> Return
+// CHECK-NEXT:   private func protUsingProt() -> Return
+// CHECK-NEXT:   public func publUsingProt() -> Return
+// CHECK-NEXT:   private func protUsingPubl() -> Return
+// CHECK-NEXT:   public func publUsingPubl() -> Return
 // CHECK-NEXT: }
 
 // CHECK:      public struct PrivUserPubl {
 // CHECK-NEXT:   public init()
-// CHECK-NEXT:   public func publUsingProt() -> Return
-// CHECK-NEXT:   public func publUsingPubl() -> Return
-// CHECK-NEXT:   private func protUsingProt() -> Return
-// CHECK-NEXT:   private func protUsingPubl() -> Return
 // CHECK-NEXT:   private func omitUsingProt() -> Return
+// CHECK-NEXT:   private func protUsingProt() -> Return
+// CHECK-NEXT:   public func publUsingProt() -> Return
 // CHECK-NEXT:   private func omitUsingPubl() -> Return
+// CHECK-NEXT:   private func protUsingPubl() -> Return
+// CHECK-NEXT:   public func publUsingPubl() -> Return
 // CHECK-NEXT: }

--- a/test/Interop/Cxx/class/constructors-module-interface.swift
+++ b/test/Interop/Cxx/class/constructors-module-interface.swift
@@ -6,18 +6,18 @@
 // CHECK-NEXT:   var x: Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: struct ImplicitDefaultConstructor {
-// CHECK-NEXT:   init()
 // CHECK-NEXT:   init(x: Int32)
+// CHECK-NEXT:   init()
 // CHECK-NEXT:   var x: Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: struct DefaultedDefaultConstructor {
-// CHECK-NEXT:   init()
 // CHECK-NEXT:   init(x: Int32)
 // CHECK-NEXT:   var x: Int32
+// CHECK-NEXT:   init()
 // CHECK-NEXT: }
 // CHECK-NEXT: struct MemberOfClassType {
-// CHECK-NEXT:   init()
 // CHECK-NEXT:   init(member: ImplicitDefaultConstructor)
+// CHECK-NEXT:   init()
 // CHECK-NEXT:   var member: ImplicitDefaultConstructor
 // CHECK-NEXT: }
 // CHECK-NEXT: struct DefaultConstructorDeleted {
@@ -25,9 +25,9 @@
 // CHECK-NEXT:   var a: UnsafeMutablePointer<Int32>
 // CHECK-NEXT: }
 // CHECK-NEXT: struct ConstructorWithParam {
-// CHECK-NEXT:   init(_ val: Int32)
 // CHECK-NEXT:   @available(*, deprecated, message
 // CHECK-NEXT:   init()
+// CHECK-NEXT:   init(_ val: Int32)
 // CHECK-NEXT:   var x: Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: struct CopyAndMoveConstructor {
@@ -41,8 +41,8 @@
 // CHECK-NEXT:   init()
 // CHECK-NEXT: }
 // CHECK-NEXT: struct ArgType {
-// CHECK-NEXT:   init()
 // CHECK-NEXT:   init(i: Int32)
+// CHECK-NEXT:   init()
 // CHECK-NEXT:   var i: Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: struct HasVirtualBase {
@@ -50,15 +50,15 @@
 // CHECK-NEXT:   var i: Int32
 // CHECK-NEXT: }
 // CHECK:      struct TemplatedConstructor {
-// CHECK-NEXT:   init<T>(_ value: T)
 // CHECK-NEXT:   @available(*, deprecated, message
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   var value: ArgType
+// CHECK-NEXT:   init<T>(_ value: T)
 // CHECK-NEXT: }
 // CHECK:      struct TemplatedConstructorWithExtraArg {
+// CHECK-NEXT:   @available(*, deprecated, message
+// CHECK-NEXT:   init()
 // CHECK-NEXT:   init<T>(_: Int32, _ value: T)
 // CHECK-NEXT:   init<T>(_ value: T, _: Int32)
 // CHECK-NEXT:   init<T, U>(_ value: T, _ other: U)
-// CHECK-NEXT:   @available(*, deprecated, message
-// CHECK-NEXT:   init()
 // CHECK-NEXT: }

--- a/test/Interop/Cxx/class/constructors-objc-module-interface.swift
+++ b/test/Interop/Cxx/class/constructors-objc-module-interface.swift
@@ -6,7 +6,7 @@
 // REQUIRES: objc_interop
 
 // CHECK:      struct ConstructorWithNSArrayParam {
-// CHECK-NEXT:   init(_ array: [Any]!)
 // CHECK-NEXT:   @available(*, deprecated, message
 // CHECK-NEXT:   init()
+// CHECK-NEXT:   init(_ array: [Any]!)
 // CHECK-NEXT: }

--- a/test/Interop/Cxx/class/friend-class-member-in-interface.swift
+++ b/test/Interop/Cxx/class/friend-class-member-in-interface.swift
@@ -30,6 +30,6 @@ struct C: B {
 // CHECK:  mutating func memberInB()
 // CHECK-NEXT: }
 // CHECK: struct C {
+// CHECK:  mutating func memberInB()
 // CHECK:  mutating func memberInC()
-// CHECK-NEXT:  mutating func memberInB()
 // CHECK-NEXT: }

--- a/test/Interop/Cxx/class/inheritance/fields-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/fields-module-interface.swift
@@ -1,8 +1,8 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=Fields -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK:      struct HasThreeFields {
-// CHECK-NEXT:   init()
 // CHECK-NEXT:   init(a: Int32, b: Int32, c: Int32)
+// CHECK-NEXT:   init()
 // CHECK-NEXT:   var a: Int32
 // CHECK-NEXT:   var b: Int32
 // CHECK-NEXT:   var c: Int32
@@ -10,38 +10,38 @@
 
 // CHECK-NEXT: struct DerivedWithSameField {
 // CHECK-NEXT:   init()
-// CHECK-NEXT:   var a: Int32
 // CHECK-NEXT:   var b: Int32
 // CHECK-NEXT:   var c: Int32
+// CHECK-NEXT:   var a: Int32
 // CHECK-NEXT: }
 
 // CHECK-NEXT: struct DerivedWithOneField {
 // CHECK-NEXT:   init()
-// CHECK-NEXT:   var d: Int32
 // CHECK-NEXT:   var a: Int32
 // CHECK-NEXT:   var b: Int32
 // CHECK-NEXT:   var c: Int32
+// CHECK-NEXT:   var d: Int32
 // CHECK-NEXT: }
 
 // CHECK-NEXT: struct HasOneField {
-// CHECK-NEXT:   init()
 // CHECK-NEXT:   init(e: Int32)
+// CHECK-NEXT:   init()
 // CHECK-NEXT:   var e: Int32
 // CHECK-NEXT: }
 
 // CHECK-NEXT: struct DerivedFromAll {
 // CHECK-NEXT:   init()
-// CHECK-NEXT:   var f: Int32
-// CHECK-NEXT:   var e: Int32
-// CHECK-NEXT:   var d: Int32
 // CHECK-NEXT:   var a: Int32
 // CHECK-NEXT:   var b: Int32
 // CHECK-NEXT:   var c: Int32
+// CHECK-NEXT:   var d: Int32
+// CHECK-NEXT:   var e: Int32
+// CHECK-NEXT:   var f: Int32
 // CHECK-NEXT: }
 
 // CHECK-NEXT: struct OneField {
-// CHECK-NEXT:   init()
 // CHECK-NEXT:   init(value: Int32)
+// CHECK-NEXT:   init()
 // CHECK-NEXT:   var value: Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: struct DerivedFromOneField {
@@ -62,10 +62,10 @@
 
 // CHECK-NEXT: struct NonTrivialDerivedWithOneField {
 // CHECK-NEXT:   init()
-// CHECK-NEXT:   var d: Int32
 // CHECK-NEXT:   var a: Int32
 // CHECK-NEXT:   var b: Int32
 // CHECK-NEXT:   var c: Int32
+// CHECK-NEXT:   var d: Int32
 // CHECK-NEXT: }
 
 // CHECK-NEXT: struct NonTrivialHasOneField {
@@ -75,10 +75,10 @@
 
 // CHECK-NEXT: struct NonTrivialDerivedFromAll {
 // CHECK-NEXT:   init()
-// CHECK-NEXT:   var f: Int32
-// CHECK-NEXT:   var e: Int32
-// CHECK-NEXT:   var d: Int32
 // CHECK-NEXT:   var a: Int32
 // CHECK-NEXT:   var b: Int32
 // CHECK-NEXT:   var c: Int32
+// CHECK-NEXT:   var d: Int32
+// CHECK-NEXT:   var e: Int32
+// CHECK-NEXT:   var f: Int32
 // CHECK-NEXT: }

--- a/test/Interop/Cxx/class/inheritance/functions-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/functions-module-interface.swift
@@ -49,11 +49,35 @@
 // CHECK-NEXT: public struct Derived {
 // CHECK-NEXT:   public init()
 // CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   public mutating func mutatingInBase() -> UnsafePointer<CChar>?
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   public func constInBase() -> UnsafePointer<CChar>?
+// CHECK-NEXT:   public mutating func refQualifierOverloadsMutating()
+// CHECK-NEXT:   public func refQualifierOverloads()
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   public func takesArgsInBase(_ a: Int32, _ b: Int32, _ c: Int32) -> UnsafePointer<CChar>?
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   public func takesNonTrivialInBase(_ a: NonTrivial) -> UnsafePointer<CChar>?
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   public func returnsNonTrivialInBase() -> NonTrivial
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   public mutating func swiftRenamed(input i: Int32) -> Int32
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   @_effects(readonly) public func pure() -> Int32
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   public func sameMethodDifferentSignature() -> Int32
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   public func inOtherBase() -> UnsafePointer<CChar>?
+// CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   public func inDerived() -> UnsafePointer<CChar>!
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   public func sameMethodNameSameSignature() -> Int32
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   public func sameMethodDifferentSignature(_ x: Int32) -> Int32
+// CHECK-NEXT: }
+
+// CHECK-NEXT: public struct DerivedFromDerived {
+// CHECK-NEXT:   public init()
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   public mutating func mutatingInBase() -> UnsafePointer<CChar>?
 // CHECK-NEXT:   @discardableResult
@@ -74,12 +98,6 @@
 // CHECK-NEXT:   public func sameMethodDifferentSignature() -> Int32
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   public func inOtherBase() -> UnsafePointer<CChar>?
-// CHECK-NEXT: }
-
-// CHECK-NEXT: public struct DerivedFromDerived {
-// CHECK-NEXT:   public init()
-// CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   public func topLevel() -> UnsafePointer<CChar>!
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   public func inDerived() -> UnsafePointer<CChar>?
 // CHECK-NEXT:   @discardableResult
@@ -87,25 +105,7 @@
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   public func sameMethodDifferentSignature(_ x: Int32) -> Int32
 // CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   public mutating func mutatingInBase() -> UnsafePointer<CChar>?
-// CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   public func constInBase() -> UnsafePointer<CChar>?
-// CHECK-NEXT:   public mutating func refQualifierOverloadsMutating()
-// CHECK-NEXT:   public func refQualifierOverloads()
-// CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   public func takesArgsInBase(_ a: Int32, _ b: Int32, _ c: Int32) -> UnsafePointer<CChar>?
-// CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   public func takesNonTrivialInBase(_ a: NonTrivial) -> UnsafePointer<CChar>?
-// CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   public func returnsNonTrivialInBase() -> NonTrivial
-// CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   public mutating func swiftRenamed(input i: Int32) -> Int32
-// CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   @_effects(readonly) public func pure() -> Int32
-// CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   public func sameMethodDifferentSignature() -> Int32
-// CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   public func inOtherBase() -> UnsafePointer<CChar>?
+// CHECK-NEXT:   public func topLevel() -> UnsafePointer<CChar>!
 // CHECK-NEXT: }
 
 // CHECK-NEXT: public struct DerivedFromNonTrivial {
@@ -134,18 +134,18 @@
 
 // CHECK-NEXT: public struct DerivedFromEmptyBaseClass {
 // CHECK-NEXT:   public init()
-// CHECK-NEXT:   public var a: Int32
-// CHECK-NEXT:   public var b: Int32
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   public func inBase() -> UnsafePointer<CChar>?
+// CHECK-NEXT:   public var a: Int32
+// CHECK-NEXT:   public var b: Int32
 // CHECK-NEXT: }
 
 // CHECK-NEXT: @discardableResult
 // CHECK-NEXT: public func getCopyCounter() -> UnsafeMutablePointer<Int32>
 // CHECK-NEXT: public struct CopyTrackedBaseClass {
-// CHECK-NEXT:   public init(_ x: Int32)
 // CHECK-NEXT:   @available(*, deprecated, message: "This zero-initializes the backing memory of the struct, which is unsafe for some C++ structs. Consider adding an explicit default initializer for this C++ struct.")
 // CHECK-NEXT:   @_transparent public init()
+// CHECK-NEXT:   public init(_ x: Int32)
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   public func getX() -> Int32
 // CHECK-NEXT:   @discardableResult
@@ -154,15 +154,15 @@
 // CHECK:      }
 
 // CHECK-NEXT: public struct CopyTrackedDerivedClass {
-// CHECK-NEXT:   public init(_ x: Int32)
 // CHECK-NEXT:   @available(*, deprecated, message: "This zero-initializes the backing memory of the struct, which is unsafe for some C++ structs. Consider adding an explicit default initializer for this C++ struct.")
 // CHECK-NEXT:   @_transparent public init()
-// CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   public func getDerivedX() -> Int32
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   public func getX() -> Int32
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   public mutating func getXMut() -> Int32
+// CHECK-NEXT:   public init(_ x: Int32)
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   public func getDerivedX() -> Int32
 // CHECK-NOT:    public
 // CHECK:      }
 
@@ -174,17 +174,16 @@
 // CHECK:      }
 
 // CHECK-NEXT: public struct CopyTrackedDerivedDerivedClass {
-// CHECK-NEXT:   public init(_ x: Int32)
 // CHECK-NEXT:   @available(*, deprecated, message: "This zero-initializes the backing memory of the struct, which is unsafe for some C++ structs. Consider adding an explicit default initializer for this C++ struct.")
 // CHECK-NEXT:   @_transparent public init()
-// CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   public func getY() -> Int32
-// CHECK-NOT:    public
-// CHECK:        @discardableResult
-// CHECK-NEXT:   public func getDerivedX() -> Int32
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   public func getX() -> Int32
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   public mutating func getXMut() -> Int32
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   public func getDerivedX() -> Int32
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   public func getY() -> Int32
+// CHECK-NEXT:   public init(_ x: Int32)
 // CHECK-NOT:    public
 // CHECK:      }

--- a/test/Interop/Cxx/class/inheritance/nested-types-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/nested-types-module-interface.swift
@@ -17,23 +17,23 @@
 // CHECK-NEXT:     typealias RawValue = {{UInt32|Int32}}
 // CHECK-NEXT:   }
 // CHECK-NEXT:   struct Struct {
-// CHECK-NEXT:     init()
 // CHECK-NEXT:     init(sa: Int32, sb: Int32)
+// CHECK-NEXT:     init()
 // CHECK-NEXT:     var sa: Int32
 // CHECK-NEXT:     var sb: Int32
 // CHECK-NEXT:   }
 // CHECK-NEXT:   struct Parent {
 // CHECK-NEXT:     init()
 // CHECK-NEXT:     struct Child {
-// CHECK-NEXT:       init()
 // CHECK-NEXT:       init(pca: Int32)
+// CHECK-NEXT:       init()
 // CHECK-NEXT:       var pca: Int32
 // CHECK-NEXT:     }
 // CHECK-NEXT:   }
 // CHECK-NEXT:   struct Union {
-// CHECK-NEXT:     init()
 // CHECK-NEXT:     init(ua: Int32)
 // CHECK-NEXT:     init(ub: Base.Struct)
+// CHECK-NEXT:     init()
 // CHECK-NEXT:     var ua: Int32
 // CHECK-NEXT:     var ub: Base.Struct
 // CHECK-NEXT:   }

--- a/test/Interop/Cxx/class/inheritance/protected-special-member-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/protected-special-member-module-interface.swift
@@ -12,8 +12,8 @@
 
 // CHECK:      struct PrivatelyInheritsProtectedDtor {
 // CHECK-NEXT:   init()
-// CHECK-NEXT:   mutating func setFromBase(_ v: Int32)
 // CHECK-NEXT:   var inDerived: Int32
+// CHECK-NEXT:   mutating func setFromBase(_ v: Int32)
 // CHECK-NEXT: }
 
 // CHECK:      struct InheritsProtectedCopy {
@@ -39,13 +39,13 @@
 // CHECK-NEXT: }
 
 // CHECK:      struct ProtectedCopyWithMove : ~Copyable {
-// CHECK-NEXT:   init()
 // CHECK-NEXT:   var fromBase: Int32
+// CHECK-NEXT:   init()
 // CHECK-NEXT: }
 
 // CHECK:      struct InheritsProtectedCopyWithMove {
 // CHECK-NEXT:   init()
+// CHECK-NEXT:   var fromBase: Int32
 // CHECK-NEXT:   func getFromBase() -> Int32
 // CHECK-NEXT:   mutating func setFromBase(_ x: Int32)
-// CHECK-NEXT:   var fromBase: Int32
 // CHECK-NEXT: }

--- a/test/Interop/Cxx/class/inheritance/using-base-members-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/using-base-members-module-interface.swift
@@ -3,48 +3,48 @@
 
 // CHECK:      public struct PublicBase {
 // CHECK-NEXT:   public init()
+// CHECK-NEXT:   private var value: Int32
 // CHECK-NEXT:   public func publicGetter() -> Int32
 // CHECK-NEXT:   public mutating func publicSetter(_ v: Int32)
 // CHECK-NEXT:   public func notExposed()
-// CHECK-NEXT:   private var value: Int32
 // CHECK-NEXT: }
 
 // CHECK:      public struct PublicBasePrivateInheritance {
 // CHECK-NEXT:   public init()
+// CHECK-NEXT:   @available(*, unavailable, message: "this base member is not accessible because it is private")
+// CHECK-NEXT:   private var value: Int32
 // CHECK-NEXT:   public func publicGetter() -> Int32
 // CHECK-NEXT:   public mutating func publicSetter(_ v: Int32)
 // CHECK-NEXT:   private func notExposed()
-// CHECK-NEXT:   @available(*, unavailable, message: "this base member is not accessible because it is private")
-// CHECK-NEXT:   private var value: Int32
 // CHECK-NEXT: }
 
 // CHECK:      public struct PublicBaseProtectedInheritance {
 // CHECK-NEXT:   public init()
+// CHECK-NEXT:   @available(*, unavailable, message: "this base member is not accessible because it is private")
+// CHECK-NEXT:   private var value: Int32
 // CHECK-NEXT:   public func publicGetter() -> Int32
 // CHECK-NEXT:   public mutating func publicSetter(_ v: Int32)
 // CHECK-NEXT:   private func notExposed()
-// CHECK-NEXT:   @available(*, unavailable, message: "this base member is not accessible because it is private")
-// CHECK-NEXT:   private var value: Int32
 // CHECK-NEXT: }
 
 // CHECK:      public struct PublicBaseUsingPrivateTypedef {
 // CHECK-NEXT:   public init()
-// CHECK-NEXT:   private typealias MyBase = PublicBase
+// CHECK-NEXT:   @available(*, unavailable, message: "this base member is not accessible because it is private")
+// CHECK-NEXT:   private var value: Int32
 // CHECK-NEXT:   public func publicGetter() -> Int32
 // CHECK-NEXT:   public mutating func publicSetter(_ v: Int32)
 // CHECK-NEXT:   private func notExposed()
-// CHECK-NEXT:   @available(*, unavailable, message: "this base member is not accessible because it is private")
-// CHECK-NEXT:   private var value: Int32
+// CHECK-NEXT:   private typealias MyBase = PublicBase
 // CHECK-NEXT: }
 
 // CHECK:      public struct PublicBaseUsingPrivateUsingType {
 // CHECK-NEXT:   public init()
-// CHECK-NEXT:   private typealias MyBase = PublicBase
+// CHECK-NEXT:   @available(*, unavailable, message: "this base member is not accessible because it is private")
+// CHECK-NEXT:   private var value: Int32
 // CHECK-NEXT:   public func publicGetter() -> Int32
 // CHECK-NEXT:   public mutating func publicSetter(_ v: Int32)
 // CHECK-NEXT:   private func notExposed()
-// CHECK-NEXT:   @available(*, unavailable, message: "this base member is not accessible because it is private")
-// CHECK-NEXT:   private var value: Int32
+// CHECK-NEXT:   private typealias MyBase = PublicBase
 // CHECK-NEXT: }
 
 // CHECK:      public struct UsingBaseConstructorWithParam {
@@ -70,14 +70,14 @@
 
 // CHECK:      public struct OperatorBasePrivateInheritance : CxxConvertibleToBool {
 // CHECK-NEXT:   public init()
-// CHECK-NEXT:   public subscript(x: Int32) -> Int32 { get }
 // CHECK-NEXT:   public func __convertToBool() -> Bool
 // CHECK-NEXT:   @available(*, unavailable, message: "use .pointee property")
 // CHECK-NEXT:   public func __operatorStar() -> Int32
-// CHECK-NEXT:   prefix public static func ! (lhs: OperatorBasePrivateInheritance) -> OperatorBase
 // CHECK-NEXT:   @available(*, unavailable, message: "use ! instead")
 // CHECK-NEXT:   public func __operatorExclaim() -> OperatorBase
 // CHECK-NEXT:   @available(*, unavailable, message: "use subscript")
 // CHECK-NEXT:   public func __operatorSubscriptConst(_ x: Int32) -> Int32
+// CHECK-NEXT:   prefix public static func ! (lhs: OperatorBasePrivateInheritance) -> OperatorBase
 // CHECK-NEXT:   public var pointee: Int32 { get }
+// CHECK-NEXT:   public subscript(x: Int32) -> Int32 { get }
 // CHECK-NEXT: }

--- a/test/Interop/Cxx/class/inheritance/virtual-methods-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/virtual-methods-module-interface.swift
@@ -8,21 +8,28 @@
 // CHECK-NEXT:   @available(*, unavailable, message: "virtual function is not available in Swift because it is pure")
 // CHECK-NEXT:   mutating func foo()
 // CHECK-NEXT:   func swiftVirtualRename()
-// CHECK: }
+// CHECK-NEXT: }
 
 // CHECK: struct Base3 {
 // CHECK-NEXT:   init()
-// CHECK: }
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   @_addressableSelf mutating func f() -> Int32
+// CHECK-NEXT: }
 
 // CHECK: struct Derived2 {
 // CHECK-NEXT:   init()
-// CHECK: }
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   @_addressableSelf mutating func f() -> Int32
+// CHECK-NEXT: }
 
 // CHECK: struct Derived<CInt> {
 // CHECK-NEXT:  init()
 // CHECK-NEXT:  mutating func foo()
-// CHECK: }
+// CHECK-NEXT:  mutating func callMe()
+// CHECK-NEXT:  func swiftVirtualRename()
+// CHECK-NEXT: }
 
 // CHECK: struct VirtualNonAbstractBase {
 // CHECK-NEXT:  init()
 // CHECK-NEXT:  func nonAbstractMethod()
+// CHECK-NEXT: }

--- a/test/Interop/Cxx/class/linked-records-module-interface.swift
+++ b/test/Interop/Cxx/class/linked-records-module-interface.swift
@@ -24,12 +24,12 @@
 // CHECK:   init()
 // CHECK: }
 // CHECK: struct F {
-// CHECK:   init()
 // CHECK:   init(_ __Anonymous_field0: F.__Unnamed_union___Anonymous_field0, m2: M)
+// CHECK:   init()
 // CHECK:   struct __Unnamed_union___Anonymous_field0 {
-// CHECK:     init()
 // CHECK:     init(c: F.__Unnamed_union___Anonymous_field0.__Unnamed_struct_c)
 // CHECK:     init(m: M)
+// CHECK:     init()
 // CHECK:     struct __Unnamed_struct_c {
 // CHECK:       init()
 // CHECK:     }
@@ -43,11 +43,11 @@
 // CHECK: }
 
 // CHECK: struct G {
-// CHECK:   init()
 // CHECK:   init(cc: G.__Unnamed_class_cc)
+// CHECK:   init()
 // CHECK:   struct __Unnamed_class_cc {
-// CHECK:     init()
 // CHECK:     init(m: M)
+// CHECK:     init()
 // CHECK:     var m: M
 // CHECK:   }
 // CHECK:   var cc: G.__Unnamed_class_cc

--- a/test/Interop/Cxx/class/member-variables-module-interface.swift
+++ b/test/Interop/Cxx/class/member-variables-module-interface.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=MemberVariablesNoDiagnostics -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK:      struct MyClass {
-// CHECK-NEXT:   init()
 // CHECK-NEXT:   init(const_member: Int32)
+// CHECK-NEXT:   init()
 // CHECK-NEXT:   var const_member: Int32 { get }
 // CHECK-NEXT: }

--- a/test/Interop/Cxx/class/memberwise-initializer-module-interface.swift
+++ b/test/Interop/Cxx/class/memberwise-initializer-module-interface.swift
@@ -4,13 +4,13 @@
 // CHECK-NEXT:   init()
 // CHECK-NEXT: }
 // CHECK-NEXT: struct StructPublicOnly {
-// CHECK-NEXT:   init()
 // CHECK-NEXT:   init(varPublic: Int32)
+// CHECK-NEXT:   init()
 // CHECK-NEXT:   var varPublic: Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: struct StructEmptyPrivateSection {
-// CHECK-NEXT:   init()
 // CHECK-NEXT:   init(varPublic: Int32)
+// CHECK-NEXT:   init()
 // CHECK-NEXT:   var varPublic: Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: struct StructPublicAndPrivate {
@@ -18,16 +18,16 @@
 // CHECK-NEXT:   var varPublic: Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: struct StructWithUnimportedMemberFunction {
-// CHECK-NEXT:   init()
 // CHECK-NEXT:   init(varPublic: Int32)
+// CHECK-NEXT:   init()
 // CHECK-NEXT:   var varPublic: Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: struct ClassPrivateOnly {
 // CHECK-NEXT:   init()
 // CHECK-NEXT: }
 // CHECK-NEXT: struct ClassPublicOnly {
-// CHECK-NEXT:   init()
 // CHECK-NEXT:   init(varPublic: Int32)
+// CHECK-NEXT:   init()
 // CHECK-NEXT:   var varPublic: Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: struct ClassEmptyPublicSection {
@@ -38,29 +38,29 @@
 // CHECK-NEXT:   var varPublic: Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: struct ClassWithUnimportedMemberFunction {
-// CHECK-NEXT:   init()
 // CHECK-NEXT:   init(varPublic: Int32)
+// CHECK-NEXT:   init()
 // CHECK-NEXT:   var varPublic: Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: struct ClassWithTemplatedFunction {
-// CHECK-NEXT:   init()
 // CHECK-NEXT:   init(varPublic: Int32)
+// CHECK-NEXT:   init()
 // CHECK-NEXT:   var varPublic: Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: struct ClassWithTemplatedUsingDecl {
-// CHECK-NEXT:   init()
 // CHECK-NEXT:   init(varPublic: Int32)
+// CHECK-NEXT:   init()
 // CHECK-NEXT:   var varPublic: Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: struct ClassWithStaticAssert {
-// CHECK-NEXT:   init()
 // CHECK-NEXT:   init(x: Int32, y: Int32)
+// CHECK-NEXT:   init()
 // CHECK-NEXT:   var x: Int32
 // CHECK-NEXT:   var y: Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: struct ClassWithStaticAssert2 {
-// CHECK-NEXT:   init()
 // CHECK-NEXT:   init(x: Int32, y: Int32)
+// CHECK-NEXT:   init()
 // CHECK-NEXT:   var x: Int32
 // CHECK-NEXT:   var y: Int32
 // CHECK-NEXT: }

--- a/test/Interop/Cxx/class/method/unsafe-projections.swift
+++ b/test/Interop/Cxx/class/method/unsafe-projections.swift
@@ -34,6 +34,8 @@
 // CHECK: }
 
 // CHECK: struct InheritSelfContained {
+// CHECK:   func explicitSelfContained() -> ExplicitSelfContained
+// CHECK:   func explicitNested() -> NestedExplicitSelfContained
 // CHECK:   func name() -> std{{.*}}string
 // CHECK:   func selfContained() -> SelfContained
 // CHECK:   func nested() -> NestedSelfContained
@@ -41,8 +43,6 @@
 // CHECK:   func value() -> Int32
 // CHECK:   func __viewUnsafe() -> View
 // CHECK:   func __pointerUnsafe() -> UnsafeMutablePointer<Int32>!
-// CHECK:   func explicitSelfContained() -> ExplicitSelfContained
-// CHECK:   func explicitNested() -> NestedExplicitSelfContained
 // CHECK: }
 
 // CHECK: struct ExplicitSelfContained {

--- a/test/Interop/Cxx/class/mutability-annotations-module-interface.swift
+++ b/test/Interop/Cxx/class/mutability-annotations-module-interface.swift
@@ -1,22 +1,22 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=MutabilityAnnotations -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK: struct HasConstMethodAnnotatedAsMutating {
+// CHECK:   var a: Int32
 // CHECK:   mutating func annotatedMutating() -> Int32
 // CHECK:   mutating func annotatedMutatingWithOtherAttrs() -> Int32
-// CHECK:   var a: Int32
 // CHECK: }
 
 // CHECK: struct HasMutableProperty {
+// CHECK:   var a: Int32
+// CHECK:   var b: Int32
 // CHECK:   func annotatedNonMutating() -> Int32
 // TODO-CHECK:   mutating func noAnnotation() -> Int32
 // CHECK:   mutating func contradictingAnnotations() -> Int32
 // CHECK:   func duplicateAnnotations() -> Int32
-// CHECK:   var a: Int32
-// CHECK:   var b: Int32
 // CHECK: }
 
 // CHECK: struct NoMutableProperty {
+// CHECK:   var a: Int32
 // CHECK:   func isConst() -> Int32
 // CHECK:   mutating func nonConst() -> Int32
-// CHECK:   var a: Int32
 // CHECK: }

--- a/test/Interop/Cxx/class/mutable-members-module-interface.swift
+++ b/test/Interop/Cxx/class/mutable-members-module-interface.swift
@@ -1,8 +1,8 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=MutableMembers -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK: struct HasPublicMutableMember {
-// CHECK:   func foo() -> Int32
 // CHECK:   var a: Int32
+// CHECK:   func foo() -> Int32
 // CHECK: }
 
 // CHECK: struct HasPrivateMutableMember {

--- a/test/Interop/Cxx/class/mutable-members-with-mutating-annotation-module-interface.swift
+++ b/test/Interop/Cxx/class/mutable-members-with-mutating-annotation-module-interface.swift
@@ -1,8 +1,8 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=MutableMembers -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop -Xcc -DUSE_MUTATING -I %swift_src_root/lib/ClangImporter/SwiftBridging | %FileCheck %s
 
 // CHECK: struct HasPublicMutableMember {
-// CHECK:   mutating func foo() -> Int32
 // CHECK:   var a: Int32
+// CHECK:   mutating func foo() -> Int32
 // CHECK: }
 
 // CHECK: struct HasPrivateMutableMember {

--- a/test/Interop/Cxx/class/nested-records-module-interface.swift
+++ b/test/Interop/Cxx/class/nested-records-module-interface.swift
@@ -58,10 +58,10 @@
 
 // CHECK: struct HasForwardDeclaredNestedType {
 // CHECK:   init()
-// CHECK:   struct ForwardDeclaredType {
+// CHECK:   struct NormalSubType {
 // CHECK:     init()
 // CHECK:   }
-// CHECK:   struct NormalSubType {
+// CHECK:   struct ForwardDeclaredType {
 // CHECK:     init()
 // CHECK:   }
 // CHECK: }
@@ -86,8 +86,8 @@
 // CHECK:   struct HasNestedForwardDeclaration {
 // CHECK:     init()
 // CHECK:     struct IsNestedForwardDeclaration {
-// CHECK:       init()
 // CHECK:       init(a: Int32)
+// CHECK:       init()
 // CHECK:       var a: Int32
 // CHECK:     }
 // CHECK:   }

--- a/test/Interop/Cxx/class/pimpl-module-interface.swift
+++ b/test/Interop/Cxx/class/pimpl-module-interface.swift
@@ -9,6 +9,6 @@
 // CHECK-NEXT: }
 
 // CHECK:      public struct HasSmartPIMPL {
-// CHECK-NEXT:   public init()
 // CHECK-NEXT:   private var smart_ptr: std.
+// CHECK-NEXT:   public init()
 // CHECK-NEXT: }

--- a/test/Interop/Cxx/class/returns-unavailable-class.swift
+++ b/test/Interop/Cxx/class/returns-unavailable-class.swift
@@ -38,11 +38,11 @@ public:
 };
 
 // CHECK: struct Struct {
-// CHECK-NEXT:   init()
 // CHECK-NEXT:   init(x: Int32, y: Int32)
-// CHECK-NEXT:   func returnsClassInTypesModules() -> Never
+// CHECK-NEXT:   init()
 // CHECK-NEXT:   var x: Int32
 // CHECK-NEXT:   var y: Int32
+// CHECK-NEXT:   func returnsClassInTypesModules() -> Never
 // CHECK-NEXT: }
 
 TemplateInTypesModule<int> funcWithClassInTypesModules();

--- a/test/Interop/Cxx/ergonomics/explicit-computed-properties.swift
+++ b/test/Interop/Cxx/ergonomics/explicit-computed-properties.swift
@@ -21,6 +21,6 @@ struct Record {
 
 // CHECK: struct Record {
 // CHECK:   init()
-// CHECK:   var x: Int32 { mutating get }
 // CHECK:   mutating func getX() -> Int32
+// CHECK:   var x: Int32 { mutating get }
 // CHECK: }

--- a/test/Interop/Cxx/ergonomics/implicit-computed-properties-module-interface.swift
+++ b/test/Interop/Cxx/ergonomics/implicit-computed-properties-module-interface.swift
@@ -38,46 +38,45 @@
 // CHECK-NEXT: }
 
 // CHECK:      struct LongNameAllLower {
-// CHECK-NOT:     var
-// CHECK-NEXT:    init()
 // CHECK-NEXT:    init(value: Int32)
-// CHECK-NEXT:    var foo: Int32
+// CHECK-NEXT:    init()
+// CHECK-NEXT:    var value: Int32
 // CHECK-NEXT:    func getfoo() -> Int32
 // CHECK-NEXT:    mutating func setfoo(_ v: Int32)
-// CHECK-NEXT:    var value: Int32
+// CHECK-NEXT:    var foo: Int32
 // CHECK-NEXT: }
 
 // CHECK:      struct LongNameAllUpper {
-// CHECK-NEXT:     init()
 // CHECK-NEXT:     init(value: Int32)
-// CHECK-NEXT:     var foo: Int32
+// CHECK-NEXT:     init()
+// CHECK-NEXT:     var value: Int32
 // CHECK-NEXT:     func getFOO() -> Int32
 // CHECK-NEXT:     mutating func setFOO(_ v: Int32)
-// CHECK-NEXT:     var value: Int32
+// CHECK-NEXT:     var foo: Int32
 // CHECK-NEXT: }
 
 // CHECK:      struct UpperCaseMix {
-// CHECK-NEXT:    init()
 // CHECK-NEXT:    init(value: Int32)
-// CHECK-NEXT:    var foo: Int32
+// CHECK-NEXT:    init()
+// CHECK-NEXT:    var value: Int32
 // CHECK-NEXT:    func getFoo() -> Int32
 // CHECK-NEXT:    mutating func SetFoo(_ v: Int32)
-// CHECK-NEXT:    var value: Int32
+// CHECK-NEXT:    var foo: Int32
 // CHECK-NEXT: }
 
 // CHECK:      struct UpperCaseGetterSetter {
-// CHECK-NEXT:    init()
 // CHECK-NEXT:    init(value: Int32)
-// CHECK-NEXT:    var foo: Int32
+// CHECK-NEXT:    init()
+// CHECK-NEXT:    var value: Int32
 // CHECK-NEXT:    func GetFoo() -> Int32
 // CHECK-NEXT:    mutating func SetFoo(_ v: Int32)
-// CHECK-NEXT:    var value: Int32
+// CHECK-NEXT:    var foo: Int32
 // CHECK-NEXT: }
 
 // CHECK:      struct GetterOnly {
 // CHECK-NEXT:    init()
-// CHECK-NEXT:    var foo: Int32 { get }
 // CHECK-NEXT:    func getFoo() -> Int32
+// CHECK-NEXT:    var foo: Int32 { get }
 // CHECK-NEXT: }
 
 // CHECK:      struct NoNameUpperGetter {
@@ -92,29 +91,29 @@
 // CHECK-NEXT: }
 
 // CHECK:      struct IntGetterSetter {
-// CHECK-NEXT:    init()
 // CHECK-NEXT:    init(val: Int32)
-// CHECK-NEXT:    var x: Int32
+// CHECK-NEXT:    init()
+// CHECK-NEXT:    var val: Int32
 // CHECK-NEXT:    func getX() -> Int32
 // CHECK-NEXT:    mutating func setX(_ v: Int32)
-// CHECK-NEXT:    var val: Int32
+// CHECK-NEXT:    var x: Int32
 // CHECK-NEXT: }
 
 // CHECK:      struct IntGetterSetterSnakeCaseUpper {
-// CHECK-NEXT:    init()
 // CHECK-NEXT:    init(val: Int32)
+// CHECK-NEXT:    init()
+// CHECK-NEXT:    var val: Int32
 // CHECK-NEXT:    func Get_X() -> Int32
 // CHECK-NEXT:    mutating func Set_X(_ v: Int32)
-// CHECK-NEXT:    var val: Int32
 // CHECK-NEXT: }
 
 // CHECK:      struct IntGetterSetterSnakeCase {
-// CHECK-NEXT:    init()
 // CHECK-NEXT:    init(val: Int32)
-// CHECK-NEXT:    var x: Int32
+// CHECK-NEXT:    init()
+// CHECK-NEXT:    var val: Int32
 // CHECK-NEXT:    func get_x() -> Int32
 // CHECK-NEXT:    mutating func set_x(_ v: Int32)
-// CHECK-NEXT:    var val: Int32
+// CHECK-NEXT:    var x: Int32
 // CHECK-NEXT: }
 
 // CHECK:      struct GetterHasArg {
@@ -124,57 +123,57 @@
 // CHECK-NEXT: }
 
 // CHECK:      struct GetterSetterIsUpper {
-// CHECK-NEXT:    init()
 // CHECK-NEXT:    init(val: Int32)
-// CHECK-NEXT:    var x: Int32
+// CHECK-NEXT:    init()
+// CHECK-NEXT:    var val: Int32
 // CHECK-NEXT:    func GETX() -> Int32
 // CHECK-NEXT:    mutating func SETX(_ v: Int32)
-// CHECK-NEXT:    var val: Int32
+// CHECK-NEXT:    var x: Int32
 // CHECK-NEXT: }
 
 // CHECK:      struct HasXAndY {
-// CHECK-NEXT:    init()
 // CHECK-NEXT:    init(val: Int32)
-// CHECK-NEXT:    var xAndY: Int32
+// CHECK-NEXT:    init()
+// CHECK-NEXT:    var val: Int32
 // CHECK-NEXT:    func GetXAndY() -> Int32
 // CHECK-NEXT:    mutating func SetXAndY(_ v: Int32)
-// CHECK-NEXT:    var val: Int32
+// CHECK-NEXT:    var xAndY: Int32
 // CHECK-NEXT: }
 
 // CHECK:      struct AllUpper {
-// CHECK-NEXT:    init()
 // CHECK-NEXT:    init(val: Int32)
-// CHECK-NEXT:    var fooandbar: Int32
+// CHECK-NEXT:    init()
+// CHECK-NEXT:    var val: Int32
 // CHECK-NEXT:    func GETFOOANDBAR() -> Int32
 // CHECK-NEXT:    mutating func SETFOOANDBAR(_ v: Int32)
-// CHECK-NEXT:    var val: Int32
+// CHECK-NEXT:    var fooandbar: Int32
 // CHECK-NEXT: }
 
 // CHECK:      struct BothUpper {
-// CHECK-NEXT:    init()
 // CHECK-NEXT:    init(val: Int32)
-// CHECK-NEXT:    var fooAndBAR: Int32
+// CHECK-NEXT:    init()
+// CHECK-NEXT:    var val: Int32
 // CHECK-NEXT:    func getFOOAndBAR() -> Int32
 // CHECK-NEXT:    mutating func setFOOAndBAR(_ v: Int32)
-// CHECK-NEXT:    var val: Int32
+// CHECK-NEXT:    var fooAndBAR: Int32
 // CHECK-NEXT: }
 
 // CHECK:      struct FirstUpper {
-// CHECK-NEXT:    init()
 // CHECK-NEXT:    init(val: Int32)
-// CHECK-NEXT:    var fooAndBar: Int32
+// CHECK-NEXT:    init()
+// CHECK-NEXT:    var val: Int32
 // CHECK-NEXT:    func getFOOAndBar() -> Int32
 // CHECK-NEXT:    mutating func setFOOAndBar(_ v: Int32)
-// CHECK-NEXT:    var val: Int32
+// CHECK-NEXT:    var fooAndBar: Int32
 // CHECK-NEXT: }
 
 // CHECK:      struct NonConstGetter {
-// CHECK-NEXT:    init()
 // CHECK-NEXT:    init(val: Int32)
-// CHECK-NEXT:    var x: Int32 { mutating get set }
+// CHECK-NEXT:    init()
+// CHECK-NEXT:    var val: Int32
 // CHECK-NEXT:    mutating func getX() -> Int32
 // CHECK-NEXT:    mutating func setX(_ v: Int32)
-// CHECK-NEXT:    var val: Int32
+// CHECK-NEXT:    var x: Int32 { mutating get set }
 // CHECK-NEXT: }
 
 // FIXME: rdar91961524
@@ -189,58 +188,58 @@
 
 // CHECK:      struct MultipleArgsSetter {
 // CHECK-NEXT:    init()
-// CHECK-NEXT:    var x: Int32
 // CHECK-NEXT:    func getX() -> Int32
 // CHECK-NEXT:    mutating func setX(_ a: Int32, _ b: Int32)
+// CHECK-NEXT:    var x: Int32 { get }
 // CHECK-NEXT: }
 
 // CHECK:      struct NonTrivial {
-// CHECK-NEXT:    init()
 // CHECK-NEXT:    init(value: Int32)
-// CHECK-NEXT:   var value: Int32
+// CHECK-NEXT:    init()
+// CHECK-NEXT:    var value: Int32
 // CHECK-NEXT: }
 
 // CHECK:      struct PtrGetterSetter {
-// CHECK-NEXT:    init()
 // CHECK-NEXT:    init(value: Int32)
-// CHECK-NEXT:    var x: UnsafeMutablePointer<Int32>? { mutating get set }
+// CHECK-NEXT:    init()
+// CHECK-NEXT:    var value: Int32
 // CHECK-NEXT:    mutating func getX() -> UnsafeMutablePointer<Int32>!
 // CHECK-NEXT:    mutating func setX(_ v: UnsafeMutablePointer<Int32>!)
-// CHECK-NEXT:    var value: Int32
+// CHECK-NEXT:    var x: UnsafeMutablePointer<Int32>? { mutating get set }
 // CHECK-NEXT: }
 
 // CHECK:      struct RefGetterSetter {
-// CHECK-NEXT:    init()
 // CHECK-NEXT:    init(value: Int32)
+// CHECK-NEXT:    init()
+// CHECK-NEXT:    var value: Int32
 // CHECK-NEXT:    mutating func getX() -> UnsafePointer<Int32>
 // CHECK-NEXT:    mutating func setX(_ v: Int32)
-// CHECK-NEXT:    var value: Int32
 // CHECK-NEXT: }
 
 // CHECK:      struct NonTrivialGetterSetter {
-// CHECK-NEXT:    init()
 // CHECK-NEXT:    init(value: NonTrivial)
-// CHECK-NEXT:    var x: NonTrivial { mutating get set }
+// CHECK-NEXT:    init()
+// CHECK-NEXT:    var value: NonTrivial
 // CHECK-NEXT:    mutating func getX() -> NonTrivial
 // CHECK-NEXT:    mutating func setX(_ v: NonTrivial)
-// CHECK-NEXT:    var value: NonTrivial
+// CHECK-NEXT:    var x: NonTrivial { mutating get set }
 // CHECK-NEXT: }
 
 // CHECK:      struct DifferentTypes {
-// CHECK-NEXT:    init()
 // CHECK-NEXT:    init(value: NonTrivial)
+// CHECK-NEXT:    init()
+// CHECK-NEXT:    var value: NonTrivial
 // CHECK-NEXT:    mutating func getX() -> NonTrivial
 // CHECK-NEXT:    mutating func setX(_ v: Int32)
-// CHECK-NEXT:    var value: NonTrivial
 // CHECK-NEXT: }
 
 // CHECK:      struct UTF8Str {
-// CHECK-NEXT:    init()
 // CHECK-NEXT:    init(value: Int32)
-// CHECK-NEXT:    var utf8Str: Int32
+// CHECK-NEXT:    init()
+// CHECK-NEXT:    var value: Int32
 // CHECK-NEXT:    func getUTF8Str() -> Int32
 // CHECK-NEXT:    mutating func setUTF8Str(_ v: Int32)
-// CHECK-NEXT:    var value: Int32
+// CHECK-NEXT:    var utf8Str: Int32
 // CHECK-NEXT: }
 
 
@@ -253,44 +252,43 @@
 // CHECK-NEXT: }
 
 // CHECK:      struct PropertyWithSameName {
-// CHECK-NEXT:    init()
 // CHECK-NEXT:    init(value: Int32)
-// CHECK-NOT:     var value: Int32
+// CHECK-NEXT:    init()
+// CHECK-NEXT:    var value: Int32
 // CHECK-NEXT:    func getValue() -> Int32
 // CHECK-NEXT:    mutating func setValue(_ i: Int32)
-// CHECK-NEXT:    var value: Int32
 // CHECK-NEXT: }
 
 // CHECK:      struct PrivatePropertyWithSameName {
 // CHECK-NEXT:    init()
+// CHECK-NEXT:    var value: Int32
 // CHECK-NEXT:    func getValue() -> Int32
 // CHECK-NEXT:    mutating func setValue(_ i: Int32)
-// CHECK-NEXT:    var value: Int32
 // CHECK-NEXT: }
 
 // CHECK:      struct SnakeCaseGetterSetter {
-// CHECK-NEXT:    init()
 // CHECK-NEXT:    init(value: Int32)
-// CHECK-NEXT:    var foo: Int32
+// CHECK-NEXT:    init()
+// CHECK-NEXT:    var value: Int32
 // CHECK-NEXT:    func get_foo() -> Int32
 // CHECK-NEXT:    mutating func set_foo(_ v: Int32)
-// CHECK-NEXT:    var value: Int32
+// CHECK-NEXT:    var foo: Int32
 // CHECK-NEXT: }
 
 // CHECK:      struct SnakeCaseUTF8Str {
-// CHECK-NEXT:    init()
 // CHECK-NEXT:    init(value: Int32)
-// CHECK-NEXT:    var utf8String: Int32
+// CHECK-NEXT:    init()
+// CHECK-NEXT:    var value: Int32
 // CHECK-NEXT:    func get_utf8_string() -> Int32
 // CHECK-NEXT:    mutating func set_utf8_string(_ v: Int32)
-// CHECK-NEXT:    var value: Int32
+// CHECK-NEXT:    var utf8String: Int32
 // CHECK-NEXT: }
 
 // CHECK:      struct SnakeCaseTrailing {
-// CHECK-NEXT:    init()
 // CHECK-NEXT:    init(value: Int32)
-// CHECK-NEXT:    var x: Int32
+// CHECK-NEXT:    init()
+// CHECK-NEXT:    var value: Int32
 // CHECK-NEXT:    func get_x_() -> Int32
 // CHECK-NEXT:    mutating func set_x_(_ v: Int32)
-// CHECK-NEXT:    var value: Int32
+// CHECK-NEXT:    var x: Int32
 // CHECK-NEXT: }

--- a/test/Interop/Cxx/foreign-reference/lifetime-operation-methods-module-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/lifetime-operation-methods-module-interface.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-ide-test -print-module -cxx-interoperability-mode=upcoming-swift -I %swift_src_root/lib/ClangImporter/SwiftBridging -module-to-print=LifetimeOperationMethods -I %S/Inputs -source-filename=x | %FileCheck %s
 
 // CHECK: class RefCountedBox {
-// CHECK:   func doRetain() 
+// CHECK:   func doRetain()
 // CHECK:   func doRelease()
 // CHECK: }
 // CHECK: class DerivedRefCountedBox {
@@ -10,8 +10,8 @@
 // CHECK: }
 
 // CHECK: class DerivedHasRelease {
-// CHECK:   func doRelease()
 // CHECK:   func doRetainInBase()
+// CHECK:   func doRelease()
 // CHECK: }
 
 // CHECK: class TemplatedDerivedHasRelease<CFloat> {

--- a/test/Interop/Cxx/foreign-reference/nullable-module-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/nullable-module-interface.swift
@@ -7,9 +7,9 @@
 // CHECK: func mutateIt(_: Empty)
 
 // CHECK: class IntPair {
-// CHECK:   func test() -> Int32
-// CHECK:   class func create() -> IntPair!
 // CHECK:   var a: Int32
 // CHECK:   var b: Int32
+// CHECK:   func test() -> Int32
+// CHECK:   class func create() -> IntPair!
 // CHECK: }
 // CHECK: func mutateIt(_ x: IntPair!)

--- a/test/Interop/Cxx/foreign-reference/pod-module-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/pod-module-interface.swift
@@ -20,13 +20,13 @@
 
 // CHECK: class IntPair {
 // CHECK: init
+// CHECK:   var a: Int32
+// CHECK:   var b: Int32
 // CHECK:   func test() -> Int32
 // CHECK:   func testMutable() -> Int32
 // CHECK:   func instancePassThroughByRef(_ ref: IntPair) -> IntPair
 // CHECK:   class func staticPassThroughByRef(_ ref: IntPair) -> IntPair
 // CHECK:   class func create() -> IntPair
-// CHECK:   var a: Int32
-// CHECK:   var b: Int32
 // CHECK: }
 // CHECK: func mutateIt(_ x: IntPair)
 // CHECK-NOT: func passThroughByValue(_ x: IntPair) -> IntPair
@@ -35,54 +35,55 @@
 // CHECK: class RefHoldingPair {
 // CHECK: init
 // CHECK-NOT: pair
+// CHECK:   var otherValue: Int32
 // CHECK:   func test() -> Int32
 // CHECK:   func testMutable() -> Int32
 // CHECK:   class func create() -> RefHoldingPair
-// CHECK:   var otherValue: Int32
 // CHECK: }
 
 // CHECK: class RefHoldingPairRef {
 // CHECK: init
+// CHECK:   var pair: IntPair
+// CHECK:   var otherValue: Int32
 // CHECK:   func test() -> Int32
 // CHECK:   func testMutable() -> Int32
 // CHECK:   class func create() -> RefHoldingPairRef
-// CHECK:   var pair: IntPair
-// CHECK:   var otherValue: Int32
 // CHECK: }
 
 // CHECK: class RefHoldingPairPtr {
 // CHECK: init
+// CHECK:   var pair: IntPair
+// CHECK:   var otherValue: Int32
 // CHECK:   func test() -> Int32
 // CHECK:   func testMutable() -> Int32
 // CHECK:   class func create() -> RefHoldingPairPtr
-// CHECK:   var pair: IntPair
-// CHECK:   var otherValue: Int32
 // CHECK: }
 
 // CHECK: struct ValueHoldingPair {
 // CHECK-NOT: pair
 // CHECK:   init()
+// CHECK:   var otherValue: Int32
 // CHECK:   func test() -> Int32
 // CHECK:   mutating func testMutable() -> Int32
 // CHECK:   static func create() -> UnsafeMutablePointer<ValueHoldingPair>
-// CHECK:   var otherValue: Int32
 // CHECK: }
 
 // CHECK: struct ValueHoldingPairRef {
-// CHECK-NOT: pair
-// CHECK:   init()
-// CHECK:   func sub(_ other: IntPair) -> Int32
-// CHECK:   func max(_ other: IntPair) -> IntPair
-// CHECK: }
+// CHECK-NEXT:   init(pair: IntPair)
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   var pair: IntPair
+// CHECK-NEXT:   func sub(_ other: IntPair) -> Int32
+// CHECK-NEXT:   func max(_ other: IntPair) -> IntPair
+// CHECK-NEXT: }
 
 // CHECK: class BigType {
 // CHECK: init
-// CHECK:   func test() -> Int32
-// CHECK:   func testMutable() -> Int32
-// CHECK:   class func create() -> BigType
 // CHECK:   var a: Int32
 // CHECK:   var b: Int32
 // CHECK:   var buffer:
+// CHECK:   func test() -> Int32
+// CHECK:   func testMutable() -> Int32
+// CHECK:   class func create() -> BigType
 // CHECK: }
 // CHECK: func mutateIt(_ x: BigType)
 // CHECK-NOT: func passThroughByValue(_ x: BigType) -> BigType

--- a/test/Interop/Cxx/foreign-reference/singleton-module-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/singleton-module-interface.swift
@@ -2,36 +2,36 @@
 
 // CHECK: class DeletedDtor {
 // CHECK: init
+// CHECK:   var value: Int32
 // CHECK:   func test() -> Int32
 // CHECK:   func testMutable() -> Int32
 // CHECK:   class func create() -> DeletedDtor
-// CHECK:   var value: Int32
 // CHECK: }
 // CHECK: func mutateIt(_ x: DeletedDtor)
 
 // CHECK: class PrivateDtor {
 // CHECK: init
+// CHECK:   var value: Int32
 // CHECK:   func test() -> Int32
 // CHECK:   func testMutable() -> Int32
 // CHECK:   class func create() -> PrivateDtor
-// CHECK:   var value: Int32
 // CHECK: }
 // CHECK: func mutateIt(_ x: PrivateDtor)
 
 // CHECK: class DeletedSpecialMembers {
 // CHECK: init
+// CHECK:   var value: Int32
 // CHECK:   func test() -> Int32
 // CHECK:   func testMutable() -> Int32
 // CHECK:   class func create() -> DeletedSpecialMembers
-// CHECK:   var value: Int32
 // CHECK: }
 // CHECK: func mutateIt(_ x: DeletedSpecialMembers)
 
 // CHECK: class PrivateSpecialMembers {
 // CHECK: init
+// CHECK:   var value: Int32
 // CHECK:   func test() -> Int32
 // CHECK:   func testMutable() -> Int32
 // CHECK:   class func create() -> PrivateSpecialMembers
-// CHECK:   var value: Int32
 // CHECK: }
 // CHECK: func mutateIt(_ x: PrivateSpecialMembers)

--- a/test/Interop/Cxx/namespace/cross-module-redecls-module-interface.swift
+++ b/test/Interop/Cxx/namespace/cross-module-redecls-module-interface.swift
@@ -34,16 +34,16 @@ namespace ns {
 
 // CHECKB:     enum ns {
 // CHECKB-NEXT: struct B {
-// CHECKB-NEXT:    init()
 // CHECKB-NEXT:    init(y: Int32)
+// CHECKB-NEXT:    init()
 // CHECKB-NEXT:    var y: Int32
 // CHECKB-NEXT:  }
 // CHECKB-NEXT: }
 
 // CHECKA:     enum ns {
 // CHECKA-NEXT: struct A {
-// CHECKA-NEXT:    init()
 // CHECKA-NEXT:    init(x: Int32)
+// CHECKA-NEXT:    init()
 // CHECKA-NEXT:    var x: Int32
 // CHECKA-NEXT:  }
 // CHECKA-NEXT: }

--- a/test/Interop/Cxx/namespace/templates-with-forward-decl-module-interface.swift
+++ b/test/Interop/Cxx/namespace/templates-with-forward-decl-module-interface.swift
@@ -8,8 +8,8 @@
 // CHECK-NEXT:   struct ForwardDeclared<T> {
 // CHECK-NEXT:   }
 // CHECK-NEXT:   struct Decl<CInt> {
-// CHECK-NEXT:     init()
 // CHECK-NEXT:     init(fwd: NS1.ForwardDeclared<CInt>)
+// CHECK-NEXT:     init()
 // CHECK-NEXT:     typealias MyInt = Int32
 // CHECK-NEXT:     var fwd: NS1.ForwardDeclared<CInt>
 // CHECK-NEXT:     static var intValue: NS1.Decl<CInt>.MyInt { get }

--- a/test/Interop/Cxx/objc-correctness/call-to-generated-init-with-nsstring.swift
+++ b/test/Interop/Cxx/objc-correctness/call-to-generated-init-with-nsstring.swift
@@ -10,8 +10,8 @@ import Foundation
 import CxxClassWithNSStringInit
 
 // CHECK-IDE-TEST: struct S {
-// CHECK-IDE-TEST:   init()
 // CHECK-IDE-TEST:   init(A: NSString?, B: NSString?, C: NSString?)
+// CHECK-IDE-TEST:   init()
 // CHECK-IDE-TEST:   var A: NSString?
 // CHECK-IDE-TEST:   var B: NSString?
 // CHECK-IDE-TEST:   var C: NSString?

--- a/test/Interop/Cxx/static/static-member-var-module-interface.swift
+++ b/test/Interop/Cxx/static/static-member-var-module-interface.swift
@@ -1,8 +1,8 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=StaticMemberVar -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK: struct WithStaticAndInstanceMember {
-// CHECK-NEXT:   init()
 // CHECK-NEXT:   init(myInstance: Int32)
-// CHECK-NEXT:   static var myStatic: Int32
+// CHECK-NEXT:   init()
 // CHECK-NEXT:   var myInstance: Int32
+// CHECK-NEXT:   static var myStatic: Int32
 // CHECK-NEXT: }

--- a/test/Interop/Cxx/stdlib/overlay/custom-contiguous-iterator-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-contiguous-iterator-module-interface.swift
@@ -6,29 +6,29 @@
 // UNSUPPORTED: LinuxDistribution=amzn-2
 
 // CHECK: struct ConstContiguousIterator : UnsafeCxxContiguousIterator, UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
-// CHECK:   var pointee: Int32
 // CHECK:   func successor() -> ConstContiguousIterator
 // CHECK:   typealias Pointee = Int32
 // CHECK:   typealias Distance = Int32
+// CHECK:   var pointee: Int32
 // CHECK: }
 
 // CHECK: struct HasCustomContiguousIteratorTag : UnsafeCxxContiguousIterator, UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
-// CHECK:   var pointee: Int32
 // CHECK:   func successor() -> HasCustomContiguousIteratorTag
 // CHECK:   typealias Pointee = Int32
 // CHECK:   typealias Distance = Int32
+// CHECK:   var pointee: Int32
 // CHECK: }
 
 // CHECK: struct MutableContiguousIterator : UnsafeCxxMutableContiguousIterator, UnsafeCxxMutableRandomAccessIterator, UnsafeCxxMutableInputIterator {
-// CHECK:   var pointee: Int32
 // CHECK:   func successor() -> MutableContiguousIterator
 // CHECK:   typealias Pointee = Int32
 // CHECK:   typealias Distance = Int32
+// CHECK:   var pointee: Int32
 // CHECK: }
 
 // CHECK: struct HasNoContiguousIteratorConcept : UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
-// CHECK:   var pointee: Int32
 // CHECK:   func successor() -> HasNoContiguousIteratorConcept
 // CHECK:   typealias Pointee = Int32
 // CHECK:   typealias Distance = Int32
+// CHECK:   var pointee: Int32
 // CHECK: }

--- a/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
@@ -1,74 +1,70 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=CustomIterator -source-filename=x -I %S/Inputs -cxx-interoperability-mode=default | %FileCheck %s
 
 // CHECK: struct ConstIterator : UnsafeCxxInputIterator {
-// CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> ConstIterator
 // CHECK:   typealias Pointee = Int32
 // CHECK:   static func == (lhs: ConstIterator, other: ConstIterator) -> Bool
+// CHECK:   var pointee: Int32 { get }
 // CHECK: }
 
 // CHECK: struct ConstRACIterator : UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
-// CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> ConstRACIterator
 // CHECK:   typealias Pointee = Int32
 // CHECK:   typealias Distance = Int32
 // CHECK:   static func += (lhs: inout ConstRACIterator, v: ConstRACIterator.difference_type)
 // CHECK:   static func - (lhs: ConstRACIterator, other: ConstRACIterator) -> Int32
 // CHECK:   static func == (lhs: ConstRACIterator, other: ConstRACIterator) -> Bool
+// CHECK:   var pointee: Int32 { get }
 // CHECK: }
 
 // CHECK: struct ConstRACIteratorRefPlusEq : UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
-// CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> ConstRACIterator
 // CHECK:   typealias Pointee = Int32
 // CHECK:   typealias Distance = Int32
 // CHECK:   static func += (lhs: inout ConstRACIteratorRefPlusEq, v: ConstRACIteratorRefPlusEq.difference_type)
 // CHECK:   static func - (lhs: ConstRACIteratorRefPlusEq, other: ConstRACIteratorRefPlusEq) -> Int32
 // CHECK:   static func == (lhs: ConstRACIteratorRefPlusEq, other: ConstRACIteratorRefPlusEq) -> Bool
+// CHECK:   var pointee: Int32 { get }
 // CHECK: }
 
 // CHECK: struct ConstIteratorOutOfLineEq : UnsafeCxxInputIterator {
-// CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> ConstIteratorOutOfLineEq
+// CHECK:   var pointee: Int32 { get }
 // CHECK: }
 // CHECK: func == (lhs: ConstIteratorOutOfLineEq, rhs: ConstIteratorOutOfLineEq) -> Bool
 
 // CHECK: struct MinimalIterator : UnsafeCxxInputIterator {
-// CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> MinimalIterator
 // CHECK:   typealias Pointee = Int32
 // CHECK:   static func == (lhs: MinimalIterator, other: MinimalIterator) -> Bool
+// CHECK:   var pointee: Int32 { get }
 // CHECK: }
 
 // CHECK: struct ForwardIterator : UnsafeCxxInputIterator {
-// CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> ForwardIterator
 // CHECK:   typealias Pointee = Int32
 // CHECK:   static func == (lhs: ForwardIterator, other: ForwardIterator) -> Bool
+// CHECK:   var pointee: Int32 { get }
 // CHECK: }
 
 // CHECK: struct HasCustomIteratorTag : UnsafeCxxInputIterator {
-// CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> HasCustomIteratorTag
 // CHECK:   typealias Pointee = Int32
 // CHECK:   static func == (lhs: HasCustomIteratorTag, other: HasCustomIteratorTag) -> Bool
+// CHECK:   var pointee: Int32 { get }
 // CHECK: }
 
 // CHECK: struct HasCustomRACIteratorTag : UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
-// CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> HasCustomRACIteratorTag
 // CHECK:   typealias Pointee = Int32
 // CHECK:   typealias Distance = Int32
 // CHECK:   static func += (lhs: inout HasCustomRACIteratorTag, x: Int32)
 // CHECK:   static func - (lhs: HasCustomRACIteratorTag, x: HasCustomRACIteratorTag) -> Int32
 // CHECK:   static func == (lhs: HasCustomRACIteratorTag, other: HasCustomRACIteratorTag) -> Bool
+// CHECK:   var pointee: Int32 { get }
 // CHECK: }
 
 // CHECK: struct HasCustomInheritedRACIteratorTag : UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
-// CHECK:   var pointee: Int32 { get }
-// CHECK:   func successor() -> HasCustomInheritedRACIteratorTag
-// CHECK:   typealias Pointee = Int32
-// CHECK:   typealias Distance = Int32
 // CHECK:   struct CustomTag0 {
 // CHECK:     init()
 // CHECK:   }
@@ -79,24 +75,27 @@
 // CHECK:   typealias CustomTag3 = HasCustomInheritedRACIteratorTag.CustomTag2
 // CHECK:   typealias CustomTag4 = HasCustomInheritedRACIteratorTag.CustomTag3
 // CHECK:   typealias iterator_category = HasCustomInheritedRACIteratorTag.CustomTag4
+// CHECK:   func successor() -> HasCustomInheritedRACIteratorTag
+// CHECK:   typealias Pointee = Int32
+// CHECK:   typealias Distance = Int32
+// CHECK:   var pointee: Int32 { get }
 // CHECK: }
 
 // CHECK: struct HasCustomIteratorTagInline : UnsafeCxxInputIterator {
-// CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> HasCustomIteratorTagInline
 // CHECK:   typealias Pointee = Int32
 // CHECK:   static func == (lhs: HasCustomIteratorTagInline, other: HasCustomIteratorTagInline) -> Bool
+// CHECK:   var pointee: Int32 { get }
 // CHECK: }
 
 // CHECK: struct HasTypedefIteratorTag : UnsafeCxxInputIterator {
-// CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> HasTypedefIteratorTag
 // CHECK:   typealias Pointee = Int32
 // CHECK:   static func == (lhs: HasTypedefIteratorTag, other: HasTypedefIteratorTag) -> Bool
+// CHECK:   var pointee: Int32 { get }
 // CHECK: }
 
 // CHECK: struct MutableRACIterator : UnsafeCxxMutableRandomAccessIterator, UnsafeCxxMutableInputIterator {
-// CHECK:   var pointee: Int32
 // CHECK:   func successor() -> MutableRACIterator
 // CHECK:   typealias Pointee = Int32
 // CHECK:   typealias Distance = Int32
@@ -111,23 +110,23 @@
 // CHECK-NOT: struct HasNoDereferenceOperator : UnsafeCxxInputIterator
 
 // CHECK: struct TemplatedIterator<CInt> : UnsafeCxxInputIterator {
-// CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> TemplatedIterator<CInt>
 // CHECK:   typealias Pointee = Int32
 // CHECK:   static func == (lhs: TemplatedIterator<CInt>, other: TemplatedIterator<CInt>) -> Bool
+// CHECK:   var pointee: Int32 { get }
 // CHECK: }
 
 // CHECK: struct TemplatedIteratorOutOfLineEq<CInt> : UnsafeCxxInputIterator {
-// CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> TemplatedIteratorOutOfLineEq<CInt>
 // CHECK:   typealias Pointee = Int32
+// CHECK:   var pointee: Int32 { get }
 // CHECK: }
 
 // CHECK: struct TemplatedRACIteratorOutOfLineEq<CInt> : UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
-// CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> TemplatedRACIteratorOutOfLineEq<CInt>
 // CHECK:   typealias Pointee = Int32
 // CHECK:   typealias Distance = TemplatedRACIteratorOutOfLineEq<CInt>.difference_type
+// CHECK:   var pointee: Int32 { get }
 // CHECK: }
 
 // CHECK: struct BaseIntIterator {
@@ -151,13 +150,13 @@
 // CHECK: }
 
 // CHECK: struct InputOutputIterator : UnsafeCxxMutableInputIterator {
-// CHECK:   var pointee: Int32
 // CHECK:   func successor() -> InputOutputIterator
 // CHECK:   typealias Pointee = Int32
+// CHECK:   var pointee: Int32
 // CHECK: }
 
 // CHECK: struct InputOutputConstIterator : UnsafeCxxMutableInputIterator {
-// CHECK:   var pointee: Int32 { get nonmutating set }
 // CHECK:   func successor() -> InputOutputConstIterator
 // CHECK:   typealias Pointee = Int32
+// CHECK:   var pointee: Int32 { get nonmutating set }
 // CHECK: }

--- a/test/Interop/Cxx/stdlib/std-span-interface.swift
+++ b/test/Interop/Cxx/stdlib/std-span-interface.swift
@@ -15,25 +15,29 @@ import StdSpan
 import CxxStdlib
 
 // CHECK:     struct DependsOnSelf {
+// CHECK:       @safe borrowing func get() -> ConstSpanOfInt
 // CHECK:       @_lifetime(borrow self)
 // CHECK-NEXT:  @_alwaysEmitIntoClient @_disfavoredOverload public borrowing func get() -> Span<CInt>
-// CHECK-NEXT:  @safe borrowing func get() -> ConstSpanOfInt
+// CHECK:     }
 
+// CHECK:     struct CaptureByReference {
 // CHECK:      mutating func set(_ x: borrowing std.{{.*}}vector<CInt, std.{{.*}}allocator<CInt>>)
+// CHECK:     }
+
 // CHECK:      func funcWithSafeWrapper(_ s: ConstSpanOfInt)
 // CHECK-NEXT: func funcWithSafeWrapper2(_ s: ConstSpanOfInt) -> ConstSpanOfInt
 // CHECK-NEXT: func funcWithSafeWrapper3(_ v: borrowing VecOfInt) -> ConstSpanOfInt
 // CHECK:      struct X {
 // CHECK-NEXT:   init()
-// CHECK-NEXT:   /// This is an auto-generated wrapper for safer interop
-// CHECK-NEXT:   @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT:   @_alwaysEmitIntoClient @_disfavoredOverload public mutating func methodWithSafeWrapper(_ s: Span<CInt>)
 // CHECK-NEXT:   mutating func methodWithSafeWrapper(_ s: ConstSpanOfInt)
-// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
-// CHECK-NEXT: @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @_lifetime(&self)
-// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public mutating func getMutable(_ s: Span<CInt>) -> MutableSpan<CInt>
-// CHECK-NEXT: mutating func getMutable(_ s: ConstSpanOfInt) -> SpanOfInt
+// CHECK-NEXT:   mutating func getMutable(_ s: ConstSpanOfInt) -> SpanOfInt
+// CHECK-DAG:    /// This is an auto-generated wrapper for safer interop
+// CHECK-DAG:    @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-DAG:    @_alwaysEmitIntoClient @_disfavoredOverload public mutating func methodWithSafeWrapper(_ s: Span<CInt>)
+// CHECK-DAG:    /// This is an auto-generated wrapper for safer interop
+// CHECK-DAG:    @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-DAG:    @_lifetime(&self)
+// CHECK-DAG:    @_alwaysEmitIntoClient @_disfavoredOverload public mutating func getMutable(_ s: Span<CInt>) -> MutableSpan<CInt>
 // CHECK-NEXT: }
 // CHECK: struct SpanWithoutTypeAlias {
 // CHECK-NEXT:   init()
@@ -45,9 +49,9 @@ import CxxStdlib
 
 // CHECK: class DependsOnSelfFRT {
 // CHECK-NEXT:   init()
+// CHECK-NEXT:   var v: std.{{.*}}vector<CInt, std.{{.*}}allocator<CInt>>
 // CHECK-NEXT:   borrowing func get() -> ConstSpanOfInt
 // CHECK-NEXT:   borrowing func {{(__)?}}getMutable{{(Unsafe)?}}() -> SpanOfInt
-// CHECK-NEXT:   var v: std.{{.*}}vector<CInt, std.{{.*}}allocator<CInt>>
 // CHECK-NEXT: }
 
 // CHECK:      /// This is an auto-generated wrapper for safer interop

--- a/test/Interop/Cxx/templates/canonical-types-module-interface.swift
+++ b/test/Interop/Cxx/templates/canonical-types-module-interface.swift
@@ -1,16 +1,16 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=CanonicalTypes -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK:      struct MagicWrapper<IntWrapper> {
-// CHECK-NEXT:   init()
 // CHECK-NEXT:   init(t: IntWrapper)
+// CHECK-NEXT:   init()
 // CHECK-NEXT:   var t: IntWrapper
 // CHECK-NEXT:   func getValuePlusArg(_ arg: Int32) -> Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: struct IntWrapper {
-// CHECK-NEXT:   init()
 // CHECK-NEXT:   init(value: Int32)
-// CHECK-NEXT:   func getValue() -> Int32
+// CHECK-NEXT:   init()
 // CHECK-NEXT:   var value: Int32
+// CHECK-NEXT:   func getValue() -> Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: typealias WrappedMagicNumberA = MagicWrapper<IntWrapper>
 // CHECK-NEXT: typealias WrappedMagicNumberB = MagicWrapper<IntWrapper>

--- a/test/Interop/Cxx/templates/class-template-non-type-parameter-module-interface.swift
+++ b/test/Interop/Cxx/templates/class-template-non-type-parameter-module-interface.swift
@@ -4,14 +4,14 @@
 // CHECK: }
 
 // CHECK: struct MagicArray<CInt, _C{{.*}}_2> {
-// CHECK:   init()
 // CHECK:   init(t: (Int32, Int32))
+// CHECK:   init()
 // CHECK:   var t: (Int32, Int32)
 // CHECK: }
 
 // CHECK: struct MagicArray<CInt, _C{{.*}}_3> {
-// CHECK:   init()
 // CHECK:   init(t: (Int32, Int32, Int32))
+// CHECK:   init()
 // CHECK:   var t: (Int32, Int32, Int32)
 // CHECK: }
 

--- a/test/Interop/Cxx/templates/enable-if-module-interface.swift
+++ b/test/Interop/Cxx/templates/enable-if-module-interface.swift
@@ -3,9 +3,11 @@
 // The `init<T>` constructor template is not yet supported in Swift.
 
 // CHECK: struct HasConstructorWithEnableIf {
-// CHECK-NEXT:  @available(*, deprecated, message: "This zero-initializes the backing memory of the struct, which is unsafe for some C++ structs. Consider adding an explicit default initializer for this C++ struct.")
+// CHECK-NEXT:  @available(*, deprecated, message: "This zero-initializes
 // CHECK-NEXT:  init()
 // CHECK-NEXT:}
 
 // CHECK: struct HasConstructorWithEnableIfUsed {
+// CHECK-NEXT:  @available(*, deprecated, message: "This zero-initializes
+// CHECK-NEXT:  init()
 // CHECK-NEXT:  init<T, U>(_: T, _: U)

--- a/test/Interop/Cxx/templates/not-pre-defined-class-template-module-interface.swift
+++ b/test/Interop/Cxx/templates/not-pre-defined-class-template-module-interface.swift
@@ -1,17 +1,17 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=NotPreDefinedClassTemplate -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK:      struct MagicWrapper<IntWrapper> {
-// CHECK-NEXT:   init()
 // CHECK-NEXT:   init(t: IntWrapper)
+// CHECK-NEXT:   init()
 // CHECK-NEXT:   var t: IntWrapper
 // CHECK-NEXT:   func getValuePlusArg(_ arg: Int32) -> Int32
 // CHECK-NEXT: }
 
 // CHECK-NEXT: struct IntWrapper {
-// CHECK-NEXT:   init()
 // CHECK-NEXT:   init(value: Int32)
-// CHECK-NEXT:   func getValue() -> Int32
+// CHECK-NEXT:   init()
 // CHECK-NEXT:   var value: Int32
+// CHECK-NEXT:   func getValue() -> Int32
 // CHECK-NEXT: }
 
 // CHECK-NEXT: typealias MagicallyWrappedIntWithoutDefinition = MagicWrapper<IntWrapper>

--- a/test/Interop/Cxx/templates/using-directive-module-interface.swift
+++ b/test/Interop/Cxx/templates/using-directive-module-interface.swift
@@ -1,15 +1,15 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=UsingDirective -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK:      struct MagicWrapper<IntWrapper> {
-// CHECK-NEXT:   init()
 // CHECK-NEXT:   init(t: IntWrapper)
+// CHECK-NEXT:   init()
 // CHECK-NEXT:   var t: IntWrapper
 // CHECK-NEXT:   func getValuePlusArg(_ arg: Int32) -> Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: struct IntWrapper {
-// CHECK-NEXT:   init()
 // CHECK-NEXT:   init(value: Int32)
-// CHECK-NEXT:   func getValue() -> Int32
+// CHECK-NEXT:   init()
 // CHECK-NEXT:   var value: Int32
+// CHECK-NEXT:   func getValue() -> Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: typealias UsingWrappedMagicNumber = MagicWrapper<IntWrapper>


### PR DESCRIPTION
We may visit and thus import these members in an unpredictable order.
To avoid future churn for module interface test cases, sort the printed
module interface output according to some rough heuristics.