### PR TITLE
FreeBSD: Disable lldb testing

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1409,7 +1409,8 @@ test-optimized
 validation-test
 test-installable-package
 
-lldb-test-swift-only
+# TODO: Re-enable LLDB tests rdar://170335687
+skip-test-lldb
 skip-test-swiftdocc
 
 [preset: freebsd_package,no_test]


### PR DESCRIPTION
LLDB has known test failures. Disabling the LLDB testing to see what else fails.