### PR TITLE
Fix an armasm failure on Windows ARM64

### DIFF
--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -123,7 +123,7 @@ else()
   # everything and there are various places where we link runtime code with
   # code built by the host compiler. Disable sanitizers for the runtime for
   # now.
-  add_compile_options(-fno-sanitize=all)
+  add_compile_options("$<$<COMPILE_LANGUAGE:C,CXX>:-fno-sanitize=all>")
 endif()
 
 # Do not enforce checks for LLVM's ABI-breaking build settings.


### PR DESCRIPTION
This avoids passing -fno-sanitize=all to ASM compilers.

[569/671] Building ASM_MARMASM object tools\swift\stdlib\public\RuntimeModule\CMakeFiles\swiftRuntime-windows-aarch64.dir\get-cpu-context-aarch64.asm.obj FAILED: [code=1] tools/swift/stdlib/public/RuntimeModule/CMakeFiles/swiftRuntime-windows-aarch64.dir/get-cpu-context-aarch64.asm.obj C:\PROGRA~2\MICROS~2\2022\BUILDT~1\VC\Tools\MSVC\1444~1.352\bin\HOSTAR~1\arm64\armasm64.exe -IS:\b\5\tools\swift\stdlib\public\RuntimeModule -IS:\SourceCache\swift\stdlib\public\RuntimeModule -IS:\SourceCache\swift\stdlib\include -IS:\SourceCache\swift\stdlib\public\SwiftShims -IS:\b\5\tools\swift\include -IS:\SourceCache\swift\include -IS:\b\5\include -IS:\SourceCache\llvm-project\llvm\..\clang\include -IS:\b\5\tools\clang\include -IS:\SourceCache\swift-corelibs-libdispatch\src\BlocksRuntime -IS:\SourceCache\swift-corelibs-libdispatch -fno-sanitize=all -o tools\swift\stdlib\public\RuntimeModule\CMakeFiles\swiftRuntime-windows-aarch64.dir\get-cpu-context-aarch64.asm.obj S:\SourceCache\swift\stdlib\public\RuntimeModule\get-cpu-context-aarch64.asm Microsoft (R) ARM Macro Assembler Version 14.44.35222.0 for 64 bits Copyright (C) Microsoft Corporation.  All rights reserved.

error A2029: unknown command-line argument or argument value -fno-sanitize=all

 Usage:      armasm [<options>] sourcefile objectfile
             armasm [<options>] -o objectfile sourcefile
             armasm -h              for help