### PR TITLE
Improve diagnostic for 'static nonmutating' functions

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1828,7 +1828,7 @@ ERROR(functions_mutating_and_not,none,
       (SelfAccessKind, SelfAccessKind))
 
 ERROR(static_functions_not_mutating,none,
-      "static functions must not be declared mutating", ())
+      "static functions must not be declared %0", (SelfAccessKind))
 
 ERROR(modifier_invalid_borrow_mutate_accessor, none,
       "%0 cannot be declared %1", (StringRef, StringRef))

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -736,7 +736,8 @@ void AttributeChecker::visitMutationAttr(DeclAttribute *attr) {
   }
   // Verify that we don't have a static function.
   if (FD->isStatic())
-    diagnoseAndRemoveAttr(attr, diag::static_functions_not_mutating);
+    diagnoseAndRemoveAttr(attr, diag::static_functions_not_mutating,
+                          attrModifier);
 
   auto *accessor = dyn_cast<AccessorDecl>(FD);
   if (accessor) {

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -137,9 +137,12 @@ struct SomeStruct {
   
   static let type_let = 5  // expected-note {{change 'let' to 'var' to make it mutable}} {{10-13=var}}
 
-  mutating static func f() {  // expected-error {{static functions must not be declared mutating}} {{3-12=}}
+  mutating static func f() {  // expected-error {{static functions must not be declared 'mutating'}} {{3-12=}}
   }
-  
+
+  nonmutating static func h() {  // expected-error {{static functions must not be declared 'nonmutating'}} {{3-15=}}
+  }
+
   mutating func g() {
     iv = 42
   }

--- a/test/decl/overload.swift
+++ b/test/decl/overload.swift
@@ -420,7 +420,7 @@ protocol ProtocolWithMutating {
   mutating func test2(_ a: Int?) // expected-note {{previously declared}}
   func test2(_ a: Int!) // expected-error{{invalid redeclaration of 'test2'}}
 
-  mutating static func classTest1() // expected-error {{static functions must not be declared mutating}} {{3-12=}} expected-note {{previously declared}}
+  mutating static func classTest1() // expected-error {{static functions must not be declared 'mutating'}} {{3-12=}} expected-note {{previously declared}}
   static func classTest1() // expected-error{{invalid redeclaration of 'classTest1()'}}
 }
 

--- a/test/decl/subscript/static.swift
+++ b/test/decl/subscript/static.swift
@@ -20,8 +20,8 @@ func useMyStruct() {
 
 struct BadStruct {
   static subscript(_ i: Int) -> String {
-    nonmutating get { fatalError() } // expected-error{{static functions must not be declared mutating}}
-    mutating set { fatalError() } // expected-error{{static functions must not be declared mutating}}
+    nonmutating get { fatalError() } // expected-error{{static functions must not be declared 'nonmutating'}}
+    mutating set { fatalError() } // expected-error{{static functions must not be declared 'mutating'}}
   }
 }
 


### PR DESCRIPTION
## Summary
- The `static_functions_not_mutating` diagnostic previously always said "static functions must not be declared mutating", even when the actual modifier was `nonmutating`, `consuming`, or `borrowing`.
- Parameterized the diagnostic with `SelfAccessKind` so it now reflects the actual modifier used (e.g. `'nonmutating'`, `'mutating'`).
- Added a test case for `nonmutating static func` and updated existing test expectations.

Resolves #77835

## Test plan
- [x] Updated expected diagnostics in `test/Sema/immutability.swift`, `test/decl/overload.swift`, `test/decl/subscript/static.swift`
- [x] Added new test case: `nonmutating static func h()` in `test/Sema/immutability.swift`
- [ ] CI validation of `lit` tests for affected test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)