### PR TITLE
[6.3][Concurrency] Fix definition of SWIFT_CONCURRENCY_ENABLE_DISPATCH.

### DIFF
--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -29,6 +29,13 @@
 #include "bitset"
 #include "queue" // TODO: remove and replace with our own mpsc
 
+// Does the runtime integrate with libdispatch?
+#if defined(SWIFT_CONCURRENCY_USES_DISPATCH)
+#define SWIFT_CONCURRENCY_ENABLE_DISPATCH SWIFT_CONCURRENCY_USES_DISPATCH
+#else
+#define SWIFT_CONCURRENCY_ENABLE_DISPATCH 0
+#endif
+
 // Does the runtime provide priority escalation support?
 #ifndef SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
 #if SWIFT_CONCURRENCY_ENABLE_DISPATCH && \

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -38,13 +38,6 @@
 #define SWIFT_CONCURRENCY_TASK_TO_THREAD_MODEL 0
 #endif
 
-// Does the runtime integrate with libdispatch?
-#if defined(SWIFT_CONCURRENCY_USES_DISPATCH)
-#define SWIFT_CONCURRENCY_ENABLE_DISPATCH SWIFT_CONCURRENCY_USES_DISPATCH
-#else
-#define SWIFT_CONCURRENCY_ENABLE_DISPATCH 0
-#endif
-
 namespace swift {
 class DefaultActor;
 class TaskOptionRecord;

--- a/test/Concurrency/Inputs/has-dispatch-private.h
+++ b/test/Concurrency/Inputs/has-dispatch-private.h
@@ -1,0 +1,6 @@
+// Swift can't #if __has_include, so do it in a C header.
+#if __has_include(<dispatch/swift_concurrency_private.h>)
+static inline int HasSwiftConcurrencyPrivateHeader(void) { return 1; }
+#else
+static inline int HasSwiftConcurrencyPrivateHeader(void) { return 0; }
+#endif

--- a/test/Concurrency/priority_escalation_thread_qos.swift
+++ b/test/Concurrency/priority_escalation_thread_qos.swift
@@ -1,0 +1,83 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-build-swift %s -import-objc-header %S/Inputs/has-dispatch-private.h -Xfrontend -disable-availability-checking -o %t/priority_escalation_thread_qos
+// RUN: %target-codesign %t/priority_escalation_thread_qos
+// RUN: %target-run %t/priority_escalation_thread_qos
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=xros
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+
+// REQUIRES: concurrency_runtime
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: back_deploy_concurrency
+
+// rdar://101077408 - Temporarily disable on simulators
+// UNSUPPORTED: DARWIN_SIMULATOR=watchos
+// UNSUPPORTED: DARWIN_SIMULATOR=ios
+// UNSUPPORTED: DARWIN_SIMULATOR=tvos
+// UNSUPPORTED: DARWIN_SIMULATOR=xros
+
+import Darwin
+import Dispatch
+import StdlibUnittest
+
+let tests = TestSuite("Task and thread priority escalation")
+
+// Swift complains if we use `wait()` in an async function. Hide it here.
+func semaphoreWait(_ sem: DispatchSemaphore) {
+  sem.wait()
+}
+
+func getEffectiveThreadPriority() -> Int32 {
+  var extInfo = thread_extended_info_data_t()
+  var count = mach_msg_type_number_t(
+    MemoryLayout<thread_extended_info_data_t>.size / MemoryLayout<integer_t>.size)
+  let thread = mach_thread_self()
+  defer { mach_port_deallocate(mach_task_self_, thread) }
+
+  let kr = withUnsafeMutablePointer(to: &extInfo) { ptr in
+    ptr.withMemoryRebound(to: integer_t.self, capacity: Int(count)) { intPtr in
+      thread_info(thread, thread_flavor_t(THREAD_EXTENDED_INFO), intPtr, &count)
+    }
+  }
+
+  precondition(kr == KERN_SUCCESS, "thread_info failed: \(kr)")
+  return extInfo.pth_curpri
+}
+
+// Test that escalating a running task actually increases the thread's
+// effective priority, not just the task-level priority. Ensure that the
+// SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION define isn't accidentally unset.
+tests.test("Thread priority escalation") {
+  // If we don't have swift_concurrency_private.h then the runtime doesn't have
+  // full priority escalation, so don't try to test it.
+  guard HasSwiftConcurrencyPrivateHeader() != 0 else { return }
+
+  let readyForEscalation = DispatchSemaphore(value: 0)
+  let doneEscalating = DispatchSemaphore(value: 0)
+  let doneTesting = DispatchSemaphore(value: 0)
+
+  let task = Task.detached(priority: .background) {
+    let priorityBefore = getEffectiveThreadPriority()
+
+    readyForEscalation.signal()
+    semaphoreWait(doneEscalating)
+
+    let priorityAfter = getEffectiveThreadPriority()
+    let taskPriority = Task.currentPriority
+
+    expectTrue(priorityAfter > priorityBefore,
+      "Thread priority should have been escalated from \(priorityBefore), " +
+      "but got \(priorityAfter). Task.currentPriority shows \(taskPriority). ")
+
+    doneTesting.signal()
+  }
+
+  semaphoreWait(readyForEscalation)
+  task.escalatePriority(to: .userInitiated)
+  doneEscalating.signal()
+  semaphoreWait(doneTesting)
+}
+
+await runAllTestsAsync()


### PR DESCRIPTION
Explanation: `SWIFT_CONCURRENCY_ENABLE_DISPATCH` was moved to a place where the definition of `SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION` couldn't see it, making `SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION` always be off. This can result in priority inversions. This was fixed on `main` as part of https://github.com/swiftlang/swift/pull/84895 but it was not fixed on 6.3.

Resolves: rdar://170175477

Main branch PR: [Concurrency] A few fixes for default isolation inference #86967

Risk: Medium. The code we're re-enabling is well-understood and well-tested, but it has been disabled for quite a while.

Reviewed By: @Bryce-MW (Technically, written by Bryce, reviewed by me.)

Testing: Added a test that verifies the desired escalation behavior.

---

Move it to Task.h so that the definition of SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION can see it. Otherwise SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION is always off.

Also add a test to verify that thread priorities actually do get boosted in places where it's supposed to be on.

rdar://170175477