### PR TITLE
[Embedded] Make a few standard library functions not depend on the Unicode tables

### DIFF
--- a/stdlib/public/core/Bool.swift
+++ b/stdlib/public/core/Bool.swift
@@ -204,11 +204,10 @@ extension Bool: LosslessStringConvertible {
   /// `"false"`, the result is `nil`. This initializer is case sensitive.
   ///
   /// - Parameter description: A string representation of the Boolean value.
-  @inlinable
   public init?(_ description: String) {
-    if description == "true" {
+    if description.compareUnicodeScalars("true") {
       self = true
-    } else if description == "false" {
+    } else if description.compareUnicodeScalars("false") {
       self = false
     } else {
       return nil

--- a/stdlib/public/core/InputStream.swift
+++ b/stdlib/public/core/InputStream.swift
@@ -40,20 +40,20 @@ public func readLine(strippingNewline: Bool = true) -> String? {
   let utf8Buffer = unsafe UnsafeBufferPointer(start: utf8Start, count: utf8Count)
   var result = unsafe String._fromUTF8Repairing(utf8Buffer).result
   if strippingNewline {
-    result = result.withoutNewline()
+    result.removeNewline()
   }
   return result
 }
 
 extension String {
   /// Remove the newline from the string
-  fileprivate func withoutNewline() -> String {
+  fileprivate mutating func removeNewline() {
     var scalars = unicodeScalars[...]
 
     // If the last character is not "\n", there's nothing to do.
     let newline: UnicodeScalar = "\n"
     guard let lastNewline = scalars.last, lastNewline == newline else {
-      return self
+      return
     }
 
     // Drop the "\n".
@@ -61,11 +61,13 @@ extension String {
 
     // Now remove "\r" if it's also there.
     let carriageReturn: UnicodeScalar = "\r"
-    guard let lastCR = scalars.last, lastCR == carriageReturn else {
-      return String(scalars)
+    if let lastCR = scalars.last, lastCR == carriageReturn {
+      // Drop the "\rn".
+      scalars = scalars.dropLast()
     }
 
-    return String(scalars.dropLast())
+    // Remove from the end of the adjusted scalars to the end of this string.
+    _guts.remove(from: scalars.endIndex, to: endIndex)
   }
 }
 

--- a/stdlib/public/core/InputStream.swift
+++ b/stdlib/public/core/InputStream.swift
@@ -39,10 +39,34 @@ public func readLine(strippingNewline: Bool = true) -> String? {
   }
   let utf8Buffer = unsafe UnsafeBufferPointer(start: utf8Start, count: utf8Count)
   var result = unsafe String._fromUTF8Repairing(utf8Buffer).result
-  if strippingNewline, result.last == "\n" || result.last == "\r\n" {
-    _ = result.removeLast()
+  if strippingNewline {
+    result = result.withoutNewline()
   }
   return result
+}
+
+extension String {
+  /// Remove the newline from the string
+  fileprivate func withoutNewline() -> String {
+    var scalars = unicodeScalars[...]
+
+    // If the last character is not "\n", there's nothing to do.
+    let newline: UnicodeScalar = "\n"
+    guard let lastNewline = scalars.last, lastNewline == newline else {
+      return self
+    }
+
+    // Drop the "\n".
+    scalars = scalars.dropLast()
+
+    // Now remove "\r" if it's also there.
+    let carriageReturn: UnicodeScalar = "\r"
+    guard let lastCR = scalars.last, lastCR == carriageReturn else {
+      return String(scalars)
+    }
+
+    return String(scalars.dropLast())
+  }
 }
 
 #endif

--- a/stdlib/public/core/StaticBigInt.swift
+++ b/stdlib/public/core/StaticBigInt.swift
@@ -183,8 +183,9 @@ extension StaticBigInt: CustomDebugStringConvertible {
     }
 
     // Overwrite leading zeros with the "±0x" indicator.
-    if let upToIndex = result.firstIndex(where: { $0 != "0" }) {
-      result.replaceSubrange(..<upToIndex, with: indicator)
+    let zero: UnicodeScalar = "0"
+    if let upToIndex = result.unicodeScalars.firstIndex(where: { $0 != zero }) {
+      result = indicator + String(result.unicodeScalars[upToIndex...])
     } else {
       result = "+0x0"
     }

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -1150,3 +1150,12 @@ extension String {
     self._guts.isTriviallyIdentical(to: other._guts)
   }
 }
+
+extension String {
+  /// Compare the Unicode scalars of this string with another string, not
+  /// accounting for normalization.
+  func compareUnicodeScalars(_ other: String) -> Bool {
+    return _guts.isTriviallyIdentical(to: other._guts) ||
+        unicodeScalars.elementsEqual(other.unicodeScalars)
+  }
+}

--- a/test/embedded/unicode-dead-strip4.swift
+++ b/test/embedded/unicode-dead-strip4.swift
@@ -11,12 +11,14 @@
 
 @_extern(c, "getline")
 func getline(
-  _ linePointer: UnsafeMutablePointer<UnsafeMutablePointer<UInt8>?>?
+  _ linePointer: UnsafeMutablePointer<UnsafeMutablePointer<UInt8>?>?,
+  _ linecapp: UnsafeMutablePointer<UInt>?,
+  _ stream: UnsafeRawPointer?
 ) -> Int
 
 @c
 func swift_stdlib_readLine_stdin(_ linePointer: UnsafeMutablePointer<UnsafeMutablePointer<UInt8>?>?) -> Int {
-  return getline(linePointer)
+  return getline(linePointer, nil, nil)
 }
 
 

--- a/test/embedded/unicode-dead-strip4.swift
+++ b/test/embedded/unicode-dead-strip4.swift
@@ -1,0 +1,38 @@
+// RUN: %target-swift-frontend -Osize -parse-as-library -enable-experimental-feature Embedded %s -c -o %t/a.o
+// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o -o %t/a.out -dead_strip %swift_obj_root/lib/swift/embedded/%module-target-triple/libswiftUnicodeDataTables.a
+// RUN: %llvm-nm --defined-only --format=just-symbols --demangle %t/a.out | sort | %FileCheck %s --check-prefix=EXCLUDES
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=wasip1
+// XFAIL: OS=wasip1
+// REQUIRES: swift_feature_Embedded
+
+@main
+struct Main {
+  static func main() {
+    let t = "true"
+    let f = "false"
+    let unrelated = "nope"
+    let b1 = Bool(t)
+    let b2 = Bool(f)
+    let b3 = Bool(unrelated)
+
+    print(b1 ?? false)
+    print(b2 ?? false)
+    print(b3 ?? false)
+  }
+}
+
+// The code avoides using any of the Unicode tables
+// EXCLUDES-NOT: swift_stdlib_case
+// EXCLUDES-NOT: swift_stdlib_graphemeBreakProperties
+// EXCLUDES-NOT: swift_stdlib_mappings
+// EXCLUDES-NOT: swift_stdlib_names
+// EXCLUDES-NOT: swift_stdlib_nfc
+// EXCLUDES-NOT: swift_stdlib_nfd
+// EXCLUDES-NOT: swift_stdlib_normData
+// EXCLUDES-NOT: swift_stdlib_scripts
+// EXCLUDES-NOT: swift_stdlib_special_mappings
+// EXCLUDES-NOT: swift_stdlib_words
+// 

--- a/test/embedded/unicode-dead-strip4.swift
+++ b/test/embedded/unicode-dead-strip4.swift
@@ -38,6 +38,9 @@ struct Main {
     if let value = readLine(), let b4 = Bool(value) {
       print(b4)
     }
+
+    let bi: StaticBigInt = 17
+    print(bi.debugDescription)
   }
 }
 

--- a/test/embedded/unicode-dead-strip4.swift
+++ b/test/embedded/unicode-dead-strip4.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Osize -parse-as-library -enable-experimental-feature Embedded %s -c -o %t/a.o
+// RUN: %target-swift-frontend -Osize -parse-as-library -enable-experimental-feature Embedded -enable-experimental-feature Extern %s -c -o %t/a.o
 // RUN: %target-clang %target-clang-resource-dir-opt %t/a.o -o %t/a.out -dead_strip %swift_obj_root/lib/swift/embedded/%module-target-triple/libswiftUnicodeDataTables.a
 // RUN: %llvm-nm --defined-only --format=just-symbols --demangle %t/a.out | sort | %FileCheck %s --check-prefix=EXCLUDES
 
@@ -7,6 +7,19 @@
 // REQUIRES: OS=macosx || OS=wasip1
 // XFAIL: OS=wasip1
 // REQUIRES: swift_feature_Embedded
+// REQUIRES: swift_feature_Extern
+
+@_extern(c, "getline")
+func getline(
+  _ linePointer: UnsafeMutablePointer<UnsafeMutablePointer<UInt8>?>?
+) -> Int
+
+@c
+func swift_stdlib_readLine_stdin(_ linePointer: UnsafeMutablePointer<UnsafeMutablePointer<UInt8>?>?) -> Int {
+  return getline(linePointer)
+}
+
+
 
 @main
 struct Main {
@@ -21,6 +34,10 @@ struct Main {
     print(b1 ?? false)
     print(b2 ?? false)
     print(b3 ?? false)
+
+    if let value = readLine(), let b4 = Bool(value) {
+      print(b4)
+    }
   }
 }
 
@@ -35,4 +52,3 @@ struct Main {
 // EXCLUDES-NOT: swift_stdlib_scripts
 // EXCLUDES-NOT: swift_stdlib_special_mappings
 // EXCLUDES-NOT: swift_stdlib_words
-// 

--- a/test/embedded/unicode-dead-strip4.swift
+++ b/test/embedded/unicode-dead-strip4.swift
@@ -5,7 +5,6 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx || OS=wasip1
-// XFAIL: OS=wasip1
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: swift_feature_Extern
 


### PR DESCRIPTION
The Unicode tables can be pretty large, so we don't want to depend on them except when we have to. Update a few operations in the standard library to no longer need the Unicode tables:
* `Bool`'s conformance to `LosslessStringConvertible` 
* `readLine`
* `StaticBigInt.debugDescription`

I came across these while introduce the `Unicode` availability domain. It's entirely possible that there are more similar functions that we'll find later. Fortunately, it's easy to do this (and test the result).