### PR TITLE
Demangling,Runtime: rename source files (NFC)

### DIFF
--- a/Runtimes/Core/Demangling/CMakeLists.txt
+++ b/Runtimes/Core/Demangling/CMakeLists.txt
@@ -8,7 +8,7 @@ add_library(swiftDemangling OBJECT
   "${SwiftCore_SWIFTC_SOURCE_DIR}/lib/Demangling/Punycode.cpp"
   "${SwiftCore_SWIFTC_SOURCE_DIR}/lib/Demangling/Remangler.cpp"
   "${SwiftCore_SWIFTC_SOURCE_DIR}/lib/Demangling/NodeDumper.cpp"
-  "${SwiftCore_SWIFTC_SOURCE_DIR}/lib/Demangling/Errors.cpp")
+  "${SwiftCore_SWIFTC_SOURCE_DIR}/lib/Demangling/DemanglingErrorHandling.cpp")
 target_compile_definitions(swiftDemangling PRIVATE
   $<$<BOOL:${BUILD_SHARED_LIBS}>:-DswiftCore_EXPORTS>
   $<$<BOOL:${SwiftCore_ENABLE_OBJC_INTEROP}>:-DSWIFT_SUPPORT_OLD_MANGLING>

--- a/Runtimes/Core/runtime/CMakeLists.txt
+++ b/Runtimes/Core/runtime/CMakeLists.txt
@@ -22,7 +22,6 @@ add_library(swiftRuntimeCore OBJECT
     EnvironmentVariables.cpp
     ErrorObjectCommon.cpp
     ErrorObjectNative.cpp
-    Errors.cpp
     ErrorDefaultImpls.cpp
     Exception.cpp
     Exclusivity.cpp
@@ -52,6 +51,7 @@ add_library(swiftRuntimeCore OBJECT
     ProtocolConformance.cpp
     RefCount.cpp
     ReflectionMirror.cpp
+    RuntimeErrorReporting.cpp
     RuntimeInvocationsTracking.cpp
     SwiftTLSContext.cpp
     ThreadingError.cpp

--- a/lib/Demangling/CMakeLists.txt
+++ b/lib/Demangling/CMakeLists.txt
@@ -18,7 +18,7 @@ add_swift_host_library(swiftDemangling STATIC
   OldRemangler.cpp
   Punycode.cpp
   Remangler.cpp
-  Errors.cpp
+  DemanglingErrorHandling.cpp
   CrashReporter.cpp)
 target_compile_definitions(swiftDemangling PRIVATE
   ${swift_demangling_compile_flags})

--- a/lib/Demangling/DemanglingErrorHandling.cpp
+++ b/lib/Demangling/DemanglingErrorHandling.cpp
@@ -1,4 +1,4 @@
-//===--- Errors.cpp - Demangling library error handling ---------*- C++ -*-===//
+//===-- DemanglingErrorHandling.cpp - Demangling library error handling ---===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -100,7 +100,7 @@ if(SWIFT_BUILD_STDLIB OR SWIFT_BUILD_REMOTE_MIRROR)
     "${SWIFT_SOURCE_DIR}/lib/Demangling/Punycode.cpp"
     "${SWIFT_SOURCE_DIR}/lib/Demangling/Remangler.cpp"
     "${SWIFT_SOURCE_DIR}/lib/Demangling/NodeDumper.cpp"
-    "${SWIFT_SOURCE_DIR}/lib/Demangling/Errors.cpp")
+    "${SWIFT_SOURCE_DIR}/lib/Demangling/DemanglingErrorHandling.cpp")
   set(swiftDemanglingCRSources
     "${SWIFT_SOURCE_DIR}/lib/Demangling/CrashReporter.cpp")
 

--- a/stdlib/public/Demangling/CMakeLists.txt
+++ b/stdlib/public/Demangling/CMakeLists.txt
@@ -9,7 +9,7 @@ set(swiftDemanglingSources
   "${SWIFT_SOURCE_DIR}/lib/Demangling/Punycode.cpp"
   "${SWIFT_SOURCE_DIR}/lib/Demangling/Remangler.cpp"
   "${SWIFT_SOURCE_DIR}/lib/Demangling/NodeDumper.cpp"
-  "${SWIFT_SOURCE_DIR}/lib/Demangling/Errors.cpp")
+  "${SWIFT_SOURCE_DIR}/lib/Demangling/DemanglingErrorHandling.cpp")
 set(swiftDemanglingCRSources
   "${SWIFT_SOURCE_DIR}/lib/Demangling/CrashReporter.cpp")
 

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -46,7 +46,6 @@ set(swift_runtime_sources
     EnvironmentVariables.cpp
     ErrorObjectCommon.cpp
     ErrorObjectNative.cpp
-    Errors.cpp
     ErrorDefaultImpls.cpp
     Exception.cpp
     Exclusivity.cpp
@@ -63,6 +62,7 @@ set(swift_runtime_sources
     ImageInspectionCOFF.cpp
     ImageInspectionStatic.cpp
     ImageInspectionWasm.cpp
+    RuntimeErrorReporting.cpp
     SymbolInfo.cpp
     KeyPaths.cpp
     KnownMetadata.cpp

--- a/stdlib/public/runtime/RuntimeErrorReporting.cpp
+++ b/stdlib/public/runtime/RuntimeErrorReporting.cpp
@@ -1,4 +1,4 @@
-//===--- Errors.cpp - Error reporting utilities ---------------------------===//
+//===--- RuntimeErrorReporting.cpp - Error reporting utilities ------------===//
 //
 // This source file is part of the Swift.org open source project
 //


### PR DESCRIPTION
This just renames two `Errors.cpp` to different names to accomodate the compaction of `libDemangling` into `swiftCoreRuntime`. This is important as when statically linked we end up with two members with the same name which produces a linker issue:
```
libswiftCore.lib(Errors.cpp.obj) : warning LNK4255: library contain multiple objects of the same name; linking object as if no debug info
```