### PR TITLE
[di] Fix a typo in a DI diagnostic. Specifically initalizer -> initializer

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -245,7 +245,7 @@ ERROR(use_of_self_before_fully_init,none,
 NOTE(stored_property_not_initialized,none,
      "'%0' not initialized", (StringRef))
 NOTE(isolated_property_initializer,none,
-     "%1 default value of '%0' cannot be used in a %2 initalizer",
+     "%1 default value of '%0' cannot be used in a %2 initializer",
      (StringRef, ActorIsolation, ActorIsolation))
 
 ERROR(selfinit_multiple_times,none,

--- a/test/Concurrency/isolated_default_property_inits.swift
+++ b/test/Concurrency/isolated_default_property_inits.swift
@@ -24,11 +24,11 @@ func requiresMainActor() -> Int { 0 }
 func requiresSomeGlobalActor() -> Int { 0 }
 
 class C1 {
-  // expected-note@+2 {{main actor-isolated default value of 'self.x' cannot be used in a nonisolated initalizer}}
-  // expected-note@+1 {{main actor-isolated default value of 'self.x' cannot be used in a global actor 'SomeGlobalActor'-isolated initalizer}}
+  // expected-note@+2 {{main actor-isolated default value of 'self.x' cannot be used in a nonisolated initializer}}
+  // expected-note@+1 {{main actor-isolated default value of 'self.x' cannot be used in a global actor 'SomeGlobalActor'-isolated initializer}}
   @MainActor var x = requiresMainActor()
-  // expected-note@+2 {{global actor 'SomeGlobalActor'-isolated default value of 'self.y' cannot be used in a nonisolated initalizer}}
-  // expected-note@+1 {{global actor 'SomeGlobalActor'-isolated default value of 'self.y' cannot be used in a main actor-isolated initalizer}}
+  // expected-note@+2 {{global actor 'SomeGlobalActor'-isolated default value of 'self.y' cannot be used in a nonisolated initializer}}
+  // expected-note@+1 {{global actor 'SomeGlobalActor'-isolated default value of 'self.y' cannot be used in a main actor-isolated initializer}}
   @SomeGlobalActor var y = requiresSomeGlobalActor()
   var z = 10
 


### PR DESCRIPTION
Just noticed it while I was working on flow isolation.