### PR TITLE
Reparenting: handle less-available reparented base protocols

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5636,6 +5636,12 @@ public:
   /// this protocol itself.
   ArrayRef<ProtocolDecl *> getAllInheritedProtocols() const;
 
+  /// Retrieve the set of protocols that are reparenting this protocol,
+  /// plus the extension defining the relationship and the index into that
+  /// extension's InheritedTypes where it occurs.
+  ArrayRef<std::tuple<ProtocolDecl *, ExtensionDecl *, unsigned>>
+  getReparentingProtocols() const;
+
   /// Determine whether this protocol has a superclass.
   bool hasSuperclass() const { return (bool)getSuperclassDecl(); }
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2815,6 +2815,8 @@ ERROR(extension_protocol_reparented_not_inheriting,none,
 ERROR(extension_protocol_reparented_duplicate,none,
       "cannot have multiple declarations of %0 being '@reparented' by %1",
       (const NominalTypeDecl *, const NominalTypeDecl *))
+NOTE(invalid_reparented_prev,none,
+     "%0 previously '@reparented' by %1 here", (const ValueDecl *, const ValueDecl *))
 ERROR(objc_generic_extension_using_type_parameter,none,
       "extension of a generic Objective-C class cannot access the class's "
       "generic parameters at runtime", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2812,6 +2812,9 @@ ERROR(extension_protocol_inheritance,none,
 ERROR(extension_protocol_reparented_not_inheriting,none,
       "%0 must directly inherit from %1 in order to be reparented",
       (const NominalTypeDecl *, const NominalTypeDecl *))
+ERROR(extension_protocol_reparented_duplicate,none,
+      "cannot have multiple declarations of %0 being '@reparented' by %1",
+      (const NominalTypeDecl *, const NominalTypeDecl *))
 ERROR(objc_generic_extension_using_type_parameter,none,
       "extension of a generic Objective-C class cannot access the class's "
       "generic parameters at runtime", ())

--- a/include/swift/AST/NameLookupRequests.h
+++ b/include/swift/AST/NameLookupRequests.h
@@ -241,6 +241,30 @@ public:
   void cacheResult(ArrayRef<ValueDecl *> value) const;
 };
 
+/// Computes the set of protocols that are reparenting a given protocol.
+class ReparentingProtocolsRequest
+    : public SimpleRequest<
+          ReparentingProtocolsRequest,
+          ArrayRef<std::tuple<ProtocolDecl *, ExtensionDecl *, unsigned>>(
+              ProtocolDecl *),
+          RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+  /// Indicates a reparenting by a protocol, defined at a specific extension,
+  /// with an index into the extension's InheritedTypes establishing it.
+  using Result = std::tuple<ProtocolDecl *, ExtensionDecl *, unsigned>;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  ArrayRef<Result> evaluate(Evaluator &, ProtocolDecl *) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
 /// Requests whether or not this class has designated initializers that are
 /// not public or @usableFromInline.
 class HasMissingDesignatedInitializersRequest :

--- a/include/swift/AST/NameLookupTypeIDZone.def
+++ b/include/swift/AST/NameLookupTypeIDZone.def
@@ -49,6 +49,9 @@ SWIFT_REQUEST(NameLookup, InheritedProtocolsRequest,
 SWIFT_REQUEST(NameLookup, AllInheritedProtocolsRequest,
               ArrayRef<ProtocolDecl *>(ProtocolDecl *), SeparatelyCached,
               NoLocationInfo)
+SWIFT_REQUEST(NameLookup, ReparentingProtocolsRequest,
+              ArrayRef<ReparentingProtocolsRequest::Result>(ProtocolDecl *), Cached,
+              NoLocationInfo)
 SWIFT_REQUEST(NameLookup, ProtocolRequirementsRequest,
               ArrayRef<ValueDecl *>(ProtocolDecl *), SeparatelyCached,
               NoLocationInfo)

--- a/include/swift/AST/NameLookupTypeIDZone.def
+++ b/include/swift/AST/NameLookupTypeIDZone.def
@@ -47,7 +47,7 @@ SWIFT_REQUEST(NameLookup, InheritedProtocolsRequest,
               ArrayRef<ProtocolDecl *>(ProtocolDecl *), SeparatelyCached,
               NoLocationInfo)
 SWIFT_REQUEST(NameLookup, AllInheritedProtocolsRequest,
-              ArrayRef<ProtocolDecl *>(ProtocolDecl *), Cached,
+              ArrayRef<ProtocolDecl *>(ProtocolDecl *), SeparatelyCached,
               NoLocationInfo)
 SWIFT_REQUEST(NameLookup, ProtocolRequirementsRequest,
               ArrayRef<ValueDecl *>(ProtocolDecl *), SeparatelyCached,

--- a/lib/AST/AvailabilityConstraint.cpp
+++ b/lib/AST/AvailabilityConstraint.cpp
@@ -294,6 +294,16 @@ swift::getAvailabilityConstraintsForDecl(const Decl *decl,
 
   getAvailabilityConstraintsForDecl(constraints, decl, context, flags);
 
+  // For requirements of reparentable protocols, add constraints from the
+  // enclosing protocol itself. We don't need to do this for ordinary protocols
+  // because of the rule that a protocol P cannot inherit from Q if Q is less
+  // available than P. Thus, the availability of the most derived protocol
+  // already carries the same or stricter constraints than its ancestors.
+  if (auto *proto = decl->getDeclContext()->getSelfProtocolDecl()) {
+    if (proto->getAttrs().hasAttribute<ReparentableAttr>())
+      getAvailabilityConstraintsForDecl(constraints, proto, context, flags);
+  }
+
   if (flags.contains(AvailabilityConstraintFlag::SkipEnclosingExtension))
     return constraints;
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7362,6 +7362,13 @@ ArrayRef<ProtocolDecl *> ProtocolDecl::getAllInheritedProtocols() const {
                            {});
 }
 
+ArrayRef<ReparentingProtocolsRequest::Result>
+ProtocolDecl::getReparentingProtocols() const {
+  auto *mutThis = const_cast<ProtocolDecl *>(this);
+  return evaluateOrDefault(getASTContext().evaluator,
+                           ReparentingProtocolsRequest{mutThis}, {});
+}
+
 ArrayRef<AssociatedTypeDecl *>
 ProtocolDecl::getAssociatedTypeMembers() const {
   if (Bits.ProtocolDecl.HasAssociatedTypes)

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -3649,6 +3649,66 @@ AllInheritedProtocolsRequest::evaluate(Evaluator &evaluator,
   return PD->getASTContext().AllocateCopy(result.getArrayRef());
 }
 
+ArrayRef<ReparentingProtocolsRequest::Result>
+ReparentingProtocolsRequest::evaluate(Evaluator &evaluator,
+                                      ProtocolDecl *PD) const {
+  // ObjC protocols cannot be reparented.
+  if (PD->isObjC())
+    return {};
+
+  auto const *expectedModule = PD->getModuleContext();
+
+  SmallPtrSet<ProtocolDecl *, 4> reparented;
+  SmallVector<Result, 4> result;
+  for (auto *ext : PD->getExtensions()) {
+
+    // Extensions in other modules can't validly declare a reparenting.
+    if (ext->getModuleContext() != expectedModule)
+      continue;
+
+    // Search for @reparented entries in the extension's inheritance clause.
+    auto inheritedTypes = ext->getInherited();
+    for (auto index : inheritedTypes.getIndices()) {
+      auto const &inherited = inheritedTypes.getEntry(index);
+
+      if (!inherited.isReparented())
+        continue;
+
+      // Resolve the type.
+      Type ty = inheritedTypes.getResolvedType(index,
+                                               TypeResolutionStage::Structural);
+
+      if (!ty || ty->hasError())
+        continue;
+
+      auto protoTy = ty->castTo<ProtocolType>();
+      ProtocolDecl *newBase = protoTy->getDecl();
+      ASSERT(newBase != PD && "reparenting itself?");
+
+      // Duplicate extension. Should only be one.
+      if (!reparented.insert(newBase).second) {
+        // FIXME: diagnose with diag::extension_protocol_reparented_duplicate
+        // and diag::invalid_redecl_prev
+        ASSERT(false);
+        continue;
+      }
+
+      result.emplace_back(newBase, ext, index);
+    }
+  }
+
+  if (result.empty())
+    return {};
+
+  // Give a stable ordering by protocols to avoid later non-determinism.
+  llvm::array_pod_sort(result.begin(), result.end(),
+                       [](Result const *a, Result const *b) {
+                         return TypeDecl::compare(std::get<ProtocolDecl *>(*a),
+                                                  std::get<ProtocolDecl *>(*b));
+                       });
+  return PD->getASTContext().AllocateCopy(result);
+}
+
 ArrayRef<ValueDecl *>
 ProtocolRequirementsRequest::evaluate(Evaluator &evaluator,
                                       ProtocolDecl *PD) const {

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -1487,38 +1487,20 @@ createProtocolToProtocolConformances(ProtocolDecl *protocol) {
     conformances.push_back(ctx.getSelfConformance(protocol));
   }
 
-  // Search extensions of the protocol for reparented conformances.
-  for (auto *ext : protocol->getExtensions()) {
-    // No valid reparentings can appear outside the protocol's module.
-    if (ext->getModuleContext() != protocol->getModuleContext())
-      continue;
+  for (auto &[newBase, ext, index] : protocol->getReparentingProtocols()) {
+    // We say that 'Self' is what conforms to the @reparented entry.
+    auto conformingType = protocol->getDeclaredInterfaceType();
+    auto const &entry = ext->getInherited().getEntry(index);
+    assert(entry.isReparented());
 
-    auto inheritedTypes = InheritedTypes(ext);
-    for (unsigned i : inheritedTypes.getIndices()) {
-      auto const &entry = inheritedTypes.getEntry(i);
-      if (!entry.isReparented())
-        continue;
+    auto loc = entry.getLoc();
+    if (!loc)
+      loc = ext->getLoc();
 
-      // We may not have already validated the inherited entry.
-      Type inheritedTy =
-          inheritedTypes.getResolvedType(i, TypeResolutionStage::Structural);
-
-      auto baseTy = inheritedTy->getAs<ProtocolType>();
-      if (!baseTy)
-        continue;
-
-      auto baseProto = baseTy->getDecl();
-      assert(baseProto);
-
-      // We say that 'Self' is what conforms to the inherited entry.
-      auto conformingType = protocol->getDeclaredInterfaceType();
-      auto *conf = ctx.getNormalConformance(
-          conformingType, baseTy->getDecl(), entry.getLoc(),
-          entry.getTypeRepr(), /*dc=*/ext, ProtocolConformanceState::Incomplete,
-          ProtocolConformanceFlags::Reparented);
-
-      conformances.push_back(conf);
-    }
+    conformances.push_back(ctx.getNormalConformance(
+        conformingType, newBase, loc, entry.getTypeRepr(), /*dc=*/ext,
+        ProtocolConformanceState::Incomplete,
+        ProtocolConformanceFlags::Reparented));
   }
 
   return conformances;

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -1489,8 +1489,15 @@ bool LinkEntity::isWeakImported(ModuleDecl *module) const {
     return depMemTy->getAssocType()->isWeakImported(module);
   }
 
-  case Kind::BaseConformanceDescriptor:
+  case Kind::BaseConformanceDescriptor: {
+    auto baseProto = getAssociatedConformance().second;
+
+    // The base protocol might be reparented and less available.
+    if (baseProto->isWeakImported(module))
+      return true;
+
     return cast<ProtocolDecl>(getDecl())->isWeakImported(module);
+  }
 
   case Kind::TypeMetadata:
   case Kind::TypeMetadataAccessFunction: {

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -1483,7 +1483,7 @@ bool LinkEntity::isWeakImported(ModuleDecl *module) const {
 
     auto &ctx = getDecl()->getASTContext();
     if (assocConformance.first->isEqual(ctx.TheSelfType))
-      return cast<ProtocolDecl>(getDecl())->isWeakImported(module);
+      return cast<ProtocolDecl>(assocConformance.second)->isWeakImported(module);
 
     auto *depMemTy = assocConformance.first->castTo<DependentMemberType>();
     return depMemTy->getAssocType()->isWeakImported(module);

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -2508,6 +2508,23 @@ public:
 
   void visitProtocolDecl(ProtocolDecl *proto) {
     for (TypeLoc requirement : proto->getInherited().getEntries()) {
+
+      // Inherited protocols can be less available than this protocol, only if
+      // this protocol has defined a @reparented extension and thus default
+      // conformance. Otherwise, clients compiled for an older version of the
+      // library could send types into a newer library that fails to provide
+      // the default witness table for the inherited protocol's requirements.
+      if (auto inheritedTy = requirement.getType()->getAs<ProtocolType>()) {
+        ProtocolDecl const *inherited = inheritedTy->getDecl();
+        bool isForReparenting = llvm::any_of(
+            proto->getReparentingProtocols(), [=](auto const &tup) {
+              return std::get<ProtocolDecl *>(tup) == inherited;
+            });
+        if (isForReparenting) {
+          continue;
+        }
+      }
+
       checkType(requirement.getType(), requirement.getTypeRepr(), proto,
                 ExportabilityReason::General,
                 DeclAvailabilityFlag::DisableUnsafeChecking);
@@ -2605,7 +2622,14 @@ public:
     //
     // 1) If the extension defines conformances, the conformed-to protocols
     // must be exported.
-    DeclAvailabilityFlags flags = DeclAvailabilityFlag::AllowPotentiallyUnavailableProtocol;
+    DeclAvailabilityFlags flags;
+
+    // Extensions of protocols can only have inherited entries for reparenting.
+    // For understandability, the `extension P: @reparented Q` defines a
+    // relationship that should have availability compatible with protocol Q.
+    if (!isa<ProtocolDecl>(extendedType))
+      flags |= DeclAvailabilityFlag::AllowPotentiallyUnavailableProtocol;
+
     flags |= DeclAvailabilityFlag::DisableUnsafeChecking;
     ExportabilityReason inheritanceReason =
       Where.getExportedLevel() == ExportedLevel::ImplicitlyExported ?

--- a/test/Availability/Inputs/reparenting.swift
+++ b/test/Availability/Inputs/reparenting.swift
@@ -1,0 +1,42 @@
+#if IncludeNewProto
+@available(macOS 12, *)
+@reparentable public protocol NewProto {
+  associatedtype Thing: Equatable
+  func new() -> Thing
+}
+
+@available(macOS 12, *)
+extension Existing: @reparented NewProto where Thing == String {
+  public func new() -> Thing { return "defaulted Existing.new" }
+}
+
+public protocol Existing: NewProto {
+  associatedtype Thing: Equatable = String
+  func existing() -> Thing
+}
+#else
+public protocol Existing {
+  associatedtype Thing: Equatable = String
+  func existing() -> Thing
+}
+#endif
+
+public protocol Derived: Existing {
+  func derived() -> Thing
+}
+
+
+public func libraryFunc(_ s: some Derived) {
+  print("libraryFunc start")
+
+  print(s.derived())
+  print(s.existing())
+
+#if IncludeNewProto
+  if #available(macOS 12, *) { // FIXME: this doesn't properly guard the block.
+    print(s.new())
+  }
+#endif
+
+  print("libraryFunc end")
+}

--- a/test/Availability/Inputs/reparenting.swift
+++ b/test/Availability/Inputs/reparenting.swift
@@ -33,9 +33,7 @@ public func libraryFunc(_ s: some Derived) {
   print(s.existing())
 
 #if IncludeNewProto
-  if #available(macOS 12, *) { // FIXME: this doesn't properly guard the block.
-    print(s.new())
-  }
+  print(s.new())
 #endif
 
   print("libraryFunc end")

--- a/test/Availability/availability_reparenting.swift
+++ b/test/Availability/availability_reparenting.swift
@@ -1,0 +1,63 @@
+// RUN: %empty-directory(%t)
+
+// Build the library with the new protocol available.
+
+// RUN: %target-build-swift -DIncludeNewProto -target %target-cpu-apple-macosx12 -parse-as-library -emit-library -enable-experimental-feature Reparenting \
+// RUN:     -emit-module-path %t/Reparenting.swiftmodule -module-name Reparenting -enable-library-evolution %S/Inputs/Reparenting.swift -o %t/%target-library-name(Reparenting)
+// RUN: %target-codesign %t/%target-library-name(Reparenting)
+
+// Build the client with an older deployment target + its custom witness for new() and run.
+
+// RUN: %target-build-swift -DIncludeCustomWitness -target %target-cpu-apple-macosx10.15 -lReparenting -module-name main -I %t -L %t %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck --check-prefixes=CHECK,NEW-CLIENT-WITNESS %s
+
+// Build the client with an older deployment target + the library-provided witness for new() and run.
+
+// RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 -lReparenting -module-name main -I %t -L %t %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck --check-prefixes=CHECK,NEW-LIB-WITNESS %s
+
+///
+// Key piece of the test:
+// Replace the library dylib with one that never even knew about NewProto while using an older deployment target,
+// then run WITHOUT rebuilding the client.
+///
+
+// RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 -parse-as-library -emit-library -enable-experimental-feature Reparenting \
+// RUN:     -emit-module-path %t/Reparenting.swiftmodule -module-name Reparenting -enable-library-evolution %S/Inputs/Reparenting.swift -o %t/%target-library-name(Reparenting)
+// RUN: %target-codesign %t/%target-library-name(Reparenting)
+// RUN: %target-run %t/a.out | %FileCheck --check-prefixes=CHECK,NEW-NO-WITNESS %s
+
+// REQUIRES: OS=macosx && (CPU=x86_64 || CPU=arm64)
+// REQUIRES: executable_test
+// UNSUPPORTED: remote_run || device_run
+
+// REQUIRES: swift_feature_Reparenting
+
+import Reparenting
+
+struct MyStruct: Derived {
+  typealias Thing = String
+  func existing() -> String { return "MyStruct.existing" }
+  func derived() -> String { return "MyStruct.derived" }
+#if IncludeCustomWitness
+  func new() -> String { return "MyStruct.new" }
+#endif
+}
+
+defer { main() }
+func main() {
+  print("start test")  // CHECK: start test
+  let ms = MyStruct()
+  libraryFunc(ms)
+  // CHECK: libraryFunc start
+  // CHECK: MyStruct.derived
+  // CHECK: MyStruct.existing
+
+  // NEW-LIB-WITNESS: defaulted Existing.new
+  // NEW-CLIENT-WITNESS: MyStruct.new
+  // NEW-NO-WITNESS-NOT: new
+
+  // CHECK: libraryFunc end
+}

--- a/test/Availability/availability_reparenting_errors.swift
+++ b/test/Availability/availability_reparenting_errors.swift
@@ -1,0 +1,65 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature Reparenting
+
+// REQUIRES: OS=macosx
+
+// REQUIRES: swift_feature_Reparenting
+
+public protocol Seq: BorrowingSeq {
+  func seq()
+}
+
+@available(macOS 99, *)
+@reparentable public protocol BorrowingSeq {
+  func borrowSeq()
+  var borrowCount: Int { get set }
+  associatedtype BorrowIter
+}
+
+@available(macOS 99, *)
+extension Seq: @reparented BorrowingSeq where BorrowIter == String {
+  public func borrowSeq() {
+    self.seq()
+  }
+
+  public var borrowCount: Int { get { } set { } }
+}
+
+func tryToUseRequirement(_ s: some Seq) { // expected-note 2{{add '@available'}}
+  s.seq()
+  s.borrowSeq() // expected-error{{'borrowSeq()' is only available in macOS 99 or newer}}
+  // expected-note@-1 {{add 'if #available'}}
+
+  _ = s.borrowCount // expected-error{{'borrowCount' is only available in macOS 99 or newer}}
+  // expected-note@-1 {{add 'if #available'}}
+}
+
+func correctedUse(_ s: some Seq) {
+  if #available(macOS 99, *) {
+    s.borrowSeq()
+    _ = s.borrowCount
+  } else {
+    s.seq()
+  }
+}
+
+func useAsBorrowingSeq1(_ bs: some BorrowingSeq) {} // expected-error 2{{'BorrowingSeq' is only available in macOS 99 or newer}} // expected-note 2{{}}
+func useAsBorrowingSeq2<T>(_ t: T) where T: BorrowingSeq {} // expected-error {{'BorrowingSeq' is only available in macOS 99 or newer}} // expected-note {{}}
+
+public struct AlwaysAvailableStruct: BorrowingSeq {
+  public typealias BorrowIter = Self
+  public func borrowSeq() {}
+  public var borrowCount: Int { get { 0 } set { } }
+}
+
+protocol NotAReparenting: BorrowingSeq {} // expected-error {{'BorrowingSeq' is only available in macOS 99 or newer}} // expected-note{{add '@available' attribute to enclosing protocol}}
+
+protocol ForgotAvailabilityOnReparenting: BorrowingSeq {}
+
+extension ForgotAvailabilityOnReparenting: @reparented BorrowingSeq where BorrowIter == Float { // expected-note 2{{add}}
+// expected-error@-1 {{'BorrowingSeq' is only available in macOS 99 or newer}}
+// expected-error@-2 {{'BorrowIter' is only available in macOS 99 or newer}}
+
+  public func borrowSeq() {} // expected-error {{cannot declare a public instance method in an extension with internal requirements}}
+
+  public var borrowCount: Int { get { } set { } } // expected-error {{cannot declare a public property in an extension with internal requirements}}
+}

--- a/test/Sema/reparenting.swift
+++ b/test/Sema/reparenting.swift
@@ -76,3 +76,15 @@ protocol Rectangle: Shape {}
 protocol Square: Rectangle {}
 extension Square : @reparented Shape {}
 // expected-error@-1 {{'Square' must directly inherit from 'Shape' in order to be reparented}}
+
+
+
+protocol MultiReparenting1: Q {}
+extension MultiReparenting1:
+                             @reparented Q,   // expected-note {{'MultiReparenting1' previously '@reparented' by 'Q' here}}
+                             @reparented Q {} // expected-error {{cannot have multiple declarations of 'MultiReparenting1' being '@reparented' by 'Q'}}
+
+protocol MultiReparenting2: R, Q {}
+extension MultiReparenting2: @reparented R {} // expected-note {{previously '@reparented' by 'R' here}}
+extension MultiReparenting2: @reparented Q {}
+extension MultiReparenting2: @reparented R {} // expected-error {{cannot have multiple declarations of 'MultiReparenting2' being '@reparented' by 'R'}}

--- a/test/Sema/reparenting.swift
+++ b/test/Sema/reparenting.swift
@@ -41,6 +41,7 @@ extension Invalid: @reparented Q & R {}
 @objc protocol ObjCProto {}
 extension ObjCProto: @reparented Q {}
 // expected-error @-1 {{@objc protocol 'ObjCProto' cannot be '@reparented'}}
+// expected-error @-2 {{'ObjCProto' must directly inherit from 'Q' in order to be reparented}}
 
 
 


### PR DESCRIPTION
This PR does a few things to make availability for reparenting work:
- It ensures base conformance descriptors properly use `extern_weak` linkage when the deployment target means the reparented protocol may not be available.
- It ensures availability checking prevents the use of the unavailable requirements of the reparentable protocol that was introduced above some other, more available protocol.

rdar://170097155