### PR TITLE
Fix module selector lookup with C++ members

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -391,8 +391,8 @@ bool swift::removeOutOfModuleDecls(SmallVectorImpl<ValueDecl*> &decls,
   decls.erase(
     std::remove_if(decls.begin(), decls.end(), [&](ValueDecl *decl) -> bool {
       bool inScope = llvm::any_of(visibleFrom, [&](ModuleDecl *visibleFromMod) {
-        return ctx.getImportCache().isImportedBy(decl->getModuleContext(),
-                                                 visibleFromMod);
+        return ctx.getImportCache().isImportedBy(
+                       decl->getModuleContextForNameLookup(), visibleFromMod);
       });
 
       LLVM_DEBUG(decl->dumpRef(llvm::dbgs()));

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -1174,7 +1174,7 @@ ModuleSelectorCorrection(const LookupResult &candidates) {
         kind = CandidateKind::MemberViaSelf;
     }
 
-    auto owningModule = decl->getModuleContext();
+    auto owningModule = decl->getModuleContextForNameLookup();
     candidateModules.insert(
       { owningModule->getNameForModuleSelector(), kind });
   }
@@ -1185,7 +1185,7 @@ ModuleSelectorCorrection(const LookupTypeResult &candidates) {
   // Produce a list of *unique* module selector diagnostics so we don't
   // emit a bunch of duplicates.
   for (auto result : candidates) {
-    auto owningModule = result.Member->getModuleContext();
+    auto owningModule = result.Member->getModuleContextForNameLookup();
     candidateModules.insert(
       { owningModule->getNameForModuleSelector(), CandidateKind::ContextFree });
   }
@@ -1194,7 +1194,7 @@ ModuleSelectorCorrection(const LookupTypeResult &candidates) {
 ModuleSelectorCorrection::
 ModuleSelectorCorrection(const SmallVectorImpl<ValueDecl *> &candidates) {
   for (auto result : candidates) {
-    auto owningModule = result->getModuleContext();
+    auto owningModule = result->getModuleContextForNameLookup();
     candidateModules.insert(
       { owningModule->getName(), CandidateKind::ContextFree });
   }
@@ -1203,7 +1203,7 @@ ModuleSelectorCorrection(const SmallVectorImpl<ValueDecl *> &candidates) {
 ModuleSelectorCorrection::
 ModuleSelectorCorrection(const SmallVectorImpl<constraints::OverloadChoice> &candidates) {
   for (auto result : candidates) {
-    auto owningModule = result.getDecl()->getModuleContext();
+    auto owningModule = result.getDecl()->getModuleContextForNameLookup();
     candidateModules.insert(
       { owningModule->getNameForModuleSelector(), CandidateKind::ContextFree });
   }

--- a/test/Interop/Cxx/modules/emit-module-interface.swift
+++ b/test/Interop/Cxx/modules/emit-module-interface.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 
 // Check if fragile Swift interface with struct extensions can be reparsed:
-// RUN: %target-swift-frontend -swift-version 5 -typecheck -emit-module-interface-path %t/UsesCxxStruct.swiftinterface %s -I %S/Inputs -swift-version 5 -cxx-interoperability-mode=default %S/Inputs/namespace-extension-lib.swift
+// RUN: %target-swift-frontend -swift-version 5 -typecheck -emit-module-interface-path %t/UsesCxxStruct.swiftinterface %s -I %S/Inputs -swift-version 5 -enable-module-selectors-in-module-interface -cxx-interoperability-mode=default %S/Inputs/namespace-extension-lib.swift
 // RUN: %target-swift-frontend -swift-version 5 -typecheck-module-from-interface  %t/UsesCxxStruct.swiftinterface -I %S/Inputs -cxx-interoperability-mode=default
 // RUN: %FileCheck --input-file=%t/UsesCxxStruct.swiftinterface %s
 
@@ -12,7 +12,7 @@
 // CHECK:     -formal-cxx-interoperability-mode=
 
 // Check if resilient Swift interface with builtin type extensions can be reparsed:
-// RUN: %target-swift-emit-module-interface(%t/ResilientStruct.swiftinterface) %s -I %S/Inputs -enable-library-evolution -swift-version 5 -cxx-interoperability-mode=default %S/Inputs/namespace-extension-lib.swift -DRESILIENT
+// RUN: %target-swift-emit-module-interface(%t/ResilientStruct.swiftinterface) %s -I %S/Inputs -enable-library-evolution -swift-version 5 -enable-module-selectors-in-module-interface -cxx-interoperability-mode=default %S/Inputs/namespace-extension-lib.swift -DRESILIENT
 // RUN: %target-swift-typecheck-module-from-interface(%t/ResilientStruct.swiftinterface) -I %S/Inputs -DRESILIENT -cxx-interoperability-mode=default
 // RUN: %FileCheck --input-file=%t/ResilientStruct.swiftinterface %s
 


### PR DESCRIPTION
Imported C++ declarations have some complicated special cases relating to module ownership that module selectors did not previously take into account. This meant that members of C++ classes and namespaces would sometimes only allow a module selector of `__ObjC` rather than the module they would normally be attributed to. Fix this oversight.