### PR TITLE
[PropertyWrappers] Better diagnostic for invalid enclosing-self subscript types

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7689,6 +7689,10 @@ GROUPED_ERROR(property_wrapper_type_requirement_not_accessible,PropertyWrappers,
 GROUPED_ERROR(property_wrapper_ambiguous_enclosing_self_subscript,PropertyWrappers,none,
       "property wrapper type %0 has multiple enclosing-self subscripts %1",
       (Type, DeclName))
+GROUPED_ERROR(property_wrapper_enclosing_self_subscript_keypath_type,PropertyWrappers,none,
+      "parameter '%0' of enclosing-self subscript has type %1; expected a "
+      "'ReferenceWritableKeyPath' type",
+      (Identifier, Type))
 GROUPED_ERROR(property_wrapper_dynamic_self_type,PropertyWrappers,none,
       "property wrapper %select{wrapped value|projected value}0 cannot have "
       "dynamic Self type", (bool))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7690,8 +7690,9 @@ GROUPED_ERROR(property_wrapper_ambiguous_enclosing_self_subscript,PropertyWrappe
       "property wrapper type %0 has multiple enclosing-self subscripts %1",
       (Type, DeclName))
 GROUPED_ERROR(property_wrapper_enclosing_self_subscript_keypath_type,PropertyWrappers,none,
-      "parameter '%0' of enclosing-self subscript has type %1; expected a "
-      "'ReferenceWritableKeyPath' type",
+      "parameter '%0' of enclosing-self subscript should have either "
+      "'WritableKeyPath<...>' or 'ReferenceWritableKeyPath<...>' type "
+      "(got %1)",
       (Identifier, Type))
 GROUPED_ERROR(property_wrapper_dynamic_self_type,PropertyWrappers,none,
       "property wrapper %select{wrapped value|projected value}0 cannot have "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7690,7 +7690,7 @@ GROUPED_ERROR(property_wrapper_ambiguous_enclosing_self_subscript,PropertyWrappe
       "property wrapper type %0 has multiple enclosing-self subscripts %1",
       (Type, DeclName))
 GROUPED_ERROR(property_wrapper_enclosing_self_subscript_keypath_type,PropertyWrappers,none,
-      "parameter '%0:' of enclosing-self subscript should have either "
+      "parameter %0 of enclosing-self subscript should have either "
       "'WritableKeyPath<...>' or 'ReferenceWritableKeyPath<...>' type "
       "(got %1)",
       (Identifier, Type))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7690,7 +7690,7 @@ GROUPED_ERROR(property_wrapper_ambiguous_enclosing_self_subscript,PropertyWrappe
       "property wrapper type %0 has multiple enclosing-self subscripts %1",
       (Type, DeclName))
 GROUPED_ERROR(property_wrapper_enclosing_self_subscript_keypath_type,PropertyWrappers,none,
-      "parameter '%0' of enclosing-self subscript should have either "
+      "parameter '%0:' of enclosing-self subscript should have either "
       "'WritableKeyPath<...>' or 'ReferenceWritableKeyPath<...>' type "
       "(got %1)",
       (Identifier, Type))

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -335,24 +335,23 @@ static bool validateEnclosingSelfSubscript(SubscriptDecl *subscript) {
   if (!indices || indices->size() != 3)
     return false;
 
-  bool isValid = true;
-  auto checkKeyPathParam = [&](unsigned index) {
+  auto checkKeyPathParam = [&](unsigned index) -> bool {
     auto *param = indices->get(index);
     auto paramTy = param->getInterfaceType();
-    if (paramTy->is<ErrorType>())
-      return;
+    if (paramTy->hasError())
+      return true;
 
     if (!paramTy->isWritableKeyPath() && !paramTy->isReferenceWritableKeyPath()) {
       param->diagnose(diag::property_wrapper_enclosing_self_subscript_keypath_type,
                       param->getArgumentName(), paramTy);
-      isValid = false;
+      return false;
     }
+    return true;
   };
 
-  checkKeyPathParam(/*wrapped/projected*/ 1);
-  checkKeyPathParam(/*storage*/ 2);
-
-  return isValid;
+  bool wrappedOrProjectedOK = checkKeyPathParam(/*wrapped/projected*/ 1);
+  bool storageOK = checkKeyPathParam(/*storage*/ 2);
+  return wrappedOrProjectedOK && storageOK;
 }
 
 PropertyWrapperTypeInfo

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -336,18 +336,21 @@ static bool validateEnclosingSelfSubscript(SubscriptDecl *subscript) {
     return false;
 
   bool isValid = true;
-  for (unsigned i : {1U, 2U}) {
-    auto *param = indices->get(i);
+  auto checkKeyPathParam = [&](unsigned index) {
+    auto *param = indices->get(index);
     auto paramTy = param->getInterfaceType();
     if (paramTy->is<ErrorType>())
-      continue;
+      return;
 
-    if (!paramTy->isReferenceWritableKeyPath()) {
+    if (!paramTy->isWritableKeyPath() && !paramTy->isReferenceWritableKeyPath()) {
       param->diagnose(diag::property_wrapper_enclosing_self_subscript_keypath_type,
                       param->getArgumentName(), paramTy);
       isValid = false;
     }
-  }
+  };
+
+  checkKeyPathParam(/*wrapped/projected*/ 1);
+  checkKeyPathParam(/*storage*/ 2);
 
   return isValid;
 }

--- a/test/decl/var/property_wrappers_invalid.swift
+++ b/test/decl/var/property_wrappers_invalid.swift
@@ -1,16 +1,4 @@
-// RUN: %target-swift-frontend -typecheck %s -verify -verify-ignore-unknown
-
-// FIXME: This should produce a diagnostic with a proper
-// source location. Right now, we just get these errors:
-
-// <unknown>:0: error: cannot infer key path type from context; consider explicitly specifying a root type
-// <unknown>:0: error: cannot infer key path type from context; consider explicitly specifying a root type
-// <unknown>:0: error: cannot infer key path type from context; consider explicitly specifying a root type
-// <unknown>:0: error: cannot infer key path type from context; consider explicitly specifying a root type
-// <unknown>:0: error: cannot infer key path type from context; consider explicitly specifying a root type
-// <unknown>:0: error: cannot infer key path type from context; consider explicitly specifying a root type
-
-// The actual problem is the type of the subscript declaration is wrong.
+// RUN: %target-swift-frontend -typecheck %s -verify
 
 public class Store {
     @Published public var state: Any
@@ -26,8 +14,8 @@ public class Store {
     set {}
   }
   public static subscript(_enclosingInstance object: Any,
-                          wrapped wrappedKeyPath: Any,
-                          storage storageKeyPath: Any)
+                          wrapped wrappedKeyPath: Any, // expected-error {{parameter 'wrapped' of enclosing-self subscript has type .*; expected a 'ReferenceWritableKeyPath' type}}
+                          storage storageKeyPath: Any) // expected-error {{parameter 'storage' of enclosing-self subscript has type .*; expected a 'ReferenceWritableKeyPath' type}}
       -> Value {
     get { fatalError() }
     set {}

--- a/test/decl/var/property_wrappers_invalid.swift
+++ b/test/decl/var/property_wrappers_invalid.swift
@@ -14,8 +14,8 @@ public class Store {
     set {}
   }
   public static subscript(_enclosingInstance object: Any,
-                          wrapped wrappedKeyPath: Any, // expected-error {{parameter 'wrapped' of enclosing-self subscript has type .*; expected a 'ReferenceWritableKeyPath' type}}
-                          storage storageKeyPath: Any) // expected-error {{parameter 'storage' of enclosing-self subscript has type .*; expected a 'ReferenceWritableKeyPath' type}}
+                          wrapped wrappedKeyPath: Any, // expected-error {{parameter 'wrapped' of enclosing-self subscript should have either 'WritableKeyPath<...>' or 'ReferenceWritableKeyPath<...>' type \(got .*\)}}
+                          storage storageKeyPath: Any) // expected-error {{parameter 'storage' of enclosing-self subscript should have either 'WritableKeyPath<...>' or 'ReferenceWritableKeyPath<...>' type \(got .*\)}}
       -> Value {
     get { fatalError() }
     set {}

--- a/test/decl/var/property_wrappers_invalid.swift
+++ b/test/decl/var/property_wrappers_invalid.swift
@@ -14,8 +14,8 @@ public class Store {
     set {}
   }
   public static subscript(_enclosingInstance object: Any,
-                          wrapped wrappedKeyPath: Any, // expected-error {{parameter '.*wrapped.*' of enclosing-self subscript should have either 'WritableKeyPath<...>' or 'ReferenceWritableKeyPath<...>' type (got .*)}}
-                          storage storageKeyPath: Any) // expected-error {{parameter '.*storage.*' of enclosing-self subscript should have either 'WritableKeyPath<...>' or 'ReferenceWritableKeyPath<...>' type (got .*)}}
+                          wrapped wrappedKeyPath: Any, // expected-error {{parameter ''wrapped':' of enclosing-self subscript should have either 'WritableKeyPath<...>' or 'ReferenceWritableKeyPath<...>' type (got 'Any')}}
+                          storage storageKeyPath: Any) // expected-error {{parameter ''storage':' of enclosing-self subscript should have either 'WritableKeyPath<...>' or 'ReferenceWritableKeyPath<...>' type (got 'Any')}}
       -> Value {
     get { fatalError() }
     set {}

--- a/test/decl/var/property_wrappers_invalid.swift
+++ b/test/decl/var/property_wrappers_invalid.swift
@@ -14,8 +14,8 @@ public class Store {
     set {}
   }
   public static subscript(_enclosingInstance object: Any,
-                          wrapped wrappedKeyPath: Any, // expected-error {{parameter 'wrapped:' of enclosing-self subscript should have either 'WritableKeyPath<...>' or 'ReferenceWritableKeyPath<...>' type \(got .*\)}}
-                          storage storageKeyPath: Any) // expected-error {{parameter 'storage:' of enclosing-self subscript should have either 'WritableKeyPath<...>' or 'ReferenceWritableKeyPath<...>' type \(got .*\)}}
+                          wrapped wrappedKeyPath: Any, // expected-error {{parameter 'wrapped:' of enclosing-self subscript should have either 'WritableKeyPath<...>' or 'ReferenceWritableKeyPath<...>' type (got .*)}}
+                          storage storageKeyPath: Any) // expected-error {{parameter 'storage:' of enclosing-self subscript should have either 'WritableKeyPath<...>' or 'ReferenceWritableKeyPath<...>' type (got .*)}}
       -> Value {
     get { fatalError() }
     set {}

--- a/test/decl/var/property_wrappers_invalid.swift
+++ b/test/decl/var/property_wrappers_invalid.swift
@@ -14,8 +14,8 @@ public class Store {
     set {}
   }
   public static subscript(_enclosingInstance object: Any,
-                          wrapped wrappedKeyPath: Any, // expected-error {{parameter ''wrapped':' of enclosing-self subscript should have either 'WritableKeyPath<...>' or 'ReferenceWritableKeyPath<...>' type (got 'Any')}}
-                          storage storageKeyPath: Any) // expected-error {{parameter ''storage':' of enclosing-self subscript should have either 'WritableKeyPath<...>' or 'ReferenceWritableKeyPath<...>' type (got 'Any')}}
+                          wrapped wrappedKeyPath: Any, // expected-error {{parameter 'wrapped' of enclosing-self subscript should have either 'WritableKeyPath<...>' or 'ReferenceWritableKeyPath<...>' type (got 'Any')}}
+                          storage storageKeyPath: Any) // expected-error {{parameter 'storage' of enclosing-self subscript should have either 'WritableKeyPath<...>' or 'ReferenceWritableKeyPath<...>' type (got 'Any')}}
       -> Value {
     get { fatalError() }
     set {}

--- a/test/decl/var/property_wrappers_invalid.swift
+++ b/test/decl/var/property_wrappers_invalid.swift
@@ -14,8 +14,8 @@ public class Store {
     set {}
   }
   public static subscript(_enclosingInstance object: Any,
-                          wrapped wrappedKeyPath: Any, // expected-error {{parameter 'wrapped' of enclosing-self subscript should have either 'WritableKeyPath<...>' or 'ReferenceWritableKeyPath<...>' type \(got .*\)}}
-                          storage storageKeyPath: Any) // expected-error {{parameter 'storage' of enclosing-self subscript should have either 'WritableKeyPath<...>' or 'ReferenceWritableKeyPath<...>' type \(got .*\)}}
+                          wrapped wrappedKeyPath: Any, // expected-error {{parameter 'wrapped:' of enclosing-self subscript should have either 'WritableKeyPath<...>' or 'ReferenceWritableKeyPath<...>' type \(got .*\)}}
+                          storage storageKeyPath: Any) // expected-error {{parameter 'storage:' of enclosing-self subscript should have either 'WritableKeyPath<...>' or 'ReferenceWritableKeyPath<...>' type \(got .*\)}}
       -> Value {
     get { fatalError() }
     set {}

--- a/test/decl/var/property_wrappers_invalid.swift
+++ b/test/decl/var/property_wrappers_invalid.swift
@@ -14,8 +14,8 @@ public class Store {
     set {}
   }
   public static subscript(_enclosingInstance object: Any,
-                          wrapped wrappedKeyPath: Any, // expected-error {{parameter 'wrapped:' of enclosing-self subscript should have either 'WritableKeyPath<...>' or 'ReferenceWritableKeyPath<...>' type (got .*)}}
-                          storage storageKeyPath: Any) // expected-error {{parameter 'storage:' of enclosing-self subscript should have either 'WritableKeyPath<...>' or 'ReferenceWritableKeyPath<...>' type (got .*)}}
+                          wrapped wrappedKeyPath: Any, // expected-error {{parameter '.*wrapped.*' of enclosing-self subscript should have either 'WritableKeyPath<...>' or 'ReferenceWritableKeyPath<...>' type (got .*)}}
+                          storage storageKeyPath: Any) // expected-error {{parameter '.*storage.*' of enclosing-self subscript should have either 'WritableKeyPath<...>' or 'ReferenceWritableKeyPath<...>' type (got .*)}}
       -> Value {
     get { fatalError() }
     set {}


### PR DESCRIPTION
## Summary
Improve diagnostics for invalid enclosing-self property wrapper subscripts.

When a wrapper declares an enclosing-self subscript but uses non-key-path parameter types (for `wrapped`/`projected` or `storage`), the compiler now emits a direct property-wrapper diagnostic on the offending parameter type.

This also avoids falling through to synthesized key path inference failures with poor/indirect diagnostics.

## Changes
- Added a new property-wrapper diagnostic:
  - `property_wrapper_enclosing_self_subscript_keypath_type`
- Validate enclosing-self subscript parameter types in `TypeCheckPropertyWrapper.cpp`.
- Ignore invalid enclosing-self subscripts for synthesis after diagnosing.
- Updated `test/decl/var/property_wrappers_invalid.swift` to verify direct diagnostics (no longer relies on `-verify-ignore-unknown`).

## Issue
Resolves https://github.com/swiftlang/swift/issues/54422

## Testing
- Added/updated regression coverage in `test/decl/var/property_wrappers_invalid.swift`.
- Swift CI requested on this PR.
