### PR TITLE
FreeBSD: un-xfail bad-generated-filenames

### DIFF
--- a/test/diagnostics/bad-generated-filenames.swift
+++ b/test/diagnostics/bad-generated-filenames.swift
@@ -5,9 +5,6 @@
 // RUN: c-index-test -read-diagnostics %t/serialized.dia > %t/serialized.txt 2>&1
 // RUN: %FileCheck %s -check-prefix CHECK-DIA < %t/serialized.txt
 
-// rdar://168250323
-// XFAIL: OS=freebsd
-
 import SlashA
 import SlashB
 


### PR DESCRIPTION
Re-enabling the diagnostics/bad-generated-filenames.swift test. I don't see what caused this test to be x-failed in the first place and is causing CI failures due to unexpectedly passing. If it is crashing in the future, I will need a core file or some way to reproduce it at the bare minimum.