### PR TITLE
[Diagnostics] Allow lexically-escalated warning groups to 'escape' the '-suppress-warnings' compiler flag.

### DIFF
--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -1427,10 +1427,15 @@ DiagnosticState::determineBehavior(const Diagnostic &diag,
   //   3) If the user substituted a different behavior for this warning, apply
   //      that change
   if (lvl == DiagnosticBehavior::Warning) {
-    if (auto userControlBehavior =
-            determineUserControlledWarningBehavior(diag, sourceMgr))
+    auto userControlBehavior =
+        determineUserControlledWarningBehavior(diag, sourceMgr);
+    if (userControlBehavior)
       lvl = *userControlBehavior;
-    if (suppressWarnings)
+
+    // Suppress all warnings when `-suppress-warnings` is used, except those
+    // *lexically* (`@warn`) escalated to error.
+    // (`-Werror` is not compatible with `-suppress-warnings`).
+    if (suppressWarnings && lvl != DiagnosticBehavior::Error)
       lvl = DiagnosticBehavior::Ignore;
   }
 

--- a/test/attr/warn_escalate_suppression.swift
+++ b/test/attr/warn_escalate_suppression.swift
@@ -1,0 +1,20 @@
+// REQUIRES: swift_feature_SourceWarningControl
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature SourceWarningControl -suppress-warnings
+
+@available(*, deprecated)
+func bar() -> [Int] { return [1,2,3] }
+
+@warn(DeprecatedDeclaration, as: error)
+func foo() -> [Int] { 
+    return bar() // expected-error {{'bar()' is deprecated}}
+}
+
+@warn(DeprecatedDeclaration, as: warning)
+func baz() -> [Int] { 
+    return bar() // Nothing is emitted
+}
+
+@warn(DeprecatedDeclaration, as: ignored)
+func daz() -> [Int] { 
+    return bar() // Nothing is emitted
+}


### PR DESCRIPTION
While '-suppress-warnings' does not fit into the overall model established with command-line controls (`-Werror`, `-Wwarning`) and declaration lexical scope controls (`@warn`), when users specify:
```swift
@warn(DiagGroupID, as: error)
```
They are explicitly opting in to treat certain diagnostic categories as build-halting error conditions and as such they should not longer be silenced by the '-suppress-warnings' flag.
