### PR TITLE
Fix lifetime type checking to infer immortal static accessors

### DIFF
--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -416,6 +416,13 @@ public:
     }
   }
 
+  void inferImmortalResult() {
+    auto targetDeps = getInferredTargetDeps(resultIndex);
+    if (!targetDeps)
+      return;
+    targetDeps->hasImmortalSpecifier = true;
+  }
+
   // Allocate LifetimeDependenceInfo in the ASTContext. Initialize it by
   // copying heap-allocated TargetDeps fields into ASTContext allocations
   // (e.g. convert SmallBitVector to IndexSubset).
@@ -1569,7 +1576,8 @@ protected:
   // Any accessors not handled here will be handled like a normal method.
   void inferAccessor(AccessorDecl *accessor) {
     if (!hasImplicitSelfParam()) {
-      // global accessors have no 'self'.
+      // Global accessors have no 'self'. Their result must be immortal.
+      depBuilder.inferImmortalResult();
       return;
     }
     bool nonEscapableSelf =

--- a/test/SILOptimizer/lifetime_dependence/verify_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence/verify_diagnostics.swift
@@ -509,3 +509,20 @@ struct SuperWrapper<T: BitwiseCopyable>: ~Escapable {
   }
 }
 
+// =============================================================================
+// Static accessors
+// =============================================================================
+
+@available(Span 0.1, *)
+struct TestStaticProperty {
+  static let staticArray = [0, 1]
+
+  static let staticSpan = staticArray.span
+}
+
+@available(Span 0.1, *)
+class TestStaticClassProperty {
+  static let staticArray = [0, 1]
+
+  static let staticSpan = staticArray.span
+}

--- a/test/Sema/lifetime_depend_infer.swift
+++ b/test/Sema/lifetime_depend_infer.swift
@@ -948,6 +948,14 @@ struct NoncopyableSelfAccessors: ~Copyable & ~Escapable {
   }
 }
 
+struct ImmortalAccessors {
+  static let staticNE = NE()
+}
+
+class ClassImmortalAccessor {
+  static let staticNE = NE()
+}
+
 // ==================================================================================
 // Common mistakes with inout parameter annotations requiring custom diagnostics...
 // ==================================================================================

--- a/test/Sema/lifetime_depend_infer_defaults.swift
+++ b/test/Sema/lifetime_depend_infer_defaults.swift
@@ -565,3 +565,15 @@ struct NoncopyableSelfAccessors: ~Copyable & ~Escapable {
   }
 
 }
+
+// DEFAULT: '@_lifetime(immortal)'
+// CHECK: @$s30lifetime_depend_infer_defaults17ImmortalAccessorsV8staticNEAA0H0VvgZ : $@convention(method) (@thin ImmortalAccessors.Type) -> @lifetime(immortal) @owned NE {
+struct ImmortalAccessors {
+  static let staticNE = NE()
+}
+
+// DEFAULT: '@_lifetime(immortal)'
+// CHECK: @$s30lifetime_depend_infer_defaults21ClassImmortalAccessorC8staticNEAA0I0VvgZ : $@convention(method) (@thick ClassImmortalAccessor.Type) -> @lifetime(immortal) @owned NE {
+class ClassImmortalAccessor {
+  static let staticNE = NE()
+}


### PR DESCRIPTION
A recent change to lifetime type checking affected the way lifetimes are
inferred for static methods resulting in diagnostic errors for accessors that
returned a non-Escapable type.

Add a special lifetime default for accessors, such as:

    /* DEFAULT: @_lifetime(immortal) */
    static let globalSpan = globalArray.span

Explicitly writing the lifetime annotation for accessors is much to
cumbersome (it forces a computed property with a getter). This also fixes a
regression in compiler behavior, even though the original behavior was
unintentional.

Fixes rdar://171283240 error: the 'get' accessor with a ~Escapable result needs
a parameter to depend on)
