### PR TITLE
Replace `vfs::getRealFileSystem` -> `vfs::createPhysicalFileSystem`

### DIFF
--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -207,8 +207,8 @@ private:
 
 public:
   SourceManager(llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS =
-                    llvm::vfs::getRealFileSystem())
-    : FileSystem(FS) {}
+                    llvm::vfs::createPhysicalFileSystem())
+      : FileSystem(FS) {}
   ~SourceManager();
 
   llvm::SourceMgr &getLLVMSourceMgr() {

--- a/lib/AST/PluginLoader.cpp
+++ b/lib/AST/PluginLoader.cpp
@@ -67,7 +67,7 @@ getPluginLoadingFS(ASTContext &Ctx) {
   // If there is an immutable file system, using real file system to load plugin
   // as the FS in SourceMgr doesn't support directory iterator.
   if (Ctx.CASOpts.HasImmutableFileSystem)
-    return llvm::vfs::getRealFileSystem();
+    return llvm::vfs::createPhysicalFileSystem();
   return Ctx.SourceMgr.getFileSystem();
 }
 

--- a/lib/ClangImporter/ClangIncludePaths.cpp
+++ b/lib/ClangImporter/ClangIncludePaths.cpp
@@ -112,7 +112,7 @@ swift::getCxxShimModuleMapPath(SearchPathOptions &opts,
                                const llvm::Triple &triple) {
   return getActualModuleMapPath("libcxxshim.modulemap", opts, langOpts, triple,
                                 /*isArchSpecific*/ false,
-                                llvm::vfs::getRealFileSystem());
+                                llvm::vfs::createPhysicalFileSystem());
 }
 
 static llvm::opt::InputArgList
@@ -129,7 +129,7 @@ ClangImporter::createClangDriver(
     const LangOptions &LangOpts, const ClangImporterOptions &ClangImporterOpts,
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs) {
 
-  auto diagVFS = vfs ? vfs : llvm::vfs::getRealFileSystem();
+  auto diagVFS = vfs ? vfs : llvm::vfs::createPhysicalFileSystem();
 
   auto diagOpts = std::make_unique<clang::DiagnosticOptions>();
   auto *silentDiagConsumer = new clang::DiagnosticConsumer();
@@ -618,7 +618,7 @@ ClangInvocationFileMapping swift::getClangInvocationFileMapping(
     bool suppressDiagnostic) {
   ClangInvocationFileMapping result;
   if (!vfs)
-    vfs = llvm::vfs::getRealFileSystem();
+    vfs = llvm::vfs::createPhysicalFileSystem();
 
   const llvm::Triple &triple = ctx.LangOpts.Target;
   llvm::SmallString<256> sysroot;

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -1023,7 +1023,7 @@ toolchains::Darwin::validateOutputInfo(DiagnosticEngine &diags,
   // If we have been provided with an SDK, go read the SDK information.
   if (!outputInfo.SDKPath.empty()) {
     auto SDKInfoOrErr = clang::parseDarwinSDKInfo(
-        *llvm::vfs::getRealFileSystem(), outputInfo.SDKPath);
+        *llvm::vfs::createPhysicalFileSystem(), outputInfo.SDKPath);
     if (SDKInfoOrErr) {
       SDKInfo = *SDKInfoOrErr;
     } else {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -4354,8 +4354,8 @@ bool CompilerInvocation::parseArgs(
                         SearchPathOpts.RuntimeResourcePath, ParsedArgs, Diags)) {
     return true;
   }
-  
-  SDKInfo = parseSDKSettings(*llvm::vfs::getRealFileSystem(), LangOpts,
+
+  SDKInfo = parseSDKSettings(*llvm::vfs::createPhysicalFileSystem(), LangOpts,
                              SearchPathOpts, Diags);
 
   updateRuntimeLibraryPaths(SearchPathOpts, FrontendOpts, LangOpts, SDKInfo);

--- a/lib/IDETool/CompilerInvocation.cpp
+++ b/lib/IDETool/CompilerInvocation.cpp
@@ -269,7 +269,8 @@ bool ide::initCompilerInvocation(
 bool ide::initInvocationByClangArguments(ArrayRef<const char *> ArgList,
                                          CompilerInvocation &Invok,
                                          std::string &Error) {
-  const auto VFS = llvm::vfs::getRealFileSystem();
+  const llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS =
+      llvm::vfs::createPhysicalFileSystem();
 
   clang::TextDiagnosticBuffer DiagBuf;
   clang::DiagnosticOptions DiagOpts;

--- a/lib/IDETool/CompilerInvocation.cpp
+++ b/lib/IDETool/CompilerInvocation.cpp
@@ -87,8 +87,10 @@ static FrontendInputsAndOutputs resolveSymbolicLinksInInputs(
   assert(FileSystem);
 
   llvm::SmallString<128> PrimaryFile;
-  if (auto err = FileSystem->getRealPath(UnresolvedPrimaryFile, PrimaryFile))
-    PrimaryFile = UnresolvedPrimaryFile;
+  if (!UnresolvedPrimaryFile.empty()) {
+    if (auto err = FileSystem->getRealPath(UnresolvedPrimaryFile, PrimaryFile))
+      PrimaryFile = UnresolvedPrimaryFile;
+  }
 
   unsigned primaryCount = 0;
   // FIXME: The frontend should be dealing with symlinks, maybe similar to

--- a/lib/IDETool/IDEInspectionInstance.cpp
+++ b/lib/IDETool/IDEInspectionInstance.cpp
@@ -506,8 +506,7 @@ void IDEInspectionInstance::performNewOperation(
         CI->removeDiagnosticConsumer(DiagC);
     };
 
-    if (FileSystem != llvm::vfs::getRealFileSystem())
-      CI->getSourceMgr().setFileSystem(FileSystem);
+    CI->getSourceMgr().setFileSystem(FileSystem);
 
     Invocation.setIDEInspectionTarget(ideInspectionTargetBuffer, Offset);
 

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -256,7 +256,7 @@ static std::optional<PGOOptions> buildIRUseOptions(const IRGenOptions &Opts,
   if (Opts.UseIRProfile.empty())
     return std::nullopt;
 
-  auto FS = llvm::vfs::getRealFileSystem();
+  auto FS = llvm::vfs::createPhysicalFileSystem();
   std::unique_ptr<llvm::IndexedInstrProfReader> Reader =
       getProfileReader(Opts.UseIRProfile.c_str(), *FS, Diags);
   if (!Reader)

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -66,7 +66,7 @@ SILGenModule::SILGenModule(SILModule &M, ModuleDecl *SM)
   if (!Opts.UseProfile.empty()) {
     // FIXME: Create file system to read the profile. In the future, the vfs
     // needs to come from CompilerInstance.
-    auto FS = llvm::vfs::getRealFileSystem();
+    auto FS = llvm::vfs::createPhysicalFileSystem();
     auto ReaderOrErr =
         llvm::IndexedInstrProfReader::create(Opts.UseProfile, *FS);
     if (auto E = ReaderOrErr.takeError()) {

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -285,7 +285,7 @@ initializePlugin(ASTContext &ctx, CompilerPlugin *plugin, StringRef libraryPath,
 #if SWIFT_BUILD_SWIFT_SYNTAX
     llvm::SmallString<128> resolvedLibraryPath;
     auto fs = ctx.CASOpts.HasImmutableFileSystem
-                  ? llvm::vfs::getRealFileSystem()
+                  ? llvm::vfs::createPhysicalFileSystem()
                   : ctx.SourceMgr.getFileSystem();
     if (auto err = fs->getRealPath(libraryPath, resolvedLibraryPath)) {
       return llvm::createStringError(err, err.message());

--- a/test/SourceKit/Misc/no-change-working-dir.swift
+++ b/test/SourceKit/Misc/no-change-working-dir.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+
+// Make sure that specifying '-working-directory' does not actually cause the
+// working directory of the process to be affected.
+
+// RUN: %sourcekitd-test -req=open -print-raw-response %s -- %s -working-directory %t > /dev/null
+// RUN: %sourcekitd-test \
+// RUN:   -req=open -req-opts=syntactic_only=1 -print-raw-response %s -- %s -working-directory %t == \
+// RUN:   -req=edit -offset=0 -length=1 -replace="//" %s == \
+// RUN:   -req=semantic-tokens %s -- %s -working-directory %t
+
+// RUN: %sourcekitd-test -req=collect-var-type %s -- %s -working-directory %t
+// RUN: %sourcekitd-test -req=collect-type %s -- %s -working-directory %t
+// RUN: %sourcekitd-test -req=refactoring.extract.expr -pos=1:1 -end-pos 1:1 %s -- %s -working-directory %t
+// RUN: %sourcekitd-test -req=active-regions %s -- %s -working-directory %t
+// RUN: %sourcekitd-test -req=related-idents -pos=1:1 %s -- %s -working-directory %t
+// RUN: %sourcekitd-test -req=range -pos=1:1 -length 1 %s -- %s -working-directory %t
+// RUN: %sourcekitd-test -req=translate -pos=1:1 -swift-name foo %s -- %s -working-directory %t
+// RUN: %sourcekitd-test -req=interface-gen %s -- %s -working-directory %t
+
+func foo(x: Int) {}
+// RUN: %sourcekitd-test -req=find-local-rename-ranges -pos=%(line-1):10 %s -- %s -working-directory %t
+
+// RUN: %sourcekitd-test -req=doc-info -module Swift -- -working-directory %t > /dev/null
+// RUN: %sourcekitd-test -req=cursor -pos=1:1 %s -- %s -working-directory %t > /dev/null

--- a/test/SourceKit/Misc/no-driver-outputs.swift
+++ b/test/SourceKit/Misc/no-driver-outputs.swift
@@ -25,3 +25,7 @@
 // RUN: %empty-directory(%t)
 // RUN: env TMPDIR=%t __XPC_TMPDIR=%t %sourcekitd-test -req=sema %s -- %s -emit-module -module-name main -emit-module-path %t/main.swiftmodule -emit-executable -o %t/foo
 // RUN: ls %t/ | count 0
+
+// RUN: %empty-directory(%t)
+// RUN: env TMP=%t TMPDIR=%t __XPC_TMPDIR=%t %sourcekitd-test -req=open %s -- %s -driver-force-response-files
+// RUN: ls %t/ | count 0

--- a/test/SourceKit/Misc/rdar98880399.swift
+++ b/test/SourceKit/Misc/rdar98880399.swift
@@ -1,4 +1,0 @@
-// Make sure we don't create any temporary files.
-// RUN: %empty-directory(%t)
-// RUN: env TMP=%t TMPDIR=%t %sourcekitd-test -req=open %s -- %s -driver-force-response-files
-// RUN: not ls %t/* >/dev/null 2>&1

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -1146,10 +1146,7 @@ ASTUnitRef ASTBuildOperation::buildASTUnit(std::string &Error) {
       Invocation, convertFileContentsToInputs(getFileContents()));
 
   Invocation.getLangOptions().CollectParsedToken = true;
-
-  if (FileSystem != llvm::vfs::getRealFileSystem()) {
-    CompIns.getSourceMgr().setFileSystem(FileSystem);
-  }
+  CompIns.getSourceMgr().setFileSystem(FileSystem);
 
   if (CompIns.setup(Invocation, Error)) {
     LOG_WARN_FUNC("Compilation setup failed!!!");

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -696,7 +696,7 @@ bool SwiftASTManager::initCompilerInvocation(
     StringRef UnresolvedPrimaryFile, std::string &Error) {
   return initCompilerInvocation(Invocation, OrigArgs, Action, Diags,
                                 UnresolvedPrimaryFile,
-                                llvm::vfs::getRealFileSystem(), Error);
+                                llvm::vfs::createPhysicalFileSystem(), Error);
 }
 
 bool SwiftASTManager::initCompilerInvocation(
@@ -747,7 +747,7 @@ SwiftASTManager::getTypecheckInvocation(ArrayRef<const char *> OrigArgs,
                                         StringRef PrimaryFile,
                                         std::string &Error) {
   return getTypecheckInvocation(OrigArgs, PrimaryFile,
-                                llvm::vfs::getRealFileSystem(), Error);
+                                llvm::vfs::createPhysicalFileSystem(), Error);
 }
 
 SwiftInvocationRef SwiftASTManager::getTypecheckInvocation(

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -1499,7 +1499,7 @@ void SwiftLangSupport::findLocalRenameRanges(
   static const char OncePerASTToken = 0;
   const void *Once = CancelOnSubsequentRequest ? &OncePerASTToken : nullptr;
   getASTManager()->processASTAsync(Invok, ASTConsumer, Once, CancellationToken,
-                                   llvm::vfs::getRealFileSystem());
+                                   llvm::vfs::createPhysicalFileSystem());
 }
 
 SourceFile *SwiftLangSupport::getSyntacticSourceFile(

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -2216,7 +2216,7 @@ llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>
 SwiftEditorDocument::getFileSystem() const {
   llvm::sys::ScopedLock L(Impl.AccessMtx);
   return Impl.SemanticInfo ? Impl.SemanticInfo->getFileSystem()
-                           : llvm::vfs::getRealFileSystem();
+                           : llvm::vfs::createPhysicalFileSystem();
 }
 
 void SwiftEditorDocument::formatText(unsigned Line, unsigned Length,

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -850,7 +850,7 @@ void SwiftLangSupport::editorOpenSwiftSourceInterface(
   const void *Once = CancelOnSubsequentRequest ? &OncePerASTToken : nullptr;
   getASTManager()->processASTAsync(Invocation, AstConsumer, Once,
                                    CancellationToken,
-                                   llvm::vfs::getRealFileSystem());
+                                   llvm::vfs::createPhysicalFileSystem());
 }
 
 void SwiftLangSupport::editorOpenHeaderInterface(EditorConsumer &Consumer,

--- a/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
@@ -248,8 +248,8 @@ void SwiftLangSupport::indexSource(StringRef InputFile,
                                    IndexingConsumer &IdxConsumer,
                                    ArrayRef<const char *> OrigArgs) {
   std::string Error;
-  auto InputBuf =
-      ASTMgr->getMemoryBuffer(InputFile, llvm::vfs::getRealFileSystem(), Error);
+  auto InputBuf = ASTMgr->getMemoryBuffer(
+      InputFile, llvm::vfs::createPhysicalFileSystem(), Error);
   if (!InputBuf) {
     IdxConsumer.failed(Error);
     return;
@@ -413,5 +413,5 @@ void SwiftLangSupport::indexToStore(
   getASTManager()->processASTAsync(Invok, ASTConsumer,
                                    /*OncePerASTToken=*/nullptr,
                                    CancellationToken,
-                                   llvm::vfs::getRealFileSystem());
+                                   llvm::vfs::createPhysicalFileSystem());
 }

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -259,7 +259,8 @@ class InMemoryFileSystemProvider: public SourceKit::FileSystemProvider {
       return nullptr;
 
     auto OverlayFS = llvm::IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem>(
-        new llvm::vfs::OverlayFileSystem(llvm::vfs::getRealFileSystem()));
+        new llvm::vfs::OverlayFileSystem(
+            llvm::vfs::createPhysicalFileSystem()));
     OverlayFS->pushOverlay(std::move(InMemoryFS));
     return OverlayFS;
   }
@@ -1049,7 +1050,7 @@ SwiftLangSupport::getFileSystem(const std::optional<VFSOptions> &vfsOptions,
   }
 
   // Fallback to the real filesystem.
-  return llvm::vfs::getRealFileSystem();
+  return llvm::vfs::createPhysicalFileSystem();
 }
 
 void SwiftLangSupport::performWithParamsToCompletionLikeOperation(

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -1982,7 +1982,7 @@ static void resolveName(
 
   Lang.getASTManager()->processASTAsync(
       Invok, std::move(Consumer), /*OncePerASTToken=*/nullptr,
-      CancellationToken, llvm::vfs::getRealFileSystem());
+      CancellationToken, llvm::vfs::createPhysicalFileSystem());
 }
 
 static void
@@ -2088,7 +2088,7 @@ resolveRange(SwiftLangSupport &Lang, StringRef PrimaryFilePath,
   const void *Once = CancelOnSubsequentRequest ? &OncePerASTToken : nullptr;
   Lang.getASTManager()->processASTAsync(Invok, std::move(Consumer), Once,
                                         CancellationToken,
-                                        llvm::vfs::getRealFileSystem());
+                                        llvm::vfs::createPhysicalFileSystem());
 }
 
 static void deliverCursorInfoResults(
@@ -2725,7 +2725,7 @@ void SwiftLangSupport::findRelatedIdentifiersInFile(
   static const char OncePerASTToken = 0;
   const void *Once = CancelOnSubsequentRequest ? &OncePerASTToken : nullptr;
   ASTMgr->processASTAsync(Invok, std::move(Consumer), Once, CancellationToken,
-                          llvm::vfs::getRealFileSystem());
+                          llvm::vfs::createPhysicalFileSystem());
 }
 
 //===----------------------------------------------------------------------===//
@@ -2805,7 +2805,7 @@ void SwiftLangSupport::findActiveRegionsInFile(
       std::make_shared<IfConfigConsumer>(InputBufferName, Receiver, Invok);
   ASTMgr->processASTAsync(Invok, std::move(Consumer),
                           /*OncePerASTToken=*/nullptr, CancellationToken,
-                          llvm::vfs::getRealFileSystem());
+                          llvm::vfs::createPhysicalFileSystem());
 }
 
 //===----------------------------------------------------------------------===//
@@ -2885,7 +2885,7 @@ void SwiftLangSupport::semanticRefactoring(
   const void *Once = CancelOnSubsequentRequest ? &OncePerASTToken : nullptr;
   getASTManager()->processASTAsync(Invok, std::move(Consumer), Once,
                                    CancellationToken,
-                                   llvm::vfs::getRealFileSystem());
+                                   llvm::vfs::createPhysicalFileSystem());
 }
 
 void SwiftLangSupport::collectExpressionTypes(
@@ -2960,7 +2960,7 @@ void SwiftLangSupport::collectExpressionTypes(
   static const char OncePerASTToken = 0;
   getASTManager()->processASTAsync(Invok, std::move(Collector),
                                    &OncePerASTToken, CancellationToken,
-                                   llvm::vfs::getRealFileSystem());
+                                   llvm::vfs::createPhysicalFileSystem());
 }
 
 void SwiftLangSupport::collectVariableTypes(
@@ -3050,5 +3050,5 @@ void SwiftLangSupport::collectVariableTypes(
   const void *Once = CancelOnSubsequentRequest ? &OncePerASTToken : nullptr;
   getASTManager()->processASTAsync(Invok, std::move(Collector), Once,
                                    CancellationToken,
-                                   llvm::vfs::getRealFileSystem());
+                                   llvm::vfs::createPhysicalFileSystem());
 }

--- a/tools/SourceKit/tools/sourcekitd/bin/InProc/CodeCompletionSwiftInterop.cpp
+++ b/tools/SourceKit/tools/sourcekitd/bin/InProc/CodeCompletionSwiftInterop.cpp
@@ -108,7 +108,7 @@ public:
 
   FileSystemRef createFileSystem() {
     auto *overlayFS =
-        new llvm::vfs::OverlayFileSystem(llvm::vfs::getRealFileSystem());
+        new llvm::vfs::OverlayFileSystem(llvm::vfs::createPhysicalFileSystem());
     overlayFS->pushOverlay(new SharedStringInMemoryFS(modifiedFiles));
     return overlayFS;
   }

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1169,7 +1169,7 @@ static bool performWithCompletionLikeOperationParams(
 
   CompletionLikeOperationParams Params{Invocation,
                                        /*Args=*/{},
-                                       llvm::vfs::getRealFileSystem(),
+                                       llvm::vfs::createPhysicalFileSystem(),
                                        CompletionBuffer.get(),
                                        Offset,
                                        CodeCompletionDiagnostics ? &PrintDiags
@@ -1709,7 +1709,8 @@ static int doBatchCodeCompletion(const CompilerInvocation &InitInvok,
   }
 
   CompilerInvocation Invocation(InitInvok);
-  auto FileSystem = llvm::vfs::getRealFileSystem();
+  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem =
+      llvm::vfs::createPhysicalFileSystem();
 
   IDEInspectionInstance IDEInspectionInst(std::make_shared<PluginRegistry>());
 

--- a/unittests/Basic/FileSystemTest.cpp
+++ b/unittests/Basic/FileSystemTest.cpp
@@ -34,7 +34,7 @@ using namespace swift;
 namespace {
 
 std::string getFileContents(llvm::StringRef path) {
-  auto fs = llvm::vfs::getRealFileSystem();
+  auto fs = llvm::vfs::createPhysicalFileSystem();
   auto file = fs->openFileForRead(path);
   if (!file)
     return "";

--- a/unittests/ClangImporter/ClangImporterTests.cpp
+++ b/unittests/ClangImporter/ClangImporterTests.cpp
@@ -108,7 +108,7 @@ static StringRef getLibstdcxxModulemapContents() {
     llvm::sys::path::remove_filename(libstdcxxModuleMapPath);
     llvm::sys::path::append(libstdcxxModuleMapPath, "libstdcxx.modulemap");
 
-    auto fs = llvm::vfs::getRealFileSystem();
+    auto fs = llvm::vfs::createPhysicalFileSystem();
     auto file = fs->openFileForRead(libstdcxxModuleMapPath);
     if (!file)
       return "";


### PR DESCRIPTION
Calling `setCurrentWorkingDirectory` on `getRealFileSystem` (which we now do with #86991) sets the working directory for the process itself. This is unsafe for clients such as SourceKit which can process multiple concurrent requests, and may be used as an in-process library in e.g sourcekit-lsp. Switch to `createPhysicalFileSystem` instead, where setting the working directory is done locally on the `FileSystem` itself.