### PR TITLE
Reparenting: avoid name clashes with injected typealiases

### DIFF
--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -323,7 +323,8 @@ static void recordTypeWitness(NormalProtocolConformance *conformance,
   if (typeDecl == nullptr && !conformance->isReparented()) {
     Identifier name;
     bool needsImplementsAttr;
-    if (isAsyncIteratorOrSequenceFailure(assocType)) {
+    if (isAsyncIteratorOrSequenceFailure(assocType) ||
+        proto->getAttrs().hasAttribute<ReparentableAttr>()) {
       // Use __<protocol>_<assocType> as the name, to keep it out of the
       // way of other names.
       llvm::SmallString<32> nameBuffer;

--- a/test/ModuleInterface/reparentable_conformance.swift
+++ b/test/ModuleInterface/reparentable_conformance.swift
@@ -1,0 +1,45 @@
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name conformances -enable-experimental-feature Reparenting
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name conformances -enable-experimental-feature Reparenting
+// RUN: %FileCheck %s < %t.swiftinterface
+
+public protocol Thingable {}
+
+public struct DefaultThingable: Thingable {}
+
+@available(macOS 75, *)
+@reparentable
+public protocol MiniBorrowSeq<Element> {
+  associatedtype Element
+
+  associatedtype BorrowIter: Thingable = DefaultThingable
+}
+
+// CHECK-LABEL: public struct Adapter<Base> : conformances.MiniBorrowSeq where Base : conformances.MiniBorrowSeq {
+@available(macOS 75, *)
+public struct Adapter<Base: MiniBorrowSeq>: MiniBorrowSeq {
+  // CHECK-NEXT: public typealias Element = Base.Element
+  public typealias Element = Base.Element
+  // CHECK-NEXT: @available(macOS 75, *)
+  // CHECK-NEXT: @_implements(conformances.MiniBorrowSeq, BorrowIter) public typealias __MiniBorrowSeq_BorrowIter = conformances.DefaultThingable
+}
+
+public struct Outer<Element, BorrowIter> where BorrowIter: Thingable {
+  // CHECK-LABEL: public struct Inner : conformances.MiniBorrowSeq {
+  public struct Inner: MiniBorrowSeq {
+  // CHECK-NEXT: @_implements(conformances.MiniBorrowSeq, BorrowIter) public typealias __MiniBorrowSeq_BorrowIter = BorrowIter
+  // CHECK-NEXT: @_implements(conformances.MiniBorrowSeq, Element) public typealias __MiniBorrowSeq_Element = Element
+  }
+}
+
+public struct UMBP<Element> {}
+
+// CHECK-LABEL: extension conformances.UMBP : conformances.MiniBorrowSeq {
+extension UMBP: MiniBorrowSeq {
+// CHECK-NEXT: @_implements(conformances.MiniBorrowSeq, BorrowIter) public typealias __MiniBorrowSeq_BorrowIter = conformances.DefaultThingable
+// CHECK-NEXT: @_implements(conformances.MiniBorrowSeq, Element) public typealias __MiniBorrowSeq_Element = Element
+
+  @available(macOS 75, *)
+  func whatever() {}
+}
+
+extension UMBP where Self.Element: Sendable {}

--- a/test/Sema/reparenting-nameclash.swift
+++ b/test/Sema/reparenting-nameclash.swift
@@ -1,0 +1,30 @@
+// RUN: %target-typecheck-verify-swift  -enable-experimental-feature Reparenting
+
+// REQUIRES: swift_feature_Reparenting
+
+public struct DefaultThing {}
+
+@reparentable
+@available(macOS 75, *)
+public protocol BorrowSeq {
+  associatedtype Thing = DefaultThing
+}
+
+public protocol Seq: BorrowSeq {}
+
+@available(macOS 75, *)
+extension Seq: @reparented BorrowSeq {}
+
+
+// Pre-existing code in a client, rebuilt agianst a new library
+// that did a reparenting:
+
+public struct Thing {}
+
+public struct Hello: Seq {
+  public func whatever() -> Thing { return Thing() }
+
+  // The above use to work, where Thing referred to the struct Thing above.
+  // But associated type witness inference injected `typealias Thing = DefaultThing`
+  // here, and that's bad!
+}


### PR DESCRIPTION
It seems fraught to be injecting typealiases for witnesses as public typealiases. Use the @_implements and `__` name trick used by AsyncSequence and friends in hopes of avoiding problems.