### PR TITLE
Fix mandatory inlining for complete lifetimes

### DIFF
--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -108,7 +108,6 @@ static  bool fixupReferenceCounts(
   bool isLexical = isLexicalPartialApply(pai);
 
   // FIXME: Can we cache this in between inlining invocations?
-  DeadEndBlocks deadEndBlocks(pai->getFunction());
   SmallVector<SILBasicBlock *, 4> leakingBlocks;
   bool invalidatedStackNesting = false;
 
@@ -153,7 +152,7 @@ static  bool fixupReferenceCounts(
       auto *stackLoc = builder.createAllocStack(loc, v->getType().getObjectType());
       builder.createCopyAddr(loc, v, stackLoc, IsNotTake, IsInitialization);
 
-      LinearLifetimeChecker checker(&deadEndBlocks, /*instIndices=*/ nullptr);
+      LinearLifetimeChecker checker(/*deadEndBlocks*/ nullptr, /*instIndices=*/ nullptr);
       bool consumedInLoop = checker.completeConsumingUseSet(
           pai, applySite.getCalleeOperand(),
           [&](SILBasicBlock::iterator insertPt) {
@@ -214,7 +213,7 @@ static  bool fixupReferenceCounts(
       // just cares about the block the value is in. In a forthcoming commit, I
       // am going to change this to use a different API on the linear lifetime
       // checker that makes this clearer.
-      LinearLifetimeChecker checker(&deadEndBlocks, /*instIndices=*/ nullptr);
+      LinearLifetimeChecker checker(/*deadEndBlocks*/ nullptr, /*instIndices=*/ nullptr);
       bool consumedInLoop = checker.completeConsumingUseSet(
           pai, applySite.getCalleeOperand(),
           [&](SILBasicBlock::iterator insertPt) {
@@ -261,7 +260,7 @@ static  bool fixupReferenceCounts(
       // just cares about the block the value is in. In a forthcoming commit, I
       // am going to change this to use a different API on the linear lifetime
       // checker that makes this clearer.
-      LinearLifetimeChecker checker(&deadEndBlocks, /*instIndices=*/ nullptr);
+      LinearLifetimeChecker checker(/*deadEndBlocks*/ nullptr, /*instIndices=*/ nullptr);
       checker.completeConsumingUseSet(
           pai, applySite.getCalleeOperand(),
           [&](SILBasicBlock::iterator insertPt) {
@@ -298,7 +297,7 @@ static  bool fixupReferenceCounts(
       // just cares about the block the value is in. In a forthcoming commit, I
       // am going to change this to use a different API on the linear lifetime
       // checker that makes this clearer.
-      LinearLifetimeChecker checker(&deadEndBlocks, /*instIndices=*/ nullptr);
+      LinearLifetimeChecker checker(/*deadEndBlocks*/ nullptr, /*instIndices=*/ nullptr);
       checker.completeConsumingUseSet(
           pai, applySite.getCalleeOperand(),
           [&](SILBasicBlock::iterator insertPt) {

--- a/test/SILOptimizer/mandatory_inlining_ownership.sil
+++ b/test/SILOptimizer/mandatory_inlining_ownership.sil
@@ -678,3 +678,73 @@ bb0(%0 : @guaranteed $String):
 sil_vtable C2 {
   #C2.i!modify: (C2) -> () -> () : @devirt_callee
 }
+
+// Ensure no SIL verification error
+
+// CHECK-LABEL: sil [ossa] @test_pa_lifetime_completion1 :
+// CHECK-NOT: apply
+// CHECK-LABEL: } // end sil function 'test_pa_lifetime_completion1'
+sil [ossa] @test_pa_lifetime_completion1 : $@convention(thin) (@owned String) -> () {
+bb0(%0 : @owned $String):
+  %1 = function_ref @closure : $@convention(thin) (@guaranteed String) -> ()
+  %2 = partial_apply [callee_guaranteed] %1(%0) : $@convention(thin) (@guaranteed String) -> ()
+  cond_br undef, bb1, bb2
+
+bb1:
+  %3 = apply %2() : $@callee_guaranteed () -> ()
+  destroy_value %2
+  %6 = tuple ()
+  return %6
+
+bb2:
+  %3a = apply %2() : $@callee_guaranteed () -> ()
+  destroy_value %2
+  unreachable
+}
+
+// CHECK-LABEL: sil [ossa] @test_pa_lifetime_completion2 :
+// CHECK-NOT: apply
+// CHECK-LABEL: } // end sil function 'test_pa_lifetime_completion2'
+sil [ossa] @test_pa_lifetime_completion2 : $@convention(thin) (@owned String) -> () {
+bb0(%0 : @owned $String):
+  %1 = function_ref @closure : $@convention(thin) (@guaranteed String) -> ()
+  %2 = partial_apply [callee_guaranteed] %1(%0) : $@convention(thin) (@guaranteed String) -> ()
+  br bb1
+
+bb1:
+  cond_br undef, bb2, bb3
+
+bb2:
+  %3 = apply %2() : $@callee_guaranteed () -> ()
+  br bb1
+
+bb3:
+  destroy_value %2
+  %t = tuple ()
+  return %t
+}
+
+// CHECK-LABEL: sil [ossa] @test_pa_lifetime_completion3 :
+// CHECK-NOT: apply
+// CHECK-LABEL: } // end sil function 'test_pa_lifetime_completion3'
+sil [ossa] @test_pa_lifetime_completion3 : $@convention(thin) (@owned String) -> () {
+bb0(%0 : @owned $String):
+  %1 = function_ref @closure : $@convention(thin) (@guaranteed String) -> ()
+  %2 = partial_apply [callee_guaranteed] %1(%0) : $@convention(thin) (@guaranteed String) -> ()
+  cond_br undef, bb1, bb2
+
+bb1:
+  %3 = apply %2() : $@callee_guaranteed () -> ()
+  destroy_value %2
+  br bb3
+
+bb2:
+  %3a = apply %2() : $@callee_guaranteed () -> ()
+  destroy_value %2
+  br bb3
+
+bb3:
+  %6 = tuple ()
+  return %6
+}
+


### PR DESCRIPTION
MandatoryInlining inserts copy_value/begin_borrow instructions to fixup ownership while
 inlining and uses LinearLifetimeChecker to insert compensating lifetime ends.

This PR ensures LinearLifetimeChecker inserts compensating lifeime ends on dead-end blocks
as well since we now verify complete lifetimes.

Resolves rdar://170326162 