### PR TITLE
[Sema] Avoid null-node crash for invalid closure parameter wrappers

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -12353,28 +12353,32 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
       }
 
       auto *backingVar = paramDecl->getPropertyWrapperBackingProperty();
-      setType(backingVar, backingType);
-
       auto *localWrappedVar = paramDecl->getPropertyWrapperWrappedValueVar();
-      setType(localWrappedVar, wrappedValueType);
 
-      if (auto *projection = paramDecl->getPropertyWrapperProjectionVar()) {
-        setType(projection, computeProjectedValueType(paramDecl, backingType));
-      }
+      // Invalid wrapper declarations can skip synthesizing local wrapper vars.
+      // Wrapper diagnostics are emitted by declaration checking; avoid
+      // crashing during closure constraint generation.
+      if (backingVar && localWrappedVar) {
+        setType(backingVar, backingType);
+        setType(localWrappedVar, wrappedValueType);
 
-      if (!paramDecl->getName().hasDollarPrefix()) {
-        if (generateWrappedPropertyTypeConstraints(paramDecl, backingType,
-                                                   param.getParameterType()))
+        if (auto *projection = paramDecl->getPropertyWrapperProjectionVar()) {
+          setType(projection, computeProjectedValueType(paramDecl, backingType));
+        }
+
+        if (!paramDecl->getName().hasDollarPrefix()) {
+          if (generateWrappedPropertyTypeConstraints(paramDecl, backingType,
+                                                     param.getParameterType()))
+            return false;
+        }
+
+        auto result = applyPropertyWrapperToParameter(
+            backingType, param.getParameterType(), paramDecl,
+            paramDecl->getName(), ConstraintKind::Equal,
+            getConstraintLocator(closure), getConstraintLocator(closure));
+        if (result.isFailure())
           return false;
       }
-
-      auto result = applyPropertyWrapperToParameter(backingType, param.getParameterType(),
-                                                    paramDecl, paramDecl->getName(),
-                                                    ConstraintKind::Equal,
-                                                    getConstraintLocator(closure),
-                                                    getConstraintLocator(closure));
-      if (result.isFailure())
-        return false;
     }
 
     Type internalType;

--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -2390,6 +2390,10 @@ static void applySolutionToClosurePropertyWrappers(ClosureExpr *closure,
 
     // Set the interface type of each property wrapper synthesized var
     auto *backingVar = param->getPropertyWrapperBackingProperty();
+    auto *wrappedValueVar = param->getPropertyWrapperWrappedValueVar();
+    if (!backingVar || !wrappedValueVar)
+      continue;
+
     auto backingType = solution.simplifyType(solution.getType(backingVar))
                            ->mapTypeOutOfEnvironment();
     backingVar->setInterfaceType(backingType);
@@ -2400,7 +2404,6 @@ static void applySolutionToClosurePropertyWrappers(ClosureExpr *closure,
               ->mapTypeOutOfEnvironment());
     }
 
-    auto *wrappedValueVar = param->getPropertyWrapperWrappedValueVar();
     auto wrappedValueType =
         solution.simplifyType(solution.getType(wrappedValueVar))
             ->mapTypeOutOfEnvironment();

--- a/test/Sema/property_wrapper_parameter_invalid.swift
+++ b/test/Sema/property_wrapper_parameter_invalid.swift
@@ -299,3 +299,12 @@ func testInvalidProjectionInAmbiguousContext() {
     ambiguous()
   }
 }
+
+// https://github.com/swiftlang/swift/issues/87479
+@propertyWrapper
+struct MissingWrappedValue { // expected-error {{property wrapper type 'MissingWrappedValue' does not contain a non-static property named 'wrappedValue'}}
+}
+
+let _: (Int) -> Int = { (@MissingWrappedValue value) in
+  value
+}


### PR DESCRIPTION
## Summary
This fixes an assertion crash when a closure parameter uses an invalid property wrapper.

For code like:

```swift
@propertyWrapper
struct A {}

let c = { (@A x) in
  return x
}
```

the compiler was asserting in `ConstraintSystem::setType` because closure wrapper-synthesized vars could be missing, but `resolveClosure` unconditionally attempted to assign types to them.

## What changed
- In `ConstraintSystem::resolveClosure` (`lib/Sema/CSSimplify.cpp`):
  - Guard use of closure wrapper-synthesized vars (`backingVar`, `wrappedValueVar`).
  - Only run wrapper-specific type assignment and wrapper constraints when those vars are present.
- In `applySolutionToClosurePropertyWrappers` (`lib/Sema/CSSyntacticElement.cpp`):
  - Guard interface type assignment for wrapper vars the same way.
- Added regression coverage in `test/Sema/property_wrapper_parameter_invalid.swift` for #87479.

## Why this approach
Invalid wrapper declarations are already diagnosed by declaration checking. In this path we only need to avoid crashing while closure constraints are being resolved/applied.

## Before / After
Before:
- Assertion failure during type checking (`Cannot set type information on null node`).

After:
- No null-node assignment in closure wrapper handling when synthesized vars are missing.
- Existing wrapper diagnostic is preserved, and regression coverage is added.

## Issue
Fixes #87479
