### PR TITLE
LifetimeDependenceUtils: add support for mutable captures

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
@@ -1116,7 +1116,7 @@ extension LifetimeDependenceDefUseWalker {
       return escapingDependence(on: localAccess.operand!)
     case .outgoingArgument:
       let arg = allocation as! FunctionArgument
-      assert(arg.type.isAddress, "returned local must be allocated with an indirect argument")
+      assert(arg.type.isAddress || arg.type.isBox, "returned local must be allocated with an indirect argument")
       return inoutDependence(argument: arg, functionExit: localAccess.instruction!)
     case .inoutYield:
       return yieldedDependence(result: localAccess.operand!)

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LocalVariableUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LocalVariableUtils.swift
@@ -320,6 +320,9 @@ struct LocalVariableAccessMap: Collection, CustomStringConvertible {
       case .indirectOut:
         self.isLiveIn = false
         self.isLiveOut = true
+      case .directGuaranteed: // Box captured by closure
+        self.isLiveIn = true
+        self.isLiveOut = true
       default:
         return nil
       }


### PR DESCRIPTION
A mutable capture is always escaping. Naturally, you can't mutably capture a
non-Escapable value. Nonetheless, code may override the lifetime of the captured
value as immortal, knowing that the closure does not actually escape.

'_overrideLifetime(capturedThing, copying: ())' quiets the diagnostics
on the caller side. But, when diagnosing the closure body itself, lifetime
analysis is upset by the boxed non-Escaping value. Simply add a case
to LocalVariableAccessMap to recognize this as a valid case so that diagnostics
can ignore it.

Fixes rdar://170592353 (error: lifetime-dependent variable 'overriddenLifetime'
escapes its scope)
