### PR TITLE
[RemoteInspection] Store the payload TypeRef of indirect enum payloads

### DIFF
--- a/include/swift/RemoteInspection/TypeLowering.h
+++ b/include/swift/RemoteInspection/TypeLowering.h
@@ -190,6 +190,14 @@ struct FieldInfo {
   int Value;
   const TypeRef *TR;
   const TypeInfo &TI;
+  /// For indirect enum cases, this stores the declared payload type.
+  const TypeRef *IndirectPayloadTR;
+
+  FieldInfo(const std::string &Name, unsigned Offset, int Value,
+            const TypeRef *TR, const TypeInfo &TI,
+            const TypeRef *IndirectPayloadTR = nullptr)
+      : Name(Name), Offset(Offset), Value(Value), TR(TR), TI(TI),
+        IndirectPayloadTR(IndirectPayloadTR) {}
 };
 
 /// Builtins and (opaque) imported value types

--- a/stdlib/public/RemoteInspection/TypeLowering.cpp
+++ b/stdlib/public/RemoteInspection/TypeLowering.cpp
@@ -2109,18 +2109,20 @@ class EnumTypeInfoBuilder {
     Cases.push_back({Name, /*offset=*/0, /*value=*/-1, nullptr, emptyTI});
   }
 
-  void addCase(const std::string &Name, const TypeRef *TR,
-               const TypeInfo *TI) {
+  void addCase(const std::string &Name, const TypeRef *TR, const TypeInfo *TI,
+               const TypeRef *IndirectPayloadTR = nullptr) {
     if (TI == nullptr) {
       markInvalid("no type info for case type", TR);
       static TypeInfo emptyTI;
-      Cases.push_back({Name, /*offset=*/0, /*value=*/-1, TR, emptyTI});
+      Cases.push_back(
+          {Name, /*offset=*/0, /*value=*/-1, TR, emptyTI, IndirectPayloadTR});
     } else {
       Size = std::max(Size, TI->getSize());
       Alignment = std::max(Alignment, TI->getAlignment());
       Borrowability = std::min(Borrowability, TI->getBorrowability());
       AddressableForDependencies |= TI->isAddressableForDependencies();
-      Cases.push_back({Name, /*offset=*/0, /*value=*/-1, TR, *TI});
+      Cases.push_back(
+          {Name, /*offset=*/0, /*value=*/-1, TR, *TI, IndirectPayloadTR});
     }
   }
 
@@ -2179,7 +2181,7 @@ public:
           ++NonGenericNonEmptyPayloadCases;
           LastPayloadCaseTR = CaseTR;
         }
-        addCase(Case.Name, CaseTR, CaseTI);
+        addCase(Case.Name, CaseTR, CaseTI, Case.Indirect ? Case.TR : nullptr);
       }
     }
     // For determining a layout strategy, cases w/ empty payload are treated the


### PR DESCRIPTION
EnumTypeInfoBuilder will build FieldInfos of indirect enum payloads with the TypeRef set to Builtin.NativeObject.

EnumTypeInfoBuilder has access to the typeref of the type behind the pointer, which currently isn't saved anywhere.

RemoteInspection clients like LLDB have to re-query it, and read metadata to find out what the type behind the reference it.

This patch adds a field to FieldInfo with the payload TypeRef, the one behind the reference.

rdar://170684760

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
