### PR TITLE
[cxx-interop] Fix miscompilation of some single field structs

### DIFF
--- a/lib/IRGen/ClassTypeInfo.h
+++ b/lib/IRGen/ClassTypeInfo.h
@@ -100,7 +100,7 @@ public:
   }
 
   void strongCustomRetain(IRGenFunction &IGF, Explosion &e,
-                          bool needsNullCheck) const {
+                          bool needsNullCheck) const override {
     assert(getReferenceCounting() == ReferenceCounting::Custom &&
            "only supported for custom ref-counting");
 
@@ -129,7 +129,7 @@ public:
   }
 
   void strongCustomRelease(IRGenFunction &IGF, Explosion &e,
-                           bool needsNullCheck) const {
+                           bool needsNullCheck) const override {
     assert(getReferenceCounting() == ReferenceCounting::Custom &&
            "only supported for custom ref-counting");
 

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -2671,8 +2671,8 @@ namespace {
         if (Refcounting == ReferenceCounting::Custom) {
           Explosion e;
           e.add(ptr);
-          getPayloadTypeInfo().as<ClassTypeInfo>().strongCustomRetain(
-              IGF, e, /*needsNullCheck*/ true);
+          getPayloadTypeInfo().strongCustomRetain(IGF, e,
+                                                  /*needsNullCheck*/ true);
           return;
         }
 
@@ -2708,8 +2708,8 @@ namespace {
         if (Refcounting == ReferenceCounting::Custom) {
           Explosion e;
           e.add(ptr);
-          getPayloadTypeInfo().as<ClassTypeInfo>().strongCustomRelease(
-              IGF, e, /*needsNullCheck*/ true);
+          getPayloadTypeInfo().strongCustomRelease(IGF, e,
+                                                   /*needsNullCheck*/ true);
           return;
         }
 

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -23,6 +23,7 @@
 #include "swift/AST/IRGenOptions.h"
 #include "swift/AST/Pattern.h"
 #include "swift/AST/ReferenceCounting.h"
+#include "swift/AST/ResilienceExpansion.h"
 #include "swift/AST/SemanticAttrs.h"
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/AST/Types.h"
@@ -277,6 +278,22 @@ namespace {
       if (fields.size() != 1)
         return false;
       return fields[0].getTypeInfo().isSingleRetainablePointer(expansion, rc);
+    }
+
+    void strongCustomRetain(IRGenFunction &IGF, Explosion &e,
+                            bool needsNullCheck) const override {
+      ReferenceCounting dummy;
+      ASSERT(isSingleRetainablePointer(ResilienceExpansion::Maximal, &dummy));
+      auto fields = asImpl().getFields();
+      fields[0].getTypeInfo().strongCustomRetain(IGF, e, needsNullCheck);
+    }
+
+    void strongCustomRelease(IRGenFunction &IGF, Explosion &e,
+                             bool needsNullCheck) const override {
+      ReferenceCounting dummy;
+      ASSERT(isSingleRetainablePointer(ResilienceExpansion::Maximal, &dummy));
+      auto fields = asImpl().getFields();
+      fields[0].getTypeInfo().strongCustomRelease(IGF, e, needsNullCheck);
     }
 
     void destroy(IRGenFunction &IGF, Address address, SILType T,

--- a/lib/IRGen/TypeInfo.h
+++ b/lib/IRGen/TypeInfo.h
@@ -438,6 +438,22 @@ public:
                                          ReferenceCounting *refcounting
                                              = nullptr) const;
 
+  /// This is virtual to support the optimizations which rely on the
+  /// representations of some structs being a single refcounted pointer.
+  virtual void strongCustomRetain(IRGenFunction &IGF, Explosion &e,
+                                  bool needsNullCheck) const {
+    llvm_unreachable(
+        "Only classes and some single field structs can implement this.");
+  }
+
+  /// This is virtual to support the optimizations which rely on the
+  /// representations of some structs being a single refcounted pointer.
+  virtual void strongCustomRelease(IRGenFunction &IGF, Explosion &e,
+                                   bool needsNullCheck) const {
+    llvm_unreachable(
+        "Only classes and some single field structs can implement this.");
+  }
+
   /// Should optimizations be enabled which rely on the representation
   /// for this type being a single Swift-retainable object pointer?
   ///

--- a/test/Interop/Cxx/foreign-reference/incomplete.swift
+++ b/test/Interop/Cxx/foreign-reference/incomplete.swift
@@ -42,8 +42,8 @@ func testOpaqueRef() {
 struct HasOpaqueRef { var mine: OpaqueRef }
 
 func testOpaqueRefInStruct() {
-  var cat : HasOpaqueRef? = nil;
-	cat = HasOpaqueRef(mine: Opaque_create())
+  var cat : HasOpaqueRef? = nil
+  cat = HasOpaqueRef(mine: Opaque_create())
   // CHECK: Destroyed OpaqueRef instance
   // CHECK-NOT: Destroyed OpaqueRef instance
 }

--- a/test/Interop/Cxx/foreign-reference/incomplete.swift
+++ b/test/Interop/Cxx/foreign-reference/incomplete.swift
@@ -37,11 +37,20 @@ func testOpaqueRef() {
   // let it go out of scope
 
   // CHECK: Destroyed OpaqueRef instance
+}
+
+struct HasOpaqueRef { var mine: OpaqueRef }
+
+func testOpaqueRefInStruct() {
+  var cat : HasOpaqueRef? = nil;
+	cat = HasOpaqueRef(mine: Opaque_create())
+  // CHECK: Destroyed OpaqueRef instance
   // CHECK-NOT: Destroyed OpaqueRef instance
 }
 
 testIncomplete()
 testOpaqueRef()
+testOpaqueRefInStruct()
 
 // CHECK: DONE
 print("DONE")


### PR DESCRIPTION
Swift has some optimizations in place to treat structs with a single refcounted field as if it was only the field. This logic was not correctly taken into account for foreign reference types when a struct like this was stored in a single element enum like an Optional.

This patch fixes this logic by updating the TypeInfo hierarchy to correctly emit strong retain/release calls during IRGen for structs with one fields.

rdar://170990579
