### PR TITLE
Sema: This test is now fast

### DIFF
--- a/validation-test/Sema/type_checker_perf/fast/custom_logical_operators.swift
+++ b/validation-test/Sema/type_checker_perf/fast/custom_logical_operators.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000 -solver-disable-performance-hacks
 // REQUIRES: tools-release,no_asan
 // REQUIRES: objc_interop
 
@@ -23,7 +23,6 @@ public func || <Predicate> (_ lhs: Predicate, _ rhs: Predicate) -> OrPredicate<P
 
 func f<T: Publisher, U: Publisher, V: Publisher>(_ sendingAction: T, _ conversationState: U, _ shouldDisableUserInput: V)
   where T.Failure == U.Failure, U.Failure == V.Failure, T.Output == Bool, U.Output == E, V.Output == Bool {
-  // expected-error@+1 {{reasonable time}}
   let _ = Publishers.CombineLatest3(sendingAction, conversationState, shouldDisableUserInput)
     .map { sendingAction, state, disableInput in
       sendingAction == false && state == .active && disableInput == false


### PR DESCRIPTION
I didn't realize it at the time but https://github.com/swiftlang/swift/pull/87249 and https://github.com/swiftlang/swift/pull/87294 broke the build, because the `-solver-disable-performance-hacks` flag made this test case fast. Instead of special-casing logical operators, they are now handled like other operators with this flag. Move the test from slow/ to fast/ and update it to pass the flag explicitly, in case we have to flip the default again for some reason.