### PR TITLE
[ConstraintSystem] A few fixes for interaction between typed throws feature and closures

### DIFF
--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -954,7 +954,11 @@ public:
 #ifndef NDEBUG
     auto fnType1 = fromType->castTo<FunctionType>();
     auto fnType2 = toType->castTo<FunctionType>();
-    assert(fnType1->isThrowing() != fnType2->isThrowing());
+    // FIXME: `AnyFunctionType::isThrowing` is going to produce `true` for
+    // function that's with `throws(Never)`, we need to address that in
+    // `TypeSimplifier`.
+    assert(fnType1->getEffectiveThrownErrorType() &&
+           !fnType2->getEffectiveThrownErrorType());
 #endif
   }
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1979,15 +1979,6 @@ namespace {
         if (closure->getThrowsLoc().isValid())
           return Type();
 
-        // Thrown type inferred from context.
-        if (auto contextualType = CS.getContextualType(
-                closure, /*forConstraint=*/false)) {
-          if (auto fnType = contextualType->getAs<AnyFunctionType>()) {
-            if (Type thrownErrorTy = fnType->getThrownError())
-              return thrownErrorTy;
-          }
-        }
-
         // We do not try to infer a thrown error type if one isn't immediately
         // available.
         return Type();

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -12389,7 +12389,6 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
     parameters.push_back(param);
   }
 
-  // Propagate @Sendable from the contextual type to the closure.
   auto closureExtInfo = inferredClosureType->getExtInfo();
   if (auto contextualFnType = contextualType->getAs<FunctionType>()) {
     if (!closureExtInfo.isSendable()) {
@@ -12398,6 +12397,23 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
       } else if (contextualFnType->isSendable()) {
         closureExtInfo = closureExtInfo.withSendable();
       }
+    }
+
+    auto inferredThrownErrorType =
+        inferredClosureType->getEffectiveThrownErrorTypeOrNever();
+    // In a typed throws context a throwing closure (as determined from the
+    // body or an explicit type) assumes an error type of the context if it's
+    // fully resolved. Do nothing if closure is either non-throwing
+    // or has an explicit typed throws annotation.
+    if (inferredThrownErrorType->isErrorExistentialType()) {
+      auto errorTy = contextualFnType->getEffectiveThrownErrorTypeOrNever();
+      // Don't propagate if the contextual error type:
+      //   - requires inference;
+      //   - is `Never` which means the contextu is non-throwing;
+      //   - is `any Error` which already matches the inferred type of the closure.
+      if (!(errorTy->hasTypeVariable() || errorTy->isNever() ||
+            errorTy->isErrorExistentialType()))
+        closureExtInfo = closureExtInfo.withThrows(/*throws=*/true, errorTy);
     }
   }
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -505,7 +505,8 @@ Type ConstraintSystem::getCaughtErrorType(CatchNode catchNode) {
   // FIXME: This will need to change when we do inference of thrown error
   // types in closures.
   if (auto closure = catchNode.dyn_cast<ClosureExpr *>()) {
-    return getClosureType(closure)->getEffectiveThrownErrorTypeOrNever();
+    auto closureTy = simplifyType(getType(closure))->castTo<FunctionType>();
+    return closureTy->getEffectiveThrownErrorTypeOrNever();
   }
 
   if (!ctx.LangOpts.hasFeature(Feature::FullTypedThrows))

--- a/test/expr/closure/typed_throws.swift
+++ b/test/expr/closure/typed_throws.swift
@@ -10,6 +10,17 @@ enum MyBadError {
 
 struct GenericError<T>: Error {}
 
+func testThrowsOverloadedOnNever() {
+  func foo(_ fn: () throws -> Void) {}
+  func foo(_ fn: () throws(Never) -> Void) {}
+
+  func bar() throws {}
+
+  foo {
+    try bar() // Ok
+  }
+}
+
 func testClosures() {
   let c1 = { () throws(MyError) in
     throw .fail
@@ -19,12 +30,11 @@ func testClosures() {
   // expected-error@-1{{invalid conversion from throwing function of type '() throws(MyError) -> ()'}}
 
   let _: () throws(MyError) -> Void = {
-    // NOTE: under full typed throws, this should succeed
-    throw MyError.fail // expected-error{{thrown expression type 'any Error' cannot be converted to error type 'MyError'}}
+    throw MyError.fail // Ok
   }
 
   let _: () throws(MyError) -> Void = {
-    throw .fail // expected-error{{type 'any Error' has no member 'fail'}}
+    throw .fail // Ok
   }
 
   // FIXME: Terrible diagnostic.

--- a/test/expr/closure/typed_throws.swift
+++ b/test/expr/closure/typed_throws.swift
@@ -37,6 +37,19 @@ func testClosures() {
     throw .fail // Ok
   }
 
+  let _: () throws(Never) -> Void = { () throws in } // Ok
+  // expected-error@-1 {{invalid conversion from throwing function of type '() throws -> Void' to non-throwing function type '() throws(Never) -> Void'}}
+
+  let _: () throws(Never) -> Void = {
+    // expected-error@-1 {{invalid conversion from throwing function of type '() throws -> Void' to non-throwing function type '() throws(Never) -> Void'}}
+    throw MyError.fail
+  }
+
+  let _: () throws(Never) -> Void = { () throws in
+    // expected-error@-1 {{invalid conversion from throwing function of type '() throws -> Void' to non-throwing function type '() throws(Never) -> Void'}}
+    throw MyError.fail
+  }
+
   // FIXME: Terrible diagnostic.
   // expected-error@+1{{unable to infer closure type without a type annotation}}
   let _ = { () throws(MyBadError) in
@@ -53,3 +66,9 @@ func testClosures() {
   _ = { () throws(GenericError<_>) in } // expected-error {{type placeholder not allowed here}}
 }
 
+func testThrowsMismatch(fn: () throws -> Void) {
+  func test(_: () throws(Never) -> Void) {}
+
+  test(fn)
+  // expected-error@-1 {{invalid conversion from throwing function of type '() throws -> Void' to non-throwing function type '() throws(Never) -> Void'}}
+}


### PR DESCRIPTION
- Removes a special case for contextual type and instead assume typed throws onto a closure during resolution. That would make sure that a contextual type of any position (i.e. parameter) is accepted.
- Fixes an assertion failure in `ThrowingFunctionConversionFailure`
- Adds a new more tests that use `throws(Never)` with closures and function values.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
