### PR TITLE
[cxx-interop] Extract C++ iterator info in a request

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -947,6 +947,17 @@ struct RefCountedPtrRequestResult {
 
 RefCountedPtrRequestResult
 getClangRefCountedSmartPointer(NominalTypeDecl *decl);
+
+/// Iterator categories, based on the std iterator tags
+enum class CxxIteratorCategory {
+  // Output,
+  Input = 1,
+  // Forward,
+  // Bidirectional,
+  RandomAccess,
+  Contiguous,
+};
+
 } // namespace importer
 
 /// On Linux, some platform libraries (glibc, libstdc++) are not modularized.

--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -713,6 +713,54 @@ private:
            ClangRefCountedSmartPointerDescriptor desc) const;
 };
 
+/// Input type for requests that act upon a (defined) C++ record decl.
+struct CxxRecordDeclDescriptor final {
+  const clang::CXXRecordDecl *decl;
+  clang::Sema &sema;
+
+  CxxRecordDeclDescriptor(const clang::CXXRecordDecl *decl, clang::Sema &sema)
+      : decl(decl), sema(sema) {
+    ASSERT(decl->hasDefinition());
+  }
+
+  friend llvm::hash_code
+  hash_value(const CxxRecordDeclDescriptor &desc) {
+    return llvm::hash_combine(desc.decl);
+  }
+
+  friend bool operator==(const CxxRecordDeclDescriptor &lhs,
+                         const CxxRecordDeclDescriptor &rhs) {
+    return lhs.decl == rhs.decl;
+  }
+
+  friend bool operator!=(const CxxRecordDeclDescriptor &lhs,
+                         const CxxRecordDeclDescriptor &rhs) {
+    return !(lhs == rhs);
+  }
+};
+
+void simple_display(llvm::raw_ostream &out,
+                    const CxxRecordDeclDescriptor &desc);
+SourceLoc
+extractNearestSourceLoc(const CxxRecordDeclDescriptor &desc);
+
+/// Uses ClangDirectLookup to find a named member inside of the given namespace.
+class CxxIteratorInfoRequest
+    : public SimpleRequest<CxxIteratorInfoRequest,
+                           std::optional<importer::CxxIteratorCategory>(
+                               CxxRecordDeclDescriptor),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+  bool isCached() const { return true; }
+
+private:
+  friend SimpleRequest;
+
+  std::optional<importer::CxxIteratorCategory>
+  evaluate(Evaluator &evaluator, CxxRecordDeclDescriptor desc) const;
+};
+
 #define SWIFT_TYPEID_ZONE ClangImporter
 #define SWIFT_TYPEID_HEADER "swift/ClangImporter/ClangImporterTypeIDZone.def"
 #include "swift/Basic/DefineTypeIDZone.h"

--- a/include/swift/ClangImporter/ClangImporterTypeIDZone.def
+++ b/include/swift/ClangImporter/ClangImporterTypeIDZone.def
@@ -54,3 +54,6 @@ SWIFT_REQUEST(ClangImporter, ClangDeclExplicitSafety,
 SWIFT_REQUEST(ClangImporter, ClangRefCountedSmartPointer,
               RefCountedPtrRequestResult(ClangRefCountedSmartPointerDescriptor),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(ClangImporter, CxxIteratorInfoRequest,
+              std::optional<CxxIteratorCategory>(CxxRecordDeclDescriptor),
+              Cached, NoLocationInfo)

--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -870,8 +870,6 @@ conformToCxxSequenceIfNeeded(ClangImporter::Implementation &impl,
       ctx.getProtocol(KnownProtocolKind::UnsafeCxxInputIterator);
   ProtocolDecl *cxxSequenceProto =
       ctx.getProtocol(KnownProtocolKind::CxxSequence);
-  ProtocolDecl *cxxConvertibleProto =
-      ctx.getProtocol(KnownProtocolKind::CxxConvertibleToCollection);
   // If the Cxx module is missing, or does not include one of the necessary
   // protocols, bail.
   if (!cxxIteratorProto || !cxxSequenceProto)
@@ -1029,6 +1027,8 @@ conformToCxxSequenceIfNeeded(ClangImporter::Implementation &impl,
   // copy of the sequence's elements) by conforming the type to
   // CxxCollectionConvertible. This enables an overload of Array.init declared
   // in the Cxx module.
+  ProtocolDecl *cxxConvertibleProto =
+      ctx.getProtocol(KnownProtocolKind::CxxConvertibleToCollection);
   if (!conformedToRAC && cxxConvertibleProto) {
     impl.addSynthesizedProtocolAttrs(
         decl, {KnownProtocolKind::CxxConvertibleToCollection});

--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -74,23 +74,22 @@ lookupCxxTypeMember(clang::Sema &Sema, const clang::CXXRecordDecl *Rec,
   R.suppressDiagnostics();
   Sema.LookupQualifiedName(R, const_cast<clang::CXXRecordDecl *>(Rec));
 
-  if (auto *td = R.getAsSingle<clang::TypeDecl>()) {
-    if (auto *paths = R.getBasePaths()) {
-      // For inherited type member, check access of the single CXXBasePath
-      if (paths->front().Access != clang::AS_public)
-        return nullptr;
-    } else {
-      // For direct (non-inherited) type member, check its access directly
-      if (td->getAccess() != clang::AS_public)
-        return nullptr;
-    }
+  if (!R.isSingleResult())
+    return nullptr; // Result was absent or ambiguous
 
-    if (mustBeComplete &&
-        !Sema.isCompleteType({}, td->getASTContext().getTypeDeclType(td)))
-      return nullptr;
-    return td;
-  }
-  return nullptr;
+  auto it = R.begin();
+  if (it->getAccess() != clang::AS_public)
+    return nullptr; // Not accessible from outside of the class
+
+  auto *td = dyn_cast<clang::TypeDecl>(it.getDecl());
+  if (!td)
+    return nullptr; // Was not a clang::TypeDecl
+
+  if (mustBeComplete &&
+      !Sema.isCompleteType({}, td->getASTContext().getTypeDeclType(td)))
+    return nullptr;
+
+  return td;
 }
 
 /// Alternative to `NominalTypeDecl::lookupDirect`.

--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -13,20 +13,27 @@
 #include "ClangDerivedConformances.h"
 #include "ImporterImpl.h"
 #include "swift/AST/ConformanceLookup.h"
+#include "swift/AST/KnownProtocols.h"
 #include "swift/AST/LayoutConstraint.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/ClangImporter/ClangImporter.h"
 #include "swift/ClangImporter/ClangImporterRequests.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/CXXInheritance.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclCXX.h"
+#include "clang/AST/DeclTemplate.h"
 #include "clang/AST/Type.h"
+#include "clang/Basic/Specifiers.h"
 #include "clang/Sema/DelayedDiagnostic.h"
 #include "clang/Sema/Lookup.h"
 #include "clang/Sema/Overload.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringSwitch.h"
 
 using namespace swift;
 using namespace swift::importer;
@@ -424,6 +431,129 @@ static bool synthesizeCXXOperator(ClangImporter::Implementation &impl,
   return true;
 }
 
+void swift::simple_display(llvm::raw_ostream &out,
+                           const CxxRecordDeclDescriptor &desc) {
+  out << "Inferring C++ iterator info for '";
+  if (desc.decl->getIdentifier())
+    out << desc.decl->getName();
+  else if (desc.decl->isAnonymousStructOrUnion())
+    out << "(anonymous record)";
+  else
+    out << "(unnamed record)";
+  out << "'\n";
+}
+
+SourceLoc
+swift::extractNearestSourceLoc(const CxxRecordDeclDescriptor &desc) {
+  return SourceLoc();
+}
+
+static std::optional<CxxIteratorCategory>
+categorizeIteratorFromTypeTag(const clang::TypeDecl *tyDecl) {
+
+  const clang::CXXRecordDecl *underlyingDecl = nullptr;
+  if (auto typedefDecl = dyn_cast<clang::TypedefNameDecl>(tyDecl))
+    // Typical case: `using iterator_tag = some_tag;`
+    underlyingDecl = typedefDecl->getUnderlyingType()
+                         .getCanonicalType()
+                         ->getAsCXXRecordDecl();
+  else
+    // Less common: `struct iterator_tag : some_tag {};`
+    underlyingDecl = dyn_cast<clang::CXXRecordDecl>(tyDecl);
+
+  if (underlyingDecl)
+    underlyingDecl = underlyingDecl->getDefinition();
+  if (!underlyingDecl)
+    return {};
+
+  std::optional<CxxIteratorCategory> category = std::nullopt;
+
+  // In the easiest case, the underlyingDecl is the iterator category tag from
+  // the std namespace, but it might also be some record that inherits from one
+  // of the std iterator tags. Look through all of its (public) bases and find
+  // the strongest iterator category.
+
+  llvm::SmallVector<const clang::CXXRecordDecl *, 2> queue;
+  queue.push_back(underlyingDecl);
+
+  while (!queue.empty()) {
+    auto *decl = queue.back();
+    queue.pop_back();
+
+    auto matchedTag = false;
+    if (decl->isInStdNamespace() && decl->getIdentifier()) {
+      auto declCategory =
+          llvm::StringSwitch<std::optional<CxxIteratorCategory>>(
+              decl->getName())
+              .Case("input_iterator_tag", CxxIteratorCategory::Input)
+              .Case("random_access_iterator_tag",
+                    CxxIteratorCategory::RandomAccess)
+              .Case("contiguous_iterator_tag", CxxIteratorCategory::Contiguous)
+              .Default(std::nullopt);
+
+      if (declCategory.has_value()) {
+        matchedTag = true;
+
+        if (!category.has_value() || category.value() < declCategory.value())
+          // This is one of the std category tags, and is stronger than what
+          // we've previously seen
+          category = declCategory;
+      }
+    }
+
+    if (!matchedTag) {
+      // We only need to explore bases if this isn't a std iterator category tag
+      for (auto base : decl->bases()) {
+        if (base.getAccessSpecifier() != clang::AS_public)
+          // Simply skip over any non-public base
+          continue;
+
+        auto *ty = base.getType()->getAs<clang::RecordType>();
+        if (!ty)
+          // Bail if we encounter some kind of base that isn't a record type
+          return {};
+
+        auto *baseDecl = dyn_cast_or_null<clang::CXXRecordDecl>(
+            ty->getDecl()->getDefinition());
+        if (!baseDecl || (baseDecl->isDependentContext() &&
+                          !baseDecl->isCurrentInstantiation(decl)))
+          // Bail if we encounter a base that isn't a defined C++ record
+          return {};
+
+        // Look at this base later
+        queue.push_back(baseDecl);
+      }
+    }
+  }
+  return category;
+}
+
+std::optional<CxxIteratorCategory>
+CxxIteratorInfoRequest::evaluate(Evaluator &evaluator,
+                                 CxxRecordDeclDescriptor desc) const {
+  auto *decl = desc.decl;
+  auto &sema = desc.sema;
+
+  if (sema.getLangOpts().CPlusPlus20) {
+    // Only look for iterator_concept if we are using C++20 or above.
+    auto *conceptDecl = lookupCxxTypeMember(sema, decl, "iterator_concept");
+    if (conceptDecl)
+      return categorizeIteratorFromTypeTag(conceptDecl);
+
+    // iterator_concept should take precedence, but if it is absent, fallback
+    // to iterator_category.
+  }
+
+  if (auto *categoryDecl = lookupCxxTypeMember(sema, decl, "iterator_category")) {
+    auto info = categorizeIteratorFromTypeTag(categoryDecl);
+    if (info == CxxIteratorCategory::Contiguous)
+      info = CxxIteratorCategory::RandomAccess;
+    return info;
+  }
+
+  return {};
+}
+
 bool swift::hasIteratorCategory(const clang::CXXRecordDecl *clangDecl) {
   clang::IdentifierInfo *name =
       &clangDecl->getASTContext().Idents.get("iterator_category");
@@ -464,115 +594,42 @@ static void
 conformToCxxIteratorIfNeeded(ClangImporter::Implementation &impl,
                              NominalTypeDecl *decl,
                              const clang::CXXRecordDecl *clangDecl) {
+  static_assert(
+      CxxIteratorCategory::Input < CxxIteratorCategory::RandomAccess &&
+      CxxIteratorCategory::RandomAccess < CxxIteratorCategory::Contiguous);
+
   PrettyStackTraceDecl trace("trying to conform to UnsafeCxxInputIterator", decl);
   ASTContext &ctx = decl->getASTContext();
   clang::ASTContext &clangCtx = clangDecl->getASTContext();
   clang::Sema &clangSema = impl.getClangSema();
 
-  if (!ctx.getProtocol(KnownProtocolKind::UnsafeCxxInputIterator))
+  if (!ctx.getProtocol(KnownProtocolKind::UnsafeCxxInputIterator) ||
+      !ctx.getProtocol(KnownProtocolKind::UnsafeCxxMutableInputIterator))
+    return; // Don't even bother if we don't have protocols for input iterators
+
+  // FIXME: hasIteratorCategory() is more conservative than it should be because
+  // it doesn't consider an inherited iterator_category, nor iterator_concept.
+  // For now, checking this maintains existing behavior and ensures consistency
+  // across ClangImporter, where clang::Sema isn't always readily available.
+
+  auto iterInfo = evaluateOrDefault(
+      ctx.evaluator, CxxIteratorInfoRequest({clangDecl, clangSema}), {});
+
+  if (!iterInfo.has_value())
     return;
 
-  // We consider a type to be an input iterator if it defines an
-  // `iterator_category` that inherits from `std::input_iterator_tag`, e.g.
-  // `using iterator_category = std::input_iterator_tag`.
-  //
-  // FIXME: The second hasIteratorCategory() is more conservative than it should
-  // be  because it doesn't consider things like inheritance, but checking this
-  // here maintains existing behavior and ensures consistency across
-  // ClangImporter, where clang::Sema isn't always readily available.
-  const auto *iteratorCategory =
-      lookupCxxTypeMember(clangSema, clangDecl, "iterator_category");
-  if (!iteratorCategory || !hasIteratorCategory(clangDecl))
-    return;
+  auto category = iterInfo.value();
+  ASSERT(category >= CxxIteratorCategory::Input);
 
-  auto unwrapUnderlyingTypeDecl =
-      [](const clang::TypeDecl *typeDecl) -> const clang::CXXRecordDecl * {
-    const clang::CXXRecordDecl *underlyingDecl = nullptr;
-    if (auto typedefDecl = dyn_cast<clang::TypedefNameDecl>(typeDecl)) {
-      auto type = typedefDecl->getUnderlyingType();
-      underlyingDecl = type->getAsCXXRecordDecl();
-    } else {
-      underlyingDecl = dyn_cast<clang::CXXRecordDecl>(typeDecl);
-    }
-    if (underlyingDecl) {
-      underlyingDecl = underlyingDecl->getDefinition();
-    }
-    return underlyingDecl;
-  };
-
-  // If `iterator_category` is a typedef or a using-decl, retrieve the
-  // underlying struct decl.
-  auto underlyingCategoryDecl = unwrapUnderlyingTypeDecl(iteratorCategory);
-  if (!underlyingCategoryDecl)
-    return;
-
-  auto isIteratorTagDecl = [&](const clang::CXXRecordDecl *base,
-                               StringRef tag) {
-    return base->isInStdNamespace() && base->getIdentifier() &&
-           base->getName() == tag;
-  };
-  auto isInputIteratorDecl = [&](const clang::CXXRecordDecl *base) {
-    return isIteratorTagDecl(base, "input_iterator_tag");
-  };
-  auto isRandomAccessIteratorDecl = [&](const clang::CXXRecordDecl *base) {
-    return isIteratorTagDecl(base, "random_access_iterator_tag");
-  };
-  auto isContiguousIteratorDecl = [&](const clang::CXXRecordDecl *base) {
-    return isIteratorTagDecl(base, "contiguous_iterator_tag"); // C++20
-  };
-
-  // Traverse all transitive bases of `underlyingDecl` to check if
-  // it inherits from `std::input_iterator_tag`.
-  bool isInputIterator = isInputIteratorDecl(underlyingCategoryDecl);
-  bool isRandomAccessIterator =
-      isRandomAccessIteratorDecl(underlyingCategoryDecl);
-  underlyingCategoryDecl->forallBases([&](const clang::CXXRecordDecl *base) {
-    if (isInputIteratorDecl(base)) {
-      isInputIterator = true;
-    }
-    if (isRandomAccessIteratorDecl(base)) {
-      isRandomAccessIterator = true;
-      isInputIterator = true;
-      return false;
-    }
-    return true;
-  });
-
-  if (!isInputIterator)
-    return;
-
-  bool isContiguousIterator = false;
-  // In C++20, `std::contiguous_iterator_tag` is specified as a type called
-  // `iterator_concept`. It is not possible to detect a contiguous iterator
-  // based on its `iterator_category`. The type might not have an
-  // `iterator_concept` defined.
-  if (const auto *iteratorConcept =
-          lookupCxxTypeMember(clangSema, clangDecl, "iterator_concept")) {
-    if (auto underlyingConceptDecl =
-            unwrapUnderlyingTypeDecl(iteratorConcept)) {
-      isContiguousIterator = isContiguousIteratorDecl(underlyingConceptDecl);
-      if (!isContiguousIterator)
-        underlyingConceptDecl->forallBases(
-            [&](const clang::CXXRecordDecl *base) {
-              if (isContiguousIteratorDecl(base)) {
-                isContiguousIterator = true;
-                return false;
-              }
-              return true;
-            });
-    }
-  }
+  // Input iterators require:
+  //   - operator*()  / .pointee
+  //   - operator++() / .successor()
+  //   - operator==() / func ==(lhs:rhs)
 
   auto *pointee = impl.lookupAndImportPointee(decl);
   if (!pointee || pointee->isGetterMutating() ||
       pointee->getTypeInContext()->hasError())
     return;
-
-  // Check if `var pointee: Pointee` is settable. This is required for the
-  // conformance to UnsafeCxxMutableInputIterator but is not necessary for
-  // UnsafeCxxInputIterator.
-  bool pointeeSettable = pointee->isSettable(nullptr);
-  Type pointeeTy = pointee->getTypeInContext();
 
   auto *successor = impl.lookupAndImportSuccessor(decl);
   if (!successor || successor->isMutating())
@@ -606,6 +663,8 @@ conformToCxxIteratorIfNeeded(ClangImporter::Implementation &impl,
   if (!equalEqual)
     return;
 
+  Type pointeeTy = pointee->getTypeInContext();
+
   // Look for __operatorStar(), which must be non-mutating and return a
   // reference. This makes sure we use the const operator* overload.
   auto operatorStar = getNonMutatingDereferenceOperator(decl);
@@ -627,18 +686,23 @@ conformToCxxIteratorIfNeeded(ClangImporter::Implementation &impl,
   impl.addSynthesizedTypealias(decl, ctx.getIdentifier("DereferenceResult"),
                                dereferenceResultTy);
 
-  if (pointeeSettable)
+  bool mutableIterator = pointee->isSettable(nullptr);
+
+  if (mutableIterator)
     impl.addSynthesizedProtocolAttrs(
         decl, {KnownProtocolKind::UnsafeCxxMutableInputIterator});
   else
     impl.addSynthesizedProtocolAttrs(
         decl, {KnownProtocolKind::UnsafeCxxInputIterator});
 
-  if (!isRandomAccessIterator ||
-      !ctx.getProtocol(KnownProtocolKind::UnsafeCxxRandomAccessIterator))
+  if (category < CxxIteratorCategory::RandomAccess ||
+      !ctx.getProtocol(KnownProtocolKind::UnsafeCxxRandomAccessIterator) ||
+      !ctx.getProtocol(KnownProtocolKind::UnsafeCxxMutableRandomAccessIterator))
     return;
 
-  // Try to conform to UnsafeCxxRandomAccessIterator if possible.
+  // Random access iterators additionally require:
+  //   - operator-()  / func -(lhs:rhs)
+  //   - operator+=() / func +=(lhs:rhs)
 
   // Check if present: `func -`
   auto minus = getMinusOperator(decl);
@@ -684,21 +748,26 @@ conformToCxxIteratorIfNeeded(ClangImporter::Implementation &impl,
     return;
 
   impl.addSynthesizedTypealias(decl, ctx.getIdentifier("Distance"), distanceTy);
-  if (pointeeSettable)
+  if (mutableIterator)
     impl.addSynthesizedProtocolAttrs(
         decl, {KnownProtocolKind::UnsafeCxxMutableRandomAccessIterator});
   else
     impl.addSynthesizedProtocolAttrs(
         decl, {KnownProtocolKind::UnsafeCxxRandomAccessIterator});
 
-  if (isContiguousIterator) {
-    if (pointeeSettable)
-      impl.addSynthesizedProtocolAttrs(
-          decl, {KnownProtocolKind::UnsafeCxxMutableContiguousIterator});
-    else
-      impl.addSynthesizedProtocolAttrs(
-          decl, {KnownProtocolKind::UnsafeCxxContiguousIterator});
-  }
+  if (category < CxxIteratorCategory::Contiguous ||
+      !ctx.getProtocol(KnownProtocolKind::UnsafeCxxContiguousIterator) ||
+      !ctx.getProtocol(KnownProtocolKind::UnsafeCxxMutableContiguousIterator))
+    return;
+
+  // Contiguous iterators do not have any additional requirements
+
+  if (mutableIterator)
+    impl.addSynthesizedProtocolAttrs(
+        decl, {KnownProtocolKind::UnsafeCxxMutableContiguousIterator});
+  else
+    impl.addSynthesizedProtocolAttrs(
+        decl, {KnownProtocolKind::UnsafeCxxContiguousIterator});
 }
 
 static void

--- a/test/Interop/Cxx/stdlib/overlay/Inputs/custom-iterator.h
+++ b/test/Interop/Cxx/stdlib/overlay/Inputs/custom-iterator.h
@@ -1300,4 +1300,158 @@ private:
       : ProtectedIteratorImpl<HasInheritedProtectedCopyConstructor>(other) {}
 };
 
+// A simple wrapper around a char * with all the operator members required of
+// a full-strength iterator.
+//
+// The template parameter U is only used to generate fresh type instances,
+// and just has to be any unique number. This helps us avoid re-defining this
+// same type repeatedly, while we create different explicit specializations of
+// std::iterator_traits<NewPtr<U>> to test.
+template <unsigned U>
+struct NewPtr {
+private:
+  char *ptr;
+  NewPtr(char *ptr) : ptr{ptr} {}
+
+public:
+  const char &operator*() const { return *ptr; }
+  char &operator*() { return *ptr; }
+  NewPtr &operator++() {
+    ++ptr;
+    return *this;
+  }
+  bool operator==(const NewPtr &other) const { return ptr == other.ptr; }
+  bool operator!=(const NewPtr &other) const { return ptr != other.ptr; }
+  bool operator<(const NewPtr &other) const { return ptr < other.ptr; }
+  NewPtr operator+(int v) const { return NewPtr{ptr + v}; }
+  int operator-(const NewPtr &other) const { return ptr - other.ptr; }
+  NewPtr operator-(int v) const { return NewPtr{ptr - v}; }
+  void operator+=(int v) { ptr += v; }
+  void operator-=(int v) { ptr -= v; }
+};
+
+struct NewPtrTraits {
+  // Everything except for iterator_category and iterator_concept
+  using difference_type = std::ptrdiff_t;
+  using value_type = char;
+  using pointer = char *;
+  using reference = char &;
+};
+
+using TaglessNewPtr = NewPtr<__LINE__>;
+
+using InputCategoryNewPtr = NewPtr<__LINE__>;
+template <> struct std::iterator_traits<InputCategoryNewPtr> : NewPtrTraits {
+  using iterator_category = std::input_iterator_tag;
+};
+
+using ForwardCategoryNewPtr = NewPtr<__LINE__>;
+template <> struct std::iterator_traits<ForwardCategoryNewPtr> : NewPtrTraits {
+  using iterator_category = std::forward_iterator_tag;
+};
+
+using RandomAccessCategoryNewPtr = NewPtr<__LINE__>;
+template <> struct std::iterator_traits<RandomAccessCategoryNewPtr> : NewPtrTraits {
+  using iterator_category = std::random_access_iterator_tag;
+};
+
+#if __cplusplus >= 202002L
+
+using ContiguousCategoryNewPtr = NewPtr<__LINE__>;
+template <> struct std::iterator_traits<ContiguousCategoryNewPtr> : NewPtrTraits {
+  using iterator_category = std::random_access_iterator_tag;
+  using iterator_concept = std::contiguous_iterator_tag;
+};
+
+using InputConceptNewPtr = NewPtr<__LINE__>;
+template <> struct std::iterator_traits<InputConceptNewPtr> : NewPtrTraits {
+  using iterator_concept = std::input_iterator_tag;
+};
+
+using ForwardConceptNewPtr = NewPtr<__LINE__>;
+template <> struct std::iterator_traits<ForwardConceptNewPtr> : NewPtrTraits {
+  using iterator_concept = std::forward_iterator_tag;
+};
+
+using RandomAccessConceptNewPtr = NewPtr<__LINE__>;
+template <> struct std::iterator_traits<RandomAccessConceptNewPtr> : NewPtrTraits {
+  using iterator_concept = std::random_access_iterator_tag;
+};
+
+using ContiguousConceptNewPtr = NewPtr<__LINE__>;
+template <> struct std::iterator_traits<ContiguousConceptNewPtr> : NewPtrTraits {
+  using iterator_concept = std::contiguous_iterator_tag;
+};
+
+using InvalidContiguousCategoryNewPtr = NewPtr<__LINE__>;
+template <> struct std::iterator_traits<InvalidContiguousCategoryNewPtr> : NewPtrTraits {
+  // You can't have a contiguous tag as the iterator_category (it has to be
+  // iterator_concept), but std::contiguous_iterator_tag inherits from
+  // std::random_access_iterator_tag, so this is treated as such.
+  using iterator_category = std::contiguous_iterator_tag;
+};
+#endif // __cplusplus >= 202002L
+
+// A simple wrapper around a char * with all the operator members required of
+// a full-strength iterator, plus a std::random_access_iterator_tag.
+//
+// The template parameter U is only used to generate fresh type instances,
+// and just has to be any unique number. This helps us avoid re-defining this
+// same type repeatedly, while we create different explicit specializations of
+// std::iterator_traits<LegacyPtr<U>> to test.
+template <unsigned U>
+struct LegacyPtr {
+  private:
+  char *ptr;
+  LegacyPtr(char *ptr) : ptr{ptr} {}
+
+public:
+  const char &operator*() const { return *ptr; }
+  char &operator*() { return *ptr; }
+  LegacyPtr &operator++() {
+    ++ptr;
+    return *this;
+  }
+  bool operator==(const LegacyPtr &other) const { return ptr == other.ptr; }
+  bool operator!=(const LegacyPtr &other) const { return ptr != other.ptr; }
+  bool operator<(const LegacyPtr &other) const { return ptr < other.ptr; }
+  LegacyPtr operator+(int v) const { return LegacyPtr{ptr + v}; }
+  int operator-(const LegacyPtr &other) const { return ptr - other.ptr; }
+  LegacyPtr operator-(int v) const { return LegacyPtr{ptr - v}; }
+  void operator+=(int v) { ptr += v; }
+  void operator-=(int v) { ptr -= v; }
+
+  using iterator_category = std::random_access_iterator_tag;
+};
+
+using BasicLegacyPtr = LegacyPtr<__LINE__>;
+
+using NotALegacyPtr = LegacyPtr<__LINE__>;
+template <> struct std::iterator_traits<NotALegacyPtr> : NewPtrTraits {};
+
+using InputCategoryLegacyPtr = LegacyPtr<__LINE__>;
+template <> struct std::iterator_traits<InputCategoryLegacyPtr> : NewPtrTraits {
+  using iterator_category = std::input_iterator_tag;
+};
+
+#if __cplusplus >= 202002L
+
+using InputConceptLegacyPtr = LegacyPtr<__LINE__>;
+template <> struct std::iterator_traits<InputConceptLegacyPtr> : NewPtrTraits {
+  using iterator_concept = std::input_iterator_tag;
+};
+
+using ContiguousConceptLegacyPtr = LegacyPtr<__LINE__>;
+template <> struct std::iterator_traits<ContiguousConceptLegacyPtr> : NewPtrTraits {
+  using iterator_concept = std::contiguous_iterator_tag;
+};
+
+using InputCategoryContiguousConceptLegacyPtr = LegacyPtr<__LINE__>;
+template <> struct std::iterator_traits<InputCategoryContiguousConceptLegacyPtr> : NewPtrTraits {
+  using iterator_category = std::input_iterator_tag;
+  using iterator_concept = std::contiguous_iterator_tag;
+};
+
+#endif // __cplusplus >= 202002L
+
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_CUSTOM_ITERATOR_H

--- a/test/Interop/Cxx/stdlib/overlay/Inputs/custom-iterator.h
+++ b/test/Interop/Cxx/stdlib/overlay/Inputs/custom-iterator.h
@@ -1392,6 +1392,19 @@ template <> struct std::iterator_traits<InvalidContiguousCategoryNewPtr> : NewPt
 };
 #endif // __cplusplus >= 202002L
 
+using IteratorTagOfMemberTypedef = NewPtr<__LINE__>;
+template <> struct std::iterator_traits<IteratorTagOfMemberTypedef> : NewPtrTraits {
+  using the_category = std::input_iterator_tag;
+  using iterator_category = the_category;
+};
+
+using non_member_input_iterator_tag = std::input_iterator_tag;
+using IteratorTagOfNonMemberTypedef = NewPtr<__LINE__>;
+template <> struct std::iterator_traits<IteratorTagOfNonMemberTypedef> : NewPtrTraits {
+  using iterator_category = non_member_input_iterator_tag;
+};
+
+
 // A simple wrapper around a char * with all the operator members required of
 // a full-strength iterator, plus a std::random_access_iterator_tag.
 //

--- a/test/Interop/Cxx/stdlib/overlay/custom-iterator-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-iterator-typechecker.swift
@@ -337,10 +337,10 @@ func check(it: ProtectedIteratorBase) {
 }
 
 func check(it: HasInheritedProtectedCopyConstructor) {
-  checkInput(it)                // expected-error {{requires}} // FIXME
+  checkInput(it)
   checkRandomAccess(it)         // expected-error {{requires}}
   checkContiguous(it)           // expected-error {{requires}}
-  checkMutableInput(it)         // expected-error {{requires}} // FIXME
+  checkMutableInput(it)
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
 }

--- a/test/Interop/Cxx/stdlib/overlay/custom-iterator-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-iterator-typechecker.swift
@@ -344,3 +344,155 @@ func check(it: HasInheritedProtectedCopyConstructor) {
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
 }
+
+func check(it: TaglessNewPtr) {
+  checkInput(it)                // expected-error {{requires}}
+  checkRandomAccess(it)         // expected-error {{requires}}
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)         // expected-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
+func check(it: InputCategoryNewPtr) {
+  checkInput(it)
+  checkRandomAccess(it)         // expected-error {{requires}}
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
+func check(it: ForwardCategoryNewPtr) {
+  checkInput(it)
+  checkRandomAccess(it)         // expected-error {{requires}}
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
+func check(it: RandomAccessCategoryNewPtr) {
+  checkInput(it)
+  checkRandomAccess(it)
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)
+  checkMutableRandomAccess(it)
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
+#if CPP20
+
+func check(it: ContiguousCategoryNewPtr) {
+  checkInput(it)
+  checkRandomAccess(it)
+  checkContiguous(it)
+  checkMutableInput(it)
+  checkMutableRandomAccess(it)
+  checkMutableContiguous(it)
+}
+
+func check(it: InputConceptNewPtr) {
+  checkInput(it)
+  checkRandomAccess(it)         // expected-cpp20-error {{requires}}
+  checkContiguous(it)           // expected-cpp20-error {{requires}}
+  checkMutableInput(it)
+  checkMutableRandomAccess(it)  // expected-cpp20-error {{requires}}
+  checkMutableContiguous(it)    // expected-cpp20-error {{requires}}
+}
+
+func check(it: ForwardConceptNewPtr) {
+  checkInput(it)
+  checkRandomAccess(it)         // expected-cpp20-error {{requires}}
+  checkContiguous(it)           // expected-cpp20-error {{requires}}
+  checkMutableInput(it)
+  checkMutableRandomAccess(it)  // expected-cpp20-error {{requires}}
+  checkMutableContiguous(it)    // expected-cpp20-error {{requires}}
+}
+
+func check(it: RandomAccessConceptNewPtr) {
+  checkInput(it)
+  checkRandomAccess(it)
+  checkContiguous(it)           // expected-cpp20-error {{requires}}
+  checkMutableInput(it)
+  checkMutableRandomAccess(it)
+  checkMutableContiguous(it)    // expected-cpp20-error {{requires}}
+}
+
+func check(it: ContiguousConceptNewPtr) {
+  checkInput(it)
+  checkRandomAccess(it)
+  checkContiguous(it)
+  checkMutableInput(it)
+  checkMutableRandomAccess(it)
+  checkMutableContiguous(it)
+}
+
+func check(it: InvalidContiguousCategoryNewPtr) {
+  checkInput(it)
+  checkRandomAccess(it)
+  checkContiguous(it)           // expected-cpp20-error {{requires}}
+  checkMutableInput(it)
+  checkMutableRandomAccess(it)
+  checkMutableContiguous(it)    // expected-cpp20-error {{requires}}
+}
+
+#endif // CPP20
+
+func check(it: BasicLegacyPtr) {
+  checkInput(it)
+  checkRandomAccess(it)
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)
+  checkMutableRandomAccess(it)
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
+func check(it: NotALegacyPtr) {
+  checkInput(it)                // expected-error {{requires}}
+  checkRandomAccess(it)         // expected-error {{requires}}
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)         // expected-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
+func check(it: InputCategoryLegacyPtr) {
+  checkInput(it)
+  checkRandomAccess(it)         // expected-error {{requires}}
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
+#if CPP20
+
+func check(it: InputConceptLegacyPtr) {
+  checkInput(it)
+  checkRandomAccess(it)         // expected-cpp20-error {{requires}}
+  checkContiguous(it)           // expected-cpp20-error {{requires}}
+  checkMutableInput(it)
+  checkMutableRandomAccess(it)  // expected-cpp20-error {{requires}}
+  checkMutableContiguous(it)    // expected-cpp20-error {{requires}}
+}
+
+func check(it: ContiguousConceptLegacyPtr) {
+  checkInput(it)
+  checkRandomAccess(it)
+  checkContiguous(it)
+  checkMutableInput(it)
+  checkMutableRandomAccess(it)
+  checkMutableContiguous(it)
+}
+
+func check(it: InputCategoryContiguousConceptLegacyPtr) {
+  checkInput(it)
+  checkRandomAccess(it)
+  checkContiguous(it)
+  checkMutableInput(it)
+  checkMutableRandomAccess(it)
+  checkMutableContiguous(it)
+}
+
+#endif // CPP20

--- a/test/Interop/Cxx/stdlib/overlay/custom-iterator-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-iterator-typechecker.swift
@@ -1,0 +1,346 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -suppress-notes -I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++20 -DCPP20 -verify-additional-prefix cpp20-
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -suppress-notes -I %S/Inputs -cxx-interoperability-mode=default
+
+// Check whether each of the custom iterator types in Inputs/custom-iterator.h
+// conform to the various iterator protocols from the C++ overlay.
+//
+// Note that we only detect contiguous iterator when C++'20 is enabled.
+
+import CustomIterator
+
+func checkInput<It: UnsafeCxxInputIterator>(_ _: It) {}
+func checkRandomAccess<It: UnsafeCxxRandomAccessIterator>(_ _: It) {}
+func checkContiguous<It: UnsafeCxxContiguousIterator>(_ _: It) {}
+func checkMutableInput<It: UnsafeCxxMutableInputIterator>(_ _: It) {}
+func checkMutableRandomAccess<It: UnsafeCxxMutableRandomAccessIterator>(_ _: It) {}
+func checkMutableContiguous<It: UnsafeCxxMutableContiguousIterator>(_ _: It) {}
+
+func check(it: ConstIterator) {
+  checkInput(it)
+  checkRandomAccess(it)         // expected-error {{requires}}
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)         // expected-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
+func check(it: ConstRACIterator) {
+  checkInput(it)
+  checkRandomAccess(it)
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)         // expected-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
+func check(it: ConstRACIteratorRefPlusEq) {
+  checkInput(it)
+  checkRandomAccess(it)
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)         // expected-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
+func check(it: ConstIteratorOutOfLineEq) {
+  checkInput(it)
+  checkRandomAccess(it)         // expected-error {{requires}}
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)         // expected-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
+func check(it: MinimalIterator) {
+  checkInput(it)
+  checkRandomAccess(it)         // expected-error {{requires}}
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)         // expected-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
+func check(it: ForwardIterator) {
+  checkInput(it)
+  checkRandomAccess(it)         // expected-error {{requires}}
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)         // expected-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
+func check(it: HasCustomIteratorTag) {
+  checkInput(it)
+  checkRandomAccess(it)         // expected-error {{requires}}
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)         // expected-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
+func check(it: HasCustomRACIteratorTag) {
+  checkInput(it)
+  checkRandomAccess(it)
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)         // expected-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
+func check(it: HasCustomInheritedRACIteratorTag) {
+  checkInput(it)
+  checkRandomAccess(it)
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)         // expected-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
+func check(it: HasCustomIteratorTagInline) {
+  checkInput(it)
+  checkRandomAccess(it)         // expected-error {{requires}}
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)         // expected-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
+func check(it: HasTypedefIteratorTag) {
+  checkInput(it)
+  checkRandomAccess(it)         // expected-error {{requires}}
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)         // expected-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
+func check(it: MutableRACIterator) {
+  checkInput(it)
+  checkRandomAccess(it)
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)
+  checkMutableRandomAccess(it)
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
+func check(it: NonReferenceDereferenceOperator) {
+  checkInput(it)
+  checkRandomAccess(it)         // expected-error {{requires}}
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)         // expected-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
+#if CPP20
+
+func check(it: ConstContiguousIterator) {
+  checkInput(it)
+  checkRandomAccess(it)
+  checkContiguous(it)
+  checkMutableInput(it)         // expected-cpp20-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-cpp20-error {{requires}}
+  checkMutableContiguous(it)    // expected-cpp20-error {{requires}}
+}
+
+func check(it: HasCustomContiguousIteratorTag) {
+  checkInput(it)
+  checkRandomAccess(it)
+  checkContiguous(it)
+  checkMutableInput(it)         // expected-cpp20-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-cpp20-error {{requires}}
+  checkMutableContiguous(it)    // expected-cpp20-error {{requires}}
+}
+
+func check(it: MutableContiguousIterator) {
+  checkInput(it)
+  checkRandomAccess(it)
+  checkContiguous(it)
+  checkMutableInput(it)
+  checkMutableRandomAccess(it)
+  checkMutableContiguous(it)
+}
+
+func check(it: HasNoContiguousIteratorConcept) {
+  checkInput(it)
+  checkRandomAccess(it)
+  checkContiguous(it)           // expected-cpp20-error {{requires}}
+  checkMutableInput(it)         // expected-cpp20-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-cpp20-error {{requires}}
+  checkMutableContiguous(it)    // expected-cpp20-error {{requires}}
+}
+
+#endif
+
+func check(it: HasNoIteratorCategory) {
+  checkInput(it)                // expected-error {{requires}}
+  checkRandomAccess(it)         // expected-error {{requires}}
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)         // expected-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
+func check(it: HasInvalidIteratorCategory) {
+  checkInput(it)                // expected-error {{requires}}
+  checkRandomAccess(it)         // expected-error {{requires}}
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)         // expected-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
+func check(it: HasNoEqualEqual) {
+  checkInput(it)                // expected-error {{requires}}
+  checkRandomAccess(it)         // expected-error {{requires}}
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)         // expected-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
+func check(it: HasInvalidEqualEqual) {
+  checkInput(it)                // expected-error {{requires}}
+  checkRandomAccess(it)         // expected-error {{requires}}
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)         // expected-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
+func check(it: HasNoIncrementOperator) {
+  checkInput(it)                // expected-error {{requires}}
+  checkRandomAccess(it)         // expected-error {{requires}}
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)         // expected-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
+func check(it: HasNoPreIncrementOperator) {
+  checkInput(it)                // expected-error {{requires}}
+  checkRandomAccess(it)         // expected-error {{requires}}
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)         // expected-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
+func check(it: HasNoDereferenceOperator) {
+  checkInput(it)                // expected-error {{requires}}
+  checkRandomAccess(it)         // expected-error {{requires}}
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)         // expected-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
+func check(it: TemplatedIteratorInt) {
+  checkInput(it)
+  checkRandomAccess(it)         // expected-error {{requires}}
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)         // expected-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
+
+func check(it: TemplatedIteratorOutOfLineEqInt) {
+  checkInput(it)
+  checkRandomAccess(it)         // expected-error {{requires}}
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)         // expected-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
+
+func check(it: TemplatedRACIteratorOutOfLineEqInt) {
+  checkInput(it)
+  checkRandomAccess(it)
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)         // expected-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
+func check(it: BaseIntIterator) {
+  checkInput(it)                // expected-error {{requires}}
+  checkRandomAccess(it)         // expected-error {{requires}}
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)         // expected-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
+func check(it: InheritedConstIterator) {
+  checkInput(it)
+  checkRandomAccess(it)         // expected-error {{requires}}
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)         // expected-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
+func check(it: InheritedTemplatedConstIteratorInt) {
+  checkInput(it)
+  checkRandomAccess(it)         // expected-error {{requires}}
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)         // expected-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
+func check(it: InheritedTemplatedConstRACIteratorInt) {
+  checkInput(it)
+  checkRandomAccess(it)
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)         // expected-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
+func check(it: InheritedTemplatedConstRACIteratorOutOfLineOpsInt) {
+  checkInput(it)
+  checkRandomAccess(it)
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)         // expected-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
+func check(it: InputOutputIterator) {
+  checkInput(it)
+  checkRandomAccess(it)         // expected-error {{requires}}
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
+func check(it: InputOutputConstIterator) {
+  checkInput(it)
+  checkRandomAccess(it)         // expected-error {{requires}}
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
+func check(it: ProtectedIteratorBase) {
+  checkInput(it)                // expected-error {{requires}}
+  checkRandomAccess(it)         // expected-error {{requires}}
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)         // expected-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
+func check(it: HasInheritedProtectedCopyConstructor) {
+  checkInput(it)                // expected-error {{requires}} // FIXME
+  checkRandomAccess(it)         // expected-error {{requires}}
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)         // expected-error {{requires}} // FIXME
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}

--- a/test/Interop/Cxx/stdlib/overlay/custom-iterator-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-iterator-typechecker.swift
@@ -439,6 +439,24 @@ func check(it: InvalidContiguousCategoryNewPtr) {
 
 #endif // CPP20
 
+func check(it: IteratorTagOfMemberTypedef) {
+  checkInput(it)
+  checkRandomAccess(it)         // expected-error {{requires}}
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
+func check(it: IteratorTagOfNonMemberTypedef) {
+  checkInput(it)
+  checkRandomAccess(it)         // expected-error {{requires}}
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+}
+
 func check(it: BasicLegacyPtr) {
   checkInput(it)
   checkRandomAccess(it)


### PR DESCRIPTION
This patch set extracts the logic for detecting iterator category info into a request. That request also uses `clang::Sema`'s qualified lookup mechanism to account for cases like inheritance. Doing so makes it reusable in other parts of ClangImporter.

Furthermore, it adds detection for explicit specializations of `std::iterator_traits<Iter>`, so that they produce a protocol conformance to `Cxx*Iterator` when `Iter` is imported.
