### PR TITLE
[Sema] Handle explicit $-labeled macro params in wrapper matching

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4466,8 +4466,12 @@ ConstraintSystem::applyPropertyWrapperToParameter(
     return getTypeMatchSuccess();
   };
 
+  auto isProjectedValueArg = argLabel.hasDollarPrefix() &&
+      (!param || param->getArgumentName() != argLabel ||
+       param->hasImplicitPropertyWrapper());
+
   // Incorrect use of projected value argument
-  if (argLabel.hasDollarPrefix() &&
+  if (isProjectedValueArg &&
       (!param || !param->hasExternalPropertyWrapper())) {
     auto *loc = getConstraintLocator(locator);
     auto *fix =
@@ -4485,7 +4489,7 @@ ConstraintSystem::applyPropertyWrapperToParameter(
     return recordPropertyWrapperFix(fix);
   }
 
-  if (argLabel.hasDollarPrefix()) {
+  if (isProjectedValueArg) {
     Type projectionType = computeProjectedValueType(param, wrapperType);
     addConstraint(matchKind, paramType, projectionType, locator,
                   /*isFavored=*/false,

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1852,12 +1852,17 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
       // the parameter label given. Otherwise look at the argument label.
       auto wrapperArgLabel = compoundParamLabel.empty() ? argument.getLabel()
                                                         : compoundParamLabel;
+      auto *paramDecl = getParameterAt(callee, paramIdx);
+      assert(paramDecl);
+
+      auto isProjectedValueArg = wrapperArgLabel.hasDollarPrefix() &&
+          (paramDecl->getArgumentName() != wrapperArgLabel ||
+           paramDecl->hasImplicitPropertyWrapper());
+
       if (paramInfo.hasExternalPropertyWrapper(paramIdx) ||
-          wrapperArgLabel.hasDollarPrefix()) {
-        auto *param = getParameterAt(callee, paramIdx);
-        assert(param);
+          isProjectedValueArg) {
         if (cs.applyPropertyWrapperToParameter(paramTy, argTy,
-                                               const_cast<ParamDecl *>(param),
+                                               const_cast<ParamDecl *>(paramDecl),
                                                wrapperArgLabel, subKind,
                                                cs.getConstraintLocator(loc),
                                                calleeLocator)

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -938,7 +938,11 @@ unwrapPropertyWrapperParameterTypes(ConstraintSystem &cs,
     }
 
     auto *paramDecl = paramList->get(i);
-    if (!paramDecl->hasAttachedPropertyWrapper() && !argLabel.hasDollarPrefix()) {
+    auto isProjectedValueArg = argLabel.hasDollarPrefix() &&
+        (paramDecl->getArgumentName() != argLabel ||
+         paramDecl->hasImplicitPropertyWrapper());
+
+    if (!paramDecl->hasAttachedPropertyWrapper() && !isProjectedValueArg) {
       adjustedParamTypes.push_back(paramTypes[i]);
       continue;
     }

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -2450,6 +2450,27 @@ public struct InitWithProjectedValueWrapperMacro: PeerMacro {
   }
 }
 
+public struct InitWithDollarProjectedValueWrapperMacro: PeerMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return [
+      """
+      private var _value: Wrapper
+      var $value: Wrapper {
+        @storageRestrictions(initializes: _value)
+        init {
+          self._value = newValue
+        }
+        get { _value }
+      }
+      """
+    ]
+  }
+}
+
 public struct RequiredDefaultInitMacro: ExtensionMacro {
   public static func expansion(
     of node: AttributeSyntax,

--- a/test/Macros/init_accessor.swift
+++ b/test/Macros/init_accessor.swift
@@ -11,6 +11,10 @@
 macro Wrapped() = #externalMacro(module: "MacroDefinition",
                                  type: "InitWithProjectedValueWrapperMacro")
 
+@attached(peer, names: arbitrary)
+macro DollarWrapped() = #externalMacro(module: "MacroDefinition",
+                                       type: "InitWithDollarProjectedValueWrapperMacro")
+
 @propertyWrapper
 struct Wrapper {
   var wrappedValue: Int {
@@ -28,4 +32,13 @@ struct Test {
 
 let test = Test(_$value: Wrapper())
 print(test.value)
+
+struct TestDollar {
+  @DollarWrapped
+  var value: Int { 1 }
+}
+
+let testDollar = TestDollar($value: Wrapper())
+print(testDollar.value)
 // CHECK: 1
+// CHECK-NEXT: 1


### PR DESCRIPTION
Summary
Fix argument-to-parameter matching for explicit `$`-labeled properties introduced by peer macros (for example, `var $value` with an `init` accessor).

Problem
When matching call arguments, `$label` was always treated as a property-wrapper projection argument. For explicit macro-generated `$` labels, this misclassification could trigger `cannot use property wrapper projection argument` and prevent memberwise initialization.

Fix
- In property-wrapper argument handling, treat `$label` as a projection argument only when it is not an exact declared parameter label (except implicit closure-wrapper parameters, which still use projection behavior).
- Apply the same rule in:
  - `ConstraintSystem::applyPropertyWrapperToParameter`
  - call argument matching in `CSSimplify`
  - unapplied function-reference wrapper adjustment in `TypeOfReference`
- Add macro regression coverage in `test/Macros/init_accessor.swift` (new `DollarWrapped` case) with supporting macro definition in `test/Macros/Inputs/syntax_macro_definitions.swift`.

Issue
Fixes #77041

Testing
- Built touched Sema objects locally (Windows):
  - `CSGen.cpp.obj`
  - `CSSimplify.cpp.obj`
  - `TypeOfReference.cpp.obj`
- Ran `utils/run-test` for `test/Macros/init_accessor.swift` in this environment; test is marked `Unsupported` due local feature/toolchain configuration, so full macro test validation is delegated to Swift CI.
