### PR TITLE
[utils] add keep_modulecache parameter to lit config

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -655,7 +655,10 @@ if re.search(r'(?:^|[ \t])-use-ld=[^ \t]*', config.swift_driver_test_options):
     config.available_features.add('linker_overridden')
 
 config.clang_module_cache_path = make_path(config.swift_test_results_dir, "clang-module-cache")
-shutil.rmtree(config.clang_module_cache_path, ignore_errors=True)
+if lit_config.params.get('keep_modulecache', None) is not None:
+    lit_config.warning("Keeping module cache from previous run. This may greatly speed up your tests but also impact the test results. Use with care.")
+else:
+    shutil.rmtree(config.clang_module_cache_path, ignore_errors=True)
 mcp_opt = "-module-cache-path %s" % shell_quote(config.clang_module_cache_path)
 clang_mcp_opt = "-fmodules-cache-path=%r" % config.clang_module_cache_path
 lit_config.note("Using Clang module cache: " + config.clang_module_cache_path)


### PR DESCRIPTION
This keeps the current default behaviour of wiping the module cache to make sure that the test results are not impacted by previous runs, while still allowing the user to circumvent this behaviour when desired by passing "--param keep_modulecache" to run-test or directly to lit. Repopulating the module cache can have a significant impact on test times for C++ interop tests as they often need to process large parts of the C++ stdlib module. Anecdotally, keeping these results cached between runs doesn't tend to impact the results too often.
