### PR TITLE
[Backtracing][PDB] Fix 32-bit Intel build.

### DIFF
--- a/stdlib/public/RuntimeModule/PDB/MultiStreamFile.swift
+++ b/stdlib/public/RuntimeModule/PDB/MultiStreamFile.swift
@@ -52,7 +52,7 @@ class MultiStreamFile {
     var size: Int
     var pages: [Int]
 
-    var valid: Bool { return size != 0xffffffff }
+    var valid: Bool { return size != Int(bitPattern: 0xffffffff) }
   }
 
   enum Kind {


### PR DESCRIPTION
`Int` can't contain `0xffffffff`.

rdar://170626274
