### PR TITLE
[DependencyScanning] Reenable Clang Module Dependency Scanning through the Shared Clang Compiler Instance

### DIFF
--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -326,10 +326,9 @@ ModuleDependencyScanningWorker::scanFilesystemForClangModuleDependency(
     const llvm::DenseSet<clang::tooling::dependencies::ModuleID>
         &alreadySeenModules) {
   diagnosticReporter.registerNamedClangModuleQuery();
-  auto clangModuleDependencies = clangScanningTool.getModuleDependencies(
-      moduleName.str(), clangScanningModuleCommandLineArgs,
-      clangScanningWorkingDirectoryPath, alreadySeenModules,
-      lookupModuleOutput);
+  auto clangModuleDependencies =
+      clangScanningTool.computeDependenciesByNameWithContext(
+          moduleName.str(), alreadySeenModules, lookupModuleOutput);
   if (!clangModuleDependencies) {
     llvm::handleAllErrors(
         clangModuleDependencies.takeError(),


### PR DESCRIPTION
This PR enables the lookup using shared compiler instance since https://github.com/llvm/llvm-project/pull/178542 (and https://github.com/swiftlang/llvm-project/pull/12245) fixed the incorrect diagnostics coming from the shared compiler instance. 

Fixes rdar://136303612. 
