### PR TITLE
[cas] Introduce a frontend option to write CAS hash to an xattr

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -507,6 +507,8 @@ REMARK(matching_output_produced,none,
 // Caching related diagnostics
 GROUPED_ERROR(error_caching_no_cas_fs, CompilationCaching, none,
     "caching is enabled without CAS file-system options, input is not immutable", ())
+GROUPED_ERROR(error_option_incompatible, CompilationCaching, none,
+    "'%0' is incompatible with '%1'", (StringRef, StringRef))
 
 REMARK(replay_output, none, "replay output file '%0': key '%1'", (StringRef, StringRef))
 REMARK(output_cache_miss, none, "cache miss for input file '%0': key '%1'", (StringRef, StringRef))

--- a/include/swift/Basic/CASOptions.h
+++ b/include/swift/Basic/CASOptions.h
@@ -34,6 +34,10 @@ public:
   /// Skip replaying outputs from cache.
   bool CacheSkipReplay = false;
 
+  /// When using EnableCaching, write the output file's hash (as determined by
+  /// the CAS hashing schema) as a file extended attribute (xattr).
+  bool WriteOutputHashXAttr = false;
+
   /// Import modules from CAS.
   bool ImportModuleFromCAS = false;
 

--- a/include/swift/Frontend/CASOutputBackends.h
+++ b/include/swift/Frontend/CASOutputBackends.h
@@ -47,7 +47,8 @@ public:
                         llvm::cas::ObjectRef BaseKey,
                         const FrontendInputsAndOutputs &InputsAndOutputs,
                         const FrontendOptions &Opts,
-                        FrontendOptions::ActionType Action);
+                        FrontendOptions::ActionType Action,
+                        bool WriteOutputHashXAttr);
   ~SwiftCASOutputBackend();
 
   llvm::Error storeCachedDiagnostics(unsigned InputIndex,

--- a/include/swift/Frontend/CachingUtils.h
+++ b/include/swift/Frontend/CachingUtils.h
@@ -38,7 +38,8 @@ createSwiftCachingOutputBackend(
     llvm::cas::ObjectStore &CAS, llvm::cas::ActionCache &Cache,
     llvm::cas::ObjectRef BaseKey,
     const FrontendInputsAndOutputs &InputsAndOutputs,
-    const FrontendOptions &Opts, FrontendOptions::ActionType Action);
+    const FrontendOptions &Opts, FrontendOptions::ActionType Action,
+    bool WriteOutputHashXAttr);
 
 /// Replay the output of the compilation from cache.
 /// Return true if outputs are replayed, false otherwise.
@@ -48,7 +49,8 @@ bool replayCachedCompilerOutputs(llvm::cas::ObjectStore &CAS,
                                  DiagnosticEngine &Diag,
                                  const FrontendOptions &Opts,
                                  CachingDiagnosticsProcessor &CDP,
-                                 bool CacheRemarks, bool UseCASBackend);
+                                 bool CacheRemarks, bool UseCASBackend,
+                                 bool WriteOutputHashXAttr);
 
 /// Replay the output of the compilation from cache for one input file.
 /// Return true if outputs are replayed, false otherwise.
@@ -61,7 +63,8 @@ bool replayCachedCompilerOutputsForInput(llvm::cas::ObjectStore &CAS,
                                          llvm::vfs::OutputBackend &OutBackend,
                                          const FrontendOptions &Opts,
                                          CachingDiagnosticsProcessor &CDP,
-                                         bool CacheRemarks, bool UseCASBackend);
+                                         bool CacheRemarks, bool UseCASBackend,
+                                         bool WriteOutputHashXAttr);
 
 /// Load the cached compile result from cache.
 std::unique_ptr<llvm::MemoryBuffer> loadCachedCompileResultFromCacheKey(

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -2344,6 +2344,10 @@ def cache_disable_replay:  Flag<["-"], "cache-disable-replay">,
   Flags<[FrontendOption, NewDriverOnlyOption, CacheInvariant]>,
   HelpText<"Skip loading the compilation result from cache">;
 
+def write_output_hash_xattr:  Flag<["-"], "write-output-hash-xattr">,
+  Flags<[FrontendOption, CacheInvariant]>,
+  HelpText<"When caching, write the output file's hash (as determined by the CAS hashing schema) as a file extended attribute.">;
+
 def cas_path: Separate<["-"], "cas-path">,
   Flags<[FrontendOption, NewDriverOnlyOption, CacheInvariant]>,
   HelpText<"Path to CAS">, MetaVarName<"<path>">;

--- a/lib/Frontend/CASOutputBackends.cpp
+++ b/lib/Frontend/CASOutputBackends.cpp
@@ -21,6 +21,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/CAS/HierarchicalTreeBuilder.h"
 #include "llvm/CAS/ObjectStore.h"
+#include "llvm/CASUtil/Utils.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Mutex.h"
 #include <optional>
@@ -59,9 +60,10 @@ public:
   Implementation(ObjectStore &CAS, ActionCache &Cache, ObjectRef BaseKey,
                  const FrontendInputsAndOutputs &InputsAndOutputs,
                  const FrontendOptions &Opts,
-                 FrontendOptions::ActionType Action)
+                 FrontendOptions::ActionType Action, bool WriteOutputHashXAttr)
       : CAS(CAS), Cache(Cache), BaseKey(BaseKey),
-        InputsAndOutputs(InputsAndOutputs), Opts(Opts), Action(Action) {
+        InputsAndOutputs(InputsAndOutputs), Opts(Opts), Action(Action),
+        WriteOutputHashXAttr(WriteOutputHashXAttr) {
     initBackend(InputsAndOutputs);
   }
 
@@ -126,6 +128,7 @@ private:
   const FrontendInputsAndOutputs &InputsAndOutputs;
   const FrontendOptions &Opts;
   FrontendOptions::ActionType Action;
+  bool WriteOutputHashXAttr;
 
   // Lock for updating output file status.
   llvm::sys::SmartMutex<true> OutputLock;
@@ -142,9 +145,11 @@ private:
 SwiftCASOutputBackend::SwiftCASOutputBackend(
     ObjectStore &CAS, ActionCache &Cache, ObjectRef BaseKey,
     const FrontendInputsAndOutputs &InputsAndOutputs,
-    const FrontendOptions &Opts, FrontendOptions::ActionType Action)
+    const FrontendOptions &Opts, FrontendOptions::ActionType Action,
+    bool WriteOutputHashXAttr)
     : Impl(*new SwiftCASOutputBackend::Implementation(
-          CAS, Cache, BaseKey, InputsAndOutputs, Opts, Action)) {}
+          CAS, Cache, BaseKey, InputsAndOutputs, Opts, Action,
+          WriteOutputHashXAttr)) {}
 
 SwiftCASOutputBackend::~SwiftCASOutputBackend() { delete &Impl; }
 
@@ -156,7 +161,7 @@ bool SwiftCASOutputBackend::isStoredDirectly(file_types::ID Kind) {
 IntrusiveRefCntPtr<OutputBackend> SwiftCASOutputBackend::cloneImpl() const {
   return makeIntrusiveRefCnt<SwiftCASOutputBackend>(
       Impl.CAS, Impl.Cache, Impl.BaseKey, Impl.InputsAndOutputs, Impl.Opts,
-      Impl.Action);
+      Impl.Action, Impl.WriteOutputHashXAttr);
 }
 
 Expected<std::unique_ptr<OutputFileImpl>>
@@ -264,6 +269,13 @@ Error SwiftCASOutputBackend::Implementation::storeImpl(
                           << "\' for input \'" << InputIndex << "\': \'"
                           << CAS.getID(*BytesRef).toString() << "\'\n";);
 
+  // FIXME: this creates an implicit requirement that the output backend is
+  // layered so that SwiftCASOutputBackend is written after the on-disk backend.
+  // The output backend interface currently doesn't let us pass this directly.
+  if (WriteOutputHashXAttr && OutputKind == file_types::TY_Object) {
+    if (auto E = llvm::cas::writeCASHashXAttr(CAS.getID(*BytesRef), Path))
+      return E;
+  }
   if (addProducedOutput(InputIndex, OutputKind, *BytesRef))
     return finalizeCacheKeysFor(InputIndex);
   return Error::success();

--- a/lib/Frontend/CachingUtils.cpp
+++ b/lib/Frontend/CachingUtils.cpp
@@ -36,6 +36,7 @@
 #include "llvm/MCCAS/MCCASObjectV1.h"
 #include "llvm/Option/ArgList.h"
 #include "llvm/Option/OptTable.h"
+#include "llvm/CASUtil/Utils.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -60,9 +61,10 @@ llvm::IntrusiveRefCntPtr<SwiftCASOutputBackend> createSwiftCachingOutputBackend(
     llvm::cas::ObjectStore &CAS, llvm::cas::ActionCache &Cache,
     llvm::cas::ObjectRef BaseKey,
     const FrontendInputsAndOutputs &InputsAndOutputs,
-    const FrontendOptions &Opts, FrontendOptions::ActionType Action) {
+    const FrontendOptions &Opts, FrontendOptions::ActionType Action,
+    bool WriteOutputHashXAttr) {
   return makeIntrusiveRefCnt<SwiftCASOutputBackend>(
-      CAS, Cache, BaseKey, InputsAndOutputs, Opts, Action);
+      CAS, Cache, BaseKey, InputsAndOutputs, Opts, Action, WriteOutputHashXAttr);
 }
 
 Error cas::CachedResultLoader::replay(CallbackTy Callback) {
@@ -147,7 +149,7 @@ static bool replayCachedCompilerOutputsImpl(
     ArrayRef<CacheInputEntry> Inputs, ObjectStore &CAS, DiagnosticEngine &Diag,
     const FrontendOptions &Opts, CachingDiagnosticsProcessor &CDP,
     DiagnosticHelper *DiagHelper, OutputBackend &Backend, bool CacheRemarks,
-    bool UseCASBackend) {
+    bool UseCASBackend, bool WriteOutputHashXAttr) {
   bool CanReplayAllOutput = true;
   struct OutputEntry {
     std::string Path;
@@ -317,6 +319,12 @@ static bool replayCachedCompilerOutputsImpl(
                     toString(std::move(E)));
       continue;
     }
+    if (WriteOutputHashXAttr && Output.Kind == file_types::ID::TY_Object) {
+      if (auto E = llvm::cas::writeCASHashXAttr(
+              CAS.getID(Output.Proxy.getRef()), Output.Path))
+        Diag.diagnose(SourceLoc(), diag::error_cas, "writing output hash xattr",
+                      toString(std::move(E)));
+    }
     if (CacheRemarks)
       Diag.diagnose(SourceLoc(), diag::replay_output, Output.Path,
                     Output.Key.toString());
@@ -330,7 +338,8 @@ static bool replayCachedCompilerOutputsImpl(
 bool replayCachedCompilerOutputs(
     ObjectStore &CAS, ActionCache &Cache, ObjectRef BaseKey,
     DiagnosticEngine &Diag, const FrontendOptions &Opts,
-    CachingDiagnosticsProcessor &CDP, bool CacheRemarks, bool UseCASBackend) {
+    CachingDiagnosticsProcessor &CDP, bool CacheRemarks, bool UseCASBackend,
+    bool WriteOutputHashXAttr) {
   // Compute all the inputs need replay.
   llvm::SmallVector<CacheInputEntry> Inputs;
   auto AllInputs = Opts.InputsAndOutputs.getAllInputs();
@@ -385,18 +394,20 @@ bool replayCachedCompilerOutputs(
   llvm::vfs::OnDiskOutputBackend Backend;
   return replayCachedCompilerOutputsImpl(Inputs, CAS, Diag, Opts, CDP,
                                          /*DiagHelper=*/nullptr, Backend,
-                                         CacheRemarks, UseCASBackend);
+                                         CacheRemarks, UseCASBackend,
+                                         WriteOutputHashXAttr);
 }
 
 bool replayCachedCompilerOutputsForInput(
     ObjectStore &CAS, ObjectRef OutputRef, const InputFile &Input,
     unsigned InputIndex, DiagnosticEngine &Diag, DiagnosticHelper &DiagHelper,
     OutputBackend &OutBackend, const FrontendOptions &Opts,
-    CachingDiagnosticsProcessor &CDP, bool CacheRemarks, bool UseCASBackend) {
+    CachingDiagnosticsProcessor &CDP, bool CacheRemarks, bool UseCASBackend,
+    bool WriteOutputHashXAttr) {
   llvm::SmallVector<CacheInputEntry> Inputs = {{Input, InputIndex, OutputRef}};
   return replayCachedCompilerOutputsImpl(Inputs, CAS, Diag, Opts, CDP,
                                          &DiagHelper, OutBackend, CacheRemarks,
-                                         UseCASBackend);
+                                         UseCASBackend, WriteOutputHashXAttr);
 }
 
 std::unique_ptr<llvm::MemoryBuffer>

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -836,6 +836,7 @@ static bool ParseCASArgs(CASOptions &Opts, ArgList &Args,
       OPT_cache_compile_job, OPT_no_cache_compile_job, /*Default=*/false);
   Opts.EnableCachingRemarks |= Args.hasArg(OPT_cache_remarks);
   Opts.CacheSkipReplay |= Args.hasArg(OPT_cache_disable_replay);
+  Opts.WriteOutputHashXAttr |= Args.hasArg(OPT_write_output_hash_xattr);
   if (const Arg *A = Args.getLastArg(OPT_cas_path))
     Opts.CASOpts.CASPath = A->getValue();
 
@@ -4224,6 +4225,17 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
 
   Opts.UseCASBackend |= Args.hasArg(OPT_cas_backend);
   Opts.EmitCASIDFile |= Args.hasArg(OPT_cas_emit_casid_file);
+
+  if (CASOpts.WriteOutputHashXAttr && Opts.UseCASBackend) {
+    Diags.diagnose(SourceLoc(), diag::error_option_incompatible,
+                         "-cas-backend", "-write-output-hash-xattr");
+    return true;
+  }
+  if (CASOpts.WriteOutputHashXAttr && Opts.EmitCASIDFile) {
+    Diags.diagnose(SourceLoc(), diag::error_option_incompatible,
+                         "-cas-emit-casid-file", "-write-output-hash-xattr");
+    return true;
+  }
 
   Opts.DebugCallsiteInfo |= Args.hasArg(OPT_debug_callsite_info);
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -516,7 +516,8 @@ void CompilerInstance::setupOutputBackend() {
     CASOutputBackend = createSwiftCachingOutputBackend(
         *CAS, *ResultCache, *CompileJobBaseKey, InAndOuts,
         Invocation.getFrontendOptions(),
-        Invocation.getFrontendOptions().RequestedAction);
+        Invocation.getFrontendOptions().RequestedAction,
+        Invocation.getCASOptions().WriteOutputHashXAttr);
 
     if (Invocation.getIRGenOptions().UseCASBackend) {
       auto OutputFiles = InAndOuts.copyOutputFilenames();

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1429,7 +1429,8 @@ static bool tryReplayCompilerResults(CompilerInstance &Instance) {
       *Instance.getCompilerBaseKey(), Instance.getDiags(),
       Instance.getInvocation().getFrontendOptions(), *CDP,
       Instance.getInvocation().getCASOptions().EnableCachingRemarks,
-      Instance.getInvocation().getIRGenOptions().UseCASBackend);
+      Instance.getInvocation().getIRGenOptions().UseCASBackend,
+      Instance.getInvocation().getCASOptions().WriteOutputHashXAttr);
 
   // If we didn't replay successfully, re-start capture.
   if (!replayed)

--- a/lib/Tooling/libSwiftScan/SwiftCaching.cpp
+++ b/lib/Tooling/libSwiftScan/SwiftCaching.cpp
@@ -928,7 +928,8 @@ static llvm::Error replayCompilation(SwiftScanReplayInstance &Instance,
   if (!replayCachedCompilerOutputsForInput(
           CAS, Comp.Output, Input, Comp.InputIndex, Inst.getDiags(), DH,
           Backend, Instance.Invocation.getFrontendOptions(), *CDP, Remarks,
-          UseCASBackend)) {
+          UseCASBackend,
+          Instance.Invocation.getCASOptions().WriteOutputHashXAttr)) {
     Inst.getDiags().diagnose(SourceLoc(), diag::cache_replay_failed,
                              "failed to load all outputs");
   }

--- a/test/CAS/output_hash_xattr.swift
+++ b/test/CAS/output_hash_xattr.swift
@@ -1,0 +1,52 @@
+// REQUIRES: OS=macosx
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test \
+// RUN:   -disable-implicit-string-processing-module-import \
+// RUN:   -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   %s -o %t/deps.json -cache-compile-job -cas-path %t/cas
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-string-processing-module-import\"" >> %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-concurrency-module-import\"" >> %t/MyApp.cmd
+// RUN: echo "\"-parse-stdlib\"" >> %t/MyApp.cmd
+
+/// Run the command first time, expect cache miss.
+// RUN: %target-swift-frontend-plain -c -cache-compile-job -Rcache-compile-job \
+// RUN:   -cas-path %t/cas %s -o %t/test.o @%t/MyApp.cmd \
+// RUN:   -write-output-hash-xattr 2>&1 | %FileCheck --check-prefix=CACHE-MISS %s
+
+// RUN: xattr -lx %t/test.o | %FileCheck %s
+
+/// Run the command a second time, expect cache hit.
+// RUN: %target-swift-frontend-plain -c -cache-compile-job -Rcache-compile-job \
+// RUN:   -cas-path %t/cas %s -o %t/test.o @%t/MyApp.cmd \
+// RUN:   -write-output-hash-xattr 2>&1 | %FileCheck --check-prefix=CACHE-HIT %s
+
+// RUN: xattr -lx %t/test.o | %FileCheck %s
+
+// The following checks the hash schema name and the 32-byte hash size.
+// CHECK: com.apple.clang.cas_output_hash:
+// CHECK: 00000000  6C 6C 76 6D 2E 63 61 73 2E 62 75 69 6C 74 69 6E  |llvm.cas.builtin|
+// CHECK: 00000010  2E 76 32 5B 42 4C 41 4B 45 33 5D 00 20 00 00 00  |.v2[BLAKE3]. ...|
+// CHECK: 00000020  {{(([A-F0-9]{2} ){16})}}|
+// CHECK: 00000030  {{(([A-F0-9]{2} ){16})}}|
+
+// CACHE-MISS: remark: cache miss for input
+// CACHE-HIT: remark: replay output file '{{.*}}{{/|\\}}test.o': key 'llvmcas://{{.*}}'
+
+/// Check that -write-output-hash-xattr with -cas-backend is an error.
+// RUN: not %target-swift-frontend-plain -c -cache-compile-job \
+// RUN:   -cas-path %t/cas %s -o %t/test.o @%t/MyApp.cmd \
+// RUN:   -cas-backend -write-output-hash-xattr 2>&1 \
+// RUN:   | %FileCheck --check-prefix=CAS-BACKEND %s
+// CAS-BACKEND: error: '-cas-backend' is incompatible with '-write-output-hash-xattr'
+
+/// Check that -write-output-hash-xattr with -cas-backend is an error.
+// RUN: not %target-swift-frontend-plain -c -cache-compile-job \
+// RUN:   -cas-path %t/cas %s -o %t/test.o @%t/MyApp.cmd \
+// RUN:   -cas-emit-casid-file -write-output-hash-xattr 2>&1 \
+// RUN:   | %FileCheck --check-prefix=CASID-FILE %s
+// CASID-FILE: error: '-cas-emit-casid-file' is incompatible with '-write-output-hash-xattr'
+
+func testFunc() {}


### PR DESCRIPTION
With the new option, when doing caching we write the hash that we already computed for the main output file to an extended attribute (xattr) on the file. This is equivalent to clang's -fwrite-output-hash-xattr option.

The format of the xattr is
name: com.apple.clang.cas_output_hash
data:
* Null-terminated hash schema name, e.g. llvm.builtin.v2[BLAKE3].
* Hash length (4 bytes, little-endian).
* Hash bytes

rdar://171185394