### PR TITLE
[NFC][Concurrency] Document BufferingPolicy behavior for non-positive buffer sizes

### DIFF
--- a/stdlib/public/Concurrency/AsyncStream.swift
+++ b/stdlib/public/Concurrency/AsyncStream.swift
@@ -167,13 +167,13 @@ public struct AsyncStream<Element> {
       /// When the buffer is full, discard the newly received element.
       ///
       /// This strategy enforces keeping at most the specified number of oldest values.
-      /// When the specified number is 0 or negative, the corresponding `AsyncStream` drops yielded values if no consumers is currently awaiting.
+      /// When the specified number is non-positive, the corresponding `AsyncStream` drops yielded values if no consumers is currently awaiting.
       case bufferingOldest(Int)
       
       /// When the buffer is full, discard the oldest element in the buffer.
       ///
       /// This strategy enforces keeping at most the specified number of newest values.
-      /// When the specified number is 0 or negative, the corresponding `AsyncStream` drops yielded values if no consumers is currently awaiting.
+      /// When the specified number is non-positive, the corresponding `AsyncStream` drops yielded values if no consumers is currently awaiting.
       case bufferingNewest(Int)
     }
 

--- a/stdlib/public/Concurrency/AsyncStream.swift
+++ b/stdlib/public/Concurrency/AsyncStream.swift
@@ -167,7 +167,6 @@ public struct AsyncStream<Element> {
       /// When the buffer is full, discard the newly received element.
       ///
       /// This strategy enforces keeping at most the specified number of oldest values.
-      /// When the specified number is non-positive, the corresponding `AsyncStream` drops yielded values if no consumers is currently awaiting.
       ///
       /// - Note: If the specified number is non-positive no elements will be buffered. 
       /// An iterator receives an element only if it is awaiting a value at the moment the continuation yields.

--- a/stdlib/public/Concurrency/AsyncStream.swift
+++ b/stdlib/public/Concurrency/AsyncStream.swift
@@ -168,16 +168,16 @@ public struct AsyncStream<Element> {
       ///
       /// This strategy enforces keeping at most the specified number of oldest values.
       ///
-      /// - Note: If the specified number is non-positive no elements will be buffered. 
-      /// An iterator receives an element only if it is awaiting a value at the moment the continuation yields.
+      /// - Note: If the specified number is zero or negative, no elements are buffered.
+      /// In that case, an iterator receives an element only if it is already awaiting a value when the continuation yields.
       case bufferingOldest(Int)
       
       /// When the buffer is full, discard the oldest element in the buffer.
       ///
       /// This strategy enforces keeping at most the specified number of newest values.
       ///
-      /// - Note: If the specified number is non-positive no elements will be buffered. 
-      /// An iterator receives an element only if it is awaiting a value at the moment the continuation yields.
+      /// - Note: If the specified number is zero or negative, no elements are buffered.
+      /// In that case, an iterator receives an element only if it is already awaiting a value when the continuation yields.
       case bufferingNewest(Int)
     }
 

--- a/stdlib/public/Concurrency/AsyncStream.swift
+++ b/stdlib/public/Concurrency/AsyncStream.swift
@@ -166,14 +166,14 @@ public struct AsyncStream<Element> {
       
       /// When the buffer is full, discard the newly received element.
       ///
-      /// This strategy enforces keeping at most the specified number of oldest
-      /// values. When the specified number is 0 or negative, the corresponding `AsyncStream` drops yielded values if no consumers is currently awaiting.
+      /// This strategy enforces keeping at most the specified number of oldest values.
+      /// When the specified number is 0 or negative, the corresponding `AsyncStream` drops yielded values if no consumers is currently awaiting.
       case bufferingOldest(Int)
       
       /// When the buffer is full, discard the oldest element in the buffer.
       ///
-      /// This strategy enforces keeping at most the specified number of newest
-      /// values. When the specified number is 0 or negative, the corresponding `AsyncStream` drops yielded values if no consumers is currently awaiting.
+      /// This strategy enforces keeping at most the specified number of newest values.
+      /// When the specified number is 0 or negative, the corresponding `AsyncStream` drops yielded values if no consumers is currently awaiting.
       case bufferingNewest(Int)
     }
 

--- a/stdlib/public/Concurrency/AsyncStream.swift
+++ b/stdlib/public/Concurrency/AsyncStream.swift
@@ -167,13 +167,13 @@ public struct AsyncStream<Element> {
       /// When the buffer is full, discard the newly received element.
       ///
       /// This strategy enforces keeping at most the specified number of oldest
-      /// values.
+      /// values. When the specified number is 0 or negative, the corresponding `AsyncStream` drops yielded values if no consumers is currently awaiting.
       case bufferingOldest(Int)
       
       /// When the buffer is full, discard the oldest element in the buffer.
       ///
       /// This strategy enforces keeping at most the specified number of newest
-      /// values.
+      /// values. When the specified number is 0 or negative, the corresponding `AsyncStream` drops yielded values if no consumers is currently awaiting.
       case bufferingNewest(Int)
     }
 

--- a/stdlib/public/Concurrency/AsyncStream.swift
+++ b/stdlib/public/Concurrency/AsyncStream.swift
@@ -168,12 +168,17 @@ public struct AsyncStream<Element> {
       ///
       /// This strategy enforces keeping at most the specified number of oldest values.
       /// When the specified number is non-positive, the corresponding `AsyncStream` drops yielded values if no consumers is currently awaiting.
+      ///
+      /// - Note: If the specified number is non-positive no elements will be buffered. 
+      /// An iterator receives an element only if it is awaiting a value at the moment the continuation yields.
       case bufferingOldest(Int)
       
       /// When the buffer is full, discard the oldest element in the buffer.
       ///
       /// This strategy enforces keeping at most the specified number of newest values.
-      /// When the specified number is non-positive, the corresponding `AsyncStream` drops yielded values if no consumers is currently awaiting.
+      ///
+      /// - Note: If the specified number is non-positive no elements will be buffered. 
+      /// An iterator receives an element only if it is awaiting a value at the moment the continuation yields.
       case bufferingNewest(Int)
     }
 

--- a/stdlib/public/Concurrency/AsyncThrowingStream.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingStream.swift
@@ -191,11 +191,13 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
       /// When the buffer is full, discard the newly received element.
       ///
       /// This strategy enforces keeping the specified amount of oldest values.
+      /// When the specified number is 0 or negative, the corresponding `AsyncThrowingStream` drops yielded values if no consumers is currently awaiting.
       case bufferingOldest(Int)
       
       /// When the buffer is full, discard the oldest element in the buffer.
       ///
       /// This strategy enforces keeping the specified amount of newest values.
+      /// When the specified number is 0 or negative, the corresponding `AsyncThrowingStream` drops yielded values if no consumers is currently awaiting.
       case bufferingNewest(Int)
     }
 

--- a/stdlib/public/Concurrency/AsyncThrowingStream.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingStream.swift
@@ -191,13 +191,13 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
       /// When the buffer is full, discard the newly received element.
       ///
       /// This strategy enforces keeping at most the specified number of oldest values.
-      /// When the specified number is 0 or negative, the corresponding `AsyncThrowingStream` drops yielded values if no consumers is currently awaiting.
+      /// When the specified number is non-positive, the corresponding `AsyncThrowingStream` drops yielded values if no consumers is currently awaiting.
       case bufferingOldest(Int)
       
       /// When the buffer is full, discard the oldest element in the buffer.
       ///
       /// This strategy enforces keeping at most the specified number of newest values.
-      /// When the specified number is 0 or negative, the corresponding `AsyncThrowingStream` drops yielded values if no consumers is currently awaiting.
+      /// When the specified number is non-positive, the corresponding `AsyncThrowingStream` drops yielded values if no consumers is currently awaiting.
       case bufferingNewest(Int)
     }
 

--- a/stdlib/public/Concurrency/AsyncThrowingStream.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingStream.swift
@@ -185,18 +185,18 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
     
     /// A strategy that handles exhaustion of a buffer’s capacity.
     public enum BufferingPolicy: Sendable {
-      /// Continue to add to the buffer, treating its capacity as infinite.
+      /// Continue to add to the buffer, without imposing a limit on the number of buffered elements.
       case unbounded
       
       /// When the buffer is full, discard the newly received element.
       ///
-      /// This strategy enforces keeping the specified amount of oldest values.
+      /// This strategy enforces keeping at most the specified number of oldest values.
       /// When the specified number is 0 or negative, the corresponding `AsyncThrowingStream` drops yielded values if no consumers is currently awaiting.
       case bufferingOldest(Int)
       
       /// When the buffer is full, discard the oldest element in the buffer.
       ///
-      /// This strategy enforces keeping the specified amount of newest values.
+      /// This strategy enforces keeping at most the specified number of newest values.
       /// When the specified number is 0 or negative, the corresponding `AsyncThrowingStream` drops yielded values if no consumers is currently awaiting.
       case bufferingNewest(Int)
     }

--- a/stdlib/public/Concurrency/AsyncThrowingStream.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingStream.swift
@@ -192,16 +192,16 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
       ///
       /// This strategy enforces keeping at most the specified number of oldest values.
       ///
-      /// - Note: If the specified number is non-positive no elements will be buffered. 
-      /// An iterator receives an element only if it is awaiting a value at the moment the continuation yields.
+      /// - Note: If the specified number is zero or negative, no elements are buffered.
+      /// In that case, an iterator receives an element only if it is already awaiting a value when the continuation yields.
       case bufferingOldest(Int)
       
       /// When the buffer is full, discard the oldest element in the buffer.
       ///
       /// This strategy enforces keeping at most the specified number of newest values.
       ///
-      /// - Note: If the specified number is non-positive no elements will be buffered. 
-      /// An iterator receives an element only if it is awaiting a value at the moment the continuation yields.
+      /// - Note: If the specified number is zero or negative, no elements are buffered.
+      /// In that case, an iterator receives an element only if it is already awaiting a value when the continuation yields.
       case bufferingNewest(Int)
     }
 

--- a/stdlib/public/Concurrency/AsyncThrowingStream.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingStream.swift
@@ -191,13 +191,17 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
       /// When the buffer is full, discard the newly received element.
       ///
       /// This strategy enforces keeping at most the specified number of oldest values.
-      /// When the specified number is non-positive, the corresponding `AsyncThrowingStream` drops yielded values if no consumers is currently awaiting.
+      ///
+      /// - Note: If the specified number is non-positive no elements will be buffered. 
+      /// An iterator receives an element only if it is awaiting a value at the moment the continuation yields.
       case bufferingOldest(Int)
       
       /// When the buffer is full, discard the oldest element in the buffer.
       ///
       /// This strategy enforces keeping at most the specified number of newest values.
-      /// When the specified number is non-positive, the corresponding `AsyncThrowingStream` drops yielded values if no consumers is currently awaiting.
+      ///
+      /// - Note: If the specified number is non-positive no elements will be buffered. 
+      /// An iterator receives an element only if it is awaiting a value at the moment the continuation yields.
       case bufferingNewest(Int)
     }
 


### PR DESCRIPTION
Updated `AsyncStream` and `AsyncThrowingStream` `BufferingPolicy` documentation to clarify behavior for non-positive buffer sizes and to make comments consistent between the two types.