### PR TITLE
Concurrency: Compile out more `@backDeployed` attributes in Embedded

### DIFF
--- a/stdlib/public/Concurrency/AsyncStream.swift
+++ b/stdlib/public/Concurrency/AsyncStream.swift
@@ -466,7 +466,9 @@ extension AsyncStream {
   /// - Returns: A tuple containing the stream and its continuation. The continuation should be passed to the
   /// producer while the stream should be passed to the consumer.
   @available(SwiftStdlib 5.1, *)
+  #if !hasFeature(Embedded)
   @backDeployed(before: SwiftStdlib 5.9)
+  #endif
   public static func makeStream(
       of elementType: Element.Type = Element.self,
       bufferingPolicy limit: Continuation.BufferingPolicy = .unbounded

--- a/stdlib/public/Concurrency/AsyncThrowingStream.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingStream.swift
@@ -508,7 +508,9 @@ extension AsyncThrowingStream {
   /// - Returns: A tuple containing the stream and its continuation. The continuation should be passed to the
   /// producer while the stream should be passed to the consumer.
   @available(SwiftStdlib 5.1, *)
+  #if !hasFeature(Embedded)
   @backDeployed(before: SwiftStdlib 5.9)
+  #endif
   public static func makeStream(
       of elementType: Element.Type = Element.self,
       throwing failureType: Failure.Type = Failure.self,

--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -203,7 +203,9 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   @inlinable
   @discardableResult
   @available(SwiftStdlib 5.1, *)
+  #if !hasFeature(Embedded)
   @backDeployed(before: SwiftStdlib 6.0)
+  #endif
   public func withValue<R>(_ valueDuringOperation: Value,
                            operation: () async throws -> R,
                            isolation: isolated (any Actor)? = #isolation,
@@ -254,7 +256,9 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   @inlinable
   @discardableResult
   @available(SwiftStdlib 5.1, *)
+  #if !hasFeature(Embedded)
   @backDeployed(before: SwiftStdlib 6.0)
+  #endif
   internal func withValueImpl<R>(_ valueDuringOperation: __owned Value,
                                  operation: () async throws -> R,
                                  isolation: isolated (any Actor)?,


### PR DESCRIPTION
Most `@backDeployed` attributes in the Concurrency module were already compiled out when building for embedded, but a few were not.
