### PR TITLE
Add additional diagnostics for borrow/mutate accessors 

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -1275,6 +1275,8 @@ NOTE(borrow_accessor_not_a_projection_note, none,
 ERROR(invalid_multiple_return_borrow_accessor, none,
       "multiple return statements in borrow accessors are not yet supported",
       ())
-
+ERROR(unsupported_borrow_abstraction, none,
+      "cannot witness borrow requirement for result type %0",
+      (Type))
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/test/SILGen/borrow_accessor.swift
+++ b/test/SILGen/borrow_accessor.swift
@@ -100,6 +100,15 @@ public struct Wrapper {
       return &_k
     }
   }
+
+  var id_ownership_modifier: Int {
+    borrowing borrow {
+      return _id
+    }
+    mutating mutate {
+      return &_id
+    }
+  }
 }
 
 public struct SimpleWrapper<T> {

--- a/test/SILGen/borrow_accessor_failures.swift
+++ b/test/SILGen/borrow_accessor_failures.swift
@@ -279,3 +279,25 @@ struct ExampleWithLazyProp {
   }
 }
 
+public struct Container<Element: ~Copyable >: ~Copyable {
+  var _storage1: UnsafeMutableBufferPointer<Element>
+  var _storage2: UnsafeMutableBufferPointer<Element>
+
+  var first: Element {
+    @_unsafeSelfDependentResult
+    borrow {
+      if (Int.random(in: 1...1000) % 2 == 0) {
+        return unsafe _storage1.baseAddress.unsafelyUnwrapped.pointee
+      }
+      return unsafe _storage2.baseAddress.unsafelyUnwrapped.pointee // expected-error {{multiple return statements in borrow accessors are not yet supported}}
+    }
+    @_unsafeSelfDependentResult
+    mutate {
+      if (Int.random(in: 1...1000) % 2 == 0) {
+        return unsafe &_storage1.baseAddress.unsafelyUnwrapped.pointee
+      }
+      return unsafe &_storage2.baseAddress.unsafelyUnwrapped.pointee // expected-error {{multiple return statements in borrow accessors are not yet supported}}
+    }
+  }
+}
+

--- a/test/SILGen/borrow_accessor_reabstraction.swift
+++ b/test/SILGen/borrow_accessor_reabstraction.swift
@@ -1,0 +1,69 @@
+// RUN: %target-swift-frontend -enable-experimental-feature BorrowAndMutateAccessors -emit-silgen %s -verify
+// RUN: %target-swift-frontend -enable-experimental-feature BorrowAndMutateAccessors -emit-silgen -enable-library-evolution %s -verify
+
+public protocol P {
+  associatedtype Element
+  var id: Element { borrow mutate }
+}
+
+public struct S1 : P {
+  public typealias Element = Int
+  var _id: Int
+
+  public var id: Int {
+    borrow { // expected-error{{cannot witness borrow requirement for result type 'Int'}}
+      return _id
+    }
+    mutate {
+      return &_id
+    }
+  }
+}
+
+public struct S2 : P {
+  public typealias Element = Int
+  public var id: Int // expected-error{{cannot witness borrow requirement for result type 'Int'}}
+}
+
+public struct S3 : P {
+  public typealias Element = String
+  var _id: String
+
+  public var id: String {
+    borrow {
+      return _id
+    }
+    mutate {
+      return &_id
+    }
+  }
+}
+
+public protocol ThingHolder {
+  associatedtype Thing
+  var thing: Thing { borrow }
+}
+
+public struct ClosureHolder: ThingHolder {
+  var theThing: () -> ()
+  public var thing: () -> () { borrow { return theThing } } // expected-error{{cannot witness borrow requirement for result type '() -> ()'}}
+}
+
+public protocol Q {
+  associatedtype Element
+  var id: Element { borrow mutate }
+}
+
+public struct OptionalConformer<Element> : Q {
+  var _id: Element?
+
+  public var id: Element? {
+    borrow {
+      return _id
+    }
+    mutate {
+      return &_id
+    }
+  }
+}
+

--- a/test/SILGen/borrow_accessor_reabstraction.swift
+++ b/test/SILGen/borrow_accessor_reabstraction.swift
@@ -1,6 +1,8 @@
 // RUN: %target-swift-frontend -enable-experimental-feature BorrowAndMutateAccessors -emit-silgen %s -verify
 // RUN: %target-swift-frontend -enable-experimental-feature BorrowAndMutateAccessors -emit-silgen -enable-library-evolution %s -verify
 
+// REQUIRES: swift_feature_BorrowAndMutateAccessors
+
 public protocol P {
   associatedtype Element
   var id: Element { borrow mutate }

--- a/test/Sema/borrow_and_mutate_accessors.swift
+++ b/test/Sema/borrow_and_mutate_accessors.swift
@@ -28,6 +28,15 @@ struct Struct {
       return &_k
     }
   }
+
+  var k3: Klass {
+    borrowing borrow {
+      return _k
+    }
+    borrowing mutate { // expected-error{{a 'mutate' accessor cannot be declared borrowing}}
+      return &_k // expected-error{{}}
+    }
+  }
 }
 
 extension Klass {


### PR DESCRIPTION
- Add a diagnostic when a borrow accessor cannot witness the protocol requirement due to reabstraction differences. 
- Add some general borrow accessor diagnostics that were missing when annotated with @_unsafeSelfDependentResult