### PR TITLE
[Runtime] Don't skip artificial subclasses in swift_getTypeName.

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -2242,6 +2242,7 @@ public enum StdLibVersion: String {
   case stdlib_6_1  = "6.1"
   case stdlib_6_2  = "6.2"
   case stdlib_6_3  = "6.3"
+  case stdlib_6_4  = "6.4"
 
   var isAvailable: Bool {
     switch self {
@@ -2261,6 +2262,8 @@ public enum StdLibVersion: String {
       return if #available(SwiftStdlib 6.2, *)  { true } else { false }
     case .stdlib_6_3:
       return if #available(SwiftStdlib 6.3, *)  { true } else { false }
+    case .stdlib_6_4:
+      return if #available(SwiftStdlib 6.4, *)  { true } else { false }
     }
   }
 }

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -81,12 +81,10 @@ static void _buildNameForMetadata(const Metadata *type,
 #if SWIFT_OBJC_INTEROP
   if (type->getKind() == MetadataKind::Class) {
     auto classType = static_cast<const ClassMetadata *>(type);
-    // Look through artificial subclasses.
-    while (classType->isTypeMetadata() && classType->isArtificialSubclass())
-      classType = classType->Superclass;
-
-    // Ask the Objective-C runtime to name ObjC classes.
-    if (!classType->isTypeMetadata()) {
+    // Ask the Objective-C runtime to name ObjC classes. isTypeMetadata should
+    // always be true here (pure ObjC classes get ObjCClassWrappers), but check
+    // it just to be sure.
+    if (!classType->isTypeMetadata() || !classType->getDescription()) {
       result += class_getName(classType);
       return;
     }

--- a/test/stdlib/RuntimeObjC.swift
+++ b/test/stdlib/RuntimeObjC.swift
@@ -747,6 +747,7 @@ Reflection.test("Name of metatype of artificial subclass") {
   expectEqual("\(type(of: obj))", "TestArtificialSubclass")
   expectEqual(String(describing: type(of: obj)), "TestArtificialSubclass")
   expectEqual(String(reflecting: type(of: obj)), "a.TestArtificialSubclass")
+  expectTrue(String(reflecting: obj).starts(with: "<a.TestArtificialSubclass: "))
 
   // Trigger the creation of a KVO subclass for TestArtificialSubclass.
   obj.addObserver(obj, forKeyPath: "foo", options: [.new], context: &KVOHandle)
@@ -758,6 +759,37 @@ Reflection.test("Name of metatype of artificial subclass") {
   expectEqual("\(type(of: obj))", "TestArtificialSubclass")
   expectEqual(String(describing: type(of: obj)), "TestArtificialSubclass")
   expectEqual(String(reflecting: type(of: obj)), "a.TestArtificialSubclass")
+  expectTrue(String(reflecting: obj).starts(with: "<a.TestArtificialSubclass: "))
+}
+
+Reflection.test("Name of ObjC class") {
+  let obj = NSObject()
+  let klass: AnyClass = object_getClass(obj)!
+  expectEqual("NSObject", String(describing: klass))
+  expectEqual("NSObject", String(reflecting: klass))
+  expectEqual("NSObject", _typeName(klass))
+  expectTrue(String(describing: obj).starts(with: "<NSObject: "))
+  expectTrue(String(reflecting: obj).starts(with: "<NSObject: "))
+}
+
+Reflection.test("Name of runtime subclass")
+.require(.stdlib_6_4).code {
+  let klass: AnyClass = objc_allocateClassPair(TestArtificialSubclass.self, "RuntimeSubclass", 0)!
+  objc_registerClassPair(klass)
+  let obj = class_createInstance(klass, 0) as! NSObject
+
+  expectEqual("RuntimeSubclass", String(describing: klass))
+  expectEqual("RuntimeSubclass", String(reflecting: klass))
+  expectTrue(String(describing: obj).starts(with: "<RuntimeSubclass: "))
+  expectTrue(String(reflecting: obj).starts(with: "<RuntimeSubclass: "))
+
+  obj.addObserver(obj, forKeyPath: "foo", options: [.new], context: &KVOHandle)
+  expectTrue(String(describing: obj).starts(with: "<RuntimeSubclass: "))
+  expectTrue(String(reflecting: obj).starts(with: "<RuntimeSubclass: "))
+  obj.removeObserver(obj, forKeyPath: "foo")
+
+  expectTrue(String(describing: obj).starts(with: "<RuntimeSubclass: "))
+  expectTrue(String(reflecting: obj).starts(with: "<RuntimeSubclass: "))
 }
 
 @objc class StringConvertibleInDebugAndOtherwise_Native : NSObject {


### PR DESCRIPTION
The only way to get a pointer to an artificial subclass is by using ObjC runtime calls to retrieve the class pointer. If someone does this, they probably want the name of that class, rather than the Swift superclass.

rdar://165919756