### PR TITLE
[Backtracing] Reorganise thread locals.

### DIFF
--- a/Runtimes/Supplemental/Runtime/CMakeLists.txt
+++ b/Runtimes/Supplemental/Runtime/CMakeLists.txt
@@ -128,6 +128,7 @@ if(${PROJECT_NAME}_ENABLE_BACKTRACING)
     Backtrace+Codable.swift
     BacktraceFormatter.swift
     BacktraceJSONFormatter.swift
+    BacktracerThreadLocals.swift
     Base64.swift
     ByteSwapping.swift
     CachingMemoryReader.swift

--- a/stdlib/public/RuntimeModule/BacktracerThreadLocals.swift
+++ b/stdlib/public/RuntimeModule/BacktracerThreadLocals.swift
@@ -1,0 +1,79 @@
+//===--- BacktracerThreadLocals.swift - TLS for Swift Backtracer ----------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Holds thread-local storage for the Swift Backtracer
+//
+//===----------------------------------------------------------------------===//
+
+import Swift
+
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+internal import Darwin
+#elseif os(Windows)
+internal import WinSDK
+#elseif canImport(Glibc)
+internal import Glibc
+#elseif canImport(Musl)
+internal import Musl
+#endif
+
+@available(Backtracing 6.2, *)
+final class BacktracerThreadLocals {
+  lazy var elfImageCache = ElfImageCache()
+  lazy var peImageCache = PeImageCache()
+  lazy var defaultSymbolLocator = DefaultSymbolLocator()
+
+  #if os(Windows)
+  private static var dwTlsIndex: DWORD = {
+    let dwNdx = TlsAlloc()
+    if dwNdx == TLS_OUT_OF_INDEXES {
+      fatalError("Unable to allocate TSD for backtracer thread locals")
+    }
+    return dwNdx
+  }()
+  #else
+  private static var key: pthread_key_t = {
+    var theKey = pthread_key_t()
+    let err = pthread_key_create(
+      &theKey,
+      { rawPtr in
+        let ptr = Unmanaged<PeImageCache>.fromOpaque(
+          notMutable(notOptional(rawPtr))
+        )
+        ptr.release()
+      }
+    )
+    if err != 0 {
+      fatalError("Unable to create TSD key for backtracer thread locals")
+    }
+    return theKey
+  }()
+  #endif
+
+  static var threadLocal: BacktracerThreadLocals {
+    #if os(Windows)
+    guard let rawPtr = TlsGetValue(dwTlsIndex) else {
+      let locals = Unmanaged<BacktracerThreadLocals>.passRetained(BacktracerThreadLocals())
+      TlsSetValue(dwTlsIndex, locals.toOpaque())
+      return locals.takeUnretainedValue()
+    }
+    #else
+    guard let rawPtr = pthread_getspecific(key) else {
+      let locals = Unmanaged<BacktracerThreadLocals>.passRetained(BacktracerThreadLocals())
+      pthread_setspecific(key, locals.toOpaque())
+      return locals.takeUnretainedValue()
+    }
+    #endif
+    let locals = Unmanaged<BacktracerThreadLocals>.fromOpaque(rawPtr)
+    return locals.takeUnretainedValue()
+  }
+}

--- a/stdlib/public/RuntimeModule/CMakeLists.txt
+++ b/stdlib/public/RuntimeModule/CMakeLists.txt
@@ -37,6 +37,7 @@ set(backtracing_sources
   Backtrace+Codable.swift
   BacktraceFormatter.swift
   BacktraceJSONFormatter.swift
+  BacktracerThreadLocals.swift
   Base64.swift
   ByteSwapping.swift
   CachingMemoryReader.swift

--- a/stdlib/public/RuntimeModule/DefaultSymbolLocator.swift
+++ b/stdlib/public/RuntimeModule/DefaultSymbolLocator.swift
@@ -45,7 +45,9 @@ public class DefaultSymbolLocator: SymbolLocator {
   public typealias Image = SymbolLocator.Image
   public typealias ImageFormat = SymbolLocator.ImageFormat
 
-  public static let shared = DefaultSymbolLocator()
+  public static var shared: DefaultSymbolLocator {
+    return BacktracerThreadLocals.threadLocal.defaultSymbolLocator
+  }
 
   enum CacheKey: Equatable, Hashable {
     case path(String)

--- a/stdlib/public/RuntimeModule/ElfImageCache.swift
+++ b/stdlib/public/RuntimeModule/ElfImageCache.swift
@@ -17,16 +17,6 @@
 
 import Swift
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-internal import Darwin
-#elseif os(Windows)
-internal import WinSDK
-#elseif canImport(Glibc)
-internal import Glibc
-#elseif canImport(Musl)
-internal import Musl
-#endif
-
 /// Provides a per-thread image cache for ELF image processing.  This means
 /// if you take multiple backtraces from a thread, you won't load the same
 /// image multiple times.
@@ -67,48 +57,7 @@ final class ElfImageCache {
     return nil
   }
 
-  #if os(Windows)
-  private static var dwTlsIndex: DWORD = {
-    let dwNdx = TlsAlloc()
-    if dwNdx == TLS_OUT_OF_INDEXES {
-      fatalError("Unable to allocate TSD for ElfImageCache")
-    }
-    return dwNdx
-  }()
-  #else
-  private static var key: pthread_key_t = {
-    var theKey = pthread_key_t()
-    let err = pthread_key_create(
-      &theKey,
-      { rawPtr in
-        let ptr = Unmanaged<ElfImageCache>.fromOpaque(
-          notMutable(notOptional(rawPtr))
-        )
-        ptr.release()
-      }
-    )
-    if err != 0 {
-      fatalError("Unable to create TSD key for ElfImageCache")
-    }
-    return theKey
-  }()
-  #endif
-
   static var threadLocal: ElfImageCache {
-    #if os(Windows)
-    guard let rawPtr = TlsGetValue(dwTlsIndex) else {
-      let cache = Unmanaged<ElfImageCache>.passRetained(ElfImageCache())
-      TlsSetValue(dwTlsIndex, cache.toOpaque())
-      return cache.takeUnretainedValue()
-    }
-    #else
-    guard let rawPtr = pthread_getspecific(key) else {
-      let cache = Unmanaged<ElfImageCache>.passRetained(ElfImageCache())
-      pthread_setspecific(key, cache.toOpaque())
-      return cache.takeUnretainedValue()
-    }
-    #endif
-    let cache = Unmanaged<ElfImageCache>.fromOpaque(rawPtr)
-    return cache.takeUnretainedValue()
+    return BacktracerThreadLocals.threadLocal.elfImageCache
   }
 }

--- a/stdlib/public/RuntimeModule/PeImageCache.swift
+++ b/stdlib/public/RuntimeModule/PeImageCache.swift
@@ -17,16 +17,6 @@
 
 import Swift
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-internal import Darwin
-#elseif os(Windows)
-internal import WinSDK
-#elseif canImport(Glibc)
-internal import Glibc
-#elseif canImport(Musl)
-internal import Musl
-#endif
-
 /// Provides a per-thread image cache for PE-COFF image processing.  This means
 /// if you take multiple backtraces from a thread, you won't load the same
 /// image multiple times.
@@ -52,48 +42,7 @@ final class PeImageCache {
     return nil
   }
 
-  #if os(Windows)
-  private static var dwTlsIndex: DWORD = {
-    let dwNdx = TlsAlloc()
-    if dwNdx == TLS_OUT_OF_INDEXES {
-      fatalError("Unable to allocate TSD for PeImageCache")
-    }
-    return dwNdx
-  }()
-  #else
-  private static var key: pthread_key_t = {
-    var theKey = pthread_key_t()
-    let err = pthread_key_create(
-      &theKey,
-      { rawPtr in
-        let ptr = Unmanaged<PeImageCache>.fromOpaque(
-          notMutable(notOptional(rawPtr))
-        )
-        ptr.release()
-      }
-    )
-    if err != 0 {
-      fatalError("Unable to create TSD key for PeImageCache")
-    }
-    return theKey
-  }()
-  #endif
-
   static var threadLocal: PeImageCache {
-    #if os(Windows)
-    guard let rawPtr = TlsGetValue(dwTlsIndex) else {
-      let cache = Unmanaged<PeImageCache>.passRetained(PeImageCache())
-      TlsSetValue(dwTlsIndex, cache.toOpaque())
-      return cache.takeUnretainedValue()
-    }
-    #else
-    guard let rawPtr = pthread_getspecific(key) else {
-      let cache = Unmanaged<PeImageCache>.passRetained(PeImageCache())
-      pthread_setspecific(key, cache.toOpaque())
-      return cache.takeUnretainedValue()
-    }
-    #endif
-    let cache = Unmanaged<PeImageCache>.fromOpaque(rawPtr)
-    return cache.takeUnretainedValue()
+    return BacktracerThreadLocals.threadLocal.peImageCache
   }
 }


### PR DESCRIPTION
Reorganise the thread locals for the backtracing code in the `Runtime` module so that there’s only one set of them, with everything else hanging off that. This also reduces code duplication and consumption of thread local variable space.

Fix the `DefaultSymbolLocator`’s shared instance to be thread local.

rdar://171432566
