### PR TITLE
Fix an ARMASM build error

### DIFF
--- a/stdlib/public/RuntimeModule/get-cpu-context-aarch64.asm
+++ b/stdlib/public/RuntimeModule/get-cpu-context-aarch64.asm
@@ -18,7 +18,7 @@
         EXPORT _swift_get_cpu_context
 
 ;; On entry, x8 contains the pointer to the arm64_gprs
-_swift_get_cpu_context PROC PUBLIC
+_swift_get_cpu_context PROC
         stp  x0,  x1, [x8, #0x00]
         stp  x2,  x3, [x8, #0x10]
         stp  x4,  x5, [x8, #0x20]


### PR DESCRIPTION
PUBLIC is a MASM directive and causes a build error in a certain version of MSVC

```
Microsoft (R) ARM Macro Assembler Version 14.44.35217.0 for 64 bits
Copyright (C) Microsoft Corporation.  All rights reserved.

D:\r\_work\swift-build\swift-build\SourceCache\swift\stdlib\public\RuntimeModule\get-cpu-context-aarch64.asm(21) : error A2003: improper line syntax: PUBLIC
```
EXPORT is an ARMASM equivalent, which is already there.

