### PR TITLE
[ExplicitModule] Teach scanner emit loaded module trace

### DIFF
--- a/include/swift/AST/SearchPathOptions.h
+++ b/include/swift/AST/SearchPathOptions.h
@@ -567,6 +567,9 @@ public:
   /// Enable auto bridging header chaining.
   bool BridgingHeaderChaining = false;
 
+  /// The module names for dependecy only imports.
+  std::vector<std::string> DependencyOnlyModuleImports;
+
   /// Return all module search paths that (non-recursively) contain a file whose
   /// name is in \p Filenames.
   SmallVector<const ModuleSearchPath *, 4>
@@ -589,21 +592,23 @@ public:
   llvm::hash_code getPCHHashComponents() const {
     using llvm::hash_combine;
     using llvm::hash_combine_range;
-    return hash_combine(SDKPath,
-                        hash_combine_range(ImportSearchPaths.begin(), ImportSearchPaths.end()),
-                        hash_combine_range(VFSOverlayFiles.begin(), VFSOverlayFiles.end()),
-                        hash_combine_range(FrameworkSearchPaths.begin(),
-                                           FrameworkSearchPaths.end()),
-                        hash_combine_range(LibrarySearchPaths.begin(),
-                                           LibrarySearchPaths.end()),
-                        RuntimeResourcePath,
-                        hash_combine_range(RuntimeLibraryImportPaths.begin(),
-                                           RuntimeLibraryImportPaths.end()),
-                        hash_combine_range(ImplicitFrameworkSearchPaths.begin(),
-                                           ImplicitFrameworkSearchPaths.end()),
-                        DisableModulesValidateSystemDependencies,
-                        ScannerModuleValidation,
-                        ModuleLoadMode);
+    return hash_combine(
+        SDKPath,
+        hash_combine_range(ImportSearchPaths.begin(), ImportSearchPaths.end()),
+        hash_combine_range(VFSOverlayFiles.begin(), VFSOverlayFiles.end()),
+        hash_combine_range(FrameworkSearchPaths.begin(),
+                           FrameworkSearchPaths.end()),
+        hash_combine_range(LibrarySearchPaths.begin(),
+                           LibrarySearchPaths.end()),
+        RuntimeResourcePath,
+        hash_combine_range(RuntimeLibraryImportPaths.begin(),
+                           RuntimeLibraryImportPaths.end()),
+        hash_combine_range(ImplicitFrameworkSearchPaths.begin(),
+                           ImplicitFrameworkSearchPaths.end()),
+        hash_combine_range(DependencyOnlyModuleImports.begin(),
+                           DependencyOnlyModuleImports.end()),
+        DisableModulesValidateSystemDependencies, ScannerModuleValidation,
+        ModuleLoadMode);
   }
 
   /// Return a hash code of any components from these options that should

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -544,12 +544,12 @@ public:
   /// Return a hash code of any components from these options that should
   /// contribute to a Swift Dependency Scanning hash.
   llvm::hash_code getModuleScanningHashComponents() const {
-    return hash_combine(ModuleName,
-                        ModuleABIName,
-                        ModuleLinkName,
-                        ImplicitObjCHeaderPath,
-                        PrebuiltModuleCachePath,
-                        UserModuleVersion);
+    return hash_combine(
+        ModuleName, ModuleABIName, ModuleLinkName, ImplicitObjCHeaderPath,
+        PrebuiltModuleCachePath,
+        llvm::hash_combine_range(ImplicitImportModuleNames.begin(),
+                                 ImplicitImportModuleNames.end()),
+        UserModuleVersion);
   }
 
   StringRef determineFallbackModuleName() const;

--- a/include/swift/FrontendTool/Dependencies.h
+++ b/include/swift/FrontendTool/Dependencies.h
@@ -1,4 +1,4 @@
-//===--- Dependencies.h -- Unified header for dependency tracing utilities --===//
+//===----------------------------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -24,15 +24,27 @@ class FrontendOptions;
 class InputFile;
 class ModuleDecl;
 class CompilerInstance;
+struct ModuleDependencyID;
+class ModuleDependenciesCache;
+class ASTContext;
 
 /// Emit the names of the modules imported by \c mainModule.
 bool emitImportedModules(ModuleDecl *mainModule, const FrontendOptions &opts,
                          llvm::vfs::OutputBackend &backend);
+
+/// Emit loadedModuleTrace file if needed.
 bool emitLoadedModuleTraceIfNeeded(ModuleDecl *mainModule,
                                    DependencyTracker *depTracker,
                                    const FrontendOptions &opts,
                                    const InputFile &input);
 
+/// Emit loadedModuleTrace file from module dependency.
+bool emitLoadedModuleTraceIfNeeded(const ModuleDependencyID &mainModule,
+                                   const ModuleDependenciesCache &cache,
+                                   const ASTContext &context,
+                                   const FrontendOptions &opts);
+
+/// Emit fine grain dependency file if needed.
 bool emitFineModuleTraceIfNeeded(CompilerInstance &Instance,
                                  const FrontendOptions &opts);
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -989,6 +989,9 @@ def import_module : Separate<["-"], "import-module">,
 def testable_import_module : Separate<["-"], "testable-import-module">,
   HelpText<"Implicitly import the specified module with @testable">;
 
+def dependency_only_import : Separate<["-"], "dependency-only-import">,
+                             HelpText<"Import the module as a dependency only">;
+
 def print_stats : Flag<["-"], "print-stats">,
   HelpText<"Print various statistics">;
 

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -467,6 +467,32 @@ void ModuleDependencyInfo::addBridgingHeaderIncludeTree(StringRef ID) {
   }
 }
 
+void ModuleDependencyInfo::addDependencyOnlyImport(StringRef ID) {
+  switch (getKind()) {
+  case swift::ModuleDependencyKind::SwiftSource: {
+    auto swiftSourceStorage =
+        cast<SwiftSourceModuleDependenciesStorage>(storage.get());
+    swiftSourceStorage->addDependencyOnlyImport(ID);
+    break;
+  }
+  default:
+    llvm_unreachable("Unexpected dependency kind");
+  }
+}
+
+const std::vector<std::string> &
+ModuleDependencyInfo::getDependencyOnlyImports() const {
+  switch (getKind()) {
+  case swift::ModuleDependencyKind::SwiftSource: {
+    auto swiftSourceStorage =
+        cast<SwiftSourceModuleDependenciesStorage>(storage.get());
+    return swiftSourceStorage->getDependencyOnlyImports();
+  }
+  default:
+    llvm_unreachable("Unexpected dependency kind");
+  }
+}
+
 void ModuleDependencyInfo::setChainedBridgingHeaderBuffer(StringRef path,
                                                           StringRef buffer) {
   switch (getKind()) {
@@ -1008,6 +1034,16 @@ ModuleDependenciesCache::getAllClangDependencies(
   return ModuleDependencyIDCollectionView(
       moduleInfo.getImportedClangDependencies(),
       moduleInfo.getHeaderClangDependencies());
+}
+
+ModuleDependencyIDCollectionView
+ModuleDependenciesCache::getAllSwiftDependencies(
+    const ModuleDependencyID &moduleID) const {
+  const auto &moduleInfo = findKnownDependency(moduleID);
+  return ModuleDependencyIDCollectionView(
+      moduleInfo.getImportedSwiftDependencies(),
+      moduleInfo.getSwiftOverlayDependencies(),
+      moduleInfo.getCrossImportOverlayDependencies());
 }
 
 llvm::ArrayRef<ModuleDependencyID>

--- a/lib/DependencyScan/CMakeLists.txt
+++ b/lib/DependencyScan/CMakeLists.txt
@@ -14,6 +14,7 @@ target_link_libraries(swiftDependencyScan INTERFACE
 target_link_libraries(swiftDependencyScan PRIVATE
   swiftClangImporter
   swiftAST
+  swiftFrontendTool
   swiftSerialization)
 
 target_link_libraries(swiftDependencyScan PUBLIC

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -785,6 +785,20 @@ ModuleDependencyScanner::getMainModuleDependencyInfo(ModuleDecl *mainModule) {
     mainDependencies.updateCommandLine(buildArgs);
   }
 
+  // Dependency only imports
+  {
+    for (auto &m : ScanASTContext.SearchPathOpts.DependencyOnlyModuleImports) {
+      // If module is seen, then it is not dependency only, ignore.
+      if (alreadyAddedModules.contains(m))
+        continue;
+
+      mainDependencies.addModuleImport(
+          m,
+          /*isExported=*/false, AccessLevel::Public, &alreadyAddedModules);
+      mainDependencies.addDependencyOnlyImport(m);
+    }
+  }
+
   return mainDependencies;
 }
 

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -45,6 +45,7 @@
 #include "swift/Frontend/FrontendOptions.h"
 #include "swift/Frontend/ModuleInterfaceLoader.h"
 #include "swift/Frontend/SerializedDiagnosticConsumer.h"
+#include "swift/FrontendTool/Dependencies.h"
 #include "swift/Strings.h"
 #include "clang/CAS/IncludeTree.h"
 #include "llvm/ADT/STLExtras.h"
@@ -1437,6 +1438,12 @@ performModuleScanImpl(
   if (ctx.Stats)
     ctx.Stats->getFrontendCounters().NumDepScanFilesystemLookups =
         scanner.getNumLookups();
+
+  if (!ctx.hadError()) {
+    emitLoadedModuleTraceIfNeeded(
+        mainModuleID, cache, ctx,
+        instance->getInvocation().getFrontendOptions());
+  }
 
   // Serialize the dependency cache if -serialize-dependency-scan-cache
   // is specified

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2687,6 +2687,10 @@ static bool ParseSearchPathArgs(SearchPathOptions &Opts, ArgList &Args,
   Opts.DisableCrossImportOverlaySearch |=
       Args.hasArg(OPT_disable_cross_import_overlay_search);
 
+  for (auto &Mod : Args.getAllArgValues(OPT_dependency_only_import)) {
+    Opts.DependencyOnlyModuleImports.push_back(Mod);
+  }
+
   // Opts.RuntimeIncludePath is set by calls to
   // setRuntimeIncludePath() or setMainExecutablePath().
   // Opts.RuntimeImportPath is set by calls to

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -547,10 +547,10 @@ bool FrontendOptions::canActionEmitLoadedModuleTrace(ActionType action) {
   case ActionType::REPL:
   case ActionType::EmitPCM:
   case ActionType::DumpPCM:
-  case ActionType::ScanDependencies:
   case ActionType::PrintVersion:
   case ActionType::PrintArguments:
     return false;
+  case ActionType::ScanDependencies:
   case ActionType::ResolveImports:
   case ActionType::Typecheck:
   case ActionType::MergeModules:

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -21,7 +21,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/FrontendTool/FrontendTool.h"
-#include "Dependencies.h"
 #include "TBD.h"
 #include "swift/AST/ASTBridging.h"
 #include "swift/AST/ASTDumper.h"
@@ -63,6 +62,7 @@
 #include "swift/Frontend/MakeStyleDependencies.h"
 #include "swift/Frontend/ModuleInterfaceLoader.h"
 #include "swift/Frontend/ModuleInterfaceSupport.h"
+#include "swift/FrontendTool/Dependencies.h"
 #include "swift/IRGen/TBDGen.h"
 #include "swift/Immediate/Immediate.h"
 #include "swift/Index/IndexRecord.h"

--- a/lib/FrontendTool/ImportedModules.cpp
+++ b/lib/FrontendTool/ImportedModules.cpp
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "Dependencies.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticEngine.h"
@@ -21,6 +20,7 @@
 #include "swift/Basic/STLExtras.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/Frontend/FrontendOptions.h"
+#include "swift/FrontendTool/Dependencies.h"
 #include "clang/Basic/Module.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/StringRef.h"

--- a/lib/Serialization/ScanningLoaders.cpp
+++ b/lib/Serialization/ScanningLoaders.cpp
@@ -217,10 +217,13 @@ SwiftModuleScanner::scanInterfaceFile(Identifier moduleID,
                /*static=*/false, /*force_load=*/true});
         }
         bool isStatic = llvm::find(ArgsRefs, "-static") != ArgsRefs.end();
+        bool isStrictMemorySafety =
+            llvm::find(ArgsRefs, "-strict-memory-safety") != ArgsRefs.end();
 
         Result = ModuleDependencyInfo::forSwiftInterfaceModule(
             InPath, compiledCandidatesRefs, ArgsRefs, {}, {}, linkLibraries,
-            isFramework, isStatic, {}, /*module-cache-key*/ "", UserModVer);
+            isFramework, isStatic, isStrictMemorySafety, {},
+            /*module-cache-key*/ "", UserModVer);
 
         // Walk the source file to find the import declarations.
         llvm::StringSet<> alreadyAddedModules;
@@ -356,6 +359,9 @@ llvm::ErrorOr<ModuleDependencyInfo> SwiftModuleScanner::scanBinaryModuleFile(
       serializedSearchPaths, binaryModuleImports->headerImport,
       definingModulePath, isFramework, loadedModuleFile->isStaticLibrary(),
       loadedModuleFile->isBuiltWithCxxInterop(),
+      loadedModuleFile->getResilienceStrategy() ==
+          ResilienceStrategy::Resilient,
+      loadedModuleFile->strictMemorySafety(),
       /*module-cache-key*/ "", userModuleVer);
 
   for (auto &macro : loadedModuleFile->getExternalMacros()) {

--- a/test/CAS/module_trace.swift
+++ b/test/CAS/module_trace.swift
@@ -13,7 +13,7 @@
 
 // RUN: %target-swift-frontend-plain -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache %t/main.swift \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
-// RUN:   -o %t/deps.json -I %t -cache-compile-job -cas-path %t/cas -swift-version 5
+// RUN:   -o %t/deps.json -I %t -cache-compile-job -cas-path %t/cas -swift-version 5 -emit-loaded-module-trace -emit-loaded-module-trace-path %t/test.trace.json 
 
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json A > %t/A.cmd
 // RUN: %swift_frontend_plain @%t/A.cmd
@@ -33,7 +33,7 @@
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
 // RUN:   -module-name Test -explicit-swift-module-map-file @%t/map.casid \
 // RUN:   -emit-reference-dependencies-path %t/test.swiftdeps -emit-dependencies \
-// RUN:   -primary-file %t/main.swift @%t/MyApp.cmd -emit-loaded-module-trace -emit-loaded-module-trace-path %t/test.trace.json 2>&1 \
+// RUN:   -primary-file %t/main.swift @%t/MyApp.cmd 2>&1 \
 // RUN:     | %FileCheck %s --check-prefix=WARNING --allow-empty
 
 // WARNING-NOT: WARNING:

--- a/test/ScanDependencies/loaded_module_trace.swift
+++ b/test/ScanDependencies/loaded_module_trace.swift
@@ -1,0 +1,55 @@
+// REQUIRES: swift_feature_RegionBasedIsolation
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/cache)
+// RUN: split-file %s %t
+
+// RUN: %target-build-swift -emit-module -module-name Module %S/../Driver/Inputs/loaded_module_trace_empty.swift \
+// RUN:   -o %t/Module.swiftmodule -module-cache-path %t/cache
+// RUN: %target-build-swift -emit-module -module-name Module2 %S/../Driver/Inputs/loaded_module_trace_imports_module.swift \
+// RUN:   -o %t/Module2.swiftmodule -I %t -module-cache-path %t/cache -strict-memory-safety
+// RUN: %target-build-swift -emit-library -module-name Plugin %S/../Driver/Inputs/loaded_module_trace_compiler_plugin.swift \
+// RUN:   -o %t/%target-library-name(Plugin) -module-cache-path %t/cache
+
+// RUN: %target-swift-frontend -scan-dependencies %t/test.swift -emit-loaded-module-trace -emit-loaded-module-trace-path %t/trace.json \
+// RUN:   -enable-upcoming-feature RegionBasedIsolation -strict-memory-safety -module-name Test -dependency-only-import B \
+// RUN:   -I %t -module-cache-path %t/cache -load-plugin-library %t/%target-library-name(Plugin) \
+// RUN:   -serialize-dependency-scan-cache -dependency-scan-cache-path %t/scan-cache -o %t/deps.json
+
+// RUN: %FileCheck %s < %t/trace.json
+
+// RUN: %target-swift-frontend -scan-dependencies %t/test.swift -emit-loaded-module-trace -emit-loaded-module-trace-path %t/trace2.json \
+// RUN:   -enable-upcoming-feature RegionBasedIsolation -strict-memory-safety -module-name Test -dependency-only-import B \
+// RUN:   -I %t -module-cache-path %t/cache -load-plugin-library %t/%target-library-name(Plugin) \
+// RUN:   -load-dependency-scan-cache -dependency-scan-cache-path %t/scan-cache -o %t/deps2.json
+
+// RUN: diff %t/trace.json %t/trace2.json
+
+// CHECK: "swiftmodulesDetailedInfo":[
+// CHECK-DAG: {"name":"Module2","path":"{{[^"]*\\[/\\]}}Module2.swiftmodule","isImportedDirectly":true,"supportsLibraryEvolution":false,"strictMemorySafety":true}
+// CHECK-DAG: {"name":"Swift","path":"{{[^"]*\\[/\\]}}Swift.swiftmodule{{(\\[/\\][^"]+[.]swiftinterface)?}}","isImportedDirectly":true,"supportsLibraryEvolution":true,"strictMemorySafety":true}
+// CHECK-DAG: {"name":"SwiftOnoneSupport","path":"{{[^"]*\\[/\\]}}SwiftOnoneSupport.swiftmodule{{(\\[/\\][^"]+[.]swiftinterface)?}}","isImportedDirectly":true,"supportsLibraryEvolution":true,"strictMemorySafety":true}
+// CHECK-DAG: {"name":"Module","path":"{{[^"]*\\[/\\]}}Module.swiftmodule","isImportedDirectly":false,"supportsLibraryEvolution":false,"strictMemorySafety":false}
+// CHECK-DAG: {"name":"A","path":"{{[^"]*\\[/\\]}}A.swiftinterface","isImportedDirectly":true,"supportsLibraryEvolution":true,"strictMemorySafety":true}
+// CHECK: ],
+// CHECK: "swiftmacros":[
+// CHECK-DAG: {"name":"Plugin","path":"{{[^"]*\\[/\\]}}{{libPlugin.dylib|libPlugin.so|Plugin.dll}}"}
+// CHECK: ]
+// CHECK: }
+// CHECK-NOT: "B"
+
+//--- test.swift
+import Module2
+import A
+
+@freestanding(expression) macro echo<T>(_: T) -> T = #externalMacro(module: "Plugin", type: "EchoMacro")
+
+//--- A.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name A
+// swift-module-flags-ignorable: -strict-memory-safety
+public func funcA() { }
+
+//--- B.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name B
+public func funcB() { }


### PR DESCRIPTION
During explicit module build, teach dependency scanner to emit the module trace file instead of each following compile job command. This reduces the duplicated info, and allows supporting fully cached build that only loads module from CAS thus cannot produce the path to the original module file on disk.

rdar://170007480

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
