### PR TITLE
Embedded Swift Concurrency: define macros when using the macOS SDK...

### DIFF
--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -312,6 +312,15 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
         # Host is macOS with a macOS SDK. To be able to build the C++ Concurrency runtime for non-Darwin targets using the macOS SDK,
         # we need to pass some extra flags and search paths.
         set(extra_c_compile_flags -stdlib=libc++ -isystem${SWIFT_SDK_OSX_PATH}/usr/include/c++/v1 -isystem${SWIFT_SDK_OSX_PATH}/usr/include -D__APPLE__)
+        # Before Xcode 26.4, we were getting these macros from TargetConditionals.h
+        # now it's on us to define those to keep using the macOS SDK for non Darwin targets
+        if("${arch}" MATCHES "armv7")
+          list(APPEND extra_c_compile_flags -DTARGET_CPU_ARM=1)
+        elseif("${arch}" MATCHES "arm64")
+          list(APPEND extra_c_compile_flags -DTARGET_CPU_ARM64=1)
+        elseif("${arch}" MATCHES "x86_64")
+          list(APPEND extra_c_compile_flags -DTARGET_CPU_X86_64=1)
+        endif()
       endif()
     endif()
 


### PR DESCRIPTION
...to build non Darwin targets.

These are needed when using the macOS SDK that ships in Xcode 26.4 beta 1 and later.

Resolves #87327
Addresses rdar://170506176