### PR TITLE
[gardening] Refactoring/cleanup pass on FlowIsolation

### DIFF
--- a/lib/SILOptimizer/Mandatory/DiagnosticHelpers.h
+++ b/lib/SILOptimizer/Mandatory/DiagnosticHelpers.h
@@ -1,0 +1,110 @@
+//===--- DiagnosticHelpers.h ----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SILOPTIMIZER_MANDATORY_DIAGNOSTICHELPERS_H
+#define SWIFT_SILOPTIMIZER_MANDATORY_DIAGNOSTICHELPERS_H
+
+#include "swift/AST/ASTContext.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILInstruction.h"
+
+namespace swift {
+namespace siloptimizer {
+
+template <typename... T, typename... U>
+static inline InFlightDiagnostic diagnoseError(ASTContext &context,
+                                               SourceLoc loc, Diag<T...> diag,
+                                               U &&...args) {
+  return std::move(context.Diags.diagnose(loc, diag, std::forward<U>(args)...)
+                       .warnUntilLanguageMode(LanguageMode::v6));
+}
+
+template <typename... T, typename... U>
+static inline InFlightDiagnostic diagnoseError(ASTContext &context,
+                                               SILLocation loc, Diag<T...> diag,
+                                               U &&...args) {
+  return siloptimizer::diagnoseError(context, loc.getSourceLoc(), diag,
+                                     std::forward<U>(args)...);
+}
+
+template <typename... T, typename... U>
+static inline InFlightDiagnostic diagnoseError(const Operand *op,
+                                               Diag<T...> diag, U &&...args) {
+  return siloptimizer::diagnoseError(
+      op->getUser()->getFunction()->getASTContext(),
+      op->getUser()->getLoc().getSourceLoc(), diag, std::forward<U>(args)...);
+}
+
+template <typename... T, typename... U>
+static InFlightDiagnostic diagnoseError(const SILInstruction *inst,
+                                        Diag<T...> diag, U &&...args) {
+  return siloptimizer::diagnoseError(inst->getFunction()->getASTContext(),
+                                     inst->getLoc().getSourceLoc(), diag,
+                                     std::forward<U>(args)...);
+}
+
+template <typename... T, typename... U>
+static InFlightDiagnostic diagnoseErrorAndHighlight(const SILInstruction *inst,
+                                                    Diag<T...> diag,
+                                                    U &&...args) {
+  return std::move(
+      siloptimizer::diagnoseError(inst->getFunction()->getASTContext(),
+                                  inst->getLoc().getSourceLoc(), diag,
+                                  std::forward<U>(args)...)
+          .highlight(inst->getLoc().getSourceRange()));
+}
+
+template <typename... T, typename... U>
+static inline InFlightDiagnostic
+diagnoseNote(ASTContext &context, SourceLoc loc, Diag<T...> diag, U &&...args) {
+  return context.Diags.diagnose(loc, diag, std::forward<U>(args)...);
+}
+
+template <typename... T, typename... U>
+static inline InFlightDiagnostic diagnoseNote(ASTContext &context,
+                                              SILLocation loc, Diag<T...> diag,
+                                              U &&...args) {
+  return siloptimizer::diagnoseNote(context, loc.getSourceLoc(), diag,
+                                    std::forward<U>(args)...);
+}
+
+template <typename... T, typename... U>
+static inline InFlightDiagnostic diagnoseNote(const Operand *op,
+                                              Diag<T...> diag, U &&...args) {
+  return siloptimizer::diagnoseNote(
+      op->getUser()->getFunction()->getASTContext(),
+      op->getUser()->getLoc().getSourceLoc(), diag, std::forward<U>(args)...);
+}
+
+template <typename... T, typename... U>
+static inline InFlightDiagnostic diagnoseNote(const SILInstruction *inst,
+                                              Diag<T...> diag, U &&...args) {
+  return siloptimizer::diagnoseNote(inst->getFunction()->getASTContext(),
+                                    inst->getLoc().getSourceLoc(), diag,
+                                    std::forward<U>(args)...);
+}
+
+template <typename... T, typename... U>
+static inline InFlightDiagnostic
+diagnoseNoteAndHighlight(const SILInstruction *inst, Diag<T...> diag,
+                         U &&...args) {
+  return std::move(
+      siloptimizer::diagnoseNote(inst->getFunction()->getASTContext(),
+                                 inst->getLoc().getSourceLoc(), diag,
+                                 std::forward<U>(args)...)
+          .highlight(inst->getLoc().getSourceRange()));
+}
+
+} // namespace siloptimizer
+} // namespace swift
+
+#endif

--- a/lib/SILOptimizer/Mandatory/FlowIsolation.cpp
+++ b/lib/SILOptimizer/Mandatory/FlowIsolation.cpp
@@ -209,7 +209,7 @@ public:
   void solve();
 
   // Verifies uses in this function, assuming solving has been performed.
-  void verifyIsolation();
+  void emitDiagnostics();
 
   /// Finds an appropriate instruction that can be blamed for introducing a
   /// source of `nonisolation` in a control-flow path leading the given
@@ -793,7 +793,7 @@ void FunctionInfo::solve() {
 }
 
 /// Enforces isolation rules, given the flow and block-local information.
-void FunctionInfo::verifyIsolation() {
+void FunctionInfo::emitDiagnostics() {
   // go through all the blocks.
   for (auto entry : *this) {
     auto &block = entry.block;
@@ -853,7 +853,7 @@ void FunctionInfo::verifyIsolation() {
     if (entry.second->hasNonisolatedStart())
       continue;
 
-    entry.second->verifyIsolation();
+    entry.second->emitDiagnostics();
   }
 }
 
@@ -875,7 +875,7 @@ void checkFlowIsolation(SILFunction *fn) {
   LLVM_DEBUG(info.print(llvm::dbgs()));
 
   // Step 3 -- With the information gathered, check for flow-isolation issues.
-  info.verifyIsolation();
+  info.emitDiagnostics();
 }
 
 /// The FlowIsolation pass performs flow-sensitive actor-isolation checking in

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -12,7 +12,7 @@
 
 #define DEBUG_TYPE "send-non-sendable"
 
-#include "swift/SIL/PrunedLiveness.h"
+#include "DiagnosticHelpers.h"
 
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/Concurrency.h"
@@ -32,6 +32,7 @@
 #include "swift/SIL/OperandDatastructures.h"
 #include "swift/SIL/OwnershipUtils.h"
 #include "swift/SIL/PatternMatch.h"
+#include "swift/SIL/PrunedLiveness.h"
 #include "swift/SIL/SILBasicBlock.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILFunction.h"
@@ -46,6 +47,7 @@
 #include "llvm/Support/Debug.h"
 
 using namespace swift;
+using namespace swift::siloptimizer;
 using namespace swift::PartitionPrimitives;
 using namespace swift::PatternMatch;
 using namespace swift::regionanalysisimpl;
@@ -364,78 +366,19 @@ findClosureUse(Operand *initialOperand) {
 //===----------------------------------------------------------------------===//
 
 template <typename... T, typename... U>
-static InFlightDiagnostic diagnoseError(ASTContext &context, SourceLoc loc,
-                                        Diag<T...> diag, U &&...args) {
-  return std::move(context.Diags.diagnose(loc, diag, std::forward<U>(args)...)
-                       .warnUntilLanguageMode(LanguageMode::v6));
-}
-
-template <typename... T, typename... U>
-static InFlightDiagnostic diagnoseError(ASTContext &context, SILLocation loc,
-                                        Diag<T...> diag, U &&...args) {
-  return ::diagnoseError(context, loc.getSourceLoc(), diag,
-                         std::forward<U>(args)...);
-}
-
-template <typename... T, typename... U>
 static InFlightDiagnostic diagnoseError(const PartitionOp &op, Diag<T...> diag,
                                         U &&...args) {
-  return ::diagnoseError(op.getSourceInst()->getFunction()->getASTContext(),
-                         op.getSourceLoc().getSourceLoc(), diag,
-                         std::forward<U>(args)...);
-}
-
-template <typename... T, typename... U>
-static InFlightDiagnostic diagnoseError(const Operand *op, Diag<T...> diag,
-                                        U &&...args) {
-  return ::diagnoseError(op->getUser()->getFunction()->getASTContext(),
-                         op->getUser()->getLoc().getSourceLoc(), diag,
-                         std::forward<U>(args)...);
-}
-
-template <typename... T, typename... U>
-static InFlightDiagnostic diagnoseError(const SILInstruction *inst,
-                                        Diag<T...> diag, U &&...args) {
-  return ::diagnoseError(inst->getFunction()->getASTContext(),
-                         inst->getLoc().getSourceLoc(), diag,
-                         std::forward<U>(args)...);
-}
-
-template <typename... T, typename... U>
-static InFlightDiagnostic diagnoseNote(ASTContext &context, SourceLoc loc,
-                                       Diag<T...> diag, U &&...args) {
-  return context.Diags.diagnose(loc, diag, std::forward<U>(args)...);
-}
-
-template <typename... T, typename... U>
-static InFlightDiagnostic diagnoseNote(ASTContext &context, SILLocation loc,
-                                       Diag<T...> diag, U &&...args) {
-  return ::diagnoseNote(context, loc.getSourceLoc(), diag,
-                        std::forward<U>(args)...);
+  return siloptimizer::diagnoseError(
+      op.getSourceInst()->getFunction()->getASTContext(),
+      op.getSourceLoc().getSourceLoc(), diag, std::forward<U>(args)...);
 }
 
 template <typename... T, typename... U>
 static InFlightDiagnostic diagnoseNote(const PartitionOp &op, Diag<T...> diag,
                                        U &&...args) {
-  return ::diagnoseNote(op.getSourceInst()->getFunction()->getASTContext(),
-                        op.getSourceLoc().getSourceLoc(), diag,
-                        std::forward<U>(args)...);
-}
-
-template <typename... T, typename... U>
-static InFlightDiagnostic diagnoseNote(const Operand *op, Diag<T...> diag,
-                                       U &&...args) {
-  return ::diagnoseNote(op->getUser()->getFunction()->getASTContext(),
-                        op->getUser()->getLoc().getSourceLoc(), diag,
-                        std::forward<U>(args)...);
-}
-
-template <typename... T, typename... U>
-static InFlightDiagnostic diagnoseNote(const SILInstruction *inst,
-                                       Diag<T...> diag, U &&...args) {
-  return ::diagnoseNote(inst->getFunction()->getASTContext(),
-                        inst->getLoc().getSourceLoc(), diag,
-                        std::forward<U>(args)...);
+  return siloptimizer::diagnoseNote(
+      op.getSourceInst()->getFunction()->getASTContext(),
+      op.getSourceLoc().getSourceLoc(), diag, std::forward<U>(args)...);
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
This PR is a pure refactoring/cleanup pass on FlowIsolation.cpp with no semantic changes. It improves naming clarity,   
 code organization, and diagnostic infrastructure.

I just built this up as I was working in flow isolation. I split this off of a larger commit. I am doing this so I can separate the actual functionality changing commits from improvements I am making as I am going.