### PR TITLE
[stdlib] Make some internal `MutableSpan` members `transparent`

### DIFF
--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -30,6 +30,7 @@ public struct MutableSpan<Element: ~Copyable>
 
   @unsafe
   @_alwaysEmitIntoClient
+  @_transparent
   internal func _start() -> UnsafeMutableRawPointer {
     unsafe _pointer._unsafelyUnwrappedUnchecked
   }
@@ -343,6 +344,7 @@ extension MutableSpan where Element: ~Copyable {
 
   @unsafe
   @_alwaysEmitIntoClient
+  @_transparent
   internal func _unsafeAddressOfElement(
     unchecked position: Index
   ) -> UnsafeMutablePointer<Element> {


### PR DESCRIPTION
* Explanation: Adds `@_transparent` to `MutableSpan._start()` and `_unsafeAddressOfElement` to improve debug mode performance when using `MutableSpan` subscripts.
* Scope: Affects performance of `MutableSpan` usage in debug mode.
* Issues:
* Risk: None, should simply improve performance.
* Testing: No new test cases.
* Reviewers: @Azoy 
