### PR TITLE
[Diagnostics] Display full diagnostic group parent chains

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -514,6 +514,12 @@ public:
   BridgedStringRef replacementText;
 };
 
+class BridgedDiagnosticCategoryEntry {
+public:
+  BridgedStringRef name;
+  BridgedStringRef documentationPath;
+};
+
 class BridgedDiagnosticFixIt {
 public:
   int64_t storage[7];

--- a/include/swift/AST/DiagnosticConsumer.h
+++ b/include/swift/AST/DiagnosticConsumer.h
@@ -31,6 +31,12 @@ namespace swift {
   class SourceManager;
   enum class DiagID : uint32_t;
 
+/// Information about a diagostic's diagnostic group
+struct DiagnosticCategoryInfo {
+  StringRef Name;
+  std::string DocumentationURL;
+};
+
 /// Information about a diagnostic passed to DiagnosticConsumers.
 struct DiagnosticInfo {
   DiagID ID = DiagID(0);
@@ -38,7 +44,6 @@ struct DiagnosticInfo {
   DiagnosticKind Kind;
   StringRef FormatString;
   ArrayRef<DiagnosticArgument> FormatArgs;
-  StringRef Category;
 
   /// Only used when directing diagnostics to different outputs.
   /// In batch mode a diagnostic may be
@@ -51,8 +56,10 @@ struct DiagnosticInfo {
   /// DiagnosticInfo of notes which are children of this diagnostic, if any
   ArrayRef<DiagnosticInfo *> ChildDiagnosticInfo;
 
-  /// Path for category documentation.
-  std::string CategoryDocumentationURL;
+  /// Full diagnostic group chain, ordered leaf-first.
+  /// Index 0 = this diagnostic's category, index 1+ = parent groups toward root.
+  /// Empty if the diagnostic has no category.
+  std::vector<DiagnosticCategoryInfo> CategoryChain;
 
   /// Represents a fix-it, a replacement of one range of text with another.
   class FixIt {
@@ -67,6 +74,17 @@ struct DiagnosticInfo {
 
     StringRef getText() const { return Text; }
   };
+
+  StringRef getCategoryName() const {
+    return CategoryChain.empty() ? StringRef() : CategoryChain[0].Name;
+  }
+  StringRef getCategoryDocumentationURL() const {
+    return CategoryChain.empty() ? StringRef() : CategoryChain[0].DocumentationURL;
+  }
+  void setCategoryDocumentationURL(std::string url) {
+    if (!CategoryChain.empty())
+      CategoryChain[0].DocumentationURL = std::move(url);
+  }
 
   /// Extra source ranges that are attached to the diagnostic.
   ArrayRef<CharSourceRange> Ranges;
@@ -87,10 +105,13 @@ struct DiagnosticInfo {
                  ArrayRef<CharSourceRange> Ranges, ArrayRef<FixIt> FixIts,
                  bool IsChildNote)
       : ID(ID), Loc(Loc), Kind(Kind), FormatString(FormatString),
-        FormatArgs(FormatArgs), Category(Category),
+        FormatArgs(FormatArgs),
         BufferIndirectlyCausingDiagnostic(BufferIndirectlyCausingDiagnostic),
         ChildDiagnosticInfo(ChildDiagnosticInfo), Ranges(Ranges),
-        FixIts(FixIts), IsChildNote(IsChildNote) {}
+        FixIts(FixIts), IsChildNote(IsChildNote) {
+    if (!Category.empty())
+      CategoryChain.push_back({Category, ""});
+  }
 };
   
 /// Abstract interface for classes that present diagnostics to the user.

--- a/include/swift/Bridging/ASTGen.h
+++ b/include/swift/Bridging/ASTGen.h
@@ -30,8 +30,8 @@ void swift_ASTGen_addQueuedDiagnostic(
     BridgedStringRef text,
     swift::DiagnosticKind severity,
     swift::SourceLoc sourceLoc,
-    BridgedStringRef categoryName,
-    BridgedStringRef documentationPath,
+    const BridgedDiagnosticCategoryEntry *_Nullable categoryChain,
+    ptrdiff_t numCategoryChainEntries,
     const swift::CharSourceRange *_Nullable highlightRanges,
     ptrdiff_t numHighlightRanges,
     BridgedArrayRef /*BridgedFixIt*/ fixIts);
@@ -39,8 +39,8 @@ void swift_ASTGen_renderSingleDiagnostic(
     void *_Nonnull state,
     BridgedStringRef text,
     swift::DiagnosticKind severity,
-    BridgedStringRef categoryName,
-    BridgedStringRef documentationPath,
+    const BridgedDiagnosticCategoryEntry *_Nullable categoryChain,
+    ptrdiff_t numCategoryChainEntries,
     ssize_t colorize,
     BridgedStringRef *_Nonnull renderedString);
 void swift_ASTGen_renderQueuedDiagnostics(

--- a/lib/AST/DiagnosticBridge.cpp
+++ b/lib/AST/DiagnosticBridge.cpp
@@ -38,7 +38,12 @@ static void addQueueDiagnostic(void *queuedDiagnostics,
                                            info.FormatArgs);
   }
 
-  StringRef documentationPath = info.CategoryDocumentationURL;
+  SmallVector<BridgedDiagnosticCategoryEntry, 4> bridgedDiagGroupChain;
+  for (const auto &entry : info.CategoryChain) {
+    bridgedDiagGroupChain.push_back(
+        {BridgedStringRef(entry.Name),
+         BridgedStringRef(StringRef(entry.DocumentationURL))});
+  }
 
   SmallVector<BridgedFixIt, 2> fixIts;
   for (const auto &fixIt : info.FixIts) {
@@ -49,8 +54,7 @@ static void addQueueDiagnostic(void *queuedDiagnostics,
       queuedDiagnostics, perFrontendState,
       text.str(),
       info.Kind, info.Loc,
-      info.Category,
-      documentationPath,
+      bridgedDiagGroupChain.data(), bridgedDiagGroupChain.size(),
       info.Ranges.data(), info.Ranges.size(),
       llvm::ArrayRef<BridgedFixIt>(fixIts));
 
@@ -78,10 +82,18 @@ void DiagnosticBridge::emitDiagnosticWithoutLocation(
                                            info.FormatArgs);
   }
 
+  SmallVector<BridgedDiagnosticCategoryEntry, 4> bridgedDiagGroupChain;
+  for (const auto &entry : info.CategoryChain) {
+    bridgedDiagGroupChain.push_back(
+        {BridgedStringRef(entry.Name),
+         BridgedStringRef(StringRef(entry.DocumentationURL))});
+  }
+
   BridgedStringRef bridgedRenderedString{nullptr, 0};
   swift_ASTGen_renderSingleDiagnostic(
-      perFrontendState, text.str(), info.Kind, info.Category,
-      llvm::StringRef(info.CategoryDocumentationURL), forceColors ? 1 : 0,
+      perFrontendState, text.str(), info.Kind,
+      bridgedDiagGroupChain.data(), bridgedDiagGroupChain.size(),
+      forceColors ? 1 : 0,
       &bridgedRenderedString);
 
   auto renderedString = bridgedRenderedString.unbridged();

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -1553,17 +1553,17 @@ DiagnosticEngine::diagnosticInfoForDiagnostic(const Diagnostic &diagnostic,
   }
 
   auto groupID = diagnostic.getGroupID();
-  StringRef Category;
+  StringRef CategoryName;
   if (auto wrapped = diagnostic.getWrappedDiagnostic())
-    Category = wrapped.value()->Category;
+    CategoryName = wrapped.value()->getCategoryName();
   else if (isAPIDigesterBreakageDiagnostic(diagnostic.getID()))
-    Category = "api-digester-breaking-change";
+    CategoryName = "api-digester-breaking-change";
   else if (isNoUsageDiagnostic(diagnostic.getID()))
-    Category = "no-usage";
+    CategoryName = "no-usage";
   else if (groupID != DiagGroupID::no_group)
-    Category = getDiagGroupInfoByID(groupID).name;
+    CategoryName = getDiagGroupInfoByID(groupID).name;
   else if (isDeprecationDiagnostic(diagnostic.getID()))
-    Category = "deprecation";
+    CategoryName = "deprecation";
 
   auto fixIts = diagnostic.getFixIts();
   if (loc.isValid()) {
@@ -1592,7 +1592,7 @@ DiagnosticEngine::diagnosticInfoForDiagnostic(const Diagnostic &diagnostic,
       getFormatStringForDiagnostic(diagnostic, includeDiagnosticName);
 
   return DiagnosticInfo(diagnostic.getID(), loc, toDiagnosticKind(behavior),
-                        formatString, diagnostic.getArgs(), Category,
+                        formatString, diagnostic.getArgs(), CategoryName,
                         getDefaultDiagnosticLoc(),
                         /*child note info*/ {}, diagnostic.getRanges(), fixIts,
                         diagnostic.isChildNote());
@@ -1740,26 +1740,50 @@ void DiagnosticEngine::emitDiagnostic(const Diagnostic &diagnostic) {
     info->ChildDiagnosticInfo = childInfoPtrs;
 
     // Capture information about the diagnostic group and its documentation
-    // URL.
+    // URL. Build the full category chain (leaf + parents).
     auto groupID = diagnostic.getGroupID();
     if (groupID != DiagGroupID::no_group) {
       const auto &diagGroup = getDiagGroupInfoByID(groupID);
 
-      if (diagGroup.toolchainLocalDocumentation) {
-        std::string localPath(getLocalDiagnosticDocumentationPath());
-        if (!localPath.empty()) {
-          if (localPath.back() != '/')
-            localPath += "/";
-          localPath += diagGroup.documentationFile;
-          localPath += ".md";
-          info->CategoryDocumentationURL = std::move(localPath);
+      auto getDiagnosticGroupDocURL =
+          [&](const DiagGroupInfo &diagGroup) -> std::string {
+        if (diagGroup.toolchainLocalDocumentation) {
+          std::string localPath(getLocalDiagnosticDocumentationPath());
+          if (!localPath.empty()) {
+            if (localPath.back() != '/')
+              localPath += "/";
+            localPath += diagGroup.documentationFile;
+            localPath += ".md";
+            return localPath;
+          }
+          return "";
         }
-      } else {
+
         std::string docURL(getDiagnosticDocumentationPath());
         if (!docURL.empty() && docURL.back() != '/')
           docURL += "/";
         docURL += diagGroup.documentationFile;
-        info->CategoryDocumentationURL = std::move(docURL);
+        return docURL;
+      };
+
+      // Set the leaf category's documentation URL.
+      info->setCategoryDocumentationURL(getDiagnosticGroupDocURL(diagGroup));
+
+      // Append parent groups by walking up supergroups.
+      auto currentID = groupID;
+      while (true) {
+        const auto &current = getDiagGroupInfoByID(currentID);
+        if (current.supergroups.empty())
+          break;
+        auto parentID = current.supergroups[0];
+        const auto &parent = getDiagGroupInfoByID(parentID);
+        std::string parentDocURL(getDiagnosticDocumentationPath());
+        if (!parentDocURL.empty() && parentDocURL.back() != '/')
+          parentDocURL += "/";
+        parentDocURL += parent.documentationFile;
+        info->CategoryChain.push_back(
+            {StringRef(parent.name), std::move(parentDocURL)});
+        currentID = parentID;
       }
     }
 

--- a/lib/ASTGen/Sources/ASTGen/DiagnosticsBridge.swift
+++ b/lib/ASTGen/Sources/ASTGen/DiagnosticsBridge.swift
@@ -172,6 +172,9 @@ fileprivate struct SimpleDiagnostic: DiagnosticMessage {
 
   let category: DiagnosticCategory?
 
+  /// Full category chain (leaf-first).
+  let categoryChain: [DiagnosticCategory]
+
   var diagnosticID: MessageID {
     .init(domain: "SwiftCompiler", id: "SimpleDiagnostic")
   }
@@ -243,6 +246,25 @@ private struct BridgedFixItMessage: FixItMessage {
   }
 }
 
+/// Convert a bridged category chain array to [DiagnosticCategory].
+private func convertCategoryChain(
+  _ ptr: UnsafePointer<BridgedDiagnosticCategoryEntry>?,
+  count: Int
+) -> [DiagnosticCategory] {
+  guard count > 0, let ptr = ptr else { return [] }
+  return (0..<count).map { i in
+    let entry = ptr[i]
+    let name = String(bridged: entry.name)
+    let docPath = String(bridged: entry.documentationPath)
+    let url: String? = if !docPath.isEmpty {
+        docPath.looksLikeURL ? docPath : "file://\(docPath)"
+      } else {
+        nil
+      }
+    return DiagnosticCategory(name: name, documentationURL: url)
+  }
+}
+
 /// Add a new diagnostic to the queue.
 @_cdecl("swift_ASTGen_addQueuedDiagnostic")
 public func addQueuedDiagnostic(
@@ -251,8 +273,8 @@ public func addQueuedDiagnostic(
   text: BridgedStringRef,
   severity: swift.DiagnosticKind,
   loc: SourceLoc,
-  categoryName: BridgedStringRef,
-  documentationPath: BridgedStringRef,
+  categoryChainPtr: UnsafePointer<BridgedDiagnosticCategoryEntry>?,
+  numCategoryChainEntries: Int,
   highlightRangesPtr: UnsafePointer<CharSourceRange>?,
   numHighlightRanges: Int,
   fixItsUntyped: BridgedArrayRef
@@ -354,29 +376,12 @@ public func addQueuedDiagnostic(
     }
   }
 
-  let documentationPath = String(bridged: documentationPath)
-  let documentationURL: String? = if !documentationPath.isEmpty {
-      // If this looks doesn't look like a URL, prepend file://.
-      documentationPath.looksLikeURL ? documentationPath : "file://\(documentationPath)"
-    } else {
-      nil
-    }
+  // Convert the category chain from bridged data.
+  let categoryChain = convertCategoryChain(categoryChainPtr, count: numCategoryChainEntries)
+  let category: DiagnosticCategory? = categoryChain.first
 
-  let categoryName = String(bridged: categoryName)
-  // If the data comes from serialized diagnostics, it's possible that
-  // the category name is empty because StringRef() is serialized into
-  // an empty string.
-  let category: DiagnosticCategory? = if !categoryName.isEmpty {
-      DiagnosticCategory(
-        name: categoryName,
-        documentationURL: documentationURL
-      )
-    } else {
-      nil
-    }
-
-  // Note that we referenced this category.
-  if let category {
+  // Register all groups for footnote generation.
+  for category in categoryChain {
     diagnosticState.pointee.referencedCategories.insert(category)
   }
 
@@ -411,7 +416,8 @@ public func addQueuedDiagnostic(
     message: SimpleDiagnostic(
       message: String(bridged: text),
       severity: severity.asSeverity,
-      category: category
+      category: category,
+      categoryChain: categoryChain
     ),
     highlights: highlights,
     fixIts: fixIts
@@ -426,8 +432,8 @@ public func renderSingleDiagnostic(
   perFrontendDiagnosticStatePtr: UnsafeMutableRawPointer,
   text: BridgedStringRef,
   severity: swift.DiagnosticKind,
-  categoryName: BridgedStringRef,
-  documentationPath: BridgedStringRef,
+  categoryChainPtr: UnsafePointer<BridgedDiagnosticCategoryEntry>?,
+  numCategoryChainEntries: Int,
   colorize: Int,
   renderedStringOutPtr: UnsafeMutablePointer<BridgedStringRef>
 ) {
@@ -435,29 +441,12 @@ public func renderSingleDiagnostic(
     to: PerFrontendDiagnosticState.self
   )
 
-  let documentationPath = String(bridged: documentationPath)
-  let documentationURL: String? = if !documentationPath.isEmpty {
-      // If this looks doesn't look like a URL, prepend file://.
-      documentationPath.looksLikeURL ? documentationPath : "file://\(documentationPath)"
-    } else {
-      nil
-    }
+  // Convert the category chain from bridged data.
+  let categoryChain = convertCategoryChain(categoryChainPtr, count: numCategoryChainEntries)
+  let category: DiagnosticCategory? = categoryChain.first
 
-  let categoryName = String(bridged: categoryName)
-  // If the data comes from serialized diagnostics, it's possible that
-  // the category name is empty because StringRef() is serialized into
-  // an empty string.
-  let category: DiagnosticCategory? = if !categoryName.isEmpty {
-      DiagnosticCategory(
-        name: categoryName,
-        documentationURL: documentationURL
-      )
-    } else {
-      nil
-    }
-
-  // Note that we referenced this category.
-  if let category {
+  // Register all groups for footnote generation.
+  for category in categoryChain {
     diagnosticState.pointee.referencedCategories.insert(category)
   }
 
@@ -467,7 +456,8 @@ public func renderSingleDiagnostic(
     SimpleDiagnostic(
       message: String(bridged: text),
       severity: severity.asSeverity,
-      category: category
+      category: category,
+      categoryChain: categoryChain
     )
   )
 

--- a/lib/Frontend/CachedDiagnostics.cpp
+++ b/lib/Frontend/CachedDiagnostics.cpp
@@ -473,13 +473,13 @@ DiagnosticSerializer::convertDiagnosticInfo(SourceManager &SM,
   };
 
   std::vector<std::string> educationalNotes;
-  if (!Info.CategoryDocumentationURL.empty())
-    educationalNotes.push_back(Info.CategoryDocumentationURL);
+  if (!Info.getCategoryDocumentationURL().empty())
+    educationalNotes.push_back(Info.getCategoryDocumentationURL().str());
   return {(uint32_t)Info.ID,
           convertSourceLoc(SM, Info.Loc),
           (uint8_t)Info.Kind,
           std::string(Text.data(), Text.size()),
-          Info.Category.str(),
+          Info.getCategoryName().str(),
           convertSourceLoc(SM, Info.BufferIndirectlyCausingDiagnostic),
           convertDiagnosticInfoArray(Info.ChildDiagnosticInfo),
           educationalNotes,
@@ -628,7 +628,7 @@ llvm::Error DiagnosticSerializer::deserializeDiagnosticInfo(
                                   FixIts,
                                   Info.IsChildNote};
   if (Info.EducationalNotePaths.size() == 1)
-    DeserializedInfo.CategoryDocumentationURL = Info.EducationalNotePaths[0];
+    DeserializedInfo.setCategoryDocumentationURL(Info.EducationalNotePaths[0]);
   return callback(DeserializedInfo);
 }
 

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -1572,7 +1572,7 @@ void DiagnosticVerifier::handleDiagnostic(SourceManager &SM,
   CapturedDiagnostics.emplace_back(message, loc.bufferID, Info.Kind,
                                    loc.sourceLoc, loc.line, loc.column, fixIts,
                                    llvm::sys::path::stem(
-                                      Info.CategoryDocumentationURL).str());
+                                      Info.getCategoryDocumentationURL()).str());
 }
 
 /// Once all diagnostics have been captured, perform verification.

--- a/lib/Frontend/PrintingDiagnosticConsumer.cpp
+++ b/lib/Frontend/PrintingDiagnosticConsumer.cpp
@@ -23,6 +23,7 @@
 #include "swift/Basic/SourceManager.h"
 #include "swift/Bridging/ASTGen.h"
 #include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/Support/MemoryBuffer.h"
@@ -137,8 +138,14 @@ void PrintingDiagnosticConsumer::printDiagnostic(SourceManager &SM,
     DiagnosticEngine::formatDiagnosticText(Out, Info.FormatString,
                                            Info.FormatArgs);
 
-    if (!Info.Category.empty())
-      Out << " [#" << Info.Category << "]";
+    if (!Info.getCategoryName().empty()) {
+      Out << " [#";
+      llvm::interleave(
+          llvm::reverse(Info.CategoryChain),
+          [&](const auto &entry) { Out << entry.Name; },
+          [&] { Out << "::"; });
+      Out << "]";
+    }
   }
 
   auto Msg = SM.GetMessage(Info.Loc, SMKind, Text, Ranges, FixIts,

--- a/lib/Frontend/SerializedDiagnosticConsumer.cpp
+++ b/lib/Frontend/SerializedDiagnosticConsumer.cpp
@@ -376,10 +376,10 @@ unsigned SerializedDiagnosticConsumer::getEmitCategory(
 
 unsigned
 SerializedDiagnosticConsumer::emitDocumentationURL(const DiagnosticInfo &Info) {
-  if (Info.CategoryDocumentationURL.empty())
+  if (Info.getCategoryDocumentationURL().empty())
     return 0;
 
-  unsigned &recordID = State->Flags[Info.CategoryDocumentationURL];
+  unsigned &recordID = State->Flags[Info.getCategoryDocumentationURL()];
   if (recordID)
     return recordID;
 
@@ -388,9 +388,9 @@ SerializedDiagnosticConsumer::emitDocumentationURL(const DiagnosticInfo &Info) {
   RecordData Record;
   Record.push_back(RECORD_DIAG_FLAG);
   Record.push_back(recordID);
-  Record.push_back(Info.CategoryDocumentationURL.size());
+  Record.push_back(Info.getCategoryDocumentationURL().size());
   State->Stream.EmitRecordWithBlob(State->Abbrevs.get(RECORD_DIAG_FLAG), Record,
-                                   Info.CategoryDocumentationURL);
+                                   Info.getCategoryDocumentationURL());
   return recordID;
 }
 
@@ -641,9 +641,10 @@ emitDiagnosticMessage(SourceManager &SM,
   addLocToRecord(Loc, SM, filename, Record);
 
   // Emit the category.
-  if (!Info.Category.empty()) {
+  if (!Info.getCategoryName().empty()) {
     Record.push_back(
-        getEmitCategory(Info.Category, Info.CategoryDocumentationURL));
+        getEmitCategory(Info.getCategoryName(),
+                        Info.getCategoryDocumentationURL()));
   } else {
     Record.push_back(0);
   }

--- a/test/PerformanceHints/array-ret.swift
+++ b/test/PerformanceHints/array-ret.swift
@@ -21,11 +21,11 @@
 // RUN: not %target-swift-frontend -typecheck %s -diagnostic-style llvm -Werror ReturnTypeImplicitCopy &> %t/output_err.txt
 // RUN: cat %t/output_err.txt | %FileCheck %s -check-prefix CHECK-ERR
 
-// CHECK-ERR: error: Performance: 'foo()' returns an array, leading to implicit copies. Consider using an 'inout' parameter instead. [#ReturnTypeImplicitCopy]
-// CHECK-ERR: error: Performance: closure returns an array, leading to implicit copies. Consider using an 'inout' parameter instead. [#ReturnTypeImplicitCopy]
+// CHECK-ERR: error: Performance: 'foo()' returns an array, leading to implicit copies. Consider using an 'inout' parameter instead. [#PerformanceHints::ReturnTypeImplicitCopy]
+// CHECK-ERR: error: Performance: closure returns an array, leading to implicit copies. Consider using an 'inout' parameter instead. [#PerformanceHints::ReturnTypeImplicitCopy]
 
-// CHECK-WARN: warning: Performance: 'foo()' returns an array, leading to implicit copies. Consider using an 'inout' parameter instead. [#ReturnTypeImplicitCopy]
-// CHECK-WARN: warning: Performance: closure returns an array, leading to implicit copies. Consider using an 'inout' parameter instead. [#ReturnTypeImplicitCopy]
+// CHECK-WARN: warning: Performance: 'foo()' returns an array, leading to implicit copies. Consider using an 'inout' parameter instead. [#PerformanceHints::ReturnTypeImplicitCopy]
+// CHECK-WARN: warning: Performance: closure returns an array, leading to implicit copies. Consider using an 'inout' parameter instead. [#PerformanceHints::ReturnTypeImplicitCopy]
 
 func foo() -> [Int] {
     return [1,2,3,4,5,6]

--- a/test/diagnostics/local-doc-diagnostic-group.swift
+++ b/test/diagnostics/local-doc-diagnostic-group.swift
@@ -4,5 +4,6 @@
 func foo() -> [Int] {
     return [1, 2, 3]
 }
-// CHECK: warning: Performance: 'foo()' returns an array, leading to implicit copies. Consider using an 'inout' parameter instead. [#ReturnTypeImplicitCopy]{{$}}
+// CHECK: warning: Performance: 'foo()' returns an array, leading to implicit copies. Consider using an 'inout' parameter instead. [#PerformanceHints::ReturnTypeImplicitCopy]{{$}}
+// CHECK: [#PerformanceHints]: <https://docs.swift.org/compiler/documentation/diagnostics/performance-hints>
 // CHECK: [#ReturnTypeImplicitCopy]: <file://{{.*}}share{{/|\\}}doc{{/|\\}}swift{{/|\\}}diagnostics{{/|\\}}return-type-implicit-copy.md>

--- a/test/diagnostics/print-diagnostic-group-chains.swift
+++ b/test/diagnostics/print-diagnostic-group-chains.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-frontend -typecheck %s -Wwarning ExistentialType 2>&1 | %FileCheck %s --check-prefix=CHECK
+// REQUIRES: swift_swift_parser
+
+@available(*, deprecated, renamed: "bar2")
+func bar() {}
+// CHECK: warning: 'bar()' is deprecated: renamed to 'bar2' [#DeprecatedDeclaration]
+bar()
+
+protocol Animal {}
+struct Tiger: Animal {}
+
+// CHECK: warning: {{.*}} returns an existential{{.*}} [#PerformanceHints::ExistentialType]
+func getAnimal() -> any Animal { return Tiger() }
+
+// Verify that both parent and child groups appear in footnotes.
+// CHECK-DAG: [#DeprecatedDeclaration]: <{{.*}}deprecated-declaration>
+// CHECK-DAG: [#ExistentialType]: <{{.*}}existential-type>
+// CHECK-DAG: [#PerformanceHints]: <{{.*}}performance-hints>

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -157,10 +157,10 @@ void EditorDiagConsumer::handleDiagnostic(SourceManager &SM,
 
   SKInfo.ID = DiagnosticEngine::diagnosticIDStringFor(Info.ID).str();
 
-  if (Info.Category == "deprecation" ||
-      Info.Category.starts_with("Deprecated")) {
+  if (Info.getCategoryName() == "deprecation" ||
+      Info.getCategoryName().starts_with("Deprecated")) {
     SKInfo.Categories.push_back(DiagnosticCategory::Deprecation);
-  } else if (Info.Category == "no-usage") {
+  } else if (Info.getCategoryName() == "no-usage") {
     SKInfo.Categories.push_back(DiagnosticCategory::NoUsage);
   }
 
@@ -173,8 +173,8 @@ void EditorDiagConsumer::handleDiagnostic(SourceManager &SM,
   }
   SKInfo.Description = Text.str();
 
-  if (!Info.CategoryDocumentationURL.empty())
-    SKInfo.EducationalNotePaths.push_back(Info.CategoryDocumentationURL);
+  if (!Info.getCategoryDocumentationURL().empty())
+    SKInfo.EducationalNotePaths.push_back(Info.getCategoryDocumentationURL().str());
 
   std::optional<unsigned> BufferIDOpt;
   if (Info.Loc.isValid()) {

--- a/unittests/AST/DiagnosticInfoTests.cpp
+++ b/unittests/AST/DiagnosticInfoTests.cpp
@@ -145,7 +145,7 @@ TEST(DiagnosticInfo, PrintDiagnosticNamesMode_Group) {
       },
       [](DiagnosticEngine &, const DiagnosticInfo &info) {
         EXPECT_FALSE(info.FormatString.ends_with(" [DeprecatedDeclaration]"));
-        EXPECT_EQ(info.Category, "DeprecatedDeclaration");
+        EXPECT_EQ(info.getCategoryName(), "DeprecatedDeclaration");
       },
       /*expectedNumCallbackCalls=*/1);
 }
@@ -166,7 +166,7 @@ TEST(DiagnosticInfo, PrintDiagnosticNamesMode_Group_WrappedDiag) {
       [](DiagnosticEngine &, const DiagnosticInfo &info) {
         EXPECT_EQ(info.ID, diag::error_in_a_future_swift_lang_mode.ID);
         EXPECT_FALSE(info.FormatString.ends_with(" [DeprecatedDeclaration]"));
-        EXPECT_EQ(info.Category, "DeprecatedDeclaration");
+        EXPECT_EQ(info.getCategoryName(), "DeprecatedDeclaration");
       },
       /*expectedNumCallbackCalls=*/1);
 }
@@ -188,7 +188,7 @@ TEST(DiagnosticInfo, CategoryDeprecation) {
             .warnUntilLanguageMode(LanguageMode::future);
       },
       [](DiagnosticEngine &, const DiagnosticInfo &info) {
-        EXPECT_EQ(info.Category, "deprecation");
+        EXPECT_EQ(info.getCategoryName(), "deprecation");
       },
       /*expectedNumCallbackCalls=*/3);
 }
@@ -207,7 +207,7 @@ TEST(DiagnosticInfo, CategoryNoUsage) {
             .warnUntilLanguageMode(LanguageMode::future);
       },
       [](DiagnosticEngine &, const DiagnosticInfo &info) {
-        EXPECT_EQ(info.Category, "no-usage");
+        EXPECT_EQ(info.getCategoryName(), "no-usage");
       },
       /*expectedNumCallbackCalls=*/3);
 }
@@ -226,7 +226,7 @@ TEST(DiagnosticInfo, CategoryAPIDigesterBreakage) {
             .warnUntilLanguageMode(LanguageMode::future);
       },
       [](DiagnosticEngine &, const DiagnosticInfo &info) {
-        EXPECT_EQ(info.Category, "api-digester-breaking-change");
+        EXPECT_EQ(info.getCategoryName(), "api-digester-breaking-change");
       },
       /*expectedNumCallbackCalls=*/3);
 }


### PR DESCRIPTION
When a diagnostic belongs to a group that has a parent group (`GROUP_LINK` in `DiagnosticGroups.def`), display the full inheritance chain in the diagnostic output, including documentation hyperlinks and footnotes for each.

For example, a diagnostic in `ExistentialType` (child of `PerformanceHints`) now renders as:
```
warning: ... [#PerformanceHints::ExistentialType]
```
Groups without parents continue to display as before (`[#DeprecatedDeclaration]`).

Resolves rdar://170805800
