### PR TITLE
[SE-0521] Allow `some P?` and `any P?` syntax (removing the need for parentheses).

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -831,6 +831,8 @@ ERROR(sil_coverage_invalid_operator, none,
 
 ERROR(expected_type,PointsToFirstBadToken,
       "expected type", ())
+ERROR(confusing_some_any_optional_composition,none,
+      "confusing use of optional after a 'some' or 'any' composition; use parentheses to clarify precedence", ())
 ERROR(expected_init_value,PointsToFirstBadToken,
       "expected initial value after '='", ())
 

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -977,16 +977,18 @@ Parser::parseTypeSimpleOrComposition(Diag<> MessageID, ParseTypeReason reason) {
   }
 
   auto applyOpaque = [&](TypeRepr *type) -> TypeRepr * {
+    if (opaqueLoc.isInvalid() && anyLoc.isInvalid()) {
+      return type;
+    }
+
     // Unwrap any layers of optionality, keeping track of what we peeled off.
     SmallVector<TypeRepr *, 2> optionals;
     TypeRepr *base = type;
     InverseTypeRepr *inverseToReapply = nullptr;
 
-    if (opaqueLoc.isValid() || anyLoc.isValid()) {
-      if (auto *inv = dyn_cast<InverseTypeRepr>(base)) {
-        inverseToReapply = inv;
-        base = inv->getConstraint();
-      }
+    if (auto *inv = dyn_cast<InverseTypeRepr>(base)) {
+      inverseToReapply = inv;
+      base = inv->getConstraint();
     }
 
     while (true) {
@@ -1010,21 +1012,19 @@ Parser::parseTypeSimpleOrComposition(Diag<> MessageID, ParseTypeReason reason) {
     // parsed as bound to the elements, not to the whole composition. Check the
     // last element so that if we have something like `some P & Q?`, we can
     // diagnose it specifically with a fix-it.
-    if (opaqueLoc.isValid() || anyLoc.isValid()) {
-      if (auto *comp = dyn_cast<CompositionTypeRepr>(base)) {
-        if (!comp->getTypes().empty()) {
-          auto *last = comp->getTypes().back();
-          auto *lastForDiag = last;
-          if (auto *inv = dyn_cast<InverseTypeRepr>(lastForDiag)) {
-            lastForDiag = inv->getConstraint();
-          }
-          if (isa<OptionalTypeRepr>(lastForDiag) ||
-              isa<ImplicitlyUnwrappedOptionalTypeRepr>(lastForDiag)) {
-            diagnose(last->getEndLoc(),
-                    diag::confusing_some_any_optional_composition)
-                .fixItInsert(comp->getStartLoc(), "(")
-                .fixItInsert(last->getEndLoc(), ")");
-          }
+    if (auto *comp = dyn_cast<CompositionTypeRepr>(base)) {
+      if (!comp->getTypes().empty()) {
+        auto *last = comp->getTypes().back();
+        auto *lastForDiag = last;
+        if (auto *inv = dyn_cast<InverseTypeRepr>(lastForDiag)) {
+          lastForDiag = inv->getConstraint();
+        }
+        if (isa<OptionalTypeRepr>(lastForDiag) ||
+            isa<ImplicitlyUnwrappedOptionalTypeRepr>(lastForDiag)) {
+          diagnose(last->getEndLoc(),
+                   diag::confusing_some_any_optional_composition)
+              .fixItInsert(comp->getStartLoc(), "(")
+              .fixItInsert(last->getEndLoc(), ")");
         }
       }
     }

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -980,6 +980,15 @@ Parser::parseTypeSimpleOrComposition(Diag<> MessageID, ParseTypeReason reason) {
     // Unwrap any layers of optionality, keeping track of what we peeled off.
     SmallVector<TypeRepr *, 2> optionals;
     TypeRepr *base = type;
+    InverseTypeRepr *inverseToReapply = nullptr;
+
+    if (opaqueLoc.isValid() || anyLoc.isValid()) {
+      if (auto *inv = dyn_cast<InverseTypeRepr>(base)) {
+        inverseToReapply = inv;
+        base = inv->getConstraint();
+      }
+    }
+
     while (true) {
       if (auto *opt = dyn_cast<OptionalTypeRepr>(base)) {
         optionals.push_back(base);
@@ -993,6 +1002,10 @@ Parser::parseTypeSimpleOrComposition(Diag<> MessageID, ParseTypeReason reason) {
       }
     }
 
+    if (inverseToReapply) {
+      base = new (Context) InverseTypeRepr(inverseToReapply->getTildeLoc(), base);
+    }
+
     // If this was a composition with `some` or `any`, the optional sugar is
     // parsed as bound to the elements, not to the whole composition. Check the
     // last element so that if we have something like `some P & Q?`, we can
@@ -1001,8 +1014,12 @@ Parser::parseTypeSimpleOrComposition(Diag<> MessageID, ParseTypeReason reason) {
       if (auto *comp = dyn_cast<CompositionTypeRepr>(base)) {
         if (!comp->getTypes().empty()) {
           auto *last = comp->getTypes().back();
-          if (isa<OptionalTypeRepr>(last) ||
-              isa<ImplicitlyUnwrappedOptionalTypeRepr>(last)) {
+          auto *lastForDiag = last;
+          if (auto *inv = dyn_cast<InverseTypeRepr>(lastForDiag)) {
+            lastForDiag = inv->getConstraint();
+          }
+          if (isa<OptionalTypeRepr>(lastForDiag) ||
+              isa<ImplicitlyUnwrappedOptionalTypeRepr>(lastForDiag)) {
             diagnose(last->getEndLoc(),
                     diag::confusing_some_any_optional_composition)
                 .fixItInsert(comp->getStartLoc(), "(")

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -6996,10 +6996,10 @@ private:
   /// a type representation with the given parent requires paretheses.
   static bool anySyntaxNeedsParens(TypeRepr *parent) {
     switch (parent->getKind()) {
-    case TypeReprKind::Optional:
-    case TypeReprKind::ImplicitlyUnwrappedOptional:
     case TypeReprKind::Protocol:
       return true;
+    case TypeReprKind::Optional:
+    case TypeReprKind::ImplicitlyUnwrappedOptional:
     case TypeReprKind::Metatype:
     case TypeReprKind::Attributed:
     case TypeReprKind::Error:
@@ -7108,7 +7108,9 @@ private:
 
       // Look through parens, inverses, `.Type` metatypes, and compositions.
       if ((*it)->isParenType() || isa<InverseTypeRepr>(*it) ||
-          isa<CompositionTypeRepr>(*it) || isa<MetatypeTypeRepr>(*it)) {
+          isa<CompositionTypeRepr>(*it) || isa<MetatypeTypeRepr>(*it) ||
+          isa<OptionalTypeRepr>(*it) ||
+          isa<ImplicitlyUnwrappedOptionalTypeRepr>(*it)) {
         continue;
       }
 

--- a/test/ModuleInterface/some_any_optional_sugar.swift
+++ b/test/ModuleInterface/some_any_optional_sugar.swift
@@ -1,0 +1,20 @@
+// Verify that we continue printing parentheses in module interfaces even if
+// they weren't present in source.
+//
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) -module-name SomeAnyOptionalSugar %s
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name SomeAnyOptionalSugar
+// RUN: %FileCheck %s < %t.swiftinterface
+
+public protocol P {
+  typealias R = Q
+}
+public protocol Q {}
+
+// CHECK: public func f(_ x: (some P)?) -> (any SomeAnyOptionalSugar::P)?
+public func f(_ x: some P?) -> any P? {}
+
+// CHECK: public func g(_ x: borrowing (any ~Copyable)?)
+public func g(_ x: borrowing any ~Copyable?) {}
+
+// CHECK: public func h(_ x: (some P.R)?)
+public func h(_ x: some P.R?) {}

--- a/test/Sema/some_any_optional_sugar.swift
+++ b/test/Sema/some_any_optional_sugar.swift
@@ -1,0 +1,121 @@
+// RUN: %target-typecheck-verify-swift -swift-version 6
+
+protocol P {}
+struct S: P {}
+
+func nonsugaredOpaqueReturn() -> (some P)? {
+  return sugaredOpaqueReturn()
+}
+func sugaredOpaqueReturn() -> some P? {
+  if Bool.random() {
+    return S()
+  } else {
+    return nil as S?
+  }
+}
+
+// `(some P)!` is not allowed, so neither should this be.
+func sugaredIUOOpaqueReturn() -> some P! {  // expected-error {{using '!' is not allowed here}}
+                                            // expected-note@-1 {{use '?' instead}}
+  return S()
+}
+
+func nonsugaredAnyParam(p: (any P)?) { sugaredAnyParam(p: p) }
+func sugaredAnyParam(p: any P?) { nonsugaredAnyParam(p: p) }
+
+func nonsugaredSomeParam(p: (some P)?) {
+  sugaredSomeParam(p: p)
+  explicitGenericParam(p: p)
+}
+func sugaredSomeParam(p: some P?) { nonsugaredSomeParam(p: p) }
+func explicitGenericParam<T: P>(p: T?) { nonsugaredSomeParam(p: p) }
+
+func testSome(p: some P?) {
+  let _: any P? = p
+  if let val = p {
+    let _: any P = val
+  }
+}
+
+let x: any P? = S()
+let y: some P? = S()
+
+struct MyType {
+  var sugaredField1: any P?
+  var sugaredField2: any P!
+  var sugaredField3: any P?!
+  var sugaredField4: any P??
+  var nonsugaredField1: (any P)?
+  var nonsugaredField2: (any P)!
+  var nonsugaredField3: (any P)?!
+  var nonsugaredField4: (any P)?
+
+  var sugaredField5: some P? { S() }
+  var sugaredField6: some P?? { S() }
+  var nonsugaredField5: (some P)? { S() }
+  var nonsugaredField6: (some P)?? { S() }
+
+  // IUOs are not allowed beneath the top-level, make sure that is still diagnosed.
+  var sugaredField7: any P!?  // expected-error {{using '!' is not allowed here}}
+                              // expected-note@-1 {{use '?' instead}}
+  var nonsugaredField7: (any P)!?  // expected-error {{using '!' is not allowed here}}
+                                   // expected-note@-1 {{use '?' instead}}
+
+  // `(some P)!` and `(some P)?!` are not allowed, so neither should these be.
+  var sugaredField8: some P! { S() }  // expected-error {{using '!' is not allowed here}}
+                                      // expected-note@-1 {{use '?' instead}}
+  var sugaredField9: some P?! { S() }  // expected-error {{using '!' is not allowed here}}
+                                       // expected-note@-1 {{use '?' instead}}
+}
+
+// Deeper optionals
+func testDoubleOptional(p: any P??) {
+  let _: (any P)?? = p
+}
+func testDoubleOptionalSome() -> some P?? {
+  testDoubleOptional(p: S())
+  return S()
+}
+
+// Works in expression context, too
+let _: [any P?] = [any P?]()
+let _: [any P??] = [any P??]()
+
+// Parentheses and compositions
+protocol Q {}
+extension S: Q {}
+
+let _: any (P)? = S()
+let _: any (P & Q)? = S()
+
+func testParens(_: some (P)?) {}
+testParens(S())
+
+func testComposition(_: some (P & Q)?) {}
+testComposition(S())
+
+// Nested protocols
+struct Outer { protocol InnerP {} }
+func testNested(_: any Outer.InnerP?) {}
+
+protocol QP {}
+protocol RP {}
+extension Optional {
+  typealias P = QP
+}
+func f98(_: any RP?.P) {}
+func f99(_: any RP?.P?) {}
+
+// ...but these should still be errors:
+
+// expected-error@+2 {{confusing use of optional after a 'some' or 'any' composition; use parentheses to clarify precedence}}{{12-12=(}}{{17-17=)}}
+// expected-error@+1 {{non-protocol, non-class type '(any Q)?' cannot be used within a protocol-constrained type}}
+let _: any P & Q? = S()
+
+// expected-error@+3 {{confusing use of optional after a 'some' or 'any' composition; use parentheses to clarify precedence}}{{12-12=(}}{{18-18=)}}
+// expected-error@+2 {{non-protocol, non-class type '(any P)?' cannot be used within a protocol-constrained type}}
+// expected-error@+1 {{non-protocol, non-class type '(any Q)?' cannot be used within a protocol-constrained type}}
+let _: any P? & Q? = S()
+
+// expected-error@+1 {{non-protocol, non-class type '(any P)?' cannot be used within a protocol-constrained type}}
+let _: any P? & Q = S()

--- a/test/Sema/some_any_optional_sugar.swift
+++ b/test/Sema/some_any_optional_sugar.swift
@@ -14,9 +14,7 @@ func sugaredOpaqueReturn() -> some P? {
   }
 }
 
-// `(some P)!` is not allowed, so neither should this be.
-func sugaredIUOOpaqueReturn() -> some P! {  // expected-error {{using '!' is not allowed here}}
-                                            // expected-note@-1 {{use '?' instead}}
+func sugaredIUOOpaqueReturn() -> some P! {
   return S()
 }
 
@@ -61,11 +59,10 @@ struct MyType {
   var nonsugaredField7: (any P)!?  // expected-error {{using '!' is not allowed here}}
                                    // expected-note@-1 {{use '?' instead}}
 
-  // `(some P)!` and `(some P)?!` are not allowed, so neither should these be.
-  var sugaredField8: some P! { S() }  // expected-error {{using '!' is not allowed here}}
-                                      // expected-note@-1 {{use '?' instead}}
-  var sugaredField9: some P?! { S() }  // expected-error {{using '!' is not allowed here}}
-                                       // expected-note@-1 {{use '?' instead}}
+  var sugaredField8: some P! { S() }
+  var sugaredField9: some P?! { S() }
+
+  var sugaredField10: some ~Copyable? { S() }
 }
 
 // Deeper optionals
@@ -117,6 +114,10 @@ let _: any P.Type? = S.self
 // expected-error@+2 {{confusing use of optional after a 'some' or 'any' composition; use parentheses to clarify precedence}}{{12-12=(}}{{17-17=)}}
 // expected-error@+1 {{non-protocol, non-class type '(any Q)?' cannot be used within a protocol-constrained type}}
 let _: any P & Q? = S()
+
+// expected-error@+2 {{confusing use of optional after a 'some' or 'any' composition; use parentheses to clarify precedence}}{{12-12=(}}{{25-25=)}}
+// expected-error@+1 {{type '(any Copyable)?' cannot be suppressed}}
+let _: any P & ~Copyable? = S()
 
 // expected-error@+3 {{confusing use of optional after a 'some' or 'any' composition; use parentheses to clarify precedence}}{{12-12=(}}{{18-18=)}}
 // expected-error@+2 {{non-protocol, non-class type '(any P)?' cannot be used within a protocol-constrained type}}

--- a/test/Sema/some_any_optional_sugar.swift
+++ b/test/Sema/some_any_optional_sugar.swift
@@ -106,6 +106,12 @@ extension Optional {
 func f98(_: any RP?.P) {}
 func f99(_: any RP?.P?) {}
 
+// Parameterized protocols
+let _: any Sequence<Int>? = [1, 2, 3]
+func someSequenceOfInt() -> some Sequence<Int>? { return [1, 2, 3] }
+
+let _: any P.Type? = S.self
+
 // ...but these should still be errors:
 
 // expected-error@+2 {{confusing use of optional after a 'some' or 'any' composition; use parentheses to clarify precedence}}{{12-12=(}}{{17-17=)}}

--- a/test/Sema/some_any_optional_sugar_ast.swift
+++ b/test/Sema/some_any_optional_sugar_ast.swift
@@ -1,0 +1,39 @@
+// RUN: %target-swift-frontend -dump-ast %s | %FileCheck %s
+
+protocol P {}
+protocol Q {}
+struct S: P {}
+
+// CHECK:      (pattern_entry
+// CHECK-NEXT:   (pattern_typed type="(any P)?"
+// CHECK-NEXT:     (pattern_any type="(any P)?")
+// CHECK-NEXT:     (type_optional
+// CHECK-NEXT:       (type_existential
+// CHECK-NEXT:         (type_unqualified_ident id="P"
+let _: any P?
+
+// CHECK:      (pattern_entry
+// CHECK-NEXT:   (pattern_typed type="(any Q)?"
+// CHECK-NEXT:     (pattern_any type="(any Q)?")
+// CHECK-NEXT:     (type_implicitly_unwrapped_optional
+// CHECK-NEXT:       (type_existential
+// CHECK-NEXT:         (type_unqualified_ident id="Q"
+let _: any Q!
+
+// CHECK:      (pattern_entry
+// CHECK-NEXT:   (pattern_typed type="(any P & Q)?"
+// CHECK-NEXT:     (pattern_any type="(any P & Q)?")
+// CHECK-NEXT:     (type_optional
+// CHECK-NEXT:       (type_existential
+// CHECK-NEXT:         (type_tuple
+// CHECK-NEXT:           (type_composite
+// CHECK-NEXT:             (type_unqualified_ident id="P"
+// CHECK-NEXT:             (type_unqualified_ident id="Q"
+let _: any (P & Q)?
+
+// CHECK:      (func_decl {{.*}}result="(some P)?" 
+// CHECK-NEXT:   (opaque_result_decl=opaque_type {{.*}}interface_type="(some P)?.Type"
+func f() -> some P? { S() }
+
+// CHECK:      (func_decl {{.*}}interface_type=" ((some P)?) -> ()"
+func g(_: some P?) {}

--- a/test/Sema/some_any_optional_sugar_ast.swift
+++ b/test/Sema/some_any_optional_sugar_ast.swift
@@ -37,3 +37,6 @@ func f() -> some P? { S() }
 
 // CHECK:      (func_decl {{.*}}interface_type=" ((some P)?) -> ()"
 func g(_: some P?) {}
+
+// CHECK:      (func_decl {{.*}}interface_type="(borrowing (any ~Copyable)?) -> ()"
+func h(_: borrowing any ~Copyable?) {}

--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -540,15 +540,9 @@ func testAnyFixIt() {
 
   // Misplaced '?'.
 
-  // expected-error@+1 {{optional 'any' type must be written '(any HasAssoc)?'}}{{10-23=(any HasAssoc)?}}
-  let _: any HasAssoc?
-  // expected-error@+1:10 {{optional 'any' type must be written '(any HasAssocGeneric<Int>)?'}}{{10-35=(any HasAssocGeneric<Int>)?}}
-  let _: any HasAssocGeneric<Int>?
   // FIXME: Better recovery
   // expected-error@+1 {{type '(any Copyable)?' cannot be suppressed}}
   let _: any ~Copyable?
-  // expected-error@+1 {{optional 'any' type must be written '(any HasAssoc.Type)?'}}{{10-28=(any HasAssoc.Type)?}}
-  let _: any HasAssoc.Type?
   // FIXME: Better recovery
   // expected-error@+1 {{type '(any Copyable.Type)?' cannot be suppressed}}
   let _: any ~Copyable.Type?

--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -469,7 +469,7 @@ func testAnyFixIt() {
   let _: HasAssoc.Type.Type.Protocol
   // expected-warning@+1 {{constraint that suppresses conformance requires 'any'}}{{10-31=(any (~Copyable).Type.Type)}}
   let _: (~Copyable).Type.Type.Protocol
-  // expected-warning@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-18=(any HasAssoc)}}
+  // expected-warning@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-18=any HasAssoc}}
   let _: HasAssoc?
   // expected-error@+1 {{type '(any Copyable)?' cannot be suppressed}}
   let _: ~Copyable?
@@ -477,7 +477,7 @@ func testAnyFixIt() {
   let _: (HasAssoc)?
   // expected-warning@+1 {{constraint that suppresses conformance requires 'any'}}{{11-20=any ~Copyable}}
   let _: (~Copyable)?
-  // expected-warning@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-18=(any HasAssoc)}}
+  // expected-warning@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-18=any HasAssoc}}
   let _: HasAssoc!
   // expected-note@+4 {{use '?' instead}}{{19-20=?}}
   // expected-default-swift-mode-warning@+3 {{using '!' here is deprecated}}
@@ -486,9 +486,9 @@ func testAnyFixIt() {
   let _: ~Copyable!
   // expected-warning@+1 {{constraint that suppresses conformance requires 'any'}}{{11-20=any ~Copyable}}
   let _: (~Copyable)!
-  // expected-warning@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-23=(any HasAssoc.Type)}}
+  // expected-warning@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-23=any HasAssoc.Type}}
   let _: HasAssoc.Type?
-  // expected-warning@+1 {{constraint that suppresses conformance requires 'any'}}{{10-26=(any (~Copyable).Type)}}
+  // expected-warning@+1 {{constraint that suppresses conformance requires 'any'}}{{10-26=any (~Copyable).Type}}
   let _: (~Copyable).Type?
   // expected-warning@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-18=(any HasAssoc)}}
   let _: HasAssoc.Protocol?
@@ -532,9 +532,9 @@ func testAnyFixIt() {
   // expected-warning@+2 {{constraint that suppresses conformance requires 'any'}}{{21-52=any NonCopyableHasAssoc & ~Copyable}}
   // expected-warning@+1 {{use of protocol 'NonCopyableHasAssoc' as a type must be written 'any NonCopyableHasAssoc'}}{{21-52=any NonCopyableHasAssoc & ~Copyable}}
   let _: (borrowing NonCopyableHasAssoc & ~Copyable) -> Void
-  // expected-warning@+3:15 {{constraint that suppresses conformance requires 'any'}}{{10-88=(any (((((~Copyable) & NonCopyableHasAssoc) & NonCopyableHasAssoc).Type.Type)).Type)}}
-  // expected-warning@+2:28 {{use of protocol 'NonCopyableHasAssoc' as a type must be written 'any NonCopyableHasAssoc'}}{{10-88=(any (((((~Copyable) & NonCopyableHasAssoc) & NonCopyableHasAssoc).Type.Type)).Type)}}
-  // expected-warning@+1:51 {{use of protocol 'NonCopyableHasAssoc' as a type must be written 'any NonCopyableHasAssoc'}}{{10-88=(any (((((~Copyable) & NonCopyableHasAssoc) & NonCopyableHasAssoc).Type.Type)).Type)}}
+  // expected-warning@+3:15 {{constraint that suppresses conformance requires 'any'}}{{10-88=any (((((~Copyable) & NonCopyableHasAssoc) & NonCopyableHasAssoc).Type.Type)).Type}}
+  // expected-warning@+2:28 {{use of protocol 'NonCopyableHasAssoc' as a type must be written 'any NonCopyableHasAssoc'}}{{10-88=any (((((~Copyable) & NonCopyableHasAssoc) & NonCopyableHasAssoc).Type.Type)).Type}}
+  // expected-warning@+1:51 {{use of protocol 'NonCopyableHasAssoc' as a type must be written 'any NonCopyableHasAssoc'}}{{10-88=any (((((~Copyable) & NonCopyableHasAssoc) & NonCopyableHasAssoc).Type.Type)).Type}}
   let _: (((((~Copyable) & NonCopyableHasAssoc) & NonCopyableHasAssoc).Type.Type)).Type?
   let _: any (((((~Copyable) & NonCopyableHasAssoc) & NonCopyableHasAssoc).Type.Type)).Type // OK
 

--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -537,15 +537,6 @@ func testAnyFixIt() {
   // expected-warning@+1:51 {{use of protocol 'NonCopyableHasAssoc' as a type must be written 'any NonCopyableHasAssoc'}}{{10-88=any (((((~Copyable) & NonCopyableHasAssoc) & NonCopyableHasAssoc).Type.Type)).Type}}
   let _: (((((~Copyable) & NonCopyableHasAssoc) & NonCopyableHasAssoc).Type.Type)).Type?
   let _: any (((((~Copyable) & NonCopyableHasAssoc) & NonCopyableHasAssoc).Type.Type)).Type // OK
-
-  // Misplaced '?'.
-
-  // FIXME: Better recovery
-  // expected-error@+1 {{type '(any Copyable)?' cannot be suppressed}}
-  let _: any ~Copyable?
-  // FIXME: Better recovery
-  // expected-error@+1 {{type '(any Copyable.Type)?' cannot be suppressed}}
-  let _: any ~Copyable.Type?
 }
 
 func testNestedMetatype() {

--- a/test/type/implicit_some/explicit_existential.swift
+++ b/test/type/implicit_some/explicit_existential.swift
@@ -267,9 +267,7 @@ func testAnyFixIt() {
   let _: (any HasAssoc.Type)? = ConformingType.self
   let _: (any HasAssoc).Protocol? = (any HasAssoc).self
 
-  // expected-error@+1 {{optional 'any' type must be written '(any HasAssoc)?'}}{{10-23=(any HasAssoc)?}}
   let _: any HasAssoc? = nil
-  // expected-error@+1 {{optional 'any' type must be written '(any HasAssoc.Type)?'}}{{10-28=(any HasAssoc.Type)?}}
   let _: any HasAssoc.Type? = nil
 }
 

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -85,7 +85,7 @@ typealias Foo = some P // expected-error{{'some' types are only permitted}}
 
 func blibble(blobble: some P) {}
 func blib() -> P & some Q { return 1 } // expected-error{{'some' should appear at the beginning}}
-func blab() -> some P? { return 1 } // expected-error{{must specify only}} expected-note{{did you mean to write an optional of an 'some' type?}}
+func blab() -> some P? { return 1 }
 func blorb<T: some P>(_: T) { } // expected-error{{'some' types are only permitted}}
 func blub<T>() -> T where T == some P { return 1 } // expected-error{{'some' types are only permitted}}
 


### PR DESCRIPTION
Let us unshackle ourselves from the parentheses that bind us. Implementation of [SE-0521](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0521-improved-optional-opaque-and-any.md) which has been accepted.

Companion of https://github.com/swiftlang/swift-syntax/pull/3268.