### PR TITLE
Fix build script for XCTest so it can link _TestingInterop

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2333,7 +2333,7 @@ for host in "${ALL_HOSTS[@]}"; do
 
                     -Ddispatch_DIR=$(build_directory ${host} libdispatch)/cmake/modules
                     -DFoundation_DIR=$(build_directory ${host} foundation)/cmake/modules
-                    -DSwiftTesting_DIR=$(build_directory ${host} swift_testing)/cmake/modules
+                    -DSwiftTesting_DIR=$(build_directory ${host} swifttesting)/cmake/modules
                     -DLLVM_DIR=$(build_directory ${host} llvm)/lib/cmake/llvm
 
                     -DXCTEST_PATH_TO_LIBDISPATCH_SOURCE:PATH=${LIBDISPATCH_SOURCE_DIR}

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3283,7 +3283,7 @@ function Test-XCTest {
       Get-ProjectBinaryCache $BuildPlatform DynamicFoundation
     }
 
-    $env:Path = "$(Get-ProjectBinaryCache $BuildPlatform XCTest);${FoundationBinaryCache}\bin;${DispatchBinaryCache};${SwiftRuntime}\usr\bin;${env:Path};$UnixToolsBinDir"
+    $env:Path = "$(Get-ProjectBinaryCache $BuildPlatform XCTest);$(Get-ProjectBinaryCache $BuildPlatform Testing)\bin;${FoundationBinaryCache}\bin;${DispatchBinaryCache};${SwiftRuntime}\usr\bin;${env:Path};$UnixToolsBinDir"
     $env:SDKROOT = Get-SwiftSDK -OS $Platform.OS -Identifier $Platform.DefaultSDK
 
     Build-CMakeProject `

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3259,6 +3259,7 @@ function Build-XCTest([Hashtable] $Platform) {
       CMAKE_Swift_FLAGS = $SwiftFlags;
       ENABLE_TESTING = "NO";
       XCTest_INSTALL_NESTED_SUBDIR = "YES";
+      SwiftTesting_DIR = (Get-ProjectCMakeModules $Platform Testing);
     }
 }
 

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -4358,8 +4358,8 @@ if (-not $SkipBuild) {
     }
 
     foreach ($Build in $WindowsSDKBuilds) {
-      Invoke-BuildStep Build-XCTest $Build
       Invoke-BuildStep Build-Testing $Build
+      Invoke-BuildStep Build-XCTest $Build
     }
 
     Write-PlatformInfoPlist Windows
@@ -4432,8 +4432,8 @@ if (-not $SkipBuild) {
     }
 
     foreach ($Build in $AndroidSDKBuilds) {
-      Invoke-BuildStep Build-XCTest $Build
       Invoke-BuildStep Build-Testing $Build
+      Invoke-BuildStep Build-XCTest $Build
     }
 
     Write-PlatformInfoPlist Android


### PR DESCRIPTION
Failed to find SwiftTesting in the earlier build: https://ci.swift.org/job/swift-corelibs-xctest-PR-Linux/139/consoleText
```
-DSwiftTesting_DIR=/home/build-user/build/Ninja-ReleaseAssert/swift_testing-linux-x86_64/cmake/modules 
...
[2026-02-23T23:30:38.885Z] -- Could NOT find SwiftTesting (missing: SwiftTesting_DIR)
```

But it was created earlier as swifttesting without the underscore:
```
[2026-02-23T23:29:27.132Z] + mkdir -p /home/build-user/build/Ninja-ReleaseAssert/swifttesting-linux-x86_64
```

Should unblock https://github.com/swiftlang/swift-corelibs-xctest/pull/525 for real this time! 🤞 