### PR TITLE
[Sema] Improve diagnostics for duplicate global actor attributes

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6228,6 +6228,8 @@ ERROR(no_concurrency_module,none,
 ERROR(multiple_global_actors,none,
       "declaration can not have multiple global actor attributes (%0 and %1)",
       (Identifier, Identifier))
+NOTE(multiple_global_actors_note,none,
+      "%0 attribute previously declared here", (Identifier))
 ERROR(global_actor_disallowed,none,
       "%kindonly0 cannot have a global actor", (const Decl *))
 ERROR(global_actor_on_actor_class,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6229,7 +6229,7 @@ ERROR(multiple_global_actors,none,
       "declaration can not have multiple global actor attributes (%0 and %1)",
       (Identifier, Identifier))
 NOTE(multiple_global_actors_note,none,
-      "%0 attribute previously declared here", (Identifier))
+      "%kindonly0 attribute previously declared here", (const Decl *))
 ERROR(global_actor_disallowed,none,
       "%kindonly0 cannot have a global actor", (const Decl *))
 ERROR(global_actor_on_actor_class,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6229,7 +6229,7 @@ ERROR(multiple_global_actors,none,
       "declaration can not have multiple global actor attributes (%0 and %1)",
       (Identifier, Identifier))
 NOTE(multiple_global_actors_note,none,
-      "%kindonly0 attribute previously declared here", (const Decl *))
+      "%0 attribute previously declared here", (const Decl *))
 ERROR(global_actor_disallowed,none,
       "%kindonly0 cannot have a global actor", (const Decl *))
 ERROR(global_actor_on_actor_class,none,

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -340,6 +340,10 @@ swift::checkGlobalActorAttributes(SourceLoc loc, ArrayRef<CustomAttr *> attrs) {
       ctx.Diags.diagnose(
           loc, diag::multiple_global_actors, globalActorNominal->getName(),
           nominal->getName());
+
+      ctx.Diags.diagnose(attr->getLocation(), diag::multiple_global_actors_note,
+                         nominal->getName());
+
       continue;
     }
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -342,7 +342,7 @@ swift::checkGlobalActorAttributes(SourceLoc loc, ArrayRef<CustomAttr *> attrs) {
           nominal->getName());
 
       ctx.Diags.diagnose(attr->getLocation(), diag::multiple_global_actors_note,
-                         nominal->getName());
+                         nominal);
 
       continue;
     }

--- a/test/attr/global_actor.swift
+++ b/test/attr/global_actor.swift
@@ -88,12 +88,12 @@ class SomeClass {
 @GA1 actor ActorInTooManyPlaces { } // expected-error{{actor 'ActorInTooManyPlaces' cannot have a global actor}}
 
 @GA1 @OtherGlobalActor func twoGlobalActors() { } // expected-error{{declaration can not have multiple global actor attributes ('OtherGlobalActor' and 'GA1')}}
-// expected-note@-1{{struct attribute previously declared here}}
+// expected-note@-1{{'GA1' attribute previously declared here}}
 
 struct Container {
   // FIXME: Diagnostic could be improved to show the generic arguments.
 @GenericGlobalActor<Int> @GenericGlobalActor<String> func twoGenericGlobalActors() { } // expected-error{{declaration can not have multiple global actor attributes ('GenericGlobalActor' and 'GenericGlobalActor')}}
-// expected-note@-1{{generic struct attribute previously declared here}}
+// expected-note@-1{{'GenericGlobalActor' attribute previously declared here}}
 }
 
 // -----------------------------------------------------------------------

--- a/test/attr/global_actor.swift
+++ b/test/attr/global_actor.swift
@@ -88,12 +88,12 @@ class SomeClass {
 @GA1 actor ActorInTooManyPlaces { } // expected-error{{actor 'ActorInTooManyPlaces' cannot have a global actor}}
 
 @GA1 @OtherGlobalActor func twoGlobalActors() { } // expected-error{{declaration can not have multiple global actor attributes ('OtherGlobalActor' and 'GA1')}}
-// expected-note@-1{{'GA1' attribute previously declared here}}
+// expected-note@-1{{struct attribute previously declared here}}
 
 struct Container {
   // FIXME: Diagnostic could be improved to show the generic arguments.
 @GenericGlobalActor<Int> @GenericGlobalActor<String> func twoGenericGlobalActors() { } // expected-error{{declaration can not have multiple global actor attributes ('GenericGlobalActor' and 'GenericGlobalActor')}}
-// expected-note@-1{{'GenericGlobalActor' attribute previously declared here}}
+// expected-note@-1{{generic struct attribute previously declared here}}
 }
 
 // -----------------------------------------------------------------------

--- a/test/attr/global_actor.swift
+++ b/test/attr/global_actor.swift
@@ -88,10 +88,12 @@ class SomeClass {
 @GA1 actor ActorInTooManyPlaces { } // expected-error{{actor 'ActorInTooManyPlaces' cannot have a global actor}}
 
 @GA1 @OtherGlobalActor func twoGlobalActors() { } // expected-error{{declaration can not have multiple global actor attributes ('OtherGlobalActor' and 'GA1')}}
+// expected-note@-1{{'GA1' attribute previously declared here}}
 
 struct Container {
   // FIXME: Diagnostic could be improved to show the generic arguments.
 @GenericGlobalActor<Int> @GenericGlobalActor<String> func twoGenericGlobalActors() { } // expected-error{{declaration can not have multiple global actor attributes ('GenericGlobalActor' and 'GenericGlobalActor')}}
+// expected-note@-1{{'GenericGlobalActor' attribute previously declared here}}
 }
 
 // -----------------------------------------------------------------------


### PR DESCRIPTION
Add a note diagnostic that points to the source location of each conflicting global actor attribute when a declaration has more than one.

Resolves https://github.com/swiftlang/swift/issues/82702.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:


For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
