### PR TITLE
Swap the alias relationship between -language-mode and -swift-version.

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -285,18 +285,18 @@ def sdk : Separate<["-"], "sdk">,
          SwiftAPIDigesterOption, SwiftSynthesizeInterfaceOption]>,
   HelpText<"Compile against <sdk>">, MetaVarName<"<sdk>">;
 
-def swift_version : Separate<["-"], "swift-version">,
-  Flags<[FrontendOption, ModuleInterfaceOption, SwiftSymbolGraphExtractOption,
-         SwiftAPIDigesterOption, SwiftSynthesizeInterfaceOption]>,
-  HelpText<"Interpret input according to a specific Swift language version number">,
-  MetaVarName<"<vers>">;
-
 def language_mode : Separate<["-"], "language-mode">,
   Flags<[FrontendOption, ModuleInterfaceOption, SwiftSymbolGraphExtractOption,
          SwiftAPIDigesterOption, SwiftSynthesizeInterfaceOption]>,
   HelpText<"Interpret input according to a specific Swift language mode">,
-  MetaVarName<"<mode>">,
-  Alias<swift_version>;
+  MetaVarName<"<mode>">;
+
+def swift_version : Separate<["-"], "swift-version">,
+  Flags<[FrontendOption, HelpHidden, ModuleInterfaceOption, SwiftSymbolGraphExtractOption,
+         SwiftAPIDigesterOption, SwiftSynthesizeInterfaceOption]>,
+  HelpText<"Interpret input according to a specific Swift language version number">,
+  MetaVarName<"<vers>">,
+  Alias<language_mode>;
 
 def min_swift_runtime_version
     : Separate<["-"], "min-swift-runtime-version">,

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -349,7 +349,7 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_sanitize_coverage_EQ);
   inputArgs.AddLastArg(arguments, options::OPT_sanitize_stable_abi_EQ);
   inputArgs.AddLastArg(arguments, options::OPT_static);
-  inputArgs.AddLastArg(arguments, options::OPT_swift_version);
+  inputArgs.AddLastArg(arguments, options::OPT_language_mode);
   inputArgs.AddLastArg(arguments, options::OPT_enforce_exclusivity_EQ);
   inputArgs.AddLastArg(arguments, options::OPT_stats_output_dir);
   inputArgs.AddLastArg(arguments, options::OPT_tools_directory);

--- a/lib/DriverTool/swift_api_digester_main.cpp
+++ b/lib/DriverTool/swift_api_digester_main.cpp
@@ -2375,7 +2375,7 @@ public:
     SDK = ParsedArgs.getLastArgValue(OPT_sdk).str();
     BaselineSDK = ParsedArgs.getLastArgValue(OPT_bsdk).str();
     Triple = ParsedArgs.getLastArgValue(OPT_target).str();
-    SwiftVersion = ParsedArgs.getLastArgValue(OPT_swift_version).str();
+    SwiftVersion = ParsedArgs.getLastArgValue(OPT_language_mode).str();
     SystemFrameworkPaths = ParsedArgs.getAllArgValues(OPT_Fsystem);
     BaselineFrameworkPaths = ParsedArgs.getAllArgValues(OPT_BF);
     FrameworkPaths = ParsedArgs.getAllArgValues(OPT_F);

--- a/lib/DriverTool/swift_symbolgraph_extract_main.cpp
+++ b/lib/DriverTool/swift_symbolgraph_extract_main.cpp
@@ -151,7 +151,7 @@ int swift_symbolgraph_extract_main(ArrayRef<const char *> Args,
   Invocation.getClangImporterOptions().ImportForwardDeclarations = true;
   Invocation.setDefaultPrebuiltCacheIfNecessary();
 
-  if (auto *A = ParsedArgs.getLastArg(OPT_swift_version)) {
+  if (auto *A = ParsedArgs.getLastArg(OPT_language_mode)) {
     using version::Version;
     auto SwiftVersion = A->getValue();
     bool isValid = false;

--- a/lib/DriverTool/swift_synthesize_interface_main.cpp
+++ b/lib/DriverTool/swift_synthesize_interface_main.cpp
@@ -148,7 +148,7 @@ int swift_synthesize_interface_main(ArrayRef<const char *> Args,
   Invocation.getClangImporterOptions().ImportForwardDeclarations = true;
   Invocation.setDefaultPrebuiltCacheIfNecessary();
 
-  if (auto *A = ParsedArgs.getLastArg(OPT_swift_version)) {
+  if (auto *A = ParsedArgs.getLastArg(OPT_language_mode)) {
     using version::Version;
     auto SwiftVersion = A->getValue();
     bool isValid = false;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1121,7 +1121,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
           FrontendOpts.RequestedAction);
   bool HadError = false;
 
-  if (auto A = Args.getLastArg(OPT_swift_version)) {
+  if (auto A = Args.getLastArg(OPT_language_mode)) {
     auto vers =
         VersionParser::parseVersionString(A->getValue(), SourceLoc(), &Diags);
     bool isValid = false;

--- a/test/CAS/module_deps_include_tree.swift
+++ b/test/CAS/module_deps_include_tree.swift
@@ -164,7 +164,7 @@ import SubE
 // CHECK: "-cas-path"
 // CHECK: "-module-name"
 // CHECK: "G"
-// CHECK: "-swift-version"
+// CHECK: {{"-language-mode"|"-swift-version"}}
 // CHECK: "5"
 // CHECK: ],
 // CHECK: "contextHash": "{{.*}}",

--- a/test/CAS/plugin_cas.swift
+++ b/test/CAS/plugin_cas.swift
@@ -146,7 +146,7 @@ import SubE
 // CHECK: "-target"
 // CHECK: "-module-name"
 // CHECK: "G"
-// CHECK: "-swift-version"
+// CHECK: {{"-language-mode"|"-swift-version"}}
 // CHECK: "5"
 // CHECK: ],
 // CHECK: "contextHash": "{{.*}}",

--- a/test/Driver/createCompilerInvocation.swift
+++ b/test/Driver/createCompilerInvocation.swift
@@ -15,7 +15,7 @@
 // NORMAL_ARGS-DAG: -o{{$}}
 // NORMAL_ARGS-DAG: foo-{{[a-z0-9]+}}.o
 // NORMAL_ARGS-DAG: -c{{$}}
-// NORMAL_ARGS-DAG: -swift-version
+// NORMAL_ARGS-DAG: -language-mode
 // NORMAL_ARGS-DAG: -module-name
 // NORMAL_ARGS-DAG: -emit-module-path
 // NORMAL_ARGS-DAG: -emit-module-doc-path

--- a/test/Driver/help.swift
+++ b/test/Driver/help.swift
@@ -11,7 +11,7 @@
 // RUN: %swift_driver -help | %FileCheck -check-prefix NEGATIVE -check-prefix NEGATIVE-SWIFT %s
 
 // Options that work with both 'swiftc' and 'swift':
-// CHECK-DAG: -swift-version
+// CHECK-DAG: -language-mode
 
 // swiftc-only options:
 // CHECK-SWIFTC-DAG: -typecheck

--- a/test/ModuleInterface/package_interface_disable_package_name.swift
+++ b/test/ModuleInterface/package_interface_disable_package_name.swift
@@ -13,7 +13,7 @@
 // RUN: %FileCheck %s < %t/Bar.private.swiftinterface
 // RUN: %FileCheck %s < %t/Bar.package.swiftinterface
 
-// CHECK: -enable-library-evolution -package-name barpkg -swift-version 6 -module-name Bar
+// CHECK: -enable-library-evolution -package-name barpkg -language-mode 6 -module-name Bar
 
 /// Building modules from non-package interfaces with package-name (default mode) should succeed.
 // RUN: %target-swift-frontend -compile-module-from-interface %t/Bar.swiftinterface -o %t/Bar.swiftmodule -module-name Bar

--- a/test/ScanDependencies/module_deps.swift
+++ b/test/ScanDependencies/module_deps.swift
@@ -147,7 +147,7 @@ import SubE
 // CHECK: "-target"
 // CHECK: "-module-name"
 // CHECK: "G"
-// CHECK: "-swift-version"
+// CHECK: {{"-language-mode"|"-swift-version"}}
 // CHECK: "5"
 // CHECK: ],
 

--- a/test/ScanDependencies/module_deps_cache_reuse.swift
+++ b/test/ScanDependencies/module_deps_cache_reuse.swift
@@ -136,7 +136,7 @@ import SubE
 // CHECK: "-target"
 // CHECK: "-module-name"
 // CHECK: "G"
-// CHECK: "-swift-version"
+// CHECK: {{"-language-mode"|"-swift-version"}}
 // CHECK: "5"
 // CHECK: ],
 // CHECK: "contextHash": "{{.*}}",


### PR DESCRIPTION
As specified in SE-0441, -language-mode should appear in help output while -swift-version should be the hidden alias.

Related to swiftlang/swift-driver#1894
