### PR TITLE
[CMAKE] don't expand the var CMAKE_SYSTEM_PROCESSOR to a string when …

### DIFF
--- a/Runtimes/Supplemental/Runtime/CMakeLists.txt
+++ b/Runtimes/Supplemental/Runtime/CMakeLists.txt
@@ -98,7 +98,7 @@ add_compile_options(
   "$<$<AND:$<BOOL:${${PROJECT_NAME}_ENABLE_LIBRARY_EVOLUTION}>,$<COMPILE_LANGUAGE:Swift>>:-enable-library-evolution>"
   "$<$<AND:$<BOOL:${${PROJECT_NAME}_ENABLE_PRESPECIALIZATION}>,$<COMPILE_LANGUAGE:Swift>>:SHELL:-Xfrontend -prespecialize-generic-metadata>")
 
-if(WIN32 AND ${CMAKE_SYSTEM_PROCESSOR} MATCHES "X86")
+if(WIN32 AND CMAKE_SYSTEM_PROCESSOR MATCHES "X86")
   # Turn on /safeseh for 32-bit x86 or we won't be able to link
   add_compile_options($<$<COMPILE_LANGUAGE:ASM_MASM>:/safeseh>)
 endif()


### PR DESCRIPTION
When performing the check `if(WIN32 AND ${CMAKE_SYSTEM_PROCESSOR} MATCHES "X86")` using `${CMAKE_SYSTEM_PROCESSOR}` expands the variable eagerly, if it's empty it would lead to an error

```
  CMake Error at CMakeLists.txt:101 (if):
    if given arguments:

      "WIN32" "AND" "MATCHES" "X86"

    Unknown arguments specified
```
since cmake can't parse it properly. Instead use the variable name which will evaluate to either true/false and not break the parsing
https://cmake.org/cmake/help/latest/command/if.html#variable-expansion

We are seeing this on apple builds because our vendor caches don't set CMAKE_SYSTEM_PROCESSOR when cross compiling