### PR TITLE
[Backtracing] [Linux] Improve thread capture edge cases

### DIFF
--- a/test/Backtracing/CrashWithThreadsLinux.swift
+++ b/test/Backtracing/CrashWithThreadsLinux.swift
@@ -45,7 +45,7 @@ func lockMutex() {
 
 func unlockMutex() {
   guard unsafe pthread_mutex_unlock(mutex) == 0 else {
-    fatalError("pthread_mutex_lock failed")
+    fatalError("pthread_mutex_unlock failed")
   }
 }
 
@@ -91,9 +91,11 @@ while (true) {
   sleep(10)
 }
 
+// CHECK-NOT: backtraces will be missing information
+
 // CHECK: *** Program crashed: Bad pointer dereference at 0x{{0+}}4 ***
 
-// CHECK-NOT: backtraces will be missing information
+// CHECK: {{Platform: .* Linux}}
 
 // make sure there are no threads before the crashing thread (rdar://164566321)
 // and check that we have some vaguely sane and symbolicated threads, including
@@ -103,8 +105,5 @@ while (true) {
 // CHECK-NOT: Thread {{[0-9]+( ".*")?}}:
 // CHECK: Thread {{[0-9]+}} {{(".*" )?}}crashed:
 // CHECK: {{0x[0-9a-f]+}} reallyCrashMe()
-
-// CHECK: Thread {{[0-9]*( ".*")?}}:
-// CHECK: {{0x[0-9a-f]+.*main.* CrashWithThreads}}
 
 // CHECK: Thread {{[0-9]*( ".*")?}}:

--- a/test/Backtracing/CrashWithThreadsLinux.swift
+++ b/test/Backtracing/CrashWithThreadsLinux.swift
@@ -9,19 +9,15 @@
 // UNSUPPORTED: asan
 // REQUIRES: executable_test
 // REQUIRES: backtracing
-// REQUIRES: OS=macosx
+// REQUIRES: OS=linux-gnu
 
 // This test proved unstable on Linux so we disabled it while focus is elsewhere,
 // as it's not critical function, but it would be nice to restore it one day.
 
-#if canImport(Darwin)
-  import Darwin
-#elseif canImport(Glibc)
+#if canImport(Glibc)
   import Glibc
 #elseif canImport(Android)
   import Android
-#elseif os(Windows)
-  import CRT
 #else
 #error("Unsupported platform")
 #endif
@@ -55,11 +51,7 @@ func unlockMutex() {
 
 
 func spawnThread(_ shouldCrash: Bool) {
-  #if os(Linux)
   var thread: pthread_t = 0
-  #elseif os(macOS)
-  var thread = pthread_t(nil)
-  #endif
   if shouldCrash {
     pthread_create(&thread, nil, { _ in
                                 // take mutex
@@ -100,6 +92,8 @@ while (true) {
 }
 
 // CHECK: *** Program crashed: Bad pointer dereference at 0x{{0+}}4 ***
+
+// CHECK-NOT: backtraces will be missing information
 
 // make sure there are no threads before the crashing thread (rdar://164566321)
 // and check that we have some vaguely sane and symbolicated threads, including

--- a/test/Backtracing/CrashWithThreadsMac.swift
+++ b/test/Backtracing/CrashWithThreadsMac.swift
@@ -36,7 +36,7 @@ func lockMutex() {
 
 func unlockMutex() {
   guard unsafe pthread_mutex_unlock(mutex) == 0 else {
-    fatalError("pthread_mutex_lock failed")
+    fatalError("pthread_mutex_unlock failed")
   }
 }
 

--- a/test/Backtracing/CrashWithThreadsMac.swift
+++ b/test/Backtracing/CrashWithThreadsMac.swift
@@ -11,9 +11,6 @@
 // REQUIRES: backtracing
 // REQUIRES: OS=macosx
 
-// This test proved unstable on Linux so we disabled it while focus is elsewhere,
-// as it's not critical function, but it would be nice to restore it one day.
-
 import Darwin
 
 let mutex = UnsafeMutablePointer<pthread_mutex_t>.allocate(capacity: 1)

--- a/test/Backtracing/CrashWithThreadsMac.swift
+++ b/test/Backtracing/CrashWithThreadsMac.swift
@@ -1,0 +1,102 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -Onone -g -o %t/CrashWithThreads
+// RUN: %target-codesign %t/CrashWithThreads
+// RUN: (env SWIFT_BACKTRACE=enable=yes,cache=no,swift-backtrace=%backtracer %target-run %t/CrashWithThreads 2>&1 || true) | %FileCheck -vv %s -dump-input-filter=all
+// RUN: (env SWIFT_BACKTRACE=enable=yes,cache=no,swift-backtrace=%backtracer,threads=all %target-run %t/CrashWithThreads 2>&1 || true) | %FileCheck -vv %s -dump-input-filter=all
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: asan
+// REQUIRES: executable_test
+// REQUIRES: backtracing
+// REQUIRES: OS=macosx
+
+// This test proved unstable on Linux so we disabled it while focus is elsewhere,
+// as it's not critical function, but it would be nice to restore it one day.
+
+import Darwin
+
+let mutex = UnsafeMutablePointer<pthread_mutex_t>.allocate(capacity: 1)
+guard unsafe pthread_mutex_init(mutex, nil) == 0 else {
+  fatalError("pthread_mutex_init failed")
+}
+
+func reallyCrashMe() {
+  print("I'm going to crash now")
+  let ptr = UnsafeMutablePointer<Int>(bitPattern: 4)!
+  ptr.pointee = 42
+}
+
+func crashMe() {
+  reallyCrashMe()
+}
+
+func lockMutex() {
+  guard unsafe pthread_mutex_lock(mutex) == 0 else {
+    fatalError("pthread_mutex_lock failed")
+  }
+}
+
+func unlockMutex() {
+  guard unsafe pthread_mutex_unlock(mutex) == 0 else {
+    fatalError("pthread_mutex_lock failed")
+  }
+}
+
+
+func spawnThread(_ shouldCrash: Bool) {
+  var thread = pthread_t(nil)
+  if shouldCrash {
+    pthread_create(&thread, nil, { _ in
+                                // take mutex
+                                lockMutex()
+
+                                crashMe()
+
+                                // this should not be run
+                                unlockMutex()
+
+                                while (true) {
+                                    sleep(10)
+                                  }
+                              }, nil)
+  } else {
+    pthread_create(&thread, nil, { _ in
+                                  while (true) {
+                                    sleep(10)
+                                  }
+                                }, nil)
+  }
+}
+
+let crashingThreadIndex = (1..<4).randomElement()
+
+lockMutex()
+
+// hold a mutex
+for threadIndex in 1..<4 {
+  spawnThread(threadIndex == crashingThreadIndex)
+}
+
+// release mutex
+unlockMutex()
+
+while (true) {
+  sleep(10)
+}
+
+// CHECK: *** Program crashed: Bad pointer dereference at 0x{{0+}}4 ***
+
+// make sure there are no threads before the crashing thread (rdar://164566321)
+// and check that we have some vaguely sane and symbolicated threads, including
+// a main thread (AFTER the crashed thread) and at least one other thread
+
+// we expect the first thread not to be another thread, it should be the crashing thread instead
+// CHECK-NOT: Thread {{[0-9]+( ".*")?}}:
+// CHECK: Thread {{[0-9]+}} {{(".*" )?}}crashed:
+// CHECK: {{0x[0-9a-f]+}} reallyCrashMe()
+
+// CHECK: Thread {{[0-9]*( ".*")?}}:
+// CHECK: {{0x[0-9a-f]+.*main.* CrashWithThreads}}
+
+// CHECK: Thread {{[0-9]*( ".*")?}}:


### PR DESCRIPTION
Improve sporadic inability to capture some thread backtraces on linux.

Occasionally (especially under stress test conditions) crashing programs on Linux were occasionally failing to capture threads with message "swift-runtime: failed to suspend thread". Root cause analysis suggested the issue was libraries such as glibc masking all signals for the process, e.g. during pthread_create. This patch adds a suitable pause and retry semantic for this case.

rdar://169803867

Also, Linux on arm64 (e.g. on Raspberry Pi or running in Docker containers on Apple Silicon Macs) was only capturing the main thread and the crashing thread, this was due to a missing SA_SIGINFO flag when registering a signal handler.

rdar://165040681



<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
