### PR TITLE
CMake Runtimes: Fix target sources

### DIFF
--- a/Runtimes/Supplemental/Runtime/CMakeLists.txt
+++ b/Runtimes/Supplemental/Runtime/CMakeLists.txt
@@ -184,7 +184,7 @@ if(${PROJECT_NAME}_ENABLE_BACKTRACING)
     endif()
   else()
     # Other platforms can use the shared `.S` file.
-    target_sources(swiftRuntime
+    target_sources(swiftRuntime PRIVATE
       get-cpu-context.S)
   endif()
 


### PR DESCRIPTION
`target_sources` requires a scope.
