### PR TITLE
ModuleInterface: Handle custom availability domains for synthesized conformances

### DIFF
--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -456,10 +456,9 @@ class InheritedProtocolCollector {
       for (auto nextAttr : D->getSemanticAvailableAttrs()) {
         // FIXME: This is just approximating the effects of nested availability
         // attributes for the same platform; formally they'd need to be merged.
-        // FIXME: [availability] This should compare availability domains.
         bool alreadyHasMoreSpecificAttrForThisPlatform = llvm::any_of(
             *cache, [nextAttr](SemanticAvailableAttr existingAttr) {
-              return existingAttr.getPlatform() == nextAttr.getPlatform();
+              return existingAttr.getDomain() == nextAttr.getDomain();
             });
         if (alreadyHasMoreSpecificAttrForThisPlatform)
           continue;
@@ -695,7 +694,7 @@ public:
     if (!printOptions.shouldPrint(nominal))
       return;
 
-    /// is this nominal specifically an 'actor' or 'distributed actor'?
+    // Is this nominal specifically an 'actor' or 'distributed actor'?
     bool anyActorClass = false;
     if (auto klass = dyn_cast<ClassDecl>(nominal)) {
       anyActorClass = klass->isAnyActor();

--- a/test/ModuleInterface/availability_custom_domains.swift
+++ b/test/ModuleInterface/availability_custom_domains.swift
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-swift-emit-module-interface(%t/Test.swiftinterface) %s \
+// RUN:   -target %target-swift-5.1-abi-triple \
 // RUN:   -I %S/../Inputs/custom-modules/availability-domains \
 // RUN:   -enable-experimental-feature CustomAvailability \
 // RUN:   -module-name Test
@@ -28,3 +29,32 @@ public func availableInColorado() { }
 @available(Arctic, unavailable)
 @available(Pacific)
 public func unavailableInArcticButAvailableInPacific() { }
+
+// CHECK:      @available(Colorado)
+// CHECK-NEXT: @available(Pacific)
+// CHECK-NEXT: @_Concurrency::MainActor public class AvailableInColoradoAndPacificMainActorClass
+@available(Colorado)
+@available(Pacific)
+@MainActor
+public class AvailableInColoradoAndPacificMainActorClass { }
+
+// CHECK:      @available(Colorado)
+// CHECK-NEXT: @available(Pacific)
+// CHECK-NEXT: public enum AvailableInColoradoAndPacificEquatableEnum
+@available(Colorado)
+@available(Pacific)
+public enum AvailableInColoradoAndPacificEquatableEnum {
+  case a
+}
+
+// CHECK:      @available(Colorado)
+// CHECK-NEXT: @available(Pacific)
+// CHECK-NEXT: extension Test::AvailableInColoradoAndPacificMainActorClass : Swift::Sendable {}
+
+// CHECK:      @available(Colorado)
+// CHECK-NEXT: @available(Pacific)
+// CHECK-NEXT: extension Test::AvailableInColoradoAndPacificEquatableEnum : Swift::Equatable {}
+
+// CHECK:      @available(Colorado)
+// CHECK-NEXT: @available(Pacific)
+// CHECK-NEXT: extension Test::AvailableInColoradoAndPacificEquatableEnum : Swift::Hashable {}


### PR DESCRIPTION
When gathering availability attributes to print in a .swiftinterface for synthesized conformances to inherited protocols, don't assume availabilty attributes always have a platform kind.

Resolves rdar://170361240.
