### PR TITLE
[Caching] Support -debug-module-path type of debug info

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -97,6 +97,8 @@ WARNING(warning_option_requires_specific_sanitizer, none,
 
 ERROR(error_option_missing_required_argument, none,
       "option '%0' is missing a required argument (%1)", (StringRef, StringRef))
+ERROR(error_option_missing_required_output_kind, none,
+      "option '%0' is missing required '%1' output", (StringRef, StringRef))
 
 ERROR(cannot_open_file,none,
       "cannot open file '%0' (%1)", (StringRef, StringRef))

--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -278,8 +278,11 @@ class IRGenOptions {
 public:
   std::string ModuleName;
 
-  /// The path to the main binary swiftmodule for the debug info.
+  /// The path/cache key to the main binary swiftmodule for the debug info.
   std::string DebugModulePath;
+
+  /// Use self key as swift module cacke key
+  bool DebugModuleSelfKey = false;
 
   /// The compilation directory for the debug info.
   std::string DebugCompilationDir;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -654,10 +654,13 @@ def module_name_EQ : Joined<["-"], "module-name=">, Flags<[FrontendOption]>,
   Alias<module_name>;
 
 def debug_module_path : Separate<["-"], "debug-module-path">,
-  Flags<[FrontendOption]>,
-  HelpText<"Path to this module's binary swiftmodule artifact (required by debug info)">;
-def debug_module_path_EQ : Joined<["-"], "debug-module-path=">, Flags<[FrontendOption]>,
+  Flags<[FrontendOption, ArgumentIsPath]>,
+  HelpText<"Path or cache key to this module's binary swiftmodule artifact (required by debug info)">;
+def debug_module_path_EQ : Joined<["-"], "debug-module-path=">, Flags<[FrontendOption, ArgumentIsPath]>,
   Alias<debug_module_path>;
+def debug_module_self_key : Flag<["-"], "debug-module-self-key">,
+  Flags<[FrontendOption]>,
+  HelpText<"Embeded the key of current job in debug info generation (required by debug info)">;
 
 def module_alias : Separate<["-"], "module-alias">,
   Flags<[FrontendOption, ModuleInterfaceOption]>,

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -38,6 +38,9 @@ namespace llvm {
   class Module;
   class TargetOptions;
   class TargetMachine;
+  namespace cas {
+    class ObjectRef;
+  }
   namespace vfs {
     class OutputBackend;
   }
@@ -261,7 +264,8 @@ namespace swift {
                       ArrayRef<std::string> parallelOutputFilenames,
                       ArrayRef<std::string> parallelIROutputFilenames,
                       llvm::GlobalVariable **outModuleHash = nullptr,
-                      cas::SwiftCASOutputBackend *casBackend = nullptr);
+                      cas::SwiftCASOutputBackend *casBackend = nullptr,
+                      std::optional<llvm::cas::ObjectRef> cacheKeyForJob = std::nullopt);
 
   /// Turn the given Swift file into LLVM IR and return the generated module.
   /// To compile and output the generated code, call \c performLLVM.
@@ -273,7 +277,8 @@ namespace swift {
                       std::shared_ptr<llvm::cas::ObjectStore> CAS,
                       StringRef PrivateDiscriminator,
                       llvm::GlobalVariable **outModuleHash = nullptr,
-                      cas::SwiftCASOutputBackend *casBackend = nullptr);
+                      cas::SwiftCASOutputBackend *casBackend = nullptr,
+                      std::optional<llvm::cas::ObjectRef> cacheKeyForJob = std::nullopt);
 
   /// Given an already created LLVM module, construct a pass pipeline and run
   /// the Swift LLVM Pipeline upon it. This will include the emission of LLVM IR

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3619,9 +3619,22 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
                      A->getAsString(Args), A->getValue());
   }
 
-  if (const Arg *A = Args.getLastArg(options::OPT_debug_module_path))
-    Opts.DebugModulePath = A->getValue();
-  
+  if (auto *A =
+          Args.getLastArg(OPT_debug_module_path, OPT_debug_module_self_key)) {
+    if (A->getOption().matches(OPT_debug_module_self_key)) {
+      if (!FrontendOpts.InputsAndOutputs.hasModuleOutputPath())
+        Diags.diagnose(SourceLoc(),
+                       diag::error_option_missing_required_output_kind,
+                       A->getAsString(Args), "swiftmodule");
+      if (!Args.hasArg(OPT_cache_compile_job))
+        Diags.diagnose(SourceLoc(),
+                       diag::error_option_missing_required_argument,
+                       A->getAsString(Args), "-cache-compile-job");
+      Opts.DebugModuleSelfKey = true;
+    } else
+      Opts.DebugModulePath = A->getValue();
+  }
+
   for (auto A : Args.getAllArgValues(options::OPT_file_prefix_map)) {
     auto SplitMap = StringRef(A).split('=');
     Opts.FilePrefixMap.addMapping(SplitMap.first, SplitMap.second);

--- a/lib/IRGen/IRGenDebugInfo.h
+++ b/lib/IRGen/IRGenDebugInfo.h
@@ -65,7 +65,8 @@ public:
   createIRGenDebugInfo(const IRGenOptions &Opts, ClangImporter &CI,
                        IRGenModule &IGM, llvm::Module &M,
                        StringRef MainOutputFilenameForDebugInfo,
-                       StringRef PrivateDiscriminator);
+                       StringRef PrivateDiscriminator,
+                       StringRef CacheKeyForJob);
   virtual ~IRGenDebugInfo();
 
   /// Finalize the llvm::DIBuilder owned by this object.

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -716,6 +716,7 @@ public:
   llvm::StringMap<ModuleDecl*> OriginalModules;
   llvm::SmallString<128> OutputFilename;
   llvm::SmallString<128> MainInputFilenameForDebugInfo;
+  llvm::SmallString<128> CacheKeyForJob;
 
   /// Order dependency -- TargetInfo must be initialized after Opts.
   const SwiftTargetInfo TargetInfo;
@@ -1643,13 +1644,14 @@ public:
               SourceFile *SF,
               StringRef ModuleName, StringRef OutputFilename,
               StringRef MainInputFilenameForDebugInfo,
-              StringRef PrivateDiscriminator);
+              StringRef PrivateDiscriminator,
+              StringRef CacheKeyForJob);
 
   /// The constructor used when we just need an IRGenModule for type lowering.
   IRGenModule(IRGenerator &irgen, std::unique_ptr<llvm::TargetMachine> &&target)
     : IRGenModule(irgen, std::move(target), /*SF=*/nullptr,
                   "<fake module name>", "<fake output filename>",
-                  "<fake main input filename>", "") {}
+                  "<fake main input filename>", "", "") {}
 
   ~IRGenModule();
 

--- a/test/CAS/debug_module_path.swift
+++ b/test/CAS/debug_module_path.swift
@@ -1,0 +1,44 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   %s -o %t/deps.json -cache-compile-job -cas-path %t/cas
+
+// RUN: %{python} %S/../../utils/swift-build-modules.py --cas %t/cas %swift_frontend_plain %t/deps.json -o %t/Test.cmd
+
+/// Check embedding CASID.
+// RUN: %target-swift-frontend-plain -O \
+// RUN:   -emit-ir -g -cache-compile-job -cas-path %t/cas \
+// RUN:   -swift-version 5 -disable-implicit-swift-modules \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   -primary-file %s @%t/Test.cmd -module-name Test -debug-module-path llvmcas://casid -o - | %FileCheck %s --check-prefix FAKEID
+
+// FAKEID: !DIModule(scope: null, name: "Test", includePath: "llvmcas://casid")
+
+/// Check embedding self key requires swiftmodule output.
+// RUN: not %target-swift-frontend-plain -O \
+// RUN:   -emit-ir -g -cache-compile-job -cas-path %t/cas \
+// RUN:   -swift-version 5 -disable-implicit-swift-modules \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   -primary-file %s @%t/Test.cmd -module-name Test -debug-module-self-key -o - 2>&1 | %FileCheck %s --check-prefix ERROR
+
+// ERROR: error: option '-debug-module-self-key' is missing required 'swiftmodule' output
+
+/// Check embedding self key matches by appending the key to the end of .ll output and make sure the debug info CASID matches the cache key.
+// RUN: %target-swift-frontend-plain -O -emit-module-path %t/Test.swiftmodule \
+// RUN:   -emit-ir -g -cache-compile-job -cas-path %t/cas \
+// RUN:   -swift-version 5 -disable-implicit-swift-modules \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   %s @%t/Test.cmd -module-name Test -debug-module-self-key -o %t/test.ll
+
+// RUN: %swift-scan-test -action compute_cache_key_from_index -cas-path %t/cas -input 0 -- \
+// RUN: %target-swift-frontend-plain -O -emit-module-path %t/Test.swiftmodule \
+// RUN:   -emit-ir -g -cache-compile-job -cas-path %t/cas \
+// RUN:   -swift-version 5 -disable-implicit-swift-modules \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   %s @%t/Test.cmd -module-name Test -debug-module-self-key -o %t/test.ll >> %t/test.ll
+
+// RUN: %FileCheck --input-file %t/test.ll --check-prefix CASID %s
+
+// CASID: !DIModule(scope: null, name: "Test", includePath: "llvmcas://[[CASID:.*]]")
+// CASID: llvmcas://[[CASID]]


### PR DESCRIPTION
Add flag `-debug-module-cache-key` and flag `-debug-module-self-key` to support embedded swift module output in the debug info via CASID.

rdar://169110002

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
