### PR TITLE
[SDKInfo] Fix SDKInfo loading to use correct VFS

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -272,7 +272,6 @@ class ASTContext final {
       symbolgraphgen::SymbolGraphOptions &SymbolGraphOpts, CASOptions &casOpts,
       SerializationOptions &serializationOpts, SourceManager &SourceMgr,
       DiagnosticEngine &Diags,
-      std::optional<clang::DarwinSDKInfo> &DarwinSDKInfo,
       llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OutBackend = nullptr);
 
 public:
@@ -299,7 +298,6 @@ public:
       symbolgraphgen::SymbolGraphOptions &SymbolGraphOpts, CASOptions &casOpts,
       SerializationOptions &serializationOpts, SourceManager &SourceMgr,
       DiagnosticEngine &Diags,
-      std::optional<clang::DarwinSDKInfo> &DarwinSDKInfo,
       llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OutBackend = nullptr);
   ~ASTContext();
 

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -324,11 +324,6 @@ public:
     return SymbolGraphOpts;
   }
 
-  std::optional<clang::DarwinSDKInfo> &getSDKInfo() { return SDKInfo; }
-  const std::optional<clang::DarwinSDKInfo> &getSDKInfo() const {
-    return SDKInfo;
-  }
-
   SearchPathOptions &getSearchPathOptions() { return SearchPathOpts; }
   const SearchPathOptions &getSearchPathOptions() const {
     return SearchPathOpts;

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -241,8 +241,7 @@ ModuleDependencyScanningWorker::ModuleDependencyScanningWorker(
                       workerCompilerInvocation->getSymbolGraphOptions(),
                       workerCompilerInvocation->getCASOptions(),
                       workerCompilerInvocation->getSerializationOptions(),
-                      ScanASTContext.SourceMgr, *workerDiagnosticEngine,
-                      workerCompilerInvocation->getSDKInfo()));
+                      ScanASTContext.SourceMgr, *workerDiagnosticEngine));
 
   scanningASTDelegate = std::make_unique<InterfaceSubContextDelegateImpl>(
       workerASTContext->SourceMgr, workerDiagnosticEngine.get(),

--- a/lib/DriverTool/modulewrap_main.cpp
+++ b/lib/DriverTool/modulewrap_main.cpp
@@ -190,13 +190,12 @@ int modulewrap_main(ArrayRef<const char *> Args, const char *Argv0,
   symbolgraphgen::SymbolGraphOptions SymbolGraphOpts;
   CASOptions CASOpts;
   SerializationOptions SerializationOpts;
-  std::optional<clang::DarwinSDKInfo> SDKInfo;
   LangOpts.Target = Invocation.getTargetTriple();
   LangOpts.EnableObjCInterop = Invocation.enableObjCInterop();
   ASTContext &ASTCtx = *ASTContext::get(
       LangOpts, TypeCheckOpts, SILOpts, SearchPathOpts, ClangImporterOpts,
       SymbolGraphOpts, CASOpts, SerializationOpts, SrcMgr, Instance.getDiags(),
-      SDKInfo, llvm::makeIntrusiveRefCnt<llvm::vfs::OnDiskOutputBackend>());
+      llvm::makeIntrusiveRefCnt<llvm::vfs::OnDiskOutputBackend>());
   registerParseRequestFunctions(ASTCtx.evaluator);
   registerTypeCheckerRequestFunctions(ASTCtx.evaluator);
 

--- a/lib/DriverTool/swift_parse_test_main.cpp
+++ b/lib/DriverTool/swift_parse_test_main.cpp
@@ -83,10 +83,9 @@ struct LibParseExecutor {
     symbolgraphgen::SymbolGraphOptions symbolOpts;
     CASOptions casOpts;
     SerializationOptions serializationOpts;
-    std::optional<clang::DarwinSDKInfo> SDKInfo;
     std::unique_ptr<ASTContext> ctx(ASTContext::get(
         langOpts, typeckOpts, silOpts, searchPathOpts, clangOpts, symbolOpts,
-        casOpts, serializationOpts, SM, diagEngine, SDKInfo));
+        casOpts, serializationOpts, SM, diagEngine));
     auto &eval = ctx->evaluator;
     registerParseRequestFunctions(eval);
     registerTypeCheckerRequestFunctions(eval);
@@ -156,14 +155,13 @@ struct ASTGenExecutor {
     CASOptions casOpts;
     symbolgraphgen::SymbolGraphOptions symbolOpts;
     SerializationOptions serializationOpts;
-    std::optional<clang::DarwinSDKInfo> SDKInfo;
 
     // Enable ASTGen.
     langOpts.enableFeature(Feature::ParserASTGen);
 
     std::unique_ptr<ASTContext> ctx(ASTContext::get(
         langOpts, typeckOpts, silOpts, searchPathOpts, clangOpts, symbolOpts,
-        casOpts, serializationOpts, SM, diagEngine, SDKInfo));
+        casOpts, serializationOpts, SM, diagEngine));
     auto &eval = ctx->evaluator;
     registerParseRequestFunctions(eval);
     registerTypeCheckerRequestFunctions(eval);

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -338,7 +338,7 @@ bool CompilerInstance::setUpASTContextIfNeeded() {
       Invocation.getSILOptions(), Invocation.getSearchPathOptions(),
       Invocation.getClangImporterOptions(), Invocation.getSymbolGraphOptions(),
       Invocation.getCASOptions(), Invocation.getSerializationOptions(),
-      SourceMgr, Diagnostics, Invocation.getSDKInfo(), OutputBackend));
+      SourceMgr, Diagnostics, OutputBackend));
   if (!Invocation.getFrontendOptions().ModuleAliasMap.empty())
     Context->setModuleAliases(Invocation.getFrontendOptions().ModuleAliasMap);
 

--- a/lib/IDETool/CompileInstance.cpp
+++ b/lib/IDETool/CompileInstance.cpp
@@ -131,13 +131,11 @@ getModifiedFunctionDeclList(const SourceFile &SF, SourceManager &tmpSM,
   symbolgraphgen::SymbolGraphOptions symbolOpts = ctx.SymbolGraphOpts;
   SerializationOptions serializationOpts = ctx.SerializationOpts;
   std::optional<clang::DarwinSDKInfo> SDKInfo;
-  if (auto *ctxSDKInfo = ctx.getDarwinSDKInfo())
-    SDKInfo = *ctxSDKInfo;
 
   DiagnosticEngine tmpDiags(tmpSM);
-  auto &tmpCtx = *ASTContext::get(langOpts, typeckOpts, silOpts, searchPathOpts,
-                                  clangOpts, symbolOpts, casOpts,
-                                  serializationOpts, tmpSM, tmpDiags, SDKInfo);
+  auto &tmpCtx =
+      *ASTContext::get(langOpts, typeckOpts, silOpts, searchPathOpts, clangOpts,
+                       symbolOpts, casOpts, serializationOpts, tmpSM, tmpDiags);
   registerParseRequestFunctions(tmpCtx.evaluator);
   registerTypeCheckerRequestFunctions(tmpCtx.evaluator);
 

--- a/lib/IDETool/IDEInspectionInstance.cpp
+++ b/lib/IDETool/IDEInspectionInstance.cpp
@@ -270,11 +270,9 @@ bool IDEInspectionInstance::performCachedOperationIfPossible(
   SerializationOptions serializationOpts =
       CachedCI->getASTContext().SerializationOpts;
   std::optional<clang::DarwinSDKInfo> SDKInfo;
-  if (auto *contextSDKInfo = CachedCI->getASTContext().getDarwinSDKInfo())
-    SDKInfo = *contextSDKInfo;
-  std::unique_ptr<ASTContext> tmpCtx(ASTContext::get(
-      langOpts, typeckOpts, silOpts, searchPathOpts, clangOpts, symbolOpts,
-      casOpts, serializationOpts, tmpSM, tmpDiags, SDKInfo));
+  std::unique_ptr<ASTContext> tmpCtx(
+      ASTContext::get(langOpts, typeckOpts, silOpts, searchPathOpts, clangOpts,
+                      symbolOpts, casOpts, serializationOpts, tmpSM, tmpDiags));
   tmpCtx->CancellationFlag = CancellationFlag;
   registerParseRequestFunctions(tmpCtx->evaluator);
   registerIDERequestFunctions(tmpCtx->evaluator);

--- a/lib/IDETool/SyntacticMacroExpansion.cpp
+++ b/lib/IDETool/SyntacticMacroExpansion.cpp
@@ -67,7 +67,7 @@ bool SyntacticMacroExpansionInstance::setup(
       invocation.getSILOptions(), invocation.getSearchPathOptions(),
       invocation.getClangImporterOptions(), invocation.getSymbolGraphOptions(),
       invocation.getCASOptions(), invocation.getSerializationOptions(),
-      SourceMgr, Diags, invocation.getSDKInfo()));
+      SourceMgr, Diags));
   registerParseRequestFunctions(Ctx->evaluator);
   registerTypeCheckerRequestFunctions(Ctx->evaluator);
 

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -1193,7 +1193,6 @@ struct ParserUnit::Implementation {
   CASOptions CASOpts;
   SerializationOptions SerializationOpts;
   DiagnosticEngine Diags;
-  std::optional<clang::DarwinSDKInfo> SDKInfo;
   ASTContext &Ctx;
   SourceManager &SM;
   unsigned BufferID;
@@ -1206,7 +1205,7 @@ struct ParserUnit::Implementation {
         SILOpts(SILOptions()), Diags(SM),
         Ctx(*ASTContext::get(LangOpts, TypeCheckerOpts, SILOpts, SearchPathOpts,
                              clangImporterOpts, symbolGraphOpts, CASOpts,
-                             SerializationOpts, SM, Diags, SDKInfo)),
+                             SerializationOpts, SM, Diags)),
         SM(SM), BufferID(BufferID) {
     registerParseRequestFunctions(Ctx.evaluator);
 

--- a/test/CAS/availability-remap.swift
+++ b/test/CAS/availability-remap.swift
@@ -1,0 +1,53 @@
+// REQUIRES: OS=xros || OS=macosx
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   %t/main.swift -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas -I %t/include -sdk %t/sdk \
+// RUN:   -scanner-prefix-map-paths %t /^tmp -scanner-prefix-map-paths %t/sdk /^sdk -target arm64-apple-xros1.0
+
+// RUN: %{python} %S/../../utils/swift-build-modules.py --cas %t/cas %swift_frontend_plain %t/deps.json -o %t/Test.cmd
+
+// RUN: %target-swift-frontend -target arm64-apple-xros1.0 \
+// RUN:   -typecheck -cache-compile-job -cas-path %t/cas \
+// RUN:   -swift-version 5 -module-name Test -sdk /^sdk \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   -cache-replay-prefix-map /^tmp %t -cache-replay-prefix-map /^sdk %t/sdk \
+// RUN:   /^tmp/main.swift @%t/Test.cmd -dump-availability-scopes 2>&1 | %FileCheck %s
+
+// CHECK: (root version=1.0
+// CHECK:   (decl version=1.1 decl=foo()
+// CHECK:     (condition_following_availability version=2.0
+
+//--- main.swift
+import A
+@available(iOS 17.4, *)
+public func foo() {
+  if #available(visionOS 2.0, *) {
+    a()
+  }
+}
+
+//--- include/A.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name A -O -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib -user-module-version 1.0
+@available(macOS 15.0, iOS 17.1, *)
+public func a() { }
+
+//--- sdk/SDKSettings.json
+{
+  "DisplayName":"visionOS 26.0",
+  "MinimalDisplayName":"26.0",
+  "Version":"26.0",
+  "VersionMap":{
+    "xrOS_iOS":{"2.0":"18.0","1.1":"17.4","2.3":"18.3","26.2":"26.2","2.6":"18.6","2.1":"18.1","1.2":"17.5","2.4":"18.4","26.4":"26.4","26.0":"26.0","2.2":"18.2","1.0":"17.1","3.4":"19.4","26.3":"26.3","2.5":"18.5"},
+    "iOS_visionOS":{"18.4":"2.4","18.0":"2.0","17.1":"1.0","17.4":"1.1","26.2":"26.2","18.3":"2.3","18.6":"2.6","18.2":"2.2","26.4":"26.4","26.0":"26.0","18.5":"2.5","18.1":"2.1","19.4":"3.4","26.3":"26.3","17.5":"1.2"},
+    "iOS_xrOS":{"18.4":"2.4","18.0":"2.0","17.1":"1.0","17.4":"1.1","26.2":"26.2","18.3":"2.3","18.6":"2.6","18.2":"2.2","26.4":"26.4","26.0":"26.0","18.5":"2.5","18.1":"2.1","19.4":"3.4","26.3":"26.3","17.5":"1.2"},
+    "visionOS_iOS":{"2.0":"18.0","1.1":"17.4","2.3":"18.3","26.2":"26.2","2.6":"18.6","2.1":"18.1","1.2":"17.5","2.4":"18.4","26.4":"26.4","26.0":"26.0","2.2":"18.2","1.0":"17.1","3.4":"19.4","26.3":"26.3","2.5":"18.5"}
+    },
+  "DefaultDeploymentTarget":"26.0",
+  "MaximumDeploymentTarget":"26.0.99",
+  "CanonicalName":"xros26.0"
+}

--- a/unittests/AST/TestContext.cpp
+++ b/unittests/AST/TestContext.cpp
@@ -38,7 +38,7 @@ TestContext::TestContext(ShouldDeclareOptionalTypes optionals,
     : TestContextBase(target),
       Ctx(*ASTContext::get(LangOpts, TypeCheckerOpts, SILOpts, SearchPathOpts,
                            ClangImporterOpts, SymbolGraphOpts, CASOpts,
-                           SerializationOpts, SourceMgr, Diags, SDKInfo)) {
+                           SerializationOpts, SourceMgr, Diags)) {
   registerParseRequestFunctions(Ctx.evaluator);
   registerTypeCheckerRequestFunctions(Ctx.evaluator);
   registerClangImporterRequestFunctions(Ctx.evaluator);

--- a/unittests/AST/TestContext.h
+++ b/unittests/AST/TestContext.h
@@ -18,7 +18,6 @@
 #include "swift/Basic/SourceManager.h"
 #include "swift/SymbolGraphGen/SymbolGraphOptions.h"
 
-#include "clang/Basic/DarwinSDKInfo.h"
 #include "llvm/TargetParser/Host.h"
 
 namespace swift {
@@ -40,7 +39,6 @@ public:
   SerializationOptions SerializationOpts;
   SourceManager SourceMgr;
   DiagnosticEngine Diags;
-  std::optional<clang::DarwinSDKInfo> SDKInfo;
 
   TestContextBase(llvm::Triple target) : Diags(SourceMgr) {
     LangOpts.Target = target;

--- a/unittests/ClangImporter/ClangImporterTests.cpp
+++ b/unittests/ClangImporter/ClangImporterTests.cpp
@@ -8,7 +8,6 @@
 #include "swift/Basic/SourceManager.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/SymbolGraphGen/SymbolGraphOptions.h"
-#include "clang/Basic/DarwinSDKInfo.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
@@ -84,10 +83,9 @@ TEST(ClangImporterTest, emitPCHInMemory) {
   swift::SerializationOptions serializationOpts;
   swift::SourceManager sourceMgr;
   swift::DiagnosticEngine diags(sourceMgr);
-  std::optional<clang::DarwinSDKInfo> SDKInfo;
   std::unique_ptr<ASTContext> context(ASTContext::get(
       langOpts, typecheckOpts, silOpts, searchPathOpts, options,
-      symbolGraphOpts, casOpts, serializationOpts, sourceMgr, diags, SDKInfo));
+      symbolGraphOpts, casOpts, serializationOpts, sourceMgr, diags));
   auto importer = ClangImporter::create(*context);
 
   std::string PCH = createFilename(cache, "bridging.h.pch");
@@ -201,7 +199,6 @@ TEST(ClangImporterTest, libStdCxxInjectionTest) {
   ClangImporterOptions options;
   CASOptions casOpts;
   SerializationOptions serializationOpts;
-  std::optional<clang::DarwinSDKInfo> SDKInfo;
   options.clangPath = "/usr/bin/clang";
   options.ExtraArgs.push_back(
       (llvm::Twine("--gcc-toolchain=") + "/opt/rh/devtoolset-9/root/usr")
@@ -209,7 +206,7 @@ TEST(ClangImporterTest, libStdCxxInjectionTest) {
   options.ExtraArgs.push_back("--gcc-toolchain");
   std::unique_ptr<ASTContext> context(ASTContext::get(
       langOpts, typecheckOpts, silOpts, searchPathOpts, options,
-      symbolGraphOpts, casOpts, serializationOpts, sourceMgr, diags, SDKInfo));
+      symbolGraphOpts, casOpts, serializationOpts, sourceMgr, diags));
 
   {
     LibStdCxxInjectionVFS vfs;

--- a/unittests/FrontendTool/ModuleLoadingTests.cpp
+++ b/unittests/FrontendTool/ModuleLoadingTests.cpp
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "gtest/gtest.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Frontend/Frontend.h"
@@ -18,9 +17,9 @@
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
 #include "swift/Serialization/Validation.h"
 #include "swift/SymbolGraphGen/SymbolGraphOptions.h"
-#include "clang/Basic/DarwinSDKInfo.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/VirtualFileSystem.h"
+#include "gtest/gtest.h"
 
 using namespace swift;
 
@@ -106,10 +105,9 @@ protected:
     SILOptions silOpts;
     CASOptions casOpts;
     SerializationOptions serializationOpts;
-    std::optional<clang::DarwinSDKInfo> SDKInfo;
     auto ctx = ASTContext::get(langOpts, typecheckOpts, silOpts, searchPathOpts,
                                clangImpOpts, symbolGraphOpts, casOpts,
-                               serializationOpts, sourceMgr, diags, SDKInfo);
+                               serializationOpts, sourceMgr, diags);
 
     ctx->addModuleInterfaceChecker(
       std::make_unique<ModuleInterfaceCheckerImpl>(*ctx, cacheDir,

--- a/unittests/Sema/SemaFixture.cpp
+++ b/unittests/Sema/SemaFixture.cpp
@@ -30,10 +30,9 @@ using namespace swift::unittest;
 using namespace swift::constraints::inference;
 
 SemaTest::SemaTest()
-    : Context(*ASTContext::get(LangOpts, TypeCheckerOpts, SILOpts,
-                               SearchPathOpts, ClangImporterOpts,
-                               SymbolGraphOpts, CASOpts, SerializationOpts,
-                               SourceMgr, Diags, SDKInfo)) {
+    : Context(*ASTContext::get(
+          LangOpts, TypeCheckerOpts, SILOpts, SearchPathOpts, ClangImporterOpts,
+          SymbolGraphOpts, CASOpts, SerializationOpts, SourceMgr, Diags)) {
   INITIALIZE_LLVM();
 
   registerParseRequestFunctions(Context.evaluator);

--- a/unittests/Sema/SemaFixture.h
+++ b/unittests/Sema/SemaFixture.h
@@ -21,11 +21,10 @@
 #include "swift/Basic/SourceManager.h"
 #include "swift/Sema/ConstraintSystem.h"
 #include "swift/SymbolGraphGen/SymbolGraphOptions.h"
-#include "clang/Basic/DarwinSDKInfo.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/TargetParser/Host.h"
 #include "llvm/Support/Path.h"
+#include "llvm/TargetParser/Host.h"
 #include "gtest/gtest.h"
 #include <string>
 
@@ -47,7 +46,6 @@ public:
   SerializationOptions SerializationOpts;
   SourceManager SourceMgr;
   DiagnosticEngine Diags;
-  std::optional<clang::DarwinSDKInfo> SDKInfo;
 
   SemaTestBase() : Diags(SourceMgr) {
     LangOpts.Target = llvm::Triple(llvm::sys::getDefaultTargetTriple());


### PR DESCRIPTION
Partially revert https://github.com/swiftlang/swift/pull/86309. Keep the SDKInfo parsing in the ASTContext separately from the search path configuration. This allows the availablity checking to load SDKSettings from the correct VFS.

rdar://169886913

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
