### PR TITLE
Embedded: Clean up stdlib and runtime feature availability

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -925,6 +925,8 @@ public:
   // runtime version.
 #define FEATURE(N, V)                                                          \
   inline AvailabilityRange get##N##Availability() const {                      \
+    if (LangOpts.hasFeature(Feature::Embedded))                                \
+      return AvailabilityRange::alwaysAvailable();                             \
     return getSwiftAvailability V;                                             \
   }                                                                            \
   inline AvailabilityRange get##N##RuntimeAvailability() const {               \

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -2133,14 +2133,15 @@ public:
   using PlatformAndVersion = std::pair<PlatformKind, llvm::VersionTuple>;
 
   /// Parse a platform and version tuple (e.g. "macOS 12.0") and append it to
-  /// the given vector. Wildcards ('*') parse successfully but are ignored.
+  /// the given vector. Wildcards (`*`) parse successfully but are ignored.
   /// Unrecognized platform names also parse successfully but are ignored.
   /// Assumes that the tuples are part of a comma separated list ending with a
-  /// trailing ')'.
+  /// trailing ')'. Sets `WasEmpty` to true if the parse was successful but
+  /// yielded an empty list.
   ParserStatus parsePlatformVersionInList(
       StringRef AttrName,
-      llvm::SmallVector<PlatformAndVersion, 4> & PlatformAndVersions,
-      bool &ParsedUnrecognizedPlatformName);
+      llvm::SmallVector<PlatformAndVersion, 4> &PlatformAndVersions,
+      bool &WasEmpty);
 
   //===--------------------------------------------------------------------===//
   // Code completion second pass.

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1927,13 +1927,18 @@ static PlatformKind getPlatformFromDomainOrIdentifier(
 
 ParserStatus Parser::parsePlatformVersionInList(StringRef AttrName,
     llvm::SmallVector<PlatformAndVersion, 4> &PlatformAndVersions,
-    bool &ParsedUnrecognizedPlatformName) {
+    bool &WasEmpty) {
   // Check for availability macros first.
   if (peekAvailabilityMacroName()) {
     SmallVector<AvailabilitySpec *, 4> Specs;
     ParserStatus MacroStatus = parseAvailabilityMacro(Specs);
     if (MacroStatus.isError())
       return MacroStatus;
+
+    if (Specs.size() == 1 && Specs.front()->isWildcard()) {
+      WasEmpty = true;
+      return makeParserSuccess();
+    }
 
     for (auto *Spec : Specs) {
       auto Platform =
@@ -1962,7 +1967,7 @@ ParserStatus Parser::parsePlatformVersionInList(StringRef AttrName,
   // Parse the platform name.
   StringRef platformText = Tok.getText();
   auto MaybePlatform = platformFromString(platformText);
-  ParsedUnrecognizedPlatformName = ParsedUnrecognizedPlatformName || !MaybePlatform.has_value();
+  WasEmpty = WasEmpty || !MaybePlatform.has_value();
   SourceLoc PlatformLoc = Tok.getLoc();
   consumeToken();
 
@@ -2025,7 +2030,7 @@ bool Parser::parseBackDeployedAttribute(DeclAttributes &Attributes,
   SourceLoc RightLoc;
   ParserStatus Status;
   bool SuppressLaterDiags = false;
-  bool ParsedUnrecognizedPlatformName = false;
+  bool EmptyPlatformAndVersions = false;
   llvm::SmallVector<PlatformAndVersion, 4> PlatformAndVersions;
 
   {
@@ -2048,7 +2053,7 @@ bool Parser::parseBackDeployedAttribute(DeclAttributes &Attributes,
             Status, tok::r_paren, LeftLoc, RightLoc,
             /*AllowSepAfterLast=*/false, [&]() -> ParserStatus {
               return parsePlatformVersionInList(AtAttrName, PlatformAndVersions,
-                                                ParsedUnrecognizedPlatformName);
+                                                EmptyPlatformAndVersions);
             });
       } while (Result == ParseListItemResult::Continue);
     }
@@ -2062,7 +2067,7 @@ bool Parser::parseBackDeployedAttribute(DeclAttributes &Attributes,
     return false;
   }
 
-  if (PlatformAndVersions.empty() && !ParsedUnrecognizedPlatformName) {
+  if (PlatformAndVersions.empty() && !EmptyPlatformAndVersions) {
     diagnose(Loc, diag::attr_availability_need_platform_version, AtAttrName);
     return false;
   }
@@ -3442,7 +3447,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
 
     StringRef AttrName = "@_originallyDefinedIn";
     bool SuppressLaterDiags = false;
-    bool ParsedUnrecognizedPlatformName = false;
+    bool EmptyPlatformAndVersions = false;
     if (parseList(tok::r_paren, LeftLoc, RightLoc,
                   /*AllowSepAfterLast=*/false,
                   diag::originally_defined_in_missing_rparen,
@@ -3484,7 +3489,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
       // Parse 'OSX 13.13'.
       case NextSegmentKind::PlatformVersion: {
         ParserStatus ListItemStatus = parsePlatformVersionInList(
-            AttrName, PlatformAndVersions, ParsedUnrecognizedPlatformName);
+            AttrName, PlatformAndVersions, EmptyPlatformAndVersions);
         if (ListItemStatus.isErrorOrHasCompletion())
           SuppressLaterDiags = true;
         return ListItemStatus;
@@ -3499,7 +3504,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
       return makeParserSuccess();
     }
 
-    if (PlatformAndVersions.empty() && !ParsedUnrecognizedPlatformName) {
+    if (PlatformAndVersions.empty() && !EmptyPlatformAndVersions) {
       diagnose(AtLoc, diag::attr_availability_need_platform_version, AttrName);
       return makeParserSuccess();
     }

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1304,7 +1304,7 @@ validateAvailabilitySpecList(Parser &P,
     }
   }
 
-  if (WildcardSpecLoc)
+  if (WildcardSpecLoc && Specs.size() > 1)
     P.diagnose(*WildcardSpecLoc, diag::attr_availability_wildcard_in_macro);
 }
 

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -605,10 +605,7 @@ static void checkGenericParams(GenericContext *ownerCtx) {
     // is not enabled.
     if (gp->isParameterPack()) {
       // Variadic nominal types require runtime support.
-      //
-      // Embedded doesn't require runtime support for this feature.
-      if (isa<NominalTypeDecl>(decl) &&
-          !ctx.LangOpts.hasFeature(Feature::Embedded)) {
+      if (isa<NominalTypeDecl>(decl)) {
         TypeChecker::checkAvailability(
             gp->getSourceRange(),
             ctx.getVariadicGenericTypeAvailability(),
@@ -628,11 +625,9 @@ static void checkGenericParams(GenericContext *ownerCtx) {
     // Value generic nominal types require runtime support.
     if (gp->isValue() && isa<NominalTypeDecl>(decl)) {
       auto nomTypeDecl = cast<NominalTypeDecl>(decl);
-      // But: Embedded doesn't require runtime support for this feature.
       // But: Stdlib/libswiftCore carries its own support,
       //      so non-public stdlib declarations are safe
-      if (!ctx.LangOpts.hasFeature(Feature::Embedded) &&
-          !(decl->getModuleContext()->isStdlibModule() &&
+      if (!(decl->getModuleContext()->isStdlibModule() &&
             !nomTypeDecl->isAccessibleFrom(nullptr))) {
         // Everything else gets diagnosed for availability
         TypeChecker::checkAvailability(

--- a/stdlib/public/Concurrency/AsyncStream.swift
+++ b/stdlib/public/Concurrency/AsyncStream.swift
@@ -466,9 +466,7 @@ extension AsyncStream {
   /// - Returns: A tuple containing the stream and its continuation. The continuation should be passed to the
   /// producer while the stream should be passed to the consumer.
   @available(SwiftStdlib 5.1, *)
-  #if !hasFeature(Embedded)
   @backDeployed(before: SwiftStdlib 5.9)
-  #endif
   public static func makeStream(
       of elementType: Element.Type = Element.self,
       bufferingPolicy limit: Continuation.BufferingPolicy = .unbounded

--- a/stdlib/public/Concurrency/AsyncThrowingStream.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingStream.swift
@@ -508,9 +508,7 @@ extension AsyncThrowingStream {
   /// - Returns: A tuple containing the stream and its continuation. The continuation should be passed to the
   /// producer while the stream should be passed to the consumer.
   @available(SwiftStdlib 5.1, *)
-  #if !hasFeature(Embedded)
   @backDeployed(before: SwiftStdlib 5.9)
-  #endif
   public static func makeStream(
       of elementType: Element.Type = Element.self,
       throwing failureType: Failure.Type = Failure.self,

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -290,6 +290,15 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
   set(SWIFT_STDLIB_HAS_ASL FALSE)
   list(APPEND LLVM_OPTIONAL_SOURCES ExecutorImpl.cpp)
 
+  # Under Embedded Swift, all stdlib APIs should be available always. Replace
+  # all availability macros with an empty expansion (`*`).
+  set(SWIFT_STDLIB_AVAILABILITY_DEFINITIONS_EMBEDDED)
+  foreach(def ${SWIFT_STDLIB_AVAILABILITY_DEFINITIONS})
+    string(REGEX REPLACE ":.*" ":*" replaced "${def}")
+    list(APPEND SWIFT_STDLIB_AVAILABILITY_DEFINITIONS_EMBEDDED "${replaced}")
+  endforeach()
+  set(SWIFT_STDLIB_AVAILABILITY_DEFINITIONS "${SWIFT_STDLIB_AVAILABILITY_DEFINITIONS_EMBEDDED}")
+
   foreach(entry ${EMBEDDED_STDLIB_TARGET_TRIPLES})
     string(REGEX REPLACE "[ \t]+" ";" list "${entry}")
     list(GET list 0 arch)

--- a/stdlib/public/Concurrency/CheckedContinuation.swift
+++ b/stdlib/public/Concurrency/CheckedContinuation.swift
@@ -314,9 +314,7 @@ public nonisolated(nonsending) func withCheckedContinuation<T>(
 
 @inlinable
 @available(SwiftStdlib 5.1, *)
-#if !$Embedded
 @backDeployed(before: SwiftStdlib 6.0)
-#endif
 @available(*, deprecated, message: "Replaced by nonisolated(nonsending) overload")
 public func withCheckedContinuation<T>( // source-compatibility overload
   isolation: isolated (any Actor)?,
@@ -427,9 +425,7 @@ public nonisolated(nonsending) func withCheckedThrowingContinuation<T>( // nonse
 
 @inlinable
 @available(SwiftStdlib 5.1, *)
-#if !$Embedded
 @backDeployed(before: SwiftStdlib 6.0)
-#endif
 @available(*, deprecated, message: "Replaced by nonisolated(nonsending) overload")
 public func withCheckedThrowingContinuation<T>(
   isolation: isolated (any Actor)?,

--- a/stdlib/public/Concurrency/DiscardingTaskGroup.swift
+++ b/stdlib/public/Concurrency/DiscardingTaskGroup.swift
@@ -70,9 +70,7 @@ import Swift
 /// - SeeAlso: ``TaskGroup``
 /// - SeeAlso: ``withThrowingDiscardingTaskGroup(returning:body:)``
 @available(SwiftStdlib 5.9, *)
-#if !hasFeature(Embedded)
 @backDeployed(before: SwiftStdlib 6.0)
-#endif
 @inlinable
 public func withDiscardingTaskGroup<GroupResult>(
   returning returnType: GroupResult.Type = GroupResult.self,
@@ -345,9 +343,7 @@ extension DiscardingTaskGroup: Sendable { }
 /// }
 /// ```
 @available(SwiftStdlib 5.9, *)
-#if !hasFeature(Embedded)
 @backDeployed(before: SwiftStdlib 6.0)
-#endif
 @inlinable
 public func withThrowingDiscardingTaskGroup<GroupResult>(
     returning returnType: GroupResult.Type = GroupResult.self,

--- a/stdlib/public/Concurrency/ExecutorAssertions.swift
+++ b/stdlib/public/Concurrency/ExecutorAssertions.swift
@@ -45,9 +45,7 @@ extension SerialExecutor {
   ///   - line: The line number to print if the assertion fails The default value is
   ///           the line where this method was called.
   @available(SwiftStdlib 5.1, *)
-  #if !$Embedded
   @backDeployed(before: SwiftStdlib 5.9)
-  #endif
   @_unavailableInEmbedded
   public func preconditionIsolated(
       _ message: @autoclosure () -> String = String(),
@@ -94,9 +92,7 @@ extension Actor {
   ///   - line: The line number to print if the assertion fails The default is
   ///           where this method was called.
   @available(SwiftStdlib 5.1, *)
-  #if !$Embedded
   @backDeployed(before: SwiftStdlib 5.9)
-  #endif
   @_unavailableInEmbedded
   public nonisolated func preconditionIsolated(
       _ message: @autoclosure () -> String = String(),
@@ -144,9 +140,7 @@ extension GlobalActor {
   ///   - line: The line number to print if the assertion fails The default is
   ///           where this method was called.
   @available(SwiftStdlib 5.1, *)
-  #if !$Embedded
   @backDeployed(before: SwiftStdlib 5.9)
-  #endif
   @_unavailableInEmbedded
   public static func preconditionIsolated(
       _ message: @autoclosure () -> String = String(),
@@ -186,9 +180,7 @@ extension SerialExecutor {
   ///   - line: The line number to print if the assertion fails The default is
   ///           where this method was called.
   @available(SwiftStdlib 5.1, *)
-  #if !$Embedded
   @backDeployed(before: SwiftStdlib 5.9)
-  #endif
   @_unavailableInEmbedded
   public func assertIsolated(
       _ message: @autoclosure () -> String = String(),
@@ -235,9 +227,7 @@ extension Actor {
   ///   - line: The line number to print if the assertion fails The default is
   ///           where this method was called.
   @available(SwiftStdlib 5.1, *)
-  #if !$Embedded
   @backDeployed(before: SwiftStdlib 5.9)
-  #endif
   @_unavailableInEmbedded
   public nonisolated func assertIsolated(
       _ message: @autoclosure () -> String = String(),
@@ -283,9 +273,7 @@ extension GlobalActor {
   ///   - line: The line number to print if the assertion fails The default is
   ///           where this method was called.
   @available(SwiftStdlib 5.1, *)
-  #if !$Embedded
   @backDeployed(before: SwiftStdlib 5.9)
-  #endif
   @_unavailableInEmbedded
   public static func assertIsolated(
       _ message: @autoclosure () -> String = String(),

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -46,9 +46,7 @@ import Swift
 ///
 /// - SeeAlso: ``TaskGroup``
 @available(SwiftStdlib 5.1, *)
-#if !hasFeature(Embedded)
 @backDeployed(before: SwiftStdlib 6.0)
-#endif
 @inlinable
 public func withTaskGroup<ChildTaskResult, GroupResult>(
   of childTaskResultType: ChildTaskResult.Type = ChildTaskResult.self,
@@ -172,9 +170,7 @@ public func _unsafeInheritExecutor_withTaskGroup<ChildTaskResult, GroupResult>(
 /// - SeeAlso: ``ThrowingTaskGroup``
 /// - SeeAlso: ``ThrowingDiscardingTaskGroup``
 @available(SwiftStdlib 5.1, *)
-#if !hasFeature(Embedded)
 @backDeployed(before: SwiftStdlib 6.0)
-#endif
 @inlinable
 public func withThrowingTaskGroup<ChildTaskResult, GroupResult>(
   of childTaskResultType: ChildTaskResult.Type = ChildTaskResult.self,
@@ -424,9 +420,7 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
   ///
   /// - Returns: The value returned by the next child task that completes.
   @available(SwiftStdlib 5.1, *)
-  #if !hasFeature(Embedded)
   @backDeployed(before: SwiftStdlib 6.0)
-  #endif
   public mutating func next(isolation: isolated (any Actor)? = #isolation) async -> ChildTaskResult? {
     // try!-safe because this function only exists for Failure == Never,
     // and as such, it is impossible to spawn a throwing child task.
@@ -444,9 +438,7 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
   /// Await all of the pending tasks added this group.
   @usableFromInline
   @available(SwiftStdlib 5.1, *)
-  #if !hasFeature(Embedded)
   @backDeployed(before: SwiftStdlib 6.0)
-  #endif
   internal mutating func awaitAllRemainingTasks(isolation: isolated (any Actor)? = #isolation) async {
     while let _ = await next(isolation: isolation) {}
   }
@@ -595,9 +587,7 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   /// Await all the remaining tasks on this group.
   @usableFromInline
   @available(SwiftStdlib 5.1, *)
-  #if !hasFeature(Embedded)
   @backDeployed(before: SwiftStdlib 6.0)
-  #endif
   internal mutating func awaitAllRemainingTasks(isolation: isolated (any Actor)? = #isolation) async {
     while true {
       do {
@@ -730,9 +720,7 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   ///
   /// - SeeAlso: `nextResult()`
   @available(SwiftStdlib 5.1, *)
-  #if !hasFeature(Embedded)
   @backDeployed(before: SwiftStdlib 6.0)
-  #endif
   public mutating func next(isolation: isolated (any Actor)? = #isolation) async throws -> ChildTaskResult? {
     return try await _taskGroupWaitNext(group: _group)
   }

--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -203,9 +203,7 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   @inlinable
   @discardableResult
   @available(SwiftStdlib 5.1, *)
-  #if !hasFeature(Embedded)
   @backDeployed(before: SwiftStdlib 6.0)
-  #endif
   public func withValue<R>(_ valueDuringOperation: Value,
                            operation: () async throws -> R,
                            isolation: isolated (any Actor)? = #isolation,
@@ -256,9 +254,7 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   @inlinable
   @discardableResult
   @available(SwiftStdlib 5.1, *)
-  #if !hasFeature(Embedded)
   @backDeployed(before: SwiftStdlib 6.0)
-  #endif
   internal func withValueImpl<R>(_ valueDuringOperation: __owned Value,
                                  operation: () async throws -> R,
                                  isolation: isolated (any Actor)?,

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -516,10 +516,10 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
   set(SWIFT_STDLIB_ENABLE_VECTOR_TYPES OFF)
 
   # Under Embedded Swift, all stdlib APIs should be available always. Replace
-  # all availability macros with very very old OS versions.
+  # all availability macros with an empty expansion (`*`).
   set(SWIFT_STDLIB_AVAILABILITY_DEFINITIONS_EMBEDDED)
   foreach(def ${SWIFT_STDLIB_AVAILABILITY_DEFINITIONS})
-    string(REGEX REPLACE ":.*" ":macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, visionOS 1.0" replaced "${def}")
+    string(REGEX REPLACE ":.*" ":*" replaced "${def}")
     list(APPEND SWIFT_STDLIB_AVAILABILITY_DEFINITIONS_EMBEDDED "${replaced}")
   endforeach()
   set(SWIFT_STDLIB_AVAILABILITY_DEFINITIONS "${SWIFT_STDLIB_AVAILABILITY_DEFINITIONS_EMBEDDED}")

--- a/test/ASTGen/availability.swift
+++ b/test/ASTGen/availability.swift
@@ -6,7 +6,8 @@
 // DEFINE:   -define-availability '_iOS54:iOS 54.0' \
 // DEFINE:   -define-availability '_macOS51_0:macOS 51.0' \
 // DEFINE:   -define-availability '_myProject 1.0:macOS 51.0' \
-// DEFINE:   -define-availability '_myProject 2.5:macOS 52.5'
+// DEFINE:   -define-availability '_myProject 2.5:macOS 52.5' \
+// DEFINE:   -define-availability "_emptyMacro:*"
 
 // RUN: %target-swift-frontend-dump-parse \
 // RUN:   %{availability} \
@@ -42,6 +43,9 @@ func testMacroNameOnly() {}
 
 @available(_myProject 2.5, *)
 func testMacroWithVersion() {}
+
+@available(_emptyMacro, *)
+func testEmptyMacro() {}
 
 @_specialize(exported: true, availability: _iOS54Aligned, *; where T == Int)
 func testSpecialize<T>(arg: T) -> T {}

--- a/test/Availability/availability_define_parsing.swift
+++ b/test/Availability/availability_define_parsing.swift
@@ -8,6 +8,7 @@
 // RUN:   -define-availability "_noVersion: macOS" \
 // RUN:   -define-availability "_duplicateVersion 1.0:iOS 13.0" \
 // RUN:   -define-availability "_duplicateVersion 1.0:iOS 13.0" \
+// RUN:   -define-availability "_allowJustWildcard:*" \
 // RUN:   2>&1 | %FileCheck %s
 
 // Force reading the argument macros.

--- a/test/ModuleInterface/availability-expansion.swift
+++ b/test/ModuleInterface/availability-expansion.swift
@@ -6,7 +6,9 @@
 // RUN:   -define-availability "_iOS9:iOS 9.0" \
 // RUN:   -define-availability "_macOS10_11:macOS 10.11" \
 // RUN:   -define-availability "_myProject 1.0:macOS 10.11" \
-// RUN:   -define-availability "_myProject 2.5:macOS 10.12"
+// RUN:   -define-availability "_myProject 2.5:macOS 10.12" \
+// RUN:   -define-availability "_emptyMacro:*"
+
 // RUN: %target-swift-typecheck-module-from-interface(%t/Test.swiftinterface)
 // RUN: %FileCheck %s < %t/Test.swiftinterface
 
@@ -34,6 +36,11 @@ public func onMyProjectV1() {}
 public func onMyProjectV2_5() {}
 // CHECK: @available(macOS 10.12, *)
 // CHECK-NEXT: public func onMyProjectV2_5
+
+@available(_emptyMacro, *)
+public func emptyMacro() {}
+// CHECK-NOT: @available
+// CHECK-NEXT: public func emptyMacro()
 
 @_specialize(exported: true, availability: SwiftStdlib 5.1, *; where T == Int)
 public func testSemanticsAvailability<T>(_ t: T) {}

--- a/test/Sema/diag_originally_definedin.swift
+++ b/test/Sema/diag_originally_definedin.swift
@@ -1,5 +1,7 @@
 // RUN: %target-typecheck-verify-swift \
-// RUN:   -define-availability "_myProject 1.0:macOS 10.10"
+// RUN:   -define-availability "_myProject 1.0:macOS 10.10" \
+// RUN:   -define-availability "_emptyMacro:*"
+
 // REQUIRES: OS=macosx
 
 @_originallyDefinedIn(module: "original", OSX 10.13) // expected-error {{'@_originallyDefinedIn' requires that 'foo()' have explicit availability for macOS}}
@@ -31,6 +33,9 @@ public func macroVersioned() {}
 @_originallyDefinedIn(module: "original", _unknownMacro) // expected-warning {{unknown platform '_unknownMacro' for attribute '@_originallyDefinedIn'}}
 // expected-error@-1 {{expected version number in '@_originallyDefinedIn' attribute}}
 public func macroUnknown() {}
+
+@_originallyDefinedIn(module: "original", _emptyMacro)
+public func macroEmpty() {}
 
 @available(macOS 10.9, *)
 @_originallyDefinedIn(module: "original", macos 10.13) // expected-warning {{unknown platform 'macos' for attribute '@_originallyDefinedIn'; did you mean 'macOS'?}} {{43-48=macOS}}

--- a/test/attr/attr_backDeployed.swift
+++ b/test/attr/attr_backDeployed.swift
@@ -1,5 +1,6 @@
 // RUN: %target-typecheck-verify-swift -parse-as-library \
-// RUN:   -define-availability "_myProject 2.0:macOS 12.0"
+// RUN:   -define-availability "_myProject 2.0:macOS 12.0" \
+// RUN:   -define-availability "_emptyMacro:*"
 
 // REQUIRES: OS=macosx
 
@@ -483,6 +484,9 @@ public func unknownMacroVersioned() {}
 
 @backDeployed(before: _unknownMacro 1.0, _myProject 2.0) // expected-warning {{unknown platform '_unknownMacro' for attribute '@backDeployed'}}
 public func knownAndUnknownMacroVersioned() {}
+
+@backDeployed(before: _emptyMacro)
+public func emptyMacro() {}
 
 @backDeployed() // expected-error {{expected 'before:' in '@backDeployed' attribute}}
 // expected-error@-1 {{expected at least one platform version in '@backDeployed' attribute}}

--- a/test/embedded/availability-macos.swift
+++ b/test/embedded/availability-macos.swift
@@ -3,10 +3,21 @@
 
 // RUN: %target-typecheck-verify-swift -target arm64-apple-macos14 -enable-experimental-feature Embedded
 // RUN: %target-typecheck-verify-swift -target arm64-apple-macos15 -enable-experimental-feature Embedded
+// RUN: %target-typecheck-verify-swift -target x86_64-apple-macos14 -enable-experimental-feature Embedded -target-min-inlining-version min
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: OS=macosx
 
-func f(_: Span<Int>) { } // Span is @available(SwiftStdlib 6.1, *)
-func g(_: Int128) { } // Int128 is @available(SwiftStdlib 6.0, *)
+public protocol P { }
+struct S: P { }
+public enum E: Error { }
+
+public func f(_: Span<Int>) { } // Span is @available(SwiftStdlib 6.1, *)
+public func g(_: Int128) { } // Int128 is @available(SwiftStdlib 6.0, *)
+public func opaqueReturn() -> some P { return S() }
+public func asyncFunc() async { }
+public actor Actor { }
+public func variadicGeneric<each T>(_: repeat each T) { }
+public func typedThrow() throws(E) { }
+public struct ValueGeneric<let N: Int> { }


### PR DESCRIPTION
Clean up availability checking for Swift runtime features and stdlib declarations when building for Embedded. 

- Previously, specific Swift runtime features had ad-hoc checks that allow them to be used when building for Embedded, regardless of deployment target on macOS. Now the compiler consistently considers all Swift X.Y versions as always being always available on Apple platforms in Embedded.
- To facilitate cleaner availability annotations for the stdlib under Embedded, availability macros are now allowed to have empty expansions (indicated by `*`). `SwiftStdlib X.Y` now has empty expansions when building for Embedded. The Embedded build of the `_Concurrency` library also now transforms its macros to be consistent with the stdlib.
- Now that empty expansions are allowed, the `#if !$Embedded` clutter that previously was needed around `@backDeployed` attributes is no longer necessary to prevent errors.