### PR TITLE
[stdlib] Define availability for SwiftStdlib 6.3

### DIFF
--- a/include/swift/AST/RuntimeVersions.def
+++ b/include/swift/AST/RuntimeVersions.def
@@ -168,7 +168,10 @@ RUNTIME_VERSION(
 
 RUNTIME_VERSION(
   (6, 3),
-  FUTURE
+  PLATFORM(macOS,   (26, 4, 0))
+  PLATFORM(iOS,     (26, 4, 0))
+  PLATFORM(watchOS, (26, 4, 0))
+  PLATFORM(visionOS,(26, 4, 0))
 )
 
 RUNTIME_VERSION(

--- a/test/Interop/Cxx/stdlib/overlay/custom-borrowing-sequence.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-borrowing-sequence.swift
@@ -12,7 +12,7 @@ import CustomBorrowingSequence
 var CxxBorrowingSequenceTestSuite = TestSuite("CxxSequence")
 
 CxxBorrowingSequenceTestSuite.test("SimpleNonCopyableSequence as Swift.BorrowingSequence") {
-  guard #available(SwiftStdlib 6.3, *) else { return }
+  guard #available(SwiftStdlib 6.4, *) else { return }
 
   let seq = SimpleNonCopyableSequence()
   let arr : [Int32] = [2, 3, 4, 5]
@@ -31,7 +31,7 @@ CxxBorrowingSequenceTestSuite.test("SimpleNonCopyableSequence as Swift.Borrowing
 }
 
 CxxBorrowingSequenceTestSuite.test("SimpleNonCopArrayWrapper as Swift.BorrowingSequence") {
-  guard #available(SwiftStdlib 6.3, *) else { return }
+  guard #available(SwiftStdlib 6.4, *) else { return }
   let seq = SimpleNonCopArrayWrapper()
   let arr : [Int32] = [10, 20, 30, 40, 50]
 
@@ -49,7 +49,7 @@ CxxBorrowingSequenceTestSuite.test("SimpleNonCopArrayWrapper as Swift.BorrowingS
 }
 
 CxxBorrowingSequenceTestSuite.test("ContiguousNonCopyableSequence as Swift.BorrowingSequence") {
-  guard #available(SwiftStdlib 6.3, *) else { return }
+  guard #available(SwiftStdlib 6.4, *) else { return }
   let seq = ContiguousNonCopyableSequence()
   let arr : [Int32] = [10, 20, 30, 40, 50]
 
@@ -71,7 +71,7 @@ CxxBorrowingSequenceTestSuite.test("ContiguousNonCopyableSequence as Swift.Borro
 }
 
 CxxBorrowingSequenceTestSuite.test("ContiguousNonCopyableSequence as Swift.BorrowingSequence, with maximumCount") {
-  guard #available(SwiftStdlib 6.3, *) else { return }
+  guard #available(SwiftStdlib 6.4, *) else { return }
   let seq = ContiguousNonCopyableSequence()
   let arr : [Int32] = [10, 20, 30, 40, 50]
 

--- a/test/Interop/Cxx/stdlib/use-std-list.swift
+++ b/test/Interop/Cxx/stdlib/use-std-list.swift
@@ -13,7 +13,7 @@ func getNumber(_ x: borrowing NonCopyable) -> Int32 {
 }
 
 StdListTestSuite.test("ListOfInt conforms to CxxBorrowingSequence") {
-    guard #available(SwiftStdlib 6.3, *) else { return }
+    guard #available(SwiftStdlib 6.4, *) else { return }
     let arr : [Int32] = [1, 2, 3]
     let lst = makeListInt()
     expectEqual(lst.size(), 3)
@@ -33,7 +33,7 @@ StdListTestSuite.test("ListOfInt conforms to CxxBorrowingSequence") {
 }
 
 StdListTestSuite.test("ListOfNonCopyable conforms to CxxBorrowingSequence") {
-    guard #available(SwiftStdlib 6.3, *) else { return }
+    guard #available(SwiftStdlib 6.4, *) else { return }
     let arr : [Int32] = [1, 2, 3]
     var lst = makeListOfNonCopyable()
     expectEqual(lst.size(), 3)

--- a/utils/availability-macros.def
+++ b/utils/availability-macros.def
@@ -46,8 +46,10 @@ SwiftStdlib 5.10:macOS 14.4, iOS 17.4, watchOS 10.4, tvOS 17.4, visionOS 1.1
 SwiftStdlib 6.0:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0
 SwiftStdlib 6.1:macOS 15.4, iOS 18.4, watchOS 11.4, tvOS 18.4, visionOS 2.4
 SwiftStdlib 6.2:macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0
-SwiftStdlib 6.3:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999
+SwiftStdlib 6.3:macOS 26.4, iOS 26.4, watchOS 26.4, tvOS 26.4, visionOS 26.4
 SwiftStdlib 6.4:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999
+# TODO: When you add a new version, remember to tell the compiler about it
+# by also adding it to include/swift/AST/RuntimeVersions.def.
 
 # Like SwiftStdlib 5.0, but also the oldest visionOS.
 SwiftCompatibilitySpan 5.0:macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, visionOS 1.0
@@ -58,8 +60,6 @@ SwiftCompatibilitySpan 6.2:macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, vision
 # Backtracing is only available for macOS in 6.2
 Backtracing 6.2: macOS 26.0
 
-# TODO: When you add a new version, remember to tell the compiler about it
-# by also adding it to include/swift/AST/RuntimeVersions.def.
 
 # Local Variables:
 # mode: conf-unix

--- a/validation-test/stdlib/StringWordBreaking.swift
+++ b/validation-test/stdlib/StringWordBreaking.swift
@@ -68,7 +68,7 @@ extension String {
   /// - Parameter i: A valid index addressing a word boundary within this
   ///    string.
   /// - Returns: The first word break strictly following `i` in the string.
-  @available(StdlibDeploymentTarget 6.3, *)
+  @available(SwiftStdlib 6.3, *)
   public func _wordIndex(before i: String.Index) -> String.Index {
     let i = self.unicodeScalars._index(roundingDown: i)
     var j = _wordIndex(somewhereAtOrBefore: unicodeScalars.index(before: i))

--- a/validation-test/stdlib/UnicodeWordRecognizer.swift
+++ b/validation-test/stdlib/UnicodeWordRecognizer.swift
@@ -248,13 +248,13 @@ extension String {
   /// This is expected to be some monotonically increasing subsequence of word
   /// boundaries detected in the forward direction, allowing some repeated
   /// items.
-  @available(StdlibDeploymentTarget 6.3, *)
+  @available(SwiftStdlib 6.3, *)
   func randomAccessWordBreaks() -> [String.Index] {
     unicodeScalars.allIndices().map { self._wordIndex(somewhereAtOrBefore: $0) }
   }
 }
 
-@available(StdlibDeploymentTarget 6.3, *)
+@available(SwiftStdlib 6.3, *)
 func check(length: Int) {
   withEveryArray(of: 0 ..< samples.count, count: length) { vector in
     let str = string(for: vector)
@@ -292,7 +292,7 @@ func check(length: Int) {
   }
 }
 
-if #available(StdlibDeploymentTarget 6.3, *) {
+if #available(SwiftStdlib 6.3, *) {
   suite.test("Exhaustive consistency checks, length 1") {
     check(length: 1)
   }


### PR DESCRIPTION
This PR updates the Standard Library to resolve `SwiftStdlib 6.3` to the new OS releases that are currently in beta:

```
SwiftStdlib 6.3:macOS 26.4, iOS 26.4, watchOS 26.4, tvOS 26.4, visionOS 26.4
```

It also updates RuntimeVersions.def to define availability for the 6.3 runtime within the compiler.
