### PR TITLE
[6.3] MandatoryDestroyHoisting: ignore type-dependent operands when computing the liverange of a value

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/MandatoryDestroyHoisting.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/MandatoryDestroyHoisting.swift
@@ -201,7 +201,7 @@ private struct Liverange {
     prunedLiverange.insert(contentsOf: nonDestroyingUsers)
 
     self.fullLiverange = InstructionRange(for: value, context)
-    fullLiverange.insert(contentsOf: value.users)
+    fullLiverange.insert(contentsOf: value.uses.ignoreTypeDependence.users)
 
     self.context = context
   }

--- a/test/SILOptimizer/mandatory-destroy-hoisting.sil
+++ b/test/SILOptimizer/mandatory-destroy-hoisting.sil
@@ -476,3 +476,32 @@ bb0(%0 : @owned $C):
   %10 = tuple ()
   return %10
 }
+
+protocol P: AnyObject {}
+
+// CHECK-LABEL: sil [ossa] @type_dependent_operand_outside_liverange :
+// CHECK:       bb2:
+// CHECK-NEXT:    destroy_value %2
+// CHECK:       } // end sil function 'type_dependent_operand_outside_liverange'
+sil [ossa] @type_dependent_operand_outside_liverange : $@convention(thin) (@in_guaranteed any P) -> () {
+
+bb0(%0 : $*any P):
+  %1 = load [copy] %0
+  %2 = open_existential_ref %1 to $@opened("093C97B4-11DD-11F1-AC30-1A9AD1B1CD90", any P) Self
+  cond_br undef, bb1, bb2
+
+bb1:
+  %4 = alloc_stack $@opened("093C97B4-11DD-11F1-AC30-1A9AD1B1CD90", any P) Self
+  store %2 to [init] %4
+  %6 = apply undef<@opened("093C97B4-11DD-11F1-AC30-1A9AD1B1CD90", any P) Self>(%4) : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in τ_0_0) -> ()
+  dealloc_stack %4
+  br bb3
+
+bb2:
+  destroy_value %2
+  br bb3
+
+bb3:
+  %11 = tuple ()
+  return %11
+}


### PR DESCRIPTION
* **Explanation**:  Type-dependent operands can appear outside the liverange of a value and therefore must be ignored. This bug caused MandatoryDestroyHoisting to insert wrong destroys. This change fixes a SIL verification error and/or a mis-compile.
* **Risk**: Very low. It's a 1-line change to ignore type-dependent operands for liverange computation
* **Testing**: Tested by lit tests.
* **Issue**: rdar://170510052
* **Reviewer**:  @meg-gupta
* **Main branch PR**: https://github.com/swiftlang/swift/pull/87562
