### PR TITLE
[test] fix for backdeployment testing

### DIFF
--- a/test/stdlib/subString.swift
+++ b/test/stdlib/subString.swift
@@ -318,12 +318,8 @@ SubstringTests.test("Substring.base") {
 }
 
 SubstringTests.test("isTriviallyIdentical(to:) small ascii")
-.skip(.custom(
-  { if #available(StdlibDeploymentTarget 6.4, *) { false } else { true } },
-  reason: "Requires Swift 6.4's standard library"
-))
-.code {
-  guard #available(StdlibDeploymentTarget 6.4, *) else { return }
+.require(.stdlib_6_4).code {
+  guard #available(SwiftStdlib 6.4, *) else { return }
 
   let a = "Hello"
   let b = "Hello"
@@ -377,12 +373,8 @@ SubstringTests.test("isTriviallyIdentical(to:) small ascii")
 }
 
 SubstringTests.test("isTriviallyIdentical(to:) small unicode")
-.skip(.custom(
-  { if #available(StdlibDeploymentTarget 6.4, *) { false } else { true } },
-  reason: "Requires Swift 6.4's standard library"
-))
-.code {
-  guard #available(StdlibDeploymentTarget 6.4, *) else { return }
+.require(.stdlib_6_4).code {
+  guard #available(SwiftStdlib 6.4, *) else { return }
 
   let a = "Cafe\u{301}"
   let b = "Cafe\u{301}"
@@ -430,12 +422,8 @@ SubstringTests.test("isTriviallyIdentical(to:) small unicode")
 }
 
 SubstringTests.test("isTriviallyIdentical(to:) large ascii")
-.skip(.custom(
-  { if #available(StdlibDeploymentTarget 6.4, *) { false } else { true } },
-  reason: "Requires Swift 6.4's standard library"
-))
-.code {
-  guard #available(StdlibDeploymentTarget 6.4, *) else { return }
+.require(.stdlib_6_4).code {
+  guard #available(SwiftStdlib 6.4, *) else { return }
 
   let a = String(repeating: "foo", count: 1000)
   let b = String(repeating: "foo", count: 1000)


### PR DESCRIPTION
Some tests related to SE-0494 in "test/stdlib/subString.swift" were using the wrong availability macro for the purpose of limiting backdeployment testing.
