### PR TITLE
[SE-0489] tweak `valueNotFound` debug description

### DIFF
--- a/stdlib/public/core/Codable.swift
+++ b/stdlib/public/core/Codable.swift
@@ -3822,9 +3822,23 @@ extension DecodingError: CustomDebugStringConvertible {
   public var debugDescription: String {
     let (message, context) = switch self {
       case .typeMismatch(let expectedType, let context):
-        ("DecodingError.typeMismatch: expected value of type \(expectedType)", context)
+        ("DecodingError.typeMismatch: Expected value of type \(expectedType)", context)
       case .valueNotFound(let expectedType, let context):
-        ("DecodingError.valueNotFound: Expected value of type \(expectedType) but found null instead", context)
+        // Note: the value can be not-found for multiple reasons. Since we do
+        // not know the reason here, it is up to debug description that is 
+        // provided to the decoding context to provide more information.
+        // 
+        // The reasons that a value was not found may include:
+        // - Keyed decoding container: the value at the given key was null.
+        // - Unkeyed decoding container: we reached the end of the container
+        //   without finding the expected value.
+        //
+        // The doc comment for valueNotFound explicitly mentions that it
+        // is used when a null value is found where a non-optional value is
+        // expected. But in practice, for example in Foundation's JSONDecoder,
+        // it is also used in the unkeyed decoding container scenario mentioned
+        // above.
+        ("DecodingError.valueNotFound: Expected value of type \(expectedType)", context)
       case .keyNotFound(let expectedKey, let context):
         ("DecodingError.keyNotFound: Key '\(expectedKey._errorPresentationDescription())' not found in keyed decoding container", context)
       case .dataCorrupted(let context):

--- a/test/stdlib/CodableTests.swift
+++ b/test/stdlib/CodableTests.swift
@@ -1113,7 +1113,7 @@ class TestCodable : TestCodableSuper {
     func test_decodingError_typeMismatch_nilUnderlyingError() {
         expectErrorDescription(
             #"""
-            DecodingError.typeMismatch: expected value of type String. Path: [0].address.city.birds[1].name. Debug description: This is where the debug description goes
+            DecodingError.typeMismatch: Expected value of type String. Path: [0].address.city.birds[1].name. Debug description: This is where the debug description goes
             """#,
             fromDecodingError: DecodingError.typeMismatch(
                 String.self,
@@ -1128,7 +1128,7 @@ class TestCodable : TestCodableSuper {
     func test_decodingError_typeMismatch_nonNilUnderlyingError() {
         expectErrorDescription(
             #"""
-            DecodingError.typeMismatch: expected value of type String. Path: [0].address[1].street. Debug description: Some debug description. Underlying error: GenericError(name: "some generic error goes here")
+            DecodingError.typeMismatch: Expected value of type String. Path: [0].address[1].street. Debug description: Some debug description. Underlying error: GenericError(name: "some generic error goes here")
             """#,
             fromDecodingError: DecodingError.typeMismatch(
                 String.self,
@@ -1144,7 +1144,7 @@ class TestCodable : TestCodableSuper {
     func test_decodingError_valueNotFound_nilUnderlyingError() {
         expectErrorDescription(
             #"""
-            DecodingError.valueNotFound: Expected value of type String but found null instead. Path: [0].firstName. Debug description: Description for debugging purposes
+            DecodingError.valueNotFound: Expected value of type String. Path: [0].firstName. Debug description: Description for debugging purposes
             """#,
             fromDecodingError: DecodingError.valueNotFound(
                 String.self,
@@ -1159,7 +1159,7 @@ class TestCodable : TestCodableSuper {
     func test_decodingError_valueNotFound_nonNilUnderlyingError() {
         expectErrorDescription(
             #"""
-            DecodingError.valueNotFound: Expected value of type Int but found null instead. Path: [0].population. Debug description: Here is the debug description for value-not-found. Underlying error: GenericError(name: "these aren\'t the droids you\'re looking for")
+            DecodingError.valueNotFound: Expected value of type Int. Path: [0].population. Debug description: Here is the debug description for value-not-found. Underlying error: GenericError(name: "these aren\'t the droids you\'re looking for")
             """#,
             fromDecodingError: DecodingError.valueNotFound(
                 Int.self,


### PR DESCRIPTION
- **Explanation**:
  See: [forum thread](https://forums.swift.org/t/se-0489-followup-decodingerror-valuenotfound-mentions-null-which-is-not-always-right/84844).
  
  The documentation for `valueNotFound` says it's used for null values, so that's what I originally put in the debug description. But in practice, for example in `Foundation.JSONDecoder`, it's also used when you hit the end of an `UnkeyedDecodingContainer` without finding the expected value.
  
  I'm planning a PR to Foundation to provide better debug descriptions to the errors (which is where I ran into this discrepancy). For now, it would be nice to refine the error message here in the stdlib.

- **Scope**:
  This is a change to code from SE-0489 that was [merged into main](https://github.com/swiftlang/swift/pull/80941) and also [merged into release/6.3](https://github.com/swiftlang/swift/pull/85768), which shipped with Xcode 26.4.
  
  The change itself is to the specific wording of a `debugDescription`, which carries no guarantees about its format.

- **Issues**:
  N/A

- **Original PRs**:
  N/A (but I could make a PR to main if that's preferable?)

- **Risk**:
  The risk is low, since this is a change to a debug string that recently changed anyway, and should never have been relied on even if it had. The change is also making the string shorter and more correct, so there shouldn't be any issues with the formatting of the message. (For example, an earlier version of SE-0489 had line breaks in the new `debugDescription`s, but those were removed due to concerns about how that would affect error logging systems.)

- **Testing**:
  Updated stdlib tests to match. I'll also try to get the stdlib tests building and running locally, but I'm kicking off a CI build because it may finish first due to disk space, build speed, and inclement weather here in Boston 😅

- **Reviewers**:
  @kperryua, @stephentyrone, @lorentey