### PR TITLE
Reparenting: adjust availability checking

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5636,6 +5636,9 @@ public:
   /// this protocol itself.
   ArrayRef<ProtocolDecl *> getAllInheritedProtocols() const;
 
+  /// Retrieve the set of protocols that are reparenting this protocol.
+  ArrayRef<ProtocolDecl *> getReparentingProtocols() const;
+
   /// Determine whether this protocol has a superclass.
   bool hasSuperclass() const { return (bool)getSuperclassDecl(); }
 
@@ -5731,6 +5734,11 @@ public:
   /// Determine whether this is a "marker" protocol, meaning that is indicates
   /// semantics but has no corresponding witness table.
   bool isMarkerProtocol() const;
+
+  /// Determine whether this is a @reparentable protocol with availability
+  /// that indicates it was introduced in a version that pre-dates the
+  /// current compilation's deployment target.
+  bool isReparentableAndUnavailable() const;
 
   /// Determine if this is an invertible protocol and return its kind,
   /// i.e., for a protocol P, returns the kind if inverse constraint ~P exists.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5636,8 +5636,11 @@ public:
   /// this protocol itself.
   ArrayRef<ProtocolDecl *> getAllInheritedProtocols() const;
 
-  /// Retrieve the set of protocols that are reparenting this protocol.
-  ArrayRef<ProtocolDecl *> getReparentingProtocols() const;
+  /// Retrieve the set of protocols that are reparenting this protocol,
+  /// plus the extension defining the relationship and the index into that
+  /// extension's InheritedTypes where it occurs.
+  ArrayRef<std::tuple<ProtocolDecl *, ExtensionDecl *, unsigned>>
+  getReparentingProtocols() const;
 
   /// Determine whether this protocol has a superclass.
   bool hasSuperclass() const { return (bool)getSuperclassDecl(); }

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2812,6 +2812,9 @@ ERROR(extension_protocol_inheritance,none,
 ERROR(extension_protocol_reparented_not_inheriting,none,
       "%0 must directly inherit from %1 in order to be reparented",
       (const NominalTypeDecl *, const NominalTypeDecl *))
+ERROR(extension_protocol_reparented_duplicate,none,
+      "cannot have multiple declarations of %0 being '@reparented' by %1",
+      (const NominalTypeDecl *, const NominalTypeDecl *))
 ERROR(objc_generic_extension_using_type_parameter,none,
       "extension of a generic Objective-C class cannot access the class's "
       "generic parameters at runtime", ())

--- a/include/swift/AST/NameLookupRequests.h
+++ b/include/swift/AST/NameLookupRequests.h
@@ -243,17 +243,23 @@ public:
 
 /// Computes the set of protocols that are reparenting a given protocol.
 class ReparentingProtocolsRequest
-    : public SimpleRequest<ReparentingProtocolsRequest,
-                           ArrayRef<ProtocolDecl *>(ProtocolDecl *),
-                           RequestFlags::Cached> {
+    : public SimpleRequest<
+          ReparentingProtocolsRequest,
+          ArrayRef<std::tuple<ProtocolDecl *, ExtensionDecl *, unsigned>>(
+              ProtocolDecl *),
+          RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
+
+  /// Indicates a reparenting by a protocol, defined at a specific extension,
+  /// with an index into the extension's InheritedTypes establishing it.
+  using Result = std::tuple<ProtocolDecl *, ExtensionDecl *, unsigned>;
 
 private:
   friend SimpleRequest;
 
   // Evaluation.
-  ArrayRef<ProtocolDecl *> evaluate(Evaluator &, ProtocolDecl *) const;
+  ArrayRef<Result> evaluate(Evaluator &, ProtocolDecl *) const;
 
 public:
   bool isCached() const { return true; }

--- a/include/swift/AST/NameLookupRequests.h
+++ b/include/swift/AST/NameLookupRequests.h
@@ -241,6 +241,24 @@ public:
   void cacheResult(ArrayRef<ValueDecl *> value) const;
 };
 
+/// Computes the set of protocols that are reparenting a given protocol.
+class ReparentingProtocolsRequest
+    : public SimpleRequest<ReparentingProtocolsRequest,
+                           ArrayRef<ProtocolDecl *>(ProtocolDecl *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  ArrayRef<ProtocolDecl *> evaluate(Evaluator &, ProtocolDecl *) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
 /// Requests whether or not this class has designated initializers that are
 /// not public or @usableFromInline.
 class HasMissingDesignatedInitializersRequest :

--- a/include/swift/AST/NameLookupTypeIDZone.def
+++ b/include/swift/AST/NameLookupTypeIDZone.def
@@ -47,7 +47,7 @@ SWIFT_REQUEST(NameLookup, InheritedProtocolsRequest,
               ArrayRef<ProtocolDecl *>(ProtocolDecl *), SeparatelyCached,
               NoLocationInfo)
 SWIFT_REQUEST(NameLookup, AllInheritedProtocolsRequest,
-              ArrayRef<ProtocolDecl *>(ProtocolDecl *), Cached,
+              ArrayRef<ProtocolDecl *>(ProtocolDecl *), SeparatelyCached,
               NoLocationInfo)
 SWIFT_REQUEST(NameLookup, ProtocolRequirementsRequest,
               ArrayRef<ValueDecl *>(ProtocolDecl *), SeparatelyCached,

--- a/include/swift/AST/NameLookupTypeIDZone.def
+++ b/include/swift/AST/NameLookupTypeIDZone.def
@@ -50,7 +50,7 @@ SWIFT_REQUEST(NameLookup, AllInheritedProtocolsRequest,
               ArrayRef<ProtocolDecl *>(ProtocolDecl *), SeparatelyCached,
               NoLocationInfo)
 SWIFT_REQUEST(NameLookup, ReparentingProtocolsRequest,
-              ArrayRef<ProtocolDecl *>(ProtocolDecl *), Cached,
+              ArrayRef<ReparentingProtocolsRequest::Result>(ProtocolDecl *), Cached,
               NoLocationInfo)
 SWIFT_REQUEST(NameLookup, ProtocolRequirementsRequest,
               ArrayRef<ValueDecl *>(ProtocolDecl *), SeparatelyCached,

--- a/include/swift/AST/NameLookupTypeIDZone.def
+++ b/include/swift/AST/NameLookupTypeIDZone.def
@@ -49,6 +49,9 @@ SWIFT_REQUEST(NameLookup, InheritedProtocolsRequest,
 SWIFT_REQUEST(NameLookup, AllInheritedProtocolsRequest,
               ArrayRef<ProtocolDecl *>(ProtocolDecl *), SeparatelyCached,
               NoLocationInfo)
+SWIFT_REQUEST(NameLookup, ReparentingProtocolsRequest,
+              ArrayRef<ProtocolDecl *>(ProtocolDecl *), Cached,
+              NoLocationInfo)
 SWIFT_REQUEST(NameLookup, ProtocolRequirementsRequest,
               ArrayRef<ValueDecl *>(ProtocolDecl *), SeparatelyCached,
               NoLocationInfo)

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7377,11 +7377,11 @@ ArrayRef<ProtocolDecl *> ProtocolDecl::getAllInheritedProtocols() const {
                            {});
 }
 
-ArrayRef<ProtocolDecl *> ProtocolDecl::getReparentingProtocols() const {
+ArrayRef<ReparentingProtocolsRequest::Result>
+ProtocolDecl::getReparentingProtocols() const {
   auto *mutThis = const_cast<ProtocolDecl *>(this);
   return evaluateOrDefault(getASTContext().evaluator,
-                           ReparentingProtocolsRequest{mutThis},
-                           {});
+                           ReparentingProtocolsRequest{mutThis}, {});
 }
 
 ArrayRef<AssociatedTypeDecl *>

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -1493,6 +1493,17 @@ createProtocolToProtocolConformances(ProtocolDecl *protocol) {
     auto const &entry = ext->getInherited().getEntry(index);
     assert(entry.isReparented());
 
+    // If the extension is not available for this deployment target, do not
+    // produce a reparented conformance.
+    if (auto extAvail = ext->getActiveAvailableAttrForCurrentPlatform()) {
+      if (auto protoIntroduction = extAvail->getIntroducedRange(ctx)) {
+        auto deploymentRange = AvailabilityRange::forDeploymentTarget(ctx);
+        if (!deploymentRange.isContainedIn(*protoIntroduction)) {
+          continue;
+        }
+      }
+    }
+
     auto loc = entry.getLoc();
     if (!loc)
       loc = ext->getLoc();

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -1487,38 +1487,20 @@ createProtocolToProtocolConformances(ProtocolDecl *protocol) {
     conformances.push_back(ctx.getSelfConformance(protocol));
   }
 
-  // Search extensions of the protocol for reparented conformances.
-  for (auto *ext : protocol->getExtensions()) {
-    // No valid reparentings can appear outside the protocol's module.
-    if (ext->getModuleContext() != protocol->getModuleContext())
-      continue;
+  for (auto &[newBase, ext, index] : protocol->getReparentingProtocols()) {
+    // We say that 'Self' is what conforms to the @reparented entry.
+    auto conformingType = protocol->getDeclaredInterfaceType();
+    auto const &entry = ext->getInherited().getEntry(index);
+    assert(entry.isReparented());
 
-    auto inheritedTypes = InheritedTypes(ext);
-    for (unsigned i : inheritedTypes.getIndices()) {
-      auto const &entry = inheritedTypes.getEntry(i);
-      if (!entry.isReparented())
-        continue;
+    auto loc = entry.getLoc();
+    if (!loc)
+      loc = ext->getLoc();
 
-      // We may not have already validated the inherited entry.
-      Type inheritedTy =
-          inheritedTypes.getResolvedType(i, TypeResolutionStage::Structural);
-
-      auto baseTy = inheritedTy->getAs<ProtocolType>();
-      if (!baseTy)
-        continue;
-
-      auto baseProto = baseTy->getDecl();
-      assert(baseProto);
-
-      // We say that 'Self' is what conforms to the inherited entry.
-      auto conformingType = protocol->getDeclaredInterfaceType();
-      auto *conf = ctx.getNormalConformance(
-          conformingType, baseTy->getDecl(), entry.getLoc(),
-          entry.getTypeRepr(), /*dc=*/ext, ProtocolConformanceState::Incomplete,
-          ProtocolConformanceFlags::Reparented);
-
-      conformances.push_back(conf);
-    }
+    conformances.push_back(ctx.getNormalConformance(
+        conformingType, newBase, loc, entry.getTypeRepr(), /*dc=*/ext,
+        ProtocolConformanceState::Incomplete,
+        ProtocolConformanceFlags::Reparented));
   }
 
   return conformances;

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -2516,9 +2516,10 @@ public:
       // the default witness table for the inherited protocol's requirements.
       if (auto inheritedTy = requirement.getType()->getAs<ProtocolType>()) {
         ProtocolDecl const *inherited = inheritedTy->getDecl();
-        auto isForReparenting = llvm::any_of(
-            proto->getReparentingProtocols(),
-            [&](ProtocolDecl const *RP) { return RP == inherited; });
+        bool isForReparenting = llvm::any_of(
+            proto->getReparentingProtocols(), [=](auto const &tup) {
+              return std::get<ProtocolDecl *>(tup) == inherited;
+            });
         if (isForReparenting) {
           continue;
         }

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -214,6 +214,12 @@ static void checkReparentedExtensionEntry(const ExtensionDecl *ext,
       childProto->getInheritedProtocols(),
       [&](ProtocolDecl *inherited) { return inherited == reparentedProto; });
 
+  // If the protocol is unavailable, then there's no issue.
+  if (reparentedProto->isReparentableAndUnavailable()) {
+    ASSERT(!found && "shouldn't be inheriting from an unavailable protocol!");
+    return;
+  }
+
   if (!found) {
     ext->getASTContext().Diags.diagnose(
         entry.getLoc(), diag::extension_protocol_reparented_not_inheriting,

--- a/test/Availability/Inputs/reparenting.swift
+++ b/test/Availability/Inputs/reparenting.swift
@@ -1,0 +1,31 @@
+@available(macOS 12, *)
+@reparentable public protocol NewProto {
+  associatedtype Thing: Equatable
+  func new() -> Thing
+}
+
+public protocol Existing: NewProto {
+  associatedtype Thing: Equatable = String
+  func existing() -> Thing
+}
+
+public protocol Derived: Existing {
+  func derived() -> Thing
+}
+
+@available(macOS 12, *)
+extension Existing: @reparented NewProto where Thing == String {
+  public func new() -> Thing { return "defaulted Existing.new" }
+}
+
+
+public func libraryFunc(_ s: some Derived) {
+  print("libraryFunc start")
+  if #available(macOS 12, *) {
+    // FIXME: this doesn't work due to "referencing instance method 'new()' on 'Existing' requires the types '(some Derived).Thing' and 'String' be equivalent"
+    // rdar://170187513
+    // print(s.new())
+    print("defaulted Existing.new")
+  }
+  print("libraryFunc end")
+}

--- a/test/Availability/availability_reparenting.swift
+++ b/test/Availability/availability_reparenting.swift
@@ -1,0 +1,50 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature Reparenting
+
+// REQUIRES: OS=macosx
+
+// REQUIRES: swift_feature_Reparenting
+
+public protocol Seq: BorrowingSeq {
+  func seq()
+}
+
+@available(macOS 99, *)
+@reparentable public protocol BorrowingSeq {
+  func borrowSeq()
+}
+
+@available(macOS 99, *)
+extension Seq: @reparented BorrowingSeq {
+  public func borrowSeq() {
+    self.seq()
+  }
+}
+
+func tryToUseRequirement(_ s: some Seq) { // expected-note {{add '@available' attribute to enclosing global function}}
+  s.seq()
+  s.borrowSeq() // expected-error {{'borrowSeq()' is only available in macOS 99 or newer}}
+  // expected-note@-1 {{add 'if #available' version check}}
+}
+
+func correctedUse(_ s: some Seq) {
+  if #available(macOS 99, *) {
+    s.borrowSeq()
+  } else {
+    s.seq()
+  }
+}
+
+func useAsBorrowingSeq1(_ bs: some BorrowingSeq) {} // expected-error 2{{'BorrowingSeq' is only available in macOS 99 or newer}} // expected-note 2{{}}
+func useAsBorrowingSeq2<T>(_ t: T) where T: BorrowingSeq {} // expected-error {{'BorrowingSeq' is only available in macOS 99 or newer}} // expected-note {{}}
+
+public struct AlwaysAvailableStruct: BorrowingSeq {
+  public func borrowSeq() {}
+}
+
+protocol NotAReparenting: BorrowingSeq {} // expected-error {{'BorrowingSeq' is only available in macOS 99 or newer}} // expected-note{{add '@available' attribute to enclosing protocol}}
+
+protocol ForgotAvailabilityOnReparenting: BorrowingSeq {}
+
+extension ForgotAvailabilityOnReparenting: @reparented BorrowingSeq { // expected-error {{'BorrowingSeq' is only available in macOS 99 or newer}} // expected-note {{}}
+  public func borrowSeq() {}
+}

--- a/test/Availability/availability_reparenting2.swift
+++ b/test/Availability/availability_reparenting2.swift
@@ -1,0 +1,58 @@
+//////////////////
+// Try first with an older macOS 10.15 library and client.
+
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 -parse-as-library -emit-library -enable-experimental-feature Reparenting \
+// RUN:     -emit-module-path %t/Reparenting.swiftmodule -module-name Reparenting -enable-library-evolution %S/Inputs/Reparenting.swift -o %t/%target-library-name(Reparenting)
+// RUN: %target-codesign %t/%target-library-name(Reparenting)
+// RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 -lReparenting -module-name main -I %t -L %t %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+//////////////////
+// Now do it all again, but with a macOS 12 library as the target that includes the reparented conformance
+// and test deployment targets both old and new
+
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -target %target-cpu-apple-macosx12 -parse-as-library -emit-library -enable-experimental-feature Reparenting \
+// RUN:     -emit-module-path %t/Reparenting.swiftmodule -module-name Reparenting -enable-library-evolution %S/Inputs/Reparenting.swift -o %t/%target-library-name(Reparenting)
+// RUN: %target-codesign %t/%target-library-name(Reparenting)
+
+// RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 -lReparenting -module-name main -I %t -L %t %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck --check-prefixes=CHECK,NEW-LIB %s
+
+// RUN: %target-build-swift -target %target-cpu-apple-macosx12 -lReparenting -module-name main -I %t -L %t %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck --check-prefixes=CHECK,NEW-LIB,NEW-CLIENT %s
+
+// REQUIRES: OS=macosx && (CPU=x86_64 || CPU=arm64)
+// REQUIRES: executable_test
+// UNSUPPORTED: remote_run || device_run
+
+// REQUIRES: swift_feature_Reparenting
+
+import Reparenting
+
+struct MyStruct: Derived {
+  typealias Thing = String
+  func existing() -> String { return "MyStruct.existing" }
+  func derived() -> String { return "MyStruct.derived" }
+}
+
+defer { main() }
+func main() {
+  print("start test")  // CHECK: start test
+  let ms = MyStruct()
+  print(ms.derived())  // CHECK: MyStruct.derived
+  print(ms.existing()) // CHECK: MyStruct.existing
+
+  if #available(macOS 12, *) {
+    print(ms.new())    // NEW-CLIENT: defaulted Existing.new
+  }
+
+  // CHECK: libraryFunc start
+  // NEW-LIB: defaulted Existing.new
+  // CHECK: libraryFunc end
+  libraryFunc(ms)
+}

--- a/test/Sema/reparenting.swift
+++ b/test/Sema/reparenting.swift
@@ -41,6 +41,7 @@ extension Invalid: @reparented Q & R {}
 @objc protocol ObjCProto {}
 extension ObjCProto: @reparented Q {}
 // expected-error @-1 {{@objc protocol 'ObjCProto' cannot be '@reparented'}}
+// expected-error @-2 {{'ObjCProto' must directly inherit from 'Q' in order to be reparented}}
 
 
 


### PR DESCRIPTION
A base protocol typically is not permitted to be less available than
one deriving (or inheriting) from it. Reparentable protocols are those
that are expected to violate that rule, by being newer than the protocol
being reparented by it.

We can handle this case cleanly by treating the derived protocol P as
not inheriting from the reparentable protocol R, when the deployment
target indicates the reparentable protocol didn't exist.

This helps us because if some type S: P, then we typically create
and check conformances for all protocols inherited by P.
But in forming the conformance of S: P, we can't form the base
conformance descriptor for P: R if R's metadata isn't present on
an older deployment target.

rdar://170097155