### PR TITLE
[Backtracing] Add the ability for a `SymbolLocator` to find images.

### DIFF
--- a/stdlib/public/RuntimeModule/ElfImageCache.swift
+++ b/stdlib/public/RuntimeModule/ElfImageCache.swift
@@ -44,7 +44,7 @@ final class ElfImageCache {
     case elf32Image(Elf32Image)
     case elf64Image(Elf64Image)
   }
-  func lookup(path: String?, alternativePaths: [String] = []) -> Result? {
+  func lookup(path: String?) -> Result? {
     guard let path = path else {
       return nil
     }
@@ -54,7 +54,7 @@ final class ElfImageCache {
     if let image = elf64[path] {
       return .elf64Image(image)
     }
-    if let source = try? ImageSource(path: path, alternativePaths: alternativePaths) {
+    if let source = try? ImageSource(path: path) {
       if let elfImage = try? Elf32Image(source: source) {
         elf32[path] = elfImage
         return .elf32Image(elfImage)

--- a/stdlib/public/RuntimeModule/ImageSource.swift
+++ b/stdlib/public/RuntimeModule/ImageSource.swift
@@ -137,7 +137,7 @@ struct ImageSource: CustomStringConvertible {
       self.bytes = chunk
     }
 
-    convenience init(path: String, alternativePaths: [String]) throws {
+    convenience init(path: String) throws {
       #if os(Windows)
       let hFile =
         path.withCString(encodedAs: UTF16.self) { lpwszPath in
@@ -184,25 +184,6 @@ struct ImageSource: CustomStringConvertible {
                   start: base, count: size))
       #else
       var fd = _swift_open(path, O_RDONLY, 0)
-
-      if fd < 0 {
-        let filePathCharacter: Character = "/" // non windows path separator
-
-        // we didn't find the image in question at the path it originally ran at
-        // so we will now check for the image at various alternative paths
-        if let imageBaseName = path.split(separator: filePathCharacter).last {
-          for alternativePath in alternativePaths {
-            let alternativeFullPath =
-              alternativePath + String(filePathCharacter) + imageBaseName
-            fd = _swift_open(alternativeFullPath, O_RDONLY, 0)
-            if fd >= 0 {
-              // we found a match
-              break
-            }
-          }
-        }
-      }
-
       if fd < 0 {
         throw ImageSourceError.posixError(_swift_get_errno())
       }
@@ -405,10 +386,8 @@ struct ImageSource: CustomStringConvertible {
   }
 
   /// Initialise with a mapped file (this is currently used by Linux)
-  init(path: String, alternativePaths: [String] = []) throws {
-    self.init(storage: try Storage(
-                  path: path,
-                  alternativePaths: alternativePaths),
+  init(path: String) throws {
+    self.init(storage: try Storage(path: path),
               isMappedImage: false, path: path)
   }
 

--- a/stdlib/public/RuntimeModule/PeImageCache.swift
+++ b/stdlib/public/RuntimeModule/PeImageCache.swift
@@ -37,14 +37,14 @@ final class PeImageCache {
     cache = [:]
   }
 
-  func lookup(path: String?, alternativePaths: [String] = []) -> PeCoffImage? {
+  func lookup(path: String?) -> PeCoffImage? {
     guard let path = path else {
       return nil
     }
     if let image = cache[path] {
       return image
     }
-    if let source = try? ImageSource(path: path, alternativePaths: alternativePaths),
+    if let source = try? ImageSource(path: path),
        let image = try? PeCoffImage(source: source) {
       cache[path] = image
       return image

--- a/stdlib/public/RuntimeModule/SymbolLocator.swift
+++ b/stdlib/public/RuntimeModule/SymbolLocator.swift
@@ -55,6 +55,7 @@ public protocol SymbolLocator {
   typealias Image = SymbolLoader.Image
   typealias ImageFormat = SymbolLoader.ImageFormat
 
+  func find(image: any Image) -> String?
   func findSymbols(for image: any Image) -> (any SymbolSource)?
   func findSymbols(for image: any Image,
                    format: ImageFormat) -> (any SymbolSource)?

--- a/stdlib/public/RuntimeModule/SymbolicatedBacktrace.swift
+++ b/stdlib/public/RuntimeModule/SymbolicatedBacktrace.swift
@@ -582,8 +582,8 @@ public struct SymbolicatedBacktrace: CustomStringConvertible {
                                       offset: 0,
                                       sourceLocation: nil)
 
-          if let hit = cache.lookup(path: theImages[imageNdx].path,
-                                    alternativePaths: alternativeSymbolFilePaths) {
+          if let imagePath = symbolLocator.find(image: theImages[imageNdx]),
+             let hit = cache.lookup(path: imagePath) {
             let symbolSource: (any SymbolSource)?
             let relativeAddress: ImageSource.Address
             switch hit {
@@ -629,8 +629,8 @@ public struct SymbolicatedBacktrace: CustomStringConvertible {
                                       offset: 0,
                                       sourceLocation: nil)
 
-          if let image = cache.lookup(path: theImages[imageNdx].path,
-                                      alternativePaths: alternativeSymbolFilePaths) {
+          if let imagePath = symbolLocator.find(image: theImages[imageNdx]),
+             let image = cache.lookup(path: imagePath) {
             let symbolSource = symbolLocator.findSymbols(for: image)
             let relativeAddress = ImageSource.Address(
               address - theImages[imageNdx].baseAddress


### PR DESCRIPTION
This is better than the `alternativePaths` mechanism because it means that a client of the `Runtime` module can do its own thing, which might even mean fetching things from a remote server or decompressing files or any other thing we might find useful.

rdar://170642627
