### PR TITLE
cmake: add `cache-build-session` to the Windows build

### DIFF
--- a/cmake/caches/Windows-aarch64.cmake
+++ b/cmake/caches/Windows-aarch64.cmake
@@ -66,6 +66,7 @@ set(LLVM_TOOLCHAIN_TOOLS
       addr2line
       ar
       c++filt
+      cache-build-session
       dsymutil
       dwp
       # lipo

--- a/cmake/caches/Windows-x86_64.cmake
+++ b/cmake/caches/Windows-x86_64.cmake
@@ -66,6 +66,7 @@ set(LLVM_TOOLCHAIN_TOOLS
       addr2line
       ar
       c++filt
+      cache-build-session
       dsymutil
       dwp
       # lipo


### PR DESCRIPTION
This is used as part of caching support on Windows. Add this to the build to facilitate packaging.