### PR TITLE
[utils] add `GENERATED-BY:` to lit

### DIFF
--- a/test/Utils/update-generated-tests/Inputs/lit-substitutions-input.txt
+++ b/test/Utils/update-generated-tests/Inputs/lit-substitutions-input.txt
@@ -1,0 +1,1 @@
+generated content

--- a/test/Utils/update-generated-tests/Inputs/lit-substitutions.expected
+++ b/test/Utils/update-generated-tests/Inputs/lit-substitutions.expected
@@ -1,2 +1,3 @@
 // GENERATED-BY: cat %path/lit-substitutions-input.txt
+// GENERATED-HASH: 03b754805b97f9b6295cbeee6d76bec3bfd9da47bbf800ce93dd96533987c380
 generated content

--- a/test/Utils/update-generated-tests/Inputs/lit-substitutions.expected
+++ b/test/Utils/update-generated-tests/Inputs/lit-substitutions.expected
@@ -1,0 +1,2 @@
+// GENERATED-BY: cat %path/lit-substitutions-input.txt
+generated content

--- a/test/Utils/update-generated-tests/Inputs/lit-substitutions.txt
+++ b/test/Utils/update-generated-tests/Inputs/lit-substitutions.txt
@@ -1,0 +1,2 @@
+// GENERATED-BY: cat %path/lit-substitutions-input.txt
+placeholder

--- a/test/Utils/update-generated-tests/Inputs/split-file-last.expected
+++ b/test/Utils/update-generated-tests/Inputs/split-file-last.expected
@@ -3,4 +3,5 @@ int x;
 
 //--- b.txt
 // GENERATED-BY: echo hello
+// GENERATED-HASH: 5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03
 hello

--- a/test/Utils/update-generated-tests/Inputs/split-file-last.expected
+++ b/test/Utils/update-generated-tests/Inputs/split-file-last.expected
@@ -1,0 +1,6 @@
+//--- a.txt
+int x;
+
+//--- b.txt
+// GENERATED-BY: echo hello
+hello

--- a/test/Utils/update-generated-tests/Inputs/split-file-last.txt
+++ b/test/Utils/update-generated-tests/Inputs/split-file-last.txt
@@ -1,0 +1,6 @@
+//--- a.txt
+int x;
+
+//--- b.txt
+// GENERATED-BY: echo hello
+placeholder

--- a/test/Utils/update-generated-tests/Inputs/split-file-not-last.expected
+++ b/test/Utils/update-generated-tests/Inputs/split-file-not-last.expected
@@ -1,0 +1,5 @@
+//--- a.txt
+// GENERATED-BY: echo hello
+hello
+//--- b.txt
+unchanged

--- a/test/Utils/update-generated-tests/Inputs/split-file-not-last.expected
+++ b/test/Utils/update-generated-tests/Inputs/split-file-not-last.expected
@@ -1,5 +1,6 @@
 //--- a.txt
 // GENERATED-BY: echo hello
+// GENERATED-HASH: 5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03
 hello
 //--- b.txt
 unchanged

--- a/test/Utils/update-generated-tests/Inputs/split-file-not-last.txt
+++ b/test/Utils/update-generated-tests/Inputs/split-file-not-last.txt
@@ -1,0 +1,5 @@
+//--- a.txt
+// GENERATED-BY: echo hello
+placeholder
+//--- b.txt
+unchanged

--- a/test/Utils/update-generated-tests/lit-substitutions.txt
+++ b/test/Utils/update-generated-tests/lit-substitutions.txt
@@ -1,0 +1,8 @@
+// RUN: %empty-directory(%t)
+// RUN: cp %S/Inputs/lit-substitutions.txt %t.txt
+
+// Run the update, supplying the %path substitution. %%path in the RUN line is
+// passed to the script as the literal string %path.
+// RUN: %update-generated-tests --subst %%path %S/Inputs/ %t.txt
+
+// RUN: %diff %t.txt %S/Inputs/lit-substitutions.expected

--- a/test/Utils/update-generated-tests/lit.local.cfg
+++ b/test/Utils/update-generated-tests/lit.local.cfg
@@ -1,0 +1,6 @@
+import sys
+
+if sys.version_info < (3, 9):
+    config.unsupported = True
+
+config.suffixes = {'.txt'}

--- a/test/Utils/update-generated-tests/no-split-file-sections.txt
+++ b/test/Utils/update-generated-tests/no-split-file-sections.txt
@@ -1,0 +1,15 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %update-generated-tests %t/test.txt
+// RUN: %diff %t/test.txt %t/test.expected
+
+//--- test.txt
+// Leave this comment
+// GENERATED-BY: echo hello
+placeholder
+
+//--- test.expected
+// Leave this comment
+// GENERATED-BY: echo hello
+hello

--- a/test/Utils/update-generated-tests/split-file-last.txt
+++ b/test/Utils/update-generated-tests/split-file-last.txt
@@ -1,0 +1,4 @@
+// RUN: cp %S/Inputs/split-file-last.txt %t.txt
+
+// RUN: %update-generated-tests %t.txt
+// RUN: %diff %t.txt %S/Inputs/split-file-last.expected

--- a/test/Utils/update-generated-tests/split-file-not-last.txt
+++ b/test/Utils/update-generated-tests/split-file-not-last.txt
@@ -1,0 +1,4 @@
+// RUN: cp %S/Inputs/split-file-not-last.txt %t.txt
+
+// RUN: %update-generated-tests %t.txt
+// RUN: %diff %t.txt %S/Inputs/split-file-not-last.expected

--- a/test/Utils/update-generated-tests/unchanged-hash.txt
+++ b/test/Utils/update-generated-tests/unchanged-hash.txt
@@ -5,12 +5,12 @@
 // RUN: %diff %t/test.txt %t/test.expected
 
 //--- test.txt
-// Leave this comment
-// GENERATED-BY: echo hello
-placeholder
-
-//--- test.expected
-// Leave this comment
 // GENERATED-BY: echo hello
 // GENERATED-HASH: 5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03
-hello
+this test output has been manually edited
+
+//--- test.expected
+// GENERATED-BY: echo hello
+// GENERATED-HASH: 5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03
+this test output has been manually edited
+

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -790,6 +790,14 @@ config.substitutions.append( ('%clang-include-dir', config.clang_include_dir) )
 config.update_verify_tests = make_path(config.swift_utils, "update-verify-tests.py")
 config.substitutions.append( ('%update-verify-tests', '%s %s' % (config.python, config.update_verify_tests)) )
 
+config.update_generated_tests = make_path(config.swift_utils, "update-generated-tests.py")
+config.lit_pythonpath = os.path.dirname(os.path.dirname(lit.__file__))
+config.substitutions.append(
+  ('%update-generated-tests',
+   'env PYTHONPATH=%s %s %s' %
+   (config.lit_pythonpath, config.python, config.update_generated_tests))
+)
+
 config.swift_include_dir = make_path(config.swift_obj_root, 'include')
 config.substitutions.append( ('%swift-include-dir', config.swift_include_dir) )
 
@@ -3338,5 +3346,7 @@ config.substitutions.append( ('%use_no_opaque_pointers', '-Xcc -Xclang -Xcc -no-
 
 if lit_config.update_tests:
     sys.path.append(config.swift_utils)
+    from update_generated_tests.litplugin import generate_test_lit_plugin
+    lit_config.test_updaters.append(generate_test_lit_plugin)
     from update_verify_tests.litplugin import uvt_lit_plugin
     lit_config.test_updaters.append(uvt_lit_plugin)

--- a/utils/lit_support/split_file.py
+++ b/utils/lit_support/split_file.py
@@ -1,0 +1,100 @@
+import os
+import shlex
+import pathlib
+
+
+class SplitFileTarget:
+    def __init__(self, slice_start_idx, test_path, lines, name):
+        self.slice_start_idx = slice_start_idx
+        self.test_path = test_path
+        self.lines = lines
+        self.name = name
+
+    def copyFrom(self, source):
+        lines_before = self.lines[: self.slice_start_idx + 1]
+        self.lines = self.lines[self.slice_start_idx + 1 :]
+        slice_end_idx = None
+        for i, l in enumerate(self.lines):
+            if SplitFileTarget._get_split_line_path(l) != None:
+                slice_end_idx = i
+                break
+        if slice_end_idx is not None:
+            lines_after = self.lines[slice_end_idx:]
+        else:
+            lines_after = []
+        with open(source, "r") as f:
+            new_lines = lines_before + f.readlines() + lines_after
+        with open(self.test_path, "w") as f:
+            for l in new_lines:
+                f.write(l)
+
+    def __str__(self):
+        return f"slice {self.name} in {self.test_path}"
+
+    @staticmethod
+    def get_target_dir(commands, test_path):
+        # posix=True breaks Windows paths because \ is treated as an escaping character
+        for cmd in commands:
+            split = shlex.split(cmd, posix=False)
+            if "split-file" not in split:
+                continue
+            start_idx = split.index("split-file")
+            split = split[start_idx:]
+            if len(split) < 3:
+                continue
+            p = unquote(split[1].strip())
+            if not test_path.samefile(p):
+                continue
+            return unquote(split[2].strip())
+        return None
+
+    @staticmethod
+    def create(path, commands, test_path, target_dir):
+        path = pathlib.Path(path)
+        with open(test_path, "r") as f:
+            lines = f.readlines()
+        for i, l in enumerate(lines):
+            p = SplitFileTarget._get_split_line_path(l)
+            if p and path.samefile(os.path.join(target_dir, p)):
+                idx = i
+                break
+        else:
+            return None
+        return SplitFileTarget(idx, test_path, lines, p)
+
+    @staticmethod
+    def _get_split_line_path(l):
+        if len(l) < 6:
+            return None
+        if l.startswith("//"):
+            l = l[2:]
+        else:
+            l = l[1:]
+        if l.startswith("--- "):
+            l = l[4:]
+        else:
+            return None
+        return l.rstrip()
+
+
+def unquote(s):
+    if len(s) > 1 and s[0] == s[-1] and (s[0] == '"' or s[0] == "'"):
+        return s[1:-1]
+    return s
+
+
+def propagate_split_files(test_path, updated_files, commands):
+    test_path = pathlib.Path(test_path)
+    split_target_dir = SplitFileTarget.get_target_dir(commands, test_path)
+    if not split_target_dir:
+        return updated_files
+
+    new = []
+    for file in updated_files:
+        target = SplitFileTarget.create(file, commands, test_path, split_target_dir)
+        if target:
+            target.copyFrom(file)
+            new.append(str(target))
+        else:
+            new.append(file)
+    return new

--- a/utils/update-generated-tests.py
+++ b/utils/update-generated-tests.py
@@ -1,0 +1,44 @@
+import sys
+import argparse
+from update_generated_tests.litplugin import update_generated_test
+
+"""
+Run the GENERATED-BY command found in a test file and update the file with
+the output.  All lines before and including the GENERATED-BY: comment are
+preserved; everything after it (up to the next split-file section header, or
+EOF) is replaced with the command's stdout.
+
+Substitutions can be applied to the GENERATED-BY command before it is
+executed by passing one or more --subst PATTERN REPLACEMENT pairs.  PATTERN
+is treated as a regular expression (as in re.sub).
+
+Example usage:
+  python3 update-generated-tests.py path/to/test.swift
+  python3 update-generated-tests.py --subst '%t' /tmp/mytest.tmp path/to/test.swift
+"""
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("test_file", help="The test file to update")
+    parser.add_argument(
+        "--subst",
+        nargs=2,
+        action="append",
+        metavar=("PATTERN", "REPLACEMENT"),
+        default=[],
+        help="Apply a substitution to the GENERATED-BY command (may be repeated)",
+    )
+    args = parser.parse_args()
+
+    (err, msg) = update_generated_test(args.test_file, substitutions=args.subst)
+    if err:
+        print(err, file=sys.stderr)
+        sys.exit(1)
+    if msg:
+        print(msg)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/utils/update_generated_tests/litplugin.py
+++ b/utils/update_generated_tests/litplugin.py
@@ -1,3 +1,4 @@
+import hashlib
 import os
 import re
 import shlex
@@ -12,6 +13,7 @@ If the GENERATED-BY is in a `split-file` slice it updates the corresponding slic
 """
 
 _GENERATED_BY_RE = re.compile(r"^//\s*GENERATED-BY:\s*(.*)")
+_GENERATED_HASH_RE = re.compile(r"^//\s*GENERATED-HASH:\s*(.*)")
 
 
 class SplitFileTarget:
@@ -116,15 +118,17 @@ def propagate_split_files(test_path, updated_files, commands):
 def _run_and_update(test_path, cmd):
     """
     Run `cmd`, use its stdout to replace the GENERATED-BY section content in
-    `test_path`. Everything before and including the GENERATED-BY line is
-    preserved; content after it up to the next split-file section header (or
-    EOF) is replaced with the command output.
+    `test_path`. A GENERATED-HASH comment is inserted after the GENERATED-BY
+    line containing a SHA-256 hash of the output. If the file already contains
+    a GENERATED-HASH and the hash matches, the file is not rewritten.
 
-    Returns an error string on failure, or None on success.
+    Returns (error_string, False) on failure.
+    Returns (None, False) if the hash is unchanged and the file was not updated.
+    Returns (None, True) if the file was updated.
     """
     proc = subprocess.run(cmd, shell=True, capture_output=True, text=True)
     if proc.returncode != 0:
-        return f"GENERATED-BY command failed:\n{proc.stderr}"
+        return (f"GENERATED-BY command failed:\n{proc.stderr}", False)
 
     output = proc.stdout
 
@@ -141,10 +145,22 @@ def _run_and_update(test_path, cmd):
         generated_by_idx is not None
     ), f"GENERATED-BY not found in {test_path}"
 
+    new_hash = hashlib.sha256(output.encode()).hexdigest()
+
+    # Check for an existing GENERATED-HASH line immediately after GENERATED-BY.
+    content_start = generated_by_idx + 1
+    old_hash = None
+    if content_start < len(lines):
+        m = _GENERATED_HASH_RE.match(lines[content_start].strip())
+        if m:
+            old_hash = m.group(1).strip()
+            content_start += 1
+
+    if old_hash == new_hash:
+        return (None, False)
+
     slice_end = None
-    for i, line in enumerate(
-        lines[generated_by_idx + 1 :], start=generated_by_idx + 1
-    ):
+    for i, line in enumerate(lines[content_start:], start=content_start):
         if SplitFileTarget._get_split_line_path(line) is not None:
             slice_end = i
             break
@@ -153,12 +169,15 @@ def _run_and_update(test_path, cmd):
     if output_lines and not output_lines[-1].endswith("\n"):
         output_lines[-1] += "\n"
 
+    hash_line = f"// GENERATED-HASH: {new_hash}\n"
     lines_after = lines[slice_end:] if slice_end is not None else []
 
     with open(test_path, "w") as f:
-        f.writelines(lines[: generated_by_idx + 1] + output_lines + lines_after)
+        f.writelines(
+            lines[: generated_by_idx + 1] + [hash_line] + output_lines + lines_after
+        )
 
-    return None
+    return (None, True)
 
 
 def update_generated_test(test_path, substitutions):
@@ -169,7 +188,8 @@ def update_generated_test(test_path, substitutions):
     lit.TestRunner.applySubstitutions), run the resulting command, and update
     the file with the output.
 
-    Returns (None, None) if no GENERATED-BY was found.
+    Returns (None, None) if no GENERATED-BY was found, or if the output did not
+    change since last generation.
     Returns (error_string, None) on failure.
     Returns (None, message_string) on success.
     """
@@ -182,10 +202,11 @@ def update_generated_test(test_path, substitutions):
         m = _GENERATED_BY_RE.match(line.strip())
         if m:
             [cmd] = applySubstitutions([m.group(1).strip()], substitutions)
-            err = _run_and_update(test_path, cmd)
+            (err, changed) = _run_and_update(test_path, cmd)
             if err:
                 return (err, None)
-            return (None, f"updated file: {test_path}")
+            if changed:
+                return (None, f"updated file: {test_path}")
 
     return (None, None)
 

--- a/utils/update_generated_tests/litplugin.py
+++ b/utils/update_generated_tests/litplugin.py
@@ -1,9 +1,7 @@
 import hashlib
-import os
 import re
-import shlex
 import subprocess
-import pathlib
+from lit_support.split_file import SplitFileTarget
 
 """
 This file provides the `generate_test_lit_plugin` function, which is invoked on failed RUN lines when lit is executed with --update-tests.
@@ -14,105 +12,6 @@ If the GENERATED-BY is in a `split-file` slice it updates the corresponding slic
 
 _GENERATED_BY_RE = re.compile(r"^//\s*GENERATED-BY:\s*(.*)")
 _GENERATED_HASH_RE = re.compile(r"^//\s*GENERATED-HASH:\s*(.*)")
-
-
-class SplitFileTarget:
-    def __init__(self, slice_start_idx, test_path, lines, name):
-        self.slice_start_idx = slice_start_idx
-        self.test_path = test_path
-        self.lines = lines
-        self.name = name
-
-    def copyFrom(self, source):
-        lines_before = self.lines[: self.slice_start_idx + 1]
-        self.lines = self.lines[self.slice_start_idx + 1 :]
-        slice_end_idx = None
-        for i, l in enumerate(self.lines):
-            if SplitFileTarget._get_split_line_path(l) != None:
-                slice_end_idx = i
-                break
-        if slice_end_idx is not None:
-            lines_after = self.lines[slice_end_idx:]
-        else:
-            lines_after = []
-        with open(source, "r") as f:
-            new_lines = lines_before + f.readlines() + lines_after
-        with open(self.test_path, "w") as f:
-            for l in new_lines:
-                f.write(l)
-
-    def __str__(self):
-        return f"slice {self.name} in {self.test_path}"
-
-    @staticmethod
-    def get_target_dir(commands, test_path):
-        # posix=True breaks Windows paths because \ is treated as an escaping character
-        for cmd in commands:
-            split = shlex.split(cmd, posix=False)
-            if "split-file" not in split:
-                continue
-            start_idx = split.index("split-file")
-            split = split[start_idx:]
-            if len(split) < 3:
-                continue
-            p = unquote(split[1].strip())
-            if not test_path.samefile(p):
-                continue
-            return unquote(split[2].strip())
-        return None
-
-    @staticmethod
-    def create(path, commands, test_path, target_dir):
-        path = pathlib.Path(path)
-        with open(test_path, "r") as f:
-            lines = f.readlines()
-        for i, l in enumerate(lines):
-            p = SplitFileTarget._get_split_line_path(l)
-            if p and path.samefile(os.path.join(target_dir, p)):
-                idx = i
-                break
-        else:
-            return None
-        return SplitFileTarget(idx, test_path, lines, p)
-
-    @staticmethod
-    def _get_split_line_path(l):
-        if len(l) < 6:
-            return None
-        if l.startswith("//"):
-            l = l[2:]
-        else:
-            l = l[1:]
-        if l.startswith("--- "):
-            l = l[4:]
-        else:
-            return None
-        return l.rstrip()
-
-
-def unquote(s):
-    if len(s) > 1 and s[0] == s[-1] and (s[0] == '"' or s[0] == "'"):
-        return s[1:-1]
-    return s
-
-
-def propagate_split_files(test_path, updated_files, commands):
-    test_path = pathlib.Path(test_path)
-    split_target_dir = SplitFileTarget.get_target_dir(commands, test_path)
-    if not split_target_dir:
-        return updated_files
-
-    new = []
-    for file in updated_files:
-        target = SplitFileTarget.create(
-            file, commands, test_path, split_target_dir
-        )
-        if target:
-            target.copyFrom(file)
-            new.append(str(target))
-        else:
-            new.append(file)
-    return new
 
 
 def _run_and_update(test_path, cmd):

--- a/utils/update_generated_tests/litplugin.py
+++ b/utils/update_generated_tests/litplugin.py
@@ -1,0 +1,199 @@
+import os
+import re
+import shlex
+import subprocess
+import pathlib
+
+"""
+This file provides the `generate_test_lit_plugin` function, which is invoked on failed RUN lines when lit is executed with --update-tests.
+It checks whether the test file contains a GENERATED-BY: line, and if so executes that line (after performing lit substitutions) and updates the file with the output.
+All lines before GENERATED-BY: are kept as is.
+If the GENERATED-BY is in a `split-file` slice it updates the corresponding slice in the source file.
+"""
+
+_GENERATED_BY_RE = re.compile(r"^//\s*GENERATED-BY:\s*(.*)")
+
+
+class SplitFileTarget:
+    def __init__(self, slice_start_idx, test_path, lines, name):
+        self.slice_start_idx = slice_start_idx
+        self.test_path = test_path
+        self.lines = lines
+        self.name = name
+
+    def copyFrom(self, source):
+        lines_before = self.lines[: self.slice_start_idx + 1]
+        self.lines = self.lines[self.slice_start_idx + 1 :]
+        slice_end_idx = None
+        for i, l in enumerate(self.lines):
+            if SplitFileTarget._get_split_line_path(l) != None:
+                slice_end_idx = i
+                break
+        if slice_end_idx is not None:
+            lines_after = self.lines[slice_end_idx:]
+        else:
+            lines_after = []
+        with open(source, "r") as f:
+            new_lines = lines_before + f.readlines() + lines_after
+        with open(self.test_path, "w") as f:
+            for l in new_lines:
+                f.write(l)
+
+    def __str__(self):
+        return f"slice {self.name} in {self.test_path}"
+
+    @staticmethod
+    def get_target_dir(commands, test_path):
+        # posix=True breaks Windows paths because \ is treated as an escaping character
+        for cmd in commands:
+            split = shlex.split(cmd, posix=False)
+            if "split-file" not in split:
+                continue
+            start_idx = split.index("split-file")
+            split = split[start_idx:]
+            if len(split) < 3:
+                continue
+            p = unquote(split[1].strip())
+            if not test_path.samefile(p):
+                continue
+            return unquote(split[2].strip())
+        return None
+
+    @staticmethod
+    def create(path, commands, test_path, target_dir):
+        path = pathlib.Path(path)
+        with open(test_path, "r") as f:
+            lines = f.readlines()
+        for i, l in enumerate(lines):
+            p = SplitFileTarget._get_split_line_path(l)
+            if p and path.samefile(os.path.join(target_dir, p)):
+                idx = i
+                break
+        else:
+            return None
+        return SplitFileTarget(idx, test_path, lines, p)
+
+    @staticmethod
+    def _get_split_line_path(l):
+        if len(l) < 6:
+            return None
+        if l.startswith("//"):
+            l = l[2:]
+        else:
+            l = l[1:]
+        if l.startswith("--- "):
+            l = l[4:]
+        else:
+            return None
+        return l.rstrip()
+
+
+def unquote(s):
+    if len(s) > 1 and s[0] == s[-1] and (s[0] == '"' or s[0] == "'"):
+        return s[1:-1]
+    return s
+
+
+def propagate_split_files(test_path, updated_files, commands):
+    test_path = pathlib.Path(test_path)
+    split_target_dir = SplitFileTarget.get_target_dir(commands, test_path)
+    if not split_target_dir:
+        return updated_files
+
+    new = []
+    for file in updated_files:
+        target = SplitFileTarget.create(
+            file, commands, test_path, split_target_dir
+        )
+        if target:
+            target.copyFrom(file)
+            new.append(str(target))
+        else:
+            new.append(file)
+    return new
+
+
+def _run_and_update(test_path, cmd):
+    """
+    Run `cmd`, use its stdout to replace the GENERATED-BY section content in
+    `test_path`. Everything before and including the GENERATED-BY line is
+    preserved; content after it up to the next split-file section header (or
+    EOF) is replaced with the command output.
+
+    Returns an error string on failure, or None on success.
+    """
+    proc = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    if proc.returncode != 0:
+        return f"GENERATED-BY command failed:\n{proc.stderr}"
+
+    output = proc.stdout
+
+    with open(test_path, "r") as f:
+        lines = f.readlines()
+
+    generated_by_idx = None
+    for i, line in enumerate(lines):
+        if _GENERATED_BY_RE.match(line.strip()):
+            generated_by_idx = i
+            break
+
+    assert (
+        generated_by_idx is not None
+    ), f"GENERATED-BY not found in {test_path}"
+
+    slice_end = None
+    for i, line in enumerate(
+        lines[generated_by_idx + 1 :], start=generated_by_idx + 1
+    ):
+        if SplitFileTarget._get_split_line_path(line) is not None:
+            slice_end = i
+            break
+
+    output_lines = output.splitlines(keepends=True)
+    if output_lines and not output_lines[-1].endswith("\n"):
+        output_lines[-1] += "\n"
+
+    lines_after = lines[slice_end:] if slice_end is not None else []
+
+    with open(test_path, "w") as f:
+        f.writelines(lines[: generated_by_idx + 1] + output_lines + lines_after)
+
+    return None
+
+
+def update_generated_test(test_path, substitutions):
+    """
+    Standalone entry point (used by update-generated-tests.py).
+    Find the GENERATED-BY directive in test_path, apply `substitutions` (a
+    sequence of (pattern, replacement) pairs as accepted by
+    lit.TestRunner.applySubstitutions), run the resulting command, and update
+    the file with the output.
+
+    Returns (None, None) if no GENERATED-BY was found.
+    Returns (error_string, None) on failure.
+    Returns (None, message_string) on success.
+    """
+    from lit.TestRunner import applySubstitutions
+
+    with open(test_path, "r") as f:
+        lines = f.readlines()
+
+    for line in lines:
+        m = _GENERATED_BY_RE.match(line.strip())
+        if m:
+            [cmd] = applySubstitutions([m.group(1).strip()], substitutions)
+            err = _run_and_update(test_path, cmd)
+            if err:
+                return (err, None)
+            return (None, f"updated file: {test_path}")
+
+    return (None, None)
+
+
+def generate_test_lit_plugin(result, test, commands):
+    from lit.TestRunner import getTempPaths, getDefaultSubstitutions
+
+    tmpDir, tmpBase = getTempPaths(test)
+    substitutions = getDefaultSubstitutions(test, tmpDir, tmpBase)
+    (err, msg) = update_generated_test(test.getFilePath(), substitutions)
+    return err or msg

--- a/utils/update_verify_tests/litplugin.py
+++ b/utils/update_verify_tests/litplugin.py
@@ -1,110 +1,11 @@
-import os
-import shlex
-import pathlib
 from update_verify_tests.core import check_expectations
+from lit_support.split_file import propagate_split_files
 
 """
 This file provides the `uvt_lit_plugin` function, which is invoked on failed RUN lines when lit is executed with --update-tests.
 It checks whether the failed command is a swift compiler invocation with the `-verify` flag and analyses the output to try to
 repair the failed test. If the updated file was originally created by `split-file` it updates the corresponding slice in the source file.
 """
-
-
-class SplitFileTarget:
-    def __init__(self, slice_start_idx, test_path, lines, name):
-        self.slice_start_idx = slice_start_idx
-        self.test_path = test_path
-        self.lines = lines
-        self.name = name
-
-    def copyFrom(self, source):
-        lines_before = self.lines[: self.slice_start_idx + 1]
-        self.lines = self.lines[self.slice_start_idx + 1 :]
-        slice_end_idx = None
-        for i, l in enumerate(self.lines):
-            if SplitFileTarget._get_split_line_path(l) != None:
-                slice_end_idx = i
-                break
-        if slice_end_idx is not None:
-            lines_after = self.lines[slice_end_idx:]
-        else:
-            lines_after = []
-        with open(source, "r") as f:
-            new_lines = lines_before + f.readlines() + lines_after
-        with open(self.test_path, "w") as f:
-            for l in new_lines:
-                f.write(l)
-
-    def __str__(self):
-        return f"slice {self.name} in {self.test_path}"
-
-    @staticmethod
-    def get_target_dir(commands, test_path):
-        # posix=True breaks Windows paths because \ is treated as an escaping character
-        for cmd in commands:
-            split = shlex.split(cmd, posix=False)
-            if "split-file" not in split:
-                continue
-            start_idx = split.index("split-file")
-            split = split[start_idx:]
-            if len(split) < 3:
-                continue
-            p = unquote(split[1].strip())
-            if not test_path.samefile(p):
-                continue
-            return unquote(split[2].strip())
-        return None
-
-    @staticmethod
-    def create(path, commands, test_path, target_dir):
-        path = pathlib.Path(path)
-        with open(test_path, "r") as f:
-            lines = f.readlines()
-        for i, l in enumerate(lines):
-            p = SplitFileTarget._get_split_line_path(l)
-            if p and path.samefile(os.path.join(target_dir, p)):
-                idx = i
-                break
-        else:
-            return None
-        return SplitFileTarget(idx, test_path, lines, p)
-
-    @staticmethod
-    def _get_split_line_path(l):
-        if len(l) < 6:
-            return None
-        if l.startswith("//"):
-            l = l[2:]
-        else:
-            l = l[1:]
-        if l.startswith("--- "):
-            l = l[4:]
-        else:
-            return None
-        return l.rstrip()
-
-
-def unquote(s):
-    if len(s) > 1 and s[0] == s[-1] and (s[0] == '"' or s[0] == "'"):
-        return s[1:-1]
-    return s
-
-
-def propagate_split_files(test_path, updated_files, commands):
-    test_path = pathlib.Path(test_path)
-    split_target_dir = SplitFileTarget.get_target_dir(commands, test_path)
-    if not split_target_dir:
-        return updated_files
-
-    new = []
-    for file in updated_files:
-        target = SplitFileTarget.create(file, commands, test_path, split_target_dir)
-        if target:
-            target.copyFrom(file)
-            new.append(str(target))
-        else:
-            new.append(file)
-    return new
 
 
 def uvt_lit_plugin(result, test, commands):


### PR DESCRIPTION
This adds an automatic test updater that checks for GENERATED-BY:
comments containing a command whose stdout is used to populate a file,
or a split-file slice in a file.

By hashing the output, the test updater won't trigger for failures
unrelated to the test file being outdated. That is, if the generated
test output hasn't changed, then regenerating the test surely won't fix
it. This serves two purposes:
 - it allows someone to make small edits to the output (e.g. add comments) and
   not have them overwritten all the time
 - only one test updater is allowed to make updates each test failure,
   so if the generated file hasn't changed, it shouldn't prevent other
   test updaters from executing

The test updater applies the same lit substitutions as would be applied
in a RUN: line, allowing Swift tool usage in the run line.