### PR TITLE
[Backtracing] Fix cross platform symbolication.

### DIFF
--- a/stdlib/public/RuntimeModule/Backtrace.swift
+++ b/stdlib/public/RuntimeModule/Backtrace.swift
@@ -363,7 +363,6 @@ public struct Backtrace: CustomStringConvertible, Sendable {
     -> SymbolicatedBacktrace? {
     return symbolicated(with: images,
                         platform: .default,
-                        alternativeSymbolFilePaths: [],
                         options: options)
   }
 
@@ -385,15 +384,17 @@ public struct Backtrace: CustomStringConvertible, Sendable {
   @_spi(Internal)
   public func symbolicated(with images: ImageMap? = nil,
                            platform: SymbolicationPlatform,
-                           alternativeSymbolFilePaths: [String],
-                           options: SymbolicationOptions = .default)
+                           options: SymbolicationOptions = .default,
+                           symbolLocator: SymbolLocator =
+                            DefaultSymbolLocator.shared,
+                           )
     -> SymbolicatedBacktrace? {
     return SymbolicatedBacktrace.symbolicate(
       backtrace: self,
       images: images,
       platform: platform,
-      alternativeSymbolFilePaths: alternativeSymbolFilePaths,
-      options: options
+      options: options,
+      symbolLocator: symbolLocator
     )
   }
 

--- a/stdlib/public/RuntimeModule/CrashLog.swift
+++ b/stdlib/public/RuntimeModule/CrashLog.swift
@@ -442,8 +442,9 @@ extension CrashLog {
     public mutating func symbolicate(
         allThreads: Bool = false,
         platform: Backtrace.SymbolicationPlatform,
-        alternativeSymbolFilePaths: [String],
-        options: Backtrace.SymbolicationOptions = .default) {
+        options: Backtrace.SymbolicationOptions = .default,
+        symbolLocator: SymbolLocator = DefaultSymbolLocator.shared
+        ) {
 
         let images = imageMap()
 
@@ -454,8 +455,9 @@ extension CrashLog {
             if let symbolicatedBacktrace = backtrace.symbolicated(
                 with: images,
                 platform: platform,
-                alternativeSymbolFilePaths: alternativeSymbolFilePaths,
-                options: options) {
+                options: options,
+                symbolLocator: symbolLocator
+                ) {
 
                 thread.updateWithBacktrace(symbolicatedBacktrace: symbolicatedBacktrace)
             }

--- a/stdlib/public/RuntimeModule/DefaultSymbolLocator.swift
+++ b/stdlib/public/RuntimeModule/DefaultSymbolLocator.swift
@@ -287,7 +287,7 @@ open class DefaultSymbolLocator: SymbolLocator {
       image: image,
       uuid: uuid,
       age: age,
-      paths: findPeCoffSymbolPaths(image: image)) {
+      paths: findImagePaths(image: image)) {
 
       peImage = peCoff.result
     } else {

--- a/stdlib/public/RuntimeModule/DefaultSymbolLocator.swift
+++ b/stdlib/public/RuntimeModule/DefaultSymbolLocator.swift
@@ -55,29 +55,59 @@ public class DefaultSymbolLocator: SymbolLocator {
 
   var cache: [CacheKey: any SymbolSource] = [:]
 
-  private func findSymbolsForElf(image: any Image) -> (any SymbolSource)? {
-    func loadElfImage(path: String, uuid: [UInt8]?) -> ElfImageCache.Result? {
-      let elfCache = ElfImageCache.threadLocal
+  private func loadElfImage(path: String, uuid: [UInt8]?) -> ElfImageCache.Result? {
+    let elfCache = ElfImageCache.threadLocal
 
-      guard let result = elfCache.lookup(path: path) else {
-        return nil
-      }
-
-      switch result {
-        case let .elf32Image(elfImage):
-          if elfImage.uuid != uuid {
-            return nil
-          }
-
-        case let .elf64Image(elfImage):
-          if elfImage.uuid != uuid {
-            return nil
-          }
-      }
-
-      return result
+    guard let result = elfCache.lookup(path: path) else {
+      return nil
     }
 
+    switch result {
+      case let .elf32Image(elfImage):
+        if elfImage.uuid != uuid {
+          return nil
+        }
+
+      case let .elf64Image(elfImage):
+        if elfImage.uuid != uuid {
+          return nil
+        }
+    }
+
+    return result
+  }
+
+  private func loadPeCoffImage(
+    path: String, uuid: [UInt8]?, age: UInt32?
+  ) -> PeCoffImage? {
+    let peCache = PeImageCache.threadLocal
+
+    guard let peImage = peCache.lookup(path: path) else {
+      return nil
+    }
+
+    if let codeview = peImage.codeview,
+        let uuid,
+        let age,
+        codeview.uuid != uuid
+          || codeview.age != age {
+      return nil
+    }
+    return peImage
+  }
+
+  private func elfDebugSymPath(for image: any Image) -> String? {
+    guard let uuid = image.uuid else {
+      return nil
+    }
+
+    let uuidString = hex(uuid)
+    let uuidSuffix = uuidString.dropFirst(2)
+    let uuidPrefix = uuidString.prefix(2)
+    return "\(elfSymbolPath)\(sep)\(uuidPrefix)\(sep)\(uuidSuffix).debug"
+  }
+
+  private func findSymbolsForElf(image: any Image) -> (any SymbolSource)? {
     func toSymbolSource(_ result: ElfImageCache.Result) -> (any SymbolSource)? {
       switch result {
         case let .elf32Image(elfImage):
@@ -98,22 +128,8 @@ public class DefaultSymbolLocator: SymbolLocator {
       return source
     }
 
-    // Now try finding it using the UUID
-    if let uuid = image.uuid {
-      let uuidString = hex(uuid)
-      let uuidSuffix = uuidString.dropFirst(2)
-      let uuidPrefix = uuidString.prefix(2)
-      let path = "\(elfSymbolPath)\(sep)\(uuidPrefix)\(sep)\(uuidSuffix).debug"
-      if let result = loadElfImage(path: path, uuid: image.uuid) {
-        let source = toSymbolSource(result)
-        cache[.uuid(uuid)] = source
-        return source
-      }
-    }
-
     // We must be able to load the original image (as an ELF image)
-    guard let imagePath = find(image: image),
-          let result = loadElfImage(path: imagePath, uuid: image.uuid) else {
+    guard let (imagePath, result) = findElf(image: image) else {
       return nil
     }
 
@@ -134,17 +150,17 @@ public class DefaultSymbolLocator: SymbolLocator {
 
       let tryLink = { (_ link: String) -> (any SymbolSource)? in
         let path1 = "\(imageDir)\(sep)\(link)"
-        if let result = loadElfImage(path: path1, uuid: image.uuid) {
+        if let result = self.loadElfImage(path: path1, uuid: image.uuid) {
           return toSymbolSource(result)
         }
 
         let path2 = "\(imageDir)\(sep).debug\(sep)\(link)"
-        if let result = loadElfImage(path: path2, uuid: image.uuid) {
+        if let result = self.loadElfImage(path: path2, uuid: image.uuid) {
           return toSymbolSource(result)
         }
 
         let path3 = "\(elfSymbolPath)\(sep)\(imageDir)\(sep)\(link)"
-        if let result = loadElfImage(path: path3, uuid: image.uuid) {
+        if let result = self.loadElfImage(path: path3, uuid: image.uuid) {
           return toSymbolSource(result)
         }
 
@@ -220,25 +236,6 @@ public class DefaultSymbolLocator: SymbolLocator {
 
   private func findSymbolsForPeCoff(image: any Image) -> (any SymbolSource)? {
     var result: (any SymbolSource)? = nil
-
-    func loadPeCoffImage(
-      path: String, uuid: [UInt8]?, age: UInt32?
-    ) -> PeCoffImage? {
-      let peCache = PeImageCache.threadLocal
-
-      guard let peImage = peCache.lookup(path: path) else {
-        return nil
-      }
-
-      if let codeview = peImage.codeview,
-         let uuid,
-         let age,
-         codeview.uuid != uuid
-           || codeview.age != age {
-        return nil
-      }
-      return peImage
-    }
 
     let uuid: [UInt8]?
     let age: UInt32?
@@ -390,40 +387,45 @@ public class DefaultSymbolLocator: SymbolLocator {
     return nil
   }
 
+  private func findElf(image: any Image) ->
+    (path: String, result: ElfImageCache.Result)? {
+
+    // check the debug/symbols path first
+    if let debugSymPath = elfDebugSymPath(for: image),
+      let result = loadElfImage(path: debugSymPath, uuid: image.uuid) {
+      return (debugSymPath,result)
+    }
+
+    // then the image path specified in the Image
+    if let imagePath = image.path,
+        let result = loadElfImage(path: imagePath, uuid: image.uuid) {
+      return (imagePath,result)
+    }
+
+    return nil
+  }
+
+  private func findPeCoff(image: any Image) ->
+    (path: String, result: PeCoffImage)? {
+
+    if let imagePath = image.path, let peCoff = loadPeCoffImage(
+      path: imagePath,
+      uuid: image.uuid,
+      age: image.age) {
+
+      return (imagePath, peCoff)
+    }
+
+    return nil
+  }
+
   public func find(image: any Image) -> String? {
-    let elfCache = ElfImageCache.threadLocal
-    let peCache = PeImageCache.threadLocal
-
-    guard let imagePath = image.path else {
-      return nil
+    if let elfImageInfo = findElf(image: image) {
+      return elfImageInfo.path
     }
 
-    if let result = elfCache.lookup(path: imagePath) {
-      switch result {
-        case let .elf32Image(elfImage):
-          if elfImage.uuid != image.uuid {
-            return nil
-          }
-
-        case let .elf64Image(elfImage):
-          if elfImage.uuid != image.uuid {
-            return nil
-          }
-      }
-
-      return imagePath
-    }
-
-    if let peImage = peCache.lookup(path: imagePath) {
-      if let codeview = peImage.codeview,
-         let uuid = image.uuid,
-         let age = image.age,
-         codeview.uuid != uuid
-           || codeview.age != age {
-        return nil
-      }
-
-      return imagePath
+    if let peCoffImageInfo = findPeCoff(image: image) {
+      return peCoffImageInfo.path
     }
 
     return nil

--- a/stdlib/public/RuntimeModule/DefaultSymbolLocator.swift
+++ b/stdlib/public/RuntimeModule/DefaultSymbolLocator.swift
@@ -158,19 +158,19 @@ open class DefaultSymbolLocator: SymbolLocator {
           debugAltLink = elfImage.getDebugAltLink()?.link
       }
 
-      let tryLink = { (_ link: String) -> (any SymbolSource)? in
+      let tryLink = { [self] (_ link: String) -> (any SymbolSource)? in
         let path1 = "\(imageDir)\(sep)\(link)"
-        if let result = self.loadElfImage(path: path1, uuid: image.uuid) {
+        if let result = loadElfImage(path: path1, uuid: image.uuid) {
           return toSymbolSource(result)
         }
 
         let path2 = "\(imageDir)\(sep).debug\(sep)\(link)"
-        if let result = self.loadElfImage(path: path2, uuid: image.uuid) {
+        if let result = loadElfImage(path: path2, uuid: image.uuid) {
           return toSymbolSource(result)
         }
 
         let path3 = "\(elfSymbolPath)\(sep)\(imageDir)\(sep)\(link)"
-        if let result = self.loadElfImage(path: path3, uuid: image.uuid) {
+        if let result = loadElfImage(path: path3, uuid: image.uuid) {
           return toSymbolSource(result)
         }
 

--- a/stdlib/public/RuntimeModule/DefaultSymbolLocator.swift
+++ b/stdlib/public/RuntimeModule/DefaultSymbolLocator.swift
@@ -130,9 +130,16 @@ open class DefaultSymbolLocator: SymbolLocator {
       return source
     }
 
+    if let uuid = image.uuid, let (imagePath, result) =
+      findElf(image: image, paths: findElfSymbolPaths(image: image)) {
+      let source = toSymbolSource(result)
+      cache[.uuid(uuid)] = source
+      return source
+    }
+
     // We must be able to load the original image (as an ELF image)
     guard let (imagePath, result) =
-      findElf(image: image, paths: findSymbolPaths(image: image)) else {
+      findElf(image: image, paths: findImagePaths(image: image)) else {
       return nil
     }
 
@@ -276,8 +283,13 @@ open class DefaultSymbolLocator: SymbolLocator {
 
     // See if we can load the image
     let peImage: PeCoffImage?
-    if let path = find(image: image) {
-      peImage = loadPeCoffImage(path: path, uuid: uuid, age: age)
+    if let peCoff = findPeCoff(
+      image: image,
+      uuid: uuid,
+      age: age,
+      paths: findPeCoffSymbolPaths(image: image)) {
+
+      peImage = peCoff.result
     } else {
       peImage = nil
     }
@@ -391,13 +403,27 @@ open class DefaultSymbolLocator: SymbolLocator {
   }
 
   open func findImagePaths(image: any Image) -> [String] {
-    [image.path]
-    .compactMap { $0 }
+    guard let imagePath = image.path else {
+      return []
+    }
+
+    return [imagePath]
   }
 
-  open func findSymbolPaths(image: any Image) -> [String] {
-    [elfDebugSymPath(for: image), image.path]
-    .compactMap { $0 }
+  open func findElfSymbolPaths(image: any Image) -> [String] {
+    guard let symbolPath = elfDebugSymPath(for: image) else {
+      return []
+    }
+
+    return [symbolPath]
+  }
+
+  open func findPeCoffSymbolPaths(image: any Image) -> [String] {
+    guard let imagePath = image.path else {
+      return []
+    }
+
+    return [imagePath]
   }
 
   private func findElf(image: any Image, paths: [String]) ->
@@ -412,15 +438,21 @@ open class DefaultSymbolLocator: SymbolLocator {
     return nil
   }
 
-  private func findPeCoff(image: any Image) ->
+  private func findPeCoff(
+    image: any Image,
+    uuid: [UInt8]?,
+    age: UInt32?,
+    paths: [String]) ->
     (path: String, result: PeCoffImage)? {
 
-    if let imagePath = image.path, let peCoff = loadPeCoffImage(
-      path: imagePath,
-      uuid: image.uuid,
-      age: image.age) {
+    for path in paths {
+      if let peCoff = loadPeCoffImage(
+        path: path,
+        uuid: uuid,
+        age: age) {
 
-      return (imagePath, peCoff)
+        return (path, peCoff)
+      }
     }
 
     return nil
@@ -434,7 +466,12 @@ open class DefaultSymbolLocator: SymbolLocator {
       return elfImageInfo.path
     }
 
-    if let peCoffImageInfo = findPeCoff(image: image) {
+    if let peCoffImageInfo = findPeCoff(
+      image: image,
+      uuid: image.uuid,
+      age: image.age,
+      paths: findImagePaths(image: image)) {
+
       return peCoffImageInfo.path
     }
 

--- a/stdlib/public/RuntimeModule/DefaultSymbolLocator.swift
+++ b/stdlib/public/RuntimeModule/DefaultSymbolLocator.swift
@@ -40,7 +40,9 @@ fileprivate let elfSymbolPath = "\(symbolPath)/.build-id"
 #endif
 
 @_spi(SymbolLocation)
-public class DefaultSymbolLocator: SymbolLocator {
+open class DefaultSymbolLocator: SymbolLocator {
+
+  public init() {}
 
   public typealias Image = SymbolLocator.Image
   public typealias ImageFormat = SymbolLocator.ImageFormat
@@ -129,7 +131,8 @@ public class DefaultSymbolLocator: SymbolLocator {
     }
 
     // We must be able to load the original image (as an ELF image)
-    guard let (imagePath, result) = findElf(image: image) else {
+    guard let (imagePath, result) =
+      findElf(image: image, paths: findSymbolPaths(image: image)) else {
       return nil
     }
 
@@ -387,19 +390,23 @@ public class DefaultSymbolLocator: SymbolLocator {
     return nil
   }
 
-  private func findElf(image: any Image) ->
+  open func findImagePaths(image: any Image) -> [String] {
+    [image.path]
+    .compactMap { $0 }
+  }
+
+  open func findSymbolPaths(image: any Image) -> [String] {
+    [elfDebugSymPath(for: image), image.path]
+    .compactMap { $0 }
+  }
+
+  private func findElf(image: any Image, paths: [String]) ->
     (path: String, result: ElfImageCache.Result)? {
 
-    // check the debug/symbols path first
-    if let debugSymPath = elfDebugSymPath(for: image),
-      let result = loadElfImage(path: debugSymPath, uuid: image.uuid) {
-      return (debugSymPath,result)
-    }
-
-    // then the image path specified in the Image
-    if let imagePath = image.path,
-        let result = loadElfImage(path: imagePath, uuid: image.uuid) {
-      return (imagePath,result)
+    for path in paths {
+      if let result = loadElfImage(path: path, uuid: image.uuid) {
+        return (path,result)
+      }
     }
 
     return nil
@@ -420,7 +427,10 @@ public class DefaultSymbolLocator: SymbolLocator {
   }
 
   public func find(image: any Image) -> String? {
-    if let elfImageInfo = findElf(image: image) {
+    if let elfImageInfo = findElf(
+      image: image,
+      paths: findImagePaths(image: image)) {
+
       return elfImageInfo.path
     }
 

--- a/stdlib/public/RuntimeModule/SymbolicatedBacktrace.swift
+++ b/stdlib/public/RuntimeModule/SymbolicatedBacktrace.swift
@@ -434,7 +434,6 @@ public struct SymbolicatedBacktrace: CustomStringConvertible {
     backtrace: Backtrace,
     images: ImageMap?,
     platform symbolicationPlatform: Backtrace.SymbolicationPlatform,
-    alternativeSymbolFilePaths: [String],
     options: Backtrace.SymbolicationOptions,
     symbolLocator: SymbolLocator = DefaultSymbolLocator.shared
   ) -> SymbolicatedBacktrace? {

--- a/stdlib/public/RuntimeModule/modules/ImageFormats/PeCoff/pe-coff.h
+++ b/stdlib/public/RuntimeModule/modules/ImageFormats/PeCoff/pe-coff.h
@@ -24,6 +24,8 @@
 
 #include <inttypes.h>
 
+#pragma pack(push, 1)
+
 namespace swift {
 namespace runtime {
 
@@ -408,6 +410,8 @@ struct pe_symbol {
 
 } // namespace runtime
 } // namespace swift
+
+#pragma pack(pop)
 
 #endif // SWIFT_PE_COFF_H_
 

--- a/stdlib/public/RuntimeModule/modules/ImageFormats/PeCoff/pe-coff.h
+++ b/stdlib/public/RuntimeModule/modules/ImageFormats/PeCoff/pe-coff.h
@@ -24,8 +24,6 @@
 
 #include <inttypes.h>
 
-#pragma pack(push, 1)
-
 namespace swift {
 namespace runtime {
 
@@ -410,8 +408,6 @@ struct pe_symbol {
 
 } // namespace runtime
 } // namespace swift
-
-#pragma pack(pop)
 
 #endif // SWIFT_PE_COFF_H_
 


### PR DESCRIPTION
Refactoring to remove an accidental dependency on the hard coded image paths in crash logs. This was causing problems for cross platform offline symbolication.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
