### PR TITLE
Tweak lifetime dependencies for 'inout' parameters

### DIFF
--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -378,7 +378,8 @@ public:
   }
 
   void inferInoutDependency(unsigned paramIndex) {
-    inferDependency(paramIndex, paramIndex, LifetimeDependenceKind::Inherit);
+    auto iter = depsArray.try_emplace(paramIndex, false, sourceIndexCap).first;
+    iter->second.addIfNew(paramIndex, LifetimeDependenceKind::Inherit);
   }
 
   // Allocate LifetimeDependenceInfo in the ASTContext. Initialize it by

--- a/test/ModuleInterface/lifetime_underscored_dependence_test.swift
+++ b/test/ModuleInterface/lifetime_underscored_dependence_test.swift
@@ -143,11 +143,11 @@ import lifetime_underscored_dependence
 // CHECK: @inlinable public func takeCopierUnannotated(f: (consuming lifetime_underscored_dependence.AnotherView) -> lifetime_underscored_dependence.AnotherView) {}
 
 // CHECK: #if compiler(>=5.3) && $ClosureLifetimes
-// CHECK-NEXT: public typealias ExplicitNestedType = @_lifetime(copy ne0) @_lifetime(ne1: copy ne0) ((lifetime_underscored_dependence.AnotherView) -> lifetime_underscored_dependence.AnotherView, _ ne0: consuming lifetime_underscored_dependence.AnotherView, _ ne1: inout lifetime_underscored_dependence.AnotherView) -> lifetime_underscored_dependence.AnotherView
+// CHECK-NEXT: public typealias ExplicitNestedType = @_lifetime(copy ne0) @_lifetime(ne1: copy ne0, copy ne1) ((lifetime_underscored_dependence.AnotherView) -> lifetime_underscored_dependence.AnotherView, _ ne0: consuming lifetime_underscored_dependence.AnotherView, _ ne1: inout lifetime_underscored_dependence.AnotherView) -> lifetime_underscored_dependence.AnotherView
 // CHECK-NEXT: #endif
 
 // CHECK: #if compiler(>=5.3) && $ClosureLifetimes
-// CHECK-NEXT: @inlinable public func takeExplicitNestedType(f: @_lifetime(copy ne0) @_lifetime(ne1: copy ne0) ((lifetime_underscored_dependence.AnotherView) -> lifetime_underscored_dependence.AnotherView, _ ne0: consuming lifetime_underscored_dependence.AnotherView, _ ne1: inout lifetime_underscored_dependence.AnotherView) -> lifetime_underscored_dependence.AnotherView) {} 
+// CHECK-NEXT: @inlinable public func takeExplicitNestedType(f: @_lifetime(copy ne0) @_lifetime(ne1: copy ne0, copy ne1) ((lifetime_underscored_dependence.AnotherView) -> lifetime_underscored_dependence.AnotherView, _ ne0: consuming lifetime_underscored_dependence.AnotherView, _ ne1: inout lifetime_underscored_dependence.AnotherView) -> lifetime_underscored_dependence.AnotherView) {} 
 // CHECK-NEXT: #endif
 
 // CHECK: #if compiler(>=5.3) && $Lifetimes

--- a/test/SIL/explicit_lifetime_dependence_specifiers.swift
+++ b/test/SIL/explicit_lifetime_dependence_specifiers.swift
@@ -34,18 +34,20 @@ typealias NoLifetimeType = (_ x: Int) -> Int
 
 // CHECK: typealias MixedLifetimeType = @_lifetime(copy ne0) (_ ne0: NE, _ neio: inout NE) -> NE
 typealias MixedLifetimeType = @_lifetime(copy ne0) (_ ne0: NE, _ neio: inout NE) -> NE
-// CHECK: typealias NestedLifetimeType = @_lifetime(neo: copy ne0) (_ nei: inout NE, _ ne0: NE, _ neo: inout NE) -> (NE) -> NE
+// CHECK: typealias NestedLifetimeType = @_lifetime(neo: copy ne0, copy neo) (_ nei: inout NE, _ ne0: NE, _ neo: inout NE) -> (NE) -> NE
 typealias NestedLifetimeType = @_lifetime(neo: copy ne0) (_ nei: inout NE, _ ne0: NE, _ neo: inout NE) -> (_ ne1: NE) -> NE
 
-// CHECK-LABEL: typealias NestedType = @_lifetime(copy ne2) @_lifetime(ne3: copy ne2) (@_lifetime(copy ne0) @_lifetime(ne1: copy ne1) (_ ne0: NE, _ ne1: inout NE) -> NE, _ ne2: consuming NE, _ ne3: inout NE) -> NE
+// CHECK-LABEL: typealias NestedType = @_lifetime(copy ne2) @_lifetime(ne3: copy ne2, copy ne3) (@_lifetime(copy ne0) @_lifetime(ne1: copy ne1) (_ ne0: NE, _ ne1: inout NE) -> NE, _ ne2: consuming NE, _ ne3: inout NE) -> NE
 typealias NestedType =
   @_lifetime(copy ne2) @_lifetime(ne3: copy ne2)
   (@_lifetime(copy ne0) @_lifetime(ne1: copy ne1) (_ ne0: NE, _ ne1: inout NE) -> NE,
    _ ne2: consuming NE, _ ne3: inout NE) -> NE
 
-// CHECK-LABEL: func takeNestedType(f: @_lifetime(copy ne2) @_lifetime(ne3: copy ne2) (@_lifetime(copy ne0) @_lifetime(ne1: copy ne1) (_ ne0: NE, _ ne1: inout NE) -> NE, _ ne2: consuming NE, _ ne3: inout NE) -> NE)
+// CHECK-LABEL: func takeNestedType(f: @_lifetime(copy ne2) @_lifetime(ne3: copy ne2, copy ne3) (@_lifetime(copy ne0) @_lifetime(ne1: copy ne1) (_ ne0: NE, _ ne1: inout NE) -> NE, _ ne2: consuming NE, _ ne3: inout NE) -> NE)
 
-// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers14takeNestedType1fyAA2NEVA2E_AEztXE_AEnAEztXE_tF : $@convention(thin) (@guaranteed @noescape @callee_guaranteed (@guaranteed @noescape @callee_guaranteed (@guaranteed NE, @lifetime(copy 1) @inout NE) -> @lifetime(copy 0) @owned NE, @owned NE, @lifetime(copy 1) @inout NE) -> @lifetime(copy 1) @owned NE) -> () {
+// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers14takeNestedType1fyAA2NEVA2E_AEztXE_AEnAEztXE_tF
+// : $@convention(thin) (@guaranteed @noescape @callee_guaranteed (@guaranteed @noescape @callee_guaranteed (@guaranteed
+// NE, @lifetime(copy 1) @inout NE) -> @lifetime(copy 0) @owned NE, @owned NE, @lifetime(copy 1, copy 2) @inout NE) -> @lifetime(copy 1) @owned NE) -> () {
 func takeNestedType(f: NestedType) {}
 
 struct BufferView : ~Escapable {

--- a/test/SIL/implicit_lifetime_dependence.swift
+++ b/test/SIL/implicit_lifetime_dependence.swift
@@ -232,7 +232,8 @@ public struct OuterNE: ~Escapable {
     self.inner1 = InnerNE(owner: owner)
   }
 
-  // CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence7OuterNEV8setInner5valueyAC0gE0V_tF : $@convention(method) (@guaranteed OuterNE.InnerNE, @lifetime(copy 0) @inout OuterNE) -> () {
+  // CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence7OuterNEV8setInner5valueyAC0gE0V_tF : $@convention(method)
+  // (@guaranteed OuterNE.InnerNE, @lifetime(copy 0, copy 1) @inout OuterNE) -> () {
   @_lifetime(self: copy value)
   mutating func setInner(value: InnerNE) {
     self.inner1 = value

--- a/test/Sema/lifetime_dependence_functype.swift
+++ b/test/Sema/lifetime_dependence_functype.swift
@@ -149,7 +149,7 @@ do {
   let x = NE()
   var y = NE()
   takeGetGenericAndArgs(f: getGeneric, o: &y, i: x)
-  // expected-error@-1{{cannot convert value of type '(inout T, borrowing T) -> ()' to expected argument type '@_lifetime(outValue: borrow inValue) (_ outValue: inout NE, _ inValue: borrowing NE) -> ()'}}
+  // expected-error@-1{{cannot convert value of type '(inout T, borrowing T) -> ()' to expected argument type '@_lifetime(outValue: copy outValue, borrow inValue) (_ outValue: inout NE, _ inValue: borrowing NE) -> ()'}}
   // expected-error@-2{{generic parameter 'T' could not be inferred}}
 }
 do {
@@ -161,7 +161,7 @@ do {
   let x = NE()
   var y = NE()
   takeGetGenericAndArgs(f: getImmortalNE, o: &y, i: x)
-  //  expected-error@-1{{cannot convert value of type '@_lifetime(0: immortal) (inout NE, borrowing NE) -> ()' to expected argument type '@_lifetime(outValue: borrow inValue) (_ outValue: inout NE, _ inValue: borrowing NE) -> ()'}}
+  //  expected-error@-1{{cannot convert value of type '@_lifetime(0: immortal) (inout NE, borrowing NE) -> ()' to expected argument type '@_lifetime(outValue: copy outValue, borrow inValue) (_ outValue: inout NE, _ inValue: borrowing NE) -> ()'}}
 }
 do {
   let _ = transfer // OK


### PR DESCRIPTION
Assume a default dependency for all 'inout' parameters regardless of the
presence of an explicit annotation.

Default to `@lifetime(inoutArg: copy inoutArg)` even if an explicit annotation
exists.

This way API authors do not need to make the inout dependency explicit when they
probably always want that and don't normally need to write it.

Now:
```
@_lifetime(a: copy b)
func foo(a: inout T, b: T)
```

implies:
```
@_lifetime(a: copy a, copy b)
func foo(a: inout T, b: T)
```

Fixes rdar://169835235 (Always default inout dependencies)
