### PR TITLE
Rename SwiftSyntax experimental SPI to ExperimentalLanguageFeatures to unify naming

### DIFF
--- a/lib/ASTGen/Sources/MacroEvaluation/Macros.swift
+++ b/lib/ASTGen/Sources/MacroEvaluation/Macros.swift
@@ -12,12 +12,12 @@
 
 import ASTBridging
 import BasicBridging
-@_spi(PluginMessage) @_spi(ExperimentalLanguageFeature) import SwiftCompilerPluginMessageHandling
+@_spi(PluginMessage) @_spi(ExperimentalLanguageFeatures) import SwiftCompilerPluginMessageHandling
 import SwiftDiagnostics
 import SwiftIfConfig
 import SwiftParser
 import SwiftSyntax
-@_spi(ExperimentalLanguageFeature) @_spi(Compiler) import SwiftSyntaxMacroExpansion
+@_spi(ExperimentalLanguageFeatures) @_spi(Compiler) import SwiftSyntaxMacroExpansion
 import swiftASTGen
 
 struct ExportedExternalMacro {

--- a/test/CAS/cached_diagnostics_macro.swift
+++ b/test/CAS/cached_diagnostics_macro.swift
@@ -58,7 +58,7 @@ import SwiftDiagnostics
 import SwiftOperators
 import SwiftSyntax
 import SwiftSyntaxBuilder
-@_spi(ExperimentalLanguageFeature) import SwiftSyntaxMacros
+@_spi(ExperimentalLanguageFeatures) import SwiftSyntaxMacros
 
 public struct CallDeprecatedMacro: ExpressionMacro {
    public static func expansion(

--- a/test/CAS/macro_deps.swift
+++ b/test/CAS/macro_deps.swift
@@ -48,7 +48,7 @@
 
 //--- macro-1.swift
 import SwiftSyntax
-@_spi(ExperimentalLanguageFeature) import SwiftSyntaxMacros
+@_spi(ExperimentalLanguageFeatures) import SwiftSyntaxMacros
 
 public struct AssertMacro: ExpressionMacro {
   public static func expansion(
@@ -65,7 +65,7 @@ public struct AssertMacro: ExpressionMacro {
 
 //--- macro-2.swift
 import SwiftSyntax
-@_spi(ExperimentalLanguageFeature) import SwiftSyntaxMacros
+@_spi(ExperimentalLanguageFeatures) import SwiftSyntaxMacros
 
 public struct StringifyMacro: ExpressionMacro {
   public static func expansion(

--- a/test/Concurrency/default_mainactor_isolation_cross_module.swift
+++ b/test/Concurrency/default_mainactor_isolation_cross_module.swift
@@ -29,7 +29,7 @@
 import SwiftOperators
 @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
 import SwiftSyntaxBuilder
-@_spi(ExperimentalLanguageFeature) import SwiftSyntaxMacros
+@_spi(ExperimentalLanguageFeatures) import SwiftSyntaxMacros
 
 public struct AddConformanceMacro: ExtensionMacro {
   public static func expansion(

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -2,7 +2,7 @@ import SwiftDiagnostics
 import SwiftOperators
 @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
 import SwiftSyntaxBuilder
-@_spi(ExperimentalLanguageFeature) import SwiftSyntaxMacros
+@_spi(ExperimentalLanguageFeatures) import SwiftSyntaxMacros
 
 /// Replace the label of the first element in the tuple with the given
 /// new label.
@@ -2662,7 +2662,6 @@ extension FunctionParameterSyntax {
   }
 }
 
-@_spi(ExperimentalLanguageFeature)
 public struct RemoteBodyMacro: BodyMacro {
   public static func expansion(
     of node: AttributeSyntax,
@@ -2701,7 +2700,6 @@ public struct RemoteBodyMacro: BodyMacro {
   }
 }
 
-@_spi(ExperimentalLanguageFeature)
 public struct BodyMacroWithControlFlow: BodyMacro {
   public static func expansion(
     of node: AttributeSyntax,
@@ -2743,7 +2741,7 @@ struct EmptyBodyMacro: BodyMacro {
   }
 }
 
-@_spi(ExperimentalLanguageFeature)
+@_spi(ExperimentalLanguageFeatures)
 public struct TracedPreambleMacro: PreambleMacro {
   public static func expansion(
     of node: AttributeSyntax,
@@ -2784,7 +2782,7 @@ public struct TracedPreambleMacro: PreambleMacro {
   }
 }
 
-@_spi(ExperimentalLanguageFeature)
+@_spi(ExperimentalLanguageFeatures)
 public struct LoggerMacro: PreambleMacro {
   public static func expansion(
     of node: AttributeSyntax,

--- a/test/Serialization/external_macros.swift
+++ b/test/Serialization/external_macros.swift
@@ -24,7 +24,7 @@
 
 //--- macro-1.swift
 import SwiftSyntax
-@_spi(ExperimentalLanguageFeature) import SwiftSyntaxMacros
+@_spi(ExperimentalLanguageFeatures) import SwiftSyntaxMacros
 
 public struct AssertMacro: ExpressionMacro {
   public static func expansion(
@@ -41,7 +41,7 @@ public struct AssertMacro: ExpressionMacro {
 
 //--- macro-2.swift
 import SwiftSyntax
-@_spi(ExperimentalLanguageFeature) import SwiftSyntaxMacros
+@_spi(ExperimentalLanguageFeatures) import SwiftSyntaxMacros
 
 public struct StringifyMacro: ExpressionMacro {
   public static func expansion(

--- a/test/Serialization/plugin_search_option_prefixing.swift
+++ b/test/Serialization/plugin_search_option_prefixing.swift
@@ -23,7 +23,7 @@
 
 //--- macro-1.swift
 import SwiftSyntax
-@_spi(ExperimentalLanguageFeature) import SwiftSyntaxMacros
+@_spi(ExperimentalLanguageFeatures) import SwiftSyntaxMacros
 
 public struct AssertMacro: ExpressionMacro {
   public static func expansion(
@@ -40,7 +40,7 @@ public struct AssertMacro: ExpressionMacro {
 
 //--- macro-2.swift
 import SwiftSyntax
-@_spi(ExperimentalLanguageFeature) import SwiftSyntaxMacros
+@_spi(ExperimentalLanguageFeatures) import SwiftSyntaxMacros
 
 public struct StringifyMacro: ExpressionMacro {
   public static func expansion(


### PR DESCRIPTION
Replaces the other ExperimentalLanguageFeature (non-plural) SPI usages with the plural version.
Also removes the `@_spi` flag from BodyMacroWithControlFlow as body macros are no longer an experimental feature.
This is liked to a PR on swift-syntax: swiftlang/swift-syntax#3272

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
