### PR TITLE
LifetimeDependence: static method type lifetimes with uncurrying

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -8357,6 +8357,9 @@ public:
   }
   ParamDecl *getImplicitSelfDecl(bool createIfNeeded=true);
 
+  /// Whether the function is a non-static method.
+  bool isInstanceMethod() const { return hasImplicitSelfDecl() && !isStatic(); }
+
   /// Retrieve the declaration that this method overrides, if any.
   AbstractFunctionDecl *getOverriddenDecl() const {
     return cast_or_null<AbstractFunctionDecl>(ValueDecl::getOverriddenDecl());

--- a/include/swift/AST/LifetimeDependence.h
+++ b/include/swift/AST/LifetimeDependence.h
@@ -379,6 +379,21 @@ public:
              ArrayRef<LifetimeTypeAttr *> lifetimeAttributes, DeclContext *dc,
              GenericEnvironment *env);
 
+  /// Compute a LifetimeDependenceInfo list for the uncurried form of a curried
+  /// function whose inner type has LifetimeDependenceInfo list
+  /// 'inner'.
+  ///
+  /// TODO: Add support for merging with lifetime dependencies from the outer
+  /// type. The outer type's result's dependencies should be copied to any
+  /// inner-type dependencies that include closure context dependencies,
+  /// replacing the closure context dependence for those entries.
+  ///
+  /// numInnerParams: number of parameters of the inner function type
+  /// numOuterParams: number of parameters of the outer function type
+  static ArrayRef<LifetimeDependenceInfo>
+  uncurry(ASTContext &ctx, ArrayRef<LifetimeDependenceInfo> inner,
+          unsigned numInnerParams, unsigned numOuterParams);
+
   bool operator==(const LifetimeDependenceInfo &other) const {
     return this->hasImmortalSpecifier() == other.hasImmortalSpecifier() &&
            this->getTargetIndex() == other.getTargetIndex() &&

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2218,7 +2218,7 @@ namespace {
       fd->addAttribute(new (Impl.SwiftContext) UnsafeAttr(/*Implicit=*/true));
 
       unsigned resultIndex = fd->getParameters()->size();
-      if (fd->hasImplicitSelfDecl()) {
+      if (fd->isInstanceMethod()) {
         ++resultIndex;
       }
       SmallVector<LifetimeDependenceInfo, 1> lifetimeDependencies;
@@ -4427,7 +4427,7 @@ namespace {
 
       auto swiftParams = result->getParameters();
       bool hasSelf =
-          result->hasImplicitSelfDecl() && !isa<ConstructorDecl>(result);
+          result->isInstanceMethod() && !isa<ConstructorDecl>(result);
       auto returnIdx = swiftParams->size() + hasSelf;
 
       if (inferSelfDependence(decl, result, returnIdx))

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2505,6 +2505,7 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
 
     auto sig = AFD->getGenericSignature();
     bool hasSelf = AFD->hasImplicitSelfDecl();
+    bool isInstanceMethod = AFD->isInstanceMethod();
 
     AnyFunctionType::ExtInfoBuilder infoBuilder;
 
@@ -2558,8 +2559,9 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
           infoBuilder = infoBuilder.withSendingResult();
       }
 
-      // Lifetime dependencies only apply to the outer function type.
-      if (!hasSelf && lifetimeDependenceInfo.has_value()) {
+      // Lifetime dependencies only apply to the outer function type for
+      // instance methods.
+      if (lifetimeDependenceInfo.has_value() && !isInstanceMethod) {
         infoBuilder =
             infoBuilder.withLifetimeDependencies(*lifetimeDependenceInfo);
       }
@@ -2579,7 +2581,7 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
       auto selfParam = computeSelfParam(AFD);
       AnyFunctionType::ExtInfoBuilder selfInfoBuilder;
       maybeAddParameterIsolation(selfInfoBuilder, {selfParam});
-      if (lifetimeDependenceInfo.has_value()) {
+      if (lifetimeDependenceInfo.has_value() && isInstanceMethod) {
         selfInfoBuilder =
             selfInfoBuilder.withLifetimeDependencies(*lifetimeDependenceInfo);
       }

--- a/test/Sema/lifetime_dependence_functype.swift
+++ b/test/Sema/lifetime_dependence_functype.swift
@@ -173,11 +173,6 @@ do {
   var y = NE()
   takeGetGenericAndArgs(f: { $0 = $1 }, o: &y, i: x) // OK
 }
-do {
-  let _ = transfer // OK
-  let _: (NE) -> NE = transfer // OK
-  let _: @_lifetime(copy ne) (_ ne: NE) -> NE = transfer // OK
-}
 
 // rdar://166912068 (Incorrect error when passing a local function with a non-escapable parameter)
 struct NEWithSpan: ~Escapable {


### PR DESCRIPTION
Fixes: rdar://170594059 (feature not implemented: nontrivial thin function reference)

The formal types of all methods are curried:

- Instance method: `(Self) -> (Params...) -> Result`
- Static method: `(Self.Type) -> (Params...) -> Result`

To be able to express lifetime dependencies on the self parameter, the lifetime
dependence information is computed as though the type has been uncurried (which
it will be during SILGen), and attached to the outer function type:

    (Params..., Self) -> Result

This causes the lifetime dependence information to be lost when referring to the
inner function type (which is of more interest in most cases). Representing the
lifetimes this way is (mostly) unnecessary for static methods, since there is no
instance of the type to depend on.

We now attach lifetime dependence information to the inner function type for
static methods. This allows us to convert static methods to their inner function
types without losing their lifetime dependence information.

Once we add support for dependencies on the captured context, we will be able to
use a similar representation for instance methods.

The only complication is that the lifetime information attached to the inner
function type must be "uncurried" when lowering static methods to SIL. This will
also be necessary for closures when we add support for dependencies on the
closure context. See LifetimeDependenceInfo::uncurry.

Example:

    struct S {
      static func f(ne: NE) -> NE { ne }
    }

- Before: S.f had type `@_lifetime(2: copy 0) (S.Type) -> (NE) -> NE`.
- Now: S.f has type `(S.Type) -> @_lifetime(copy 0) (NE) -> NE`.

In the short term, this makes it impossible to express lifetime dependencies on
the self parameter of a static method (i.e. S.Type), which should almost never
be necessary.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
