### PR TITLE
[CS] A couple more Sendable dependence fixes

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6948,9 +6948,15 @@ bool swift::contextRequiresStrictConcurrencyChecking(
         }
 
         if (auto type = getType(closure)) {
-          if (auto fnType = type->getAs<AnyFunctionType>())
-            if (fnType->isAsync() || fnType->isSendable())
+          if (auto fnType = type->getAs<AnyFunctionType>()) {
+            // Check if the closure is async or Sendable. Ignore Sendable
+            // dependence for the purposes of this check since we don't know
+            // whether or not the closure is Sendable.
+            if (fnType->isAsync() ||
+                (!fnType->getSendableDependentType() && fnType->isSendable())) {
               return true;
+            }
+          }
         }
       }
 

--- a/validation-test/compiler_crashers_fixed/AnyFunctionType-isSendable-5b9a95.swift
+++ b/validation-test/compiler_crashers_fixed/AnyFunctionType-isSendable-5b9a95.swift
@@ -1,0 +1,6 @@
+// {"frontendArgs":["-typecheck","-enable-upcoming-feature","InferSendableFromCaptures","-strict-concurrency=minimal"],"kind":"custom","signature":"swift::AnyFunctionType::isSendable() const","signatureAssert":"Assertion failed: (!hasSendableDependentType() && \"Query Sendable dependence first\"), function isSendable"}
+// RUN: not %target-swift-frontend -typecheck -enable-upcoming-feature InferSendableFromCaptures -strict-concurrency=minimal %s
+// REQUIRES: swift_feature_InferSendableFromCaptures
+func a()[].reduce = {
+  a
+}

--- a/validation-test/compiler_crashers_fixed/AnyFunctionType-isSendable-b243b8.swift
+++ b/validation-test/compiler_crashers_fixed/AnyFunctionType-isSendable-b243b8.swift
@@ -1,0 +1,3 @@
+// {"kind":"typecheck","languageMode":6,"original":"1d5c6bbb","signature":"swift::AnyFunctionType::isSendable() const","signatureAssert":"Assertion failed: (!hasSendableDependentType() && \"Query Sendable dependence first\"), function isSendable"}
+// RUN: not %target-swift-frontend -typecheck -swift-version 6 %s
+.appending ?? \a


### PR DESCRIPTION
Delay conformance lookup to Sendable for a Sendable-dependent functions, and treat a Sendable-dependent closure as non-Sendable in `contextRequiresStrictConcurrencyChecking`.