### PR TITLE
[CS] Better handle ErrorType

### DIFF
--- a/lib/IDE/CodeCompletionStringBuilder.cpp
+++ b/lib/IDE/CodeCompletionStringBuilder.cpp
@@ -48,7 +48,7 @@ Type ide::eraseArchetypes(Type type, GenericSignature genericSig) {
       // Don't erase opaque archetype.
       if (isa<OpaqueTypeArchetypeType>(archetypeType) &&
           archetypeType->isRoot())
-        return std::nullopt;
+        return archetypeType;
 
       auto genericSig =
           archetypeType->getGenericEnvironment()->getGenericSignature();

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9025,7 +9025,12 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
           loc,
           LocatorPathElt::ConformanceRequirement(conformance.getConcrete()));
 
-      for (const auto &req : conformance.getConditionalRequirements()) {
+      for (auto req : conformance.getConditionalRequirements()) {
+        // Replace any ErrorTypes with holes if needed in case of substitution
+        // failure.
+        req = req.tranformSubjectTypes([&](Type ty) {
+          return replaceInferableTypesWithTypeVars(ty, loc);
+        });
         addConstraint(
             req, getConstraintLocator(conformanceLoc,
                                       LocatorPathElt::ConditionalRequirement(

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -1523,7 +1523,14 @@ void ConstraintSystem::openGenericRequirement(
         signature->prohibitsIsolatedConformance(req.getFirstType()).has_value();
   }
 
-  addConstraint(req.tranformSubjectTypes(substFn),
+  // Open the requirement's subject type, replacing ErrorTypes with holes if
+  // needed in case of substitution failure.
+  auto openedReq = req.tranformSubjectTypes([&](Type ty) {
+    return replaceInferableTypesWithTypeVars(substFn(ty), locator,
+                                             preparedOverload);
+  });
+
+  addConstraint(openedReq,
                 locator.withPathElement(
                     LocatorPathElt::TypeParameterRequirement(index, kind)),
                 /*isFavored=*/false, prohibitIsolatedConformance,

--- a/test/IDE/complete_name_lookup.swift
+++ b/test/IDE/complete_name_lookup.swift
@@ -47,6 +47,6 @@ extension ObservableConvertibleType {
 }
 // CATCHSEQUENCE_DOT-DAG: Keyword[self]/CurrNominal:          self[#CatchSequence<S>.Type#]; name=self
 // CATCHSEQUENCE_DOT-DAG: Keyword/CurrNominal:                Type[#CatchSequence<S>.Type#]; name=Type
-// CATCHSEQUENCE_DOT-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]: init()[#CatchSequence<S>#]; name=init()
-// CATCHSEQUENCE_DOT-DAG: Decl[StaticMethod]/Super/TypeRelation[Convertible]: catchError()[#Observable<CatchSequence<S>.T>#]; name=catchError()
+// CATCHSEQUENCE_DOT-DAG: Decl[Constructor]/CurrNominal: init()[#CatchSequence<S>#]; name=init()
+// CATCHSEQUENCE_DOT-DAG: Decl[StaticMethod]/Super: catchError()[#Observable<CatchSequence<S>.T>#]; name=catchError()
 // CATCHSEQUENCE_DOT-DAG: Decl[TypeAlias]/Super: T[#Observable<S.Element.T>.T#]; name=T

--- a/test/IDE/complete_opaque_result.swift
+++ b/test/IDE/complete_opaque_result.swift
@@ -181,13 +181,33 @@ struct ConcreteTestProtocol2: TestProtocol2 {
 // OVERRIDE_TestProtocol2-NOT: foo()
 // OVERRIDE_TestProtocol2-NOT: inExt()
 }
+struct ConcreteGenericTestProtocol2<U>: TestProtocol2 {
+  func foo() -> some Comparable { 1 }
+  #^OVERRIDE_Generic_TestProtocol2^#
+  // OVERRIDE_Generic_TestProtocol2-NOT: foo()
+  // OVERRIDE_Generic_TestProtocol2-NOT: inExt()
+  // OVERRIDE_Generic_TestProtocol2-DAG: Decl[InstanceMethod]/Super:         func bar() -> Assoc {|};
+  // OVERRIDE_Generic_TestProtocol2-DAG: Decl[InstanceMethod]/Super:         func baz(x: @autoclosure () -> Assoc) -> (Assoc) -> Assoc {|};
+  // OVERRIDE_Generic_TestProtocol2-DAG: Decl[AssociatedType]/Super:         typealias Assoc = {#(Type)#};
+  // OVERRIDE_Generic_TestProtocol2-NOT: foo()
+  // OVERRIDE_Generic_TestProtocol2-NOT: inExt()
+
+  func test() {
+    self.#^POSTFIX_ConcreteGenericTestProtocol2^#
+    // POSTFIX_ConcreteGenericTestProtocol2-DAG: Keyword[self]/CurrNominal:          self[#ConcreteGenericTestProtocol2<U>#];
+    // POSTFIX_ConcreteGenericTestProtocol2-DAG: Decl[InstanceMethod]/CurrNominal:   foo()[#Comparable#];
+    // POSTFIX_ConcreteGenericTestProtocol2-DAG: Decl[InstanceMethod]/Super:         bar()[#Comparable#];
+    // POSTFIX_ConcreteGenericTestProtocol2-DAG: Decl[InstanceMethod]/Super:         baz({#x: Comparable#})[#(Comparable) -> Comparable#];
+    // POSTFIX_ConcreteGenericTestProtocol2-DAG: Decl[InstanceMethod]/Super:         inExt()[#Comparable#];
+  }
+}
 func testUseTestProtocol2(value: ConcreteTestProtocol2) {
   value.#^POSTFIX_ConcreteTestProtocol2^#
 // POSTFIX_ConcreteTestProtocol2-DAG: Keyword[self]/CurrNominal:          self[#ConcreteTestProtocol2#];
 // POSTFIX_ConcreteTestProtocol2-DAG: Decl[InstanceMethod]/CurrNominal:   foo()[#Comparable#];
-// POSTFIX_ConcreteTestProtocol2-DAG: Decl[InstanceMethod]/Super:         bar()[#ConcreteTestProtocol2.Assoc#];
-// POSTFIX_ConcreteTestProtocol2-DAG: Decl[InstanceMethod]/Super:         baz({#x: ConcreteTestProtocol2.Assoc#})[#(ConcreteTestProtocol2.Assoc) -> ConcreteTestProtocol2.Assoc#];
-// POSTFIX_ConcreteTestProtocol2-DAG: Decl[InstanceMethod]/Super:         inExt()[#ConcreteTestProtocol2.Assoc#];
+// POSTFIX_ConcreteTestProtocol2-DAG: Decl[InstanceMethod]/Super:         bar()[#Comparable#];
+// POSTFIX_ConcreteTestProtocol2-DAG: Decl[InstanceMethod]/Super:         baz({#x: Comparable#})[#(Comparable) -> Comparable#];
+// POSTFIX_ConcreteTestProtocol2-DAG: Decl[InstanceMethod]/Super:         inExt()[#Comparable#];
 }
 
 struct Generic<T> {

--- a/validation-test/IDE/crashers_fixed/ConstraintSystem-matchFunctionTypes-06eb4e.swift
+++ b/validation-test/IDE/crashers_fixed/ConstraintSystem-matchFunctionTypes-06eb4e.swift
@@ -1,3 +1,3 @@
 // {"kind":"complete","original":"febd2f61","signature":"swift::constraints::ConstraintSystem::matchFunctionTypes(swift::FunctionType*, swift::FunctionType*, swift::constraints::ConstraintKind, swift::optionset::OptionSet<swift::constraints::ConstraintSystem::TypeMatchFlags, unsigned int>, swift::constraints::ConstraintLocatorBuilder)","signatureAssert":"Assertion failed: (Index < Length && \"Invalid index!\"), function operator[]"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
 Optional#^^# = {

--- a/validation-test/IDE/crashers_fixed/RequirementMachine-verify-93646f.swift
+++ b/validation-test/IDE/crashers_fixed/RequirementMachine-verify-93646f.swift
@@ -1,5 +1,5 @@
 // {"kind":"complete","original":"ac690622","signature":"swift::rewriting::RequirementMachine::verify(swift::rewriting::MutableTerm const&) const"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
 protocol a {
 associatedtype b
 func c -> b

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar116122902.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar116122902.swift
@@ -12,8 +12,7 @@ struct Test {
   var tuple: (value: any AnyValue, id: Int)?
 
   mutating func test<T>(v: Value<T>) {
-    // FIXME(diagnostics): This isn't a useful error message
-    _ = { // expected-error {{unable to infer closure type without a type annotation}}
+    _ = {
       self.tuple = (v, 42)
       return 0
     }

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar116122902.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar116122902.swift
@@ -6,17 +6,15 @@ protocol AnyValue {
 struct Value<T> {}
 
 extension Value: AnyValue where T = { // expected-error {{use '==' for same-type requirements rather than '='}} expected-error {{expected type}}
-// expected-note@-1 {{requirement from conditional conformance of 'Value<T>' to 'AnyValue'}}
 }
 
 struct Test {
   var tuple: (value: any AnyValue, id: Int)?
 
   mutating func test<T>(v: Value<T>) {
-    _ = {
-      // FIXME(diagnostics): This isn't a useful error message
+    // FIXME(diagnostics): This isn't a useful error message
+    _ = { // expected-error {{unable to infer closure type without a type annotation}}
       self.tuple = (v, 42)
-      // expected-error@-1 {{generic struct 'Value' requires the types 'T' and '_' be equivalent}}
       return 0
     }
   }

--- a/validation-test/compiler_crashers_fixed/ContextualFailure-tryProtocolConformanceFixIt-a8c84d.swift
+++ b/validation-test/compiler_crashers_fixed/ContextualFailure-tryProtocolConformanceFixIt-a8c84d.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"bee4b7dd","signature":"swift::constraints::ContextualFailure::tryProtocolConformanceFixIt() const","signatureAssert":"Assertion failed: (!missingProtoTypeStrings.empty() && \"type already conforms to all the protocols?\"), function tryProtocolConformanceFixIt"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 protocol a<b, c> {
   associatedtype b
   associatedtype c

--- a/validation-test/compiler_crashers_fixed/RequirementFailure-RequirementFailure-60a9df.swift
+++ b/validation-test/compiler_crashers_fixed/RequirementFailure-RequirementFailure-60a9df.swift
@@ -1,5 +1,7 @@
 // {"kind":"typecheck","signature":"swift::constraints::RequirementFailure::RequirementFailure(swift::constraints::Solution const&, swift::Type, swift::Type, swift::constraints::ConstraintLocator*)","signatureAssert":"Assertion failed: (getRequirementDC() && \"Couldn't find where the requirement came from?\"), function RequirementFailure"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
-protocol a{associatedtype b} extension a where b == {
-  protocol c var d : c {
-    d
+// RUN: not %target-swift-frontend -typecheck %s
+extension Error where Self == <#type#> {
+  var a: Error {
+    .a
+  }
+}

--- a/validation-test/compiler_crashers_fixed/RequirementFailure-RequirementFailure-60a9df.swift
+++ b/validation-test/compiler_crashers_fixed/RequirementFailure-RequirementFailure-60a9df.swift
@@ -1,7 +1,7 @@
 // {"kind":"typecheck","signature":"swift::constraints::RequirementFailure::RequirementFailure(swift::constraints::Solution const&, swift::Type, swift::Type, swift::constraints::ConstraintLocator*)","signatureAssert":"Assertion failed: (getRequirementDC() && \"Couldn't find where the requirement came from?\"), function RequirementFailure"}
-// RUN: not %target-swift-frontend -typecheck %s
-extension Error where Self == <#type#> {
+// RUN: %target-typecheck-verify-swift
+extension Error where Self == <#type#> { // expected-error {{editor placeholder in source file}} expected-error {{cannot find type '<#type#>' in scope}}
   var a: Error {
-    .a
+    .a // expected-error {{instance member 'a' cannot be used on type 'any Error'}}
   }
 }

--- a/validation-test/compiler_crashers_fixed/RequirementFailure-RequirementFailure-f6e255.swift
+++ b/validation-test/compiler_crashers_fixed/RequirementFailure-RequirementFailure-f6e255.swift
@@ -1,7 +1,5 @@
 // {"kind":"typecheck","signature":"swift::constraints::RequirementFailure::RequirementFailure(swift::constraints::Solution const&, swift::Type, swift::Type, swift::constraints::ConstraintLocator*)","signatureAssert":"Assertion failed: (getRequirementDC() && \"Couldn't find where the requirement came from?\"), function RequirementFailure"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
-extension Error where Self == <#type#> {
-  var a: Error {
-    .a
-  }
-}
+// RUN: not %target-swift-frontend -typecheck %s
+protocol a{associatedtype b} extension a where b == {
+  protocol c var d : c {
+    d

--- a/validation-test/compiler_crashers_fixed/SkipSameTypeRequirement-diagnose-438c8a.swift
+++ b/validation-test/compiler_crashers_fixed/SkipSameTypeRequirement-diagnose-438c8a.swift
@@ -1,4 +1,4 @@
 // {"kind":"typecheck","signature":"swift::constraints::SkipSameTypeRequirement::diagnose(swift::constraints::Solution const&, bool) const","signatureAssert":"Assertion failed: (getGenericContext() && \"Affected decl not within a generic context?\"), function RequirementFailure"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 protocol a struct b extension Dictionary : a where Value == let func !c {
   let d : [Int:b] let : a = d


### PR DESCRIPTION
Split this out of #87073. Refuse to match ErrorType in `matchTypes` and ensure we replace ErrorTypes with holes in opened requirements.