### PR TITLE
Improve XMACROS in PartitionOpError.def to eliminate more boilerplate.

### DIFF
--- a/include/swift/SILOptimizer/Utils/PartitionOpError.def
+++ b/include/swift/SILOptimizer/Utils/PartitionOpError.def
@@ -10,63 +10,162 @@
 //
 //===----------------------------------------------------------------------===//
 ///
-/// This file contains macros for creating PartitionOpErrors for use with
-/// SendNonSendable. This just makes it easier to add these errors without
-/// needing to write so much boielr plate.
+/// This file contains macros for defining PartitionOpError kinds used by
+/// SendNonSendable diagnostics. Using an X-macro pattern reduces boilerplate
+/// when adding new error types and ensures consistency across:
+/// - Error kind enumeration
+/// - Error struct definitions
+/// - Error handler dispatch (handleError)
+/// - Verbatim error emission (emitVerbatimErrors)
 ///
 //===----------------------------------------------------------------------===//
 
+//===----------------------------------------------------------------------===//
+//                              Macro Definitions
+//===----------------------------------------------------------------------===//
+//
+// Errors fall into two categories based on how they are emitted:
+//
+// 1. Data Dependent Errors: These errors require additional context from
+//    analysis data structures (like sendingOpToRequireInstMultiMap) to emit
+//    diagnostics. They are handled immediately during dataflow evaluation in
+//    handleError(). Example: LocalUseAfterSend needs to record send/use pairs
+//    for later. These are today just made PARTITION_OP_ERROR. We can categorize
+//    them separately in the future if needed.
+//
+// 2. VERBATIM ERRORS (PARTITION_OP_VERBATIM_ERROR):
+//    These errors are self-contained - all information needed for emission
+//    is stored within the error struct itself. They are collected during
+//    dataflow and batch-emitted later in emitVerbatimErrors().
+//    Example: SentNeverSendable contains the operand and isolation info.
+//
+// The VERBATIM_SPECIAL_EMISSION_EMITTER variant handles verbatim errors that
+// require custom emission logic that doesn't fit the standard pattern.
+
+/// Base macro for all partition operation errors. Data-dependent errors that
+/// require immediate handling during dataflow should use this directly.
 #ifndef PARTITION_OP_ERROR
 #define PARTITION_OP_ERROR(Name)
 #endif
 
-/// An error created if we discover a value was locally used after it
-/// was already sent.
+/// Macro for verbatim errors that contain all state needed for emission.
+/// These are collected during dataflow and emitted later via a diagnostic
+/// emitter class named `<Name>DiagnosticEmitter` with an `emit()` method.
+/// The emitter constructor takes (RegionAnalysisFunctionInfo*, <Name>Error).
+#ifndef PARTITION_OP_VERBATIM_ERROR
+#define PARTITION_OP_VERBATIM_ERROR(Name) PARTITION_OP_ERROR(Name)
+#endif
+
+/// Macro for verbatim errors with non-standard emission patterns.
 ///
-/// The arguments in the type are:
+/// Standard verbatim errors map 1:1 to diagnostic emitters. This macro is for
+/// errors that need special handling, such as:
+/// - Emitting multiple diagnostics from a single error
+/// - Requiring additional filtering logic before emission
+/// - Needing access to data not passed through the standard constructor
 ///
-/// 1. The PartitionOp that required the element to be alive.
+/// Errors using this macro are explicitly handled in emitVerbatimErrors()
+/// rather than through the X-macro expansion.
+#ifndef PARTITION_OP_VERBATIM_SPECIAL_EMISSION_EMITTER
+#define PARTITION_OP_VERBATIM_SPECIAL_EMISSION_EMITTER(Name) PARTITION_OP_VERBATIM_ERROR(Name)
+#endif
+
+//===----------------------------------------------------------------------===//
+//                              Error Definitions
+//===----------------------------------------------------------------------===//
+
+/// A value was used after its region was already sent to another isolation
+/// domain.
 ///
-/// 2. The element in the PartitionOp that was asked to be alive.
+/// This is a data-dependent error because we need to track the relationship
+/// between the sending operation and all subsequent uses in
+/// sendingOpToRequireInstMultiMap for deferred diagnostic emission.
 ///
-/// 3. The operand of the instruction that originally sent the region. Can be
-/// used to get the immediate value sent or the sending instruction.
+/// Error struct fields:
+/// - op: The PartitionOp representing the use that required the element.
+/// - sentElement: The element that was used after being sent.
+/// - sendingOp: The operand of the instruction that originally sent the region.
 PARTITION_OP_ERROR(LocalUseAfterSend)
 
-/// This is called if we detect a never sendable element that was actually sent.
+/// An 'inout sending' parameter was sent but not reinitialized before the
+/// function exits.
 ///
-/// E.x.: passing a main actor exposed value to a sending parameter.
-PARTITION_OP_ERROR(SentNeverSendable)
-
-/// This is emitted when a never sendable value is passed into a sending
-/// result. The sending result will be viewed in our caller as disconnected and
-/// able to be sent.
-PARTITION_OP_ERROR(AssignNeverSendableIntoSendingResult)
-
-/// This is emitted when an inout sending parameter has been sent in a function
-/// body but has not been reinitialized at the end of the function.
+/// When a function sends an 'inout sending' parameter's region, it must
+/// reinitialize the parameter with a disconnected value before returning.
+/// This ensures the caller doesn't observe the parameter in an invalid state.
+///
+/// This is a data-dependent error because it needs to record the send location
+/// for use in later diagnostic emission alongside other send-related errors.
 PARTITION_OP_ERROR(InOutSendingNotInitializedAtExit)
 
-/// This is emitted when an inout sending parameter has been assigned a
-/// non-disconnected value (e.x.: a value exposed to main actor isolated code)
-/// at end of function without being reinitialized with something disconnected.
-PARTITION_OP_ERROR(InOutSendingNotDisconnectedAtExit)
+//===---
+// Verbatim Errors
+//
+// These are self-contained and can be emitted using only their stored state.
+//===---
 
-/// This is emitted when a concrete inout sending parameter is returned.
-PARTITION_OP_ERROR(InOutSendingReturned)
-
-/// Used to signify an "unknown code pattern" has occured while performing
-/// dataflow.
+/// An unrecognized code pattern was encountered during dataflow analysis.
 ///
-/// DISCUSSION: Our dataflow cannot emit errors itself so this is a callback
-/// to our user so that we can emit that error as we process.
-PARTITION_OP_ERROR(UnknownCodePattern)
+/// This is a fallback error indicating the analysis found SIL that it doesn't
+/// know how to handle. It may indicate a gap in the analysis or new SIL
+/// constructs that need support.
+PARTITION_OP_VERBATIM_ERROR(UnknownCodePattern)
 
-/// Used to signify that an isolation crossing function is returning a
-/// non-Sendable value.
-PARTITION_OP_ERROR(NonSendableIsolationCrossingResult)
+/// A non-Sendable value that must stay in its isolation domain was passed to a
+/// 'sending' parameter or into another isolation domain.
+///
+/// Example: Passing a value in a @MainActor region to a function expecting a
+/// 'sending' parameter.
+///
+/// Error struct contains the sending operand and isolation info of the
+/// non-Sendable value, which is sufficient to emit the diagnostic.
+PARTITION_OP_VERBATIM_ERROR(SentNeverSendable)
 
-/// Used to signify that two 'inout sending' values are in the same region.
-PARTITION_OP_ERROR(InOutSendingParametersInSameRegion)
+/// A non-Sendable value was assigned into a 'sending' result parameter.
+///
+/// When a function has a 'sending' out-parameter, the caller expects to
+/// receive a disconnected value that can be freely sent. Assigning an
+/// isolated value violates this contract.
+///
+/// Example: Storing a value from an @MainActor-isolated region into an 'inout
+/// sending T' parameter that the caller expects to be sendable.
+PARTITION_OP_VERBATIM_ERROR(AssignNeverSendableIntoSendingResult)
 
+/// An 'inout sending' parameter was assigned an isolated (non-disconnected)
+/// value at function exit.
+///
+/// Similar to InOutSendingNotInitializedAtExit, but here the parameter WAS
+/// reinitialized - just with a value that isn't disconnected. The caller
+/// expects 'inout sending' parameters to contain disconnected values.
+PARTITION_OP_VERBATIM_ERROR(InOutSendingNotDisconnectedAtExit)
+
+/// A concrete 'inout sending' parameter's value is being returned from
+/// the function.
+PARTITION_OP_VERBATIM_ERROR(InOutSendingReturned)
+
+/// A function crossing isolation boundaries is returning a non-Sendable value.
+///
+/// When a function's result crosses isolation domains (e.g., an async function
+/// called from a different actor), returning a non-Sendable type is unsafe.
+PARTITION_OP_VERBATIM_ERROR(NonSendableIsolationCrossingResult)
+
+//===---
+// Verbatim Errors with Special Emission
+//
+// These need custom handling that doesn't fit the standard emitter pattern.
+//===---
+
+/// Two or more 'inout sending' parameters belong to the same region.
+///
+/// This is problematic because 'inout sending' parameters must be
+/// independently transferable. If they share a region, sending one would
+/// invalidate the other.
+///
+/// Uses SPECIAL_EMISSION because a single error may need to emit multiple
+/// diagnostics (one for each pair of parameters in the same region) and
+/// requires filtering based on diagnostic behavior settings.
+PARTITION_OP_VERBATIM_SPECIAL_EMISSION_EMITTER(InOutSendingParametersInSameRegion)
+
+#undef PARTITION_OP_VERBATIM_SPECIAL_EMISSION_EMITTER
+#undef PARTITION_OP_VERBATIM_ERROR
 #undef PARTITION_OP_ERROR

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -749,7 +749,7 @@ struct DiagnosticEvaluator final
         sendingOpToRequireInstMultiMap(sendingOpToRequireInstMultiMap),
         foundVerbatimErrors(foundVerbatimErrors) {}
 
-  void handleLocalUseAfterSend(LocalUseAfterSendError &&error) const {
+  void handleLocalUseAfterSendError(LocalUseAfterSendError &&error) const {
     const auto &partitionOp = *error.op;
     REGIONBASEDISOLATION_LOG(error.print(llvm::dbgs(), info->getValueMap()));
 
@@ -776,48 +776,24 @@ struct DiagnosticEvaluator final
                        partitionOp.getSourceInst()));
   }
 
-  void handleUnknownCodePattern(UnknownCodePatternError &&error) const {
-    const PartitionOp &op = *error.op;
-
-    if (shouldAbortOnUnknownPatternMatchError()) {
-      llvm::report_fatal_error(
-          "RegionIsolation: Aborting on unknown pattern match error");
-    }
-
-    REGIONBASEDISOLATION_LOG(llvm::dbgs() << "Emitting Error. Verbatim Error: "
-                                             "Unknown Code Pattern.\n"
-                             << "  Inst: " << *op.getSourceInst());
-    diagnoseError(op.getSourceInst(),
-                  diag::regionbasedisolation_unknown_pattern);
-  }
-
+  /// Dispatch an error discovered during dataflow to the appropriate handler.
+  ///
+  /// This uses X-macros from PartitionOpError.def to generate the switch cases:
+  /// - PARTITION_OP_ERROR: Data-dependent errors are handled immediately via
+  ///   handle<Name>Error() methods, which may record state for later emission.
+  /// - PARTITION_OP_VERBATIM_ERROR: Self-contained errors are collected into
+  ///   foundVerbatimErrors for batch emission later in emitVerbatimErrors().
   void handleError(PartitionOpError &&error) {
     switch (error.getKind()) {
-    case PartitionOpError::LocalUseAfterSend: {
-      return handleLocalUseAfterSend(
-          std::move(error).getLocalUseAfterSendError());
-    }
-    case PartitionOpError::InOutSendingNotDisconnectedAtExit:
-    case PartitionOpError::InOutSendingReturned:
-    case PartitionOpError::SentNeverSendable:
-    case PartitionOpError::AssignNeverSendableIntoSendingResult:
-    case PartitionOpError::NonSendableIsolationCrossingResult:
-    case PartitionOpError::InOutSendingParametersInSameRegion:
-      // We are going to process these later... but dump so we can see that we
-      // handled an error here. The rest of the explicit handlers will dump as
-      // appropriate if they want to emit an error here (some will squelch the
-      // error).
-      REGIONBASEDISOLATION_LOG(error.print(llvm::dbgs(), info->getValueMap()));
-      foundVerbatimErrors.emplace_back(std::move(error));
-      return;
-    case PartitionOpError::InOutSendingNotInitializedAtExit: {
-      return handleInOutSendingNotInitializedAtExitError(
-          std::move(error).getInOutSendingNotInitializedAtExitError());
-    }
-    case PartitionOpError::UnknownCodePattern: {
-      return handleUnknownCodePattern(
-          std::move(error).getUnknownCodePatternError());
-    }
+#define PARTITION_OP_ERROR(NAME)                                               \
+  case PartitionOpError::NAME:                                                 \
+    return handle##NAME##Error(std::move(error).get##NAME##Error());
+#define PARTITION_OP_VERBATIM_ERROR(NAME)                                      \
+  case PartitionOpError::NAME:                                                 \
+    REGIONBASEDISOLATION_LOG(error.print(llvm::dbgs(), info->getValueMap()));  \
+    foundVerbatimErrors.emplace_back(std::move(error));                        \
+    return;
+#include "swift/SILOptimizer/Utils/PartitionOpError.def"
     }
     llvm_unreachable("Covered switch isn't covered?!");
   }
@@ -1556,7 +1532,19 @@ void SendNonSendableImpl::emitUseAfterSendDiagnostics() {
 
 namespace {
 
-class SendNeverSentDiagnosticEmitter {
+/// Helper class that provides the core diagnostic emission logic for
+/// SentNeverSendable errors.
+///
+/// This class handles the mechanics of emitting diagnostics: tracking whether
+/// an error was emitted, providing diagnostic convenience methods, and emitting
+/// an "unknown pattern" error if no specific diagnostic was produced. It's used
+/// as a composition member by SentNeverSendableDiagnosticEmitter, which handles
+/// the higher-level logic of determining WHAT diagnostic to emit based on the
+/// error context.
+///
+/// The separation exists because the diagnostic emission logic is reusable,
+/// while the inference logic for determining the appropriate diagnostic varies.
+class SendNeverSentDiagnosticEmitterHelper {
   /// The use that actually caused the send.
   Operand *sendingOperand;
 
@@ -1574,14 +1562,14 @@ class SendNeverSentDiagnosticEmitter {
   bool emittedErrorDiagnostic = false;
 
 public:
-  SendNeverSentDiagnosticEmitter(
+  SendNeverSentDiagnosticEmitterHelper(
       Operand *sendingOperand,
       llvm::PointerUnion<SILValue, SILInstruction *> neverSent,
       SILDynamicMergedIsolationInfo isolationRegionInfo)
       : sendingOperand(sendingOperand), neverSent(neverSent),
         isolationRegionInfo(isolationRegionInfo) {}
 
-  ~SendNeverSentDiagnosticEmitter() {
+  ~SendNeverSentDiagnosticEmitterHelper() {
     if (!emittedErrorDiagnostic) {
       emitUnknownPatternError();
     } else if (auto proto = isolationRegionInfo.getIsolationInfo()
@@ -1981,18 +1969,29 @@ private:
   }
 };
 
-class SentNeverSendableDiagnosticInferrer {
+/// Diagnostic emitter for SentNeverSendable errors.
+///
+/// This is a verbatim error emitter (see PartitionOpError.def) that follows
+/// the standard pattern: constructor takes (RegionAnalysisFunctionInfo*, Error)
+/// and provides an emit() method.
+///
+/// The emitter analyzes the error context to determine the most appropriate
+/// diagnostic. For example, it handles:
+/// - Sending actor-isolated values to functions expecting sendable values
+/// - Capturing isolated values in closures passed to sending parameters
+/// - Various special cases like autoclosures and async let
+class SentNeverSendableDiagnosticEmitter {
   struct AutoClosureWalker;
 
   RegionAnalysisValueMap &valueMap;
-  SendNeverSentDiagnosticEmitter diagnosticEmitter;
+  SendNeverSentDiagnosticEmitterHelper diagnosticEmitter;
 
   using SentNeverSendableError = PartitionOpError::SentNeverSendableError;
 
 public:
-  SentNeverSendableDiagnosticInferrer(RegionAnalysisValueMap &valueMap,
-                                      SentNeverSendableError error)
-      : valueMap(valueMap),
+  SentNeverSendableDiagnosticEmitter(RegionAnalysisFunctionInfo *info,
+                                     SentNeverSendableError error)
+      : valueMap(info->getValueMap()),
         diagnosticEmitter(error.op->getSourceOp(),
                           valueMap.getRepresentative(error.sentElement),
                           error.isolationRegionInfo) {}
@@ -2001,7 +2000,7 @@ public:
   /// error". If we emit such an error, we should bail without emitting any
   /// further diagnostics, since we may not have any diagnostics or be in an
   /// inconcistent state.
-  bool run();
+  bool emit();
 
 private:
   /// \p actualCallerIsolation is used to override the caller isolation we use
@@ -2028,7 +2027,7 @@ private:
 
 } // namespace
 
-bool SentNeverSendableDiagnosticInferrer::initForSendingPartialApply(
+bool SentNeverSendableDiagnosticEmitter::initForSendingPartialApply(
     FullApplySite fas, Operand *callsiteOp) {
   // This is the partial apply that is being passed as a sending parameter.
   auto *sendingPAI =
@@ -2127,7 +2126,7 @@ bool SentNeverSendableDiagnosticInferrer::initForSendingPartialApply(
   return true;
 }
 
-bool SentNeverSendableDiagnosticInferrer::initForIsolatedPartialApply(
+bool SentNeverSendableDiagnosticEmitter::initForIsolatedPartialApply(
     Operand *op, AbstractClosureExpr *ace,
     std::optional<ActorIsolation> actualCallerIsolation) {
   auto diagnosticPair = findClosureUse(op);
@@ -2168,15 +2167,15 @@ bool SentNeverSendableDiagnosticInferrer::initForIsolatedPartialApply(
 
 /// This walker visits an AutoClosureExpr and looks for uses of a specific
 /// captured value. We want to error on the uses in the autoclosure.
-struct SentNeverSendableDiagnosticInferrer::AutoClosureWalker : ASTWalker {
-  SendNeverSentDiagnosticEmitter &foundTypeInfo;
+struct SentNeverSendableDiagnosticEmitter::AutoClosureWalker : ASTWalker {
+  SendNeverSentDiagnosticEmitterHelper &foundTypeInfo;
   ValueDecl *targetDecl;
   SILIsolationInfo targetDeclIsolationInfo;
   SmallPtrSet<Expr *, 8> visitedCallExprDeclRefExprs;
   SILLocation captureLoc;
   bool isAsyncLet;
 
-  AutoClosureWalker(SendNeverSentDiagnosticEmitter &foundTypeInfo,
+  AutoClosureWalker(SendNeverSentDiagnosticEmitterHelper &foundTypeInfo,
                     ValueDecl *targetDecl,
                     SILIsolationInfo targetDeclIsolationInfo,
                     SILLocation captureLoc, bool isAsyncLet)
@@ -2233,7 +2232,7 @@ struct SentNeverSendableDiagnosticInferrer::AutoClosureWalker : ASTWalker {
   }
 };
 
-bool SentNeverSendableDiagnosticInferrer::run() {
+bool SentNeverSendableDiagnosticEmitter::emit() {
   // We need to find the isolation info.
   auto *op = diagnosticEmitter.getOperand();
   auto loc = op->getUser()->getLoc();
@@ -2377,12 +2376,27 @@ bool SentNeverSendableDiagnosticInferrer::run() {
 }
 
 //===----------------------------------------------------------------------===//
-//               MARK: InOutSendingReturnedError Error Emitter
+//              MARK: InOutSendingReturned Error Emitter
 //===----------------------------------------------------------------------===//
 
 namespace {
 
+/// Diagnostic emitter for InOutSendingReturned errors.
+///
+/// This is a verbatim error emitter (see PartitionOpError.def) that follows
+/// the standard pattern: constructor takes (RegionAnalysisFunctionInfo*, Error)
+/// and provides an emit() method.
+///
+/// This error occurs when a function returns a value that is in the same region
+/// as an 'inout sending' parameter. This creates a problematic situation where
+/// both the return value and the inout parameter reference the same value, but
+/// 'sending' implies the value could be sent to another isolation
+/// domain safely.
 class InOutSendingReturnedDiagnosticEmitter {
+public:
+  using Error = PartitionOpError::InOutSendingReturnedError;
+
+private:
   /// A region analysis function info that we use if we need to determine which
   /// incoming block edge had an error upon it.
   RegionAnalysisFunctionInfo *raFuncInfo;
@@ -2413,14 +2427,16 @@ class InOutSendingReturnedDiagnosticEmitter {
 public:
   class LastValueEnum;
 
-  InOutSendingReturnedDiagnosticEmitter(
-      RegionAnalysisFunctionInfo *raFuncInfo, TermInst *functionExitingInst,
-      SILValue inoutSendingParam, Element inoutSendingParamElement,
-      SILValue erroringValue, SILDynamicMergedIsolationInfo isolationInfo)
-      : raFuncInfo(raFuncInfo), functionExitingInst(functionExitingInst),
-        inoutSendingParam(inoutSendingParam),
-        inoutSendingParamElement(inoutSendingParamElement),
-        returnedValue(erroringValue), isolationInfo(isolationInfo) {}
+  InOutSendingReturnedDiagnosticEmitter(RegionAnalysisFunctionInfo *raFuncInfo,
+                                        Error error)
+      : raFuncInfo(raFuncInfo),
+        functionExitingInst(cast<TermInst>(error.op->getSourceInst())),
+        inoutSendingParam(raFuncInfo->getValueMap().getRepresentative(
+            error.inoutSendingElement)),
+        inoutSendingParamElement(error.inoutSendingElement),
+        returnedValue(
+            raFuncInfo->getValueMap().getRepresentative(error.returnedValue)),
+        isolationInfo(error.isolationInfo) {}
 
   ~InOutSendingReturnedDiagnosticEmitter() {
     // If we were supposed to emit a diagnostic and didn't emit an unknown
@@ -3023,7 +3039,21 @@ bool InOutSendingReturnedDiagnosticEmitter::LastValueEnum::
 
 namespace {
 
-class InOutSendingNotDisconnectedDiagnosticEmitter {
+/// Diagnostic emitter for InOutSendingNotDisconnectedAtExit errors.
+///
+/// This is a verbatim error emitter (see PartitionOpError.def) that follows
+/// the standard pattern: constructor takes (RegionAnalysisFunctionInfo*, Error)
+/// and provides an emit() method.
+///
+/// This error occurs when an 'inout sending' parameter ends up in an isolated
+/// region at function exit. The contract requires such parameters to be
+/// "disconnected" (not associated with any actor) when the function returns,
+/// so the caller can safely send the value elsewhere.
+class InOutSendingNotDisconnectedAtExitDiagnosticEmitter {
+public:
+  using Error = PartitionOpError::InOutSendingNotDisconnectedAtExitError;
+
+private:
   /// The function exiting inst where the 'inout sending' parameter was actor
   /// isolated.
   TermInst *functionExitingInst;
@@ -3038,14 +3068,14 @@ class InOutSendingNotDisconnectedDiagnosticEmitter {
   bool emittedErrorDiagnostic = false;
 
 public:
-  InOutSendingNotDisconnectedDiagnosticEmitter(
-      TermInst *functionExitingInst, SILValue inoutSendingParam,
-      SILDynamicMergedIsolationInfo actorIsolatedRegionInfo)
-      : functionExitingInst(functionExitingInst),
-        inoutSendingParam(inoutSendingParam),
-        actorIsolatedRegionInfo(actorIsolatedRegionInfo) {}
+  InOutSendingNotDisconnectedAtExitDiagnosticEmitter(
+      RegionAnalysisFunctionInfo *info, Error error)
+      : functionExitingInst(cast<TermInst>(error.op->getSourceInst())),
+        inoutSendingParam(
+            info->getValueMap().getRepresentative(error.inoutSendingElement)),
+        actorIsolatedRegionInfo(error.isolationInfo) {}
 
-  ~InOutSendingNotDisconnectedDiagnosticEmitter() {
+  ~InOutSendingNotDisconnectedAtExitDiagnosticEmitter() {
     // If we were supposed to emit a diagnostic and didn't emit an unknown
     // pattern error.
     if (!emittedErrorDiagnostic)
@@ -3111,7 +3141,7 @@ public:
 
 } // namespace
 
-void InOutSendingNotDisconnectedDiagnosticEmitter::emit() {
+void InOutSendingNotDisconnectedAtExitDiagnosticEmitter::emit() {
   // We should always be able to find a name for an inout sending param. If we
   // do not, emit an unknown pattern error.
   auto varName = inferNameHelper(inoutSendingParam);
@@ -3136,12 +3166,26 @@ void InOutSendingNotDisconnectedDiagnosticEmitter::emit() {
 }
 
 //===----------------------------------------------------------------------===//
-//           MARK: AssignIsolatedIntoSendingResultDiagnosticEmitter
+//         MARK: AssignNeverSendableIntoSendingResult Error Emitter
 //===----------------------------------------------------------------------===//
 
 namespace {
 
-class AssignIsolatedIntoSendingResultDiagnosticEmitter {
+/// Diagnostic emitter for AssignNeverSendableIntoSendingResult errors.
+///
+/// This is a verbatim error emitter (see PartitionOpError.def) that follows
+/// the standard pattern: constructor takes (RegionAnalysisFunctionInfo*, Error)
+/// and provides an emit() method.
+///
+/// This error occurs when an isolated (non-Sendable) value is assigned into a
+/// 'sending' out-parameter or result. The caller expects such results to be
+/// "disconnected" and safe to send, but the value is tied to an isolation
+/// domain and cannot be safely sent.
+class AssignNeverSendableIntoSendingResultDiagnosticEmitter {
+public:
+  using Error = PartitionOpError::AssignNeverSendableIntoSendingResultError;
+
+private:
   /// The use that actually caused the send.
   Operand *srcOperand;
 
@@ -3162,15 +3206,13 @@ class AssignIsolatedIntoSendingResultDiagnosticEmitter {
   bool emittedErrorDiagnostic = false;
 
 public:
-  AssignIsolatedIntoSendingResultDiagnosticEmitter(
-      Operand *srcOperand, SILFunctionArgument *outSendingResult,
-      SILValue neverSentValue,
-      SILDynamicMergedIsolationInfo isolatedValueIsolationRegionInfo)
-      : srcOperand(srcOperand), outSendingResult(outSendingResult),
-        neverSentValue(neverSentValue),
-        isolatedValueIsolationRegionInfo(isolatedValueIsolationRegionInfo) {}
+  AssignNeverSendableIntoSendingResultDiagnosticEmitter(
+      RegionAnalysisFunctionInfo *info, Error error)
+      : srcOperand(error.op->getSourceOp()), outSendingResult(error.destValue),
+        neverSentValue(error.srcValue),
+        isolatedValueIsolationRegionInfo(error.srcIsolationRegionInfo) {}
 
-  ~AssignIsolatedIntoSendingResultDiagnosticEmitter() {
+  ~AssignNeverSendableIntoSendingResultDiagnosticEmitter() {
     // If we were supposed to emit a diagnostic and didn't emit an unknown
     // pattern error.
     if (!emittedErrorDiagnostic)
@@ -3269,7 +3311,7 @@ static SILValue findOutParameter(SILValue v) {
   }
 }
 
-void AssignIsolatedIntoSendingResultDiagnosticEmitter::emit() {
+void AssignNeverSendableIntoSendingResultDiagnosticEmitter::emit() {
   // Then emit the note with greater context.
   auto descriptiveKindStr =
       isolatedValueIsolationRegionInfo.printForDiagnostics(getFunction());
@@ -3376,8 +3418,21 @@ static void addSendableFixIt(const GenericTypeParamDecl *genericArgument,
   }
 }
 
+//===----------------------------------------------------------------------===//
+//         MARK: NonSendableIsolationCrossingResult Error Emitter
+//===----------------------------------------------------------------------===//
+
 namespace {
 
+/// Diagnostic emitter for NonSendableIsolationCrossingResult errors.
+///
+/// This is a verbatim error emitter (see PartitionOpError.def) that follows
+/// the standard pattern: constructor takes (RegionAnalysisFunctionInfo*, Error)
+/// and provides an emit() method.
+///
+/// This error occurs when a function that crosses isolation boundaries (e.g.,
+/// calling from one actor to another) returns a non-Sendable value. Since the
+/// result will cross isolation domains, it must be Sendable.
 struct NonSendableIsolationCrossingResultDiagnosticEmitter {
   RegionAnalysisValueMap &valueMap;
 
@@ -3392,8 +3447,8 @@ struct NonSendableIsolationCrossingResultDiagnosticEmitter {
   SILValue representative;
 
   NonSendableIsolationCrossingResultDiagnosticEmitter(
-      RegionAnalysisValueMap &valueMap, Error &&error)
-      : valueMap(valueMap), error(std::move(error)),
+      RegionAnalysisFunctionInfo *info, Error &&error)
+      : valueMap(info->getValueMap()), error(std::move(error)),
         representative(valueMap.getRepresentative(error.returnValueElement)) {}
 
   SILFunction *getFunction() const {
@@ -3565,11 +3620,22 @@ void NonSendableIsolationCrossingResultDiagnosticEmitter::emit() {
 }
 
 //===----------------------------------------------------------------------===//
-//               MARK: InOutSendingParametersInSameRegionError
+//         MARK: InOutSendingParametersInSameRegion Error Emitter
 //===----------------------------------------------------------------------===//
 
 namespace {
 
+/// Diagnostic emitter for InOutSendingParametersInSameRegion errors.
+///
+/// Unlike standard verbatim error emitters, this uses
+/// PARTITION_OP_VERBATIM_SPECIAL_EMISSION_EMITTER because:
+/// 1. A single error may contain multiple pairs of conflicting parameters
+/// 2. Each pair requires filtering based on diagnostic behavior settings
+/// 3. The emitter is invoked multiple times from a loop in emitVerbatimErrors()
+///
+/// This error occurs when two 'inout sending' parameters end up in the same
+/// region, making them interdependent. Since each must be independently
+/// sendable, sharing a region violates the contract.
 class InOutSendingParametersInSameRegionDiagnosticEmitter {
   /// The function exiting inst where the 'inout sending' parameter was actor
   /// isolated.
@@ -3692,73 +3758,75 @@ void InOutSendingParametersInSameRegionDiagnosticEmitter::emit() {
 }
 
 //===----------------------------------------------------------------------===//
+//                 MARK: UnknownCodePatternDiagnosticEmitter
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+class UnknownCodePatternDiagnosticEmitter {
+public:
+  using Error = PartitionOpError::UnknownCodePatternError;
+
+private:
+  SILInstruction *inst;
+
+public:
+  UnknownCodePatternDiagnosticEmitter(RegionAnalysisFunctionInfo *info,
+                                      Error error)
+      : inst(error.op->getSourceInst()) {}
+
+  void emit() {
+    if (shouldAbortOnUnknownPatternMatchError()) {
+      llvm::report_fatal_error(
+          "RegionIsolation: Aborting on unknown pattern match error");
+    }
+
+    REGIONBASEDISOLATION_LOG(llvm::dbgs() << "Emitting Error. Verbatim Error: "
+                                             "Unknown Code Pattern.\n"
+                                          << "  Inst: " << *inst);
+    diagnoseError(inst, diag::regionbasedisolation_unknown_pattern);
+  }
+};
+
+} // namespace
+
+//===----------------------------------------------------------------------===//
 //                         MARK: Top Level Entrypoint
 //===----------------------------------------------------------------------===//
 
+/// Emit diagnostics for all collected verbatim errors.
+///
+/// Verbatim errors are self-contained and were collected during dataflow
+/// evaluation in handleError(). This method iterates through them and
+/// dispatches to the appropriate diagnostic emitter.
+///
+/// This uses X-macros from PartitionOpError.def to generate the switch cases:
+/// - PARTITION_OP_ERROR: Should never appear here (handled immediately during
+///   dataflow), so we assert unreachable.
+/// - PARTITION_OP_VERBATIM_ERROR: Creates a <Name>DiagnosticEmitter and calls
+///   emit(). Emitters must follow the naming convention and constructor
+///   signature documented in PartitionOpError.def.
+/// - PARTITION_OP_VERBATIM_SPECIAL_EMISSION_EMITTER: Generates no code; these
+///   errors are handled explicitly below the X-macro expansion.
 void SendNonSendableImpl::emitVerbatimErrors() {
   for (auto &erasedError : foundVerbatimErrors) {
     switch (erasedError.getKind()) {
-    case PartitionOpError::UnknownCodePattern:
-    case PartitionOpError::LocalUseAfterSend:
-    case PartitionOpError::InOutSendingNotInitializedAtExit:
-      llvm_unreachable("Handled elsewhere");
-    case PartitionOpError::AssignNeverSendableIntoSendingResult: {
-      auto error =
-          std::move(erasedError).getAssignNeverSendableIntoSendingResultError();
-      REGIONBASEDISOLATION_LOG(error.print(llvm::dbgs(), info->getValueMap()));
-      AssignIsolatedIntoSendingResultDiagnosticEmitter emitter(
-          error.op->getSourceOp(), error.destValue, error.srcValue,
-          error.srcIsolationRegionInfo);
-      emitter.emit();
-      continue;
-    }
-    case PartitionOpError::InOutSendingNotDisconnectedAtExit: {
-      auto error =
-          std::move(erasedError).getInOutSendingNotDisconnectedAtExitError();
-      auto inoutSendingVal =
-          info->getValueMap().getRepresentative(error.inoutSendingElement);
-      auto isolationRegionInfo = error.isolationInfo;
-
-      REGIONBASEDISOLATION_LOG(error.print(llvm::dbgs(), info->getValueMap()));
-
-      InOutSendingNotDisconnectedDiagnosticEmitter emitter(
-          cast<TermInst>(error.op->getSourceInst()), inoutSendingVal,
-          isolationRegionInfo);
-      emitter.emit();
-      continue;
-    }
-    case PartitionOpError::InOutSendingReturned: {
-      auto error = std::move(erasedError).getInOutSendingReturnedError();
-      auto inoutSendingVal =
-          info->getValueMap().getRepresentative(error.inoutSendingElement);
-      auto returnedValue =
-          info->getValueMap().getRepresentative(error.returnedValue);
-
-      REGIONBASEDISOLATION_LOG(error.print(llvm::dbgs(), info->getValueMap()));
-
-      InOutSendingReturnedDiagnosticEmitter emitter(
-          info, cast<TermInst>(error.op->getSourceInst()), inoutSendingVal,
-          error.inoutSendingElement, returnedValue, error.isolationInfo);
-      emitter.emit();
-      continue;
-    }
-    case PartitionOpError::SentNeverSendable: {
-      auto e = std::move(erasedError).getSentNeverSendableError();
-      REGIONBASEDISOLATION_LOG(e.print(llvm::dbgs(), info->getValueMap()));
-      SentNeverSendableDiagnosticInferrer diagnosticInferrer(
-          info->getValueMap(), std::move(e));
-      diagnosticInferrer.run();
-      continue;
-    }
-    case PartitionOpError::NonSendableIsolationCrossingResult: {
-      auto e =
-          std::move(erasedError).getNonSendableIsolationCrossingResultError();
-      REGIONBASEDISOLATION_LOG(e.print(llvm::dbgs(), info->getValueMap()));
-      NonSendableIsolationCrossingResultDiagnosticEmitter diagnosticInferrer(
-          info->getValueMap(), std::move(e));
-      diagnosticInferrer.emit();
-      continue;
-    }
+#define PARTITION_OP_ERROR(NAME)                                               \
+  case PartitionOpError::NAME:                                                 \
+    llvm_unreachable("Handled elsewhere");
+#define PARTITION_OP_VERBATIM_ERROR(NAME)                                      \
+  case PartitionOpError::NAME: {                                               \
+    auto error = std::move(erasedError).get##NAME##Error();                    \
+    REGIONBASEDISOLATION_LOG(error.print(llvm::dbgs(), info->getValueMap()));  \
+    NAME##DiagnosticEmitter emitter(info, std::move(error));                   \
+    emitter.emit();                                                            \
+    continue;                                                                  \
+  }
+#define PARTITION_OP_VERBATIM_SPECIAL_EMISSION_EMITTER(NAME)
+#include "swift/SILOptimizer/Utils/PartitionOpError.def"
+    // Special handling for InOutSendingParametersInSameRegion: a single error
+    // may produce multiple diagnostics (one per pair of conflicting params),
+    // and requires filtering based on diagnostic behavior.
     case PartitionOpError::InOutSendingParametersInSameRegion: {
       auto e =
           std::move(erasedError).getInOutSendingParametersInSameRegionError();


### PR DESCRIPTION
I did this by:

1. Standardizing the constructors of diagnostic emitters to take the same parameters.

2. Changed the names of emitters so that they match the names of errors so I can use the XMACRO.

3. Changed the various switches that needed to be edited previously for verbatim and non-verbatim errors to be driven by the XMACROS now. This required the former two changes to compile successfully.

The result is that adding new errors is much simpler and easier to do.
