### PR TITLE
[Modules] Don't search for cross import when building interface

### DIFF
--- a/lib/Serialization/ScanningLoaders.cpp
+++ b/lib/Serialization/ScanningLoaders.cpp
@@ -174,6 +174,7 @@ SwiftModuleScanner::scanInterfaceFile(Identifier moduleID,
         // Add explicit Swift dependency compilation flags
         Args.push_back("-explicit-interface-module-build");
         Args.push_back("-disable-implicit-swift-modules");
+        Args.push_back("-disable-cross-import-overlay-search");
 
         // Handle clang arguments. For caching build, all arguments are passed
         // with `-direct-clang-cc1-module-build`.

--- a/test/CAS/cross_import.swift
+++ b/test/CAS/cross_import.swift
@@ -23,6 +23,11 @@
 
 // RUN: %{python} %S/../../utils/swift-build-modules.py --cas %t/cas %swift_frontend_plain %t/deps.json -o %t/MyApp.cmd
 
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json D | %FileCheck --check-prefix CHECK-D %s
+
+// CHECK-D: "-disable-implicit-swift-modules"
+// CHECK-D: "-disable-cross-import-overlay-search"
+
 // RUN: %FileCheck %s --input-file=%t/MyApp.cmd --check-prefix CMD
 // CMD: -swift-module-cross-import
 // CMD-NEXT: [[CMI1:[B|C]]]
@@ -73,10 +78,18 @@ version: 1
 modules:
   - name: _C_A
 
+//--- D.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name D -O -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib -user-module-version 1.0
+import A
+import B
+public func d() { }
+
 //--- main.swift
 import A
 import B
 import C
+import D
 
 func test () {
   b_a()

--- a/test/ScanDependencies/explicit-swift-dependencies.swift
+++ b/test/ScanDependencies/explicit-swift-dependencies.swift
@@ -43,6 +43,7 @@ import F
 // ...
 // CHECK:                 "-explicit-interface-module-build",
 // CHECK-NEXT:            "-disable-implicit-swift-modules",
+// CHECK-NEXT:            "-disable-cross-import-overlay-search",
 // CHECK-NEXT:            "-Xcc",
 // CHECK-NEXT:            "-fno-implicit-modules",
 // CHECK-NEXT:            "-Xcc",


### PR DESCRIPTION
Do not search for cross import when building swiftinterfaces. This is uncessary because:
* The cross import modules are explicitly listed in the interface file thus there is no need to walk the file system to discover more cross imports.
* All cross imports are discovered by scanner already and the dependencies are passed to the interface building job. There is no need to search file system to find the module to consume.

This reduces the work needed when building interface and fix a bug that the file system walk when caching is enabled can cause build failures on windows platform.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
