### PR TITLE
Diagnose member type access on opaque types

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6534,6 +6534,9 @@ ERROR(opaque_type_in_parameter,none,
       "'some' cannot appear in parameter position in %select{result|parameter}0"
       " type %1",
       (bool, Type))
+ERROR(opaque_type_member_type,none,
+      "cannot access member type %0 on opaque type %1",
+      (DeclNameRef, Type))
 
 // Function differentiability
 ERROR(attr_only_on_parameters_of_differentiable,none,

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -222,16 +222,6 @@ Type TypeResolution::resolveDependentMemberType(
   if (!genericSig)
     return ErrorType::get(baseTy);
 
-  if (baseTy->is<OpaqueTypeArchetypeType>()) {
-    if (!options.contains(TypeResolutionFlags::SilenceErrors)) {
-      ctx.Diags.diagnose(repr->getNameLoc(),
-                         diag::opaque_type_member_type,
-                         repr->getNameRef(), baseTy)
-          .highlight(baseRange);
-    }
-    return ErrorType::get(ctx);
-  }
-
   // Look for a nested type with the given name.
   if (auto nestedType = genericSig->lookupNestedType(baseTy, refIdentifier)) {
     if (options.isGenericRequirement()) {
@@ -2062,7 +2052,9 @@ static Type resolveQualifiedIdentTypeRepr(const TypeResolution &resolution,
 
   // Short-circuiting.
   if (repr->isInvalid()) return ErrorType::get(ctx);
-  if (parentTy->is<OpaqueTypeArchetypeType>()) {
+  // Reject explicit syntax like `(some P).T`, but allow member type lookup on
+  // opaque archetypes introduced by generic requirements.
+  if (repr->getBase()->hasOpaque()) {
     if (!options.contains(TypeResolutionFlags::SilenceErrors)) {
       diags.diagnose(repr->getNameLoc(),
                      diag::opaque_type_member_type,

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2052,9 +2052,11 @@ static Type resolveQualifiedIdentTypeRepr(const TypeResolution &resolution,
 
   // Short-circuiting.
   if (repr->isInvalid()) return ErrorType::get(ctx);
-  // Reject explicit syntax like `(some P).T`, but allow member type lookup on
-  // opaque archetypes introduced by generic requirements.
-  if (repr->getBase()->hasOpaque()) {
+  // Reject member type access only when the base is explicitly written as an
+  // opaque type, e.g. `(some P).T`.
+  auto *baseRepr = repr->getBase()->getWithoutParens();
+  if (isa<OpaqueReturnTypeRepr>(baseRepr) ||
+      isa<NamedOpaqueReturnTypeRepr>(baseRepr)) {
     if (!options.contains(TypeResolutionFlags::SilenceErrors)) {
       diags.diagnose(repr->getNameLoc(),
                      diag::opaque_type_member_type,

--- a/test/Sema/opaque_member_type.swift
+++ b/test/Sema/opaque_member_type.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+protocol P {
+  associatedtype T
+  var t: T { get }
+}
+
+struct S: P {
+  var t: Int { 23 }
+}
+
+let spt: (some P).T = S().t // expected-error {{cannot access member type}}


### PR DESCRIPTION
This fixes a compiler crash when explicitly annotating a value with (someP).T. Opaque types intentionally hide associated types, so this should be a clean diagnostic. The change adds a targeted check in type resolution and a regression test. Fixes #87039 