### PR TITLE
[Constraint] Conditionally increase member lookup impact

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11417,6 +11417,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
   // We'd need to record original base type because it might be a type
   // variable representing another missing member.
   auto origBaseTy = baseTy;
+
   // Resolve the base type, if we can. If we can't resolve the base type,
   // then we can't solve this constraint.
   baseTy = simplifyType(baseTy, flags);
@@ -11671,6 +11672,9 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
 
       bool alreadyDiagnosed = (result.OverallResult ==
                                MemberLookupResult::ErrorAlreadyDiagnosed);
+      std::optional<Constraint*> pastResult = this->findConstraintKindAt(locator, ConstraintKind::ValueMember);
+      alreadyDiagnosed |= pastResult.has_value();
+
       auto *fix = DefineMemberBasedOnUse::create(*this, baseTy, member,
                                                  alreadyDiagnosed, locator);
 
@@ -11681,6 +11685,9 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
       if (instanceTy->is<AnyFunctionType>()) {
         impact += 10;
       }
+
+      if (pastResult.has_value()) //We may want to inspect it
+        impact +=5;
 
       auto *anchorExpr = getAsExpr(locator->getAnchor());
       if (anchorExpr) {


### PR DESCRIPTION
When member lookup constraint simplification has succeeded on a type or subtype, increase the impact for failures on super types as the success is the more likely path.

Includes implementation to record the success of the member lookup

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
