### PR TITLE
Sema: Clean up existential conversion handling in CSOptimizer.cpp

### DIFF
--- a/lib/Sema/CSOptimizer.cpp
+++ b/lib/Sema/CSOptimizer.cpp
@@ -874,12 +874,6 @@ static bool isSubtypeOfExistentialType(Type candidateType, Type existentialType)
     return false;
 
   return llvm::all_of(layout.getProtocols(), [&](ProtocolDecl *P) {
-    if (auto superclass = P->getSuperclassDecl()) {
-      if (!isSubclassOf(candidateType,
-                        superclass->getDeclaredInterfaceType()))
-        return false;
-    }
-
     auto result = TypeChecker::containsProtocol(candidateType, P,
                                                 /*allowMissing=*/false);
     return result.first || result.second;

--- a/lib/Sema/CSOptimizer.cpp
+++ b/lib/Sema/CSOptimizer.cpp
@@ -1056,7 +1056,7 @@ scoreCandidateMatch(ConstraintSystem &cs,
   }
 
   // Conversion from a concrete type to its existential value.
-  if (paramType->isExistentialType() && !paramType->isAny()) {
+  if (paramType->isExistentialType()) {
     if (isSubtypeOfExistentialType(candidateType, paramType))
       return 100;
   }
@@ -1084,12 +1084,6 @@ scoreCandidateMatch(ConstraintSystem &cs,
   }
 
   if (paramType->isAnyExistentialType()) {
-    // If the parameter is `Any` we assume that all candidates are
-    // convertible to it, which makes it a perfect match. The solver
-    // would then decide whether erasing to an existential is preferable.
-    if (paramType->isAny())
-      return 100;
-
     // If the parameter is `Any.Type` we assume that all metatype
     // candidates are convertible to it.
     if (auto *EMT = paramType->getAs<ExistentialMetatypeType>()) {

--- a/lib/Sema/CSOptimizer.cpp
+++ b/lib/Sema/CSOptimizer.cpp
@@ -834,21 +834,19 @@ static std::optional<DisjunctionInfo> preserveFavoringOfUnlabeledUnaryArgument(
 /// FIXME: This should be a common utility somewhere instead of being
 /// re-implemented in several places in the compiler.
 static bool isSubclassOf(Type candidateType, Type superclassType) {
-  if (auto *selfType = candidateType->getAs<DynamicSelfType>()) {
-    candidateType = selfType->getSelfType();
-  }
-
-  if (auto *archetypeType = candidateType->getAs<ArchetypeType>()) {
-    candidateType = archetypeType->getSuperclass();
-    if (!candidateType)
-      return false;
-  }
+  auto *superclassDecl = superclassType->getClassOrBoundGenericClass();
+  if (!superclassDecl)
+    return false;
 
   auto *subclassDecl = candidateType->getClassOrBoundGenericClass();
-  auto *superclassDecl = superclassType->getClassOrBoundGenericClass();
-
-  if (!(subclassDecl && superclassDecl))
-    return false;
+  if (!subclassDecl) {
+    candidateType = candidateType->getSuperclass();
+    if (!candidateType)
+      return false;
+    subclassDecl = candidateType->getClassOrBoundGenericClass();
+    if (!subclassDecl)
+      return false;
+  }
 
   return superclassDecl->isSuperclassOf(subclassDecl);
 }

--- a/test/Constraints/issue-87300.swift
+++ b/test/Constraints/issue-87300.swift
@@ -1,0 +1,28 @@
+// RUN: %target-typecheck-verify-swift
+
+// https://github.com/swiftlang/swift/issues/87300
+
+func f(_ t: Any) -> Int {}
+func f(_ t: AnyClass) -> String {}
+
+func f(t: Any) -> Int {}
+func f(t: AnyClass) -> String {}
+
+class T {}
+
+do {
+  let result = f(T.self)
+  let _: String = result
+}
+
+struct S: ~Copyable {}
+
+do {
+  let result = f(S.self)
+  let _: Int = result
+}
+
+do {
+  let result = f(t: S.self)
+  let _: Int = result
+}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -758,10 +758,10 @@ func invalidDictionaryLiteral() {
 //===----------------------------------------------------------------------===//
 // nil/metatype comparisons
 //===----------------------------------------------------------------------===//
-_ = Int.self == nil  // expected-warning {{comparing non-optional value of type 'Int.Type' to 'nil' always returns false}}
-_ = nil == Int.self  // expected-warning {{comparing non-optional value of type 'Int.Type' to 'nil' always returns false}}
-_ = Int.self != nil  // expected-warning {{comparing non-optional value of type 'Int.Type' to 'nil' always returns true}}
-_ = nil != Int.self  // expected-warning {{comparing non-optional value of type 'Int.Type' to 'nil' always returns true}}
+_ = Int.self == nil  // expected-warning {{comparing non-optional value of type 'any (~Copyable & ~Escapable).Type' to 'nil' always returns false}}
+_ = nil == Int.self  // expected-warning {{comparing non-optional value of type 'any (~Copyable & ~Escapable).Type' to 'nil' always returns false}}
+_ = Int.self != nil  // expected-warning {{comparing non-optional value of type 'any (~Copyable & ~Escapable).Type' to 'nil' always returns true}}
+_ = nil != Int.self  // expected-warning {{comparing non-optional value of type 'any (~Copyable & ~Escapable).Type' to 'nil' always returns true}}
 
 _ = Int.self == .none  // expected-warning {{comparing non-optional value of type 'any (~Copyable & ~Escapable).Type' to 'Optional.none' always returns false}}
 _ = .none == Int.self  // expected-warning {{comparing non-optional value of type 'any (~Copyable & ~Escapable).Type' to 'Optional.none' always returns false}}

--- a/validation-test/Sema/type_checker_perf/fast/array_concatenation.swift
+++ b/validation-test/Sema/type_checker_perf/fast/array_concatenation.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=300
 
 // Self-contained test case
 protocol P1 {}; func f<T: P1>(_: T, _: T) -> T { fatalError() }

--- a/validation-test/Sema/type_checker_perf/fast/cfstring_iuo.swift
+++ b/validation-test/Sema/type_checker_perf/fast/cfstring_iuo.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-scope-threshold=8000 -solver-enable-prune-disjunctions
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=100 -solver-enable-prune-disjunctions
 
 // REQUIRES: objc_interop
 

--- a/validation-test/Sema/type_checker_perf/fast/complex_swiftui_padding_conditions.swift
+++ b/validation-test/Sema/type_checker_perf/fast/complex_swiftui_padding_conditions.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.15 -solver-scope-threshold=5500
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.15 -solver-scope-threshold=3000
 // REQUIRES: OS=macosx
 
 import SwiftUI

--- a/validation-test/Sema/type_checker_perf/fast/fast-operator-typechecking.swift
+++ b/validation-test/Sema/type_checker_perf/fast/fast-operator-typechecking.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 5 -solver-scope-threshold=1000
+// RUN: %target-typecheck-verify-swift -swift-version 5 -solver-scope-threshold=500
 
 // rdar://problem/32998180
 func checksum(value: UInt16) -> UInt16 {

--- a/validation-test/Sema/type_checker_perf/fast/issue-54466.swift
+++ b/validation-test/Sema/type_checker_perf/fast/issue-54466.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-scope-threshold=25000
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=15000
 // Succeeds in 125ms with 19934 scopes
 
 // https://github.com/swiftlang/swift/issues/54466

--- a/validation-test/Sema/type_checker_perf/fast/issue-54795.swift
+++ b/validation-test/Sema/type_checker_perf/fast/issue-54795.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-scope-threshold=10000 -target %target-cpu-apple-macosx10.15
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=2000 -target %target-cpu-apple-macosx10.15
 // Succeeds in 60ms with 5572 scopes
 
 // REQUIRES: objc_interop

--- a/validation-test/Sema/type_checker_perf/fast/member_chains_and_operators_with_iou_base_types.swift
+++ b/validation-test/Sema/type_checker_perf/fast/member_chains_and_operators_with_iou_base_types.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck -solver-scope-threshold=1000
+// RUN: %target-swift-frontend %s -typecheck -solver-scope-threshold=3000
 
 // REQUIRES: OS=macosx,no_asan
 // REQUIRES: objc_interop

--- a/validation-test/Sema/type_checker_perf/fast/multi_statement_closure_with_simd_variable.swift
+++ b/validation-test/Sema/type_checker_perf/fast/multi_statement_closure_with_simd_variable.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=200
 // REQUIRES: objc_interop,no_asan
 
 // REQUIRES: OS=macosx

--- a/validation-test/Sema/type_checker_perf/fast/operator_chain_with_hetergeneous_arguments.swift
+++ b/validation-test/Sema/type_checker_perf/fast/operator_chain_with_hetergeneous_arguments.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=200
 // REQUIRES: tools-release,no_asan
 
 // TODO(performance): This should be converted in a scale test once performance issue is fixed

--- a/validation-test/Sema/type_checker_perf/fast/operators_inside_closure.swift
+++ b/validation-test/Sema/type_checker_perf/fast/operators_inside_closure.swift
@@ -1,5 +1,4 @@
-// RUN: %target-swift-frontend -typecheck %s -solver-scope-threshold=10000
-// RUN: %target-swift-frontend -typecheck %s -solver-scope-threshold=1000 -solver-enable-prune-disjunctions
+// RUN: %target-swift-frontend -typecheck %s -solver-scope-threshold=500
 // REQUIRES: tools-release,no_asan
 
 // Selecting operators from the closure before arguments to `zip` makes this "too complex"

--- a/validation-test/Sema/type_checker_perf/fast/operators_inside_closure_2.swift
+++ b/validation-test/Sema/type_checker_perf/fast/operators_inside_closure_2.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck %s -solver-scope-threshold=10000
+// RUN: %target-swift-frontend -typecheck %s -solver-scope-threshold=300
 // REQUIRES: tools-release,no_asan
 
 // Selecting operators from the closure before arguments to `zip` makes this "too complex"

--- a/validation-test/Sema/type_checker_perf/fast/rdar23620262.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar23620262.swift
@@ -1,11 +1,8 @@
-// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000 -solver-enable-performance-hacks
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=15000 -solver-disable-performance-hacks
 // REQUIRES: tools-release,no_asan
 
 // UNSUPPORTED: OS=linux-gnu
-
-// expected-no-diagnostics
-
-// REQUIRES: 33958047
 
 let a: [Double] = []
 _ = a.map { $0 - 1.0 }

--- a/validation-test/Sema/type_checker_perf/fast/rdar32998180.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar32998180.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-scope-threshold=12000
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=2000
 // REQUIRES: tools-release,no_asan
 // REQUIRES: OS=macosx
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar46713933_literal_arg.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar46713933_literal_arg.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-scope-threshold=1000
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=200
 // REQUIRES: tools-release,no_asan
 
 func wrap<T>(_ key: String, _ value: T) -> T { return value }

--- a/validation-test/Sema/type_checker_perf/fast/rdar82458467.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar82458467.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-scope-threshold=2000
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=700
 
 func test() {
   let _ = (1 + 2) + (3 + 4) + (5 + 6) + 0.5

--- a/validation-test/Sema/type_checker_perf/fast/should_skip_bitwise_2.swift
+++ b/validation-test/Sema/type_checker_perf/fast/should_skip_bitwise_2.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck %s -solver-scope-threshold=4000 -solver-enable-optimize-operator-defaults -solver-enable-prune-disjunctions
+// RUN: %target-swift-frontend -typecheck %s -solver-scope-threshold=500
 
 func f1a() { let _ = ((1 << 1) + (~(~((1 * 1) - (-(1 + (~(1)))))))) << ((1 - 1) * 1) }
 func f1b() { let _: Int8 = ((1 << 1) + (~(~((1 * 1) - (-(1 + (~(1)))))))) << ((1 - 1) * 1) }

--- a/validation-test/Sema/type_checker_perf/fast/should_skip_bitwise_3.swift
+++ b/validation-test/Sema/type_checker_perf/fast/should_skip_bitwise_3.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck %s -solver-scope-threshold=15000
+// RUN: %target-swift-frontend -typecheck %s -solver-scope-threshold=500
 
 // REQUIRES: tools-release,no_asan
 

--- a/validation-test/Sema/type_checker_perf/fast/swift_package_index_4.swift
+++ b/validation-test/Sema/type_checker_perf/fast/swift_package_index_4.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck %s -solver-scope-threshold=60000
+// RUN: %target-swift-frontend -typecheck %s -solver-scope-threshold=40000
 // REQUIRES: tools-release,no_asan
 
 protocol ArgumentProtocol {}


### PR DESCRIPTION
I'm preparing to add support for existentials to canPossiblyConvertTo(), so in service of that I'm splitting off some more code from scoreCandidateMatch(). Once that is done, I'd like to unify some of this code in Subtyping.cpp.

This is mostly NFC, but while I'm here, I implemented the missing support for evaluating metatype vs existential metatype matches.

- Fixes https://github.com/swiftlang/swift/issues/87300