### PR TITLE
embedded: specialize vtables of classes which are a target of cast operations

### DIFF
--- a/test/embedded/generic-classes.swift
+++ b/test/embedded/generic-classes.swift
@@ -92,6 +92,12 @@ func testBaseDerived3() -> Derived3<Int, Bool> {
   return Derived3()
 }
 
+// Check that IRGen doesn't crash
+public func castToClassWhichIsNeverCreated(_ o: AnyObject) -> Outer<Bool> {
+  return o as! Outer<Bool>
+}
+
+
 @main
 struct Main {
   static func main() {


### PR DESCRIPTION
Even if the specific class is never created, we need to specialize a vtable, because it's used in IRGen for generating the code for the cast operation.

Fixes a crash in IRGen
https://github.com/swiftlang/swift/issues/87248
rdar://170435034
