### PR TITLE
TempRValueElimination: ignore `fix_lifetime` instruction in alias analysis

### DIFF
--- a/test/SILOptimizer/temp-rvalue-elimination2.swift
+++ b/test/SILOptimizer/temp-rvalue-elimination2.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend %s -O -module-name=test -disable-availability-checking -emit-sil | %FileCheck %s
+
+// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
+
+// CHECK-LABEL: sil @$s4test12getAnyObject4from3keyyXlSgSDySOypG_SOtF :
+// CHECK-NOT:     alloc_stack
+// CHECK-NOT:     copy_addr
+// CHECK:       } // end sil function '$s4test12getAnyObject4from3keyyXlSgSDySOypG_SOtF'
+public func getAnyObject(from dict: Dictionary<ObjectIdentifier, Any>, key: ObjectIdentifier) -> AnyObject? {
+  getValue(from: dict, forKey: key, as: AnyObject.self)
+}
+
+func getValue<Value>(from dict: Dictionary<ObjectIdentifier, Any>, forKey key: ObjectIdentifier, as: Value.Type) -> Value? {
+  @_transparent func project<T>( t: consuming T) -> Value {
+    unsafeBitCast(t, to: Value.self)
+  }
+  if let value = dict[key] {
+    return _openExistential(consume value, do: project)
+  } else {
+    return nil
+  }
+}
+

--- a/test/SILOptimizer/temp_rvalue_opt_ossa.sil
+++ b/test/SILOptimizer/temp_rvalue_opt_ossa.sil
@@ -1897,3 +1897,20 @@ bb1:
   %9 = tuple ()
   return %9 : $()
 }
+
+// CHECK-LABEL: sil [ossa] @ignore_fix_lifetime :
+// CHECK-NOT:     alloc_stack
+// CHECK-NOT:     copy_addr
+// CHECK-LABEL: } // end sil function 'ignore_fix_lifetime'
+sil [ossa] @ignore_fix_lifetime : $@convention(thin) (@inout Klass) -> () {
+bb0(%0 : $*Klass):
+  %1 = alloc_stack $Klass
+  copy_addr %0 to [init] %1
+  fix_lifetime %0
+  %4 = apply undef(%1) : $@convention(thin) (@in_guaranteed Klass) -> ()
+  destroy_addr %1
+  dealloc_stack %1
+  %r = tuple ()
+  return %r
+}
+


### PR DESCRIPTION
`fix_lifetime` has memory-write effects defined.
However, in TempRValueElimination we don't shrink lifetimes. Therefore we can safely ignore this instruction.

rdar://168840965
