### PR TITLE
DiagnoseUnreachable: ignore `ignored_user` instructions

### DIFF
--- a/lib/SILOptimizer/Mandatory/DiagnoseUnreachable.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseUnreachable.cpp
@@ -775,7 +775,8 @@ static bool simplifyBlocksWithCallsToNoReturn(SILBasicBlock &BB,
     // happens when passing a guaranteed argument through generic code paths
     // to no return functions.
     if (isa<EndBorrowInst>(currInst) || isa<EndAccessInst>(currInst) ||
-        isa<EndLifetimeInst>(currInst) || isa<ExtendLifetimeInst>(currInst)) {
+        isa<EndLifetimeInst>(currInst) || isa<ExtendLifetimeInst>(currInst) ||
+        isa<IgnoredUseInst>(currInst)) {
       return false;
     }
 

--- a/test/SILOptimizer/diagnose_unreachable.swift
+++ b/test/SILOptimizer/diagnose_unreachable.swift
@@ -585,3 +585,8 @@ class C2 {
     self.i = i
   }
 }
+
+func noWarningForWait(for task: Task<Never, any Error>) async throws -> Never {
+    try await task.value
+}
+


### PR DESCRIPTION
Fixes a wrong "will never be executed" warning

rdar://169271677
https://github.com/swiftlang/swift/issues/86891
