### PR TITLE
[RemoteInspection] Return SinglePayloadEnumTypeInfo for single-payloa…

### DIFF
--- a/stdlib/public/RemoteInspection/TypeLowering.cpp
+++ b/stdlib/public/RemoteInspection/TypeLowering.cpp
@@ -2221,8 +2221,16 @@ public:
         // Zero-sized enum with only one empty case
         return TC.makeTypeInfo<TrivialEnumTypeInfo>(Kind, Cases);
       } else {
-        // Enum that has only one payload case is represented as that case
-        return TC.getTypeInfo(LastPayloadCaseTR, ExternalTypeInfo);
+        // Single-case enum with a payload: same layout as the payload,
+        // but wrapped in a SinglePayloadEnumTypeInfo to preserve case metadata.
+        auto *CaseTI = TC.getTypeInfo(LastPayloadCaseTR, ExternalTypeInfo);
+        if (CaseTI == nullptr)
+          return nullptr;
+        NumExtraInhabitants = CaseTI->getNumExtraInhabitants();
+        unsigned Stride = CaseTI->getStride();
+        return TC.makeTypeInfo<SinglePayloadEnumTypeInfo>(
+            Size, Alignment, Stride, NumExtraInhabitants, Borrowability,
+            AddressableForDependencies, Kind, Cases);
       }
     }
 

--- a/stdlib/public/RemoteInspection/TypeLowering.cpp
+++ b/stdlib/public/RemoteInspection/TypeLowering.cpp
@@ -708,38 +708,35 @@ public:
   bool readExtraInhabitantIndex(remote::MemoryReader &reader,
                        remote::RemoteAddress address,
                        int *extraInhabitantIndex) const override {
-    FieldInfo PayloadCase = getCases()[0];
+    const FieldInfo &PayloadCase = getCases()[0];
     if (getSize() < PayloadCase.TI.getSize()) {
       // Single payload enums that use a separate tag don't export any XIs
       // So this is an invalid request.
       return false;
     }
 
-    // Single payload enums inherit XIs from their payload type
-    auto NumCases = getNumCases();
-    if (NumCases == 1) {
-      *extraInhabitantIndex = -1;
-      return true;
-    } else {
-      if (!PayloadCase.TI.readExtraInhabitantIndex(reader, address,
-                                                   extraInhabitantIndex)) {
-        return false;
-      }
-      auto NumNonPayloadCases = NumCases - 1;
-      if (*extraInhabitantIndex < 0
-          || (unsigned long)*extraInhabitantIndex < NumNonPayloadCases) {
-        *extraInhabitantIndex = -1;
-      } else {
-        *extraInhabitantIndex -= NumNonPayloadCases;
-      }
-      return true;
+    // Single payload enums inherit XIs from their payload type, less the ones
+    // the non-payload cases are encoded in.
+    if (!PayloadCase.TI.readExtraInhabitantIndex(reader, address,
+                                                 extraInhabitantIndex)) {
+      return false;
     }
+    int NumNonPayloadCases = getNumCases() - 1;
+    if (*extraInhabitantIndex < NumNonPayloadCases) {
+      *extraInhabitantIndex = -1;
+    } else {
+      *extraInhabitantIndex -= NumNonPayloadCases;
+    }
+    return true;
   }
 
   BitMask getSpareBits(TypeConverter &TC, bool &hasAddrOnly) const override {
-    FieldInfo PayloadCase = getCases()[0];
+    const FieldInfo &PayloadCase = getCases()[0];
     size_t payloadSize = PayloadCase.TI.getSize();
     if (getSize() <= payloadSize) {
+      // With no non-payload cases the representation is exactly the payload's.
+      if (getNumCases() == 1)
+        return PayloadCase.TI.getSpareBits(TC, hasAddrOnly);
       return BitMask::zeroMask(getSize());
     }
     size_t tagSize = getSize() - payloadSize;
@@ -2249,8 +2246,16 @@ public:
         // Zero-sized enum with only one empty case
         return TC.makeTypeInfo<TrivialEnumTypeInfo>(Kind, Cases);
       } else {
-        // Enum that has only one payload case is represented as that case
-        return TC.getTypeInfo(LastPayloadCaseTR, ExternalTypeInfo);
+        // Single-case enum with a payload: same layout as the payload,
+        // but wrapped in a SinglePayloadEnumTypeInfo to preserve case metadata.
+        auto *CaseTI = TC.getTypeInfo(LastPayloadCaseTR, ExternalTypeInfo);
+        if (CaseTI == nullptr)
+          return nullptr;
+        NumExtraInhabitants = CaseTI->getNumExtraInhabitants();
+        unsigned Stride = CaseTI->getStride();
+        return TC.makeTypeInfo<SinglePayloadEnumTypeInfo>(
+            Size, Alignment, Stride, NumExtraInhabitants, Borrowability,
+            AddressableForDependencies, Kind, Cases);
       }
     }
 

--- a/test/Reflection/typeref_lowering.swift
+++ b/test/Reflection/typeref_lowering.swift
@@ -1078,6 +1078,12 @@
 // CHECK-32-NEXT:       (field name=u offset=4
 // CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1)))))
 
+12TypeLowering13SingletonEnumO
+// CHECK-64: (enum TypeLowering.SingletonEnum)
+// CHECK-64-NEXT: (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
+// CHECK-64-NEXT:   (case name=Payload index=0 offset=0
+// CHECK-64-NEXT:     (reference kind=strong refcounting=native)))
+
 12TypeLowering10EnumStructV
 // CHECK-64: (struct TypeLowering.EnumStruct)
 // CHECK-64-NEXT: (struct size=81 alignment=8 stride=88 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
@@ -1098,7 +1104,9 @@
 // CHECK-64-NEXT:      (case name=C index=2)
 // CHECK-64-NEXT:      (case name=D index=3)))
 // CHECK-64-NEXT:   (field name=singleton offset=8
-// CHECK-64-NEXT:     (reference kind=strong refcounting=native))
+// CHECK-64-NEXT:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
+// CHECK-64-NEXT:       (case name=Payload index=0 offset=0
+// CHECK-64-NEXT:         (reference kind=strong refcounting=native))))
 // CHECK-64-NEXT:   (field name=singlePayload offset=16
 // CHECK-64-NEXT:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=1
 // CHECK-64-NEXT:       (case name=Indirect index=0 offset=0

--- a/test/Reflection/typeref_lowering.swift
+++ b/test/Reflection/typeref_lowering.swift
@@ -1078,6 +1078,24 @@
 // CHECK-32-NEXT:       (field name=u offset=4
 // CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1)))))
 
+12TypeLowering13SingletonEnumO
+// CHECK-64: (enum TypeLowering.SingletonEnum)
+// CHECK-64-NEXT: (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
+// CHECK-64-NEXT:   (case name=Payload index=0 offset=0
+// CHECK-64-NEXT:     (reference kind=strong refcounting=native)))
+
+12TypeLowering13SingletonEnumOSg
+// The enum keeps the extra inhabitants of its payload, so an enclosing Optional
+// spends one of them on `none` instead of growing a discriminator.
+// CHECK-64: (bound_generic_enum Swift.Optional
+// CHECK-64-NEXT:   (enum TypeLowering.SingletonEnum))
+// CHECK-64-NEXT: (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=1
+// CHECK-64-NEXT:   (case name=some index=0 offset=0
+// CHECK-64-NEXT:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
+// CHECK-64-NEXT:       (case name=Payload index=0 offset=0
+// CHECK-64-NEXT:         (reference kind=strong refcounting=native))))
+// CHECK-64-NEXT:   (case name=none index=1))
+
 12TypeLowering10EnumStructV
 // CHECK-64: (struct TypeLowering.EnumStruct)
 // CHECK-64-NEXT: (struct size=81 alignment=8 stride=88 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
@@ -1098,7 +1116,9 @@
 // CHECK-64-NEXT:      (case name=C index=2)
 // CHECK-64-NEXT:      (case name=D index=3)))
 // CHECK-64-NEXT:   (field name=singleton offset=8
-// CHECK-64-NEXT:     (reference kind=strong refcounting=native))
+// CHECK-64-NEXT:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
+// CHECK-64-NEXT:       (case name=Payload index=0 offset=0
+// CHECK-64-NEXT:         (reference kind=strong refcounting=native))))
 // CHECK-64-NEXT:   (field name=singlePayload offset=16
 // CHECK-64-NEXT:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=1
 // CHECK-64-NEXT:       (case name=Indirect index=0 offset=0

--- a/validation-test/Reflection/reflect_Enum_SingleCaseCFPayload.swift
+++ b/validation-test/Reflection/reflect_Enum_SingleCaseCFPayload.swift
@@ -40,7 +40,9 @@ reflect(object: ClassWithSingleCaseCFPayloadEnum())
 // CHECK64-NEXT:  (field name=e1 offset=16 
 // CHECK64-NEXT:   (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483646 bitwise_takable=1 
 // CHECK64-NEXT:    (case name=some index=0 offset=0 
-// CHECK64-NEXT:    (reference kind=strong refcounting=unknown)) 
+// CHECK64-NEXT:    (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:      (case name=only index=0 offset=0
+// CHECK64-NEXT:       (reference kind=strong refcounting=unknown))))
 
 // CHECK32: Type info:
 
@@ -53,14 +55,14 @@ reflect(enum: SingleCaseCFPayloadEnum.only(cfs1))
 // CHECK-NEXT: (enum reflect_Enum_SingleCaseCFPayload.SingleCaseCFPayloadEnum)
 
 // CHECK: Type info:
-// CHECK-NEXT: (reference kind=strong refcounting=unknown) 
-
+// CHECK-NEXT: (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-NEXT:   (case name=only index=0 offset=0
+// CHECK-NEXT:     (reference kind=strong refcounting=unknown)))
 // CHECK: Mangled name: $s32reflect_Enum_SingleCaseCFPayload0cdeB0O 
 // CHECK-NEXT: Demangled name: reflect_Enum_SingleCaseCFPayload.SingleCaseCFPayloadEnum 
 
 // CHECK: Enum value:
-// CHECK-NEXT: (reference kind=strong refcounting=unknown)
-
+// CHECK-NEXT: (enum_value name=only index=0
 // CHECK: Mangled name: $s32reflect_Enum_SingleCaseCFPayload0cdeB0O 
 // CHECK-NEXT: Demangled name: reflect_Enum_SingleCaseCFPayload.SingleCaseCFPayloadEnum 
 

--- a/validation-test/Reflection/reflect_Enum_SingleCaseIntPayload.swift
+++ b/validation-test/Reflection/reflect_Enum_SingleCaseIntPayload.swift
@@ -45,18 +45,22 @@ reflect(object: ClassWithSingleCaseIntPayloadEnum())
 // CHECK-64:   (field name=e3 offset=40
 // CHECK-64:     (single_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:       (case name=some index=0 offset=0
-// CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
-// CHECK-64:           (field name=_value offset=0
-// CHECK-64:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK-64:         (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:           (case name=only index=0 offset=0
+// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:               (field name=_value offset=0
+// CHECK-64:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-64:       (case name=none index=1)))
 // CHECK-64:   (field name=e4 offset=56
 // CHECK-64:     (single_payload_enum size=10 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:       (case name=some index=0 offset=0
 // CHECK-64:         (single_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:           (case name=some index=0 offset=0
-// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
-// CHECK-64:               (field name=_value offset=0
-// CHECK-64:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK-64:             (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:               (case name=only index=0 offset=0
+// CHECK-64:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:                   (field name=_value offset=0
+// CHECK-64:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-64:           (case name=none index=1)))
 // CHECK-64:       (case name=none index=1))))
 
@@ -81,18 +85,22 @@ reflect(object: ClassWithSingleCaseIntPayloadEnum())
 // CHECK-32:   (field name=e3 offset=20
 // CHECK-32:     (single_payload_enum size=5 alignment=4 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:       (case name=some index=0 offset=0
-// CHECK-32:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
-// CHECK-32:           (field name=_value offset=0
-// CHECK-32:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK-32:         (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:           (case name=only index=0 offset=0
+// CHECK-32:             (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:               (field name=_value offset=0
+// CHECK-32:                 (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-32:       (case name=none index=1)))
 // CHECK-32:   (field name=e4 offset=28
 // CHECK-32:     (single_payload_enum size=6 alignment=4 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:       (case name=some index=0 offset=0
 // CHECK-32:         (single_payload_enum size=5 alignment=4 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:           (case name=some index=0 offset=0
-// CHECK-32:             (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
-// CHECK-32:               (field name=_value offset=0
-// CHECK-32:                 (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK-32:             (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:               (case name=only index=0 offset=0
+// CHECK-32:                 (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32:                   (field name=_value offset=0
+// CHECK-32:                     (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-32:           (case name=none index=1))
 // CHECK-32:       (case name=none index=1))))
 
@@ -105,14 +113,16 @@ reflect(enum: SingleCaseIntPayloadEnum.only(77))
 // CHECK-64: (enum reflect_Enum_SingleCaseIntPayload.SingleCaseIntPayloadEnum)
 
 // CHECK-64: Type info:
-// CHECK-64: (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
-// CHECK-64:   (field name=_value offset=0
-// CHECK-64:     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))
+// CHECK-64: (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:   (case name=only index=0 offset=0
+// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64:       (field name=_value offset=0
+// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 // CHECK-64: Enum value:
-// CHECK-64: (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
-// CHECK-64:   (field name=_value offset=0
-// CHECK-64:     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))
+// CHECK-64: (enum_value name=only index=0
+// CHECK-64: (struct Swift.Int)
+// CHECK-64: )
 
 doneReflecting()
 

--- a/validation-test/Reflection/reflect_Enum_SingleCasePointerPayload.swift
+++ b/validation-test/Reflection/reflect_Enum_SingleCasePointerPayload.swift
@@ -38,21 +38,29 @@ reflect(object: ClassWithSingleCasePointerPayloadEnum())
 // CHECK-64:   (field name=e1 offset=16
 // CHECK-64:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-1]] bitwise_takable=1
 // CHECK-64:       (case name=some index=0 offset=0
-// CHECK-64:         (reference kind=strong refcounting=native))
+// CHECK-64:         (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
+// CHECK-64:           (case name=only index=0 offset=0
+// CHECK-64:             (reference kind=strong refcounting=native))))
 // CHECK-64:       (case name=none index=1)))
 // CHECK-64:   (field name=e2 offset=24
-// CHECK-64:     (reference kind=strong refcounting=native))
+// CHECK-64:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
+// CHECK-64:       (case name=only index=0 offset=0
+// CHECK-64:         (reference kind=strong refcounting=native))))
 // CHECK-64:   (field name=e3 offset=32
 // CHECK-64:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-1]] bitwise_takable=1
 // CHECK-64:       (case name=some index=0 offset=0
-// CHECK-64:         (reference kind=strong refcounting=native))
+// CHECK-64:         (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
+// CHECK-64:           (case name=only index=0 offset=0
+// CHECK-64:             (reference kind=strong refcounting=native))))
 // CHECK-64:       (case name=none index=1)))
 // CHECK-64:   (field name=e4 offset=40
 // CHECK-64:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-2]] bitwise_takable=1
 // CHECK-64:       (case name=some index=0 offset=0
 // CHECK-64:         (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-1]] bitwise_takable=1
 // CHECK-64:           (case name=some index=0 offset=0
-// CHECK-64:             (reference kind=strong refcounting=native))
+// CHECK-64:             (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
+// CHECK-64:               (case name=only index=0 offset=0
+// CHECK-64:                 (reference kind=strong refcounting=native))))
 // CHECK-64:           (case name=none index=1)))
 // CHECK-64:       (case name=none index=1))))
 
@@ -66,21 +74,29 @@ reflect(object: ClassWithSingleCasePointerPayloadEnum())
 // CHECK-32:   (field name=e1 offset=8
 // CHECK-32:     (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095 bitwise_takable=1
 // CHECK-32:       (case name=some index=0 offset=0
-// CHECK-32:         (reference kind=strong refcounting=native))
+// CHECK-32:         (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
+// CHECK-32:           (case name=only index=0 offset=0
+// CHECK-32:             (reference kind=strong refcounting=native))))
 // CHECK-32:       (case name=none index=1)))
 // CHECK-32:   (field name=e2 offset=12
-// CHECK-32:     (reference kind=strong refcounting=native))
+// CHECK-32:     (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
+// CHECK-32:       (case name=only index=0 offset=0
+// CHECK-32:         (reference kind=strong refcounting=native))))
 // CHECK-32:   (field name=e3 offset=16
 // CHECK-32:     (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095 bitwise_takable=1
 // CHECK-32:       (case name=some index=0 offset=0
-// CHECK-32:         (reference kind=strong refcounting=native))
+// CHECK-32:         (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
+// CHECK-32:           (case name=only index=0 offset=0
+// CHECK-32:             (reference kind=strong refcounting=native))))
 // CHECK-32:       (case name=none index=1)))
 // CHECK-32:   (field name=e4 offset=20
 // CHECK-32:     (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4094 bitwise_takable=1
 // CHECK-32:       (case name=some index=0 offset=0
 // CHECK-32:         (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095 bitwise_takable=1
 // CHECK-32:           (case name=some index=0 offset=0
-// CHECK-32:             (reference kind=strong refcounting=native))
+// CHECK-32:             (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
+// CHECK-32:               (case name=only index=0 offset=0
+// CHECK-32:                 (reference kind=strong refcounting=native))))
 // CHECK-32:           (case name=none index=1)))
 // CHECK-32:       (case name=none index=1))))
 
@@ -93,10 +109,14 @@ reflect(enum: SingleCasePointerPayloadEnum.only(Marker()))
 // CHECK-64: (enum reflect_Enum_SingleCasePointerPayload.SingleCasePointerPayloadEnum)
 
 // CHECK-64: Type info:
-// CHECK-64: (reference kind=strong refcounting=native)
+// CHECK-64: (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
+// CHECK-64:   (case name=only index=0 offset=0
+// CHECK-64:     (reference kind=strong refcounting=native)))
 
 // CHECK-64: Enum value:
-// CHECK-64: (reference kind=strong refcounting=native)
+// CHECK-64: (enum_value name=only index=0
+// CHECK-64: (class reflect_Enum_SingleCasePointerPayload.Marker)
+// CHECK-64: )
 
 // CHECK-32: Reflecting an enum.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
@@ -105,10 +125,14 @@ reflect(enum: SingleCasePointerPayloadEnum.only(Marker()))
 // CHECK-32: (enum reflect_Enum_SingleCasePointerPayload.SingleCasePointerPayloadEnum)
 
 // CHECK-32: Type info:
-// CHECK-32: (reference kind=strong refcounting=native)
+// CHECK-32: (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
+// CHECK-32:   (case name=only index=0 offset=0
+// CHECK-32:     (reference kind=strong refcounting=native)))
 
 // CHECK-32: Enum value:
-// CHECK-32: (reference kind=strong refcounting=native)
+// CHECK-32: (enum_value name=only index=0
+// CHECK-32: (class reflect_Enum_SingleCasePointerPayload.Marker)
+// CHECK-32: )
 
 doneReflecting()
 


### PR DESCRIPTION
…d-only enums

Previously, EnumTypeInfoBuilder::build() returned the raw payload TypeInfo directly when an enum had exactly one case with a payload and no other cases. This lost the enum wrapper, causing clients to lose on enum information.
