### PR TITLE
ELF: Overhaul metadata extraction

### DIFF
--- a/include/swift/Remote/MemoryReader.h
+++ b/include/swift/Remote/MemoryReader.h
@@ -123,6 +123,15 @@ public:
   /// Look up the given public symbol name in the remote process.
   virtual RemoteAddress getSymbolAddress(const std::string &name) = 0;
 
+  /// Lookup the given public symbol name from a given ImageStart address when
+  /// operating on multi-image processes.
+  ///
+  /// Performs a full-process lookup if not overridden in a subclass.
+  virtual RemoteAddress getSymbolAddress(RemoteAddress ImageStart,
+                                         const std::string &name) {
+    return getSymbolAddress(name);
+  }
+
   /// Attempts to read a C string from the given address in the remote
   /// process.
   ///

--- a/include/swift/RemoteInspection/ELFReflectionSections.def
+++ b/include/swift/RemoteInspection/ELFReflectionSections.def
@@ -1,0 +1,24 @@
+//===--- ELFReflectionSections.def ----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_REFLECTION_SECTION
+#define SWIFT_REFLECTION_SECTION(name, field)
+#endif
+
+SWIFT_REFLECTION_SECTION(swift5_fieldmd,               Field)
+SWIFT_REFLECTION_SECTION(swift5_assocty,               AssociatedType)
+SWIFT_REFLECTION_SECTION(swift5_builtin,               Builtin)
+SWIFT_REFLECTION_SECTION(swift5_capture,               Capture)
+SWIFT_REFLECTION_SECTION(swift5_typeref,               TypeReference)
+SWIFT_REFLECTION_SECTION(swift5_reflstr,               ReflectionString)
+SWIFT_REFLECTION_SECTION(swift5_protocol_conformances, Conformance)
+SWIFT_REFLECTION_SECTION(swift5_mpenum,                MultiPayloadEnum)

--- a/include/swift/RemoteInspection/ReflectionContext.h
+++ b/include/swift/RemoteInspection/ReflectionContext.h
@@ -103,19 +103,11 @@ template <> struct MachOTraits<8> {
 template <unsigned char ELFClass> struct ELFTraits;
 
 template <> struct ELFTraits<llvm::ELF::ELFCLASS32> {
-  using Header = const struct llvm::ELF::Elf32_Ehdr;
-  using Section = const struct llvm::ELF::Elf32_Shdr;
-  using Offset = llvm::ELF::Elf32_Off;
-  using Size = llvm::ELF::Elf32_Word;
-  static constexpr unsigned char ELFClass = llvm::ELF::ELFCLASS32;
+  using Pointer = uint32_t;
 };
 
 template <> struct ELFTraits<llvm::ELF::ELFCLASS64> {
-  using Header = const struct llvm::ELF::Elf64_Ehdr;
-  using Section = const struct llvm::ELF::Elf64_Shdr;
-  using Offset = llvm::ELF::Elf64_Off;
-  using Size = llvm::ELF::Elf64_Xword;
-  static constexpr unsigned char ELFClass = llvm::ELF::ELFCLASS64;
+  using Pointer = uint64_t;
 };
 
 } // namespace
@@ -541,257 +533,93 @@ public:
   template <typename T>
   std::optional<uint32_t> readELFSections(
       RemoteAddress ImageStart,
-      std::optional<llvm::sys::MemoryBlock> FileBuffer,
       llvm::SmallVector<llvm::StringRef, 1> PotentialModuleNames = {}) {
-    // When reading from the FileBuffer we can simply return a pointer to
-    // the underlying data.
-    // When reading from the process, we need to keep the memory around
-    // until the end of the function, so we store it inside ReadDataBuffer.
-    // We do this so in both cases we can return a simple pointer.
-    std::vector<MemoryReader::ReadBytesResult> ReadDataBuffer;
-    auto readData = [&](uint64_t Offset, uint64_t Size) -> const void * {
-      if (FileBuffer.has_value()) {
-        auto Buffer = FileBuffer.value();
-        if (Offset + Size > Buffer.allocatedSize())
-          return nullptr;
-        return (const void *)((uint64_t)Buffer.base() + Offset);
-      } else {
-        MemoryReader::ReadBytesResult Buf =
-            this->getReader().readBytes(ImageStart + Offset, Size);
-        if (!Buf)
-          return nullptr;
-        ReadDataBuffer.push_back(std::move(Buf));
-        return ReadDataBuffer.back().get();
-      }
+
+    // Must match SwiftRT-ELF.cpp
+    constexpr llvm::StringRef ELFReflectionSectionSymbol =
+        "__swift5_reflection_sections";
+    constexpr uint64_t ELFReflectionSectionsVersion = 1;
+
+    const unsigned pointerSize = sizeof(typename T::Pointer);
+
+    // Locate reflection section table
+    RemoteAddress tableAddr = getReader().getSymbolAddress(
+        ImageStart, ELFReflectionSectionSymbol.str());
+
+    if (!tableAddr)
+      return std::nullopt;
+
+    typename T::Pointer version = 0;
+    if (!getReader().readInteger(tableAddr, pointerSize, &version))
+      return std::nullopt;
+    if (version != ELFReflectionSectionsVersion)
+      return std::nullopt;
+
+    auto readTableSection =
+        [&](unsigned index) -> std::pair<RemoteRef<void>, uint64_t> {
+      RemoteAddress startFieldAddr = tableAddr + (1 + 2 * index) * pointerSize;
+      RemoteAddress stopFieldAddr = tableAddr + (2 + 2 * index) * pointerSize;
+
+      auto start = getReader().readPointer(startFieldAddr, pointerSize);
+      auto stop = getReader().readPointer(stopFieldAddr, pointerSize);
+
+      if (!start || !stop)
+        return {nullptr, 0};
+      RemoteAddress sectionStart = start->getResolvedAddress();
+      RemoteAddress sectionStop = stop->getResolvedAddress();
+
+      if (!sectionStart || !sectionStop || sectionStart >= sectionStop)
+        return {nullptr, 0};
+
+      const uint64_t secSize =
+          sectionStop.getRawAddress() - sectionStart.getRawAddress();
+      if (secSize == 0)
+        return {nullptr, 0};
+
+      auto sectionBuffer = this->getReader().readBytes(sectionStart, secSize);
+      if (!sectionBuffer)
+        return {nullptr, 0};
+      auto secContents = RemoteRef<void>(sectionStart, sectionBuffer.get());
+      savedBuffers.push_back(std::move(sectionBuffer));
+      return {secContents, secSize};
     };
 
-    const void *Buf = readData(0, sizeof(typename T::Header));
-    if (!Buf)
-      return {};
-    auto Hdr = reinterpret_cast<const typename T::Header *>(Buf);
-    assert(Hdr->getFileClass() == T::ELFClass && "invalid ELF file class");
+    enum {
+      idx_fieldmd = 0,
+      idx_assocty,
+      idx_builtin,
+      idx_capture,
+      idx_typeref,
+      idx_reflstr,
+      idx_conform,
+      idx_mpenum,
+    };
 
-    // From the header, grab information about the section header table.
-    uint64_t SectionHdrAddress = Hdr->e_shoff;
-    uint16_t SectionHdrNumEntries = Hdr->e_shnum;
-    uint16_t SectionEntrySize = Hdr->e_shentsize;
+    auto fieldMd = readTableSection(idx_fieldmd);
+    auto assoctyMd = readTableSection(idx_assocty);
+    auto builtinMd = readTableSection(idx_builtin);
+    auto captureMd = readTableSection(idx_capture);
+    auto typerefMd = readTableSection(idx_typeref);
+    auto reflstrMd = readTableSection(idx_reflstr);
+    auto conformanceMd = readTableSection(idx_conform);
+    auto mpenumMd = readTableSection(idx_mpenum);
 
-    if (sizeof(typename T::Section) > SectionEntrySize)
-      return {};
+    if (!(fieldMd.first || assoctyMd.first || builtinMd.first ||
+          captureMd.first || typerefMd.first || reflstrMd.first ||
+          conformanceMd.first || mpenumMd.first))
+      return std::nullopt;
 
-    // Special handling for large amount of sections.
-    // From the elf man page, describing e_shnum:
-    //
-    // If the number of entries in the section header table is
-    // larger than or equal to SHN_LORESERVE (0xff00), e_shnum
-    // holds the value zero and the real number of entries in the
-    // section header table is held in the sh_size member of the
-    // initial entry in section header table.  Otherwise, the
-    // sh_size member of the initial entry in the section header
-    // table holds the value zero.
-    if (SectionHdrNumEntries == 0 && SectionEntrySize > 0) {
-      auto SecBuf = readData(SectionHdrAddress, sizeof(typename T::Section));
-      if (!SecBuf)
-        return {};
-      const typename T::Section *FirstSectHdr =
-          reinterpret_cast<const typename T::Section *>(SecBuf);
-      SectionHdrNumEntries = FirstSectHdr->sh_size;
-    }
-
-    if (SectionHdrNumEntries == 0)
-      return {};
-
-    // Collect all the section headers, we need them to look up the
-    // reflection sections (by name) and the string table.
-    // We read the section headers from the FileBuffer, since they are
-    // not mapped in the child process.
-    std::vector<const typename T::Section *> SecHdrVec;
-    for (unsigned I = 0; I < SectionHdrNumEntries; ++I) {
-      uint64_t Offset = SectionHdrAddress + (I * SectionEntrySize);
-      auto SecBuf = readData(Offset, sizeof(typename T::Section));
-      if (!SecBuf)
-        return {};
-      const typename T::Section *SecHdr =
-          reinterpret_cast<const typename T::Section *>(SecBuf);
-
-      SecHdrVec.push_back(SecHdr);
-    }
-
-    // This provides quick access to the section header string table index.
-    // We also here handle the unlikely even where the section index overflows
-    // and it's just a pointer to secondary storage (SHN_XINDEX).
-    uint32_t SecIdx = Hdr->e_shstrndx;
-    if (SecIdx == llvm::ELF::SHN_XINDEX) {
-      assert(!SecHdrVec.empty() && "malformed ELF object");
-      SecIdx = SecHdrVec[0]->sh_link;
-    }
-
-    assert(SecIdx < SecHdrVec.size() && "malformed ELF object");
-
-    const typename T::Section *SecHdrStrTab = SecHdrVec[SecIdx];
-    typename T::Offset StrTabOffset = SecHdrStrTab->sh_offset;
-    typename T::Size StrTabSize = SecHdrStrTab->sh_size;
-
-    auto StrTabBuf = readData(StrTabOffset, StrTabSize);
-    if (!StrTabBuf)
-      return {};
-    auto StrTab = reinterpret_cast<const char *>(StrTabBuf);
-    bool Error = false;
-
-    // GNU ld and lld both merge sections regardless of the
-    // `SHF_GNU_RETAIN` flag.  gold, presently, does not.  The Swift
-    // compiler has a couple of switches that control whether or not
-    // the reflection sections are stripped; when these are enabled,
-    // it will _not_ set `SHF_GNU_RETAIN` on the reflection metadata
-    // sections.  However, `swiftrt.o` contains declarations of the
-    // sections _with_ the `SHF_GNU_RETAIN` flag set, which makes
-    // sense since at runtime we will only expect to be able to access
-    // reflection metadata that we said we wanted to exist at runtime.
-    //
-    // The upshot is that when linking with gold, we can end up with
-    // two sets of reflection metadata sections.  In a normal build
-    // where the compiler flags are the same for every linked object,
-    // we'll have *either* all retained *or* all un-retained sections
-    // (the retained sections will still exist because of `swiftrt.o`,
-    // but will be empty).  The only time we'd expect to have a mix is
-    // where some code was compiled with a different setting of the
-    // metadata stripping flags.  If that happens, the code below will
-    // simply add both sets of reflection sections, with the retained
-    // ones added first.
-    //
-    // See also https://sourceware.org/bugzilla/show_bug.cgi?id=31415.
-    auto findELFSectionByName =
-        [&](llvm::StringRef Name, bool Retained) -> std::pair<RemoteRef<void>, uint64_t> {
-          if (Error)
-            return {nullptr, 0};
-          // Now for all the sections, find their name.
-          for (const typename T::Section *Hdr : SecHdrVec) {
-            // Skip unused headers
-            if (Hdr->sh_type == llvm::ELF::SHT_NULL)
-              continue;
-            uint32_t Offset = Hdr->sh_name;
-            const char *Start = (const char *)StrTab + Offset;
-            uint64_t StringSize = strnlen(Start, StrTabSize - Offset);
-            if (StringSize > StrTabSize - Offset) {
-              Error = true;
-              break;
-            }
-            std::string SecName(Start, StringSize);
-            if (SecName != Name)
-              continue;
-            if (Retained != bool(Hdr->sh_flags & llvm::ELF::SHF_GNU_RETAIN))
-              continue;
-            RemoteAddress SecStart = ImageStart + Hdr->sh_addr;
-            auto SecSize = Hdr->sh_size;
-            MemoryReader::ReadBytesResult SecBuf;
-            if (FileBuffer.has_value()) {
-              // sh_offset gives us the offset to the section in the file,
-              // while sh_addr gives us the offset in the process.
-              auto Offset = Hdr->sh_offset;
-              if (FileBuffer->allocatedSize() < Offset + SecSize) {
-                Error = true;
-                break;
-              }
-              auto *Buf = malloc(SecSize);
-              SecBuf = MemoryReader::ReadBytesResult(
-                  Buf, [](const void *ptr) { free(const_cast<void *>(ptr)); });
-              memcpy((void *)Buf,
-                     (const void *)((uint64_t)FileBuffer->base() + Offset),
-                     SecSize);
-            } else {
-              SecBuf = this->getReader().readBytes(SecStart, SecSize);
-            }
-            if (!SecBuf)
-              return {nullptr, 0};
-            auto SecContents = RemoteRef<void>(SecStart, SecBuf.get());
-            savedBuffers.push_back(std::move(SecBuf));
-            return {SecContents, SecSize};
-          }
-          return {nullptr, 0};
-        };
-
-    SwiftObjectFileFormatELF ObjectFileFormat;
-    auto FieldMdSec = findELFSectionByName(
-        ObjectFileFormat.getSectionName(ReflectionSectionKind::fieldmd), true);
-    auto AssocTySec = findELFSectionByName(
-        ObjectFileFormat.getSectionName(ReflectionSectionKind::assocty), true);
-    auto BuiltinTySec = findELFSectionByName(
-        ObjectFileFormat.getSectionName(ReflectionSectionKind::builtin), true);
-    auto CaptureSec = findELFSectionByName(
-        ObjectFileFormat.getSectionName(ReflectionSectionKind::capture), true);
-    auto TypeRefMdSec = findELFSectionByName(
-        ObjectFileFormat.getSectionName(ReflectionSectionKind::typeref), true);
-    auto ReflStrMdSec = findELFSectionByName(
-        ObjectFileFormat.getSectionName(ReflectionSectionKind::reflstr), true);
-    auto ConformMdSec = findELFSectionByName(
-        ObjectFileFormat.getSectionName(ReflectionSectionKind::conform), true);
-    auto MPEnumMdSec = findELFSectionByName(
-        ObjectFileFormat.getSectionName(ReflectionSectionKind::mpenum), true);
-
-    if (Error)
-      return {};
-
-    std::optional<uint32_t> result = {};
-
-    // We succeed if at least one of the sections is present in the
-    // ELF executable.
-    if (FieldMdSec.first || AssocTySec.first || BuiltinTySec.first ||
-        CaptureSec.first || TypeRefMdSec.first || ReflStrMdSec.first ||
-        ConformMdSec.first || MPEnumMdSec.first) {
-      ReflectionInfo info = {{FieldMdSec.first, FieldMdSec.second},
-                             {AssocTySec.first, AssocTySec.second},
-                             {BuiltinTySec.first, BuiltinTySec.second},
-                             {CaptureSec.first, CaptureSec.second},
-                             {TypeRefMdSec.first, TypeRefMdSec.second},
-                             {ReflStrMdSec.first, ReflStrMdSec.second},
-                             {ConformMdSec.first, ConformMdSec.second},
-                             {MPEnumMdSec.first, MPEnumMdSec.second},
-                             PotentialModuleNames};
-      result = this->addReflectionInfo(info);
-    }
-
-    // Also check for the non-retained versions of the sections; we'll
-    // only return a single reflection info ID if both are found (and it'll
-    // be the one for the retained sections if we have them), but we'll
-    // still add all the reflection information.
-    FieldMdSec = findELFSectionByName(
-        ObjectFileFormat.getSectionName(ReflectionSectionKind::fieldmd), false);
-    AssocTySec = findELFSectionByName(
-        ObjectFileFormat.getSectionName(ReflectionSectionKind::assocty), false);
-    BuiltinTySec = findELFSectionByName(
-        ObjectFileFormat.getSectionName(ReflectionSectionKind::builtin), false);
-    CaptureSec = findELFSectionByName(
-        ObjectFileFormat.getSectionName(ReflectionSectionKind::capture), false);
-    TypeRefMdSec = findELFSectionByName(
-        ObjectFileFormat.getSectionName(ReflectionSectionKind::typeref), false);
-    ReflStrMdSec = findELFSectionByName(
-        ObjectFileFormat.getSectionName(ReflectionSectionKind::reflstr), false);
-    ConformMdSec = findELFSectionByName(
-        ObjectFileFormat.getSectionName(ReflectionSectionKind::conform), false);
-    MPEnumMdSec = findELFSectionByName(
-        ObjectFileFormat.getSectionName(ReflectionSectionKind::mpenum), false);
-
-    if (Error)
-      return {};
-
-    if (FieldMdSec.first || AssocTySec.first || BuiltinTySec.first ||
-        CaptureSec.first || TypeRefMdSec.first || ReflStrMdSec.first ||
-        ConformMdSec.first || MPEnumMdSec.first) {
-      ReflectionInfo info = {{FieldMdSec.first, FieldMdSec.second},
-                             {AssocTySec.first, AssocTySec.second},
-                             {BuiltinTySec.first, BuiltinTySec.second},
-                             {CaptureSec.first, CaptureSec.second},
-                             {TypeRefMdSec.first, TypeRefMdSec.second},
-                             {ReflStrMdSec.first, ReflStrMdSec.second},
-                             {ConformMdSec.first, ConformMdSec.second},
-                             {MPEnumMdSec.first, MPEnumMdSec.second},
-                             PotentialModuleNames};
-      auto rid = this->addReflectionInfo(info);
-      if (!result)
-        result = rid;
-    }
-
-    return result;
+    return this->addReflectionInfo({
+        {fieldMd.first, fieldMd.second},
+        {assoctyMd.first, assoctyMd.second},
+        {builtinMd.first, builtinMd.second},
+        {captureMd.first, captureMd.second},
+        {typerefMd.first, typerefMd.second},
+        {reflstrMd.first, reflstrMd.second},
+        {conformanceMd.first, conformanceMd.second},
+        {mpenumMd.first, mpenumMd.second},
+        PotentialModuleNames,
+    });
   }
 
   /// Parses metadata information from an ELF image. Because the Section
@@ -814,7 +642,6 @@ public:
   ///     \b std::nullopt otherwise.
   std::optional<uint32_t>
   readELF(RemoteAddress ImageStart,
-          std::optional<llvm::sys::MemoryBlock> FileBuffer,
           llvm::SmallVector<llvm::StringRef, 1> PotentialModuleNames = {}) {
     auto Buf =
         this->getReader().readBytes(ImageStart, sizeof(llvm::ELF::Elf64_Ehdr));
@@ -831,10 +658,10 @@ public:
     unsigned char FileClass = Hdr->getFileClass();
     if (FileClass == llvm::ELF::ELFCLASS64) {
       return readELFSections<ELFTraits<llvm::ELF::ELFCLASS64>>(
-          ImageStart, FileBuffer, PotentialModuleNames);
+          ImageStart, PotentialModuleNames);
     } else if (FileClass == llvm::ELF::ELFCLASS32) {
       return readELFSections<ELFTraits<llvm::ELF::ELFCLASS32>>(
-          ImageStart, FileBuffer, PotentialModuleNames);
+          ImageStart, PotentialModuleNames);
     } else {
       return std::nullopt;
     }
@@ -1164,8 +991,7 @@ public:
         && MagicBytes[1] == llvm::ELF::ElfMagic[1]
         && MagicBytes[2] == llvm::ELF::ElfMagic[2]
         && MagicBytes[3] == llvm::ELF::ElfMagic[3]) {
-      return readELF(ImageStart, std::optional<llvm::sys::MemoryBlock>(),
-                     PotentialModuleNames);
+      return readELF(ImageStart, PotentialModuleNames);
     }
 
     // WASM.

--- a/include/swift/RemoteInspection/ReflectionContext.h
+++ b/include/swift/RemoteInspection/ReflectionContext.h
@@ -104,10 +104,12 @@ template <unsigned char ELFClass> struct ELFTraits;
 
 template <> struct ELFTraits<llvm::ELF::ELFCLASS32> {
   using Pointer = uint32_t;
+  static constexpr size_t PointerSize = sizeof(Pointer);
 };
 
 template <> struct ELFTraits<llvm::ELF::ELFCLASS64> {
   using Pointer = uint64_t;
+  static constexpr size_t PointerSize = sizeof(Pointer);
 };
 
 } // namespace
@@ -538,9 +540,7 @@ public:
     // Must match SwiftRT-ELF.cpp
     constexpr llvm::StringRef ELFReflectionSectionSymbol =
         "__swift5_reflection_sections";
-    constexpr uint64_t ELFReflectionSectionsVersion = 1;
-
-    const unsigned pointerSize = sizeof(typename T::Pointer);
+    constexpr uint64_t ELFReflectionSectionsVersion = 1u;
 
     // Locate reflection section table
     RemoteAddress tableAddr = getReader().getSymbolAddress(
@@ -550,18 +550,25 @@ public:
       return std::nullopt;
 
     typename T::Pointer version = 0;
-    if (!getReader().readInteger(tableAddr, pointerSize, &version))
+    if (!getReader().readInteger(tableAddr, T::PointerSize, &version))
       return std::nullopt;
     if (version != ELFReflectionSectionsVersion)
       return std::nullopt;
 
-    auto readTableSection =
-        [&](unsigned index) -> std::pair<RemoteRef<void>, uint64_t> {
-      RemoteAddress startFieldAddr = tableAddr + (1 + 2 * index) * pointerSize;
-      RemoteAddress stopFieldAddr = tableAddr + (2 + 2 * index) * pointerSize;
+    struct ReflectionSection {
+      RemoteRef<void> contents;
+      uint64_t size;
+      explicit operator bool() const { return contents != nullptr; }
+    };
 
-      auto start = getReader().readPointer(startFieldAddr, pointerSize);
-      auto stop = getReader().readPointer(stopFieldAddr, pointerSize);
+    auto readTableSection = [&](unsigned index) -> ReflectionSection {
+      RemoteAddress startFieldAddr =
+          tableAddr + (1 + 2 * index) * T::PointerSize;
+      RemoteAddress stopFieldAddr =
+          tableAddr + (2 + 2 * index) * T::PointerSize;
+
+      auto start = getReader().readPointer(startFieldAddr, T::PointerSize);
+      auto stop = getReader().readPointer(stopFieldAddr, T::PointerSize);
 
       if (!start || !stop)
         return {nullptr, 0};
@@ -584,42 +591,34 @@ public:
       return {secContents, secSize};
     };
 
-    enum {
-      idx_fieldmd = 0,
-      idx_assocty,
-      idx_builtin,
-      idx_capture,
-      idx_typeref,
-      idx_reflstr,
-      idx_conform,
-      idx_mpenum,
+    enum : unsigned {
+#define SWIFT_REFLECTION_SECTION(Name, Field) idx_##Name,
+#include "ELFReflectionSections.def"
+#undef SWIFT_REFLECTION_SECTION
+      kELFReflectionSectionCount
     };
 
-    auto fieldMd = readTableSection(idx_fieldmd);
-    auto assoctyMd = readTableSection(idx_assocty);
-    auto builtinMd = readTableSection(idx_builtin);
-    auto captureMd = readTableSection(idx_capture);
-    auto typerefMd = readTableSection(idx_typeref);
-    auto reflstrMd = readTableSection(idx_reflstr);
-    auto conformanceMd = readTableSection(idx_conform);
-    auto mpenumMd = readTableSection(idx_mpenum);
+    ReflectionSection sections[kELFReflectionSectionCount];
+    bool populated = false;
 
-    if (!(fieldMd.first || assoctyMd.first || builtinMd.first ||
-          captureMd.first || typerefMd.first || reflstrMd.first ||
-          conformanceMd.first || mpenumMd.first))
+#define SWIFT_REFLECTION_SECTION(Name, Field)                                  \
+  sections[idx_##Name] = readTableSection(idx_##Name);                         \
+  populated |= bool(sections[idx_##Name]);
+#include "ELFReflectionSections.def"
+#undef SWIFT_REFLECTION_SECTION
+
+    if (!populated)
       return std::nullopt;
 
-    return this->addReflectionInfo({
-        {fieldMd.first, fieldMd.second},
-        {assoctyMd.first, assoctyMd.second},
-        {builtinMd.first, builtinMd.second},
-        {captureMd.first, captureMd.second},
-        {typerefMd.first, typerefMd.second},
-        {reflstrMd.first, reflstrMd.second},
-        {conformanceMd.first, conformanceMd.second},
-        {mpenumMd.first, mpenumMd.second},
+    ReflectionInfo info{
+#define SWIFT_REFLECTION_SECTION(Name, Field)                                  \
+  {sections[idx_##Name].contents, sections[idx_##Name].size},
+#include "ELFReflectionSections.def"
+#undef SWIFT_REFLECTION_SECTION
         PotentialModuleNames,
-    });
+    };
+
+    return this->addReflectionInfo(info);
   }
 
   /// Parses metadata information from an ELF image. Because the Section

--- a/include/swift/StaticMirror/ObjectFileContext.h
+++ b/include/swift/StaticMirror/ObjectFileContext.h
@@ -78,6 +78,10 @@ public:
                                                uint64_t pointerValue) const;
 
   remote::RemoteAbsolutePointer getDynamicSymbol(uint64_t Addr) const;
+
+  /// Lookup the virtual address of the given symbol in this image's symbol
+  /// table.
+  std::optional<uint64_t> getSymbolAddress(StringRef name) const;
 };
 
 /// MemoryReader that reads from the on-disk representation of an executable
@@ -134,6 +138,11 @@ public:
 
   remote::RemoteAbsolutePointer
   getDynamicSymbol(reflection::RemoteAddress Addr) override;
+
+  /// Lookup the name in an image at a given start address
+  reflection::RemoteAddress
+  getSymbolAddress(reflection::RemoteAddress ImageStart,
+                   const std::string &name) override;
 };
 
 using ReflectionContextOwner = std::unique_ptr<void, void (*)(void *)>;

--- a/lib/StaticMirror/ObjectFileContext.cpp
+++ b/lib/StaticMirror/ObjectFileContext.cpp
@@ -234,12 +234,6 @@ void Image::scanELF(const llvm::object::ELFObjectFileBase *O) {
   } else {
     return;
   }
-
-  // FIXME: ReflectionContext tries to read bits of the ELF structure that
-  // aren't normally mapped by a phdr. Until that's fixed,
-  // allow access to the whole file 1:1 in address space that isn't otherwise
-  // mapped.
-  Segments.push_back({HeaderAddress, O->getData()});
 }
 
 void Image::scanCOFF(const llvm::object::COFFObjectFile *O) {

--- a/lib/StaticMirror/ObjectFileContext.cpp
+++ b/lib/StaticMirror/ObjectFileContext.cpp
@@ -377,6 +377,35 @@ remote::RemoteAbsolutePointer Image::getDynamicSymbol(uint64_t Addr) const {
                             remote::RemoteAddress::DefaultAddressSpace));
 }
 
+std::optional<uint64_t> Image::getSymbolAddress(StringRef Name) const {
+  auto findIn = [&](auto &&Symbols) -> std::optional<uint64_t> {
+    for (const auto &Symb : Symbols) {
+      auto SymbName = Symb.getName();
+      if (!SymbName) {
+        llvm::consumeError(SymbName.takeError());
+        continue;
+      }
+      if (*SymbName != Name)
+        continue;
+      auto Value = Symb.getValue();
+      if (!Value) {
+        llvm::consumeError(Value.takeError());
+        continue;
+      }
+      return *Value;
+    }
+    return std::nullopt;
+  };
+  // Prefer the regular symbol table and then fall back to the dynamic symbol
+  // table.
+  if (auto Addr = findIn(O->symbols()))
+    return Addr;
+  if (const auto *ELF = dyn_cast<llvm::object::ELFObjectFileBase>(O))
+    if (auto Addr = findIn(ELF->getDynamicSymbolIterators()))
+      return Addr;
+  return std::nullopt;
+}
+
 std::pair<const Image *, uint64_t>
 ObjectMemoryReader::decodeImageIndexAndAddress(uint64_t Addr) const {
   for (auto &Image : Images) {
@@ -526,6 +555,24 @@ ObjectMemoryReader::getImageStartAddress(unsigned i) const {
                             reflection::RemoteAddress::DefaultAddressSpace)));
 }
 
+reflection::RemoteAddress
+ObjectMemoryReader::getSymbolAddress(reflection::RemoteAddress imageStart,
+                                     const std::string &name) {
+  const Image *image;
+  uint64_t imageAddr;
+  std::tie(image, imageAddr) =
+      decodeImageIndexAndAddress(imageStart.getRawAddress());
+  if (!image)
+    return reflection::RemoteAddress();
+
+  auto symbolAddr = image->getSymbolAddress(name);
+  if (!symbolAddr)
+    return reflection::RemoteAddress();
+  return reflection::RemoteAddress(encodeImageIndexAndAddress(
+      image, remote::RemoteAddress(
+                 *symbolAddr, reflection::RemoteAddress::DefaultAddressSpace)));
+}
+
 ReadBytesResult ObjectMemoryReader::readBytes(reflection::RemoteAddress Addr,
                                               uint64_t Size) {
   auto addrValue = Addr.getRawAddress();
@@ -581,7 +628,17 @@ ObjectMemoryReader::getDynamicSymbol(reflection::RemoteAddress Addr) {
   if (!image)
     return nullptr;
 
-  return image->getDynamicSymbol(imageAddr);
+  auto resolved = image->getDynamicSymbol(imageAddr);
+  if (!resolved)
+    return resolved;
+
+  // A relocation that resolves to an absolute address is image-relative. Mix
+  // the image index back into the result so the resulting address refers to the
+  // same image, mirroring `resolvePointer`.
+  if (resolved.getSymbol().empty())
+    return remote::RemoteAbsolutePointer(remote::RemoteAddress(
+        encodeImageIndexAndAddress(image, resolved.getResolvedAddress())));
+  return resolved;
 }
 
 uint64_t ObjectMemoryReader::getPtrauthMask() {

--- a/stdlib/public/runtime/SwiftRT-ELF.cpp
+++ b/stdlib/public/runtime/SwiftRT-ELF.cpp
@@ -70,10 +70,61 @@ DECLARE_SWIFT_SECTION(swift5_tests)
 }
 
 #undef DECLARE_SWIFT_SECTION
+#undef DECLARE_SWIFT_REFLECTION_SECTION
 
 namespace {
 static swift::MetadataSections sections{};
 }
+
+// Statically initialized read-only table identifying Swift reflection metadata
+// sections. Exported by the public symbol containing the start/stop pointer
+// bounds to each section.
+//
+// Unlike the `sections` table above, the data is initialized by the linker,
+// making the data valid both on disk and when loaded, so no need for a loader,
+// relocations, or a constructor function
+
+struct SwiftReflectionSectionBounds {
+  const void *start;
+  const void *stop;
+};
+
+#define SWIFT_REFLECTION_SECTIONS_VERSION 1u
+
+// This ordering matches the ReflectionInfo struct layout in
+// `ReflectionContext.h`.
+//
+// NOTE! Bump the version number if new members are added or if they are
+// re-ordered.
+struct SwiftReflectionSections {
+  __swift_uintptr_t version;
+
+  SwiftReflectionSectionBounds swift5_fieldmd;
+  SwiftReflectionSectionBounds swift5_assocty;
+  SwiftReflectionSectionBounds swift5_builtin;
+  SwiftReflectionSectionBounds swift5_capture;
+  SwiftReflectionSectionBounds swift5_typeref;
+  SwiftReflectionSectionBounds swift5_reflstr;
+  SwiftReflectionSectionBounds swift5_protocol_conformances;
+  SwiftReflectionSectionBounds swift5_mpenum;
+};
+
+#define SWIFT_REFLECTION_SECTION_BOUNDS(name)                                  \
+  {static_cast<const void *>(&__start_##name),                                 \
+   static_cast<const void *>(&__stop_##name)}
+
+extern "C" __attribute__((__used__, __visibility__("default")))
+const SwiftReflectionSections __swift5_reflection_sections = {
+    SWIFT_REFLECTION_SECTIONS_VERSION,
+    SWIFT_REFLECTION_SECTION_BOUNDS(swift5_fieldmd),
+    SWIFT_REFLECTION_SECTION_BOUNDS(swift5_assocty),
+    SWIFT_REFLECTION_SECTION_BOUNDS(swift5_builtin),
+    SWIFT_REFLECTION_SECTION_BOUNDS(swift5_capture),
+    SWIFT_REFLECTION_SECTION_BOUNDS(swift5_typeref),
+    SWIFT_REFLECTION_SECTION_BOUNDS(swift5_reflstr),
+    SWIFT_REFLECTION_SECTION_BOUNDS(swift5_protocol_conformances),
+    SWIFT_REFLECTION_SECTION_BOUNDS(swift5_mpenum),
+};
 
 SWIFT_ALLOWED_RUNTIME_GLOBAL_CTOR_BEGIN
 __attribute__((__constructor__))

--- a/test/Reflection/box_descriptors.sil
+++ b/test/Reflection/box_descriptors.sil
@@ -2,12 +2,6 @@
 // RUN: %target-build-swift %s -emit-module -emit-library -module-name capture_descriptors -o %t/capture_descriptors%{target-shared-library-suffix}
 // RUN: %target-swift-reflection-dump %t/capture_descriptors%{target-shared-library-suffix} | %FileCheck %s
 
-// https://github.com/apple/swift/issues/53148
-// UNSUPPORTED: OS=linux-gnu, OS=linux-android, OS=linux-androideabi
-
-// https://github.com/apple/swift/issues/55339
-// XFAIL: OS=openbsd
-
 sil_stage canonical
 
 import Builtin

--- a/test/Reflection/capture_descriptors.sil
+++ b/test/Reflection/capture_descriptors.sil
@@ -1,19 +1,9 @@
 
 // REQUIRES: no_asan
 
-// https://github.com/apple/swift/issues/55339
-// XFAIL: OS=openbsd
-// UNSUPPORTED: OS=linux-android, OS=linux-androideabi
-
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -emit-module -emit-library -module-name capture_descriptors -o %t/capture_descriptors%{target-shared-library-suffix} -L%t/../../.. -lBlocksRuntime
 // RUN: %target-swift-reflection-dump %t/capture_descriptors%{target-shared-library-suffix} | %FileCheck %s
-
-// lld on FreeBSD relocates some of the metadata sections resulting in invalid
-// offsets in section headers, breaking the Swift reflection data ELF parser
-// resulting in missing metadata.
-// rdar://159139154
-// UNSUPPORTED: OS=freebsd
 
 sil_stage canonical
 

--- a/test/Reflection/typeref_decoding_imported.swift
+++ b/test/Reflection/typeref_decoding_imported.swift
@@ -2,9 +2,6 @@
 //
 // LC_DYLD_CHAINED_FIXUPS decode not currently supported (default on visionOS)
 // UNSUPPORTED: OS=xros
-//
-// https://github.com/apple/swift/issues/55339
-// XFAIL: OS=openbsd
 
 // rdar://100558042
 // UNSUPPORTED: CPU=arm64e
@@ -20,14 +17,6 @@
 
 // RUN: %target-build-swift -target %target-swift-5.2-abi-triple %S/Inputs/ImportedTypes.swift %S/Inputs/ImportedTypesOther.swift -parse-as-library -emit-module -emit-library %no-fixup-chains -module-name TypesToReflect -o %t/%target-library-name(TypesToReflect) -I %S/Inputs -whole-module-optimization -num-threads 2
 // RUN: %target-swift-reflection-dump %t/%target-library-name(TypesToReflect) | %FileCheck %s --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-cpu
-
-// UNSUPPORTED: OS=linux-android, OS=linux-androideabi
-
-// lld on FreeBSD relocates some of the metadata sections resulting in invalid
-// offsets in section headers, breaking the Swift reflection data ELF parser
-// resulting in missing metadata.
-// rdar://159139154
-// XFAIL: OS=freebsd
 
 // CHECK-32: FIELDS:
 // CHECK-32: =======

--- a/unittests/MetadataReader/CMakeLists.txt
+++ b/unittests/MetadataReader/CMakeLists.txt
@@ -1,7 +1,14 @@
 add_swift_unittest(SwiftMetadataReaderTests
-  MetadataReaderTest.cpp)
+  MetadataReaderTest.cpp
+  ObjectFileContextTest.cpp
+)
+
 target_link_libraries(SwiftMetadataReaderTests
   PRIVATE
   swiftBasic
   swiftDemangling
-  )
+  swiftStaticMirror
+  swiftRemoteInspection
+  LLVMObject
+  LLVMObjectYAML
+)

--- a/unittests/MetadataReader/ObjectFileContextTest.cpp
+++ b/unittests/MetadataReader/ObjectFileContextTest.cpp
@@ -1,0 +1,166 @@
+//===--- ObjectFileContextTest.cpp ----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/StaticMirror/ObjectFileContext.h"
+#include "swift/Remote/RemoteAddress.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Object/ObjectFile.h"
+#include "llvm/ObjectYAML/yaml2obj.h"
+#include "gtest/gtest.h"
+
+using namespace swift;
+using namespace swift::static_mirror;
+
+namespace {
+
+// Minimal ELF64 dynamic library that exposes the two relocations
+// Image::scanELFType records:
+//   * R_X86_64_RELATIVE — pure-address branch (no symbol name). The recorded
+//     value is `HeaderAddress + r_addend`, so a non-zero addend lets us
+//     verify the addend was actually folded into the recorded address.
+//   * R_X86_64_64       — symbol-named branch (resolved via the LLVM resolver).
+//
+// Also exposing the `image_local` symbol to verify `getSymbolAddress`.
+// `PT_LOAD` covers all sections so `reloc` offsets fall inside a segment
+// that `decodeImageIndexAndAddress` can find.
+constexpr llvm::StringLiteral kFixtureYaml = R"(--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_DYN
+  Machine: EM_X86_64
+Sections:
+  - Name:    .text
+    Type:    SHT_PROGBITS
+    Flags:   [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address: 0x1000
+    Size:    0x10
+  - Name:    .data
+    Type:    SHT_PROGBITS
+    Flags:   [ SHF_ALLOC, SHF_WRITE ]
+    Address: 0x1010
+    Size:    0x20
+  - Name:    .rela.dyn
+    Type:    SHT_RELA
+    Flags:   [ SHF_ALLOC ]
+    Address: 0x1030
+    Link:    .dynsym
+    Relocations:
+      - Offset: 0x1010
+        Type:   R_X86_64_RELATIVE
+        Addend: 0x0004
+      - Offset: 0x1018
+        Type:   R_X86_64_64
+        Symbol: external
+  - Name:    .dynamic
+    Type:    SHT_DYNAMIC
+    Flags:   [ SHF_ALLOC ]
+    Address: 0x1080
+    Link:    .dynstr
+    Entries:
+      - Tag:   DT_RELA
+        Value: 0x1030
+      - Tag:   DT_RELASZ
+        Value: 0x30
+      - Tag:   DT_RELAENT
+        Value: 0x18
+      - Tag:   DT_NULL
+        Value: 0x0
+Symbols:
+  - Name:    image_local
+    Type:    STT_FUNC
+    Section: .text
+    Value:   0x1000
+    Binding: STB_GLOBAL
+DynamicSymbols:
+  - Name:    external
+ProgramHeaders:
+  - Type:     PT_LOAD
+    Flags:    [ PF_R ]
+    VAddr:    0x1000
+    FirstSec: .text
+    LastSec:  .dynamic
+)";
+
+std::unique_ptr<llvm::object::ObjectFile>
+buildFixture(llvm::SmallVectorImpl<char> &Storage) {
+  return llvm::yaml::yaml2ObjectFile(
+      Storage, kFixtureYaml,
+      [](const llvm::Twine &Msg) { ADD_FAILURE() << Msg.str(); });
+}
+
+class ObjectFileContextTest : public ::testing::Test {
+protected:
+  llvm::SmallVector<char, 0> Storage0;
+  llvm::SmallVector<char, 0> Storage1;
+  std::unique_ptr<llvm::object::ObjectFile> Obj0;
+  std::unique_ptr<llvm::object::ObjectFile> Obj1;
+
+  void SetUp() override {
+    Obj0 = buildFixture(Storage0);
+    Obj1 = buildFixture(Storage1);
+    ASSERT_TRUE(Obj0);
+    ASSERT_TRUE(Obj1);
+  }
+};
+
+// A two-image setup is required to make the slide non-zero — with a single
+// image, ObjectMemoryReader leaves Slide at 0 and the asymmetry fix becomes a
+// no-op that the test couldn't observe.
+TEST_F(ObjectFileContextTest, SymmetricPointerReaders) {
+  std::vector<const llvm::object::ObjectFile *> Objects{Obj0.get(), Obj1.get()};
+  ObjectMemoryReader Reader(Objects);
+
+  constexpr uint64_t HeaderAddress = 0x1000;
+  constexpr uint64_t LocalSymbolValue = 0x1000;
+  constexpr uint64_t RelativeRelocOffset = 0x1010;
+  constexpr uint64_t RelativeRelocAddend = 0x0004;
+  constexpr uint64_t SymbolNamedRelocOffset = 0x1018;
+
+  auto Image1Start = Reader.getImageStartAddress(1);
+  uint64_t Slide1 = Image1Start.getRawAddress() - HeaderAddress;
+  ASSERT_NE(Slide1, 0u)
+      << "Multi-image setup should produce a non-zero slide for image 1";
+
+  /// Verify resolved symbol address includes image1 slide.
+  {
+    auto Resolved = Reader.getSymbolAddress(Image1Start, "image_local");
+    EXPECT_EQ(Resolved.getRawAddress(), LocalSymbolValue + Slide1);
+  }
+
+  // Verify looking up a dynamic symbol by relocation address works and that it
+  // includes the addend and image slide.
+  {
+    swift::remote::RemoteAddress RelocAddr(
+        RelativeRelocOffset + Slide1,
+        swift::remote::RemoteAddress::DefaultAddressSpace);
+    auto Resolved = Reader.getDynamicSymbol(RelocAddr);
+    ASSERT_TRUE(static_cast<bool>(Resolved));
+    EXPECT_TRUE(Resolved.getSymbol().empty());
+    EXPECT_EQ(Resolved.getResolvedAddress().getRawAddress(),
+              HeaderAddress + RelativeRelocAddend + Slide1);
+  }
+
+  // Verify that looking up a symbol by name preserves the symbol name and
+  // resolve address is empty.
+  {
+    swift::remote::RemoteAddress RelocAddr(
+        SymbolNamedRelocOffset + Slide1,
+        swift::remote::RemoteAddress::DefaultAddressSpace);
+    auto Resolved = Reader.getDynamicSymbol(RelocAddr);
+    ASSERT_TRUE(static_cast<bool>(Resolved));
+    EXPECT_EQ(Resolved.getSymbol(), "external");
+    EXPECT_FALSE(static_cast<bool>(Resolved.getResolvedAddress()));
+  }
+}
+
+} // namespace


### PR DESCRIPTION
The old static mirror metadata extraction mechanism used section headers to try and find the metadata sections. This is fine for MachO binaries, where section headers are guaranteed to be included in the loaded image. On ELF, this is not the case. As a workaround, the `Image::scanELF` machinery would attempt to add the entire file as its own segment.

```c++
// FIXME: ReflectionContext tries to read bits of the ELF structure that
// aren't normally mapped by a phdr. Until that's fixed,
// allow access to the whole file 1:1 in address space that isn't otherwise
// mapped.
Segments.push_back({HeaderAddress, O->getData()});
```

This worked when the virtual address and file offsets aligned, but with `lld` on FreeBSD, these were not always the same and so we would fail to find the metadata, even with the hack in place.

The new design uses a table, stored as a note, which is guaranteed to get its own segment. In executables, the executable will be the first thing loaded, so the addresses of the section start/stop symbols can be pre-computed and populated into that table, but with shared objects, they cannot, so `lld` leaves them empty and sets the appropriate relocation data for the loader. The object memory reader didn't used to apply the relocations, only track them, so I've taught it to apply the relocations and read from the relocated memory, setting up our table for static mirrors.

The table is nearly identical to the MetadataSections table that the runtime loads. The main difference is that the table contains the start/stop pointer rather than the start pointer and byte count. This is because the loader can apply the relocations and give us the symbol address for each start/stop pointer, but cannot do the subtraction necessary to give us the byte count without the additional constructor function.

For future work, we should be able to adjust the table that `swift_addNewDSOImage` consumes to take the start/stop pointers instead of the start pointer and the byte count. Many of the metadata registration functions already add the count to the start pointer to get the end pointer as it is, which means that we are creating the constructor function to do the subtraction to get the byte count, and then immediately turning around and inverting it to get the end pointer again. It should help reduce load times on ELF platforms if we could simply take the relocated table and pass that into the runtime registration function directly.

Re-enables: 
 - test/Reflection/typeref_decoding_imported.swift
 - test/Reflection/capture_descriptors.sil

Fixes: rdar://159139154