### PR TITLE
[CoroutineAccessors] Be more conservative about ABI wreakage in non-r…esilient mode for underscorde accessors

### DIFF
--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -3013,11 +3013,6 @@ static bool requiresCorrespondingUnderscoredCoroutineAccessorImpl(
     }
   }
 
-  // Non-stable modules have no ABI to keep stable.
-  if (storage->getModuleContext()->getResilienceStrategy() !=
-      ResilienceStrategy::Resilient)
-    return false;
-
   // Non-exported storage has no ABI to keep stable.
   if (isExported(storage) == ExportedLevel::None)
     return false;

--- a/test/IRGen/coroutine_accessors_future.swift
+++ b/test/IRGen/coroutine_accessors_future.swift
@@ -17,11 +17,11 @@ public struct OhOh {
 // Verify that we emit a get, set, and `yielding mutate` implementation:
 
 // Getter definition
-// CHECK: define swiftcc i64 @"$s26coroutine_accessors_future02OhD0V1gSivg"(i64 %0) #0
+// CHECK: define{{.*}} swiftcc i64 @"$s26coroutine_accessors_future02OhD0V1gSivg"(i64 %0) #0
 
 // Setter definition
-// CHECK: define swiftcc void @"$s26coroutine_accessors_future02OhD0V1gSivs"(i64 %0, ptr swiftself captures(none) dereferenceable(8) %1) #0
+// CHECK: define{{.*}} swiftcc void @"$s26coroutine_accessors_future02OhD0V1gSivs"(i64 %0, ptr swiftself captures(none) dereferenceable(8) %1) #0
 
 // yielding mutate definition
-// CHECK: define {{(swiftcc|swiftcorocc)}} { ptr, ptr } @"$s26coroutine_accessors_future02OhD0V1gSivx"(ptr noalias %0, ptr swiftcoro %1, ptr swiftself captures(none) dereferenceable(8) %2)
+// CHECK: define{{.*}} {{(swiftcc|swiftcorocc)}} { ptr, ptr } @"$s26coroutine_accessors_future02OhD0V1gSivx"(ptr noalias %0, ptr{{( swiftcoro)?}} %1, ptr swiftself captures(none) dereferenceable(8) %2)
 

--- a/test/IRGen/coroutine_accessors_future.swift
+++ b/test/IRGen/coroutine_accessors_future.swift
@@ -5,6 +5,8 @@
 
 // REQUIRES: swift_feature_CoroutineAccessors
 
+// REQUIRES: OS_FAMILY=darwin || OS=linux-gnu
+
 // Simple struct available well after CoroutineAccessors feature is present.
 // We don't need old `_modify` accessors for this because no older
 // client can possibly be trying to access it:

--- a/test/IRGen/coroutine_accessors_future.swift
+++ b/test/IRGen/coroutine_accessors_future.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-emit-irgen  \
+// RUN:    -enable-experimental-feature CoroutineAccessors  \
+// RUN:    %s                     \
+// RUN: | %IRGenFileCheck %s
+
+// REQUIRES: swift_feature_CoroutineAccessors
+
+// Simple struct available well after CoroutineAccessors feature is present.
+// We don't need old `_modify` accessors for this because no older
+// client can possibly be trying to access it:
+
+@available(macOS 999.99, *)
+public struct OhOh {
+    public var g: Int = 0
+}
+
+// Verify that we emit a get, set, and `yielding mutate` implementation:
+
+// Getter definition
+// CHECK: define swiftcc i64 @"$s26coroutine_accessors_future02OhD0V1gSivg"(i64 %0) #0
+
+// Setter definition
+// CHECK: define swiftcc void @"$s26coroutine_accessors_future02OhD0V1gSivs"(i64 %0, ptr swiftself captures(none) dereferenceable(8) %1) #0
+
+// yielding mutate definition
+// CHECK: define {{(swiftcc|swiftcorocc)}} { ptr, ptr } @"$s26coroutine_accessors_future02OhD0V1gSivx"(ptr noalias %0, ptr swiftcoro %1, ptr swiftself captures(none) dereferenceable(8) %2)
+

--- a/test/IRGen/coroutine_accessors_past.swift
+++ b/test/IRGen/coroutine_accessors_past.swift
@@ -17,17 +17,17 @@ public struct OhOh {
 // Verify that we emit a get, set, `_modify`, and `yielding mutate` implementation:
 
 // Variable initialization expression
-// CHECK: define swiftcc i64 @"$s24coroutine_accessors_past02OhD0V1gSivpfi"() #0
+// CHECK: define{{.*}} swiftcc i64 @"$s24coroutine_accessors_past02OhD0V1gSivpfi"() #0
 
 // Getter definition
-// CHECK: define swiftcc i64 @"$s24coroutine_accessors_past02OhD0V1gSivg"(i64 %0) #0
+// CHECK: define{{.*}} swiftcc i64 @"$s24coroutine_accessors_past02OhD0V1gSivg"(i64 %0) #0
 
 // Setter definition
-// CHECK: define swiftcc void @"$s24coroutine_accessors_past02OhD0V1gSivs"(i64 %0, ptr swiftself captures(none) dereferenceable(8) %1) #0
+// CHECK: define{{.*}} swiftcc void @"$s24coroutine_accessors_past02OhD0V1gSivs"(i64 %0, ptr swiftself captures(none) dereferenceable(8) %1) #0
 
 // _modify definition
-// CHECK: define swiftcc { ptr, ptr } @"$s24coroutine_accessors_past02OhD0V1gSivM"(ptr noalias dereferenceable(32) %0, ptr swiftself captures(none) dereferenceable(8) %1) #1
+// CHECK: define{{.*}} swiftcc { ptr, ptr } @"$s24coroutine_accessors_past02OhD0V1gSivM"(ptr noalias dereferenceable(32) %0, ptr swiftself captures(none) dereferenceable(8) %1) #1
 
 // yielding mutate definition
-// CHECK: define {{(swiftcc|swiftcorocc)}} { ptr, ptr } @"$s24coroutine_accessors_past02OhD0V1gSivx"(ptr noalias %0, ptr swiftcoro %1, ptr swiftself captures(none) dereferenceable(8) %2) #1
+// CHECK: define{{.*}} {{(swiftcc|swiftcorocc)}} { ptr, ptr } @"$s24coroutine_accessors_past02OhD0V1gSivx"(ptr noalias %0, ptr{{( swiftcoro)?}} %1, ptr swiftself captures(none) dereferenceable(8) %2) #1
 

--- a/test/IRGen/coroutine_accessors_past.swift
+++ b/test/IRGen/coroutine_accessors_past.swift
@@ -5,6 +5,8 @@
 
 // REQUIRES: swift_feature_CoroutineAccessors
 
+// REQUIRES: OS_FAMILY=darwin || OS=linux-gnu
+
 // Simple struct available before CoroutineAccessors feature is present:
 
 // We have to emit a `_modify` to support old clients, and

--- a/test/IRGen/coroutine_accessors_past.swift
+++ b/test/IRGen/coroutine_accessors_past.swift
@@ -1,0 +1,33 @@
+// RUN: %target-swift-emit-irgen  \
+// RUN:    -enable-experimental-feature CoroutineAccessors  \
+// RUN:    %s                     \
+// RUN: | %IRGenFileCheck %s
+
+// REQUIRES: swift_feature_CoroutineAccessors
+
+// Simple struct available before CoroutineAccessors feature is present:
+
+// We have to emit a `_modify` to support old clients, and
+// a `yielding mutate` so we can migrate to the more efficient form.
+
+public struct OhOh {
+    public var g: Int = 0
+}
+
+// Verify that we emit a get, set, `_modify`, and `yielding mutate` implementation:
+
+// Variable initialization expression
+// CHECK: define swiftcc i64 @"$s24coroutine_accessors_past02OhD0V1gSivpfi"() #0
+
+// Getter definition
+// CHECK: define swiftcc i64 @"$s24coroutine_accessors_past02OhD0V1gSivg"(i64 %0) #0
+
+// Setter definition
+// CHECK: define swiftcc void @"$s24coroutine_accessors_past02OhD0V1gSivs"(i64 %0, ptr swiftself captures(none) dereferenceable(8) %1) #0
+
+// _modify definition
+// CHECK: define swiftcc { ptr, ptr } @"$s24coroutine_accessors_past02OhD0V1gSivM"(ptr noalias dereferenceable(32) %0, ptr swiftself captures(none) dereferenceable(8) %1) #1
+
+// yielding mutate definition
+// CHECK: define {{(swiftcc|swiftcorocc)}} { ptr, ptr } @"$s24coroutine_accessors_past02OhD0V1gSivx"(ptr noalias %0, ptr swiftcoro %1, ptr swiftself captures(none) dereferenceable(8) %2) #1
+

--- a/test/IRGen/coroutine_accessors_popless.swift
+++ b/test/IRGen/coroutine_accessors_popless.swift
@@ -51,6 +51,11 @@
 // CHECK-arm64e-SAME:    i64 40879 },
 // CHECK-arm64e-SAME:  section "llvm.ptrauth",
 // CHECK-arm64e-SAME:  align 8
+// CHECK-apple-LABEL: _swift_coro_typed_malloc_allocator = linkonce_odr hidden constant %swift.coro_allocator {
+// CHECK-apple-SAME:       i32 259,
+// CHECK-apple-SAME:       _swift_coro_typed_malloc
+// CHECK-apple-SAME:       _swift_coro_free
+// CHECK-apple-SAME:  }
 // CHECK-LABEL: _swift_coro_async_allocator = linkonce_odr hidden constant %swift.coro_allocator {
 // CHECK-SAME:      i32 1,
 // CHECK-SAME:      _swift_coro_task_alloc
@@ -84,11 +89,6 @@
 // CHECK-arm64e-SAME:    i64 40879 },
 // CHECK-arm64e-SAME:  section "llvm.ptrauth",
 // CHECK-arm64e-SAME:  align 8
-// CHECK-apple-LABEL: _swift_coro_typed_malloc_allocator = linkonce_odr hidden constant %swift.coro_allocator {
-// CHECK-apple-SAME:       i32 259,
-// CHECK-apple-SAME:       _swift_coro_typed_malloc
-// CHECK-apple-SAME:       _swift_coro_free 
-// CHECK-apple-SAME:  }
 
 // CHECK-LABEL: @_swift_coro_alloc(
 // CHECK-SAME:      ptr [[FRAME:%[^,]+]]


### PR DESCRIPTION
There is an argument that in non-resilient mode there is no ABI to preserve. But let's try to be more conservative with this wrt _read/_modify emission.

Author: Tim Kientzle @tbkka

rdar://169282655