### PR TITLE
IRGen/Runtime: Fix discrepancies in Borrow type layout.

### DIFF
--- a/lib/IRGen/FixedTypeInfo.h
+++ b/lib/IRGen/FixedTypeInfo.h
@@ -104,6 +104,7 @@ public:
   llvm::Value *getIsTriviallyDestroyable(IRGenFunction &IGF, SILType T) const override;
   llvm::Value *getIsBitwiseTakable(IRGenFunction &IGF, SILType T) const override;
   llvm::Value *getIsBitwiseBorrowable(IRGenFunction &IGF, SILType T) const override;
+  llvm::Value *getIsAddressableForDependencies(IRGenFunction &IGF, SILType T) const override;
   llvm::Value *isDynamicallyPackedInline(IRGenFunction &IGF,
                                          SILType T) const override;
 

--- a/lib/IRGen/GenArray.cpp
+++ b/lib/IRGen/GenArray.cpp
@@ -586,6 +586,11 @@ public:
     return Element.getIsBitwiseBorrowable(IGF,
                                           getElementSILType(IGF.IGM, T));
   }
+  llvm::Value *getIsAddressableForDependencies(IRGenFunction &IGF,
+                                      SILType T) const override {
+    return Element.getIsAddressableForDependencies(IGF,
+                                          getElementSILType(IGF.IGM, T));
+  }
   llvm::Value *isDynamicallyPackedInline(IRGenFunction &IGF,
                                          SILType T) const override {
     auto startBB = IGF.Builder.GetInsertBlock();

--- a/lib/IRGen/GenOpaque.h
+++ b/lib/IRGen/GenOpaque.h
@@ -224,6 +224,10 @@ namespace irgen {
   /// Emit a load of the 'isBitwiseBorrowable' value witness.
   llvm::Value *emitLoadOfIsBitwiseBorrowable(IRGenFunction &IGF, SILType T);
 
+  /// Emit a load of the 'isAddressableForDependencies' value witness.
+  llvm::Value *emitLoadOfIsAddressableForDependencies(IRGenFunction &IGF,
+                                                      SILType T);
+
   /// Emit a load of the 'isInline' value witness.
   llvm::Value *emitLoadOfIsInline(IRGenFunction &IGF, SILType T);
 

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -243,6 +243,13 @@ llvm::Value *FixedTypeInfo::getIsBitwiseBorrowable(IRGenFunction &IGF, SILType T
   return llvm::ConstantInt::get(IGF.IGM.Int1Ty,
       getBitwiseTakable(ResilienceExpansion::Maximal) == IsBitwiseTakableAndBorrowable);
 }
+llvm::Value *FixedTypeInfo::getIsAddressableForDependencies(IRGenFunction &IGF, SILType T) const {
+
+  bool isAFD = T.isAddressableForDeps(IGF.IGM.getSILModule(),
+                                      TypeExpansionContext::minimal());
+  
+  return llvm::ConstantInt::get(IGF.IGM.Int1Ty, isAFD);
+}
 llvm::Constant *FixedTypeInfo::getStaticStride(IRGenModule &IGM) const {
   return IGM.getSize(getFixedStride());
 }
@@ -1365,6 +1372,9 @@ namespace {
       llvm_unreachable("should not call on an immovable opaque type");
     }
     llvm::Value *getIsBitwiseBorrowable(IRGenFunction &IGF, SILType T) const override {
+      llvm_unreachable("should not call on an immovable opaque type");
+    }
+    llvm::Value *getIsAddressableForDependencies(IRGenFunction &IGF, SILType T) const override {
       llvm_unreachable("should not call on an immovable opaque type");
     }
     llvm::Value *isDynamicallyPackedInline(IRGenFunction &IGF,

--- a/lib/IRGen/NonFixedTypeInfo.h
+++ b/lib/IRGen/NonFixedTypeInfo.h
@@ -114,6 +114,10 @@ public:
     return emitLoadOfIsBitwiseBorrowable(IGF, T);
   }
 
+  llvm::Value *getIsAddressableForDependencies(IRGenFunction &IGF, SILType T) const override {
+    return emitLoadOfIsAddressableForDependencies(IGF, T);
+  }
+
   llvm::Value *isDynamicallyPackedInline(IRGenFunction &IGF,
                                          SILType T) const override {
     return emitLoadOfIsInline(IGF, T);

--- a/lib/IRGen/TypeInfo.h
+++ b/lib/IRGen/TypeInfo.h
@@ -327,6 +327,7 @@ public:
   virtual llvm::Value *getIsTriviallyDestroyable(IRGenFunction &IGF, SILType T) const = 0;
   virtual llvm::Value *getIsBitwiseTakable(IRGenFunction &IGF, SILType T) const = 0;
   virtual llvm::Value *getIsBitwiseBorrowable(IRGenFunction &IGF, SILType T) const = 0;
+  virtual llvm::Value *getIsAddressableForDependencies(IRGenFunction &IGF, SILType T) const = 0;
   virtual llvm::Value *isDynamicallyPackedInline(IRGenFunction &IGF,
                                                  SILType T) const = 0;
 

--- a/stdlib/public/runtime/Borrow.cpp
+++ b/stdlib/public/runtime/Borrow.cpp
@@ -16,6 +16,10 @@
 namespace swift {
 
 BorrowRepresentation swift_getBorrowRepresentation(const Metadata *referent) {
+  if (referent->getValueWitnesses()->getSize() > 4 * sizeof(uintptr_t)) {
+    return BorrowRepresentation::Pointer;
+  }
+
   if (!referent->getValueWitnesses()->isBitwiseBorrowable() ||
       referent->getValueWitnesses()->isAddressableForDependencies()) {
     return BorrowRepresentation::Pointer;

--- a/test/Interpreter/borrow_layout.swift
+++ b/test/Interpreter/borrow_layout.swift
@@ -1,0 +1,123 @@
+// RUN: %empty-directory(%t)
+//
+// RUN: %target-build-swift -enable-experimental-feature BuiltinModule \
+// RUN:   -enable-experimental-feature Lifetimes \
+// RUN:   -enable-experimental-feature AnyAppleOSAvailability \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend LoanPointer \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend OptionalLoanPointer \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend Optional2LoanPointer \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend LoanNPEnum \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend OptionalLoanNPEnum \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend Optional2LoanNPEnum \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend LoanAFD \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend OptionalLoanAFD \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend Optional2LoanAFD \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend LoanNBB \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend OptionalLoanNBB \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend Optional2LoanNBB \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend LoanNotQuiteBig \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend OptionalLoanNotQuiteBig \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend Optional2LoanNotQuiteBig \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend LoanAlmostBig \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend OptionalLoanAlmostBig \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend Optional2LoanAlmostBig \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend LoanBig \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend OptionalLoanBig \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend Optional2LoanBig \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend LoanGrainy \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend OptionalLoanGrainy \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend Optional2LoanGrainy \
+// RUN:   -o %t/a.out \
+// RUN:   %s
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out 2>&1 | %FileCheck %s
+
+// Type layout verifier is only compiled into the runtime in asserts builds.
+// REQUIRES: swift_stdlib_asserts
+
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+//
+// REQUIRES: swift_feature_Lifetimes
+// REQUIRES: swift_feature_BuiltinModule
+// REQUIRES: swift_feature_AnyAppleOSAvailability
+
+// CHECK-NOT: Type verification
+
+import Builtin
+
+struct Loan<T: ~Copyable>: ~Escapable {
+	var value: Builtin.Borrow<T>
+
+	@_lifetime(immortal) init() { fatalError() }
+}
+
+// Typealiases for the type verifier:
+
+typealias URP = UnsafeRawPointer
+
+// RawPointer has one extra inhabitant, uses the value representation for
+// Borrow, so Borrow<RawPointer> should have one extra inhabitant
+typealias LoanPointer = Loan<UnsafeRawPointer>
+typealias OptionalLoanPointer = Optional<Loan<UnsafeRawPointer>>
+typealias Optional2LoanPointer = Optional<Optional<Loan<UnsafeRawPointer>>>
+
+// No-payload enum should have 256 - 3 = 253 extra inhabitants and use the
+// Borrow value representation
+enum NPEnum { case a, b, c }
+
+typealias LoanNPEnum = Loan<NPEnum>
+typealias OptionalLoanNPEnum = Optional<Loan<NPEnum>>
+typealias Optional2LoanNPEnum = Optional<Optional<Loan<NPEnum>>>
+
+// Addressable-for-dependencies type, uses the pointer borrow representation,
+// which should have one extra inhabitant 
+@available(anyAppleOS 26, *)
+struct AFD { var x: [1 of Int] }
+
+@available(anyAppleOS 26, *)
+typealias LoanAFD = Loan<AFD>
+@available(anyAppleOS 26, *)
+typealias OptionalLoanAFD = Optional<Loan<AFD>>
+@available(anyAppleOS 26, *)
+typealias Optional2LoanAFD = Optional<Optional<Loan<AFD>>>
+
+// Non-bitwise-borrowable type, uses the pointer borrow representation,
+// which should have one extra inhabitant 
+struct NBB { weak var x: AnyObject?; var y: Int }
+
+typealias LoanNBB = Loan<NBB>
+typealias OptionalLoanNBB = Optional<Loan<NBB>>
+typealias Optional2LoanNBB = Optional<Optional<Loan<NBB>>>
+
+// Below the "big" type threshold, still uses the value representation
+struct NotQuiteBig { var x, y, z: UnsafeRawPointer }
+
+typealias LoanNotQuiteBig = Loan<NotQuiteBig>
+typealias OptionalLoanNotQuiteBig = Optional<Loan<NotQuiteBig>>
+typealias Optional2LoanNotQuiteBig = Optional<Optional<Loan<NotQuiteBig>>>
+
+// Just at the "big" type threshold, still uses the value representation
+struct AlmostBig { var x, y, z, w: UnsafeRawPointer }
+
+typealias LoanAlmostBig = Loan<AlmostBig>
+typealias OptionalLoanAlmostBig = Optional<Loan<AlmostBig>>
+typealias Optional2LoanAlmostBig = Optional<Optional<Loan<AlmostBig>>>
+
+// Over the "big" type threshold, uses the pointer representation
+struct Big { var x, y, z, w, v: UnsafeRawPointer }
+
+typealias LoanBig = Loan<Big>
+typealias OptionalLoanBig = Optional<Loan<Big>>
+typealias Optional2LoanBig = Optional<Optional<Loan<Big>>>
+
+struct Grainy { var x, y, z, w, v: Bool }
+
+typealias LoanGrainy = Loan<Grainy>
+typealias OptionalLoanGrainy = Optional<Loan<Grainy>>
+typealias Optional2LoanGrainy = Optional<Optional<Loan<Grainy>>>
+
+// CHECK-NOT: *** Type verification
+// CHECK: ok!
+print("ok!")


### PR DESCRIPTION
On the compiler side, `Borrow` ought to use extra inhabitants from its value representation, or at least the null pointer for the pointer representation.

On the runtime side, the choice of representation needs to take size into account.