### PR TITLE
[cxx-interop] Emit strong attribute for Any properties in reverse interop

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -2001,7 +2001,7 @@ private:
       }
     }
 
-    if (ty->isObjCExistentialType() && !isCFTypeRef(ty))
+    if ((ty->isObjCExistentialType() || ty->isAny()) && !isCFTypeRef(ty))
       return true;
 
     return false;

--- a/test/PrintAsObjC/any_as_id.swift
+++ b/test/PrintAsObjC/any_as_id.swift
@@ -16,6 +16,7 @@
 // RUN: %FileCheck %s < %t/any_as_id.h
 
 // RUN: %check-in-clang %t/any_as_id.h
+// RUN: %check-in-clang %t/any_as_id.h -fno-objc-arc
 
 import Foundation
 
@@ -64,6 +65,8 @@ class AnyAsIdTest : NSObject {
 // CHECK-NEXT: - (id _Nullable)wrapAny:(id _Nonnull)x SWIFT_WARN_UNUSED_RESULT;
   @objc func wrapAny(_ x : Any) -> Any? { return x }
 
+  @objc var contents: Any?
+// CHECK-NEXT:  @property (nonatomic, strong) id _Nullable contents;
 // CHECK-NEXT:  - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
   /* implicit inherited init() */
 


### PR DESCRIPTION
We already do this for ObjC existentials, Any should behave the same way. The lack of this attribute triggers a warning when ARC is off.

rdar://171345626
