### PR TITLE
[cxx-interop] Gate CxxBorrowingSequence in swiftinterface behind $BorrowingSequence

### DIFF
--- a/Runtimes/Overlay/Cxx/CMakeLists.txt
+++ b/Runtimes/Overlay/Cxx/CMakeLists.txt
@@ -35,7 +35,8 @@ target_compile_options(swiftCxx PRIVATE
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -nostdinc++>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature AllowUnsafeAttribute>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature BuiltinModule>"
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature Lifetimes>")
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature Lifetimes>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature BorrowingSequence>")
 target_link_libraries(swiftCxx PUBLIC
   $<$<BOOL:${SwiftSwiftDirectRuntime_FOUND}>:swiftSwiftDirectRuntime>
   swiftCore)

--- a/Runtimes/Overlay/cmake/modules/ExperimentalFeatures.cmake
+++ b/Runtimes/Overlay/cmake/modules/ExperimentalFeatures.cmake
@@ -5,4 +5,5 @@ add_compile_options(
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature LifetimeDependence>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature InoutLifetimeDependence>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature LifetimeDependenceMutableAccessors>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature BorrowingSequence>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-upcoming-feature MemberImportVisibility>")

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -601,7 +601,23 @@ static bool usesFeatureReparenting(Decl *decl) {
 UNINTERESTING_FEATURE(AnyAppleOSAvailability)
 UNINTERESTING_FEATURE(StrictAccessControl)
 UNINTERESTING_FEATURE(BorrowInout)
-UNINTERESTING_FEATURE(BorrowingSequence)
+
+// CxxBorrowingSequence and CxxBorrowingIterator, defined in the Cxx overlay,
+// conform to BorrowingSequence and BorrowingIteratorProtocol. When a newer
+// compiler is used with an older SDK, the Cxx module interface may reference
+// these Swift stdlib protocols even though they don't exist in the SDK's
+// stdlib. To handle this, we guard them behind the `BorrowingSequence`
+// experimental flag.
+static bool usesFeatureBorrowingSequence(Decl *decl) {
+  if (auto *ext = dyn_cast<ExtensionDecl>(decl))
+    decl = ext->getExtendedNominal();
+
+  if (auto *proto = dyn_cast<ProtocolDecl>(decl))
+    return proto->getNameStr() == "CxxBorrowingSequence";
+  if (auto *sd = dyn_cast<StructDecl>(decl))
+    return sd->getNameStr() == "CxxBorrowingIterator";
+  return false;
+}
 
 // ----------------------------------------------------------------------------
 // MARK: - FeatureSet

--- a/stdlib/public/Cxx/CMakeLists.txt
+++ b/stdlib/public/Cxx/CMakeLists.txt
@@ -26,6 +26,7 @@ add_swift_target_library(swiftCxx STATIC NO_LINK_NAME IS_STDLIB IS_SWIFT_ONLY
     -enable-experimental-feature AllowUnsafeAttribute
     -enable-experimental-feature Lifetimes
     -enable-experimental-feature SuppressedAssociatedTypesWithDefaults
+    -enable-experimental-feature BorrowingSequence
     -strict-memory-safety
     # This module should not pull in the C++ standard library, so we disable it explicitly.
     # For functionality that depends on the C++ stdlib, use C++ stdlib overlay (`swiftstd` module).


### PR DESCRIPTION
`CxxBorrowingSequence` and `CxxBorrowingIterator`, defined in the Cxx overlay, conform to `BorrowingSequence` and `BorrowingIteratorProtocol`. When a newer compiler is used with an older SDK, the Cxx module interface may reference these Swift stdlib protocols even though they don't exist in the SDK's stdlib. To handle this, we guard them behind the `BorrowingSequence` experimental flag.

rdar://171010039