### PR TITLE
[Driver][Windows] Ignore LNK4217 with -static-stdlib

### DIFF
--- a/lib/Driver/WindowsToolChains.cpp
+++ b/lib/Driver/WindowsToolChains.cpp
@@ -133,6 +133,15 @@ toolchains::Windows::constructInvocation(const DynamicLinkJobAction &job,
       context.Args.hasFlag(options::OPT_static_stdlib,
                            options::OPT_no_static_stdlib, false);
 
+  if (wantsStaticStdlib) {
+    // Windows dispatch headers declare exported APIs as dllimport. When
+    // statically linking the stdlib, those symbols may be satisfied by
+    // dispatch.lib and trigger LNK4217 ("locally defined symbol imported").
+    // Suppress that warning so -Xlinker /WX can be used successfully.
+    Arguments.push_back("-Xlinker");
+    Arguments.push_back("/IGNORE:4217");
+  }
+
   SmallVector<std::string, 4> RuntimeLibPaths;
   getRuntimeLibraryPaths(RuntimeLibPaths, context.Args, context.OI.SDKPath,
                          /*Shared=*/!wantsStaticStdlib);

--- a/test/Driver/windows-static-stdlib-linker.swift
+++ b/test/Driver/windows-static-stdlib-linker.swift
@@ -1,0 +1,4 @@
+// RUN: %swiftc_driver -sdk "" -driver-print-jobs -target x86_64-unknown-windows-msvc -static-stdlib %s 2>&1 | %FileCheck %s
+
+// CHECK: clang{{(\.exe)?"? }}
+// CHECK-DAG: -Xlinker /IGNORE:4217


### PR DESCRIPTION
## Summary
When targeting Windows with `-static-stdlib`, the driver now adds `/IGNORE:4217` to the linker invocation.

`dispatch` headers on Windows declare exports as `dllimport`. In static-stdlib links, those symbols can be resolved from `dispatch.lib`, which triggers LNK4217 ("locally defined symbol imported"). If callers also pass `/WX`, that warning becomes a hard error and the link fails.

This updates the Windows link job construction to suppress LNK4217 only when `-static-stdlib` is enabled.

## Before / After
**Before**
- Windows static-stdlib link jobs did not pass `/IGNORE:4217`.
- Builds like `swift build ... -Xswiftc -static-stdlib -Xlinker /WX` could fail with LNK4217 from `_Concurrency` objects importing `dispatch` symbols.

**After**
- Windows static-stdlib link jobs include `-Xlinker /IGNORE:4217`.
- `/WX` no longer escalates this specific import warning to an error in that mode.

## Tests
- Added `test/Driver/windows-static-stdlib-linker.swift` to check that `-static-stdlib` for `x86_64-unknown-windows-msvc` emits `-Xlinker /IGNORE:4217`.

## Local Validation
- Verified the current (pre-patch) installed toolchain `-###` link invocation does not include `/IGNORE:4217`.
- Full end-to-end repro with a locally built head toolchain was not possible in this environment (Windows static stdlib setup here fails earlier with `unable to load standard library for target`).
- Driver-level change is covered by the added driver test.

## Issue
Fixes #87516.
