### PR TITLE
[6.3][Concurrency] Weak link SE-0505 protocol requirements.

### DIFF
--- a/stdlib/public/Concurrency/Clock.swift
+++ b/stdlib/public/Concurrency/Clock.swift
@@ -50,7 +50,9 @@ public protocol Clock<Duration>: Sendable {
   /// - at instant:  The time at which we would like it to run.
   /// - tolerance:   The ideal maximum delay we are willing to tolerate.
   ///
+  #if !os(Windows)
   @_weakLinked
+  #endif
   @available(StdlibDeploymentTarget 6.3, *)
   func run(_ job: consuming ExecutorJob,
            at instant: Instant, tolerance: Duration?)
@@ -71,7 +73,9 @@ public protocol Clock<Duration>: Sendable {
   /// - at instant:  The time at which we would like it to run.
   /// - tolerance:   The ideal maximum delay we are willing to tolerate.
   ///
+  #if !os(Windows)
   @_weakLinked
+  #endif
   @available(StdlibDeploymentTarget 6.3, *)
   func enqueue(_ job: consuming ExecutorJob,
                on executor: some Executor,

--- a/stdlib/public/Concurrency/Clock.swift
+++ b/stdlib/public/Concurrency/Clock.swift
@@ -50,6 +50,7 @@ public protocol Clock<Duration>: Sendable {
   /// - at instant:  The time at which we would like it to run.
   /// - tolerance:   The ideal maximum delay we are willing to tolerate.
   ///
+  @_weakLinked
   @available(StdlibDeploymentTarget 6.3, *)
   func run(_ job: consuming ExecutorJob,
            at instant: Instant, tolerance: Duration?)
@@ -70,6 +71,7 @@ public protocol Clock<Duration>: Sendable {
   /// - at instant:  The time at which we would like it to run.
   /// - tolerance:   The ideal maximum delay we are willing to tolerate.
   ///
+  @_weakLinked
   @available(StdlibDeploymentTarget 6.3, *)
   func enqueue(_ job: consuming ExecutorJob,
                on executor: some Executor,

--- a/stdlib/public/Concurrency/Clock.swift
+++ b/stdlib/public/Concurrency/Clock.swift
@@ -87,6 +87,7 @@ public protocol Clock<Duration>: Sendable {
 extension Clock {
   // The default implementation works by creating a trampoline and calling
   // the run() method.
+  @_weakLinked
   @available(StdlibDeploymentTarget 6.3, *)
   public func enqueue(_ job: consuming ExecutorJob,
                       on executor: some Executor,
@@ -97,6 +98,7 @@ extension Clock {
 
   // Clocks that do not implement run will fatalError() if you try to use
   // them with an executor that does not understand them.
+  @_weakLinked
   @available(StdlibDeploymentTarget 6.3, *)
   public func run(_ job: consuming ExecutorJob,
                   at instant: Instant, tolerance: Duration?) {

--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -144,6 +144,7 @@ extension Executor {
   /// Executors that implement SchedulingExecutor should provide their
   /// own copy of this method, which will allow the compiler to avoid a
   /// potentially expensive runtime cast.
+  @_weakLinked
   @available(StdlibDeploymentTarget 6.3, *)
   public var asSchedulingExecutor: (any SchedulingExecutor)? {
     return self as? SchedulingExecutor
@@ -168,6 +169,7 @@ extension Executor {
   #if os(WASI) || !$Embedded
   // This defaults to `false` so that existing third-party Executor
   // implementations will work as expected.
+  @_weakLinked
   @available(StdlibDeploymentTarget 6.3, *)
   public var isMainExecutor: Bool { false }
   #endif // os(WASI) || !$Embedded

--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -38,7 +38,9 @@ public protocol Executor: AnyObject, Sendable {
 
   #if os(WASI) || !$Embedded
   /// `true` if this is the main executor.
+  #if !os(Windows)
   @_weakLinked
+  #endif
   @available(StdlibDeploymentTarget 6.3, *)
   var isMainExecutor: Bool { get }
   #endif // os(WASI) || !$Embedded
@@ -50,7 +52,9 @@ public protocol Executor: AnyObject, Sendable {
   /// Executors that implement SchedulingExecutor should provide their
   /// own copy of this method, which will allow the compiler to avoid a
   /// potentially expensive runtime cast.
+  #if !os(Windows)
   @_weakLinked
+  #endif
   @available(StdlibDeploymentTarget 6.3, *)
   var asSchedulingExecutor: (any SchedulingExecutor)? { get }
   #endif

--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -38,6 +38,7 @@ public protocol Executor: AnyObject, Sendable {
 
   #if os(WASI) || !$Embedded
   /// `true` if this is the main executor.
+  @_weakLinked
   @available(StdlibDeploymentTarget 6.3, *)
   var isMainExecutor: Bool { get }
   #endif // os(WASI) || !$Embedded
@@ -49,6 +50,7 @@ public protocol Executor: AnyObject, Sendable {
   /// Executors that implement SchedulingExecutor should provide their
   /// own copy of this method, which will allow the compiler to avoid a
   /// potentially expensive runtime cast.
+  @_weakLinked
   @available(StdlibDeploymentTarget 6.3, *)
   var asSchedulingExecutor: (any SchedulingExecutor)? { get }
   #endif


### PR DESCRIPTION
Mark the new protocol requirements as weak linked so we can pull them from 6.3 without breaking things.

rdar://169805891
