### PR TITLE
Synthesize builtin generic parameter names when there are more than 6 generic parameters

### DIFF
--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -287,11 +287,13 @@ static const char * const GenericParamNames[] = {
   "Z"
 };
 
-static GenericTypeParamDecl*
-createGenericParam(ASTContext &ctx, const char *name, unsigned index,
-                   bool isParameterPack = false) {
+static GenericTypeParamDecl *createGenericParam(ASTContext &ctx,
+                                                const Twine &name,
+                                                unsigned index,
+                                                bool isParameterPack = false) {
+  SmallString<2> StrBuf;
   ModuleDecl *M = ctx.TheBuiltinModule;
-  Identifier ident = ctx.getIdentifier(name);
+  Identifier ident = ctx.getIdentifier(name.toStringRef(StrBuf));
 
   auto paramKind = GenericTypeParamKind::Type;
 
@@ -308,12 +310,12 @@ createGenericParam(ASTContext &ctx, const char *name, unsigned index,
 static GenericParamList *getGenericParams(ASTContext &ctx,
                                           unsigned numParameters,
                                           bool areParameterPacks = false) {
-  assert(numParameters <= std::size(GenericParamNames));
-
+  const unsigned numNamedParams = std::size(GenericParamNames);
   SmallVector<GenericTypeParamDecl *, 2> genericParams;
   for (unsigned i = 0; i != numParameters; ++i)
-    genericParams.push_back(createGenericParam(ctx, GenericParamNames[i], i,
-                                               areParameterPacks));
+    genericParams.push_back(createGenericParam(
+        ctx, i < numNamedParams ? GenericParamNames[i] : "T" + Twine(i), i,
+        areParameterPacks));
 
   auto paramList = GenericParamList::create(ctx, SourceLoc(), genericParams,
                                             SourceLoc());

--- a/test/AutoDiff/compiler_crashers_fixed/issue-87091-builtin-arity7.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/issue-87091-builtin-arity7.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend-typecheck -parse-stdlib %s
+
+import Swift
+import _Differentiation
+
+// https://github.com/swiftlang/swift/issues/87091
+// Ensure we can create builtins with more than 6 generic parameters
+
+@inlinable
+public func valueWithPullback<A, B, C, D, E, F, G, H, Result>(
+    at a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H, of body: @differentiable(reverse) (A, B, C, D, E, F, G, H) -> Result
+) -> (value: Result,
+      pullback: (Result.TangentVector)
+      -> (A.TangentVector, B.TangentVector, C.TangentVector, D.TangentVector, E.TangentVector, F.TangentVector, G.TangentVector, H.TangentVector)) {
+    return Builtin.applyDerivative_vjp_arity8(body, a, b, c, d, e, f, g, h)
+}


### PR DESCRIPTION
First 6 got pre-defined names.

Fixes #87091
