### PR TITLE
[Concurrency] Adopt nonisolated(nonsending) in TaskLocal.withValue

### DIFF
--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -226,20 +226,47 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   /// in specific child tasks, the more specific (i.e. "deeper") binding is
   /// returned when the value is read.
   ///
+  /// The operation is guaranteed to execute in the calling context.
+  ///
   /// If the value is a reference type, it will be retained for the duration of
   /// the operation closure.
   ///
   /// If this method is called form a context where no current Swift concurrency task
   /// is available, a fallback thread-local is used to manage the task locals and
   /// all existing semantics of task-locals are upheld as-if a task was actually available.
+  @_alwaysEmitIntoClient
+  @discardableResult
+  @available(SwiftStdlib 5.1, *)
+  // ABI Note: @abi needed because the mangling otherwise conflicts with the
+  // legacy @_unsafeInheritExecutor declaration.
+  @abi(
+    nonisolated(nonsending) func withValueNonisolatedNonsending<R, E: Error>(
+      _ valueDuringOperation: Value,
+      operation: nonisolated(nonsending) () async throws(E) -> R,
+      file: String, line: UInt
+    ) async throws(E) -> R
+  )
+  public nonisolated(nonsending) func withValue<R, E: Error>(
+    _ valueDuringOperation: Value,
+    operation: nonisolated(nonsending) () async throws(E) -> R,
+    file: String = #fileID, line: UInt = #line
+  ) async throws(E) -> R {
+    return try await withValueImpl(
+      valueDuringOperation,
+      operation: operation,
+      file: file, line: line)
+  }
+
   @inlinable
   @discardableResult
   @available(SwiftStdlib 5.1, *)
   @backDeployed(before: SwiftStdlib 6.0)
-  public func withValue<R>(_ valueDuringOperation: Value,
-                           operation: () async throws -> R,
-                           isolation: isolated (any Actor)? = #isolation,
-                           file: String = #fileID, line: UInt = #line) async rethrows -> R {
+  public func withValue<R>(
+    _ valueDuringOperation: Value,
+    operation: () async throws -> R,
+    isolation: isolated (any Actor)? = #isolation,
+    file: String = #fileID, line: UInt = #line
+  ) async rethrows -> R {
     return try await withValueImpl(
       valueDuringOperation,
       operation: operation,
@@ -282,23 +309,42 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   /// Split the calls Builtin.{add,remove}TaskLocalValue from the compiler-emitted
   /// calls to swift_task_de/alloc for the copy as follows:
   /// - withValue contains the compiler-emitted calls swift_task_de/alloc.
-  /// - withValueImpl contains the calls to Builtin.{add,remove}TaskLocalValue
-  @inlinable
+  /// - withValueImpl contains the calls to Builtin.taskLocalValuePush/Pop
+  @_alwaysEmitIntoClient
   @discardableResult
   @available(SwiftStdlib 5.1, *)
-  @backDeployed(before: SwiftStdlib 6.0)
-  internal func withValueImpl<R>(_ valueDuringOperation: __owned Value,
-                                 operation: () async throws -> R,
-                                 isolation: isolated (any Actor)?,
-                                 file: String = #fileID, line: UInt = #line) async rethrows -> R {
-#if $BuiltinAddTaskLocalValue
-    let binding = Builtin.addTaskLocalValue(key, consume valueDuringOperation)
-    defer { Builtin.removeTaskLocalValue(binding) }
+  internal nonisolated(nonsending) func withValueImpl<R, E: Error>(
+    _ valueDuringOperation: __owned Value,
+    operation: nonisolated(nonsending) () async throws(E) -> R,
+    file: String = #fileID, line: UInt = #line
+  ) async throws(E) -> R {
+#if $BuiltinConcurrencyStackNesting
+    Builtin.taskLocalValuePush(key, consume valueDuringOperation)
+    defer { Builtin.taskLocalValuePop() }
 #else
     _taskLocalValuePush(key: key, value: consume valueDuringOperation)
     defer { _taskLocalValuePop() }
 #endif
+    return try await operation()
+  }
 
+  @inlinable
+  @discardableResult
+  @available(SwiftStdlib 5.1, *)
+  @backDeployed(before: SwiftStdlib 6.0)
+  internal func withValueImpl<R>(
+    _ valueDuringOperation: __owned Value,
+    operation: () async throws -> R,
+    isolation: isolated (any Actor)?,
+    file: String = #fileID, line: UInt = #line
+  ) async rethrows -> R {
+#if $BuiltinConcurrencyStackNesting
+    Builtin.taskLocalValuePush(key, consume valueDuringOperation)
+    defer { Builtin.taskLocalValuePop() }
+#else
+    _taskLocalValuePush(key: key, value: consume valueDuringOperation)
+    defer { _taskLocalValuePop() }
+#endif
     return try await operation()
   }
 


### PR DESCRIPTION
This provides stricter execution guarantees that the operation will always execute on the calling context. Passing some arbitrary isolation is not supported.


Part of rdar://163327630