### PR TITLE
[6.3 🍒][Dependency Scanning] Fix suspected use-after-free in `recordClangDependency`

### DIFF
--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -826,7 +826,8 @@ void ModuleDependenciesCache::recordClangDependency(
         diag::dependency_scan_unexpected_variant_module_map_note,
         priorClangModuleDetails->moduleMapFile, dependency.ClangModuleMapFile);
 
-    auto newClangModuleDetails = bridgeClangModule(dependency).getAsClangModule();
+    auto newClangModuleInfo = bridgeClangModule(dependency);
+    auto newClangModuleDetails = newClangModuleInfo.getAsClangModule();
     auto diagnoseExtraCommandLineFlags =
         [&diags](const ClangModuleDependencyStorage *checkModuleDetails,
                const ClangModuleDependencyStorage *baseModuleDetails,


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift/pull/87112
---------------------
- **Explanation**
We are hitting a `EXC_BAD_ACCESS` crash in `swift::ModuleDependenciesCache::recordClangDependency`. The only interesting thing this method does appears to be emitting a diagnostic note when encountering a variant Clang dependency node within the same scan. When preparing the diagnostic messages, the scanner needs to access the Clang module details of the prior-discovered node. We get at the prior node's details with: `auto newClangModuleDetails = bridgeClangModule(dependency).getAsClangModule();`, where `bridgeClangModule` returns a module info by-value and `.getAsClangModule()` returns a pointer to an object allocated to have its lifetime tied to the info value. It seems that by the time we access this pointer a few lines of code later to get at the command-line strings, the value has gone out of scope and the corresponding memory has been deallocated. Keeping the module info object in scope for the duration of the diagnostic code should resolve it.

- **Resolves**:  rdar://165870730
- **Main branch PR**: https://github.com/swiftlang/swift/pull/87112
- **Risk**: Low, this splits up a line of code into two to create a scoped temporary variable in order to extend its lifetime. It does not otherwise change any semantics.
- **Reviewed By**: TBD
- **Testing**: It is challenging to test this code since its purpose is to diagnose an error condition we do not currently know how to diagnose ourselves, unfortunately. That said, the change is really trivial. 
