### PR TITLE
[DebugInfo] No longer assign non-fixed-size types the size of a pointer

### DIFF
--- a/lib/IRGen/DebugTypeInfo.cpp
+++ b/lib/IRGen/DebugTypeInfo.cpp
@@ -197,9 +197,14 @@ CompletedDebugTypeInfo::getFromTypeInfo(swift::Type Ty, const TypeInfo &Info,
                                         std::optional<Size::int_type> Size) {
   if (!Ty || Ty->hasTypeParameter())
     return {};
-  auto *StorageType = IGM.getStorageTypeForUnlowered(Ty);
   std::optional<uint64_t> SizeInBits;
-  if (StorageType->isSized())
+
+  auto *StorageType = IGM.getStorageTypeForUnlowered(Ty);
+  // Prefer the storage type where possible. This is more accurate in case of
+  // Int1 where we see the exact number of used bits.
+  // If the type does NOT have a fixed size, then ignore the storage type as it
+  // ithe storage type is just a pointer.
+  if (StorageType->isSized() && Info.isFixedSize())
     SizeInBits = IGM.DataLayout.getTypeSizeInBits(StorageType);
   else if (Info.isFixedSize()) {
     const FixedTypeInfo &FixTy = *cast<const FixedTypeInfo>(&Info);

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -2317,9 +2317,12 @@ private:
           return createSpecializedEnumType(EnumTy, Decl, MangledName,
                                            SizeInBits, AlignInBits, Scope, File,
                                            FwdDeclLine, Flags);
-        if (CompletedDbgTy)
-          return createEnumType(*CompletedDbgTy, Decl, MangledName, AlignInBits,
-                                Scope, L.File, L.Line, Flags);
+        // If we do not know the size of this type, pass a size of 0.
+        // FIXME: createEnumType should not require a sized debug info type.
+        if (!CompletedDbgTy)
+          CompletedDbgTy = CompletedDebugTypeInfo::get(DbgTy, 0);
+        return createEnumType(*CompletedDbgTy, Decl, MangledName, AlignInBits,
+                              Scope, L.File, L.Line, Flags);
       }
       return createOpaqueStructWithSizedContainer(
           Scope, Decl->getName().str(), L.File, FwdDeclLine, SizeInBits,
@@ -2827,12 +2830,15 @@ private:
     if (auto *Decl = DbgTy.getDecl())
       Name = Decl->getName().str();
 
-    // If this is a forward decl, create one for this mangled name and don't
-    // cache it.
-    if (!isa<PrimaryArchetypeType>(DbgTy.getType()) &&
-        !isa<TypeAliasType>(DbgTy.getType()) &&
-        (DbgTy.isForwardDecl() || DbgTy.isFixedBuffer() ||
-         !completeType(DbgTy))) {
+    // If this type can have a definition that provides us with its layout/size,
+    // then only emit a forward declaration.
+    // TODO: This check can probably be simplified and generalized.
+    const bool RequiresSize = !isa<PrimaryArchetypeType>(DbgTy.getType()) &&
+                              !DbgTy.getType()->hasArchetype() &&
+                              !isa<TypeAliasType>(DbgTy.getType());
+    const bool HasNoFixedSize =
+        DbgTy.isForwardDecl() || DbgTy.isFixedBuffer() || !completeType(DbgTy);
+    if (RequiresSize && HasNoFixedSize) {
       // In LTO type uniquing is performed based on the UID. Forward
       // declarations may not have a unique ID to avoid a forward declaration
       // winning over a full definition.

--- a/test/DebugInfo/generic_tuple_size.swift
+++ b/test/DebugInfo/generic_tuple_size.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend %s -emit-ir -gdwarf-types -o - | %FileCheck %s
+
+// Tests that tuples with no known size are not given a size in DWARF.
+
+protocol Prot {
+  associatedtype Associated
+}
+
+func generic_func<B: Prot>(_ b: B) {
+  let x: (first: Int, optionalSecond: B.Associated?) = (first: 0, optionalSecond: nil)
+  _ = x
+}
+
+// CHECK: !DICompositeType(tag: DW_TAG_structure_type, {{.*}}name: "$sSi5first_10Associated18generic_tuple_size4ProtPQzSg14optionalSecondtD"
+// CHECK-NOT: size:
+// CHECK-SAME:)

--- a/test/DebugInfo/value-generics.swift
+++ b/test/DebugInfo/value-generics.swift
@@ -8,7 +8,7 @@ struct Slab<let N: Int, Element: ~Copyable>: ~Copyable {
 
 extension Slab: Copyable where Element: Copyable {}
 
-// CHECK-DAG: !DICompositeType({{.*}}name: "$sxq_BVD"
+// CHECK-DAG: !DICompositeType({{.*}}name: "Builtin.FixedArray", {{.*}}identifier: "$sxq_BVD"
 func genericBA<let N: Int, Element>(_: Builtin.FixedArray<N, Element>) {}
 
 // CHECK-DAG: !DICompositeType({{.*}}name: "$s4main4SlabVyxq_GD"


### PR DESCRIPTION
`CompletedDebugTypeInfo::getFromTypeInfo` currently uses the storage type as
the preferred source of size information.
For address-only types (and any other type that has no fixed size at compile
time), the storage type is always changed to a pointer.

This currently causes that some non-fixed-size types (e.g., generics)
are assigned the size of a pointer as their actual size in the generated
debug information.

For example:

```
protocol P {
associatedtype S
}

func foo<B: P>(_ b: B) {
let x: (aaa: Int, bbb: B.S?) = (aaa: 0, bbb: nil)
_ = x
let y: (Fx: Int, Fy: Int) = (Fx: 0, Fy: 0)
_ = y
}
```

results in the following DWARF output where the first struct
is given size 8 (= the size of a pointer).

```
0x000000d4:   DW_TAG_structure_type
                DW_AT_name	("$sSi3aaa_1S4main1PPQzSg3bbbtD")
                DW_AT_linkage_name	("$sSi3aaa_1S4main1PPQzSg3bbbtD")
                DW_AT_byte_size	(0x08)
                DW_AT_APPLE_runtime_class	(DW_LANG_Swift)

0x000000f3:   DW_TAG_structure_type
                DW_AT_name	("$sSi2Fx_Si2FytD")
                DW_AT_linkage_name	("$sSi2Fx_Si2FytD")
                DW_AT_byte_size	(0x10)
                DW_AT_APPLE_runtime_class	(DW_LANG_Swift)
```

This change modifies `CompletedDebugTypeInfo::getFromTypeInfo` to ignore the
storage size for types that do not have fixed size. Generics now have no
specified size or 0 in DWARF. FixedArray<A, B> without substituted type/size
is now also emitted using the dedicated FixedArray code.