### PR TITLE
Avoid automatically making pack argument into tuple

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6403,6 +6403,9 @@ ERROR(expansion_expr_not_allowed,none,
 ERROR(invalid_expansion_argument,none,
       "cannot pass value pack expansion to non-pack parameter of type %0",
       (Type))
+NOTE(did_you_mean_tuple_pack_expansion,none,
+      "did you mean to expand the pack into a tuple?",
+      ())
 ERROR(expansion_not_variadic,none,
       "pack expansion %0 must contain at least one pack reference", (Type))
 ERROR(pack_reference_outside_expansion,none,

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -608,6 +608,47 @@ do {
   }
 }
 
+// https://github.com/swiftlang/swift/issues/69245
+do {
+  func want_tuple<each T>(_ arg: (repeat each T)) {}
+  func give_arg<each T>(_ arg: repeat each T) {
+  	want_tuple(repeat each arg)
+    // expected-error@-1 {{cannot pass value pack expansion to non-pack parameter of type '(repeat each T)'}}
+    // expected-note@-2 {{did you mean to expand the pack into a tuple?}} {{15-15=(}}{{30-30=)}}
+  }
+
+  func want_tuples<each T>(a: (repeat each T), b: (repeat each T)) {}
+  func give_args<each T>(_ arg: repeat each T) {
+    want_tuples(a: repeat each arg, b: repeat each arg)
+    // expected-error@-1 2 {{cannot pass value pack expansion to non-pack parameter of type '(repeat each T)'}}
+    // expected-note@-2:20 {{did you mean to expand the pack into a tuple?}} {{20-20=(}}{{35-35=)}}
+    // expected-note@-3:40 {{did you mean to expand the pack into a tuple?}} {{40-40=(}}{{55-55=)}}
+  }
+
+  struct S<each T> {
+    let tuple: (repeat each T)
+  }
+
+  func initWithPack<each T>(xs: repeat each T) -> S<repeat each T> {
+    return S(tuple: repeat each xs)
+    // expected-error@-1 {{cannot pass value pack expansion to non-pack parameter of type '(repeat each T)'}}
+    // expected-note@-2 {{did you mean to expand the pack into a tuple?}} {{21-21=(}}{{35-35=)}}
+  }
+
+  struct Box<T> {
+    let v: T
+    init(_ v: T) {
+      self.v = v
+    }
+  }
+  
+  func wants_nested_tuple<each T>(_ arg: Box<(repeat each T)>) {}
+  func gives_nested<each T>(_ arg: repeat each T) {
+    wants_nested_tuple(Box(repeat each arg))
+    // expected-error@-1 {{cannot pass value pack expansion to non-pack parameter of type 'T'}}
+  }
+}
+
 // rdar://110401127 - name lookup bug when abstract tuple stored property shadows a global
 do {
   let c = [false, true]

--- a/validation-test/compiler_crashers_fixed/ExprRewriter-coerceToType-685973.swift
+++ b/validation-test/compiler_crashers_fixed/ExprRewriter-coerceToType-685973.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","signature":"(anonymous namespace)::ExprRewriter::coerceToType(swift::Expr*, swift::Type, swift::constraints::ConstraintLocatorBuilder)"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 struct a < each b : Collection {
       c : ( repeat each b
         extension


### PR DESCRIPTION
Fixes #69245 by ensuring CSSimplify does not wrap PackExpansionType in a tuple when it is the argument for a tuple parameter. This was causing a crash. Also changes matchTypes to wrap such a pack expansion in a tuple after diagnosing so we can infer more types. Adds a tailored diagnostic, note, and fix-it to AllowInvalidPackExpansion for tuple containing pack expansion parameters, that wraps with parens and names tuple parameter instead of non-pack parameter.

```swift
func want_tuple<each T>(_ arg: (repeat each T)) {}
func give_arg<each T>(_ arg: repeat each T) {
	want_tuple(repeat each arg)
}
```
```
error: cannot pass value pack expansion to tuple parameter of type '(repeat each T)'
1 | func want_tuple<each T>(_ arg: (repeat each T)) {}
2 | func give_arg<each T>(_ arg: repeat each T) {
3 |     want_tuple(repeat each arg)
  |             |- error: cannot pass value pack expansion to tuple parameter of type '(repeat each T)'
  |             `- note: did you mean to wrap the argument in a tuple?
4 | }
5 |
```

Not tied to the language in these diagnostics or comments, please let me know how they can be improved.

I'm using clangd which added a couple includes to diagnostics and simplify, should I remove those before committing? I think they are already included transitively.