### PR TITLE
[ModuleInterface] Fix associated type selectors more

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -6403,14 +6403,15 @@ class TypePrinter : public TypeVisitor<TypePrinter, void, NonRecursivePrintOptio
   }
 
   bool isMemberOfGenericParameter(TypeBase *T) {
+    if (T->is<DependentMemberType>())    // desugars typealiases
+      // Parent is always a generic parameter.
+      return true;
+
     Type parent = nullptr;
     if (auto alias = dyn_cast<TypeAliasType>(T))    // don't desugar
       parent = alias->getParent();
     else if (auto generic = T->getAs<AnyGenericType>())
       parent = generic->getParent();
-    else if (T->is<DependentMemberType>())
-      // Parent is always a generic parameter.
-      return true;
     return parent && (parent->is<SubstitutableType>() ||
                         isMemberOfGenericParameter(parent.getPointer()));
   }

--- a/test/ModuleInterface/module_selector.swift
+++ b/test/ModuleInterface/module_selector.swift
@@ -256,3 +256,34 @@ public struct ProtoSet<T: Proto> {
 
 // DIAG-ALIAS-OVERRIDDEN: warning: ignoring -alias-module-names-in-module-interface (overridden by -enable-module-selectors-in-module-interface)
 // DIAG-ALIAS-NOT-OVERRIDDEN-NOT: warning: ignoring -alias-module-names-in-module-interface (overridden by -enable-module-selectors-in-module-interface)
+
+// rdar://169720990 -- complicated protocol hierarchy with typealias in protocol
+
+// CHECK-LABEL: class TypeAliasNestClass
+public final class TypeAliasNestClass<GenericParam: TypeAliasNestProtocol>: TypeAliasNestProtocol {
+  // CHECK: typealias AssociatedType4 =
+  // CHECK-ENABLED-SAME: TestCase::TypeAliasNestClass<GenericParam>.AssociatedType1.AssociatedType4
+  // CHECK-DISABLED-SAME: TestCase.TypeAliasNestClass<GenericParam>.AssociatedType1.AssociatedType4
+  // CHECK-PRESERVE-SAME: AssociatedType1.AssociatedType4
+  // CHECK-ALIAS-SAME: Module___TestCase.TypeAliasNestClass<GenericParam>.AssociatedType1.AssociatedType4
+  public typealias AssociatedType4 = AssociatedType1.AssociatedType4
+
+  public typealias AssociatedType1 = GenericParam.AssociatedType1
+}
+
+public protocol TypeAliasNestProtocol {
+  associatedtype AssociatedType1: AssociatedType1Protocol
+}
+
+public protocol AssociatedType1Protocol {
+  associatedtype AssociatedType2: AssociatedType2Protocol
+  typealias AssociatedType4 = AssociatedType2.AssociatedType3.AssociatedType4
+}
+
+public protocol AssociatedType2Protocol {
+  associatedtype AssociatedType3: AssociatedType3Protocol
+}
+
+public protocol AssociatedType3Protocol {
+  associatedtype AssociatedType4
+}


### PR DESCRIPTION
Qualification has discovered a complicated test case where the module interface printer incorrectly adds module selectors to nested types that don’t support them. Tweak module interface printing to omit the module selector in more situations.

Fixes rdar://169720990.