### PR TITLE
Ignore generic context when module selector used

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -193,16 +193,16 @@ protected:
     LiteralCapacity : 32
   );
 
-  SWIFT_INLINE_BITFIELD(DeclRefExpr, Expr, 2+3+1+1,
+  SWIFT_INLINE_BITFIELD(DeclRefExpr, Expr, 2+4+1+1,
     Semantics : 2, // an AccessSemantics
-    FunctionRefInfo : 3,
+    FunctionRefInfo : 4,
     IsImplicitlyAsync : 1,
     IsImplicitlyThrows : 1
   );
 
-  SWIFT_INLINE_BITFIELD(UnresolvedDeclRefExpr, Expr, 2+3,
+  SWIFT_INLINE_BITFIELD(UnresolvedDeclRefExpr, Expr, 2+4,
     DeclRefKind : 2,
-    FunctionRefInfo : 3
+    FunctionRefInfo : 4
   );
 
   SWIFT_INLINE_BITFIELD(MemberRefExpr, LookupExpr, 2,
@@ -225,8 +225,8 @@ protected:
     NumElements : 32
   );
 
-  SWIFT_INLINE_BITFIELD(UnresolvedDotExpr, Expr, 3,
-    FunctionRefInfo : 3
+  SWIFT_INLINE_BITFIELD(UnresolvedDotExpr, Expr, 4,
+    FunctionRefInfo : 4
   );
 
   SWIFT_INLINE_BITFIELD_FULL(SubscriptExpr, LookupExpr, 2,
@@ -235,12 +235,12 @@ protected:
 
   SWIFT_INLINE_BITFIELD_EMPTY(DynamicSubscriptExpr, DynamicLookupExpr);
 
-  SWIFT_INLINE_BITFIELD_FULL(UnresolvedMemberExpr, Expr, 3,
-    FunctionRefInfo : 3
+  SWIFT_INLINE_BITFIELD_FULL(UnresolvedMemberExpr, Expr, 4,
+    FunctionRefInfo : 4
   );
 
-  SWIFT_INLINE_BITFIELD(OverloadSetRefExpr, Expr, 3,
-    FunctionRefInfo : 3
+  SWIFT_INLINE_BITFIELD(OverloadSetRefExpr, Expr, 4,
+    FunctionRefInfo : 4
   );
 
   SWIFT_INLINE_BITFIELD(BooleanLiteralExpr, LiteralExpr, 1,

--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -384,7 +384,7 @@ class Constraint final : public llvm::ilist_node<Constraint>,
   unsigned IsIsolated : 1;
 
   /// The kind of function reference, for member references.
-  unsigned TheFunctionRefInfo : 3;
+  unsigned TheFunctionRefInfo : 4;
 
   /// The trailing closure matching for an applicable function constraint,
   /// if any. 0 = None, 1 = Forward, 2 = Backward.

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3520,6 +3520,7 @@ public:
       printRecArbitrary([&](Label label) {
         printHead("function_ref_info", ExprModifierColor, label);
         printFlag(info.isCompoundName(), "is_compound_name");
+        printFlag(info.hasModuleSelector(), "has_module_selector");
         printField(info.getApplyLevel(), Label::always("apply_level"));
         printFoot();
       }, label);

--- a/lib/AST/FunctionRefInfo.cpp
+++ b/lib/AST/FunctionRefInfo.cpp
@@ -22,11 +22,13 @@
 using namespace swift;
 
 FunctionRefInfo FunctionRefInfo::unapplied(DeclNameLoc nameLoc) {
-  return FunctionRefInfo(ApplyLevel::Unapplied, nameLoc.isCompound());
+  return FunctionRefInfo(ApplyLevel::Unapplied, nameLoc.isCompound(),
+                         nameLoc.getModuleSelectorLoc().isValid());
 }
 
 FunctionRefInfo FunctionRefInfo::unapplied(DeclNameRef nameRef) {
-  return FunctionRefInfo(ApplyLevel::Unapplied, nameRef.isCompoundName());
+  return FunctionRefInfo(ApplyLevel::Unapplied, nameRef.isCompoundName(),
+                         nameRef.hasModuleSelector());
 }
 
 FunctionRefInfo FunctionRefInfo::addingApplicationLevel() const {
@@ -39,7 +41,7 @@ FunctionRefInfo FunctionRefInfo::addingApplicationLevel() const {
       return ApplyLevel::DoubleApply;
     }
   };
-  return FunctionRefInfo(withApply(), isCompoundName());
+  return FunctionRefInfo(withApply(), isCompoundName(), hasModuleSelector());
 }
 
 void FunctionRefInfo::dump(raw_ostream &os) const {
@@ -54,8 +56,16 @@ void FunctionRefInfo::dump(raw_ostream &os) const {
     os << "double apply";
     break;
   }
-  if (isCompoundName())
-    os << " (compound)";
+  if (isCompoundName() || hasModuleSelector()) {
+    os << " (";
+    if (isCompoundName())
+      os << "compound";
+    if (isCompoundName() && hasModuleSelector())
+      os << ", ";
+    if (hasModuleSelector())
+      os << "module selector";
+    os << ")";
+  }
 }
 
 void FunctionRefInfo::dump() const {

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -4476,8 +4476,8 @@ bool MissingMemberFailure::diagnoseAsError() {
       auto result = cs.performMemberLookup(
           ConstraintKind::ValueMember,
           getName().withoutArgumentLabels(getASTContext()), metatypeTy,
-          FunctionRefInfo::doubleBaseNameApply(), getLocator(),
-          /*includeInaccessibleMembers=*/true);
+          FunctionRefInfo::doubleBaseNameApply(getName().hasModuleSelector()),
+          getLocator(), /*includeInaccessibleMembers=*/true);
 
       // If there are no `init` members at all produce a tailored
       // diagnostic for that, otherwise fallback to generic

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2451,7 +2451,8 @@ namespace {
         // so we need to set a non-compound reference to make sure that e.g.
         // `case test(x: Int, y: Int)` gets the labels preserved when matched
         // with `case let .test(tuple)`.
-        auto functionRefInfo = FunctionRefInfo::unappliedBaseName();
+        auto functionRefInfo = FunctionRefInfo::unappliedBaseName(
+                                    enumPattern->getName().hasModuleSelector());
         if (enumPattern->hasSubPattern())
           functionRefInfo = functionRefInfo.addingApplicationLevel();
 
@@ -2461,7 +2462,8 @@ namespace {
         // arguments (tuple-to-tuple conversion).
         // FIXME: We ought to be preserving labels and matching in the solver.
         if (dyn_cast_or_null<TuplePattern>(enumPattern->getSubPattern()))
-          functionRefInfo = FunctionRefInfo::singleCompoundNameApply();
+          functionRefInfo = FunctionRefInfo::singleCompoundNameApply(
+                                    enumPattern->getName().hasModuleSelector());
 
         auto patternLocator =
             locator.withPathElement(LocatorPathElt::PatternMatch(pattern));
@@ -3571,7 +3573,8 @@ namespace {
       // Look up the macros with this name.
       auto moduleIdent = expr->getModuleName().getBaseName();
       auto macroIdent = expr->getMacroName().withoutArgumentLabels(ctx);
-      FunctionRefInfo functionRefInfo = FunctionRefInfo::singleBaseNameApply();
+      FunctionRefInfo functionRefInfo =
+          FunctionRefInfo::singleBaseNameApply(macroIdent.hasModuleSelector());
       auto macros = lookupMacros(moduleIdent, macroIdent, functionRefInfo,
                                  expr->getMacroRoles());
       if (macros.empty()) {
@@ -3579,7 +3582,8 @@ namespace {
         if (macroIdent.hasModuleSelector()) {
           auto anyMacroIdent = DeclNameRef(macroIdent.getFullName());
           ModuleSelectorCorrection correction(
-            lookupMacros(moduleIdent, anyMacroIdent, functionRefInfo,
+            lookupMacros(moduleIdent, anyMacroIdent,
+                         FunctionRefInfo::singleBaseNameApply(),
                          expr->getMacroRoles()));
           if (correction.diagnose(ctx, expr->getMacroNameLoc(), macroIdent))
             return Type();

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -87,6 +87,9 @@ enum class TypeResolutionFlags : uint16_t {
 
   /// Whether the immediate context has an @escaping attribute.
   DirectEscaping = 1 << 14,
+
+  /// Whether the name being resolved has a module selector or not.
+  HasModuleSelector = 1 << 15,
 };
 
 /// Type resolution contexts that require special handling.

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -1166,9 +1166,11 @@ ConstraintSystem::getTypeOfReferencePre(OverloadChoice choice,
   // Unqualified reference to a type.
   if (auto typeDecl = dyn_cast<TypeDecl>(value)) {
     // Resolve the reference to this type declaration in our current context.
+    TypeResolutionOptions opts = TypeResolverContext::InExpression;
+    if (choice.getFunctionRefInfo().hasModuleSelector())
+      opts |= TypeResolutionFlags::HasModuleSelector;
     auto type =
-        TypeResolution::forInterface(useDC, TypeResolverContext::InExpression,
-                                     /*unboundTyOpener*/ nullptr,
+        TypeResolution::forInterface(useDC, opts, /*unboundTyOpener*/ nullptr,
                                      /*placeholderHandler*/ nullptr,
                                      /*packElementOpener*/ nullptr)
             .resolveTypeInContext(typeDecl, /*foundDC*/ nullptr,

--- a/test/decl/typealias/generic.swift
+++ b/test/decl/typealias/generic.swift
@@ -481,3 +481,20 @@ struct TestNestedRequirementInference<T> {
     foo((x, s)) // expected-error {{instance method 'foo' requires the types 'T' and 'S.A' (aka 'Float') be equivalent}}
   }
 }
+
+//
+// Nested self-referential generic typealiases
+// (similar to a pattern used for `Task.Handle` backwards compatibility)
+//
+
+extension X where T == Never, U == Never {
+  typealias SelfRef1 = X
+  typealias SelfRef2 = generic.X
+  typealias SelfRef3 = generic::X
+}
+
+func testSelfRefs(
+  _: X.SelfRef1<Int, Int>, // expected-error {{cannot specialize non-generic type 'X<Never, Never>'}}
+  _: X.SelfRef2<Int, Int>, // no-error
+  _: X.SelfRef3<Int, Int> // no-error
+) {}


### PR DESCRIPTION
Normally, an unbound reference to a generic type within its own context is automatically bound to the identity generic arguments:

```swift
struct G<T> {
    typealias TA = G    // as if you wrote G<T>
}
```

Module selectors normally disable this kind of contextual behavior; make sure that this is not an exception.

To pipe the information needed to do this through the constraint solver, we extend FunctionRefInfo to remember whether a module selector was used.

Fixes an intermittent failure in `Sanitizers/tsan/basic_future.swift` encountered while testing #87132.