### PR TITLE
Reflection: Support for `Builtin.Borrow`.

### DIFF
--- a/include/swift/RemoteInspection/DescriptorFinder.h
+++ b/include/swift/RemoteInspection/DescriptorFinder.h
@@ -22,19 +22,36 @@ namespace reflection {
 
 class TypeRef;
 
+/// Enum representing the bitwise-takability and/or borrowability of a type.
+///
+/// A type is bitwise-takable if it can be moved with a `memmove`-equivalent
+/// operation. A type is bitwise-borrowable if it can be passed as a borrow
+/// with memcpy-equivalent behavior (such as passing the value in registers
+/// instead of passing its address). A type must be bitwise-takable if it is
+/// bitwise-borrowable, but the inverse is not true.
+enum class BitwiseBorrowability : unsigned {
+  None,
+  TakableOnly,
+  TakableAndBorrowable
+};
+
 /// An abstract interface for a builtin type descriptor.
 struct BuiltinTypeDescriptorBase {
   const uint32_t Size;
   const uint32_t Alignment;
   const uint32_t Stride;
   const uint32_t NumExtraInhabitants;
-  const bool IsBitwiseTakable;
+  const BitwiseBorrowability Borrowability;
+  const bool AddressableForDependencies;
 
   BuiltinTypeDescriptorBase(uint32_t Size, uint32_t Alignment, uint32_t Stride,
-                            uint32_t NumExtraInhabitants, bool IsBitwiseTakable)
+                            uint32_t NumExtraInhabitants,
+                            BitwiseBorrowability Borrowability,
+                            bool AFD)
       : Size(Size), Alignment(Alignment), Stride(Stride),
         NumExtraInhabitants(NumExtraInhabitants),
-        IsBitwiseTakable(IsBitwiseTakable) {}
+        Borrowability(Borrowability),
+        AddressableForDependencies(AFD) {}
 
   virtual ~BuiltinTypeDescriptorBase(){};
 

--- a/include/swift/RemoteInspection/ReflectionContext.h
+++ b/include/swift/RemoteInspection/ReflectionContext.h
@@ -2347,14 +2347,16 @@ private:
     Builder.addField(*OffsetToFirstCapture,
                      /*alignment=*/sizeof(StoredPointer),
                      /*numExtraInhabitants=*/0,
-                     /*bitwiseTakable=*/true);
+                     /*borrowability=*/BitwiseBorrowability::TakableAndBorrowable,
+                     /*afd*/ false);
 
     // Skip the closure's necessary bindings struct, if it's present.
     auto SizeOfNecessaryBindings = Info.NumBindings * sizeof(StoredPointer);
     Builder.addField(/*size=*/SizeOfNecessaryBindings,
                      /*alignment=*/sizeof(StoredPointer),
                      /*numExtraInhabitants=*/0,
-                     /*bitwiseTakable=*/true);
+                     /*borrowability=*/BitwiseBorrowability::TakableAndBorrowable,
+                     /*afd*/ false);
 
     // FIXME: should be unordered_set but I'm too lazy to write a hash
     // functor

--- a/stdlib/public/RemoteInspection/TypeRefBuilder.cpp
+++ b/stdlib/public/RemoteInspection/TypeRefBuilder.cpp
@@ -623,8 +623,11 @@ public:
   BuiltinTypeDescriptorImpl(RemoteRef<BuiltinTypeDescriptor> BTD,
                             TypeRefBuilder &Builder)
       : BuiltinTypeDescriptorBase(BTD->Size, BTD->getAlignment(),
-                                       BTD->Stride, BTD->NumExtraInhabitants,
-                                       BTD->isBitwiseTakable()),
+                                  BTD->Stride, BTD->NumExtraInhabitants,
+                                  BTD->isBitwiseTakable()
+                                    ? BitwiseBorrowability::TakableAndBorrowable
+                                    : BitwiseBorrowability::None,
+                                  /*AFD*/ false),
         BTD(BTD), Builder(Builder) {}
 
   ~BuiltinTypeDescriptorImpl() override {}

--- a/test/Reflection/Inputs/TypeLowering.swift
+++ b/test/Reflection/Inputs/TypeLowering.swift
@@ -272,3 +272,51 @@ public struct RefersToOtherAssocType {
   var x: OpaqueWitness.A
   var y: OpaqueWitness.A
 }
+
+public enum SimpleEnum {
+  case a, b, c
+}
+
+public enum NormalSinglePayloadEnum {
+  case a(Int)
+  case b
+}
+
+public struct AFD { var x: [1 of Int] }
+
+public enum AFDSinglePayloadEnum {
+  case a(AFD)
+  case b
+}
+
+public enum NormalMultiPayloadEnum {
+  case a(Int)
+  case b(Int)
+}
+
+public enum AFDMultiPayloadEnum {
+  case a(AFD)
+  case b(Int)
+}
+
+public struct NormalStruct {
+  var a: Int
+  var b: Int
+}
+
+public struct AFDStruct {
+  var a: AFD
+  var b: Int
+}
+
+public struct NotQuiteBig {
+  var a, b, c: Int
+}
+
+public struct AlmostBig {
+  var a, b, c, d: Int
+}
+
+public struct Big {
+  var a, b, c, d, e: Int
+}


### PR DESCRIPTION
Plumb the `BitwiseBorrowable` and `AddressableForDependencies` layout properties through reflection TypeLowering, and implement type layout for `Builtin.Borrow` based on those properties.
