### PR TITLE
Add a `BorrowInout` experimental feature flag.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8523,6 +8523,10 @@ NOTE(lifetime_escapable_source_requires_escapable_note, none,
 ERROR(lifetime_dependence_unknown_type, none,
       "lifetime dependence checking failed due to unknown %0 type", (StringRef))
 
+ERROR(borrow_inout_experimental,none,
+      "'%0' is an experimental feature",
+      (StringRef))
+
 //------------------------------------------------------------------------------
 // MARK: Lifetime Dependence Requirements
 //------------------------------------------------------------------------------

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -619,6 +619,9 @@ EXPERIMENTAL_FEATURE(SourceWarningControl, true)
 /// Allows a `get` returning a noncopyable type have owned semantics in opaque interfaces.
 EXPERIMENTAL_FEATURE(UnderscoreOwned, true)
 
+/// Allows the standard library `Borrow` and `Inout` types to be used.
+EXPERIMENTAL_FEATURE(BorrowInout, true)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -599,6 +599,7 @@ static bool usesFeatureReparenting(Decl *decl) {
 
 UNINTERESTING_FEATURE(AnyAppleOSAvailability)
 UNINTERESTING_FEATURE(StrictAccessControl)
+UNINTERESTING_FEATURE(BorrowInout)
 
 // ----------------------------------------------------------------------------
 // MARK: - FeatureSet

--- a/test/stdlib/Inputs/BorrowInoutFakeStdlib.swift
+++ b/test/stdlib/Inputs/BorrowInoutFakeStdlib.swift
@@ -1,0 +1,19 @@
+// Just enough definition here to test the behavior of referencing the names.
+public struct Borrow<Target: ~Copyable>: ~Escapable {
+	@_lifetime(immortal)
+	init() {}
+}
+public struct Inout<Target: ~Copyable>: ~Escapable, ~Copyable {
+	@_lifetime(immortal)
+	init() {}
+}
+
+@_marker public protocol Copyable {}
+@_marker public protocol Escapable {}
+
+public struct Int {}
+
+// Make sure the stdlib is able to refer to its own declarations irrespective
+// of feature flag settings.
+public func referenceBorrow(x: Borrow<Int>) {}
+public func referenceInout(x: consuming Inout<Int>) {}

--- a/test/stdlib/borrow_inout_requires_feature.swift
+++ b/test/stdlib/borrow_inout_requires_feature.swift
@@ -1,0 +1,17 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -enable-experimental-feature Lifetimes -parse-stdlib -emit-module-path %t -module-name Swift %S/Inputs/BorrowInoutFakeStdlib.swift
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -nostdimport -I %t -verify-additional-prefix missing-
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -nostdimport -I %t -enable-experimental-feature BorrowInout
+// 
+// REQUIRES: swift_feature_BorrowInout
+// REQUIRES: swift_feature_Lifetimes
+
+@available(SwiftStdlib 6.4, *)
+func f(_: Borrow<Int>) { }
+// expected-missing-error@-1{{'Borrow' is an experimental feature}}
+
+
+@available(SwiftStdlib 6.4, *)
+func g(_: consuming Inout<Int>) { }
+// expected-missing-error@-1{{'Inout' is an experimental feature}}
+


### PR DESCRIPTION
This gates access to the new standard library `Borrow` and `Inout` types until they are officially accepted.
