### PR TITLE
[NFC][Runtime] Remove references to RemoteInspection from Runtime

### DIFF
--- a/stdlib/public/runtime/GenericCacheEntry.h
+++ b/stdlib/public/runtime/GenericCacheEntry.h
@@ -17,7 +17,6 @@
 #include "swift/ABI/Metadata.h"
 #include "swift/ABI/MetadataValues.h"
 #include "swift/Basic/Unreachable.h"
-#include "swift/RemoteInspection/GenericMetadataCacheEntry.h"
 #include "swift/Runtime/LibPrespecialized.h"
 
 namespace swift {

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -31,7 +31,6 @@
 #include "swift/Basic/Range.h"
 #include "swift/Basic/STLExtras.h"
 #include "swift/Demangling/Demangler.h"
-#include "swift/RemoteInspection/GenericMetadataCacheEntry.h"
 #include "swift/Runtime/Borrow.h"
 #include "swift/Runtime/Casting.h"
 #include "swift/Runtime/EnvironmentVariables.h"

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -23,7 +23,6 @@
 #include "swift/Basic/Range.h"
 #include "swift/Demangling/Demangler.h"
 #include "swift/Demangling/TypeDecoder.h"
-#include "swift/RemoteInspection/Records.h"
 #include "swift/Runtime/Casting.h"
 #include "swift/Runtime/Concurrent.h"
 #include "swift/Runtime/Debug.h"
@@ -48,7 +47,8 @@
 
 using namespace swift;
 using namespace Demangle;
-using namespace reflection;
+
+using FieldDescriptor = reflection::TargetFieldDescriptor<InProcess>;
 
 #if SWIFT_OBJC_INTEROP
 #include <objc/runtime.h>


### PR DESCRIPTION
In an effort to disentangle the three sets of llvm headers the targets in stlib uses (real llvm headers, RuntimeHeaders/llvm, stdlib/include/llvm), this patch completely removes the includes from the runtime to RemoteInspection.

This is the first patch to eventually completely remove RuntimeHeaders/llvm headers.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
