### PR TITLE
[utils] remove use of litConfig.quiet

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -323,8 +323,7 @@ def inferSwiftBinary(binaryName):
     execPath = lit.util.which(binaryName, PATH)
 
     if execPath:
-        if not lit_config.quiet:
-            lit_config.note('using %s: %s' % (binaryName, execPath))
+        lit_config.note('using %s: %s' % (binaryName, execPath))
     else:
         msg = "couldn't find '%s' program, try setting %s in your environment"
         lit_config.warning(msg % (binaryName, envVarName))


### PR DESCRIPTION
https://github.com/swiftlang/llvm-project/pull/12338 removes the `quiet` member of `LitConfig`, and instead calls to `note()` automatically silence themselves if the diagnostic level is not verbose enough. Land this first to prevent errors when the llvm-project PR lands.