### PR TITLE
Improve compatibility between swift::version::Version and llvm::Versi…

### DIFF
--- a/include/swift/Basic/Version.h
+++ b/include/swift/Basic/Version.h
@@ -92,8 +92,7 @@ public:
     return Components.empty();
   }
 
-  /// Convert to a (maximum-4-element) llvm::VersionTuple, truncating
-  /// away any 5th component that might be in this version.
+  /// Convert to an llvm::VersionTuple.
   operator llvm::VersionTuple() const;
 
   /// Returns the concrete version to use when \e this version is provided as

--- a/lib/Basic/Version.cpp
+++ b/lib/Basic/Version.cpp
@@ -112,6 +112,9 @@ Version::Version(const llvm::VersionTuple &version) {
       Components.emplace_back(*subminor);
       if (auto build = version.getBuild()) {
         Components.emplace_back(*build);
+        if (auto subbuild = version.getSubbuild()) {
+          Components.emplace_back(*subbuild);
+        }
       }
     }
   }
@@ -132,11 +135,14 @@ Version::operator llvm::VersionTuple() const
                               (unsigned)Components[1],
                               (unsigned)Components[2]);
  case 4:
- case 5:
    return llvm::VersionTuple((unsigned)Components[0],
                               (unsigned)Components[1],
                               (unsigned)Components[2],
                               (unsigned)Components[3]);
+ case 5:
+   return llvm::VersionTuple((unsigned)Components[0], (unsigned)Components[1],
+                             (unsigned)Components[2], (unsigned)Components[3],
+                             (unsigned)Components[4]);
  default:
    llvm_unreachable("swift::version::Version with 6 or more components");
   }

--- a/unittests/Basic/CMakeLists.txt
+++ b/unittests/Basic/CMakeLists.txt
@@ -42,6 +42,7 @@ add_swift_unittest(SwiftBasicTests
   TransformRangeTest.cpp
   TypeLookupError.cpp
   UnicodeTest.cpp
+  SwiftVersionTest.cpp
   ${generated_tests}
   )
 

--- a/unittests/Basic/SwiftVersionTest.cpp
+++ b/unittests/Basic/SwiftVersionTest.cpp
@@ -1,0 +1,38 @@
+//===--- SwiftVersionTest.cpp ---------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Basic/Version.h"
+#include "gtest/gtest.h"
+
+namespace {
+
+TEST(SwiftVersion, Interop) {
+  ASSERT_EQ((llvm::VersionTuple)swift::version::Version(),
+            llvm::VersionTuple());
+  ASSERT_EQ((llvm::VersionTuple)swift::version::Version({1}),
+            llvm::VersionTuple(1));
+  ASSERT_EQ((llvm::VersionTuple)swift::version::Version({1, 2}),
+            llvm::VersionTuple(1, 2));
+  ASSERT_EQ((llvm::VersionTuple)swift::version::Version({1, 2, 3}),
+            llvm::VersionTuple(1, 2, 3));
+  ASSERT_EQ((llvm::VersionTuple)swift::version::Version({1, 2, 3, 4}),
+            llvm::VersionTuple(1, 2, 3, 4));
+  ASSERT_EQ((llvm::VersionTuple)swift::version::Version({1, 2, 3, 4, 5}),
+            llvm::VersionTuple(1, 2, 3, 4, 5));
+
+  ASSERT_NE((llvm::VersionTuple)swift::version::Version({1, 2, 3, 4, 5}),
+            llvm::VersionTuple(1, 2, 3, 4, 6));
+  ASSERT_NE((llvm::VersionTuple)swift::version::Version({1, 2, 3, 4, 5}),
+            llvm::VersionTuple(1, 2, 3, 4));
+}
+
+} // namespace


### PR DESCRIPTION
…onTuple

llvm::VersionTuple now also supports 5-component versions; this patch removes the limitation of stripping the last component when converting from a swift::version::Version to an llvm::VersionTuple. This fixes a bug in LLDB's Swift version compatibility warning.

rdar://170181060

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
