### PR TITLE
[cxx-interop] Fix miscompilation of Optional structs with FRTs

### DIFF
--- a/lib/IRGen/ClassTypeInfo.h
+++ b/lib/IRGen/ClassTypeInfo.h
@@ -82,6 +82,12 @@ public:
     HeapTypeInfo::emitScalarRelease(IGF, value, atomicity);
   }
 
+  bool canValueWitnessExtraInhabitantsUpTo(IRGenModule &IGM,
+                                           unsigned index) const override {
+    // Custom refcounting functions might not support null pointers.
+    return index == 0 && getReferenceCounting() != ReferenceCounting::Custom;
+  }
+
   void emitScalarRetain(IRGenFunction &IGF, llvm::Value *value,
                         Atomicity atomicity) const override {
     if (getReferenceCounting() == ReferenceCounting::Custom) {

--- a/test/Interop/Cxx/foreign-reference/incomplete.swift
+++ b/test/Interop/Cxx/foreign-reference/incomplete.swift
@@ -41,9 +41,15 @@ func testOpaqueRef() {
 
 struct HasOpaqueRef { var mine: OpaqueRef }
 
+struct HasOpaqueRef2 { var mine: OpaqueRef 
+                       var cheese: Int }
+
 func testOpaqueRefInStruct() {
   var cat : HasOpaqueRef? = nil
   cat = HasOpaqueRef(mine: Opaque_create())
+  var dog : HasOpaqueRef2? = nil
+  dog = HasOpaqueRef2(mine: Opaque_create(), cheese: 23)
+  // CHECK: Destroyed OpaqueRef instance
   // CHECK: Destroyed OpaqueRef instance
   // CHECK-NOT: Destroyed OpaqueRef instance
 }


### PR DESCRIPTION
When an optional is initialized, Swift generates a zero-initialized stack allocation for the optional and uses assignment operation to store the payload into this memory. The assignment will destroy the previously owned payload. In this case the previously owned payload is the zero initialized struct, IRGen was not aware that we should not call release on this zero initialized memory unconditionally. This PR makes sure we emit a null check when we emit a consume for an optional.

rdar://171258910
