### PR TITLE
[utils] add --lit-args to run-test

### DIFF
--- a/utils/run-test
+++ b/utils/run-test
@@ -163,6 +163,12 @@ def main():
     parser.add_argument("--update-tests", action="store_true",
                         help="Invoke lit with --update-tests to auto-repair failing tests "
                              "(when possible)")
+    parser.add_argument("--lit-args",
+                        type=argparse.types.ShellSplitType(),
+                        action=argparse.actions.AppendAction,
+                        default=[],
+                        help="direct passthrough options for lit, for options not directly "
+                             "supported by run-test")
 
     args = parser.parse_args()
 
@@ -285,6 +291,8 @@ def main():
 
     if args.update_tests:
         test_args.append('--update-tests')
+
+    test_args += args.lit_args
 
     test_cmd = [sys.executable, args.lit] + test_args + paths
 


### PR DESCRIPTION
This makes it possible to pass through any lit option even if it's not explicitly supported by run-test. This is different from --param, because "--param foo" gets forwarded as "--param foo" to lit, so it only supports the --param options.