### PR TITLE
[Sema] Diagnose non-Sendable types in @concurrent to nonisolated(nons…

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2708,13 +2708,20 @@ namespace {
             return;
           }
 
-          // Conversions from non-Sendable types are handled by
-          // region-based isolation.
-          // Function conversions are used to inject concurrency attributes
-          // into interface types until that changes we won't be able to
-          // diagnose all of the cases here.
-          if (!fromFnType->isSendable())
+          // Conversions from non-Sendable types are generally handled by
+          // region-based isolation. However, converting from a
+          // @concurrent (NonIsolated async) type to nonisolated(nonsending)
+          // crosses an isolation boundary and needs Sendable checking
+          // even for non-@Sendable types (e.g. variable type annotations).
+          // See: https://github.com/swiftlang/swift/issues/87234
+          if (!fromFnType->isSendable()) {
+            if (fromFnType->isAsync() &&
+                fromIsolation.isNonIsolated() &&
+                toIsolation.isNonIsolatedCaller()) {
+              diagnoseNonSendableParametersAndResult(toFnType);
+            }
             return;
+          }
 
           switch (toIsolation.getKind()) {
           // Converting to `nonisolated(nonsending)` function type

--- a/test/Concurrency/attr_execution/conversions.swift
+++ b/test/Concurrency/attr_execution/conversions.swift
@@ -162,3 +162,24 @@ func testNonSendableDiagnostics(
   let _: @MyActor () async -> NonSendable = globalActor2
   // expected-error@-1 {{cannot convert value actor-isolated to 'MainActor' to specified type actor-isolated to 'MyActor'}}
 }
+
+// Non-@Sendable @concurrent variable type conversion (https://github.com/swiftlang/swift/issues/87234)
+func testNonSendableConcurrentVarConversion() {
+  // @concurrent variable type (non-@Sendable) -> nonisolated(nonsending)
+  // crosses an isolation boundary and must check for Sendable.
+  let fn1: @concurrent (NonSendable) async -> Void = { _ in }
+  let _: nonisolated(nonsending) (NonSendable) async -> Void = fn1 // expected-note {{type 'NonSendable' does not conform to 'Sendable' protocol}}
+  // expected-error@-1 {{cannot convert '(NonSendable) async -> Void' to 'nonisolated(nonsending) (NonSendable) async -> Void' because crossing of an isolation boundary requires parameter and result types to conform to 'Sendable' protocol}}
+
+  let fn2: @concurrent () async -> NonSendable = { NonSendable() }
+  let _: nonisolated(nonsending) () async -> NonSendable = fn2 // expected-note {{type 'NonSendable' does not conform to 'Sendable' protocol}}
+  // expected-error@-1 {{cannot convert '() async -> NonSendable' to 'nonisolated(nonsending) () async -> NonSendable' because crossing of an isolation boundary requires parameter and result types to conform to 'Sendable' protocol}}
+
+  // @concurrent variable type with Sendable types should be fine.
+  let fn3: @concurrent (Int) async -> Void = { _ in }
+  let _: nonisolated(nonsending) (Int) async -> Void = fn3 // Ok
+
+  // Non-async @concurrent -> nonisolated(nonsending) doesn't cross boundary.
+  let fn4: (NonSendable) -> Void = { _ in }
+  let _: nonisolated(nonsending) (NonSendable) async -> Void = fn4 // Ok
+}


### PR DESCRIPTION
Previously, [checkFunctionConversion](cci:1://file:///Users/sriramvarunkumar/swift/lib/Sema/TypeCheckConcurrency.cpp:2620:4-2854:5) in [TypeCheckConcurrency.cpp](cci:7://file:///Users/sriramvarunkumar/swift/lib/Sema/TypeCheckConcurrency.cpp:0:0-0:0) skipped Sendable boundary-crossing checks for all non-`@Sendable` function types (line 2716), deferring entirely to region-based isolation. This allowed `@concurrent` variable type annotations (e.g., `let fn: @concurrent (NonSendable) async -> Void`) to silently convert to `nonisolated(nonsending)` without verifying that parameter and result types conform to [Sendable](cci:1://file:///Users/sriramvarunkumar/swift/include/swift/AST/ExtInfo.h:884:2-884:68), enabling potential data races.

### Changes

- **[lib/Sema/TypeCheckConcurrency.cpp](cci:7://file:///Users/sriramvarunkumar/swift/lib/Sema/TypeCheckConcurrency.cpp:0:0-0:0)**: Before the early return for non-`@Sendable` types, added a targeted check for async [NonIsolated](cci:1://file:///Users/sriramvarunkumar/swift/include/swift/AST/ExtInfo.h:109:2-111:3) → `NonIsolatedNonsending` conversions. This emits `invalid_function_conversion_with_non_sendable` when non-Sendable parameter/result types are detected.

- **[test/Concurrency/attr_execution/conversions.swift](cci:7://file:///Users/sriramvarunkumar/swift/test/Concurrency/attr_execution/conversions.swift:0:0-0:0)**: Added `testNonSendableConcurrentVarConversion()` with test cases covering:
  - Non-Sendable parameter type (expected error ✅)
  - Non-Sendable result type (expected error ✅)
  - Sendable types like [Int](cci:1://file:///Users/sriramvarunkumar/swift/lib/Sema/TypeCheckAttr.cpp:3876:0-3880:1) (no error ✅)
  - Non-async function (no boundary crossing, no error ✅)

Resolves https://github.com/swiftlang/swift/issues/87234