### PR TITLE
[cxx-interop] Improvements for CxxBorrowingSequence

### DIFF
--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -255,23 +255,6 @@ static FuncDecl *getPlusEqualOperator(NominalTypeDecl *decl, Type distanceTy) {
   return dyn_cast_or_null<FuncDecl>(result);
 }
 
-static FuncDecl *getNonMutatingDereferenceOperator(NominalTypeDecl *decl) {
-  auto isValid = [](ValueDecl *starOperator) -> bool {
-    auto starOp = dyn_cast<FuncDecl>(starOperator);
-    if (!starOp || starOp->isMutating())
-      return false;
-    auto params = starOp->getParameters();
-    if (params->size() != 0)
-      return false;
-    auto returnTy = starOp->getResultInterfaceType();
-    return static_cast<bool>(returnTy->getAnyPointerElementType());
-  };
-
-  ValueDecl *result = lookupOperator(
-      decl, decl->getASTContext().getIdentifier("__operatorStar"), isValid);
-  return dyn_cast_or_null<FuncDecl>(result);
-}
-
 static clang::FunctionDecl *
 instantiateTemplatedOperator(ClangImporter::Implementation &impl,
                              const clang::CXXRecordDecl *classDecl,
@@ -643,7 +626,8 @@ conformToCxxIteratorIfNeeded(ClangImporter::Implementation &impl,
   //   - operator++() / .successor()
   //   - operator==() / func ==(lhs:rhs)
 
-  auto *pointee = impl.lookupAndImportPointee(decl);
+  auto [pointee, operatorStar, _] =
+      impl.lookupAndImportPointeeAndOperatorStar(decl);
   if (!pointee || pointee->isGetterMutating() ||
       pointee->getTypeInContext()->hasError())
     return;
@@ -684,11 +668,8 @@ conformToCxxIteratorIfNeeded(ClangImporter::Implementation &impl,
 
   // Look for __operatorStar(), which must be non-mutating and return a
   // reference. This makes sure we use the const operator* overload.
-  auto operatorStar = getNonMutatingDereferenceOperator(decl);
   Type dereferenceResultTy = pointeeTy;
-  if (operatorStar) {
-    assert(!operatorStar->isMutating() &&
-           "this __operatorStar can't be mutating");
+  if (operatorStar && !operatorStar->isMutating()) {
     auto operatorStarReturnTy = operatorStar->getResultInterfaceType();
     assert(operatorStarReturnTy &&
            "__operatorStar doesn't have a return type?");
@@ -898,7 +879,7 @@ static void conformToCxxOptional(ClangImporter::Implementation &impl,
   decl->addMember(importedConstructor);
 }
 
-static void conformToCxxBorrowingSequenceIfNedded(
+static void conformToCxxBorrowingSequenceIfNeeded(
     ClangImporter::Implementation &impl, NominalTypeDecl *decl,
     const clang::CXXRecordDecl *clangDecl,
     const ProtocolConformance *rawIteratorConformance) {
@@ -1001,7 +982,7 @@ conformToCxxSequenceIfNeeded(ClangImporter::Implementation &impl,
   impl.addSynthesizedTypealias(decl, ctx.getIdentifier("RawIterator"),
                                rawIteratorTy);
 
-  conformToCxxBorrowingSequenceIfNedded(impl, decl, clangDecl,
+  conformToCxxBorrowingSequenceIfNeeded(impl, decl, clangDecl,
                                         rawIteratorConformance);
 
   // `CxxSequence` and `CxxRandomAccessCollection` protocols require `Element`

--- a/lib/ClangImporter/ClangLookup.cpp
+++ b/lib/ClangImporter/ClangLookup.cpp
@@ -511,15 +511,17 @@ static FuncDecl *importUnavailableMethod(ClangImporter::Implementation &Impl,
   return func;
 }
 
-VarDecl *
-ClangImporter::Implementation::lookupAndImportPointee(NominalTypeDecl *Struct) {
+std::tuple<VarDecl *, FuncDecl *, FuncDecl *>
+ClangImporter::Implementation::lookupAndImportPointeeAndOperatorStar(
+    NominalTypeDecl *Struct) {
   const auto *CXXRecord =
       dyn_cast<clang::CXXRecordDecl>(Struct->getClangDecl());
 
   if (!CXXRecord)
-    return nullptr;
+    return {};
 
-  if (auto [it, inserted] = importedPointeeCache.try_emplace(Struct, nullptr);
+  if (auto [it, inserted] = importedPointeeCache.try_emplace(
+          Struct, std::make_tuple(nullptr, nullptr, nullptr));
       !inserted)
     return it->second;
 
@@ -534,7 +536,7 @@ ClangImporter::Implementation::lookupAndImportPointee(NominalTypeDecl *Struct) {
       clang::OverloadedOperatorKind::OO_Star);
   auto R = lookupCXXMember(Sema, name, CXXRecord);
   if (!R.has_value())
-    return nullptr;
+    return {};
 
   auto overloads = filterMethodOverloads(R.value(), CXXRecord);
 
@@ -576,7 +578,7 @@ ClangImporter::Implementation::lookupAndImportPointee(NominalTypeDecl *Struct) {
   }
 
   if (!CXXGetter && !CXXSetter)
-    return nullptr;
+    return {};
 
   FuncDecl *getter = nullptr, *setter = nullptr;
 
@@ -584,7 +586,7 @@ ClangImporter::Implementation::lookupAndImportPointee(NominalTypeDecl *Struct) {
     setter = importUnavailableMethod(*this, CXXSetter, CXXSetterAccess, Struct,
                                      "use .pointee property");
     if (!setter)
-      return nullptr;
+      return {};
   }
 
   if (CXXGetter == CXXSetter) {
@@ -593,19 +595,26 @@ ClangImporter::Implementation::lookupAndImportPointee(NominalTypeDecl *Struct) {
     getter = importUnavailableMethod(*this, CXXGetter, CXXGetterAccess, Struct,
                                      "use .pointee property");
     if (!getter)
-      return nullptr;
+      return {};
   }
 
   SwiftDeclSynthesizer synth{*this};
   auto *pointee = synth.makeDereferencedPointeeProperty(getter, setter);
   if (!pointee)
-    return nullptr;
+    return {};
 
   importAttributes(CXXGetter ? CXXGetter : CXXSetter, pointee);
 
   Struct->addMember(pointee);
-  importedPointeeCache[Struct] = pointee;
-  return pointee;
+  auto pointeeAndOpStar =
+      std::make_tuple(pointee, getter ? getter : setter, setter);
+  importedPointeeCache[Struct] = pointeeAndOpStar;
+  return pointeeAndOpStar;
+}
+
+VarDecl *
+ClangImporter::Implementation::lookupAndImportPointee(NominalTypeDecl *Struct) {
+  return std::get<0>(lookupAndImportPointeeAndOperatorStar(Struct));
 }
 
 FuncDecl *ClangImporter::Implementation::lookupAndImportSuccessor(

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -708,26 +708,42 @@ private:
       unavailableMethods;
 
 public:
+  /// Attempt to lookup and import the synthesized .pointee computed property.
+  /// It also synthesizes __operatorStar(), which is used as the getter and
+  /// setter for .pointee.
+  //
+  /// Requires that \a Record is a (Swift) StructDecl and is imported from
+  /// a CXXRecordDecl.
+  //
+  /// This function is idempotent, and if successful, ensures the synthesized
+  /// .pointee and __operatorStar() methods that it returns are members of \a
+  /// Record.
+  std::tuple<VarDecl *, FuncDecl *, FuncDecl *>
+  lookupAndImportPointeeAndOperatorStar(NominalTypeDecl *Record);
+
   // Attempt to lookup and import the synthesized .pointee computed property.
   //
-  // Requires that \a Record is a (Swift) StructDecl and is import from
-  // a CXXRecordDecl.
+  /// Requires that \a Record is a (Swift) StructDecl and is imported from
+  /// a CXXRecordDecl.
   //
-  // This function is idempotent, and if successful, ensures the synthesized
-  // .pointee that it returns is a mamber of \a Record.
+  /// This function is idempotent, and if successful, ensures the synthesized
+  /// .pointee that it returns are members of \a Record.
   VarDecl *lookupAndImportPointee(NominalTypeDecl *Record);
 
-  // Attempt to lookup and import the synthesized .successor() method.
+  /// Attempt to lookup and import the synthesized .successor() method.
   //
-  // Requires that \a Record is a (Swift) StructDecl and is import from
-  // a CXXRecordDecl.
+  /// Requires that \a Record is a (Swift) StructDecl and is imported from
+  /// a CXXRecordDecl.
   //
-  // This function is idempotent, and if successful, ensures the synthesized
-  // .successor() that it returns is a mamber of \a Record.
+  /// This function is idempotent, and if successful, ensures the synthesized
+  /// .successor() that it returns is a member of \a Record.
   FuncDecl *lookupAndImportSuccessor(NominalTypeDecl *Record);
 
 private:
-  llvm::DenseMap<NominalTypeDecl *, VarDecl *> importedPointeeCache;
+  /// Stores <.pointee, func __operatorStar(), mutating func __operatorStar()>
+  llvm::DenseMap<NominalTypeDecl *,
+                 std::tuple<VarDecl *, FuncDecl *, FuncDecl *>>
+      importedPointeeCache;
   llvm::DenseMap<NominalTypeDecl *, FuncDecl *> importedSuccessorCache;
 
 public:

--- a/stdlib/public/Cxx/CxxBorrowingSequence.swift
+++ b/stdlib/public/Cxx/CxxBorrowingSequence.swift
@@ -35,8 +35,7 @@ public protocol CxxBorrowingSequence<Element> : BorrowingSequence, ~Copyable, ~E
 
 @frozen
 @available(SwiftStdlib 6.4, *)
-public struct CxxBorrowingIterator<T>: BorrowingIteratorProtocol, ~Escapable, ~Copyable where T: CxxBorrowingSequence & ~Copyable & ~Escapable, T.Element: ~Copyable {
-  public typealias Element = T.RawIterator.Pointee
+public struct CxxBorrowingIterator<T>: BorrowingIteratorProtocol<T.Element>, ~Escapable, ~Copyable where T: CxxBorrowingSequence & ~Copyable & ~Escapable, T.Element: ~Copyable {
 
   @usableFromInline
   internal var current: T.RawIterator
@@ -49,30 +48,11 @@ public struct CxxBorrowingIterator<T>: BorrowingIteratorProtocol, ~Escapable, ~C
     self.current = begin
     self.end = end
   }
-
-  @inlinable
-  public mutating func skip(by offset: Int) -> Int {
-    var remainder = offset
-    while remainder > 0 {
-      let span = nextSpan(maximumCount: remainder)
-      if span.isEmpty { break }
-      remainder &-= span.count
-    }
-    return offset &- remainder
-  }
 }
 
 // For non-contiguous iterators, we create a span of size one for each element
 @available(SwiftStdlib 6.4, *)
 extension CxxBorrowingIterator where T: ~Copyable & ~Escapable, T.Element: ~Copyable {
-  // FIXME methods `skip(by:)` and `nextSpan()` should be inherited from BorrowingSequence,
-  // but currently are not because of a bug. These will be removed once it gets fixed. 
-  @inlinable
-  @_lifetime(&self)
-  public mutating func nextSpan() -> Span<Element> {
-    nextSpan(maximumCount: Int.max)
-  }
-
   @inlinable
   @_lifetime(&self)
   public mutating func nextSpan(maximumCount: Int) -> Span<Element> {
@@ -104,7 +84,7 @@ extension CxxBorrowingIterator where T: ~Copyable & ~Escapable, T.RawIterator: U
   @inlinable
   @_lifetime(&self)
   public mutating func nextSpan(maximumCount: Int) -> Span<Element> {
-    if self.current == self.end {
+    if maximumCount < 1 || self.current == self.end {
       return Span()
     }
 
@@ -123,6 +103,6 @@ extension CxxBorrowingSequence where Element: ~Copyable, Self: ~Copyable {
   @_lifetime(borrow self)
   public borrowing func makeBorrowingIterator() -> CxxBorrowingIterator<Self> {
     let iterator = CxxBorrowingIterator<Self>(begin: __beginUnsafe(), end: __endUnsafe(), sequence: self)
-    return unsafe _cxxOverrideLifetime(iterator, borrowing: self)
+    return iterator
   }
 }

--- a/stdlib/public/Cxx/UnsafeCxxIterators.swift
+++ b/stdlib/public/Cxx/UnsafeCxxIterators.swift
@@ -13,8 +13,8 @@
 /// Bridged C++ iterator that allows to traverse the elements of a sequence 
 /// using a for-in loop.
 ///
-/// Mostly useful for conforming a type to the `CxxSequence` protocol and should
-/// not generally be used directly.
+/// Mostly useful for conforming a type to the `CxxSequence` protocol.
+/// Do not directly use this protocol in Swift.
 ///
 /// - SeeAlso: https://en.cppreference.com/w/cpp/named_req/InputIterator
 public protocol UnsafeCxxInputIterator: Equatable {

--- a/test/Interop/Cxx/stdlib/Inputs/std-map.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-map.h
@@ -20,13 +20,23 @@ inline Map initEmptyMap() { return {}; }
 inline UnorderedMap initEmptyUnorderedMap() { return {}; }
 
 struct NonCopyable {
-  NonCopyable() = default;
+  NonCopyable(int n) : number(n) {}
   NonCopyable(const NonCopyable &other) = delete;
   NonCopyable(NonCopyable &&other) = default;
   ~NonCopyable() {}
+
+  int number;
 };
 
 using MapNonCopyableKey = std::map<NonCopyable, int>;
 using MapNonCopyableValue = std::map<int, NonCopyable>;
+
+inline MapNonCopyableValue initMapNonCopyableValue() {
+  MapNonCopyableValue m;
+  m.emplace(1, 1);
+  m.emplace(3, 3);
+  m.emplace(7, 7);
+  return m;
+}
 
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_MAP_H

--- a/test/Interop/Cxx/stdlib/Inputs/std-set.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-set.h
@@ -13,10 +13,12 @@ inline UnorderedSetOfCInt initUnorderedSetOfCInt() { return {2, 4, 6}; }
 inline MultisetOfCInt initMultisetOfCInt() { return {2, 2, 4, 6}; }
 
 struct NonCopyable {
-  NonCopyable() = default;
+  NonCopyable(int n) : number(n) {}
   NonCopyable(const NonCopyable &other) = delete;
   NonCopyable(NonCopyable &&other) = default;
   ~NonCopyable() {}
+
+  int number;
 };
 
 using SetOfNonCopyable = std::set<NonCopyable>;

--- a/test/Interop/Cxx/stdlib/overlay/Inputs/custom-borrowing-sequence.h
+++ b/test/Interop/Cxx/stdlib/overlay/Inputs/custom-borrowing-sequence.h
@@ -50,4 +50,41 @@ struct SWIFT_NONCOPYABLE ContiguousNonCopyableSequence {
 };
 #endif
 
+struct NonInlineDereferenceOperatorSequence {
+  NonInlineDereferenceOperator begin() const {
+    return NonInlineDereferenceOperator(1);
+  }
+  NonInlineDereferenceOperator end() const {
+    return NonInlineDereferenceOperator(5);
+  }
+};
+
+struct NoConstDereferenceOperatorSequence {
+  NoConstDereferenceOperator begin() const {
+    return NoConstDereferenceOperator(1);
+  }
+  NoConstDereferenceOperator end() const {
+    return NoConstDereferenceOperator(5);
+  }
+};
+
+struct DifferentResultsDereferenceOperatorSequence {
+  DifferentResultsDereferenceOperator begin() const {
+    return DifferentResultsDereferenceOperator(1, 42);
+  }
+  DifferentResultsDereferenceOperator end() const {
+    return DifferentResultsDereferenceOperator(5, 56);
+  }
+};
+
+struct ConstRACButNotBorrowingIteratorSequence {
+  int arr[5] = {2, 1, 2, 7, 5};
+  ConstRACButNotBorrowingIterator begin() const {
+    return ConstRACButNotBorrowingIterator(&arr[0]);
+  }
+  ConstRACButNotBorrowingIterator end() const {
+    return ConstRACButNotBorrowingIterator(&arr[5]);
+  }
+};
+
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_CUSTOM_BORROWING_SEQUENCE_H

--- a/test/Interop/Cxx/stdlib/overlay/Inputs/custom-iterator.h
+++ b/test/Interop/Cxx/stdlib/overlay/Inputs/custom-iterator.h
@@ -365,31 +365,72 @@ public:
   }
 };
 
-struct NonReferenceDereferenceOperator {
-private:
-  int value;
-
-public:
+struct DifferentResultsDereferenceOperator {
   using iterator_category = std::input_iterator_tag;
   using value_type = int;
   using pointer = int *;
   using reference = const int &;
   using difference_type = int;
 
-  NonReferenceDereferenceOperator(int value) : value(value) {}
-  NonReferenceDereferenceOperator(
-      const NonReferenceDereferenceOperator &other) = default;
+  int value;
+  long ghost;
 
-  int operator*() const { return value; }
+  DifferentResultsDereferenceOperator(int value, long ghost)
+      : value(value), ghost(ghost) {}
 
-  NonReferenceDereferenceOperator &operator++() {
+  long &operator*() { return ghost; }
+  const int &operator*() const { return value; }
+  DifferentResultsDereferenceOperator &operator++() {
     value++;
     return *this;
   }
-
-  bool operator==(const NonReferenceDereferenceOperator &other) const {
+  bool operator==(const DifferentResultsDereferenceOperator &other) const {
     return value == other.value;
   }
+};
+
+// A container with a nested iterator type
+struct HasNestedIterator {
+  class NestedIterator {
+  public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = int;
+    using reference = const int &;
+    using pointer = const int *;
+    using difference_type = ptrdiff_t;
+
+    NestedIterator() : ptr(nullptr) {}
+    NestedIterator(const int *p) : ptr(p) {}
+
+    reference operator*() const { return *ptr; }
+    pointer operator->() const { return ptr; }
+
+    NestedIterator &operator++() {
+      ++ptr;
+      return *this;
+    }
+    NestedIterator operator++(int) {
+      auto tmp = *this;
+      ++ptr;
+      return tmp;
+    }
+
+    bool operator==(const NestedIterator &other) const {
+      return ptr == other.ptr;
+    }
+    bool operator!=(const NestedIterator &other) const {
+      return ptr != other.ptr;
+    }
+
+  private:
+    const int *ptr;
+  };
+
+  NestedIterator begin() const { return NestedIterator(data); }
+  NestedIterator end() const { return NestedIterator(data + 5); }
+
+private:
+  int data[5] = {1, 2, 3, 4, 5};
 };
 
 #if __cplusplus >= 202002L
@@ -618,6 +659,144 @@ public:
   }
 };
 #endif
+
+// MARK: Iterators with dereference operators that prevent conformance to
+// CxxBorrowingSequence.
+
+struct NonInlineDereferenceOperator {
+  using iterator_category = std::input_iterator_tag;
+  using value_type = int;
+  using pointer = int *;
+  using reference = const int &;
+  using difference_type = int;
+
+  NonInlineDereferenceOperator(int value) : value(value) {}
+  NonInlineDereferenceOperator(const NonInlineDereferenceOperator &other) =
+      default;
+
+  NonInlineDereferenceOperator &operator++() {
+    value++;
+    return *this;
+  }
+
+  bool operator==(const NonInlineDereferenceOperator &other) const {
+    return value == other.value;
+  }
+
+  int value;
+};
+
+inline int &operator*(NonInlineDereferenceOperator &s) { return s.value; }
+
+struct NonReferenceDereferenceOperator {
+private:
+  int value;
+
+public:
+  using iterator_category = std::input_iterator_tag;
+  using value_type = int;
+  using pointer = int *;
+  using reference = const int &;
+  using difference_type = int;
+
+  NonReferenceDereferenceOperator(int value) : value(value) {}
+  NonReferenceDereferenceOperator(
+      const NonReferenceDereferenceOperator &other) = default;
+
+  int operator*() const { return value; }
+
+  NonReferenceDereferenceOperator &operator++() {
+    value++;
+    return *this;
+  }
+
+  bool operator==(const NonReferenceDereferenceOperator &other) const {
+    return value == other.value;
+  }
+};
+
+struct NoConstDereferenceOperator {
+  using iterator_category = std::input_iterator_tag;
+  using value_type = int;
+  using pointer = int *;
+  using reference = const int &;
+  using difference_type = int;
+
+  int value;
+  NoConstDereferenceOperator(int value) : value(value) {}
+
+  int &operator*() { return value; }
+
+  // This is the binary variant of operator* (i.e., multiply) and should be
+  // accessible via the synthesized static func *(lhs, rhs) operator. Since
+  // there's no const deref operator, NoConstDereferenceOperator shouldn't
+  // conform to UnsafeCxxInputIterator.
+  int operator*(const NoConstDereferenceOperator &other) const {
+    return other.value;
+  }
+  NoConstDereferenceOperator &operator++() {
+    value++;
+    return *this;
+  }
+  bool operator==(const NoConstDereferenceOperator &other) const {
+    return value == other.value;
+  }
+};
+
+struct ConstRACButNotBorrowingIterator {
+private:
+  const int *value;
+
+public:
+  using iterator_category = std::random_access_iterator_tag;
+  using value_type = int;
+  using pointer = int *;
+  using reference = const int &;
+  using difference_type = int;
+
+  ConstRACButNotBorrowingIterator(const int *value) : value(value) {}
+  ConstRACButNotBorrowingIterator(
+      const ConstRACButNotBorrowingIterator &other) = default;
+
+  int operator*() const { return *value; }
+
+  ConstRACButNotBorrowingIterator &operator++() {
+    value++;
+    return *this;
+  }
+  ConstRACButNotBorrowingIterator operator++(int) {
+    auto tmp = ConstRACButNotBorrowingIterator(value);
+    value++;
+    return tmp;
+  }
+
+  void operator+=(difference_type v) { value += v; }
+  void operator-=(difference_type v) { value -= v; }
+  ConstRACButNotBorrowingIterator operator+(difference_type v) const {
+    return ConstRACButNotBorrowingIterator(value + v);
+  }
+  ConstRACButNotBorrowingIterator operator-(difference_type v) const {
+    return ConstRACButNotBorrowingIterator(value - v);
+  }
+  friend ConstRACButNotBorrowingIterator
+  operator+(difference_type v, const ConstRACButNotBorrowingIterator &it) {
+    return it + v;
+  }
+  int operator-(const ConstRACButNotBorrowingIterator &other) const {
+    return value - other.value;
+  }
+
+  bool operator<(const ConstRACButNotBorrowingIterator &other) const {
+    return value < other.value;
+  }
+
+  bool operator==(const ConstRACButNotBorrowingIterator &other) const {
+    return value == other.value;
+  }
+  bool operator!=(const ConstRACButNotBorrowingIterator &other) const {
+    return value != other.value;
+  }
+};
 
 // MARK: Types that are not actually iterators
 

--- a/test/Interop/Cxx/stdlib/overlay/custom-borrowing-sequence-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-borrowing-sequence-module-interface.swift
@@ -28,3 +28,31 @@
 // CHECK:   typealias RawIterator = NonReferenceDereferenceOperator
 // CHECK:   typealias Iterator = CxxIterator<NonReferenceDereferenceOperatorSequence>
 // CHECK: }
+
+// CHECK: struct NonInlineDereferenceOperatorSequence {
+// CHECK-NOT:   typealias Element
+// CHECK-NOT:   typealias RawIterator
+// CHECK-NOT:   typealias Iterator
+// CHECK: }
+
+// CHECK: struct NoConstDereferenceOperatorSequence {
+// CHECK-NOT:   typealias Element
+// CHECK-NOT:   typealias RawIterator
+// CHECK-NOT:   typealias Iterator
+// CHECK: }
+
+// CHECK: struct DifferentResultsDereferenceOperatorSequence : CxxConvertibleToCollection, CxxBorrowingSequence {
+// CHECK:   typealias Element = DifferentResultsDereferenceOperator.Pointee
+// CHECK:   typealias RawIterator = DifferentResultsDereferenceOperator
+// CHECK:   typealias BorrowingIterator = CxxBorrowingIterator<DifferentResultsDereferenceOperatorSequence>
+// CHECK:   typealias Iterator = CxxIterator<DifferentResultsDereferenceOperatorSequence>
+// CHECK: }
+
+// CHECK: struct ConstRACButNotBorrowingIteratorSequence : CxxRandomAccessCollection {
+// CHECK:   typealias Element = ConstRACButNotBorrowingIterator.Pointee
+// CHECK:   typealias RawIterator = ConstRACButNotBorrowingIterator
+// CHECK:   typealias Iterator = CxxIterator<ConstRACButNotBorrowingIteratorSequence>
+// CHECK:   typealias Index = Int
+// CHECK:   typealias Indices = Range<Int>
+// CHECK:   typealias SubSequence = Slice<ConstRACButNotBorrowingIteratorSequence>
+// CHECK: }

--- a/test/Interop/Cxx/stdlib/overlay/custom-borrowing-sequence-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-borrowing-sequence-typechecker.swift
@@ -3,11 +3,29 @@
 import CustomBorrowingSequence
 
 func checkBorrowingSequence<S>(_ seq: borrowing S) where S: CxxBorrowingSequence, S: ~Copyable {
-  // expected-note@-1 {{where 'S' = 'NonReferenceDereferenceOperatorSequence'}}
+  // expected-note@-1 {{where 'S' = 'NonInlineDereferenceOperatorSequence'}}
+  // expected-note@-2 {{where 'S' = 'NonReferenceDereferenceOperatorSequence'}}
+  // expected-note@-3 {{where 'S' = 'NoConstDereferenceOperatorSequence'}}
+  // expected-note@-4 {{where 'S' = 'ConstRACButNotBorrowingIteratorSequence'}}
   var _ = seq.makeBorrowingIterator()
 }
+
+func checkRandomAccessCollection<S>(_ seq: borrowing S) where S: CxxRandomAccessCollection {}
+
+checkBorrowingSequence(NonInlineDereferenceOperatorSequence())
+// expected-error@-1 {{global function 'checkBorrowingSequence' requires that 'NonInlineDereferenceOperatorSequence' conform to 'CxxBorrowingSequence'}}
 
 // NonReferenceDereferenceOperatorSequence doesn't conform to CxxBorrowingSequence because operator* 
 // (the dereference operator) doesn't return a reference
 checkBorrowingSequence(NonReferenceDereferenceOperatorSequence()) 
 // expected-error@-1 {{global function 'checkBorrowingSequence' requires that 'NonReferenceDereferenceOperatorSequence' conform to 'CxxBorrowingSequence'}}
+
+// NoConstDereferenceOperatorSequence doesn't conform to CxxBorrowingSequence because there is no const operator* (the dereference operator)
+checkBorrowingSequence(NoConstDereferenceOperatorSequence()) 
+// expected-error@-1 {{global function 'checkBorrowingSequence' requires that 'NoConstDereferenceOperatorSequence' conform to 'CxxBorrowingSequence'}}
+
+// ConstRACButNotBorrowingIteratorSequence doesn't conform to CxxBorrowingSequence because operator* 
+// (the dereference operator) doesn't return a reference. However, it still conforms to CxxRandomAccessCollection.
+checkBorrowingSequence(ConstRACButNotBorrowingIteratorSequence()) 
+// expected-error@-1 {{global function 'checkBorrowingSequence' requires that 'ConstRACButNotBorrowingIteratorSequence' conform to 'CxxBorrowingSequence'}}
+checkRandomAccessCollection(ConstRACButNotBorrowingIteratorSequence())

--- a/test/Interop/Cxx/stdlib/overlay/custom-borrowing-sequence.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-borrowing-sequence.swift
@@ -18,16 +18,16 @@ CxxBorrowingSequenceTestSuite.test("SimpleNonCopyableSequence as Swift.Borrowing
   let arr : [Int32] = [2, 3, 4, 5]
 
   var iterator = seq.makeBorrowingIterator()
-    var counter = 0
-    while true {
-        let span = iterator.nextSpan()
-        if (span.count == 0) { break }
-        for i in 0..<span.count {
-            expectEqual(span[i], arr[counter])
-            counter += 1
-        }
+  var counter = 0
+  while true {
+    let span = iterator.nextSpan()
+    if (span.count == 0) { break }
+    for i in 0..<span.count {
+      expectEqual(span[i], arr[counter])
+      counter += 1
     }
-    expectEqual(counter, 4)
+  }
+  expectEqual(counter, 4)
 }
 
 CxxBorrowingSequenceTestSuite.test("SimpleNonCopArrayWrapper as Swift.BorrowingSequence") {
@@ -36,16 +36,16 @@ CxxBorrowingSequenceTestSuite.test("SimpleNonCopArrayWrapper as Swift.BorrowingS
   let arr : [Int32] = [10, 20, 30, 40, 50]
 
   var iterator = seq.makeBorrowingIterator()
-    var counter = 0
-    while true {
-        let span = iterator.nextSpan()
-        if (span.count == 0) { break }
-        for i in 0..<span.count {
-            expectEqual(span[i].number, arr[counter])
-            counter += 1
-        }
+  var counter = 0
+  while true {
+    let span = iterator.nextSpan()
+    if (span.count == 0) { break }
+    for i in 0..<span.count {
+      expectEqual(span[i].number, arr[counter])
+      counter += 1
     }
-    expectEqual(counter, 5)
+  }
+  expectEqual(counter, 5)
 }
 
 CxxBorrowingSequenceTestSuite.test("ContiguousNonCopyableSequence as Swift.BorrowingSequence") {
@@ -57,14 +57,14 @@ CxxBorrowingSequenceTestSuite.test("ContiguousNonCopyableSequence as Swift.Borro
   var innerCounter = 0
   var outerCounter = 0
   while true {
-      let span = iterator.nextSpan()
-      if (span.count == 0) { break }
-      expectEqual(span.count, 5)
-      for i in 0..<span.count {
-          expectEqual(span[i], arr[innerCounter])
-          innerCounter += 1
-      }
-      outerCounter += 1
+    let span = iterator.nextSpan()
+    if (span.count == 0) { break }
+    expectEqual(span.count, 5)
+    for i in 0..<span.count {
+      expectEqual(span[i], arr[innerCounter])
+      innerCounter += 1
+    }
+    outerCounter += 1
   }
   expectEqual(innerCounter, 5)
   expectEqual(outerCounter, 1)
@@ -79,13 +79,13 @@ CxxBorrowingSequenceTestSuite.test("ContiguousNonCopyableSequence as Swift.Borro
   var innerCounter = 0
   var outerCounter = 0
   while true {
-      let span = iterator.nextSpan(maximumCount: 3)
-      if (span.count == 0) { break }
-      for i in 0..<span.count {
-          expectEqual(span[i], arr[innerCounter])
-          innerCounter += 1
-      }
-      outerCounter += 1
+    let span = iterator.nextSpan(maximumCount: 3)
+    if (span.count == 0) { break }
+    for i in 0..<span.count {
+      expectEqual(span[i], arr[innerCounter])
+      innerCounter += 1
+    }
+    outerCounter += 1
   }
   expectEqual(innerCounter, 5)
   expectEqual(outerCounter, 2)

--- a/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=CustomIterator -source-filename=x -I %S/Inputs -cxx-interoperability-mode=default | %FileCheck %s
 
 // CHECK: struct ConstIterator : UnsafeCxxInputIterator {
+// CHECK:   func __operatorStar() -> UnsafePointer<Int32>
 // CHECK:   func successor() -> ConstIterator
 // CHECK:   typealias Pointee = Int32
 // CHECK:   static func == (lhs: ConstIterator, other: ConstIterator) -> Bool
@@ -99,6 +100,61 @@
 // CHECK:   func successor() -> MutableRACIterator
 // CHECK:   typealias Pointee = Int32
 // CHECK:   typealias Distance = Int32
+// CHECK: }
+
+// CHECK: struct DifferentResultsDereferenceOperator : UnsafeCxxMutableInputIterator {
+// CHECK:   mutating func __operatorStar() -> UnsafeMutablePointer<Int>
+// CHECK:   func __operatorStar() -> UnsafePointer<Int32>
+// CHECK:   func successor() -> DifferentResultsDereferenceOperator
+// CHECK:   typealias Pointee = Int32
+// CHECK:   typealias DereferenceResult = UnsafePointer<Int32>
+// CHECK:   static func == (lhs: DifferentResultsDereferenceOperator, other: DifferentResultsDereferenceOperator) -> Bool
+// CHECK:   var pointee: Int32
+// CHECK: }
+
+// CHECK: struct HasNestedIterator : CxxConvertibleToCollection, CxxBorrowingSequence {
+// CHECK:   struct NestedIterator : UnsafeCxxInputIterator {
+// CHECK:     func __operatorStar() -> HasNestedIterator.NestedIterator.reference
+// CHECK:     var ptr: UnsafePointer<Int32>!
+// CHECK:     func successor() -> HasNestedIterator.NestedIterator
+// CHECK:     var pointee: Int32 { get }
+// CHECK:   }
+// CHECK: }
+
+// CHECK: struct NonInlineDereferenceOperator {
+// CHECK-NOT:   func __operatorStar()
+// CHECK:   func successor() -> NonInlineDereferenceOperator
+// CHECK-NOT:   typealias Pointee
+// CHECK-NOT:   typealias DereferenceResult
+// CHECK-NOT:   var pointee
+// CHECK: }
+
+// CHECK: struct NonReferenceDereferenceOperator : UnsafeCxxInputIterator {
+// CHECK:   func __operatorStar() -> Int32
+// CHECK:   func successor() -> NonReferenceDereferenceOperator
+// CHECK:   typealias Pointee = Int32
+// CHECK:   typealias DereferenceResult = Int32
+// CHECK:   var pointee: Int32 { get }
+// CHECK: }
+
+// CHECK: struct NoConstDereferenceOperator {
+// CHECK:   mutating func __operatorStar() -> UnsafeMutablePointer<Int32>
+// CHECK:   static func * (lhs: NoConstDereferenceOperator, other: NoConstDereferenceOperator) -> Int32
+// CHECK:   static func == (lhs: NoConstDereferenceOperator, other: NoConstDereferenceOperator) -> Bool
+// CHECK:   func successor() -> NoConstDereferenceOperator
+// CHECK:   var pointee: Int32 { mutating get set }
+// CHECK: }
+
+// CHECK: struct ConstRACButNotBorrowingIterator : UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
+// CHECK:   func __operatorStar() -> Int32
+// CHECK:   func successor() -> ConstRACButNotBorrowingIterator
+// CHECK:   typealias Pointee = Int32
+// CHECK:   typealias DereferenceResult = Int32
+// CHECK:   typealias Distance = Int32
+// CHECK:   static func += (lhs: inout ConstRACButNotBorrowingIterator, v: ConstRACButNotBorrowingIterator.difference_type)
+// CHECK:   static func - (lhs: ConstRACButNotBorrowingIterator, other: ConstRACButNotBorrowingIterator) -> Int32
+// CHECK:   static func == (lhs: ConstRACButNotBorrowingIterator, other: ConstRACButNotBorrowingIterator) -> Bool
+// CHECK:   var pointee: Int32 { get }
 // CHECK: }
 
 // CHECK-NOT: struct HasNoIteratorCategory : UnsafeCxxInputIterator

--- a/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
@@ -103,7 +103,6 @@
 // CHECK: }
 
 // CHECK: struct DifferentResultsDereferenceOperator : UnsafeCxxMutableInputIterator {
-// CHECK:   mutating func __operatorStar() -> UnsafeMutablePointer<Int>
 // CHECK:   func __operatorStar() -> UnsafePointer<Int32>
 // CHECK:   func successor() -> DifferentResultsDereferenceOperator
 // CHECK:   typealias Pointee = Int32

--- a/test/Interop/Cxx/stdlib/overlay/custom-iterator-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-iterator-typechecker.swift
@@ -6,9 +6,12 @@
 // contiguous iterators.
 //
 // RUN: %if !(LinuxDistribution=ubuntu-20.04 || LinuxDistribution=amzn-2) %{ \
-// RUN:   %target-typecheck-verify-swift -verify-ignore-unrelated -suppress-notes -I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++20 -DCPP20 -verify-additional-prefix cpp20- \
+// RUN:   %target-typecheck-verify-swift -verify-ignore-unrelated -suppress-notes -I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++20 -enable-experimental-feature SuppressedAssociatedTypesWithDefaults -enable-experimental-feature BorrowingSequence -DCPP20 -verify-additional-prefix cpp20- \
 // RUN: %}
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -suppress-notes -I %S/Inputs -cxx-interoperability-mode=default
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -suppress-notes -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature SuppressedAssociatedTypesWithDefaults -enable-experimental-feature BorrowingSequence
+
+// REQUIRES: swift_feature_SuppressedAssociatedTypesWithDefaults
+// REQUIRES: swift_feature_BorrowingSequence
 
 import CustomIterator
 
@@ -18,6 +21,8 @@ func checkContiguous<It: UnsafeCxxContiguousIterator>(_ _: It) {}
 func checkMutableInput<It: UnsafeCxxMutableInputIterator>(_ _: It) {}
 func checkMutableRandomAccess<It: UnsafeCxxMutableRandomAccessIterator>(_ _: It) {}
 func checkMutableContiguous<It: UnsafeCxxMutableContiguousIterator>(_ _: It) {}
+@available(SwiftStdlib 6.4, *)
+func checkBorrowingIterator<It: BorrowingIteratorProtocol>(_ _: It) {}
 
 func check(it: ConstIterator) {
   checkInput(it)
@@ -26,6 +31,7 @@ func check(it: ConstIterator) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: ConstRACIterator) {
@@ -35,6 +41,7 @@ func check(it: ConstRACIterator) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: ConstRACIteratorRefPlusEq) {
@@ -44,6 +51,7 @@ func check(it: ConstRACIteratorRefPlusEq) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: ConstIteratorOutOfLineEq) {
@@ -53,6 +61,7 @@ func check(it: ConstIteratorOutOfLineEq) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: MinimalIterator) {
@@ -62,6 +71,7 @@ func check(it: MinimalIterator) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: ForwardIterator) {
@@ -71,6 +81,7 @@ func check(it: ForwardIterator) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: HasCustomIteratorTag) {
@@ -80,6 +91,7 @@ func check(it: HasCustomIteratorTag) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: HasCustomRACIteratorTag) {
@@ -89,6 +101,7 @@ func check(it: HasCustomRACIteratorTag) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: HasCustomInheritedRACIteratorTag) {
@@ -98,6 +111,7 @@ func check(it: HasCustomInheritedRACIteratorTag) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: HasCustomIteratorTagInline) {
@@ -107,6 +121,7 @@ func check(it: HasCustomIteratorTagInline) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: HasTypedefIteratorTag) {
@@ -116,6 +131,7 @@ func check(it: HasTypedefIteratorTag) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: MutableRACIterator) {
@@ -125,15 +141,27 @@ func check(it: MutableRACIterator) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
-func check(it: NonReferenceDereferenceOperator) {
+func check(it: HasNestedIterator.NestedIterator) {
   checkInput(it)
   checkRandomAccess(it)         // expected-error {{requires}}
   checkContiguous(it)           // expected-error {{requires}}
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
+}
+
+func check(it: DifferentResultsDereferenceOperator) {
+  checkInput(it)
+  checkRandomAccess(it)         // expected-error {{requires}}
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 #if CPP20
@@ -145,6 +173,7 @@ func check(it: ConstContiguousIterator) {
   checkMutableInput(it)         // expected-cpp20-error {{requires}}
   checkMutableRandomAccess(it)  // expected-cpp20-error {{requires}}
   checkMutableContiguous(it)    // expected-cpp20-error {{requires}}
+  checkBorrowingIterator(it)    // expected-cpp20-error {{requires}}
 }
 
 func check(it: HasCustomContiguousIteratorTag) {
@@ -154,6 +183,7 @@ func check(it: HasCustomContiguousIteratorTag) {
   checkMutableInput(it)         // expected-cpp20-error {{requires}}
   checkMutableRandomAccess(it)  // expected-cpp20-error {{requires}}
   checkMutableContiguous(it)    // expected-cpp20-error {{requires}}
+  checkBorrowingIterator(it)    // expected-cpp20-error {{requires}}
 }
 
 func check(it: MutableContiguousIterator) {
@@ -163,6 +193,7 @@ func check(it: MutableContiguousIterator) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)
   checkMutableContiguous(it)
+  checkBorrowingIterator(it)    // expected-cpp20-error {{requires}}
 }
 
 func check(it: HasNoContiguousIteratorConcept) {
@@ -172,9 +203,51 @@ func check(it: HasNoContiguousIteratorConcept) {
   checkMutableInput(it)         // expected-cpp20-error {{requires}}
   checkMutableRandomAccess(it)  // expected-cpp20-error {{requires}}
   checkMutableContiguous(it)    // expected-cpp20-error {{requires}}
+  checkBorrowingIterator(it)    // expected-cpp20-error {{requires}}
 }
 
 #endif
+
+func check(it: NonInlineDereferenceOperator) {
+  checkInput(it)                // expected-error {{requires}}
+  checkRandomAccess(it)         // expected-error {{requires}}
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)         // expected-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
+}
+
+func check(it: NonReferenceDereferenceOperator) {
+  checkInput(it)
+  checkRandomAccess(it)         // expected-error {{requires}}
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)         // expected-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
+}
+
+func check(it: NoConstDereferenceOperator) {
+  checkInput(it)                // expected-error {{requires}}
+  checkRandomAccess(it)         // expected-error {{requires}}
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)         // expected-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
+}
+
+func check(it: ConstRACButNotBorrowingIterator) {
+  checkInput(it)
+  checkRandomAccess(it)
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)         // expected-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
+}
+
 
 func check(it: HasNoIteratorCategory) {
   checkInput(it)                // expected-error {{requires}}
@@ -183,6 +256,7 @@ func check(it: HasNoIteratorCategory) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: HasInvalidIteratorCategory) {
@@ -192,6 +266,7 @@ func check(it: HasInvalidIteratorCategory) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: HasNoEqualEqual) {
@@ -201,6 +276,7 @@ func check(it: HasNoEqualEqual) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: HasInvalidEqualEqual) {
@@ -210,6 +286,7 @@ func check(it: HasInvalidEqualEqual) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: HasNoIncrementOperator) {
@@ -219,6 +296,7 @@ func check(it: HasNoIncrementOperator) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: HasNoPreIncrementOperator) {
@@ -228,6 +306,7 @@ func check(it: HasNoPreIncrementOperator) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: HasNoDereferenceOperator) {
@@ -237,6 +316,7 @@ func check(it: HasNoDereferenceOperator) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: TemplatedIteratorInt) {
@@ -246,6 +326,7 @@ func check(it: TemplatedIteratorInt) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 
@@ -256,6 +337,7 @@ func check(it: TemplatedIteratorOutOfLineEqInt) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 
@@ -266,6 +348,7 @@ func check(it: TemplatedRACIteratorOutOfLineEqInt) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: BaseIntIterator) {
@@ -275,6 +358,7 @@ func check(it: BaseIntIterator) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: InheritedConstIterator) {
@@ -284,6 +368,7 @@ func check(it: InheritedConstIterator) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: InheritedTemplatedConstIteratorInt) {
@@ -293,6 +378,7 @@ func check(it: InheritedTemplatedConstIteratorInt) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: InheritedTemplatedConstRACIteratorInt) {
@@ -302,6 +388,7 @@ func check(it: InheritedTemplatedConstRACIteratorInt) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: InheritedTemplatedConstRACIteratorOutOfLineOpsInt) {
@@ -311,6 +398,7 @@ func check(it: InheritedTemplatedConstRACIteratorOutOfLineOpsInt) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: InputOutputIterator) {
@@ -320,6 +408,7 @@ func check(it: InputOutputIterator) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: InputOutputConstIterator) {
@@ -329,6 +418,7 @@ func check(it: InputOutputConstIterator) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: ProtectedIteratorBase) {
@@ -338,6 +428,7 @@ func check(it: ProtectedIteratorBase) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: HasInheritedProtectedCopyConstructor) {
@@ -347,6 +438,7 @@ func check(it: HasInheritedProtectedCopyConstructor) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: TaglessNewPtr) {
@@ -356,6 +448,7 @@ func check(it: TaglessNewPtr) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: InputCategoryNewPtr) {
@@ -365,6 +458,7 @@ func check(it: InputCategoryNewPtr) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: ForwardCategoryNewPtr) {
@@ -374,6 +468,7 @@ func check(it: ForwardCategoryNewPtr) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: RandomAccessCategoryNewPtr) {
@@ -383,6 +478,7 @@ func check(it: RandomAccessCategoryNewPtr) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 #if CPP20
@@ -394,6 +490,7 @@ func check(it: ContiguousCategoryNewPtr) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)
   checkMutableContiguous(it)
+  checkBorrowingIterator(it)    // expected-cpp20-error {{requires}}
 }
 
 func check(it: InputConceptNewPtr) {
@@ -403,6 +500,7 @@ func check(it: InputConceptNewPtr) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)  // expected-cpp20-error {{requires}}
   checkMutableContiguous(it)    // expected-cpp20-error {{requires}}
+  checkBorrowingIterator(it)    // expected-cpp20-error {{requires}}
 }
 
 func check(it: ForwardConceptNewPtr) {
@@ -421,6 +519,7 @@ func check(it: RandomAccessConceptNewPtr) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)
   checkMutableContiguous(it)    // expected-cpp20-error {{requires}}
+  checkBorrowingIterator(it)    // expected-cpp20-error {{requires}}
 }
 
 func check(it: ContiguousConceptNewPtr) {
@@ -430,6 +529,7 @@ func check(it: ContiguousConceptNewPtr) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)
   checkMutableContiguous(it)
+  checkBorrowingIterator(it)    // expected-cpp20-error {{requires}}
 }
 
 func check(it: InvalidContiguousCategoryNewPtr) {
@@ -439,6 +539,7 @@ func check(it: InvalidContiguousCategoryNewPtr) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)
   checkMutableContiguous(it)    // expected-cpp20-error {{requires}}
+  checkBorrowingIterator(it)    // expected-cpp20-error {{requires}}
 }
 
 #endif // CPP20
@@ -450,6 +551,7 @@ func check(it: IteratorTagOfMemberTypedef) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: IteratorTagOfNonMemberTypedef) {
@@ -459,6 +561,7 @@ func check(it: IteratorTagOfNonMemberTypedef) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: BasicLegacyPtr) {
@@ -468,6 +571,7 @@ func check(it: BasicLegacyPtr) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: NotALegacyPtr) {
@@ -477,6 +581,7 @@ func check(it: NotALegacyPtr) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: InputCategoryLegacyPtr) {
@@ -486,6 +591,7 @@ func check(it: InputCategoryLegacyPtr) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 #if CPP20
@@ -497,6 +603,7 @@ func check(it: InputConceptLegacyPtr) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)  // expected-cpp20-error {{requires}}
   checkMutableContiguous(it)    // expected-cpp20-error {{requires}}
+  checkBorrowingIterator(it)    // expected-cpp20-error {{requires}}
 }
 
 func check(it: ContiguousConceptLegacyPtr) {
@@ -506,6 +613,7 @@ func check(it: ContiguousConceptLegacyPtr) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)
   checkMutableContiguous(it)
+  checkBorrowingIterator(it)    // expected-cpp20-error {{requires}}
 }
 
 func check(it: InputCategoryContiguousConceptLegacyPtr) {
@@ -515,6 +623,7 @@ func check(it: InputCategoryContiguousConceptLegacyPtr) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)
   checkMutableContiguous(it)
+  checkBorrowingIterator(it)    // expected-cpp20-error {{requires}}
 }
 
 #endif // CPP20

--- a/test/Interop/Cxx/stdlib/use-std-list.swift
+++ b/test/Interop/Cxx/stdlib/use-std-list.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
+// Test iterating through a list using the borrowing iterators (currently behind a feature flag).
 
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/stdlib/use-std-span-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-span-typechecker.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop -Xcc -std=c++20 2>&1
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop -Xcc -std=c++20 2>&1 -disable-availability-checking
 // REQUIRES: std_span
 
 import StdSpan
@@ -6,24 +6,25 @@ import StdSpan
 func takesSequence<T: Sequence>(_ _: T) {}
 // expected-note@-1 {{where 'T' = 'SpanOfNonCopyable'}}
 
+func takesBorrowingSequence<T: CxxBorrowingSequence>(_ _: T) {}
+
 func takesSpan<S: CxxMutableSpan>(_ _: S) {}
 
 let arr: [Int32] = [1, 2, 3]
 arr.withUnsafeBufferPointer { ubpointer in
     let _ = ConstSpanOfInt(ubpointer) // okay
     let _ = ConstSpanOfInt(ubpointer.baseAddress!, ubpointer.count) 
-    // expected-warning@-1 {{'init(_:_:)' is deprecated: use 'init(_:)' instead.}}
 }
 
 arr.withUnsafeBufferPointer { ubpointer in 
     // FIXME: this crashes the compiler once we import span's templated ctors as Swift generics.
     let _ = ConstSpanOfInt(ubpointer.baseAddress, ubpointer.count)
-    // expected-warning@-1 {{'init(_:_:)' is deprecated: use 'init(_:)' instead.}}
 }
 
 let s1 = initSpan()
 for _ in s1 {}
 takesSequence(s1)
+takesBorrowingSequence(s1)
 takesSpan(s1)
 
 let s2 = makeSpanOfNonCopyable()
@@ -31,4 +32,5 @@ for _ in s2 {}
 // expected-error@-1 {{for-in loop requires 'SpanOfNonCopyable'}} to conform to 'Sequence'
 takesSequence(s2)
 // expected-error@-1 {{global function 'takesSequence' requires that 'SpanOfNonCopyable'}} conform to 'Sequence'
+takesBorrowingSequence(s2)
 takesSpan(s2)


### PR DESCRIPTION
This patch addresses some of the reviews from https://github.com/swiftlang/swift/pull/87186. It also improves the test coverage for `CxxBorrowingSequence` and tests the experimental feature `BorrowingForLoop`.