### PR TITLE
ABI: unify suppressed associated types mangling

### DIFF
--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -1362,10 +1362,6 @@ void GenericSignatureImpl::getRequirementsWithInverses(
     SmallVector<InverseRequirement, 2> &inverses) const {
   auto &ctx = getASTContext();
 
-  // TODO: deprecate support for this old version of the feature.
-  const bool LegacySuppAssoc =
-      ctx.LangOpts.hasFeature(Feature::SuppressedAssociatedTypes);
-
   llvm::SmallSet<CanType, 12> seenDMTs;
   auto addInverses = [&](Type tyParam) {
     // We keep track of member types for which we tried to add an inverse,
@@ -1416,21 +1412,19 @@ void GenericSignatureImpl::getRequirementsWithInverses(
   ///     public func i<T: P>(..) where T.A: ~Copyable {}
   ///     public func c<T: P>(..) where T.A: Copyable {}
   ///
-  /// The legacy version of the feature, without defaults, `i` would not mention
-  /// any inverses, as it was taken as a given it's ~Copyable, and only in `c`
-  /// would we see (both in mangling and interfaces) `T.A: Copyable`.
+  /// Function `i` WILL mention the inverse `T.A: ~Copyable` in its symbol
+  /// and interfaces, but `c` will NOT mention `T.A: Copyable`, as that's a
+  /// given for primary associated types.
   ///
-  /// In the new version, WITH defaults for PATs, it's the opposite.
-  /// Function `f` now WILL mention the inverse `T.A: ~Copyable` in `i`,
-  /// but `c` will not mention `T.A: Copyable`, as it's a given.
+  /// For non-primary associated types, it's the opposite.
+  /// Function `i` WILL NOT mention the inverse `T.A: ~Copyable` in its symbol
+  /// or interfaces, but `c` WILL mention `T.A: Copyable`, as that's NOT assumed
+  /// for a non-primary associated type.
   ///
-  /// For non-primary associated types, the behavior is the same as the legacy
-  /// version of the feature.
+  /// In theory this scheme is generalizable to any subset of associated types
+  /// for which a default is to be assumed for either Copyable and/or Escapable.
+  /// The idea is to mention what is NOT the default for the associatedtype.
   for (auto req : getRequirements()) {
-
-    // We never emitted inverses for any associated types in the legacy version.
-    if (LegacySuppAssoc)
-      break;
 
     if (req.getKind() != RequirementKind::Conformance)
       continue;

--- a/test/ModuleInterface/associated_type_suppressed.swift
+++ b/test/ModuleInterface/associated_type_suppressed.swift
@@ -1,17 +1,28 @@
 // RUN: %empty-directory(%t)
 
+// --- SuppressedAssociatedTypesWithDefaults
 // RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name assoc -enable-experimental-feature SuppressedAssociatedTypesWithDefaults
 // RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name assoc
-// RUN: %FileCheck %s < %t.swiftinterface
+// RUN: %FileCheck --check-prefixes=INTERFACE,INTERFACE-NEW %s < %t.swiftinterface
 
 // RUN: %target-swift-frontend -emit-silgen %s -module-name assoc -enable-experimental-feature SuppressedAssociatedTypesWithDefaults -o %t.silgen
-// RUN: %FileCheck --check-prefix=SIL %s < %t.silgen
+// RUN: %FileCheck --check-prefixes=SIL,SIL-NEW %s < %t.silgen
+
+// --- SuppressedAssociatedTypes
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name assoc -enable-experimental-feature SuppressedAssociatedTypes
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name assoc
+// RUN: %FileCheck --check-prefixes=INTERFACE,INTERFACE-LEGACY %s < %t.swiftinterface
+
+// RUN: %target-swift-frontend -emit-silgen %s -module-name assoc -enable-experimental-feature SuppressedAssociatedTypes -o %t.silgen
+// RUN: %FileCheck --check-prefixes=SIL,SIL-LEGACY %s < %t.silgen
+
 
 // REQUIRES: swift_feature_SuppressedAssociatedTypesWithDefaults
+// REQUIRES: swift_feature_SuppressedAssociatedTypes
 
-// CHECK-LABEL: public protocol P<Element> : ~Copyable {
-// CHECK:          associatedtype Element : ~Copyable
-// CHECK:          associatedtype Iterator : ~Copyable
+// INTERFACE-LABEL: public protocol P<Element> : ~Copyable {
+// INTERFACE:          associatedtype Element : ~Copyable
+// INTERFACE:          associatedtype Iterator : ~Copyable
 public protocol P<Element>: ~Copyable {
   associatedtype Element: ~Copyable
   associatedtype Iterator: ~Copyable
@@ -23,7 +34,7 @@ public protocol Ordinary<Element> {
 }
 
 // For ordinary protocols with associated types, we shouldn't emit any Copyable / ~Copyable...
-// CHECK-NOT: Copyable
+// INTERFACE-NOT: Copyable
 public func ordinary<T: Ordinary>(_ t: T) {}
 public struct Thing<T: Ordinary> {}
 
@@ -31,73 +42,109 @@ public struct Thing<T: Ordinary> {}
 // Keep in mind that `Rj` and `RJ` mean inverses for associated types!
 //////
 
-// CHECK: public func ncElement<T>(_ t: T) where T : assoc::P, T.Element : ~Copyable
+// INTERFACE: public func ncElement<T>(_ t: T) where T : assoc::P, T.Element : ~Copyable
 // SIL: @$s5assoc9ncElementyyxAA1PRz0C0Rj_zlF :
 public func ncElement<T: P>(_ t: T) where T.Element: ~Copyable {}
 
-// CHECK: public func ncElement_pi<T>(_ t: T) where T : assoc::P, T.Element : ~Copyable
+// INTERFACE: public func ncElement_pi<T>(_ t: T) where T : assoc::P, T.Element : ~Copyable
 // SIL: @$s5assoc12ncElement_piyyxAA1PRzlF :
 @_preInverseGenerics
 public func ncElement_pi<T: P>(_ t: T) where T.Element: ~Copyable {}
 
-// CHECK: public func ncIter<T>(_ t: T) where T : assoc::P
-// SIL: @$s5assoc6ncIteryyxAA1PRzlF :
+// INTERFACE: public func ncIter<T>(_ t: T) where T : assoc::P
+// SIL-NEW:    @$s5assoc6ncIteryyxAA1PRzlF :
+// SIL-LEGACY: @$s5assoc6ncIteryyxAA1PRz7ElementRj_zlF :
 public func ncIter<T: P>(_ t: T) where T.Iterator: ~Copyable {}
 
-// CHECK: public func ncIter2<T>(_ t: T) where T : assoc::P
-// SIL: @$s5assoc7ncIter2yyxAA1PRzlF :
-public func ncIter2<T: P>(_ t: T) {}
+// INTERFACE: public func ncIter2<T>(_ t: T) where T : assoc::P
+// SIL-NEW:    @$s5assoc7ncIter2yyxAA1PRzlF :
+// SIL-LEGACY: @$s5assoc7ncIter2yyxAA1PRz7ElementRj_zlF :
+public func ncIter2<T: P>(_ t: T) {
+  // NOTE: this print is executed in a different test
+  print("hello \(t)")
+}
 
-// CHECK: public func ncBoth<T>(_ t: T) where T : assoc::P, T.Element : ~Copyable
+// vv Compare ncIter3 with ncIter2 ^^
+// To get the same mangling under both versions of the feature,
+// one must be specific about the Element being Copyable, since
+// it's not assumed to be under the old feature, but it IS under the new one.
+
+// INTERFACE: public func ncIter3<T>(_ t: T) where T : assoc::P
+// SIL    @$s5assoc7ncIter3yyxAA1PRzlF :
+public func ncIter3<T: P>(_ t: T) where T.Element: Copyable {}
+
+// INTERFACE: public func ncBoth<T>(_ t: T) where T : assoc::P, T.Element : ~Copyable
 // SIL: @$s5assoc6ncBothyyxAA1PRz7ElementRj_zlF :
 public func ncBoth<T: P>(_ t: T) where T.Iterator: ~Copyable, T.Element: ~Copyable {}
 
-// CHECK: public func bothCopyable<T>(_ t: T) where T : assoc::P, T.Iterator : Swift::Copyable
-// SIL: @$s5assoc12bothCopyableyyxAA1PRzs0C08IteratorRpzlF :
+// INTERFACE: public func bothCopyable<T>(_ t: T) where T : assoc::P, T.Iterator : Swift::Copyable
+// SIL-NEW:    @$s5assoc12bothCopyableyyxAA1PRzs0C08IteratorRpzlF :
+// SIL-LEGACY: @$s5assoc12bothCopyableyyxAA1PRzs0C08IteratorRpz7ElementRj_zlF :
 public func bothCopyable<T: P>(_ t: T) where T.Iterator: Copyable {}
 
-// CHECK-LABEL: public struct Holder<S> where S : assoc::P, S : ~Copyable, S.Element : ~Copyable {
+// INTERFACE-LABEL: public struct Holder<S> where S : assoc::P, S : ~Copyable, S.Element : ~Copyable {
 public struct Holder<S> where S.Element: ~Copyable, S: P & ~Copyable {
 
-// CHECK: public func defaultedElement<T>(_ t: T) where T : assoc::P
-// SIL: @$s5assoc6HolderVAARi_z7ElementRj_zrlE09defaultedC0yyqd__AA1PRd__lF :
+// INTERFACE: public func defaultedElement<T>(_ t: T) where T : assoc::P
+// SIL-NEW:    @$s5assoc6HolderVAARi_z7ElementRj_zrlE09defaultedC0yyqd__AA1PRd__lF :
+// SIL-LEGACY: @$s5assoc6HolderVAARi_z7ElementRj_zrlE09defaultedC0yyqd__AA1PRd__ADRj_d__lF :
   public func defaultedElement<T>(_ t: T) where T: P {}
 
-// CHECK: public func ncElement<T>(_ t: T) where T : assoc::P, T.Element : ~Copyable
+// INTERFACE: public func ncElement<T>(_ t: T) where T : assoc::P, T.Element : ~Copyable
 // SIL: @$s5assoc6HolderVAARi_z7ElementRj_zrlE02ncC0yyqd__AA1PRd__ADRj_d__lF :
   public func ncElement<T>(_ t: T) where T: P, T.Element: ~Copyable {}
 
-// CHECK: public func copyableIter<T>(_ t: T) where T : assoc::P, T.Iterator : Swift::Copyable
-// SIL: @$s5assoc6HolderVAARi_z7ElementRj_zrlE12copyableIteryyqd__AA1PRd__s8Copyable8IteratorRpd__lF :
+// INTERFACE: public func copyableIter<T>(_ t: T) where T : assoc::P, T.Iterator : Swift::Copyable
+// SIL-NEW:    @$s5assoc6HolderVAARi_z7ElementRj_zrlE12copyableIteryyqd__AA1PRd__s8Copyable8IteratorRpd__lF :
+// SIL-LEGACY: @$s5assoc6HolderVAARi_z7ElementRj_zrlE12copyableIteryyqd__AA1PRd__s8Copyable8IteratorRpd__ADRj_d__lF :
 public func copyableIter<T: P>(_ t: T) where T.Iterator: Copyable {}
 }
 
-// CHECK: extension assoc::Holder {
+// INTERFACE-NEW: extension assoc::Holder {
+// INTERFACE-LEGACY: extension assoc::Holder where S.Element : ~Copyable {
 extension Holder {
-  // SIL: @$s5assoc6HolderV19forceIntoInterface1yyF :
+  // SIL-NEW:    @$s5assoc6HolderV19forceIntoInterface1yyF :
+  // SIL-LEGACY: @$s5assoc6HolderVAA7ElementRj_zrlE19forceIntoInterface1yyF :
   public func forceIntoInterface1() {}
+
+  // SIL:        @$s5assoc6HolderV20forceIntoInterface1cyyF :
+  public func forceIntoInterface1c() where S.Element: Copyable {}
 }
 
-// CHECK: extension assoc::Holder where S.Iterator : Swift::Copyable {
+// INTERFACE-NEW: extension assoc::Holder where S.Iterator : Swift::Copyable {
+// INTERFACE-LEGACY: extension assoc::Holder where S.Iterator : Swift::Copyable, S.Element : ~Copyable {
 extension Holder where S.Iterator: Copyable {
-  // SIL: @$s5assoc6HolderVAAs8Copyable8IteratorRpzrlE19forceIntoInterface2yyF :
+  // SIL-NEW:    @$s5assoc6HolderVAAs8Copyable8IteratorRpzrlE19forceIntoInterface2yyF :
+  // SIL-LEGACY: @$s5assoc6HolderVAAs8Copyable8IteratorRpz7ElementRj_zrlE19forceIntoInterface2yyF :
   public func forceIntoInterface2() {}
+
+  // SIL:        @$s5assoc6HolderVAAs8Copyable8IteratorRpzrlE20forceIntoInterface2cyyF :
+  public func forceIntoInterface2c() where S.Element: Copyable {}
 }
 
-// CHECK: extension assoc::Holder where S.Element : ~Copyable {
+// INTERFACE: extension assoc::Holder where S.Element : ~Copyable {
 extension Holder where S.Element: ~Copyable {
   // SIL: @$s5assoc6HolderVAA7ElementRj_zrlE19forceIntoInterface5yyF :
   public func forceIntoInterface5() {}
 }
 
-// CHECK: extension assoc::P {
+// INTERFACE-NEW: extension assoc::P {
+// INTERFACE-LEGACY: extension assoc::P where Self.Element : ~Copyable {
 extension P {
-  // SIL: @$s5assoc1PPAAE19forceIntoInterface3yyF :
+  // SIL-NEW:    @$s5assoc1PPAAE19forceIntoInterface3yyF :
+  // SIL-LEGACY: @$s5assoc1PPAA7ElementRj_zrlE19forceIntoInterface3yyF :
   public func forceIntoInterface3() {}
+  // SIL:        @$s5assoc1PPAAE20forceIntoInterface3cyyF :
+  public func forceIntoInterface3c() where Element: Copyable {}
 }
 
-// CHECK: extension assoc::P where Self.Iterator : Swift::Copyable {
+// INTERFACE-NEW: extension assoc::P where Self.Iterator : Swift::Copyable {
+// INTERFACE-LEGACY: extension assoc::P where Self.Iterator : Swift::Copyable, Self.Element : ~Copyable {
 extension P where Iterator: Copyable {
-  // SIL: @$s5assoc1PPAAs8Copyable8IteratorRpzrlE19forceIntoInterface4yyF
+  // SIL-NEW:    @$s5assoc1PPAAs8Copyable8IteratorRpzrlE19forceIntoInterface4yyF :
+  // SIL-LEGACY: @$s5assoc1PPAAs8Copyable8IteratorRpz7ElementRj_zrlE19forceIntoInterface4yyF :
   public func forceIntoInterface4() {}
+
+  // SIL:        @$s5assoc1PPAAs8Copyable8IteratorRpzrlE20forceIntoInterface4cyyF :
+  public func forceIntoInterface4c() where Element: Copyable {}
 }

--- a/test/ModuleInterface/associated_type_suppressed.swift
+++ b/test/ModuleInterface/associated_type_suppressed.swift
@@ -70,7 +70,7 @@ public func ncIter2<T: P>(_ t: T) {
 // it's not assumed to be under the old feature, but it IS under the new one.
 
 // INTERFACE: public func ncIter3<T>(_ t: T) where T : assoc::P
-// SIL    @$s5assoc7ncIter3yyxAA1PRzlF :
+// SIL:   @$s5assoc7ncIter3yyxAA1PRzlF :
 public func ncIter3<T: P>(_ t: T) where T.Element: Copyable {}
 
 // INTERFACE: public func ncBoth<T>(_ t: T) where T : assoc::P, T.Element : ~Copyable

--- a/test/ModuleInterface/associated_type_suppressed_client.swift
+++ b/test/ModuleInterface/associated_type_suppressed_client.swift
@@ -1,0 +1,87 @@
+// ---------------------
+// Feature mixing: library = NEW, client = OLD
+// RUN: %empty-directory(%t)
+
+// RUN: %target-build-swift -target %target-cpu-apple-macosx13 -parse-as-library -emit-library -enable-experimental-feature SuppressedAssociatedTypesWithDefaults \
+// RUN:     -emit-module-path %t/lib.swiftmodule -emit-module-interface-path %t/lib.swiftinterface \
+// RUN:     -module-name lib -enable-library-evolution %S/associated_type_suppressed.swift -o %t/%target-library-name(lib)
+// RUN: %target-codesign %t/%target-library-name(lib)
+
+// RUN: %target-swift-frontend -DEXPECTED_ERROR -typecheck -verify -verify-ignore-unrelated -enable-experimental-feature SuppressedAssociatedTypes -I %t -L %t %s
+
+// RUN: %target-build-swift -enable-experimental-feature SuppressedAssociatedTypes -target %target-cpu-apple-macosx13 -llib -module-name main -I %t -L %t %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck --check-prefixes=EXEC %s
+
+// Try again after deleting the swiftmodule to force rebuilding from its interface
+// RUN: rm %t/lib.swiftmodule
+
+// RUN: %target-build-swift -enable-experimental-feature SuppressedAssociatedTypes -target %target-cpu-apple-macosx13 -llib -module-name main -I %t -L %t %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck --check-prefixes=EXEC %s
+
+// Ensure NEW & NEW works too.
+// RUN: %target-build-swift -enable-experimental-feature SuppressedAssociatedTypesWithDefaults -target %target-cpu-apple-macosx13 -llib -module-name main -I %t -L %t %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck --check-prefixes=EXEC %s
+
+
+// ---------------------
+// Feature mixing: library = OLD, client = NEW
+// RUN: %empty-directory(%t)
+
+// RUN: %target-build-swift -target %target-cpu-apple-macosx13 -parse-as-library -emit-library -enable-experimental-feature SuppressedAssociatedTypes \
+// RUN:     -emit-module-path %t/lib.swiftmodule -emit-module-interface-path %t/lib.swiftinterface \
+// RUN:     -module-name lib -enable-library-evolution %S/associated_type_suppressed.swift -o %t/%target-library-name(lib)
+// RUN: %target-codesign %t/%target-library-name(lib)
+
+// RUN: %target-build-swift -DEXPECTED_ERROR -enable-experimental-feature SuppressedAssociatedTypesWithDefaults -target %target-cpu-apple-macosx13 -llib -module-name main -I %t -L %t %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck --check-prefixes=EXEC %s
+
+
+// REQUIRES: OS=macosx && (CPU=x86_64 || CPU=arm64)
+// REQUIRES: executable_test
+// UNSUPPORTED: remote_run || device_run
+
+// REQUIRES: swift_feature_SuppressedAssociatedTypesWithDefaults
+// REQUIRES: swift_feature_SuppressedAssociatedTypes
+
+import lib
+
+struct NC: ~Copyable {}
+public struct S<Element, Iterator>: P where Element: ~Copyable, Iterator: ~Copyable {}
+
+public protocol OldVersion<Element> {
+  associatedtype Element: ~Copyable // expected-warning {{experimental feature 'SuppressedAssociatedTypes' is deprecated; see SE-503 for the official version}}
+}
+
+// `ncIter2` is defined with a generic signature <T: P> where P has a suppressed primary associated type Element.
+// Under a library built using the NEW feature, it should require S's first type to be Copyable, otherwise, it's not
+// required to be Copyable.
+
+ncIter2(S<Int, Int>())  // EXEC: hello S<Int, Int>()
+ncIter2(S<Int, NC>())   // EXEC: hello S<Int, NC>()
+
+// Ensure no linking error calling other kinds of public funcs
+public func check<C, NC>(_ s: S<C, NC>) {
+  ncIter(s)
+  ncIter2(s)
+  ncIter3(s)
+  ncBoth(s)
+  ncElement_pi(s)
+  ncElement(s)
+  bothCopyable(s)
+}
+check(S<String, String>())
+
+#if EXPECTED_ERROR
+ncIter2(S<NC, NC>()) // expected-error {{global function 'ncIter2' requires that 'NC' conform to 'Copyable'}}
+
+func requireCopyable<T: Copyable>(_ t: T) {} // expected-note {{}}
+
+func test<T: OldVersion>(_ t: borrowing T, _ e: borrowing T.Element) {
+  requireCopyable(e) // expected-error {{global function 'requireCopyable' requires that 'T.Element' conform to 'Copyable'}}
+}
+#endif
+


### PR DESCRIPTION
The legacy, experimental SuppressedAssociatedTypes feature never
mangled any inverses into generic signatures of functions, nor mentioned
them in interfaces at all. In the new version of the feature that's been
officially accepted as [SE-503](https://swiftlang.github.io/swift-evolution/#?proposal=SE-503), we now _do_ default primary associated
types to be Copyable & Escapable when they're suppressed. And we do mention
the suppressions in the interfaces as needed.

Rather than having the compiler mangle functions in two different ways,
this patch has the compiler be consistent about its mangling and interfaces,
regardless of which feature you're using.

This should mean that a future upgrade from the legacy feature to the
new one won't create an ABI break, only a source break (as expected).

So, an ABI change now before more people use the wrong experimental feature
will make it easier to migrate to the officially-accepted version later on.

rdar://170669869