### PR TITLE
[android] Fix CI for recent trunk pulls

### DIFF
--- a/stdlib/public/runtime/Backtrace.cpp
+++ b/stdlib/public/runtime/Backtrace.cpp
@@ -1340,9 +1340,8 @@ _swift_spawnBacktracer(CrashInfo *crashInfo)
   #ifdef _WIN32
   _swift_formatUnsigned(GetCurrentProcessId(), pid_buf);
   #endif
-#endif
 
-#if TARGET_OS_OSX || TARGET_OS_MACCATALYST || defined(__linux__)
+  #if TARGET_OS_OSX || TARGET_OS_MACCATALYST || defined(__linux__)
   // Set-up the environment array
   const char *env[BACKTRACE_MAX_ENV_VARS + 1];
 
@@ -1358,16 +1357,16 @@ _swift_spawnBacktracer(CrashInfo *crashInfo)
 
   // SUSv3 says argv and envp are "completely constant" and that the reason
   // posix_spawn() et al use char * const * is for compatibility.
-#ifdef __linux__
+  #ifdef __linux__
   int ret = safe_spawn(&child, swiftBacktracePath, memserver_fd,
                        const_cast<char * const *>(backtracer_argv),
                        const_cast<char * const *>(env));
-#else
+  #else
   int ret = posix_spawn(&child, swiftBacktracePath,
                         nullptr, nullptr,
                         const_cast<char * const *>(backtracer_argv),
                         const_cast<char * const *>(env));
-#endif
+  #endif
   if (ret < 0)
     return false;
 
@@ -1382,7 +1381,7 @@ _swift_spawnBacktracer(CrashInfo *crashInfo)
 
   return false;
 
-#elif defined(_WIN32)
+  #elif defined(_WIN32)
   HANDLE hOutput;
   if (_swift_backtraceSettings.outputTo == OutputTo::Stderr)
     hOutput = GetStdHandle(STD_ERROR_HANDLE);
@@ -1461,6 +1460,7 @@ _swift_spawnBacktracer(CrashInfo *crashInfo)
 
   CloseHandle(processInfo.hProcess);
   return dwExitCode == 0;
+  #endif
 #endif
 }
 

--- a/test/Interop/Cxx/class/access/using-non-public-module-interface.swift
+++ b/test/Interop/Cxx/class/access/using-non-public-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=UsingNonPublic -print-access -I %S/Inputs -source-filename=x -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers | tee %s.out | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=UsingNonPublic -print-access -I %S/Inputs -source-filename=x -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers | %FileCheck %s
 // REQUIRES: swift_feature_ImportNonPublicCxxMembers
 
 // CHECK:      public struct PublUser {


### PR DESCRIPTION
@j-hui, you just added this in #87026, likely for your own local testing, but [it fails on the Android CI](https://ci.swift.org/job/oss-swift-package-swift-sdk-for-android/243/console). I see that most tests don't use `tee` for this reason.

Let me know if this is okay, but don't merge, as the Android CI was already broken with another issue, so I think I'll need to add another commit for that too.