### PR TITLE
ClangImporter: mark macro alias function getters as `@Sendable`

### DIFF
--- a/lib/ClangImporter/ImportMacro.cpp
+++ b/lib/ClangImporter/ImportMacro.cpp
@@ -430,13 +430,18 @@ ValueDecl *importDeclAlias(ClangImporter::Implementation &clang,
     return nullptr;
 
   swift::ASTContext &Ctx = DC->getASTContext();
+  bool IsFunction = D->getType()->isFunctionType();
   ImportedType Ty =
-      clang.importType(D->getType(), ImportTypeKind::Abstract,
+      clang.importType(D->getType(),
+                      IsFunction
+                          ? ImportTypeKind::Variable
+                          : ImportTypeKind::Abstract,
                        [&clang, &D](Diagnostic &&Diag) {
                          clang.addImportDiagnostic(D, std::move(Diag),
                                                    D->getLocation());
                        }, /*AllowsNSUIntegerAsInt*/true,
-                       Bridgeability::None, { });
+                       Bridgeability::None,
+                       IsFunction ? ImportTypeAttr::Sendable : ImportTypeAttr());
   swift::Type GetterTy = FunctionType::get({}, Ty.getType(), ASTExtInfo{});
   swift::Type SetterTy =
       FunctionType::get({AnyFunctionType::Param(Ty.getType())},

--- a/test/ClangImporter/Inputs/custom-modules/Aliases.h
+++ b/test/ClangImporter/Inputs/custom-modules/Aliases.h
@@ -51,3 +51,10 @@ extern const int const_overloaded __attribute__((__swift_name__("overload")));
 
 void variadic(int count, ...);
 #define aliased_variadic variadic
+
+void function(void);
+#define aliased_function function
+
+__attribute__((__swift_attr__("@MainActor")))
+void main_actor_function(void);
+#define MAFunction main_actor_function

--- a/test/SILGen/variadic.swift
+++ b/test/SILGen/variadic.swift
@@ -13,8 +13,8 @@ public func f() {
             // closure #1 in f()
 // CHECK: bb0(%0 : $*(), %1 : $CVaListPointer):
             // function_ref u_vformatMessage.getter
-// CHECK: [[PROJECTION:%.*]] = function_ref @$sSC16u_vformatMessageyys5Int32V_s14CVaListPointerVSgtcvg : $@convention(thin) () -> @owned @callee_guaranteed (Int32, Optional<CVaListPointer>) -> ()
-// CHECK: [[FUNCTION:%.*]] = apply [[PROJECTION]]() : $@convention(thin) () -> @owned @callee_guaranteed (Int32, Optional<CVaListPointer>) -> ()
+// CHECK: [[PROJECTION:%.*]] = function_ref @$sSC16u_vformatMessageyys5Int32V_s14CVaListPointerVSgtcvg : $@convention(thin) () -> @owned @Sendable @callee_guaranteed (Int32, Optional<CVaListPointer>) -> ()
+// CHECK: [[FUNCTION:%.*]] = apply [[PROJECTION]]() : $@convention(thin) () -> @owned @Sendable @callee_guaranteed (Int32, Optional<CVaListPointer>) -> ()
 // CHECK: [[VALIST:%.*]] = enum $Optional<CVaListPointer>, #Optional.some!enumelt, %1
 // CHECK: [[BORROW:%.*]] = begin_borrow [[FUNCTION]]
-// CHECK: {{.*}} = apply [[BORROW]]({{.*}}, [[VALIST]]) : $@callee_guaranteed (Int32, Optional<CVaListPointer>) -> ()
+// CHECK: {{.*}} = apply [[BORROW]]({{.*}}, [[VALIST]]) : $@Sendable @callee_guaranteed (Int32, Optional<CVaListPointer>) -> ()


### PR DESCRIPTION
Any C imported function pointer should be `@Sendable`. Mark the getter appropriately to avoid spurious warnings for Swift 6 mode.