### PR TITLE
[Frontend] don't free AST context early with -verify

### DIFF
--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1990,6 +1990,13 @@ static void freeASTContextIfPossible(CompilerInstance &Instance) {
     return;
   }
 
+  // DiagnosticVerifier hasn't run yet. Freeing the AST context will free the
+  // source buffers.
+  if (Instance.getInvocation().getDiagnosticOptions().VerifyMode !=
+      DiagnosticOptions::NoVerify) {
+    return;
+  }
+
   // Make sure to perform the end of pipeline actions now, because they need
   // access to the ASTContext.
   performEndOfPipelineActions(Instance);

--- a/test/Interop/Cxx/swiftify-import/span-in-ctor.swift
+++ b/test/Interop/Cxx/swiftify-import/span-in-ctor.swift
@@ -2,12 +2,8 @@
 
 // RUN: rm -rf %t
 // RUN: split-file %s %t
-// RUN: %target-swift-frontend -c -plugin-path %swift-plugin-dir -I %t/Inputs -Xcc -std=c++20 -cxx-interoperability-mode=default %t/method.swift -dump-macro-expansions -verify 2>&1 | %FileCheck %s
-
-// CHECK: @_alwaysEmitIntoClient 
-// CHECK: public init(_ sp: Span<CInt>) {
-// CHECK:    unsafe self.init(IntSpan(sp))
-// CHECK: }
+// RUN: %target-swift-frontend -c -plugin-path %swift-plugin-dir -I %t%{fs-sep}Inputs -Xcc -std=c++20 -cxx-interoperability-mode=default %t/method.swift \
+// RUN:   -Rmacro-expansions -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}method.h -suppress-notes
 
 
 //--- Inputs/module.modulemap
@@ -17,7 +13,6 @@ module Method {
 }
 
 //--- Inputs/method.h
-
 #include <span>
 
 using IntSpan = std::span<const int>;
@@ -25,6 +20,13 @@ using IntSpan = std::span<const int>;
 class Foo {
 public:
    Foo();
+// expected-expansion@+7:18{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_disfavoredOverload|}}
+//   expected-remark@3{{macro content: |public init(_ sp: Span<CInt>) {|}}
+//   expected-remark@4{{macro content: |    unsafe self.init(IntSpan(sp))|}}
+//   expected-remark@5{{macro content: |}|}}
+// }}
    Foo(IntSpan sp [[clang::noescape]]);
 };
 


### PR DESCRIPTION
This new version of test/Interop/Cxx/swiftify-import/span-in-ctor.swift would trigger a UAF when it combined -verify with running the entire compilation pipeline.