### PR TITLE
[Concurrency]: Make AsyncStream cancellation more atomic

### DIFF
--- a/stdlib/public/Concurrency/AsyncStream.swift
+++ b/stdlib/public/Concurrency/AsyncStream.swift
@@ -203,7 +203,7 @@ public struct AsyncStream<Element> {
     /// finish, the stream enters a terminal state and doesn't produce any
     /// additional elements.
     public func finish() {
-      storage.finish()
+      storage.terminate(reason: .finished)
     }
 
     /// A callback to invoke when canceling iteration of an asynchronous

--- a/stdlib/public/Concurrency/AsyncThrowingStream.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingStream.swift
@@ -227,7 +227,7 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
     /// finish, the stream enters a terminal state and doesn't produce any additional
     /// elements.
     public func finish(throwing error: __owned Failure? = nil) {
-      storage.finish(throwing: error)
+      storage.terminate(reason: .finished(error))
     }
 
     /// A callback to invoke when canceling iteration of an asynchronous
@@ -469,7 +469,7 @@ extension AsyncThrowingStream.Continuation {
     case .success(let val):
       return storage.yield(val)
     case .failure(let err):
-      storage.finish(throwing: err)
+      storage.terminate(reason: .finished(err))
       return .terminated
     }
   }


### PR DESCRIPTION
The existing behavior of stream termination due to cancellation required
taking the stream's internal lock twice, and allowed the `onTermination`
handler to be invoked before updating the internal state to record that
a terminal state was reached. This changes the logic to more closely
match the behavior of the `finish()` implementation so that the lock is
only acquired once, and the appropriate state transitions occur before
calling out to the callback.