### PR TITLE
stdlib: Fix compiler warnings in Concurrency, Cxx, and RuntimeModule

### DIFF
--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -225,7 +225,7 @@ extension Task {
     // This is @available(SwiftStdlib 6.4, *) but can't use SwiftStdlib in transparent function
     if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999, *) {
       let ignoreTaskCancellationShield: UInt64 = 0x1
-      return unsafe _taskIsCancelledWithFlags(_task, flags: ignoreTaskCancellationShield)
+      return _taskIsCancelledWithFlags(_task, flags: ignoreTaskCancellationShield)
     } else {
       return _taskIsCancelled(_task)
     }

--- a/stdlib/public/Cxx/UnsafeCxxIterators.swift
+++ b/stdlib/public/Cxx/UnsafeCxxIterators.swift
@@ -85,7 +85,7 @@ extension Optional: @unsafe UnsafeCxxInputIterator where Wrapped: UnsafeCxxInput
     guard let value = self else {
       fatalError("Could not dereference nullptr")
     }
-    return unsafe value.__operatorStar()
+    return value.__operatorStar()
   }
 }
 

--- a/stdlib/public/RuntimeModule/ImageSource.swift
+++ b/stdlib/public/RuntimeModule/ImageSource.swift
@@ -183,7 +183,7 @@ struct ImageSource: CustomStringConvertible {
       self.init(mapped: UnsafeRawBufferPointer(
                   start: base, count: size))
       #else
-      var fd = _swift_open(path, O_RDONLY, 0)
+      let fd = _swift_open(path, O_RDONLY, 0)
       if fd < 0 {
         throw ImageSourceError.posixError(_swift_get_errno())
       }


### PR DESCRIPTION
- Remove spurious `unsafe` on non-unsafe calls in TaskCancellation.swift and UnsafeCxxIterators.swift
- Change `var fd` to `let fd` in ImageSource.swift since it is never mutated
