### PR TITLE
[6.3][Concurrency] Mark a type as nonisolated if a conformance requires it

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6242,11 +6242,19 @@ computeDefaultInferredActorIsolation(ValueDecl *value) {
               if (getIsolationFromAttributes(ext).has_value())
                 return {};
 
-              // Keep looking.
-            } else {
-              // The type is nonisolated, so its members are nonisolated.
-              return {};
+              // Members declared in an extension are @MainActor isolated
+              // even if it's an extension of a nonisolated type. This helps
+              // to extend types from other modules, for example, to conform
+              // to new protocols declared in @MainActor isolated module without
+              // having to explicitly state `@MainActor`.
+              auto isolation =
+                  ActorIsolation::forGlobalActor(globalActor)
+                      .withPreconcurrency(!ctx.isLanguageModeAtLeast(6));
+              return {{{isolation, {}}, nullptr, {}}};
             }
+
+            // The type is nonisolated, so its members are nonisolated.
+            return {};
           }
         }
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -23,6 +23,8 @@
 #include "TypeCheckType.h"
 #include "TypeChecker.h"
 #include "swift/AST/ASTWalker.h"
+#include "swift/AST/ActorIsolation.h"
+#include "swift/AST/Attr.h"
 #include "swift/AST/Concurrency.h"
 #include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/DiagnosticGroups.h"
@@ -6259,8 +6261,12 @@ computeDefaultInferredActorIsolation(ValueDecl *value) {
         nominalTypeDecl = value->getDeclContext()->getSelfNominalTypeDecl();
       }
       if (nominalTypeDecl &&
-          sendableConformanceRequiresNonisolated(nominalTypeDecl))
-        return { };
+          sendableConformanceRequiresNonisolated(nominalTypeDecl)) {
+        InferredActorIsolation isolation{
+            ActorIsolation::forNonisolated(/*unsafe=*/false), /*source=*/{}};
+        return {
+            {isolation, /*overridenValue=*/nullptr, /*overridenIsolation=*/{}}};
+      }
 
       if (isa<TypeDecl>(value) || isa<ExtensionDecl>(value) ||
           isa<AbstractStorageDecl>(value) ||
@@ -8604,8 +8610,15 @@ ActorIsolation swift::inferConformanceIsolation(
         return *attrIsolation;
 
       // If we're defaulting to main-actor isolation, use that.
-      if (getDefaultIsolationForContext(dc) == DefaultIsolation::MainActor)
+      if (getDefaultIsolationForContext(dc) == DefaultIsolation::MainActor) {
+        // If type is `nonisolated` it means that defaulting didn't apply it
+        // it (i.e. due to direct conformance to a `Sendable` protocol), and
+        // it doesn't apply to extensions as well.
+        if (nominalIsolation.isNonisolated())
+          return nominalIsolation;
+
         return ActorIsolation::forMainActor(ctx);
+      }
     }
 
     return ActorIsolation::forNonisolated(false);

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -8619,10 +8619,13 @@ ActorIsolation swift::inferConformanceIsolation(
 
       // If we're defaulting to main-actor isolation, use that.
       if (getDefaultIsolationForContext(dc) == DefaultIsolation::MainActor) {
-        // If type is `nonisolated` it means that defaulting didn't apply it
-        // it (i.e. due to direct conformance to a `Sendable` protocol), and
-        // it doesn't apply to extensions as well.
-        if (nominalIsolation.isNonisolated())
+        // Infer conformance as `@MainActor`-isolated only if neither type nor
+        // member, that serves as a witness, are isolated, otherwise in this
+        // mode either type or extension would have to be explicitly or
+        // implicitly nonisolated (i.e. via primary declaration conforming to
+        // a `Sendable` protocol) and that gives us a hint that conformance
+        // should be nonisolated as well.
+        if (nominalIsolation.isNonisolated() && !hasKnownIsolatedWitness)
           return nominalIsolation;
 
         return ActorIsolation::forMainActor(ctx);

--- a/test/Concurrency/default_mainactor_isolation_cross_module.swift
+++ b/test/Concurrency/default_mainactor_isolation_cross_module.swift
@@ -1,0 +1,86 @@
+// RUN: %empty-directory(%t/src)
+// RUN: split-file %s %t/src
+
+// Build macros
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %t/src/macro_definitions.swift -g -no-toolchain-stdlib-rpath
+
+/// Build the library
+// RUN: %target-swift-frontend -emit-module %t/src/Lib.swift \
+// RUN:   -module-name Lib \
+// RUN:   -enable-library-evolution \
+// RUN:   -emit-module-path %t/Lib.swiftmodule \
+// RUN:   -emit-module-interface-path %t/Lib.swiftinterface
+
+// RUN: %target-swift-typecheck-module-from-interface(%t/Lib.swiftinterface) -module-name Lib
+
+// Build the client using module
+// RUN: %target-swift-frontend -typecheck -verify -load-plugin-library %t/%target-library-name(MacroDefinition) -default-isolation MainActor -module-name Client -I %t %t/src/Client.swift
+// RUN: %target-swift-frontend -typecheck -verify -load-plugin-library %t/%target-library-name(MacroDefinition) -default-isolation MainActor -module-name ClientWithMacro -I %t %t/src/ClientWithMacro.swift
+
+// RUN: rm %t/Lib.swiftmodule
+
+// Re-build the client using interface
+// RUN: %target-swift-frontend -typecheck -verify -load-plugin-library %t/%target-library-name(MacroDefinition) -default-isolation MainActor -module-name Client -I %t %t/src/Client.swift
+// RUN: %target-swift-frontend -typecheck -verify -load-plugin-library %t/%target-library-name(MacroDefinition) -default-isolation MainActor -module-name ClientWithMacro -I %t %t/src/ClientWithMacro.swift
+
+// REQUIRES: swift_swift_parser, executable_test
+
+//--- macro_definitions.swift
+import SwiftOperators
+@_spi(ExperimentalLanguageFeatures) import SwiftSyntax
+import SwiftSyntaxBuilder
+@_spi(ExperimentalLanguageFeature) import SwiftSyntaxMacros
+
+public struct AddConformanceMacro: ExtensionMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [ExtensionDeclSyntax] {
+    let conformance: DeclSyntax =
+      """
+      extension \(type.trimmed): Q {}
+      """
+
+    guard let extensionDecl = conformance.as(ExtensionDeclSyntax.self) else {
+      return []
+    }
+
+    return [extensionDecl]
+  }
+}
+
+//--- Lib.swift
+public protocol Other {
+}
+
+public protocol P: Sendable {
+}
+
+public protocol Q: P, Other {
+}
+
+public protocol W: Q {
+}
+
+@attached(extension, conformances: Q)
+public macro AddQ() = #externalMacro(module: "MacroDefinition", type: "AddConformanceMacro")
+
+//--- ClientWithMacro.swift
+import Lib
+
+@AddQ
+struct S: W {
+  var x: Int // Ok (no errors about conformance isolation)
+}
+
+//--- Client.swift
+import Lib
+
+struct S: P {
+}
+
+extension S: Q { // Ok (no errors about conformance isolation)
+}

--- a/test/Concurrency/default_mainactor_isolation_cross_module.swift
+++ b/test/Concurrency/default_mainactor_isolation_cross_module.swift
@@ -86,7 +86,7 @@ extension S: Q { // Ok (no errors about conformance isolation)
 }
 
 // @MainActor
-func globalFn() {}
+func globalFn() {} // expected-note {{calls to global function 'globalFn()' from outside of its actor context are implicitly asynchronous}}
 func takesMainActor(_: @MainActor () -> Void) {}
 
 // Check that a member declared in an extension of nonisolated type is considered @MainActor isolated
@@ -107,4 +107,13 @@ extension S: W {
   func testIsolation(v: S) {
     takesMainActor(v.mainActorWitness) // Ok
   }
+}
+
+struct S2: P {
+}
+
+extension S2: W {
+ nonisolated func mainActorWitness() {
+   globalFn() // expected-error {{call to main actor-isolated global function 'globalFn()' in a synchronous nonisolated context}}
+ }
 }


### PR DESCRIPTION
- Explanation:

  When default isolation is set to `MainActor` a type should be considered `nonisolated` if it's primary definition is stated to conform to a `Sendable` or `SendableMetatype` protocol. But default isolation computation currently produces "unspecified" instead which cannot be used as a condition during conformance isolation inference and so some implied conformances are wrongly considered to be `@MainActor`.

  The change adjusts the default isolation computation to produce `nonisolated` isolation in the case described above and adds a condition to the conformance isolation checking to prevent inferring `@MainActor` from an extension if a type itself is `nonisolated`.

- Resolves: rdar://166542727

- Main branch PR: https://github.com/swiftlang/swift/pull/86682

- Risk: Low. This change allows more code to type-check in `@MainActor` as default isolation mode and affects only extensions.

- Reviewed By: @hborla  

- Testing: Added new test-cases to the suite.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
