### PR TITLE
ClangImporter: Suppress warnings from system modules during pcm gener…

### DIFF
--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -2159,6 +2159,8 @@ void importer::finalizeLookupTable(
             nameImporter.getClangContext().getSourceManager(), diagLoc);
 
         DiagnosticEngine &swiftDiags = nameImporter.getContext().Diags;
+        if (decl->getOwningModule()->IsSystem)
+          continue;
         swiftDiags.diagnose(swiftSourceLoc, diag::unresolvable_clang_decl,
                             decl->getNameAsString(), swiftName->getName());
         StringRef moduleName =

--- a/test/ClangImporter/Inputs/custom-modules/SystemModuleWithWarnings.h
+++ b/test/ClangImporter/Inputs/custom-modules/SystemModuleWithWarnings.h
@@ -1,0 +1,10 @@
+#ifndef SYSTEM_MODULE_WITH_WARNINGS_H
+#define SYSTEM_MODULE_WITH_WARNINGS_H
+
+// Test NS_SWIFT_NAME warning suppression (unresolvable_clang_decl)
+typedef enum {
+  TestValue1,
+  TestValue2
+} TestEnum __attribute__((swift_name("NonExistentType.TestEnum")));
+
+#endif // SYSTEM_MODULE_WITH_WARNINGS_H

--- a/test/ClangImporter/Inputs/custom-modules/module.modulemap
+++ b/test/ClangImporter/Inputs/custom-modules/module.modulemap
@@ -297,3 +297,8 @@ module CVarArgs {
   header "CVarArgs.h"
   export *
 }
+
+module SystemModuleWithWarnings {
+  header "SystemModuleWithWarnings.h"
+  export *
+}

--- a/test/ClangImporter/pcm-emit-system-module-suppress-warning.swift
+++ b/test/ClangImporter/pcm-emit-system-module-suppress-warning.swift
@@ -1,0 +1,21 @@
+// Test that warnings from system modules are suppressed during PCM generation
+
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-emit-pcm -module-name SystemModuleWithWarnings \
+// RUN:   -Xcc -Xclang -Xcc -emit-module \
+// RUN:   -Xcc -Xclang -Xcc -fsystem-module \
+// RUN:   -o %t/SystemModuleWithWarnings.pcm \
+// RUN:   %S/Inputs/custom-modules/module.modulemap 2>&1 | %FileCheck %s --allow-empty
+
+// Verify NO warnings are emitted for system modules
+// CHECK-NOT: warning:
+
+// Emit PCM for NON-system module - should show warnings
+// RUN: %target-swift-emit-pcm -module-name SystemModuleWithWarnings \
+// RUN:   -o %t/SystemModuleWithWarnings.pcm \
+// RUN:   %S/Inputs/custom-modules/module.modulemap 2>&1 | %FileCheck %s --check-prefix=CHECK-WARNINGS
+
+// CHECK-WARNINGS: warning:
+
+import SystemModuleWithWarnings


### PR DESCRIPTION
…ation

Suppress Swift warnings (unresolvable_clang_decl) when generating precompiled modules for system frameworks.

rdar://170174282

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
