### PR TITLE
Generalize `String` functions for typed throws

### DIFF
--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -229,15 +229,15 @@ extension _SmallString: RandomAccessCollection, MutableCollection {
 }
 
 extension _SmallString {
-  @inlinable @inline(__always)
+  @_alwaysEmitIntoClient @inline(__always)
   @safe
-  internal func withUTF8<Result>(
-    _ f: (UnsafeBufferPointer<UInt8>) throws -> Result
-  ) rethrows -> Result {
+  internal func withUTF8<Result, E: Error>(
+    _ f: (UnsafeBufferPointer<UInt8>) throws(E) -> Result
+  ) throws(E) -> Result {
     let count = self.count
     var raw = self.zeroTerminatedRawCodeUnits
-    return try unsafe Swift._withUnprotectedUnsafeBytes(of: &raw) {
-      let rawPtr = unsafe $0.baseAddress._unsafelyUnwrappedUnchecked
+    return try unsafe Swift._withUnprotectedUnsafeBytes(of: &raw) { buffer throws(E) in
+      let rawPtr = unsafe buffer.baseAddress._unsafelyUnwrappedUnchecked
       // Rebind the underlying (UInt64, UInt64) tuple to UInt8 for the
       // duration of the closure. Accessing self after this rebind is undefined.
       let ptr = unsafe rawPtr.bindMemory(to: UInt8.self, capacity: count)
@@ -249,15 +249,30 @@ extension _SmallString {
     }
   }
 
+#if !hasFeature(Embedded)
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @abi(
+    func withUTF8<Result>(
+      _ f: (UnsafeBufferPointer<UInt8>) throws -> Result
+    ) throws -> Result
+  )
+  @usableFromInline
+  internal func __rethrows_withUTF8<Result>(
+    _ f: (UnsafeBufferPointer<UInt8>) throws -> Result
+  ) throws -> Result {
+    return try self.withUTF8(f)
+  }
+#endif // !hasFeature(Embedded)
+
   // Overwrite stored code units, including uninitialized. `f` should return the
   // new count. This will re-establish the invariant after `f` that all bits
   // between the last code unit and the discriminator are unset.
-  @inline(__always)
-  fileprivate mutating func withMutableCapacity(
-    _ f: (UnsafeMutableRawBufferPointer) throws -> Int
-  ) rethrows {
-    let len = try unsafe withUnsafeMutableBytes(of: &_storage) {
-      try unsafe f(.init(start: $0.baseAddress, count: _SmallString.capacity))
+  @_alwaysEmitIntoClient @inline(__always)
+  fileprivate mutating func withMutableCapacity<E: Error>(
+    _ f: (UnsafeMutableRawBufferPointer) throws(E) -> Int
+  ) throws(E) {
+    let len = try unsafe withUnsafeMutableBytes(of: &_storage) { buffer throws(E) in
+      try unsafe f(.init(start: buffer.baseAddress, count: _SmallString.capacity))
     }
 
     if len <= 0 {
@@ -321,14 +336,14 @@ extension _SmallString {
   }
 
   @inline(__always)
-  internal init(
+  internal init<E: Error>(
     initializingUTF8With initializer: (
       _ buffer: UnsafeMutableBufferPointer<UInt8>
-    ) throws -> Int
-  ) rethrows {
+    ) throws(E) -> Int
+  ) throws(E) {
     self.init()
-    try unsafe self.withMutableCapacity {
-      try unsafe $0.withMemoryRebound(to: UInt8.self, initializer)
+    try unsafe self.withMutableCapacity { buffer throws(E) in
+      try unsafe buffer.withMemoryRebound(to: UInt8.self, initializer)
     }
     self._invariantCheck()
   }

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -641,30 +641,94 @@ extension String {
   ///   - initializer: A closure that accepts a buffer covering uninitialized
   ///     memory with room for `capacity` UTF-8 code units, initializes
   ///     that memory, and returns the number of initialized elements.
-  @inline(__always)
+#if hasFeature(Embedded)
+  @_alwaysEmitIntoClient @inline(__always)
   @available(SwiftStdlib 5.3, *)
-  public init(
+  public init<E: Error>(
     unsafeUninitializedCapacity capacity: Int,
     initializingUTF8With initializer: (
       _ buffer: UnsafeMutableBufferPointer<UInt8>
-    ) throws -> Int
-  ) rethrows {
+    ) throws(E) -> Int
+  ) throws(E) {
+    // Unable to call init(__rethrows_unsafeUninitializedCapacity:initializingUTF8With:)
+    // in Embedded Swift due to thrown `any Error`.
+
+    try unsafe self.init(
+      __impl_unsafeUninitializedCapacity: capacity,
+      initializingUTF8With: initializer
+    )
+  }
+
+  @available(SwiftStdlib 5.3, *)
+  @usableFromInline
+  internal init<E: Error>(
+    __impl_unsafeUninitializedCapacity capacity: Int,
+    initializingUTF8With initializer: (
+      _ buffer: UnsafeMutableBufferPointer<UInt8>
+    ) throws(E) -> Int
+  ) throws(E) {
     self = try unsafe String(
       _uninitializedCapacity: capacity,
       initializingUTF8With: initializer
     )
   }
+#else
+  @_alwaysEmitIntoClient @inline(__always)
+  @available(SwiftStdlib 5.3, *)
+  public init<E: Error>(
+    unsafeUninitializedCapacity capacity: Int,
+    initializingUTF8With initializer: (
+      _ buffer: UnsafeMutableBufferPointer<UInt8>
+    ) throws(E) -> Int
+  ) throws(E) {
+    do {
+      try unsafe self.init(
+        __rethrows_unsafeUninitializedCapacity: capacity,
+        initializingUTF8With: initializer
+      )
+    } catch {
+      throw error as! E
+    }
+  }
 
-  @inline(__always)
+  // ABI-preserved entrypoint for the rethrows version of init(unsafeUninitializedCapacity:initializingUTF8With:),
+  // which has been superseded by the typed-throws version. Expressed as "throws",
+  // which is ABI-compatible with "rethrows".
+  // Called from the typed throws version to avoid exposing the non-usableFromInline
+  // String(_uninitializedCapacity:initializingUTF8With:) as ABI.
+  @abi(
+    init(
+      unsafeUninitializedCapacity capacity: Int,
+      initializingUTF8With initializer: (
+        _ buffer: UnsafeMutableBufferPointer<UInt8>
+      ) throws -> Int
+    ) throws
+  )
+  @available(SwiftStdlib 5.3, *)
+  @usableFromInline
   internal init(
-    _uninitializedCapacity capacity: Int,
+    __rethrows_unsafeUninitializedCapacity capacity: Int,
     initializingUTF8With initializer: (
       _ buffer: UnsafeMutableBufferPointer<UInt8>
     ) throws -> Int
-  ) rethrows {
+  ) throws {
+    self = try unsafe String(
+      _uninitializedCapacity: capacity,
+      initializingUTF8With: initializer
+    )
+  }
+#endif // hasFeature(Embedded)
+
+  @inline(__always)
+  internal init<E: Error>(
+    _uninitializedCapacity capacity: Int,
+    initializingUTF8With initializer: (
+      _ buffer: UnsafeMutableBufferPointer<UInt8>
+    ) throws(E) -> Int
+  ) throws(E) {
     if _fastPath(capacity <= _SmallString.capacity) {
-      let smol = try unsafe _SmallString(initializingUTF8With: {
-        try unsafe initializer(.init(start: $0.baseAddress, count: capacity))
+      let smol = try unsafe _SmallString(initializingUTF8With: { buffer throws(E) in
+        try unsafe initializer(.init(start: buffer.baseAddress, count: capacity))
       })
       // Fast case where we fit in a _SmallString and don't need UTF8 validation
       if _fastPath(smol.isASCII) {
@@ -694,12 +758,27 @@ extension String {
   ///   `withCString(_:)` method. The pointer argument is valid only for the
   ///   duration of the method's execution.
   /// - Returns: The return value, if any, of the `body` closure parameter.
-  @inlinable // fast-path: already C-string compatible
-  public func withCString<Result>(
-    _ body: (UnsafePointer<Int8>) throws -> Result
-  ) rethrows -> Result {
+  @_alwaysEmitIntoClient // (Primarily @inlinable) fast-path: already C-string compatible
+  public func withCString<Result, E: Error>(
+    _ body: (UnsafePointer<Int8>) throws(E) -> Result
+  ) throws(E) -> Result {
     return try unsafe _guts.withCString(body)
   }
+
+#if !hasFeature(Embedded)
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @abi(
+    func withCString<Result>(
+      _ body: (UnsafePointer<Int8>) throws -> Result
+    ) throws -> Result
+  )
+  @usableFromInline
+  internal func __rethrows_withCString<Result>(
+    _ body: (UnsafePointer<Int8>) throws -> Result
+  ) throws -> Result {
+    return try unsafe withCString(body)
+  }
+#endif // !hasFeature(Embedded)
 
   /// Calls the given closure with a pointer to the contents of the string,
   /// represented as a null-terminated sequence of code units.
@@ -717,15 +796,15 @@ extension String {
   ///   - targetEncoding: The encoding in which the code units should be
   ///     interpreted.
   /// - Returns: The return value, if any, of the `body` closure parameter.
-  @inlinable
+  @_alwaysEmitIntoClient
   @inline(__always) // Eliminate dynamic type check when possible
-  public func withCString<Result, TargetEncoding: Unicode.Encoding>(
+  public func withCString<Result, TargetEncoding: Unicode.Encoding, E: Error>(
     encodedAs targetEncoding: TargetEncoding.Type,
-    _ body: (UnsafePointer<TargetEncoding.CodeUnit>) throws -> Result
-  ) rethrows -> Result {
+    _ body: (UnsafePointer<TargetEncoding.CodeUnit>) throws(E) -> Result
+  ) throws(E) -> Result {
     if targetEncoding == UTF8.self {
       return try unsafe self.withCString {
-        (cPtr: UnsafePointer<CChar>) -> Result  in
+        (cPtr: UnsafePointer<CChar>) throws(E) -> Result  in
         _internalInvariant(UInt8.self == TargetEncoding.CodeUnit.self)
         let ptr = unsafe UnsafeRawPointer(cPtr).assumingMemoryBound(
           to: TargetEncoding.CodeUnit.self)
@@ -735,14 +814,31 @@ extension String {
     return try unsafe _slowWithCString(encodedAs: targetEncoding, body)
   }
 
-  @usableFromInline @inline(never) // slow-path
-  @_effects(releasenone)
-  internal func _slowWithCString<Result, TargetEncoding: Unicode.Encoding>(
+#if !hasFeature(Embedded)
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @abi(
+    func withCString<Result, TargetEncoding: Unicode.Encoding>(
+      encodedAs targetEncoding: TargetEncoding.Type,
+      _ body: (UnsafePointer<TargetEncoding.CodeUnit>) throws -> Result
+    ) throws -> Result
+  )
+  @usableFromInline
+  internal func __rethrows_withCString<Result, TargetEncoding: Unicode.Encoding>(
     encodedAs targetEncoding: TargetEncoding.Type,
     _ body: (UnsafePointer<TargetEncoding.CodeUnit>) throws -> Result
-  ) rethrows -> Result {
+  ) throws -> Result {
+    return try unsafe withCString(encodedAs: targetEncoding, body)
+  }
+#endif // !hasFeature(Embedded)
+
+  @_alwaysEmitIntoClient @inline(never) // slow-path
+  @_effects(releasenone)
+  internal func _slowWithCString<Result, TargetEncoding: Unicode.Encoding, E: Error>(
+    encodedAs targetEncoding: TargetEncoding.Type,
+    _ body: (UnsafePointer<TargetEncoding.CodeUnit>) throws(E) -> Result
+  ) throws(E) -> Result {
     var copy = self
-    return try copy.withUTF8 { utf8 in
+    return try copy.withUTF8 { utf8 throws(E) in
       var arg = Array<TargetEncoding.CodeUnit>()
       arg.reserveCapacity(1 &+ self._guts.count / 4)
       let repaired = unsafe transcode(
@@ -756,6 +852,25 @@ extension String {
       return try unsafe body(arg)
     }
   }
+
+#if !hasFeature(Embedded)
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @abi(
+    func _slowWithCString<Result, TargetEncoding: Unicode.Encoding>(
+      encodedAs targetEncoding: TargetEncoding.Type,
+      _ body: (UnsafePointer<TargetEncoding.CodeUnit>) throws -> Result
+    ) throws -> Result
+  )
+  @usableFromInline
+  internal func __rethrows_underscore_slowWithCString<
+    Result, TargetEncoding: Unicode.Encoding
+  >(
+    encodedAs targetEncoding: TargetEncoding.Type,
+    _ body: (UnsafePointer<TargetEncoding.CodeUnit>) throws -> Result
+  ) throws -> Result {
+    return try unsafe _slowWithCString(encodedAs: targetEncoding, body)
+  }
+#endif // !hasFeature(Embedded)
 }
 
 extension String: _ExpressibleByBuiltinUnicodeScalarLiteral {
@@ -1106,10 +1221,56 @@ extension String {
     return codeUnits
   }
 
+#if hasFeature(Embedded)
+  @_alwaysEmitIntoClient
   public // @testable
-  func _withNFCCodeUnits(_ f: (UInt8) throws -> Void) rethrows {
+  func _withNFCCodeUnits<E: Error>(
+    _ f: (UInt8) throws(E) -> Void
+  ) throws(E) {
+    // Unable to call __rethrows_underscore_withNFCCodeUnits(_:)
+    // in Embedded Swift due to thrown `any Error`.
+
+    try _withNFCCodeUnitsImpl(f)
+  }
+
+  @usableFromInline
+  internal
+  func _withNFCCodeUnitsImpl<E: Error>(
+    _ f: (UInt8) throws(E) -> Void
+  ) throws(E) {
     try _gutsSlice._withNFCCodeUnits(f)
   }
+#else
+  @_alwaysEmitIntoClient
+  public // @testable
+  func _withNFCCodeUnits<E: Error>(
+    _ f: (UInt8) throws(E) -> Void
+  ) throws(E) {
+    do {
+      try __rethrows_underscore_withNFCCodeUnits(f)
+    } catch {
+      throw error as! E
+    }
+  }
+
+  // ABI-preserved entrypoint for the rethrows version of _withNFCCodeUnits,
+  // which has been superseded by the typed-throws version. Expressed as "throws",
+  // which is ABI-compatible with "rethrows".
+  // Called from the typed throws version to avoid exposing the non-usableFromInline
+  // _gutsSlice._withNFCCodeUnits as ABI.
+  @abi(
+    func _withNFCCodeUnits(
+      _ f: (UInt8) throws -> Void
+    ) throws
+  )
+  @usableFromInline
+  internal
+  func __rethrows_underscore_withNFCCodeUnits(
+    _ f: (UInt8) throws -> Void
+  ) throws {
+    try _gutsSlice._withNFCCodeUnits(f)
+  }
+#endif
 }
 
 extension String {

--- a/stdlib/public/core/StringCreate.swift
+++ b/stdlib/public/core/StringCreate.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -188,12 +188,12 @@ extension String {
     }
   }
 
-  internal static func _fromLargeUTF8Repairing(
+  internal static func _fromLargeUTF8Repairing<E: Error>(
     uninitializedCapacity capacity: Int,
     initializingWith initializer: (
       _ buffer: UnsafeMutableBufferPointer<UInt8>
-    ) throws -> Int
-  ) rethrows -> String {
+    ) throws(E) -> Int
+  ) throws(E) -> String {
     let result = try unsafe __StringStorage.create(
       uninitializedCodeUnitCapacity: capacity,
       initializingUncheckedUTF8With: initializer)

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -158,10 +158,10 @@ extension _StringGuts {
      return _slowPath(_object.isForeign)
   }
 
-  @inlinable @inline(__always)
-  internal func withFastUTF8<R>(
-    _ f: (UnsafeBufferPointer<UInt8>) throws -> R
-  ) rethrows -> R {
+  @_alwaysEmitIntoClient @inline(__always)
+  internal func withFastUTF8<R, E: Error>(
+    _ f: (UnsafeBufferPointer<UInt8>) throws(E) -> R
+  ) throws(E) -> R {
     _internalInvariant(isFastUTF8)
 
     if self.isSmall { return try _SmallString(_object).withUTF8(f) }
@@ -170,24 +170,71 @@ extension _StringGuts {
     return try unsafe f(_object.fastUTF8)
   }
 
-  @inlinable @inline(__always)
-  internal func withFastUTF8<R>(
-    range: Range<Int>,
+#if !hasFeature(Embedded)
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @abi(
+    func withFastUTF8<R>(
+      _ f: (UnsafeBufferPointer<UInt8>) throws -> R
+    ) throws -> R
+  )
+  @usableFromInline
+  internal func __rethrows_withFastUTF8<R>(
     _ f: (UnsafeBufferPointer<UInt8>) throws -> R
-  ) rethrows -> R {
-    return try unsafe self.withFastUTF8 { wholeUTF8 in
+  ) throws -> R {
+    return try unsafe self.withFastUTF8(f)
+  }
+#endif // !hasFeature(Embedded)
+
+  @_alwaysEmitIntoClient @inline(__always)
+  internal func withFastUTF8<R, E: Error>(
+    range: Range<Int>,
+    _ f: (UnsafeBufferPointer<UInt8>) throws(E) -> R
+  ) throws(E) -> R {
+    return try unsafe self.withFastUTF8 { wholeUTF8 throws(E) in
       return try unsafe f(unsafe UnsafeBufferPointer(rebasing: wholeUTF8[range]))
     }
   }
 
-  @inlinable @inline(__always)
-  internal func withFastCChar<R>(
-    _ f: (UnsafeBufferPointer<CChar>) throws -> R
-  ) rethrows -> R {
-    return try unsafe self.withFastUTF8 { utf8 in
+#if !hasFeature(Embedded)
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @abi(
+    func withFastUTF8<R>(
+      range: Range<Int>,
+      _ f: (UnsafeBufferPointer<UInt8>) throws -> R
+    ) throws -> R
+  )
+  @usableFromInline
+  internal func __rethrows_withFastUTF8<R>(
+    range: Range<Int>,
+    _ f: (UnsafeBufferPointer<UInt8>) throws -> R
+  ) throws -> R {
+    return try unsafe self.withFastUTF8(range: range, f)
+  }
+#endif // !hasFeature(Embedded)
+
+  @_alwaysEmitIntoClient @inline(__always)
+  internal func withFastCChar<R, E: Error>(
+    _ f: (UnsafeBufferPointer<CChar>) throws(E) -> R
+  ) throws(E) -> R {
+    return try unsafe self.withFastUTF8 { utf8 throws(E) in
       return try unsafe utf8.withMemoryRebound(to: CChar.self, f)
     }
   }
+
+#if !hasFeature(Embedded)
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @abi(
+    func withFastCChar<R>(
+      _ f: (UnsafeBufferPointer<CChar>) throws -> R
+    ) throws -> R
+  )
+  @usableFromInline
+  internal func __rethrows_withFastCChar<R>(
+    _ f: (UnsafeBufferPointer<CChar>) throws -> R
+  ) throws -> R {
+    return try unsafe self.withFastCChar(f)
+  }
+#endif // !hasFeature(Embedded)
 }
 
 // Internal invariants
@@ -218,30 +265,60 @@ extension _StringGuts {
 
 // C String interop
 extension _StringGuts {
-  @inlinable @inline(__always) // fast-path: already C-string compatible
-  internal func withCString<Result>(
-    _ body: (UnsafePointer<Int8>) throws -> Result
-  ) rethrows -> Result {
+  @_alwaysEmitIntoClient @inline(__always) // fast-path: already C-string compatible
+  internal func withCString<Result, E: Error>(
+    _ body: (UnsafePointer<Int8>) throws(E) -> Result
+  ) throws(E) -> Result {
     if _slowPath(!_object.isFastZeroTerminated) {
       return try unsafe _slowWithCString(body)
     }
 
-    return try unsafe self.withFastCChar {
-      return try unsafe body($0.baseAddress._unsafelyUnwrappedUnchecked)
+    return try unsafe self.withFastCChar { cchar throws(E) in
+      return try unsafe body(cchar.baseAddress._unsafelyUnwrappedUnchecked)
     }
   }
 
-  @inline(never) // slow-path
+#if !hasFeature(Embedded)
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @abi(
+    func withCString<Result>(
+      _ body: (UnsafePointer<Int8>) throws -> Result
+    ) throws -> Result
+  )
   @usableFromInline
-  internal func _slowWithCString<Result>(
+  internal func __rethrows_withCString<Result>(
     _ body: (UnsafePointer<Int8>) throws -> Result
-  ) rethrows -> Result {
+  ) throws -> Result {
+    return try unsafe self.withCString(body)
+  }
+#endif // !hasFeature(Embedded)
+
+  @inline(never) // slow-path
+  @_alwaysEmitIntoClient
+  internal func _slowWithCString<Result, E: Error>(
+    _ body: (UnsafePointer<Int8>) throws(E) -> Result
+  ) throws(E) -> Result {
     _internalInvariant(!_object.isFastZeroTerminated)
-    return try unsafe String(self).utf8CString.withUnsafeBufferPointer {
-      let ptr = unsafe $0.baseAddress._unsafelyUnwrappedUnchecked
+    return try unsafe String(self).utf8CString.withUnsafeBufferPointer { buffer throws(E) in
+      let ptr = unsafe buffer.baseAddress._unsafelyUnwrappedUnchecked
       return try unsafe body(ptr)
     }
   }
+  
+#if !hasFeature(Embedded)
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @abi(
+    func _slowWithCString<Result>(
+      _ body: (UnsafePointer<Int8>) throws -> Result
+    ) throws -> Result
+  )
+  @usableFromInline
+  internal func __rethrows_underscore_slowWithCString<Result>(
+    _ body: (UnsafePointer<Int8>) throws -> Result
+  ) throws -> Result {
+    return try unsafe self._slowWithCString(body)
+  }
+#endif // !hasFeature(Embedded)
 }
 
 extension _StringGuts {

--- a/stdlib/public/core/StringGutsSlice.swift
+++ b/stdlib/public/core/StringGutsSlice.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -79,9 +79,9 @@ internal struct _StringGutsSlice {
   }
 
   @inline(__always)
-  internal func withFastUTF8<R>(
-    _ f: (UnsafeBufferPointer<UInt8>) throws -> R
-  ) rethrows -> R {
+  internal func withFastUTF8<R, E: Error>(
+    _ f: (UnsafeBufferPointer<UInt8>) throws(E) -> R
+  ) throws(E) -> R {
     return try unsafe _guts.withFastUTF8(range: _offsetRange, f)
   }
 

--- a/stdlib/public/core/StringNormalization.swift
+++ b/stdlib/public/core/StringNormalization.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -72,12 +72,16 @@ internal func _isScalarNFCQC(
 }
 
 extension _StringGutsSlice {
-  internal func _withNFCCodeUnits(_ f: (UInt8) throws -> Void) rethrows {
+  internal func _withNFCCodeUnits<E: Error>(
+    _ f: (UInt8) throws(E) -> Void
+  ) throws(E) {
     let substring = String(_guts)[range]
     // Fast path: If we're already NFC (or ASCII), then we don't need to do
     // anything at all.
     if _fastPath(_guts.isNFC) {
-      try substring.utf8.forEach(f)
+      for byte in substring.utf8 {
+        try f(byte)
+      }
       return
     }
 
@@ -90,8 +94,8 @@ extension _StringGutsSlice {
       // Because we have access to the fastUTF8, we can go through that instead
       // of accessing the UTF8 view on String.
       if isNFCQC {
-        try unsafe withFastUTF8 {
-          for unsafe byte in unsafe $0 {
+        try unsafe withFastUTF8 { buffer throws(E) in
+          for unsafe byte in unsafe buffer {
             try f(byte)
           }
         }
@@ -116,8 +120,8 @@ extension _StringGutsSlice {
     }
 
     for scalar in substring.unicodeScalars._internalNFC {
-      try scalar.withUTF8CodeUnits {
-        for unsafe byte in unsafe $0 {
+      try scalar.withUTF8CodeUnits { buffer throws(E) in
+        for unsafe byte in unsafe buffer {
           try f(byte)
         }
       }

--- a/stdlib/public/core/StringProtocol.swift
+++ b/stdlib/public/core/StringProtocol.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -225,9 +225,9 @@ extension String {
   ///
   @_alwaysEmitIntoClient
   @safe
-  public mutating func withUTF8<R>(
-    _ body: (UnsafeBufferPointer<UInt8>) throws -> R
-  ) rethrows -> R {
+  public mutating func withUTF8<R, E: Error>(
+    _ body: (UnsafeBufferPointer<UInt8>) throws(E) -> R
+  ) throws(E) -> R {
     makeContiguousUTF8()
     return try unsafe _guts.withFastUTF8(body)
   }
@@ -293,9 +293,9 @@ extension Substring {
   ///
   @_alwaysEmitIntoClient
   @safe
-  public mutating func withUTF8<R>(
-    _ body: (UnsafeBufferPointer<UInt8>) throws -> R
-  ) rethrows -> R {
+  public mutating func withUTF8<R, E: Error>(
+    _ body: (UnsafeBufferPointer<UInt8>) throws(E) -> R
+  ) throws(E) -> R {
     makeContiguousUTF8()
     return try unsafe _wholeGuts.withFastUTF8(range: _offsetRange, body)
   }

--- a/stdlib/public/core/StringStorage.swift
+++ b/stdlib/public/core/StringStorage.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -361,12 +361,12 @@ extension __StringStorage {
 
   // The caller is expected to check UTF8 validity and ASCII-ness and update
   // the resulting StringStorage accordingly
-  internal static func create(
+  internal static func create<E: Error>(
     uninitializedCodeUnitCapacity capacity: Int,
     initializingUncheckedUTF8With initializer: (
       _ buffer: UnsafeMutableBufferPointer<UInt8>
-    ) throws -> Int
-  ) rethrows -> __StringStorage {
+    ) throws(E) -> Int
+  ) throws(E) -> __StringStorage {
     let storage = __StringStorage.create(
       codeUnitCapacity: capacity,
       countAndFlags: _CountAndFlags(mortalCount: 0, isASCII: false)

--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -517,13 +517,28 @@ extension Substring: StringProtocol {
   ///   `withCString(_:)` method. The pointer argument is valid only for the
   ///   duration of the method's execution.
   /// - Returns: The return value, if any, of the `body` closure parameter.
-  @inlinable // specialization
-  public func withCString<Result>(
-    _ body: (UnsafePointer<CChar>) throws -> Result) rethrows -> Result {
+  @_alwaysEmitIntoClient // (Primarily @inlinable) specialization
+  public func withCString<Result, E: Error>(
+    _ body: (UnsafePointer<CChar>) throws(E) -> Result) throws(E) -> Result {
     // TODO(String performance): Detect when we cover the rest of a nul-
     // terminated String, and thus can avoid a copy.
     return try unsafe String(self).withCString(body)
   }
+
+#if !hasFeature(Embedded)
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @abi(
+    func withCString<Result>(
+      _ body: (UnsafePointer<CChar>) throws -> Result
+    ) throws -> Result
+  )
+  @usableFromInline
+  internal func __rethrows_withCString<Result>(
+    _ body: (UnsafePointer<CChar>) throws -> Result
+  ) throws -> Result {
+    return try unsafe withCString(body)
+  }
+#endif // !hasFeature(Embedded)
 
   /// Calls the given closure with a pointer to the contents of the string,
   /// represented as a null-terminated sequence of code units.
@@ -541,15 +556,32 @@ extension Substring: StringProtocol {
   ///   - targetEncoding: The encoding in which the code units should be
   ///     interpreted.
   /// - Returns: The return value, if any, of the `body` closure parameter.
-  @inlinable // specialization
-  public func withCString<Result, TargetEncoding: _UnicodeEncoding>(
+  @_alwaysEmitIntoClient // (Primarily @inlinable) specialization
+  public func withCString<Result, TargetEncoding: _UnicodeEncoding, E: Error>(
     encodedAs targetEncoding: TargetEncoding.Type,
-    _ body: (UnsafePointer<TargetEncoding.CodeUnit>) throws -> Result
-  ) rethrows -> Result {
+    _ body: (UnsafePointer<TargetEncoding.CodeUnit>) throws(E) -> Result
+  ) throws(E) -> Result {
     // TODO(String performance): Detect when we cover the rest of a nul-
     // terminated String, and thus can avoid a copy.
     return try unsafe String(self).withCString(encodedAs: targetEncoding, body)
   }
+
+#if !hasFeature(Embedded)
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @abi(
+    func withCString<Result, TargetEncoding: Unicode.Encoding>(
+      encodedAs targetEncoding: TargetEncoding.Type,
+      _ body: (UnsafePointer<TargetEncoding.CodeUnit>) throws -> Result
+    ) throws -> Result
+  )
+  @usableFromInline
+  internal func __rethrows_withCString<Result, TargetEncoding: Unicode.Encoding>(
+    encodedAs targetEncoding: TargetEncoding.Type,
+    _ body: (UnsafePointer<TargetEncoding.CodeUnit>) throws -> Result
+  ) throws -> Result {
+    return try unsafe withCString(encodedAs: targetEncoding, body)
+  }
+#endif // !hasFeature(Embedded)
 }
 
 extension Substring {

--- a/stdlib/public/core/UnicodeScalar.swift
+++ b/stdlib/public/core/UnicodeScalar.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -520,20 +520,35 @@ extension Unicode.Scalar {
   }
 
   // Access the scalar as encoded in UTF-8
-  @inlinable
+  @_alwaysEmitIntoClient
   @safe
-  internal func withUTF8CodeUnits<Result>(
-    _ body: (UnsafeBufferPointer<UInt8>) throws -> Result
-  ) rethrows -> Result {
+  internal func withUTF8CodeUnits<Result, E: Error>(
+    _ body: (UnsafeBufferPointer<UInt8>) throws(E) -> Result
+  ) throws(E) -> Result {
     let encodedScalar = UTF8.encode(self)!
     var (codeUnits, utf8Count) = encodedScalar._bytes
 
     // The first code unit is in the least significant byte of codeUnits.
     codeUnits = codeUnits.littleEndian
-    return try unsafe Swift._withUnprotectedUnsafePointer(to: &codeUnits) {
-      return try unsafe $0.withMemoryRebound(to: UInt8.self, capacity: 4) {
-        return try unsafe body(UnsafeBufferPointer(start: $0, count: utf8Count))
+    return try unsafe Swift._withUnprotectedUnsafePointer(to: &codeUnits) { buffer throws(E) in
+      return try unsafe buffer.withMemoryRebound(to: UInt8.self, capacity: 4) { rebound throws(E) in
+        return try unsafe body(UnsafeBufferPointer(start: rebound, count: utf8Count))
       }
     }
   }
+
+#if !hasFeature(Embedded)
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @abi(
+    func withUTF8CodeUnits<Result>(
+      _ body: (UnsafeBufferPointer<UInt8>) throws -> Result
+    ) throws -> Result
+  )
+  @usableFromInline
+  internal func __rethrows_withUTF8CodeUnits<Result>(
+    _ body: (UnsafeBufferPointer<UInt8>) throws -> Result
+  ) throws -> Result {
+    return try self.withUTF8CodeUnits(body)
+  }
+#endif // !hasFeature(Embedded)
 }

--- a/test/IDE/complete_literal.swift
+++ b/test/IDE/complete_literal.swift
@@ -28,7 +28,7 @@
   "swift".#^LITERAL4^#
 }
 
-// LITERAL4-DAG:     Decl[InstanceMethod]/CurrNominal/IsSystem: withCString({#(body): (UnsafePointer<Int8>) throws -> Result##(UnsafePointer<Int8>) throws -> Result#})[' rethrows'][#Result#]; name=withCString(:){{$}}
+// LITERAL4-DAG:     Decl[InstanceMethod]/CurrNominal/IsSystem: withCString({#(body): (UnsafePointer<Int8>) throws(Error) -> Result##(UnsafePointer<Int8>) throws(Error) -> Result#})[' throws'][#Result#]; name=withCString(:){{$}}
 
 // FIXME: we should show the qualified String.Index type.
 // rdar://problem/20788802

--- a/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
@@ -65,6 +65,18 @@ Func Set.filter(_:) has self access kind changing from __Consuming to Consuming
 Func Set.filter(_:) is now without rethrows
 Func Substring.filter(_:) has generic signature change from to <E where E : Swift.Error>
 Func Substring.filter(_:) is now without rethrows
+Func String.withCString(_:) has generic signature change from <Result> to <Result, E where E : Swift.Error>
+Func String.withCString(_:) is now without rethrows
+Func String.withCString(encodedAs:_:) has generic signature change from <Result, TargetEncoding where TargetEncoding : Swift._UnicodeEncoding> to <Result, TargetEncoding, E where TargetEncoding : Swift._UnicodeEncoding, E : Swift.Error>
+Func String.withCString(encodedAs:_:) is now without rethrows
+Func String.withUTF8(_:) has generic signature change from <R> to <R, E where E : Swift.Error>
+Func String.withUTF8(_:) is now without rethrows
+Func Substring.withCString(_:) has generic signature change from <Result> to <Result, E where E : Swift.Error>
+Func Substring.withCString(_:) is now without rethrows
+Func Substring.withCString(encodedAs:_:) has generic signature change from <Result, TargetEncoding where TargetEncoding : Swift._UnicodeEncoding> to <Result, TargetEncoding, E where TargetEncoding : Swift._UnicodeEncoding, E : Swift.Error>
+Func Substring.withCString(encodedAs:_:) is now without rethrows
+Func Substring.withUTF8(_:) has generic signature change from <R> to <R, E where E : Swift.Error>
+Func Substring.withUTF8(_:) is now without rethrows
 
 Protocol SIMDScalar has generic signature change from <Self == Self.SIMD16Storage.Scalar, Self.SIMD16Storage : Swift.SIMDStorage, Self.SIMD2Storage : Swift.SIMDStorage, Self.SIMD32Storage : Swift.SIMDStorage, Self.SIMD4Storage : Swift.SIMDStorage, Self.SIMD64Storage : Swift.SIMDStorage, Self.SIMD8Storage : Swift.SIMDStorage, Self.SIMDMaskScalar : Swift.FixedWidthInteger, Self.SIMDMaskScalar : Swift.SIMDScalar, Self.SIMDMaskScalar : Swift.SignedInteger, Self.SIMD16Storage.Scalar == Self.SIMD2Storage.Scalar, Self.SIMD2Storage.Scalar == Self.SIMD32Storage.Scalar, Self.SIMD32Storage.Scalar == Self.SIMD4Storage.Scalar, Self.SIMD4Storage.Scalar == Self.SIMD64Storage.Scalar, Self.SIMD64Storage.Scalar == Self.SIMD8Storage.Scalar> to <Self : Swift.BitwiseCopyable, Self == Self.SIMD16Storage.Scalar, Self.SIMD16Storage : Swift.SIMDStorage, Self.SIMD2Storage : Swift.SIMDStorage, Self.SIMD32Storage : Swift.SIMDStorage, Self.SIMD4Storage : Swift.SIMDStorage, Self.SIMD64Storage : Swift.SIMDStorage, Self.SIMD8Storage : Swift.SIMDStorage, Self.SIMDMaskScalar : Swift.FixedWidthInteger, Self.SIMDMaskScalar : Swift.SIMDScalar, Self.SIMDMaskScalar : Swift.SignedInteger, Self.SIMDMaskScalar == Self.SIMDMaskScalar.SIMDMaskScalar, Self.SIMD16Storage.Scalar == Self.SIMD2Storage.Scalar, Self.SIMD2Storage.Scalar == Self.SIMD32Storage.Scalar, Self.SIMD32Storage.Scalar == Self.SIMD4Storage.Scalar, Self.SIMD4Storage.Scalar == Self.SIMD64Storage.Scalar, Self.SIMD64Storage.Scalar == Self.SIMD8Storage.Scalar>
 

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -96,7 +96,16 @@ Func Sequence.filter(_:) has been removed
 Func Sequence.map(_:) has been removed
 Func Dictionary.filter(_:) has been removed
 Func Set.filter(_:) has been removed
+Func String._slowWithCString(encodedAs:_:) has been removed
+Func String._withNFCCodeUnits(_:) has been renamed to Func __rethrows_underscore_withNFCCodeUnits(_:)
+Func String._withNFCCodeUnits(_:) has mangled name changing from 'Swift.String._withNFCCodeUnits((Swift.UInt8) throws -> ()) throws -> ()' to 'Swift.String.__rethrows_underscore_withNFCCodeUnits((Swift.UInt8) throws -> ()) throws -> ()'
+Func String._withNFCCodeUnits(_:) is now without rethrows
+Func String.withCString(_:) has been removed
+Func String.withCString(encodedAs:_:) has been removed
 Func Substring.filter(_:) has been removed
+Func Substring.withCString(_:) has been removed
+Func Substring.withCString(encodedAs:_:) has been removed
+Func Unicode.Scalar.withUTF8CodeUnits(_:) has been removed
 Func _ArrayProtocol.filter(_:) has been removed
 Constructor Result.init(catching:) has been removed
 Func withoutActuallyEscaping(_:do:) has been renamed to Func __abi_withoutActuallyEscaping(_:do:)
@@ -839,6 +848,12 @@ Func Dictionary.merge(_:uniquingKeysWith:) has been removed
 Func Dictionary.merging(_:uniquingKeysWith:) has been removed
 Func _NativeDictionary.mapValues(_:) has been removed
 Func _NativeDictionary.merge(_:isUnique:uniquingKeysWith:) has been removed
+Func _SmallString.withUTF8(_:) has been removed
+Func _StringGuts._slowWithCString(_:) has been removed
+Func _StringGuts.withCString(_:) has been removed
+Func _StringGuts.withFastCChar(_:) has been removed
+Func _StringGuts.withFastUTF8(_:) has been removed
+Func _StringGuts.withFastUTF8(range:_:) has been removed
 Func __CocoaDictionary.mapValues(_:) has been removed
 
 


### PR DESCRIPTION
Generalizes `String`:
- `init(unsafeUninitializedCapacity:initializingUTF8With:)`
- `withCString(_:)`
- `withCString(encodedAs:_:)`
- `withUTF8(_:)`
- `_withNFCCodeUnits(_:)`

and `Substring`:
  - `withCString(_:)`
  - `withCString(encodedAs:_:)`
  - `withUTF8(_:)`

for typed throws.