### PR TITLE
Basic support for closures with lifetime dependencies

### DIFF
--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -2956,6 +2956,13 @@ static CanSILFunctionType getSILFunctionType(
   auto lowerLifetimeDependence
     = [&](const LifetimeDependenceInfo &formalDeps,
           unsigned target) -> LifetimeDependenceInfo {
+      if (target == parameterMap.size()) {
+        // The target is the result, represented by the number of parameters.
+        // Parameters may have been added if there were closure captures, so
+        // update the result index accordingly.
+        target = inputs.size();
+      }
+
       if (formalDeps.isImmortal()) {
         return LifetimeDependenceInfo(
             nullptr, nullptr, target,

--- a/test/SIL/closure_lifetime_dependence.swift
+++ b/test/SIL/closure_lifetime_dependence.swift
@@ -1,0 +1,64 @@
+// RUN: %target-swift-frontend %s \
+// RUN: -emit-sil  -target %target-swift-5.1-abi-triple \
+// RUN: -enable-experimental-feature Lifetimes \
+// RUN: | %FileCheck %s
+
+// REQUIRES: swift_feature_Lifetimes
+
+struct NE : ~Escapable {
+    func condition() -> Bool {
+        return true
+    }
+}
+
+func takePicker(picker: @_lifetime(copy ne0, copy ne1) (_ ne0: NE, _ ne1: NE) -> NE) {
+    let x = NE()
+    let y = NE()
+    _ = picker(x, y)
+}
+
+func callTakePicker(cond: Bool, ne: NE) {
+  takePicker { ne0, ne1 in ne0 }
+  takePicker { if cond { return $0 } else { return $1 } }
+  takePicker { if ne.condition() { return $0 } else { return $1 } }
+  takePicker { if cond || ne.condition() { return $0 } else { return $1 } }
+}
+
+// Closures in callTakePicker
+
+// CHECK-LABEL: sil private @$s27closure_lifetime_dependence14callTakePicker4cond2neySb_AA2NEVtFA2F_AFtXEfU_ : $@convention(thin) (@guaranteed NE, @guaranteed NE) -> @lifetime(copy 0, copy 1) @owned NE {
+// CHECK-LABEL: } // end sil function '$s27closure_lifetime_dependence14callTakePicker4cond2neySb_AA2NEVtFA2F_AFtXEfU_'
+
+// CHECK-LABEL: sil private @$s27closure_lifetime_dependence14callTakePicker4cond2neySb_AA2NEVtFA2F_AFtXEfU0_ : $@convention(thin) (@guaranteed NE, @guaranteed NE, Bool) -> @lifetime(copy 0, copy 1) @owned NE {
+// CHECK-LABEL: } // end sil function '$s27closure_lifetime_dependence14callTakePicker4cond2neySb_AA2NEVtFA2F_AFtXEfU0_'
+
+// CHECK-LABEL: sil private @$s27closure_lifetime_dependence14callTakePicker4cond2neySb_AA2NEVtFA2F_AFtXEfU1_ : $@convention(thin) (@guaranteed NE, @guaranteed NE, @guaranteed NE) -> @lifetime(copy 0, copy 1) @owned NE {
+// CHECK-LABEL: } // end sil function '$s27closure_lifetime_dependence14callTakePicker4cond2neySb_AA2NEVtFA2F_AFtXEfU1_'
+
+// CHECK-LABEL: sil private @$s27closure_lifetime_dependence14callTakePicker4cond2neySb_AA2NEVtFA2F_AFtXEfU2_ : $@convention(thin) (@guaranteed NE, @guaranteed NE, Bool, @guaranteed NE) -> @lifetime(copy 0, copy 1) @owned NE {
+// CHECK-LABEL: } // end sil function '$s27closure_lifetime_dependence14callTakePicker4cond2neySb_AA2NEVtFA2F_AFtXEfU2_'
+
+func takeOnePicker(picker: @_lifetime(copy ne0) (_ ne0: NE, NE) -> NE) {
+    let x = NE()
+    let y = NE()
+    _ = picker(x, y)
+}
+
+func takeOtherOnePicker(picker: @_lifetime(copy ne1) (NE, _ ne1: NE) -> NE) {
+    let x = NE()
+    let y = NE()
+    _ = picker(x, y)
+}
+
+func callTakeOnePicker() {
+  takeOnePicker { ne0, ne1 in ne0 }
+  takeOtherOnePicker { ne0, ne1 in ne1 }
+}
+
+// Closures in callTakeOnePicker
+
+// CHECK-LABEL: sil private @$s27closure_lifetime_dependence17callTakeOnePickeryyFAA2NEVAD_ADtXEfU_ : $@convention(thin) (@guaranteed NE, @guaranteed NE) -> @lifetime(copy 0) @owned NE {
+// CHECK-LABEL: } // end sil function '$s27closure_lifetime_dependence17callTakeOnePickeryyFAA2NEVAD_ADtXEfU_'
+
+// CHECK-LABEL: sil private @$s27closure_lifetime_dependence17callTakeOnePickeryyFAA2NEVAD_ADtXEfU0_ : $@convention(thin) (@guaranteed NE, @guaranteed NE) -> @lifetime(copy 1) @owned NE {
+// CHECK-LABEL: } // end sil function '$s27closure_lifetime_dependence17callTakeOnePickeryyFAA2NEVAD_ADtXEfU0_'

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_closure.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_closure.swift
@@ -49,3 +49,98 @@ func ncint_get_neint_mutable_local() {
   }
   ncInt.value = 1
 }
+
+struct NE: ~Escapable {
+  public func condition() -> Bool {
+    return true
+  }
+}
+
+func takePicker(picker: @_lifetime(copy ne0, copy ne1) (_ ne0: NE, _ ne1: NE) -> NE) {
+    let x = NE()
+    let y = NE()
+    _ = picker(x, y)
+}
+
+func takeOnePicker(picker: @_lifetime(copy ne0) (_ ne0: NE, NE) -> NE) {
+    let x = NE()
+    let y = NE()
+    _ = picker(x, y)
+}
+
+func takeMutator(mutator: @_lifetime(ne: copy ne) (_ ne: inout NE) -> ()) {
+  var ne = NE()
+  mutator(&ne)
+  let _ = ne
+}
+
+func testClosureLifetimes(cond: Bool) {
+  takePicker { ne0, ne1 in ne0 } // OK
+  takePicker { ne0, ne1 in ne1 } // OK
+
+  takePicker { ne0, ne1 in if cond { return ne0 } else { return ne1 } } // OK
+
+  // Several of the following error cases should start passing with no source
+  // changes once closure context lifetimes are implemented. Some may require
+  // explicit lifetime annotations; for those, add an extra test case with the
+  // annotation.
+  
+  // OK, ne2 is captured but its lifetime is not related
+  let ne2 = NE()
+  takePicker { ne0, ne1 in
+    if ne2.condition() { return ne0 } else { return ne1 }
+  }
+
+  let ne3 = NE()
+  // expected-error@-1{{lifetime-dependent variable 'ne3' escapes its scope}}
+  // expected-note@-2{{it depends on a closure capture; this is not yet supported}}
+  takePicker { ne0, ne1 in ne3 }
+  // expected-note@-1{{this use causes the lifetime-dependent value to escape}}
+
+  var ne4 = NE() // expected-error{{lifetime-dependent variable 'ne4' escapes its scope}}
+  takePicker { ne0, ne1 in
+    ne4 = NE()   // expected-note{{it depends on the lifetime of this parent value}}
+    return ne0   // expected-note{{this use causes the lifetime-dependent value to escape}}
+  }
+  let _ = ne4
+
+  let ne5 = NE() // expected-note{{it depends on a closure capture; this is not yet supported}}
+  takePicker { ne0, ne1 in
+    let ne = ne5 // expected-error{{lifetime-dependent variable 'ne' escapes its scope}}
+    return ne    // expected-note{{this use causes the lifetime-dependent value to escape}}
+  }
+
+  var ne6 = NE()           // expected-error{{lifetime-dependent variable 'ne6' escapes its scope}}
+  takePicker { ne0, ne1 in // expected-note{{it depends on the lifetime of argument 'ne1'}}
+    ne6 = ne1
+    return ne0             // expected-note{{this use causes the lifetime-dependent value to escape}}
+  }
+  let _ = ne6
+
+  takeMutator { ne0 in // OK
+    let neLocal = ne0
+    ne0 = neLocal
+  }
+
+  let ne8 = NE()       // expected-note{{it depends on a closure capture; this is not yet supported}}
+  takeMutator { ne0 in // expected-error{{lifetime-dependent variable 'ne0' escapes its scope}}
+    ne0 = ne8
+  }                    // expected-note{{this use causes the lifetime-dependent value to escape}}
+
+
+  takeOnePicker { ne0, ne1 in ne0 } // OK
+  takeOnePicker { ne0, ne1 in ne1 }
+  // expected-error@-1{{lifetime-dependent variable 'ne1' escapes its scope}}
+  // expected-note@-2{{it depends on the lifetime of argument 'ne1'}}
+  // expected-note@-3{{this use causes the lifetime-dependent value to escape}}
+
+  takeOnePicker { ne0, ne1 in
+                 // expected-error@-1{{lifetime-dependent variable 'ne1' escapes its scope}}
+                 // expected-note@-2{{it depends on the lifetime of argument 'ne1'}}
+    if cond {
+      return ne0
+    } else {
+      return ne1 // expected-note{{this use causes the lifetime-dependent value to escape}}
+    }
+  }
+}

--- a/test/Sema/lifetime_dependence_functype.swift
+++ b/test/Sema/lifetime_dependence_functype.swift
@@ -164,6 +164,16 @@ do {
   //  expected-error@-1{{cannot convert value of type '@_lifetime(0: immortal) (inout NE, borrowing NE) -> ()' to expected argument type '@_lifetime(outValue: borrow inValue) (_ outValue: inout NE, _ inValue: borrowing NE) -> ()'}}
 }
 do {
+  let x = NE()
+  var y = NE()
+  takeGetGenericAndArgs(f: { $1 = $0 }, o: &y, i: x) // expected-error{{cannot assign to value: '$1' is immutable}}
+}
+do {
+  let x = NE()
+  var y = NE()
+  takeGetGenericAndArgs(f: { $0 = $1 }, o: &y, i: x) // OK
+}
+do {
   let _ = transfer // OK
   let _: (NE) -> NE = transfer // OK
   let _: @_lifetime(copy ne) (_ ne: NE) -> NE = transfer // OK


### PR DESCRIPTION
rdar://169976227
This allows us to coerce closure expressions to function types with lifetime dependencies.

Since captures are added to the parameter list when lowering closures to SIL functions, we also need to update the result index when lowering their lifetime dependencies.

Since we do not yet have a way to represent lifetime dependencies to/from a closure's captures, closures that imply such dependencies will currently cause errors.

TODO:
- [x] Rebase on main after #87027 merges and update the docs file to reflect closure support.
- [x] SIL tests
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
