### PR TITLE
[sema] Refactor usesFlowSensitiveIsolation to improve clarity and fix destructor check

### DIFF
--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -453,7 +453,7 @@ ActorIsolation getActorIsolationOfContext(
 bool isSameActorIsolated(ValueDecl *value, DeclContext *dc);
 
 /// Determines whether this function's body uses flow-sensitive isolation.
-bool usesFlowSensitiveIsolation(AbstractFunctionDecl const *fn);
+bool usesFlowSensitiveIsolation(AbstractFunctionDecl *fn);
 
 void simple_display(llvm::raw_ostream &out, const ActorIsolation &state);
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -8371,6 +8371,12 @@ ActorReferenceResult ActorReferenceResult::Builder::build() {
 
   // The declaration we are accessing is actor-isolated. First, check whether
   // we are on the same actor already.
+  //
+  // NOTE: An important but non-obvious property is that we must use an else if
+  // here and not move isIsolated into this check since
+  // equivalentIsolationContext does not take into account actors which have the
+  // same isolation but differ in terms of actor instance. We want to consider
+  // these to not match.
   if (referencedActor && declIsolation == ActorIsolation::ActorInstance &&
       declIsolation.isActorInstanceForSelfParameter()) {
     // If this instance is isolated, we're in the same concurrency domain.

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -231,6 +231,8 @@ struct ActorReferenceResult {
   const ActorIsolation isolation;
 
 private:
+  struct Builder;
+
   static ActorReferenceResult
   forSameConcurrencyDomain(ActorIsolation isolation,
                            Options options = std::nullopt);


### PR DESCRIPTION
This commit refactors usesFlowSensitiveIsolation and related helpers by:

1. Remove unnecessary const qualifiers that required const_cast workarounds. Making a parameter const only to unconst it in the body just wastes text.

2. Rename requiresFlowIsolation to isolatedConstructorRequiresFlowIsolation to better express what the function checks

3. Improve code structure with early returns and clearer logic flow.

----

Just slimming down a larger commit