### PR TITLE
[Concurrency] Fix #86820 withTaskCanHan which used wrong availability

### DIFF
--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -151,7 +151,8 @@ public func withTaskCancellationHandler<Return, Failure>(
 /// as resuming a continuation, may acquire these same internal locks.
 /// Therefore, if a cancellation handler must acquire a lock, other code should
 /// not cancel tasks or resume continuations while holding that lock.
-@available(SwiftStdlib 6.0, *)
+@available(SwiftStdlib 5.1, *)
+@backDeployed(before: SwiftStdlib 6.0)
 public func withTaskCancellationHandler<T>(
   operation: () async throws -> T,
   onCancel handler: @Sendable () -> Void,


### PR DESCRIPTION
We need to keep this API for source compatibility, and it was brought back in #86820 however it used wrong availability, we need this to be 5.1+ with backdeployment as it was before

resolves rdar://171011139
