### PR TITLE
[SILGen] Move self into consuming accessors when possible

### DIFF
--- a/test/SILGen/moveonly_consuming_get_on_rvalue.swift
+++ b/test/SILGen/moveonly_consuming_get_on_rvalue.swift
@@ -1,0 +1,98 @@
+// RUN: %target-swift-emit-silgen -module-name test -enable-experimental-feature Lifetimes %s | %FileCheck %s
+// RUN: %target-swift-emit-sil -module-name test -enable-experimental-feature Lifetimes %s -sil-verify-all
+
+// REQUIRES: swift_feature_Lifetimes
+
+// Test that calling a consuming accessor on a noncopyable rvalue passes the owned value directly
+// instead of initiating a borrow scope and copying the value within it.
+
+// The tests use forcing the value out of an optional as the means to get the rvalue.
+
+struct NC: ~Copyable {
+  var nc2: NC2 = NC2()
+  
+  @_owned var value: NC2 {
+    consuming get { NC2() }
+  }
+}
+
+struct NC2: ~Copyable {
+  init() {}
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s4test14consume_objectyyF
+// CHECK:       switch_enum {{%.*}}, case #Optional.some!enumelt: [[BB:bb[0-9]+]]
+// CHECK:       [[BB]]([[OWNED_NC:%.*]] : @owned $NC):
+// CHECK-NOT:     begin_borrow
+// CHECK-NOT:     copy_value
+// CHECK:         = apply {{%.*}}([[OWNED_NC]])
+// CHECK:       } // end sil function
+func consume_object() {
+  let nc: NC? = NC()
+  let _ = nc!.value
+}
+
+struct AddressOnlyNC: ~Copyable {
+  // Here to make the value address only.
+  var _x: Any?
+  
+  @_owned var value: NC? {
+    consuming get {
+      NC()
+    }
+  }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s4test15consume_addressyyF
+// CHECK:       switch_enum_addr [[ENUM_ADDR:%.*]], case #Optional.some!enumelt: [[BB:bb[0-9]+]]
+// CHECK:       [[BB]]:
+// CHECK-NOT:     copy_addr {{%.*}} to
+// CHECK:         [[TAKEN:%.*]] = unchecked_take_enum_data_addr [[ENUM_ADDR]]
+// CHECK:         = apply {{%.*}}([[TAKEN]])
+// CHECK:       } // end sil function
+func consume_address() {
+  let nc: AddressOnlyNC? = AddressOnlyNC()
+  let x = nc!.value
+  _ = x
+}
+
+// Original reproducing case:
+
+struct X: ~Escapable, ~Copyable {
+  @_lifetime(immortal)
+  init() {}
+}
+
+struct MutableView: ~Copyable, ~Escapable {
+  @_lifetime(immortal)
+  init() {}
+  
+  @_owned var x: X {
+    @_lifetime(copy self)
+    consuming get {
+      X()
+    }
+  }
+}
+
+struct Source: ~Copyable {
+  @_lifetime(&self)
+  mutating func input() -> MutableView? {
+    MutableView()
+  }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s4test21mutateValueFromSourceyyF
+// CHECK:       switch_enum {{%.*}}, case #Optional.some!enumelt: [[BB:bb[0-9]+]]
+// CHECK:       [[BB]]([[OWNED_MV:%.*]] : @owned $MutableView):
+// CHECK-NOT:     begin_borrow
+// CHECK-NOT:     copy_value
+// CHECK:         = apply {{%.*}}([[OWNED_MV]])
+// CHECK:       } // end sil function
+func mutateValueFromSource() {
+  var source = Source()
+  let mv = source.input()
+  
+  let x = mv!.x
+  _ = x
+}


### PR DESCRIPTION
When invoking an accessor, the main SILGen path for preparing the `self` argument [unconditionally emits a borrow scope](https://github.com/swiftlang/swift/blob/main/lib/SILGen/SILGenApply.cpp#L7534) and uses the self value within it. This results in the value being a +0 when we go to emit it. It only later checks if the accessor needs a +1 value and [emits a copy if needed](https://github.com/swiftlang/swift/blob/main/lib/SILGen/SILGenApply.cpp#L7467). The core issue is that in some nontrivial cases, the move checker ends up choking on these unnecessary copies and diagnoses `Copy of noncopyable typed value. This is a compiler bug. Please file a bug with a small example of the bug`.

**Further description of the issue**:

The core pattern that gets emitted here (focusing on an example of invoking a `consuming` accessor on output of a force, from the radar) is:
```
  bb2(%0 : @owned $NC):
      %1 = begin_borrow %0 : $NC      
      %2 = copy_value %1 : $NC  
      %3 = function_ref @NC.value.getter
      %4 = apply %3(%2)   
      end_borrow %1 : $NC
      destroy_value %0 : $NC  
```
We borrow first, then copy (because we didn't realize we needed a +1 until after we had the borrowed value).  

In cases like this where the borrow + copy is not accompanied by a `mark_unresolved_non_copyable_value`, the move checker will diagnose this as a failure.

**Solution**:

This change addresses the issue by adding a move-only aware  path to the logic which prepares `self` for an accessor by checking up front if it's a `consuming` accessor and `self` is already +1, in which case it skips emitting a borrow scope and forwards the owned value directly to the accessor, like:
```
 bb2(%0 : @owned $NC):
      %1 = function_ref @NC.value.getter
      %2 = apply %1(%0) 
```

**Caveats/Notes**:

This does not cover all cases like this, it's a specific fix for the case where the `base` which arrives at the preparation for an accessor is in-tact as a +1 value, which I've tested definitely happens in the case where the consuming accessor is invoked on a temporary value resulting from a force. However I noticed in basic cases like `x.y` (without the intermediate operation which creates a temporary) there is still the borrow+copy pair because specifically in `SILGenLValue::visitRec` it has a [special case for noncopyable values](https://github.com/swiftlang/swift/blob/main/lib/SILGen/SILGenLValue.cpp#L3342) where it assumes we are trying to borrow the base and eagerly emits a borrow scope. It ends up working because it emits a `mark_unresolved_non_copyable_value` and the resulting gets fixed up later, but maybe this would be another place that should be expanded to handle cases where we actually are trying to consume the base rather than borrow it.

Also one more note: This fix only applies to invoking an explicitly consuming accessor (like a `consuming get`). It does not fix the case where the member being accessed is a direct stored property. That path has a similar issue of borrowing, then copying, but is also a bit more complicated because I think it requires some inference about the expression to understand if the access should be a consume or not. I leave that for a separate change.

So in general there are still several ways to end up in a situation where we already borrowed the base by the time we get to the accessor preparation, in which case the change in this PR won't do anything, but it should be a safe improvement for the cases where the owned value is in-tact at that point.

Resolves rdar://170436722

