### PR TITLE
[AST] ASTPrinter: convert `canAppearOnDecl` into an assertion

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1590,10 +1590,12 @@ void PrintAST::printAttributes(const Decl *D) {
     }
   }
 
-  // Attributes that are not permitted to appear should not be printed
-  for (auto *attr : attrs) {
-    if (!attr->canAppearOnDecl(D))
-      scope.Options.ExcludeAttrList.push_back(attr->getKind());
+  // Attributes that are not permitted to appear should not be attached.
+  // This is the last line of defense against printing incorrect attributes
+  // and by so doing breaking interface files.
+  if (CONDITIONAL_ASSERT_enabled()) {
+    for (auto *attr : attrs)
+      ASSERT(attr->canAppearOnDecl(D));
   }
 
   attrs.print(Printer, Options, D);


### PR DESCRIPTION
Follow-up to https://github.com/swiftlang/swift/pull/86967.

The callers are responsible for constructing declarations that are valid, let's double-check that all of the attached attributes to the declaration can indeed appear on it before printing instead of simply skipping them.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
