### PR TITLE
Add a missing dependency for symlink_clang_headers_static

### DIFF
--- a/stdlib/public/SwiftShims/swift/shims/CMakeLists.txt
+++ b/stdlib/public/SwiftShims/swift/shims/CMakeLists.txt
@@ -170,6 +170,7 @@ if(NOT SWIFT_BUILT_STANDALONE)
 
   foreach(target
       symlink_clang_headers
+      symlink_clang_headers_static
       clang-builtin-headers
       clang-resource-dir-symlink
       clang-builtin-headers-in-clang-resource-dir)


### PR DESCRIPTION
This fixes a flaky build failure during swfit testing on Windows:

```
[3215/5709] Symlinking Clang resource headers into D:/r/_work/swift-build/swift-build/BinaryCache/1/./lib/swift_static/clang
FAILED: [code=1] lib/swift_static/clang D:/r/_work/swift-build/swift-build/BinaryCache/1/lib/swift_static/clang
C:\Windows\system32\cmd.exe /C "cd /D D:\r\_work\swift-build\swift-build\BinaryCache\1\tools\swift\stdlib\public\SwiftShims\swift\shims && "C:\Program Files\CMake\bin\cmake.exe" -E make_directory D:/r/_work/swift-build/swift-build/BinaryCache/1/./lib/swift_static && "C:\Program Files\CMake\bin\cmake.exe" -E copy_directory D:/r/_work/swift-build/swift-build/BinaryCache/1/./lib/clang/21 D:/r/_work/swift-build/swift-build/BinaryCache/1/./lib/swift_static/clang"
Error copying directory from "D:/r/_work/swift-build/swift-build/BinaryCache/1/./lib/clang/21" to "D:/r/_work/swift-build/swift-build/BinaryCache/1/./lib/swift_static/clang".
```
