### PR TITLE
Support untyped throws in Embedded Swift

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/EmbeddedSwiftDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/EmbeddedSwiftDiagnostics.swift
@@ -94,15 +94,20 @@ private struct FunctionChecker {
         for conf in ie.conformances {
           try checkConformance(conf, location: ie.location)
         }
-      } else if instruction is OpenExistentialAddrInst {
-          // okay in embedded with exitentials
+      } else if instruction is OpenExistentialAddrInst
+             || instruction is OpenExistentialBoxInst
+             || instruction is OpenExistentialBoxValueInst {
+          // okay in embedded with existentials
       } else {
-          // not supported even in embedded with exitentials
+          // not supported even in embedded with existentials
         throw Diagnostic(.embedded_swift_existential_type, instruction.operands[0].value.type, at: instruction.location)
       }
 
     case let aeb as AllocExistentialBoxInst:
-      throw Diagnostic(.embedded_swift_existential_type, aeb.type, at: instruction.location)
+      if !context.options.enableEmbeddedSwiftExistentials {
+        throw Diagnostic(.embedded_swift_existential_type, aeb.type, at: instruction.location)
+      }
+      // With EmbeddedExistentials enabled, error boxing is supported.
 
     case let ier as InitExistentialRefInst:
       for conf in ier.conformances {

--- a/stdlib/public/SwiftShims/swift/shims/EmbeddedShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/EmbeddedShims.h
@@ -240,18 +240,24 @@ _swift_embedded_metadata_destroy(void *metadata, void *value) {
 }
 
 // Swift implementation of error box destroy logic (defined in EmbeddedRuntime.swift).
-extern void _swift_embedded_error_destroy_impl(void * _Nonnull object);
+// Takes the object as a regular swiftcc parameter (x0/rdi on arm64/x86_64).
+SWIFT_CC_swift extern void _swift_embedded_error_destroy_impl(void * _Nonnull object);
 
-// Calling convention wrapper: swiftcc + swiftself, matching HeapObjectDestroyer.
-// Weak linkage ensures linker deduplication across TUs.
-SWIFT_CC_swift __attribute__((weak)) void
-_swift_embedded_error_destroy(SWIFT_CONTEXT void * _Nonnull object) {
+// Calling convention bridge: HeapObjectDestroyer passes the object via swiftself
+// (x20 on arm64, r13 on x86_64), but @_silgen_name Swift functions receive it as a
+// regular parameter (x0/rdi). This wrapper receives via SWIFT_CONTEXT (swiftself)
+// and forwards as a regular parameter to the Swift implementation.
+// Named _swift_embedded_error_box_destroy (not _swift_embedded_error_destroy) to
+// avoid SIL name collision — Swift IRGen would otherwise shadow the clang-compiled
+// version, losing the swiftcall/swiftself attributes.
+SWIFT_CC_swift static inline void
+_swift_embedded_error_box_destroy(SWIFT_CONTEXT void * _Nonnull object) {
   _swift_embedded_error_destroy_impl(object);
 }
 
-// Returns the address of the wrapper for metadata storage initialization.
+// Returns the address of the calling convention bridge for metadata storage init.
 static inline void * _Nonnull _swift_embedded_error_destroy_ptr(void) {
-  return (void *)_swift_embedded_error_destroy;
+  return (void *)_swift_embedded_error_box_destroy;
 }
 
 #ifdef __cplusplus

--- a/stdlib/public/SwiftShims/swift/shims/EmbeddedShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/EmbeddedShims.h
@@ -220,6 +220,40 @@ _swift_embedded_existential_init_with_copy(void *dst, void *srcExist) {
   }
 }
 
+// Helpers for value-witness operations used by the embedded error runtime.
+static inline void
+_swift_embedded_metadata_initialize_with_copy(void *metadata, void *dst, void *src) {
+  EmbeddedMetaDataPrefix *fullmeta = _swift_embedded_get_full_metadata(metadata);
+  fullmeta->vwt->initializeWithCopyFn(dst, src, metadata);
+}
+
+static inline void
+_swift_embedded_metadata_initialize_with_take(void *metadata, void *dst, void *src) {
+  EmbeddedMetaDataPrefix *fullmeta = _swift_embedded_get_full_metadata(metadata);
+  fullmeta->vwt->initializeWithTakeFn(dst, src, metadata);
+}
+
+static inline void
+_swift_embedded_metadata_destroy(void *metadata, void *value) {
+  EmbeddedMetaDataPrefix *fullmeta = _swift_embedded_get_full_metadata(metadata);
+  fullmeta->vwt->destroyFn(value, metadata);
+}
+
+// Swift implementation of error box destroy logic (defined in EmbeddedRuntime.swift).
+extern void _swift_embedded_error_destroy_impl(void * _Nonnull object);
+
+// Calling convention wrapper: swiftcc + swiftself, matching HeapObjectDestroyer.
+// Weak linkage ensures linker deduplication across TUs.
+SWIFT_CC_swift __attribute__((weak)) void
+_swift_embedded_error_destroy(SWIFT_CONTEXT void * _Nonnull object) {
+  _swift_embedded_error_destroy_impl(object);
+}
+
+// Returns the address of the wrapper for metadata storage initialization.
+static inline void * _Nonnull _swift_embedded_error_destroy_ptr(void) {
+  return (void *)_swift_embedded_error_destroy;
+}
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -352,6 +352,158 @@ public func swift_deallocBox(_ pointer: UnsafeMutableRawPointer) {
   )
 }
 
+// MARK: - Error boxing (swift_allocError / swift_deallocError / swift_getErrorValue)
+
+/// Error box layout: [HeapObject header] [type ptr] [errorConformance ptr] [alignment padding] [value]
+
+/// Compute the byte offset from the start of an error box to the stored value,
+/// and the total allocation size needed for the box.
+private func _errorBoxLayout(
+  metadata: UnsafeRawPointer
+) -> (startOfValue: Int, totalSize: Int, totalAlignMask: Int) {
+  let alignMask = Int(unsafe _swift_embedded_metadata_get_align_mask(
+    UnsafeMutableRawPointer(mutating: metadata)))
+  let size = Int(unsafe _swift_embedded_metadata_get_size(
+    UnsafeMutableRawPointer(mutating: metadata)))
+  let headerSize = unsafe MemoryLayout<HeapObject>.size
+    + 2 * MemoryLayout<UnsafeRawPointer>.size
+  let headerAlignMask = unsafe MemoryLayout<UnsafeRawPointer>.alignment - 1
+  let startOfValue = (headerSize + alignMask) & ~alignMask
+  return (startOfValue, startOfValue + size, alignMask | headerAlignMask)
+}
+
+/// Read the type metadata, error conformance, and value address from an error box.
+private func _errorBoxContents(
+  _ p: UnsafeRawPointer
+) -> (type: UnsafeRawPointer, conformance: UnsafeRawPointer, value: UnsafeMutableRawPointer) {
+  let type = unsafe (UnsafeMutableRawPointer(mutating: p)
+    + MemoryLayout<HeapObject>.size)
+    .assumingMemoryBound(to: UnsafeRawPointer.self).pointee
+  let conformance = unsafe (UnsafeMutableRawPointer(mutating: p)
+    + MemoryLayout<HeapObject>.size + MemoryLayout<UnsafeRawPointer>.size)
+    .assumingMemoryBound(to: UnsafeRawPointer.self).pointee
+  let layout = unsafe _errorBoxLayout(metadata: type)
+  let value = unsafe UnsafeMutableRawPointer(mutating: p).advanced(by: layout.startOfValue)
+  return unsafe (type, conformance, value)
+}
+
+/// Error box destroy implementation. Called from C wrapper `_swift_embedded_error_destroy`
+/// (in EmbeddedShims.h) which provides the swiftcc+swiftself convention for HeapObjectDestroyer.
+@c
+public func _swift_embedded_error_destroy_impl(
+  _ object: UnsafeMutableRawPointer
+) {
+  let contents = unsafe _errorBoxContents(UnsafeRawPointer(object))
+  unsafe _swift_embedded_metadata_destroy(
+    UnsafeMutableRawPointer(mutating: contents.type), contents.value)
+  let layout = unsafe _errorBoxLayout(metadata: contents.type)
+  unsafe swift_slowDealloc(object, layout.totalSize, layout.totalAlignMask)
+}
+
+/// Metadata storage for error boxes. Layout matches ClassMetadata: [superclass, destroy, ivarDestroyer].
+/// Uses a tuple instead of ClassMetadata because @_silgen_name requires a compile-time constant
+/// initializer, and struct initializers (even with all-nil fields) are not compile-time constants.
+/// linkonce_odr linkage ensures a single copy after linking (pointer identity).
+@_silgen_name("_swift_embedded_error_metadata_storage")
+var _errorMetadataStorage:
+  (superclass: UnsafeRawPointer?, destroy: UnsafeRawPointer?, ivarDestroyer: UnsafeRawPointer?)
+  = (superclass: nil, destroy: nil, ivarDestroyer: nil)
+
+private var _errorMetadataInitialized = false
+
+private func _ensureErrorMetadataInitialized() {
+  guard !_errorMetadataInitialized else { return }
+  let destroyPtr = unsafe _swift_embedded_error_destroy_ptr()
+  unsafe withUnsafeMutablePointer(to: &_errorMetadataStorage.destroy) { p in
+    unsafe (p.pointee = UnsafeRawPointer(destroyPtr))
+  }
+  _errorMetadataInitialized = true
+}
+
+/// Allocate a heap box for an `any Error` existential.
+@_silgen_name("swift_allocError")
+public func swift_allocError(
+  _ metadata: Builtin.RawPointer,          // concrete error type metadata
+  _ errorConformance: Builtin.RawPointer,  // Error witness table
+  _ initialValue: Builtin.RawPointer,      // initial value (null = none)
+  _ isTake: Bool                           // true = take, false = copy
+) -> (Builtin.RawPointer, Builtin.RawPointer) {
+  let layout = unsafe _errorBoxLayout(metadata: UnsafeRawPointer(metadata))
+
+  _ensureErrorMetadataInitialized()
+  let metaPtr = unsafe Builtin.addressof(&_errorMetadataStorage)
+  let objectPtr = swift_allocObject(
+    metadata: metaPtr,
+    requiredSize: layout.totalSize,
+    requiredAlignmentMask: layout.totalAlignMask)
+  let p = UnsafeMutableRawPointer(objectPtr)
+
+  // Store type and errorConformance after the HeapObject header
+  unsafe (p + MemoryLayout<HeapObject>.size)
+    .assumingMemoryBound(to: UnsafeRawPointer.self)
+    .pointee = UnsafeRawPointer(metadata)
+  unsafe (p + MemoryLayout<HeapObject>.size
+    + MemoryLayout<UnsafeRawPointer>.size)
+    .assumingMemoryBound(to: UnsafeRawPointer.self)
+    .pointee = UnsafeRawPointer(errorConformance)
+
+  let valueAddr = unsafe p.advanced(by: layout.startOfValue)
+
+  if let src = unsafe UnsafeMutableRawPointer(bitPattern: Int(Builtin.ptrtoint_Word(initialValue))) {
+    if isTake {
+      unsafe _swift_embedded_metadata_initialize_with_take(
+        UnsafeMutableRawPointer(metadata), valueAddr, src)
+    } else {
+      unsafe _swift_embedded_metadata_initialize_with_copy(
+        UnsafeMutableRawPointer(metadata), valueAddr, src)
+    }
+  }
+
+  return (objectPtr, valueAddr._rawValue)
+}
+
+/// Deallocate an error box whose value has already been destroyed (error-path cleanup).
+@c
+public func swift_deallocError(
+  _ box: Builtin.RawPointer,
+  _ metadata: Builtin.RawPointer
+) {
+  let layout = unsafe _errorBoxLayout(metadata: UnsafeRawPointer(metadata))
+  unsafe swift_slowDealloc(
+    UnsafeMutableRawPointer(box), layout.totalSize, layout.totalAlignMask)
+}
+
+/// Extract the value address, type metadata, and error conformance from an error box.
+/// Writes a (OpaqueValue*, TypeMetadata*, WitnessTable*) triple to `out`.
+@c
+public func swift_getErrorValue(
+  _ box: Builtin.RawPointer,
+  _ scratch: Builtin.RawPointer,
+  _ out: Builtin.RawPointer
+) {
+  let p = UnsafeRawPointer(box)
+  let contents = unsafe _errorBoxContents(p)
+
+  // Write (value*, type*, witness*) to the output triple
+  let outPtr = unsafe UnsafeMutableRawPointer(out)
+    .assumingMemoryBound(
+      to: (UnsafeMutableRawPointer, UnsafeRawPointer, UnsafeRawPointer).self)
+  unsafe outPtr.pointee = (contents.value, contents.type, contents.conformance)
+}
+
+/// Error-specific retain (same as swift_retain; no ObjC bridging in embedded).
+@c
+public func swift_errorRetain(_ object: Builtin.RawPointer) -> Builtin.RawPointer {
+  swift_retain(object: object)
+  return object
+}
+
+/// Error-specific release (same as swift_release; no ObjC bridging in embedded).
+@c
+public func swift_errorRelease(_ object: Builtin.RawPointer) {
+  swift_release(object: object)
+}
+
 @_silgen_name("swift_makeBoxUnique")
 public func swifft_makeBoxUnique(buffer: Builtin.RawPointer, metadata: Builtin.RawPointer, alignMask: Int) -> (Builtin.RawPointer, Builtin.RawPointer){
   let addrOfHeapObjectPtr = unsafe UnsafeMutablePointer<Builtin.RawPointer>(buffer)
@@ -417,6 +569,54 @@ public func swift_dynamicCast(
   let isTakeOnSuccess : Bool = (flags & DynamicCastFlags.TakeOnSuccess) != 0
   let isDestroyOnFailure : Bool =
     (flags & DynamicCastFlags.DestroyOnFailure) != 0
+
+  // Check if src is an `any Error` existential (a single pointer to a heap error
+  // box), as opposed to a regular 4-word existential container.  The error box is
+  // detected by comparing the heap object's metadata pointer to the error-box
+  // metadata storage.  This must be tested before the regular existential path
+  // because `any Error` stack slots are only 1 word wide; projectExistentialMetadata
+  // would read 12 bytes past the slot and return garbage.
+  let boxPtrRaw: Builtin.RawPointer = unsafe UnsafeMutableRawPointer(src)
+    .assumingMemoryBound(to: Builtin.RawPointer.self).pointee
+  let boxPtrBits = UInt(Builtin.ptrtoint_Word(boxPtrRaw))
+  if boxPtrBits != 0,
+     unsafe _swift_embedded_get_heap_object_metadata_pointer(
+       UnsafeMutableRawPointer(boxPtrRaw)) == UnsafeMutableRawPointer(Builtin.addressof(&_errorMetadataStorage)) {
+    // src holds a pointer to an error box. Extract the concrete type.
+    let contents = unsafe _errorBoxContents(UnsafeRawPointer(boxPtrRaw))
+
+    // For class types, check the superclass chain; for value types, compare directly.
+    var typeMatches = unsafe contents.type == UnsafeRawPointer(dstMetadata)
+    let srcIsClass = unsafe isClassMetadata(contents.type._rawValue)
+    if !typeMatches && srcIsClass && isClassMetadata(dstMetadata) {
+      // The stored value is a class reference; walk its superclass chain.
+      let classObj = unsafe contents.value.assumingMemoryBound(to: UnsafeMutableRawPointer.self).pointee
+      typeMatches = unsafe swift_dynamicCastClass(
+        object: classObj,
+        targetMetadata: UnsafeRawPointer(dstMetadata)) != nil
+    }
+
+    if typeMatches {
+      // Types match: copy/take the value from the box into dest.
+      if isTakeOnSuccess {
+        unsafe _swift_embedded_metadata_initialize_with_take(
+          UnsafeMutableRawPointer(mutating: contents.type), UnsafeMutableRawPointer(dest), contents.value)
+      } else {
+        unsafe _swift_embedded_metadata_initialize_with_copy(
+          UnsafeMutableRawPointer(mutating: contents.type), UnsafeMutableRawPointer(dest), contents.value)
+      }
+      return true
+    } else {
+      // Type mismatch.
+      if isDestroyOnFailure {
+        swift_release(object: boxPtrRaw)
+      }
+      if isUnconditionalCast {
+        fatalError("failed cast")
+      }
+      return false
+    }
+  }
 
   let srcMetadata = projectExistentialMetadata(src)
 

--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -358,7 +358,8 @@ public func swift_deallocBox(_ pointer: UnsafeMutableRawPointer) {
 
 /// Compute the byte offset from the start of an error box to the stored value,
 /// and the total allocation size needed for the box.
-private func _errorBoxLayout(
+@usableFromInline
+internal func _errorBoxLayout(
   metadata: UnsafeRawPointer
 ) -> (startOfValue: Int, totalSize: Int, totalAlignMask: Int) {
   let alignMask = Int(unsafe _swift_embedded_metadata_get_align_mask(
@@ -373,7 +374,8 @@ private func _errorBoxLayout(
 }
 
 /// Read the type metadata, error conformance, and value address from an error box.
-private func _errorBoxContents(
+@usableFromInline
+internal func _errorBoxContents(
   _ p: UnsafeRawPointer
 ) -> (type: UnsafeRawPointer, conformance: UnsafeRawPointer, value: UnsafeMutableRawPointer) {
   let type = unsafe (UnsafeMutableRawPointer(mutating: p)
@@ -387,17 +389,22 @@ private func _errorBoxContents(
   return unsafe (type, conformance, value)
 }
 
-/// Error box destroy implementation. Called from C wrapper `_swift_embedded_error_destroy`
-/// (in EmbeddedShims.h) which provides the swiftcc+swiftself convention for HeapObjectDestroyer.
-@c
-public func _swift_embedded_error_destroy_impl(
-  _ object: UnsafeMutableRawPointer
+/// Error box destroy implementation. Called from the C calling convention bridge
+/// `_swift_embedded_error_box_destroy` (in EmbeddedShims.h), which receives the object
+/// via swiftself (as required by HeapObjectDestroyer) and forwards it here as a regular
+/// swiftcc parameter. This indirection is necessary because Swift cannot produce a
+/// function with the swiftself attribute on a free function parameter.
+/// @used ensures IRGen emits this even though no Swift code calls it directly.
+@_silgen_name("_swift_embedded_error_destroy_impl") @export(implementation) @used
+public func _errorBoxDestroyImpl(
+  _ object: Builtin.RawPointer
 ) {
-  let contents = unsafe _errorBoxContents(UnsafeRawPointer(object))
+  let p = UnsafeMutableRawPointer(object)
+  let contents = unsafe _errorBoxContents(UnsafeRawPointer(p))
   unsafe _swift_embedded_metadata_destroy(
     UnsafeMutableRawPointer(mutating: contents.type), contents.value)
   let layout = unsafe _errorBoxLayout(metadata: contents.type)
-  unsafe swift_slowDealloc(object, layout.totalSize, layout.totalAlignMask)
+  unsafe swift_slowDealloc(p, layout.totalSize, layout.totalAlignMask)
 }
 
 /// Metadata storage for error boxes. Layout matches ClassMetadata: [superclass, destroy, ivarDestroyer].
@@ -579,7 +586,8 @@ public func swift_dynamicCast(
   let boxPtrRaw: Builtin.RawPointer = unsafe UnsafeMutableRawPointer(src)
     .assumingMemoryBound(to: Builtin.RawPointer.self).pointee
   let boxPtrBits = UInt(Builtin.ptrtoint_Word(boxPtrRaw))
-  if boxPtrBits != 0,
+  let isAligned = unsafe (boxPtrBits & UInt(MemoryLayout<UnsafeRawPointer>.alignment - 1)) == 0
+  if boxPtrBits != 0 && isAligned,
      unsafe _swift_embedded_get_heap_object_metadata_pointer(
        UnsafeMutableRawPointer(boxPtrRaw)) == UnsafeMutableRawPointer(Builtin.addressof(&_errorMetadataStorage)) {
     // src holds a pointer to an error box. Extract the concrete type.

--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -394,8 +394,8 @@ internal func _errorBoxContents(
 /// via swiftself (as required by HeapObjectDestroyer) and forwards it here as a regular
 /// swiftcc parameter. This indirection is necessary because Swift cannot produce a
 /// function with the swiftself attribute on a free function parameter.
-/// @used ensures IRGen emits this even though no Swift code calls it directly.
-@_silgen_name("_swift_embedded_error_destroy_impl") @export(implementation) @used
+/// Linked transitively via the Swift reference in `_ensureErrorMetadataInitialized`.
+@_silgen_name("_swift_embedded_error_destroy_impl") @export(implementation)
 public func _errorBoxDestroyImpl(
   _ object: Builtin.RawPointer
 ) {
@@ -420,6 +420,10 @@ private var _errorMetadataInitialized = false
 
 private func _ensureErrorMetadataInitialized() {
   guard !_errorMetadataInitialized else { return }
+  // Reference the impl from Swift to ensure the SIL linker includes it transitively
+  // when swift_allocError is linked. Without this, the function is only referenced
+  // from C (the swiftself wrapper in EmbeddedShims.h) which the SIL linker can't follow.
+  _ = unsafe unsafeBitCast(_errorBoxDestroyImpl, to: UnsafeRawPointer.self)
   let destroyPtr = unsafe _swift_embedded_error_destroy_ptr()
   unsafe withUnsafeMutablePointer(to: &_errorMetadataStorage.destroy) { p in
     unsafe (p.pointee = UnsafeRawPointer(destroyPtr))

--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -417,13 +417,15 @@ var _errorMetadataStorage:
   = (superclass: nil, destroy: nil, ivarDestroyer: nil)
 
 private var _errorMetadataInitialized = false
+// Holds a Swift reference to _errorBoxDestroyImpl so the SIL linker includes it
+// transitively when swift_allocError is linked. Without this, the impl is only
+// referenced from C (the swiftself wrapper in EmbeddedShims.h) which the SIL
+// linker can't follow. The reference is written once during metadata init.
+private var _errorBoxDestroyImplRef: (Builtin.RawPointer) -> Void = { _ in }
 
 private func _ensureErrorMetadataInitialized() {
   guard !_errorMetadataInitialized else { return }
-  // Reference the impl from Swift to ensure the SIL linker includes it transitively
-  // when swift_allocError is linked. Without this, the function is only referenced
-  // from C (the swiftself wrapper in EmbeddedShims.h) which the SIL linker can't follow.
-  _ = unsafe unsafeBitCast(_errorBoxDestroyImpl, to: UnsafeRawPointer.self)
+  _errorBoxDestroyImplRef = _errorBoxDestroyImpl
   let destroyPtr = unsafe _swift_embedded_error_destroy_ptr()
   unsafe withUnsafeMutablePointer(to: &_errorMetadataStorage.destroy) { p in
     unsafe (p.pointee = UnsafeRawPointer(destroyPtr))

--- a/test/embedded/multi-module-debug-info.swift
+++ b/test/embedded/multi-module-debug-info.swift
@@ -2,7 +2,7 @@
 // RUN: %{python} %utils/split_file.py -o %t %s
 
 // RUN: %target-swift-frontend -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded -parse-as-library
-// RUN: %target-swift-frontend -c -I %t %t/Main.swift -enable-experimental-feature Embedded -verify -verify-ignore-unrelated -o /dev/null
+// RUN: %target-swift-frontend -c -I %t %t/Main.swift -enable-experimental-feature Embedded -o /dev/null
 
 // REQUIRES: OS=macosx || OS=linux-gnu || OS=wasip1
 // REQUIRES: swift_feature_Embedded
@@ -14,7 +14,7 @@ public struct MyError: Error {
 
 @inline(never)
 public func foo<T>(_ t: T) throws {
-  throw MyError() // expected-error {{cannot use a value of protocol type 'any Error' in embedded Swift}}
+  throw MyError()
 }
 
 @inline(never)
@@ -30,6 +30,6 @@ public func callit<T>(_ t: T) {
 import MyModule
 
 public func testit() {
-  callit(27) // expected-note {{generic specialization called here}}
+  callit(27)
 }
 

--- a/test/embedded/throw-trap.swift
+++ b/test/embedded/throw-trap.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-frontend -emit-ir %s -enable-experimental-feature Embedded 2>&1 | %FileCheck %s --check-prefix CHECK-EXISTENTIALS
+// RUN: %target-swift-frontend -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s --check-prefix CHECK-EXISTENTIALS-IR
 // RUN: %target-swift-frontend -Xllvm -sil-print-types -emit-sil %s -enable-experimental-feature Embedded -throws-as-traps | %FileCheck %s --check-prefix CHECK-TRAPS-SIL
 // RUN: %target-swift-frontend -emit-ir %s -enable-experimental-feature Embedded -throws-as-traps | %FileCheck %s --check-prefix CHECK-TRAPS-IR
 
@@ -23,7 +23,7 @@ public func catching1() {
   }
 }
 
-// CHECK-EXISTENTIALS: error: cannot use a value of protocol type 'any Error' in embedded Swift
+// CHECK-EXISTENTIALS-IR: call swiftcc { ptr, ptr } @swift_allocError(
 
 // CHECK-TRAPS-SIL:      sil @$e4main9throwing1SiyKF : $@convention(thin) () -> (Int, @error any Error) {
 // CHECK-TRAPS-SIL-NEXT: bb0:

--- a/test/embedded/untyped-throws-class-hierarchy-exec.swift
+++ b/test/embedded/untyped-throws-class-hierarchy-exec.swift
@@ -1,0 +1,59 @@
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu || OS=wasip1
+// REQUIRES: swift_feature_Embedded
+
+class BaseError: Error {
+  let code: Int
+  init(code: Int) { self.code = code }
+  deinit { print("BaseError deinit") }
+}
+
+class SubError: BaseError {
+  let detail: Int
+  init(code: Int, detail: Int) {
+    self.detail = detail
+    super.init(code: code)
+  }
+  deinit { print("SubError deinit") }
+}
+
+func throwSub() throws {
+  throw SubError(code: 1, detail: 42)
+}
+
+@main
+struct Main {
+  static func main() {
+    // Catch subclass as base class
+    do {
+      try throwSub()
+    } catch let e as BaseError {
+      print(e.code == 1 ? "OK1" : "FAIL1")
+    } catch {
+      print("FAIL-unexpected")
+    }
+
+    // Catch subclass as exact subclass type
+    do {
+      try throwSub()
+    } catch let e as SubError {
+      print(e.detail == 42 ? "OK2" : "FAIL2")
+    } catch {
+      print("FAIL-unexpected")
+    }
+  }
+}
+
+// CHECK: OK1
+// CHECK: SubError deinit
+// CHECK: BaseError deinit
+// CHECK: OK2
+// CHECK: SubError deinit
+// CHECK: BaseError deinit
+// CHECK-NOT: FAIL
+// CHECK-NOT: deinit

--- a/test/embedded/untyped-throws-exec.swift
+++ b/test/embedded/untyped-throws-exec.swift
@@ -1,0 +1,57 @@
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -enable-experimental-feature EmbeddedExistentials -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -enable-experimental-feature Embedded -enable-experimental-feature EmbeddedExistentials -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu || OS=wasip1
+// REQUIRES: swift_feature_Embedded
+
+enum MyError: Error, Equatable {
+  case simple
+  case withValue(Int)
+}
+
+func mayThrow(_ n: Int) throws {
+  if n == 0 { throw MyError.simple }
+  if n == 1 { throw MyError.withValue(42) }
+}
+
+@main
+struct Main {
+  static func main() {
+    // Catch untyped error, verify it's the right case
+    do {
+      try mayThrow(0)
+    } catch let e as MyError {
+      print(e == .simple ? "OK1" : "FAIL")
+    } catch {
+      print("FAIL")
+    }
+
+    do {
+      try mayThrow(1)
+    } catch let e as MyError {
+      if case .withValue(let n) = e {
+        print(n == 42 ? "OK2" : "FAIL")
+      } else {
+        print("FAIL")
+      }
+    } catch {
+      print("FAIL")
+    }
+
+    // No-throw path
+    do {
+      try mayThrow(99)
+      print("OK3")
+    } catch {
+      print("FAIL")
+    }
+  }
+}
+
+// CHECK: OK1
+// CHECK: OK2
+// CHECK: OK3
+// CHECK-NOT: FAIL

--- a/test/embedded/untyped-throws-exec.swift
+++ b/test/embedded/untyped-throws-exec.swift
@@ -6,6 +6,7 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx || OS=linux-gnu || OS=wasip1
 // REQUIRES: swift_feature_Embedded
+// REQUIRES: swift_feature_EmbeddedExistentials
 
 enum MyError: Error, Equatable {
   case simple

--- a/test/embedded/untyped-throws-exec.swift
+++ b/test/embedded/untyped-throws-exec.swift
@@ -18,6 +18,10 @@ func mayThrow(_ n: Int) throws {
   if n == 1 { throw MyError.withValue(42) }
 }
 
+func withRethrow(_ body: () throws -> Void) rethrows {
+  try body()
+}
+
 @main
 struct Main {
   static func main() {
@@ -49,10 +53,29 @@ struct Main {
     } catch {
       print("FAIL")
     }
+
+    // Rethrows propagates error
+    do {
+      try withRethrow { try mayThrow(0) }
+    } catch let e as MyError {
+      print(e == .simple ? "OK4" : "FAIL")
+    } catch {
+      print("FAIL")
+    }
+
+    // Rethrows with non-throwing closure
+    do {
+      try withRethrow { }
+      print("OK5")
+    } catch {
+      print("FAIL")
+    }
   }
 }
 
 // CHECK: OK1
 // CHECK: OK2
 // CHECK: OK3
+// CHECK: OK4
+// CHECK: OK5
 // CHECK-NOT: FAIL


### PR DESCRIPTION
**Explanation**: We would like untyped throws to be available in Embedded Swift when system allocator is available.
**Scope**: limited to Embedded Swift.
**Risk**: low due to isolated scope, additive nature of the change, and no adoption of untyped throws in Embedded Swift so far.
**Testing**: added new lit tests.
**Issue**: rdar://171325402