### PR TITLE
[CS] Avoid binding unwrapped type for SingleValueStmtExpr

### DIFF
--- a/lib/Sema/BindingProducer.cpp
+++ b/lib/Sema/BindingProducer.cpp
@@ -336,8 +336,14 @@ bool TypeVarBindingProducer::computeNext() {
         // expression is non-optional), if we allow  both the solver would
         // find two solutions that differ only in location of optional
         // injection.
-        if (!TypeVar->getImpl().isClosureResultType() || objTy->isVoid() ||
-            objTy->isTypeVariableOrMember()) {
+        //
+        // The same applies to the result of a SingleValueStmtExpr, we want to
+        // attempt conversions as part of the join between results rather than
+        // between the expression and its context.
+        auto *loc = TypeVar->getImpl().getLocator();
+        if (!(TypeVar->getImpl().isClosureResultType() && !objTy->isVoid() &&
+              !objTy->isTypeVariableOrMember()) &&
+            !loc->directlyAt<SingleValueStmtExpr>()) {
           // If T is a type variable, only attempt this if both the
           // type variable we are trying bindings for, and the type
           // variable we will attempt to bind, both have the same

--- a/test/Constraints/issue-79474.swift
+++ b/test/Constraints/issue-79474.swift
@@ -1,0 +1,36 @@
+// RUN: %target-typecheck-verify-swift
+
+// https://github.com/swiftlang/swift/issues/79474
+
+enum SwitchResult {
+  case ints([Int])
+  case strings([String])
+}
+
+func diagnoseLaterBranchMemberError(_ value: SwitchResult) -> [Int]? {
+  switch value {
+  case .strings:
+    nil
+
+  case .ints(let values):
+    if values.count > 1 {
+      values.missingMember // expected-error {{value of type '[Int]' has no member 'missingMember'}}
+    } else {
+      nil
+    }
+  }
+}
+
+let _: Int? = if true {
+  nil
+} else {
+  [0].missingMember // expected-error {{value of type '[Int]' has no member 'missingMember'}}
+}
+
+func typeMismatch() -> String? {
+  return if .random() {
+    nil
+  } else {
+    1.0 // expected-error {{cannot convert value of type 'Double' to specified type 'String'}}
+  }
+}

--- a/test/Constraints/issue-87552.swift
+++ b/test/Constraints/issue-87552.swift
@@ -1,0 +1,17 @@
+// RUN: %target-typecheck-verify-swift
+
+// https://github.com/swiftlang/swift/issues/87552
+
+struct S {
+  init(_ xs: some Sequence<Int>) {}
+}
+func foo<T>(_ fn: T?) -> [T] { [] }
+
+// FIXME: This ought to work
+let _ = S(foo(.init())) // expected-error {{member 'init()' in 'Int?' produces result of type 'Int', but context expects 'Int?'}}
+let _ = S(foo({ .init() }()))
+
+let _ = S(foo(if .random() { .init() } else { .init() })) // expected-error {{'if' may only be used as expression}}
+
+let _ = S.init(foo(.init()))
+let _ = S.init(foo({ .init() }()))


### PR DESCRIPTION
Like closure results, we want the conversion to happen within the individual branches of the expression. This avoids unhelpful diagnostics around `nil` literals.

Resolves #79474
rdar://118813324