### PR TITLE
Sema: Public `@implementation` signatures can reference hidden dependencies

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3188,7 +3188,8 @@ public:
   /// \sa hasOpenAccess
   AccessScope
   getFormalAccessScope(const DeclContext *useDC = nullptr,
-                       bool treatUsableFromInlineAsPublic = false) const;
+                       bool treatUsableFromInlineAsPublic = false,
+                       bool ignoreImportAccessLevel = false) const;
 
 
   /// Copy the formal access level and @usableFromInline attribute from

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -575,6 +575,10 @@ public:
   /// returns \c this.
   DeclContext *getImplementedObjCContext() const;
 
+  /// Is this DeclContext marked `@c @implementation` or an implementation
+  /// function in an `@objc @implementation` extension.
+  bool isInObjCImplementationContext() const;
+
   /// Returns the source file that contains this context, or null if this
   /// is not within a source file.
   LLVM_READONLY

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6730,6 +6730,15 @@ DeclContext *DeclContext::getImplementedObjCContext() const {
   return const_cast<DeclContext *>(this);
 }
 
+bool DeclContext::isInObjCImplementationContext() const {
+  auto AFD = dyn_cast_or_null<AbstractFunctionDecl>(getAsDecl());
+  if (!AFD)
+    return false;
+
+  return (AFD->getCDeclKind() && AFD->getImplementedObjCDecl()) ||
+         AFD->isObjCMemberImplementation();
+}
+
 Decl *Decl::getObjCImplementationDecl() const {
   if (!hasClangNode())
     // This *is* the implementation, if it has one.

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -77,6 +77,7 @@ using CheckDeclAccessCallback = void(AccessScope, SourceLoc, ImportAccessLevel);
 class AccessControlCheckerBase {
 protected:
   bool checkUsableFromInline;
+  bool ignoreImportAccessLevel;
 
   bool shouldSkipChecking(const ValueDecl *decl);
 
@@ -122,8 +123,10 @@ protected:
                        AccessScope contextAccessScope, const DeclContext *useDC,
                        llvm::function_ref<CheckDeclAccessCallback> diagnose);
 
-  AccessControlCheckerBase(bool checkUsableFromInline)
-      : checkUsableFromInline(checkUsableFromInline) {}
+  AccessControlCheckerBase(bool checkUsableFromInline,
+                           bool ignoreImportAccessLevel)
+      : checkUsableFromInline(checkUsableFromInline),
+        ignoreImportAccessLevel(ignoreImportAccessLevel) {}
 
 public:
   void checkGenericParamAccess(
@@ -291,7 +294,8 @@ void AccessControlCheckerBase::checkTypeAccessImpl(
   if (type) {
     std::optional<AccessScope> typeAccessScope =
         TypeAccessScopeChecker::getAccessScope(type, useDC,
-                                               checkUsableFromInline);
+                                               checkUsableFromInline,
+                                               ignoreImportAccessLevel);
 
     // Note: This means that the type itself is invalid for this particular
     // context, because it references declarations from two incompatible scopes.
@@ -318,7 +322,8 @@ void AccessControlCheckerBase::checkTypeAccessImpl(
 
     auto typeReprAccessScope =
         TypeAccessScopeChecker::getAccessScope(typeRepr, useDC,
-                                               checkUsableFromInline);
+                                               checkUsableFromInline,
+                                               ignoreImportAccessLevel);
     if (!typeReprAccessScope.has_value())
       return;
 
@@ -358,7 +363,7 @@ void AccessControlCheckerBase::checkTypeAccessImpl(
       typeRepr, problematicAccessScope, useDC, checkUsableFromInline);
 
   ImportAccessLevel complainImport = std::nullopt;
-  if (complainRepr) {
+  if (complainRepr && !ignoreImportAccessLevel) {
     const ValueDecl *VD = complainRepr->getBoundDecl();
     assert(VD &&
            "findTypeDeclWithAccessScope should return bound TypeReprs only");
@@ -680,11 +685,14 @@ class AccessControlChecker : public AccessControlCheckerBase,
                              public DeclVisitor<AccessControlChecker> {
 public:
 
-  AccessControlChecker(bool allowUsableFromInline)
-    : AccessControlCheckerBase(allowUsableFromInline) {}
+  AccessControlChecker(bool allowUsableFromInline,
+                       bool ignoreImportAccessLevel)
+    : AccessControlCheckerBase(allowUsableFromInline,
+                               ignoreImportAccessLevel) {}
 
   AccessControlChecker()
-      : AccessControlCheckerBase(/*checkUsableFromInline=*/false) {}
+      : AccessControlCheckerBase(/*checkUsableFromInline=*/false,
+                                 /*ignoreImportAccessLevel=*/false) {}
 
   void visit(Decl *D) {
     if (D->isInvalid() || D->isImplicit())
@@ -1439,7 +1447,8 @@ class UsableFromInlineChecker : public AccessControlCheckerBase,
                                 public DeclVisitor<UsableFromInlineChecker> {
 public:
   UsableFromInlineChecker()
-      : AccessControlCheckerBase(/*checkUsableFromInline=*/true) {}
+      : AccessControlCheckerBase(/*checkUsableFromInline=*/true,
+                                 /*ignoreImportAccessLevel=*/false) {}
 
   void visit(Decl *D) {
     if (!D->getASTContext().isLanguageModeAtLeast(4, 2))
@@ -2881,7 +2890,10 @@ void swift::checkAccessControl(Decl *D) {
   if (isa<ValueDecl>(D) || isa<PatternBindingDecl>(D)) {
     bool allowInlineable =
         D->getDeclContext()->isInSpecializeExtensionContext();
-    AccessControlChecker(allowInlineable).visit(D);
+    bool ignoreImportAccessLevel =
+        D->getInnermostDeclContext()->isInObjCImplementationContext();
+
+    AccessControlChecker(allowInlineable, ignoreImportAccessLevel).visit(D);
     UsableFromInlineChecker().visit(D);
   } else if (auto *ED = dyn_cast<ExtensionDecl>(D)) {
     checkExtensionAccess(ED);

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -273,8 +273,8 @@ const {
     case DisallowedOriginKind::NonPublicImport:
     case DisallowedOriginKind::InternalBridgingHeaderImport:
     case DisallowedOriginKind::ImplementationOnly:
-      return DiagnosticBehavior::Ignore;
     case DisallowedOriginKind::SPIOnly:
+      return DiagnosticBehavior::Ignore;
     case DisallowedOriginKind::SPIImported:
     case DisallowedOriginKind::SPILocal:
     case DisallowedOriginKind::MissingImport:

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -265,6 +265,25 @@ const {
     }
   }
 
+  // Allow references to hidden dependencies from `@c/objc @implementation`
+  // decl signatures.
+  if (getDeclContext()->isInObjCImplementationContext()) {
+    switch (originKind) {
+    case DisallowedOriginKind::None:
+    case DisallowedOriginKind::NonPublicImport:
+    case DisallowedOriginKind::InternalBridgingHeaderImport:
+    case DisallowedOriginKind::ImplementationOnly:
+      return DiagnosticBehavior::Ignore;
+    case DisallowedOriginKind::SPIOnly:
+    case DisallowedOriginKind::SPIImported:
+    case DisallowedOriginKind::SPILocal:
+    case DisallowedOriginKind::MissingImport:
+    case DisallowedOriginKind::FragileCxxAPI:
+    case DisallowedOriginKind::ImplementationOnlyMemoryLayout:
+      break;
+    }
+  }
+
   // Exportability checking for non-library-evolution was introduced late,
   // downgrade errors to warnings by default.
   auto &ctx = DC->getASTContext();

--- a/test/ClangImporter/Inputs/c-bridging-header.h
+++ b/test/ClangImporter/Inputs/c-bridging-header.h
@@ -9,4 +9,7 @@ typedef struct {
 } MyPoint;
 
 typedef double MyDouble;
+
+void cImpl(MyPoint);
+
 #endif

--- a/test/ClangImporter/InternalBridgingHeader/implementation_only_checking.swift
+++ b/test/ClangImporter/InternalBridgingHeader/implementation_only_checking.swift
@@ -22,6 +22,9 @@ public func f() -> Any {
 
 // CHECK: var 'red' imported as 'internal' from bridging header
 
+@c @implementation
+public func cImpl(_ a: MyPoint) { } // No error on public reference to `MyPoint`
+
 @frozen
 public struct FrozenStruct {
     var p: MyPoint // expected-error {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}

--- a/test/ClangImporter/restricted_import_and_c_objc_implementation.swift
+++ b/test/ClangImporter/restricted_import_and_c_objc_implementation.swift
@@ -1,0 +1,102 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+/// internal import
+// RUN: %target-swift-frontend -typecheck -I %t %t/Client.swift \
+// RUN:   -sdk %clang-importer-sdk -swift-version 6 -enable-library-evolution \
+// RUN:   -disable-objc-attr-requires-foundation-module \
+// RUN:   -emit-module-interface-path %t/Client.swiftinterface \
+// RUN:   -emit-objc-header-path %t/Client-Swift.h
+// RUN: %target-swift-typecheck-module-from-interface(%t/Client.swiftinterface)
+// RUN: %target-clang -fsyntax-only %t/Client-Swift.h
+// RUN: %FileCheck %s --input-file %t/Client-Swift.h --check-prefix CHECK-COMPAT
+// CHECK-COMPAT-NOT: MyDouble
+// CHECK-COMPAT-NOT: MyPoint
+
+/// @_implementationOnly import
+// RUN: %target-swift-frontend -typecheck -I %t %t/Client.swift -D IOI \
+// RUN:   -sdk %clang-importer-sdk -swift-version 6 -enable-library-evolution \
+// RUN:   -disable-objc-attr-requires-foundation-module \
+// RUN:   -emit-module-interface-path %t/Client.swiftinterface \
+// RUN:   -emit-objc-header-path %t/Client-Swift.h
+// RUN: %target-swift-typecheck-module-from-interface(%t/Client.swiftinterface)
+// RUN: %target-clang -fsyntax-only %t/Client-Swift.h
+// RUN: %FileCheck %s --input-file %t/Client-Swift.h --check-prefix CHECK-COMPAT
+
+/// Check where we still raise errors
+// RUN: %target-swift-frontend -typecheck -I %t %t/Client.swift -D ERRORS \
+// RUN:   -sdk %clang-importer-sdk -swift-version 6 -enable-library-evolution \
+// RUN:   -disable-objc-attr-requires-foundation-module \
+// RUN:   -emit-module-interface-path %t/Client.swiftinterface \
+// RUN:   -emit-objc-header-path %t/Client-Swift.h \
+// RUN:   -verify -verify-additional-file %t/Lib.h
+
+// REQUIRES: objc_interop
+
+//--- module.modulemap
+module Lib {
+    header "Lib.h"
+}
+
+//--- Lib.h
+@import Foundation;
+
+typedef struct {
+  double x, y;
+} MyPoint;
+
+typedef double MyDouble; // expected-note {{type declared here}}
+
+void canReferenceHiddenDependency(MyPoint, MyDouble);
+void stillUnusableFromInlinable(); // expected-note {{global function 'stillUnusableFromInlinable()' is not '@usableFromInline' or public}}
+
+@interface ObjCImplClass: NSObject // expected-note {{class declared here}}
+@property MyPoint point;
+- (nonnull instancetype)initWithPoint:(MyPoint)point;
+- (void)method:(MyDouble)a;
+@end
+
+//--- Client.swift
+
+#if IOI
+  @_implementationOnly import Lib
+#else
+  internal import Lib // expected-note {{type alias 'MyDouble' imported as 'internal' from 'Lib' here}}
+  // expected-note @-1 {{global function 'stillUnusableFromInlinable()' imported as 'internal' from 'Lib' here}}
+  // expected-note @-2 {{class 'ObjCImplClass' imported as 'internal' from 'Lib' here}}
+#endif
+
+@c @implementation
+public func canReferenceHiddenDependency(_ a: MyPoint, _ b: MyDouble) { }
+
+@c @implementation
+public func stillUnusableFromInlinable() { }
+
+@objc @implementation
+extension ObjCImplClass { // expected-error {{cannot use class 'ObjCImplClass' in an extension with public or '@usableFromInline' members; 'Lib' was not imported publicly}}
+  var point: MyPoint
+
+  public init(point: MyPoint) {
+    self.point = point
+  }
+
+  public func method(_ a: MyDouble) {
+    func localFunc(_ b: MyDouble) {}
+    localFunc(a)
+  }
+
+#if ERRORS
+  final public func notAnImplementation(a: MyDouble) {} // expected-error {{method cannot be declared public because its parameter uses an internal type}}
+  // expected-note @-1 {{type alias 'MyDouble' is imported by this file as 'internal' from 'Lib'}}
+
+  final public func notAnImplementationLocal(a: SomeInternalType) {} // expected-error {{method cannot be declared public because its parameter uses an internal type}}
+#endif
+}
+
+internal struct SomeInternalType {} // expected-note {{type declared here}}
+
+#if ERRORS
+@inlinable public func inlinable() {
+    stillUnusableFromInlinable() // expected-error {{global function 'stillUnusableFromInlinable()' is internal and cannot be referenced from an '@inlinable' function}}
+}
+#endif

--- a/test/ClangImporter/restricted_import_and_c_objc_implementation.swift
+++ b/test/ClangImporter/restricted_import_and_c_objc_implementation.swift
@@ -23,6 +23,16 @@
 // RUN: %target-clang -fsyntax-only %t/Client-Swift.h
 // RUN: %FileCheck %s --input-file %t/Client-Swift.h --check-prefix CHECK-COMPAT
 
+/// @_spiOnly import
+// RUN: %target-swift-frontend -typecheck -I %t %t/Client.swift -D SPIONLY \
+// RUN:   -sdk %clang-importer-sdk -swift-version 6 -enable-library-evolution \
+// RUN:   -disable-objc-attr-requires-foundation-module \
+// RUN:   -emit-module-interface-path %t/Client.swiftinterface \
+// RUN:   -emit-objc-header-path %t/Client-Swift.h
+// RUN: %target-swift-typecheck-module-from-interface(%t/Client.swiftinterface)
+// RUN: %target-clang -fsyntax-only %t/Client-Swift.h
+// RUN: %FileCheck %s --input-file %t/Client-Swift.h --check-prefix CHECK-COMPAT
+
 /// Check where we still raise errors
 // RUN: %target-swift-frontend -typecheck -I %t %t/Client.swift -D ERRORS \
 // RUN:   -sdk %clang-importer-sdk -swift-version 6 -enable-library-evolution \
@@ -60,6 +70,8 @@ void stillUnusableFromInlinable(); // expected-note {{global function 'stillUnus
 
 #if IOI
   @_implementationOnly import Lib
+#elseif SPIONLY
+  @_spiOnly import Lib
 #else
   internal import Lib // expected-note {{type alias 'MyDouble' imported as 'internal' from 'Lib' here}}
   // expected-note @-1 {{global function 'stillUnusableFromInlinable()' imported as 'internal' from 'Lib' here}}


### PR DESCRIPTION
Implementations functions marked `@c @implementation` or implementation members of an `@objc @implementation` aren't part of the Swift API. Their declaration in C is the API definition, the Swift part only contributes to the ABI. This allows us to loosen some of the usual exportability checks on these functions as they are only relevant to API.

Here we allow such functions to be marked public even if their signature use types from a restricted import. In practical cases the type is the class itself or otherwise comes in via the same import as the C declaration. One may want to mark the function as public to set the symbol visibility or satisfy a requirement. Since the API visibility is determined by how the C headers are distributed, the restrictions on the import aren't relevant here.