### PR TITLE
Test: flaky bad-generated-filenames.swift

### DIFF
--- a/test/diagnostics/bad-generated-filenames.swift
+++ b/test/diagnostics/bad-generated-filenames.swift
@@ -1,3 +1,7 @@
+// This test is flaky, occasionally crashing in `c-index-test`.
+// rdar://168250323
+// ALLOW_RETRIES: 5
+
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t/SlashA.swiftmodule %S/Inputs/slash.swift
 // RUN: %target-swift-frontend -emit-module -o %t/SlashB.swiftmodule %S/Inputs/slash.swift


### PR DESCRIPTION
Adding the 'ALLOW_RETRIES` to
`diagnostics/bad-generated-filenames.swift`

There is an occasional assertion failure in `c-index-test` that I suspect is related to recent changes in the FileManager related to filenames:

```
Assertion failed: (DirInfo &&
  "The directory of a virtual file should already be in the cache.")
```

This is happening in `getVirtualFileRef` in
`llvm-project/clang/lib/Basic/FileManager.cpp` on line 419.

https://github.com/swiftlang/llvm-project/blob/cb7976f735018074787ce9b86040c081bb568b93/clang/lib/Basic/FileManager.cpp#L418-L419