### PR TITLE
[cxx-interop] Check copyability of associated types

### DIFF
--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -921,6 +921,11 @@ conformToCxxSequenceIfNeeded(ClangImporter::Implementation &impl,
   conformToCxxBorrowingSequenceIfNedded(impl, decl, clangDecl,
                                         rawIteratorConformance);
 
+  // `CxxSequence` and `CxxRandomAccessCollection` protocols require `Element`
+  // to be Copyable and Escapable
+  if (!pointeeTy->isCopyable() || !pointeeTy->isEscapable())
+    return;
+
   // CxxSequence conformance.
   // Take the default definition of `Iterator` from CxxSequence protocol. This
   // type is currently `CxxIterator<Self>`.

--- a/stdlib/public/Cxx/CxxSpan.swift
+++ b/stdlib/public/Cxx/CxxSpan.swift
@@ -62,7 +62,7 @@ public func _cxxOverrideLifetime<
 ///
 /// C++ standard library type `std::span` conforms to this protocol.
 public protocol CxxSpan<Element> {
-  associatedtype Element
+  associatedtype Element: ~Copyable
   associatedtype Size: BinaryInteger
 
   init()
@@ -72,7 +72,7 @@ public protocol CxxSpan<Element> {
   func __dataUnsafe() -> UnsafePointer<Element>?
 }
 
-extension CxxSpan {
+extension CxxSpan where Element: ~Copyable {
   /// Creates a C++ span from a Swift UnsafeBufferPointer
   @_alwaysEmitIntoClient
   public init(_ unsafeBufferPointer: UnsafeBufferPointer<Element>) {
@@ -100,7 +100,7 @@ extension CxxSpan {
 }
 
 @available(SwiftCompatibilitySpan 5.0, *)
-extension Span {
+extension Span where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @unsafe
   @_unsafeNonescapableResult
@@ -116,7 +116,7 @@ extension Span {
 }
 
 @available(SwiftCompatibilitySpan 5.0, *)
-extension MutableSpan {
+extension MutableSpan where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @unsafe
   @_unsafeNonescapableResult
@@ -132,7 +132,7 @@ extension MutableSpan {
 }
 
 public protocol CxxMutableSpan<Element> {
-  associatedtype Element
+  associatedtype Element: ~Copyable
   associatedtype Size: BinaryInteger
 
   init()
@@ -142,7 +142,7 @@ public protocol CxxMutableSpan<Element> {
   func __dataUnsafe() -> UnsafeMutablePointer<Element>?
 }
 
-extension CxxMutableSpan {
+extension CxxMutableSpan where Element: ~Copyable {
   /// Creates a C++ span from a Swift UnsafeMutableBufferPointer
   @_alwaysEmitIntoClient
   public init(_ unsafeMutableBufferPointer: UnsafeMutableBufferPointer<Element>) {

--- a/test/Interop/Cxx/stdlib/Inputs/std-span.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-span.h
@@ -201,4 +201,19 @@ struct IMMORTAL_FRT DependsOnSelfFRT {
   }
 };
 
+struct NonCopyable {
+  NonCopyable(int n) : number(n) {}
+  NonCopyable(const NonCopyable &other) = delete;
+  NonCopyable(NonCopyable &&other) = default;
+  ~NonCopyable() {}
+  int number;
+};
+
+using SpanOfNonCopyable = std::span<NonCopyable>;
+
+inline SpanOfNonCopyable makeSpanOfNonCopyable() {
+  static NonCopyable arr[]{1, 2, 3};
+  return SpanOfNonCopyable(arr);
+}
+
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_SPAN_H

--- a/test/Interop/Cxx/stdlib/use-std-span-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-span-typechecker.swift
@@ -3,6 +3,11 @@
 
 import StdSpan
 
+func takesSequence<T: Sequence>(_ _: T) {}
+// expected-note@-1 {{where 'T' = 'SpanOfNonCopyable'}}
+
+func takesSpan<S: CxxMutableSpan>(_ _: S) {}
+
 let arr: [Int32] = [1, 2, 3]
 arr.withUnsafeBufferPointer { ubpointer in
     let _ = ConstSpanOfInt(ubpointer) // okay
@@ -15,3 +20,15 @@ arr.withUnsafeBufferPointer { ubpointer in
     let _ = ConstSpanOfInt(ubpointer.baseAddress, ubpointer.count)
     // expected-warning@-1 {{'init(_:_:)' is deprecated: use 'init(_:)' instead.}}
 }
+
+let s1 = initSpan()
+for _ in s1 {}
+takesSequence(s1)
+takesSpan(s1)
+
+let s2 = makeSpanOfNonCopyable()
+for _ in s2 {}
+// expected-error@-1 {{for-in loop requires 'SpanOfNonCopyable'}} to conform to 'Sequence'
+takesSequence(s2)
+// expected-error@-1 {{global function 'takesSequence' requires that 'SpanOfNonCopyable'}} conform to 'Sequence'
+takesSpan(s2)


### PR DESCRIPTION
Owning C++ types are copyable only if their underlying type is also copyable, i.e., a `std::vector<MoveOnlyType>` is move-only, for example. However, this is not true for `std::span` - even when the underlying type of a `std::span` is move-only, the `std::span` itself will still be copyable.

Previously, when synthesising a conformance to a C++ standard library overlay protocol, we used to check if the protocol had the necessary inverse requirements, but didn't do the same check for associated types. This patch addresses this in two ways:

1. When adding the synthesised conformance to `CxxSequence` (which includes `CxxRandomAccessCollection` and friends), we first check if the underlying type is non copyable and, if so, skip all of these conformances
2. Adapt `CxxSpan` to accept a non copyable `Element`

For all other Cxx overlay protocols, if the type that conforms to it is copyable, then so is its primary associated type.