### PR TITLE
[CompatibilityPacks] Don't export symbols.

### DIFF
--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -463,7 +463,11 @@ bool swift_compareProtocolConformanceDescriptors(
 ///
 /// \returns a metadata pack allocated on the heap, with the least significant
 /// bit set to true.
+#if SWIFT_COMPATIBILITY_PACKS
+SWIFT_RUNTIME_COMPATIBILITY SWIFT_CC(swift)
+#else
 SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
+#endif
 const Metadata * const *
 swift_allocateMetadataPack(const Metadata * const *ptr, size_t count);
 
@@ -478,7 +482,11 @@ swift_allocateMetadataPack(const Metadata * const *ptr, size_t count);
 ///
 /// \returns a witness table pack allocated on the heap, with the least
 /// significant bit set to true.
+#if SWIFT_COMPATIBILITY_PACKS
+SWIFT_RUNTIME_COMPATIBILITY SWIFT_CC(swift)
+#else
 SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
+#endif
 const WitnessTable * const *
 swift_allocateWitnessTablePack(const WitnessTable * const *ptr, size_t count);
 

--- a/stdlib/public/SwiftShims/swift/shims/Visibility.h
+++ b/stdlib/public/SwiftShims/swift/shims/Visibility.h
@@ -293,6 +293,13 @@
 #define SWIFT_RUNTIME_STDLIB_INTERNAL SWIFT_LIBRARY_VISIBILITY
 #endif
 
+// Used when declaring functions in a static compatibility library
+#if defined(__cplusplus)
+#define SWIFT_RUNTIME_COMPATIBILITY extern "C" SWIFT_LIBRARY_VISIBILITY
+#else
+#define SWIFT_RUNTIME_COMPATIBILITY SWIFT_LIBRARY_VISIBILITY
+#endif
+
 #if __has_builtin(__builtin_expect)
 #define SWIFT_LIKELY(expression) (__builtin_expect(!!(expression), 1))
 #define SWIFT_UNLIKELY(expression) (__builtin_expect(!!(expression), 0))

--- a/stdlib/toolchain/CompatibilityPacks/Metadata.cpp
+++ b/stdlib/toolchain/CompatibilityPacks/Metadata.cpp
@@ -15,6 +15,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#define SWIFT_COMPATIBILITY_PACKS 1
+
 #include "../../public/runtime/MetadataCache.h"
 
 using namespace swift;
@@ -129,7 +131,7 @@ PackCacheEntry<PackType>::PackCacheEntry(
 static SimpleGlobalCache<PackCacheEntry<Metadata>,
                          MetadataPackTag> MetadataPacks;
 
-SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
+SWIFT_RUNTIME_COMPATIBILITY SWIFT_CC(swift)
 const Metadata * const *
 swift_allocateMetadataPack(const Metadata * const *ptr, size_t count) {
   if (MetadataPackPointer(reinterpret_cast<uintptr_t>(ptr)).getLifetime()
@@ -147,7 +149,7 @@ swift_allocateMetadataPack(const Metadata * const *ptr, size_t count) {
 static SimpleGlobalCache<PackCacheEntry<WitnessTable>,
                          WitnessTablePackTag> WitnessTablePacks;
 
-SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
+SWIFT_RUNTIME_COMPATIBILITY SWIFT_CC(swift)
 const WitnessTable * const *
 swift_allocateWitnessTablePack(const WitnessTable * const *ptr, size_t count) {
   if (WitnessTablePackPointer(reinterpret_cast<uintptr_t>(ptr)).getLifetime()


### PR DESCRIPTION
Mark the symbols in libswiftCompatibilityPacks.a as hidden.

rdar://169305717
