### PR TITLE
[cxx-interop] Disable failing tests on Amazon Linux 2

### DIFF
--- a/test/Interop/Cxx/stdlib/overlay/custom-borrowing-sequence.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-borrowing-sequence.swift
@@ -1,7 +1,10 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=default -I %swift_src_root/lib/ClangImporter/SwiftBridging -Xcc -std=c++20)
 //
 // REQUIRES: executable_test
-// REQUIRES: OS=macosx || OS=linux-gnu || OS=freebsd
+// Ubuntu 20.04 ships with an old version of libstdc++, which does not provide
+// std::contiguous_iterator_tag from C++20.
+// UNSUPPORTED: LinuxDistribution=ubuntu-20.04
+// UNSUPPORTED: LinuxDistribution=amzn-2
 
 import StdlibUnittest
 import CustomBorrowingSequence

--- a/test/Interop/Cxx/stdlib/use-std-vector-borrowing-iterators.swift
+++ b/test/Interop/Cxx/stdlib/use-std-vector-borrowing-iterators.swift
@@ -1,0 +1,57 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-6 -Xcc -std=c++20)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20)
+
+// Also test this with a bridging header instead of the StdVector module.
+// RUN: %empty-directory(%t2)
+// RUN: cp %S/Inputs/std-vector.h %t2/std-vector-bridging-header.h
+// RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-vector-bridging-header.h -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20)
+// RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-vector-bridging-header.h -cxx-interoperability-mode=swift-6 -Xcc -std=c++20)
+// RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-vector-bridging-header.h -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20)
+
+// Ubuntu 20.04 ships with an old version of libstdc++, which does not provide
+// std::contiguous_iterator_tag from C++20.
+// REQUIRES: OS=macosx || OS=windows-msvc
+
+// REQUIRES: executable_test
+
+import StdlibUnittest
+#if !BRIDGING_HEADER
+import StdVector
+#endif
+import CxxStdlib
+
+var StdVectorBorrowingIteratorTestSuite = TestSuite("StdVectorBorrowingIterator")
+
+StdVectorBorrowingIteratorTestSuite.test("VecOfInt has contiguous iterator").require(.stdlib_6_3).code {
+    guard #available(SwiftStdlib 6.3, *) else { return }
+    let arr : [Int32] = [1, 2, 3, 4, 5]
+    let v = Vector(arr)
+    expectEqual(v.size(), 5)
+    var iterator = v.makeBorrowingIterator()
+    var counter = 0
+    while true {
+        let span = iterator._nextSpan()
+        if (span.count == 0) { break }
+        expectEqual(span.count, 5)
+        counter += 1
+    }
+    expectEqual(counter, 1)
+}
+
+StdVectorBorrowingIteratorTestSuite.test("VectorOfNonCopyable has contiguous iterator").require(.stdlib_6_3).code {
+    guard #available(SwiftStdlib 6.3, *) else { return }
+    let v = makeVectorOfNonCopyable()
+    expectEqual(v.size(), 3)
+    var iterator = v.makeBorrowingIterator()
+    var counter = 0
+    while true {
+        let span = iterator._nextSpan()
+        if (span.count == 0) { break }
+        expectEqual(span.count, 3)
+        counter += 1
+    }
+    expectEqual(counter, 1)
+}
+
+runAllTests()


### PR DESCRIPTION
The tests `custom-borrowing-sequence.swift` and `use-std-vector.swift` are both failing on Amazon Linux 2. 
- The first one, because libstdc++ in this platform doesn't provide `std::contiguous_iterator_tag`, which this test makes use of. 
- The second one fails with a runtime crash which I cannot reproduce locally. I believe this runtime crash is related to the other test, and might happen because we end up with an invalid conformance of `std::vector::iterator` to a contiguous iterator. Since this test was never tested with C++20 anyways because of another issue, I've broken the `use-std-vector.swift` into two for now.

rdar://170347140