### PR TITLE
[SIL deserialization] Keep reading vtable entries while there are vtable entries

### DIFF
--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -4485,12 +4485,7 @@ SILVTable *SILDeserializer::readVTable(DeclID VId) {
 
   std::vector<SILVTable::Entry> vtableEntries;
   // Another SIL_VTABLE record means the end of this VTable.
-  while (kind != SIL_VTABLE && kind != SIL_WITNESS_TABLE &&
-         kind != SIL_DEFAULT_WITNESS_TABLE &&
-         kind != SIL_DEFAULT_OVERRIDE_TABLE && kind != SIL_FUNCTION &&
-         kind != SIL_PROPERTY && kind != SIL_MOVEONLY_DEINIT) {
-    assert(kind == SIL_VTABLE_ENTRY &&
-           "Content of Vtable should be in SIL_VTABLE_ENTRY.");
+  while (kind == SIL_VTABLE_ENTRY) {
     ArrayRef<uint64_t> ListOfValues;
     DeclID NameID;
     unsigned RawEntryKind, IsNonOverridden;

--- a/test/embedded/multi-module-deserialization-crash.swift
+++ b/test/embedded/multi-module-deserialization-crash.swift
@@ -1,0 +1,30 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module -o %t/A.swiftmodule %t/A.swift -enable-experimental-feature Embedded -enable-experimental-feature CheckImplementationOnly -parse-as-library
+// RUN: %target-swift-frontend -c -I %t %t/B.swift -enable-experimental-feature Embedded -enable-experimental-feature CheckImplementationOnly
+
+// REQUIRES: OS=macosx || OS=linux-gnu || OS=wasip1
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: swift_feature_CheckImplementationOnly
+
+//--- A.swift
+public final class Foo {
+    @export(interface)
+    public init() {}
+    
+    @export(interface)
+    deinit {}
+}
+
+// this is load-bearing somehow: without this, no crash
+func foo() {}
+
+//--- B.swift
+import A
+
+func bar() {
+    _ = Foo()
+}


### PR DESCRIPTION
The logic here would keep reading vtable entries so long as some other top-level record wasn't hit, then assert that the entry it found was a vtable entry. However, the list of "top-level record kinds" was ad hoc and doesn't regularly get updated. Switch to a loop that reads vtable entries while there are vtable entries, since there's only one kind here anyway.

Fixes an Embedded Swift crash where a SIL global variable was after the vtable entries, rdar://171009492.