### PR TITLE
[loadable-by-address] Update debug variable type when rewriting alloc_stack

### DIFF
--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -1759,9 +1759,8 @@ public:
 
 /// Given that we've allocated space to hold a scalar value, try to rewrite
 /// the uses of the scalar to be uses of the address.
-static void rewriteUsesOfSscalar(StructLoweringState &pass,
-                                 SILValue address, SILValue scalar,
-                                 StoreInst *storeToAddress) {
+static void rewriteUsesOfScalar(StructLoweringState &pass, SILValue address,
+                                SILValue scalar, StoreInst *storeToAddress) {
   // Copy the uses, since we're going to edit them.
   SmallVector<Operand *, 8> uses(scalar->getUses());
   for (Operand *scalarUse : uses) {
@@ -1812,7 +1811,7 @@ static void allocateAndSetForInstResult(StructLoweringState &pass,
   auto store = createStoreInit(pass, II, inst->getLoc(), instResult, alloc);
 
   // Traverse all the uses of instResult - see if we can replace
-  rewriteUsesOfSscalar(pass, alloc, instResult, store);
+  rewriteUsesOfScalar(pass, alloc, instResult, store);
 }
 
 static void allocateAndSetForArgument(StructLoweringState &pass,
@@ -1832,7 +1831,7 @@ static void allocateAndSetForArgument(StructLoweringState &pass,
   auto store = createStoreInit(pass, II, loc, value, alloc);
 
   // Traverse all the uses of value - see if we can replace
-  rewriteUsesOfSscalar(pass, alloc, value, store);
+  rewriteUsesOfScalar(pass, alloc, value, store);
 }
 
 static bool allUsesAreReplaceable(StructLoweringState &pass,

--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -2141,8 +2141,13 @@ static void rewriteFunction(StructLoweringState &pass,
     SILType currSILType = instr->getType();
     SILType newSILType = pass.getNewSILType(pass.F->getLoweredFunctionType(),
                                             currSILType);
-    auto *newInstr = allocBuilder.createAllocStack(instr->getLoc(), newSILType,
-                                                   instr->getVarInfo());
+    auto varInfo = instr->getVarInfo();
+    // Update the debug variable type to match the new SSA type so the
+    // SIL verifier does not see a mismatch between the two.
+    if (varInfo && varInfo->Type)
+      varInfo->Type = newSILType.getObjectType();
+    auto *newInstr =
+        allocBuilder.createAllocStack(instr->getLoc(), newSILType, varInfo);
     instr->replaceAllUsesWith(newInstr);
     instr->getParent()->erase(instr);
   }

--- a/test/IRGen/loadable_by_address_swift6.sil
+++ b/test/IRGen/loadable_by_address_swift6.sil
@@ -1,0 +1,42 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -loadable-address -sil-print-types | %FileCheck %s
+
+// Complementary SIL-level test for loadable_by_address_swift6.swift.
+//
+// Tests that LoadableByAddress correctly handles a @sil_sending Optional
+// closure parameter where the closure takes a large-loadable struct by value.
+//
+// G<Int> is large loadable: its 4 String fields exceed the threshold, so
+// LoadableByAddress must convert the @guaranteed G<Int> parameter convention
+// inside the nested closure type to @in_guaranteed (by-address lowering).
+// The @sil_sending attribute on the outer parameter must be preserved.
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+public struct G<T> {
+  @_hasStorage public let a: String { get }
+  @_hasStorage public let b: String { get }
+  @_hasStorage public let c: String { get }
+  @_hasStorage public let d: String { get }
+}
+
+// Test: LoadableByAddress lowers @guaranteed G<Int> -> @in_guaranteed G<Int>
+// inside a nested Optional<@callee_guaranteed ...> type, while preserving
+// the @sil_sending attribute on the outer function parameter.
+//
+// CHECK-LABEL:  sil @test_sending_optional_closure : $@convention(thin) <T> (@sil_sending @owned Optional<@callee_guaranteed @substituted <τ_0_0 where τ_0_0 : Copyable, τ_0_0 : Escapable> (@in_guaranteed G<τ_0_0>) -> () for <T>>) -> () {
+// CHECK: alloc_stack $Optional<@callee_guaranteed @substituted <τ_0_0 where τ_0_0 : Copyable, τ_0_0 : Escapable> (@in_guaranteed G<τ_0_0>) -> () for <T>>, var, name "body", type $Optional<@callee_guaranteed @substituted <τ_0_0 where τ_0_0 : Copyable, τ_0_0 : Escapable> (@in_guaranteed G<τ_0_0>) -> () for <T>>
+// CHECK:       } // end sil function 'test_sending_optional_closure'
+sil @test_sending_optional_closure : $@convention(thin) <T> (@sil_sending @owned Optional<@callee_guaranteed @substituted <τ_0_0 where τ_0_0 : Copyable, τ_0_0 : Escapable> (@guaranteed G<τ_0_0>) -> () for <T>>) -> () {
+// %0 "body"                                      // user: %2
+bb0(%0 : $Optional<@callee_guaranteed @substituted <τ_0_0 where τ_0_0 : Copyable, τ_0_0 : Escapable> (@guaranteed G<τ_0_0>) -> () for <T>>):
+  %1 = alloc_stack [lexical] [var_decl] $Optional<@callee_guaranteed @substituted <τ_0_0 where τ_0_0 : Copyable, τ_0_0 : Escapable> (@guaranteed G<τ_0_0>) -> () for <T>>, var, name "body", type $Optional<@callee_guaranteed @substituted <τ_0_0 where τ_0_0 : Copyable, τ_0_0 : Escapable> (@guaranteed G<τ_0_0>) -> () for <T>>
+  debug_value %0 : $Optional<@callee_guaranteed @substituted <τ_0_0 where τ_0_0 : Copyable, τ_0_0 : Escapable> (@guaranteed G<τ_0_0>) -> () for <T>>, var, name "arg", type $Optional<@callee_guaranteed @substituted <τ_0_0 where τ_0_0 : Copyable, τ_0_0 : Escapable> (@guaranteed G<τ_0_0>) -> () for <T>>
+  store %0 to %1
+  destroy_addr %1
+  dealloc_stack %1
+  %5 = tuple ()
+  return %5
+}

--- a/test/IRGen/loadable_by_address_swift6.swift
+++ b/test/IRGen/loadable_by_address_swift6.swift
@@ -1,0 +1,12 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
+// RUN: %target-swift-frontend -I %t -c %s -swift-version 6 -sil-verify-all
+
+public struct G<T> {
+    public let a: String
+    public let b: String
+    public let c: String
+    public let d: String
+}
+
+func f<T>(body: sending ((G<T>) -> Void)?) {}


### PR DESCRIPTION
The LoadableByAddress pass rewrites alloc_stack instructions when their element
type changes (e.g., a function parameter convention changes from @guaranteed to
@in_guaranteed for large/opaque types). However, it was passing the original
SILDebugVariable info through unchanged. When the VarInfo has an explicit Type
field set this creates a mismatch between the SSA type and the debug type,
causing a SIL verifier failure.

In this patch, I just change the pass to update the alloc_stack as
appropriate. I verified that this cannot happen with debug_value since we do not
store the extra type info in it if we have an object typed thing. Since
loadable_by_address only changes objects -> addresses, it can never happen.

rdar://164268891

