### PR TITLE
[Build][Backtracer] Disable backtracer build for 32-bit Windows.

### DIFF
--- a/Runtimes/Supplemental/StackWalker/CMakeLists.txt
+++ b/Runtimes/Supplemental/StackWalker/CMakeLists.txt
@@ -60,30 +60,43 @@ add_link_options($<$<PLATFORM_ID:Windows>:LINKER:/WX>)
 # Ensure all symbols are fully resolved on Linux
 add_link_options($<$<PLATFORM_ID:Android,Linux>:LINKER:-z,defs>)
 
-add_executable(swift-backtrace
-  main.swift
-  AnsiColor.swift
-  JSON.swift
-  TargetMacOS.swift
-  TargetLinux.swift
-  TargetWindows.swift
-  Themes.swift
-  Timing.swift
-  Utils.swift)
-set_target_properties(swift-backtrace PROPERTIES
-  Swift_MODULE_NAME swift_backtrace)
-target_compile_options(swift-backtrace PRIVATE
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I${${PROJECT_NAME}_SWIFTC_SOURCE_DIR}/include>")
-target_link_libraries(swift-backtrace PRIVATE
-  swiftShims
-  swiftCore
-  swift_Builtin_float
-  swiftRuntime
-  swiftCxx
-  $<$<PLATFORM_ID:Darwin>:swiftDarwin>
-  $<$<PLATFORM_ID:Linux>:swiftGlibc>
-  $<$<PLATFORM_ID:Windows>:swiftCRT>
-  $<$<PLATFORM_ID:Windows>:swiftWinSDK>)
+# Don't build on 32-bit Windows; it doesn't work there
+set(should_build_backtracer YES)
+if(WIN32)
+  string(TOUPPER "${CMAKE_SYSTEM_PROCESSOR}" processor)
+  if(processor STREQUAL "X86" OR processor STREQUAL "I686")
+    set(should_build_backtracer NO)
+  endif()
+endif()
 
-install(TARGETS swift-backtrace
-  RUNTIME DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}/swift")
+if(should_build_backtracer)
+
+  add_executable(swift-backtrace
+    main.swift
+    AnsiColor.swift
+    JSON.swift
+    TargetMacOS.swift
+    TargetLinux.swift
+    TargetWindows.swift
+    Themes.swift
+    Timing.swift
+    Utils.swift)
+  set_target_properties(swift-backtrace PROPERTIES
+    Swift_MODULE_NAME swift_backtrace)
+  target_compile_options(swift-backtrace PRIVATE
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I${${PROJECT_NAME}_SWIFTC_SOURCE_DIR}/include>")
+  target_link_libraries(swift-backtrace PRIVATE
+    swiftShims
+    swiftCore
+    swift_Builtin_float
+    swiftRuntime
+    swiftCxx
+    $<$<PLATFORM_ID:Darwin>:swiftDarwin>
+    $<$<PLATFORM_ID:Linux>:swiftGlibc>
+    $<$<PLATFORM_ID:Windows>:swiftCRT>
+    $<$<PLATFORM_ID:Windows>:swiftWinSDK>)
+
+  install(TARGETS swift-backtrace
+    RUNTIME DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}/swift")
+
+endif()

--- a/Runtimes/Supplemental/StackWalker/CMakeLists.txt
+++ b/Runtimes/Supplemental/StackWalker/CMakeLists.txt
@@ -61,42 +61,34 @@ add_link_options($<$<PLATFORM_ID:Windows>:LINKER:/WX>)
 add_link_options($<$<PLATFORM_ID:Android,Linux>:LINKER:-z,defs>)
 
 # Don't build on 32-bit Windows; it doesn't work there
-set(should_build_backtracer YES)
-if(WIN32)
-  string(TOUPPER "${CMAKE_SYSTEM_PROCESSOR}" processor)
-  if(processor STREQUAL "X86" OR processor STREQUAL "I686")
-    set(should_build_backtracer NO)
-  endif()
+if(WIN32 AND CMAKE_SYSTEM_PROCESSOR MATCHES "^(i[3-6]86|x86)$")
+  message(FATAL_ERROR "Swift C-interop does not respect calling conventions on 32-bit")
 endif()
 
-if(should_build_backtracer)
+add_executable(swift-backtrace
+  main.swift
+  AnsiColor.swift
+  JSON.swift
+  TargetMacOS.swift
+  TargetLinux.swift
+  TargetWindows.swift
+  Themes.swift
+  Timing.swift
+  Utils.swift)
+set_target_properties(swift-backtrace PROPERTIES
+  Swift_MODULE_NAME swift_backtrace)
+target_compile_options(swift-backtrace PRIVATE
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I${${PROJECT_NAME}_SWIFTC_SOURCE_DIR}/include>")
+target_link_libraries(swift-backtrace PRIVATE
+  swiftShims
+  swiftCore
+  swift_Builtin_float
+  swiftRuntime
+  swiftCxx
+  $<$<PLATFORM_ID:Darwin>:swiftDarwin>
+  $<$<PLATFORM_ID:Linux>:swiftGlibc>
+  $<$<PLATFORM_ID:Windows>:swiftCRT>
+  $<$<PLATFORM_ID:Windows>:swiftWinSDK>)
 
-  add_executable(swift-backtrace
-    main.swift
-    AnsiColor.swift
-    JSON.swift
-    TargetMacOS.swift
-    TargetLinux.swift
-    TargetWindows.swift
-    Themes.swift
-    Timing.swift
-    Utils.swift)
-  set_target_properties(swift-backtrace PROPERTIES
-    Swift_MODULE_NAME swift_backtrace)
-  target_compile_options(swift-backtrace PRIVATE
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I${${PROJECT_NAME}_SWIFTC_SOURCE_DIR}/include>")
-  target_link_libraries(swift-backtrace PRIVATE
-    swiftShims
-    swiftCore
-    swift_Builtin_float
-    swiftRuntime
-    swiftCxx
-    $<$<PLATFORM_ID:Darwin>:swiftDarwin>
-    $<$<PLATFORM_ID:Linux>:swiftGlibc>
-    $<$<PLATFORM_ID:Windows>:swiftCRT>
-    $<$<PLATFORM_ID:Windows>:swiftWinSDK>)
-
-  install(TARGETS swift-backtrace
-    RUNTIME DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}/swift")
-
-endif()
+install(TARGETS swift-backtrace
+  RUNTIME DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}/swift")

--- a/stdlib/public/core/DebuggerSupport.swift
+++ b/stdlib/public/core/DebuggerSupport.swift
@@ -57,7 +57,7 @@ import SwiftShims
 ///
 /// The description implementation has the following requirements:
 ///
-/// * The body of the description implementation must a single string
+/// * The body of the description implementation must be a single string
 ///   expression. String concatenation is not supported, use string interpolation
 ///   instead.
 /// * String interpolation can reference stored properties only, functions calls

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3372,27 +3372,29 @@ function Build-ExperimentalSDK([Hashtable] $Platform) {
 
     # NOTE: we only build this if static variants are enabled to ensure that we
     # can statically link the runtime.
-    Record-OperationTime $Platform "Build-ExperimentalBacktrace" {
-      Invoke-IsolatingEnvVars {
-        $env:Path = "$(Get-CMarkBinaryCache $Platform)\src;$(Get-PinnedToolchainRuntime);${env:Path}"
+    if ($Platform.Architecture.ShortName -ne "x86") {
+      Record-OperationTime $Platform "Build-ExperimentalBacktrace" {
+        Invoke-IsolatingEnvVars {
+          $env:Path = "$(Get-CMarkBinaryCache $Platform)\src;$(Get-PinnedToolchainRuntime);${env:Path}"
 
-        $SDKRoot = Get-SwiftSDK -OS $Platform.OS -Identifier "$($Platform.OS)Experimental"
+          $SDKRoot = Get-SwiftSDK -OS $Platform.OS -Identifier "$($Platform.OS)Experimental"
 
-        Build-CMakeProject `
-          -Src $SourceCache\swift\Runtimes\Supplemental\StackWalker `
-          -Bin (Get-ProjectBinaryCache $Platform ExperimentalBacktrace) `
-          -InstallTo "${SDKRoot}\usr" `
-          -Platform $Platform `
-          -UseBuiltCompilers CXX,Swift `
-          -SwiftSDK $null `
-          -UseGNUDriver `
-          -Defines @{
-            CMAKE_Swift_FLAGS = @("-static-stdlib");
-            SwiftCore_DIR = "$(Get-ProjectBinaryCache $Platform ExperimentalStaticRuntime)\cmake\SwiftCore";
-            SwiftCxxOverlay_DIR = "$(Get-ProjectBinaryCache $Platform ExperimentalStaticOverlay)\Cxx\cmake\SwiftCxxOverlay";
-            SwiftOverlay_DIR = "$(Get-ProjectBinaryCache $Platform ExperimentalStaticOverlay)\cmake\SwiftOverlay";
-            SwiftRuntime_DIR = "$(Get-ProjectBinaryCache $Platform ExperimentalStaticRuntimeModule)\cmake\SwiftRuntime";
-          }
+          Build-CMakeProject `
+            -Src $SourceCache\swift\Runtimes\Supplemental\StackWalker `
+            -Bin (Get-ProjectBinaryCache $Platform ExperimentalBacktrace) `
+            -InstallTo "${SDKRoot}\usr" `
+            -Platform $Platform `
+            -UseBuiltCompilers CXX,Swift `
+            -SwiftSDK $null `
+            -UseGNUDriver `
+            -Defines @{
+              CMAKE_Swift_FLAGS = @("-static-stdlib");
+              SwiftCore_DIR = "$(Get-ProjectBinaryCache $Platform ExperimentalStaticRuntime)\cmake\SwiftCore";
+              SwiftCxxOverlay_DIR = "$(Get-ProjectBinaryCache $Platform ExperimentalStaticOverlay)\Cxx\cmake\SwiftCxxOverlay";
+              SwiftOverlay_DIR = "$(Get-ProjectBinaryCache $Platform ExperimentalStaticOverlay)\cmake\SwiftOverlay";
+              SwiftRuntime_DIR = "$(Get-ProjectBinaryCache $Platform ExperimentalStaticRuntimeModule)\cmake\SwiftRuntime";
+            }
+        }
       }
     }
   }


### PR DESCRIPTION
The backtracer doesn't support 32-bit Windows, because Swift can't call Windows API functions successfully there.

rdar://170769502
