### PR TITLE
[Swiftify] add SWIFT_NO_SAFE_WRAPPER annotation

### DIFF
--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -1714,7 +1714,9 @@ void DiagnosticEngine::emitDiagnostic(const Diagnostic &diagnostic) {
       auto child =
           diagnosticInfoForDiagnostic(childNotes[i],
                                       /* includeDiagnosticName= */ true);
-      assert(child);
+      assert(child || state.getSuppressNotes());
+      if (!child)
+        continue;
       assert(child->Kind == DiagnosticKind::Note &&
              "Expected child diagnostics to all be notes?!");
       childInfo.push_back(*child);

--- a/lib/ClangImporter/SwiftBridging/swift/bridging
+++ b/lib/ClangImporter/SwiftBridging/swift/bridging
@@ -360,6 +360,10 @@
 /// unsafe constituents.
 #define SWIFT_SAFE __attribute__((swift_attr("safe")))
 
+/// Do not generate a safe wrapper overload function even if this function
+/// contains annotations that would trigger it otherwise.
+#define SWIFT_NO_SAFE_WRAPPER __attribute__((swift_attr("no_safe_wrapper")))
+
 #else  // #if _CXX_INTEROP_HAS_ATTRIBUTE(swift_attr)
 
 // Empty defines for compilers that don't support `attribute(swift_attr)`.
@@ -386,6 +390,7 @@
 #define SWIFT_PRIVATE_FILEID(_fileID)
 #define SWIFT_UNSAFE
 #define SWIFT_SAFE
+#define SWIFT_NO_SAFE_WRAPPER
 
 #endif // #if _CXX_INTEROP_HAS_ATTRIBUTE(swift_attr)
 

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -30,6 +30,7 @@
 
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Attr.h"
+#include "clang/AST/Attrs.inc"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclObjC.h"
 #include "clang/AST/DeclTemplate.h"
@@ -479,6 +480,14 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
                          const AbstractFunctionDecl *MappedDecl,
                          const T *ClangDecl) {
   DLOG_SCOPE("Checking '" << *ClangDecl << "' for bounds and lifetime info\n");
+
+  if (ClangDecl->hasAttrs())
+    for (auto attr : ClangDecl->getAttrs())
+      if (auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr))
+        if (swiftAttr->getAttribute() == "no_safe_wrapper") {
+          DLOG("skipping function with no_safe_wrapper\n");
+          return false;
+        }
 
   // FIXME: for private macro generated functions we do not serialize the
   // SILFunction's body anywhere triggering assertions.

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -30,7 +30,6 @@
 
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Attr.h"
-#include "clang/AST/Attrs.inc"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclObjC.h"
 #include "clang/AST/DeclTemplate.h"

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -480,13 +480,15 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
                          const T *ClangDecl) {
   DLOG_SCOPE("Checking '" << *ClangDecl << "' for bounds and lifetime info\n");
 
-  if (ClangDecl->hasAttrs())
-    for (auto attr : ClangDecl->getAttrs())
-      if (auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr))
-        if (swiftAttr->getAttribute() == "no_safe_wrapper") {
-          DLOG("skipping function with no_safe_wrapper\n");
-          return false;
-        }
+  if (ClangDecl->hasAttrs()) {
+    for (auto *attr : ClangDecl->getAttrs()) {
+      if (auto *swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr);
+          swiftAttr && swiftAttr->getAttribute() == "no_safe_wrapper") {
+        DLOG("skipping function with no_safe_wrapper\n");
+        return false;
+      }
+    }
+  }
 
   // FIXME: for private macro generated functions we do not serialize the
   // SILFunction's body anywhere triggering assertions.

--- a/test/Interop/Cxx/swiftify-import/no-safe-wrapper-attr.swift
+++ b/test/Interop/Cxx/swiftify-import/no-safe-wrapper-attr.swift
@@ -1,0 +1,65 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -plugin-path %swift-plugin-dir -I %t -cxx-interoperability-mode=default %t/test.swift -emit-module \
+// RUN:   -verify -Rmacro-expansions -verify-additional-file %t%{fs-sep}test.h -suppress-notes
+
+//--- test.h
+#define __counted_by(x) __attribute__((__counted_by__(x)))
+#define SWIFT_NO_SAFE_WRAPPER __attribute__((swift_attr("no_safe_wrapper")));
+
+// expected-expansion@+7:63{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func control_group_function(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
+//   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
+//   expected-remark@4{{macro content: |    return unsafe control_group_function(p.baseAddress!, len)|}}
+//   expected-remark@5{{macro content: |}|}}
+// }}
+void control_group_function(int * __counted_by(len) p, int len);
+
+void foo(int * __counted_by(len) p, int len) SWIFT_NO_SAFE_WRAPPER;
+
+struct Bar {
+  // expected-expansion@+8:63{{
+  //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+  //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload|}}
+  //   expected-remark@3{{macro content: |public mutating func control_group_method(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
+  //   expected-remark@4{{macro content: |    let len = Int32(exactly: p.count)!|}}
+  //   expected-remark@5{{macro content: |    return unsafe control_group_method(p.baseAddress!, len)|}}
+  //   expected-remark@6{{macro content: |}|}}
+  // }}
+  void control_group_method(int * __counted_by(len) p, int len);
+
+  void baz(int * __counted_by(len) p, int len) SWIFT_NO_SAFE_WRAPPER;
+};
+
+//--- module.modulemap
+module Test {
+  header "test.h"
+}
+
+//--- test.swift
+// GENERATED-BY: %target-swift-ide-test -plugin-path %swift-plugin-dir -I %t -cxx-interoperability-mode=upcoming-swift -print-module -module-to-print=Test -source-filename=x > %t/Test-interface.swift && %swift-function-caller-generator Test %t/Test-interface.swift
+// GENERATED-HASH: 52710b9bd39420d372ef8f0bb9a3046b1a22e6056114ef7862674685fc654da5
+import Test
+
+func call_control_group_function(_ p: UnsafeMutablePointer<Int32>!, _ len: Int32) {
+  return unsafe control_group_function(p, len)
+}
+
+func call_foo(_ p: UnsafeMutablePointer<Int32>!, _ len: Int32) {
+  return unsafe foo(p, len)
+}
+func call_control_group_method(_ self: inout Bar, _ p: UnsafeMutablePointer<Int32>!, _ len: Int32) {
+  return unsafe self.control_group_method(p, len)
+}
+func call_baz(_ self: inout Bar, _ p: UnsafeMutablePointer<Int32>!, _ len: Int32) {
+  return unsafe self.baz(p, len)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_control_group_method(_ self: inout Bar, _ p: UnsafeMutableBufferPointer<Int32>) {
+  return unsafe self.control_group_method(p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_control_group_function(_ p: UnsafeMutableBufferPointer<Int32>) {
+  return unsafe control_group_function(p)
+}


### PR DESCRIPTION
This adds SWIFT_NO_SAFE_WRAPPER, which can be used to signal that a
function should not get a safe interop wrapper. This can serve as a
fallback if a safe wrapper blocks compilation, while waiting for a fix
to ship.

rdar://169146789