### PR TITLE
[Parse] Add fix-it for computed_property_missing_type with non-observing accessors

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -8051,6 +8051,13 @@ struct Parser::ParsedAccessors {
         func(accessor);
   }
 
+  bool hasAccessorRequiringExplicitType() const {
+    return llvm::any_of(Accessors, [](AccessorDecl *accessor) {
+      return !accessor->isObservingAccessor() &&
+             accessor->getAccessorKind() != AccessorKind::Init;
+    });
+  }
+
   /// Find the first accessor that can be used to perform mutation.
   AccessorDecl *findFirstMutator() const {
     if (Init) return Init;
@@ -8664,12 +8671,11 @@ Parser::parseDeclVarGetSet(PatternBindingEntry &entry, ParseDeclOptions Flags,
     return nullptr;
 
   if (!typedPattern) {
-    if (accessors.Get || accessors.Set || accessors.Address ||
-        accessors.MutableAddress) {
+    if (accessors.hasAccessorRequiringExplicitType()) {
       SourceLoc locAfterPattern = pattern->getLoc().getAdvancedLoc(
         pattern->getBoundName().getLength());
       diagnose(pattern->getLoc(), diag::computed_property_missing_type)
-        .fixItInsert(locAfterPattern, ": <# Type #>");
+          .fixItInsert(locAfterPattern, ": <# Type #>");
       Invalid = true;
     }
   }

--- a/test/Parse/computed_property_missing_type_fixit.swift
+++ b/test/Parse/computed_property_missing_type_fixit.swift
@@ -1,0 +1,9 @@
+// RUN: %target-typecheck-verify-swift
+
+func localComputedPropertyMissingType() {
+  var int {} // expected-error {{computed property must have an explicit type}} {{10-10=: <# Type #>}} expected-error {{type annotation missing in pattern}}
+}
+
+var x { // expected-error {{computed property must have an explicit type}} {{6-6=: <# Type #>}} expected-error {{type annotation missing in pattern}}
+  _read {}
+}


### PR DESCRIPTION
Fixes #87324

## Summary
This change makes the parser emit the existing `: <# Type #>` insertion fix-it whenever `computed_property_missing_type` is diagnosed for computed properties that use non-observing accessors beyond the previously hard-coded subset.

Specifically:
- Adds a small helper in `ParsedAccessors` to detect accessors that require an explicit type annotation.
- Uses that helper at the `computed_property_missing_type` diagnostic site.
- Keeps `init` accessors excluded from this check to preserve existing behavior for init-accessor diagnostics.

## Test
- Adds `test/Parse/computed_property_missing_type_fixit.swift` with:
  - local reproduction `var int {}`
  - `_read` accessor coverage
