### PR TITLE
[Utils] Update module path to relative path for caching build

### DIFF
--- a/utils/swift-build-modules.py
+++ b/utils/swift-build-modules.py
@@ -49,20 +49,26 @@ def main():
             if 'clang' in name:
                 build_module(args.swift_frontend, 'clang', detail)
                 module["moduleName"] = name['clang']
-                module["clangModulePath"] = detail["modulePath"]
                 if "moduleCacheKey" in detail["details"]['clang']:
                     module["clangModuleCacheKey"] = detail["details"]['clang']["moduleCacheKey"]
+                    module["clangModulePath"] = os.path.basename(detail["modulePath"])
+                else:
+                    module["clangModulePath"] = detail["modulePath"]
             if 'swift' in name:
                 build_module(args.swift_frontend, 'swift', detail)
                 module["moduleName"] = name['swift']
-                module["modulePath"] = detail["modulePath"]
                 if "moduleCacheKey" in detail["details"]['swift']:
                     module["moduleCacheKey"] = detail["details"]['swift']["moduleCacheKey"]
+                    module["modulePath"] = os.path.basename(detail["modulePath"])
+                else:
+                    module["modulePath"] = detail["modulePath"]
             if 'swiftPrebuiltExternal' in name:
                 module["moduleName"] = name['swiftPrebuiltExternal']
-                module["modulePath"] = detail["modulePath"]
                 if "moduleCacheKey" in detail["details"]['swiftPrebuiltExternal']:
                     module["moduleCacheKey"] = detail["details"]['swiftPrebuiltExternal']["moduleCacheKey"]
+                    module["modulePath"] = os.path.basename(detail["modulePath"])
+                else:
+                    module["modulePath"] = detail["modulePath"]
             modules.append(module)
 
         # Write output response file if requested.


### PR DESCRIPTION
To match the behavior of swift-driver and not introducing path dependencies in swift test utilities.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
