### PR TITLE
[Parse] Add fix-it for missing type annotation in all computed proper…

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -8062,6 +8062,12 @@ struct Parser::ParsedAccessors {
       return Mutate;
     return nullptr;
   }
+
+  bool hasNonObservingAccessor() const {
+    return Get || DistributedGet || Set || Read || YieldingBorrow || 
+           Modify || YieldingMutate || Address || MutableAddress || 
+           Init || Borrow || Mutate;
+  }
 };
 
 static ParserStatus parseAccessorIntroducer(Parser &P,
@@ -8664,8 +8670,7 @@ Parser::parseDeclVarGetSet(PatternBindingEntry &entry, ParseDeclOptions Flags,
     return nullptr;
 
   if (!typedPattern) {
-    if (accessors.Get || accessors.Set || accessors.Address ||
-        accessors.MutableAddress) {
+    if (accessors.hasNonObservingAccessor()) {
       SourceLoc locAfterPattern = pattern->getLoc().getAdvancedLoc(
         pattern->getBoundName().getLength());
       diagnose(pattern->getLoc(), diag::computed_property_missing_type)

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -276,6 +276,18 @@ var x2 { // expected-error{{computed property must have an explicit type}} {{7-7
   }
 }
 
+var x2_read { // expected-error{{computed property must have an explicit type}} {{12-12=: <# Type #>}} expected-error{{type annotation missing in pattern}}
+  _read {
+    yield _x
+  }
+}
+
+var x2_modify { // expected-error{{computed property must have an explicit type}} {{14-14=: <# Type #>}} expected-error{{type annotation missing in pattern}}
+  _modify {
+    yield &_x // expected-error{{cannot yield reference to storage of type 'X' as an inout yield of type '_'}}
+  }
+}
+
 var (x3): X { // expected-error{{getter/setter can only be defined for a single variable}}
   get {
     return _x


### PR DESCRIPTION
Fixes #87324

Previously, the diagnostic with fix-it `: <# Type #>` was only shown for 
computed properties using get, set, unsafeAddress, or unsafeMutableAddress.

This extends the fix-it to ALL non-observing accessors including _read, 
_modify, and other accessor types.

Added hasNonObservingAccessor() helper method to check for any accessor 
that makes a property computed (excluding willSet/didSet).

Test coverage added for all accessor types.