### PR TITLE
Require compatible lifetimes in protocol conformance checking and function type matching

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3345,6 +3345,8 @@ NOTE(protocol_witness_throws_conflict,none,
      "candidate throws, but protocol does not allow it", ())
 NOTE(protocol_witness_not_objc,none,
      "candidate is explicitly '@nonobjc'", ())
+NOTE(protocol_witness_lifetime_conflict, none,
+     "candidate has a lifetime dependence not specified by the protocol", ())
 NOTE(protocol_witness_enum_case_payload, none,
      "candidate is an enum case with associated values, "
      "but protocol does not allow it", ())

--- a/include/swift/AST/LifetimeDependence.h
+++ b/include/swift/AST/LifetimeDependence.h
@@ -21,6 +21,7 @@
 #include "swift/AST/Identifier.h"
 #include "swift/AST/IndexSubset.h"
 #include "swift/AST/Ownership.h"
+#include "swift/AST/Type.h"
 #include "swift/Basic/Debug.h"
 #include "swift/Basic/OptionSet.h"
 #include "swift/Basic/SourceLoc.h"
@@ -407,6 +408,104 @@ public:
   }
   
   SWIFT_DEBUG_DUMPER(dump());
+};
+
+/// The interface of a function or method with lifetime dependencies.
+///
+/// This type abstracts over inconsistencies in the representation of function
+/// type lifetime dependencies.
+///
+/// The lifetime dependencies of normal function types are attached directly
+/// to the function type:
+///
+///     @_lifetime(...) (Params...) -> Result
+///
+/// Instance methods have curried function types. Since lifetime dependencies
+/// can involve the self parameter, they are attached to the outer type:
+///
+///     @_lifetime(...) (Self) -> (Params...) -> Result
+///
+/// Static methods cannot have lifetime dependencies involving self, so their
+/// lifetime dependencies are attached to the actual interface type.
+///
+///     (Self.Type) -> @_lifetime(...) (Params...) -> Result
+class LifetimeDependentInterface {
+  /// (Params...) -> Result: The function's interface type.
+  AnyFunctionType *interface;
+  /// Self: The type of self, if it exists.
+  std::optional<Type> implicitSelfType;
+  /// @_lifetime(...): The lifetime dependencies of the interface.
+  ArrayRef<LifetimeDependenceInfo> lifetimes;
+
+public:
+  /// Construct a lifetime-dependent interface for a function declaration with
+  /// the specified interface type.
+  ///
+  /// For methods, the interface type should be the "inner" function type.
+  /// I.e. (Params...) -> Result
+  LifetimeDependentInterface(AbstractFunctionDecl *afd,
+                             AnyFunctionType *interface);
+
+  /// Construct a lifetime-dependent interface for a function type.
+  LifetimeDependentInterface(AnyFunctionType *type);
+
+  /// Construct a LifetimeDependentInterface from a ValueDecl and interface
+  /// type. If the ValueDecl is an instance of AbstractFunctionDecl, call the
+  /// (AbstractFunctionDecl*, AnyFunctionType*) constructor. Otherwise, call the
+  /// (AnyFunctionType*) constructor with 'interface'.
+  static LifetimeDependentInterface fromValueDecl(ValueDecl *decl,
+                                                  AnyFunctionType *interface);
+
+  ArrayRef<LifetimeDependenceInfo> getLifetimeDependencies() const {
+    return lifetimes;
+  }
+
+  /// Get the type of the lifetime source or target with the given index.
+  Type getSourceOrTargetType(unsigned index) const;
+
+  /// Determine whether this interface's lifetime dependencies
+  /// are compatible with those specified by 'to'. If they are, and all
+  /// other aspects of the types are compatible, a function with this interface
+  /// can be cast to type 'to'.
+  ///
+  /// This is determined according to the Lifetime Subtyping rules in
+  /// ‎docs/ReferenceGuides/LifetimeAnnotation.md.
+  ///
+  /// Examples:
+  ///   struct NE: ~Escapable {}
+  ///   @_lifetime(copy ne0, copy ne1)
+  ///   func copying01(ne0: NE, ne1: NE) -> NE {
+  ///     return ne1
+  ///   }
+  ///   @_lifetime(copy ne0)
+  ///   func copying0(ne0: NE, ne1: NE) -> NE {
+  ///     return ne0
+  ///   }
+  ///   func takeCopying01(
+  ///     f: @_lifetime(copy ne0, copy ne1)
+  ///       (_ ne0: NE, _ ne1: NE) -> NE) {}
+  ///   func takeCopying0(
+  ///     f: @_lifetime(copy ne0)
+  ///       (_ ne0: NE, _ ne1: NE) -> NE) {}
+  ///
+  ///   takeCopying0(f: copying0)    // OK: Dependencies match exactly.
+  ///   takeCopying01(f: copying01)  // OK: Dependencies match exactly.
+  ///   takeCopying01(f: copying0)   // OK: No dependencies are dropped.
+  ///   takeCopying0(f: copying01)   // Error: The dependence on the second
+  ///   parameter is dropped.
+  bool canConvertTo(const LifetimeDependentInterface &to) const;
+
+  /// Whether the lifetime dependencies 'fromDeps' are convertible to those
+  /// of the target with the same index in 'to'.
+  /// See canConvertTo.
+  ///
+  /// 'fromDeps' is assumed to be a member of this->lifetimes.
+  bool canConvertTargetTo(const LifetimeDependenceInfo &fromDeps,
+                          const LifetimeDependentInterface &to) const;
+
+  /// Whether this interface has a lifetime dependence target with the given
+  /// index.
+  bool hasTarget(unsigned targetIndex) const;
 };
 
 std::optional<LifetimeDependenceInfo>

--- a/include/swift/AST/RequirementMatch.h
+++ b/include/swift/AST/RequirementMatch.h
@@ -109,6 +109,10 @@ enum class MatchKind : uint8_t {
   /// The witness did not match because it cannot satisy borrow/mutate
   /// requirement.
   BorrowMutateConflict,
+
+  /// The witness did not match because it has lifetime dependencies that do not
+  /// match those of the requirement.
+  LifetimeConflict,
 };
 
 // Describes the kind of optional adjustment performed when
@@ -415,6 +419,7 @@ struct RequirementMatch {
     case MatchKind::MissingDifferentiableAttr:
     case MatchKind::EnumCaseWithAssociatedValues:
     case MatchKind::BorrowMutateConflict:
+    case MatchKind::LifetimeConflict:
       return false;
     }
 
@@ -453,6 +458,7 @@ struct RequirementMatch {
     case MatchKind::MissingDifferentiableAttr:
     case MatchKind::EnumCaseWithAssociatedValues:
     case MatchKind::BorrowMutateConflict:
+    case MatchKind::LifetimeConflict:
       return false;
     }
 
@@ -490,6 +496,7 @@ struct RequirementMatch {
     case MatchKind::MissingDifferentiableAttr:
     case MatchKind::EnumCaseWithAssociatedValues:
     case MatchKind::BorrowMutateConflict:
+    case MatchKind::LifetimeConflict:
       return false;
     }
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3202,6 +3202,11 @@ public:
                                ConstraintKind kind, TypeMatchOptions flags,
                                ConstraintLocatorBuilder locator);
 
+  /// Subroutine of \c matchTypes()
+  bool matchFunctionLifetimes(const LifetimeDependentInterface &func1,
+                              const LifetimeDependentInterface &func2,
+                              ConstraintLocatorBuilder locator);
+
   /// Subroutine of \c matchTypes(), which matches up a value to a
   /// superclass.
   TypeMatchResult matchSuperclassTypes(Type type1, Type type2,

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -2101,6 +2101,157 @@ void LifetimeDependenceInfo::dump() const {
 }
 
 // =============================================================================
+// MARK: LifetimeDependentInterface
+// =============================================================================
+
+LifetimeDependentInterface::LifetimeDependentInterface(
+    AbstractFunctionDecl *afd, AnyFunctionType *interface)
+    : interface(interface),
+      implicitSelfType(afd->isInstanceMethod()
+                           ? std::optional(afd->getImplicitSelfDecl()
+                                               ->toFunctionParam()
+                                               .getPlainType())
+                           : std::nullopt),
+      // Instance methods' lifetime dependencies are attached to the outer type
+      // of the method's interface (see LifetimeDependentInterface), so we must
+      // get them from there, rather than the normal interface type.
+      lifetimes(afd->isInstanceMethod()
+                    ? afd->getInterfaceType()
+                          ->castTo<AnyFunctionType>()
+                          ->getLifetimeDependencies()
+                    : interface->getLifetimeDependencies()) {}
+
+LifetimeDependentInterface::LifetimeDependentInterface(AnyFunctionType *type)
+    : interface(type), implicitSelfType(std::nullopt),
+      lifetimes(type->getLifetimeDependencies()) {}
+
+LifetimeDependentInterface
+LifetimeDependentInterface::fromValueDecl(ValueDecl *decl,
+                                          AnyFunctionType *type) {
+  if (auto *afd = dyn_cast<AbstractFunctionDecl>(decl)) {
+    return LifetimeDependentInterface(afd, type);
+  }
+  return LifetimeDependentInterface(type);
+}
+
+Type LifetimeDependentInterface::getSourceOrTargetType(unsigned index) const {
+  const auto numParams = interface->getNumParams();
+  if (index < numParams) {
+    return interface->getParams()[index].getPlainType();
+  }
+  if (index == numParams) {
+    return implicitSelfType ? *implicitSelfType : interface->getResult();
+  }
+  if (implicitSelfType && index == numParams + 1) {
+    return interface->getResult();
+  }
+  llvm_unreachable("Invalid lifetime source or target index.");
+}
+
+bool LifetimeDependentInterface::canConvertTo(
+    const LifetimeDependentInterface &other) const {
+  // If from and to are the same array, they naturally match. This case should
+  // be reasonably common because lifetime dependence info is canonicalized.
+  if (lifetimes == other.lifetimes) {
+    return true;
+  }
+
+  // Check each dependency target...
+  return llvm::all_of(lifetimes, [&](const LifetimeDependenceInfo &target) {
+    return canConvertTargetTo(target, other);
+  });
+}
+
+/// Determine whether type is "known" (see isTypeUnknown) and ~Escapable.
+static bool isTypeKnownAndEscapable(Type type) {
+  if (isTypeUnknown(type))
+    return false;
+  return type->isEscapable();
+}
+
+bool LifetimeDependentInterface::canConvertTargetTo(
+    const LifetimeDependenceInfo &fromDeps,
+    const LifetimeDependentInterface &to) const {
+  const auto targetIndex = fromDeps.getTargetIndex();
+  // Lifetime dependencies with Escapable targets, and 'copy' dependencies with
+  // Escapable sources are always ignored (see Dependency type requirements in
+  // LifetimeAnnotation.md).
+  //
+  // We only need to check if the target and sources are Escapable for the
+  // lifetime dependence we are converting from (this), not the one we are
+  // converting to (other). This is because we allow conversion to types with
+  // additional dependencies: even if some of the dependencies of 'other' should
+  // be ignored, they could not prevent convertibility unless 'this' had a
+  // conflicting dependence (with the same source & target as one of 'other's
+  // "ignorable" dependencies, but a different scope, copy vs borrow). In that
+  // case, we would detect a mismatch regardless, due to the conflicting
+  // dependence not being present in 'other'.
+
+  const auto other = getLifetimeDependenceFor(to.lifetimes, targetIndex);
+
+  // If the dependence target is Escapable, we ignore this lifetime dependence.
+  if (isTypeKnownAndEscapable(getSourceOrTargetType(targetIndex)))
+    return true;
+
+  // The target must be the same.
+  if (other && targetIndex != other->getTargetIndex()) {
+    return false;
+  }
+
+  // Immortal lifetimes are the least restrictive, so only immortal lifetimes
+  // can convert to them.
+  if (other && other->isImmortal()) {
+    return fromDeps.isImmortal();
+  }
+
+  // Accordingly, immortal lifetimes can convert to any non-immortal lifetimes.
+  if (fromDeps.isImmortal()) {
+    return true;
+  }
+
+  const auto isSubset = [&](IndexSubset *from, IndexSubset *to,
+                            bool ignoreEscapableSources = false) {
+    // The empty set is a subset of every set, and every set is a subset of
+    // itself. An empty set is represented with a nullptr.
+    if (!from || from == to)
+      return true;
+
+    ASSERT(!from->isEmpty() &&
+           "Empty dependence source lists are represented with nullptr.");
+
+    // The set 'from' is non-empty, so it cannot be a subset of an empty 'to'.
+    if (!to)
+      return false;
+
+    if (!ignoreEscapableSources) {
+      return from->isSubsetOf(to);
+    }
+
+    // Check whether from's set of (potentially) ~Escapable lifetime sources is
+    // a subset of to's.
+    return llvm::all_of(from->getIndices(), [&](const unsigned source) {
+      return to->contains(source) ||
+             isTypeKnownAndEscapable(getSourceOrTargetType(source));
+    });
+  };
+
+  return
+      // Ignore copy dependencies with an Escapable source if the
+      // getSourceOrTargetType predicate is supplied.
+      isSubset(fromDeps.getInheritIndices(),
+               other ? other->getInheritIndices() : nullptr,
+               /*ignoreEscapableSources=*/true) &&
+      isSubset(fromDeps.getScopeIndices(),
+               other ? other->getScopeIndices() : nullptr) &&
+      isSubset(fromDeps.getAddressableIndices(),
+               other ? other->getAddressableIndices() : nullptr);
+}
+
+bool LifetimeDependentInterface::hasTarget(unsigned targetIndex) const {
+  return getLifetimeDependenceFor(lifetimes, targetIndex).has_value();
+}
+
+// =============================================================================
 // SIL parsing support
 // =============================================================================
 

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -2528,11 +2528,21 @@ AssociatedTypeInference::getPotentialTypeWitnessesByMatchingTypes(ValueDecl *req
 
   };
 
+  const auto matchLifetimes =
+      [&](const LifetimeDependentInterface &witnessInterface,
+          const LifetimeDependentInterface &reqInterface)
+      -> std::optional<RequirementMatch> {
+    if (!witnessInterface.canConvertTo(reqInterface))
+      return RequirementMatch(witness, MatchKind::LifetimeConflict);
+    return std::nullopt;
+  };
+
   // Match the witness. If we don't succeed, throw away the inference
   // information.
   // FIXME: A renamed match might be useful to retain for the failure case.
-  if (!matchWitness(dc, req, witness, setup, matchTypes, finalize)
-          .isWellFormed()) {
+  if (!matchWitness(dc, req, witness, setup, matchTypes, matchLifetimes,
+                    finalize)
+           .isWellFormed()) {
     inferred.Inferred.clear();
   }
 

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -2335,8 +2335,7 @@ AssociatedTypeInference::getPotentialTypeWitnessesByMatchingTypes(ValueDecl *req
     return inferred;
   }
 
-  auto setup =
-      [&]() -> std::tuple<std::optional<RequirementMatch>, Type, Type, Type, Type> {
+  auto setup = [&]() -> MatchWitnessTypes {
     // Compute the requirement and witness types we'll use for matching.
     witnessType = witness->getInterfaceType()->getReferenceStorageReferent();
     witnessType = getWitnessTypeForMatching(conformance, witness, witnessType);
@@ -2373,9 +2372,8 @@ AssociatedTypeInference::getPotentialTypeWitnessesByMatchingTypes(ValueDecl *req
                                                      witnessThrownError);
     }
 
-    return std::make_tuple(std::nullopt,
-                           reqType, witnessType,
-                           reqThrownError, witnessThrownError);
+    return MatchWitnessTypes{reqType, witnessType, reqThrownError,
+                             witnessThrownError};
   };
 
   /// Visits a requirement type to match it to a potential witness for

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3123,6 +3123,41 @@ ConstraintSystem::matchFunctionIsolations(FunctionType *func1,
   llvm_unreachable("bad kind");
 }
 
+bool ConstraintSystem::matchFunctionLifetimes(
+    const LifetimeDependentInterface &from,
+    const LifetimeDependentInterface &to, ConstraintLocatorBuilder locator) {
+
+  // A function with a lifetime dependency in a generic context is equivalent to
+  // one without that lifetime dependency when the substituted type is
+  // Escapable.
+  //
+  // There is also a subtype relationship from less-constrained to
+  // more-constrained lifetime dependencies (see
+  // LifetimeDependentInterface::canConvertTo).
+  if (!from.canConvertTo(to)) {
+    auto escapable = getASTContext()
+                         .getProtocol(KnownProtocolKind::Escapable)
+                         ->getDeclaredType();
+
+    for (auto &fromDep : from.getLifetimeDependencies()) {
+      // If a dependency is present for the same target in both types, then
+      // the dependency must match.
+      if (to.hasTarget(fromDep.getTargetIndex())) {
+        if (!from.canConvertTargetTo(fromDep, to))
+          return false;
+        continue;
+      }
+
+      // If the dependency is absent from the destination type, constrain the
+      // corresponding parameter or result in the source type to be Escapable.
+      addConstraint(ConstraintKind::ConformsTo,
+                    from.getSourceOrTargetType(fromDep.getTargetIndex()),
+                    escapable, locator);
+    }
+  }
+  return true;
+}
+
 ConstraintSystem::TypeMatchResult
 ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
                                      ConstraintKind kind, TypeMatchOptions flags,
@@ -3198,45 +3233,8 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
   if (!matchFunctionIsolations(func1, func2, kind, flags, locator))
     return getTypeMatchFailure(locator);
 
-  // A function with a lifetime dependency in a generic context is equivalent to
-  // one without that lifetime dependency when the substituted type is
-  // Escapable.
-  //
-  // TODO: There should also be a subtype relationship from less-constrained to
-  // more-constrained lifetime dependencies.
-  if (func1->getLifetimeDependencies() != func2->getLifetimeDependencies()) {
-    auto escapable = getASTContext().getProtocol(KnownProtocolKind::Escapable)
-      ->getDeclaredType();
-
-    for (auto &fromDep : func1->getLifetimeDependencies()) {
-      auto toDep = func2->getLifetimeDependenceFor(fromDep.getTargetIndex());
-      if (toDep) {
-        // If a dependency is present for the same target in both types, then
-        // the dependency must match.
-        if (fromDep != *toDep) {
-          return getTypeMatchFailure(locator);
-        }
-        
-        continue;
-      }
-      
-      // If the dependency is absent from the destination type, constrain the
-      // corresponding parameter or result in the source type to be Escapable.
-      if (fromDep.getTargetIndex() == func1->getParams().size()) {
-        // Result dependency.
-        addConstraint(ConstraintKind::ConformsTo,
-                      func1->getResult(),
-                      escapable,
-                      locator);
-      } else {
-        // Parameter dependency.
-        addConstraint(ConstraintKind::ConformsTo,
-                    func1->getParams()[fromDep.getTargetIndex()].getPlainType(),
-                    escapable,
-                    locator);
-      }
-    }
-  }
+  if (!matchFunctionLifetimes(func1, func2, locator))
+    return getTypeMatchFailure(locator);
 
   // To contextual type increase the score to avoid ambiguity when solver can
   // find more than one viable binding different only in representation e.g.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -770,6 +770,9 @@ RequirementMatch swift::matchWitness(
         std::tuple<std::optional<RequirementMatch>, Type, Type, Type, Type>(void)>
         setup,
     llvm::function_ref<std::optional<RequirementMatch>(Type, Type)> matchTypes,
+    llvm::function_ref<std::optional<RequirementMatch>(
+        const LifetimeDependentInterface &, const LifetimeDependentInterface &)>
+        matchLifetimes,
     llvm::function_ref<RequirementMatch(bool, ArrayRef<OptionalAdjustment>)>
         finalize) {
   bool decomposeFunctionType = false;
@@ -908,6 +911,13 @@ RequirementMatch swift::matchWitness(
       if (!witnessFnType->getExtInfo().isAsync() &&
             (req->isObjC() && reqFnType->getExtInfo().isAsync())) {
         return RequirementMatch(witness, MatchKind::AsyncConflict);
+      }
+
+      // Check that lifetime dependencies match
+      if (auto result = matchLifetimes(
+              LifetimeDependentInterface::fromValueDecl(witness, witnessFnType),
+              LifetimeDependentInterface::fromValueDecl(req, reqFnType))) {
+        return std::move(result.value());
       }
 
       if (!reqThrownError) {
@@ -1321,6 +1331,17 @@ swift::matchWitness(WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
                            reqThrownError, witnessThrownError);
   };
 
+  // Attempt to add constraints to make the supplied function types match.
+  auto matchLifetimes = [&](const LifetimeDependentInterface &witnessInterface,
+                            const LifetimeDependentInterface &reqInterface)
+      -> std::optional<RequirementMatch> {
+    if (!cs->matchFunctionLifetimes(witnessInterface, reqInterface,
+                                    witnessLocator)) {
+      return RequirementMatch(witness, MatchKind::LifetimeConflict);
+    }
+    return std::nullopt;
+  };
+
   // Match a type in the requirement to a type in the witness.
   auto matchTypes = [&](Type reqType,
                         Type witnessType) -> std::optional<RequirementMatch> {
@@ -1411,7 +1432,8 @@ swift::matchWitness(WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
     return result;
   };
 
-  return matchWitness(dc, req, witness, setup, matchTypes, finalize);
+  return matchWitness(dc, req, witness, setup, matchTypes, matchLifetimes,
+                      finalize);
 }
 
 bool
@@ -3346,6 +3368,10 @@ diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
       diags.diagnose(witness, diag::protocol_witness_borrow_mutate_conflict,
                      diagMsg);
     }
+    break;
+  }
+  case MatchKind::LifetimeConflict: {
+    diags.diagnose(match.Witness, diag::protocol_witness_lifetime_conflict);
     break;
   }
   }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -766,9 +766,7 @@ static PossibleEffects getEffects(ValueDecl *value);
 
 RequirementMatch swift::matchWitness(
     DeclContext *dc, ValueDecl *req, ValueDecl *witness,
-    llvm::function_ref<
-        std::tuple<std::optional<RequirementMatch>, Type, Type, Type, Type>(void)>
-        setup,
+    llvm::function_ref<MatchWitnessTypes(void)> setup,
     llvm::function_ref<std::optional<RequirementMatch>(Type, Type)> matchTypes,
     llvm::function_ref<std::optional<RequirementMatch>(
         const LifetimeDependentInterface &, const LifetimeDependentInterface &)>
@@ -787,11 +785,11 @@ RequirementMatch swift::matchWitness(
   // in the process.
   Type reqType, witnessType, reqThrownError, witnessThrownError;
   {
-    std::optional<RequirementMatch> result;
-    std::tie(result, reqType, witnessType, reqThrownError, witnessThrownError) = setup();
-    if (result) {
-      return std::move(result.value());
-    }
+    auto types = setup();
+    reqType = types.requirement;
+    witnessType = types.witness;
+    reqThrownError = types.requirementThrows;
+    witnessThrownError = types.witnessThrows;
   }
 
   SmallVector<OptionalAdjustment, 2> optionalAdjustments;
@@ -1263,7 +1261,7 @@ swift::matchWitness(WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
 
   // Set up the constraint system for matching.
   auto setup =
-      [&]() -> std::tuple<std::optional<RequirementMatch>, Type, Type, Type, Type> {
+      [&]() -> MatchWitnessTypes {
     // Construct a constraint system to use to solve the equality between
     // the required type and the witness type.
     cs.emplace(dc, ConstraintSystemFlags::AllowFixes);
@@ -1327,8 +1325,8 @@ swift::matchWitness(WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
 
     Type witnessThrownError = openWitnessTypeInfo.thrownErrorTypeOnAccess;
 
-    return std::make_tuple(std::nullopt, reqType, openWitnessType,
-                           reqThrownError, witnessThrownError);
+    return MatchWitnessTypes{reqType, openWitnessType, reqThrownError,
+                             witnessThrownError};
   };
 
   // Attempt to add constraints to make the supplied function types match.

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -179,6 +179,9 @@ RequirementMatch matchWitness(
         std::tuple<std::optional<RequirementMatch>, Type, Type, Type, Type>(void)>
         setup,
     llvm::function_ref<std::optional<RequirementMatch>(Type, Type)> matchTypes,
+    llvm::function_ref<std::optional<RequirementMatch>(
+        const LifetimeDependentInterface &, const LifetimeDependentInterface &)>
+        matchLifetimes,
     llvm::function_ref<RequirementMatch(bool, ArrayRef<OptionalAdjustment>)>
         finalize);
 

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -170,14 +170,24 @@ public:
   void resolveSingleWitness(ValueDecl *requirement);
 };
 
+/// The types that should be used when matching a witness and a requirement.
+struct MatchWitnessTypes {
+  /// The interface type of the requirement.
+  Type requirement;
+  /// The interface type of the witness.
+  Type witness;
+  /// The type the requirement throws.
+  Type requirementThrows;
+  /// The type the witness throws.
+  Type witnessThrows;
+};
+
 /// Match the given witness to the given requirement.
 ///
 /// \returns the result of performing the match.
 RequirementMatch matchWitness(
     DeclContext *dc, ValueDecl *req, ValueDecl *witness,
-    llvm::function_ref<
-        std::tuple<std::optional<RequirementMatch>, Type, Type, Type, Type>(void)>
-        setup,
+    llvm::function_ref<MatchWitnessTypes(void)> setup,
     llvm::function_ref<std::optional<RequirementMatch>(Type, Type)> matchTypes,
     llvm::function_ref<std::optional<RequirementMatch>(
         const LifetimeDependentInterface &, const LifetimeDependentInterface &)>

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_protocol.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_protocol.swift
@@ -1,0 +1,28 @@
+// RUN: %target-swift-frontend %s -emit-sil \
+// RUN:   -enable-builtin-module \
+// RUN:   -sil-verify-all \
+// RUN:   -module-name test \
+// RUN:   -enable-experimental-feature Lifetimes \
+// RUN:   | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_Lifetimes
+
+import Builtin
+struct NE: ~Escapable {}
+
+// In rdar://157801454, a bug is mentioned where the lifetimes specified by a protocol are copied to the implementation.
+// This test verifies that this does not happen.
+protocol P157801454 {
+  @_lifetime(borrow a1, borrow a2)
+  func lifetimetest(a1: Int, a2: Int) -> NE
+}
+
+// CHECK-LABEL: sil hidden @$s4test10S157801454V12lifetimetest2a12a2AA2NEVSi_SitF : $@convention(method) (Int, Int, S157801454) -> @lifetime(borrow 1) @owned NE {
+// CHECK-LABEL: } // end sil function '$s4test10S157801454V12lifetimetest2a12a2AA2NEVSi_SitF'
+struct S157801454 : P157801454 {
+  @_lifetime(borrow a2)
+  func lifetimetest(a1: Int, a2: Int) -> NE {
+    fatalError()
+  }
+}

--- a/test/Sema/lifetime_attr.swift
+++ b/test/Sema/lifetime_attr.swift
@@ -310,3 +310,19 @@ func baz1() -> @_lifetime(copy span) (_ span: Span<Int>) -> Span<Int> {
 func baz2() -> @_lifetime(copy span) (_ span: Span<Int>) -> Span<Int> {
   return Holder.incorrect  // expected-error{{cannot convert return expression of type '@_lifetime(borrow 0) (Span<Int>) -> Span<Int>' to return type '@_lifetime(copy span) (_ span: Span<Int>) -> Span<Int>'}}
 }
+
+struct StaticIOMethods {
+  @_lifetime(ne0: copy ne0)
+  static func staticInoutCopying0(ne0: inout NE, ne1: borrowing NE)  {}
+  @_lifetime(ne0: copy ne0, borrow ne1)
+  static func staticInoutCopying0Borrowing1(ne0: inout NE, ne1: borrowing NE)  {}
+  @_lifetime(ne0: copy ne0, copy ne1)
+  static func staticInoutCopying0Copying1(ne0: inout NE, ne1: borrowing NE)  {}
+}
+
+do {
+  typealias IOTransfer = @_lifetime(ne0: copy ne0, borrow ne1) (_ ne0: inout NE, _ ne1: borrowing NE) -> ()
+  let _: IOTransfer = StaticIOMethods.staticInoutCopying0 // OK
+  let _: IOTransfer = StaticIOMethods.staticInoutCopying0Borrowing1 // OK
+  let _: IOTransfer = StaticIOMethods.staticInoutCopying0Copying1 // expected-error {{cannot convert value of type '@_lifetime(0: copy 0, copy 1) (inout NE, borrowing NE) -> ()' to specified type 'IOTransfer' (aka '@_lifetime(ne0: copy ne0, borrow ne1) (_ ne0: inout NE, _ ne1: borrowing NE) -> ()')}}
+}

--- a/test/Sema/lifetime_dependence_functype.swift
+++ b/test/Sema/lifetime_dependence_functype.swift
@@ -160,8 +160,7 @@ do {
 do {
   let x = NE()
   var y = NE()
-  takeGetGenericAndArgs(f: getImmortalNE, o: &y, i: x)
-  //  expected-error@-1{{cannot convert value of type '@_lifetime(0: immortal) (inout NE, borrowing NE) -> ()' to expected argument type '@_lifetime(outValue: copy outValue, borrow inValue) (_ outValue: inout NE, _ inValue: borrowing NE) -> ()'}}
+  takeGetGenericAndArgs(f: getImmortalNE, o: &y, i: x) // OK
 }
 do {
   let x = NE()
@@ -220,3 +219,183 @@ public let TypeParameterResultFunctionType = copyCNE as (CNE<NE>) -> _          
                                                                                                               // expected-error@-1{{failed to produce diagnostic for expression}}
 public let TypeParameterResultFunctionTypeAnnotated = copyCNE as @_lifetime(borrow cne) (_ cne: CNE<NE>) -> _ // expected-error{{lifetime dependence checking failed due to unknown result type}}
                                                                                                               // expected-error@-1{{failed to produce diagnostic for expression}}
+
+// Lifetime "Subtype" Relationships
+//
+// Adding sources to a lifetime dependency makes it more restrictive, since the
+// target depends on all of the sources. Hence, functions can be passed as
+// function types with a superset of the function's dependencies.
+
+func takeCopying0(
+  f: @_lifetime(copy ne0)
+    (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE) {}
+
+func takeCopying1(
+  f: @_lifetime(copy ne1)
+    (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE) {}
+
+func takeCopying01(
+  f: @_lifetime(copy ne0, copy ne1)
+    (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE) {}
+
+@_lifetime(copy ne0)
+func copying0(ne0: NE, ne1: NE, ne2: borrowing NE, ne3: borrowing NE, ne4: inout NE) -> NE {
+  return ne0
+}
+
+@_lifetime(copy ne1)
+func copying1(ne0: NE, ne1: NE, ne2: borrowing NE, ne3: borrowing NE, ne4: inout NE) -> NE {
+  return ne1
+}
+
+@_lifetime(copy ne0, copy ne1)
+func copying01(ne0: NE, ne1: NE, ne2: borrowing NE, ne3: borrowing NE, ne4: inout NE) -> NE {
+  return ne0
+}
+
+
+func takeBorrowing2(
+  f: @_lifetime(borrow ne2)
+    (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE) {}
+
+func takeBorrowing3(
+  f: @_lifetime(borrow ne3)
+    (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE) {}
+
+func takeBorrowing23(
+  f: @_lifetime(borrow ne2, borrow ne3)
+    (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE) {}
+
+@_lifetime(borrow ne2)
+func borrowing2(ne0: NE, ne1: NE, ne2: borrowing NE, ne3: borrowing NE, ne4: inout NE) -> NE {
+  return ne2
+}
+
+@_lifetime(borrow ne3)
+func borrowing3(ne0: NE, ne1: NE, ne2: borrowing NE, ne3: borrowing NE, ne4: inout NE) -> NE {
+  return ne3
+}
+
+@_lifetime(borrow ne2, borrow ne3)
+func borrowing23(ne0: NE, ne1: NE, ne2: borrowing NE, ne3: borrowing NE, ne4: inout NE) -> NE {
+  return ne2
+}
+
+
+func takeCopying0Borrowing2(
+  f: @_lifetime(copy ne0, borrow ne2)
+    (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE) {}
+
+@_lifetime(copy ne0, borrow ne2)
+func copying0borrowing2(ne0: NE, ne1: NE, ne2: borrowing NE, ne3: borrowing NE, ne4: inout NE) -> NE {
+  return ne2
+}
+
+@_lifetime(copy ne0, borrow ne2, borrow ne3)
+func copying0borrowing2borrowing3(ne0: NE, ne1: NE, ne2: borrowing NE, ne3: borrowing NE, ne4: inout NE) -> NE {
+  return ne2
+}
+
+@_lifetime(copy ne0, copy ne1, borrow ne2)
+func copying0copying1borrowing2(ne0: NE, ne1: NE, ne2: borrowing NE, ne3: borrowing NE, ne4: inout NE) -> NE {
+  return ne2
+}
+
+@_lifetime(copy ne0, copy ne1, borrow ne2, borrow ne3)
+func copying0copying1borrowing2borrowing3(ne0: NE, ne1: NE, ne2: borrowing NE, ne3: borrowing NE, ne4: inout NE) -> NE {
+  return ne2
+}
+
+@_lifetime(&ne4)
+func mutborrowing4(ne0: NE, ne1: NE, ne2: borrowing NE, ne3: borrowing NE, ne4: inout NE) -> NE{
+  return ne4
+}
+
+func takeMutborrowing4(f: @_lifetime(&ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE) {}
+
+@_lifetime(immortal)
+func immortalFn(ne0: NE, ne1: NE, ne2: borrowing NE, ne3: borrowing NE, ne4: inout NE) -> NE {
+  return NE()
+}
+
+func takeImmortal(f: @_lifetime(immortal) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE) {}
+
+
+@_lifetime(ne0: copy ne0)
+func inout0(ne0: inout NE, ne1: NE) {}
+
+@_lifetime(ne0: copy ne0, copy ne1)
+func inout01(ne0: inout NE, ne1: NE) {}
+
+func takeInout0(f: @_lifetime(ne0: copy ne0) (_ ne0: inout NE, _ ne1: NE) -> ()) {}
+func takeInout01(f: @_lifetime(ne0: copy ne0, copy ne1) (_ ne0: inout NE, _ ne1: NE) -> ()) {}
+
+
+func callLifetimeFunctions() {
+  takeCopying0(f: copying0) // OK
+  takeCopying0(f: copying1) // expected-error{{cannot convert value of type '@_lifetime(copy 1) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(copy ne0) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeCopying0(f: copying01) // expected-error{{cannot convert value of type '@_lifetime(copy 0, copy 1) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(copy ne0) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+
+  takeCopying1(f: copying0) // expected-error{{cannot convert value of type '@_lifetime(copy 0) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(copy ne1) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeCopying1(f: copying1) // OK
+  takeCopying1(f: copying01) // expected-error{{cannot convert value of type '@_lifetime(copy 0, copy 1) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(copy ne1) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+
+  takeCopying01(f: copying0) // OK
+  takeCopying01(f: copying1) // OK
+  takeCopying01(f: copying01) // OK
+
+
+  takeBorrowing2(f: borrowing2) // OK
+  takeBorrowing2(f: borrowing3) // expected-error{{cannot convert value of type '@_lifetime(borrow 3) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(borrow ne2) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeBorrowing2(f: borrowing23) // expected-error{{cannot convert value of type '@_lifetime(borrow 2, borrow 3) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(borrow ne2) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+
+  takeBorrowing3(f: borrowing2) // expected-error{{cannot convert value of type '@_lifetime(borrow 2) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(borrow ne3) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeBorrowing3(f: borrowing3) // OK
+  takeBorrowing3(f: borrowing23) // expected-error{{cannot convert value of type '@_lifetime(borrow 2, borrow 3) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(borrow ne3) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+
+  takeBorrowing23(f: borrowing2) // OK
+  takeBorrowing23(f: borrowing3) // OK
+  takeBorrowing23(f: borrowing23) // OK
+
+
+  takeCopying0(f: copying0borrowing2) // expected-error{{cannot convert value of type '@_lifetime(copy 0, borrow 2) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(copy ne0) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeBorrowing2(f: copying0borrowing2) // expected-error{{cannot convert value of type '@_lifetime(copy 0, borrow 2) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(borrow ne2) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+
+  takeCopying0Borrowing2(f: copying0) // OK
+  takeCopying0Borrowing2(f: borrowing2) // OK
+  takeCopying0Borrowing2(f: copying0borrowing2) // OK
+  takeCopying0Borrowing2(f: copying0borrowing2borrowing3) // expected-error{{cannot convert value of type '@_lifetime(copy 0, borrow 2, borrow 3) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(copy ne0, borrow ne2) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeCopying0Borrowing2(f: copying0copying1borrowing2) // expected-error{{cannot convert value of type '@_lifetime(copy 0, copy 1, borrow 2) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(copy ne0, borrow ne2) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeCopying0Borrowing2(f: copying0copying1borrowing2borrowing3) // expected-error{{cannot convert value of type '@_lifetime(copy 0, copy 1, borrow 2, borrow 3) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(copy ne0, borrow ne2) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+
+
+  takeMutborrowing4(f: mutborrowing4) // OK
+  takeMutborrowing4(f: copying0) // expected-error{{cannot convert value of type '@_lifetime(copy 0) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(&ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeCopying0(f: mutborrowing4) // expected-error{{cannot convert value of type '@_lifetime(&4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(copy ne0) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeBorrowing2(f: mutborrowing4) // expected-error{{cannot convert value of type '@_lifetime(&4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(borrow ne2) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+
+
+  takeCopying0(f: immortalFn) // OK
+  takeCopying1(f: immortalFn) // OK
+  takeCopying01(f: immortalFn) // OK
+  takeBorrowing2(f: immortalFn) // OK
+  takeBorrowing3(f: immortalFn) // OK
+  takeBorrowing23(f: immortalFn) // OK
+  takeCopying0Borrowing2(f: immortalFn) // OK
+  takeMutborrowing4(f: immortalFn) // OK
+
+  takeImmortal(f: copying0) // expected-error{{cannot convert value of type '@_lifetime(copy 0) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(immortal) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeImmortal(f: copying1) // expected-error{{cannot convert value of type '@_lifetime(copy 1) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(immortal) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeImmortal(f: copying01) // expected-error{{cannot convert value of type '@_lifetime(copy 0, copy 1) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(immortal) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeImmortal(f: borrowing2) // expected-error{{cannot convert value of type '@_lifetime(borrow 2) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(immortal) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeImmortal(f: borrowing3) // expected-error{{cannot convert value of type '@_lifetime(borrow 3) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(immortal) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeImmortal(f: borrowing23) // expected-error{{cannot convert value of type '@_lifetime(borrow 2, borrow 3) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(immortal) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeImmortal(f: copying0borrowing2) // expected-error{{cannot convert value of type '@_lifetime(copy 0, borrow 2) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(immortal) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeImmortal(f: mutborrowing4) // expected-error{{cannot convert value of type '@_lifetime(&4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(immortal) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeImmortal(f: immortalFn) // OK
+
+  takeInout0(f: inout0) // OK
+  takeInout0(f: inout01) // expected-error{{cannot convert value of type '@_lifetime(0: copy 0, copy 1) (inout NE, NE) -> ()' to expected argument type '@_lifetime(ne0: copy ne0) (_ ne0: inout NE, _ ne1: NE) -> ()'}}
+  takeInout01(f: inout01) // OK
+  takeInout01(f: inout0) // OK
+}

--- a/test/decl/protocol/conforms/lifetime.swift
+++ b/test/decl/protocol/conforms/lifetime.swift
@@ -1,0 +1,353 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature Lifetimes -enable-experimental-feature SuppressedAssociatedTypesWithDefaults
+
+// REQUIRES: swift_feature_Lifetimes
+// REQUIRES: swift_feature_SuppressedAssociatedTypesWithDefaults
+
+struct NE: ~Escapable {}
+
+// MARK: Instance methods
+
+protocol P {
+  // One note is produced for each failed conformance for each method.
+
+  // TODO: Update expected notes once we add closure context dependencies and
+  // can attach method lifetime dependence information to the function type.
+  @_lifetime(copy a, copy c)
+  func foo(a: NE, b: NE, c: NE) -> NE
+  // expected-note@-1 {{protocol requires function 'foo(a:b:c:)' with type '(NE, NE, NE) -> NE'}}
+  // expected-note@-2 {{protocol requires function 'foo(a:b:c:)' with type '(NE, NE, NE) -> NE'}}
+  // expected-note@-3 {{protocol requires function 'foo(a:b:c:)' with type '(NE, NE, NE) -> NE'}}
+  // expected-note@-4 {{protocol requires function 'foo(a:b:c:)' with type '(NE, NE, NE) -> NE'}}
+}
+
+struct ExactMatchP: P {
+  @_lifetime(copy a, copy c)
+  func foo(a: NE, b: NE, c: NE) -> NE { a } // OK
+}
+
+struct DisjointCopyP: P { // expected-error {{type 'DisjointCopyP' does not conform to protocol 'P'}} expected-note {{add stubs for conformance}}
+  @_lifetime(copy b, copy c)
+  func foo(a: NE, b: NE, c: NE) -> NE { b } // expected-note {{candidate has a lifetime dependence not specified by the protocol}}
+}
+
+struct DisjointBorrowP: P { // expected-error {{type 'DisjointBorrowP' does not conform to protocol 'P'}} expected-note {{add stubs for conformance}}
+  @_lifetime(borrow a)
+  func foo(a: NE, b: NE, c: NE) -> NE { a } // expected-note {{candidate has a lifetime dependence not specified by the protocol}}
+}
+
+struct SupersetCopyP: P { // expected-error {{type 'SupersetCopyP' does not conform to protocol 'P'}} expected-note {{add stubs for conformance}}
+  @_lifetime(copy a, copy b, copy c)
+  func foo(a: NE, b: NE, c: NE) -> NE { b } // expected-note {{candidate has a lifetime dependence not specified by the protocol}}
+}
+
+struct SupersetBorrowP: P { // expected-error {{type 'SupersetBorrowP' does not conform to protocol 'P'}} expected-note {{add stubs for conformance}}
+  @_lifetime(copy a, copy c, borrow b)
+  func foo(a: NE, b: NE, c: NE) -> NE { b } // expected-note {{candidate has a lifetime dependence not specified by the protocol}}
+}
+
+// Witnesses can conform to the protocol if they have a subset of the lifetimes specified by the protocol.
+
+struct SubsetImmortalP: P { // OK
+  @_lifetime(immortal)
+  func foo(a: NE, b: NE, c: NE) -> NE { fatalError() } // OK
+}
+
+struct SubsetAP: P { // OK
+  @_lifetime(copy a)
+  func foo(a: NE, b: NE, c: NE) -> NE { a } // OK
+}
+
+// MARK: Static methods
+protocol PS {
+  @_lifetime(copy a, copy c)
+  static func baz(a: NE, b: NE, c: NE) -> NE
+  // expected-note@-1 {{protocol requires function 'baz(a:b:c:)' with type '@_lifetime(copy a, copy c) (a a: NE, b b: NE, c c: NE) -> NE'}}
+  // expected-note@-2 {{protocol requires function 'baz(a:b:c:)' with type '@_lifetime(copy a, copy c) (a a: NE, b b: NE, c c: NE) -> NE'}}
+  // expected-note@-3 {{protocol requires function 'baz(a:b:c:)' with type '@_lifetime(copy a, copy c) (a a: NE, b b: NE, c c: NE) -> NE'}}
+  // expected-note@-4 {{protocol requires function 'baz(a:b:c:)' with type '@_lifetime(copy a, copy c) (a a: NE, b b: NE, c c: NE) -> NE'}}
+}
+
+struct ExactMatchPS: PS {
+  @_lifetime(copy a, copy c)
+  static func baz(a: NE, b: NE, c: NE) -> NE { a } // OK
+}
+
+struct DisjointCopyPS: PS { // expected-error {{type 'DisjointCopyPS' does not conform to protocol 'PS'}} expected-note {{add stubs for conformance}}
+  @_lifetime(copy b, copy c)
+  static func baz(a: NE, b: NE, c: NE) -> NE { b } // expected-note {{candidate has a lifetime dependence not specified by the protocol}}
+}
+
+struct DisjointBorrowPS: PS { // expected-error {{type 'DisjointBorrowPS' does not conform to protocol 'PS'}} expected-note {{add stubs for conformance}}
+  @_lifetime(borrow a)
+  static func baz(a: NE, b: NE, c: NE) -> NE { a } // expected-note {{candidate has a lifetime dependence not specified by the protocol}}
+}
+
+struct SupersetCopyPS: PS { // expected-error {{type 'SupersetCopyPS' does not conform to protocol 'PS'}} expected-note {{add stubs for conformance}}
+  @_lifetime(copy a, copy b, copy c)
+  static func baz(a: NE, b: NE, c: NE) -> NE { b } // expected-note {{candidate has a lifetime dependence not specified by the protocol}}
+}
+
+struct SupersetBorrowPS: PS { // expected-error {{type 'SupersetBorrowPS' does not conform to protocol 'PS'}} expected-note {{add stubs for conformance}}
+  @_lifetime(copy a, copy c, borrow b)
+  static func baz(a: NE, b: NE, c: NE) -> NE { b } // expected-note {{candidate has a lifetime dependence not specified by the protocol}}
+}
+
+struct SubsetImmortalPS: PS { // OK
+  @_lifetime(immortal)
+  static func baz(a: NE, b: NE, c: NE) -> NE { fatalError() } // OK
+}
+
+struct SubsetAPS: PS { // OK
+  @_lifetime(copy a)
+  static func baz(a: NE, b: NE, c: NE) -> NE { a } // OK
+}
+
+// MARK: Inferred defaults equivalent to explicit spelling.
+//
+// Whether the dependencies were explicit or inferred should not affect
+// conformance.
+protocol Q {
+  func baz(ne: NE) -> NE
+  @_lifetime(copy ne)
+  func qux(ne: NE) -> NE
+}
+
+struct ExplicitQ: Q { // OK
+  @_lifetime(copy ne)
+  func baz(ne: NE) -> NE { ne }
+  @_lifetime(copy ne)
+  func qux(ne: NE) -> NE { ne }
+}
+
+struct ImplicitQ: Q { // OK
+  func baz(ne: NE) -> NE { ne }
+  func qux(ne: NE) -> NE { ne }
+}
+
+// MARK: Conformances with function-type parameters.
+//
+// A witness method taking a function-type parameter f conforms if f's lifetime
+// dependencies in the witness are a *superset* of the dependencies specified by
+// the protocol. This ensures that the witness will respect the lifetime
+// dependencies for any function that could be passed as a parameter to the
+// protocol's method.
+
+protocol R {
+  func bar(f: @_lifetime(copy a, copy c) (_ a: NE, _ b: NE, _ c: NE) -> NE)
+  // expected-note@-1 {{protocol requires function 'bar(f:)' with type '(@_lifetime(copy a, copy c) (_ a: NE, _ b: NE, _ c: NE) -> NE) -> ()'}}
+  // expected-note@-2 {{protocol requires function 'bar(f:)' with type '(@_lifetime(copy a, copy c) (_ a: NE, _ b: NE, _ c: NE) -> NE) -> ()'}}
+  // expected-note@-3 {{protocol requires function 'bar(f:)' with type '(@_lifetime(copy a, copy c) (_ a: NE, _ b: NE, _ c: NE) -> NE) -> ()'}}
+  // expected-note@-4 {{protocol requires function 'bar(f:)' with type '(@_lifetime(copy a, copy c) (_ a: NE, _ b: NE, _ c: NE) -> NE) -> ()'}}
+  // expected-note@-5 {{protocol requires function 'bar(f:)' with type '(@_lifetime(copy a, copy c) (_ a: NE, _ b: NE, _ c: NE) -> NE) -> ()'}}
+}
+
+struct ExactMatchR: R {
+  func bar( // OK
+    f: @_lifetime(copy a, copy c) (_ a: NE, _ b: NE, _ c: NE) -> NE) {}
+}
+
+struct DisjointCopyR: R { // expected-error {{type 'DisjointCopyR' does not conform to protocol 'R'}} expected-note {{add stubs for conformance}}
+  func bar( // expected-note {{candidate has non-matching type '(@_lifetime(copy b, copy c) (_ a: NE, _ b: NE, _ c: NE) -> NE) -> ()'}}
+    f: @_lifetime(copy b, copy c) (_ a: NE, _ b: NE, _ c: NE) -> NE) {}
+}
+
+struct MismatchBorrow: R { // expected-error {{type 'MismatchBorrow' does not conform to protocol 'R'}} expected-note {{add stubs for conformance}}
+  func bar( // expected-note {{candidate has non-matching type '(@_lifetime(borrow a, borrow c) (_ a: NE, _ b: NE, _ c: NE) -> NE) -> ()'}}
+    f: @_lifetime(borrow a, borrow c) (_ a: NE, _ b: NE, _ c: NE) -> NE) {}
+}
+
+struct DisjointBorrowR: R { // expected-error {{type 'DisjointBorrowR' does not conform to protocol 'R'}} expected-note {{add stubs for conformance}}
+  func bar( // expected-note {{candidate has non-matching type '(@_lifetime(borrow a) (_ a: NE, _ b: NE, _ c: NE) -> NE) -> ()'}}
+    f: @_lifetime(borrow a) (_ a: NE, _ b: NE, _ c: NE) -> NE) {}
+}
+
+struct SupersetCopyR: R { // OK
+  func bar( // OK
+    f: @_lifetime(copy a, copy b, copy c) (_ a: NE, _ b: NE, _ c: NE) -> NE) {}
+}
+
+struct SupersetBorrowR: R { // OK
+  func bar( // OK
+    f: @_lifetime(copy a, copy c, borrow b) (_ a: NE, _ b: NE, _ c: NE) -> NE) {}
+}
+
+struct SubsetImmortalR: R { // expected-error {{type 'SubsetImmortalR' does not conform to protocol 'R'}} expected-note {{add stubs for conformance}}
+  func bar( // expected-note {{candidate has non-matching type '(@_lifetime(immortal) (_ a: NE, _ b: NE, _ c: NE) -> NE) -> ()'}}
+    f: @_lifetime(immortal) (_ a: NE, _ b: NE, _ c: NE) -> NE) {}
+}
+
+struct SubsetAR: R { // expected-error {{type 'SubsetAR' does not conform to protocol 'R'}} expected-note {{add stubs for conformance}}
+  func bar( // expected-note {{candidate has non-matching type '(@_lifetime(copy a) (_ a: NE, _ b: NE, _ c: NE) -> NE) -> ()'}}
+    f: @_lifetime(copy a) (_ a: NE, _ b: NE, _ c: NE) -> NE) {}
+}
+
+// MARK: Types conforming to non-Escapable protocols
+protocol S: ~Escapable {
+  associatedtype T: ~Escapable
+  @_lifetime(a: copy a, copy b)
+  @_lifetime(b: copy b)
+  @_lifetime(copy a, copy c)
+  func foo(a: inout T, b: inout T, c: T) -> T
+  // expected-note@-1 {{protocol requires function 'foo(a:b:c:)' with type '(inout BorrowMismatchS.T, inout BorrowMismatchS.T, BorrowMismatchS.T) -> BorrowMismatchS.T' (aka '(inout NE, inout NE, NE) -> NE')}}
+  // expected-note@-2 {{protocol requires function 'foo(a:b:c:)' with type '(inout BorrowMismatchS2.T, inout BorrowMismatchS2.T, BorrowMismatchS2.T) -> BorrowMismatchS2.T' (aka '(inout NE, inout NE, NE) -> NE')}}
+  // expected-note@-3 {{protocol requires function 'foo(a:b:c:)' with type '(inout SupersetResultS.T, inout SupersetResultS.T, SupersetResultS.T) -> SupersetResultS.T' (aka '(inout NE, inout NE, NE) -> NE')}}
+  // expected-note@-4 {{protocol requires function 'foo(a:b:c:)' with type '(inout SupersetAS.T, inout SupersetAS.T, SupersetAS.T) -> SupersetAS.T' (aka '(inout NE, inout NE, NE) -> NE')}}
+}
+
+struct ExactMatchS: S { // OK
+  typealias T = NE
+  @_lifetime(a: copy a, copy b)
+  @_lifetime(b: copy b)
+  @_lifetime(copy a, copy c)
+  func foo(a: inout T, b: inout T, c: T) -> T { fatalError() }
+}
+
+struct BorrowMismatchS: S { // expected-error {{type 'BorrowMismatchS' does not conform to protocol 'S'}} expected-note {{add stubs for conformance}}
+  typealias T = NE
+  @_lifetime(a: copy a, copy b)
+  @_lifetime(b: copy b)
+  @_lifetime(copy a, borrow c)
+  func foo(a: inout T, b: inout T, c: T) -> T { fatalError() }
+  // expected-note@-1 {{candidate has a lifetime dependence not specified by the protocol}}
+}
+
+struct BorrowMismatchS2: S { // expected-error {{type 'BorrowMismatchS2' does not conform to protocol 'S'}} expected-note {{add stubs for conformance}}
+  typealias T = NE
+  @_lifetime(a: copy a, copy b)
+  @_lifetime(b: &a, copy b)
+  @_lifetime(copy a, copy c)
+  func foo(a: inout T, b: inout T, c: T) -> T { fatalError() }
+  // expected-note@-1 {{candidate has a lifetime dependence not specified by the protocol}}
+}
+
+struct SubsetImmortalS: S { // OK
+  typealias T = NE
+  @_lifetime(a: immortal)
+  @_lifetime(b: immortal)
+  @_lifetime(immortal)
+  func foo(a: inout T, b: inout T, c: T) -> T { fatalError() }
+}
+
+struct SubsetAS: S { // OK
+  typealias T = NE
+  @_lifetime(a: copy a)
+  @_lifetime(b: copy b)
+  @_lifetime(copy c)
+  func foo(a: inout T, b: inout T, c: T) -> T { fatalError() }
+}
+
+struct SubsetCS: S { // OK
+  typealias T = NE
+  @_lifetime(a: copy a, copy b)
+  @_lifetime(b: copy b)
+  @_lifetime(copy c)
+  func foo(a: inout T, b: inout T, c: T) -> T { fatalError() }
+}
+
+struct SupersetResultS: S { // expected-error {{type 'SupersetResultS' does not conform to protocol 'S'}} expected-note {{add stubs for conformance}}
+  typealias T = NE
+  @_lifetime(a: copy a, copy b)
+  @_lifetime(b: copy b)
+  @_lifetime(copy a, copy b, copy c)
+  func foo(a: inout T, b: inout T, c: T) -> T { fatalError() }
+  // expected-note@-1 {{candidate has a lifetime dependence not specified by the protocol}}
+}
+
+struct SupersetAS: S { // expected-error {{type 'SupersetAS' does not conform to protocol 'S'}} expected-note {{add stubs for conformance}}
+  typealias T = NE
+  @_lifetime(a: copy a, copy b, copy c)
+  @_lifetime(b: copy b)
+  @_lifetime(copy a, copy c)
+  func foo(a: inout T, b: inout T, c: T) -> T { fatalError() }
+  // expected-note@-1 {{candidate has a lifetime dependence not specified by the protocol}}
+}
+
+struct EscapableS: S { // OK
+  func foo(a: inout Int, b: inout Int, c: Int) -> Int { a }
+}
+
+// MARK: Conditionally escapable types conforming to protocols
+protocol IGet { // expected-note{{type 'NEGet' does not conform to inherited protocol 'Escapable'}}
+  associatedtype T
+  func get() -> T
+}
+
+public struct CNEGetCopy<T: ~Escapable>: ~Escapable {
+  let ne: T
+
+  @_lifetime(copy ne)
+  init(ne: T) { self.ne = ne }
+
+  @_lifetime(copy self)
+  func get() -> T { ne }
+}
+extension CNEGetCopy: Escapable where T: Escapable {}
+extension CNEGetCopy: IGet { } // OK: Dependencies are ignored when the target is Escapable.
+
+public struct CNEGetBorrow<T: ~Escapable>: ~Escapable {
+  let e: T
+
+  @_lifetime(borrow e)
+  init(e: borrowing T) { self.e = e }
+
+  @_lifetime(borrow self)
+  func get() -> T { e }
+}
+extension CNEGetBorrow: Escapable where T: Escapable {}
+extension CNEGetBorrow: IGet { } // OK: Dependencies are ignored when the target is Escapable.
+
+public struct NEGet: ~Escapable {
+  @_lifetime(copy self)
+  func get() -> NE { fatalError() }
+}
+extension NEGet: IGet { } // expected-error{{type 'NEGet' does not conform to protocol 'Escapable'}}
+
+// MARK: rdar://157801454 ([nonescapable] [typechecker] Unexpected lifetime error while conforming a method with a different lifetime annotation)
+protocol P157801454 {
+  @_lifetime(array1)
+  func lifetimetest(array1: Int, array2: Int) -> NE // expected-note{{protocol requires function 'lifetimetest(array1:array2:)' with type '(Int, Int) -> NE'}}
+}
+
+struct S157801454 : P157801454 { // expected-error{{type 'S157801454' does not conform to protocol 'P157801454'}} expected-note {{add stubs for conformance}}
+  @_lifetime(array2)
+  func lifetimetest(array1: Int, array2: Int) -> NE { // expected-note{{candidate has a lifetime dependence not specified by the protocol}}
+    fatalError()
+  }
+}
+
+// MARK: Simultaneous conformance to conflicting protocols
+protocol CopyF: ~Escapable {
+  @_lifetime(copy self)
+  func f() -> NE // expected-note{{protocol requires function 'f()' with type '() -> NE'}}
+}
+
+protocol BorrowF: ~Escapable {
+  @_lifetime(borrow self)
+  func f() -> NE
+}
+
+struct OverloadF: ~Escapable {
+  @_lifetime(borrow self)
+  func f() -> NE { fatalError() } // expected-note{{candidate has a lifetime dependence not specified by the protocol}}
+}
+extension OverloadF: BorrowF {}
+extension OverloadF: CopyF {} // expected-error{{type 'OverloadF' does not conform to protocol 'CopyF'}} expected-note{{add stubs for conformance}}
+
+// MARK: Static protocol methods
+protocol SM {
+  @_lifetime(ne0: copy ne0)
+  static func f(ne0: inout NE, ne1: borrowing NE)
+  //expected-note@-1 {{protocol requires function 'f(ne0:ne1:)' with type '@_lifetime(ne0: copy ne0) (ne0 ne0: inout NE, ne1 ne1: borrowing NE) -> ()'}}
+}
+struct ExactMatchSM: SM { // OK
+  @_lifetime(ne0: copy ne0)
+  static func f(ne0: inout NE, ne1: borrowing NE) {}
+}
+struct SubsetSM: SM { // OK
+  @_lifetime(ne0: immortal)
+  static func f(ne0: inout NE, ne1: borrowing NE) { fatalError() }
+}
+struct SupersetSM: SM { // expected-error{{type 'SupersetSM' does not conform to protocol 'SM'}} expected-note{{add stubs for conformance}}
+  @_lifetime(ne0: copy ne0, copy ne1)
+  static func f(ne0: inout NE, ne1: borrowing NE) { fatalError() } // expected-note{{candidate has a lifetime dependence not specified by the protocol}}
+}


### PR DESCRIPTION
Fixes:
- rdar://160970376 (protocol requirements should require matching methods signatures, including `@lifetime`)
- rdar://157801454 ([nonescapable] [typechecker] Unexpected lifetime error while conforming a method with a different lifetime annotation)
- rdar://169975618 ([nonescapable] Type conversion for function types with lifetime dependencies)
- rdar://170996751 (Test lifetime dependence for inout parameters of static methods)
- rdar://172653349 (Generalised abstract interface for lifetime compatibility checking)

For a type to safely conform to a protocol, the lifetime dependencies specified in the protocol must a *superset* of those specified by the type's corresponding witness methods. This ensures that however the protocol is used, the lifetime dependencies of the witness methods are not violated. The same logic applies to function type coercion: as long as the new type has "more restrictive" lifetime dependencies, the constraints imposed by the original type will still hold.

To support this, we introduce `LifetimeDependenceInfo::isConvertibleTo` and `matchLifetimeDependencies`. With these functions, we allow one function type to convert to another if the new type has a superset of the original's lifetime dependencies. This includes appropriate handling for immortal and nonexistent lifetime dependencies, as well as conditionally Escapable types.

It is not sufficient to require that the dependencies of the protocol and witness are equal, since this would break existing code where the witness method has a *strict subset* of the lifetime dependencies specified by the protocol.

Formalised lifetime subtyping rules: https://github.com/swiftlang/swift/pull/87567/changes

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
