### PR TITLE
[SIL] [Crash] Fix generic `isolated deinit` substitutions

### DIFF
--- a/lib/SILGen/SILGenDestructor.cpp
+++ b/lib/SILGen/SILGenDestructor.cpp
@@ -429,8 +429,8 @@ void SILGenFunction::emitIsolatingDestructor(DestructorDecl *dd) {
         B.createIntegerLiteral(loc, wordTy, 0);
 
     // Schedule isolated execution
-    B.createApply(loc, swiftDeinitOnExecutorFunc,
-                  getForwardingSubstitutionMap(),
+    // _deinitOnExecutor is not generic, even when the enclosing destructor is.
+    B.createApply(loc, swiftDeinitOnExecutorFunc, SubstitutionMap(),
                   {castedSelf, castedDeallocator, executor, flagsInst});
   });
 }

--- a/validation-test/SILOptimizer/gh87462.swift
+++ b/validation-test/SILOptimizer/gh87462.swift
@@ -2,7 +2,7 @@
 
 // REQUIRES: VENDOR=apple
 
-@available(macOS 15.4, *)
+@available(SwiftStdlib 6.1, *)
 actor Bar<T> {
   isolated deinit {}
 }

--- a/validation-test/SILOptimizer/gh87462.swift
+++ b/validation-test/SILOptimizer/gh87462.swift
@@ -2,6 +2,11 @@
 
 // REQUIRES: VENDOR=apple
 
+@available(macOS 15.4, *)
+actor Bar<T> {
+  isolated deinit {}
+}
+
 @MainActor
 final class Foo<T> {
   isolated deinit {}

--- a/validation-test/SILOptimizer/gh87462.swift
+++ b/validation-test/SILOptimizer/gh87462.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend -target %target-cpu-apple-macos14 -parse-as-library -c -O %s
+
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+
+@MainActor
+final class Foo<T> {
+  isolated deinit {}
+}

--- a/validation-test/SILOptimizer/gh87462.swift
+++ b/validation-test/SILOptimizer/gh87462.swift
@@ -1,7 +1,6 @@
-// RUN: %target-swift-frontend -target %target-cpu-apple-macos14 -parse-as-library -c -O %s
+// RUN: %target-swift-frontend -target %target-swift-5.5-abi-triple -parse-as-library -c -O %s
 
 // REQUIRES: VENDOR=apple
-// REQUIRES: OS=macosx
 
 @MainActor
 final class Foo<T> {


### PR DESCRIPTION
Fixes #87462

This adds a regression test and fixes generic `isolated deinit` code generation so `_deinitOnExecutor` is called without generic substitutions.

`_deinitOnExecutor` is not generic, but generic isolated deinits were forwarding the destructor substitution map into the helper apply. Under `-O`, that produced an invalid apply shape for generic `@MainActor` classes, which later crashed `EarlyPerfInliner`.

Test: `validation-test/SILOptimizer/gh87462.swift`
