### PR TITLE
[test] Limit `index_system_modules_swiftinterfaces.swift` to macOS for now

### DIFF
--- a/test/Index/index_system_modules_swiftinterfaces.swift
+++ b/test/Index/index_system_modules_swiftinterfaces.swift
@@ -1,6 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
+// FIXME: Currently non-determinstically failing for non-macOS configs (rdar://170709684)
+// REQUIRES: OS=macosx
+
 /// Setup the SDK composed of SecretModule, SystemModule, SystemDepA, SystemDepB, and SystemDepCommon
 // RUN: %empty-directory(%t/SDK)
 // RUN: mkdir -p %t/SDK/Frameworks/SecretModule.framework/Modules/SecretModule.swiftmodule


### PR DESCRIPTION
Only run on macOS while we investigate the flaky failure on other platforms.