### PR TITLE
[Sema] Ensure API-level property wrapper attached to a closure parameter actually has required init before type checking

### DIFF
--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -3822,7 +3822,9 @@ PropertyWrapperInitializerInfoRequest::evaluate(Evaluator &evaluator,
   if (auto *projection = var->getPropertyWrapperProjectionVar()) {
     createPBD(projection);
 
-    if (var->hasExternalPropertyWrapper()) {
+    // Make sure that we actually have init(projectedValue:)
+    // before attempting to type check it.
+    if (var->hasExternalPropertyWrapper() && wrapperInfo.hasProjectedValueInit) {
       // Projected-value initialization is currently only supported for parameters.
       auto *param = dyn_cast<ParamDecl>(var);
       auto *placeholder = PropertyWrapperValuePlaceholderExpr::create(

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -2152,3 +2152,24 @@ struct TestInitError {
   // expected-error@+1 {{cannot convert value of type 'Int' to specified type 'WrapperWithFailableInit<Int>'}}
   @WrapperWithFailableInit var value: Int = 10
 }
+
+// https://github.com/swiftlang/swift/issues/87513
+@propertyWrapper
+struct WrapperWithNoProjectedValueInit {
+  var wrappedValue: Int
+  var projectedValue: String {
+    get {
+      String(self.wrappedValue)
+    }
+  }
+
+  init(wrappedValue: Int) {
+    self.wrappedValue = wrappedValue
+  }
+}
+
+struct TestWrapperWithNoProjectedValueInitOnClosureParameter {
+  let c: (Int) -> (Int, String, WrapperWithNoProjectedValueInit) = { (@WrapperWithNoProjectedValueInit x) in
+    (x, $x, _x)
+  }
+}


### PR DESCRIPTION
Resolves #87513.

For closures with API-level property wrappers attached to a parameter, the compiler concludes it has external effects and will synthesize a call to `init(projectedValue:)` even if one doesn't exist. Instead, we want to first check if this initializer actually exists; if it does, we will continue.