### PR TITLE
[Concurrency] Minor typo in DiscardingTaskGroup docs

### DIFF
--- a/stdlib/public/Concurrency/DiscardingTaskGroup.swift
+++ b/stdlib/public/Concurrency/DiscardingTaskGroup.swift
@@ -189,7 +189,7 @@ public struct DiscardingTaskGroup {
 
   /// A Boolean value that indicates whether the group has any remaining tasks.
   ///
-  /// At the start of the body of a `withDiscardingTaskGroup(of:returning:body:)` call,
+  /// At the start of the body of a `withDiscardingTaskGroup(returning:body:)` call,
   /// the task group is always empty.
   ///
   /// It's guaranteed to be empty when returning from that body
@@ -266,7 +266,7 @@ extension DiscardingTaskGroup: Sendable { }
 /// before returning from this function:
 ///
 /// ```
-/// try await withThrowingDiscardingTaskGroup(of: Void.self) { group in
+/// try await withThrowingDiscardingTaskGroup { group in
 ///   group.addTask { /* slow-task */ }
 ///   // slow-task executes...
 /// }


### PR DESCRIPTION
We do not have the of: parameter in the discarding version of groups

resolves rdar://147498367

