### PR TITLE
[Sema] Allow Sendable conformance for structs with global-actor-isolated stored properties

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -7072,10 +7072,13 @@ static bool checkSendableInstanceStorage(
           invalid = invalid || (behavior == DiagnosticBehavior::Unspecified);
           return true;
         }
+      }
 
-        if (!(isolation.isNonisolated() || isolation.isUnspecified())) {
-          return false; // skip sendable check on actor-isolated properties
-        }
+      // Actor-isolated properties don't need Sendable checking because
+      // they can only be accessed from within the actor's isolation domain.
+      // This applies to all nominal types (classes, structs, enums).
+      if (!(isolation.isNonisolated() || isolation.isUnspecified())) {
+        return false; // skip sendable check on actor-isolated properties
       }
 
       return checkSendabilityOfMemberType(property, propertyType);

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -393,6 +393,18 @@ final class C14: Sendable { // expected-warning{{default initializer for 'C14' c
   @SomeActor let nc1 = NotConcurrent()
 }
 
+// Structs with actor-isolated properties should also be accepted as Sendable,
+// just like classes (https://github.com/swiftlang/swift/issues/87543)
+struct S13: Sendable {
+  @MainActor let ns: NotSendable? = nil
+  nonisolated init() {}
+}
+
+struct S14: Sendable {
+  @SomeActor let nc1 = NotConcurrent()
+  nonisolated init() {}
+}
+
 extension NotConcurrent {
   func f() { }
 


### PR DESCRIPTION
Actor-isolated stored properties can only be accessed from within their isolation domain, so they are already safe regardless of whether the enclosing type is a class or a struct. However, [checkSendableInstanceStorage()](cci:1://file:///Users/omermurataydin/Desktop/swift/lib/Sema/TypeCheckConcurrency.cpp:1397:0-1398:68) only skipped the Sendable member check for actor-isolated properties when the enclosing type was a class. This meant a `final class` with `@MainActor let` of non-Sendable type was accepted as Sendable, but an identical struct was rejected.

This change lifts the actor-isolation guard out of the `isa<ClassDecl>` block so it applies uniformly to all nominal types.

**Changes:**
- [lib/Sema/TypeCheckConcurrency.cpp](cci:7://file:///Users/omermurataydin/Desktop/swift/lib/Sema/TypeCheckConcurrency.cpp:0:0-0:0) — moved the isolation check to apply to structs/enums too
- [test/Concurrency/concurrent_value_checking.swift](cci:7://file:///Users/omermurataydin/Desktop/swift/test/Concurrency/concurrent_value_checking.swift:0:0-0:0) — added struct regression tests (`S13`, `S14`)

Resolves https://github.com/swiftlang/swift/issues/87543
