### PR TITLE
Fix incorrect fix-it for static member access on opaque type instance

### DIFF
--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -315,6 +315,12 @@ func StaticProtocolGenericFunc<t : StaticP>(_: t) {
   t.f()
 }
 
+// https://github.com/swiftlang/swift/issues/85157
+// Suggest type(of:) for static member access on opaque type instance
+func staticMemberOnOpaqueType(p: some StaticP) {
+  p.f() // expected-error{{static member 'f' cannot be used on instance of type 'some StaticP'}} {{3-3=type(of: }} {{4-4=)}}
+}
+
 //===----------------------------------------------------------------------===//
 // Operators
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
## Summary

- When a static member is accessed on an instance of an opaque type (`some P`) or generic type parameter, the fix-it now suggests `type(of: p).x` instead of incorrectly replacing the instance with the unspellable type name (e.g., `some P`)
- Adds archetype/type-parameter check in the fallback fix-it path in `CSDiagnostics.cpp`
- Adds test case verifying the correct fix-it for `some P` instances

Fixes https://github.com/swiftlang/swift/issues/85157

## Test plan

- [ ] Verify `test/decl/protocol/protocols.swift` passes with the new test case checking the `type(of:)` fix-it
- [ ] Verify existing static member diagnostic tests still pass (no regressions for concrete types)

🤖 Generated with [Claude Code](https://claude.com/claude-code)