### PR TITLE
[6.3][Concurrency] Skip `Sendable` checking for `nonisolated(nonsending)` …

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2829,7 +2829,6 @@ namespace {
           case FunctionTypeIsolation::Kind::NonIsolated: {
             switch (fromIsolation.getKind()) {
             case FunctionTypeIsolation::Kind::Parameter:
-            case FunctionTypeIsolation::Kind::NonIsolatedNonsending:
             case FunctionTypeIsolation::Kind::Erased:
               diagnoseNonSendableParametersAndResult(
                   toFnType, version::Version::getFutureMajorLanguageVersion());
@@ -2841,13 +2840,13 @@ namespace {
               break;
             }
 
-            case FunctionTypeIsolation::Kind::NonIsolated: {
-              // nonisolated synchronous <-> @concurrent
-              if (fromFnType->isAsync() != toFnType->isAsync()) {
-                diagnoseNonSendableParametersAndResult(
-                    toFnType,
-                    version::Version::getFutureMajorLanguageVersion());
-              }
+            case FunctionTypeIsolation::Kind::NonIsolated:
+            case FunctionTypeIsolation::Kind::NonIsolatedNonsending: {
+              // Converting a `nonisolated(nonsending)` function type to a
+              // `@concurrent` one is the same as converting it to an
+              // actor-isolated function type. `nonisolated(nonsending)`
+              // functions run on the caller's actor without crossing an
+              // isolation boundary and so no Sendable checking is necessary.
               break;
             }
             }

--- a/test/Concurrency/attr_execution/conversions.swift
+++ b/test/Concurrency/attr_execution/conversions.swift
@@ -141,10 +141,9 @@ func testNonSendableDiagnostics(
   // expected-warning@-1 {{cannot convert '@isolated(any) @Sendable () async -> NonSendable' to '() async -> NonSendable' because crossing of an isolation boundary requires parameter and result types to conform to 'Sendable' protocol}}
 
 
-  let _: @concurrent (NonSendable) async -> Void = caller1 // expected-note {{type 'NonSendable' does not conform to 'Sendable' protocol}}
-  // expected-warning@-1 {{cannot convert 'nonisolated(nonsending) @Sendable (NonSendable) async -> Void' to '(NonSendable) async -> Void' because crossing of an isolation boundary requires parameter and result types to conform to 'Sendable' protocol}}
-  let _: @concurrent () async -> NonSendable = caller2 // expected-note {{type 'NonSendable' does not conform to 'Sendable' protocol}}
-  // expected-warning@-1 {{cannot convert 'nonisolated(nonsending) @Sendable () async -> NonSendable' to '() async -> NonSendable' because crossing of an isolation boundary requires parameter and result types to conform to 'Sendable' protocol}}
+  // Calling `nonisolated(nonsending)` from `@concurrent` doesn't cross an isolation boundary.
+  let _: @concurrent (NonSendable) async -> Void = caller1 // Ok
+  let _: @concurrent () async -> NonSendable = caller2 // Ok
 
   let _: @MainActor (NonSendable) async -> Void = nonIsolated1 // Ok
   let _: @MainActor (NonSendable) async -> Void = nonIsolated2 // expected-note {{type 'NonSendable' does not conform to 'Sendable' protocol}}


### PR DESCRIPTION
…-> `@concurrent` conversions

- Explanation:

  Converting a `nonisolated(nonsending)` function type to a `@concurrent` one is the same as converting it to an actor-isolated function type. `nonisolated(nonsending)` functions run on the caller's actor without crossing an isolation boundary and so no Sendable checking is necessary.

- Resolves: https://github.com/swiftlang/swift/issues/86203, https://github.com/swiftlang/swift/issues/87235, rdar://170380869

- Main branch PR: https://github.com/swiftlang/swift/pull/87270

- Risk: Very Low. The change removes extraneous Sendable checking for some conversion and lets them be accepted without warnings.

- Reviewed By: @ktoso @hborla  

- Testing: Added new test-cases to the suite.

(cherry picked from commit 5f9efd2fc1763a1fe03e1bd601654be7628a20df)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
