### PR TITLE
[Test] Fix shell syntax in validation tests for internal shell compatibility

### DIFF
--- a/validation-test/Python/call_swiftc_after_relocate_xdg_cache_home_under.swift
+++ b/validation-test/Python/call_swiftc_after_relocate_xdg_cache_home_under.swift
@@ -4,7 +4,7 @@
 // RUN: mkdir -p %t
 // RUN: split-file %s %t
 //
-// RUN: PYTHONPATH=%utils %{python} %t/run_swiftc_with_relocated_xdg_cache_home.py %t/.cache %swiftc_driver_plain %t/hello.swift
+// RUN: env PYTHONPATH=%utils %{python} %t/run_swiftc_with_relocated_xdg_cache_home.py %t/.cache %swiftc_driver_plain %t/hello.swift
 // RUN: ls %t/.cache/clang/ModuleCache
 
 //--- run_swiftc_with_relocated_xdg_cache_home.py

--- a/validation-test/SIL/verify_all_overlays.py
+++ b/validation-test/SIL/verify_all_overlays.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# RUN: ${python} %s %target-swiftmodule-name %platform-sdk-overlay-dir \
+# RUN: %{python} %s %target-swiftmodule-name %platform-sdk-overlay-dir \
 # RUN:     %swift_src_root \
 # RUN:     %target-sil-opt -sdk %sdk -enable-sil-verify-all \
 # RUN:       -F %sdk/System/Library/PrivateFrameworks \


### PR DESCRIPTION
Partially address #84407 

```
#87109 fixed:
- validation-test/Python/call_swiftc_after_relocate_xdg_cache_home_under.swift
- validation-test/SIL/verify_all_overlays.py

```