### PR TITLE
[stdlib] Fix typo in Task+TaskExecutor doc comment

### DIFF
--- a/stdlib/public/Concurrency/Task+TaskExecutor.swift
+++ b/stdlib/public/Concurrency/Task+TaskExecutor.swift
@@ -25,7 +25,7 @@ import Swift
 /// For an in depth discussion of this topic, see ``TaskExecutor``.
 ///
 /// ### Disabling task executor preference
-/// Passing `nil` as executor means disabling any preference preference (if it was set) and the task hierarchy
+/// Passing `nil` as executor means disabling any preference (if it was set) and the task hierarchy
 /// will execute without any executor preference until a different preference is set.
 ///
 /// ### Asynchronous function execution semantics in presence of task executor preferences


### PR DESCRIPTION
## Summary

Fix a duplicated word in a stdlib concurrency doc comment.

- Updated `stdlib/public/Concurrency/Task+TaskExecutor.swift`
- Changed `preference preference` to `preference`

## Notes

This is a documentation-only typo fix with no behavioral changes.
