### PR TITLE
[SILCombine] Ensure we emit an end_borrow after simplifying init_borrow_addr

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -2185,12 +2185,19 @@ final public class IgnoredUseInst : Instruction, UnaryInstruction {
 final public class ImplicitActorToOpaqueIsolationCastInst
   : SingleValueInstruction, UnaryInstruction {}
 
-final public class MakeBorrowInst
+public protocol MakeBorrowInstruction
   : SingleValueInstruction, UnaryInstruction {
+  var referent: Value { get }
+}
+
+extension MakeBorrowInstruction {
   public var referent: Value {
     operands[0].value
   }
 }
+
+final public class MakeBorrowInst 
+  : SingleValueInstruction, MakeBorrowInstruction, UnaryInstruction {}
 
 final public class DereferenceBorrowInst
   : SingleValueInstruction, UnaryInstruction {
@@ -2200,11 +2207,7 @@ final public class DereferenceBorrowInst
 }
 
 final public class MakeAddrBorrowInst
-  : SingleValueInstruction, UnaryInstruction {
-  public var referent: Value {
-    operands[0].value
-  }
-}
+  : SingleValueInstruction, MakeBorrowInstruction, UnaryInstruction {}
 
 final public class DereferenceAddrBorrowInst
   : SingleValueInstruction, UnaryInstruction {

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -4361,41 +4361,6 @@ sil @test_type_value_concrete_negative : $@convention(thin) () -> Int {
   return %val : $Int
 }
 
-// CHECK-LABEL: sil @test_init_borrow_addr_generic : $@convention(thin) <T> (@in_guaranteed T) -> @out Builtin.Borrow<T> {
-// CHECK:         init_borrow_addr %0 : $*Builtin.Borrow<T> with %1 : $*T
-// CHECK-LABEL: } // end sil function 'test_init_borrow_addr_generic'
-sil @test_init_borrow_addr_generic : $@convention(thin) <T> (@in_guaranteed T) -> @out Builtin.Borrow<T> {
-bb0(%0 : $*Builtin.Borrow<T>, %1 : $*T):
-  init_borrow_addr %0 : $*Builtin.Borrow<T> with %1 : $*T
-  %r = tuple ()
-  return %r : $()
-}
-
-// CHECK-LABEL: sil @test_init_borrow_addr_loadable : $@convention(thin) (@in_guaranteed Int) -> @out Builtin.Borrow<Int> {
-// CHECK-NOT:     init_borrow_addr
-// CHECK:         [[LOADED_INT:%.*]] = load %1 : $*Int
-// CHECK:         [[BORROW:%.*]] = make_borrow [[LOADED_INT]]
-// CHECK:         store [[BORROW]] to %0 : $*Builtin.Borrow<Int>
-// CHECK-LABEL: } // end sil function 'test_init_borrow_addr_loadable'
-sil @test_init_borrow_addr_loadable : $@convention(thin) (@in_guaranteed Int) -> @out Builtin.Borrow<Int> {
-bb0(%0 : $*Builtin.Borrow<Int>, %1 : $*Int):
-  init_borrow_addr %0 : $*Builtin.Borrow<Int> with %1 : $*Int
-  %r = tuple ()
-  return %r : $()
-}
-
-// CHECK-LABEL: sil @test_init_borrow_addr_addressonly : $@convention(thin) (@in_guaranteed AddressOnlyEnum) -> @out Builtin.Borrow<AddressOnlyEnum> {
-// CHECK-NOT:     init_borrow_addr
-// CHECK:         [[BORROW:%.*]] = make_addr_borrow %1 : $*AddressOnlyEnum
-// CHECK:         store [[BORROW]] to %0 : $*Builtin.Borrow<AddressOnlyEnum>
-// CHECK-LABEL: } // end sil function 'test_init_borrow_addr_addressonly'
-sil @test_init_borrow_addr_addressonly : $@convention(thin) (@in_guaranteed AddressOnlyEnum) -> @out Builtin.Borrow<AddressOnlyEnum> {
-bb0(%0 : $*Builtin.Borrow<AddressOnlyEnum>, %1 : $*AddressOnlyEnum):
-  init_borrow_addr %0 : $*Builtin.Borrow<AddressOnlyEnum> with %1 : $*AddressOnlyEnum
-  %r = tuple ()
-  return %r : $()
-}
-
 // CHECK-LABEL: sil @test_dereference_borrow : $@convention(thin) (Int) -> Int {
 // CHECK:       bb0([[INT:%.*]] : $Int):
 // CHECK-NEXT:    return [[INT]] : $Int

--- a/test/SILOptimizer/sil_combine_init_borrow_addr.sil
+++ b/test/SILOptimizer/sil_combine_init_borrow_addr.sil
@@ -1,0 +1,73 @@
+// RUN: %target-sil-opt -sil-print-types -enable-objc-interop -enable-sil-verify-all %s -sil-combine | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+
+// Declare this SIL to be canonical because some tests break raw SIL
+// conventions. e.g. address-type block args. -enforce-exclusivity=none is also
+// required to allow address-type block args in canonical SIL.
+sil_stage canonical
+
+import Builtin
+import Swift
+
+enum AddressOnlyEnum {
+  case Loadable(Builtin.Int32)
+  case AddressOnly(Any)
+}
+
+struct MyInt {
+  var value: Builtin.Int32
+}
+
+struct MoveOnlyStruct: ~Copyable {
+  var value: MyInt
+}
+
+// CHECK-LABEL: sil @test_init_borrow_addr_generic : $@convention(thin) <T> (@in_guaranteed T) -> @out Builtin.Borrow<T> {
+// CHECK:         init_borrow_addr %0 : $*Builtin.Borrow<T> with %1 : $*T
+// CHECK-LABEL: } // end sil function 'test_init_borrow_addr_generic'
+sil @test_init_borrow_addr_generic : $@convention(thin) <T> (@in_guaranteed T) -> @out Builtin.Borrow<T> {
+bb0(%0 : $*Builtin.Borrow<T>, %1 : $*T):
+  init_borrow_addr %0 : $*Builtin.Borrow<T> with %1 : $*T
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @test_init_borrow_addr_loadable : $@convention(thin) (@in_guaranteed Int) -> @out Builtin.Borrow<Int> {
+// CHECK-NOT:     init_borrow_addr
+// CHECK:         [[LOADED_INT:%.*]] = load %1 : $*Int
+// CHECK:         [[BORROW:%.*]] = make_borrow [[LOADED_INT]]
+// CHECK:         store [[BORROW]] to %0 : $*Builtin.Borrow<Int>
+// CHECK-LABEL: } // end sil function 'test_init_borrow_addr_loadable'
+sil @test_init_borrow_addr_loadable : $@convention(thin) (@in_guaranteed Int) -> @out Builtin.Borrow<Int> {
+bb0(%0 : $*Builtin.Borrow<Int>, %1 : $*Int):
+  init_borrow_addr %0 : $*Builtin.Borrow<Int> with %1 : $*Int
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @test_init_borrow_addr_addressonly : $@convention(thin) (@in_guaranteed AddressOnlyEnum) -> @out Builtin.Borrow<AddressOnlyEnum> {
+// CHECK-NOT:     init_borrow_addr
+// CHECK:         [[BORROW:%.*]] = make_addr_borrow %1 : $*AddressOnlyEnum
+// CHECK:         store [[BORROW]] to %0 : $*Builtin.Borrow<AddressOnlyEnum>
+// CHECK-LABEL: } // end sil function 'test_init_borrow_addr_addressonly'
+sil @test_init_borrow_addr_addressonly : $@convention(thin) (@in_guaranteed AddressOnlyEnum) -> @out Builtin.Borrow<AddressOnlyEnum> {
+bb0(%0 : $*Builtin.Borrow<AddressOnlyEnum>, %1 : $*AddressOnlyEnum):
+  init_borrow_addr %0 : $*Builtin.Borrow<AddressOnlyEnum> with %1 : $*AddressOnlyEnum
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil [ossa] @test_init_borrow_addr_ossa : $@convention(thin) (@in_guaranteed MoveOnlyStruct) -> @out Builtin.Borrow<MoveOnlyStruct> {
+// CHECK-NOT:     init_borrow_addr
+// CHECK:         [[LOADED:%.*]] = load_borrow %1 : $*MoveOnlyStruct
+// CHECK:         [[BORROW:%.*]] = make_borrow [[LOADED]]
+// CHECK:         store [[BORROW]] to [trivial] %0 : $*Builtin.Borrow<MoveOnlyStruct>
+// CHECK:         end_borrow [[LOADED]]
+// CHECK-LABEL: } // end sil function 'test_init_borrow_addr_ossa'
+sil [ossa] @test_init_borrow_addr_ossa : $@convention(thin) (@in_guaranteed MoveOnlyStruct) -> @out Builtin.Borrow<MoveOnlyStruct> {
+bb0(%0 : $*Builtin.Borrow<MoveOnlyStruct>, %1 : $*MoveOnlyStruct):
+  init_borrow_addr %0 : $*Builtin.Borrow<MoveOnlyStruct> with %1 : $*MoveOnlyStruct
+  %r = tuple ()
+  return %r : $()
+}

--- a/test/SILOptimizer/sil_combine_init_borrow_addr.sil
+++ b/test/SILOptimizer/sil_combine_init_borrow_addr.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -sil-print-types -enable-objc-interop -enable-sil-verify-all %s -sil-combine | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all %s -onone-simplification -simplify-instruction=init_borrow_addr | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 

--- a/test/SILOptimizer/sil_combine_ossa.sil
+++ b/test/SILOptimizer/sil_combine_ossa.sil
@@ -5664,17 +5664,3 @@ bb2:
   destroy_value [dead_end] %0
   unreachable
 }
-
-// CHECK-LABEL: sil [ossa] @test_init_borrow_addr_ossa : $@convention(thin) (@in_guaranteed MoveOnlyStruct) -> @out Builtin.Borrow<MoveOnlyStruct> {
-// CHECK-NOT:     init_borrow_addr
-// CHECK:         [[LOADED:%.*]] = load_borrow %1 : $*MoveOnlyStruct
-// CHECK:         [[BORROW:%.*]] = make_borrow [[LOADED]]
-// CHECK:         store [[BORROW]] to [trivial] %0 : $*Builtin.Borrow<MoveOnlyStruct>
-// CHECK:         end_borrow [[LOADED]]
-// CHECK-LABEL: } // end sil function 'test_init_borrow_addr_ossa'
-sil [ossa] @test_init_borrow_addr_ossa : $@convention(thin) (@in_guaranteed MoveOnlyStruct) -> @out Builtin.Borrow<MoveOnlyStruct> {
-bb0(%0 : $*Builtin.Borrow<MoveOnlyStruct>, %1 : $*MoveOnlyStruct):
-  init_borrow_addr %0 : $*Builtin.Borrow<MoveOnlyStruct> with %1 : $*MoveOnlyStruct
-  %r = tuple ()
-  return %r : $()
-}

--- a/test/SILOptimizer/sil_combine_ossa.sil
+++ b/test/SILOptimizer/sil_combine_ossa.sil
@@ -5665,3 +5665,16 @@ bb2:
   unreachable
 }
 
+// CHECK-LABEL: sil [ossa] @test_init_borrow_addr_ossa : $@convention(thin) (@in_guaranteed MoveOnlyStruct) -> @out Builtin.Borrow<MoveOnlyStruct> {
+// CHECK-NOT:     init_borrow_addr
+// CHECK:         [[LOADED:%.*]] = load_borrow %1 : $*MoveOnlyStruct
+// CHECK:         [[BORROW:%.*]] = make_borrow [[LOADED]]
+// CHECK:         store [[BORROW]] to [trivial] %0 : $*Builtin.Borrow<MoveOnlyStruct>
+// CHECK:         end_borrow [[LOADED]]
+// CHECK-LABEL: } // end sil function 'test_init_borrow_addr_ossa'
+sil [ossa] @test_init_borrow_addr_ossa : $@convention(thin) (@in_guaranteed MoveOnlyStruct) -> @out Builtin.Borrow<MoveOnlyStruct> {
+bb0(%0 : $*Builtin.Borrow<MoveOnlyStruct>, %1 : $*MoveOnlyStruct):
+  init_borrow_addr %0 : $*Builtin.Borrow<MoveOnlyStruct> with %1 : $*MoveOnlyStruct
+  %r = tuple ()
+  return %r : $()
+}


### PR DESCRIPTION
I forgot to make sure that if this emitted a `load_borrow` that it properly emitted an `end_borrow` after making the borrow type.