### PR TITLE
utils: allow building brotli with the pinned toolchain

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2518,7 +2518,8 @@ function Build-Brotli([Hashtable] $Platform) {
     -Src $SourceCache\brotli `
     -Bin "$(Get-ProjectBinaryCache $Platform brotli)" `
     -Platform $Platform `
-    -UseMSVCCompilers C `
+    -UseMSVCCompilers $(if ($UseHostToolchain) { @("C") } else { @("") }) `
+    -UsePinnedCompilers $(if ($UseHostToolchain) { @("") } else { @("C") }) `
     -BuildTargets default `
     -Defines @{
       BUILD_SHARED_LIBS = "NO";


### PR DESCRIPTION
Allow building brotli with the pinned and the host toolchain as per the user. This is needed to build with the CAS.