### PR TITLE
[PrintAsClang] skip header maps when collecting include paths

### DIFF
--- a/lib/PrintAsClang/PrintAsClang.cpp
+++ b/lib/PrintAsClang/PrintAsClang.cpp
@@ -450,6 +450,11 @@ writeImports(raw_ostream &out, llvm::SmallPtrSetImpl<ImportModuleTy> &imports,
 
     for (auto searchDir = clangHeaderSearchInfo.search_dir_begin();
          searchDir != clangHeaderSearchInfo.search_dir_end(); ++searchDir) {
+      // Header map lookup is not supported for now, so don't add the hmap
+      // paths to the search list.
+      if (searchDir->isHeaderMap())
+          continue;
+
       // Ensure search directories end in / so that we don't prefix match
       // against a folder that starts with the same substring.
       auto path = normalizePath(searchDir->getName());

--- a/test/PrintAsObjC/emit-clang-header-nonmodular-includes-skip-header-maps.swift
+++ b/test/PrintAsObjC/emit-clang-header-nonmodular-includes-skip-header-maps.swift
@@ -1,0 +1,26 @@
+// REQUIRES: objc_interop
+
+// RUN: %empty-directory(%t)
+
+// Create a header map that maps header-regular.h to its real path.
+// RUN: echo '{"mappings": {"header-regular.h": "%/S/Inputs/custom-modules/header_subdirectory/header-regular.h"}}' > %t/hmap.json
+// RUN: %hmaptool write %t/hmap.json %t/headers.hmap
+
+// Compile with the header map as a search directory alongside a regular
+// include directory. The header map should be skipped when collecting include
+// paths for nonmodular includes.
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -emit-objc-header-path %t/textual-imports.h -Xcc -fmodule-map-file=%S/Inputs/custom-modules/module.modulemap -Xcc -I%t/headers.hmap -Xcc -I%S/Inputs/custom-modules/header_subdirectory/ -emit-clang-header-nonmodular-includes %s
+// RUN: %FileCheck %s < %t/textual-imports.h
+
+import EmitClangHeaderNonmodularIncludesStressTest
+
+public class Bar : Baz {}
+
+// CHECK: @import EmitClangHeaderNonmodularIncludesStressTest;
+// CHECK-NEXT: #elif defined(__OBJC__)
+// CHECK-NEXT: #import <header-regular.h>
+// CHECK-NEXT: #import <header-symlink.h>
+// CHECK-NEXT: #else
+// CHECK-NEXT: #include <header-regular.h>
+// CHECK-NEXT: #include <header-symlink.h>
+// CHECK-NEXT: #endif


### PR DESCRIPTION
Header map lookup is not handled when doing prefix checks for textual header inclusion. Skip adding them to the list instead of adding invalid paths for each header map.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
