### PR TITLE
[gardening] Modernize BitDataflow debug printing to use print+dump pattern

### DIFF
--- a/include/swift/SIL/BitDataflow.h
+++ b/include/swift/SIL/BitDataflow.h
@@ -138,7 +138,9 @@ public:
   void solveBackwardWithUnion();
 
   /// Debug dump the BitDataflow state.
-  void dump() const;
+  SWIFT_DEBUG_DUMP { print(llvm::dbgs()); }
+
+  void print(llvm::raw_ostream &os) const;
 };
 
 } // end swift namespace

--- a/lib/SIL/Utils/BitDataflow.cpp
+++ b/lib/SIL/Utils/BitDataflow.cpp
@@ -142,12 +142,12 @@ void BitDataflow::solveBackwardWithUnion() {
   });
 }
 
-void BitDataflow::dump() const {
-    for (auto bd : blockStates) {
-    llvm::dbgs() << "bb" << bd.block.getDebugID() << ":\n"
-                 << "    entry: " << bd.data.entrySet << '\n'
-                 << "    gen:   " << bd.data.genSet << '\n'
-                 << "    kill:  " << bd.data.killSet << '\n'
-                 << "    exit:  " << bd.data.exitSet << '\n';
+void BitDataflow::print(llvm::raw_ostream &os) const {
+  for (const auto &bd : blockStates) {
+    os << "bb" << bd.block.getDebugID() << ":\n"
+       << "    entry: " << bd.data.entrySet << '\n'
+       << "    gen:   " << bd.data.genSet << '\n'
+       << "    kill:  " << bd.data.killSet << '\n'
+       << "    exit:  " << bd.data.exitSet << '\n';
   }
 }


### PR DESCRIPTION
NFC. Just peeling off small things from a alrger commit.

Replace the standalone dump() method with a print(llvm::raw_ostream &os) method that writes to an arbitrary output stream, and implement dump() via the SWIFT_DEBUG_DUMP macro delegating to print(llvm::dbgs()). Also fix a minor indentation issue in the original dump() body and switch the loop variable to a const reference.

This follows the standard Swift/SIL convention for debug-printable types, making BitDataflow consistent with the rest of the codebase and allowing its state to be printed to streams other than stderr.
