### PR TITLE
[test][android] Enable Availability/availability_custom_domains_witness_table because it is passing

### DIFF
--- a/test/Availability/availability_custom_domains_witness_table.swift
+++ b/test/Availability/availability_custom_domains_witness_table.swift
@@ -1,6 +1,4 @@
 // REQUIRES: swift_feature_CustomAvailability
-// XFAIL: OS=linux-android
-// XFAIL: OS=linux-androideabi
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-silgen -module-name main %s -verify \


### PR DESCRIPTION
This is [breaking the Android CI because it is unexpectedly passing](https://ci.swift.org/job/oss-swift-package-swift-sdk-for-android/251/console), added in #87010 today.