### PR TITLE
Add implicit receiver syntax

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -169,6 +169,25 @@ ParserResult<Expr> Parser::parseExprArrow() {
   return makeParserResult(arrow);
 }
 
+/// For the `and`/`or` implicit receiver syntax, extract the receiver
+/// (base object) of the last method call in an expression.  For example,
+/// given `hw.split(",")[0].contains("h")`, this returns the sub-expression
+/// `hw.split(",")[0]` — the receiver of the outermost `.contains(...)` call.
+/// Returns nullptr when the receiver cannot be syntactically determined.
+static Expr *extractImplicitBase(Expr *E) {
+  if (!E)
+    return nullptr;
+  // For `base.method(args)`: CallExpr whose function is an UnresolvedDotExpr.
+  if (auto *callExpr = dyn_cast<CallExpr>(E)) {
+    if (auto *dotExpr = dyn_cast<UnresolvedDotExpr>(callExpr->getFn()))
+      return dotExpr->getBase();
+  }
+  // For `base.member` (no trailing call): UnresolvedDotExpr directly.
+  if (auto *dotExpr = dyn_cast<UnresolvedDotExpr>(E))
+    return dotExpr->getBase();
+  return nullptr;
+}
+
 /// parseExprSequence
 ///
 ///   expr-sequence(Mode):
@@ -179,6 +198,8 @@ ParserResult<Expr> Parser::parseExprArrow() {
 ///     '=' expr-unary
 ///     expr-is
 ///     expr-as
+///     'and' expr-sequence-element(Mode)
+///     'or'  expr-sequence-element(Mode)
 ///
 /// The sequencing for binary exprs is not structural, i.e., binary operators
 /// are not inherently right-associative. If present, '?' and ':' tokens must
@@ -188,6 +209,11 @@ ParserResult<Expr> Parser::parseExprArrow() {
 /// is not structural.  'try' is not permitted at arbitrary points in
 /// a sequence; in the places it's permitted, it's hoisted out to
 /// apply to everything to its right.
+///
+/// The contextual keywords 'and' and 'or' act as word-form aliases for '&&'
+/// and '||'.  When followed by a leading-dot expression such as
+/// `.method(args)`, the receiver of the preceding call is used as the
+/// implicit base, so `a.f() and .g()` is equivalent to `a.f() && a.g()`.
 ParserResult<Expr> Parser::parseExprSequence(Diag<> Message,
                                              bool isExprBasic,
                                              bool isForConditionalDirective) {
@@ -334,6 +360,56 @@ parse_operator:
     }
 
     case tok::identifier: {
+      // 'and' and 'or' are word-form aliases for '&&' and '||' respectively.
+      // When followed by a leading-dot expression, the receiver of the
+      // preceding call expression is used as the implicit base for the RHS.
+      if (Tok.isContextualKeyword("and") || Tok.isContextualKeyword("or")) {
+        bool isAnd = Tok.isContextualKeyword("and");
+        SourceLoc opLoc = consumeToken();
+
+        // Create a synthetic && or || operator reference.
+        Identifier opIdent = Context.getIdentifier(isAnd ? "&&" : "||");
+        auto *opExpr = new (Context)
+            UnresolvedDeclRefExpr(DeclNameRef(opIdent),
+                                  DeclRefKind::BinaryOperator,
+                                  DeclNameLoc(opLoc));
+        SequencedExprs.push_back(opExpr);
+
+        // If the next token is a leading '.' (not at a new line), check for
+        // implicit-receiver syntax: `lhs and .method(args)`.
+        // The receiver is extracted from the last operand in the sequence.
+        //
+        // SequencedExprs layout after pushing the operator:
+        //   [..., lhsOperand (size-2), opExpr (size-1)]
+        // We need at least 2 elements (one operand + the operator we pushed)
+        // to have a valid lhsOperand to extract the receiver from.
+        if (Tok.is(tok::period_prefix) && !Tok.isAtStartOfLine() &&
+            SequencedExprs.size() >= 2) {
+          // lhsOperand is the most-recently-parsed operand — at index size-2
+          // because we just pushed the operator at the back (index size-1).
+          Expr *lhsOperand = SequencedExprs[SequencedExprs.size() - 2];
+          if (Expr *implicitBase = extractImplicitBase(lhsOperand)) {
+            // Parse '.method(args)' using implicitBase as the receiver object.
+            // parseExprPostfixSuffix will see the leading '.' and produce
+            // UnresolvedDotExpr(implicitBase, method) + optional call suffix.
+            auto baseResult = makeParserResult(implicitBase);
+            auto rhs = parseExprPostfixSuffix(baseResult, isExprBasic,
+                                              /*periodHasKeyPathBehavior=*/false);
+            SequenceStatus |= rhs;
+            if (rhs.isNull())
+              return nullptr;
+            SequencedExprs.push_back(rhs.get());
+            if (SequenceStatus.isError() && !SequenceStatus.hasCodeCompletion())
+              break;
+            goto parse_operator;
+          }
+        }
+        // No implicit-receiver syntax; the RHS will be parsed normally in
+        // the next loop iteration.
+        Message = diag::expected_expr_after_operator;
+        break;
+      }
+
       // 'async' followed by 'throws' or '->' implies that we have an arrow
       // expression.
       if (!(Tok.isContextualKeyword("async") &&

--- a/test/Parse/and_or_operator.swift
+++ b/test/Parse/and_or_operator.swift
@@ -1,0 +1,53 @@
+// RUN: %target-typecheck-verify-swift
+
+// Tests for the 'and' and 'or' contextual keyword operators, which are
+// word-form aliases for '&&' and '||'.  When followed by a leading-dot
+// expression (.method(args)), the receiver of the preceding call is used as
+// the implicit base.
+
+// ---------------------------------------------------------------------------
+// Basic 'and' / 'or' as aliases for '&&' / '||'
+// ---------------------------------------------------------------------------
+
+func boolAnd(_ a: Bool, _ b: Bool) -> Bool { a && b }
+func boolOr(_ a: Bool, _ b: Bool) -> Bool { a || b }
+
+let t = true
+let f = false
+
+let _ = t and f          // equivalent to t && f
+let _ = t or f           // equivalent to t || f
+let _ = t and t or f     // equivalent to t && t || f
+let _ = (t and f) or t   // equivalent to (t && f) || t
+
+// ---------------------------------------------------------------------------
+// Implicit-receiver syntax: `expr and .method(args)`
+// ---------------------------------------------------------------------------
+
+let hw = "Hello, World!"
+
+// Simple case: check the same string for two substrings.
+let _ = hw.contains("Hello") or .contains("World")   // hw.contains("Hello") || hw.contains("World")
+let _ = hw.contains("Hello") and .contains("World")  // hw.contains("Hello") && hw.contains("World")
+
+// Chained method with intermediate result.
+let words = ["swift", "language"]
+let _ = words.contains("swift") or .contains("language")
+
+// Accessing .isEmpty as a property (no call suffix on LHS).
+struct Wrapper {
+    var flag: Bool
+    func check() -> Bool { flag }
+}
+let w = Wrapper(flag: true)
+// 'and' / 'or' without implicit-receiver (plain boolean operands).
+let _ = w.check() and w.check()
+let _ = w.check() or w.check()
+
+// ---------------------------------------------------------------------------
+// 'and' / 'or' used as variable names (contextual keywords, not reserved)
+// ---------------------------------------------------------------------------
+
+let and = true   // 'and' can still be used as an identifier
+let or = false   // 'or' can still be used as an identifier
+let _ = and || or


### PR DESCRIPTION
Add implicit receiver syntax
This pull request adds support for the contextual keywords `and` and `or` as word-form aliases for the logical operators `&&` and `||` in Swift. It also introduces a new implicit receiver syntax, allowing chained calls like `a.f() and .g()`, where the receiver of the preceding call is used for the following method. The changes include parser logic updates and new tests to verify the feature.

**Parser enhancements for `and`/`or` operators:**

* Added recognition of `and` and `or` as contextual keywords, parsing them as aliases for `&&` and `||`.
* Implemented implicit receiver syntax: when `and`/`or` is followed by a leading-dot expression (e.g., `.method(args)`), the parser extracts the receiver from the previous method call and uses it as the base for the next call. [[1]](diffhunk://#diff-05c51f326e4b7debe4fb63d4031780848f43e2e7bd74b7d4cdbc31a186e48460R363-R412) [[2]](diffhunk://#diff-05c51f326e4b7debe4fb63d4031780848f43e2e7bd74b7d4cdbc31a186e48460R172-R190)
* Updated parser documentation to describe the new syntax and its behavior. [[1]](diffhunk://#diff-05c51f326e4b7debe4fb63d4031780848f43e2e7bd74b7d4cdbc31a186e48460R212-R216) [[2]](diffhunk://#diff-05c51f326e4b7debe4fb63d4031780848f43e2e7bd74b7d4cdbc31a186e48460R201-R202)

**Testing:**

* Added `test/Parse/and_or_operator.swift` with cases covering basic usage, implicit receiver chaining, and ensuring `and`/`or` remain available as variable names.*

*For example, see this code:*
```swift
let hello = “Hello, World!"
if hello.contains(“o”) && .contains(“r”) {
    ...
}
``` 
This now compiles.

>This will save time and is the equivalent of function chaining for Boolean statements.