### PR TITLE
Add fix-it and remove redundant error for computed property missing type

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -8671,6 +8671,9 @@ Parser::parseDeclVarGetSet(PatternBindingEntry &entry, ParseDeclOptions Flags,
       diagnose(pattern->getLoc(), diag::computed_property_missing_type)
         .fixItInsert(locAfterPattern, ": <# Type #>");
       Invalid = true;
+      // Mark the variable invalid so that TypeCheckPattern does not emit a
+      // redundant 'type annotation missing in pattern' diagnostic.
+      PrimaryVar->setInvalid();
     }
   }
 

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -441,8 +441,7 @@ protocol ShouldntCrash {
   let fullName2: String  // expected-error {{protocols cannot require properties to be immutable; declare read-only properties by using 'var' with a '{ get }' specifier}} {{3-6=var}} {{24-24= { get \}}}
 
   // <rdar://problem/16789886> Assert on protocol property requirement without a type
-  var propertyWithoutType { get } // expected-error {{type annotation missing in pattern}}
-  // expected-error@-1 {{computed property must have an explicit type}} {{26-26=: <# Type #>}}
+  var propertyWithoutType { get } // expected-error {{computed property must have an explicit type}} {{26-26=: <# Type #>}}
 }
 
 // rdar://problem/18168866

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -270,11 +270,17 @@ var computed_prop_with_init_1: X {
   get {}
 } = X()  // expected-error {{expected expression}} expected-error {{consecutive statements on a line must be separated by ';'}} {{2-2=;}}
 
-var x2 { // expected-error{{computed property must have an explicit type}} {{7-7=: <# Type #>}} expected-error{{type annotation missing in pattern}}
+var x2 { // expected-error{{computed property must have an explicit type}} {{7-7=: <# Type #>}}
   get {
     return _x
   }
 }
+
+// https://github.com/swiftlang/swift/issues/87322
+// https://github.com/swiftlang/swift/issues/87324
+// Computed property missing type should emit a single error with a fix-it,
+// not a redundant 'type annotation missing in pattern' error.
+var int {} // expected-error{{computed property must have an explicit type}} {{8-8=: <# Type #>}}
 
 var (x3): X { // expected-error{{getter/setter can only be defined for a single variable}}
   get {

--- a/test/decl/var/static_var.swift
+++ b/test/decl/var/static_var.swift
@@ -288,9 +288,8 @@ extension ProtoAdopter : ProtosEvilTwin {}
 // rdar://18990358
 public struct Foo { // expected-note {{to match this opening '{'}}}
   public static let S { _ = 0; aaaaaa // expected-error{{computed property must have an explicit type}} {{22-22=: <# Type #>}}
-    // expected-error@-1{{type annotation missing in pattern}}
-    // expected-error@-2{{'let' declarations cannot be computed properties}} {{17-20=var}}
-    // expected-error@-3{{cannot find 'aaaaaa' in scope}}
+    // expected-error@-1{{'let' declarations cannot be computed properties}} {{17-20=var}}
+    // expected-error@-2{{cannot find 'aaaaaa' in scope}}
 }
 
 // expected-error@+1 {{expected '}' in struct}}


### PR DESCRIPTION
Fixes #87322 and #87324

## Summary
When a computed property is missing a type annotation (e.g., `var int {}`), the compiler now:
1. Emits only ONE error instead of two redundant errors
2. Provides a fix-it to insert the type annotation placeholder

## Before
```
error: computed property must have an explicit type
error: type annotation missing in pattern  // redundant!
```

## After
```
error: computed property must have an explicit type
       fix-it: insert ': <#Type#>'
```

## Test
Added test case verifying single error + fix-it behavior.