### PR TITLE
[cxx-interop] Do not bridge types behind top-level references

### DIFF
--- a/test/Interop/Cxx/foreign-reference/Inputs/refcounted-smartptrs.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/refcounted-smartptrs.h
@@ -124,6 +124,9 @@ inline RefOfBase bridgedFunction3() {
 inline PtrOfBase bridgedFunction4() {
   return PtrOfBase(RefCountedBase::forSmartPtr());
 }
+inline void notBridgedFunction(RefOfBase &ptr) {}
+inline void notBridgedFunction2(const RefOfBase &ptr) {}
+inline void notBridgedFunction3(RefOfBase &&ptr) {}
 
 namespace errors { // expected-note * {{'errors' declared here}}
 struct __attribute__((

--- a/test/Interop/Cxx/foreign-reference/refcounted-smartpointers-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/refcounted-smartpointers-interface.swift
@@ -4,3 +4,6 @@
 // CHECK: func bridgedFunction2(_ ptr: RefCountedBase?)
 // CHECK: func bridgedFunction3() -> RefCountedBase
 // CHECK: func bridgedFunction4() -> RefCountedBase?
+// CHECK: func notBridgedFunction(_ ptr: inout RefOfBase)
+// CHECK: func notBridgedFunction2(_ ptr: RefOfBase)
+// CHECK: func notBridgedFunction3(consuming ptr: consuming RefOfBase)

--- a/test/Interop/Cxx/foreign-reference/refcounted-smartpointers.swift
+++ b/test/Interop/Cxx/foreign-reference/refcounted-smartpointers.swift
@@ -31,6 +31,14 @@ func bridgedFunctionsWithOptionalInjection() {
     takesOptional(bridgedFunction3())
 }
 
+func notBridgedFunctions(_ r: RefCountedBase) {
+    print("noBridging")
+    var smartPtr = RefOfBase(r)
+    notBridgedFunction(&smartPtr)
+    notBridgedFunction2(RefOfBase(r))
+    notBridgedFunction3(consuming: RefOfBase(r))
+}
+
 conversions(RefCountedBase())
 // CHECK: created
 // CHECK: conversions
@@ -48,4 +56,8 @@ bridgedFunctions(RefCountedBase())
 bridgedFunctionsWithOptionalInjection()
 // CHECK: bridgingWithInjection
 // CHECK: created
+// CHECK: destroyed
+notBridgedFunctions(RefCountedBase())
+// CHECK: created
+// CHECK: noBridging
 // CHECK: destroyed


### PR DESCRIPTION
We already don't bridge types that are behind references in general. Top level references for parameters should behave the same as non-top-level references. This also should prevent hitting some unsupported scenarios.

rdar://169967726
