### PR TITLE
[Test][Driver] Replace shell syntax with lit substitutions for internal shell compatibility

### DIFF
--- a/test/Driver/environment.swift
+++ b/test/Driver/environment.swift
@@ -2,7 +2,6 @@
 // UNSUPPORTED: OS=windows-msvc
 // Apple's "System Integrity Protection" makes this test fail on OS X.
 
-// RUN: %swift_driver_plain -sdk "" -target x86_64-unknown-gnu-linux -L/foo/ -driver-use-frontend-path %S/Inputs/print-var.sh %s LD_LIBRARY_PATH | %FileCheck -check-prefix=CHECK${LD_LIBRARY_PATH+_LAX} %s
+// RUN: %swift_driver_plain -sdk "" -target x86_64-unknown-gnu-linux -L/foo/ -driver-use-frontend-path %S/Inputs/print-var.sh %s LD_LIBRARY_PATH | %FileCheck %s
 
-// CHECK: {{^/foo/:[^:]+/lib/swift/linux$}}
-// CHECK_LAX: {{^/foo/:[^:]+/lib/swift/linux}}
+// CHECK: {{^/foo/:[^:]+/lib/swift/linux}}

--- a/test/Driver/static-stdlib-autolink-linux.swift
+++ b/test/Driver/static-stdlib-autolink-linux.swift
@@ -12,10 +12,7 @@
 // RUN: %t/main | %FileCheck %s
 // CHECK: Hello
 
-// RUN: if [ %target-os == "linux-gnu" ]; \
-// RUN: then \
-// RUN:   ldd %t/main | %FileCheck %s --check-prefix=LDD; \
-// RUN: fi
+// RUN: %if OS=linux-gnu %{ ldd %t/main | %FileCheck %s --check-prefix=LDD %}
 
 // LDD-NOT: libswiftCore.so
 // LDD-NOT: libswift_Concurrency.so


### PR DESCRIPTION
Partially address #84407 

```
#87107 fixed:
- test/Driver/environment.swift
- test/Driver/static-stdlib-autolink-linux.swift
```

For `environment.swift`, it always uses the lax pattern (#84988).