### PR TITLE
stdlib: fix the ArraySlice liverange dependency

### DIFF
--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -403,6 +403,10 @@ BUILTIN_SIL_OPERATION(LegacyCondFail, "condfail", Special)
 /// Fixes the lifetime of any heap references in a value.
 BUILTIN_SIL_OPERATION(FixLifetime, "fixLifetime", Special)
 
+/// result = markDependence<T, V>(value: T, base: V)
+/// Directly translates to the `mark_dependence` SIL instruction.
+BUILTIN_SIL_OPERATION(MarkDependence, "markDependence", Special)
+
 /// isUnique : <T> (inout T[?]) -> Int1
 ///
 /// This builtin takes an inout object reference and returns a boolean. Passing

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -280,6 +280,7 @@ LANGUAGE_FEATURE(ModuleSelector, 491, "Module selectors (`Module::name` syntax)"
 LANGUAGE_FEATURE(BuiltinConcurrencyStackNesting, 0, "Concurrency Stack Nesting Builtins")
 LANGUAGE_FEATURE(ClosureLifetimes, 0, "Support @_lifetime on function types")
 BASELINE_LANGUAGE_FEATURE(ExcludePrivateFromMemberwiseInit, 502, "Exclude private initialized properties from memberwise init")
+LANGUAGE_FEATURE(BuiltinMarkDependence, 0, "markDependence Builtin")
 
 // TEMPORARY: Never use this, because it is only meant to allow us to model
 // suppression of @c in Swift interfaces as a temporary measure.

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -2029,6 +2029,17 @@ static ValueDecl *getFixLifetimeOperation(ASTContext &C, Identifier Id) {
   return builder.build(Id);
 }
 
+static ValueDecl *getMarkDependenceOperation(ASTContext &C, Identifier Id) {
+  // <T, V> (T, V) -> T
+  BuiltinFunctionBuilder builder(C, 2);
+  auto genericValueParam = makeGenericParam(0);
+  auto genericBaseParam = makeGenericParam(1);
+  builder.addParameter(genericValueParam);
+  builder.addParameter(genericBaseParam);
+  builder.setResult(genericValueParam);
+  return builder.build(Id);
+}
+
 static ValueDecl *getExtractElementOperation(ASTContext &Context, Identifier Id,
                                              Type FirstTy, Type SecondTy) {
   // (Vector<N, T>, Int32) -> T
@@ -3290,6 +3301,9 @@ ValueDecl *swift::getBuiltinValueDecl(ASTContext &Context, Identifier Id) {
 
   case BuiltinValueKind::FixLifetime:
     return getFixLifetimeOperation(Context, Id);
+
+  case BuiltinValueKind::MarkDependence:
+    return getMarkDependenceOperation(Context, Id);
 
   case BuiltinValueKind::CanBeObjCClass:
     return getCanBeObjCClassOperation(Context, Id);

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -450,6 +450,7 @@ static bool usesFeatureCoroutineAccessors(Decl *decl) {
 
 UNINTERESTING_FEATURE(GeneralizedIsSameMetaTypeBuiltin)
 UNINTERESTING_FEATURE(CustomAvailability)
+UNINTERESTING_FEATURE(BuiltinMarkDependence)
 
 static bool usesFeatureAsyncExecutionBehaviorAttributes(Decl *decl) {
   // Explicit `@concurrent` attribute on the declaration.

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -291,6 +291,18 @@ static ManagedValue emitBuiltinFixLifetime(SILGenFunction &SGF,
   return ManagedValue::forObjectRValueWithoutOwnership(SGF.emitEmptyTuple(loc));
 }
 
+static ManagedValue emitBuiltinMarkDependence(SILGenFunction &SGF,
+                                              SILLocation loc,
+                                              SubstitutionMap substitutions,
+                                              ArrayRef<ManagedValue> args,
+                                              SGFContext C) {
+  auto *md = SGF.B.createMarkDependence(loc, args[0].getValue(), args[1].getValue(),
+                                        MarkDependenceKind::Escaping);
+  ASSERT(md->getOwnershipKind() != OwnershipKind::Owned &&
+         "Builtin.markDependence only works for none and guaranteed ownership");
+  return ManagedValue::forBorrowedObjectRValue(md);
+}
+
 static ManagedValue emitCastToReferenceType(SILGenFunction &SGF,
                                             SILLocation loc,
                                             SubstitutionMap substitutions,

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -236,7 +236,7 @@ extension ArraySlice {
   @inlinable
   @_semantics("array.get_element_address")
   internal func _getElementAddress(_ index: Int) -> UnsafeMutablePointer<Element> {
-    return unsafe _buffer.subscriptBaseAddress + index
+    return unsafe _buffer.getSubscriptBaseAddress() + index
   }
 }
 
@@ -555,7 +555,7 @@ extension ArraySlice: RandomAccessCollection, MutableCollection {
     _modify {
       _makeMutableAndUnique() // makes the array native, too
       _checkSubscript_native(index)
-      let address = unsafe _buffer.subscriptBaseAddress + index
+      let address = unsafe _buffer.getSubscriptBaseAddress() + index
       defer { _endMutation() }
       yield unsafe &address.pointee
     }

--- a/stdlib/public/core/SliceBuffer.swift
+++ b/stdlib/public/core/SliceBuffer.swift
@@ -109,6 +109,16 @@ internal struct _SliceBuffer<Element>
     }
   }
 
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  internal func getSubscriptBaseAddress() -> UnsafeMutablePointer<Element> {
+#if $BuiltinMarkDependence
+    return unsafe Builtin.markDependence(subscriptBaseAddress, owner)
+#else
+    return unsafe subscriptBaseAddress
+#endif
+  }
+
   @inlinable
   internal var _hasNativeBuffer: Bool {
     return (endIndexAndFlags & 1) != 0
@@ -181,7 +191,7 @@ internal struct _SliceBuffer<Element>
 
   @inlinable
   internal var firstElementAddress: UnsafeMutablePointer<Element> {
-    return unsafe subscriptBaseAddress + startIndex
+    return unsafe getSubscriptBaseAddress() + startIndex
   }
 
   @inlinable
@@ -261,7 +271,7 @@ internal struct _SliceBuffer<Element>
     _internalInvariant(bounds.upperBound >= bounds.lowerBound)
     _internalInvariant(bounds.upperBound <= endIndex)
     let c = bounds.count
-    unsafe target.initialize(from: subscriptBaseAddress + bounds.lowerBound, count: c)
+    unsafe target.initialize(from: getSubscriptBaseAddress() + bounds.lowerBound, count: c)
     return unsafe target + c
   }
 
@@ -374,7 +384,7 @@ internal struct _SliceBuffer<Element>
   internal func getElement(_ i: Int) -> Element {
     _internalInvariant(i >= startIndex, "slice index is out of range (before startIndex)")
     _internalInvariant(i < endIndex, "slice index is out of range")
-    return unsafe subscriptBaseAddress[i]
+    return unsafe getSubscriptBaseAddress()[i]
   }
 
   /// Access the element at `position`.
@@ -389,7 +399,7 @@ internal struct _SliceBuffer<Element>
     nonmutating set {
       _internalInvariant(position >= startIndex, "slice index is out of range (before startIndex)")
       _internalInvariant(position < endIndex, "slice index is out of range")
-      unsafe subscriptBaseAddress[position] = newValue
+      unsafe getSubscriptBaseAddress()[position] = newValue
     }
   }
 

--- a/test/SILGen/builtins.swift
+++ b/test/SILGen/builtins.swift
@@ -993,3 +993,21 @@ func taskCancellationShieldPush() async {
 func taskCancellationShieldPop() async {
   Builtin.taskCancellationShieldPop()
 }
+
+// CHECK-LABEL: sil hidden [ossa] @$s8builtins20markDependencTrivialySpyxGAC_yXltlF :
+// CHECK:   [[M:%.*]] = mark_dependence %0 : $UnsafeMutablePointer<T> on %1
+// CHECK:   return [[M]]
+// CHECK: } // end sil function '$s8builtins20markDependencTrivialySpyxGAC_yXltlF'
+func markDependencTrivial<T>(_ p: UnsafeMutablePointer<T>, _ o: AnyObject) -> UnsafeMutablePointer<T> {
+  return Builtin.markDependence(p, o)
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s8builtins24markDependenceGuaranteedyyXlyXl_yXltF :
+// CHECK:   [[M:%.*]] = mark_dependence %0 : $AnyObject on %1
+// CHECK:   [[C:%.*]] = copy_value [[M]]
+// CHECK:   return [[C]]
+// CHECK: } // end sil function '$s8builtins24markDependenceGuaranteedyyXlyXl_yXltF'
+func markDependenceGuaranteed(_ p: AnyObject, _ o: AnyObject) -> AnyObject {
+  return Builtin.markDependence(p, o)
+}
+

--- a/test/stdlib/ArraySlice.swift
+++ b/test/stdlib/ArraySlice.swift
@@ -1,0 +1,25 @@
+// RUN: %target-run-simple-swift(-O)
+// REQUIRES: executable_test
+// REQUIRES: reflection
+
+import StdlibUnittest
+
+let testSuite = TestSuite("ArraySlice")
+
+@inline(never)
+func getArray() -> [String] {
+  return [_opaqueIdentity("a very long string which is is not inlined")]
+}
+
+@inline(never)
+func testSliceLiverange() -> String {
+  let a = getArray()
+  let s = a[0..<1]
+  return s[0]
+}
+
+testSuite.test("liverange") {
+  expectEqual(testSliceLiverange(), "a very long string which is is not inlined")
+}
+
+runAllTests()


### PR DESCRIPTION
Explicitly mark the dependency between the base pointer and the owner object.
Otherwise the owner object could be destroyed too early.
So far we got away with this because array semantic functions were not inlined in OSSA. However, with https://github.com/swiftlang/swift/pull/87315 this is becoming a real problem.

Fixes a miscompile.