### PR TITLE
[Concurrency] Look-through explicit capture lists when determining cl…

### DIFF
--- a/test/Concurrency/issue-87097.swift
+++ b/test/Concurrency/issue-87097.swift
@@ -1,0 +1,48 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift  -target %target-swift-5.1-abi-triple %s -parse-as-library -module-name main -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx
+
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: OS=windows-msvc
+
+actor MyActor {
+  func test(_ closure: nonisolated(nonsending) () async -> Void) async {
+    self.assertIsolated()
+    await closure()
+  }
+}
+
+nonisolated func test() async {
+  let a = MyActor()
+  let x = 1
+
+  await a.test { [x] in
+    let iso = #isolation
+    // CHECK: Optional(main.MyActor)
+    print(iso)
+    assert(iso === a)
+    iso!.assertIsolated()
+    a.assertIsolated()
+  }
+
+  await a.test {
+    let iso = #isolation
+    // CHECK: Optional(main.MyActor)
+    print(iso)
+    assert(iso === a)
+    iso!.assertIsolated()
+    a.assertIsolated()
+  }
+}
+
+@main struct Main {
+  static func main() async {
+    await test()
+  }
+}


### PR DESCRIPTION
…osure isolation

We need a contextual parent of the closure expression to determine whether it's a function conversion to a `nonisolated(nonsending)` function type, without that isolation checker would incorrectly mark the closure `@concurrent` in cases where solver conservatively used a conversion instead of apply `nonisolated(nonsending)` onto the closure directly.

Resolves: https://github.com/swiftlang/swift/issues/87097
Resolves: rdar://170007831

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
