### PR TITLE
[cxx-interop] Load function template members alongside storage

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -10707,7 +10707,11 @@ void ClangRecordMemberLoader::load(const clang::RecordDecl *clangRecord,
 
     // Skip this member if caller asked for storage and this isn't a field,
     // or vice versa.
-    if (storage != isa<clang::FieldDecl>(m))
+    //
+    // FIXME: also load eagerly function templates for now, even though they are
+    //        technically not storage members, because otherwise those templated
+    //        members can't be looked up from the SwiftLookupTable.
+    if (storage != isa<clang::FieldDecl, clang::FunctionTemplateDecl>(m))
       continue;
 
     // Make sure we always pull in record fields. Everything else had better

--- a/test/Interop/Cxx/templates/Inputs/member-templates.h
+++ b/test/Interop/Cxx/templates/Inputs/member-templates.h
@@ -28,6 +28,8 @@ template <class T> struct TemplateClassWithMemberTemplates {
 
   template <class U> void setValue(U val) { value = val; }
 
+  template <class U> U getValue() const { return value; }
+
   template<class U> TemplateClassWithMemberTemplates<U> toOtherSpec(const U& u) const {
     return {u};
   }
@@ -36,6 +38,13 @@ template <class T> struct TemplateClassWithMemberTemplates {
 };
 
 using IntWrapper = TemplateClassWithMemberTemplates<int>;
+
+struct IntHolder {
+  int value;
+  IntHolder(int val) : value(val) {}
+  template <class U> U getValue() const { return value; }
+  template <class U> const U &getValueRef() const { return value; }
+};
 
 struct HasStaticMemberTemplates {
   template <class T> static T add(T a, T b) { return a + b; }

--- a/test/Interop/Cxx/templates/member-templates.swift
+++ b/test/Interop/Cxx/templates/member-templates.swift
@@ -9,8 +9,40 @@ var TemplatesTestSuite = TestSuite("Member Templates")
 
 TemplatesTestSuite.test("Set value - IntWrapper") {
   var w = IntWrapper(11)
+
+  expectEqual(w.value, 11)
+
+  let v1: CInt = w.getValue()
+  expectEqual(v1, 11)
+
   w.setValue(42)
   expectEqual(w.value, 42)
+}
+
+TemplatesTestSuite.test("IntHolder") {
+  var h = IntHolder(11)
+
+  let v1: CInt = h.getValue()
+  expectEqual(v1, 11)
+
+  let rv1: CInt = h.getValueRef().pointee
+  expectEqual(rv1, 11)
+
+  let r1: UnsafePointer<CInt> = h.getValueRef()
+  expectEqual(r1.pointee, 11)
+
+  h.value = 22
+
+  let v2: CInt = h.getValue()
+  expectEqual(v2, 22)
+
+  let rv2: CInt = h.getValueRef().pointee
+  expectEqual(rv2, 22)
+
+  let r2: UnsafePointer<CInt> = h.getValueRef()
+  expectEqual(r2.pointee, 22)
+
+  expectEqual(r1.pointee, 22)
 }
 
 TemplatesTestSuite.test("Templated Add") {


### PR DESCRIPTION
Due to still-to-be investigated shortcomings of lazy name lookup, the Swift compiler is is unable to look up templated member functions. This previously worked because we were loading all members eagerly, including such templated member functions, but once we started only loading storage members in 3b4a298da50042b70ca4d7d396383c9de100a525, this broke.

For now, load FunctionTemplateDecl members eagerly to restore that old behavior.

The updated test fails without this change, and passes after it. More thorough testing should be done for satisfactory coverage, but there seem to be other unrelated issues to work through like SILGen assertion failures due to incorrect nullability handling, etc. In particular, we are only testing methods that return references for now, and not pointers, which do not get imported properly due to imperfect type round-tripping during template instantiation.

rdar://170576709