### PR TITLE
Skip stub generation for pack expansion types in conformance diagnostics

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3783,6 +3783,17 @@ printRequirementStub(ValueDecl *Requirement, DeclContext *Adopter,
       return false;
     }
   }
+
+  // FIXME: The proper fix is to handle pack expansion types in the
+  // ASTPrinter's type substitution logic (TypeTransformContext). This
+  // workaround avoids the crash by skipping stub generation for requirements
+  // whose interface type contains a pack expansion, since setBaseType()
+  // triggers substitution that fails on these types.
+  if (auto interfaceType = Requirement->getInterfaceType()) {
+    if (interfaceType->hasPackExpansionType())
+      return false;
+  }
+
   // FIXME: Infer body indentation from the source rather than hard-coding
   // 4 spaces.
   ASTContext &Ctx = Requirement->getASTContext();

--- a/test/Generics/variadic_generic_pack_conformance_stub.swift
+++ b/test/Generics/variadic_generic_pack_conformance_stub.swift
@@ -1,0 +1,65 @@
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.9-abi-triple
+
+// Ensure protocol conformance diagnostics don't crash when requirements
+// involve pack expansion types. The ASTPrinter's type substitution via
+// TypeTransformContext crashes on pack expansions during stub generation.
+
+// ---- Pack expansion in function signature (metatype packs) ----
+
+protocol PackMetatypeProto1 {
+  func f<each T>(_: (repeat (each T).Type)) -> (repeat (each T).Type)
+  // expected-note@-1 {{protocol requires function 'f' with type .*}}
+}
+
+class ClassMetatype: PackMetatypeProto1 {} // expected-error {{type 'ClassMetatype' does not conform to protocol 'PackMetatypeProto1'}}
+
+protocol PackMetatypeProto2 {
+  func f<each T>(_: (repeat (each T).Type)) -> (repeat (each T).Type)
+  // expected-note@-1 {{protocol requires function 'f' with type .*}}
+}
+
+struct StructMetatype: PackMetatypeProto2 {} // expected-error {{type 'StructMetatype' does not conform to protocol 'PackMetatypeProto2'}}
+
+protocol PackMetatypeProto3 {
+  func f<each T>(_: (repeat (each T).Type)) -> (repeat (each T).Type)
+  // expected-note@-1 {{protocol requires function 'f' with type .*}}
+}
+
+enum EnumMetatype: PackMetatypeProto3 {} // expected-error {{type 'EnumMetatype' does not conform to protocol 'PackMetatypeProto3'}}
+
+// ---- Pack expansion with associated type constraints ----
+
+protocol HasAssoc { associatedtype U }
+
+protocol PackAssocProto1 {
+  func g<each T: HasAssoc>(_: (repeat (each T))) -> (repeat (each T).U)
+  // expected-note@-1 {{protocol requires function 'g' with type .*}}
+}
+
+class ClassAssoc: PackAssocProto1 {} // expected-error {{type 'ClassAssoc' does not conform to protocol 'PackAssocProto1'}}
+
+protocol PackAssocProto2 {
+  func g<each T: HasAssoc>(_: (repeat (each T))) -> (repeat (each T).U)
+  // expected-note@-1 {{protocol requires function 'g' with type .*}}
+}
+
+struct StructAssoc: PackAssocProto2 {} // expected-error {{type 'StructAssoc' does not conform to protocol 'PackAssocProto2'}}
+
+protocol PackAssocProto3 {
+  func g<each T: HasAssoc>(_: (repeat (each T))) -> (repeat (each T).U)
+  // expected-note@-1 {{protocol requires function 'g' with type .*}}
+}
+
+enum EnumAssoc: PackAssocProto3 {} // expected-error {{type 'EnumAssoc' does not conform to protocol 'PackAssocProto3'}}
+
+// ---- Valid conformance with pack expansion types should still compile ----
+
+protocol ValidPackProto {
+  func f<each T>(_: (repeat (each T).Type)) -> (repeat (each T).Type)
+}
+
+struct ValidConformer: ValidPackProto {
+  func f<each T>(_ t: (repeat (each T).Type)) -> (repeat (each T).Type) {
+    return t
+  }
+}


### PR DESCRIPTION
## Summary

Fix a crash in `printRequirementStub` when diagnosing missing protocol conformances involving pack expansion types.

## Problem

When a type (class, struct, or enum) fails to conform to a protocol that has requirements with variadic generic (pack expansion) types, the compiler crashes with an assertion failure:

```
Assertion failed: (!empty()), function back, file ArrayRef.h
```

The crash occurs because `printRequirementStub` calls `setBaseType(AdopterTy)` which triggers the ASTPrinter's `TypeTransformContext` substitution, and this substitution cannot handle pack expansion types.

## Fix

Skip stub generation early in `printRequirementStub()` for any requirement whose interface type contains a pack expansion. This is placed before the `PrintOptions` setup to avoid unnecessary work.

Key improvements over the initial version:
- **Universal**: applies to all adopter types (class, struct, enum), not just classes — the crash is in the ASTPrinter's substitution logic, not class-specific
- **Early return**: check is at the top of the function, before `PrintOptions` setup
- **FIXME documented**: notes that the proper fix is in the ASTPrinter's `TypeTransformContext`

The conformance error and "protocol requires" note are still emitted correctly; only the fixit stub is suppressed.

## Test plan

- [x] `test/Generics/variadic_generic_pack_conformance_stub.swift` covering:
  - Class, struct, and enum conformance failures with pack metatype requirements
  - Associated type pack expansion requirements
  - Valid conformance (positive test) to ensure no regression
- [x] Verified the crash reproduces on Swift 6.2.3 without the fix