### PR TITLE
[cxx-interop] Fix .pointee lookup for foreign reference types

### DIFF
--- a/lib/ClangImporter/ClangLookup.cpp
+++ b/lib/ClangImporter/ClangLookup.cpp
@@ -486,10 +486,7 @@ ClangImporter::Implementation::lookupAndImportPointee(NominalTypeDecl *Struct) {
   const auto *CXXRecord =
       dyn_cast<clang::CXXRecordDecl>(Struct->getClangDecl());
 
-  if (!CXXRecord || !isa<StructDecl>(Struct))
-    // Do not synthesize successor() if this is not a C++ record, or if it is
-    // a foreign reference type (successor() needs to copy values of this type),
-    // which would be a ClassDecl rather than a StructDecl.
+  if (!CXXRecord)
     return nullptr;
 
   if (auto [it, inserted] = importedPointeeCache.try_emplace(Struct, nullptr);

--- a/test/Interop/Cxx/operators/Inputs/pointee-overloads.h
+++ b/test/Interop/Cxx/operators/Inputs/pointee-overloads.h
@@ -95,3 +95,51 @@ struct Pointee_LNonConst_RNonConst {
   int &operator*() & { return x; }
   int &operator*() && { return y; }
 };
+
+struct FRT_Const_NonConst {
+  void ref() const { ++count; }
+  void deref() const { if (--count <= 0) delete this; }
+
+  const int& operator*() const { return value; }
+  int& operator*() { return value; }
+
+  FRT_Const_NonConst(int value) : value{value}, count{1} {}
+
+  int value;
+  mutable int count;
+} __attribute__((swift_attr("import_reference")))
+  __attribute__((swift_attr("retain:.ref")))
+  __attribute__((swift_attr("release:.deref")));
+
+__attribute__((swift_attr("returns_retained")))
+inline FRT_Const_NonConst * _Nonnull new_FRT_Const_NonConst(int value) {
+  return new FRT_Const_NonConst{value};
+}
+
+template<typename T>
+struct Template_FRT_Const_NonConst {
+  void ref() const { ++count; }
+  void deref() const { if (--count <= 0) delete this; }
+
+  const T& operator*() const { return value; }
+  T& operator*() { return value; }
+
+  Template_FRT_Const_NonConst(T value) : value{value}, count{1} {}
+
+  T value;
+  mutable int count;
+} __attribute__((swift_attr("import_reference")))
+  __attribute__((swift_attr("retain:.ref")))
+  __attribute__((swift_attr("release:.deref")));
+
+__attribute__((swift_attr("returns_retained")))
+inline Template_FRT_Const_NonConst<int> * _Nonnull
+Int_Template_FRT_Const_NonConst(int value) {
+  return new Template_FRT_Const_NonConst{value};
+}
+
+__attribute__((swift_attr("returns_retained")))
+inline Template_FRT_Const_NonConst<double> * _Nonnull
+Double_Template_FRT_Const_NonConst(double value) {
+  return new Template_FRT_Const_NonConst{value};
+}

--- a/test/Interop/Cxx/operators/pointee-overloads-typechecker.swift
+++ b/test/Interop/Cxx/operators/pointee-overloads-typechecker.swift
@@ -112,3 +112,19 @@ let _ = lPointee_LNonConst_RNonConst.pointee // expected-error {{cannot use muta
 var vPointee_LNonConst_RNonConst = Pointee_LNonConst_RNonConst()
 let _ = vPointee_LNonConst_RNonConst.pointee
 vPointee_LNonConst_RNonConst.pointee = 42
+
+let vFRT_Const_NonConst = new_FRT_Const_NonConst(42)
+let _ = vFRT_Const_NonConst.pointee
+vFRT_Const_NonConst.pointee = 67
+
+let vInt_FRT_Const_NonConst = Int_Template_FRT_Const_NonConst(42)
+let _: Int32 = vInt_FRT_Const_NonConst.pointee
+vInt_FRT_Const_NonConst.pointee = 4
+vInt_FRT_Const_NonConst.pointee = false // expected-error {{cannot assign value of type 'Bool' to type 'Int32'}}
+vInt_FRT_Const_NonConst.pointee = 4.2 // expected-error {{cannot assign value of type 'Double' to type 'Int32'}}
+
+let vFloat_FRT_Const_NonConst = Double_Template_FRT_Const_NonConst(6.7)
+let _: Double = vFloat_FRT_Const_NonConst.pointee
+vFloat_FRT_Const_NonConst.pointee = 4
+vFloat_FRT_Const_NonConst.pointee = false // expected-error {{cannot assign value of type 'Bool' to type 'Double'}}
+vFloat_FRT_Const_NonConst.pointee = 4.2

--- a/test/Interop/Cxx/operators/pointee-overloads.swift
+++ b/test/Interop/Cxx/operators/pointee-overloads.swift
@@ -153,4 +153,46 @@ PointeeOverloadTestSuite.test("Pointee_LNonConst_RNonConst") {
   expectEqual(a.y, 6060)
 }
 
+PointeeOverloadTestSuite.test("FRT_Const_NonConst") {
+  let a = new_FRT_Const_NonConst(8888)
+  expectEqual(a.pointee, 8888)
+
+  let b = a
+  a.pointee = 8866
+  expectEqual(a.pointee, 8866)
+  expectEqual(b.pointee, 8866)
+
+  b.pointee = 6688
+  expectEqual(a.pointee, 6688)
+  expectEqual(b.pointee, 6688)
+}
+
+PointeeOverloadTestSuite.test("Int_Template_FRT_Const_NonConst") {
+  let a = Int_Template_FRT_Const_NonConst(8888)
+  expectEqual(a.pointee, 8888)
+
+  let b = a
+  a.pointee = 8866
+  expectEqual(a.pointee, 8866)
+  expectEqual(b.pointee, 8866)
+
+  b.pointee = 6688
+  expectEqual(a.pointee, 6688)
+  expectEqual(b.pointee, 6688)
+}
+
+PointeeOverloadTestSuite.test("Double_Template_FRT_Const_NonConst") {
+  let a = Double_Template_FRT_Const_NonConst(88.88)
+  expectEqual(a.pointee, 88.88)
+
+  let b = a
+  a.pointee = 88.66
+  expectEqual(a.pointee, 88.66)
+  expectEqual(b.pointee, 88.66)
+
+  b.pointee = 66.88
+  expectEqual(a.pointee, 66.88)
+  expectEqual(b.pointee, 66.88)
+}
+
 runAllTests()


### PR DESCRIPTION
This regression was introduced in c2952b77aa6771ecc26d3753805b10000bba04c9

rdar://170233903