### PR TITLE
[Concurrency] Don't infer `@MainActor` by default on typealiases and …

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -27,6 +27,7 @@
 #include "swift/AST/Attr.h"
 #include "swift/AST/Concurrency.h"
 #include "swift/AST/ConformanceLookup.h"
+#include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticGroups.h"
 #include "swift/AST/DistributedDecl.h"
 #include "swift/AST/ExistentialLayout.h"
@@ -6159,6 +6160,16 @@ computeDefaultInferredActorIsolation(ValueDecl *value) {
         if (!contextIsolation.isMainActor())
           return {};
       }
+
+      // Global variables cannot be global actor isolated.
+      if (auto *var = dyn_cast<VarDecl>(value)) {
+        if (var->isTopLevelGlobal())
+          return {};
+      }
+
+      // typealiases cannot infer `@MainActor` regardless where they appear.
+      if (isa<TypeAliasDecl>(value))
+        return {};
 
       // Members and nested types must check the isolation of the enclosing
       // nominal type.

--- a/test/Concurrency/default_isolation_MainActor_cross_module.swift
+++ b/test/Concurrency/default_isolation_MainActor_cross_module.swift
@@ -23,6 +23,9 @@
 
 //--- A.swift
 
+// CHECK-NOT: @_Concurrency.MainActor @preconcurrency public var x: Swift.Int
+public var x: Int = 42
+
 // CHECK: @_Concurrency.MainActor @preconcurrency public protocol P
 public protocol P {
 }
@@ -33,6 +36,20 @@ nonisolated public protocol Q: Sendable {
 
 // CHECK: @_Concurrency.MainActor @preconcurrency public struct S : A.P {
 public struct S: P {
+  // CHECK: @_Concurrency.MainActor @preconcurrency public enum E : Swift.String {
+  // CHECK:   case a
+  // CHECK:   case b
+  // CHECK:   nonisolated public init?(rawValue: Swift.String)
+  // CHECK:   public typealias RawValue = Swift.String
+  // CHECK:   nonisolated public var rawValue: Swift.String {
+  // CHECK:     get
+  // CHECK:   }
+  // CHECK: }
+  public enum E: String {
+    case a
+    case b
+  }
+
   // CHECK:   @_Concurrency.MainActor @preconcurrency public func f()
   public func f() {}
 
@@ -82,6 +99,18 @@ open class IsolatedDeinitTest {
 }
 // CHECK: }
 
+// CHECK: @_Concurrency.MainActor @preconcurrency public struct TestAccessors {
+public struct TestAccessors {
+  // CHECK: @_Concurrency.MainActor @preconcurrency public var test: Swift.Int {
+  // CHECK:   get
+  // CHECK:   set
+  // CHECK: }
+  public var test: Int {
+    get { 42 }
+    set { }
+  }
+}
+// CHECK: }
 
 //--- Client.swift
 import A


### PR DESCRIPTION
…global properties

Global actor attribute cannot appear on these declarations and SE-0466 explicitly prohibits such inference as well.

I also added tests for accessors and enum cases mentioned in the proposal to make sure that they don't get `@MainActor` inferred.

Resolves: rdar://170564335

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
