### PR TITLE
[SILOptimizer] Fix wrong Integer overflow diagnostic type

### DIFF
--- a/lib/SILOptimizer/Utils/ConstantFolding.cpp
+++ b/lib/SILOptimizer/Utils/ConstantFolding.cpp
@@ -864,6 +864,8 @@ constantFoldAndCheckIntegerConversions(BuiltinInst *BI,
       }
     } else if (auto *ILE = Loc.getAsASTNode<IntegerLiteralExpr>()) {
       UserDstTy = ILE->getType();
+    } else if (auto *E = Loc.getAsASTNode<Expr>()) {
+      UserDstTy = E->getType();
     }
 
     // Assume that we're converting from a literal if the source type is

--- a/lib/SILOptimizer/Utils/ConstantFolding.cpp
+++ b/lib/SILOptimizer/Utils/ConstantFolding.cpp
@@ -862,8 +862,6 @@ constantFoldAndCheckIntegerConversions(BuiltinInst *BI,
         UserSrcTy = unaryArg->getType();
         UserDstTy = CE->getType();
       }
-    } else if (auto *ILE = Loc.getAsASTNode<IntegerLiteralExpr>()) {
-      UserDstTy = ILE->getType();
     } else if (auto *E = Loc.getAsASTNode<Expr>()) {
       UserDstTy = E->getType();
     }

--- a/test/SILOptimizer/diagnostic_constant_propagation.swift
+++ b/test/SILOptimizer/diagnostic_constant_propagation.swift
@@ -328,6 +328,14 @@ func testAssumeNonNegative() {
   _ = _assumeNonNegative(input) // expected-error {{assumed non-negative value '-3' is negative}}
 }
 
+func testUnsignedSwitchOverflow(val: UInt) {
+  switch val { // expected-error {{negative integer '-24' overflows when stored into unsigned type 'UInt'}}
+    case 12: break
+    case -24: break
+    default: break
+  }
+}
+
 protocol Num { func Double() -> Self }
 
 extension Int8 : Num {


### PR DESCRIPTION
When an integer literal overflows its target type, the diagnostic could incorrectly display a Builtin type (e.g. 'Builtin.Int64') instead of the user-facing type (e.g. 'UInt').

Resolves https://github.com/swiftlang/swift/issues/83877

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
