### PR TITLE
[test] add self-contained version of rdar36838495.swift

### DIFF
--- a/validation-test/Sema/type_checker_perf/fast/rdar36838495-self-contained.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar36838495-self-contained.swift
@@ -1,0 +1,59 @@
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=2000
+// REQUIRES: tools-release,no_asan
+// REQUIRES: OS=macosx
+
+// This restates the test in rdar36838495.swift, but insulates it from
+// changes in the standard library.
+// Note: at time of original commit, works with threshold of 1908
+
+struct T {
+  enum B {
+    case a
+    case b
+  }
+
+  let name: String
+  let b: B
+}
+
+struct A {
+  enum C {
+    case a
+    case b
+    case c
+  }
+
+  let name: String
+  let t: T
+  let c: C
+
+  var isX: Bool {
+    return self.t.b == .a
+  }
+}
+
+let x: [String: A] = [:]
+let _ = x.values.filterRT { $0.isX }
+                .filterRT { $0.t.b != .a }
+                .filterRT { $0.c == .a || $0.c == .b }
+                .filterRT { $0.isX }
+                .filterRT { $0.t.b != .a }
+                .sorted { $0.name < $1.name }
+
+extension Sequence {
+  func filterRT(_ predicate: (Element) throws -> Bool) rethrows -> [Element] {
+    fatalError()
+  }
+}
+
+extension RangeReplaceableCollection {
+  func filterRT(_ predicate: (Element) throws -> Bool) rethrows -> Self {
+    fatalError()
+  }
+}
+
+extension Array {
+  func filterRT(_ predicate: (Element) throws -> Bool) rethrows -> [Element] {
+    fatalError()
+  }
+}


### PR DESCRIPTION
Adds a self-contained version of the validation test rdar36838495.swift

Generalizing the `filter(_:)` functions to typed throws slows down the type checker (see https://github.com/swiftlang/swift/pull/87020). That change regresses the performance of this test. It’s not completely clear to me whether the test guards a regression of the type checker or of the standard library, so this adds a reproduction of the test’s original form and performance.
