### PR TITLE
Fix async let teardown ordering crash (#81771)

### DIFF
--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -2335,7 +2335,7 @@ FUNCTION(TaskAlloc,
          ARGS(SizeTy),
          ATTRS(NoUnwind),
          EFFECT(RuntimeEffect::Concurrency),
-         MEMEFFECTS(ArgMemOnly))
+         MEMEFFECTS(InaccessibleOrArgMemOnly))
 
 // void swift_task_dealloc(void *ptr);
 FUNCTION(TaskDealloc,
@@ -2345,7 +2345,7 @@ FUNCTION(TaskDealloc,
          ARGS(Int8PtrTy),
          ATTRS(NoUnwind),
          EFFECT(RuntimeEffect::Concurrency),
-         MEMEFFECTS(ArgMemOnly))
+         MEMEFFECTS(InaccessibleOrArgMemOnly))
 
 // void swift_task_dealloc_through(void *ptr);
 FUNCTION(TaskDeallocThrough,
@@ -2355,7 +2355,7 @@ FUNCTION(TaskDeallocThrough,
          ARGS(Int8PtrTy),
          ATTRS(NoUnwind),
          EFFECT(RuntimeEffect::Concurrency),
-         MEMEFFECTS(ArgMemOnly))
+         MEMEFFECTS(InaccessibleOrArgMemOnly))
 
 // void swift_task_cancel(AsyncTask *task);
 FUNCTION(TaskCancel,

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -788,6 +788,7 @@ namespace RuntimeConstants {
   const auto ReadOnly = llvm::MemoryEffects::readOnly();
   const auto ArgMemOnly = llvm::MemoryEffects::argMemOnly();
   const auto ArgMemReadOnly = llvm::MemoryEffects::argMemOnly(llvm::ModRefInfo::Ref);
+  const auto InaccessibleOrArgMemOnly = llvm::MemoryEffects::inaccessibleOrArgMemOnly();
   const auto NoReturn = llvm::Attribute::NoReturn;
   const auto NoUnwind = llvm::Attribute::NoUnwind;
   const auto ZExt = llvm::Attribute::ZExt;

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -1317,10 +1317,10 @@ bool SILInstruction::isAllocatingStack() const {
   }
 
   if (auto *BI = dyn_cast<BuiltinInst>(this)) {
-    // FIXME: BuiltinValueKind::StartAsyncLetWithLocalBuffer
     if (auto BK = BI->getBuiltinKind();
         BK && (*BK == BuiltinValueKind::StackAlloc ||
-               *BK == BuiltinValueKind::UnprotectedStackAlloc)) {
+               *BK == BuiltinValueKind::UnprotectedStackAlloc ||
+               *BK == BuiltinValueKind::StartAsyncLetWithLocalBuffer)) {
       return true;
     }
   }
@@ -1343,10 +1343,34 @@ StackAllocationIsNested_t SILInstruction::isStackAllocationNested() const {
   assert(isAllocatingStack());
   if (auto ASI = dyn_cast<AllocStackInst>(this)) {
     return ASI->isStackAllocationNested();
-  } else {
-    // TODO: implement for all remaining allocations
-    return StackAllocationIsNested;
   }
+
+  // StartAsyncLetWithLocalBuffer allocates stack memory that is deallocated
+  // by FinishAsyncLet (an async operation / suspension point). Mark as
+  // non-nested so that StackNesting does not attempt to move or create
+  // deallocations for it, preserving the LIFO ordering of async let teardown.
+  if (auto *BI = dyn_cast<BuiltinInst>(this)) {
+    if (auto BK = BI->getBuiltinKind();
+        BK && *BK == BuiltinValueKind::StartAsyncLetWithLocalBuffer) {
+      return StackAllocationIsNotNested;
+    }
+  }
+
+  // All remaining stack-allocating instructions return StackAllocationIsNested,
+  // which lets StackNesting track and fix their ordering. This is correct
+  // because each of them:
+  //   (a) follows LIFO discipline, and
+  //   (b) has its deallocation within the same non-suspended region
+  //       (i.e., deallocation does not cross suspension points).
+  //
+  // The remaining types are:
+  //   - AllocPackInst
+  //   - AllocPackMetadataInst
+  //   - On-stack AllocRefInstBase
+  //   - On-stack PartialApplyInst
+  //   - Callee-allocated BeginApplyInst
+  //   - StackAlloc / UnprotectedStackAlloc builtins
+  return StackAllocationIsNested;
 }
 
 void SILInstruction::setStackAllocationIsNested(
@@ -1373,9 +1397,9 @@ bool SILInstruction::isDeallocatingStack() const {
     return true;
 
   if (auto *BI = dyn_cast<BuiltinInst>(this)) {
-    // FIXME: BuiltinValueKind::FinishAsyncLet
     if (auto BK = BI->getBuiltinKind();
-        BK && (*BK == BuiltinValueKind::StackDealloc)) {
+        BK && (*BK == BuiltinValueKind::StackDealloc ||
+               *BK == BuiltinValueKind::FinishAsyncLet)) {
       return true;
     }
   }

--- a/test/Concurrency/Runtime/async_let_teardown_ordering.swift
+++ b/test/Concurrency/Runtime/async_let_teardown_ordering.swift
@@ -1,0 +1,39 @@
+// https://github.com/swiftlang/swift/issues/81771
+// Verify that multiple async let bindings produce correct LIFO teardown
+// ordering (finish/dealloc/finish/dealloc), not finish/finish/dealloc/dealloc.
+// The incorrect ordering causes a runtime crash ("freed pointer was not the
+// last allocation") when targeting pre-macOS 13 / pre-iOS 16 or when the
+// result type is large.
+
+// RUN: %target-run-simple-swift(-swift-version 6 -parse-as-library) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+// UNSUPPORTED: back_deployment_runtime
+
+struct MyData {
+  var p1, p2, p3, p4, p5, p6: Int
+  var p7: Int
+}
+
+struct MyWrapper: ~Copyable {
+  var payload: MyData?
+}
+
+func async_let_crash() async {
+  async let one: Never? = Never?.none
+  async let two: Never? = Never?.none
+  if let _ = await one {}
+  _ = await two
+  _ = try? MyWrapper()
+}
+
+@main
+enum App {
+  static func main() async {
+    await async_let_crash()
+    // CHECK: ok
+    print("ok")
+  }
+}

--- a/test/IRGen/async_let_dealloc_ordering.swift
+++ b/test/IRGen/async_let_dealloc_ordering.swift
@@ -1,0 +1,33 @@
+// https://github.com/swiftlang/swift/issues/81771
+// Verify that in the LLVM IR after CoroSplit, swift_task_dealloc for the second
+// async let's closure appears BEFORE swift_asyncLet_finish for the first async
+// let, ensuring correct LIFO teardown ordering.
+
+// RUN: %target-swift-frontend -emit-ir -module-name test -swift-version 6 -parse-as-library %s | %FileCheck %s
+
+// REQUIRES: concurrency
+
+struct MyData {
+  var p1, p2, p3, p4, p5, p6: Int
+  var p7: Int
+}
+
+struct MyWrapper: ~Copyable {
+  var payload: MyData?
+}
+
+func async_let_crash() async {
+  async let one: Never? = Never?.none
+  async let two: Never? = Never?.none
+  if let _ = await one {}
+  _ = await two
+  _ = try? MyWrapper()
+}
+
+// After CoroSplit, the continuation that runs between the two finishAsyncLet
+// calls must contain swift_task_dealloc for closure2 BEFORE calling
+// swift_asyncLet_finish for closure1.
+
+// CHECK-LABEL: define {{.*}} @"$s4test15async_let_crashyyYaFTY5_"
+// CHECK: call swiftcc void @swift_task_dealloc
+// CHECK: musttail call swifttailcc void @swift_asyncLet_finish


### PR DESCRIPTION
Resolves [#75501](https://github.com/swiftlang/swift/issues/75501), resolves [#87481](https://github.com/swiftlang/swift/issues/87481), resolves [#81771](https://github.com/swiftlang/swift/issues/81771)

Multiple `async let` bindings produced incorrect LIFO teardown ordering (finish/finish/dealloc/dealloc instead of finish/dealloc/finish/dealloc), causing a runtime crash in the task allocator ("freed pointer was not the last allocation").

Two complementary fixes:

1. Make StackNesting aware of async let stack operations by teaching `isAllocatingStack()` to recognize `StartAsyncLetWithLocalBuffer` and `isDeallocatingStack()` to recognize `FinishAsyncLet`. Mark async let allocations as `StackAllocationIsNotNested` so StackNesting preserves LIFO ordering without attempting to move or create deallocations across suspension points.

2. Correct MEMEFFECTS for `swift_task_alloc`, `swift_task_dealloc`, and `swift_task_dealloc_through` from `ArgMemOnly` to `InaccessibleOrArgMemOnly`. These functions modify the task allocator's internal linked list (inaccessible memory), not just argument memory. The incorrect annotation allowed LLVM passes to move `swift_task_dealloc` across suspension boundaries.