### PR TITLE
Detect and error for nested each expressions

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6406,6 +6406,12 @@ ERROR(pack_reference_outside_expansion,none,
 ERROR(each_non_pack,none,
       "'each' cannot be applied to non-pack type %0",
       (Type))
+ERROR(nested_each_not_allowed,none,
+      "'each' cannot be applied to an expression containing 'each'",
+      ())
+NOTE(note_inner_each,none,
+      "inner 'each' applied here",
+      ())
 ERROR(pack_reference_must_be_in_expansion,none,
       "pack reference %0 requires expansion using keyword 'repeat'",
       (TypeRepr*))

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -440,6 +440,9 @@ enum class FixKind : uint8_t {
   /// Allow 'each' applied to a non-pack type.
   AllowInvalidPackElement,
 
+  // Allow 'each' applied to an expression containing another 'each'.
+  AllowPackElementWithNesting,
+
   /// Allow pack references outside of pack expansions.
   AllowInvalidPackReference,
 
@@ -2207,6 +2210,35 @@ public:
 
   static bool classof(const ConstraintFix *fix) {
     return fix->getKind() == FixKind::AllowInvalidPackElement;
+  }
+};
+
+class AllowPackElementWithNesting final : public ConstraintFix {
+  PackElementExpr *innerPackElement;
+
+  AllowPackElementWithNesting(ConstraintSystem &cs,
+                              PackElementExpr *innerPackElement,
+                              ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::AllowPackElementWithNesting, locator),
+        innerPackElement(innerPackElement) {}
+
+public:
+  std::string getName() const override {
+    return "allow pack element with nested 'each'";
+  }
+
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
+
+  bool coalesceAndDiagnose(const Solution &solution,
+                           ArrayRef<ConstraintFix *> fixes,
+                           bool asNote = false) const override;
+
+  static AllowPackElementWithNesting *create(ConstraintSystem &cs,
+                                             PackElementExpr *innerPackElement,
+                                             ConstraintLocator *locator);
+
+  static bool classof(const ConstraintFix *fix) {
+    return fix->getKind() == FixKind::AllowPackElementWithNesting;
   }
 };
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6604,6 +6604,13 @@ bool InvalidPackElement::diagnoseAsError() {
   return true;
 }
 
+bool PackElementWithNesting::diagnoseAsError() {
+  emitDiagnostic(diag::nested_each_not_allowed);
+  for (PackElementExpr *innerPackElement : innerPackElements)
+    emitDiagnosticAt(innerPackElement->getLoc(), diag::note_inner_each);
+  return true;
+}
+
 bool InvalidPackReference::diagnoseAsError() {
   auto patternType =
       getPatternTypeOfSingleUnlabeledPackExpansionTuple(packType);

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2010,6 +2010,22 @@ public:
   bool diagnoseAsError() override;
 };
 
+/// Diagnose \c each applied to a pack that contains another \c each applied
+/// pack as a sub-expression.
+class PackElementWithNesting final : public FailureDiagnostic {
+  llvm::SmallVector<PackElementExpr *, 4> innerPackElements;
+
+public:
+  PackElementWithNesting(
+      const Solution &solution,
+      llvm::SmallVector<PackElementExpr *, 4> innerPackElements,
+      ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator),
+        innerPackElements(innerPackElements) {}
+
+  bool diagnoseAsError() override;
+};
+
 /// Diagnose pack references outside of pack expansion expressions.
 class InvalidPackReference final : public FailureDiagnostic {
   Type packType;

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -358,6 +358,9 @@ namespace {
     /// A stack of pack expansions that can open pack elements.
     llvm::SmallVector<PackExpansionExpr *, 1> OuterExpansions;
 
+    /// A stack of pack elements to diagnose illegal nesting.
+    llvm::SmallVector<PackElementExpr *, 1> PackElements;
+
     /// Returns false and emits the specified diagnostic if the member reference
     /// base is a nil literal. Returns true otherwise.
     bool isValidBaseOfMemberRef(Expr *base, Diag<> diagnostic) {
@@ -703,6 +706,10 @@ namespace {
 
       auto expansionType = PackExpansionType::get(patternType, shapeTypeVar);
       CS.setType(expr, expansionType);
+    }
+
+    void pushPackElementExpr(PackElementExpr *expr) {
+      PackElements.push_back(expr);
     }
 
     /// Records a fix for an invalid AST node, and returns a hole for it.
@@ -2772,6 +2779,22 @@ namespace {
       auto *packExpansion = CS.getPackElementExpansion(expr);
       auto elementType = openPackElement(
           packType, CS.getConstraintLocator(expr), packExpansion);
+
+      // This pack element should have been pushed before visit was called.
+      assert(PackElements.size() > 0 &&
+             "Pack element being visited should be in PackElements");
+      PackElements.pop_back();
+
+      // This expression is a sub-expression of another PackElementExpr if there
+      // are still elements on the stack.
+      if (!PackElements.empty()) {
+        PackElementExpr *outerPackElement = PackElements.back();
+        PackElementExpr *innerPackElement = expr;
+
+        CS.recordFix(AllowPackElementWithNesting::create(
+            CS, innerPackElement, CS.getConstraintLocator(outerPackElement)));
+      }
+
       if (packExpansion) {
         auto expansionType =
             CS.getType(packExpansion)->castTo<PackExpansionType>();
@@ -3851,6 +3874,10 @@ namespace {
 
       if (auto *expansion = dyn_cast<PackExpansionExpr>(expr)) {
         CG.pushPackExpansionExpr(expansion);
+      }
+
+      if (auto *element = dyn_cast<PackElementExpr>(expr)) {
+        CG.pushPackElementExpr(element);
       }
 
       return Action::Continue(expr);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -15886,6 +15886,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::NotCompileTimeLiteral:
   case FixKind::RenameConflictingPatternVariables:
   case FixKind::AllowInvalidPackElement:
+  case FixKind::AllowPackElementWithNesting:
   case FixKind::AllowInvalidPackReference:
   case FixKind::AllowInvalidPackExpansion:
   case FixKind::IgnoreWhereClauseInPackIteration:


### PR DESCRIPTION
This PR adds a new fix for an each expression that contains another each as a nested subexpression.

This means the following code gets an error, instead of crashing the compiler:

```swift
struct G<each T> {
    func f<U, V>(_: U, _: V) -> (repeat each T) {}
    
    func g(t: repeat each T, u: repeat each T) {
        let _ = (repeat each f(each t, each u))
    }
}
```
```
error: 'each' cannot be applied to an expression containing 'each'
 3 |
 4 |     func g(t: repeat each T, u: repeat each T) {
 5 |         let _ = (repeat each f(each t, each u))
   |                         |      |       `- note: inner 'each' applied here
   |                         |      `- note: inner 'each' applied here
   |                         `- error: 'each' cannot be applied to an expression containing 'each'
 6 |     }
 7 | }
```

In some cases the arms are drawn wrong, but that issue isn't limited to this change and seems to be an issue with errors at the location of 'each' in general, so I've opened a separate issue for that: https://github.com/swiftlang/swift/issues/87173

In every case I could come up with, removing the outer each was a somewhat reasonable fix-it, since you can't use each to flatten the returned tuple of a function, but I wasn't confident that wouldn't be a reach in some cases, and it sometimes just leads to a different error. Very open to adding it though--it would be appropriate in the example I give in this description for example. All the cases I am aware of use a type parameter pack on a struct, and use 'each' on a method that returns this pack within a tuple, which won't actually flatten / expand that tuple, but also won't get flagged as being invalid use of 'each' since it does return a pack. We allow this today, although you don't get any different behavior than omitting it:

This doesn't cover cases with repeat in the parameter of a repeated closure, since I think it makes sense to address this in a separate PR (https://github.com/swiftlang/swift/issues/87262):

```swift
func foo<each T>(_ t: repeat each T) {
	repeat ({(arg: repeat each T) in
		each arg
	}())
}
```

This change adds another error to the already unfortunate case where a pack of functions is applied and needs parens (https://github.com/swiftlang/swift/issues/87223), but I'd like to address this with a specialized error in another PR:
```swift
    func bar<each I, each O>(a: repeat each I, f: repeat (each I) -> each O) -> (repeat each O) {
      return (repeat each f(each a));
      // expected-error@-1 {{'each' cannot be applied to non-pack type 'τ_1_1'}}
      // expected-error@-2 {{value pack '(each I) -> each O' must be referenced with 'each'}}
      // expected-error@-3 {{'each' cannot be applied to an expression containing 'each'}}
      // expected-note@-4 {{inner 'each' applied here}}
    }
```