### PR TITLE
🌸 [6.3] [cxx-interop] Synthesize subscript without requiring ClangNode

### DIFF
--- a/test/Interop/Cxx/class/inheritance/Inputs/using-base-members.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/using-base-members.h
@@ -68,7 +68,7 @@ struct OperatorBase {
   operator bool() const { return true; }
   int operator*() const { return 456; }
   OperatorBase operator!() const { return *this; }
-  // int operator[](const int x) const { return x; } // FIXME: see below
+  int operator[](const int x) const { return x; }
 };
 
 struct OperatorBasePrivateInheritance : private OperatorBase {
@@ -76,7 +76,7 @@ public:
   using OperatorBase::operator bool;
   using OperatorBase::operator*;
   using OperatorBase::operator!;
-  // using OperatorBase::operator[];  // FIXME: using operator[] is broken
+  using OperatorBase::operator[];
 };
 
 #endif // !_USING_BASE_MEMBERS_H

--- a/test/Interop/Cxx/class/inheritance/using-base-members-executable.swift
+++ b/test/Interop/Cxx/class/inheritance/using-base-members-executable.swift
@@ -60,7 +60,7 @@ UsingBaseTestSuite.test("OperatorBasePrivateInheritance") {
   // expectTrue(Bool(fromCxx: p))
   // expectTrue(Bool(fromCxx: !p))
   expectEqual(456, p.pointee)
-  // expectEqual(789, p[789])   // FIXME: operator[] is currently broken
+  expectEqual(789, p[789])
 }
 
 runAllTests()

--- a/test/Interop/Cxx/class/inheritance/using-base-members-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/using-base-members-module-interface.swift
@@ -70,6 +70,7 @@
 
 // CHECK:      public struct OperatorBasePrivateInheritance : CxxConvertibleToBool {
 // CHECK-NEXT:   public init()
+// CHECK-NEXT:   public subscript(x: Int32) -> Int32 { get }
 // CHECK-NEXT:   public var pointee: Int32 { get }
 // CHECK-NEXT:   public func __convertToBool() -> Bool
 // CHECK-NEXT:   @available(*, unavailable, message: "use .pointee property")
@@ -77,4 +78,6 @@
 // CHECK-NEXT:   prefix public static func ! (lhs: OperatorBasePrivateInheritance) -> OperatorBase
 // CHECK-NEXT:   @available(*, unavailable, message: "use ! instead")
 // CHECK-NEXT:   public func __operatorExclaim() -> OperatorBase
+// CHECK-NEXT:   @available(*, unavailable, message: "use subscript")
+// CHECK-NEXT:   public func __operatorSubscriptConst(_ x: Int32) -> Int32
 // CHECK-NEXT: }


### PR DESCRIPTION
**Explanation**: An assertion fails when a derived class inherits operator[] from a base class, because the derived class's operator[] is a synthesized shim that does not have a ClangNode associated with it.

**Resolves**: rdar://167701851

**Main branch PR**: https://github.com/swiftlang/swift/pull/86360

**Risk**: Low, this change is small and localized and actually fixes some previously broken tests in the test suite

**Testing**: Added as part of the patch, been running in `main` since more than a month ago

**Reviewed by**: @Xazax-hun @egorzhdan @hnrklssn 