### PR TITLE
[Availability] Update existing @available fix-it for #57378

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7249,6 +7249,9 @@ NOTE(availability_guard_with_version_check, none,
 NOTE(availability_add_attribute, none,
      "add '@available' attribute to enclosing %kindonly0", (const Decl *))
 
+NOTE(availability_update_attribute, none,
+     "update '@available' attribute on enclosing %kindonly0", (const Decl *))
+
 ERROR(availability_inout_accessor_only_in, none,
       "cannot pass as inout because %0 is only available in %1"
       "%select{| %3 or newer}2",

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -692,14 +692,6 @@ static void fixAvailabilityForDecl(
   if (TypeChecker::diagnosticIfDeclCannotBePotentiallyUnavailable(D).has_value())
     return;
 
-  // Don't suggest adding an @available attribute to a declaration that already
-  // has one that is active for the given domain.
-  // FIXME: Emit a fix-it to adjust the existing attribute instead.
-  if (D->hasAnyMatchingActiveAvailableAttr([&](SemanticAvailableAttr attr) {
-        return attr.getDomain().isRelated(Domain);
-      }))
-    return;
-
   // For some declarations (variables, enum elements), the location in concrete
   // syntax to suggest the Fix-It may differ from the declaration to which
   // we attach availability attributes in the abstract syntax tree during
@@ -712,6 +704,30 @@ static void fixAvailabilityForDecl(
   if (isa<PatternBindingDecl>(DeclForDiagnostic)) {
     DeclForDiagnostic = D;
   }
+
+  // If there is already an active @available attribute for this domain,
+  // suggest updating the existing introduced version when it is less strict
+  // than the required availability.
+  bool hasRelatedActiveAvailabilityAttr = false;
+  for (auto attr : D->getSemanticAvailableAttrs()) {
+    if (!attr.isActive(Context) || !attr.getDomain().isRelated(Domain))
+      continue;
+    hasRelatedActiveAvailabilityAttr = true;
+
+    auto existingAvailability = attr.getIntroducedRange(Context);
+    auto existingVersionRange = attr.getIntroducedSourceRange();
+
+    if (Domain.isVersioned() && RequiredAvailability.hasMinimumVersion() &&
+        existingAvailability && existingVersionRange.isValid() &&
+        existingAvailability->isSupersetOf(RequiredAvailability)) {
+      D->diagnose(diag::availability_update_attribute, DeclForDiagnostic)
+          .fixItReplace(existingVersionRange,
+                        RequiredAvailability.getVersionString());
+      return;
+    }
+  }
+  if (hasRelatedActiveAvailabilityAttr)
+    return;
 
   SourceLoc InsertLoc =
       ConcDecl->getAttributeInsertionLoc(/*forModifier=*/false);

--- a/test/Availability/api-availability-only.swift
+++ b/test/Availability/api-availability-only.swift
@@ -8,6 +8,7 @@ public struct S {}
 
 @available(macOS 51, *)
 public func newFunc() {
+// expected-note@-1 {{update '@available' attribute on enclosing}}
   _ = S() // expected-error {{'S' is only available in}}
   // expected-note @-1 {{add 'if #available' version check}}
 }

--- a/test/Availability/availability_define.swift
+++ b/test/Availability/availability_define.swift
@@ -56,6 +56,7 @@ public func noOtherOSes() {}
 
 @available(_iOS53Aligned, *)
 func client() {
+// expected-note@-1 {{update '@available' attribute on enclosing global function}}
   onMacOS50()
   onMacOS51_0() // expected-error {{is only available in macOS 51.0 or newer}}
   // expected-note @-1 {{add 'if #available' version check}}

--- a/test/Availability/availability_swiftui.swift
+++ b/test/Availability/availability_swiftui.swift
@@ -13,3 +13,4 @@ class AnyColorBox: LessAvailable {} // Ok, exception specifically for AnyColorBo
 @available(macOS 10.15, *)
 @usableFromInline
 class OtherClass: LessAvailable {} // expected-error {{'LessAvailable' is only available in macOS 11 or newer; clients of 'SwiftUI' may have a lower deployment target}}
+// expected-note@-1 {{update '@available' attribute on enclosing}}

--- a/test/Availability/availability_target_min_inlining.swift
+++ b/test/Availability/availability_target_min_inlining.swift
@@ -208,6 +208,7 @@ public func deployedUseNoAvailable( // expected-note 5 {{add '@available' attrib
 
 @available(macOS 10.9, *)
 public func deployedUseBeforeInliningTarget(
+// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
@@ -237,6 +238,7 @@ public func deployedUseBeforeInliningTarget(
 
 @available(macOS 10.10, *)
 public func deployedUseAtInliningTarget(
+// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
@@ -266,6 +268,7 @@ public func deployedUseAtInliningTarget(
 
 @available(macOS 10.14.5, *)
 public func deployedUseBetweenTargets(
+// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
@@ -295,6 +298,7 @@ public func deployedUseBetweenTargets(
 
 @available(macOS 10.15, *)
 public func deployedUseAtDeploymentTarget(
+// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
@@ -635,6 +639,7 @@ public func spiDeployedUseNoAvailable( // expected-note 3 {{add '@available' att
 
 @available(macOS 10.9, *)
 @inlinable public func inlinedUseBeforeInliningTarget(
+// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
@@ -672,6 +677,7 @@ public func spiDeployedUseNoAvailable( // expected-note 3 {{add '@available' att
 
 @available(macOS 10.10, *)
 @inlinable public func inlinedUseAtInliningTarget(
+// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
@@ -709,6 +715,7 @@ public func spiDeployedUseNoAvailable( // expected-note 3 {{add '@available' att
 
 @available(macOS 10.14.5, *)
 @inlinable public func inlinedUseBetweenTargets(
+// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
@@ -742,6 +749,7 @@ public func spiDeployedUseNoAvailable( // expected-note 3 {{add '@available' att
 
 @available(macOS 10.15, *)
 @inlinable public func inlinedUseAtDeploymentTarget(
+// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
@@ -889,6 +897,7 @@ public func spiDeployedUseNoAvailable( // expected-note 3 {{add '@available' att
 
 @available(macOS 10.15, *)
 @inlinable public var inlinedAtDeploymentTargetGlobal: Any {
+// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
   _ = NoAvailable()
   _ = BeforeInliningTarget()
   _ = AtInliningTarget()
@@ -1039,6 +1048,7 @@ public func spiDeployedUseNoAvailable( // expected-note 3 {{add '@available' att
 @available(macOS 10.10, *)
 @backDeployed(before: macOS 999.0)
 public func backDeployedToInliningTarget(
+// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
@@ -1319,6 +1329,7 @@ public struct PublicStruct { // expected-note 21 {{add '@available' attribute}}
 
   @available(macOS 10.14, *)
   public internal(set) var internalSetter: Void {
+  // expected-note@-1 * {{update '@available' attribute on enclosing.*}}
     @inlinable get {
       // Public inlinable getter acts like @inlinable
       _ = NoAvailable()
@@ -1604,6 +1615,7 @@ extension BetweenTargets { // expected-note 2 {{add '@available' attribute to en
 
 @available(macOS 10.15, *)
 extension BetweenTargets {
+// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
   public func publicFuncInExtensionWithExplicitAvailability( // expected-note {{add '@available' attribute to enclosing instance method}}
     _: NoAvailable,
     _: BeforeInliningTarget,
@@ -1618,6 +1630,7 @@ extension BetweenTargets {
 extension BetweenTargets { // expected-note {{add '@available' attribute to enclosing extension}}
   @available(macOS 10.15, *)
   public func publicFuncWithExplicitAvailabilityInExtension(
+  // expected-note@-1 * {{update '@available' attribute on enclosing.*}}
     _: NoAvailable,
     _: BeforeInliningTarget,
     _: AtInliningTarget,
@@ -1670,6 +1683,7 @@ extension BetweenTargets {
 
 @available(macOS 10.10, *)
 extension BetweenTargets { // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}}
+// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
   public func publicFuncInExcessivelyAvailableExtension() {}
 }
 
@@ -1822,6 +1836,7 @@ public protocol NoAvailableProtoWithAssoc { // expected-note 3 {{add '@available
 
 @available(macOS 10.9, *)
 public protocol BeforeInliningTargetProtoWithAssoc {
+// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
   associatedtype A: NoAvailableProto
   associatedtype B: BeforeInliningTargetProto
   associatedtype C: AtInliningTargetProto
@@ -1836,6 +1851,7 @@ public protocol BeforeInliningTargetProtoWithAssoc {
 
 @available(macOS 10.10, *)
 public protocol AtInliningTargetProtoWithAssoc {
+// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
   associatedtype A: NoAvailableProto
   associatedtype B: BeforeInliningTargetProto
   associatedtype C: AtInliningTargetProto
@@ -1850,6 +1866,7 @@ public protocol AtInliningTargetProtoWithAssoc {
 
 @available(macOS 10.14.5, *)
 public protocol BetweenTargetsProtoWithAssoc {
+// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
   associatedtype A: NoAvailableProto
   associatedtype B: BeforeInliningTargetProto
   associatedtype C: AtInliningTargetProto
@@ -1863,6 +1880,7 @@ public protocol BetweenTargetsProtoWithAssoc {
 
 @available(macOS 10.15, *)
 public protocol AtDeploymentTargetProtoWithAssoc {
+// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
   associatedtype A: NoAvailableProto
   associatedtype B: BeforeInliningTargetProto
   associatedtype C: AtInliningTargetProto

--- a/test/Availability/availability_target_min_inlining.swift
+++ b/test/Availability/availability_target_min_inlining.swift
@@ -208,7 +208,7 @@ public func deployedUseNoAvailable( // expected-note 5 {{add '@available' attrib
 
 @available(macOS 10.9, *)
 public func deployedUseBeforeInliningTarget(
-// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
+// expected-note@-1 {{update '@available' attribute on enclosing global function}}
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
@@ -238,7 +238,7 @@ public func deployedUseBeforeInliningTarget(
 
 @available(macOS 10.10, *)
 public func deployedUseAtInliningTarget(
-// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
+// expected-note@-1 {{update '@available' attribute on enclosing global function}}
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
@@ -268,7 +268,7 @@ public func deployedUseAtInliningTarget(
 
 @available(macOS 10.14.5, *)
 public func deployedUseBetweenTargets(
-// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
+// expected-note@-1 {{update '@available' attribute on enclosing global function}}
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
@@ -298,7 +298,7 @@ public func deployedUseBetweenTargets(
 
 @available(macOS 10.15, *)
 public func deployedUseAtDeploymentTarget(
-// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
+// expected-note@-1 {{update '@available' attribute on enclosing global function}}
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
@@ -639,7 +639,7 @@ public func spiDeployedUseNoAvailable( // expected-note 3 {{add '@available' att
 
 @available(macOS 10.9, *)
 @inlinable public func inlinedUseBeforeInliningTarget(
-// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
+// expected-note@-1 {{update '@available' attribute on enclosing global function}}
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
@@ -677,7 +677,7 @@ public func spiDeployedUseNoAvailable( // expected-note 3 {{add '@available' att
 
 @available(macOS 10.10, *)
 @inlinable public func inlinedUseAtInliningTarget(
-// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
+// expected-note@-1 {{update '@available' attribute on enclosing global function}}
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
@@ -715,7 +715,7 @@ public func spiDeployedUseNoAvailable( // expected-note 3 {{add '@available' att
 
 @available(macOS 10.14.5, *)
 @inlinable public func inlinedUseBetweenTargets(
-// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
+// expected-note@-1 {{update '@available' attribute on enclosing global function}}
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
@@ -749,7 +749,7 @@ public func spiDeployedUseNoAvailable( // expected-note 3 {{add '@available' att
 
 @available(macOS 10.15, *)
 @inlinable public func inlinedUseAtDeploymentTarget(
-// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
+// expected-note@-1 {{update '@available' attribute on enclosing global function}}
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
@@ -897,7 +897,7 @@ public func spiDeployedUseNoAvailable( // expected-note 3 {{add '@available' att
 
 @available(macOS 10.15, *)
 @inlinable public var inlinedAtDeploymentTargetGlobal: Any {
-// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
+// expected-note@-1 {{update '@available' attribute on enclosing var}}
   _ = NoAvailable()
   _ = BeforeInliningTarget()
   _ = AtInliningTarget()
@@ -1048,7 +1048,7 @@ public func spiDeployedUseNoAvailable( // expected-note 3 {{add '@available' att
 @available(macOS 10.10, *)
 @backDeployed(before: macOS 999.0)
 public func backDeployedToInliningTarget(
-// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
+// expected-note@-1 {{update '@available' attribute on enclosing global function}}
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
@@ -1329,7 +1329,7 @@ public struct PublicStruct { // expected-note 21 {{add '@available' attribute}}
 
   @available(macOS 10.14, *)
   public internal(set) var internalSetter: Void {
-  // expected-note@-1 * {{update '@available' attribute on enclosing.*}}
+  // expected-note@-1 {{update '@available' attribute on enclosing property}}
     @inlinable get {
       // Public inlinable getter acts like @inlinable
       _ = NoAvailable()
@@ -1615,7 +1615,7 @@ extension BetweenTargets { // expected-note 2 {{add '@available' attribute to en
 
 @available(macOS 10.15, *)
 extension BetweenTargets {
-// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
+// expected-note@-1 {{update '@available' attribute on enclosing extension}}
   public func publicFuncInExtensionWithExplicitAvailability( // expected-note {{add '@available' attribute to enclosing instance method}}
     _: NoAvailable,
     _: BeforeInliningTarget,
@@ -1630,7 +1630,7 @@ extension BetweenTargets {
 extension BetweenTargets { // expected-note {{add '@available' attribute to enclosing extension}}
   @available(macOS 10.15, *)
   public func publicFuncWithExplicitAvailabilityInExtension(
-  // expected-note@-1 * {{update '@available' attribute on enclosing.*}}
+  // expected-note@-1 {{update '@available' attribute on enclosing instance method}}
     _: NoAvailable,
     _: BeforeInliningTarget,
     _: AtInliningTarget,
@@ -1683,7 +1683,7 @@ extension BetweenTargets {
 
 @available(macOS 10.10, *)
 extension BetweenTargets { // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}}
-// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
+// expected-note@-1 {{update '@available' attribute on enclosing extension}}
   public func publicFuncInExcessivelyAvailableExtension() {}
 }
 
@@ -1836,7 +1836,7 @@ public protocol NoAvailableProtoWithAssoc { // expected-note 3 {{add '@available
 
 @available(macOS 10.9, *)
 public protocol BeforeInliningTargetProtoWithAssoc {
-// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
+// expected-note@-1 {{update '@available' attribute on enclosing protocol}}
   associatedtype A: NoAvailableProto
   associatedtype B: BeforeInliningTargetProto
   associatedtype C: AtInliningTargetProto
@@ -1851,7 +1851,7 @@ public protocol BeforeInliningTargetProtoWithAssoc {
 
 @available(macOS 10.10, *)
 public protocol AtInliningTargetProtoWithAssoc {
-// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
+// expected-note@-1 {{update '@available' attribute on enclosing protocol}}
   associatedtype A: NoAvailableProto
   associatedtype B: BeforeInliningTargetProto
   associatedtype C: AtInliningTargetProto
@@ -1866,7 +1866,7 @@ public protocol AtInliningTargetProtoWithAssoc {
 
 @available(macOS 10.14.5, *)
 public protocol BetweenTargetsProtoWithAssoc {
-// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
+// expected-note@-1 {{update '@available' attribute on enclosing protocol}}
   associatedtype A: NoAvailableProto
   associatedtype B: BeforeInliningTargetProto
   associatedtype C: AtInliningTargetProto
@@ -1880,7 +1880,7 @@ public protocol BetweenTargetsProtoWithAssoc {
 
 @available(macOS 10.15, *)
 public protocol AtDeploymentTargetProtoWithAssoc {
-// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
+// expected-note@-1 {{update '@available' attribute on enclosing protocol}}
   associatedtype A: NoAvailableProto
   associatedtype B: BeforeInliningTargetProto
   associatedtype C: AtInliningTargetProto

--- a/test/Availability/availability_versions.swift
+++ b/test/Availability/availability_versions.swift
@@ -17,6 +17,9 @@ func globalFuncAvailableOn51() -> Int { return 10 }
 @available(OSX, introduced: 52)
 func globalFuncAvailableOn52() -> Int { return 11 }
 
+@available(OSX, introduced: 42)
+func globalFuncAvailableOn42() -> Int { return 12 }
+
 // Top level should reflect the minimum deployment target.
 let ignored1: Int = globalFuncAvailableOn10_9()
 
@@ -57,6 +60,7 @@ func functionWithoutAvailability() {
 // Functions with annotations should refine their bodies.
 @available(OSX, introduced: 51)
 func functionAvailableOn51() {
+// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
   let _: Int = globalFuncAvailableOn10_9()
   let _: Int = globalFuncAvailableOn51()
 
@@ -420,6 +424,7 @@ class ClassWithPotentiallyUnavailableProperties {
 
   @available(OSX, introduced: 10.9)
   var availableOn10_9Computed: Int {
+  // expected-note@-1 * {{update '@available' attribute on enclosing.*}}
     get {
       let _: Int = availableOn51Stored // expected-error {{'availableOn51Stored' is only available in macOS 51 or newer}}
           // expected-note@-1 {{add 'if #available' version check}}
@@ -502,6 +507,7 @@ class ClassWithPotentiallyUnavailableProperties {
 
 @available(OSX, introduced: 51)
 class ClassWithReferencesInInitializers {
+// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
   var propWithInitializer51: Int = globalFuncAvailableOn51()
 
   var propWithInitializer52: Int = globalFuncAvailableOn52() // expected-error {{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
@@ -618,6 +624,7 @@ enum EnumIntroducedOn52 {
 
 @available(OSX, introduced: 51)
 enum CompassPoint {
+// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
   case North
   case South
   case East
@@ -1021,6 +1028,7 @@ class SubWithLargerMemberAvailability : SuperWithLimitedMemberAvailability {
         // expected-note@-1 2{{add '@available' attribute to enclosing class}}
   @available(OSX, introduced: 10.9)
   override func someMethod() {
+  // expected-note@-1 * {{update '@available' attribute on enclosing.*}}
     super.someMethod() // expected-error {{'someMethod()' is only available in macOS 51 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
     
@@ -1031,6 +1039,7 @@ class SubWithLargerMemberAvailability : SuperWithLimitedMemberAvailability {
   
   @available(OSX, introduced: 10.9)
   override var someProperty: Int {
+  // expected-note@-1 * {{update '@available' attribute on enclosing.*}}
     get { 
       let _ = super.someProperty // expected-error {{'someProperty' is only available in macOS 51 or newer}}
           // expected-note@-1 {{add 'if #available' version check}}
@@ -1106,6 +1115,7 @@ protocol ProtocolAvailableOn51 {
 
 @available(OSX, introduced: 10.9)
 protocol ProtocolAvailableOn10_9InheritingFromProtocolAvailableOn51 : ProtocolAvailableOn51 { // expected-error {{'ProtocolAvailableOn51' is only available in macOS 51 or newer}}
+// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
 }
 
 @available(OSX, introduced: 51)
@@ -1118,6 +1128,7 @@ protocol UnavailableProtocolInheritingFromProtocolAvailableOn51 : ProtocolAvaila
 
 @available(OSX, introduced: 10.9)
 class SubclassAvailableOn10_9OfClassAvailableOn51 : ClassAvailableOn51 { // expected-error {{'ClassAvailableOn51' is only available in macOS 51 or newer}}
+// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
 }
 
 @available(OSX, unavailable)
@@ -1142,12 +1153,14 @@ func castToPotentiallyUnavailableProtocol() {
 
 @available(OSX, introduced: 10.9)
 class SubclassAvailableOn10_9OfClassAvailableOn51AlsoAdoptingProtocolAvailableOn51 : ClassAvailableOn51, ProtocolAvailableOn51 { // expected-error {{'ClassAvailableOn51' is only available in macOS 51 or newer}}
+// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
 }
 
 class SomeGenericClass<T> { }
 
 @available(OSX, introduced: 10.9)
 class SubclassAvailableOn10_9OfSomeGenericClassOfProtocolAvailableOn51 : SomeGenericClass<ProtocolAvailableOn51> { // expected-error {{'ProtocolAvailableOn51' is only available in macOS 51 or newer}}
+// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
 }
 
 @available(OSX, unavailable)
@@ -1194,6 +1207,7 @@ extension ClassAvailableOn51 { }
 
 @available(OSX, introduced: 51)
 extension ClassAvailableOn51 {
+// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
   func m() {
       // expected-note@-1 {{add '@available' attribute to enclosing instance method}}
     let _ = globalFuncAvailableOn51()
@@ -1491,6 +1505,30 @@ public func fixitForReferenceInGlobalFunctionWithDeclModifier() {
       // expected-error@-1 {{'functionAvailableOn51()' is only available in macOS 51 or newer}}
       // expected-note@-2 {{add 'if #available' version check}} {{3-26=if #available(macOS 51, *) {\n      functionAvailableOn51()\n  } else {\n      // Fallback on earlier versions\n  }}}
       
+}
+
+@available(macOS 12, *)
+func fixitForUpdatingExistingAvailabilitySimple() {
+      // expected-note@-1 {{update '@available' attribute on enclosing global function}} {{1510:18-20=52}}
+  let _ = globalFuncAvailableOn52()
+      // expected-error@-1 {{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
+      // expected-note@-2 {{add 'if #available' version check}}
+}
+
+@available(macOS 12, iOS 8.0, *)
+func fixitForUpdatingExistingAvailabilityMultiPlatform() {
+      // expected-note@-1 {{update '@available' attribute on enclosing global function}} {{1518:18-20=52}}
+  let _ = globalFuncAvailableOn52()
+      // expected-error@-1 {{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
+      // expected-note@-2 {{add 'if #available' version check}}
+}
+
+@available(macOS, introduced: 12, obsoleted: 9999)
+func fixitForUpdatingExistingAvailabilityLongForm() {
+      // expected-note@-1 {{update '@available' attribute on enclosing global function}} {{1526:31-33=52}}
+  let _ = globalFuncAvailableOn52()
+      // expected-error@-1 {{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
+      // expected-note@-2 {{add 'if #available' version check}}
 }
 
 func fixitForReferenceInGlobalFunctionWithAttribute() -> Never {
@@ -1803,6 +1841,7 @@ class ClassWithShortFormAvailableOn54 {
 
 @available(OSX 10.9, *)
 func funcWithShortFormAvailableOn10_9() {
+// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
   let _ = ClassWithShortFormAvailableOn51() // expected-error {{'ClassWithShortFormAvailableOn51' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
@@ -1835,6 +1874,7 @@ func funcWithMultipleShortFormAnnotationsForDifferentPlatforms() {
 @available(OSX 53, *)
 @available(OSX 52, *)
 func funcWithMultipleShortFormAnnotationsForTheSamePlatform() {
+// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
   let _ = ClassWithShortFormAvailableOn53()
 
   let _ = ClassWithShortFormAvailableOn54() // expected-error {{'ClassWithShortFormAvailableOn54' is only available in macOS 54 or newer}}
@@ -1844,6 +1884,7 @@ func funcWithMultipleShortFormAnnotationsForTheSamePlatform() {
 // FIXME: This is weird, but it's already accepted. It should probably be diagnosed.
 @available(iOS 14, *, OSX 51)
 func funcWithWeirdShortFormAvailableOn51() {
+// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
   let _ = ClassWithShortFormAvailableOn51()
   let _ = ClassWithShortFormAvailableOn54() // expected-error {{'ClassWithShortFormAvailableOn54' is only available in macOS 54 or newer}}
   // expected-note@-1 {{add 'if #available' version check}}

--- a/test/Concurrency/deinit_isolation_availability.swift
+++ b/test/Concurrency/deinit_isolation_availability.swift
@@ -1,6 +1,6 @@
-// RUN: %target-typecheck-verify-swift -swift-version 5 %s -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify-additional-prefix deployment- -verify-additional-prefix inlining-
-// RUN: %target-typecheck-verify-swift -swift-version 5 %s -strict-concurrency=complete -target %target-swift-6.1-abi-triple
-// RUN: %target-typecheck-verify-swift -swift-version 5 %s -strict-concurrency=complete -target %target-swift-6.1-abi-triple -target-min-inlining-version min -verify-additional-prefix inlining-
+// RUN: %target-typecheck-verify-swift -swift-version 5 -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify-additional-prefix deployment- -verify-additional-prefix inlining-
+// RUN: %target-typecheck-verify-swift -swift-version 5 -strict-concurrency=complete -target %target-swift-6.1-abi-triple
+// RUN: %target-typecheck-verify-swift -swift-version 5 -strict-concurrency=complete -target %target-swift-6.1-abi-triple -target-min-inlining-version min -verify-additional-prefix inlining-
 
 // Test -emit-module configurations.
 
@@ -69,6 +69,7 @@ public actor SomeGlobalActor {
 
 @available(SwiftStdlib 5.1, *)
 @SomeGlobalActor public class C6 {
+// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
   var x: Int = 0
 
   isolated deinit { // expected-deployment-error{{isolated deinit is only available in macOS 15.4.0 or newer}}
@@ -87,6 +88,7 @@ public actor SomeGlobalActor {
 
 @available(SwiftStdlib 5.1, *)
 @_fixed_layout @SomeGlobalActor public class C8 {
+// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
   @usableFromInline var x: Int = 0
 
   @inlinable isolated deinit { // expected-inlining-error{{isolated deinit is only available in macOS 15.4.0 or newer}}
@@ -114,6 +116,7 @@ actor A {
 
 @available(SwiftStdlib 5.1, *)
 public actor A1 {
+// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
   var x: Int = 0
 
   isolated deinit { // expected-deployment-error{{isolated deinit is only available in macOS 15.4.0 or newer}}
@@ -123,6 +126,7 @@ public actor A1 {
 
 @available(SwiftStdlib 5.1, *)
 public actor A2 {
+// expected-note@-1 * {{update '@available' attribute on enclosing.*}}
   @usableFromInline var x: Int = 0
 
   @inlinable isolated deinit { // expected-inlining-error{{isolated deinit is only available in macOS 15.4.0 or newer}}

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -38,6 +38,7 @@ func acceptSendableFn(_: @Sendable @escaping () -> Void) { }
 
 @available(SwiftStdlib 5.1, *)
 func testCV(
+// expected-note@-1 {{update '@available' attribute on enclosing}}
   ns1: NS1, ns1array: [NS1], ns2: NS2, ns3: NS3, ns4: NS4,
   fn: @escaping () -> Void
   // expected-note @-1 {{parameter 'fn' is implicitly non-Sendable}}
@@ -61,6 +62,7 @@ func testCV(
 
 @available(SwiftStdlib 5.1, *)
 func testCV(
+// expected-note@-1 {{update '@available' attribute on enclosing}}
   ns1: NS1, ns1array: [NS1], ns2: NS2, ns3: NS3, ns4: NS4,
   fn: @escaping () -> Void
   // expected-note@-1{{parameter 'fn' is implicitly non-Sendable}}

--- a/test/Sema/Inputs/conformance_availability_implied_other.swift
+++ b/test/Sema/Inputs/conformance_availability_implied_other.swift
@@ -4,5 +4,6 @@ extension Conformer1: Derived2 {}
 
 @available(macOS 100, *)
 extension Conformer2: Derived1 {}
-// expected-error@-1 {{conformance of 'Conformer2' to 'Base' is only available in macOS 200 or newer}}
+// expected-note@-1 {{update '@available' attribute on enclosing}}
+// expected-error@-2 {{conformance of 'Conformer2' to 'Base' is only available in macOS 200 or newer}}
 

--- a/test/attr/ApplicationMain/attr_main_struct_available_future.swift
+++ b/test/attr/ApplicationMain/attr_main_struct_available_future.swift
@@ -5,6 +5,7 @@
 @main // expected-error {{'main()' is only available in macOS 99 or newer}}
 @available(OSX 10.0, *)
 struct EntryPoint {
+// expected-note@-1 {{update '@available' attribute on enclosing}}
   @available(OSX 99, *)
   static func main() {
   }

--- a/test/attr/attr_availability_ios_to_visionos_decl_remap.swift
+++ b/test/attr/attr_availability_ios_to_visionos_decl_remap.swift
@@ -81,6 +81,7 @@ func testDeploymentTarget() {
 
 @available(iOS 17.4, *)
 func testAfterDeployment_iOS() {
+// expected-note@-1 {{update '@available' attribute on enclosing}}
   doSomething()
   doSomethingElse() // expected-error {{'doSomethingElse()' is unavailable in visionOS: you don't want to do that anyway}}
   doSomethingFarFuture() // expected-error {{'doSomethingFarFuture()' is only available in iOS 99.0 or newer}}

--- a/test/attr/attr_availability_osx.swift
+++ b/test/attr/attr_availability_osx.swift
@@ -116,6 +116,7 @@ extension TestStruct {
 
 @available(macOS 10.11, *)
 func testMemberAvailability() {
+// expected-note@-1 {{update '@available' attribute on enclosing}}
   TestStruct().doTheThing() // expected-error {{'doTheThing()' is unavailable}}
   TestStruct().doAnotherThing() // expected-error {{'doAnotherThing()' is unavailable}}
   TestStruct().doThirdThing() // expected-error {{'doThirdThing()' is unavailable}}

--- a/test/attr/typed_throws_availability_osx.swift
+++ b/test/attr/typed_throws_availability_osx.swift
@@ -9,4 +9,5 @@ enum MyError: Error {
 
 @available(macOS 12, *)
 func throwMyErrorBadly() throws(MyError) { }
-// expected-error@-1{{'MyError' is only available in macOS 13 or newer}}
+// expected-note@-1 {{update '@available' attribute on enclosing}}
+// expected-error@-2 {{'MyError' is only available in macOS 13 or newer}}


### PR DESCRIPTION
Summary
Improve availability diagnostics so the compiler suggests updating an existing @available attribute when it is insufficient, instead of only suppressing the add-attribute fix-it.

Specifically, when an enclosing declaration already has an active related availability attribute with an introduced version that is less strict than the required availability, emit a fix-it to replace that existing introduced version in place.

Changes
- Update availability fix-it generation in `TypeCheckAvailability.cpp` to prefer updating an existing enclosing `@available` introduced version when applicable.
- Add/update diagnostics text in `DiagnosticsSema.def`.
- Update regression expectations in availability/concurrency/attr tests to match emitted notes/fix-its.

Testing
- Updated test coverage in:
  - `test/Availability/availability_versions.swift`
  - `test/Availability/availability_target_min_inlining.swift`
  - `test/Availability/availability_define.swift`
  - related expectation updates in touched tests listed in this PR.

Issue
Resolves #57378

Context
Fresh PR replacing #87402 to keep history clean.