### PR TITLE
[ClangImporter] ImportMacroAliases: Mark imported alias declarations …

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -50,6 +50,7 @@
 #include "swift/AST/ResilienceExpansion.h"
 #include "swift/AST/SourceFile.h"
 #include "swift/AST/Stmt.h"
+#include "swift/AST/StorageImpl.h"
 #include "swift/AST/SwiftNameTranslation.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/TypeLoc.h"

--- a/test/Concurrency/test_imported_macro_aliases.swift
+++ b/test/Concurrency/test_imported_macro_aliases.swift
@@ -1,0 +1,39 @@
+// RUN: %empty-directory(%t/src)
+// RUN: %empty-directory(%t/sdk)
+// RUN: split-file %s %t/src
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %t/src/main.swift \
+// RUN:   -import-objc-header %t/src/Test.h \
+// RUN:   -swift-version 6 \
+// RUN:   -enable-experimental-feature ImportMacroAliases \
+// RUN:   -module-name main -I %t -verify -verify-ignore-unrelated
+
+// REQUIRES: objc_interop
+// REQUIRES: concurrency
+// REQUIRES: swift_feature_ImportMacroAliases
+
+// Make sure that aliases imported into Swift as properties don't create concurrency issues.
+
+//--- Test.h
+#define F f
+
+void f();
+
+//--- main.swift
+func test() {
+  _ = F // Ok
+}
+
+func testAsync() async {
+  _ = F // Ok
+}
+
+actor A {
+  func test() {
+    _ = F // Ok
+  }
+
+  @MainActor static func testGlobalIsolated() {
+    _ = F // Ok
+  }
+}


### PR DESCRIPTION
…as preconcurrency and computed

Extract logic that synthesizes a `VarDecl` for an alias into `VarDecl::createImported` and set the new declaration as synthesized, imported and `@preconcurrency`.

Use `makeComputed` to set all the appropriate bits about storage.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
