### PR TITLE
SIL, Basic, Sema, Shims: adjust for LLDB

### DIFF
--- a/include/swift/Basic/Located.h
+++ b/include/swift/Basic/Located.h
@@ -59,20 +59,21 @@ template <typename T, typename Enable> struct DenseMapInfo;
 
 template<typename T>
 struct DenseMapInfo<swift::Located<T>> {
+  using SourceLoc = swift::SourceLoc;
 
   static inline swift::Located<T> getEmptyKey() {
     return swift::Located<T>(DenseMapInfo<T>::getEmptyKey(),
-                             DenseMapInfo<swift::SourceLoc>::getEmptyKey());
+                             DenseMapInfo<SourceLoc>::getEmptyKey());
   }
 
   static inline swift::Located<T> getTombstoneKey() {
     return swift::Located<T>(DenseMapInfo<T>::getTombstoneKey(),
-                             DenseMapInfo<swift::SourceLoc>::getTombstoneKey());
+                             DenseMapInfo<SourceLoc>::getTombstoneKey());
   }
 
   static unsigned getHashValue(const swift::Located<T> &LocatedVal) {
     return detail::combineHashValue(DenseMapInfo<T>::getHashValue(LocatedVal.Item),
-                            DenseMapInfo<swift::SourceLoc>::getHashValue(LocatedVal.Loc));
+                            DenseMapInfo<SourceLoc>::getHashValue(LocatedVal.Loc));
   }
 
   static bool isEqual(const swift::Located<T> &LHS, const swift::Located<T> &RHS) {

--- a/include/swift/SIL/SILNode.h
+++ b/include/swift/SIL/SILNode.h
@@ -525,30 +525,35 @@ template <class To>
 struct cast_convert_val<To, swift::SILNode*, swift::SILNode*> {
   using ret_type = typename cast_retty<To, swift::SILNode*>::ret_type;
   static ret_type doit(swift::SILNode *node) {
-    return swift::cast_from_SILNode<To>::doit(node);
+    using swift::cast_from_SILNode;
+    return cast_from_SILNode<To>::doit(node);
   }
 };
 template <class To>
 struct cast_convert_val<To, const swift::SILNode *, const swift::SILNode *> {
-  using ret_type = typename cast_retty<To, const swift::SILNode*>::ret_type;
+  using SILNode = swift::SILNode;
+  using ret_type = typename cast_retty<To, const SILNode*>::ret_type;
   static ret_type doit(const swift::SILNode *node) {
-    return swift::cast_from_SILNode<To>::doit(const_cast<swift::SILNode*>(node));
+    using ::swift::cast_from_SILNode;
+    return cast_from_SILNode<To>::doit(const_cast<SILNode*>(node));
   }
 };
 template <class To>
 struct cast_convert_val<To, swift::SILInstruction*, swift::SILInstruction*> {
   using ret_type = typename cast_retty<To, swift::SILInstruction*>::ret_type;
   static ret_type doit(swift::SILInstruction *inst) {
-    return swift::cast_from_SILInstruction<To>::doit(inst);
+    using ::swift::cast_from_SILInstruction;
+    return cast_from_SILInstruction<To>::doit(inst);
   }
 };
 template <class To>
 struct cast_convert_val<To, const swift::SILInstruction *,
                             const swift::SILInstruction *> {
-  using ret_type = typename cast_retty<To, const swift::SILInstruction*>::ret_type;
-  static ret_type doit(const swift::SILInstruction *inst) {
-    return swift::cast_from_SILInstruction<To>::
-             doit(const_cast<swift::SILInstruction*>(inst));
+  using SILInstruction = swift::SILInstruction;
+  using ret_type = typename cast_retty<To, const SILInstruction*>::ret_type;
+  static ret_type doit(const SILInstruction *inst) {
+    using ::swift::cast_from_SILInstruction;
+    return cast_from_SILInstruction<To>::doit(const_cast<SILInstruction*>(inst));
   }
 };
 

--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -154,19 +154,19 @@ public:
     /// subclass, returning \c None if unsuccessful.
     template <class T>
     std::optional<T> getAs() const {
-      if (auto *result = dyn_cast<T>(this))
+      if (auto *result = llvm::dyn_cast<T>(this))
         return *result;
       return std::nullopt;
     }
 
     /// Cast the path element to a specific \c LocatorPathElt subclass.
     template <class T>
-    T castTo() const { return *cast<T>(this); }
+    T castTo() const { return *llvm::cast<T>(this); }
 
     /// Checks whether the path element is a specific \c LocatorPathElt
     /// subclass.
     template <class T>
-    bool is() const { return isa<T>(this); }
+    bool is() const { return llvm::isa<T>(this); }
 
     /// Return the summary flags for this particular element.
     unsigned getNewSummaryFlags() const;

--- a/stdlib/public/SwiftShims/swift/shims/RefCount.h
+++ b/stdlib/public/SwiftShims/swift/shims/RefCount.h
@@ -1590,16 +1590,16 @@ template <>
 template <PerformDeinit performDeinit>
 inline bool RefCounts<SideTableRefCountBits>::
 doDecrementSideTable(SideTableRefCountBits oldbits, uint32_t dec) {
-  swift::crash("side table refcount must not have "
-               "a side table entry of its own");
+  using ::swift::crash;
+  crash("side table refcount must not have a side table entry of its own");
 }
 
 template <>
 template <PerformDeinit performDeinit>
 inline bool RefCounts<SideTableRefCountBits>::
 doDecrementNonAtomicSideTable(SideTableRefCountBits oldbits, uint32_t dec) {
-  swift::crash("side table refcount must not have "
-               "a side table entry of its own");
+  using ::swift::crash;
+  crash("side table refcount must not have a side table entry of its own");
 }
 
 template <>


### PR DESCRIPTION
LLDB defines `lldb::private::swift::` which causes ambiguity for lookups. Use aliases and fully qualified names to avoid the ambiguity.