### PR TITLE
[ASTPrinter] Print `Sendable` conformance for package types in swift …

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -27,6 +27,7 @@
 #include "swift/AST/Comment.h"
 #include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/DeclContext.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/FileUnit.h"
 #include "swift/AST/GenericEnvironment.h"
@@ -8505,6 +8506,7 @@ swift::getInheritedForPrinting(
 
   InheritedTypes inherited = InheritedTypes(decl);
 
+  bool explicitSendable = false;
   // Collect explicit inherited types.
   for (auto i : inherited.getIndices()) {
     if (auto ty = inherited.getResolvedType(i)) {
@@ -8570,6 +8572,10 @@ swift::getInheritedForPrinting(
         entry = InheritedEntry(TypeLoc::withoutLoc(strippedType),
                                entry.getOptions());
       }
+
+      if (auto P = type->getKnownProtocol()) {
+        explicitSendable |= *P == KnownProtocolKind::Sendable;
+      }
     }
 
     Results.push_back(entry);
@@ -8600,6 +8606,38 @@ swift::getInheritedForPrinting(
         uncheckedProtocols.push_back(proto);
       if (attr->isSuppressed())
         suppressedProtocols.push_back(proto);
+    }
+  }
+
+  if (auto *T = dyn_cast<NominalTypeDecl>(decl)) {
+    auto *sendable =
+        T->getASTContext().getProtocol(KnownProtocolKind::Sendable);
+
+    // If printing is for a package interface, let's add derived/implied `Sendable`
+    // conformance to avoid having to infer it while type-checking the interface
+    // file later. Such inference is not always possible, because i.e. a package
+    // declaration can have private storage that won't be printed in a package
+    // interface file and attempting inference would produce an invalid result.
+    bool shouldPrintSynthesizedSendable = [&] {
+      // If `Sendable` is stated explicit or imported from ObjC, were are done.
+      if (explicitSendable || protocols.contains(sendable))
+        return false;
+
+      // Otherwise only do this for package declarations.
+      return options.printPackageInterface() && isPackage(T);
+    }();
+
+    if (shouldPrintSynthesizedSendable) {
+      auto conformance =
+          lookupConformance(T->getDeclaredInterfaceType(), sendable,
+                            /*allowMissing=*/false);
+      if (conformance.isConcrete() &&
+          !conformance.hasUnavailableConformance()) {
+        auto *concrete = conformance.getConcrete();
+        if (concrete->getSourceKind() == ConformanceEntryKind::Synthesized ||
+            concrete->getSourceKind() == ConformanceEntryKind::Implied)
+          protocols.insert(sendable);
+      }
     }
   }
 

--- a/test/Concurrency/sendable_package_types.swift
+++ b/test/Concurrency/sendable_package_types.swift
@@ -1,0 +1,94 @@
+// RUN: %target-swift-frontend -emit-module %s \
+// RUN:   -module-name _A -swift-version 5 \
+// RUN:   -strict-concurrency=complete \
+// RUN:   -package-name A \
+// RUN:   -enable-library-evolution \
+// RUN:     -emit-module-path %t/A.swiftmodule \
+// RUN:     -emit-module-interface-path %t/A.swiftinterface \
+// RUN:     -emit-package-module-interface-path %t/A.package.swiftinterface \
+// RUN:     -emit-private-module-interface-path %t/A.private.swiftinterface \
+// RUN:   -verify
+
+// RUN: %target-swift-typecheck-module-from-interface(%t/A.package.swiftinterface) -module-name _A
+// RUN: %target-swift-typecheck-module-from-interface(%t/A.private.swiftinterface) -module-name _A
+
+// RUN: %FileCheck %s < %t/A.package.swiftinterface
+
+// REQUIRES: concurrency
+
+// CHECK: package struct S : Swift.Sendable {
+package struct S {
+  package let x: Int = 42
+}
+
+private class NonSendable {
+}
+
+@usableFromInline
+protocol P: Sendable {
+}
+
+// CHECK: final package class A : _A.P, Swift.Sendable {
+package final class A: P {
+  let x: Int = 42
+}
+
+// CHECK: package struct NS {
+// CHECK: }
+package struct NS {
+  private var v: NonSendable
+}
+
+// CHECK: package enum Unavailable : Swift.Equatable {
+package enum Unavailable: Equatable {
+  case test
+}
+
+@available(*, unavailable)
+extension Unavailable: Sendable {
+}
+
+// CHECK: @usableFromInline
+// CHECK: internal struct InternalTest {
+// CHECK: }
+@usableFromInline
+struct InternalTest {
+  var x: Int = 42
+}
+
+// CHECK: package struct ConditionalTest<T> where T : AnyObject {
+package struct ConditionalTest<T: AnyObject> {
+  weak var test: T?
+}
+
+extension ConditionalTest: Sendable where T: Sendable {
+}
+
+@available(macOS 15.0, *)
+@_originallyDefinedIn(module: "A", macOS 15.0)
+public struct Test1: Sendable {
+  // CHECK: package enum Storage : Swift.Equatable, Swift.Sendable {
+  package enum Storage: Equatable {
+    case empty
+  }
+
+  package var storage: Storage
+}
+
+@available(macOS 15.0, *)
+@_originallyDefinedIn(module: "A", macOS 15.0)
+public struct Test2: Sendable {
+  // CHECK: package struct Storage : Swift.Equatable {
+  package struct Storage: Equatable {  // expected-note {{consider making struct 'Storage' conform to the 'Sendable' protocol}}
+    // CHECK-NOT: private var ns: NS
+    private var ns: NS = NS()
+  }
+
+  // CHECK: package class NS : Swift.Equatable {
+  package class NS : Equatable {
+    package static func ==(_: NS, _: NS) -> Bool { false }
+  }
+
+  package var storage: Storage
+  // expected-warning@-1 {{stored property 'storage' of 'Sendable'-conforming struct 'Test2' has non-Sendable type 'Test2.Storage'}}
+}

--- a/test/ModuleInterface/package_interface.swift
+++ b/test/ModuleInterface/package_interface.swift
@@ -60,7 +60,7 @@ package enum PkgEnum {
   case blue, yellow
 }
 
-// CHECK-PKG: package enum PkgEnum {
+// CHECK-PKG: package enum PkgEnum : Swift.Sendable {
 // CHECK-PKG:   case blue, yellow
 // CHECK-PKG:   package static func == (a: Bar.PkgEnum, b: Bar.PkgEnum) -> Swift.Bool
 // CHECK-PKG:   package func hash(into hasher: inout Swift.Hasher)
@@ -137,7 +137,7 @@ package struct PkgStruct {
   package private(set) var four: String
 }
 
-// CHECK-PKG: package struct PkgStruct {
+// CHECK-PKG: package struct PkgStruct : Swift.Sendable {
 // CHECK-PKG:   package var one: Swift.String
 // CHECK-PKG:   package var four: Swift.String {
 // CHECK-PKG:     get


### PR DESCRIPTION
…interfaces

If printing is for a package interface, let's add derived/implied `Sendable` conformance to avoid having to infer it while type-checking the interface file later. Such inference is not always possible, because i.e. a package declaration can have private storage that won't be printed in a package interface file and attempting inference would produce an invalid result.

Resolves: rdar://166159992

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
