### PR TITLE
[sil-mode] Fix broken regex and remove duplicates

### DIFF
--- a/utils/sil-mode.el
+++ b/utils/sil-mode.el
@@ -21,10 +21,8 @@
   (list
    ;; Comments
    '("^#!.*" . font-lock-comment-face)
-   ;; Types
-   '("\\b[A-Z][a-zA-Z_0-9]*\\b" . font-lock-type-face)
    ;; Floating point constants
-   '("\\b[-+]?[0-9]+\.[0-9]+\\b" . font-lock-preprocessor-face)
+   '("\\b[-+]?[0-9]+\\.[0-9]+\\b" . font-lock-preprocessor-face)
    ;; Integer literals
    '("\\b[-]?[0-9]+\\b" . font-lock-preprocessor-face)
    ;; Decl and type keywords
@@ -35,7 +33,10 @@
                     "sil_witness_table" "sil_scope")
                   'words) . font-lock-keyword-face)
    ;; SIL Types
-   '("\\b[$][*]?[A-Z][z-aA-Z_[0-9]*\\b" . font-lock-type-face)
+   '("\\b[$][*]?[A-Z][a-zA-Z_0-9]*\\b" . font-lock-type-face)
+
+   ;; Types
+   '("\\b[A-Z][a-zA-Z_0-9]*\\b" . font-lock-type-face)
 
    ;; SIL Stage
    '("sil_stage" . font-lock-keyword-face)
@@ -93,9 +94,7 @@
                     "end_lifetime"
                     "is_unique"
                     "destroy_not_escaped_closure"
-                    "copy_block"
-                    "copy_block_without_escaping"
-                    "is_unique")
+                    "copy_block_without_escaping")
                   'words) . font-lock-keyword-face)
    ;; Literals
    `(,(regexp-opt '("function_ref"
@@ -116,7 +115,7 @@
                   'words) . font-lock-keyword-face)
    ;; Aggregate Types
    `(,(regexp-opt '("retain_value" "release_value_addr" "release_value"
-                    "release_value_addr" "tuple" "tuple_extract"
+                    "tuple" "tuple_extract"
                     "tuple_element_addr" "struct" "struct_extract"
                     "struct_element_addr" "ref_element_addr" "ref_tail_addr"
                     "autorelease_value" "copy_value" "destroy_value"
@@ -140,8 +139,7 @@
                     "alloc_existential_box" "project_existential_box"
                     "open_existential_box" "dealloc_existential_box"
                     "init_existential_ref" "open_existential_ref"
-                    "open_existential_metatype"
-                    "objc_protocol")
+                    "open_existential_metatype")
                   'words) . font-lock-keyword-face)
    ;; Unchecked Conversions
    `(,(regexp-opt '("upcast"
@@ -316,7 +314,6 @@
   (interactive)
   (kill-all-local-variables)
   (use-local-map sil-mode-map)         ;; Provides the local keymap.
-  (setq major-mode 'sil-mode)
 
   (make-local-variable 'font-lock-defaults)
   (setq major-mode 'sil-mode           ;; This is how describe-mode


### PR DESCRIPTION
I noticed that `$Int` and `$*Float` weren’t being highlighted properly, and I also did some cleanup.