### PR TITLE
Time to retire building multi-architecture toolchains by default?

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1468,9 +1468,6 @@ wasmkit
 release-debuginfo
 compiler-vendor=apple
 
-# Cross compile for Apple Silicon
-infer-cross-compile-hosts-on-darwin
-
 lldb-use-system-debugserver
 lldb-build-type=Release
 build-ninja
@@ -1684,6 +1681,18 @@ skip-test-indexstore-db
 [preset: buildbot_osx_package,no_test]
 mixin-preset=
     buildbot_osx_package
+    mixin_buildbot_osx_package,no_test
+
+[preset: buildbot_osx_package,multi_arch]
+mixin-preset=
+    buildbot_osx_package
+# Cross compile for Apple Silicon
+infer-cross-compile-hosts-on-darwin
+
+# build multiple architecture
+[preset: buildbot_osx_package,no_test,multi_arch]
+mixin-preset=
+    buildbot_osx_package,multi_arch
     mixin_buildbot_osx_package,no_test
 
 # macOS package with out test

--- a/utils/build-toolchain
+++ b/utils/build-toolchain
@@ -29,6 +29,9 @@ function usage() {
   echo "-a --no-assert"
   echo "No assertions"
   echo ""
+  echo "-m --multi-arch"
+  echo "Build toolchain for Intel as well as Apple Silicon"
+  echo ""
   echo "--distcc"
   echo "Build with distcc to speed up the toolchain build"
   echo ""
@@ -112,6 +115,9 @@ while [ $# -ne 0 ]; do
     -a|--no-assert)
       NO_ASSERTIONS=",no_assertions"
   ;;
+    -m|--multi-arch)
+      MULTI_ARCH=",multi_arch"
+  ;;
   -h|--help)
     usage
     exit 0
@@ -162,7 +168,7 @@ SCCACHE_FLAG="${SCCACHE_FLAG}"
 
 ./utils/build-script ${DRY_RUN} ${DISTCC_FLAG} ${PRESET_FILE_FLAGS} \
         ${SCCACHE_FLAG} \
-        --preset="${PRESET_PREFIX}${SWIFT_PACKAGE}${NO_ASSERTIONS}${NO_TEST}${USE_OS_RUNTIME}${MACOS_ONLY}" \
+        --preset="${PRESET_PREFIX}${SWIFT_PACKAGE}${NO_ASSERTIONS}${NO_TEST}${USE_OS_RUNTIME}${MACOS_ONLY}${MULTI_ARCH}" \
         install_destdir="${SWIFT_INSTALL_DIR}" \
         installable_package="${SWIFT_INSTALLABLE_PACKAGE}" \
         install_toolchain_dir="${SWIFT_TOOLCHAIN_DIR}" \


### PR DESCRIPTION
This PR arises out of a [discussion on the swift forums](https://forums.swift.org/t/unable-to-build-toolchain-due-to-thin-libzstd-dylib) where it has become difficult to build a toolchain using the script swift/utils/build-toolchain. This is because the listed dependancies no longer ship multi-architecture by default. Has the time come to not build multi-architecture by default by removing infer-cross-compile-hosts-on-darwin from the default buildbot_osx_package preset and mix it in on demand for when people actually need/want it (for example the overnight toolchain builds). 

For other builds from the command line and including those started during review of PRs to this repo I'm sure people would rather have their results in half the time than include an Intel slice which few can be using 6 years on from the migration to Apple Silicon. cc: @shahmishal 
