### PR TITLE
[draft] AsyncStream multiple awaits behavior change

### DIFF
--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -939,6 +939,10 @@ void swift_continuation_throwingResumeWithError(AsyncTask *continuation,
 extern "C" SWIFT_CC(swift)
 void swift_continuation_logFailedCheck(const char *message);
 
+/// SPI helper to log multiple awaiters on the same `AsyncStream` or `AsyncThrowingStream`.
+extern "C" SWIFT_CC(swift)
+void swift_asyncstream_multiple_awaiters();
+
 /// Drain the queue
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_asyncMainDrainQueue [[noreturn]]();

--- a/include/swift/Runtime/ConcurrencyHooks.def
+++ b/include/swift/Runtime/ConcurrencyHooks.def
@@ -57,6 +57,8 @@ SWIFT_CONCURRENCY_HOOK(bool, swift_task_isOnExecutor,
 
 SWIFT_CONCURRENCY_HOOK(void, swift_task_enqueueMainExecutor, Job *job);
 
+SWIFT_CONCURRENCY_HOOK0(void, swift_asyncstream_multiple_awaiters);
+
 SWIFT_CONCURRENCY_HOOK0(SerialExecutorRef, swift_task_getMainExecutor);
 
 SWIFT_CONCURRENCY_HOOK(bool, swift_task_isMainExecutor, SerialExecutorRef);

--- a/stdlib/public/Concurrency/AsyncStreamBuffer.swift
+++ b/stdlib/public/Concurrency/AsyncStreamBuffer.swift
@@ -607,10 +607,24 @@ final class _AsyncStreamCriticalStorage<Contents>: @unchecked Sendable {
   }
 }
 
-@inline(never)
-@_silgen_name("asyncstream_on_multiple_awaiters_detected")
-func onMultipleAwaitersDetected() {
-  unsafe logFailedCheck("SWIFT ASYNCSTREAM: used by multiple awaiters!")
+public func _onMultipleAwaitersDetectedHook(
+  _ newValue: ((() -> ()) -> ())?
+) {
+  onMultipleAwaitersDetectedHook = newValue
 }
+
+@inline(never)
+fileprivate func onMultipleAwaitersDetected() {
+  let original = {
+    unsafe logFailedCheck("SWIFT ASYNCSTREAM: used by multiple awaiters!")
+  }
+  if let onMultipleAwaitersDetectedHook {
+    onMultipleAwaitersDetectedHook(original)
+  } else {
+    original()
+  }
+}
+
+var onMultipleAwaitersDetectedHook: ((() -> ()) -> ())?
 
 #endif

--- a/stdlib/public/Concurrency/AsyncStreamBuffer.swift
+++ b/stdlib/public/Concurrency/AsyncStreamBuffer.swift
@@ -234,9 +234,7 @@ extension AsyncStream {
     func next(_ continuation: UnsafeContinuation<Element?, Never>) {
       lock()
       unsafe state.continuations.append(continuation)
-      if unsafe state.continuations.count > 1 {
-        onMultipleAwaitersDetected()
-      }
+      let hasMultipleAwaiters = unsafe state.continuations.count > 1
       if unsafe state.pending.count > 0 {
         let cont = unsafe state.continuations.removeFirst()
         let toSend = unsafe state.pending.removeFirst()
@@ -249,7 +247,9 @@ extension AsyncStream {
       } else {
         unlock()
       }
-
+      if hasMultipleAwaiters {
+        onMultipleAwaitersDetected()
+      }
     }
 
     func next() async -> Element? {
@@ -495,9 +495,7 @@ extension AsyncThrowingStream {
     func next(_ continuation: UnsafeContinuation<Element?, Error>) {
       lock()
       unsafe state.continuations.append(continuation)
-      if unsafe state.continuations.count > 1 {
-        onMultipleAwaitersDetected()
-      }
+      let hasMultipleAwaiters = unsafe state.continuations.count > 1
       if unsafe state.pending.count > 0 {
         let cont = unsafe state.continuations.removeFirst()
         let toSend = unsafe state.pending.removeFirst()
@@ -520,6 +518,9 @@ extension AsyncThrowingStream {
         }
       } else {
         unlock()
+      }
+      if hasMultipleAwaiters {
+        onMultipleAwaitersDetected()
       }
     }
 
@@ -609,7 +610,7 @@ final class _AsyncStreamCriticalStorage<Contents>: @unchecked Sendable {
 @inline(never)
 @_silgen_name("asyncstream_on_multiple_awaiters_detected")
 func onMultipleAwaitersDetected() {
-  unsafe logFailedCheck("SWIFT ASYNCSTREAM MISUSE: used by multiple awaiters!")
+  unsafe logFailedCheck("SWIFT ASYNCSTREAM: used by multiple awaiters!")
 }
 
 #endif

--- a/stdlib/public/Concurrency/AsyncStreamBuffer.swift
+++ b/stdlib/public/Concurrency/AsyncStreamBuffer.swift
@@ -606,14 +606,10 @@ final class _AsyncStreamCriticalStorage<Contents>: @unchecked Sendable {
   }
 }
 
-@available(SwiftStdlib 5.1, *)
-@_silgen_name("swift_continuation_logFailedCheck")
-internal func logFailedCheck(_ message: UnsafeRawPointer)
-
 @inline(never)
 @_silgen_name("asyncstream_on_multiple_awaiters_detected")
 func onMultipleAwaitersDetected() {
-  logFailedCheck("SWIFT ASYNCSTREAM MISUSE: used by multiple awaiters!")
+  unsafe logFailedCheck("SWIFT ASYNCSTREAM MISUSE: used by multiple awaiters!")
 }
 
 #endif

--- a/stdlib/public/Concurrency/ConcurrencyHooks.cpp
+++ b/stdlib/public/Concurrency/ConcurrencyHooks.cpp
@@ -215,6 +215,21 @@ swift_task_donateThreadToGlobalExecutorUntilOrig(bool (*condition)(void *),
   return swift_task_donateThreadToGlobalExecutorUntilImpl(condition, context);
 }
 
+SWIFT_CC(swift) static void
+swift_asyncstream_on_multiple_awaitersOrig() {
+  swift_reportError(0, "SWIFT ASYNCSTREAM: used by multiple awaiters!");
+}
+
+
+SWIFT_CC(swift) void
+swift::swift_asyncstream_multiple_awaiters() {
+  if (SWIFT_UNLIKELY(swift_asyncstream_multiple_awaiters_hook)) {
+    swift_asyncstream_multiple_awaiters_hook(swift_asyncstream_on_multiple_awaitersOrig);
+  } else {
+    swift_asyncstream_on_multiple_awaitersOrig();
+  }
+}
+
 void swift::
 swift_task_donateThreadToGlobalExecutorUntil(bool (*condition)(void *),
                                              void *context) {


### PR DESCRIPTION
This pr changes `AsyncThrowingStream` to no longer crash when multiple consumers are awaiting it by copy-pasting the behavior from `AsyncStream`. 

It also adds a function that's called when multiple awaiters are detected on either type, which (in theory) can be swapped out by IDE vendors or individual projects to customize the behavior. This is the draft part of the pr, the way I did this doesn't align with how other "hooks" are set up in the project, and I haven't tried hooking it yet. I'm putting this up now to get feedback on the approach and hopefully get some guidance on the best way to implement the hook 