### PR TITLE
[stdlib] Fix documentation typo in Observations.swift

### DIFF
--- a/stdlib/public/Observation/Sources/Observation/Observations.swift
+++ b/stdlib/public/Observation/Sources/Observation/Observations.swift
@@ -166,7 +166,7 @@ public struct Observations<Element: Sendable, Failure: Error>: AsyncSequence, Se
   public struct Iterator: AsyncIteratorProtocol {
     // the state ivar serves two purposes:
     // 1) to store a critical region of state of the mutations
-    // 2) to idenitify the termination of _this_ sequence
+    // 2) to identify the termination of _this_ sequence
     var state: _ManagedCriticalState<State>?
     let emit: Emit
     var started = false


### PR DESCRIPTION
Hi, I fixed a documentation typo in `Observations.swift`.

- `idenitify` → `identify`

Please check out the changes. Thanks!