### PR TITLE
[sil] Add support for ApplySite::getCalleeDeclRef.

### DIFF
--- a/include/swift/SIL/ApplySite.h
+++ b/include/swift/SIL/ApplySite.h
@@ -170,6 +170,12 @@ public:
     FOREACH_IMPL_RETURN(getCalleeFunction());
   }
 
+  /// Gets the referenced function by looking through partial apply,
+  /// convert_function, and thin to thick function until we find a function_ref.
+  SILDeclRef getCalleeDeclRef() const {
+    FOREACH_IMPL_RETURN(getCalleeDeclRef());
+  }
+
   bool isCalleeDynamicallyReplaceable() const {
     FOREACH_IMPL_RETURN(isCalleeDynamicallyReplaceable());
   }

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -2802,6 +2802,18 @@ public:
   /// issues. It is at the bottom of the file.
   SILFunction *getCalleeFunction() const;
 
+  /// Returns the SILDeclRef for a referenced function after looking through
+  /// partial_apply, convert_function, and thin_to_thick_function.
+  ///
+  /// If we do not find something that we know how to handle, we return an empty
+  /// SILDeclRef.
+  ///
+  /// This is based off of getCalleeOrigin.
+  ///
+  /// This is defined out of line to work around incomplete definition
+  /// issues. It is next to getCalleeFunction at the bottom of the file.
+  SILDeclRef getCalleeDeclRef() const;
+
   bool isCalleeDynamicallyReplaceable() const;
 
   /// Gets the referenced function if the callee is a function_ref instruction.

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -2179,6 +2179,31 @@ SILModule &SILInstructionContext::getModule() {
   return storage.get<SILFunction *>()->getModule();
 }
 
+template <class Impl, class Base>
+SILDeclRef ApplyInstBase<Impl, Base, false>::getCalleeDeclRef() const {
+  SILValue origin = getCalleeOrigin();
+  if (!origin)
+    return {};
+
+  if (auto *fri = dyn_cast<FunctionRefInst>(origin))
+    return fri->getReferencedFunction()->getDeclRef();
+
+  if (auto *m = dyn_cast<MethodInst>(origin))
+    return m->getMember();
+
+  return {};
+}
+
+template SILDeclRef
+ApplyInstBase<ApplyInst, SingleValueInstruction, false>::getCalleeDeclRef()
+    const;
+template SILDeclRef ApplyInstBase<PartialApplyInst, SingleValueInstruction,
+                                  false>::getCalleeDeclRef() const;
+template SILDeclRef ApplyInstBase<BeginApplyInst, MultipleValueInstruction,
+                                  false>::getCalleeDeclRef() const;
+template SILDeclRef
+ApplyInstBase<TryApplyInst, TryApplyInstBase, false>::getCalleeDeclRef() const;
+
 #ifndef NDEBUG
 
 //---


### PR DESCRIPTION
This can be used to get the SILDeclRef for all of the various apply site kinds. It is a composition of getCalleeOrigin + special code for handling FunctionRefs and MethodInst. It essentially lets one abstract over the function ref/method inst code.
