### PR TITLE
SuppressedAssociatedTypesWithDefaults: swiftinterface and mangling support

### DIFF
--- a/include/swift/AST/Requirement.h
+++ b/include/swift/AST/Requirement.h
@@ -202,10 +202,6 @@ public:
   /// 'T : C' can be satisfied; however, if 'T' already has an unrelated
   /// superclass requirement, 'T : C' cannot be satisfied.
   bool canBeSatisfied() const;
-  
-  /// True if the requirement states a conformance to an invertible protocol
-  /// that is implied by default (such as `Copyable` or `Escapable`.
-  bool isInvertibleProtocolRequirement() const;
 
   /// Linear order on requirements in a generic signature.
   int compare(const Requirement &other) const;

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2967,7 +2967,7 @@ static void reconcileInverses(
       if (baseSig && baseSig->requiresProtocol(inv.subject, inv.protocol))
         return true;
 
-      auto gp = inv.subject->castTo<GenericTypeParamType>();
+      auto gp = inv.subject->getRootGenericParam();
 
       // Remove inverses that were either already mangled for this entity,
       // or chosen not to be included in the output.

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1863,7 +1863,7 @@ InversesAtDepth::InversesAtDepth(GenericContext *level) {
 }
 bool InversesAtDepth::operator()(const InverseRequirement &inverse) const {
   if (includedDepth) {
-    auto d = inverse.subject->castTo<GenericTypeParamType>()->getDepth();
+    auto d = inverse.subject->getRootGenericParam()->getDepth();
     return d == includedDepth.value();
   }
   return false;
@@ -1934,7 +1934,7 @@ void PrintAST::printGenericSignature(
 
     SmallVector<InverseRequirement, 2> inversesAtDepth;
     for (auto inverseReq : inverses) {
-      if (inverseReq.subject->castTo<GenericTypeParamType>()->getDepth() == depth)
+      if (inverseReq.subject->getRootGenericParam()->getDepth() == depth)
         inversesAtDepth.push_back(inverseReq);
     }
 

--- a/lib/AST/Requirement.cpp
+++ b/lib/AST/Requirement.cpp
@@ -222,12 +222,6 @@ bool Requirement::canBeSatisfied() const {
   llvm_unreachable("Bad requirement kind");
 }
 
-bool Requirement::isInvertibleProtocolRequirement() const {
-  return getKind() == RequirementKind::Conformance
-      && getFirstType()->is<GenericTypeParamType>()
-      && getProtocolDecl()->getInvertibleProtocolKind();
-}
-
 /// Determine the canonical ordering of requirements.
 static unsigned getRequirementKindOrder(RequirementKind kind) {
   switch (kind) {

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -4428,6 +4428,20 @@ NodePointer Demangler::demangleGenericRequirement() {
       if (!inverseKind)
         return nullptr;
       break;
+    case 'j':
+      ConstraintKind = Inverse;
+      TypeKind = Assoc;
+      inverseKind = demangleIndexAsNode();
+      if (!inverseKind)
+        return nullptr;
+      break;
+    case 'J':
+      ConstraintKind = Inverse;
+      TypeKind = CompoundAssoc;
+      inverseKind = demangleIndexAsNode();
+      if (!inverseKind)
+        return nullptr;
+      break;
     default:  ConstraintKind = Protocol; TypeKind = Generic; pushBack(); break;
   }
 

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2325,13 +2325,17 @@ namespace {
       }
       condReqs.clear();
 
+      // Enumerate the conditional requirements from the conformance.
       for (auto condReq : normal->getConditionalRequirements()) {
-        // We don't need to collect conditional requirements for invertible
-        // protocol requirements here, since they are encoded in the inverse
-        // list above.
-        if (!condReq.isInvertibleProtocolRequirement()) {
-          condReqs.push_back(condReq);
+        // We don't need to collect conditional requirements for
+        // GenericTypeParamType here, since they are encoded in the inverse
+        // list above. But we do need to include those for DependentMemberType.
+        if (condReq.getKind() == RequirementKind::Conformance &&
+            condReq.getFirstType()->getAs<GenericTypeParamType>() &&
+            condReq.getProtocolDecl()->getInvertibleProtocolKind()) {
+          continue;
         }
+        condReqs.push_back(condReq);
       }
       if (condReqs.empty() || Conformance->isReparented()) {
         // For a protocol P that conforms to another protocol, introduce a

--- a/test/Casting/suppressed-associated-types.swift
+++ b/test/Casting/suppressed-associated-types.swift
@@ -1,0 +1,103 @@
+// RUN: %target-run-simple-swift(-enable-experimental-feature SuppressedAssociatedTypesWithDefaults) \
+// RUN:      | %FileCheck --check-prefix=EXEC %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_feature_SuppressedAssociatedTypesWithDefaults
+
+protocol P {
+    func p()
+}
+
+protocol Q {
+    func q()
+}
+
+protocol Style<Primary> {
+  associatedtype Primary: ~Copyable
+  associatedtype Secondary: ~Copyable
+}
+
+struct Hat<S: Style> where S.Primary: ~Copyable {}
+
+extension Hat: P /*<implied> where S.Primary: Copyable */ {
+    func p() {
+        print("\(self) : P")
+    }
+}
+
+extension Hat: Q where S.Primary: ~Copyable, S.Secondary: Copyable {
+    func q() {
+        print("\(self) : Q")
+    }
+}
+
+struct NC: ~Copyable {}
+
+struct AllCopyable: Style {
+  typealias Primary = Int
+  typealias Secondary = Int
+}
+
+struct NCPrimary: Style {
+  typealias Primary = NC
+  typealias Secondary = Int
+}
+
+struct NCSecondary: Style {
+  typealias Primary = Int
+  typealias Secondary = NC
+}
+
+struct NCBoth: Style {
+  typealias Primary = NC
+  typealias Secondary = NC
+}
+
+
+@inline(never)
+func castP<T>(value: T) -> (any P)? {
+    return value as? any P
+}
+
+@inline(never)
+func castQ<T>(value: T) -> (any Q)? {
+    return value as? any Q
+}
+
+func test<T>(_ t: T) {
+  if let p = castP(value: t) {
+    p.p()
+  } else {
+    print("\(t) is not a P")
+  }
+  if let q = castQ(value: t) {
+    q.q()
+  } else {
+    print("\(t) is not a Q")
+  }
+}
+
+func main() {
+    // EXEC: going to test
+    print("going to test")
+
+    // EXEC-NEXT: Hat<AllCopyable>() : P
+    // EXEC-NEXT: Hat<AllCopyable>() : Q
+    test(Hat<AllCopyable>())
+
+    // EXEC-NEXT: Hat<NCPrimary>() is not a P
+    // EXEC-NEXT: Hat<NCPrimary>() : Q
+    test(Hat<NCPrimary>())
+
+    // EXEC-NEXT: Hat<NCSecondary>() : P
+    // EXEC-NEXT: Hat<NCSecondary>() is not a Q
+    test(Hat<NCSecondary>())
+
+    // EXEC-NEXT: Hat<NCBoth>() is not a P
+    // EXEC-NEXT: Hat<NCBoth>() is not a Q
+    test(Hat<NCBoth>())
+
+    // EXEC-NEXT: done testing
+    print("done testing")
+}
+main()

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -366,6 +366,8 @@ $S1T19protocol_resilience17ResilientProtocolPTl ---> associated type descriptor 
 $S18resilient_protocol21ResilientBaseProtocolTL ---> protocol requirements base descriptor for resilient_protocol.ResilientBaseProtocol
 $S1t1PP10AssocType2_AA1QTn ---> associated conformance descriptor for t.P.AssocType2: t.Q
 $S1t1PP10AssocType2_AA1QTN ---> default associated conformance accessor for t.P.AssocType2: t.Q
+$s4mini3SeqPxAA06BorrowB0TN ---> default associated conformance accessor for mini.Seq.A: mini.BorrowSeq
+$s4mini3SeqPxAA06BorrowB0Tn ---> associated conformance descriptor for mini.Seq.A: mini.BorrowSeq
 $s4Test6testityyxlFAA8MystructV_TB5 ---> generic specialization <Test.Mystruct> of Test.testit<A>(A) -> ()
 $sSUss17FixedWidthIntegerRzrlEyxqd__cSzRd__lufCSu_SiTg5 ---> generic specialization <Swift.UInt, Swift.Int> of (extension in Swift):Swift.UnsignedInteger< where A: Swift.FixedWidthInteger>.init<A where A1: Swift.BinaryInteger>(A1) -> A
 $s4test7genFuncyyx_q_tr0_lFSi_SbTtt1g5 ---> generic specialization <Swift.Int, Swift.Bool> of test.genFunc<A, B>(A, B) -> ()

--- a/test/ModuleInterface/associated_type_suppressed.swift
+++ b/test/ModuleInterface/associated_type_suppressed.swift
@@ -1,0 +1,97 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name assoc -enable-experimental-feature SuppressedAssociatedTypesWithDefaults
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name assoc
+// RUN: %FileCheck %s < %t.swiftinterface
+
+// RUN: %target-swift-frontend -emit-silgen %s -module-name assoc -enable-experimental-feature SuppressedAssociatedTypesWithDefaults -o %t.silgen
+// RUN: %FileCheck --check-prefix=SIL %s < %t.silgen
+
+// REQUIRES: swift_feature_SuppressedAssociatedTypesWithDefaults
+
+// CHECK-LABEL: public protocol P<Element> : ~Copyable {
+// CHECK:          associatedtype Element : ~Copyable
+// CHECK:          associatedtype Iterator : ~Copyable
+public protocol P<Element>: ~Copyable {
+  associatedtype Element: ~Copyable
+  associatedtype Iterator: ~Copyable
+}
+
+public protocol Ordinary<Element> {
+  associatedtype Element
+  associatedtype Iterator
+}
+
+// For ordinary protocols with associated types, we shouldn't emit any Copyable / ~Copyable...
+// CHECK-NOT: Copyable
+public func ordinary<T: Ordinary>(_ t: T) {}
+public struct Thing<T: Ordinary> {}
+
+///////
+// Keep in mind that `Rj` and `RJ` mean inverses for associated types!
+//////
+
+// CHECK: public func ncElement<T>(_ t: T) where T : assoc.P, T.Element : ~Copyable
+// SIL: @$s5assoc9ncElementyyxAA1PRz0C0Rj_zlF :
+public func ncElement<T: P>(_ t: T) where T.Element: ~Copyable {}
+
+// CHECK: public func ncElement_pi<T>(_ t: T) where T : assoc.P, T.Element : ~Copyable
+// SIL: @$s5assoc12ncElement_piyyxAA1PRzlF :
+@_preInverseGenerics
+public func ncElement_pi<T: P>(_ t: T) where T.Element: ~Copyable {}
+
+// CHECK: public func ncIter<T>(_ t: T) where T : assoc.P
+// SIL: @$s5assoc6ncIteryyxAA1PRzlF :
+public func ncIter<T: P>(_ t: T) where T.Iterator: ~Copyable {}
+
+// CHECK: public func ncIter2<T>(_ t: T) where T : assoc.P
+// SIL: @$s5assoc7ncIter2yyxAA1PRzlF :
+public func ncIter2<T: P>(_ t: T) {}
+
+// CHECK: public func ncBoth<T>(_ t: T) where T : assoc.P, T.Element : ~Copyable
+// SIL: @$s5assoc6ncBothyyxAA1PRz7ElementRj_zlF :
+public func ncBoth<T: P>(_ t: T) where T.Iterator: ~Copyable, T.Element: ~Copyable {}
+
+// CHECK: public func bothCopyable<T>(_ t: T) where T : assoc.P, T.Iterator : Swift.Copyable
+// SIL: @$s5assoc12bothCopyableyyxAA1PRzs0C08IteratorRpzlF :
+public func bothCopyable<T: P>(_ t: T) where T.Iterator: Copyable {}
+
+// CHECK-LABEL: public struct Holder<S> where S : assoc.P, S : ~Copyable, S.Element : ~Copyable {
+public struct Holder<S> where S.Element: ~Copyable, S: P & ~Copyable {
+
+// CHECK: public func defaultedElement<T>(_ t: T) where T : assoc.P
+// SIL: @$s5assoc6HolderVAARi_z7ElementRj_zrlE09defaultedC0yyqd__AA1PRd__lF :
+  public func defaultedElement<T>(_ t: T) where T: P {}
+
+// CHECK: public func ncElement<T>(_ t: T) where T : assoc.P, T.Element : ~Copyable
+// SIL: @$s5assoc6HolderVAARi_z7ElementRj_zrlE02ncC0yyqd__AA1PRd__ADRj_d__lF :
+  public func ncElement<T>(_ t: T) where T: P, T.Element: ~Copyable {}
+
+// CHECK: public func copyableIter<T>(_ t: T) where T : assoc.P, T.Iterator : Swift.Copyable
+// SIL: @$s5assoc6HolderVAARi_z7ElementRj_zrlE12copyableIteryyqd__AA1PRd__s8Copyable8IteratorRpd__lF :
+public func copyableIter<T: P>(_ t: T) where T.Iterator: Copyable {}
+}
+
+// CHECK: extension assoc.Holder {
+extension Holder {
+  // SIL: @$s5assoc6HolderV19forceIntoInterface1yyF :
+  public func forceIntoInterface1() {}
+}
+
+// CHECK: extension assoc.Holder where S.Iterator : Swift.Copyable {
+extension Holder where S.Iterator: Copyable {
+  // SIL: @$s5assoc6HolderVAAs8Copyable8IteratorRpzrlE19forceIntoInterface2yyF :
+  public func forceIntoInterface2() {}
+}
+
+// CHECK: extension assoc.P {
+extension P {
+  // SIL: @$s5assoc1PPAAE19forceIntoInterface3yyF :
+  public func forceIntoInterface3() {}
+}
+
+// CHECK: extension assoc.P where Self.Iterator : Swift.Copyable {
+extension P where Iterator: Copyable {
+  // SIL: @$s5assoc1PPAAs8Copyable8IteratorRpzrlE19forceIntoInterface4yyF
+  public func forceIntoInterface4() {}
+}


### PR DESCRIPTION
We weren't emitting swiftinterfaces correctly for SuppressedAssociatedTypesWithDefaults, as the inverses were never getting printed for extensions that suppress the default that's added due to the primary associated type suppression. I believe we also had the mangling and runtime type casting incorrect, or at least, untested for the -WithDefaults version until now.

rdar://169536826