### PR TITLE
[update-checkout] allow to use `--reset-to-remote` with commit hash

### DIFF
--- a/utils/update_checkout/tests/test_clone.py
+++ b/utils/update_checkout/tests/test_clone.py
@@ -249,9 +249,15 @@ class SchemeWithHashTestCase(scheme_mock.SchemeMockTestCase):
         with open(self.config_path, "w") as f:
             json.dump(self.config, f)
 
-    def test_clone_with_commit_hash(self):
+    def test_clone_with_skip_history(self):
+        self._test_clone_with_commit_hash(["--skip-history"])
+
+    def test_clone_with_reset_to_remote(self):
+        self._test_clone_with_commit_hash(["--reset-to-remote"])
+
+    def _test_clone_with_commit_hash(self, additional_flags):
         """
-        Test that cloning with --skip-history works with commit hashes.
+        Test that cloning works with commit hashes.
         """
         self.call(
             [
@@ -261,11 +267,10 @@ class SchemeWithHashTestCase(scheme_mock.SchemeMockTestCase):
                 "--source-root",
                 self.source_root,
                 "--clone",
-                "--skip-history",
                 "--scheme",
                 self.commit_scheme_name,
                 "--verbose",
-            ]
+            ] + additional_flags
         )
 
         for repo in self.get_all_repos():

--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -259,9 +259,8 @@ def update_single_repository(pool_args: UpdateArguments):
         # If we were asked to reset to the specified branch, do the hard
         # reset and return.
         if checkout_target and pool_args.reset_to_remote and not cross_repo:
-            full_target = full_target_name(repo_path, "origin", checkout_target)
             Git.run(
-                repo_path, ["reset", "--hard", full_target], echo=verbose, prefix=prefix
+                repo_path, ["reset", "--hard", checkout_target], echo=verbose, prefix=prefix
             )
             return
 
@@ -823,20 +822,6 @@ def validate_config(config: Dict[str, Any]):
                 )
             else:
                 seen[alias] = scheme_name
-
-
-def full_target_name(repo_path: Path, repository: str, target: str) -> str:
-    tag, _, _ = Git.run(repo_path, ["tag", "-l", target], fatal=True)
-    if tag == target:
-        return tag
-
-    branch, _, _ = Git.run(repo_path, ["branch", "--list", target], fatal=True)
-    branch = branch.replace("* ", "")
-    if branch == target:
-        name = "%s/%s" % (repository, target)
-        return name
-
-    raise RuntimeError("Cannot determine if %s is a branch or a tag" % target)
 
 
 def skip_list_for_platform(config: Dict[str, Any], all_repos: bool) -> List[str]:


### PR DESCRIPTION
Namely, do not enforce the checkout target is either a branch or a tag, let `git` complain in case instead.