### PR TITLE
[Swiftify] handle ~Escapable return values

### DIFF
--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -533,23 +533,30 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
 
     bool returnIsStdSpan = printer.registerStdSpanTypeMapping(
         swiftReturnTy, clangReturnTy);
+    bool returnHasBoundsInfo = returnIsStdSpan;
     auto *CAT = clangReturnTy->getAs<clang::CountAttributedType>();
     if (SwiftifiableCAT(clangASTContext, CAT, swiftReturnTy)) {
       printer.printCountedBy(CAT, SwiftifyInfoPrinter::RETURN_VALUE_INDEX);
       DLOG("Found bounds info '" << clang::QualType(CAT, 0) << "' on return value\n");
-      attachMacro = true;
+      returnHasBoundsInfo = attachMacro = true;
     }
     auto dependsOnClass = [](const ParamDecl *fromParam) {
       return fromParam->getInterfaceType()->isAnyClassReferenceType();
     };
+    bool returnValueIsEscapable = !isNonEscapable(clangReturnTy);
+    bool returnValueWillBeEscapable = returnValueIsEscapable && !returnHasBoundsInfo;
     bool returnHasLifetimeInfo = false;
     if (getImplicitObjectParamAnnotation<clang::LifetimeBoundAttr>(ClangDecl)) {
       DLOG("Found lifetimebound attribute on implicit 'this'\n");
       if (!dependsOnClass(
               MappedDecl->getImplicitSelfDecl(/*createIfNeeded*/ true))) {
-        printer.printLifetimeboundReturn(SwiftifyInfoPrinter::SELF_PARAM_INDEX,
-                                         true);
-        returnHasLifetimeInfo = true;
+        if (!returnValueWillBeEscapable) {
+          printer.printLifetimeboundReturn(SwiftifyInfoPrinter::SELF_PARAM_INDEX,
+                                           true);
+          returnHasLifetimeInfo = true;
+        } else {
+          DLOG("lifetimebound ignored because return value is escapable");
+        }
       } else {
         DLOG("lifetimebound ignored because it depends on class with refcount\n");
       }
@@ -625,23 +632,32 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
       if (clangParam->template hasAttr<clang::LifetimeBoundAttr>()) {
         DLOG("Found lifetimebound attribute\n");
         if (!dependsOnClass(swiftParam)) {
-          // If this parameter has bounds info we will tranform it into a Span,
-          // so then it will no longer be Escapable.
-          bool willBeEscapable =
-              !isNonEscapable(clangParamTy) &&
-              (!paramHasBoundsInfo ||
-               mappedIndex == SwiftifyInfoPrinter::SELF_PARAM_INDEX);
-          printer.printLifetimeboundReturn(mappedIndex, willBeEscapable);
-          paramHasLifetimeInfo = true;
-          returnHasLifetimeInfo = true;
+          if (!returnValueWillBeEscapable) {
+            // If this parameter has bounds info we will tranform it into a
+            // Span, so then it will no longer be Escapable.
+            bool willBeEscapable =
+                !isNonEscapable(clangParamTy) &&
+                (!paramHasBoundsInfo ||
+                 mappedIndex == SwiftifyInfoPrinter::SELF_PARAM_INDEX);
+            printer.printLifetimeboundReturn(mappedIndex, willBeEscapable);
+            paramHasLifetimeInfo = true;
+            returnHasLifetimeInfo = true;
+          } else {
+            DLOG("lifetimebound ignored because return value is escapable");
+          }
         } else {
-          DLOG("lifetimebound ignored because it depends on class with refcount\n");
+          DLOG("lifetimebound ignored because it depends on class with "
+               "refcount\n");
         }
       }
       if (paramIsStdSpan && paramHasLifetimeInfo) {
         DLOG("Found both std::span and lifetime info\n");
         attachMacro = true;
       }
+    }
+    if (!returnHasLifetimeInfo && !returnValueIsEscapable) {
+      DLOG("~Escapable return value without lifetime info\n");
+      return false;
     }
     if (returnIsStdSpan && returnHasLifetimeInfo) {
       DLOG("Found both std::span and lifetime info for return value\n");

--- a/test/Interop/C/swiftify-import/Inputs/counted-by-lifetimebound.h
+++ b/test/Interop/C/swiftify-import/Inputs/counted-by-lifetimebound.h
@@ -22,3 +22,10 @@ opaque_t * __counted_by(len) opaque(int len, int len2, opaque_t * p __counted_by
 int * __counted_by(len) noncountedLifetime(int len, int * p __lifetimebound);
 
 int * __counted_by(13) _Nullable constant(int * _Nullable p __counted_by_or_null(13) __lifetimebound);
+
+struct EscapableStruct {};
+// make sure __lifetimebound is ignored when return value is escapable
+struct EscapableStruct lifetimeboundEscapableReturn(int len, int * __counted_by(len) p __lifetimebound);
+
+struct __attribute__((swift_attr("~Escapable"))) NonescapableStruct {};
+struct NonescapableStruct lifetimeboundNonescapableReturn(int len, int * __counted_by(len) p __lifetimebound);

--- a/test/Interop/C/swiftify-import/Inputs/counted-by-lifetimebound.h
+++ b/test/Interop/C/swiftify-import/Inputs/counted-by-lifetimebound.h
@@ -29,3 +29,5 @@ struct EscapableStruct lifetimeboundEscapableReturn(int len, int * __counted_by(
 
 struct __attribute__((swift_attr("~Escapable"))) NonescapableStruct {};
 struct NonescapableStruct lifetimeboundNonescapableReturn(int len, int * __counted_by(len) p __lifetimebound);
+
+struct NonescapableStruct lifetimeboundNonescapableReturnDoubleBounds(int len, int * __counted_by(len) p __lifetimebound, struct NonescapableStruct s __lifetimebound);

--- a/test/Interop/C/swiftify-import/counted-by-lifetimebound.swift
+++ b/test/Interop/C/swiftify-import/counted-by-lifetimebound.swift
@@ -17,11 +17,20 @@ import CountedByLifetimeboundClang
 // CHECK-NEXT: @_lifetime(p: copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func complexExpr(_ len: Int32, _ offset: Int32, _ p: inout MutableSpan<Int32>) -> MutableSpan<Int32>
 
-// CHECK:      /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @_lifetime(copy p)
 // CHECK-NEXT: @_lifetime(p: copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func constant(_ p: inout MutableSpan<Int32>?) -> MutableSpan<Int32>?
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func lifetimeboundEscapableReturn(_ p: UnsafeMutableBufferPointer<Int32>) -> EscapableStruct
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @_lifetime(copy p)
+// CHECK-NEXT: @_lifetime(p: copy p)
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func lifetimeboundNonescapableReturn(_ p: inout MutableSpan<Int32>) -> NonescapableStruct
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
@@ -105,4 +114,15 @@ public func callNoncountedLifetime(_ p: UnsafeMutablePointer<CInt>) {
 @inlinable
 public func callConstant(_ p: inout MutableSpan<CInt>?) {
   let _: MutableSpan<CInt>? = constant(&p)
+}
+
+@inlinable
+public func callLifetimeboundEscapableReturn(_ p: UnsafeMutableBufferPointer<CInt>) {
+  let _ = unsafe lifetimeboundEscapableReturn(p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@inlinable
+public func callLifetimeboundNonescapableReturn(_ p: inout MutableSpan<CInt>) {
+  let _ = lifetimeboundNonescapableReturn(&p)
 }

--- a/test/Interop/C/swiftify-import/counted-by-lifetimebound.swift
+++ b/test/Interop/C/swiftify-import/counted-by-lifetimebound.swift
@@ -34,6 +34,12 @@ import CountedByLifetimeboundClang
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @_lifetime(copy p, copy s)
+// CHECK-NEXT: @_lifetime(p: copy p)
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func lifetimeboundNonescapableReturnDoubleBounds(_ p: inout MutableSpan<Int32>, _ s: NonescapableStruct) -> NonescapableStruct
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @_lifetime(borrow p)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func noncountedLifetime(_ len: Int32, _ p: UnsafeMutablePointer<Int32>!) -> MutableSpan<Int32>
 
@@ -125,4 +131,10 @@ public func callLifetimeboundEscapableReturn(_ p: UnsafeMutableBufferPointer<CIn
 @inlinable
 public func callLifetimeboundNonescapableReturn(_ p: inout MutableSpan<CInt>) {
   let _ = lifetimeboundNonescapableReturn(&p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@inlinable
+public func callLifetimeboundNonescapableReturnDoubleBounds(_ p: inout MutableSpan<CInt>, _ s: NonescapableStruct) {
+  let _ = lifetimeboundNonescapableReturnDoubleBounds(&p, s)
 }

--- a/test/Interop/C/swiftify-import/nonescapable-return-without-lifetime.swift
+++ b/test/Interop/C/swiftify-import/nonescapable-return-without-lifetime.swift
@@ -1,0 +1,38 @@
+// REQUIRES: swift_feature_SafeInteropWrappers
+// REQUIRES: swift_feature_Lifetimes
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -emit-module -I %t -plugin-path %swift-plugin-dir -strict-memory-safety -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature Lifetimes %t/test.swift \
+// RUN:    -Rmacro-expansions -verify -verify-additional-file %t%{fs-sep}test.h
+
+//--- module.modulemap
+module Test {
+    header "test.h"
+}
+
+//--- test.h
+#pragma once
+
+#define __counted_by(x) __attribute__((__counted_by__(x)))
+
+struct __attribute__((swift_attr("~Escapable"))) NonescapableStruct {};
+// expected-note@+3{{'nonescapableReturnNoLifetime' declared here}}
+// expected-error@+2{{a function with a ~Escapable result requires '@_lifetime(...)'}}
+// expected-warning@+1{{the returned type 'struct NonescapableStruct' is annotated as non-escapable; its lifetime dependencies must be annotated}}
+struct NonescapableStruct nonescapableReturnNoLifetime(int len, int * __counted_by(len) p);
+
+//--- test.swift
+import Test
+
+func test(_ p: UnsafeMutablePointer<CInt>, _ len: CInt) {
+    let _ = unsafe nonescapableReturnNoLifetime(len, p)
+}
+
+func test(_ p: UnsafeMutableBufferPointer<CInt>) -> NonescapableStruct {
+    // expected-error@+2{{missing argument for parameter #2 in call}}
+    // expected-error@+1{{cannot convert value of type 'UnsafeMutableBufferPointer<CInt>' (aka 'UnsafeMutableBufferPointer<Int32>') to expected argument type 'Int32'}}
+    let ret = unsafe nonescapableReturnNoLifetime(p)
+    // expected-error@+1{{cannot convert return expression of type 'NonescapableStruct.Type' to return type 'NonescapableStruct'}}
+    return NonescapableStruct
+}

--- a/test/Macros/SwiftifyImport/CountedBy/UnrelatedNonescapableReturn.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/UnrelatedNonescapableReturn.swift
@@ -1,0 +1,51 @@
+// REQUIRES: swift_swift_parser
+// REQUIRES: swift_feature_Lifetimes
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend %t/test.swift -emit-module -plugin-path %swift-plugin-dir -strict-memory-safety -enable-experimental-feature Lifetimes -verify
+// RUN: env SWIFT_BACKTRACE="" %target-swift-frontend %t/test.swift -typecheck -plugin-path %swift-plugin-dir -enable-experimental-feature Lifetimes -dump-macro-expansions 2> %t/expansions.out
+// RUN: %diff %t/expansions.out %t/expansions.expected
+
+//--- test.swift
+public enum NonescapableEnum: ~Escapable {
+  case foo
+}
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"), .lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .copy))
+@_lifetime(borrow ptr)
+public func myFunc(_ ptr: UnsafePointer<CInt>, _ len: CInt) -> NonescapableEnum {
+  return .foo
+}
+
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"), .lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .copy), .lifetimeDependence(dependsOn: .param(3), pointer: .return, type: .copy))
+@_lifetime(extraNE: copy extraNE) @_lifetime(borrow ptr, copy extraNE)
+public func myFunc2(_ ptr: UnsafeMutablePointer<CInt>, _ len: CInt, _ extraNE: inout NonescapableEnum) -> NonescapableEnum {
+  return .foo
+}
+
+//--- expansions.expected
+@__swiftmacro_4test6myFunc15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_lifetime(copy ptr) @_disfavoredOverload
+public func myFunc(_ ptr: Span<CInt>) -> NonescapableEnum {
+    let len = CInt(exactly: ptr.count)!
+    let _ptrPtr = unsafe ptr.withUnsafeBufferPointer {
+        unsafe $0
+    }
+    return unsafe _swiftifyOverrideLifetime(unsafe myFunc(_ptrPtr.baseAddress!, len), copying: ())
+}
+------------------------------
+@__swiftmacro_4test7myFunc215_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_lifetime(copy ptr, copy extraNE) @_lifetime(ptr: copy ptr) @_lifetime(extraNE: copy extraNE) @_disfavoredOverload
+public func myFunc2(_ ptr: inout MutableSpan<CInt>, _ extraNE: inout NonescapableEnum) -> NonescapableEnum {
+    let len = CInt(exactly: ptr.count)!
+    let _ptrPtr = unsafe ptr.withUnsafeMutableBufferPointer {
+        unsafe $0
+    }
+    return unsafe _swiftifyOverrideLifetime(unsafe myFunc2(_ptrPtr.baseAddress!, len, &extraNE), copying: ())
+}
+------------------------------


### PR DESCRIPTION
This adds support for safe wrappers on imported functions returning a ~Escapable value. This is only done if there is lifetime information for the return value, as the wrapper will always have a lifetime error otherwise. __lifetimebound is also ignored *unless* the return value is ~Escapable (or will be transformed to a Span), since lifetime info for an Escapable return value is an error. To enable testing this it also adds merging of lifetime annotations from the underlying funciton and the extra info added by the macro.

rdar://157884394