### PR TITLE
Sema: Teach disjunction pruning about CF toll-free bridging

### DIFF
--- a/lib/Sema/CSLookahead.cpp
+++ b/lib/Sema/CSLookahead.cpp
@@ -95,15 +95,16 @@ static ConflictReason canPossiblyConvertTo(
       // Toll-free bridging CF -> ObjC.
       if (lhsDecl->getForeignClassKind() == ClassDecl::ForeignKind::CFType &&
           rhsDecl->getForeignClassKind() != ClassDecl::ForeignKind::CFType) {
-        return canPossiblyConvertTo(getBridgedObjCClass(lhsDecl), rhsDecl);
+        lhsDecl = getBridgedObjCClass(lhsDecl);
 
       // Toll-free bridging ObjC -> CF.
       } else if (lhsDecl->getForeignClassKind() != ClassDecl::ForeignKind::CFType &&
                  rhsDecl->getForeignClassKind() == ClassDecl::ForeignKind::CFType) {
-        return canPossiblyConvertTo(lhsDecl, getBridgedObjCClass(rhsDecl));
+        rhsDecl = getBridgedObjCClass(rhsDecl);
+      }
 
-      // Subclassing relationships.
-      } else if (!rhsDecl->isSuperclassOf(lhsDecl))
+      // Check for a subclassing relationship.
+      if (!rhsDecl->isSuperclassOf(lhsDecl))
         return ConflictFlag::Class;
 
       break;

--- a/validation-test/Sema/type_checker_perf/slow/cfstring_iuo.swift
+++ b/validation-test/Sema/type_checker_perf/slow/cfstring_iuo.swift
@@ -1,0 +1,15 @@
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=8000
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+func f(str: CFString!) {
+  let _ = [ // expected-error {{reasonable time}}
+    str: String(str),
+    str: String(str),
+    str: String(str),
+    str: String(str),
+    str: String(str)
+  ]
+}

--- a/validation-test/Sema/type_checker_perf/slow/cfstring_iuo.swift
+++ b/validation-test/Sema/type_checker_perf/slow/cfstring_iuo.swift
@@ -1,11 +1,13 @@
-// RUN: %target-typecheck-verify-swift -solver-scope-threshold=8000
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=8000 -solver-enable-prune-disjunctions
 
 // REQUIRES: objc_interop
+
+// This is valid, but slow.
 
 import Foundation
 
 func f(str: CFString!) {
-  let _ = [ // expected-error {{reasonable time}}
+  let _ = [
     str: String(str),
     str: String(str),
     str: String(str),

--- a/validation-test/Sema/type_checker_perf/slow/custom_cgfloat_int_operator.swift
+++ b/validation-test/Sema/type_checker_perf/slow/custom_cgfloat_int_operator.swift
@@ -1,0 +1,17 @@
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=100000
+
+// Passes with default limits but slow
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+func * (int: Int, float: CGFloat) -> CGFloat { fatalError() }
+
+func g(_: CGFloat, _: CGFloat) {}
+func g(_: Double, _: Double) {}
+
+func f(x: Int, y: CGFloat) {
+  g(y - y / 2 - (x * 10), -y - 15 + (x * 10))
+  // expected-error@-1 {{reasonable time}}
+}


### PR DESCRIPTION
This fixes a too complex regression in the `cfstring_iuo.swift` test, and in fact the expression is now type checked more quickly than before.