### PR TITLE
[Serialization] Store the explicit module map in swiftmodules 

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -88,6 +88,8 @@ namespace swift {
   class DerivativeAttr;
   class DifferentiableAttr;
   class ExtensionDecl;
+  struct ExplicitSwiftModuleMap;
+  struct ExplicitClangModuleMap;
   struct ExternalSourceLocs;
   class ForeignRepresentationInfo;
   class FuncDecl;
@@ -1074,8 +1076,8 @@ public:
   /// Does any proper bookkeeping to keep all module loaders up to date as well.
   void addSearchPath(StringRef searchPath, bool isFramework, bool isSystem);
 
-  /// Adds the path to the explicitly built module \c name.
-  void addExplicitModulePath(StringRef name, std::string path);
+  ExplicitSwiftModuleMap *getExplicitSwiftModuleMap();
+  ExplicitClangModuleMap *getExplicitClangModuleMap();
 
   /// Adds a module loader to this AST context.
   ///

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -181,8 +181,7 @@ private:
 
   ClangInvocationFileMapping clangFileMapping;
 
-  ClangImporter(ASTContext &ctx, DependencyTracker *tracker,
-                DWARFImporterDelegate *dwarfImporterDelegate);
+  ClangImporter(ASTContext &ctx, DependencyTracker *tracker);
 
   /// Creates a clone of Clang importer's compiler instance that has been
   /// configured for operations on precompiled outputs (either emitting a
@@ -207,17 +206,11 @@ public:
   ///
   /// \param tracker The object tracking files this compilation depends on.
   ///
-  /// \param dwarfImporterDelegate A helper object that can synthesize
-  /// Clang Decls from debug info. Used by LLDB.
-  ///
   /// \returns a new Clang module importer, or null (with a diagnostic) if
   /// an error occurred.
   static std::unique_ptr<ClangImporter>
-  create(ASTContext &ctx,
-         const IRGenOptions *IRGenOpts = nullptr,
-         std::string swiftPCHHash = "",
-         DependencyTracker *tracker = nullptr,
-         DWARFImporterDelegate *dwarfImporterDelegate = nullptr,
+  create(ASTContext &ctx, const IRGenOptions *IRGenOpts = nullptr,
+         std::string swiftPCHHash = "", DependencyTracker *tracker = nullptr,
          bool ignoreFileMapping = false);
 
   static std::string getClangSystemOverlayFile(const SearchPathOptions &Opts);
@@ -230,6 +223,10 @@ public:
       llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> baseFS,
       bool suppressDiagnostics = false,
       llvm::function_ref<StringRef(StringRef)> allocateString = nullptr);
+
+  /// Install a helper object that can synthesize Clang Decls from debug
+  /// info. Used by LLDB.
+  void setDWARFImporterDelegate(DWARFImporterDelegate *dwarfImporterDelegate);
 
   std::vector<std::string>
   getClangDriverArguments(ASTContext &ctx, bool ignoreClangTarget = false);
@@ -271,9 +268,6 @@ public:
   ClangImporter &operator=(ClangImporter &&) = delete;
 
   ~ClangImporter();
-
-  /// Only to be used by lldb-moduleimport-test.
-  void setDWARFImporterDelegate(DWARFImporterDelegate &delegate);
 
   /// Create a new clang::DependencyCollector customized to
   /// ClangImporter's specific uses.

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -141,10 +141,12 @@ class CompilerInvocation;
 /// A ModuleLoader that loads explicitly built Swift modules specified via
 /// -swift-module-file or modules found in a provided
 /// -explicit-swift-module-map-file JSON input.
-class ExplicitSwiftModuleLoader: public SerializedModuleLoaderBase {
-  explicit ExplicitSwiftModuleLoader(ASTContext &ctx, DependencyTracker *tracker,
-                                     ModuleLoadingMode loadMode,
-                                     bool IgnoreSwiftSourceInfoFile);
+class ExplicitSwiftModuleLoader : public SerializedModuleLoaderBase {
+  explicit ExplicitSwiftModuleLoader(
+      ASTContext &ctx, DependencyTracker *tracker, ModuleLoadingMode loadMode,
+      bool IgnoreSwiftSourceInfoFile,
+      std::unique_ptr<ExplicitSwiftModuleMap> ExplicitModuleMap,
+      std::unique_ptr<ExplicitClangModuleMap> ExplicitClangModuleMap);
 
   bool findModule(ImportPath::Element moduleID,
                   SmallVectorImpl<char> *moduleInterfacePath,
@@ -174,28 +176,32 @@ class ExplicitSwiftModuleLoader: public SerializedModuleLoaderBase {
 
   struct Implementation;
   Implementation &Impl;
-public:
-  static std::unique_ptr<ExplicitSwiftModuleLoader>
-  create(ASTContext &ctx,
-         DependencyTracker *tracker, ModuleLoadingMode loadMode,
-         StringRef ExplicitSwiftModuleMap,
-         const llvm::StringMap<std::string> &ExplicitSwiftModuleInputs,
-         bool IgnoreSwiftSourceInfoFile);
 
-  void addExplicitModulePath(StringRef name, std::string path) override;
+public:
+  static std::unique_ptr<ExplicitSwiftModuleLoader> create(
+      ASTContext &ctx, DependencyTracker *tracker, ModuleLoadingMode loadMode,
+      StringRef ExplicitSwiftModuleMapPath,
+      const llvm::StringMap<std::string> &ExplicitSwiftModuleInputs,
+      bool IgnoreSwiftSourceInfoFile,
+      std::unique_ptr<ExplicitSwiftModuleMap> ExplicitModuleMap = nullptr,
+      std::unique_ptr<ExplicitClangModuleMap> ExplicitClangModuleMap = nullptr);
+
   /// Append visible module names to \p names. Note that names are possibly
   /// duplicated, and not guaranteed to be ordered in any way.
   void collectVisibleTopLevelModuleNames(
       SmallVectorImpl<Identifier> &names) const override;
   ~ExplicitSwiftModuleLoader();
+  ExplicitSwiftModuleMap *getExplicitSwiftModuleMap() override;
+  ExplicitClangModuleMap *getExplicitClangModuleMap() override;
 };
 
 class ExplicitCASModuleLoader : public SerializedModuleLoaderBase {
-  explicit ExplicitCASModuleLoader(ASTContext &ctx, llvm::cas::ObjectStore &CAS,
-                                   llvm::cas::ActionCache &cache,
-                                   DependencyTracker *tracker,
-                                   ModuleLoadingMode loadMode,
-                                   bool IgnoreSwiftSourceInfoFile);
+  explicit ExplicitCASModuleLoader(
+      ASTContext &ctx, llvm::cas::ObjectStore &CAS,
+      llvm::cas::ActionCache &cache, DependencyTracker *tracker,
+      ModuleLoadingMode loadMode, bool IgnoreSwiftSourceInfoFile,
+      std::unique_ptr<ExplicitSwiftModuleMap> ExplicitModuleMap,
+      std::unique_ptr<ExplicitClangModuleMap> ExplicitClangModuleMap);
 
   bool findModule(ImportPath::Element moduleID,
                   SmallVectorImpl<char> *moduleInterfacePath,
@@ -225,75 +231,89 @@ class ExplicitCASModuleLoader : public SerializedModuleLoaderBase {
   Implementation &Impl;
 
 public:
-  static std::unique_ptr<ExplicitCASModuleLoader>
-  create(ASTContext &ctx, llvm::cas::ObjectStore &CAS,
-         llvm::cas::ActionCache &cache, DependencyTracker *tracker,
-         ModuleLoadingMode loadMode, StringRef ExplicitSwiftModuleMap,
-         const llvm::StringMap<std::string> &ExplicitSwiftModuleInputs,
-         bool IgnoreSwiftSourceInfoFile);
+  static std::unique_ptr<ExplicitCASModuleLoader> create(
+      ASTContext &ctx, llvm::cas::ObjectStore &CAS,
+      llvm::cas::ActionCache &cache, DependencyTracker *tracker,
+      ModuleLoadingMode loadMode, StringRef ExplicitSwiftModuleMapPath,
+      const llvm::StringMap<std::string> &ExplicitSwiftModuleInputs,
+      bool IgnoreSwiftSourceInfoFile,
+      std::unique_ptr<ExplicitSwiftModuleMap> ExplicitModuleMap = nullptr,
+      std::unique_ptr<ExplicitClangModuleMap> ExplicitClangModuleMap = nullptr);
 
   /// Append visible module names to \p names. Note that names are possibly
   /// duplicated, and not guaranteed to be ordered in any way.
   void collectVisibleTopLevelModuleNames(
       SmallVectorImpl<Identifier> &names) const override;
 
-  void addExplicitModulePath(StringRef name, std::string path) override;
-
   ~ExplicitCASModuleLoader();
+  ExplicitSwiftModuleMap *getExplicitSwiftModuleMap() override;
+  ExplicitClangModuleMap *getExplicitClangModuleMap() override;
 };
 
-// Explicitly-specified Swift module inputs
+/// Explicitly-specified Swift module inputs.
 struct ExplicitSwiftModuleInputInfo {
   ExplicitSwiftModuleInputInfo(
-      std::string modulePath, std::optional<std::string> moduleDocPath,
+      std::string modulePath, std::optional<std::string> moduleAlias,
+      std::optional<std::string> moduleDocPath,
       std::optional<std::string> moduleSourceInfoPath,
       std::optional<std::vector<std::string>> headerDependencyPaths,
       bool isFramework = false, bool isSystem = false,
       std::optional<std::string> moduleCacheKey = std::nullopt)
-      : modulePath(modulePath), moduleDocPath(moduleDocPath),
+      : modulePath(modulePath), moduleAlias(moduleAlias),
+        moduleDocPath(moduleDocPath),
         moduleSourceInfoPath(moduleSourceInfoPath),
         headerDependencyPaths(headerDependencyPaths), isFramework(isFramework),
         isSystem(isSystem), moduleCacheKey(moduleCacheKey) {}
-  // Path of the .swiftmodule file.
+  /// Path of the .swiftmodule file.
   std::string modulePath;
-  // Path of the .swiftmoduledoc file.
+  /// Any alias for this module.
+  std::optional<std::string> moduleAlias;
+  /// Path of the .swiftmoduledoc file.
   std::optional<std::string> moduleDocPath;
-  // Path of the .swiftsourceinfo file.
+  /// Path of the .swiftsourceinfo file.
   std::optional<std::string> moduleSourceInfoPath;
-  // Paths of the precompiled header dependencies of this module.
+  /// Paths of the precompiled header dependencies of this module.
   std::optional<std::vector<std::string>> headerDependencyPaths;
-  // A flag that indicates whether this module is a framework
+  /// A flag that indicates whether this module is a framework
   bool isFramework = false;
-  // A flag that indicates whether this module is a system module
+  /// A flag that indicates whether this module is a system module
   bool isSystem = false;
-  // The cache key for clang module.
+  /// The cache key for clang module.
   std::optional<std::string> moduleCacheKey;
 };
 
-// Explicitly-specified Clang module inputs
+/// Explicitly-specified Clang module inputs.
 struct ExplicitClangModuleInputInfo {
   ExplicitClangModuleInputInfo(
       std::string moduleMapPath, std::string modulePath,
-      bool isFramework = false, bool isSystem = false,
-      bool isBridgingHeaderDependency = true,
+      std::optional<std::string> moduleAlias, bool isFramework = false,
+      bool isSystem = false, bool isBridgingHeaderDependency = true,
       std::optional<std::string> moduleCacheKey = std::nullopt)
       : moduleMapPath(moduleMapPath), modulePath(modulePath),
-        isFramework(isFramework), isSystem(isSystem),
+        moduleAlias(moduleAlias), isFramework(isFramework), isSystem(isSystem),
         isBridgingHeaderDependency(isBridgingHeaderDependency),
         moduleCacheKey(moduleCacheKey) {}
-  // Path of the Clang module map file.
+  /// Path of the Clang module map file.
   std::string moduleMapPath;
-  // Path of a compiled Clang explicit module file (pcm).
+  /// Path of a compiled Clang explicit module file (pcm).
   std::string modulePath;
-  // A flag that indicates whether this module is a framework
+  std::optional<std::string> moduleAlias;
+  /// A flag that indicates whether this module is a framework
   bool isFramework = false;
-  // A flag that indicates whether this module is a system module
+  /// A flag that indicates whether this module is a system module
   bool isSystem = false;
-  // A flag that indicates whether this is a module dependency of a textual header input
+  /// A flag that indicates whether this is a module dependency of a textual
+  /// header input
   bool isBridgingHeaderDependency = true;
-  // The cache key for clang module.
+  /// The cache key for clang module.
   std::optional<std::string> moduleCacheKey;
 };
+
+struct ExplicitSwiftModuleMap
+    : public llvm::StringMap<ExplicitSwiftModuleInputInfo> {};
+
+struct ExplicitClangModuleMap
+    : public llvm::StringMap<ExplicitClangModuleInputInfo> {};
 
 /// Parser of explicit module maps passed into the compiler.
 //  [
@@ -324,11 +344,11 @@ class ExplicitModuleMapParser {
 public:
   ExplicitModuleMapParser(llvm::BumpPtrAllocator &Allocator) : Saver(Allocator) {}
 
-  llvm::Error parseSwiftExplicitModuleMap(
-      llvm::MemoryBufferRef BufferRef,
-      llvm::StringMap<ExplicitSwiftModuleInputInfo> &swiftModuleMap,
-      llvm::StringMap<ExplicitClangModuleInputInfo> &clangModuleMap,
-      llvm::StringMap<std::string> &moduleAliases) {
+  llvm::Error
+  parseSwiftExplicitModuleMap(llvm::MemoryBufferRef BufferRef,
+                              ExplicitSwiftModuleMap &swiftModuleMap,
+                              ExplicitClangModuleMap &clangModuleMap,
+                              llvm::StringMap<std::string> &moduleAliases) {
     using namespace llvm::yaml;
     // Use a new source manager instead of the one from ASTContext because we
     // don't want the JSON file to be persistent.
@@ -366,11 +386,11 @@ private:
       llvm_unreachable("Unexpected JSON value for isFramework");
   }
 
-  llvm::Error parseSingleModuleEntry(
-      llvm::yaml::Node &node,
-      llvm::StringMap<ExplicitSwiftModuleInputInfo> &swiftModuleMap,
-      llvm::StringMap<ExplicitClangModuleInputInfo> &clangModuleMap,
-      llvm::StringMap<std::string> &moduleAliases) {
+  llvm::Error
+  parseSingleModuleEntry(llvm::yaml::Node &node,
+                         ExplicitSwiftModuleMap &swiftModuleMap,
+                         ExplicitClangModuleMap &clangModuleMap,
+                         llvm::StringMap<std::string> &moduleAliases) {
     using namespace llvm::yaml;
     auto *mapNode = dyn_cast<MappingNode>(&node);
     if (!mapNode)
@@ -431,24 +451,18 @@ private:
       assert((clangModuleMapPath.empty() &&
               clangModulePath.empty()) &&
              "Unexpected Clang dependency details for Swift module");
-      ExplicitSwiftModuleInputInfo entry(swiftModulePath.value(),
-                                         swiftModuleDocPath,
-                                         swiftModuleSourceInfoPath,
-                                         headerDependencyPaths,
-                                         isFramework,
-                                         isSystem,
-                                         swiftModuleCacheKey);
+      ExplicitSwiftModuleInputInfo entry(
+          swiftModulePath.value(), moduleAlias, swiftModuleDocPath,
+          swiftModuleSourceInfoPath, headerDependencyPaths, isFramework,
+          isSystem, swiftModuleCacheKey);
       didInsert = swiftModuleMap.try_emplace(moduleName, std::move(entry)).second;
     } else {
       assert((!clangModuleMapPath.empty() ||
               !clangModulePath.empty()) &&
              "Expected Clang dependency module");
-      ExplicitClangModuleInputInfo entry(clangModuleMapPath,
-                                         clangModulePath,
-                                         isFramework,
-                                         isSystem,
-                                         isBridgingHeaderDependency,
-                                         clangModuleCacheKey);
+      ExplicitClangModuleInputInfo entry(
+          clangModuleMapPath, clangModulePath, moduleAlias, isFramework,
+          isSystem, isBridgingHeaderDependency, clangModuleCacheKey);
       didInsert = clangModuleMap.try_emplace(moduleName, std::move(entry)).second;
     }
     if (!didInsert)

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -27,9 +27,11 @@ namespace swift {
 class ModuleFile;
 class PathObfuscator;
 class ModuleFileSharedCore;
+struct ExplicitSwiftModuleMap;
+struct ExplicitClangModuleMap;
 enum class ModuleLoadingBehavior;
 namespace file_types {
-  enum ID : uint8_t;
+enum ID : uint8_t;
 }
 
 /// How a dependency should be loaded.
@@ -269,7 +271,12 @@ public:
   /// attempt with a given status, to be used for diagnostic output.
   static std::optional<std::string> invalidModuleReason(serialization::Status status);
 
-  virtual void addExplicitModulePath(StringRef name, std::string path) {};
+  virtual ExplicitSwiftModuleMap *getExplicitSwiftModuleMap() {
+    return nullptr;
+  }
+  virtual ExplicitClangModuleMap *getExplicitClangModuleMap() {
+    return nullptr;
+  }
 };
 
 /// Imports serialized Swift modules into an ASTContext.

--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -28,6 +28,8 @@
 namespace swift {
 
 class ModuleFile;
+struct ExplicitSwiftModuleMap;
+struct ExplicitClangModuleMap;
 enum class ResilienceStrategy : unsigned;
 
 namespace serialization {
@@ -304,12 +306,13 @@ struct SearchPath {
 /// \param[out] dependencies If present, will be populated with list of
 /// input files the module depends on, if present in INPUT_BLOCK.
 ValidationInfo validateSerializedAST(
-    StringRef data,
-    StringRef requiredSDK,
+    StringRef data, StringRef requiredSDK,
     ExtendedValidationInfo *extendedInfo = nullptr,
     SmallVectorImpl<SerializationOptions::FileDependency> *dependencies =
         nullptr,
     SmallVectorImpl<SearchPath> *searchPaths = nullptr,
+    ExplicitSwiftModuleMap *explicitSwiftModuleMap = nullptr,
+    ExplicitClangModuleMap *explicitClangModuleMa = nullptr,
     std::optional<llvm::Triple> target = std::nullopt);
 
 /// Emit diagnostics explaining a failure to load a serialized AST.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2211,9 +2211,15 @@ void ASTContext::addSearchPath(StringRef searchPath, bool isFramework,
     clangLoader->addSearchPath(searchPath, isFramework, isSystem);
 }
 
-void ASTContext::addExplicitModulePath(StringRef name, std::string path) {
+ExplicitSwiftModuleMap *ASTContext::getExplicitSwiftModuleMap() {
   if (getImpl().TheExplicitSwiftModuleLoader)
-    getImpl().TheExplicitSwiftModuleLoader->addExplicitModulePath(name, path);
+    return getImpl().TheExplicitSwiftModuleLoader->getExplicitSwiftModuleMap();
+  return nullptr;
+}
+ExplicitClangModuleMap *ASTContext::getExplicitClangModuleMap() {
+  if (getImpl().TheExplicitSwiftModuleLoader)
+    return getImpl().TheExplicitSwiftModuleLoader->getExplicitClangModuleMap();
+  return nullptr;
 }
 
 void ASTContext::addModuleLoader(std::unique_ptr<ModuleLoader> loader,

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -458,10 +458,8 @@ bool ClangImporter::Implementation::shouldIgnoreBridgeHeaderTopLevelDecl(
   return importer::isForwardDeclOfType(D);
 }
 
-ClangImporter::ClangImporter(ASTContext &ctx, DependencyTracker *tracker,
-                             DWARFImporterDelegate *dwarfImporterDelegate)
-    : ClangModuleLoader(tracker),
-      Impl(*new Implementation(ctx, tracker, dwarfImporterDelegate)) {}
+ClangImporter::ClangImporter(ASTContext &ctx, DependencyTracker *tracker)
+    : ClangModuleLoader(tracker), Impl(*new Implementation(ctx, tracker)) {}
 
 ClangImporter::~ClangImporter() {
   delete &Impl;
@@ -1417,12 +1415,11 @@ std::unique_ptr<clang::CompilerInvocation> ClangImporter::createClangInvocation(
   return CI;
 }
 
-std::unique_ptr<ClangImporter> ClangImporter::create(
-    ASTContext &ctx, const IRGenOptions *IRGenOpts, std::string swiftPCHHash,
-    DependencyTracker *tracker,
-    DWARFImporterDelegate *dwarfImporterDelegate, bool ignoreFileMapping) {
-  std::unique_ptr<ClangImporter> importer{
-      new ClangImporter(ctx, tracker, dwarfImporterDelegate)};
+std::unique_ptr<ClangImporter>
+ClangImporter::create(ASTContext &ctx, const IRGenOptions *IRGenOpts,
+                      std::string swiftPCHHash, DependencyTracker *tracker,
+                      bool ignoreFileMapping) {
+  std::unique_ptr<ClangImporter> importer{new ClangImporter(ctx, tracker)};
   auto &importerOpts = ctx.ClangImporterOpts;
 
   auto bridgingPCH = importerOpts.getPCHInputPath();
@@ -2895,8 +2892,7 @@ bool PlatformAvailability::treatDeprecatedAsUnavailable(
 }
 
 ClangImporter::Implementation::Implementation(
-    ASTContext &ctx, DependencyTracker *dependencyTracker,
-    DWARFImporterDelegate *dwarfImporterDelegate)
+    ASTContext &ctx, DependencyTracker *dependencyTracker)
     : SwiftContext(ctx), ImportForwardDeclarations(
                              ctx.ClangImporterOpts.ImportForwardDeclarations),
       DisableSwiftBridgeAttr(ctx.ClangImporterOpts.DisableSwiftBridgeAttr),
@@ -2911,8 +2907,7 @@ ClangImporter::Implementation::Implementation(
       BridgingHeaderLookupTable(new SwiftLookupTable(nullptr)),
       platformAvailability(ctx.LangOpts), nameImporter(),
       DisableSourceImport(ctx.ClangImporterOpts.DisableSourceImport),
-      SwiftDependencyTracker(dependencyTracker),
-      DWARFImporter(dwarfImporterDelegate) {}
+      SwiftDependencyTracker(dependencyTracker) {}
 
 ClangImporter::Implementation::~Implementation() {
 #ifndef NDEBUG

--- a/lib/ClangImporter/DWARFImporter.cpp
+++ b/lib/ClangImporter/DWARFImporter.cpp
@@ -204,11 +204,6 @@ void ClangImporter::Implementation::lookupTypeDeclDWARF(
   }
 }
 
-void ClangImporter::setDWARFImporterDelegate(DWARFImporterDelegate &delegate) {
+void ClangImporter::setDWARFImporterDelegate(DWARFImporterDelegate *delegate) {
   Impl.setDWARFImporterDelegate(delegate);
-}
-
-void ClangImporter::Implementation::setDWARFImporterDelegate(
-    DWARFImporterDelegate &delegate) {
-  DWARFImporter = &delegate;
 }

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -440,9 +440,12 @@ class LLVM_LIBRARY_VISIBILITY ClangImporter::Implementation
   using Version = importer::ImportNameVersion;
 
 public:
-  Implementation(ASTContext &ctx, DependencyTracker *dependencyTracker,
-                 DWARFImporterDelegate *dwarfImporterDelegate);
+  Implementation(ASTContext &ctx, DependencyTracker *dependencyTracker);
   ~Implementation();
+
+  void setDWARFImporterDelegate(DWARFImporterDelegate *dwarfImporterDelegate) {
+    DWARFImporter = dwarfImporterDelegate;
+  }
 
   class DiagnosticWalker : public clang::RecursiveASTVisitor<DiagnosticWalker> {
   public:
@@ -924,11 +927,6 @@ private:
   /// The DWARF importer delegate, if installed.
   DWARFImporterDelegate *DWARFImporter = nullptr;
 
-public:
-  /// Only used for testing.
-  void setDWARFImporterDelegate(DWARFImporterDelegate &delegate);
-
-private:
   /// The list of Clang modules found in the debug info.
   llvm::DenseMap<Identifier, LoadedFile *> DWARFModuleUnits;
 

--- a/lib/DriverTool/modulewrap_main.cpp
+++ b/lib/DriverTool/modulewrap_main.cpp
@@ -200,10 +200,8 @@ int modulewrap_main(ArrayRef<const char *> Args, const char *Argv0,
   registerTypeCheckerRequestFunctions(ASTCtx.evaluator);
 
   IRGenOptions IRGenOpts;
-  ASTCtx.addModuleLoader(ClangImporter::create(ASTCtx, &IRGenOpts,
-                                               "", nullptr, nullptr,
-                                               true),
-                         true);
+  ASTCtx.addModuleLoader(
+      ClangImporter::create(ASTCtx, &IRGenOpts, "", nullptr, true), true);
   ModuleDecl *M =
       ModuleDecl::createEmpty(ASTCtx.getIdentifier("swiftmodule"), ASTCtx);
   std::unique_ptr<Lowering::TypeConverter> TC(

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -2206,13 +2206,30 @@ static void addModuleAliasesFromExplicitSwiftModuleMap(
 struct ExplicitSwiftModuleLoader::Implementation {
   ASTContext &Ctx;
   llvm::BumpPtrAllocator Allocator;
-  llvm::StringMap<ExplicitSwiftModuleInputInfo> ExplicitModuleMap;
-  Implementation(ASTContext &Ctx) : Ctx(Ctx) {}
+  std::unique_ptr<ExplicitSwiftModuleMap> ExplicitModuleMap;
+  std::unique_ptr<ExplicitClangModuleMap> ExplicitClangModuleMap;
+  llvm::StringMap<std::string> ModuleAliases;
+  Implementation(
+      ASTContext &Ctx,
+      std::unique_ptr<swift::ExplicitSwiftModuleMap> ExplicitSwiftModuleMapPtr,
+      std::unique_ptr<swift::ExplicitClangModuleMap> ExplicitClangModuleMapPtr)
+      : Ctx(Ctx), ExplicitModuleMap(std::move(ExplicitSwiftModuleMapPtr)),
+        ExplicitClangModuleMap(std::move(ExplicitClangModuleMapPtr)) {
+    if (!ExplicitModuleMap)
+      ExplicitModuleMap = std::make_unique<swift::ExplicitSwiftModuleMap>();
+    if (!ExplicitClangModuleMap)
+      ExplicitClangModuleMap =
+          std::make_unique<swift::ExplicitClangModuleMap>();
+    for (auto &entry : *ExplicitModuleMap)
+      if (auto alias = entry.getValue().moduleAlias)
+        ModuleAliases.insert({entry.getKey(), *alias});
+    for (auto &entry : *ExplicitClangModuleMap)
+      if (auto alias = entry.getValue().moduleAlias)
+        ModuleAliases.insert({entry.getKey(), *alias});
+  }
 
   void parseSwiftExplicitModuleMap(StringRef fileName) {
     ExplicitModuleMapParser parser(Allocator);
-    llvm::StringMap<ExplicitClangModuleInputInfo> ExplicitClangModuleMap;
-    llvm::StringMap<std::string> ModuleAliases;
     // Load the input file.
     llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> fileBufOrErr =
         llvm::MemoryBuffer::getFile(fileName);
@@ -2223,19 +2240,21 @@ struct ExplicitSwiftModuleLoader::Implementation {
     }
 
     auto error = parser.parseSwiftExplicitModuleMap(
-        (*fileBufOrErr)->getMemBufferRef(), ExplicitModuleMap,
-        ExplicitClangModuleMap, ModuleAliases);
+        (*fileBufOrErr)->getMemBufferRef(), *ExplicitModuleMap,
+        *ExplicitClangModuleMap, ModuleAliases);
     llvm::handleAllErrors(std::move(error), [this, &fileName](
                                                 const llvm::StringError &E) {
       Ctx.Diags.diagnose(SourceLoc(), diag::explicit_swift_module_map_corrupted,
                          fileName, E.getMessage());
     });
+  }
 
+  void setupModuleLoader() {
     // A single module map can define multiple modules; keep track of the ones
     // we've seen so that we don't generate duplicate flags.
     std::set<std::string> moduleMapsSeen;
     std::vector<std::string> &extraClangArgs = Ctx.ClangImporterOpts.ExtraArgs;
-    for (auto &entry : ExplicitClangModuleMap) {
+    for (auto &entry : *ExplicitClangModuleMap) {
       const auto &moduleMapPath = entry.getValue().moduleMapPath;
       if (!moduleMapPath.empty() &&
           entry.getValue().isBridgingHeaderDependency &&
@@ -2258,22 +2277,30 @@ struct ExplicitSwiftModuleLoader::Implementation {
   void addCommandLineExplicitInputs(
     const llvm::StringMap<std::string> &commandLineExplicitInputs) {
     for (const auto &moduleInput : commandLineExplicitInputs) {
-      ExplicitSwiftModuleInputInfo entry(moduleInput.getValue(), {}, {}, {});
-      ExplicitModuleMap.try_emplace(moduleInput.first(), std::move(entry));
+      ExplicitSwiftModuleInputInfo entry(moduleInput.getValue(), {}, {}, {},
+                                         {});
+      ExplicitModuleMap->try_emplace(moduleInput.first(), std::move(entry));
     }
   }
 };
 
 ExplicitSwiftModuleLoader::ExplicitSwiftModuleLoader(
-      ASTContext &ctx,
-      DependencyTracker *tracker,
-      ModuleLoadingMode loadMode,
-      bool IgnoreSwiftSourceInfoFile):
-        SerializedModuleLoaderBase(ctx, tracker, loadMode,
-                                   IgnoreSwiftSourceInfoFile),
-        Impl(*new Implementation(ctx)) {}
+    ASTContext &ctx, DependencyTracker *tracker, ModuleLoadingMode loadMode,
+    bool IgnoreSwiftSourceInfoFile,
+    std::unique_ptr<ExplicitSwiftModuleMap> ExplicitModuleMap,
+    std::unique_ptr<ExplicitClangModuleMap> ExplicitClangModuleMap)
+    : SerializedModuleLoaderBase(ctx, tracker, loadMode,
+                                 IgnoreSwiftSourceInfoFile),
+      Impl(*new Implementation(ctx, std::move(ExplicitModuleMap),
+                               std::move(ExplicitClangModuleMap))) {}
 
 ExplicitSwiftModuleLoader::~ExplicitSwiftModuleLoader() { delete &Impl; }
+ExplicitSwiftModuleMap *ExplicitSwiftModuleLoader::getExplicitSwiftModuleMap() {
+  return Impl.ExplicitModuleMap.get();
+}
+ExplicitClangModuleMap *ExplicitSwiftModuleLoader::getExplicitClangModuleMap() {
+  return Impl.ExplicitClangModuleMap.get();
+}
 
 bool ExplicitSwiftModuleLoader::findModule(
     ImportPath::Element ModuleID, SmallVectorImpl<char> *ModuleInterfacePath,
@@ -2290,10 +2317,10 @@ bool ExplicitSwiftModuleLoader::findModule(
   // input file has 'import Foo', a module called Bar (real name) should be searched.
   StringRef moduleName = Ctx.getRealModuleName(ModuleID.Item).str();
 
-  auto it = Impl.ExplicitModuleMap.find(moduleName);
+  auto it = Impl.ExplicitModuleMap->find(moduleName);
   // If no explicit module path is given matches the name, return with an
   // error code.
-  if (it == Impl.ExplicitModuleMap.end()) {
+  if (it == Impl.ExplicitModuleMap->end()) {
     return false;
   }
   auto &moduleInfo = it->getValue();
@@ -2378,9 +2405,9 @@ bool ExplicitSwiftModuleLoader::canImportModule(
   // maps Foo appearing in source files, e.g. 'import Foo', to the real module
   // name Bar (on-disk name), which should be searched for loading.
   StringRef moduleName = Ctx.getRealModuleName(mID.Item).str();
-  auto it = Impl.ExplicitModuleMap.find(moduleName);
+  auto it = Impl.ExplicitModuleMap->find(moduleName);
   // If no provided explicit module matches the name, then it cannot be imported.
-  if (it == Impl.ExplicitModuleMap.end()) {
+  if (it == Impl.ExplicitModuleMap->end()) {
     return false;
   }
 
@@ -2420,26 +2447,29 @@ bool ExplicitSwiftModuleLoader::canImportModule(
 
 void ExplicitSwiftModuleLoader::collectVisibleTopLevelModuleNames(
       SmallVectorImpl<Identifier> &names) const {
-  for (auto &entry: Impl.ExplicitModuleMap) {
+  for (auto &entry : *Impl.ExplicitModuleMap) {
     names.push_back(Ctx.getIdentifier(entry.getKey()));
   }
 }
 
-std::unique_ptr<ExplicitSwiftModuleLoader>
-ExplicitSwiftModuleLoader::create(ASTContext &ctx,
-    DependencyTracker *tracker, ModuleLoadingMode loadMode,
-    StringRef ExplicitSwiftModuleMap,
+std::unique_ptr<ExplicitSwiftModuleLoader> ExplicitSwiftModuleLoader::create(
+    ASTContext &ctx, DependencyTracker *tracker, ModuleLoadingMode loadMode,
+    StringRef ExplicitSwiftModuleMapPath,
     const llvm::StringMap<std::string> &ExplicitSwiftModuleInputs,
-    bool IgnoreSwiftSourceInfoFile) {
-  auto result = std::unique_ptr<ExplicitSwiftModuleLoader>(
-    new ExplicitSwiftModuleLoader(ctx, tracker, loadMode,
-                                  IgnoreSwiftSourceInfoFile));
+    bool IgnoreSwiftSourceInfoFile,
+    std::unique_ptr<swift::ExplicitSwiftModuleMap> ExplicitModuleMap,
+    std::unique_ptr<swift::ExplicitClangModuleMap> ExplicitClangModuleMap) {
+  auto result =
+      std::unique_ptr<ExplicitSwiftModuleLoader>(new ExplicitSwiftModuleLoader(
+          ctx, tracker, loadMode, IgnoreSwiftSourceInfoFile,
+          std::move(ExplicitModuleMap), std::move(ExplicitClangModuleMap)));
   auto &Impl = result->Impl;
   // If the explicit module map is given, try parse it.
-  if (!ExplicitSwiftModuleMap.empty()) {
+  if (!ExplicitSwiftModuleMapPath.empty()) {
     // Parse a JSON file to collect explicitly built modules.
-    Impl.parseSwiftExplicitModuleMap(ExplicitSwiftModuleMap);
+    Impl.parseSwiftExplicitModuleMap(ExplicitSwiftModuleMapPath);
   }
+  Impl.setupModuleLoader();
   // If some modules are provided with explicit
   // '-swift-module-file' options, add those as well.
   if (!ExplicitSwiftModuleInputs.empty()) {
@@ -2449,23 +2479,38 @@ ExplicitSwiftModuleLoader::create(ASTContext &ctx,
   return result;
 }
 
-void ExplicitSwiftModuleLoader::addExplicitModulePath(StringRef name,
-                                                      std::string path) {
-  ExplicitSwiftModuleInputInfo entry(path, {}, {}, {});
-  Impl.ExplicitModuleMap.try_emplace(name, std::move(entry));
-}
-
 struct ExplicitCASModuleLoader::Implementation {
   ASTContext &Ctx;
   llvm::BumpPtrAllocator Allocator;
   llvm::cas::ObjectStore &CAS;
   llvm::cas::ActionCache &Cache;
 
-  llvm::StringMap<ExplicitSwiftModuleInputInfo> ExplicitModuleMap;
+  std::unique_ptr<ExplicitSwiftModuleMap> ExplicitModuleMap;
+  std::unique_ptr<ExplicitClangModuleMap> ExplicitClangModuleMap;
+  llvm::StringMap<std::string> ModuleAliases;
 
-  Implementation(ASTContext &Ctx, llvm::cas::ObjectStore &CAS,
-                 llvm::cas::ActionCache &Cache)
-      : Ctx(Ctx), CAS(CAS), Cache(Cache) {}
+  Implementation(
+      ASTContext &Ctx, llvm::cas::ObjectStore &CAS,
+      llvm::cas::ActionCache &Cache,
+      std::unique_ptr<swift::ExplicitSwiftModuleMap> ExplicitSwiftModuleMapPtr,
+      std::unique_ptr<swift::ExplicitClangModuleMap> ExplicitClangModuleMapPtr)
+      : Ctx(Ctx), CAS(CAS), Cache(Cache),
+        ExplicitModuleMap(std::move(ExplicitSwiftModuleMapPtr)),
+        ExplicitClangModuleMap(std::move(ExplicitClangModuleMapPtr)) {
+    {
+      if (!ExplicitModuleMap)
+        ExplicitModuleMap = std::make_unique<swift::ExplicitSwiftModuleMap>();
+      if (!ExplicitClangModuleMap)
+        ExplicitClangModuleMap =
+            std::make_unique<swift::ExplicitClangModuleMap>();
+      for (auto &entry : *ExplicitModuleMap)
+        if (auto alias = entry.getValue().moduleAlias)
+          ModuleAliases.insert({entry.getKey(), *alias});
+      for (auto &entry : *ExplicitClangModuleMap)
+        if (auto alias = entry.getValue().moduleAlias)
+          ModuleAliases.insert({entry.getKey(), *alias});
+    }
+  }
 
   std::unique_ptr<llvm::MemoryBuffer> loadBuffer(StringRef ID) {
     auto key = CAS.parseID(ID);
@@ -2500,8 +2545,6 @@ struct ExplicitCASModuleLoader::Implementation {
       return;
 
     ExplicitModuleMapParser parser(Allocator);
-    llvm::StringMap<ExplicitClangModuleInputInfo> ExplicitClangModuleMap;
-    llvm::StringMap<std::string> ModuleAliases;
     auto buf = loadBuffer(ID);
     if (!buf) {
       Ctx.Diags.diagnose(SourceLoc(), diag::explicit_swift_module_map_missing,
@@ -2512,14 +2555,16 @@ struct ExplicitCASModuleLoader::Implementation {
         llvm::MemoryBuffer::getFile(ID);
 
     auto error = parser.parseSwiftExplicitModuleMap(
-        buf->getMemBufferRef(), ExplicitModuleMap, ExplicitClangModuleMap,
+        buf->getMemBufferRef(), *ExplicitModuleMap, *ExplicitClangModuleMap,
         ModuleAliases);
     llvm::handleAllErrors(std::move(error), [this,
                                              &ID](const llvm::StringError &E) {
       Ctx.Diags.diagnose(SourceLoc(), diag::explicit_swift_module_map_corrupted,
                          ID, E.getMessage());
     });
+  }
 
+  void setupModuleLoader() {
     std::set<std::string> moduleMapsSeen;
     std::vector<std::string> &extraClangArgs = Ctx.ClangImporterOpts.ExtraArgs;
     // Append -Xclang if we are not in direct cc1 mode.
@@ -2527,7 +2572,7 @@ struct ExplicitCASModuleLoader::Implementation {
       if (!Ctx.ClangImporterOpts.DirectClangCC1ModuleBuild)
         extraClangArgs.push_back("-Xclang");
     };
-    for (auto &entry : ExplicitClangModuleMap) {
+    for (auto &entry : *ExplicitClangModuleMap) {
       const auto &moduleMapPath = entry.getValue().moduleMapPath;
       if (!moduleMapPath.empty() && !Ctx.CASOpts.EnableCaching &&
           moduleMapsSeen.find(moduleMapPath) == moduleMapsSeen.end()) {
@@ -2558,8 +2603,9 @@ struct ExplicitCASModuleLoader::Implementation {
   void addCommandLineExplicitInputs(
       const llvm::StringMap<std::string> &commandLineExplicitInputs) {
     for (const auto &moduleInput : commandLineExplicitInputs) {
-      ExplicitSwiftModuleInputInfo entry(moduleInput.getValue(), {}, {}, {});
-      ExplicitModuleMap.try_emplace(moduleInput.getKey(), std::move(entry));
+      ExplicitSwiftModuleInputInfo entry(moduleInput.getValue(), {}, {}, {},
+                                         {});
+      ExplicitModuleMap->try_emplace(moduleInput.getKey(), std::move(entry));
     }
   }
 
@@ -2617,7 +2663,7 @@ struct ExplicitCASModuleLoader::Implementation {
 
   llvm::Expected<std::unique_ptr<llvm::MemoryBuffer>>
   loadModuleFromPath(StringRef Path, DiagnosticEngine &Diags) {
-    for (auto &Deps : ExplicitModuleMap) {
+    for (auto &Deps : *ExplicitModuleMap) {
       if (Deps.second.modulePath == Path) {
         if (!Deps.second.moduleCacheKey)
           return nullptr;
@@ -2630,17 +2676,24 @@ struct ExplicitCASModuleLoader::Implementation {
   }
 };
 
-ExplicitCASModuleLoader::ExplicitCASModuleLoader(ASTContext &ctx,
-                                                 llvm::cas::ObjectStore &CAS,
-                                                 llvm::cas::ActionCache &cache,
-                                                 DependencyTracker *tracker,
-                                                 ModuleLoadingMode loadMode,
-                                                 bool IgnoreSwiftSourceInfoFile)
+ExplicitCASModuleLoader::ExplicitCASModuleLoader(
+    ASTContext &ctx, llvm::cas::ObjectStore &CAS, llvm::cas::ActionCache &cache,
+    DependencyTracker *tracker, ModuleLoadingMode loadMode,
+    bool IgnoreSwiftSourceInfoFile,
+    std::unique_ptr<ExplicitSwiftModuleMap> ExplicitModuleMap,
+    std::unique_ptr<ExplicitClangModuleMap> ExplicitClangModuleMap)
     : SerializedModuleLoaderBase(ctx, tracker, loadMode,
                                  IgnoreSwiftSourceInfoFile),
-      Impl(*new Implementation(ctx, CAS, cache)) {}
+      Impl(*new Implementation(ctx, CAS, cache, std::move(ExplicitModuleMap),
+                               std::move(ExplicitClangModuleMap))) {}
 
 ExplicitCASModuleLoader::~ExplicitCASModuleLoader() { delete &Impl; }
+ExplicitSwiftModuleMap *ExplicitCASModuleLoader::getExplicitSwiftModuleMap() {
+  return Impl.ExplicitModuleMap.get();
+}
+ExplicitClangModuleMap *ExplicitCASModuleLoader::getExplicitClangModuleMap() {
+  return Impl.ExplicitClangModuleMap.get();
+}
 
 bool ExplicitCASModuleLoader::findModule(
     ImportPath::Element ModuleID, SmallVectorImpl<char> *ModuleInterfacePath,
@@ -2658,10 +2711,10 @@ bool ExplicitCASModuleLoader::findModule(
   // searched.
   StringRef moduleName = Ctx.getRealModuleName(ModuleID.Item).str();
 
-  auto it = Impl.ExplicitModuleMap.find(moduleName);
+  auto it = Impl.ExplicitModuleMap->find(moduleName);
   // If no explicit module path is given matches the name, return with an
   // error code.
-  if (it == Impl.ExplicitModuleMap.end()) {
+  if (it == Impl.ExplicitModuleMap->end()) {
     return false;
   }
   auto &moduleInfo = it->getValue();
@@ -2725,10 +2778,10 @@ bool ExplicitCASModuleLoader::canImportModule(
   // Foo=Bar' maps Foo appearing in source files, e.g. 'import Foo', to the real
   // module name Bar (on-disk name), which should be searched for loading.
   StringRef moduleName = Ctx.getRealModuleName(mID.Item).str();
-  auto it = Impl.ExplicitModuleMap.find(moduleName);
+  auto it = Impl.ExplicitModuleMap->find(moduleName);
   // If no provided explicit module matches the name, then it cannot be
   // imported.
-  if (it == Impl.ExplicitModuleMap.end()) {
+  if (it == Impl.ExplicitModuleMap->end()) {
     return false;
   }
 
@@ -2756,42 +2809,30 @@ bool ExplicitCASModuleLoader::canImportModule(
 
 void ExplicitCASModuleLoader::collectVisibleTopLevelModuleNames(
     SmallVectorImpl<Identifier> &names) const {
-  for (auto &entry : Impl.ExplicitModuleMap) {
+  for (auto &entry : *Impl.ExplicitModuleMap) {
     names.push_back(Ctx.getIdentifier(entry.getKey()));
   }
-}
-
-void ExplicitCASModuleLoader::addExplicitModulePath(StringRef name,
-                                                    std::string path) {
-  // This is used by LLDB to discover the paths to dependencies of binary Swift
-  // modules. Only do this if path exists in CAS, since there are use-cases
-  // where a binary Swift module produced on a different machine is provided and
-  // replacements for its dependencies are provided via the explicit module map.
-  auto ID = Impl.CAS.parseID(path);
-  if (!ID)
-    return llvm::consumeError(ID.takeError());
-  if (!Impl.CAS.getReference(*ID))
-    return;
-
-  ExplicitSwiftModuleInputInfo entry(path, {}, {}, {});
-  Impl.ExplicitModuleMap.try_emplace(name, std::move(entry));
 }
 
 std::unique_ptr<ExplicitCASModuleLoader> ExplicitCASModuleLoader::create(
     ASTContext &ctx, llvm::cas::ObjectStore &CAS, llvm::cas::ActionCache &cache,
     DependencyTracker *tracker, ModuleLoadingMode loadMode,
-    StringRef ExplicitSwiftModuleMap,
+    StringRef ExplicitSwiftModuleMapPath,
     const llvm::StringMap<std::string> &ExplicitSwiftModuleInputs,
-    bool IgnoreSwiftSourceInfoFile) {
+    bool IgnoreSwiftSourceInfoFile,
+    std::unique_ptr<ExplicitSwiftModuleMap> ExplicitModuleMap,
+    std::unique_ptr<ExplicitClangModuleMap> ExplicitClangModuleMap) {
   auto result =
       std::unique_ptr<ExplicitCASModuleLoader>(new ExplicitCASModuleLoader(
-          ctx, CAS, cache, tracker, loadMode, IgnoreSwiftSourceInfoFile));
+          ctx, CAS, cache, tracker, loadMode, IgnoreSwiftSourceInfoFile,
+          std::move(ExplicitModuleMap), std::move(ExplicitClangModuleMap)));
   auto &Impl = result->Impl;
   // If the explicit module map is given, try parse it.
-  if (!ExplicitSwiftModuleMap.empty()) {
+  if (!ExplicitSwiftModuleMapPath.empty()) {
     // Parse a JSON file to collect explicitly built modules.
-    Impl.parseSwiftExplicitModuleMap(ExplicitSwiftModuleMap);
+    Impl.parseSwiftExplicitModuleMap(ExplicitSwiftModuleMapPath);
   }
+  Impl.setupModuleLoader();
   // If some modules are provided with explicit
   // '-swift-module-file' options, add those as well.
   if (!ExplicitSwiftModuleInputs.empty()) {

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -214,11 +214,6 @@ ModuleFile::loadDependenciesForFileContext(const FileUnit *file,
     auto importPath = builder.copyTo(ctx);
     auto modulePath = importPath.getModulePath(dependency.isScoped());
     auto accessPath = importPath.getAccessPath(dependency.isScoped());
-    if (!getContext().LangOpts.DisableDeserializationOfExplicitPaths &&
-        !dependency.Core.BinaryModulePath.empty())
-      ctx.addExplicitModulePath(modulePath.front().Item.str(),
-                                dependency.Core.BinaryModulePath.str());
-
     auto module = getModule(modulePath, /*allowLoading*/true);
     if (!module || module->failedToLoad()) {
       // If we're missing the module we're an overlay for, treat that specially.

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -123,7 +123,6 @@ public:
   public:
     const StringRef RawPath;
     const StringRef RawSPIs;
-    const StringRef BinaryModulePath;
 
   private:
     using ImportFilterKind = ModuleDecl::ImportFilterKind;
@@ -138,9 +137,9 @@ public:
       return static_cast<ImportFilterKind>(1 << RawImportControl);
     }
 
-    Dependency(StringRef path, StringRef spiGroups, StringRef binaryModulePath,
-               bool isHeader, ImportFilterKind importControl, bool isScoped)
-        : RawPath(path), RawSPIs(spiGroups), BinaryModulePath(binaryModulePath),
+    Dependency(StringRef path, StringRef spiGroups, bool isHeader,
+               ImportFilterKind importControl, bool isScoped)
+        : RawPath(path), RawSPIs(spiGroups),
           RawImportControl(rawControlFromKind(importControl)),
           IsHeader(isHeader), IsScoped(isScoped) {
       assert(llvm::popcount(static_cast<unsigned>(importControl)) == 1 &&
@@ -149,15 +148,14 @@ public:
     }
 
   public:
-    Dependency(StringRef path, StringRef spiGroups, StringRef binaryModulePath,
+    Dependency(StringRef path, StringRef spiGroups,
                ImportFilterKind importControl, bool isScoped)
-        : Dependency(path, spiGroups, binaryModulePath, false, importControl,
-                     isScoped) {}
+        : Dependency(path, spiGroups, false, importControl, isScoped) {}
 
     static Dependency forHeader(StringRef headerPath, bool exported) {
       auto importControl =
           exported ? ImportFilterKind::Exported : ImportFilterKind::Default;
-      return Dependency(headerPath, {}, {}, true, importControl, false);
+      return Dependency(headerPath, {}, true, importControl, false);
     }
 
     bool isExported() const {

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 985; // Wasm extern import module/name in serialized SIL
+const uint16_t SWIFTMODULE_VERSION_MINOR = 986; // explicit module map
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1121,97 +1121,100 @@ namespace options_block {
 ///
 /// \sa INPUT_BLOCK_ID
 namespace input_block {
-  enum {
-    IMPORTED_MODULE = 1,
-    LINK_LIBRARY,
-    IMPORTED_HEADER,
-    IMPORTED_HEADER_CONTENTS,
-    MODULE_FLAGS, // [unused]
-    SEARCH_PATH,
-    FILE_DEPENDENCY,
-    DEPENDENCY_DIRECTORY,
-    MODULE_INTERFACE_PATH,
-    IMPORTED_MODULE_SPIS,
-    IMPORTED_MODULE_PATH,
-    EXTERNAL_MACRO,
-  };
+enum {
+  IMPORTED_MODULE = 1,
+  LINK_LIBRARY,
+  IMPORTED_HEADER,
+  IMPORTED_HEADER_CONTENTS,
+  MODULE_FLAGS, // [unused]
+  SEARCH_PATH,
+  FILE_DEPENDENCY,
+  DEPENDENCY_DIRECTORY,
+  MODULE_INTERFACE_PATH,
+  IMPORTED_MODULE_SPIS,
+  EXPLICIT_MODULE_MAP_ENTRY,
+  EXTERNAL_MACRO,
+};
 
-  using ImportedModuleLayout = BCRecordLayout<
-    IMPORTED_MODULE,
-    ImportControlField, // import kind
-    BCFixed<1>,         // scoped?
-    BCFixed<1>,         // has spis?
-    BCFixed<1>,         // has path?
-    BCBlob //  module name, with submodule path pieces separated by \0s.  If the
-           // 'scoped' flag is set, the final path piece is an access path
-           // within the module.
-  >;
+using ImportedModuleLayout =
+    BCRecordLayout<IMPORTED_MODULE,
+                   ImportControlField, // import kind
+                   BCFixed<1>,         // scoped?
+                   BCFixed<1>,         // has spis?
+                   BCBlob //  module name, with submodule path pieces separated
+                          //  by \0s.  If the
+                          // 'scoped' flag is set, the final path piece is an
+                          // access path within the module.
+                   >;
 
-  using ImportedModuleSPILayout = BCRecordLayout<
-    IMPORTED_MODULE_SPIS,
-    BCBlob // SPI names, separated by \0s
-  >;
+using ImportedModuleSPILayout =
+    BCRecordLayout<IMPORTED_MODULE_SPIS,
+                   BCBlob // SPI names, separated by \0s
+                   >;
 
-  using ImportedModulePathLayout = BCRecordLayout<
-    IMPORTED_MODULE_PATH,
-    BCBlob // Module file path
-  >;
+using ExplicitModuleMapEntryLayout =
+    BCRecordLayout<EXPLICIT_MODULE_MAP_ENTRY,
+                   BCFixed<1>, // framework
+                   BCFixed<1>, // system
+                   BCFixed<1>, // bridgedheader dependency
+                   BCVBR<16>,  // module directory
+                   BCVBR<16>,  // module doc directory
+                   BCVBR<16>,  // module source info directory
+                   BCVBR<16>,  // clang module map directory
+                   BCBlob // \0 separated: moduleName, modulePath, moduleAlias
+                          // moduleDocPath, moduleSourceInfoPath,
+                          // moduleCacheKey, clangModuleMapPath,
+                          // headerDependencyPaths
+                   >;
 
-  using ExternalMacroLayout = BCRecordLayout<
-    EXTERNAL_MACRO,
-    ImportControlField, // import kind
-    BCBlob // ModuleName, Library Path, Executable Path, separated by \0s
-  >;
+using ExternalMacroLayout =
+    BCRecordLayout<EXTERNAL_MACRO,
+                   ImportControlField, // import kind
+                   BCBlob // ModuleName, Library Path, Executable Path,
+                          // separated by \0s
+                   >;
 
-  using LinkLibraryLayout = BCRecordLayout<
-    LINK_LIBRARY,
-    LibraryKindField, // kind
-    BCFixed<1>, // static
-    BCFixed<1>, // forced?
-    BCBlob // library name
-  >;
+using LinkLibraryLayout = BCRecordLayout<LINK_LIBRARY,
+                                         LibraryKindField, // kind
+                                         BCFixed<1>,       // static
+                                         BCFixed<1>,       // forced?
+                                         BCBlob            // library name
+                                         >;
 
-  using ImportedHeaderLayout = BCRecordLayout<
-    IMPORTED_HEADER,
-    BCFixed<1>, // exported?
-    FileSizeField, // file size (for validation)
-    FileHashField, // file hash (for validation)
-    BCBlob // file path
-  >;
+using ImportedHeaderLayout =
+    BCRecordLayout<IMPORTED_HEADER,
+                   BCFixed<1>,    // exported?
+                   FileSizeField, // file size (for validation)
+                   FileHashField, // file hash (for validation)
+                   BCBlob         // file path
+                   >;
 
-  using ImportedHeaderContentsLayout = BCRecordLayout<
-    IMPORTED_HEADER_CONTENTS,
-    BCBlob
-  >;
+using ImportedHeaderContentsLayout =
+    BCRecordLayout<IMPORTED_HEADER_CONTENTS, BCBlob>;
 
-  using SearchPathLayout = BCRecordLayout<
-    SEARCH_PATH,
-    BCFixed<1>, // framework?
-    BCFixed<1>, // system?
-    BCBlob      // path
-  >;
+using SearchPathLayout = BCRecordLayout<SEARCH_PATH,
+                                        BCFixed<1>, // framework?
+                                        BCFixed<1>, // system?
+                                        BCBlob      // path
+                                        >;
 
-  using FileDependencyLayout = BCRecordLayout<
-    FILE_DEPENDENCY,
-    FileSizeField,                 // file size (for validation)
-    FileModTimeOrContentHashField, // mtime or content hash (for validation)
-    BCFixed<1>,                    // are we reading mtime (0) or hash (1)?
-    BCFixed<1>,                    // SDK-relative?
-    BCVBR<8>,                      // subpath-relative index (0=none)
-    BCBlob                         // path
-  >;
+using FileDependencyLayout =
+    BCRecordLayout<FILE_DEPENDENCY,
+                   FileSizeField,                 // file size (for validation)
+                   FileModTimeOrContentHashField, // mtime or content hash (for
+                                                  // validation)
+                   BCFixed<1>, // are we reading mtime (0) or hash (1)?
+                   BCFixed<1>, // SDK-relative?
+                   BCVBR<8>,   // subpath-relative index (0=none)
+                   BCBlob      // path
+                   >;
 
-  using DependencyDirectoryLayout = BCRecordLayout<
-    DEPENDENCY_DIRECTORY,
-    BCBlob
-  >;
+using DependencyDirectoryLayout = BCRecordLayout<DEPENDENCY_DIRECTORY, BCBlob>;
 
-  using ModuleInterfaceLayout = BCRecordLayout<
-    MODULE_INTERFACE_PATH,
-    BCFixed<1>, // SDK-relative?
-    BCBlob      // file path
-  >;
-
+using ModuleInterfaceLayout = BCRecordLayout<MODULE_INTERFACE_PATH,
+                                             BCFixed<1>, // SDK-relative?
+                                             BCBlob      // file path
+                                             >;
 }
 
 /// The record types within the "decls-and-types" block.

--- a/test/Serialization/module-dependencies.swift
+++ b/test/Serialization/module-dependencies.swift
@@ -1,9 +1,41 @@
 // RUN: %empty-directory(%t)
-// RUN: mkdir %t/a %t/b
-// RUN: %target-swift-frontend -emit-module -o %t/b/B.swiftmodule %S/../Inputs/empty.swift -disable-implicit-swift-modules -parse-stdlib
+// RUN: mkdir %t/inputs
+// RUN: echo "[{" > %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"A\"," >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/t/inputs/A.swiftmodule\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
+// RUN: echo "}," >> %/t/inputs/map.json
+// RUN: echo "{" >> %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"B\"," >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/t/inputs/B.swiftmodule\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
+// RUN: echo "}," >> %/t/inputs/map.json
+// RUN: echo "{" >> %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"Swift\"," >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/stdlib_module\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
+// RUN: echo "}," >> %/t/inputs/map.json
+// RUN: echo "{" >> %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"SwiftOnoneSupport\"," >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/ononesupport_module\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
+// RUN: echo "}," >> %/t/inputs/map.json
+// RUN: echo "{" >> %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"_Concurrency\"," >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/concurrency_module\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
+// RUN: echo "}," >> %/t/inputs/map.json
+// RUN: echo "]" >> %/t/inputs/map.json
+// RUN: %target-swift-frontend -emit-module -o %t/inputs/B.swiftmodule %S/../Inputs/empty.swift -disable-implicit-swift-modules -parse-stdlib
 //-no-serialize-debugging-options
-// RUN: %target-swift-frontend -emit-module -o %t/a/A.swiftmodule %S/Inputs/a.swift -swift-module-file=B=%t/b/B.swiftmodule -disable-implicit-swift-modules -parse-stdlib
+// RUN: %target-swift-frontend -emit-module -o %t/inputs/A.swiftmodule %S/Inputs/a.swift -swift-module-file=B=%t/inputs/B.swiftmodule -disable-implicit-swift-modules -parse-stdlib
 
-// Not passing in path to b/B.swiftmodule -- it should be found in the INPUT block.
-// RUN: %target-swift-frontend -emit-module -o %t/Library.swiftmodule %s -swift-module-file=A=%t/a/A.swiftmodule -disable-implicit-swift-modules -parse-stdlib
+// RUN: %target-swift-frontend -emit-module -o %t/Library.swiftmodule %s -disable-implicit-swift-modules -parse-stdlib -explicit-swift-module-map-file %t/inputs/map.json -g
+// RUN: %lldb-moduleimport-test %t/Library.swiftmodule --dump-explicit-module-map | %FileCheck %s
+
+// Test the the explicit module map got serialized.
+
+// CHECK-DAG: inputs{{/|\\\\}}A.swiftmodule
+// CHECK-DAG: inputs{{/|\\\\}}B.swiftmodule
+// CHECK-DAG: Swift.swiftmodule
 import A


### PR DESCRIPTION
Currently only the top level dependencies get serialized in Swift modules. In practice this is not enough information to fully replay a module import sequence, especially when the dependencies include binary SDK modules that were built elsewhere. In this case we cannot follow the links to its depenencies, since they refer to paths on a different machine or unavailable CAS. During an EBM build, the dependency scanner writes the complete list of dependencies into a json file called the explicit Swift module map -- including the local locations of the dependencies of binary SDK modules. Using this LLDB can replay a module import with 100% accuracy.

rdar://170514919

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
