### PR TITLE
[DebugInfo] Emit DW_TAG_reference_type for indirect enum cases in DWARF

### DIFF
--- a/test/DebugInfo/indirect_enum.swift
+++ b/test/DebugInfo/indirect_enum.swift
@@ -1,0 +1,24 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -gdwarf-types -o - | %FileCheck %s
+
+// Test that indirect enum cases are represented with DW_TAG_reference_type.
+
+// CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "TreeNode", {{.*}}elements: ![[OUTER:[0-9]+]]
+// CHECK-DAG: ![[OUTER]] = !{![[VP:[0-9]+]]}
+// CHECK-DAG: ![[VP]] = !DICompositeType(tag: DW_TAG_variant_part, {{.*}}elements: ![[ELTS:[0-9]+]])
+// CHECK-DAG: ![[ELTS]] = !{![[LEAF:[0-9]+]], ![[BRANCH:[0-9]+]]}
+
+// Both cases should have reference types since this is an indirect enum
+// CHECK-DAG: ![[LEAF]] = !DIDerivedType(tag: DW_TAG_member, name: "leaf", {{.*}}baseType: ![[LEAF_REF:[0-9]+]]
+// CHECK-DAG: ![[LEAF_REF]] = !DIDerivedType(tag: DW_TAG_reference_type, baseType: ![[INT:[0-9]+]]
+// CHECK-DAG: ![[INT]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Int",
+
+// CHECK-DAG: ![[BRANCH]] = !DIDerivedType(tag: DW_TAG_member, name: "branch", {{.*}}baseType: ![[BRANCH_REF:[0-9]+]]
+// CHECK-DAG: ![[BRANCH_REF]] = !DIDerivedType(tag: DW_TAG_reference_type, baseType: ![[TUPLE:[0-9]+]]
+// CHECK-DAG: ![[TUPLE]] = !DICompositeType(tag: DW_TAG_structure_type, name: "$s13indirect_enum8TreeNodeO_ACtD",
+
+indirect enum TreeNode {
+  case leaf(Int)
+  case branch(TreeNode, TreeNode)
+}
+
+let tree = TreeNode.leaf(42)

--- a/test/DebugInfo/indirect_enum_case.swift
+++ b/test/DebugInfo/indirect_enum_case.swift
@@ -1,0 +1,29 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -gdwarf-types -o - | %FileCheck %s
+
+// Test that explicit `indirect case` declarations are represented with
+// DW_TAG_reference_type in debug info, while non-indirect cases
+// are represented directly.
+
+// CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "MixedEnum", {{.*}}elements: ![[OUTER:[0-9]+]]
+// CHECK-DAG: ![[OUTER]] = !{![[VP:[0-9]+]]}
+// CHECK-DAG: ![[VP]] = !DICompositeType(tag: DW_TAG_variant_part, {{.*}}elements: ![[ELTS:[0-9]+]])
+// CHECK-DAG: ![[ELTS]] = !{![[EMPTY:[0-9]+]], ![[VALUE:[0-9]+]], ![[INDIRECT:[0-9]+]]}
+
+// The empty case has no type
+// CHECK-DAG: ![[EMPTY]] = !DIDerivedType(tag: DW_TAG_member, name: "empty",
+
+// The value case should NOT have a reference type (it's not indirect)
+// CHECK-DAG: ![[VALUE]] = !DIDerivedType(tag: DW_TAG_member, name: "value", {{.*}}baseType: ![[INT:[0-9]+]]
+// CHECK-DAG: ![[INT]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Int",
+
+// The indirect case should have a reference type
+// CHECK-DAG: ![[INDIRECT]] = !DIDerivedType(tag: DW_TAG_member, name: "indirectValue", {{.*}}baseType: ![[IND_REF:[0-9]+]]
+// CHECK-DAG: ![[IND_REF]] = !DIDerivedType(tag: DW_TAG_reference_type, baseType: ![[INT]]
+
+enum MixedEnum {
+  case empty
+  case value(Int)
+  indirect case indirectValue(Int)
+}
+
+let mixed = MixedEnum.value(42)

--- a/test/DebugInfo/indirect_enum_generic.swift
+++ b/test/DebugInfo/indirect_enum_generic.swift
@@ -1,0 +1,48 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -gdwarf-types -o - | %FileCheck %s
+
+// Test that indirect cases in generic enums are represented with
+// DW_TAG_reference_type in debug info.
+
+
+// CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "Tree", {{.*}}elements: ![[TREE_OUTER:[0-9]+]]
+// CHECK-DAG: ![[TREE_OUTER]] = !{![[TREE_VP:[0-9]+]]}
+// CHECK-DAG: ![[TREE_VP]] = !DICompositeType(tag: DW_TAG_variant_part, {{.*}}elements: ![[TREE_ELTS:[0-9]+]])
+// CHECK-DAG: ![[TREE_ELTS]] = !{![[LEAF:[0-9]+]], ![[BRANCH:[0-9]+]]}
+
+// Both cases should have reference types since the entire enum is indirect
+// CHECK-DAG: ![[LEAF]] = !DIDerivedType(tag: DW_TAG_member, name: "leaf", {{.*}}baseType: ![[LEAF_REF:[0-9]+]]
+// CHECK-DAG: ![[LEAF_REF]] = !DIDerivedType(tag: DW_TAG_reference_type,
+
+// CHECK-DAG: ![[BRANCH]] = !DIDerivedType(tag: DW_TAG_member, name: "branch", {{.*}}baseType: ![[BRANCH_REF:[0-9]+]]
+// CHECK-DAG: ![[BRANCH_REF]] = !DIDerivedType(tag: DW_TAG_reference_type,
+
+indirect enum Tree<T> {
+  case leaf(T)
+  case branch(Tree<T>, Tree<T>)
+}
+
+
+// CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "GenericOption", {{.*}}elements: ![[OPT_OUTER:[0-9]+]]
+// CHECK-DAG: ![[OPT_OUTER]] = !{![[OPT_VP:[0-9]+]]}
+// CHECK-DAG: ![[OPT_VP]] = !DICompositeType(tag: DW_TAG_variant_part, {{.*}}elements: ![[OPT_ELTS:[0-9]+]])
+// CHECK-DAG: ![[OPT_ELTS]] = !{![[NONE:[0-9]+]], ![[SOME:[0-9]+]], ![[REC:[0-9]+]]}
+
+// The empty case has no type
+// CHECK-DAG: ![[NONE]] = !DIDerivedType(tag: DW_TAG_member, name: "none",
+
+// The `some` case should NOT have a reference type (it's not indirect)
+// CHECK-DAG: ![[SOME]] = !DIDerivedType(tag: DW_TAG_member, name: "some", {{.*}}baseType: ![[SOME_TY:[0-9]+]]
+// CHECK-DAG: ![[SOME_TY]] = !DICompositeType(tag: DW_TAG_structure_type,
+
+// The `recursive` case should have a reference type
+// CHECK-DAG: ![[REC]] = !DIDerivedType(tag: DW_TAG_member, name: "recursive", {{.*}}baseType: ![[REC_REF:[0-9]+]]
+// CHECK-DAG: ![[REC_REF]] = !DIDerivedType(tag: DW_TAG_reference_type,
+
+enum GenericOption<T> {
+  case none
+  case some(T)
+  indirect case recursive(GenericOption<T>)
+}
+
+let tree = Tree<Int>.leaf(42)
+let opt = GenericOption<String>.some("hello")


### PR DESCRIPTION
Wrap indirect enum case payload types in DW_TAG_reference_type to indicate that the case stores a pointer to a heap-allocated box rather than the payload directly.

rdar://170687015

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
