### PR TITLE
[Frontend][Driver] Update a last note to refer to `-language-mode` instead

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -152,8 +152,8 @@ ERROR(error_load_resolved_plugin,none,
       "invalid value '%0' in '-load-resolved-plugin'; "
       "make sure to use format '<library path>#<plugin path>#<module names>' where library and plugin path can't both be empty", (StringRef))
 
-NOTE(note_valid_swift_versions, none,
-     "valid arguments to '-swift-version' are %0", (StringRef))
+NOTE(note_valid_language_modes, none,
+     "valid arguments to '-language-mode' are %0", (StringRef))
 
 ERROR(error_module_interface_requires_language_mode,none,
       "emitting module interface files requires '-language-mode'", ())

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -520,7 +520,7 @@ static void diagnoseSwiftVersion(std::optional<version::Version> &vers,
         [&](LanguageMode mode) { os << "'" << mode.versionString() << "'"; });
   }
 
-  diags.diagnose(SourceLoc(), diag::note_valid_swift_versions, modesStr);
+  diags.diagnose(SourceLoc(), diag::note_valid_language_modes, modesStr);
 }
 
 /// Create a new Regex instance out of the string value in \p RpassArg.

--- a/test/Driver/swift-version-7-no-asserts.swift
+++ b/test/Driver/swift-version-7-no-asserts.swift
@@ -1,5 +1,5 @@
 // RUN: not %target-swiftc_driver -swift-version 7 -typecheck %s 2>&1 | %FileCheck --check-prefix ERROR_7 %s
 // REQUIRES: no_asserts
 
-// ERROR_7: <unknown>:0: error: invalid value '7' in '-swift-version 7'
-// ERROR_7: <unknown>:0: note: valid arguments to '-swift-version' are '4', '4.2', '5', '6'
+// ERROR_7: <unknown>:0: error: invalid value '7' in '-language-mode 7'
+// ERROR_7: <unknown>:0: note: valid arguments to '-language-mode' are '4', '4.2', '5', '6'

--- a/test/Driver/swift-version.swift
+++ b/test/Driver/swift-version.swift
@@ -15,7 +15,7 @@
 // RUN: not %target-swiftc_driver -language-mode 5 -typecheck %s 2>&1 | %FileCheck --check-prefix ERROR_5 %s
 
 // BAD: invalid value
-// BAD: note: valid arguments to '-swift-version' are '4', '4.2', '5', '6'
+// BAD: note: valid arguments to '-language-mode' are '4', '4.2', '5', '6'
 
 #if swift(>=3)
 asdf


### PR DESCRIPTION
Also, fix a no-asserts test that was missed, this is a follow-up to #87284.