### PR TITLE
LifetimeDependence closure context dependence

### DIFF
--- a/docs/ReferenceGuides/LifetimeAnnotation.md
+++ b/docs/ReferenceGuides/LifetimeAnnotation.md
@@ -238,7 +238,7 @@ Similarly, an implicit initializer of a non-Escapable struct defaults to `@_life
 
 Function types can also have lifetime dependencies. This makes it possible to pass a callback function parameter that returns a non-Escapable type.
 The annotation syntax is the same as above, and the default lifetime inference rules for non-member functions apply.
-Support for lifetime dependencies on captured values is not yet implemented, so methods and certain closures (see below) cannot be passed.
+In addition to dependencies on the parameters, a function type's outputs can have dependencies on a captured context.
 
 Examples:
 
@@ -269,11 +269,12 @@ func takeProcessor2(ne0: NE, ne1: NE,
 }
 ```
 
-Currently, there is no way to express lifetime dependencies on the captured context.
-Closures can use the captured context, but cannot return or write to captured `~Escapable` values.
+A dependence on a closure's context can be expressed with the `captures` source keyword.
+A `captures` dependence is inferred by default for all function types.
+Closures can use the captured context, but cannot write to captured `~Escapable` values.
 
 ```swift
-func takePicker(/* DEFAULT: @_lifetime(copy ne0, copy ne1) */
+func takePicker(/* DEFAULT: @_lifetime(captures, copy ne0, copy ne1) */
                 picker: (NE, NE) -> NE) {
     let x = NE()
     let y = NE()
@@ -284,7 +285,7 @@ func predicate(ne: NE) -> Bool { ... }
 // OK, only parameters are used
 takePicker { ne0, ne1 in ne0 }
 
-// Error: Captured ~Escapable variable ne2 escapes.
+// OK, the inferred lifetime for the result includes a `captures` dependence.
 let ne2 = NE()
 takePicker { ne0, ne1 in ne2 }
 
@@ -306,6 +307,7 @@ The rules for matching are as follows:
 - The lifetime dependencies for an individual target match if every dependence source present in the original function is also present for that target in the interface.
 - The matching dependencies must be of the same kind: a `copy` constraint in the original function must have a matching `copy` constraint in the interface.
 - An `immortal` dependency is treated as an empty list of sources: on a function it will match any interface, but only another `immortal` dependency can match an `immortal` dependency on an interface.
+- A `captures` dependence can be added but not removed.
 - Dependencies with an `Escapable` source or target in the original function may be ignored, as described in "Dependency type requirements" above.
 - For the lifetimes to match overall, they must match for each lifetime target in the original function.
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8610,8 +8610,8 @@ ERROR(lifetime_dependence_ctor_non_self_or_nil_return, none,
        ())
 ERROR(lifetime_dependence_cannot_be_applied_to_tuple_elt, none,
       "lifetime dependence specifiers cannot be applied to tuple elements", ())
-ERROR(lifetime_dependence_immortal_conflict_name, none,
-      "conflict between the parameter name and 'immortal' contextual keyword", ())
+ERROR(lifetime_dependence_contextual_keyword_conflict_name, none,
+      "conflict between the parameter name and '%0' contextual keyword", (StringRef))
 ERROR(lifetime_dependence_function_type, none,
       "lifetime dependencies on function types are not supported",
       ())

--- a/include/swift/AST/LifetimeDependence.h
+++ b/include/swift/AST/LifetimeDependence.h
@@ -23,6 +23,7 @@
 #include "swift/AST/Ownership.h"
 #include "swift/AST/Type.h"
 #include "swift/Basic/Debug.h"
+#include "swift/Basic/FlagSet.h"
 #include "swift/Basic/OptionSet.h"
 #include "swift/Basic/SourceLoc.h"
 
@@ -144,6 +145,17 @@ public:
     return getName().str() == "immortal";
   }
 
+  /// A specifier indicating that the target depends on variables in the
+  /// captured context.
+  static constexpr StringRef CapturesContextSpecifier = "captures";
+
+  bool isCapturesSpecifier() const {
+    if (getDescriptorKind() != LifetimeDescriptor::DescriptorKind::Named) {
+      return false;
+    }
+    return getName().str() == CapturesContextSpecifier;
+  }
+
   std::string getString() const;
 };
 
@@ -190,16 +202,40 @@ public:
   }
 };
 
+class LifetimeFlags : public FlagSet<uint8_t> {
+public:
+  enum {
+    /// Whether the lifetime dependence info entry has an immortal specifier.
+    HasImmortalSpecifier = 0,
+    /// Whether the lifetime dependence info entry originated from an
+    /// annotation.
+    IsFromAnnotation = 1,
+    /// Whether the LifetimeDependenceInfo entry includes a dependence on the
+    /// closure context.
+    Captures = 2,
+  };
+
+  explicit constexpr LifetimeFlags(uint8_t bits) : FlagSet(bits) {}
+  constexpr LifetimeFlags() {}
+
+  FLAGSET_DEFINE_FLAG_ACCESSORS_AND_BUILDER(HasImmortalSpecifier,
+                                            hasImmortalSpecifier,
+                                            setImmortalSpecifier,
+                                            withImmortalSpecifier)
+  FLAGSET_DEFINE_FLAG_ACCESSORS_AND_BUILDER(IsFromAnnotation, isFromAnnotation,
+                                            setAnnotated, withAnnotated)
+  FLAGSET_DEFINE_FLAG_ACCESSORS_AND_BUILDER(Captures, hasCaptures, setCaptures,
+                                            withCaptures)
+};
+
 class LifetimeDependenceInfo {
   IndexSubset *inheritLifetimeParamIndices;
   IndexSubset *scopeLifetimeParamIndices;
-  // The outer bool is the "isFromAnnotation" bit. The inner one is the
-  // "hasImmortalSpecifier" bit.
-  llvm::PointerIntPair<llvm::PointerIntPair<IndexSubset *, 1, bool>, 1, bool>
-      addressableParamIndicesAndImmortalAndFromAnnotation;
+  IndexSubset *addressableParamIndices;
   IndexSubset *conditionallyAddressableParamIndices;
 
   unsigned targetIndex;
+  const LifetimeFlags flags;
 
   static unsigned numParams(IndexSubset *paramIndices) {
     return paramIndices ? paramIndices->getCapacity() : 0;
@@ -213,18 +249,17 @@ public:
   /// Fully-initialized dependence info.
   LifetimeDependenceInfo(IndexSubset *inheritLifetimeParamIndices,
                          IndexSubset *scopeLifetimeParamIndices,
-                         unsigned targetIndex, bool hasImmortalSpecifier,
-                         bool isFromAnnotation,
+                         unsigned targetIndex,
                          IndexSubset *addressableParamIndices,
-                         IndexSubset *conditionallyAddressableParamIndices)
+                         IndexSubset *conditionallyAddressableParamIndices,
+                         LifetimeFlags flags)
       : inheritLifetimeParamIndices(inheritLifetimeParamIndices),
         scopeLifetimeParamIndices(scopeLifetimeParamIndices),
-        addressableParamIndicesAndImmortalAndFromAnnotation(
-            {addressableParamIndices, hasImmortalSpecifier}, isFromAnnotation),
+        addressableParamIndices(addressableParamIndices),
         conditionallyAddressableParamIndices(
             conditionallyAddressableParamIndices),
-        targetIndex(targetIndex) {
-    ASSERT(this->hasImmortalSpecifier() || hasDependencySource());
+        targetIndex(targetIndex), flags(flags) {
+    ASSERT(!empty());
     ASSERT(!inheritLifetimeParamIndices ||
            !inheritLifetimeParamIndices->isEmpty());
     ASSERT(!scopeLifetimeParamIndices || !scopeLifetimeParamIndices->isEmpty());
@@ -260,25 +295,22 @@ public:
   /// addressable parameter indices unset for now.
   LifetimeDependenceInfo(IndexSubset *inheritLifetimeParamIndices,
                          IndexSubset *scopeLifetimeParamIndices,
-                         unsigned targetIndex, bool hasImmortalSpecifier,
-                         bool isFromAnnotation)
+                         unsigned targetIndex, LifetimeFlags flags)
       : LifetimeDependenceInfo(inheritLifetimeParamIndices,
                                scopeLifetimeParamIndices, targetIndex,
-                               hasImmortalSpecifier, isFromAnnotation,
                                // set during SIL type lowering
-                               nullptr, nullptr) {}
+                               nullptr, nullptr, flags) {}
 
   operator bool() const { return !empty(); }
 
   bool empty() const {
     return !hasImmortalSpecifier() && inheritLifetimeParamIndices == nullptr &&
-           scopeLifetimeParamIndices == nullptr;
+           !hasCaptures() && scopeLifetimeParamIndices == nullptr;
   }
 
-  bool hasImmortalSpecifier() const {
-    return addressableParamIndicesAndImmortalAndFromAnnotation.getPointer()
-        .getInt();
-  }
+  LifetimeFlags getFlags() const { return flags; }
+
+  bool hasImmortalSpecifier() const { return flags.hasImmortalSpecifier(); }
 
   bool isImmortal() const {
     return hasImmortalSpecifier() && !hasDependencySource();
@@ -288,9 +320,11 @@ public:
   /// the source program (Swift or SIL). Such dependencies are likely to differ
   /// from the default (inferred) ones, so they must be included when printing a
   /// Swift function's type.
-  bool isFromAnnotation() const {
-    return addressableParamIndicesAndImmortalAndFromAnnotation.getInt();
-  }
+  bool isFromAnnotation() const { return flags.isFromAnnotation(); }
+
+  /// Whether the target depends on the closure context.
+  /// This is implicitly true for any function type.
+  bool hasCaptures() const { return flags.hasCaptures(); }
 
   unsigned getTargetIndex() const { return targetIndex; }
 
@@ -301,8 +335,7 @@ public:
     return scopeLifetimeParamIndices != nullptr;
   }
   bool hasAddressableParamIndices() const {
-    return addressableParamIndicesAndImmortalAndFromAnnotation.getPointer()
-               .getPointer() != nullptr;
+    return addressableParamIndices != nullptr;
   }
 
   unsigned getParamIndicesLength() const {
@@ -327,10 +360,7 @@ public:
   /// This indicates that any dependency on the parameter value is dependent
   /// not only on the value, but the memory location of a particular instance
   /// of the value.
-  IndexSubset *getAddressableIndices() const {
-    return addressableParamIndicesAndImmortalAndFromAnnotation.getPointer()
-        .getPointer();
-  }
+  IndexSubset *getAddressableIndices() const { return addressableParamIndices; }
   /// Return the set of parameters which may have addressable dependencies
   /// depending on the type of the parameter.
   ///
@@ -397,6 +427,7 @@ public:
 
   bool operator==(const LifetimeDependenceInfo &other) const {
     return this->hasImmortalSpecifier() == other.hasImmortalSpecifier() &&
+           this->hasCaptures() == other.hasCaptures() &&
            this->getTargetIndex() == other.getTargetIndex() &&
            this->getInheritIndices() == other.getInheritIndices() &&
            this->getAddressableIndices() == other.getAddressableIndices() &&

--- a/include/swift/Basic/FlagSet.h
+++ b/include/swift/Basic/FlagSet.h
@@ -25,10 +25,6 @@ namespace swift {
 
 /// A template designed to simplify the task of defining a wrapper type
 /// for a flags bitfield.
-///
-/// Unfortunately, this doesn't currently support functional-style
-/// building patterns, which means this can't practically be used for
-/// types that need to be used in constant expressions.
 template <typename IntType>
 class FlagSet {
   static_assert(std::is_integral<IntType>::value,
@@ -50,13 +46,13 @@ protected:
 
   /// Read a single-bit flag.
   template <unsigned Bit>
-  bool getFlag() const {
+  constexpr bool getFlag() const {
     return Bits & maskFor<Bit>();
   }
 
   /// Set a single-bit flag.
   template <unsigned Bit>
-  void setFlag(bool value) {
+  constexpr void setFlag(bool value) {
     if (value) {
       Bits |= maskFor<Bit>();
     } else {
@@ -72,7 +68,8 @@ protected:
 
   /// Assign to a multi-bit field.
   template <unsigned FirstBit, unsigned BitWidth, typename FieldType = IntType>
-  void setField(typename std::enable_if<true, FieldType>::type value) {
+  constexpr void
+  setField(typename std::enable_if<true, FieldType>::type value) {
     // Note that we suppress template argument deduction for FieldType.
     assert(IntType(value) <= lowMaskFor<BitWidth>() && "value out of range");
     Bits = (Bits & ~maskFor<FirstBit, BitWidth>())
@@ -87,6 +84,19 @@ protected:
   }                                                        \
   void SETTER(bool value) {                                \
     this->template setFlag<BIT>(value);                    \
+  }
+
+  // A convenient macro for defining a getter, setter and builder for a flag.
+  // The builder method returns a copy of the flagset with the relevant bit set
+  // to the specified value. Builder method chaining provides a clean, safe way
+  // to construct flag sets within (constant) expression contexts.
+#define FLAGSET_DEFINE_FLAG_ACCESSORS_AND_BUILDER(BIT, GETTER, SETTER,         \
+                                                  BUILDER)                     \
+  FLAGSET_DEFINE_FLAG_ACCESSORS(BIT, GETTER, SETTER)                           \
+  [[nodiscard]] constexpr auto BUILDER(bool value = true) const {              \
+    auto result = *this;                                                       \
+    result.template setFlag<BIT>(value);                                       \
+    return result;                                                             \
   }
 
   // A convenient macro for defining a getter and setter for a field.

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -199,6 +199,7 @@ struct BridgedLifetimeDependenceInfo {
   SwiftUInt targetIndex;
   bool hasImmortalSpecifier;
   bool fromAnnotation;
+  bool hasCaptures;
 
   BRIDGED_INLINE BridgedLifetimeDependenceInfo(swift::LifetimeDependenceInfo info);
 

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -180,7 +180,8 @@ BridgedLifetimeDependenceInfo::BridgedLifetimeDependenceInfo(
           info.getConditionallyAddressableIndices()),
       targetIndex(info.getTargetIndex()),
       hasImmortalSpecifier(info.hasImmortalSpecifier()),
-      fromAnnotation(info.isFromAnnotation()) {}
+      fromAnnotation(info.isFromAnnotation()), hasCaptures(info.hasCaptures()) {
+}
 
 SwiftInt BridgedLifetimeDependenceInfoArray::count() const {
   return lifetimeDependenceInfoArray.unbridged<swift::LifetimeDependenceInfo>().size();
@@ -192,7 +193,8 @@ BridgedLifetimeDependenceInfoArray::at(SwiftInt index) const {
 }
 
 bool BridgedLifetimeDependenceInfo::empty() const {
-  return !hasImmortalSpecifier && inheritLifetimeParamIndices == nullptr &&
+  return !hasImmortalSpecifier && !hasCaptures &&
+         inheritLifetimeParamIndices == nullptr &&
          scopeLifetimeParamIndices == nullptr;
 }
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -575,6 +575,13 @@ static std::string getLifetimeDependenceInfoSourceListString(
     }
     return result;
   };
+  if (info.hasCaptures()) {
+    if (!isFirstSpecifier) {
+      lifetimeDependenceString += ", ";
+    }
+    lifetimeDependenceString += LifetimeDescriptor::CapturesContextSpecifier;
+    isFirstSpecifier = false;
+  }
   if (info.hasImmortalSpecifier()) {
     if (!isFirstSpecifier) {
       lifetimeDependenceString += ", ";

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -7122,7 +7122,10 @@ public:
       ArrayRef<AnyFunctionType::Param> params = fnType->getParams();
 
       for (const auto &lifetimeDependence : info.getLifetimeDependencies()) {
-        if (lifetimeDependence.isFromAnnotation()) {
+        // In .swiftinterface files, only print lifetime dependencies that
+        // originated from explicit @lifetime annotations.
+        if (!Options.IsForSwiftInterface ||
+            lifetimeDependence.isFromAnnotation()) {
           Printer.printSwiftLifetimeDependence(lifetimeDependence, params);
         }
       }

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -193,6 +193,13 @@ std::string LifetimeDependenceInfo::getString() const {
   };
   // Unlike the AST printer, there is no need check isDefaultSuppressed() for
   // SIL printing because SIL does not assume any defaults.
+  if (hasCaptures()) {
+    if (!isFirstSpecifier) {
+      lifetimeDependenceString += ", ";
+    }
+    lifetimeDependenceString += LifetimeDescriptor::CapturesContextSpecifier;
+    isFirstSpecifier = false;
+  }
   if (hasImmortalSpecifier()) {
     if (!isFirstSpecifier) {
       lifetimeDependenceString += ", ";
@@ -217,6 +224,7 @@ std::string LifetimeDependenceInfo::getString() const {
 void LifetimeDependenceInfo::Profile(llvm::FoldingSetNodeID &ID) const {
   ID.AddBoolean(hasImmortalSpecifier());
   ID.AddBoolean(isFromAnnotation());
+  ID.AddBoolean(hasCaptures());
   ID.AddInteger(targetIndex);
   if (inheritLifetimeParamIndices) {
     ID.AddInteger((uint8_t)LifetimeDependenceKind::Inherit);
@@ -306,23 +314,22 @@ struct LifetimeDependenceBuilder {
   struct TargetDeps {
     SmallBitVector inheritIndices;
     SmallBitVector scopeIndices;
-    HasAnnotation hasAnnotationStatus;
     TargetKind targetKind;
-    bool hasImmortalSpecifier = false;
+    LifetimeFlags flags;
 
     TargetDeps(HasAnnotation hasAnnotation, TargetKind targetKind,
                unsigned capacity)
         : inheritIndices(capacity), scopeIndices(capacity),
-          hasAnnotationStatus(hasAnnotation), targetKind(targetKind) {}
+          targetKind(targetKind),
+          flags(LifetimeFlags().withAnnotated(hasAnnotation ==
+                                              HasAnnotation::Annotated)) {}
 
     bool empty() const {
-      return !(hasImmortalSpecifier || inheritIndices.any()
-               || scopeIndices.any());
+      return !(flags.hasImmortalSpecifier() || flags.hasCaptures() ||
+               inheritIndices.any() || scopeIndices.any());
     }
 
-    bool hasAnnotation() const {
-      return hasAnnotationStatus == HasAnnotation::Annotated;
-    }
+    bool hasAnnotation() const { return flags.isFromAnnotation(); }
 
     bool isInout() const {
       return targetKind == TargetKind::Inout;
@@ -331,8 +338,8 @@ struct LifetimeDependenceBuilder {
     void addIfNew(unsigned sourceIndex, LifetimeDependenceKind kind) {
       // Some inferrence rules may attempt to add an inherit dependency after a
       // scope dependency (accessor wrapper + getter method).
-      if (hasImmortalSpecifier || inheritIndices[sourceIndex]
-          || scopeIndices[sourceIndex]) {
+      if (flags.hasImmortalSpecifier() || inheritIndices[sourceIndex] ||
+          scopeIndices[sourceIndex]) {
         return;
       }
       switch (kind) {
@@ -411,7 +418,7 @@ public:
                             TargetKind::Inout, sourceIndexCap()).first;
     // An immortal specifier erases any inferred inout dependency;
     // other annotations do not.
-    if (!iter->second.hasImmortalSpecifier) {
+    if (!iter->second.flags.hasImmortalSpecifier()) {
       iter->second.addIfNew(paramIndex, LifetimeDependenceKind::Inherit);
     }
   }
@@ -420,7 +427,7 @@ public:
     auto targetDeps = getInferredTargetDeps(resultIndex);
     if (!targetDeps)
       return;
-    targetDeps->hasImmortalSpecifier = true;
+    targetDeps->flags.setImmortalSpecifier(true);
   }
 
   // Allocate LifetimeDependenceInfo in the ASTContext. Initialize it by
@@ -443,20 +450,22 @@ public:
       IndexSubset *inheritIndices = nullptr;
       if (deps.inheritIndices.any()) {
         inheritIndices = IndexSubset::get(ctx, deps.inheritIndices);
-        ASSERT(!deps.hasImmortalSpecifier || deps.isInout() &&
-               "cannot combine immortal lifetime with parameter dependency");
+        ASSERT(
+            !deps.flags.hasImmortalSpecifier() ||
+            deps.isInout() &&
+                "cannot combine immortal lifetime with parameter dependency");
       }
       IndexSubset *scopeIndices = nullptr;
       if (deps.scopeIndices.any()) {
         scopeIndices = IndexSubset::get(ctx, deps.scopeIndices);
-        ASSERT(!deps.hasImmortalSpecifier || deps.isInout() &&
-               "cannot combine immortal lifetime with parameter dependency");
+        ASSERT(
+            !deps.flags.hasImmortalSpecifier() ||
+            deps.isInout() &&
+                "cannot combine immortal lifetime with parameter dependency");
       }
       lifetimeDependencies.push_back(LifetimeDependenceInfo(
           /*inheritLifetimeParamIndices*/ inheritIndices,
-          /*scopeLifetimeParamIndices*/ scopeIndices, targetIndex,
-          /*hasImmortalSpecifier*/ deps.hasImmortalSpecifier,
-          /*isFromAnnotation*/ deps.hasAnnotation()));
+          /*scopeLifetimeParamIndices*/ scopeIndices, targetIndex, deps.flags));
     }
     if (lifetimeDependencies.empty()) {
       return std::nullopt;
@@ -755,12 +764,8 @@ public:
       inferMutatingSelf();
       inferInoutParams();
 
-      // TODO: Once we infer dependence on the closure context, enable
-      // diagnostics for missing functino type result dependencies.
-      if (isLifetimeForDecl()) {
-        diagnoseMissingResultDependencies(
+      diagnoseMissingResultDependencies(
           diag::lifetime_dependence_feature_required_return.ID);
-      }
       diagnoseMissingSelfDependencies(
         diag::lifetime_dependence_feature_required_mutating.ID);
       diagnoseMissingInoutDependencies(
@@ -785,10 +790,8 @@ public:
     // If precise diagnostics were already issued, bypass
     // diagnoseMissingDependencies to avoid redundant diagnostics.
     if (!performedDiagnostics) {
-      if (isLifetimeForDecl()) {
-        diagnoseMissingResultDependencies(
+      diagnoseMissingResultDependencies(
           diag::lifetime_dependence_cannot_infer_return.ID);
-      }
       diagnoseMissingSelfDependencies(
         diag::lifetime_dependence_cannot_infer_mutating.ID);
       diagnoseMissingInoutDependencies(
@@ -1373,22 +1376,35 @@ protected:
   }
 
   // Initialize TargetDeps based on the function's @_lifetime attributes.
-  void initializeDescriptorDeps(unsigned targetIndex,
-                                TargetDeps &deps,
+  void initializeDescriptorDeps(unsigned targetIndex, TargetDeps &deps,
                                 LifetimeDescriptor source) {
-    if (source.isImmortalSpecifier()) {
-      // Record the immortal dependency even if it is invalid to suppress other diagnostics.
-      deps.hasImmortalSpecifier = true;
-      auto immortalParam =
-          llvm::find_if(parameterInfos, [](auto const &paramInfo) {
-            return paramInfo.param.getInternalLabel().is("immortal");
+    // Find a parameter in parameterInfos with internal label 'keyword'.
+    // If one exists, diagnose a conflict with the contextual keyword, and
+    // return an iterator to it. Otherwise, return parameterInfos.end().
+    const auto findAndDiagnoseConflictingName = [&](const StringRef keyword) {
+      auto conflictParam =
+          llvm::find_if(parameterInfos, [&](auto const &paramInfo) {
+            return paramInfo.param.getInternalLabel().is(keyword);
           });
 
-      if (immortalParam != parameterInfos.end()) {
-        ctx.Diags.diagnose(immortalParam->loc,
-                           diag::lifetime_dependence_immortal_conflict_name);
-        return;
+      if (conflictParam != parameterInfos.end()) {
+        ctx.Diags.diagnose(
+            conflictParam->loc,
+            diag::lifetime_dependence_contextual_keyword_conflict_name,
+            keyword);
       }
+
+      return conflictParam;
+    };
+
+    if (source.isImmortalSpecifier()) {
+      // Record the immortal dependency even if it is invalid to suppress other
+      // diagnostics.
+      deps.flags.setImmortalSpecifier(true);
+      auto immortalParam = findAndDiagnoseConflictingName("immortal");
+      if (immortalParam != parameterInfos.end())
+        return;
+
       // @_lifetime(target: immortal, copy source) is allowed for inout targets.
       if (!deps.isInout()) {
         if (deps.inheritIndices.any() || deps.scopeIndices.any()) {
@@ -1396,6 +1412,14 @@ protected:
                              diag::lifetime_dependence_immortal_alone);
         }
       }
+      return;
+    }
+
+    if (!isLifetimeForDecl() && source.isCapturesSpecifier()) {
+      // Record the closure context dependency for function types.
+      deps.flags.setCaptures(true);
+      findAndDiagnoseConflictingName(
+          LifetimeDescriptor::CapturesContextSpecifier);
       return;
     }
 
@@ -1429,7 +1453,7 @@ protected:
                             unsigned paramIndexToSet,
                             LifetimeDependenceKind lifetimeKind) {
     // @_lifetime(target: immortal, copy source) is allowed for inout targets.
-    if (deps.hasImmortalSpecifier && !deps.isInout()) {
+    if (deps.flags.hasImmortalSpecifier() && !deps.isInout()) {
       diagnose(descriptor.getLoc(), diag::lifetime_dependence_immortal_alone);
       return;
     }
@@ -1500,6 +1524,9 @@ protected:
           // Regular functions and initializers that return a non-Escapable
           // value - single parameter default rule.
           inferNonEscapableResultOnParam();
+        } else {
+          // Function types - closure context default rule
+          inferNonEscapingResultOnClosureContext();
         }
       }
     }
@@ -1919,6 +1946,17 @@ protected:
     resultDeps->addIfNew(*candidateParamIndex, *candidateLifetimeKind);
   }
 
+  // Infer result dependence on the closure context for function types.
+  void inferNonEscapingResultOnClosureContext() {
+    assert(!isLifetimeForDecl() &&
+           "Only infer closure context dependence for function types");
+    TargetDeps *resultDeps = depBuilder.getInferredTargetDeps(resultIndex);
+    if (!resultDeps)
+      return;
+
+    resultDeps->flags.setCaptures(true);
+  }
+
   // Infer a mutating 'self' dependency when 'self' is non-Escapable and the
   // result is 'void'.
   void inferMutatingSelf() {
@@ -2073,9 +2111,9 @@ ArrayRef<LifetimeDependenceInfo> LifetimeDependenceInfo::uncurry(
     const auto targetIndex = (innerDep.getTargetIndex() == numInnerParams)
                                  ? numUncurriedParams
                                  : innerDep.getTargetIndex();
-    uncurried.push_back(LifetimeDependenceInfo(
-        inherit, scope, targetIndex, innerDep.hasImmortalSpecifier(),
-        innerDep.isFromAnnotation(), addressable, conditionallyAddressable));
+    uncurried.push_back(
+        LifetimeDependenceInfo(inherit, scope, targetIndex, addressable,
+                               conditionallyAddressable, innerDep.flags));
   }
 
   return ctx.AllocateCopy(uncurried);
@@ -2209,6 +2247,11 @@ bool LifetimeDependentInterface::canConvertTargetTo(
     return true;
   }
 
+  // A dependence on closure captures can be added, but not removed.
+  if (fromDeps.hasCaptures() && other && !other->hasCaptures()) {
+    return false;
+  }
+
   const auto isSubset = [&](IndexSubset *from, IndexSubset *to,
                             bool ignoreEscapableSources = false) {
     // The empty set is a subset of every set, and every set is a subset of
@@ -2298,7 +2341,9 @@ static std::optional<LifetimeDependenceInfo> checkSILTypeModifiers(
       return false;
     };
 
-  bool hasImmortalSpecifier= false;
+  LifetimeFlags flags;
+  flags.setAnnotated(true);
+
   for (auto source : lifetimeDependentRepr->getLifetimeEntry()->getSources())
   {
     switch (source.getDescriptorKind()) {
@@ -2327,32 +2372,39 @@ static std::optional<LifetimeDependenceInfo> checkSILTypeModifiers(
       break;
     }
     case LifetimeDescriptor::DescriptorKind::Named: {
-      assert(source.isImmortalSpecifier());
-      hasImmortalSpecifier = true;
+      if (source.isImmortalSpecifier()) {
+        flags.setImmortalSpecifier(true);
+      } else if (source.isCapturesSpecifier()) {
+        flags.setCaptures(true);
+      } else {
+        llvm_unreachable(
+            "SIL can only have ordered, immortal or captures lifetime "
+            "dependence specifier kind");
+      }
       break;
     }
     default:
-      llvm_unreachable("SIL can only have ordered or immortal lifetime "
-                       "dependence specifier kind");
+      llvm_unreachable(
+          "SIL can only have ordered, immortal or captures lifetime "
+          "dependence specifier kind");
     }
   }
 
   return LifetimeDependenceInfo(
-    inheritLifetimeParamIndices.any()
-    ? IndexSubset::get(ctx, inheritLifetimeParamIndices)
-    : nullptr,
-    scopeLifetimeParamIndices.any()
-    ? IndexSubset::get(ctx, scopeLifetimeParamIndices)
-    : nullptr,
-    targetIndex,
-    /*hasImmortalSpecifier*/ hasImmortalSpecifier,
-    /*isFromAnnotation*/ true,
-    addressableLifetimeParamIndices.any()
-    ? IndexSubset::get(ctx, addressableLifetimeParamIndices)
-    : nullptr,
-    conditionallyAddressableLifetimeParamIndices.any()
-    ? IndexSubset::get(ctx, conditionallyAddressableLifetimeParamIndices)
-    : nullptr);
+      inheritLifetimeParamIndices.any()
+          ? IndexSubset::get(ctx, inheritLifetimeParamIndices)
+          : nullptr,
+      scopeLifetimeParamIndices.any()
+          ? IndexSubset::get(ctx, scopeLifetimeParamIndices)
+          : nullptr,
+      targetIndex,
+      addressableLifetimeParamIndices.any()
+          ? IndexSubset::get(ctx, addressableLifetimeParamIndices)
+          : nullptr,
+      conditionallyAddressableLifetimeParamIndices.any()
+          ? IndexSubset::get(ctx, conditionallyAddressableLifetimeParamIndices)
+          : nullptr,
+      flags);
 }
 
 std::optional<llvm::ArrayRef<LifetimeDependenceInfo>>

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2203,9 +2203,9 @@ namespace {
         ++resultIndex;
       }
       SmallVector<LifetimeDependenceInfo, 1> lifetimeDependencies;
-      LifetimeDependenceInfo immortalLifetime(nullptr, nullptr, resultIndex,
-                                              /*isImmortal*/ true,
-                                              /*isFromAnnotation*/ true);
+      LifetimeDependenceInfo immortalLifetime(
+          nullptr, nullptr, resultIndex,
+          LifetimeFlags().withImmortalSpecifier().withAnnotated());
       lifetimeDependencies.push_back(immortalLifetime);
       Impl.SwiftContext.evaluator.cacheOutput(
           LifetimeDependenceInfoRequest{fd},
@@ -4362,8 +4362,7 @@ namespace {
         dependenciesOfRet[result->getSelfIndex()] = true;
         lifetimeDependencies.emplace_back(
             nullptr, IndexSubset::get(Impl.SwiftContext, dependenciesOfRet),
-            returnIdx,
-            /*isImmortal*/ false, /*isFromAnnotation*/ true);
+            returnIdx, LifetimeFlags().withAnnotated());
         Impl.SwiftContext.evaluator.cacheOutput(
             LifetimeDependenceInfoRequest{result},
             Impl.SwiftContext.AllocateCopy(lifetimeDependencies));
@@ -4431,9 +4430,9 @@ namespace {
       auto &ASTContext = result->getASTContext();
 
       SmallVector<LifetimeDependenceInfo, 1> lifetimeDependencies;
-      LifetimeDependenceInfo immortalLifetime(nullptr, nullptr, 0,
-                                              /*isImmortal*/ true,
-                                              /*isFromAnnotation*/ true);
+      LifetimeDependenceInfo immortalLifetime(
+          nullptr, nullptr, 0,
+          LifetimeFlags().withImmortalSpecifier().withAnnotated());
       if (hasUnsafeAPIAttr(decl) && !isEscapable(decl->getReturnType())) {
         lifetimeDependencies.push_back(immortalLifetime);
         Impl.SwiftContext.evaluator.cacheOutput(
@@ -4525,7 +4524,7 @@ namespace {
             inheritedDepVec.any()
                 ? IndexSubset::get(Impl.SwiftContext, inheritedDepVec)
                 : nullptr,
-            nullptr, idx, /*isImmortal=*/false, /*isFromAnnotation=*/true);
+            nullptr, idx, LifetimeFlags().withAnnotated());
       }
 
       if (inheritLifetimeParamIndicesForReturn.any() ||
@@ -4539,8 +4538,7 @@ namespace {
                 ? IndexSubset::get(Impl.SwiftContext,
                                    scopedLifetimeParamIndicesForReturn)
                 : nullptr,
-            returnIdx,
-            /*isImmortal*/ false, /*isFromAnnotation*/ true);
+            returnIdx, LifetimeFlags().withAnnotated());
       else if (auto *ctordecl = dyn_cast<clang::CXXConstructorDecl>(decl)) {
         // Assume default constructed view types have no dependencies.
         if (ctordecl->isDefaultConstructor() &&

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -2950,14 +2950,21 @@ static CanSILFunctionType getSILFunctionType(
     destructurer.destructure(origResultType, substFormalResultType);
   }
 
+  // range [begin, end) of inputs corresponding to lowered closure captures.
+  std::pair<unsigned, unsigned> captureInputIndices;
+
   // Lower the capture context parameters, if any.
   if (constant && constant->getAnyFunctionRef()) {
+    const unsigned numInputsBefore = inputs.size();
     // Lower in the context of the closure. Since the set of captures is a
     // private contract between the closure and its enclosing context, we
     // don't need to keep its capture types opaque.
     lowerCaptureContextParameters(TC, *constant, genericSig,
                                   TC.getCaptureTypeExpansionContext(*constant),
                                   inputs, extInfoBuilder);
+    // Determine the range of inputs that correspond to lowered captures so we
+    // can lower a 'captures' lifetime dependence.
+    captureInputIndices = {numInputsBefore, inputs.size()};
   }
   
   // Form the lowered lifetime dependency records using the parameter mapping
@@ -2966,20 +2973,37 @@ static CanSILFunctionType getSILFunctionType(
   auto lowerLifetimeDependence
     = [&](const LifetimeDependenceInfo &formalDeps,
           unsigned target) -> LifetimeDependenceInfo {
-      if (target == parameterMap.size()) {
-        // The target is the result, represented by the number of parameters.
-        // Parameters may have been added if there were closure captures, so
-        // update the result index accordingly.
-        target = inputs.size();
+    auto flags = formalDeps.getFlags();
+
+    if (target == parameterMap.size()) {
+      // The target is the result, represented by the number of parameters.
+      // Parameters may have been added if there were closure captures, so
+      // update the result index accordingly.
+      target = inputs.size();
+    }
+
+    auto lowerIndexSet =
+        [&](IndexSubset *formal,
+            bool withClosureContextDependence) -> IndexSubset * {
+      if (!formal && !withClosureContextDependence) {
+        return nullptr;
       }
 
-      auto lowerIndexSet = [&](IndexSubset *formal) -> IndexSubset * {
-        if (!formal) {
-          return nullptr;
-        }
-        
-        SmallBitVector loweredIndices;
-        loweredIndices.resize(parameterMap.size());      
+      SmallBitVector loweredIndices;
+      loweredIndices.resize(inputs.size());
+
+      if (withClosureContextDependence &&
+          captureInputIndices.first < captureInputIndices.second) {
+        // There are lowered captures, with which we can replace the closure
+        // context dependence.
+        flags.setCaptures(false);
+        // With a formal dependence on the closure context, add a lowered
+        // dependence on each capture.
+        loweredIndices.set(captureInputIndices.first,
+                           captureInputIndices.second);
+      }
+
+      if (formal) {
         for (unsigned j = 0; j < parameterMap.size(); ++j) {
           int formalIndex = parameterMap[j];
           if (formalIndex < 0) {
@@ -2987,49 +3011,51 @@ static CanSILFunctionType getSILFunctionType(
           }
           loweredIndices[j] = formal->contains(formalIndex);
         }
-        
-        if (!loweredIndices.any()) {
-          return nullptr;
-        }
-        
-        return IndexSubset::get(TC.Context, loweredIndices);
-      };
-      
-      IndexSubset *inheritIndicesSet
-        = lowerIndexSet(formalDeps.getInheritIndices());
-      IndexSubset *scopeIndicesSet
-        = lowerIndexSet(formalDeps.getScopeIndices());
-      
-      // If the original formal parameter dependencies were lowered away
-      // entirely (such as if they were of `()` type), then there is effectively
-      // no dependency, leaving behind an immortal value.
-      if (!inheritIndicesSet && !scopeIndicesSet) {
-        return LifetimeDependenceInfo(
-            nullptr, nullptr, target,
-            /*hasImmortalSpecifier*/ true,
-            /*fromAnnotation*/ formalDeps.isFromAnnotation());
       }
-      
-      SmallBitVector addressableDeps = scopeIndicesSet
-        ? scopeIndicesSet->getBitVector() & addressableParams
-        : SmallBitVector(1, false);
-      IndexSubset *addressableSet = addressableDeps.any()
-        ? IndexSubset::get(TC.Context, addressableDeps)
-        : nullptr;
-        
-      SmallBitVector condAddressableDeps = scopeIndicesSet
-        ? scopeIndicesSet->getBitVector() & conditionallyAddressableParams
-        : SmallBitVector(1, false);
-      IndexSubset *condAddressableSet = condAddressableDeps.any()
-        ? IndexSubset::get(TC.Context, condAddressableDeps)
-        : nullptr;
 
-      return LifetimeDependenceInfo(
-        inheritIndicesSet, scopeIndicesSet, target,
-        formalDeps.hasImmortalSpecifier(),
-        /*fromAnnotation*/ formalDeps.isFromAnnotation(), addressableSet,
-        condAddressableSet);
+      if (!loweredIndices.any()) {
+        return nullptr;
+      }
+
+      return IndexSubset::get(TC.Context, loweredIndices);
     };
+
+    // A formal dependence on the closure context corresponds to a scoped/borrow
+    // dependence on every capture.
+    IndexSubset *inheritIndicesSet =
+        lowerIndexSet(formalDeps.getInheritIndices(), false);
+    IndexSubset *scopeIndicesSet =
+        lowerIndexSet(formalDeps.getScopeIndices(), formalDeps.hasCaptures());
+
+    // If the original formal parameter dependencies were lowered away
+    // entirely (such as if they were of `()` type), then there is effectively
+    // no dependency, leaving behind a value that is either immortal, or
+    // depends on the function's closure context.
+    if (!inheritIndicesSet && !scopeIndicesSet) {
+      if (!flags.hasCaptures())
+        flags.setImmortalSpecifier(true);
+      return LifetimeDependenceInfo(nullptr, nullptr, target, flags);
+    }
+
+    SmallBitVector addressableDeps =
+        scopeIndicesSet ? scopeIndicesSet->getBitVector() & addressableParams
+                        : SmallBitVector(1, false);
+    IndexSubset *addressableSet =
+        addressableDeps.any() ? IndexSubset::get(TC.Context, addressableDeps)
+                              : nullptr;
+
+    SmallBitVector condAddressableDeps =
+        scopeIndicesSet
+            ? scopeIndicesSet->getBitVector() & conditionallyAddressableParams
+            : SmallBitVector(1, false);
+    IndexSubset *condAddressableSet =
+        condAddressableDeps.any()
+            ? IndexSubset::get(TC.Context, condAddressableDeps)
+            : nullptr;
+
+    return LifetimeDependenceInfo(inheritIndicesSet, scopeIndicesSet, target,
+                                  addressableSet, condAddressableSet, flags);
+  };
   // Lower parameter dependencies.
   for (unsigned i = 0; i < parameterMap.size(); ++i) {
     if (parameterMap[i] < 0) {
@@ -5318,8 +5344,7 @@ TypeConverter::getLoweredFormalTypes(SILDeclRef constant,
   if (innerExtInfo.getLifetimeDependencies().size() > 0) {
     ASSERT(extInfo.getLifetimeDependencies().size() == 0 &&
            "We only support uncurrying function types where at most one of the "
-           "inner and outer type has lifetime dependencies, because we do not "
-           "yet support closure context lifetime dependencies.");
+           "inner and outer type has lifetime dependencies.");
 
     auto uncurriedLifetimes = LifetimeDependenceInfo::uncurry(
         Context, innerExtInfo.getLifetimeDependencies(),

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -9602,16 +9602,18 @@ ModuleFile::maybeReadLifetimeDependence() {
 
   unsigned targetIndex;
   unsigned paramIndicesLength;
-  bool isImmortal;
+  bool hasImmortalSpecifier;
   bool isFromAnnotation;
+  bool hasCaptures;
   bool hasInheritLifetimeParamIndices;
   bool hasScopeLifetimeParamIndices;
   bool hasAddressableParamIndices;
   ArrayRef<uint64_t> lifetimeDependenceData;
   LifetimeDependenceLayout::readRecord(
-      scratch, targetIndex, paramIndicesLength, isImmortal, isFromAnnotation,
-      hasInheritLifetimeParamIndices, hasScopeLifetimeParamIndices,
-      hasAddressableParamIndices, lifetimeDependenceData);
+      scratch, targetIndex, paramIndicesLength, hasImmortalSpecifier,
+      isFromAnnotation, hasCaptures, hasInheritLifetimeParamIndices,
+      hasScopeLifetimeParamIndices, hasAddressableParamIndices,
+      lifetimeDependenceData);
 
   SmallBitVector inheritLifetimeParamIndices(paramIndicesLength, false);
   SmallBitVector scopeLifetimeParamIndices(paramIndicesLength, false);
@@ -9645,9 +9647,13 @@ ModuleFile::maybeReadLifetimeDependence() {
       hasScopeLifetimeParamIndices
           ? IndexSubset::get(ctx, scopeLifetimeParamIndices)
           : nullptr,
-      targetIndex, isImmortal, isFromAnnotation,
+      targetIndex,
       hasAddressableParamIndices
           ? IndexSubset::get(ctx, addressableParamIndices)
           : nullptr,
-      nullptr);
+      nullptr,
+      LifetimeFlags()
+          .withImmortalSpecifier(hasImmortalSpecifier)
+          .withAnnotated(isFromAnnotation)
+          .withCaptures(hasCaptures));
 }

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 994; // SIL code generation model
+const uint16_t SWIFTMODULE_VERSION_MINOR = 995; // LifetimeDependenceInfo hasCaptures flag
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -2394,8 +2394,9 @@ namespace decls_block {
       BCRecordLayout<LIFETIME_DEPENDENCE,
                      BCVBR<4>,           // targetIndex
                      BCVBR<4>,           // paramIndicesLength
-                     BCFixed<1>,         // isImmortal
+                     BCFixed<1>,         // hasImmortalSpecifier
                      BCFixed<1>,         // isFromAnnotation
+                     BCFixed<1>,         // hasCaptures
                      BCFixed<1>,         // hasInheritLifetimeParamIndices
                      BCFixed<1>,         // hasScopeLifetimeParamIndices
                      BCFixed<1>,         // hasAddressableParamIndices

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2852,7 +2852,8 @@ void Serializer::writeLifetimeDependencies(
     LifetimeDependenceLayout::emitRecord(
         Out, ScratchRecord, abbrCode, info.getTargetIndex(),
         info.getParamIndicesLength(), info.hasImmortalSpecifier(),
-        info.isFromAnnotation(), info.hasInheritLifetimeParamIndices(),
+        info.isFromAnnotation(), info.hasCaptures(),
+        info.hasInheritLifetimeParamIndices(),
         info.hasScopeLifetimeParamIndices(), info.hasAddressableParamIndices(),
         paramIndices);
     paramIndices.clear();

--- a/test/ModuleInterface/Inputs/lifetime_underscored_dependence.swift
+++ b/test/ModuleInterface/Inputs/lifetime_underscored_dependence.swift
@@ -101,6 +101,23 @@ public func takeCopier(f: @_lifetime(io: copy io) @_lifetime(copy inview) (_ inv
 @inlinable
 public func takeCopierUnannotated(f: (consuming AnotherView) -> AnotherView) {}
 
+// Function type lifetime dependencies are printed as they appeared in Swift.
+// Internal labels are preserved when a function type has explicit lifetime
+// dependence information, since these may be used to refer to the sources and
+// targets of lifetimes.
+
+public typealias LabelledNE2NE = @_lifetime(copy ne) (_ ne: AnotherView) -> AnotherView
+public typealias InferredNE2NE = (AnotherView) -> AnotherView
+public typealias InferredLabelledNE2NE = (_ ne: AnotherView) -> AnotherView
+
+public typealias NamedLifetimeType = @_lifetime(copy ne) (_ ne: AnotherView, _ ne2: AnotherView) -> AnotherView
+public typealias InferredLifetimeType = (_ ne: AnotherView, AnotherView) -> AnotherView
+public typealias ImmortalLifetimeType = @_lifetime(immortal) (_ ne: AnotherView, _ ne2: AnotherView) -> AnotherView
+public typealias CapturesLifetimeType = @_lifetime(captures) (_ ne: AnotherView, _ ne2: AnotherView) -> AnotherView
+
+public typealias MixedLifetimeType = @_lifetime(copy ne0) (_ ne0: AnotherView, _ neio: inout AnotherView) -> AnotherView
+public typealias NestedLifetimeType = @_lifetime(neo: copy ne0) (_ nei: inout AnotherView, _ ne0: AnotherView, _ neo: inout AnotherView) -> (_ ne1: AnotherView) -> AnotherView
+
 public typealias ExplicitNestedType = @_lifetime(copy ne0) @_lifetime(ne1: copy ne0) ((AnotherView) -> AnotherView, _ ne0: consuming AnotherView, _ ne1: inout AnotherView) -> AnotherView
 
 @inlinable

--- a/test/ModuleInterface/lifetime_underscored_dependence_test.swift
+++ b/test/ModuleInterface/lifetime_underscored_dependence_test.swift
@@ -143,6 +143,36 @@ import lifetime_underscored_dependence
 // CHECK: @inlinable public func takeCopierUnannotated(f: (consuming lifetime_underscored_dependence::AnotherView) -> lifetime_underscored_dependence::AnotherView) {}
 
 // CHECK: #if compiler(>=5.3) && $ClosureLifetimes
+// CHECK-NEXT: typealias LabelledNE2NE = @_lifetime(copy ne) (_ ne: lifetime_underscored_dependence::AnotherView) -> lifetime_underscored_dependence::AnotherView
+// CHECK-NEXT: #endif
+
+// CHECK-NEXT: typealias InferredNE2NE = (lifetime_underscored_dependence::AnotherView) -> lifetime_underscored_dependence::AnotherView
+
+// CHECK-NEXT: typealias InferredLabelledNE2NE = (_ ne: lifetime_underscored_dependence::AnotherView) -> lifetime_underscored_dependence::AnotherView
+
+// CHECK: #if compiler(>=5.3) && $ClosureLifetimes
+// CHECK-NEXT: typealias NamedLifetimeType = @_lifetime(copy ne) (_ ne: lifetime_underscored_dependence::AnotherView, _ ne2: lifetime_underscored_dependence::AnotherView) -> lifetime_underscored_dependence::AnotherView
+// CHECK-NEXT: #endif
+
+// CHECK-NEXT: typealias InferredLifetimeType = (_ ne: lifetime_underscored_dependence::AnotherView, lifetime_underscored_dependence::AnotherView) -> lifetime_underscored_dependence::AnotherView
+
+// CHECK: #if compiler(>=5.3) && $ClosureLifetimes
+// CHECK-NEXT: typealias ImmortalLifetimeType = @_lifetime(immortal) (_ ne: lifetime_underscored_dependence::AnotherView, _ ne2: lifetime_underscored_dependence::AnotherView) -> lifetime_underscored_dependence::AnotherView
+// CHECK-NEXT: #endif
+
+// CHECK: #if compiler(>=5.3) && $ClosureLifetimes
+// CHECK-NEXT: typealias CapturesLifetimeType = @_lifetime(captures) (_ ne: lifetime_underscored_dependence::AnotherView, _ ne2: lifetime_underscored_dependence::AnotherView) -> lifetime_underscored_dependence::AnotherView
+// CHECK-NEXT: #endif
+
+// CHECK: #if compiler(>=5.3) && $ClosureLifetimes
+// CHECK-NEXT: typealias MixedLifetimeType = @_lifetime(copy ne0) (_ ne0: lifetime_underscored_dependence::AnotherView, _ neio: inout lifetime_underscored_dependence::AnotherView) -> lifetime_underscored_dependence::AnotherView
+// CHECK-NEXT: #endif
+
+// CHECK: #if compiler(>=5.3) && $ClosureLifetimes
+// CHECK-NEXT: typealias NestedLifetimeType = @_lifetime(neo: copy ne0, copy neo) (_ nei: inout lifetime_underscored_dependence::AnotherView, _ ne0: lifetime_underscored_dependence::AnotherView, _ neo: inout lifetime_underscored_dependence::AnotherView) -> (_ ne1: lifetime_underscored_dependence::AnotherView) -> lifetime_underscored_dependence::AnotherView
+// CHECK-NEXT: #endif
+
+// CHECK: #if compiler(>=5.3) && $ClosureLifetimes
 // CHECK-NEXT: public typealias ExplicitNestedType = @_lifetime(copy ne0) @_lifetime(ne1: copy ne0, copy ne1) ((lifetime_underscored_dependence::AnotherView) -> lifetime_underscored_dependence::AnotherView, _ ne0: consuming lifetime_underscored_dependence::AnotherView, _ ne1: inout lifetime_underscored_dependence::AnotherView) -> lifetime_underscored_dependence::AnotherView
 // CHECK-NEXT: #endif
 

--- a/test/SIL/Parser/lifetime_dependence.sil
+++ b/test/SIL/Parser/lifetime_dependence.sil
@@ -79,3 +79,9 @@ bb0(%0 : @noImplicitCopy @_eagerMove $BufferView):
   return %12 : $BufferView                        
 } 
 
+// CHECK-LABEL: sil hidden @takeCapturesClosure : $@convention(thin) (@guaranteed @noescape @callee_guaranteed () -> @lifetime(captures) @owned BufferView) -> ()
+sil hidden @takeCapturesClosure : $@convention(thin) (@guaranteed @noescape @callee_guaranteed () -> @lifetime(captures) @owned BufferView) -> () {
+bb0(%0 : $@noescape @callee_guaranteed () -> @lifetime(captures) @owned BufferView):
+  %1 = tuple ()
+  return %1 : $()
+}

--- a/test/SIL/closure_lifetime_dependence.swift
+++ b/test/SIL/closure_lifetime_dependence.swift
@@ -62,3 +62,42 @@ func callTakeOnePicker() {
 
 // CHECK-LABEL: sil private @$s27closure_lifetime_dependence17callTakeOnePickeryyFAA2NEVAD_ADtXEfU0_ : $@convention(thin) (@guaranteed NE, @guaranteed NE) -> @lifetime(copy 1) @owned NE {
 // CHECK-LABEL: } // end sil function '$s27closure_lifetime_dependence17callTakeOnePickeryyFAA2NEVAD_ADtXEfU0_'
+
+// Closure Context Dependencies
+
+// If there is another matching parameter to depend on, do not infer dependence on the context.
+// CHECK-LABEL: sil hidden @$s27closure_lifetime_dependence22inferredLifetimePicker6pickeryAA2NEVAE_AEtXE_tF : $@convention(thin) (@guaranteed @noescape @callee_guaranteed (@guaranteed NE, @guaranteed NE) -> @lifetime(captures, copy 0, copy 1) @owned NE) -> () {
+// CHECK-LABEL: } // end sil function '$s27closure_lifetime_dependence22inferredLifetimePicker6pickeryAA2NEVAE_AEtXE_tF'
+func inferredLifetimePicker(picker: (NE, NE) -> NE) {
+}
+
+// CHECK-LABEL: sil hidden @$s27closure_lifetime_dependence22contextDependentPicker6pickeryAA2NEVyXE_tF : $@convention(thin) (@guaranteed @noescape @callee_guaranteed () -> @lifetime(captures) @owned NE) -> () {
+// CHECK-LABEL: } // end sil function '$s27closure_lifetime_dependence22contextDependentPicker6pickeryAA2NEVyXE_tF'
+func contextDependentPicker(picker: () -> NE) {
+  _ = picker()
+}
+
+func callContextDependentPicker() {
+  let ne = NE()
+  contextDependentPicker { ne }
+}
+
+// CHECK-LABEL: sil hidden @$s27closure_lifetime_dependence28contextAndArgDependentPicker6pickeryAA2NEVAEXE_tF : $@convention(thin) (@guaranteed @noescape @callee_guaranteed (@guaranteed NE) -> @lifetime(captures, copy 0) @owned NE) -> () {
+// CHECK-LABEL: } // end sil function '$s27closure_lifetime_dependence28contextAndArgDependentPicker6pickeryAA2NEVAEXE_tF'
+func contextAndArgDependentPicker(picker: @_lifetime(captures, copy ne) (_ ne: NE) -> NE) {
+  let x = NE()
+  _ = picker(x)
+}
+
+func callContextAndArgDependentPicker() {
+  let ne = NE()
+  contextAndArgDependentPicker { neArg in ne } // OK
+  contextAndArgDependentPicker { neArg in neArg } // OK
+}
+
+// CHECK-LABEL: sil private @$s27closure_lifetime_dependence32callContextAndArgDependentPickeryyFAA2NEVADXEfU_ : $@convention(thin) (@guaranteed NE, @guaranteed NE) -> @lifetime(copy 0, borrow 1) @owned NE {
+// CHECK-LABEL: } // end sil function '$s27closure_lifetime_dependence32callContextAndArgDependentPickeryyFAA2NEVADXEfU_'
+
+// The captures dependence here is technically unnecessary, but causes no harm, since the closure is only called in one place.
+// CHECK-LABEL: sil private @$s27closure_lifetime_dependence32callContextAndArgDependentPickeryyFAA2NEVADXEfU0_ : $@convention(thin) (@guaranteed NE) -> @lifetime(captures, copy 0) @owned NE {
+// CHECK-LABEL: } // end sil function '$s27closure_lifetime_dependence32callContextAndArgDependentPickeryyFAA2NEVADXEfU0_'

--- a/test/SIL/explicit_lifetime_dependence_specifiers.swift
+++ b/test/SIL/explicit_lifetime_dependence_specifiers.swift
@@ -10,33 +10,6 @@ import Builtin
 
 struct NE: ~Escapable {}
 
-// Function type lifetime dependencies are printed as they appeared in Swift.
-// Internal labels are preserved when a function type has explicit lifetime
-// dependence information, since these may be used to refer to the sources and
-// targets of lifetimes.
-
-// CHECK-LABEL: typealias LabelledNE2NE = @_lifetime(copy ne) (_ ne: NE) -> NE
-typealias LabelledNE2NE = @_lifetime(copy ne) (_ ne: NE) -> NE
-// CHECK-LABEL: typealias InferredNE2NE = (NE) -> NE
-typealias InferredNE2NE = (NE) -> NE
-// CHECK-LABEL: typealias InferredLabelledNE2NE = (NE) -> NE
-typealias InferredLabelledNE2NE = (_ ne: NE) -> NE
-
-// CHECK-LABEL: typealias NamedLifetimeType = @_lifetime(copy ne) (_ ne: NE, _ ne2: NE) -> NE
-typealias NamedLifetimeType = @_lifetime(copy ne) (_ ne: NE, _ ne2: NE) -> NE
-// CHECK-LABEL: typealias InferredLifetimeType = (NE, NE) -> NE
-typealias InferredLifetimeType = (_ ne: NE, NE) -> NE
-// CHECK-LABEL: typealias ImmortalLifetimeType = @_lifetime(immortal) (_ ne: NE, _ ne2: NE) -> NE
-typealias ImmortalLifetimeType = @_lifetime(immortal) (_ ne: NE, _ ne2: NE) -> NE
-
-// CHECK-LABEL: typealias NoLifetimeType = (Int) -> Int
-typealias NoLifetimeType = (_ x: Int) -> Int
-
-// CHECK: typealias MixedLifetimeType = @_lifetime(copy ne0) (_ ne0: NE, _ neio: inout NE) -> NE
-typealias MixedLifetimeType = @_lifetime(copy ne0) (_ ne0: NE, _ neio: inout NE) -> NE
-// CHECK: typealias NestedLifetimeType = @_lifetime(neo: copy ne0, copy neo) (_ nei: inout NE, _ ne0: NE, _ neo: inout NE) -> (NE) -> NE
-typealias NestedLifetimeType = @_lifetime(neo: copy ne0) (_ nei: inout NE, _ ne0: NE, _ neo: inout NE) -> (_ ne1: NE) -> NE
-
 // CHECK-LABEL: typealias NestedType = @_lifetime(copy ne2) @_lifetime(ne3: copy ne2, copy ne3) (@_lifetime(copy ne0) @_lifetime(ne1: copy ne1) (_ ne0: NE, _ ne1: inout NE) -> NE, _ ne2: consuming NE, _ ne3: inout NE) -> NE
 typealias NestedType =
   @_lifetime(copy ne2) @_lifetime(ne3: copy ne2)

--- a/test/SIL/implicit_lifetime_dependence.swift
+++ b/test/SIL/implicit_lifetime_dependence.swift
@@ -7,12 +7,9 @@
 
 struct NE: ~Escapable {}
 
-// CHECK-LABEL: typealias ImplicitNestedType = ((NE, inout NE) -> NE, consuming NE, inout NE) -> NE
 typealias ImplicitNestedType = ((NE, inout NE) -> NE, consuming NE, inout NE) -> NE
 
-// CHECK-LABEL: func takeImplicitNestedType(f: ((NE, inout NE) -> NE, consuming NE, inout NE) -> NE)
-
-// CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence22takeImplicitNestedType1fyAA2NEVA2E_AEztXE_AEnAEztXE_tF : $@convention(thin) (@guaranteed @noescape @callee_guaranteed (@guaranteed @noescape @callee_guaranteed (@guaranteed NE, @lifetime(copy 1) @inout NE) -> @lifetime(copy 0) @owned NE, @owned NE, @lifetime(copy 2) @inout NE) -> @lifetime(copy 1) @owned NE) -> () {
+// CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence22takeImplicitNestedType1fyAA2NEVA2E_AEztXE_AEnAEztXE_tF : $@convention(thin) (@guaranteed @noescape @callee_guaranteed (@guaranteed @noescape @callee_guaranteed (@guaranteed NE, @lifetime(copy 1) @inout NE) -> @lifetime(captures, copy 0) @owned NE, @owned NE, @lifetime(copy 2) @inout NE) -> @lifetime(captures, copy 1) @owned NE) -> () {
 func takeImplicitNestedType(f: ImplicitNestedType) {}
 
 struct BufferView : ~Escapable {

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_closure.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_closure.swift
@@ -68,7 +68,19 @@ func takeOnePicker(picker: @_lifetime(copy ne0) (_ ne0: NE, NE) -> NE) {
     _ = picker(x, y)
 }
 
+func takeCapturePicker(picker: /* DEFAULT: @_lifetime(captures, copy ne0, copy ne1) */ (_ ne0: NE, _ ne1: NE) -> NE) {
+    let x = NE()
+    let y = NE()
+    _ = picker(x, y)
+}
+
 func takeMutator(mutator: @_lifetime(ne: copy ne) (_ ne: inout NE) -> ()) {
+  var ne = NE()
+  mutator(&ne)
+  let _ = ne
+}
+
+func takeCaptureMutator(mutator: @_lifetime(ne: captures, copy ne) (_ ne: inout NE) -> ()) {
   var ne = NE()
   mutator(&ne)
   let _ = ne
@@ -142,6 +154,24 @@ func testClosureLifetimes(cond: Bool) {
     } else {
       return ne1 // expected-note{{this use causes the lifetime-dependent value to escape}}
     }
+  }
+
+  // Callbacks with captures dependencies.
+
+  takeCapturePicker { ne0, ne1 in ne0 } // OK
+  takeCapturePicker { ne0, ne1 in ne1 } // OK
+  let ne9 = NE()
+  takeCapturePicker { ne0, ne1 in ne9 } // OK
+
+
+  takeCaptureMutator { ne0 in // OK
+    let neLocal = ne0
+    ne0 = neLocal
+  }
+
+  let ne10 = NE()
+  takeCaptureMutator { ne0 in // OK
+    ne0 = ne10
   }
 }
 

--- a/test/SILOptimizer/lifetime_dependence/verify_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence/verify_diagnostics.swift
@@ -452,7 +452,8 @@ func testMutableCapture(arg: consuming NCE, action: @escaping (inout NCE) -> ())
 
 // Implicit dependence on a nonescaping closure context.
 //
-// TODO: remove the _overrideLifetime when context dependencies are tracked.
+// TODO: remove the _overrideLifetime when context dependencies are tracked and
+// non-escaping function types can be used as (copy) dependence sources (rdar://172511809).
 @_lifetime(borrow value)
 func testBasicClosureDependency(value: AnyObject, body: () -> NE) -> NE {
   return _overrideLifetime(body(), borrowing: value)

--- a/test/Sema/lifetime_dependence_functype.swift
+++ b/test/Sema/lifetime_dependence_functype.swift
@@ -50,7 +50,7 @@ func applyBorrow(nc: borrowing NC, borrow: (borrowing NC) -> NE) -> NE {
 }
 
 func testBorrow(nc: consuming NC) {
-  let borrowed = applyBorrow(nc: nc, borrow: borrow) // expected-error{{argument type 'NE' does not conform to expected type 'Escapable'}}
+  let borrowed = applyBorrow(nc: nc, borrow: borrow) // expected-error{{cannot convert value of type '@_lifetime(borrow 0) (borrowing NC) -> NE' to expected argument type '@_lifetime(captures) (borrowing NC) -> NE'}}
   _ = consume nc
   _ = transfer(borrowed)
 }
@@ -330,15 +330,18 @@ func inout01(ne0: inout NE, ne1: NE) {}
 func takeInout0(f: @_lifetime(ne0: copy ne0) (_ ne0: inout NE, _ ne1: NE) -> ()) {}
 func takeInout01(f: @_lifetime(ne0: copy ne0, copy ne1) (_ ne0: inout NE, _ ne1: NE) -> ()) {}
 
+func takeCopying0Captures(
+  f: @_lifetime(copy ne0, captures)
+    (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE) {}
 
 func callLifetimeFunctions() {
   takeCopying0(f: copying0) // OK
-  takeCopying0(f: copying1) // expected-error{{cannot convert value of type '@_lifetime(copy 1) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(copy ne0) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
-  takeCopying0(f: copying01) // expected-error{{cannot convert value of type '@_lifetime(copy 0, copy 1) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(copy ne0) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeCopying0(f: copying1) // expected-error{{cannot convert value of type '@_lifetime(copy 1) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(copy ne0) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeCopying0(f: copying01) // expected-error{{cannot convert value of type '@_lifetime(copy 0, copy 1) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(copy ne0) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
 
-  takeCopying1(f: copying0) // expected-error{{cannot convert value of type '@_lifetime(copy 0) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(copy ne1) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeCopying1(f: copying0) // expected-error{{cannot convert value of type '@_lifetime(copy 0) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(copy ne1) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
   takeCopying1(f: copying1) // OK
-  takeCopying1(f: copying01) // expected-error{{cannot convert value of type '@_lifetime(copy 0, copy 1) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(copy ne1) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeCopying1(f: copying01) // expected-error{{cannot convert value of type '@_lifetime(copy 0, copy 1) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(copy ne1) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
 
   takeCopying01(f: copying0) // OK
   takeCopying01(f: copying1) // OK
@@ -346,33 +349,33 @@ func callLifetimeFunctions() {
 
 
   takeBorrowing2(f: borrowing2) // OK
-  takeBorrowing2(f: borrowing3) // expected-error{{cannot convert value of type '@_lifetime(borrow 3) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(borrow ne2) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
-  takeBorrowing2(f: borrowing23) // expected-error{{cannot convert value of type '@_lifetime(borrow 2, borrow 3) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(borrow ne2) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeBorrowing2(f: borrowing3) // expected-error{{cannot convert value of type '@_lifetime(borrow 3) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(borrow ne2) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeBorrowing2(f: borrowing23) // expected-error{{cannot convert value of type '@_lifetime(borrow 2, borrow 3) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(borrow ne2) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
 
-  takeBorrowing3(f: borrowing2) // expected-error{{cannot convert value of type '@_lifetime(borrow 2) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(borrow ne3) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeBorrowing3(f: borrowing2) // expected-error{{cannot convert value of type '@_lifetime(borrow 2) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(borrow ne3) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
   takeBorrowing3(f: borrowing3) // OK
-  takeBorrowing3(f: borrowing23) // expected-error{{cannot convert value of type '@_lifetime(borrow 2, borrow 3) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(borrow ne3) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeBorrowing3(f: borrowing23) // expected-error{{cannot convert value of type '@_lifetime(borrow 2, borrow 3) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(borrow ne3) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
 
   takeBorrowing23(f: borrowing2) // OK
   takeBorrowing23(f: borrowing3) // OK
   takeBorrowing23(f: borrowing23) // OK
 
 
-  takeCopying0(f: copying0borrowing2) // expected-error{{cannot convert value of type '@_lifetime(copy 0, borrow 2) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(copy ne0) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
-  takeBorrowing2(f: copying0borrowing2) // expected-error{{cannot convert value of type '@_lifetime(copy 0, borrow 2) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(borrow ne2) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeCopying0(f: copying0borrowing2) // expected-error{{cannot convert value of type '@_lifetime(copy 0, borrow 2) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(copy ne0) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeBorrowing2(f: copying0borrowing2) // expected-error{{cannot convert value of type '@_lifetime(copy 0, borrow 2) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(borrow ne2) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
 
   takeCopying0Borrowing2(f: copying0) // OK
   takeCopying0Borrowing2(f: borrowing2) // OK
   takeCopying0Borrowing2(f: copying0borrowing2) // OK
-  takeCopying0Borrowing2(f: copying0borrowing2borrowing3) // expected-error{{cannot convert value of type '@_lifetime(copy 0, borrow 2, borrow 3) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(copy ne0, borrow ne2) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
-  takeCopying0Borrowing2(f: copying0copying1borrowing2) // expected-error{{cannot convert value of type '@_lifetime(copy 0, copy 1, borrow 2) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(copy ne0, borrow ne2) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
-  takeCopying0Borrowing2(f: copying0copying1borrowing2borrowing3) // expected-error{{cannot convert value of type '@_lifetime(copy 0, copy 1, borrow 2, borrow 3) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(copy ne0, borrow ne2) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeCopying0Borrowing2(f: copying0borrowing2borrowing3) // expected-error{{cannot convert value of type '@_lifetime(copy 0, borrow 2, borrow 3) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(copy ne0, borrow ne2) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeCopying0Borrowing2(f: copying0copying1borrowing2) // expected-error{{cannot convert value of type '@_lifetime(copy 0, copy 1, borrow 2) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(copy ne0, borrow ne2) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeCopying0Borrowing2(f: copying0copying1borrowing2borrowing3) // expected-error{{cannot convert value of type '@_lifetime(copy 0, copy 1, borrow 2, borrow 3) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(copy ne0, borrow ne2) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
 
 
   takeMutborrowing4(f: mutborrowing4) // OK
-  takeMutborrowing4(f: copying0) // expected-error{{cannot convert value of type '@_lifetime(copy 0) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(&ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
-  takeCopying0(f: mutborrowing4) // expected-error{{cannot convert value of type '@_lifetime(&4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(copy ne0) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
-  takeBorrowing2(f: mutborrowing4) // expected-error{{cannot convert value of type '@_lifetime(&4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(borrow ne2) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeMutborrowing4(f: copying0) // expected-error{{cannot convert value of type '@_lifetime(copy 0) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(&ne4) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeCopying0(f: mutborrowing4) // expected-error{{cannot convert value of type '@_lifetime(&4) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(copy ne0) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeBorrowing2(f: mutborrowing4) // expected-error{{cannot convert value of type '@_lifetime(&4) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(borrow ne2) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
 
 
   takeCopying0(f: immortalFn) // OK
@@ -384,18 +387,29 @@ func callLifetimeFunctions() {
   takeCopying0Borrowing2(f: immortalFn) // OK
   takeMutborrowing4(f: immortalFn) // OK
 
-  takeImmortal(f: copying0) // expected-error{{cannot convert value of type '@_lifetime(copy 0) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(immortal) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
-  takeImmortal(f: copying1) // expected-error{{cannot convert value of type '@_lifetime(copy 1) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(immortal) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
-  takeImmortal(f: copying01) // expected-error{{cannot convert value of type '@_lifetime(copy 0, copy 1) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(immortal) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
-  takeImmortal(f: borrowing2) // expected-error{{cannot convert value of type '@_lifetime(borrow 2) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(immortal) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
-  takeImmortal(f: borrowing3) // expected-error{{cannot convert value of type '@_lifetime(borrow 3) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(immortal) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
-  takeImmortal(f: borrowing23) // expected-error{{cannot convert value of type '@_lifetime(borrow 2, borrow 3) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(immortal) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
-  takeImmortal(f: copying0borrowing2) // expected-error{{cannot convert value of type '@_lifetime(copy 0, borrow 2) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(immortal) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
-  takeImmortal(f: mutborrowing4) // expected-error{{cannot convert value of type '@_lifetime(&4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(immortal) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeImmortal(f: copying0) // expected-error{{cannot convert value of type '@_lifetime(copy 0) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(immortal) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeImmortal(f: copying1) // expected-error{{cannot convert value of type '@_lifetime(copy 1) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(immortal) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeImmortal(f: copying01) // expected-error{{cannot convert value of type '@_lifetime(copy 0, copy 1) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(immortal) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeImmortal(f: borrowing2) // expected-error{{cannot convert value of type '@_lifetime(borrow 2) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(immortal) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeImmortal(f: borrowing3) // expected-error{{cannot convert value of type '@_lifetime(borrow 3) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(immortal) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeImmortal(f: borrowing23) // expected-error{{cannot convert value of type '@_lifetime(borrow 2, borrow 3) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(immortal) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeImmortal(f: copying0borrowing2) // expected-error{{cannot convert value of type '@_lifetime(copy 0, borrow 2) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(immortal) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeImmortal(f: mutborrowing4) // expected-error{{cannot convert value of type '@_lifetime(&4) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(immortal) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
   takeImmortal(f: immortalFn) // OK
 
   takeInout0(f: inout0) // OK
   takeInout0(f: inout01) // expected-error{{cannot convert value of type '@_lifetime(0: copy 0, copy 1) (inout NE, NE) -> ()' to expected argument type '@_lifetime(ne0: copy ne0) (_ ne0: inout NE, _ ne1: NE) -> ()'}}
   takeInout01(f: inout01) // OK
   takeInout01(f: inout0) // OK
+
+  let ne5 = NE()
+  let copying0Captures: @_lifetime(copy ne0, captures)
+    (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE = {
+      ne0, ne1, ne2, ne3, ne4 in
+      ne5
+    }
+
+  takeCopying0(f: copying0Captures) // expected-error{{cannot convert value of type '@_lifetime(captures, copy ne0) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE' to expected argument type '@_lifetime(copy ne0) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeCopying0Captures(f: copying0) // OK
+  takeCopying0Captures(f: copying0Captures) // OK
 }

--- a/test/Serialization/Inputs/def_explicit_lifetime_dependence.swift
+++ b/test/Serialization/Inputs/def_explicit_lifetime_dependence.swift
@@ -114,3 +114,5 @@ public struct GCM {
     return message
   }
 }
+public func takeViewCallback(f: @_lifetime(captures) () -> BufferView) {
+}

--- a/test/Serialization/Inputs/def_implicit_lifetime_dependence.swift
+++ b/test/Serialization/Inputs/def_implicit_lifetime_dependence.swift
@@ -85,3 +85,5 @@ public struct GCM {
     return message
   }
 }
+public func takeViewCallback(f: () -> BufferView) {
+}

--- a/test/Serialization/explicit_lifetime_dependence.swift
+++ b/test/Serialization/explicit_lifetime_dependence.swift
@@ -59,6 +59,11 @@ func testStaticMethod(
   let gcmX = gcm.x
   message = propagatedMessage
 }
+
+func testViewCallback(view: BufferView) {
+  takeViewCallback { view }
+}
+
 // CHECK: sil @$s32def_explicit_lifetime_dependence6deriveyAA10BufferViewVADF : $@convention(thin) (@guaranteed BufferView) -> @lifetime(borrow 0) @owned BufferView
 // CHECK: sil @$s32def_explicit_lifetime_dependence16consumeAndCreateyAA10BufferViewVADnF : $@convention(thin) (@owned BufferView) -> @lifetime(copy 0) @owned BufferView
 // CHECK: sil @$s32def_explicit_lifetime_dependence15borrowAndCreateyAA10BufferViewVADF : $@convention(thin) (@guaranteed BufferView) -> @lifetime(borrow 0) @owned BufferView
@@ -67,3 +72,4 @@ func testStaticMethod(
 // CHECK-LABEL: sil @$s32def_explicit_lifetime_dependence3GCMV4open7inPlace3tagys14MutableRawSpanVz_s0kL0VtFZ : $@convention(method) (@lifetime(copy 0) @inout MutableRawSpan, @guaranteed RawSpan, @thin GCM.Type) -> ()
 // CHECK-LABEL: sil @$s32def_explicit_lifetime_dependence3GCMV9propagate7messages14MutableRawSpanVAGn_tFZ : $@convention(method) (@owned MutableRawSpan, @thin GCM.Type) -> @lifetime(copy 0) @owned MutableRawSpan
 // CHECK-LABEL: sil @$s32def_explicit_lifetime_dependence3GCMV1xs7RawSpanVvg : $@convention(method) (GCM) -> @lifetime(borrow 0) @owned RawSpan
+// CHECK: sil @$s32def_explicit_lifetime_dependence16takeViewCallback1fyAA06BufferF0VyXE_tF : $@convention(thin) (@guaranteed @noescape @callee_guaranteed () -> @lifetime(captures) @owned BufferView)

--- a/test/Serialization/implicit_lifetime_dependence.swift
+++ b/test/Serialization/implicit_lifetime_dependence.swift
@@ -71,6 +71,10 @@ func testStaticMethod(
   message = propagatedMessage
 }
 
+func testViewCallback(view: BufferView) {
+  takeViewCallback { view }
+}
+
 // CHECK-LABEL: sil @$s32def_implicit_lifetime_dependence10BufferViewVyACSW_SitcfC : $@convention(method) (UnsafeRawBufferPointer, Int, @thin BufferView.Type) -> @lifetime(borrow 0) @owned BufferView
 // CHECK-LABEL: sil @$s32def_implicit_lifetime_dependence6deriveyAA10BufferViewVADF : $@convention(thin) (@guaranteed BufferView) -> @lifetime(copy 0) @owned BufferView
 // CHECK-LABEL: sil @$s32def_implicit_lifetime_dependence16consumeAndCreateyAA10BufferViewVADnF : $@convention(thin) (@owned BufferView) -> @lifetime(copy 0) @owned BufferView
@@ -79,3 +83,4 @@ func testStaticMethod(
 // CHECK-LABEL: sil @$s32def_implicit_lifetime_dependence7WrapperV4viewAA10BufferViewVvr : $@yield_once @convention(method) (@guaranteed Wrapper) -> @lifetime(copy 0) @yields @guaranteed BufferView
 // CHECK-LABEL: sil @$s32def_implicit_lifetime_dependence3GCMV4open7inPlace3tagys14MutableRawSpanVz_s0kL0VtFZ : $@convention(method) (@lifetime(copy 0) @inout MutableRawSpan, @guaranteed RawSpan, @thin GCM.Type) -> ()
 // CHECK-LABEL: sil @$s32def_implicit_lifetime_dependence3GCMV9propagate7messages14MutableRawSpanVAGn_tFZ : $@convention(method) (@owned MutableRawSpan, @thin GCM.Type) -> @lifetime(copy 0) @owned MutableRawSpan
+// CHECK-LABEL: sil @$s32def_implicit_lifetime_dependence16takeViewCallback1fyAA06BufferF0VyXE_tF : $@convention(thin) (@guaranteed @noescape @callee_guaranteed () -> @lifetime(captures) @owned BufferView) -> ()


### PR DESCRIPTION
- **Explanation**: Express lifetime dependencies on the closure context.
  - Implements the closure capture dependency syntax described here:
https://github.com/atrick/swift-evolution/blob/lifetime-dependency/proposals/NNNN-lifetime-dependency.md#closure-capture-dependency-syntax
  - We also replace closure context dependencies with dependencies on the newly-added function parameters that correspond to the captured variables when lowering functions to SIL.
  - Automatically infer a dependence on the closure context if no explicit dependencies were specified with an annotation for a `~Escapable` result of a function type.
    **This causes different, incompatible lifetimes to be inferred for certain function declarations and types with the same signature.** See the [`testBorrow` test case](https://github.com/aidan-hall/swift/blob/lifedep-infer-closure-dependence/test/Sema/lifetime_dependence_functype.swift#L52) for an example. To compensate for this, we now print all lifetime dependencies in diagnostics, including inferred ones.
    Follow-up PR to address this issue: https://github.com/swiftlang/swift/pull/88623
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: This changes the lifetime inference rules for function types, so it could break code that works with function types involving `~Escapable` types.
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Issues**:
  - rdar://134318039 ([nonescapable] inferred captures: infer lifetime dependency for function types with nonescapable results equivalent to @lifetime(copy closure))
  - rdar://171217486 ([nonescapable] closure type conversion with lifetime dependencies)
  <!--
  References to issues the changes resolve, if any.
  -->
- **Risk**: This should only affect code that uses function types involving lifetime dependencies, which are a relatively new, experimental feature, so the risk should be low.
  <!--
  The (specific) risk to the release for taking the changes.
  -->
- **Testing**: Unit tests
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->