### PR TITLE
Support reading DWARFv2 format in `DwarfReader`

### DIFF
--- a/stdlib/public/RuntimeModule/Dwarf.swift
+++ b/stdlib/public/RuntimeModule/Dwarf.swift
@@ -662,7 +662,7 @@ class DwarfReader<S: DwarfSource & AnyObject> {
       // .2 version
       let version = Int(maybeSwap(try cursor.read(as: Dwarf_Half.self)))
 
-      if version < 3 || version > 5 {
+      if version < 2 || version > 5 {
         throw DwarfError.unsupportedVersion(version)
       }
 
@@ -693,7 +693,7 @@ class DwarfReader<S: DwarfSource & AnyObject> {
 
         dieBounds = Bounds(base: cursor.pos, size: next - cursor.pos)
       } else {
-        if version >= 3 && version <= 4 {
+        if version >= 2 && version <= 4 {
           // .3 debug_abbrev_offset
           abbrevOffset = Address(maybeSwap(try cursor.read(as: Dwarf_Word.self)))
 
@@ -825,7 +825,7 @@ class DwarfReader<S: DwarfSource & AnyObject> {
       // .2 version
       let version = Int(maybeSwap(try cursor.read(as: Dwarf_Half.self)))
 
-      if version < 3 || version > 5 {
+      if version < 2 || version > 5 {
         cursor.pos = nextOffset
         continue
       }
@@ -882,7 +882,7 @@ class DwarfReader<S: DwarfSource & AnyObject> {
       var dirNames: [String] = []
       var fileInfo: [DwarfFileInfo] = []
 
-      if version == 3 || version == 4 {
+      if version >= 2 && version <= 4 {
         // .11 include_directories
 
         // Prior to version 5, the compilation directory is not included; put


### PR DESCRIPTION
Turns out adding DWARFv2 support is easy. It is essentially the same as DWARFv3 minus a few additional missing fields.

This resolves #86955. I tested by grabbing some DWARFv2/ELF32 binaries from Yocto 3.1 (built for an armv7 device) and ran them through the `DwarfReader` test app:

```bash
./test-linux-x86_64/Backtracing/Output/DwarfReader.swift.tmp/DwarfReader /path/to/libc6-dwarfv2-elf32-libs/libm-2.31.so
./test-linux-x86_64/Backtracing/Output/DwarfReader.swift.tmp/DwarfReader /path/to/libc6-dwarfv2-elf32-libs/libc-2.31.so
./test-linux-x86_64/Backtracing/Output/DwarfReader.swift.tmp/DwarfReader /path/to/libc6-dwarfv2-elf32-libs/ld-2.31.so
```

Attached here in case someone else wants to double check against the *.so files: [libc6-dwarfv2-elf32-libs.zip](https://github.com/user-attachments/files/25192397/libc6-dwarfv2-elf32-libs.zip)

@al45tair @weissi 