### PR TITLE
[cxx-interop] Fine tune escapability inference

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5472,6 +5472,36 @@ getConditionalCopyableAttrParams(const clang::RecordDecl *decl) {
   return getConditionalAttrParams(decl, "copyable_if:");
 }
 
+// For certain types when the special member functions just forward to the
+// members' special member functions we can derive escapability from the
+// constituents.
+static bool canDeriveEscapabilityFromMembers(const clang::CXXRecordDecl *decl) {
+  // Do not do any inference for polymoprhic types as we might not know the
+  // semantics of the derived types that can be used through base pointers.
+  if (decl->isPolymorphic())
+    return false;
+
+  for (auto *ctor : decl->ctors()) {
+    if ((ctor->isCopyConstructor() || ctor->isMoveConstructor()) &&
+        ctor->isUserProvided())
+      return false;
+  }
+
+  if (auto *dtor = decl->getDestructor()) {
+    if (dtor->isUserProvided())
+      return false;
+  }
+
+  for (auto *method : decl->methods()) {
+    if ((method->isMoveAssignmentOperator() ||
+         method->isCopyAssignmentOperator()) &&
+        method->isUserProvided())
+      return false;
+  }
+
+  return true;
+}
+
 CxxEscapability
 ClangTypeEscapability::evaluate(Evaluator &evaluator,
                                 EscapabilityLookupDescriptor desc) const {
@@ -5484,10 +5514,10 @@ ClangTypeEscapability::evaluate(Evaluator &evaluator,
   // as such
   // - a record type is escapable if it is annotated with SWIFT_ESCAPABLE_IF()
   // and none of the annotation arguments are non-escapable
-  // - an aggregate or non-cxx record is escapable if none of their fields or
-  // bases are non-escapable (as long as they have a definition)
-  //   * we only infer escapability for simple types, with no user-declared
-  //   constructors, virtual bases or virtual member functions
+  // - a non-cxx record, or a CxxRecordDecl where the special member functions
+  // are forwarding to the fields' special member functions, is escapable if
+  // none of their fields or bases are non-escapable (as long as they have a
+  // definition)
   //   * for more complex CxxRecordDecls, we rely solely on escapability
   //   annotations
   // - in all other cases, the record has unknown escapability (e.g. no
@@ -5514,6 +5544,8 @@ ClangTypeEscapability::evaluate(Evaluator &evaluator,
         return CxxEscapability::NonEscapable;
       if (hasEscapableAttr(recordDecl))
         continue;
+      if (hasSwiftAttribute(recordDecl, "unsafe"))
+        return CxxEscapability::Unknown;
       SmallVector<int> STLParams;
       if (recordDecl->isInStdNamespace()) {
         STLParams = STLConditionalParams.lookup(recordDecl->getName());
@@ -5533,7 +5565,7 @@ ClangTypeEscapability::evaluate(Evaluator &evaluator,
       // escapability annotations
       auto cxxRecordDecl = dyn_cast<clang::CXXRecordDecl>(recordDecl);
       if (recordDecl->getDefinition() &&
-          (!cxxRecordDecl || cxxRecordDecl->isAggregate())) {
+          (!cxxRecordDecl || canDeriveEscapabilityFromMembers(cxxRecordDecl))) {
         if (cxxRecordDecl) {
           for (auto base : cxxRecordDecl->bases())
             maybePushToStack(base.getType()->getUnqualifiedDesugaredType());
@@ -8163,7 +8195,7 @@ static bool isForeignReferenceType(const clang::QualType type,
   return semanticsKind == CxxRecordSemanticsKind::Reference;
 }
 
-static bool hasSwiftAttribute(const clang::Decl *decl, StringRef attr) {
+bool importer::hasSwiftAttribute(const clang::Decl *decl, StringRef attr) {
   if (decl->hasAttrs() && llvm::any_of(decl->getAttrs(), [&](auto *A) {
         if (auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(A))
           return swiftAttr->getAttribute() == attr;

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -2174,6 +2174,7 @@ Identifier getOperatorName(ASTContext &ctx, clang::OverloadedOperatorKind op);
 /// correspond to an overloaded C++ operator.
 Identifier getOperatorName(ASTContext &ctx, Identifier op);
 
+bool hasSwiftAttribute(const clang::Decl *decl, StringRef attr);
 bool hasOwnedValueAttr(const clang::RecordDecl *decl);
 bool hasUnsafeAPIAttr(const clang::Decl *decl);
 bool hasIteratorAPIAttr(const clang::Decl *decl);

--- a/test/Interop/Cxx/class/nonescapable-errors.swift
+++ b/test/Interop/Cxx/class/nonescapable-errors.swift
@@ -184,9 +184,9 @@ struct Aggregate {
   void someMethod() {}
 }; 
 
-// This is a complex record (has user-declared constructors), so we don't infer escapability.
-// By default, it's imported as escapable, which generates an error 
-// because of the non-escapable field 'View'
+// This is a complex record (has user-declared constructor), but since the copy
+// constructor is defaulted and there is no user-provided destructor, we infer
+// escapability from fields. The View field makes it non-escapable.
 struct ComplexRecord {
   int a;
   View b;
@@ -196,12 +196,38 @@ struct ComplexRecord {
   ComplexRecord(const ComplexRecord &other) = default;
 }; 
 
+// escapability is not inferred since it has a user provided copy constructor.
+struct ComplexRecord2 {
+  int a;
+  View b;
+  bool c;
+
+  ComplexRecord2() : a(1), b(), c(false) {}
+  ComplexRecord2(const ComplexRecord2 &other);
+}; 
+
+// escapability is not inferred since it has a user provided copy assignment.
+struct ComplexRecord3 {
+  int a;
+  View b;
+  bool c;
+
+  ComplexRecord3() : a(1), b(), c(false) {}
+  ComplexRecord3& operator=(const ComplexRecord3& other);
+}; 
+
 // expected-LIFETIMES-error@+2 {{a function with a ~Escapable result needs a parameter to depend on}}
 // expected-LIFETIMES-note@+1 {{'@_lifetime(immortal)' can be used to indicate that values produced by this initializer have no lifetime dependencies}}
 Aggregate m1();
 // expected-NO-LIFETIMES-error@-1 {{a function cannot return a ~Escapable result}}
 
-ComplexRecord m2(); // expected-note {{'m2()' has been explicitly marked unavailable here}}
+// expected-LIFETIMES-error@+2 {{a function with a ~Escapable result needs a parameter to depend on}}
+// expected-LIFETIMES-note@+1 {{'@_lifetime(immortal)' can be used to indicate that values produced by this initializer have no lifetime dependencies}}
+ComplexRecord m2();
+// expected-NO-LIFETIMES-error@-1 {{a function cannot return a ~Escapable result}}
+
+ComplexRecord2 m3(); // expected-note {{'m3()' has been explicitly marked unavailable here}}
+ComplexRecord3 m4(); // expected-note {{'m4()' has been explicitly marked unavailable here}}
 
 // expected-error@+1 {{multiple SWIFT_NONESCAPABLE annotations found on 'DoubleNonEscapableAnnotation'}}
 struct SWIFT_NONESCAPABLE SWIFT_NONESCAPABLE DoubleNonEscapableAnnotation {};
@@ -354,5 +380,7 @@ public func optional() {
 
 public func inferedEscapability() {
     m1()
-    m2() // expected-error {{'m2()' is unavailable: return type is unavailable in Swift}}
+    m2()
+    m3()  // expected-error {{'m3()' is unavailable: return type is unavailable in Swift}}
+    m4()  // expected-error {{'m4()' is unavailable: return type is unavailable in Swift}}
 }


### PR DESCRIPTION
Previously, we only inferred escapability for aggregates. This is overly restrictive as the following type is not aggregate (since C++20):

struct S { int i = 0; S() = default; };

The new heuristics infers the escapability of a type from the escapability of its members when:
* There is no user-provided special member functions, so the semantics of copy/move/destruction is determined by the semantics of the members and bases.
* The type is not polymorphic
* None of the members have unsafe types (unless those types have explicit escapability annotations).

rdar://171134601
