### PR TITLE
[Sema] Diagnose shared mutating/optional fixes for #87218

### DIFF
--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -998,6 +998,10 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
+    return diagnose(*commonFixes.front().first);
+  }
+
   static ForceOptional *create(ConstraintSystem &cs, Type fromType, Type toType,
                                ConstraintLocator *locator);
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2612,51 +2612,35 @@ static bool diagnoseAmbiguity(
     }
   }
 
-  // If each ambiguous solution shares the same set of fixes, diagnose the
-  // individual fixes directly instead of producing a generic overload error.
+  // If there are multiple kinds of fixes associated with this overload set,
+  // prefer diagnosing fixes that are common to all viable solutions instead
+  // of immediately falling back to a generic ambiguity diagnostic.
   {
     llvm::MapVector<std::pair<FixKind, ConstraintLocator *>,
                     SmallVector<std::pair<const Solution *,
                                           const ConstraintFix *>, 4>>
-        fixesByKindAndLocator;
+        fixesByKind;
     for (const auto &entry : aggregateFix) {
-      fixesByKindAndLocator[{entry.second->getKind(), entry.second->getLocator()}]
-          .push_back(entry);
+      auto *fix = entry.second;
+      fixesByKind[{fix->getKind(), fix->getLocator()}].push_back(entry);
     }
 
-    bool diagnosedAllCommonFixes = false;
-    {
-      DiagnosticTransaction transaction(DE);
+    bool diagnosedCommonFix = false;
+    for (auto &entry : fixesByKind) {
+      auto &commonFixes = entry.second;
 
-      bool allDiagnosed = true;
-      size_t coveredFixes = 0;
+      llvm::SmallPtrSet<const Solution *, 4> affectedSolutions;
+      for (const auto &fix : commonFixes)
+        affectedSolutions.insert(fix.first);
 
-      for (const auto &entry : fixesByKindAndLocator) {
-        const auto &commonFixes = entry.second;
+      if (affectedSolutions.size() != solutions.size())
+        continue;
 
-        // Only diagnose groups that are present in every viable solution.
-        if (!llvm::all_of(solutions, [&](const Solution &solution) {
-              return llvm::any_of(commonFixes, [&](const auto &fix) {
-                return fix.first == &solution;
-              });
-            })) {
-          continue;
-        }
-
-        coveredFixes += commonFixes.size();
-        if (!commonFixes.front().second->diagnoseForAmbiguity(commonFixes)) {
-          allDiagnosed = false;
-          break;
-        }
-      }
-
-      diagnosedAllCommonFixes =
-          coveredFixes == aggregateFix.size() && allDiagnosed;
-      if (!diagnosedAllCommonFixes)
-        transaction.abort();
+      diagnosedCommonFix |=
+          commonFixes.front().second->diagnoseForAmbiguity(commonFixes);
     }
 
-    if (diagnosedAllCommonFixes)
+    if (diagnosedCommonFix)
       return true;
   }
 

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1519,6 +1519,15 @@ func testUnwrapFixIts(x: Int?) throws {
   let _: Int = try! .optionalThrowsMember ?? 0
 }
 
+// https://github.com/swiftlang/swift/issues/87218
+func issue87218() {
+  let dictionary = [String: [String]]()
+  let optionalValue: String? = nil
+  if let array = dictionary["foo"] {
+    array.append(optionalValue) // expected-error {{cannot use mutating member on immutable value: 'array' is a 'let' constant}} expected-error {{value of optional type 'String?' must be unwrapped to a value of type 'String'}} expected-note {{coalesce using '??' to provide a default when the optional value contains 'nil'}} expected-note {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+  }
+}
+
 // https://github.com/apple/swift/issues/63746
 func issue63746() {
   let fn1 = {


### PR DESCRIPTION
﻿## Summary
Fix ambiguity diagnostics to surface shared fix diagnostics instead of falling back to a generic overload failure.

In the failing pattern from #87218, viable solutions all carry two fixes:
- `allow mutating member on r-value base`
- `force optional`

Previously we still emitted:
- `no exact matches in call to instance method 'append'`

This change teaches ambiguity diagnosis to:
- group fixes by `(FixKind, locator)`
- require each group to be present in every viable solution
- diagnose each common group via `diagnoseForAmbiguity`
- return early when all common groups diagnose successfully

## Regression test
Added `issue87218()` to `test/Constraints/diagnostics.swift` asserting both diagnostics for:
- immutable base mutating call
- optional argument passed to non-optional parameter (with unwrap notes)

## Issue
Resolves https://github.com/swiftlang/swift/issues/87218

## Testing
- Expected validation path: Swift CI and targeted Constraints diagnostics tests.
