### PR TITLE
[embedded] Don't change AST decls with markUsableFromInline in embedded

### DIFF
--- a/lib/SIL/IR/SIL.cpp
+++ b/lib/SIL/IR/SIL.cpp
@@ -41,6 +41,9 @@ FormalLinkage swift::getDeclLinkage(const ValueDecl *D) {
           !D->getObjCImplementationDecl())
     return FormalLinkage::PublicNonUnique;
 
+  if (D->getASTContext().LangOpts.hasFeature(Feature::Embedded))
+    return FormalLinkage::PublicUnique;
+
   switch (D->getEffectiveAccess()) {
   case AccessLevel::Package:
     return FormalLinkage::PackageUnique;

--- a/lib/SIL/IR/SIL.cpp
+++ b/lib/SIL/IR/SIL.cpp
@@ -41,7 +41,7 @@ FormalLinkage swift::getDeclLinkage(const ValueDecl *D) {
           !D->getObjCImplementationDecl())
     return FormalLinkage::PublicNonUnique;
 
-  if (D->getASTContext().LangOpts.hasFeature(Feature::Embedded))
+  if (SILDeclRef::declHasNonUniqueDefinition(D))
     return FormalLinkage::PublicUnique;
 
   switch (D->getEffectiveAccess()) {

--- a/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
+++ b/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
@@ -1045,6 +1045,11 @@ void CrossModuleOptimization::makeDeclUsableFromInline(ValueDecl *decl) {
   if (decl->getEffectiveAccess() >= AccessLevel::Package)
     return;  
 
+  // In Embedded Swift every ValueDecl is usableFromInline. (see
+  // ValueDecl::isUsableFromInline.
+  if (decl->getASTContext().LangOpts.hasFeature(Feature::Embedded))
+    return;
+
   // This function should not be called in Package CMO mode.
   assert(!isPackageCMOEnabled(M.getSwiftModule()));
 

--- a/test/embedded/concurrency-deleted-method.swift
+++ b/test/embedded/concurrency-deleted-method.swift
@@ -38,7 +38,7 @@ actor MyActor {
 }
 
 // CHECK-IR:      @swift_deletedAsyncMethodErrorTu =
-// CHECK-IR:      @"$e4main7MyActorCN" = constant <{ ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr }> <{
+// CHECK-IR:      @"$e4main7MyActorCN" = hidden constant <{ ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr }> <{
 // CHECK-IR-SAME:   ptr null,
 // CHECK-IR-SAME:   ptr @"$e4main7MyActorCfD{{(.ptrauth[.0-9]*)?}}",
 // CHECK-IR-SAME:   ptr null,

--- a/test/embedded/linkage/weak_linkage_bug.swift
+++ b/test/embedded/linkage/weak_linkage_bug.swift
@@ -3,11 +3,21 @@
 
 
 // RUN: %target-swift-frontend -c -wmo -emit-module -o %t/C.o %t/C.swift -enable-experimental-feature Embedded -parse-as-library -enable-experimental-feature EmbeddedExistentials
-
 // RUN: %target-swift-frontend -num-threads 1 -c -I %t -emit-module -o %t/D.o -o %t/D2.o %t/D.swift %t/D2.swift -wmo -enable-experimental-feature Embedded -parse-as-library -enable-experimental-feature EmbeddedExistentials
 
 // RUN: %target-clang %target-clang-resource-dir-opt %t/C.o %t/D.o %t/D2.o  -o %t/Application
 // RUN: %target-run %t/Application | %FileCheck %s
+
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-ir -wmo -emit-module -o %t/C.ll %t/C.swift -enable-experimental-feature Embedded -parse-as-library -enable-experimental-feature EmbeddedExistentials -enable-experimental-feature CoroutineAccessors
+// RUN: %target-swift-frontend -num-threads 1 -emit-ir -I %t -emit-module -o %t/D.ll -o %t/D2.ll %t/D.swift %t/D2.swift -wmo -enable-experimental-feature Embedded -parse-as-library -enable-experimental-feature EmbeddedExistentials -enable-experimental-feature CoroutineAccessors
+
+// RUN:  %FileCheck %s --check-prefix=VTABLE-C < %t/C.ll
+// RUN:  %FileCheck %s --check-prefix=VTABLE-D < %t/D.ll
+
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
@@ -15,6 +25,10 @@
 // REQUIRES: swift_feature_EmbeddedExistentials
 
 // CHECK: MyClass.foo
+
+// Make sure the vtable layouts match.
+// VTABLE-C: @"$e1C7MyClassCySiGMf" = linkonce_odr hidden constant <{ ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr }>
+// VTABLE-D: @"$e1C7MyClassCySiGMf" = linkonce_odr hidden constant <{ ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr }>
 
 //--- C.swift
 public class BaseClass {}

--- a/test/embedded/linkage/weak_linkage_bug.swift
+++ b/test/embedded/linkage/weak_linkage_bug.swift
@@ -23,6 +23,7 @@
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: swift_feature_EmbeddedExistentials
+// REQUIRES: swift_feature_CoroutineAccessors
 
 // CHECK: MyClass.foo
 


### PR DESCRIPTION
The current approach of changing the AST mid compiler pipeline (in the CMO pass) is not tenable/maintainable imo. We can't get different answers throughout the compilation process about AST properties -- there is no way about reasoning what things mean.

Instead, we treat internal and lower linkages as public for the purposes of symbol visibility for linkage reasons in SIL/IRGen.

rdar://171083081