### PR TITLE
[cxx-interop] Extend the lifetime of unwrapped spans

### DIFF
--- a/stdlib/public/Cxx/CxxSpan.swift
+++ b/stdlib/public/Cxx/CxxSpan.swift
@@ -92,10 +92,13 @@ extension CxxSpan {
   @_alwaysEmitIntoClient
   @unsafe
   public init(_ span: Span<Element>) {
-    let (p, c) = unsafe unsafeBitCast(span, to: (UnsafeRawPointer?, Int).self)
-    unsafe precondition(p != nil, "Span should not point to nil")
-    let binding = unsafe p!.bindMemory(to: Element.self, capacity: c)
-    unsafe self.init(binding, Size(c))
+    let p = unsafe span.withUnsafeBufferPointer {
+        unsafe $0
+    }
+    defer {
+      _fixLifetime(span)
+    }
+    unsafe self.init(p)
   }
 }
 
@@ -155,9 +158,12 @@ extension CxxMutableSpan {
   @_alwaysEmitIntoClient
   @unsafe
   public init(_ span: consuming MutableSpan<Element>) {
-    let (p, c) = unsafe unsafeBitCast(span, to: (UnsafeMutableRawPointer?, Int).self)
-    unsafe precondition(p != nil, "Span should not point to nil")
-    let binding = unsafe p!.bindMemory(to: Element.self, capacity: c)
-    unsafe self.init(binding, Size(c))
+    let p = unsafe span.withUnsafeMutableBufferPointer {
+        unsafe $0
+    }
+    defer {
+      _fixLifetime(span)
+    }
+    unsafe self.init(p)
   }
 }


### PR DESCRIPTION
While currently we should not run into any lifetime issues with the existing code the new version should make sure that the object on which the spans depend will be kept alive for longer in case the function is inlined.
