### PR TITLE
[cxx-interop] Fix missing type traits for enums imported from ObjC

### DIFF
--- a/lib/PrintAsClang/PrintClangValueType.cpp
+++ b/lib/PrintAsClang/PrintClangValueType.cpp
@@ -634,8 +634,9 @@ void ClangValueTypePrinter::printTypeGenericTraits(
   if (const auto nd =
           dyn_cast_or_null<clang::NamedDecl>(typeDecl->getClangDecl()))
     isOSObject = !DeclAndTypePrinter::maybeGetOSObjectBaseName(nd).empty();
-  bool addPointer = (typeDecl->isObjC() && !isOSObject) ||
-                    (classDecl && classDecl->isForeignReferenceType());
+  bool addPointer =
+      (typeDecl->isObjC() && !isOSObject && !isa<EnumDecl>(typeDecl)) ||
+      (classDecl && classDecl->isForeignReferenceType());
 
   if (objCxxOnly)
     os << "#if defined(__OBJC__)\n";

--- a/test/Interop/SwiftToCxx/enums/Inputs/ObjCFrozenEnum.h
+++ b/test/Interop/SwiftToCxx/enums/Inputs/ObjCFrozenEnum.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#if __has_attribute(enum_extensibility)
+#define CLOSED_ENUM_ATTR __attribute__((enum_extensibility(closed)))
+#else
+#define CLOSED_ENUM_ATTR
+#endif
+
+typedef enum CLOSED_ENUM_ATTR ObjCFrozenEnum : unsigned int {
+    ObjCFrozenEnumFirst = 0,
+    ObjCFrozenEnumSecond = 1,
+    ObjCFrozenEnumThird = 2,
+} ObjCFrozenEnum;

--- a/test/Interop/SwiftToCxx/enums/Inputs/module.modulemap
+++ b/test/Interop/SwiftToCxx/enums/Inputs/module.modulemap
@@ -1,0 +1,4 @@
+module ObjCFrozenEnum {
+  header "ObjCFrozenEnum.h"
+  export *
+}

--- a/test/Interop/SwiftToCxx/enums/objc-frozen-enum-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/objc-frozen-enum-in-cxx.swift
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name UseObjCFrozenEnum -cxx-interoperability-mode=default -clang-header-expose-decls=all-public -I %S/Inputs/ -typecheck -verify -emit-clang-header-path %t/UseObjCFrozenEnum.h
+
+// RUN: echo "#include \"ObjCFrozenEnum.h\"" > %t/full-header.h
+// RUN: cat %t/UseObjCFrozenEnum.h >> %t/full-header.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/full-header.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -I %S/Inputs)
+// RUN: %FileCheck %s < %t/full-header.h
+
+import ObjCFrozenEnum
+
+public func returnsObjCFrozenEnumOpt() -> ObjCFrozenEnum? {
+    return nil
+}
+
+public func takesObjCFrozenEnumOpt(_ x: ObjCFrozenEnum?) {}
+
+// CHECK: isUsableInGenericContext<ObjCFrozenEnum>
+// CHECK: TypeMetadataTrait<ObjCFrozenEnum>


### PR DESCRIPTION
We did not generate type traits for enums that were imported from ObjC, as a result whenever those types are used in a generic context (e.g., as the generic argument of an optional) we produced a reverse interop header that did not compile. This patch makes sure we emit the type traits for imported enums.

rdar://171288150