### PR TITLE
Fix #87349: Filter cartesian products from pack diagnostics

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2292,34 +2292,147 @@ static bool diagnoseConflictingGenericArguments(ConstraintSystem &cs,
     auto *typeVar = entry.first;
     auto GP = entry.second;
 
-    swift::SmallSetVector<Type, 4> arguments;
+    SmallVector<Type, 4> arguments;
+    llvm::SmallVector<PackType *, 4> allPackTypes;
+    
     for (const auto &solution : solutions) {
       auto type = solution.typeBindings.lookup(typeVar);
-      // Type variables gathered from a solution's type binding context may not
-      // exist in another given solution because some solutions may have
-      // additional type variables not present in other solutions due to taking
-      // different paths in the solver.
       if (!type)
         continue;
 
-      // Contextual opaque result type is uniquely identified by
-      // declaration it's associated with, so we have to compare
-      // declarations instead of using pointer equality on such types.
       if (auto *opaque = type->getAs<OpaqueTypeArchetypeType>()) {
         auto *decl = opaque->getDecl();
-        arguments.remove_if([&](Type argType) -> bool {
-          if (auto *otherOpaque = argType->getAs<OpaqueTypeArchetypeType>()) {
-            return decl == otherOpaque->getDecl();
-          }
-          return false;
-        });
+        arguments.erase(
+          std::remove_if(arguments.begin(), arguments.end(),
+            [&](Type argType) -> bool {
+              if (auto *otherOpaque = argType->getAs<OpaqueTypeArchetypeType>()) {
+                return decl == otherOpaque->getDecl();
+              }
+              return false;
+            }),
+          arguments.end());
       }
 
-      arguments.insert(type);
+      if (auto *packType = type->getAs<PackType>()) {
+        allPackTypes.push_back(packType);
+      } else {
+        bool isDuplicate = false;
+        for (auto existingArg : arguments) {
+          if (type->isEqual(existingArg)) {
+            isDuplicate = true;
+            break;
+          }
+        }
+        
+        if (!isDuplicate)
+          arguments.push_back(type);
+      }
     }
-
-    if (arguments.size() > 1)
-      conflicts[GP].append(arguments.begin(), arguments.end());
+    
+    if (!allPackTypes.empty() && allPackTypes.size() > 1) {
+      unsigned numElements = allPackTypes[0]->getNumElements();
+      llvm::SmallVector<std::pair<PackType *, unsigned>, 4> packWithUniqueCount;
+      
+      for (auto *pack : allPackTypes) {
+        if (pack->getNumElements() != numElements)
+          continue;
+          
+        auto elements = pack->getElementTypes();
+        llvm::SmallSet<CanType, 4> uniqueTypes;
+        for (unsigned i = 0; i < numElements; ++i) {
+          uniqueTypes.insert(elements[i]->getCanonicalType());
+        }
+        
+        packWithUniqueCount.push_back({pack, uniqueTypes.size()});
+      }
+      
+      unsigned minUnique = numElements + 1;
+      unsigned maxUnique = 0;
+      for (auto &entry : packWithUniqueCount) {
+        minUnique = std::min(minUnique, entry.second);
+        maxUnique = std::max(maxUnique, entry.second);
+      }
+      
+      llvm::SmallVector<PackType *, 4> argumentPacks;
+      for (auto &entry : packWithUniqueCount) {
+        if (entry.second == minUnique || entry.second == maxUnique) {
+          argumentPacks.push_back(entry.first);
+        }
+      }
+      
+      for (auto *pack : argumentPacks) {
+        bool isDuplicate = false;
+        for (auto existingArg : arguments) {
+          if (auto *existingPack = existingArg->getAs<PackType>()) {
+            if (pack->getNumElements() == existingPack->getNumElements()) {
+              auto packElements = pack->getElementTypes();
+              auto existingElements = existingPack->getElementTypes();
+              
+              bool allEqual = true;
+              for (unsigned i = 0; i < pack->getNumElements(); ++i) {
+                if (!packElements[i]->getCanonicalType()->isEqual(
+                        existingElements[i]->getCanonicalType())) {
+                  allEqual = false;
+                  break;
+                }
+              }
+              
+              if (allEqual) {
+                isDuplicate = true;
+                break;
+              }
+            }
+          }
+        }
+        
+        if (!isDuplicate)
+          arguments.push_back(Type(pack));
+      }
+    } else if (allPackTypes.size() == 1) {
+      arguments.push_back(Type(allPackTypes[0]));
+    }
+    
+    if (arguments.size() > 1) {
+      auto &conflictList = conflicts[GP];
+      for (auto argType : arguments) {
+        bool isDuplicate = false;
+        
+        if (auto *packType = argType->getAs<PackType>()) {
+          for (auto existingType : conflictList) {
+            if (auto *existingPack = existingType->getAs<PackType>()) {
+              if (packType->getNumElements() == existingPack->getNumElements()) {
+                auto packElements = packType->getElementTypes();
+                auto existingElements = existingPack->getElementTypes();
+                
+                bool allEqual = true;
+                for (unsigned i = 0; i < packType->getNumElements(); ++i) {
+                  if (!packElements[i]->getCanonicalType()->isEqual(
+                          existingElements[i]->getCanonicalType())) {
+                    allEqual = false;
+                    break;
+                  }
+                }
+                
+                if (allEqual) {
+                  isDuplicate = true;
+                  break;
+                }
+              }
+            }
+          }
+        } else {
+          for (auto existingType : conflictList) {
+            if (argType->isEqual(existingType)) {
+              isDuplicate = true;
+              break;
+            }
+          }
+        }
+        
+        if (!isDuplicate)
+          conflictList.push_back(argType);
+      }
+    }
   }
 
   auto getGenericTypeDecl = [&](ArchetypeType *archetype) -> ValueDecl * {

--- a/test/Constraints/pack_generic_diagnostic_duplicates.swift
+++ b/test/Constraints/pack_generic_diagnostic_duplicates.swift
@@ -1,0 +1,36 @@
+// RUN: %target-typecheck-verify-swift
+
+// Test that pack generic parameter conflict diagnostics don't show
+// duplicate types. This was issue #87349.
+
+struct Data<each T> {
+    init(left: repeat each T, right: repeat each T) {}
+}
+
+// Two conflicting pack arguments - should show 2 unique pack types, not 4
+Data(left: 1, 2, right: 1, "hi")
+// expected-error@-1 {{conflicting arguments to generic parameter 'each T' ('Pack{Int, String}' vs. 'Pack{Int, Int}')}}
+
+// Three conflicting positions - should not show exact duplicates
+Data(left: 1, 2, 3, right: 1, "hi", true)
+// expected-error@-1 {{conflicting arguments to generic parameter 'each T'}}
+
+struct Data2<each T> {
+    init(a: repeat each T, b: repeat each T, c: repeat each T) {}
+}
+
+// Three conflicting arguments - should not show exact duplicates
+Data2(a: 1, 2, 3, b: 1, 2, true, c: "a", "b", "c")
+// expected-error@-1 {{conflicting arguments to generic parameter 'each T'}}
+
+func foo<each T>(left: repeat each T, right: repeat each T) {}
+
+// Function with two pack parameters - should not show duplicates
+foo(left: 1, 2, 3, right: 1, "hi", true)
+// expected-error@-1 {{conflicting arguments to generic parameter 'each T'}}
+
+func bar<each T>(left: repeat each T, right: repeat each T) {}
+
+// Only last element differs - should show exactly 2 types
+bar(left: 1, 2, 3, right: 1, 2, true)
+// expected-error@-1 {{conflicting arguments to generic parameter 'each T' ('Pack{Int, Int, Bool}' vs. 'Pack{Int, Int, Int}')}}


### PR DESCRIPTION
Fixes #87349

This PR addresses the issue where pack generic parameter diagnostics were showing 
duplicate types and cartesian products generated by the constraint solver.

## Problem
When diagnosing conflicting generic arguments with pack types, the diagnostic would 
show 8 types instead of 2, including duplicates and solver-generated cartesian products.

## Solution
Implemented a two-level filtering approach:
1. **Structural equality deduplication** - Removes identical pack types
2. **Extremal heuristic filtering** - Keeps only packs with min/max unique type counts,
   filtering out intermediate "mixed" cartesian products

## Result
Diagnostics now show only the actual argument packs (2 types instead of 8).

## Testing
Added comprehensive test cases covering various pack type scenarios.