### PR TITLE
[Concurrency] InferSendableFromCaptures: Capturing non-`SendableMetatype` archetypes affects sendability of a reference

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -7224,6 +7224,10 @@ public:
   /// type we can represent.
   Type getExistentialType() const;
 
+  /// Determine whether it's possible for this type to have an isolated
+  /// conformance. This could be prohibited in the generic signature.
+  bool mayHaveIsolatedConformance() const;
+
   // Implement isa/cast/dyncast/etc.
   static bool classof(const TypeBase *T) {
     return T->getKind() >= TypeKind::First_ArchetypeType

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5367,6 +5367,16 @@ Type getDynamicSelfReplacementType(Type baseObjTy, const ValueDecl *member,
 
 ValueDecl *getOverloadChoiceDecl(Constraint *choice);
 
+/// Determine whether this type is considered `Sendable` when captured
+/// i.e. a base type of a partially applied member reference.
+///
+/// The requirement here is more strict than regular `Sendable` conformance:
+///  - The type has to conform to `Sendable`;
+///  - All referenced type parameters have to conform to `SendableMetatype`.
+///
+/// This function requires the type to be fully resolved.
+bool isSendableCapture(Type type);
+
 /// Find any references to external type variables used in the body of a
 /// conjunction element (e.g closures, taps, if/switch expressions).
 ///

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3779,6 +3779,12 @@ Type ArchetypeType::getExistentialType() const {
   return genericEnv->maybeApplyOuterContextSubstitutions(existentialType);
 }
 
+bool ArchetypeType::mayHaveIsolatedConformance() const {
+  auto genericEnv = getGenericEnvironment();
+  auto genericSig = genericEnv->getGenericSignature();
+  return !genericSig->prohibitsIsolatedConformance(getInterfaceType());
+}
+
 bool ArchetypeType::requiresClass() const {
   if (auto layout = getLayoutConstraint())
     return layout->isClass();

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2978,8 +2978,8 @@ ConstraintSystem::TypeMatchResult ConstraintSystem::matchFunctionSendability(
 
   // Sendability is given by either the sendability of the dependent type if
   // present, otherwise it's given by the function itself.
-  auto func1Sendable = dep1 ? dep1->isSendableType() : func1->isSendable();
-  auto func2Sendable = dep2 ? dep2->isSendableType() : func2->isSendable();
+  auto func1Sendable = dep1 ? isSendableCapture(dep1) : func1->isSendable();
+  auto func2Sendable = dep2 ? isSendableCapture(dep2) : func2->isSendable();
 
   if (func1Sendable != func2Sendable) {
     // A @Sendable function can be a subtype of a non-@Sendable function.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -33,6 +33,7 @@
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/TypeTransform.h"
+#include "swift/AST/Types.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/Statistic.h"
@@ -1725,7 +1726,7 @@ struct TypeSimplifier : public TypeTransform<TypeSimplifier> {
       return std::pair(ty, false);
 
     // Otherwise we've flattened the dependence, evaluate Sendable.
-    return std::make_pair(Type(), ty->isSendableType());
+    return std::make_pair(Type(), isSendableCapture(ty));
   }
 };
 
@@ -5287,6 +5288,23 @@ bool constraints::isOperatorDisjunction(Constraint *disjunction) {
 
   auto *decl = getOverloadChoiceDecl(choices.front());
   return decl ? decl->isOperator() : false;
+}
+
+bool constraints::isSendableCapture(Type type) {
+  ASSERT(!type->hasTypeVariable());
+
+  if (!type->isSendableType())
+    return false;
+
+  // All of the type parameters involved in the type that may have isolated
+  // conformances have to conform to `SendableMetatype`.
+  return !type.findIf([&](Type innerTy) {
+    if (auto *archetypeTy = innerTy->getAs<ArchetypeType>()) {
+      if (archetypeTy->mayHaveIsolatedConformance())
+        return !MetatypeType::get(archetypeTy)->isSendableType();
+    }
+    return false;
+  });
 }
 
 ASTNode constraints::findAsyncNode(ClosureExpr *closure) {

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2920,10 +2920,7 @@ namespace {
             // If the generic signature of the environment prohibits this
             // type to have an isolated conformance, there is nothing to
             // diagnose.
-            Type interfaceType = archetype->getInterfaceType();
-            auto genericEnv = archetype->getGenericEnvironment();
-            auto genericSig = genericEnv->getGenericSignature();
-            if (genericSig->prohibitsIsolatedConformance(interfaceType))
+            if (!archetype->mayHaveIsolatedConformance())
               continue;
           } else {
             continue;

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -1049,7 +1049,7 @@ FunctionType *ConstraintSystem::adjustFunctionTypeForConcurrency(
           if (sendableDepTy->hasTypeVariable()) {
             extInfo = extInfo.withSendableDependentType(sendableDepTy);
           } else {
-            extInfo = extInfo.withSendable(sendableDepTy->isSendableType());
+            extInfo = extInfo.withSendable(isSendableCapture(sendableDepTy));
           }
           referenceTy =
               referenceTy->withExtInfo(extInfo)->castTo<FunctionType>();

--- a/test/Concurrency/sendable_metatype_typecheck.swift
+++ b/test/Concurrency/sendable_metatype_typecheck.swift
@@ -158,7 +158,7 @@ do {
 
   func test<T: Comparable>(s: S<T>) {
     compute(s, >) // expected-warning {{converting non-Sendable function value to '@Sendable (T, T) -> Bool' may introduce data races}}
-    compute(s, S.test) // expected-warning {{capture of non-Sendable type 'T.Type' in an isolated closure}}
+    compute(s, S.test) // expected-warning {{converting non-Sendable function value to '@Sendable (T, T) -> Bool' may introduce data races}}
   }
 }
 
@@ -203,5 +203,19 @@ func nonSendableSequence<S: AsyncSequence>(_ s: S) throws {
       // expected-warning@-1{{capture of non-Sendable type 'S.Type' in an isolated closure}}
       print(i)
     }
+  }
+}
+
+func testNonSendableMetatypeCaptures() {
+  struct Box<Wrapped> {}
+
+  func testNonSendableMetatype<T: P>(_: T) {
+    let fn = Box<T>.init // Ok
+    let _: @Sendable () -> Box<T> = fn // expected-error {{converting non-Sendable function value to '@Sendable () -> Box<T>' may introduce data races}}
+  }
+
+  func test<T: P & SendableMetatype>(_: T) {
+    let fn = Box<T>.init // Ok
+    let _: @Sendable () -> Box<T> = fn // Ok
   }
 }


### PR DESCRIPTION
If a partial application captures any non-`SendableMetatype` type parameter,
then it can call methods that are isolated to the current context and so the
function value cannot be `@Sendable`.

Resolves: rdar://170475422

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
