### PR TITLE
EmbeddedSwiftDiagnostics: ignore `destroy_value` with a `dead_end` flag

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/EmbeddedSwiftDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/EmbeddedSwiftDiagnostics.swift
@@ -176,7 +176,7 @@ private struct FunctionChecker {
     case let apply as ApplySite:
       try checkApply(apply: apply)
 
-    case let destroy as DestroyValueInst:
+    case let destroy as DestroyValueInst where !destroy.isDeadEnd:
       let type = destroy.destroyedValue.type
       if let nominal = type.nominal,
          !nominal.hasClangNode,

--- a/test/embedded/diagnostics.sil
+++ b/test/embedded/diagnostics.sil
@@ -1,0 +1,26 @@
+// RUN: %target-sil-opt -enable-experimental-feature Embedded -embedded-swift-diagnostics -I %test-resource-dir/embedded %s -o /dev/null
+
+// REQUIRES: swift_feature_Embedded
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+struct MyStruct: ~Copyable {
+  deinit
+}
+
+sil [ossa] @testit : $@convention(thin) (@owned MyStruct) -> @owned MyStruct {
+bb0(%0 : @owned $MyStruct):
+  cond_br undef, bb1, bb2
+
+bb1:
+  destroy_value [dead_end] %0
+  unreachable
+
+bb2:
+  return %0
+}
+


### PR DESCRIPTION
Fixes a false "deinit of non-copyable type not visible in the current module" error

rdar://171009835
