### PR TITLE
[MemberLoading] Split storage and non-storage member loading

### DIFF
--- a/include/swift/AST/LazyResolver.h
+++ b/include/swift/AST/LazyResolver.h
@@ -87,11 +87,25 @@ class alignas(void*) LazyMemberLoader {
 public:
   virtual ~LazyMemberLoader() = default;
 
-  /// Populates a given decl \p D with all of its members.
+  /// Populates a given decl \p D with all members that affect storage.
   ///
-  /// The implementation should add the members to D.
-  virtual void
-  loadAllMembers(Decl *D, uint64_t contextData) = 0;
+  /// INVARIANT: this method should only ever be called once for \p D, to avoid
+  /// adding duplicates to the linked list of members. It is the responsibility
+  /// of the caller (IterableDeclContext) to ensure this.
+  ///
+  /// An exception is when \p D is an imported clang::NamespaceDecl, in which
+  /// case no members are ever added (kind of a hack, should consider fixing it)
+  virtual void loadStorageMembers(Decl *D, uint64_t contextData) = 0;
+
+  /// Populates a given decl \p D with all members that do not affect storage.
+  ///
+  /// INVARIANT: this method should only ever be called once for \p D, to avoid
+  /// adding duplicates to the linked list of members. It is the responsibility
+  /// of the caller (IterableDeclContext) to ensure this.
+  ///
+  /// INVARIANT: the caller (an IterableDeclContext with a lazy loader)
+  /// must have already called loadStorageMembers() before calling this.
+  virtual void loadNonStorageMembers(Decl *D, uint64_t contextData) = 0;
 
   /// Populates a vector with all members of \p IDC that have DeclName
   /// matching \p N.

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -7892,16 +7892,6 @@ void ClangImporter::Implementation::markMemberSynthesizedPerType(
   membersSynthesizedPerType.insert(decl);
 }
 
-size_t ClangImporter::Implementation::getImportedBaseMemberDeclArity(
-    const ValueDecl *valueDecl) {
-  if (auto *func = dyn_cast<FuncDecl>(valueDecl)) {
-    if (auto *params = func->getParameters()) {
-      return params->size();
-    }
-  }
-  return 0;
-}
-
 ValueDecl *
 ClangImporter::importBaseMemberDecl(ValueDecl *decl, DeclContext *newContext,
                                     ClangInheritanceInfo inheritance) {

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -749,8 +749,6 @@ public:
   bool isMemberSynthesizedPerType(const ValueDecl *decl);
   void markMemberSynthesizedPerType(const ValueDecl *decl);
 
-  static size_t getImportedBaseMemberDeclArity(const ValueDecl *valueDecl);
-
   // Cache for already-specialized function templates and any thunks they may
   // have.
   llvm::DenseMap<clang::FunctionDecl *, ValueDecl *>
@@ -1707,20 +1705,17 @@ public:
   loadNamedMembers(const IterableDeclContext *IDC, DeclBaseName N,
                    uint64_t contextData) override;
 
+  void insertMembersAndAlternates(const clang::NamedDecl *nd,
+                                  SmallVectorImpl<Decl *> &members,
+                                  DeclContext *expectedDC = nullptr);
+
 private:
   void
   loadAllMembersOfObjcContainer(Decl *D,
                                 const clang::ObjCContainerDecl *objcContainer);
-  void loadAllMembersOfRecordDecl(NominalTypeDecl *swiftDecl,
-                                  const clang::RecordDecl *clangRecord,
-                                  ClangInheritanceInfo inheritance);
-
   void collectMembersToAdd(const clang::ObjCContainerDecl *objcContainer,
                            Decl *D, DeclContext *DC,
                            SmallVectorImpl<Decl *> &members);
-  void insertMembersAndAlternates(const clang::NamedDecl *nd,
-                                  SmallVectorImpl<Decl *> &members,
-                                  DeclContext *expectedDC = nullptr);
   void loadAllMembersIntoExtension(Decl *D, uint64_t extra);
 
   /// Imports \p decl under \p nameVersion with the name \p newName, and adds

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1698,8 +1698,8 @@ public:
     return found->second;
   }
 
-  virtual void
-  loadAllMembers(Decl *D, uint64_t unused) override;
+  virtual void loadStorageMembers(Decl *D, uint64_t unused) override;
+  virtual void loadNonStorageMembers(Decl *D, uint64_t unused) override;
 
   virtual TinyPtrVector<ValueDecl *>
   loadNamedMembers(const IterableDeclContext *IDC, DeclBaseName N,
@@ -1716,7 +1716,7 @@ private:
   void collectMembersToAdd(const clang::ObjCContainerDecl *objcContainer,
                            Decl *D, DeclContext *DC,
                            SmallVectorImpl<Decl *> &members);
-  void loadAllMembersIntoExtension(Decl *D, uint64_t extra);
+  void loadAllMembersIntoExtension(ExtensionDecl *ext, uint64_t extra);
 
   /// Imports \p decl under \p nameVersion with the name \p newName, and adds
   /// it and its alternates to \p ext.

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -130,7 +130,8 @@ static void computeLoweredProperties(NominalTypeDecl *decl,
 
   // Just walk over the members of the type, forcing backing storage
   // for lazy properties and property wrappers to be synthesized.
-  for (auto *member : implDecl->getMembers()) {
+  implDecl->loadStorageMembers();
+  for (auto *member : implDecl->getCurrentMembersWithoutLoading()) {
     // Expand peer macros.
     (void)evaluateOrDefault(
         ctx.evaluator,
@@ -229,7 +230,8 @@ static void enumerateStoredPropertiesAndMissing(
     visitMember(idVar);
   if (auto actorSystemVar = decl->getDistributedActorSystemProperty())
     visitMember(actorSystemVar);
-  for (auto *member : implDecl->getMembers())
+  implDecl->loadStorageMembers();
+  for (auto *member : implDecl->getCurrentMembersWithoutLoading())
     visitMember(member);
 }
 
@@ -351,7 +353,8 @@ InitializablePropertiesRequest::evaluate(Evaluator &evaluator,
     member->visitAuxiliaryDecls(visitMember);
   };
 
-  for (auto *member : decl->getMembers())
+  decl->loadStorageMembers();
+  for (auto *member : decl->getCurrentMembersWithoutLoading())
     visitMember(member);
 
   return decl->getASTContext().AllocateCopy(results);

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -8663,7 +8663,7 @@ ModuleFile::handleErrorAndSupplyMissingMember(ASTContext &context,
   return handleErrorAndSupplyMissingMiscMember(std::move(error));
 }
 
-void ModuleFile::loadAllMembers(Decl *container, uint64_t contextData) {
+void ModuleFile::loadStorageMembers(Decl *container, uint64_t contextData) {
   PrettyStackTraceDecl trace("loading members for", container);
   ++NumMemberListsLoaded;
 

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -921,8 +921,11 @@ public:
   /// Has no effect in NDEBUG builds.
   void verify() const;
 
-  virtual void loadAllMembers(Decl *D,
-                              uint64_t contextData) override;
+  // For now, loadStorageMembers() does the job of loading both storage and
+  // non-storage members. In the future, these responsibilities may be divided
+  // between the two methods so that we do not deserialize unneeded members.
+  virtual void loadStorageMembers(Decl *D, uint64_t contextData) override;
+  virtual void loadNonStorageMembers(Decl *D, uint64_t contextData) override {}
 
   virtual TinyPtrVector<ValueDecl *>
   loadNamedMembers(const IterableDeclContext *IDC, DeclBaseName N,

--- a/test/Interop/Cxx/class/linked-records-module-interface.swift
+++ b/test/Interop/Cxx/class/linked-records-module-interface.swift
@@ -26,6 +26,7 @@
 // CHECK: struct F {
 // CHECK:   init(_ __Anonymous_field0: F.__Unnamed_union___Anonymous_field0, m2: M)
 // CHECK:   init()
+// CHECK:   var __Anonymous_field0: F.__Unnamed_union___Anonymous_field0
 // CHECK:   struct __Unnamed_union___Anonymous_field0 {
 // CHECK:     init(c: F.__Unnamed_union___Anonymous_field0.__Unnamed_struct_c)
 // CHECK:     init(m: M)
@@ -36,7 +37,6 @@
 // CHECK:     var c: F.__Unnamed_union___Anonymous_field0.__Unnamed_struct_c
 // CHECK:     var m: M
 // CHECK:   }
-// CHECK:   var __Anonymous_field0: F.__Unnamed_union___Anonymous_field0
 // CHECK:   var c: F.__Unnamed_union___Anonymous_field0.__Unnamed_struct_c
 // CHECK:   var m: M
 // CHECK:   var m2: M

--- a/test/Interop/Cxx/namespace/templates-with-forward-decl-module-interface.swift
+++ b/test/Interop/Cxx/namespace/templates-with-forward-decl-module-interface.swift
@@ -10,8 +10,8 @@
 // CHECK-NEXT:   struct Decl<CInt> {
 // CHECK-NEXT:     init(fwd: NS1.ForwardDeclared<CInt>)
 // CHECK-NEXT:     init()
-// CHECK-NEXT:     typealias MyInt = Int32
 // CHECK-NEXT:     var fwd: NS1.ForwardDeclared<CInt>
+// CHECK-NEXT:     typealias MyInt = Int32
 // CHECK-NEXT:     static var intValue: NS1.Decl<CInt>.MyInt { get }
 // CHECK-NEXT:   }
 // CHECK-NEXT:   @available(*, unavailable, message: "Un-specialized class templates are not currently supported. Please use a specialization of this type.")


### PR DESCRIPTION
getStoredProperties() shouldn't call getMembers(), because can have the side effect of un-lazily loading everything. Instead, only ensure that storage-relevant members are loaded and iterate through those.

This patch set builds on #87026 (which merged separately) to avoid the import order from catastrophically messing up every single module interface test (which happened anyway; see the mongo diff there).

This patch set is necessary for the lazy importing work in #87016.

rdar://156949141