### PR TITLE
SILGen: emit destroy_value if discarding error 

### DIFF
--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -1722,8 +1722,10 @@ void SILGenFunction::emitThrow(SILLocation loc, ManagedValue exnMV,
     // A direct error value is passed to the epilog block as a BB argument.
     args.push_back(exn);
   } else if (shouldDiscard) {
-    if (exn && exn->getType().isAddress())
+    if (exn->getType().isAddress())
       B.createDestroyAddr(loc, exn);
+    else
+      B.createDestroyValue(loc, exn);
   }
 
   // Emit clean-ups needed prior to entering throw block.

--- a/test/SILGen/typed_throws_generic.swift
+++ b/test/SILGen/typed_throws_generic.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types %s -enable-experimental-feature FullTypedThrows | %FileCheck %s
+// RUN: %target-swift-emit-silgen -swift-version 5 -Xllvm -sil-print-types %s -enable-experimental-feature FullTypedThrows | %FileCheck %s
 
 // REQUIRES: swift_feature_FullTypedThrows
 
@@ -419,4 +419,17 @@ func asyncThrowsLoadableGeneric<E>(_ b: Bool, _: E) async throws(LoadableGeneric
   if b {
     throw LoadableGenericError<E>()
   }
+}
+
+// CHECK-LABEL: sil {{.*}} @$sSci20typed_throws_genericE5first7ElementQzSgyYaF
+// CHECK:         try_apply {{.*}} error [[ERROR_BB:bb[0-9]+]]
+//
+// CHECK:         [[ERROR_BB]]([[ERROR:%.*]] : @owned $any Error):
+// CHECK:           destroy_value [[ERROR]] : $any Error
+extension AsyncSequence {
+    func first() async -> Element? {
+        try? await self.first { _ in
+            return true
+        }
+    }
 }


### PR DESCRIPTION
Fixes an emission issue with typed throws where the error path after a `try_apply` is missing a `destroy_value` on the unused basic block argument holding the error.

Forgetting to emit that makes the SIL verifier upset.

rdar://170353819
