### PR TITLE
[UVT] fix type error when mulitple split files are updated

### DIFF
--- a/utils/update_verify_tests/litplugin.py
+++ b/utils/update_verify_tests/litplugin.py
@@ -101,7 +101,7 @@ def propagate_split_files(test_path, updated_files, commands):
         target = SplitFileTarget.create(file, commands, test_path, split_target_dir)
         if target:
             target.copyFrom(file)
-            new.append(target)
+            new.append(str(target))
         else:
             new.append(file)
     return new


### PR DESCRIPTION
When only one file is updated, SplitFile is automatically coerced into a string as part of the string interpolation. When joining multiple strings however, this requires an explicit cast.