### PR TITLE
[cxx-interop] Look for non-unsafe name during Clang lookup

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -10761,11 +10761,7 @@ void ClangRecordMemberLoader::load(const clang::RecordDecl *clangRecord,
 
     // Skip this member if caller asked for storage and this isn't a field,
     // or vice versa.
-    //
-    // FIXME: also load eagerly function templates for now, even though they are
-    //        technically not storage members, because otherwise those templated
-    //        members can't be looked up from the SwiftLookupTable.
-    if (storage != isa<clang::FieldDecl, clang::FunctionTemplateDecl>(m))
+    if (storage != isa<clang::FieldDecl>(m))
       continue;
 
     // Make sure we always pull in record fields. Everything else had better

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -1964,26 +1964,6 @@ void importer::addEntryToLookupTable(SwiftLookupTable &table,
     }
   }
 
-  if (auto methodDecl = dyn_cast<clang::CXXMethodDecl>(named)) {
-    // If the return type is a template instantiation, it is not possible to
-    // determine safety/unsafety of the method without instantiating the
-    // template. Let's add both safe and unsafe versions of the name to the
-    // lookup table.
-    if (auto returnTy = desugarIfElaborated(methodDecl->getReturnType());
-        isa<clang::TemplateSpecializationType>(returnTy)) {
-      auto importedName = nameImporter.importName(methodDecl, currentVersion);
-      if (importedName && importedName.getDeclName().isSpecial()) {
-        if (StringRef id = importedName.getDeclName().getBaseIdentifier().str();
-            id.starts_with("__") && id.ends_with("Unsafe")) {
-          StringRef safeId = id.drop_front(2).drop_back(6);
-          table.addEntry(
-              DeclBaseName(nameImporter.getContext().getIdentifier(safeId)),
-              named, importedName.getEffectiveContext());
-        }
-      }
-    }
-  }
-
   // Class template instantiations are imported lazily, however, the lookup
   // table must include their mangled name (__CxxTemplateInst...) to make it
   // possible to find these decls during deserialization. For any C++ typedef


### PR DESCRIPTION
When we determine that a C++ method is unsafe, we import it with a mangled name __{{name}}Unsafe. But our heuristics for determining unsafety depend on the definition of record types, which might not exist if that record is an uninstantiated class template. Thus, if we come across such a method while populating the SwiftLookupTable, we will add to the lookup table with the key {{name}} rather than __{{name}}Unsafe. However, when we later import this method, we may determine that it is unsafe according to class templates that have since been instantiated.

I tried to account for this scenario by storing both the original and the unsafe-mangled name in this commit:

    commit f305ffc69f2fbfc80eaa984c170d3f735f4b5cc4
    [cxx-interop] Instantiate CXXMethodDecl return type before importing

But I now realize that messing with the SwiftLookupTable was the wrong appraoch, and that moreover I was doing so incorrectly (I was dropping the unsafe-mangling rather than adding it).

That led to the following workaround patch:

    commit 807496352bfd89a18f7b85b0b82740226b4d5f42
    [cxx-interop] Load function template members alongside storage

This patch removes the workaround as well as the original SwiftLookupTable hack by doing what I probably should have done in the first place, which is to just look up {{name}} only when I'm already looking up __{{name}}Unsafe.

The test cases from those commits, however, are still checked in to ensure this change doesn't regress what those prior commits were trying to fix.

rdar://170576709