### PR TITLE
[CSSolver] Exclude overloads that are generic only over an error type…

### DIFF
--- a/test/Constraints/generic_overload_filtering_with_typed_throws.swift
+++ b/test/Constraints/generic_overload_filtering_with_typed_throws.swift
@@ -1,0 +1,22 @@
+// RUN: %target-typecheck-verify-swift
+
+// With filtering Set.filter is preferred over Sequence.filter but that
+// results in a worse solution than if it did use Sequence.filter.
+
+extension Set {
+  func myFilter<E: Error>(_: (Element) throws(E) -> Bool) throws(E) -> Set<Element> { self }
+  func myFilter2(_: (Element) throws -> Bool) rethrows -> Set<Element> { self }
+}
+
+extension Sequence {
+  func myFilter<E: Error>(_: (Element) throws(E) -> Bool) throws(E) -> [Self.Element] { [] }
+  func myFilter2(_: (Element) throws -> Bool) rethrows -> [Self.Element] { [] }
+}
+
+func test(clusterID: Int, values: [Int: Set<Int>]) {
+  let matching1 = values[clusterID]?.myFilter { _ in false } ?? []
+  let matching2 = values[clusterID]?.myFilter2 { _ in false } ?? []
+  
+  let _: [Int] = matching1 // Ok
+  let _: [Int] = matching2 // Ok
+}


### PR DESCRIPTION
… from generic overload optimization

Typed throws adoption could cause source compatibility regressions because it makes some overloads generic when they used to be concrete and didn't participate in this generic-only optimization that covers cases where there are only two overloads.

Resolves: rdar://171016238

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
