### PR TITLE
[EmitAsyncEntryReturnMetadata] Emit sections for all async funclets

### DIFF
--- a/lib/LLVMPasses/LLVMEmitAsyncEntryReturnMetadata.cpp
+++ b/lib/LLVMPasses/LLVMEmitAsyncEntryReturnMetadata.cpp
@@ -18,6 +18,7 @@ PreservedAnalyses AsyncEntryReturnMetadataPass::run(Module &M,
 
   SmallVector<llvm::Function *, 16> asyncEntries;
   SmallVector<llvm::Function *, 16> asyncReturns;
+  SmallVector<llvm::Function *, 16> asyncContinuations;
   for (auto &F : M) {
     if (F.isDeclaration())
       continue;
@@ -26,6 +27,8 @@ PreservedAnalyses AsyncEntryReturnMetadataPass::run(Module &M,
       asyncEntries.push_back(&F);
     if (F.hasFnAttribute("async_ret"))
       asyncReturns.push_back(&F);
+    if (F.hasFnAttribute("async_continuation"))
+      asyncContinuations.push_back(&F);
   }
 
   auto &ctxt = M.getContext();
@@ -83,6 +86,8 @@ PreservedAnalyses AsyncEntryReturnMetadataPass::run(Module &M,
   addSection("__TEXT,__swift_as_ret, coalesced, no_dead_strip",
              "__swift_async_ret_functlets",
              asyncReturns);
+  addSection("__TEXT,__swift_as_cont, coalesced, no_dead_strip",
+             "__swift_async_cont_functlets", asyncContinuations);
 
   if (!changed)
     return PreservedAnalyses::all();

--- a/test/IRGen/async_frame_entry_return_metadata.swift
+++ b/test/IRGen/async_frame_entry_return_metadata.swift
@@ -9,14 +9,24 @@
 // ENABLED: @__swift_async_entry_functlets = internal constant [2 x i32] [i32 trunc (i64 sub (i64 ptrtoint (ptr @"$s5async6calleeyyYaF" to i64), i64 ptrtoint (ptr @__swift_async_entry_functlets to i64)) to i32), i32 trunc (i64 sub (i64 ptrtoint (ptr @"$s5async6callerySiSbYaF" to i64), i64 ptrtoint (ptr getelementptr inbounds ([2 x i32], ptr @__swift_async_entry_functlets, i32 0, i32 1) to i64)) to i32)], section "__TEXT,__swift_as_entry, coalesced, no_dead_strip", no_sanitize_address, align 4
 // ENABLED: @__swift_async_ret_functlets = internal constant [1 x i32] [i32 trunc (i64 sub (i64 ptrtoint (ptr @"$s5async6callerySiSbYaFTQ1_" to i64), i64 ptrtoint (ptr @__swift_async_ret_functlets to i64)) to i32)], section "__TEXT,__swift_as_ret, coalesced, no_dead_strip", no_sanitize_address, align 4
 
-// ENABLED: define{{.*}} swifttailcc void @"$s5async6callerySiSbYaF"{{.*}} [[CALLER_FUNCLET_ATTRS:#[0-9]+]]
-// ENABLED: define{{.*}} internal swifttailcc void @"$s5async6callerySiSbYaFTY0_"{{.*}} [[CALLER_FUNCLET_ATTRS2:#[0-9]+]]
+// ENABLED: @__swift_async_cont_functlets = internal constant [3 x i32]
+// ENABLED-SAME: ptr @"$s5async6calleeyyYaFTY0_"
+// ENABLED-SAME: ptr @"$s5async6callerySiSbYaFTY0_"
+// ENABLED-SAME: ptr @"$s5async6callerySiSbYaFTY2_"
+// ENABLED-SAME: section "__TEXT,__swift_as_cont, coalesced, no_dead_strip", no_sanitize_address, align 4
 
-// ENABLED: attributes [[CALLER_FUNCLET_ATTRS2]] = { {{.*}}noinline
-// ENABLED: attributes [[CALLER_FUNCLET_ATTRS]] = { {{.*}}noinline
+// ENABLED: define{{.*}} swifttailcc void @"$s5async6callerySiSbYaF"{{.*}} [[ENTRY_ATTR:#[0-9]+]]
+// ENABLED: define{{.*}} internal swifttailcc void @"$s5async6callerySiSbYaFTY0_"{{.*}} [[CONTINUATION_ATTR:#[0-9]+]]
+// ENABLED: define{{.*}} internal swifttailcc void @"$s5async6callerySiSbYaFTQ1_"{{.*}} [[RET_ATTR:#[0-9]+]]
+// ENABLED: define{{.*}} internal swifttailcc void @"$s5async6callerySiSbYaFTY2_"{{.*}} [[CONTINUATION_ATTR]]
+
+// ENABLED: attributes [[ENTRY_ATTR]] = { {{.*}} "async_entry"
+// ENABLED: attributes [[CONTINUATION_ATTR]] = { {{.*}} "async_continuation"
+// ENABLED: attributes [[RET_ATTR]] = { {{.*}} "async_ret"
 
 // DISABLED-NOT: @__swift_async_entry_functlets
 // DISABLED-NOT: @__swift_async_ret_functlets
+// DISABLED-NOT: @__swift_async_cont_functlets
 // DISABLED-NOT: s5async6calleeyyYaF.0
 // DISABLED-NOT: s5async6callerySiSbYaF.0
 


### PR DESCRIPTION
This builds upon previous work, which created a section for async entry funclets and a section for async exit funclets, to also create a section for all other funclets, allowing tools to identify any async funclet.

Depends on:
* https://github.com/swiftlang/llvm-project/pull/12303

rdar://146656133

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

