### PR TITLE
SIL: Use getASTType() instead of getRawASTType() in getBoxTypeForEnumElement

### DIFF
--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -5412,7 +5412,7 @@ CanSILBoxType TypeConverter::getBoxTypeForEnumElement(
   }
 
   // Use the enum's signature for the box type.
-  auto boundEnum = enumType.getRawASTType();
+  auto boundEnum = enumType.getASTType();
 
   // Lower the enum element's argument in the box's context.
   auto eltIntfTy = elt->getPayloadInterfaceType();

--- a/test/SILOptimizer/moveonly_enum_crash.swift
+++ b/test/SILOptimizer/moveonly_enum_crash.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil -verify %s
+// https://github.com/swiftlang/swift/issues/87406
 
 public enum List<Element> {
       case empty

--- a/test/SILOptimizer/moveonly_enum_crash.swift
+++ b/test/SILOptimizer/moveonly_enum_crash.swift
@@ -21,28 +21,17 @@ func testListMethodAndProperty(_ x: consuming List<Int>) {
       _ = x.prop
 }
 
-public enum MoveOnlyList<Element>: ~Copyable {
-      case empty
-      indirect case list(Element, MoveOnlyList)
-
-      consuming func performAction() {}
-      
-      var prop: Int {
-          consuming get { return 0 }
-      }
-}
-
-func testMoveOnlyListMethod(_ tail: consuming MoveOnlyList<Int>) {
+func testListMethodMultipleConsume(_ tail: consuming List<Int>) {
       tail.performAction() // expected-note {{consumed here}}
       tail.performAction() // expected-error {{'tail' used after consume}}
 }
 
-func testMoveOnlyListProperty(_ tail: consuming MoveOnlyList<Int>) {
+func testListPropertyMultipleConsume(_ tail: consuming List<Int>) {
       let _ = tail.prop // expected-note {{consumed here}}
       let _ = tail.prop // expected-error {{'tail' used after consume}}
 }
 
-func testMoveOnlyListMultipleConsume(_ value: Int, _ tail: consuming MoveOnlyList<Int>) -> MoveOnlyList<Int> {
+func testListMultipleConsume(_ value: Int, _ tail: consuming List<Int>) -> List<Int> {
       let _ = tail.prop // expected-note {{consumed here}}
       return .list(value, tail) // expected-error {{'tail' used after consume}}
 }

--- a/test/SILOptimizer/moveonly_enum_crash.swift
+++ b/test/SILOptimizer/moveonly_enum_crash.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+
+public enum List<Element> {
+      case empty
+      indirect case list(Element, List)
+}
+
+func cons(_ value: Int, _ tail: consuming List<Int>) -> List<Int> {
+      return .list(value, tail)
+}

--- a/test/SILOptimizer/moveonly_enum_crash.swift
+++ b/test/SILOptimizer/moveonly_enum_crash.swift
@@ -4,8 +4,45 @@
 public enum List<Element> {
       case empty
       indirect case list(Element, List)
+      
+      consuming func performAction() {}
+      
+      var prop: Int {
+          consuming get { return 0 }
+      }
 }
 
 func cons(_ value: Int, _ tail: consuming List<Int>) -> List<Int> {
       return .list(value, tail)
+}
+
+func testListMethodAndProperty(_ x: consuming List<Int>) {
+      x.performAction()
+      _ = x.prop
+}
+
+public enum MoveOnlyList<Element>: ~Copyable {
+      case empty
+      indirect case list(Element, MoveOnlyList)
+
+      consuming func performAction() {}
+      
+      var prop: Int {
+          consuming get { return 0 }
+      }
+}
+
+func testMoveOnlyListMethod(_ tail: consuming MoveOnlyList<Int>) {
+      tail.performAction() // expected-note {{consumed here}}
+      tail.performAction() // expected-error {{'tail' used after consume}}
+}
+
+func testMoveOnlyListProperty(_ tail: consuming MoveOnlyList<Int>) {
+      let _ = tail.prop // expected-note {{consumed here}}
+      let _ = tail.prop // expected-error {{'tail' used after consume}}
+}
+
+func testMoveOnlyListMultipleConsume(_ value: Int, _ tail: consuming MoveOnlyList<Int>) -> MoveOnlyList<Int> {
+      let _ = tail.prop // expected-note {{consumed here}}
+      return .list(value, tail) // expected-error {{'tail' used after consume}}
 }


### PR DESCRIPTION
This PR changes getRawASTType() to getASTType() in getBoxTypeForEnumElement to fix a crash with move-only enums.

Fixes issue #87406.