### PR TITLE
[ModuleInterface] Enable module selectors by default

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -199,6 +199,12 @@ WARNING(ignoring_option_requires_option,none,
         "ignoring %0 (requires %1)", (StringRef, StringRef))
 WARNING(warn_ignore_option_overridden_by,none,
         "ignoring %0 (overridden by %1)", (StringRef, StringRef))
+WARNING(ignoring_option_obsolete_module_selectors,none,
+        "ignoring '%0'; this option has been obsoleted by module selectors "
+        "(add '-disable-module-selectors-in-module-interface' to restore "
+        "original behavior)",
+        (StringRef))
+
 
 WARNING(warn_implicit_concurrency_import_failed,none,
         "unable to perform implicit import of \"_Concurrency\" module: no such module found", ())

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -614,21 +614,19 @@ static void ParseModuleInterfaceArgs(ModuleInterfaceOptions &Opts,
             .Default(true);
   } else {
     // Any heuristics we might add would go here.
-    Opts.UseModuleSelectors = false;
+    Opts.UseModuleSelectors = true;
   }
 
   if (Opts.PreserveTypesAsWritten && Opts.UseModuleSelectors) {
     Opts.PreserveTypesAsWritten = false;
-    diags.diagnose(SourceLoc(), diag::warn_ignore_option_overridden_by,
-                   "-module-interface-preserve-types-as-written",
-                   "-enable-module-selectors-in-module-interface");
+    diags.diagnose(SourceLoc(), diag::ignoring_option_obsolete_module_selectors,
+                   "-module-interface-preserve-types-as-written");
   }
 
   if (Opts.AliasModuleNames && Opts.UseModuleSelectors) {
     Opts.AliasModuleNames = false;
-    diags.diagnose(SourceLoc(), diag::warn_ignore_option_overridden_by,
-                   "-alias-module-names-in-module-interface",
-                   "-enable-module-selectors-in-module-interface");
+    diags.diagnose(SourceLoc(), diag::ignoring_option_obsolete_module_selectors,
+                   "-alias-module-names-in-module-interface");
   }
 }
 

--- a/test/AutoDiff/ModuleInterface/differentiation.swift
+++ b/test/AutoDiff/ModuleInterface/differentiation.swift
@@ -5,11 +5,11 @@
 import _Differentiation
 
 public func a(f: @differentiable(reverse) (Float) -> Float) {}
-// CHECK: public func a(f: @differentiable(reverse) (Swift.Float) -> Swift.Float)
+// CHECK: public func a(f: @differentiable(reverse) (Swift::Float) -> Swift::Float)
 
 // TODO: Remove once `@differentiable` becomes deprecated.
 public func b(f: @differentiable(reverse) (Float) -> Float) {}
-// CHECK: public func b(f: @differentiable(reverse) (Swift.Float) -> Swift.Float)
+// CHECK: public func b(f: @differentiable(reverse) (Swift::Float) -> Swift::Float)
 
 public func c(f: @differentiable(reverse) (Float, @noDerivative Float) -> Float) {}
-// CHECK: public func c(f: @differentiable(reverse) (Swift.Float, @noDerivative Swift.Float) -> Swift.Float)
+// CHECK: public func c(f: @differentiable(reverse) (Swift::Float, @noDerivative Swift::Float) -> Swift::Float)

--- a/test/ClangImporter/clang-function-types.swift
+++ b/test/ClangImporter/clang-function-types.swift
@@ -4,11 +4,11 @@
 
 import ctypes
 
-// CHECK: f1: (@convention(c, cType: "size_t (*)(size_t)") (Swift.Int) -> Swift.Int)?
+// CHECK: f1: (@convention(c, cType: "size_t (*)(size_t)") (Swift::Int) -> Swift::Int)?
 public let f1 = getFunctionPointer_()
 
-// CHECK: f2: (@convention(c) ((@convention(c, cType: "size_t (*)(size_t)") (Swift.Int) -> Swift.Int)?) -> (@convention(c, cType: "size_t (*)(size_t)") (Swift.Int) -> Swift.Int)?)?
+// CHECK: f2: (@convention(c) ((@convention(c, cType: "size_t (*)(size_t)") (Swift::Int) -> Swift::Int)?) -> (@convention(c, cType: "size_t (*)(size_t)") (Swift::Int) -> Swift::Int)?)?
 public let f2 = getHigherOrderFunctionPointer()
 
-// CHECK: f3: () -> (@convention(c) (Swift.UnsafeMutablePointer<ctypes.Dummy>?) -> Swift.UnsafeMutablePointer<ctypes.Dummy>?)?
+// CHECK: f3: () -> (@convention(c) (Swift::UnsafeMutablePointer<ctypes::Dummy>?) -> Swift::UnsafeMutablePointer<ctypes::Dummy>?)?
 public let f3 = getFunctionPointer3

--- a/test/Concurrency/attr_execution/nonisolated_cross_module_with_flag_enabled.swift
+++ b/test/Concurrency/attr_execution/nonisolated_cross_module_with_flag_enabled.swift
@@ -28,7 +28,7 @@ public final class Test {
   // CHECK: nonisolated(nonsending) final public func test() async
   public nonisolated func test() async {}
 
-  // CHECK: @_Concurrency.MainActor final public func compute(callback: nonisolated(nonsending) @escaping @Sendable () async -> Swift.Void)
+  // CHECK: @_Concurrency::MainActor final public func compute(callback: nonisolated(nonsending) @escaping @Sendable () async -> Swift::Void)
   public func compute(callback: @escaping @Sendable () async -> Void) {}
 }
 
@@ -36,18 +36,18 @@ public struct InferenceTest {
   // CHECK: nonisolated(nonsending) public func infersAttr() async
   public func infersAttr() async {}
 
-  // CHECK: public func testNested(callback: @escaping (nonisolated(nonsending) @Sendable () async -> Swift.Void) -> Swift.Void)
+  // CHECK: public func testNested(callback: @escaping (nonisolated(nonsending) @Sendable () async -> Swift::Void) -> Swift::Void)
   public func testNested(callback: @escaping (@Sendable () async -> Void) -> Void) {}
-  // CHECK: public func testNested(dict: [Swift.String : (nonisolated(nonsending) () async -> Swift.Void)?])
+  // CHECK: public func testNested(dict: [Swift::String : (nonisolated(nonsending) () async -> Swift::Void)?])
   public func testNested(dict: [String: (() async -> Void)?]) {}
 
-  // CHECK: nonisolated(nonsending) public func testAutoclosure(value1 fn: nonisolated(nonsending) @autoclosure () async -> Swift.Int) async
+  // CHECK: nonisolated(nonsending) public func testAutoclosure(value1 fn: nonisolated(nonsending) @autoclosure () async -> Swift::Int) async
   public func testAutoclosure(value1 fn: @autoclosure () async -> Int) async { await fn() }
-  // CHECK: nonisolated(nonsending) public func testAutoclosure(value2 fn: nonisolated(nonsending) @autoclosure () async -> Swift.Int) async
+  // CHECK: nonisolated(nonsending) public func testAutoclosure(value2 fn: nonisolated(nonsending) @autoclosure () async -> Swift::Int) async
   public func testAutoclosure(value2 fn: nonisolated(nonsending) @autoclosure () async -> Int) async { await fn() }
 }
 
-// CHECK: nonisolated extension A.InferenceTest {
+// CHECK: nonisolated extension A::InferenceTest {
 // CHECK:   nonisolated(nonsending) public func testInExtension() async
 // CHECK:   @concurrent public func testConcurrentInExtension() async
 // CHECK: }
@@ -63,7 +63,7 @@ public protocol P {
   func testWitness() async
 }
 
-// CHECK: public struct WitnessTest : nonisolated A.P {
+// CHECK: public struct WitnessTest : nonisolated A::P {
 // CHECK:   nonisolated(nonsending) public func testWitness() async
 // CHECK: }
 public struct WitnessTest: nonisolated P {
@@ -77,16 +77,16 @@ nonisolated public class NoinsolatedClassTest {
   public func test() async {}
 }
 
-// CHECK: public typealias F = nonisolated(nonsending) () async -> Swift.Void
+// CHECK: public typealias F = nonisolated(nonsending) () async -> Swift::Void
 public typealias F = () async -> Void
 // CHECK: public typealias G<T> = nonisolated(nonsending) () async -> T
 public typealias G<T> = () async -> T
 
-// CHECK: public func testTypeAlias(_: @escaping A.F)
+// CHECK: public func testTypeAlias(_: @escaping A::F)
 public func testTypeAlias(_: @escaping F) {}
 
 // CHECK: public struct TestGenericTypeAlias {
-// CHECK:   public subscript<U>(_: nonisolated(nonsending) () async -> U) -> Swift.Bool {
+// CHECK:   public subscript<U>(_: nonisolated(nonsending) () async -> U) -> Swift::Bool {
 // CHECK:     get
 // CHECK:   }
 // CHECK: }

--- a/test/Concurrency/default_isolation_MainActor_cross_module.swift
+++ b/test/Concurrency/default_isolation_MainActor_cross_module.swift
@@ -23,25 +23,26 @@
 
 //--- A.swift
 
-// CHECK-NOT: @_Concurrency.MainActor @preconcurrency public var x: Swift.Int
+// CHECK-NOT: @_Concurrency::MainActor @preconcurrency public var x: Swift::Int
+// CHECK: {{^}}public var x: Swift::Int
 public var x: Int = 42
 
-// CHECK: @_Concurrency.MainActor @preconcurrency public protocol P
+// CHECK: @_Concurrency::MainActor @preconcurrency public protocol P
 public protocol P {
 }
 
-// CHECK: nonisolated public protocol Q : Swift.Sendable
+// CHECK: nonisolated public protocol Q : Swift::Sendable
 nonisolated public protocol Q: Sendable {
 }
 
-// CHECK: @_Concurrency.MainActor @preconcurrency public struct S : A.P {
+// CHECK: @_Concurrency::MainActor @preconcurrency public struct S : A::P {
 public struct S: P {
-  // CHECK: @_Concurrency.MainActor @preconcurrency public enum E : Swift.String {
+  // CHECK: @_Concurrency::MainActor @preconcurrency public enum E : Swift::String {
   // CHECK:   case a
   // CHECK:   case b
-  // CHECK:   nonisolated public init?(rawValue: Swift.String)
-  // CHECK:   public typealias RawValue = Swift.String
-  // CHECK:   nonisolated public var rawValue: Swift.String {
+  // CHECK:   nonisolated public init?(rawValue: Swift::String)
+  // CHECK:   public typealias RawValue = Swift::String
+  // CHECK:   nonisolated public var rawValue: Swift::String {
   // CHECK:     get
   // CHECK:   }
   // CHECK: }
@@ -50,19 +51,19 @@ public struct S: P {
     case b
   }
 
-  // CHECK:   @_Concurrency.MainActor @preconcurrency public func f()
+  // CHECK:   @_Concurrency::MainActor @preconcurrency public func f()
   public func f() {}
 
-  // CHECK: @_Concurrency.MainActor @preconcurrency public struct Inner {
+  // CHECK: @_Concurrency::MainActor @preconcurrency public struct Inner {
   public struct Inner {
-    // CHECK: @_Concurrency.MainActor @preconcurrency public init()
+    // CHECK: @_Concurrency::MainActor @preconcurrency public init()
     public init() {}
   }
   // CHECK: }
 }
 // CHECK: }
 
-// CHECK: public struct R : A.Q {
+// CHECK: public struct R : A::Q {
 public struct R: Q {
   // CHECK: public struct Inner {
   public struct Inner {
@@ -71,37 +72,37 @@ public struct R: Q {
   }
   // CHECK: }
 
-  // CHECK: @_Concurrency.MainActor @preconcurrency public struct InnerIsolated : A.P {
+  // CHECK: @_Concurrency::MainActor @preconcurrency public struct InnerIsolated : A::P {
   // CHECK: }
   public struct InnerIsolated: P {}
 }
 // CHECK: }
 
-// CHECK: @_Concurrency.MainActor @preconcurrency public func testGlobal()
+// CHECK: @_Concurrency::MainActor @preconcurrency public func testGlobal()
 public func testGlobal() {}
 
-// CHECK: @_Concurrency.MainActor @preconcurrency public class C {
+// CHECK: @_Concurrency::MainActor @preconcurrency public class C {
 public class C {
-  // CHECK: @_Concurrency.MainActor @preconcurrency public init()
+  // CHECK: @_Concurrency::MainActor @preconcurrency public init()
   public init() {}
 
-  // CHECK: @_Concurrency.MainActor @preconcurrency public static var value: Swift.Int
+  // CHECK: @_Concurrency::MainActor @preconcurrency public static var value: Swift::Int
   public static var value = 42
 
-  // CHECK: {{(@objc )?}} @_Concurrency.MainActor deinit
+  // CHECK: {{(@objc )?}} @_Concurrency::MainActor deinit
 }
 // CHECK: }
 
-// CHECK: @_Concurrency.MainActor @preconcurrency open class IsolatedDeinitTest {
+// CHECK: @_Concurrency::MainActor @preconcurrency open class IsolatedDeinitTest {
 open class IsolatedDeinitTest {
   // CHECK:   {{(@objc )?}} isolated deinit
   isolated deinit {}
 }
 // CHECK: }
 
-// CHECK: @_Concurrency.MainActor @preconcurrency public struct TestAccessors {
+// CHECK: @_Concurrency::MainActor @preconcurrency public struct TestAccessors {
 public struct TestAccessors {
-  // CHECK: @_Concurrency.MainActor @preconcurrency public var test: Swift.Int {
+  // CHECK: @_Concurrency::MainActor @preconcurrency public var test: Swift::Int {
   // CHECK:   get
   // CHECK:   set
   // CHECK: }

--- a/test/Concurrency/sendable_package_types.swift
+++ b/test/Concurrency/sendable_package_types.swift
@@ -16,7 +16,7 @@
 
 // REQUIRES: concurrency
 
-// CHECK: package struct S : Swift.Sendable {
+// CHECK: package struct S : Swift::Sendable {
 package struct S {
   package let x: Int = 42
 }
@@ -28,7 +28,7 @@ private class NonSendable {
 protocol P: Sendable {
 }
 
-// CHECK: final package class A : _A.P, Swift.Sendable {
+// CHECK: final package class A : _A::P, Swift::Sendable {
 package final class A: P {
   let x: Int = 42
 }
@@ -39,7 +39,7 @@ package struct NS {
   private var v: NonSendable
 }
 
-// CHECK: package enum Unavailable : Swift.Equatable {
+// CHECK: package enum Unavailable : Swift::Equatable {
 package enum Unavailable: Equatable {
   case test
 }
@@ -67,7 +67,7 @@ extension ConditionalTest: Sendable where T: Sendable {
 @available(macOS 15.0, *)
 @_originallyDefinedIn(module: "A", macOS 15.0)
 public struct Test1: Sendable {
-  // CHECK: package enum Storage : Swift.Equatable, Swift.Sendable {
+  // CHECK: package enum Storage : Swift::Equatable, Swift::Sendable {
   package enum Storage: Equatable {
     case empty
   }
@@ -78,13 +78,13 @@ public struct Test1: Sendable {
 @available(macOS 15.0, *)
 @_originallyDefinedIn(module: "A", macOS 15.0)
 public struct Test2: Sendable {
-  // CHECK: package struct Storage : Swift.Equatable {
+  // CHECK: package struct Storage : Swift::Equatable {
   package struct Storage: Equatable {  // expected-note {{consider making struct 'Storage' conform to the 'Sendable' protocol}}
     // CHECK-NOT: private var ns: NS
     private var ns: NS = NS()
   }
 
-  // CHECK: package class NS : Swift.Equatable {
+  // CHECK: package class NS : Swift::Equatable {
   package class NS : Equatable {
     package static func ==(_: NS, _: NS) -> Bool { false }
   }

--- a/test/Concurrency/sending_conditional_suppression.swift
+++ b/test/Concurrency/sending_conditional_suppression.swift
@@ -6,100 +6,100 @@
 
 public class NonSendableKlass {}
 
-// CHECK: public func transferArgTest(_ x: sending test.NonSendableKlass)
+// CHECK: public func transferArgTest(_ x: sending test::NonSendableKlass)
 public func transferArgTest(_ x: sending NonSendableKlass) {}
 
-// CHECK-NEXT: public func transferResultTest() -> sending test.NonSendableKlass
+// CHECK-NEXT: public func transferResultTest() -> sending test::NonSendableKlass
 public func transferResultTest() -> sending NonSendableKlass { fatalError() }
 
-// CHECK-NEXT: public func transferArgAndResultTest(_ x: test.NonSendableKlass, _ y: sending test.NonSendableKlass, _ z: test.NonSendableKlass) -> sending test.NonSendableKlass
+// CHECK-NEXT: public func transferArgAndResultTest(_ x: test::NonSendableKlass, _ y: sending test::NonSendableKlass, _ z: test::NonSendableKlass) -> sending test::NonSendableKlass
 public func transferArgAndResultTest(_ x: NonSendableKlass, _ y: sending NonSendableKlass, _ z: NonSendableKlass) -> sending NonSendableKlass { fatalError() }
 
-// CHECK-NEXT: public func argEmbeddedInType(_ fn: (sending test.NonSendableKlass) -> ())
+// CHECK-NEXT: public func argEmbeddedInType(_ fn: (sending test::NonSendableKlass) -> ())
 public func argEmbeddedInType(_ fn: (sending NonSendableKlass) -> ()) {}
 
-// CHECK-NEXT: public func resultEmbeddedInType(_ fn: () -> sending test.NonSendableKlass)
+// CHECK-NEXT: public func resultEmbeddedInType(_ fn: () -> sending test::NonSendableKlass)
 public func resultEmbeddedInType(_ fn: () -> sending NonSendableKlass) {}
 
-// CHECK-NEXT: public func argAndResultEmbeddedInType(_ fn: (test.NonSendableKlass, sending test.NonSendableKlass, test.NonSendableKlass) -> sending test.NonSendableKlass)
+// CHECK-NEXT: public func argAndResultEmbeddedInType(_ fn: (test::NonSendableKlass, sending test::NonSendableKlass, test::NonSendableKlass) -> sending test::NonSendableKlass)
 public func argAndResultEmbeddedInType(_ fn: (NonSendableKlass, sending NonSendableKlass, NonSendableKlass) -> sending NonSendableKlass) {}
 
 // CHECK-LABEL: public class TestInKlass
 public class TestInKlass {
-  // CHECK-NEXT: public func testKlassArg(_ x: sending test.NonSendableKlass)
+  // CHECK-NEXT: public func testKlassArg(_ x: sending test::NonSendableKlass)
   public func testKlassArg(_ x: sending NonSendableKlass) { fatalError() }
 
-  // CHECK-NEXT: public func testKlassResult() -> sending test.NonSendableKlass
+  // CHECK-NEXT: public func testKlassResult() -> sending test::NonSendableKlass
   public func testKlassResult() -> sending NonSendableKlass { fatalError() }
 
-  // CHECK-NEXT: public func testKlassArgAndResult(_ x: test.NonSendableKlass, _ y: sending test.NonSendableKlass, z: test.NonSendableKlass) -> sending test.NonSendableKlass
+  // CHECK-NEXT: public func testKlassArgAndResult(_ x: test::NonSendableKlass, _ y: sending test::NonSendableKlass, z: test::NonSendableKlass) -> sending test::NonSendableKlass
   public func testKlassArgAndResult(_ x: NonSendableKlass, _ y: sending NonSendableKlass, z: NonSendableKlass) -> sending NonSendableKlass { fatalError() }
 }
 
 // CHECK-LABEL: public struct TestInStruct
 public struct TestInStruct {
-  // CHECK-NEXT: public func testKlassArg(_ x: sending test.NonSendableKlass)
+  // CHECK-NEXT: public func testKlassArg(_ x: sending test::NonSendableKlass)
   public func testKlassArg(_ x: sending NonSendableKlass) { fatalError() }
 
-  // CHECK-NEXT: public func testKlassResult() -> sending test.NonSendableKlass
+  // CHECK-NEXT: public func testKlassResult() -> sending test::NonSendableKlass
   public func testKlassResult() -> sending NonSendableKlass { fatalError() }
 
-  // CHECK-NEXT: public func testKlassArgAndResult(_ x: test.NonSendableKlass, _ y: sending test.NonSendableKlass, z: test.NonSendableKlass) -> sending test.NonSendableKlass
+  // CHECK-NEXT: public func testKlassArgAndResult(_ x: test::NonSendableKlass, _ y: sending test::NonSendableKlass, z: test::NonSendableKlass) -> sending test::NonSendableKlass
   public func testKlassArgAndResult(_ x: NonSendableKlass, _ y: sending NonSendableKlass, z: NonSendableKlass) -> sending NonSendableKlass { fatalError() }
 
-  // CHECK-NEXT: public func testFunctionArg(_ x: () -> sending test.NonSendableKlass)
+  // CHECK-NEXT: public func testFunctionArg(_ x: () -> sending test::NonSendableKlass)
   public func testFunctionArg(_ x: () -> sending NonSendableKlass) { fatalError() }
 
-  // CHECK-NEXT: public func testFunctionResult() -> () -> sending test.NonSendableKlass
+  // CHECK-NEXT: public func testFunctionResult() -> () -> sending test::NonSendableKlass
   public func testFunctionResult() -> (() -> sending NonSendableKlass) { fatalError() }
 
   // CHECK-NEXT: @usableFromInline
-  // CHECK-NEXT: internal func testUsableFromInlineKlassArg(_ x: sending test.NonSendableKlass)
+  // CHECK-NEXT: internal func testUsableFromInlineKlassArg(_ x: sending test::NonSendableKlass)
   @usableFromInline func testUsableFromInlineKlassArg(_ x: sending NonSendableKlass) { fatalError() }
 
   // CHECK-NEXT: @usableFromInline
-  // CHECK-NEXT: internal func testUsableFromInlineKlassResult() -> sending test.NonSendableKlass
+  // CHECK-NEXT: internal func testUsableFromInlineKlassResult() -> sending test::NonSendableKlass
   @usableFromInline
   func testUsableFromInlineKlassResult() -> sending NonSendableKlass { fatalError() }
 
   // CHECK-NEXT: @usableFromInline
-  // CHECK-NEXT: internal func testUsableFromInlineKlassArgAndResult(_ x: test.NonSendableKlass, _ y: sending test.NonSendableKlass, z: test.NonSendableKlass) -> sending test.NonSendableKlass
+  // CHECK-NEXT: internal func testUsableFromInlineKlassArgAndResult(_ x: test::NonSendableKlass, _ y: sending test::NonSendableKlass, z: test::NonSendableKlass) -> sending test::NonSendableKlass
   @usableFromInline
   func testUsableFromInlineKlassArgAndResult(_ x: NonSendableKlass, _ y: sending NonSendableKlass, z: NonSendableKlass) -> sending NonSendableKlass { fatalError() }
 
   // CHECK-NEXT: @usableFromInline
-  // CHECK-NEXT: internal func testUsableFromInlineFunctionArg(_ x: () -> sending test.NonSendableKlass)
+  // CHECK-NEXT: internal func testUsableFromInlineFunctionArg(_ x: () -> sending test::NonSendableKlass)
   @usableFromInline
   func testUsableFromInlineFunctionArg(_ x: () -> sending NonSendableKlass) { fatalError() }
 
   // CHECK-NEXT: @usableFromInline
-  // CHECK-NEXT: internal func testUsableFromInlineFunctionResult() -> () -> sending test.NonSendableKlass
+  // CHECK-NEXT: internal func testUsableFromInlineFunctionResult() -> () -> sending test::NonSendableKlass
   @usableFromInline
   func testUsableFromInlineFunctionResult() -> (() -> sending NonSendableKlass) { fatalError() }
 
-  // CHECK-NEXT: public var publicVarFieldFunctionArg: (sending test.NonSendableKlass) -> ()
+  // CHECK-NEXT: public var publicVarFieldFunctionArg: (sending test::NonSendableKlass) -> ()
   public var publicVarFieldFunctionArg: (sending NonSendableKlass) -> ()
 
   // CHECK-NEXT: @usableFromInline
-  // CHECK-NEXT: internal var internalVarFieldFunctionArg: (sending test.NonSendableKlass) -> ()
+  // CHECK-NEXT: internal var internalVarFieldFunctionArg: (sending test::NonSendableKlass) -> ()
   @usableFromInline
   var internalVarFieldFunctionArg: (sending NonSendableKlass) -> ()
 
-  // CHECK-NEXT: public let publicLetFieldFunctionArg: (sending test.NonSendableKlass) -> ()
+  // CHECK-NEXT: public let publicLetFieldFunctionArg: (sending test::NonSendableKlass) -> ()
   public let publicLetFieldFunctionArg: (sending NonSendableKlass) -> ()
 
   // CHECK-NEXT: @usableFromInline
-  // CHECK-NEXT: internal let internalLetFieldFunctionArg: (sending test.NonSendableKlass) -> ()
+  // CHECK-NEXT: internal let internalLetFieldFunctionArg: (sending test::NonSendableKlass) -> ()
   @usableFromInline
   let internalLetFieldFunctionArg: (sending NonSendableKlass) -> ()
 
   // CHECK-NEXT: @usableFromInline
-  // CHECK-NEXT: internal init(_ x: Swift.Int, transformWithResult: @escaping () async throws -> sending test.NonSendableKlass)
+  // CHECK-NEXT: internal init(_ x: Swift::Int, transformWithResult: @escaping () async throws -> sending test::NonSendableKlass)
   @usableFromInline
   internal init(_ x: Int, transformWithResult: @escaping () async throws -> sending NonSendableKlass) { fatalError() }
 }
 
-// CHECK-LABEL: @inlinable public func withCheckedContinuation<T>(isolation: isolated (any _Concurrency.Actor)? = #isolation, function: Swift.String = #function, _ body: (_Concurrency.CheckedContinuation<T, Swift.Never>) -> Swift.Void) async -> sending T {
+// CHECK-LABEL: @inlinable public func withCheckedContinuation<T>(isolation: isolated (any _Concurrency::Actor)? = #isolation, function: Swift::String = #function, _ body: (_Concurrency::CheckedContinuation<T, Swift::Never>) -> Swift::Void) async -> sending T {
 // CHECK-NEXT:  fatalError()
 // CHECK-NEXT: }
 @inlinable public func withCheckedContinuation<T>(
@@ -110,10 +110,10 @@ public struct TestInStruct {
   fatalError()
 }
 
-// CHECK-LABEL: public var publicGlobal: (sending test.NonSendableKlass) -> ()
+// CHECK-LABEL: public var publicGlobal: (sending test::NonSendableKlass) -> ()
 public var publicGlobal: (sending NonSendableKlass) -> () = { x in fatalError() }
 
 // CHECK: @usableFromInline
-// CHECK-NEXT: internal var usableFromInlineGlobal: (sending test.NonSendableKlass) -> ()
+// CHECK-NEXT: internal var usableFromInlineGlobal: (sending test::NonSendableKlass) -> ()
 @usableFromInline
 internal var usableFromInlineGlobal: (sending NonSendableKlass) -> () = { x in fatalError() }

--- a/test/Concurrency/sending_interfacefile_printing.swift
+++ b/test/Concurrency/sending_interfacefile_printing.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -typecheck -enable-library-evolution -parse-as-library -emit-module-interface-path - -module-name MyFile -swift-version 6 | %FileCheck %s
-// RUN: %target-swift-frontend %s -typecheck -enable-library-evolution -parse-as-library -emit-module-interface-path - -module-name MyFile -swift-version 6 -module-interface-preserve-types-as-written | %FileCheck -check-prefix=CHECK-REPR %s
+// RUN: %target-swift-frontend %s -typecheck -enable-library-evolution -parse-as-library -emit-module-interface-path - -module-name MyFile -swift-version 6 -disable-module-selectors-in-module-interface -module-interface-preserve-types-as-written | %FileCheck -check-prefix=CHECK-REPR %s
 
 // The force printing type reprs option is only available in asserts builds.
 // REQUIRES: asserts
@@ -11,17 +11,17 @@
 
 public class NonSendableKlass {}
 
-// CHECK: public func test() -> sending MyFile.NonSendableKlass
+// CHECK: public func test() -> sending MyFile::NonSendableKlass
 
 // CHECK-REPR: public func test() -> sending NonSendableKlass
 public func test() -> sending NonSendableKlass { NonSendableKlass() }
 
-// CHECK: public func test2(_ x: sending MyFile.NonSendableKlass)
+// CHECK: public func test2(_ x: sending MyFile::NonSendableKlass)
 
 // CHECK-REPR: public func test2(_ x: sending NonSendableKlass)
 public func test2(_ x: sending NonSendableKlass) {}
 
-// CHECK: @_Concurrency.MainActor public var closure: () -> sending MyFile.NonSendableKlass
+// CHECK: @_Concurrency::MainActor public var closure: () -> sending MyFile::NonSendableKlass
 
 // CHECK-REPR: @_Concurrency.MainActor public var closure: () -> sending NonSendableKlass
 @MainActor public var closure: () -> sending NonSendableKlass = { NonSendableKlass() }

--- a/test/CrossImport/module-interface.swift
+++ b/test/CrossImport/module-interface.swift
@@ -41,6 +41,6 @@ public func shadow(_: DeclaringLibrary.ShadowTy, _: ShadowTy) {}
 // CHECK-DAG: import BystandingLibrary
 // CHECK-DAG: import _OverlayLibrary
 
-// CHECK-DAG: public func fn(_: DeclaringLibrary.DeclaringLibraryTy, _: BystandingLibrary.BystandingLibraryTy, _: _OverlayLibrary.OverlayLibraryTy)
-// CHECK-DAG: public func alias(_: _OverlayLibrary.OverlayLibraryTy)
-// CHECK-DAG: public func shadow(_: _OverlayLibrary.ShadowTy, _: _OverlayLibrary.ShadowTy)
+// CHECK-DAG: public func fn(_: DeclaringLibrary::DeclaringLibraryTy, _: BystandingLibrary::BystandingLibraryTy, _: _OverlayLibrary::OverlayLibraryTy)
+// CHECK-DAG: public func alias(_: _OverlayLibrary::OverlayLibraryTy)
+// CHECK-DAG: public func shadow(_: _OverlayLibrary::ShadowTy, _: _OverlayLibrary::ShadowTy)

--- a/test/Interop/C/modules/print-qualified-clang-types/print-qualified-clang-types-spi.swift
+++ b/test/Interop/C/modules/print-qualified-clang-types/print-qualified-clang-types-spi.swift
@@ -11,4 +11,4 @@
 // RUN: %FileCheck --input-file=%t/spi_main_module/SpiMainModule.swiftinterface %s
 // RUN: %target-swift-frontend -typecheck -swift-version 5 %t/spi_main_module/SpiMainModule.swiftinterface -I %t/helper_module -I %S/Inputs
 
-// CHECK: public func funcTakingForeignStruct(_ param: ForeignB.ForeignStruct)
+// CHECK: public func funcTakingForeignStruct(_ param: ForeignB::ForeignStruct)

--- a/test/Interop/C/modules/print-qualified-clang-types/print-qualified-clang-types.swift
+++ b/test/Interop/C/modules/print-qualified-clang-types/print-qualified-clang-types.swift
@@ -33,4 +33,4 @@
 // RUN: %FileCheck --input-file=%t/main_module/MainModule.swiftinterface %s
 // RUN: %target-swift-frontend -typecheck -swift-version 5 %t/main_module/MainModule.swiftinterface -I %t/helper_module -I %S/Inputs
 
-// CHECK: public func funcTakingForeignStruct(_ param: ForeignB.ForeignStruct)
+// CHECK: public func funcTakingForeignStruct(_ param: ForeignB::ForeignStruct)

--- a/test/Interop/Cxx/modules/prevent-module-shadowed-by-namespace.swift
+++ b/test/Interop/Cxx/modules/prevent-module-shadowed-by-namespace.swift
@@ -37,13 +37,13 @@ import c2cxx
 
 // Exposes a (fully-qualified) c2cxx decl in its module interface.
 public func shimId(_ n: c2cxx_number) -> c2cxx_number { return n }
-// CHECK: public func shimId(_ n: c2cxx.c2cxx_number) -> c2cxx.c2cxx_number
+// CHECK: public func shimId(_ n: c2cxx::c2cxx_number) -> c2cxx::c2cxx_number
 //                                ^^^^^`- refers to the module
 
 // @inlinable functions have their bodies splatted in the module interface file;
 // those verbatim bodies may contain unqualified names.
 @inlinable public func shimIdInline(_ n: c2cxx_number) -> c2cxx_number {
-// CHECK:  public func shimIdInline(_ n: c2cxx.c2cxx_number) -> c2cxx.c2cxx_number
+// CHECK:  public func shimIdInline(_ n: c2cxx::c2cxx_number) -> c2cxx::c2cxx_number
 //                                       ^^^^^`- refers to the module
           let m: c2cxx_number = n
 // CHECK: let m: c2cxx_number = n

--- a/test/LiteralExpressions/EnumRawValueInterface.swift
+++ b/test/LiteralExpressions/EnumRawValueInterface.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend -emit-module -module-name EnumRawValueInterface -emit-module-interface-path %t/EnumRawValueInterface.swiftinterface -enable-library-evolution -swift-version 5 %s -enable-experimental-feature LiteralExpressions
 // RUN: %FileCheck %s < %t/EnumRawValueInterface.swiftinterface
 
-// CHECK-LABEL: public enum E1 : Swift.Int {
+// CHECK-LABEL: public enum E1 : Swift::Int {
 public enum E1: Int {
     // CHECK-NEXT: case a
     // CHECK-NEXT: case b
@@ -11,9 +11,9 @@ public enum E1: Int {
     case a = 2 + 2
     case b
     case c
-  // CHECK-DAG: public typealias RawValue = Swift.Int
-  // CHECK-DAG: public init?(rawValue: Swift.Int)
-  // CHECK-DAG: public var rawValue: Swift.Int {
+  // CHECK-DAG: public typealias RawValue = Swift::Int
+  // CHECK-DAG: public init?(rawValue: Swift::Int)
+  // CHECK-DAG: public var rawValue: Swift::Int {
   // CHECK-DAG:   get{{$}}
   // CHECK-DAG: }    
 } // CHECK: {{^}$}}

--- a/test/LiteralExpressions/SectionInterface.swift
+++ b/test/LiteralExpressions/SectionInterface.swift
@@ -7,4 +7,4 @@
 @section("mysection") public let intBinaryArithOp1 = 1 + 1
 
 // As of today, the values do not get printed in the textual interface
-// CHECK: @section("mysection") public let intBinaryArithOp1: Swift.Int
+// CHECK: @section("mysection") public let intBinaryArithOp1: Swift::Int

--- a/test/Macros/macro_default_argument_library.swift
+++ b/test/Macros/macro_default_argument_library.swift
@@ -14,7 +14,7 @@ public macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(
     module: "MacroDefinition", type: "StringifyMacro"
 )
 
-// CHECK: public func foo(param: (Swift.String, Swift.String) = #stringify(#fileID))
+// CHECK: public func foo(param: (Swift::String, Swift::String) = #stringify(#fileID))
 public func foo(param: (String, String) = #stringify(#fileID)) {
     print(param)
 }

--- a/test/Macros/macro_expand_conformances.swift
+++ b/test/Macros/macro_expand_conformances.swift
@@ -33,7 +33,7 @@ public struct PublicEquatable {
 
 // INTERFACE-NOT: @Equatable
 // INTERFACE: public struct PublicEquatable
-// INTERFACE: extension ModuleWithEquatable.PublicEquatable : Swift.Equatable
+// INTERFACE: extension ModuleWithEquatable::PublicEquatable : Swift::Equatable
 
 #else
 import ModuleWithEquatable

--- a/test/ModuleInterface/ConstKeyword.swift
+++ b/test/ModuleInterface/ConstKeyword.swift
@@ -15,6 +15,6 @@ public struct A {
 	public func takeConst2(a b: _const Int) {}
 }
 
-// CHECK: _const public static let A: Swift.String
-// CHECK: public func takeConst1(a: _const Swift.Int)
-// CHECK: public func takeConst2(a b: _const Swift.Int)
+// CHECK: _const public static let A: Swift{{::|\.}}String
+// CHECK: public func takeConst1(a: _const Swift{{::|\.}}Int)
+// CHECK: public func takeConst2(a b: _const Swift{{::|\.}}Int)

--- a/test/ModuleInterface/Inputs/enums-layout-helper.swift
+++ b/test/ModuleInterface/Inputs/enums-layout-helper.swift
@@ -1,4 +1,4 @@
-// CHECK-LABEL: public enum FutureproofEnum : Swift.Int
+// CHECK-LABEL: public enum FutureproofEnum : Swift::Int
 public enum FutureproofEnum: Int {
   // CHECK-NEXT: case a{{$}}
   case a = 1
@@ -10,7 +10,7 @@ public enum FutureproofEnum: Int {
   case d
 }
 
-// CHECK-LABEL: public enum FrozenEnum : Swift.Int
+// CHECK-LABEL: public enum FrozenEnum : Swift::Int
 @_frozen public enum FrozenEnum: Int {
   // CHECK-NEXT: case a{{$}}
   case a = 1
@@ -22,7 +22,7 @@ public enum FutureproofEnum: Int {
   case d
 }
 
-// CHECK-LABEL: public enum FutureproofObjCEnum : Swift.Int32
+// CHECK-LABEL: public enum FutureproofObjCEnum : Swift::Int32
 @objc public enum FutureproofObjCEnum: Int32 {
   // CHECK-NEXT: case a = 1{{$}}
   case a = 1
@@ -34,7 +34,7 @@ public enum FutureproofEnum: Int {
   case d
 }
 
-// CHECK-LABEL: public enum FrozenObjCEnum : Swift.Int32
+// CHECK-LABEL: public enum FrozenObjCEnum : Swift::Int32
 @_frozen @objc public enum FrozenObjCEnum: Int32 {
   // CHECK-NEXT: case a = 1{{$}}
   case a = 1
@@ -46,7 +46,7 @@ public enum FutureproofEnum: Int {
   case d
 }
 
-// CHECK-LABEL: public enum FutureproofUnicodeScalarEnum : Swift.Unicode.Scalar
+// CHECK-LABEL: public enum FutureproofUnicodeScalarEnum : Swift::Unicode.Swift::Scalar
 public enum FutureproofUnicodeScalarEnum: Unicode.Scalar {
   // CHECK-NEXT: case a{{$}}
   case a = "A"
@@ -56,7 +56,7 @@ public enum FutureproofUnicodeScalarEnum: Unicode.Scalar {
 public indirect enum FutureproofIndirectEnum {
   // CHECK-NEXT: case a{{$}}
   case a
-  // CHECK-NEXT: case b(Swift.Int){{$}}
+  // CHECK-NEXT: case b(Swift::Int){{$}}
   case b(Int)
   // CHECK-NEXT: case c{{$}}
   case c
@@ -66,7 +66,7 @@ public indirect enum FutureproofIndirectEnum {
 @_frozen public indirect enum FrozenIndirectEnum {
   // CHECK-NEXT: case a{{$}}
   case a
-  // CHECK-NEXT: case b(Swift.Int){{$}}
+  // CHECK-NEXT: case b(Swift::Int){{$}}
   case b(Int)
   // CHECK-NEXT: case c{{$}}
   case c
@@ -76,7 +76,7 @@ public indirect enum FutureproofIndirectEnum {
 public enum FutureproofIndirectCaseEnum {
   // CHECK-NEXT: {{^}} case a{{$}}
   case a
-  // CHECK-NEXT: indirect case b(Swift.Int){{$}}
+  // CHECK-NEXT: indirect case b(Swift::Int){{$}}
   indirect case b(Int)
   // CHECK-NEXT: {{^}} case c{{$}}
   case c
@@ -88,9 +88,9 @@ public enum FutureproofIndirectMultiCaseEnum {
   // CHECK-MULTI-FILE-NEXT: {{^}} case a1{{$}}
   // CHECK-MULTI-FILE-NEXT: {{^}} case a2{{$}}
   case a1, a2
-  // CHECK-SINGLE-FRONTEND-NEXT: indirect case b1(Swift.Int), b2(Swift.Int){{$}}
-  // CHECK-MULTI-FILE-NEXT: indirect case b1(Swift.Int){{$}}
-  // CHECK-MULTI-FILE-NEXT: indirect case b2(Swift.Int){{$}}
+  // CHECK-SINGLE-FRONTEND-NEXT: indirect case b1(Swift::Int), b2(Swift::Int){{$}}
+  // CHECK-MULTI-FILE-NEXT: indirect case b1(Swift::Int){{$}}
+  // CHECK-MULTI-FILE-NEXT: indirect case b2(Swift::Int){{$}}
   indirect case b1(Int), b2(Int)
   // CHECK-NEXT: {{^}} case c{{$}}
   case c
@@ -100,7 +100,7 @@ public enum FutureproofIndirectMultiCaseEnum {
 @_frozen public enum FrozenIndirectCaseEnum {
   // CHECK-NEXT: {{^}} case a{{$}}
   case a
-  // CHECK-NEXT: indirect case b(Swift.Int){{$}}
+  // CHECK-NEXT: indirect case b(Swift::Int){{$}}
   indirect case b(Int)
   // CHECK-NEXT: {{^}} case c{{$}}
   case c
@@ -112,9 +112,9 @@ public enum FutureproofIndirectMultiCaseEnum {
   // CHECK-MULTI-FILE-NEXT: {{^}} case a1{{$}}
   // CHECK-MULTI-FILE-NEXT: {{^}} case a2{{$}}
   case a1, a2
-  // CHECK-SINGLE-FRONTEND-NEXT: indirect case b1(Swift.Int), b2(Swift.Int){{$}}
-  // CHECK-MULTI-FILE-NEXT: indirect case b1(Swift.Int){{$}}
-  // CHECK-MULTI-FILE-NEXT: indirect case b2(Swift.Int){{$}}
+  // CHECK-SINGLE-FRONTEND-NEXT: indirect case b1(Swift::Int), b2(Swift::Int){{$}}
+  // CHECK-MULTI-FILE-NEXT: indirect case b1(Swift::Int){{$}}
+  // CHECK-MULTI-FILE-NEXT: indirect case b2(Swift::Int){{$}}
   indirect case b1(Int), b2(Int)
   // CHECK-NEXT: {{^}} case c{{$}}
   case c

--- a/test/ModuleInterface/access-filter.swift
+++ b/test/ModuleInterface/access-filter.swift
@@ -48,13 +48,13 @@ internal struct UFIStruct {
 
 // CHECK: public protocol PublicProto {{[{]$}}
 public protocol PublicProto {
-  // CHECK-NEXT: associatedtype Assoc = Swift.Int
+  // CHECK-NEXT: associatedtype Assoc = Swift::Int
   associatedtype Assoc = Int
   // CHECK-NEXT: func requirement()
   func requirement()
 } // CHECK-NEXT: {{^[}]$}}
 
-// CHECK: extension AccessFilter.PublicProto {{[{]$}}
+// CHECK: extension AccessFilter::PublicProto {{[{]$}}
 extension PublicProto {
   // CHECK: public func publicMethod(){{$}}
   public func publicMethod() {}
@@ -65,7 +65,7 @@ extension PublicProto {
   @usableFromInline internal func ufiMethod() {}
 } // CHECK: {{^[}]$}}
 
-// CHECK: {{^}}extension AccessFilter.PublicProto {{[{]$}}
+// CHECK: {{^}}extension AccessFilter::PublicProto {{[{]$}}
 public extension PublicProto {
   // CHECK: public func publicExtPublicMethod(){{$}}
   func publicExtPublicMethod() {}
@@ -91,13 +91,13 @@ extension InternalProto_BAD {
 // CHECK-NEXT: internal protocol UFIProto {{[{]$}}
 @usableFromInline
 internal protocol UFIProto {
-  // CHECK-NEXT: associatedtype Assoc = Swift.Int
+  // CHECK-NEXT: associatedtype Assoc = Swift::Int
   associatedtype Assoc = Int
   // CHECK-NEXT: func requirement()
   func requirement()
 } // CHECK-NEXT: {{^[}]$}}
 
-// CHECK: extension AccessFilter.UFIProto {{[{]$}}
+// CHECK: extension AccessFilter::UFIProto {{[{]$}}
 extension UFIProto {
   // CHECK: public func publicMethod(){{$}}
   public func publicMethod() {}
@@ -108,9 +108,9 @@ extension UFIProto {
   @usableFromInline internal func ufiMethod() {}
 } // CHECK: {{^[}]$}}
 
-// CHECK: extension AccessFilter.PublicStruct {{[{]$}}
+// CHECK: extension AccessFilter::PublicStruct {{[{]$}}
 extension PublicStruct {
-  // CHECK: public static var secretlySettable: Swift.Int {
+  // CHECK: public static var secretlySettable: Swift::Int {
   // CHECK-NEXT: get
   // CHECK-NEXT: }
   public private(set) static var secretlySettable: Int = 0
@@ -121,21 +121,21 @@ extension InternalStruct_BAD: PublicProto {
   internal static var dummy: Int { return 0 }
 }
 
-// CHECK: extension AccessFilter.UFIStruct : AccessFilter.PublicProto {{[{]$}}
+// CHECK: extension AccessFilter::UFIStruct : AccessFilter::PublicProto {{[{]$}}
 extension UFIStruct: PublicProto {
   // CHECK-NEXT: @usableFromInline
   // CHECK-NEXT: internal func requirement()
   @usableFromInline func requirement() {}
   internal static var dummy: Int { return 0 }
   // CHECK-NEXT: @usableFromInline
-  // CHECK-NEXT: internal typealias Assoc = Swift.Int
+  // CHECK-NEXT: internal typealias Assoc = Swift::Int
 } // CHECK-NEXT: {{^[}]$}}
 
 // CHECK: public enum PublicEnum {{[{]$}}
 public enum PublicEnum {
   // CHECK-NEXT: case x
   case x
-  // CHECK-NEXT: case y(Swift.Int)
+  // CHECK-NEXT: case y(Swift::Int)
   case y(Int)
 } // CHECK-NEXT: {{^[}]$}}
 
@@ -148,7 +148,7 @@ enum InternalEnum_BAD {
 @usableFromInline enum UFIEnum {
   // CHECK-NEXT: case x
   case x
-  // CHECK-NEXT: case y(Swift.Int)
+  // CHECK-NEXT: case y(Swift::Int)
   case y(Int)
 } // CHECK-NEXT: {{^[}]$}}
 
@@ -167,13 +167,13 @@ class InternalClass_BAD {
 // CHECK: public struct GenericStruct<T>
 public struct GenericStruct<T> {}
 
-// CHECK: extension AccessFilter.GenericStruct where T == AccessFilter.PublicStruct {{[{]$}}
-extension GenericStruct where T == AccessFilter.PublicStruct {
+// CHECK: extension AccessFilter::GenericStruct where T == AccessFilter::PublicStruct {{[{]$}}
+extension GenericStruct where T == AccessFilter::PublicStruct {
   // CHECK-NEXT: public func constrainedToPublicStruct(){{$}}
   public func constrainedToPublicStruct() {}
 } // CHECK-NEXT: {{^[}]$}}
-// CHECK: extension AccessFilter.GenericStruct where T == AccessFilter.UFIStruct {{[{]$}}
-extension GenericStruct where T == AccessFilter.UFIStruct {
+// CHECK: extension AccessFilter::GenericStruct where T == AccessFilter::UFIStruct {{[{]$}}
+extension GenericStruct where T == AccessFilter::UFIStruct {
   // CHECK-NEXT: @usableFromInline{{$}}
   // CHECK-NEXT: internal func constrainedToUFIStruct(){{$}}
   @usableFromInline internal func constrainedToUFIStruct() {}
@@ -182,12 +182,12 @@ extension GenericStruct where T == InternalStruct_BAD {
   @usableFromInline internal func constrainedToInternalStruct_BAD() {}
 }
 
-// CHECK: extension AccessFilter.GenericStruct where T == AccessFilter.PublicStruct {{[{]$}}
+// CHECK: extension AccessFilter::GenericStruct where T == AccessFilter::PublicStruct {{[{]$}}
 extension GenericStruct where PublicStruct == T {
   // CHECK-NEXT: public func constrainedToPublicStruct2(){{$}}
   public func constrainedToPublicStruct2() {}
 } // CHECK-NEXT: {{^[}]$}}
-// CHECK: extension AccessFilter.GenericStruct where T == AccessFilter.UFIStruct {{[{]$}}
+// CHECK: extension AccessFilter::GenericStruct where T == AccessFilter::UFIStruct {{[{]$}}
 extension GenericStruct where UFIStruct == T {
   // CHECK-NEXT: @usableFromInline{{$}}
   // CHECK-NEXT: internal func constrainedToUFIStruct2(){{$}}
@@ -197,12 +197,12 @@ extension GenericStruct where InternalStruct_BAD == T {
   @usableFromInline internal func constrainedToInternalStruct2_BAD() {}
 }
 
-// CHECK: extension AccessFilter.GenericStruct where T : AccessFilter.PublicProto {{[{]$}}
+// CHECK: extension AccessFilter::GenericStruct where T : AccessFilter::PublicProto {{[{]$}}
 extension GenericStruct where T: PublicProto {
   // CHECK-NEXT: public func constrainedToPublicProto(){{$}}
   public func constrainedToPublicProto() {}
 } // CHECK-NEXT: {{^[}]$}}
-// CHECK: extension AccessFilter.GenericStruct where T : AccessFilter.UFIProto {{[{]$}}
+// CHECK: extension AccessFilter::GenericStruct where T : AccessFilter::UFIProto {{[{]$}}
 extension GenericStruct where T: UFIProto {
   // CHECK-NEXT: @usableFromInline{{$}}
   // CHECK-NEXT: internal func constrainedToUFIProto(){{$}}
@@ -212,12 +212,12 @@ extension GenericStruct where T: InternalProto_BAD {
   @usableFromInline internal func constrainedToInternalProto_BAD() {}
 }
 
-// CHECK: extension AccessFilter.GenericStruct where T : AccessFilter.PublicClass {{[{]$}}
+// CHECK: extension AccessFilter::GenericStruct where T : AccessFilter::PublicClass {{[{]$}}
 extension GenericStruct where T: PublicClass {
   // CHECK-NEXT: public func constrainedToPublicClass(){{$}}
   public func constrainedToPublicClass() {}
 } // CHECK-NEXT: {{^[}]$}}
-// CHECK: extension AccessFilter.GenericStruct where T : AccessFilter.UFIClass {{[{]$}}
+// CHECK: extension AccessFilter::GenericStruct where T : AccessFilter::UFIClass {{[{]$}}
 extension GenericStruct where T: UFIClass {
   // CHECK-NEXT: @usableFromInline{{$}}
   // CHECK-NEXT: internal func constrainedToUFIClass(){{$}}
@@ -227,7 +227,7 @@ extension GenericStruct where T: InternalClass_BAD {
   @usableFromInline internal func constrainedToInternalClass_BAD() {}
 }
 
-// CHECK: extension AccessFilter.GenericStruct where T : AnyObject {{[{]$}}
+// CHECK: extension AccessFilter::GenericStruct where T : AnyObject {{[{]$}}
 extension GenericStruct where T: AnyObject {
   // CHECK-NEXT: public func constrainedToAnyObject(){{$}}
   public func constrainedToAnyObject() {}
@@ -236,21 +236,21 @@ extension GenericStruct where T: AnyObject {
 public struct PublicAliasBase {}
 internal struct ReallyInternalAliasBase_BAD {}
 
-// CHECK: public typealias PublicAlias = AccessFilter.PublicAliasBase
+// CHECK: public typealias PublicAlias = AccessFilter::PublicAliasBase
 public typealias PublicAlias = PublicAliasBase
 internal typealias InternalAlias_BAD = PublicAliasBase
 // CHECK: @usableFromInline
-// CHECK-NEXT: internal typealias UFIAlias = AccessFilter.PublicAliasBase
+// CHECK-NEXT: internal typealias UFIAlias = AccessFilter::PublicAliasBase
 @usableFromInline internal typealias UFIAlias = PublicAliasBase
 
 internal typealias ReallyInternalAlias_BAD = ReallyInternalAliasBase_BAD
 
-// CHECK: extension AccessFilter.GenericStruct where T == AccessFilter.PublicAliasBase {{[{]$}}
+// CHECK: extension AccessFilter::GenericStruct where T == AccessFilter::PublicAliasBase {{[{]$}}
 extension GenericStruct where T == PublicAlias {
   // CHECK-NEXT: public func constrainedToPublicAlias(){{$}}
   public func constrainedToPublicAlias() {}
 } // CHECK-NEXT: {{^[}]$}}
-// CHECK: extension AccessFilter.GenericStruct where T == AccessFilter.PublicAliasBase {{[{]$}}
+// CHECK: extension AccessFilter::GenericStruct where T == AccessFilter::PublicAliasBase {{[{]$}}
 extension GenericStruct where T == UFIAlias {
   // CHECK-NEXT: @usableFromInline{{$}}
   // CHECK-NEXT: internal func constrainedToUFIAlias(){{$}}
@@ -275,7 +275,7 @@ extension GenericStruct: PublicProto where T: InternalProto_BAD {
 
 public struct MultiGenericStruct<First, Second> {}
 
-// CHECK: extension AccessFilter.MultiGenericStruct where First == AccessFilter.PublicStruct, Second == AccessFilter.PublicStruct {{[{]$}}
+// CHECK: extension AccessFilter::MultiGenericStruct where First == AccessFilter::PublicStruct, Second == AccessFilter::PublicStruct {{[{]$}}
 extension MultiGenericStruct where First == PublicStruct, Second == PublicStruct {
   // CHECK-NEXT: public func publicPublic(){{$}}
   public func publicPublic() {}

--- a/test/ModuleInterface/actor_availability.swift
+++ b/test/ModuleInterface/actor_availability.swift
@@ -11,7 +11,7 @@
 // CHECK:     public actor ActorWithImplicitAvailability {
 public actor ActorWithImplicitAvailability {
   // CHECK:      @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
-  // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor {
+  // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency::UnownedSerialExecutor {
   // CHECK-NEXT:   get
   // CHECK-NEXT: }
 }
@@ -22,7 +22,7 @@ public actor ActorWithImplicitAvailability {
 @available(SwiftStdlib 5.2, *)
 public actor ActorWithExplicitAvailability {
   // CHECK:      @available(iOS 13.4, tvOS 13.4, watchOS 6.2, macOS 10.15.4, *)
-  // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor {
+  // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency::UnownedSerialExecutor {
   // CHECK-NEXT:   get
   // CHECK-NEXT: }
 }
@@ -34,7 +34,7 @@ public actor ActorWithExplicitAvailability {
 public actor UnavailableActor {
   // CHECK:      @available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
   // CHECK-NEXT: @available(macOS, unavailable, introduced: 10.15)
-  // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor {
+  // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency::UnownedSerialExecutor {
   // CHECK-NEXT:   get
   // CHECK-NEXT: }
 }
@@ -48,7 +48,7 @@ public actor DeprecatedAndObsoleteInSwift6Actor {
   // CHECK:      @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
   // CHECK-NEXT: @available(*, deprecated, message: "Will be unavailable Swift 6")
   // CHECK-NEXT: @available(swift, obsoleted: 6)
-  // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor {
+  // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency::UnownedSerialExecutor {
   // CHECK-NEXT:   get
   // CHECK-NEXT: }
 }
@@ -61,19 +61,19 @@ public enum Enum {
   // CHECK:       @_hasMissingDesignatedInitializers public actor NestedActor {
   public actor NestedActor {
     // CHECK: @available(iOS 13.4, tvOS 13.4, watchOS 6.2, macOS 10.15.4, *)
-    // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor {
+    // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency::UnownedSerialExecutor {
     // CHECK-NEXT:   get
     // CHECK-NEXT: }
   }
 }
 
-// CHECK: extension Library.Enum {
+// CHECK: extension Library::Enum {
 extension Enum {
   // CHECK-NOT: #if compiler(>=5.3) && $Actors
   // CHECK:     @_hasMissingDesignatedInitializers public actor ExtensionNestedActor {
   public actor ExtensionNestedActor {
     // CHECK:      @available(iOS 13.4, tvOS 13.4, watchOS 6.2, macOS 10.15.4, *)
-    // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor {
+    // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency::UnownedSerialExecutor {
     // CHECK-NEXT:   get
     // CHECK-NEXT: }
   }
@@ -85,7 +85,7 @@ extension Enum {
   public actor UnavailableExtensionNestedActor {
     // CHECK:      @available(iOS 13.4, tvOS 13.4, watchOS 6.2, *)
     // CHECK-NEXT: @available(macOS, unavailable, introduced: 10.15.4)
-    // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor {
+    // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency::UnownedSerialExecutor {
     // CHECK-NEXT:   get
     // CHECK-NEXT: }
   }
@@ -112,12 +112,12 @@ public struct SPIAvailableStruct {
     // CHECK-PUBLIC-NEXT: @available(tvOS, unavailable)
     // CHECK-PUBLIC-NEXT: @available(watchOS, unavailable)
     // CHECK-PUBLIC-NEXT: @available(macOS, unavailable)
-    // CHECK-PUBLIC-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor
+    // CHECK-PUBLIC-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency::UnownedSerialExecutor
     // CHECK-PRIVATE: @_spi_available(iOS, introduced: 13.4)
     // CHECK-PRIVATE-NEXT: @_spi_available(tvOS, introduced: 13.4)
     // CHECK-PRIVATE-NEXT: @_spi_available(watchOS, introduced: 6.2)
     // CHECK-PRIVATE-NEXT: @_spi_available(macOS, unavailable, introduced: 10.15.4)
-    // CHECK-PRIVATE-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor
+    // CHECK-PRIVATE-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency::UnownedSerialExecutor
   }
 }
 
@@ -129,7 +129,7 @@ public class MacCatalystAvailableClass {
   // CHECK:     @_hasMissingDesignatedInitializers public actor NestedActor
   public actor NestedActor {
     // CHECK:      @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, macCatalyst 13.1, *)
-    // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor
+    // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency::UnownedSerialExecutor
   }
 
   // CHECK-NOT:  #if compiler(>=5.3) && $Actors
@@ -138,7 +138,7 @@ public class MacCatalystAvailableClass {
   @available(macCatalyst 14, *)
   public actor LessAvailableMacCatalystActor {
     // CHECK:      @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, macCatalyst 14, *)
-    // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor
+    // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency::UnownedSerialExecutor
   }
 
   // CHECK-NOT: #if compiler(>=5.3) && $Actors
@@ -147,7 +147,7 @@ public class MacCatalystAvailableClass {
   @available(iOS 15.0, macOS 12.0, *)
   public actor AvailableiOSAndMacOSNestedActor {
     // CHECK:      @available(iOS 15.0, tvOS 13.0, watchOS 6.0, macOS 12.0, *)
-    // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor
+    // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency::UnownedSerialExecutor
   }
 
   // CHECK-NOT:  #if compiler(>=5.3) && $Actors
@@ -157,6 +157,6 @@ public class MacCatalystAvailableClass {
   public actor UnavailableiOSNestedActor {
     // CHECK:      @available(tvOS 13.0, watchOS 6.0, macOS 10.15, *)
     // CHECK-NEXT: @available(iOS, unavailable, introduced: 13.0)
-    // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor
+    // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency::UnownedSerialExecutor
   }
 }

--- a/test/ModuleInterface/actor_init.swift
+++ b/test/ModuleInterface/actor_init.swift
@@ -14,7 +14,7 @@
 public actor TestActor {
   private var x: Int
 
-  // CHECK: public convenience init(convenience x: Swift.Int)
+  // CHECK: public convenience init(convenience x: Swift::Int)
   public init(convenience x: Int) {
     self.init(designated: x)
   }
@@ -24,16 +24,16 @@ public actor TestActor {
     self.x = 0
   }
 
-  // CHECK: public init(designated x: Swift.Int)
+  // CHECK: public init(designated x: Swift::Int)
   public init(designated x: Int) {
     self.x = x
   }
 }
 
-// CHECK-LABEL: extension Library.TestActor {
+// CHECK-LABEL: extension Library::TestActor {
 @available(SwiftStdlib 5.5, *)
 extension TestActor {
-  // CHECK: public convenience init(convenienceInExtension x: Swift.Int)
+  // CHECK: public convenience init(convenienceInExtension x: Swift::Int)
   public init(convenienceInExtension x: Int) {
     self.init(designated: x)
   }

--- a/test/ModuleInterface/actor_isolation.swift
+++ b/test/ModuleInterface/actor_isolation.swift
@@ -19,7 +19,7 @@ import Preconcurrency
 public actor SomeActor {
   nonisolated func maine() { }
 
-  // CHECK: nonisolated public func takesIsolated(other: isolated {{(Test.)?}}SomeActor)
+  // CHECK: nonisolated public func takesIsolated(other: isolated {{(Test::)?}}SomeActor)
   public nonisolated func takesIsolated(other: isolated SomeActor) { }
 }
 
@@ -31,8 +31,8 @@ public struct SomeGlobalActor {
   public static let shared = SomeActor()
 }
 
-// CHECK: @{{(Test.)?}}SomeGlobalActor public protocol P1
-// CHECK-NEXT: @{{(Test.)?}}SomeGlobalActor func method()
+// CHECK: @{{(Test::)?}}SomeGlobalActor public protocol P1
+// CHECK-NEXT: @{{(Test::)?}}SomeGlobalActor func method()
 
 @available(SwiftStdlib 5.1, *)
 @SomeGlobalActor
@@ -41,7 +41,7 @@ public protocol P1 {
 }
 
 // CHECK: class C1
-// CHECK-NEXT: @{{(Test.)?}}SomeGlobalActor public func method()
+// CHECK-NEXT: @{{(Test::)?}}SomeGlobalActor public func method()
 
 @available(SwiftStdlib 5.1, *)
 public class C1: P1 {
@@ -53,17 +53,17 @@ public class C1: P1 {
 @SomeGlobalActor
 public class C2 { }
 
-// CHECK: @{{(Test.)?}}SomeGlobalActor public class C2
+// CHECK: @{{(Test::)?}}SomeGlobalActor public class C2
 
 @available(SwiftStdlib 5.1, *)
 public class C3: C2 { }
 
-// CHECK: public class C4 : Swift.UnsafeSendable
+// CHECK: public class C4 : Swift::UnsafeSendable
 
 @available(SwiftStdlib 5.1, *)
 public class C4: UnsafeSendable { }
 
-// CHECK: public class C5 : @unchecked Swift.Sendable
+// CHECK: public class C5 : @unchecked Swift::Sendable
 
 @available(SwiftStdlib 5.1, *)
 public class C5: @unchecked Sendable { }
@@ -72,7 +72,7 @@ public class C5: @unchecked Sendable { }
 @available(SwiftStdlib 5.1, *)
 public class C6 { }
 
-// CHECK: extension {{(Test.)?}}C6 : @unchecked Swift.Sendable
+// CHECK: extension {{(Test::)?}}C6 : @unchecked Swift::Sendable
 
 @available(SwiftStdlib 5.1, *)
 extension C6: @unchecked Sendable { }
@@ -81,7 +81,7 @@ extension C6: @unchecked Sendable { }
 @available(SwiftStdlib 5.1, *)
 public class C7 { }
 
-// CHECK: extension {{(Test.)?}}C7 : Swift.UnsafeSendable
+// CHECK: extension {{(Test::)?}}C7 : Swift::UnsafeSendable
 
 @available(SwiftStdlib 5.1, *)
 extension C7: UnsafeSendable { }
@@ -93,10 +93,10 @@ public protocol P2 {
 }
 
 
-// CHECK: class {{(Test.)?}}C8 : {{(Test.)?}}P2 {
+// CHECK: class {{(Test::)?}}C8 : {{(Test::)?}}P2 {
 @available(SwiftStdlib 5.1, *)
 public class C8 : P2 {
-  // CHECK: @{{(Test.)?}}SomeGlobalActor public func method()
+  // CHECK: @{{(Test::)?}}SomeGlobalActor public func method()
   public func method() {}
 }
 
@@ -111,4 +111,4 @@ public struct StructWithImplicitlyNonSendable {
 // bit in conformances which is not serialized and not present in the textual
 // form.
 
-// SYNTHESIZED: extension Test.C2 : Swift.Sendable {}
+// SYNTHESIZED: extension Test::C2 : Swift::Sendable {}

--- a/test/ModuleInterface/actor_objc.swift
+++ b/test/ModuleInterface/actor_objc.swift
@@ -13,7 +13,7 @@
 import Foundation
 
 // CHECK-LABEL: @objc @_inheritsConvenienceInitializers
-// CHECK: public actor SomeActor : ObjectiveC.NSObject {
+// CHECK: public actor SomeActor : ObjectiveC::NSObject {
 // CHECK: @objc override public init()
 @available(SwiftStdlib 5.1, *)
 public actor SomeActor: NSObject {

--- a/test/ModuleInterface/actor_protocol.swift
+++ b/test/ModuleInterface/actor_protocol.swift
@@ -9,7 +9,7 @@
 /// and not via some extension. The requirement is due to the unique
 /// optimizations applied to the implementation of actors.
 
-// CHECK-NOT: extension {{.+}} : _Concurrency.Actor
+// CHECK-NOT: extension {{.+}} : _Concurrency::Actor
 
 // CHECK: public actor PlainActorClass {
 @available(SwiftStdlib 5.1, *)
@@ -17,7 +17,7 @@ public actor PlainActorClass {
   nonisolated public func enqueue(_ job: UnownedJob) { }
 }
 
-// CHECK: public actor ExplicitActorClass : _Concurrency.Actor {
+// CHECK: public actor ExplicitActorClass : _Concurrency::Actor {
 @available(SwiftStdlib 5.1, *)
 public actor ExplicitActorClass : Actor {
   nonisolated public func enqueue(_ job: UnownedJob) { }
@@ -31,13 +31,13 @@ public actor EmptyActor {}
 @available(SwiftStdlib 5.1, *)
 public actor EmptyActorClass {}
 
-// CHECK: public protocol Cat : _Concurrency.Actor {
+// CHECK: public protocol Cat : _Concurrency::Actor {
 @available(SwiftStdlib 5.1, *)
 public protocol Cat : Actor {
   func mew()
 }
 
-// CHECK: public actor HouseCat : Library.Cat {
+// CHECK: public actor HouseCat : Library::Cat {
 @available(SwiftStdlib 5.1, *)
 public actor HouseCat : Cat {
   nonisolated public func mew() {}
@@ -50,7 +50,7 @@ public protocol ToothyMouth {
   func chew()
 }
 
-// CHECK: public actor Lion : Library.ToothyMouth, _Concurrency.Actor {
+// CHECK: public actor Lion : Library::ToothyMouth, _Concurrency::Actor {
 @available(SwiftStdlib 5.1, *)
 public actor Lion : ToothyMouth, Actor {
   nonisolated public func chew() {}

--- a/test/ModuleInterface/ambiguous-aliases-workaround-swiftinterface-objc.swift
+++ b/test/ModuleInterface/ambiguous-aliases-workaround-swiftinterface-objc.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public class C: NSObject {
-  // CHECK: @objc override dynamic public func observeValue(forKeyPath keyPath: Swift.String?, of object: Any?, change: [Foundation.NSKeyValueChangeKey : Any]?, context: Swift.UnsafeMutableRawPointer?)
+  // CHECK: @objc override dynamic public func observeValue(forKeyPath keyPath: Swift::String?, of object: Any?, change: [Foundation::NSKeyValueChangeKey : Any]?, context: Swift::UnsafeMutableRawPointer?)
   public override func observeValue(
     forKeyPath keyPath: String?,
     of object: Any?,

--- a/test/ModuleInterface/ambiguous-aliases-workaround-swiftinterface.swift
+++ b/test/ModuleInterface/ambiguous-aliases-workaround-swiftinterface.swift
@@ -19,6 +19,7 @@
 // RUN:     -emit-module-interface-path %t/Client.swiftinterface \
 // RUN:     -emit-private-module-interface-path %t/Client.private.swiftinterface \
 // RUN:     %t/Client.swift -I %t -experimental-spi-only-imports \
+// RUN:     -disable-module-selectors-in-module-interface \
 // RUN:     -alias-module-names-in-module-interface -parse-stdlib
 // RUN: %target-swift-typecheck-module-from-interface(%t/Client.swiftinterface) -I%t
 // RUN: %target-swift-typecheck-module-from-interface(%t/Client.private.swiftinterface) -module-name Client -I%t

--- a/test/ModuleInterface/assoc_type_inference_tvos.swift
+++ b/test/ModuleInterface/assoc_type_inference_tvos.swift
@@ -18,9 +18,9 @@ extension TheColor {
   // that is inferred to have tvOS availability based on its enclosing type
   // having iOS availability that predates the introduction of tvOS.
 
-  // CHECK: public init?(rawValue: Swift.String)
+  // CHECK: public init?(rawValue: Swift::String)
   // CHECK-NOT: @available(tvOS)
-  // CHECK: public typealias RawValue = Swift.String
+  // CHECK: public typealias RawValue = Swift::String
   public enum StaticNamedColor: String {
     case black
   }

--- a/test/ModuleInterface/associated_type_suppressed.swift
+++ b/test/ModuleInterface/associated_type_suppressed.swift
@@ -31,72 +31,72 @@ public struct Thing<T: Ordinary> {}
 // Keep in mind that `Rj` and `RJ` mean inverses for associated types!
 //////
 
-// CHECK: public func ncElement<T>(_ t: T) where T : assoc.P, T.Element : ~Copyable
+// CHECK: public func ncElement<T>(_ t: T) where T : assoc::P, T.Element : ~Copyable
 // SIL: @$s5assoc9ncElementyyxAA1PRz0C0Rj_zlF :
 public func ncElement<T: P>(_ t: T) where T.Element: ~Copyable {}
 
-// CHECK: public func ncElement_pi<T>(_ t: T) where T : assoc.P, T.Element : ~Copyable
+// CHECK: public func ncElement_pi<T>(_ t: T) where T : assoc::P, T.Element : ~Copyable
 // SIL: @$s5assoc12ncElement_piyyxAA1PRzlF :
 @_preInverseGenerics
 public func ncElement_pi<T: P>(_ t: T) where T.Element: ~Copyable {}
 
-// CHECK: public func ncIter<T>(_ t: T) where T : assoc.P
+// CHECK: public func ncIter<T>(_ t: T) where T : assoc::P
 // SIL: @$s5assoc6ncIteryyxAA1PRzlF :
 public func ncIter<T: P>(_ t: T) where T.Iterator: ~Copyable {}
 
-// CHECK: public func ncIter2<T>(_ t: T) where T : assoc.P
+// CHECK: public func ncIter2<T>(_ t: T) where T : assoc::P
 // SIL: @$s5assoc7ncIter2yyxAA1PRzlF :
 public func ncIter2<T: P>(_ t: T) {}
 
-// CHECK: public func ncBoth<T>(_ t: T) where T : assoc.P, T.Element : ~Copyable
+// CHECK: public func ncBoth<T>(_ t: T) where T : assoc::P, T.Element : ~Copyable
 // SIL: @$s5assoc6ncBothyyxAA1PRz7ElementRj_zlF :
 public func ncBoth<T: P>(_ t: T) where T.Iterator: ~Copyable, T.Element: ~Copyable {}
 
-// CHECK: public func bothCopyable<T>(_ t: T) where T : assoc.P, T.Iterator : Swift.Copyable
+// CHECK: public func bothCopyable<T>(_ t: T) where T : assoc::P, T.Iterator : Swift::Copyable
 // SIL: @$s5assoc12bothCopyableyyxAA1PRzs0C08IteratorRpzlF :
 public func bothCopyable<T: P>(_ t: T) where T.Iterator: Copyable {}
 
-// CHECK-LABEL: public struct Holder<S> where S : assoc.P, S : ~Copyable, S.Element : ~Copyable {
+// CHECK-LABEL: public struct Holder<S> where S : assoc::P, S : ~Copyable, S.Element : ~Copyable {
 public struct Holder<S> where S.Element: ~Copyable, S: P & ~Copyable {
 
-// CHECK: public func defaultedElement<T>(_ t: T) where T : assoc.P
+// CHECK: public func defaultedElement<T>(_ t: T) where T : assoc::P
 // SIL: @$s5assoc6HolderVAARi_z7ElementRj_zrlE09defaultedC0yyqd__AA1PRd__lF :
   public func defaultedElement<T>(_ t: T) where T: P {}
 
-// CHECK: public func ncElement<T>(_ t: T) where T : assoc.P, T.Element : ~Copyable
+// CHECK: public func ncElement<T>(_ t: T) where T : assoc::P, T.Element : ~Copyable
 // SIL: @$s5assoc6HolderVAARi_z7ElementRj_zrlE02ncC0yyqd__AA1PRd__ADRj_d__lF :
   public func ncElement<T>(_ t: T) where T: P, T.Element: ~Copyable {}
 
-// CHECK: public func copyableIter<T>(_ t: T) where T : assoc.P, T.Iterator : Swift.Copyable
+// CHECK: public func copyableIter<T>(_ t: T) where T : assoc::P, T.Iterator : Swift::Copyable
 // SIL: @$s5assoc6HolderVAARi_z7ElementRj_zrlE12copyableIteryyqd__AA1PRd__s8Copyable8IteratorRpd__lF :
 public func copyableIter<T: P>(_ t: T) where T.Iterator: Copyable {}
 }
 
-// CHECK: extension assoc.Holder {
+// CHECK: extension assoc::Holder {
 extension Holder {
   // SIL: @$s5assoc6HolderV19forceIntoInterface1yyF :
   public func forceIntoInterface1() {}
 }
 
-// CHECK: extension assoc.Holder where S.Iterator : Swift.Copyable {
+// CHECK: extension assoc::Holder where S.Iterator : Swift::Copyable {
 extension Holder where S.Iterator: Copyable {
   // SIL: @$s5assoc6HolderVAAs8Copyable8IteratorRpzrlE19forceIntoInterface2yyF :
   public func forceIntoInterface2() {}
 }
 
-// CHECK: extension assoc.Holder where S.Element : ~Copyable {
+// CHECK: extension assoc::Holder where S.Element : ~Copyable {
 extension Holder where S.Element: ~Copyable {
   // SIL: @$s5assoc6HolderVAA7ElementRj_zrlE19forceIntoInterface5yyF :
   public func forceIntoInterface5() {}
 }
 
-// CHECK: extension assoc.P {
+// CHECK: extension assoc::P {
 extension P {
   // SIL: @$s5assoc1PPAAE19forceIntoInterface3yyF :
   public func forceIntoInterface3() {}
 }
 
-// CHECK: extension assoc.P where Self.Iterator : Swift.Copyable {
+// CHECK: extension assoc::P where Self.Iterator : Swift::Copyable {
 extension P where Iterator: Copyable {
   // SIL: @$s5assoc1PPAAs8Copyable8IteratorRpzrlE19forceIntoInterface4yyF
   public func forceIntoInterface4() {}

--- a/test/ModuleInterface/async_sequence_conformance.swift
+++ b/test/ModuleInterface/async_sequence_conformance.swift
@@ -12,7 +12,7 @@ public struct SequenceAdapter<Base: AsyncSequence>: AsyncSequence {
   // CHECK-NEXT: public typealias Element = Base.Element
 
   // CHECK: @available(
-  // CHECK: @_implements(_Concurrency.AsyncIteratorProtocol, Failure)
+  // CHECK: @_implements(_Concurrency::AsyncIteratorProtocol, Failure)
   // CHECK-SAME: public typealias __AsyncIteratorProtocol_Failure = Base.Failure
   public typealias Element = Base.Element
 
@@ -24,7 +24,7 @@ public struct SequenceAdapter<Base: AsyncSequence>: AsyncSequence {
   public func makeAsyncIterator() -> AsyncIterator { AsyncIterator() }
 
   // CHECK: @available(
-  // CHECK: @_implements(_Concurrency.AsyncSequence, Failure)
+  // CHECK: @_implements(_Concurrency::AsyncSequence, Failure)
   // CHECK-SAME: public typealias __AsyncSequence_Failure = Base.Failure
 }
 
@@ -38,7 +38,7 @@ public struct OtherSequenceAdapter<Base: AsyncSequence>: AsyncSequence {
   // CHECK-LABEL: public struct AsyncIterator
   // CHECK: @available{{.*}}macOS 10.15
   // CHECK: @available(
-  // CHECK: @_implements(_Concurrency.AsyncIteratorProtocol, Failure)
+  // CHECK: @_implements(_Concurrency::AsyncIteratorProtocol, Failure)
   // CHECK-SAME: public typealias __AsyncIteratorProtocol_Failure = Base.Failure
   public typealias Element = Base.Element
 
@@ -61,9 +61,9 @@ public struct MineOwnIterator<Element>: AsyncSequence, AsyncIteratorProtocol {
   public mutating func next() async -> Element? { nil }
   public func makeAsyncIterator() -> Self { self }
 
-  // CHECK:      @_implements(_Concurrency.AsyncIteratorProtocol, Failure)
-  // CHECK-SAME: public typealias __AsyncIteratorProtocol_Failure = Swift.Never
+  // CHECK:      @_implements(_Concurrency::AsyncIteratorProtocol, Failure)
+  // CHECK-SAME: public typealias __AsyncIteratorProtocol_Failure = Swift::Never
 
-  // CHECK:      @_implements(_Concurrency.AsyncSequence, Failure)
-  // CHECK-SAME: public typealias __AsyncSequence_Failure = Swift.Never
+  // CHECK:      @_implements(_Concurrency::AsyncSequence, Failure)
+  // CHECK-SAME: public typealias __AsyncSequence_Failure = Swift::Never
 }

--- a/test/ModuleInterface/attrs.swift
+++ b/test/ModuleInterface/attrs.swift
@@ -7,26 +7,26 @@
 // RUN: %FileCheck %s --check-prefixes CHECK,PUBLIC-CHECK --input-file %t.swiftinterface
 // RUN: %FileCheck %s --check-prefixes CHECK,PRIVATE-CHECK --input-file %t.private.swiftinterface
 
-// CHECK: @_transparent public func glass() -> Swift.Int { return 0 }{{$}}
+// CHECK: @_transparent public func glass() -> Swift::Int { return 0 }{{$}}
 @_transparent public func glass() -> Int { return 0 }
 
 // CHECK: @_effects(readnone) public func illiterate(){{$}}
 @_effects(readnone) public func illiterate() {}
 
-// CHECK: @_effects(notEscaping arg1.**) public func escapeEffects(arg1: Swift.Int){{$}}
+// CHECK: @_effects(notEscaping arg1.**) public func escapeEffects(arg1: Swift::Int){{$}}
 @_effects(notEscaping arg1.**) public func escapeEffects(arg1: Int) {}
 
 // CHECK-LABEL: @frozen public struct Point {
 @frozen public struct Point {
-  // CHECK-NEXT: public var x: Swift.Int
+  // CHECK-NEXT: public var x: Swift::Int
   public var x: Int
-  // CHECK-NEXT: public var y: Swift.Int
+  // CHECK-NEXT: public var y: Swift::Int
   public var y: Int
 } // CHECK-NEXT: {{^}$}}
 
 public func someGenericFunction<T>(_ t: T) -> Int { return 0 }
 
-// CHECK: @_specialize(exported: true, kind: full, target: someGenericFunction(_:), where T == Swift.Int)
+// CHECK: @_specialize(exported: true, kind: full, target: someGenericFunction(_:), where T == Swift::Int)
 // CHECK: internal func __specialize_someGenericFunction<T>(_ t: T)
 @_specialize(exported: true, target: someGenericFunction(_:), where T == Int)
 internal func __specialize_someGenericFunction<T>(_ t: T) -> Int {
@@ -36,21 +36,21 @@ internal func __specialize_someGenericFunction<T>(_ t: T) -> Int {
 @abi(func __abi__abiAttrOnFunction(param: Int))
 public func abiAttrOnFunction(param: Int) {}
 // CHECK: #if {{.*}} $ABIAttributeSE0479
-// CHECK: @abi(func __abi__abiAttrOnFunction(param: Swift.Int))
-// CHECK: public func abiAttrOnFunction(param: Swift.Int)
+// CHECK: @abi(func __abi__abiAttrOnFunction(param: Swift::Int))
+// CHECK: public func abiAttrOnFunction(param: Swift::Int)
 // CHECK: #else
 // CHECK: @_silgen_name("$s5attrs07__abi__B14AttrOnFunction5paramySi_tF")
-// CHECK: public func abiAttrOnFunction(param: Swift.Int)
+// CHECK: public func abiAttrOnFunction(param: Swift::Int)
 // CHECK: #endif
 
 @abi(let __abi__abiAttrOnVar: Int)
 public var abiAttrOnVar: Int = 42
 // CHECK: #if {{.*}} $ABIAttributeSE0479
-// CHECK: @abi(var __abi__abiAttrOnVar: Swift.Int)
-// CHECK: public var abiAttrOnVar: Swift.Int
+// CHECK: @abi(var __abi__abiAttrOnVar: Swift::Int)
+// CHECK: public var abiAttrOnVar: Swift::Int
 // CHECK: #else
 // CHECK: @available(*, unavailable, message: "this compiler cannot match the ABI specified by the @abi attribute")
-// CHECK: public var abiAttrOnVar: Swift.Int
+// CHECK: public var abiAttrOnVar: Swift::Int
 // CHECK: #endif
 
 public struct MutatingTest {

--- a/test/ModuleInterface/attrs_objc.swift
+++ b/test/ModuleInterface/attrs_objc.swift
@@ -33,10 +33,10 @@ public class ObjCTest: NSObject {
 
   // CHECK: #if {{.*}} $ABIAttributeSE0479
   // CHECK: @abi(func abiIBActionFunc(_: Any))
-  // CHECK: @objc @IBAction @_Concurrency.MainActor @preconcurrency public func abiIBActionFunc(_: Any)
+  // CHECK: @objc @IBAction @_Concurrency::MainActor @preconcurrency public func abiIBActionFunc(_: Any)
   // CHECK: #else
   // CHECK: @_silgen_name("$s10attrs_objc8ObjCTestC15abiIBActionFuncyyypF")
-  // CHECK: @objc @IBAction @_Concurrency.MainActor @preconcurrency public func abiIBActionFunc(_: Any)
+  // CHECK: @objc @IBAction @_Concurrency::MainActor @preconcurrency public func abiIBActionFunc(_: Any)
   // CHECK: #endif
   @abi(func abiIBActionFunc(_: Any))
   @IBAction public func abiIBActionFunc(_: Any) {}

--- a/test/ModuleInterface/availability-expansion.swift
+++ b/test/ModuleInterface/availability-expansion.swift
@@ -37,5 +37,5 @@ public func onMyProjectV2_5() {}
 
 @_specialize(exported: true, availability: SwiftStdlib 5.1, *; where T == Int)
 public func testSemanticsAvailability<T>(_ t: T) {}
-// CHECK: @_specialize(exported: true, kind: full, availability: macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *; where T == Swift.Int)
+// CHECK: @_specialize(exported: true, kind: full, availability: macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *; where T == Swift::Int)
 // CHECK-NEXT: public func testSemanticsAvailability

--- a/test/ModuleInterface/availability-macos.swift
+++ b/test/ModuleInterface/availability-macos.swift
@@ -13,26 +13,26 @@
 // CHECK-LABEL: public struct StructWithProperties
 public struct StructWithProperties {
   // CHECK:      @available(macOS, unavailable)
-  // CHECK-NEXT: public var unavailableComputed: Swift.Int {
+  // CHECK-NEXT: public var unavailableComputed: Swift::Int {
   // CHECK-NEXT:   get
   // CHECK-NEXT: }
   @available(macOS, unavailable)
   public var unavailableComputed: Int { 1 }
 
   // CHECK:      @available(macOS 51, *)
-  // CHECK-NEXT: public let introducedAtDeploymentStored: Swift.Int
+  // CHECK-NEXT: public let introducedAtDeploymentStored: Swift::Int
   @available(macOS 51, *)
   public let introducedAtDeploymentStored: Int = 1
 
   // CHECK:      @available(macOS 99, *)
-  // CHECK-NEXT: public var introducedAfterDeploymentComputed: Swift.Int {
+  // CHECK-NEXT: public var introducedAfterDeploymentComputed: Swift::Int {
   // CHECK-NEXT:   get
   // CHECK-NEXT: }
   @available(macOS 99, *)
   public var introducedAfterDeploymentComputed: Int { 1 }
 
   // CHECK:      @available(macOS, unavailable)
-  // CHECK-NEXT: public let introducedAtDeploymentSPIStored: Swift.Int
+  // CHECK-NEXT: public let introducedAtDeploymentSPIStored: Swift::Int
   @_spi_available(macOS 51, *)
   public let introducedAtDeploymentSPIStored: Int = 1
 }
@@ -55,12 +55,12 @@ public enum EnumWithAssociatedValues {
   case introducedAfterDeployment
 
   // CHECK:      @available(macOS, unavailable)
-  // CHECK-NEXT: case unavailableWithAssoc(Swift.Int)
+  // CHECK-NEXT: case unavailableWithAssoc(Swift::Int)
   @available(macOS, unavailable)
   case unavailableWithAssoc(Int)
 
   // CHECK:      @available(macOS 51, *)
-  // CHECK-NEXT: case introducedAtDeploymentWithAssoc(Swift.Int)
+  // CHECK-NEXT: case introducedAtDeploymentWithAssoc(Swift::Int)
   @available(macOS 51, *)
   case introducedAtDeploymentWithAssoc(Int)
 }

--- a/test/ModuleInterface/back-deployed-attr.swift
+++ b/test/ModuleInterface/back-deployed-attr.swift
@@ -9,17 +9,17 @@
 
 public struct TopLevelStruct {
   // CHECK: @backDeployed(before: macOS 12.0)
-  // CHECK: public func backDeployedFunc_SinglePlatform() -> Swift.Int { return 41 }
+  // CHECK: public func backDeployedFunc_SinglePlatform() -> Swift::Int { return 41 }
   @backDeployed(before: macOS 12.0)
   public func backDeployedFunc_SinglePlatform() -> Int { return 41 }
   
   // CHECK: @backDeployed(before: macOS 12.0, iOS 15.0)
-  // CHECK: public func backDeployedFunc_MultiPlatform() -> Swift.Int { return 42 }
+  // CHECK: public func backDeployedFunc_MultiPlatform() -> Swift::Int { return 42 }
   @backDeployed(before: macOS 12.0, iOS 15.0)
   public func backDeployedFunc_MultiPlatform() -> Int { return 42 }
 
   // CHECK: @backDeployed(before: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0)
-  // CHECK: public func backDeployedFunc_MultiPlatformSeparate() -> Swift.Int { return 43 }
+  // CHECK: public func backDeployedFunc_MultiPlatformSeparate() -> Swift::Int { return 43 }
   @backDeployed(before: macOS 12.0)
   @backDeployed(before: iOS 15.0)
   @backDeployed(before: watchOS 8.0)
@@ -27,14 +27,14 @@ public struct TopLevelStruct {
   public func backDeployedFunc_MultiPlatformSeparate() -> Int { return 43 }
 
   // CHECK: @backDeployed(before: macOS 12.0)
-  // CHECK: public var backDeployedComputedProperty: Swift.Int {
+  // CHECK: public var backDeployedComputedProperty: Swift::Int {
   // CHECK-NEXT:   get { 44 }
   // CHECK-NEXT: }
   @backDeployed(before: macOS 12.0)
   public var backDeployedComputedProperty: Int { 44 }
 
   // CHECK: @backDeployed(before: macOS 12.0)
-  // CHECK: public var backDeployedPropertyWithAccessors: Swift.Int {
+  // CHECK: public var backDeployedPropertyWithAccessors: Swift::Int {
   // CHECK-NEXT:   get { 45 }
   // CHECK-NEXT: }
   @backDeployed(before: macOS 12.0)
@@ -43,7 +43,7 @@ public struct TopLevelStruct {
   }
 
   // CHECK: @backDeployed(before: macOS 12.0)
-  // CHECK: public subscript(index: Swift.Int) -> Swift.Int {
+  // CHECK: public subscript(index: Swift::Int) -> Swift::Int {
   // CHECK-NEXT:   get { 46 }
   // CHECK-NEXT: }
   @backDeployed(before: macOS 12.0)
@@ -53,13 +53,13 @@ public struct TopLevelStruct {
 }
 
 // CHECK: @backDeployed(before: iOS 15.0)
-// CHECK: public func backDeployedFunc_iOSOnly() -> Swift.Int
+// CHECK: public func backDeployedFunc_iOSOnly() -> Swift::Int
 // CHECK-NOT: return 99
 @backDeployed(before: iOS 15.0)
 public func backDeployedFunc_iOSOnly() -> Int { return 99 }
 
 // CHECK: @backDeployed(before: macOS 12.0)
-// CHECK: public func backDeployTopLevelFunc_macOS() -> Swift.Int {
+// CHECK: public func backDeployTopLevelFunc_macOS() -> Swift::Int {
 // CHECK-NEXT:   return 47
 // CHECK-NEXT: }
 // CHECK-NOT: fatalError()
@@ -73,28 +73,28 @@ public func backDeployTopLevelFunc_macOS() -> Int {
 }
 
 // CHECK: @backDeployed(before: macOS 26.0, iOS 26.0, tvOS 26.0, watchOS 26.0, visionOS 26.0)
-// CHECK: public func backDeployedBeforeVersionsMappingTo26() -> Swift.Int { return 26 }
+// CHECK: public func backDeployedBeforeVersionsMappingTo26() -> Swift::Int { return 26 }
 @backDeployed(before: macOS 16.0, iOS 19.0, tvOS 19.0, watchOS 12.0, visionOS 3.0)
 public func backDeployedBeforeVersionsMappingTo26() -> Int { return 26 }
 
 // CHECK: @backDeployed(before: macOS 27.0, iOS 27.0, tvOS 27.0, watchOS 27.0, visionOS 27.0)
-// CHECK: public func backDeployedBeforeVersionsMappingTo27() -> Swift.Int { return 27 }
+// CHECK: public func backDeployedBeforeVersionsMappingTo27() -> Swift::Int { return 27 }
 @backDeployed(before: macOS 17.0, iOS 20.0, tvOS 20.0, watchOS 13.0, visionOS 4.0)
 public func backDeployedBeforeVersionsMappingTo27() -> Int { return 27 }
 
 // CHECK: @backDeployed(before: macOS 26.0, iOS 26.0, tvOS 26.0, watchOS 26.0, visionOS 26.0)
-// CHECK: public func backDeployedBefore26() -> Swift.Int { return 26 }
+// CHECK: public func backDeployedBefore26() -> Swift::Int { return 26 }
 @backDeployed(before: macOS 26.0, iOS 26.0, tvOS 26.0, watchOS 26.0, visionOS 26.0)
 public func backDeployedBefore26() -> Int { return 26 }
 
 // MARK: - Availability macros
 
 // CHECK: @backDeployed(before: macOS 12.1)
-// CHECK: public func backDeployTopLevelFunc_macOS12_1() -> Swift.Int { return 48 }
+// CHECK: public func backDeployTopLevelFunc_macOS12_1() -> Swift::Int { return 48 }
 @backDeployed(before: _macOS12_1)
 public func backDeployTopLevelFunc_macOS12_1() -> Int { return 48 }
 
 // CHECK: @backDeployed(before: macOS 12.1, iOS 15.1)
-// CHECK: public func backDeployTopLevelFunc_myProject() -> Swift.Int { return 49 }
+// CHECK: public func backDeployTopLevelFunc_myProject() -> Swift::Int { return 49 }
 @backDeployed(before: _myProject 1.0)
 public func backDeployTopLevelFunc_myProject() -> Int { return 49 }

--- a/test/ModuleInterface/bitwise_copyable.swift
+++ b/test/ModuleInterface/bitwise_copyable.swift
@@ -7,10 +7,10 @@
 @frozen
 public struct S_Implicit_Noncopyable: ~Copyable {}
 
-// CHECK-NOT: extension Test.S_Implicit_Noncopyable : Swift.BitwiseCopyable {}
+// CHECK-NOT: extension Test::S_Implicit_Noncopyable : Swift::BitwiseCopyable {}
 
 // CHECK:      public protocol BitwiseCopyable {
 // CHECK-NEXT: }
-// CHECK-NEXT: public typealias _BitwiseCopyable = Test.BitwiseCopyable
+// CHECK-NEXT: public typealias _BitwiseCopyable = Test::BitwiseCopyable
 public protocol BitwiseCopyable {}
 public typealias _BitwiseCopyable = BitwiseCopyable

--- a/test/ModuleInterface/bitwise_copyable_stdlib.swift
+++ b/test/ModuleInterface/bitwise_copyable_stdlib.swift
@@ -6,7 +6,7 @@
 // CHECK:      public protocol BitwiseCopyable {
 // CHECK-NEXT: }
 
-// CHECK-NEXT: public typealias _BitwiseCopyable = Swift.BitwiseCopyable
+// CHECK-NEXT: public typealias _BitwiseCopyable = Swift::BitwiseCopyable
 public protocol BitwiseCopyable {}
 public typealias _BitwiseCopyable = BitwiseCopyable
 

--- a/test/ModuleInterface/borrow_accessor_test.swift
+++ b/test/ModuleInterface/borrow_accessor_test.swift
@@ -25,12 +25,12 @@ import borrow_accessors
 
 // CHECK: public protocol P {
 // CHECK:   #if compiler(>=5.3) && $BorrowAndMutateAccessors
-// CHECK:   var k: borrow_accessors.Klass { borrow mutate }
+// CHECK:   var k: borrow_accessors::Klass { borrow mutate }
 // CHECK:   #endif
 // CHECK: }
-// CHECK: public struct Wrapper : borrow_accessors.P {
+// CHECK: public struct Wrapper : borrow_accessors::P {
 // CHECK:   #if compiler(>=5.3) && $BorrowAndMutateAccessors
-// CHECK:   public var k: borrow_accessors.Klass {
+// CHECK:   public var k: borrow_accessors::Klass {
 // CHECK:     borrow
 // CHECK:     mutate
 // CHECK:   }

--- a/test/ModuleInterface/closure.swift
+++ b/test/ModuleInterface/closure.swift
@@ -6,8 +6,8 @@
 
 // CHECK: import Swift
 
-// CHECK: public let MyClosureVar: (Swift.Int) -> Swift.Int
+// CHECK: public let MyClosureVar: (Swift::Int) -> Swift::Int
 public let MyClosureVar: (Int) -> Int = { $0 }
 
-// CHECK: public let MyOtherClosureVar: (_ x: Swift.Int) -> Swift.Int
+// CHECK: public let MyOtherClosureVar: (_ x: Swift::Int) -> Swift::Int
 public let MyOtherClosureVar: (_ x: Int) -> Int = { x in x }

--- a/test/ModuleInterface/concurrency.swift
+++ b/test/ModuleInterface/concurrency.swift
@@ -65,32 +65,32 @@ func callFn() async {
 // CHECK: public func fn() async
 // CHECK: public func reasyncFn(_: () async -> ()) reasync
 // CHECK: public func takesSendable(_ block: {{@escaping @Sendable|@Sendable @escaping}} () async throws ->
-// CHECK: public func takesMainActor(_ block: {{@escaping @_Concurrency.MainActor|@MainActor @escaping}} () ->
+// CHECK: public func takesMainActor(_ block: {{@escaping @_Concurrency::MainActor|@MainActor @escaping}} () ->
 
-// CHECK:      @_Concurrency.MainActor @preconcurrency public protocol UnsafeMainProtocol {
-// CHECK-NEXT:   @_Concurrency.MainActor @preconcurrency func requirement()
+// CHECK:      @_Concurrency{{::|\.}}MainActor @preconcurrency public protocol UnsafeMainProtocol {
+// CHECK-NEXT:   @_Concurrency{{::|\.}}MainActor @preconcurrency func requirement()
 // CHECK-NEXT: }
 
-// CHECK:      @_Concurrency.MainActor @preconcurrency public struct InferredUnsafeMainActor :
-// CHECK-NEXT:   @_Concurrency.MainActor @preconcurrency public func requirement()
-// CHECK-NEXT:   @preconcurrency @_Concurrency.MainActor public func explicitPreconcurrency()
+// CHECK:      @_Concurrency{{::|\.}}MainActor @preconcurrency public struct InferredUnsafeMainActor :
+// CHECK-NEXT:   @_Concurrency{{::|\.}}MainActor @preconcurrency public func requirement()
+// CHECK-NEXT:   @preconcurrency @_Concurrency{{::|\.}}MainActor public func explicitPreconcurrency()
 // CHECK-NEXT: }
 
-// CHECK:      @preconcurrency @_Concurrency.MainActor public protocol PreconcurrencyMainProtocol {
-// CHECK-NEXT:   @_Concurrency.MainActor @preconcurrency func requirement()
+// CHECK:      @preconcurrency @_Concurrency{{::|\.}}MainActor public protocol PreconcurrencyMainProtocol {
+// CHECK-NEXT:   @_Concurrency{{::|\.}}MainActor @preconcurrency func requirement()
 // CHECK-NEXT: }
 
-// CHECK:      @_Concurrency.MainActor @preconcurrency public struct InferredPreconcurrencyMainActor :
-// CHECK-NEXT:   @_Concurrency.MainActor @preconcurrency public func requirement()
-// CHECK-NEXT:   @preconcurrency @_Concurrency.MainActor public func explicitPreconcurrency()
+// CHECK:      @_Concurrency{{::|\.}}MainActor @preconcurrency public struct InferredPreconcurrencyMainActor :
+// CHECK-NEXT:   @_Concurrency{{::|\.}}MainActor @preconcurrency public func requirement()
+// CHECK-NEXT:   @preconcurrency @_Concurrency{{::|\.}}MainActor public func explicitPreconcurrency()
 // CHECK-NEXT: }
 
-// CHECK-TYPECHECKED: public struct UncheckedSendable : @unchecked Swift.Sendable
+// CHECK-TYPECHECKED: public struct UncheckedSendable : @unchecked Swift::Sendable
 // CHECK-ASWRITTEN: public struct UncheckedSendable : @unchecked Sendable
 
-// CHECK-TYPECHECKED: extension Swift.UnsafePointer : @unchecked @retroactive Swift.Sendable
+// CHECK-TYPECHECKED: extension Swift::UnsafePointer : @unchecked @retroactive Swift::Sendable
 // CHECK-ASWRITTEN: extension UnsafePointer : @retroactive @unchecked Sendable
 
-// RUN: %target-swift-emit-module-interface(%t/LibraryPreserveTypesAsWritten.swiftinterface) %s -enable-experimental-concurrency -DLIBRARY -module-name LibraryPreserveTypesAsWritten -module-interface-preserve-types-as-written
+// RUN: %target-swift-emit-module-interface(%t/LibraryPreserveTypesAsWritten.swiftinterface) %s -enable-experimental-concurrency -DLIBRARY -module-name LibraryPreserveTypesAsWritten -disable-module-selectors-in-module-interface -module-interface-preserve-types-as-written
 // RUN: %target-swift-typecheck-module-from-interface(%t/LibraryPreserveTypesAsWritten.swiftinterface) -enable-experimental-concurrency
 // RUN: %FileCheck --check-prefix=CHECK --check-prefix=CHECK-ASWRITTEN %s < %t/LibraryPreserveTypesAsWritten.swiftinterface

--- a/test/ModuleInterface/conditional_pack_requirements.swift
+++ b/test/ModuleInterface/conditional_pack_requirements.swift
@@ -14,8 +14,8 @@ public struct GG1<A: P, each B: P> where A.A == C<repeat (each B).A> {}
 
 extension GG1: Q where A: Q, repeat each B: Q {}
 
-// CHECK-LABEL: public struct GG1<A, each B> where A : conditional_pack_requirements.P, repeat each B : conditional_pack_requirements.P, A.A == conditional_pack_requirements.C<repeat (each B).A> {
-// CHECK-LABEL: extension conditional_pack_requirements.GG1 : conditional_pack_requirements.Q where A : conditional_pack_requirements.Q, repeat each B : conditional_pack_requirements.Q {
+// CHECK-LABEL: public struct GG1<A, each B> where A : conditional_pack_requirements::P, repeat each B : conditional_pack_requirements::P, A.A == conditional_pack_requirements::C<repeat (each B).A> {
+// CHECK-LABEL: extension conditional_pack_requirements::GG1 : conditional_pack_requirements::Q where A : conditional_pack_requirements::Q, repeat each B : conditional_pack_requirements::Q {
 
 
 public struct GG2<each A: P> {
@@ -24,17 +24,17 @@ public struct GG2<each A: P> {
 
 extension GG2.Nested: Q where repeat each A: Q, repeat each B: Q {}
 
-// CHECK-LABEL: public struct GG2<each A> where repeat each A : conditional_pack_requirements.P {
-// CHECK-LABEL: public struct Nested<each B> where repeat each B : conditional_pack_requirements.P, repeat (each A).A == (each B).A {
-// CHECK-LABEL: extension conditional_pack_requirements.GG2.Nested : conditional_pack_requirements.Q where repeat each A : conditional_pack_requirements.Q, repeat each B : conditional_pack_requirements.Q {
+// CHECK-LABEL: public struct GG2<each A> where repeat each A : conditional_pack_requirements::P {
+// CHECK-LABEL: public struct Nested<each B> where repeat each B : conditional_pack_requirements::P, repeat (each A).A == (each B).A {
+// CHECK-LABEL: extension conditional_pack_requirements::GG2.conditional_pack_requirements::Nested : conditional_pack_requirements::Q where repeat each A : conditional_pack_requirements::Q, repeat each B : conditional_pack_requirements::Q {
 
 
 public struct GG3<A: P, each B: P> where A.A : C<repeat (each B).A> {}
 
 extension GG3: Q where A: Q, repeat each B: Q {}
 
-// CHECK-LABEL: public struct GG3<A, each B> where A : conditional_pack_requirements.P, repeat each B : conditional_pack_requirements.P, A.A : conditional_pack_requirements.C<repeat (each B).A> {
-// CHECK-LABEL: extension conditional_pack_requirements.GG3 : conditional_pack_requirements.Q where A : conditional_pack_requirements.Q, repeat each B : conditional_pack_requirements.Q {
+// CHECK-LABEL: public struct GG3<A, each B> where A : conditional_pack_requirements::P, repeat each B : conditional_pack_requirements::P, A.A : conditional_pack_requirements::C<repeat (each B).A> {
+// CHECK-LABEL: extension conditional_pack_requirements::GG3 : conditional_pack_requirements::Q where A : conditional_pack_requirements::Q, repeat each B : conditional_pack_requirements::Q {
 
 
 public struct GG4<each A: P> {
@@ -43,6 +43,6 @@ public struct GG4<each A: P> {
 
 extension GG4.Nested: Q where repeat each A: Q, repeat each B: Q {}
 
-// CHECK-LABEL: public struct GG4<each A> where repeat each A : conditional_pack_requirements.P {
-// CHECK-LABEL: public struct Nested<each B> where repeat each B : conditional_pack_requirements.P, repeat (each A).A : conditional_pack_requirements.C<(each B).A> {
-// CHECK-LABEL: extension conditional_pack_requirements.GG4.Nested : conditional_pack_requirements.Q where repeat each A : conditional_pack_requirements.Q, repeat each B : conditional_pack_requirements.Q {
+// CHECK-LABEL: public struct GG4<each A> where repeat each A : conditional_pack_requirements::P {
+// CHECK-LABEL: public struct Nested<each B> where repeat each B : conditional_pack_requirements::P, repeat (each A).A : conditional_pack_requirements::C<(each B).A> {
+// CHECK-LABEL: extension conditional_pack_requirements::GG4.conditional_pack_requirements::Nested : conditional_pack_requirements::Q where repeat each A : conditional_pack_requirements::Q, repeat each B : conditional_pack_requirements::Q {

--- a/test/ModuleInterface/conformance_suppression.swift
+++ b/test/ModuleInterface/conformance_suppression.swift
@@ -3,6 +3,6 @@
 // RUN: %FileCheck %s < %t.swiftinterface
 // RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface -module-name Mojuel)
 
-// CHECK:     public enum RecollectionOrganization<T> : ~Swift.BitwiseCopyable, Swift.Copyable where T : ~Copyable {
+// CHECK:     public enum RecollectionOrganization<T> : ~Swift::BitwiseCopyable, Swift::Copyable where T : ~Copyable {
 // CHECK-NEXT: }
 public enum RecollectionOrganization<T : ~Copyable> : ~BitwiseCopyable, Copyable {}

--- a/test/ModuleInterface/conformances.swift
+++ b/test/ModuleInterface/conformances.swift
@@ -15,64 +15,64 @@ public protocol SimpleProto {
   func inference(_: Inferred)
 } // CHECK: {{^}$}}
 
-// CHECK-LABEL: public struct SimpleImpl<Element> : conformances.SimpleProto {
+// CHECK-LABEL: public struct SimpleImpl<Element> : conformances::SimpleProto {
 public struct SimpleImpl<Element>: SimpleProto {
   // NEGATIVE-NOT: typealias Element =
-  // CHECK: public func inference(_: Swift.Int){{$}}
+  // CHECK: public func inference(_: Swift::Int){{$}}
   public func inference(_: Int) {}
-  // CHECK: public typealias Inferred = Swift.Int
+  // CHECK: public typealias Inferred = Swift::Int
 } // CHECK: {{^}$}}
 
 
 public protocol PublicProto {}
 private protocol PrivateProto {}
 
-// CHECK: public struct A1 : conformances.PublicProto {
-// NEGATIVE-NOT: extension conformances.A1
+// CHECK: public struct A1 : conformances::PublicProto {
+// NEGATIVE-NOT: extension conformances::A1
 public struct A1: PublicProto, PrivateProto {}
-// CHECK: public struct A2 : conformances.PublicProto {
-// NEGATIVE-NOT: extension conformances.A2
+// CHECK: public struct A2 : conformances::PublicProto {
+// NEGATIVE-NOT: extension conformances::A2
 public struct A2: PrivateProto, PublicProto {}
 // CHECK: public struct A3 {
-// CHECK-END: extension conformances.A3 : conformances.PublicProto {}
+// CHECK-END: extension conformances::A3 : conformances::PublicProto {}
 public struct A3: PublicProto & PrivateProto {}
 // CHECK: public struct A4 {
-// CHECK-END: extension conformances.A4 : conformances.PublicProto {}
+// CHECK-END: extension conformances::A4 : conformances::PublicProto {}
 public struct A4: PrivateProto & PublicProto {}
 
 public protocol PublicBaseProto {}
 private protocol PrivateSubProto: PublicBaseProto {}
 
 // CHECK: public struct B1 {
-// CHECK-END: extension conformances.B1 : conformances.PublicBaseProto {}
+// CHECK-END: extension conformances::B1 : conformances::PublicBaseProto {}
 public struct B1: PrivateSubProto {}
-// CHECK: public struct B2 : conformances.PublicBaseProto {
-// NEGATIVE-NOT: extension conformances.B2
+// CHECK: public struct B2 : conformances::PublicBaseProto {
+// NEGATIVE-NOT: extension conformances::B2
 public struct B2: PublicBaseProto, PrivateSubProto {}
 // CHECK: public struct B3 {
-// CHECK-END: extension conformances.B3 : conformances.PublicBaseProto {}
+// CHECK-END: extension conformances::B3 : conformances::PublicBaseProto {}
 public struct B3: PublicBaseProto & PrivateSubProto {}
-// CHECK: public struct B4 : conformances.PublicBaseProto {
-// NEGATIVE-NOT: extension conformances.B4 {
-// NEGATIVE-NOT: extension conformances.B4
+// CHECK: public struct B4 : conformances::PublicBaseProto {
+// NEGATIVE-NOT: extension conformances::B4 {
+// NEGATIVE-NOT: extension conformances::B4
 public struct B4: PublicBaseProto {}
 extension B4: PrivateSubProto {}
 // CHECK: public struct B5 {
-// CHECK: extension conformances.B5 : conformances.PublicBaseProto {
+// CHECK: extension conformances::B5 : conformances::PublicBaseProto {
 // NEGATIVE-NOT: extension B5
 public struct B5: PrivateSubProto {}
 extension B5: PublicBaseProto {}
 // CHECK: public struct B6 {
-// NEGATIVE-NOT: extension conformances.B6 : conformances.PrivateSubProto
-// NEGATIVE-NOT: extension conformances.B6 {
-// CHECK: extension conformances.B6 : conformances.PublicBaseProto {
+// NEGATIVE-NOT: extension conformances::B6 : conformances::PrivateSubProto
+// NEGATIVE-NOT: extension conformances::B6 {
+// CHECK: extension conformances::B6 : conformances::PublicBaseProto {
 public struct B6 {}
 extension B6: PrivateSubProto {}
 extension B6: PublicBaseProto {}
 // CHECK: public struct B7 {
-// CHECK: extension conformances.B7 : conformances.PublicBaseProto {
-// NEGATIVE-NOT: extension conformances.B7 : conformances.PrivateSubProto {
-// NEGATIVE-NOT: extension conformances.B7 {
+// CHECK: extension conformances::B7 : conformances::PublicBaseProto {
+// NEGATIVE-NOT: extension conformances::B7 : conformances::PrivateSubProto {
+// NEGATIVE-NOT: extension conformances::B7 {
 public struct B7 {}
 extension B7: PublicBaseProto {}
 extension B7: PrivateSubProto {}
@@ -89,90 +89,90 @@ public protocol ConditionallyConformed {}
 public protocol ConditionallyConformedAgain {}
 
 // CHECK-END: @available(*, unavailable)
-// CHECK-END-NEXT: extension conformances.OuterGeneric : conformances.ConditionallyConformed, conformances.ConditionallyConformedAgain where T : _ConstraintThatIsNotPartOfTheAPIOfThisLibrary {}
+// CHECK-END-NEXT: extension conformances::OuterGeneric : conformances::ConditionallyConformed, conformances::ConditionallyConformedAgain where T : _ConstraintThatIsNotPartOfTheAPIOfThisLibrary {}
 extension OuterGeneric: ConditionallyConformed where T: PrivateProto {}
 extension OuterGeneric: ConditionallyConformedAgain where T == PrivateProto {}
 
-// CHECK-END: extension conformances.OuterGeneric.Inner : conformances.PublicBaseProto {}
+// CHECK-END: extension conformances::OuterGeneric.conformances::Inner : conformances::PublicBaseProto {}
 // CHECK-END: @available(*, unavailable)
-// CHECK-END-NEXT: extension conformances.OuterGeneric.Inner : conformances.ConditionallyConformed, conformances.ConditionallyConformedAgain where T : _ConstraintThatIsNotPartOfTheAPIOfThisLibrary {}
+// CHECK-END-NEXT: extension conformances::OuterGeneric.conformances::Inner : conformances::ConditionallyConformed, conformances::ConditionallyConformedAgain where T : _ConstraintThatIsNotPartOfTheAPIOfThisLibrary {}
 extension OuterGeneric.Inner: ConditionallyConformed where T: PrivateProto {}
 extension OuterGeneric.Inner: ConditionallyConformedAgain where T == PrivateProto {}
 
 private protocol AnotherPrivateSubProto: PublicBaseProto {}
 
 // CHECK: public struct C1 {
-// CHECK-END: extension conformances.C1 : conformances.PublicBaseProto {}
+// CHECK-END: extension conformances::C1 : conformances::PublicBaseProto {}
 public struct C1: PrivateSubProto, AnotherPrivateSubProto {}
 // CHECK: public struct C2 {
-// CHECK-END: extension conformances.C2 : conformances.PublicBaseProto {}
+// CHECK-END: extension conformances::C2 : conformances::PublicBaseProto {}
 public struct C2: PrivateSubProto & AnotherPrivateSubProto {}
 // CHECK: public struct C3 {
-// NEGATIVE-NOT: extension conformances.C3 {
-// CHECK-END: extension conformances.C3 : conformances.PublicBaseProto {}
+// NEGATIVE-NOT: extension conformances::C3 {
+// CHECK-END: extension conformances::C3 : conformances::PublicBaseProto {}
 public struct C3: PrivateSubProto {}
 extension C3: AnotherPrivateSubProto {}
 
 public protocol PublicSubProto: PublicBaseProto {}
 public protocol APublicSubProto: PublicBaseProto {}
 
-// CHECK: public struct D1 : conformances.PublicSubProto {
-// NEGATIVE-NOT: extension conformances.D1
+// CHECK: public struct D1 : conformances::PublicSubProto {
+// NEGATIVE-NOT: extension conformances::D1
 public struct D1: PublicSubProto, PrivateSubProto {}
-// CHECK: public struct D2 : conformances.PublicSubProto {
-// NEGATIVE-NOT: extension conformances.D2
+// CHECK: public struct D2 : conformances::PublicSubProto {
+// NEGATIVE-NOT: extension conformances::D2
 public struct D2: PrivateSubProto, PublicSubProto {}
 // CHECK: public struct D3 {
-// CHECK-END: extension conformances.D3 : conformances.PublicBaseProto {}
-// CHECK-END: extension conformances.D3 : conformances.PublicSubProto {}
+// CHECK-END: extension conformances::D3 : conformances::PublicBaseProto {}
+// CHECK-END: extension conformances::D3 : conformances::PublicSubProto {}
 public struct D3: PrivateSubProto & PublicSubProto {}
 // CHECK: public struct D4 {
-// CHECK-END: extension conformances.D4 : conformances.APublicSubProto {}
-// CHECK-END: extension conformances.D4 : conformances.PublicBaseProto {}
+// CHECK-END: extension conformances::D4 : conformances::APublicSubProto {}
+// CHECK-END: extension conformances::D4 : conformances::PublicBaseProto {}
 public struct D4: APublicSubProto & PrivateSubProto {}
 // CHECK: public struct D5 {
-// NEGATIVE-NOT: extension conformances.D5 : conformances.PrivateSubProto {
-// NEGATIVE-NOT: extension conformances.D5 {
-// CHECK: extension conformances.D5 : conformances.PublicSubProto {
+// NEGATIVE-NOT: extension conformances::D5 : conformances::PrivateSubProto {
+// NEGATIVE-NOT: extension conformances::D5 {
+// CHECK: extension conformances::D5 : conformances::PublicSubProto {
 public struct D5: PrivateSubProto {}
 extension D5: PublicSubProto {}
-// CHECK: public struct D6 : conformances.PublicSubProto {
-// NEGATIVE-NOT: extension conformances.D6 {
-// NEGATIVE-NOT: extension conformances.D6
+// CHECK: public struct D6 : conformances::PublicSubProto {
+// NEGATIVE-NOT: extension conformances::D6 {
+// NEGATIVE-NOT: extension conformances::D6
 public struct D6: PublicSubProto {}
 extension D6: PrivateSubProto {}
 
 private typealias PrivateProtoAlias = PublicProto
 
 // CHECK: public struct E1 {
-// CHECK-END: extension conformances.E1 : conformances.PublicProto {}
+// CHECK-END: extension conformances::E1 : conformances::PublicProto {}
 public struct E1: PrivateProtoAlias {}
 
 private typealias PrivateSubProtoAlias = PrivateSubProto
 
 // CHECK: public struct F1 {
-// CHECK-END: extension conformances.F1 : conformances.PublicBaseProto {}
+// CHECK-END: extension conformances::F1 : conformances::PublicBaseProto {}
 public struct F1: PrivateSubProtoAlias {}
 
 private protocol ClassConstrainedProto: PublicProto, AnyObject {}
 
 public class G1: ClassConstrainedProto {}
 // CHECK: public class G1 {
-// CHECK-END: extension conformances.G1 : conformances.PublicProto {}
+// CHECK-END: extension conformances::G1 : conformances::PublicProto {}
 
 public class Base {}
 private protocol BaseConstrainedProto: Base, PublicProto {}
 
 public class H1: Base, ClassConstrainedProto {}
-// CHECK: public class H1 : conformances.Base {
-// CHECK-END: extension conformances.H1 : conformances.PublicProto {}
+// CHECK: public class H1 : conformances::Base {
+// CHECK-END: extension conformances::H1 : conformances::PublicProto {}
 
 public struct MultiGeneric<T, U, V> {}
 extension MultiGeneric: PublicProto where U: PrivateProto {}
 
 // CHECK: public struct MultiGeneric<T, U, V> {
 // CHECK-END: @available(*, unavailable)
-// CHECK-END-NEXT: extension conformances.MultiGeneric : conformances.PublicProto where T : _ConstraintThatIsNotPartOfTheAPIOfThisLibrary {}
+// CHECK-END-NEXT: extension conformances::MultiGeneric : conformances::PublicProto where T : _ConstraintThatIsNotPartOfTheAPIOfThisLibrary {}
 
 
 internal struct InternalImpl_BAD: PrivateSubProto {}
@@ -199,35 +199,35 @@ public struct CoolTVType: PrivateSubProto {}
 // CHECK: public struct CoolTVType {
 // CHECK-END: @available(iOS, unavailable)
 // CHECK-END-NEXT: @available(macOS, unavailable)
-// CHECK-END-NEXT: extension conformances.CoolTVType : conformances.PublicBaseProto {}
+// CHECK-END-NEXT: extension conformances::CoolTVType : conformances::PublicBaseProto {}
 
 @available(macOS 10.99, *)
 public struct VeryNewMacType: PrivateSubProto {}
 // CHECK: public struct VeryNewMacType {
 // CHECK-END: @available(macOS 10.99, *)
-// CHECK-END-NEXT: extension conformances.VeryNewMacType : conformances.PublicBaseProto {}
+// CHECK-END-NEXT: extension conformances::VeryNewMacType : conformances::PublicBaseProto {}
 
 public struct VeryNewMacProto {}
 @available(macOS 10.98, *)
 extension VeryNewMacProto: PrivateSubProto {}
 // CHECK: public struct VeryNewMacProto {
 // CHECK-END: @available(macOS 10.98, *)
-// CHECK-END-NEXT: extension conformances.VeryNewMacProto : conformances.PublicBaseProto {}
+// CHECK-END-NEXT: extension conformances::VeryNewMacProto : conformances::PublicBaseProto {}
 
 public struct PrivateProtoConformer {}
 extension PrivateProtoConformer : PrivateProto {
   public var member: Int { return 0 }
 }
 // CHECK: public struct PrivateProtoConformer {
-// CHECK: extension conformances.PrivateProtoConformer {
-// CHECK-NEXT: public var member: Swift.Int {
+// CHECK: extension conformances::PrivateProtoConformer {
+// CHECK-NEXT: public var member: Swift::Int {
 // CHECK-NEXT:   get
 // CHECK-NEXT: }
 // CHECK-NEXT: {{^}$}}
-// NEGATIVE-NOT: extension conformances.PrivateProtoConformer : conformances.PrivateProto {
+// NEGATIVE-NOT: extension conformances::PrivateProtoConformer : conformances::PrivateProto {
 
-// NEGATIVE-NOT: extension {{(Swift.)?}}Bool{{.+}}Hashable
-// NEGATIVE-NOT: extension {{(Swift.)?}}Bool{{.+}}Equatable
+// NEGATIVE-NOT: extension {{(Swift::)?}}Bool{{.+}}Hashable
+// NEGATIVE-NOT: extension {{(Swift::)?}}Bool{{.+}}Equatable
 
 
 @available(macOS 10.97, iOS 13.22, *)
@@ -242,11 +242,11 @@ public struct NestedAvailabilityOuter {
 // NEGATIVE-NOT: @_nonSendable
 // CHECK-LABEL: public struct NonSendable {
 // CHECK: @available(*, unavailable)
-// CHECK-NEXT: extension conformances.NonSendable : @unchecked Swift.Sendable {
+// CHECK-NEXT: extension conformances::NonSendable : @unchecked Swift::Sendable {
 
 // CHECK-END: @available(macOS 10.97, iOS 13.23, *)
 // CHECK-END: @available(tvOS, unavailable)
-// CHECK-END: extension conformances.NestedAvailabilityOuter.Inner : conformances.PublicBaseProto {}
+// CHECK-END: extension conformances::NestedAvailabilityOuter.conformances::Inner : conformances::PublicBaseProto {}
 
 
 // CHECK-END: @usableFromInline

--- a/test/ModuleInterface/convenience-init.swift
+++ b/test/ModuleInterface/convenience-init.swift
@@ -25,7 +25,7 @@ public class Base {
 }
 
 public class Derived: Base {
-  // CHECK: {{^}}  public init(z: Swift.Int)
+  // CHECK: {{^}}  public init(z: Swift::Int)
   public init(z: Int) {
     super.init(x: z)
   }
@@ -42,8 +42,8 @@ public class Derived2: Base {
     super.init(x: 1)
   }
 
-  // MERGE: {{^}}  override public convenience init(x: Swift.Int)
-  // SINGLE: {{^}}  override convenience public init(x: Swift.Int)
+  // MERGE: {{^}}  override public convenience init(x: Swift::Int)
+  // SINGLE: {{^}}  override convenience public init(x: Swift::Int)
   override convenience public init(x: Int) {
     self.init()
   }

--- a/test/ModuleInterface/coroutine_accessors.swift
+++ b/test/ModuleInterface/coroutine_accessors.swift
@@ -11,12 +11,12 @@
 var _i: Int = 0
 
 // CHECK:      #if compiler(>=5.3) && $CoroutineAccessors
-// CHECK-NEXT: public var i: Swift.Int {
+// CHECK-NEXT: public var i: Swift::Int {
 // CHECK-NEXT:   read
 // CHECK-NEXT:   modify
 // CHECK-NEXT: }
 // CHECK-NEXT: #else
-// CHECK-NEXT: public var i: Swift.Int {
+// CHECK-NEXT: public var i: Swift::Int {
 // CHECK-NEXT:   _read
 // CHECK-NEXT:   _modify
 // CHECK-NEXT: }

--- a/test/ModuleInterface/default-args.swift
+++ b/test/ModuleInterface/default-args.swift
@@ -11,52 +11,52 @@
 
 // CHECK: class Base {
 public class Base {
-  // CHECK: init(x: Swift.Int = 3)
+  // CHECK: init(x: Swift{{::|\.}}Int = 3)
   public init(x: Int = 3) {}
   public convenience init(convInit: Int) {
     self.init(x: convInit)
   }
-  // CHECK: foo(y: Swift.Int = 42)
+  // CHECK: foo(y: Swift{{::|\.}}Int = 42)
   public func foo(y: Int = 42) {}
 }
 
-// CHECK: class Derived : Test.Base {
+// CHECK: class Derived : Test{{::|\.}}Base {
 public class Derived: Base {
-  // CHECK: init(y: Swift.Int)
+  // CHECK: init(y: Swift{{::|\.}}Int)
   public convenience init(y: Int) {
     self.init()
   }
 
-  // CHECK-NOT: init(convInit: Swift.Int = super)
-  // CHECK: override {{(public )?}}init(x: Swift.Int = super)
-  // CHECK-NOT: init(convInit: Swift.Int = super)
+  // CHECK-NOT: init(convInit: Swift{{::|\.}}Int = super)
+  // CHECK: override {{(public )?}}init(x: Swift{{::|\.}}Int = super)
+  // CHECK-NOT: init(convInit: Swift{{::|\.}}Int = super)
 }
 
 public enum Enum {
-  // CHECK: case pie(filling: Swift.String = "apple")
+  // CHECK: case pie(filling: Swift{{::|\.}}String = "apple")
   case pie(filling: String = "apple")
 }
 
 public struct HasSubscript {
-  // CHECK: subscript(x: Swift.Int = 0) -> Swift.Int {
+  // CHECK: subscript(x: Swift{{::|\.}}Int = 0) -> Swift{{::|\.}}Int {
   public subscript(x: Int = 0) -> Int { return 0 }
 }
 
-// CHECK: func hasClosureDefaultArg(_ x: () -> Swift.Void = {
+// CHECK: func hasClosureDefaultArg(_ x: () -> Swift{{::|\.}}Void = {
 // CHECK-NEXT: })
 public func hasClosureDefaultArg(_ x: () -> Void = {
 }) {
 }
 
-// CHECK: func hasMagicDefaultArgs(_ f: Swift.String = #file, _ fu: Swift.String = #function, _ l: Swift.Int = #line)
+// CHECK: func hasMagicDefaultArgs(_ f: Swift{{::|\.}}String = #file, _ fu: Swift{{::|\.}}String = #function, _ l: Swift{{::|\.}}Int = #line)
 public func hasMagicDefaultArgs(_ f: String = #file, _ fu: String = #function, _ l: Int = #line) {}
 
-// CHECK: func hasSimpleDefaultArgs(_ x: Swift.Int = 0, b: Swift.Int = 1)
+// CHECK: func hasSimpleDefaultArgs(_ x: Swift{{::|\.}}Int = 0, b: Swift{{::|\.}}Int = 1)
 public func hasSimpleDefaultArgs(_ x: Int = 0, b: Int = 1) {
 }
 
 // rdar://83202870
 // https://github.com/apple/swift/issues/57504
 // Make sure we can extract the textual representation here.
-// CHECK: func hasTupleConstructionDefaultArgs(_ x: Any = (), y: (Swift.String, Swift.Int) = ("", 0))
+// CHECK: func hasTupleConstructionDefaultArgs(_ x: Any = (), y: (Swift{{::|\.}}String, Swift{{::|\.}}Int) = ("", 0))
 public func hasTupleConstructionDefaultArgs(_ x: Any = Void(), y: (String, Int) = (String, Int)("", 0)) {}

--- a/test/ModuleInterface/derived_conformances_nonisolated.swift
+++ b/test/ModuleInterface/derived_conformances_nonisolated.swift
@@ -5,14 +5,14 @@
 
 // REQUIRES: concurrency
 
-// CHECK: @_Concurrency.MainActor public struct X1 : Swift.Equatable, Swift.Hashable, Swift.Codable
+// CHECK: @_Concurrency::MainActor public struct X1 : Swift::Equatable, Swift::Hashable, Swift::Codable
 @MainActor public struct X1: Equatable, Hashable, Codable {
   let x: Int
   let y: String
 
-  // CHECK: nonisolated public static func == (a: Library.X1, b: Library.X1) -> Swift.Bool
-  // CHECK: nonisolated public func encode(to encoder: any Swift.Encoder) throws
-  // CHECK: nonisolated public func hash(into hasher: inout Swift.Hasher)
-  // CHECK: nonisolated public var hashValue: Swift.Int
-  // CHECK: nonisolated public init(from decoder: any Swift.Decoder) throws
+  // CHECK: nonisolated public static func == (a: Library::X1, b: Library::X1) -> Swift::Bool
+  // CHECK: nonisolated public func encode(to encoder: any Swift::Encoder) throws
+  // CHECK: nonisolated public func hash(into hasher: inout Swift::Hasher)
+  // CHECK: nonisolated public var hashValue: Swift::Int
+  // CHECK: nonisolated public init(from decoder: any Swift::Decoder) throws
 }

--- a/test/ModuleInterface/distributed-actor.swift
+++ b/test/ModuleInterface/distributed-actor.swift
@@ -32,53 +32,53 @@ import Distributed
 // CHECK-NEXT: distributed public actor DA {
 @available(SwiftStdlib 5.7, *)
 public distributed actor DA {
-  // CHECK: @_compilerInitialized nonisolated final public let id: Distributed.LocalTestingDistributedActorSystem.ActorID
-  // CHECK: nonisolated final public let actorSystem: Library.DA.ActorSystem
-  // CHECK: public typealias ActorSystem = Distributed.LocalTestingDistributedActorSystem
+  // CHECK: @_compilerInitialized nonisolated final public let id: Distributed::LocalTestingDistributedActorSystem.Distributed::ActorID
+  // CHECK: nonisolated final public let actorSystem: Library::DA.Library::ActorSystem
+  // CHECK: public typealias ActorSystem = Distributed::LocalTestingDistributedActorSystem
   public typealias ActorSystem = LocalTestingDistributedActorSystem
 
-  // CHECK:       public static func resolve(id: Distributed.LocalTestingDistributedActorSystem.ActorID, using system: Library.DA.ActorSystem) throws -> Library.DA
-  // CHECK:       public typealias ID = Distributed.LocalTestingDistributedActorSystem.ActorID
-  // CHECK:       public typealias SerializationRequirement = any Swift.Decodable & Swift.Encodable
+  // CHECK:       public static func resolve(id: Distributed::LocalTestingDistributedActorSystem.Distributed::ActorID, using system: Library::DA.Library::ActorSystem) throws -> Library::DA
+  // CHECK:       public typealias ID = Distributed::LocalTestingDistributedActorSystem.Distributed::ActorID
+  // CHECK:       public typealias SerializationRequirement = any Swift::Decodable & Swift::Encodable
   // CHECK:       {{@objc deinit|deinit}}
-  // CHECK:       nonisolated public var hashValue: Swift.Int {
+  // CHECK:       nonisolated public var hashValue: Swift::Int {
   // CHECK-NEXT:    get
   // CHECK-NEXT:  }
-  // CHECK:       public init(actorSystem system: Library.DA.ActorSystem)
+  // CHECK:       public init(actorSystem system: Library::DA.Library::ActorSystem)
   // CHECK:       @available(iOS 16.0, tvOS 16.0, watchOS 9.0, macOS 13.0, *)
-  // CHECK-NEXT:  @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor {
+  // CHECK-NEXT:  @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency::UnownedSerialExecutor {
   // CHECK-NEXT:    get
   // CHECK-NEXT:  }
 }
 
 // CHECK-NOT: #if compiler(>=5.3) && $Actors
 // CHECK: @available({{.*}})
-// CHECK-NEXT: distributed public actor DAG<ActorSystem> where ActorSystem : Distributed.DistributedActorSystem, ActorSystem.SerializationRequirement == any Swift.Decodable & Swift.Encodable {
+// CHECK-NEXT: distributed public actor DAG<ActorSystem> where ActorSystem : Distributed::DistributedActorSystem, ActorSystem.SerializationRequirement == any Swift::Decodable & Swift::Encodable {
 @available(SwiftStdlib 6.0, *)
 public distributed actor DAG<ActorSystem> where ActorSystem: DistributedActorSystem<any Codable> {
   // CHECK: @_compilerInitialized nonisolated final public let id: ActorSystem.ActorID
   // CHECK: nonisolated final public let actorSystem: ActorSystem
 
-// CHECK: public static func resolve(id: ActorSystem.ActorID, using system: ActorSystem) throws -> Library.DAG<ActorSystem>
+// CHECK: public static func resolve(id: ActorSystem.ActorID, using system: ActorSystem) throws -> Library::DAG<ActorSystem>
 // CHECK: public typealias ID = ActorSystem.ActorID
-// CHECK: public typealias SerializationRequirement = any Swift.Decodable & Swift.Encodable
+// CHECK: public typealias SerializationRequirement = any Swift::Decodable & Swift::Encodable
 // CHECK: {{@objc deinit|deinit}}
-// CHECK: nonisolated public var hashValue: Swift.Int {
+// CHECK: nonisolated public var hashValue: Swift::Int {
 // CHECK:   get
 // CHECK: }
 // CHECK: public init(actorSystem system: ActorSystem)
 // CHECK: @available(iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, macOS 15.0, *)
-// CHECK: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor {
+// CHECK: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency::UnownedSerialExecutor {
 // CHECK:   get
 // CHECK: }
 }
 
 // CHECK-NOT: #if compiler(>=5.3) && $Actors
 // CHECK:     @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-// CHECK-NEXT:extension Library.DA : Swift.Encodable {}
+// CHECK-NEXT:extension Library::DA : Swift::Encodable {}
 // CHECK-NOT: #if compiler(>=5.3) && $Actors
 // CHECK:     @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-// CHECK-NEXT:extension Library.DA : Swift.Decodable {}
+// CHECK-NEXT:extension Library::DA : Swift::Decodable {}
 
 //--- Client.swift
 

--- a/test/ModuleInterface/effectful_properties.swift
+++ b/test/ModuleInterface/effectful_properties.swift
@@ -5,7 +5,7 @@
 public struct MyStruct {}
 
 // CHECK-NOT:    #if compiler(>=5.3) && $EffectfulProp
-// CHECK:        public var status: Swift.Bool {
+// CHECK:        public var status: Swift::Bool {
 // CHECK:          get async throws
 // CHECK:        }
 
@@ -16,13 +16,13 @@ public extension MyStruct {
 }
 
 // CHECK-NOT:    #if compiler(>=5.3) && $EffectfulProp
-// CHECK:        public var hello: Swift.Int {
+// CHECK:        public var hello: Swift::Int {
 // CHECK:            get async
 // CHECK:          }
 
 
 // CHECK-NOT:    #if compiler(>=5.3) && $EffectfulProp
-// CHECK:        public subscript(x: Swift.Int) -> Swift.Void {
+// CHECK:        public subscript(x: Swift::Int) -> Swift::Void {
 // CHECK:            get async throws
 // CHECK:          }
 
@@ -35,7 +35,7 @@ public class C {
 }
 
 // CHECK-NOT:    #if compiler(>=5.3) && $EffectfulProp
-// CHECK:        public var world: Swift.Int {
+// CHECK:        public var world: Swift::Int {
 // CHECK:          get throws
 // CHECK:        }
 
@@ -44,11 +44,11 @@ public enum E {
 }
 
 // CHECK-NOT:    #if compiler(>=5.3) && $EffectfulProp
-// CHECK:        var books: Swift.Int { get async }
+// CHECK:        var books: Swift::Int { get async }
 
 
 // CHECK-NOT:    #if compiler(>=5.3) && $EffectfulProp
-// CHECK:        subscript(x: Swift.Int) -> Swift.Int { get throws }
+// CHECK:        subscript(x: Swift::Int) -> Swift::Int { get throws }
 
 public protocol P {
   var books: Int { get async }

--- a/test/ModuleInterface/empty-extension.swift
+++ b/test/ModuleInterface/empty-extension.swift
@@ -51,10 +51,10 @@ extension IOIImportedType {
 // CHECK-NOT: funcForAnotherOS
 
 extension NormalImportedType : PublicProto {}
-// CHECK: extension Lib.NormalImportedType
+// CHECK: extension Lib::NormalImportedType
 
 extension ExportedType : PublicProto {}
-// CHECK: extension IndirectLib.ExportedType
+// CHECK: extension IndirectLib::ExportedType
 
 extension NormalImportedType {
   #if os(macOS)

--- a/test/ModuleInterface/enable_builtin_module.swift
+++ b/test/ModuleInterface/enable_builtin_module.swift
@@ -10,7 +10,7 @@
 // CHECK: import _StringProcessing
 // CHECK: import _SwiftConcurrencyShims
 
-// CHECK: public func something(with x: Builtin.RawPointer)
+// CHECK: public func something(with x: Builtin::RawPointer)
 
 import Builtin
 

--- a/test/ModuleInterface/escape-Type-and-Protocol.swift
+++ b/test/ModuleInterface/escape-Type-and-Protocol.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name main
 // RUN: %FileCheck %s < %t.swiftinterface
 
-// CHECK: public let Type: Swift.Int
+// CHECK: public let Type: Swift::Int
 public let Type = 0
 
 // CHECK: public struct A {
@@ -19,7 +19,7 @@ public class B {
   // CHECK: }
   public class `Type` {}
 
-  // CHECK-NEXT: public var `Type`: Swift.Int
+  // CHECK-NEXT: public var `Type`: Swift::Int
   public var `Type` = 0
 // CHECK: }
 }
@@ -35,7 +35,7 @@ public struct C {
 
 // CHECK: public struct D {
 public struct D {
-  // CHECK: public typealias `Type` = Swift.Int
+  // CHECK: public typealias `Type` = Swift::Int
   public typealias `Type` = Int
 // CHECK-NEXT: }
 }

--- a/test/ModuleInterface/escaping_functions.swift
+++ b/test/ModuleInterface/escaping_functions.swift
@@ -12,5 +12,5 @@ public enum A {
 }
 
 // CHECK-LABEL: public enum A {
-// CHECK-NEXT:    case function((@escaping () -> Swift.Void) -> Swift.Void)
+// CHECK-NEXT:    case function((@escaping () -> Swift::Void) -> Swift::Void)
 // CHECK-NEXT:  }

--- a/test/ModuleInterface/exclusivity.swift
+++ b/test/ModuleInterface/exclusivity.swift
@@ -2,42 +2,42 @@
 // RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name exclusivity
 // RUN: %FileCheck %s < %t.swiftinterface
 
-// CHECK: @exclusivity(checked) public var checkedGlobalVar: Swift.Int
+// CHECK: @exclusivity(checked) public var checkedGlobalVar: Swift::Int
 @exclusivity(checked)
 public var checkedGlobalVar = 1
 
-// CHECK: @exclusivity(unchecked) public var uncheckedGlobalVar: Swift.Int
+// CHECK: @exclusivity(unchecked) public var uncheckedGlobalVar: Swift::Int
 @exclusivity(unchecked)
 public var uncheckedGlobalVar = 1
 
 // CHECK-LABEL: public struct Struct
 public struct Struct {
-  // CHECK: @exclusivity(unchecked) public static var uncheckedStaticVar: Swift.Int
+  // CHECK: @exclusivity(unchecked) public static var uncheckedStaticVar: Swift::Int
   @exclusivity(unchecked)
   public static var uncheckedStaticVar: Int = 27
 
-  // CHECK: @exclusivity(checked) public static var checkedStaticVar: Swift.Int
+  // CHECK: @exclusivity(checked) public static var checkedStaticVar: Swift::Int
   @exclusivity(checked)
   public static var checkedStaticVar: Int = 27
 }
 
 // CHECK-LABEL: public class Class
 public class Class {
-  // CHECK: @exclusivity(unchecked) public var uncheckedInstanceVar: Swift.Int
+  // CHECK: @exclusivity(unchecked) public var uncheckedInstanceVar: Swift::Int
   @exclusivity(unchecked)
   public var uncheckedInstanceVar: Int = 27
 
-  // CHECK: @exclusivity(checked) public var checkedInstanceVar: Swift.Int
+  // CHECK: @exclusivity(checked) public var checkedInstanceVar: Swift::Int
   @exclusivity(checked)
   public var checkedInstanceVar: Int = 27
 
-  // CHECK:      @exclusivity(unchecked) public var uncheckedPrivateSetInstanceVar: Swift.Int {
+  // CHECK:      @exclusivity(unchecked) public var uncheckedPrivateSetInstanceVar: Swift::Int {
   // CHECK-NEXT:   get
   // CHECK-NEXT: }
   @exclusivity(unchecked)
   public private(set) var uncheckedPrivateSetInstanceVar: Int = 27
 
-  // CHECK: @exclusivity(unchecked) public static var uncheckedStaticVar: Swift.Int
+  // CHECK: @exclusivity(unchecked) public static var uncheckedStaticVar: Swift::Int
   @exclusivity(unchecked)
   public static var uncheckedStaticVar: Int = 27
 }

--- a/test/ModuleInterface/execution_behavior_attrs.swift
+++ b/test/ModuleInterface/execution_behavior_attrs.swift
@@ -7,12 +7,12 @@
 
 public struct TestWithAttrs {
   // CHECK: #if compiler(>=5.3) && $AsyncExecutionBehaviorAttributes
-  // CHECK-NEXT: public func test(_: nonisolated(nonsending) @escaping () async -> Swift.Void)
+  // CHECK-NEXT: public func test(_: nonisolated(nonsending) @escaping () async -> Swift::Void)
   // CHECK-NEXT: #endif
   public func test(_: nonisolated(nonsending) @escaping () async -> Void) {}
 
   // CHECK: #if compiler(>=5.3) && $AsyncExecutionBehaviorAttributes
-  // CHECK-NEXT: public func withInOut(fn: nonisolated(nonsending) inout () async -> Swift.Void)
+  // CHECK-NEXT: public func withInOut(fn: nonisolated(nonsending) inout () async -> Swift::Void)
   // CHECK-NEXT: #endif
   public func withInOut(fn: nonisolated(nonsending) inout () async -> Void) {}
 }
@@ -26,14 +26,14 @@ public struct Test {
   }
 
   // CHECK: #if compiler(>=5.3) && $AsyncExecutionBehaviorAttributes
-  // CHECK-NEXT: @concurrent public init(something: Swift.Int) async
+  // CHECK-NEXT: @concurrent public init(something: Swift::Int) async
   // CHECK-NEXT: #endif
   @concurrent
   public init(something: Int) async {
   }
 
   // CHECK-NOT: #if compiler(>=5.3) && $AsyncExecutionBehaviorAttributes
-  // CHECK: public init(noExplicit: Swift.String) async
+  // CHECK: public init(noExplicit: Swift::String) async
   // CHECK-NOT: #endif
   public init(noExplicit: String) async {
   }
@@ -46,27 +46,27 @@ public struct Test {
   }
 
   // CHECK: #if compiler(>=5.3) && $AsyncExecutionBehaviorAttributes
-  // CHECK-NEXT: public func other(_: nonisolated(nonsending) () async -> Swift.Void)
+  // CHECK-NEXT: public func other(_: nonisolated(nonsending) () async -> Swift::Void)
   // CHECK-NEXT: #endif
   public func other(_: nonisolated(nonsending) () async -> Void) {}
 
   // CHECK-NOT: #if compiler(>=5.3) && $AsyncExecutionBehaviorAttributes
-  // CHECK: public func concurrentResult(_: () async -> Swift.Void) -> (Swift.Int) async -> Swift.Void
+  // CHECK: public func concurrentResult(_: () async -> Swift::Void) -> (Swift::Int) async -> Swift::Void
   // CHECK-NOT: #endif
   public func concurrentResult(_: () async -> Void) -> @concurrent (Int) async -> Void {}
 
   // CHECK: #if compiler(>=5.3) && $AsyncExecutionBehaviorAttributes
-  // CHECK-NEXT: public func nestedPositions1(_: Swift.Array<[Swift.String : nonisolated(nonsending) (Swift.Int) async -> Swift.Void]>)
+  // CHECK-NEXT: public func nestedPositions1(_: Swift::Array<[Swift::String : nonisolated(nonsending) (Swift::Int) async -> Swift::Void]>)
   // CHECK-NEXT: #endif
   public func nestedPositions1(_: Array<[String: nonisolated(nonsending) (Int) async -> Void]>) {}
 
   // CHECK-NOT: #if compiler(>=5.3) && $AsyncExecutionBehaviorAttributes
-  // CHECK: public func nestedPositions2(_: Swift.Array<[Swift.String : (Swift.Int) async -> Swift.Void]>)
+  // CHECK: public func nestedPositions2(_: Swift::Array<[Swift::String : (Swift::Int) async -> Swift::Void]>)
   // CHECK-NOT: #endif
   public func nestedPositions2(_: Array<[String: @concurrent (Int) async -> Void]>) {}
 
   // CHECK: #if compiler(>=5.3) && $AsyncExecutionBehaviorAttributes
-  // CHECK-NEXT: nonisolated(nonsending) public var testOnVar: Swift.Int {
+  // CHECK-NEXT: nonisolated(nonsending) public var testOnVar: Swift::Int {
   // CHECK-NEXT:   get async
   // CHECK-NEXT: }
   // CHECK-NEXT: #endif
@@ -78,7 +78,7 @@ public struct Test {
   }
 
   // CHECK: #if compiler(>=5.3) && $AsyncExecutionBehaviorAttributes
-  // CHECK-NEXT: @concurrent public var testOnVarConcurrent: Swift.Int {
+  // CHECK-NEXT: @concurrent public var testOnVarConcurrent: Swift::Int {
   // CHECK-NEXT:   get async
   // CHECK-NEXT: }
   // CHECK-NEXT: #endif
@@ -90,7 +90,7 @@ public struct Test {
   }
 
   // CHECK: #if compiler(>=5.3) && $AsyncExecutionBehaviorAttributes
-  // CHECK-NEXT: nonisolated(nonsending) public subscript(onSubscript _: Swift.Int) -> Swift.Bool {
+  // CHECK-NEXT: nonisolated(nonsending) public subscript(onSubscript _: Swift::Int) -> Swift::Bool {
   // CHECK-NEXT:   get async
   // CHECK-NEXT: }
   // CHECK-NEXT: #endif
@@ -102,7 +102,7 @@ public struct Test {
   }
 
   // CHECK: #if compiler(>=5.3) && $AsyncExecutionBehaviorAttributes
-  // CHECK-NEXT: @concurrent public subscript(concurrentOnSubscript _: Swift.Int) -> Swift.Bool {
+  // CHECK-NEXT: @concurrent public subscript(concurrentOnSubscript _: Swift::Int) -> Swift::Bool {
   // CHECK-NEXT:   get async
   // CHECK-NEXT: }
   // CHECK-NEXT: #endif

--- a/test/ModuleInterface/existential-any.swift
+++ b/test/ModuleInterface/existential-any.swift
@@ -10,32 +10,32 @@ public protocol P { }
 
 // CHECK: public protocol Q
 public protocol Q {
-  // CHECK: associatedtype A : main.P
+  // CHECK: associatedtype A : main::P
   associatedtype A: P
 }
 
-// CHECK: public func takesAndReturnsP(_ x: any main.P) -> any main.P
+// CHECK: public func takesAndReturnsP(_ x: any main::P) -> any main::P
 public func takesAndReturnsP(_ x: P) -> P {
   return x
 }
 
-// CHECK: public func takesAndReturnsOptionalP(_ x: (any main.P)?) -> (any main.P)?
+// CHECK: public func takesAndReturnsOptionalP(_ x: (any main::P)?) -> (any main::P)?
 public func takesAndReturnsOptionalP(_ x: P?) -> P? {
   return x
 }
 
-// CHECK: public func takesAndReturnsQ(_ x: any main.Q) -> any main.Q
+// CHECK: public func takesAndReturnsQ(_ x: any main::Q) -> any main::Q
 public func takesAndReturnsQ(_ x: any Q) -> any Q {
   return x
 }
 
 // CHECK: public struct S
 public struct S {
-  // CHECK: public var p: any main.P
+  // CHECK: public var p: any main::P
   public var p: P
-  // CHECK: public var maybeP: (any main.P)?
+  // CHECK: public var maybeP: (any main::P)?
   public var maybeP: P?
-  // CHECK: public var q: any main.Q
+  // CHECK: public var q: any main::Q
   public var q: any Q
 }
 
@@ -44,22 +44,22 @@ public protocol ProtocolTypealias {
   typealias A = P
 }
 
-// CHECK: public func dependentExistential<T>(value: (T) -> any main.P) where T : main.ProtocolTypealias
+// CHECK: public func dependentExistential<T>(value: (T) -> any main::P) where T : main::ProtocolTypealias
 public func dependentExistential<T: ProtocolTypealias>(value: (T) -> T.A) {}
 
 public protocol Yescopyable {}
 public protocol Noncopyable: ~Copyable {}
 
-// CHECK: public func existentialMetatype1(_: any (main.Noncopyable & ~Copyable).Type)
-// CHECK: public func existentialMetatype2(_: any (main.Noncopyable & main.Yescopyable).Type)
+// CHECK: public func existentialMetatype1(_: any (main::Noncopyable & ~Copyable).Type)
+// CHECK: public func existentialMetatype2(_: any (main::Noncopyable & main::Yescopyable).Type)
 // CHECK: public func existentialMetatype3(_: any ~Copyable.Type)
 
 public func existentialMetatype1(_: any (Noncopyable & ~Copyable).Type) {}
 public func existentialMetatype2(_: any (Yescopyable & Noncopyable).Type) {}
 public func existentialMetatype3(_: any ~Copyable.Type) {}
 
-// CHECK: public func metatypeExistential1(_: (any main.Noncopyable & ~Copyable).Type)
-// CHECK: public func metatypeExistential2(_: (any main.Noncopyable & main.Yescopyable).Type)
+// CHECK: public func metatypeExistential1(_: (any main::Noncopyable & ~Copyable).Type)
+// CHECK: public func metatypeExistential2(_: (any main::Noncopyable & main::Yescopyable).Type)
 // CHECK: public func metatypeExistential3(_: (any ~Copyable).Type)
 
 public func metatypeExistential1(_: (any Noncopyable & ~Copyable).Type) {}

--- a/test/ModuleInterface/export-as-in-swiftinterfaces-submodules.swift
+++ b/test/ModuleInterface/export-as-in-swiftinterfaces-submodules.swift
@@ -80,20 +80,20 @@ import Library.Submodule
 // PUBLIC-LABEL: public func foo
 // PRIVATE-LABEL: public func foo
 public func foo(
-  // PUBLIC-SAME: a: Library.LibraryCoreType
-  // PRIVATE-SAME: a: Library.LibraryCoreType
+  // PUBLIC-SAME: a: Library::LibraryCoreType
+  // PRIVATE-SAME: a: Library::LibraryCoreType
   a: LibraryCoreType,
-  // PUBLIC-SAME: b: Library.LibraryCoreSubmoduleType
-  // PRIVATE-SAME: b: LibraryCore.LibraryCoreSubmoduleType
+  // PUBLIC-SAME: b: Library::LibraryCoreSubmoduleType
+  // PRIVATE-SAME: b: LibraryCore::LibraryCoreSubmoduleType
   b: LibraryCoreSubmoduleType,
-  // PUBLIC-SAME: c: Library.LibraryCoreReexportedSubmoduleType
-  // PRIVATE-SAME: c: LibraryCore.LibraryCoreReexportedSubmoduleType
+  // PUBLIC-SAME: c: Library::LibraryCoreReexportedSubmoduleType
+  // PRIVATE-SAME: c: LibraryCore::LibraryCoreReexportedSubmoduleType
   c: LibraryCoreReexportedSubmoduleType,
-  // PUBLIC-SAME: d: Library.LibraryType
-  // PRIVATE-SAME: d: Library.LibraryType
+  // PUBLIC-SAME: d: Library::LibraryType
+  // PRIVATE-SAME: d: Library::LibraryType
   d: LibraryType,
-  // PUBLIC-SAME: e: Library.LibrarySubmoduleType
-  // PRIVATE-SAME: e: Library.LibrarySubmoduleType
+  // PUBLIC-SAME: e: Library::LibrarySubmoduleType
+  // PRIVATE-SAME: e: Library::LibrarySubmoduleType
   e: LibrarySubmoduleType
 ) {}
 
@@ -106,13 +106,13 @@ import LibraryCore.ReexportedSubmodule
 // PUBLIC-LABEL: public func foo
 // PRIVATE-LABEL: public func foo
 public func foo(
-  // PUBLIC-SAME: a: Library.LibraryCoreType
-  // PRIVATE-SAME: a: LibraryCore.LibraryCoreType
+  // PUBLIC-SAME: a: Library::LibraryCoreType
+  // PRIVATE-SAME: a: LibraryCore::LibraryCoreType
   a: LibraryCoreType,
-  // PUBLIC-SAME: b: Library.LibraryCoreSubmoduleType
-  // PRIVATE-SAME: b: LibraryCore.LibraryCoreSubmoduleType
+  // PUBLIC-SAME: b: Library::LibraryCoreSubmoduleType
+  // PRIVATE-SAME: b: LibraryCore::LibraryCoreSubmoduleType
   b: LibraryCoreSubmoduleType,
-  // PUBLIC-SAME: c: Library.LibraryCoreReexportedSubmoduleType
-  // PRIVATE-SAME: c: LibraryCore.LibraryCoreReexportedSubmoduleType
+  // PUBLIC-SAME: c: Library::LibraryCoreReexportedSubmoduleType
+  // PRIVATE-SAME: c: LibraryCore::LibraryCoreReexportedSubmoduleType
   c: LibraryCoreReexportedSubmoduleType
 ) {}

--- a/test/ModuleInterface/export-as-in-swiftinterfaces.swift
+++ b/test/ModuleInterface/export-as-in-swiftinterfaces.swift
@@ -69,8 +69,8 @@ struct exportedClangType {};
 @_exported import Exported
 
 public func foo(a: exportedClangType) {}
-// CHECK-USE-EXPORTED: Exported.exportedClangType
-// CHECK-USE-EXPORTER: Exporter.exportedClangType
+// CHECK-USE-EXPORTED: Exported::exportedClangType
+// CHECK-USE-EXPORTER: Exporter::exportedClangType
 
 //--- Exporter.swift
 @_exported import Exported

--- a/test/ModuleInterface/exported-module-name.swift
+++ b/test/ModuleInterface/exported-module-name.swift
@@ -8,12 +8,12 @@
 // CHECK: import CoreKit
 import CoreKit
 
-// CHECK-LABEL: public struct CKThingWrapper : Swift.RawRepresentable {
+// CHECK-LABEL: public struct CKThingWrapper : Swift::RawRepresentable {
 public struct CKThingWrapper: RawRepresentable {
   public var rawValue: CKThing
   public init(rawValue: CKThing) {
     self.rawValue = rawValue
   }
   // Note that this is CoreKit.CKThing, not ExportAsCoreKit.CKThing
-  // CHECK: public typealias RawValue = CoreKit.CKThing
+  // CHECK: public typealias RawValue = CoreKit::CKThing
 } // CHECK: {{^}$}}

--- a/test/ModuleInterface/feature-LexicalLifetimes.swift
+++ b/test/ModuleInterface/feature-LexicalLifetimes.swift
@@ -15,6 +15,6 @@ public struct Permanent {}
 @_eagerMove
 public class Transient {}
 
-// CHECK: @_lexicalLifetimes public func lexicalInAModuleWithoutLexicalLifetimes(_ t: FeatureTest.Transient)
+// CHECK: @_lexicalLifetimes public func lexicalInAModuleWithoutLexicalLifetimes(_ t: FeatureTest::Transient)
 @_lexicalLifetimes
 public func lexicalInAModuleWithoutLexicalLifetimes(_ t: Transient) {}

--- a/test/ModuleInterface/features.swift
+++ b/test/ModuleInterface/features.swift
@@ -24,14 +24,14 @@
 // verify that those guards no longer pollute the emitted interface.
 
 // CHECK:      public actor MyActor
-// CHECK:        @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor {
+// CHECK:        @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency::UnownedSerialExecutor {
 // CHECK-NEXT:     get
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 public actor MyActor {
 }
 
-// CHECK:     extension FeatureTest.MyActor
+// CHECK:     extension FeatureTest::MyActor
 public extension MyActor {
   // CHECK:     testFunc
   func testFunc() async { }
@@ -45,27 +45,27 @@ public func globalAsync() async { }
 // CHECK-NEXT: }
 @_marker public protocol MP { }
 
-// CHECK:      @_marker public protocol MP2 : FeatureTest.MP {
+// CHECK:      @_marker public protocol MP2 : FeatureTest::MP {
 // CHECK-NEXT: }
 @_marker public protocol MP2: MP { }
 
-// CHECK:      public protocol MP3 : AnyObject, FeatureTest.MP {
+// CHECK:      public protocol MP3 : AnyObject, FeatureTest::MP {
 // CHECK-NEXT: }
 public protocol MP3: AnyObject, MP { }
 
-// CHECK:      extension FeatureTest.MP2 {
+// CHECK:      extension FeatureTest::MP2 {
 // CHECK-NEXT: func inMP2
 extension MP2 {
   public func inMP2() { }
 }
 
-// CHECK: class OldSchool : FeatureTest.MP {
+// CHECK: class OldSchool : FeatureTest::MP {
 public class OldSchool: MP {
   // CHECK:     takeClass()
   public func takeClass() async { }
 }
 
-// CHECK: class OldSchool2 : FeatureTest.MP {
+// CHECK: class OldSchool2 : FeatureTest::MP {
 public class OldSchool2: MP {
   // CHECK:     takeClass()
   public func takeClass() async { }
@@ -78,7 +78,7 @@ public class OldSchool2: MP {
 
 // CHECK: public struct UsesRP {
 public struct UsesRP {
-  // CHECK:  public var value: (any FeatureTest.RP)? {
+  // CHECK:  public var value: (any FeatureTest::RP)? {
   // CHECK-NEXT:  get
   public var value: RP? {
     nil
@@ -100,11 +100,11 @@ public struct IsRP: RP {
 // CHECK: public func acceptsRP
 public func acceptsRP<T: RP>(_: T) { }
 
-// CHECK:     extension Swift.Array : FeatureTest.MP where Element : FeatureTest.MP {
+// CHECK:     extension Swift::Array : FeatureTest::MP where Element : FeatureTest::MP {
 extension Array: FeatureTest.MP where Element : FeatureTest.MP { }
 // CHECK: }
 
-// CHECK:     extension FeatureTest.OldSchool : Swift.UnsafeSendable {
+// CHECK:     extension FeatureTest::OldSchool : Swift::UnsafeSendable {
 extension OldSchool: UnsafeSendable { }
 // CHECK-NEXT: }
 
@@ -135,4 +135,4 @@ public func unavailableFromAsyncFunc() { }
 @available(*, noasync, message: "Test")
 public func noAsyncFunc() { }
 
-// CHECK-NOT: extension FeatureTest.MyActor : Swift.Sendable
+// CHECK-NOT: extension FeatureTest::MyActor : Swift::Sendable

--- a/test/ModuleInterface/fixed-layout-property-initializers.swift
+++ b/test/ModuleInterface/fixed-layout-property-initializers.swift
@@ -15,24 +15,24 @@
 // COMMON: @frozen public struct MyStruct {
 @frozen
 public struct MyStruct {
-  // COMMON: public var publicVar: Swift.Bool = false
+  // COMMON: public var publicVar: Swift::Bool = false
   public var publicVar: Bool = false
 
-  // COMMON: internal var internalVar: (Swift.Bool, Swift.Bool) = (false, true)
+  // COMMON: internal var internalVar: (Swift::Bool, Swift::Bool) = (false, true)
   internal var internalVar: (Bool, Bool) = (false, true)
 
-  // COMMON: private var privateVar: Swift.Bool = Bool(4 < 10)
+  // COMMON: private var privateVar: Swift::Bool = Bool(4 < 10)
   private var privateVar: Bool = Bool(4 < 10)
 
   // COMMON: @usableFromInline
-  // COMMON-NEXT: internal var ufiVar: Swift.Bool = true
+  // COMMON-NEXT: internal var ufiVar: Swift::Bool = true
   @usableFromInline internal var ufiVar: Bool = true
 
-  // COMMON: public var multiVar1: Swift.Bool = Bool(false), (multiVar2, multiVar3): (Swift.Bool, Swift.Bool) = (true, 3 == 0)
+  // COMMON: public var multiVar1: Swift::Bool = Bool(false), (multiVar2, multiVar3): (Swift::Bool, Swift::Bool) = (true, 3 == 0)
   public var multiVar1: Bool = Bool(false), (multiVar2, multiVar3): (Bool, Bool) = (true, 3 == 0)
 
-  // NONRESILIENT: @_hasInitialValue public static var staticVar: Swift.Bool
-  // RESILIENT: {{^}}  public static var staticVar: Swift.Bool
+  // NONRESILIENT: @_hasInitialValue public static var staticVar: Swift::Bool
+  // RESILIENT: {{^}}  public static var staticVar: Swift::Bool
   public static var staticVar: Bool = Bool(true && false)
 
   // FROMSOURCE: @inlinable internal init() {}
@@ -43,21 +43,21 @@ public struct MyStruct {
 // COMMON: @_fixed_layout public class MyClass {
 @_fixed_layout
 public class MyClass {
-  // COMMON: public var publicVar: Swift.Bool = false
+  // COMMON: public var publicVar: Swift::Bool = false
   public var publicVar: Bool = false
 
-  // COMMON: internal var internalVar: Swift.Bool = false
+  // COMMON: internal var internalVar: Swift::Bool = false
   internal var internalVar: Bool = false
 
-  // COMMON: private var privateVar: Swift.UInt8 = UInt8(2)
+  // COMMON: private var privateVar: Swift::UInt8 = UInt8(2)
   private var privateVar: UInt8 = UInt8(2)
 
   // COMMON: @usableFromInline
-  // COMMON-NEXT: internal var ufiVar: Swift.Bool = true
+  // COMMON-NEXT: internal var ufiVar: Swift::Bool = true
   @usableFromInline internal var ufiVar: Bool = true
 
-  // NONRESILIENT: @_hasInitialValue public static var staticVar: Swift.Bool
-  // RESILIENT: {{^}}  public static var staticVar: Swift.Bool
+  // NONRESILIENT: @_hasInitialValue public static var staticVar: Swift::Bool
+  // RESILIENT: {{^}}  public static var staticVar: Swift::Bool
   public static var staticVar: Bool = Bool(true && false)
 
   // FROMSOURCE: @inlinable internal init() {}
@@ -65,6 +65,6 @@ public class MyClass {
   @inlinable init() {}
 }
 
-// NONRESILIENT: @_hasInitialValue public var topLevelVar: Swift.Bool
-// RESILIENT: {{^}}public var topLevelVar: Swift.Bool
+// NONRESILIENT: @_hasInitialValue public var topLevelVar: Swift::Bool
+// RESILIENT: {{^}}public var topLevelVar: Swift::Bool
 public var topLevelVar: Bool = Bool(false && !true)

--- a/test/ModuleInterface/global-actor.swift
+++ b/test/ModuleInterface/global-actor.swift
@@ -15,42 +15,42 @@
   public static let shared = Actor()
 }
 
-// CHECK: @Test.GlobalActor public func funcBoundToGlobalActor()
+// CHECK: @Test::GlobalActor public func funcBoundToGlobalActor()
 @available(SwiftStdlib 5.1, *)
 @GlobalActor public func funcBoundToGlobalActor() { }
 
-// CHECK: public func funcWithParameterBoundToGlobalActor(_ x: Test.ClassBoundToGlobalActor)
+// CHECK: public func funcWithParameterBoundToGlobalActor(_ x: Test::ClassBoundToGlobalActor)
 @available(SwiftStdlib 5.1, *)
 public func funcWithParameterBoundToGlobalActor(_ x: ClassBoundToGlobalActor) { }
 
-// CHECK: @Test.GlobalActor public class ClassBoundToGlobalActor
+// CHECK: @Test::GlobalActor public class ClassBoundToGlobalActor
 @available(SwiftStdlib 5.1, *)
 @GlobalActor public class ClassBoundToGlobalActor { }
 
-// CHECK: extension Test.ClassBoundToGlobalActor
+// CHECK: extension Test::ClassBoundToGlobalActor
 @available(SwiftStdlib 5.1, *)
 extension ClassBoundToGlobalActor {
   public func someMethod() { }
 }
 
-// CHECK: @Test.GlobalActor public class DerivedFromClassBoundToGlobalActor : Test.ClassBoundToGlobalActor
+// CHECK: @Test::GlobalActor public class DerivedFromClassBoundToGlobalActor : Test::ClassBoundToGlobalActor
 @available(SwiftStdlib 5.1, *)
 public class DerivedFromClassBoundToGlobalActor: ClassBoundToGlobalActor {}
 
 // CHECK: public class NoActorClass
 @available(SwiftStdlib 5.1, *)
 public class NoActorClass {
-  // CHECK: @Test.GlobalActor public var varBoundToGlobalActor: Swift.Int
+  // CHECK: @Test::GlobalActor public var varBoundToGlobalActor: Swift::Int
   @GlobalActor public var varBoundToGlobalActor: Int
   
-  // CHECK: @Test.GlobalActor public init()
+  // CHECK: @Test::GlobalActor public init()
   @GlobalActor public init() {
     self.varBoundToGlobalActor = 0
   }
 
-  // CHECK: @Test.GlobalActor public func methodBoundToGlobalActor()
+  // CHECK: @Test::GlobalActor public func methodBoundToGlobalActor()
   @GlobalActor public func methodBoundToGlobalActor() { }
 }
 
-// CHECK: extension Test.GlobalActor : _Concurrency.GlobalActor {}
-// CHECK: extension Test.ClassBoundToGlobalActor : Swift.Sendable {}
+// CHECK: extension Test::GlobalActor : _Concurrency::GlobalActor {}
+// CHECK: extension Test::ClassBoundToGlobalActor : Swift::Sendable {}

--- a/test/ModuleInterface/iboutlet-private-set.swift
+++ b/test/ModuleInterface/iboutlet-private-set.swift
@@ -11,7 +11,7 @@
 @objc public class MyType {}
 
 open class Bar {
-	// CHECK: @objc @IBOutlet weak public var foo: Foo.MyType! {
+	// CHECK: @objc @IBOutlet weak public var foo: Foo::MyType! {
 	// CHECK-NEXT: get
 	// CHECK-NEXT: }
 	@IBOutlet public private(set) weak var foo: MyType!

--- a/test/ModuleInterface/if-configs.swift
+++ b/test/ModuleInterface/if-configs.swift
@@ -7,7 +7,7 @@
 // RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface)
 // RUN: %FileCheck %s < %t.swiftinterface
 
-// CHECK-LABEL: func hasClosureDefaultArgWithComplexNestedPoundIfs(_ x: () -> Swift.Void = {
+// CHECK-LABEL: func hasClosureDefaultArgWithComplexNestedPoundIfs(_ x: () -> Swift{{::|\.}}Void = {
 // CHECK-NOT: #if NOT_PROVIDED
 // CHECK-NOT: print("should not exist")
 // CHECK-NOT: #elseif !NOT_PROVIDED
@@ -35,7 +35,7 @@ public func hasClosureDefaultArgWithComplexNestedPoundIfs(_ x: () -> Void = {
 }) {
 }
 
-// CHECK-LABEL: func hasClosureDefaultArgWithComplexPoundIf(_ x: () -> Swift.Void = {
+// CHECK-LABEL: func hasClosureDefaultArgWithComplexPoundIf(_ x: () -> Swift{{::|\.}}Void = {
 // CHECK-NOT: #if NOT_PROVIDED
 // CHECK-NOT: print("should not exist")
 // CHECK-NOT: #else
@@ -64,7 +64,7 @@ public func hasClosureDefaultArgWithComplexPoundIf(_ x: () -> Void = {
 }) {
 }
 
-// CHECK-LABEL: func hasClosureDefaultArgWithMultilinePoundIfCondition(_ x: () -> Swift.Void = {
+// CHECK-LABEL: func hasClosureDefaultArgWithMultilinePoundIfCondition(_ x: () -> Swift{{::|\.}}Void = {
 // CHECK-NOT: #if (
 // CHECK-NOT:   !false && true
 // CHECK-NOT: )
@@ -95,7 +95,7 @@ public func hasClosureDefaultArgWithMultilinePoundIfCondition(_ x: () -> Void = 
 }) {
 }
 
-// CHECK-LABEL: func hasClosureDefaultArgWithSinglePoundIf(_ x: () -> Swift.Void = {
+// CHECK-LABEL: func hasClosureDefaultArgWithSinglePoundIf(_ x: () -> Swift{{::|\.}}Void = {
 // CHECK-NOT: #if true
 // CHECK: print("true")
 // CHECK-NOT: #else

--- a/test/ModuleInterface/inheritActorContext_attr.swift
+++ b/test/ModuleInterface/inheritActorContext_attr.swift
@@ -4,35 +4,35 @@
 // RUN: %FileCheck %s < %t/Library.swiftinterface
 
 // CHECK-NOT: #if compiler(>=5.3) && $AlwaysInheritActorContext
-// CHECK: public func globalTest(@_inheritActorContext _: @Sendable () async -> Swift.Void)
+// CHECK: public func globalTest(@_inheritActorContext _: @Sendable () async -> Swift::Void)
 // CHECK-NOT: #endif
 public func globalTest(@_inheritActorContext _: @Sendable () async -> Void) {}
 
 // CHECK: #if compiler(>=5.3) && $AlwaysInheritActorContext
-// CHECK-NEXT: public func globalTestAlways(@_inheritActorContext(always) _: @Sendable () async -> Swift.Void)
+// CHECK-NEXT: public func globalTestAlways(@_inheritActorContext(always) _: @Sendable () async -> Swift::Void)
 // CHECK-NEXT: #endif
 public func globalTestAlways(@_inheritActorContext(always) _: @Sendable () async -> Void) {}
 
 public struct Test {
   // CHECK-NOT: #if compiler(>=5.3) && $AlwaysInheritActorContext
-  // CHECK: public init(@_inheritActorContext x: @Sendable () async -> Swift.Int)
+  // CHECK: public init(@_inheritActorContext x: @Sendable () async -> Swift::Int)
   // CHECK-NOT: #endif
   public init(@_inheritActorContext x: @Sendable () async -> Int) {}
 
   // CHECK: #if compiler(>=5.3) && $AlwaysInheritActorContext
-  // CHECK-NEXT: public init(@_inheritActorContext(always) y: sending () async -> Swift.Void)
+  // CHECK-NEXT: public init(@_inheritActorContext(always) y: sending () async -> Swift::Void)
   // CHECK-NEXT: #endif
   public init(@_inheritActorContext(always) y: sending () async -> Void) {}
 
   // CHECK-NOT: #if compiler(>=5.3) && $AlwaysInheritActorContext
-  // CHECK: public subscript(@_inheritActorContext _: @Sendable () async -> Swift.Void) -> Swift.Bool {
+  // CHECK: public subscript(@_inheritActorContext _: @Sendable () async -> Swift::Void) -> Swift::Bool {
   // CHECK-NEXT:   get
   // CHECK-NEXT: }
   // CHECK-NOT: #endif
   public subscript(@_inheritActorContext _: @Sendable () async -> Void) -> Bool { false }
 
   // CHECK: #if compiler(>=5.3) && $AlwaysInheritActorContext
-  // CHECK-NEXT: public subscript(@_inheritActorContext(always) _: @Sendable (Swift.Int) async -> Swift.Void) -> Swift.Bool {
+  // CHECK-NEXT: public subscript(@_inheritActorContext(always) _: @Sendable (Swift::Int) async -> Swift::Void) -> Swift::Bool {
   // CHECK-NEXT:   get
   // CHECK-NEXT: }
   public subscript(@_inheritActorContext(always) _: @Sendable (Int) async -> Void) -> Bool { false }

--- a/test/ModuleInterface/inherited-defaults-execution.swift
+++ b/test/ModuleInterface/inherited-defaults-execution.swift
@@ -17,10 +17,10 @@
 // RUN: %FileCheck --check-prefix=INTERFACE %s < %t/Inherited.swiftinterface
 //
 // INTERFACE: public class Base {
-// INTERFACE:   public init(x: Swift.Int = 45, y: Swift.Int = 98)
+// INTERFACE:   public init(x: Swift::Int = 45, y: Swift::Int = 98)
 // INTERFACE: }
-// INTERFACE: public class Derived : Inherited.Base {
-// INTERFACE:   override public init(x: Swift.Int = super, y: Swift.Int = super)
+// INTERFACE: public class Derived : Inherited::Base {
+// INTERFACE:   override public init(x: Swift::Int = super, y: Swift::Int = super)
 // INTERFACE: }
 
 // 4) Generate a main.swift file that uses the 'Inherited' library and makes use

--- a/test/ModuleInterface/inherited-generic-parameters.swift
+++ b/test/ModuleInterface/inherited-generic-parameters.swift
@@ -21,16 +21,16 @@ public class Base<In, Out> {
 // CHECK-NEXT: public init<A>(_ a1: A, _ a2: A)
   public init<A>(_ a1: A, _ a2: A) {}
 
-// CHECK-NEXT: public init<C>(_: C) where C : main.Base<In, Out>
+// CHECK-NEXT: public init<C>(_: C) where C : main::Base<In, Out>
   public init<C>(_: C) where C : Base<In, Out> {}
 // CHECK: }
 }
 
-// CHECK: public class Derived<T> : {{(main.)?}}Base<T, T> {
+// CHECK: public class Derived<T> : {{(main::)?}}Base<T, T> {
 public class Derived<T> : Base<T, T> {
 // CHECK-NEXT: override public init(x: @escaping (T) -> T)
 // CHECK-NEXT: override public init<A>(_ a1: A, _ a2: A)
-// CHECK-NEXT: override public init<C>(_ __argument1: C) where C : main.Base<T, T>
+// CHECK-NEXT: override public init<C>(_ __argument1: C) where C : main::Base<T, T>
 // CHECK-NEXT: {{(@objc )?}}deinit
 // CHECK-NEXT: }
 }

--- a/test/ModuleInterface/inherited-objc-superclass-initializers.swift
+++ b/test/ModuleInterface/inherited-objc-superclass-initializers.swift
@@ -6,16 +6,16 @@
 
 import InheritedObjCInits
 
-// CHECK: @objc @_inheritsConvenienceInitializers public class Subclass2 : InheritedObjCInits.HasAvailableInit {
+// CHECK: @objc @_inheritsConvenienceInitializers public class Subclass2 : InheritedObjCInits::HasAvailableInit {
 public class Subclass2: HasAvailableInit {
-  // CHECK-NEXT: @objc override dynamic public init(unavailable: InheritedObjCInits.UnavailableInSwift)
+  // CHECK-NEXT: @objc override dynamic public init(unavailable: InheritedObjCInits::UnavailableInSwift)
   // CHECK-NEXT: @objc override dynamic public init()
   // CHECK-NEXT: @objc deinit
 } // CHECK-NEXT:{{^}$}}
 
-// CHECK: @objc @_inheritsConvenienceInitializers public class Subclass1 : InheritedObjCInits.HasUnavailableInit {
+// CHECK: @objc @_inheritsConvenienceInitializers public class Subclass1 : InheritedObjCInits::HasUnavailableInit {
 public class Subclass1: HasUnavailableInit {
-  // CHECK-NOT: InheritedObjCInits.UnavailableInSwift
+  // CHECK-NOT: InheritedObjCInits::UnavailableInSwift
   // CHECK-NEXT: @objc override dynamic public init()
   // CHECK-NEXT: @objc deinit
 } // CHECK-NEXT:{{^}$}}

--- a/test/ModuleInterface/inherits-superclass-initializers.swift
+++ b/test/ModuleInterface/inherits-superclass-initializers.swift
@@ -8,11 +8,11 @@
 
 // CHECK: @_hasMissingDesignatedInitializers open class Base {
 open class Base {
-  // CHECK-NEXT: public init(arg: Swift.Int)
+  // CHECK-NEXT: public init(arg: Swift::Int)
   public init(arg: Int) {
     print("public init from Base")
   }
-  // CHECK-NOT: init(secret: Swift.Int)
+  // CHECK-NOT: init(secret: Swift::Int)
   internal init(secret: Int) {
     print("secret init from Base")
   }
@@ -28,12 +28,12 @@ open class Base {
 // CHECK-NOT: @_hasMissingDesignatedInitializers
 // CHECK: open class InlineBase {
 open class InlineBase {
-  // CHECK-NEXT: public init(arg: Swift.Int)
+  // CHECK-NEXT: public init(arg: Swift::Int)
   public init(arg: Int) {
     print("public init from Inline Base")
   }
 
-  // CHECK-NOT: @usableFromInline init(secret: Swift.Int)
+  // CHECK-NOT: @usableFromInline init(secret: Swift::Int)
   @usableFromInline
   internal init(secret: Int) {
     print("secret init from Inline Base")
@@ -46,14 +46,14 @@ open class InlineBase {
   // CHECK: }
 }
 
-// CHECK: @_inheritsConvenienceInitializers @_hasMissingDesignatedInitializers public class Sub : Module.Base {
+// CHECK: @_inheritsConvenienceInitializers @_hasMissingDesignatedInitializers public class Sub : Module::Base {
 public class Sub : Base {
-  // CHECK: override public init(arg: Swift.Int)
+  // CHECK: override public init(arg: Swift::Int)
   public override init(arg: Int) {
     print("public init from Sub")
     super.init(arg: arg)
   }
-  // CHECK-NOT: init(secret: Swift.Int)
+  // CHECK-NOT: init(secret: Swift::Int)
   internal override init(secret: Int) {
     print("secret init from Sub")
     super.init(secret: secret)
@@ -61,9 +61,9 @@ public class Sub : Base {
 // CHECK: }
 }
 
-// CHECK: @_inheritsConvenienceInitializers @_hasMissingDesignatedInitializers public class SubSub : Module.Sub {
+// CHECK: @_inheritsConvenienceInitializers @_hasMissingDesignatedInitializers public class SubSub : Module::Sub {
 public class SubSub: Sub {
-  // CHECK: override public init(arg: Swift.Int)
+  // CHECK: override public init(arg: Swift::Int)
   public override init(arg: Int) {
     print("public init from SubSub")
     super.init(arg: arg)

--- a/test/ModuleInterface/init_accessors.swift
+++ b/test/ModuleInterface/init_accessors.swift
@@ -24,7 +24,7 @@
 public struct Inlinable {
   var _x: Int
 
-// CHECK:      public var x: Swift.Int {
+// CHECK:      public var x: Swift::Int {
 // CHECK-NEXT:    @usableFromInline
 // CHECK-NEXT:    @storageRestrictions(initializes: _x) init
 // CHECK-NEXT:    get
@@ -49,7 +49,7 @@ public struct Inlinable {
 }
 
 public struct Internal {
-// CHECK:      public var y: Swift.Int {
+// CHECK:      public var y: Swift::Int {
 // CHECK-NEXT:   get
 // CHECK-NEXT: }
 
@@ -70,7 +70,7 @@ public struct Transparent {
    @usableFromInline
    var _x: Int
 
-// CHECK:      public var x: Swift.Int {
+// CHECK:      public var x: Swift::Int {
 // CHECK-NEXT:   @_alwaysEmitIntoClient @storageRestrictions(initializes: _x) init {
 // CHECK-NEXT:     self._x = newValue
 // CHECK-NEXT:   }

--- a/test/ModuleInterface/inlinable-function.swift
+++ b/test/ModuleInterface/inlinable-function.swift
@@ -6,9 +6,9 @@
 // RUN: %target-swift-typecheck-module-from-interface(%t/TestFromModule.swiftinterface) -module-name Test
 // RUN: %FileCheck %s --check-prefix FROMMODULE --check-prefix CHECK < %t/TestFromModule.swiftinterface
 
-// CHECK-LABEL: public struct Foo : Swift.Hashable {
+// CHECK-LABEL: public struct Foo : Swift::Hashable {
 public struct Foo: Hashable {
-  // CHECK: public var inlinableGetPublicSet: Swift.Int {
+  // CHECK: public var inlinableGetPublicSet: Swift::Int {
   public var inlinableGetPublicSet: Int {
   // FROMSOURCE: @inlinable get {
   // FROMMODULE: @inlinable get{{$}}
@@ -25,10 +25,10 @@ public struct Foo: Hashable {
     // CHECK-NEXT: {{^}}  }
   }
 
-  // CHECK: public var noAccessors: Swift.Int{{$}}
+  // CHECK: public var noAccessors: Swift::Int{{$}}
   public var noAccessors: Int
 
-  // CHECK: public var hasDidSet: Swift.Int {
+  // CHECK: public var hasDidSet: Swift::Int {
   public var hasDidSet: Int {
     // CHECK-NEXT: get{{$}}
     // CHECK-NEXT: set{{(\(value\))?}}{{$}}
@@ -39,7 +39,7 @@ public struct Foo: Hashable {
     // CHECK-NEXT: {{^}}  }
   }
 
-  // CHECK: @_transparent public var transparent: Swift.Int {
+  // CHECK: @_transparent public var transparent: Swift::Int {
   // FROMMODULE-NEXT: get{{$}}
   // FROMSOURCE-NEXT: get {
   // FROMSOURCE-NEXT:   return 34
@@ -50,7 +50,7 @@ public struct Foo: Hashable {
     return 34
   }
 
-  // CHECK: public var transparentSet: Swift.Int {
+  // CHECK: public var transparentSet: Swift::Int {
   public var transparentSet: Int {
     // CHECK-NEXT: get{{$}}
     get {
@@ -82,7 +82,7 @@ public struct Foo: Hashable {
     }
   }
 
-  // CHECK: @inlinable public var inlinableProperty: Swift.Int {
+  // CHECK: @inlinable public var inlinableProperty: Swift::Int {
   @inlinable
   public var inlinableProperty: Int {
     // FROMMODULE:      get{{$}}
@@ -111,7 +111,7 @@ public struct Foo: Hashable {
     // CHECK-NEXT: }
   }
 
-  // CHECK: @inlinable public var inlinableReadAndModify: Swift.Int {
+  // CHECK: @inlinable public var inlinableReadAndModify: Swift::Int {
   @inlinable
   public var inlinableReadAndModify: Int {
     // FROMMODULE:      _read{{$}}
@@ -133,7 +133,7 @@ public struct Foo: Hashable {
     // CHECK-NEXT: }
   }
 
-  // CHECK: public var inlinableReadNormalModify: Swift.Int {
+  // CHECK: public var inlinableReadNormalModify: Swift::Int {
   public var inlinableReadNormalModify: Int {
     // FROMMODULE: @inlinable _read{{$}}
     // FROMSOURCE: @inlinable _read {
@@ -154,7 +154,7 @@ public struct Foo: Hashable {
     // CHECK-NEXT: }
   }
 
-  // CHECK: public var normalReadInlinableModify: Swift.Int {
+  // CHECK: public var normalReadInlinableModify: Swift::Int {
   public var normalReadInlinableModify: Int {
     // CHECK: _read{{$}}
     // CHECK-NOT: yield 0
@@ -175,7 +175,7 @@ public struct Foo: Hashable {
     // CHECK-NEXT: }
   }
 
-  // CHECK: public var normalReadAndModify: Swift.Int {
+  // CHECK: public var normalReadAndModify: Swift::Int {
   public var normalReadAndModify: Int {
     // CHECK-NEXT: _read{{$}}
     _read { yield 0 }
@@ -218,7 +218,7 @@ public struct Foo: Hashable {
     print("Not inlinable")
   }
 
-  // CHECK: public subscript(i: Swift.Int) -> Swift.Int {
+  // CHECK: public subscript(i: Swift::Int) -> Swift::Int {
   // CHECK-NEXT:   get{{$}}
   // FROMSOURCE-NEXT:   @inlinable set[[NEWVALUE]] { print("set") }
   // FROMMODULE-NEXT:   @inlinable set[[NEWVALUE]]{{$}}
@@ -228,7 +228,7 @@ public struct Foo: Hashable {
     @inlinable set { print("set") }
   }
 
-  // CHECK: public subscript(j: Swift.Int, k: Swift.Int) -> Swift.Int {
+  // CHECK: public subscript(j: Swift::Int, k: Swift::Int) -> Swift::Int {
   // FROMMODULE-NEXT:   @inlinable get{{$}}
   // FROMSOURCE-NEXT:   @inlinable get { return 0 }
   // CHECK-NEXT:   set[[NEWVALUE]]{{$}}
@@ -238,7 +238,7 @@ public struct Foo: Hashable {
     set { print("set") }
   }
 
-  // CHECK: @inlinable public subscript(l: Swift.Int, m: Swift.Int, n: Swift.Int) -> Swift.Int {
+  // CHECK: @inlinable public subscript(l: Swift::Int, m: Swift::Int, n: Swift::Int) -> Swift::Int {
   // FROMMODULE-NEXT:   get{{$}}
   // FROMSOURCE-NEXT:   get { return 0 }
   // FROMMODULE-NEXT:   set[[NEWVALUE]]{{$}}
@@ -250,8 +250,8 @@ public struct Foo: Hashable {
     set { print("set") }
   }
 
-  // FROMMODULE: @inlinable public init(value: Swift.Int){{$}}
-  // FROMSOURCE: @inlinable public init(value: Swift.Int) {
+  // FROMMODULE: @inlinable public init(value: Swift::Int){{$}}
+  // FROMSOURCE: @inlinable public init(value: Swift::Int) {
   // FROMSOURCE-NEXT: topLevelUsableFromInline()
   // FROMSOURCE-NEXT: noAccessors = value
   // FROMSOURCE-NEXT: hasDidSet = value

--- a/test/ModuleInterface/isolated-deinit.swift
+++ b/test/ModuleInterface/isolated-deinit.swift
@@ -29,7 +29,7 @@ public class SyncClassDefaultPublic {
 // CHECK-NOT: #
 // CHECK: open class SyncClassGlobalActorOpen {
 // CHECK-NOT: #
-// CHECK: {{(@objc )?}}@_Concurrency.MainActor deinit
+// CHECK: {{(@objc )?}}@_Concurrency::MainActor deinit
 // CHECK-NOT: #
 // CHECK: }
 open class SyncClassGlobalActorOpen {
@@ -40,14 +40,14 @@ open class SyncClassGlobalActorOpen {
 // CHECK: public class SyncClassGlobalActorPublic {
 // CHECK-NOT: #
 // CHECK-NOT: #
-// CHECK: {{(@objc )?}}@_Concurrency.MainActor deinit
+// CHECK: {{(@objc )?}}@_Concurrency::MainActor deinit
 // CHECK: }
 public class SyncClassGlobalActorPublic {
     @MainActor deinit {}
 }
 
 // CHECK-NOT: #
-// CHECK: @_Concurrency.MainActor open class SyncClassIsolatedOpen {
+// CHECK: @_Concurrency::MainActor open class SyncClassIsolatedOpen {
 // CHECK-NOT: #
 // CHECK: {{(@objc )?}}isolated deinit
 // CHECK-NOT: #
@@ -58,7 +58,7 @@ open class SyncClassIsolatedOpen {
 }
 
 // CHECK-NOT: #
-// CHECK: @_Concurrency.MainActor public class SyncClassIsolatedPublic {
+// CHECK: @_Concurrency::MainActor public class SyncClassIsolatedPublic {
 // CHECK-NOT: #
 // CHECK: {{(@objc )?}}isolated deinit
 // CHECK: }
@@ -68,7 +68,7 @@ public class SyncClassIsolatedPublic {
 }
 
 // CHECK-NOT: #
-// CHECK: @_Concurrency.MainActor open class SyncClassNonisolatedOpen {
+// CHECK: @_Concurrency::MainActor open class SyncClassNonisolatedOpen {
 // CHECK-NOT: #
 // CHECK: {{(@objc )?}}nonisolated deinit
 // CHECK-NOT: #
@@ -79,7 +79,7 @@ open class SyncClassNonisolatedOpen {
 }
 
 // CHECK-NOT: #
-// CHECK: @_Concurrency.MainActor public class SyncClassNonisolatedPublic {
+// CHECK: @_Concurrency::MainActor public class SyncClassNonisolatedPublic {
 // CHECK-NOT: #
 // CHECK: {{(@objc )?}}nonisolated deinit
 // CHECK: }
@@ -103,7 +103,7 @@ public actor SyncActorDefaultPublic {
 // CHECK-NOT: #
 // CHECK: public actor SyncActorGlobalActorPublic {
 // CHECK-NOT: #
-// CHECK: {{(@objc )?}}@_Concurrency.MainActor deinit
+// CHECK: {{(@objc )?}}@_Concurrency::MainActor deinit
 // CHECK: }
 public actor SyncActorGlobalActorPublic {
     @MainActor deinit {}

--- a/test/ModuleInterface/isolated_conformance.swift
+++ b/test/ModuleInterface/isolated_conformance.swift
@@ -9,7 +9,7 @@ public protocol MyProtocol {
 @MainActor
 public class MyClass { }
 
-// CHECK: extension isolated_conformance.MyClass : @{{.*}}MainActor isolated_conformance.MyProtocol {
+// CHECK: extension isolated_conformance::MyClass : @{{.*}}MainActor isolated_conformance::MyProtocol {
 extension MyClass: @MainActor MyProtocol {
   @MainActor public func f() { }
 }

--- a/test/ModuleInterface/isolated_deinit.swift
+++ b/test/ModuleInterface/isolated_deinit.swift
@@ -11,7 +11,7 @@
 
 // REQUIRES: concurrency
 
-// CHECK: @_Concurrency.MainActor @preconcurrency public class C1 {
+// CHECK: @_Concurrency::MainActor @preconcurrency public class C1 {
 // CHECK:   {{(@objc )?}} isolated deinit
 // CHECK: }
 
@@ -23,7 +23,7 @@ public class C1 {
 }
 
 // CHECK: @preconcurrency public class C2 {
-// CHECK:   {{(@objc )?}} @_Concurrency.MainActor deinit
+// CHECK:   {{(@objc )?}} @_Concurrency::MainActor deinit
 // CHECK: }
 
 @preconcurrency

--- a/test/ModuleInterface/lazy-vars.swift
+++ b/test/ModuleInterface/lazy-vars.swift
@@ -12,13 +12,13 @@
 // RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules -emit-module-interface-path - %t/TestResilient.swiftmodule -module-name TestResilient | %FileCheck %s
 
 // CHECK: @frozen public struct HasLazyVarsFixedLayout {
-// CHECK-NEXT: public var foo: Swift.Int {
+// CHECK-NEXT: public var foo: Swift::Int {
 // CHECK-NEXT:   mutating get
 // CHECK-NEXT:   set
 // CHECK-NEXT: }
-// CHECK: private var $__lazy_storage_$_foo: Swift.Int?
+// CHECK: private var $__lazy_storage_$_foo: Swift::Int?
 // CHECK-NOT: private var bar
-// CHECK: private var $__lazy_storage_$_bar: Swift.Int?
+// CHECK: private var $__lazy_storage_$_bar: Swift::Int?
 // CHECK-NEXT: }
 @frozen
 public struct HasLazyVarsFixedLayout {
@@ -27,13 +27,13 @@ public struct HasLazyVarsFixedLayout {
 }
 
 // CHECK: public struct HasLazyVars {
-// CHECK-NEXT: public var foo: Swift.Int {
+// CHECK-NEXT: public var foo: Swift::Int {
 // CHECK-NEXT:   mutating get
 // CHECK-NEXT:   set
 // CHECK-NEXT: }
-// NONRESILIENT: private var $__lazy_storage_$_foo: Swift.Int?
+// NONRESILIENT: private var $__lazy_storage_$_foo: Swift::Int?
 // CHECK-NOT: private var bar
-// NONRESILIENT: private var $__lazy_storage_$_bar: Swift.Int?
+// NONRESILIENT: private var $__lazy_storage_$_bar: Swift::Int?
 // CHECK-NEXT: }
 public struct HasLazyVars {
   public lazy var foo: Int = 0

--- a/test/ModuleInterface/lifetime_dependence_test.swift
+++ b/test/ModuleInterface/lifetime_dependence_test.swift
@@ -24,31 +24,31 @@
 
 import lifetime_dependence
 // CHECK: @lifetime(borrow a)
-// CHECK-NEXT: @inlinable internal init(_ ptr: Swift.UnsafeRawBufferPointer, _ a: borrowing Swift.Array<Swift.Int>) {
+// CHECK-NEXT: @inlinable internal init(_ ptr: Swift::UnsafeRawBufferPointer, _ a: borrowing Swift::Array<Swift::Int>) {
 // CHECK: @lifetime(copy a)
-// CHECK-NEXT: @inlinable internal init(_ ptr: Swift.UnsafeRawBufferPointer, _ a: consuming lifetime_dependence.AnotherView) {
+// CHECK-NEXT: @inlinable internal init(_ ptr: Swift::UnsafeRawBufferPointer, _ a: consuming lifetime_dependence::AnotherView) {
 
 // CHECK: @lifetime(copy x)
-// CHECK-NEXT: @inlinable public func derive(_ x: consuming lifetime_dependence.BufferView) -> lifetime_dependence.BufferView {
+// CHECK-NEXT: @inlinable public func derive(_ x: consuming lifetime_dependence::BufferView) -> lifetime_dependence::BufferView {
 
 // CHECK: @lifetime(copy view)
-// CHECK-NEXT: @inlinable public func consumeAndCreate(_ view: consuming lifetime_dependence.BufferView) -> lifetime_dependence.BufferView {
+// CHECK-NEXT: @inlinable public func consumeAndCreate(_ view: consuming lifetime_dependence::BufferView) -> lifetime_dependence::BufferView {
 
 // CHECK: @lifetime(copy this, copy that)
-// CHECK-NEXT: @inlinable public func deriveThisOrThat(_ this: consuming lifetime_dependence.BufferView, _ that: consuming lifetime_dependence.BufferView) -> lifetime_dependence.BufferView {
+// CHECK-NEXT: @inlinable public func deriveThisOrThat(_ this: consuming lifetime_dependence::BufferView, _ that: consuming lifetime_dependence::BufferView) -> lifetime_dependence::BufferView {
 
 // Check that an implicitly dependent variable accessor is guarded by LifetimeDependence.
 //
-// CHECK: extension lifetime_dependence.Container {
+// CHECK: extension lifetime_dependence::Container {
 // CHECK-NEXT: #if compiler(>=5.3) && $LifetimeDependence
-// CHECK-NEXT:   public var storage: lifetime_dependence.BufferView {
+// CHECK-NEXT:   public var storage: lifetime_dependence::BufferView {
 
-// CHECK-LABEL: extension Swift.UnsafeMutableBufferPointer where Element : ~Copyable {
+// CHECK-LABEL: extension Swift::UnsafeMutableBufferPointer where Element : ~Copyable {
 // CHECK:   #if compiler(>=5.3) && $LifetimeDependence
-// CHECK:   public var span: Swift.Span<Element> {
+// CHECK:   public var span: Swift::Span<Element> {
 // CHECK:     @lifetime(borrow self)
 // CHECK:     @_alwaysEmitIntoClient get {
 // CHECK:   #if compiler(>=5.3) && $NonescapableAccessorOnTrivial && $LifetimeDependence
-// CHECK:   public var mutableSpan: Swift.MutableSpan<Element> {
+// CHECK:   public var mutableSpan: Swift::MutableSpan<Element> {
 // CHECK:     @lifetime(borrow self)
 // CHECK:     @_alwaysEmitIntoClient get {

--- a/test/ModuleInterface/lifetime_underscored_dependence_test.swift
+++ b/test/ModuleInterface/lifetime_underscored_dependence_test.swift
@@ -8,7 +8,7 @@
 
 // Check the interfaces
 
-// RUN: %FileCheck %s < %t/lifetime_underscored_dependence.swiftinterface
+// RUN: %FileCheck %s --input-file %t/lifetime_underscored_dependence.swiftinterface
 
 // See if we can compile a module through just the interface and typecheck using it.
 
@@ -24,13 +24,13 @@
 import lifetime_underscored_dependence
 // CHECK:  #if compiler(>=5.3) && $Lifetimes
 // CHECK:  @_lifetime(borrow a)
-// CHECK:  @inlinable internal init(_ ptr: Swift.UnsafeRawBufferPointer, _ a: borrowing Swift.Array<Swift.Int>) {
+// CHECK:  @inlinable internal init(_ ptr: Swift::UnsafeRawBufferPointer, _ a: borrowing Swift::Array<Swift::Int>) {
 // CHECK:    let bv = BufferView(ptr, a.count)
 // CHECK:    self = _overrideLifetime(bv, borrowing: a)
 // CHECK:  }
 // CHECK:  #else
 // CHECK:  @lifetime(borrow a)
-// CHECK:  @inlinable internal init(_ ptr: Swift.UnsafeRawBufferPointer, _ a: borrowing Swift.Array<Swift.Int>) {
+// CHECK:  @inlinable internal init(_ ptr: Swift::UnsafeRawBufferPointer, _ a: borrowing Swift::Array<Swift::Int>) {
 // CHECK:    let bv = BufferView(ptr, a.count)
 // CHECK:    self = _overrideLifetime(bv, borrowing: a)
 // CHECK:  }
@@ -38,13 +38,13 @@ import lifetime_underscored_dependence
 
 // CHECK:  #if compiler(>=5.3) && $Lifetimes
 // CHECK:  @_lifetime(copy a)
-// CHECK:  @inlinable internal init(_ ptr: Swift.UnsafeRawBufferPointer, _ a: consuming lifetime_underscored_dependence.AnotherView) {
+// CHECK:  @inlinable internal init(_ ptr: Swift::UnsafeRawBufferPointer, _ a: consuming lifetime_underscored_dependence::AnotherView) {
 // CHECK:    let bv = BufferView(ptr, a._count)
 // CHECK:    self = _overrideLifetime(bv, copying: a)
 // CHECK:  }
 // CHECK:  #else
 // CHECK:  @lifetime(copy a)
-// CHECK:  @inlinable internal init(_ ptr: Swift.UnsafeRawBufferPointer, _ a: consuming lifetime_underscored_dependence.AnotherView) {
+// CHECK:  @inlinable internal init(_ ptr: Swift::UnsafeRawBufferPointer, _ a: consuming lifetime_underscored_dependence::AnotherView) {
 // CHECK:    let bv = BufferView(ptr, a._count)
 // CHECK:    self = _overrideLifetime(bv, copying: a)
 // CHECK:  }
@@ -52,14 +52,14 @@ import lifetime_underscored_dependence
 
 // CHECK:#if compiler(>=5.3) && $Lifetimes
 // CHECK:@_lifetime(copy x)
-// CHECK:@inlinable public func derive(_ x: consuming lifetime_underscored_dependence.BufferView) -> lifetime_underscored_dependence.BufferView {
+// CHECK:@inlinable public func derive(_ x: consuming lifetime_underscored_dependence::BufferView) -> lifetime_underscored_dependence::BufferView {
 // CHECK:  let pointer = x._ptr
 // CHECK:  let bv = BufferView(pointer, x._count)
 // CHECK:  return _overrideLifetime(bv, copying: x)
 // CHECK:}
 // CHECK:#else
 // CHECK:@lifetime(copy x)
-// CHECK:@inlinable public func derive(_ x: consuming lifetime_underscored_dependence.BufferView) -> lifetime_underscored_dependence.BufferView {
+// CHECK:@inlinable public func derive(_ x: consuming lifetime_underscored_dependence::BufferView) -> lifetime_underscored_dependence::BufferView {
 // CHECK:  let pointer = x._ptr
 // CHECK:  let bv = BufferView(pointer, x._count)
 // CHECK:  return _overrideLifetime(bv, copying: x)
@@ -68,14 +68,14 @@ import lifetime_underscored_dependence
 
 // CHECK:#if compiler(>=5.3) && $Lifetimes
 // CHECK:@_lifetime(copy view)
-// CHECK:@inlinable public func consumeAndCreate(_ view: consuming lifetime_underscored_dependence.BufferView) -> lifetime_underscored_dependence.BufferView {
+// CHECK:@inlinable public func consumeAndCreate(_ view: consuming lifetime_underscored_dependence::BufferView) -> lifetime_underscored_dependence::BufferView {
 // CHECK:  let pointer = view._ptr
 // CHECK:  let bv = BufferView(pointer, view._count)
 // CHECK:  return _overrideLifetime(bv, copying: view)
 // CHECK:}
 // CHECK:#else
 // CHECK:@lifetime(copy view)
-// CHECK:@inlinable public func consumeAndCreate(_ view: consuming lifetime_underscored_dependence.BufferView) -> lifetime_underscored_dependence.BufferView {
+// CHECK:@inlinable public func consumeAndCreate(_ view: consuming lifetime_underscored_dependence::BufferView) -> lifetime_underscored_dependence::BufferView {
 // CHECK:  let pointer = view._ptr
 // CHECK:  let bv = BufferView(pointer, view._count)
 // CHECK:  return _overrideLifetime(bv, copying: view)
@@ -84,7 +84,7 @@ import lifetime_underscored_dependence
 
 // CHECK:#if compiler(>=5.3) && $Lifetimes
 // CHECK:@_lifetime(copy this, copy that)
-// CHECK:@inlinable public func deriveThisOrThat(_ this: consuming lifetime_underscored_dependence.BufferView, _ that: consuming lifetime_underscored_dependence.BufferView) -> lifetime_underscored_dependence.BufferView {
+// CHECK:@inlinable public func deriveThisOrThat(_ this: consuming lifetime_underscored_dependence::BufferView, _ that: consuming lifetime_underscored_dependence::BufferView) -> lifetime_underscored_dependence::BufferView {
 // CHECK:  if (Int.random(in: 1..<100) == 0) {
 // CHECK:    let thisView = BufferView(this._ptr, this._count)
 // CHECK:    return _overrideLifetime(thisView, copying: this)
@@ -94,7 +94,7 @@ import lifetime_underscored_dependence
 // CHECK:}
 // CHECK:#else
 // CHECK:@lifetime(copy this, copy that)
-// CHECK:@inlinable public func deriveThisOrThat(_ this: consuming lifetime_underscored_dependence.BufferView, _ that: consuming lifetime_underscored_dependence.BufferView) -> lifetime_underscored_dependence.BufferView {
+// CHECK:@inlinable public func deriveThisOrThat(_ this: consuming lifetime_underscored_dependence::BufferView, _ that: consuming lifetime_underscored_dependence::BufferView) -> lifetime_underscored_dependence::BufferView {
 // CHECK:  if (Int.random(in: 1..<100) == 0) {
 // CHECK:    let thisView = BufferView(this._ptr, this._count)
 // CHECK:    return _overrideLifetime(thisView, copying: this)
@@ -104,20 +104,20 @@ import lifetime_underscored_dependence
 // CHECK:}
 // CHECK:#endif
 
-// CHECK: extension lifetime_underscored_dependence.Container {
+// CHECK: extension lifetime_underscored_dependence::Container {
 // CHECK-NEXT: #if compiler(>=5.3) && $Lifetimes
-// CHECK-NEXT:   public var storage: lifetime_underscored_dependence.BufferView {
+// CHECK-NEXT:   public var storage: lifetime_underscored_dependence::BufferView {
 
-// CHECK: public struct RigidArray : ~Swift.Copyable {
+// CHECK: public struct RigidArray : ~Swift::Copyable {
 // CHECK:   @usableFromInline
-// CHECK:   internal let _ptr: Swift.UnsafeRawBufferPointer
+// CHECK:   internal let _ptr: Swift::UnsafeRawBufferPointer
 // CHECK:   #if compiler(>=5.3) && $Lifetimes
-// CHECK:   public var span: Swift.RawSpan {
+// CHECK:   public var span: Swift::RawSpan {
 // CHECK:     @_lifetime(borrow self)
 // CHECK:     get
 // CHECK:   }
 // CHECK:   #else
-// CHECK:   public var span: Swift.RawSpan {
+// CHECK:   public var span: Swift::RawSpan {
 // CHECK:     @lifetime(borrow self)
 // CHECK:     get
 // CHECK:   }
@@ -127,81 +127,81 @@ import lifetime_underscored_dependence
 // CHECK: #if compiler(>=5.3) && $ClosureLifetimes
 // CHECK-NEXT: #if compiler(>=5.3) && $Lifetimes
 // CHECK-NEXT: @_lifetime(copy ne0)
-// CHECK-NEXT: @inlinable public func takeCopier(f: @_lifetime(io: copy io) @_lifetime(copy inview) (_ inview: consuming lifetime_underscored_dependence.AnotherView, _ io: inout lifetime_underscored_dependence.AnotherView) -> lifetime_underscored_dependence.AnotherView, ne0: consuming lifetime_underscored_dependence.AnotherView, ne1: inout lifetime_underscored_dependence.AnotherView) -> lifetime_underscored_dependence.AnotherView {
+// CHECK-NEXT: @inlinable public func takeCopier(f: @_lifetime(io: copy io) @_lifetime(copy inview) (_ inview: consuming lifetime_underscored_dependence::AnotherView, _ io: inout lifetime_underscored_dependence::AnotherView) -> lifetime_underscored_dependence::AnotherView, ne0: consuming lifetime_underscored_dependence::AnotherView, ne1: inout lifetime_underscored_dependence::AnotherView) -> lifetime_underscored_dependence::AnotherView {
 // CHECK-NEXT:   let ne2 = f(ne0, &ne1)
 // CHECK-NEXT:   return ne2
 // CHECK-NEXT: }
 // CHECK-NEXT: #else
 // CHECK-NEXT: @lifetime(copy ne0)
-// CHECK-NEXT: @inlinable public func takeCopier(f: @_lifetime(io: copy io) @_lifetime(copy inview) (_ inview: consuming lifetime_underscored_dependence.AnotherView, _ io: inout lifetime_underscored_dependence.AnotherView) -> lifetime_underscored_dependence.AnotherView, ne0: consuming lifetime_underscored_dependence.AnotherView, ne1: inout lifetime_underscored_dependence.AnotherView) -> lifetime_underscored_dependence.AnotherView {
+// CHECK-NEXT: @inlinable public func takeCopier(f: @_lifetime(io: copy io) @_lifetime(copy inview) (_ inview: consuming lifetime_underscored_dependence::AnotherView, _ io: inout lifetime_underscored_dependence::AnotherView) -> lifetime_underscored_dependence::AnotherView, ne0: consuming lifetime_underscored_dependence::AnotherView, ne1: inout lifetime_underscored_dependence::AnotherView) -> lifetime_underscored_dependence::AnotherView {
 // CHECK-NEXT:   let ne2 = f(ne0, &ne1)
 // CHECK-NEXT:   return ne2
 // CHECK-NEXT: }
 // CHECK-NEXT: #endif
 // CHECK-NEXT: #endif
 
-// CHECK: @inlinable public func takeCopierUnannotated(f: (consuming lifetime_underscored_dependence.AnotherView) -> lifetime_underscored_dependence.AnotherView) {}
+// CHECK: @inlinable public func takeCopierUnannotated(f: (consuming lifetime_underscored_dependence::AnotherView) -> lifetime_underscored_dependence::AnotherView) {}
 
 // CHECK: #if compiler(>=5.3) && $ClosureLifetimes
-// CHECK-NEXT: public typealias ExplicitNestedType = @_lifetime(copy ne0) @_lifetime(ne1: copy ne0, copy ne1) ((lifetime_underscored_dependence.AnotherView) -> lifetime_underscored_dependence.AnotherView, _ ne0: consuming lifetime_underscored_dependence.AnotherView, _ ne1: inout lifetime_underscored_dependence.AnotherView) -> lifetime_underscored_dependence.AnotherView
+// CHECK-NEXT: public typealias ExplicitNestedType = @_lifetime(copy ne0) @_lifetime(ne1: copy ne0, copy ne1) ((lifetime_underscored_dependence::AnotherView) -> lifetime_underscored_dependence::AnotherView, _ ne0: consuming lifetime_underscored_dependence::AnotherView, _ ne1: inout lifetime_underscored_dependence::AnotherView) -> lifetime_underscored_dependence::AnotherView
 // CHECK-NEXT: #endif
 
 // CHECK: #if compiler(>=5.3) && $ClosureLifetimes
-// CHECK-NEXT: @inlinable public func takeExplicitNestedType(f: @_lifetime(copy ne0) @_lifetime(ne1: copy ne0, copy ne1) ((lifetime_underscored_dependence.AnotherView) -> lifetime_underscored_dependence.AnotherView, _ ne0: consuming lifetime_underscored_dependence.AnotherView, _ ne1: inout lifetime_underscored_dependence.AnotherView) -> lifetime_underscored_dependence.AnotherView) {} 
+// CHECK-NEXT: @inlinable public func takeExplicitNestedType(f: @_lifetime(copy ne0) @_lifetime(ne1: copy ne0, copy ne1) ((lifetime_underscored_dependence::AnotherView) -> lifetime_underscored_dependence::AnotherView, _ ne0: consuming lifetime_underscored_dependence::AnotherView, _ ne1: inout lifetime_underscored_dependence::AnotherView) -> lifetime_underscored_dependence::AnotherView) {} 
 // CHECK-NEXT: #endif
 
 // CHECK: #if compiler(>=5.3) && $Lifetimes
-// CHECK-NEXT: @inlinable public func returnableCopier(_ aView: lifetime_underscored_dependence.AnotherView) -> lifetime_underscored_dependence.AnotherView {
+// CHECK-NEXT: @inlinable public func returnableCopier(_ aView: lifetime_underscored_dependence::AnotherView) -> lifetime_underscored_dependence::AnotherView {
 // CHECK-NEXT:   return aView
 // CHECK-NEXT: }
 // CHECK-NEXT: #else
-// CHECK-NEXT: @inlinable public func returnableCopier(_ aView: lifetime_underscored_dependence.AnotherView) -> lifetime_underscored_dependence.AnotherView {
+// CHECK-NEXT: @inlinable public func returnableCopier(_ aView: lifetime_underscored_dependence::AnotherView) -> lifetime_underscored_dependence::AnotherView {
 // CHECK-NEXT:   return aView
 // CHECK-NEXT: }
 // CHECK-NEXT: #endif
 
 // CHECK: #if compiler(>=5.3) && $ClosureLifetimes
-// CHECK-NEXT: @inlinable public func returnCopier() -> @_lifetime(copy a) (_ a: lifetime_underscored_dependence.AnotherView) -> lifetime_underscored_dependence.AnotherView {
+// CHECK-NEXT: @inlinable public func returnCopier() -> @_lifetime(copy a) (_ a: lifetime_underscored_dependence::AnotherView) -> lifetime_underscored_dependence::AnotherView {
 // CHECK-NEXT:  return returnableCopier
 // CHECK-NEXT: }
 // CHECK-NEXT: #endif
 
 // CHECK: #if compiler(>=5.3) && $Lifetimes
 // CHECK-NEXT: @_lifetime(dest: immortal)
-// CHECK-NEXT: @inlinable public func immortalInout(dest: inout lifetime_underscored_dependence.AnotherView) {
+// CHECK-NEXT: @inlinable public func immortalInout(dest: inout lifetime_underscored_dependence::AnotherView) {
 // CHECK-NEXT:   dest = _overrideLifetime(dest, copying: ())
 // CHECK-NEXT: }
 // CHECK-NEXT: #else
 // CHECK-NEXT: @lifetime(dest: immortal)
-// CHECK-NEXT: @inlinable public func immortalInout(dest: inout lifetime_underscored_dependence.AnotherView) {
+// CHECK-NEXT: @inlinable public func immortalInout(dest: inout lifetime_underscored_dependence::AnotherView) {
 // CHECK-NEXT:   dest = _overrideLifetime(dest, copying: ())
 // CHECK-NEXT: }
 // CHECK-NEXT: #endif
 
 // CHECK: #if compiler(>=5.3) && $ClosureLifetimes
-// CHECK-NEXT: @inlinable public func takeImmortalInout(closure: @_lifetime(dest: immortal) (_ dest: inout lifetime_underscored_dependence.AnotherView) -> ()) {}
+// CHECK-NEXT: @inlinable public func takeImmortalInout(closure: @_lifetime(dest: immortal) (_ dest: inout lifetime_underscored_dependence::AnotherView) -> ()) {}
 // CHECK-NEXT: #endif
 
 // CHECK: #if compiler(>=5.3) && $Lifetimes
 // CHECK-NEXT: @_lifetime(dest: immortal, copy source)
-// CHECK-NEXT: @inlinable public func fullReassign(dest: inout lifetime_underscored_dependence.AnotherView, source: lifetime_underscored_dependence.AnotherView) {
+// CHECK-NEXT: @inlinable public func fullReassign(dest: inout lifetime_underscored_dependence::AnotherView, source: lifetime_underscored_dependence::AnotherView) {
 // CHECK-NEXT:   dest = source
 // CHECK-NEXT: }
 // CHECK-NEXT: #else
 // CHECK-NEXT: @lifetime(dest: immortal, copy source)
-// CHECK-NEXT: @inlinable public func fullReassign(dest: inout lifetime_underscored_dependence.AnotherView, source: lifetime_underscored_dependence.AnotherView) {
+// CHECK-NEXT: @inlinable public func fullReassign(dest: inout lifetime_underscored_dependence::AnotherView, source: lifetime_underscored_dependence::AnotherView) {
 // CHECK-NEXT:   dest = source
 // CHECK-NEXT: }
 // CHECK-NEXT: #endif
 
 // CHECK: #if compiler(>=5.3) && $ClosureLifetimes
-// CHECK-NEXT: @inlinable public func takeFullReassign(closure: @_lifetime(dest: immortal, copy source) (_ dest: inout lifetime_underscored_dependence.AnotherView, _ source: lifetime_underscored_dependence.AnotherView) -> ()) {}
+// CHECK-NEXT: @inlinable public func takeFullReassign(closure: @_lifetime(dest: immortal, copy source) (_ dest: inout lifetime_underscored_dependence::AnotherView, _ source: lifetime_underscored_dependence::AnotherView) -> ()) {}
 // CHECK-NEXT: #endif
 
 // CHECK: #if compiler(>=5.3) && $ClosureLifetimes
-// CHECK-NEXT: @inlinable public func takeReadBorrower(f: @_lifetime(borrow a) (_ a: lifetime_underscored_dependence.AnotherView) -> lifetime_underscored_dependence.AnotherView) {}
+// CHECK-NEXT: @inlinable public func takeReadBorrower(f: @_lifetime(borrow a) (_ a: lifetime_underscored_dependence::AnotherView) -> lifetime_underscored_dependence::AnotherView) {}
 // CHECK-NEXT: #endif
 
 // CHECK-NEXT: #if compiler(>=5.3) && $ClosureLifetimes
-// CHECK-NEXT: @inlinable public func takeWriteBorrower(f: @_lifetime(&a) (_ a: inout lifetime_underscored_dependence.AnotherView) -> lifetime_underscored_dependence.AnotherView) {}
+// CHECK-NEXT: @inlinable public func takeWriteBorrower(f: @_lifetime(&a) (_ a: inout lifetime_underscored_dependence::AnotherView) -> lifetime_underscored_dependence::AnotherView) {}
 // CHECK-NEXT: #endif

--- a/test/ModuleInterface/macros.swift
+++ b/test/ModuleInterface/macros.swift
@@ -9,16 +9,16 @@
 // RUN: %FileCheck %s < %t/Macros.swiftinterface --check-prefix CHECK
 // RUN: %target-swift-frontend -compile-module-from-interface %t/Macros.swiftinterface -o %t/Macros.swiftmodule
 
-// CHECK: @freestanding(expression) public macro publicStringify<T>(_ value: T) -> (T, Swift.String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
+// CHECK: @freestanding(expression) public macro publicStringify<T>(_ value: T) -> (T, Swift::String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
 @freestanding(expression) public macro publicStringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
 
-// CHECK: @freestanding(expression) public macro labeledStringify<T>(_ value: T, label: Swift.String) -> (T, Swift.String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
+// CHECK: @freestanding(expression) public macro labeledStringify<T>(_ value: T, label: Swift::String) -> (T, Swift::String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
 @freestanding(expression) public macro labeledStringify<T>(_ value: T, label: String) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
 
-// CHECK: @freestanding(expression) public macro unlabeledStringify<T>(_ value: T, label: Swift.String) -> (T, Swift.String) = #labeledStringify(value, label: "default label")
+// CHECK: @freestanding(expression) public macro unlabeledStringify<T>(_ value: T, label: Swift::String) -> (T, Swift::String) = #labeledStringify(value, label: "default label")
 @freestanding(expression) public macro unlabeledStringify<T>(_ value: T, label: String) -> (T, String) = #labeledStringify(value, label: "default label")
 
-// CHECK: @freestanding(expression) public macro publicLine<T>() -> T = #externalMacro(module: "MacroDefinition", type: "Line") where T : Swift.ExpressibleByIntegerLiteral
+// CHECK: @freestanding(expression) public macro publicLine<T>() -> T = #externalMacro(module: "MacroDefinition", type: "Line") where T : Swift::ExpressibleByIntegerLiteral
 @freestanding(expression) public macro publicLine<T: ExpressibleByIntegerLiteral>() -> T = #externalMacro(module: "MacroDefinition", type: "Line")
 
 // CHECK: @attached(accessor) public macro myWrapper() = #externalMacro(module: "MacroDefinition", type: "Wrapper")
@@ -33,7 +33,7 @@
 // CHECK: @attached(accessor, names: named(init)) public macro AccessorInitFunc() = #externalMacro(module: "MacroDefinition", type: "AccessorInitFuncMacro")
 @attached(accessor, names: named(init)) public macro AccessorInitFunc() = #externalMacro(module: "MacroDefinition", type: "AccessorInitFuncMacro")
 
-// CHECK: @attached(extension, conformances: Swift.Sendable) @attached(member) public macro AddSendable() = #externalMacro(module: "MacroDefinition", type: "SendableExtensionMacro")
+// CHECK: @attached(extension, conformances: Swift::Sendable) @attached(member) public macro AddSendable() = #externalMacro(module: "MacroDefinition", type: "SendableExtensionMacro")
 @attached(extension, conformances: Sendable) @attached(member) public macro AddSendable() = #externalMacro(module: "MacroDefinition", type: "SendableExtensionMacro")
 
 // CHECK-NOT: internalStringify

--- a/test/ModuleInterface/member-typealias.swift
+++ b/test/ModuleInterface/member-typealias.swift
@@ -8,7 +8,7 @@ public struct MyStruct<T> {
   public typealias AliasInt = Int
 
   public func foo(x: AliasInt) -> AliasT { fatalError() }
-// CHECK:  public func foo(x: MyModule.MyStruct<T>.AliasInt) -> MyModule.MyStruct<T>.AliasT
+// CHECK:  public func foo(x: MyModule::MyStruct<T>.MyModule::AliasInt) -> MyModule::MyStruct<T>.MyModule::AliasT
 }
 
 public class MyBase<U> {
@@ -17,7 +17,7 @@ public class MyBase<U> {
 }
 
 public class MyDerived<X>: MyBase<X> {
-// CHECK-LABEL: public class MyDerived<X> : MyModule.MyBase<X> {
+// CHECK-LABEL: public class MyDerived<X> : MyModule::MyBase<X> {
   public func bar(x: AliasU) -> AliasInt { fatalError() }
-// CHECK:  public func bar(x: MyModule.MyDerived<X>.AliasU) -> MyModule.MyDerived<X>.AliasInt
+// CHECK:  public func bar(x: MyModule::MyDerived<X>.MyModule::AliasU) -> MyModule::MyDerived<X>.MyModule::AliasInt
 }

--- a/test/ModuleInterface/modifiers.swift
+++ b/test/ModuleInterface/modifiers.swift
@@ -6,7 +6,7 @@
 
 // CHECK-LABEL: final public class FinalClass {
 public final class FinalClass {
-  // CHECK: @inlinable final public class var a: Swift.Int {
+  // CHECK: @inlinable final public class var a: Swift::Int {
   // FROMSOURCE-NEXT: {{^}} get {
   // FROMSOURCE-NEXT: return 3
   // FROMSOURCE-NEXT: }
@@ -17,7 +17,7 @@ public final class FinalClass {
     return 3
   }
 
-  // CHECK: final public class var b: Swift.Int {
+  // CHECK: final public class var b: Swift::Int {
   // FROMSOURCE-NEXT: {{^}} @inlinable get {
   // FROMSOURCE-NEXT:   return 3
   // FROMSOURCE-NEXT: }
@@ -33,7 +33,7 @@ public final class FinalClass {
     }
   }
 
-  // CHECK: public static var c: Swift.Int {
+  // CHECK: public static var c: Swift::Int {
   // CHECK-NEXT: {{^}} get
   // FROMSOURCE-NEXT:   @inlinable set[[NEWVALUE]] {}
   // FROMMODULE-NEXT:   @inlinable set[[NEWVALUE]]{{$}}
@@ -45,7 +45,7 @@ public final class FinalClass {
     @inlinable set {}
   }
 
-  // CHECK: @objc dynamic final public var d: Swift.Int {
+  // CHECK: @objc dynamic final public var d: Swift::Int {
   // CHECK-NEXT: {{^}} @objc get{{$}}
   // CHECK-NEXT: {{^}} @objc set[[NEWVALUE]]{{$}}
   // CHECK-NEXT: }
@@ -61,33 +61,33 @@ public final class FinalClass {
 public class Base {
   // CHECK-NEXT: @objc public init(){{$}}
   @objc public init() {}
-  // CHECK-NEXT: @objc required public init(x: Swift.Int){{$}}
+  // CHECK-NEXT: @objc required public init(x: Swift::Int){{$}}
   @objc public required init(x: Int) {}
   // CHECK-NEXT: @objc deinit{{$}}
 } // CHECK-NEXT: {{^}$}}
 
 
-// CHECK-LABEL: public class SubImplicit : {{(Test[.])?Base}} {
+// CHECK-LABEL: public class SubImplicit : {{(Test::)?Base}} {
 public class SubImplicit: Base {
   // CHECK-NEXT: @objc override public init(){{$}}
-  // CHECK-NEXT: @objc required public init(x: Swift.Int){{$}}
+  // CHECK-NEXT: @objc required public init(x: Swift::Int){{$}}
   // CHECK-NEXT: @objc deinit{{$}}
 } // CHECK-NEXT: {{^}$}}
 
 
-// CHECK-LABEL: public class SubExplicit : {{(Test[.])?Base}} {
+// CHECK-LABEL: public class SubExplicit : {{(Test::)?Base}} {
 public class SubExplicit: Base {
   // Make sure adding "required" preserves both "required" and "override".
   // CHECK-NEXT: @objc override required public init(){{$}}
   public override required init() { super.init() }
-  // CHECK-NEXT: @objc required public init(x: Swift.Int){{$}}
+  // CHECK-NEXT: @objc required public init(x: Swift::Int){{$}}
   public required init(x: Int) { super.init() }
   // CHECK-NEXT: @objc deinit{{$}}
 } // CHECK-NEXT: {{^}$}}
 
 // CHECK-LABEL: public struct MyStruct {
 public struct MyStruct {
-  // CHECK: public var e: Swift.Int {
+  // CHECK: public var e: Swift::Int {
   // CHECK-NEXT: {{^}} mutating get{{$}}
   // FROMSOURCE-NEXT: {{^}} @inlinable nonmutating set[[NEWVALUE]] {}
   // FROMMODULE-NEXT: {{^}} @inlinable nonmutating set[[NEWVALUE]]{{$}}

--- a/test/ModuleInterface/module_selector.swift
+++ b/test/ModuleInterface/module_selector.swift
@@ -17,7 +17,7 @@
 // Test default behavior
 // RUN: %empty-directory(%t/default)
 // RUN: %target-swift-emit-module-interface(%t/default/TestCase.swiftinterface) %s %clang-importer-sdk -F %clang-importer-sdk-path/frameworks -I %S/Inputs/module_selector -target %target-stable-abi-triple -module-name TestCase 2>%t/default/stderr.txt
-// RUN: %FileCheck --input-file %t/default/TestCase.swiftinterface %s --check-prefixes CHECK,CHECK-DISABLED,CHECK-NOT-ALIAS
+// RUN: %FileCheck --input-file %t/default/TestCase.swiftinterface %s --check-prefixes CHECK,CHECK-ENABLED,CHECK-NOT-ALIAS
 // RUN: %FileCheck --input-file %t/default/stderr.txt %s --allow-empty --check-prefix DIAG-PRESERVE-NOT-OVERRIDDEN
 // RUN: %target-swift-typecheck-module-from-interface(%t/default/TestCase.swiftinterface) %clang-importer-sdk -F %clang-importer-sdk-path/frameworks -I %S/Inputs/module_selector -target %target-stable-abi-triple -module-name TestCase
 
@@ -251,12 +251,6 @@ public struct ProtoSet<T: Proto> {
   public let singleText: T.Text
 }
 
-// DIAG-PRESERVE-OVERRIDDEN: warning: ignoring -module-interface-preserve-types-as-written (overridden by -enable-module-selectors-in-module-interface)
-// DIAG-PRESERVE-NOT-OVERRIDDEN-NOT: warning: ignoring -module-interface-preserve-types-as-written (overridden by -enable-module-selectors-in-module-interface)
-
-// DIAG-ALIAS-OVERRIDDEN: warning: ignoring -alias-module-names-in-module-interface (overridden by -enable-module-selectors-in-module-interface)
-// DIAG-ALIAS-NOT-OVERRIDDEN-NOT: warning: ignoring -alias-module-names-in-module-interface (overridden by -enable-module-selectors-in-module-interface)
-
 // rdar://169720990 -- complicated protocol hierarchy with typealias in protocol
 
 // CHECK-LABEL: class TypeAliasNestClass
@@ -287,3 +281,9 @@ public protocol AssociatedType2Protocol {
 public protocol AssociatedType3Protocol {
   associatedtype AssociatedType4
 }
+
+// DIAG-PRESERVE-OVERRIDDEN: warning: ignoring '-module-interface-preserve-types-as-written'; this option has been obsoleted by module selectors (add '-disable-module-selectors-in-module-interface' to restore original behavior)
+// DIAG-PRESERVE-NOT-OVERRIDDEN-NOT: warning: ignoring '-module-interface-preserve-types-as-written'; this option has been obsoleted by module selectors (add '-disable-module-selectors-in-module-interface' to restore original behavior)
+
+// DIAG-ALIAS-OVERRIDDEN: warning: ignoring '-alias-module-names-in-module-interface'; this option has been obsoleted by module selectors (add '-disable-module-selectors-in-module-interface' to restore original behavior)
+// DIAG-ALIAS-NOT-OVERRIDDEN-NOT: warning: ignoring '-alias-module-names-in-module-interface'; this option has been obsoleted by module selectors (add '-disable-module-selectors-in-module-interface' to restore original behavior)

--- a/test/ModuleInterface/module_shadowing.swift
+++ b/test/ModuleInterface/module_shadowing.swift
@@ -9,19 +9,19 @@
 
 // Build this file as a module and check that it emits the expected warnings.
 // RUN: %empty-directory(%t/subtest-1)
-// RUN: %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/mcp -emit-module-interface-path %t/subtest-1/module_shadowing.swiftinterface %s -enable-library-evolution -module-name module_shadowing -I %t/lib -swift-version 5 2>&1 | %FileCheck --check-prefix OTHER --implicit-check-not TestModule %s
+// RUN: %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/mcp -emit-module-interface-path %t/subtest-1/module_shadowing.swiftinterface %s -enable-library-evolution -module-name module_shadowing -I %t/lib -disable-module-selectors-in-module-interface -swift-version 5 2>&1 | %FileCheck --check-prefix OTHER --implicit-check-not TestModule %s
 
 // Make sure that preserve-types-as-written disables this warning.
 // RUN: %empty-directory(%t/subtest-2)
-// RUN: %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/mcp -emit-module-interface-path %t/subtest-2/module_shadowing.swiftinterface %s -enable-library-evolution -module-name module_shadowing -I %t/lib -module-interface-preserve-types-as-written -swift-version 5 -verify
+// RUN: %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/mcp -emit-module-interface-path %t/subtest-2/module_shadowing.swiftinterface %s -enable-library-evolution -module-name module_shadowing -I %t/lib -disable-module-selectors-in-module-interface -module-interface-preserve-types-as-written -swift-version 5 -verify
 
 // alias-module-names-in-module-interface also disables this warning.
 // RUN: %empty-directory(%t/subtest-2)
-// RUN: %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/mcp -emit-module-interface-path %t/subtest-2/module_shadowing.swiftinterface %s -enable-library-evolution -module-name module_shadowing -I %t/lib -alias-module-names-in-module-interface -swift-version 5 -verify
+// RUN: %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/mcp -emit-module-interface-path %t/subtest-2/module_shadowing.swiftinterface %s -enable-library-evolution -module-name module_shadowing -I %t/lib -disable-module-selectors-in-module-interface -alias-module-names-in-module-interface -swift-version 5 -verify
 
 // Build this module in a different configuration where it will shadow itself.
 // RUN: %empty-directory(%t/subtest-3)
-// RUN: %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/mcp -emit-module-interface-path %t/subtest-3/ShadowyHorror.swiftinterface %s -enable-library-evolution -module-name ShadowyHorror -DSELF_SHADOW -swift-version 5 2>&1 | %FileCheck --check-prefix SELF --implicit-check-not TestModule %s
+// RUN: %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/mcp -emit-module-interface-path %t/subtest-3/ShadowyHorror.swiftinterface %s -enable-library-evolution -module-name ShadowyHorror -DSELF_SHADOW -disable-module-selectors-in-module-interface -swift-version 5 2>&1 | %FileCheck --check-prefix SELF --implicit-check-not TestModule %s
 
 // FIXME: Verify that the module-shadowing bugs we're trying to address haven't
 // been fixed (https://github.com/apple/swift/issues/43510).

--- a/test/ModuleInterface/moveonly_interface.swift
+++ b/test/ModuleInterface/moveonly_interface.swift
@@ -13,12 +13,12 @@ public struct FileDescriptor: ~Copyable {
 }
 
 public class FileHandle {
-  // INTERFACE: public var _stored: test.FileDescriptor
+  // INTERFACE: public var _stored: test::FileDescriptor
 
   // SILGEN: @_hasStorage @_hasInitialValue public var _stored: FileDescriptor { get set }
   public var _stored: FileDescriptor = FileDescriptor()
 
-  // INTERFACE:       public var file: test.FileDescriptor {
+  // INTERFACE:       public var file: test::FileDescriptor {
   // INTERFACE-NEXT:    _read
   // INTERFACE-NEXT:    _modify
   // INTERFACE-NEXT:  }

--- a/test/ModuleInterface/non-public-designated-inits.swift
+++ b/test/ModuleInterface/non-public-designated-inits.swift
@@ -12,7 +12,7 @@ open class A {
   // init should not be inheritable.
   init() {}
 
-  // CHECK-NEXT: public init(_: Swift.Int)
+  // CHECK-NEXT: public init(_: Swift::Int)
   public init(_: Int) {}
 
   // CHECK-NEXT: convenience public init(hi: ())

--- a/test/ModuleInterface/noncopyable_generics.swift
+++ b/test/ModuleInterface/noncopyable_generics.swift
@@ -56,46 +56,46 @@ import NoncopyableGenerics_Misc
 // CHECK-MISC: public struct rdar118697289_S2<Element> {
 // CHECK-MISC: public static func allCopyable1<T>(_ a: T, _ b: T) -> T
 
-// CHECK-MISC: public static func allCopyable2<T>(_ s: T) where T : NoncopyableGenerics_Misc._NoCopyP
+// CHECK-MISC: public static func allCopyable2<T>(_ s: T) where T : NoncopyableGenerics_Misc::_NoCopyP
 
-// CHECK-MISC: public static func oneCopyable1<T, V>(_ s: T, _ v: borrowing V) where T : {{.*}}._NoCopyP, V : ~Copyable
+// CHECK-MISC: public static func oneCopyable1<T, V>(_ s: T, _ v: borrowing V) where T : {{.*}}::_NoCopyP, V : ~Copyable
 
-// CHECK-MISC: public static func oneCopyable2<T, V>(_ s: borrowing T, _ v: V) where T : {{.*}}._NoCopyP, T : ~Copyable
+// CHECK-MISC: public static func oneCopyable2<T, V>(_ s: borrowing T, _ v: V) where T : {{.*}}::_NoCopyP, T : ~Copyable
 
-// CHECK-MISC: public static func oneCopyable3<T, V>(_ s: borrowing T, _ v: V) where T : {{.*}}._NoCopyP, T : ~Copyable
+// CHECK-MISC: public static func oneCopyable3<T, V>(_ s: borrowing T, _ v: V) where T : {{.*}}::_NoCopyP, T : ~Copyable
 
 // CHECK-MISC: public static func basic_some(_ s: some _NoCopyP)
 
 // CHECK-MISC: public static func basic_some_nc(_ s: borrowing some _NoCopyP & ~Copyable)
 
-// CHECK-MISC: public static func oneEscapable<T, V>(_ s: T, _ v: V) where T : NoncopyableGenerics_Misc._NoEscapableP, T : ~Escapable
+// CHECK-MISC: public static func oneEscapable<T, V>(_ s: T, _ v: V) where T : NoncopyableGenerics_Misc::_NoEscapableP, T : ~Escapable
 
-// CHECK-MISC: public static func canEscapeButConforms<T>(_ t: T) where T : {{.*}}._NoEscapableP
+// CHECK-MISC: public static func canEscapeButConforms<T>(_ t: T) where T : {{.*}}::_NoEscapableP
 
 // CHECK-MISC: public static func opaqueNonEscapable(_ s: some _NoEscapableP & ~Escapable)
 
 // CHECK-MISC: public static func opaqueEscapable(_ s: some _NoEscapableP)
 
-// CHECK-MISC: public struct ExplicitHello<T> : ~Swift.Copyable where T : ~Copyable {
+// CHECK-MISC: public struct ExplicitHello<T> : ~Swift::Copyable where T : ~Copyable {
 
-// CHECK-MISC: extension {{.*}}.ExplicitHello : Swift.Copyable where T : Swift.Copyable {
+// CHECK-MISC: extension {{.*}}::ExplicitHello : Swift::Copyable where T : Swift::Copyable {
 
-// CHECK-MISC: public struct Hello<T> : ~Swift.Copyable, ~Swift.Escapable where T : ~Copyable, T : ~Escapable {
+// CHECK-MISC: public struct Hello<T> : ~Swift::Copyable, ~Swift::Escapable where T : ~Copyable, T : ~Escapable {
 
-// CHECK-MISC: extension NoncopyableGenerics_Misc.Hello : Swift.Escapable where T : Swift.Escapable, T : ~Copyable {
+// CHECK-MISC: extension NoncopyableGenerics_Misc::Hello : Swift::Escapable where T : Swift::Escapable, T : ~Copyable {
 // CHECK-MISC-NEXT: }
 
-// CHECK-MISC: extension NoncopyableGenerics_Misc.Hello : Swift.Copyable where T : Swift.Copyable, T : ~Escapable {
+// CHECK-MISC: extension NoncopyableGenerics_Misc::Hello : Swift::Copyable where T : Swift::Copyable, T : ~Escapable {
 // CHECK-MISC-NEXT: }
 
 // CHECK-MISC: public protocol TestAssocTypes {
-// CHECK-MISC-NEXT:   associatedtype A : {{.*}}._NoCopyP, ~Copyable
+// CHECK-MISC-NEXT:   associatedtype A : {{.*}}::_NoCopyP, ~Copyable
 
-// CHECK-MISC: public typealias SomeAlias<G> = {{.*}}.Hello<G>
+// CHECK-MISC: public typealias SomeAlias<G> = {{.*}}::Hello<G>
 
-// CHECK-MISC: public typealias AliasWithInverse<G> = {{.*}}.Hello<G> where G : ~Copyable, G : ~Escapable
+// CHECK-MISC: public typealias AliasWithInverse<G> = {{.*}}::Hello<G> where G : ~Copyable, G : ~Escapable
 
-// CHECK-MISC: public struct RudePointer<T> : Swift.Copyable where T : ~Copyable {
+// CHECK-MISC: public struct RudePointer<T> : Swift::Copyable where T : ~Copyable {
 
 // CHECK-MISC: noInversesSTART
 // CHECK-MISC-NOT: ~
@@ -105,22 +105,22 @@ import NoncopyableGenerics_Misc
 // CHECK-MISC: public func checkAnyInv2<Result>(_ t: borrowing Result) where Result : ~Copyable, Result : ~Escapable
 // CHECK-MISC: public func checkAnyObject<Result>(_ t: Result) where Result : AnyObject
 
-// CHECK-MISC: public struct Outer<A> : ~Swift.Copyable where A : ~Copyable {
+// CHECK-MISC: public struct Outer<A> : ~Swift::Copyable where A : ~Copyable {
 // CHECK-MISC-NEXT:   public func innerFn<B>(_ b: borrowing B) where B : ~Copyable
-// CHECK-MISC:   public struct InnerStruct<C> : ~Swift.Copyable where C : ~Copyable {
+// CHECK-MISC:   public struct InnerStruct<C> : ~Swift::Copyable where C : ~Copyable {
 // CHECK-MISC-NEXT:     public func g<D>(_ d: borrowing D) where D : ~Copyable
-// CHECK-MISC:   public struct InnerVariation1<D> : ~Swift.Copyable, ~Swift.Escapable where D : ~Copyable
-// CHECK-MISC:   public struct InnerVariation2<D> : ~Swift.Copyable, ~Swift.Escapable where D : ~Escapable
+// CHECK-MISC:   public struct InnerVariation1<D> : ~Swift::Copyable, ~Swift::Escapable where D : ~Copyable
+// CHECK-MISC:   public struct InnerVariation2<D> : ~Swift::Copyable, ~Swift::Escapable where D : ~Escapable
 
-// CHECK-MISC: extension {{.*}}.Outer : Swift.Copyable where A : Swift.Copyable {
+// CHECK-MISC: extension {{.*}}::Outer : Swift::Copyable where A : Swift::Copyable {
 
-// CHECK-MISC: extension {{.*}}.Outer.InnerStruct : Swift.Copyable where A : Swift.Copyable, C : Swift.Copyable {
+// CHECK-MISC: extension {{.*}}::Outer.{{.*}}::InnerStruct : Swift::Copyable where A : Swift::Copyable, C : Swift::Copyable {
 
-// CHECK-MISC: extension {{.*}}.Outer.InnerVariation1 : Swift.Copyable where A : Swift.Copyable, D : Swift.Copyable {
+// CHECK-MISC: extension {{.*}}::Outer.{{.*}}::InnerVariation1 : Swift::Copyable where A : Swift::Copyable, D : Swift::Copyable {
 
-// CHECK-MISC: extension {{.*}}.Outer.InnerVariation2 : Swift.Escapable where D : Swift.Escapable, A : ~Copyable {
+// CHECK-MISC: extension {{.*}}::Outer.{{.*}}::InnerVariation2 : Swift::Escapable where D : Swift::Escapable, A : ~Copyable {
 
-// CHECK-MISC: extension {{.*}}.Outer.InnerStruct {
+// CHECK-MISC: extension {{.*}}::Outer.{{.*}}::InnerStruct {
 // CHECK-MISC-NEXT:   public func hello<T>(_ t: T) where T : ~Escapable
 
 // CHECK-MISC: @_preInverseGenerics public func old_swap<T>(_ a: inout T, _ b: inout T) where T : ~Copyable
@@ -131,40 +131,40 @@ import NoncopyableGenerics_Misc
 
 // CHECK-MISC:      public struct LoudlyNC<T> where T : ~Copyable {
 // CHECK-MISC-NEXT: }
-// CHECK-MISC-NEXT: public func _indexHumongousDonuts<TTT, T>(_ aggregate: Swift.UnsafePointer<TTT>, _ index: Swift.Int) -> T
-// CHECK-MISC-NEXT: public func referToLoud(_ t: {{.*}}.LoudlyNC<Swift.String>)
-// CHECK-MISC-NEXT: public func referToLoudProperGuarding(_ t: {{.*}}.LoudlyNC<Swift.String>)
-// CHECK-MISC-NEXT: public struct NoCopyPls : ~Swift.Copyable {
+// CHECK-MISC-NEXT: public func _indexHumongousDonuts<TTT, T>(_ aggregate: Swift::UnsafePointer<TTT>, _ index: Swift::Int) -> T
+// CHECK-MISC-NEXT: public func referToLoud(_ t: {{.*}}::LoudlyNC<Swift::String>)
+// CHECK-MISC-NEXT: public func referToLoudProperGuarding(_ t: {{.*}}::LoudlyNC<Swift::String>)
+// CHECK-MISC-NEXT: public struct NoCopyPls : ~Swift::Copyable {
 // CHECK-MISC-NEXT: }
-// CHECK-MISC-NEXT: public func substCopyable(_ t: Swift.String?)
+// CHECK-MISC-NEXT: public func substCopyable(_ t: Swift::String?)
 // CHECK-MISC-NEXT: public func substGenericCopyable<T>(_ t: T?)
 
-// CHECK-MISC-NEXT: public func substNC(_ t: borrowing {{.*}}.NoCopyPls?)
+// CHECK-MISC-NEXT: public func substNC(_ t: borrowing {{.*}}::NoCopyPls?)
 // CHECK-MISC-NEXT: public func substGenericNC<T>(_ t: borrowing T?) where T : ~Copyable
 
 // CHECK-MISC:      public protocol Publik : ~Copyable {
 // CHECK-MISC-NEXT: }
 // CHECK-MISC-NEXT: public struct Concrete : ~Copyable {
 // CHECK-MISC-NEXT: }
-// CHECK-MISC-NEXT: public struct Generic<T> : ~Copyable where T : {{.*}}.Publik, T : ~Copyable {
+// CHECK-MISC-NEXT: public struct Generic<T> : ~Copyable where T : {{.*}}::Publik, T : ~Copyable {
 // CHECK-MISC-NEXT: }
 // CHECK-MISC-NEXT: public struct VeryNested : ~Copyable {
 // CHECK-MISC-NEXT: }
 // CHECK-MISC-NEXT: public struct Twice : ~Copyable, ~Copyable {
 // CHECK-MISC-NEXT: }
-// CHECK-MISC-NEXT: public struct RegularTwice : ~Swift.Copyable, ~Swift.Copyable {
+// CHECK-MISC-NEXT: public struct RegularTwice : ~Swift::Copyable, ~Swift::Copyable {
 // CHECK-MISC-NEXT: }
 
-// CHECK-MISC-NEXT: public struct Continuation<T, E> where E : Swift.Error, T : ~Copyable {
+// CHECK-MISC-NEXT: public struct Continuation<T, E> where E : Swift::Error, T : ~Copyable {
 
-// CHECK-MISC: @frozen public enum Moptional<Wrapped> : ~Swift.Copyable, ~Swift.Escapable where Wrapped : ~Copyable, Wrapped : ~Escapable {
-// CHECK-MISC: extension {{.*}}.Moptional : Swift.Copyable where Wrapped : Swift.Copyable, Wrapped : ~Escapable {
-// CHECK-MISC: extension {{.*}}.Moptional : Swift.Escapable where Wrapped : Swift.Escapable, Wrapped : ~Copyable {
+// CHECK-MISC: @frozen public enum Moptional<Wrapped> : ~Swift::Copyable, ~Swift::Escapable where Wrapped : ~Copyable, Wrapped : ~Escapable {
+// CHECK-MISC: extension {{.*}}::Moptional : Swift::Copyable where Wrapped : Swift::Copyable, Wrapped : ~Escapable {
+// CHECK-MISC: extension {{.*}}::Moptional : Swift::Escapable where Wrapped : Swift::Escapable, Wrapped : ~Copyable {
 
 // CHECK-MISC-NOT:  ~
 
-// NOTE: below are extensions emitted at the end of NoncopyableGenerics_Misc.swift
-// CHECK-MISC: extension {{.*}}.VeryNested : {{.*}}.Publik {}
+// NOTE: below are extensions emitted at the end of NoncopyableGenerics_Misc::swift
+// CHECK-MISC: extension {{.*}}::VeryNested : {{.*}}::Publik {}
 
 import Swiftskell
 
@@ -174,27 +174,27 @@ import Swiftskell
 
 // CHECK: public protocol Eq : ~Copyable {
 
-// CHECK: extension Swiftskell.Eq where Self : ~Copyable {
+// CHECK: extension Swiftskell::Eq where Self : ~Copyable {
 
-// CHECK: public enum Either<Success, Failure> : ~Swift.Copyable where Failure : Swift.Error, Success : ~Copyable {
+// CHECK: public enum Either<Success, Failure> : ~Swift::Copyable where Failure : Swift::Error, Success : ~Copyable {
 
 /// This one is position dependent so we can ensure the associated type was printed correctly.
 // CHECK: public protocol Generator : ~Copyable {
 // CHECK-NEXT:   associatedtype Element : ~Copyable
 
-// CHECK: public enum Pair<L, R> : ~Swift.Copyable where L : ~Copyable, R : ~Copyable {
+// CHECK: public enum Pair<L, R> : ~Swift::Copyable where L : ~Copyable, R : ~Copyable {
 
-// CHECK: extension Swiftskell.Pair : Swift.Copyable where L : Swift.Copyable, R : Swift.Copyable {
+// CHECK: extension Swiftskell::Pair : Swift::Copyable where L : Swift::Copyable, R : Swift::Copyable {
 
-// CHECK: public enum Maybe<Wrapped> : ~Swift.Copyable where Wrapped : ~Copyable {
+// CHECK: public enum Maybe<Wrapped> : ~Swift::Copyable where Wrapped : ~Copyable {
 
-// CHECK: extension Swiftskell.Maybe : Swift.Copyable where Wrapped : Swift.Copyable {
+// CHECK: extension Swiftskell::Maybe : Swift::Copyable where Wrapped : Swift::Copyable {
 
-// CHECK: extension Swiftskell.Maybe : Swiftskell.Show where Wrapped : Swiftskell.Show, Wrapped : ~Copyable {
+// CHECK: extension Swiftskell::Maybe : Swiftskell::Show where Wrapped : Swiftskell::Show, Wrapped : ~Copyable {
 
-// CHECK: extension Swiftskell.Maybe : Swiftskell.Eq where Wrapped : Swiftskell.Eq, Wrapped : ~Copyable {
+// CHECK: extension Swiftskell::Maybe : Swiftskell::Eq where Wrapped : Swiftskell::Eq, Wrapped : ~Copyable {
 
-// CHECK: public func isJust<A>(_ m: borrowing Swiftskell.Maybe<A>) -> Swift.Bool where A : ~Copyable
+// CHECK: public func isJust<A>(_ m: borrowing Swiftskell::Maybe<A>) -> Swift::Bool where A : ~Copyable
 
 struct FileDescriptor: ~Copyable, Eq, Show {
   let id: Int

--- a/test/ModuleInterface/nonescapable_types.swift
+++ b/test/ModuleInterface/nonescapable_types.swift
@@ -12,25 +12,25 @@ public protocol P: ~Escapable {
   associatedtype A
 }
 
-// CHECK: public struct X<T> : ~Swift.Escapable where T : ~Escapable {
+// CHECK: public struct X<T> : ~Swift::Escapable where T : ~Escapable {
 // CHECK: }
 public struct X<T: ~Escapable>: ~Escapable { }
 
-// CHECK:      extension Test.X {
+// CHECK:      extension Test::X {
 // CHECK-NEXT:   func f()
 // CHECK:      }
 extension X where T: Escapable {
   public func f() { }
 }
 
-// CHECK: extension Test.X where T : ~Escapable {
+// CHECK: extension Test::X where T : ~Escapable {
 // CHECK:   public func g(other: borrowing T)
 // CHECK: }
 extension X where T: ~Escapable {
   public func g(other: borrowing T) { }
 }
 
-// CHECK: public enum Y<T> : ~Swift.Escapable where T : ~Escapable {
+// CHECK: public enum Y<T> : ~Swift::Escapable where T : ~Escapable {
 // CHECK:   case none
 // CHECK:   case some(T)
 // CHECK: }
@@ -42,14 +42,14 @@ public enum Y<T: ~Escapable>: ~Escapable {
 extension Y: Escapable where T: Escapable { }
 
 // CHECK: @lifetime(copy y)
-// CHECK: public func derive<T>(_ y: Test.Y<T>) -> Test.Y<T> where T : ~Escapable
+// CHECK: public func derive<T>(_ y: Test::Y<T>) -> Test::Y<T> where T : ~Escapable
 @lifetime(copy y)
 public func derive<T : ~Escapable>(_ y: Y<T>) -> Y<T> {
   y
 }
 
 // CHECK: @lifetime(copy x)
-// CHECK: public func derive<T>(_ x: Test.X<T>) -> Test.X<T> where T : ~Escapable
+// CHECK: public func derive<T>(_ x: Test::X<T>) -> Test::X<T> where T : ~Escapable
 @lifetime(copy x)
 public func derive<T : ~Escapable>(_ x: X<T>) -> X<T> {
   x

--- a/test/ModuleInterface/nsmanaged-attr.swift
+++ b/test/ModuleInterface/nsmanaged-attr.swift
@@ -16,24 +16,24 @@
 import CoreData
 import Foundation
 
-// CHECK: @objc @_inheritsConvenienceInitializers{{ nonisolated | }}public class MyObject : CoreData.NSManagedObject {
+// CHECK: @objc @_inheritsConvenienceInitializers{{ nonisolated | }}public class MyObject : CoreData::NSManagedObject {
 public class MyObject: NSManagedObject {
-  // CHECK: @objc @NSManaged{{ nonisolated | }}dynamic public var myVar: Swift.String {
+  // CHECK: @objc @NSManaged{{ nonisolated | }}dynamic public var myVar: Swift::String {
   // CHECK-NEXT: @objc get
   // CHECK-NEXT: @objc set
   // CHECK-NEXT: }
   @NSManaged public var myVar: String
-  // CHECK: @NSManaged @objc{{ nonisolated | }}dynamic public var myVar2: Swift.String {
+  // CHECK: @NSManaged @objc{{ nonisolated | }}dynamic public var myVar2: Swift::String {
   // CHECK-NEXT: @objc get
   // CHECK-NEXT: @objc set
   // CHECK-NEXT: }
   @NSManaged @objc public var myVar2: String
-  // CHECK: @NSManaged @objc dynamic{{ nonisolated | }}public var myVar3: Swift.String {
+  // CHECK: @NSManaged @objc dynamic{{ nonisolated | }}public var myVar3: Swift::String {
   // CHECK-NEXT: @objc get
   // CHECK-NEXT: @objc set
   // CHECK-NEXT: }
   @NSManaged @objc dynamic public var myVar3: String
-  // CHECK: @NSManaged @objc dynamic{{ nonisolated | }}public var myVar4: Swift.String {
+  // CHECK: @NSManaged @objc dynamic{{ nonisolated | }}public var myVar4: Swift::String {
   // CHECK-NEXT: @objc get
   // CHECK-NEXT: }
   @NSManaged @objc dynamic public private(set) var myVar4: String

--- a/test/ModuleInterface/objc_implementation.swift
+++ b/test/ModuleInterface/objc_implementation.swift
@@ -28,7 +28,7 @@ import Foundation
 // @_objcImplementation class
 //
 
-// CHECK-LABEL: extension objc_implementation.ImplClass {
+// CHECK-LABEL: extension objc_implementation::ImplClass {
 @_objcImplementation extension ImplClass {
   // CHECK-NOT: init()
   @objc public override init() {
@@ -45,13 +45,13 @@ import Foundation
   // CHECK-NOT: var letProperty1:
   @objc public let letProperty1: Int32
 
-  // CHECK-DAG: @nonobjc public var letProperty2: Swift.Int32 { get }
+  // CHECK-DAG: @nonobjc public var letProperty2: Swift::Int32 { get }
   @nonobjc public let letProperty2: Int32
 
-  // CHECK-DAG: final public var implProperty2: ObjectiveC.NSObject? { get set }
+  // CHECK-DAG: final public var implProperty2: ObjectiveC::NSObject? { get set }
   public final var implProperty2: NSObject?
 
-  // CHECK-DAG: final public var implProperty3: ObjectiveC.NSObject? {
+  // CHECK-DAG: final public var implProperty3: ObjectiveC::NSObject? {
   public final var implProperty3: NSObject? {
     didSet { }
   }
@@ -68,7 +68,7 @@ import Foundation
 //
 
 // Empty category should be omitted, so there's only one `extension ImplClass`.
-// CHECK-NOT: extension objc_implementation.ImplClass {
+// CHECK-NOT: extension objc_implementation::ImplClass {
 @_objcImplementation(Category1) extension ImplClass {
   // NEGATIVE-NOT: func category1Method
   @objc public func category1Method(_: Int32) {
@@ -80,7 +80,7 @@ import Foundation
 // Second @_objcImplementation class, inherited initializer
 //
 
-// NEGATIVE-NOT: extension objc_implementation.NoInitImplClass
+// NEGATIVE-NOT: extension objc_implementation::NoInitImplClass
 @_objcImplementation extension NoInitImplClass {
   // NEGATIVE-NOT: var s1:
   @objc public let s1 = "s1v"
@@ -96,7 +96,7 @@ import Foundation
 // @objc subclass of @_objcImplementation class
 //
 
-// CHECK-LABEL: @objc @_inheritsConvenienceInitializers open class SwiftSubclass : objc_implementation.ImplClass {
+// CHECK-LABEL: @objc @_inheritsConvenienceInitializers open class SwiftSubclass : objc_implementation::ImplClass {
 open class SwiftSubclass: ImplClass {
   // CHECK-DAG: @objc override dynamic open func mainMethod
   override open func mainMethod(_: Int32) {

--- a/test/ModuleInterface/opaque-result-types.swift
+++ b/test/ModuleInterface/opaque-result-types.swift
@@ -7,35 +7,35 @@
 public protocol Foo {}
 extension Int: Foo {}
 
-// CHECK-LABEL: public func foo(_: Swift.Int) -> some OpaqueResultTypes.Foo
+// CHECK-LABEL: public func foo(_: Swift::Int) -> some OpaqueResultTypes::Foo
 @available(SwiftStdlib 5.1, *)
 public func foo(_: Int) -> some Foo {
   return 1738
 }
 
-// CHECK-LABEL: @inlinable public func foo(_: Swift.String) -> some OpaqueResultTypes.Foo {
+// CHECK-LABEL: @inlinable public func foo(_: Swift::String) -> some OpaqueResultTypes::Foo {
 @available(SwiftStdlib 5.1, *)
 @inlinable public func foo(_: String) -> some Foo {
   return 679
 }
 
-// CHECK-LABEL: public func foo<T>(_ x: T) -> some OpaqueResultTypes.Foo where T : OpaqueResultTypes.Foo
+// CHECK-LABEL: public func foo<T>(_ x: T) -> some OpaqueResultTypes::Foo where T : OpaqueResultTypes::Foo
 @available(SwiftStdlib 5.1, *)
 public func foo<T: Foo>(_ x: T) -> some Foo {
   return x
 }
 
-// CHECK-LABEL: public var globalComputedVar: some OpaqueResultTypes.Foo {
+// CHECK-LABEL: public var globalComputedVar: some OpaqueResultTypes::Foo {
 // CHECK-NEXT:    get
 // CHECK-NEXT:  }
 @available(SwiftStdlib 5.1, *)
 public var globalComputedVar: some Foo { 123 }
 
-// CHECK-LABEL: public var globalVar: some OpaqueResultTypes.Foo{{$}}
+// CHECK-LABEL: public var globalVar: some OpaqueResultTypes::Foo{{$}}
 @available(SwiftStdlib 5.1, *)
 public var globalVar: some Foo = 123
 
-// CHECK-LABEL: public var globalVarTuple: (some OpaqueResultTypes.Foo, some OpaqueResultTypes.Foo){{$}}
+// CHECK-LABEL: public var globalVarTuple: (some OpaqueResultTypes::Foo, some OpaqueResultTypes::Foo){{$}}
 @available(SwiftStdlib 5.1, *)
 public var globalVarTuple: (some Foo, some Foo) = (123, foo(123))
 
@@ -54,7 +54,7 @@ public protocol AssocTypeInference {
 public struct Bar<T>: AssocTypeInference {
   public init() {}
 
-  // CHECK-LABEL: public func foo(_: Swift.Int) -> some OpaqueResultTypes.Foo
+  // CHECK-LABEL: public func foo(_: Swift::Int) -> some OpaqueResultTypes::Foo
   @available(SwiftStdlib 5.1, *)
   public func foo(_: Int) -> some Foo {
     return 20721
@@ -65,7 +65,7 @@ public struct Bar<T>: AssocTypeInference {
     return 219
   }
 
-  // CHECK-LABEL: public func foo<U>(_ x: U) -> some OpaqueResultTypes.Foo where U : OpaqueResultTypes.Foo
+  // CHECK-LABEL: public func foo<U>(_ x: U) -> some OpaqueResultTypes::Foo where U : OpaqueResultTypes::Foo
   @available(SwiftStdlib 5.1, *)
   public func foo<U: Foo>(_ x: U) -> some Foo {
     return x
@@ -75,7 +75,7 @@ public struct Bar<T>: AssocTypeInference {
   public struct Bas: AssocTypeInference {
     public init() {}
 
-    // CHECK-LABEL: public func foo(_: Swift.Int) -> some OpaqueResultTypes.Foo
+    // CHECK-LABEL: public func foo(_: Swift::Int) -> some OpaqueResultTypes::Foo
     @available(SwiftStdlib 5.1, *)
     public func foo(_: Int) -> some Foo {
       return 20721
@@ -86,7 +86,7 @@ public struct Bar<T>: AssocTypeInference {
       return 219
     }
 
-    // CHECK-LABEL: public func foo<U>(_ x: U) -> some OpaqueResultTypes.Foo where U : OpaqueResultTypes.Foo
+    // CHECK-LABEL: public func foo<U>(_ x: U) -> some OpaqueResultTypes::Foo where U : OpaqueResultTypes::Foo
     @available(SwiftStdlib 5.1, *)
     public func foo<U: Foo>(_ x: U) -> some Foo {
       return x
@@ -110,7 +110,7 @@ public struct Bar<T>: AssocTypeInference {
   public struct Bass<U: Foo>: AssocTypeInference {
     public init() {}
 
-    // CHECK-LABEL: public func foo(_: Swift.Int) -> some OpaqueResultTypes.Foo
+    // CHECK-LABEL: public func foo(_: Swift::Int) -> some OpaqueResultTypes::Foo
     @available(SwiftStdlib 5.1, *)
     public func foo(_: Int) -> some Foo {
       return 20721
@@ -121,13 +121,13 @@ public struct Bar<T>: AssocTypeInference {
       return 219
     }
 
-    // CHECK-LABEL: public func foo(_ x: U) -> some OpaqueResultTypes.Foo
+    // CHECK-LABEL: public func foo(_ x: U) -> some OpaqueResultTypes::Foo
     @available(SwiftStdlib 5.1, *)
     public func foo(_ x: U) -> some Foo {
       return x
     }
 
-    // CHECK-LABEL: public func foo<V>(_ x: V) -> some OpaqueResultTypes.Foo where V : OpaqueResultTypes.Foo
+    // CHECK-LABEL: public func foo<V>(_ x: V) -> some OpaqueResultTypes::Foo where V : OpaqueResultTypes::Foo
     @available(SwiftStdlib 5.1, *)
     public func foo<V: Foo>(_ x: V) -> some Foo {
       return x
@@ -174,7 +174,7 @@ public struct Zim: AssocTypeInference {
     return 219
   }
 
-  // CHECK-LABEL: public func foo<U>(_ x: U) -> some OpaqueResultTypes.Foo where U : OpaqueResultTypes.Foo
+  // CHECK-LABEL: public func foo<U>(_ x: U) -> some OpaqueResultTypes::Foo where U : OpaqueResultTypes::Foo
   @available(SwiftStdlib 5.1, *)
   public func foo<U: Foo>(_ x: U) -> some Foo {
     return x
@@ -194,7 +194,7 @@ public struct Zim: AssocTypeInference {
       return 219
     }
 
-    // CHECK-LABEL: public func foo<U>(_ x: U) -> some OpaqueResultTypes.Foo where U : OpaqueResultTypes.Foo
+    // CHECK-LABEL: public func foo<U>(_ x: U) -> some OpaqueResultTypes::Foo where U : OpaqueResultTypes::Foo
     @available(SwiftStdlib 5.1, *)
     public func foo<U: Foo>(_ x: U) -> some Foo {
       return x
@@ -214,7 +214,7 @@ public struct Zim: AssocTypeInference {
   public struct Zung<U: Foo>: AssocTypeInference {
     public init() {}
 
-    // CHECK-LABEL: public func foo(_: Swift.Int) -> some OpaqueResultTypes.Foo
+    // CHECK-LABEL: public func foo(_: Swift::Int) -> some OpaqueResultTypes::Foo
     @available(SwiftStdlib 5.1, *)
     public func foo(_: Int) -> some Foo {
       return 20721
@@ -230,7 +230,7 @@ public struct Zim: AssocTypeInference {
       return x
     }
 
-    // CHECK-LABEL: public func foo<V>(_ x: V) -> some OpaqueResultTypes.Foo where V : OpaqueResultTypes.Foo
+    // CHECK-LABEL: public func foo<V>(_ x: V) -> some OpaqueResultTypes::Foo where V : OpaqueResultTypes::Foo
     @available(SwiftStdlib 5.1, *)
     public func foo<V: Foo>(_ x: V) -> some Foo {
       return x

--- a/test/ModuleInterface/originally-defined-attr-synthesized-extension.swift
+++ b/test/ModuleInterface/originally-defined-attr-synthesized-extension.swift
@@ -14,13 +14,13 @@ public enum MyCase: Int {
 
 // CHECK: @_originallyDefinedIn(module: "Bar", macOS 10.9)
 // CHECK: @_originallyDefinedIn(module: "Bar", iOS 13.0)
-// CHECK: public enum MyCase : Swift.Int
+// CHECK: public enum MyCase : Swift::Int
 
 // CHECK: @_originallyDefinedIn(module: "Bar", macOS 10.9)
 // CHECK: @_originallyDefinedIn(module: "Bar", iOS 13.0)
-// CHECK: extension Foo.MyCase : Swift.Equatable {}
+// CHECK: extension Foo::MyCase : Swift::Equatable {}
 
 // CHECK: @_originallyDefinedIn(module: "Bar", macOS 10.9)
 // CHECK: @_originallyDefinedIn(module: "Bar", iOS 13.0)
-// CHECK: extension Foo.MyCase : Swift.Hashable {}
+// CHECK: extension Foo::MyCase : Swift::Hashable {}
 

--- a/test/ModuleInterface/pack_expansion_type.swift
+++ b/test/ModuleInterface/pack_expansion_type.swift
@@ -7,7 +7,7 @@
 // CHECK: public func variadicFunction<each T, each U>(t: repeat each T, u: repeat each U) -> (repeat (each T, each U)) where (repeat (each T, each U)) : Any
 public func variadicFunction<each T, each U>(t: repeat each T, u: repeat each U) -> (repeat (each T, each U)) {}
 
-// CHECK: public func variadicFunctionWithRequirement<each T>(t: repeat each T) where repeat each T : Swift.Equatable
+// CHECK: public func variadicFunctionWithRequirement<each T>(t: repeat each T) where repeat each T : Swift::Equatable
 public func variadicFunctionWithRequirement<each T: Equatable>(t: repeat each T) {}
 
 // CHECK: public struct VariadicType<each T> {
@@ -15,35 +15,35 @@ public struct VariadicType<each T> {
   // CHECK: public func variadicMethod<each U>(t: repeat each T, u: repeat each U) -> (repeat (each T, each U)) where (repeat (each T, each U)) : Any
   public func variadicMethod<each U>(t: repeat each T, u: repeat each  U) -> (repeat (each T, each U)) {}
 
-  // CHECK: public func returnsSelf() -> PackExpansionType.VariadicType<repeat each T>
+  // CHECK: public func returnsSelf() -> PackExpansionType::VariadicType<repeat each T>
   public func returnsSelf() -> Self {}
 }
 // CHECK: }
 
 // The second requirement should not be prefixed with 'repeat'
-// CHECK: public struct SameTypeReq<T, each U> where T : Swift.Sequence, T.Element == PackExpansionType.VariadicType<repeat each U> {
+// CHECK: public struct SameTypeReq<T, each U> where T : Swift::Sequence, T.Element == PackExpansionType::VariadicType<repeat each U> {
 public struct SameTypeReq<T: Sequence, each U> where T.Element == VariadicType<repeat each U> {}
 // CHECK: }
 
 /// Pack expansion types
 
-// CHECK: public func returnsVariadicType() -> PackExpansionType.VariadicType<>
+// CHECK: public func returnsVariadicType() -> PackExpansionType::VariadicType<>
 public func returnsVariadicType() -> VariadicType< > {}
 
-// CHECK: public func returnsVariadicType() -> PackExpansionType.VariadicType<Swift.Int, Swift.String, Swift.Float>
+// CHECK: public func returnsVariadicType() -> PackExpansionType::VariadicType<Swift::Int, Swift::String, Swift::Float>
 public func returnsVariadicType() -> VariadicType<Int, String, Float> {}
 
-// CHECK: public func returnsVariadicType<each T>() -> PackExpansionType.VariadicType<repeat each T>
+// CHECK: public func returnsVariadicType<each T>() -> PackExpansionType::VariadicType<repeat each T>
 public func returnsVariadicType<each T>() -> VariadicType<repeat each T> {}
 
-// CHECK: public typealias VariadicAlias<each T> = PackExpansionType.VariadicType<repeat Swift.Array<each T>>
+// CHECK: public typealias VariadicAlias<each T> = PackExpansionType::VariadicType<repeat Swift::Array<each T>>
 public typealias VariadicAlias<each T> = VariadicType<repeat Array<each T>>
 
-// CHECK: public func returnsVariadicAlias() -> PackExpansionType.VariadicAlias<>
+// CHECK: public func returnsVariadicAlias() -> PackExpansionType::VariadicAlias<>
 public func returnsVariadicAlias() -> VariadicAlias< > {}
 
-// CHECK: public func returnsVariadicAlias() -> PackExpansionType.VariadicAlias<Swift.Int, Swift.String, Swift.Float>
+// CHECK: public func returnsVariadicAlias() -> PackExpansionType::VariadicAlias<Swift::Int, Swift::String, Swift::Float>
 public func returnsVariadicAlias() -> VariadicAlias<Int, String, Float> {}
 
-// CHECK: public func returnsVariadicAlias<each T>() -> PackExpansionType.VariadicAlias<repeat each T>
+// CHECK: public func returnsVariadicAlias<each T>() -> PackExpansionType::VariadicAlias<repeat each T>
 public func returnsVariadicAlias<each T>() -> VariadicAlias<repeat each T> {}

--- a/test/ModuleInterface/package_interface.swift
+++ b/test/ModuleInterface/package_interface.swift
@@ -26,9 +26,9 @@ public enum PubEnum {
 // CHECK: -package-name barpkg
 // CHECK: public enum PubEnum {
 // CHECK:   case red, green
-// CHECK:   public static func == (a: Bar.PubEnum, b: Bar.PubEnum) -> Swift.Bool
-// CHECK:   public func hash(into hasher: inout Swift.Hasher)
-// CHECK:   public var hashValue: Swift.Int {
+// CHECK:   public static func == (a: Bar::PubEnum, b: Bar::PubEnum) -> Swift::Bool
+// CHECK:   public func hash(into hasher: inout Swift::Hasher)
+// CHECK:   public var hashValue: Swift::Int {
 // CHECK:     get
 // CHECK:   }
 // CHECK: }
@@ -45,7 +45,7 @@ public func pubFunc(arg: PubEnum) {
   }
 }
 
-// CHECK: @_transparent public func pubFunc(arg: Bar.PubEnum) {
+// CHECK: @_transparent public func pubFunc(arg: Bar::PubEnum) {
 // CHECK:   switch arg {
 // CHECK:   case .red:
 // CHECK:     print("r")
@@ -60,11 +60,11 @@ package enum PkgEnum {
   case blue, yellow
 }
 
-// CHECK-PKG: package enum PkgEnum : Swift.Sendable {
+// CHECK-PKG: package enum PkgEnum : Swift::Sendable {
 // CHECK-PKG:   case blue, yellow
-// CHECK-PKG:   package static func == (a: Bar.PkgEnum, b: Bar.PkgEnum) -> Swift.Bool
-// CHECK-PKG:   package func hash(into hasher: inout Swift.Hasher)
-// CHECK-PKG:   package var hashValue: Swift.Int {
+// CHECK-PKG:   package static func == (a: Bar::PkgEnum, b: Bar::PkgEnum) -> Swift::Bool
+// CHECK-PKG:   package func hash(into hasher: inout Swift::Hasher)
+// CHECK-PKG:   package var hashValue: Swift::Int {
 // CHECK-PKG:     get
 // CHECK-PKG:   }
 // CHECK-PKG: }
@@ -79,11 +79,11 @@ package enum UfiPkgEnum {
 // CHECK: package enum UfiPkgEnum {
 // CHECK:   case one, two
 // CHECK:   @usableFromInline
-// CHECK:   package static func == (a: Bar.UfiPkgEnum, b: Bar.UfiPkgEnum) -> Swift.Bool
+// CHECK:   package static func == (a: Bar::UfiPkgEnum, b: Bar::UfiPkgEnum) -> Swift::Bool
 // CHECK:   @usableFromInline
-// CHECK:   package func hash(into hasher: inout Swift.Hasher)
+// CHECK:   package func hash(into hasher: inout Swift::Hasher)
 // CHECK:   @usableFromInline
-// CHECK:   package var hashValue: Swift.Int {
+// CHECK:   package var hashValue: Swift::Int {
 // CHECK:     @usableFromInline
 // CHECK:     get
 // CHECK:   }
@@ -100,7 +100,7 @@ package func pkgFunc(arg: UfiPkgEnum) {
     print("def")
   }
 }
-// CHECK: @inlinable package func pkgFunc(arg: Bar.UfiPkgEnum) {
+// CHECK: @inlinable package func pkgFunc(arg: Bar::UfiPkgEnum) {
 // CHECK:   switch arg {
 // CHECK:   case .one:
 // CHECK:     print("1")
@@ -119,13 +119,13 @@ package func pkgFunc(arg: UfiPkgEnum) {
   public package(set) var five: String
 }
 // CHECK: @frozen public struct FrozenPub {
-// CHECK:   public var one: Swift.String
-// CHECK:   internal var two: Swift.String
-// CHECK:   private var three: Swift.String
-// CHECK:   @_hasStorage public var four: Swift.String {
+// CHECK:   public var one: Swift::String
+// CHECK:   internal var two: Swift::String
+// CHECK:   private var three: Swift::String
+// CHECK:   @_hasStorage public var four: Swift::String {
 // CHECK:     get
 // CHECK:   }
-// CHECK:   @_hasStorage public var five: Swift.String {
+// CHECK:   @_hasStorage public var five: Swift::String {
 // CHECK:     get
 // CHECK:   }
 // CHECK: }
@@ -137,9 +137,9 @@ package struct PkgStruct {
   package private(set) var four: String
 }
 
-// CHECK-PKG: package struct PkgStruct : Swift.Sendable {
-// CHECK-PKG:   package var one: Swift.String
-// CHECK-PKG:   package var four: Swift.String {
+// CHECK-PKG: package struct PkgStruct : Swift::Sendable {
+// CHECK-PKG:   package var one: Swift::String
+// CHECK-PKG:   package var four: Swift::String {
 // CHECK-PKG:     get
 // CHECK-PKG:   }
 // CHECK-PKG: }
@@ -161,12 +161,12 @@ public class PubKlass {
 }
 
 // CHECK: public class PubKlass {
-// CHECK:   public var pubVarInPub: Swift.String
-// CHECK-PKG:   package var pkgVarInPub: Swift.String
-// CHECK:   public var pubVarPrivSetInPub: Swift.Int {
+// CHECK:   public var pubVarInPub: Swift::String
+// CHECK-PKG:   package var pkgVarInPub: Swift::String
+// CHECK:   public var pubVarPrivSetInPub: Swift::Int {
 // CHECK:     get
 // CHECK:   }
-// CHECK:   public var pubVarPkgSetInPub: Swift.Int {
+// CHECK:   public var pubVarPkgSetInPub: Swift::Int {
 // CHECK:     get
 // CHECK:   }
 // CHECK:   public init()
@@ -191,8 +191,8 @@ package class PkgKlass {
 }
 
 // CHECK-PKG: package class PkgKlass {
-// CHECK-PKG:   package var pkgVarInPkg: Swift.String
-// CHECK-PKG:   package var pkgVarPrivSetInPkg: Swift.Int {
+// CHECK-PKG:   package var pkgVarInPkg: Swift::String
+// CHECK-PKG:   package var pkgVarPrivSetInPkg: Swift::Int {
 // CHECK-PKG:     get
 // CHECK-PKG:   }
 // CHECK-PKG:   package init()
@@ -205,7 +205,7 @@ public protocol PubProto {
 }
 
 // CHECK: public protocol PubProto {
-// CHECK:   var p1: Swift.String { get set }
+// CHECK:   var p1: Swift::String { get set }
 // CHECK:   func f1()
 // CHECK: }
 
@@ -217,8 +217,8 @@ public extension PubProto {
   func f2() { print("f2") }
 }
 
-// CHECK: extension Bar.PubProto {
-// CHECK:   public var p2: Swift.Int {
+// CHECK: extension Bar::PubProto {
+// CHECK:   public var p2: Swift::Int {
 // CHECK:     get
 // CHECK:   }
 // CHECK:   public func f1()
@@ -232,11 +232,11 @@ extension PubProto {
   public func f3() { print("f3") } // expected to show up in public interface
 }
 
-// CHECK: extension Bar.PubProto {
-// CHECK:   public var p3: Swift.Int {
+// CHECK: extension Bar::PubProto {
+// CHECK:   public var p3: Swift::Int {
 // CHECK:     get
 // CHECK:   }
-// CHECK-PKG:   package var p4: Swift.Int {
+// CHECK-PKG:   package var p4: Swift::Int {
 // CHECK-PKG:     get
 // CHECK-PKG:   }
 // CHECK:   public func f3()
@@ -247,7 +247,7 @@ package protocol PkgProto {
   func g1()
 }
 // CHECK-PKG: package protocol PkgProto {
-// CHECK-PKG:   var k1: Swift.String { get set }
+// CHECK-PKG:   var k1: Swift::String { get set }
 // CHECK-PKG:   func g1()
 // CHECK-PKG: }
 
@@ -256,8 +256,8 @@ package extension PkgProto {
   func g1() { print("g1 ext") }
   func g2() { print("g2") }
 }
-// CHECK-PKG: extension Bar.PkgProto {
-// CHECK-PKG:   package var k2: Swift.Int {
+// CHECK-PKG: extension Bar::PkgProto {
+// CHECK-PKG:   package var k2: Swift::Int {
 // CHECK-PKG:     get
 // CHECK-PKG:   }
 // CHECK-PKG:   package func g1()
@@ -270,31 +270,31 @@ extension PkgProto {
   package func g3() { print("g3") }
 }
 
-// CHECK-PKG: extension Bar.PkgProto {
-// CHECK-PKG:   package var k3: Swift.Int {
+// CHECK-PKG: extension Bar::PkgProto {
+// CHECK-PKG:   package var k3: Swift::Int {
 // CHECK-PKG:     get
 // CHECK-PKG:   }
 // CHECK-PKG:   package func g3()
 // CHECK-PKG: }
 
 public func pub(x: Int, y: String) { print("pub func") }
-// CHECK: public func pub(x: Swift.Int, y: Swift.String)
+// CHECK: public func pub(x: Swift::Int, y: Swift::String)
 
 @_spi(LibBar) public func spi(x: Int, y: String) { print("spi func") }
-// CHECK-PRIV: @_spi(LibBar) public func spi(x: Swift.Int, y: Swift.String)
+// CHECK-PRIV: @_spi(LibBar) public func spi(x: Swift::Int, y: Swift::String)
 
 @usableFromInline
 package func ufipkg(x: Int, y: String) { print("ufi pkg func") }
 // CHECK: @usableFromInline
-// CHECK: package func ufipkg(x: Swift.Int, y: Swift.String)
+// CHECK: package func ufipkg(x: Swift::Int, y: Swift::String)
 
 package func pkg(x: Int, y: String) { print("pkg func") }
-// CHECK-PKG: package func pkg(x: Swift.Int, y: Swift.String)
+// CHECK-PKG: package func pkg(x: Swift::Int, y: Swift::String)
 
 func int(x: Int, y: String) { print("int func") }
 private func priv(x: Int, y: String) { print("priv func") }
 
-// CHECK: extension Bar.PubEnum : Swift.Equatable {}
-// CHECK: extension Bar.PubEnum : Swift.Hashable {}
-// CHECK: extension Bar.FrozenPub : Swift.Sendable {}
+// CHECK: extension Bar::PubEnum : Swift::Equatable {}
+// CHECK: extension Bar::PubEnum : Swift::Hashable {}
+// CHECK: extension Bar::FrozenPub : Swift::Sendable {}
 

--- a/test/ModuleInterface/parameterized-protocol-opaque-result-types.swift
+++ b/test/ModuleInterface/parameterized-protocol-opaque-result-types.swift
@@ -12,27 +12,27 @@ public protocol Q<T>: P {}
 struct S<T>: Q {}
 
 
-// CHECK-LABEL: public func returnsP() -> some ParameterizedProtocols.P
+// CHECK-LABEL: public func returnsP() -> some ParameterizedProtocols::P
 public func returnsP() -> some P { return S<Int>() }
 
-// CHECK-LABEL: public func returnsPInt() -> some ParameterizedProtocols.P<Swift.Int>
+// CHECK-LABEL: public func returnsPInt() -> some ParameterizedProtocols::P<Swift::Int>
 public func returnsPInt() -> some P<Int> { return S<Int>() }
 
-// CHECK-LABEL: public func returnsPT<T>(_: T) -> some ParameterizedProtocols.P<T>
+// CHECK-LABEL: public func returnsPT<T>(_: T) -> some ParameterizedProtocols::P<T>
 public func returnsPT<T>(_: T) -> some P<T> { return S<T>() }
 
-// CHECK-LABEL: public func returnsPArrayT<T>(_: T) -> some ParameterizedProtocols.P<Swift.Array<T>>
+// CHECK-LABEL: public func returnsPArrayT<T>(_: T) -> some ParameterizedProtocols::P<Swift::Array<T>>
 public func returnsPArrayT<T>(_: T) -> some P<Array<T>> { return S<Array<T>>() }
 
 
-// CHECK-LABEL: public func returnsQ() -> some ParameterizedProtocols.Q
+// CHECK-LABEL: public func returnsQ() -> some ParameterizedProtocols::Q
 public func returnsQ() -> some Q { return S<Int>() }
 
-// CHECK-LABEL: public func returnsQInt() -> some ParameterizedProtocols.Q<Swift.Int>
+// CHECK-LABEL: public func returnsQInt() -> some ParameterizedProtocols::Q<Swift::Int>
 public func returnsQInt() -> some Q<Int> { return S<Int>() }
 
-// CHECK-LABEL: public func returnsQT<T>(_: T) -> some ParameterizedProtocols.Q<T>
+// CHECK-LABEL: public func returnsQT<T>(_: T) -> some ParameterizedProtocols::Q<T>
 public func returnsQT<T>(_: T) -> some Q<T> { return S<T>() }
 
-// CHECK-LABEL: public func returnsQArrayT<T>(_: T) -> some ParameterizedProtocols.Q<Swift.Array<T>>
+// CHECK-LABEL: public func returnsQArrayT<T>(_: T) -> some ParameterizedProtocols::Q<Swift::Array<T>>
 public func returnsQArrayT<T>(_: T) -> some Q<Array<T>> { return S<Array<T>>() }

--- a/test/ModuleInterface/parameterized-protocol-synthesized-extension.swift
+++ b/test/ModuleInterface/parameterized-protocol-synthesized-extension.swift
@@ -19,5 +19,5 @@ protocol Q1 : Q2 {}
 
 public protocol Q2 {}
 
-// CHECK: extension ParameterizedProtocols.S1 : ParameterizedProtocols.P2 {}
-// CHECK-NEXT: extension ParameterizedProtocols.S2 : ParameterizedProtocols.Q2 {}
+// CHECK: extension ParameterizedProtocols::S1 : ParameterizedProtocols::P2 {}
+// CHECK-NEXT: extension ParameterizedProtocols::S2 : ParameterizedProtocols::Q2 {}

--- a/test/ModuleInterface/parameterized-protocol-type-inheritance.swift
+++ b/test/ModuleInterface/parameterized-protocol-type-inheritance.swift
@@ -6,24 +6,24 @@ public protocol Fancy<Stuff> {
     associatedtype Stuff
 }
 
-// CHECK: public struct T : Library.Fancy {
-// CHECK: public typealias Stuff = Swift.Float64
+// CHECK: public struct T : Library::Fancy {
+// CHECK: public typealias Stuff = Swift::Float64
 public struct T: Fancy<Float64> {
 }
 
 public protocol Q {
 }
 
-// CHECK: public struct S : Library.Fancy & Library.Q {
-// CHECK: public typealias Stuff = Swift.Int
+// CHECK: public struct S : Library::Fancy & Library::Q {
+// CHECK: public typealias Stuff = Swift::Int
 public struct S: Fancy<Int> & Q {
 }
 
 public protocol P {
 }
 
-// CHECK: public struct V : Library.Fancy & Library.P & Library.Q {
-// CHECK: public typealias Stuff = Swift.CChar32
+// CHECK: public struct V : Library::Fancy & Library::P & Library::Q {
+// CHECK: public typealias Stuff = Swift::CChar32
 public struct V: ((Fancy<CChar32> & P) & Q) {
 }
 
@@ -31,9 +31,9 @@ public protocol Bar<T> {
   associatedtype T
 }
 
-// CHECK: public struct X : Library.Bar & Library.Fancy
-// CHECK: public typealias Stuff = Swift.CChar32
-// CHECK: public typealias T = Swift.Int
+// CHECK: public struct X : Library::Bar & Library::Fancy
+// CHECK: public typealias Stuff = Swift::CChar32
+// CHECK: public typealias T = Swift::Int
 public struct X: Fancy<CChar32> & Bar<Int> {
 }
 
@@ -44,8 +44,8 @@ public protocol B<A>: ~Copyable {
   associatedtype A
 }
 
-// CHECK: public class Derived : Library.Base & Library.B {
-// CHECK: public typealias A = Swift.Int
+// CHECK: public class Derived : Library::Base & Library::B {
+// CHECK: public typealias A = Swift::Int
 public class Derived: Base & B<Int> {
 }
 
@@ -53,9 +53,9 @@ public protocol R<E>: ~Copyable & ~Escapable {
   associatedtype E
 }
 
-// CHECK: public struct N : Library.B & Library.R & ~Copyable {
-// CHECK: public typealias A = Swift.Float64
-// CHECK: public typealias E = Swift.Int
+// CHECK: public struct N : Library::B & Library::R & ~Copyable {
+// CHECK: public typealias A = Swift::Float64
+// CHECK: public typealias E = Swift::Int
 public struct N: R<Int> & B<Float64> & ~Copyable  {
 }
 
@@ -67,5 +67,5 @@ public protocol P2<AT> {
    associatedtype AT
 }
 
-// CHECK-COUNT-1: public typealias AT = Swift.Int
+// CHECK-COUNT-1: public typealias AT = Swift::Int
 public struct S1: P1<Int>, P2<Int> {}

--- a/test/ModuleInterface/parameterized-protocols.swift
+++ b/test/ModuleInterface/parameterized-protocols.swift
@@ -9,6 +9,6 @@ public protocol HasPrimaryAssociatedTypes<T, U> {
 }
 
 // CHECK:      public protocol HasPrimaryAssociatedTypes<T, U> {
-// CHECK-NEXT:   associatedtype T : Swift.Collection
-// CHECK-NEXT:   associatedtype U : Swift.Equatable where Self.U == Self.T.Element
+// CHECK-NEXT:   associatedtype T : Swift::Collection
+// CHECK-NEXT:   associatedtype U : Swift::Equatable where Self.U == Self.T.Element
 // CHECK-NEXT: }

--- a/test/ModuleInterface/preconcurrency_conformances.swift
+++ b/test/ModuleInterface/preconcurrency_conformances.swift
@@ -45,7 +45,7 @@ public protocol WithAssoc {
 import A
 
 // CHECK-NOT: #if {{.*}} $DynamicActorIsolation
-// CHECK: @_Concurrency.MainActor public struct GlobalActorTest : @preconcurrency A.P
+// CHECK: @_Concurrency::MainActor public struct GlobalActorTest : @preconcurrency A::P
 
 @MainActor
 public struct GlobalActorTest : @preconcurrency P {
@@ -57,13 +57,13 @@ public class ExtTest {
 }
 
 // CHECK-NOT: #if {{.*}} $DynamicActorIsolation
-// CHECK: extension Client.ExtTest : @preconcurrency A.P
+// CHECK: extension Client::ExtTest : @preconcurrency A::P
 extension ExtTest : @preconcurrency P {
   public func test() -> Int { 1 }
 }
 
 // CHECK-NOT: #if {{.*}} && $DynamicActorIsolation
-// CHECK: public actor ActorTest : @preconcurrency A.P
+// CHECK: public actor ActorTest : @preconcurrency A::P
 public actor ActorTest : @preconcurrency P {
   public func test() -> Int { 2 }
 }
@@ -72,7 +72,7 @@ public actor ActorExtTest {
 }
 
 // CHECK-NOT: #if {{.*}} $DynamicActorIsolation
-// CHECK: extension Client.ActorExtTest : @preconcurrency A.Q
+// CHECK: extension Client::ActorExtTest : @preconcurrency A::Q
 extension ActorExtTest : @preconcurrency Q {
   public var x: Int { 42 }
 }
@@ -80,12 +80,12 @@ extension ActorExtTest : @preconcurrency Q {
 public struct TestConditional<T> {}
 
 // CHECK-NOT: #if {{.*}} $DynamicActorIsolation
-// CHECK: extension Client.TestConditional : @preconcurrency A.WithAssoc where T == Swift.Int {
-// CHECK-NEXT:  @_Concurrency.MainActor public func test() -> T
+// CHECK: extension Client::TestConditional : @preconcurrency A::WithAssoc where T == Swift::Int {
+// CHECK-NEXT:  @_Concurrency::MainActor public func test() -> T
 // CHECK-NEXT: }
 extension TestConditional : @preconcurrency WithAssoc where T == Int {
   @MainActor public func test() -> T { 42 } // Ok
 }
 
 // CHECK-NOT: #if {{.*}} $DynamicActorIsolation
-// CHECK: extension Client.GlobalActorTest : Swift.Sendable {}
+// CHECK: extension Client::GlobalActorTest : Swift::Sendable {}

--- a/test/ModuleInterface/preconcurrency_imports.swift
+++ b/test/ModuleInterface/preconcurrency_imports.swift
@@ -10,7 +10,7 @@
 
 // CHECK: {{^}}@preconcurrency import OtherLib
 // CHECK: {{^}}@preconcurrency import PreconcurrencyLib
-// CHECK: public struct Struct1 : Swift.Sendable
+// CHECK: public struct Struct1 : Swift::Sendable
 // CHECK: public struct Struct2
 
 //--- PreconcurrencyLib.swift

--- a/test/ModuleInterface/preserve-type-repr.swift
+++ b/test/ModuleInterface/preserve-type-repr.swift
@@ -5,7 +5,7 @@
 // RUN: %target-swift-typecheck-module-from-interface(%t/External.swiftinterface) -module-name External
 
 // -- Check output with -module-interface-preserve-types-as-written.
-// RUN: %target-swift-emit-module-interface(%t/Preserve.swiftinterface) %s -module-name PreferTypeRepr -module-interface-preserve-types-as-written -I %t
+// RUN: %target-swift-emit-module-interface(%t/Preserve.swiftinterface) %s -module-name PreferTypeRepr -disable-module-selectors-in-module-interface -module-interface-preserve-types-as-written -I %t
 // RUN: %target-swift-typecheck-module-from-interface(%t/Preserve.swiftinterface) -module-name PreferTypeRepr -I %t
 // RUN: %FileCheck --check-prefixes=CHECK,PREFER %s < %t/Preserve.swiftinterface
 
@@ -26,13 +26,13 @@ public struct GenericToy<T> {
 import External
 
 // PREFER: extension Toy
-// DONTPREFER: extension External.Toy
+// DONTPREFER: extension External::Toy
 extension Toy {
     public static var new: Toy { Toy() }
 }
 
 // PREFER: extension GenericToy {
-// DONTPREFER: extension External.GenericToy {
+// DONTPREFER: extension External::GenericToy {
 extension GenericToy {
     public static var new: GenericToy<T> { GenericToy() }
 }
@@ -40,14 +40,15 @@ extension GenericToy {
 public protocol Pet {}
 
 // PREFER: public struct Parrot : Pet {
-// DONTPREFER: public struct Parrot : PreferTypeRepr.Pet {
+// DONTPREFER: public struct Parrot : PreferTypeRepr::Pet {
 // CHECK-NEXT: }
 public struct Parrot: Pet {}
 
-// CHECK: public struct Ex<T> where T : PreferTypeRepr.Pet {
+// PREFER: public struct Ex<T> where T : PreferTypeRepr.Pet {
+// DONTPREFER: public struct Ex<T> where T : PreferTypeRepr::Pet {
 public struct Ex<T: Pet> {
   // PREFER: public var hasCeasedToBe: Bool {
-  // DONTPREFER: public var hasCeasedToBe: Swift.Bool {
+  // DONTPREFER: public var hasCeasedToBe: Swift::Bool {
   // CHECK: get
   // CHECK-NEXT: }
   public var hasCeasedToBe: Bool { false }
@@ -60,14 +61,14 @@ public struct Ex<T: Pet> {
 public struct My<T> {}
 
 // PREFER: extension My where T : PreferTypeRepr.Pet
-// DONTPREFER: extension PreferTypeRepr.My where T : PreferTypeRepr.Pet
+// DONTPREFER: extension PreferTypeRepr::My where T : PreferTypeRepr::Pet
 extension My where T: Pet {
   // PREFER: public func isPushingUpDaisies() -> String
-  // DONTPREFER: public func isPushingUpDaisies() -> Swift.String
+  // DONTPREFER: public func isPushingUpDaisies() -> Swift::String
   public func isPushingUpDaisies() -> String { "" }
 }
 
 // PREFER: public func isNoMore(_ pet: Ex<Parrot>) -> Bool
-// DONTPREFER: public func isNoMore(_ pet: PreferTypeRepr.Ex<PreferTypeRepr.Parrot>) -> Swift.Bool
+// DONTPREFER: public func isNoMore(_ pet: PreferTypeRepr::Ex<PreferTypeRepr::Parrot>) -> Swift::Bool
 public func isNoMore(_ pet: Ex<Parrot>) -> Bool {}
 #endif

--- a/test/ModuleInterface/private-stored-members.swift
+++ b/test/ModuleInterface/private-stored-members.swift
@@ -15,34 +15,34 @@
 
 // COMMON: struct MyStruct {{{$}}
 public struct MyStruct {
-// COMMON-NEXT: var publicVar: Swift.Int64{{$}}
+// COMMON-NEXT: var publicVar: Swift::Int64{{$}}
   public var publicVar: Int64
 
-// COMMON-NEXT: let publicLet: Swift.Bool{{$}}
+// COMMON-NEXT: let publicLet: Swift::Bool{{$}}
   public let publicLet: Bool
 
-// CHECK-NEXT: internal var internalVar: Swift.Int64{{$}}
-// RESILIENT-NOT: internal var internalVar: Swift.Int64{{$}}
+// CHECK-NEXT: internal var internalVar: Swift::Int64{{$}}
+// RESILIENT-NOT: internal var internalVar: Swift::Int64{{$}}
   var internalVar: Int64
 
-// CHECK-NEXT: internal let internalLet: Swift.Bool{{$}}
-// RESILIENT-NOT: internal let internalLet: Swift.Bool{{$}}
+// CHECK-NEXT: internal let internalLet: Swift::Bool{{$}}
+// RESILIENT-NOT: internal let internalLet: Swift::Bool{{$}}
   let internalLet: Bool
 
 // COMMON-NEXT: @usableFromInline
-// COMMON-NEXT: internal var ufiVar: Swift.Int64{{$}}
+// COMMON-NEXT: internal var ufiVar: Swift::Int64{{$}}
   @usableFromInline var ufiVar: Int64
 
 // COMMON-NEXT: @usableFromInline
-// COMMON-NEXT: internal let ufiLet: Swift.Bool{{$}}
+// COMMON-NEXT: internal let ufiLet: Swift::Bool{{$}}
   @usableFromInline let ufiLet: Bool
 
-// CHECK-NEXT: private var privateVar: Swift.Int64{{$}}
-// RESILIENT-NOT: private var privateVar: Swift.Int64{{$}}
+// CHECK-NEXT: private var privateVar: Swift::Int64{{$}}
+// RESILIENT-NOT: private var privateVar: Swift::Int64{{$}}
   private var privateVar: Int64
 
-// CHECK-NEXT: private let privateLet: Swift.Bool{{$}}
-// RESILIENT-NOT: private let privateLet: Swift.Bool{{$}}
+// CHECK-NEXT: private let privateLet: Swift::Bool{{$}}
+// RESILIENT-NOT: private let privateLet: Swift::Bool{{$}}
   private let privateLet: Bool
 
 // CHECK-NOT: private var
@@ -55,7 +55,7 @@ public struct MyStruct {
 // RESILIENT-NOT: private static var
   private static var staticPrivateVar: Int64 = 0
 
-// COMMON: var publicEndVar: Swift.Int64{{$}}
+// COMMON: var publicEndVar: Swift::Int64{{$}}
   public var publicEndVar: Int64 = 0
 
 // COMMON: }{{$}}
@@ -63,34 +63,34 @@ public struct MyStruct {
 
 // COMMON: class MyClass {{{$}}
 public class MyClass {
-// COMMON-NEXT: var publicVar: Swift.Int64{{$}}
+// COMMON-NEXT: var publicVar: Swift::Int64{{$}}
   public var publicVar: Int64 = 0
 
-// COMMON-NEXT: let publicLet: Swift.Bool{{$}}
+// COMMON-NEXT: let publicLet: Swift::Bool{{$}}
   public let publicLet: Bool = true
 
-// CHECK-NEXT: internal var internalVar: Swift.Int64{{$}}
-// RESILIENT-NOT: internal var internalVar: Swift.Int64{{$}}
+// CHECK-NEXT: internal var internalVar: Swift::Int64{{$}}
+// RESILIENT-NOT: internal var internalVar: Swift::Int64{{$}}
   var internalVar: Int64 = 0
 
-// CHECK-NEXT: internal let internalLet: Swift.Bool{{$}}
-// RESILIENT-NOT: internal let internalLet: Swift.Bool{{$}}
+// CHECK-NEXT: internal let internalLet: Swift::Bool{{$}}
+// RESILIENT-NOT: internal let internalLet: Swift::Bool{{$}}
   let internalLet: Bool = true
 
 // COMMON-NEXT: @usableFromInline
-// COMMON-NEXT: internal var ufiVar: Swift.Int64{{$}}
+// COMMON-NEXT: internal var ufiVar: Swift::Int64{{$}}
   @usableFromInline var ufiVar: Int64 = 0
 
 // COMMON-NEXT: @usableFromInline
-// COMMON-NEXT: internal let ufiLet: Swift.Bool{{$}}
+// COMMON-NEXT: internal let ufiLet: Swift::Bool{{$}}
   @usableFromInline let ufiLet: Bool = true
 
-// CHECK-NEXT: private var privateVar: Swift.Int64{{$}}
-// RESILIENT-NOT: private var privateVar: Swift.Int64{{$}}
+// CHECK-NEXT: private var privateVar: Swift::Int64{{$}}
+// RESILIENT-NOT: private var privateVar: Swift::Int64{{$}}
   private var privateVar: Int64 = 0
 
-// CHECK-NEXT: private let privateLet: Swift.Bool{{$}}
-// RESILIENT-NOT: private let privateLet: Swift.Bool{{$}}
+// CHECK-NEXT: private let privateLet: Swift::Bool{{$}}
+// RESILIENT-NOT: private let privateLet: Swift::Bool{{$}}
   private let privateLet: Bool = true
 
 // CHECK-NOT: private var
@@ -103,7 +103,7 @@ public class MyClass {
 // RESILIENT-NOT: private static var
   private static var staticPrivateVar: Int64 = 0
 
-// COMMON: var publicEndVar: Swift.Int64{{$}}
+// COMMON: var publicEndVar: Swift::Int64{{$}}
   public var publicEndVar: Int64 = 0
 
   public init() {}

--- a/test/ModuleInterface/property_wrapper_availability.swift
+++ b/test/ModuleInterface/property_wrapper_availability.swift
@@ -29,7 +29,7 @@ public struct UnavailableWrapper<T> {
 // CHECK: public struct HasWrappers {
 public struct HasWrappers {
   // CHECK: @available(macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4, *)
-  // CHECK-NEXT: @Library.ConditionallyAvailableWrapper<Swift.Int> public var x: Swift.Int {
+  // CHECK-NEXT: @Library::ConditionallyAvailableWrapper<Swift::Int> public var x: Swift::Int {
   // CHECK-NEXT:   get
   // CHECK-NEXT:   @available(iOS 13.4, tvOS 13.4, watchOS 6.2, macOS 10.15.4, *)
   // CHECK-NEXT:   set
@@ -50,7 +50,7 @@ public struct HasWrappers {
 @available(watchOS, unavailable)
 @available(tvOS, unavailable)
 public struct UnavailableHasWrappers {
-  // CHECK-LABEL:   @Library.UnavailableWrapper<Swift.Int> public var x: Swift.Int {
+  // CHECK-LABEL:   @Library::UnavailableWrapper<Swift::Int> public var x: Swift::Int {
   // CHECK-NEXT:      get
   // CHECK-NEXT:      @available(iOS, unavailable)
   // CHECK-NEXT:      @available(tvOS, unavailable)

--- a/test/ModuleInterface/property_wrappers.swift
+++ b/test/ModuleInterface/property_wrappers.swift
@@ -62,72 +62,72 @@ public struct ProjectedValueWrapper<T> {
 
 // CHECK: public struct HasWrappers {
 public struct HasWrappers {
-  // CHECK: @TestResilient.Wrapper<Swift.Int> public var x: {{(Swift.)?}}Int {
+  // CHECK: @TestResilient::Wrapper<Swift::Int> public var x: {{(Swift::)?}}Int {
   // CHECK-NEXT: get
   // CHECK-NEXT: set
   // CHECK-NEXT: _modify  
   // CHECK-NEXT: }  
   @Wrapper public var x: Int
 
-  // CHECK: @TestResilient.WrapperWithInitialValue<Swift.Int> @_projectedValueProperty($y) public var y: Swift.Int {
+  // CHECK: @TestResilient::WrapperWithInitialValue<Swift::Int> @_projectedValueProperty($y) public var y: Swift::Int {
   // CHECK-NEXT: get
   // CHECK-NEXT: }  
   @WrapperWithInitialValue public private(set) var y = 17
 
-  // CHECK: public var $y: TestResilient.Wrapper<{{(Swift.)?}}Int> {
+  // CHECK: public var $y: TestResilient::Wrapper<{{(Swift::)?}}Int> {
   // CHECK-NEXT: get
   // CHECK-NEXT: }  
 
-  // CHECK: @TestResilient.HasTwoTypeParameters<Swift.Int, Swift.String> public var w1: Swift.Int {
+  // CHECK: @TestResilient::HasTwoTypeParameters<Swift::Int, Swift::String> public var w1: Swift::Int {
   // CHECK-NEXT:   get
   // CHECK-NEXT:   set
   // CHECK-NEXT:   _modify
   // CHECK-NEXT: }
   @HasTwoTypeParameters(wrappedValue: 0, "other") public var w1: Int
 
-  // CHECK: @TestResilient.HasTwoTypeParameters<Swift.Int, Swift.String> public var w2: Swift.Int {
+  // CHECK: @TestResilient::HasTwoTypeParameters<Swift::Int, Swift::String> public var w2: Swift::Int {
   // CHECK-NEXT:   get
   // CHECK-NEXT:   set
   // CHECK-NEXT:   _modify
   // CHECK-NEXT: }
   @HasTwoTypeParameters("other") public var w2: Int = 0
 
-  // CHECK: @TestResilient.HasTwoTypeParameters<TestResilient.HasTwoTypeParameters<Swift.Int, Swift.Double>, Swift.String> @TestResilient.HasTwoTypeParameters public var w3: Swift.Int {
+  // CHECK: @TestResilient::HasTwoTypeParameters<TestResilient::HasTwoTypeParameters<Swift::Int, Swift::Double>, Swift::String> @TestResilient::HasTwoTypeParameters public var w3: Swift::Int {
   // CHECK-NEXT:   get
   // CHECK-NEXT:   set
   // CHECK-NEXT:   _modify
   // CHECK-NEXT: }
   @HasTwoTypeParameters("a")  @HasTwoTypeParameters(1.0) public var w3: Int = 0
 
-  // CHECK: @TestResilient.WrapperWithInitialValue<Swift.Bool> @_projectedValueProperty($z) public var z: Swift.Bool {
+  // CHECK: @TestResilient::WrapperWithInitialValue<Swift::Bool> @_projectedValueProperty($z) public var z: Swift::Bool {
   // CHECK-NEXT: get
   // CHECK-NEXT: set
   // CHECK-NEXT: _modify
   // CHECK-NEXT: }  
   @WrapperWithInitialValue(alternate: false) public var z
 
-  // CHECK: @TestResilient.HasTwoTypeParameters<TestResilient.Wrapper<Swift.Int>, Swift.String> @TestResilient.Wrapper public var composed: Swift.Int {
+  // CHECK: @TestResilient::HasTwoTypeParameters<TestResilient::Wrapper<Swift::Int>, Swift::String> @TestResilient::Wrapper public var composed: Swift::Int {
   // CHECK-NEXT:   get
   // CHECK-NEXT:   set
   // CHECK-NEXT:   _modify
   // CHECK-NEXT: }
   @HasTwoTypeParameters("other") @Wrapper public var composed: Int = 42
   
-  // CHECK: public func hasParameterWithImplementationWrapper(x: Swift.Int)
+  // CHECK: public func hasParameterWithImplementationWrapper(x: Swift::Int)
   public func hasParameterWithImplementationWrapper(@Wrapper x: Int) { }
 
-  // CHECK: public func hasParameterWithImplementationWrapperComposed(x: Swift.Int)
+  // CHECK: public func hasParameterWithImplementationWrapperComposed(x: Swift::Int)
   public func hasParameterWithImplementationWrapperComposed(@Wrapper @ProjectedValueWrapper x: Int) { }
 
-  // CHECK: @inlinable public func hasParameterWithImplementationWrapperInlinable(@TestResilient.Wrapper x: Swift.Int)
+  // CHECK: @inlinable public func hasParameterWithImplementationWrapperInlinable(@TestResilient::Wrapper x: Swift::Int)
   @inlinable public func hasParameterWithImplementationWrapperInlinable(@Wrapper x: Int) { }
 
-  // CHECK: @_alwaysEmitIntoClient public func hasParameterWithImplementationWrapperAEIC(@TestResilient.Wrapper x: Swift.Int)
+  // CHECK: @_alwaysEmitIntoClient public func hasParameterWithImplementationWrapperAEIC(@TestResilient::Wrapper x: Swift::Int)
   @_alwaysEmitIntoClient public func hasParameterWithImplementationWrapperAEIC(@Wrapper x: Int) { }
 
-  // CHECK: public func hasParameterWithAPIWrapper(@TestResilient.ProjectedValueWrapper<Swift.Int> x: Swift.Int)
+  // CHECK: public func hasParameterWithAPIWrapper(@TestResilient::ProjectedValueWrapper<Swift::Int> x: Swift::Int)
   public func hasParameterWithAPIWrapper(@ProjectedValueWrapper x: Int) { }
 
-  // CHECK: public func hasParameterWithAPIWrapperComposed(@TestResilient.ProjectedValueWrapper<TestResilient.Wrapper<Swift.Int>> @TestResilient.Wrapper x: Swift.Int)
+  // CHECK: public func hasParameterWithAPIWrapperComposed(@TestResilient::ProjectedValueWrapper<TestResilient::Wrapper<Swift::Int>> @TestResilient::Wrapper x: Swift::Int)
   public func hasParameterWithAPIWrapperComposed(@ProjectedValueWrapper @Wrapper x: Int) { }
 }

--- a/test/ModuleInterface/protocol-with-self-constraint.swift
+++ b/test/ModuleInterface/protocol-with-self-constraint.swift
@@ -18,9 +18,9 @@ extension P {
   public static func blah4<T>(_: Self.Nested) where Self : Foo<T> {}
 }
 
-// CHECK-LABEL: extension Test.P {
-// CHECK-NEXT:    public static func blah1<T>(_: Self) where Self == Test.Foo<T>
-// CHECK-NEXT:    public static func blah2<T>(_: Test.Foo<T>.Nested) where Self == Test.Foo<T>
-// CHECK-NEXT:    public static func blah3<T>(_: Self) where Self : Test.Foo<T>
-// CHECK-NEXT:    public static func blah4<T>(_: Test.Foo<T>.Nested) where Self : Test.Foo<T>
+// CHECK-LABEL: extension Test::P {
+// CHECK-NEXT:    public static func blah1<T>(_: Self) where Self == Test::Foo<T>
+// CHECK-NEXT:    public static func blah2<T>(_: Test::Foo<T>.Test::Nested) where Self == Test::Foo<T>
+// CHECK-NEXT:    public static func blah3<T>(_: Self) where Self : Test::Foo<T>
+// CHECK-NEXT:    public static func blah4<T>(_: Test::Foo<T>.Test::Nested) where Self : Test::Foo<T>
 // CHECK-NEXT:  }

--- a/test/ModuleInterface/protocol_extension_type_witness.swift
+++ b/test/ModuleInterface/protocol_extension_type_witness.swift
@@ -25,10 +25,10 @@ public struct S<B>: P {
   public func d(_: String) {}
 }
 
-// CHECK-LABEL: public struct S<B> : protocol_extension_type_witness.P {
+// CHECK-LABEL: public struct S<B> : protocol_extension_type_witness::P {
 // CHECK-NEXT:    public func b(_: B)
-// CHECK-NEXT:    public func d(_: Swift.String)
+// CHECK-NEXT:    public func d(_: Swift::String)
 // CHECK-NEXT:    public typealias A = B
-// CHECK-NEXT:    public typealias C = Swift.String
-// CHECK-NEXT:    public typealias D = Swift.String
+// CHECK-NEXT:    public typealias C = Swift::String
+// CHECK-NEXT:    public typealias D = Swift::String
 // CHECK-NEXT:  }

--- a/test/ModuleInterface/reparenting.swift
+++ b/test/ModuleInterface/reparenting.swift
@@ -14,14 +14,14 @@ public protocol Circle {
   func fill() -> Color
 }
 
-// CHECK-LABEL: public protocol Ball : Library.Circle {
-// CHECK:         associatedtype Color = Swift.Int
+// CHECK-LABEL: public protocol Ball : Library::Circle {
+// CHECK:         associatedtype Color = Swift::Int
 public protocol Ball: Circle {
   associatedtype Color = Int
   func roll()
 }
 
-// CHECK-LABEL: extension Library.Ball : @reparented Library.Circle where Self.Color == Swift.Int {
+// CHECK-LABEL: extension Library::Ball : @reparented Library::Circle where Self.Color == Swift::Int {
 // CHECK:         public func fill() -> Self.Color
 // CHECK-NOT:     typealias
 extension Ball: @reparented Circle where Color == Int {

--- a/test/ModuleInterface/requires-stored-property-inits-attr.swift
+++ b/test/ModuleInterface/requires-stored-property-inits-attr.swift
@@ -5,7 +5,7 @@
 // CHECK: @requires_stored_property_inits public class RequiresStoredPropertyInits
 @requires_stored_property_inits
 public class RequiresStoredPropertyInits {
-  // CHECK: final public let a: Swift.Int{{$}}
+  // CHECK: final public let a: Swift::Int{{$}}
   public let a: Int = 0
 
   public init() {}

--- a/test/ModuleInterface/resolve-imports.swift
+++ b/test/ModuleInterface/resolve-imports.swift
@@ -6,7 +6,7 @@
 
 // CHECK: import Swift
 
-// CHECK: public func f() -> Swift.Int
+// CHECK: public func f() -> Swift::Int
 public func f() -> Int {}
 
 // Deliberate semantic errors to ensure private and internal declarations don't

--- a/test/ModuleInterface/result_builders.swift
+++ b/test/ModuleInterface/result_builders.swift
@@ -40,13 +40,13 @@ public struct TupleBuilder {
   public static func buildIf<T>(_ value: T?) -> T? { return value }
 }
 
-// CHECK-LABEL: public func tuplify<T>(_ cond: Swift.Bool, @ResultBuilders.TupleBuilder body: (Swift.Bool) -> T)
+// CHECK-LABEL: public func tuplify<T>(_ cond: Swift::Bool, @ResultBuilders::TupleBuilder body: (Swift::Bool) -> T)
 public func tuplify<T>(_ cond: Bool, @TupleBuilder body: (Bool) -> T) {
   print(body(cond))
 }
 
 public struct UsesBuilderProperty {
-  // CHECK: public var myVar: (Swift.String, Swift.String) {
+  // CHECK: public var myVar: (Swift::String, Swift::String) {
   // CHECK-NEXT: get
   // CHECK-NEXT: }
   @TupleBuilder public var myVar: (String, String) {
@@ -54,16 +54,16 @@ public struct UsesBuilderProperty {
     "goodbye"
   }
 
-  // CHECK: public func myFunc(@ResultBuilders.TupleBuilder fn: () -> ())
+  // CHECK: public func myFunc(@ResultBuilders::TupleBuilder fn: () -> ())
   public func myFunc(@TupleBuilder fn: () -> ()) {}
 }
 
 public protocol ProtocolWithBuilderProperty {
   associatedtype Assoc
 
-  // CHECK: @ResultBuilders.TupleBuilder var myVar: Self.Assoc { get }
+  // CHECK: @ResultBuilders::TupleBuilder var myVar: Self.Assoc { get }
   @TupleBuilder var myVar: Assoc { get }
 
-  // CHECK: @ResultBuilders.TupleBuilder func myFunc<T1, T2>(_ t1: T1, _ t2: T2) -> (T1, T2)
+  // CHECK: @ResultBuilders::TupleBuilder func myFunc<T1, T2>(_ t1: T1, _ t2: T2) -> (T1, T2)
   @TupleBuilder func myFunc<T1, T2>(_ t1: T1, _ t2: T2) -> (T1, T2)
 }

--- a/test/ModuleInterface/retroactive-conformances.swift
+++ b/test/ModuleInterface/retroactive-conformances.swift
@@ -2,11 +2,11 @@
 // RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name Test
 // RUN: %FileCheck %s < %t.swiftinterface
 
-// CHECK: extension Swift.Int : @retroactive Swift.Identifiable {
-// CHECK:   public var id: Swift.Int {
+// CHECK: extension Swift::Int : @retroactive Swift::Identifiable {
+// CHECK:   public var id: Swift::Int {
 // CHECK:     get
 // CHECK:   }
-// CHECK:   public typealias ID = Swift.Int
+// CHECK:   public typealias ID = Swift::Int
 // CHECK: }
 extension Int: @retroactive Identifiable {
     public var id: Int { self }

--- a/test/ModuleInterface/sendable_availability.swift
+++ b/test/ModuleInterface/sendable_availability.swift
@@ -28,18 +28,18 @@ extension X {
 
 // CHECK: @available(macOS, unavailable, introduced: 11.0)
 // CHECK-NEXT: @available(*, unavailable)
-// CHECK-NEXT: extension Library.X{{( )?}}: @unchecked Swift.Sendable {
+// CHECK-NEXT: extension Library::X{{( )?}}: @unchecked Swift::Sendable {
 
 // CHECK: @available(*, unavailable)
-// CHECK-NEXT: extension Library.Y{{( )?}}: @unchecked Swift.Sendable {
+// CHECK-NEXT: extension Library::Y{{( )?}}: @unchecked Swift::Sendable {
 
 // CHECK: @available(macOS, unavailable, introduced: 12.0)
 // CHECK-NEXT: @available(*, unavailable)
-// CHECK-NEXT: extension Library.X.A{{( )?}}: @unchecked Swift.Sendable {
+// CHECK-NEXT: extension Library::X.Library::A{{( )?}}: @unchecked Swift::Sendable {
 
 // CHECK: @available(macOS, unavailable, introduced: 11.0)
 // CHECK-NEXT: @available(*, unavailable)
-// CHECK-NEXT: extension Library.X.B{{( )?}}: @unchecked Swift.Sendable {
+// CHECK-NEXT: extension Library::X.Library::B{{( )?}}: @unchecked Swift::Sendable {
 
 // RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -target %target-cpu-apple-macosx12.0 -DLIBRARY -module-name Library -module-interface-preserve-types-as-written
 // RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -module-name Library

--- a/test/ModuleInterface/skip-override-keyword.swift
+++ b/test/ModuleInterface/skip-override-keyword.swift
@@ -21,15 +21,15 @@ public class BaseClass {
   @usableFromInline func doSomethingUsableFromInline() {}
 }
 
-// CHECK: @_inheritsConvenienceInitializers public class DerivedClass : {{Foo|FooWithTesting}}.BaseClass
+// CHECK: @_inheritsConvenienceInitializers public class DerivedClass : {{Foo|FooWithTesting}}::BaseClass
 public class DerivedClass: BaseClass {
   // CHECK: public init()
   public override init() { super.init() }
-  // CHECK: public var property: Swift.Int
+  // CHECK: public var property: Swift::Int
   public override var property : Int { return 0 }
   // CHECK: public func doSomething()
   public override func doSomething() { }
-  // CHECK: public subscript(index: Swift.Int) -> Swift.Int
+  // CHECK: public subscript(index: Swift::Int) -> Swift::Int
   public override subscript(index: Int) -> Int { get {return 0} set(newValue) {} }
   // CHECK: @inlinable override public func doSomethingInline() { super.doSomethingInline() }
   @inlinable public override func doSomethingInline() { super.doSomethingInline() }

--- a/test/ModuleInterface/skip-override-spi.swift
+++ b/test/ModuleInterface/skip-override-spi.swift
@@ -9,7 +9,7 @@ public class HideyHole {
   @_spi(Private) public init() {}
 }
 
-// CHECK: @_inheritsConvenienceInitializers public class StashyCache : Foo.HideyHole
+// CHECK: @_inheritsConvenienceInitializers public class StashyCache : Foo::HideyHole
 public class StashyCache: HideyHole {
   // CHECK: public init()
 }

--- a/test/ModuleInterface/skip-redundant-conformances.swift
+++ b/test/ModuleInterface/skip-redundant-conformances.swift
@@ -5,21 +5,21 @@
 
 // CHECK: public protocol ProtocolA : AnyObject
 public protocol ProtocolA : AnyObject {}
-// CHECK: public protocol ProtocolB : Foo.ProtocolA
+// CHECK: public protocol ProtocolB : Foo::ProtocolA
 public protocol ProtocolB: ProtocolA {}
 // CHECK-NOT: ProtocolC
 protocol ProtocolC: ProtocolA {}
 
-// CHECK: @_hasMissingDesignatedInitializers public class A : Foo.ProtocolB
+// CHECK: @_hasMissingDesignatedInitializers public class A : Foo::ProtocolB
 public class A: ProtocolB {}
-// CHECK: @_inheritsConvenienceInitializers @_hasMissingDesignatedInitializers public class B : Foo.A
+// CHECK: @_inheritsConvenienceInitializers @_hasMissingDesignatedInitializers public class B : Foo::A
 public class B: A, ProtocolC {}
 
 // CHECK: @_hasMissingDesignatedInitializers public class C
 public class C {}
 extension C: ProtocolC {}
-// CHECK: @_inheritsConvenienceInitializers @_hasMissingDesignatedInitializers public class D : Foo.C
+// CHECK: @_inheritsConvenienceInitializers @_hasMissingDesignatedInitializers public class D : Foo::C
 public class D: C {}
 
-// CHECK: extension Foo.C : Foo.ProtocolA {}
-// CHECK-NOT: extension Foo.D : Foo.ProtocolA {}
+// CHECK: extension Foo::C : Foo::ProtocolA {}
+// CHECK-NOT: extension Foo::D : Foo::ProtocolA {}

--- a/test/ModuleInterface/smoke-test.swift
+++ b/test/ModuleInterface/smoke-test.swift
@@ -9,7 +9,7 @@
 // CHECK: public func verySimpleFunction(){{$}}
 public func verySimpleFunction() {}
 
-// CHECK: public func ownership(_ x: __shared Swift.AnyObject){{$}}
+// CHECK: public func ownership(_ x: __shared Swift::AnyObject){{$}}
 public func ownership(_ x: __shared AnyObject) {}
 
 // CHECK-MULTI-FILE: public func otherFileFunction(){{$}}

--- a/test/ModuleInterface/specialize-attr.swift
+++ b/test/ModuleInterface/specialize-attr.swift
@@ -3,17 +3,17 @@
 // R/UN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name Test
 // RUN: %FileCheck %s --implicit-check-not "\$SpecializeAttributeWithAvailability" < %t.swiftinterface
 
-// CHECK: @_specialize(exported: false, kind: full, where T == Swift.Double)
+// CHECK: @_specialize(exported: false, kind: full, where T == Swift::Double)
 // CHECK: public func specialize<T>(_ t: T)
 @_specialize(exported: false, where T == Double)
 public func specialize<T>(_ t: T) {}
 
-// CHECK: @_specialize(exported: true, kind: full, availability: macOS, introduced: 12; where T == Swift.Int)
+// CHECK: @_specialize(exported: true, kind: full, availability: macOS, introduced: 12; where T == Swift::Int)
 // CHECK: public func specializeWithAvailability<T>(_ t: T)
 @_specialize(exported: true, availability: macOS 12, *; where T == Int)
 public func specializeWithAvailability<T>(_ t: T) {}
 
-// CHECK: @_specialize(exported: true, kind: full, availability: macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *; where T == Swift.Int)
+// CHECK: @_specialize(exported: true, kind: full, availability: macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *; where T == Swift::Int)
 // CHECK: public func specializeWithStdlibAvailability<T>(value: T) async
 @_specialize(exported: true, availability: SwiftStdlib 5.1, *; where T == Int)
 public func specializeWithStdlibAvailability<T>(value: T) async {}

--- a/test/ModuleInterface/specialized-extension.swift
+++ b/test/ModuleInterface/specialized-extension.swift
@@ -10,33 +10,33 @@ public struct Tree<T> {
   }
 }
 
-// CHECK: extension Test.Tree.Branch.Nest.Egg {
+// CHECK: extension Test::Tree.Test::Branch.Test::Nest.Test::Egg {
 // CHECK:   public static func tweet()
 // CHECK: }
 extension Tree.Branch.Nest.Egg { public static func tweet() {} }
 
-// CHECK: extension Test.Tree.Branch.Nest.Egg where T == Swift.Int {
+// CHECK: extension Test::Tree.Test::Branch.Test::Nest.Test::Egg where T == Swift::Int {
 // CHECK:   public static func twoot()
 // CHECK: }
 extension Tree<Int>.Branch.Nest.Egg { public static func twoot() {} }
 
-// CHECK: extension Test.Tree.Branch.Nest.Egg where T == Swift.Int, B == Swift.String {
+// CHECK: extension Test::Tree.Test::Branch.Test::Nest.Test::Egg where T == Swift::Int, B == Swift::String {
 // CHECK:   public static func twote()
 // CHECK: }
 extension Tree<Int>.Branch<String>.Nest.Egg { public static func twote() {} }
 
-// CHECK: extension Test.Tree.Branch.Nest.Egg where T == Swift.Int, B == Swift.String, N == () {
+// CHECK: extension Test::Tree.Test::Branch.Test::Nest.Test::Egg where T == Swift::Int, B == Swift::String, N == () {
 // CHECK:   public static func twite()
 // CHECK: }
 extension Tree<Int>.Branch<String>.Nest<Void>.Egg { public static func twite() {} }
 
-// CHECK: extension Swift.Array where Element == Swift.String {
-// CHECK:   public func rejoinder() -> Swift.String
+// CHECK: extension Swift::Array where Element == Swift::String {
+// CHECK:   public func rejoinder() -> Swift::String
 // CHECK: }
 extension [String] { public func rejoinder() -> String { return self.joined() } }
 
-// CHECK: public typealias StringDict<T> = [Swift.String : T]
+// CHECK: public typealias StringDict<T> = [Swift::String : T]
 public typealias StringDict<T> = [String: T]
 
-// CHECK: extension Swift.Dictionary where Key == Swift.String, Value == Swift.Int
+// CHECK: extension Swift::Dictionary where Key == Swift::String, Value == Swift::Int
 extension StringDict<Int> { public static func mark() {} }

--- a/test/ModuleInterface/static-initialize-objc-metadata-attr.swift
+++ b/test/ModuleInterface/static-initialize-objc-metadata-attr.swift
@@ -17,7 +17,7 @@ public class Super<T>: NSObject, NSCoding {
 }
 
 // CHECK-NOT: @_staticInitializeObjCMetadata
-// CHECK: public class Sub : Module.Super<Swift.Int>
+// CHECK: public class Sub : Module::Super<Swift::Int>
 public class Sub: Super<Int> {
   required public init(coder: NSCoder) {}
   override public func encode(with: NSCoder) {}

--- a/test/ModuleInterface/stored-properties.swift
+++ b/test/ModuleInterface/stored-properties.swift
@@ -18,12 +18,12 @@
 
 // COMMON: public struct HasStoredProperties {
 public struct HasStoredProperties {
-  // COMMON: public var computedGetter: Swift.Int {
+  // COMMON: public var computedGetter: Swift::Int {
   // COMMON-NEXT: get
   // COMMON-NEXT: }
   public var computedGetter: Int { return 3 }
 
-  // COMMON: public var computedGetSet: Swift.Int {
+  // COMMON: public var computedGetSet: Swift::Int {
   // COMMON-NEXT: get
   // COMMON-NEXT: set
   // COMMON-NEXT: }
@@ -32,14 +32,14 @@ public struct HasStoredProperties {
     set {}
   }
 
-  // COMMON: public let simpleStoredImmutable: Swift.Int{{$}}
+  // COMMON: public let simpleStoredImmutable: Swift::Int{{$}}
   public let simpleStoredImmutable: Int
 
-  // COMMON: public var simpleStoredMutable: Swift.Int{{$}}
+  // COMMON: public var simpleStoredMutable: Swift::Int{{$}}
   public var simpleStoredMutable: Int
 
-  // CHECK: @_hasStorage public var storedWithObservers: Swift.Bool {
-  // RESILIENT:   {{^}}  public var storedWithObservers: Swift.Bool {
+  // CHECK: @_hasStorage public var storedWithObservers: Swift::Bool {
+  // RESILIENT:   {{^}}  public var storedWithObservers: Swift::Bool {
   // CHECK-NEXT:  {{^}}    @_transparent get
   // RESILIENT-NEXT: {{^}} get
   // COMMON-NEXT: {{^}}    set
@@ -48,18 +48,18 @@ public struct HasStoredProperties {
     willSet {}
   }
 
-  // CHECK: @_hasStorage public var storedPrivateSet: Swift.Int {
-  // RESILIENT:   {{^}}  public var storedPrivateSet: Swift.Int {
+  // CHECK: @_hasStorage public var storedPrivateSet: Swift::Int {
+  // RESILIENT:   {{^}}  public var storedPrivateSet: Swift::Int {
   // COMMON-NEXT: {{^}}    get
   // COMMON-NEXT: {{^}}  }
   public private(set) var storedPrivateSet: Int
 
-  // CHECK: private var privateVar: Swift.Bool
-  // RESILIENT-NOT: private var privateVar: Swift.Bool
+  // CHECK: private var privateVar: Swift::Bool
+  // RESILIENT-NOT: private var privateVar: Swift::Bool
   private var privateVar: Bool
 
-  // CHECK: @_hasStorage @_hasInitialValue public var storedWithObserversInitialValue: Swift.Int {
-  // RESILIENT:   {{^}}  public var storedWithObserversInitialValue: Swift.Int {
+  // CHECK: @_hasStorage @_hasInitialValue public var storedWithObserversInitialValue: Swift::Int {
+  // RESILIENT:   {{^}}  public var storedWithObserversInitialValue: Swift::Int {
   // COMMON-NEXT: {{^}}    get
   // COMMON-NEXT: {{^}}    set
   // COMMON-NEXT: {{^}}  }
@@ -82,19 +82,19 @@ public struct HasStoredProperties {
 // COMMON: @frozen public struct BagOfVariables {
 @frozen
 public struct BagOfVariables {
-  // COMMON: private let hidden: Swift.Int = 0
+  // COMMON: private let hidden: Swift::Int = 0
   private let hidden: Int = 0
 
-  // COMMON: public let a: Swift.Int = 0
+  // COMMON: public let a: Swift::Int = 0
   public let a: Int = 0
 
-  // COMMON: public let (x, y): (Swift.Int, Swift.Int) = (0, 0)
+  // COMMON: public let (x, y): (Swift::Int, Swift::Int) = (0, 0)
   public let (x, y) = (0, 0)
 
-  // COMMON: public var b: Swift.Bool = false
+  // COMMON: public var b: Swift::Bool = false
   public var b: Bool = false
 
-  // COMMON: public var c: Swift.Int = 0
+  // COMMON: public var c: Swift::Int = 0
   public var c: Int = 0
 
   // COMMON: public init()
@@ -106,10 +106,10 @@ public struct BagOfVariables {
 // COMMON: @frozen public struct HasStoredPropertiesFixedLayout {
 @frozen
 public struct HasStoredPropertiesFixedLayout {
-  // COMMON: public var simpleStoredMutable: StoredProperties.BagOfVariables
+  // COMMON: public var simpleStoredMutable: StoredProperties::BagOfVariables
   public var simpleStoredMutable: BagOfVariables
 
-  // COMMON:      {{^}} @_hasStorage public var storedWithObservers: StoredProperties.BagOfVariables {
+  // COMMON:      {{^}} @_hasStorage public var storedWithObservers: StoredProperties::BagOfVariables {
   // COMMON-NEXT: {{^}}    get
   // COMMON-NEXT: {{^}}    set
   // COMMON-NEXT: {{^}} }

--- a/test/ModuleInterface/stub-init.swift
+++ b/test/ModuleInterface/stub-init.swift
@@ -13,12 +13,12 @@ public class Derived: Base {
 }
 
 // CHECK-LABEL: public class Base {
-// CHECK-NEXT:    public init(x: Swift.Int)
+// CHECK-NEXT:    public init(x: Swift::Int)
 // CHECK-NEXT:    {{(@objc )?}}deinit
 // CHECK-NEXT: }
 
-// CHECK-LABEL: public class Derived : test.Base {
-// CHECK-NEXT:    public init(z: Swift.Int)
+// CHECK-LABEL: public class Derived : test::Base {
+// CHECK-NEXT:    public init(z: Swift::Int)
 // CHECK-NEXT:    {{(@objc )?}}deinit
 // CHECK-NEXT: }
 

--- a/test/ModuleInterface/submodule-type.swift
+++ b/test/ModuleInterface/submodule-type.swift
@@ -4,8 +4,8 @@
 
 import HasSubmodule.Submodule
 
-// CHECK: public func takesHasSubmoduleType(_ x: HasSubmodule.HasSubmoduleType)
+// CHECK: public func takesHasSubmoduleType(_ x: HasSubmodule::HasSubmoduleType)
 public func takesHasSubmoduleType(_ x: HasSubmoduleType) {}
 
-// CHECK: public func takesSubmoduleType(_ x: HasSubmodule.SubmoduleType)
+// CHECK: public func takesSubmoduleType(_ x: HasSubmodule::SubmoduleType)
 public func takesSubmoduleType(_ x: SubmoduleType) {}

--- a/test/ModuleInterface/synthesized-conformances.swift
+++ b/test/ModuleInterface/synthesized-conformances.swift
@@ -3,26 +3,26 @@
 // RUN: %FileCheck %s < %t.swiftinterface
 // RUN: %FileCheck -check-prefix=NEGATIVE %s < %t.swiftinterface
 
-// CHECK-LABEL: public enum HasRawValue : Swift.Int {
+// CHECK-LABEL: public enum HasRawValue : Swift::Int {
 public enum HasRawValue: Int {
   // CHECK-NEXT: case a, b, c
   case a, b = 5, c
-  // CHECK-DAG: public typealias RawValue = Swift.Int
-  // CHECK-DAG: public init?(rawValue: Swift.Int)
-  // CHECK-DAG: public var rawValue: Swift.Int {
+  // CHECK-DAG: public typealias RawValue = Swift::Int
+  // CHECK-DAG: public init?(rawValue: Swift::Int)
+  // CHECK-DAG: public var rawValue: Swift::Int {
   // CHECK-DAG:   get{{$}}
   // CHECK-DAG: }
 } // CHECK: {{^}$}}
 
 // CHECK-LABEL: @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
-// CHECK-NEXT: public enum HasRawValueAndAvailability : Swift.Int {
+// CHECK-NEXT: public enum HasRawValueAndAvailability : Swift::Int {
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 public enum HasRawValueAndAvailability: Int {
   // CHECK-NEXT: case a, b, c
   case a, b, c
-  // CHECK-DAG: public typealias RawValue = Swift.Int
-  // CHECK-DAG: public init?(rawValue: Swift.Int)
-  // CHECK-DAG: public var rawValue: Swift.Int {
+  // CHECK-DAG: public typealias RawValue = Swift::Int
+  // CHECK-DAG: public init?(rawValue: Swift::Int)
+  // CHECK-DAG: public var rawValue: Swift::Int {
   // CHECK-DAG:   get{{$}}
   // CHECK-DAG: }
 } // CHECK: {{^}$}}
@@ -31,16 +31,16 @@ public enum HasRawValueAndAvailability: Int {
   case a, b = 5, c
 }
 
-// CHECK-LABEL: @objc public enum ObjCEnum : Swift.Int32 {
+// CHECK-LABEL: @objc public enum ObjCEnum : Swift::Int32 {
 // CHECK-NEXT: case a, b = 5, c
-// CHECK-DAG: public typealias RawValue = Swift.Int32
-// CHECK-DAG: public init?(rawValue: Swift.Int32)
-// CHECK-DAG: public var rawValue: Swift.Int32 {
+// CHECK-DAG: public typealias RawValue = Swift::Int32
+// CHECK-DAG: public init?(rawValue: Swift::Int32)
+// CHECK-DAG: public var rawValue: Swift::Int32 {
 // CHECK-DAG:   get{{$}}
 // CHECK-DAG: }
 // CHECK: {{^}$}}
 
-// CHECK-LABEL: public enum NoRawValueWithExplicitEquatable : Swift.Equatable {
+// CHECK-LABEL: public enum NoRawValueWithExplicitEquatable : Swift::Equatable {
 public enum NoRawValueWithExplicitEquatable : Equatable {
   // CHECK-NEXT: case a, b, c
   case a, b, c
@@ -52,29 +52,29 @@ public enum NoRawValueWithExplicitHashable {
 case a, b, c
 } // CHECK: {{^}$}}
 
-// CHECK-LABEL: extension synthesized.NoRawValueWithExplicitHashable : Swift.Hashable {
+// CHECK-LABEL: extension synthesized::NoRawValueWithExplicitHashable : Swift::Hashable {
 extension NoRawValueWithExplicitHashable : Hashable {
   // CHECK-NEXT: public func foo()
   public func foo() {}
 } // CHECK: {{^}$}}
 
-// CHECK: extension synthesized.HasRawValue : Swift.Equatable {}
-// CHECK: extension synthesized.HasRawValue : Swift.Hashable {}
-// CHECK: extension synthesized.HasRawValue : Swift.RawRepresentable {}
+// CHECK: extension synthesized::HasRawValue : Swift::Equatable {}
+// CHECK: extension synthesized::HasRawValue : Swift::Hashable {}
+// CHECK: extension synthesized::HasRawValue : Swift::RawRepresentable {}
 
 // CHECK: @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
-// CHECK-NEXT: extension synthesized.HasRawValueAndAvailability : Swift.Equatable {}
+// CHECK-NEXT: extension synthesized::HasRawValueAndAvailability : Swift::Equatable {}
 // CHECK: @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
-// CHECK-NEXT: extension synthesized.HasRawValueAndAvailability : Swift.Hashable {}
+// CHECK-NEXT: extension synthesized::HasRawValueAndAvailability : Swift::Hashable {}
 // CHECK: @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
-// CHECK-NEXT: extension synthesized.HasRawValueAndAvailability : Swift.RawRepresentable {}
+// CHECK-NEXT: extension synthesized::HasRawValueAndAvailability : Swift::RawRepresentable {}
 
-// CHECK: extension synthesized.ObjCEnum : Swift.Equatable {}
-// CHECK: extension synthesized.ObjCEnum : Swift.Hashable {}
-// CHECK: extension synthesized.ObjCEnum : Swift.RawRepresentable {}
+// CHECK: extension synthesized::ObjCEnum : Swift::Equatable {}
+// CHECK: extension synthesized::ObjCEnum : Swift::Hashable {}
+// CHECK: extension synthesized::ObjCEnum : Swift::RawRepresentable {}
 
-// CHECK: extension synthesized.NoRawValueWithExplicitEquatable : Swift.Hashable {}
-// NEGATIVE-NOT: extension {{.+}}NoRawValueWithExplicitEquatable : Swift.Equatable
+// CHECK: extension synthesized::NoRawValueWithExplicitEquatable : Swift::Hashable {}
+// NEGATIVE-NOT: extension {{.+}}NoRawValueWithExplicitEquatable : Swift::Equatable
 
-// NEGATIVE-NOT: NoRawValueWithExplicitHashable : Swift.Equatable
-// NEGATIVE-NOT: NoRawValueWithExplicitHashable : Swift.Hashable {}
+// NEGATIVE-NOT: NoRawValueWithExplicitHashable : Swift::Equatable
+// NEGATIVE-NOT: NoRawValueWithExplicitHashable : Swift::Hashable {}

--- a/test/ModuleInterface/tilde_sendable.swift
+++ b/test/ModuleInterface/tilde_sendable.swift
@@ -6,7 +6,7 @@
 // REQUIRES: swift_feature_TildeSendable
 
 // CHECK: #if compiler(>=5.3) && $TildeSendable
-// CHECK: public class A : ~Swift.Sendable {
+// CHECK: public class A : ~Swift::Sendable {
 // CHECK: }
 // CHECK: #else
 // CHECK: public class A {
@@ -20,22 +20,22 @@ protocol P {
 }
 
 // CHECK: #if compiler(>=5.3) && $TildeSendable
-// CHECK: public struct S : ~Swift.Sendable {
-// CHECK:   public let x: Swift.Int
+// CHECK: public struct S : ~Swift::Sendable {
+// CHECK:   public let x: Swift::Int
 // CHECK: }
 // CHECK: #else
 // CHECK: public struct S {
-// CHECK:   public let x: Swift.Int
+// CHECK:   public let x: Swift::Int
 // CHECK: }
 // CHECK: #endif
 
-// CHECK-NOT: extension Library.S : Swift.Sendable {}
+// CHECK-NOT: extension Library::S : Swift::Sendable {}
 public struct S: P, ~Sendable {
   public let x: Int
 }
 
 // CHECK: #if compiler(>=5.3) && $TildeSendable
-// CHECK: public struct B<T> : ~Swift.Sendable {
+// CHECK: public struct B<T> : ~Swift::Sendable {
 // CHECK: }
 // CHECK: #else
 // CHECK: public struct B<T> {
@@ -44,7 +44,7 @@ public struct S: P, ~Sendable {
 public struct B<T>: ~Sendable {
 }
 
-// CHECK: extension Library.B : Swift.Sendable where T : Swift.Sendable {
+// CHECK: extension Library::B : Swift::Sendable where T : Swift::Sendable {
 // CHECK: }
 extension B: Sendable where T: Sendable {
 }

--- a/test/ModuleInterface/top-level-Type-and-Protocol.swift
+++ b/test/ModuleInterface/top-level-Type-and-Protocol.swift
@@ -12,13 +12,13 @@ public struct Type {}
 // CHECK-NEXT: }
 public protocol Protocol {}
 
-// CHECK: public func usesType(_ x: MyModule.`Type`)
+// CHECK: public func usesType(_ x: MyModule::`Type`)
 public func usesType(_ x: Type) {}
 
-// CHECK: public func genericProtocol<T>(_ x: T) where T : MyModule.`Protocol`
+// CHECK: public func genericProtocol<T>(_ x: T) where T : MyModule::`Protocol`
 public func genericProtocol<T: Protocol>(_ x: T) {}
 
-// CHECK: public func existentialProtocol(_ x: any MyModule.`Protocol`)
+// CHECK: public func existentialProtocol(_ x: any MyModule::`Protocol`)
 public func existentialProtocol(_ x: Protocol) {}
 
 // CHECK: public struct Parent {
@@ -36,11 +36,11 @@ public struct Parent {
   // CHECK-NEXT: }
 }
 
-// CHECK: public func usesNestedType(_ x: MyModule.Parent.`Type`)
+// CHECK: public func usesNestedType(_ x: MyModule::Parent.MyModule::`Type`)
 public func usesNestedType(_ x: Parent.`Type`) {}
 
-// CHECK: public func usesNestedTypeProtocol(_ x: MyModule.Parent.`Type`.`Protocol`)
+// CHECK: public func usesNestedTypeProtocol(_ x: MyModule::Parent.MyModule::`Type`.MyModule::`Protocol`)
 public func usesNestedTypeProtocol(_ x: Parent.`Type`.`Protocol`) {}
 
-// CHECK: public func usesNestedProtocol(_ x: MyModule.Parent.`Protocol`)
+// CHECK: public func usesNestedProtocol(_ x: MyModule::Parent.MyModule::`Protocol`)
 public func usesNestedProtocol(_ x: Parent.`Protocol`) {}

--- a/test/ModuleInterface/type-shadowing.swift
+++ b/test/ModuleInterface/type-shadowing.swift
@@ -23,4 +23,4 @@ extension Bakery.Cake {
 }
 #endif
 
-// CHECK: extension Bakery.Cake
+// CHECK: extension Bakery::Cake

--- a/test/ModuleInterface/typed_throws.swift
+++ b/test/ModuleInterface/typed_throws.swift
@@ -7,13 +7,13 @@ public enum MyError: Error {
   case fail
 }
 
-// CHECK: public func throwsMyError() throws(Test.MyError)
+// CHECK: public func throwsMyError() throws(Test::MyError)
 public func throwsMyError() throws(MyError) { }
 
-// CHECK: public func takesClosureThrowingMyError(_ closure: () throws(Test.MyError) -> Swift.Void)
+// CHECK: public func takesClosureThrowingMyError(_ closure: () throws(Test::MyError) -> Swift::Void)
 public func takesClosureThrowingMyError(_ closure: () throws(MyError) -> Void) {}
 
 public struct HasThrowingInit {
-  // CHECK: public init() throws(Test.MyError)
+  // CHECK: public init() throws(Test::MyError)
   public init() throws(MyError) { }
 }

--- a/test/ModuleInterface/value_generics.swift
+++ b/test/ModuleInterface/value_generics.swift
@@ -3,9 +3,9 @@
 // RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name ValueGeneric -disable-availability-checking
 // RUN: %FileCheck --implicit-check-not=ValueGenericsNameLookup %s < %t.swiftinterface
 
-// CHECK: public struct Slab<Element, let N : Swift.Int>
+// CHECK: public struct Slab<Element, let N : Swift::Int>
 public struct Slab<Element, let N: Int> {
-  // CHECK-LABEL: public var count: Swift.Int {
+  // CHECK-LABEL: public var count: Swift::Int {
   // CHECK-NEXT:    get {
   // CHECK-NEXT:      N
   // CHECK-NEXT:    }
@@ -18,13 +18,13 @@ public struct Slab<Element, let N: Int> {
   public init() {}
 }
 
-// CHECK: public func usesGenericSlab<let N : Swift.Int>(_: ValueGeneric.Slab<Swift.Int, N>)
+// CHECK: public func usesGenericSlab<let N : Swift::Int>(_: ValueGeneric::Slab<Swift::Int, N>)
 public func usesGenericSlab<let N: Int>(_: Slab<Int, N>) {}
 
-// CHECK: public func usesConcreteSlab(_: ValueGeneric.Slab<Swift.Int, 2>)
+// CHECK: public func usesConcreteSlab(_: ValueGeneric::Slab<Swift::Int, 2>)
 public func usesConcreteSlab(_: Slab<Int, 2>) {}
 
-// CHECK: public func usesNegativeSlab(_: ValueGeneric.Slab<Swift.String, -10>)
+// CHECK: public func usesNegativeSlab(_: ValueGeneric::Slab<Swift::String, -10>)
 public func usesNegativeSlab(_: Slab<String, -10>) {}
 
 @inlinable

--- a/test/ModuleInterface/var-with-init-and-accessors.swiftinterface
+++ b/test/ModuleInterface/var-with-init-and-accessors.swiftinterface
@@ -10,7 +10,7 @@
     }
 }
 // INTERFACE: @frozen public struct Struct {
-// INTERFACE-LABEL: @_hasStorage public var values: [Swift.Int] = .init() { @_accessorBlock
+// INTERFACE-LABEL: @_hasStorage public var values: [Swift::Int] = .init() { @_accessorBlock
 // INTERFACE-NEXT:     @_transparent get
 // INTERFACE-NEXT:     set
 // INTERFACE-NEXT:   }

--- a/test/ModuleInterface/variadic-opaque-result-types.swift
+++ b/test/ModuleInterface/variadic-opaque-result-types.swift
@@ -12,7 +12,7 @@ public struct I1<each T>: IteratorProtocol {
   public mutating func next() -> (some Any)? { return 3 }
 }
 
-// CHECK: public struct I1<each T> : Swift.IteratorProtocol {
+// CHECK: public struct I1<each T> : Swift::IteratorProtocol {
 // CHECK:  public mutating func next() -> (some Any)?
 // CHECK:  public typealias Element = @_opaqueReturnTypeOf("$s25VariadicOpaqueResultTypes2I1V4nextQrSgyF", 0) __<repeat each T>
 // CHECK: }
@@ -24,8 +24,8 @@ public struct S1<each T>: Sequence {
   }
 }
 
-// CHECK: public struct S1<each T> : Swift.Sequence {
-// CHECK:   public func makeIterator() -> some Swift.IteratorProtocol
+// CHECK: public struct S1<each T> : Swift::Sequence {
+// CHECK:   public func makeIterator() -> some Swift::IteratorProtocol
 // CHECK:   public typealias Element = (@_opaqueReturnTypeOf("$s25VariadicOpaqueResultTypes2S1V12makeIteratorQryF", 0) __<repeat each T>).Element
 // CHECK:   public typealias Iterator = @_opaqueReturnTypeOf("$s25VariadicOpaqueResultTypes2S1V12makeIteratorQryF", 0) __<repeat each T>
 // CHECK: }
@@ -44,7 +44,7 @@ public struct Scalar<T> {
 
 
 // CHECK: public struct Scalar<T> {
-// CHECK:   public struct I2<U> : Swift.IteratorProtocol {
+// CHECK:   public struct I2<U> : Swift::IteratorProtocol {
 // CHECK:     public mutating func next() -> (some Any)?
 // CHECK:     public typealias Element = @_opaqueReturnTypeOf("$s25VariadicOpaqueResultTypes6ScalarV2I2V4nextQrSgyF", 0) __<T, U>
 // CHECK:   }
@@ -57,10 +57,10 @@ public struct S2: Sequence {
   }
 }
 
-// CHECK: public struct S2 : Swift.Sequence {
-// CHECK:   public func makeIterator() -> VariadicOpaqueResultTypes.Scalar<Swift.Int>.I2<Swift.Bool>
-// CHECK:   public typealias Element = @_opaqueReturnTypeOf("$s25VariadicOpaqueResultTypes6ScalarV2I2V4nextQrSgyF", 0) __<Swift.Int, Swift.Bool>
-// CHECK:   public typealias Iterator = VariadicOpaqueResultTypes.Scalar<Swift.Int>.I2<Swift.Bool>
+// CHECK: public struct S2 : Swift::Sequence {
+// CHECK:   public func makeIterator() -> VariadicOpaqueResultTypes::Scalar<Swift::Int>.VariadicOpaqueResultTypes::I2<Swift::Bool>
+// CHECK:   public typealias Element = @_opaqueReturnTypeOf("$s25VariadicOpaqueResultTypes6ScalarV2I2V4nextQrSgyF", 0) __<Swift::Int, Swift::Bool>
+// CHECK:   public typealias Iterator = VariadicOpaqueResultTypes::Scalar<Swift::Int>.VariadicOpaqueResultTypes::I2<Swift::Bool>
 // CHECK: }
 
 
@@ -74,7 +74,7 @@ public struct Variadic<each T> {
     public mutating func next() -> (some Any)? { return 3 }
   }
 
-  // CHECK: public struct I3<each U> : Swift.IteratorProtocol {
+  // CHECK: public struct I3<each U> : Swift::IteratorProtocol {
   // CHECK:   public mutating func next() -> (some Any)?
   // CHECK:   public typealias Element = @_opaqueReturnTypeOf("$s25VariadicOpaqueResultTypes0A0V2I3V4nextQrSgyF", 0) __<repeat each T>.__<repeat each U>
   // CHECK: }
@@ -89,8 +89,8 @@ public struct Variadic<each T> {
 
   // CHECK: public struct Middle {
   // CHECK:   public struct Inner<each U> {
-  // CHECK:     public struct I4 : Swift.IteratorProtocol {
-  // CHECK:       public mutating func next() -> (some Any)?       
+  // CHECK:     public struct I4 : Swift::IteratorProtocol {
+  // CHECK:       public mutating func next() -> (some Any)?
   // CHECK:       public typealias Element = @_opaqueReturnTypeOf("$s25VariadicOpaqueResultTypes0A0V6MiddleV5InnerV2I4V4nextQrSgyF", 0) __<repeat each T>.__<repeat each U>
   // CHECK:     }
   // CHECK:   }
@@ -98,10 +98,10 @@ public struct Variadic<each T> {
 }
 // CHECK: }
 
-// CHECK: public struct S3 : Swift.Sequence {
-// CHECK:   public func makeIterator() -> VariadicOpaqueResultTypes.Variadic<Swift.Int, Swift.Bool>.I3<Swift.Float, Swift.Double>
-// CHECK:   public typealias Element = @_opaqueReturnTypeOf("$s25VariadicOpaqueResultTypes0A0V2I3V4nextQrSgyF", 0) __<Swift.Int, Swift.Bool>.__<Swift.Float, Swift.Double>
-// CHECK:   public typealias Iterator = VariadicOpaqueResultTypes.Variadic<Swift.Int, Swift.Bool>.I3<Swift.Float, Swift.Double>
+// CHECK: public struct S3 : Swift::Sequence {
+// CHECK:   public func makeIterator() -> VariadicOpaqueResultTypes::Variadic<Swift::Int, Swift::Bool>.VariadicOpaqueResultTypes::I3<Swift::Float, Swift::Double>
+// CHECK:   public typealias Element = @_opaqueReturnTypeOf("$s25VariadicOpaqueResultTypes0A0V2I3V4nextQrSgyF", 0) __<Swift::Int, Swift::Bool>.__<Swift::Float, Swift::Double>
+// CHECK:   public typealias Iterator = VariadicOpaqueResultTypes::Variadic<Swift::Int, Swift::Bool>.VariadicOpaqueResultTypes::I3<Swift::Float, Swift::Double>
 // CHECK: }
 public struct S3: Sequence {
   public func makeIterator() -> Variadic<Int, Bool>.I3<Float, Double> {
@@ -109,10 +109,10 @@ public struct S3: Sequence {
   }
 }
 
-// CHECK: public struct S4 : Swift.Sequence {
-// CHECK:   public func makeIterator() -> VariadicOpaqueResultTypes.Variadic<Swift.Int, Swift.Bool>.Middle.Inner<Swift.Float, Swift.Double>.I4
-// CHECK:   public typealias Element = @_opaqueReturnTypeOf("$s25VariadicOpaqueResultTypes0A0V6MiddleV5InnerV2I4V4nextQrSgyF", 0) __<Swift.Int, Swift.Bool>.__<Swift.Float, Swift.Double>
-// CHECK:   public typealias Iterator = VariadicOpaqueResultTypes.Variadic<Swift.Int, Swift.Bool>.Middle.Inner<Swift.Float, Swift.Double>.I4
+// CHECK: public struct S4 : Swift::Sequence {
+// CHECK:   public func makeIterator() -> VariadicOpaqueResultTypes::Variadic<Swift::Int, Swift::Bool>.VariadicOpaqueResultTypes::Middle.VariadicOpaqueResultTypes::Inner<Swift::Float, Swift::Double>.VariadicOpaqueResultTypes::I4
+// CHECK:   public typealias Element = @_opaqueReturnTypeOf("$s25VariadicOpaqueResultTypes0A0V6MiddleV5InnerV2I4V4nextQrSgyF", 0) __<Swift::Int, Swift::Bool>.__<Swift::Float, Swift::Double>
+// CHECK:   public typealias Iterator = VariadicOpaqueResultTypes::Variadic<Swift::Int, Swift::Bool>.VariadicOpaqueResultTypes::Middle.VariadicOpaqueResultTypes::Inner<Swift::Float, Swift::Double>.VariadicOpaqueResultTypes::I4
 // CHECK: }
 public struct S4: Sequence {
   public func makeIterator() -> Variadic<Int, Bool>.Middle.Inner<Float, Double>.I4 {

--- a/test/ModuleInterface/where-clause.swift
+++ b/test/ModuleInterface/where-clause.swift
@@ -19,7 +19,7 @@ public struct Holder<Value> {
         self.value = value
     }
 
-    // CHECK-NEXT: public init<T>(_ value: T) where Value == Swift.AnyHashable, T : Swift.Hashable{{$}}
+    // CHECK-NEXT: public init<T>(_ value: T) where Value == Swift::AnyHashable, T : Swift::Hashable{{$}}
     public init<T : Hashable>(_ value: T) where Value == AnyHashable {
         self.value = value
     }
@@ -33,7 +33,7 @@ public struct Holder<Value> {
             self.fn = fn
         }
 
-        // CHECK-NEXT: func transform(_ holder: main.Holder<Value>) -> Result{{$}}
+        // CHECK-NEXT: func transform(_ holder: main::Holder<Value>) -> Result{{$}}
         public func transform(_ holder: Holder<Value>) -> Result {
             return fn(holder.value)
         }
@@ -44,9 +44,9 @@ public struct Holder<Value> {
 // CHECK-NEXT: }
 }
 
-// CHECK-NEXT: extension main.Holder.Transform where Value == Swift.Int {
+// CHECK-NEXT: extension main::Holder.main::Transform where Value == Swift::Int {
 extension Holder.Transform where Value == Int {
-    // CHECK-NEXT: public func negate(_ holder: main.Holder<Value>) -> Result{{$}}
+    // CHECK-NEXT: public func negate(_ holder: main::Holder<Value>) -> Result{{$}}
     public func negate(_ holder: Holder<Value>) -> Result {
         return transform(Holder(value: -holder.value))
     }

--- a/test/SILGen/magic_identifier_filepath.swift
+++ b/test/SILGen/magic_identifier_filepath.swift
@@ -27,4 +27,4 @@ func indirectUse() {
 }
 
 public func functionWithFilePathDefaultArgument(file: String = #filePath) {}
-// SWIFTINTERFACE: public func functionWithFilePathDefaultArgument(file: Swift.String = #filePath)
+// SWIFTINTERFACE: public func functionWithFilePathDefaultArgument(file: Swift::String = #filePath)

--- a/test/SILOptimizer/package-cmo-swiftinterface.swift
+++ b/test/SILOptimizer/package-cmo-swiftinterface.swift
@@ -61,6 +61,6 @@ public func run() -> Int {
 // CHECK-PKG-INTERFACE-NOT: @usableFromInline
 // CHECK-INTERFACE-NOT: @usableFromInline
 // CHECK-PKG-INTERFACE: package class PkgKlass {
-// CHECK-PKG-INTERFACE:   @inline(never) package func bar() -> Swift.Int
-// CHECK-PKG-INTERFACE:   @inline(never) package func foo(_ arg: Lib.PkgKlass) -> Swift.Int?
-// CHECK-INTERFACE: public func run() -> Swift.Int
+// CHECK-PKG-INTERFACE:   @inline(never) package func bar() -> Swift::Int
+// CHECK-PKG-INTERFACE:   @inline(never) package func foo(_ arg: Lib::PkgKlass) -> Swift::Int?
+// CHECK-INTERFACE: public func run() -> Swift::Int

--- a/test/SPI/implicit_spi_import.swift
+++ b/test/SPI/implicit_spi_import.swift
@@ -25,7 +25,7 @@
 // RUN: %FileCheck %s --check-prefix CHECK-A < %t/ClientA.private.swiftinterface
 // CHECK-A-NOT: @_spi(_) import Lib
 // CHECK-A: import Lib
-// CHECK-A: @_spi(_) public func useImplicit() -> Lib._Klass
+// CHECK-A: @_spi(_) public func useImplicit() -> Lib::_Klass
 
 // RUN: %target-swift-frontend -emit-module %t/ClientB.swift \
 // RUN:   -module-name ClientB -swift-version 5 -I %t \
@@ -36,8 +36,8 @@
 // CHECK-B-NOT: @_spi(_) @_spi(core) import Lib
 // CHECK-B-NOT: @_spi(core) @_spi(_) import Lib
 // CHECK-B: @_spi(core) import Lib
-// CHECK-B: @_spi(_) public func useImplicit() -> Lib._Klass
-// CHECK-B: @_spi(core) public func useSPICore() -> Lib.CoreStruct
+// CHECK-B: @_spi(_) public func useImplicit() -> Lib::_Klass
+// CHECK-B: @_spi(core) public func useSPICore() -> Lib::CoreStruct
 
 // RUN: %target-swift-frontend -emit-module %t/ClientZ.swift \
 // RUN:   -module-name ClientZ -swift-version 5 -I %t \
@@ -46,7 +46,7 @@
 // RUN:   -emit-private-module-interface-path %t/ClientZ.private.swiftinterface
 // RUN: %FileCheck %s --check-prefix CHECK-Z < %t/ClientZ.private.swiftinterface
 // CHECK-Z: @_spi(_) import Lib
-// CHECK-Z: @_spi(_) public func useImplicit() -> Lib._Klass
+// CHECK-Z: @_spi(_) public func useImplicit() -> Lib::_Klass
 
 
 //--- Lib.swift

--- a/test/SPI/private_swiftinterface.swift
+++ b/test/SPI/private_swiftinterface.swift
@@ -13,15 +13,15 @@
 
 // Test the spi parameter of the _specialize attribute in the private interface.
 // RUN: %FileCheck -check-prefix=CHECK-HELPER-PRIVATE %s < %t/SPIHelper.private.swiftinterface
-// CHECK-HELPER-PRIVATE: @_specialize(exported: true, spi: HelperSPI, kind: full, where T == Swift.Int)
+// CHECK-HELPER-PRIVATE: @_specialize(exported: true, spi: HelperSPI, kind: full, where T == Swift::Int)
 // CHECK-HELPER-PRIVATE-NEXT: public func genericFunc<T>(_ t: T)
-// CHECK-HELPER-PRIVATE:  @_specialize(exported: true, spi: HelperSPI, kind: full, where T == Swift.Int)
+// CHECK-HELPER-PRIVATE:  @_specialize(exported: true, spi: HelperSPI, kind: full, where T == Swift::Int)
 // CHECK-HELPER-PRIVATE-NEXT:  public func genericFunc2<T>(_ t: T)
-// CHECK-HELPER-PRIVATE:  @_specialize(exported: true, spi: HelperSPI, kind: full, where T == Swift.Int)
+// CHECK-HELPER-PRIVATE:  @_specialize(exported: true, spi: HelperSPI, kind: full, where T == Swift::Int)
 // CHECK-HELPER-PRIVATE-NEXT:  public func genericFunc3<T>(_ t: T)
-// CHECK-HELPER-PRIVATE:  @_specialize(exported: true, spi: HelperSPI, kind: full, where T == Swift.Int)
+// CHECK-HELPER-PRIVATE:  @_specialize(exported: true, spi: HelperSPI, kind: full, where T == Swift::Int)
 // CHECK-HELPER-PRIVATE-NEXT:  public func genericFunc4<T>(_ t: T)
-// CHECK-HELPER-PRIVATE:   @_specialize(exported: true, spi: HelperSPI, kind: full, where T == Swift.Int)
+// CHECK-HELPER-PRIVATE:   @_specialize(exported: true, spi: HelperSPI, kind: full, where T == Swift::Int)
 // CHECK-HELPER-PRIVATE-NEXT:  public func prespecializedMethod<T>(_ t: T)
 
 
@@ -65,8 +65,8 @@ public func foo() {}
 }
 
 @_spi(MySPI) public extension SPIClassLocal {
-// CHECK-PRIVATE: @_spi(MySPI) extension {{.+}}.SPIClassLocal
-// CHECK-PUBLIC-NOT: extension {{.+}}.SPIClassLocal
+// CHECK-PRIVATE: @_spi(MySPI) extension {{.+}}::SPIClassLocal
+// CHECK-PUBLIC-NOT: extension {{.+}}::SPIClassLocal
 
   @_spi(MySPI) func extensionMethod() {}
   // CHECK-PRIVATE: @_spi(MySPI) public func extensionMethod
@@ -102,8 +102,8 @@ private class PrivateClassLocal {}
 // CHECK-PUBLIC-NOT: useOfSPITypeOk
 
 @_spi(LocalSPI) extension SPIClass {
-  // CHECK-PRIVATE: @_spi(LocalSPI) extension SPIHelper.SPIClass
-  // CHECK-PUBLIC-NOT: SPIHelper.SPIClass
+  // CHECK-PRIVATE: @_spi(LocalSPI) extension SPIHelper::SPIClass
+  // CHECK-PUBLIC-NOT: SPIHelper::SPIClass
 
   @_spi(LocalSPI) public func extensionSPIMethod() {}
   // CHECK-PRIVATE: @_spi(LocalSPI) public func extensionSPIMethod()
@@ -140,28 +140,28 @@ public class SomeClass {
 
 public struct PublicStruct {
   @_spi(S) public var spiVar: SomeClass
-  // CHECK-PRIVATE: @_spi(S) public var spiVar: {{.*}}.SomeClass
+  // CHECK-PRIVATE: @_spi(S) public var spiVar: {{.*}}::SomeClass
   // CHECK-PUBLIC-NOT: spiVar
 
   public var publicVarWithSPISet: SomeClass {
     get { SomeClass() }
     @_spi(S) set {}
   }
-  // CHECK-PRIVATE: public var publicVarWithSPISet: {{.*}}.SomeClass {
+  // CHECK-PRIVATE: public var publicVarWithSPISet: {{.*}}::SomeClass {
   // CHECK-PRIVATE-NEXT:   get
   // CHECK-PRIVATE-NEXT:   @_spi(S) set
   // CHECK-PRIVATE-NEXT: }
-  // CHECK-PUBLIC: public var publicVarWithSPISet: {{.*}}.SomeClass {
+  // CHECK-PUBLIC: public var publicVarWithSPISet: {{.*}}::SomeClass {
   // CHECK-PUBLIC-NEXT:   get
   // CHECK-PUBLIC-NEXT: }
 
   @_spi(S) @Wrapper public var spiWrappedSimple: SomeClass
-  // CHECK-PRIVATE: @_spi(S) @{{.*}}.Wrapper public var spiWrappedSimple: {{.*}}.SomeClass
+  // CHECK-PRIVATE: @_spi(S) @{{.*}}::Wrapper public var spiWrappedSimple: {{.*}}::SomeClass
   // CHECK-PUBLIC-NOT: spiWrappedSimple
 
   @_spi(S) @WrapperWithInitialValue public var spiWrappedDefault: SomeClass
-  // CHECK-PRIVATE: @_spi(S) @{{.*}}.WrapperWithInitialValue @_projectedValueProperty($spiWrappedDefault) public var spiWrappedDefault: {{.*}}.SomeClass
-  // CHECK-PRIVATE: @_spi(S) public var $spiWrappedDefault: {{.*}}.Wrapper<{{.*}}.SomeClass>
+  // CHECK-PRIVATE: @_spi(S) @{{.*}}::WrapperWithInitialValue @_projectedValueProperty($spiWrappedDefault) public var spiWrappedDefault: {{.*}}::SomeClass
+  // CHECK-PRIVATE: @_spi(S) public var $spiWrappedDefault: {{.*}}::Wrapper<{{.*}}::SomeClass>
   // CHECK-PUBLIC-NOT: spiWrappedDefault
 }
 
@@ -189,7 +189,7 @@ public enum PublicEnum {
   // CHECK-PUBLIC-NOT: spiCaseB
 
   @_spi(S) case spiCaseWithPayload(_ c: SomeClass)
-  // CHECK-PRIVATE: @_spi(S) case spiCaseWithPayload(_: {{.*}}.SomeClass)
+  // CHECK-PRIVATE: @_spi(S) case spiCaseWithPayload(_: {{.*}}::SomeClass)
   // CHECK-PUBLIC-NOT: spiCaseWithPayload
 }
 
@@ -218,7 +218,7 @@ private protocol PrivateConstraint {}
 
 @_spi(LocalSPI)
 extension PublicType: SPIProto2 where T: SPIProto2 {}
-// CHECK-PRIVATE: extension {{.*}}.PublicType : {{.*}}.SPIProto2 where T : {{.*}}.SPIProto2
+// CHECK-PRIVATE: extension {{.*}}::PublicType : {{.*}}::SPIProto2 where T : {{.*}}::SPIProto2
 // CHECK-PUBLIC-NOT: _ConstraintThatIsNotPartOfTheAPIOfThisLibrary
 
 public protocol LocalPublicProto {}
@@ -240,14 +240,14 @@ extension IOIPublicStruct : LocalPublicProto {}
 
 public struct OpType {}
 @_spi(S) public func +(_ s1: OpType, _ s2: OpType) -> OpType { s1 }
-// CHECK-PRIVATE: @_spi(S) public func + (s1: {{.*}}.OpType, s2: {{.*}}.OpType) -> {{.*}}.OpType
+// CHECK-PRIVATE: @_spi(S) public func + (s1: {{.*}}::OpType, s2: {{.*}}::OpType) -> {{.*}}::OpType
 // CHECK-PUBLIC-NOT: func +
 
 // The dummy conformance should be only in the private swiftinterface for
 // SPI extensions.
 @_spi(LocalSPI)
 extension PublicType: SPIProto where T: PrivateConstraint {}
-// CHECK-PRIVATE: extension {{.*}}.PublicType : {{.*}}.SPIProto where T : _ConstraintThatIsNotPartOfTheAPIOfThisLibrary
+// CHECK-PRIVATE: extension {{.*}}::PublicType : {{.*}}::SPIProto where T : _ConstraintThatIsNotPartOfTheAPIOfThisLibrary
 // CHECK-PUBLIC-NOT: _ConstraintThatIsNotPartOfTheAPIOfThisLibrary
 
 // Preserve SPI information when printing indirect conformances via
@@ -255,5 +255,5 @@ extension PublicType: SPIProto where T: PrivateConstraint {}
 @_spi(S) public protocol SPIProtocol {}
 internal protocol InternalProtocol: SPIProtocol {}
 public struct PublicStruct2: InternalProtocol {}
-// CHECK-PRIVATE: @_spi(S) extension {{.*}}PublicStruct2 : {{.*}}.SPIProtocol
+// CHECK-PRIVATE: @_spi(S) extension {{.*}}::PublicStruct2 : {{.*}}::SPIProtocol
 // CHECK-PUBLIC-NOT: SPIProtocol

--- a/test/SPI/spi-only-swiftinterface-and-merged-decls.swift
+++ b/test/SPI/spi-only-swiftinterface-and-merged-decls.swift
@@ -40,4 +40,4 @@ import B
 
 @_spi(_)
 public func foo(_ a: MovingType) {}
-// CHECK: A.MovingType
+// CHECK: A::MovingType

--- a/test/SPI/spi_internal_accessor.swift
+++ b/test/SPI/spi_internal_accessor.swift
@@ -79,12 +79,12 @@ public struct InternalSet {
     get { 0 }
     set { }
   }
-// CHECK-PRIVATE:   @_spi(X) public var long: Swift.Int {
+// CHECK-PRIVATE:   @_spi(X) public var long: Swift::Int {
 // CHECK-PRIVATE:     @_spi(X) get
 // CHECK-PRIVATE:   }
 
   @_spi(X) public internal(set) var short: Int
-// CHECK-PRIVATE:   @_spi(X) public var short: Swift.Int {
+// CHECK-PRIVATE:   @_spi(X) public var short: Swift::Int {
 // CHECK-PRIVATE:     get
 // CHECK-PRIVATE:   }
 }

--- a/test/SPI/spi_only_import_swiftinterfaces.swift
+++ b/test/SPI/spi_only_import_swiftinterfaces.swift
@@ -81,8 +81,8 @@ import InconsistentPublic
 extension IOIPublicStruct {
   public func foo() {}
 }
-// CHECK-PUBLIC-NOT: A_SPIOnlyImported.IOIPublicStruct
-// CHECK-PRIVATE: @_spi{{.*}} extension A_SPIOnlyImported.IOIPublicStruct
+// CHECK-PUBLIC-NOT: A_SPIOnlyImported::IOIPublicStruct
+// CHECK-PRIVATE: @_spi{{.*}} extension A_SPIOnlyImported::IOIPublicStruct
 
 //--- FileB.swift
 @_spiOnly import ConstantSPIOnly

--- a/test/Sema/accessibility_package_inline_interface.swift
+++ b/test/Sema/accessibility_package_inline_interface.swift
@@ -16,7 +16,7 @@
 // CHECK-UTILS:   @usableFromInline
 // CHECK-UTILS:   package init()
 // CHECK-UTILS:   @usableFromInline
-// CHECK-UTILS:   package var pkgVar: Swift.Double
+// CHECK-UTILS:   package var pkgVar: Swift::Double
 // CHECK-UTILS:   @usableFromInline
 // CHECK-UTILS:   deinit
 // CHECK-UTILS: }
@@ -34,7 +34,7 @@
 // CHECK-UTILS:   @usableFromInline
 // CHECK-UTILS:   internal init()
 // CHECK-UTILS:   @usableFromInline
-// CHECK-UTILS:   internal var internalVar: Swift.Double
+// CHECK-UTILS:   internal var internalVar: Swift::Double
 // CHECK-UTILS:   @usableFromInline
 // CHECK-UTILS:   deinit
 // CHECK-UTILS: }

--- a/test/Sema/accessibility_package_interface.swift
+++ b/test/Sema/accessibility_package_interface.swift
@@ -70,11 +70,11 @@
 // CHECK-PUBLIC-CLIENT: ufiPackageFunc()
 // CHECK-PUBLIC-CLIENT: let u = UfiPackageKlass()
 // CHECK-PUBLIC-CLIENT: return u.ufiPkgVar
-// CHECK-PUBLIC-CLIENT: public class ClientKlass1 : Utils.UfiPackageProto
+// CHECK-PUBLIC-CLIENT: public class ClientKlass1 : Utils::UfiPackageProto
 // CHECK-PUBLIC-CLIENT: @usableFromInline
-// CHECK-PUBLIC-CLIENT: package var ufiPkgVar: Swift.String
-// CHECK-PUBLIC-CLIENT: public class ClientKlass2 : Utils.UfiPackageProto
-// CHECK-PUBLIC-CLIENT: public var ufiPkgVar: Swift.String
+// CHECK-PUBLIC-CLIENT: package var ufiPkgVar: Swift::String
+// CHECK-PUBLIC-CLIENT: public class ClientKlass2 : Utils::UfiPackageProto
+// CHECK-PUBLIC-CLIENT: public var ufiPkgVar: Swift::String
 
 // RUN: %target-swift-typecheck-module-from-interface(%t/Client.private.swiftinterface) -module-name Client -I %t -verify
 

--- a/test/Sema/implementation-only-override.swift
+++ b/test/Sema/implementation-only-override.swift
@@ -13,7 +13,7 @@
 import FooKit
 @_implementationOnly import FooKit_SECRET
 
-// CHECK-LABEL: class GoodChild : FooKit.Parent {
+// CHECK-LABEL: class GoodChild : FooKit::Parent {
 //  CHECK-NEXT:   @objc override dynamic public init()
 //  CHECK-NEXT:   @objc deinit
 //  CHECK-NEXT: }
@@ -38,7 +38,7 @@ public class GoodChild: Parent {
   }
 }
 
-// CHECK-LABEL: class QuietChild : FooKit.Parent {
+// CHECK-LABEL: class QuietChild : FooKit::Parent {
 //  CHECK-NEXT:   @objc deinit
 //  CHECK-NEXT: }
 public class QuietChild: Parent {
@@ -47,7 +47,7 @@ public class QuietChild: Parent {
   internal required init(requiredSECRET: Int32) {}
 }
 
-// CHECK-LABEL: class GoodGenericChild<Toy> : FooKit.Parent {
+// CHECK-LABEL: class GoodGenericChild<Toy> : FooKit::Parent {
 //  CHECK-NEXT:   @objc override dynamic public init()
 //  CHECK-NEXT:   @objc deinit
 //  CHECK-NEXT: }
@@ -102,7 +102,7 @@ internal class PrivateGrandchild: GoodChild {
   }
 }
 
-// CHECK-LABEL: class SubscriptChild : FooKit.SubscriptParent {
+// CHECK-LABEL: class SubscriptChild : FooKit::SubscriptParent {
 //  CHECK-NEXT:   @objc deinit
 //  CHECK-NEXT: }
 public class SubscriptChild: SubscriptParent {

--- a/test/Sema/missing-import-inlinable-code.swift
+++ b/test/Sema/missing-import-inlinable-code.swift
@@ -31,7 +31,7 @@
 // RUN: %target-swift-typecheck-module-from-interface(%t/ClientFixed.swiftinterface) -I %t
 
 /// The inserted missing imports should be aliased.
-// RUN: %target-swift-emit-module-interface(%t/ClientFixed.swiftinterface) %t/clientFileA-Swift5.swift %t/clientFileB.swift -I %t -alias-module-names-in-module-interface
+// RUN: %target-swift-emit-module-interface(%t/ClientFixed.swiftinterface) %t/clientFileA-Swift5.swift %t/clientFileB.swift -I %t -disable-module-selectors-in-module-interface -alias-module-names-in-module-interface
 // RUN: %target-swift-typecheck-module-from-interface(%t/ClientFixed.swiftinterface) -I %t
 // RUN: cat %t/ClientFixed.swiftinterface | %FileCheck -check-prefix ALIASED %s
 // ALIASED: import Module___libB

--- a/test/Serialization/Safety/indirect-conformance.swift
+++ b/test/Serialization/Safety/indirect-conformance.swift
@@ -23,10 +23,10 @@ public class IndirectConformant {
 }
 
 extension IndirectConformant: InternalProtocol {}
-// CHECK: extension Lib.IndirectConformant : Lib.PublicProtocol {}
+// CHECK: extension Lib::IndirectConformant : Lib::PublicProtocol {}
 
 extension String: InternalProtocol {}
-// CHECK: extension Swift.String : Lib.PublicProtocol {}
+// CHECK: extension Swift::String : Lib::PublicProtocol {}
 
 //--- Client.swift
 

--- a/test/SourceKit/DocSupport/doc_internal_closure_label.swift
+++ b/test/SourceKit/DocSupport/doc_internal_closure_label.swift
@@ -15,4 +15,4 @@
 public func foo(_ callback: (_ myInternalParam: Int) -> Void) {}
 
 // SWIFT_INTERFACE: import Swift
-// SWIFT_INTERFACE: public func foo(_ callback: (_ myInternalParam: Swift.Int) -> Swift.Void)
+// SWIFT_INTERFACE: public func foo(_ callback: (_ myInternalParam: Swift::Int) -> Swift::Void)

--- a/test/Unsafe/module-interface.swift
+++ b/test/Unsafe/module-interface.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name UserModule
 // RUN: %FileCheck %s < %t.swiftinterface
 
-// CHECK: @unsafe public func getIntUnsafely() -> Swift.Int
+// CHECK: @unsafe public func getIntUnsafely() -> Swift::Int
 @unsafe public func getIntUnsafely() -> Int { 0 }
 
 public struct UnsafeIterator: @unsafe IteratorProtocol {
@@ -29,7 +29,7 @@ public protocol P {
   func f()
 }
 
-// CHECK: public struct X : @unsafe UserModule.P
+// CHECK: public struct X : @unsafe UserModule::P
 public struct X: @unsafe P {
 // CHECK:  @unsafe public func f()
   @unsafe public func f() { }

--- a/validation-test/ParseableInterface/rdar128577611.swift
+++ b/validation-test/ParseableInterface/rdar128577611.swift
@@ -7,10 +7,10 @@ struct InternalStruct {}
 extension [Int: InternalStruct]: Sendable {}
 
 // CHECK: @available(*, unavailable)
-// CHECK-NEXT: extension Swift.Dictionary : Swift.Copyable where Key : _ConstraintThatIsNotPartOfTheAPIOfThisLibrary {}
+// CHECK-NEXT: extension Swift::Dictionary : Swift::Copyable where Key : _ConstraintThatIsNotPartOfTheAPIOfThisLibrary {}
 
 // CHECK: @available(*, unavailable)
-// CHECK-NEXT: extension Swift.Dictionary : Swift.Escapable where Key : _ConstraintThatIsNotPartOfTheAPIOfThisLibrary {}
+// CHECK-NEXT: extension Swift::Dictionary : Swift::Escapable where Key : _ConstraintThatIsNotPartOfTheAPIOfThisLibrary {}
 
 // CHECK: @available(*, unavailable)
-// CHECK-NEXT: extension Swift.Dictionary : Swift.Sendable where Key : _ConstraintThatIsNotPartOfTheAPIOfThisLibrary {}
+// CHECK-NEXT: extension Swift::Dictionary : Swift::Sendable where Key : _ConstraintThatIsNotPartOfTheAPIOfThisLibrary {}

--- a/validation-test/ParseableInterface/unsafe-mainactor.swift
+++ b/validation-test/ParseableInterface/unsafe-mainactor.swift
@@ -7,8 +7,8 @@
 
 import AppKit
 
-// CHECK: @objc @_inheritsConvenienceInitializers @_Concurrency.MainActor @preconcurrency public class Subclass : AppKit.NSView {
+// CHECK: @objc @_inheritsConvenienceInitializers @_Concurrency::MainActor @preconcurrency public class Subclass : AppKit::NSView {
 public class Subclass: NSView {
-  // CHECK: @_Concurrency.MainActor @preconcurrency @objc override dynamic public init(frame frameRect: Foundation.NSRect)
-  // CHECK: @_Concurrency.MainActor @preconcurrency @objc required dynamic public init?(coder: Foundation.NSCoder)
+  // CHECK: @_Concurrency::MainActor @preconcurrency @objc override dynamic public init(frame frameRect: Foundation::NSRect)
+  // CHECK: @_Concurrency::MainActor @preconcurrency @objc required dynamic public init?(coder: Foundation::NSCoder)
 }


### PR DESCRIPTION
And update tests to use them. (There's about ten lines of implementation and a thousand of test updates here.)

This commit depends on fixes in swiftlang/swift PRs https://github.com/swiftlang/swift/pull/86905, https://github.com/swiftlang/swift/pull/87129, and https://github.com/swiftlang/swift/pull/87130. ~~(The PR temporarily incorporates a commit from #86905; this will be rebased away.)~~

Fixes rdar://169749886.