### PR TITLE
[Sema] Let lazy storage inherit original variable isolation

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6086,7 +6086,7 @@ ERROR(non_concurrent_type_member,none,
       (Type, bool, DeclName, const ValueDecl *, bool))
 ERROR(concurrent_value_class_mutable_property,none,
       "stored property %0 of 'Sendable'-conforming %kind1 is mutable",
-      (DeclName, const ValueDecl *))
+      (const ValueDecl *, const ValueDecl *))
 ERROR(concurrent_value_outside_source_file,none,
       "conformance to 'Sendable' must occur in the same source file as "
       "%kind0; use '@unchecked Sendable' for retroactive conformance",

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6307,6 +6307,16 @@ static InferredActorIsolation computeActorIsolation(Evaluator &evaluator,
       };
   }
 
+  // If this declaration is lazy storage, it has the same isolation as the
+  // original variable. Use the evaluator to cache and avoid running
+  // addAttributesForActorIsolation on the original variable a second time,
+  // duplicating attributes.
+  if (auto var = dyn_cast<VarDecl>(value))
+    if (var->isLazyStorageProperty())
+      if (auto originalVar = var->getOriginalVarForBackingStorage())
+        return evaluateOrDefault(evaluator, ActorIsolationRequest{originalVar},
+                                 InferredActorIsolation::forUnspecified());
+
   auto isolationFromAttr = getIsolationFromAttributes(value);
   ASTContext &ctx = value->getASTContext();
 
@@ -7142,7 +7152,10 @@ static bool checkSendableInstanceStorage(
           if (behavior != DiagnosticBehavior::Ignore) {
             property
                 ->diagnose(diag::concurrent_value_class_mutable_property,
-                           property->getName(), nominal)
+                           property->isLazyStorageProperty()
+                               ? property->getOriginalVarForBackingStorage()
+                               : property,
+                           nominal)
                 .limitBehaviorWithPreconcurrency(behavior, preconcurrency);
           }
           invalid = invalid || (behavior == DiagnosticBehavior::Unspecified);

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -1471,6 +1471,26 @@ final class MainActorInit: Sendable {
   func f() {}
 }
 
+final class Exponentiator: Sendable {
+  @MainActor
+  var numbers: [Int]
+
+  init(_ numbers: [Int]) {
+    self.numbers = numbers
+  }
+
+  @MainActor
+  lazy var squared: [Int] = {
+    numbers.map { $0 * $0 }
+  }()
+
+  // expected-warning@+2 {{stored property 'cubed' of 'Sendable'-conforming class 'Exponentiator' is mutable; this is an error in the Swift 6 language mode}}
+  // expected-warning@+1 {{main actor-isolated default value in a nonisolated context}}
+  lazy var cubed: [Int] = {
+    zip(squared, numbers).map { $0 * $1 }
+  }()
+}
+
 actor DunkTracker {
   private var lebron: Int?
   private var curry: Int? // expected-note {{property declared here}}


### PR DESCRIPTION
Fixes rdar://156415458 by adding a case to computeActorIsolation to give a lazy storage property the same isolation as the original variable.

```swift
final class Exponentiator: Sendable {
  @MainActor
  var numbers: [Int]

  init(_ numbers: [Int]) {
    self.numbers = numbers
  }

  @MainActor
  lazy var squared: [Int] = {
    numbers.map { $0 * $0 }
  }()

  lazy var cubed: [Int] = {
    zip(squared, numbers).map { $0 * $1 }
  }()
}
```
```
debug-files/lazy_sending.swift:14:12: error: main actor-isolated default value in a nonisolated context
12 |   }()
13 |
14 |   lazy var cubed: [Int] = {
   |            `- error: main actor-isolated default value in a nonisolated context
15 |     zip(squared, numbers).map { $0 * $1 }
16 |   }()

debug-files/lazy_sending.swift:14:12: error: lazy stored property 'cubed' of 'Sendable'-conforming class 'Exponentiator' is mutable
12 |   }()
13 |
14 |   lazy var cubed: [Int] = {
   |            `- error: lazy stored property 'cubed' of 'Sendable'-conforming class 'Exponentiator' is mutable
15 |     zip(squared, numbers).map { $0 * $1 }
16 |   }()
```

```swift
  lazy var moreNumbers: [Int] = {
	[1, 2, 3, 4]
  }()
```
```
debug-files/lazy_sending.swift:18:12: error: lazy stored property 'moreNumbers' of 'Sendable'-conforming class 'Exponentiator' is mutable
16 |   // }()
17 |
18 |   lazy var moreNumbers: [Int] = {
   |            `- error: lazy stored property 'moreNumbers' of 'Sendable'-conforming class 'Exponentiator' is mutable
19 |    [1, 2, 3, 4]
20 |   }()
```

Having multiple instances of `concurrent_value_class_mutable_property` seems to only diagnose one...

Before this change, an error would also have been reported on squared, even though it was main actor isolated.
