### PR TITLE
LifetimeDependence: Fix mutable borrow printing

### DIFF
--- a/test/ModuleInterface/Inputs/lifetime_underscored_dependence.swift
+++ b/test/ModuleInterface/Inputs/lifetime_underscored_dependence.swift
@@ -136,3 +136,9 @@ public func fullReassign(dest: inout AnotherView, source: AnotherView) {
 @inlinable public func takeFullReassign(
   closure: @_lifetime(dest: immortal, copy source) (_ dest: inout AnotherView, _ source: AnotherView) -> ()
 ) {}
+
+@inlinable
+public func takeReadBorrower(f: @_lifetime(borrow a) (_ a: AnotherView) -> AnotherView) {}
+
+@inlinable
+public func takeWriteBorrower(f: @_lifetime(&a) (_ a: inout AnotherView) -> AnotherView) {}

--- a/test/ModuleInterface/lifetime_underscored_dependence_test.swift
+++ b/test/ModuleInterface/lifetime_underscored_dependence_test.swift
@@ -197,3 +197,11 @@ import lifetime_underscored_dependence
 // CHECK: #if compiler(>=5.3) && $ClosureLifetimes
 // CHECK-NEXT: @inlinable public func takeFullReassign(closure: @_lifetime(dest: immortal, copy source) (_ dest: inout lifetime_underscored_dependence.AnotherView, _ source: lifetime_underscored_dependence.AnotherView) -> ()) {}
 // CHECK-NEXT: #endif
+
+// CHECK: #if compiler(>=5.3) && $ClosureLifetimes
+// CHECK-NEXT: @inlinable public func takeReadBorrower(f: @_lifetime(borrow a) (_ a: lifetime_underscored_dependence.AnotherView) -> lifetime_underscored_dependence.AnotherView) {}
+// CHECK-NEXT: #endif
+
+// CHECK-NEXT: #if compiler(>=5.3) && $ClosureLifetimes
+// CHECK-NEXT: @inlinable public func takeWriteBorrower(f: @_lifetime(&a) (_ a: inout lifetime_underscored_dependence.AnotherView) -> lifetime_underscored_dependence.AnotherView) {}
+// CHECK-NEXT: #endif


### PR DESCRIPTION
Use the '&' specifier for inout scoped dependence sources, since this is the only kind of borrowed dependence they can have.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
