### PR TITLE
[test][android] Fix building the Android tests on the Windows toolchain CI again

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2778,14 +2778,14 @@ function Test-Runtime([Hashtable] $Platform) {
       -UseBuiltCompilers C,CXX,Swift `
       -SwiftSDK $null `
       -BuildTargets check-swift-validation-only_non_executable `
-      -Defines @{
+      -Defines ($PlatformDefines + @{
         SWIFT_INCLUDE_TESTS = "YES";
         SWIFT_INCLUDE_TEST_BINARIES = "YES";
         SWIFT_BUILD_TEST_SUPPORT_MODULES = "YES";
         SWIFT_NATIVE_LLVM_TOOLS_PATH = Join-Path -Path $CompilersBinaryCache -ChildPath "bin";
         SWIFT_ENABLE_EXPERIMENTAL_CXX_INTEROP = "YES";
         LLVM_LIT_ARGS = "-vv";
-      }
+      })
   }
 }
 


### PR DESCRIPTION
This was fixed in #86694, but the subsequent massive #84906 appears to have [inadvertently disabled adding the needed Android API level](https://github.com/swiftlang/swift/pull/84906/changes#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9R2774), as it was started late last year, long before the fix was added.