### PR TITLE
[ConstraintSystem] Propagate typed throws error type into throwing cl…

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -505,7 +505,8 @@ Type ConstraintSystem::getCaughtErrorType(CatchNode catchNode) {
   // FIXME: This will need to change when we do inference of thrown error
   // types in closures.
   if (auto closure = catchNode.dyn_cast<ClosureExpr *>()) {
-    return getClosureType(closure)->getEffectiveThrownErrorTypeOrNever();
+    auto closureTy = simplifyType(getType(closure))->castTo<FunctionType>();
+    return closureTy->getEffectiveThrownErrorTypeOrNever();
   }
 
   if (!ctx.LangOpts.hasFeature(Feature::FullTypedThrows))

--- a/test/expr/closure/typed_throws.swift
+++ b/test/expr/closure/typed_throws.swift
@@ -19,12 +19,11 @@ func testClosures() {
   // expected-error@-1{{invalid conversion from throwing function of type '() throws(MyError) -> ()'}}
 
   let _: () throws(MyError) -> Void = {
-    // NOTE: under full typed throws, this should succeed
-    throw MyError.fail // expected-error{{thrown expression type 'any Error' cannot be converted to error type 'MyError'}}
+    throw MyError.fail // Ok
   }
 
   let _: () throws(MyError) -> Void = {
-    throw .fail // expected-error{{type 'any Error' has no member 'fail'}}
+    throw .fail // Ok
   }
 
   // FIXME: Terrible diagnostic.


### PR DESCRIPTION
…osures

In a typed throws context a throwing closure (as determined from the body or an explicit `throws`) assumes an error type of the context that is a supertype of `any Error`.

This is a carve out from `FullTypedThrows` feature that let's more code that adopted typed throws to type-check without source compatibility impact since without context a closure would still be using un-typed throws and no additional inference of error type is done.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
