### PR TITLE
Optimizer: fix three problems with lifetime completion and infinite loops

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
@@ -233,6 +233,16 @@ private func optimize(function: Function, _ context: FunctionPassContext, _ modu
     // stores in global init functions.
     eliminateDeadStores(in: function, context)
   }
+
+  // This cleanup is already done in `runSimplification`. However, `specializeApplies`, which runs
+  // afterwards, can create unreachable blocks and incomplete lifetimes, again.
+  _ = context.removeDeadBlocks(in: function)
+  if context.needBreakInfiniteLoops {
+    breakInfiniteLoops(in: function, context)
+  }
+  if context.needCompleteLifetimes {
+    completeLifetimes(in: function, context)
+  }
 }
 
 private func inlineAndDevirtualize(apply: FullApplySite, alreadyInlinedFunctions: inout Set<PathFunctionTuple>,

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -1482,9 +1482,8 @@ public:
       removeUnreachableBlocks(*getFunction());
       invalidateAnalysis(SILAnalysis::InvalidationKind::FunctionBody);
 
-      // We know that this pass does not create infinite loops even if it
-      // deletes basic blocks.
-      getFunction()->setNeedBreakInfiniteLoops(false);
+      if (getFunction()->needBreakInfiniteLoops())
+        breakInfiniteLoops(getPassManager(), getFunction());
       if (getFunction()->needCompleteLifetimes())
         completeAllLifetimes(getPassManager(), getFunction());
 

--- a/test/SILOptimizer/existential_specializer2.sil
+++ b/test/SILOptimizer/existential_specializer2.sil
@@ -1,0 +1,45 @@
+// RUN: %target-sil-opt %s -existential-specializer -mandatory-performance-optimizations -sil-combine | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+
+class C {}
+
+public protocol P {}
+
+public struct S : P {
+  var o: AnyObject
+}
+
+// Just check that we generate valid SIL
+// CHECK-LABEL: sil [signature_optimized_thunk] [heuristic_always_inline] [ossa] @doesnt_return :
+// CHECK:       } // end sil function 'doesnt_return'
+sil [ossa] @doesnt_return : $@convention(thin) (@in P, @inout P, @owned C) -> Never {
+bb0(%0 : $*P, %1 : $*P, %2 : @owned $C):
+  copy_addr %0 to [init] %1
+  destroy_addr %0
+  destroy_value [dead_end] %2
+  unreachable
+}
+
+// Just check that we generate valid SIL
+// CHECK-LABEL: sil [ossa] @specialize_no_return_function :
+// CHECK-LABEL: } // end sil function 'specialize_no_return_function'
+sil [ossa] @specialize_no_return_function : $@convention(thin) (@owned S, @inout P, @owned C) -> () {
+bb0(%0 : @owned $S, %1 : $*P, %2 : @owned $C):
+  %4 = alloc_stack $P
+  %5 = init_existential_addr %4, $S
+  store %0 to [init] %5
+  %7 = function_ref @doesnt_return : $@convention(thin) (@in P, @inout P, @owned C) -> Never
+  %8 = apply %7(%4, %1, %2) : $@convention(thin) (@in P, @inout P, @owned C) -> Never
+  dealloc_stack %4 : $*P
+  %10 = tuple ()
+  return %10 : $()
+}
+
+sil_witness_table S: P module test {}
+

--- a/test/SILOptimizer/mandatory_performance_optimizations.sil
+++ b/test/SILOptimizer/mandatory_performance_optimizations.sil
@@ -17,6 +17,8 @@ struct S6: ~Copyable {
   deinit
 }
 
+class C {}
+
 sil_global [let] @g1 : $Int32
 sil_global [let] @g2 : $Int32
 sil_global [let] @g3 : $Int32
@@ -229,6 +231,27 @@ bb2:
   br bb3
 bb3:
   return %1 : $Int32
+}
+
+sil [ossa] @generic_no_return : $@convention(thin) <T> () -> @out T {
+bb0(%0 : $*T):
+  unreachable
+}
+
+// CHECK-LABEL: sil [no_allocation] [perf_constraint] [ossa] @specialize_no_return :
+// CHECK:          destroy_value [dead_end] %0
+// CHECK-NEXT:     unreachable
+// CHECK:       } // end sil function 'specialize_no_return'
+sil [ossa] [no_allocation] @specialize_no_return : $@convention(thin) (@owned C) -> () {
+bb0(%0 : @owned $C):
+  %1 = alloc_stack $Never
+  %4 = function_ref @generic_no_return : $@convention(thin) <T> () -> @out T
+  apply %4<Never>(%1) : $@convention(thin) <T> () -> @out T
+  apply undef<Never>(%1) : $@convention(thin) <T> () -> @out T
+  dealloc_stack %1
+  destroy_value %0
+  %19 = tuple ()
+  return %19
 }
 
 sil @createNonTrivialStruct : $@convention(thin) (Int) -> @owned NonTrivialStruct

--- a/test/SILOptimizer/performance_inliner.sil
+++ b/test/SILOptimizer/performance_inliner.sil
@@ -989,3 +989,29 @@ entry(%executor: $Builtin.Executor):
   %r = tuple ()
   return %r : $()
 }
+
+sil [ossa] @does_not_throw : $@convention(thin) () -> @error any Error {
+bb0:
+  %1 = tuple ()
+  return %1
+}
+
+// CHECK-LABEL: sil [ossa] @inlining_produces_infinite_loop
+// CHECK:         builtin "infinite_loop_true_condition"()
+// CHECK:         unreachable
+// CHECK:       } // end sil function 'inlining_produces_infinite_loop'
+sil [ossa] @inlining_produces_infinite_loop : $@convention(thin) () -> @error any Error {
+bb0:
+  br bb1
+
+bb1:
+  %4 = function_ref @does_not_throw : $@convention(thin) () -> @error any Error
+  try_apply %4() : $@convention(thin) () -> @error any Error, normal bb2, error bb3
+
+bb2(%6 : $()):
+  br bb1
+
+bb3(%13 : @owned $any Error):
+  throw %13
+}
+


### PR DESCRIPTION
* Inliner: break infinite loops which are a result of inlining

This can happen if the only exit of a loop is the throw-branch of a `try_apply` and the inlined function does not actually throw.

rdar://169569071

* MandatoryPerformanceOptimizations: make sure to break infinite loops and complete lifetimes

Those tasks are already done within the optimization in `runSimplification`. However, afterwards we specialize generics in the function. And specialization can create unreachable blocks and incomplete lifetimes.

rdar://169554780

* ExistentialSpecializer: complete lifetimes in the generated thunk if needed

If the thunk calls to a no-return function, it is ended with an `unreachable`. This may introduce incomplete lifetimes.

rdar://169555460