### PR TITLE
Pass SwiftTesting_DIR to cmake_options for swift-corelibs-xctest

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2333,6 +2333,7 @@ for host in "${ALL_HOSTS[@]}"; do
 
                     -Ddispatch_DIR=$(build_directory ${host} libdispatch)/cmake/modules
                     -DFoundation_DIR=$(build_directory ${host} foundation)/cmake/modules
+                    -DSwiftTesting_DIR=$(build_directory ${host} swift_testing)/cmake/modules
                     -DLLVM_DIR=$(build_directory ${host} llvm)/lib/cmake/llvm
 
                     -DXCTEST_PATH_TO_LIBDISPATCH_SOURCE:PATH=${LIBDISPATCH_SOURCE_DIR}


### PR DESCRIPTION
Provides the path to the swift-testing modules
(https://github.com/swiftlang/swift-testing/pull/1573) when building swift-corelibs-xctest. This allows xctest to link against the _TestingInterop library, which is produced by the swift-testing project.

It's only passed when these conditions are met:

* ${product} is swift-corelibs-xctest

* ${host} is not macosx

The macosx pipeline is unchanged (and probably broken), although I don't believe it is currently in use since swift-corelibs-xctest is not present in the macOS OSS toolchain.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
