### PR TITLE
Sema: Add two test cases for type checking performance regressions in 6.3

### DIFF
--- a/validation-test/Sema/type_checker_perf/slow/custom_logical_operators.swift
+++ b/validation-test/Sema/type_checker_perf/slow/custom_logical_operators.swift
@@ -1,0 +1,33 @@
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
+// REQUIRES: tools-release,no_asan
+// REQUIRES: objc_interop
+
+// https://forums.swift.org/t/typechecker-performance-is-way-worse-in-6-3/84779
+
+import Combine
+
+enum E {
+  case active
+}
+
+public struct AndPredicate<T> {}
+public struct OrPredicate<T> {}
+
+public func && <Predicate> (_ lhs: Predicate, _ rhs: Predicate) -> AndPredicate<Predicate> {
+  fatalError()
+}
+
+public func || <Predicate> (_ lhs: Predicate, _ rhs: Predicate) -> OrPredicate<Predicate> {
+  fatalError()
+}
+
+func f<T: Publisher, U: Publisher, V: Publisher>(_ sendingAction: T, _ conversationState: U, _ shouldDisableUserInput: V)
+  where T.Failure == U.Failure, U.Failure == V.Failure, T.Output == Bool, U.Output == E, V.Output == Bool {
+  // expected-error@+1 {{reasonable time}}
+  let _ = Publishers.CombineLatest3(sendingAction, conversationState, shouldDisableUserInput)
+    .map { sendingAction, state, disableInput in
+      sendingAction == false && state == .active && disableInput == false
+    }
+    .removeDuplicates()
+    .eraseToAnyPublisher()
+}

--- a/validation-test/Sema/type_checker_perf/slow/leading_dot_delay.swift
+++ b/validation-test/Sema/type_checker_perf/slow/leading_dot_delay.swift
@@ -1,0 +1,30 @@
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=100
+
+// https://forums.swift.org/t/typechecker-performance-is-way-worse-in-6-3/84779
+
+class NSColor: Equatable {
+  init(red: Double, green: Double, blue: Double, alpha: Double) {}
+
+  static func ==(_: NSColor, _: NSColor) -> Bool { return false }
+}
+
+var backgroundColor: NSColor
+var optBackgroundColor: NSColor?
+
+func XCTAssertEqual<T: Equatable>(_: T, _: T) {}
+
+func test() {
+  XCTAssertEqual(backgroundColor, .init(red: 244.0 / 255.0, green: 218.0 / 255.0, blue: 129.0 / 255.0, alpha: 1.0))
+  XCTAssertEqual(backgroundColor, .init(red: 244 / 255.0, green: 218 / 255.0, blue: 129 / 255.0, alpha: 1.0))  // expected-error {{reasonable time}}
+  XCTAssertEqual(backgroundColor, NSColor(red: 244.0 / 255.0, green: 218.0 / 255.0, blue: 129.0 / 255.0, alpha: 1.0))
+  XCTAssertEqual(backgroundColor, NSColor(red: 244 / 255.0, green: 218 / 255.0, blue: 129 / 255.0, alpha: 1.0))
+  XCTAssertEqual(backgroundColor, NSColor.init(red: 244.0 / 255.0, green: 218.0 / 255.0, blue: 129.0 / 255.0, alpha: 1.0))
+  XCTAssertEqual(backgroundColor, NSColor.init(red: 244 / 255.0, green: 218 / 255.0, blue: 129 / 255.0, alpha: 1.0))
+
+  XCTAssertEqual(optBackgroundColor, .init(red: 244.0 / 255.0, green: 218.0 / 255.0, blue: 129.0 / 255.0, alpha: 1.0))
+  XCTAssertEqual(optBackgroundColor, .init(red: 244 / 255.0, green: 218 / 255.0, blue: 129 / 255.0, alpha: 1.0))  // expected-error {{reasonable time}}
+  XCTAssertEqual(optBackgroundColor, NSColor(red: 244.0 / 255.0, green: 218.0 / 255.0, blue: 129.0 / 255.0, alpha: 1.0))
+  XCTAssertEqual(optBackgroundColor, NSColor(red: 244 / 255.0, green: 218 / 255.0, blue: 129 / 255.0, alpha: 1.0))
+  XCTAssertEqual(optBackgroundColor, NSColor.init(red: 244.0 / 255.0, green: 218.0 / 255.0, blue: 129.0 / 255.0, alpha: 1.0))
+  XCTAssertEqual(optBackgroundColor, NSColor.init(red: 244 / 255.0, green: 218 / 255.0, blue: 129 / 255.0, alpha: 1.0))
+}


### PR DESCRIPTION
https://github.com/swiftlang/swift/pull/87159 will address `custom_logical_operators.swift`.