### PR TITLE
[Serialization][wasm] Preserve wasm import metadata for SIL serialization

### DIFF
--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 984; // @_lifetime attribute isFromAnnotation flag
+const uint16_t SWIFTMODULE_VERSION_MINOR = 985; // Wasm extern import module/name in serialized SIL
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -86,6 +86,10 @@ enum class ExtraStringFlavor : uint8_t {
   AsmName,
   /// section attribute
   Section,
+  /// wasm import module name for @_extern(wasm)
+  WasmImportModule,
+  /// wasm import field/name for @_extern(wasm)
+  WasmImportName,
 };
 
 /// The record types within the "sil-index" block.

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -608,6 +608,10 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
   }
   if (!F.section().empty())
     ++numTrailingRecords;
+  if (!F.wasmImportModuleName().empty())
+    ++numTrailingRecords;
+  if (!F.wasmImportFieldName().empty())
+    ++numTrailingRecords;
 
   SILFunctionLayout::emitRecord(
       Out, ScratchRecord, abbrCode, toStableSILLinkage(Linkage),
@@ -648,6 +652,10 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
   // record count above.
   writeExtraStringIfNonEmpty(ExtraStringFlavor::AsmName, F.asmName());
   writeExtraStringIfNonEmpty(ExtraStringFlavor::Section, F.section());
+  writeExtraStringIfNonEmpty(ExtraStringFlavor::WasmImportModule,
+                             F.wasmImportModuleName());
+  writeExtraStringIfNonEmpty(ExtraStringFlavor::WasmImportName,
+                             F.wasmImportFieldName());
 
   if (NoBody)
     return;

--- a/test/Serialization/wasm-extern-import.swift
+++ b/test/Serialization/wasm-extern-import.swift
@@ -1,0 +1,36 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -emit-sib -emit-module-path %t/Lib.swiftmodule \
+// RUN:   -module-name Lib -target wasm32-unknown-wasip1 \
+// RUN:   -enable-experimental-feature Extern -parse-stdlib %t/Lib.swift -o %t/Lib.sib
+// RUN: %target-swift-frontend -emit-ir -I %t -target wasm32-unknown-wasip1 \
+// RUN:   -enable-experimental-feature Extern -parse-stdlib %t/Client.swift | %FileCheck %s
+
+// Check that wasm import names are preserved in the serialized SIL
+// RUN: %target-swift-frontend -emit-sib -I %t -target wasm32-unknown-wasip1 \
+// RUN:   -enable-experimental-feature Extern -parse-stdlib %t/Client.swift -o %t/Client.sib
+// RUN: %target-swift-frontend -emit-ir -I %t -target wasm32-unknown-wasip1 \
+// RUN:   -enable-experimental-feature Extern -parse-stdlib %t/Client.sib | %FileCheck %s
+
+// REQUIRES: swift_feature_Extern
+// REQUIRES: CODEGENERATOR=WebAssembly
+
+//--- Lib.swift
+@_extern(wasm, module: "mod", name: "foo") public func foo()
+@_extern(wasm, module: "modOnly", name: "") public func modOnly()
+@_extern(wasm, module: "", name: "nameOnly") public func nameOnly()
+
+//--- Client.swift
+import Lib
+public func use() {
+    foo()
+    modOnly()
+    nameOnly()
+}
+
+// CHECK: declare swiftcc void @"$s3Lib3fooyyF"() #[[ATTR:[0-9]+]]
+// CHECK: declare swiftcc void @"$s3Lib7modOnlyyyF"() #[[ATTR_MOD_ONLY:[0-9]+]]
+// CHECK: declare swiftcc void @"$s3Lib8nameOnlyyyF"() #[[ATTR_NAME_ONLY:[0-9]+]]
+// CHECK: attributes #[[ATTR]] = {{.*}}"wasm-import-module"="mod"{{.*}}"wasm-import-name"="foo"
+// CHECK: attributes #[[ATTR_MOD_ONLY]] = {{.*}}"wasm-import-module"="modOnly"{{.*}}
+// CHECK: attributes #[[ATTR_NAME_ONLY]] = {{.*}}"wasm-import-name"="nameOnly"{{.*}}


### PR DESCRIPTION
Serialize/deserialize wasm import module/name for SIL serialization so inlined decls keep their import names. Otherwise, inlining a function with `@_extern(wasm)` would lose the import name and cause IRGen to emit an import from the default module "env".

Related links: https://github.com/swiftwasm/JavaScriptKit/pull/631 https://github.com/swiftwasm/JavaScriptKit/pull/628

Resolves https://github.com/swiftlang/swift/issues/87320