### PR TITLE
test: Use deployment targets instead of availability in some tests

### DIFF
--- a/test/Concurrency/startImmediatelyIsolation.swift
+++ b/test/Concurrency/startImmediatelyIsolation.swift
@@ -1,14 +1,12 @@
-// RUN: %target-swift-frontend -parse-as-library -swift-version 6 -emit-sil -verify %s
+// RUN: %target-swift-frontend -parse-as-library -swift-version 6 -target %target-swift-6.2-abi-triple -emit-sil -verify %s
 // REQUIRES: concurrency
 
-@available(SwiftStdlib 6.2, *)
 func sync() -> Task<String, Never> {
   Task.immediate {
     return ""
   }
 }
 
-@available(SwiftStdlib 6.2, *)
 func async() async throws {
   let t1 = Task.immediate {
     return ""
@@ -43,7 +41,6 @@ func async() async throws {
   }
 }
 
-@available(SwiftStdlib 6.2, *)
 actor TestSelfCapture {
   func method() {}
 
@@ -54,7 +51,6 @@ actor TestSelfCapture {
   }
 }
 
-@available(SwiftStdlib 6.2, *)
 struct TestThrowing {
   func test() {
     // expected-error@+1{{invalid conversion from throwing function of type '() throws -> Void' to non-throwing function type '@isolated(any) () async -> Void'}}

--- a/test/Constraints/async.swift
+++ b/test/Constraints/async.swift
@@ -1,39 +1,31 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.5-abi-triple
 
 // REQUIRES: concurrency
 
-@available(SwiftStdlib 5.5, *)
 func doAsynchronously() async { }
-@available(SwiftStdlib 5.5, *)
 func doSynchronously() { }
 
-@available(SwiftStdlib 5.5, *)
 func testConversions() async {
   let _: () -> Void = doAsynchronously // expected-error{{invalid conversion from 'async' function of type '() async -> ()' to synchronous function type '() -> Void'}}
   let _: () async -> Void = doSynchronously // okay
 }
 
 // Overloading
-@available(SwiftStdlib 5.5, *)
 @available(swift, deprecated: 4.0, message: "synchronous is no fun")
 func overloadedSame(_: Int = 0) -> String { "synchronous" }
 
-@available(SwiftStdlib 5.5, *)
+
 func overloadedSame() async -> String { "asynchronous" }
 
-@available(SwiftStdlib 5.5, *)
+
 func overloaded() -> String { "synchronous" }
-@available(SwiftStdlib 5.5, *)
 func overloaded() async -> Double { 3.14159 }
 
-@available(SwiftStdlib 5.5, *)
 @available(swift, deprecated: 4.0, message: "synchronous is no fun")
 func overloadedOptDifference() -> String { "synchronous" }
 
-@available(SwiftStdlib 5.5, *)
 func overloadedOptDifference() async -> String? { nil }
 
-@available(SwiftStdlib 5.5, *)
 func testOverloadedSync() {
   _ = overloadedSame() // expected-warning{{synchronous is no fun}}
 
@@ -63,7 +55,6 @@ func testOverloadedSync() {
   let _: Int = fn4 // expected-error{{value of type '() async -> ()'}}
 }
 
-@available(SwiftStdlib 5.5, *)
 func testOverloadedAsync() async {
   _ = await overloadedSame() // no warning
 
@@ -98,12 +89,9 @@ func testOverloadedAsync() async {
   let _: Int = fn4 // expected-error{{value of type '() async -> ()'}}
 }
 
-@available(SwiftStdlib 5.5, *)
 func takesAsyncClosure(_ closure: () async -> String) -> Int { 0 }
-@available(SwiftStdlib 5.5, *)
 func takesAsyncClosure(_ closure: () -> String) -> String { "" }
 
-@available(SwiftStdlib 5.5, *)
 func testPassAsyncClosure() {
   let a = takesAsyncClosure { await overloadedSame() }
   let _: Double = a // expected-error{{convert value of type 'Int'}}
@@ -112,7 +100,6 @@ func testPassAsyncClosure() {
   let _: Double = b // expected-error{{convert value of type 'String'}}
 }
 
-@available(SwiftStdlib 5.5, *)
 struct FunctionTypes {
   var syncNonThrowing: () -> Void
   var syncThrowing: () throws -> Void
@@ -135,27 +122,22 @@ struct FunctionTypes {
 }
 
 // Overloading when there is conversion from sync to async.
-@available(SwiftStdlib 5.5, *)
 func bar(_ f: (Int) -> Int) -> Int {
   return f(2)
 }
 
-@available(SwiftStdlib 5.5, *)
 func bar(_ f: (Int) async -> Int) async -> Int {
   return await f(2)
 }
 
-@available(SwiftStdlib 5.5, *)
 func incrementSync(_ x: Int) -> Int {
   return x + 1
 }
 
-@available(SwiftStdlib 5.5, *)
 func incrementAsync(_ x: Int) async -> Int {
   return x + 1
 }
 
-@available(SwiftStdlib 5.5, *)
 func testAsyncWithConversions() async {
   _ = bar(incrementSync)
   _ = bar { -$0 }
@@ -181,24 +163,19 @@ struct OverloadInImplicitAsyncClosure {
   init(int: Int) throws { }
 }
 
-@available(SwiftStdlib 5.5, *)
 func test(_: Int) async throws {}
 
 @discardableResult
-@available(SwiftStdlib 5.5, *)
 func test(_: Int) -> String { "" }
 
-@available(SwiftStdlib 5.5, *)
 func compute(_: @escaping () -> Void) {}
 
-@available(SwiftStdlib 5.5, *)
 func test_sync_in_closure_context() {
   compute {
     test(42) // Ok (select sync overloads and discards the result)
   }
 }
 
-@available(SwiftStdlib 5.5, *)
 func test_async_calls_in_async_context(v: Int) async {
   final class Test : Sendable {
     init(_: Int) {}

--- a/test/Distributed/distributed_actor_layout.swift
+++ b/test/Distributed/distributed_actor_layout.swift
@@ -9,7 +9,6 @@
 import Distributed
 import FakeDistributedActorSystems
 
-@available(SwiftStdlib 5.7, *)
 typealias DefaultDistributedActorSystem = FakeActorSystem
 
 class MyClass { }
@@ -24,7 +23,6 @@ protocol HasActorSystem {
 extension MyActor: HasActorSystem { }
 
 // CHECK: %T27distributed_actor_accessors7MyActorC = type <{ %swift.refcounted, %swift.defaultactor, %T27FakeDistributedActorSystems0C7AddressV, %T27FakeDistributedActorSystems0aC6SystemV, ptr }>
-@available(SwiftStdlib 5.7, *)
 public distributed actor MyActor {
   var field: MyClass = MyClass()
 
@@ -36,7 +34,6 @@ public distributed actor MyActor {
 // This does not have the concrete fields in the IR type because the LocalTestingDistributedActorSystem
 // is declared in Distributed, which means that it is compiled with library evolution turned on,
 // which causes the type to be laid out at runtime.
-@available(SwiftStdlib 5.7, *)
 public distributed actor MyActorInt {
   public typealias ActorSystem = LocalTestingDistributedActorSystem
   var field: String = ""

--- a/test/Interpreter/actor_class_forbid_objc_assoc_objects.swift
+++ b/test/Interpreter/actor_class_forbid_objc_assoc_objects.swift
@@ -17,7 +17,6 @@ defer { runAllTests() }
 
 var Tests = TestSuite("Actor.AssocObject")
 
-@available(SwiftStdlib 5.0, *)
 final actor Actor {
 }
 
@@ -31,7 +30,6 @@ if #available(SwiftStdlib 5.0, *) {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
 actor Actor2 {
 }
 
@@ -45,7 +43,6 @@ if #available(SwiftStdlib 5.0, *) {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
 actor Actor5<T> {
   var state: T
   init(state: T) { self.state = state }
@@ -69,7 +66,6 @@ if #available(SwiftStdlib 5.0, *) {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
 actor ActorNSObjectSubKlass : NSObject {}
 
 if #available(SwiftStdlib 5.0, *) {
@@ -80,7 +76,6 @@ if #available(SwiftStdlib 5.0, *) {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
 actor ActorNSObjectSubKlassGeneric<T> : NSObject {
   var state: T
   init(state: T) { self.state = state }

--- a/test/SILOptimizer/lifetime_dependence/stdlib_span.swift
+++ b/test/SILOptimizer/lifetime_dependence/stdlib_span.swift
@@ -1,9 +1,9 @@
 // RUN: %target-swift-frontend %s -emit-sil \
+// RUN:   -target %target-swift-6.2-abi-triple \
 // RUN:   -o /dev/null \
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -disable-access-control \
 // RUN:   -enable-experimental-feature Lifetimes
 
 // REQUIRES: swift_in_compiler
@@ -16,7 +16,6 @@
 // =============================================================================
 
 extension UnsafeRawBufferPointer {
-  @available(SwiftStdlib 6.2, *)
   public var storage: RawSpan {
     @_lifetime(borrow self)
     get {
@@ -26,24 +25,20 @@ extension UnsafeRawBufferPointer {
   }
 }
 
-@available(SwiftStdlib 6.2, *)
 func read(_ span: RawSpan) {}
 
-@available(SwiftStdlib 6.2, *)
 func testUBPStorage(ubp: UnsafeRawBufferPointer) {
   // 'span' is valid within the lexical scope of variable 'ubp', which is the entire function.
   let span = ubp.storage
   read(span)
 }
 
-@available(SwiftStdlib 6.2, *)
 @_lifetime(borrow ubp)
 func testUBPStorageReturn(ubp: UnsafeRawBufferPointer) -> RawSpan {
   // 'storage' can be returned since the function's return value also has a dependence on 'ubp'.
   return ubp.storage
 }
 
-@available(SwiftStdlib 6.2, *)
 @_lifetime(borrow ubp)
 func testUBPStorageCopy(ubp: UnsafeRawBufferPointer) -> RawSpan {
   let localBuffer = ubp
@@ -52,7 +47,6 @@ func testUBPStorageCopy(ubp: UnsafeRawBufferPointer) -> RawSpan {
                              // expected-note  @-2{{this use causes the lifetime-dependent value to escape}}
 }
 
-@available(SwiftStdlib 6.2, *)
 func testUBPStorageEscape(array: [Int64]) {
   var span = RawSpan()  // expected-error{{lifetime-dependent variable 'span' escapes its scope}}
   array.withUnsafeBytes {  // expected-note{{it depends on the lifetime of argument '$0'}}


### PR DESCRIPTION
Simplify a few tests that were making heavy use of availability annoations that can be avoided by setting a Swift release aligned deployment target.
