### PR TITLE
[Literal Expressions][WIP] Lift restriction to have integer-value generic arguments be parenthesized

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -291,6 +291,8 @@ SUPPRESSIBLE_LANGUAGE_FEATURE(CAttribute, 495, "@c attribute")
 
 BASELINE_LANGUAGE_FEATURE(AnyAppleOSAvailability, 0, "Support `anyAppleOS` availability")
 
+BASELINE_LANGUAGE_FEATURE(LiteralExpressions, 0, "Support unparenthesized literal expressions")
+
 //===----------------------------------------------------------------------===//
 // MARK: - Swift 6 features
 //===----------------------------------------------------------------------===//
@@ -550,9 +552,6 @@ EXPERIMENTAL_FEATURE(CompileTimeValues, true)
 /// Allow declaration of compile-time values bypassing
 /// syntactic legality checking
 EXPERIMENTAL_FEATURE(CompileTimeValuesPreview, false)
-
-/// Allow use of literal expressions as literals
-EXPERIMENTAL_FEATURE(LiteralExpressions, true)
 
 /// Allow function body macros applied to closures.
 EXPERIMENTAL_FEATURE(ClosureBodyMacro, true)

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -625,6 +625,9 @@ public:
   /// composition.
   SourceLoc skipUntilGreaterInTypeList(bool protocolComposition = false);
 
+  void skipUntilGreaterOrComma();
+  bool skipUntilOfOrEndOfLine();
+
   /// skipUntilDeclStmtRBrace - Skip to the next decl or '}'.
   void skipUntilDeclRBrace();
 
@@ -1415,10 +1418,10 @@ public:
   ParserResult<TypeRepr> parseTypeSimple(
       Diag<> MessageID, ParseTypeReason reason);
 
-  ParserResult<TypeRepr> parseTypeOrValue();
+  ParserResult<TypeRepr> parseGenericArgument();
   ParserResult<TypeRepr>
-  parseTypeOrValue(Diag<> MessageID,
-                   ParseTypeReason reason = ParseTypeReason::Unspecified);
+  parseGenericArgument(Diag<> MessageID,
+                       ParseTypeReason reason = ParseTypeReason::Unspecified);
 
   /// Parse layout constraint.
   LayoutConstraint parseLayoutConstraint(Identifier LayoutConstraintID);
@@ -1739,7 +1742,7 @@ public:
   /// generic parameter list. If the parse fails, or the closing '>' is not
   /// followed by one of the above tokens, then this function returns false,
   /// and the expression will parse with the '<' as an operator.
-  bool canParseAsGenericArgumentList();
+  bool canParseAsGenericArgumentList(bool isGenericArgTypeExpr = false);
 
   bool canParseTypeSimple();
   bool canParseTypeSimpleOrComposition();
@@ -1793,15 +1796,21 @@ public:
   ParserResult<Expr> parseExprArrow();
   ParserResult<Expr> parseExprSequence(Diag<> ID,
                                        bool isExprBasic,
-                                       bool isForConditionalDirective = false);
+                                       bool isForConditionalDirective,
+                                       bool isGenericArgTypeExpr);
   ParserResult<Expr> parseExprSequenceElement(Diag<> ID,
-                                              bool isExprBasic);
+                                              bool isExprBasic,
+                                              bool isGenericArgTypeExpr);
   ParserResult<Expr> parseExprPostfixSuffix(ParserResult<Expr> inner,
                                             bool isExprBasic,
-                                            bool periodHasKeyPathBehavior);
-  ParserResult<Expr> parseExprPostfix(Diag<> ID, bool isExprBasic);
-  ParserResult<Expr> parseExprPrimary(Diag<> ID, bool isExprBasic);
-  ParserResult<Expr> parseExprUnary(Diag<> ID, bool isExprBasic);
+                                            bool periodHasKeyPathBehavior,
+                                            bool isGenericArgTypeExpr);
+  ParserResult<Expr> parseExprPostfix(Diag<> ID, bool isExprBasic,
+                                      bool isGenericArgTypeExpr);
+  ParserResult<Expr> parseExprPrimary(Diag<> ID, bool isExprBasic,
+                                      bool isGenericArgTypeExpr = false);
+  ParserResult<Expr> parseExprUnary(Diag<> ID, bool isExprBasic,
+                                    bool isGenericArgTypeExpr);
   ParserResult<Expr> parseExprKeyPathObjC();
   ParserResult<Expr> parseExprKeyPath();
   ParserResult<Expr> parseExprSelector();
@@ -1910,7 +1919,8 @@ public:
       DiagRef diag);
 
   ParserResult<Expr> parseExprIdentifier(bool allowKeyword,
-                                         bool allowModuleSelector = true);
+                                         bool allowModuleSelector = true,
+                                         bool isGenericArgTypeExpr = false);
   Expr *parseExprEditorPlaceholder(Token PlaceholderTok,
                                    Identifier PlaceholderId);
 
@@ -2084,6 +2094,8 @@ public:
   ParserStatus
   parseProtocolOrAssociatedTypeWhereClause(TrailingWhereClause *&trailingWhere,
                                            bool isProtocol);
+
+  bool isGenericArgumentExpressionDelimiter();
 
   //===--------------------------------------------------------------------===//
   // Availability Specification Parsing

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -427,7 +427,6 @@ static bool usesFeatureBuiltinAddTaskLocalValue(Decl *decl) {
 }
 
 UNINTERESTING_FEATURE(CompileTimeValuesPreview)
-UNINTERESTING_FEATURE(LiteralExpressions)
 UNINTERESTING_FEATURE(StrictMemorySafety)
 UNINTERESTING_FEATURE(LibraryEvolution)
 UNINTERESTING_FEATURE(SafeInteropWrappers)

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4144,7 +4144,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
         return makeParserSuccess();
       }
      
-      auto countType = parseTypeOrValue(diag::expected_type);
+      auto countType = parseGenericArgument(diag::expected_type);
       if (countType.isNull()) {
         return makeParserSuccess();
       }

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -63,7 +63,8 @@ ParserResult<Expr> Parser::parseExprImpl(Diag<> Message, bool isExprBasic) {
   }
 
   return parseExprSequence(Message, isExprBasic,
-                                /*forConditionalDirective*/false);
+                                /*forConditionalDirective*/false,
+                                /*isGenericArg*/false);
 }
 
 /// parseExprIs
@@ -190,7 +191,8 @@ ParserResult<Expr> Parser::parseExprArrow() {
 /// apply to everything to its right.
 ParserResult<Expr> Parser::parseExprSequence(Diag<> Message,
                                              bool isExprBasic,
-                                             bool isForConditionalDirective) {
+                                             bool isForConditionalDirective,
+                                             bool isGenericArgTypeExpr) {
   SmallVector<Expr*, 8> SequencedExprs;
   SourceLoc startLoc = Tok.getLoc();
   ParserStatus SequenceStatus;
@@ -201,7 +203,7 @@ ParserResult<Expr> Parser::parseExprSequence(Diag<> Message,
 
     // Parse a unary expression.
     ParserResult<Expr> Primary =
-      parseExprSequenceElement(Message, isExprBasic);
+      parseExprSequenceElement(Message, isExprBasic, isGenericArgTypeExpr);
     SequenceStatus |= Primary;
 
     if (SequenceStatus.hasCodeCompletion() && CodeCompletionCallbacks)
@@ -221,7 +223,9 @@ ParserResult<Expr> Parser::parseExprSequence(Diag<> Message,
 
     if (isForConditionalDirective && Tok.isAtStartOfLine())
       break;
-    
+
+    if (isGenericArgTypeExpr && isGenericArgumentExpressionDelimiter())
+      break;
 parse_operator:
     switch (Tok.getKind()) {
     case tok::oper_binary_spaced:
@@ -256,7 +260,8 @@ parse_operator:
       
       // Parse the middle expression of the ternary.
       ParserResult<Expr> middle = parseExprSequence(
-          diag::expected_expr_after_ternary_question, isExprBasic);
+          diag::expected_expr_after_ternary_question, isExprBasic,
+                                                    false, false);
       SequenceStatus |= middle;
       ParserStatus Status = middle;
       if (middle.isNull())
@@ -393,7 +398,8 @@ done:
 /// 'try' is not actually allowed at an arbitrary position of a
 /// sequence, but this isn't enforced until sequence-folding.
 ParserResult<Expr> Parser::parseExprSequenceElement(Diag<> message,
-                                                    bool isExprBasic) {
+                                                    bool isExprBasic,
+                                                    bool isGenericArgTypeExpr) {
   // Check whether the user mistyped "async" for "await", but only in cases
   // where we are sure that "async" would be ill-formed as an identifier.
   bool isReplaceableAsync = Tok.isContextualKeyword("async") &&
@@ -408,7 +414,7 @@ ParserResult<Expr> Parser::parseExprSequenceElement(Diag<> message,
     Tok.setKind(tok::contextual_keyword);
     SourceLoc awaitLoc = consumeToken();
     ParserResult<Expr> sub =
-      parseExprSequenceElement(diag::expected_expr_after_await, isExprBasic);
+      parseExprSequenceElement(diag::expected_expr_after_await, isExprBasic, isGenericArgTypeExpr);
     if (!sub.hasCodeCompletion() && !sub.isNull()) {
       if (auto anyTry = dyn_cast<AnyTryExpr>(sub.get())) {
         // "try" must precede "await".
@@ -436,7 +442,7 @@ ParserResult<Expr> Parser::parseExprSequenceElement(Diag<> message,
     Tok.setKind(tok::contextual_keyword);
     SourceLoc unsafeLoc = consumeToken();
     ParserResult<Expr> sub =
-      parseExprSequenceElement(diag::expected_expr_after_unsafe, isExprBasic);
+      parseExprSequenceElement(diag::expected_expr_after_unsafe, isExprBasic, isGenericArgTypeExpr);
     if (!sub.hasCodeCompletion() && !sub.isNull()) {
       sub = makeParserResult(new (Context) UnsafeExpr(unsafeLoc, sub.get()));
     }
@@ -452,7 +458,7 @@ ParserResult<Expr> Parser::parseExprSequenceElement(Diag<> message,
 
     SourceLoc consumeLoc = consumeToken();
     ParserResult<Expr> sub =
-        parseExprSequenceElement(diag::expected_expr_after_move, isExprBasic);
+        parseExprSequenceElement(diag::expected_expr_after_move, isExprBasic, isGenericArgTypeExpr);
     if (!sub.isNull()) {
       sub = makeParserResult(new (Context) ConsumeExpr(consumeLoc, sub.get()));
     }
@@ -467,7 +473,7 @@ ParserResult<Expr> Parser::parseExprSequenceElement(Diag<> message,
 
     SourceLoc copyLoc = consumeToken();
     ParserResult<Expr> sub =
-        parseExprSequenceElement(diag::expected_expr_after_copy, isExprBasic);
+        parseExprSequenceElement(diag::expected_expr_after_copy, isExprBasic, isGenericArgTypeExpr);
     if (!sub.isNull()) {
       sub = makeParserResult(new (Context) CopyExpr(copyLoc, sub.get()));
     }
@@ -482,7 +488,7 @@ ParserResult<Expr> Parser::parseExprSequenceElement(Diag<> message,
         .fixItReplace(awaitLoc, "consume");
 
       ParserResult<Expr> sub =
-          parseExprSequenceElement(diag::expected_expr_after_move, isExprBasic);
+          parseExprSequenceElement(diag::expected_expr_after_move, isExprBasic, isGenericArgTypeExpr);
       if (!sub.hasCodeCompletion() && !sub.isNull()) {
         sub = makeParserResult(new (Context) ConsumeExpr(awaitLoc, sub.get()));
       }
@@ -493,7 +499,7 @@ ParserResult<Expr> Parser::parseExprSequenceElement(Diag<> message,
       Tok.setKind(tok::contextual_keyword);
       SourceLoc awaitLoc = consumeToken();
       ParserResult<Expr> sub = parseExprSequenceElement(
-          diag::expected_expr_after_borrow, isExprBasic);
+          diag::expected_expr_after_borrow, isExprBasic, isGenericArgTypeExpr);
       if (!sub.hasCodeCompletion() && !sub.isNull()) {
         sub = makeParserResult(new (Context) BorrowExpr(awaitLoc, sub.get()));
       }
@@ -535,7 +541,7 @@ ParserResult<Expr> Parser::parseExprSequenceElement(Diag<> message,
       !peekToken().isAtStartOfLine()) {
     SourceLoc loc = consumeToken();
     ParserResult<Expr> ref =
-        parseExprSequenceElement(diag::expected_expr_after_each, isExprBasic);
+        parseExprSequenceElement(diag::expected_expr_after_each, isExprBasic, isGenericArgTypeExpr);
     if (ref.isNull())
       return ref;
 
@@ -570,8 +576,8 @@ ParserResult<Expr> Parser::parseExprSequenceElement(Diag<> message,
   }
 
   ParserResult<Expr> sub = hadTry
-      ? parseExprSequenceElement(message, isExprBasic)
-      : parseExprUnary(message, isExprBasic);
+      ? parseExprSequenceElement(message, isExprBasic, isGenericArgTypeExpr)
+      : parseExprUnary(message, isExprBasic, isGenericArgTypeExpr);
 
   if (hadTry && !sub.hasCodeCompletion() && !sub.isNull()) {
     switch (trySuffix ? trySuffix->getKind() : tok::NUM_TOKENS) {
@@ -619,7 +625,8 @@ ParserResult<Expr> Parser::parseExprSequenceElement(Diag<> message,
 ///     operator-prefix expr-unary(Mode)
 ///     '&' expr-unary(Mode)
 ///
-ParserResult<Expr> Parser::parseExprUnary(Diag<> Message, bool isExprBasic) {
+ParserResult<Expr> Parser::parseExprUnary(Diag<> Message, bool isExprBasic,
+                                          bool isGenericArgTypeExpr) {
   UnresolvedDeclRefExpr *Operator;
 
   // First check to see if we have the start of a regex literal `/.../`.
@@ -644,12 +651,12 @@ ParserResult<Expr> Parser::parseExprUnary(Diag<> Message, bool isExprBasic) {
   switch (Tok.getKind()) {
   default:
     // If the next token is not an operator, just parse this as expr-postfix.
-    return parseExprPostfix(Message, isExprBasic);
+    return parseExprPostfix(Message, isExprBasic, isGenericArgTypeExpr);
 
   case tok::amp_prefix: {
     SourceLoc Loc = consumeToken(tok::amp_prefix);
 
-    ParserResult<Expr> SubExpr = parseExprUnary(Message, isExprBasic);
+    ParserResult<Expr> SubExpr = parseExprUnary(Message, isExprBasic, isGenericArgTypeExpr);
     if (SubExpr.hasCodeCompletion())
       return makeParserCodeCompletionResult<Expr>(SubExpr.getPtrOrNull());
     if (SubExpr.isNull())
@@ -690,7 +697,7 @@ ParserResult<Expr> Parser::parseExprUnary(Diag<> Message, bool isExprBasic) {
   }
   }
 
-  ParserResult<Expr> SubExpr = parseExprUnary(Message, isExprBasic);
+  ParserResult<Expr> SubExpr = parseExprUnary(Message, isExprBasic, isGenericArgTypeExpr);
   ParserStatus Status = SubExpr;
   if (SubExpr.isNull())
     return Status;
@@ -737,7 +744,8 @@ ParserResult<Expr> Parser::parseExprKeyPath() {
 
   if (!startsWithSymbol(Tok, '.')) {
     rootResult = parseExprPostfix(diag::expr_keypath_expected_expr,
-                                  /*isBasic=*/true);
+                                  /*isBasic=*/true,
+                                  /*isGenericArgTypeExpr=*/false);
     parseStatus = rootResult;
 
     if (rootResult.isParseErrorOrHasCompletion())
@@ -762,7 +770,8 @@ ParserResult<Expr> Parser::parseExprKeyPath() {
     // Inside a keypath's path, the period always behaves normally: the key path
     // behavior is only the separation between type and path.
     pathResult = parseExprPostfixSuffix(inner, /*isExprBasic=*/true,
-                                        /*periodHasKeyPathBehavior=*/false);
+                                        /*periodHasKeyPathBehavior=*/false,
+                                        /*isGenericArgTypeExpr=*/false);
     parseStatus |= pathResult;
   }
 
@@ -1242,7 +1251,8 @@ getMagicIdentifierLiteralKind(tok Kind, const LangOptions &Opts) {
 
 ParserResult<Expr>
 Parser::parseExprPostfixSuffix(ParserResult<Expr> Result, bool isExprBasic,
-                               bool periodHasKeyPathBehavior) {
+                               bool periodHasKeyPathBehavior,
+                               bool isGenericArgTypeExpr) {
   // Handle suffix expressions.
   while (1) {
     // FIXME: Better recovery.
@@ -1329,7 +1339,8 @@ Parser::parseExprPostfixSuffix(ParserResult<Expr> Result, bool isExprBasic,
         // otherwise it will get parsed as a get-set clause on a variable
         // declared by `baseExpr.<complete>` which is clearly wrong.
         parseExprPostfixSuffix(makeParserResult(CCExpr), isExprBasic,
-                               periodHasKeyPathBehavior);
+                               periodHasKeyPathBehavior,
+                               isGenericArgTypeExpr);
 
         return makeParserCodeCompletionResult(CCExpr);
       }
@@ -1438,6 +1449,9 @@ Parser::parseExprPostfixSuffix(ParserResult<Expr> Result, bool isExprBasic,
       if (periodHasKeyPathBehavior && startsWithSymbol(Tok, '.'))
         break;
 
+      if (isGenericArgTypeExpr && isGenericArgumentExpressionDelimiter())
+        break;
+
       Expr *oper = parseExprOperator();
 
       Result = makeParserResult(
@@ -1496,7 +1510,8 @@ Parser::parseExprPostfixSuffix(ParserResult<Expr> Result, bool isExprBasic,
             // '#elseif'/'#else' bodies might start with invalid tokens.
             if (isAtStartOfPostfixExprSuffix() || Tok.is(tok::pound_if)) {
               auto expr = parseExprPostfixSuffix(Result, isExprBasic,
-                                                 periodHasKeyPathBehavior);
+                                                 periodHasKeyPathBehavior,
+                                                 isGenericArgTypeExpr);
 
               if (isActive)
                 activeElements.push_back(expr.get());
@@ -1611,14 +1626,16 @@ Parser::parseExprPostfixSuffix(ParserResult<Expr> Result, bool isExprBasic,
 ///     expr-postfix(basic)
 ///     expr-trailing-closure
 ///
-ParserResult<Expr> Parser::parseExprPostfix(Diag<> ID, bool isExprBasic) {
-  auto Result = parseExprPrimary(ID, isExprBasic);
+ParserResult<Expr> Parser::parseExprPostfix(Diag<> ID, bool isExprBasic,
+                                            bool isGenericArgTypeExpr) {
+  auto Result = parseExprPrimary(ID, isExprBasic, isGenericArgTypeExpr);
   // If we couldn't parse any expr, don't attempt to parse suffixes.
   if (Result.isNull())
     return Result;
 
   return parseExprPostfixSuffix(Result, isExprBasic,
-                                /*periodHasKeyPathBehavior=*/InSwiftKeyPath);
+                                /*periodHasKeyPathBehavior=*/InSwiftKeyPath,
+                                isGenericArgTypeExpr);
 }
 
 /// parseExprPrimary
@@ -1653,7 +1670,8 @@ ParserResult<Expr> Parser::parseExprPostfix(Diag<> ID, bool isExprBasic) {
 ///     expr-discard
 ///     expr-selector
 ///
-ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
+ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic,
+                                            bool isGenericArgTypeExpr) {
   switch (Tok.getKind()) {
   case tok::integer_literal: {
     StringRef Text = copyAndStripUnderscores(Tok.getText());
@@ -1753,7 +1771,9 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
   case tok::kw_init:
   case tok::kw_Self:         // Self
   case tok::colon_colon:     // module selector with missing module name
-    return parseExprIdentifier(/*allowKeyword=*/true);
+    return parseExprIdentifier(/*allowKeyword=*/true,
+                               /*allowModuleSelector=*/true,
+                               isGenericArgTypeExpr);
 
   case tok::kw_Any: { // Any
     if (peekToken().is(tok::colon_colon))
@@ -2484,7 +2504,8 @@ ParserStatus Parser::parseFreestandingMacroExpansion(
 ///   expr-identifier:
 ///     unqualified-decl-name generic-args?
 ParserResult<Expr> Parser::parseExprIdentifier(bool allowKeyword,
-                                               bool allowModuleSelector) {
+                                               bool allowModuleSelector,
+                                               bool isGenericArgTypeExpr) {
   ParserStatus status;
   assert(Tok.isAny(tok::identifier, tok::kw_self, tok::kw_Self,
                    tok::colon_colon) ||
@@ -2514,7 +2535,7 @@ ParserResult<Expr> Parser::parseExprIdentifier(bool allowKeyword,
   ///     lparen_following rparen lsquare_following rsquare lbrace rbrace
   ///     period_following comma semicolon
   ///
-  if (canParseAsGenericArgumentList()) {
+  if (canParseAsGenericArgumentList(isGenericArgTypeExpr)) {
     auto argStatus = parseGenericArguments(args, LAngleLoc, RAngleLoc);
     status |= argStatus;
     if (argStatus.isErrorOrHasCompletion())

--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -319,7 +319,11 @@ ParserStatus Parser::parseGenericWhereClause(
     // identifier if we're dealing with a same-type constraint.
     //
     // Note: This can be a value type, e.g. '123 == N' or 'N == 123'.
-    ParserResult<TypeRepr> FirstType = parseTypeOrValue();
+    // Only integer literals are supported as values in where clauses;
+    // full literal expressions are not yet supported here.
+    ParserResult<TypeRepr> FirstType = canParseGenericValueLiteral()
+        ? parseGenericValueLiteral()
+        : parseType();
 
     if (FirstType.hasCodeCompletion()) {
       Status.setHasCodeCompletionAndIsError();
@@ -383,7 +387,11 @@ ParserStatus Parser::parseGenericWhereClause(
       // Parse the second type.
       //
       // Note: This can be a value type, e.g. '123 == N' or 'N == 123'.
-      ParserResult<TypeRepr> SecondType = parseTypeOrValue();
+      // Only integer literals are supported as values in where clauses;
+      // full literal expressions are not yet supported here.
+      ParserResult<TypeRepr> SecondType = canParseGenericValueLiteral()
+          ? parseGenericValueLiteral()
+          : parseType();
       Status |= SecondType;
       if (SecondType.isNull())
         SecondType = makeParserResult(ErrorTypeRepr::create(Context, PreviousLoc));

--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -865,7 +865,8 @@ Result Parser::parseIfConfigRaw(
       llvm::SaveAndRestore<bool> S(InPoundIfEnvironment, true);
       ParserResult<Expr> result = parseExprSequence(diag::expected_expr,
                                                       /*isBasic*/true,
-                                                      /*isForDirective*/true);
+                                                      /*isForDirective*/true,
+                                                      /*isGenericArg*/false);
       if (result.hasCodeCompletion())
         return makeParserCodeCompletionStatus();
       if (result.isNull())

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -750,7 +750,7 @@ ParserStatus Parser::parseGenericArguments(SmallVectorImpl<TypeRepr *> &Args,
   if (!startsWithGreater(Tok)) {
     while (true) {
       // Note: This can be a value type, e.g. 'InlineArray<3, Int>'.
-      ParserResult<TypeRepr> Ty = parseTypeOrValue(diag::expected_type);
+      ParserResult<TypeRepr> Ty = parseGenericArgument(diag::expected_type);
       if (Ty.isNull() || Ty.hasCodeCompletion()) {
         // Skip until we hit the '>'.
         RAngleLoc = skipUntilGreaterInTypeList();
@@ -1341,7 +1341,7 @@ ParserResult<TypeRepr> Parser::parseTypeInlineArray(SourceLoc lSquare) {
 
   // 'isStartOfInlineArrayTypeBody' means we should at least have a type and
   // 'of' to start with.
-  auto count = parseTypeOrValue();
+  auto count = parseGenericArgument();
   if (count.isNull())
     return makeParserError();
 
@@ -1353,7 +1353,7 @@ ParserResult<TypeRepr> Parser::parseTypeInlineArray(SourceLoc lSquare) {
 
   // Allow parsing a value for better recovery, Sema will diagnose any
   // mismatch.
-  auto element = parseTypeOrValue();
+  auto element = parseGenericArgument();
   if (element.hasCodeCompletion() || element.isNull())
     return element;
 
@@ -1535,42 +1535,54 @@ Parser::parseTypeImplicitlyUnwrappedOptional(ParserResult<TypeRepr> base) {
   return makeParserResult(ParserStatus(base), TyR);
 }
 
-ParserResult<TypeRepr> Parser::parseTypeOrValue() {
-  return parseTypeOrValue(diag::expected_type);
+ParserResult<TypeRepr> Parser::parseGenericArgument() {
+  return parseGenericArgument(diag::expected_type);
 }
 
-ParserResult<TypeRepr> Parser::parseTypeOrValue(Diag<> MessageID,
+ParserResult<TypeRepr> Parser::parseGenericArgument(Diag<> MessageID,
                                                 ParseTypeReason reason) {
-  if (canParseGenericValueLiteral())
-    return parseGenericValueLiteral();
+  if (!Context.LangOpts.hasFeature(Feature::LiteralExpressions)) {
+    if (canParseGenericValueLiteral())
+      return parseGenericValueLiteral();
+    return parseType(MessageID, reason);
+  }
 
   // Look ahead to consider if this is a generic value expression
   // or possibly a tuple type with a postfix grammar
-  bool shouldParseValueExpr = false;
-  if (Context.LangOpts.hasFeature(Feature::LiteralExpressions) &&
-      Tok.is(tok::l_paren)) {
+  bool shouldParseUnambiguousValueExpr = false;
+  if (Tok.is(tok::l_paren)) {
     BacktrackingScope backtrack(*this);
     skipSingle();
     if (Tok.is(tok::comma) || startsWithGreater(Tok) ||
         (Tok.isContextualKeyword("of") && !Tok.isAtStartOfLine()))
-      shouldParseValueExpr = true;
+      shouldParseUnambiguousValueExpr = true;
   }
 
-  if (shouldParseValueExpr) {
-    // Ensure that constituent references get parsed as declaration references,
-    // not type references.
-    llvm::SaveAndRestore<PatternBindingState> X(
-        InBindingPattern, PatternBindingState::NotInBinding);
-    auto expr = parseExprPrimary(MessageID, false);
-    if (expr.isNull()) {
-      diagnose(Tok, MessageID);
-      return makeParserError();
-    }
-    return makeParserResult(
-        new (Context) GenericArgumentExprTypeRepr(expr.get(), &Context));
+  if (Tok.isMinus())
+    Tok.setKind(tok::oper_prefix);
+
+  llvm::SaveAndRestore<PatternBindingState> X(
+      InBindingPattern, PatternBindingState::NotInBinding);
+  ParserResult<Expr> parsedExpr;
+  if (shouldParseUnambiguousValueExpr) {
+    parsedExpr = parseExprPrimary(MessageID, false);
   } else {
-    return parseType(MessageID, reason);
+    parsedExpr = parseExprSequence(MessageID, /*isBasicExpr=*/ true,
+                                   /*isForConditionalDirective=*/ false,
+                                   /*isGenericArgTypeExpr=*/ true);
   }
+
+  if (parsedExpr.isNull()) {
+    diagnose(Tok, MessageID);
+    return makeParserError();
+  }
+
+  return makeParserResult(
+      new (Context) GenericArgumentExprTypeRepr(parsedExpr.get(), &Context));
+}
+
+bool Parser::isGenericArgumentExpressionDelimiter() {
+  return (Tok.isAnyOperator() && Tok.getText() == "==") || startsWithGreater(Tok) || Tok.is(tok::comma);
 }
 
 bool Parser::canParseGenericValueLiteral() {
@@ -1605,7 +1617,8 @@ ParserResult<TypeRepr> Parser::parseGenericValueLiteral() {
 // Speculative type list parsing
 //===----------------------------------------------------------------------===//
 
-static bool isGenericTypeDisambiguatingToken(Parser &P) {
+static bool isGenericTypeDisambiguatingToken(Parser &P,
+                                             bool isGenericArgTypeExpr) {
   auto &tok = P.Tok;
   switch (tok.getKind()) {
   default:
@@ -1631,9 +1644,19 @@ static bool isGenericTypeDisambiguatingToken(Parser &P) {
     if (tok.getText() == "&")
       return true;
 
+    // Inside a generic argument expression, '>' closes an outer
+    // generic argument list. It can't be a comparison operator because
+    // parseExprSequence stops at '>' in a generic argument expression too.
+    if (isGenericArgTypeExpr && P.isGenericArgumentExpressionDelimiter())
+      return true;
+
     LLVM_FALLTHROUGH;
   case tok::oper_binary_unspaced:
   case tok::oper_postfix:
+    // Inside a generic argument expression, '>' closes the list.
+    if (isGenericArgTypeExpr && P.isGenericArgumentExpressionDelimiter())
+      return true;
+
     // These might be '?' or '!' type modifiers.
     return P.isOptionalToken(tok) || P.isImplicitlyUnwrappedOptionalToken(tok);
 
@@ -1644,14 +1667,14 @@ static bool isGenericTypeDisambiguatingToken(Parser &P) {
   }
 }
 
-bool Parser::canParseAsGenericArgumentList() {
+bool Parser::canParseAsGenericArgumentList(bool isGenericArgTypeExpr) {
   if (!Tok.isAnyOperator() || Tok.getText() != "<")
     return false;
 
   BacktrackingScope backtrack(*this);
 
   if (canParseGenericArguments())
-    return isGenericTypeDisambiguatingToken(*this);
+    return isGenericTypeDisambiguatingToken(*this, isGenericArgTypeExpr);
 
   return false;
 }
@@ -1668,11 +1691,16 @@ bool Parser::canParseGenericArguments() {
   }
 
   do {
-    if (Context.LangOpts.hasFeature(Feature::LiteralExpressions) &&
-        Tok.is(tok::l_paren))
-      skipSingle();
-    else if (!canParseType())
+    if (Context.LangOpts.hasFeature(Feature::LiteralExpressions)) {
+      if (Tok.is(tok::l_paren))
+        skipSingle();
+      else
+        skipUntilGreaterOrComma();
+    } else if (canParseGenericValueLiteral()) {
+      parseGenericValueLiteral();
+    } else if (!canParseType()) {
       return false;
+    }
 
     // Parse the comma, if the list continues.
     // This could be the trailing comma.
@@ -1707,17 +1735,6 @@ bool Parser::canParseTypeSimple() {
       if (!canParseTypeIdentifier())
         return false;
     }
-
-    // '-' can only appear before integers being used as types like '-123'.
-    if (Tok.isMinus()) {
-      consumeToken();
-
-      if (!Tok.is(tok::integer_literal))
-        return false;
-
-      consumeToken();
-    }
-
     break;
   case tok::kw_protocol:
     return canParseOldStyleProtocolComposition();
@@ -1740,10 +1757,6 @@ bool Parser::canParseTypeSimple() {
   case tok::kw__:
     consumeToken();
     break;
-  case tok::integer_literal:
-    consumeToken();
-    break;
-
   default:
     return false;
   }
@@ -1894,11 +1907,21 @@ bool Parser::canParseStartOfInlineArrayType() {
   // expression or type. We specifically look for any type, not just integers
   // for better recovery in e.g cases where the user writes '[Int of 2]'. We
   // only do type-scalar since variadics would be ambiguous e.g 'Int...of'.
-  if (Context.LangOpts.hasFeature(Feature::LiteralExpressions) &&
-      Tok.is(tok::l_paren))
-    skipSingle(); // Assume a parentheses-delimited value expression
-  else if (!canParseTypeScalar())
+
+  if (Context.LangOpts.hasFeature(Feature::LiteralExpressions)) {
+    if (Tok.is(tok::l_paren))
+      skipSingle();
+    else {
+      CancellableBacktrackingScope backtrack(*this);
+      if (!skipUntilOfOrEndOfLine())
+        return false;
+      backtrack.cancelBacktrack();
+    }
+  } else if (canParseGenericValueLiteral()) {
+    parseGenericValueLiteral();
+  } else if (!canParseTypeScalar()) {
     return false;
+  }
 
   // For now we don't allow multi-line since that would require
   // disambiguation.

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -809,6 +809,23 @@ SourceLoc Parser::skipUntilGreaterInTypeList(bool protocolComposition) {
   }
 }
 
+void Parser::skipUntilGreaterOrComma() {
+  // Track nested '<'/'>' depth so that nested generic types are skipped as a
+  // unit rather than stopping at the inner '>'.
+  unsigned depth = 0;
+  while (Tok.isNot(tok::eof, tok::pound_endif, tok::pound_else,
+                   tok::pound_elseif, tok::r_paren, tok::r_brace,
+                   tok::r_square, tok::l_brace, tok::semi)) {
+    if (depth == 0 && (startsWithGreater(Tok) || Tok.is(tok::comma)))
+      break;
+    if (startsWithLess(Tok))
+      ++depth;
+    else if (startsWithGreater(Tok))
+      --depth;
+    skipSingle();
+  }
+}
+
 void Parser::skipUntilDeclRBrace() {
   while (Tok.isNot(tok::eof, tok::r_brace, tok::pound_endif,
                    tok::pound_else, tok::pound_elseif,
@@ -872,6 +889,15 @@ bool Parser::skipUntilTokenOrEndOfLine(tok T1, tok T2) {
     skipSingle();
 
   return Tok.isAny(T1, T2) && !Tok.isAtStartOfLine();
+}
+
+bool Parser::skipUntilOfOrEndOfLine() {
+  while (!Tok.isContextualKeyword("of") && !Tok.isAtStartOfLine() &&
+         Tok.isNot(tok::eof, tok::r_paren, tok::r_brace, tok::r_square,
+                   tok::l_brace, tok::semi))
+    skipSingle();
+
+  return Tok.isContextualKeyword("of") && !Tok.isAtStartOfLine();
 }
 
 bool Parser::parseEndIfDirective(SourceLoc &Loc) {

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -1121,7 +1121,7 @@ bool SILParser::parseASTTypeOrValue(CanType &result,
                                     GenericSignature genericSig,
                                     GenericParamList *genericParams,
                                     bool forceContextualType) {
-  auto parsedType = P.parseTypeOrValue();
+  auto parsedType = P.parseGenericArgument();
   if (parsedType.isNull()) return true;
 
   // If we weren't given a specific generic context to resolve the type

--- a/test/LiteralExpressions/IntegerGenericArithmetic.swift
+++ b/test/LiteralExpressions/IntegerGenericArithmetic.swift
@@ -6,32 +6,32 @@
 // Arithmetic operators
 // =============================================================================
 
-let add1: InlineArray<(2 + 3), Int> = [1, 2, 3, 4, 5]
-let add2: InlineArray<(0 + 5), Int> = [1, 2, 3, 4, 5]
-let add3: InlineArray<(1 + 1 + 1), Int> = [1, 2, 3]
+let add1: InlineArray<2 + 3, Int> = [1, 2, 3, 4, 5]
+let add2: InlineArray<0 + 5, Int> = [1, 2, 3, 4, 5]
+let add3: InlineArray<1 + 1 + 1, Int> = [1, 2, 3]
 
-let sub1: InlineArray<(5 - 2), Int> = [1, 2, 3]
-let sub2: InlineArray<(10 - 5 - 2), Int> = [1, 2, 3]
+let sub1: InlineArray<5 - 2, Int> = [1, 2, 3]
+let sub2: InlineArray<10 - 5 - 2, Int> = [1, 2, 3]
 
-let mul1: InlineArray<(2 * 3), Int> = [1, 2, 3, 4, 5, 6]
-let mul3: InlineArray<(2 * 2 * 2), Int> = [1, 2, 3, 4, 5, 6, 7, 8]
+let mul1: InlineArray<2 * 3, Int> = [1, 2, 3, 4, 5, 6]
+let mul3: InlineArray<2 * 2 * 2, Int> = [1, 2, 3, 4, 5, 6, 7, 8]
 
-let div1: InlineArray<(10 / 2), Int> = [1, 2, 3, 4, 5]
-let div2: InlineArray<(9 / 3), Int> = [1, 2, 3]
+let div1: InlineArray<10 / 2, Int> = [1, 2, 3, 4, 5]
+let div2: InlineArray<9 / 3, Int> = [1, 2, 3]
 
-let mod1: InlineArray<(7 % 4), Int> = [1, 2, 3]
-let mod2: InlineArray<(10 % 3), Int> = [1]
+let mod1: InlineArray<7 % 4, Int> = [1, 2, 3]
+let mod2: InlineArray<10 % 3, Int> = [1]
 
 // =============================================================================
 // Bitwise operators
 // =============================================================================
 
-let and1: InlineArray<(7 & 3), Int> = [1, 2, 3]
-let or1: InlineArray<(2 | 1), Int> = [1, 2, 3]
-let xor1: InlineArray<(5 ^ 2), Int> = [1, 2, 3, 4, 5, 6, 7]
+let and1: InlineArray<7 & 3, Int> = [1, 2, 3]
+let or1: InlineArray<2 | 1, Int> = [1, 2, 3]
+let xor1: InlineArray<5 ^ 2, Int> = [1, 2, 3, 4, 5, 6, 7]
 
-let lshift1: InlineArray<(1 << 3), Int> = [1, 2, 3, 4, 5, 6, 7, 8]
-let lshift2: InlineArray<(1 << 5), Int> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+let lshift1: InlineArray<1 << 3, Int> = [1, 2, 3, 4, 5, 6, 7, 8]
+let lshift2: InlineArray<1 << 5, Int> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
                                          11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
                                          21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
                                          31, 32]
@@ -43,40 +43,40 @@ let rshift2: InlineArray<(32 >> 3), Int> = [1, 2, 3, 4]
 // Operator Precedence
 // =============================================================================
 
-let prec1: InlineArray<(2 + 3 * 2), Int> = [1, 2, 3, 4, 5, 6, 7, 8]
-let prec2: InlineArray<(10 - 6 / 2), Int> = [1, 2, 3, 4, 5, 6, 7]
-let prec3: InlineArray<(1 << 2 + 1), Int> = [1, 2, 3, 4, 5]
+let prec1: InlineArray<2 + 3 * 2, Int> = [1, 2, 3, 4, 5, 6, 7, 8]
+let prec2: InlineArray<10 - 6 / 2, Int> = [1, 2, 3, 4, 5, 6, 7]
+let prec3: InlineArray<1 << 2 + 1, Int> = [1, 2, 3, 4, 5]
 
 // =============================================================================
 // Parentheses
 // =============================================================================
 
-let paren1: InlineArray<((2 + 3)), Int> = [1, 2, 3, 4, 5]
-let paren2: InlineArray<((2 + 3) * 2), Int> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-let paren3: InlineArray<(2 * (1 + 2)), Int> = [1, 2, 3, 4, 5, 6]
-let paren4: InlineArray<((1 + 1) * 2), Int> = [1, 2, 3, 4]
+let paren1: InlineArray<(2 + 3), Int> = [1, 2, 3, 4, 5]
+let paren2: InlineArray<(2 + 3) * 2, Int> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+let paren3: InlineArray<2 * (1 + 2), Int> = [1, 2, 3, 4, 5, 6]
+let paren4: InlineArray<(1 + 1) * 2, Int> = [1, 2, 3, 4]
 
 // =============================================================================
 // Sugar Syntax [N of T]
 // =============================================================================
 
-let sugar1: [(2 + 3) of Int] = [1, 2, 3, 4, 5]
-let sugar2: [(1 << 2) of String] = ["a", "b", "c", "d"]
-let sugar3: [((2 * 3)) of Double] = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+let sugar1: [2 + 3 of Int] = [1, 2, 3, 4, 5]
+let sugar2: [1 << 2 of String] = ["a", "b", "c", "d"]
+let sugar3: [(2 * 3) of Double] = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
 
 // =============================================================================
 // Nested
 // =============================================================================
 
-let nested1: InlineArray<(1 + 1), InlineArray<(2 + 1), Int>> = [[1, 2, 3], [4, 5, 6]]
-let nested2: [(2 * 2) of [(1 + 2) of Int]] = [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]]
+let nested1: InlineArray<1 + 1, InlineArray<2 + 1, Int>> = [[1, 2, 3], [4, 5, 6]]
+let nested2: [2 * 2 of [1 + 2 of Int]] = [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]]
 
 // =============================================================================
 // Function Parameters
 // =============================================================================
 
-func takeInlineArray<T>(_ arr: InlineArray<(2 + 2), T>) {}
-func takeSugarArray<T>(_ arr: [(1 << 1) of T]) {}
+func takeInlineArray<T>(_ arr: InlineArray<2 + 2, T>) {}
+func takeSugarArray<T>(_ arr: [1 << 1 of T]) {}
 
 func testFunctionCalls() {
   takeInlineArray([1, 2, 3, 4])
@@ -89,9 +89,9 @@ func testFunctionCalls() {
 // Type Aliases with Literal Expression Generics
 // =============================================================================
 
-typealias FourInts = InlineArray<(2 * 2), Int>
-typealias EightStrings = InlineArray<(1 << 3), String>
-typealias SugarSixDoubles = [(2 + 4) of Double]
+typealias FourInts = InlineArray<2 * 2, Int>
+typealias EightStrings = InlineArray<1 << 3, String>
+typealias SugarSixDoubles = [2 + 4 of Double]
 
 let alias1: FourInts = [1, 2, 3, 4]
 let alias2: EightStrings = ["a", "b", "c", "d", "e", "f", "g", "h"]
@@ -102,8 +102,8 @@ let alias3: SugarSixDoubles = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
 // =============================================================================
 
 struct Container {
-    var data: InlineArray<(3 + 2), Int>
-    var buffer: [(1 << 2) of UInt8]
+    var data: InlineArray<3 + 2, Int>
+    var buffer: [1 << 2 of UInt8]
 }
 
 func testStruct() {
@@ -115,11 +115,11 @@ func testStruct() {
 // Return Types
 // =============================================================================
 
-func makeArray() -> InlineArray<(2 + 1), Int> {
+func makeArray() -> InlineArray<2 + 1, Int> {
   return [1, 2, 3]
 }
 
-func makeSugarArray() -> [(4 - 1) of String] {
+func makeSugarArray() -> [4 - 1 of String] {
   return ["a", "b", "c"]
 }
 
@@ -127,5 +127,5 @@ func makeSugarArray() -> [(4 - 1) of String] {
 // Expression position
 // =============================================================================
 
-let addExpr1 = InlineArray<(2 + 3), Int>(repeating: 5)
-let addExpr2 = InlineArray<(0 + 5), Int>(repeating: 4)
+let addExpr1 = InlineArray<2 + 3, Int>(repeating: 5)
+let addExpr2 = InlineArray<0 + 5, Int>(repeating: 4)

--- a/test/LiteralExpressions/IntegerGenericConstantFolding.swift
+++ b/test/LiteralExpressions/IntegerGenericConstantFolding.swift
@@ -2,63 +2,63 @@
 // REQUIRES: swift_feature_LiteralExpressions
 // RUN: %target-swift-frontend -typecheck -dump-ast %s -disable-availability-checking -enable-experimental-feature LiteralExpressions | %FileCheck %s
 
-let foldAdd: InlineArray<(2 + 3), Int> = [1, 2, 3, 4, 5]
+let foldAdd: InlineArray<2 + 3, Int> = [1, 2, 3, 4, 5]
 // CHECK-LABEL: (pattern_named type="InlineArray<5, Int>" "foldAdd")
 
-let foldMul: InlineArray<(2 * 3), Int> = [1, 2, 3, 4, 5, 6]
+let foldMul: InlineArray<2 * 3, Int> = [1, 2, 3, 4, 5, 6]
 // CHECK-LABEL: (pattern_named type="InlineArray<6, Int>" "foldMul")
 
-let foldShift: InlineArray<(1 << 4), Int> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+let foldShift: InlineArray<1 << 4, Int> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
 // CHECK-LABEL: (pattern_named type="InlineArray<16, Int>" "foldShift")
 
-let foldComplex: InlineArray<((2 + 3) * 2), Int> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+let foldComplex: InlineArray<(2 + 3) * 2, Int> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 // CHECK-LABEL: (pattern_named type="InlineArray<10, Int>" "foldComplex")
 
-let foldOr: InlineArray<(4 | 3), Int> = [1, 2, 3, 4, 5, 6, 7]
+let foldOr: InlineArray<4 | 3, Int> = [1, 2, 3, 4, 5, 6, 7]
 // CHECK-LABEL: (pattern_named type="InlineArray<7, Int>" "foldOr")
 
-let nest1: InlineArray<((1 + 1) * (2 + 1)), Int> = [1, 2, 3, 4, 5, 6]
+let nest1: InlineArray<(1 + 1) * (2 + 1), Int> = [1, 2, 3, 4, 5, 6]
 // CHECK-LABEL: (pattern_named type="InlineArray<6, Int>" "nest1")
 
-let nest2: InlineArray<(((1 << 2) + 1) - 2), Int> = [1, 2, 3]
+let nest2: InlineArray<((1 << 2) + 1) - 2, Int> = [1, 2, 3]
 // CHECK-LABEL: (pattern_named type="InlineArray<3, Int>" "nest2")
 
-let sugarFold1: [(2 + 2) of Int] = [1, 2, 3, 4]
+let sugarFold1: [2 + 2 of Int] = [1, 2, 3, 4]
 // CHECK-LABEL: (pattern_named type="[4 of Int]" "sugarFold1")
 
-let sugarFold2: [(1 << 3) of String] = ["a", "b", "c", "d", "e", "f", "g", "h"]
+let sugarFold2: [1 << 3 of String] = ["a", "b", "c", "d", "e", "f", "g", "h"]
 // CHECK-LABEL: (pattern_named type="[8 of String]" "sugarFold2")
 
-typealias PowerOfTwo = InlineArray<(1 << 4), Int>
+typealias PowerOfTwo = InlineArray<1 << 4, Int>
 let aliasCheck: PowerOfTwo = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
 // CHECK-LABEL: (pattern_named type="PowerOfTwo" "aliasCheck")
 
-typealias ComputedSize = InlineArray<((3 + 2) * (4 - 2)), Int>
+typealias ComputedSize = InlineArray<(3 + 2) * (4 - 2), Int>
 let aliasComputed: ComputedSize = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 // CHECK-LABEL: (pattern_named type="ComputedSize" "aliasComputed")
 
-let nestedExpr: InlineArray<(1 + 1), InlineArray<(2 + 1), Int>> = [[1, 2, 3], [4, 5, 6]]
+let nestedExpr: InlineArray<1 + 1, InlineArray<2 + 1, Int>> = [[1, 2, 3], [4, 5, 6]]
 // CHECK-LABEL: (pattern_named type="InlineArray<2, InlineArray<3, Int>>" "nestedExpr")
 
-let nestedSugar: [(2 * 1) of [(1 + 2) of Int]] = [[1, 2, 3], [4, 5, 6]]
+let nestedSugar: [2 * 1 of [1 + 2 of Int]] = [[1, 2, 3], [4, 5, 6]]
 // CHECK-LABEL: (pattern_named type="[2 of [3 of Int]]" "nestedSugar")
 
 
-func process(_ arr: InlineArray<(2 * 4), Int>) -> Int { return 42 }
+func process(_ arr: InlineArray<2 * 4, Int>) -> Int { return 42 }
 // CHECK-LABEL: (func_decl decl_context={{.*}} range=[{{.*}}] "process(_:)" interface_type="(InlineArray<8, Int>) -> Int"
 
 let processResult = process([1, 2, 3, 4, 5, 6, 7, 8])
 // CHECK-LABEL: (pattern_named type="Int" "processResult")
 
 let base = 2
-let variableRef: InlineArray<(base + 1), Int> = [1, 2, 3]
+let variableRef: InlineArray<base + 1, Int> = [1, 2, 3]
 // CHECK-LABEL: (pattern_named type="InlineArray<3, Int>" "variableRef")
 
 let negativeBase: InlineArray<-3, Int>
 // CHECK-LABEL: (pattern_named type="InlineArray<-3, Int>" "negativeBase")
-let negative: InlineArray<(-3), Int>
+let negative: InlineArray<-3, Int>
 // CHECK-LABEL: (pattern_named type="InlineArray<-3, Int>" "negative")
-let negativeFold: InlineArray<(2-5), Int>
+let negativeFold: InlineArray<2-5, Int>
 // CHECK-LABEL: (pattern_named type="InlineArray<-3, Int>" "negativeFold")
 
 struct W<let N: Int, let M: Int> {}
@@ -72,7 +72,7 @@ extension W where N == 2, M == 6 {
   func bothMatch() -> Int { N + M }
 }
 // Verify that folded expressions in requirements produce the correct types.
-func makeW() -> W<(1+1), (2*3)> { W() }
+func makeW() -> W<1+1, (2*3)> { W() }
 // CHECK-LABEL: (func_decl decl_context={{.*}} range=[{{.*}}] "makeW()" interface_type="() -> W<2, 6>"
 let wResult = makeW().nIsTwo()
 // CHECK-LABEL: (pattern_named type="Int" "wResult")
@@ -82,7 +82,7 @@ let wResult3 = makeW().bothMatch()
 // CHECK-LABEL: (pattern_named type="Int" "wResult3")
 
 // Expression argument in type position should be equivalent to the folded literal.
-let exprArg: W<(3 - 1), (2 + 4)> = W()
+let exprArg: W<3 - 1, (2 + 4)> = W()
 // CHECK-LABEL: (pattern_named type="W<2, 6>" "exprArg")
 let exprArgResult = exprArg.nIsTwo()
 // CHECK-LABEL: (pattern_named type="Int" "exprArgResult")
@@ -92,7 +92,7 @@ let exprArgResult2 = exprArg.bothMatch()
 struct V<let N: Int> {}
 let letNumWithInit = 12
 struct Foo {
-  let foo: V<(letNumWithInit)>
+  let foo: V<letNumWithInit>
   // CHECK-LABEL: (pattern_named type="V<12>" "foo")
 }
 
@@ -100,5 +100,5 @@ struct S<T> {
     typealias X = T
     // CHECK-LABEL: (typealias decl_context={{.*}} range=[{{.*}}] "X" interface_type="S<T>.X.Type"
 }
-func foo(_ x: S<(S<()>.X)>) {}
+func foo(_ x: S<S<()>.X>) {}
 // CHECK-LABEL: (func_decl decl_context={{.*}} range=[{{.*}}] "foo(_:)" interface_type="(S<S<()>.X>) -> ()"

--- a/test/LiteralExpressions/IntegerGenericErrors.swift
+++ b/test/LiteralExpressions/IntegerGenericErrors.swift
@@ -2,21 +2,21 @@
 // REQUIRES: swift_feature_LiteralExpressions
 // RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature LiteralExpressions
 
-let wrongCount1: InlineArray<(2 + 3), Int> = [1, 2, 3]
+let wrongCount1: InlineArray<2 + 3, Int> = [1, 2, 3]
 // expected-error@-1 {{expected '5' elements in inline array literal, but got '3'}}
 
-let wrongCount2: InlineArray<(1 << 2), Int> = [1, 2, 3, 4, 5, 6]
+let wrongCount2: InlineArray<1 << 2, Int> = [1, 2, 3, 4, 5, 6]
 // expected-error@-1 {{expected '4' elements in inline array literal, but got '6'}}
 
-let wrongCount3: [(3 * 2) of Int] = [1, 2, 3]
+let wrongCount3: [3 * 2 of Int] = [1, 2, 3]
 // expected-error@-1 {{expected '6' elements in inline array literal, but got '3'}}
 
-let typeMismatch1: InlineArray<(2 + 1), Int> = ["a", "b", "c"]
+let typeMismatch1: InlineArray<2 + 1, Int> = ["a", "b", "c"]
 // expected-error@-1 {{cannot convert value of type 'String' to expected element type 'Int'}}
 // expected-error@-2 {{cannot convert value of type 'String' to expected element type 'Int'}}
 // expected-error@-3 {{cannot convert value of type 'String' to expected element type 'Int'}}
 
-let typeMismatch2: [(1 + 1) of String] = [1, 2]
+let typeMismatch2: [1 + 1 of String] = [1, 2]
 // expected-error@-1 {{cannot convert value of type 'Int' to expected element type 'String'}}
 // expected-error@-2 {{cannot convert value of type 'Int' to expected element type 'String'}}
 
@@ -27,15 +27,15 @@ let invalidElement3: [3 of 5] = [1, 2, 3]
 func takeExact3<T>(_ arr: InlineArray<3, T>) {}
 func takeExact4<T>(_ arr: InlineArray<4, T>) {}
 func testTypeMismatch() {
-  let arr: InlineArray<(2 + 1), Int> = [1, 2, 3]
+  let arr: InlineArray<2 + 1, Int> = [1, 2, 3]
   takeExact3(arr)  // OK - both are 3
   takeExact4(arr)  // expected-error {{cannot convert value of type 'InlineArray<3, Int>' to expected argument type 'InlineArray<4, Int>'}}
   // expected-note@-1 {{arguments to generic parameter 'count' ('3' and '4') are expected to be equal}}
 }
 
 func testAssignment() {
-    let a: InlineArray<(2 + 2), Int> = [1, 2, 3, 4]  // 4 elements
-    let b: InlineArray<(1 + 2), Int> = [1, 2, 3]     // 3 elements
+    let a: InlineArray<2 + 2, Int> = [1, 2, 3, 4]  // 4 elements
+    let b: InlineArray<1 + 2, Int> = [1, 2, 3]     // 3 elements
 
     var c: InlineArray<4, Int> = a  // OK
     c = b  // expected-error {{cannot assign value of type 'InlineArray<3, Int>' to type 'InlineArray<4, Int>'}}
@@ -44,10 +44,10 @@ func testAssignment() {
 }
 
 // Valid empty array
-let zeroResult: InlineArray<(3 - 3), Int> = []
+let zeroResult: InlineArray<3 - 3, Int> = []
 
 func getCount() -> Int { return 3 }
-let nonLiteral2: InlineArray<(getCount()), Int> = [1, 2, 3]
+let nonLiteral2: InlineArray<getCount(), Int> = [1, 2, 3]
 // expected-error@-1 {{generic value must be an integer literal expression}}
 // expected-error@-2 {{not supported in a literal expression}}
 
@@ -55,20 +55,20 @@ let nonLiteral2: InlineArray<(getCount()), Int> = [1, 2, 3]
 let invalidElement1: InlineArray<3, 5> = [1, 2, 3]
 // expected-error@-1 {{cannot use value type '5' for generic argument 'Element'}}
 
-let nestedMatch: InlineArray<2, InlineArray<(1 + 1), Int>> = [[1, 2], [3, 4]]
-let nestedMismatch: InlineArray<2, InlineArray<(1 + 1), Int>> = [[1, 2], [3, 4, 5]]
+let nestedMatch: InlineArray<2, InlineArray<1 + 1, Int>> = [[1, 2], [3, 4]]
+let nestedMismatch: InlineArray<2, InlineArray<1 + 1, Int>> = [[1, 2], [3, 4, 5]]
 // expected-error@-1 {{cannot convert value of type '[Int]' to expected element type 'InlineArray<2, Int>'}}
 
-let nestedMismatch2: [(1 + 1) of [(2 + 1) of Int]] = [[1, 2, 3], [4, 5]]
+let nestedMismatch2: [1 + 1 of [2 + 1 of Int]] = [[1, 2, 3], [4, 5]]
 // expected-error@-1 {{cannot convert value of type '[Int]' to expected element type '[3 of Int]'}}
 
-let divZero: InlineArray<(1/0), Int>
+let divZero: InlineArray<1/0, Int>
 // expected-error@-1 {{division by zero}}
 // expected-error@-2 {{generic value must be an integer literal expression}}
 
 let backwardsSugar = [Int of (1+2)]
 // expected-error@-1 {{cannot pass type 'Int' as a value for generic value 'count'}}
-// expected-error@-2 {{expected type}}
+// expected-error@-2 {{cannot use value type '3' for generic argument 'Element'}}
 
 struct S<each T> {}
 S<1, 2, 3>
@@ -77,29 +77,29 @@ S<1, 2, 3>
 // expected-error@-3 {{cannot use value type '3' for generic argument 'each T'}}
 
 struct S2<each T> {}
-S2<(1 + 3)>
+S2<1 + 3>
 // expected-error@-1 {{cannot use value type '4' for generic argument 'each T'}}
 
 struct V<let N: Int> {}
 var num = 1
-var _: V<(num)>
+var _: V<num>
 // expected-error@-1 {{not supported in a literal expression}}
 // expected-error@-2 {{generic value must be an integer literal expression}}
 
 let letNum: Int
 letNum = 1
-var _: V<(letNum)>
+var _: V<letNum>
 // expected-error@-1 {{not supported in a literal expression}}
 // expected-error@-2 {{generic value must be an integer literal expression}}
 
 func genNum() -> Int { 1 }
-var _: V<(genNum())>
+var _: V<genNum()>
 // expected-error@-1 {{not supported in a literal expression}}
 // expected-error@-2 {{generic value must be an integer literal expression}}
 
 struct SelfRef<let N: Int> {}
-func + (lhs: SelfRef<(1 + 1)>, rhs: Int) {}
+func + (lhs: SelfRef<1 + 1>, rhs: Int) {}
 // expected-error@-1 {{circular reference}}
-// expected-note@-2 {{while resolving type '(1 + 1)'}}
-// expected-note@-3 {{while resolving type 'SelfRef<(1 + 1)>'}}
+// expected-note@-2 {{while resolving type '1 + 1'}}
+// expected-note@-3 {{while resolving type 'SelfRef<1 + 1>'}}
 // expected-note@-4 {{through reference here}}

--- a/test/LiteralExpressions/IntegerGenericExpressionInterface.swift
+++ b/test/LiteralExpressions/IntegerGenericExpressionInterface.swift
@@ -8,49 +8,49 @@
 // integer literals in the emitted .swiftinterface file.
 
 // CHECK-LABEL: public let add: Swift::InlineArray<5, Swift::Int>
-public let add: InlineArray<(2 + 3), Int> = [1, 2, 3, 4, 5]
+public let add: InlineArray<2 + 3, Int> = [1, 2, 3, 4, 5]
 // CHECK-LABEL: public let sub: Swift::InlineArray<3, Swift::Int>
-public let sub: InlineArray<(5 - 2), Int> = [1, 2, 3]
+public let sub: InlineArray<5 - 2, Int> = [1, 2, 3]
 // CHECK-LABEL: public let mul: Swift::InlineArray<6, Swift::Int>
-public let mul: InlineArray<(2 * 3), Int> = [1, 2, 3, 4, 5, 6]
+public let mul: InlineArray<2 * 3, Int> = [1, 2, 3, 4, 5, 6]
 // CHECK-LABEL: public let div: Swift::InlineArray<5, Swift::Int>
-public let div: InlineArray<(10 / 2), Int> = [1, 2, 3, 4, 5]
+public let div: InlineArray<10 / 2, Int> = [1, 2, 3, 4, 5]
 // CHECK-LABEL: public let preced: Swift::InlineArray<4, (Swift::Int, Swift::Float)>
-public let preced: InlineArray<(1 + 3 * 2 - 3), (Int, Float)> = [(1, 1.1), (2, 2.2), (3, 3.3), (4, 4.4)]
+public let preced: InlineArray<1 + 3 * 2 - 3, (Int, Float)> = [(1, 1.1), (2, 2.2), (3, 3.3), (4, 4.4)]
 // CHECK-LABEL: public let nestedParens: Swift::InlineArray<10, Swift::Int>
-public let nestedParens: InlineArray<((2 + 3) * 2), Int> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+public let nestedParens: InlineArray<(2 + 3) * 2, Int> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 // CHECK-LABEL: public let nested: Swift::InlineArray<4, (Swift::InlineArray<2, Swift::Int>, Swift::Float)>
-public let nested: InlineArray<(1 + 3 * 2 - 3), (InlineArray<(1+1), Int>, Float)> = [([1, 1], 1.1), ([2, 2], 2.2), ([3, 3], 3.3), ([4, 4], 4.4)]
+public let nested: InlineArray<1 + 3 * 2 - 3, (InlineArray<1+1, Int>, Float)> = [([1, 1], 1.1), ([2, 2], 2.2), ([3, 3], 3.3), ([4, 4], 4.4)]
 // CHECK-LABEL: public let nestedBoth: Swift::InlineArray<2, Swift::InlineArray<3, Swift::Int>>
-public let nestedBoth: InlineArray<(1 + 1), InlineArray<(2 + 1), Int>> = [[1, 2, 3], [4, 5, 6]]
+public let nestedBoth: InlineArray<1 + 1, InlineArray<2 + 1, Int>> = [[1, 2, 3], [4, 5, 6]]
 // CHECK-LABEL: public let sugar: [5 of Swift::Int]
-public let sugar: [(2 + 3) of Int] = [1, 2, 3, 4, 5]
+public let sugar: [2 + 3 of Int] = [1, 2, 3, 4, 5]
 // CHECK-LABEL: public let sugarShift: [4 of Swift::String]
-public let sugarShift: [(1 << 2) of String] = ["a", "b", "c", "d"]
+public let sugarShift: [1 << 2 of String] = ["a", "b", "c", "d"]
 // CHECK-LABEL: public let sugarNested: [2 of [3 of Swift::Int]]
-public let sugarNested: [(1 + 1) of [(2 + 1) of Int]] = [[1, 2, 3], [4, 5, 6]]
+public let sugarNested: [1 + 1 of [2 + 1 of Int]] = [[1, 2, 3], [4, 5, 6]]
 
 
 // CHECK-LABEL: public typealias PowerOfTwo = Swift::InlineArray<16, Swift::Int>
-public typealias PowerOfTwo = InlineArray<(1 << 4), Int>
+public typealias PowerOfTwo = InlineArray<1 << 4, Int>
 // CHECK-LABEL: public typealias ComputedSize = Swift::InlineArray<10, Swift::Int>
-public typealias ComputedSize = InlineArray<((3 + 2) * (4 - 2)), Int>
+public typealias ComputedSize = InlineArray<(3 + 2) * (4 - 2), Int>
 // CHECK-LABEL: public typealias SugarAlias = [6 of Swift::Double]
-public typealias SugarAlias = [(2 * 3) of Double]
+public typealias SugarAlias = [2 * 3 of Double]
 
 // CHECK-LABEL: public func takeArray(_ arr: Swift::InlineArray<4, Swift::Int>)
-public func takeArray(_ arr: InlineArray<(2 + 2), Int>) {}
+public func takeArray(_ arr: InlineArray<2 + 2, Int>) {}
 // CHECK-LABEL: public func takeSugar(_ arr: [2 of Swift::Int])
-public func takeSugar(_ arr: [(1 << 1) of Int]) {}
+public func takeSugar(_ arr: [1 << 1 of Int]) {}
 // CHECK-LABEL: public func returnArray() -> Swift::InlineArray<3, Swift::Int>
-public func returnArray() -> InlineArray<(2 + 1), Int> { return [1, 2, 3] }
+public func returnArray() -> InlineArray<2 + 1, Int> { return [1, 2, 3] }
 // CHECK-LABEL: public func returnSugar() -> [3 of Swift::String]
-public func returnSugar() -> [(4 - 1) of String] { return ["a", "b", "c"] }
+public func returnSugar() -> [4 - 1 of String] { return ["a", "b", "c"] }
 
 // CHECK-LABEL: public func takeGeneric<T>(_ arr: Swift::InlineArray<4, T>)
-public func takeGeneric<T>(_ arr: InlineArray<(2 * 2), T>) {}
+public func takeGeneric<T>(_ arr: InlineArray<2 * 2, T>) {}
 // CHECK-LABEL: public func returnGeneric<T>(_ t: T) -> Swift::InlineArray<3, T>
-public func returnGeneric<T>(_ t: T) -> InlineArray<(1 + 2), T> {
+public func returnGeneric<T>(_ t: T) -> InlineArray<1 + 2, T> {
   return InlineArray(repeating: t)
 }
 
@@ -58,11 +58,11 @@ public func returnGeneric<T>(_ t: T) -> InlineArray<(1 + 2), T> {
 // CHECK-NEXT:    public var data: Swift::InlineArray<5, Swift::Int>
 // CHECK-NEXT:    public var buffer: [4 of Swift::UInt8]
 public struct Container {
-  public var data: InlineArray<(3 + 2), Int>
-  public var buffer: [(1 << 2) of UInt8]
+  public var data: InlineArray<3 + 2, Int>
+  public var buffer: [1 << 2 of UInt8]
 
   // CHECK:       public init(data: Swift::InlineArray<5, Swift::Int>, buffer: [4 of Swift::UInt8])
-  public init(data: InlineArray<(3 + 2), Int>, buffer: [(1 << 2) of UInt8]) {
+  public init(data: InlineArray<3 + 2, Int>, buffer: [1 << 2 of UInt8]) {
     self.data = data
     self.buffer = buffer
   }

--- a/test/LiteralExpressions/IntegerGenericExpressionRequirementErrors.swift
+++ b/test/LiteralExpressions/IntegerGenericExpressionRequirementErrors.swift
@@ -16,7 +16,7 @@ extension V where M == 6 {
 }
 
 func testRequirementExprMatch() {
-  let a: V<(1+1), 6> = V()
+  let a: V<1+1, 6> = V()
   a.nIsTwo() // OK
   a.mIsSix() // OK
 }
@@ -26,29 +26,23 @@ struct S<let N: Int> {
 }
 
 func testRequirementExprMismatch() {
-  let b: V<(3 + 0), 0> = V()
+  let b: V<3 + 0, 0> = V()
   b.nIsTwo() // expected-error {{referencing instance method 'nIsTwo()' on 'V' requires the types '3' and '2' be equivalent}}
   b.mIsSix() // expected-error {{referencing instance method 'mIsSix()' on 'V' requires the types '0' and '6' be equivalent}}
 }
 
 func testRequirementExprToExprEquiv() {
-  let c: V<(1 + 1), 0> = V()
+  let c: V<1 + 1, 0> = V()
   c.nIsTwo() // OK
 }
 
 func takesV2<let M: Int>(_ v: V<2, M>) {}
 func takesV5<let M: Int>(_ v: V<5, M>) {}
 func testExprArgPassedToConstrainedFunc() {
-  let v: V<(1 + 1), 0> = V()
+  let v: V<1 + 1, 0> = V()
   takesV2(v)  // OK
   takesV5(v)  // expected-error {{cannot convert value of type 'V<2, 0>' to expected argument type 'V<5, 0>'}}
 }
-
-func foo(_: () -> Void) {}
-var _: S<(foo() { // expected-error {{closures are not supported in generic value literal expressions}}
-  struct Inner {}
-  let inner = Inner()
-})>
 
 struct SRef<let N: Int> {
     func foo() where S<(N)> == S<(1+1)> {}


### PR DESCRIPTION
Instead of asking users to specify the argument expression in a `(` `)` pair:
```swift
let x: InlineArray<(2+2), int> = ...
```
Allow plain expressions:
```swift
let x: InlineArray<2+2, int> = ...
```
This is achieved by:
- Changing the speculative parsing logic to, instead of `skipSingle()` on a perenthesized expression, skip **until** a `,`(comma) token or a `>`(greater than) token.
- Changing the `parseTypeOrValue` logic to *always* parse the generic argument as an expression (when the LiteralExpressions feature is enabled).
- Teaching expression parsing logic to, in the context of a generic argument expression, not consider operators `>` and `==` and `,`.
  - Those operators are all still available to the user if they do choose to parenthesize the generic argument expression.