### PR TITLE
[Perf] Deduplicate imported-module scans for forward-declared ObjC types

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -6013,8 +6013,11 @@ namespace {
         mainModule->getImportedModules(importedModules,
                                        ModuleDecl::getImportFilterAll());
 
+        llvm::SmallSet<ModuleDecl *, 16> seenModules;
         for (auto &import : importedModules) {
           if (import.importedModule->isNonSwiftModule())
+            continue;
+          if (!seenModules.insert(import.importedModule).second)
             continue;
 
           if (T *result = resolveSwiftDeclImpl<T>(

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -103,6 +103,10 @@
 STATISTIC(NumTotalImportedEntities, "# of imported clang entities");
 STATISTIC(NumFactoryMethodsAsInitializers,
           "# of factory methods mapped to initializers");
+STATISTIC(
+    NumSkippedDuplicateImportedSwiftModulesForForwardDeclaredObjCTypes,
+    "# of duplicate imported Swift modules skipped while resolving "
+    "forward-declared ObjC types");
 
 using namespace swift;
 using namespace importer;
@@ -6017,8 +6021,10 @@ namespace {
         for (auto &import : importedModules) {
           if (import.importedModule->isNonSwiftModule())
             continue;
-          if (!seenModules.insert(import.importedModule).second)
+          if (!seenModules.insert(import.importedModule).second) {
+            ++NumSkippedDuplicateImportedSwiftModulesForForwardDeclaredObjCTypes;
             continue;
+          }
 
           if (T *result = resolveSwiftDeclImpl<T>(
                   decl, name, hasKnownSwiftName, import.importedModule,

--- a/test/ClangImporter/incomplete_objc_types_swift_definition_imported_stats.swift
+++ b/test/ClangImporter/incomplete_objc_types_swift_definition_imported_stats.swift
@@ -1,0 +1,32 @@
+// REQUIRES: asserts
+// REQUIRES: objc_interop
+// REQUIRES: swift_feature_ImportObjcForwardDeclarations
+//
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-build-swift -parse-as-library %S/Inputs/custom-modules/IncompleteTypes/complete-swift-types.swift -module-name CompleteSwiftTypes -emit-module -emit-module-path %t/CompleteSwiftTypes.swiftmodule
+// RUN: %target-build-swift -parse-as-library %t/unrelated.swift -module-name UnrelatedSwiftModule -emit-module -emit-module-path %t/UnrelatedSwiftModule.swiftmodule
+// RUN: not %target-swift-frontend -parse-as-library -enable-upcoming-feature ImportObjcForwardDeclarations -enable-objc-interop -typecheck -I %S/Inputs/custom-modules/IncompleteTypes -I %t %t/extra1.swift %t/extra2.swift %t/extra3.swift %t/trigger.swift -diagnostic-style llvm -print-stats 2>&1 | %FileCheck %s
+
+// CHECK: note: interface 'Foo' is incomplete and cannot be imported as a stub; its name conflicts with a class in module 'CompleteSwiftTypes'
+// CHECK: {{[1-9][0-9]*}} Clang module importer - # of duplicate imported Swift modules skipped while resolving forward-declared ObjC types
+
+//--- unrelated.swift
+public struct Irrelevant {}
+
+//--- extra1.swift
+import UnrelatedSwiftModule
+
+//--- extra2.swift
+import UnrelatedSwiftModule
+
+//--- extra3.swift
+import UnrelatedSwiftModule
+
+//--- trigger.swift
+import CompleteSwiftTypes
+import ObjCLibraryForwardDeclaringCompleteSwiftTypes
+
+func test() {
+  _ = returnAFoo()
+}


### PR DESCRIPTION
Fixes #75107

Forward-declared Objective-C types fall back to `hasNonLocalNativeSwiftDecl` to see whether some imported Swift module already provides a matching native declaration. The imported-module list can contain the same `ModuleDecl` many times in large builds.

That matters here because the lookup only uses import.importedModule, so duplicate entries repeat the exact same `resolveSwiftDeclImpl(...)` work. In the reported `CoreHaptics` case, `AVAudioSession` is only a forward declaration while importing the `CHHapticEngine` initializer signature, and repeatedly rescanning duplicate modules dominates the cost of importing that parameter type.

This change deduplicates `ModuleDecl` pointers before the scan so each imported Swift module is checked at most once. In the local repro that motivated #75107, that dropped this forward-declaration scan from roughly 500ms to roughly 5ms and removed the long-expression warning entirely.

#### Explanation for why this was so slow:
  1. `CHHapticEngine()` constructor lookup imports `initWithAudioSession:error:`.
  2. Importing that initializer imports parameter `audioSession: AVAudioSession`.
  3. `AVAudioSession` is seen here as a forward-declared ObjC class, not a full definition.
  4. That sends the importer into `hasNonLocalNativeSwiftDecl(...)` to check whether some Swift-native declaration with the same name exists in imported Swift modules.
  5. That function was scanning `mainModule->getImportedModules()` linearly without deduping identical `ModuleDecl *` values.
  6. In this build, the imported-module list contains many repeated entries, especially SwiftUI and some Foundation.
  7. Each repeated `resolveSwiftDeclImpl(...)` check was only about 1ms, but there were enough duplicates to add up to roughly 500-570ms.