### PR TITLE
[Backtracing] `baseAddress` is `Optional`, so we need a `!` here.

### DIFF
--- a/stdlib/public/RuntimeModule/DefaultSymbolLocator.swift
+++ b/stdlib/public/RuntimeModule/DefaultSymbolLocator.swift
@@ -256,7 +256,7 @@ public class DefaultSymbolLocator: SymbolLocator {
 
         uuid = Array(theUUID[0..<16])
         age = theUUID[16..<20].withUnsafeBytes {
-          return $0.assumingMemoryBound(to: UInt32.self).baseAddress.pointee
+          return $0.assumingMemoryBound(to: UInt32.self).baseAddress!.pointee
         }
       }
     } else {


### PR DESCRIPTION
I don't understand how this passed PR testing (or built) previously, but it did both, then started failing.

rdar://170887396
