### PR TITLE
[stdlib] Implement RigidArray and UniqueArray from swift-collections

### DIFF
--- a/Runtimes/Core/Core/CMakeLists.txt
+++ b/Runtimes/Core/Core/CMakeLists.txt
@@ -145,6 +145,7 @@ add_library(swiftCore
   # RigidArray sources
   RigidArray/RigidArray.swift
   RigidArray/RigidArray+Append.swift
+  RigidArray/RigidArray+Container.swift
   RigidArray/RigidArray+Descriptions.swift
   RigidArray/RigidArray+Equatable.swift
   RigidArray/RigidArray+Hashable.swift
@@ -227,6 +228,7 @@ add_library(swiftCore
   # UniqueArray sources
   UniqueArray/UniqueArray.swift
   UniqueArray/UniqueArray+Append.swift
+  UniqueArray/UniqueArray+Container.swift
   UniqueArray/UniqueArray+Descriptions.swift
   UniqueArray/UniqueArray+Equatable.swift
   UniqueArray/UniqueArray+Hashable.swift

--- a/Runtimes/Core/Core/CMakeLists.txt
+++ b/Runtimes/Core/Core/CMakeLists.txt
@@ -141,6 +141,18 @@ add_library(swiftCore
   REPL.swift
   Result.swift
   Reverse.swift
+
+  # RigidArray sources
+  RigidArray/RigidArray.swift
+  RigidArray/RigidArray+Append.swift
+  RigidArray/RigidArray+Descriptions.swift
+  RigidArray/RigidArray+Equatable.swift
+  RigidArray/RigidArray+Hashable.swift
+  RigidArray/RigidArray+Initializers.swift
+  RigidArray/RigidArray+Insertions.swift
+  RigidArray/RigidArray+Removals.swift
+  RigidArray/RigidArray+Replacements.swift
+
   Runtime.swift
   RuntimeFunctionCounters.swift
   SipHash.swift
@@ -211,6 +223,18 @@ add_library(swiftCore
   UnicodeScalarProperties.swift
   CharacterProperties.swift # ORDER DEPENDENCY: UnicodeScalarProperties.swift
   UnicodeSPI.swift
+
+  # UniqueArray sources
+  UniqueArray/UniqueArray.swift
+  UniqueArray/UniqueArray+Append.swift
+  UniqueArray/UniqueArray+Descriptions.swift
+  UniqueArray/UniqueArray+Equatable.swift
+  UniqueArray/UniqueArray+Hashable.swift
+  UniqueArray/UniqueArray+Initializers.swift
+  UniqueArray/UniqueArray+Insertions.swift
+  UniqueArray/UniqueArray+Removals.swift
+  UniqueArray/UniqueArray+Replacements.swift
+
   UniqueBox.swift
   Unmanaged.swift
   UnmanagedOpaqueString.swift

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -154,6 +154,7 @@ split_embedded_sources(
   # RigidArray sources
   EMBEDDED RigidArray/RigidArray.swift
   EMBEDDED RigidArray/RigidArray+Append.swift
+  EMBEDDED RigidArray/RigidArray+Container.swift
   EMBEDDED RigidArray/RigidArray+Descriptions.swift
   EMBEDDED RigidArray/RigidArray+Equatable.swift
   EMBEDDED RigidArray/RigidArray+Hashable.swift
@@ -233,6 +234,7 @@ split_embedded_sources(
   # UniqueArray sources
   EMBEDDED UniqueArray/UniqueArray.swift
   EMBEDDED UniqueArray/UniqueArray+Append.swift
+  EMBEDDED UniqueArray/UniqueArray+Container.swift
   EMBEDDED UniqueArray/UniqueArray+Descriptions.swift
   EMBEDDED UniqueArray/UniqueArray+Equatable.swift
   EMBEDDED UniqueArray/UniqueArray+Hashable.swift

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -150,6 +150,18 @@ split_embedded_sources(
   EMBEDDED Repeat.swift
   EMBEDDED Result.swift
   EMBEDDED Reverse.swift
+
+  # RigidArray sources
+  EMBEDDED RigidArray/RigidArray.swift
+  EMBEDDED RigidArray/RigidArray+Append.swift
+  EMBEDDED RigidArray/RigidArray+Descriptions.swift
+  EMBEDDED RigidArray/RigidArray+Equatable.swift
+  EMBEDDED RigidArray/RigidArray+Hashable.swift
+  EMBEDDED RigidArray/RigidArray+Initializers.swift
+  EMBEDDED RigidArray/RigidArray+Insertions.swift
+  EMBEDDED RigidArray/RigidArray+Removals.swift
+  EMBEDDED RigidArray/RigidArray+Replacements.swift
+
   EMBEDDED Runtime.swift
     NORMAL RuntimeFunctionCounters.swift
   EMBEDDED Sendable.swift
@@ -217,6 +229,18 @@ split_embedded_sources(
     NORMAL ThreadLocalStorage.swift
   EMBEDDED UInt128.swift
   EMBEDDED UIntBuffer.swift
+
+  # UniqueArray sources
+  EMBEDDED UniqueArray/UniqueArray.swift
+  EMBEDDED UniqueArray/UniqueArray+Append.swift
+  EMBEDDED UniqueArray/UniqueArray+Descriptions.swift
+  EMBEDDED UniqueArray/UniqueArray+Equatable.swift
+  EMBEDDED UniqueArray/UniqueArray+Hashable.swift
+  EMBEDDED UniqueArray/UniqueArray+Initializers.swift
+  EMBEDDED UniqueArray/UniqueArray+Insertions.swift
+  EMBEDDED UniqueArray/UniqueArray+Removals.swift
+  EMBEDDED UniqueArray/UniqueArray+Replacements.swift
+
   EMBEDDED UTF16.swift
   EMBEDDED UTF32.swift
   EMBEDDED UTF8.swift

--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -293,6 +293,7 @@
   "RigidArray": [
     "RigidArray.swift",
     "RigidArray+Append.swift",
+    "RigidArray+Container.swift",
     "RigidArray+Descriptions.swift",
     "RigidArray+Equatable.swift",
     "RigidArray+Hashable.swift",
@@ -304,6 +305,7 @@
   "UniqueArray": [
     "UniqueArray.swift",
     "UniqueArray+Append.swift",
+    "UniqueArray+Container.swift",
     "UniqueArray+Descriptions.swift",
     "UniqueArray+Equatable.swift",
     "UniqueArray+Hashable.swift",

--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -289,5 +289,27 @@
   ],
   "Result": [
     "Result.swift"
+  ],
+  "RigidArray": [
+    "RigidArray.swift",
+    "RigidArray+Append.swift",
+    "RigidArray+Descriptions.swift",
+    "RigidArray+Equatable.swift",
+    "RigidArray+Hashable.swift",
+    "RigidArray+Initializers.swift",
+    "RigidArray+Insertions.swift",
+    "RigidArray+Removals.swift",
+    "RigidArray+Replacements.swift"
+  ],
+  "UniqueArray": [
+    "UniqueArray.swift",
+    "UniqueArray+Append.swift",
+    "UniqueArray+Descriptions.swift",
+    "UniqueArray+Equatable.swift",
+    "UniqueArray+Hashable.swift",
+    "UniqueArray+Initializers.swift",
+    "UniqueArray+Insertions.swift",
+    "UniqueArray+Removals.swift",
+    "UniqueArray+Replacements.swift"
   ]
 }

--- a/stdlib/public/core/RigidArray/RigidArray+Append.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Append.swift
@@ -1,0 +1,347 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2024 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if !COLLECTIONS_SINGLE_MODULE
+import InternalCollectionsUtilities
+import ContainersPreview
+#endif
+
+#if compiler(>=6.2)
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray where Element: ~Copyable {
+  /// Adds an element to the end of the array.
+  ///
+  /// If the array does not have sufficient capacity to hold any more elements,
+  /// then this triggers a runtime error.
+  ///
+  /// - Parameter item: The element to append to the collection.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  public mutating func append(_ item: consuming Element) {
+    precondition(!isFull, "RigidArray capacity overflow")
+    unsafe _storage.initializeElement(at: _count, to: item)
+    _count &+= 1
+  }
+
+  /// Adds an element to the end of the array, if possible.
+  ///
+  /// If the array does not have sufficient capacity to hold any more elements,
+  /// then this returns the given item without appending it; otherwise it
+  /// returns nil.
+  ///
+  /// - Parameter item: The element to append to the array.
+  /// - Returns: `item` if the array is full; otherwise nil.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  public mutating func pushLast(_ item: consuming Element) -> Element? {
+    if isFull { return item }
+    append(item)
+    return nil
+  }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray where Element: ~Copyable {
+  /// Append a given number of items to the end of this array by populating
+  /// an output span.
+  ///
+  /// If the array does not have sufficient capacity to store the new items in
+  /// the buffer, then this triggers a runtime error.
+  ///
+  /// If the callback fails to fully populate its output span or if
+  /// it throws an error, then the array keeps all items that were
+  /// successfully initialized before the callback terminated the insertion.
+  ///
+  /// - Parameters:
+  ///    - newItemCount: The number of items to append to the array.
+  ///    - initializer: A callback that gets called at most once to directly
+  ///       populate newly reserved storage within the array. The function
+  ///       is allowed to initialize fewer than `newItemCount` items.
+  ///       The array is appended however many items the callback adds to
+  ///       the output span before it returns (or before it throws an error).
+  ///
+  /// - Complexity: O(`newItemCount`)
+  @_alwaysEmitIntoClient
+  public mutating func append<E: Error>(
+    addingCount newItemCount: Int,
+    initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
+  ) throws(E) {
+    precondition(newItemCount >= 0, "Cannot add a negative number of items")
+    precondition(freeCapacity >= newItemCount, "RigidArray capacity overflow")
+    let buffer = _freeSpace._extracting(first: newItemCount)
+    var span = OutputSpan(buffer: buffer, initializedCount: 0)
+    defer {
+      _count &+= span.finalize(for: buffer)
+      span = OutputSpan()
+    }
+    return try initializer(&span)
+  }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray where Element: ~Copyable {
+  /// Moves the elements of a buffer to the end of this array, leaving the
+  /// buffer uninitialized.
+  ///
+  /// If the array does not have sufficient capacity to hold all items in the
+  /// buffer, then this triggers a runtime error.
+  ///
+  /// - Parameters:
+  ///    - items: A fully initialized buffer whose contents to move into
+  ///        the array.
+  ///
+  /// - Complexity: O(`items.count`)
+  @_alwaysEmitIntoClient
+  public mutating func append(
+    moving items: UnsafeMutableBufferPointer<Element>
+  ) {
+    precondition(items.count <= freeCapacity, "RigidArray capacity overflow")
+    guard items.count > 0 else { return }
+    let c = unsafe _freeSpace._moveInitializePrefix(from: items)
+    assert(c == items.count)
+    _count &+= items.count
+  }
+
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+  /// Moves the elements of a input span to the end of this array, leaving the
+  /// span empty.
+  ///
+  /// If the array does not have sufficient capacity to hold all items in its
+  /// storage, then this triggers a runtime error.
+  ///
+  /// - Parameters:
+  ///    - items: An input span whose contents need to be appended to this array.
+  ///
+  /// - Complexity: O(`items.count`)
+  @_alwaysEmitIntoClient
+  public mutating func append(
+    moving items: inout InputSpan<Element>
+  ) {
+    items.withUnsafeMutableBufferPointer { buffer, count in
+      let source = buffer._extracting(last: count)
+      unsafe self.append(moving: source)
+      count = 0
+    }
+  }
+#endif
+
+  /// Moves the elements of an output span to the end of this array, leaving the
+  /// span empty.
+  ///
+  /// If the array does not have sufficient capacity to hold all items in its
+  /// storage, then this triggers a runtime error.
+  ///
+  /// - Parameters:
+  ///    - items: An output span whose contents need to be appended to this array.
+  ///
+  /// - Complexity: O(`items.count`)
+  @_alwaysEmitIntoClient
+  public mutating func append(
+    moving items: inout OutputSpan<Element>
+  ) {
+    items.withUnsafeMutableBufferPointer { buffer, count in
+      let source = buffer._extracting(first: count)
+      unsafe self.append(moving: source)
+      count = 0
+    }
+  }
+
+  /// Appends the elements of a given array to the end of this array by moving
+  /// them between the containers. On return, the input array becomes empty, but
+  /// it is not destroyed, and it preserves its original storage capacity.
+  ///
+  /// If the target array does not have sufficient capacity to hold all items
+  /// in the source array, then this triggers a runtime error.
+  ///
+  /// - Parameters:
+  ///    - items: An array whose items to move to the end of this array.
+  ///
+  /// - Complexity: O(`items.count`)
+  @_alwaysEmitIntoClient
+  public mutating func append(
+    moving items: inout RigidArray<Element>
+  ) {
+    // FIXME: Remove this in favor of a generic algorithm over range-replaceable containers
+    items.edit { span in
+      self.append(moving: &span)
+    }
+  }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray where Element: ~Copyable {
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+  /// Appends the elements of a given container to the end of this array by
+  /// consuming the source container.
+  ///
+  /// If the target array does not have sufficient capacity to hold all items
+  /// in the source array, then this triggers a runtime error.
+  ///
+  /// - Parameters:
+  ///    - items: A container whose contents to move into this array.
+  ///
+  /// - Complexity: O(`items.count`)
+  @_alwaysEmitIntoClient
+  public mutating func append(
+    consuming items: consuming RigidArray<Element>
+  ) {
+    // FIXME: Remove this in favor of a generic algorithm over consumable containers
+    var items = items
+    self.append(moving: &items)
+  }
+#endif
+}
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray {
+  /// Copies the elements of a buffer to the end of this array.
+  ///
+  /// If the array does not have sufficient capacity to hold all items in the
+  /// buffer, then this triggers a runtime error.
+  ///
+  /// - Parameters:
+  ///    - newElements: A fully initialized buffer whose contents to copy into
+  ///       the array.
+  ///
+  /// - Complexity: O(`newElements.count`)
+  @_alwaysEmitIntoClient
+  public mutating func append(
+    copying newElements: UnsafeBufferPointer<Element>
+  ) {
+    precondition(
+      newElements.count <= freeCapacity,
+      "RigidArray capacity overflow")
+    guard newElements.count > 0 else { return }
+    unsafe _freeSpace.baseAddress.unsafelyUnwrapped.initialize(
+      from: newElements.baseAddress.unsafelyUnwrapped, count: newElements.count)
+    _count &+= newElements.count
+  }
+
+  /// Copies the elements of a buffer to the end of this array.
+  ///
+  /// If the array does not have sufficient capacity to hold all items in the
+  /// buffer, then this triggers a runtime error.
+  ///
+  /// - Parameters:
+  ///    - newElements: A fully initialized buffer whose contents to copy into
+  ///        the array.
+  ///
+  /// - Complexity: O(`newElements.count`)
+  @_alwaysEmitIntoClient
+  public mutating func append(
+    copying items: UnsafeMutableBufferPointer<Element>
+  ) {
+    unsafe self.append(copying: UnsafeBufferPointer(items))
+  }
+
+  /// Copies the elements of a span to the end of this array.
+  ///
+  /// If the array does not have sufficient capacity to hold all items in the
+  /// span, then this triggers a runtime error.
+  ///
+  /// - Parameters:
+  ///    - newElements: A span whose contents to copy into the array.
+  ///
+  /// - Complexity: O(`newElements.count`)
+  @_alwaysEmitIntoClient
+  public mutating func append(copying items: Span<Element>) {
+    unsafe items.withUnsafeBufferPointer { source in
+      unsafe self.append(copying: source)
+    }
+  }
+
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  internal mutating func _append<S: Sequence<Element>>(
+    prefixOf items: S
+  ) -> S.Iterator {
+    let (it, c) = unsafe items._copyContents(initializing: _freeSpace)
+    _count += c
+    return it
+  }
+  
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+  @inlinable
+  internal mutating func _append<
+    Source: BorrowingSequence<Element> & ~Copyable & ~Escapable
+  >(
+    copying newElements: borrowing Source
+  ) {
+    let target = _freeSpace
+    _count += newElements._copyContents(intoPrefixOf: target)
+  }
+#endif
+
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+  /// Copies the elements of a borrowing sequence to the end of this array.
+  ///
+  /// If the array does not have sufficient capacity to hold all items in the
+  /// source sequence, then this triggers a runtime error.
+  ///
+  /// - Parameters:
+  ///    - newElements: A container whose contents to copy into the array.
+  ///
+  /// - Complexity: O(`newElements.count`)
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  public mutating func append<
+    Source: BorrowingSequence<Element> & ~Copyable & ~Escapable
+  >(
+    copying newElements: borrowing Source
+  ) {
+    _append(copying: newElements)
+  }
+#endif
+
+  /// Copies the elements of a sequence to the end of this array.
+  ///
+  /// If the array does not have sufficient capacity to hold all items in the
+  /// sequence, then this triggers a runtime error.
+  ///
+  /// - Parameters:
+  ///    - newElements: The new elements to copy into the array.
+  ///
+  /// - Complexity: O(*m*), where *m* is the length of `newElements`.
+  @_alwaysEmitIntoClient
+  public mutating func append(copying newElements: some Sequence<Element>) {
+    let done: Void? = newElements.withContiguousStorageIfAvailable { buffer in
+      unsafe self.append(copying: buffer)
+      return
+    }
+    if done != nil { return }
+
+    var it = self._append(prefixOf: newElements)
+    precondition(it.next() == nil, "RigidArray capacity overflow")
+  }
+  
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+  /// Copies the elements of a borrowing sequence to the end of this array.
+  ///
+  /// If the array does not have sufficient capacity to hold all items in the
+  /// source sequence, then this triggers a runtime error.
+  ///
+  /// - Parameters:
+  ///    - newElements: The new elements to copy into the array.
+  ///
+  /// - Complexity: O(*m*), where *m* is the length of `newElements`.
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  public mutating func append<
+    Source: BorrowingSequence<Element> & Sequence<Element>
+  >(copying newElements: Source) {
+    _append(copying: newElements)
+  }
+#endif
+}
+#endif

--- a/stdlib/public/core/RigidArray/RigidArray+Append.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Append.swift
@@ -23,7 +23,7 @@ extension RigidArray where Element: ~Copyable {
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   public mutating func append(_ item: consuming Element) {
-    precondition(!isFull, "RigidArray capacity overflow")
+    _precondition(!isFull, "RigidArray capacity overflow")
     unsafe _storage.initializeElement(at: _count, to: item)
     _count &+= 1
   }
@@ -74,8 +74,8 @@ extension RigidArray where Element: ~Copyable {
     addingCount newItemCount: Int,
     initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
   ) throws(E) {
-    precondition(newItemCount >= 0, "Cannot add a negative number of items")
-    precondition(freeCapacity >= newItemCount, "RigidArray capacity overflow")
+    _precondition(newItemCount >= 0, "Cannot add a negative number of items")
+    _precondition(freeCapacity >= newItemCount, "RigidArray capacity overflow")
     let buffer = unsafe _freeSpace._extracting(first: newItemCount)
     var span = unsafe OutputSpan(buffer: buffer, initializedCount: 0)
     defer {
@@ -104,10 +104,10 @@ extension RigidArray where Element: ~Copyable {
   public mutating func append(
     moving items: UnsafeMutableBufferPointer<Element>
   ) {
-    precondition(items.count <= freeCapacity, "RigidArray capacity overflow")
+    _precondition(items.count <= freeCapacity, "RigidArray capacity overflow")
     guard items.count > 0 else { return }
     let c = unsafe _freeSpace._moveInitializePrefix(from: items)
-    assert(c == items.count)
+    _internalInvariant(c == items.count)
     _count &+= items.count
   }
 
@@ -151,7 +151,7 @@ extension RigidArray {
   public mutating func append(
     copying newElements: UnsafeBufferPointer<Element>
   ) {
-    precondition(
+    _precondition(
       newElements.count <= freeCapacity,
       "RigidArray capacity overflow")
     guard newElements.count > 0 else { return }
@@ -224,6 +224,6 @@ extension RigidArray {
     if done != nil { return }
 
     var it = self._append(prefixOf: newElements)
-    precondition(it.next() == nil, "RigidArray capacity overflow")
+    _precondition(it.next() == nil, "RigidArray capacity overflow")
   }
 }

--- a/stdlib/public/core/RigidArray/RigidArray+Append.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Append.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 @available(SwiftStdlib 6.4, *)
-extension RigidArray where Element: ~Copyable {
+extension _RigidArray where Element: ~Copyable {
   /// Adds an element to the end of the array.
   ///
   /// If the array does not have sufficient capacity to hold any more elements,
@@ -22,7 +22,7 @@ extension RigidArray where Element: ~Copyable {
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func append(_ item: consuming Element) {
+  internal mutating func append(_ item: consuming Element) {
     _precondition(!isFull, "RigidArray capacity overflow")
     unsafe _storage.initializeElement(at: _count, to: item)
     _count &+= 1
@@ -40,7 +40,7 @@ extension RigidArray where Element: ~Copyable {
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func pushLast(_ item: consuming Element) -> Element? {
+  internal mutating func pushLast(_ item: consuming Element) -> Element? {
     if isFull { return item }
     append(item)
     return nil
@@ -48,7 +48,7 @@ extension RigidArray where Element: ~Copyable {
 }
 
 @available(SwiftStdlib 6.4, *)
-extension RigidArray where Element: ~Copyable {
+extension _RigidArray where Element: ~Copyable {
   /// Append a given number of items to the end of this array by populating
   /// an output span.
   ///
@@ -70,7 +70,7 @@ extension RigidArray where Element: ~Copyable {
   /// - Complexity: O(`newItemCount`)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func append<E: Error>(
+  internal mutating func append<E: Error>(
     addingCount newItemCount: Int,
     initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
   ) throws(E) {
@@ -87,7 +87,7 @@ extension RigidArray where Element: ~Copyable {
 }
 
 @available(SwiftStdlib 6.4, *)
-extension RigidArray where Element: ~Copyable {
+extension _RigidArray where Element: ~Copyable {
   /// Moves the elements of a buffer to the end of this array, leaving the
   /// buffer uninitialized.
   ///
@@ -101,7 +101,7 @@ extension RigidArray where Element: ~Copyable {
   /// - Complexity: O(`items.count`)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func append(
+  internal mutating func append(
     moving items: UnsafeMutableBufferPointer<Element>
   ) {
     _precondition(items.count <= freeCapacity, "RigidArray capacity overflow")
@@ -123,7 +123,7 @@ extension RigidArray where Element: ~Copyable {
   /// - Complexity: O(`items.count`)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func append(
+  internal mutating func append(
     moving items: inout OutputSpan<Element>
   ) {
     unsafe items.withUnsafeMutableBufferPointer { buffer, count in
@@ -135,7 +135,7 @@ extension RigidArray where Element: ~Copyable {
 }
 
 @available(SwiftStdlib 6.4, *)
-extension RigidArray {
+extension _RigidArray {
   /// Copies the elements of a buffer to the end of this array.
   ///
   /// If the array does not have sufficient capacity to hold all items in the
@@ -148,7 +148,7 @@ extension RigidArray {
   /// - Complexity: O(`newElements.count`)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func append(
+  internal mutating func append(
     copying newElements: UnsafeBufferPointer<Element>
   ) {
     _precondition(
@@ -172,7 +172,7 @@ extension RigidArray {
   /// - Complexity: O(`newElements.count`)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func append(
+  internal mutating func append(
     copying items: UnsafeMutableBufferPointer<Element>
   ) {
     unsafe self.append(copying: UnsafeBufferPointer(items))
@@ -189,8 +189,8 @@ extension RigidArray {
   /// - Complexity: O(`newElements.count`)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func append(copying items: Span<Element>) {
-    unsafe items.withUnsafeBufferPointer { source in
+  internal mutating func append(copying items: Span<Element>) {
+    items.withUnsafeBufferPointer { source in
       unsafe self.append(copying: source)
     }
   }
@@ -216,7 +216,7 @@ extension RigidArray {
   /// - Complexity: O(*m*), where *m* is the length of `newElements`.
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func append(copying newElements: some Sequence<Element>) {
+  internal mutating func append(copying newElements: some Sequence<Element>) {
     let done: Void? = newElements.withContiguousStorageIfAvailable { buffer in
       unsafe self.append(copying: buffer)
       return

--- a/stdlib/public/core/RigidArray/RigidArray+Container.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Container.swift
@@ -1,134 +1,122 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift Collections open source project
+// This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2025 - 2026 Apple Inc. and the Swift project authors
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 
-#if !COLLECTIONS_SINGLE_MODULE
-import InternalCollectionsUtilities
-import ContainersPreview
-#endif
-
-#if compiler(>=6.2)
-
-#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
-@available(SwiftStdlib 5.0, *)
-extension RigidArray: BorrowingSequence where Element: ~Copyable {
-  public typealias BorrowingIterator = Span<Element>.BorrowingIterator
-  
-  @inlinable
-  public var estimatedCount: EstimatedCount {
-    .exactly(count)
-  }
-  
-  @_alwaysEmitIntoClient
-  @inline(__always)
-  public func makeBorrowingIterator() -> BorrowingIterator {
-    self.span.makeBorrowingIterator()
-  }
-}
-#endif
-
-#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
-@available(SwiftStdlib 5.0, *)
-extension RigidArray: Container where Element: ~Copyable {
-}
-#endif
-
-@available(SwiftStdlib 5.0, *)
+@available(SwiftStdlib 6.4, *)
 extension RigidArray where Element: ~Copyable {
   /// A Boolean value indicating whether this array contains no elements.
   ///
   /// - Complexity: O(1)
-  @inlinable
-  @inline(__always)
-  public var isEmpty: Bool { count == 0 }
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  public var isEmpty: Bool {
+    count == 0
+  }
 
   /// The number of elements in this array.
   ///
   /// - Complexity: O(1)
-  @inlinable
-  @inline(__always)
-  public var count: Int { _count }
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  public var count: Int {
+    _count
+  }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftStdlib 6.4, *)
 extension RigidArray where Element: ~Copyable {
   /// A type that represents a position in the array: an integer offset from the
   /// start.
   ///
   /// Valid indices consist of the position of every element and a "past the
   /// end” position that’s not valid for use as a subscript argument.
+  @available(SwiftStdlib 6.4, *)
   public typealias Index = Int
 
   /// The position of the first element in a nonempty array. This is always zero.
   ///
   /// - Complexity: O(1)
-  @inlinable
-  @inline(__always)
-  public var startIndex: Int { 0 }
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  public var startIndex: Int {
+    0
+  }
 
   /// The array’s "past the end” position—that is, the position one greater than
   /// the last valid subscript argument. This is always equal to the array's
   /// count.
   ///
   /// - Complexity: O(1)
-  @inlinable
-  @inline(__always)
-  public var endIndex: Int { count }
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  public var endIndex: Int {
+    count
+  }
 
   /// The range of indices that are valid for subscripting the array.
   ///
   /// - Complexity: O(1)
-  @inlinable
-  @inline(__always)
-  public var indices: Range<Int> { unsafe Range(uncheckedBounds: (0, count)) }
-  
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   @_transparent
-  package func _checkItemIndex(_ index: Int) {
+  public var indices: Range<Int> {
+    unsafe Range(uncheckedBounds: (0, count))
+  }
+
+  @_alwaysEmitIntoClient
+  @_transparent
+  internal func _checkItemIndex(_ index: Int) {
     precondition(
       UInt(bitPattern: index) < UInt(bitPattern: _count),
       "Index out of bounds")
   }
-  
+
   @_alwaysEmitIntoClient
   @_transparent
-  package func _checkValidIndex(_ index: Int) {
+  internal func _checkValidIndex(_ index: Int) {
     precondition(
       UInt(bitPattern: index) <= UInt(bitPattern: _count),
       "Index out of bounds")
   }
-  
+
   @_alwaysEmitIntoClient
   @_transparent
-  package func _checkValidBounds(_ subrange: Range<Int>) {
+  internal func _checkValidBounds(_ subrange: Range<Int>) {
     precondition(
       subrange.lowerBound >= 0 && subrange.upperBound <= _count,
       "Index range out of bounds")
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftStdlib 6.4, *)
 extension RigidArray where Element: ~Copyable {
-  @inlinable @inline(__always)
+  @_alwaysEmitIntoClient
+  @_transparent
   internal func _ptr(to index: Int) -> UnsafePointer<Element> {
     _checkItemIndex(index)
-    let p = _storage.baseAddress.unsafelyUnwrapped.advanced(by: index)
-    return UnsafePointer(p)
+    let p = unsafe _storage.baseAddress.unsafelyUnwrapped.advanced(by: index)
+    return unsafe UnsafePointer(p)
   }
 
-  @inlinable @inline(__always)
+  @_alwaysEmitIntoClient
+  @_transparent
   internal mutating func _mutablePtr(
     to index: Int
   ) -> UnsafeMutablePointer<Element> {
     _checkItemIndex(index)
-    return _storage.baseAddress.unsafelyUnwrapped.advanced(by: index)
+    return unsafe _storage.baseAddress.unsafelyUnwrapped.advanced(by: index)
   }
 
   /// Accesses the element at the specified position.
@@ -138,20 +126,24 @@ extension RigidArray where Element: ~Copyable {
   ///     to the `endIndex` property.
   ///
   /// - Complexity: O(1)
-  @inlinable
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public subscript(position: Int) -> Element {
-    @inline(__always)
-    unsafeAddress {
-      _ptr(to: position)
+    @_transparent
+    @_unsafeSelfDependentResult
+    borrow {
+      unsafe _ptr(to: position).pointee
     }
-    @inline(__always)
-    unsafeMutableAddress {
-      _mutablePtr(to: position)
+
+    @_transparent
+    @_unsafeSelfDependentResult
+    mutate {
+      unsafe &_mutablePtr(to: position).pointee
     }
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftStdlib 6.4, *)
 extension RigidArray where Element: ~Copyable {
   /// Exchanges the values at the specified indices of the array.
   ///
@@ -162,14 +154,16 @@ extension RigidArray where Element: ~Copyable {
   /// - Parameter j: The index of the second valud to swap.
   ///
   /// - Complexity: O(1)
-  @inlinable
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public mutating func swapAt(_ i: Int, _ j: Int) {
     _checkItemIndex(i)
     _checkItemIndex(j)
     unsafe _items.swapAt(i, j)
   }
 }
-@available(SwiftStdlib 5.0, *)
+
+@available(SwiftStdlib 6.4, *)
 extension RigidArray where Element: ~Copyable {
   /// Returns the position immediately after the given index.
   ///
@@ -182,9 +176,12 @@ extension RigidArray where Element: ~Copyable {
   ///     than `endIndex`.
   /// - Returns: The index immediately following `i`.
   /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  @inline(__always)
-  public func index(after index: Int) -> Int { index + 1 }
+  @_transparent
+  public func index(after index: Int) -> Int {
+    index + 1
+  }
   
   /// Returns the position immediately before the given index.
   ///
@@ -197,9 +194,12 @@ extension RigidArray where Element: ~Copyable {
   ///     than `startIndex`.
   /// - Returns: The index immediately preceding `i`.
   /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  @inline(__always)
-  public func index(before index: Int) -> Int { index - 1 }
+  @_transparent
+  public func index(before index: Int) -> Int {
+    index - 1
+  }
 
   /// Replaces the given index with its successor.
   ///
@@ -211,9 +211,12 @@ extension RigidArray where Element: ~Copyable {
   /// - Parameter index: A valid index of the array. `i` must be less
   ///     than `endIndex`.
   /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  @inline(__always)
-  public func formIndex(after index: inout Int) { index += 1 }
+  @_transparent
+  public func formIndex(after index: inout Int) {
+    index += 1
+  }
 
   /// Replaces the given index with its predecessor.
   ///
@@ -225,9 +228,12 @@ extension RigidArray where Element: ~Copyable {
   /// - Parameter index: A valid index of the array. `i` must be greater than
   ///     `startIndex`.
   /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  @inline(__always)
-  public func formIndex(before index: inout Int) { index -= 1 }
+  @_transparent
+  public func formIndex(before index: inout Int) {
+    index -= 1
+  }
 
   /// Returns an index that is the specified distance from the given index.
   ///
@@ -246,8 +252,9 @@ extension RigidArray where Element: ~Copyable {
   ///    If `n` is negative, this is the same value as the result of `abs(n)`
   ///    calls to `index(before:)`.
   /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  @inline(__always)
+  @_transparent
   public func index(_ index: Int, offsetBy n: Int) -> Int {
     index + n
   }
@@ -264,8 +271,9 @@ extension RigidArray where Element: ~Copyable {
   ///    to start, the result is zero.
   /// - Returns: The distance between `start` and `end`.
   /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  @inline(__always)
+  @_transparent
   public func distance(from start: Index, to end: Index) -> Int {
     end - start
   }
@@ -301,93 +309,13 @@ extension RigidArray where Element: ~Copyable {
   ///    Likewise, if `n < 0`, a limit that is greater than `index` has no
   ///    effect.
   /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   public func formIndex(
-    _ index: inout Index, offsetBy n: inout Int, limitedBy limit: Index
+    _ index: inout Index,
+    offsetBy n: inout Int,
+    limitedBy limit: Index
   ) {
     index._advance(by: &n, limitedBy: limit)
   }
-
-  /// Return a span over the array's storage that begins with the element at
-  /// the given index, and extends to the end of the contiguous storage chunk
-  /// that contains it, but no more than `maximumCount` items.
-  ///
-  /// On return, the index is updated to address the next item following the
-  /// end of the returned span.
-  ///
-  /// This method can be used to efficiently process the items of a container in
-  /// bulk, by directly iterating over its piecewise contiguous pieces of
-  /// storage:
-  ///
-  ///     var index = items.startIndex
-  ///     while true {
-  ///       let span = items.nextSpan(after: &index, maximumCount: 4)
-  ///       if span.isEmpty { break }
-  ///       // Process items in `span`
-  ///     }
-  ///
-  /// The `maximumCount` argument gives the caller control over the number of
-  /// items it receives from the iterator. This lets the caller avoid getting
-  /// more elements than it would be able to immediately process, which would
-  /// significantly complicate container use.
-  ///
-  /// If the caller is able to process any number available items, it can signal
-  /// that by passing `Int.max` as the `maximumCount`, or simply by calling the
-  /// `nexSpan(after:)` method, which does precisely that. This is frequently
-  /// the case when the caller simply wants to iterate over the entire
-  /// container in a single loop.
-  ///
-  /// `maximumCount` sets an upper bound. To read a specific number of items,
-  /// the caller usually needs to invoke `nextSpan` in a loop:
-  ///
-  ///     var items: some Container<Int>
-  ///     var index = items.startIndex
-  ///     var remainder = numberOfItemsToRead
-  ///     while remainder > 0 {
-  ///       let next = items.nextSpan(after: &index, maximumCount: remainder)
-  ///       guard !next.isEmpty else {
-  ///         // Container does not have enough items
-  ///         break
-  ///       }
-  ///       remainder -= next.count
-  ///       // Process items in `next`
-  ///     }
-  ///
-  /// - Note: The spans returned by this method are not guaranteed to be
-  ///    disjunct. Some containers may use the same storage chunk (or parts of a
-  ///    storage chunk) multiple times, to repeat their contents.
-  ///
-  /// - Note: Repeated invocations of `nextSpan` on the same container and index
-  ///    are not guaranteed to return identical results. (This is particularly
-  ///    the case with containers that can store contents in their "inline"
-  ///    representation. Such containers may not always have a unique address
-  ///    in memory; the locations of the spans exposed by this method may vary
-  ///    between different borrows of the same container.)
-  ///
-  /// - Parameter index: A valid index in the container, including the end
-  ///     index. On return, this index is advanced by the count of the resulting
-  ///     span, to simplify iteration.
-  /// - Parameter maximumCount: The maximum number of items the caller is able
-  ///     to process immediately. `maximumCount` must be greater than zero.
-  ///     If you are able to process an arbitrary number of items, set
-  ///     `maximumCount` to `Int.max`, or call the `nextSpan(after:)` method.
-  /// - Returns: A span over contiguous storage that starts at the given index.
-  ///     If the input index is the end index, then this returns an empty span.
-  ///     Otherwise the result is non-empty, with its first element matching the
-  ///     element at the input index.
-  /// - Complexity: O(1)
-  @inlinable
-  @_lifetime(borrow self)
-  public func nextSpan(
-    after index: inout Int, maximumCount: Int
-  ) -> Span<Element> {
-    _checkValidIndex(index)
-    precondition(maximumCount > 0, "maximumCount must be positive")
-    let start = index
-    index = start &+ Swift.min(maximumCount, _count &- start)
-    return _span(in: Range(uncheckedBounds: (start, index)))
-  }
 }
-
-#endif
-

--- a/stdlib/public/core/RigidArray/RigidArray+Container.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Container.swift
@@ -1,0 +1,393 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2025 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if !COLLECTIONS_SINGLE_MODULE
+import InternalCollectionsUtilities
+import ContainersPreview
+#endif
+
+#if compiler(>=6.2)
+
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+@available(SwiftStdlib 5.0, *)
+extension RigidArray: BorrowingSequence where Element: ~Copyable {
+  public typealias BorrowingIterator = Span<Element>.BorrowingIterator
+  
+  @inlinable
+  public var estimatedCount: EstimatedCount {
+    .exactly(count)
+  }
+  
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  public func makeBorrowingIterator() -> BorrowingIterator {
+    self.span.makeBorrowingIterator()
+  }
+}
+#endif
+
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+@available(SwiftStdlib 5.0, *)
+extension RigidArray: Container where Element: ~Copyable {
+}
+#endif
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray where Element: ~Copyable {
+  /// A Boolean value indicating whether this array contains no elements.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  @inline(__always)
+  public var isEmpty: Bool { count == 0 }
+
+  /// The number of elements in this array.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  @inline(__always)
+  public var count: Int { _count }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray where Element: ~Copyable {
+  /// A type that represents a position in the array: an integer offset from the
+  /// start.
+  ///
+  /// Valid indices consist of the position of every element and a "past the
+  /// end” position that’s not valid for use as a subscript argument.
+  public typealias Index = Int
+
+  /// The position of the first element in a nonempty array. This is always zero.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  @inline(__always)
+  public var startIndex: Int { 0 }
+
+  /// The array’s "past the end” position—that is, the position one greater than
+  /// the last valid subscript argument. This is always equal to the array's
+  /// count.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  @inline(__always)
+  public var endIndex: Int { count }
+
+  /// The range of indices that are valid for subscripting the array.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  @inline(__always)
+  public var indices: Range<Int> { unsafe Range(uncheckedBounds: (0, count)) }
+  
+  @_alwaysEmitIntoClient
+  @_transparent
+  package func _checkItemIndex(_ index: Int) {
+    precondition(
+      UInt(bitPattern: index) < UInt(bitPattern: _count),
+      "Index out of bounds")
+  }
+  
+  @_alwaysEmitIntoClient
+  @_transparent
+  package func _checkValidIndex(_ index: Int) {
+    precondition(
+      UInt(bitPattern: index) <= UInt(bitPattern: _count),
+      "Index out of bounds")
+  }
+  
+  @_alwaysEmitIntoClient
+  @_transparent
+  package func _checkValidBounds(_ subrange: Range<Int>) {
+    precondition(
+      subrange.lowerBound >= 0 && subrange.upperBound <= _count,
+      "Index range out of bounds")
+  }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray where Element: ~Copyable {
+  @inlinable @inline(__always)
+  internal func _ptr(to index: Int) -> UnsafePointer<Element> {
+    _checkItemIndex(index)
+    let p = _storage.baseAddress.unsafelyUnwrapped.advanced(by: index)
+    return UnsafePointer(p)
+  }
+
+  @inlinable @inline(__always)
+  internal mutating func _mutablePtr(
+    to index: Int
+  ) -> UnsafeMutablePointer<Element> {
+    _checkItemIndex(index)
+    return _storage.baseAddress.unsafelyUnwrapped.advanced(by: index)
+  }
+
+  /// Accesses the element at the specified position.
+  ///
+  /// - Parameter position: The position of the element to access.
+  ///     The position must be a valid index of the array that is not equal
+  ///     to the `endIndex` property.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  public subscript(position: Int) -> Element {
+    @inline(__always)
+    unsafeAddress {
+      _ptr(to: position)
+    }
+    @inline(__always)
+    unsafeMutableAddress {
+      _mutablePtr(to: position)
+    }
+  }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray where Element: ~Copyable {
+  /// Exchanges the values at the specified indices of the array.
+  ///
+  /// Both parameters must be valid indices of the array and not equal to
+  /// endIndex. Passing the same index as both `i` and `j` has no effect.
+  ///
+  /// - Parameter i: The index of the first value to swap.
+  /// - Parameter j: The index of the second valud to swap.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  public mutating func swapAt(_ i: Int, _ j: Int) {
+    _checkItemIndex(i)
+    _checkItemIndex(j)
+    unsafe _items.swapAt(i, j)
+  }
+}
+@available(SwiftStdlib 5.0, *)
+extension RigidArray where Element: ~Copyable {
+  /// Returns the position immediately after the given index.
+  ///
+  /// - Note: To improve performance, this method does not validate that the
+  ///    index is valid before incrementing it. Index validation is
+  ///    deferred until the resulting index is used to access an element.
+  ///    This optimization may be removed in future versions; do not rely on it.
+  ///
+  /// - Parameter index: A valid index of the array. `i` must be less
+  ///     than `endIndex`.
+  /// - Returns: The index immediately following `i`.
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  public func index(after index: Int) -> Int { index + 1 }
+  
+  /// Returns the position immediately before the given index.
+  ///
+  /// - Note: To improve performance, this method does not validate that the
+  ///    index is valid before decrementing it. Index validation is
+  ///    deferred until the resulting index is used to access an element.
+  ///    This optimization may be removed in future versions; do not rely on it.
+  ///
+  /// - Parameter index: A valid index of the array. `i` must be greater
+  ///     than `startIndex`.
+  /// - Returns: The index immediately preceding `i`.
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  public func index(before index: Int) -> Int { index - 1 }
+
+  /// Replaces the given index with its successor.
+  ///
+  /// - Note: To improve performance, this method does not validate that the
+  ///    given index is valid before incrementing it. Index validation is
+  ///    deferred until the resulting index is used to access an element.
+  ///    This optimization may be removed in future versions; do not rely on it.
+  ///
+  /// - Parameter index: A valid index of the array. `i` must be less
+  ///     than `endIndex`.
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  public func formIndex(after index: inout Int) { index += 1 }
+
+  /// Replaces the given index with its predecessor.
+  ///
+  /// - Note: To improve performance, this method does not validate that the
+  ///    given index is valid before decrementing it. Index validation is
+  ///    deferred until the resulting index is used to access an element.
+  ///    This optimization may be removed in future versions; do not rely on it.
+  ///
+  /// - Parameter index: A valid index of the array. `i` must be greater than
+  ///     `startIndex`.
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  public func formIndex(before index: inout Int) { index -= 1 }
+
+  /// Returns an index that is the specified distance from the given index.
+  ///
+  /// The value passed as `n` must not offset `index` beyond the bounds of the
+  /// array.
+  ///
+  /// - Note: To improve performance, this method does not validate that the
+  ///    given index is valid before offseting it. Index validation is
+  ///    deferred until the resulting index is used to access an element.
+  ///    This optimization may be removed in future versions; do not rely on it.
+  ///
+  /// - Parameter index: A valid index of the array.
+  /// - Parameter n: The distance by which to offset `index`.
+  /// - Returns: An index offset by distance from `index`. If `n` is positive,
+  ///    this is the same value as the result of `n` calls to `index(after:)`.
+  ///    If `n` is negative, this is the same value as the result of `abs(n)`
+  ///    calls to `index(before:)`.
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  public func index(_ index: Int, offsetBy n: Int) -> Int {
+    index + n
+  }
+  
+  /// Returns the distance between two indices.
+  ///
+  /// - Note: To improve performance, this method does not validate that the
+  ///    given index is valid before offseting it. Index validation is
+  ///    deferred until the resulting index is used to access an element.
+  ///    This optimization may be removed in future versions; do not rely on it.
+  ///
+  /// - Parameter start: A valid index of the collection.
+  /// - Parameter end: Another valid index of the collection. If end is equal
+  ///    to start, the result is zero.
+  /// - Returns: The distance between `start` and `end`.
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  public func distance(from start: Index, to end: Index) -> Int {
+    end - start
+  }
+  
+  /// Offsets the given index by the specified distance, but no further than
+  /// the given limiting index.
+  ///
+  /// If the operation was able to offset `index` by exactly the requested
+  /// number of steps without hitting `limit`, then on return `n` is set to `0`,
+  /// and `index` is set to the adjusted index.
+  ///
+  /// If the operation hits the limit before it can take the requested number
+  /// of steps, then on return `index` is set to `limit`, and `n` is set
+  /// to the number of steps that couldn't be taken.
+  ///
+  /// The value passed as `n` must not offset `index` beyond the bounds of the
+  /// container, unless the index passed as `limit` prevents offsetting beyond
+  /// those bounds.
+  ///
+  /// - Note: To improve performance, this method does not validate that the
+  ///    given index is valid before offseting it. Index validation is
+  ///    deferred until the resulting index is used to access an element.
+  ///    This optimization may be removed in future versions; do not rely on it.
+  ///
+  /// - Parameter index: A valid index of the array. On return, `index` is
+  ///    set to `limit` if
+  /// - Parameter n: The distance to offset `index`.
+  ///    On return, `n` is set to zero if the operation succeeded without
+  ///    hitting the limit; otherwise, `n` reflects the number of steps that
+  ///    couldn't be taken.
+  /// - Parameter limit: A valid index of the array to use as a limit.
+  ///    If `n > 0`, a limit that is less than `index` has no effect.
+  ///    Likewise, if `n < 0`, a limit that is greater than `index` has no
+  ///    effect.
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public func formIndex(
+    _ index: inout Index, offsetBy n: inout Int, limitedBy limit: Index
+  ) {
+    index._advance(by: &n, limitedBy: limit)
+  }
+
+  /// Return a span over the array's storage that begins with the element at
+  /// the given index, and extends to the end of the contiguous storage chunk
+  /// that contains it, but no more than `maximumCount` items.
+  ///
+  /// On return, the index is updated to address the next item following the
+  /// end of the returned span.
+  ///
+  /// This method can be used to efficiently process the items of a container in
+  /// bulk, by directly iterating over its piecewise contiguous pieces of
+  /// storage:
+  ///
+  ///     var index = items.startIndex
+  ///     while true {
+  ///       let span = items.nextSpan(after: &index, maximumCount: 4)
+  ///       if span.isEmpty { break }
+  ///       // Process items in `span`
+  ///     }
+  ///
+  /// The `maximumCount` argument gives the caller control over the number of
+  /// items it receives from the iterator. This lets the caller avoid getting
+  /// more elements than it would be able to immediately process, which would
+  /// significantly complicate container use.
+  ///
+  /// If the caller is able to process any number available items, it can signal
+  /// that by passing `Int.max` as the `maximumCount`, or simply by calling the
+  /// `nexSpan(after:)` method, which does precisely that. This is frequently
+  /// the case when the caller simply wants to iterate over the entire
+  /// container in a single loop.
+  ///
+  /// `maximumCount` sets an upper bound. To read a specific number of items,
+  /// the caller usually needs to invoke `nextSpan` in a loop:
+  ///
+  ///     var items: some Container<Int>
+  ///     var index = items.startIndex
+  ///     var remainder = numberOfItemsToRead
+  ///     while remainder > 0 {
+  ///       let next = items.nextSpan(after: &index, maximumCount: remainder)
+  ///       guard !next.isEmpty else {
+  ///         // Container does not have enough items
+  ///         break
+  ///       }
+  ///       remainder -= next.count
+  ///       // Process items in `next`
+  ///     }
+  ///
+  /// - Note: The spans returned by this method are not guaranteed to be
+  ///    disjunct. Some containers may use the same storage chunk (or parts of a
+  ///    storage chunk) multiple times, to repeat their contents.
+  ///
+  /// - Note: Repeated invocations of `nextSpan` on the same container and index
+  ///    are not guaranteed to return identical results. (This is particularly
+  ///    the case with containers that can store contents in their "inline"
+  ///    representation. Such containers may not always have a unique address
+  ///    in memory; the locations of the spans exposed by this method may vary
+  ///    between different borrows of the same container.)
+  ///
+  /// - Parameter index: A valid index in the container, including the end
+  ///     index. On return, this index is advanced by the count of the resulting
+  ///     span, to simplify iteration.
+  /// - Parameter maximumCount: The maximum number of items the caller is able
+  ///     to process immediately. `maximumCount` must be greater than zero.
+  ///     If you are able to process an arbitrary number of items, set
+  ///     `maximumCount` to `Int.max`, or call the `nextSpan(after:)` method.
+  /// - Returns: A span over contiguous storage that starts at the given index.
+  ///     If the input index is the end index, then this returns an empty span.
+  ///     Otherwise the result is non-empty, with its first element matching the
+  ///     element at the input index.
+  /// - Complexity: O(1)
+  @inlinable
+  @_lifetime(borrow self)
+  public func nextSpan(
+    after index: inout Int, maximumCount: Int
+  ) -> Span<Element> {
+    _checkValidIndex(index)
+    precondition(maximumCount > 0, "maximumCount must be positive")
+    let start = index
+    index = start &+ Swift.min(maximumCount, _count &- start)
+    return _span(in: Range(uncheckedBounds: (start, index)))
+  }
+}
+
+#endif
+

--- a/stdlib/public/core/RigidArray/RigidArray+Container.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Container.swift
@@ -11,14 +11,14 @@
 //===----------------------------------------------------------------------===//
 
 @available(SwiftStdlib 6.4, *)
-extension RigidArray where Element: ~Copyable {
+extension _RigidArray where Element: ~Copyable {
   /// A Boolean value indicating whether this array contains no elements.
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   @_transparent
-  public var isEmpty: Bool {
+  internal var isEmpty: Bool {
     count == 0
   }
 
@@ -28,20 +28,21 @@ extension RigidArray where Element: ~Copyable {
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   @_transparent
-  public var count: Int {
+  internal var count: Int {
     _count
   }
 }
 
 @available(SwiftStdlib 6.4, *)
-extension RigidArray where Element: ~Copyable {
+extension _RigidArray where Element: ~Copyable {
   /// A type that represents a position in the array: an integer offset from the
   /// start.
   ///
   /// Valid indices consist of the position of every element and a "past the
   /// end” position that’s not valid for use as a subscript argument.
   @available(SwiftStdlib 6.4, *)
-  public typealias Index = Int
+  @usableFromInline
+  internal typealias Index = Int
 
   /// The position of the first element in a nonempty array. This is always zero.
   ///
@@ -49,7 +50,7 @@ extension RigidArray where Element: ~Copyable {
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   @_transparent
-  public var startIndex: Int {
+  internal var startIndex: Int {
     0
   }
 
@@ -61,7 +62,7 @@ extension RigidArray where Element: ~Copyable {
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   @_transparent
-  public var endIndex: Int {
+  internal var endIndex: Int {
     count
   }
 
@@ -71,7 +72,7 @@ extension RigidArray where Element: ~Copyable {
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   @_transparent
-  public var indices: Range<Int> {
+  internal var indices: Range<Int> {
     unsafe Range(uncheckedBounds: (0, count))
   }
 
@@ -101,7 +102,7 @@ extension RigidArray where Element: ~Copyable {
 }
 
 @available(SwiftStdlib 6.4, *)
-extension RigidArray where Element: ~Copyable {
+extension _RigidArray where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @_transparent
   internal func _ptr(to index: Int) -> UnsafePointer<Element> {
@@ -128,7 +129,7 @@ extension RigidArray where Element: ~Copyable {
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public subscript(position: Int) -> Element {
+  internal subscript(position: Int) -> Element {
     @_transparent
     @_unsafeSelfDependentResult
     borrow {
@@ -144,7 +145,7 @@ extension RigidArray where Element: ~Copyable {
 }
 
 @available(SwiftStdlib 6.4, *)
-extension RigidArray where Element: ~Copyable {
+extension _RigidArray where Element: ~Copyable {
   /// Exchanges the values at the specified indices of the array.
   ///
   /// Both parameters must be valid indices of the array and not equal to
@@ -156,7 +157,7 @@ extension RigidArray where Element: ~Copyable {
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func swapAt(_ i: Int, _ j: Int) {
+  internal mutating func swapAt(_ i: Int, _ j: Int) {
     _checkItemIndex(i)
     _checkItemIndex(j)
     unsafe _items.swapAt(i, j)
@@ -164,7 +165,7 @@ extension RigidArray where Element: ~Copyable {
 }
 
 @available(SwiftStdlib 6.4, *)
-extension RigidArray where Element: ~Copyable {
+extension _RigidArray where Element: ~Copyable {
   /// Returns the position immediately after the given index.
   ///
   /// - Note: To improve performance, this method does not validate that the
@@ -179,10 +180,10 @@ extension RigidArray where Element: ~Copyable {
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   @_transparent
-  public func index(after index: Int) -> Int {
+  internal func index(after index: Int) -> Int {
     index + 1
   }
-  
+
   /// Returns the position immediately before the given index.
   ///
   /// - Note: To improve performance, this method does not validate that the
@@ -197,7 +198,7 @@ extension RigidArray where Element: ~Copyable {
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   @_transparent
-  public func index(before index: Int) -> Int {
+  internal func index(before index: Int) -> Int {
     index - 1
   }
 
@@ -214,7 +215,7 @@ extension RigidArray where Element: ~Copyable {
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   @_transparent
-  public func formIndex(after index: inout Int) {
+  internal func formIndex(after index: inout Int) {
     index += 1
   }
 
@@ -231,7 +232,7 @@ extension RigidArray where Element: ~Copyable {
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   @_transparent
-  public func formIndex(before index: inout Int) {
+  internal func formIndex(before index: inout Int) {
     index -= 1
   }
 
@@ -255,7 +256,7 @@ extension RigidArray where Element: ~Copyable {
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   @_transparent
-  public func index(_ index: Int, offsetBy n: Int) -> Int {
+  internal func index(_ index: Int, offsetBy n: Int) -> Int {
     index + n
   }
   
@@ -274,7 +275,7 @@ extension RigidArray where Element: ~Copyable {
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   @_transparent
-  public func distance(from start: Index, to end: Index) -> Int {
+  internal func distance(from start: Index, to end: Index) -> Int {
     end - start
   }
   
@@ -311,7 +312,7 @@ extension RigidArray where Element: ~Copyable {
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public func formIndex(
+  internal func formIndex(
     _ index: inout Index,
     offsetBy n: inout Int,
     limitedBy limit: Index

--- a/stdlib/public/core/RigidArray/RigidArray+Container.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Container.swift
@@ -299,7 +299,7 @@ extension RigidArray where Element: ~Copyable {
   ///    This optimization may be removed in future versions; do not rely on it.
   ///
   /// - Parameter index: A valid index of the array. On return, `index` is
-  ///    set to `limit` if
+  ///    set to the resulting position.
   /// - Parameter n: The distance to offset `index`.
   ///    On return, `n` is set to zero if the operation succeeded without
   ///    hitting the limit; otherwise, `n` reflects the number of steps that

--- a/stdlib/public/core/RigidArray/RigidArray+Container.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Container.swift
@@ -78,7 +78,7 @@ extension RigidArray where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @_transparent
   internal func _checkItemIndex(_ index: Int) {
-    precondition(
+    _precondition(
       UInt(bitPattern: index) < UInt(bitPattern: _count),
       "Index out of bounds")
   }
@@ -86,7 +86,7 @@ extension RigidArray where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @_transparent
   internal func _checkValidIndex(_ index: Int) {
-    precondition(
+    _precondition(
       UInt(bitPattern: index) <= UInt(bitPattern: _count),
       "Index out of bounds")
   }
@@ -94,7 +94,7 @@ extension RigidArray where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @_transparent
   internal func _checkValidBounds(_ subrange: Range<Int>) {
-    precondition(
+    _precondition(
       subrange.lowerBound >= 0 && subrange.upperBound <= _count,
       "Index range out of bounds")
   }

--- a/stdlib/public/core/RigidArray/RigidArray+Descriptions.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Descriptions.swift
@@ -1,30 +1,31 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift Collections open source project
+// This source file is part of the Swift.org open source project
 //
 // Copyright (c) 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6.2)
+// FIXME: Waiting for https://github.com/swiftlang/swift/pull/85874 to land
 
-@available(SwiftStdlib 5.0, *)
-extension RigidArray /*: CustomStringConvertible */ where Element: ~Copyable {
-  public var description: String {
-    /// FIXME: Print the item descriptions when available.
-    "<\(count) items>"
-  }
-}
+// @available(SwiftStdlib 6.4, *)
+// extension RigidArray: CustomStringConvertible where Element: ~Copyable {
+//   @available(SwiftStdlib 6.4, *)
+//   public var description: String {
+//     /// FIXME: Print the item descriptions when available.
+//     "<\(count) items>"
+//   }
+// }
 
-@available(SwiftStdlib 5.0, *)
-extension RigidArray /*: CustomDebugStringConvertible */ where Element: ~Copyable {
-  public var debugDescription: String {
-    /// FIXME: Print the item descriptions when available.
-    "<\(count) items>"
-  }
-}
-
-#endif
+// @available(SwiftStdlib 6.4, *)
+// extension RigidArray: CustomDebugStringConvertible where Element: ~Copyable {
+//   @available(SwiftStdlib 6.4, *)
+//   public var debugDescription: String {
+//     /// FIXME: Print the item descriptions when available.
+//     "<\(count) items>"
+//   }
+// }

--- a/stdlib/public/core/RigidArray/RigidArray+Descriptions.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Descriptions.swift
@@ -1,0 +1,30 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if compiler(>=6.2)
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray /*: CustomStringConvertible */ where Element: ~Copyable {
+  public var description: String {
+    /// FIXME: Print the item descriptions when available.
+    "<\(count) items>"
+  }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray /*: CustomDebugStringConvertible */ where Element: ~Copyable {
+  public var debugDescription: String {
+    /// FIXME: Print the item descriptions when available.
+    "<\(count) items>"
+  }
+}
+
+#endif

--- a/stdlib/public/core/RigidArray/RigidArray+Descriptions.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Descriptions.swift
@@ -10,22 +10,30 @@
 //
 //===----------------------------------------------------------------------===//
 
-// FIXME: Waiting for https://github.com/swiftlang/swift/pull/85874 to land
-
-// @available(SwiftStdlib 6.4, *)
+// FIXME: Enable once SE-0499 is implemented
+// @available(SwiftStdlib x.y, *)
 // extension RigidArray: CustomStringConvertible where Element: ~Copyable {
-//   @available(SwiftStdlib 6.4, *)
-//   public var description: String {
-//     /// FIXME: Print the item descriptions when available.
-//     "<\(count) items>"
-//   }
 // }
 
-// @available(SwiftStdlib 6.4, *)
+@available(SwiftStdlib 6.4, *)
+extension RigidArray where Element: ~Copyable {
+  @available(SwiftStdlib 6.4, *)
+  public var description: String {
+    /// FIXME: Print the item descriptions when available.
+    "<\(count) items>"
+  }
+}
+
+// FIXME: Enable once SE-0499 is implemented
+// @available(SwiftStdlib x.y, *)
 // extension RigidArray: CustomDebugStringConvertible where Element: ~Copyable {
-//   @available(SwiftStdlib 6.4, *)
-//   public var debugDescription: String {
-//     /// FIXME: Print the item descriptions when available.
-//     "<\(count) items>"
-//   }
 // }
+
+@available(SwiftStdlib 6.4, *)
+extension RigidArray where Element: ~Copyable {
+  @available(SwiftStdlib 6.4, *)
+  public var debugDescription: String {
+    /// FIXME: Print the item descriptions when available.
+    "<\(count) items>"
+  }
+}

--- a/stdlib/public/core/RigidArray/RigidArray+Descriptions.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Descriptions.swift
@@ -16,9 +16,9 @@
 // }
 
 @available(SwiftStdlib 6.4, *)
-extension RigidArray where Element: ~Copyable {
+extension _RigidArray where Element: ~Copyable {
   @available(SwiftStdlib 6.4, *)
-  public var description: String {
+  internal var description: String {
     /// FIXME: Print the item descriptions when available.
     "<\(count) items>"
   }
@@ -30,9 +30,9 @@ extension RigidArray where Element: ~Copyable {
 // }
 
 @available(SwiftStdlib 6.4, *)
-extension RigidArray where Element: ~Copyable {
+extension _RigidArray where Element: ~Copyable {
   @available(SwiftStdlib 6.4, *)
-  public var debugDescription: String {
+  internal var debugDescription: String {
     /// FIXME: Print the item descriptions when available.
     "<\(count) items>"
   }

--- a/stdlib/public/core/RigidArray/RigidArray+Equatable.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Equatable.swift
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if compiler(>=6.2)
+
+#if !COLLECTIONS_SINGLE_MODULE
+import InternalCollectionsUtilities
+#endif
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray /*: Equatable */ where Element: Equatable /* & ~Copyable */ {
+  public func isTriviallyIdentical(to other: borrowing Self) -> Bool {
+    self._storage._isIdentical(to: other._storage)
+    && self._count == other._count
+  }
+}
+
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray /*: Equatable */ where Element: Equatable /* & ~Copyable */ {
+  @inlinable
+  public static func ==(
+    left: borrowing Self,
+    right: borrowing Self
+  ) -> Bool {
+    left.span._elementsEqual(to: right.span)
+  }
+}
+
+#endif

--- a/stdlib/public/core/RigidArray/RigidArray+Equatable.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Equatable.swift
@@ -1,38 +1,30 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift Collections open source project
+// This source file is part of the Swift.org open source project
 //
 // Copyright (c) 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6.2)
-
-#if !COLLECTIONS_SINGLE_MODULE
-import InternalCollectionsUtilities
-#endif
-
-@available(SwiftStdlib 5.0, *)
-extension RigidArray /*: Equatable */ where Element: Equatable /* & ~Copyable */ {
-  public func isTriviallyIdentical(to other: borrowing Self) -> Bool {
-    self._storage._isIdentical(to: other._storage)
-    && self._count == other._count
-  }
-}
-
-
-@available(SwiftStdlib 5.0, *)
-extension RigidArray /*: Equatable */ where Element: Equatable /* & ~Copyable */ {
-  @inlinable
+@available(SwiftStdlib 6.4, *)
+extension RigidArray: Equatable where Element: Equatable & ~Copyable {
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public static func ==(
     left: borrowing Self,
     right: borrowing Self
   ) -> Bool {
     left.span._elementsEqual(to: right.span)
   }
-}
 
-#endif
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public func isTriviallyIdentical(to other: borrowing Self) -> Bool {
+    unsafe self._count == other._count &&
+    self._storage.isTriviallyIdentical(to: other._storage)
+  }
+}

--- a/stdlib/public/core/RigidArray/RigidArray+Equatable.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Equatable.swift
@@ -11,6 +11,15 @@
 //===----------------------------------------------------------------------===//
 
 @available(SwiftStdlib 6.4, *)
+extension RigidArray where Element: ~Copyable {
+  @_alwaysEmitIntoClient
+  public func isTriviallyIdentical(to other: borrowing Self) -> Bool {
+    unsafe self._count == other._count &&
+    self._storage.isTriviallyIdentical(to: other._storage)
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
 extension RigidArray: Equatable where Element: Equatable & ~Copyable {
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
@@ -19,12 +28,5 @@ extension RigidArray: Equatable where Element: Equatable & ~Copyable {
     right: borrowing Self
   ) -> Bool {
     left.span._elementsEqual(to: right.span)
-  }
-
-  @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
-  public func isTriviallyIdentical(to other: borrowing Self) -> Bool {
-    unsafe self._count == other._count &&
-    self._storage.isTriviallyIdentical(to: other._storage)
   }
 }

--- a/stdlib/public/core/RigidArray/RigidArray+Equatable.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Equatable.swift
@@ -11,19 +11,19 @@
 //===----------------------------------------------------------------------===//
 
 @available(SwiftStdlib 6.4, *)
-extension RigidArray where Element: ~Copyable {
+extension _RigidArray where Element: ~Copyable {
   @_alwaysEmitIntoClient
-  public func isTriviallyIdentical(to other: borrowing Self) -> Bool {
-    unsafe self._count == other._count &&
-    self._storage.isTriviallyIdentical(to: other._storage)
+  internal func isTriviallyIdentical(to other: borrowing Self) -> Bool {
+    unsafe _count == other._count &&
+    _storage.isTriviallyIdentical(to: other._storage)
   }
 }
 
 @available(SwiftStdlib 6.4, *)
-extension RigidArray: Equatable where Element: Equatable & ~Copyable {
+extension _RigidArray: Equatable where Element: Equatable & ~Copyable {
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public static func ==(
+  internal static func ==(
     left: borrowing Self,
     right: borrowing Self
   ) -> Bool {

--- a/stdlib/public/core/RigidArray/RigidArray+Hashable.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Hashable.swift
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if compiler(>=6.2)
+
+#if !COLLECTIONS_SINGLE_MODULE
+import InternalCollectionsUtilities
+#endif
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray /*: Hashable */ where Element: Hashable /* & ~Copyable */ {
+  @inlinable
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(self.count)
+    self.span._hashContents(into: &hasher)
+  }
+}
+
+#endif

--- a/stdlib/public/core/RigidArray/RigidArray+Hashable.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Hashable.swift
@@ -1,27 +1,21 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift Collections open source project
+// This source file is part of the Swift.org open source project
 //
 // Copyright (c) 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6.2)
-
-#if !COLLECTIONS_SINGLE_MODULE
-import InternalCollectionsUtilities
-#endif
-
-@available(SwiftStdlib 5.0, *)
-extension RigidArray /*: Hashable */ where Element: Hashable /* & ~Copyable */ {
-  @inlinable
+@available(SwiftStdlib 6.4, *)
+extension RigidArray: Hashable where Element: Hashable & ~Copyable {
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public func hash(into hasher: inout Hasher) {
     hasher.combine(self.count)
     self.span._hashContents(into: &hasher)
   }
 }
-
-#endif

--- a/stdlib/public/core/RigidArray/RigidArray+Hashable.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Hashable.swift
@@ -11,10 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 @available(SwiftStdlib 6.4, *)
-extension RigidArray: Hashable where Element: Hashable & ~Copyable {
+extension _RigidArray: Hashable where Element: Hashable & ~Copyable {
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public func hash(into hasher: inout Hasher) {
+  internal func hash(into hasher: inout Hasher) {
     hasher.combine(self.count)
     self.span._hashContents(into: &hasher)
   }

--- a/stdlib/public/core/RigidArray/RigidArray+Initializers.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Initializers.swift
@@ -1,34 +1,31 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift Collections open source project
+// This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2024 - 2026 Apple Inc. and the Swift project authors
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 
-#if !COLLECTIONS_SINGLE_MODULE
-import InternalCollectionsUtilities
-import ContainersPreview
-#endif
-
-#if compiler(>=6.2)
-
-@available(SwiftStdlib 5.0, *)
+@available(SwiftStdlib 6.4, *)
 extension RigidArray where Element: ~Copyable {
   /// Initializes a new rigid array with zero capacity and no elements.
   ///
   /// - Complexity: O(1)
-  @inlinable
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
   public init() {
     unsafe _storage = .init(start: nil, count: 0)
     _count = 0
   }
   
   /// Initializes a new rigid array with the specified capacity and no elements.
-  @inlinable
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public init(capacity: Int) {
     precondition(capacity >= 0, "Array capacity must be nonnegative")
     if capacity > 0 {
@@ -40,7 +37,7 @@ extension RigidArray where Element: ~Copyable {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftStdlib 6.4, *)
 extension RigidArray where Element: ~Copyable {
   /// Creates a new array with the specified capacity, directly initializing
   /// its storage using an output span.
@@ -52,7 +49,8 @@ extension RigidArray where Element: ~Copyable {
   ///       is allowed to add fewer than `capacity` items. The array is
   ///       initialized with however many items the callback adds to the
   ///       output span before it returns (or before it throws an error).
-  @inlinable
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public init<E: Error>(
     capacity: Int,
     initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
@@ -62,8 +60,8 @@ extension RigidArray where Element: ~Copyable {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
-extension RigidArray /*where Element: Copyable*/ {
+@available(SwiftStdlib 6.4, *)
+extension RigidArray where Element: Copyable {
   /// Creates a new array containing the specified number of a single,
   /// repeated value.
   ///
@@ -73,6 +71,8 @@ extension RigidArray /*where Element: Copyable*/ {
   ///     `repeating` parameter. `count` must be zero or greater.
   ///
   /// - Complexity: O(`count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public init(repeating repeatedValue: Element, count: Int) {
     self.init(capacity: count)
     unsafe _freeSpace.initialize(repeating: repeatedValue)
@@ -80,20 +80,8 @@ extension RigidArray /*where Element: Copyable*/ {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
-extension RigidArray where Element: ~Copyable {
-  /// Creates a new rigid array taking over the storage of the specified
-  /// unique array instance, consuming it in the process.
-  ///
-  /// - Complexity: O(1)
-  @inlinable
-  public init(consuming array: consuming UniqueArray<Element>) {
-    self = array._storage
-  }
-}
-
-@available(SwiftStdlib 5.0, *)
-extension RigidArray /*where Element: Copyable*/ {
+@available(SwiftStdlib 6.4, *)
+extension RigidArray where Element: Copyable {
   /// Creates a new array with the specified capacity, holding a copy
   /// of the contents of a given sequence.
   ///
@@ -101,8 +89,9 @@ extension RigidArray /*where Element: Copyable*/ {
   ///   - capacity: The storage capacity of the new array.
   ///   - contents: The sequence whose contents to copy into the new array.
   ///      The sequence must not contain more than `capacity` elements.
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  @inline(__always)
+  @_transparent
   public init(
     capacity: Int,
     copying contents: some Sequence<Element>
@@ -110,50 +99,7 @@ extension RigidArray /*where Element: Copyable*/ {
     self.init(capacity: capacity)
     self.append(copying: contents)
   }
-  
-#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
-  /// Creates a new array with the specified capacity, holding a copy
-  /// of the contents of a given container.
-  ///
-  /// - Parameters:
-  ///   - capacity: The storage capacity of the new array, or nil to allocate
-  ///      just enough capacity to store the contents.
-  ///   - contents: The container whose contents to copy into the new array.
-  ///      The container must not contain more than `capacity` elements.
-  @_alwaysEmitIntoClient
-  @inline(__always)
-  public init<Source: BorrowingSequence<Element> & ~Copyable & ~Escapable>(
-    capacity: Int,
-    copying contents: borrowing Source
-  ) {
-    self.init(capacity: capacity)
-    self.append(copying: contents)
-  }
-  
-#endif
-  
-#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
-  /// Creates a new array with the specified capacity, holding a copy
-  /// of the contents of a given container.
-  ///
-  /// - Parameters:
-  ///   - capacity: The storage capacity of the new array, or nil to allocate
-  ///      just enough capacity to store the contents.
-  ///   - contents: The container whose contents to copy into the new array.
-  ///      The container must not contain more than `capacity` elements.
-  @_alwaysEmitIntoClient
-  @inline(__always)
-  public init<Source: BorrowingSequence<Element> & Sequence<Element>>(
-    capacity: Int,
-    copying contents: Source
-  ) {
-    self.init(capacity: capacity)
-    self.append(copying: contents)
-  }
-#endif
-  
-  // FIXME: Add a version that's generic over `Container`, with an optional capacity
-  
+
   /// Creates a new array with the specified capacity, holding a copy
   /// of the contents of a given collection.
   ///
@@ -162,8 +108,9 @@ extension RigidArray /*where Element: Copyable*/ {
   ///      just enough capacity to store the contents.
   ///   - contents: The collection whose contents to copy into the new array.
   ///      The collection must not contain more than `capacity` elements.
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  @inline(__always)
+  @_transparent
   public init(
     capacity: Int? = nil,
     copying contents: some Collection<Element>
@@ -180,8 +127,9 @@ extension RigidArray /*where Element: Copyable*/ {
   ///      just enough capacity to store the contents of the span.
   ///   - span: The span whose contents to copy into the new array.
   ///      The span must not contain more than `capacity` elements.
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  @inline(__always)
+  @_transparent
   public init(
     capacity: Int? = nil,
     copying span: Span<Element>
@@ -190,7 +138,3 @@ extension RigidArray /*where Element: Copyable*/ {
     self.append(copying: span)
   }
 }
-
-// FIXME: Add init(moving:), init(consuming:)
-
-#endif

--- a/stdlib/public/core/RigidArray/RigidArray+Initializers.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Initializers.swift
@@ -1,0 +1,196 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2024 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if !COLLECTIONS_SINGLE_MODULE
+import InternalCollectionsUtilities
+import ContainersPreview
+#endif
+
+#if compiler(>=6.2)
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray where Element: ~Copyable {
+  /// Initializes a new rigid array with zero capacity and no elements.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  public init() {
+    unsafe _storage = .init(start: nil, count: 0)
+    _count = 0
+  }
+  
+  /// Initializes a new rigid array with the specified capacity and no elements.
+  @inlinable
+  public init(capacity: Int) {
+    precondition(capacity >= 0, "Array capacity must be nonnegative")
+    if capacity > 0 {
+      unsafe _storage = .allocate(capacity: capacity)
+    } else {
+      unsafe _storage = .init(start: nil, count: 0)
+    }
+    _count = 0
+  }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray where Element: ~Copyable {
+  /// Creates a new array with the specified capacity, directly initializing
+  /// its storage using an output span.
+  ///
+  /// - Parameters:
+  ///   - capacity: The storage capacity of the new array.
+  ///   - body: A callback that gets called at most once to directly
+  ///       populate newly reserved storage within the array. The function
+  ///       is allowed to add fewer than `capacity` items. The array is
+  ///       initialized with however many items the callback adds to the
+  ///       output span before it returns (or before it throws an error).
+  @inlinable
+  public init<E: Error>(
+    capacity: Int,
+    initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
+  ) throws(E) {
+    self.init(capacity: capacity)
+    try edit(initializer)
+  }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray /*where Element: Copyable*/ {
+  /// Creates a new array containing the specified number of a single,
+  /// repeated value.
+  ///
+  /// - Parameters:
+  ///   - repeatedValue: The element to repeat.
+  ///   - count: The number of times to repeat the value passed in the
+  ///     `repeating` parameter. `count` must be zero or greater.
+  ///
+  /// - Complexity: O(`count`)
+  public init(repeating repeatedValue: Element, count: Int) {
+    self.init(capacity: count)
+    unsafe _freeSpace.initialize(repeating: repeatedValue)
+    _count = count
+  }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray where Element: ~Copyable {
+  /// Creates a new rigid array taking over the storage of the specified
+  /// unique array instance, consuming it in the process.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  public init(consuming array: consuming UniqueArray<Element>) {
+    self = array._storage
+  }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray /*where Element: Copyable*/ {
+  /// Creates a new array with the specified capacity, holding a copy
+  /// of the contents of a given sequence.
+  ///
+  /// - Parameters:
+  ///   - capacity: The storage capacity of the new array.
+  ///   - contents: The sequence whose contents to copy into the new array.
+  ///      The sequence must not contain more than `capacity` elements.
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  public init(
+    capacity: Int,
+    copying contents: some Sequence<Element>
+  ) {
+    self.init(capacity: capacity)
+    self.append(copying: contents)
+  }
+  
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+  /// Creates a new array with the specified capacity, holding a copy
+  /// of the contents of a given container.
+  ///
+  /// - Parameters:
+  ///   - capacity: The storage capacity of the new array, or nil to allocate
+  ///      just enough capacity to store the contents.
+  ///   - contents: The container whose contents to copy into the new array.
+  ///      The container must not contain more than `capacity` elements.
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  public init<Source: BorrowingSequence<Element> & ~Copyable & ~Escapable>(
+    capacity: Int,
+    copying contents: borrowing Source
+  ) {
+    self.init(capacity: capacity)
+    self.append(copying: contents)
+  }
+  
+#endif
+  
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+  /// Creates a new array with the specified capacity, holding a copy
+  /// of the contents of a given container.
+  ///
+  /// - Parameters:
+  ///   - capacity: The storage capacity of the new array, or nil to allocate
+  ///      just enough capacity to store the contents.
+  ///   - contents: The container whose contents to copy into the new array.
+  ///      The container must not contain more than `capacity` elements.
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  public init<Source: BorrowingSequence<Element> & Sequence<Element>>(
+    capacity: Int,
+    copying contents: Source
+  ) {
+    self.init(capacity: capacity)
+    self.append(copying: contents)
+  }
+#endif
+  
+  // FIXME: Add a version that's generic over `Container`, with an optional capacity
+  
+  /// Creates a new array with the specified capacity, holding a copy
+  /// of the contents of a given collection.
+  ///
+  /// - Parameters:
+  ///   - capacity: The storage capacity of the new array, or nil to allocate
+  ///      just enough capacity to store the contents.
+  ///   - contents: The collection whose contents to copy into the new array.
+  ///      The collection must not contain more than `capacity` elements.
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  public init(
+    capacity: Int? = nil,
+    copying contents: some Collection<Element>
+  ) {
+    self.init(capacity: capacity ?? contents.count)
+    self.append(copying: contents)
+  }
+
+  /// Creates a new array with the specified capacity, holding a copy
+  /// of the contents of the given span.
+  ///
+  /// - Parameters:
+  ///   - capacity: The storage capacity of the new array, or nil to allocate
+  ///      just enough capacity to store the contents of the span.
+  ///   - span: The span whose contents to copy into the new array.
+  ///      The span must not contain more than `capacity` elements.
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  public init(
+    capacity: Int? = nil,
+    copying span: Span<Element>
+  ) {
+    self.init(capacity: capacity ?? span.count)
+    self.append(copying: span)
+  }
+}
+
+// FIXME: Add init(moving:), init(consuming:)
+
+#endif

--- a/stdlib/public/core/RigidArray/RigidArray+Initializers.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Initializers.swift
@@ -27,7 +27,7 @@ extension RigidArray where Element: ~Copyable {
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   public init(capacity: Int) {
-    precondition(capacity >= 0, "Array capacity must be nonnegative")
+    _precondition(capacity >= 0, "Array capacity must be nonnegative")
     if capacity > 0 {
       unsafe _storage = .allocate(capacity: capacity)
     } else {

--- a/stdlib/public/core/RigidArray/RigidArray+Initializers.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Initializers.swift
@@ -11,14 +11,14 @@
 //===----------------------------------------------------------------------===//
 
 @available(SwiftStdlib 6.4, *)
-extension RigidArray where Element: ~Copyable {
+extension _RigidArray where Element: ~Copyable {
   /// Initializes a new rigid array with zero capacity and no elements.
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   @_transparent
-  public init() {
+  internal init() {
     unsafe _storage = .init(start: nil, count: 0)
     _count = 0
   }
@@ -26,7 +26,7 @@ extension RigidArray where Element: ~Copyable {
   /// Initializes a new rigid array with the specified capacity and no elements.
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public init(capacity: Int) {
+  internal init(capacity: Int) {
     _precondition(capacity >= 0, "Array capacity must be nonnegative")
     if capacity > 0 {
       unsafe _storage = .allocate(capacity: capacity)
@@ -38,7 +38,7 @@ extension RigidArray where Element: ~Copyable {
 }
 
 @available(SwiftStdlib 6.4, *)
-extension RigidArray where Element: ~Copyable {
+extension _RigidArray where Element: ~Copyable {
   /// Creates a new array with the specified capacity, directly initializing
   /// its storage using an output span.
   ///
@@ -51,7 +51,7 @@ extension RigidArray where Element: ~Copyable {
   ///       output span before it returns (or before it throws an error).
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public init<E: Error>(
+  internal init<E: Error>(
     capacity: Int,
     initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
   ) throws(E) {
@@ -61,7 +61,7 @@ extension RigidArray where Element: ~Copyable {
 }
 
 @available(SwiftStdlib 6.4, *)
-extension RigidArray where Element: Copyable {
+extension _RigidArray where Element: Copyable {
   /// Creates a new array containing the specified number of a single,
   /// repeated value.
   ///
@@ -73,7 +73,7 @@ extension RigidArray where Element: Copyable {
   /// - Complexity: O(`count`)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public init(repeating repeatedValue: Element, count: Int) {
+  internal init(repeating repeatedValue: Element, count: Int) {
     self.init(capacity: count)
     unsafe _freeSpace.initialize(repeating: repeatedValue)
     _count = count
@@ -81,7 +81,7 @@ extension RigidArray where Element: Copyable {
 }
 
 @available(SwiftStdlib 6.4, *)
-extension RigidArray where Element: Copyable {
+extension _RigidArray where Element: Copyable {
   /// Creates a new array with the specified capacity, holding a copy
   /// of the contents of a given sequence.
   ///
@@ -92,7 +92,7 @@ extension RigidArray where Element: Copyable {
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   @_transparent
-  public init(
+  internal init(
     capacity: Int,
     copying contents: some Sequence<Element>
   ) {
@@ -111,7 +111,7 @@ extension RigidArray where Element: Copyable {
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   @_transparent
-  public init(
+  internal init(
     capacity: Int? = nil,
     copying contents: some Collection<Element>
   ) {
@@ -130,7 +130,7 @@ extension RigidArray where Element: Copyable {
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   @_transparent
-  public init(
+  internal init(
     capacity: Int? = nil,
     copying span: Span<Element>
   ) {

--- a/stdlib/public/core/RigidArray/RigidArray+Insertions.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Insertions.swift
@@ -1,0 +1,497 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2024 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if !COLLECTIONS_SINGLE_MODULE
+import InternalCollectionsUtilities
+import ContainersPreview
+#endif
+
+#if compiler(>=6.2)
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray where Element: ~Copyable {
+  /// Inserts a new element into the array at the specified position.
+  ///
+  /// If the array does not have sufficient capacity to hold any more elements,
+  /// then this triggers a runtime error.
+  ///
+  /// The new element is inserted before the element currently at the specified
+  /// index. If you pass the array's `endIndex` as the `index` parameter, then
+  /// the new element is appended to the container.
+  ///
+  /// All existing elements at or following the specified position are moved to
+  /// make room for the new item.
+  ///
+  /// - Parameter item: The new element to insert into the array.
+  /// - Parameter index: The position at which to insert the new element.
+  ///   `index` must be a valid index in the array.
+  ///
+  /// - Complexity: O(`self.count`)
+  @inlinable
+  public mutating func insert(_ item: consuming Element, at index: Int) {
+    _checkValidIndex(index)
+    precondition(!isFull, "RigidArray capacity overflow")
+    if index < count {
+      let source = unsafe _storage.extracting(index ..< count)
+      let target = unsafe _storage.extracting(index + 1 ..< count + 1)
+      let last = unsafe target.moveInitialize(fromContentsOf: source)
+      assert(last == target.endIndex)
+    }
+    unsafe _storage.initializeElement(at: index, to: item)
+    _count += 1
+  }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray where Element: ~Copyable {
+  /// Inserts a given number of new items into this array at the specified
+  /// position, using a callback to directly initialize array storage by
+  /// populating an output span.
+  ///
+  /// Existing elements in the array's storage are moved towards the back as
+  /// needed to make room for the new items.
+  ///
+  /// If the capacity of the array isn't sufficient to accommodate the specified
+  /// number of new elements, then this method triggers a runtime error.
+  ///
+  ///     var buffer = RigidArray<Int>(capacity: 20)
+  ///     buffer.append([-999, 999])
+  ///     var i = 0
+  ///     buffer.insert(capacity: 3, at: 1) { target in
+  ///       while !target.isFull {
+  ///         target.append(i)
+  ///         i += 1
+  ///       }
+  ///     }
+  ///     // `buffer` now contains [-999, 0, 1, 2, 999]
+  ///
+  /// If the callback fails to fully populate its output span or if
+  /// it throws an error, then the array keeps all items that were
+  /// successfully initialized before the callback terminated the insertion.
+  ///
+  /// Partial insertions create a gap in array storage that needs to be
+  /// closed by moving already inserted items to their correct positions given
+  /// the adjusted count. This adds some overhead compared to adding exactly as
+  /// many items as promised.
+  ///
+  /// - Parameters:
+  ///    - newItemCount: The maximum number of items to insert into the array.
+  ///    - index: The position at which to insert the new items.
+  ///       `index` must be a valid index in the array.
+  ///    - initializer: A callback that gets called at most once to directly
+  ///       populate newly reserved storage within the array. The function
+  ///      is always called with an empty output span.
+  ///
+  /// - Complexity: O(`self.count` + `newItemCount`) in addition to the complexity
+  ///    of the callback invocations.
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  public mutating func insert<E: Error>(
+    addingCount newItemCount: Int,
+    at index: Int,
+    initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
+  ) throws(E) {
+    _checkValidIndex(index)
+    precondition(newItemCount >= 0, "Cannot add a negative number of items")
+    precondition(newItemCount <= freeCapacity, "RigidArray capacity overflow")
+    let target = unsafe _openGap(at: index, count: newItemCount)
+    _count &+= newItemCount
+    var span = OutputSpan(buffer: target, initializedCount: 0)
+    defer {
+      let c = span.finalize(for: target)
+      if c < newItemCount {
+        _closeGap(at: index &+ c, count: newItemCount &- c)
+        _count &-= newItemCount &- c
+      }
+      span = OutputSpan()
+    }
+    try initializer(&span)
+  }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray where Element: ~Copyable {
+  /// Moves the elements of a fully initialized buffer into this array,
+  /// starting at the specified position, and leaving the buffer
+  /// uninitialized.
+  ///
+  /// All existing elements at or following the specified position are moved to
+  /// make room for the new items.
+  ///
+  /// If the capacity of the array isn't sufficient to accommodate the new
+  /// elements, then this method triggers a runtime error.
+  ///
+  /// - Parameters:
+  ///    - items: A fully initialized buffer whose contents to move into
+  ///        the array.
+  ///    - index: The position at which to insert the new items.
+  ///       `index` must be a valid index in the array.
+  ///
+  /// - Complexity: O(`self.count` + `items.count`)
+  @_alwaysEmitIntoClient
+  public mutating func insert(
+    moving items: UnsafeMutableBufferPointer<Element>,
+    at index: Int
+  ) {
+    insert(addingCount: items.count, at: index) { target in
+      target._append(moving: items)
+    }
+  }
+
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+  /// Moves the elements of an input span into this array,
+  /// starting at the specified position, and leaving the span empty.
+  ///
+  /// All existing elements at or following the specified position are moved to
+  /// make room for the new items.
+  ///
+  /// If the capacity of the array isn't sufficient to accommodate the new
+  /// elements, then this method triggers a runtime error.
+  ///
+  /// - Parameters:
+  ///    - items: An input span whose contents to move into
+  ///        the array.
+  ///    - index: The position at which to insert the new items.
+  ///       `index` must be a valid index in the array.
+  ///
+  /// - Complexity: O(`self.count` + `items.count`)
+  @_alwaysEmitIntoClient
+  public mutating func insert(
+    moving items: inout InputSpan<Element>,
+    at index: Int
+  ) {
+    items.withUnsafeMutableBufferPointer { buffer, count in
+      let source = buffer._extracting(last: count)
+      unsafe self.insert(moving: source, at: index)
+      count = 0
+    }
+  }
+#endif
+
+  /// Moves the elements of an output span into this array,
+  /// starting at the specified position, and leaving the span empty.
+  ///
+  /// All existing elements at or following the specified position are moved to
+  /// make room for the new items.
+  ///
+  /// If the capacity of the array isn't sufficient to accommodate the new
+  /// elements, then this method triggers a runtime error.
+  ///
+  /// - Parameters:
+  ///    - items: An output span whose contents to move into
+  ///        the array.
+  ///    - index: The position at which to insert the new items.
+  ///       `index` must be a valid index in the array.
+  ///
+  /// - Complexity: O(`self.count` + `items.count`)
+  @_alwaysEmitIntoClient
+  public mutating func insert(
+    moving items: inout OutputSpan<Element>,
+    at index: Int
+  ) {
+    items.withUnsafeMutableBufferPointer { buffer, count in
+      let source = buffer._extracting(first: count)
+      unsafe self.insert(moving: source, at: index)
+      count = 0
+    }
+  }
+
+  /// Inserts the elements of a given array into the given position in this
+  /// array by moving them between the containers. On return, the input array
+  /// becomes empty, but it is not destroyed, and it preserves its original
+  /// storage capacity.
+  ///
+  /// All existing elements at or following the specified position are moved to
+  /// make room for the new items.
+  ///
+  /// If the capacity of the array isn't sufficient to accommodate the new
+  /// elements, then this method triggers a runtime error.
+  ///
+  /// - Parameters:
+  ///    - items: An array whose contents to move into `self`.
+  ///    - index: The position at which to insert the new items.
+  ///       `index` must be a valid index in the array.
+  ///
+  /// - Complexity: O(`count` + `items.count`)
+  @_alwaysEmitIntoClient
+  public mutating func insert(
+    moving items: inout RigidArray<Element>,
+    at index: Int
+  ) {
+    // FIXME: Remove this in favor of a generic algorithm over consumable containers
+    guard !items.isEmpty else { return }
+    items.edit { source in
+      self.insert(moving: &source, at: index)
+    }
+  }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray where Element: ~Copyable {
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+  /// Inserts the elements of a given array into the given position in this
+  /// array by consuming the source container.
+  ///
+  /// All existing elements at or following the specified position are moved to
+  /// make room for the new items.
+  ///
+  /// If the capacity of the array isn't sufficient to accommodate the new
+  /// elements, then this method triggers a runtime error.
+  ///
+  /// - Parameters:
+  ///    - items: The array whose contents to move into `self`.
+  ///    - index: The position at which to insert the new items.
+  ///       `index` must be a valid index in the array.
+  ///
+  /// - Complexity: O(`count` + `items.count`)
+  @_alwaysEmitIntoClient
+  public mutating func insert(
+    consuming items: consuming RigidArray<Element>,
+    at index: Int
+  ) {
+    // FIXME: Remove this in favor of a generic algorithm over consumable containers
+    var items = items
+    self.insert(moving: &items, at: index)
+  }
+#endif
+}
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray {
+  /// Copies the elements of a fully initialized buffer pointer into this
+  /// array at the specified position.
+  ///
+  /// The new elements are inserted before the element currently at the
+  /// specified index. If you pass the array’s `endIndex` as the `index`
+  /// parameter, then the new elements are appended to the end of the array.
+  ///
+  /// All existing elements at or following the specified position are moved to
+  /// make room for the new items.
+  ///
+  /// If the capacity of the array isn't sufficient to accommodate the new
+  /// elements, then this method triggers a runtime error.
+  ///
+  /// - Parameters:
+  ///    - newElements: The new elements to insert into the array. The buffer
+  ///       must be fully initialized.
+  ///    - index: The position at which to insert the new elements. It must be
+  ///       a valid index of the array.
+  ///
+  /// - Complexity: O(`count` + `newElements.count`)
+  @inlinable
+  public mutating func insert(
+    copying newElements: UnsafeBufferPointer<Element>, at index: Int
+  ) {
+    guard newElements.count > 0 else { return }
+    self.insert(addingCount: newElements.count, at: index) { target in
+      target._append(copying: newElements)
+    }
+  }
+
+  /// Copies the elements of a fully initialized buffer pointer into this
+  /// array at the specified position.
+  ///
+  /// The new elements are inserted before the element currently at the
+  /// specified index. If you pass the array’s `endIndex` as the `index`
+  /// parameter, then the new elements are appended to the end of the array.
+  ///
+  /// All existing elements at or following the specified position are moved to
+  /// make room for the new item.
+  ///
+  /// If the capacity of the array isn't sufficient to accommodate the new
+  /// elements, then this method triggers a runtime error.
+  ///
+  /// - Parameters:
+  ///    - newElements: The new elements to insert into the array. The buffer
+  ///       must be fully initialized.
+  ///    - index: The position at which to insert the new elements. It must be
+  ///       a valid index of the array.
+  ///
+  /// - Complexity: O(`count` + `newElements.count`)
+  @inlinable
+  @inline(__always)
+  public mutating func insert(
+    copying newElements: UnsafeMutableBufferPointer<Element>,
+    at index: Int
+  ) {
+    unsafe self.insert(copying: UnsafeBufferPointer(newElements), at: index)
+  }
+
+  /// Copies the elements of a span into this array at the specified position.
+  ///
+  /// The new elements are inserted before the element currently at the
+  /// specified index. If you pass the array’s `endIndex` as the `index`
+  /// parameter, then the new elements are appended to the end of the array.
+  ///
+  /// All existing elements at or following the specified position are moved to
+  /// make room for the new item.
+  ///
+  /// If the capacity of the array isn't sufficient to accommodate the new
+  /// elements, then this method triggers a runtime error.
+  ///
+  /// - Parameters:
+  ///    - newElements: The new elements to insert into the array.
+  ///    - index: The position at which to insert the new elements. It must be
+  ///        a valid index of the array.
+  ///
+  /// - Complexity: O(`count` + `newElements.count`)
+  @inlinable
+  @inline(__always)
+  public mutating func insert(
+    copying newElements: Span<Element>, at index: Int
+  ) {
+    guard newElements.count > 0 else { return }
+    self.insert(addingCount: newElements.count, at: index) { target in
+      target._append(copying: newElements)
+    }
+  }
+
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+  @_alwaysEmitIntoClient
+  internal mutating func _insertContainer<
+    C: Container<Element> & ~Copyable & ~Escapable
+  >(
+    at index: Int,
+    copying items: borrowing C,
+    newCount: Int
+  ) {
+    var it = items.makeBorrowingIterator()
+    insert(addingCount: newCount, at: index) { target in
+      while !target.isFull {
+        let source = it.nextSpan(maximumCount: target.freeCapacity)
+        precondition(!source.isEmpty, "Broken container: mismatching count")
+        target._append(copying: source)
+      }
+    }
+    precondition(it.nextSpan().isEmpty, "Broken container: mismatching count")
+  }
+#endif
+
+  @inlinable
+  internal mutating func _insertCollection(
+    at index: Int,
+    copying items: some Collection<Element>,
+    newCount: Int
+  ) {
+    _checkValidIndex(index)
+    precondition(newCount <= freeCapacity, "RigidArray capacity overflow")
+    let gap = unsafe _openGap(at: index, count: newCount)
+
+    let done: Void? = items.withContiguousStorageIfAvailable { buffer in
+      let i = unsafe gap._initializePrefix(copying: buffer)
+      precondition(
+        i == newCount,
+        "Broken Collection: count doesn't match contents")
+      _count += newCount
+    }
+    if done != nil { return }
+
+    var (it, copied) = unsafe items._copyContents(initializing: gap)
+    precondition(
+      it.next() == nil && copied == newCount,
+      "Broken Collection: count doesn't match contents")
+    _count += newCount
+  }
+
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+  /// Copies the elements of a container into this array at the specified
+  /// position.
+  ///
+  /// The new elements are inserted before the element currently at the
+  /// specified index. If you pass the array’s `endIndex` as the `index`
+  /// parameter, then the new elements are appended to the end of the array.
+  ///
+  /// All existing elements at or following the specified position are moved to
+  /// make room for the new item.
+  ///
+  /// If the capacity of the array isn't sufficient to accommodate the new
+  /// elements, then this method triggers a runtime error.
+  ///
+  /// - Parameters:
+  ///    - newElements: The new elements to insert into the array.
+  ///    - index: The position at which to insert the new elements. It must be
+  ///        a valid index of the array.
+  ///
+  /// - Complexity: O(`self.count` + `newElements.count`).
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  public mutating func insert<
+    C: Container<Element> & ~Copyable & ~Escapable
+  >(
+    copying newElements: borrowing C, at index: Int
+  ) {
+    _insertContainer(
+      at: index, copying: newElements, newCount: newElements.count)
+  }
+#endif
+
+  /// Copies the elements of a collection into this array at the specified
+  /// position.
+  ///
+  /// The new elements are inserted before the element currently at the
+  /// specified index. If you pass the array’s `endIndex` as the `index`
+  /// parameter, then the new elements are appended to the end of the array.
+  ///
+  /// All existing elements at or following the specified position are moved
+  /// to make room for the new item.
+  ///
+  /// If the capacity of the array isn't sufficient to accommodate the new
+  /// elements, then this method triggers a runtime error.
+  ///
+  /// - Parameters:
+  ///    - newElements: The new elements to insert into the array.
+  ///    - index: The position at which to insert the new elements. It must be
+  ///        a valid index of the array.
+  ///
+  /// - Complexity: O(`count` + `newElements.count`)
+  @inlinable
+  @inline(__always)
+  public mutating func insert(
+    copying newElements: some Collection<Element>, at index: Int
+  ) {
+    _insertCollection(
+      at: index, copying: newElements, newCount: newElements.count)
+  }
+
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+  /// Copies the elements of a container into this array at the specified
+  /// position.
+  ///
+  /// The new elements are inserted before the element currently at the
+  /// specified index. If you pass the array’s `endIndex` as the `index`
+  /// parameter, then the new elements are appended to the end of the array.
+  ///
+  /// All existing elements at or following the specified position are moved to
+  /// make room for the new item.
+  ///
+  /// If the capacity of the array isn't sufficient to accommodate the new
+  /// elements, then this method triggers a runtime error.
+  ///
+  /// - Parameters:
+  ///    - newElements: The new elements to insert into the array.
+  ///    - index: The position at which to insert the new elements. It must be
+  ///        a valid index of the array.
+  ///
+  /// - Complexity: O(`self.count` + `newElements.count`)
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  public mutating func insert<
+    C: Container<Element> & Collection<Element>
+  >(
+    copying newElements: borrowing C, at index: Int
+  ) {
+    _insertContainer(
+      at: index, copying: newElements, newCount: newElements.count)
+  }
+#endif
+}
+
+#endif

--- a/stdlib/public/core/RigidArray/RigidArray+Insertions.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Insertions.swift
@@ -170,36 +170,6 @@ extension RigidArray where Element: ~Copyable {
       count = 0
     }
   }
-
-  /// Inserts the elements of a given array into the given position in this
-  /// array by moving them between the containers. On return, the input array
-  /// becomes empty, but it is not destroyed, and it preserves its original
-  /// storage capacity.
-  ///
-  /// All existing elements at or following the specified position are moved to
-  /// make room for the new items.
-  ///
-  /// If the capacity of the array isn't sufficient to accommodate the new
-  /// elements, then this method triggers a runtime error.
-  ///
-  /// - Parameters:
-  ///    - items: An array whose contents to move into `self`.
-  ///    - index: The position at which to insert the new items.
-  ///       `index` must be a valid index in the array.
-  ///
-  /// - Complexity: O(`count` + `items.count`)
-  @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
-  public mutating func insert(
-    moving items: inout RigidArray<Element>,
-    at index: Int
-  ) {
-    // FIXME: Remove this in favor of a generic algorithm over consumable containers
-    guard !items.isEmpty else { return }
-    items.edit { source in
-      self.insert(moving: &source, at: index)
-    }
-  }
 }
 
 @available(SwiftStdlib 6.4, *)

--- a/stdlib/public/core/RigidArray/RigidArray+Insertions.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Insertions.swift
@@ -33,7 +33,7 @@ extension RigidArray where Element: ~Copyable {
   @_alwaysEmitIntoClient
   public mutating func insert(_ item: consuming Element, at index: Int) {
     _checkValidIndex(index)
-    precondition(!isFull, "RigidArray capacity overflow")
+    _precondition(!isFull, "RigidArray capacity overflow")
     if index < count {
       let source = unsafe _storage.extracting(index ..< count)
       let target = unsafe _storage.extracting(index + 1 ..< count + 1)
@@ -95,8 +95,8 @@ extension RigidArray where Element: ~Copyable {
     initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
   ) throws(E) {
     _checkValidIndex(index)
-    precondition(newItemCount >= 0, "Cannot add a negative number of items")
-    precondition(newItemCount <= freeCapacity, "RigidArray capacity overflow")
+    _precondition(newItemCount >= 0, "Cannot add a negative number of items")
+    _precondition(newItemCount <= freeCapacity, "RigidArray capacity overflow")
     let target = unsafe _openGap(at: index, count: newItemCount)
     _count &+= newItemCount
     var span = unsafe OutputSpan(buffer: target, initializedCount: 0)
@@ -270,12 +270,12 @@ extension RigidArray {
     newCount: Int
   ) {
     _checkValidIndex(index)
-    precondition(newCount <= freeCapacity, "RigidArray capacity overflow")
+    _precondition(newCount <= freeCapacity, "RigidArray capacity overflow")
     let gap = unsafe _openGap(at: index, count: newCount)
 
     let done: Void? = items.withContiguousStorageIfAvailable { buffer in
       let i = unsafe gap._initializePrefix(copying: buffer)
-      precondition(
+      _precondition(
         i == newCount,
         "Broken Collection: count doesn't match contents")
       _count += newCount
@@ -283,7 +283,7 @@ extension RigidArray {
     if done != nil { return }
 
     var (it, copied) = unsafe items._copyContents(initializing: gap)
-    precondition(
+    _precondition(
       it.next() == nil && copied == newCount,
       "Broken Collection: count doesn't match contents")
     _count += newCount

--- a/stdlib/public/core/RigidArray/RigidArray+Insertions.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Insertions.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 @available(SwiftStdlib 6.4, *)
-extension RigidArray where Element: ~Copyable {
+extension _RigidArray where Element: ~Copyable {
   /// Inserts a new element into the array at the specified position.
   ///
   /// If the array does not have sufficient capacity to hold any more elements,
@@ -31,7 +31,7 @@ extension RigidArray where Element: ~Copyable {
   /// - Complexity: O(`self.count`)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func insert(_ item: consuming Element, at index: Int) {
+  internal mutating func insert(_ item: consuming Element, at index: Int) {
     _checkValidIndex(index)
     _precondition(!isFull, "RigidArray capacity overflow")
     if index < count {
@@ -46,7 +46,7 @@ extension RigidArray where Element: ~Copyable {
 }
 
 @available(SwiftStdlib 6.4, *)
-extension RigidArray where Element: ~Copyable {
+extension _RigidArray where Element: ~Copyable {
   /// Inserts a given number of new items into this array at the specified
   /// position, using a callback to directly initialize array storage by
   /// populating an output span.
@@ -89,7 +89,7 @@ extension RigidArray where Element: ~Copyable {
   ///    of the callback invocations.
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func insert<E: Error>(
+  internal mutating func insert<E: Error>(
     addingCount newItemCount: Int,
     at index: Int,
     initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
@@ -113,7 +113,7 @@ extension RigidArray where Element: ~Copyable {
 }
 
 @available(SwiftStdlib 6.4, *)
-extension RigidArray where Element: ~Copyable {
+extension _RigidArray where Element: ~Copyable {
   /// Moves the elements of a fully initialized buffer into this array,
   /// starting at the specified position, and leaving the buffer
   /// uninitialized.
@@ -133,7 +133,7 @@ extension RigidArray where Element: ~Copyable {
   /// - Complexity: O(`self.count` + `items.count`)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func insert(
+  internal mutating func insert(
     moving items: UnsafeMutableBufferPointer<Element>,
     at index: Int
   ) {
@@ -160,7 +160,7 @@ extension RigidArray where Element: ~Copyable {
   /// - Complexity: O(`self.count` + `items.count`)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func insert(
+  internal mutating func insert(
     moving items: inout OutputSpan<Element>,
     at index: Int
   ) {
@@ -173,7 +173,7 @@ extension RigidArray where Element: ~Copyable {
 }
 
 @available(SwiftStdlib 6.4, *)
-extension RigidArray {
+extension _RigidArray where Element: Copyable {
   /// Copies the elements of a fully initialized buffer pointer into this
   /// array at the specified position.
   ///
@@ -196,7 +196,7 @@ extension RigidArray {
   /// - Complexity: O(`count` + `newElements.count`)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func insert(
+  internal mutating func insert(
     copying newElements: UnsafeBufferPointer<Element>, at index: Int
   ) {
     guard newElements.count > 0 else { return }
@@ -227,7 +227,7 @@ extension RigidArray {
   /// - Complexity: O(`count` + `newElements.count`)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func insert(
+  internal mutating func insert(
     copying newElements: UnsafeMutableBufferPointer<Element>,
     at index: Int
   ) {
@@ -254,7 +254,7 @@ extension RigidArray {
   /// - Complexity: O(`count` + `newElements.count`)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func insert(
+  internal mutating func insert(
     copying newElements: Span<Element>, at index: Int
   ) {
     guard newElements.count > 0 else { return }
@@ -310,7 +310,7 @@ extension RigidArray {
   /// - Complexity: O(`count` + `newElements.count`)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func insert(
+  internal mutating func insert(
     copying newElements: some Collection<Element>, at index: Int
   ) {
     _insertCollection(

--- a/stdlib/public/core/RigidArray/RigidArray+Removals.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Removals.swift
@@ -1,0 +1,136 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2024 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if !COLLECTIONS_SINGLE_MODULE
+import InternalCollectionsUtilities
+import ContainersPreview
+#endif
+
+#if compiler(>=6.2)
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray where Element: ~Copyable {
+  /// Removes and returns the element at the specified position.
+  ///
+  /// All the elements following the specified position are moved to close the
+  /// gap.
+  ///
+  /// - Parameter i: The position of the element to remove. `index` must be
+  ///   a valid index of the array that is not equal to the end index.
+  /// - Returns: The removed element.
+  ///
+  /// - Complexity: O(`count`)
+  @inlinable
+  @discardableResult
+  public mutating func remove(at index: Int) -> Element {
+    _checkItemIndex(index)
+    let old = unsafe _storage.moveElement(from: index)
+    _closeGap(at: index, count: 1)
+    _count -= 1
+    return old
+  }
+
+  /// Removes all elements from the array, preserving its allocated capacity.
+  ///
+  /// - Complexity: O(*n*), where *n* is the original count of the array.
+  @inlinable
+  public mutating func removeAll() {
+    unsafe _items.deinitialize()
+    _count = 0
+  }
+
+  /// Removes and returns the last element of the array.
+  ///
+  /// The array must not be empty.
+  ///
+  /// - Returns: The last element of the original array.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  @discardableResult
+  public mutating func removeLast() -> Element {
+    precondition(!isEmpty, "Cannot remove last element from an empty array")
+    let old = unsafe _storage.moveElement(from: _count - 1)
+    _count -= 1
+    return old
+  }
+
+  /// Removes and discards the specified number of elements from the end of the
+  /// array.
+  ///
+  /// Attempting to remove more elements than exist in the array
+  /// triggers a runtime error.
+  ///
+  /// - Parameter k: The number of elements to remove from the array.
+  ///   `k` must be greater than or equal to zero and must not exceed
+  ///   the count of the array.
+  ///
+  /// - Complexity: O(`k`)
+  @inlinable
+  public mutating func removeLast(_ k: Int) {
+    if k == 0 { return }
+    precondition(
+      k >= 0 && k <= _count,
+      "Count of elements to remove is out of bounds")
+    unsafe _storage.extracting(
+      Range(uncheckedBounds: (_count - k, _count))
+    ).deinitialize()
+    _count &-= k
+  }
+
+  /// Removes the specified subrange of elements from the array.
+  ///
+  /// All the elements following the specified subrange are moved to close the
+  /// resulting gap.
+  ///
+  /// - Parameter bounds: The subrange of the array to remove. The bounds
+  ///   of the range must be valid indices of the array.
+  ///
+  /// - Complexity: O(`count`)
+  @inlinable
+  public mutating func removeSubrange(_  bounds: Range<Int>) {
+    _checkValidBounds(bounds)
+    guard !bounds.isEmpty else { return }
+    unsafe _storage.extracting(bounds).deinitialize()
+    _closeGap(at: bounds.lowerBound, count: bounds.count)
+    _count -= bounds.count
+  }
+
+  /// Removes the specified subrange of elements from the array.
+  ///
+  /// - Parameter bounds: The subrange of the array to remove. The bounds of the
+  ///   range must be valid indices of the array.
+  ///
+  /// - Complexity: O(`count`)
+  @_alwaysEmitIntoClient
+  public mutating func removeSubrange(_  bounds: some RangeExpression<Int>) {
+    // FIXME: Remove this in favor of a standard algorithm.
+    removeSubrange(bounds.relative(to: indices))
+  }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray where Element: ~Copyable {
+  /// Removes and returns the last element of the array, if there is one.
+  ///
+  /// - Returns: The last element of the array if the array is not empty;
+  ///     otherwise, `nil`.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public mutating func popLast() -> Element? {
+    // FIXME: Remove this in favor of a standard algorithm.
+    if isEmpty { return nil }
+    return removeLast()
+  }
+}
+
+#endif

--- a/stdlib/public/core/RigidArray/RigidArray+Removals.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Removals.swift
@@ -1,22 +1,16 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift Collections open source project
+// This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2024 - 2025 Apple Inc. and the Swift project authors
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 
-#if !COLLECTIONS_SINGLE_MODULE
-import InternalCollectionsUtilities
-import ContainersPreview
-#endif
-
-#if compiler(>=6.2)
-
-@available(SwiftStdlib 5.0, *)
+@available(SwiftStdlib 6.4, *)
 extension RigidArray where Element: ~Copyable {
   /// Removes and returns the element at the specified position.
   ///
@@ -28,7 +22,8 @@ extension RigidArray where Element: ~Copyable {
   /// - Returns: The removed element.
   ///
   /// - Complexity: O(`count`)
-  @inlinable
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   @discardableResult
   public mutating func remove(at index: Int) -> Element {
     _checkItemIndex(index)
@@ -41,7 +36,8 @@ extension RigidArray where Element: ~Copyable {
   /// Removes all elements from the array, preserving its allocated capacity.
   ///
   /// - Complexity: O(*n*), where *n* is the original count of the array.
-  @inlinable
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public mutating func removeAll() {
     unsafe _items.deinitialize()
     _count = 0
@@ -54,7 +50,8 @@ extension RigidArray where Element: ~Copyable {
   /// - Returns: The last element of the original array.
   ///
   /// - Complexity: O(1)
-  @inlinable
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   @discardableResult
   public mutating func removeLast() -> Element {
     precondition(!isEmpty, "Cannot remove last element from an empty array")
@@ -74,7 +71,8 @@ extension RigidArray where Element: ~Copyable {
   ///   the count of the array.
   ///
   /// - Complexity: O(`k`)
-  @inlinable
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public mutating func removeLast(_ k: Int) {
     if k == 0 { return }
     precondition(
@@ -95,7 +93,8 @@ extension RigidArray where Element: ~Copyable {
   ///   of the range must be valid indices of the array.
   ///
   /// - Complexity: O(`count`)
-  @inlinable
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public mutating func removeSubrange(_  bounds: Range<Int>) {
     _checkValidBounds(bounds)
     guard !bounds.isEmpty else { return }
@@ -110,6 +109,7 @@ extension RigidArray where Element: ~Copyable {
   ///   range must be valid indices of the array.
   ///
   /// - Complexity: O(`count`)
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   public mutating func removeSubrange(_  bounds: some RangeExpression<Int>) {
     // FIXME: Remove this in favor of a standard algorithm.
@@ -117,7 +117,7 @@ extension RigidArray where Element: ~Copyable {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftStdlib 6.4, *)
 extension RigidArray where Element: ~Copyable {
   /// Removes and returns the last element of the array, if there is one.
   ///
@@ -125,6 +125,7 @@ extension RigidArray where Element: ~Copyable {
   ///     otherwise, `nil`.
   ///
   /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   public mutating func popLast() -> Element? {
     // FIXME: Remove this in favor of a standard algorithm.
@@ -132,5 +133,3 @@ extension RigidArray where Element: ~Copyable {
     return removeLast()
   }
 }
-
-#endif

--- a/stdlib/public/core/RigidArray/RigidArray+Removals.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Removals.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 @available(SwiftStdlib 6.4, *)
-extension RigidArray where Element: ~Copyable {
+extension _RigidArray where Element: ~Copyable {
   /// Removes and returns the element at the specified position.
   ///
   /// All the elements following the specified position are moved to close the
@@ -25,7 +25,7 @@ extension RigidArray where Element: ~Copyable {
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   @discardableResult
-  public mutating func remove(at index: Int) -> Element {
+  internal mutating func remove(at index: Int) -> Element {
     _checkItemIndex(index)
     let old = unsafe _storage.moveElement(from: index)
     _closeGap(at: index, count: 1)
@@ -38,7 +38,7 @@ extension RigidArray where Element: ~Copyable {
   /// - Complexity: O(*n*), where *n* is the original count of the array.
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func removeAll() {
+  internal mutating func removeAll() {
     unsafe _items.deinitialize()
     _count = 0
   }
@@ -53,7 +53,7 @@ extension RigidArray where Element: ~Copyable {
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   @discardableResult
-  public mutating func removeLast() -> Element {
+  internal mutating func removeLast() -> Element {
     _precondition(!isEmpty, "Cannot remove last element from an empty array")
     let old = unsafe _storage.moveElement(from: _count - 1)
     _count -= 1
@@ -73,7 +73,7 @@ extension RigidArray where Element: ~Copyable {
   /// - Complexity: O(`k`)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func removeLast(_ k: Int) {
+  internal mutating func removeLast(_ k: Int) {
     if k == 0 { return }
     _precondition(
       k >= 0 && k <= _count,
@@ -95,7 +95,7 @@ extension RigidArray where Element: ~Copyable {
   /// - Complexity: O(`count`)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func removeSubrange(_  bounds: Range<Int>) {
+  internal mutating func removeSubrange(_  bounds: Range<Int>) {
     _checkValidBounds(bounds)
     guard !bounds.isEmpty else { return }
     unsafe _storage.extracting(bounds).deinitialize()
@@ -111,14 +111,14 @@ extension RigidArray where Element: ~Copyable {
   /// - Complexity: O(`count`)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func removeSubrange(_  bounds: some RangeExpression<Int>) {
+  internal mutating func removeSubrange(_  bounds: some RangeExpression<Int>) {
     // FIXME: Remove this in favor of a standard algorithm.
     removeSubrange(bounds.relative(to: indices))
   }
 }
 
 @available(SwiftStdlib 6.4, *)
-extension RigidArray where Element: ~Copyable {
+extension _RigidArray where Element: ~Copyable {
   /// Removes and returns the last element of the array, if there is one.
   ///
   /// - Returns: The last element of the array if the array is not empty;
@@ -127,7 +127,7 @@ extension RigidArray where Element: ~Copyable {
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func popLast() -> Element? {
+  internal mutating func popLast() -> Element? {
     // FIXME: Remove this in favor of a standard algorithm.
     if isEmpty { return nil }
     return removeLast()

--- a/stdlib/public/core/RigidArray/RigidArray+Removals.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Removals.swift
@@ -54,7 +54,7 @@ extension RigidArray where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @discardableResult
   public mutating func removeLast() -> Element {
-    precondition(!isEmpty, "Cannot remove last element from an empty array")
+    _precondition(!isEmpty, "Cannot remove last element from an empty array")
     let old = unsafe _storage.moveElement(from: _count - 1)
     _count -= 1
     return old
@@ -75,7 +75,7 @@ extension RigidArray where Element: ~Copyable {
   @_alwaysEmitIntoClient
   public mutating func removeLast(_ k: Int) {
     if k == 0 { return }
-    precondition(
+    _precondition(
       k >= 0 && k <= _count,
       "Count of elements to remove is out of bounds")
     unsafe _storage.extracting(

--- a/stdlib/public/core/RigidArray/RigidArray+Replacements.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Replacements.swift
@@ -1,22 +1,16 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift Collections open source project
+// This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2024 - 2026 Apple Inc. and the Swift project authors
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 
-#if !COLLECTIONS_SINGLE_MODULE
-import InternalCollectionsUtilities
-import ContainersPreview
-#endif
-
-#if compiler(>=6.2)
-
-@available(SwiftStdlib 5.0, *)
+@available(SwiftStdlib 6.4, *)
 extension RigidArray where Element: ~Copyable {
   /// Replaces the specified range of elements by a given count of new items,
   /// using a callback to directly initialize array storage by populating
@@ -58,7 +52,8 @@ extension RigidArray where Element: ~Copyable {
   ///
   /// - Complexity: O(`self.count` + `newItemCount`) in addition to the complexity
   ///    of the callback invocations.
-  @inlinable
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public mutating func replace<E: Error>(
     removing subrange: Range<Int>,
     addingCount newItemCount: Int,
@@ -83,10 +78,10 @@ extension RigidArray where Element: ~Copyable {
   ) throws(E) -> Void {
     // Destroy removed items
     unsafe _items.extracting(subrange).deinitialize()
-    let target = _resizeGap(in: subrange, to: newItemCount)
-    var span = OutputSpan(buffer: target, initializedCount: 0)
+    let target = unsafe _resizeGap(in: subrange, to: newItemCount)
+    var span = unsafe OutputSpan(buffer: target, initializedCount: 0)
     defer {
-      let c = span.finalize(for: target)
+      let c = unsafe span.finalize(for: target)
       if c < newItemCount {
         self._closeGap(
           at: subrange.lowerBound &+ c,
@@ -99,110 +94,7 @@ extension RigidArray where Element: ~Copyable {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
-extension RigidArray where Element: ~Copyable {
-#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
-  /// Replaces the specified range of elements by a given count of new items,
-  /// using callbacks to consume old items, and to then insert new ones.
-  ///
-  /// The number of new items need not match the number of elements being
-  /// removed.
-  ///
-  /// This method has the same overall effect as calling
-  ///
-  ///     try array.consume(subrange, consumingWith: consumer)
-  ///     try array.insert(
-  ///       addingCount: newItemCount,
-  ///       at: subrange.lowerBound,
-  ///       initializingWith: initializer)
-  ///
-  /// Except it performs faster (by a constant factor), by avoiding moving
-  /// some items in the deque twice.
-  ///
-  /// If the capacity of the array isn't sufficient to accommodate the specified
-  /// number of new elements, then this method triggers a runtime error.
-  ///
-  /// The `consumer` callback is not required to fully depopulate its input
-  /// span. Any items the callback leaves in the span still get removed and
-  /// discarded from the array before insertions begin.
-  ///
-  /// The `initializer` callback is not required to fully populate its
-  /// output span, and it is allowed to throw an error. In such cases, the
-  /// deque keeps all items that were successfully initialized before the
-  /// callback terminated.
-  ///
-  /// Partial insertions create a gap in array storage that needs to be
-  /// closed by moving newly inserted items to their correct positions given
-  /// the adjusted count. This adds some overhead compared to adding exactly as
-  /// many items as promised.
-  ///
-  /// - Parameters:
-  ///   - subrange: The subrange of the deque to replace. The bounds of
-  ///      the range must be valid indices in the deque.
-  ///   - newItemCount: the maximum number of items to replace the old subrange.
-  ///   - consumer: A callback that gets called at most once to consume
-  ///      the elements to be removed directly from the deque's storage. The
-  ///      function is always called with a non-empty input span.
-  ///   - initializer: A callback that gets called at most once to directly
-  ///      populate newly reserved storage within the deque. The function
-  ///      is always called with an empty output span.
-  ///
-  /// - Complexity: O(`self.count` + `newItemCount`) in addition to the
-  ///    complexity of the callback invocations.
-  @inlinable
-  public mutating func replace<E: Error>(
-    removing subrange: Range<Int>,
-    consumingWith consumer: (inout InputSpan<Element>) -> Void,
-    addingCount newItemCount: Int,
-    initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
-  ) throws(E) -> Void {
-    _checkValidBounds(subrange)
-    precondition(newItemCount >= 0, "Cannot add a negative number of items")
-    precondition(
-      newItemCount - subrange.count <= freeCapacity,
-      "RigidArray capacity overflow")
-    try _uncheckedReplace(
-      removing: subrange,
-      consumingWith: consumer,
-      addingCount: newItemCount,
-      initializingWith: initializer)
-  }
-
-  @_alwaysEmitIntoClient
-  internal mutating func _uncheckedReplace<E: Error>(
-    removing subrange: Range<Int>,
-    consumingWith consumer: (inout InputSpan<Element>) -> Void,
-    addingCount newItemCount: Int,
-    initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
-  ) throws(E) -> Void {
-    do {
-      // Consume items to be removed
-      let buffer = unsafe _storage.extracting(subrange)
-      var span = InputSpan(buffer: buffer, initializedCount: buffer.count)
-      consumer(&span)
-      _ = consume span
-    }
-    do {
-      // Insert new items
-      let target = _resizeGap(in: subrange, to: newItemCount)
-      var span = OutputSpan(buffer: target, initializedCount: 0)
-      defer {
-        let c = span.finalize(for: target)
-        if c < newItemCount {
-          self._closeGap(
-            at: subrange.lowerBound &+ c,
-            count: capacity &- c)
-        }
-        span = OutputSpan()
-      }
-      try initializer(&span)
-    }
-  }
-#endif
-}
-
-
-@available(SwiftStdlib 5.0, *)
+@available(SwiftStdlib 6.4, *)
 extension RigidArray where Element: ~Copyable {
   /// Replaces the specified range of elements by moving the elements of a
   /// fully initialized buffer into their place. On return, the buffer is left
@@ -232,57 +124,18 @@ extension RigidArray where Element: ~Copyable {
   ///     the array.
   ///
   /// - Complexity: O(`self.count` + `newElements.count`)
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   public mutating func replace(
     removing subrange: Range<Int>,
     moving newElements: UnsafeMutableBufferPointer<Element>,
   ) {
     replace(removing: subrange, addingCount: newElements.count) { target in
-      target.withUnsafeMutableBufferPointer { buffer, count in
+      unsafe target.withUnsafeMutableBufferPointer { buffer, count in
         count = unsafe buffer._moveInitializePrefix(from: newElements)
       }
     }
   }
-  
-#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
-  /// Replaces the specified range of elements by moving the contents of an
-  /// input span into their place. On return, the span is left empty.
-  ///
-  /// This method has the effect of removing the specified range of elements
-  /// from the array and inserting the new elements starting at the same
-  /// location. The number of new elements need not match the number of elements
-  /// being removed.
-  ///
-  /// If the capacity of the array isn't sufficient to accommodate the new
-  /// elements, then this method triggers a runtime error.
-  ///
-  /// If you pass a zero-length range as the `subrange` parameter, this method
-  /// inserts the elements of `newElements` at `subrange.lowerBound`. This case
-  /// is more directly expressed by calling `insert(moving:at:)`.
-  ///
-  /// Likewise, if you pass a zero-length buffer as the `newElements`
-  /// parameter, this method removes the elements in the given subrange
-  /// without replacement. This case is more directly expressed by calling
-  /// `removeSubrange`.
-  ///
-  /// - Parameters:
-  ///   - subrange: The subrange of the array to replace. The bounds of
-  ///     the range must be valid indices in the array.
-  ///   - items: An input span whose contents are to be moved into the array.
-  ///
-  /// - Complexity: O(`self.count` + `items.count`)
-  @_alwaysEmitIntoClient
-  public mutating func replace(
-    removing subrange: Range<Int>,
-    moving items: inout InputSpan<Element>
-  ) {
-    items.withUnsafeMutableBufferPointer { buffer, count in
-      let source = buffer._extracting(last: count)
-      unsafe self.replace(removing: subrange, moving: source)
-      count = 0
-    }
-  }
-#endif
 
   /// Replaces the specified range of elements by moving the contents of an
   /// output span into their place. On return, the span is left empty.
@@ -310,102 +163,22 @@ extension RigidArray where Element: ~Copyable {
   ///   - items: An output span whose contents are to be moved into the array.
   ///
   /// - Complexity: O(`self.count` + `items.count`)
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   public mutating func replace(
     removing subrange: Range<Int>,
     moving items: inout OutputSpan<Element>
   ) {
-    items.withUnsafeMutableBufferPointer { buffer, count in
-      let source = buffer._extracting(first: count)
-      unsafe self.replace(removing: subrange, moving: source)
-      count = 0
-    }
-  }
-
-  /// Replaces the specified range of elements by moving the elements of a
-  /// another array into their place.  On return, the source array
-  /// becomes empty, but it is not destroyed, and it preserves its original
-  /// storage capacity.
-  ///
-  /// This method has the effect of removing the specified range of elements
-  /// from the array and inserting the new elements starting at the same
-  /// location. The number of new elements need not match the number of elements
-  /// being removed.
-  ///
-  /// If the capacity of the array isn't sufficient to accommodate the new
-  /// elements, then this method triggers a runtime error.
-  ///
-  /// If you pass a zero-length range as the `subrange` parameter, this method
-  /// inserts the elements of `newElements` at `subrange.lowerBound`. This case
-  /// is more directly expressed by calling `insert(moving:at:)`.
-  ///
-  /// Likewise, if you pass a zero-length buffer as the `newElements`
-  /// parameter, this method removes the elements in the given subrange
-  /// without replacement. This case is more directly expressed by calling
-  /// `removeSubrange`.
-  ///
-  /// - Parameters:
-  ///   - subrange: The subrange of the array to replace. The bounds of
-  ///     the range must be valid indices in the array.
-  ///   - newElements: An array whose contents to move into `self`.
-  ///
-  /// - Complexity: O(`self.count` + `newElements.count`)
-  @_alwaysEmitIntoClient
-  public mutating func replace(
-    removing subrange: Range<Int>,
-    moving newElements: inout RigidArray<Element>,
-  ) {
-    // FIXME: Remove this in favor of a generic algorithm over consumable containers
-    unsafe newElements._unsafeEdit { buffer, count in
-      let source = buffer._extracting(first: count)
+    unsafe items.withUnsafeMutableBufferPointer { buffer, count in
+      let source = unsafe buffer._extracting(first: count)
       unsafe self.replace(removing: subrange, moving: source)
       count = 0
     }
   }
 }
 
-@available(SwiftStdlib 5.0, *)
-extension RigidArray where Element: ~Copyable {
-#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
-  /// Replaces the specified range of elements by moving the elements of a
-  /// given array into their place, consuming it in the process.
-  ///
-  /// This method has the effect of removing the specified range of elements
-  /// from the array and inserting the new elements starting at the same
-  /// location. The number of new elements need not match the number of elements
-  /// being removed.
-  ///
-  /// If the capacity of the array isn't sufficient to accommodate the new
-  /// elements, then this method triggers a runtime error.
-  ///
-  /// If you pass a zero-length range as the `subrange` parameter, this method
-  /// inserts the elements of `newElements` at `subrange.lowerBound`. This case
-  /// is more directly expressed by calling `insert(consuming:at:)`.
-  ///
-  /// Likewise, if you pass a zero-length buffer as the `newElements`
-  /// parameter, this method removes the elements in the given subrange
-  /// without replacement. This case is more directly expressed by calling
-  /// `removeSubrange`.
-  ///
-  /// - Parameters:
-  ///   - subrange: The subrange of the array to replace. The bounds of
-  ///     the range must be valid indices in the array.
-  ///   - newElements: An array whose contents to move into `self`.
-  ///
-  /// - Complexity: O(`self.count` + `newElements.count`)
-  @_alwaysEmitIntoClient
-  public mutating func replace(
-    removing subrange: Range<Int>,
-    consuming newElements: consuming RigidArray<Element>,
-  ) {
-    // FIXME: Remove this in favor of a generic algorithm over consumable containers
-    replace(removing: subrange, moving: &newElements)
-  }
-#endif
-}
-
-@available(SwiftStdlib 5.0, *)
-extension RigidArray {
+@available(SwiftStdlib 6.4, *)
+extension RigidArray where Element: Copyable {
   /// Replaces the specified subrange of elements by copying the elements of
   /// the given buffer pointer, which must be fully initialized.
   ///
@@ -432,13 +205,14 @@ extension RigidArray {
   ///   - newElements: The new elements to copy into the collection.
   ///
   /// - Complexity: O(`self.count` + `newElements.count`)
-  @inlinable
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public mutating func replace(
     removing subrange: Range<Int>,
     copying newElements: UnsafeBufferPointer<Element>
   ) {
     replace(removing: subrange, addingCount: newElements.count) { target in
-      target.withUnsafeMutableBufferPointer { buffer, count in
+      unsafe target.withUnsafeMutableBufferPointer { buffer, count in
         count = unsafe buffer._initializePrefix(copying: newElements)
       }
     }
@@ -470,7 +244,8 @@ extension RigidArray {
   ///   - newElements: The new elements to copy into the collection.
   ///
   /// - Complexity: O(`self.count` + `newElements.count`)
-  @inlinable
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public mutating func replace(
     removing subrange: Range<Int>,
     copying newElements: UnsafeMutableBufferPointer<Element>
@@ -506,7 +281,8 @@ extension RigidArray {
   ///   - newElements: The new elements to copy into the collection.
   ///
   /// - Complexity: O(`self.count` + `newElements.count`)
-  @inlinable
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public mutating func replace(
     removing subrange: Range<Int>,
     copying newElements: Span<Element>
@@ -515,40 +291,15 @@ extension RigidArray {
       unsafe self.replace(removing: subrange, copying: buffer)
     }
   }
-  
-#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
-  @inlinable
-  internal mutating func _replace<
-    C: Container<Element> & ~Copyable & ~Escapable
-  >(
-    removing subrange: Range<Int>,
-    copyingContainer items: borrowing C,
-    newCount: Int
-  ) {
-    var it = items.makeBorrowingIterator()
-    self.replace(removing: subrange, addingCount: newCount) { target in
-      while !target.isFull {
-        let source = it.nextSpan(maximumCount: target.freeCapacity)
-        precondition(
-          !source.isEmpty,
-          "Broken Container: count doesn't match contents")
-        target._append(copying: source)
-      }
-      precondition(
-        it.nextSpan().isEmpty,
-        "Broken Container: count doesn't match contents")
-    }
-  }
-#endif
 
-  @inlinable
+  @_alwaysEmitIntoClient
   internal mutating func _replace(
     removing subrange: Range<Int>,
     copyingCollection newElements: __owned some Collection<Element>,
     newCount: Int
   ) {
     self.replace(removing: subrange, addingCount: newCount) { target in
-      target.withUnsafeMutableBufferPointer { dst, dstCount in
+      unsafe target.withUnsafeMutableBufferPointer { dst, dstCount in
         let done: Void? = newElements.withContiguousStorageIfAvailable { src in
           let i = unsafe dst._initializePrefix(copying: src)
           precondition(
@@ -565,50 +316,7 @@ extension RigidArray {
           "Broken Collection: count doesn't match contents")
       }
     }
-
   }
-
-#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
-  /// Replaces the specified subrange of elements by copying the elements of
-  /// the given container.
-  ///
-  /// This method has the effect of removing the specified range of elements
-  /// from the array and inserting the new elements starting at the same
-  /// location. The number of new elements need not match the number of elements
-  /// being removed.
-  ///
-  /// If the capacity of the array isn't sufficient to accommodate the new
-  /// elements, then this method triggers a runtime error.
-  ///
-  /// If you pass a zero-length range as the `subrange` parameter, this method
-  /// inserts the elements of `newElements` at `subrange.lowerBound`. This case
-  /// is more directly expressed by calling `insert(copying:at:)`.
-  ///
-  /// Likewise, if you pass a zero-length container as the `newElements`
-  /// parameter, this method removes the elements in the given subrange
-  /// without replacement. This case is more directly expressed by calling
-  /// `removeSubrange`.
-  ///
-  /// - Parameters:
-  ///   - subrange: The subrange of the array to replace. The bounds of
-  ///     the range must be valid indices in the array.
-  ///   - newElements: The new elements to copy into the collection.
-  ///
-  /// - Complexity: O(`self.count` + `newElements.count`)
-  @inlinable
-  @inline(__always)
-  public mutating func replace<
-    C: Container<Element> & ~Copyable & ~Escapable
-  >(
-    removing subrange: Range<Int>,
-    copying newElements: borrowing C
-  ) {
-    _replace(
-      removing: subrange,
-      copyingContainer: newElements,
-      newCount: newElements.count)
-  }
-#endif
 
   /// Replaces the specified subrange of elements by copying the elements of
   /// the given collection.
@@ -636,8 +344,8 @@ extension RigidArray {
   ///   - newElements: The new elements to copy into the collection.
   ///
   /// - Complexity: O(`self.count` + `newElements.count`)
-  @inlinable
-  @inline(__always)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public mutating func replace(
     removing subrange: Range<Int>,
     copying newElements: __owned some Collection<Element>
@@ -647,49 +355,4 @@ extension RigidArray {
       copyingCollection: newElements,
       newCount: newElements.count)
   }
-  
-#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
-  /// Replaces the specified subrange of elements by copying the elements of
-  /// the given container.
-  ///
-  /// This method has the effect of removing the specified range of elements
-  /// from the array and inserting the new elements starting at the same
-  /// location. The number of new elements need not match the number of elements
-  /// being removed.
-  ///
-  /// If the capacity of the array isn't sufficient to accommodate the new
-  /// elements, then this method triggers a runtime error.
-  ///
-  /// If you pass a zero-length range as the `subrange` parameter, this method
-  /// inserts the elements of `newElements` at `subrange.lowerBound`. This case
-  /// is more directly expressed by calling `insert(copying:at:)`.
-  ///
-  /// Likewise, if you pass a zero-length container as the `newElements`
-  /// parameter, this method removes the elements in the given subrange
-  /// without replacement. This case is more directly expressed by calling
-  /// `removeSubrange`.
-  ///
-  /// - Parameters:
-  ///   - subrange: The subrange of the array to replace. The bounds of
-  ///     the range must be valid indices in the array.
-  ///   - newElements: The new elements to copy into the collection.
-  ///
-  /// - Complexity: O(*n* + *m*), where *n* is count of this array and
-  ///   *m* is the count of `newElements`.
-  @inlinable
-  @inline(__always)
-  public mutating func replace<
-    C: Container<Element> & Collection<Element>
-  >(
-    removing subrange: Range<Int>,
-    copying newElements: C
-  ) {
-    _replace(
-      removing: subrange,
-      copyingContainer: newElements,
-      newCount: newElements.count)
-  }
-#endif
 }
-
-#endif

--- a/stdlib/public/core/RigidArray/RigidArray+Replacements.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Replacements.swift
@@ -1,0 +1,695 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2024 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if !COLLECTIONS_SINGLE_MODULE
+import InternalCollectionsUtilities
+import ContainersPreview
+#endif
+
+#if compiler(>=6.2)
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray where Element: ~Copyable {
+  /// Replaces the specified range of elements by a given count of new items,
+  /// using a callback to directly initialize array storage by populating
+  /// an output span.
+  ///
+  /// The number of new items need not match the number of elements being
+  /// removed.
+  ///
+  /// This method has the same overall effect as calling
+  ///
+  ///     try array.removeSubrange(subrange)
+  ///     try array.insert(
+  ///       addingCount: newItemCount,
+  ///       at: subrange.lowerBound,
+  ///       initializingWith: initializer)
+  ///
+  /// Except it performs faster (by a constant factor), by avoiding moving
+  /// some items in the array twice.
+  ///
+  /// If the array does not have sufficient capacity to accommodate the new
+  /// elements, then this method triggers a runtime error.
+  ///
+  /// If the callback fails to fully populate its output span or if
+  /// it throws an error, then the array keeps all items that were
+  /// successfully initialized before the callback terminated the prepend.
+  ///
+  /// Partial insertions create a gap in array storage that needs to be
+  /// closed by moving newly inserted items to their correct positions given
+  /// the adjusted count. This adds some overhead compared to adding exactly as
+  /// many items as promised.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the array to replace. The bounds of
+  ///      the range must be valid indices in the array.
+  ///   - newItemCount: the maximum number of items to replace the old subrange.
+  ///   - initializer: A callback that gets called at most once to directly
+  ///      populate newly reserved storage within the array. The function
+  ///      is always called with an empty output span.
+  ///
+  /// - Complexity: O(`self.count` + `newItemCount`) in addition to the complexity
+  ///    of the callback invocations.
+  @inlinable
+  public mutating func replace<E: Error>(
+    removing subrange: Range<Int>,
+    addingCount newItemCount: Int,
+    initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
+  ) throws(E) -> Void {
+    _checkValidBounds(subrange)
+    precondition(newItemCount >= 0, "Cannot add a negative number of items")
+    precondition(
+      newItemCount - subrange.count <= freeCapacity,
+      "RigidArray capacity overflow")
+    try _uncheckedReplace(
+      removing: subrange,
+      addingCount: newItemCount,
+      initializingWith: initializer)
+  }
+
+  @_alwaysEmitIntoClient
+  internal mutating func _uncheckedReplace<E: Error>(
+    removing subrange: Range<Int>,
+    addingCount newItemCount: Int,
+    initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
+  ) throws(E) -> Void {
+    // Destroy removed items
+    unsafe _items.extracting(subrange).deinitialize()
+    let target = _resizeGap(in: subrange, to: newItemCount)
+    var span = OutputSpan(buffer: target, initializedCount: 0)
+    defer {
+      let c = span.finalize(for: target)
+      if c < newItemCount {
+        self._closeGap(
+          at: subrange.lowerBound &+ c,
+          count: newItemCount &- c)
+        _count &-= newItemCount &- c
+      }
+      span = OutputSpan()
+    }
+    try initializer(&span)
+  }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray where Element: ~Copyable {
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+  /// Replaces the specified range of elements by a given count of new items,
+  /// using callbacks to consume old items, and to then insert new ones.
+  ///
+  /// The number of new items need not match the number of elements being
+  /// removed.
+  ///
+  /// This method has the same overall effect as calling
+  ///
+  ///     try array.consume(subrange, consumingWith: consumer)
+  ///     try array.insert(
+  ///       addingCount: newItemCount,
+  ///       at: subrange.lowerBound,
+  ///       initializingWith: initializer)
+  ///
+  /// Except it performs faster (by a constant factor), by avoiding moving
+  /// some items in the deque twice.
+  ///
+  /// If the capacity of the array isn't sufficient to accommodate the specified
+  /// number of new elements, then this method triggers a runtime error.
+  ///
+  /// The `consumer` callback is not required to fully depopulate its input
+  /// span. Any items the callback leaves in the span still get removed and
+  /// discarded from the array before insertions begin.
+  ///
+  /// The `initializer` callback is not required to fully populate its
+  /// output span, and it is allowed to throw an error. In such cases, the
+  /// deque keeps all items that were successfully initialized before the
+  /// callback terminated.
+  ///
+  /// Partial insertions create a gap in array storage that needs to be
+  /// closed by moving newly inserted items to their correct positions given
+  /// the adjusted count. This adds some overhead compared to adding exactly as
+  /// many items as promised.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the deque to replace. The bounds of
+  ///      the range must be valid indices in the deque.
+  ///   - newItemCount: the maximum number of items to replace the old subrange.
+  ///   - consumer: A callback that gets called at most once to consume
+  ///      the elements to be removed directly from the deque's storage. The
+  ///      function is always called with a non-empty input span.
+  ///   - initializer: A callback that gets called at most once to directly
+  ///      populate newly reserved storage within the deque. The function
+  ///      is always called with an empty output span.
+  ///
+  /// - Complexity: O(`self.count` + `newItemCount`) in addition to the
+  ///    complexity of the callback invocations.
+  @inlinable
+  public mutating func replace<E: Error>(
+    removing subrange: Range<Int>,
+    consumingWith consumer: (inout InputSpan<Element>) -> Void,
+    addingCount newItemCount: Int,
+    initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
+  ) throws(E) -> Void {
+    _checkValidBounds(subrange)
+    precondition(newItemCount >= 0, "Cannot add a negative number of items")
+    precondition(
+      newItemCount - subrange.count <= freeCapacity,
+      "RigidArray capacity overflow")
+    try _uncheckedReplace(
+      removing: subrange,
+      consumingWith: consumer,
+      addingCount: newItemCount,
+      initializingWith: initializer)
+  }
+
+  @_alwaysEmitIntoClient
+  internal mutating func _uncheckedReplace<E: Error>(
+    removing subrange: Range<Int>,
+    consumingWith consumer: (inout InputSpan<Element>) -> Void,
+    addingCount newItemCount: Int,
+    initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
+  ) throws(E) -> Void {
+    do {
+      // Consume items to be removed
+      let buffer = unsafe _storage.extracting(subrange)
+      var span = InputSpan(buffer: buffer, initializedCount: buffer.count)
+      consumer(&span)
+      _ = consume span
+    }
+    do {
+      // Insert new items
+      let target = _resizeGap(in: subrange, to: newItemCount)
+      var span = OutputSpan(buffer: target, initializedCount: 0)
+      defer {
+        let c = span.finalize(for: target)
+        if c < newItemCount {
+          self._closeGap(
+            at: subrange.lowerBound &+ c,
+            count: capacity &- c)
+        }
+        span = OutputSpan()
+      }
+      try initializer(&span)
+    }
+  }
+#endif
+}
+
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray where Element: ~Copyable {
+  /// Replaces the specified range of elements by moving the elements of a
+  /// fully initialized buffer into their place. On return, the buffer is left
+  /// in an uninitialized state.
+  ///
+  /// This method has the effect of removing the specified range of elements
+  /// from the array and inserting the new elements starting at the same
+  /// location. The number of new elements need not match the number of elements
+  /// being removed.
+  ///
+  /// If the capacity of the array isn't sufficient to accommodate the new
+  /// elements, then this method triggers a runtime error.
+  ///
+  /// If you pass a zero-length range as the `subrange` parameter, this method
+  /// inserts the elements of `newElements` at `subrange.lowerBound`. This case
+  /// is more directly expressed by calling `insert(moving:at:)`.
+  ///
+  /// Likewise, if you pass a zero-length buffer as the `newElements`
+  /// parameter, this method removes the elements in the given subrange
+  /// without replacement. This case is more directly expressed by calling
+  /// `removeSubrange`.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the array to replace. The bounds of
+  ///     the range must be valid indices in the array.
+  ///   - newElements: A fully initialized buffer whose contents to move into
+  ///     the array.
+  ///
+  /// - Complexity: O(`self.count` + `newElements.count`)
+  @_alwaysEmitIntoClient
+  public mutating func replace(
+    removing subrange: Range<Int>,
+    moving newElements: UnsafeMutableBufferPointer<Element>,
+  ) {
+    replace(removing: subrange, addingCount: newElements.count) { target in
+      target.withUnsafeMutableBufferPointer { buffer, count in
+        count = unsafe buffer._moveInitializePrefix(from: newElements)
+      }
+    }
+  }
+  
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+  /// Replaces the specified range of elements by moving the contents of an
+  /// input span into their place. On return, the span is left empty.
+  ///
+  /// This method has the effect of removing the specified range of elements
+  /// from the array and inserting the new elements starting at the same
+  /// location. The number of new elements need not match the number of elements
+  /// being removed.
+  ///
+  /// If the capacity of the array isn't sufficient to accommodate the new
+  /// elements, then this method triggers a runtime error.
+  ///
+  /// If you pass a zero-length range as the `subrange` parameter, this method
+  /// inserts the elements of `newElements` at `subrange.lowerBound`. This case
+  /// is more directly expressed by calling `insert(moving:at:)`.
+  ///
+  /// Likewise, if you pass a zero-length buffer as the `newElements`
+  /// parameter, this method removes the elements in the given subrange
+  /// without replacement. This case is more directly expressed by calling
+  /// `removeSubrange`.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the array to replace. The bounds of
+  ///     the range must be valid indices in the array.
+  ///   - items: An input span whose contents are to be moved into the array.
+  ///
+  /// - Complexity: O(`self.count` + `items.count`)
+  @_alwaysEmitIntoClient
+  public mutating func replace(
+    removing subrange: Range<Int>,
+    moving items: inout InputSpan<Element>
+  ) {
+    items.withUnsafeMutableBufferPointer { buffer, count in
+      let source = buffer._extracting(last: count)
+      unsafe self.replace(removing: subrange, moving: source)
+      count = 0
+    }
+  }
+#endif
+
+  /// Replaces the specified range of elements by moving the contents of an
+  /// output span into their place. On return, the span is left empty.
+  ///
+  /// This method has the effect of removing the specified range of elements
+  /// from the array and inserting the new elements starting at the same
+  /// location. The number of new elements need not match the number of elements
+  /// being removed.
+  ///
+  /// If the capacity of the array isn't sufficient to accommodate the new
+  /// elements, then this method triggers a runtime error.
+  ///
+  /// If you pass a zero-length range as the `subrange` parameter, this method
+  /// inserts the elements of `newElements` at `subrange.lowerBound`. This case
+  /// is more directly expressed by calling `insert(moving:at:)`.
+  ///
+  /// Likewise, if you pass a zero-length buffer as the `newElements`
+  /// parameter, this method removes the elements in the given subrange
+  /// without replacement. This case is more directly expressed by calling
+  /// `removeSubrange`.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the array to replace. The bounds of
+  ///     the range must be valid indices in the array.
+  ///   - items: An output span whose contents are to be moved into the array.
+  ///
+  /// - Complexity: O(`self.count` + `items.count`)
+  @_alwaysEmitIntoClient
+  public mutating func replace(
+    removing subrange: Range<Int>,
+    moving items: inout OutputSpan<Element>
+  ) {
+    items.withUnsafeMutableBufferPointer { buffer, count in
+      let source = buffer._extracting(first: count)
+      unsafe self.replace(removing: subrange, moving: source)
+      count = 0
+    }
+  }
+
+  /// Replaces the specified range of elements by moving the elements of a
+  /// another array into their place.  On return, the source array
+  /// becomes empty, but it is not destroyed, and it preserves its original
+  /// storage capacity.
+  ///
+  /// This method has the effect of removing the specified range of elements
+  /// from the array and inserting the new elements starting at the same
+  /// location. The number of new elements need not match the number of elements
+  /// being removed.
+  ///
+  /// If the capacity of the array isn't sufficient to accommodate the new
+  /// elements, then this method triggers a runtime error.
+  ///
+  /// If you pass a zero-length range as the `subrange` parameter, this method
+  /// inserts the elements of `newElements` at `subrange.lowerBound`. This case
+  /// is more directly expressed by calling `insert(moving:at:)`.
+  ///
+  /// Likewise, if you pass a zero-length buffer as the `newElements`
+  /// parameter, this method removes the elements in the given subrange
+  /// without replacement. This case is more directly expressed by calling
+  /// `removeSubrange`.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the array to replace. The bounds of
+  ///     the range must be valid indices in the array.
+  ///   - newElements: An array whose contents to move into `self`.
+  ///
+  /// - Complexity: O(`self.count` + `newElements.count`)
+  @_alwaysEmitIntoClient
+  public mutating func replace(
+    removing subrange: Range<Int>,
+    moving newElements: inout RigidArray<Element>,
+  ) {
+    // FIXME: Remove this in favor of a generic algorithm over consumable containers
+    unsafe newElements._unsafeEdit { buffer, count in
+      let source = buffer._extracting(first: count)
+      unsafe self.replace(removing: subrange, moving: source)
+      count = 0
+    }
+  }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray where Element: ~Copyable {
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+  /// Replaces the specified range of elements by moving the elements of a
+  /// given array into their place, consuming it in the process.
+  ///
+  /// This method has the effect of removing the specified range of elements
+  /// from the array and inserting the new elements starting at the same
+  /// location. The number of new elements need not match the number of elements
+  /// being removed.
+  ///
+  /// If the capacity of the array isn't sufficient to accommodate the new
+  /// elements, then this method triggers a runtime error.
+  ///
+  /// If you pass a zero-length range as the `subrange` parameter, this method
+  /// inserts the elements of `newElements` at `subrange.lowerBound`. This case
+  /// is more directly expressed by calling `insert(consuming:at:)`.
+  ///
+  /// Likewise, if you pass a zero-length buffer as the `newElements`
+  /// parameter, this method removes the elements in the given subrange
+  /// without replacement. This case is more directly expressed by calling
+  /// `removeSubrange`.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the array to replace. The bounds of
+  ///     the range must be valid indices in the array.
+  ///   - newElements: An array whose contents to move into `self`.
+  ///
+  /// - Complexity: O(`self.count` + `newElements.count`)
+  @_alwaysEmitIntoClient
+  public mutating func replace(
+    removing subrange: Range<Int>,
+    consuming newElements: consuming RigidArray<Element>,
+  ) {
+    // FIXME: Remove this in favor of a generic algorithm over consumable containers
+    replace(removing: subrange, moving: &newElements)
+  }
+#endif
+}
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray {
+  /// Replaces the specified subrange of elements by copying the elements of
+  /// the given buffer pointer, which must be fully initialized.
+  ///
+  /// This method has the effect of removing the specified range of elements
+  /// from the array and inserting the new elements starting at the same
+  /// location. The number of new elements need not match the number of elements
+  /// being removed.
+  ///
+  /// If the capacity of the array isn't sufficient to accommodate the new
+  /// elements, then this method triggers a runtime error.
+  ///
+  /// If you pass a zero-length range as the `subrange` parameter, this method
+  /// inserts the elements of `newElements` at `subrange.lowerBound`. This case
+  /// is more directly expressed by calling `insert(copying:at:)`.
+  ///
+  /// Likewise, if you pass a zero-length buffer as the `newElements`
+  /// parameter, this method removes the elements in the given subrange
+  /// without replacement. This case is more directly expressed by calling
+  /// `removeSubrange`.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the array to replace. The bounds of
+  ///     the range must be valid indices in the array.
+  ///   - newElements: The new elements to copy into the collection.
+  ///
+  /// - Complexity: O(`self.count` + `newElements.count`)
+  @inlinable
+  public mutating func replace(
+    removing subrange: Range<Int>,
+    copying newElements: UnsafeBufferPointer<Element>
+  ) {
+    replace(removing: subrange, addingCount: newElements.count) { target in
+      target.withUnsafeMutableBufferPointer { buffer, count in
+        count = unsafe buffer._initializePrefix(copying: newElements)
+      }
+    }
+  }
+
+  /// Replaces the specified subrange of elements by copying the elements of
+  /// the given buffer pointer, which must be fully initialized.
+  ///
+  /// This method has the effect of removing the specified range of elements
+  /// from the array and inserting the new elements starting at the same
+  /// location. The number of new elements need not match the number of elements
+  /// being removed.
+  ///
+  /// If the capacity of the array isn't sufficient to accommodate the new
+  /// elements, then this method triggers a runtime error.
+  ///
+  /// If you pass a zero-length range as the `subrange` parameter, this method
+  /// inserts the elements of `newElements` at `subrange.lowerBound`. This case
+  /// is more directly expressed by calling `insert(copying:at:)`.
+  ///
+  /// Likewise, if you pass a zero-length buffer as the `newElements`
+  /// parameter, this method removes the elements in the given subrange
+  /// without replacement. This case is more directly expressed by calling
+  /// `removeSubrange`.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the array to replace. The bounds of
+  ///     the range must be valid indices in the array.
+  ///   - newElements: The new elements to copy into the collection.
+  ///
+  /// - Complexity: O(`self.count` + `newElements.count`)
+  @inlinable
+  public mutating func replace(
+    removing subrange: Range<Int>,
+    copying newElements: UnsafeMutableBufferPointer<Element>
+  ) {
+    unsafe self.replace(
+      removing: subrange,
+      copying: UnsafeBufferPointer(newElements))
+  }
+
+  /// Replaces the specified subrange of elements by copying the elements of
+  /// the given span.
+  ///
+  /// This method has the effect of removing the specified range of elements
+  /// from the array and inserting the new elements starting at the same
+  /// location. The number of new elements need not match the number of elements
+  /// being removed.
+  ///
+  /// If the capacity of the array isn't sufficient to accommodate the new
+  /// elements, then this method triggers a runtime error.
+  ///
+  /// If you pass a zero-length range as the `subrange` parameter, this method
+  /// inserts the elements of `newElements` at `subrange.lowerBound`. This case
+  /// is more directly expressed by calling `insert(copying:at:)`.
+  ///
+  /// Likewise, if you pass a zero-length span as the `newElements`
+  /// parameter, this method removes the elements in the given subrange
+  /// without replacement. This case is more directly expressed by calling
+  /// `removeSubrange`.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the array to replace. The bounds of
+  ///     the range must be valid indices in the array.
+  ///   - newElements: The new elements to copy into the collection.
+  ///
+  /// - Complexity: O(`self.count` + `newElements.count`)
+  @inlinable
+  public mutating func replace(
+    removing subrange: Range<Int>,
+    copying newElements: Span<Element>
+  ) {
+    unsafe newElements.withUnsafeBufferPointer { buffer in
+      unsafe self.replace(removing: subrange, copying: buffer)
+    }
+  }
+  
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+  @inlinable
+  internal mutating func _replace<
+    C: Container<Element> & ~Copyable & ~Escapable
+  >(
+    removing subrange: Range<Int>,
+    copyingContainer items: borrowing C,
+    newCount: Int
+  ) {
+    var it = items.makeBorrowingIterator()
+    self.replace(removing: subrange, addingCount: newCount) { target in
+      while !target.isFull {
+        let source = it.nextSpan(maximumCount: target.freeCapacity)
+        precondition(
+          !source.isEmpty,
+          "Broken Container: count doesn't match contents")
+        target._append(copying: source)
+      }
+      precondition(
+        it.nextSpan().isEmpty,
+        "Broken Container: count doesn't match contents")
+    }
+  }
+#endif
+
+  @inlinable
+  internal mutating func _replace(
+    removing subrange: Range<Int>,
+    copyingCollection newElements: __owned some Collection<Element>,
+    newCount: Int
+  ) {
+    self.replace(removing: subrange, addingCount: newCount) { target in
+      target.withUnsafeMutableBufferPointer { dst, dstCount in
+        let done: Void? = newElements.withContiguousStorageIfAvailable { src in
+          let i = unsafe dst._initializePrefix(copying: src)
+          precondition(
+            i == newCount,
+            "Broken Collection: count doesn't match contents")
+          dstCount = i
+        }
+        if done != nil { return }
+
+        var (it, copied) = unsafe newElements._copyContents(initializing: dst)
+        dstCount = copied
+        precondition(
+          it.next() == nil && copied == newCount,
+          "Broken Collection: count doesn't match contents")
+      }
+    }
+
+  }
+
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+  /// Replaces the specified subrange of elements by copying the elements of
+  /// the given container.
+  ///
+  /// This method has the effect of removing the specified range of elements
+  /// from the array and inserting the new elements starting at the same
+  /// location. The number of new elements need not match the number of elements
+  /// being removed.
+  ///
+  /// If the capacity of the array isn't sufficient to accommodate the new
+  /// elements, then this method triggers a runtime error.
+  ///
+  /// If you pass a zero-length range as the `subrange` parameter, this method
+  /// inserts the elements of `newElements` at `subrange.lowerBound`. This case
+  /// is more directly expressed by calling `insert(copying:at:)`.
+  ///
+  /// Likewise, if you pass a zero-length container as the `newElements`
+  /// parameter, this method removes the elements in the given subrange
+  /// without replacement. This case is more directly expressed by calling
+  /// `removeSubrange`.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the array to replace. The bounds of
+  ///     the range must be valid indices in the array.
+  ///   - newElements: The new elements to copy into the collection.
+  ///
+  /// - Complexity: O(`self.count` + `newElements.count`)
+  @inlinable
+  @inline(__always)
+  public mutating func replace<
+    C: Container<Element> & ~Copyable & ~Escapable
+  >(
+    removing subrange: Range<Int>,
+    copying newElements: borrowing C
+  ) {
+    _replace(
+      removing: subrange,
+      copyingContainer: newElements,
+      newCount: newElements.count)
+  }
+#endif
+
+  /// Replaces the specified subrange of elements by copying the elements of
+  /// the given collection.
+  ///
+  /// This method has the effect of removing the specified range of elements
+  /// from the array and inserting the new elements starting at the same
+  /// location. The number of new elements need not match the number of elements
+  /// being removed.
+  ///
+  /// If the capacity of the array isn't sufficient to accommodate the new
+  /// elements, then this method triggers a runtime error.
+  ///
+  /// If you pass a zero-length range as the `subrange` parameter, this method
+  /// inserts the elements of `newElements` at `subrange.lowerBound`. This case
+  /// is more directly expressed by calling `insert(copying:at:)`.
+  ///
+  /// Likewise, if you pass a zero-length collection as the `newElements`
+  /// parameter, this method removes the elements in the given subrange
+  /// without replacement. This case is more directly expressed by calling
+  /// `removeSubrange`.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the array to replace. The bounds of
+  ///     the range must be valid indices in the array.
+  ///   - newElements: The new elements to copy into the collection.
+  ///
+  /// - Complexity: O(`self.count` + `newElements.count`)
+  @inlinable
+  @inline(__always)
+  public mutating func replace(
+    removing subrange: Range<Int>,
+    copying newElements: __owned some Collection<Element>
+  ) {
+    _replace(
+      removing: subrange,
+      copyingCollection: newElements,
+      newCount: newElements.count)
+  }
+  
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+  /// Replaces the specified subrange of elements by copying the elements of
+  /// the given container.
+  ///
+  /// This method has the effect of removing the specified range of elements
+  /// from the array and inserting the new elements starting at the same
+  /// location. The number of new elements need not match the number of elements
+  /// being removed.
+  ///
+  /// If the capacity of the array isn't sufficient to accommodate the new
+  /// elements, then this method triggers a runtime error.
+  ///
+  /// If you pass a zero-length range as the `subrange` parameter, this method
+  /// inserts the elements of `newElements` at `subrange.lowerBound`. This case
+  /// is more directly expressed by calling `insert(copying:at:)`.
+  ///
+  /// Likewise, if you pass a zero-length container as the `newElements`
+  /// parameter, this method removes the elements in the given subrange
+  /// without replacement. This case is more directly expressed by calling
+  /// `removeSubrange`.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the array to replace. The bounds of
+  ///     the range must be valid indices in the array.
+  ///   - newElements: The new elements to copy into the collection.
+  ///
+  /// - Complexity: O(*n* + *m*), where *n* is count of this array and
+  ///   *m* is the count of `newElements`.
+  @inlinable
+  @inline(__always)
+  public mutating func replace<
+    C: Container<Element> & Collection<Element>
+  >(
+    removing subrange: Range<Int>,
+    copying newElements: C
+  ) {
+    _replace(
+      removing: subrange,
+      copyingContainer: newElements,
+      newCount: newElements.count)
+  }
+#endif
+}
+
+#endif

--- a/stdlib/public/core/RigidArray/RigidArray+Replacements.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Replacements.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 @available(SwiftStdlib 6.4, *)
-extension RigidArray where Element: ~Copyable {
+extension _RigidArray where Element: ~Copyable {
   /// Replaces the specified range of elements by a given count of new items,
   /// using a callback to directly initialize array storage by populating
   /// an output span.
@@ -54,7 +54,7 @@ extension RigidArray where Element: ~Copyable {
   ///    of the callback invocations.
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func replace<E: Error>(
+  internal mutating func replace<E: Error>(
     removing subrange: Range<Int>,
     addingCount newItemCount: Int,
     initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
@@ -95,7 +95,7 @@ extension RigidArray where Element: ~Copyable {
 }
 
 @available(SwiftStdlib 6.4, *)
-extension RigidArray where Element: ~Copyable {
+extension _RigidArray where Element: ~Copyable {
   /// Replaces the specified range of elements by moving the elements of a
   /// fully initialized buffer into their place. On return, the buffer is left
   /// in an uninitialized state.
@@ -126,7 +126,7 @@ extension RigidArray where Element: ~Copyable {
   /// - Complexity: O(`self.count` + `newElements.count`)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func replace(
+  internal mutating func replace(
     removing subrange: Range<Int>,
     moving newElements: UnsafeMutableBufferPointer<Element>,
   ) {
@@ -165,7 +165,7 @@ extension RigidArray where Element: ~Copyable {
   /// - Complexity: O(`self.count` + `items.count`)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func replace(
+  internal mutating func replace(
     removing subrange: Range<Int>,
     moving items: inout OutputSpan<Element>
   ) {
@@ -178,7 +178,7 @@ extension RigidArray where Element: ~Copyable {
 }
 
 @available(SwiftStdlib 6.4, *)
-extension RigidArray where Element: Copyable {
+extension _RigidArray where Element: Copyable {
   /// Replaces the specified subrange of elements by copying the elements of
   /// the given buffer pointer, which must be fully initialized.
   ///
@@ -207,7 +207,7 @@ extension RigidArray where Element: Copyable {
   /// - Complexity: O(`self.count` + `newElements.count`)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func replace(
+  internal mutating func replace(
     removing subrange: Range<Int>,
     copying newElements: UnsafeBufferPointer<Element>
   ) {
@@ -246,7 +246,7 @@ extension RigidArray where Element: Copyable {
   /// - Complexity: O(`self.count` + `newElements.count`)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func replace(
+  internal mutating func replace(
     removing subrange: Range<Int>,
     copying newElements: UnsafeMutableBufferPointer<Element>
   ) {
@@ -283,11 +283,11 @@ extension RigidArray where Element: Copyable {
   /// - Complexity: O(`self.count` + `newElements.count`)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func replace(
+  internal mutating func replace(
     removing subrange: Range<Int>,
     copying newElements: Span<Element>
   ) {
-    unsafe newElements.withUnsafeBufferPointer { buffer in
+    newElements.withUnsafeBufferPointer { buffer in
       unsafe self.replace(removing: subrange, copying: buffer)
     }
   }
@@ -346,7 +346,7 @@ extension RigidArray where Element: Copyable {
   /// - Complexity: O(`self.count` + `newElements.count`)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func replace(
+  internal mutating func replace(
     removing subrange: Range<Int>,
     copying newElements: __owned some Collection<Element>
   ) {

--- a/stdlib/public/core/RigidArray/RigidArray+Replacements.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Replacements.swift
@@ -54,8 +54,8 @@ extension _RigidArray where Element: ~Copyable {
   ///    of the callback invocations.
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  internal mutating func replace<E: Error>(
-    removing subrange: Range<Int>,
+  internal mutating func replaceSubrange<E: Error>(
+    _ subrange: Range<Int>,
     addingCount newItemCount: Int,
     initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
   ) throws(E) -> Void {
@@ -64,15 +64,15 @@ extension _RigidArray where Element: ~Copyable {
     _precondition(
       newItemCount - subrange.count <= freeCapacity,
       "RigidArray capacity overflow")
-    try _uncheckedReplace(
-      removing: subrange,
+    try _uncheckedReplaceSubrange(
+      subrange,
       addingCount: newItemCount,
       initializingWith: initializer)
   }
 
   @_alwaysEmitIntoClient
-  internal mutating func _uncheckedReplace<E: Error>(
-    removing subrange: Range<Int>,
+  internal mutating func _uncheckedReplaceSubrange<E: Error>(
+    _ subrange: Range<Int>,
     addingCount newItemCount: Int,
     initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
   ) throws(E) -> Void {
@@ -126,11 +126,11 @@ extension _RigidArray where Element: ~Copyable {
   /// - Complexity: O(`self.count` + `newElements.count`)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  internal mutating func replace(
-    removing subrange: Range<Int>,
+  internal mutating func replaceSubrange(
+    _ subrange: Range<Int>,
     moving newElements: UnsafeMutableBufferPointer<Element>,
   ) {
-    replace(removing: subrange, addingCount: newElements.count) { target in
+    replaceSubrange(subrange, addingCount: newElements.count) { target in
       unsafe target.withUnsafeMutableBufferPointer { buffer, count in
         count = unsafe buffer._moveInitializePrefix(from: newElements)
       }
@@ -165,13 +165,13 @@ extension _RigidArray where Element: ~Copyable {
   /// - Complexity: O(`self.count` + `items.count`)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  internal mutating func replace(
-    removing subrange: Range<Int>,
+  internal mutating func replaceSubrange(
+    _ subrange: Range<Int>,
     moving items: inout OutputSpan<Element>
   ) {
     unsafe items.withUnsafeMutableBufferPointer { buffer, count in
       let source = unsafe buffer._extracting(first: count)
-      unsafe self.replace(removing: subrange, moving: source)
+      unsafe replaceSubrange(subrange, moving: source)
       count = 0
     }
   }
@@ -207,11 +207,11 @@ extension _RigidArray where Element: Copyable {
   /// - Complexity: O(`self.count` + `newElements.count`)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  internal mutating func replace(
-    removing subrange: Range<Int>,
+  internal mutating func replaceSubrange(
+    _ subrange: Range<Int>,
     copying newElements: UnsafeBufferPointer<Element>
   ) {
-    replace(removing: subrange, addingCount: newElements.count) { target in
+    replaceSubrange(subrange, addingCount: newElements.count) { target in
       unsafe target.withUnsafeMutableBufferPointer { buffer, count in
         count = unsafe buffer._initializePrefix(copying: newElements)
       }
@@ -246,12 +246,12 @@ extension _RigidArray where Element: Copyable {
   /// - Complexity: O(`self.count` + `newElements.count`)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  internal mutating func replace(
-    removing subrange: Range<Int>,
+  internal mutating func replaceSubrange(
+    _ subrange: Range<Int>,
     copying newElements: UnsafeMutableBufferPointer<Element>
   ) {
-    unsafe self.replace(
-      removing: subrange,
+    unsafe replaceSubrange(
+      subrange,
       copying: UnsafeBufferPointer(newElements))
   }
 
@@ -283,22 +283,22 @@ extension _RigidArray where Element: Copyable {
   /// - Complexity: O(`self.count` + `newElements.count`)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  internal mutating func replace(
-    removing subrange: Range<Int>,
+  internal mutating func replaceSubrange(
+    _ subrange: Range<Int>,
     copying newElements: Span<Element>
   ) {
     newElements.withUnsafeBufferPointer { buffer in
-      unsafe self.replace(removing: subrange, copying: buffer)
+      unsafe replaceSubrange(subrange, copying: buffer)
     }
   }
 
   @_alwaysEmitIntoClient
-  internal mutating func _replace(
-    removing subrange: Range<Int>,
+  internal mutating func _replaceSubrange(
+    _ subrange: Range<Int>,
     copyingCollection newElements: __owned some Collection<Element>,
     newCount: Int
   ) {
-    self.replace(removing: subrange, addingCount: newCount) { target in
+    replaceSubrange(subrange, addingCount: newCount) { target in
       unsafe target.withUnsafeMutableBufferPointer { dst, dstCount in
         let done: Void? = newElements.withContiguousStorageIfAvailable { src in
           let i = unsafe dst._initializePrefix(copying: src)
@@ -346,12 +346,12 @@ extension _RigidArray where Element: Copyable {
   /// - Complexity: O(`self.count` + `newElements.count`)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  internal mutating func replace(
-    removing subrange: Range<Int>,
+  internal mutating func replaceSubrange(
+    _ subrange: Range<Int>,
     copying newElements: __owned some Collection<Element>
   ) {
-    _replace(
-      removing: subrange,
+    _replaceSubrange(
+      subrange,
       copyingCollection: newElements,
       newCount: newElements.count)
   }

--- a/stdlib/public/core/RigidArray/RigidArray+Replacements.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Replacements.swift
@@ -60,8 +60,8 @@ extension RigidArray where Element: ~Copyable {
     initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
   ) throws(E) -> Void {
     _checkValidBounds(subrange)
-    precondition(newItemCount >= 0, "Cannot add a negative number of items")
-    precondition(
+    _precondition(newItemCount >= 0, "Cannot add a negative number of items")
+    _precondition(
       newItemCount - subrange.count <= freeCapacity,
       "RigidArray capacity overflow")
     try _uncheckedReplace(
@@ -302,7 +302,7 @@ extension RigidArray where Element: Copyable {
       unsafe target.withUnsafeMutableBufferPointer { dst, dstCount in
         let done: Void? = newElements.withContiguousStorageIfAvailable { src in
           let i = unsafe dst._initializePrefix(copying: src)
-          precondition(
+          _precondition(
             i == newCount,
             "Broken Collection: count doesn't match contents")
           dstCount = i
@@ -311,7 +311,7 @@ extension RigidArray where Element: Copyable {
 
         var (it, copied) = unsafe newElements._copyContents(initializing: dst)
         dstCount = copied
-        precondition(
+        _precondition(
           it.next() == nil && copied == newCount,
           "Broken Collection: count doesn't match contents")
       }

--- a/stdlib/public/core/RigidArray/RigidArray+Replacements.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Replacements.swift
@@ -348,7 +348,7 @@ extension _RigidArray where Element: Copyable {
   @_alwaysEmitIntoClient
   internal mutating func replaceSubrange(
     _ subrange: Range<Int>,
-    copying newElements: __owned some Collection<Element>
+    copying newElements: consuming some Collection<Element>
   ) {
     _replaceSubrange(
       subrange,

--- a/stdlib/public/core/RigidArray/RigidArray.swift
+++ b/stdlib/public/core/RigidArray/RigidArray.swift
@@ -1,0 +1,452 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2024 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if !COLLECTIONS_SINGLE_MODULE
+import InternalCollectionsUtilities
+import ContainersPreview
+#endif
+
+#if compiler(<6.2)
+
+/// A fixed capacity, heap allocated, noncopyable array of potentially
+/// noncopyable elements.
+@frozen
+@available(*, unavailable, message: "RigidArray requires a Swift 6.2 toolchain")
+public struct RigidArray<Element: ~Copyable>: ~Copyable {
+  @usableFromInline
+  internal var _storage: UnsafeMutableBufferPointer<Element>
+
+  @usableFromInline
+  internal var _count: Int
+
+  deinit {
+    _storage.extracting(0 ..< _count).deinitialize()
+    _storage.deallocate()
+  }
+
+  public init() {
+    fatalError()
+  }
+}
+
+#else
+
+/// A fixed capacity, heap allocated, noncopyable array of potentially
+/// noncopyable elements.
+///
+/// `RigidArray` instances are created with a specific maximum capacity. Elements
+/// can be added to the array up to that capacity, but no more: trying to add an
+/// item to a full array results in a runtime trap.
+///
+///      var items = RigidArray<Int>(capacity: 2)
+///      items.append(1)
+///      items.append(2)
+///      items.append(3) // Runtime error: RigidArray capacity overflow
+///
+/// Rigid arrays provide convenience properties to help verify that it has
+/// enough available capacity: `isFull` and `freeCapacity`.
+///
+///     guard items.freeCapacity >= 4 else { throw CapacityOverflow() }
+///     items.append(copying: newItems)
+///
+/// It is possible to extend or shrink the capacity of a rigid array instance,
+/// but this needs to be done explicitly, with operations dedicated to this
+/// purpose (such as ``reserveCapacity`` and ``reallocate(capacity:)``).
+/// The array never resizes itself automatically.
+///
+/// It therefore requires careful manual analysis or up front runtime capacity
+/// checks to prevent the array from overflowing its storage. This makes
+/// this type more difficult to use than a dynamic array. However, it allows
+/// this construct to provide predictably stable performance.
+///
+/// This trading of usability in favor of stable performance limits `RigidArray`
+/// to the most resource-constrained of use cases, such as space-constrained
+/// environments that require carefully accounting of every heap allocation, or
+/// time-constrained applications that cannot accommodate unexpected latency
+/// spikes due to a reallocation getting triggered at an inopportune moment.
+///
+/// For use cases outside of these narrow domains, we generally recommmend
+/// the use of ``UniqueArray`` rather than `RigidArray`. (For copyable elements,
+/// the standard `Array` is an even more convenient choice.)
+@available(SwiftStdlib 5.0, *)
+@safe
+@frozen
+public struct RigidArray<Element: ~Copyable>: ~Copyable {
+  @usableFromInline
+  internal var _storage: UnsafeMutableBufferPointer<Element>
+
+  @usableFromInline
+  internal var _count: Int
+
+  @_alwaysEmitIntoClient
+  deinit {
+    unsafe _storage.extracting(0 ..< _count).deinitialize()
+    unsafe _storage.deallocate()
+  }
+  
+  @_alwaysEmitIntoClient
+  package init(_storage: UnsafeMutableBufferPointer<Element>, count: Int) {
+    self._storage = _storage
+    self._count = count
+  }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray: @unchecked Sendable where Element: Sendable & ~Copyable {}
+
+
+//MARK: - Basics
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray where Element: ~Copyable {
+  /// The maximum number of elements this rigid array can hold.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  @_transparent
+  public var capacity: Int { _assumeNonNegative(unsafe _storage.count) }
+
+  /// The number of additional elements that can be added to this array without
+  /// exceeding its storage capacity.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  @_transparent
+  public var freeCapacity: Int {
+    _assumeNonNegative(capacity &- count)
+  }
+
+  /// A Boolean value indicating whether this rigid array is fully populated.
+  /// If this property returns true, then the array's storage is at capacity,
+  /// and it cannot accommodate any additional elements.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  @inline(__always)
+  public var isFull: Bool { freeCapacity == 0 }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray where Element: ~Copyable {
+  @inlinable
+  internal var _items: UnsafeMutableBufferPointer<Element> {
+    unsafe _storage.extracting(Range(uncheckedBounds: (0, _count)))
+  }
+
+  @inlinable
+  internal var _freeSpace: UnsafeMutableBufferPointer<Element> {
+    unsafe _storage.extracting(Range(uncheckedBounds: (_count, capacity)))
+  }
+}
+
+//MARK: - Span creation
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray where Element: ~Copyable {
+  /// A span over the elements of this array, providing direct read-only access.
+  ///
+  /// - Complexity: O(1)
+  public var span: Span<Element> {
+    @_lifetime(borrow self)
+    @inlinable
+    get {
+      let result = unsafe Span(_unsafeElements: _items)
+      return unsafe _overrideLifetime(result, borrowing: self)
+    }
+  }
+
+  /// A mutable span over the elements of this array, providing direct
+  /// mutating access.
+  ///
+  /// - Complexity: O(1)
+  public var mutableSpan: MutableSpan<Element> {
+    @_lifetime(&self)
+    @inlinable
+    mutating get {
+      let result = unsafe MutableSpan(_unsafeElements: _items)
+      return unsafe _overrideLifetime(result, mutating: &self)
+    }
+  }
+
+  @inlinable
+  @_lifetime(borrow self)
+  internal func _span(in range: Range<Int>) -> Span<Element> {
+    span.extracting(range)
+  }
+
+  @inlinable
+  @_lifetime(&self)
+  internal mutating func _mutableSpan(
+    in range: Range<Int>
+  ) -> MutableSpan<Element> {
+    let result = unsafe MutableSpan(_unsafeElements: _items.extracting(range))
+    return unsafe _overrideLifetime(result, mutating: &self)
+  }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray where Element: ~Copyable {
+  /// Arbitrarily edit the storage underlying this array by invoking a
+  /// user-supplied closure with a mutable `OutputSpan` view over it.
+  /// This method calls its function argument at most once, allowing it to
+  /// arbitrarily modify the contents of the output span it is given.
+  /// The argument is free to add, remove or reorder any items; however,
+  /// it is not allowed to replace the span or change its capacity.
+  ///
+  /// When the function argument finishes (whether by returning or throwing an
+  /// error) the rigid array instance is updated to match the final contents of
+  /// the output span.
+  ///
+  /// - Parameter body: A function that edits the contents of this array through
+  ///    an `OutputSpan` argument. This method invokes this function
+  ///    at most once.
+  /// - Returns: This method returns the result of its function argument.
+  /// - Complexity: Adds O(1) overhead to the complexity of the function
+  ///    argument.
+  @inlinable
+  public mutating func edit<E: Error, R: ~Copyable>(
+    _ body: (inout OutputSpan<Element>) throws(E) -> R
+  ) throws(E) -> R {
+    var span = OutputSpan(buffer: _storage, initializedCount: _count)
+    defer {
+      _count = span.finalize(for: _storage)
+      span = OutputSpan()
+    }
+    return try body(&span)
+  }
+
+  // FIXME: Stop using and remove this in favor of `edit`
+  @unsafe
+  @inlinable
+  internal mutating func _unsafeEdit<E: Error, R: ~Copyable>(
+    _ body: (UnsafeMutableBufferPointer<Element>, inout Int) throws(E) -> R
+  ) throws(E) -> R {
+    defer { precondition(_count >= 0 && _count <= capacity) }
+    return unsafe try body(_storage, &_count)
+  }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray where Element: ~Copyable {
+  @inlinable
+  internal func _contiguousSubrange(following index: inout Int) -> Range<Int> {
+    precondition(index >= 0 && index <= _count, "Index out of bounds")
+    defer { index = _count }
+    return unsafe Range(uncheckedBounds: (index, _count))
+  }
+
+  @inlinable
+  internal func _contiguousSubrange(preceding index: inout Int) -> Range<Int> {
+    precondition(index >= 0 && index <= _count, "Index out of bounds")
+    defer { index = 0 }
+    return unsafe Range(uncheckedBounds: (0, index))
+  }
+}
+
+//MARK: - Container primitives
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray where Element: ~Copyable {
+  /// Return a borrowing span over the maximal storage chunk following the
+  /// specified position in the array. The span provides direct read-only access
+  /// to all array elements in the range `index ..< count`.
+  ///
+  /// - Parameter index: A valid index in the array, including the end index.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  @_lifetime(borrow self)
+  public func span(after index: inout Int) -> Span<Element> {
+    _span(in: _contiguousSubrange(following: &index))
+  }
+
+  /// Return a borrowing span over the maximal storage chunk preceding the
+  /// specified position in the array. The span provides direct read-only access
+  /// to all array elements in the range `0 ..< index`.
+  ///
+  /// - Parameter index: A valid index in the array, including the end index.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  @_lifetime(borrow self)
+  public func span(before index: inout Int) -> Span<Element> {
+    _span(in: _contiguousSubrange(preceding: &index))
+  }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray where Element: ~Copyable {
+  /// Return a mutable span over the maximal storage chunk following the
+  /// specified position in the array. The span provides direct mutating access
+  /// to all array elements in the range `index ..< count`.
+  ///
+  /// - Parameter index: A valid index in the array, including the end index.
+  ///
+  /// - Complexity: O(1)
+  @_lifetime(&self)
+  public mutating func mutableSpan(
+    after index: inout Int
+  ) -> MutableSpan<Element> {
+    _mutableSpan(in: _contiguousSubrange(following: &index))
+  }
+
+  /// Return a mutable span over the maximal storage chunk preceding the specified
+  /// position in the array. The span provides direct mutating access to all
+  /// array elements in the range `0 ..< index`.
+  ///
+  /// - Parameter index: A valid index in the array, including the end index.
+  ///
+  /// - Complexity: O(1)
+  @_lifetime(&self)
+  public mutating func mutableSpan(
+    before index: inout Int
+  ) -> MutableSpan<Element> {
+    _mutableSpan(in: _contiguousSubrange(preceding: &index))
+  }
+}
+
+//MARK: - Resizing
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray where Element: ~Copyable {
+  /// Grow or shrink the capacity of a rigid array instance without discarding
+  /// its contents.
+  ///
+  /// This operation replaces the array's storage buffer with a newly allocated
+  /// buffer of the specified capacity, moving all existing elements
+  /// to its new storage. The old storage is then deallocated.
+  ///
+  /// - Parameter newCapacity: The desired new capacity. `newCapacity` must be
+  ///    greater than or equal to the current count.
+  ///
+  /// - Complexity: O(`count`)
+  @inlinable
+  public mutating func reallocate(capacity newCapacity: Int) {
+    precondition(newCapacity >= count, "RigidArray capacity overflow")
+    guard newCapacity != capacity else { return }
+    let newStorage: UnsafeMutableBufferPointer<Element> = .allocate(
+      capacity: newCapacity)
+    let i = unsafe newStorage.moveInitialize(fromContentsOf: self._items)
+    assert(i == count)
+    unsafe _storage.deallocate()
+    unsafe _storage = newStorage
+  }
+
+  /// Ensure that the array has capacity to store the specified number of
+  /// elements, by growing its storage buffer if necessary.
+  ///
+  /// If `capacity < n`, then this operation reallocates the rigid array's
+  /// storage to grow it; on return, the array's capacity becomes `n`.
+  /// Otherwise the array is left as is.
+  ///
+  /// - Complexity: O(`count`)
+  @inlinable
+  public mutating func reserveCapacity(_ n: Int) {
+    guard capacity < n else { return }
+    reallocate(capacity: n)
+  }
+}
+
+//MARK: - Copying helpers
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray {
+  /// Copy the contents of this array into a newly allocated rigid array
+  /// instance with just enough capacity to hold all its elements.
+  ///
+  /// - Complexity: O(`count`)
+  @_alwaysEmitIntoClient
+  public func clone() -> Self {
+    clone(capacity: self.count)
+  }
+  
+  /// Copy the contents of this array into a newly allocated rigid array
+  /// instance with the specified capacity.
+  ///
+  /// - Parameter capacity: The desired capacity of the resulting rigid array.
+  ///    `capacity` must be greater than or equal to `count`.
+  ///
+  /// - Complexity: O(`count`)
+  @inlinable
+  public func clone(capacity: Int) -> Self {
+    precondition(capacity >= count, "RigidArray capacity overflow")
+    var result = RigidArray<Element>(capacity: capacity)
+    let initialized = unsafe result._storage.initialize(fromContentsOf: _items)
+    precondition(initialized == count)
+    result._count = count
+    return result
+  }
+}
+
+
+//MARK: - Opening and closing gaps
+
+@available(SwiftStdlib 5.0, *)
+extension RigidArray where Element: ~Copyable {
+  @inlinable
+  internal mutating func _closeGap(
+    at index: Int, count: Int
+  ) {
+    guard count > 0 else { return }
+    let source = unsafe _storage.extracting(
+      Range(uncheckedBounds: (index + count, _count)))
+    let target = unsafe _storage.extracting(
+      Range(uncheckedBounds: (index, index + source.count)))
+    let i = unsafe target.moveInitialize(fromContentsOf: source)
+    assert(i == target.endIndex)
+  }
+
+  @inlinable
+  @unsafe
+  internal mutating func _openGap(
+    at index: Int, count: Int
+  ) -> UnsafeMutableBufferPointer<Element> {
+    assert(index >= 0 && index <= _count)
+    assert(count <= freeCapacity)
+    guard count > 0 else { return unsafe _storage.extracting(index ..< index) }
+    let source = unsafe _storage.extracting(
+      Range(uncheckedBounds: (index, _count)))
+    let target = unsafe _storage.extracting(
+      Range(uncheckedBounds: (index + count, _count + count)))
+    let i = unsafe target.moveInitialize(fromContentsOf: source)
+    assert(i == target.count)
+    return unsafe _storage.extracting(
+      Range(uncheckedBounds: (index, index + count)))
+  }
+  
+  /// Resize the gap in the given subrange to have the specified count.
+  /// This operation moves elements following the gap to be at their expected
+  /// new location, and it adjusts the container's count to reflect the change.
+  ///
+  /// - Returns: A buffer pointer addressing the newly opened gap, to be
+  ///     initialized by the caller.
+  @inlinable
+  @unsafe
+  internal mutating func _resizeGap(
+    in subrange: Range<Int>, to newItemCount: Int
+  ) -> UnsafeMutableBufferPointer<Element> {
+    assert(subrange.lowerBound >= 0 && subrange.upperBound <= _count)
+    assert(newItemCount >= 0 && newItemCount - subrange.count <= freeCapacity)
+    if newItemCount > subrange.count {
+      _ = unsafe _openGap(
+        at: subrange.upperBound, count: newItemCount - subrange.count)
+    } else if newItemCount < subrange.count {
+      _closeGap(
+        at: subrange.lowerBound + newItemCount, count: subrange.count - newItemCount)
+    }
+    _count += newItemCount - subrange.count
+    let gapRange = unsafe Range(
+      uncheckedBounds: (subrange.lowerBound, subrange.lowerBound + newItemCount))
+    return unsafe _storage.extracting(gapRange)
+  }
+}
+
+#endif

--- a/stdlib/public/core/RigidArray/RigidArray.swift
+++ b/stdlib/public/core/RigidArray/RigidArray.swift
@@ -75,26 +75,6 @@ extension RigidArray: @unchecked Sendable where Element: Sendable & ~Copyable {}
 
 @available(SwiftStdlib 6.4, *)
 extension RigidArray where Element: ~Copyable {
-  /// A Boolean value indicating whether this array contains no elements.
-  ///
-  /// - Complexity: O(1)
-  @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
-  @_transparent
-  public var isEmpty: Bool {
-    count == 0
-  }
-
-  /// The number of elements in this array.
-  ///
-  /// - Complexity: O(1)
-  @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
-  @_transparent
-  public var count: Int {
-    _count
-  }
-
   /// The maximum number of elements this rigid array can hold.
   ///
   /// - Complexity: O(1)

--- a/stdlib/public/core/RigidArray/RigidArray.swift
+++ b/stdlib/public/core/RigidArray/RigidArray.swift
@@ -231,68 +231,6 @@ extension RigidArray where Element: ~Copyable {
 
 @available(SwiftStdlib 6.4, *)
 extension RigidArray where Element: ~Copyable {
-  /// Return a borrowing span over the maximal storage chunk following the
-  /// specified position in the array. The span provides direct read-only access
-  /// to all array elements in the range `index ..< count`.
-  ///
-  /// - Parameter index: A valid index in the array, including the end index.
-  ///
-  /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
-  @_lifetime(borrow self)
-  internal func span(after index: inout Int) -> Span<Element> {
-    _span(in: _contiguousSubrange(following: &index))
-  }
-
-  /// Return a borrowing span over the maximal storage chunk preceding the
-  /// specified position in the array. The span provides direct read-only access
-  /// to all array elements in the range `0 ..< index`.
-  ///
-  /// - Parameter index: A valid index in the array, including the end index.
-  ///
-  /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
-  @_lifetime(borrow self)
-  internal func span(before index: inout Int) -> Span<Element> {
-    _span(in: _contiguousSubrange(preceding: &index))
-  }
-}
-
-@available(SwiftStdlib 6.4, *)
-extension RigidArray where Element: ~Copyable {
-  /// Return a mutable span over the maximal storage chunk following the
-  /// specified position in the array. The span provides direct mutating access
-  /// to all array elements in the range `index ..< count`.
-  ///
-  /// - Parameter index: A valid index in the array, including the end index.
-  ///
-  /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
-  @_lifetime(&self)
-  internal mutating func mutableSpan(
-    after index: inout Int
-  ) -> MutableSpan<Element> {
-    _mutableSpan(in: _contiguousSubrange(following: &index))
-  }
-
-  /// Return a mutable span over the maximal storage chunk preceding the specified
-  /// position in the array. The span provides direct mutating access to all
-  /// array elements in the range `0 ..< index`.
-  ///
-  /// - Parameter index: A valid index in the array, including the end index.
-  ///
-  /// - Complexity: O(1)
-  @_alwaysEmitIntoClient
-  @_lifetime(&self)
-  public mutating func mutableSpan(
-    before index: inout Int
-  ) -> MutableSpan<Element> {
-    _mutableSpan(in: _contiguousSubrange(preceding: &index))
-  }
-}
-
-@available(SwiftStdlib 6.4, *)
-extension RigidArray where Element: ~Copyable {
   /// Grow or shrink the capacity of a rigid array instance without discarding
   /// its contents.
   ///

--- a/stdlib/public/core/RigidArray/RigidArray.swift
+++ b/stdlib/public/core/RigidArray/RigidArray.swift
@@ -50,7 +50,8 @@
 @available(SwiftStdlib 6.4, *)
 @frozen
 @safe
-public struct RigidArray<Element: ~Copyable>: ~Copyable {
+@usableFromInline
+internal struct _RigidArray<Element: ~Copyable>: ~Copyable {
   @usableFromInline
   internal var _storage: UnsafeMutableBufferPointer<Element>
 
@@ -71,17 +72,17 @@ public struct RigidArray<Element: ~Copyable>: ~Copyable {
 }
 
 @available(SwiftStdlib 6.4, *)
-extension RigidArray: @unchecked Sendable where Element: Sendable & ~Copyable {}
+extension _RigidArray: @unchecked Sendable where Element: Sendable & ~Copyable {}
 
 @available(SwiftStdlib 6.4, *)
-extension RigidArray where Element: ~Copyable {
+extension _RigidArray where Element: ~Copyable {
   /// The maximum number of elements this rigid array can hold.
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   @_transparent
-  public var capacity: Int {
+  internal var capacity: Int {
     _assumeNonNegative(unsafe _storage.count)
   }
 
@@ -92,7 +93,7 @@ extension RigidArray where Element: ~Copyable {
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   @_transparent
-  public var freeCapacity: Int {
+  internal var freeCapacity: Int {
     _assumeNonNegative(capacity &- count)
   }
 
@@ -104,13 +105,13 @@ extension RigidArray where Element: ~Copyable {
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   @_transparent
-  public var isFull: Bool {
+  internal var isFull: Bool {
     freeCapacity == 0
   }
 }
 
 @available(SwiftStdlib 6.4, *)
-extension RigidArray where Element: ~Copyable {
+extension _RigidArray where Element: ~Copyable {
   @_alwaysEmitIntoClient
   internal var _items: UnsafeMutableBufferPointer<Element> {
     unsafe _storage.extracting(Range(uncheckedBounds: (0, _count)))
@@ -123,14 +124,14 @@ extension RigidArray where Element: ~Copyable {
 }
 
 @available(SwiftStdlib 6.4, *)
-extension RigidArray where Element: ~Copyable {
+extension _RigidArray where Element: ~Copyable {
   /// A span over the elements of this array, providing direct read-only access.
   ///
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   @_transparent
-  public var span: Span<Element> {
+  internal var span: Span<Element> {
     @_lifetime(borrow self)
     get {
       let result = unsafe Span(_unsafeElements: _items)
@@ -145,7 +146,7 @@ extension RigidArray where Element: ~Copyable {
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   @_transparent
-  public var mutableSpan: MutableSpan<Element> {
+  internal var mutableSpan: MutableSpan<Element> {
     @_lifetime(&self)
     mutating get {
       let result = unsafe MutableSpan(_unsafeElements: _items)
@@ -170,7 +171,7 @@ extension RigidArray where Element: ~Copyable {
 }
 
 @available(SwiftStdlib 6.4, *)
-extension RigidArray where Element: ~Copyable {
+extension _RigidArray where Element: ~Copyable {
   /// Arbitrarily edit the storage underlying this array by invoking a
   /// user-supplied closure with a mutable `OutputSpan` view over it.
   /// This method calls its function argument at most once, allowing it to
@@ -190,7 +191,7 @@ extension RigidArray where Element: ~Copyable {
   ///    argument.
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func edit<E: Error, R: ~Copyable>(
+  internal mutating func edit<E: Error, R: ~Copyable>(
     _ body: (inout OutputSpan<Element>) throws(E) -> R
   ) throws(E) -> R {
     var span = unsafe OutputSpan(buffer: _storage, initializedCount: _count)
@@ -213,7 +214,7 @@ extension RigidArray where Element: ~Copyable {
 }
 
 @available(SwiftStdlib 6.4, *)
-extension RigidArray where Element: ~Copyable {
+extension _RigidArray where Element: ~Copyable {
   @_alwaysEmitIntoClient
   internal func _contiguousSubrange(following index: inout Int) -> Range<Int> {
     _precondition(index >= 0 && index <= _count, "Index out of bounds")
@@ -230,7 +231,7 @@ extension RigidArray where Element: ~Copyable {
 }
 
 @available(SwiftStdlib 6.4, *)
-extension RigidArray where Element: ~Copyable {
+extension _RigidArray where Element: ~Copyable {
   /// Grow or shrink the capacity of a rigid array instance without discarding
   /// its contents.
   ///
@@ -244,7 +245,7 @@ extension RigidArray where Element: ~Copyable {
   /// - Complexity: O(`count`)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func reallocate(capacity newCapacity: Int) {
+  internal mutating func reallocate(capacity newCapacity: Int) {
     _precondition(newCapacity >= count, "RigidArray capacity overflow")
     guard newCapacity != capacity else { return }
     let newStorage: UnsafeMutableBufferPointer<Element> = .allocate(
@@ -265,21 +266,21 @@ extension RigidArray where Element: ~Copyable {
   /// - Complexity: O(`count`)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func reserveCapacity(_ n: Int) {
+  internal mutating func reserveCapacity(_ n: Int) {
     guard capacity < n else { return }
     reallocate(capacity: n)
   }
 }
 
 @available(SwiftStdlib 6.4, *)
-extension RigidArray {
+extension _RigidArray {
   /// Copy the contents of this array into a newly allocated rigid array
   /// instance with just enough capacity to hold all its elements.
   ///
   /// - Complexity: O(`count`)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public func clone() -> Self {
+  internal func clone() -> Self {
     clone(capacity: self.count)
   }
   
@@ -292,9 +293,9 @@ extension RigidArray {
   /// - Complexity: O(`count`)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public func clone(capacity: Int) -> Self {
+  internal func clone(capacity: Int) -> Self {
     _precondition(capacity >= count, "RigidArray capacity overflow")
-    var result = RigidArray<Element>(capacity: capacity)
+    var result = Self(capacity: capacity)
     let initialized = unsafe result._storage.initialize(fromContentsOf: _items)
     _precondition(initialized == count)
     result._count = count
@@ -303,7 +304,7 @@ extension RigidArray {
 }
 
 @available(SwiftStdlib 6.4, *)
-extension RigidArray where Element: ~Copyable {
+extension _RigidArray where Element: ~Copyable {
   @_alwaysEmitIntoClient
   internal mutating func _closeGap(
     at index: Int, count: Int

--- a/stdlib/public/core/RigidArray/RigidArray.swift
+++ b/stdlib/public/core/RigidArray/RigidArray.swift
@@ -207,7 +207,7 @@ extension RigidArray where Element: ~Copyable {
   internal mutating func _unsafeEdit<E: Error, R: ~Copyable>(
     _ body: (UnsafeMutableBufferPointer<Element>, inout Int) throws(E) -> R
   ) throws(E) -> R {
-    defer { precondition(_count >= 0 && _count <= capacity) }
+    defer { _precondition(_count >= 0 && _count <= capacity) }
     return unsafe try body(_storage, &_count)
   }
 }
@@ -216,14 +216,14 @@ extension RigidArray where Element: ~Copyable {
 extension RigidArray where Element: ~Copyable {
   @_alwaysEmitIntoClient
   internal func _contiguousSubrange(following index: inout Int) -> Range<Int> {
-    precondition(index >= 0 && index <= _count, "Index out of bounds")
+    _precondition(index >= 0 && index <= _count, "Index out of bounds")
     defer { index = _count }
     return unsafe Range(uncheckedBounds: (index, _count))
   }
 
   @_alwaysEmitIntoClient
   internal func _contiguousSubrange(preceding index: inout Int) -> Range<Int> {
-    precondition(index >= 0 && index <= _count, "Index out of bounds")
+    _precondition(index >= 0 && index <= _count, "Index out of bounds")
     defer { index = 0 }
     return unsafe Range(uncheckedBounds: (0, index))
   }
@@ -245,7 +245,7 @@ extension RigidArray where Element: ~Copyable {
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   public mutating func reallocate(capacity newCapacity: Int) {
-    precondition(newCapacity >= count, "RigidArray capacity overflow")
+    _precondition(newCapacity >= count, "RigidArray capacity overflow")
     guard newCapacity != capacity else { return }
     let newStorage: UnsafeMutableBufferPointer<Element> = .allocate(
       capacity: newCapacity)
@@ -293,10 +293,10 @@ extension RigidArray {
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   public func clone(capacity: Int) -> Self {
-    precondition(capacity >= count, "RigidArray capacity overflow")
+    _precondition(capacity >= count, "RigidArray capacity overflow")
     var result = RigidArray<Element>(capacity: capacity)
     let initialized = unsafe result._storage.initialize(fromContentsOf: _items)
-    precondition(initialized == count)
+    _precondition(initialized == count)
     result._count = count
     return result
   }
@@ -314,7 +314,7 @@ extension RigidArray where Element: ~Copyable {
     let target = unsafe _storage.extracting(
       Range(uncheckedBounds: (index, index + source.count)))
     let i = unsafe target.moveInitialize(fromContentsOf: source)
-    assert(i == target.endIndex)
+    _internalInvariant(i == target.endIndex)
   }
 
   @unsafe
@@ -322,15 +322,15 @@ extension RigidArray where Element: ~Copyable {
   internal mutating func _openGap(
     at index: Int, count: Int
   ) -> UnsafeMutableBufferPointer<Element> {
-    assert(index >= 0 && index <= _count)
-    assert(count <= freeCapacity)
+    _internalInvariant(index >= 0 && index <= _count)
+    _internalInvariant(count <= freeCapacity)
     guard count > 0 else { return unsafe _storage.extracting(index ..< index) }
     let source = unsafe _storage.extracting(
       Range(uncheckedBounds: (index, _count)))
     let target = unsafe _storage.extracting(
       Range(uncheckedBounds: (index + count, _count + count)))
     let i = unsafe target.moveInitialize(fromContentsOf: source)
-    assert(i == target.count)
+    _internalInvariant(i == target.count)
     return unsafe _storage.extracting(
       Range(uncheckedBounds: (index, index + count)))
   }
@@ -346,8 +346,8 @@ extension RigidArray where Element: ~Copyable {
   internal mutating func _resizeGap(
     in subrange: Range<Int>, to newItemCount: Int
   ) -> UnsafeMutableBufferPointer<Element> {
-    assert(subrange.lowerBound >= 0 && subrange.upperBound <= _count)
-    assert(newItemCount >= 0 && newItemCount - subrange.count <= freeCapacity)
+    _internalInvariant(subrange.lowerBound >= 0 && subrange.upperBound <= _count)
+    _internalInvariant(newItemCount >= 0 && newItemCount - subrange.count <= freeCapacity)
     if newItemCount > subrange.count {
       _ = unsafe _openGap(
         at: subrange.upperBound, count: newItemCount - subrange.count)

--- a/stdlib/public/core/Span/OutputSpan.swift
+++ b/stdlib/public/core/Span/OutputSpan.swift
@@ -570,7 +570,7 @@ extension OutputSpan where Element: Copyable {
   @_alwaysEmitIntoClient
   @_lifetime(self: copy self)
   internal mutating func _append(copying source: Span<Element>) {
-    unsafe source.withUnsafeBufferPointer { buffer in
+    source.withUnsafeBufferPointer { buffer in
       unsafe self._append(copying: buffer)
     }
   }

--- a/stdlib/public/core/Span/OutputSpan.swift
+++ b/stdlib/public/core/Span/OutputSpan.swift
@@ -519,3 +519,59 @@ extension OutputSpan {
     unsafe finalize(for: UnsafeMutableBufferPointer(rebasing: buffer))
   }
 }
+
+@available(SwiftCompatibilitySpan 5.0, *)
+@_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
+extension OutputSpan where Element: ~Copyable {
+  @_alwaysEmitIntoClient
+  @_lifetime(self: copy self)
+  internal mutating func _append(
+    moving source: UnsafeMutableBufferPointer<Element>
+  ) {
+    guard source.count > 0 else { return }
+    unsafe self.withUnsafeMutableBufferPointer { dst, dstCount in
+      let dstEnd = dstCount + source.count
+      precondition(dstEnd <= dst.count, "OutputSpan capacity overflow")
+      unsafe dst
+        ._extracting(uncheckedFrom: dstCount, to: dstEnd)
+        ._moveInitializeAll(fromContentsOf: source)
+      dstCount &+= source.count
+    }
+  }
+
+  @_alwaysEmitIntoClient
+  @_lifetime(self: copy self)
+  @_lifetime(source: copy source)
+  internal mutating func _append(moving source: inout OutputSpan<Element>) {
+    unsafe source.withUnsafeMutableBufferPointer { src, srcCount in
+      let items = unsafe src._extracting(uncheckedFrom: 0, to: srcCount)
+      unsafe self._append(moving: items)
+      srcCount = 0
+    }
+  }
+}
+
+@available(SwiftCompatibilitySpan 5.0, *)
+@_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
+extension OutputSpan where Element: Copyable {
+  @_alwaysEmitIntoClient
+  @_lifetime(self: copy self)
+  internal mutating func _append(copying source: UnsafeBufferPointer<Element>) {
+    unsafe self.withUnsafeMutableBufferPointer { dst, dstCount in
+      let dstEnd = dstCount + source.count
+      precondition(dstEnd <= dst.count, "OutputSpan capacity overflow")
+      unsafe dst
+        ._extracting(uncheckedFrom: dstCount, to: dstEnd)
+        ._initializeAll(fromContentsOf: source)
+      dstCount &+= source.count
+    }
+  }
+
+  @_alwaysEmitIntoClient
+  @_lifetime(self: copy self)
+  internal mutating func _append(copying source: Span<Element>) {
+    unsafe source.withUnsafeBufferPointer { buffer in
+      unsafe self._append(copying: buffer)
+    }
+  }
+}

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -1012,8 +1012,8 @@ extension Span: BorrowingSequence where Element: ~Copyable {
 extension Span where Element: Equatable & ~Copyable {
   @_alwaysEmitIntoClient
   internal func _elementsEqual(to other: borrowing Self) -> Bool {
-    return unsafe self.withUnsafeBufferPointer { a in
-      unsafe other.withUnsafeBufferPointer { b in
+    return self.withUnsafeBufferPointer { a in
+      other.withUnsafeBufferPointer { b in
         guard a.count == b.count else { return false }
         guard unsafe a.baseAddress != b.baseAddress else { return true }
         var i = 0

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -1006,3 +1006,38 @@ extension Span: BorrowingSequence where Element: ~Copyable {
   }
 }
 #endif
+
+@available(SwiftCompatibilitySpan 5.0, *)
+@_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
+extension Span where Element: Equatable & ~Copyable {
+  @_alwaysEmitIntoClient
+  internal func _elementsEqual(to other: borrowing Self) -> Bool {
+    return unsafe self.withUnsafeBufferPointer { a in
+      unsafe other.withUnsafeBufferPointer { b in
+        guard a.count == b.count else { return false }
+        guard unsafe a.baseAddress != b.baseAddress else { return true }
+        var i = 0
+        while i < self.count {
+          guard unsafe a[i] == b[i] else { return false }
+          i &+= 1
+        }
+        return true
+      }
+    }
+  }
+}
+
+@available(SwiftCompatibilitySpan 5.0, *)
+@_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
+extension Span where Element: Hashable & ~Copyable {
+  @_alwaysEmitIntoClient
+  internal func _hashContents(into hasher: inout Hasher) {
+    // Note: no discriminating combine call -- caller is expected to do that
+    // separately when needed.
+    var i = 0
+    while i < self.count {
+      hasher.combine(unsafe self[unchecked: i])
+      i &+= 1
+    }
+  }
+}

--- a/stdlib/public/core/Stride.swift
+++ b/stdlib/public/core/Stride.swift
@@ -288,6 +288,33 @@ extension Strideable where Self: FloatingPoint, Self == Stride {
   }
 }
 
+extension Strideable {
+  @_alwaysEmitIntoClient
+  internal mutating func _advance(
+    by distance: inout Stride, limitedBy limit: Self
+  ) {
+    if distance >= 0 {
+      guard limit >= self else {
+        self = self.advanced(by: distance)
+        distance = 0
+        return
+      }
+      let d = Swift.min(distance, self.distance(to: limit))
+      self = self.advanced(by: d)
+      distance -= d
+    } else {
+      guard limit <= self else {
+        self = self.advanced(by: distance)
+        distance = 0
+        return
+      }
+      let d = Swift.max(distance, self.distance(to: limit))
+      self = self.advanced(by: d)
+      distance -= d
+    }
+  }
+}
+
 /// An iterator for a `StrideTo` instance.
 @frozen
 public struct StrideToIterator<Element: Strideable> {

--- a/stdlib/public/core/UniqueArray/UniqueArray+Append.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Append.swift
@@ -1,0 +1,336 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2024 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if !COLLECTIONS_SINGLE_MODULE
+import InternalCollectionsUtilities
+import ContainersPreview
+#endif
+
+#if compiler(>=6.2)
+
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray where Element: ~Copyable {
+  /// Adds an element to the end of the array.
+  ///
+  /// If the array does not have sufficient capacity to hold any more elements,
+  /// then this reallocates the array's storage to grow its capacity, using a
+  /// geometric growth rate.
+  ///
+  /// - Parameter item: The element to append to the collection.
+  ///
+  /// - Complexity: O(1) as amortized over many invocations on the same array.
+  @inlinable
+  public mutating func append(_ item: consuming Element) {
+    _ensureFreeCapacity(1)
+    _storage.append(item)
+  }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray where Element: ~Copyable {
+  /// Append a given number of items to the end of this array by populating
+  /// an output span.
+  ///
+  /// If the array does not have sufficient capacity to hold the requested
+  /// number of new elements, then this reallocates the array's storage to
+  /// grow its capacity, using a geometric growth rate.
+  ///
+  /// If the callback fails to fully populate its output span or if
+  /// it throws an error, then the array keeps all items that were
+  /// successfully initialized before the callback terminated the insertion.
+  ///
+  /// - Parameters:
+  ///    - newItemCount: The number of items to append to the array.
+  ///    - initializer: A callback that gets called at most once to directly
+  ///       populate newly reserved storage within the array. The function
+  ///       is allowed to initialize fewer than `uninitializedCount` items.
+  ///       The array is appended however many items the callback adds to the
+  ///       output span before it returns (or before it throws an error).
+  ///
+  /// - Complexity: O(`uninitializedCount`)
+  @_alwaysEmitIntoClient
+  public mutating func append<E: Error>(
+    addingCount newItemCount: Int,
+    initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
+  ) throws(E) {
+    _ensureFreeCapacity(newItemCount)
+    return try _storage.append(
+      addingCount: newItemCount,
+      initializingWith: initializer)
+  }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray where Element: ~Copyable {
+  /// Moves the elements of a buffer to the end of this array, leaving the
+  /// buffer uninitialized.
+  ///
+  /// If the array does not have sufficient capacity to hold all items in the
+  /// buffer, then this reallocates the array's storage to grow its capacity,
+  /// using a geometric growth rate.
+  ///
+  /// - Parameters:
+  ///    - items: A fully initialized buffer whose contents to move into
+  ///        the array.
+  ///
+  /// - Complexity: O(`count` + `items.count`)
+  @_alwaysEmitIntoClient
+  public mutating func append(
+    moving items: UnsafeMutableBufferPointer<Element>
+  ) {
+    _ensureFreeCapacity(items.count)
+    _storage.append(moving: items)
+  }
+  
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+  /// Moves the elements of a input span to the end of this array, leaving the
+  /// span empty.
+  ///
+  /// If the array does not have sufficient capacity to hold all new items,
+  /// then this reallocates the array's storage to grow its capacity,
+  /// using a geometric growth rate.
+  ///
+  /// - Parameters:
+  ///    - items: An input span whose contents need to be appended to this array.
+  ///
+  /// - Complexity: O(`items.count`)
+  @_alwaysEmitIntoClient
+  public mutating func append(
+    moving items: inout InputSpan<Element>
+  ) {
+    _ensureFreeCapacity(items.count)
+    _storage.append(moving: &items)
+  }
+#endif
+
+  /// Moves the elements of a output span to the end of this array, leaving the
+  /// span empty.
+  ///
+  /// If the array does not have sufficient capacity to hold all new items,
+  /// then this reallocates the array's storage to grow its capacity,
+  /// using a geometric growth rate.
+  ///
+  /// - Parameters:
+  ///    - items: An output span whose contents need to be appended to this array.
+  ///
+  /// - Complexity: O(`items.count`)
+  @_alwaysEmitIntoClient
+  public mutating func append(
+    moving items: inout OutputSpan<Element>
+  ) {
+    _ensureFreeCapacity(items.count)
+    _storage.append(moving: &items)
+  }
+
+  /// Appends the elements of a given array to the end of this array by moving
+  /// them between the containers. On return, the input array becomes empty, but
+  /// it is not destroyed, and it preserves its original storage capacity.
+  ///
+  /// If the target array does not have sufficient capacity to hold all items
+  /// in the source array, then this automatically grows the target array's
+  /// capacity, using a geometric growth rate.
+  ///
+  /// - Parameters:
+  ///    - items: An array whose items to move to the end of this array.
+  ///
+  /// - Complexity: O(`items.count`) when amortized over many invocations on
+  ///     the same array
+  @_alwaysEmitIntoClient
+  public mutating func append(
+    moving items: inout RigidArray<Element>
+  ) {
+    // FIXME: Remove this in favor of a generic algorithm over range-replaceable containers
+    _ensureFreeCapacity(items.count)
+    _storage.append(moving: &items)
+  }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray where Element: ~Copyable {
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+  /// Appends the elements of a given container to the end of this array by
+  /// consuming the source container.
+  ///
+  /// If the target array does not have sufficient capacity to hold all items
+  /// in the source array, then this automatically grows the target array's
+  /// capacity, using a geometric growth rate.
+  ///
+  /// - Parameters:
+  ///    - items: An array whose items to move to the end of this array.
+  ///
+  /// - Complexity: O(`items.count`)
+  @_alwaysEmitIntoClient
+  public mutating func append(
+    consuming items: consuming RigidArray<Element>
+  ) {
+    // FIXME: Remove this in favor of a generic algorithm over consumable containers
+    var items = items
+    self.append(moving: &items)
+  }
+#endif
+}
+
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray {
+  /// Copies the elements of a buffer to the end of this array.
+  ///
+  /// If the array does not have sufficient capacity to hold all items
+  /// in the source buffer, then this automatically grows the array's
+  /// capacity, using a geometric growth rate.
+  ///
+  /// - Parameters:
+  ///    - newElements: A fully initialized buffer whose contents to copy into
+  ///       the array.
+  ///
+  /// - Complexity: O(`newElements.count`) when amortized over many
+  ///     invocations on the same array.
+  @_alwaysEmitIntoClient
+  public mutating func append(
+    copying newElements: UnsafeBufferPointer<Element>
+  ) {
+    _ensureFreeCapacity(newElements.count)
+    unsafe _storage.append(copying: newElements)
+  }
+
+  /// Copies the elements of a buffer to the end of this array.
+  ///
+  /// If the array does not have sufficient capacity to hold enough elements,
+  /// then this reallocates the array's storage to extend its capacity, using
+  /// a geometric growth rate.
+  ///
+  /// - Parameters:
+  ///    - newElements: A fully initialized buffer whose contents to copy into
+  ///       the array.
+  ///
+  /// - Complexity: O(`newElements.count`) when amortized over many
+  ///     invocations on the same array.
+  @_alwaysEmitIntoClient
+  public mutating func append(
+    copying newElements: UnsafeMutableBufferPointer<Element>
+  ) {
+    unsafe self.append(copying: UnsafeBufferPointer(newElements))
+  }
+
+  /// Copies the elements of a span to the end of this array.
+  ///
+  /// If the array does not have sufficient capacity to hold enough elements,
+  /// then this reallocates the array's storage to extend its capacity, using a
+  /// geometric growth rate.
+  ///
+  /// - Parameters:
+  ///    - newElements: A span whose contents to copy into the array.
+  ///
+  /// - Complexity: O(`newElements.count`) when amortized over many
+  ///     invocations on the same array.
+  @_alwaysEmitIntoClient
+  public mutating func append(copying newElements: Span<Element>) {
+    _ensureFreeCapacity(newElements.count)
+    _storage.append(copying: newElements)
+  }
+
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+  @inlinable
+  internal mutating func _append<
+    Source: BorrowingSequence<Element> & ~Copyable & ~Escapable
+  >(
+    copying newElements: borrowing Source
+  ) {
+    _ensureFreeCapacity(newElements.underestimatedCount)
+    var it = newElements.makeBorrowingIterator()
+    while true {
+      let span = it.nextSpan()
+      if span.isEmpty { break }
+      _ensureFreeCapacity(span.count)
+      _storage.append(copying: span)
+    }
+  }
+  // FIXME: Add _append(copyingContainer:), forwarding to the same method on RigidArray
+#endif
+
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+  /// Copies the elements of a borrowing sequence to the end of this array.
+  ///
+  /// If the array does not have sufficient capacity to hold enough elements,
+  /// then this reallocates the array's storage to extend its capacity, using
+  /// a geometric growth rate. If the input sequence does not provide a precise
+  /// estimate of its count, then the array's storage may need to be resized
+  /// more than once.
+  ///
+  /// - Parameters:
+  ///    - newElements: A container whose contents to copy into the array.
+  ///
+  /// - Complexity: O(`newElements.count`), when amortized over many invocations
+  ///    over the same array.
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  public mutating func append<
+    Source: BorrowingSequence<Element> & ~Copyable & ~Escapable
+  >(
+    copying newElements: borrowing Source
+  ) {
+    self._append(copying: newElements)
+  }
+
+#endif
+
+  /// Copies the elements of a sequence to the end of this array.
+  ///
+  /// If the array does not have sufficient capacity to hold enough elements,
+  /// then this reallocates the array's storage to extend its capacity, using
+  /// a geometric growth rate. If the input sequence does not provide a precise
+  /// estimate of its count, then the array's storage may need to be resized
+  /// more than once.
+  ///
+  /// - Parameters:
+  ///    - newElements: The new elements to copy into the array.
+  ///
+  /// - Complexity: O(*m*), where *m* is the length of `newElements`, when
+  ///     amortized over many invocations over the same array.
+  @_alwaysEmitIntoClient
+  public mutating func append(copying newElements: some Sequence<Element>) {
+    let done: Void? = newElements.withContiguousStorageIfAvailable { buffer in
+      _ensureFreeCapacity(buffer.count)
+      unsafe _storage.append(copying: buffer)
+      return
+    }
+    if done != nil { return }
+
+    _ensureFreeCapacity(newElements.underestimatedCount)
+    var it = _storage._append(prefixOf: newElements)
+    while let item = it.next() {
+      _ensureFreeCapacity(1)
+      _storage.append(item)
+    }
+  }
+  
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+  /// Copies the elements of a container to the end of this array.
+  ///
+  /// If the array does not have sufficient capacity to hold enough elements,
+  /// then this reallocates the array's storage to extend its capacity, using a
+  /// geometric growth rate.
+  ///
+  /// - Parameters:
+  ///    - newElements: A container whose contents to copy into the array.
+  ///
+  /// - Complexity: O(`newElements.count`), when amortized over many invocations
+  ///    over the same array.
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  public mutating func append<
+    Source: BorrowingSequence<Element> & Sequence<Element>
+  >(copying newElements: Source) {
+    self._append(copying: newElements)
+  }
+#endif
+}
+
+#endif

--- a/stdlib/public/core/UniqueArray/UniqueArray+Append.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Append.swift
@@ -1,22 +1,16 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift Collections open source project
+// This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2024 - 2026 Apple Inc. and the Swift project authors
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 
-#if !COLLECTIONS_SINGLE_MODULE
-import InternalCollectionsUtilities
-import ContainersPreview
-#endif
-
-#if compiler(>=6.2)
-
-@available(SwiftStdlib 5.0, *)
+@available(SwiftStdlib 6.4, *)
 extension UniqueArray where Element: ~Copyable {
   /// Adds an element to the end of the array.
   ///
@@ -27,14 +21,15 @@ extension UniqueArray where Element: ~Copyable {
   /// - Parameter item: The element to append to the collection.
   ///
   /// - Complexity: O(1) as amortized over many invocations on the same array.
-  @inlinable
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public mutating func append(_ item: consuming Element) {
     _ensureFreeCapacity(1)
     _storage.append(item)
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftStdlib 6.4, *)
 extension UniqueArray where Element: ~Copyable {
   /// Append a given number of items to the end of this array by populating
   /// an output span.
@@ -56,6 +51,7 @@ extension UniqueArray where Element: ~Copyable {
   ///       output span before it returns (or before it throws an error).
   ///
   /// - Complexity: O(`uninitializedCount`)
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   public mutating func append<E: Error>(
     addingCount newItemCount: Int,
@@ -68,7 +64,7 @@ extension UniqueArray where Element: ~Copyable {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftStdlib 6.4, *)
 extension UniqueArray where Element: ~Copyable {
   /// Moves the elements of a buffer to the end of this array, leaving the
   /// buffer uninitialized.
@@ -82,34 +78,14 @@ extension UniqueArray where Element: ~Copyable {
   ///        the array.
   ///
   /// - Complexity: O(`count` + `items.count`)
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   public mutating func append(
     moving items: UnsafeMutableBufferPointer<Element>
   ) {
     _ensureFreeCapacity(items.count)
-    _storage.append(moving: items)
+    unsafe _storage.append(moving: items)
   }
-  
-#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
-  /// Moves the elements of a input span to the end of this array, leaving the
-  /// span empty.
-  ///
-  /// If the array does not have sufficient capacity to hold all new items,
-  /// then this reallocates the array's storage to grow its capacity,
-  /// using a geometric growth rate.
-  ///
-  /// - Parameters:
-  ///    - items: An input span whose contents need to be appended to this array.
-  ///
-  /// - Complexity: O(`items.count`)
-  @_alwaysEmitIntoClient
-  public mutating func append(
-    moving items: inout InputSpan<Element>
-  ) {
-    _ensureFreeCapacity(items.count)
-    _storage.append(moving: &items)
-  }
-#endif
 
   /// Moves the elements of a output span to the end of this array, leaving the
   /// span empty.
@@ -122,6 +98,7 @@ extension UniqueArray where Element: ~Copyable {
   ///    - items: An output span whose contents need to be appended to this array.
   ///
   /// - Complexity: O(`items.count`)
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   public mutating func append(
     moving items: inout OutputSpan<Element>
@@ -129,56 +106,9 @@ extension UniqueArray where Element: ~Copyable {
     _ensureFreeCapacity(items.count)
     _storage.append(moving: &items)
   }
-
-  /// Appends the elements of a given array to the end of this array by moving
-  /// them between the containers. On return, the input array becomes empty, but
-  /// it is not destroyed, and it preserves its original storage capacity.
-  ///
-  /// If the target array does not have sufficient capacity to hold all items
-  /// in the source array, then this automatically grows the target array's
-  /// capacity, using a geometric growth rate.
-  ///
-  /// - Parameters:
-  ///    - items: An array whose items to move to the end of this array.
-  ///
-  /// - Complexity: O(`items.count`) when amortized over many invocations on
-  ///     the same array
-  @_alwaysEmitIntoClient
-  public mutating func append(
-    moving items: inout RigidArray<Element>
-  ) {
-    // FIXME: Remove this in favor of a generic algorithm over range-replaceable containers
-    _ensureFreeCapacity(items.count)
-    _storage.append(moving: &items)
-  }
 }
 
-@available(SwiftStdlib 5.0, *)
-extension UniqueArray where Element: ~Copyable {
-#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
-  /// Appends the elements of a given container to the end of this array by
-  /// consuming the source container.
-  ///
-  /// If the target array does not have sufficient capacity to hold all items
-  /// in the source array, then this automatically grows the target array's
-  /// capacity, using a geometric growth rate.
-  ///
-  /// - Parameters:
-  ///    - items: An array whose items to move to the end of this array.
-  ///
-  /// - Complexity: O(`items.count`)
-  @_alwaysEmitIntoClient
-  public mutating func append(
-    consuming items: consuming RigidArray<Element>
-  ) {
-    // FIXME: Remove this in favor of a generic algorithm over consumable containers
-    var items = items
-    self.append(moving: &items)
-  }
-#endif
-}
-
-@available(SwiftStdlib 5.0, *)
+@available(SwiftStdlib 6.4, *)
 extension UniqueArray {
   /// Copies the elements of a buffer to the end of this array.
   ///
@@ -192,6 +122,7 @@ extension UniqueArray {
   ///
   /// - Complexity: O(`newElements.count`) when amortized over many
   ///     invocations on the same array.
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   public mutating func append(
     copying newElements: UnsafeBufferPointer<Element>
@@ -212,6 +143,7 @@ extension UniqueArray {
   ///
   /// - Complexity: O(`newElements.count`) when amortized over many
   ///     invocations on the same array.
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   public mutating func append(
     copying newElements: UnsafeMutableBufferPointer<Element>
@@ -230,56 +162,12 @@ extension UniqueArray {
   ///
   /// - Complexity: O(`newElements.count`) when amortized over many
   ///     invocations on the same array.
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   public mutating func append(copying newElements: Span<Element>) {
     _ensureFreeCapacity(newElements.count)
     _storage.append(copying: newElements)
   }
-
-#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
-  @inlinable
-  internal mutating func _append<
-    Source: BorrowingSequence<Element> & ~Copyable & ~Escapable
-  >(
-    copying newElements: borrowing Source
-  ) {
-    _ensureFreeCapacity(newElements.underestimatedCount)
-    var it = newElements.makeBorrowingIterator()
-    while true {
-      let span = it.nextSpan()
-      if span.isEmpty { break }
-      _ensureFreeCapacity(span.count)
-      _storage.append(copying: span)
-    }
-  }
-  // FIXME: Add _append(copyingContainer:), forwarding to the same method on RigidArray
-#endif
-
-#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
-  /// Copies the elements of a borrowing sequence to the end of this array.
-  ///
-  /// If the array does not have sufficient capacity to hold enough elements,
-  /// then this reallocates the array's storage to extend its capacity, using
-  /// a geometric growth rate. If the input sequence does not provide a precise
-  /// estimate of its count, then the array's storage may need to be resized
-  /// more than once.
-  ///
-  /// - Parameters:
-  ///    - newElements: A container whose contents to copy into the array.
-  ///
-  /// - Complexity: O(`newElements.count`), when amortized over many invocations
-  ///    over the same array.
-  @_alwaysEmitIntoClient
-  @inline(__always)
-  public mutating func append<
-    Source: BorrowingSequence<Element> & ~Copyable & ~Escapable
-  >(
-    copying newElements: borrowing Source
-  ) {
-    self._append(copying: newElements)
-  }
-
-#endif
 
   /// Copies the elements of a sequence to the end of this array.
   ///
@@ -294,6 +182,7 @@ extension UniqueArray {
   ///
   /// - Complexity: O(*m*), where *m* is the length of `newElements`, when
   ///     amortized over many invocations over the same array.
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   public mutating func append(copying newElements: some Sequence<Element>) {
     let done: Void? = newElements.withContiguousStorageIfAvailable { buffer in
@@ -310,27 +199,4 @@ extension UniqueArray {
       _storage.append(item)
     }
   }
-  
-#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
-  /// Copies the elements of a container to the end of this array.
-  ///
-  /// If the array does not have sufficient capacity to hold enough elements,
-  /// then this reallocates the array's storage to extend its capacity, using a
-  /// geometric growth rate.
-  ///
-  /// - Parameters:
-  ///    - newElements: A container whose contents to copy into the array.
-  ///
-  /// - Complexity: O(`newElements.count`), when amortized over many invocations
-  ///    over the same array.
-  @_alwaysEmitIntoClient
-  @inline(__always)
-  public mutating func append<
-    Source: BorrowingSequence<Element> & Sequence<Element>
-  >(copying newElements: Source) {
-    self._append(copying: newElements)
-  }
-#endif
 }
-
-#endif

--- a/stdlib/public/core/UniqueArray/UniqueArray+Append.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Append.swift
@@ -109,7 +109,7 @@ extension UniqueArray where Element: ~Copyable {
 }
 
 @available(SwiftStdlib 6.4, *)
-extension UniqueArray {
+extension UniqueArray where Element: Copyable {
   /// Copies the elements of a buffer to the end of this array.
   ///
   /// If the array does not have sufficient capacity to hold all items

--- a/stdlib/public/core/UniqueArray/UniqueArray+Container.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Container.swift
@@ -1,91 +1,78 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift Collections open source project
+// This source file is part of the Swift.org open source project
 //
 // Copyright (c) 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 
-#if !COLLECTIONS_SINGLE_MODULE
-import InternalCollectionsUtilities
-import ContainersPreview
-#endif
-
-#if compiler(>=6.2)
-
-#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
-@available(SwiftStdlib 5.0, *)
-extension UniqueArray: BorrowingSequence where Element: ~Copyable {
-  public typealias BorrowingIterator = RigidArray<Element>.BorrowingIterator
-  
-  public var estimatedCount: EstimatedCount {
-    .exactly(count)
-  }
-
-  @_alwaysEmitIntoClient
-  @inline(__always)
-  public func makeBorrowingIterator() -> BorrowingIterator {
-    self._storage.makeBorrowingIterator()
-  }
-}
-#endif
-
-#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
-@available(SwiftStdlib 5.0, *)
-extension UniqueArray: Container where Element: ~Copyable {
-}
-#endif
-
-@available(SwiftStdlib 5.0, *)
+@available(SwiftStdlib 6.4, *)
 extension UniqueArray where Element: ~Copyable {
   /// A Boolean value indicating whether this array contains no elements.
   ///
   /// - Complexity: O(1)
-  @inlinable
-  @inline(__always)
-  public var isEmpty: Bool { _storage.isEmpty }
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  public var isEmpty: Bool {
+    _storage.isEmpty
+  }
 
   /// The number of elements in this array.
   ///
   /// - Complexity: O(1)
-  @inlinable
-  @inline(__always)
-  public var count: Int { _storage.count }
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  public var count: Int {
+    _storage.count
+  }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftStdlib 6.4, *)
 extension UniqueArray where Element: ~Copyable {
   /// A type that represents a position in the array: an integer offset from the
   /// start.
   ///
   /// Valid indices consist of the position of every element and a "past the
   /// end” position that’s not valid for use as a subscript argument.
+  @available(SwiftStdlib 6.4, *)
   public typealias Index = Int
 
   /// The position of the first element in a nonempty array. This is always zero.
   ///
   /// - Complexity: O(1)
-  @inlinable
-  @inline(__always)
-  public var startIndex: Int { _storage.startIndex }
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  public var startIndex: Int {
+    _storage.startIndex
+  }
 
   /// The array’s "past the end” position—that is, the position one greater than
   /// the last valid subscript argument. This is always equal to array's count.
   ///
   /// - Complexity: O(1)
-  @inlinable
-  @inline(__always)
-  public var endIndex: Int { _storage.count }
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  public var endIndex: Int {
+    _storage.count
+  }
 
   /// The range of indices that are valid for subscripting the array.
   ///
   /// - Complexity: O(1)
-  @inlinable
-  @inline(__always)
-  public var indices: Range<Int> { _storage.indices }
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  public var indices: Range<Int> {
+    _storage.indices
+  }
 
   /// Accesses the element at the specified position.
   ///
@@ -94,20 +81,24 @@ extension UniqueArray where Element: ~Copyable {
   ///     to the `endIndex` property.
   ///
   /// - Complexity: O(1)
-  @inlinable
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public subscript(position: Int) -> Element {
-    @inline(__always)
-    unsafeAddress {
-      _storage._ptr(to: position)
+    @_transparent
+    @_unsafeSelfDependentResult
+    borrow {
+      unsafe _storage._ptr(to: position).pointee
     }
-    @inline(__always)
-    unsafeMutableAddress {
-      _storage._mutablePtr(to: position)
+
+    @_transparent
+    @_unsafeSelfDependentResult
+    mutate {
+      unsafe &_storage._mutablePtr(to: position).pointee
     }
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftStdlib 6.4, *)
 extension UniqueArray where Element: ~Copyable {
   /// Exchanges the values at the specified indices of the array.
   ///
@@ -118,14 +109,14 @@ extension UniqueArray where Element: ~Copyable {
   /// - Parameter j: The index of the second valud to swap.
   ///
   /// - Complexity: O(1)
-  @inlinable
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public mutating func swapAt(_ i: Int, _ j: Int) {
     _storage.swapAt(i, j)
   }
 }
 
-
-@available(SwiftStdlib 5.0, *)
+@available(SwiftStdlib 6.4, *)
 extension UniqueArray where Element: ~Copyable {
   /// Returns the position immediately after the given index.
   ///
@@ -138,9 +129,12 @@ extension UniqueArray where Element: ~Copyable {
   ///     than `endIndex`.
   /// - Returns: The index immediately following `i`.
   /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  @inline(__always)
-  public func index(after index: Int) -> Int { index + 1 }
+  @_transparent
+  public func index(after index: Int) -> Int {
+    index + 1
+  }
   
   /// Returns the position immediately before the given index.
   ///
@@ -153,9 +147,12 @@ extension UniqueArray where Element: ~Copyable {
   ///     than `startIndex`.
   /// - Returns: The index immediately preceding `i`.
   /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  @inline(__always)
-  public func index(before index: Int) -> Int { index - 1 }
+  @_transparent
+  public func index(before index: Int) -> Int {
+    index - 1
+  }
 
   /// Replaces the given index with its successor.
   ///
@@ -167,9 +164,12 @@ extension UniqueArray where Element: ~Copyable {
   /// - Parameter index: A valid index of the array. `i` must be less
   ///     than `endIndex`.
   /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  @inline(__always)
-  public func formIndex(after index: inout Int) { index += 1 }
+  @_transparent
+  public func formIndex(after index: inout Int) {
+    index += 1
+  }
 
   /// Replaces the given index with its predecessor.
   ///
@@ -181,9 +181,12 @@ extension UniqueArray where Element: ~Copyable {
   /// - Parameter index: A valid index of the array. `i` must be greater than
   ///     `startIndex`.
   /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  @inline(__always)
-  public func formIndex(before index: inout Int) { index -= 1 }
+  @_transparent
+  public func formIndex(before index: inout Int) {
+    index -= 1
+  }
 
   /// Returns an index that is the specified distance from the given index.
   ///
@@ -202,8 +205,9 @@ extension UniqueArray where Element: ~Copyable {
   ///    If `n` is negative, this is the same value as the result of `abs(n)`
   ///    calls to `index(before:)`.
   /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  @inline(__always)
+  @_transparent
   public func index(_ index: Int, offsetBy n: Int) -> Int {
     index + n
   }
@@ -220,8 +224,9 @@ extension UniqueArray where Element: ~Copyable {
   ///    to start, the result is zero.
   /// - Returns: The distance between `start` and `end`.
   /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  @inline(__always)
+  @_transparent
   public func distance(from start: Index, to end: Index) -> Int {
     end - start
   }
@@ -257,88 +262,13 @@ extension UniqueArray where Element: ~Copyable {
   ///    Likewise, if `n < 0`, a limit that is greater than `index` has no
   ///    effect.
   /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   public func formIndex(
-    _ index: inout Index, offsetBy n: inout Int, limitedBy limit: Index
+    _ index: inout Index,
+    offsetBy n: inout Int,
+    limitedBy limit: Index
   ) {
     _storage.formIndex(&index, offsetBy: &n, limitedBy: limit)
   }
-
-  /// Return a span over the array's storage that begins with the element at
-  /// the given index, and extends to the end of the contiguous storage chunk
-  /// that contains it, but no more than `maximumCount` items.
-  ///
-  /// On return, the index is updated to address the next item following the
-  /// end of the returned span.
-  ///
-  /// This method can be used to efficiently process the items of a container in
-  /// bulk, by directly iterating over its piecewise contiguous pieces of
-  /// storage:
-  ///
-  ///     var index = items.startIndex
-  ///     while true {
-  ///       let span = items.nextSpan(after: &index, maximumCount: 4)
-  ///       if span.isEmpty { break }
-  ///       // Process items in `span`
-  ///     }
-  ///
-  /// The `maximumCount` argument gives the caller control over the number of
-  /// items it receives from the iterator. This lets the caller avoid getting
-  /// more elements than it would be able to immediately process, which would
-  /// significantly complicate container use.
-  ///
-  /// If the caller is able to process any number available items, it can signal
-  /// that by passing `Int.max` as the `maximumCount`, or simply by calling the
-  /// `nexSpan(after:)` method, which does precisely that. This is frequently
-  /// the case when the caller simply wants to iterate over the entire
-  /// container in a single loop.
-  ///
-  /// `maximumCount` sets an upper bound. To read a specific number of items,
-  /// the caller usually needs to invoke `nextSpan` in a loop:
-  ///
-  ///     var items: some Container<Int>
-  ///     var index = items.startIndex
-  ///     var remainder = numberOfItemsToRead
-  ///     while remainder > 0 {
-  ///       let next = items.nextSpan(after: &index, maximumCount: remainder)
-  ///       guard !next.isEmpty else {
-  ///         // Container does not have enough items
-  ///         break
-  ///       }
-  ///       remainder -= next.count
-  ///       // Process items in `next`
-  ///     }
-  ///
-  /// - Note: The spans returned by this method are not guaranteed to be
-  ///    disjunct. Some containers may use the same storage chunk (or parts of a
-  ///    storage chunk) multiple times, to repeat their contents.
-  ///
-  /// - Note: Repeated invocations of `nextSpan` on the same container and index
-  ///    are not guaranteed to return identical results. (This is particularly
-  ///    the case with containers that can store contents in their "inline"
-  ///    representation. Such containers may not always have a unique address
-  ///    in memory; the locations of the spans exposed by this method may vary
-  ///    between different borrows of the same container.)
-  ///
-  /// - Parameter index: A valid index in the container, including the end
-  ///     index. On return, this index is advanced by the count of the resulting
-  ///     span, to simplify iteration.
-  /// - Parameter maximumCount: The maximum number of items the caller is able
-  ///     to process immediately. `maximumCount` must be greater than zero.
-  ///     If you are able to process an arbitrary number of items, set
-  ///     `maximumCount` to `Int.max`, or call the `nextSpan(after:)` method.
-  /// - Returns: A span over contiguous storage that starts at the given index.
-  ///     If the input index is the end index, then this returns an empty span.
-  ///     Otherwise the result is non-empty, with its first element matching the
-  ///     element at the input index.
-  /// - Complexity: O(1)
-  @inlinable
-  @_lifetime(borrow self)
-  public func nextSpan(
-    after index: inout Int, maximumCount: Int
-  ) -> Span<Element> {
-    _storage.nextSpan(after: &index, maximumCount: maximumCount)
-  }
 }
-
-#endif

--- a/stdlib/public/core/UniqueArray/UniqueArray+Container.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Container.swift
@@ -1,0 +1,344 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if !COLLECTIONS_SINGLE_MODULE
+import InternalCollectionsUtilities
+import ContainersPreview
+#endif
+
+#if compiler(>=6.2)
+
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray: BorrowingSequence where Element: ~Copyable {
+  public typealias BorrowingIterator = RigidArray<Element>.BorrowingIterator
+  
+  public var estimatedCount: EstimatedCount {
+    .exactly(count)
+  }
+
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  public func makeBorrowingIterator() -> BorrowingIterator {
+    self._storage.makeBorrowingIterator()
+  }
+}
+#endif
+
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray: Container where Element: ~Copyable {
+}
+#endif
+
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray where Element: ~Copyable {
+  /// A Boolean value indicating whether this array contains no elements.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  @inline(__always)
+  public var isEmpty: Bool { _storage.isEmpty }
+
+  /// The number of elements in this array.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  @inline(__always)
+  public var count: Int { _storage.count }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray where Element: ~Copyable {
+  /// A type that represents a position in the array: an integer offset from the
+  /// start.
+  ///
+  /// Valid indices consist of the position of every element and a "past the
+  /// end” position that’s not valid for use as a subscript argument.
+  public typealias Index = Int
+
+  /// The position of the first element in a nonempty array. This is always zero.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  @inline(__always)
+  public var startIndex: Int { _storage.startIndex }
+
+  /// The array’s "past the end” position—that is, the position one greater than
+  /// the last valid subscript argument. This is always equal to array's count.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  @inline(__always)
+  public var endIndex: Int { _storage.count }
+
+  /// The range of indices that are valid for subscripting the array.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  @inline(__always)
+  public var indices: Range<Int> { _storage.indices }
+
+  /// Accesses the element at the specified position.
+  ///
+  /// - Parameter position: The position of the element to access.
+  ///     The position must be a valid index of the array that is not equal
+  ///     to the `endIndex` property.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  public subscript(position: Int) -> Element {
+    @inline(__always)
+    unsafeAddress {
+      _storage._ptr(to: position)
+    }
+    @inline(__always)
+    unsafeMutableAddress {
+      _storage._mutablePtr(to: position)
+    }
+  }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray where Element: ~Copyable {
+  /// Exchanges the values at the specified indices of the array.
+  ///
+  /// Both parameters must be valid indices of the array and not equal to
+  /// endIndex. Passing the same index as both `i` and `j` has no effect.
+  ///
+  /// - Parameter i: The index of the first value to swap.
+  /// - Parameter j: The index of the second valud to swap.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  public mutating func swapAt(_ i: Int, _ j: Int) {
+    _storage.swapAt(i, j)
+  }
+}
+
+
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray where Element: ~Copyable {
+  /// Returns the position immediately after the given index.
+  ///
+  /// - Note: To improve performance, this method does not validate that the
+  ///    index is valid before incrementing it. Index validation is
+  ///    deferred until the resulting index is used to access an element.
+  ///    This optimization may be removed in future versions; do not rely on it.
+  ///
+  /// - Parameter index: A valid index of the array. `i` must be less
+  ///     than `endIndex`.
+  /// - Returns: The index immediately following `i`.
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  public func index(after index: Int) -> Int { index + 1 }
+  
+  /// Returns the position immediately before the given index.
+  ///
+  /// - Note: To improve performance, this method does not validate that the
+  ///    index is valid before decrementing it. Index validation is
+  ///    deferred until the resulting index is used to access an element.
+  ///    This optimization may be removed in future versions; do not rely on it.
+  ///
+  /// - Parameter index: A valid index of the array. `i` must be greater
+  ///     than `startIndex`.
+  /// - Returns: The index immediately preceding `i`.
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  public func index(before index: Int) -> Int { index - 1 }
+
+  /// Replaces the given index with its successor.
+  ///
+  /// - Note: To improve performance, this method does not validate that the
+  ///    given index is valid before incrementing it. Index validation is
+  ///    deferred until the resulting index is used to access an element.
+  ///    This optimization may be removed in future versions; do not rely on it.
+  ///
+  /// - Parameter index: A valid index of the array. `i` must be less
+  ///     than `endIndex`.
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  public func formIndex(after index: inout Int) { index += 1 }
+
+  /// Replaces the given index with its predecessor.
+  ///
+  /// - Note: To improve performance, this method does not validate that the
+  ///    given index is valid before decrementing it. Index validation is
+  ///    deferred until the resulting index is used to access an element.
+  ///    This optimization may be removed in future versions; do not rely on it.
+  ///
+  /// - Parameter index: A valid index of the array. `i` must be greater than
+  ///     `startIndex`.
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  public func formIndex(before index: inout Int) { index -= 1 }
+
+  /// Returns an index that is the specified distance from the given index.
+  ///
+  /// The value passed as `n` must not offset `index` beyond the bounds of the
+  /// array.
+  ///
+  /// - Note: To improve performance, this method does not validate that the
+  ///    given index is valid before offseting it. Index validation is
+  ///    deferred until the resulting index is used to access an element.
+  ///    This optimization may be removed in future versions; do not rely on it.
+  ///
+  /// - Parameter index: A valid index of the array.
+  /// - Parameter n: The distance by which to offset `index`.
+  /// - Returns: An index offset by distance from `index`. If `n` is positive,
+  ///    this is the same value as the result of `n` calls to `index(after:)`.
+  ///    If `n` is negative, this is the same value as the result of `abs(n)`
+  ///    calls to `index(before:)`.
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  public func index(_ index: Int, offsetBy n: Int) -> Int {
+    index + n
+  }
+  
+  /// Returns the distance between two indices.
+  ///
+  /// - Note: To improve performance, this method does not validate that the
+  ///    given index is valid before offseting it. Index validation is
+  ///    deferred until the resulting index is used to access an element.
+  ///    This optimization may be removed in future versions; do not rely on it.
+  ///
+  /// - Parameter start: A valid index of the collection.
+  /// - Parameter end: Another valid index of the collection. If end is equal
+  ///    to start, the result is zero.
+  /// - Returns: The distance between `start` and `end`.
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  public func distance(from start: Index, to end: Index) -> Int {
+    end - start
+  }
+  
+  /// Offsets the given index by the specified distance, but no further than
+  /// the given limiting index.
+  ///
+  /// If the operation was able to offset `index` by exactly the requested
+  /// number of steps without hitting `limit`, then on return `n` is set to `0`,
+  /// and `index` is set to the adjusted index.
+  ///
+  /// If the operation hits the limit before it can take the requested number
+  /// of steps, then on return `index` is set to `limit`, and `n` is set
+  /// to the number of steps that couldn't be taken.
+  ///
+  /// The value passed as `n` must not offset `index` beyond the bounds of the
+  /// container, unless the index passed as `limit` prevents offsetting beyond
+  /// those bounds.
+  ///
+  /// - Note: To improve performance, this method does not validate that the
+  ///    given index is valid before offseting it. Index validation is
+  ///    deferred until the resulting index is used to access an element.
+  ///    This optimization may be removed in future versions; do not rely on it.
+  ///
+  /// - Parameter index: A valid index of the array. On return, `index` is
+  ///    set to `limit` if
+  /// - Parameter n: The distance to offset `index`.
+  ///    On return, `n` is set to zero if the operation succeeded without
+  ///    hitting the limit; otherwise, `n` reflects the number of steps that
+  ///    couldn't be taken.
+  /// - Parameter limit: A valid index of the array to use as a limit.
+  ///    If `n > 0`, a limit that is less than `index` has no effect.
+  ///    Likewise, if `n < 0`, a limit that is greater than `index` has no
+  ///    effect.
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public func formIndex(
+    _ index: inout Index, offsetBy n: inout Int, limitedBy limit: Index
+  ) {
+    _storage.formIndex(&index, offsetBy: &n, limitedBy: limit)
+  }
+
+  /// Return a span over the array's storage that begins with the element at
+  /// the given index, and extends to the end of the contiguous storage chunk
+  /// that contains it, but no more than `maximumCount` items.
+  ///
+  /// On return, the index is updated to address the next item following the
+  /// end of the returned span.
+  ///
+  /// This method can be used to efficiently process the items of a container in
+  /// bulk, by directly iterating over its piecewise contiguous pieces of
+  /// storage:
+  ///
+  ///     var index = items.startIndex
+  ///     while true {
+  ///       let span = items.nextSpan(after: &index, maximumCount: 4)
+  ///       if span.isEmpty { break }
+  ///       // Process items in `span`
+  ///     }
+  ///
+  /// The `maximumCount` argument gives the caller control over the number of
+  /// items it receives from the iterator. This lets the caller avoid getting
+  /// more elements than it would be able to immediately process, which would
+  /// significantly complicate container use.
+  ///
+  /// If the caller is able to process any number available items, it can signal
+  /// that by passing `Int.max` as the `maximumCount`, or simply by calling the
+  /// `nexSpan(after:)` method, which does precisely that. This is frequently
+  /// the case when the caller simply wants to iterate over the entire
+  /// container in a single loop.
+  ///
+  /// `maximumCount` sets an upper bound. To read a specific number of items,
+  /// the caller usually needs to invoke `nextSpan` in a loop:
+  ///
+  ///     var items: some Container<Int>
+  ///     var index = items.startIndex
+  ///     var remainder = numberOfItemsToRead
+  ///     while remainder > 0 {
+  ///       let next = items.nextSpan(after: &index, maximumCount: remainder)
+  ///       guard !next.isEmpty else {
+  ///         // Container does not have enough items
+  ///         break
+  ///       }
+  ///       remainder -= next.count
+  ///       // Process items in `next`
+  ///     }
+  ///
+  /// - Note: The spans returned by this method are not guaranteed to be
+  ///    disjunct. Some containers may use the same storage chunk (or parts of a
+  ///    storage chunk) multiple times, to repeat their contents.
+  ///
+  /// - Note: Repeated invocations of `nextSpan` on the same container and index
+  ///    are not guaranteed to return identical results. (This is particularly
+  ///    the case with containers that can store contents in their "inline"
+  ///    representation. Such containers may not always have a unique address
+  ///    in memory; the locations of the spans exposed by this method may vary
+  ///    between different borrows of the same container.)
+  ///
+  /// - Parameter index: A valid index in the container, including the end
+  ///     index. On return, this index is advanced by the count of the resulting
+  ///     span, to simplify iteration.
+  /// - Parameter maximumCount: The maximum number of items the caller is able
+  ///     to process immediately. `maximumCount` must be greater than zero.
+  ///     If you are able to process an arbitrary number of items, set
+  ///     `maximumCount` to `Int.max`, or call the `nextSpan(after:)` method.
+  /// - Returns: A span over contiguous storage that starts at the given index.
+  ///     If the input index is the end index, then this returns an empty span.
+  ///     Otherwise the result is non-empty, with its first element matching the
+  ///     element at the input index.
+  /// - Complexity: O(1)
+  @inlinable
+  @_lifetime(borrow self)
+  public func nextSpan(
+    after index: inout Int, maximumCount: Int
+  ) -> Span<Element> {
+    _storage.nextSpan(after: &index, maximumCount: maximumCount)
+  }
+}
+
+#endif

--- a/stdlib/public/core/UniqueArray/UniqueArray+Container.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Container.swift
@@ -252,7 +252,7 @@ extension UniqueArray where Element: ~Copyable {
   ///    This optimization may be removed in future versions; do not rely on it.
   ///
   /// - Parameter index: A valid index of the array. On return, `index` is
-  ///    set to `limit` if
+  ///    set to the resulting position.
   /// - Parameter n: The distance to offset `index`.
   ///    On return, `n` is set to zero if the operation succeeded without
   ///    hitting the limit; otherwise, `n` reflects the number of steps that

--- a/stdlib/public/core/UniqueArray/UniqueArray+Descriptions.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Descriptions.swift
@@ -1,0 +1,30 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if compiler(>=6.2)
+
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray /*: CustomStringConvertible */ where Element: ~Copyable {
+  public var description: String {
+    /// FIXME: Print the item descriptions when available.
+    "<\(count) items>"
+  }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray /*: CustomDebugStringConvertible */ where Element: ~Copyable {
+  public var debugDescription: String {
+    /// FIXME: Print the item descriptions when available.
+    "<\(count) items>"
+  }
+}
+
+#endif

--- a/stdlib/public/core/UniqueArray/UniqueArray+Descriptions.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Descriptions.swift
@@ -1,30 +1,29 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift Collections open source project
+// This source file is part of the Swift.org open source project
 //
 // Copyright (c) 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6.2)
+// FIXME: Waiting for https://github.com/swiftlang/swift/pull/85874 to land
 
-@available(SwiftStdlib 5.0, *)
-extension UniqueArray /*: CustomStringConvertible */ where Element: ~Copyable {
-  public var description: String {
-    /// FIXME: Print the item descriptions when available.
-    "<\(count) items>"
-  }
-}
+// @available(SwiftStdlib 6.4, *)
+// extension UniqueArray: CustomStringConvertible where Element: ~Copyable {
+//   public var description: String {
+//     /// FIXME: Print the item descriptions when available.
+//     "<\(count) items>"
+//   }
+// }
 
-@available(SwiftStdlib 5.0, *)
-extension UniqueArray /*: CustomDebugStringConvertible */ where Element: ~Copyable {
-  public var debugDescription: String {
-    /// FIXME: Print the item descriptions when available.
-    "<\(count) items>"
-  }
-}
-
-#endif
+// @available(SwiftStdlib 6.4, *)
+// extension UniqueArray: CustomDebugStringConvertible where Element: ~Copyable {
+//   public var debugDescription: String {
+//     /// FIXME: Print the item descriptions when available.
+//     "<\(count) items>"
+//   }
+// }

--- a/stdlib/public/core/UniqueArray/UniqueArray+Descriptions.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Descriptions.swift
@@ -10,20 +10,28 @@
 //
 //===----------------------------------------------------------------------===//
 
-// FIXME: Waiting for https://github.com/swiftlang/swift/pull/85874 to land
-
-// @available(SwiftStdlib 6.4, *)
+// FIXME: Enable once SE-0499 is implemented
+// @available(SwiftStdlib x.y, *)
 // extension UniqueArray: CustomStringConvertible where Element: ~Copyable {
-//   public var description: String {
-//     /// FIXME: Print the item descriptions when available.
-//     "<\(count) items>"
-//   }
 // }
 
-// @available(SwiftStdlib 6.4, *)
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray where Element: ~Copyable {
+  public var description: String {
+    /// FIXME: Print the item descriptions when available.
+    "<\(count) items>"
+  }
+}
+
+// FIXME: Enable once SE-0499 is implemented
+// @available(SwiftStdlib x.y, *)
 // extension UniqueArray: CustomDebugStringConvertible where Element: ~Copyable {
-//   public var debugDescription: String {
-//     /// FIXME: Print the item descriptions when available.
-//     "<\(count) items>"
-//   }
 // }
+
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray where Element: ~Copyable {
+  public var debugDescription: String {
+    /// FIXME: Print the item descriptions when available.
+    "<\(count) items>"
+  }
+}

--- a/stdlib/public/core/UniqueArray/UniqueArray+Equatable.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Equatable.swift
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if compiler(>=6.2)
+
+#if !COLLECTIONS_SINGLE_MODULE
+import InternalCollectionsUtilities
+#endif
+
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray /*: Equatable */ where Element: Equatable /* & ~Copyable */ {
+  @inlinable
+  public static func ==(
+    left: borrowing Self,
+    right: borrowing Self
+  ) -> Bool {
+    left.span._elementsEqual(to: right.span)
+  }
+}
+
+#endif

--- a/stdlib/public/core/UniqueArray/UniqueArray+Equatable.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Equatable.swift
@@ -1,29 +1,29 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift Collections open source project
+// This source file is part of the Swift.org open source project
 //
 // Copyright (c) 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6.2)
-
-#if !COLLECTIONS_SINGLE_MODULE
-import InternalCollectionsUtilities
-#endif
-
-@available(SwiftStdlib 5.0, *)
-extension UniqueArray /*: Equatable */ where Element: Equatable /* & ~Copyable */ {
-  @inlinable
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray: Equatable where Element: Equatable & ~Copyable {
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public static func ==(
     left: borrowing Self,
     right: borrowing Self
   ) -> Bool {
     left.span._elementsEqual(to: right.span)
   }
-}
 
-#endif
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public func isTriviallyIdentical(to other: borrowing Self) -> Bool {
+    _storage.isTriviallyIdentical(to: other._storage)
+  }
+}

--- a/stdlib/public/core/UniqueArray/UniqueArray+Equatable.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Equatable.swift
@@ -14,8 +14,7 @@
 extension UniqueArray where Element: ~Copyable {
   @_alwaysEmitIntoClient
   public func isTriviallyIdentical(to other: borrowing Self) -> Bool {
-    unsafe self._count == other._count &&
-    self._storage.isTriviallyIdentical(to: other._storage)
+    _storage.isTriviallyIdentical(to: other._storage)
   }
 }
 

--- a/stdlib/public/core/UniqueArray/UniqueArray+Equatable.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Equatable.swift
@@ -11,6 +11,15 @@
 //===----------------------------------------------------------------------===//
 
 @available(SwiftStdlib 6.4, *)
+extension UniqueArray where Element: ~Copyable {
+  @_alwaysEmitIntoClient
+  public func isTriviallyIdentical(to other: borrowing Self) -> Bool {
+    unsafe self._count == other._count &&
+    self._storage.isTriviallyIdentical(to: other._storage)
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
 extension UniqueArray: Equatable where Element: Equatable & ~Copyable {
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
@@ -19,11 +28,5 @@ extension UniqueArray: Equatable where Element: Equatable & ~Copyable {
     right: borrowing Self
   ) -> Bool {
     left.span._elementsEqual(to: right.span)
-  }
-
-  @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
-  public func isTriviallyIdentical(to other: borrowing Self) -> Bool {
-    _storage.isTriviallyIdentical(to: other._storage)
   }
 }

--- a/stdlib/public/core/UniqueArray/UniqueArray+Hashable.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Hashable.swift
@@ -1,26 +1,20 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift Collections open source project
+// This source file is part of the Swift.org open source project
 //
 // Copyright (c) 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6.2)
-
-@available(SwiftStdlib 5.0, *)
-extension UniqueArray /*: Hashable */ where Element: Hashable /* & ~Copyable */ {
-  @inlinable
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray: Hashable where Element: Hashable & ~Copyable {
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public func hash(into hasher: inout Hasher) {
-    hasher.combine(self.count)
-    let span = self.span
-    for i in 0 ..< count {
-      hasher.combine(span[unchecked: i])
-    }
+    _storage.hash(into: &hasher)
   }
 }
-
-#endif

--- a/stdlib/public/core/UniqueArray/UniqueArray+Hashable.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Hashable.swift
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if compiler(>=6.2)
+
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray /*: Hashable */ where Element: Hashable /* & ~Copyable */ {
+  @inlinable
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(self.count)
+    let span = self.span
+    for i in 0 ..< count {
+      hasher.combine(span[unchecked: i])
+    }
+  }
+}
+
+#endif

--- a/stdlib/public/core/UniqueArray/UniqueArray+Initializers.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Initializers.swift
@@ -1,0 +1,161 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2024 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if !COLLECTIONS_SINGLE_MODULE
+import InternalCollectionsUtilities
+import ContainersPreview
+#endif
+
+#if compiler(>=6.2)
+
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray where Element: ~Copyable {
+  /// Initializes a new unique array with no elements.
+  @inlinable
+  public init() {
+    _storage = .init(capacity: 0)
+  }
+  
+  /// Initializes a new unique array with the specified capacity and no elements.
+  @inlinable
+  public init(capacity: Int) {
+    _storage = .init(capacity: capacity)
+  }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray where Element: ~Copyable {
+  /// Creates a new array with the specified capacity, directly initializing
+  /// its storage using an output span.
+  ///
+  /// - Parameters:
+  ///   - capacity: The storage capacity of the new array.
+  ///   - body: A callback that gets called at most once to directly
+  ///       populate newly reserved storage within the array. The function
+  ///       is allowed to add fewer than `capacity` items. The array is
+  ///       initialized with however many items the callback adds to the
+  ///       output span before it returns (or before it throws an error).
+  @inlinable
+  public init<E: Error>(
+    capacity: Int,
+    initializingWith body: (inout OutputSpan<Element>) throws(E) -> Void
+  ) throws(E) {
+    self.init(capacity: capacity)
+    try edit(body)
+  }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray /*where Element: Copyable*/ {
+  /// Creates a new array containing the specified number of a single,
+  /// repeated value.
+  ///
+  /// - Parameters:
+  ///   - repeatedValue: The element to repeat.
+  ///   - count: The number of times to repeat the value passed in the
+  ///     `repeating` parameter. `count` must be zero or greater.
+  ///
+  /// - Complexity: O(`count`)
+  public init(repeating repeatedValue: Element, count: Int) {
+    self.init(consuming: RigidArray(repeating: repeatedValue, count: count))
+  }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray where Element: ~Copyable {
+  /// Creates a new unique array taking over the storage of the specified
+  /// rigid array instance, consuming it in the process.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  public init(consuming storage: consuming RigidArray<Element>) {
+    self._storage = storage
+  }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray /*where Element: Copyable*/ {
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+  /// Creates a new array with the specified initial capacity, holding a copy
+  /// of the contents of a given borrowing sequence.
+  ///
+  /// - Parameters:
+  ///   - capacity: The storage capacity of the new array, or nil to allocate
+  ///      just enough capacity to store the contents.
+  ///   - contents: A sequence whose contents to copy into the new array.
+  ///      The sequence must not contain more than `capacity` elements.
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  public init<Source: BorrowingSequence<Element> & ~Copyable & ~Escapable>(
+    capacity: Int? = nil,
+    copying contents: borrowing Source
+  ) {
+    self.init(capacity: capacity ?? 0)
+    self.append(copying: contents)
+  }
+#endif
+
+  /// Creates a new array with the specified initial capacity, holding a copy
+  /// of the contents of a given sequence.
+  ///
+  /// - Parameters:
+  ///   - capacity: The storage capacity of the new array, or nil to allocate
+  ///      just enough capacity to store the contents.
+  ///   - contents: The sequence whose contents to copy into the new array.
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  public init(
+    capacity: Int? = nil,
+    copying contents: some Sequence<Element>
+  ) {
+    self.init(capacity: capacity ?? 0)
+    self.append(copying: contents)
+  }
+  
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+  /// Creates a new array with the specified initial capacity, holding a copy
+  /// of the contents of a given container.
+  ///
+  /// - Parameters:
+  ///   - capacity: The storage capacity of the new array, or nil to allocate
+  ///      just enough capacity to store the contents.
+  ///   - contents: The container whose contents to copy into the new array.
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  public init<Source: BorrowingSequence<Element> & Sequence<Element>>(
+    capacity: Int? = nil,
+    copying contents: Source
+  ) {
+    self.init(capacity: capacity ?? 0)
+    self.append(copying: contents)
+  }
+#endif
+
+  /// Creates a new array with the specified capacity, holding a copy
+  /// of the contents of the given span.
+  ///
+  /// - Parameters:
+  ///   - capacity: The storage capacity of the new array, or nil to allocate
+  ///      just enough capacity to store the contents of the span.
+  ///   - span: The span whose contents to copy into the new array.
+  ///      The span must not contain more than `capacity` elements.
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  public init(
+    capacity: Int? = nil,
+    copying span: Span<Element>
+  ) {
+    self.init(capacity: capacity ?? span.count)
+    self.append(copying: span)
+  }
+}
+
+#endif

--- a/stdlib/public/core/UniqueArray/UniqueArray+Initializers.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Initializers.swift
@@ -1,37 +1,33 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift Collections open source project
+// This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2024 - 2026 Apple Inc. and the Swift project authors
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 
-#if !COLLECTIONS_SINGLE_MODULE
-import InternalCollectionsUtilities
-import ContainersPreview
-#endif
-
-#if compiler(>=6.2)
-
-@available(SwiftStdlib 5.0, *)
+@available(SwiftStdlib 6.4, *)
 extension UniqueArray where Element: ~Copyable {
   /// Initializes a new unique array with no elements.
-  @inlinable
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public init() {
     _storage = .init(capacity: 0)
   }
   
   /// Initializes a new unique array with the specified capacity and no elements.
-  @inlinable
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public init(capacity: Int) {
     _storage = .init(capacity: capacity)
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftStdlib 6.4, *)
 extension UniqueArray where Element: ~Copyable {
   /// Creates a new array with the specified capacity, directly initializing
   /// its storage using an output span.
@@ -43,7 +39,8 @@ extension UniqueArray where Element: ~Copyable {
   ///       is allowed to add fewer than `capacity` items. The array is
   ///       initialized with however many items the callback adds to the
   ///       output span before it returns (or before it throws an error).
-  @inlinable
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public init<E: Error>(
     capacity: Int,
     initializingWith body: (inout OutputSpan<Element>) throws(E) -> Void
@@ -53,8 +50,8 @@ extension UniqueArray where Element: ~Copyable {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
-extension UniqueArray /*where Element: Copyable*/ {
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray where Element: Copyable {
   /// Creates a new array containing the specified number of a single,
   /// repeated value.
   ///
@@ -64,45 +61,28 @@ extension UniqueArray /*where Element: Copyable*/ {
   ///     `repeating` parameter. `count` must be zero or greater.
   ///
   /// - Complexity: O(`count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public init(repeating repeatedValue: Element, count: Int) {
     self.init(consuming: RigidArray(repeating: repeatedValue, count: count))
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftStdlib 6.4, *)
 extension UniqueArray where Element: ~Copyable {
   /// Creates a new unique array taking over the storage of the specified
   /// rigid array instance, consuming it in the process.
   ///
   /// - Complexity: O(1)
-  @inlinable
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public init(consuming storage: consuming RigidArray<Element>) {
     self._storage = storage
   }
 }
 
-@available(SwiftStdlib 5.0, *)
-extension UniqueArray /*where Element: Copyable*/ {
-#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
-  /// Creates a new array with the specified initial capacity, holding a copy
-  /// of the contents of a given borrowing sequence.
-  ///
-  /// - Parameters:
-  ///   - capacity: The storage capacity of the new array, or nil to allocate
-  ///      just enough capacity to store the contents.
-  ///   - contents: A sequence whose contents to copy into the new array.
-  ///      The sequence must not contain more than `capacity` elements.
-  @_alwaysEmitIntoClient
-  @inline(__always)
-  public init<Source: BorrowingSequence<Element> & ~Copyable & ~Escapable>(
-    capacity: Int? = nil,
-    copying contents: borrowing Source
-  ) {
-    self.init(capacity: capacity ?? 0)
-    self.append(copying: contents)
-  }
-#endif
-
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray where Element: Copyable {
   /// Creates a new array with the specified initial capacity, holding a copy
   /// of the contents of a given sequence.
   ///
@@ -110,8 +90,8 @@ extension UniqueArray /*where Element: Copyable*/ {
   ///   - capacity: The storage capacity of the new array, or nil to allocate
   ///      just enough capacity to store the contents.
   ///   - contents: The sequence whose contents to copy into the new array.
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  @inline(__always)
   public init(
     capacity: Int? = nil,
     copying contents: some Sequence<Element>
@@ -119,25 +99,6 @@ extension UniqueArray /*where Element: Copyable*/ {
     self.init(capacity: capacity ?? 0)
     self.append(copying: contents)
   }
-  
-#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
-  /// Creates a new array with the specified initial capacity, holding a copy
-  /// of the contents of a given container.
-  ///
-  /// - Parameters:
-  ///   - capacity: The storage capacity of the new array, or nil to allocate
-  ///      just enough capacity to store the contents.
-  ///   - contents: The container whose contents to copy into the new array.
-  @_alwaysEmitIntoClient
-  @inline(__always)
-  public init<Source: BorrowingSequence<Element> & Sequence<Element>>(
-    capacity: Int? = nil,
-    copying contents: Source
-  ) {
-    self.init(capacity: capacity ?? 0)
-    self.append(copying: contents)
-  }
-#endif
 
   /// Creates a new array with the specified capacity, holding a copy
   /// of the contents of the given span.
@@ -147,8 +108,8 @@ extension UniqueArray /*where Element: Copyable*/ {
   ///      just enough capacity to store the contents of the span.
   ///   - span: The span whose contents to copy into the new array.
   ///      The span must not contain more than `capacity` elements.
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  @inline(__always)
   public init(
     capacity: Int? = nil,
     copying span: Span<Element>
@@ -157,5 +118,3 @@ extension UniqueArray /*where Element: Copyable*/ {
     self.append(copying: span)
   }
 }
-
-#endif

--- a/stdlib/public/core/UniqueArray/UniqueArray+Initializers.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Initializers.swift
@@ -64,7 +64,7 @@ extension UniqueArray where Element: Copyable {
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   public init(repeating repeatedValue: Element, count: Int) {
-    self.init(consuming: RigidArray(repeating: repeatedValue, count: count))
+    self.init(consuming: _RigidArray(repeating: repeatedValue, count: count))
   }
 }
 
@@ -76,7 +76,7 @@ extension UniqueArray where Element: ~Copyable {
   /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public init(consuming storage: consuming RigidArray<Element>) {
+  internal init(consuming storage: consuming _RigidArray<Element>) {
     self._storage = storage
   }
 }

--- a/stdlib/public/core/UniqueArray/UniqueArray+Initializers.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Initializers.swift
@@ -25,6 +25,13 @@ extension UniqueArray where Element: ~Copyable {
   public init(capacity: Int) {
     _storage = .init(capacity: capacity)
   }
+
+  /// Initializes a new unique array with the specified capacity and no elements.
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public init(minimumCapacity: Int) {
+    self.init(capacity: minimumCapacity)
+  }
 }
 
 @available(SwiftStdlib 6.4, *)

--- a/stdlib/public/core/UniqueArray/UniqueArray+Insertions.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Insertions.swift
@@ -1,22 +1,16 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift Collections open source project
+// This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2024 - 2025 Apple Inc. and the Swift project authors
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 
-#if !COLLECTIONS_SINGLE_MODULE
-import InternalCollectionsUtilities
-import ContainersPreview
-#endif
-
-#if compiler(>=6.2)
-
-@available(SwiftStdlib 5.0, *)
+@available(SwiftStdlib 6.4, *)
 extension UniqueArray where Element: ~Copyable {
   /// Inserts a new element into the array at the specified position.
   ///
@@ -36,7 +30,8 @@ extension UniqueArray where Element: ~Copyable {
   ///   `index` must be a valid index in the array.
   ///
   /// - Complexity: O(`self.count`)
-  @inlinable
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public mutating func insert(_ item: consuming Element, at index: Int) {
     precondition(index >= 0 && index <= count)
     // FIXME: Avoid moving the subsequent elements twice.
@@ -45,7 +40,7 @@ extension UniqueArray where Element: ~Copyable {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftStdlib 6.4, *)
 extension UniqueArray where Element: ~Copyable {
   /// Inserts a given number of new items into this array at the specified
   /// position, using a callback to directly initialize array storage by
@@ -79,8 +74,8 @@ extension UniqueArray where Element: ~Copyable {
   ///       supplied count, and it must fully populate it before returning.
   ///
   /// - Complexity: O(`self.count` + `count`)
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  @inline(__always)
   public mutating func insert<E: Error>(
     addingCount newItemCount: Int,
     at index: Int,
@@ -94,7 +89,7 @@ extension UniqueArray where Element: ~Copyable {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftStdlib 6.4, *)
 extension UniqueArray where Element: ~Copyable {
   /// Moves the elements of a fully initialized buffer into this array,
   /// starting at the specified position, and leaving the buffer
@@ -109,6 +104,7 @@ extension UniqueArray where Element: ~Copyable {
   ///        the array.
   ///
   /// - Complexity: O(`self.count` + `items.count`)
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   public mutating func insert(
     moving items: UnsafeMutableBufferPointer<Element>,
@@ -116,36 +112,8 @@ extension UniqueArray where Element: ~Copyable {
   ) {
     // FIXME: Avoid moving the subsequent elements twice.
     _ensureFreeCapacity(items.count)
-    _storage.insert(moving: items, at: index)
+    unsafe _storage.insert(moving: items, at: index)
   }
-
-#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
-  /// Moves the elements of an input span into this array,
-  /// starting at the specified position, and leaving the span empty.
-  ///
-  /// All existing elements at or following the specified position are moved to
-  /// make room for the new items.
-  ///
-  /// If the array does not have sufficient capacity to hold the new elements,
-  /// then this reallocates storage to extend its capacity, using a geometric
-  /// growth rate.
-  ///
-  /// - Parameters:
-  ///    - items: An input span whose contents to move into
-  ///        the array.
-  ///    - index: The position at which to insert the new items.
-  ///       `index` must be a valid index in the array.
-  ///
-  /// - Complexity: O(`self.count` + `items.count`)
-  @_alwaysEmitIntoClient
-  public mutating func insert(
-    moving items: inout InputSpan<Element>,
-    at index: Int
-  ) {
-    _ensureFreeCapacity(items.count)
-    _storage.insert(moving: &items, at: index)
-  }
-#endif
 
   /// Moves the elements of an output span into this array,
   /// starting at the specified position, and leaving the span empty.
@@ -164,6 +132,7 @@ extension UniqueArray where Element: ~Copyable {
   ///       `index` must be a valid index in the array.
   ///
   /// - Complexity: O(`self.count` + `items.count`)
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   public mutating func insert(
     moving items: inout OutputSpan<Element>,
@@ -186,6 +155,7 @@ extension UniqueArray where Element: ~Copyable {
   ///    - items: An array whose contents to move into `self`.
   ///
   /// - Complexity: O(`self.count` + `items.count`)
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   public mutating func insert(
     moving items: inout RigidArray<Element>,
@@ -197,36 +167,8 @@ extension UniqueArray where Element: ~Copyable {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
-extension UniqueArray where Element: ~Copyable {
-#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
-  /// Inserts the elements of a given array into the given position in this
-  /// array by consuming the source container.
-  ///
-  /// If the array does not have sufficient capacity to hold all elements,
-  /// then this reallocates storage to extend its capacity, using a geometric
-  /// growth rate.
-  ///
-  /// - Parameters:
-  ///    - items: A fully initialized buffer whose contents to move into
-  ///        the array.
-  ///
-  /// - Complexity: O(`self.count` + `items.count`)
-  @_alwaysEmitIntoClient
-  public mutating func insert(
-    consuming items: consuming RigidArray<Element>,
-    at index: Int
-  ) {
-    // FIXME: Remove this in favor of a generic algorithm over consumable containers
-    // FIXME: Avoid moving the subsequent elements twice.
-    _ensureFreeCapacity(items.count)
-    _storage.insert(consuming: items, at: index)
-  }
-#endif
-}
-
-@available(SwiftStdlib 5.0, *)
-extension UniqueArray {
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray where Element: Copyable {
   /// Copyies the elements of a fully initialized buffer pointer into this
   /// array at the specified position.
   ///
@@ -248,7 +190,8 @@ extension UniqueArray {
   ///       a valid index of the array.
   ///
   /// - Complexity: O(`self.count` + `newElements.count`)
-  @inlinable
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public mutating func insert(
     copying newElements: UnsafeBufferPointer<Element>, at index: Int
   ) {
@@ -278,7 +221,8 @@ extension UniqueArray {
   ///       a valid index of the array.
   ///
   /// - Complexity: O(`self.count` + `newElements.count`)
-  @inlinable
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public mutating func insert(
     copying newElements: UnsafeMutableBufferPointer<Element>,
     at index: Int
@@ -305,7 +249,8 @@ extension UniqueArray {
   ///        a valid index of the array.
   ///
   /// - Complexity: O(`self.count` + `newElements.count`)
-  @inlinable
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public mutating func insert(
     copying newElements: Span<Element>, at index: Int
   ) {
@@ -313,42 +258,6 @@ extension UniqueArray {
     _ensureFreeCapacity(newElements.count)
     _storage.insert(copying: newElements, at: index)
   }
-
-#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
-  /// Copies the elements of a container into this array at the specified
-  /// position.
-  ///
-  /// The new elements are inserted before the element currently at the
-  /// specified index. If you pass the array’s `endIndex` as the `index`
-  /// parameter, then the new elements are appended to the end of the array.
-  ///
-  /// All existing elements at or following the specified position are moved to
-  /// make room for the new item.
-  ///
-  /// If the array does not have sufficient capacity to hold enough elements,
-  /// then this reallocates the array's storage to extend its capacity, using a
-  /// geometric growth rate.
-  ///
-  /// - Parameters:
-  ///    - newElements: The new elements to insert into the array.
-  ///    - index: The position at which to insert the new elements. It must be
-  ///        a valid index of the array.
-  ///
-  /// - Complexity: O(*n* + *m*), where *n* is count of this array and
-  ///    *m* is the count of `newElements`.
-  @_alwaysEmitIntoClient
-  @inline(__always)
-  public mutating func insert<
-    C: Container<Element> & ~Copyable & ~Escapable
-  >(
-    copying newElements: borrowing C, at index: Int
-  ) {
-    // FIXME: Avoid moving the subsequent elements twice.
-    let c = newElements.count
-    _ensureFreeCapacity(c)
-    _storage._insertContainer(at: index, copying: newElements, newCount: c)
-  }
-#endif
 
   /// Copies the elements of a collection into this array at the specified
   /// position.
@@ -370,7 +279,8 @@ extension UniqueArray {
   ///        a valid index of the array.
   ///
   /// - Complexity: O(`self.count` + `newElements.count`)
-  @inlinable
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public mutating func insert(
     copying newElements: some Collection<Element>, at index: Int
   ) {
@@ -380,42 +290,4 @@ extension UniqueArray {
     _storage._insertCollection(
       at: index, copying: newElements, newCount: newCount)
   }
-  
-#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
-  /// Copies the elements of a container into this array at the specified
-  /// position.
-  ///
-  /// The new elements are inserted before the element currently at the
-  /// specified index. If you pass the array’s `endIndex` as the `index`
-  /// parameter, then the new elements are appended to the end of the array.
-  ///
-  /// All existing elements at or following the specified position are moved to
-  /// make room for the new item.
-  ///
-  /// If the array does not have sufficient capacity to hold enough elements,
-  /// then this reallocates the array's storage to extend its capacity, using a
-  /// geometric growth rate.
-  ///
-  /// - Parameters:
-  ///    - newElements: The new elements to insert into the array.
-  ///    - index: The position at which to insert the new elements. It must be
-  ///        a valid index of the array.
-  ///
-  /// - Complexity: O(*n* + *m*), where *n* is count of this array and
-  ///    *m* is the count of `newElements`.
-  @_alwaysEmitIntoClient
-  @inline(__always)
-  public mutating func insert<
-    C: Container<Element> & Collection<Element>
-  >(
-    copying newElements: borrowing C, at index: Int
-  ) {
-    // FIXME: Avoid moving the subsequent elements twice.
-    let c = newElements.count
-    _ensureFreeCapacity(c)
-    _storage._insertContainer(at: index, copying: newElements, newCount: c)
-  }
-#endif
 }
-
-#endif

--- a/stdlib/public/core/UniqueArray/UniqueArray+Insertions.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Insertions.swift
@@ -1,0 +1,421 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2024 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if !COLLECTIONS_SINGLE_MODULE
+import InternalCollectionsUtilities
+import ContainersPreview
+#endif
+
+#if compiler(>=6.2)
+
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray where Element: ~Copyable {
+  /// Inserts a new element into the array at the specified position.
+  ///
+  /// If the array does not have sufficient capacity to hold any more elements,
+  /// then this reallocates storage to extend its capacity, using a geometric
+  /// growth rate.
+  ///
+  /// The new element is inserted before the element currently at the specified
+  /// index. If you pass the array's `endIndex` as the `index` parameter, then
+  /// the new element is appended to the container.
+  ///
+  /// All existing elements at or following the specified position are moved to
+  /// make room for the new item.
+  ///
+  /// - Parameter item: The new element to insert into the array.
+  /// - Parameter i: The position at which to insert the new element.
+  ///   `index` must be a valid index in the array.
+  ///
+  /// - Complexity: O(`self.count`)
+  @inlinable
+  public mutating func insert(_ item: consuming Element, at index: Int) {
+    precondition(index >= 0 && index <= count)
+    // FIXME: Avoid moving the subsequent elements twice.
+    _ensureFreeCapacity(1)
+    _storage.insert(item, at: index)
+  }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray where Element: ~Copyable {
+  /// Inserts a given number of new items into this array at the specified
+  /// position, using a callback to directly initialize array storage by
+  /// populating an output span.
+  ///
+  /// Existing elements in the array's storage are moved towards the back as
+  /// needed to make room for the new items.
+  ///
+  /// If the array does not have sufficient capacity to hold the new elements,
+  /// then this operation reallocates storage to extend its capacity, using a
+  /// geometric growth rate.
+  ///
+  ///     var buffer = UniqueArray<Int>()
+  ///     buffer.append([-999, 999])
+  ///     var i = 0
+  ///     buffer.insert(capacity: 3, at: 1) { target in
+  ///       while !target.isFull {
+  ///         target.append(i)
+  ///         i += 1
+  ///       }
+  ///     }
+  ///     // `buffer` now contains [-999, 0, 1, 2, 999]
+  ///
+  /// - Parameters:
+  ///    - count: The number of items to insert into the array.
+  ///    - index: The position at which to insert the new items.
+  ///       `index` must be a valid index in the array.
+  ///    - body: A callback that gets called at most once to directly
+  ///       populate newly reserved storage within the array. The function
+  ///       is called with an empty output span of capacity matching the
+  ///       supplied count, and it must fully populate it before returning.
+  ///
+  /// - Complexity: O(`self.count` + `count`)
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  public mutating func insert<E: Error>(
+    addingCount newItemCount: Int,
+    at index: Int,
+    initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
+  ) throws(E) {
+    _ensureFreeCapacity(newItemCount)
+    try _storage.insert(
+      addingCount: newItemCount,
+      at: index,
+      initializingWith: initializer)
+  }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray where Element: ~Copyable {
+  /// Moves the elements of a fully initialized buffer into this array,
+  /// starting at the specified position, and leaving the buffer
+  /// uninitialized.
+  ///
+  /// If the array does not have sufficient capacity to hold all elements,
+  /// then this reallocates storage to extend its capacity, using a geometric
+  /// growth rate.
+  ///
+  /// - Parameters:
+  ///    - items: A fully initialized buffer whose contents to move into
+  ///        the array.
+  ///
+  /// - Complexity: O(`self.count` + `items.count`)
+  @_alwaysEmitIntoClient
+  public mutating func insert(
+    moving items: UnsafeMutableBufferPointer<Element>,
+    at index: Int
+  ) {
+    // FIXME: Avoid moving the subsequent elements twice.
+    _ensureFreeCapacity(items.count)
+    _storage.insert(moving: items, at: index)
+  }
+
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+  /// Moves the elements of an input span into this array,
+  /// starting at the specified position, and leaving the span empty.
+  ///
+  /// All existing elements at or following the specified position are moved to
+  /// make room for the new items.
+  ///
+  /// If the array does not have sufficient capacity to hold the new elements,
+  /// then this reallocates storage to extend its capacity, using a geometric
+  /// growth rate.
+  ///
+  /// - Parameters:
+  ///    - items: An input span whose contents to move into
+  ///        the array.
+  ///    - index: The position at which to insert the new items.
+  ///       `index` must be a valid index in the array.
+  ///
+  /// - Complexity: O(`self.count` + `items.count`)
+  @_alwaysEmitIntoClient
+  public mutating func insert(
+    moving items: inout InputSpan<Element>,
+    at index: Int
+  ) {
+    _ensureFreeCapacity(items.count)
+    _storage.insert(moving: &items, at: index)
+  }
+#endif
+
+  /// Moves the elements of an output span into this array,
+  /// starting at the specified position, and leaving the span empty.
+  ///
+  /// All existing elements at or following the specified position are moved to
+  /// make room for the new items.
+  ///
+  /// If the array does not have sufficient capacity to hold the new elements,
+  /// then this reallocates storage to extend its capacity, using a geometric
+  /// growth rate.
+  ///
+  /// - Parameters:
+  ///    - items: An output span whose contents to move into
+  ///        the array.
+  ///    - index: The position at which to insert the new items.
+  ///       `index` must be a valid index in the array.
+  ///
+  /// - Complexity: O(`self.count` + `items.count`)
+  @_alwaysEmitIntoClient
+  public mutating func insert(
+    moving items: inout OutputSpan<Element>,
+    at index: Int
+  ) {
+    _ensureFreeCapacity(items.count)
+    _storage.insert(moving: &items, at: index)
+  }
+
+  /// Inserts the elements of a given array into the given position in this
+  /// array by moving them between the containers. On return, the input array
+  /// becomes empty, but it is not destroyed, and it preserves its original
+  /// storage capacity.
+  ///
+  /// If the array does not have sufficient capacity to hold all elements,
+  /// then this reallocates storage to extend its capacity, using a geometric
+  /// growth rate.
+  ///
+  /// - Parameters:
+  ///    - items: An array whose contents to move into `self`.
+  ///
+  /// - Complexity: O(`self.count` + `items.count`)
+  @_alwaysEmitIntoClient
+  public mutating func insert(
+    moving items: inout RigidArray<Element>,
+    at index: Int
+  ) {
+    // FIXME: Avoid moving the subsequent elements twice.
+    _ensureFreeCapacity(items.count)
+    _storage.insert(moving: &items, at: index)
+  }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray where Element: ~Copyable {
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+  /// Inserts the elements of a given array into the given position in this
+  /// array by consuming the source container.
+  ///
+  /// If the array does not have sufficient capacity to hold all elements,
+  /// then this reallocates storage to extend its capacity, using a geometric
+  /// growth rate.
+  ///
+  /// - Parameters:
+  ///    - items: A fully initialized buffer whose contents to move into
+  ///        the array.
+  ///
+  /// - Complexity: O(`self.count` + `items.count`)
+  @_alwaysEmitIntoClient
+  public mutating func insert(
+    consuming items: consuming RigidArray<Element>,
+    at index: Int
+  ) {
+    // FIXME: Remove this in favor of a generic algorithm over consumable containers
+    // FIXME: Avoid moving the subsequent elements twice.
+    _ensureFreeCapacity(items.count)
+    _storage.insert(consuming: items, at: index)
+  }
+#endif
+}
+
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray {
+  /// Copyies the elements of a fully initialized buffer pointer into this
+  /// array at the specified position.
+  ///
+  /// The new elements are inserted before the element currently at the
+  /// specified index. If you pass the array’s `endIndex` as the `index`
+  /// parameter, then the new elements are appended to the end of the array.
+  ///
+  /// All existing elements at or following the specified position are moved to
+  /// make room for the new item.
+  ///
+  /// If the array does not have sufficient capacity to hold enough elements,
+  /// then this reallocates the array's storage to extend its capacity, using a
+  /// geometric growth rate.
+  ///
+  /// - Parameters:
+  ///    - newElements: The new elements to insert into the array. The buffer
+  ///       must be fully initialized.
+  ///    - index: The position at which to insert the new elements. It must be
+  ///       a valid index of the array.
+  ///
+  /// - Complexity: O(`self.count` + `newElements.count`)
+  @inlinable
+  public mutating func insert(
+    copying newElements: UnsafeBufferPointer<Element>, at index: Int
+  ) {
+    // FIXME: Avoid moving the subsequent elements twice.
+    _ensureFreeCapacity(newElements.count)
+    unsafe _storage.insert(copying: newElements, at: index)
+  }
+
+  /// Copyies the elements of a fully initialized buffer pointer into this
+  /// array at the specified position.
+  ///
+  /// The new elements are inserted before the element currently at the
+  /// specified index. If you pass the array’s `endIndex` as the `index`
+  /// parameter, then the new elements are appended to the end of the array.
+  ///
+  /// All existing elements at or following the specified position are moved to
+  /// make room for the new item.
+  ///
+  /// If the array does not have sufficient capacity to hold enough elements,
+  /// then this reallocates the array's storage to extend its capacity, using a
+  /// geometric growth rate.
+  ///
+  /// - Parameters:
+  ///    - newElements: The new elements to insert into the array. The buffer
+  ///       must be fully initialized.
+  ///    - index: The position at which to insert the new elements. It must be
+  ///       a valid index of the array.
+  ///
+  /// - Complexity: O(`self.count` + `newElements.count`)
+  @inlinable
+  public mutating func insert(
+    copying newElements: UnsafeMutableBufferPointer<Element>,
+    at index: Int
+  ) {
+    unsafe self.insert(copying: UnsafeBufferPointer(newElements), at: index)
+  }
+
+  /// Copies the elements of a span into this array at the specified position.
+  ///
+  /// The new elements are inserted before the element currently at the
+  /// specified index. If you pass the array’s `endIndex` as the `index`
+  /// parameter, then the new elements are appended to the end of the array.
+  ///
+  /// All existing elements at or following the specified position are moved to
+  /// make room for the new item.
+  ///
+  /// If the array does not have sufficient capacity to hold enough elements,
+  /// then this reallocates the array's storage to extend its capacity, using a
+  /// geometric growth rate.
+  ///
+  /// - Parameters:
+  ///    - newElements: The new elements to insert into the array.
+  ///    - index: The position at which to insert the new elements. It must be
+  ///        a valid index of the array.
+  ///
+  /// - Complexity: O(`self.count` + `newElements.count`)
+  @inlinable
+  public mutating func insert(
+    copying newElements: Span<Element>, at index: Int
+  ) {
+    // FIXME: Avoid moving the subsequent elements twice.
+    _ensureFreeCapacity(newElements.count)
+    _storage.insert(copying: newElements, at: index)
+  }
+
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+  /// Copies the elements of a container into this array at the specified
+  /// position.
+  ///
+  /// The new elements are inserted before the element currently at the
+  /// specified index. If you pass the array’s `endIndex` as the `index`
+  /// parameter, then the new elements are appended to the end of the array.
+  ///
+  /// All existing elements at or following the specified position are moved to
+  /// make room for the new item.
+  ///
+  /// If the array does not have sufficient capacity to hold enough elements,
+  /// then this reallocates the array's storage to extend its capacity, using a
+  /// geometric growth rate.
+  ///
+  /// - Parameters:
+  ///    - newElements: The new elements to insert into the array.
+  ///    - index: The position at which to insert the new elements. It must be
+  ///        a valid index of the array.
+  ///
+  /// - Complexity: O(*n* + *m*), where *n* is count of this array and
+  ///    *m* is the count of `newElements`.
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  public mutating func insert<
+    C: Container<Element> & ~Copyable & ~Escapable
+  >(
+    copying newElements: borrowing C, at index: Int
+  ) {
+    // FIXME: Avoid moving the subsequent elements twice.
+    let c = newElements.count
+    _ensureFreeCapacity(c)
+    _storage._insertContainer(at: index, copying: newElements, newCount: c)
+  }
+#endif
+
+  /// Copies the elements of a collection into this array at the specified
+  /// position.
+  ///
+  /// The new elements are inserted before the element currently at the
+  /// specified index. If you pass the array’s `endIndex` as the `index`
+  /// parameter, then the new elements are appended to the end of the array.
+  ///
+  /// All existing elements at or following the specified position are moved
+  /// to make room for the new item.
+  ///
+  /// If the array does not have sufficient capacity to hold enough elements,
+  /// then this reallocates the array's storage to extend its capacity, using a
+  /// geometric growth rate.
+  ///
+  /// - Parameters:
+  ///    - newElements: The new elements to insert into the array.
+  ///    - index: The position at which to insert the new elements. It must be
+  ///        a valid index of the array.
+  ///
+  /// - Complexity: O(`self.count` + `newElements.count`)
+  @inlinable
+  public mutating func insert(
+    copying newElements: some Collection<Element>, at index: Int
+  ) {
+    // FIXME: Avoid moving the subsequent elements twice.
+    let newCount = newElements.count
+    _ensureFreeCapacity(newCount)
+    _storage._insertCollection(
+      at: index, copying: newElements, newCount: newCount)
+  }
+  
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+  /// Copies the elements of a container into this array at the specified
+  /// position.
+  ///
+  /// The new elements are inserted before the element currently at the
+  /// specified index. If you pass the array’s `endIndex` as the `index`
+  /// parameter, then the new elements are appended to the end of the array.
+  ///
+  /// All existing elements at or following the specified position are moved to
+  /// make room for the new item.
+  ///
+  /// If the array does not have sufficient capacity to hold enough elements,
+  /// then this reallocates the array's storage to extend its capacity, using a
+  /// geometric growth rate.
+  ///
+  /// - Parameters:
+  ///    - newElements: The new elements to insert into the array.
+  ///    - index: The position at which to insert the new elements. It must be
+  ///        a valid index of the array.
+  ///
+  /// - Complexity: O(*n* + *m*), where *n* is count of this array and
+  ///    *m* is the count of `newElements`.
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  public mutating func insert<
+    C: Container<Element> & Collection<Element>
+  >(
+    copying newElements: borrowing C, at index: Int
+  ) {
+    // FIXME: Avoid moving the subsequent elements twice.
+    let c = newElements.count
+    _ensureFreeCapacity(c)
+    _storage._insertContainer(at: index, copying: newElements, newCount: c)
+  }
+#endif
+}
+
+#endif

--- a/stdlib/public/core/UniqueArray/UniqueArray+Insertions.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Insertions.swift
@@ -141,30 +141,6 @@ extension UniqueArray where Element: ~Copyable {
     _ensureFreeCapacity(items.count)
     _storage.insert(moving: &items, at: index)
   }
-
-  /// Inserts the elements of a given array into the given position in this
-  /// array by moving them between the containers. On return, the input array
-  /// becomes empty, but it is not destroyed, and it preserves its original
-  /// storage capacity.
-  ///
-  /// If the array does not have sufficient capacity to hold all elements,
-  /// then this reallocates storage to extend its capacity, using a geometric
-  /// growth rate.
-  ///
-  /// - Parameters:
-  ///    - items: An array whose contents to move into `self`.
-  ///
-  /// - Complexity: O(`self.count` + `items.count`)
-  @available(SwiftStdlib 6.4, *)
-  @_alwaysEmitIntoClient
-  public mutating func insert(
-    moving items: inout RigidArray<Element>,
-    at index: Int
-  ) {
-    // FIXME: Avoid moving the subsequent elements twice.
-    _ensureFreeCapacity(items.count)
-    _storage.insert(moving: &items, at: index)
-  }
 }
 
 @available(SwiftStdlib 6.4, *)

--- a/stdlib/public/core/UniqueArray/UniqueArray+Insertions.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Insertions.swift
@@ -145,7 +145,7 @@ extension UniqueArray where Element: ~Copyable {
 
 @available(SwiftStdlib 6.4, *)
 extension UniqueArray where Element: Copyable {
-  /// Copyies the elements of a fully initialized buffer pointer into this
+  /// Copies the elements of a fully initialized buffer pointer into this
   /// array at the specified position.
   ///
   /// The new elements are inserted before the element currently at the
@@ -176,7 +176,7 @@ extension UniqueArray where Element: Copyable {
     unsafe _storage.insert(copying: newElements, at: index)
   }
 
-  /// Copyies the elements of a fully initialized buffer pointer into this
+  /// Copies the elements of a fully initialized buffer pointer into this
   /// array at the specified position.
   ///
   /// The new elements are inserted before the element currently at the

--- a/stdlib/public/core/UniqueArray/UniqueArray+Insertions.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Insertions.swift
@@ -33,7 +33,7 @@ extension UniqueArray where Element: ~Copyable {
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   public mutating func insert(_ item: consuming Element, at index: Int) {
-    precondition(index >= 0 && index <= count)
+    _precondition(index >= 0 && index <= count)
     // FIXME: Avoid moving the subsequent elements twice.
     _ensureFreeCapacity(1)
     _storage.insert(item, at: index)

--- a/stdlib/public/core/UniqueArray/UniqueArray+Removals.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Removals.swift
@@ -1,29 +1,23 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift Collections open source project
+// This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2024 - 2025 Apple Inc. and the Swift project authors
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 
-#if !COLLECTIONS_SINGLE_MODULE
-import InternalCollectionsUtilities
-import ContainersPreview
-#endif
-
-#if compiler(>=6.2)
-
-@available(SwiftStdlib 5.0, *)
+@available(SwiftStdlib 6.4, *)
 extension UniqueArray where Element: ~Copyable {
   /// Removes all elements from the array, optionally preserving its
   /// allocated capacity.
   ///
   /// - Complexity: O(*n*), where *n* is the original count of the array.
-  @inlinable
-  @inline(__always)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public mutating func removeAll(keepingCapacity keepCapacity: Bool = false) {
     if keepCapacity {
       _storage.removeAll()
@@ -39,9 +33,9 @@ extension UniqueArray where Element: ~Copyable {
   /// - Returns: The last element of the original array.
   ///
   /// - Complexity: O(1)
-  @inlinable
-  @inline(__always)
+  @available(SwiftStdlib 6.4, *)
   @discardableResult
+  @_alwaysEmitIntoClient
   public mutating func removeLast() -> Element {
     _storage.removeLast()
   }
@@ -57,7 +51,8 @@ extension UniqueArray where Element: ~Copyable {
   ///    the count of the array.
   ///
   /// - Complexity: O(`k`)
-  @inlinable
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public mutating func removeLast(_ k: Int) {
     _storage.removeLast(k)
   }
@@ -72,9 +67,9 @@ extension UniqueArray where Element: ~Copyable {
   /// - Returns: The removed element.
   ///
   /// - Complexity: O(`self.count`)
-  @inlinable
-  @inline(__always)
+  @available(SwiftStdlib 6.4, *)
   @discardableResult
+  @_alwaysEmitIntoClient
   public mutating func remove(at index: Int) -> Element {
     _storage.remove(at: index)
   }
@@ -88,7 +83,8 @@ extension UniqueArray where Element: ~Copyable {
   ///   of the range must be valid indices of the array.
   ///
   /// - Complexity: O(`self.count`)
-  @inlinable
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public mutating func removeSubrange(_  bounds: Range<Int>) {
     _storage.removeSubrange(bounds)
   }
@@ -99,6 +95,7 @@ extension UniqueArray where Element: ~Copyable {
   ///   of the range must be valid indices of the array.
   ///
   /// - Complexity: O(`self.count`)
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   public mutating func removeSubrange(_  bounds: some RangeExpression<Int>) {
     // FIXME: Remove this in favor of a standard algorithm.
@@ -106,7 +103,7 @@ extension UniqueArray where Element: ~Copyable {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftStdlib 6.4, *)
 extension UniqueArray where Element: ~Copyable {
   /// Removes and returns the last element of the array, if there is one.
   ///
@@ -114,11 +111,10 @@ extension UniqueArray where Element: ~Copyable {
   ///    otherwise, `nil`.
   ///
   /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   public mutating func popLast() -> Element? {
     if isEmpty { return nil }
     return removeLast()
   }
 }
-
-#endif

--- a/stdlib/public/core/UniqueArray/UniqueArray+Removals.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Removals.swift
@@ -1,0 +1,124 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2024 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if !COLLECTIONS_SINGLE_MODULE
+import InternalCollectionsUtilities
+import ContainersPreview
+#endif
+
+#if compiler(>=6.2)
+
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray where Element: ~Copyable {
+  /// Removes all elements from the array, optionally preserving its
+  /// allocated capacity.
+  ///
+  /// - Complexity: O(*n*), where *n* is the original count of the array.
+  @inlinable
+  @inline(__always)
+  public mutating func removeAll(keepingCapacity keepCapacity: Bool = false) {
+    if keepCapacity {
+      _storage.removeAll()
+    } else {
+      _storage = RigidArray(capacity: 0)
+    }
+  }
+
+  /// Removes and returns the last element of the array.
+  ///
+  /// The array must not be empty.
+  ///
+  /// - Returns: The last element of the original array.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  @inline(__always)
+  @discardableResult
+  public mutating func removeLast() -> Element {
+    _storage.removeLast()
+  }
+
+  /// Removes and discards the specified number of elements from the end of the
+  /// array.
+  ///
+  /// Attempting to remove more elements than exist in the array triggers a
+  /// runtime error.
+  ///
+  /// - Parameter k: The number of elements to remove from the array.
+  ///   `k` must be greater than or equal to zero and must not exceed
+  ///    the count of the array.
+  ///
+  /// - Complexity: O(`k`)
+  @inlinable
+  public mutating func removeLast(_ k: Int) {
+    _storage.removeLast(k)
+  }
+
+  /// Removes and returns the element at the specified position.
+  ///
+  /// All the elements following the specified position are moved to close the
+  /// gap.
+  ///
+  /// - Parameter i: The position of the element to remove. `index` must be
+  ///   a valid index of the array that is not equal to the end index.
+  /// - Returns: The removed element.
+  ///
+  /// - Complexity: O(`self.count`)
+  @inlinable
+  @inline(__always)
+  @discardableResult
+  public mutating func remove(at index: Int) -> Element {
+    _storage.remove(at: index)
+  }
+
+  /// Removes the specified subrange of elements from the array.
+  ///
+  /// All the elements following the specified subrange are moved to close the
+  /// resulting gap.
+  ///
+  /// - Parameter bounds: The subrange of the array to remove. The bounds
+  ///   of the range must be valid indices of the array.
+  ///
+  /// - Complexity: O(`self.count`)
+  @inlinable
+  public mutating func removeSubrange(_  bounds: Range<Int>) {
+    _storage.removeSubrange(bounds)
+  }
+
+  /// Removes the specified subrange of elements from the array.
+  ///
+  /// - Parameter bounds: The subrange of the array to remove. The bounds
+  ///   of the range must be valid indices of the array.
+  ///
+  /// - Complexity: O(`self.count`)
+  @_alwaysEmitIntoClient
+  public mutating func removeSubrange(_  bounds: some RangeExpression<Int>) {
+    // FIXME: Remove this in favor of a standard algorithm.
+    removeSubrange(bounds.relative(to: indices))
+  }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray where Element: ~Copyable {
+  /// Removes and returns the last element of the array, if there is one.
+  ///
+  /// - Returns: The last element of the array if the array is not empty;
+  ///    otherwise, `nil`.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public mutating func popLast() -> Element? {
+    if isEmpty { return nil }
+    return removeLast()
+  }
+}
+
+#endif

--- a/stdlib/public/core/UniqueArray/UniqueArray+Removals.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Removals.swift
@@ -12,18 +12,13 @@
 
 @available(SwiftStdlib 6.4, *)
 extension UniqueArray where Element: ~Copyable {
-  /// Removes all elements from the array, optionally preserving its
-  /// allocated capacity.
+  /// Removes all elements from the array, preserving its allocated capacity.
   ///
   /// - Complexity: O(*n*), where *n* is the original count of the array.
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func removeAll(keepingCapacity keepCapacity: Bool = false) {
-    if keepCapacity {
-      _storage.removeAll()
-    } else {
-      _storage = _RigidArray(capacity: 0)
-    }
+  public mutating func removeAll() {
+    _storage.removeAll()
   }
 
   /// Removes and returns the last element of the array.

--- a/stdlib/public/core/UniqueArray/UniqueArray+Removals.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Removals.swift
@@ -22,7 +22,7 @@ extension UniqueArray where Element: ~Copyable {
     if keepCapacity {
       _storage.removeAll()
     } else {
-      _storage = RigidArray(capacity: 0)
+      _storage = _RigidArray(capacity: 0)
     }
   }
 

--- a/stdlib/public/core/UniqueArray/UniqueArray+Replacements.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Replacements.swift
@@ -1,0 +1,599 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2024 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if !COLLECTIONS_SINGLE_MODULE
+import InternalCollectionsUtilities
+import ContainersPreview
+#endif
+
+#if compiler(>=6.2)
+
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray where Element: ~Copyable {
+  /// Replaces the specified range of elements by a given count of new items,
+  /// using a callback to directly initialize array storage by populating
+  /// an output span.
+  ///
+  /// The number of new items need not match the number of elements being
+  /// removed.
+  ///
+  /// This method has the same overall effect as calling
+  ///
+  ///     try array.removeSubrange(subrange)
+  ///     try array.insert(
+  ///       addingCount: newItemCount,
+  ///       at: subrange.lowerBound,
+  ///       initializingWith: initializer)
+  ///
+  /// Except it performs faster (by a constant factor), by avoiding moving
+  /// some items in the array twice.
+  ///
+  /// If the array does not have sufficient capacity to perform the replacement,
+  /// then this reallocates storage to extend its capacity, using a geometric
+  /// growth rate.
+  ///
+  /// If the callback fails to fully populate its output span or if
+  /// it throws an error, then the array keeps all items that were
+  /// successfully initialized before the callback terminated the prepend.
+  ///
+  /// Partial insertions create a gap in array storage that needs to be
+  /// closed by moving newly inserted items to their correct positions given
+  /// the adjusted count. This adds some overhead compared to adding exactly as
+  /// many items as promised.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the array to replace. The bounds of
+  ///      the range must be valid indices in the array.
+  ///   - newItemCount: the maximum number of items to replace the old subrange.
+  ///   - initializer: A callback that gets called at most once to directly
+  ///      populate newly reserved storage within the array. The function
+  ///      is always called with an empty output span.
+  ///
+  /// - Complexity: O(`self.count` + `newItemCount`) in addition to the complexity
+  ///    of the callback invocations.
+  @inlinable
+  public mutating func replace<E: Error>(
+    removing subrange: Range<Int>,
+    addingCount newItemCount: Int,
+    initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
+  ) throws(E) -> Void {
+    _storage._checkValidBounds(subrange)
+    precondition(newItemCount >= 0, "Cannot add a negative number of items")
+    // FIXME: Avoid moving the subsequent elements twice on resize.
+    _ensureFreeCapacity(newItemCount - subrange.count)
+    try _storage._uncheckedReplace(
+      removing: subrange,
+      addingCount: newItemCount,
+      initializingWith: initializer)
+  }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray where Element: ~Copyable {
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+  /// Replaces the specified range of elements by a given count of new items,
+  /// using callbacks to consume old items, and to then insert new ones.
+  ///
+  /// The number of new items need not match the number of elements being
+  /// removed.
+  ///
+  /// This method has the same overall effect as calling
+  ///
+  ///     try array.consume(subrange, consumingWith: consumer)
+  ///     try array.insert(
+  ///       addingCount: newItemCount,
+  ///       at: subrange.lowerBound,
+  ///       initializingWith: initializer)
+  ///
+  /// Except it performs faster (by a constant factor), by avoiding moving
+  /// some items in the deque twice.
+  ///
+  /// If the array does not have sufficient capacity to perform the replacement,
+  /// then this reallocates storage to extend its capacity, using a geometric
+  /// growth rate.
+  ///
+  /// The `consumer` callback is not required to fully depopulate its input
+  /// span. Any items the callback leaves in the span still get removed and
+  /// discarded from the array before insertions begin.
+  ///
+  /// The `initializer` callback is not required to fully populate its
+  /// output span, and it is allowed to throw an error. In such cases, the
+  /// deque keeps all items that were successfully initialized before the
+  /// callback terminated.
+  ///
+  /// Partial insertions create a gap in array storage that needs to be
+  /// closed by moving newly inserted items to their correct positions given
+  /// the adjusted count. This adds some overhead compared to adding exactly as
+  /// many items as promised.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the deque to replace. The bounds of
+  ///      the range must be valid indices in the deque.
+  ///   - consumer: A callback that gets called at most once to consume
+  ///      the elements to be removed directly from the deque's storage. The
+  ///      function is always called with a non-empty input span.
+  ///   - newItemCount: the maximum number of items to replace the old subrange.
+  ///   - initializer: A callback that gets called at most once to directly
+  ///      populate newly reserved storage within the deque. The function
+  ///      is always called with an empty output span.
+  ///
+  /// - Complexity: O(`self.count` + `newItemCount`) in addition to the
+  ///    complexity of the callback invocations.
+  @inlinable
+  public mutating func replace<E: Error>(
+    removing subrange: Range<Int>,
+    consumingWith consumer: (inout InputSpan<Element>) -> Void,
+    addingCount newItemCount: Int,
+    initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
+  ) throws(E) -> Void {
+    _storage._checkValidBounds(subrange)
+    precondition(newItemCount >= 0, "Cannot add a negative number of items")
+    _ensureFreeCapacity(newItemCount - subrange.count)
+    try _storage._uncheckedReplace(
+      removing: subrange,
+      consumingWith: consumer,
+      addingCount: newItemCount,
+      initializingWith: initializer)
+  }
+#endif
+}
+
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray where Element: ~Copyable {
+  /// Replaces the specified range of elements by moving the elements of a
+  /// fully initialized buffer into their place. On return, the buffer is left
+  /// in an uninitialized state.
+  ///
+  /// This method has the effect of removing the specified range of elements
+  /// from the array and inserting the new elements starting at the same
+  /// location. The number of new elements need not match the number of elements
+  /// being removed.
+  ///
+  /// If the array does not have sufficient capacity to perform the replacement,
+  /// then this reallocates the array's storage to extend its capacity, using a
+  /// geometric growth rate.
+  ///
+  /// If you pass a zero-length range as the `subrange` parameter, this method
+  /// inserts the elements of `newElements` at `subrange.lowerBound`. Calling
+  /// the `insert(copying:at:)` method instead is preferred in this case.
+  ///
+  /// Likewise, if you pass a zero-length buffer as the `newElements`
+  /// parameter, this method removes the elements in the given subrange
+  /// without replacement. Calling the `removeSubrange(_:)` method instead is
+  /// preferred in this case.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the array to replace. The bounds of
+  ///     the range must be valid indices in the array.
+  ///   - newElements: A fully initialized buffer whose contents to move into
+  ///     the array.
+  ///
+  /// - Complexity: O(`self.count` + `newElements.count`)
+  @_alwaysEmitIntoClient
+  public mutating func replace(
+    removing subrange: Range<Int>,
+    moving newElements: UnsafeMutableBufferPointer<Element>,
+  ) {
+    // FIXME: Avoid moving the subsequent elements twice.
+    _ensureFreeCapacity(newElements.count - subrange.count)
+    _storage.replace(removing: subrange, moving: newElements)
+  }
+
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+  /// Replaces the specified range of elements by moving the contents of an
+  /// input span into their place. On return, the span is left empty.
+  ///
+  /// This method has the effect of removing the specified range of elements
+  /// from the array and inserting the new elements starting at the same
+  /// location. The number of new elements need not match the number of elements
+  /// being removed.
+  ///
+  /// If the array does not have sufficient capacity to perform the replacement,
+  /// then this reallocates the array's storage to extend its capacity, using a
+  /// geometric growth rate.
+  ///
+  /// If you pass a zero-length range as the `subrange` parameter, this method
+  /// inserts the elements of `newElements` at `subrange.lowerBound`. Calling
+  /// the `insert(moving:at:)` method instead is preferred in this case.
+  ///
+  /// Likewise, if you pass a zero-length buffer as the `newElements`
+  /// parameter, this method removes the elements in the given subrange
+  /// without replacement. Calling the `removeSubrange(_:)` method instead is
+  /// preferred in this case.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the array to replace. The bounds of
+  ///     the range must be valid indices in the array.
+  ///   - items: An input span whose contents are to be moved into the array.
+  ///
+  /// - Complexity: O(`self.count` + `items.count`)
+  @_alwaysEmitIntoClient
+  public mutating func replace(
+    removing subrange: Range<Int>,
+    moving items: inout InputSpan<Element>
+  ) {
+    // FIXME: Avoid moving the subsequent elements twice.
+    _ensureFreeCapacity(items.count - subrange.count)
+    _storage.replace(removing: subrange, moving: &items)
+  }
+#endif
+
+  /// Replaces the specified range of elements by moving the contents of an
+  /// output span into their place. On return, the span is left empty.
+  ///
+  /// This method has the effect of removing the specified range of elements
+  /// from the array and inserting the new elements starting at the same
+  /// location. The number of new elements need not match the number of elements
+  /// being removed.
+  ///
+  /// If the array does not have sufficient capacity to perform the replacement,
+  /// then this reallocates the array's storage to extend its capacity, using a
+  /// geometric growth rate.
+  ///
+  /// If you pass a zero-length range as the `subrange` parameter, this method
+  /// inserts the elements of `newElements` at `subrange.lowerBound`. Calling
+  /// the `insert(moving:at:)` method instead is preferred in this case.
+  ///
+  /// Likewise, if you pass a zero-length buffer as the `newElements`
+  /// parameter, this method removes the elements in the given subrange
+  /// without replacement. Calling the `removeSubrange(_:)` method instead is
+  /// preferred in this case.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the array to replace. The bounds of
+  ///     the range must be valid indices in the array.
+  ///   - items: An output span whose contents are to be moved into the array.
+  ///
+  /// - Complexity: O(`self.count` + `items.count`)
+  @_alwaysEmitIntoClient
+  public mutating func replace(
+    removing subrange: Range<Int>,
+    moving items: inout OutputSpan<Element>
+  ) {
+    // FIXME: Avoid moving the subsequent elements twice.
+    _ensureFreeCapacity(items.count - subrange.count)
+    _storage.replace(removing: subrange, moving: &items)
+  }
+
+  /// Replaces the specified range of elements by moving the elements of a
+  /// another array into their place.  On return, the source array
+  /// becomes empty, but it is not destroyed, and it preserves its original
+  /// storage capacity.
+  ///
+  /// This method has the effect of removing the specified range of elements
+  /// from the array and inserting the new elements starting at the same
+  /// location. The number of new elements need not match the number of elements
+  /// being removed.
+  ///
+  /// If the array does not have sufficient capacity to hold enough elements,
+  /// then this reallocates the array's storage to extend its capacity, using a
+  /// geometric growth rate.
+  ///
+  /// If you pass a zero-length range as the `subrange` parameter, this method
+  /// inserts the elements of `newElements` at `subrange.lowerBound`. Calling
+  /// the `insert(copying:at:)` method instead is preferred in this case.
+  ///
+  /// Likewise, if you pass a zero-length buffer as the `newElements`
+  /// parameter, this method removes the elements in the given subrange
+  /// without replacement. Calling the `removeSubrange(_:)` method instead is
+  /// preferred in this case.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the array to replace. The bounds of
+  ///     the range must be valid indices in the array.
+  ///   - newElements: An array whose contents to move into `self`.
+  ///
+  /// - Complexity: O(`self.count` + `newElements.count`)
+  @_alwaysEmitIntoClient
+  public mutating func replace(
+    removing subrange: Range<Int>,
+    moving newElements: inout RigidArray<Element>,
+  ) {
+    // FIXME: Avoid moving the subsequent elements twice.
+    _ensureFreeCapacity(newElements.count - subrange.count)
+    _storage.replace(removing: subrange, moving: &newElements)
+  }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray where Element: ~Copyable {
+  /// Replaces the specified range of elements by moving the elements of a
+  /// given array into their place, consuming it in the process.
+  ///
+  /// This method has the effect of removing the specified range of elements
+  /// from the array and inserting the new elements starting at the same
+  /// location. The number of new elements need not match the number of elements
+  /// being removed.
+  ///
+  /// If the array does not have sufficient capacity to perform the replacement,
+  /// then this reallocates the array's storage to extend its capacity, using a
+  /// geometric growth rate.
+  ///
+  /// If you pass a zero-length range as the `subrange` parameter, this method
+  /// inserts the elements of `newElements` at `subrange.lowerBound`. Calling
+  /// the `insert(copying:at:)` method instead is preferred in this case.
+  ///
+  /// Likewise, if you pass a zero-length buffer as the `newElements`
+  /// parameter, this method removes the elements in the given subrange
+  /// without replacement. Calling the `removeSubrange(_:)` method instead is
+  /// preferred in this case.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the array to replace. The bounds of
+  ///     the range must be valid indices in the array.
+  ///   - newElements: An array whose contents to move into `self`.
+  ///
+  /// - Complexity: O(`self.count` + `newElements.count`)
+  @_alwaysEmitIntoClient
+  public mutating func replace(
+    removing subrange: Range<Int>,
+    consuming newElements: consuming RigidArray<Element>,
+  ) {
+    replace(removing: subrange, moving: &newElements)
+  }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray {
+  /// Replaces the specified subrange of elements by copying the elements of
+  /// the given buffer pointer, which must be fully initialized.
+  ///
+  /// This method has the effect of removing the specified range of elements
+  /// from the array and inserting the new elements starting at the same location.
+  /// The number of new elements need not match the number of elements being
+  /// removed.
+  ///
+  /// If the capacity of the array isn't sufficient to perform the replacement,
+  /// then this reallocates the array's storage to extend its capacity, using a
+  /// geometric growth rate.
+  ///
+  /// If you pass a zero-length range as the `subrange` parameter, this method
+  /// inserts the elements of `newElements` at `subrange.lowerBound`. Calling
+  /// the `insert(copying:at:)` method instead is preferred in this case.
+  ///
+  /// Likewise, if you pass a zero-length buffer as the `newElements`
+  /// parameter, this method removes the elements in the given subrange
+  /// without replacement. Calling the `removeSubrange(_:)` method instead is
+  /// preferred in this case.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the array to replace. The bounds of
+  ///     the range must be valid indices in the array.
+  ///   - newElements: The new elements to copy into the collection.
+  ///
+  /// - Complexity: O(*n* + *m*), where *n* is count of this array and
+  ///   *m* is the count of `newElements`.
+  @inlinable
+  @inline(__always)
+  public mutating func replace(
+    removing subrange: Range<Int>,
+    copying newElements: UnsafeBufferPointer<Element>
+  ) {
+    // FIXME: Avoid moving the subsequent elements twice.
+    _ensureFreeCapacity(newElements.count)
+    unsafe _storage.replace(removing: subrange, copying: newElements)
+  }
+
+  /// Replaces the specified subrange of elements by copying the elements of
+  /// the given buffer pointer, which must be fully initialized.
+  ///
+  /// This method has the effect of removing the specified range of elements
+  /// from the array and inserting the new elements starting at the same location.
+  /// The number of new elements need not match the number of elements being
+  /// removed.
+  ///
+  /// If the capacity of the array isn't sufficient to perform the replacement,
+  /// then this reallocates the array's storage to extend its capacity, using a
+  /// geometric growth rate.
+  ///
+  /// If you pass a zero-length range as the `subrange` parameter, this method
+  /// inserts the elements of `newElements` at `subrange.lowerBound`. Calling
+  /// the `insert(copying:at:)` method instead is preferred in this case.
+  ///
+  /// Likewise, if you pass a zero-length buffer as the `newElements`
+  /// parameter, this method removes the elements in the given subrange
+  /// without replacement. Calling the `removeSubrange(_:)` method instead is
+  /// preferred in this case.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the array to replace. The bounds of
+  ///     the range must be valid indices in the array.
+  ///   - newElements: The new elements to copy into the collection.
+  ///
+  /// - Complexity: O(*n* + *m*), where *n* is count of this array and
+  ///   *m* is the count of `newElements`.
+  @inlinable
+  @inline(__always)
+  public mutating func replace(
+    removing subrange: Range<Int>,
+    copying newElements: UnsafeMutableBufferPointer<Element>
+  ) {
+    unsafe self.replace(
+      removing: subrange,
+      copying: UnsafeBufferPointer(newElements))
+  }
+
+  /// Replaces the specified subrange of elements by copying the elements of
+  /// the given span.
+  ///
+  /// This method has the effect of removing the specified range of elements
+  /// from the array and inserting the new elements starting at the same location.
+  /// The number of new elements need not match the number of elements being
+  /// removed.
+  ///
+  /// If the capacity of the array isn't sufficient to perform the replacement,
+  /// then this reallocates the array's storage to extend its capacity, using a
+  /// geometric growth rate.
+  ///
+  /// If you pass a zero-length range as the `subrange` parameter, this method
+  /// inserts the elements of `newElements` at `subrange.lowerBound`. Calling
+  /// the `insert(copying:at:)` method instead is preferred in this case.
+  ///
+  /// Likewise, if you pass a zero-length span as the `newElements`
+  /// parameter, this method removes the elements in the given subrange
+  /// without replacement. Calling the `removeSubrange(_:)` method instead is
+  /// preferred in this case.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the array to replace. The bounds of
+  ///     the range must be valid indices in the array.
+  ///   - newElements: The new elements to copy into the collection.
+  ///
+  /// - Complexity: O(*n* + *m*), where *n* is count of this array and
+  ///   *m* is the count of `newElements`.
+  @inlinable
+  public mutating func replace(
+    removing subrange: Range<Int>,
+    copying newElements: Span<Element>
+  ) {
+    // FIXME: Avoid moving the subsequent elements twice.
+    _ensureFreeCapacity(newElements.count)
+    _storage.replace(removing: subrange, copying: newElements)
+  }
+  
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+  /// Replaces the specified subrange of elements by copying the elements of
+  /// the given container.
+  ///
+  /// This method has the effect of removing the specified range of elements
+  /// from the array and inserting the new elements starting at the same location.
+  /// The number of new elements need not match the number of elements being
+  /// removed.
+  ///
+  /// If the capacity of the array isn't sufficient to perform the replacement,
+  /// then this reallocates the array's storage to extend its capacity, using a
+  /// geometric growth rate.
+  ///
+  /// If you pass a zero-length range as the `subrange` parameter, this method
+  /// inserts the elements of `newElements` at `subrange.lowerBound`. Calling
+  /// the `insert(copying:at:)` method instead is preferred in this case.
+  ///
+  /// Likewise, if you pass a zero-length container as the `newElements`
+  /// parameter, this method removes the elements in the given subrange
+  /// without replacement. Calling the `removeSubrange(_:)` method instead is
+  /// preferred in this case.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the array to replace. The bounds of
+  ///     the range must be valid indices in the array.
+  ///   - newElements: The new elements to copy into the collection.
+  ///
+  /// - Complexity: O(*n* + *m*), where *n* is count of this array and
+  ///   *m* is the count of `newElements`.
+  @inlinable
+  @inline(__always)
+  public mutating func replace<
+    C: Container<Element> & ~Copyable & ~Escapable
+  >(
+    removing subrange: Range<Int>,
+    copying newElements: borrowing C
+  ) {
+    // FIXME: Avoid moving the subsequent elements twice.
+    let c = newElements.count
+    _ensureFreeCapacity(c - subrange.count)
+    _storage._replace(
+      removing: subrange,
+      copyingContainer: newElements,
+      newCount: c)
+  }
+#endif
+
+  /// Replaces the specified subrange of elements by copying the elements of
+  /// the given collection.
+  ///
+  /// This method has the effect of removing the specified range of elements
+  /// from the array and inserting the new elements starting at the same location.
+  /// The number of new elements need not match the number of elements being
+  /// removed.
+  ///
+  /// If the capacity of the array isn't sufficient to perform the replacement,
+  /// then this reallocates the array's storage to extend its capacity, using a
+  /// geometric growth rate.
+  ///
+  /// If you pass a zero-length range as the `subrange` parameter, this method
+  /// inserts the elements of `newElements` at `subrange.lowerBound`. Calling
+  /// the `insert(copying:at:)` method instead is preferred in this case.
+  ///
+  /// Likewise, if you pass a zero-length collection as the `newElements`
+  /// parameter, this method removes the elements in the given subrange
+  /// without replacement. Calling the `removeSubrange(_:)` method instead is
+  /// preferred in this case.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the array to replace. The bounds of
+  ///     the range must be valid indices in the array.
+  ///   - newElements: The new elements to copy into the collection.
+  ///
+  /// - Complexity: O(*n* + *m*), where *n* is count of this array and
+  ///   *m* is the count of `newElements`.
+  @inlinable
+  @inline(__always)
+  public mutating func replace(
+    removing subrange: Range<Int>,
+    copying newElements: __owned some Collection<Element>
+  ) {
+    // FIXME: Avoid moving the subsequent elements twice.
+    let c = newElements.count
+    _ensureFreeCapacity(c)
+    _storage._replace(
+      removing: subrange,
+      copyingCollection: newElements,
+      newCount: c)
+  }
+  
+#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
+  /// Replaces the specified subrange of elements by copying the elements of
+  /// the given container.
+  ///
+  /// This method has the effect of removing the specified range of elements
+  /// from the array and inserting the new elements starting at the same location.
+  /// The number of new elements need not match the number of elements being
+  /// removed.
+  ///
+  /// If the capacity of the array isn't sufficient to perform the replacement,
+  /// then this reallocates the array's storage to extend its capacity, using a
+  /// geometric growth rate.
+  ///
+  /// If you pass a zero-length range as the `subrange` parameter, this method
+  /// inserts the elements of `newElements` at `subrange.lowerBound`. Calling
+  /// the `insert(copying:at:)` method instead is preferred in this case.
+  ///
+  /// Likewise, if you pass a zero-length container as the `newElements`
+  /// parameter, this method removes the elements in the given subrange
+  /// without replacement. Calling the `removeSubrange(_:)` method instead is
+  /// preferred in this case.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the array to replace. The bounds of
+  ///     the range must be valid indices in the array.
+  ///   - newElements: The new elements to copy into the collection.
+  ///
+  /// - Complexity: O(*n* + *m*), where *n* is count of this array and
+  ///   *m* is the count of `newElements`.
+  @inlinable
+  @inline(__always)
+  public mutating func replaceSubrange<
+    C: Container<Element> & Collection<Element>
+  >(
+    _ subrange: Range<Int>,
+    copying newElements: borrowing C
+  ) {
+    // FIXME: Avoid moving the subsequent elements twice.
+    let c = newElements.count
+    _ensureFreeCapacity(c - subrange.count)
+    _storage._replace(
+      removing: subrange,
+      copyingContainer: newElements,
+      newCount: c)
+  }
+#endif
+}
+#endif

--- a/stdlib/public/core/UniqueArray/UniqueArray+Replacements.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Replacements.swift
@@ -1,22 +1,16 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift Collections open source project
+// This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2024 - 2025 Apple Inc. and the Swift project authors
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 
-#if !COLLECTIONS_SINGLE_MODULE
-import InternalCollectionsUtilities
-import ContainersPreview
-#endif
-
-#if compiler(>=6.2)
-
-@available(SwiftStdlib 5.0, *)
+@available(SwiftStdlib 6.4, *)
 extension UniqueArray where Element: ~Copyable {
   /// Replaces the specified range of elements by a given count of new items,
   /// using a callback to directly initialize array storage by populating
@@ -59,7 +53,8 @@ extension UniqueArray where Element: ~Copyable {
   ///
   /// - Complexity: O(`self.count` + `newItemCount`) in addition to the complexity
   ///    of the callback invocations.
-  @inlinable
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public mutating func replace<E: Error>(
     removing subrange: Range<Int>,
     addingCount newItemCount: Int,
@@ -76,77 +71,7 @@ extension UniqueArray where Element: ~Copyable {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
-extension UniqueArray where Element: ~Copyable {
-#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
-  /// Replaces the specified range of elements by a given count of new items,
-  /// using callbacks to consume old items, and to then insert new ones.
-  ///
-  /// The number of new items need not match the number of elements being
-  /// removed.
-  ///
-  /// This method has the same overall effect as calling
-  ///
-  ///     try array.consume(subrange, consumingWith: consumer)
-  ///     try array.insert(
-  ///       addingCount: newItemCount,
-  ///       at: subrange.lowerBound,
-  ///       initializingWith: initializer)
-  ///
-  /// Except it performs faster (by a constant factor), by avoiding moving
-  /// some items in the deque twice.
-  ///
-  /// If the array does not have sufficient capacity to perform the replacement,
-  /// then this reallocates storage to extend its capacity, using a geometric
-  /// growth rate.
-  ///
-  /// The `consumer` callback is not required to fully depopulate its input
-  /// span. Any items the callback leaves in the span still get removed and
-  /// discarded from the array before insertions begin.
-  ///
-  /// The `initializer` callback is not required to fully populate its
-  /// output span, and it is allowed to throw an error. In such cases, the
-  /// deque keeps all items that were successfully initialized before the
-  /// callback terminated.
-  ///
-  /// Partial insertions create a gap in array storage that needs to be
-  /// closed by moving newly inserted items to their correct positions given
-  /// the adjusted count. This adds some overhead compared to adding exactly as
-  /// many items as promised.
-  ///
-  /// - Parameters:
-  ///   - subrange: The subrange of the deque to replace. The bounds of
-  ///      the range must be valid indices in the deque.
-  ///   - consumer: A callback that gets called at most once to consume
-  ///      the elements to be removed directly from the deque's storage. The
-  ///      function is always called with a non-empty input span.
-  ///   - newItemCount: the maximum number of items to replace the old subrange.
-  ///   - initializer: A callback that gets called at most once to directly
-  ///      populate newly reserved storage within the deque. The function
-  ///      is always called with an empty output span.
-  ///
-  /// - Complexity: O(`self.count` + `newItemCount`) in addition to the
-  ///    complexity of the callback invocations.
-  @inlinable
-  public mutating func replace<E: Error>(
-    removing subrange: Range<Int>,
-    consumingWith consumer: (inout InputSpan<Element>) -> Void,
-    addingCount newItemCount: Int,
-    initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
-  ) throws(E) -> Void {
-    _storage._checkValidBounds(subrange)
-    precondition(newItemCount >= 0, "Cannot add a negative number of items")
-    _ensureFreeCapacity(newItemCount - subrange.count)
-    try _storage._uncheckedReplace(
-      removing: subrange,
-      consumingWith: consumer,
-      addingCount: newItemCount,
-      initializingWith: initializer)
-  }
-#endif
-}
-
-@available(SwiftStdlib 5.0, *)
+@available(SwiftStdlib 6.4, *)
 extension UniqueArray where Element: ~Copyable {
   /// Replaces the specified range of elements by moving the elements of a
   /// fully initialized buffer into their place. On return, the buffer is left
@@ -177,6 +102,7 @@ extension UniqueArray where Element: ~Copyable {
   ///     the array.
   ///
   /// - Complexity: O(`self.count` + `newElements.count`)
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   public mutating func replace(
     removing subrange: Range<Int>,
@@ -184,47 +110,8 @@ extension UniqueArray where Element: ~Copyable {
   ) {
     // FIXME: Avoid moving the subsequent elements twice.
     _ensureFreeCapacity(newElements.count - subrange.count)
-    _storage.replace(removing: subrange, moving: newElements)
+    unsafe _storage.replace(removing: subrange, moving: newElements)
   }
-
-#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
-  /// Replaces the specified range of elements by moving the contents of an
-  /// input span into their place. On return, the span is left empty.
-  ///
-  /// This method has the effect of removing the specified range of elements
-  /// from the array and inserting the new elements starting at the same
-  /// location. The number of new elements need not match the number of elements
-  /// being removed.
-  ///
-  /// If the array does not have sufficient capacity to perform the replacement,
-  /// then this reallocates the array's storage to extend its capacity, using a
-  /// geometric growth rate.
-  ///
-  /// If you pass a zero-length range as the `subrange` parameter, this method
-  /// inserts the elements of `newElements` at `subrange.lowerBound`. Calling
-  /// the `insert(moving:at:)` method instead is preferred in this case.
-  ///
-  /// Likewise, if you pass a zero-length buffer as the `newElements`
-  /// parameter, this method removes the elements in the given subrange
-  /// without replacement. Calling the `removeSubrange(_:)` method instead is
-  /// preferred in this case.
-  ///
-  /// - Parameters:
-  ///   - subrange: The subrange of the array to replace. The bounds of
-  ///     the range must be valid indices in the array.
-  ///   - items: An input span whose contents are to be moved into the array.
-  ///
-  /// - Complexity: O(`self.count` + `items.count`)
-  @_alwaysEmitIntoClient
-  public mutating func replace(
-    removing subrange: Range<Int>,
-    moving items: inout InputSpan<Element>
-  ) {
-    // FIXME: Avoid moving the subsequent elements twice.
-    _ensureFreeCapacity(items.count - subrange.count)
-    _storage.replace(removing: subrange, moving: &items)
-  }
-#endif
 
   /// Replaces the specified range of elements by moving the contents of an
   /// output span into their place. On return, the span is left empty.
@@ -253,6 +140,7 @@ extension UniqueArray where Element: ~Copyable {
   ///   - items: An output span whose contents are to be moved into the array.
   ///
   /// - Complexity: O(`self.count` + `items.count`)
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   public mutating func replace(
     removing subrange: Range<Int>,
@@ -262,86 +150,9 @@ extension UniqueArray where Element: ~Copyable {
     _ensureFreeCapacity(items.count - subrange.count)
     _storage.replace(removing: subrange, moving: &items)
   }
-
-  /// Replaces the specified range of elements by moving the elements of a
-  /// another array into their place.  On return, the source array
-  /// becomes empty, but it is not destroyed, and it preserves its original
-  /// storage capacity.
-  ///
-  /// This method has the effect of removing the specified range of elements
-  /// from the array and inserting the new elements starting at the same
-  /// location. The number of new elements need not match the number of elements
-  /// being removed.
-  ///
-  /// If the array does not have sufficient capacity to hold enough elements,
-  /// then this reallocates the array's storage to extend its capacity, using a
-  /// geometric growth rate.
-  ///
-  /// If you pass a zero-length range as the `subrange` parameter, this method
-  /// inserts the elements of `newElements` at `subrange.lowerBound`. Calling
-  /// the `insert(copying:at:)` method instead is preferred in this case.
-  ///
-  /// Likewise, if you pass a zero-length buffer as the `newElements`
-  /// parameter, this method removes the elements in the given subrange
-  /// without replacement. Calling the `removeSubrange(_:)` method instead is
-  /// preferred in this case.
-  ///
-  /// - Parameters:
-  ///   - subrange: The subrange of the array to replace. The bounds of
-  ///     the range must be valid indices in the array.
-  ///   - newElements: An array whose contents to move into `self`.
-  ///
-  /// - Complexity: O(`self.count` + `newElements.count`)
-  @_alwaysEmitIntoClient
-  public mutating func replace(
-    removing subrange: Range<Int>,
-    moving newElements: inout RigidArray<Element>,
-  ) {
-    // FIXME: Avoid moving the subsequent elements twice.
-    _ensureFreeCapacity(newElements.count - subrange.count)
-    _storage.replace(removing: subrange, moving: &newElements)
-  }
 }
 
-@available(SwiftStdlib 5.0, *)
-extension UniqueArray where Element: ~Copyable {
-  /// Replaces the specified range of elements by moving the elements of a
-  /// given array into their place, consuming it in the process.
-  ///
-  /// This method has the effect of removing the specified range of elements
-  /// from the array and inserting the new elements starting at the same
-  /// location. The number of new elements need not match the number of elements
-  /// being removed.
-  ///
-  /// If the array does not have sufficient capacity to perform the replacement,
-  /// then this reallocates the array's storage to extend its capacity, using a
-  /// geometric growth rate.
-  ///
-  /// If you pass a zero-length range as the `subrange` parameter, this method
-  /// inserts the elements of `newElements` at `subrange.lowerBound`. Calling
-  /// the `insert(copying:at:)` method instead is preferred in this case.
-  ///
-  /// Likewise, if you pass a zero-length buffer as the `newElements`
-  /// parameter, this method removes the elements in the given subrange
-  /// without replacement. Calling the `removeSubrange(_:)` method instead is
-  /// preferred in this case.
-  ///
-  /// - Parameters:
-  ///   - subrange: The subrange of the array to replace. The bounds of
-  ///     the range must be valid indices in the array.
-  ///   - newElements: An array whose contents to move into `self`.
-  ///
-  /// - Complexity: O(`self.count` + `newElements.count`)
-  @_alwaysEmitIntoClient
-  public mutating func replace(
-    removing subrange: Range<Int>,
-    consuming newElements: consuming RigidArray<Element>,
-  ) {
-    replace(removing: subrange, moving: &newElements)
-  }
-}
-
-@available(SwiftStdlib 5.0, *)
+@available(SwiftStdlib 6.4, *)
 extension UniqueArray {
   /// Replaces the specified subrange of elements by copying the elements of
   /// the given buffer pointer, which must be fully initialized.
@@ -371,8 +182,8 @@ extension UniqueArray {
   ///
   /// - Complexity: O(*n* + *m*), where *n* is count of this array and
   ///   *m* is the count of `newElements`.
-  @inlinable
-  @inline(__always)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public mutating func replace(
     removing subrange: Range<Int>,
     copying newElements: UnsafeBufferPointer<Element>
@@ -410,8 +221,8 @@ extension UniqueArray {
   ///
   /// - Complexity: O(*n* + *m*), where *n* is count of this array and
   ///   *m* is the count of `newElements`.
-  @inlinable
-  @inline(__always)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public mutating func replace(
     removing subrange: Range<Int>,
     copying newElements: UnsafeMutableBufferPointer<Element>
@@ -449,7 +260,8 @@ extension UniqueArray {
   ///
   /// - Complexity: O(*n* + *m*), where *n* is count of this array and
   ///   *m* is the count of `newElements`.
-  @inlinable
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public mutating func replace(
     removing subrange: Range<Int>,
     copying newElements: Span<Element>
@@ -458,53 +270,6 @@ extension UniqueArray {
     _ensureFreeCapacity(newElements.count)
     _storage.replace(removing: subrange, copying: newElements)
   }
-  
-#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
-  /// Replaces the specified subrange of elements by copying the elements of
-  /// the given container.
-  ///
-  /// This method has the effect of removing the specified range of elements
-  /// from the array and inserting the new elements starting at the same location.
-  /// The number of new elements need not match the number of elements being
-  /// removed.
-  ///
-  /// If the capacity of the array isn't sufficient to perform the replacement,
-  /// then this reallocates the array's storage to extend its capacity, using a
-  /// geometric growth rate.
-  ///
-  /// If you pass a zero-length range as the `subrange` parameter, this method
-  /// inserts the elements of `newElements` at `subrange.lowerBound`. Calling
-  /// the `insert(copying:at:)` method instead is preferred in this case.
-  ///
-  /// Likewise, if you pass a zero-length container as the `newElements`
-  /// parameter, this method removes the elements in the given subrange
-  /// without replacement. Calling the `removeSubrange(_:)` method instead is
-  /// preferred in this case.
-  ///
-  /// - Parameters:
-  ///   - subrange: The subrange of the array to replace. The bounds of
-  ///     the range must be valid indices in the array.
-  ///   - newElements: The new elements to copy into the collection.
-  ///
-  /// - Complexity: O(*n* + *m*), where *n* is count of this array and
-  ///   *m* is the count of `newElements`.
-  @inlinable
-  @inline(__always)
-  public mutating func replace<
-    C: Container<Element> & ~Copyable & ~Escapable
-  >(
-    removing subrange: Range<Int>,
-    copying newElements: borrowing C
-  ) {
-    // FIXME: Avoid moving the subsequent elements twice.
-    let c = newElements.count
-    _ensureFreeCapacity(c - subrange.count)
-    _storage._replace(
-      removing: subrange,
-      copyingContainer: newElements,
-      newCount: c)
-  }
-#endif
 
   /// Replaces the specified subrange of elements by copying the elements of
   /// the given collection.
@@ -534,8 +299,8 @@ extension UniqueArray {
   ///
   /// - Complexity: O(*n* + *m*), where *n* is count of this array and
   ///   *m* is the count of `newElements`.
-  @inlinable
-  @inline(__always)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public mutating func replace(
     removing subrange: Range<Int>,
     copying newElements: __owned some Collection<Element>
@@ -548,52 +313,4 @@ extension UniqueArray {
       copyingCollection: newElements,
       newCount: c)
   }
-  
-#if COLLECTIONS_UNSTABLE_CONTAINERS_PREVIEW
-  /// Replaces the specified subrange of elements by copying the elements of
-  /// the given container.
-  ///
-  /// This method has the effect of removing the specified range of elements
-  /// from the array and inserting the new elements starting at the same location.
-  /// The number of new elements need not match the number of elements being
-  /// removed.
-  ///
-  /// If the capacity of the array isn't sufficient to perform the replacement,
-  /// then this reallocates the array's storage to extend its capacity, using a
-  /// geometric growth rate.
-  ///
-  /// If you pass a zero-length range as the `subrange` parameter, this method
-  /// inserts the elements of `newElements` at `subrange.lowerBound`. Calling
-  /// the `insert(copying:at:)` method instead is preferred in this case.
-  ///
-  /// Likewise, if you pass a zero-length container as the `newElements`
-  /// parameter, this method removes the elements in the given subrange
-  /// without replacement. Calling the `removeSubrange(_:)` method instead is
-  /// preferred in this case.
-  ///
-  /// - Parameters:
-  ///   - subrange: The subrange of the array to replace. The bounds of
-  ///     the range must be valid indices in the array.
-  ///   - newElements: The new elements to copy into the collection.
-  ///
-  /// - Complexity: O(*n* + *m*), where *n* is count of this array and
-  ///   *m* is the count of `newElements`.
-  @inlinable
-  @inline(__always)
-  public mutating func replaceSubrange<
-    C: Container<Element> & Collection<Element>
-  >(
-    _ subrange: Range<Int>,
-    copying newElements: borrowing C
-  ) {
-    // FIXME: Avoid moving the subsequent elements twice.
-    let c = newElements.count
-    _ensureFreeCapacity(c - subrange.count)
-    _storage._replace(
-      removing: subrange,
-      copyingContainer: newElements,
-      newCount: c)
-  }
-#endif
 }
-#endif

--- a/stdlib/public/core/UniqueArray/UniqueArray+Replacements.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Replacements.swift
@@ -61,7 +61,7 @@ extension UniqueArray where Element: ~Copyable {
     initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
   ) throws(E) -> Void {
     _storage._checkValidBounds(subrange)
-    precondition(newItemCount >= 0, "Cannot add a negative number of items")
+    _precondition(newItemCount >= 0, "Cannot add a negative number of items")
     // FIXME: Avoid moving the subsequent elements twice on resize.
     _ensureFreeCapacity(newItemCount - subrange.count)
     try _storage._uncheckedReplace(

--- a/stdlib/public/core/UniqueArray/UniqueArray+Replacements.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Replacements.swift
@@ -189,7 +189,7 @@ extension UniqueArray {
     copying newElements: UnsafeBufferPointer<Element>
   ) {
     // FIXME: Avoid moving the subsequent elements twice.
-    _ensureFreeCapacity(newElements.count)
+    _ensureFreeCapacity(newElements.count - subrange.count)
     unsafe _storage.replace(removing: subrange, copying: newElements)
   }
 
@@ -267,7 +267,7 @@ extension UniqueArray {
     copying newElements: Span<Element>
   ) {
     // FIXME: Avoid moving the subsequent elements twice.
-    _ensureFreeCapacity(newElements.count)
+    _ensureFreeCapacity(newElements.count - subrange.count)
     _storage.replace(removing: subrange, copying: newElements)
   }
 
@@ -307,7 +307,7 @@ extension UniqueArray {
   ) {
     // FIXME: Avoid moving the subsequent elements twice.
     let c = newElements.count
-    _ensureFreeCapacity(c)
+    _ensureFreeCapacity(c - subrange.count)
     _storage._replace(
       removing: subrange,
       copyingCollection: newElements,

--- a/stdlib/public/core/UniqueArray/UniqueArray+Replacements.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Replacements.swift
@@ -303,7 +303,7 @@ extension UniqueArray where Element: Copyable {
   @_alwaysEmitIntoClient
   public mutating func replaceSubrange(
     _ subrange: Range<Int>,
-    copying newElements: __owned some Collection<Element>
+    copying newElements: consuming some Collection<Element>
   ) {
     // FIXME: Avoid moving the subsequent elements twice.
     let c = newElements.count

--- a/stdlib/public/core/UniqueArray/UniqueArray+Replacements.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Replacements.swift
@@ -55,8 +55,8 @@ extension UniqueArray where Element: ~Copyable {
   ///    of the callback invocations.
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func replace<E: Error>(
-    removing subrange: Range<Int>,
+  public mutating func replaceSubrange<E: Error>(
+    _ subrange: Range<Int>,
     addingCount newItemCount: Int,
     initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
   ) throws(E) -> Void {
@@ -64,8 +64,8 @@ extension UniqueArray where Element: ~Copyable {
     _precondition(newItemCount >= 0, "Cannot add a negative number of items")
     // FIXME: Avoid moving the subsequent elements twice on resize.
     _ensureFreeCapacity(newItemCount - subrange.count)
-    try _storage._uncheckedReplace(
-      removing: subrange,
+    try _storage._uncheckedReplaceSubrange(
+      subrange,
       addingCount: newItemCount,
       initializingWith: initializer)
   }
@@ -104,13 +104,13 @@ extension UniqueArray where Element: ~Copyable {
   /// - Complexity: O(`self.count` + `newElements.count`)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func replace(
-    removing subrange: Range<Int>,
+  public mutating func replaceSubrange(
+    _ subrange: Range<Int>,
     moving newElements: UnsafeMutableBufferPointer<Element>,
   ) {
     // FIXME: Avoid moving the subsequent elements twice.
     _ensureFreeCapacity(newElements.count - subrange.count)
-    unsafe _storage.replace(removing: subrange, moving: newElements)
+    unsafe _storage.replaceSubrange(subrange, moving: newElements)
   }
 
   /// Replaces the specified range of elements by moving the contents of an
@@ -142,18 +142,18 @@ extension UniqueArray where Element: ~Copyable {
   /// - Complexity: O(`self.count` + `items.count`)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func replace(
-    removing subrange: Range<Int>,
+  public mutating func replaceSubrange(
+    _ subrange: Range<Int>,
     moving items: inout OutputSpan<Element>
   ) {
     // FIXME: Avoid moving the subsequent elements twice.
     _ensureFreeCapacity(items.count - subrange.count)
-    _storage.replace(removing: subrange, moving: &items)
+    _storage.replaceSubrange(subrange, moving: &items)
   }
 }
 
 @available(SwiftStdlib 6.4, *)
-extension UniqueArray {
+extension UniqueArray where Element: Copyable {
   /// Replaces the specified subrange of elements by copying the elements of
   /// the given buffer pointer, which must be fully initialized.
   ///
@@ -184,13 +184,13 @@ extension UniqueArray {
   ///   *m* is the count of `newElements`.
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func replace(
-    removing subrange: Range<Int>,
+  public mutating func replaceSubrange(
+    _ subrange: Range<Int>,
     copying newElements: UnsafeBufferPointer<Element>
   ) {
     // FIXME: Avoid moving the subsequent elements twice.
     _ensureFreeCapacity(newElements.count - subrange.count)
-    unsafe _storage.replace(removing: subrange, copying: newElements)
+    unsafe _storage.replaceSubrange(subrange, copying: newElements)
   }
 
   /// Replaces the specified subrange of elements by copying the elements of
@@ -223,12 +223,12 @@ extension UniqueArray {
   ///   *m* is the count of `newElements`.
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func replace(
-    removing subrange: Range<Int>,
+  public mutating func replaceSubrange(
+    _ subrange: Range<Int>,
     copying newElements: UnsafeMutableBufferPointer<Element>
   ) {
-    unsafe self.replace(
-      removing: subrange,
+    unsafe self.replaceSubrange(
+      subrange,
       copying: UnsafeBufferPointer(newElements))
   }
 
@@ -262,13 +262,13 @@ extension UniqueArray {
   ///   *m* is the count of `newElements`.
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func replace(
-    removing subrange: Range<Int>,
+  public mutating func replaceSubrange(
+    _ subrange: Range<Int>,
     copying newElements: Span<Element>
   ) {
     // FIXME: Avoid moving the subsequent elements twice.
     _ensureFreeCapacity(newElements.count - subrange.count)
-    _storage.replace(removing: subrange, copying: newElements)
+    _storage.replaceSubrange(subrange, copying: newElements)
   }
 
   /// Replaces the specified subrange of elements by copying the elements of
@@ -301,15 +301,15 @@ extension UniqueArray {
   ///   *m* is the count of `newElements`.
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func replace(
-    removing subrange: Range<Int>,
+  public mutating func replaceSubrange(
+    _ subrange: Range<Int>,
     copying newElements: __owned some Collection<Element>
   ) {
     // FIXME: Avoid moving the subsequent elements twice.
     let c = newElements.count
     _ensureFreeCapacity(c - subrange.count)
-    _storage._replace(
-      removing: subrange,
+    _storage._replaceSubrange(
+      subrange,
       copyingCollection: newElements,
       newCount: c)
   }

--- a/stdlib/public/core/UniqueArray/UniqueArray.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray.swift
@@ -1,0 +1,308 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Collections open source project
+//
+// Copyright (c) 2024 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if !COLLECTIONS_SINGLE_MODULE
+import InternalCollectionsUtilities
+import ContainersPreview
+#endif
+
+#if compiler(<6.2)
+
+/// A dynamically self-resizing, heap allocated, noncopyable array
+/// of potentially noncopyable elements.
+@frozen
+@available(*, unavailable, message: "UniqueArray requires a Swift 6.2 toolchain")
+public struct UniqueArray<Element: ~Copyable>: ~Copyable {
+  @usableFromInline
+  internal var _storage: RigidArray<Element>
+
+  @inlinable
+  public init() {
+    fatalError()
+  }
+}
+
+#else
+
+/// A dynamically self-resizing, heap allocated, noncopyable array of
+/// potentially noncopyable elements.
+///
+/// `UniqueArray` instances automatically resize their underlying storage as
+/// needed to accommodate newly inserted items, using a geometric growth curve.
+/// This lets code using `UniqueArray` avoid having to allocate enough
+/// capacity in advance; on the other hand, it makes it difficult to tell
+/// when and where such reallocations may happen.
+///
+/// For example, appending an element to a `UniqueArray` has highly variable
+/// complexity; often, it runs at a constant cost, but if the operation has to
+/// resize storage, then the cost of an individual append suddenly becomes
+/// proportional to the size of the whole array.
+///
+/// The geometric growth curve allows the cost of such latency spikes to
+/// get amortized across repeated invocations, bringing the average cost back
+/// to O(1); but the spikes make this construct less suitable for use cases that
+/// expect predictable, consistent performance on every operation.
+///
+/// Implicit growth also makes it more difficult to predict/analyze the amount
+/// of memory an algorithm would need. Developers targeting environments with
+/// stringent limits on heap allocations may prefer to avoid using dynamically
+/// resizing container types as a matter of policy. The type `RigidArray` provides
+/// a fixed-capacity array variant that caters specifically for these use cases,
+/// trading ease-of-use for more consistent/predictable execution.
+/// For copyable elements, the copy-on-write `Array` type is an
+/// even more convenient and expressive choice.
+@available(SwiftStdlib 5.0, *)
+@frozen
+public struct UniqueArray<Element: ~Copyable>: ~Copyable {
+  @usableFromInline
+  internal var _storage: RigidArray<Element>
+
+  @_alwaysEmitIntoClient
+  package init(_storage: consuming RigidArray<Element>) {
+    self._storage = _storage
+  }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray: Sendable where Element: Sendable & ~Copyable {}
+
+//MARK: - Basics
+
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray where Element: ~Copyable {
+  /// The maximum number of elements this array can hold without having to
+  /// reallocate its storage.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  @inline(__always)
+  public var capacity: Int { _assumeNonNegative(_storage.capacity) }
+
+  /// The number of additional elements that can be added to this array without
+  /// reallocating its storage.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  @inline(__always)
+  public var freeCapacity: Int {
+    _assumeNonNegative(_storage.capacity &- _storage.count)
+  }
+}
+
+//MARK: - Span creation
+
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray where Element: ~Copyable {
+  /// A span over the elements of this array, providing direct read-only access.
+  ///
+  /// - Complexity: O(1)
+  public var span: Span<Element> {
+    @_lifetime(borrow self)
+    @inlinable
+    get {
+      _storage.span
+    }
+  }
+
+  /// A mutable span over the elements of this array, providing direct
+  /// mutating access.
+  ///
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 5.0, *)
+  public var mutableSpan: MutableSpan<Element> {
+    @_lifetime(&self)
+    @inlinable
+    mutating get {
+      _storage.mutableSpan
+    }
+  }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray where Element: ~Copyable {
+  /// Arbitrarily edit the storage underlying this array by invoking a
+  /// user-supplied closure with a mutable `OutputSpan` view over it.
+  /// This method calls its function argument at most once, allowing it to
+  /// arbitrarily modify the contents of the output span it is given.
+  /// The argument is free to add, remove or reorder any items; however,
+  /// it is not allowed to replace the span or change its capacity.
+  ///
+  /// When the function argument finishes (whether by returning or throwing an
+  /// error) the rigid array instance is updated to match the final contents of
+  /// the output span.
+  ///
+  /// - Parameter body: A function that edits the contents of this array through
+  ///    an `OutputSpan` argument. This method invokes this function
+  ///    at most once.
+  /// - Returns: This method returns the result of its function argument.
+  /// - Complexity: Adds O(1) overhead to the complexity of the function
+  ///    argument.
+  @inlinable @inline(__always)
+  public mutating func edit<E: Error, R: ~Copyable>(
+    _ body: (inout OutputSpan<Element>) throws(E) -> R
+  ) throws(E) -> R {
+    try _storage.edit(body)
+  }
+}
+
+//MARK: - Container primitives
+
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray where Element: ~Copyable {
+  /// Return a borrowing span over the maximal storage chunk following the
+  /// specified position in the array. The span provides direct read-only access
+  /// to all array elements in the range `index ..< count`.
+  ///
+  /// - Parameter index: A valid index in the array, including the end index.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  @_lifetime(borrow self)
+  public func span(after index: inout Int) -> Span<Element> {
+    _storage.span(after: &index)
+  }
+
+  /// Return a borrowing span over the maximal storage chunk preceding the
+  /// specified position in the array. The span provides direct read-only access
+  /// to all array elements in the range `0 ..< index`.
+  ///
+  /// - Parameter index: A valid index in the array, including the end index.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  @_lifetime(borrow self)
+  public func span(before index: inout Int) -> Span<Element> {
+    _storage.span(before: &index)
+  }
+}
+
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray where Element: ~Copyable {
+  /// Return a mutable span over the maximal storage chunk following the
+  /// specified position in the array. The span provides direct mutating access
+  /// to all array elements in the range `index ..< count`.
+  ///
+  /// - Parameter index: A valid index in the array, including the end index.
+  ///
+  /// - Complexity: O(1)
+  @_lifetime(&self)
+  public mutating func mutableSpan(
+    after index: inout Int
+  ) -> MutableSpan<Element> {
+    _storage.mutableSpan(after: &index)
+  }
+
+  /// Return a mutable span over the maximal storage chunk preceding the specified
+  /// position in the array. The span provides direct mutating access to all
+  /// array elements in the range `0 ..< index`.
+  ///
+  /// - Parameter index: A valid index in the array, including the end index.
+  ///
+  /// - Complexity: O(1)
+  @_lifetime(&self)
+  public mutating func mutableSpan(
+    before index: inout Int
+  ) -> MutableSpan<Element> {
+    _storage.mutableSpan(before: &index)
+  }
+}
+
+//MARK: - Resizing
+
+@_alwaysEmitIntoClient
+@_transparent
+internal func _growUniqueArrayCapacity(_ capacity: Int) -> Int {
+  // A growth factor of 1.5 seems like a reasonable compromise between
+  // over-allocating memory and wasting cycles on repeatedly resizing storage.
+  let c = (3 &* UInt(bitPattern: capacity) &+ 1) / 2
+  return Int(bitPattern: c)
+}
+
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray where Element: ~Copyable {
+  /// Grow or shrink the capacity of a unique array instance without discarding
+  /// its contents.
+  ///
+  /// This operation replaces the array's storage buffer with a newly allocated
+  /// buffer of the specified capacity, moving all existing elements
+  /// to its new storage. The old storage is then deallocated.
+  ///
+  /// - Parameter newCapacity: The desired new capacity. `newCapacity` must be
+  ///    greater than or equal to the current count.
+  ///
+  /// - Complexity: O(`count`)
+  @inlinable
+  public mutating func reallocate(capacity: Int) {
+    _storage.reallocate(capacity: capacity)
+  }
+
+  /// Ensure that the array has capacity to store the specified number of
+  /// elements, by growing its storage buffer if necessary.
+  ///
+  /// If `capacity < n`, then this operation reallocates the unique array's
+  /// storage to grow it; on return, the array's capacity becomes `n`.
+  /// Otherwise the array is left as is.
+  ///
+  /// - Complexity: O(`count`)
+  @inlinable
+  public mutating func reserveCapacity(_ n: Int) {
+    _storage.reserveCapacity(n)
+  }
+
+  @_alwaysEmitIntoClient
+  @_transparent
+  internal mutating func _ensureFreeCapacity(_ freeCapacity: Int) {
+    guard _storage.freeCapacity < freeCapacity else { return }
+    _ensureFreeCapacitySlow(freeCapacity)
+  }
+
+  @_alwaysEmitIntoClient
+  @_transparent
+  internal func _grow(freeCapacity: Int) -> Int {
+    Swift.max(
+      count + freeCapacity,
+      _growUniqueArrayCapacity(capacity))
+  }
+
+  @inlinable
+  internal mutating func _ensureFreeCapacitySlow(_ freeCapacity: Int) {
+    let newCapacity = _grow(freeCapacity: freeCapacity)
+    reallocate(capacity: newCapacity)
+  }
+}
+
+//MARK: - Copying helpers
+
+@available(SwiftStdlib 5.0, *)
+extension UniqueArray {
+  /// Copy the contents of this array into a newly allocated unique array
+  /// instance with just enough capacity to hold all its elements.
+  ///
+  /// - Complexity: O(`count`)
+  @_alwaysEmitIntoClient
+  public func clone() -> Self {
+    UniqueArray(consuming: _storage.clone())
+  }
+  
+  /// Copy the contents of this array into a newly allocated unique array
+  /// instance with the specified capacity.
+  ///
+  /// - Parameter capacity: The desired capacity of the resulting unique array.
+  ///    `capacity` must be greater than or equal to `count`.
+  ///
+  /// - Complexity: O(`count`)
+  @inlinable
+  @inline(__always)
+  public func clone(capacity: Int) -> Self {
+    UniqueArray(consuming: _storage.clone(capacity: capacity))
+  }
+}
+#endif

--- a/stdlib/public/core/UniqueArray/UniqueArray.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray.swift
@@ -1,36 +1,14 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift Collections open source project
+// This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2024 - 2026 Apple Inc. and the Swift project authors
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-
-#if !COLLECTIONS_SINGLE_MODULE
-import InternalCollectionsUtilities
-import ContainersPreview
-#endif
-
-#if compiler(<6.2)
-
-/// A dynamically self-resizing, heap allocated, noncopyable array
-/// of potentially noncopyable elements.
-@frozen
-@available(*, unavailable, message: "UniqueArray requires a Swift 6.2 toolchain")
-public struct UniqueArray<Element: ~Copyable>: ~Copyable {
-  @usableFromInline
-  internal var _storage: RigidArray<Element>
-
-  @inlinable
-  public init() {
-    fatalError()
-  }
-}
-
-#else
 
 /// A dynamically self-resizing, heap allocated, noncopyable array of
 /// potentially noncopyable elements.
@@ -59,54 +37,56 @@ public struct UniqueArray<Element: ~Copyable>: ~Copyable {
 /// trading ease-of-use for more consistent/predictable execution.
 /// For copyable elements, the copy-on-write `Array` type is an
 /// even more convenient and expressive choice.
-@available(SwiftStdlib 5.0, *)
+@available(SwiftStdlib 6.4, *)
 @frozen
 public struct UniqueArray<Element: ~Copyable>: ~Copyable {
   @usableFromInline
   internal var _storage: RigidArray<Element>
 
   @_alwaysEmitIntoClient
-  package init(_storage: consuming RigidArray<Element>) {
+  internal init(_storage: consuming RigidArray<Element>) {
     self._storage = _storage
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftStdlib 6.4, *)
 extension UniqueArray: Sendable where Element: Sendable & ~Copyable {}
 
-//MARK: - Basics
-
-@available(SwiftStdlib 5.0, *)
+@available(SwiftStdlib 6.4, *)
 extension UniqueArray where Element: ~Copyable {
   /// The maximum number of elements this array can hold without having to
   /// reallocate its storage.
   ///
   /// - Complexity: O(1)
-  @inlinable
-  @inline(__always)
-  public var capacity: Int { _assumeNonNegative(_storage.capacity) }
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  public var capacity: Int {
+    _assumeNonNegative(_storage.capacity)
+  }
 
   /// The number of additional elements that can be added to this array without
   /// reallocating its storage.
   ///
   /// - Complexity: O(1)
-  @inlinable
-  @inline(__always)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
   public var freeCapacity: Int {
     _assumeNonNegative(_storage.capacity &- _storage.count)
   }
 }
 
-//MARK: - Span creation
-
-@available(SwiftStdlib 5.0, *)
+@available(SwiftStdlib 6.4, *)
 extension UniqueArray where Element: ~Copyable {
   /// A span over the elements of this array, providing direct read-only access.
   ///
   /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public var span: Span<Element> {
     @_lifetime(borrow self)
-    @inlinable
+    @_transparent
     get {
       _storage.span
     }
@@ -116,17 +96,18 @@ extension UniqueArray where Element: ~Copyable {
   /// mutating access.
   ///
   /// - Complexity: O(1)
-  @available(SwiftStdlib 5.0, *)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public var mutableSpan: MutableSpan<Element> {
     @_lifetime(&self)
-    @inlinable
+    @_transparent
     mutating get {
       _storage.mutableSpan
     }
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftStdlib 6.4, *)
 extension UniqueArray where Element: ~Copyable {
   /// Arbitrarily edit the storage underlying this array by invoking a
   /// user-supplied closure with a mutable `OutputSpan` view over it.
@@ -145,77 +126,15 @@ extension UniqueArray where Element: ~Copyable {
   /// - Returns: This method returns the result of its function argument.
   /// - Complexity: Adds O(1) overhead to the complexity of the function
   ///    argument.
-  @inlinable @inline(__always)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
   public mutating func edit<E: Error, R: ~Copyable>(
     _ body: (inout OutputSpan<Element>) throws(E) -> R
   ) throws(E) -> R {
     try _storage.edit(body)
   }
 }
-
-//MARK: - Container primitives
-
-@available(SwiftStdlib 5.0, *)
-extension UniqueArray where Element: ~Copyable {
-  /// Return a borrowing span over the maximal storage chunk following the
-  /// specified position in the array. The span provides direct read-only access
-  /// to all array elements in the range `index ..< count`.
-  ///
-  /// - Parameter index: A valid index in the array, including the end index.
-  ///
-  /// - Complexity: O(1)
-  @inlinable
-  @_lifetime(borrow self)
-  public func span(after index: inout Int) -> Span<Element> {
-    _storage.span(after: &index)
-  }
-
-  /// Return a borrowing span over the maximal storage chunk preceding the
-  /// specified position in the array. The span provides direct read-only access
-  /// to all array elements in the range `0 ..< index`.
-  ///
-  /// - Parameter index: A valid index in the array, including the end index.
-  ///
-  /// - Complexity: O(1)
-  @inlinable
-  @_lifetime(borrow self)
-  public func span(before index: inout Int) -> Span<Element> {
-    _storage.span(before: &index)
-  }
-}
-
-@available(SwiftStdlib 5.0, *)
-extension UniqueArray where Element: ~Copyable {
-  /// Return a mutable span over the maximal storage chunk following the
-  /// specified position in the array. The span provides direct mutating access
-  /// to all array elements in the range `index ..< count`.
-  ///
-  /// - Parameter index: A valid index in the array, including the end index.
-  ///
-  /// - Complexity: O(1)
-  @_lifetime(&self)
-  public mutating func mutableSpan(
-    after index: inout Int
-  ) -> MutableSpan<Element> {
-    _storage.mutableSpan(after: &index)
-  }
-
-  /// Return a mutable span over the maximal storage chunk preceding the specified
-  /// position in the array. The span provides direct mutating access to all
-  /// array elements in the range `0 ..< index`.
-  ///
-  /// - Parameter index: A valid index in the array, including the end index.
-  ///
-  /// - Complexity: O(1)
-  @_lifetime(&self)
-  public mutating func mutableSpan(
-    before index: inout Int
-  ) -> MutableSpan<Element> {
-    _storage.mutableSpan(before: &index)
-  }
-}
-
-//MARK: - Resizing
 
 @_alwaysEmitIntoClient
 @_transparent
@@ -226,7 +145,7 @@ internal func _growUniqueArrayCapacity(_ capacity: Int) -> Int {
   return Int(bitPattern: c)
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftStdlib 6.4, *)
 extension UniqueArray where Element: ~Copyable {
   /// Grow or shrink the capacity of a unique array instance without discarding
   /// its contents.
@@ -239,7 +158,8 @@ extension UniqueArray where Element: ~Copyable {
   ///    greater than or equal to the current count.
   ///
   /// - Complexity: O(`count`)
-  @inlinable
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public mutating func reallocate(capacity: Int) {
     _storage.reallocate(capacity: capacity)
   }
@@ -252,7 +172,8 @@ extension UniqueArray where Element: ~Copyable {
   /// Otherwise the array is left as is.
   ///
   /// - Complexity: O(`count`)
-  @inlinable
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public mutating func reserveCapacity(_ n: Int) {
     _storage.reserveCapacity(n)
   }
@@ -272,21 +193,20 @@ extension UniqueArray where Element: ~Copyable {
       _growUniqueArrayCapacity(capacity))
   }
 
-  @inlinable
+  @_alwaysEmitIntoClient
   internal mutating func _ensureFreeCapacitySlow(_ freeCapacity: Int) {
     let newCapacity = _grow(freeCapacity: freeCapacity)
     reallocate(capacity: newCapacity)
   }
 }
 
-//MARK: - Copying helpers
-
-@available(SwiftStdlib 5.0, *)
+@available(SwiftStdlib 6.4, *)
 extension UniqueArray {
   /// Copy the contents of this array into a newly allocated unique array
   /// instance with just enough capacity to hold all its elements.
   ///
   /// - Complexity: O(`count`)
+  @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   public func clone() -> Self {
     UniqueArray(consuming: _storage.clone())
@@ -299,10 +219,9 @@ extension UniqueArray {
   ///    `capacity` must be greater than or equal to `count`.
   ///
   /// - Complexity: O(`count`)
-  @inlinable
-  @inline(__always)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
   public func clone(capacity: Int) -> Self {
     UniqueArray(consuming: _storage.clone(capacity: capacity))
   }
 }
-#endif

--- a/stdlib/public/core/UniqueArray/UniqueArray.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray.swift
@@ -41,10 +41,10 @@
 @frozen
 public struct UniqueArray<Element: ~Copyable>: ~Copyable {
   @usableFromInline
-  internal var _storage: RigidArray<Element>
+  internal var _storage: _RigidArray<Element>
 
   @_alwaysEmitIntoClient
-  internal init(_storage: consuming RigidArray<Element>) {
+  internal init(_storage: consuming _RigidArray<Element>) {
     self._storage = _storage
   }
 }

--- a/stdlib/public/core/UniqueArray/UniqueArray.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray.swift
@@ -189,7 +189,7 @@ extension UniqueArray where Element: ~Copyable {
   @_transparent
   internal func _grow(freeCapacity: Int) -> Int {
     Swift.max(
-      count + freeCapacity,
+      count &+ freeCapacity,
       _growUniqueArrayCapacity(capacity))
   }
 

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -580,8 +580,10 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
     return unsafe Self(start: baseAddress, count: newCount)
   }
 
+  // Note: This is public because 'libCompatibilitySpan' builds the span sources
+  // as a separate module, so it doesn't have access to 'internal' stdlib API.
   @_alwaysEmitIntoClient
-  internal func _extracting(uncheckedFrom start: Int, to end: Int) -> Self {
+  public func _extracting(uncheckedFrom start: Int, to end: Int) -> Self {
     guard let base = self.baseAddress else {
       return Self(_empty: ())
     }
@@ -618,8 +620,10 @@ extension UnsafeMutableBufferPointer where Element: Copyable {
     _internalInvariant(i == self.endIndex)
   }
 
+  // Note: This is public because 'libCompatibilitySpan' builds the span sources
+  // as a separate module, so it doesn't have access to 'internal' stdlib API.
   @_alwaysEmitIntoClient
-  internal func _initializeAll(
+  public func _initializeAll(
     fromContentsOf source: UnsafeBufferPointer<Element>
   ) {
     let i = unsafe self.initialize(fromContentsOf: source)
@@ -641,8 +645,10 @@ extension UnsafeMutableBufferPointer where Element: ~Copyable {
     return source.count
   }
 
+  // Note: This is public because 'libCompatibilitySpan' builds the span sources
+  // as a separate module, so it doesn't have access to 'internal' stdlib API.
   @_alwaysEmitIntoClient
-  internal func _moveInitializeAll(fromContentsOf source: Self) {
+  public func _moveInitializeAll(fromContentsOf source: Self) {
     let i = unsafe self.moveInitialize(fromContentsOf: source)
     _internalInvariant(i == self.endIndex)
   }

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -572,7 +572,82 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   public func extracting(_ bounds: UnboundedRange) -> Self {
     unsafe self
   }
+
+  @_alwaysEmitIntoClient
+  internal func _extracting(first maxLength: Int) -> Self {
+    _precondition(maxLength >= 0, "Cannot have a prefix of negative length")
+    let newCount = Swift.min(maxLength, count)
+    return unsafe Self(start: baseAddress, count: newCount)
+  }
+
+  @_alwaysEmitIntoClient
+  internal func _extracting(uncheckedFrom start: Int, to end: Int) -> Self {
+    guard let base = self.baseAddress else {
+      return Self(_empty: ())
+    }
+    return unsafe Self(start: base + start, count: end &- start)
+  }
 }
+
+%if Mutable:
+extension UnsafeMutableBufferPointer where Element: Copyable {
+  /// Initialize slots at the start of this buffer by copying data from `source`.
+  ///
+  /// If `Element` is not bitwise copyable, then the memory region addressed by `self` must be
+  /// entirely uninitialized, while `source` must be fully initialized.
+  ///
+  /// The `source` buffer must fit entirely in `self`.
+  ///
+  /// - Returns: The index after the last item that was initialized in this buffer.
+  @_alwaysEmitIntoClient
+  internal func _initializePrefix(
+    copying source: UnsafeBufferPointer<Element>
+  ) -> Int {
+    if source.isEmpty { return 0 }
+    _precondition(source.count <= self.count)
+    unsafe self.baseAddress._unsafelyUnwrappedUnchecked.initialize(
+      from: source.baseAddress._unsafelyUnwrappedUnchecked,
+      count: source.count
+    )
+    return source.count
+  }
+
+  @_alwaysEmitIntoClient
+  internal func _initializeAll(fromContentsOf source: Self) {
+    let i = unsafe self.initialize(fromContentsOf: source)
+    _internalInvariant(i == self.endIndex)
+  }
+
+  @_alwaysEmitIntoClient
+  internal func _initializeAll(
+    fromContentsOf source: UnsafeBufferPointer<Element>
+  ) {
+    let i = unsafe self.initialize(fromContentsOf: source)
+    _internalInvariant(i == self.endIndex)
+  }
+}
+
+extension UnsafeMutableBufferPointer where Element: ~Copyable {
+  @_alwaysEmitIntoClient
+  internal func _moveInitializePrefix(
+    from source: UnsafeMutableBufferPointer<Element>
+  ) -> Int {
+    if source.isEmpty { return 0 }
+    _debugPrecondition(source.count <= self.count)
+    unsafe self.baseAddress._unsafelyUnwrappedUnchecked.moveInitialize(
+      from: source.baseAddress._unsafelyUnwrappedUnchecked,
+      count: source.count
+    )
+    return source.count
+  }
+
+  @_alwaysEmitIntoClient
+  internal func _moveInitializeAll(fromContentsOf source: Self) {
+    let i = unsafe self.moveInitialize(fromContentsOf: source)
+    _internalInvariant(i == self.endIndex)
+  }
+}
+%end
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -1308,3 +1308,26 @@ Added: _$ss9UniqueBoxVsRi_zrlE7pointerSpyxGvg
 
 // Cross-encoding strcmp for Foundation
 Added: __swift_unicodeBuffersEqual_nonNormalizing
+
+// RigidArray
+Added: _$ss10RigidArrayVMa
+Added: _$ss10RigidArrayVMn
+Added: _$ss10RigidArrayVsRi_zrlE6_countSivM
+Added: _$ss10RigidArrayVsRi_zrlE6_countSivg
+Added: _$ss10RigidArrayVsRi_zrlE6_countSivs
+Added: _$ss10RigidArrayVsRi_zrlE8_storageSryxGvM
+Added: _$ss10RigidArrayVsRi_zrlE8_storageSryxGvg
+Added: _$ss10RigidArrayVsRi_zrlE8_storageSryxGvs
+Added: _$ss10RigidArrayVsSHRzRi_zrlE9hashValueSivg
+Added: _$ss10RigidArrayVyxGSHsSHRzRi_zrlMc
+Added: _$ss10RigidArrayVyxGSQsSQRzRi_zrlMc
+
+// UniqueArray
+Added: _$ss11UniqueArrayVMa
+Added: _$ss11UniqueArrayVMn
+Added: _$ss11UniqueArrayVsRi_zrlE8_storages05RigidB0VyxGvM
+Added: _$ss11UniqueArrayVsRi_zrlE8_storages05RigidB0VyxGvr
+Added: _$ss11UniqueArrayVsRi_zrlE8_storages05RigidB0VyxGvs
+Added: _$ss11UniqueArrayVsSHRzRi_zrlE9hashValueSivg
+Added: _$ss11UniqueArrayVyxGSHsSHRzRi_zrlMc
+Added: _$ss11UniqueArrayVyxGSQsSQRzRi_zrlMc

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -1309,18 +1309,18 @@ Added: _$ss9UniqueBoxVsRi_zrlE7pointerSpyxGvg
 // Cross-encoding strcmp for Foundation
 Added: __swift_unicodeBuffersEqual_nonNormalizing
 
-// RigidArray
-Added: _$ss10RigidArrayVMa
-Added: _$ss10RigidArrayVMn
-Added: _$ss10RigidArrayVsRi_zrlE6_countSivM
-Added: _$ss10RigidArrayVsRi_zrlE6_countSivg
-Added: _$ss10RigidArrayVsRi_zrlE6_countSivs
-Added: _$ss10RigidArrayVsRi_zrlE8_storageSryxGvM
-Added: _$ss10RigidArrayVsRi_zrlE8_storageSryxGvg
-Added: _$ss10RigidArrayVsRi_zrlE8_storageSryxGvs
-Added: _$ss10RigidArrayVsSHRzRi_zrlE9hashValueSivg
-Added: _$ss10RigidArrayVyxGSHsSHRzRi_zrlMc
-Added: _$ss10RigidArrayVyxGSQsSQRzRi_zrlMc
+// _RigidArray
+Added: _$ss11_RigidArrayVMa
+Added: _$ss11_RigidArrayVMn
+Added: _$ss11_RigidArrayVsRi_zrlE6_countSivM
+Added: _$ss11_RigidArrayVsRi_zrlE6_countSivg
+Added: _$ss11_RigidArrayVsRi_zrlE6_countSivs
+Added: _$ss11_RigidArrayVsRi_zrlE8_storageSryxGvM
+Added: _$ss11_RigidArrayVsRi_zrlE8_storageSryxGvg
+Added: _$ss11_RigidArrayVsRi_zrlE8_storageSryxGvs
+Added: _$ss11_RigidArrayVsSHRzRi_zrlE9hashValueSivg
+Added: _$ss11_RigidArrayVyxGSHsSHRzRi_zrlMc
+Added: _$ss11_RigidArrayVyxGSQsSQRzRi_zrlMc
 
 // UniqueArray
 Added: _$ss11UniqueArrayVMa

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -1325,9 +1325,11 @@ Added: _$ss11_RigidArrayVyxGSQsSQRzRi_zrlMc
 // UniqueArray
 Added: _$ss11UniqueArrayVMa
 Added: _$ss11UniqueArrayVMn
-Added: _$ss11UniqueArrayVsRi_zrlE8_storages05RigidB0VyxGvM
-Added: _$ss11UniqueArrayVsRi_zrlE8_storages05RigidB0VyxGvr
-Added: _$ss11UniqueArrayVsRi_zrlE8_storages05RigidB0VyxGvs
+Added: _$ss11UniqueArrayVsRi_zrlE8_storages06_RigidB0VyxGvM
+Added: _$ss11UniqueArrayVsRi_zrlE8_storages06_RigidB0VyxGvr
+Added: _$ss11UniqueArrayVsRi_zrlE8_storages06_RigidB0VyxGvs
 Added: _$ss11UniqueArrayVsSHRzRi_zrlE9hashValueSivg
 Added: _$ss11UniqueArrayVyxGSHsSHRzRi_zrlMc
 Added: _$ss11UniqueArrayVyxGSQsSQRzRi_zrlMc
+Added: _$ss11UniqueArrayVsRi_zrlE11descriptionSSvg
+Added: _$ss11UniqueArrayVsRi_zrlE16debugDescriptionSSvg

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -1305,18 +1305,18 @@ Added: _$ss9UniqueBoxVsRi_zrlE7pointerSpyxGvg
 // Cross-encoding strcmp for Foundation
 Added: __swift_unicodeBuffersEqual_nonNormalizing
 
-// RigidArray
-Added: _$ss10RigidArrayVMa
-Added: _$ss10RigidArrayVMn
-Added: _$ss10RigidArrayVsRi_zrlE6_countSivM
-Added: _$ss10RigidArrayVsRi_zrlE6_countSivg
-Added: _$ss10RigidArrayVsRi_zrlE6_countSivs
-Added: _$ss10RigidArrayVsRi_zrlE8_storageSryxGvM
-Added: _$ss10RigidArrayVsRi_zrlE8_storageSryxGvg
-Added: _$ss10RigidArrayVsRi_zrlE8_storageSryxGvs
-Added: _$ss10RigidArrayVsSHRzRi_zrlE9hashValueSivg
-Added: _$ss10RigidArrayVyxGSHsSHRzRi_zrlMc
-Added: _$ss10RigidArrayVyxGSQsSQRzRi_zrlMc
+// _RigidArray
+Added: _$ss11_RigidArrayVMa
+Added: _$ss11_RigidArrayVMn
+Added: _$ss11_RigidArrayVsRi_zrlE6_countSivM
+Added: _$ss11_RigidArrayVsRi_zrlE6_countSivg
+Added: _$ss11_RigidArrayVsRi_zrlE6_countSivs
+Added: _$ss11_RigidArrayVsRi_zrlE8_storageSryxGvM
+Added: _$ss11_RigidArrayVsRi_zrlE8_storageSryxGvg
+Added: _$ss11_RigidArrayVsRi_zrlE8_storageSryxGvs
+Added: _$ss11_RigidArrayVsSHRzRi_zrlE9hashValueSivg
+Added: _$ss11_RigidArrayVyxGSHsSHRzRi_zrlMc
+Added: _$ss11_RigidArrayVyxGSQsSQRzRi_zrlMc
 
 // UniqueArray
 Added: _$ss11UniqueArrayVMa

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -1321,9 +1321,11 @@ Added: _$ss11_RigidArrayVyxGSQsSQRzRi_zrlMc
 // UniqueArray
 Added: _$ss11UniqueArrayVMa
 Added: _$ss11UniqueArrayVMn
-Added: _$ss11UniqueArrayVsRi_zrlE8_storages05RigidB0VyxGvM
-Added: _$ss11UniqueArrayVsRi_zrlE8_storages05RigidB0VyxGvr
-Added: _$ss11UniqueArrayVsRi_zrlE8_storages05RigidB0VyxGvs
+Added: _$ss11UniqueArrayVsRi_zrlE8_storages06_RigidB0VyxGvM
+Added: _$ss11UniqueArrayVsRi_zrlE8_storages06_RigidB0VyxGvr
+Added: _$ss11UniqueArrayVsRi_zrlE8_storages06_RigidB0VyxGvs
 Added: _$ss11UniqueArrayVsSHRzRi_zrlE9hashValueSivg
 Added: _$ss11UniqueArrayVyxGSHsSHRzRi_zrlMc
 Added: _$ss11UniqueArrayVyxGSQsSQRzRi_zrlMc
+Added: _$ss11UniqueArrayVsRi_zrlE11descriptionSSvg
+Added: _$ss11UniqueArrayVsRi_zrlE16debugDescriptionSSvg

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -1304,3 +1304,26 @@ Added: _$ss9UniqueBoxVsRi_zrlE7pointerSpyxGvg
 
 // Cross-encoding strcmp for Foundation
 Added: __swift_unicodeBuffersEqual_nonNormalizing
+
+// RigidArray
+Added: _$ss10RigidArrayVMa
+Added: _$ss10RigidArrayVMn
+Added: _$ss10RigidArrayVsRi_zrlE6_countSivM
+Added: _$ss10RigidArrayVsRi_zrlE6_countSivg
+Added: _$ss10RigidArrayVsRi_zrlE6_countSivs
+Added: _$ss10RigidArrayVsRi_zrlE8_storageSryxGvM
+Added: _$ss10RigidArrayVsRi_zrlE8_storageSryxGvg
+Added: _$ss10RigidArrayVsRi_zrlE8_storageSryxGvs
+Added: _$ss10RigidArrayVsSHRzRi_zrlE9hashValueSivg
+Added: _$ss10RigidArrayVyxGSHsSHRzRi_zrlMc
+Added: _$ss10RigidArrayVyxGSQsSQRzRi_zrlMc
+
+// UniqueArray
+Added: _$ss11UniqueArrayVMa
+Added: _$ss11UniqueArrayVMn
+Added: _$ss11UniqueArrayVsRi_zrlE8_storages05RigidB0VyxGvM
+Added: _$ss11UniqueArrayVsRi_zrlE8_storages05RigidB0VyxGvr
+Added: _$ss11UniqueArrayVsRi_zrlE8_storages05RigidB0VyxGvs
+Added: _$ss11UniqueArrayVsSHRzRi_zrlE9hashValueSivg
+Added: _$ss11UniqueArrayVyxGSHsSHRzRi_zrlMc
+Added: _$ss11UniqueArrayVyxGSQsSQRzRi_zrlMc


### PR DESCRIPTION
Take the implementations of `RigidArray` and `UniqueArray` from [swift-collections](https://github.com/apple/swift-collections) and integrate them within the standard library adjusting where needed.