### PR TITLE
embedded: fix a wrong "deinit of non-copyable type not visible in the current module" error

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
@@ -161,29 +161,15 @@ private func optimize(function: Function, _ context: FunctionPassContext, _ modu
           worklist.addWitnessMethods(of: conformance, moduleContext)
 
         default:
-          if !devirtualizeDeinits(of: bi, isMandatory: true, simplifyCtxt) {
-            // If invoked from SourceKit avoid reporting false positives when WMO is turned off for indexing purposes.
-            if moduleContext.enableWMORequiredDiagnostics {
-              context.diagnosticEngine.diagnose(.deinit_not_visible, at: bi.location)
-            }
-          }
+          _ = devirtualizeDeinits(of: bi, isMandatory: true, simplifyCtxt)
         }
 
       // We need to de-virtualize deinits of non-copyable types to be able to specialize the deinitializers.
       case let destroyValue as DestroyValueInst:
-        if !devirtualizeDeinits(of: destroyValue, isMandatory: true, simplifyCtxt) {
-          // If invoked from SourceKit avoid reporting false positives when WMO is turned off for indexing purposes.
-          if moduleContext.enableWMORequiredDiagnostics {
-            context.diagnosticEngine.diagnose(.deinit_not_visible, at: destroyValue.location)
-          }
-        }
+        _ = devirtualizeDeinits(of: destroyValue, isMandatory: true, simplifyCtxt)
+
       case let destroyAddr as DestroyAddrInst:
-        if !devirtualizeDeinits(of: destroyAddr, isMandatory: true, simplifyCtxt) {
-          // If invoked from SourceKit avoid reporting false positives when WMO is turned off for indexing purposes.
-          if moduleContext.enableWMORequiredDiagnostics {
-            context.diagnosticEngine.diagnose(.deinit_not_visible, at: destroyAddr.location)
-          }
-        }
+        _ = devirtualizeDeinits(of: destroyAddr, isMandatory: true, simplifyCtxt)
 
       case let iem as InitExistentialMetatypeInst:
         if iem.uses.ignoreDebugUses.isEmpty {

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -1232,7 +1232,7 @@ ERROR(executor_factory_must_conform, none,
 
 // TODO: print the name of the nominal type
 ERROR(deinit_not_visible, none,
-      "deinit of non-copyable type not visible in the current module", ())
+      "deinit of non-copyable type %0 not visible in the current module", (Type))
 
 ERROR(lifetime_variable_outside_scope, none,
       "lifetime-dependent variable '%0' escapes its scope", (Identifier))

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -3341,12 +3341,6 @@ void SILSerializer::writeSILVTable(const SILVTable &vt) {
 }
 
 void SILSerializer::writeSILMoveOnlyDeinit(const SILMoveOnlyDeinit &deinit) {
-  // Do not emit deinit for non-public nominal types unless everything has to be
-  // serialized.
-  if (!Options.SerializeAllSIL && deinit.getNominalDecl()->getEffectiveAccess() <
-                                 swift::AccessLevel::Package)
-    return;
-
   SILFunction *impl = deinit.getImplementation();
   if (!Options.SerializeAllSIL &&
       // Package CMO for MoveOnlyDeinit is not supported so

--- a/test/embedded/noncopyable-deinits.swift
+++ b/test/embedded/noncopyable-deinits.swift
@@ -1,0 +1,93 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -c -I%t -parse-as-library %t/MyModule.swift -package-name P -o %t/MyModule.o -emit-module -emit-module-path %t/MyModule.swiftmodule -emit-empty-object-file
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -c -I%t %t/Main.swift -package-name P -o %t/Main.o
+// RUN: %target-clang %target-clang-resource-dir-opt %t/Main.o %t/MyModule.o -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_feature_Embedded
+
+//--- MyModule.swift
+
+public struct PublicNC: ~Copyable {
+  public init() {}
+
+  deinit {
+    print("deinit PublicNC")
+  }
+}
+
+package struct PackageNC: ~Copyable {
+  package init() {}
+
+  deinit {
+    print("deinit PackageNC")
+  }
+}
+
+package struct PackageGeneric<T>: ~Copyable {
+  var t: T
+
+  package init(_ t: T) { self.t = t }
+
+  deinit {
+    print("deinit PackageGeneric")
+  }
+}
+
+struct InternalNC: ~Copyable {
+  deinit {
+    print("deinit InternalNC")
+  }
+}
+
+private struct PrivateNC: ~Copyable {
+  deinit {
+    print("deinit PrivateNC")
+  }
+}
+
+public func testInternal<T>(_ t: T) {
+  _ = InternalNC()
+}
+
+public func testPrivate<T>(_ t: T) {
+  _ = PrivateNC()
+}
+
+//--- Main.swift
+
+import MyModule
+
+@inline(never)
+public func testPublic() {
+  _ = PublicNC()
+}
+
+@inline(never)
+public func testPackage() {
+  _ = PackageNC()
+}
+
+@inline(never)
+public func testPackageGeneric() {
+  _ = PackageGeneric(27)
+}
+
+// CHECK: deinit PublicNC
+testPublic()
+
+// CHECK: deinit PackageNC
+testPackage()
+
+// CHECK: deinit PackageGeneric
+testPackageGeneric()
+
+// CHECK: deinit InternalNC
+testInternal(0)
+
+// CHECK: deinit PrivateNC
+testPrivate(0)
+


### PR DESCRIPTION
When a non-public non-copyable type with a deinit is defined in a module, we got this error in a client module when the compiler tried to de-virtualize the deinit call.

This PR also improves the error message: the error message now includes call tree information, source location and the type of the struct containing the deinit.

rdar://166051414