### PR TITLE
[Test][remote-run] Replace backtick command substitution with count in dry-run

### DIFF
--- a/test/remote-run/dry-run.test-sh
+++ b/test/remote-run/dry-run.test-sh
@@ -3,7 +3,7 @@ UNSUPPORTED: OS=windows-msvc
 
 RUN: %empty-directory(%t)
 RUN: %debug-remote-run -n --input-prefix %S/Inputs/ ls %S/Inputs/upload/1.txt %S/Inputs/upload/2.txt 2>&1 >/dev/null | %FileCheck -check-prefix CHECK-INPUT %s
-RUN: test -z "`ls %t`"
+RUN: ls %t | count 0
 RUN: test ! -e %t-REMOTE
 
 CHECK-INPUT: /usr/bin/env /bin/mkdir -p {{.+}}-REMOTE/input


### PR DESCRIPTION
Partially address #84407 

```
#87108 fixed test/remote-run/dry-run.test-sh
```