### PR TITLE
TypedThrows: fix late end_borrow in default catch

### DIFF
--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -4060,10 +4060,23 @@ void SILGenFunction::emitCatchDispatch(DoCatchStmt *S, ManagedValue exn,
       ? CastConsumptionKind::BorrowAlways
       : CastConsumptionKind::CopyOnSuccess;
 
+  // ManagedValue::borrow pushes an EndBorrow cleanup for owned object-typed
+  // values, but the returned ManagedValue does not carry the cleanup handle.
+  // Detect the new cleanup by sampling the depth before/after, so the failure
+  // path below can sequence the end_borrow before consuming `exn`.
+  std::optional<CleanupHandle> endBorrowExn;
+  ManagedValue borrowedExn;
+  {
+    auto before = Cleanups.getCleanupsDepth();
+    borrowedExn = exn.borrow(*this, S);
+    if (before != Cleanups.getCleanupsDepth())
+      endBorrowExn = Cleanups.getTopCleanup();
+  }
+
   // Our model is that sub-cases get the exception at +0 and the throw (if we
   // need to rethrow the exception) gets the exception at +1 since we need to
   // trampoline it's ownership to our caller.
-  ConsumableManagedValue subject = {exn.borrow(*this, S), consumptionKind};
+  ConsumableManagedValue subject = {borrowedExn, consumptionKind};
 
   auto failure = [&](SILLocation location) {
     // If we fail to match anything, just rethrow the exception.
@@ -4076,11 +4089,20 @@ void SILGenFunction::emitCatchDispatch(DoCatchStmt *S, ManagedValue exn,
       return;
     }
 
+    // emitThrow may consume `exn` (e.g., by storing it into an existential
+    // box during erasure) before the surrounding scope's cleanups fire,
+    // which could put an EndBorrow after the consume. Emit the end_borrow
+    // eagerly here and put the EndBorrow cleanup into a Dormant state.
+    CleanupStateRestorationScope scope(Cleanups);
+    if (endBorrowExn) {
+      B.createEndBorrow(location, borrowedExn.getValue());
+      scope.pushCleanupState(*endBorrowExn, CleanupState::Dormant);
+    }
+
     // Since we borrowed exn before sending it to our subcases, we know that it
     // must be at +1 at this point. That being said, SILGenPattern will
     // potentially invoke this for each of the catch statements, so we need to
     // copy before we pass it into the throw.
-    CleanupStateRestorationScope scope(Cleanups);
     if (exn.hasCleanup()) {
       scope.pushCleanupState(exn.getCleanup(),
                              CleanupState::PersistentlyActive);

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -185,8 +185,8 @@ func all_together_now(_ flag: Bool) -> Cat {
 // CHECK:   switch_enum [[SUBERROR]] : $HomeworkError, case #HomeworkError.TooHard!enumelt: {{bb[0-9]+}}, default [[SWITCH_MATCH_FAIL_BB:bb[0-9]+]],
 //
 // CHECK: [[SWITCH_MATCH_FAIL_BB]]([[SUBERROR:%.*]] : @owned $HomeworkError):
-// CHECK:   destroy_value [[SUBERROR]]
 // CHECK:   end_borrow [[BORROWED_ERROR]]
+// CHECK:   destroy_value [[SUBERROR]]
 // CHECK:   br [[RETHROW_BB:bb[0-9]+]]([[ERROR]] : $any Error)
 //
 // CHECK: [[CAST_NO_BB]]:
@@ -222,8 +222,8 @@ func all_together_now_two(_ flag: Bool) throws -> Cat? {
 // CHECK:   switch_enum [[SUBERROR]] : $HomeworkError, case #HomeworkError.TooHard!enumelt: {{bb[0-9]+}}, case #HomeworkError.TooMuch!enumelt: {{bb[0-9]+}}, default [[SWITCH_MATCH_FAIL_BB:bb[0-9]+]],
 //
 // CHECK: [[SWITCH_MATCH_FAIL_BB]]([[SUBERROR:%.*]] : @owned $HomeworkError):
-// CHECK:   destroy_value [[SUBERROR]]
 // CHECK:   end_borrow [[BORROWED_ERROR]]
+// CHECK:   destroy_value [[SUBERROR]]
 // CHECK:   br [[RETHROW_BB:bb[0-9]+]]([[ERROR]] : $any Error)
 //
 // CHECK: [[CAST_NO_BB]]:
@@ -272,8 +272,8 @@ func all_together_now_three(_ flag: Bool) throws -> Cat? {
 // CHECK:   br bb2([[RETVAL]] : $Optional<Cat>)
 //
 // CHECK: [[SWITCH_MATCH_FAIL_BB]]([[SUBERROR:%.*]] : @owned $HomeworkError):
-// CHECK:   destroy_value [[SUBERROR]]
 // CHECK:   end_borrow [[BORROWED_ERROR]]
+// CHECK:   destroy_value [[SUBERROR]]
 // CHECK:   br [[RETHROW_BB:bb[0-9]+]]([[ERROR]] : $any Error)
 //
 // CHECK: [[CAST_NO_BB]]:
@@ -346,19 +346,19 @@ func all_together_now_four(_ flag: Bool) throws -> Cat? {
 
 //   Catch other HomeworkErrors.
 // CHECK:    [[NO_MATCH]]([[CATCHALL_ERROR:%.*]] : @owned $HomeworkError):
+// CHECK-NEXT: end_borrow [[BORROWED_ERROR]]
 // CHECK-NEXT: destroy_value [[CATCHALL_ERROR]]
 // CHECK-NEXT: dealloc_stack [[DEST_TEMP]]
 // CHECK-NEXT: destroy_addr [[SRC_TEMP]]
 // CHECK-NEXT: dealloc_stack [[SRC_TEMP]]
-// CHECK-NEXT: end_borrow [[BORROWED_ERROR]]
 // CHECK-NEXT: br [[RETHROW:bb[0-9]+]]
 
 //   Catch other types.
 // CHECK:    [[NOT_HWE]]:
+// CHECK-NEXT: end_borrow [[BORROWED_ERROR]]
 // CHECK-NEXT: dealloc_stack [[DEST_TEMP]]
 // CHECK-NEXT: destroy_addr [[SRC_TEMP]]
 // CHECK-NEXT: dealloc_stack [[SRC_TEMP]]
-// CHECK-NEXT: end_borrow [[BORROWED_ERROR]]
 // CHECK-NEXT: br [[RETHROW]]
 
 // Rethrow

--- a/test/SILGen/typed_throws_reabstraction.swift
+++ b/test/SILGen/typed_throws_reabstraction.swift
@@ -1,4 +1,6 @@
 // RUN: %target-swift-emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-emit-sil %s -sil-verify-all > /dev/null
+
 func test2() throws { // Not OK
   // The literal closure below is in a generic error context, even though
   // it statically throws `any Error`, leading it to be emitted with an
@@ -15,7 +17,7 @@ func test2() throws { // Not OK
     // CHECK: bb{{[0-9]+}}:
     // CHECK: bb{{[0-9]+}}:
     // CHECK:      end_borrow [[ERROR_BORROW]]
-    // CHECK-NEXT: store [[ERROR]] to [init]
+    // CHECK:      store [[ERROR]] to [init]
     // CHECK-NEXT: throw_addr
 
     catch is E1 { /* ignore */ }
@@ -61,3 +63,72 @@ func test3<E: Error>(e: E) {
     throw e
   }
 }
+
+// rdar://170997361
+// Need to stop borrowing the error value earlier, if the error value is not matched by the catch's pattern.
+// In the analogy of a 'switch', it's like a 'default' case where we are throwing the original error.
+// Previously we were emitting the end_borrow after doing the consuming store into an existential box.
+enum DonutError: Error {
+    case invalidItemType
+    case validError(any Error)
+    case unknown((any Error)?)
+}
+
+func testDonutError() throws {
+    let handler: () throws(DonutError) -> String = { () throws(DonutError) in
+        throw DonutError.invalidItemType
+    }
+
+    do {
+        _ = try handler()
+    } catch DonutError.invalidItemType {
+    } catch DonutError.validError {
+      try testDonutError()
+    }
+}
+// CHECK-LABEL: sil{{.*}} @{{.*}}testDonutErroryyKF :
+// CHECK: bb{{.*}}([[ERROR:%.*]] : @owned $DonutError):
+// CHECK:   [[ERROR_BORROW:%.*]] = begin_borrow [[ERROR]]
+// CHECK:   switch_enum [[ERROR_BORROW]]
+// CHECK: bb{{.*}}({{%.*}} : @guaranteed $Optional<any Error>):
+// CHECK:   end_borrow [[ERROR_BORROW]]
+// CHECK:   store [[ERROR]]
+
+class Box {}
+enum BoxError: Error {
+  case a(Box)
+  case b(Box)
+  case c(Box)
+}
+func mightBoxThrow() throws {}
+func testRethrowFromIsAndSwitch() throws {
+  do {
+    try mightBoxThrow()
+  } catch BoxError.a {
+  }
+}
+// CHECK-LABEL: sil{{.*}} @{{.*}}testRethrowFromIsAndSwitchyyKF :
+// CHECK: bb{{.*}}([[ERROR:%.*]] : @owned $any Error):
+// CHECK:   [[ERROR_BORROW:%.*]] = begin_borrow [[ERROR]]
+// CHECK:   checked_cast_addr_br copy_on_success {{.*}}, [[CAST_SUCCESS_BB:bb[0-9]+]], [[CAST_FAIL_BB:bb[0-9]+]]
+// CHECK: [[CAST_SUCCESS_BB]]:
+// CHECK:   switch_enum {{.*}}, case #BoxError.a!enumelt: [[SWITCH_SUCCESS_BB:bb[0-9]+]], default [[SWITCH_DEFAULT_BB:bb[0-9]+]]
+
+// match success for pattern `BoxError.a`: end the borrow before the destroy
+// CHECK: [[SWITCH_SUCCESS_BB]](
+// CHECK:   end_borrow [[ERROR_BORROW]]
+// CHECK:   destroy_value [[ERROR]]
+
+// switch_enum-default block: end the borrow before re-throwing.
+// CHECK: [[SWITCH_DEFAULT_BB]](
+// CHECK:   end_borrow [[ERROR_BORROW]]
+// CHECK:   br [[RETHROW_BLOCK:bb[0-9]+]]([[ERROR]])
+
+// `is`-cast-fail block: end the borrow before re-throwing.
+// CHECK: [[CAST_FAIL_BB]]:
+// CHECK:   end_borrow [[ERROR_BORROW]]
+// CHECK:   br [[RETHROW_BLOCK]]([[ERROR]])
+
+// CHECK: [[RETHROW_BLOCK]]({{.*}} @owned $any Error):
+// CHECK-NEXT:  throw
+// CHECK: } // end sil function '$s26typed_throws_reabstraction26testRethrowFromIsAndSwitchyyKF'

--- a/validation-test/compiler_crashers_fixed/LinearLifetimeChecker-checkValueImpl-c6a49f.swift
+++ b/validation-test/compiler_crashers_fixed/LinearLifetimeChecker-checkValueImpl-c6a49f.swift
@@ -1,5 +1,5 @@
 // {"kind":"emit-silgen","original":"776b50d4","signature":"swift::LinearLifetimeChecker::checkValueImpl(swift::SILValue, llvm::ArrayRef<swift::Operand*>, llvm::ArrayRef<swift::Operand*>, swift::LinearLifetimeChecker::ErrorBuilder&, std::__1::optional<llvm::function_ref<void (swift::SILBasicBlock*)>>, std::__1::optional<llvm::function_ref<void (swift::Operand*)>>)","signatureNext":"LinearLifetimeChecker::checkValue"}
-// RUN: not --crash %target-swift-frontend -emit-silgen %s
+// RUN: %target-swift-frontend -emit-silgen %s
 enum a: Error {
   case b(String)
 }


### PR DESCRIPTION
The SILVerifier gets upset if you consume a value before ending the borrow of it:

```
%borrowOfError = begin_borrow %errorVal
switch_enum %borrowOfError, ... default bb5

bb5(...):
  store %errorVal to [init] <existential-box>
  end_borrow %borrowOfError
```

We'd end up doing that in the default case sometimes.

rdar://170997361