### PR TITLE
[ASTDumper] always label ForEachStmt's desugared BraceStmt

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3368,7 +3368,7 @@ public:
 
     printRec(S->getBody(), Label::optional("body"));
 
-    printRec(S->getCachedDesugaredStmt(), Label::optional("desugared_loop"));
+    printRec(S->getCachedDesugaredStmt(), Label::always("desugared_loop"));
 
     printFoot();
   }


### PR DESCRIPTION
Resolves rdar://170494821

This PR ensures that we always label  the Desugared counterpart of a ForEachStmt as "desugared_loop". This makes the output of -dump-ast much clearer as the BraceStmt will not be mistaken for a child of the original ForEachStmt.