### PR TITLE
Infer lifetime defaults for conditionally Escapable dependencies

### DIFF
--- a/include/swift/AST/ProtocolConformanceRef.h
+++ b/include/swift/AST/ProtocolConformanceRef.h
@@ -217,7 +217,7 @@ public:
 
   SWIFT_DEBUG_DUMP;
   void dump(llvm::raw_ostream &out, unsigned indent = 0,
-            bool details = true) const;
+            bool details = true) const LLVM_ATTRIBUTE_USED;
 
   void print(llvm::raw_ostream &out) const;
 

--- a/test/SIL/Parser/basic2_noncopyable_generics.sil
+++ b/test/SIL/Parser/basic2_noncopyable_generics.sil
@@ -34,3 +34,5 @@ struct NEG<T : ~Escapable> : ~Escapable {
     self.t = t
   }
 }
+
+extension NEG: Escapable where T: Escapable {}

--- a/test/SIL/implicit_lifetime_dependence.swift
+++ b/test/SIL/implicit_lifetime_dependence.swift
@@ -220,17 +220,7 @@ public struct OuterNE: ~Escapable {
     set { inner1 = newValue }
   }
 
-  public struct InnerNE: ~Escapable {
-    @_lifetime(copy owner)
-    init<Owner: ~Escapable & ~Copyable>(
-      owner: borrowing Owner
-    ) {}
-  }
-
-  @_lifetime(copy owner)
-  init<Owner: ~Copyable & ~Escapable>(owner: borrowing Owner) {
-    self.inner1 = InnerNE(owner: owner)
-  }
+  public struct InnerNE: ~Escapable {}
 
   // CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence7OuterNEV8setInner5valueyAC0gE0V_tF : $@convention(method)
   // (@guaranteed OuterNE.InnerNE, @lifetime(copy 0, copy 1) @inout OuterNE) -> () {

--- a/test/SIL/lifetime_dependence_param_position_test.swift
+++ b/test/SIL/lifetime_dependence_param_position_test.swift
@@ -8,7 +8,7 @@
 public struct Span<Element> : ~Escapable {
   private var baseAddress: UnsafeRawPointer
   public let count: Int
-  @_lifetime(copy owner)
+  @_lifetime(borrow owner)
   public init<Owner: ~Copyable & ~Escapable>(
       baseAddress: UnsafeRawPointer,
       count: Int,

--- a/test/SILOptimizer/borrow_accessor_address_only_non_escapable.swift
+++ b/test/SILOptimizer/borrow_accessor_address_only_non_escapable.swift
@@ -14,6 +14,8 @@ struct Butt<T: ~Escapable>: ~Escapable {
 	}
 }
 
+extension Butt: Escapable where T: Escapable {}
+
 struct Tubb<T>: ~Escapable {
 	var x: T
 

--- a/test/SILOptimizer/functionsigopts.sil
+++ b/test/SILOptimizer/functionsigopts.sil
@@ -1840,6 +1840,8 @@ struct NE<T> : ~Escapable where T : ~Escapable {
   init(_ t: borrowing T)
 }
 
+extension NE: Escapable where T: Escapable {}
+
 // CHECK-NOT: sil [serialized] [signature_optimized_thunk] [heuristic_always_inline] @neinit :
 sil [noinline] @neinit : $@convention(method) <T where T : ~Escapable> (@in_guaranteed T, @thin NE<T>.Type) -> @lifetime(copy 0) @owned NE<T> {
 bb0(%0 : @noImplicitCopy $*T, %1 : $@thin NE<T>.Type):

--- a/test/SILOptimizer/functionsigopts_crash.swift
+++ b/test/SILOptimizer/functionsigopts_crash.swift
@@ -62,6 +62,8 @@ struct NE<T : ~Escapable> : ~Escapable {
   init(_ t: borrowing T) {}
 }
 
+extension NE: Escapable where T: Escapable {}
+
 @_lifetime(copy t)
 func getNE<T : ~Escapable>(_ t: borrowing T) -> NE<T> {
   return NE(t)

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_diagnostics.swift
@@ -60,6 +60,8 @@ extension NEOptional where Wrapped: ~Escapable {
   public init(_ some: consuming Wrapped) { self = .some(some) }
 }
 
+extension NEOptional: Escapable where Wrapped: Escapable {}
+
 func takeClosure(_: () -> ()) {}
 
 // No mark_dependence is needed for a inherited scope.

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_generic.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_generic.swift
@@ -52,7 +52,7 @@ struct NCInt: ~Copyable {
 struct NEInt: ~Escapable {
   let value: Builtin.Int64
 
-  @_lifetime(copy o)
+  @_lifetime(borrow o)
   init<O: ~Copyable & ~Escapable>(v: Builtin.Int64, o: borrowing O) {
     self.value = v
   }

--- a/test/SILOptimizer/moveonly_addresschecker.swift
+++ b/test/SILOptimizer/moveonly_addresschecker.swift
@@ -82,6 +82,8 @@ struct TestCoroAccessorOfCoroAccessor<T : ~Escapable> : ~Copyable & ~Escapable {
   }
 }
 
+extension TestCoroAccessorOfCoroAccessor: Escapable where T: Escapable {}
+
 @usableFromInline
 internal func unsafeBitCast<T: ~Escapable & ~Copyable, U>(
    _ x: consuming T, to type: U.Type

--- a/test/Sema/lifetime_depend_infer.swift
+++ b/test/Sema/lifetime_depend_infer.swift
@@ -27,52 +27,70 @@ struct MutNE: ~Copyable & ~Escapable {}
 // Same-type default rule
 // =============================================================================
 
+/* DEFAULT: @_lifetime(copy ne) */
 func sameTypeParam(ne: NE) -> NE { ne }
 
+/* DEFAULT: @_lifetime(copy ne) */
 func sameTypeConsumingParam(ne: consuming NE) -> NE { ne }
 
+/* DEFAULT: @_lifetime(copy ne) */
 func sameTypeBorrowingParam(ne: borrowing NE) -> NE { ne }
 
 func sameTypeInoutParam(ne: inout NE) -> NE { ne } // expected-error{{cannot infer the lifetime dependence scope on a function with a ~Escapable parameter, specify '@_lifetime(borrow ne)' or '@_lifetime(copy ne)'}}
 
+/* DEFAULT: @_lifetime(copy ne, copy ne2) */
 func sameTypeParam_sameTypeParam(ne1: NE, ne2: NE) -> NE { ne1 }
 
+/* DEFAULT: @_lifetime(copy ne) */
 func sameTypeParam_otherTypeParam(ne: NE, c: C) -> NE { ne }
 
+/* DEFAULT: @_lifetime(copy ne) */
 func sameTypeParam_sameTypeInoutParam(ne: NE, mutNE: inout NE) -> NE { ne }
 
 struct NonEscapable<T>: ~Escapable {
   @_lifetime(immortal)
   init() {}
 
+  /* DEFAULT: @_lifetime(copy ne) */
   init(ne: Self) {}
 
   init(c: C) {} // expected-error{{cannot borrow the lifetime of 'c', which has consuming ownership on an initializer}}
 
+  /* DEFAULT: @_lifetime(copy ne) */
   init(ne: Self, c: C) {}
 
+  /* DEFAULT: @_lifetime(copy ne) */
   init<U>(ne: Self, u: U) {}
 
+  /* DEFAULT: @_lifetime(copy neNominal) */
   init<U>(neNominal: NonEscapable<T>, u: U) {}
 
   init<U>(other: NonEscapable<U>) {} // expected-error{{cannot infer the lifetime dependence scope on an initializer with a ~Escapable parameter, specify '@_lifetime(borrow other)' or '@_lifetime(copy other)'}}
 
+  /* DEFAULT: @_lifetime(copy self) */
   func sameTypeSelf_noParam() -> Self { self }
 
+  /* DEFAULT: @_lifetime(copy self) */
   consuming func sameTypeConsumingSelf_noParam() -> Self { self }
 
+  /* DEFAULT: @_lifetime(copy self) */
   borrowing func sameTypeBorrowingSelf_noParam() -> Self { self }
 
   mutating func sameTypeMutatingSelf() -> Self { self } // expected-error{{a mutating method with a ~Escapable result requires '@_lifetime(...)'}}
 
+  /* DEFAULT: @_lifetime(copy self, copy ne) */
   func sameTypeSelf_sameTypeParam(ne: Self) -> Self { self }
 
+  /* DEFAULT: @_lifetime(copy self) */
   func sameTypeSelf_otherTypeParam(c: C) -> Self { self }
 
+  /* DEFAULT: @_lifetime(copy self) */
   func sameTypeSelf_sameTypeInoutParam(mutNE: inout Self) -> Self { self }
 
+  /* DEFAULT: @_lifetime(copy self) */
   func sameArchetypeSelf<U>(u: U) -> Self { self }
 
+  /* DEFAULT: @_lifetime(copy self) */
   func sameNominalTypeSelf_genericParam<U>(u: U) -> NonEscapable<T> { self }
 
   func otherNominalTypeSelf_genericParam<U>(u: U) -> NonEscapable<U> { NonEscapable<U>() } // expected-error{{a method with a ~Escapable result requires '@_lifetime(...)'}}
@@ -90,6 +108,7 @@ protocol NonEscapableProtocol: ~Escapable {
 
   init(neProtocol: any NonEscapableProtocol, c: C) // expected-error{{an initializer with a ~Escapable result requires '@_lifetime(...)'}}
 
+  /* DEFAULT: @_lifetime(copy self) */
   func sameArchetypeSelf() -> Self
 
   mutating func sameArchetypeMutatingSelf() -> Self // expected-error{{a mutating method with a ~Escapable result requires '@_lifetime(...)'}}
@@ -101,6 +120,7 @@ extension NonEscapableProtocol where Self: ~Escapable {
   }
 }
 
+/* DEFAULT: @_lifetime(copy ne) */
 func sameGenericTypeParam<T: ~Escapable>(ne: T) -> T {
   ne
 }
@@ -144,6 +164,91 @@ extension AssociatedQ where Q == QQ {
   static func sameAssociatedTypeParam(a: Q.U) -> QQ.U {
     QQ.U.create()
   }
+}
+
+// =============================================================================
+// Same type default rule for conditionally Escapable parameters
+// =============================================================================
+
+/* DEFAULT: @_lifetime(copy t) */
+func unconditionalNESource<T: ~Escapable>(ne: NE, t: T) -> T {
+  t
+}
+
+struct NE1<T: ~Escapable>: ~Escapable {
+  var t: T
+}
+
+extension NE1: Escapable where T: Escapable {}
+
+/* DEFAULT: @_lifetime(copy ne) */
+func conditionalNESource<T: ~Escapable>(ne: NE1<T>) -> T {
+  ne.t
+}
+
+/* DEFAULT: @_lifetime(copy t) */
+func conditionalNEDest<T: ~Escapable>(t: T) -> NE1<T> {
+  NE1(t: t)
+}
+
+struct NE2<T: ~Escapable>: ~Escapable {
+  var t: T
+}
+
+extension NE2: Escapable where T: Escapable {}
+
+/* DEFAULT: @_lifetime(copy ne) */
+func conditionalNESourceDest<T: ~Escapable>(ne: NE1<T>) -> NE2<T> {
+  NE2(t: ne.t)
+}
+
+/* DEFAULT: @_lifetime(copy ne) */
+func conditionalNENestedSource<T: ~Escapable>(ne: NE1<NE1<T>>) -> NE2<T> {
+  NE2(t: ne.t.t)
+}
+
+/* DEFAULT: @_lifetime(copy ne) */
+func specializedNESource(ne: NE1<NE>) -> NE { ne.t }
+
+/* DEFAULT: @_lifetime(copy ne) */
+func specializedNEDest(ne: NE) -> NE1<NE> { NE1(t: ne) }
+
+/* DEFAULT: @_lifetime(copy ne) */
+func specializedNESourceDest(ne: NE1<NE>) -> NE2<NE> {
+  NE2<NE>(t: ne.t)
+}
+
+/* DEFAULT: @_lifetime(copy ne) */
+func optionalUnwrap(ne: NE?) -> NE { ne! }
+
+/* DEFAULT: @_lifetime(copy ne) */
+func optionalWrap(ne: NE) -> NE? { ne }
+
+struct NEPair<T: ~Escapable, U: ~Escapable>: ~Escapable {
+  var t: T
+  var u: U
+
+  @_lifetime(copy t, copy u)
+  init(t: T, u: U) {
+    self.t = t
+    self.u = u
+  }
+}
+
+extension NEPair: Escapable where T: Escapable, U: Escapable {}
+
+func testNEPair<T: ~Escapable, U: ~Escapable>(ne: NEPair<T, U>) -> T {
+  ne.t
+}
+
+struct NESpareType<T: ~Escapable, U: ~Escapable>: ~Escapable {
+  var t: T
+}
+
+extension NESpareType: Escapable where T: Escapable, U: ~Escapable {}
+
+func testNESpareType<T: ~Escapable, U>(ne: NESpareType<T, U>) -> T {
+  ne.t
 }
 
 // =============================================================================


### PR DESCRIPTION
- **Document new @_lifetime restrictions and defaults**
  

- **Infer lifetime defaults for conditionally Escapable dependencies**
  Example:
  
      /* DEFAULT @_lifetime(copy t) */
      func foo<T: ~Escapable>(t: T?) -> T
  
  See Same-type default lifetime:
  https://github.com/swiftlang/swift/blob/main/docs/ReferenceGuides/LifetimeAnnotation.md#same-type-default-lifetime
  
  Fixes rdar://150959598 ([nonescapable] infer & check same-type
  dependencies for functions returning non-Escapable types)
  

- **[NFC] Update tests for conditionally ~Escapable dependencies**
  These changes are not required for the tests to pass but the tests now properly
  express the original intention, which was to test conditionally Escapable types.
  

- **Add tests for same-type default lifetimes.**
  