### PR TITLE
Runtime: add CMake module for inter-module dependency

### DIFF
--- a/Runtimes/Supplemental/Runtime/CMakeLists.txt
+++ b/Runtimes/Supplemental/Runtime/CMakeLists.txt
@@ -188,12 +188,15 @@ set_target_properties(swiftRuntime PROPERTIES
   Swift_MODULE_NAME Runtime)
 target_compile_definitions(swiftRuntime PRIVATE
   SWIFT_ASM_AVAILABLE)
-target_compile_options(swiftRuntime PRIVATE
+target_compile_options(swiftRuntime PUBLIC
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fmodule-map-file=${CMAKE_CURRENT_SOURCE_DIR}/modules/module.modulemap>")
 # FIXME: We should split out the parts that are needed by the runtime to avoid
 # pulling in headers from the compiler.
 target_include_directories(swiftRuntime PRIVATE
   "${${PROJECT_NAME}_SWIFTC_SOURCE_DIR}/include")
+# FIXME: Why is this not implicitly in the interface flags?
+target_include_directories(swiftRuntime INTERFACE
+  "$<$<COMPILE_LANGUAGE:Swift>:$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${${PROJECT_NAME}_INSTALL_SWIFTMODULEDIR}>>")
 target_link_libraries(swiftRuntime PUBLIC
   swiftShims
   swiftCore
@@ -220,3 +223,22 @@ generate_plist(swiftRuntime "${CMAKE_PROJECT_VERSION}" swiftRuntime)
 embed_manifest(swiftRuntime)
 
 include("${${PROJECT_NAME}_VENDOR_MODULE_DIR}/SwiftRuntime.cmake" OPTIONAL)
+
+# Inter-project install info
+export(EXPORT SwiftRuntimeTargets
+  FILE "cmake/SwiftRuntime/SwiftRuntimeTargets.cmake")
+install(EXPORT SwiftRuntimeTargets
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/SwiftRuntime"
+  FILE "SwiftRuntimeTargets.cmake"
+  COMPONENT SwiftRuntimeCMake)
+include(CMakePackageConfigHelpers)
+configure_package_config_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/interface/SwiftRuntimeConfig.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/cmake/SwiftRuntime/SwiftRuntimeConfig.cmake"
+  INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/SwiftRuntime")
+write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/cmake/SwiftRuntime/SwiftRuntimeConfigVersion.cmake"
+  VERSION "${PROJECT_VERSION}"
+  COMPATIBILITY ExactVersion)
+install(FILES
+  "${CMAKE_CURRENT_BINARY_DIR}/cmake/SwiftRuntime/SwiftRuntimeConfig.cmake"
+  "${CMAKE_CURRENT_BINARY_DIR}/cmake/SwiftRuntime/SwiftRuntimeConfigVersion.cmake"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/SwiftRuntime")

--- a/Runtimes/Supplemental/Runtime/cmake/interface/SwiftRuntimeConfig.cmake.in
+++ b/Runtimes/Supplemental/Runtime/cmake/interface/SwiftRuntimeConfig.cmake.in
@@ -1,0 +1,2 @@
+@PACKAGE_INIT@
+include("${CMAKE_CURRENT_LIST_DIR}/SwiftRuntimeTargets.cmake")


### PR DESCRIPTION
Introduce the CMake machinery to allow inter-module dependency. This module is consumed by the stack walker for its implementation. As a result, we need to provide the infrastructure for it to depend on the build artifacts.