### PR TITLE
[6.3][stdlib] Define availability for SwiftStdlib 6.3

### DIFF
--- a/include/swift/AST/RuntimeVersions.def
+++ b/include/swift/AST/RuntimeVersions.def
@@ -168,7 +168,10 @@ RUNTIME_VERSION(
 
 RUNTIME_VERSION(
   (6, 3),
-  FUTURE
+  PLATFORM(macOS,   (26, 4, 0))
+  PLATFORM(iOS,     (26, 4, 0))
+  PLATFORM(watchOS, (26, 4, 0))
+  PLATFORM(visionOS,(26, 4, 0))
 )
 
 END_MAJOR_VERSION(6)

--- a/utils/availability-macros.def
+++ b/utils/availability-macros.def
@@ -46,7 +46,9 @@ SwiftStdlib 5.10:macOS 14.4, iOS 17.4, watchOS 10.4, tvOS 17.4, visionOS 1.1
 SwiftStdlib 6.0:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0
 SwiftStdlib 6.1:macOS 15.4, iOS 18.4, watchOS 11.4, tvOS 18.4, visionOS 2.4
 SwiftStdlib 6.2:macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0
-SwiftStdlib 6.3:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999
+SwiftStdlib 6.3:macOS 26.4, iOS 26.4, watchOS 26.4, tvOS 26.4, visionOS 26.4
+# TODO: When you add a new version, remember to tell the compiler about it
+# by also adding it to include/swift/AST/RuntimeVersions.def.
 
 # Like SwiftStdlib 5.0, but also the oldest visionOS.
 SwiftCompatibilitySpan 5.0:macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, visionOS 1.0
@@ -56,9 +58,6 @@ SwiftCompatibilitySpan 6.2:macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, vision
 
 # Backtracing is only available for macOS in 6.2
 Backtracing 6.2: macOS 26.0
-
-# TODO: When you add a new version, remember to tell the compiler about it
-# by also adding it to include/swift/AST/RuntimeVersions.def.
 
 # Local Variables:
 # mode: conf-unix

--- a/validation-test/stdlib/StringWordBreaking.swift
+++ b/validation-test/stdlib/StringWordBreaking.swift
@@ -68,7 +68,7 @@ extension String {
   /// - Parameter i: A valid index addressing a word boundary within this
   ///    string.
   /// - Returns: The first word break strictly following `i` in the string.
-  @available(StdlibDeploymentTarget 6.3, *)
+  @available(SwiftStdlib 6.3, *)
   public func _wordIndex(before i: String.Index) -> String.Index {
     let i = self.unicodeScalars._index(roundingDown: i)
     var j = _wordIndex(somewhereAtOrBefore: unicodeScalars.index(before: i))

--- a/validation-test/stdlib/UnicodeWordRecognizer.swift
+++ b/validation-test/stdlib/UnicodeWordRecognizer.swift
@@ -248,13 +248,13 @@ extension String {
   /// This is expected to be some monotonically increasing subsequence of word
   /// boundaries detected in the forward direction, allowing some repeated
   /// items.
-  @available(StdlibDeploymentTarget 6.3, *)
+  @available(SwiftStdlib 6.3, *)
   func randomAccessWordBreaks() -> [String.Index] {
     unicodeScalars.allIndices().map { self._wordIndex(somewhereAtOrBefore: $0) }
   }
 }
 
-@available(StdlibDeploymentTarget 6.3, *)
+@available(SwiftStdlib 6.3, *)
 func check(length: Int) {
   withEveryArray(of: 0 ..< samples.count, count: length) { vector in
     let str = string(for: vector)
@@ -292,7 +292,7 @@ func check(length: Int) {
   }
 }
 
-if #available(StdlibDeploymentTarget 6.3, *) {
+if #available(SwiftStdlib 6.3, *) {
   suite.test("Exhaustive consistency checks, length 1") {
     check(length: 1)
   }


### PR DESCRIPTION
* **Explanation**:  This PR updates the Standard Library to resolve the SwiftStdlib 6.3 availability macro to reflect the new OS releases that are currently in beta.
* **Risk**: Minimal; this change is already shipping in the beta SDKs
* **Testing**: Regular CI
* **Issue**: Resolves https://github.com/swiftlang/swift/issues/87517
* **Reviewer**:  @tshortli
* **Main branch PR**: https://github.com/swiftlang/swift/pull/87510