### PR TITLE
[Concurrency] Consistent use of @discardableResult in Task.immediate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@
 
 ## Swift (next)
 
+* Unstructured task initializers (`Task.init`, `Task.immediate`, `Task.detached`, etc) now use typed-throws
+  and will warn if an operation is throwing and the result of the task is not stored or ignored. This 
+  addresses a long standing issue where it was too easy to miss that an operation was throwing:
+  
+  ```swift
+  Task { // now warns that result is ignored
+    try example()
+  }
+  Task { // no warning, as previously
+    try example()
+  }
+  ```
+
 * Calling from Objective-C into into asynchronous Swift APIs will now attempt use `Task.immediate`
   instead of `Task` when available. This reduces the initial enqueue delay which Task would incur
   (by enqueueing on the global pool before calling the async target), and can improve performance

--- a/stdlib/public/Concurrency/Task+immediate.swift.gyb
+++ b/stdlib/public/Concurrency/Task+immediate.swift.gyb
@@ -35,7 +35,7 @@ import Swift
 
 @available(SwiftStdlib 6.2, *)
 % if IS_THROWING:
-extension Task { // throwing Failure error type
+extension Task { // typed throwing Failure error type
 % else:
 extension Task where Failure == ${FAILURE_TYPE} {
 % end
@@ -76,7 +76,9 @@ extension Task where Failure == ${FAILURE_TYPE} {
   /// - Returns: A reference to the unstructured task which may be awaited on.
   @available(SwiftStdlib 6.2, *)
   @_alwaysEmitIntoClient
+% if not IS_THROWING:
   @discardableResult
+% end
   public static func ${METHOD_NAME}(
     name: String? = nil,
     priority: TaskPriority? = nil,

--- a/stdlib/public/Concurrency/Task+init.swift.gyb
+++ b/stdlib/public/Concurrency/Task+init.swift.gyb
@@ -296,9 +296,7 @@ extension Task where Failure == ${FAILURE_TYPE} {
   /// - Returns: A reference to the task.
 % end # IS_DEPRECATED
   ${"\n  ".join(adjust_availability(ALL_AVAILABILITY))}
-% if not IS_THROWING:
   @discardableResult
-% end
   public ${METHOD_VARIANT}(
     ${",\n    ".join(adjust_params_for_kind(PARAMS))}
   ) ${ARROW_RETURN_TYPE}{

--- a/stdlib/public/Concurrency/Task+init.swift.gyb
+++ b/stdlib/public/Concurrency/Task+init.swift.gyb
@@ -296,7 +296,9 @@ extension Task where Failure == ${FAILURE_TYPE} {
   /// - Returns: A reference to the task.
 % end # IS_DEPRECATED
   ${"\n  ".join(adjust_availability(ALL_AVAILABILITY))}
+% if not IS_THROWING:
   @discardableResult
+% end
   public ${METHOD_VARIANT}(
     ${",\n    ".join(adjust_params_for_kind(PARAMS))}
   ) ${ARROW_RETURN_TYPE}{

--- a/test/Concurrency/task_discardable_result.swift
+++ b/test/Concurrency/task_discardable_result.swift
@@ -1,0 +1,74 @@
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %s -emit-sil -o /dev/null -verify
+
+// REQUIRES: concurrency
+
+enum Boom: Error {
+  case bang
+}
+
+@available(SwiftStdlib 6.2, *)
+func tests() async {
+  // Task.init
+
+  Task {
+    42
+  }
+
+  Task { () throws -> Int in // expected-warning {{result of 'Task<Success, Failure>' initializer is unused}}
+    if Bool.random() { throw Boom.bang }
+    return 42
+  }
+
+  Task { () throws(Boom) -> Int in // expected-warning {{result of 'Task<Success, Failure>' initializer is unused}}
+    if Bool.random() { throw Boom.bang }
+    return 42
+  }
+
+  // Task.detached
+
+  Task.detached {
+    42
+  }
+
+  Task.detached { () throws -> Int in // expected-warning {{result of call to 'detached(name:priority:operation:)' is unused}}
+    if Bool.random() { throw Boom.bang }
+    return 42
+  }
+
+  Task.detached { () throws(Boom) -> Int in // expected-warning {{result of call to 'detached(name:priority:operation:)' is unused}}
+    if Bool.random() { throw Boom.bang }
+    return 42
+  }
+
+  // Task.immediate
+
+  Task.immediate {
+    42
+  }
+
+  Task.immediate { () throws -> Int in // expected-warning {{result of call to 'immediate(name:priority:executorPreference:operation:)' is unused}}
+    if Bool.random() { throw Boom.bang }
+    return 42
+  }
+
+  Task.immediate { () throws(Boom) -> Int in // expected-warning {{result of call to 'immediate(name:priority:executorPreference:operation:)' is unused}}
+    if Bool.random() { throw Boom.bang }
+    return 42
+  }
+
+  // Task.immediateDetached
+
+  Task.immediateDetached {
+    42
+  }
+
+  Task.immediateDetached { () throws -> Int in // expected-warning {{result of call to 'immediateDetached(name:priority:executorPreference:operation:)' is unused}}
+    if Bool.random() { throw Boom.bang }
+    return 42
+  }
+
+  Task.immediateDetached { () throws(Boom) -> Int in // expected-warning {{result of call to 'immediateDetached(name:priority:executorPreference:operation:)' is unused}}
+    if Bool.random() { throw Boom.bang }
+    return 42
+  }
+}


### PR DESCRIPTION
During the adoption of typed throws we improved the handling of discarding Task when the operation is throwing. This is a long debated problem where it is too simple to ignore failures in `Task {}` and we made this change consistently for all unstructured tasks now.

Added changelog entry to make this explicit.