### PR TITLE
[Backtracing] If the backtracer crashes, backtrace it (once).

### DIFF
--- a/stdlib/public/runtime/BacktracePrivate.h
+++ b/stdlib/public/runtime/BacktracePrivate.h
@@ -141,6 +141,7 @@ struct BacktraceSettings {
   Symbolication    symbolicate;
   bool             suppressWarnings;
   OutputFormat     format;
+  bool             inBacktracer;
   const char      *swiftBacktracePath;
   const char      *outputPath;
 };

--- a/stdlib/public/runtime/EnvironmentVariables.def
+++ b/stdlib/public/runtime/EnvironmentVariables.def
@@ -125,6 +125,9 @@ VARIABLE(SWIFT_BACKTRACE, string, "",
          "crash catching and backtracing support in the runtime. "
          "See docs/Backtracing.rst in the Swift repository for details.")
 
+VARIABLE(SWIFT_IS_BACKTRACING, bool, false,
+         "Set to `true` if we are running the backtracer.")
+
 VARIABLE(SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE, string, "",
          "Allows for suppressing 'is current executor' equality check crashes. "
          "As since Swift 6.0 checking for current executor equality, may crash "

--- a/test/Backtracing/EarlyMessage.swift
+++ b/test/Backtracing/EarlyMessage.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -parse-as-library -Onone -g -o %t/EarlyMessage.exe
 // RUN: %target-codesign %t/EarlyMessage.exe
-// RUN: ! env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/EarlyMessage.exe > %t/EarlyMessage.out 2>&1
+// RUN: ! env SWIFT_BACKTRACE=enable=yes,cache=no,warnings=suppressed %target-run %t/EarlyMessage.exe > %t/EarlyMessage.out 2>&1
 // RUN: %FileCheck %s < %t/EarlyMessage.out
 
 // UNSUPPORTED: use_os_stdlib


### PR DESCRIPTION
If the backtracer crashes, at present we get no clues as to what went wrong.  This makes it very hard to debug.  Part of the reason for this is that we were worried about it entering a recursive backtracing loop, however not having any messages at all when something goes awry is a bit of a problem.

To address this, have the backtracing code set an environment variable to indicate that we're backtracing, then if we crash with that variable set, disable the backtracer for the subsequent run of the backtracer.  This means that if the initial backtracer instance crashes, we will try to run at most one more instance to backtrace *that*.

rdar://170801141
