### PR TITLE
Add BorrowingSequence experimental feature flag

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8425,6 +8425,10 @@ ERROR(noncopyable_cannot_have_read_set_accessor,none,
       "noncopyable %select{variable|subscript}0 cannot provide a read and set accessor",
       (unsigned))
 
+ERROR(borrowingsequence_experimental,none,
+      "'%0' requires -enable-experimental-feature BorrowingSequence",
+      (StringRef))
+
 //------------------------------------------------------------------------------
 // MARK: Init accessors
 //------------------------------------------------------------------------------

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -623,6 +623,9 @@ EXPERIMENTAL_FEATURE(UnderscoreOwned, true)
 /// Allows the standard library `Borrow` and `Inout` types to be used.
 EXPERIMENTAL_FEATURE(BorrowInout, true)
 
+/// Allow access to the BorrowingSequence protocols/types outside the stdlib.
+EXPERIMENTAL_FEATURE(BorrowingSequence, false)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -601,6 +601,7 @@ static bool usesFeatureReparenting(Decl *decl) {
 UNINTERESTING_FEATURE(AnyAppleOSAvailability)
 UNINTERESTING_FEATURE(StrictAccessControl)
 UNINTERESTING_FEATURE(BorrowInout)
+UNINTERESTING_FEATURE(BorrowingSequence)
 
 // ----------------------------------------------------------------------------
 // MARK: - FeatureSet


### PR DESCRIPTION
This gates the ability to use the BorrowingSequence protocol's name (and the names of the related types) behind a feature flag.

Landing this separately from #87483.