### PR TITLE
[CS] Propagate Sendable-dependence into closures

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -4214,8 +4214,14 @@ public:
       if (auto fType = Ty->getAs<AnyFunctionType>()) {
         printFlag(!fType->getExtInfo().isNoEscape(), "escaping",
                   ClosureModifierColor);
-        printFlag(fType->getExtInfo().isSendable(), "sendable",
-                  ClosureModifierColor);
+        if (auto sendableTy = fType->getSendableDependentType()) {
+          printFieldQuoted(sendableTy.getString(),
+                           Label::always("sendable_dep"),
+                           ClosureModifierColor);
+        } else {
+          printFlag(fType->getExtInfo().isSendable(), "sendable",
+                    ClosureModifierColor);
+        }
       }
     }
   }
@@ -6632,7 +6638,8 @@ namespace {
           printField(representation, Label::always("representation"));
         }
         printFlag(!T->isNoEscape(), "escaping");
-        printFlag(T->isSendable(), "Sendable");
+        if (!T->getSendableDependentType())
+          printFlag(T->isSendable(), "Sendable");
         printFlag(T->isAsync(), "async");
         printFlag(T->isThrowing(), "throws");
         printFlag(T->hasSendingResult(), "sending_result");
@@ -6674,6 +6681,9 @@ namespace {
       if (Type globalActor = T->getGlobalActor()) {
         printFieldQuoted(globalActor.getString(), Label::always("global_actor"));
       }
+
+      if (auto sendableTy = T->getSendableDependentType())
+        printRec(sendableTy, Label::always("sendable_dep"));
 
       printClangTypeRec(T->getClangTypeInfo(), T->getASTContext(),
                         Label::optional("clang_type_info"));

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -12392,8 +12392,13 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
   // Propagate @Sendable from the contextual type to the closure.
   auto closureExtInfo = inferredClosureType->getExtInfo();
   if (auto contextualFnType = contextualType->getAs<FunctionType>()) {
-    if (contextualFnType->isSendable())
-      closureExtInfo = closureExtInfo.withSendable();
+    if (!closureExtInfo.isSendable()) {
+      if (auto sendTy = contextualFnType->getSendableDependentType()) {
+        closureExtInfo = closureExtInfo.withSendableDependentType(sendTy);
+      } else if (contextualFnType->isSendable()) {
+        closureExtInfo = closureExtInfo.withSendable();
+      }
+    }
   }
 
   // Propagate sending result from the contextual type to the closure.

--- a/test/Concurrency/sendable_methods.swift
+++ b/test/Concurrency/sendable_methods.swift
@@ -332,3 +332,13 @@ do {
     static func ff() {}
   }
 }
+
+extension GenericE {
+  func foo() -> T { fatalError() }
+}
+
+func testClosureSendableDependence(_ x: NonSendable, _ fn: @Sendable () -> Void) {
+  // This is fine since we resolve the closure before we bind T.
+  func foo<T>(_ x: T, _ y: T) {}
+  foo(GenericE.a.foo, { (x, 0).1 })
+}

--- a/validation-test/IDE/crashers_fixed/AnyFunctionType-isSendable-7673fc.swift
+++ b/validation-test/IDE/crashers_fixed/AnyFunctionType-isSendable-7673fc.swift
@@ -1,0 +1,5 @@
+// {"kind":"complete","languageMode":6,"original":"2a410454","signature":"swift::AnyFunctionType::isSendable() const","signatureAssert":"Assertion failed: (!hasSendableDependentType() && \"Query Sendable dependence first\"), function isSendable"}
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -swift-version 6 -source-filename %s
+[].reduce = {
+  #^^#
+}

--- a/validation-test/compiler_crashers_fixed/AnyFunctionType-isSendable-7b4103.swift
+++ b/validation-test/compiler_crashers_fixed/AnyFunctionType-isSendable-7b4103.swift
@@ -1,0 +1,4 @@
+// {"kind":"typecheck","languageMode":6,"signature":"swift::AnyFunctionType::isSendable() const","signatureAssert":"Assertion failed: (!hasSendableDependentType() && \"Query Sendable dependence first\"), function isSendable"}
+// RUN: not %target-swift-frontend -typecheck -swift-version 6 %s
+[].reduce = {
+}


### PR DESCRIPTION
Missed this in my original Sendable-dependence patch (#85730), the sendability of a closure can be dependent if its contextual type is. I'm not sure this case ever actually matters in practice, but it seems like we ought to be consistent with the existing logic and not have the behavior be dependent on whether the dependence is evaluated before or after the closure is resolved.