### PR TITLE
build: use `-imsvc` for `clang-cl` not for `clang`

### DIFF
--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -11,7 +11,7 @@ project(swift-stdlib LANGUAGES C CXX)
 # being built on Windows.  Since we know that we only support `clang-cl` as the
 # compiler for the runtime due to the use of the Swift calling convention, we
 # simply override the CMake behaviour unconditionally.
-if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows" AND MSVC AND CLANG_C_COMPILER_ID MATCHES Clang)
   set(CMAKE_INCLUDE_SYSTEM_FLAG_C "-imsvc ")
   set(CMAKE_INCLUDE_SYSTEM_FLAG_CXX "-imsvc ")
 else()


### PR DESCRIPTION
When using the GNU driver, prefer `-Isystem` over `-imsvc` to allow building with the GNU driver. This is currently required to make progress on enabling CAS for Windows.