### PR TITLE
[cxx-interop] `static constexpr` fields should not prevent memberwise initialization

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2629,10 +2629,14 @@ namespace {
           if (!isa<clang::TypeDecl>(nd) && !isa<clang::FunctionDecl>(nd) &&
               !isa<clang::TypeAliasTemplateDecl>(nd) &&
               !isa<clang::FunctionTemplateDecl>(nd)) {
-            // We don't know what this member is.
-            // Assume it may be important in C.
-            hasUnreferenceableStorage = true;
-            hasMemberwiseInitializer = false;
+            auto varDecl = dyn_cast<clang::VarDecl>(nd);
+            // Static fields don't affect the memberwise initializer.
+            if (!(varDecl && varDecl->isStaticDataMember())) {
+              // We don't know what this member is.
+              // Assume it may be important in C.
+              hasUnreferenceableStorage = true;
+              hasMemberwiseInitializer = false;
+            }
           }
           continue;
         }

--- a/test/Interop/Cxx/class/Inputs/memberwise-initializer.h
+++ b/test/Interop/Cxx/class/Inputs/memberwise-initializer.h
@@ -82,4 +82,9 @@ struct ClassWithStaticAssert2 {
   int x, y;
 };
 
+struct ClassWithConstexprStatic {
+  int x;
+  static constexpr int y = 0;
+};
+
 #endif

--- a/test/Interop/Cxx/class/memberwise-initializer-module-interface.swift
+++ b/test/Interop/Cxx/class/memberwise-initializer-module-interface.swift
@@ -64,3 +64,8 @@
 // CHECK-NEXT:   var x: Int32
 // CHECK-NEXT:   var y: Int32
 // CHECK-NEXT: }
+// CHECK-NEXT: struct ClassWithConstexprStatic {
+// CHECK-NEXT:   init(x: Int32)
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   var x: Int32
+// CHECK-NEXT: }

--- a/test/Interop/Cxx/class/memberwise-initializer-typechecker.swift
+++ b/test/Interop/Cxx/class/memberwise-initializer-typechecker.swift
@@ -18,3 +18,5 @@ let classWithUnimportedMemberFunction = ClassWithUnimportedMemberFunction(varPub
 
 let _ = ClassWithStaticAssert(x: 6, y: 7)
 let _ = ClassWithStaticAssert2(x: 6, y: 7)
+
+let _ = ClassWithConstexprStatic(x: 123)

--- a/test/Interop/Cxx/class/memberwise-initializer.swift
+++ b/test/Interop/Cxx/class/memberwise-initializer.swift
@@ -1,0 +1,15 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=default)
+
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import MemberwiseInitializer
+
+var Suite = TestSuite("Memberwise Initializer")
+
+Suite.test("ClassWithConstexprStatic") {
+  let instance = ClassWithConstexprStatic(x: 123)
+  expectEqual(123, instance.x)
+}
+
+runAllTests()


### PR DESCRIPTION
Swift currently doesn't import `static constexpr` fields of C++ structs. An unintended side effect of this was that if a C++ struct has a `static constexpr` field, Swift would try to import it, fail, and decide that the C++ struct can not be initialized with a memberwise Swift initializer. This change removes the limitation.

rdar://169736395

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
