### PR TITLE
Threading: rename `Win32.cpp` to `WindowsThreading.cpp` (NFC)

### DIFF
--- a/Runtimes/Core/Threading/CMakeLists.txt
+++ b/Runtimes/Core/Threading/CMakeLists.txt
@@ -6,7 +6,7 @@ add_library(swiftThreading OBJECT
   "${SwiftCore_SWIFTC_SOURCE_DIR}/lib/Threading/C11.cpp"
   "${SwiftCore_SWIFTC_SOURCE_DIR}/lib/Threading/Linux.cpp"
   "${SwiftCore_SWIFTC_SOURCE_DIR}/lib/Threading/Pthreads.cpp"
-  "${SwiftCore_SWIFTC_SOURCE_DIR}/lib/Threading/Win32.cpp")
+  "${SwiftCore_SWIFTC_SOURCE_DIR}/lib/Threading/WindowsThreading.cpp")
 target_link_libraries(swiftThreading PRIVATE swiftShims)
 
 # FIXME: We should split out the parts that are needed by the runtime

--- a/Runtimes/Core/runtime/CMakeLists.txt
+++ b/Runtimes/Core/runtime/CMakeLists.txt
@@ -57,7 +57,7 @@ add_library(swiftRuntimeCore OBJECT
     ThreadingError.cpp
     Tracing.cpp
     AccessibleFunction.cpp
-    Win32.cpp)
+    WindowsUnicode.cpp)
 
 if(SwiftCore_ENABLE_RUNTIME_LEAK_CHECKER)
   target_sources(swiftRuntimeCore PRIVATE

--- a/lib/Threading/CMakeLists.txt
+++ b/lib/Threading/CMakeLists.txt
@@ -9,6 +9,6 @@ add_swift_host_library(swiftThreading STATIC
   C11.cpp
   Linux.cpp
   Pthreads.cpp
-  Win32.cpp
+  WindowsThreading.cpp
   Errors.cpp
   ThreadSanitizer.cpp)

--- a/lib/Threading/WindowsThreading.cpp
+++ b/lib/Threading/WindowsThreading.cpp
@@ -1,4 +1,4 @@
-//==--- Win32.cpp - Threading abstraction implementation ------- -*-C++ -*-===//
+//===--- WindowsThreading.cpp - Threading abstraction implementation ------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/stdlib/public/Threading/CMakeLists.txt
+++ b/stdlib/public/Threading/CMakeLists.txt
@@ -9,5 +9,5 @@ add_swift_target_library(swiftThreading OBJECT_LIBRARY
   "${SWIFT_SOURCE_DIR}/lib/Threading/C11.cpp"
   "${SWIFT_SOURCE_DIR}/lib/Threading/Linux.cpp"
   "${SWIFT_SOURCE_DIR}/lib/Threading/Pthreads.cpp"
-  "${SWIFT_SOURCE_DIR}/lib/Threading/Win32.cpp"
+  "${SWIFT_SOURCE_DIR}/lib/Threading/WindowsThreading.cpp"
   INSTALL_IN_COMPONENT never_install)

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -81,7 +81,7 @@ set(swift_runtime_sources
     ThreadingError.cpp
     Tracing.cpp
     AccessibleFunction.cpp
-    Win32.cpp)
+    WindowsUnicode.cpp)
 
 # We pull this in separately here because other dylibs will need it, but only
 # will have the __tsan_on_initialize called, and on Darwin, RTLD_NEXT can't be

--- a/stdlib/public/runtime/WindowsUnicode.cpp
+++ b/stdlib/public/runtime/WindowsUnicode.cpp
@@ -1,4 +1,4 @@
-//===--- Win32.cpp - Win32 utility functions --------------------*- C++ -*-===//
+//===--- WindowsUnicode.cpp - Windows Unicode utility functions -*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/stdlib/toolchain/CompatibilityThreading/CMakeLists.txt
+++ b/stdlib/toolchain/CompatibilityThreading/CMakeLists.txt
@@ -5,7 +5,7 @@ add_swift_target_library(swiftCompatibilityThreading OBJECT_LIBRARY
   "${SWIFT_SOURCE_DIR}/lib/Threading/C11.cpp"
   "${SWIFT_SOURCE_DIR}/lib/Threading/Linux.cpp"
   "${SWIFT_SOURCE_DIR}/lib/Threading/Pthreads.cpp"
-  "${SWIFT_SOURCE_DIR}/lib/Threading/Win32.cpp"
+  "${SWIFT_SOURCE_DIR}/lib/Threading/WindowsThreading.cpp"
   INSTALL_IN_COMPONENT never_install
   TARGET_SDKS ${SWIFT_DARWIN_PLATFORMS}
 


### PR DESCRIPTION
This renames the source file to accomodate static linking of the runtime. When `libswiftCore.lib` is linked against, we would encounter a linker warning due to the replicated filename.