### PR TITLE
[stdlib] Fix Range.randomElement() crash for large integer ranges

### DIFF
--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -312,6 +312,45 @@ where Bound: Strideable, Bound.Stride: SignedInteger
   }
 }
 
+extension Range where Bound: FixedWidthInteger, Bound.Stride: SignedInteger {
+  /// Returns a random element of the range, using the given generator as a
+  /// source for randomness.
+  ///
+  /// This override avoids the default `Collection.randomElement()`, which
+  /// narrows the element count to `Int` and crashes for ranges whose count
+  /// exceeds `Int.max` (e.g. `UInt128.min..<UInt128.max`).
+  ///
+  /// - Parameter generator: The random number generator to use when choosing a
+  ///   random element.
+  /// - Returns: A random element from the range. If the range is empty,
+  ///   the method returns `nil`.
+  ///
+  /// - Complexity: O(1).
+  @inlinable
+  public func randomElement<T: RandomNumberGenerator>(
+    using generator: inout T
+  ) -> Bound? {
+    guard !isEmpty else { return nil }
+    return Bound.random(in: self, using: &generator)
+  }
+
+  /// Returns a random element of the range.
+  ///
+  /// This override avoids the default `Collection.randomElement()`, which
+  /// narrows the element count to `Int` and crashes for ranges whose count
+  /// exceeds `Int.max` (e.g. `UInt128.min..<UInt128.max`).
+  ///
+  /// - Returns: A random element from the range. If the range is empty,
+  ///   the method returns `nil`.
+  ///
+  /// - Complexity: O(1).
+  @inlinable
+  public func randomElement() -> Bound? {
+    var g = SystemRandomNumberGenerator()
+    return randomElement(using: &g)
+  }
+}
+
 extension Range where Bound: Strideable, Bound.Stride: SignedInteger {
   /// Creates an instance equivalent to the given `ClosedRange`.
   ///

--- a/test/stdlib/RangeTraps.swift
+++ b/test/stdlib/RangeTraps.swift
@@ -146,5 +146,24 @@ if #available(SwiftStdlib 5.5, *) {
   }
 }
 
+// Regression test for https://github.com/swiftlang/swift/issues/82985
+// Range.randomElement() should not crash on ranges larger than Int.max.
+RangeTraps.test("randomElement/LargeRange")
+  .code {
+  let range: Range<UInt> = 0 ..< UInt.max
+  let element = range.randomElement()
+  expectNotNil(element)
+  if let e = element {
+    expectTrue(range.contains(e))
+  }
+}
+
+RangeTraps.test("randomElement/EmptyRange")
+  .code {
+  let range: Range<UInt> = 0 ..< 0
+  let element = range.randomElement()
+  expectNil(element)
+}
+
 runAllTests()
 


### PR DESCRIPTION
## Summary

`Range.randomElement()` crashes with "Distance is not representable in Int" for ranges whose element count exceeds `Int.max` (e.g. `UInt128.min..<UInt128.max`).

The default `Collection.randomElement()` narrows the count to `Int` via `numericCast`, which traps on overflow.

## Fix

Add a `randomElement` override on `Range where Bound: FixedWidthInteger` that delegates directly to `Bound.random(in:)`, bypassing the `Int` bottleneck entirely. This keeps all arithmetic in the `Bound` type and handles the full range natively in O(1).

## Testing

Added regression tests in [RangeTraps.swift](cci:7://file:///Users/marceloazevedo/Development/Swift/swift/test/stdlib/RangeTraps.swift:0:0-0:0):
- Large range (`UInt.min..<UInt.max`) returns a valid element
- Empty range returns `nil`

Resolves https://github.com/swiftlang/swift/issues/82985