### PR TITLE
[Dependency Scanning] Fix suspected use-after-free in `recordClangDependency`

### DIFF
--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -813,7 +813,8 @@ void ModuleDependenciesCache::recordClangDependency(
         diag::dependency_scan_unexpected_variant_module_map_note,
         priorClangModuleDetails->moduleMapFile, dependency.ClangModuleMapFile);
 
-    auto newClangModuleDetails = bridgeClangModule(dependency).getAsClangModule();
+    auto newClangModuleInfo = bridgeClangModule(dependency);
+    auto newClangModuleDetails = newClangModuleInfo.getAsClangModule();
     auto diagnoseExtraCommandLineFlags =
         [&diags](const ClangModuleDependencyStorage *checkModuleDetails,
                const ClangModuleDependencyStorage *baseModuleDetails,


### PR DESCRIPTION
We are hitting a `EXC_BAD_ACCESS` crash in:
```
swift::ModuleDependenciesCache::recordClangDependency
cacheComputedClangModuleLookupResults
```
The only interesting thing this method does appears to be emitting a diagnostic note when encountering a variant Clang dependency node within the same scan. When preparing the diagnostic messages, the scanner needs to access the Clang module details of the prior-discovered node.

We get at the prior node's details with:
```c++
auto newClangModuleDetails = bridgeClangModule(dependency).getAsClangModule(); 
```
Where `bridgeClangModule` returns a module info by-value and `.getAsClangModule()` returns a pointer to an object allocated to have its lifetime tied to the info value. It seems that by the time we access this pointer a few lines of code later to get at the command-line strings, the value has gone out of scope and the corresponding memory has been deallocated.

Keeping the module info object in scope for the duration of the diagnostic code should resolve it.

Resolves rdar://165870730
