### PR TITLE
SILGen: avoid source-break-by-assert for unowned actor capture

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -2175,7 +2175,7 @@ public:
                            CanType FormalConcreteType, SILValue Concrete,
                            ArrayRef<ProtocolConformanceRef> Conformances,
                            ValueOwnershipKind forwardingOwnershipKind) {
-    ASSERT(FormalConcreteType->isBridgeableObjectType());
+    assert(FormalConcreteType->isBridgeableObjectType());
     return insert(InitExistentialRefInst::create(
         getSILDebugLocation(Loc), ExistentialType, FormalConcreteType, Concrete,
         Conformances, &getFunction(), forwardingOwnershipKind));

--- a/test/SILGen/isolated_any_issue-77365-noasserts.swift
+++ b/test/SILGen/isolated_any_issue-77365-noasserts.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-emit-sil %s -swift-version 5
+// RUN: %target-swift-emit-sil %s -swift-version 6
+
+// REQUIRES: concurrency
+// REQUIRES: no_asserts
+
+actor A {
+  func f() {
+    let _: @isolated(any) () -> Void = { [unowned self] in
+        self.preconditionIsolated()
+    }
+  }
+
+  func g() {
+    Task {
+        [unowned self] in
+        self.preconditionIsolated()
+    }
+  }
+}

--- a/test/SILGen/isolated_any_issue-77365.swift
+++ b/test/SILGen/isolated_any_issue-77365.swift
@@ -2,6 +2,7 @@
 // RUN: not --crash %target-swift-emit-silgen %s -swift-version 6 -sil-verify-none 2>&1 | %FileCheck %s
 
 // REQUIRES: concurrency
+// REQUIRES: asserts
 
 // https://github.com/swiftlang/swift/issues/77365
 // FIXME: This sort of pattern should be diagnosed as an error in Sema if possible.


### PR DESCRIPTION
In e87857d57ea62aab5103444e8abf1ebf5bea67a9 an existing asserts-build-only assertion was sunk and upgraded to an always-on ASSERT. While well-intentioned to help avoid a possible miscompile, it has the effect of introducing a source break in production builds of the compiler via an assertion crash, which is not good and sows confusion.

rdar://170678242