### PR TITLE
[Sema] Suppress redundant `missing type annotation` error in computed property

### DIFF
--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -871,12 +871,16 @@ Type PatternTypeRequest::evaluate(Evaluator &evaluator,
     if (options & TypeResolutionFlags::AllowUnspecifiedTypes)
       return PlaceholderType::get(Context, P);
 
-    Context.Diags.diagnose(P->getLoc(), diag::cannot_infer_type_for_pattern);
     if (auto named = dyn_cast<NamedPattern>(P)) {
       if (auto var = named->getDecl()) {
         var->setInvalid();
+        if (!var->getTypeReprOrParentPatternTypeRepr() &&
+            !var->getAllAccessors().empty()) {
+          return ErrorType::get(Context);
+        }
       }
     }
+    Context.Diags.diagnose(P->getLoc(), diag::cannot_infer_type_for_pattern);
     return ErrorType::get(Context);
 
   // A tuple pattern propagates its tuple-ness out.

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -441,8 +441,7 @@ protocol ShouldntCrash {
   let fullName2: String  // expected-error {{protocols cannot require properties to be immutable; declare read-only properties by using 'var' with a '{ get }' specifier}} {{3-6=var}} {{24-24= { get \}}}
 
   // <rdar://problem/16789886> Assert on protocol property requirement without a type
-  var propertyWithoutType { get } // expected-error {{type annotation missing in pattern}}
-  // expected-error@-1 {{computed property must have an explicit type}} {{26-26=: <# Type #>}}
+  var propertyWithoutType { get } // expected-error {{computed property must have an explicit type}} {{26-26=: <# Type #>}}
 }
 
 // rdar://problem/18168866

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -270,7 +270,7 @@ var computed_prop_with_init_1: X {
   get {}
 } = X()  // expected-error {{expected expression}} expected-error {{consecutive statements on a line must be separated by ';'}} {{2-2=;}}
 
-var x2 { // expected-error{{computed property must have an explicit type}} {{7-7=: <# Type #>}} expected-error{{type annotation missing in pattern}}
+var x2 { // expected-error{{computed property must have an explicit type}} {{7-7=: <# Type #>}}
   get {
     return _x
   }

--- a/test/decl/var/static_var.swift
+++ b/test/decl/var/static_var.swift
@@ -288,9 +288,8 @@ extension ProtoAdopter : ProtosEvilTwin {}
 // rdar://18990358
 public struct Foo { // expected-note {{to match this opening '{'}}}
   public static let S { _ = 0; aaaaaa // expected-error{{computed property must have an explicit type}} {{22-22=: <# Type #>}}
-    // expected-error@-1{{type annotation missing in pattern}}
-    // expected-error@-2{{'let' declarations cannot be computed properties}} {{17-20=var}}
-    // expected-error@-3{{cannot find 'aaaaaa' in scope}}
+    // expected-error@-1{{'let' declarations cannot be computed properties}} {{17-20=var}}
+    // expected-error@-2{{cannot find 'aaaaaa' in scope}}
 }
 
 // expected-error@+1 {{expected '}' in struct}}


### PR DESCRIPTION
Detects `if` the declaration doesn't have a type (`!var->getTypeReprOrParentPatternTypeRepr()`) and have accessors like `{}`, `{ get }` (`!var->getAllAccessors().empty()`)

which is likely where our issue resides.

Resolves #87322

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:


For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
