### PR TITLE
LifetimeDependence: Prevent lifetime dependencies on escaping function types

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8522,6 +8522,8 @@ NOTE(lifetime_escapable_source_requires_escapable_note, none,
      "use '@_lifetime(%0%1)' instead", (StringRef, StringRef))
 ERROR(lifetime_dependence_unknown_type, none,
       "lifetime dependence checking failed due to unknown %0 type", (StringRef))
+ERROR(lifetime_dependence_escaping_closure, none,
+      "an escaping function type cannot output ~Escapable values", ())
 
 //------------------------------------------------------------------------------
 // MARK: Lifetime Dependence Requirements

--- a/test/ModuleInterface/Inputs/lifetime_underscored_dependence.swift
+++ b/test/ModuleInterface/Inputs/lifetime_underscored_dependence.swift
@@ -101,21 +101,8 @@ public func takeCopier(f: @_lifetime(io: copy io) @_lifetime(copy inview) (_ inv
 @inlinable
 public func takeCopierUnannotated(f: (consuming AnotherView) -> AnotherView) {}
 
-public typealias ExplicitNestedType = @_lifetime(copy ne0) @_lifetime(ne1: copy ne0) ((AnotherView) -> AnotherView, _ ne0: consuming AnotherView, _ ne1: inout AnotherView) -> AnotherView
-
 @inlinable
-public func takeExplicitNestedType(f: ExplicitNestedType) {}
-
-
-@inlinable
-public func returnableCopier(_ aView: AnotherView) -> AnotherView {
-  return aView
-}
-
-@inlinable
-public func returnCopier() -> @_lifetime(copy a) (_ a: AnotherView) -> AnotherView {
-  return returnableCopier
-}
+public func takeExplicitNestedType(f: @_lifetime(copy ne0) @_lifetime(ne1: copy ne0) ((AnotherView) -> AnotherView, _ ne0: consuming AnotherView, _ ne1: inout AnotherView) -> AnotherView) {}
 
 @inlinable
 @_lifetime(dest: immortal)

--- a/test/ModuleInterface/lifetime_underscored_dependence_test.swift
+++ b/test/ModuleInterface/lifetime_underscored_dependence_test.swift
@@ -143,27 +143,7 @@ import lifetime_underscored_dependence
 // CHECK: @inlinable public func takeCopierUnannotated(f: (consuming lifetime_underscored_dependence.AnotherView) -> lifetime_underscored_dependence.AnotherView) {}
 
 // CHECK: #if compiler(>=5.3) && $ClosureLifetimes
-// CHECK-NEXT: public typealias ExplicitNestedType = @_lifetime(copy ne0) @_lifetime(ne1: copy ne0, copy ne1) ((lifetime_underscored_dependence.AnotherView) -> lifetime_underscored_dependence.AnotherView, _ ne0: consuming lifetime_underscored_dependence.AnotherView, _ ne1: inout lifetime_underscored_dependence.AnotherView) -> lifetime_underscored_dependence.AnotherView
-// CHECK-NEXT: #endif
-
-// CHECK: #if compiler(>=5.3) && $ClosureLifetimes
 // CHECK-NEXT: @inlinable public func takeExplicitNestedType(f: @_lifetime(copy ne0) @_lifetime(ne1: copy ne0, copy ne1) ((lifetime_underscored_dependence.AnotherView) -> lifetime_underscored_dependence.AnotherView, _ ne0: consuming lifetime_underscored_dependence.AnotherView, _ ne1: inout lifetime_underscored_dependence.AnotherView) -> lifetime_underscored_dependence.AnotherView) {} 
-// CHECK-NEXT: #endif
-
-// CHECK: #if compiler(>=5.3) && $Lifetimes
-// CHECK-NEXT: @inlinable public func returnableCopier(_ aView: lifetime_underscored_dependence.AnotherView) -> lifetime_underscored_dependence.AnotherView {
-// CHECK-NEXT:   return aView
-// CHECK-NEXT: }
-// CHECK-NEXT: #else
-// CHECK-NEXT: @inlinable public func returnableCopier(_ aView: lifetime_underscored_dependence.AnotherView) -> lifetime_underscored_dependence.AnotherView {
-// CHECK-NEXT:   return aView
-// CHECK-NEXT: }
-// CHECK-NEXT: #endif
-
-// CHECK: #if compiler(>=5.3) && $ClosureLifetimes
-// CHECK-NEXT: @inlinable public func returnCopier() -> @_lifetime(copy a) (_ a: lifetime_underscored_dependence.AnotherView) -> lifetime_underscored_dependence.AnotherView {
-// CHECK-NEXT:  return returnableCopier
-// CHECK-NEXT: }
 // CHECK-NEXT: #endif
 
 // CHECK: #if compiler(>=5.3) && $Lifetimes

--- a/test/SIL/explicit_lifetime_dependence_specifiers.swift
+++ b/test/SIL/explicit_lifetime_dependence_specifiers.swift
@@ -15,40 +15,34 @@ struct NE: ~Escapable {}
 // dependence information, since these may be used to refer to the sources and
 // targets of lifetimes.
 
-// CHECK-LABEL: typealias LabelledNE2NE = @_lifetime(copy ne) (_ ne: NE) -> NE
-typealias LabelledNE2NE = @_lifetime(copy ne) (_ ne: NE) -> NE
-// CHECK-LABEL: typealias InferredNE2NE = (NE) -> NE
-typealias InferredNE2NE = (NE) -> NE
-// CHECK-LABEL: typealias InferredLabelledNE2NE = (NE) -> NE
-typealias InferredLabelledNE2NE = (_ ne: NE) -> NE
+// CHECK-LABEL: func takeLabelledNE2NE(f: @_lifetime(copy ne) (_ ne: NE) -> NE)
+func takeLabelledNE2NE(f: @_lifetime(copy ne) (_ ne: NE) -> NE) {}
+// CHECK-LABEL: func takeInferredNE2NE(f: (NE) -> NE)
+func takeInferredNE2NE(f: (NE) -> NE) {}
+// CHECK-LABEL: func takeInferredLabelledNE2NE(f: (NE) -> NE)
+func takeInferredLabelledNE2NE(f: (_ ne: NE) -> NE) {}
 
-// CHECK-LABEL: typealias NamedLifetimeType = @_lifetime(copy ne) (_ ne: NE, _ ne2: NE) -> NE
-typealias NamedLifetimeType = @_lifetime(copy ne) (_ ne: NE, _ ne2: NE) -> NE
-// CHECK-LABEL: typealias InferredLifetimeType = (NE, NE) -> NE
-typealias InferredLifetimeType = (_ ne: NE, NE) -> NE
-// CHECK-LABEL: typealias ImmortalLifetimeType = @_lifetime(immortal) (_ ne: NE, _ ne2: NE) -> NE
-typealias ImmortalLifetimeType = @_lifetime(immortal) (_ ne: NE, _ ne2: NE) -> NE
+// CHECK-LABEL: func takeNamedLifetimeType(f: @_lifetime(copy ne) (_ ne: NE, _ ne2: NE) -> NE)
+func takeNamedLifetimeType(f: @_lifetime(copy ne) (_ ne: NE, _ ne2: NE) -> NE) {}
+// CHECK-LABEL: func takeInferredLifetimeType(f: (NE, NE) -> NE)
+func takeInferredLifetimeType(f: (_ ne: NE, NE) -> NE) {}
+// CHECK-LABEL: func takeImmortalLifetimeType(f: @_lifetime(immortal) (_ ne: NE, _ ne2: NE) -> NE)
+func takeImmortalLifetimeType(f: @_lifetime(immortal) (_ ne: NE, _ ne2: NE) -> NE) {}
 
-// CHECK-LABEL: typealias NoLifetimeType = (Int) -> Int
-typealias NoLifetimeType = (_ x: Int) -> Int
+// CHECK-LABEL: func takeNoLifetimeType(f: (Int) -> Int)
+func takeNoLifetimeType(f: (_ x: Int) -> Int) {}
 
-// CHECK: typealias MixedLifetimeType = @_lifetime(copy ne0) (_ ne0: NE, _ neio: inout NE) -> NE
-typealias MixedLifetimeType = @_lifetime(copy ne0) (_ ne0: NE, _ neio: inout NE) -> NE
-// CHECK: typealias NestedLifetimeType = @_lifetime(neo: copy ne0, copy neo) (_ nei: inout NE, _ ne0: NE, _ neo: inout NE) -> (NE) -> NE
-typealias NestedLifetimeType = @_lifetime(neo: copy ne0) (_ nei: inout NE, _ ne0: NE, _ neo: inout NE) -> (_ ne1: NE) -> NE
-
-// CHECK-LABEL: typealias NestedType = @_lifetime(copy ne2) @_lifetime(ne3: copy ne2, copy ne3) (@_lifetime(copy ne0) @_lifetime(ne1: copy ne1) (_ ne0: NE, _ ne1: inout NE) -> NE, _ ne2: consuming NE, _ ne3: inout NE) -> NE
-typealias NestedType =
-  @_lifetime(copy ne2) @_lifetime(ne3: copy ne2)
-  (@_lifetime(copy ne0) @_lifetime(ne1: copy ne1) (_ ne0: NE, _ ne1: inout NE) -> NE,
-   _ ne2: consuming NE, _ ne3: inout NE) -> NE
+// CHECK: func takeMixedLifetimeType(f: @_lifetime(copy ne0) (_ ne0: NE, _ neio: inout NE) -> NE)
+func takeMixedLifetimeType(f: @_lifetime(copy ne0) (_ ne0: NE, _ neio: inout NE) -> NE) {}
 
 // CHECK-LABEL: func takeNestedType(f: @_lifetime(copy ne2) @_lifetime(ne3: copy ne2, copy ne3) (@_lifetime(copy ne0) @_lifetime(ne1: copy ne1) (_ ne0: NE, _ ne1: inout NE) -> NE, _ ne2: consuming NE, _ ne3: inout NE) -> NE)
 
 // CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers14takeNestedType1fyAA2NEVA2E_AEztXE_AEnAEztXE_tF
 // : $@convention(thin) (@guaranteed @noescape @callee_guaranteed (@guaranteed @noescape @callee_guaranteed (@guaranteed
 // NE, @lifetime(copy 1) @inout NE) -> @lifetime(copy 0) @owned NE, @owned NE, @lifetime(copy 1, copy 2) @inout NE) -> @lifetime(copy 1) @owned NE) -> () {
-func takeNestedType(f: NestedType) {}
+func takeNestedType(f: @_lifetime(copy ne2) @_lifetime(ne3: copy ne2)
+  (@_lifetime(copy ne0) @_lifetime(ne1: copy ne1) (_ ne0: NE, _ ne1: inout NE) -> NE,
+   _ ne2: consuming NE, _ ne3: inout NE) -> NE) {}
 
 struct BufferView : ~Escapable {
   let ptr: UnsafeRawBufferPointer

--- a/test/SIL/implicit_lifetime_dependence.swift
+++ b/test/SIL/implicit_lifetime_dependence.swift
@@ -7,13 +7,10 @@
 
 struct NE: ~Escapable {}
 
-// CHECK-LABEL: typealias ImplicitNestedType = ((NE, inout NE) -> NE, consuming NE, inout NE) -> NE
-typealias ImplicitNestedType = ((NE, inout NE) -> NE, consuming NE, inout NE) -> NE
-
 // CHECK-LABEL: func takeImplicitNestedType(f: ((NE, inout NE) -> NE, consuming NE, inout NE) -> NE)
 
 // CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence22takeImplicitNestedType1fyAA2NEVA2E_AEztXE_AEnAEztXE_tF : $@convention(thin) (@guaranteed @noescape @callee_guaranteed (@guaranteed @noescape @callee_guaranteed (@guaranteed NE, @lifetime(copy 1) @inout NE) -> @lifetime(copy 0) @owned NE, @owned NE, @lifetime(copy 2) @inout NE) -> @lifetime(copy 1) @owned NE) -> () {
-func takeImplicitNestedType(f: ImplicitNestedType) {}
+func takeImplicitNestedType(f: ((NE, inout NE) -> NE, consuming NE, inout NE) -> NE) {}
 
 struct BufferView : ~Escapable {
   let ptr: UnsafeRawBufferPointer

--- a/test/Sema/lifetime_attr_nofeature.swift
+++ b/test/Sema/lifetime_attr_nofeature.swift
@@ -13,8 +13,8 @@ func f_inout_infer(a: inout MutableRawSpan) {} // DEFAULT OK
 
 func f_inout_no_infer(a: inout MutableRawSpan, b: RawSpan) {} // DEFAULT OK
 
-typealias DeriveType = @_lifetime(copy ne) (_ ne: NE) -> NE // expected-error{{'@_lifetime' attribute is only valid when experimental feature Lifetimes is enabled}}
+func takeDeriveType(f: @_lifetime(copy ne) (_ ne: NE) -> NE) {} // expected-error{{'@_lifetime' attribute is only valid when experimental feature Lifetimes is enabled}}
 
-typealias InoutInferType = (inout MutableRawSpan) -> Void // DEFAULT OK
+func takeInoutInferType(f: (inout MutableRawSpan) -> Void) {} // DEFAULT OK
 
-typealias InoutNoInferType = (inout MutableRawSpan, RawSpan) -> Void // DEFAULT OK
+func takeInoutNoInferType(f: (inout MutableRawSpan, RawSpan) -> Void) {} // DEFAULT OK

--- a/test/Sema/lifetime_dependence_functype.swift
+++ b/test/Sema/lifetime_dependence_functype.swift
@@ -57,72 +57,74 @@ func testBorrow(nc: consuming NC) {
 
 // Tests adapted from lifetime_attr.swift for function types.
 class Klass {}
-typealias InvalidAttrOnNonExistingParamType = @_lifetime(copy nonexisting) (_ ne: NE) -> NE // expected-error{{invalid parameter name specified 'nonexisting'}}
+func takeInvalidAttrOnNonExistingParamType(f: @_lifetime(copy nonexisting) (_ ne: NE) -> NE) {} // expected-error{{invalid parameter name specified 'nonexisting'}}
 
-typealias InvalidAttrOnNonExistingSelfType = @_lifetime(copy self) (_ ne: NE) -> NE // expected-error{{invalid lifetime dependence specifier on non-existent self}}
+func takeInvalidAttrOnNonExistingSelfType(f: @_lifetime(copy self) (_ ne: NE) -> NE) {} // expected-error{{invalid lifetime dependence specifier on non-existent self}}
 
-typealias InvalidAttrOnExistingParamIndexType = @_lifetime(0) (_ ne: NE) -> NE // expected-error{{expected 'copy', 'borrow', or '&' followed by an identifier or 'self' in lifetime dependence specifier}}
+func takeInvalidAttrOnExistingParamIndexType(f: @_lifetime(0) (_ ne: NE) -> NE) {} // expected-error{{expected 'copy', 'borrow', or '&' followed by an identifier or 'self' in lifetime dependence specifier}}
 
-typealias InvalidAttrOnNonExistingParamIndexType = @_lifetime(2) (_ ne: NE) -> NE // expected-error{{expected 'copy', 'borrow', or '&' followed by an identifier or 'self' in lifetime dependence specifier}}
+func takeInvalidAttrOnNonExistingParamIndexType(f: @_lifetime(2) (_ ne: NE) -> NE) {} // expected-error{{expected 'copy', 'borrow', or '&' followed by an identifier or 'self' in lifetime dependence specifier}}
 
-typealias InvalidDuplicateLifetimeDependenceType = @_lifetime(copy ne, borrow ne) (_ ne: borrowing NE) -> NE // expected-error{{duplicate lifetime dependence specifier}}
+func takeInvalidDuplicateLifetimeDependenceType(f: @_lifetime(copy ne, borrow ne) (_ ne: borrowing NE) -> NE) {} // expected-error{{duplicate lifetime dependence specifier}}
 
-typealias InvalidDependenceConsumeKlassType = @_lifetime(borrow x) (_ x: consuming Klass) -> NE // expected-error{{invalid use of borrow dependence with consuming ownership}}
+func takeInvalidDependenceConsumeKlassType(f: @_lifetime(borrow x) (_ x: consuming Klass) -> NE) {} // expected-error{{invalid use of borrow dependence with consuming ownership}}
 
-typealias InvalidDependenceBorrowKlassType = @_lifetime(&x) (_ x: borrowing Klass) -> NE // expected-error{{invalid use of & dependence with borrowing ownership}}
+func takeInvalidDependenceBorrowKlassType(f: @_lifetime(&x) (_ x: borrowing Klass) -> NE) {} // expected-error{{invalid use of & dependence with borrowing ownership}}
                                                                                          // expected-note @-1{{use '@_lifetime(borrow x)' instead}}
 
-typealias InvalidDependenceInoutKlassType = @_lifetime(borrow x) (_ x: inout Klass) -> NE // expected-error{{invalid use of borrow dependence with inout ownership}}
+func takeInvalidDependenceInoutKlassType(f: @_lifetime(borrow x) (_ x: inout Klass) -> NE) {} // expected-error{{invalid use of borrow dependence with inout ownership}}
                                                                                           // expected-note @-1{{use '@_lifetime(&x)' instead}}
 
-typealias InvalidDependenceConsumeIntType = @_lifetime(borrow x) (_ x: consuming Int) -> NE // OK
+func takeInvalidDependenceConsumeIntType(f: @_lifetime(borrow x) (_ x: consuming Int) -> NE) {} // OK
 
-typealias InvalidDependenceBorrowIntType = @_lifetime(&x) (_ x: borrowing Int) -> NE // expected-error{{invalid use of & dependence with borrowing ownership}}
+func takeInvalidDependenceBorrowIntType(f: @_lifetime(&x) (_ x: borrowing Int) -> NE) {} // expected-error{{invalid use of & dependence with borrowing ownership}}
                                                                                      // expected-note @-1{{use '@_lifetime(borrow x)' instead}}
 
-typealias InvalidDependenceInoutIntType = @_lifetime(borrow x) (_ x: inout Int) -> NE // expected-error{{invalid use of borrow dependence with inout ownership}}
+func takeInvalidDependenceInoutIntType(f: @_lifetime(borrow x) (_ x: inout Int) -> NE) {} // expected-error{{invalid use of borrow dependence with inout ownership}}
                                                                                       // expected-note @-1{{use '@_lifetime(&x)' instead}}
 
-typealias InvalidTargetType =
-  @_lifetime(result: copy source1)
-  @_lifetime(result: copy source2) // expected-error{{invalid duplicate target lifetime dependencies on function}}                                 
-  (_ result: inout NE, _ source1: consuming NE, _ source2: consuming NE) -> ()
+func takeInvalidTargetType(
+  f:
+    @_lifetime(result: copy source1)
+    @_lifetime(result: copy source2) // expected-error{{invalid duplicate target lifetime dependencies on function}}                                 
+    (_ result: inout NE, _ source1: consuming NE, _ source2: consuming NE) -> ()) {}
 
-typealias InvalidSourceType =
-  @_lifetime(result: copy source)
-  @_lifetime(result: borrow source) // expected-error{{invalid duplicate target lifetime dependencies on function}}
-  (_ result: inout NE, _ source: consuming NE) -> ()
+func takeInvalidSourceType(
+  f:
+    @_lifetime(result: copy source)
+    @_lifetime(result: borrow source) // expected-error{{invalid duplicate target lifetime dependencies on function}}
+    (_ result: inout NE, _ source: consuming NE) -> ()) {}
 
-typealias ImmortalConflictType = @_lifetime(immortal) (_ immortal: Int) -> NE // expected-error{{conflict between the parameter name and 'immortal' contextual keyword}}
+func takeImmortalConflictType(f: @_lifetime(immortal) (_ immortal: Int) -> NE) {} // expected-error{{conflict between the parameter name and 'immortal' contextual keyword}}
 
-typealias TestParameterDepType = @_lifetime(span: borrow holder) (_ holder: AnyObject, _ span: Span<Int>) -> () // expected-error{{lifetime-dependent parameter 'span' must be 'inout'}}
+func takeTestParameterDepType(f: @_lifetime(span: borrow holder) (_ holder: AnyObject, _ span: Span<Int>) -> ()) {} // expected-error{{lifetime-dependent parameter 'span' must be 'inout'}}
 
-typealias InoutLifetimeDependenceType = @_lifetime(&ne) (_ ne: inout NE) -> NE
+func takeInoutLifetimeDependenceType(f: @_lifetime(&ne) (_ ne: inout NE) -> NE) {}
 
-typealias DependOnEscapableType1 = @_lifetime(copy k) (_ k: inout Klass) -> NE // expected-error{{cannot copy the lifetime of an Escapable type}}
+func takeDependOnEscapableType1(f: @_lifetime(copy k) (_ k: inout Klass) -> NE) {} // expected-error{{cannot copy the lifetime of an Escapable type}}
                                                                                // expected-note@-1{{use '@_lifetime(&k)' instead}}
 
-typealias DependOnEscapableType2 = @_lifetime(copy k) (_ k: borrowing Klass) -> NE // expected-error{{cannot copy the lifetime of an Escapable type}}
+func takeDependOnEscapableType2(f: @_lifetime(copy k) (_ k: borrowing Klass) -> NE) {} // expected-error{{cannot copy the lifetime of an Escapable type}}
                                                                                    // expected-note@-1{{use '@_lifetime(borrow k)' instead}}
 
-typealias DependOnEscapableType3 = @_lifetime(copy k) (_ k: consuming Klass) -> NE // expected-error{{cannot copy the lifetime of an Escapable type}}
+func takeDependOnEscapableType3(f: @_lifetime(copy k) (_ k: consuming Klass) -> NE) {} // expected-error{{cannot copy the lifetime of an Escapable type}}
                                                                                    // expected-note@-1{{use '@_lifetime(borrow k)' instead}}
 
-typealias GetIntType1 = @_lifetime(inValue) (_ inValue: Int) -> Int // expected-error{{invalid lifetime dependence on an Escapable result}}
+func takeGetIntType1(f: @_lifetime(inValue) (_ inValue: Int) -> Int) {} // expected-error{{invalid lifetime dependence on an Escapable result}}
 
-typealias GetIntType2 = @_lifetime(outValue: borrow inValue) (_ outValue: inout Int, _ inValue: Int) -> () // expected-error{{invalid lifetime dependence on an Escapable target}}
+func takeGetIntType2(f: @_lifetime(outValue: borrow inValue) (_ outValue: inout Int, _ inValue: Int) -> ()) {} // expected-error{{invalid lifetime dependence on an Escapable target}}
 
-typealias GetGenericEscapableType<T> = @_lifetime(inValue) (_ inValue: T) -> T // expected-error{{invalid lifetime dependence on an Escapable result}}
+func takeGetGenericEscapableType<T>(f: @_lifetime(inValue) (_ inValue: T) -> T) {} // expected-error{{invalid lifetime dependence on an Escapable result}}
 
-typealias GetGenericEscapableType2<T> =
-  @_lifetime(outValue: borrow inValue) // expected-error{{invalid lifetime dependence on an Escapable target}}
-  (_ outValue: inout T, _ inValue: T) -> ()
+func takeGetGenericEscapableType2<T>(
+  f: @_lifetime(outValue: borrow inValue) // expected-error{{invalid lifetime dependence on an Escapable target}}
+    (_ outValue: inout T, _ inValue: T) -> ()) {}
 
-typealias GetGenericNonEscapableType2<T: ~Escapable> =
-  @_lifetime(borrow inValue) (_ inValue: borrowing T) -> T // OK
+func takeGetGenericNonEscapableType2<T: ~Escapable>(
+  f: @_lifetime(borrow inValue) (_ inValue: borrowing T) -> T) {} // OK
 
-typealias GetGenericCorrectType<T: ~Escapable> =
-  @_lifetime(outValue: borrow inValue) (_ outValue: inout T, _ inValue: borrowing T) -> () // OK
+func takeGetGenericCorrectType<T: ~Escapable>(
+  f: @_lifetime(outValue: borrow inValue) (_ outValue: inout T, _ inValue: borrowing T) -> ()) {} // OK
 
 @_lifetime(outValue: copy inValue) // OK
 func getGeneric<T : ~Escapable>(_ outValue: inout T, _ inValue: borrowing T) { // expected-note{{in call to function 'getGeneric'}}
@@ -174,9 +176,12 @@ do {
   takeGetGenericAndArgs(f: { $0 = $1 }, o: &y, i: x) // OK
 }
 do {
+  // Lifetime-annotated escaping function types
   let _ = transfer // OK
-  let _: (NE) -> NE = transfer // OK
-  let _: @_lifetime(copy ne) (_ ne: NE) -> NE = transfer // OK
+  let _: (NE) -> NE = transfer // expected-error{{an escaping function type cannot output ~Escapable values}}
+                               // expected-error@-1{{value of type 'NE' does not conform to specified type 'Escapable'}}
+  let _: @_lifetime(copy ne) (_ ne: NE) -> NE = transfer // expected-error{{an escaping function type cannot output ~Escapable values}}
+                                                         // expected-error@-1{{value of type 'NE' does not conform to specified type 'Escapable'}}
 }
 
 // rdar://166912068 (Incorrect error when passing a local function with a non-escapable parameter)
@@ -207,23 +212,28 @@ struct CNE<T: ~Escapable>: ~Escapable {
 func copyCNE(cne: CNE<NE>) -> CNE<NE> {
     return cne
 }
+func inoutCNE(cne: inout CNE<NE>) {}
 
-public let UnboundGenericParamFunctionType : (CNE) -> CNE<NE> = copyCNE                                         // expected-error{{lifetime dependence checking failed due to unknown parameter type}}
-                                                                                                                // expected-error@-1{{value of type 'CNE<NE>' does not conform to specified type 'Escapable'}}
-public let UnboundGenericParamFunctionTypeAnnotated : @_lifetime(borrow cne) (_ cne: CNE) -> CNE<NE> = copyCNE  // expected-error{{lifetime dependence checking failed due to unknown parameter type}}
-                                                                                                                // expected-error@-1{{value of type 'CNE<NE>' does not conform to specified type 'Escapable'}}
-public let UnboundGenericResultFunctionType : (CNE<NE>) -> CNE = copyCNE                                        // expected-error{{lifetime dependence checking failed due to unknown result type}}
-                                                                                                                // expected-error@-1{{value of type 'CNE<NE>' does not conform to specified type 'Escapable'}}
-public let UnboundGenericResultFunctionTypeAnnotated : @_lifetime(borrow cne) (_ cne: CNE<NE>) -> CNE = copyCNE // expected-error{{lifetime dependence checking failed due to unknown result type}}
-                                                                                                                // expected-error@-1{{value of type 'CNE<NE>' does not conform to specified type 'Escapable'}}
+public let UnboundGenericParamFunctionType : (CNE) -> CNE<NE> = copyCNE                                             // expected-error{{lifetime dependence checking failed due to unknown parameter type}}
+                                                                                                                    // expected-error@-1{{value of type 'CNE<NE>' does not conform to specified type 'Escapable'}}
+public let UnboundGenericParamFunctionTypeAnnotated : @_lifetime(borrow cne) (_ cne: CNE) -> CNE<NE> = copyCNE      // expected-error{{lifetime dependence checking failed due to unknown parameter type}}
+                                                                                                                    // expected-error@-1{{value of type 'CNE<NE>' does not conform to specified type 'Escapable'}}
+public let UnboundGenericResultFunctionType : (CNE<NE>) -> CNE = copyCNE                                            // expected-error{{value of type 'CNE<NE>' does not conform to specified type 'Escapable'}}
+public let UnboundGenericResultFunctionTypeAnnotated : @_lifetime(borrow cne) (_ cne: CNE<NE>) -> CNE = copyCNE     // expected-error{{lifetime dependence checking failed due to unknown result type}}
+                                                                                                                    // expected-error@-1{{value of type 'CNE<NE>' does not conform to specified type 'Escapable'}}
+public let UnboundGenericInoutFunctionType : (inout CNE) -> () = inoutCNE                                           // expected-error{{value of type 'CNE<NE>' does not conform to specified type 'Escapable'}}
+public let UnboundGenericInoutFunctionTypeAnnotated : @_lifetime(cne: copy cne) (_ cne: inout CNE) -> () = inoutCNE // expected-error{{lifetime dependence checking failed due to unknown parameter type}}
+                                                                                                                    // expected-error@-1{{value of type 'CNE<NE>' does not conform to specified type 'Escapable'}}
 
 public let TypeParameterParamFunctionType = copyCNE as (_) -> CNE<NE>                                         // expected-error{{lifetime dependence checking failed due to unknown parameter type}}
                                                                                                               // expected-error@-1{{failed to produce diagnostic for expression}}
 public let TypeParameterParamFunctionTypeAnnotated = copyCNE as @_lifetime(borrow cne) (_ cne: _) -> CNE<NE>  // expected-error{{lifetime dependence checking failed due to unknown parameter type}}
                                                                                                               // expected-error@-1{{failed to produce diagnostic for expression}}
-public let TypeParameterResultFunctionType = copyCNE as (CNE<NE>) -> _                                        // expected-error{{lifetime dependence checking failed due to unknown result type}}
-                                                                                                              // expected-error@-1{{failed to produce diagnostic for expression}}
+public let TypeParameterResultFunctionType = copyCNE as (CNE<NE>) -> _                                        // expected-error{{failed to produce diagnostic for expression}}
 public let TypeParameterResultFunctionTypeAnnotated = copyCNE as @_lifetime(borrow cne) (_ cne: CNE<NE>) -> _ // expected-error{{lifetime dependence checking failed due to unknown result type}}
+                                                                                                              // expected-error@-1{{failed to produce diagnostic for expression}}
+public let TypeParameterInoutFunctionType = inoutCNE as (_) -> ()                                             // expected-error{{failed to produce diagnostic for expression}}
+public let TypeParameterInoutFunctionTypeAnnotated = inoutCNE as @_lifetime(copy cne) (_ cne: _) -> ()        // expected-error{{lifetime dependence checking failed due to unknown parameter type}}
                                                                                                               // expected-error@-1{{failed to produce diagnostic for expression}}
 
 // Closure Context Dependence Tests
@@ -243,4 +253,17 @@ func testIndirectClosureResult<T>(f: () -> CNE<T>) -> CNE<T> {
   // expected-error @-1{{a function with a ~Escapable result needs a parameter to depend on}}
   // expected-note  @-2{{'@_lifetime(immortal)' can be used to indicate that values produced by this initializer have no lifetime dependencies}}
   f()
+}
+
+// Escaping Closure Tests
+func returnEscapingTransfer() -> @_lifetime(copy a) (_ a: NE) -> NE {
+  // expected-error @-1{{an escaping function type cannot output ~Escapable values}}
+  return transfer // expected-error{{return expression of type 'NE' does not conform to 'Escapable'}}
+}
+func implicitReturnEscapingTransfer() -> (NE) -> NE {
+  // expected-error @-1{{an escaping function type cannot output ~Escapable values}}
+  return transfer // expected-error{{return expression of type 'NE' does not conform to 'Escapable}}
+}
+func takeEscapingTransfer(f: @escaping @_lifetime(copy a) (_ a: NE) -> NE) -> () {
+  // expected-error @-1{{an escaping function type cannot output ~Escapable values}}
 }


### PR DESCRIPTION
rdar://170463765 ([nonescape] Prevent lifetime dependencies on escaping function types)

Currently, any function type is considered `@escaping` unless it is the type of a function parameter and it does not have an `@escaping` annotation. Such types should not have lifetime dependencies, so they cannot have `~Escapable` outputs (return value or inout parameters). Add a diagnostic to prevent this. To avoid false positives, we should only trigger the diagnostic for parameters that are inout, and results.

This prevents users from using such types in other places, notably type aliases. As a follow-up, we should allow function types to be non-`@escaping` in more situations.