### PR TITLE
[build-script] Add MinSizeRel to is_release_variant

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/product.py
+++ b/utils/swift_build_support/swift_build_support/products/product.py
@@ -20,8 +20,8 @@ from .. import shell
 from .. import targets
 
 
-def is_release_variant(build_variant):
-    return build_variant in ['Release', 'RelWithDebInfo']
+def is_release_variant(build_variant: str) -> bool:
+    return build_variant in ['Release', 'RelWithDebInfo', 'MinSizeRel']
 
 
 def is_debug_info_variant(build_variant):


### PR DESCRIPTION
MinSizeRel is one of the default cmake release build types.
When building swift, it conditionally add/remove flags depending on the build type.
[see](https://cmake.org/cmake/help/v3.3/variable/CMAKE_BUILD_TYPE.html)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
