### PR TITLE
Embedded:  Require a deinit in classes with properties referencing a hidden dependency

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3894,6 +3894,7 @@ NOTE(construct_raw_representable_from_unwrapped_value,none,
       "in a property declaration marked public or in a '@frozen' or '@usableFromInline' context|" \
       "in a property declaration member of a type not marked '@_implementationOnly'|" \
       "in a property declaration member of an open class|" \
+      "in a property declaration member of a class without the required '@export(interface)' deinit in Embedded|" \
       "in an associated value of a public or '@usableFromInline' enum|" \
       "in an associated value of an enum not marked '@_implementationOnly'}"
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3893,6 +3893,7 @@ NOTE(construct_raw_representable_from_unwrapped_value,none,
       "in an '@available' attribute here|" \
       "in a property declaration marked public or in a '@frozen' or '@usableFromInline' context|" \
       "in a property declaration member of a type not marked '@_implementationOnly'|" \
+      "in a property declaration member of an open class|" \
       "in an associated value of a public or '@usableFromInline' enum|" \
       "in an associated value of an enum not marked '@_implementationOnly'}"
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3941,6 +3941,12 @@ ERROR(unexportable_clang_function_type,none,
       "it may use anonymous types or types defined outside of a module",
       (Type))
 
+NOTE(embedded_classes_require_export_interface_deinit,none,
+     "add a '@export(interface)' deinit to the class "
+     "for properties to reference a hidden dependency. "
+     "This is a restriction in Embedded mode.",
+     ())
+
 ERROR(cxx_class_instantiation_failed,none,
       "couldn't instantiate a C++ class template",
       ())

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2839,8 +2839,20 @@ ExportedLevel VarDecl::isLayoutExposedToClients() const {
 
   // Class layouts are not exposed to clients, except for subclassing.
   if (isa<ClassDecl>(parent) &&
-      !parent->hasOpenAccess(getDeclContext()))
-    return ExportedLevel::None;
+      !parent->hasOpenAccess(getDeclContext())) {
+
+    if (!parent->getASTContext().LangOpts.hasFeature(Feature::Embedded))
+      return ExportedLevel::None;
+
+    // In embedded, we need to ensure the class has a deinit marked
+    // '@export(interface)'.
+    for (auto member : parent->getMembers()) {
+      if (isa<DestructorDecl>(member) &&
+          member->isNeverEmittedIntoClient()) {
+        return ExportedLevel::None;
+      }
+    }
+  }
 
   auto M = getDeclContext()->getParentModule();
   if (M->getResilienceStrategy() != ResilienceStrategy::Resilient) {

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -297,6 +297,7 @@ static bool shouldDiagnoseDeclAccess(const ValueDecl *D,
   case ExportabilityReason::ResultBuilder:
   case ExportabilityReason::PropertyWrapper:
   case ExportabilityReason::ImplicitlyPublicVarDecl:
+  case ExportabilityReason::ImplicitlyPublicVarDeclOpenClass:
   case ExportabilityReason::ImplicitlyPublicAssociatedValue:
     return isInternalBridgingHeader &&
            where.getExportedLevel() == ExportedLevel::ImplicitlyExported;

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -298,6 +298,7 @@ static bool shouldDiagnoseDeclAccess(const ValueDecl *D,
   case ExportabilityReason::PropertyWrapper:
   case ExportabilityReason::ImplicitlyPublicVarDecl:
   case ExportabilityReason::ImplicitlyPublicVarDeclOpenClass:
+  case ExportabilityReason::ImplicitlyPublicVarDeclClassDeinit:
   case ExportabilityReason::ImplicitlyPublicAssociatedValue:
     return isInternalBridgingHeader &&
            where.getExportedLevel() == ExportedLevel::ImplicitlyExported;

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -399,6 +399,22 @@ static bool diagnoseValueDeclRefExportability(SourceLoc loc, const ValueDecl *D,
         .limitBehavior(limit.merge(commonBehavior));
 
     D->diagnose(diag::kind_declared_here, D->getDescriptiveKind());
+
+    // Suggest a fix for references from class properties in embedded mode.
+    if (reason == ExportabilityReason::ImplicitlyPublicVarDeclClassDeinit) {
+      auto *parentClass = dyn_cast_or_null<ClassDecl>(DC->getAsDecl());
+      if (parentClass) {
+        auto inFlight = parentClass->diagnose(
+            diag::embedded_classes_require_export_interface_deinit);
+
+        auto insertLoc = parentClass->getBraces().End;
+        StringRef insertIndent =
+          Lexer::getIndentationForLine(ctx.SourceMgr, insertLoc);
+        std::string fixit = (insertIndent + "@export(interface)\n" +
+                             insertIndent + "deinit {}\n").str();
+        inFlight.fixItInsert(insertLoc, fixit);
+      }
+    }
   } else {
     ctx.Diags.diagnose(loc, diag::inlinable_decl_ref_from_hidden_module, D,
                        fragileKind.getSelector(), definingModule->getName(),

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -2309,6 +2309,8 @@ public:
     if (CD) {
       if (CD->getFormalAccess() == AccessLevel::Open)
         return ExportabilityReason::ImplicitlyPublicVarDeclOpenClass;
+      else if (CD->getASTContext().LangOpts.hasFeature(Feature::Embedded))
+        return ExportabilityReason::ImplicitlyPublicVarDeclClassDeinit;
     }
 
     return ExportabilityReason::ImplicitlyPublicVarDecl;

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -2300,9 +2300,18 @@ public:
 
   /// Pick the appropriate \c ExportabilityReason for stored properties.
   ExportabilityReason getVarDeclExportabilityReason() const {
-    return Where.getExportedLevel() == ExportedLevel::ImplicitlyExported
-               ? ExportabilityReason::ImplicitlyPublicVarDecl
-               : ExportabilityReason::PublicVarDecl;
+    // If explicit use library-evolution style reason.
+    if (Where.getExportedLevel() != ExportedLevel::ImplicitlyExported)
+      return ExportabilityReason::PublicVarDecl;
+
+    // Reasons specific to classes in non-library-evolution mode or embedded.
+    auto *CD = dyn_cast_or_null<ClassDecl>(Where.getDeclContext()->getAsDecl());
+    if (CD) {
+      if (CD->getFormalAccess() == AccessLevel::Open)
+        return ExportabilityReason::ImplicitlyPublicVarDeclOpenClass;
+    }
+
+    return ExportabilityReason::ImplicitlyPublicVarDecl;
   }
 
   void checkAvailabilityDomains(const Decl *D) {

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -2298,6 +2298,13 @@ public:
     }
   }
 
+  /// Pick the appropriate \c ExportabilityReason for stored properties.
+  ExportabilityReason getVarDeclExportabilityReason() const {
+    return Where.getExportedLevel() == ExportedLevel::ImplicitlyExported
+               ? ExportabilityReason::ImplicitlyPublicVarDecl
+               : ExportabilityReason::PublicVarDecl;
+  }
+
   void checkAvailabilityDomains(const Decl *D) {
     D = D->getAbstractSyntaxDeclForAttributes();
 
@@ -2396,10 +2403,7 @@ public:
     if (seenVars.count(theVar))
       return;
 
-    ExportabilityReason reason =
-      Where.getExportedLevel() == ExportedLevel::ImplicitlyExported ?
-        ExportabilityReason::ImplicitlyPublicVarDecl :
-        ExportabilityReason::PublicVarDecl;
+    auto reason = getVarDeclExportabilityReason();
     checkType(theVar->getValueInterfaceType(), /*typeRepr*/nullptr, theVar,
               reason);
 
@@ -2422,10 +2426,7 @@ public:
       anyVar = V;
     });
 
-    ExportabilityReason reason =
-      Where.getExportedLevel() == ExportedLevel::ImplicitlyExported ?
-        ExportabilityReason::ImplicitlyPublicVarDecl :
-        ExportabilityReason::PublicVarDecl;
+    auto reason = getVarDeclExportabilityReason();
     checkType(TP->hasType() ? TP->getType() : Type(),
               TP->getTypeRepr(), anyVar ? (Decl *)anyVar : (Decl *)PBD,
               reason);

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -87,6 +87,7 @@ enum class ExportabilityReason : unsigned {
   PublicVarDecl,
   ImplicitlyPublicVarDecl,
   ImplicitlyPublicVarDeclOpenClass,
+  ImplicitlyPublicVarDeclClassDeinit,
   AssociatedValue,
   ImplicitlyPublicAssociatedValue,
 };

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -86,6 +86,7 @@ enum class ExportabilityReason : unsigned {
   AvailableAttribute,
   PublicVarDecl,
   ImplicitlyPublicVarDecl,
+  ImplicitlyPublicVarDeclOpenClass,
   AssociatedValue,
   ImplicitlyPublicAssociatedValue,
 };

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -3014,7 +3014,7 @@ static bool requiresCorrespondingUnderscoredCoroutineAccessorImpl(
   }
 
   // Non-exported storage has no ABI to keep stable.
-  if (isExported(storage) == ExportedLevel::None)
+  if (isExported(storage) != ExportedLevel::Exported)
     return false;
 
   // The non-underscored accessor is not present, the underscored accessor

--- a/test/ClangImporter/InternalBridgingHeader/exportability_checking_objc.swift
+++ b/test/ClangImporter/InternalBridgingHeader/exportability_checking_objc.swift
@@ -609,6 +609,9 @@ public class PublicClassUser {
 
   @export(interface)
   private func privateFunc(h: HiddenLayout) {}
+
+  @export(interface)
+  deinit {}
 }
 
 open class OpenClassUser {
@@ -616,33 +619,36 @@ open class OpenClassUser {
   public init() { fatalError() }
 
   private var ta: TA
-  // expected-non-library-evolution-error @-1 {{'TA' aliases '__ObjC.RestrictedType' and cannot be used in a property declaration member of a type not marked '@_implementationOnly' because it was imported via the internal bridging header}}
+  // expected-non-library-evolution-error @-1 {{'TA' aliases '__ObjC.RestrictedType' and cannot be used in a property declaration member of an open class because it was imported via the internal bridging header}}
 
   public var publicField: RestrictedType
   // expected-error @-1 {{property cannot be declared public because its type uses an internal type}}
   // expected-note @-2 {{struct 'RestrictedType' is imported by this file as 'internal' from bridging header}}
 
   private var privateField: RestrictedType
-  // expected-non-library-evolution-error @-1 {{cannot use struct 'RestrictedType' in a property declaration member of a type not marked '@_implementationOnly'; it was imported via the internal bridging header}}
+  // expected-non-library-evolution-error @-1 {{cannot use struct 'RestrictedType' in a property declaration member of an open class; it was imported via the internal bridging header}}
   private var a: ExposedLayoutPublic
   private var aa: ExposedLayoutInternal
   private var b: ExposedLayoutPrivate
   private var c: HiddenLayout
-  // expected-non-library-evolution-error @-1 {{cannot use struct 'HiddenLayout' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenLayout' is marked '@_implementationOnly'}}
+  // expected-non-library-evolution-error @-1 {{cannot use struct 'HiddenLayout' in a property declaration member of an open class; 'HiddenLayout' is marked '@_implementationOnly'}}
 
   private var d: ExposedEnumPublic
   private var e: ExposedEnumPrivate
   private var f: HiddenEnum
-  // expected-non-library-evolution-error @-1 {{cannot use enum 'HiddenEnum' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenEnum' is marked '@_implementationOnly'}}
+  // expected-non-library-evolution-error @-1 {{cannot use enum 'HiddenEnum' in a property declaration member of an open class; 'HiddenEnum' is marked '@_implementationOnly'}}
 
   private var g: ExposedProtocolPublic
   private var h: ExposedProtocolInternal
   private var i: ExposedProtocolPrivate
   private var j: HiddenProtocol
-  // expected-non-library-evolution-error @-1 {{cannot use protocol 'HiddenProtocol' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenProtocol' is marked '@_implementationOnly'}}
+  // expected-non-library-evolution-error @-1 {{cannot use protocol 'HiddenProtocol' in a property declaration member of an open class; 'HiddenProtocol' is marked '@_implementationOnly'}}
 
   @export(interface)
   private func privateFunc(h: HiddenLayout) {}
+
+  @export(interface)
+  deinit {}
 }
 
 @_fixed_layout
@@ -689,6 +695,9 @@ public class FixedClassUser {
 
   @export(interface)
   private func privateFunc(h: HiddenLayout) {}
+
+  @export(interface)
+  deinit {}
 }
 
 internal class InternalClassUser {
@@ -715,6 +724,9 @@ internal class InternalClassUser {
   private var j: HiddenProtocol
 
   private func privateFunc(h: HiddenLayout) {} // expected-embedded-error {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
+
+  @export(interface)
+  deinit {}
 }
 
 private class PrivateClassUser {
@@ -741,6 +753,9 @@ private class PrivateClassUser {
   private var j: HiddenProtocol
 
   private func privateFunc(h: HiddenLayout) {} // expected-embedded-error {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
+
+  @export(interface)
+  deinit {}
 }
 
 @_implementationOnly

--- a/test/Sema/hidden-memory-layout.swift
+++ b/test/Sema/hidden-memory-layout.swift
@@ -38,6 +38,7 @@
 // RUN: %target-swift-frontend -emit-module -verify -verify-ignore-unrelated %s -I %t \
 // RUN:   -swift-version 6 -target arm64-apple-none-macho \
 // RUN:   -enable-experimental-feature Embedded \
+// RUN:   -verify-additional-prefix embedded-not-opt-in- \
 // RUN:   -verify-additional-prefix embedded- \
 // RUN:   -verify-additional-prefix not-opt-in-
 
@@ -112,6 +113,7 @@ private struct HiddenLayout {
 // expected-note @-2 1 {{initializer 'init()' is not '@usableFromInline' or public}}
 // expected-note @-3 9 {{struct declared here}}
 // expected-note @-4 4 {{type declared here}}
+// expected-embedded-note @-5 1 {{struct declared here}}
 }
 
 public enum ExposedEnumPublic {
@@ -132,6 +134,7 @@ private enum HiddenEnum {
 // expected-note @-1 6 {{enum declared here}}
 // expected-note @-2 2 {{enum 'HiddenEnum' is not '@usableFromInline' or public}}
 // expected-note @-3 2 {{type declared here}}
+// expected-embedded-note @-4 1 {{enum declared here}}
   case A
 // expected-note @-1 {{enum case 'A' is not '@usableFromInline' or public}}
   case B
@@ -155,6 +158,7 @@ private protocol HiddenProtocol {
 // expected-note @-1 {{protocol 'HiddenProtocol' is not '@usableFromInline' or public}}
 // expected-note @-2 9 {{protocol declared here}}
 // expected-note @-3 4 {{type declared here}}
+// expected-embedded-note @-4 1 {{protocol declared here}}
 }
 
 @_spi(S) public struct SPIStruct {}
@@ -665,6 +669,42 @@ public class PublicClassUser: ProtocolFromDirect {
 
   @export(interface)
   private func privateFunc(h: HiddenLayout) {}
+
+  @export(interface)
+  deinit {}
+}
+
+public class PublicClassUserWithoutDeinit: ProtocolFromDirect {
+// expected-error @-1 {{cannot use protocol 'ProtocolFromDirect' in a public or '@usableFromInline' conformance; 'directs' has been imported as implementation-only}}
+
+  public init() { fatalError() }
+
+  private var ta: TA
+  // expected-embedded-not-opt-in-warning @-1 {{'TA' aliases 'directs.StructFromDirect' and cannot be used in a property declaration member of a class without the required '@export(interface)' deinit in Embedded because 'directs' has been imported as implementation-only}}
+  // expected-embedded-opt-in-error @-2 {{'TA' aliases 'directs.StructFromDirect' and cannot be used in a property declaration member of a class without the required '@export(interface)' deinit in Embedded because 'directs' has been imported as implementation-only}}
+
+  public var publicField: StructFromDirect
+  // expected-error @-1 {{cannot use struct 'StructFromDirect' in a property declaration marked public or in a '@frozen' or '@usableFromInline' context; 'directs' has been imported as implementation-only}}
+
+  private var privateField: StructFromDirect
+  // expected-embedded-not-opt-in-warning @-1 {{cannot use struct 'StructFromDirect' in a property declaration member of a class without the required '@export(interface)' deinit in Embedded; 'directs' has been imported as implementation-only}}
+  // expected-embedded-opt-in-error @-2 {{cannot use struct 'StructFromDirect' in a property declaration member of a class without the required '@export(interface)' deinit in Embedded; 'directs' has been imported as implementation-only}}
+  private var a: ExposedLayoutPublic
+  private var aa: ExposedLayoutInternal
+  private var b: ExposedLayoutPrivate
+  private var c: HiddenLayout
+  // expected-embedded-error @-1 {{cannot use struct 'HiddenLayout' in a property declaration member of a class without the required '@export(interface)' deinit in Embedded; 'HiddenLayout' is marked '@_implementationOnly'}}
+
+  private var d: ExposedEnumPublic
+  private var e: ExposedEnumPrivate
+  private var f: HiddenEnum
+  // expected-embedded-error @-1 {{cannot use enum 'HiddenEnum' in a property declaration member of a class without the required '@export(interface)' deinit in Embedded; 'HiddenEnum' is marked '@_implementationOnly'}}
+
+  private var g: ExposedProtocolPublic
+  private var h: ExposedProtocolInternal
+  private var i: ExposedProtocolPrivate
+  private var j: HiddenProtocol
+  // expected-embedded-error @-1 {{cannot use protocol 'HiddenProtocol' in a property declaration member of a class without the required '@export(interface)' deinit in Embedded; 'HiddenProtocol' is marked '@_implementationOnly'}}
 }
 
 open class OpenClassUser: ProtocolFromDirect {
@@ -701,6 +741,9 @@ open class OpenClassUser: ProtocolFromDirect {
 
   @export(interface)
   private func privateFunc(h: HiddenLayout) {}
+
+  @export(interface)
+  deinit {}
 }
 
 @_fixed_layout
@@ -773,6 +816,9 @@ internal class InternalClassUser: ProtocolFromDirect {
   private var j: HiddenProtocol
 
   private func privateFunc(h: HiddenLayout) {} // expected-embedded-error {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
+
+  @export(interface)
+  deinit {}
 }
 
 private class PrivateClassUser: ProtocolFromDirect {
@@ -801,6 +847,9 @@ private class PrivateClassUser: ProtocolFromDirect {
   private var j: HiddenProtocol
 
   private func privateFunc(h: HiddenLayout) {} // expected-embedded-error {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
+
+  @export(interface)
+  deinit {}
 }
 
 @_implementationOnly

--- a/test/Sema/hidden-memory-layout.swift
+++ b/test/Sema/hidden-memory-layout.swift
@@ -673,31 +673,31 @@ open class OpenClassUser: ProtocolFromDirect {
   public init() { fatalError() }
 
   private var ta: TA
-  // expected-opt-in-error @-1 {{'TA' aliases 'directs.StructFromDirect' and cannot be used in a property declaration member of a type not marked '@_implementationOnly' because 'directs' has been imported as implementation-only}}
-  // expected-not-opt-in-warning @-2 {{'TA' aliases 'directs.StructFromDirect' and cannot be used in a property declaration member of a type not marked '@_implementationOnly' because 'directs' has been imported as implementation-only}}
+  // expected-opt-in-error @-1 {{'TA' aliases 'directs.StructFromDirect' and cannot be used in a property declaration member of an open class because 'directs' has been imported as implementation-only}}
+  // expected-not-opt-in-warning @-2 {{'TA' aliases 'directs.StructFromDirect' and cannot be used in a property declaration member of an open class because 'directs' has been imported as implementation-only}}
 
   public var publicField: StructFromDirect
   // expected-error @-1 {{cannot use struct 'StructFromDirect' in a property declaration marked public or in a '@frozen' or '@usableFromInline' context; 'directs' has been imported as implementation-only}}
 
   private var privateField: StructFromDirect
-  // expected-opt-in-error @-1 {{cannot use struct 'StructFromDirect' in a property declaration member of a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
-  // expected-not-opt-in-warning @-2 {{cannot use struct 'StructFromDirect' in a property declaration member of a type not marked '@_implementationOnly'; 'directs' has been imported as implementation-only}}
+  // expected-opt-in-error @-1 {{cannot use struct 'StructFromDirect' in a property declaration member of an open class; 'directs' has been imported as implementation-only}}
+  // expected-not-opt-in-warning @-2 {{cannot use struct 'StructFromDirect' in a property declaration member of an open class; 'directs' has been imported as implementation-only}}
   private var a: ExposedLayoutPublic
   private var aa: ExposedLayoutInternal
   private var b: ExposedLayoutPrivate
   private var c: HiddenLayout
-  // expected-error @-1 {{cannot use struct 'HiddenLayout' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenLayout' is marked '@_implementationOnly'}}
+  // expected-error @-1 {{cannot use struct 'HiddenLayout' in a property declaration member of an open class; 'HiddenLayout' is marked '@_implementationOnly'}}
 
   private var d: ExposedEnumPublic
   private var e: ExposedEnumPrivate
   private var f: HiddenEnum
-  // expected-error @-1 {{cannot use enum 'HiddenEnum' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenEnum' is marked '@_implementationOnly'}}
+  // expected-error @-1 {{cannot use enum 'HiddenEnum' in a property declaration member of an open class; 'HiddenEnum' is marked '@_implementationOnly'}}
 
   private var g: ExposedProtocolPublic
   private var h: ExposedProtocolInternal
   private var i: ExposedProtocolPrivate
   private var j: HiddenProtocol
-  // expected-error @-1 {{cannot use protocol 'HiddenProtocol' in a property declaration member of a type not marked '@_implementationOnly'; 'HiddenProtocol' is marked '@_implementationOnly'}}
+  // expected-error @-1 {{cannot use protocol 'HiddenProtocol' in a property declaration member of an open class; 'HiddenProtocol' is marked '@_implementationOnly'}}
 
   @export(interface)
   private func privateFunc(h: HiddenLayout) {}

--- a/test/Sema/hidden-memory-layout.swift
+++ b/test/Sema/hidden-memory-layout.swift
@@ -676,6 +676,7 @@ public class PublicClassUser: ProtocolFromDirect {
 
 public class PublicClassUserWithoutDeinit: ProtocolFromDirect {
 // expected-error @-1 {{cannot use protocol 'ProtocolFromDirect' in a public or '@usableFromInline' conformance; 'directs' has been imported as implementation-only}}
+// expected-embedded-note @-2 4 {{add a '@export(interface)' deinit to the class for properties to reference a hidden dependency. This is a restriction in Embedded mode.}}
 
   public init() { fatalError() }
 


### PR DESCRIPTION
Even without library-evolution, we allow references to hidden dependencies from class properties as long as the class is not marked open. In embedded, references from functions are only accepted when marked `@export(interface)` as it can't be inlined in clients otherwise.

Combine both requirements to protect the implicitly generated destructor as well. Add a requirement for classes with such a property to explicitly declare a `@export(interface)` deinit. Otherwise the synthesized deinit can be inlined in clients and cause a deserialization failure.

rdar://170855491