### PR TITLE
build: correct compiler variant detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1161,8 +1161,8 @@ swift_common_cxx_warnings()
 # Set sanitizer options for Swift compiler.
 swift_common_sanitizer_config()
 
-# Check if we're build with MSVC or Clang-cl, as these compilers have similar command line arguments.
-if("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC" OR "${CMAKE_CXX_SIMULATE_ID}" STREQUAL "MSVC")
+# Check if we're build with MSVC or clang-cl, as these compilers have similar command line arguments.
+if("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC" OR "${CMAKE_C_COMPILER_FRONTEND_VARIANT}" STREQUAL "MSVC")
   set(SWIFT_COMPILER_IS_MSVC_LIKE TRUE)
 endif()
 


### PR DESCRIPTION
Properly detect the compiler frontend being `cl` compatible. This is important to thread through all the options for the compiler.

Extracted from the changes by @hjyamauchi