### PR TITLE
SILGen: Fix effective thrown error type for integrated function conversion emission

### DIFF
--- a/test/SILGen/typed_throws_reabstraction.swift
+++ b/test/SILGen/typed_throws_reabstraction.swift
@@ -37,3 +37,27 @@ func test1() throws { // OK
     try gorble()
   }
 }
+
+// rdar://169150387
+func test3<E: Error>(e: E) {
+  // CHECK-LABEL: sil private [ossa] @$s{{.+}}5test31eyx_ts5ErrorRzlFyyxYKcfU_ : $@convention(thin) <E where E : Error> (@in_guaranteed E) -> @error any Error {
+  // CHECK:      bb0([[V1:%.+]] : @closureCapture $*E):
+  // CHECK:        [[V2:%.+]] = alloc_stack $E
+  // CHECK-NEXT:   copy_addr [[V1]] to [init] [[V2]]
+  // CHECK:        [[V3:%.+]] = alloc_stack $any Error
+  // CHECK-NEXT:   [[V4:%.+]] = alloc_stack $E
+  // CHECK-NEXT:   copy_addr [take] [[V2]] to [init] [[V4]]
+  // CHECK-NEXT:   [[V5:%.+]] = alloc_existential_box $any Error, $E
+  // CHECK-NEXT:   [[V6:%.+]] = project_existential_box $E in [[V5]]
+  // CHECK-NEXT:   store [[V5]] to [init] [[V3]]
+  // CHECK-NEXT:   copy_addr [take] [[V4]] to [init] [[V6]]
+  // CHECK-NEXT:   [[V7:%.+]] = load [take] [[V3]]
+  // CHECK-NEXT:   dealloc_stack [[V4]]
+  // CHECK-NEXT:   dealloc_stack [[V3]]
+  // CHECK-NEXT:   dealloc_stack [[V2]]
+  // CHECK-NEXT:   throw [[V7]]
+  // CHECK-NEXT: } // end sil function '$s{{.+}}5test31eyx_ts5ErrorRzlFyyxYKcfU_'
+  let _: () throws -> Void = { () throws(E) -> Void in
+    throw e
+  }
+}

--- a/validation-test/compiler_crashers_fixed/rdar169150387.swift
+++ b/validation-test/compiler_crashers_fixed/rdar169150387.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-emit-silgen %s -verify
+
+public func withThrowingClosure<Result>(
+  _ body: () throws -> Result
+) rethrows -> Result {
+  return try body()
+}
+
+func witNestedThrowingClosure<E, Result>(
+  _ body: () throws(E) -> Result
+) throws(E) -> Result where E: Error {
+  do {
+    return try withThrowingClosure { () throws(E) in
+      try body()
+    }
+  } catch let error as E {
+    throw error
+  } catch {
+    fatalError()
+  }
+}


### PR DESCRIPTION
Sometimes, as an optimization, we fulfill a function conversion expression that wraps a closure literal by adjusting the emission of the closure function instead of emitting a thunk. For example, the following closure is emitted as an untyped throws function, and the errors thrown in its body are type-erased:

```swift
func foo<E: Error>(e: E) {
  let _: () throws -> Void = { () throws(E) -> Void in
    throw e
  }
}
```

Be careful not to rely on the thrown error type stored in the AST node, since it may differ from the effective thrown error type tracked by SILGen.

Fixes rdar://169150387.