### PR TITLE
[MoveOnlyWrappedTypeEliminator] Handle ConvertEscapeToNoEscapeInst

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveOnlyWrappedTypeEliminator.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyWrappedTypeEliminator.cpp
@@ -65,9 +65,9 @@ struct SILMoveOnlyWrappedTypeEliminatorVisitor
   llvm::SmallSetVector<SILInstruction *, 8> &pendingInsts;
   llvm::SmallVector<SILInstruction *, 8> deferredInsts;
 
-  SILMoveOnlyWrappedTypeEliminatorVisitor(llvm::SmallSetVector<SILInstruction *, 8> &pendingInsts):
-    pendingInsts(pendingInsts)
-  {}
+  SILMoveOnlyWrappedTypeEliminatorVisitor(
+      llvm::SmallSetVector<SILInstruction *, 8> &pendingInsts)
+      : pendingInsts(pendingInsts) {}
 
   // If 'user's operand is not yet visited, push it onto the end of
   // 'pendingInsts' and pretend we didn't see it yet. This is only relevant for
@@ -216,6 +216,7 @@ struct SILMoveOnlyWrappedTypeEliminatorVisitor
   NO_UPDATE_NEEDED(CheckedCastBranch)
   NO_UPDATE_NEEDED(ClassMethod)
   NO_UPDATE_NEEDED(ConvertFunction)
+  NO_UPDATE_NEEDED(ConvertEscapeToNoEscape)
   NO_UPDATE_NEEDED(CopyAddr)
   NO_UPDATE_NEEDED(DeallocBox)
   NO_UPDATE_NEEDED(DeallocStack)
@@ -259,9 +260,9 @@ struct SILMoveOnlyWrappedTypeEliminatorVisitor
     return true;
   }
 
-#define ELIMINATE_POTENTIAL_IDENTITY_CAST(NAME) \
-  bool visit##NAME##Inst(NAME##Inst *cast) { \
-    return eliminateIdentityCast(cast); \
+#define ELIMINATE_POTENTIAL_IDENTITY_CAST(NAME)                                \
+  bool visit##NAME##Inst(NAME##Inst *cast) {                                   \
+    return eliminateIdentityCast(cast);                                        \
   }
   ELIMINATE_POTENTIAL_IDENTITY_CAST(Upcast)
   ELIMINATE_POTENTIAL_IDENTITY_CAST(UncheckedAddrCast)
@@ -419,7 +420,7 @@ bool SILMoveOnlyWrappedTypeEliminator::process() {
   }
 
   SILMoveOnlyWrappedTypeEliminatorVisitor visitor{touchedInsts};
-  while(true) {
+  while (true) {
     while (!touchedInsts.empty()) {
       visitor.visit(touchedInsts.pop_back_val());
     }

--- a/test/SILOptimizer/moveonly_type_eliminator.sil
+++ b/test/SILOptimizer/moveonly_type_eliminator.sil
@@ -711,3 +711,21 @@ bb0(%0 : @noImplicitCopy @_eagerMove $Trivial):
   %99 = tuple ()
   return %99 : $()
 }
+
+// Regression test for https://github.com/swiftlang/swift/issues/87454
+// Ensure convert_escape_to_noescape is handled without crashing.
+//
+// CHECK-LABEL: sil [ossa] @convert_escape_to_noescape_moveonly : $@convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> () {
+// CHECK: convert_escape_to_noescape
+// CHECK-LABEL: } // end sil function 'convert_escape_to_noescape_moveonly'
+sil [ossa] @convert_escape_to_noescape_moveonly : $@convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> () {
+bb0(%0 : @guaranteed $@callee_guaranteed () -> ()):
+  %1 = copyable_to_moveonlywrapper [guaranteed] %0 : $@callee_guaranteed () -> ()
+  %2 = moveonlywrapper_to_copyable [guaranteed] %1 : $@moveOnly @callee_guaranteed () -> ()
+  %3 = copy_value %2 : $@callee_guaranteed () -> ()
+  %4 = convert_escape_to_noescape %3 : $@callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> ()
+  destroy_value %4 : $@noescape @callee_guaranteed () -> ()
+  destroy_value %3 : $@callee_guaranteed () -> ()
+  %99 = tuple ()
+  return %99 : $()
+}


### PR DESCRIPTION
The MoveOnlyWrappedTypeEliminator pass did not handle convert_escape_to_noescape instructions, causing a compiler crash (UNREACHABLE) when compiling code that passes a borrowing @escaping closure to a non-escaping parameter.

Add ConvertEscapeToNoEscape to the NO_UPDATE_NEEDED list, matching the existing treatment of ConvertFunction. Both are pure type-level conversions that require no ownership adjustments when eliminating move-only wrapper types.

Fixes #87454

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
