### PR TITLE
Android: Use CMAKE_SYSROOT for Android sysroot

### DIFF
--- a/Runtimes/Overlay/Android/clang/CMakeLists.txt
+++ b/Runtimes/Overlay/Android/clang/CMakeLists.txt
@@ -1,5 +1,3 @@
-
-# FIXME: how do we determine the sysroot? `CMAKE_SYSROOT` does not contain the sysroot.
 file(CONFIGURE
   OUTPUT android-ndk-overlay.yaml
   CONTENT [[
@@ -8,7 +6,7 @@ version: 0
 case-sensitive: false
 use-external-names: true
 roots:
-  - name: "@CMAKE_ANDROID_NDK@/toolchains/llvm/prebuilt/windows-x86_64/sysroot/usr/include"
+  - name: "@CMAKE_SYSROOT@/usr/include"
     type: directory
     contents:
       - name: module.modulemap
@@ -25,7 +23,7 @@ ESCAPE_QUOTES @ONLY NEWLINE_STYLE LF)
 
 add_library(SwiftAndroid INTERFACE)
 target_compile_options(SwiftAndroid INTERFACE
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc --sysroot=\"${CMAKE_ANDROID_NDK_TOOLCHAIN_UNIFIED}/sysroot\">"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc --sysroot=\"${CMAKE_SYSROOT}\">"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-vfsoverlay ${CMAKE_CURRENT_BINARY_DIR}/android-ndk-overlay.yaml>")
 
 install(TARGETS SwiftAndroid

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1747,6 +1747,7 @@ function Build-CMakeProject {
         Add-KeyValueIfNew $Defines CMAKE_ANDROID_API "$AndroidAPILevel"
         Add-KeyValueIfNew $Defines CMAKE_ANDROID_ARCH_ABI $Platform.Architecture.ABI
         Add-KeyValueIfNew $Defines CMAKE_ANDROID_NDK "$AndroidNDKPath"
+        Add-KeyValueIfNew $Defines CMAKE_SYSROOT "$AndroidSysroot"
 
         if ($UseASM) {
         }
@@ -1754,7 +1755,7 @@ function Build-CMakeProject {
         if ($UseC) {
           Add-KeyValueIfNew $Defines CMAKE_C_COMPILER_TARGET $Platform.Triple
 
-          $CFLAGS = @("--sysroot=${AndroidSysroot}", "-ffunction-sections", "-fdata-sections")
+          $CFLAGS = @("-ffunction-sections", "-fdata-sections")
           if ($DebugInfo) {
             $CFLAGS += @("-gdwarf")
           }
@@ -1764,7 +1765,7 @@ function Build-CMakeProject {
         if ($UseCXX) {
           Add-KeyValueIfNew $Defines CMAKE_CXX_COMPILER_TARGET $Platform.Triple
 
-          $CXXFLAGS = @("--sysroot=${AndroidSysroot}", "-ffunction-sections", "-fdata-sections")
+          $CXXFLAGS = @("-ffunction-sections", "-fdata-sections")
           if ($DebugInfo) {
             $CXXFLAGS += @("-gdwarf")
           }
@@ -1790,6 +1791,8 @@ function Build-CMakeProject {
           [string[]] $SwiftFlags = @()
 
           $SwiftFlags += if ($SwiftSDK) {
+            # TODO: CMake does not yet have support for passing `CMAKE_SYSROOT` to the Swift compiler yet.
+            #       Once we have that, we can drop `-sysroot $AndroidSysroot` here.
             @("-sdk", $SwiftSDK, "-sysroot", $AndroidSysroot)
           } else {
             @()


### PR DESCRIPTION
The NDK configures `CMAKE_SYSROOT` in `android-legacy.toolchain.cmake`. I've verified this from Android NDK r26b to r29.

This gets the build system cross-compiling to Android from a non-Windows builder.