### PR TITLE
[sema] Honor explicit global actor isolation for async closures in constraint solver

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2043,12 +2043,9 @@ namespace {
         if (hasIsolatedParameter(closureParams))
           return FunctionTypeIsolation::forParameter();
 
-        // Honor an explicit global actor.  This is suppressed if the
-        // closure is async (but should it be?).
-        if (!extInfo.isAsync()) {
-          if (auto actorType = getExplicitGlobalActor(closure))
-            return FunctionTypeIsolation::forGlobalActor(actorType);
-        }
+        // Honor an explicit global actor.
+        if (auto actorType = getExplicitGlobalActor(closure))
+          return FunctionTypeIsolation::forGlobalActor(actorType);
 
         if (closure->getAttrs().hasAttribute<ConcurrentAttr>()) {
           return FunctionTypeIsolation::forNonIsolated();

--- a/test/Concurrency/global_actor_function_types.swift
+++ b/test/Concurrency/global_actor_function_types.swift
@@ -55,7 +55,7 @@ func testClosures(i: Int) async {
   let cl2 = { @SomeGlobalActor in
     await someSlowOperation()
   }
-  let _: Double = cl2 // expected-error{{cannot convert value of type '() async -> Int' to specified type 'Double'}}
+  let _: Double = cl2 // expected-error{{cannot convert value of type '@SomeGlobalActor () async -> Int' to specified type 'Double'}}
 
   let cl3 = { @SomeGlobalActor [i] in
     print(i + onSomeGlobalActor())
@@ -437,4 +437,22 @@ func testGlobalActorAutoclosure(_ x: HasMainActorFns) {
   takesMainActorFn(HasMainActorFns.staticFn)
   takesMainActorFn(HasMainActorFns.instanceFn(x))
   takesMainActorFn(x.instanceFn)
+}
+
+// rdar://169803154 - The constraint solver must honor an explicit global actor on
+// async closures, not just sync ones.  These should typecheck without errors or
+// actor-stripping warnings.
+func testAsyncMainActorClosurePreservesGlobalActor() {
+  // Sync @MainActor closure - always worked.
+  let _: @MainActor () -> Void = { @MainActor in }
+
+  // Async @MainActor closure - fixed by rdar://169803154.
+  let _: @MainActor () async -> Void = { @MainActor in }
+
+  // Explicitly annotated async @MainActor closure in Task.detached should compile
+  // cleanly; before the fix it would produce an unknown-pattern error because the
+  // constraint solver treated the closure as non-isolated despite the annotation.
+  _ = Task.detached { @MainActor in
+    await Task.yield()
+  }
 }

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -2416,3 +2416,22 @@ struct IndirectAssignTests {
     }
   }
 }
+
+// rdar://169803154 - @MainActor async closure with for-try-await must not produce
+// spurious non-Sendable / unknown-pattern errors.  The constraint solver must honor
+// an explicit global actor on an async closure the same way it does for a sync one.
+@MainActor
+class rdar169803154_Klass {
+  init() {
+    Task.detached { @MainActor in
+      _ = self
+      for try await x in rdar169803154_Seq.seq { _ = x }
+    }
+  }
+}
+
+enum rdar169803154_Seq {
+  static var seq: some AsyncSequence<Float, Error> {
+    AsyncThrowingStream(Float.self) { $0.finish() }
+  }
+}

--- a/test/SILGen/isolated_any.swift
+++ b/test/SILGen/isolated_any.swift
@@ -269,7 +269,7 @@ func testEraseAsyncNonIsolatedClosure() {
 
 // CHECK-LABEL: sil hidden [ossa] @$s4test0A26EraseAsyncMainActorClosureyyF
 // CHECK:         // function_ref closure #1
-// CHECK-NEXT:    [[CLOSURE_FN:%.*]] = function_ref @$s4test0A26EraseAsyncMainActorClosureyyFyyYaYbcfU_ :
+// CHECK-NEXT:    [[CLOSURE_FN:%.*]] = function_ref @$s4test0A26EraseAsyncMainActorClosureyyFyyYaYbScMYccfU_ :
 // CHECK-NEXT:    [[MAIN_ACTOR_METATYPE:%.*]] = metatype $@thick MainActor.Type
 // CHECK-NEXT:    // function_ref
 // CHECK-NEXT:    [[MAIN_ACTOR_SHARED_FN:%.*]] = function_ref @$sScM6sharedScMvgZ :


### PR DESCRIPTION
NOTE: This is a draft since I am just testing this out with the source compat suite. I will add more tests/etc if it looks good.


----

Fixes rdar://169803154

Previously, we were emitting an unknown pattern error in code like:

```
@MainActor
class MainActorIsolatedKlass {
  init() {
    Task.detached { @MainActor in
      _ = self
      for try await x in E.seq {
      }
    }
  }
}

enum E {
  static var seq: some AsyncSequence<Float, Error> {
    AsyncThrowingStream(Float.self) { $0.finish() }
  }
}
```

The issue was that the closure was considered non-Sendable despite being @MainActor due to the `try await` in it. Investigation revealed an inconsistency between the constraint solver and getClosureIsolation:

1. In the constraint solver, we were only honoring explicit global actor isolation for non-async functions, which caused us to not infer that the closure should have been Sendable despite the try await.

2. Later getClosureIsolation did the correct thing and we labeled the closure as having global actor isolation, but that did not impact the actual type of the closure being Sendable at the SIL level.

The result was a non-Sendable main actor isolated closure.

This commit removes the restriction that prevented honoring explicit global actor isolation for async closures, making the constraint solver consistent with getClosureIsolation.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
