### PR TITLE
Sema: Start working on incremental binding set and disjunction selection

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -1024,6 +1024,9 @@ namespace swift {
     /// Enable the experimental "prepared overloads" optimization.
     bool SolverEnablePreparedOverloads = true;
 
+    /// Enable generation of transitive conformance constraints.
+    bool SolverEnableTransitiveConformance = true;
+
     /// Enable experimental optimization to skip contradictory disjunction
     /// choices.
     bool SolverPruneDisjunctions = true;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -444,6 +444,12 @@ def solver_enable_crash_on_valid_salvage : Flag<["-"], "solver-enable-crash-on-v
 def solver_disable_crash_on_valid_salvage : Flag<["-"], "solver-disable-crash-on-valid-salvage">,
   HelpText<"Accept valid solutions in diagnostic mode">;
 
+def solver_enable_transitive_conformance : Flag<["-"], "solver-enable-transitive-conformance">,
+  HelpText<"Enable transitive conformance constraint optimization">;
+
+def solver_disable_transitive_conformance : Flag<["-"], "solver-disable-transitive-conformance">,
+  HelpText<"Disable transitive conformance constraint optimization">;
+
 def disable_named_lazy_import_as_member_loading :
   Flag<["-"], "disable-named-lazy-import-as-member-loading">,
   HelpText<"Import all of a type's import-as-member globals together, as Swift "

--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -242,6 +242,9 @@ struct PotentialBindings {
   /// The constraint system this type variable and its bindings belong to.
   ConstraintSystem &CS;
 
+  /// This must be incremented whenever any of the below state changes.
+  unsigned GenerationNumber = 0;
+
   /// The type variable this bindings are associated with. Note that his
   /// property could change when associated with a constraint graph node
   /// that is being re-used. Calling \c reset sets it to `nullptr`.

--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -635,7 +635,11 @@ public:
 
   static BindingScore formBindingScore(const BindingSet &b);
 
-  bool operator==(const BindingSet &other);
+  bool operator==(const BindingSet &other) const;
+
+  bool operator!=(const BindingSet &other) const {
+    return !(*this == other);
+  }
 
   /// Compare two sets of bindings, where \c this < other indicates that
   /// \c this is a better set of bindings that \c other.

--- a/include/swift/Sema/CSDisjunction.h
+++ b/include/swift/Sema/CSDisjunction.h
@@ -1,0 +1,48 @@
+//===--- SolverDisjunction.h - Book-keeping about disjunctions --*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines a data type that stores information about the choices of
+// an active unsolved disjunction.
+//
+//===----------------------------------------------------------------------===//
+#ifndef SWIFT_SEMA_CS_DISJUNCTION_H
+#define SWIFT_SEMA_CS_DISJUNCTION_H
+
+namespace swift {
+
+class FunctionType;
+
+namespace constraints {
+
+class Constraint;
+
+class SolverDisjunction {
+  Constraint *disjunction;
+  FunctionType *argFuncType = nullptr;
+
+public:
+  SolverDisjunction(Constraint *disjunction)
+    : disjunction(disjunction) {}
+
+  void pruneDisjunctionIfNeeded(ConstraintSystem &cs, Constraint *applicableFn);
+  void pruneDisjunction(ConstraintSystem &cs, Constraint *applicableFn,
+                        bool verify);
+  void undoArgFuncTypeChange(FunctionType *oldFuncType) {
+  	argFuncType = oldFuncType;
+  }
+};
+
+}  // end namespace
+
+}  // end namespace
+
+#endif  // SWIFT_SEMA_CS_DISJUNCTION_H

--- a/include/swift/Sema/CSTrail.def
+++ b/include/swift/Sema/CSTrail.def
@@ -145,8 +145,9 @@ CHANGE(RecordedKeyPath)
 CHANGE(RetiredConstraint)
 CHANGE(AddedBinding)
 CHANGE(RetractedBinding)
+CHANGE(PrunedDisjunction)
 
-LAST_CHANGE(RetractedBinding)
+LAST_CHANGE(PrunedDisjunction)
 
 #undef LOCATOR_CHANGE
 #undef EXPR_CHANGE

--- a/include/swift/Sema/CSTrail.h
+++ b/include/swift/Sema/CSTrail.h
@@ -150,6 +150,11 @@ public:
         TypeVariableType *Originator;
       } Binding;
 
+      struct {
+        Constraint *Disjunction;
+        FunctionType *ArgFuncType;
+      } Disjunction;
+
       ConstraintFix *TheFix;
       ConstraintLocator *TheLocator;
       PackExpansionType *TheExpansion;
@@ -265,6 +270,10 @@ public:
     /// bindings.
     static Change RetractedBinding(TypeVariableType *typeVar,
                                    inference::PotentialBinding binding);
+
+    /// Create a change that disjunction pruning was performed.
+    static Change PrunedDisjunction(Constraint *disjunction,
+                                    FunctionType *argFuncType);
 
     /// Undo this change, reverting the constraint graph to the state it
     /// had prior to this change.

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1767,9 +1767,6 @@ public:
   /// Note: this is only used to support ObjCSelectorExpr at the moment.
   llvm::SmallPtrSet<Expr *, 2> UnevaluatedRootExprs;
 
-  /// The total number of disjunctions created.
-  unsigned CountDisjunctions = 0;
-
 private:
   bool PreparingOverload = false;
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -71,6 +71,9 @@ struct PreparedOverloadBuilder;
 // Subtyping.h
 enum class ConversionBehavior : unsigned;
 
+// CSDisjunction.h
+class SolverDisjunction;
+
 } // end namespace constraints
 
 // Forward declare some TypeChecker related functions
@@ -1962,6 +1965,10 @@ private:
 
   /// The constraint graph.
   ConstraintGraph CG;
+
+  /// Information about the remaining disjunctions we have yet to attempt
+  /// in this path.
+  llvm::DenseMap<Constraint *, SolverDisjunction> RemainingDisjunctions;
 
   /// A mapping from constraint locators to the set of opened types associated
   /// with that locator.
@@ -4790,6 +4797,8 @@ public:
     TypeVariableType *tyvar,
     unsigned *numOptionalUnwraps = nullptr);
 
+  SolverDisjunction &getRemainingDisjunction(Constraint *disjunction);
+
 private:
   /// Solve the system of constraints after it has already been
   /// simplified.
@@ -4804,9 +4813,6 @@ private:
   /// \returns The selected disjunction and a set of it's favored choices.
   std::optional<std::pair<Constraint *, llvm::TinyPtrVector<Constraint *>>>
   selectDisjunction();
-
-  void pruneDisjunction(Constraint *disjunction,
-                        Constraint *applicableFn);
 
   /// Pick a conjunction from the InactiveConstraints list.
   ///

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2134,6 +2134,11 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
                    OPT_solver_disable_crash_on_valid_salvage,
                    Opts.CrashOnValidSalvage);
 
+  Opts.SolverEnableTransitiveConformance =
+      Args.hasFlag(OPT_solver_enable_transitive_conformance,
+                   OPT_solver_disable_transitive_conformance,
+                   Opts.SolverEnableTransitiveConformance);
+
   Opts.SolverEnablePreparedOverloads =
       Args.hasFlag(OPT_solver_enable_prepared_overloads,
                    OPT_solver_disable_prepared_overloads,

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -2066,6 +2066,8 @@ void PotentialBindings::infer(Constraint *constraint) {
   if (!Constraints.insert(constraint))
     return;
 
+  ++GenerationNumber;
+
   // Record the change, if there are active scopes.
   if (CS.solverState)
     CS.recordChange(
@@ -2261,6 +2263,8 @@ void PotentialBindings::retract(Constraint *constraint) {
   if (!Constraints.remove(constraint))
     return;
 
+  ++GenerationNumber;
+
   // Record the change, if there are active scopes.
   if (CS.solverState)
     CS.recordChange(SolverTrail::Change::RetractedConstraintFromInference(
@@ -2357,6 +2361,8 @@ void PotentialBindings::dump(llvm::raw_ostream &out, unsigned indent) const {
   } else {
     out << "<<No type variable assigned>>\n";
   }
+
+  out << "generation: " << GenerationNumber << " ";
 
   out << "[constraints: ";
   interleave(

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1111,7 +1111,7 @@ void PotentialBindings::inferFromLiteral(Constraint *constraint) {
   Literals.emplace_back(protocol, constraint, defaultType, /*isDirect=*/true);
 }
 
-bool BindingSet::operator==(const BindingSet &other) {
+bool BindingSet::operator==(const BindingSet &other) const {
   if (AdjacentVars != other.AdjacentVars)
     return false;
 

--- a/lib/Sema/CSOptimizer.cpp
+++ b/lib/Sema/CSOptimizer.cpp
@@ -26,6 +26,7 @@
 #include "swift/Basic/OptionSet.h"
 #include "swift/Sema/ConstraintGraph.h"
 #include "swift/Sema/ConstraintSystem.h"
+#include "swift/Sema/CSDisjunction.h"
 #include "swift/Sema/TypeVariableType.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/DenseMap.h"
@@ -1920,7 +1921,9 @@ ConstraintSystem::selectDisjunction() {
         applicableFn.get()->getFirstType()->getAs<FunctionType>();
     }
 
-    pruneDisjunction(disjunction, applicableFn.getPtrOrNull());
+    getRemainingDisjunction(disjunction)
+      .pruneDisjunctionIfNeeded(*this, applicableFn.getPtrOrNull());
+
     auto info = computeDisjunctionInfo(*this, disjunctions, index, favorings);
     favorings.try_emplace(disjunction, info);
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -36,6 +36,7 @@
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/Statistic.h"
+#include "swift/Sema/CSDisjunction.h"
 #include "swift/Sema/CSFix.h"
 #include "swift/Sema/ConstraintGraph.h"
 #include "swift/Sema/IDETypeChecking.h"

--- a/test/Serialization/transitive_conformances_and_cgfloat_double.swift
+++ b/test/Serialization/transitive_conformances_and_cgfloat_double.swift
@@ -1,5 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module %s -o %t -solver-disable-crash-on-valid-salvage
-// RUN: not --crash %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module %s -o %t -solver-enable-crash-on-valid-salvage
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module %s -o %t -solver-enable-crash-on-valid-salvage -solver-disable-transitive-conformance
 
 // REQUIRES: objc_interop
 


### PR DESCRIPTION
Both `determineBestBindings()` and `selectDisjunction()` iterate over all type variables and disjunctions, respectively, and perform a bunch of computation to rank them, and pick the best one. All of this computation is then thrown out and repeated next time.

This change chips away at some of the unnecessary work. Disjunction pruning is now only attempted if the simplified type of the applicable function constraint changed. Binding sets are only recomputed if the potential bindings changed, or if transitive inference changed the binding set.

In both cases, the algorithms still result in quadratic behavior because we must still iterate over all binding sets and disjunctions. For binding sets, we perform transitive inference, and for disjunctions, we perform the CSOptimizer's disjunction ranking. Both of these need additional work to become incremental, but once that's done, we can store type variables and disjunctions in a priority queue, and then `determineBestBindings()` and `selectDisjunction()` will become O(log n) operations instead of O(n) as today.