### PR TITLE
Reparenting: third batch of fixes

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2809,6 +2809,9 @@ ERROR(extension_nongeneric_trailing_where,none,
 ERROR(extension_protocol_inheritance,none,
       "extension of protocol %0 cannot declare inheritance relationship",
       (Identifier))
+ERROR(extension_protocol_reparented_not_inheriting,none,
+      "%0 must directly inherit from %1 in order to be reparented",
+      (const NominalTypeDecl *, const NominalTypeDecl *))
 ERROR(objc_generic_extension_using_type_parameter,none,
       "extension of a generic Objective-C class cannot access the class's "
       "generic parameters at runtime", ())

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3050,6 +3050,8 @@ void PrintAST::printInherited(const Decl *decl) {
         Printer << "@retroactive ";
       if (inherited.isPreconcurrency())
         Printer << "@preconcurrency ";
+      if (inherited.isReparented())
+        Printer << "@reparented ";
       switch (inherited.getExplicitSafety()) {
       case ExplicitSafety::Unspecified:
       case ExplicitSafety::Safe:

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -3595,38 +3595,14 @@ InheritedProtocolsRequest::evaluate(Evaluator &evaluator,
   llvm::SmallSetVector<ProtocolDecl *, 2> inherited;
 
   assert(!PD->wasDeserialized());
-  using TypeOrExt = PointerUnion<const TypeDecl *, const ExtensionDecl *>;
 
   InvertibleProtocolSet inverses;
   bool anyObject = false;
-  auto addFrom = [&](TypeOrExt decl) {
-    for (const auto &found :
-         getDirectlyInheritedNominalTypeDecls(decl, inverses, anyObject)) {
-      auto proto = dyn_cast<ProtocolDecl>(found.Item);
-      if (proto && proto != PD)
-        inherited.insert(proto);
-    }
-  };
-
-  // Add from the inheritance clause of the protocol itself.
-  addFrom(PD);
-
-  // Add from extensions of the protocol, as the inherited entries on those
-  // extensions are considered to be inherited by this protocol.
-  //
-  // We don't do this from getDirectlyInheritedNominalTypeDecls, only to avoid
-  // doing a const_cast to access the extensions there.
-  //
-  // We avoid @objc protocols, as they don't support @reparented and can trigger
-  // a request evaluator cycle when visiting its extensions.
-  if (!PD->getAttrs().getAttribute<ObjCAttr>()) {
-    for (auto *ext : PD->getExtensions()) {
-      // Skip extensions in other modules, they're never permitted to reparent.
-      if (ext->getModuleContext() != PD->getModuleContext())
-        continue;
-
-      addFrom(ext);
-    }
+  for (const auto &found :
+       getDirectlyInheritedNominalTypeDecls(PD, inverses, anyObject)) {
+    auto proto = dyn_cast<ProtocolDecl>(found.Item);
+    if (proto && proto != PD)
+      inherited.insert(proto);
   }
 
   // Apply inverses.

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -316,7 +316,11 @@ static void recordTypeWitness(NormalProtocolConformance *conformance,
   auto &ctx = dc->getASTContext();
 
   // If there was no type declaration, synthesize one.
-  if (typeDecl == nullptr) {
+  //
+  // Skip reparented conformances. They take place within protocol extensions
+  // and typealiases with the same name as an associatedtype are typically
+  // defined to constrain the associatedtype within the whole protocol.
+  if (typeDecl == nullptr && !conformance->isReparented()) {
     Identifier name;
     bool needsImplementsAttr;
     if (isAsyncIteratorOrSequenceFailure(assocType)) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2595,6 +2595,8 @@ checkIndividualConformance(NormalProtocolConformance *conformance) {
       allowImpliedConditionalConformance = true;
   } else if (Proto->isMarkerProtocol()) {
     allowImpliedConditionalConformance = true;
+  } else if (Proto->getAttrs().hasAttribute<ReparentableAttr>()) {
+    allowImpliedConditionalConformance = true;
   }
 
   if (conformance->getSourceKind() == ConformanceEntryKind::Implied &&

--- a/test/Generics/conditional_conformances_reparenting.swift
+++ b/test/Generics/conditional_conformances_reparenting.swift
@@ -1,0 +1,15 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature Reparenting
+
+// REQUIRES: swift_feature_Reparenting
+
+protocol P {}
+
+@reparentable protocol Reparentable {}
+protocol S: Reparentable {}
+
+struct Nachos<T> {}
+extension Nachos: S where T: P {}
+
+// Expect no error here the conditional conformance to S
+// implying conformance to Reparentable and needing to
+// write that in a separate extension of Nachos.

--- a/test/Generics/reparenting_associated_types1.swift
+++ b/test/Generics/reparenting_associated_types1.swift
@@ -9,7 +9,7 @@
 public protocol BorrowingSeq<BSElement> {
   associatedtype BSElement // expected-note {{protocol requires nested type 'BSElement'}}
 }
-public protocol Seq {
+public protocol Seq: BorrowingSeq {
   associatedtype Element
 }
 extension Seq: @reparented BorrowingSeq // expected-error {{type 'Self' does not conform to protocol 'BorrowingSeq'}} // expected-note {{add stubs for conformance}}
@@ -20,7 +20,7 @@ extension Seq: @reparented BorrowingSeq // expected-error {{type 'Self' does not
 public protocol Door {
   associatedtype Key  // expected-note 2{{protocol requires nested type 'Key'}}
 }
-public protocol WitnessUsingSelf {}
+public protocol WitnessUsingSelf: Door {}
 struct Wrapper<T> {}
 extension WitnessUsingSelf: @reparented Door where Key == Wrapper<Key> {}
 // expected-error@-1 {{cannot build rewrite system for generic signature; concrete type nesting limit exceeded}}
@@ -31,7 +31,7 @@ extension WitnessUsingSelf: @reparented Door where Key == Wrapper<Key> {}
 
 
 // Both A and Z are candidates to witness Key, so we pick neither!
-public protocol AmbiguousWitness {
+public protocol AmbiguousWitness: Door {
   associatedtype A
   associatedtype Z
 }

--- a/test/Generics/reparenting_associated_types2.swift
+++ b/test/Generics/reparenting_associated_types2.swift
@@ -8,7 +8,7 @@
 public protocol BorrowingSeq<Element> {
   associatedtype Element
 }
-public protocol Seq {
+public protocol Seq: BorrowingSeq {
   associatedtype Element
 }
 extension Seq: @reparented BorrowingSeq {}

--- a/test/Generics/reparenting_associated_types3.swift
+++ b/test/Generics/reparenting_associated_types3.swift
@@ -8,7 +8,7 @@
 // doesn't refer to itself, e.g.,
 // "CheckReparentingWitnesses found illegal witness Self.Element of BorrowingSeq that is not within expected protocol context Seq"
 
-public protocol Seq {
+public protocol Seq: BorrowingSeq {
 
 // Seq should've declared an Element to witness BorrowingSeq's Element
 #if FIXED

--- a/test/Generics/reparenting_associated_types4.swift
+++ b/test/Generics/reparenting_associated_types4.swift
@@ -9,7 +9,7 @@
 public protocol BorrowingSeq<Zelement> {
   associatedtype Zelement
 }
-public protocol Seq {
+public protocol Seq: BorrowingSeq {
   associatedtype Element
 }
 extension Seq: @reparented BorrowingSeq
@@ -23,11 +23,11 @@ public protocol Door {
 }
 
 
-public protocol FixedKey {}
+public protocol FixedKey: Door {}
 extension FixedKey: @reparented Door where Key == String {}
 
 
-public protocol BoundGenericKey {
+public protocol BoundGenericKey: Door {
   associatedtype MyKey
 }
 struct Wrapper<T> {}

--- a/test/ModuleInterface/reparenting.swift
+++ b/test/ModuleInterface/reparenting.swift
@@ -1,0 +1,29 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -module-name Library -enable-experimental-feature Reparenting
+// RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -module-name Library
+// RUN: %FileCheck %s --check-prefixes=CHECK < %t/Library.swiftinterface
+
+// REQUIRES: swift_feature_Reparenting
+
+// CHECK-LABEL: @reparentable public protocol Circle {
+
+@reparentable
+public protocol Circle {
+  associatedtype Color
+  func fill() -> Color
+}
+
+// CHECK-LABEL: public protocol Ball : Library.Circle {
+// CHECK:         associatedtype Color = Swift.Int
+public protocol Ball: Circle {
+  associatedtype Color = Int
+  func roll()
+}
+
+// CHECK-LABEL: extension Library.Ball : @reparented Library.Circle where Self.Color == Swift.Int {
+// CHECK:         public func fill() -> Self.Color
+// CHECK-NOT:     typealias
+extension Ball: @reparented Circle where Color == Int {
+  public func fill() -> Color { return 0xFFFD74 }
+}

--- a/test/Sema/reparenting.swift
+++ b/test/Sema/reparenting.swift
@@ -9,10 +9,10 @@ protocol Q {}
 @reparentable
 protocol R {}
 
-protocol P {}
+protocol P: Q {}
 extension P : @reparented Q {}
 
-protocol P2 {}
+protocol P2: Q, R {}
 extension P2 : @reparented Q, @reparented R {}
 
 protocol DirectlyOnProto: @reparented R {}
@@ -50,14 +50,14 @@ public protocol GrandParentJiji {
 }
 @reparentable
 public protocol ParentJiji: GrandParentJiji {} // expected-note {{'Jiji' does not conform to inherited protocol 'GrandParentJiji'}}
-public protocol Jiji {
+public protocol Jiji: ParentJiji {
   associatedtype Element
 }
 extension Jiji: @reparented ParentJiji {} // expected-error {{'Jiji' cannot conform to 'GrandParentJiji'}}
 // expected-note@-1 {{only concrete types such as structs, enums and classes can conform to protocols}}
 
 
-public protocol Pumpkin {}
+public protocol Pumpkin: AnyObjParent, ActorParent, SendableParent {}
 @reparentable public protocol AnyObjParent: AnyObject {}
 @reparentable public protocol ActorParent: Actor {}
 @reparentable public protocol SendableParent: Sendable {}
@@ -65,3 +65,13 @@ public protocol Pumpkin {}
 extension Pumpkin: @reparented AnyObjParent {} // expected-error {{non-class type 'Pumpkin' cannot conform to class protocol 'AnyObjParent'}}
 extension Pumpkin: @reparented ActorParent {}  // expected-error {{non-class type 'Pumpkin' cannot conform to class protocol 'ActorParent'}}
 extension Pumpkin: @reparented SendableParent {}
+
+@reparentable protocol Shape {}
+protocol Pyramid {}
+extension Pyramid: @reparented Shape {}
+// expected-error@-1 {{'Pyramid' must directly inherit from 'Shape' in order to be reparented}}
+
+protocol Rectangle: Shape {}
+protocol Square: Rectangle {}
+extension Square : @reparented Shape {}
+// expected-error@-1 {{'Square' must directly inherit from 'Shape' in order to be reparented}}

--- a/validation-test/Evolution/Inputs/protocol_add_reparented.swift
+++ b/validation-test/Evolution/Inputs/protocol_add_reparented.swift
@@ -23,7 +23,7 @@ public protocol SeedEater {
   var seedKinds: Kind { get }
 }
 
-public protocol Bird {
+public protocol Bird: SeedEater {
   func eat(_ food: Int) -> Int
 }
 

--- a/validation-test/Evolution/Inputs/protocol_add_reparented_seq.swift
+++ b/validation-test/Evolution/Inputs/protocol_add_reparented_seq.swift
@@ -31,7 +31,7 @@ public protocol Seq<Element> {
   func makeIterator() -> Iterator
 }
 #else
-public protocol Seq<Element> {
+public protocol Seq<Element>: BorrowingSeq {
   associatedtype Element
   associatedtype Iterator: Iterable
   func makeIterator() -> Iterator

--- a/validation-test/Evolution/test_protocol_add_reparented.swift
+++ b/validation-test/Evolution/test_protocol_add_reparented.swift
@@ -14,9 +14,29 @@ let clientVersion = 0
 let clientVersion = 1
 #endif
 
+protocol P {
+  func getPValue() -> Int
+}
+
 // A type on the client side that is never updated for the new world
 struct Eagle: Bird {
   func eat(_ food: Int) -> Int { return food }
+}
+
+// A conditionally-conforming type that is not updated.
+struct Lark<T> {
+  let t: T
+  init(_ t: T) { self.t = t }
+}
+extension Lark: Bird where T: P {
+  func eat(_ food: Int) -> Int {
+    return food + t.getPValue()
+  }
+}
+
+// Strings return their length for a "P-value"
+extension String: P {
+  func getPValue() -> Int { return self.count }
 }
 
 #if !BEFORE
@@ -37,28 +57,50 @@ extension UInt: @retroactive AsInt {
 #endif
 
 ProtocolAddReparentedTest.test("Some Types") {
-  let e = Eagle()
-  let ans = libraryVersion() + clientVersion
-  expectEqual(SomeType.feed(e, clientVersion), ans)
-  expectEqual(SomeType.count(e, clientVersion), ans)
+  let base = libraryVersion() + clientVersion // basic answer
+  do {
+    let e = Eagle()
+    expectEqual(SomeType.feed(e, clientVersion), base)
+    expectEqual(SomeType.count(e, clientVersion), base)
+  }
+
+  do {
+    let str = "12345"
+    let e = Lark(str)
+    expectEqual(SomeType.feed(e, clientVersion), base + str.count)
+    expectEqual(SomeType.count(e, clientVersion), base)
+  }
 
   #if !BEFORE
-  let 💯 = Plus100Eagle()
-  expectEqual(SomeType.feed(💯, clientVersion), ans + 100)
-  expectEqual(SomeType.count(💯, clientVersion), ans + 100)
+  do {
+    let 💯 = Plus100Eagle()
+    expectEqual(SomeType.feed(💯, clientVersion), base + 100)
+    expectEqual(SomeType.count(💯, clientVersion), base + 100)
+  }
   #endif
 }
 
 ProtocolAddReparentedTest.test("Existential Types") {
-  let e = Eagle()
-  let ans = libraryVersion() + clientVersion
-  expectEqual(ExistentialType.feed(e, clientVersion), ans)
-  expectEqual(ExistentialType.count(e, clientVersion), ans)
+  let base = libraryVersion() + clientVersion // basic answer
+  do {
+    let e = Eagle()
+    expectEqual(ExistentialType.feed(e, clientVersion), base)
+    expectEqual(ExistentialType.count(e, clientVersion), base)
+  }
+
+  do {
+    let str = "12345"
+    let e = Lark(str)
+    expectEqual(ExistentialType.feed(e, clientVersion), base + str.count)
+    expectEqual(ExistentialType.count(e, clientVersion), base)
+  }
 
   #if !BEFORE
-  let 💯 = Plus100Eagle()
-  expectEqual(ExistentialType.feed(💯, clientVersion), ans + 100)
-  expectEqual(ExistentialType.count(💯, clientVersion), ans + 100)
+  do {
+    let 💯 = Plus100Eagle()
+    expectEqual(ExistentialType.feed(💯, clientVersion), base + 100)
+    expectEqual(ExistentialType.count(💯, clientVersion), base + 100)
+  }
   #endif
 }
 


### PR DESCRIPTION
- Allow conditional conformances to, e.g., Sequence to imply conformance to BorrowingSequence, because the latter is `@reparentable`.

rdar://169878220