### PR TITLE
[6.3 🍒] Ensure we check for thrown error types when resolving custom derivatives

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -6371,6 +6371,14 @@ static bool checkFunctionSignature(
   if (!candidateGenSig.requirementsNotSatisfiedBy(requiredGenSig).empty())
     return false;
 
+  // Check that both functions throws same error type (if any)
+  if (required->isThrowing() != candidateFnTy->isThrowing())
+    return false;
+  if (required->hasThrownError() != candidateFnTy->hasThrownError() ||
+      (required->hasThrownError() &&
+       !required->getThrownError()->isEqual(candidateFnTy->getThrownError())))
+    return false;
+
   // Check that parameter types match, disregarding labels.
   if (required->getNumParams() != candidateFnTy->getNumParams())
     return false;

--- a/test/AutoDiff/compiler_crashers_fixed/issue-86998-incompatible-thrown-types.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/issue-86998-incompatible-thrown-types.swift
@@ -1,0 +1,39 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+// https://github.com/swiftlang/swift/issues/84365
+// Ensure we check thrown types when resolving custom derivatives
+import _Differentiation
+
+extension Array where Element: Differentiable {
+    // expected-note @+2 {{candidate instance method does not have type equal to or less constrained than '<Element, Result, E where Element : Differentiable, Result : Differentiable, E : Error> (Array<Element>) -> (@differentiable(reverse) (Element) throws(E) -> Result) throws -> [Result]'}}
+    @differentiable(reverse, wrt: self)
+    public func differentiableThrowingMap<Result: Differentiable, E: Error>(
+      _ body: @differentiable(reverse) (Element) throws(E) -> Result
+    ) throws(E) -> [Result] {
+        try map(body)
+    }
+
+  // expected-error @+1 {{referenced declaration 'differentiableThrowingMap' could not be resolved}}
+    @derivative(of: differentiableThrowingMap)
+    public func _vjpDifferentiableThrowingMap<Result: Differentiable, E: Error>(
+        _ body: @differentiable(reverse) (Element) throws(E) -> Result
+  ) throws -> ( // succeeds when turned into throws(E)
+        value: [Result],
+        pullback: (Array<Result>.TangentVector) -> Array.TangentVector
+    ) {
+        let count = self.count
+        var values: [Result] = []
+        var pullbacks: [(Result.TangentVector) -> Element.TangentVector] = []
+        values.reserveCapacity(count)
+        pullbacks.reserveCapacity(count)
+        for x in self {
+            let (y, pb) = try valueWithPullback(at: x, of: body)
+            values.append(y)
+            pullbacks.append(pb)
+        }
+        func pullback(_ tans: Array<Result>.TangentVector) -> Array.TangentVector {
+            .init(zip(tans.base, pullbacks).map { tan, pb in pb(tan) })
+        }
+        return (value: values, pullback: pullback)
+    }
+}


### PR DESCRIPTION
- **Explanation**:
This change adds additional checks in constraint resolution to ensure that when resolving custom derivatives, we verify that both the required function and the candidate derivative have matching thrown error types. Previously the thrown-error-type check was missing, which could cause incorrect resolutions or silent acceptance of invalid derivative definitions. A new compiler test case is also added to guard against regressions.

- **Scope**:
This affects type-checking, specifically in automatic differentiation pipelines. It is a correctness fix and should not break existing code, but invalid custom derivative definitions that previously compiled may now be diagnosed.

- **Issues**:
https://github.com/swiftlang/swift/issues/86998

- **Original PRs**:
https://github.com/swiftlang/swift/pull/86999

- **Risk**:
Low. The change tightens function signature checks for derivative resolution. It’s unlikely to affect most user code, but will catch ambiguous derivative definitions as compilation errors now.

- **Testing**:
A new regression test has been added to verify that incompatible thrown error types are correctly diagnosed. Standard Swift CI tests have passed on `main`.

- **Reviewers**:
Approved by @kovdan01
