### PR TITLE
[cxx-interop] Disallow substituting with Swift functions that have inout

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2625,6 +2625,10 @@ ERROR(unable_to_convert_generic_swift_types,none,
 ERROR(unable_to_substitute_cxx_function_template,none,
       "could not substitute parameters for C++ function template '%0': %1",
       (StringRef, StringRef))
+ERROR(unable_to_substitute_cxx_template_argument_with_swift_closure_inout_param,none,
+      "could not substitute parameters for C++ function template '%0' with "
+      "Swift closure of %1 type that has an inout parameter",
+      (StringRef, Type))
 
 // Type aliases
 ERROR(type_alias_underlying_type_access,none,

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -7221,17 +7221,38 @@ swift::getModuleCachePathFromClang(const clang::CompilerInstance &Clang) {
 
 clang::FunctionDecl *ClangImporter::instantiateCXXFunctionTemplate(
     ASTContext &ctx, clang::FunctionTemplateDecl *func, SubstitutionMap subst) {
-  SmallVector<clang::TemplateArgument, 4> templateSubst;
-  std::unique_ptr<TemplateInstantiationError> error =
-      ctx.getClangTemplateArguments(func->getTemplateParameters(),
-                                    subst.getReplacementTypes(), templateSubst);
-
   auto getFuncName = [&]() -> std::string {
     std::string funcName;
     llvm::raw_string_ostream funcNameStream(funcName);
     func->printQualifiedName(funcNameStream);
     return funcName;
   };
+
+  for (auto type : subst.getReplacementTypes()) {
+    const auto *funcType = type->getAs<AnyFunctionType>();
+    if (!funcType)
+      continue;
+
+    // Disallow substituting template params with Swift functions that have
+    // inout params, since they cannot be lowered in SILGen.
+    bool hasInOutParam =
+        llvm::any_of(funcType->getParams(),
+                     [](const auto &param) { return param.isInOut(); });
+    if (hasInOutParam) {
+      // TODO: Use the location of the apply here.
+      Impl.diagnose(
+          HeaderLoc(func->getBeginLoc()),
+          diag::
+              unable_to_substitute_cxx_template_argument_with_swift_closure_inout_param,
+          getFuncName(), type);
+      return nullptr;
+    }
+  }
+
+  SmallVector<clang::TemplateArgument, 4> templateSubst;
+  std::unique_ptr<TemplateInstantiationError> error =
+      ctx.getClangTemplateArguments(func->getTemplateParameters(),
+                                    subst.getReplacementTypes(), templateSubst);
 
   if (error) {
     std::string failedTypesStr;

--- a/test/Interop/Cxx/templates/function-template-typecheck.swift
+++ b/test/Interop/Cxx/templates/function-template-typecheck.swift
@@ -1,0 +1,86 @@
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -typecheck -verify -suppress-remarks -suppress-notes \
+// RUN:     -cxx-interoperability-mode=default \
+// RUN:     -I %t%{fs-sep}Inputs %t%{fs-sep}main.swift \
+// RUN:     -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}header.h
+
+//--- Inputs/module.modulemap
+module CxxHeader {
+    header "header.h"
+    requires cplusplus
+}
+
+//--- Inputs/header.h
+#pragma once
+
+// TODO: the following diagnostics should be moved to main.swift at the call site
+//       that triggers the instantiation (see static-cast-typecheck.swift)
+// expected-error@+2{{could not substitute parameters for C++ function template 'funcTempl' with Swift closure of '(inout Int32) -> ()' type that has an inout parameter}}
+// expected-error@+1{{could not substitute parameters for C++ function template 'funcTempl' with Swift closure of '(Int32, inout Int32) -> ()' type that has an inout parameter}}
+template <class T> void funcTempl(T value) { }
+
+// expected-error@+2 2{{could not substitute parameters for C++ function template 'funcTempl2' with Swift closure of '(inout Int32) -> ()' type that has an inout parameter}}
+// expected-error@+1 2{{could not substitute parameters for C++ function template 'funcTempl2' with Swift closure of '(Int32, inout Int32) -> ()' type that has an inout parameter}}
+template <class T, class U> void funcTempl2(T t, U u) { }
+
+// expected-error@+1 {{could not substitute parameters for C++ function template 'funcTemplAndIntRef' with Swift closure of '(inout Int32) -> ()' type that has an inout parameter}}
+template <class T> void funcTemplAndIntRef(T value, int &ref) { }
+
+int get42(void) { return 42; }
+
+//--- main.swift
+import CxxHeader
+
+func takesTrue() { funcTempl(true) }
+func takesBool(x: Bool) { funcTempl(x) }
+
+var x: Int32 = 1
+var y: Int32 = 2
+
+// OK: () -> ()
+func takesRecursively() { funcTempl(takesRecursively) }
+func takesRecursiveClosure() { funcTempl({() in takesRecursiveClosure()}) }
+func takesSwiftClosure() { funcTempl({() in ()}) }
+func takesTakesTrue() { funcTempl(takesTrue) }
+
+// OK: () -> Bool
+func takesSwiftClosureReturningBool() { funcTempl({() -> Bool in true}) }
+// OK: (Bool) -> ()
+func takesSwiftClosureTakingBool() { funcTempl({(x: Bool) in ()}) }
+func takesTakesBool() { funcTempl(takesBool) }
+
+// OK: (Int32, Int32) -> Int32
+func add(_ a: Int32, _ b: Int32) -> Int32 { return a + b }
+funcTempl(add)
+
+// OK: C++ func
+funcTempl(get42)
+
+// OK: (Int32, Int32) -> Int32 & C++ func
+funcTempl2(add, get42)
+funcTempl2(get42, add)
+
+// BAD: (inout Int32) -> ()
+func inoutFoo(_ a : inout Int32) { a += 1 }
+funcTempl(inoutFoo)
+
+// BAD: (Int32, inout Int32) -> ()
+func inoutBar(_ a: Int32, _ b : inout Int32) { b += 1 }
+funcTempl(inoutBar)
+
+// BAD: (Int32, Int32) -> Int32 & (inout Int32) -> ()
+funcTempl2(add, inoutFoo)
+funcTempl2(inoutFoo, add)
+
+// BAD: (Int32, Int32) -> Int32 & (Int32, inout Int32) -> ()
+funcTempl2(add, inoutBar)
+funcTempl2(inoutBar, add)
+
+// OK: Int32 & inout Int32
+funcTemplAndIntRef(x, &y)
+
+// OK: () -> () & inout Int32
+funcTemplAndIntRef({() in ()}, &x)
+
+// BAD: (inout Int32) -> () & inout Int32
+funcTemplAndIntRef(inoutFoo, &x)


### PR DESCRIPTION
Substituting C++ function template parameters with Swift functions that
have inout parameters causes an assertion failure in SILGen, because
inout parameters cannot be lowered in a bridging thunk. Disallow
substituting template parameters with such Swift functions.

rdar://166628039
