### PR TITLE
[Completion] Disable an assertion for now

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1639,8 +1639,11 @@ void CodeCompletionCallbacksImpl::readyForTypeChecking(SourceFile *SrcFile) {
   default:
     break;
   }
-  ASSERT(!ParsedExpr || Kind == CompletionKind::KeyPathExprObjC
-         && "Should use solver-based completion for expressions");
+  // FIXME: We ought to enable the below assertion to make sure expressions
+  // are handled using solver-based completion, but that can be tripped up by
+  // lookaheads in the parser (https://github.com/swiftlang/swift/issues/87338).
+  //  ASSERT(!ParsedExpr || Kind == CompletionKind::KeyPathExprObjC
+  //         && "Should use solver-based completion for expressions");
 
   // Add keywords even if type checking fails completely.
   addKeywords(CompletionContext.getResultSink(), MaybeFuncBody);

--- a/validation-test/IDE/crashers_fixed/CodeCompletionCallbacksImpl-readyForTypeChecking-59c26c.swift
+++ b/validation-test/IDE/crashers_fixed/CodeCompletionCallbacksImpl-readyForTypeChecking-59c26c.swift
@@ -1,0 +1,4 @@
+// {"kind":"complete","original":"06e7188f","signature":"(anonymous namespace)::CodeCompletionCallbacksImpl::readyForTypeChecking(swift::SourceFile*)","signatureAssert":"Assertion failed: (!ParsedExpr || Kind == CompletionKind::KeyPathExprObjC && \"Should use solver-based completion for expressions\"), function readyForTypeChecking"}
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+case (a: b#^^#
+<#expression#>


### PR DESCRIPTION
We ought to re-enable this once we're able to rollback completion state when backtracking in the parser (#87338).