### PR TITLE
[RemoteInspection] Make TypeRef class carry its mangling flavor

### DIFF
--- a/include/swift/RemoteInspection/ReflectionContext.h
+++ b/include/swift/RemoteInspection/ReflectionContext.h
@@ -233,8 +233,10 @@ public:
   explicit ReflectionContext(
       std::shared_ptr<MemoryReader> reader,
       remote::ExternalTypeRefCache *externalCache = nullptr,
-      reflection::DescriptorFinder *descriptorFinder = nullptr)
-      : super(std::move(reader), *this, externalCache, descriptorFinder) {}
+      reflection::DescriptorFinder *descriptorFinder = nullptr,
+      Mangle::ManglingFlavor Flavor = Mangle::ManglingFlavor::Default)
+      : super(std::move(reader), *this, externalCache, descriptorFinder,
+              Flavor) {}
 
   ReflectionContext(const ReflectionContext &other) = delete;
   ReflectionContext &operator=(const ReflectionContext &other) = delete;

--- a/stdlib/public/RemoteInspection/TypeLowering.cpp
+++ b/stdlib/public/RemoteInspection/TypeLowering.cpp
@@ -1693,7 +1693,8 @@ const TypeRef *TypeConverter::getRawPointerTypeRef() {
   if (RawPointerTR != nullptr)
     return RawPointerTR;
 
-  RawPointerTR = BuiltinTypeRef::create(Builder, "Bp");
+  RawPointerTR =
+      BuiltinTypeRef::create(Builder, "Bp", Builder.getManglingFlavor());
   return RawPointerTR;
 }
 
@@ -1701,7 +1702,8 @@ const TypeRef *TypeConverter::getNativeObjectTypeRef() {
   if (NativeObjectTR != nullptr)
     return NativeObjectTR;
 
-  NativeObjectTR = BuiltinTypeRef::create(Builder, "Bo");
+  NativeObjectTR =
+      BuiltinTypeRef::create(Builder, "Bo", Builder.getManglingFlavor());
   return NativeObjectTR;
 }
 
@@ -1709,7 +1711,8 @@ const TypeRef *TypeConverter::getUnknownObjectTypeRef() {
   if (UnknownObjectTR != nullptr)
     return UnknownObjectTR;
 
-  UnknownObjectTR = BuiltinTypeRef::create(Builder, "BO");
+  UnknownObjectTR =
+      BuiltinTypeRef::create(Builder, "BO", Builder.getManglingFlavor());
   return UnknownObjectTR;
 }
 
@@ -1717,7 +1720,8 @@ const TypeRef *TypeConverter::getThinFunctionTypeRef() {
   if (ThinFunctionTR != nullptr)
     return ThinFunctionTR;
 
-  ThinFunctionTR = BuiltinTypeRef::create(Builder, "yyXf");
+  ThinFunctionTR =
+      BuiltinTypeRef::create(Builder, "yyXf", Builder.getManglingFlavor());
   return ThinFunctionTR;
 }
 
@@ -1725,7 +1729,8 @@ const TypeRef *TypeConverter::getAnyMetatypeTypeRef() {
   if (AnyMetatypeTR != nullptr)
     return AnyMetatypeTR;
 
-  AnyMetatypeTR = BuiltinTypeRef::create(Builder, "ypXp");
+  AnyMetatypeTR =
+      BuiltinTypeRef::create(Builder, "ypXp", Builder.getManglingFlavor());
   return AnyMetatypeTR;
 }
 

--- a/stdlib/public/RemoteInspection/TypeRefBuilder.cpp
+++ b/stdlib/public/RemoteInspection/TypeRefBuilder.cpp
@@ -187,7 +187,7 @@ TypeRefBuilder::ReflectionTypeDescriptorFinder::normalizeReflectionName(
           reflectionNameRemoteAddress, std::optional<std::string>()));
       return {};
     default:
-      auto mangling = mangleNode(node, Mangle::ManglingFlavor::Default);
+      auto mangling = mangleNode(node, Builder.getManglingFlavor());
       if (!mangling.isSuccess()) {
         NormalizedReflectionNameCache.insert(std::make_pair(
             reflectionNameRemoteAddress, std::optional<std::string>()));


### PR DESCRIPTION
The mangling flavor indicates whether a type is a "regular" Swift type
or an embedded Swift type. Since it's addition, the TypeRef does not
carry enough information to convert itself into a mangled name. It
should thus carry the mangling flavor so this operation is possible.

rdar://142915501
