### PR TITLE
[Backtracing] Add an option to close all file handles 

### DIFF
--- a/docs/Backtracing.rst
+++ b/docs/Backtracing.rst
@@ -118,6 +118,9 @@ follows:
 |                 |         | related to the state of the backtracer.  This is |
 |                 |         | sometimes useful for testing.                    |
 +-----------------+---------+--------------------------------------------------+
+| close-fds       | false   | Close all file descriptors on the crashing       |
+|                 |         | process before starting to gather a crash log.   |
++-----------------+---------+--------------------------------------------------+
 
 (*) On macOS 26 and later, this defaults to ``tty`` rather than ``yes``. On
     earlier versions, the default is ``no``.

--- a/docs/Backtracing.rst
+++ b/docs/Backtracing.rst
@@ -118,8 +118,9 @@ follows:
 |                 |         | related to the state of the backtracer.  This is |
 |                 |         | sometimes useful for testing.                    |
 +-----------------+---------+--------------------------------------------------+
-| close-fds       | false   | Close all file descriptors on the crashing       |
+| close-fds       | false   | Close all file descriptors in the crashing       |
 |                 |         | process before starting to gather a crash log.   |
+|                 |         | (This does nothing on Windows.)                  |
 +-----------------+---------+--------------------------------------------------+
 
 (*) On macOS 26 and later, this defaults to ``tty`` rather than ``yes``. On

--- a/stdlib/public/runtime/Backtrace.cpp
+++ b/stdlib/public/runtime/Backtrace.cpp
@@ -150,6 +150,9 @@ SWIFT_RUNTIME_STDLIB_INTERNAL BacktraceSettings _swift_backtraceSettings = {
 
   // outputPath
   NULL,
+
+  // closeFds
+  false,
 };
 
 }
@@ -782,6 +785,8 @@ _swift_processBacktracingSetting(llvm::StringRef key,
     }
   } else if (key.equals_insensitive("cache")) {
     _swift_backtraceSettings.cache = parseBoolean(value);
+  } else if (key.equals_insensitive("close-fds")) {
+    _swift_backtraceSettings.closeFds = parseBoolean(value);
   } else if (key.equals_insensitive("output-to")) {
     if (value.equals_insensitive("auto"))
       _swift_backtraceSettings.outputTo = OutputTo::Auto;

--- a/stdlib/public/runtime/BacktracePrivate.h
+++ b/stdlib/public/runtime/BacktracePrivate.h
@@ -144,6 +144,7 @@ struct BacktraceSettings {
   bool             inBacktracer;
   const char      *swiftBacktracePath;
   const char      *outputPath;
+  bool             closeFds;
 };
 
 SWIFT_RUNTIME_STDLIB_INTERNAL BacktraceSettings _swift_backtraceSettings;

--- a/stdlib/public/runtime/CrashHandlerLinux.cpp
+++ b/stdlib/public/runtime/CrashHandlerLinux.cpp
@@ -65,9 +65,6 @@
 
 #include "BacktracePrivate.h"
 
-// Run the memserver in a thread (0) or separate process (1)
-#define MEMSERVER_USE_PROCESS 0
-
 #ifndef lengthof
 #define lengthof(x)     (sizeof(x) / sizeof(x[0]))
 #endif
@@ -86,7 +83,7 @@ uint32_t currently_paused();
 void wait_paused(uint32_t expected, const struct timespec *timeout);
 int  memserver_start();
 int  memserver_entry(void *);
-void closeFds(int keepOpen);
+void closeFds(int memserver_master_fd);
 
 ssize_t safe_read(int fd, void *buf, size_t len) {
   uint8_t *ptr = (uint8_t *)buf;
@@ -291,12 +288,10 @@ handle_fatal_signal(int signum,
       write(STDERR_FILENO, message, strlen(message));
   }
 
-#if !MEMSERVER_USE_PROCESS
-  /* If the memserver is in-process, it may have set signal handlers,
+  /* The memserver may have set signal handlers,
      so reset SIGSEGV and SIGBUS again */
   reset_signal(SIGSEGV);
   reset_signal(SIGBUS);
-#endif
 
   // Restart the other threads
   resume_other_threads();
@@ -679,23 +674,6 @@ wait_paused(uint32_t expected, const struct timespec *timeout)
            || errno == EAGAIN);
 }
 
-#define MIN_FD_TO_CLOSE 3
-#define MAX_FD_TO_CLOSE ~0
-
-void
-closeFds(int keepOpen) {
-  // We don't attempt to close memserver_fd, if the mem server is in process
-  // we need to leave it open, if it's in a sub process then this function
-  // should be running on the parent (crashing) process and should already
-  // have closed it.
-
-  // Otherwise we close all file descriptors after stderr except the end of
-  // the pipe used by swift-backtrace.
-
-  _close_range(MIN_FD_TO_CLOSE, keepOpen-1, 0);
-  _close_range(keepOpen+1, MAX_FD_TO_CLOSE, 0);
-}
-
 // .. Memory server ............................................................
 
 /* The memory server exists so that we can gain access to the crashing
@@ -711,6 +689,37 @@ int memserver_fd;
 sigjmp_buf memserver_fault_buf;
 pid_t memserver_pid;
 
+#define MIN_FD_TO_CLOSE 3
+#define MAX_FD_TO_CLOSE ~0
+
+void
+closeFds(int memserver_master_fd) {
+  // We don't attempt to close either of the file descriptors for the
+  // pipe used to communicate with the memserver thread.
+
+  // Otherwise we close all file descriptors after stderr except the end of
+  // the pipe used by swift-backtrace.
+
+  int keepOpen1 = memserver_master_fd;
+  int keepOpen2 = memserver_fd;
+
+  if (keepOpen2 > keepOpen1+1) {
+    _close_range(MIN_FD_TO_CLOSE, keepOpen1-1, 0);
+    _close_range(keepOpen1+1, keepOpen2-1, 0);
+    _close_range(keepOpen2+1, MAX_FD_TO_CLOSE, 0);
+  } else if (keepOpen2+1 < keepOpen1) {
+    _close_range(MIN_FD_TO_CLOSE, keepOpen2-1, 0);
+    _close_range(keepOpen2+1, keepOpen1-1, 0);
+    _close_range(keepOpen1+1, MAX_FD_TO_CLOSE, 0);
+  } else {
+    // the file descriptors are adjacent
+    int fd1 = keepOpen2 > keepOpen1 ? keepOpen1 : keepOpen2;
+    int fd2 = keepOpen2 > keepOpen1 ? keepOpen2 : keepOpen1;
+    _close_range(MIN_FD_TO_CLOSE, fd1-1, 0);
+    _close_range(fd2+1, MAX_FD_TO_CLOSE, 0);    
+  }
+}
+
 int
 memserver_start()
 {
@@ -725,34 +734,19 @@ memserver_start()
 
   memserver_fd = fds[0];
   ret = clone(memserver_entry, memserver_stack + sizeof(memserver_stack),
-#if MEMSERVER_USE_PROCESS
-              0,
-#else
               #ifndef __musl__
               // Can't use CLONE_THREAD on musl because the clone() function
               // there returns EINVAL if we do.
               CLONE_THREAD | CLONE_SIGHAND |
               #endif
               CLONE_VM | CLONE_FILES | CLONE_FS | CLONE_IO,
-#endif
               NULL);
   if (ret < 0) {
     memserver_error("memserver_start: clone failed");
     return ret;
   }
 
-#if MEMSERVER_USE_PROCESS
-  memserver_pid = ret;
-
-  /* Tell the Yama LSM module, if it's running, that it's OK for
-     the memserver to read process memory */
-  prctl(PR_SET_PTRACER, ret);
-
-  close(fds[0]);
-  memserver_fd = 0;
-#else
   memserver_pid = getpid();
-#endif
 
   return fds[1];
 }
@@ -784,10 +778,6 @@ int
 memserver_entry(void *dummy __attribute__((unused))) {
   int fd = memserver_fd;
   int result = 1;
-
-#if MEMSERVER_USE_PROCESS || defined(__musl__)
-  prctl(PR_SET_NAME, "[backtrace]");
-#endif
 
   struct sigaction sa;
   sigfillset(&sa.sa_mask);

--- a/stdlib/public/runtime/CrashHandlerLinux.cpp
+++ b/stdlib/public/runtime/CrashHandlerLinux.cpp
@@ -86,6 +86,7 @@ uint32_t currently_paused();
 void wait_paused(uint32_t expected, const struct timespec *timeout);
 int  memserver_start();
 int  memserver_entry(void *);
+void closeFds(int keepOpen);
 
 ssize_t safe_read(int fd, void *buf, size_t len) {
   uint8_t *ptr = (uint8_t *)buf;
@@ -203,7 +204,7 @@ _swift_installCrashHandler()
 
 namespace {
 
-// Older glibc and musl don't have these two syscalls
+// Older glibc and musl don't have these syscalls
 pid_t
 gettid()
 {
@@ -213,6 +214,13 @@ gettid()
 int
 tgkill(int tgid, int tid, int sig) {
   return syscall(SYS_tgkill, tgid, tid, sig);
+}
+
+#define CLOSE_RANGE_UNSHARE 0x2
+#define CLOSE_RANGE_CLOEXEC 0x4
+
+static int _close_range(unsigned int first, unsigned int last, int flags) {
+  return syscall(SYS_close_range, first, last, flags);
 }
 
 void
@@ -671,20 +679,21 @@ wait_paused(uint32_t expected, const struct timespec *timeout)
            || errno == EAGAIN);
 }
 
-#define MIN_FD_TO_CLOSE 0
-#define MAX_FD_TO_CLOSE 1000
+#define MIN_FD_TO_CLOSE 3
+#define MAX_FD_TO_CLOSE ~0
 
 void
-closeFds(int fd) {
-  for (int i = MIN_FD_TO_CLOSE; i < MAX_FD_TO_CLOSE; i++) {
-    // we don't attempt to close memserver_fd, if the mem server is in process
-    // we need to leave it open, if it's in a sub process then this function
-    // should be running on the parent (crashing) process and should already
-    // have closed it
-    if (i != STDOUT_FILENO && i != STDERR_FILENO && i != fd) {
-      close(i);
-    }
-  }
+closeFds(int keepOpen) {
+  // We don't attempt to close memserver_fd, if the mem server is in process
+  // we need to leave it open, if it's in a sub process then this function
+  // should be running on the parent (crashing) process and should already
+  // have closed it.
+
+  // Otherwise we close all file descriptors after stderr except the end of
+  // the pipe used by swift-backtrace.
+
+  _close_range(MIN_FD_TO_CLOSE, keepOpen-1, 0);
+  _close_range(keepOpen+1, MAX_FD_TO_CLOSE, 0);
 }
 
 // .. Memory server ............................................................

--- a/stdlib/public/runtime/CrashHandlerMacOS.cpp
+++ b/stdlib/public/runtime/CrashHandlerMacOS.cpp
@@ -195,6 +195,18 @@ resume_other_threads()
   os_unfair_lock_unlock(&crashLock);
 }
 
+#define MIN_FD_TO_CLOSE 0
+#define MAX_FD_TO_CLOSE 1000
+
+void
+closeFds() {
+  for (int i = MIN_FD_TO_CLOSE; i < MAX_FD_TO_CLOSE; i++) {
+    if (i != STDOUT_FILENO && i != STDERR_FILENO) {
+      close(i);
+    }
+  }
+}
+
 void
 handle_fatal_signal(int signum,
                     siginfo_t *pinfo,
@@ -251,6 +263,10 @@ handle_fatal_signal(int signum,
 #endif
 
   _swift_displayCrashMessage(signum, pc);
+
+  if (_swift_backtraceSettings.closeFds) {
+    closeFds();
+  }
 
   /* Start the backtracer; this will suspend the process, so there's no need
      to try to suspend other threads from here. */

--- a/stdlib/public/runtime/CrashHandlerMacOS.cpp
+++ b/stdlib/public/runtime/CrashHandlerMacOS.cpp
@@ -72,6 +72,8 @@ const int signalsToHandle[] = {
   SIGTRAP
 };
 
+static struct rlimit rlp = {0};
+
 } // namespace
 
 namespace swift {
@@ -81,6 +83,8 @@ namespace backtrace {
 SWIFT_RUNTIME_STDLIB_INTERNAL int
 _swift_installCrashHandler()
 {
+  getrlimit(RLIMIT_NOFILE, &rlp);
+
   stack_t ss;
 
   // See if an alternate signal stack already exists
@@ -195,15 +199,12 @@ resume_other_threads()
   os_unfair_lock_unlock(&crashLock);
 }
 
-#define MIN_FD_TO_CLOSE 0
-#define MAX_FD_TO_CLOSE 1000
+#define MIN_FD_TO_CLOSE 3
 
 void
 closeFds() {
-  for (int i = MIN_FD_TO_CLOSE; i < MAX_FD_TO_CLOSE; i++) {
-    if (i != STDOUT_FILENO && i != STDERR_FILENO) {
-      close(i);
-    }
+  for (int i = MIN_FD_TO_CLOSE; i < rlp.rlim_max; i++) {
+    close(i);
   }
 }
 

--- a/stdlib/public/runtime/CrashHandlerMacOS.cpp
+++ b/stdlib/public/runtime/CrashHandlerMacOS.cpp
@@ -72,8 +72,6 @@ const int signalsToHandle[] = {
   SIGTRAP
 };
 
-static struct rlimit rlp = {0};
-
 } // namespace
 
 namespace swift {
@@ -83,8 +81,6 @@ namespace backtrace {
 SWIFT_RUNTIME_STDLIB_INTERNAL int
 _swift_installCrashHandler()
 {
-  getrlimit(RLIMIT_NOFILE, &rlp);
-
   stack_t ss;
 
   // See if an alternate signal stack already exists
@@ -205,7 +201,7 @@ resume_other_threads()
 void
 closeFds() {
   for (int i = MIN_FD_TO_CLOSE; i < MAX_FD_TO_CLOSE; i++) {
-    close(i)
+    close(i);
   }
 }
 

--- a/stdlib/public/runtime/CrashHandlerMacOS.cpp
+++ b/stdlib/public/runtime/CrashHandlerMacOS.cpp
@@ -200,11 +200,12 @@ resume_other_threads()
 }
 
 #define MIN_FD_TO_CLOSE 3
+#define MAX_FD_TO_CLOSE 100
 
 void
 closeFds() {
-  for (int i = MIN_FD_TO_CLOSE; i < rlp.rlim_max; i++) {
-    close(i);
+  for (int i = MIN_FD_TO_CLOSE; i < MAX_FD_TO_CLOSE; i++) {
+    close(i)
   }
 }
 

--- a/stdlib/public/runtime/CrashHandlerWindows.cpp
+++ b/stdlib/public/runtime/CrashHandlerWindows.cpp
@@ -196,6 +196,22 @@ LONG reallyHandleException(EXCEPTION_POINTERS *ExceptionInfo) {
   return EXCEPTION_CONTINUE_SEARCH;
 }
 
+#define MIN_FD_TO_CLOSE 0
+#define MAX_FD_TO_CLOSE 1000
+
+void
+closeFds() {
+  let stdOutFd = _fileno(stdout);
+  let stdErrFd = _fileno(stderr);
+  for (int i = MIN_FD_TO_CLOSE; i < MAX_FD_TO_CLOSE; i++) {
+    if (i != stdOutFd && i != stdErrFd) {
+      // _close should close the underlying file handle
+      // https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/close
+      _close(i);
+    }
+  }
+}
+
 void *pcFromContext(PCONTEXT Context) {
 #if defined(_M_X64)
   return (void *)(Context->Rip);

--- a/stdlib/public/runtime/CrashHandlerWindows.cpp
+++ b/stdlib/public/runtime/CrashHandlerWindows.cpp
@@ -187,6 +187,9 @@ LONG reallyHandleException(EXCEPTION_POINTERS *ExceptionInfo) {
   // It isn't safe to try to stop all the threads here on Windows, so we
   // delegate doing that to the backtracer process.
 
+  // Also, closing open file descriptors is
+  // not something we can easily do on Windows.
+
   if (!_swift_spawnBacktracer(&crashInfo)) {
     const char *message = _swift_backtraceSettings.color == OnOffTty::On
       ? " failed\n\n" : " failed ***\n\n";
@@ -194,14 +197,6 @@ LONG reallyHandleException(EXCEPTION_POINTERS *ExceptionInfo) {
   }
 
   return EXCEPTION_CONTINUE_SEARCH;
-}
-
-#define MIN_FD_TO_CLOSE 0
-#define MAX_FD_TO_CLOSE 1000
-
-void
-closeFds() {
-  // This is not something we can easily do on Windows.
 }
 
 void *pcFromContext(PCONTEXT Context) {

--- a/stdlib/public/runtime/CrashHandlerWindows.cpp
+++ b/stdlib/public/runtime/CrashHandlerWindows.cpp
@@ -201,15 +201,7 @@ LONG reallyHandleException(EXCEPTION_POINTERS *ExceptionInfo) {
 
 void
 closeFds() {
-  let stdOutFd = _fileno(stdout);
-  let stdErrFd = _fileno(stderr);
-  for (int i = MIN_FD_TO_CLOSE; i < MAX_FD_TO_CLOSE; i++) {
-    if (i != stdOutFd && i != stdErrFd) {
-      // _close should close the underlying file handle
-      // https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/close
-      _close(i);
-    }
-  }
+  // This is not something we can easily do on Windows.
 }
 
 void *pcFromContext(PCONTEXT Context) {


### PR DESCRIPTION
Add an option so that when the backtracer starts in a crashing process it will close all unnecessary file descriptors before it tries to start gathering the backtrace as that may take time.

rdar://144402533

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
