### PR TITLE
[Tests] NFC: Add a test-case that covers difference in leading-dot in…

### DIFF
--- a/test/Constraints/leading-dot+result-builders.swift
+++ b/test/Constraints/leading-dot+result-builders.swift
@@ -1,0 +1,45 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol Element {
+  associatedtype Context
+}
+
+protocol P {
+  associatedtype V: P
+}
+
+@resultBuilder
+struct TupleBuilder<Context> {
+  static func buildBlock<E: Element>(_ t1: E) -> (E) where E.Context == Context {
+    return (t1)
+  }
+}
+
+
+func test<B, V, T: P, U>(_: KeyPath<B, T>, _: V, @TupleBuilder<B> a: () -> U) where V == T.V, V: Equatable {}
+func test<B, V, T: P, U>(_: KeyPath<B, T>, _: V.V, @TupleBuilder<B> a: () -> U) where V == T.V, V: ExpressibleByNilLiteral, V.V: Equatable {}
+
+enum E: String, P, ExpressibleByNilLiteral {
+  typealias V = Self
+
+  case empty
+
+  init(nilLiteral: ()) { self = .empty }
+}
+
+struct S : Element {
+  typealias Context = Self
+
+  struct Inner<T: P>: P {
+    typealias V = T
+  }
+
+  var value: Inner<E>
+
+  init() { fatalError() }
+}
+
+// FIXME(diagnostics): This diagnostic is wrong. The problem is that `test` is ambiguous and should be diagnosed pre-salvage.
+test(\.value, .empty) { // expected-error {{cannot infer key path type from context; consider explicitly specifying a root type}}
+  S()
+}


### PR DESCRIPTION
…ference

This test-case used to type-check successfully before because it would reject the first overload of `test` because instead of resolving closure first the solver would select a type variable that represents a base type of `.empty` and fail.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
