### PR TITLE
Runtime: fix the `Runtime` module build

### DIFF
--- a/Runtimes/Supplemental/Runtime/CMakeLists.txt
+++ b/Runtimes/Supplemental/Runtime/CMakeLists.txt
@@ -116,7 +116,7 @@ add_library(swiftRuntime
 
 # Optionally add backtracing sources
 if(${PROJECT_NAME}_ENABLE_BACKTRACING)
-  target_sources(swiftRuntime
+  target_sources(swiftRuntime PRIVATE
     Address.swift
     Backtrace.swift
     Backtrace+Codable.swift
@@ -165,13 +165,13 @@ if(${PROJECT_NAME}_ENABLE_BACKTRACING)
     # the different architectures we support.
     string(TOUPPER "${CMAKE_SYSTEM_PROCESSOR}" processor)
     if(processor STREQUAL "AMD64")
-      target_sources(swiftRuntime
+      target_sources(swiftRuntime PRIVATE
         get-cpu-context-x86_64.asm)
     elseif(processor STREQUAL "X86")
-      target_sources(swiftRuntime
+      target_sources(swiftRuntime PRIVATE
         get-cpu-context-i686.asm)
     elseif(processor STREQUAL "ARM64")
-      target_sources(swiftRuntime
+      target_sources(swiftRuntime PRIVATE
         get-cpu-context-aarch64.asm)
     else()
       message(FATAL_ERROR "You need to implement assembly code for ${processor}")

--- a/Runtimes/Supplemental/Runtime/CMakeLists.txt
+++ b/Runtimes/Supplemental/Runtime/CMakeLists.txt
@@ -98,6 +98,11 @@ add_compile_options(
   "$<$<AND:$<BOOL:${${PROJECT_NAME}_ENABLE_LIBRARY_EVOLUTION}>,$<COMPILE_LANGUAGE:Swift>>:-enable-library-evolution>"
   "$<$<AND:$<BOOL:${${PROJECT_NAME}_ENABLE_PRESPECIALIZATION}>,$<COMPILE_LANGUAGE:Swift>>:SHELL:-Xfrontend -prespecialize-generic-metadata>")
 
+if(WIN32 AND ${CMAKE_SYSTEM_PROCESSOR} MATCHES "X86")
+  # Turn on /safeseh for 32-bit x86 or we won't be able to link
+  add_compile_options($<$<COMPILE_LANGUAGE:ASM_MASM>:/safeseh>)
+endif()
+
 find_package(SwiftSwiftDirectRuntime)
 
 # LNK4049: symbol 'symbol' defined in 'filename.obj' is imported


### PR DESCRIPTION
Correct the build rules for the `Runtime` module. We were missing a keyword in the `target_sources` invocation and did not apply `/SAFESEH` properly for Windows X86.