### PR TITLE
[cxx-interop] Fix modularization for `<cmath>` with libstdc++

### DIFF
--- a/stdlib/public/Cxx/libstdcxx/libstdcxx.modulemap
+++ b/stdlib/public/Cxx/libstdcxx/libstdcxx.modulemap
@@ -84,6 +84,12 @@ module std {
       export *
     }
 
+    module cmath {
+      header "cmath"
+      requires cplusplus
+      export *
+    }
+
     module cstdlib {
       header "cstdlib"
       requires cplusplus

--- a/test/Interop/Cxx/stdlib/Inputs/include-math.h
+++ b/test/Interop/Cxx/stdlib/Inputs/include-math.h
@@ -1,0 +1,3 @@
+#include <math.h>
+
+int getMyInt() { return 42; }

--- a/test/Interop/Cxx/stdlib/Inputs/module.modulemap
+++ b/test/Interop/Cxx/stdlib/Inputs/module.modulemap
@@ -123,3 +123,8 @@ module StdList {
   requires cplusplus
   export *
 }
+
+module IncludeMath {
+  header "include-math.h"
+  export *
+}

--- a/test/Interop/Cxx/stdlib/use-math.swift
+++ b/test/Interop/Cxx/stdlib/use-math.swift
@@ -1,0 +1,7 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=upcoming-swift
+
+// This ensures that Swift can import C/C++ modules that contain `#include <math.h>`.
+
+import IncludeMath
+
+let x = getMyInt()


### PR DESCRIPTION
This fixes compiler errors on Fedora 42 and similar distros.

`<cmath>` wasn't correctly listed in the modulemap that Swift injects into libstdc++.

rdar://152032606 / resolves https://github.com/swiftlang/swift/issues/81774

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
