### PR TITLE
[Distributed] introduce signpost tracing in Distributed module

### DIFF
--- a/Runtimes/Supplemental/Distributed/CMakeLists.txt
+++ b/Runtimes/Supplemental/Distributed/CMakeLists.txt
@@ -99,7 +99,12 @@ add_library(swiftDistributed
   DistributedDefaultExecutor.swift
   DistributedMacros.swift
   DistributedMetadata.swift
-  LocalTestingDistributedActorSystem.swift)
+  LocalTestingDistributedActorSystem.swift
+
+  # Tracing
+  TracingDistributed.swift
+  TracingDistributed.cpp
+  TracingDistributedSignpost.cpp)
 
 set_target_properties(swiftDistributed PROPERTIES
   Swift_MODULE_NAME Distributed)

--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -339,6 +339,14 @@ IDENTIFIER(decodeNextArgument)
 IDENTIFIER(SerializationRequirement)
 IDENTIFIER_WITH_NAME(builderSelf, "$builderSelf")
 
+IDENTIFIER_(traceDistributedRemoteCall)
+IDENTIFIER_(traceDistributedRemoteCallEnd)
+IDENTIFIER_(traceDistributedEncodeArgumentsBegin)
+IDENTIFIER_(traceDistributedEncodeArgumentsEnd)
+IDENTIFIER(targetActor)
+IDENTIFIER(targetIdentifier)
+IDENTIFIER(argumentCount)
+
 // Attribute options
 IDENTIFIER(always)
 IDENTIFIER_(_always)

--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -340,6 +340,14 @@ IDENTIFIER(decodeNextArgument)
 IDENTIFIER(SerializationRequirement)
 IDENTIFIER_WITH_NAME(builderSelf, "$builderSelf")
 
+IDENTIFIER_(traceDistributedRemoteCall)
+IDENTIFIER_(traceDistributedRemoteCallEnd)
+IDENTIFIER_(traceDistributedEncodeArgumentsBegin)
+IDENTIFIER_(traceDistributedEncodeArgumentsEnd)
+IDENTIFIER(targetActor)
+IDENTIFIER(targetIdentifier)
+IDENTIFIER(argumentCount)
+
 // Attribute options
 IDENTIFIER(always)
 IDENTIFIER_(_always)

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -16,6 +16,10 @@
 #include "DerivedConformance/DerivedConformance.h"
 #include "TypeChecker.h"
 #include "swift/AST/ASTMangler.h"
+#include "swift/AST/AvailabilityDomain.h"
+#include "swift/AST/AvailabilityQuery.h"
+#include "swift/AST/AvailabilityRange.h"
+#include "swift/AST/AvailabilitySpec.h"
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/DistributedDecl.h"
@@ -94,6 +98,255 @@ mangleDistributedThunkForAccessorRecordName(
   auto mangled =
       C.AllocateCopy(mangler.mangleDistributedThunkRef(cast<FuncDecl>(thunk)));
   return mangled;
+}
+
+/// Synthesize, appending to \p stmts:
+///
+///   var $remoteCallSpanID = _traceDistributedRemoteCall(
+///     targetActor: self, targetIdentifier: "<mangledName>")
+///
+/// Returns the '$remoteCallSpanID' variable, which 'synthesizeTraceRemoteCallEnd'
+/// then closes. Split from the end so the begin can sit before the 'do' while
+/// the end sits on both the success and the 'catch' paths inside it.
+static VarDecl *
+synthesizeTraceRemoteCallBegin(ASTContext &C, SourceLoc sloc, DeclNameLoc dloc,
+                               AbstractFunctionDecl *thunk, VarDecl *selfDecl,
+                               StringRef mangledName,
+                               SmallVectorImpl<ASTNode> &stmts) {
+  VarDecl *spanIDVar =
+      VarDeclBuilder(thunk, C.getIdentifier("$remoteCallSpanID"))
+          .introducer(VarDecl::Introducer::Var);
+
+  Expr *args[] = {
+      // targetActor: some DistributedActor
+      new (C) DeclRefExpr(selfDecl, dloc, /*implicit=*/true,
+                          AccessSemantics::Ordinary,
+                          selfDecl->getInterfaceType()),
+      // targetIdentifier: String
+      new (C) StringLiteralExpr(mangledName, SourceRange(), /*implicit=*/true),
+  };
+  DeclName name(C, C.Id_traceDistributedRemoteCall,
+                {C.Id_targetActor, C.Id_targetIdentifier});
+  auto *beginCall = CallExpr::createImplicit(
+      C, UnresolvedDeclRefExpr::createImplicit(C, name),
+      ArgumentList::forImplicitCallTo(DeclNameRef(name), args, C));
+
+  stmts.push_back(PatternBindingDecl::createImplicit(
+      C, StaticSpellingKind::None, NamedPattern::createImplicit(C, spanIDVar),
+      beginCall, thunk));
+  stmts.push_back(spanIDVar);
+
+  return spanIDVar;
+}
+
+/// Synthesize the call that closes the interval opened by
+/// 'synthesizeTraceRemoteCallBegin':
+///
+///   _traceDistributedRemoteCallEnd($remoteCallSpanID)              // success
+///   _traceDistributedRemoteCallEnd($remoteCallSpanID, error: $err) // failure
+///
+/// The callee is referenced by base name with labelled arguments, so a later
+/// defaulted parameter does not break name resolution (mirrors the
+/// encode-arguments wrapper). A null \p errorVar closes it as a success.
+static Expr *
+synthesizeTraceRemoteCallEnd(ASTContext &C, SourceLoc sloc, DeclNameLoc dloc,
+                             VarDecl *spanIDVar, VarDecl *errorVar) {
+  auto implicit = true;
+  SmallVector<Argument, 2> args;
+  args.push_back(Argument(sloc, Identifier(),
+                          new (C) DeclRefExpr(ConcreteDeclRef(spanIDVar), dloc,
+                                              implicit)));
+  if (errorVar) {
+    args.push_back(Argument(sloc, C.Id_error,
+                            new (C) DeclRefExpr(ConcreteDeclRef(errorVar), dloc,
+                                                implicit)));
+  }
+  DeclNameRef name(C.Id_traceDistributedRemoteCallEnd);
+  return CallExpr::createImplicit(
+      C, new (C) UnresolvedDeclRefExpr(name, DeclRefKind::Ordinary, dloc),
+      ArgumentList::createImplicit(C, args));
+}
+
+/// Wrap \p remoteCallExpr so the outbound remote-call interval is measured
+/// around exactly it: begins the interval (appended to \p stmts), then returns
+/// the 'do'/'catch' that runs the call, closes the interval on both paths and
+/// produces the call's result:
+///
+///   do {
+///     let $result = try await system.remoteCall(...)
+///     _traceDistributedRemoteCallEnd($remoteCallSpanID)
+///     return $result
+///   } catch let $remoteCallError {
+///     _traceDistributedRemoteCallEnd($remoteCallSpanID, error: $remoteCallError)
+///     throw $remoteCallError
+///   }
+///
+/// For a 'Void' returning call there is no '$result'; the call runs, the
+/// interval is closed, then the thunk returns.
+static DoCatchStmt *
+wrapTraceRemoteCall(ASTContext &C, SourceLoc sloc, DeclNameLoc dloc,
+                    AbstractFunctionDecl *thunk, VarDecl *selfDecl,
+                    StringRef mangledName, Expr *remoteCallExpr,
+                    bool isVoidReturn, SmallVectorImpl<ASTNode> &stmts) {
+  auto implicit = true;
+
+  VarDecl *spanIDVar = synthesizeTraceRemoteCallBegin(
+      C, sloc, dloc, thunk, selfDecl, mangledName, stmts);
+
+  VarDecl *errorVar =
+      VarDeclBuilder(thunk, C.getIdentifier("$remoteCallError"))
+          .introducer(VarDecl::Introducer::Let);
+
+  // --- The 'do' body: run the call, close the interval, return the result
+  SmallVector<ASTNode, 3> doBodyStmts;
+  if (isVoidReturn) {
+    doBodyStmts.push_back(remoteCallExpr);
+    doBodyStmts.push_back(
+        synthesizeTraceRemoteCallEnd(C, sloc, dloc, spanIDVar, /*errorVar=*/nullptr));
+    doBodyStmts.push_back(ReturnStmt::createImplicit(C, sloc, /*result=*/nullptr));
+  } else {
+    VarDecl *resultVar =
+        VarDeclBuilder(thunk, C.getIdentifier("$remoteCallResult"))
+            .introducer(VarDecl::Introducer::Let);
+    doBodyStmts.push_back(PatternBindingDecl::createImplicit(
+        C, StaticSpellingKind::None, NamedPattern::createImplicit(C, resultVar),
+        remoteCallExpr, thunk));
+    doBodyStmts.push_back(resultVar);
+    doBodyStmts.push_back(
+        synthesizeTraceRemoteCallEnd(C, sloc, dloc, spanIDVar, /*errorVar=*/nullptr));
+    doBodyStmts.push_back(ReturnStmt::createImplicit(
+        C, sloc,
+        new (C) DeclRefExpr(ConcreteDeclRef(resultVar), dloc, implicit)));
+  }
+  auto *doBody = BraceStmt::create(C, sloc, doBodyStmts, sloc, implicit);
+
+  // --- 'catch let $remoteCallError': close the interval reporting the error
+  // type, then rethrow
+  auto *errorPattern = NamedPattern::createImplicit(C, errorVar);
+
+  SmallVector<ASTNode, 2> catchBodyStmts;
+  catchBodyStmts.push_back(
+      synthesizeTraceRemoteCallEnd(C, sloc, dloc, spanIDVar, errorVar));
+  catchBodyStmts.push_back(new (C) ThrowStmt(
+      sloc, new (C) DeclRefExpr(ConcreteDeclRef(errorVar), dloc, implicit)));
+  auto *catchBody = BraceStmt::create(C, sloc, catchBodyStmts, sloc, implicit);
+
+  auto *caseStmt = CaseStmt::createImplicit(C, CaseParentKind::DoCatch,
+                                            {CaseLabelItem(errorPattern)},
+                                            catchBody);
+
+  return DoCatchStmt::create(thunk, LabeledStmtInfo(), sloc, sloc, TypeLoc(),
+                             doBody, {caseStmt}, implicit);
+}
+
+/// Synthesize, appending to \p stmts:
+///
+///   var $encodeSpanID = _traceDistributedEncodeArgumentsBegin(
+///     targetActor: self, targetIdentifier: "<mangledName>",
+///     argumentCount: <argumentCount>)
+///
+/// Returns the '$encodeSpanID' variable. The encoding statements must then be
+/// handed to 'synthesizeTraceEncodeArguments', which wraps them so the interval
+/// is closed on every path.
+static VarDecl *
+synthesizeTraceEncodeArgumentsBegin(ASTContext &C, SourceLoc sloc,
+                                    DeclNameLoc dloc,
+                                    AbstractFunctionDecl *thunk,
+                                    VarDecl *selfDecl, StringRef mangledName,
+                                    unsigned argumentCount,
+                                    SmallVectorImpl<ASTNode> &stmts) {
+  VarDecl *spanIDVar = VarDeclBuilder(thunk, C.getIdentifier("$encodeSpanID"))
+                            .introducer(VarDecl::Introducer::Var);
+
+  Expr *beginArgs[] = {
+      new (C) DeclRefExpr(selfDecl, dloc, /*implicit=*/true,
+                          AccessSemantics::Ordinary,
+                          selfDecl->getInterfaceType()),
+      new (C) StringLiteralExpr(mangledName, SourceRange(), /*implicit=*/true),
+      IntegerLiteralExpr::createFromUnsigned(C, argumentCount, sloc),
+  };
+  DeclName beginName(C, C.Id_traceDistributedEncodeArgumentsBegin,
+                     {C.Id_targetActor, C.Id_targetIdentifier,
+                      C.Id_argumentCount});
+  auto *beginCall = CallExpr::createImplicit(
+      C, UnresolvedDeclRefExpr::createImplicit(C, beginName),
+      ArgumentList::forImplicitCallTo(DeclNameRef(beginName), beginArgs, C));
+
+  stmts.push_back(PatternBindingDecl::createImplicit(
+      C, StaticSpellingKind::None, NamedPattern::createImplicit(C, spanIDVar),
+      beginCall, thunk));
+  stmts.push_back(spanIDVar);
+
+  return spanIDVar;
+}
+
+/// Wrap the invocation encoding statements so the encoding interval is closed
+/// on every path out of them:
+///
+///   do {
+///     <encodingStmts>
+///     _traceDistributedEncodeArgumentsEnd($encodeSpanID)
+///   } catch let $encodeError {
+///     _traceDistributedEncodeArgumentsEnd($encodeSpanID, error: $encodeError)
+///     throw $encodeError
+///   }
+static DoCatchStmt *
+synthesizeTraceEncodeArguments(ASTContext &C, SourceLoc sloc, DeclNameLoc dloc,
+                               AbstractFunctionDecl *thunk,
+                               VarDecl *spanIDVar,
+                               ArrayRef<ASTNode> encodingStmts) {
+  auto implicit = true;
+
+  VarDecl *errorVar = VarDeclBuilder(thunk, C.getIdentifier("$encodeError"))
+                          .introducer(VarDecl::Introducer::Let);
+
+  // Closes the encoding interval. Passing no error means the encoding
+  // succeeded; passing one reports the error's type into the trace.
+  //
+  // The callee is referenced by its base name and the labels are attached to
+  // the arguments, rather than forming a compound 'DeclName'. A compound name
+  // has to spell the callee's *entire* parameter list, so it would stop
+  // resolving the moment another defaulted parameter is added.
+  auto endEncodingCall = [&](bool failed) -> Expr * {
+    SmallVector<Argument, 2> args;
+
+    args.push_back(Argument(sloc, Identifier(),
+                            new (C) DeclRefExpr(ConcreteDeclRef(spanIDVar),
+                                                dloc, implicit)));
+    if (failed) {
+      args.push_back(Argument(sloc, C.Id_error,
+                              new (C) DeclRefExpr(ConcreteDeclRef(errorVar),
+                                                  dloc, implicit)));
+    }
+
+    DeclNameRef name(C.Id_traceDistributedEncodeArgumentsEnd);
+    return CallExpr::createImplicit(
+        C, new (C) UnresolvedDeclRefExpr(name, DeclRefKind::Ordinary, dloc),
+        ArgumentList::createImplicit(C, args));
+  };
+
+  // --- The 'do' body: the encoding itself, then close the interval
+  SmallVector<ASTNode, 8> doBodyStmts(encodingStmts.begin(),
+                                      encodingStmts.end());
+  doBodyStmts.push_back(endEncodingCall(/*failed=*/false));
+  auto *doBody = BraceStmt::create(C, sloc, doBodyStmts, sloc, implicit);
+
+  // --- 'catch let $encodeError': close the interval reporting the error type,
+  // then rethrow
+  auto *errorPattern = NamedPattern::createImplicit(C, errorVar);
+
+  SmallVector<ASTNode, 2> catchBodyStmts;
+  catchBodyStmts.push_back(endEncodingCall(/*failed=*/true));
+  catchBodyStmts.push_back(new (C) ThrowStmt(
+      sloc, new (C) DeclRefExpr(ConcreteDeclRef(errorVar), dloc, implicit)));
+  auto *catchBody = BraceStmt::create(C, sloc, catchBodyStmts, sloc, implicit);
+
+  auto *caseStmt = CaseStmt::createImplicit(
+      C, CaseParentKind::DoCatch,
+      {CaseLabelItem(errorPattern)}, catchBody);
+
+  return DoCatchStmt::create(thunk, LabeledStmtInfo(), sloc, sloc, TypeLoc(),
+                             doBody, {caseStmt}, implicit);
 }
 
 static std::pair<BraceStmt *, bool>
@@ -183,7 +436,7 @@ deriveBodyDistributed_thunk(AbstractFunctionDecl *thunk, void *context) {
   // --- self.actorSystem
   auto systemRefExpr =
       UnresolvedDotExpr::createImplicit(
-          C, new (C) DeclRefExpr(selfDecl, dloc, implicit), //  TODO: make createImplicit
+          C, new (C) DeclRefExpr(selfDecl, dloc, implicit),
           C.Id_actorSystem);
 
   VarDecl *systemVar =
@@ -220,8 +473,24 @@ deriveBodyDistributed_thunk(AbstractFunctionDecl *thunk, void *context) {
     remoteBranchStmts.push_back(invocationVar);
   }
 
+  // --- Mangle the thunk name
+  auto mangledAccessorRecordName =
+      mangleDistributedThunkForAccessorRecordName(C, thunk);
+
+  // === Begin measuring how long encoding the invocation takes. The interval is
+  // closed right after 'doneRecording' below, and also on the throwing path out
+  // of any of the encoding calls, so it is never left open
+  VarDecl *encodeSpanIDVar = synthesizeTraceEncodeArgumentsBegin(
+      C, sloc, dloc, thunk, selfDecl, mangledAccessorRecordName,
+      func->getParameters()->size(), remoteBranchStmts);
+
+  // The encoding statements are collected separately so they can be wrapped in
+  // a 'do'/'catch' that closes the encoding interval on every path
+  SmallVector<ASTNode, 8> encodingStmts;
+
   // --- Recording invocation details
   // -- recordGenericSubstitution(s)
+  // TODO: trace all these encoding calls as well so we can record timing for them?
   if (auto genEnv = thunk->getGenericEnvironment()) {
     auto recordGenericSubstitutionName =
         DeclName(C, C.Id_recordGenericSubstitution,
@@ -251,7 +520,7 @@ deriveBodyDistributed_thunk(AbstractFunctionDecl *thunk, void *context) {
           recordGenericSubArgsList);
       recordGenericSub = TryExpr::createImplicit(C, sloc, recordGenericSub);
 
-      remoteBranchStmts.push_back(recordGenericSub);
+      encodingStmts.push_back(recordGenericSub);
     }
   }
 
@@ -355,8 +624,8 @@ deriveBodyDistributed_thunk(AbstractFunctionDecl *thunk, void *context) {
         auto callArgPB = PatternBindingDecl::createImplicit(
             C, StaticSpellingKind::None, callArgPattern, initCallArgCallExpr, thunk);
 
-        remoteBranchStmts.push_back(callArgPB);
-        remoteBranchStmts.push_back(callArgVar);
+        encodingStmts.push_back(callArgPB);
+        encodingStmts.push_back(callArgVar);
 
         /// --- Pass the argumentRepr to the recordArgument function
         auto recordArgArgsList = ArgumentList::forImplicitCallTo(
@@ -376,7 +645,7 @@ deriveBodyDistributed_thunk(AbstractFunctionDecl *thunk, void *context) {
                     recordArgumentName),
                 recordArgArgsList));
 
-        remoteBranchStmts.push_back(tryRecordArgExpr);
+        encodingStmts.push_back(tryRecordArgExpr);
       }
     }
   }
@@ -404,7 +673,7 @@ deriveBodyDistributed_thunk(AbstractFunctionDecl *thunk, void *context) {
                 recordErrorTypeName),
             recordArgsList));
 
-    remoteBranchStmts.push_back(tryRecordErrorTyExpr);
+    encodingStmts.push_back(tryRecordErrorTyExpr);
   }
 
   // -- recordReturnType
@@ -437,7 +706,7 @@ deriveBodyDistributed_thunk(AbstractFunctionDecl *thunk, void *context) {
                 recordReturnTypeName),
             recordArgsList));
 
-    remoteBranchStmts.push_back(tryRecordReturnTyExpr);
+    encodingStmts.push_back(tryRecordReturnTyExpr);
   }
 
   // -- doneRecording
@@ -457,8 +726,13 @@ deriveBodyDistributed_thunk(AbstractFunctionDecl *thunk, void *context) {
                 doneRecordingName),
             argsList));
 
-    remoteBranchStmts.push_back(tryDoneRecordingExpr);
+    encodingStmts.push_back(tryDoneRecordingExpr);
   }
+
+  // === Wrap the encoding in a 'do'/'catch' that closes the encoding interval,
+  // marking it failed if any of the 'record...' calls threw
+  remoteBranchStmts.push_back(synthesizeTraceEncodeArguments(
+      C, sloc, dloc, thunk, encodeSpanIDVar, encodingStmts));
 
   // === Prepare the 'RemoteCallTarget'
   VarDecl *targetVar = VarDeclBuilder(thunk, C.Id_target)
@@ -466,14 +740,9 @@ deriveBodyDistributed_thunk(AbstractFunctionDecl *thunk, void *context) {
                            .type(remoteCallTargetTy);
 
   {
-    // --- Mangle the thunk name
-    auto mangledAccessorRecordName =
-        mangleDistributedThunkForAccessorRecordName(C, thunk);
-
     StringLiteralExpr *mangledTargetStringLiteral =
         new (C) StringLiteralExpr(mangledAccessorRecordName,
                                   SourceRange(), implicit);
-
     // --- let target = RemoteCallTarget(<mangled name>)
     Pattern *targetPattern = NamedPattern::createImplicit(C, targetVar);
 
@@ -574,8 +843,12 @@ deriveBodyDistributed_thunk(AbstractFunctionDecl *thunk, void *context) {
         CallExpr::createImplicit(C, systemRemoteCallRef, remoteCallArgs);
     remoteCallExpr = AwaitExpr::createImplicit(C, sloc, remoteCallExpr);
     remoteCallExpr = TryExpr::createImplicit(C, sloc, remoteCallExpr);
-    auto returnRemoteCall = ReturnStmt::createImplicit(C, sloc, remoteCallExpr);
-    remoteBranchStmts.push_back(returnRemoteCall);
+    // Measure the outbound remote-call interval around exactly this call: the
+    // wrapper begins the interval, runs the call, then closes it on both the
+    // returning and the throwing path and produces its result.
+    remoteBranchStmts.push_back(wrapTraceRemoteCall(
+        C, sloc, dloc, thunk, selfDecl, mangledAccessorRecordName,
+        remoteCallExpr, isVoidReturn, remoteBranchStmts));
   }
 
   // ---------------------------------------------------------------------------

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -103,7 +103,7 @@ set(SWIFT_RUNTIME_CONCURRENCY_C_SOURCES
   TaskGroup.cpp
   TaskLocal.cpp
   ThreadingError.cpp
-  TracingSignpost.cpp
+  TracingConcurrencySignpost.cpp
   AsyncStream.cpp
   linker-support/magic-symbols-for-install-name.c
 )

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -108,7 +108,7 @@ set(SWIFT_RUNTIME_CONCURRENCY_C_SOURCES
   TaskLocal.cpp
   TaskRegistry.cpp
   ThreadingError.cpp
-  TracingSignpost.cpp
+  TracingConcurrencySignpost.cpp
   AsyncStream.cpp
   linker-support/magic-symbols-for-install-name.c
 )

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -26,7 +26,7 @@
 #include "TaskGroupPrivate.h"
 #include "TaskLocal.h"
 #include "TaskPrivate.h"
-#include "Tracing.h"
+#include "TracingConcurrency.h"
 #include "swift/ABI/Metadata.h"
 #include "swift/ABI/Task.h"
 #include "swift/ABI/TaskOptions.h"

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -27,7 +27,7 @@
 #include "TaskLocal.h"
 #include "TaskPrivate.h"
 #include "TaskRegistry.h"
-#include "Tracing.h"
+#include "TracingConcurrency.h"
 #include "swift/ABI/Metadata.h"
 #include "swift/ABI/Task.h"
 #include "swift/ABI/TaskOptions.h"

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -19,7 +19,7 @@
 
 #include "Error.h"
 #include "TaskLocal.h"
-#include "Tracing.h"
+#include "TracingConcurrency.h"
 #include "swift/ABI/Metadata.h"
 #include "swift/ABI/Task.h"
 #include "swift/ABI/TaskStatus.h"

--- a/stdlib/public/Concurrency/TracingConcurrency.h
+++ b/stdlib/public/Concurrency/TracingConcurrency.h
@@ -131,9 +131,9 @@ void task_switch_executor(AsyncTask *task, SerialExecutorRef serialExecutor,
 } // namespace swift
 
 #if SWIFT_STDLIB_TRACING
-#include "TracingSignpost.h"
+#include "TracingConcurrencySignpost.h"
 #else
-#include "TracingStubs.h"
+#include "TracingConcurrencyStubs.h"
 #endif
 
 #endif

--- a/stdlib/public/Concurrency/TracingConcurrencySignpost.cpp
+++ b/stdlib/public/Concurrency/TracingConcurrencySignpost.cpp
@@ -16,7 +16,7 @@
 
 #if SWIFT_STDLIB_TRACING
 
-#include "TracingSignpost.h"
+#include "TracingConcurrencySignpost.h"
 #include "swift/Runtime/EnvironmentVariables.h"
 #include <stdio.h>
 

--- a/stdlib/public/Concurrency/TracingConcurrencySignpost.h
+++ b/stdlib/public/Concurrency/TracingConcurrencySignpost.h
@@ -18,7 +18,7 @@
 #define SWIFT_CONCURRENCY_TRACINGSIGNPOST_H
 
 #include "TaskPrivate.h"
-#include "Tracing.h"
+#include "TracingConcurrency.h"
 #include "swift/ABI/Task.h"
 #include "swift/Basic/Lazy.h"
 #include "swift/Runtime/Casting.h"

--- a/stdlib/public/Concurrency/TracingConcurrencyStubs.h
+++ b/stdlib/public/Concurrency/TracingConcurrencyStubs.h
@@ -17,7 +17,7 @@
 #ifndef SWIFT_CONCURRENCY_TRACINGSIGNPOST_H
 #define SWIFT_CONCURRENCY_TRACINGSIGNPOST_H
 
-#include "Tracing.h"
+#include "TracingConcurrency.h"
 #include "swift/ABI/Executor.h"
 
 namespace swift {

--- a/stdlib/public/Distributed/CMakeLists.txt
+++ b/stdlib/public/Distributed/CMakeLists.txt
@@ -35,6 +35,11 @@ add_swift_target_library(swiftDistributed ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS
   DistributedMetadata.swift
   LocalTestingDistributedActorSystem.swift
 
+  # Tracing
+  TracingDistributed.swift
+  TracingDistributed.cpp
+  TracingDistributedSignpost.cpp
+
   SWIFT_MODULE_DEPENDS_IOS ${swift_distributed_darwin_dependencies}
   SWIFT_MODULE_DEPENDS_OSX ${swift_distributed_darwin_dependencies}
   SWIFT_MODULE_DEPENDS_TVOS ${swift_distributed_darwin_dependencies}

--- a/stdlib/public/Distributed/DistributedActor.cpp
+++ b/stdlib/public/Distributed/DistributedActor.cpp
@@ -20,17 +20,27 @@
 #include "swift/Basic/Casting.h"
 #include "swift/Runtime/AccessibleFunction.h"
 #include "swift/Runtime/Concurrency.h"
+#include "TracingDistributed.h"
 
 using namespace swift;
 
 static const AccessibleFunctionRecord *
 findDistributedAccessor(const char *targetNameStart, size_t targetNameLength) {
-  if (auto *func = runtime::swift_findAccessibleFunction(targetNameStart,
-                                                         targetNameLength)) {
-    assert(func->Flags.isDistributed());
-    return func;
+  auto record = runtime::swift_findAccessibleFunction(targetNameStart, targetNameLength);
+
+  if (distributed::trace::distributed_trace_is_enabled()) {
+    distributed::trace::distributed_find_accessible_function(
+        targetNameStart, targetNameLength,
+        record,
+        record ? record->Name.get()                : nullptr,
+        record ? record->GenericEnvironment.get()  : nullptr,
+        record ? *record->Function.get()           : nullptr
+    );
   }
-  return nullptr;
+
+  assert((!record || record->Flags.isDistributed()) &&
+         "Found distributed accessor was not 'distributed'!");
+  return record;
 }
 
 

--- a/stdlib/public/Distributed/DistributedActorSystem.swift
+++ b/stdlib/public/Distributed/DistributedActorSystem.swift
@@ -436,6 +436,46 @@ extension DistributedActorSystem {
     let targetName = target.identifier
     let targetNameUTF8 = Array(targetName.utf8)
 
+    // Measure the whole inbound execution: decoding, invoking the target and
+    // the result handler. The nested phases (decode, invoke) draw inside it.
+    // TODO: include more information like the number of decoded args etc?
+    var executeSpanID: UInt64 = _traceDistributedExecuteTarget(
+      targetActor: actor, targetIdentifier: target.identifier)
+    // Closes the execution interval. Calling this more than once is harmless,
+    // only the first call is recorded. The 'defer' below guarantees the
+    // interval is closed however we leave this function.
+    func endExecuteSpan(error: (any Error)? = nil, failed: Bool = false) {
+      guard executeSpanID != 0 else { return }
+      _traceDistributedExecuteTargetEnd(executeSpanID, error: error,
+                                        failed: failed)
+      executeSpanID = 0
+    }
+    defer {
+      // A 'defer' cannot see the error that is propagating, so this only
+      // reports that the execution did not run to completion
+      endExecuteSpan(failed: true)
+    }
+
+    // Measure how long decoding the incoming invocation takes. Note that the
+    // individual argument values are decoded by the distributed accessor
+    // (via 'decodeNextArgument'), so they are not part of this interval.
+    var decodeSpanID: UInt64 = _traceDistributedDecodeArgumentsBegin(
+      targetActor: actor, targetIdentifier: target.identifier)
+    // Closes the decoding interval. Calling this more than once is harmless,
+    // only the first call is recorded. The 'defer' below guarantees the
+    // interval is closed even when decoding throws.
+    func endDecodeSpan(_ argumentCount: Int, failed: Bool = false) {
+      guard decodeSpanID != 0 else { return }
+      _traceDistributedDecodeArgumentsEnd(
+        decodeSpanID, argumentCount: argumentCount, failed: failed)
+      decodeSpanID = 0
+    }
+    defer {
+      // A 'defer' cannot see the error that is propagating, so this only
+      // reports that decoding did not run to completion
+      endDecodeSpan(0, failed: true)
+    }
+
     // Gen the generic environment (if any) associated with the target.
     let genericEnv =
       targetNameUTF8.withUnsafeBufferPointer { targetNameUTF8 in
@@ -576,9 +616,32 @@ extension DistributedActorSystem {
       _openExistential(returnTypeFromTypeInfo, do: doDestroyReturnTypeBuffer)
     }
 
+    // Measure the execution of the target itself
+    var invokeSpanID: UInt64 = 0
+    // Closes the execution interval. Calling this more than once is harmless,
+    // only the first call is recorded. The 'defer' below guarantees the
+    // interval is closed however we leave this function.
+    func endInvokeSpan(error: (any Error)? = nil, failed: Bool = false) {
+      guard invokeSpanID != 0 else { return }
+      _traceDistributedInvokeTargetEnd(invokeSpanID, error: error,
+                                       failed: failed)
+      invokeSpanID = 0
+    }
+    defer {
+      // A 'defer' cannot see the error that is propagating, so this only
+      // reports that the target did not run to completion
+      endInvokeSpan(failed: true)
+    }
+
     do {
       let returnType = try invocationDecoder.decodeReturnType() ?? returnTypeFromTypeInfo
       // let errorType = try invocationDecoder.decodeErrorType() // TODO(distributed): decide how to use when typed throws are done
+
+      // Decoding of the invocation is complete
+      endDecodeSpan(argumentTypes.count)
+
+      invokeSpanID = _traceDistributedInvokeTargetBegin(
+        targetActor: actor, targetIdentifier: target.identifier)
 
       // Execute the target!
       try unsafe await _executeDistributedTarget(
@@ -596,6 +659,9 @@ extension DistributedActorSystem {
       // we must properly deinitialize it.
       executeDistributedTargetHasThrown = false
 
+      // The target ran to completion; the result handler is invoked next
+      endInvokeSpan()
+
       if returnType == Void.self {
         try await handler.onReturnVoid()
       } else {
@@ -605,7 +671,22 @@ extension DistributedActorSystem {
           metatype: returnType
         )
       }
+
+      _traceDistributedInvokeResultHandler(
+        targetActor: actor, targetIdentifier: target.identifier, error: nil)
+
+      // The whole inbound execution ran to completion
+      endExecuteSpan()
     } catch {
+      // Unlike the 'defer', here the error is in hand, so the execution
+      // interval can report which error type it failed with
+      endInvokeSpan(error: error)
+
+      _traceDistributedInvokeResultHandler(
+        targetActor: actor, targetIdentifier: target.identifier, error: error)
+
+      endExecuteSpan(error: error)
+
       try await handler.onThrow(error: error)
     }
   }

--- a/stdlib/public/Distributed/DistributedActorSystem.swift
+++ b/stdlib/public/Distributed/DistributedActorSystem.swift
@@ -469,6 +469,46 @@ extension DistributedActorSystem {
     let targetName = target.identifier
     let targetNameUTF8 = Array(targetName.utf8)
 
+    // Measure the whole inbound execution: decoding, invoking the target and
+    // the result handler. The nested phases (decode, invoke) draw inside it.
+    // TODO: include more information like the number of decoded args etc?
+    var executeSpanID: UInt64 = _traceDistributedExecuteTarget(
+      targetActor: actor, targetIdentifier: target.identifier)
+    // Closes the execution interval. Calling this more than once is harmless,
+    // only the first call is recorded. The 'defer' below guarantees the
+    // interval is closed however we leave this function.
+    func endExecuteSpan(error: (any Error)? = nil, failed: Bool = false) {
+      guard executeSpanID != 0 else { return }
+      _traceDistributedExecuteTargetEnd(executeSpanID, error: error,
+                                        failed: failed)
+      executeSpanID = 0
+    }
+    defer {
+      // A 'defer' cannot see the error that is propagating, so this only
+      // reports that the execution did not run to completion
+      endExecuteSpan(failed: true)
+    }
+
+    // Measure how long decoding the incoming invocation takes. Note that the
+    // individual argument values are decoded by the distributed accessor
+    // (via 'decodeNextArgument'), so they are not part of this interval.
+    var decodeSpanID: UInt64 = _traceDistributedDecodeArgumentsBegin(
+      targetActor: actor, targetIdentifier: target.identifier)
+    // Closes the decoding interval. Calling this more than once is harmless,
+    // only the first call is recorded. The 'defer' below guarantees the
+    // interval is closed even when decoding throws.
+    func endDecodeSpan(_ argumentCount: Int, failed: Bool = false) {
+      guard decodeSpanID != 0 else { return }
+      _traceDistributedDecodeArgumentsEnd(
+        decodeSpanID, argumentCount: argumentCount, failed: failed)
+      decodeSpanID = 0
+    }
+    defer {
+      // A 'defer' cannot see the error that is propagating, so this only
+      // reports that decoding did not run to completion
+      endDecodeSpan(0, failed: true)
+    }
+
     // Gen the generic environment (if any) associated with the target.
     let genericEnv =
       targetNameUTF8.withUnsafeBufferPointer { targetNameUTF8 in
@@ -623,9 +663,32 @@ extension DistributedActorSystem {
       _openExistential(returnTypeFromTypeInfo, do: doDestroyReturnTypeBuffer)
     }
 
+    // Measure the execution of the target itself
+    var invokeSpanID: UInt64 = 0
+    // Closes the execution interval. Calling this more than once is harmless,
+    // only the first call is recorded. The 'defer' below guarantees the
+    // interval is closed however we leave this function.
+    func endInvokeSpan(error: (any Error)? = nil, failed: Bool = false) {
+      guard invokeSpanID != 0 else { return }
+      _traceDistributedInvokeTargetEnd(invokeSpanID, error: error,
+                                       failed: failed)
+      invokeSpanID = 0
+    }
+    defer {
+      // A 'defer' cannot see the error that is propagating, so this only
+      // reports that the target did not run to completion
+      endInvokeSpan(failed: true)
+    }
+
     do {
       let returnType = try invocationDecoder.decodeReturnType() ?? returnTypeFromTypeInfo
       // let errorType = try invocationDecoder.decodeErrorType() // TODO(distributed): decide how to use when typed throws are done
+
+      // Decoding of the invocation is complete
+      endDecodeSpan(argumentTypes.count)
+
+      invokeSpanID = _traceDistributedInvokeTargetBegin(
+        targetActor: actor, targetIdentifier: target.identifier)
 
       // Execute the target!
       try unsafe await _executeDistributedTarget(
@@ -643,6 +706,9 @@ extension DistributedActorSystem {
       // we must properly deinitialize it.
       executeDistributedTargetHasThrown = false
 
+      // The target ran to completion; the result handler is invoked next
+      endInvokeSpan()
+
       if returnType == Void.self {
         try await handler.onReturnVoid()
       } else {
@@ -652,7 +718,22 @@ extension DistributedActorSystem {
           metatype: returnType
         )
       }
+
+      _traceDistributedInvokeResultHandler(
+        targetActor: actor, targetIdentifier: target.identifier, error: nil)
+
+      // The whole inbound execution ran to completion
+      endExecuteSpan()
     } catch {
+      // Unlike the 'defer', here the error is in hand, so the execution
+      // interval can report which error type it failed with
+      endInvokeSpan(error: error)
+
+      _traceDistributedInvokeResultHandler(
+        targetActor: actor, targetIdentifier: target.identifier, error: error)
+
+      endExecuteSpan(error: error)
+
       try await handler.onThrow(error: error)
     }
   }

--- a/stdlib/public/Distributed/TracingDistributed.cpp
+++ b/stdlib/public/Distributed/TracingDistributed.cpp
@@ -1,0 +1,122 @@
+///===--- TracingDistributed.cpp - Distributed tracing runtime ------------===///
+///
+/// This source file is part of the Swift.org open source project
+///
+/// Copyright (c) 2024 - 2025 Apple Inc. and the Swift project authors
+/// Licensed under Apache License v2.0 with Runtime Library Exception
+///
+/// See https://swift.org/LICENSE.txt for license information
+/// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+///
+///===----------------------------------------------------------------------===///
+///
+/// Export some tracing functions which need to be called from Swift.
+///
+///===----------------------------------------------------------------------===///
+
+#include "swift/ABI/HeapObject.h"
+#include "TracingDistributed.h"
+
+using namespace swift;
+
+SWIFT_CC(swift)
+SWIFT_EXPORT_FROM(swiftDistributed)
+bool swift_distributed_trace_is_enabled() {
+  return distributed::trace::distributed_trace_is_enabled();
+}
+
+SWIFT_CC(swift)
+SWIFT_EXPORT_FROM(swiftDistributed)
+uint64_t swift_distributed_trace_remote_call_outbound_begin(
+    HeapObject *targetActor,
+    const char *targetActorID,
+    const char *targetIdentifier) {
+  return distributed::trace::distributed_remote_call_outbound_begin(
+      targetActor, targetActorID, targetIdentifier);
+}
+
+SWIFT_CC(swift)
+SWIFT_EXPORT_FROM(swiftDistributed)
+void swift_distributed_trace_remote_call_outbound_end(uint64_t spanID,
+                                                      const char *errorType) {
+  distributed::trace::distributed_remote_call_outbound_end(spanID, errorType);
+}
+
+SWIFT_CC(swift)
+SWIFT_EXPORT_FROM(swiftDistributed)
+uint64_t swift_distributed_trace_encode_arguments_begin(
+    HeapObject *targetActor,
+    const char *targetIdentifier,
+    size_t argumentCount) {
+  return distributed::trace::distributed_encode_arguments_begin(
+      targetActor, targetIdentifier, argumentCount);
+}
+
+SWIFT_CC(swift)
+SWIFT_EXPORT_FROM(swiftDistributed)
+void swift_distributed_trace_encode_arguments_end(uint64_t spanID,
+                                                  const char *errorType) {
+  distributed::trace::distributed_encode_arguments_end(spanID, errorType);
+}
+
+SWIFT_CC(swift)
+SWIFT_EXPORT_FROM(swiftDistributed)
+uint64_t swift_distributed_trace_decode_arguments_begin(
+    HeapObject *targetActor,
+    const char *targetIdentifier) {
+  return distributed::trace::distributed_decode_arguments_begin(
+      targetActor, targetIdentifier);
+}
+
+SWIFT_CC(swift)
+SWIFT_EXPORT_FROM(swiftDistributed)
+void swift_distributed_trace_decode_arguments_end(uint64_t spanID,
+                                                  size_t argumentCount,
+                                                  const char *errorType) {
+  distributed::trace::distributed_decode_arguments_end(spanID, argumentCount,
+                                                       errorType);
+}
+
+SWIFT_CC(swift)
+SWIFT_EXPORT_FROM(swiftDistributed)
+uint64_t swift_distributed_trace_execute_target_begin(
+    HeapObject *targetActor,
+    const char *targetActorID,
+    const char *targetIdentifier) {
+  return distributed::trace::distributed_execute_distributed_target_begin(
+      targetActor, targetActorID, targetIdentifier);
+}
+
+SWIFT_CC(swift)
+SWIFT_EXPORT_FROM(swiftDistributed)
+void swift_distributed_trace_execute_target_end(uint64_t spanID,
+                                                const char *errorType) {
+  distributed::trace::distributed_execute_distributed_target_end(spanID,
+                                                                 errorType);
+}
+
+SWIFT_CC(swift)
+SWIFT_EXPORT_FROM(swiftDistributed)
+uint64_t swift_distributed_trace_invoke_target_begin(
+    HeapObject *targetActor,
+    const char *targetIdentifier) {
+  return distributed::trace::distributed_invoke_target_begin(
+      targetActor, targetIdentifier);
+}
+
+SWIFT_CC(swift)
+SWIFT_EXPORT_FROM(swiftDistributed)
+void swift_distributed_trace_invoke_target_end(uint64_t spanID,
+                                               const char *errorType) {
+  distributed::trace::distributed_invoke_target_end(spanID, errorType);
+}
+
+SWIFT_CC(swift)
+SWIFT_EXPORT_FROM(swiftDistributed)
+void swift_distributed_trace_invoke_result_handler(
+    HeapObject *targetActor,
+    const char *targetIdentifier,
+    const char *errorType) {
+  distributed::trace::distributed_invoke_result_handler(
+      targetActor, targetIdentifier, errorType);
+}

--- a/stdlib/public/Distributed/TracingDistributed.h
+++ b/stdlib/public/Distributed/TracingDistributed.h
@@ -1,0 +1,149 @@
+//===--- Tracing.h - Support code for distributed tracing ----------*- C++ -*-//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Support code for tracing events in the distributed runtime
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_DISTRIBUTED_TRACING_H
+#define SWIFT_DISTRIBUTED_TRACING_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+namespace swift {
+class AsyncTask;
+struct HeapObject;
+
+namespace distributed {
+namespace trace {
+
+/// Check if tracing of the Distributed module is enabled.
+///
+/// This can be used to avoid expensive operations (like string formatting)
+/// when tracing is disabled.
+bool distributed_trace_is_enabled();
+
+/// ==== Outbound ------------------------------------------------------------------------------------------------------
+
+/// Begins an interval covering the whole outgoing call: from just before
+/// `remoteCall` is invoked until it returns (or throws), spanning encoding, the
+/// transport round trip and decoding the reply. The nested phases (such as
+/// `distributed_encode_arguments`) draw inside it.
+///
+/// Returns an opaque trace ID which must be passed to
+/// `distributed_remote_call_outbound_end`, or 0 if tracing is not enabled.
+uint64_t distributed_remote_call_outbound_begin(HeapObject *localTargetActor,
+                                                const char *targetActorId,
+                                                const char *targetIdentifier);
+
+/// Ends the interval started by `distributed_remote_call_outbound_begin`.
+///
+/// A `spanId` of 0 is ignored.
+void distributed_remote_call_outbound_end(uint64_t spanId, const char *errorType);
+
+/// Begins an interval covering the encoding of an outgoing invocation:
+/// the generic substitutions, arguments, error and return types, up to and
+/// including `doneRecording`.
+///
+/// Returns an opaque trace ID which must be passed to
+/// `distributed_encode_arguments_end`, or 0 if tracing is not enabled.
+///
+/// Only the actor pointer is recorded, not its type or ID; the
+/// `distributed_remote_call_outbound` interval opened for the same call carries
+/// those, and computing them is comparatively expensive.
+uint64_t distributed_encode_arguments_begin(HeapObject *localTargetActor,
+                                            const char *targetIdentifier,
+                                            size_t argumentCount);
+
+/// Ends the interval started by `distributed_encode_arguments_begin`.
+///
+/// A `spanId` of 0 is ignored.
+void distributed_encode_arguments_end(uint64_t spanId, const char *errorType);
+
+/// ==== Inbound -------------------------------------------------------------------------------------------------------
+
+/// Begins an interval covering the whole inbound execution of a call, from
+/// `DistributedActorSystem/executeDistributedTarget` being invoked until it
+/// returns (or throws), spanning decoding, invoking the target and the result
+/// handler. The nested phases (decode, invoke) draw inside it.
+///
+/// Returns an opaque trace ID which must be passed to
+/// `distributed_execute_distributed_target_end`, or 0 if tracing is not enabled.
+uint64_t distributed_execute_distributed_target_begin(HeapObject *localTargetActor,
+                                                      const char *targetActorId,
+                                                      const char *targetIdentifier);
+
+/// Ends the interval started by `distributed_execute_distributed_target_begin`.
+///
+/// A `spanId` of 0 is ignored.
+void distributed_execute_distributed_target_end(uint64_t spanId, const char *errorType);
+
+/// Begins an interval covering the decoding of an incoming invocation:
+/// the generic substitutions, witness tables, parameter types and return type.
+///
+/// Note that the decoding of the individual argument *values* happens inside
+/// the distributed accessor (via `decodeNextArgument`) and is therefore not
+/// part of this interval.
+///
+/// Returns an opaque trace ID which must be passed to
+/// `distributed_decode_arguments_end`, or 0 if tracing is not enabled.
+uint64_t distributed_decode_arguments_begin(HeapObject *localTargetActor,
+                                            const char *targetIdentifier);
+
+/// Ends the interval started by `distributed_decode_arguments_begin`.
+///
+/// A `spanId` of 0 is ignored.
+void distributed_decode_arguments_end(uint64_t spanId, size_t argumentCount,
+                                      const char *errorType);
+
+/// Begins an interval covering the execution of the distributed target itself:
+/// from invoking the user's function until control returns and the result
+/// handler is about to be invoked. This is the "how long did handling this call
+/// take" measurement, excluding decoding the invocation.
+///
+/// Returns an opaque trace ID which must be passed to
+/// `distributed_invoke_target_end`, or 0 if tracing is not enabled.
+uint64_t distributed_invoke_target_begin(HeapObject *localTargetActor,
+                                         const char *targetIdentifier);
+
+/// Ends the interval started by `distributed_invoke_target_begin`.
+///
+/// A `spanId` of 0 is ignored.
+void distributed_invoke_target_end(uint64_t spanId, const char *errorType);
+
+/// Emitted when `swift_findAccessibleFunction` has found (or not) a distributed function accessor.
+void distributed_find_accessible_function(const char *targetName,
+                                          size_t targetNameLength,
+                                          const void *accessibleFunctionRecord,
+                                          const char *funcName,
+                                          const void *genericEnv,
+                                          const void *funcPtr);
+
+/// Emitted when a result handler is invoked after execution of a local distributed call target completes.
+///
+/// This will always be after `distributed_execute_distributed_target`.
+void distributed_invoke_result_handler(HeapObject *localActor,
+                                       const char *targetIdentifier,
+                                       const char *errorType);
+
+} // namespace trace
+} // namespace distributed
+} // namespace swift
+
+#if SWIFT_STDLIB_TRACING
+#include "TracingDistributedSignpost.h"
+#else
+#include "TracingDistributedStubs.h"
+#endif
+
+#endif

--- a/stdlib/public/Distributed/TracingDistributed.swift
+++ b/stdlib/public/Distributed/TracingDistributed.swift
@@ -1,0 +1,381 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Swift
+
+// The tracing runtime entry points these functions call were introduced in
+// SwiftStdlib 6.5, but the tracing calls themselves are emitted from the
+// distributed thunks synthesized in *client* code, and from
+// 'executeDistributedTarget' below, neither of which can require 6.5.
+//
+// The entry points are therefore declared '@available(SwiftStdlib 6.5, *)' and
+// each of the functions below is '@_alwaysEmitIntoClient' and performs the
+// '#available' check itself. That way callers can invoke them unconditionally
+// and tracing simply does nothing when the runtime does not provide it.
+
+/// Check if tracing of the Distributed module is currently enabled.
+///
+/// Use this to avoid expensive operations (like string interpolation) when
+/// tracing is disabled.
+@available(SwiftStdlib 5.7, *)
+@_alwaysEmitIntoClient
+public func _distributedTraceIsEnabled() -> Bool {
+  if #available(anyAppleOS 9999, *) {
+    return _traceDistributedIsEnabled()
+  }
+  return false
+}
+
+/// Invokes `body` with the qualified type name of `error`, or with nil when the
+/// traced operation succeeded.
+///
+/// Pass `failed` to report a failure when no error value is available, as in a
+/// `defer` that cannot see the error propagating out of the operation. `body`
+/// then gets an empty name, which the runtime records as a failure without an
+/// error type.
+///
+/// Only the error's *type* is reported. Its description is deliberately not
+/// traced, because an error value can carry data from the call it failed on,
+/// whereas the type name is safe to log publicly.
+@available(SwiftStdlib 5.7, *)
+@_alwaysEmitIntoClient
+internal func _withDistributedTraceErrorType<Result>(
+  _ error: (any Error)?,
+  failed: Bool = false,
+  _ body: (UnsafePointer<CChar>?) -> Result
+) -> Result {
+  guard let error else {
+    guard failed else { return body(nil) }
+    return "".withCString { namePtr in unsafe body(namePtr) }
+  }
+  return _typeName(type(of: error), qualified: true).withCString { namePtr in
+    unsafe body(namePtr)
+  }
+}
+
+/// Begins an interval measuring the whole outgoing call: from just before
+/// `remoteCall` is invoked until it returns, spanning encoding, the transport
+/// round trip and decoding the reply.
+///
+/// The returned span ID must be passed to `_traceDistributedRemoteCallEnd`. It
+/// is 0 when tracing is disabled, in which case ending the interval is a no-op.
+@available(SwiftStdlib 5.7, *)
+@_alwaysEmitIntoClient
+public func _traceDistributedRemoteCall(
+  targetActor: some DistributedActor,
+  targetIdentifier: String
+) -> UInt64 {
+  guard #available(anyAppleOS 9999, *) else { return 0 }
+  guard _distributedTraceIsEnabled() else { return 0 }
+
+  let targetActorID = "\(targetActor.id)"
+  return targetActorID.withCString { actorIDPtr in
+    unsafe targetIdentifier.withCString { identifierPtr in
+      unsafe _traceRemoteCallOutboundBegin(targetActor, actorIDPtr, identifierPtr)
+    }
+  }
+}
+
+/// Ends the interval started by `_traceDistributedRemoteCall`.
+@available(SwiftStdlib 5.7, *)
+@_alwaysEmitIntoClient
+public func _traceDistributedRemoteCallEnd(
+  _ spanID: UInt64,
+  error: (any Error)? = nil,
+  failed: Bool = false
+) {
+  guard #available(anyAppleOS 9999, *) else { return }
+  guard spanID != 0 else { return }
+  unsafe _withDistributedTraceErrorType(error, failed: failed) { errorTypePtr in
+    unsafe _traceRemoteCallOutboundEnd(spanID, errorTypePtr)
+  }
+}
+
+/// Begins an interval measuring the encoding of an outgoing invocation:
+/// the generic substitutions, arguments, error and return types, up to and
+/// including `doneRecording`.
+///
+/// The returned span ID must be passed to
+/// `_traceDistributedEncodeArgumentsEnd`. It is 0 when tracing is disabled, in
+/// which case ending the interval is a no-op.
+@available(SwiftStdlib 5.7, *)
+@_alwaysEmitIntoClient
+public func _traceDistributedEncodeArgumentsBegin(
+  targetActor: some DistributedActor,
+  targetIdentifier: String,
+  argumentCount: Int
+) -> UInt64 {
+  guard #available(anyAppleOS 9999, *) else { return 0 }
+  guard _distributedTraceIsEnabled() else { return 0 }
+
+  return targetIdentifier.withCString { identifierPtr in
+    unsafe _traceEncodeArgumentsBegin(targetActor, identifierPtr, argumentCount)
+  }
+}
+
+/// Ends the interval started by `_traceDistributedEncodeArgumentsBegin`.
+@available(SwiftStdlib 5.7, *)
+@_alwaysEmitIntoClient
+public func _traceDistributedEncodeArgumentsEnd(
+  _ spanID: UInt64,
+  error: (any Error)? = nil,
+  failed: Bool = false
+) {
+  guard #available(anyAppleOS 9999, *) else { return }
+  guard spanID != 0 else { return }
+  unsafe _withDistributedTraceErrorType(error, failed: failed) { errorTypePtr in
+    unsafe _traceEncodeArgumentsEnd(spanID, errorTypePtr)
+  }
+}
+
+/// Begins an interval measuring the decoding of an incoming invocation:
+/// the generic substitutions, witness tables, parameter types and return type.
+///
+/// The decoding of the individual argument *values* happens inside the
+/// distributed accessor (via `decodeNextArgument`) and is therefore not part of
+/// this interval.
+///
+/// The returned span ID must be passed to
+/// `_traceDistributedDecodeArgumentsEnd`. It is 0 when tracing is disabled, in
+/// which case ending the interval is a no-op.
+@available(SwiftStdlib 5.7, *)
+@_alwaysEmitIntoClient
+public func _traceDistributedDecodeArgumentsBegin(
+  targetActor: some DistributedActor,
+  targetIdentifier: String
+) -> UInt64 {
+  guard #available(anyAppleOS 9999, *) else { return 0 }
+  guard _distributedTraceIsEnabled() else { return 0 }
+
+  return targetIdentifier.withCString { identifierPtr in
+    unsafe _traceDecodeArgumentsBegin(targetActor, identifierPtr)
+  }
+}
+
+/// Ends the interval started by `_traceDistributedDecodeArgumentsBegin`.
+@available(SwiftStdlib 5.7, *)
+@_alwaysEmitIntoClient
+public func _traceDistributedDecodeArgumentsEnd(
+  _ spanID: UInt64,
+  argumentCount: Int,
+  error: (any Error)? = nil,
+  failed: Bool = false
+) {
+  guard #available(anyAppleOS 9999, *) else { return }
+  guard spanID != 0 else { return }
+  unsafe _withDistributedTraceErrorType(error, failed: failed) { errorTypePtr in
+    unsafe _traceDecodeArgumentsEnd(spanID, argumentCount, errorTypePtr)
+  }
+}
+
+/// Begins an interval measuring the whole inbound execution of a call, from
+/// `executeDistributedTarget` being invoked until it returns, spanning decoding,
+/// invoking the target and the result handler.
+///
+/// The returned span ID must be passed to
+/// `_traceDistributedExecuteTargetEnd`. It is 0 when tracing is disabled, in
+/// which case ending the interval is a no-op.
+@available(SwiftStdlib 5.7, *)
+@_alwaysEmitIntoClient
+public func _traceDistributedExecuteTarget(
+  targetActor: some DistributedActor,
+  targetIdentifier: String
+) -> UInt64 {
+  guard #available(anyAppleOS 9999, *) else { return 0 }
+  guard _distributedTraceIsEnabled() else { return 0 }
+
+  let targetActorID = "\(targetActor.id)"
+  return targetActorID.withCString { actorIDPtr in
+    unsafe targetIdentifier.withCString { identifierPtr in
+      unsafe _traceExecuteDistributedTargetBegin(targetActor, actorIDPtr, identifierPtr)
+    }
+  }
+}
+
+/// Ends the interval started by `_traceDistributedExecuteTarget`.
+@available(SwiftStdlib 5.7, *)
+@_alwaysEmitIntoClient
+public func _traceDistributedExecuteTargetEnd(
+  _ spanID: UInt64,
+  error: (any Error)? = nil,
+  failed: Bool = false
+) {
+  guard #available(anyAppleOS 9999, *) else { return }
+  guard spanID != 0 else { return }
+  unsafe _withDistributedTraceErrorType(error, failed: failed) { errorTypePtr in
+    unsafe _traceExecuteDistributedTargetEnd(spanID, errorTypePtr)
+  }
+}
+
+/// Begins an interval measuring the execution of the distributed target: from
+/// invoking the user's function until control returns and the result handler is
+/// about to be invoked.
+///
+/// This is the "how long did handling this call take" measurement; decoding the
+/// invocation is measured separately by
+/// `_traceDistributedDecodeArgumentsBegin`.
+///
+/// The returned span ID must be passed to
+/// `_traceDistributedInvokeTargetEnd`. It is 0 when tracing is disabled, in
+/// which case ending the interval is a no-op.
+@available(SwiftStdlib 5.7, *)
+@_alwaysEmitIntoClient
+public func _traceDistributedInvokeTargetBegin(
+  targetActor: some DistributedActor,
+  targetIdentifier: String
+) -> UInt64 {
+  guard #available(anyAppleOS 9999, *) else { return 0 }
+  guard _distributedTraceIsEnabled() else { return 0 }
+
+  return targetIdentifier.withCString { identifierPtr in
+    unsafe _traceInvokeTargetBegin(targetActor, identifierPtr)
+  }
+}
+
+/// Ends the interval started by `_traceDistributedInvokeTargetBegin`.
+@available(SwiftStdlib 5.7, *)
+@_alwaysEmitIntoClient
+public func _traceDistributedInvokeTargetEnd(
+  _ spanID: UInt64,
+  error: (any Error)? = nil,
+  failed: Bool = false
+) {
+  guard #available(anyAppleOS 9999, *) else { return }
+  guard spanID != 0 else { return }
+  unsafe _withDistributedTraceErrorType(error, failed: failed) { errorTypePtr in
+    unsafe _traceInvokeTargetEnd(spanID, errorTypePtr)
+  }
+}
+
+@available(SwiftStdlib 5.7, *)
+@_alwaysEmitIntoClient
+public func _traceDistributedInvokeResultHandler(
+  targetActor: some DistributedActor,
+  targetIdentifier: String,
+  error: (any Error)?
+) {
+  guard #available(anyAppleOS 9999, *) else { return }
+  guard _distributedTraceIsEnabled() else { return }
+
+  targetIdentifier.withCString { identifierPtr in
+    unsafe _withDistributedTraceErrorType(error) { errorTypePtr in
+      unsafe _traceInvokeResultHandler(targetActor, identifierPtr, errorTypePtr)
+    }
+  }
+}
+
+// ==== -----------------------------------------------------------------------
+// MARK: Runtime entry points
+
+@available(SwiftStdlib 6.5, *)
+@usableFromInline
+@_silgen_name("swift_distributed_trace_is_enabled")
+internal func _traceDistributedIsEnabled() -> Bool
+
+@available(SwiftStdlib 6.5, *)
+@usableFromInline
+@_silgen_name("swift_distributed_trace_remote_call_outbound_begin")
+internal func _traceRemoteCallOutboundBegin(
+  _ targetActor: AnyObject,
+  _ targetActorID: UnsafePointer<CChar>?,
+  _ targetIdentifier: UnsafePointer<CChar>?
+) -> UInt64
+
+@available(SwiftStdlib 6.5, *)
+@usableFromInline
+@_silgen_name("swift_distributed_trace_remote_call_outbound_end")
+internal func _traceRemoteCallOutboundEnd(
+  _ spanID: UInt64,
+  _ errorType: UnsafePointer<CChar>?
+)
+
+@available(SwiftStdlib 6.5, *)
+@usableFromInline
+@_silgen_name("swift_distributed_trace_execute_target_begin")
+internal func _traceExecuteDistributedTargetBegin(
+  _ targetActor: AnyObject,
+  _ targetActorID: UnsafePointer<CChar>?,
+  _ targetIdentifier: UnsafePointer<CChar>?
+) -> UInt64
+
+@available(SwiftStdlib 6.5, *)
+@usableFromInline
+@_silgen_name("swift_distributed_trace_execute_target_end")
+internal func _traceExecuteDistributedTargetEnd(
+  _ spanID: UInt64,
+  _ errorType: UnsafePointer<CChar>?
+)
+
+@available(SwiftStdlib 6.5, *)
+@usableFromInline
+@_silgen_name("swift_distributed_trace_encode_arguments_begin")
+internal func _traceEncodeArgumentsBegin(
+  _ targetActor: AnyObject,
+  _ targetIdentifier: UnsafePointer<CChar>?,
+  _ argumentCount: Int
+) -> UInt64
+
+@available(SwiftStdlib 6.5, *)
+@usableFromInline
+@_silgen_name("swift_distributed_trace_encode_arguments_end")
+internal func _traceEncodeArgumentsEnd(
+  _ spanID: UInt64,
+  _ errorType: UnsafePointer<CChar>?
+)
+
+@available(SwiftStdlib 6.5, *)
+@usableFromInline
+@_silgen_name("swift_distributed_trace_decode_arguments_begin")
+internal func _traceDecodeArgumentsBegin(
+  _ targetActor: AnyObject,
+  _ targetIdentifier: UnsafePointer<CChar>?
+) -> UInt64
+
+@available(SwiftStdlib 6.5, *)
+@usableFromInline
+@_silgen_name("swift_distributed_trace_decode_arguments_end")
+internal func _traceDecodeArgumentsEnd(
+  _ spanID: UInt64,
+  _ argumentCount: Int,
+  _ errorType: UnsafePointer<CChar>?
+)
+
+@available(SwiftStdlib 6.5, *)
+@usableFromInline
+@_silgen_name("swift_distributed_trace_invoke_target_begin")
+internal func _traceInvokeTargetBegin(
+  _ targetActor: AnyObject,
+  _ targetIdentifier: UnsafePointer<CChar>?
+) -> UInt64
+
+@available(SwiftStdlib 6.5, *)
+@usableFromInline
+@_silgen_name("swift_distributed_trace_invoke_target_end")
+internal func _traceInvokeTargetEnd(
+  _ spanID: UInt64,
+  _ errorType: UnsafePointer<CChar>?
+)
+
+@available(SwiftStdlib 6.5, *)
+@usableFromInline
+@_silgen_name("swift_distributed_trace_invoke_result_handler")
+internal func _traceInvokeResultHandler(
+  _ targetActor: AnyObject,
+  _ targetIdentifier: UnsafePointer<CChar>?,
+  _ errorType: UnsafePointer<CChar>?
+)
+
+
+
+
+
+

--- a/stdlib/public/Distributed/TracingDistributedSignpost.cpp
+++ b/stdlib/public/Distributed/TracingDistributedSignpost.cpp
@@ -1,0 +1,49 @@
+//===--- TracingSignpost.cpp - Tracing with the signpost API -------*- C++ -*-//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Tracing for Distributed module implemented with the os_signpost API.
+//
+//===----------------------------------------------------------------------===//
+
+#if SWIFT_STDLIB_TRACING
+
+#include "TracingDistributedSignpost.h"
+#include <stdio.h>
+
+#define SWIFT_LOG_DISTRIBUTED_SUBSYSTEM "com.apple.swift.distributed"
+#define SWIFT_LOG_DISTRIBUTED_REMOTE_CALLS_CATEGORY "RemoteCalls"
+
+namespace swift {
+namespace distributed {
+namespace trace {
+
+os_log_t DistributedRemoteCallsLog;
+swift::once_t LogsToken;
+bool TracingEnabled;
+
+void setupLogs(void *unused) {
+  if (!swift::runtime::trace::shouldEnableTracing()) {
+    TracingEnabled = false;
+    return;
+  }
+
+  TracingEnabled = true;
+  DistributedRemoteCallsLog =
+      os_log_create(SWIFT_LOG_DISTRIBUTED_SUBSYSTEM,
+                    SWIFT_LOG_DISTRIBUTED_REMOTE_CALLS_CATEGORY);
+}
+
+} // namespace trace
+} // namespace distributed
+} // namespace swift
+
+#endif

--- a/stdlib/public/Distributed/TracingDistributedSignpost.h
+++ b/stdlib/public/Distributed/TracingDistributedSignpost.h
@@ -1,0 +1,362 @@
+//===--- TracingSignpost.h - Tracing with the signpost API ---------*- C++ -*-//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Distributed tracing implemented with the os_signpost API.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_DISTRIBUTED_TRACINGSIGNPOST_H
+#define SWIFT_DISTRIBUTED_TRACINGSIGNPOST_H
+
+#include "TracingDistributed.h"
+#include "swift/Basic/Lazy.h"
+#include "swift/Runtime/Casting.h"
+#include "swift/Runtime/HeapObject.h"
+#include "swift/Runtime/TracingCommon.h"
+#include <inttypes.h>
+#include <os/log.h>
+#include <os/signpost.h>
+
+// Compatibility notes:
+//
+// These signposts can be read by external software that isn't synced with the
+// Swift runtime build. Changes here must be considered carefully to avoid
+// breaking users of these signposts.
+//
+// We may:
+// * Add new signpost calls with new names. (Keeping in mind that they won't be
+//   picked up by software that doesn't know about them.)
+// * Remove existing calls if the given event is somehow no longer relevant.
+// * Change format strings.
+// * Add format string arguments.
+//
+// We may NOT:
+// * Change the order of existing format string arguments.
+// * Change event names.
+// * Change subsystem names.
+
+#define SWIFT_LOG_DISTRIBUTED_OUTBOUND_REMOTE_CALL_NAME "distributed_outbound_remote_call"
+#define SWIFT_LOG_DISTRIBUTED_OUTBOUND_ENCODE_ARGUMENTS_NAME "distributed_outbound_encode_arguments"
+
+#define SWIFT_LOG_DISTRIBUTED_INBOUND_EXECUTE_TARGET_NAME "distributed_inbound_execute_target"
+#define SWIFT_LOG_DISTRIBUTED_INBOUND_DECODE_ARGUMENTS_NAME "distributed_inbound_decode_arguments"
+#define SWIFT_LOG_DISTRIBUTED_INBOUND_INVOKE_TARGET_NAME "distributed_inbound_invoke_target"
+#define SWIFT_LOG_DISTRIBUTED_INBOUND_FIND_ACCESSIBLE_FUNCTION_NAME "distributed_inbound_find_accessible_function"
+#define SWIFT_LOG_DISTRIBUTED_INBOUND_INVOKE_RESULT_HANDLER_NAME "distributed_inbound_invoke_result_handler"
+
+namespace swift {
+namespace distributed {
+namespace trace {
+
+extern os_log_t DistributedRemoteCallsLog;
+extern swift::once_t LogsToken;
+extern bool TracingEnabled;
+
+void setupLogs(void *unused);
+
+// Check a representative os_signpost function for NULL rather than doing a
+// standard availability check, for better performance if the check doesn't get
+// optimized out.
+#define ENSURE_LOGS(...)                                                       \
+  do {                                                                         \
+    if (!runtime::trace::tracingReady())                                       \
+      return __VA_ARGS__;                                                      \
+    swift::once(LogsToken, setupLogs, nullptr);                                \
+    if (!TracingEnabled)                                                       \
+      return __VA_ARGS__;                                                      \
+  } while (0)
+
+// Every function does ENSURE_LOGS() before making any os_signpost calls, so
+// we can skip availability checking on all the individual calls.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability"
+#pragma clang diagnostic ignored "-Wunguarded-availability-new"
+
+// ==== ------------------------------------------------------------------------
+// MARK: Tracing control
+
+inline bool distributed_trace_is_enabled() {
+  if (!runtime::trace::tracingReady())
+    return false;
+  swift::once(LogsToken, setupLogs, nullptr);
+  return TracingEnabled && os_signpost_enabled(DistributedRemoteCallsLog);
+}
+
+// ==== ------------------------------------------------------------------------
+// MARK: Outbound
+
+inline uint64_t distributed_remote_call_outbound_begin(HeapObject *localTargetActor,
+                                                       const char *targetActorId,
+                                                       const char *targetIdentifier) {
+  ENSURE_LOGS(0);
+
+  if (!os_signpost_enabled(DistributedRemoteCallsLog))
+    return 0;
+
+  auto typeName = swift_getTypeName(swift_getObjectType(localTargetActor),
+                                    /*qualified=*/true);
+
+  auto id = os_signpost_id_generate(DistributedRemoteCallsLog);
+  os_signpost_interval_begin(
+      DistributedRemoteCallsLog, id,
+      SWIFT_LOG_DISTRIBUTED_OUTBOUND_REMOTE_CALL_NAME,
+      "actor=%p"
+      " actorType=%{public}.*s"
+      " targetActorId=%{public}s"
+      " targetFunction=%{public}s",
+      localTargetActor,
+      (int)typeName.length, typeName.data,
+      targetActorId ? targetActorId : "<unknown>",
+      targetIdentifier ? targetIdentifier : "<unknown>");
+  return id;
+}
+
+inline void distributed_remote_call_outbound_end(uint64_t spanId,
+                                                 const char *errorType) {
+  if (!spanId)
+    return;
+
+  ENSURE_LOGS();
+
+  if (!os_signpost_enabled(DistributedRemoteCallsLog))
+    return;
+
+  os_signpost_interval_end(
+      DistributedRemoteCallsLog, spanId,
+      SWIFT_LOG_DISTRIBUTED_OUTBOUND_REMOTE_CALL_NAME,
+      "success=%{bool}d"
+      " errorType=%{public}s",
+      errorType == nullptr,
+      errorType ? errorType : "");
+}
+
+inline uint64_t distributed_encode_arguments_begin(HeapObject *localTargetActor,
+                                                   const char *targetIdentifier,
+                                                   size_t argumentCount) {
+  ENSURE_LOGS(0);
+
+  if (!os_signpost_enabled(DistributedRemoteCallsLog))
+    return 0;
+
+  auto id = os_signpost_id_generate(DistributedRemoteCallsLog);
+  os_signpost_interval_begin(
+      DistributedRemoteCallsLog, id,
+      SWIFT_LOG_DISTRIBUTED_OUTBOUND_ENCODE_ARGUMENTS_NAME,
+      "actor=%p"
+      " targetFunction=%{public}s"
+      " argumentCount=%ld",
+      localTargetActor,
+      targetIdentifier ? targetIdentifier : "<unknown>",
+      (long)argumentCount);
+  return id;
+}
+
+inline void distributed_encode_arguments_end(uint64_t spanId,
+                                             const char *errorType) {
+  if (!spanId)
+    return;
+
+  ENSURE_LOGS();
+
+  if (!os_signpost_enabled(DistributedRemoteCallsLog))
+    return;
+
+  os_signpost_interval_end(
+      DistributedRemoteCallsLog, spanId,
+      SWIFT_LOG_DISTRIBUTED_OUTBOUND_ENCODE_ARGUMENTS_NAME,
+      "success=%{bool}d"
+      " errorType=%{public}s",
+      errorType == nullptr,
+      errorType ? errorType : "");
+}
+
+// ==== ------------------------------------------------------------------------
+// MARK: Inbound
+
+inline uint64_t distributed_execute_distributed_target_begin(HeapObject *localTargetActor,
+                                                             const char *targetActorId,
+                                                             const char *targetIdentifier) {
+  ENSURE_LOGS(0);
+
+  if (!os_signpost_enabled(DistributedRemoteCallsLog))
+    return 0;
+
+  auto typeName = swift_getTypeName(swift_getObjectType(localTargetActor),
+                                    /*qualified=*/true);
+
+  auto id = os_signpost_id_generate(DistributedRemoteCallsLog);
+  os_signpost_interval_begin(
+      DistributedRemoteCallsLog, id,
+      SWIFT_LOG_DISTRIBUTED_INBOUND_EXECUTE_TARGET_NAME,
+      "actor=%p"
+      " actorType=%{public}.*s"
+      " targetActorId=%{public}s"
+      " targetFunction=%{public}s",
+      localTargetActor,
+      (int)typeName.length, typeName.data,
+      targetActorId ? targetActorId : "<unknown>",
+      targetIdentifier ? targetIdentifier : "<unknown>");
+  return id;
+}
+
+inline void distributed_execute_distributed_target_end(uint64_t spanId,
+                                                       const char *errorType) {
+  if (!spanId)
+    return;
+
+  ENSURE_LOGS();
+
+  if (!os_signpost_enabled(DistributedRemoteCallsLog))
+    return;
+
+  os_signpost_interval_end(
+      DistributedRemoteCallsLog, spanId,
+      SWIFT_LOG_DISTRIBUTED_INBOUND_EXECUTE_TARGET_NAME,
+      "success=%{bool}d"
+      " errorType=%{public}s",
+      errorType == nullptr,
+      errorType ? errorType : "");
+}
+
+inline uint64_t distributed_decode_arguments_begin(HeapObject *localTargetActor,
+                                                   const char *targetIdentifier) {
+  ENSURE_LOGS(0);
+
+  if (!os_signpost_enabled(DistributedRemoteCallsLog))
+    return 0;
+
+  auto id = os_signpost_id_generate(DistributedRemoteCallsLog);
+  os_signpost_interval_begin(
+      DistributedRemoteCallsLog, id,
+      SWIFT_LOG_DISTRIBUTED_INBOUND_DECODE_ARGUMENTS_NAME,
+      "actor=%p"
+      " targetFunction=%{public}s",
+      localTargetActor,
+      targetIdentifier ? targetIdentifier : "<unknown>");
+  return id;
+}
+
+inline void distributed_decode_arguments_end(uint64_t spanId,
+                                             size_t argumentCount,
+                                             const char *errorType) {
+  if (!spanId)
+    return;
+
+  ENSURE_LOGS();
+
+  if (!os_signpost_enabled(DistributedRemoteCallsLog))
+    return;
+
+  os_signpost_interval_end(
+      DistributedRemoteCallsLog, spanId,
+      SWIFT_LOG_DISTRIBUTED_INBOUND_DECODE_ARGUMENTS_NAME,
+      "argumentCount=%ld"
+      " success=%{bool}d"
+      " errorType=%{public}s",
+      (long)argumentCount,
+      errorType == nullptr,
+      errorType ? errorType : "");
+}
+
+inline uint64_t distributed_invoke_target_begin(HeapObject *localTargetActor,
+                                                const char *targetIdentifier) {
+  ENSURE_LOGS(0);
+
+  if (!os_signpost_enabled(DistributedRemoteCallsLog))
+    return 0;
+
+  auto id = os_signpost_id_generate(DistributedRemoteCallsLog);
+  os_signpost_interval_begin(
+      DistributedRemoteCallsLog, id,
+      SWIFT_LOG_DISTRIBUTED_INBOUND_INVOKE_TARGET_NAME,
+      "actor=%p"
+      " targetFunction=%{public}s",
+      localTargetActor,
+      targetIdentifier ? targetIdentifier : "<unknown>");
+  return id;
+}
+
+inline void distributed_invoke_target_end(uint64_t spanId,
+                                          const char *errorType) {
+  if (!spanId)
+    return;
+
+  ENSURE_LOGS();
+
+  if (!os_signpost_enabled(DistributedRemoteCallsLog))
+    return;
+
+  os_signpost_interval_end(
+      DistributedRemoteCallsLog, spanId,
+      SWIFT_LOG_DISTRIBUTED_INBOUND_INVOKE_TARGET_NAME,
+      "success=%{bool}d"
+      " errorType=%{public}s",
+      errorType == nullptr,
+      errorType ? errorType : "");
+}
+
+inline void distributed_find_accessible_function(const char *targetName,
+                                                 size_t targetNameLength,
+                                                 const void *accessibleFunctionRecord,
+                                                 const char *funcName,
+                                                 const void *genericEnv,
+                                                 const void *funcPtr) {
+  ENSURE_LOGS();
+
+  if (!os_signpost_enabled(DistributedRemoteCallsLog))
+    return;
+
+  auto id = os_signpost_id_generate(DistributedRemoteCallsLog);
+  os_signpost_event_emit(
+      DistributedRemoteCallsLog, id,
+      SWIFT_LOG_DISTRIBUTED_INBOUND_FIND_ACCESSIBLE_FUNCTION_NAME,
+      "targetName=%{public}.*s"
+      " accessibleFunctionRecord=%p"
+      " funcName=%{public}s"
+      " genericEnv=%p"
+      " funcPtr=%p",
+      (int)targetNameLength, targetName ? targetName : "<no-name>",
+      accessibleFunctionRecord,
+      funcName ? funcName : "<not found>",
+      genericEnv,
+      funcPtr);
+}
+
+inline void distributed_invoke_result_handler(HeapObject *localTargetActor,
+                                              const char *targetIdentifier,
+                                              const char *errorType) {
+  ENSURE_LOGS();
+
+  if (!os_signpost_enabled(DistributedRemoteCallsLog))
+    return;
+
+  auto id = os_signpost_id_generate(DistributedRemoteCallsLog);
+  os_signpost_event_emit(
+      DistributedRemoteCallsLog, id,
+      SWIFT_LOG_DISTRIBUTED_INBOUND_INVOKE_RESULT_HANDLER_NAME,
+      "actor=%p"
+      " targetFunction=%{public}s"
+      " success=%{bool}d"
+      " errorType=%{public}s",
+      localTargetActor,
+      targetIdentifier ? targetIdentifier : "<unknown>",
+      errorType == nullptr,
+      errorType ? errorType : "");
+}
+
+#pragma clang diagnostic pop
+
+} // namespace trace
+} // namespace distributed
+} // namespace swift
+
+#endif

--- a/stdlib/public/Distributed/TracingDistributedStubs.h
+++ b/stdlib/public/Distributed/TracingDistributedStubs.h
@@ -1,0 +1,92 @@
+//===--- TracingStubs.h - Default stub implementation of tracing. --*- C++ -*-//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Distributed tracing stubs for OSes without tracing support.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_DISTRIBUTED_TRACINGSTUBS_H
+#define SWIFT_DISTRIBUTED_TRACINGSTUBS_H
+
+#include "TracingDistributed.h"
+
+namespace swift {
+namespace distributed {
+namespace trace {
+
+inline bool distributed_trace_is_enabled() { return false; }
+
+inline uint64_t distributed_remote_call_outbound_begin(HeapObject *localTargetActor,
+                                                       const char *targetActorID,
+                                                       const char *targetIdentifier) {
+  return 0;
+}
+
+inline void distributed_remote_call_outbound_end(uint64_t spanId,
+                                                 const char *errorType) {
+}
+
+inline uint64_t distributed_encode_arguments_begin(HeapObject *localTargetActor,
+                                                   const char *targetIdentifier,
+                                                   size_t argumentCount) {
+  return 0;
+}
+
+inline void distributed_encode_arguments_end(uint64_t spanId, const char *errorType) {
+}
+
+inline uint64_t distributed_decode_arguments_begin(HeapObject *localTargetActor,
+                                                   const char *targetIdentifier) {
+  return 0;
+}
+
+inline void distributed_decode_arguments_end(uint64_t spanId,
+                                             size_t argumentCount,
+                                             const char *errorType) {
+}
+
+inline uint64_t distributed_invoke_target_begin(HeapObject *localTargetActor,
+                                                const char *targetIdentifier) {
+  return 0;
+}
+
+inline void distributed_invoke_target_end(uint64_t spanId, const char *errorType) {
+}
+
+inline uint64_t distributed_execute_distributed_target_begin(HeapObject *localTargetActor,
+                                                             const char *targetActorID,
+                                                             const char *targetIdentifier) {
+  return 0;
+}
+
+inline void distributed_execute_distributed_target_end(uint64_t spanId,
+                                                       const char *errorType) {
+}
+
+inline void distributed_find_accessible_function(const char *targetName,
+                                                 size_t targetNameLength,
+                                                 const void *accessibleFunctionRecord,
+                                                 const char *funcName,
+                                                 const void *genericEnv,
+                                                 const void *funcPtr) {
+}
+
+inline void distributed_invoke_result_handler(HeapObject *localTargetActor,
+                                              const char *targetIdentifier,
+                                              const char *errorType) {
+}
+
+} // namespace trace
+} // namespace distributed
+} // namespace swift
+
+#endif

--- a/test/Distributed/Runtime/distributed_signpost_tracing.swift
+++ b/test/Distributed/Runtime/distributed_signpost_tracing.swift
@@ -1,0 +1,208 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-future-triple %S/../Inputs/FakeDistributedActorSystems.swift
+
+// The signposts must come out the same way however the caller was compiled, so
+// check an unoptimized and an optimized build.
+// RUN: %target-build-swift -module-name main -target %target-future-triple -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out.Onone -Onone
+// RUN: %target-codesign %t/a.out.Onone
+// RUN: %target-run %t/a.out.Onone | %FileCheck %s
+
+// RUN: %target-build-swift -module-name main -target %target-future-triple -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out.O -O
+// RUN: %target-codesign %t/a.out.O
+// RUN: %target-run %t/a.out.O | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: distributed
+// REQUIRES: OS=macosx
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+// Show what a trace of a distributed call looks like, by CHECK-ing the
+// signposts 'log stream' reports for one. A 'FakeRoundtripActorSystem' drives
+// both sides in this one process, so a single call produces the outbound
+// signposts as well as the inbound ones.
+//
+// The stream is collected while the calls run and printed verbatim afterwards,
+// rather than as it arrives, so the signposts land in one contiguous block that
+// the actor system's own output cannot interleave with.
+
+import Distributed
+import FakeDistributedActorSystems
+import Foundation
+
+typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
+
+/// Accumulates the bytes `log stream` writes. Kept separate from
+/// 'SignpostStream' so the pipe's readability handler does not have to capture
+/// the object that owns the pipe.
+final class StreamBuffer {
+  private let lock = NSLock()
+  private var data = Data()
+
+  func append(_ more: Data) {
+    lock.lock()
+    data.append(more)
+    lock.unlock()
+  }
+
+  var text: String {
+    lock.lock()
+    defer { lock.unlock() }
+    return String(data: data, encoding: .utf8) ?? ""
+  }
+}
+
+/// Collects everything `log stream` reports for this process on the Distributed
+/// subsystem, to be printed once the traced calls are done.
+final class SignpostStream {
+  /// Must match 'SWIFT_LOG_DISTRIBUTED_SUBSYSTEM' in
+  /// stdlib/public/Distributed/TracingDistributedSignpost.cpp
+  static let subsystem = "com.apple.swift.distributed"
+
+  private let process = Process()
+  private let pipe = Pipe()
+  private let buffer = StreamBuffer()
+
+  init() {
+    let pid = ProcessInfo.processInfo.processIdentifier
+
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/log")
+    process.arguments = [
+      "stream",
+      "--signpost",
+      "--predicate",
+      "subsystem == \"\(SignpostStream.subsystem)\""
+        + " AND processIdentifier == \(pid)",
+    ]
+    process.standardOutput = pipe
+    process.standardError = FileHandle.nullDevice
+
+    // Capture the buffer, not 'self': the handler is retained by the pipe,
+    // which this object owns, so capturing 'self' would be a cycle
+    let buffer = self.buffer
+    pipe.fileHandleForReading.readabilityHandler = { handle in
+      let data = handle.availableData
+      guard !data.isEmpty else { return }
+      buffer.append(data)
+    }
+  }
+
+  /// Starts the stream and waits for it to connect to the logging daemon.
+  /// `log stream` prints its header banner before it is actually live, so this
+  /// simply waits long enough for the connection to come up; the earliest
+  /// signposts would otherwise be missed.
+  func start() async throws {
+    try process.run()
+    try await Task.sleep(for: .seconds(5))
+  }
+
+  /// Stops the stream and prints everything it reported, verbatim.
+  func finishAndPrint() async throws {
+    // Give the last signposts time to make it through the daemon
+    try await Task.sleep(for: .seconds(3))
+
+    process.terminate()
+    process.waitUntilExit()
+
+    print(buffer.text)
+  }
+}
+
+enum GreeterError: Error {
+  case boom
+}
+
+distributed actor Greeter {
+  distributed func greet(name: String) -> String {
+    "Hello, \(name)!"
+  }
+
+  distributed func boom() throws -> String {
+    throw GreeterError.boom
+  }
+}
+
+@main struct Main {
+  static func main() async throws {
+    let stream = SignpostStream()
+    try await stream.start()
+
+    let system = DefaultDistributedActorSystem()
+
+    // ==== A call that returns ------------------------------------------------
+    do {
+      let local = Greeter(actorSystem: system)
+      let remote = try Greeter.resolve(id: local.id, using: system)
+
+      let reply = try await remote.greet(name: "Caplin")
+      precondition(reply == "Hello, Caplin!", "unexpected reply: \(reply)")
+    }
+
+    // ==== A call whose target throws -----------------------------------------
+    do {
+      let local = Greeter(actorSystem: system)
+      let remote = try Greeter.resolve(id: local.id, using: system)
+
+      do {
+        _ = try await remote.boom()
+        fatalError("expected 'boom()' to throw")
+      } catch {
+        // expected
+      }
+    }
+
+    try await stream.finishAndPrint()
+
+    // ==== The returning call -------------------------------------------------
+
+    // The whole outbound call is one interval; the thunk opens it, then brackets
+    // encoding the invocation inside it, carrying the target's mangled accessor
+    // record name and how many arguments are being encoded
+    // CHECK:      begin]{{.*}}distributed_outbound_encode_arguments: actor=0x{{[0-9a-f]+}} targetFunction=$s4main7GreeterC5greet4nameS2S_tYaKFTE argumentCount=1
+    // CHECK-NEXT: end]{{.*}}distributed_outbound_encode_arguments: success=true errorType=
+
+    // Only then is 'remoteCall' invoked, inside the outbound remote-call interval
+    // CHECK-NEXT: begin]{{.*}}distributed_outbound_remote_call: actor=0x{{[0-9a-f]+}} actorType=main.Greeter targetActorId={{.*}} targetFunction=$s4main7GreeterC5greet4nameS2S_tYaKFTE
+
+    // The callee side: 'executeDistributedTarget' is one interval spanning
+    // decoding, invoking the target and the result handler
+    // CHECK-NEXT: begin]{{.*}}distributed_inbound_execute_target: actor=0x{{[0-9a-f]+}} actorType=main.Greeter targetActorId={{.*}} targetFunction=$s4main7GreeterC5greet4nameS2S_tYaKFTE
+    // CHECK-NEXT: begin]{{.*}}distributed_inbound_decode_arguments: actor=0x{{[0-9a-f]+}} targetFunction=$s4main7GreeterC5greet4nameS2S_tYaKFTE
+
+    // Looking the accessor up falls inside the decode interval
+    // CHECK-NEXT: event]{{.*}}distributed_inbound_find_accessible_function: targetName=$s4main7GreeterC5greet4nameS2S_tYaKFTE
+    // CHECK-NEXT: end]{{.*}}distributed_inbound_decode_arguments: argumentCount=1 success=true errorType=
+
+    // Executing the target, which decodes the argument values as it goes
+    // CHECK-NEXT: begin]{{.*}}distributed_inbound_invoke_target: actor=0x{{[0-9a-f]+}} targetFunction=$s4main7GreeterC5greet4nameS2S_tYaKFTE
+    // CHECK-NEXT: event]{{.*}}distributed_inbound_find_accessible_function: targetName=$s4main7GreeterC5greet4nameS2S_tYaKFTE
+    // CHECK-NEXT: end]{{.*}}distributed_inbound_invoke_target: success=true errorType=
+    // CHECK-NEXT: event]{{.*}}distributed_inbound_invoke_result_handler: actor=0x{{[0-9a-f]+}} targetFunction=$s4main7GreeterC5greet4nameS2S_tYaKFTE success=true errorType=
+
+    // Then the two enclosing intervals close, innermost (callee) first
+    // CHECK-NEXT: end]{{.*}}distributed_inbound_execute_target: success=true errorType=
+    // CHECK-NEXT: end]{{.*}}distributed_outbound_remote_call: success=true errorType=
+
+    // ==== The throwing call --------------------------------------------------
+
+    // Encoding and decoding still succeed; only the target itself throws
+    // CHECK-NEXT: begin]{{.*}}distributed_outbound_encode_arguments: actor=0x{{[0-9a-f]+}} targetFunction=$s4main7GreeterC4boomSSyYaKFTE argumentCount=0
+    // CHECK-NEXT: end]{{.*}}distributed_outbound_encode_arguments: success=true errorType=
+    // CHECK-NEXT: begin]{{.*}}distributed_outbound_remote_call: {{.*}}targetFunction=$s4main7GreeterC4boomSSyYaKFTE
+    // CHECK-NEXT: begin]{{.*}}distributed_inbound_execute_target: {{.*}}targetFunction=$s4main7GreeterC4boomSSyYaKFTE
+    // CHECK-NEXT: begin]{{.*}}distributed_inbound_decode_arguments: actor=0x{{[0-9a-f]+}} targetFunction=$s4main7GreeterC4boomSSyYaKFTE
+    // CHECK-NEXT: event]{{.*}}distributed_inbound_find_accessible_function: targetName=$s4main7GreeterC4boomSSyYaKFTE
+    // CHECK-NEXT: end]{{.*}}distributed_inbound_decode_arguments: argumentCount=0 success=true errorType=
+    // CHECK-NEXT: begin]{{.*}}distributed_inbound_invoke_target: actor=0x{{[0-9a-f]+}} targetFunction=$s4main7GreeterC4boomSSyYaKFTE
+    // CHECK-NEXT: event]{{.*}}distributed_inbound_find_accessible_function: targetName=$s4main7GreeterC4boomSSyYaKFTE
+
+    // The three nested intervals that reach the error all report the target's
+    // error type: the invoke interval, the enclosing execute interval, and the
+    // outbound remote-call interval; the result handler event carries it too
+    // CHECK-NEXT: end]{{.*}}distributed_inbound_invoke_target: success=false errorType=main.GreeterError
+    // CHECK-NEXT: event]{{.*}}distributed_inbound_invoke_result_handler: actor=0x{{[0-9a-f]+}} targetFunction=$s4main7GreeterC4boomSSyYaKFTE success=false errorType=main.GreeterError
+    // CHECK-NEXT: end]{{.*}}distributed_inbound_execute_target: success=false errorType=main.GreeterError
+    // CHECK-NEXT: end]{{.*}}distributed_outbound_remote_call: success=false errorType=main.GreeterError
+  }
+}

--- a/test/Distributed/SIL/distributed_thunk_tracing.swift
+++ b/test/Distributed/SIL/distributed_thunk_tracing.swift
@@ -1,0 +1,141 @@
+// RUN: %target-swift-emit-silgen %s -target %target-swift-5.7-abi-triple | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s -target %target-swift-5.7-abi-triple | %FileCheck %s --check-prefix=NOAVAIL
+
+// REQUIRES: concurrency
+// REQUIRES: distributed
+// REQUIRES: OS=macosx
+
+// The distributed thunk emits tracing calls on its remote branch: an interval
+// around encoding the invocation, and an interval around the whole 'remoteCall'
+// (the outbound remote-call interval), each closed on both the success and the
+// throwing path.
+//
+// The tracing entry points are '@_alwaysEmitIntoClient' and do their own
+// '#available' check for the tracing runtime, so the thunk calls them
+// unconditionally and no availability check is emitted into the thunk itself.
+// NOAVAIL-NOT: _stdlib_isOSVersionAtLeast
+
+import Distributed
+
+distributed actor DA {
+  typealias ActorSystem = LocalTestingDistributedActorSystem
+
+  // CHECK-LABEL: sil hidden [thunk] [distributed] {{.*}} @$s25distributed_thunk_tracing2DAC5greet4nameS2S_tYaKFTE
+  // CHECK:       bb0({{%[0-9]+}} : @guaranteed $String, [[SELF:%[0-9]+]] : @guaranteed $DA):
+
+  // The thunk only takes the remote branch when the actor is remote
+  // CHECK:       {{%[0-9]+}} = function_ref @swift_distributed_actor_is_remote : $@convention(thin) (@guaranteed AnyObject) -> Bool
+  // CHECK:       {{%[0-9]+}} = apply {{%[0-9]+}}({{%[0-9]+}}) : $@convention(thin) (@guaranteed AnyObject) -> Bool
+  // CHECK:       cond_br {{%[0-9]+}}, [[REMOTE_BB:bb[0-9]+]], {{bb[0-9]+}}
+
+  // === The encode span ID lives in a 'var' box, so the 'catch' further down
+  // reads back the very value the interval was opened with
+  // CHECK:       [[ENCODE_SPAN_BOX:%[0-9]+]] = alloc_box ${ var UInt64 }
+  // CHECK:       [[ENCODE_SPAN_BORROW:%[0-9]+]] = begin_borrow [var_decl] [[ENCODE_SPAN_BOX]]
+  // CHECK:       [[ENCODE_SPAN_ADDR:%[0-9]+]] = project_box [[ENCODE_SPAN_BORROW]], 0
+
+  // The encode interval opens with the target's mangled accessor record name and
+  // the argument count, and is handed 'self' as the actor being called
+  // CHECK:       {{%[0-9]+}} = string_literal utf8 "$s25distributed_thunk_tracing2DAC5greet4nameS2S_tYaKFTE"
+  // CHECK:       [[ENCODE_BEGIN_FN:%[0-9]+]] = function_ref @$s11Distributed06_traceA20EncodeArgumentsBegin11targetActor0F10Identifier13argumentCounts6UInt64Vx_SSSitAA0aG0RzlF : $@convention(thin) <τ_0_0 where τ_0_0 : DistributedActor> (@guaranteed τ_0_0, @guaranteed String, Int) -> UInt64
+  // CHECK:       [[ENCODE_SPAN:%[0-9]+]] = apply [[ENCODE_BEGIN_FN]]<DA>([[SELF]], {{%[0-9]+}}, {{%[0-9]+}}) : $@convention(thin) <τ_0_0 where τ_0_0 : DistributedActor> (@guaranteed τ_0_0, @guaranteed String, Int) -> UInt64
+  // CHECK:       store [[ENCODE_SPAN]] to [trivial] [[ENCODE_SPAN_ADDR]]
+
+  // === The encoding sits inside the interval, and each 'record...' call gets
+  // its own error edge out of it
+  // CHECK:       [[RECORD_ARG:%[0-9]+]] = function_ref @$s11Distributed29LocalTestingInvocationEncoderV14recordArgumentyyAA010RemoteCallG0VyxGKSeRzSERzlF : $@convention(method) <τ_0_0 where τ_0_0 : Decodable, τ_0_0 : Encodable> (@in_guaranteed RemoteCallArgument<τ_0_0>, @inout LocalTestingInvocationEncoder) -> @error any Error
+  // CHECK:       try_apply [[RECORD_ARG]]<String>({{%[0-9]+}}, {{%[0-9]+}}) : $@convention(method) <τ_0_0 where τ_0_0 : Decodable, τ_0_0 : Encodable> (@in_guaranteed RemoteCallArgument<τ_0_0>, @inout LocalTestingInvocationEncoder) -> @error any Error, normal {{bb[0-9]+}}, error [[ARG_ERR_BB:bb[0-9]+]]
+
+  // CHECK:       [[RECORD_RET:%[0-9]+]] = function_ref @$s11Distributed29LocalTestingInvocationEncoderV16recordReturnTypeyyxmKSeRzSERzlF : $@convention(method) <τ_0_0 where τ_0_0 : Decodable, τ_0_0 : Encodable> (@thick τ_0_0.Type, @inout LocalTestingInvocationEncoder) -> @error any Error
+  // CHECK:       try_apply [[RECORD_RET]]<String>({{%[0-9]+}}, {{%[0-9]+}}) : $@convention(method) <τ_0_0 where τ_0_0 : Decodable, τ_0_0 : Encodable> (@thick τ_0_0.Type, @inout LocalTestingInvocationEncoder) -> @error any Error, normal {{bb[0-9]+}}, error [[RET_ERR_BB:bb[0-9]+]]
+
+  // CHECK:       [[DONE_REC:%[0-9]+]] = function_ref @$s11Distributed29LocalTestingInvocationEncoderV13doneRecordingyyKF : $@convention(method) (@inout LocalTestingInvocationEncoder) -> @error any Error
+  // CHECK:       try_apply [[DONE_REC]]({{%[0-9]+}}) : $@convention(method) (@inout LocalTestingInvocationEncoder) -> @error any Error, normal {{bb[0-9]+}}, error [[DONE_ERR_BB:bb[0-9]+]]
+
+  // === Encoding done: the span ID is read back out of the box and the encode
+  // interval is closed with no error, so the trace records it as a success
+  // CHECK:       [[ENCODE_SPAN_READ:%[0-9]+]] = begin_access [read] [unknown] [[ENCODE_SPAN_ADDR]]
+  // CHECK:       [[ENCODE_SPAN_VAL:%[0-9]+]] = load [trivial] [[ENCODE_SPAN_READ]]
+  // CHECK:       [[ENCODE_NO_ERROR:%[0-9]+]] = enum $Optional<any Error>, #Optional.none!enumelt
+  // CHECK:       [[ENCODE_FAILED_DFLT:%[0-9]+]] = function_ref @$s11Distributed06_traceA18EncodeArgumentsEnd_5error6failedys6UInt64V_s5Error_pSgSbtFfA1_ : $@convention(thin) () -> Bool
+  // CHECK:       [[ENCODE_FAILED:%[0-9]+]] = apply [[ENCODE_FAILED_DFLT]]() : $@convention(thin) () -> Bool
+  // CHECK:       [[ENCODE_END_FN:%[0-9]+]] = function_ref @$s11Distributed06_traceA18EncodeArgumentsEnd_5error6failedys6UInt64V_s5Error_pSgSbtF : $@convention(thin) (UInt64, @guaranteed Optional<any Error>, Bool) -> ()
+  // CHECK:       {{%[0-9]+}} = apply [[ENCODE_END_FN]]([[ENCODE_SPAN_VAL]], [[ENCODE_NO_ERROR]], [[ENCODE_FAILED]]) : $@convention(thin) (UInt64, @guaranteed Optional<any Error>, Bool) -> ()
+
+  // === Then the outbound remote-call interval opens, with its own 'var' box so
+  // the 'remoteCall' error path can close the very interval this opened
+  // CHECK:       [[CALL_SPAN_BOX:%[0-9]+]] = alloc_box ${ var UInt64 }
+  // CHECK:       [[CALL_SPAN_BORROW:%[0-9]+]] = begin_borrow [var_decl] [[CALL_SPAN_BOX]]
+  // CHECK:       [[CALL_SPAN_ADDR:%[0-9]+]] = project_box [[CALL_SPAN_BORROW]], 0
+
+  // It carries the same mangled name and 'self', and returns the span ID
+  // CHECK:       {{%[0-9]+}} = string_literal utf8 "$s25distributed_thunk_tracing2DAC5greet4nameS2S_tYaKFTE"
+  // CHECK:       [[CALL_BEGIN_FN:%[0-9]+]] = function_ref @$s11Distributed06_traceA10RemoteCall11targetActor0E10Identifiers6UInt64Vx_SStAA0aF0RzlF : $@convention(thin) <τ_0_0 where τ_0_0 : DistributedActor> (@guaranteed τ_0_0, @guaranteed String) -> UInt64
+  // CHECK:       [[CALL_SPAN:%[0-9]+]] = apply [[CALL_BEGIN_FN]]<DA>([[SELF]], {{%[0-9]+}}) : $@convention(thin) <τ_0_0 where τ_0_0 : DistributedActor> (@guaranteed τ_0_0, @guaranteed String) -> UInt64
+  // CHECK:       store [[CALL_SPAN]] to [trivial] [[CALL_SPAN_ADDR]]
+
+  // ...and only then is 'remoteCall' invoked, on the same 'self', inside the
+  // interval, with its own error edge
+  // CHECK:       [[REMOTE_CALL:%[0-9]+]] = function_ref @$s11Distributed012LocalTestingA11ActorSystemC10remoteCall2on6target10invocation8throwing9returningq0_x_AA06RemoteG6TargetVAA0bC17InvocationEncoderVzq_mq0_mtYaKAA0aD0Rzs5ErrorR_SeR0_SER0_AA0bcD2IDV0R0Rtzr1_lF : $@convention(method) @async <τ_0_0, τ_0_1, τ_0_2 where τ_0_0 : DistributedActor, τ_0_1 : Error, τ_0_2 : Decodable, τ_0_2 : Encodable, τ_0_0.ID == LocalTestingActorID> (@guaranteed τ_0_0, @in_guaranteed RemoteCallTarget, @inout LocalTestingInvocationEncoder, @thick τ_0_1.Type, @thick τ_0_2.Type, @guaranteed LocalTestingDistributedActorSystem) -> (@out τ_0_2, @error any Error)
+  // CHECK:       try_apply [[REMOTE_CALL]]<DA, Never, String>({{%[0-9]+}}, [[SELF]], {{%[0-9]+}}, {{%[0-9]+}}, {{%[0-9]+}}, {{%[0-9]+}}, {{%[0-9]+}}) : {{.*}}, normal [[CALL_OK_BB:bb[0-9]+]], error [[CALL_ERR_BB:bb[0-9]+]]
+
+  // === Success: the remote-call span ID is read back out of its box and the
+  // interval is closed with no error, then the thunk returns the result
+  // CHECK:       [[CALL_OK_BB]]({{%[0-9]+}} : $()):
+  // CHECK:       [[CALL_SPAN_READ:%[0-9]+]] = begin_access [read] [unknown] [[CALL_SPAN_ADDR]]
+  // CHECK:       [[CALL_SPAN_VAL:%[0-9]+]] = load [trivial] [[CALL_SPAN_READ]]
+  // CHECK:       [[CALL_NO_ERROR:%[0-9]+]] = enum $Optional<any Error>, #Optional.none!enumelt
+  // CHECK:       [[CALL_FAILED_DFLT:%[0-9]+]] = function_ref @$s11Distributed06_traceA13RemoteCallEnd_5error6failedys6UInt64V_s5Error_pSgSbtFfA1_ : $@convention(thin) () -> Bool
+  // CHECK:       [[CALL_FAILED:%[0-9]+]] = apply [[CALL_FAILED_DFLT]]() : $@convention(thin) () -> Bool
+  // CHECK:       [[CALL_END_FN:%[0-9]+]] = function_ref @$s11Distributed06_traceA13RemoteCallEnd_5error6failedys6UInt64V_s5Error_pSgSbtF : $@convention(thin) (UInt64, @guaranteed Optional<any Error>, Bool) -> ()
+  // CHECK:       {{%[0-9]+}} = apply [[CALL_END_FN]]([[CALL_SPAN_VAL]], [[CALL_NO_ERROR]], [[CALL_FAILED]]) : $@convention(thin) (UInt64, @guaranteed Optional<any Error>, Bool) -> ()
+
+  // === Encoding failure: one shared catch block closes the encode interval,
+  // reporting the error that was thrown so the trace carries its type
+  // CHECK:       [[ENCODE_CATCH_BB:bb[0-9]+]]({{%[0-9]+}} : @owned $any Error):
+
+  // The error is bound to a 'let' so it can be both reported and rethrown
+  // CHECK:       {{%[0-9]+}} = move_value [lexical] [var_decl] {{%[0-9]+}}
+
+  // The same encode span ID as above, read back out of the box
+  // CHECK:       [[ENCODE_SPAN_READ2:%[0-9]+]] = begin_access [read] [unknown] [[ENCODE_SPAN_ADDR]]
+  // CHECK:       [[ENCODE_SPAN_VAL2:%[0-9]+]] = load [trivial] [[ENCODE_SPAN_READ2]]
+  // CHECK:       [[ENCODE_SOME_ERROR:%[0-9]+]] = enum $Optional<any Error>, #Optional.some!enumelt, {{%[0-9]+}}
+  // CHECK:       [[ENCODE_FAILED_DFLT2:%[0-9]+]] = function_ref @$s11Distributed06_traceA18EncodeArgumentsEnd_5error6failedys6UInt64V_s5Error_pSgSbtFfA1_ : $@convention(thin) () -> Bool
+  // CHECK:       [[ENCODE_FAILED2:%[0-9]+]] = apply [[ENCODE_FAILED_DFLT2]]() : $@convention(thin) () -> Bool
+  // CHECK:       [[ENCODE_END_FN2:%[0-9]+]] = function_ref @$s11Distributed06_traceA18EncodeArgumentsEnd_5error6failedys6UInt64V_s5Error_pSgSbtF : $@convention(thin) (UInt64, @guaranteed Optional<any Error>, Bool) -> ()
+  // CHECK:       {{%[0-9]+}} = apply [[ENCODE_END_FN2]]([[ENCODE_SPAN_VAL2]], [[ENCODE_SOME_ERROR]], [[ENCODE_FAILED2]]) : $@convention(thin) (UInt64, @guaranteed Optional<any Error>, Bool) -> ()
+
+  // The encode interval is closed before the error is rethrown, never after
+  // CHECK:       {{%[0-9]+}} = builtin "willThrow"({{%[0-9]+}}) : $()
+  // CHECK:       br [[THROW_BB:bb[0-9]+]]({{%[0-9]+}})
+
+  // ...and every 'record...' error edge branches into exactly that block
+  // CHECK:       [[ARG_ERR_BB]]({{%[0-9]+}} : @owned $any Error):
+  // CHECK:       br [[ENCODE_CATCH_BB]]({{%[0-9]+}})
+  // CHECK:       [[RET_ERR_BB]]({{%[0-9]+}} : @owned $any Error):
+  // CHECK:       br [[ENCODE_CATCH_BB]]({{%[0-9]+}})
+  // CHECK:       [[DONE_ERR_BB]]({{%[0-9]+}} : @owned $any Error):
+  // CHECK:       br [[ENCODE_CATCH_BB]]({{%[0-9]+}})
+
+  // === 'remoteCall' failure: its own catch block closes the remote-call
+  // interval, reporting the thrown error's type, then rethrows
+  // CHECK:       [[CALL_ERR_BB]]({{%[0-9]+}} : @owned $any Error):
+  // CHECK:       {{%[0-9]+}} = move_value [lexical] [var_decl] {{%[0-9]+}}
+  // CHECK:       [[CALL_SPAN_READ2:%[0-9]+]] = begin_access [read] [unknown] [[CALL_SPAN_ADDR]]
+  // CHECK:       [[CALL_SPAN_VAL2:%[0-9]+]] = load [trivial] [[CALL_SPAN_READ2]]
+  // CHECK:       [[CALL_SOME_ERROR:%[0-9]+]] = enum $Optional<any Error>, #Optional.some!enumelt, {{%[0-9]+}}
+  // CHECK:       [[CALL_FAILED_DFLT2:%[0-9]+]] = function_ref @$s11Distributed06_traceA13RemoteCallEnd_5error6failedys6UInt64V_s5Error_pSgSbtFfA1_ : $@convention(thin) () -> Bool
+  // CHECK:       [[CALL_FAILED2:%[0-9]+]] = apply [[CALL_FAILED_DFLT2]]() : $@convention(thin) () -> Bool
+  // CHECK:       [[CALL_END_FN2:%[0-9]+]] = function_ref @$s11Distributed06_traceA13RemoteCallEnd_5error6failedys6UInt64V_s5Error_pSgSbtF : $@convention(thin) (UInt64, @guaranteed Optional<any Error>, Bool) -> ()
+  // CHECK:       {{%[0-9]+}} = apply [[CALL_END_FN2]]([[CALL_SPAN_VAL2]], [[CALL_SOME_ERROR]], [[CALL_FAILED2]]) : $@convention(thin) (UInt64, @guaranteed Optional<any Error>, Bool) -> ()
+  // CHECK:       {{%[0-9]+}} = builtin "willThrow"({{%[0-9]+}}) : $()
+  // CHECK:       br [[THROW_BB]]({{%[0-9]+}})
+
+  // The rethrow is shared by the encode and 'remoteCall' error paths
+  // CHECK:       [[THROW_BB]]({{%[0-9]+}} : @owned $any Error):
+  // CHECK:       throw {{%[0-9]+}}
+  distributed func greet(name: String) -> String {
+    return "Hello, \(name)!"
+  }
+}


### PR DESCRIPTION
We need to emit signposts in order to understand distributed usage at runtime better.

This follows the established pattern of how we do it in concurrency module.

I did use claude code to help generate the boilerplate, it's basically a copy of tracing.h infra in Concurrency, I did thoroughly review the code, the AST synthesis I did manually.