### PR TITLE
Reparenting: adjust name lookup for associated types

### DIFF
--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -2316,10 +2316,16 @@ computeOverriddenAssociatedTypes(AssociatedTypeDecl *assocType) {
     // Objective-C protocols
     if (inheritedProto->isObjC()) return TypeWalker::Action::Continue;
 
-    // Associated types defined within reparentable protocols Q
-    // are not overridden by one defined in any reparented ones P, i.e.,
-    // if P was reparented by Q, then P's associated type serves as the anchor.
-    // We skip processing any protocols further inherited by the reparentable.
+    // Associated types defined within reparentable protocol RP
+    // are not "overridden" by one defined in a downstream protocol, i.e.,
+    // if P inherits from RP, then P's associated type does not override RP's,
+    // causing P's associated type to serves as the anchor.
+    //
+    // We skip processing any protocols further inherited by RP as they should
+    // all be @reparentable as well.
+    //
+    // See a corresponding bit of code in `swift::removeOverriddenDecls`, where
+    // we deprioritize @reparentable associated types in name-lookup too.
     if (inheritedProto->getAttrs().hasAttribute<ReparentableAttr>())
       return TypeWalker::Action::SkipNode;
 

--- a/test/Availability/availability_reparenting_namelookup.swift
+++ b/test/Availability/availability_reparenting_namelookup.swift
@@ -1,0 +1,26 @@
+// RUN: %target-typecheck-verify-swift  -enable-experimental-feature Reparenting
+
+// REQUIRES: swift_feature_Reparenting
+
+
+@reparentable
+@available(macOS 75, *)
+public protocol BorrowSeq<Element> {
+  associatedtype Element
+}
+
+public protocol Seq<Element>: BorrowSeq {
+  associatedtype Element
+}
+
+@available(macOS 75, *)
+extension Seq: @reparented BorrowSeq {}
+
+public protocol Coll<Element>: Seq {
+  override associatedtype Element
+}
+
+public protocol LCP: Coll, Seq {}
+
+// This unqualified reference to Element should not resolve to BorrowSeq.Element
+extension LCP where Element: Sendable {}


### PR DESCRIPTION
We don't consider an associated type of a @reparentable protocol to be an overridden decl of any protocols inheriting from it. If we did, then it'd affect how getReducedType and other bits of comparison between associated types work, because they prefer anchors, i.e., associated types not overriding anything else (see `swift::compareAssociatedTypes`).

That worked fine until availability checking brought to light that name lookup also relies getOverriddenDecls() to determine which associated type decl one would be the one we refer to in a protocol. So in this case it's not the reduced type, but rather the actual `DeclRefTypeRepr` that name-lookup finds for `Element`, that actually _does_ need to view that one coming from the @reparentable one as being "overridden", or shadowed I guess, by any other protocols downstream of it.

rdar://170819864