### PR TITLE
Some optimization fixes

### DIFF
--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -1958,7 +1958,8 @@ public:
   }
 
   SILValue visitPhi(SILPhiArgument *phi) {
-    assert(false && "unexpected phi on access path");
+    // "Address" phis can happen because we look through `pointer_to_address`
+    // instructions and a phi can be a `Builtin.RawPointer`.
     return SILValue();
   }
 

--- a/include/swift/SILOptimizer/PassManager/PassManager.h
+++ b/include/swift/SILOptimizer/PassManager/PassManager.h
@@ -134,8 +134,8 @@ public:
   /// This is useful if a pass needs an updated analysis after invalidating the SIL of a function.
   void updateAnalysis();
 
-  void beginVerifyFunction(SILFunction *function);
-  void endVerifyFunction();
+  SILFunction *beginVerifyFunction(SILFunction *function);
+  void endVerifyFunction(SILFunction *prevFunction);
 
   void setNeedFixStackNesting(bool newValue) { needFixStackNesting = newValue; }
   bool getNeedFixStackNesting() const { return needFixStackNesting; }

--- a/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
+++ b/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
@@ -44,11 +44,6 @@
 
 using namespace swift;
 
-// Utility command line argument to dump the module before we eliminate
-// ownership from it.
-static llvm::cl::opt<std::string>
-DumpBefore("sil-dump-before-ome-to-path", llvm::cl::Hidden);
-
 //===----------------------------------------------------------------------===//
 //                               Implementation
 //===----------------------------------------------------------------------===//
@@ -909,55 +904,55 @@ static void prepareSILFunctionForOptimization(ModuleDecl *, SILFunction *f) {
 
 namespace {
 
-struct OwnershipModelEliminator : SILFunctionTransform {
+// The OwnershipModelEliminator must be a module pass because it installs a
+// deserialization handler, which affects all functions in the module.
+// If it would be a function pass, the deserialization handler eliminates
+// ownership in de-serialized functions which might be used by other
+// functions (than the currently optimized) which still require OSSA.
+struct OwnershipModelEliminator : SILModuleTransform {
   OwnershipModelEliminator() {}
 
   void run() override {
-    if (DumpBefore.size()) {
-      getFunction()->dump(DumpBefore.c_str());
-    }
+    for (SILFunction &f : *getModule()) {
+      if (!f.hasOwnership())
+        continue;
 
-    auto *f = getFunction();
-    auto &mod = getFunction()->getModule();
+      // Verify here to make sure ownership is correct before we strip.
+      {
+        // Add a pretty stack trace entry to tell users who see a verification
+        // failure triggered by this verification check that they need to re-run
+        // with -sil-verify-all to actually find the pass that introduced the
+        // verification error.
+        //
+        // DISCUSSION: This occurs due to the crash from the verification
+        // failure happening in the pass itself. This causes us to dump the
+        // SILFunction and emit a msg that this pass (OME) is the culprit. This
+        // is generally correct for most passes, but not for OME since we are
+        // verifying before we have even modified the function to ensure that
+        // all ownership invariants have been respected before we lower
+        // ownership from the function.
+        llvm::PrettyStackTraceString silVerifyAllMsgOnFailure(
+            "Found verification error when verifying before lowering "
+            "ownership. Please re-run with -sil-verify-all to identify the "
+            "actual pass that introduced the verification error.");
+        f.verify(getAnalysis<BasicCalleeAnalysis>()->getCalleeCache());
+        getPassManager()->runSwiftFunctionVerification(&f);
+      }
 
-    if (!f->hasOwnership())
-      return;
-
-    // Verify here to make sure ownership is correct before we strip.
-    {
-      // Add a pretty stack trace entry to tell users who see a verification
-      // failure triggered by this verification check that they need to re-run
-      // with -sil-verify-all to actually find the pass that introduced the
-      // verification error.
-      //
-      // DISCUSSION: This occurs due to the crash from the verification
-      // failure happening in the pass itself. This causes us to dump the
-      // SILFunction and emit a msg that this pass (OME) is the culprit. This
-      // is generally correct for most passes, but not for OME since we are
-      // verifying before we have even modified the function to ensure that
-      // all ownership invariants have been respected before we lower
-      // ownership from the function.
-      llvm::PrettyStackTraceString silVerifyAllMsgOnFailure(
-          "Found verification error when verifying before lowering "
-          "ownership. Please re-run with -sil-verify-all to identify the "
-          "actual pass that introduced the verification error.");
-      f->verify(getAnalysis<BasicCalleeAnalysis>()->getCalleeCache());
-      getPassManager()->runSwiftFunctionVerification(f);
-    }
-
-    if (stripOwnership(*f)) {
-      auto InvalidKind = SILAnalysis::InvalidationKind::BranchesAndInstructions;
-      invalidateAnalysis(InvalidKind);
+      if (stripOwnership(f)) {
+        auto InvalidKind = SILAnalysis::InvalidationKind::BranchesAndInstructions;
+        invalidateAnalysis(&f, InvalidKind);
+      }
     }
 
     // Register a handler so that all future things we deserialize have ownership stripped.
     using NotificationHandlerTy =
         FunctionBodyDeserializationNotificationHandler;
     std::unique_ptr<DeserializationNotificationHandler> ptr;
-    if (!mod.hasRegisteredDeserializationNotificationHandlerForAllFuncOME()) {
+    if (!getModule()->hasRegisteredDeserializationNotificationHandlerForAllFuncOME()) {
       ptr.reset(new NotificationHandlerTy(prepareSILFunctionForOptimization));
-      mod.registerDeserializationNotificationHandler(std::move(ptr));
-      mod.setRegisteredDeserializationNotificationHandlerForAllFuncOME();
+      getModule()->registerDeserializationNotificationHandler(std::move(ptr));
+      getModule()->setRegisteredDeserializationNotificationHandlerForAllFuncOME();
     }
   }
 };

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -1532,21 +1532,23 @@ void SwiftPassInvocation::verifyEverythingIsCleared() {
   SILContext::verifyEverythingIsCleared();
 }
 
-void SwiftPassInvocation::beginVerifyFunction(SILFunction *function) {
-  if (transform) {
+SILFunction *SwiftPassInvocation::beginVerifyFunction(SILFunction *function) {
+  SILFunction *prevFunction = this->function;
+  if (transform && this->function) {
     ASSERT(this->function == function);
   } else {
     ASSERT(!this->function);
     this->function = function;
   }
+  return prevFunction;
 }
 
-void SwiftPassInvocation::endVerifyFunction() {
+void SwiftPassInvocation::endVerifyFunction(SILFunction *prevFunction) {
   ASSERT(function);
   if (!transform) {
     verifyEverythingIsCleared();
-    function = nullptr;
   }
+  function = prevFunction;
 }
 
 irgen::IRGenModule *SwiftPassInvocation::getIRGenModule() {

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -92,20 +92,6 @@ static void addMandatoryDebugSerialization(SILPassPipelinePlan &P) {
   P.addMandatoryInlining();
 }
 
-static void addOwnershipModelEliminatorPipeline(SILPassPipelinePlan &P) {
-  P.startPipeline("Ownership Model Eliminator");
-  P.addAddressLowering();
-  P.addOwnershipModelEliminator();
-}
-
-/// Passes for performing definite initialization. Must be run together in this
-/// order.
-static void addDefiniteInitialization(SILPassPipelinePlan &P) {
-  P.addDefiniteInitialization();
-  P.addLetPropertyLowering();
-  P.addRawSILInstLowering();
-}
-
 // This pipeline defines a set of mandatory diagnostic passes and a set of
 // supporting optimization passes that enable those diagnostics. These are run
 // before any performance optimizations and in contrast to those optimizations
@@ -137,7 +123,12 @@ static void addMandatoryDiagnosticOptPipeline(SILPassPipelinePlan &P) {
 
   P.addNoReturnFolding();
   P.addBooleanLiteralFolding();
-  addDefiniteInitialization(P);
+
+  /// Passes for performing definite initialization.
+  /// Must be run together in this order.
+  P.addDefiniteInitialization();
+  P.addLetPropertyLowering();
+  P.addRawSILInstLowering();
 
   P.addAddressLowering();
 
@@ -366,7 +357,9 @@ SILPassPipelinePlan SILPassPipelinePlan::getLowerHopToActorPassPipeline(
 SILPassPipelinePlan SILPassPipelinePlan::getOwnershipEliminatorPassPipeline(
     const SILOptions &Options) {
   SILPassPipelinePlan P(Options);
-  addOwnershipModelEliminatorPipeline(P);
+  P.startPipeline("Ownership Model Eliminator");
+  P.addAddressLowering();
+  P.addOwnershipModelEliminator();
   return P;
 }
 

--- a/lib/SILOptimizer/Utils/OptimizerBridging.cpp
+++ b/lib/SILOptimizer/Utils/OptimizerBridging.cpp
@@ -61,9 +61,9 @@ void SILPassManager::runSwiftFunctionVerification(SILFunction *f) {
     return;
   }
 
-  getSwiftPassInvocation()->beginVerifyFunction(f);
+  SILFunction *prevFunction = getSwiftPassInvocation()->beginVerifyFunction(f);
   BridgedVerifier::runSwiftFunctionVerification(f, getSwiftPassInvocation());
-  getSwiftPassInvocation()->endVerifyFunction();
+  getSwiftPassInvocation()->endVerifyFunction(prevFunction);
 }
 
 void SILPassManager::runSwiftModuleVerification() {

--- a/test/SILOptimizer/capture_propagation.sil
+++ b/test/SILOptimizer/capture_propagation.sil
@@ -585,7 +585,6 @@ bb0:
 // CHECK:         [[K:%[0-9]+]] = keypath
 // CHECK:         [[F:%[0-9]+]] = function_ref @swift_getAtKeyPath
 // CHECK:         apply [[F]]<Str, Int>({{%[0-9]+, %[0-9]+}}, [[K]]
-// CHECK:         strong_release [[K]]
 // CHECK:       } // end sil function '$s18closureWithKeypath{{.*}}main3StrVSiTf3npk_n'
 sil @closureWithKeypath : $@convention(thin) (Str, @guaranteed KeyPath<Str, Int>) -> Int {
 bb0(%0 : $Str, %1 : $KeyPath<Str, Int>):
@@ -695,8 +694,9 @@ bb0:
 
 // CHECK-LABEL: sil shared [ossa] @$s22closureWithKeypathOSSA{{.*}}main3StrVSiTf3npk_n : $@convention(thin) (Str) -> Int {
 // CHECK:         [[K:%[0-9]+]] = keypath
+// CHECK:         [[BB:%[0-9]+]] = begin_borrow [[K]]
 // CHECK:         [[F:%[0-9]+]] = function_ref @swift_getAtKeyPath
-// CHECK:         apply [[F]]<Str, Int>({{%[0-9]+, %[0-9]+}}, [[K]]
+// CHECK:         apply [[F]]<Str, Int>({{%[0-9]+, %[0-9]+}}, [[BB]]
 // CHECK:         destroy_value [[K]]
 // CHECK:       } // end sil function '$s22closureWithKeypathOSSA{{.*}}main3StrVSiTf3npk_n'
 sil [ossa] @closureWithKeypathOSSA : $@convention(thin) (Str, @guaranteed KeyPath<Str, Int>) -> Int {
@@ -736,8 +736,9 @@ bb0(%0 : $Int):
 
 // CHECK-LABEL: sil shared [ossa] @$s24closureWithKeypathAndInt{{.*}}4main3StrVSiTf3npkn_n : $@convention(thin) (Str, Int) -> Int {
 // CHECK:         [[K:%[0-9]+]] = keypath
+// CHECK:         [[BB:%[0-9]+]] = begin_borrow [[K]]
 // CHECK:         [[F:%[0-9]+]] = function_ref @swift_getAtKeyPath
-// CHECK:         apply [[F]]<Str, Int>({{%[0-9]+, %[0-9]+}}, [[K]]
+// CHECK:         apply [[F]]<Str, Int>({{%[0-9]+, %[0-9]+}}, [[BB]]
 // CHECK:         destroy_value [[K]]
 // CHECK:       } // end sil function '$s24closureWithKeypathAndInt{{.*}}4main3StrVSiTf3npkn_n'
 sil [ossa] @closureWithKeypathAndInt : $@convention(thin) (Str, @guaranteed KeyPath<Str, Int>, Int) -> Int {
@@ -777,8 +778,9 @@ bb0(%0 : $*Int):
 
 // CHECK-LABEL: sil shared [ossa] @$s22closureWithKeypathAndT{{.*}}4main3StrVSiTf3npkn_n : $@convention(thin) (Str, @in_guaranteed Int) -> Int {
 // CHECK:         [[K:%[0-9]+]] = keypath
+// CHECK:         [[BB:%[0-9]+]] = begin_borrow [[K]]
 // CHECK:         [[F:%[0-9]+]] = function_ref @swift_getAtKeyPath
-// CHECK:         apply [[F]]<Str, Int>({{%[0-9]+, %[0-9]+}}, [[K]]
+// CHECK:         apply [[F]]<Str, Int>({{%[0-9]+, %[0-9]+}}, [[BB]]
 // CHECK:         destroy_value [[K]]
 // CHECK:       } // end sil function '$s22closureWithKeypathAndT{{.*}}4main3StrVSiTf3npkn_n'
 sil [ossa] @closureWithKeypathAndT : $@convention(thin) <T> (Str, @guaranteed KeyPath<Str, Int>, @in_guaranteed T) -> Int {
@@ -793,6 +795,48 @@ bb0(%0 : $Str, %1 : @guaranteed $KeyPath<Str, Int>, %2 : $*T):
   dealloc_stack %4 : $*Str
   return %9 : $Int
 }
+
+sil [ossa] @testUpcastInClosure : $@convention(thin) () -> () {
+bb0:
+  %0 = keypath $WritableKeyPath<Str, Int>, (root $Str; stored_property #Str.a : $Int)
+  %1 = function_ref @closureWithWritableKeypath : $@convention(thin) (Str, @guaranteed WritableKeyPath<Str, Int>) -> Int
+  %2 = partial_apply [callee_guaranteed] %1(%0) : $@convention(thin) (Str, @guaranteed WritableKeyPath<Str, Int>) -> Int
+  %4 = function_ref @callee2WithKeypath : $@convention(thin) (@callee_guaranteed (Str) -> Int) -> ()
+  %5 = apply %4(%2) : $@convention(thin) (@callee_guaranteed (Str) -> Int) -> ()
+  destroy_value %2
+  %7 = tuple ()
+  return %7 : $()
+}
+
+// CHECK-LABEL: sil shared [ossa] @$s26closureWithWritableKeypath{{.*}}4main3StrVSiTf3npk_n : $@convention(thin) (Str) -> Int {
+// CHECK:         [[K:%[0-9]+]] = keypath
+// CHECK:         [[BB:%[0-9]+]] = begin_borrow [[K]]
+// CHECK:         [[UC:%[0-9]+]] = upcast [[BB]]
+// CHECK:         [[F:%[0-9]+]] = function_ref @swift_getAtKeyPath
+// CHECK:         apply [[F]]<Str, Int>({{%[0-9]+, %[0-9]+}}, [[UC]]
+// CHECK:         destroy_value [[K]]
+// CHECK:       } // end sil function '$s26closureWithWritableKeypath{{.*}}4main3StrVSiTf3npk_n'
+sil [ossa] @closureWithWritableKeypath : $@convention(thin) (Str, @guaranteed WritableKeyPath<Str, Int>) -> Int {
+bb0(%0 : $Str, %1 : @guaranteed $WritableKeyPath<Str, Int>):
+  %2 = upcast %1 to $KeyPath<Str, Int>
+  %4 = alloc_stack $Str
+  store %0 to [trivial] %4 : $*Str
+  %6 = function_ref @swift_getAtKeyPath : $@convention(thin) <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0, @guaranteed KeyPath<τ_0_0, τ_0_1>) -> @out τ_0_1
+  %7 = alloc_stack $Int
+  %8 = apply %6<Str, Int>(%7, %4, %2) : $@convention(thin) <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0, @guaranteed KeyPath<τ_0_0, τ_0_1>) -> @out τ_0_1
+  cond_br undef, bb1, bb2
+
+bb1:
+  unreachable
+
+bb2:
+  %9 = load [trivial] %7 : $*Int
+  dealloc_stack %7 : $*Int
+  dealloc_stack %4 : $*Str
+  return %9 : $Int
+}
+
+sil @callee2WithKeypath : $@convention(thin) (@callee_guaranteed (Str) -> Int) -> ()
 
 sil @useIntClosure : $@convention(thin) (@noescape @callee_guaranteed (Str) -> Builtin.Int32) -> ()
 

--- a/test/SILOptimizer/cse_ossa.sil
+++ b/test/SILOptimizer/cse_ossa.sil
@@ -1488,3 +1488,22 @@ bb6:
   %35 = tuple ()
   return %35
 }
+
+// Just make sure that CSE doesn't crash
+sil [ossa] @pointer_phi : $@convention(thin) (@in_guaranteed C) -> () {
+bb0(%0 : $*C):
+  %1 = load_borrow %0
+  %2 = ref_tail_addr %1, $Int
+  %3 = address_to_pointer %2 to $Builtin.RawPointer
+  end_borrow %1
+  br bb1(%3)
+
+bb1(%6 : $Builtin.RawPointer):
+  %7 = pointer_to_address %6 to [strict] $*Int
+  fix_lifetime %7
+  %9 = pointer_to_address %6 to [strict] $*Int
+  fix_lifetime %9
+  %11 = tuple ()
+  return %11
+}
+


### PR DESCRIPTION
This PR contains fixes for problems which showed up when extending the OSSA pipeline: https://github.com/swiftlang/swift/pull/87315

* Remove a wrong assert in MemAccessUtils
* ConstantCapturePropagation: insert borrow scopes for specialized guaranteed arguments
* Make the OwnershipModelEliminator a module pass

For details see the commit messages