### PR TITLE
use BorrowingSequence Protocol when appropriate

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4022,7 +4022,6 @@ static bool generateForEachStmtConstraints(ConstraintSystem &cs,
                                            Pattern *typeCheckedPattern,
                                            bool shouldBindPatternVarsOneWay) {
   auto &ctx = cs.getASTContext();
-  bool isBorrowing = ctx.LangOpts.hasFeature(Feature::BorrowingForLoop);
   bool isAsync = stmt->getAwaitLoc().isValid();
   auto *sequenceExpr = stmt->getSequence();
 
@@ -4031,9 +4030,7 @@ static bool generateForEachStmtConstraints(ConstraintSystem &cs,
   // contextual type for diagnostics.
   auto *sequenceProto = TypeChecker::getProtocol(
       ctx, stmt->getForLoc(),
-      isAsync ? KnownProtocolKind::AsyncSequence
-              : (isBorrowing ? KnownProtocolKind::BorrowingSequence
-                             : KnownProtocolKind::Sequence));
+      isAsync ? KnownProtocolKind::AsyncSequence : KnownProtocolKind::Sequence);
   if (!sequenceProto)
     return true;
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9910,7 +9910,8 @@ ConstraintSystem::simplifyForEachElementConstraint(
   auto contextualTy = getContextualTypeInfo(anchor)->getType();
   auto *seqProto = contextualTy->castTo<ProtocolType>()->getDecl();
   auto isAsync = seqProto->isSpecificProtocol(KnownProtocolKind::AsyncSequence);
-  auto isBorrowing = shouldUseBorrowingSequence(ctx, seqTy, isAsync);
+  auto isBorrowing =
+      shouldUseBorrowingSequence(ctx, seqTy, isAsync, anchor.getStartLoc());
 
   if (isBorrowing) {
     seqProto = ctx.getProtocol(KnownProtocolKind::BorrowingSequence);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -19,6 +19,7 @@
 #include "OpenedExistentials.h"
 #include "TypeCheckConcurrency.h"
 #include "TypeCheckEffects.h"
+#include "TypeChecker.h"
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/Decl.h"
@@ -9909,12 +9910,10 @@ ConstraintSystem::simplifyForEachElementConstraint(
   auto contextualTy = getContextualTypeInfo(anchor)->getType();
   auto *seqProto = contextualTy->castTo<ProtocolType>()->getDecl();
   auto isAsync = seqProto->isSpecificProtocol(KnownProtocolKind::AsyncSequence);
-  auto isBorrowing =
-      seqProto->isSpecificProtocol(KnownProtocolKind::BorrowingSequence);
+  auto isBorrowing = shouldUseBorrowingSequence(ctx, seqTy, isAsync);
 
-  if (seqTy->isExistentialType() && !isAsync && isBorrowing) {
-    isBorrowing = false;
-    seqProto = ctx.getProtocol(KnownProtocolKind::Sequence);
+  if (isBorrowing) {
+    seqProto = ctx.getProtocol(KnownProtocolKind::BorrowingSequence);
   }
 
   auto *contextualLoc = getConstraintLocator(

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -3440,7 +3440,7 @@ FuncDecl *TypeChecker::getForEachIteratorNextFunction(
 }
 
 bool swift::shouldUseBorrowingSequence(ASTContext &ctx, Type seqTy,
-                                       bool isAsync) {
+                                       bool isAsync, SourceLoc loc) {
   if (!ctx.LangOpts.hasFeature(Feature::BorrowingForLoop)) {
     return false;
   }
@@ -3449,7 +3449,9 @@ bool swift::shouldUseBorrowingSequence(ASTContext &ctx, Type seqTy,
     return false;
   }
 
-  if (!ctx.getProtocol(KnownProtocolKind::BorrowingSequence)) {
+  auto *borrowingSeqProto =
+      ctx.getProtocol(KnownProtocolKind::BorrowingSequence);
+  if (!borrowingSeqProto) {
     return false;
   }
 
@@ -3462,10 +3464,19 @@ bool swift::shouldUseBorrowingSequence(ASTContext &ctx, Type seqTy,
   // Fall back to Sequence if no conformance to BorrowingSequence is found.
   // This ensures that we maintain Sequence as the minimal required
   // conformance.
-  if (!lookupConformance(
-          seqTy, ctx.getProtocol(KnownProtocolKind::BorrowingSequence))) {
+  auto seqConformanceRef = lookupConformance(seqTy, borrowingSeqProto);
+  if (seqConformanceRef.isInvalid()) {
     return false;
   }
+
+  if (auto *conformance = seqConformanceRef.getConcrete()) {
+    auto protoAvail = AvailabilityContext::forDeclSignature(borrowingSeqProto);
+    auto *dc = conformance->getDeclContext();
+    auto availability = AvailabilityContext::forLocation(loc, dc);
+    if (!availability.isContainedIn(protoAvail))
+      return false;
+  }
+
   return true;
 }
 
@@ -3501,7 +3512,8 @@ public:
         (stmt->getWhere() && stmt->getWhere()->getType()->hasError()))
       return nullptr;
 
-    isBorrowing = shouldUseBorrowingSequence(ctx, seqType, isAsync);
+    isBorrowing = shouldUseBorrowingSequence(ctx, seqType, isAsync,
+                                             sequence->getStartLoc());
 
     sequenceProto =
         isAsync ? ctx.getProtocol(KnownProtocolKind::AsyncSequence)

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -3439,13 +3439,43 @@ FuncDecl *TypeChecker::getForEachIteratorNextFunction(
   return ctx.getAsyncIteratorNext();
 }
 
+bool swift::shouldUseBorrowingSequence(ASTContext &ctx, Type seqTy,
+                                       bool isAsync) {
+  if (!ctx.LangOpts.hasFeature(Feature::BorrowingForLoop)) {
+    return false;
+  }
+
+  if (isAsync || seqTy->isExistentialType()) {
+    return false;
+  }
+
+  if (!ctx.getProtocol(KnownProtocolKind::BorrowingSequence)) {
+    return false;
+  }
+
+  // Always prefer conformance to Sequence over BorrowingSequence when
+  // both are available.
+  if (lookupConformance(seqTy, ctx.getProtocol(KnownProtocolKind::Sequence))) {
+    return false;
+  }
+
+  // Fall back to Sequence if no conformance to BorrowingSequence is found.
+  // This ensures that we maintain Sequence as the minimal required
+  // conformance.
+  if (!lookupConformance(
+          seqTy, ctx.getProtocol(KnownProtocolKind::BorrowingSequence))) {
+    return false;
+  }
+  return true;
+}
+
 namespace {
 class DesugarForEachStmt {
   ForEachStmt *stmt;
   DeclContext *dc;
   ASTContext &ctx;
   bool isAsync;
-  bool isBorrowing;
+  bool isBorrowing = false;
   VarDecl *makeIteratorVar = nullptr;
   ProtocolDecl *sequenceProto = nullptr;
   ProtocolConformanceRef seqConformanceRef;
@@ -3455,8 +3485,7 @@ public:
   DesugarForEachStmt(ForEachStmt *stmt)
       : stmt(stmt), dc(stmt->getDeclContext()),
         ctx(stmt->getDeclContext()->getASTContext()),
-        isAsync(stmt->getAwaitLoc().isValid()),
-        isBorrowing(ctx.LangOpts.hasFeature(Feature::BorrowingForLoop)) {}
+        isAsync(stmt->getAwaitLoc().isValid()) {}
 
   BraceStmt *operator()() {
     auto *sequence = stmt->getSequence();
@@ -3472,7 +3501,7 @@ public:
         (stmt->getWhere() && stmt->getWhere()->getType()->hasError()))
       return nullptr;
 
-    isBorrowing = isBorrowing && !seqType->isExistentialType();
+    isBorrowing = shouldUseBorrowingSequence(ctx, seqType, isAsync);
 
     sequenceProto =
         isAsync ? ctx.getProtocol(KnownProtocolKind::AsyncSequence)

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1560,6 +1560,11 @@ bool maybeDiagnoseMissingImportForMember(
 /// source file.
 void diagnoseMissingImports(SourceFile &sf);
 
+// Guide ForEachStmt type-checking by indicating whether the BorrowingSequence
+// protocol should be used, thus enabling Borrowing iteration for a given
+// sequence type.
+bool shouldUseBorrowingSequence(ASTContext &ctx, Type seqTy, bool isAsync);
+
 } // end namespace swift
 
 #endif

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1563,7 +1563,8 @@ void diagnoseMissingImports(SourceFile &sf);
 // Guide ForEachStmt type-checking by indicating whether the BorrowingSequence
 // protocol should be used, thus enabling Borrowing iteration for a given
 // sequence type.
-bool shouldUseBorrowingSequence(ASTContext &ctx, Type seqTy, bool isAsync);
+bool shouldUseBorrowingSequence(ASTContext &ctx, Type seqTy, bool isAsync,
+                                SourceLoc loc);
 
 } // end namespace swift
 

--- a/test/Interpreter/foreach_borrowing.swift
+++ b/test/Interpreter/foreach_borrowing.swift
@@ -1,6 +1,5 @@
-// RUN: %target-run-simple-swift(-enable-experimental-feature BorrowingForLoop \
-// RUN: -Xfrontend -disable-availability-checking) \
-// RUN:     %s | %FileCheck %s
+// RUN: %target-run-simple-swift(-enable-experimental-feature BorrowingForLoop) \
+// RUN: %s | %FileCheck %s
 
 // REQUIRES: swift_feature_BorrowingForLoop
 // REQUIRES: executable_test
@@ -15,6 +14,7 @@ extension NoncopyableInt: Equatable {
   }
 }
 
+@available(SwiftStdlib 6.4, *)
 func testContinueTarget(seq: borrowing Span<NoncopyableInt>) {
   for element in seq {
     if (element.value == 2){
@@ -27,6 +27,7 @@ func testContinueTarget(seq: borrowing Span<NoncopyableInt>) {
   }
 }
 
+@available(SwiftStdlib 6.4, *)
 func testBreakTarget(seq: borrowing Span<NoncopyableInt>) {
   for element in seq {
     if (element.value == 3){
@@ -39,6 +40,7 @@ func testBreakTarget(seq: borrowing Span<NoncopyableInt>) {
   }
 }
 
+@available(SwiftStdlib 6.4, *)
 func testWhereClause(seq: borrowing Span<NoncopyableInt>) {
   for element in seq where element.value.isMultiple(of: 2) {
     // CHECK: element.value = 0
@@ -47,6 +49,7 @@ func testWhereClause(seq: borrowing Span<NoncopyableInt>) {
   }
 }
 
+@available(SwiftStdlib 6.4, *)
 func testWhereClauseWithContinue(seq: borrowing Span<NoncopyableInt>) {
   for element in seq where element.value > 0 {
     if (element.value == 2){
@@ -58,6 +61,7 @@ func testWhereClauseWithContinue(seq: borrowing Span<NoncopyableInt>) {
   }
 }
 
+@available(SwiftStdlib 6.4, *)
 func testWhereClauseWithBreak(seq: borrowing Span<NoncopyableInt>) {
   for element in seq where element.value.isMultiple(of: 2) {
     if (element.value > 1){
@@ -68,6 +72,7 @@ func testWhereClauseWithBreak(seq: borrowing Span<NoncopyableInt>) {
   }
 }
 
+@available(SwiftStdlib 6.4, *)
 func testNestedForLoops(seq: borrowing Span<NoncopyableInt>) {
   for element in seq{
     let arr = [0, 1, 2, 3]
@@ -81,6 +86,7 @@ func testNestedForLoops(seq: borrowing Span<NoncopyableInt>) {
   }
 }
 
+@available(SwiftStdlib 6.4, *)
 func testNestedForLoopsWithBreak(seq: borrowing Span<NoncopyableInt>) {
   for element in seq{
     let arr = [0, 1, 2, 3]
@@ -95,6 +101,7 @@ func testNestedForLoopsWithBreak(seq: borrowing Span<NoncopyableInt>) {
   }
 }
 
+@available(SwiftStdlib 6.4, *)
 func testNestedForLoopsWithContinue(seq: borrowing Span<NoncopyableInt>) {
   for element in seq{
     let arr = [0, 1, 2, 3]
@@ -113,6 +120,7 @@ func testNestedForLoopsWithContinue(seq: borrowing Span<NoncopyableInt>) {
   }
 }
 
+@available(SwiftStdlib 6.4, *)
 func testNestedForLoopsWithWhereClause(seq: borrowing Span<NoncopyableInt>) {
   for element in seq where element.value != 2 {
     let arr = [0, 1, 2, 3]
@@ -134,18 +142,20 @@ buffer.initializeElement(at: 1, to: NoncopyableInt(value: 1))
 buffer.initializeElement(at: 2, to: NoncopyableInt(value: 2))
 buffer.initializeElement(at: 3, to: NoncopyableInt(value: 3))
 
-let seq = Span<NoncopyableInt>(_unsafeElements: buffer)
+if #available(SwiftStdlib 6.4, *){
+  let seq = Span<NoncopyableInt>(_unsafeElements: buffer)
+  testContinueTarget(seq: seq)
+  testBreakTarget(seq: seq)
+  testWhereClause(seq: seq)
+  testWhereClauseWithContinue(seq: seq)
+  testWhereClauseWithBreak(seq: seq)
+  testNestedForLoops(seq: seq)
+  testNestedForLoopsWithBreak(seq: seq)
+  testNestedForLoopsWithContinue(seq: seq)
+  testNestedForLoopsWithWhereClause(seq: seq)
+}
 
-testContinueTarget(seq: seq)
-testBreakTarget(seq: seq)
-testWhereClause(seq: seq)
-testWhereClauseWithContinue(seq: seq)
-testWhereClauseWithBreak(seq: seq)
-testNestedForLoops(seq: seq)
-testNestedForLoopsWithBreak(seq: seq)
-testNestedForLoopsWithContinue(seq: seq)
-testNestedForLoopsWithWhereClause(seq: seq)
-
+@available(SwiftStdlib 6.4, *)
 func testCopyableContinueTarget(seq: borrowing Span<Int>) {
   for element in seq {
     if (element == 2){
@@ -158,6 +168,7 @@ func testCopyableContinueTarget(seq: borrowing Span<Int>) {
   }
 }
 
+@available(SwiftStdlib 6.4, *)
 func testCopyableBreakTarget(seq: borrowing Span<Int>) {
   for element in seq {
     if (element == 3){
@@ -170,6 +181,7 @@ func testCopyableBreakTarget(seq: borrowing Span<Int>) {
   }
 }
 
+@available(SwiftStdlib 6.4, *)
 func testCopyableWhereClause(seq: borrowing Span<Int>) {
   for element in seq where element.isMultiple(of: 2) {
     // CHECK: element = 0
@@ -178,6 +190,7 @@ func testCopyableWhereClause(seq: borrowing Span<Int>) {
   }
 }
 
+@available(SwiftStdlib 6.4, *)
 func testCopyableWhereClauseWithContinue(seq: borrowing Span<Int>) {
   for element in seq where element > 0 {
     if (element == 2){
@@ -189,6 +202,7 @@ func testCopyableWhereClauseWithContinue(seq: borrowing Span<Int>) {
   }
 }
 
+@available(SwiftStdlib 6.4, *)
 func testCopyableWhereClauseWithBreak(seq: borrowing Span<Int>) {
   for element in seq where element.isMultiple(of: 2) {
     if (element > 1){
@@ -199,6 +213,7 @@ func testCopyableWhereClauseWithBreak(seq: borrowing Span<Int>) {
   }
 }
 
+@available(SwiftStdlib 6.4, *)
 func testCopyableNestedForLoops(seq: borrowing Span<Int>) {
   for element in seq{
     let arr = [0, 1, 2, 3]
@@ -213,10 +228,12 @@ func testCopyableNestedForLoops(seq: borrowing Span<Int>) {
 }
 
 let arr = [0, 1, 2 , 3]
-let copyableSpan = arr.span
-testCopyableContinueTarget(seq: copyableSpan)
-testCopyableBreakTarget(seq: copyableSpan)
-testCopyableWhereClause(seq: copyableSpan)
-testCopyableWhereClauseWithContinue(seq: copyableSpan)
-testCopyableWhereClauseWithBreak(seq: copyableSpan)
-testCopyableNestedForLoops(seq: copyableSpan)
+if #available(SwiftStdlib 6.4, *){
+  let copyableSpan = arr.span
+  testCopyableContinueTarget(seq: copyableSpan)
+  testCopyableBreakTarget(seq: copyableSpan)
+  testCopyableWhereClause(seq: copyableSpan)
+  testCopyableWhereClauseWithContinue(seq: copyableSpan)
+  testCopyableWhereClauseWithBreak(seq: copyableSpan)
+  testCopyableNestedForLoops(seq: copyableSpan)
+}

--- a/test/Profiler/coverage_foreach_borrowing.swift
+++ b/test/Profiler/coverage_foreach_borrowing.swift
@@ -1,9 +1,10 @@
-// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -suppress-warnings -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_foreach_borrowing -enable-experimental-feature BorrowingForLoop -disable-availability-checking %s | %FileCheck %s
-// RUN: %target-swift-frontend -profile-generate -profile-coverage-mapping -emit-ir -enable-experimental-feature BorrowingForLoop -disable-availability-checking %s
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -suppress-warnings -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_foreach_borrowing -enable-experimental-feature BorrowingForLoop %s | %FileCheck %s
+// RUN: %target-swift-frontend -profile-generate -profile-coverage-mapping -emit-ir -enable-experimental-feature BorrowingForLoop %s
 
 // REQUIRES: swift_feature_BorrowingForLoop
 
 // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_foreach_borrowing.forEachBasic
+@available(SwiftStdlib 6.4, *)
 func forEachBasic(seq: borrowing Span<Int>) -> Int {
   var sum: Int = 0
 
@@ -28,6 +29,7 @@ func forEachBasic(seq: borrowing Span<Int>) -> Int {
 }
 
 // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_foreach_borrowing.nestedForEach
+@available(SwiftStdlib 6.4, *)
 func nestedForEach(seq1: borrowing Span<Int>, seq2: borrowing Span<Int>) -> Int {
   var sum: Int = 0
 
@@ -43,6 +45,7 @@ func nestedForEach(seq1: borrowing Span<Int>, seq2: borrowing Span<Int>) -> Int 
 }
 
 // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_foreach_borrowing.forEachWithBreak
+@available(SwiftStdlib 6.4, *)
 func forEachWithBreak(seq: borrowing Span<Int>) -> Int {
   var sum: Int = 0
 
@@ -56,6 +59,7 @@ func forEachWithBreak(seq: borrowing Span<Int>) -> Int {
 }
 
 // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_foreach_borrowing.forEachWithWhere
+@available(SwiftStdlib 6.4, *)
 func forEachWithWhere(seq: borrowing Span<Int>) -> Int {
   var sum: Int = 0
 
@@ -74,6 +78,7 @@ func forEachWithWhere(seq: borrowing Span<Int>) -> Int {
 }
 
 // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_foreach_borrowing.forEachWithReturn
+@available(SwiftStdlib 6.4, *)
 func forEachWithReturn(seq: borrowing Span<Int>) -> Int {
   var sum: Int = 0
 
@@ -89,6 +94,7 @@ func forEachWithReturn(seq: borrowing Span<Int>) -> Int {
 }
 
 // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_foreach_borrowing.forEachWithContinue
+@available(SwiftStdlib 6.4, *)
 func forEachWithContinue(seq: borrowing Span<Int>) -> Int {
   var sum: Int = 0
 
@@ -104,6 +110,7 @@ func forEachWithContinue(seq: borrowing Span<Int>) -> Int {
 }
 
 // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_foreach_borrowing.forEachMultipleConditions
+@available(SwiftStdlib 6.4, *)
 func forEachMultipleConditions(seq: borrowing Span<Int>) -> Int {
   var sum: Int = 0
 

--- a/test/SILGen/foreach_borrowing.swift
+++ b/test/SILGen/foreach_borrowing.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-emit-silgen -Xllvm -sil-print-types \
 // RUN:     -g -Xllvm -sil-print-debuginfo-verbose \
 // RUN:     -enable-experimental-feature BorrowingForLoop \
-// RUN:     -disable-availability-checking \
 // RUN:     %s | %FileCheck %s
 
 // REQUIRES: swift_feature_BorrowingForLoop
@@ -16,7 +15,8 @@ extension NoncopyableInt: Equatable {
   }
 }
 
-// CHECK-LABEL: sil hidden [ossa] @$s17foreach_borrowing32testNonCopyableBorrowingSequence3seqys4SpanVyAA14NoncopyableIntVG_tF : $@convention(thin) (@guaranteed Span<NoncopyableInt>) -> () {
+// CHECK-LABEL: sil hidden {{.*}}[ossa] @$s17foreach_borrowing32testNonCopyableBorrowingSequence3seqys4SpanVyAA14NoncopyableIntVG_tF : $@convention(thin) (@guaranteed Span<NoncopyableInt>) -> () {
+@available(SwiftStdlib 6.4, *)
 func testNonCopyableBorrowingSequence(seq: borrowing Span<NoncopyableInt>) {
   // With borrowing feature enabled, we expect makeBorrowingIterator and nextSpan to be called
   // CHECK: = function_ref @$ss4SpanVsRi_zrlE21makeBorrowingIterators0aD0VyxGyF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (@guaranteed Span<τ_0_0>) -> @lifetime(borrow 0) @out SpanIterator<τ_0_0>
@@ -37,7 +37,8 @@ func testNonCopyableBorrowingSequence(seq: borrowing Span<NoncopyableInt>) {
 }
 
 
-// CHECK-LABEL: sil hidden [ossa] @$s17foreach_borrowing29testCopyableBorrowingSequence3seqys4SpanVySiG_tF : $@convention(thin) (@guaranteed Span<Int>) -> () {
+// CHECK-LABEL: sil hidden {{.*}}[ossa] @$s17foreach_borrowing29testCopyableBorrowingSequence3seqys4SpanVySiG_tF : $@convention(thin) (@guaranteed Span<Int>) -> () {
+@available(SwiftStdlib 6.4, *)
 func testCopyableBorrowingSequence(seq: borrowing Span<Int>) {
   // With borrowing feature enabled, we expect makeBorrowingIterator and nextSpan to be called
   // CHECK: = function_ref @$ss4SpanVsRi_zrlE21makeBorrowingIterators0aD0VyxGyF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (@guaranteed Span<τ_0_0>) -> @lifetime(borrow 0) @out SpanIterator<τ_0_0>
@@ -57,7 +58,8 @@ func testCopyableBorrowingSequence(seq: borrowing Span<Int>) {
   }
 }
 
-// CHECK-LABEL: sil hidden [ossa] @$s17foreach_borrowing35testContinueTargetBorrowingSequenceyyF : $@convention(thin) () -> () {
+// CHECK-LABEL: sil hidden {{.*}}[ossa] @$s17foreach_borrowing35testContinueTargetBorrowingSequenceyyF : $@convention(thin) () -> () {
+@available(SwiftStdlib 6.4, *)
 func testContinueTargetBorrowingSequence() {
   let arr = [0, 1, 2, 3]
   let seq = arr.span
@@ -87,7 +89,8 @@ func testContinueTargetBorrowingSequence() {
   }
 }
 
-// CHECK-LABEL: sil hidden [ossa] @$s17foreach_borrowing32testBreakTargetBorrowingSequenceyyF : $@convention(thin) () -> () {
+// CHECK-LABEL: sil hidden {{.*}}[ossa] @$s17foreach_borrowing32testBreakTargetBorrowingSequenceyyF : $@convention(thin) () -> () {
+@available(SwiftStdlib 6.4, *)
 func testBreakTargetBorrowingSequence() {
   let arr = [0, 1, 2, 3]
   let seq = arr.span
@@ -118,7 +121,8 @@ func testBreakTargetBorrowingSequence() {
 }
 
 
-// CHECK-LABEL: sil hidden [ossa] @$s17foreach_borrowing20testForEachLocations3seq3valys4SpanVySiG_SitF : $@convention(thin) (@guaranteed Span<Int>, Int) -> () {
+// CHECK-LABEL: sil hidden {{.*}}[ossa] @$s17foreach_borrowing20testForEachLocations3seq3valys4SpanVySiG_SitF : $@convention(thin) (@guaranteed Span<Int>, Int) -> () {
+@available(SwiftStdlib 6.4, *)
 func testForEachLocations(seq: borrowing Span<Int>, val: Int) {
   // Test that synthesized code has correct source locations for the borrowing foreach loop.
   // The borrowing foreach desugars to:
@@ -172,7 +176,8 @@ func testForEachLocations(seq: borrowing Span<Int>, val: Int) {
   }
 }
 
-// CHECK-LABEL: sil hidden [ossa] @$s17foreach_borrowing34testForEachNonCopyableSILDebugInfo3seqys4SpanVyAA14NoncopyableIntVG_tF : $@convention(thin) (@guaranteed Span<NoncopyableInt>) -> () {
+// CHECK-LABEL: sil hidden {{.*}}[ossa] @$s17foreach_borrowing34testForEachNonCopyableSILDebugInfo3seqys4SpanVyAA14NoncopyableIntVG_tF : $@convention(thin) (@guaranteed Span<NoncopyableInt>) -> () {
+@available(SwiftStdlib 6.4, *)
 func testForEachNonCopyableSILDebugInfo(seq: borrowing Span<NoncopyableInt>){
   // CHECK: debug_value {{.*}} : $*NoncopyableInt, let, name "element", expr op_deref, loc "{{.*}}":[[@LINE+1]]:7 isImplicit: false
   for element in seq {

--- a/test/SILGen/foreach_borrowing.swift
+++ b/test/SILGen/foreach_borrowing.swift
@@ -136,11 +136,11 @@ func testForEachLocations(seq: borrowing Span<Int>, val: Int) {
   //     }
   //   }
 
-  // _makeBorrowingIterator() function_ref should be at "for" keyword location (172:3)
+  // makeBorrowingIterator() function_ref should be at "for" keyword location (172:3)
   // CHECK: [[MAKE_BORROWING_IT:%.*]] = function_ref @$ss4SpanVsRi_zrlE21makeBorrowingIterators0aD0VyxGyF {{.*}}, loc "{{.*}}":[[@LINE+31]]:3
   // CHECK: apply [[MAKE_BORROWING_IT]]{{.*}}, loc "{{.*}}":[[@LINE+30]]:18
 
-  // _nextSpan() function_ref should be at "for" keyword location
+  // nextSpan() function_ref should be at "for" keyword location
   // CHECK: [[NEXT_SPAN:%.*]] = function_ref @$ss12SpanIteratorVsRi_zrlE04nextA012maximumCounts0A0VyxGSi_tF {{.*}}, loc "{{.*}}":[[@LINE+27]]:3
   // CHECK: apply [[NEXT_SPAN]]{{.*}}, loc "{{.*}}":[[@LINE+26]]:3
 


### PR DESCRIPTION
This PR aims to make some progress towards adopting BorrowingSequence. It has been decided that for the time being, we will only default to BorrowingSequence when:
1. it is the only conformance available.
2. it is an explicit conformance.

Resolves rdar://165954597.