### PR TITLE
[Tests] NFC: Use result of `Task.init` to silence the warning

### DIFF
--- a/test/NameLookup/member_import_visibility_for_each.swift
+++ b/test/NameLookup/member_import_visibility_for_each.swift
@@ -83,7 +83,7 @@ func testAsync() async throws {
       }
   }
 
-  Task {
+  _ = Task {
     while !Task.isCancelled {
       do {
         for try await _ in getAsyncCounter(upTo: 3) {


### PR DESCRIPTION
It seems like something might be broken about `@discardableResult` on `Task.init` API but for now let's silence the warning to unblock the CI.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
