### PR TITLE
[Diagnostics] Prefer sibling branch member errors over contextual nil mismatches

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9210,11 +9210,18 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
 
     // If this is a `nil` literal, it would be a contextual failure.
     if (auto *Nil = getAsExpr<NilLiteralExpr>(anchor)) {
-      auto *fixLocator = getConstraintLocator(
-          getContextualType(Nil, /*forConstraint=*/false)
-              ? locator.withPathElement(LocatorPathElt::ContextualType(
-                    getContextualTypePurpose(Nil)))
-              : locator);
+      ConstraintLocator *fixLocator = nullptr;
+      if (auto contextualInfo = getContextualTypeInfo(Nil)) {
+        fixLocator = contextualInfo->locator;
+      }
+
+      if (!fixLocator) {
+        fixLocator = getConstraintLocator(
+            getContextualType(Nil, /*forConstraint=*/false)
+                ? locator.withPathElement(LocatorPathElt::ContextualType(
+                      getContextualTypePurpose(Nil)))
+                : locator);
+      }
 
       // Only requirement placed directly on `nil` literal is
       // `ExpressibleByNilLiteral`, so if `nil` is an argument
@@ -9232,7 +9239,16 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
       auto *fix =
           ContextualMismatch::create(*this, protocolTy, type, fixLocator);
 
-      return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
+      auto impact = 1u;
+      using SingleValueStmtResult = LocatorPathElt::SingleValueStmtResult;
+      if (auto branchElt = fixLocator->findLast<SingleValueStmtResult>()) {
+        // Mirror the existing branch scoring for contextual mismatches, but
+        // keep the first branch expensive enough that concrete errors in
+        // sibling branches still win diagnostics over a `nil` mismatch.
+        impact = branchElt->getIndex() > 0 ? 9 + branchElt->getIndex() : 5;
+      }
+      return recordFix(fix, impact) ? SolutionKind::Error
+                                    : SolutionKind::Solved;
     }
 
     // If there is a missing conformance between source and destination

--- a/test/Constraints/issue-79474.swift
+++ b/test/Constraints/issue-79474.swift
@@ -1,0 +1,26 @@
+// RUN: %target-typecheck-verify-swift
+
+enum SwitchResult {
+  case ints([Int])
+  case strings([String])
+}
+
+func diagnoseLaterBranchMemberError(_ value: SwitchResult) -> [Int]? {
+  switch value {
+  case .strings:
+    nil
+
+  case .ints(let values):
+    if values.count > 1 {
+      values.missingMember // expected-error {{value of type '[Int]' has no member 'missingMember'}}
+    } else {
+      nil
+    }
+  }
+}
+
+let _: Int? = if true {
+  nil
+} else {
+  [0].missingMember // expected-error {{value of type '[Int]' has no member 'missingMember'}}
+}


### PR DESCRIPTION
Fixes #79474

When a `nil` literal inside an `if` or `switch` expression fails the `ExpressibleByNilLiteral` salvage path, the solver was synthesizing a fresh contextual locator and recording a cheap contextual mismatch directly on `nil`.
That discarded the existing single-value-statement branch locator, which let an early `nil` mismatch beat a concrete diagnostic in a sibling branch.

Reuse the existing contextual locator when it is available and score these branch-local `nil` mismatches like other single-value-statement contextual mismatches, with the first branch still expensive enough that a concrete sibling-branch member error wins diagnostics.

Adds a regression test covering both `switch` and `if` expressions with implicit returns.

### Validation:
- Xcode 26.3 `swift-frontend` reproduces the bogus `nil` diagnostic on the new test file
- Rebuilt local `swift-frontend` from this branch passes the same test file with `-verify`
