### PR TITLE
[CS] Always turn invalid DependentMemberTypes into holes

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1342,6 +1342,9 @@ public:
   /// Retrieve the fixed score of this solution
   Score &getFixedScore() { return FixedScore; }
 
+  /// Whether the solution has any holes.
+  bool hasHoles() const { return FixedScore.Data[SK_Hole] > 0; }
+
   /// Check whether this solution has a fixed binding for the given type
   /// variable.
   bool hasFixedType(TypeVariableType *typeVar) const;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2687,6 +2687,10 @@ assessRequirementFailureImpact(ConstraintSystem &cs, Type requirementType,
     // bump the impact even higher as they cannot conform to protocols at all.
     if (resolvedTy->isAny() || resolvedTy->isAnyObject())
       impact += 4;
+
+    // Metatypes also cannot conform to protocols, so bump their impact.
+    if (resolvedTy->is<AnyMetatypeType>())
+      impact += 4;
   }
 
   // If this requirement is associated with an overload choice let's

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1810,6 +1810,11 @@ static Type replacePlaceholderType(PlaceholderType *placeholder,
     if (!tv)
       return std::nullopt;
 
+    // If we have a concrete fixed type we can use that directly.
+    auto fixedTy = S.getFixedType(tv);
+    if (!fixedTy->isPlaceholder())
+      return ErrorType::get(fixedTy);
+
     auto *gp = getGenericParamForHoleTypeVar(tv, S);
     if (!gp)
       return std::nullopt;

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1348,7 +1348,7 @@ swift::matchWitness(WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
                      .Data[SK_MissingSynthesizableConformance] > 0;
     }();
 
-    if (!solution || !solution->Fixes.empty()) {
+    if (!solution || !solution->Fixes.empty() || solution->hasHoles()) {
       if (!requiresNonSendable)
         return RequirementMatch(witness, MatchKind::TypeConflict,
                                 witnessType);

--- a/test/AssociatedTypeInference/missing_conformance.swift
+++ b/test/AssociatedTypeInference/missing_conformance.swift
@@ -4,20 +4,18 @@
 // in various ways.
 
 protocol LikeSetAlgebra {
-    func onion(_ other: Self) -> Self // expected-note {{protocol requires function 'onion' with type '(X) -> X'}}
-    func indifference(_ other: Self) -> Self // expected-note {{protocol requires function 'indifference' with type '(X) -> X'}}
-
+    func onion(_ other: Self) -> Self
+    func indifference(_ other: Self) -> Self
 }
 protocol LikeOptionSet : LikeSetAlgebra, RawRepresentable {}
 extension LikeOptionSet where RawValue : FixedWidthInteger {
-    func onion(_ other: Self) -> Self { return self } // expected-note {{candidate would match if 'X.RawValue' conformed to 'FixedWidthInteger'}}
-    func indifference(_ other: Self) -> Self { return self } // expected-note {{candidate would match if 'X.RawValue' conformed to 'FixedWidthInteger'}}
+    func onion(_ other: Self) -> Self { return self }
+    func indifference(_ other: Self) -> Self { return self }
 }
 
 struct X : LikeOptionSet {}
-// expected-error@-1 {{type 'X' does not conform to protocol 'LikeSetAlgebra'}}
-// expected-error@-2 {{type 'X' does not conform to protocol 'RawRepresentable'}}
-// expected-note@-3 {{add stubs for conformance}}
+// expected-error@-1 {{type 'X' does not conform to protocol 'RawRepresentable'}}
+// expected-note@-2 {{add stubs for conformance}}
 
 protocol IterProtocol {}
 protocol LikeSequence {

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1570,6 +1570,13 @@ func testNilCoalescingOperatorRemoveFix() {
       ?? "").isEmpty {} // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{-1:9-+0:12=}}
 }
 
+func testMetatypeArgMismatch() {
+  func metatypeGenericOverloaded(_ x: UInt.Type) {}
+  func metatypeGenericOverloaded<T: Equatable>(_ x: T) {}
+  metatypeGenericOverloaded(Int.self)
+  // expected-error@-1 {{cannot convert value of type 'Int.Type' to expected argument type 'UInt.Type'}}
+}
+
 // https://github.com/apple/swift/issues/74617
 struct Foo_74617 {
   public var bar: Float { 123 }

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1129,12 +1129,14 @@ func rdar17170728() {
     // expected-error@-1 4 {{optional type 'Int?' cannot be used as a boolean; test for '!= nil' instead}}
   }
 
-  // FIXME: Bad diagnostic, `Bool.Stride` is bogus, we shouldn't be suggesting
-  // `reduce(into:)`, and the actual problem is that Int cannot be used as a boolean
-  // condition.
+  // FIXME: Bad diagnostic, we shouldn't be suggesting `reduce(into:)`, and the
+  // actual problem is that Int cannot be used as a boolean condition.
   let _ = [i, j, k].reduce(0 as Int?) { // expected-error {{missing argument label 'into:' in call}}
+    // expected-error@-1 {{cannot convert value of type 'Int?' to expected argument type '(inout (Bool, Bool) -> Bool?, Int?) throws -> ()'}}
+    // FIXME: ^ This error is because we don't correctly recover from missing
+    // argument label fixes in certain cases (https://github.com/swiftlang/swift/issues/86472)
     $0 && $1 ? $0 + $1 : ($0 ? $0 : ($1 ? $1 : nil))
-    // expected-error@-1 {{binary operator '+' cannot be applied to operands of type 'Bool.Stride' and 'Bool'}}
+    // expected-error@-1 {{binary operator '+' cannot be applied to two 'Bool' operands}}
   }
 }
 

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -993,13 +993,11 @@ do {
   func foo<T, U>(_: T, _: U) where T: Sequence, U: Sequence, T.Element == U.Element {}
   // expected-note@-1 {{required by local function 'foo' where 'T' = 'Set<Int>.Type'}}
   // expected-note@-2 {{required by local function 'foo' where 'U' = 'Array<String>.Type'}}
-  // expected-note@-3 {{where 'T.Element' = 'Set<Int>.Type.Element', 'U.Element' = 'Array<String>.Type.Element'}}
 
   foo(Set<Int>, Array<String>)
   // expected-error@-1 {{type 'Set<Int>.Type' cannot conform to 'Sequence'}}
   // expected-error@-2 {{type 'Array<String>.Type' cannot conform to 'Sequence'}}
-  // expected-error@-3 {{local function 'foo' requires the types 'Set<Int>.Type.Element' and 'Array<String>.Type.Element' be equivalent}}
-  // expected-note@-4 2 {{only concrete types such as structs, enums and classes can conform to protocols}}
+  // expected-note@-3 2 {{only concrete types such as structs, enums and classes can conform to protocols}}
 }
 
 // https://github.com/apple/swift/issues/56173

--- a/test/Generics/where_clause_contextually_generic_decls.swift
+++ b/test/Generics/where_clause_contextually_generic_decls.swift
@@ -64,7 +64,7 @@ func testProtocolExtensions<T1, T2, T3, T4>(t1: T1, t2: T2, t3: T3, t4: T4)
 }
 
 class Class<T> {
-  // expected-note@+1 {{where 'T' = 'T}} // expected-note@+1 {{where 'T.Assoc' = 'T.Assoc'}}
+  // expected-note@+1 {{where 'T' = 'T}}
   static func staticFunc() where T: Whereable, T.Assoc == Int { }
 
   // expected-note@+1 {{candidate requires that the types 'T' and 'Bool' be equivalent}}
@@ -101,7 +101,6 @@ extension Class where T == Bool {
 }
 
 func testMemberDeclarations<T, U: Comparable>(arg1: Class<T>, arg2: Class<U>) {
-  // expected-error@+2 {{static method 'staticFunc()' requires the types 'T.Assoc' and 'Int' be equivalent}}
   // expected-error@+1 {{static method 'staticFunc()' requires that 'T' conform to 'Whereable'}}
   Class<T>.staticFunc()
   Class<T>.staticExtensionFunc() // expected-error {{static method 'staticExtensionFunc()' requires that 'T' inherit from 'Class<Int>'}}

--- a/test/Interop/Cxx/class/conforms-to-missing-associated-type.swift
+++ b/test/Interop/Cxx/class/conforms-to-missing-associated-type.swift
@@ -27,5 +27,5 @@ extension P {
   func foo(_: A) {}
 }
 func test(x : S) {
-    x.foo(0) // expected-error{{cannot convert value of type 'Int' to expected argument type 'S.A'}}
+    x.foo(0)
 }

--- a/test/Parse/inverses.swift
+++ b/test/Parse/inverses.swift
@@ -123,9 +123,7 @@ func typeInExpression() {
 
   _ = X<(borrowing any ~Copyable) -> Void>()
 
-  _ = ~Copyable.self // expected-error{{type '(any Copyable).Type' cannot conform to 'BinaryInteger'}}
-  // expected-note@-1{{required by referencing operator function '~' on 'BinaryInteger' where 'Self' = '(any Copyable).Type'}}
-  // expected-note@-2 {{only concrete types such as structs, enums and classes can conform to protocols}}
+  _ = ~Copyable.self // expected-error{{unary operator '~' cannot be applied to an operand of type '(any Copyable).Type'}}
   _ = (any ~Copyable).self
 }
 

--- a/test/decl/protocol/existential_member_access/concrete.swift
+++ b/test/decl/protocol/existential_member_access/concrete.swift
@@ -163,10 +163,8 @@ protocol CompositionBrokenClassConformance_b: CompositionBrokenClassConformance_
   func method(_: A)
 }
 do {
-  // FIXME: Should GenericSignature::getConcreteType return the null type instead
-  // of the error type here for Self.A, despite the broken conformance?
   let exist: any CompositionBrokenClassConformance_b & BadConformanceClass
-  exist.method(false) // expected-error {{failed to produce diagnostic for expression}}
+  exist.method(false)
 }
 
 // https://github.com/swiftlang/swift/issues/65533

--- a/test/decl/protocol/existential_member_access/constraint_failure.swift
+++ b/test/decl/protocol/existential_member_access/constraint_failure.swift
@@ -41,8 +41,7 @@ do {
 
   exist.method1() // expected-error {{instance method 'method1()' requires that 'Self.A' inherit from 'Class<Self>'}}
   exist.method2()
-  // expected-error@-1 {{instance method 'method2()' requires the types 'Self' and 'Self.A.Element' be equivalent}}
-  // expected-error@-2 {{instance method 'method2()' requires that 'Self.A' conform to 'Sequence'}}
+  // expected-error@-1 {{instance method 'method2()' requires that 'Self.A' conform to 'Sequence'}}
   _ = exist.method3(false) // ok
   exist.method4(false)
   // expected-error@-1 {{instance method 'method4' requires that 'Bool' inherit from 'Class<Self.A>'}}
@@ -89,9 +88,8 @@ do {
   let exist2: any UnfulfillableGenericRequirementsDerived3
 
   exist1.method6(false)
-  // expected-error@-1 {{instance method 'method6' requires that 'Self.A.Element' conform to 'Sequence'}}
-  // expected-error@-2 {{instance method 'method6' requires that 'Self.A' conform to 'Sequence'}}
-  // expected-error@-3 {{instance method 'method6' requires that 'Bool' conform to 'UnfulfillableGenericRequirements'}}
+  // expected-error@-1 {{instance method 'method6' requires that 'Self.A' conform to 'Sequence'}}
+  // expected-error@-2 {{instance method 'method6' requires that 'Bool' conform to 'UnfulfillableGenericRequirements'}}
   exist2.method6(false)
   // expected-error@-1 {{member 'method6' cannot be used on value of type 'any UnfulfillableGenericRequirementsDerived3'; consider using a generic constraint instead}}
   // expected-error@-2 {{instance method 'method6' requires that 'Bool' conform to 'UnfulfillableGenericRequirements'}}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -748,8 +748,8 @@ func invalidDictionaryLiteral() {
 
 
 [4].joined(separator: [1])
-// expected-error@-1 {{no exact matches in call to instance method 'joined'}}
-// There is one more note here - candidate requires that 'Int' conform to 'Sequence' (requirement specified as 'Self.Element' : 'Sequence') pointing to Sequence extension
+// expected-error@-1:2 {{cannot convert value of type 'Int' to expected element type 'String'}}
+// expected-error@-2:23 {{cannot convert value of type '[Int]' to expected argument type 'String'}}
 
 [4].joined(separator: [[[1]]])
 // expected-error@-1 {{cannot convert value of type 'Int' to expected element type 'String'}}

--- a/validation-test/IDE/crashers_fixed/DependentMemberType-get-af29e9.swift
+++ b/validation-test/IDE/crashers_fixed/DependentMemberType-get-af29e9.swift
@@ -1,0 +1,9 @@
+// {"kind":"complete","original":"7ab2abac","signature":"swift::DependentMemberType::get(swift::Type, swift::AssociatedTypeDecl*)"}
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+protocol a {
+  associatedtype b
+}
+extension Sequence where Element: a {
+c -> [Element.b]
+{
+  .c(#^^#

--- a/validation-test/IDE/crashers_fixed/DependentMemberType-get-fa652e.swift
+++ b/validation-test/IDE/crashers_fixed/DependentMemberType-get-fa652e.swift
@@ -1,0 +1,4 @@
+// {"kind":"complete","original":"4249eb4f","signature":"swift::DependentMemberType::get(swift::Type, swift::AssociatedTypeDecl*)"}
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+protocol a { associatedtype b }
+struct c func d<e: Collection>(e, e.Element.b ) where e.Element: a func bar(arr: c) { d(arr) #^^#

--- a/validation-test/IDE/crashers_fixed/NormalProtocolConformance-setWitness-2174e8.swift
+++ b/validation-test/IDE/crashers_fixed/NormalProtocolConformance-setWitness-2174e8.swift
@@ -1,0 +1,5 @@
+// {"kind":"complete","original":"26141d06","signature":"swift::NormalProtocolConformance::setWitness(swift::ValueDecl*, swift::Witness) const","signatureAssert":"Assertion failed: ((!isComplete() || isInvalid() || (dyn_cast<FuncDecl>(requirement) ? (dyn_cast<FuncDecl>(requirement)->isDistributed() || dyn_cast<FuncDecl>(requirement)->isDistributedThunk()) : false) || requirement->getAttrs().hasAttribute<OptionalAttr>() || requirement->isUnavailable()) && \"Conformance already complete?\"), function setWitness"}
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+class a: OptionSet {
+  #^^#
+}

--- a/validation-test/compiler_crashers_fixed/ConstraintSystem-applySolution-516c1e.swift
+++ b/validation-test/compiler_crashers_fixed/ConstraintSystem-applySolution-516c1e.swift
@@ -1,0 +1,8 @@
+// {"kind":"typecheck","original":"27457093","signature":"swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::constraints::SyntacticElementTarget)","signatureAssert":"Assertion failed: (isValidType(type) && \"type binding has invalid type\"), function applySolution"}
+// RUN: not %target-swift-frontend -typecheck %s
+struct a: RangeReplaceableCollection {
+  var b = {
+    max
+    RangeReplaceableCollection
+  }
+}

--- a/validation-test/compiler_crashers_fixed/ConstraintSystem-applySolution-c6953c.swift
+++ b/validation-test/compiler_crashers_fixed/ConstraintSystem-applySolution-c6953c.swift
@@ -1,0 +1,15 @@
+// {"kind":"typecheck","original":"04310d73","signature":"swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::constraints::SyntacticElementTarget)","signatureAssert":"Assertion failed: (isValidType(type) && \"type binding has invalid type\"), function applySolution"}
+// RUN: not %target-swift-frontend -typecheck %s
+protocol a {
+  typealias b
+}
+protocol c: a
+  struct d<e: a {
+    f : e.b    let elements: e
+  }
+  protocol g: c
+    struct h: g {
+i {
+  d(f: i
+  elements
+: self

--- a/validation-test/compiler_crashers_fixed/NormalProtocolConformance-setWitness-097a17.swift
+++ b/validation-test/compiler_crashers_fixed/NormalProtocolConformance-setWitness-097a17.swift
@@ -1,0 +1,4 @@
+// {"kind":"typecheck","original":"00ecd163","signature":"swift::NormalProtocolConformance::setWitness(swift::ValueDecl*, swift::Witness) const","signatureAssert":"Assertion failed: ((!isComplete() || isInvalid() || (dyn_cast<FuncDecl>(requirement) ? (dyn_cast<FuncDecl>(requirement)->isDistributed() || dyn_cast<FuncDecl>(requirement)->isDistributedThunk()) : false) || requirement->getAttrs().hasAttribute<OptionalAttr>() || requirement->isUnavailable()) && \"Conformance already complete?\"), function setWitness"}
+// RUN: not %target-swift-frontend -typecheck %s
+struct a: OptionSet
+  let b  !a(

--- a/validation-test/compiler_crashers_fixed/TypeTransform-doIt-b7d484.swift
+++ b/validation-test/compiler_crashers_fixed/TypeTransform-doIt-b7d484.swift
@@ -1,3 +1,3 @@
 // {"kind":"typecheck","signature":"swift::TypeTransform<swift::Type::transformRec(llvm::function_ref<std::__1::optional<swift::Type> (swift::TypeBase*)>) const::Transform>::doIt(swift::Type, swift::TypePosition)","signatureAssert":"Assertion failed: (!ty->is<InOutType>() && \"Cannot have InOutType in a tuple\"), function TupleTypeElt"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 [Int : Int](Int) { a, b in a[b b= b * b


### PR DESCRIPTION
Ensure we don't ever form DependentMemberTypes with concrete base types in cases where we're unable to lookup a valid witness. Instead, these DependentMemberTypes become holes. Plus a few changes required to avoid regressing diagnostics.

I'm planning on adding an assert to `DependentMemberType::get` to enforce that we no longer form any with a concrete base, but I'd like to run that on the fuzzer for a bit first.