### PR TITLE
Core: add missing source file for Windows

### DIFF
--- a/Runtimes/Core/runtime/CMakeLists.txt
+++ b/Runtimes/Core/runtime/CMakeLists.txt
@@ -130,7 +130,8 @@ if(SwiftCore_ENABLE_BACKTRACING)
     Backtrace.cpp
     BacktraceUtils.cpp
     CrashHandlerMacOS.cpp
-    CrashHandlerLinux.cpp)
+    CrashHandlerLinux.cpp
+    CrashHandlerWindows.cpp)
 endif()
 
 target_sources(swiftRuntimeCore PRIVATE


### PR DESCRIPTION
The crash handler interface was missing in the runtime build. This re-synchronises the runtime source list.