### PR TITLE
[Test][LinkerSections] Fix ! pipeline negation for lit internal shell

### DIFF
--- a/test/LinkerSections/function_sections.swift
+++ b/test/LinkerSections/function_sections.swift
@@ -2,8 +2,9 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -Xfrontend -function-sections -emit-module -emit-library -static -parse-stdlib %S/Inputs/FunctionSections.swift -o %t/libFunctionSections.a
 // RUN: %target-build-swift -Xlinker --gc-sections -Xlinker -Map=%t/FunctionSections.map -I%t -L%t -lFunctionSections %S/Inputs/FunctionSectionsUse.swift
-// RUN: ! head -1 %t/FunctionSections.map | grep -q "Archive members" || %FileCheck --check-prefix GOLD %s < %t/FunctionSections.map
-// RUN: ! head -1 %t/FunctionSections.map | grep -q "VMA" || %FileCheck --check-prefix LLD %s < %t/FunctionSections.map
+// RUN: head -1 %t/FunctionSections.map > %t/first-line.txt
+// RUN: ! grep -q "Archive members" %t/first-line.txt || %FileCheck --check-prefix GOLD %s < %t/FunctionSections.map
+// RUN: ! grep -q "VMA" %t/first-line.txt || %FileCheck --check-prefix LLD %s < %t/FunctionSections.map
 
 // GOLD: Discarded input sections
 // GOLD: .text.$s16FunctionSections5func2yyF


### PR DESCRIPTION
Partially address #84407 

I'm not 100% certain but looks like shell `!` negates the entire pipeline's exit code (what's suppose to happen/current implementation), but lit's shell only negates the first command in the pipeline.

The fix is to break the pipeline into a file and a single `!` grep on the file.