### PR TITLE
Stdlib: switch to SuppressedAssociatedTypesWithDefaults

### DIFF
--- a/Runtimes/Core/cmake/modules/ExperimentalFeatures.cmake
+++ b/Runtimes/Core/cmake/modules/ExperimentalFeatures.cmake
@@ -1,5 +1,5 @@
 add_compile_options(
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature SuppressedAssociatedTypes>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature SuppressedAssociatedTypesWithDefaults>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature SE427NoInferenceOnExtension>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature NonescapableTypes>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature LifetimeDependence>"

--- a/Runtimes/Overlay/cmake/modules/ExperimentalFeatures.cmake
+++ b/Runtimes/Overlay/cmake/modules/ExperimentalFeatures.cmake
@@ -1,5 +1,5 @@
 add_compile_options(
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature SuppressedAssociatedTypes>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature SuppressedAssociatedTypesWithDefaults>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature SE427NoInferenceOnExtension>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature NonescapableTypes>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature LifetimeDependence>"

--- a/Runtimes/Supplemental/Differentiation/CMakeLists.txt
+++ b/Runtimes/Supplemental/Differentiation/CMakeLists.txt
@@ -66,7 +66,7 @@ add_compile_options(
   $<$<COMPILE_LANGUAGE:Swift>:-nostdlibimport>
   $<$<COMPILE_LANGUAGE:Swift>:-parse-stdlib>
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-library-level api>"
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature SuppressedAssociatedTypes>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature SuppressedAssociatedTypesWithDefaults>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature SE427NoInferenceOnExtension>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature NonescapableTypes>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature LifetimeDependence>"

--- a/Runtimes/Supplemental/Distributed/CMakeLists.txt
+++ b/Runtimes/Supplemental/Distributed/CMakeLists.txt
@@ -71,7 +71,7 @@ add_compile_options(
   $<$<COMPILE_LANGUAGE:Swift>:-nostdlibimport>
   $<$<COMPILE_LANGUAGE:Swift>:-strict-memory-safety>
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Werror StrictMemorySafety>"
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature SuppressedAssociatedTypes>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature SuppressedAssociatedTypesWithDefaults>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature SE427NoInferenceOnExtension>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature NonescapableTypes>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature LifetimeDependence>"

--- a/Runtimes/Supplemental/Observation/CMakeLists.txt
+++ b/Runtimes/Supplemental/Observation/CMakeLists.txt
@@ -68,7 +68,7 @@ add_compile_options(
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -enforce-exclusivity=unchecked>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -target-min-inlining-version -Xfrontend min>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-string-processing-module-import>"
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature SuppressedAssociatedTypes>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature SuppressedAssociatedTypesWithDefaults>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature SE427NoInferenceOnExtension>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature NonescapableTypes>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature LifetimeDependence>"

--- a/Runtimes/Supplemental/Runtime/CMakeLists.txt
+++ b/Runtimes/Supplemental/Runtime/CMakeLists.txt
@@ -84,7 +84,7 @@ add_compile_options(
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -target-min-inlining-version -Xfrontend min>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-concurrency-module-import>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-string-processing-module-import>"
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature SuppressedAssociatedTypes>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature SuppressedAssociatedTypesWithDefaults>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature SE427NoInferenceOnExtension>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature NonescapableTypes>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature LifetimeDependence>"

--- a/Runtimes/Supplemental/StringProcessing/CMakeLists.txt
+++ b/Runtimes/Supplemental/StringProcessing/CMakeLists.txt
@@ -57,7 +57,7 @@ option(${PROJECT_NAME}_ENABLE_PRESPECIALIZATION "Enable generic metadata prespec
 add_compile_options(
   $<$<COMPILE_LANGUAGE:Swift>:-explicit-module-build>
   $<$<COMPILE_LANGUAGE:Swift>:-nostdlibimport>
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature SuppressedAssociatedTypes>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature SuppressedAssociatedTypesWithDefaults>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature SE427NoInferenceOnExtension>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature NonescapableTypes>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature LifetimeDependence>"

--- a/Runtimes/Supplemental/Synchronization/CMakeLists.txt
+++ b/Runtimes/Supplemental/Synchronization/CMakeLists.txt
@@ -73,7 +73,7 @@ add_compile_options(
   $<$<COMPILE_LANGUAGE:Swift>:-enable-builtin-module>
   $<$<COMPILE_LANGUAGE:Swift>:-strict-memory-safety>
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Werror StrictMemorySafety>"
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature SuppressedAssociatedTypes>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature SuppressedAssociatedTypesWithDefaults>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature SE427NoInferenceOnExtension>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature NonescapableTypes>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature LifetimeDependence>"

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -634,7 +634,7 @@ function(_compile_swift_files
     list(APPEND swift_flags "-experimental-hermetic-seal-at-link")
   endif()
 
-  list(APPEND swift_flags "-enable-experimental-feature" "SuppressedAssociatedTypes")
+  list(APPEND swift_flags "-enable-experimental-feature" "SuppressedAssociatedTypesWithDefaults")
   list(APPEND swift_flags "-enable-experimental-feature" "SE427NoInferenceOnExtension")
 
   list(APPEND swift_flags "-enable-experimental-feature" "NonescapableTypes")

--- a/stdlib/public/core/BorrowingSequence.swift
+++ b/stdlib/public/core/BorrowingSequence.swift
@@ -63,10 +63,11 @@ public protocol _BorrowingSequence<_Element>: ~Copyable, ~Escapable {
 
 @available(SwiftStdlib 6.3, *)
 extension _BorrowingSequence where Self: _BorrowingIteratorProtocol & ~Escapable,
-  _BorrowingIterator == Self
+  _BorrowingIterator == Self,
+  _Element: ~Copyable
 {
   @lifetime(borrow self)
-  public func makeBorrowingIterator() -> _BorrowingIterator {
+  public func _makeBorrowingIterator() -> _BorrowingIterator {
     self
   }
 }

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -1196,7 +1196,7 @@ Added: _$ss18_BorrowingSequenceMp
 Added: _$ss18_BorrowingSequenceP01_A8IteratorAB_s01_aC8ProtocolTn
 Added: _$ss18_BorrowingSequenceP05_makeA8Iterator01_aD0QzyFTj
 Added: _$ss18_BorrowingSequenceP05_makeA8Iterator01_aD0QzyFTq
-Added: _$ss18_BorrowingSequencePs01_A8IteratorABQzRszRi0_zrlE04makeaC0xyF
+Added: _$ss18_BorrowingSequencePs01_A8IteratorABQzRszRi0_z8_ElementABRj_zrlE05_makeaC0xyF
 Added: _$ss18_BorrowingSequenceTL
 Added: _$ss26_BorrowingIteratorProtocolMp
 Added: _$ss26_BorrowingIteratorProtocolP5_skip2byS2i_tFTj

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -1191,7 +1191,7 @@ Added: _$ss18_BorrowingSequenceMp
 Added: _$ss18_BorrowingSequenceP01_A8IteratorAB_s01_aC8ProtocolTn
 Added: _$ss18_BorrowingSequenceP05_makeA8Iterator01_aD0QzyFTj
 Added: _$ss18_BorrowingSequenceP05_makeA8Iterator01_aD0QzyFTq
-Added: _$ss18_BorrowingSequencePs01_A8IteratorABQzRszRi0_zrlE04makeaC0xyF
+Added: _$ss18_BorrowingSequencePs01_A8IteratorABQzRszRi0_z8_ElementABRj_zrlE05_makeaC0xyF
 Added: _$ss18_BorrowingSequenceTL
 Added: _$ss26_BorrowingIteratorProtocolMp
 Added: _$ss26_BorrowingIteratorProtocolP5_skip2byS2i_tFTj

--- a/test/stdlib/Span/SpanTests.swift
+++ b/test/stdlib/Span/SpanTests.swift
@@ -10,9 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: %target-run-stdlib-swift
+// RUN: %target-run-stdlib-swift(-enable-experimental-feature SuppressedAssociatedTypesWithDefaults)
 
 // REQUIRES: executable_test
+// REQUIRES: swift_feature_SuppressedAssociatedTypesWithDefaults
 
 import StdlibUnittest
 
@@ -652,7 +653,7 @@ suite.test("Span Sendability")
 }
 
 @available(SwiftStdlib 6.3, *)
-extension _BorrowingSequence where Self: ~Copyable & ~Escapable {
+extension _BorrowingSequence where Self: ~Copyable & ~Escapable, _Element: ~Copyable {
   func reduce<T: ~Copyable>(
     _ initial: consuming T,
     _ nextPartialResult: @escaping (consuming T, borrowing _Element) -> T
@@ -713,7 +714,7 @@ extension NoncopyableInt: Equatable {
 }
 
 @available(SwiftStdlib 6.3, *)
-extension _BorrowingSequence where Self: ~Escapable & ~Copyable, _Element: Equatable {
+extension _BorrowingSequence where Self: ~Escapable & ~Copyable, _Element: Equatable & ~Copyable {
   func elementsEqual<S: _BorrowingSequence<_Element>>(
     _ rhs: borrowing S
   ) -> Bool


### PR DESCRIPTION
Ever since `_BorrowingSequence` and friends landed in the standard library, it's introduced a primary associated type that is suppressed. Since the mangling of generic signatures is different depending on whether you're using `SuppressedAssociatedTypes` and the `-WithDefaults` version, we should introduce it with the new mangling in-place. It's also source breaking to make this switch happen later on, since defaults will get assumed where they were not before.

rdar://170650908