### PR TITLE
Create tailored diagnostic for default argument from different isolation domain

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5814,6 +5814,21 @@ NOTE(property_requires_actor,none,
 ERROR(isolated_default_argument_context,none,
       "%0 default value in a %1 context", 
       (ActorIsolation, ActorIsolation))
+ERROR(different_actor_isolated_default_argument_context,none,
+      "default value for %kind0 must be %1-isolated",
+      (const ValueDecl *, Identifier))
+NOTE(note_expected_same_actor_default_argument,none,
+      "expected default value to have same isolation as %kind0 (got %1 and %2)",
+      (const ValueDecl *, Identifier, Identifier))
+ERROR(same_actor_isolated_default_argument_context,none,
+      "cannot use default value from different instance of %0",
+      (Identifier))
+NOTE(same_actor_isolated_default_argument_context_note,none,
+      "default value must be isolated to %0",
+      (Identifier))
+NOTE(same_actor_isolated_default_argument_context_specified_here,none,
+      "%0 specified here",
+      (Identifier))
 ERROR(conflicting_default_argument_isolation,none,
       "default argument cannot be both %0 and %1",
       (ActorIsolation, ActorIsolation))

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6819,9 +6819,61 @@ DefaultInitializerIsolation::evaluate(Evaluator &evaluator,
     if (enclosingIsolation != requiredIsolation) {
       bool preconcurrency =
           !isa<ParamDecl>(var) || requiredIsolation.preconcurrency();
-      var->diagnose(diag::isolated_default_argument_context, requiredIsolation,
-                    enclosingIsolation)
+      // If both are actor isolation, it's unhelpful to print 'actor-isolated'
+      // twice. Check if that's the case and we have the actor instances needed
+      // to say something more specific.
+      if (!(requiredIsolation.getKind() == ActorIsolation::ActorInstance &&
+            enclosingIsolation.getKind() == ActorIsolation::ActorInstance &&
+            requiredIsolation.getActor() && enclosingIsolation.getActor())) {
+        var->diagnose(diag::isolated_default_argument_context,
+                      requiredIsolation, enclosingIsolation)
+            .warnUntilLanguageModeIf(preconcurrency, LanguageMode::v6);
+        return ActorIsolation::forUnspecified();
+      }
+
+      // Tailor a precise diagnostic to surface the mismatch in the actors, or
+      // that each instance of an actor type is isolated, and that these are
+      // potentially different instances. This won't occur for global actors,
+      // since they share an isolation domain.
+
+      auto requiredActor = requiredIsolation.getActor();
+      auto enclosingActor = enclosingIsolation.getActor();
+
+      if (requiredActor != enclosingActor) {
+        var->diagnose(diag::different_actor_isolated_default_argument_context,
+                      var, enclosingActor->getName())
+            .warnUntilLanguageModeIf(preconcurrency, LanguageMode::v6);
+        var->diagnose(diag::note_expected_same_actor_default_argument, var,
+                      requiredActor->getName(), enclosingActor->getName());
+        return ActorIsolation::forUnspecified();
+      }
+
+      var->diagnose(diag::same_actor_isolated_default_argument_context,
+                    requiredActor->getName())
           .warnUntilLanguageModeIf(preconcurrency, LanguageMode::v6);
+
+      auto enclosingActorInstance = enclosingIsolation.getActorInstance();
+      if (!enclosingActorInstance)
+        return ActorIsolation::forUnspecified();
+
+      // Note the name of the actor instance the default should be isolated
+      // to. Usually this is 'self'.
+      ASTContext &ctx = var->getASTContext();
+      ctx.Diags
+          .diagnose(initExpr->getLoc(),
+                    diag::same_actor_isolated_default_argument_context_note,
+                    enclosingActorInstance->getName())
+          .highlight(initExpr->getSourceRange());
+
+      if (enclosingActorInstance->isActorSelf())
+        return ActorIsolation::forUnspecified();
+
+      // If it's not actor self, like an isolated param, note where it is
+      // specified.
+      ctx.Diags.diagnose(
+          enclosingActorInstance->getLoc(),
+          diag::same_actor_isolated_default_argument_context_specified_here,
+          enclosingActorInstance->getName());
       return ActorIsolation::forUnspecified();
     }
   }

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -1836,3 +1836,40 @@ func testPartialApplyWithIsolatedParameters() {
     fn(42, a) //expected-error {{call to actor-isolated let 'fn' in a synchronous nonisolated context}}
   }
 }
+
+actor SharedDefaultTest {
+  static let shared = SharedDefaultTest()
+
+  var value = 42
+
+  func test(_: Int = SharedDefaultTest.shared.value) {} // expected-error {{cannot use default value from different instance of 'SharedDefaultTest'}}
+  // expected-note@-1 {{default value must be isolated to 'self'}}
+}
+
+actor AnotherActorsDefaultTest {
+  var anotherValue = SharedDefaultTest.shared.value // expected-warning {{default value for property 'anotherValue' must be 'AnotherActorsDefaultTest'-isolated; this is an error in the Swift 6 language mode}}
+  // expected-note@-1:7 {{expected default value to have same isolation as property 'anotherValue' (got 'SharedDefaultTest' and 'AnotherActorsDefaultTest')}}
+
+  func test(_: Int = SharedDefaultTest.shared.value) {} // expected-error {{default value for parameter must be 'AnotherActorsDefaultTest'-isolated}}
+  // expected-note@-1:13 {{expected default value to have same isolation as parameter (got 'SharedDefaultTest' and 'AnotherActorsDefaultTest')}}
+}
+
+class IsolatedParamTest {
+  func test(_: Int = SharedDefaultTest.shared.value, owner: isolated SharedDefaultTest) {}
+  // expected-error@-1:13 {{cannot use default value from different instance of 'SharedDefaultTest'}}
+  // expected-note@-2:47 {{default value must be isolated to 'owner'}}
+  // expected-note@-3:54 {{'owner' specified here}}
+}
+
+class DifferentActorIsolatedParamTest {
+  func test(_: Int = SharedDefaultTest.shared.value, owner: isolated AnotherActorsDefaultTest) {}
+  // expected-error@-1:13 {{default value for parameter must be 'AnotherActorsDefaultTest'-isolated}}
+  // expected-note@-2:13 {{expected default value to have same isolation as parameter (got 'SharedDefaultTest' and 'AnotherActorsDefaultTest')}}
+}
+
+class GlobalDefaultIsolationTest {
+  @SomeGlobalActor
+  func test(_: Int = SharedDefaultTest.shared.value) {}
+  // expected-error@-1 {{actor-isolated default value in a global actor 'SomeGlobalActor'-isolated context}}
+}
+


### PR DESCRIPTION
Fixes #79077, rdar://143965795, #84519, rdar://161333188

Adds a tailored diagnostic for when the default value and the context it's being used in are both actor-isolated, to name the specific actors or explain that state cannot be accessed between instances of an actor, since each instance is its own isolation domain.

For code like this, in language mode 6:
```swift
actor OtherActor {
    static let shared = OtherActor()
    var name: String = "other actor"
}

actor MyActor {
    static let shared = MyActor()

    var name = "my actor"
    var other = OtherActor.shared.name

    func test(_: String = MyActor.shared.name) {}

    func test2(_: String = OtherActor.shared.name) {}
}

class IsolatedParamTests {
    func test(_: String = MyActor.shared.name, a: isolated MyActor) {}

    func test2(_: String = OtherActor.shared.name, a: isolated MyActor) {}
}
```

We can now produce more coherent errors:

```
debug-files/iso_mismatch.swift:10:9: error: default value for property 'other' must be 'MyActor'-isolated
 8 |
 9 |     var name = "my actor"
10 |     var other = OtherActor.shared.name
   |         |- error: default value for property 'other' must be 'MyActor'-isolated
   |         `- note: expected default value to have same isolation as property 'other' (got 'OtherActor' and 'MyActor')
11 |
12 |     func test(_: String = MyActor.shared.name) {}

debug-files/iso_mismatch.swift:12:15: error: cannot use default value from different instance of 'MyActor'
10 |     var other = OtherActor.shared.name
11 |
12 |     func test(_: String = MyActor.shared.name) {}
   |               |                          `- note: default value must be isolated to 'self'
   |               `- error: cannot use default value from different instance of 'MyActor'
13 |
14 |     func test2(_: String = OtherActor.shared.name) {}

debug-files/iso_mismatch.swift:14:16: error: default value for parameter must be 'MyActor'-isolated
12 |     func test(_: String = MyActor.shared.name) {}
13 |
14 |     func test2(_: String = OtherActor.shared.name) {}
   |                |- error: default value for parameter must be 'MyActor'-isolated
   |                `- note: expected default value to have same isolation as parameter (got 'OtherActor' and 'MyActor')
15 | }
16 |

debug-files/iso_mismatch.swift:18:15: error: cannot use default value from different instance of 'MyActor'
16 |
17 | class IsolatedParamTests {
18 |     func test(_: String = MyActor.shared.name, a: isolated MyActor) {}
   |               |                          |     `- note: 'a' specified here
   |               |                          `- note: default value must be isolated to 'a'
   |               `- error: cannot use default value from different instance of 'MyActor'
19 |
20 |     func test2(_: String = OtherActor.shared.name, a: isolated MyActor) {}

debug-files/iso_mismatch.swift:20:16: error: default value for parameter must be 'MyActor'-isolated
18 |     func test(_: String = MyActor.shared.name, a: isolated MyActor) {}
19 |
20 |     func test2(_: String = OtherActor.shared.name, a: isolated MyActor) {}
   |                |- error: default value for parameter must be 'MyActor'-isolated
   |                `- note: expected default value to have same isolation as parameter (got 'OtherActor' and 'MyActor')
21 | }
22 |
```