### PR TITLE
[Swiftify] extend lifetime of unwrapped spans

### DIFF
--- a/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
@@ -919,6 +919,9 @@ struct CountedOrSizedPointerThunkBuilder: ParamBoundsThunkBuilder, PointerBounds
         unsafe \(raw: name)\(raw: questionMark).\(raw: funcName) { unsafe $0 }
         """)
       res.append(CodeBlockItemSyntax.Item(try VariableDeclSyntax("let \(unwrappedName) = \(unwrappedCall)")))
+      let lifetimeFix = ExprSyntax("_fixLifetime(\(raw: name))")
+      let deferLifetime = StmtSyntax("defer { \(lifetimeFix) }")
+      res.append(CodeBlockItemSyntax.Item(deferLifetime))
     }
 
     return res

--- a/test/Interop/C/swiftify-import/availability.swift
+++ b/test/Interop/C/swiftify-import/availability.swift
@@ -1,4 +1,3 @@
-
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
@@ -67,6 +66,9 @@ public func span(_ p: inout MutableSpan<Int32>) {
     let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
         unsafe $0
     }
+    defer {
+        _fixLifetime(p)
+    }
     return unsafe span(_pPtr.baseAddress!, len)
 }
 ------------------------------
@@ -88,6 +90,9 @@ public func span(_ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
     let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
         unsafe $0
+    }
+    defer {
+        _fixLifetime(p)
     }
     return unsafe span(_pPtr.baseAddress!, len)
 }
@@ -111,6 +116,9 @@ public func span(_ p: inout MutableSpan<Int32>) {
     let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
         unsafe $0
     }
+    defer {
+        _fixLifetime(p)
+    }
     return unsafe span(_pPtr.baseAddress!, len)
 }
 ------------------------------
@@ -131,6 +139,9 @@ public func span(_ p: inout MutableSpan<Int32>) {
     let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
         unsafe $0
     }
+    defer {
+        _fixLifetime(p)
+    }
     return unsafe span(_pPtr.baseAddress!, len)
 }
 ------------------------------
@@ -150,6 +161,9 @@ public func span(_ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
     let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
         unsafe $0
+    }
+    defer {
+        _fixLifetime(p)
     }
     return unsafe span(_pPtr.baseAddress!, len)
 }

--- a/test/Interop/C/swiftify-import/availability.swift
+++ b/test/Interop/C/swiftify-import/availability.swift
@@ -42,6 +42,9 @@ public func span(_ p: inout MutableSpan<Int32>) {
     let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
         unsafe $0
     }
+    defer {
+        _fixLifetime(p)
+    }
     return unsafe span(_pPtr.baseAddress!, len)
 }
 ------------------------------

--- a/test/Interop/C/swiftify-import/bridging-header-from-module.swift
+++ b/test/Interop/C/swiftify-import/bridging-header-from-module.swift
@@ -34,6 +34,9 @@ imports for @__swiftmacro_So3foo15_SwiftifyImportfMp_.swift:
     let _pPtr = unsafe p.withUnsafeBufferPointer {
         unsafe $0
     }
+    defer {
+        _fixLifetime(p)
+    }
     return unsafe foo(len, _pPtr.baseAddress!, x)
 }
 ------------------------------

--- a/test/Interop/C/swiftify-import/bridging-header-nontrivial.swift
+++ b/test/Interop/C/swiftify-import/bridging-header-nontrivial.swift
@@ -38,6 +38,9 @@ imports for @__swiftmacro_So3bar15_SwiftifyImportfMp_.swift:
     let _pPtr = unsafe p.withUnsafeBufferPointer {
         unsafe $0
     }
+    defer {
+        _fixLifetime(p)
+    }
     return unsafe foo(len, _pPtr.baseAddress!)
 }
 ------------------------------
@@ -48,6 +51,9 @@ imports for @__swiftmacro_So3bar15_SwiftifyImportfMp_.swift:
     let len = Int32(exactly: p.count)!
     let _pPtr = unsafe p.withUnsafeBufferPointer {
         unsafe $0
+    }
+    defer {
+        _fixLifetime(p)
     }
     return unsafe bar(len, _pPtr.baseAddress!)
 }

--- a/test/Interop/C/swiftify-import/bridging-header.swift
+++ b/test/Interop/C/swiftify-import/bridging-header.swift
@@ -32,6 +32,9 @@ imports for @__swiftmacro_So3foo15_SwiftifyImportfMp_.swift:
     let _pPtr = unsafe p.withUnsafeBufferPointer {
         unsafe $0
     }
+    defer {
+        _fixLifetime(p)
+    }
     return unsafe foo(len, _pPtr.baseAddress!, x)
 }
 ------------------------------

--- a/test/Interop/C/swiftify-import/import-as-instance-method.swift
+++ b/test/Interop/C/swiftify-import/import-as-instance-method.swift
@@ -113,6 +113,9 @@ public mutating func basic(_ p: inout MutableSpan<Int32>) {
     let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
         unsafe $0
     }
+    defer {
+        _fixLifetime(p)
+    }
     return unsafe basic(_pPtr.baseAddress!, len)
 }
 ------------------------------
@@ -124,6 +127,9 @@ public func basic(_ a: UnsafeMutablePointer<A>!, _ p: inout MutableSpan<Int32>) 
     let len = Int32(exactly: p.count)!
     let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
         unsafe $0
+    }
+    defer {
+        _fixLifetime(p)
     }
     return unsafe basic(a, _pPtr.baseAddress!, len)
 }
@@ -137,6 +143,9 @@ public mutating func bar(_ p: inout MutableSpan<Int32>) {
     let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
         unsafe $0
     }
+    defer {
+        _fixLifetime(p)
+    }
     return unsafe bar(_pPtr.baseAddress!, len)
 }
 ------------------------------
@@ -148,6 +157,9 @@ public func renamed(_ a: UnsafeMutablePointer<A>!, _ p: inout MutableSpan<Int32>
     let len = Int32(exactly: p.count)!
     let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
         unsafe $0
+    }
+    defer {
+        _fixLifetime(p)
     }
     return unsafe renamed(a, _pPtr.baseAddress!, len)
 }
@@ -161,6 +173,9 @@ public func constSelf(_ p: inout MutableSpan<Int32>) {
     let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
         unsafe $0
     }
+    defer {
+        _fixLifetime(p)
+    }
     return unsafe constSelf(_pPtr.baseAddress!, len)
 }
 ------------------------------
@@ -172,6 +187,9 @@ public func constSelf(_ a: UnsafePointer<A>!, _ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
     let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
         unsafe $0
+    }
+    defer {
+        _fixLifetime(p)
     }
     return unsafe constSelf(a, _pPtr.baseAddress!, len)
 }
@@ -185,6 +203,9 @@ public func valSelf(_ p: inout MutableSpan<Int32>) {
     let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
         unsafe $0
     }
+    defer {
+        _fixLifetime(p)
+    }
     return unsafe valSelf(_pPtr.baseAddress!, len)
 }
 ------------------------------
@@ -196,6 +217,9 @@ public func valSelf(_ a: A, _ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
     let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
         unsafe $0
+    }
+    defer {
+        _fixLifetime(p)
     }
     return unsafe valSelf(a, _pPtr.baseAddress!, len)
 }
@@ -225,6 +249,9 @@ public func refSelf(_ p: inout MutableSpan<Int32>) {
     let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
         unsafe $0
     }
+    defer {
+        _fixLifetime(p)
+    }
     return unsafe refSelf(_pPtr.baseAddress!, len)
 }
 ------------------------------
@@ -236,6 +263,9 @@ public func refSelf(_ c: C!, _ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
     let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
         unsafe $0
+    }
+    defer {
+        _fixLifetime(p)
     }
     return unsafe refSelf(c, _pPtr.baseAddress!, len)
 }
@@ -249,6 +279,9 @@ public func refSelf(_ p: inout MutableSpan<Int32>) {
     let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
         unsafe $0
     }
+    defer {
+        _fixLifetime(p)
+    }
     return unsafe refSelf(_pPtr.baseAddress!, len)
 }
 ------------------------------
@@ -261,6 +294,9 @@ public func refSelfCF(_ d: D!, _ p: inout MutableSpan<Int32>) {
     let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
         unsafe $0
     }
+    defer {
+        _fixLifetime(p)
+    }
     return unsafe refSelfCF(d, _pPtr.baseAddress!, len)
 }
 ------------------------------
@@ -272,6 +308,9 @@ public func nonescaping(_ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
     let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
         unsafe $0
+    }
+    defer {
+        _fixLifetime(p)
     }
     return unsafe nonescaping(_pPtr.baseAddress!, len)
 }
@@ -311,6 +350,9 @@ public /*not inherited*/ init!(pointerA2 p: inout MutableSpan<Int32>) {
     let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
         unsafe $0
     }
+    defer {
+        _fixLifetime(p)
+    }
     unsafe self.init(countA2: len, pointerA2: _pPtr.baseAddress!)
 }
 ------------------------------
@@ -322,6 +364,9 @@ public func createA2(_ p: inout MutableSpan<Int32>) -> UnsafeMutablePointer<A>! 
     let len = Int32(exactly: p.count)!
     let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
         unsafe $0
+    }
+    defer {
+        _fixLifetime(p)
     }
     return unsafe createA2(len, _pPtr.baseAddress!)
 }

--- a/test/Interop/Cxx/swiftify-import/parameter-type-from-namespace.swift
+++ b/test/Interop/Cxx/swiftify-import/parameter-type-from-namespace.swift
@@ -77,22 +77,25 @@ namespace foo {
 //   expected-note@1 5{{in expansion of macro '_SwiftifyImport' on global function 'bar' here}}
 // }}
 __attribute__((swift_attr("@_SwiftifyImport(.countedBy(pointer: .param(1), count: \"len\"))"))) void bar(float *p, int len, foo::foo_t extra);
-// expected-expansion@+13:94{{
+// expected-expansion@+16:94{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_disfavoredOverload public func bar2(_ p: Span<foo.foo_t>, _ extra: foo.foo_t) {|}}
 //   expected-remark@3{{macro content: |    let len = foo.foo_t(exactly: p.count)!|}}
 //   expected-remark@4{{macro content: |    let _pPtr = unsafe p.withUnsafeBufferPointer {|}}
 //   expected-remark@5{{macro content: |        unsafe $0|}}
 //   expected-remark@6{{macro content: |    }|}}
-//   expected-remark@7{{macro content: |    return unsafe bar2(_pPtr.baseAddress!, len, extra)|}}
-//   expected-remark@8{{macro content: |}|}}
+//   expected-remark@7{{macro content: |    defer {|}}
+//   expected-remark@8{{macro content: |        _fixLifetime(p)|}}
+//   expected-remark@9{{macro content: |    }|}}
+//   expected-remark@10{{macro content: |    return unsafe bar2(_pPtr.baseAddress!, len, extra)|}}
+//   expected-remark@11{{macro content: |}|}}
 // }}
 // expected-expansion@+3:6{{
-//   expected-note@1 8{{in expansion of macro '_SwiftifyImport' on global function 'bar2' here}}
+//   expected-note@1 11{{in expansion of macro '_SwiftifyImport' on global function 'bar2' here}}
 // }}
 void bar2(const foo::foo_t * __counted_by(len) p __noescape, foo::foo_t len, foo::foo_t extra);
 namespace baz {
-  // expected-expansion@+14:100{{
+  // expected-expansion@+17:100{{
   //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
   //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_disfavoredOverload|}}
   //   expected-remark@3{{macro content: |public static func baz_func(_ p: Span<foo.foo_t>, _ extra: foo.foo_t) {|}}
@@ -100,11 +103,14 @@ namespace baz {
   //   expected-remark@5{{macro content: |    let _pPtr = unsafe p.withUnsafeBufferPointer {|}}
   //   expected-remark@6{{macro content: |        unsafe $0|}}
   //   expected-remark@7{{macro content: |    }|}}
-  //   expected-remark@8{{macro content: |    return unsafe baz_func(_pPtr.baseAddress!, len, extra)|}}
-  //   expected-remark@9{{macro content: |}|}}
+  //   expected-remark@8{{macro content: |    defer {|}}
+  //   expected-remark@9{{macro content: |        _fixLifetime(p)|}}
+  //   expected-remark@10{{macro content: |    }|}}
+  //   expected-remark@11{{macro content: |    return unsafe baz_func(_pPtr.baseAddress!, len, extra)|}}
+  //   expected-remark@12{{macro content: |}|}}
   // }}
   // expected-expansion@+3:8{{
-  //   expected-note@1 9{{in expansion of macro '_SwiftifyImport' on static method 'baz_func' here}}
+  //   expected-note@1 12{{in expansion of macro '_SwiftifyImport' on static method 'baz_func' here}}
   // }}
   void baz_func(const foo::foo_t * __counted_by(len) p __noescape, foo::foo_t len, foo::foo_t extra);
 }

--- a/test/Macros/SwiftifyImport/CountedBy/Anonymous.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Anonymous.swift
@@ -52,6 +52,9 @@ public func myFunc3(_ _myFunc3_param0: Span<CInt>) {
     let __myFunc3_param0Ptr = unsafe _myFunc3_param0.withUnsafeBufferPointer {
         unsafe $0
     }
+    defer {
+        _fixLifetime(_myFunc3_param0)
+    }
     return unsafe myFunc3(__myFunc3_param0Ptr.baseAddress!, _myFunc3_param1)
 }
 ------------------------------
@@ -63,6 +66,9 @@ public func myFunc4(_ _myFunc4_param0: inout MutableSpan<CInt>) {
     let _myFunc4_param1 = CInt(exactly: _myFunc4_param0.count)!
     let __myFunc4_param0Ptr = unsafe _myFunc4_param0.withUnsafeMutableBufferPointer {
         unsafe $0
+    }
+    defer {
+        _fixLifetime(_myFunc4_param0)
     }
     return unsafe myFunc4(__myFunc4_param0Ptr.baseAddress!, _myFunc4_param1)
 }

--- a/test/Macros/SwiftifyImport/CountedBy/ConstantCount.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/ConstantCount.swift
@@ -120,6 +120,9 @@ public func noescape(_ ptr: Span<CInt>) {
     let _ptrPtr = unsafe ptr.withUnsafeBufferPointer {
         unsafe $0
     }
+    defer {
+        _fixLifetime(ptr)
+    }
     return unsafe noescape(_ptrPtr.baseAddress!)
 }
 ------------------------------
@@ -134,6 +137,9 @@ public func noescapeOpt(_ ptr: Span<CInt>?) {
     }
     let _ptrPtr = unsafe ptr?.withUnsafeBufferPointer {
         unsafe $0
+    }
+    defer {
+        _fixLifetime(ptr)
     }
     return unsafe noescapeOpt(_ptrPtr?.baseAddress)
 }
@@ -150,6 +156,9 @@ public func noescapeMut(_ ptr: inout MutableSpan<CInt>) {
     let _ptrPtr = unsafe ptr.withUnsafeMutableBufferPointer {
         unsafe $0
     }
+    defer {
+        _fixLifetime(ptr)
+    }
     return unsafe noescapeMut(_ptrPtr.baseAddress!)
 }
 ------------------------------
@@ -164,6 +173,9 @@ public func noescapeMutOpt(_ ptr: inout MutableSpan<CInt>?) {
     }
     let _ptrPtr = unsafe ptr?.withUnsafeMutableBufferPointer {
         unsafe $0
+    }
+    defer {
+        _fixLifetime(ptr)
     }
     return unsafe noescapeMutOpt(_ptrPtr?.baseAddress)
 }

--- a/test/Macros/SwiftifyImport/CountedBy/MutableSpan.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/MutableSpan.swift
@@ -22,6 +22,9 @@ public func myFunc(_ ptr: inout MutableSpan<CInt>) {
     let _ptrPtr = unsafe ptr.withUnsafeMutableBufferPointer {
         unsafe $0
     }
+    defer {
+        _fixLifetime(ptr)
+    }
     return unsafe myFunc(_ptrPtr.baseAddress!, len)
 }
 ------------------------------

--- a/test/Macros/SwiftifyImport/CountedBy/Nullable.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Nullable.swift
@@ -44,6 +44,9 @@ public func myFunc2(_ ptr: inout MutableSpan<CInt>?) {
     let _ptrPtr = unsafe ptr?.withUnsafeMutableBufferPointer {
         unsafe $0
     }
+    defer {
+        _fixLifetime(ptr)
+    }
     return unsafe myFunc2(_ptrPtr?.baseAddress, len)
 }
 ------------------------------
@@ -57,8 +60,14 @@ public func myFunc3(_ ptr: inout MutableSpan<CInt>?, _ ptr2: inout MutableSpan<C
     let _ptrPtr = unsafe ptr?.withUnsafeMutableBufferPointer {
         unsafe $0
     }
+    defer {
+        _fixLifetime(ptr)
+    }
     let _ptr2Ptr = unsafe ptr2?.withUnsafeMutableBufferPointer {
         unsafe $0
+    }
+    defer {
+        _fixLifetime(ptr2)
     }
     return unsafe myFunc3(_ptrPtr?.baseAddress, len, _ptr2Ptr?.baseAddress, len2)
 }
@@ -71,6 +80,9 @@ public func myFunc4(_ ptr: inout MutableSpan<CInt>?) -> MutableSpan<CInt>? {
     let len = CInt(exactly: ptr?.count ?? 0)!
     let _ptrPtr = unsafe ptr?.withUnsafeMutableBufferPointer {
         unsafe $0
+    }
+    defer {
+        _fixLifetime(ptr)
     }
     return unsafe _swiftifyOverrideLifetime({ () in
       let _resultValue = unsafe myFunc4(_ptrPtr?.baseAddress, len)

--- a/test/Macros/SwiftifyImport/CountedBy/PointerReturn.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/PointerReturn.swift
@@ -55,6 +55,9 @@ public func lifetimeDependentCopy(_ p: Span<CInt>, _ len2: CInt) -> Span<CInt> {
     let _pPtr = unsafe p.withUnsafeBufferPointer {
         unsafe $0
     }
+    defer {
+        _fixLifetime(p)
+    }
     return unsafe _swiftifyOverrideLifetime(Span<CInt> (_unsafeStart: unsafe lifetimeDependentCopy(_pPtr.baseAddress!, len1, len2), count: Int(len2)), copying: ())
 }
 ------------------------------

--- a/test/Macros/SwiftifyImport/CountedBy/Protocol.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Protocol.swift
@@ -59,6 +59,9 @@ extension SpanProtocol {
         let _ptrPtr = unsafe ptr.withUnsafeBufferPointer {
             unsafe $0
         }
+        defer {
+            _fixLifetime(ptr)
+        }
         return unsafe foo(_ptrPtr.baseAddress!, len)
     }
     /// This is an auto-generated wrapper for safer interop
@@ -78,6 +81,9 @@ extension MixedProtocol {
         let len = CInt(exactly: ptr.count)!
         let _ptrPtr = unsafe ptr.withUnsafeBufferPointer {
             unsafe $0
+        }
+        defer {
+            _fixLifetime(ptr)
         }
         return unsafe foo(_ptrPtr.baseAddress!, len)
     }

--- a/test/Macros/SwiftifyImport/CountedBy/SimpleSpan.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/SimpleSpan.swift
@@ -22,6 +22,9 @@ public func myFunc(_ ptr: Span<CInt>) {
     let _ptrPtr = unsafe ptr.withUnsafeBufferPointer {
         unsafe $0
     }
+    defer {
+        _fixLifetime(ptr)
+    }
     return unsafe myFunc(_ptrPtr.baseAddress!, len)
 }
 ------------------------------

--- a/test/Macros/SwiftifyImport/CountedBy/SimpleSpanWithReturn.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/SimpleSpanWithReturn.swift
@@ -23,6 +23,9 @@ public func myFunc(_ ptr: Span<CInt>) -> CInt {
     let _ptrPtr = unsafe ptr.withUnsafeBufferPointer {
         unsafe $0
     }
+    defer {
+        _fixLifetime(ptr)
+    }
     return unsafe myFunc(_ptrPtr.baseAddress!, len)
 }
 ------------------------------

--- a/test/Macros/SwiftifyImport/CountedBy/SpanAndUnsafeBuffer.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/SpanAndUnsafeBuffer.swift
@@ -23,6 +23,9 @@ public func myFunc(_ ptr1: Span<CInt>, _ ptr2: UnsafeBufferPointer<CInt>) {
     let _ptr1Ptr = unsafe ptr1.withUnsafeBufferPointer {
         unsafe $0
     }
+    defer {
+        _fixLifetime(ptr1)
+    }
     return unsafe myFunc(_ptr1Ptr.baseAddress!, len1, ptr2.baseAddress!, len2)
 }
 ------------------------------

--- a/test/Macros/SwiftifyImport/CountedBy/UnrelatedNonescapableReturn.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/UnrelatedNonescapableReturn.swift
@@ -34,6 +34,9 @@ public func myFunc(_ ptr: Span<CInt>) -> NonescapableEnum {
     let _ptrPtr = unsafe ptr.withUnsafeBufferPointer {
         unsafe $0
     }
+    defer {
+        _fixLifetime(ptr)
+    }
     return unsafe _swiftifyOverrideLifetime(unsafe myFunc(_ptrPtr.baseAddress!, len), copying: ())
 }
 ------------------------------
@@ -45,6 +48,9 @@ public func myFunc2(_ ptr: inout MutableSpan<CInt>, _ extraNE: inout Nonescapabl
     let len = CInt(exactly: ptr.count)!
     let _ptrPtr = unsafe ptr.withUnsafeMutableBufferPointer {
         unsafe $0
+    }
+    defer {
+        _fixLifetime(ptr)
     }
     return unsafe _swiftifyOverrideLifetime(unsafe myFunc2(_ptrPtr.baseAddress!, len, &extraNE), copying: ())
 }

--- a/test/Macros/SwiftifyImport/CountedBy/Whitespace.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Whitespace.swift
@@ -24,8 +24,14 @@ public func myFunc(_ ptr: inout MutableSpan<CInt>?, _ ptr2: inout MutableSpan<CI
     let _ptrPtr = unsafe ptr?.withUnsafeMutableBufferPointer {
         unsafe $0
     }
+    defer {
+        _fixLifetime(ptr)
+    }
     let _ptr2Ptr = unsafe ptr2?.withUnsafeMutableBufferPointer {
         unsafe $0
+    }
+    defer {
+        _fixLifetime(ptr2)
     }
     return unsafe _swiftifyOverrideLifetime({ () in
       let _resultValue = unsafe myFunc(_ptrPtr?.baseAddress, len, _ptr2Ptr?.baseAddress, len2)

--- a/test/Macros/SwiftifyImport/CxxSpan/LifetimeboundSpan.swift
+++ b/test/Macros/SwiftifyImport/CxxSpan/LifetimeboundSpan.swift
@@ -126,6 +126,9 @@ public func myFunc6(_ span: Span<CInt>, _ ptr: RawSpan, _ count: CInt, _ size: C
     let _ptrPtr = unsafe ptr.withUnsafeBytes {
         unsafe $0
     }
+    defer {
+        _fixLifetime(ptr)
+    }
     return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe myFunc6(SpanOfInt(span), _ptrPtr.baseAddress!, count, size)), copying: ())
 }
 ------------------------------
@@ -141,6 +144,9 @@ public func myFunc7(_ span: Span<CInt>, _ ptr: RawSpan, _ count: CInt, _ size: C
     let _ptrPtr = unsafe ptr.withUnsafeBytes {
         unsafe $0
     }
+    defer {
+        _fixLifetime(ptr)
+    }
     return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe myFunc7(SpanOfInt(span), _ptrPtr.baseAddress!, count, size)), copying: ())
 }
 ------------------------------
@@ -155,6 +161,9 @@ public func myFunc8(_ ptr: RawSpan, _ span: Span<CInt>, _ count: CInt, _ size: C
     }
     let _ptrPtr = unsafe ptr.withUnsafeBytes {
         unsafe $0
+    }
+    defer {
+        _fixLifetime(ptr)
     }
     return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe myFunc8(_ptrPtr.baseAddress!, SpanOfInt(span), count, size)), copying: ())
 }

--- a/test/Macros/SwiftifyImport/SizedBy/MutableRawSpan.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/MutableRawSpan.swift
@@ -22,6 +22,9 @@ public func myFunc(_ ptr: inout MutableRawSpan) {
     let _ptrPtr = unsafe ptr.withUnsafeMutableBytes {
         unsafe $0
     }
+    defer {
+        _fixLifetime(ptr)
+    }
     return unsafe myFunc(_ptrPtr.baseAddress!, size)
 }
 ------------------------------

--- a/test/Macros/SwiftifyImport/SizedBy/Nullable.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/Nullable.swift
@@ -44,6 +44,9 @@ public func myFunc2(_ ptr: inout MutableRawSpan?) {
     let _ptrPtr = unsafe ptr?.withUnsafeMutableBytes {
         unsafe $0
     }
+    defer {
+        _fixLifetime(ptr)
+    }
     return unsafe myFunc2(_ptrPtr?.baseAddress, len)
 }
 ------------------------------
@@ -57,8 +60,14 @@ public func myFunc3(_ ptr: inout MutableRawSpan?, _ ptr2: inout MutableRawSpan?)
     let _ptrPtr = unsafe ptr?.withUnsafeMutableBytes {
         unsafe $0
     }
+    defer {
+        _fixLifetime(ptr)
+    }
     let _ptr2Ptr = unsafe ptr2?.withUnsafeMutableBytes {
         unsafe $0
+    }
+    defer {
+        _fixLifetime(ptr2)
     }
     return unsafe myFunc3(_ptrPtr?.baseAddress, len, _ptr2Ptr?.baseAddress, len2)
 }
@@ -71,6 +80,9 @@ public func myFunc4(_ ptr: inout MutableRawSpan?) -> MutableRawSpan? {
     let len = CInt(exactly: ptr?.byteCount ?? 0)!
     let _ptrPtr = unsafe ptr?.withUnsafeMutableBytes {
         unsafe $0
+    }
+    defer {
+        _fixLifetime(ptr)
     }
     return unsafe _swiftifyOverrideLifetime({ () in
       let _resultValue = unsafe myFunc4(_ptrPtr?.baseAddress, len)

--- a/test/Macros/SwiftifyImport/SizedBy/Opaque.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/Opaque.swift
@@ -69,6 +69,9 @@ public func nonnullSpan(_ ptr: RawSpan) {
     let _ptrPtr = unsafe ptr.withUnsafeBytes {
         unsafe $0
     }
+    defer {
+        _fixLifetime(ptr)
+    }
     return unsafe nonnullSpan(OpaquePointer(_ptrPtr.baseAddress!), size)
 }
 ------------------------------
@@ -81,6 +84,9 @@ public func nullableSpan(_ ptr: RawSpan?) {
     let _ptrPtr = unsafe ptr?.withUnsafeBytes {
         unsafe $0
     }
+    defer {
+        _fixLifetime(ptr)
+    }
     return unsafe nullableSpan(OpaquePointer(_ptrPtr?.baseAddress), size)
 }
 ------------------------------
@@ -92,6 +98,9 @@ public func impNullableSpan(_ ptr: RawSpan) {
     let size = CInt(exactly: ptr.byteCount)!
     let _ptrPtr = unsafe ptr.withUnsafeBytes {
         unsafe $0
+    }
+    defer {
+        _fixLifetime(ptr)
     }
     return unsafe impNullableSpan(OpaquePointer(_ptrPtr.baseAddress!), size)
 }

--- a/test/Macros/SwiftifyImport/SizedBy/OpaqueReturn.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/OpaqueReturn.swift
@@ -67,6 +67,9 @@ public func nonnullSpan(p: RawSpan) -> RawSpan {
     let _pPtr = unsafe p.withUnsafeBytes {
         unsafe $0
     }
+    defer {
+        _fixLifetime(p)
+    }
     return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe UnsafeRawPointer(unsafe nonnullSpan(p: OpaquePointer(_pPtr.baseAddress!), size: size)), byteCount: Int(size)), copying: ())
 }
 ------------------------------
@@ -78,6 +81,9 @@ public func nullableSpan(p: RawSpan?) -> RawSpan? {
     let size = CInt(exactly: p?.byteCount ?? 0)!
     let _pPtr = unsafe p?.withUnsafeBytes {
         unsafe $0
+    }
+    defer {
+        _fixLifetime(p)
     }
     return unsafe _swiftifyOverrideLifetime({ () in
       let _resultValue = unsafe nullableSpan(p: OpaquePointer(_pPtr?.baseAddress), size)
@@ -97,6 +103,9 @@ public func impNullableSpan(p: RawSpan) -> RawSpan {
     let size = CInt(exactly: p.byteCount)!
     let _pPtr = unsafe p.withUnsafeBytes {
         unsafe $0
+    }
+    defer {
+        _fixLifetime(p)
     }
     return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe UnsafeRawPointer(unsafe impNullableSpan(p: OpaquePointer(_pPtr.baseAddress!), size)), byteCount: Int(size)), copying: ())
 }

--- a/test/Macros/SwiftifyImport/SizedBy/PointerReturn.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/PointerReturn.swift
@@ -64,6 +64,9 @@ public func lifetimeDependentCopy(_ p: RawSpan, _ len2: CInt) -> RawSpan {
     let _pPtr = unsafe p.withUnsafeBytes {
         unsafe $0
     }
+    defer {
+        _fixLifetime(p)
+    }
     return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe lifetimeDependentCopy(_pPtr.baseAddress!, len1, len2), byteCount: Int(len2)), copying: ())
 }
 ------------------------------
@@ -84,6 +87,9 @@ public func lifetimeDependentCopyMut(_ p: inout MutableRawSpan, _ len2: CInt) ->
     let len1 = CInt(exactly: p.byteCount)!
     let _pPtr = unsafe p.withUnsafeMutableBytes {
         unsafe $0
+    }
+    defer {
+        _fixLifetime(p)
     }
     return unsafe _swiftifyOverrideLifetime(MutableRawSpan(_unsafeStart: unsafe lifetimeDependentCopyMut(_pPtr.baseAddress!, len1, len2), byteCount: Int(len2)), copying: ())
 }

--- a/test/Macros/SwiftifyImport/SizedBy/SimpleRawSpan.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/SimpleRawSpan.swift
@@ -22,6 +22,9 @@ public func myFunc(_ ptr: RawSpan) {
     let _ptrPtr = unsafe ptr.withUnsafeBytes {
         unsafe $0
     }
+    defer {
+        _fixLifetime(ptr)
+    }
     return unsafe myFunc(_ptrPtr.baseAddress!, size)
 }
 ------------------------------

--- a/test/Macros/SwiftifyImport/SizedBy/SimpleRawSpanWithReturn.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/SimpleRawSpanWithReturn.swift
@@ -23,6 +23,9 @@ public func myFunc(_ ptr: RawSpan) -> CInt {
     let _ptrPtr = unsafe ptr.withUnsafeBytes {
         unsafe $0
     }
+    defer {
+        _fixLifetime(ptr)
+    }
     return unsafe myFunc(_ptrPtr.baseAddress!, size)
 }
 ------------------------------

--- a/test/Macros/SwiftifyImport/SizedBy/TypedPointer.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/TypedPointer.swift
@@ -109,6 +109,9 @@ public func constParamNoreturn(_ ptr: RawSpan) {
     let _ptrPtr = unsafe ptr.withUnsafeBytes {
         unsafe $0
     }
+    defer {
+        _fixLifetime(ptr)
+    }
     return unsafe constParamNoreturn(_ptrPtr.baseAddress!.assumingMemoryBound(to: CChar.self), size)
 }
 ------------------------------
@@ -120,6 +123,9 @@ public func mutParamNoreturn(_ ptr: inout MutableRawSpan) {
     let size = CInt(exactly: ptr.byteCount)!
     let _ptrPtr = unsafe ptr.withUnsafeMutableBytes {
         unsafe $0
+    }
+    defer {
+        _fixLifetime(ptr)
     }
     return unsafe mutParamNoreturn(_ptrPtr.baseAddress!.assumingMemoryBound(to: UInt8.self), size)
 }
@@ -133,6 +139,9 @@ public func constReturnDependence(_ ptr: RawSpan) -> RawSpan {
     let _ptrPtr = unsafe ptr.withUnsafeBytes {
         unsafe $0
     }
+    defer {
+        _fixLifetime(ptr)
+    }
     return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe constReturnDependence(size, _ptrPtr.baseAddress!.assumingMemoryBound(to: UInt8.self)), byteCount: Int(size)), copying: ())
 }
 ------------------------------
@@ -144,6 +153,9 @@ public func mutReturnDependence(_ ptr: inout MutableRawSpan) -> MutableRawSpan {
     let size = CInt(exactly: ptr.byteCount)!
     let _ptrPtr = unsafe ptr.withUnsafeMutableBytes {
         unsafe $0
+    }
+    defer {
+        _fixLifetime(ptr)
     }
     return unsafe _swiftifyOverrideLifetime(MutableRawSpan(_unsafeStart: unsafe mutReturnDependence(size, _ptrPtr.baseAddress!.assumingMemoryBound(to: UInt8.self)), byteCount: Int(size)), copying: ())
 }


### PR DESCRIPTION
If a wrapper function is inlined, the span lifetime can end up being
shortened past the use of the internal pointer. This adds an artificial
lifetime extension to prevent this from happening.

rdar://170108525