### PR TITLE
Fix lifetime type checking for nonescaping closures

### DIFF
--- a/test/Sema/lifetime_dependence_functype.swift
+++ b/test/Sema/lifetime_dependence_functype.swift
@@ -50,7 +50,7 @@ func applyBorrow(nc: borrowing NC, borrow: (borrowing NC) -> NE) -> NE {
 }
 
 func testBorrow(nc: consuming NC) {
-  let borrowed = applyBorrow(nc: nc, borrow: borrow) // OK
+  let borrowed = applyBorrow(nc: nc, borrow: borrow) // expected-error{{argument type 'NE' does not conform to expected type 'Escapable'}}
   _ = consume nc
   _ = transfer(borrowed)
 }
@@ -220,22 +220,3 @@ public let TypeParameterResultFunctionType = copyCNE as (CNE<NE>) -> _          
                                                                                                               // expected-error@-1{{failed to produce diagnostic for expression}}
 public let TypeParameterResultFunctionTypeAnnotated = copyCNE as @_lifetime(borrow cne) (_ cne: CNE<NE>) -> _ // expected-error{{lifetime dependence checking failed due to unknown result type}}
                                                                                                               // expected-error@-1{{failed to produce diagnostic for expression}}
-
-// Closure Context Dependence Tests
-
-// This case should pass after we add support for dependencies on the closure context.
-// 
-// We had to move it out of
-// SILOptimizer/lifetime_dependence/verify_diagnostics.swift because it causes
-// an error during type checking with the current version of function type
-// lifetime checking, preventing the SIL diagnostic checks that file tests from
-// running.
-//
-// TODO: Add more diagnostic tests when implementing closure context
-// dependencies, including SILOptimizer diagnostic tests such as the one this
-// originated as.
-func testIndirectClosureResult<T>(f: () -> CNE<T>) -> CNE<T> {
-  // expected-error @-1{{a function with a ~Escapable result needs a parameter to depend on}}
-  // expected-note  @-2{{'@_lifetime(immortal)' can be used to indicate that values produced by this initializer have no lifetime dependencies}}
-  f()
-}


### PR DESCRIPTION
A nonescaping closure that returns a ~Escapable result and has no @_lifetime
annotation is assumed to depend on its closure context.

This fixes overly strict type checking introduced by:

    commit e98a7a6bf8b
    Date:   Fri Feb 6 02:09:25 2026
    Merge pull request #86842
    LifetimeDependence: Support function types

Fix:

1. Disable missing dependency diagnostics for ~Escapable results

Continue allow the most basic nonescaping closure types without annotation:

    func f(body: () -> NE) -> NE

2. Disable single-parameter inference for function types

Do *not* infer a default parameter dependency here:

    func f(body: (AnyObject) -> NE) -> NE

The single-parameter rule should only apply to unambiguous function
declarations. It never applies to function types. Function types should instead
infer a dependency on the closure context.

Fixes rdar://171031632 ([nonescapable] allow nonescaping closures to return
non-Escapable types)
