### PR TITLE
Suggest 'isolated' for deinit when accessing a relevant actor

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5835,6 +5835,12 @@ GROUPED_ERROR(actor_isolated_call,ActorIsolatedCall,none,
 GROUPED_ERROR(actor_isolated_call_decl,ActorIsolatedCall,none,
       "call to %0 %kind1 in a synchronous %2 context",
       (ActorIsolation, const ValueDecl *, ActorIsolation))
+NOTE(mark_deinit_isolated_to_access,none,
+      "add 'isolated' to run isolated to %0, which may be later than 'nonisolated deinit'",
+      (Identifier))
+NOTE(marked_nonisolated_here,none,
+      "marked as 'nonisolated' here",
+      ())
 ERROR(actor_isolated_partial_apply,none,
         "actor-isolated %kind0 can not be partially applied",
         (const ValueDecl *))

--- a/test/Concurrency/deinit_isolation.swift
+++ b/test/Concurrency/deinit_isolation.swift
@@ -171,7 +171,7 @@ class ImplicitDeinit {
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s16deinit_isolation13DefaultDeinitCfD : $@convention(method) (@owned DefaultDeinit) -> () {
 @FirstActor
 class DefaultDeinit {
-    deinit {
+    deinit { // expected-note {{add 'isolated' to run isolated to 'FirstActor', which may be later than 'nonisolated deinit'}}
 #if !SILGEN
         isolatedFunc() // expected-error {{call to global actor 'FirstActor'-isolated global function 'isolatedFunc()' in a synchronous nonisolated context}}
 #endif
@@ -212,7 +212,7 @@ class BadPropagatedDeinit {
 @FirstActor
 class NonisolatedDeinit {
     // nonisolated deinit
-    nonisolated deinit {
+    nonisolated deinit { // expected-note {{marked as 'nonisolated' here}}
 #if !SILGEN
         isolatedFunc() // expected-error {{call to global actor 'FirstActor'-isolated global function 'isolatedFunc()' in a synchronous nonisolated context}}
 #endif
@@ -280,7 +280,7 @@ class ImplicitDeinitInheritNonisolated: BaseWithNonisolatedDeinit {
 @FirstActor
 class DefaultDeinitInheritNonisolated: BaseWithNonisolatedDeinit {
     // nonisolated deinit
-    deinit {
+    deinit { // expected-note {{add 'isolated' to run isolated to 'FirstActor', which may be later than 'nonisolated deinit'}}
 #if !SILGEN
         isolatedFunc() // expected-error {{call to global actor 'FirstActor'-isolated global function 'isolatedFunc()' in a synchronous nonisolated context}}
 #endif
@@ -321,7 +321,7 @@ class PropagatedDeinitInheritNonisolated: BaseWithNonisolatedDeinit {
 @FirstActor
 class NonisolatedDeinitInheritNonisolated: BaseWithNonisolatedDeinit {
     // nonisolated deinit
-    nonisolated deinit {
+    nonisolated deinit { // expected-note {{marked as 'nonisolated' here}}
 #if !SILGEN
         isolatedFunc() // expected-error {{call to global actor 'FirstActor'-isolated global function 'isolatedFunc()' in a synchronous nonisolated context}}
 #endif
@@ -383,6 +383,7 @@ class ImplicitDeinitInheritIsolated1: BaseWithDeinitIsolatedOnFirstActor {
 @FirstActor
 class DefaultDeinitIsolated1: BaseWithDeinitIsolatedOnFirstActor {
     // nonisolated deinit
+    // expected-note@+1 {{add 'isolated' to run isolated to 'FirstActor', which may be later than 'nonisolated deinit'}}
     deinit { // expected-error {{nonisolated deinitializer 'deinit' has different actor isolation from global actor 'FirstActor'-isolated overridden declaration}}
         isolatedFunc() // expected-error {{call to global actor 'FirstActor'-isolated global function 'isolatedFunc()' in a synchronous nonisolated context}}
     }
@@ -433,6 +434,7 @@ class PropagatedDeinitIsolated1: BaseWithDeinitIsolatedOnFirstActor {
 @FirstActor
 class NonisolatedDeinitIsolated1: BaseWithDeinitIsolatedOnFirstActor {
     // nonisolated deinit
+    // expected-note@+1 {{marked as 'nonisolated' here}}
     nonisolated deinit { // expected-error {{nonisolated deinitializer 'deinit' has different actor isolation from global actor 'FirstActor'-isolated overridden declaration}}
         isolatedFunc() // expected-error {{call to global actor 'FirstActor'-isolated global function 'isolatedFunc()' in a synchronous nonisolated context}}
     }
@@ -512,6 +514,7 @@ class PropagatedDeinitIsolated2: BaseWithDeinitIsolatedOnSecondActor {
 @FirstActor
 class NonisolatedDeinitIsolated2: BaseWithDeinitIsolatedOnSecondActor {
     // nonisolated deinit
+    // expected-note@+1 {{marked as 'nonisolated' here}}
     nonisolated deinit { // expected-error {{nonisolated deinitializer 'deinit' has different actor isolation from global actor 'SecondActor'-isolated overridden declaration}}
         isolatedFunc() // expected-error {{call to global actor 'FirstActor'-isolated global function 'isolatedFunc()' in a synchronous nonisolated context}}
     }

--- a/test/Concurrency/deinit_isolation_import/test.swift
+++ b/test/Concurrency/deinit_isolation_import/test.swift
@@ -251,7 +251,7 @@ class ProbeImplicit_BaseIsolatedClass: BaseIsolatedClass {}
 // CHECK-SYMB-NEXT: // Isolation: nonisolated
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s4test30ProbeDefault_BaseIsolatedClassCfD : $@convention(method) (@owned ProbeDefault_BaseIsolatedClass) -> () {
 class ProbeDefault_BaseIsolatedClass: BaseIsolatedClass {
-    deinit {
+    deinit { // expected-note {{add 'isolated' to run isolated to 'MainActor', which may be later than 'nonisolated deinit'}}
 #if !SILGEN
         isolatedFunc() // expected-error {{call to main actor-isolated global function 'isolatedFunc()' in a synchronous nonisolated context}}
 #endif
@@ -311,7 +311,7 @@ class ProbeImplicit_DerivedIsolatedClass: DerivedIsolatedClass {}
 // CHECK-SYMB-NEXT: // Isolation: nonisolated
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s4test33ProbeDefault_DerivedIsolatedClassCfD : $@convention(method) (@owned ProbeDefault_DerivedIsolatedClass) -> () {
 class ProbeDefault_DerivedIsolatedClass: DerivedIsolatedClass {
-    deinit {
+    deinit { // expected-note {{add 'isolated' to run isolated to 'MainActor', which may be later than 'nonisolated deinit'}}
 #if !SILGEN
         isolatedFunc() // expected-error {{call to main actor-isolated global function 'isolatedFunc()' in a synchronous nonisolated context}}
 #endif

--- a/test/Concurrency/deinit_isolation_objc.swift
+++ b/test/Concurrency/deinit_isolation_objc.swift
@@ -174,7 +174,7 @@ func isolatedFunc() {}  // expected-note 15{{calls to global function 'isolatedF
 // CHECK-SYMB-NEXT: sil hidden [ossa] @$s21deinit_isolation_objc13DefaultDeinitCfD : $@convention(method) (@owned DefaultDeinit) -> () {
 @FirstActor
 @objc class DefaultDeinit: NSObject {
-    deinit {
+    deinit { // expected-note {{add 'isolated' to run isolated to 'FirstActor', which may be later than 'nonisolated deinit'}}
 #if !SILGEN
         isolatedFunc() // expected-error {{call to global actor 'FirstActor'-isolated global function 'isolatedFunc()' in a synchronous nonisolated context}}
 #endif
@@ -215,7 +215,7 @@ func isolatedFunc() {}  // expected-note 15{{calls to global function 'isolatedF
 @FirstActor
 @objc class NonisolatedDeinit : NSObject {
     // nonisolated deinit
-    nonisolated deinit {
+    nonisolated deinit { // expected-note {{marked as 'nonisolated' here}}
 #if !SILGEN
         isolatedFunc() // expected-error {{call to global actor 'FirstActor'-isolated global function 'isolatedFunc()' in a synchronous nonisolated context}}
 #endif
@@ -283,7 +283,7 @@ func isolatedFunc() {}  // expected-note 15{{calls to global function 'isolatedF
 @FirstActor
 @objc class DefaultDeinitInheritNonisolated: BaseWithNonisolatedDeinit {
     // nonisolated deinit
-    deinit {
+    deinit { // expected-note {{add 'isolated' to run isolated to 'FirstActor', which may be later than 'nonisolated deinit'}}
 #if !SILGEN
         isolatedFunc() // expected-error {{call to global actor 'FirstActor'-isolated global function 'isolatedFunc()' in a synchronous nonisolated context}}
 #endif
@@ -324,7 +324,7 @@ func isolatedFunc() {}  // expected-note 15{{calls to global function 'isolatedF
 @FirstActor
 @objc class NonisolatedDeinitInheritNonisolated: BaseWithNonisolatedDeinit {
     // nonisolated deinit
-    nonisolated deinit {
+    nonisolated deinit { // expected-note {{marked as 'nonisolated' here}}
 #if !SILGEN
         isolatedFunc() // expected-error {{call to global actor 'FirstActor'-isolated global function 'isolatedFunc()' in a synchronous nonisolated context}}
 #endif
@@ -386,6 +386,7 @@ func isolatedFunc() {}  // expected-note 15{{calls to global function 'isolatedF
 @FirstActor
 @objc class DefaultDeinitIsolated1: BaseWithDeinitIsolatedOnFirstActor {
     // nonisolated deinit
+    // expected-note@+1 {{add 'isolated' to run isolated to 'FirstActor', which may be later than 'nonisolated deinit'}}
     deinit { // expected-error {{nonisolated deinitializer 'deinit' has different actor isolation from global actor 'FirstActor'-isolated overridden declaration}}
         isolatedFunc() // expected-error {{call to global actor 'FirstActor'-isolated global function 'isolatedFunc()' in a synchronous nonisolated context}}
     }
@@ -434,6 +435,7 @@ func isolatedFunc() {}  // expected-note 15{{calls to global function 'isolatedF
 @FirstActor
 @objc class NonisolatedDeinitIsolated1: BaseWithDeinitIsolatedOnFirstActor {
     // nonisolated deinit
+    // expected-note@+1 {{marked as 'nonisolated' here}}
     nonisolated deinit { // expected-error {{nonisolated deinitializer 'deinit' has different actor isolation from global actor 'FirstActor'-isolated overridden declaration}}
         isolatedFunc() // expected-error {{call to global actor 'FirstActor'-isolated global function 'isolatedFunc()' in a synchronous nonisolated context}}
     }
@@ -513,6 +515,7 @@ func isolatedFunc() {}  // expected-note 15{{calls to global function 'isolatedF
 @FirstActor
 @objc class NonisolatedDeinitIsolated2: BaseWithDeinitIsolatedOnSecondActor {
     // nonisolated deinit
+    // expected-note@+1 {{marked as 'nonisolated' here}}
     nonisolated deinit { // expected-error {{nonisolated deinitializer 'deinit' has different actor isolation from global actor 'SecondActor'-isolated overridden declaration}}
         isolatedFunc() // expected-error {{call to global actor 'FirstActor'-isolated global function 'isolatedFunc()' in a synchronous nonisolated context}}
     }

--- a/test/Concurrency/flow_isolation.swift
+++ b/test/Concurrency/flow_isolation.swift
@@ -130,7 +130,7 @@ actor Demons {
     self.ns = x
   }
 
-  deinit {
+  deinit { // expected-note {{add 'isolated' to run isolated to 'Demons', which may be later than 'nonisolated deinit'}} {{3-3=isolated }}
     let _ = self.ns // expected-warning {{cannot access property 'ns' with a non-Sendable type 'NonSendableType' from nonisolated deinit; this is an error in the Swift 6 language mode}}
   }
 }
@@ -161,7 +161,7 @@ actor ExampleFromProposal {
   }
 
 
-  deinit {
+  deinit { // expected-note 2 {{add 'isolated' to run isolated to 'ExampleFromProposal', which may be later than 'nonisolated deinit'}} {{3-3=isolated }}
     _ = self.immutableSendable  // ok
     _ = self.mutableSendable    // ok
     _ = self.nonSendable // expected-warning {{cannot access property 'nonSendable' with a non-Sendable type 'NonSendableType' from nonisolated deinit; this is an error in the Swift 6 language mode}}
@@ -201,7 +201,7 @@ class CheckGAIT1 {
     silly += 2 // expected-warning {{cannot access property 'silly' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
-  deinit {
+  deinit { // expected-note {{add 'isolated' to run isolated to 'MainActor', which may be later than 'nonisolated deinit'}} {{3-3=isolated }}
     _ = ns // expected-warning {{cannot access property 'ns' with a non-Sendable type 'NonSendableType' from nonisolated deinit; this is an error in the Swift 6 language mode}}
     f() // expected-note {{after calling instance method 'f()', only nonisolated properties of 'self' can be accessed from a deinit}}
     _ = silly // expected-warning {{cannot access property 'silly' here in deinitializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
@@ -621,7 +621,7 @@ actor Ahmad {
     prop += 1 // expected-warning {{cannot access property 'prop' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
-  deinit {
+  deinit { // expected-note {{add 'isolated' to run isolated to 'Ahmad', which may be later than 'nonisolated deinit'}} {{3-3=isolated }}
     let x = computedProp // expected-warning {{actor-isolated property 'computedProp' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
     // expected-note @-1 {{after accessing property 'computedProp', only nonisolated properties of 'self' can be accessed from a deinit}}
 
@@ -667,9 +667,10 @@ actor NonIsolatedDeinitExceptionForSwift5 {
     x = 0
   }
 
-  deinit {
-    cleanup() // expected-warning {{actor-isolated instance method 'cleanup()' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    // expected-note @-1 {{after calling instance method 'cleanup()', only nonisolated properties of 'self' can be accessed from a deinit}}
+  deinit { // expected-note {{add 'isolated' to run isolated to 'NonIsolatedDeinitExceptionForSwift5', which may be later than 'nonisolated deinit'}} {{3-3=isolated }}
+    // expected-warning@+2 {{actor-isolated instance method 'cleanup()' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    // expected-note@+1 {{after calling instance method 'cleanup()', only nonisolated properties of 'self' can be accessed from a deinit}}
+    cleanup()
 
     x = 1 // expected-warning {{cannot access property 'x' here in deinitializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
@@ -729,7 +730,7 @@ actor OhBrother {
 @available(SwiftStdlib 5.1, *)
 class CheckDeinitFromClass: AwesomeUIView {
   var ns: NonSendableType?
-  deinit {
+  deinit { // expected-note 2 {{add 'isolated' to run isolated to 'MainActor', which may be later than 'nonisolated deinit'}} {{3-3=isolated }}
     ns?.f() // expected-warning {{cannot access property 'ns' with a non-Sendable type 'NonSendableType?' from nonisolated deinit; this is an error in the Swift 6 language mode}}
     ns = nil // expected-warning {{cannot access property 'ns' with a non-Sendable type 'NonSendableType?' from nonisolated deinit; this is an error in the Swift 6 language mode}}
   }
@@ -738,7 +739,7 @@ class CheckDeinitFromClass: AwesomeUIView {
 @available(SwiftStdlib 5.1, *)
 actor CheckDeinitFromActor {
   var ns: NonSendableType?
-  deinit {
+  deinit { // expected-note 2 {{add 'isolated' to run isolated to 'CheckDeinitFromActor', which may be later than 'nonisolated deinit'}} {{3-3=isolated }}
     ns?.f() // expected-warning {{cannot access property 'ns' with a non-Sendable type 'NonSendableType?' from nonisolated deinit; this is an error in the Swift 6 language mode}}
     ns = nil // expected-warning {{cannot access property 'ns' with a non-Sendable type 'NonSendableType?' from nonisolated deinit; this is an error in the Swift 6 language mode}}
   }

--- a/test/Concurrency/predates_concurrency_import_deinit.swift
+++ b/test/Concurrency/predates_concurrency_import_deinit.swift
@@ -15,7 +15,7 @@ actor ActorWithDeinit {
   var ns: NonStrictClass = NonStrictClass()
   var ss: StrictStruct = StrictStruct()
 
-  deinit {
+  deinit { // expected-note{{add 'isolated' to run isolated to 'ActorWithDeinit', which may be later than 'nonisolated deinit'}} {{3-3=isolated }}
     print(ns)
     print(ss) // expected-warning{{cannot access property 'ss' with a non-Sendable type 'StrictStruct' from nonisolated deinit}}
   }


### PR DESCRIPTION
Fixes rdar://154409893 by adding a function `maybeAddIsolatedDeinitFixIt` to emit a note about the isolation domain and a fix-it for inserting 'isolated'. Calls this function after emitting any relevent errors about accessing actor isolated state. Also scatters this new note throughout the concurrency tests, in all the places it's applicable. Adds two weird deinit edge cases to actor_isolation around key paths in deinit and mutating async methods in deinit, since I don't think this is covered anywhere today.

Using something from the actor `deinit` could be a part of:
```swift
class NonSendableType {
  var x: Int = 0
  func f() {}
}

@MainActor class AwesomeUIView {}

class CheckDeinitFromClass: AwesomeUIView {
  var ns: NonSendableType?
  deinit {
    ns?.f()
  }
}
```
now suggests a fix:
```
error: cannot access property 'ns' with a non-Sendable type 'NonSendableType?' from nonisolated deinit
 1 | class NonSendableType {
   |       `- note: class 'NonSendableType' does not conform to the 'Sendable' protocol
 2 |   var x: Int = 0
 3 |   func f() {}
   :
 8 | class CheckDeinitFromClass: AwesomeUIView {
 9 |   var ns: NonSendableType?
10 |   deinit {
   |   `- note: add 'isolated' to run isolated to 'MainActor', which may be later than 'nonisolated deinit'
11 |     ns?.f()
   |       `- error: cannot access property 'ns' with a non-Sendable type 'NonSendableType?' from nonisolated deinit
12 |   }
13 | }
```

You can see in the diff that this ends up being appropriate in a lot of existing tests, hopefully it can be merge conflict free long enough for tests to pass 😅 

I'm not completely sold on the phrasing of the diagnostic, but I spent a decent bit trying to come up with something concise that:
- mentions the actor that the `deinit` _could_ be run on if it was `isolated` (important when the deinit is on a class that gets its actor from some distant superclass)
- highlights the risk associated with this change (see [the isolated deinit proposal](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0371-isolated-synchronous-deinit.md#motivation) for an explanation of the risk around nondeterministically running the deinit, don't want someone to just accept when they are closing a file or something)
- isn't so alarmist that people are unwilling to accept the fix when it's fine (like `note: add 'isolated' to run nondeterministically on 'MainActor'` which reads to me as may never run)
- doesn't assume what the programmer understands about nonisolated deinits

This could benefit from an error group, but I think a wider scoped one may be more appropriate.