### PR TITLE
utils: enable backtracing in the runtimes build on Windows

### DIFF
--- a/Runtimes/Supplemental/Runtime/CMakeLists.txt
+++ b/Runtimes/Supplemental/Runtime/CMakeLists.txt
@@ -173,7 +173,7 @@ if(${PROJECT_NAME}_ENABLE_BACKTRACING)
     if(processor STREQUAL "AMD64")
       target_sources(swiftRuntime PRIVATE
         get-cpu-context-x86_64.asm)
-    elseif(processor STREQUAL "X86")
+    elseif(processor STREQUAL "X86" OR processor STREQUAL "I686")
       target_sources(swiftRuntime PRIVATE
         get-cpu-context-i686.asm)
     elseif(processor STREQUAL "ARM64")

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2873,6 +2873,8 @@ function Build-ExperimentalRuntime([Hashtable] $Platform, [switch] $Static = $fa
         dispatch_DIR = (Get-ProjectCMakeModules $Platform CDispatch);
 
         # FIXME(compnerd) remove this once the default option is flipped to `ON`.
+        SwiftCore_ENABLE_BACKTRACING = "YES";
+        # FIXME(compnerd) remove this once the default option is flipped to `ON`.
         SwiftCore_ENABLE_CONCURRENCY = "YES";
         # FIXME(compnerd) remove this once the default option is flipped to `ON`.
         SwiftCore_ENABLE_REMOTE_MIRROR = "YES";
@@ -3045,6 +3047,8 @@ function Build-ExperimentalRuntime([Hashtable] $Platform, [switch] $Static = $fa
         # FIXME(compnerd) this currently causes a build failure on Windows, but
         # this should be enabled when building the dynamic runtime.
         SwiftRuntime_ENABLE_LIBRARY_EVOLUTION = "NO";
+
+        SwiftRuntime_ENABLE_BACKTRACING = "YES";
       }
   }
 }


### PR DESCRIPTION
This enables the backtracing paths on the new runtimes build on Windows which is required to build `swift-backtrace`.