### PR TITLE
[cxx-interop] [test] Disable contiguous iterator test on distros with old libstdc++

### DIFF
--- a/test/Interop/Cxx/stdlib/overlay/custom-iterator-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-iterator-typechecker.swift
@@ -1,10 +1,14 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -suppress-notes -I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++20 -DCPP20 -verify-additional-prefix cpp20-
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -suppress-notes -I %S/Inputs -cxx-interoperability-mode=default
-
 // Check whether each of the custom iterator types in Inputs/custom-iterator.h
 // conform to the various iterator protocols from the C++ overlay.
 //
 // Note that we only detect contiguous iterator when C++'20 is enabled.
+// This is disabled for some distributions that are known to lack support for
+// contiguous iterators.
+//
+// RUN: %if !(LinuxDistribution=ubuntu-20.04 || LinuxDistribution=amzn-2) %{ \
+// RUN:   %target-typecheck-verify-swift -verify-ignore-unrelated -suppress-notes -I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++20 -DCPP20 -verify-additional-prefix cpp20- \
+// RUN: %}
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -suppress-notes -I %S/Inputs -cxx-interoperability-mode=default
 
 import CustomIterator
 


### PR DESCRIPTION
This test was added in #87268 but it did not account for the fact that we run CI on machines that don't support contiguous iterator.