### PR TITLE
Runtime: propagate dependencies and remove Concurrency linkage

### DIFF
--- a/Runtimes/Supplemental/Runtime/CMakeLists.txt
+++ b/Runtimes/Supplemental/Runtime/CMakeLists.txt
@@ -82,6 +82,7 @@ add_compile_options(
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Werror StrictMemorySafety>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -enforce-exclusivity=unchecked>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -target-min-inlining-version -Xfrontend min>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-concurrency-module-import>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-string-processing-module-import>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature NoncopyableGenerics2>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature SuppressedAssociatedTypes>"
@@ -205,7 +206,6 @@ target_include_directories(swiftRuntime INTERFACE
 target_link_libraries(swiftRuntime PUBLIC
   swiftShims
   swiftCore
-  swift_Concurrency
   swiftCxxStdlib
   swiftCxx
   $<$<PLATFORM_ID:Android>:swiftAndroid>

--- a/Runtimes/Supplemental/Runtime/cmake/interface/SwiftRuntimeConfig.cmake.in
+++ b/Runtimes/Supplemental/Runtime/cmake/interface/SwiftRuntimeConfig.cmake.in
@@ -1,2 +1,5 @@
 @PACKAGE_INIT@
+include(CMakeFindDependencyMacro)
+find_dependency(SwiftOverlay)
+find_dependency(SwiftCxxOverlay)
 include("${CMAKE_CURRENT_LIST_DIR}/SwiftRuntimeTargets.cmake")


### PR DESCRIPTION
The `Runtime` module does not use concurrency and does not need to link against it. Remove that false dependency to help reduce static linking overheads. Additionally, forward the dependencies to clients to avoid the unnecessary `find_package`s in the client.