### PR TITLE
[Swiftify] check clang type for escapability instead of Swift type

### DIFF
--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -26,6 +26,7 @@
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/TypeWalker.h"
 #include "swift/Basic/Defer.h"
+#include "swift/ClangImporter/ClangImporterRequests.h"
 
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Attr.h"
@@ -503,6 +504,15 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
     if (CheckForwardDecls.IsIncompatibleImport(swiftReturnTy, clangReturnTy))
       return false;
 
+    auto isNonEscapable = [&Self](clang::QualType ty) {
+      // We only care whether it's _known_ ~Escapable, because it affects
+      // lifetime info requirements.
+      return evaluateOrDefault(Self.SwiftContext.evaluator,
+                               ClangTypeEscapability({ty.getTypePtr(), &Self}),
+                               CxxEscapability::Escapable) ==
+             CxxEscapability::NonEscapable;
+    };
+
     bool returnIsStdSpan = printer.registerStdSpanTypeMapping(
         swiftReturnTy, clangReturnTy);
     auto *CAT = clangReturnTy->getAs<clang::CountAttributedType>();
@@ -600,7 +610,7 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
           // If this parameter has bounds info we will tranform it into a Span,
           // so then it will no longer be Escapable.
           bool willBeEscapable =
-              swiftParamTy->isEscapable() &&
+              !isNonEscapable(clangParamTy) &&
               (!paramHasBoundsInfo ||
                mappedIndex == SwiftifyInfoPrinter::SELF_PARAM_INDEX);
           printer.printLifetimeboundReturn(mappedIndex, willBeEscapable);

--- a/test/Interop/C/swiftify-import/import-as-instance-method.swift
+++ b/test/Interop/C/swiftify-import/import-as-instance-method.swift
@@ -205,7 +205,7 @@ public func nonescaping(_ p: inout MutableSpan<Int32>) {
 @__swiftmacro_So1BV24nonescapingLifetimebound15_SwiftifyImportfMp_.swift
 ------------------------------
 /// This is an auto-generated wrapper for safer interop
-@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy self) @_disfavoredOverload
+@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(&self) @_disfavoredOverload
 public mutating func nonescapingLifetimebound(_ len: Int32) -> MutableSpan<Int32> {
     return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: unsafe nonescapingLifetimebound(len), count: Int(len)), copying: ())
 }


### PR DESCRIPTION
Checking the escapability of types at this point during compilation can return the wrong result and prevent the correct result from being calculated later due to caching.

rdar://169839008