### PR TITLE
[ExplicitModule] Do not add explicit module from serialized module

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -449,9 +449,6 @@ namespace swift {
     bool EnableDeserializationSafety =
       ::getenv("SWIFT_ENABLE_DESERIALIZATION_SAFETY");
 
-    /// Disable injecting deserializes module paths into the explict module map.
-    bool DisableDeserializationOfExplicitPaths = false;
-
     /// Attempt to recover for imported modules with broken modularization
     /// in an unsafe way. Currently applies only to xrefs where the target
     /// decl moved to a different module that is already loaded.

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -210,10 +210,6 @@ ModuleFile::loadDependenciesForFileContext(const FileUnit *file,
     auto importPath = builder.copyTo(ctx);
     auto modulePath = importPath.getModulePath(dependency.isScoped());
     auto accessPath = importPath.getAccessPath(dependency.isScoped());
-    if (!getContext().LangOpts.DisableDeserializationOfExplicitPaths &&
-        !dependency.Core.BinaryModulePath.empty())
-      ctx.addExplicitModulePath(modulePath.front().Item.str(),
-                                dependency.Core.BinaryModulePath.str());
 
     auto module = getModule(modulePath, /*allowLoading*/true);
     if (!module || module->failedToLoad()) {

--- a/test/CAS/non-caching-import-cas-built.swift
+++ b/test/CAS/non-caching-import-cas-built.swift
@@ -1,0 +1,61 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+/// Build Test Module using caching.
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   %t/Test.swift -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas -I %t/include
+// RUN: %{python} %S/../../utils/swift-build-modules.py --cas %t/cas %swift_frontend_plain %t/deps.json -o %t/Test.cmd
+
+// RUN: %target-swift-frontend-plain \
+// RUN:   -emit-module -cache-compile-job -cas-path %t/cas \
+// RUN:   -swift-version 5 %t/Test.swift -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   -module-name Test -o %t/include/Test.swiftmodule @%t/Test.cmd
+
+/// Build User Module without caching with the swift overlay removed.
+// RUN: rm %t/include/B.swiftinterface
+// RUN: %target-swift-frontend -scan-dependencies -module-name User -module-cache-path %t/clang-module-cache -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   %t/User.swift -o %t/deps2.json -swift-version 5 -I %t/include
+// RUN: %{python} %S/../../utils/swift-build-modules.py %swift_frontend_plain %t/deps2.json -o %t/User.cmd
+
+// RUN: %target-swift-frontend -typecheck \
+// RUN:   -swift-version 5 %t/User.swift -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   -module-name User @%t/User.cmd
+
+//--- Test.swift
+import B
+public func test() {}
+
+//--- User.swift
+import Test
+
+func use() {
+  test()
+}
+
+//--- include/module.modulemap
+module A {
+  header "A.h"
+  export *
+}
+
+module B {
+  header "B.h"
+  export *
+}
+
+//--- include/A.h
+void notused(void);
+
+//--- include/B.h
+#include "A.h"
+void notused2(void);
+
+//--- include/B.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name B -O -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib -user-module-version 1.0
+@_exported import B
+public func c() { }


### PR DESCRIPTION
When performing explicit module build, the module dependency graph is completed and should never be updated. The encoded dependency in the swift module should not be treated as additional info since the dependency scanner is the only source of truth.

This aligns the explicit module build behavior with other implicit module build in a corner case where external dependency is changed in a way that allow implicit build to work.

rdar://169744781

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
