### PR TITLE
[flow-isolation/rbi] Support initializing global-actor-isolated fields in nonisolated actor inits before self escapes

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -1220,6 +1220,40 @@ GROUPED_ERROR(regionbasedisolation_inout_sending_in_same_region, RegionIsolation
 NOTE(regionbasedisolation_inout_sending_in_same_region_note, none,
      "caller function assumes on return that %0 and %1 cannot be used to access each other implying sending them to different isolation domains does not risk a data race", (Identifier, Identifier))
 
+//===
+// Merge Region Failure Error
+//
+
+ERROR(regionbasedisolation_merge_region_failure_error_unknown, none,
+      "allowing references between %select{%0|%1 %0}4 and %3 %2 risks causing data races",
+      (Identifier, StringRef, Identifier, StringRef, bool))
+NOTE(regionbasedisolation_merge_region_failure_error_unknown_note, none,
+     "%0 could become accessible to %3 code despite remaining accessible to %select{code in the current task|%1 code}4",
+     (Identifier, StringRef, Identifier, StringRef, bool))
+ERROR(regionbasedisolation_merge_region_failure_error_assign, none,
+      "assigning %select{%0|%1 %0}4 to %3 %2 risks causing data races",
+      (Identifier, StringRef, Identifier, StringRef, bool))
+NOTE(regionbasedisolation_merge_region_failure_error_assign_note, none,
+      "%0 could become accessible to %2 code despite remaining accessible to %select{code in the current task|%1 code}3",
+      (Identifier, StringRef, StringRef, bool))
+ERROR(regionbasedisolation_merge_region_failure_error_functionisolation, none,
+      "passing %select{%0|%1 %0}4 to %3 %kind2 risks causing data races",
+      (Identifier, StringRef, const ValueDecl *, StringRef, bool))
+ERROR(regionbasedisolation_merge_region_failure_error_functionisolation_type, none,
+      "passing %select{%0|%1 %0}4 to %3 %kind2 risks causing data races",
+      (Type, StringRef, const ValueDecl *, StringRef, bool))
+
+ERROR(regionbasedisolation_merge_region_failure_error_functionisolation_sil, none,
+      "passing %1 %0 to %3 %2 risks causing data races",
+      (Identifier, StringRef, Identifier, StringRef))
+
+// We always put the potential task-isolated value first to simplify the note.
+ERROR(regionbasedisolation_merge_region_failure_error_nonisolatedfunction, none,
+      "passing %select{%0|%1 %0}5 and %3 %2 as arguments to %kind4 risks causing data races",
+      (Identifier, StringRef, Identifier, StringRef, const ValueDecl *, bool))
+NOTE(regionbasedisolation_merge_region_failure_error_nonisolatedfunction_note, none,
+     "%2 could begin referencing %0 allowing concurrent access to %0 by %3 code and %select{code in the current task|%1 code}5", (Identifier, StringRef, Identifier, StringRef, const ValueDecl *, bool))
+
 // Concurrency related diagnostics
 ERROR(cannot_find_executor_factory_type, none,
       "the DefaultExecutorFactory type could not be found", ())

--- a/include/swift/SIL/SILArgument.h
+++ b/include/swift/SIL/SILArgument.h
@@ -447,6 +447,15 @@ public:
                SILParameterInfo::Isolated);
   }
 
+  /// Returns true if this SILFunctionArgument is an isolated leading
+  /// ImplicitBuiltinActor.
+  bool isImplicitBuiltinActor() const {
+    return isIsolated() &&
+           getKnownParameterInfo().getOptions().contains(
+               SILParameterInfo::ImplicitLeading) &&
+           getType().isBuiltinImplicitActor();
+  }
+
   Lifetime getLifetime() const {
     return getType()
         .getLifetime(*getFunction())

--- a/include/swift/SILOptimizer/Utils/PartitionOpError.def
+++ b/include/swift/SILOptimizer/Utils/PartitionOpError.def
@@ -149,6 +149,12 @@ PARTITION_OP_VERBATIM_ERROR(InOutSendingReturned)
 /// called from a different actor), returning a non-Sendable type is unsafe.
 PARTITION_OP_VERBATIM_ERROR(NonSendableIsolationCrossingResult)
 
+/// Used to signify that when performing the analysis two regions with
+/// incompatible isolations were attempted to be merged. Contains information
+/// to SendNonSendable knows /why/ the region merge happened so that we can
+/// emit a nice diagnostic.
+PARTITION_OP_VERBATIM_ERROR(IncompatibleRegionMerge)
+
 //===---
 // Verbatim Errors with Special Emission
 //

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -90,6 +90,49 @@ class Partition;
 class SendingOperandToStateMap;
 class RegionAnalysisValueMap;
 
+enum class RegionMergeReason : uint8_t {
+  Unknown = 0,
+
+  /// We are assigning src into dst but since src can not be overwritten
+  /// completely, we have to merge the whole region of src into dst
+  /// region. E.x.: a MainActor isolated struct with multiple fields where a
+  /// task-isolated value is merged into one of those fields.
+  Assign = 1,
+
+  /// dstRegionElt is an ActorIsolated introducing value from a function
+  /// with isolation. srcRegionElt is a value that is in a region with some
+  /// other incompatible isolation.
+  ///
+  /// E.x.: Passing a task-isolated value to a MainActor isolated function.
+  IsolatedFunction = 2,
+
+  /// Regions are being merged as a result of capturing values in a
+  /// nonisolated closure. This occurs when a closure with no isolation
+  /// captures multiple values from different isolation domains.
+  ///
+  /// E.x.: A nonisolated closure capturing both a MainActor isolated value
+  /// and a task-isolated value.
+  NonisolatedClosure = 3,
+
+  /// Regions are being merged due to passing values to a compiler builtin
+  /// operation. Builtins do not cross isolation boundaries, so their operands
+  /// must be in compatible regions.
+  ///
+  /// E.x.: Passing values with incompatible isolation to a builtin operation.
+  Builtin = 4,
+
+  /// Regions are being merged due to calling a nonisolated function.
+  /// Nonisolated functions do not establish isolation boundaries, so their
+  /// parameters are merged with the result region.
+  ///
+  /// E.x.: Passing multiple arguments with incompatible isolation to a
+  /// nonisolated function.
+  NonisolatedFunction = 5,
+
+  First = Assign,
+  Last = NonisolatedFunction,
+};
+
 /// The representative value of the equivalence class that makes up a tracked
 /// value.
 ///
@@ -573,7 +616,41 @@ public:
     /// element of the region that was captured by reference in a closure, we
     /// can ignore the use.
     RequireOfMutableBaseOfSendableValue,
+
+    // RegionMergeReason is packed into bits 2-4 (3 bits total).
+    // With 3 bits, we can represent 8 values (0-7).
+    RegionMergeReasonBitStart = 2,
+    RegionMergeReasonBitEnd = 5,
+
+#ifdef REGION_MERGE_REASON_DEF
+#error "REGION_MERGE_REASON_DEF already defined"
+#endif
+#define REGION_MERGE_REASON_DEF(NAME)                                          \
+  RegionMergeReason##NAME = uint8_t(RegionMergeReason::NAME)                   \
+                            << RegionMergeReasonBitStart
+    REGION_MERGE_REASON_DEF(Assign),
+    REGION_MERGE_REASON_DEF(IsolatedFunction),
+    REGION_MERGE_REASON_DEF(NonisolatedClosure),
+    REGION_MERGE_REASON_DEF(Builtin),
+    REGION_MERGE_REASON_DEF(NonisolatedFunction),
+#undef REGION_MERGE_REASON_DEF
+
+    // Mask = ((1 << number_of_bits) - 1) << first_bit
+    // With 3 bits starting at bit 2: ((1 << 3) - 1) << 2 = 7 << 2 = 0b11100
+    RegionMergeReasonMask = uint8_t(unsigned(1 << (RegionMergeReasonBitEnd -
+                                                   RegionMergeReasonBitStart)) -
+                                    1)
+                            << RegionMergeReasonBitStart,
+    RegionMergeReasonFirst = RegionMergeReasonAssign,
+    RegionMergeReasonLast = RegionMergeReasonNonisolatedFunction,
   };
+
+  static_assert((1 << unsigned(Flag::RegionMergeReasonBitStart)) <=
+                    unsigned(Flag::RegionMergeReasonFirst) &&
+                "Out of bit region");
+  static_assert((1 << unsigned(Flag::RegionMergeReasonBitEnd)) >
+                    uint8_t(Flag::RegionMergeReasonLast) &&
+                "Out of bit region");
   using Options = OptionSet<Flag>;
 
 private:
@@ -587,12 +664,13 @@ private:
 
   PartitionOpKind opKind;
 
-  Options options;
+  uint8_t options;
 
   // TODO: can the following declarations be merged?
   PartitionOp(PartitionOpKind opKind, Element arg1,
               SILInstruction *sourceInst = nullptr, Options options = {})
-      : source(sourceInst), opArg1(arg1), opKind(opKind), options(options) {
+      : source(sourceInst), opArg1(arg1), opKind(opKind),
+        options(options.toRaw()) {
     assert(((opKind != PartitionOpKind::Send &&
              opKind != PartitionOpKind::UndoSend) ||
             sourceInst) &&
@@ -601,7 +679,8 @@ private:
 
   PartitionOp(PartitionOpKind opKind, Element arg1, Operand *sourceOperand,
               Options options = {})
-      : source(sourceOperand), opArg1(arg1), opKind(opKind), options(options) {
+      : source(sourceOperand), opArg1(arg1), opKind(opKind),
+        options(options.toRaw()) {
     assert(((opKind != PartitionOpKind::Send &&
              opKind != PartitionOpKind::UndoSend) ||
             bool(sourceOperand)) &&
@@ -611,7 +690,7 @@ private:
   PartitionOp(PartitionOpKind opKind, Element arg1, Element arg2,
               SILInstruction *sourceInst = nullptr, Options options = {})
       : source(sourceInst), opArg1(arg1), opArg2(arg2), opKind(opKind),
-        options(options) {
+        options(options.toRaw()) {
     assert(((opKind != PartitionOpKind::Send &&
              opKind != PartitionOpKind::UndoSend) ||
             sourceInst) &&
@@ -619,12 +698,15 @@ private:
   }
 
   PartitionOp(PartitionOpKind opKind, Element arg1, Element arg2,
-              Operand *sourceOp = nullptr, Options options = {})
+              Operand *sourceOp = nullptr, Options options = {},
+              RegionMergeReason reason = RegionMergeReason::Unknown)
       : source(sourceOp), opArg1(arg1), opArg2(arg2), opKind(opKind),
         options(options) {
+    // Use the helper to put the reason in so we do not hard code it here.
+    setRegionMergeReason(reason);
     assert((opKind == PartitionOpKind::AssignDirect ||
             opKind == PartitionOpKind::Merge) &&
-           "Only supported for assign_direct and merge");
+           "Only supported for assign_direct, merge, and merge_failure");
   }
 
   PartitionOp(PartitionOpKind opKind, Element arg1, Element arg2, Element arg3,
@@ -679,9 +761,10 @@ public:
   }
 
   static PartitionOp Merge(Element destElement, Element srcElement,
+                           RegionMergeReason reason,
                            Operand *sourceOperand = nullptr) {
     return PartitionOp(PartitionOpKind::Merge, destElement, srcElement,
-                       sourceOperand);
+                       sourceOperand, {}, reason);
   }
 
   static PartitionOp Require(Element tgt, SILInstruction *sourceInst = nullptr,
@@ -709,7 +792,7 @@ public:
   bool operator==(const PartitionOp &other) const {
     return opKind == other.opKind && opArg1 == other.opArg1 &&
            opArg2 == other.opArg2 && opArg3 == other.opArg3 &&
-           source == other.source;
+           source == other.source && options == other.options;
   };
 
   bool operator<(const PartitionOp &other) const {
@@ -746,7 +829,11 @@ public:
       return *opArg3 < other.opArg3;
     }
 
-    return source < other.source;
+    if (source != other.source) {
+      return source < other.source;
+    }
+
+    return options < other.options;
   }
 
   PartitionOpKind getKind() const { return opKind; }
@@ -755,7 +842,23 @@ public:
   Element getOpArg2() const { return opArg2.value(); }
   Element getOpArg3() const { return opArg3.value(); }
 
-  Options getOptions() const { return options; }
+  /// Return options without merge failure reasons. Those are just stored
+  /// inline.
+  Options getOptions() const {
+    return Options(options & ~uint8_t(Flag::RegionMergeReasonMask));
+  }
+
+  RegionMergeReason getRegionMergeReason() const {
+    // Apply the mask and then shift over the final result.
+    return RegionMergeReason((options & uint8_t(Flag::RegionMergeReasonMask)) >>
+                             uint8_t(Flag::RegionMergeReasonBitStart));
+  }
+
+  void setRegionMergeReason(RegionMergeReason reason) {
+    // Mask out the old bits and shift in the new bits.
+    options = (options & ~uint8_t(Flag::RegionMergeReasonMask)) |
+              (uint8_t(reason) << unsigned(Flag::RegionMergeReasonBitStart));
+  }
 
   void getOpArgs(SmallVectorImpl<Element> &args) const {
     if (opArg1.has_value())
@@ -1337,6 +1440,56 @@ public:
     }
   };
 
+  /// Error emitted when attempting to merge two regions with incompatible
+  /// isolation domains.
+  ///
+  /// This error is detected during partition evaluation when we try to merge
+  /// a source region into a destination region, but their isolation attributes
+  /// are incompatible (e.g., merging a task-isolated value into a MainActor-
+  /// isolated value).
+  ///
+  /// The error contains:
+  /// - srcRegionElt: An element from the source region being merged
+  /// - dstRegionElt: An element from the destination region (merge target)
+  /// - Isolation info for both regions
+  /// - Reason: Context about why the merge is happening (assign, function call,
+  ///   etc.), which enables emitting better diagnostics than just "a merge
+  ///   happened here". For example, we can say "cannot pass X to function Y"
+  ///   instead of "cannot merge region X into region Y".
+  struct IncompatibleRegionMergeError {
+    using Reason = RegionMergeReason;
+
+    const PartitionOp *op;
+
+    Element srcRegionElt;
+    SILDynamicMergedIsolationInfo srcIsolationRegionInfo;
+    Element dstRegionElt;
+    SILDynamicMergedIsolationInfo dstIsolationRegionInfo;
+    Reason reason;
+
+    IncompatibleRegionMergeError(
+        const PartitionOp &op, Element srcRegionElt,
+        SILDynamicMergedIsolationInfo srcIsolationRegionInfo,
+        Element dstRegionElt,
+        SILDynamicMergedIsolationInfo dstIsolationRegionInfo,
+        Reason reason = Reason::Unknown)
+        : op(&op), srcRegionElt(srcRegionElt),
+          srcIsolationRegionInfo(srcIsolationRegionInfo),
+          dstRegionElt(dstRegionElt),
+          dstIsolationRegionInfo(dstIsolationRegionInfo), reason(reason) {}
+
+    IncompatibleRegionMergeError(IncompatibleRegionMergeError &&other) =
+        default;
+    IncompatibleRegionMergeError &
+    operator=(IncompatibleRegionMergeError &&other) = default;
+
+    void print(llvm::raw_ostream &os, RegionAnalysisValueMap &valueMap) const;
+
+    SWIFT_DEBUG_DUMPER(dump(RegionAnalysisValueMap &valueMap)) {
+      print(llvm::dbgs(), valueMap);
+    }
+  };
+
 #define PARTITION_OP_ERROR(NAME)                                               \
   static_assert(!std::is_copy_constructible_v<NAME##Error>,                    \
                 #NAME " must not be copy constructable");                      \
@@ -1698,7 +1851,9 @@ public:
 
     switch (op.getKind()) {
     case PartitionOpKind::AssignDirect: {
-      assert(p.isTrackingElement(op.getOpArg2()) &&
+      auto destElement = op.getOpArg1();
+      auto srcElement = op.getOpArg2();
+      assert(p.isTrackingElement(srcElement) &&
              "Assign PartitionOp's source argument should be already tracked");
 
       // First emit any errors if we are assigning a non-disconnected thing into
@@ -1709,28 +1864,51 @@ public:
       //
       // NOTE: This does not emit any errors on purpose. We rely on requires and
       // other instructions to emit errors.
-      p.assignElement(op.getOpArg1(), op.getOpArg2());
+      p.assignElement(destElement, srcElement);
       return;
     }
     case PartitionOpKind::AssignIndirect: {
-      assert(p.isTrackingElement(op.getOpArg1()) &&
+      auto destElement = op.getOpArg1();
+      auto srcElement = op.getOpArg2();
+      assert(p.isTrackingElement(destElement) &&
              "Assign PartitionOp's dest argument should be already tracked");
-      assert(p.isTrackingElement(op.getOpArg2()) &&
+      assert(p.isTrackingElement(srcElement) &&
              "Assign PartitionOp's source argument should be already tracked");
 
       // First emit any errors if we are assigning a non-disconnected thing into
       // a sending result.
       handleAssignNonDisconnectedIntoSendingResult(op);
 
+      // Check if our actual destElement is directly actor isolated in a way
+      // that does not match our srcElement's region. In that case, the memory
+      // itself is actor isolated and we have to emit an incompatible merge
+      // error.
+      auto destIsolation = getIsolationRegionInfo(destElement);
+      auto srcRegIsolation = getIsolationRegionInfo(p.getRegion(srcElement));
+      if (!srcRegIsolation.merge(destIsolation)) {
+        // See if either of our elements are nonisolated(unsafe). In such a
+        // case, we need to avoid emitting the error. We still do not merge
+        // since regions can only have one isolation and we would break that
+        // invariant when looking at other values in the region that are not
+        // marked as nonisolated(unsafe).
+        if (getIsolationRegionInfo(srcElement).isUnsafeNonIsolated() ||
+            getIsolationRegionInfo(destElement).isUnsafeNonIsolated())
+          return;
+        return handleError(IncompatibleRegionMergeError(
+            op, srcElement, srcRegIsolation, destElement, destIsolation,
+            RegionMergeReason::Assign));
+      }
+
       // Create extra region for our dest and merge it into dest's region.
-      p.trackNewElement(op.getOpArg3());
-      p.merge(op.getOpArg1(), op.getOpArg3());
+      auto oldValueElement = op.getOpArg3();
+      p.trackNewElement(oldValueElement);
+      p.merge(destElement, oldValueElement);
 
       // Then perform the actual assignment.
       //
       // NOTE: This does not emit any errors on purpose. We rely on requires and
       // other instructions to emit errors.
-      p.assignElement(op.getOpArg1(), op.getOpArg2());
+      p.assignElement(destElement, srcElement);
       return;
     }
     case PartitionOpKind::AssignFresh: {
@@ -1818,19 +1996,39 @@ public:
       return;
     }
     case PartitionOpKind::Merge: {
-      assert(p.isTrackingElement(op.getOpArg1()) &&
-             p.isTrackingElement(op.getOpArg2()) &&
+      auto destElement = op.getOpArg1();
+      auto srcElement = op.getOpArg2();
+      assert(p.isTrackingElement(destElement) &&
+             p.isTrackingElement(srcElement) &&
              "Merge PartitionOp's arguments should already be tracked");
 
       // Emit an error if we are assigning a non-disconnected thing into a
       // sending result.
       handleAssignNonDisconnectedIntoSendingResult(op);
 
+      // Check if we can merge our two regions successfully. If we cannot, we
+      // need to emit an error and not perform the actual merge.
+      auto destRegIsolation = getIsolationRegionInfo(p.getRegion(destElement));
+      auto srcRegIsolation = getIsolationRegionInfo(p.getRegion(srcElement));
+      if (!destRegIsolation.merge(srcRegIsolation)) {
+        // See if either of our elements are nonisolated(unsafe). In such a
+        // case, we need to avoid emitting the error. We still do not merge
+        // since regions can only have one isolation and we would break that
+        // invariant when looking at other values in the region that are not
+        // marked as nonisolated(unsafe).
+        if (getIsolationRegionInfo(srcElement).isUnsafeNonIsolated() ||
+            getIsolationRegionInfo(destElement).isUnsafeNonIsolated())
+          return;
+        return handleError(IncompatibleRegionMergeError(
+            op, srcElement, srcRegIsolation, destElement, destRegIsolation,
+            op.getRegionMergeReason()));
+      }
+
       // Then perform the actual merge.
       //
       // NOTE: This does not emit any errors on purpose. We rely on requires and
       // other instructions to emit errors.
-      p.merge(op.getOpArg1(), op.getOpArg2());
+      p.merge(srcElement, destElement);
       return;
     }
     case PartitionOpKind::Require:
@@ -1963,6 +2161,7 @@ public:
 
       // Then emit an unknown code pattern error.
       return handleError(UnknownCodePatternError(op));
+
     case PartitionOpKind::NonSendableIsolationCrossingResult: {
       // Then emit the error.
       return handleError(

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -422,7 +422,7 @@ struct SendingOperandState {
   /// The dynamic isolation info of the region of value when we sent.
   ///
   /// This will contain the isolated value if we found one.
-  SILDynamicMergedIsolationInfo isolationInfo;
+  std::optional<SILDynamicMergedIsolationInfo> isolationInfo;
 
   /// The dynamic isolation history at this point.
   IsolationHistory isolationHistory;
@@ -435,6 +435,22 @@ struct SendingOperandState {
 
   SendingOperandState(IsolationHistory history)
       : isolationInfo(), isolationHistory(history), isClosureCaptured(false) {}
+
+  bool merge(SILDynamicMergedIsolationInfo newIsolationInfo) {
+    if (!isolationInfo) {
+      isolationInfo = newIsolationInfo;
+      return true;
+    }
+    auto newIsolation = isolationInfo->merge(newIsolationInfo);
+    if (!newIsolation)
+      return false;
+    isolationInfo = newIsolation;
+    return true;
+  }
+
+  SILIsolationInfo getIsolationInfo() const {
+    return isolationInfo.value().getIsolationInfo();
+  }
 };
 
 class SendingOperandToStateMap {
@@ -1456,21 +1472,47 @@ public:
   std::optional<std::pair<SILDynamicMergedIsolationInfo, bool>>
   getIsolationRegionInfo(Region region, Operand *sourceOp) const {
     bool isClosureCapturedElt = false;
-    std::optional<SILDynamicMergedIsolationInfo> isolationRegionInfo =
-        SILDynamicMergedIsolationInfo();
+    std::optional<SILDynamicMergedIsolationInfo> isolationRegionInfo;
 
     for (const auto &pair : p.range()) {
       if (pair.second == region) {
-        isolationRegionInfo =
-            isolationRegionInfo->merge(getIsolationRegionInfo(pair.first));
-        if (!isolationRegionInfo)
+        auto other = getIsolationRegionInfo(pair.first);
+        // If other is invalid, just return nil.
+        if (!bool(other))
           return {};
+
+        // Otherwise, if we haven't tracked any isolation region info
+        // yet... just assign our optional to that and continue.
+        if (!isolationRegionInfo.has_value()) {
+          isolationRegionInfo = other;
+          continue;
+        }
+
+        // If we have an isolation region info that is not invalid at this point
+        // in our accumulator and other should not be invalid either. Perform
+        // the merge.
+        assert(isolationRegionInfo.has_value() && bool(*isolationRegionInfo) &&
+               "Should have a valid, non-invalid isolation");
+        isolationRegionInfo = isolationRegionInfo->merge(other);
+
+        // Then check if as a result of merging, we now have an invalid value,
+        // return nil in such a case.
+        if (!bool(isolationRegionInfo.value()))
+          return {};
+
+        // Otherwise, gather if we have a closure capture.
         if (sourceOp) {
           isClosureCapturedElt |= isClosureCaptured(pair.first, sourceOp);
         }
       }
     }
 
+    // If we found any element in our region, we should have a value in our
+    // accumulator. This signals some sort of error. Return nil in such a case.
+    if (!isolationRegionInfo.has_value())
+      return {};
+
+    // Otherwise, return the value that we computed.
     return {{isolationRegionInfo.value(), isClosureCapturedElt}};
   }
 
@@ -1758,9 +1800,7 @@ public:
       // Mark op.getOpArg1() as sent.
       SendingOperandState &state = operandToStateMap.get(op.getSourceOp());
       state.isClosureCaptured |= regionHasClosureCapturedElt;
-      if (auto newInfo = state.isolationInfo.merge(sentRegionIsolation)) {
-        state.isolationInfo = *newInfo;
-      } else {
+      if (!state.merge(sentRegionIsolation)) {
         handleError(UnknownCodePatternError(op));
       }
       assert(state.isolationInfo && "Cannot have unknown");

--- a/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
+++ b/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
@@ -171,24 +171,28 @@ public:
   /// This forms a lattice of semantics. The lattice progresses from left ->
   /// right below:
   ///
-  /// Unknown -> Disconnected -> Task -> Actor.
+  ///                 ---> Task ----
+  ///                /              \
+  /// Disconnected --                --> Invalid
+  ///                \              /
+  ///                 ---> Actor ---
   ///
   enum Kind : uint8_t {
-    /// Unknown means no information. We error when merging on it.
-    Unknown,
-
     /// An entity with disconnected isolation can be freely sent into another
     /// isolation domain. These are associated with "use after send"
     /// diagnostics.
-    Disconnected,
+    Disconnected = 0,
 
     /// An entity that is in the same region as a task-isolated value. Cannot be
     /// sent into another isolation domain.
-    Task,
+    Task = 1,
 
     /// An entity that is in the same region as an actor-isolated value. Cannot
     /// be sent into another isolation domain.
-    Actor,
+    Actor = 2,
+
+    /// Invalid means that we had information that did not work.
+    Invalid = 3,
   };
 
   enum class Flag : uint8_t {
@@ -280,9 +284,9 @@ private:
       SILValue value, CanType sourceType, CanType destType);
 
 public:
-  SILIsolationInfo() : actorIsolation(), kind(Kind::Unknown), options(0) {}
+  SILIsolationInfo() : actorIsolation(), kind(Kind::Invalid), options(0) {}
 
-  operator bool() const { return kind != Kind::Unknown; }
+  operator bool() const { return kind != Kind::Invalid; }
 
   operator Kind() const { return getKind(); }
 
@@ -665,12 +669,12 @@ public:
   SILDynamicMergedIsolationInfo(SILIsolationInfo innerInfo)
       : innerInfo(innerInfo) {}
 
-  /// Returns nullptr only if both this isolation info and \p other are actor
+  /// Returns invalid only if both this isolation info and \p other are actor
   /// isolated to incompatible actors.
-  [[nodiscard]] std::optional<SILDynamicMergedIsolationInfo>
+  [[nodiscard]] SILDynamicMergedIsolationInfo
   merge(SILIsolationInfo other) const;
 
-  [[nodiscard]] std::optional<SILDynamicMergedIsolationInfo>
+  [[nodiscard]] SILDynamicMergedIsolationInfo
   merge(SILDynamicMergedIsolationInfo other) const {
     return merge(other.getIsolationInfo());
   }

--- a/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
+++ b/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
@@ -203,7 +203,8 @@ public:
     UnsafeNonIsolated = 0x1,
 
     /// If set, this means that this actor isolation is from an isolated
-    /// parameter and should be allowed to merge into a self parameter.
+    /// parameter and should be allowed to merge into a self parameter or an
+    /// implicit builtin actor.
     UnappliedIsolatedAnyParameter = 0x2,
 
     /// If set, this was a TaskIsolated value from a nonisolated(nonsending)

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -1878,7 +1878,8 @@ struct PartitionOpBuilder {
         PartitionOp::UndoSend(lookupValueID(representative), unsendingInst));
   }
 
-  void addMerge(TrackableValue destValue, Operand *srcOperand) {
+  void addMerge(TrackableValue destValue, Operand *srcOperand,
+                RegionMergeReason reason = RegionMergeReason::Unknown) {
     if (destValue.isSendable())
       return;
     auto rep = destValue.getRepresentative().getValue();
@@ -1889,8 +1890,9 @@ struct PartitionOpBuilder {
     if (lookupValueID(rep) == lookupValueID(srcOperand->get()))
       return;
 
-    currentInstPartitionOps->emplace_back(PartitionOp::Merge(
-        lookupValueID(rep), lookupValueID(srcOperand->get()), srcOperand));
+    currentInstPartitionOps->emplace_back(
+        PartitionOp::Merge(lookupValueID(rep), lookupValueID(srcOperand->get()),
+                           reason, srcOperand));
   }
 
   /// Mark \p value artifically as being part of an actor-isolated region by
@@ -1902,7 +1904,8 @@ struct PartitionOpBuilder {
     currentInstPartitionOps->emplace_back(
         PartitionOp::AssignFresh(elt, currentInst));
     currentInstPartitionOps->emplace_back(
-        PartitionOp::Merge(sourceValue.getID(), elt, sourceOperand));
+        PartitionOp::Merge(elt, sourceValue.getID(),
+                           RegionMergeReason::IsolatedFunction, sourceOperand));
   }
 
   void addRequire(TrackableValueLookupResult value);
@@ -1934,6 +1937,11 @@ public:
       llvm::report_fatal_error(
           "RegionIsolation: Aborting on unknown pattern match error");
     }
+    currentInstPartitionOps->emplace_back(
+        PartitionOp::UnknownPatternError(lookupValueID(value), currentInst));
+  }
+
+  void addMergeError(SILValue value) {
     currentInstPartitionOps->emplace_back(
         PartitionOp::UnknownPatternError(lookupValueID(value), currentInst));
   }
@@ -2375,22 +2383,12 @@ public:
   translateSILMultiAssign(const DirectResultsRangeTy &directResultValues,
                           const IndirectResultsRangeTy &indirectResultAddresses,
                           const SourceValueRangeTy &sourceValues,
+                          RegionMergeReason reason,
                           SILIsolationInfo resultIsolationInfoOverride = {},
                           bool requireSrcValues = true) {
     SmallVector<std::pair<Operand *, TrackableValue>, 8> sourceOperandTVPairs;
     SmallVector<TrackableValue, 8> directResultTVs;
     SmallVector<std::pair<Operand *, TrackableValue>, 8> indirectResultTVPairs;
-
-    // A helper we use to emit an unknown patten error if our merge is
-    // invalid. This ensures we guarantee that if we find an actor merge error,
-    // the compiler halts. Importantly this lets our users know 100% that if the
-    // compiler exits successfully, actor merge errors could not have happened.
-    SILDynamicMergedIsolationInfo mergedInfo;
-    if (resultIsolationInfoOverride) {
-      mergedInfo = SILDynamicMergedIsolationInfo(resultIsolationInfoOverride);
-    } else {
-      mergedInfo = SILDynamicMergedIsolationInfo::getDisconnected(false);
-    }
 
     // For each operand...
     for (Operand *srcOperand : sourceValues) {
@@ -2420,38 +2418,22 @@ public:
           continue;
 
         sourceOperandTVPairs.push_back({srcOperand, value});
-        auto originalMergedInfo = mergedInfo;
-        (void)originalMergedInfo;
-        if (mergedInfo)
-          mergedInfo = mergedInfo.merge(value.getIsolationRegionInfo());
-
-        // If we fail to merge, then we have an incompatibility in between some
-        // of our arguments (consider isolated to different actors) or with the
-        // isolationInfo we specified. Emit an unknown patten error.
-        if (!mergedInfo) {
-          REGIONBASEDISOLATION_LOG(
-              llvm::dbgs() << "Merge Failure!\n"
-                           << "Original Info: ";
-              if (originalMergedInfo) originalMergedInfo->printForDiagnostics(
-                  builder.getFunction(), llvm::dbgs());
-              else llvm::dbgs() << "nil";
-              llvm::dbgs() << "\nValue Rep: "
-                           << value.getRepresentative().getValue();
-              llvm::dbgs() << "Original Src: " << src;
-              llvm::dbgs() << "Value Info: ";
-              value.getIsolationRegionInfo().printForDiagnostics(
-                  builder.getFunction(), llvm::dbgs());
-              llvm::dbgs() << "\n");
-          builder.addUnknownPatternError(src);
-          continue;
-        }
       }
     }
 
-    // Merge all srcs.
-    for (unsigned i = 1; i < sourceOperandTVPairs.size(); i++) {
-      builder.addMerge(sourceOperandTVPairs[i - 1].second,
-                       sourceOperandTVPairs[i].first);
+    // Merge all srcs if we have any.
+    if (sourceOperandTVPairs.size()) {
+      // NOTE: A merge can fail if we have multiple operands with incompatible
+      // regions. We will dynamically emit an error in such a case and not merge
+      // that value into our region... we do want to merge /all/ other operands
+      // though so we merge as much as possible. To ensure that this happens, we
+      // merge all operands into the first operand's region to ensure that we
+      // are always accumulating into a value that we haven't skipped since we
+      // never skip the firstValue.
+      auto firstValue = sourceOperandTVPairs[0].second;
+      for (unsigned i = 1; i < sourceOperandTVPairs.size(); i++) {
+        builder.addMerge(firstValue, sourceOperandTVPairs[i].first, reason);
+      }
     }
 
     // Then process our direct results.
@@ -2733,7 +2715,8 @@ public:
     translateSILMultiAssign(
         directResults,
         ArrayRef<Operand *>(), // No indirect results for a partial_apply.
-        makeOperandRefRange(pai->getAllOperands()));
+        makeOperandRefRange(pai->getAllOperands()),
+        RegionMergeReason::NonisolatedClosure);
   }
 
   void translateCreateAsyncTask(BuiltinInst *bi) {
@@ -2762,7 +2745,8 @@ public:
     // needed. The important thing is that in the future, builtins that use
     // indirect results are passed in the indirect result array.
     return translateSILMultiAssign(bi->getResults(), ArrayRef<Operand *>(),
-                                   makeOperandRefRange(bi->getAllOperands()));
+                                   makeOperandRefRange(bi->getAllOperands()),
+                                   RegionMergeReason::Builtin);
   }
 
   void translateNonIsolationCrossingSILApply(FullApplySite fas) {
@@ -2825,8 +2809,9 @@ public:
 
     // If our result is not a 'sending' result, just do the normal multi-assign.
     if (!type->hasSendingResult()) {
-      return translateSILMultiAssign(applyResults, ArrayRef<Operand *>(),
-                                     nonSendingParameters, isolationInfo);
+      return translateSILMultiAssign(
+          applyResults, ArrayRef<Operand *>(), nonSendingParameters,
+          RegionMergeReason::NonisolatedFunction, isolationInfo);
     }
 
     // If our result is a 'sending' result, then pass in empty as our results,
@@ -3089,9 +3074,9 @@ public:
   template <>
   void translateSILAssignIndirect<Operand *>(Operand *dest,
                                              Operand *srcOperand) {
-    return translateSILMultiAssign(ArrayRef<SILValue>(),
-                                   TinyPtrVector<Operand *>(dest),
-                                   TinyPtrVector<Operand *>(srcOperand));
+    return translateSILMultiAssign(
+        ArrayRef<SILValue>(), TinyPtrVector<Operand *>(dest),
+        TinyPtrVector<Operand *>(srcOperand), RegionMergeReason::Assign);
   }
 
   /// Perform an assign for dest that is a direct parameter. It should be a
@@ -3099,16 +3084,17 @@ public:
   template <typename Collection>
   void translateSILAssignDirect(SILValue dest, Collection collection) {
     return translateSILMultiAssign(TinyPtrVector<SILValue>(dest),
-                                   ArrayRef<Operand *>(), collection);
+                                   ArrayRef<Operand *>(), collection,
+                                   RegionMergeReason::Assign);
   }
 
   template <>
   void translateSILAssignDirect(SILValue dest,
                                 MutableArrayRef<Operand> collection) {
     auto transform = [](Operand &op) { return &op; };
-    return translateSILMultiAssign(TinyPtrVector<SILValue>(dest),
-                                   ArrayRef<Operand *>(),
-                                   makeTransformRange(collection, transform));
+    return translateSILMultiAssign(
+        TinyPtrVector<SILValue>(dest), ArrayRef<Operand *>(),
+        makeTransformRange(collection, transform), RegionMergeReason::Assign);
   }
   /// Perform an assign for dest that is a direct parameter. It should be a
   /// parameter of the current inst we are processing.
@@ -3124,8 +3110,8 @@ public:
   /// isolationInfo is set.
   void translateSILAssignFresh(SILValue val) {
     return translateSILMultiAssign(TinyPtrVector<SILValue>(val),
-                                   ArrayRef<Operand *>(),
-                                   ArrayRef<Operand *>());
+                                   ArrayRef<Operand *>(), ArrayRef<Operand *>(),
+                                   RegionMergeReason::Assign);
   }
 
   void translateSILAssignFresh(SILValue val, SILIsolationInfo info) {
@@ -3141,7 +3127,7 @@ public:
 
   template <typename Collection>
   void translateSILMerge(SILValue dest, Collection srcCollection,
-                         bool requireOperands,
+                         bool requireOperands, RegionMergeReason reason,
                          SILIsolationInfo resultIsolationInfoOverride = {}) {
     auto destResult =  tryToTrackValue(dest);
     if (!destResult)
@@ -3167,21 +3153,23 @@ public:
         }
 
         if (srcResult->value.isNonSendable())
-          builder.addMerge(destResult->value, op);
+          builder.addMerge(destResult->value, op, reason);
       }
     }
   }
 
   template <>
-  void translateSILMerge<Operand *>(SILValue dest, Operand *src,
-                                    bool requireOperands,
-                                    SILIsolationInfo resultIsolationInfoOverride) {
+  void
+  translateSILMerge<Operand *>(SILValue dest, Operand *src,
+                               bool requireOperands, RegionMergeReason reason,
+                               SILIsolationInfo resultIsolationInfoOverride) {
     return translateSILMerge(dest, TinyPtrVector<Operand *>(src),
-                             requireOperands, resultIsolationInfoOverride);
+                             requireOperands, reason,
+                             resultIsolationInfoOverride);
   }
 
-  void translateSILMerge(MutableArrayRef<Operand> array,
-                         bool requireOperands,
+  void translateSILMerge(MutableArrayRef<Operand> array, bool requireOperands,
+                         RegionMergeReason reason,
                          SILIsolationInfo resultIsolationInfoOverride = {}) {
     if (array.size() < 2)
       return;
@@ -3246,7 +3234,8 @@ public:
         return translateSILAssignIndirect(dest, src);
 
       // Stores to possibly aliased storage must be treated as merges.
-      return translateSILMerge(destValue, src, /*requireOperand*/true,
+      return translateSILMerge(destValue, src, /*requireOperand*/ true,
+                               RegionMergeReason::Assign,
                                resultIsolationInfoOverride);
     }
 
@@ -3283,9 +3272,9 @@ public:
             dest, makeOperandRefRange(inst->getElementOperands()));
 
       // Stores to possibly aliased storage must be treated as merges.
-      return translateSILMerge(dest,
-                               makeOperandRefRange(inst->getElementOperands()),
-                               /*requireOperands=*/true);
+      return translateSILMerge(
+          dest, makeOperandRefRange(inst->getElementOperands()),
+          /*requireOperands=*/true, RegionMergeReason::Assign);
     }
 
     // Stores to storage of non-Sendable type can be ignored.
@@ -3306,7 +3295,7 @@ public:
       enumOperands.push_back(selectEnumInst.getDefaultResultOperand());
     return translateSILMultiAssign(
         TinyPtrVector<SILValue>(selectEnumInst->getResult(0)),
-        ArrayRef<Operand *>(), enumOperands);
+        ArrayRef<Operand *>(), enumOperands, RegionMergeReason::Assign);
   }
 
   void translateSILSwitchEnum(SwitchEnumInst *switchEnumInst) {
@@ -3335,9 +3324,9 @@ public:
                        SILIsolationInfo resultIsolationInfoOverride = {}) {
     argSources.argSources.setFrozen();
     for (auto pair : argSources.argSources.getRange()) {
-      translateSILMultiAssign(TinyPtrVector<SILValue>(pair.first),
-                              ArrayRef<Operand *>(), pair.second,
-                              resultIsolationInfoOverride);
+      translateSILMultiAssign(
+          TinyPtrVector<SILValue>(pair.first), ArrayRef<Operand *>(),
+          pair.second, RegionMergeReason::Unknown, resultIsolationInfoOverride);
     }
   }
 
@@ -3426,6 +3415,7 @@ public:
       return translateSILMultiAssign(
           inst->getResults(), ArrayRef<Operand *>(),
           makeOperandRefRange(inst->getAllOperands()),
+          RegionMergeReason::Assign,
           SILIsolationInfo::getConformanceIsolation(inst));
 
     case TranslationSemantics::Require:
@@ -4120,11 +4110,12 @@ PartitionOpTranslator::visitStoreBorrowInst(StoreBorrowInst *sbi) {
       !isProjectedFromAggregate(destValue)) {
     translateSILMultiAssign(sbi->getResults(), ArrayRef<Operand *>(),
                             makeOperandRefRange(sbi->getAllOperands()),
-                            SILIsolationInfo(), false /*require src*/);
+                            RegionMergeReason::Assign, SILIsolationInfo(),
+                            false /*require src*/);
   } else {
     // Stores to possibly aliased storage must be treated as merges.
     translateSILMerge(destValue, &sbi->getAllOperands()[StoreBorrowInst::Src],
-                      false /*require src*/);
+                      false /*require src*/, RegionMergeReason::Assign);
   }
 
   return TranslationSemantics::Special;
@@ -4328,7 +4319,8 @@ PartitionOpTranslator::visitBeginDeallocRefInst(BeginDeallocRefInst *bdr) {
 TranslationSemantics PartitionOpTranslator::visitMergeIsolationRegionInst(
     MergeIsolationRegionInst *mir) {
   // But we want to require and merge the base into the result.
-  translateSILMerge(mir->getAllOperands(), true /*require operands*/);
+  translateSILMerge(mir->getAllOperands(), true /*require operands*/,
+                    RegionMergeReason::Assign);
   return TranslationSemantics::Special;
 }
 
@@ -4449,6 +4441,7 @@ TranslationSemantics PartitionOpTranslator::visitCheckedCastAddrBranchInst(
   // but still correct.
   translateSILMultiAssign(ArrayRef<SILValue>(), ArrayRef<Operand *>(),
                           makeOperandRefRange(ccabi->getAllOperands()),
+                          RegionMergeReason::Unknown,
                           SILIsolationInfo::getConformanceIsolation(ccabi));
   return TranslationSemantics::Special;
 }
@@ -4585,6 +4578,11 @@ static bool canComputeRegionsForFunction(SILFunction *fn) {
   // is enabled. If not, there is a major bug in the compiler and we should
   // fail loudly.
   if (!fn->getASTContext().getProtocol(KnownProtocolKind::Sendable))
+    return false;
+
+  // We do not check thunks. We only emit diagnostics for user created
+  // functions.
+  if (fn->isThunk())
     return false;
 
   return true;

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -2385,7 +2385,7 @@ public:
     // invalid. This ensures we guarantee that if we find an actor merge error,
     // the compiler halts. Importantly this lets our users know 100% that if the
     // compiler exits successfully, actor merge errors could not have happened.
-    std::optional<SILDynamicMergedIsolationInfo> mergedInfo;
+    SILDynamicMergedIsolationInfo mergedInfo;
     if (resultIsolationInfoOverride) {
       mergedInfo = SILDynamicMergedIsolationInfo(resultIsolationInfoOverride);
     } else {
@@ -2423,7 +2423,7 @@ public:
         auto originalMergedInfo = mergedInfo;
         (void)originalMergedInfo;
         if (mergedInfo)
-          mergedInfo = mergedInfo->merge(value.getIsolationRegionInfo());
+          mergedInfo = mergedInfo.merge(value.getIsolationRegionInfo());
 
         // If we fail to merge, then we have an incompatibility in between some
         // of our arguments (consider isolated to different actors) or with the

--- a/lib/SILOptimizer/Mandatory/FlowIsolation.cpp
+++ b/lib/SILOptimizer/Mandatory/FlowIsolation.cpp
@@ -894,6 +894,11 @@ class FlowIsolation : public SILFunctionTransform {
     if (fn->wasDeserializedCanonical())
       return;
 
+    // Do not run on thunks. We trust those and there isn't a benefit to the
+    // user. Any issue there is a compiler bug.
+    if (fn->isThunk())
+      return;
+
     // Look for functions that use flow-isolation.
     if (auto *dc = fn->getDeclContext())
       if (auto *afd = dyn_cast_or_null<AbstractFunctionDecl>(dc->getAsDecl()))

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -3732,6 +3732,264 @@ public:
 } // namespace
 
 //===----------------------------------------------------------------------===//
+//                      MARK: Incompatible Region Merge
+//===----------------------------------------------------------------------===//
+
+struct IncompatibleRegionMergeDiagnosticEmitter {
+  using Error = DiagnosticEvaluator::IncompatibleRegionMergeError;
+  RegionAnalysisValueMap &valueMap;
+  Operand *op;
+  Element srcRegionValueElt;
+  SILDynamicMergedIsolationInfo srcIsolationInfo;
+  Element dstRegionValueElt;
+  SILDynamicMergedIsolationInfo dstIsolationInfo;
+  RegionMergeReason reason;
+
+  IncompatibleRegionMergeDiagnosticEmitter(RegionAnalysisFunctionInfo *info,
+                                           Error error)
+      : valueMap(info->getValueMap()), op(error.op->getSourceOp()),
+        srcRegionValueElt(error.srcRegionElt),
+        srcIsolationInfo(error.srcIsolationRegionInfo),
+        dstRegionValueElt(error.dstRegionElt),
+        dstIsolationInfo(error.dstIsolationRegionInfo),
+        // NOTE: We purposely use the reason from the error, not from the op in
+        // the error since we may have an error reason that was specified
+        // explicitly when the error was created, not from the actual
+        // PartitionOp.
+        reason(error.reason) {}
+
+  void emit();
+
+  SILFunction *getFunction() const { return op->getFunction(); }
+
+  std::optional<DiagnosticBehavior> getBehaviorLimit() const {
+    return op->get()->getType().getConcurrencyDiagnosticBehavior(getFunction());
+  }
+
+private:
+  void emitUnknownPatternError() {
+    EMIT_UNKNOWN_PATTERN_ERROR(IncompatibleRegionMergeErrorEmitter,
+                               op->getUser(), getBehaviorLimit());
+  }
+
+  void emitUnknown();
+  void emitAssign();
+  void emitNonisolatedFunction();
+  void emitIsolatedFunction();
+};
+
+void IncompatibleRegionMergeDiagnosticEmitter::emitUnknown() {
+  auto srcRegionValue = valueMap.getRepresentativeValue(srcRegionValueElt);
+  auto dstRegionValue = valueMap.getRepresentativeValue(dstRegionValueElt);
+
+  // For now skip this.
+  if (dstRegionValue.hasRegionIntroducingInst())
+    return;
+
+  auto srcIsolation = srcIsolationInfo;
+  auto dstIsolation = dstIsolationInfo;
+
+  // Canonicalize so that srcRegionValue is always the task-isolated value. We
+  // do this only here since in this case, we can get away with doing this to
+  // implement a simpler diagnostic. E.x.: This doesn't work for assign.
+  if (!srcIsolation->isTaskIsolated() && dstIsolation->isTaskIsolated()) {
+    std::swap(srcIsolation, dstIsolation);
+    std::swap(srcRegionValue, dstRegionValue);
+  }
+
+  // We should always be able to find a name for an inout sending param. If we
+  // do not, emit an unknown pattern error.
+  auto srcName = inferNameHelper(srcRegionValue.getValue());
+  if (!srcName) {
+    return emitUnknownPatternError();
+  }
+  auto dstName = inferNameHelper(dstRegionValue.getValue());
+  if (!dstName) {
+    return emitUnknownPatternError();
+  }
+
+  auto srcIsolationStr = srcIsolation.printForDiagnostics(getFunction());
+  auto dstIsolationStr = dstIsolation.printForDiagnostics(getFunction());
+
+  diagnoseError(op->getUser(),
+                diag::regionbasedisolation_merge_region_failure_error_unknown,
+                *srcName, srcIsolationStr, *dstName, dstIsolationStr,
+                !srcIsolation->isTaskIsolated())
+      .limitBehaviorIf(getBehaviorLimit());
+  diagnoseNote(
+      op->getUser(),
+      diag::regionbasedisolation_merge_region_failure_error_unknown_note,
+      *srcName, srcIsolationStr, *dstName, dstIsolationStr,
+      !srcIsolation->isTaskIsolated());
+}
+
+void IncompatibleRegionMergeDiagnosticEmitter::emitAssign() {
+  auto srcRegionValue = valueMap.getRepresentativeValue(srcRegionValueElt);
+  auto dstRegionValue = valueMap.getRepresentativeValue(dstRegionValueElt);
+
+  auto srcIsolation = srcIsolationInfo;
+  auto dstIsolation = dstIsolationInfo;
+
+  // Canonicalize so that srcRegionValue is always the task-isolated value. We
+  // do this only here since in this case, we can get away with doing this to
+  // implement a simpler diagnostic. E.x.: This doesn't work for assign.
+  if (!srcIsolation->isTaskIsolated() && dstIsolation->isTaskIsolated()) {
+    std::swap(srcIsolation, dstIsolation);
+    std::swap(srcRegionValue, dstRegionValue);
+  }
+
+  // We should always be able to find a name for an inout sending param. If we
+  // do not, emit an unknown pattern error.
+  auto srcName = inferNameHelper(srcRegionValue.getValue());
+  if (!srcName) {
+    return emitUnknownPatternError();
+  }
+  auto dstName = inferNameHelper(dstRegionValue.getValue());
+  if (!dstName) {
+    return emitUnknownPatternError();
+  }
+
+  auto srcIsolationStr = srcIsolationInfo.printForDiagnostics(getFunction());
+  auto dstIsolationStr = dstIsolationInfo.printForDiagnostics(getFunction());
+  diagnoseError(op->getUser(),
+                diag::regionbasedisolation_merge_region_failure_error_assign,
+                *srcName, srcIsolationStr, *dstName, dstIsolationStr,
+                !srcIsolation->isTaskIsolated())
+      .limitBehaviorIf(getBehaviorLimit());
+  diagnoseNote(
+      op->getUser(),
+      diag::regionbasedisolation_merge_region_failure_error_assign_note,
+      *srcName, srcIsolationStr, dstIsolationStr,
+      !srcIsolation->isTaskIsolated());
+}
+
+void IncompatibleRegionMergeDiagnosticEmitter::emitNonisolatedFunction() {
+  auto srcIsolation = srcIsolationInfo;
+  auto dstIsolation = dstIsolationInfo;
+  auto srcRegionValue = valueMap.getRepresentativeValue(srcRegionValueElt);
+  auto dstRegionValue = valueMap.getRepresentativeValue(dstRegionValueElt);
+
+  // Canonicalize so that srcRegionValue is always the task-isolated value. We
+  // do this only here since in this case, we can get away with doing this to
+  // implement a simpler diagnostic. E.x.: This doesn't work for assign.
+  if (!srcIsolation->isTaskIsolated() && dstIsolation->isTaskIsolated()) {
+    std::swap(srcIsolation, dstIsolation);
+    std::swap(srcRegionValue, dstRegionValue);
+  }
+
+  // We should always be able to find a name for an inout sending param. If we
+  // do not, emit an unknown pattern error.
+  auto srcName = inferNameHelper(srcRegionValue.getValue());
+  if (!srcName) {
+    return emitUnknownPatternError();
+  }
+  auto dstName = inferNameHelper(dstRegionValue.getValue());
+  if (!dstName) {
+    return emitUnknownPatternError();
+  }
+
+  auto srcIsolationStr = srcIsolation.printForDiagnostics(getFunction());
+  auto dstIsolationStr = dstIsolation.printForDiagnostics(getFunction());
+  auto as = ApplySite::isa(op->getUser());
+  if (!as)
+    return emitUnknownPatternError();
+  auto declRef = as.getCalleeDeclRef();
+  if (!declRef)
+    return emitUnknownPatternError();
+
+  diagnoseError(
+      op->getUser(),
+      diag::regionbasedisolation_merge_region_failure_error_nonisolatedfunction,
+      *srcName, srcIsolationStr, *dstName, dstIsolationStr, declRef.getDecl(),
+      !srcIsolation->isTaskIsolated())
+      .limitBehaviorIf(getBehaviorLimit());
+  diagnoseNote(
+      op->getUser(),
+      diag::
+          regionbasedisolation_merge_region_failure_error_nonisolatedfunction_note,
+      *srcName, srcIsolationStr, *dstName, dstIsolationStr, declRef.getDecl(),
+      !srcIsolation->isTaskIsolated());
+}
+
+void IncompatibleRegionMergeDiagnosticEmitter::emitIsolatedFunction() {
+
+  auto dstRegionValue = valueMap.getRepresentativeValue(dstRegionValueElt);
+  assert(dstRegionValue.hasRegionIntroducingInst());
+
+  auto declRef = ApplySite::isa(dstRegionValue.getActorRegionIntroducingInst())
+                     .getCalleeDeclRef();
+  if (!declRef)
+    return emitUnknownPatternError();
+
+  auto srcRegionValue = valueMap.getRepresentativeValue(srcRegionValueElt);
+  auto srcIsolation = srcIsolationInfo;
+  auto dstIsolation = dstIsolationInfo;
+
+  // Canonicalize so that srcRegionValue is always the task-isolated value. We
+  // do this only here since in this case, we can get away with doing this to
+  // implement a simpler diagnostic. E.x.: This doesn't work for assign.
+  if (!srcIsolation->isTaskIsolated() && dstIsolation->isTaskIsolated()) {
+    std::swap(srcIsolation, dstIsolation);
+    std::swap(srcRegionValue, dstRegionValue);
+  }
+
+  auto srcIsolationStr = srcIsolation.printForDiagnostics(getFunction());
+  auto dstIsolationStr = dstIsolation.printForDiagnostics(getFunction());
+
+  // We should always be able to find a name for an inout sending param. If we
+  // do not, emit an unknown pattern error.
+  auto srcName = inferNameHelper(srcRegionValue.getValue());
+  if (!srcName) {
+    if (auto *svi =
+            dyn_cast<SingleValueInstruction>(srcRegionValue.getValue())) {
+      if (auto *expr = svi->getLoc().getAsASTNode<Expr>()) {
+        diagnoseError(
+            op->getUser(),
+            diag::
+                regionbasedisolation_merge_region_failure_error_functionisolation_type,
+            expr->findOriginalType(), srcIsolationStr, declRef.getDecl(),
+            dstIsolationStr, !srcIsolation->isTaskIsolated())
+            .limitBehaviorIf(getBehaviorLimit());
+        return;
+      }
+    }
+    if (auto *arg = dyn_cast<SILFunctionArgument>(srcRegionValue.getValue())) {
+      diagnoseError(
+          op->getUser(),
+          diag::
+              regionbasedisolation_merge_region_failure_error_functionisolation_type,
+          arg->getDecl()->getInterfaceType(), srcIsolationStr,
+          declRef.getDecl(), dstIsolationStr, !srcIsolation->isTaskIsolated())
+          .limitBehaviorIf(getBehaviorLimit());
+      return;
+    }
+    return emitUnknownPatternError();
+  }
+  diagnoseError(
+      op->getUser(),
+      diag::regionbasedisolation_merge_region_failure_error_functionisolation,
+      *srcName, srcIsolationStr, declRef.getDecl(), dstIsolationStr,
+      !srcIsolation->isTaskIsolated())
+      .limitBehaviorIf(getBehaviorLimit());
+}
+
+void IncompatibleRegionMergeDiagnosticEmitter::emit() {
+  switch (reason) {
+  case RegionMergeReason::NonisolatedFunction:
+    return emitNonisolatedFunction();
+  case RegionMergeReason::NonisolatedClosure:
+  case RegionMergeReason::Builtin:
+  case RegionMergeReason::Unknown:
+    return emitUnknown();
+  case RegionMergeReason::Assign:
+    return emitAssign();
+  case RegionMergeReason::IsolatedFunction:
+    return emitIsolatedFunction();
+  }
+  llvm_unreachable("Unhandled case");
+}
+
+//===----------------------------------------------------------------------===//
 //                         MARK: Top Level Entrypoint
 //===----------------------------------------------------------------------===//
 

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -1169,7 +1169,7 @@ bool UseAfterSendDiagnosticInferrer::initForIsolatedPartialApply(
   if (auto rootValueAndName = inferNameAndRootHelper(sendingOp->get())) {
     diagnosticEmitter.emitNamedIsolationCrossingDueToCapture(
         diagnosticOp->getUser()->getLoc(), rootValueAndName->first,
-        state.isolationInfo.getIsolationInfo(), crossing);
+        state.getIsolationInfo(), crossing);
     return true;
   }
 
@@ -1370,8 +1370,7 @@ void UseAfterSendDiagnosticInferrer::infer() {
     if (auto rootValueAndName = inferNameAndRootHelper(sendingOp->get())) {
       auto &state = sendingOpToStateMap.get(sendingOp);
       return diagnosticEmitter.emitNamedIsolationCrossingError(
-          baseLoc, rootValueAndName->first,
-          state.isolationInfo.getIsolationInfo(),
+          baseLoc, rootValueAndName->first, state.getIsolationInfo(),
           *sourceApply->getIsolationCrossing());
     }
 
@@ -1399,8 +1398,7 @@ void UseAfterSendDiagnosticInferrer::infer() {
   auto captureInfo =
       autoClosureExpr->getCaptureInfo().getCaptures()[captureIndex];
   auto *captureDecl = captureInfo.getDecl();
-  AutoClosureWalker walker(*this, captureDecl,
-                           state.isolationInfo.getIsolationInfo());
+  AutoClosureWalker walker(*this, captureDecl, state.getIsolationInfo());
   autoClosureExpr->walk(walker);
 }
 

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -123,6 +123,37 @@ void PartitionOpError::InOutSendingParametersInSameRegionError::print(
   }
 }
 
+void PartitionOpError::IncompatibleRegionMergeError::print(
+    llvm::raw_ostream &os, RegionAnalysisValueMap &valueMap) const {
+  os << "    Emitting Error. Kind: IncompatibleRegionMergeError!\n"
+     << "        Src ID:  %%" << srcRegionElt
+     << "        Src Rep: " << valueMap.getRepresentativeValue(srcRegionElt)
+     << "        Dst ID:  %%" << dstRegionElt
+     << "        Dst Rep: " << valueMap.getRepresentativeValue(dstRegionElt)
+     << "        Reason: ";
+  switch (reason) {
+  case Reason::Unknown:
+    os << "unknown\n";
+    return;
+  case Reason::Assign:
+    os << "assign\n";
+    return;
+  case Reason::IsolatedFunction:
+    os << "isolated_function\n";
+    return;
+  case Reason::NonisolatedClosure:
+    os << "nonisolated_closure\n";
+    return;
+  case Reason::Builtin:
+    os << "builtin\n";
+    return;
+  case Reason::NonisolatedFunction:
+    os << "nonisolated_function\n";
+    return;
+  }
+  llvm_unreachable("Unhandled case");
+}
+
 //===----------------------------------------------------------------------===//
 //                             MARK: PartitionOp
 //===----------------------------------------------------------------------===//

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -958,6 +958,8 @@ SILIsolationInfo SILIsolationInfo::get(SILArgument *arg) {
     return attr->isUnsafe();
   }();
 
+  auto *func = fArg->getFunction();
+
   // If we have a closure capture that is not an indirect result or indirect
   // result error, we want to treat it as sending so that we properly handle
   // async lets.
@@ -967,7 +969,7 @@ SILIsolationInfo SILIsolationInfo::get(SILArgument *arg) {
   // sync with that code.
   if (!fArg->isIndirectResult() && !fArg->isIndirectErrorResult() &&
       fArg->isClosureCapture()) {
-    if (auto declRef = arg->getFunction()->getDeclRef();
+    if (auto declRef = func->getDeclRef();
         declRef && declRef.isAsyncLetClosure) {
       return SILIsolationInfo::getDisconnected(
           isClosureCapturedNonisolatedUnsafe);
@@ -977,10 +979,10 @@ SILIsolationInfo SILIsolationInfo::get(SILArgument *arg) {
   // Before we do anything further, see if we have an isolated parameter. This
   // handles isolated self and specifically marked isolated.
   if (auto *isolatedArg = llvm::cast_or_null<SILFunctionArgument>(
-          fArg->getFunction()->maybeGetIsolatedArgument())) {
+          func->maybeGetIsolatedArgument())) {
     // See if the function is nonisolated(nonsending). In such a case, return
     // task isolated.
-    if (auto funcIsolation = fArg->getFunction()->getActorIsolation();
+    if (auto funcIsolation = func->getActorIsolation();
         funcIsolation && funcIsolation->isCallerIsolationInheriting()) {
       return SILIsolationInfo::getTaskIsolated(fArg)
           .withNonisolatedNonsendingTaskIsolated(true)
@@ -1002,36 +1004,48 @@ SILIsolationInfo SILIsolationInfo::get(SILArgument *arg) {
 
   // Otherwise, see if we need to handle this isolation computation specially
   // due to information from the decl ref if we have one.
-  if (auto declRef = fArg->getFunction()->getDeclRef()) {
-    // First check if we have an allocator decl ref. If we do and we have an
-    // actor instance isolation, then we know that we are actively just calling
-    // the initializer. To just make region isolation work, treat this as
-    // disconnected so we can construct the actor value. Users cannot write
-    // allocator functions so we just need to worry about compiler generated
-    // code. In the case of a non-actor, we can only have an allocator that is
-    // global-actor isolated, so we will never hit this code path.
-    if (declRef.kind == SILDeclRef::Kind::Allocator) {
-      if (auto isolation = fArg->getFunction()->getActorIsolation()) {
-        if (isolation->isActorInstanceIsolated()) {
-          return SILIsolationInfo::getDisconnected(
-              false /*nonisolated(unsafe)*/);
-        }
+  if (auto declRef = func->getDeclRef()) {
+    if (auto funcIsolation = func->getActorIsolation()) {
+      // First check if we have an allocator decl ref. If we do and we have an
+      // actor instance isolation, then we know that we are actively just
+      // calling the initializer. To just make region isolation work, treat this
+      // as disconnected so we can construct the actor value. Users cannot write
+      // allocator functions so we just need to worry about compiler generated
+      // code. In the case of a non-actor, we can only have an allocator that is
+      // global-actor isolated, so we will never hit this code path.
+      if (declRef.kind == SILDeclRef::Kind::Allocator &&
+          funcIsolation->isActorInstanceIsolated()) {
+        return SILIsolationInfo::getDisconnected(false /*nonisolated(unsafe)*/);
       }
-    }
 
-    // Then see if we have an init accessor that is isolated to an actor
-    // instance, but for which we have not actually passed self. In such a case,
-    // we need to pass in a "fake" ActorInstance that users know is a sentinel
-    // for the self value.
-    if (auto functionIsolation = fArg->getFunction()->getActorIsolation()) {
-      if (functionIsolation->isActorInstanceIsolated() && declRef.getDecl()) {
+      // Then see if we have an init accessor that is isolated to an actor
+      // instance, but for which we have not actually passed self. In such a
+      // case, we need to pass in a "fake" ActorInstance that users know is a
+      // sentinel for the self value.
+      if (funcIsolation->isActorInstanceIsolated() && declRef.getDecl()) {
         if (auto *accessor =
                 dyn_cast_or_null<AccessorDecl>(declRef.getFuncDecl())) {
           if (accessor->isInitAccessor()) {
             return SILIsolationInfo::getActorInstanceIsolated(
                 fArg, ActorInstance::getForActorAccessorInit(),
-                functionIsolation->getActor());
+                funcIsolation->getActor());
           }
+        }
+      }
+
+      // Check if we have a nonisolated synchronous initializer for an actor. In
+      // such a case, we want to treat the non-Sendable parameters as being in
+      // the actor's isolation domain. This is a special case from the region
+      // isolation proposal and ensures that nonisolated async and sync
+      // initializers act the same way.
+      if (funcIsolation->isNonisolated() &&
+          declRef.kind == SILDeclRef::Kind::Initializer &&
+          !func->getLoweredFunctionType()->isAsync()) {
+        // Just performing some defensive checks here.
+        if (auto *self =
+                cast_or_null<SILFunctionArgument>(func->getSelfArgument());
+            self && self->getType().isAnyActor()) {
+          return SILIsolationInfo::getActorInstanceIsolated(fArg, self);
         }
       }
     }

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -479,7 +479,7 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
       auto actualIsolatedValue =
           ActorInstance::lookThroughInsts(isolatedOp->get());
 
-      // First see if we have a .none enum inst. In such a case, we are actually
+      // See if we have a .none enum inst. In such a case, we are actually
       // on the nonisolated global queue.
       if (auto *ei = dyn_cast<EnumInst>(actualIsolatedValue)) {
         if (ei->getElement()->getParentEnum()->isOptionalDecl() &&
@@ -490,6 +490,20 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
           // nonisolated.
           return SILIsolationInfo::getDisconnected(false);
         }
+      }
+
+      // Then check if we are passing the implicit builtin actor to this. In
+      // such a case, this is nonisolated(nonsending).
+      if (auto *fArg = dyn_cast<SILFunctionArgument>(actualIsolatedValue);
+          fArg && fArg->isImplicitBuiltinActor()) {
+        // TODO: We probably should split this API so that the user in the case
+        // where we are asking for a specific value, we use that value and if we
+        // are asking for the instruction generally (for instance if we are
+        // generating an actor introducing value), we set a bit on the
+        // SILIsolationInfo saying that the isolation was introduced by the
+        // instruction. This is important for isolation history eventually.
+        return SILIsolationInfo::getTaskIsolated(SILValue())
+            .withNonisolatedNonsendingTaskIsolated(true);
       }
 
       // Then using that value, grab the AST type from the actual isolated
@@ -1731,7 +1745,8 @@ SILValue ActorInstance::lookThroughInsts(SILValue value) {
         isa<CopyableToMoveOnlyWrapperValueInst>(svi) ||
         isa<MoveOnlyWrapperToCopyableValueInst>(svi) ||
         isa<InitExistentialRefInst>(svi) || isa<UncheckedRefCastInst>(svi) ||
-        isa<UnconditionalCheckedCastInst>(svi)) {
+        isa<UnconditionalCheckedCastInst>(svi) ||
+        isa<ImplicitActorToOpaqueIsolationCastInst>(svi)) {
       value = lookThroughInsts(svi->getOperand(0));
       continue;
     }
@@ -1846,6 +1861,22 @@ SILDynamicMergedIsolationInfo::merge(SILIsolationInfo other) const {
           .withMergedIsolatedConformance(rhs.getIsolatedConformance());
     return {rhs};
   case CombinedKind::TaskActor:
+    // If we have a nonisolated(nonsending) task isolated value and an unapplied
+    // isolated any parameter, allow for it to merge by just taking the isolated
+    // any parameter.
+    //
+    // TODO: Should we model unapplied isolated any parameter as a separate
+    // lattice element?
+    //
+    // TODO: Should we model NonisolatedNonsendingTaskIsolated as a separate
+    // kind. It is sort of an Actor, but we do not want to treat it like an
+    // actor when emitting diagnostics and the like.
+    if (lhs.isNonisolatedNonsendingTaskIsolated() &&
+        rhs.isUnappliedIsolatedAnyParameter()) {
+      return {lhs};
+    }
+
+    // Otherwise, fail.
     return {SILIsolationInfo()};
   case CombinedKind::TaskInvalid:
     return {rhs};

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -902,13 +902,26 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
     }
   }
 
-  /// Consider non-Sendable metatypes to be task-isolated, so they cannot cross
-  /// into another isolation domain.
+  /// Consider non-Sendable metatypes to be isolated to the context in which it
+  /// is initialized so they cannot into another isolation domain.
   if (auto *mi = dyn_cast<MetatypeInst>(inst)) {
-    if (auto funcIsolation = mi->getFunction()->getActorIsolation();
-        funcIsolation && funcIsolation->isCallerIsolationInheriting()) {
-      return SILIsolationInfo::getTaskIsolated(mi)
-          .withNonisolatedNonsendingTaskIsolated(true);
+    if (auto funcIsolation = mi->getFunction()->getActorIsolation()) {
+      if (funcIsolation->isCallerIsolationInheriting()) {
+        return SILIsolationInfo::getTaskIsolated(mi)
+            .withNonisolatedNonsendingTaskIsolated(true);
+      }
+
+      if (funcIsolation->isGlobalActor()) {
+        return SILIsolationInfo::getGlobalActorIsolated(
+            mi, funcIsolation->getGlobalActor());
+      }
+
+      if (funcIsolation->isActorInstanceIsolated()) {
+        if (auto *iso = llvm::cast_or_null<SILFunctionArgument>(
+                mi->getFunction()->maybeGetIsolatedArgument())) {
+          return SILIsolationInfo::getActorInstanceIsolated(mi, iso);
+        }
+      }
     }
 
     return SILIsolationInfo::getTaskIsolated(mi);

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -1284,8 +1284,8 @@ void SILIsolationInfo::printActorIsolationForDiagnostics(
 
 void SILIsolationInfo::print(SILFunction *fn, llvm::raw_ostream &os) const {
   switch (Kind(*this)) {
-  case Unknown:
-    os << "unknown";
+  case Invalid:
+    os << "invalid";
     return;
   case Disconnected:
     os << "disconnected";
@@ -1358,7 +1358,7 @@ bool SILIsolationInfo::hasSameIsolation(const SILIsolationInfo &other) const {
     return false;
 
   switch (getKind()) {
-  case Unknown:
+  case Invalid:
   case Disconnected:
     return true;
   case Task:
@@ -1408,7 +1408,7 @@ void SILIsolationInfo::Profile(llvm::FoldingSetNodeID &id) const {
   id.AddInteger(getKind());
   id.AddInteger(getOptions().toRaw());
   switch (getKind()) {
-  case Unknown:
+  case Invalid:
   case Disconnected:
     return;
   case Task:
@@ -1436,8 +1436,8 @@ StringRef SILIsolationInfo::printForDiagnostics(SILFunction *fn) const {
 void SILIsolationInfo::printForDiagnostics(SILFunction *fn,
                                            llvm::raw_ostream &os) const {
   switch (Kind(*this)) {
-  case Unknown:
-    llvm::report_fatal_error("Printing unknown for diagnostics?!");
+  case Invalid:
+    llvm::report_fatal_error("Printing invalid for diagnostics?!");
     return;
   case Disconnected:
     os << "disconnected";
@@ -1504,8 +1504,8 @@ StringRef SILIsolationInfo::printForCodeDiagnostic(SILFunction *fn) const {
 void SILIsolationInfo::printForCodeDiagnostic(SILFunction *fn,
                                               llvm::raw_ostream &os) const {
   switch (Kind(*this)) {
-  case Unknown:
-    llvm::report_fatal_error("Printing unknown for code diagnostic?!");
+  case Invalid:
+    llvm::report_fatal_error("Printing invalid for code diagnostic?!");
     return;
   case Disconnected:
     llvm::report_fatal_error("Printing disconnected for code diagnostic?!");
@@ -1548,8 +1548,8 @@ void SILIsolationInfo::printForCodeDiagnostic(SILFunction *fn,
 void SILIsolationInfo::printForOneLineLogging(SILFunction *fn,
                                               llvm::raw_ostream &os) const {
   switch (Kind(*this)) {
-  case Unknown:
-    os << "unknown";
+  case Invalid:
+    os << "invalid";
     return;
   case Disconnected:
     os << "disconnected";
@@ -1790,69 +1790,92 @@ SILValue ActorInstance::lookThroughInsts(SILValue value) {
 //                    MARK: SILDynamicMergedIsolationInfo
 //===----------------------------------------------------------------------===//
 
-std::optional<SILDynamicMergedIsolationInfo>
+SILDynamicMergedIsolationInfo
 SILDynamicMergedIsolationInfo::merge(SILIsolationInfo other) const {
-  // If we are greater than the other kind, then we are further along the
-  // lattice. We ignore the change.
-  //
-  // NOTE: If we are further along, then we both cannot be task isolated. In
-  // such a case, we are the only potential thing that can be
-  // nonisolated(unsafe)... so we do not need to try to propagate.
-  if (unsigned(innerInfo.getKind() > unsigned(other.getKind()))) {
-    return {*this};
-  }
+  auto lhs = innerInfo;
+  auto rhs = other;
 
-  // If we are both actor isolated...
-  if (innerInfo.isActorIsolated() && other.isActorIsolated()) {
-    // If both innerInfo and other have the same isolation, we are obviously
-    // done. Just return innerInfo since we could return either.
-    if (innerInfo.hasSameIsolation(other))
-      return {innerInfo.withMergedIsolatedConformance(other.getIsolatedConformance())};
+  if (lhs.getKind() > rhs.getKind())
+    std::swap(lhs, rhs);
 
-    // Ok, there is some difference in between innerInfo and other. Lets see if
+#ifdef KIND_COMBINE
+#error "KIND_COMBINE already defined?!"
+#endif
+
+#ifdef KIND_COMBINE_DECL
+#error "KIND_COMBINE_DECL already defined?!"
+#endif
+
+#define KIND_COMBINE(X, Y) (uint8_t(X) | (uint8_t(Y) << 2))
+  enum class CombinedKind : uint8_t {
+#define KIND_COMBINE_DECL(X, Y)                                                \
+  X##Y = KIND_COMBINE(SILIsolationInfo::Kind::X, SILIsolationInfo::Kind::Y)
+    KIND_COMBINE_DECL(Disconnected, Disconnected),
+    KIND_COMBINE_DECL(Disconnected, Task),
+    KIND_COMBINE_DECL(Disconnected, Actor),
+    KIND_COMBINE_DECL(Disconnected, Invalid),
+    KIND_COMBINE_DECL(Task, Task),
+    KIND_COMBINE_DECL(Task, Actor),
+    KIND_COMBINE_DECL(Task, Invalid),
+    KIND_COMBINE_DECL(Actor, Actor),
+    KIND_COMBINE_DECL(Actor, Invalid),
+    KIND_COMBINE_DECL(Invalid, Invalid)
+  };
+
+  switch (CombinedKind(KIND_COMBINE(lhs.getKind(), rhs.getKind()))) {
+  case CombinedKind::DisconnectedDisconnected:
+    // If we are both disconnected and rhs has the unsafeNonIsolated bit set,
+    // drop that bit and return that.
+    //
+    // DISCUSSION: We do not want to preserve the unsafe non isolated bit after
+    // merging. These bits should not propagate through merging and should
+    // instead always be associated with non-merged infos.
+    if (rhs.isDisconnected() && rhs.isUnsafeNonIsolated()) {
+      return {rhs.withUnsafeNonIsolated(false)};
+    }
+    return {lhs};
+
+  case CombinedKind::DisconnectedTask:
+  case CombinedKind::DisconnectedActor:
+  case CombinedKind::DisconnectedInvalid:
+    return {rhs};
+  case CombinedKind::TaskTask:
+    if (lhs.isNonisolatedNonsendingTaskIsolated() ||
+        rhs.isNonisolatedNonsendingTaskIsolated())
+      return lhs.withNonisolatedNonsendingTaskIsolated(true)
+          .withMergedIsolatedConformance(rhs.getIsolatedConformance());
+    return {rhs};
+  case CombinedKind::TaskActor:
+    return {SILIsolationInfo()};
+  case CombinedKind::TaskInvalid:
+    return {rhs};
+  case CombinedKind::ActorActor: {
+    // If both lhs and rhs have the same isolation, we are obviously
+    // done. Just return lhs since we could return either.
+    if (lhs.hasSameIsolation(rhs))
+      return {lhs.withMergedIsolatedConformance(rhs.getIsolatedConformance())};
+
+    // Ok, there is some difference in between lhs and rhs. Lets see if
     // they are both actor instance isolated and if either are unapplied
     // isolated any parameter. In such a case, take the one that is further
     // along.
-    if (innerInfo.getActorIsolation().isActorInstanceIsolated() &&
-        other.getActorIsolation().isActorInstanceIsolated()) {
-      if (innerInfo.isUnappliedIsolatedAnyParameter())
-        return other.withMergedIsolatedConformance(innerInfo.getIsolatedConformance());
-      if (other.isUnappliedIsolatedAnyParameter())
-        return innerInfo.withMergedIsolatedConformance(other.getIsolatedConformance());
+    if (lhs.getActorIsolation().isActorInstanceIsolated() &&
+        rhs.getActorIsolation().isActorInstanceIsolated()) {
+      if (lhs.isUnappliedIsolatedAnyParameter())
+        return rhs.withMergedIsolatedConformance(lhs.getIsolatedConformance());
+      if (rhs.isUnappliedIsolatedAnyParameter())
+        return lhs.withMergedIsolatedConformance(rhs.getIsolatedConformance());
     }
 
-    // Otherwise, they do not match... so return None to signal merge failure.
-    return {};
+    return {SILIsolationInfo()};
   }
-
-  // If we are both disconnected and other has the unsafeNonIsolated bit set,
-  // drop that bit and return that.
-  //
-  // DISCUSSION: We do not want to preserve the unsafe non isolated bit after
-  // merging. These bits should not propagate through merging and should instead
-  // always be associated with non-merged infos.
-  if (other.isDisconnected() && other.isUnsafeNonIsolated()) {
-    return {other.withUnsafeNonIsolated(false)};
+  case CombinedKind::ActorInvalid:
+  case CombinedKind::InvalidInvalid:
+    return {rhs};
   }
-
-  // We know that we are either the same as other or other is further along. If
-  // other is further along, it is the only thing that can propagate the task
-  // isolated bit. So we do not need to do anything. If we are equal though, we
-  // may need to propagate the bit. This ensures that when we emit a diagnostic
-  // we appropriately say potentially actor isolated code instead of code in the
-  // current task.
-  //
-  // TODO: We should really represent this as a separate isolation info
-  // kind... but that would be a larger change than we want for 6.2.
-  if (innerInfo.isTaskIsolated() && other.isTaskIsolated()) {
-    if (innerInfo.isNonisolatedNonsendingTaskIsolated() ||
-        other.isNonisolatedNonsendingTaskIsolated())
-      return other.withNonisolatedNonsendingTaskIsolated(true)
-        .withMergedIsolatedConformance(innerInfo.getIsolatedConformance());
-  }
-
-  // Otherwise, just return other.
-  return {other};
+  llvm_unreachable("Unhandled case?!");
+#undef KIND_COMBINE_DECL
+#undef KIND_COMBINE
 }
 
 void ActorInstance::print(llvm::raw_ostream &os) const {
@@ -1946,8 +1969,8 @@ static FunctionTest IsolationMergeTest(
       auto secondValue = arguments.takeValue();
       SILIsolationInfo firstValueInfo = SILIsolationInfo::get(firstValue);
       SILIsolationInfo secondValueInfo = SILIsolationInfo::get(secondValue);
-      std::optional<SILDynamicMergedIsolationInfo> mergedInfo(firstValueInfo);
-      mergedInfo = mergedInfo->merge(secondValueInfo);
+      SILDynamicMergedIsolationInfo mergedInfo(firstValueInfo);
+      mergedInfo = mergedInfo.merge(secondValueInfo);
       llvm::outs() << "First Value: " << *firstValue;
       llvm::outs() << "First Isolation: ";
       firstValueInfo.printForOneLineLogging(&function, llvm::outs());

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -8563,18 +8563,32 @@ ActorReferenceResult ActorReferenceResult::Builder::build() {
   // It's only okay for the value to cross isolation boundaries if the property
   // type is Sendable. Note that if the init is a nonisolated actor init,
   // Sendable checking is already performed on arguments at the call-site.
-  if ((declIsolation.isActorIsolated() && contextIsolation.isGlobalActor()) ||
-      declIsolation.isGlobalActor()) {
-    auto *init = dyn_cast<ConstructorDecl>(fromDC);
-    if (init && init->isDesignatedInit() && isStoredProperty(decl) &&
-        (!referencedActor || referencedActor->isSelf())) {
-      auto type = fromDC->mapTypeIntoEnvironment(decl->getInterfaceType());
-      if (!type->isSendableType()) {
-        // Treat the decl isolation as 'preconcurrency' to downgrade violations
-        // to warnings, because violating Sendable here is accepted by the
-        // Swift 5.9 compiler.
-        options |= Flags::CompatibilityDowngrade;
-        return forEntersActor(declIsolation, options);
+  if (auto *init = dyn_cast<ConstructorDecl>(fromDC)) {
+    // If strict concurrency is complete, we allow for users to initialize
+    // global actor non-Sendable types in initializers more aggressively through
+    // the usage of flow isolation.
+    if (fromDC->getASTContext().LangOpts.StrictConcurrencyLevel >=
+            StrictConcurrency::Complete &&
+        referencedActor && referencedActor->isSelf() &&
+        referencedActor->actor->isActorSelf() &&
+        !contextIsolation.isGlobalActor() &&
+        checkedByFlowIsolation(fromDC, *referencedActor, decl, declRefLoc,
+                               useKind))
+      return forSameConcurrencyDomain(declIsolation, options);
+
+    if ((declIsolation.isActorIsolated() && contextIsolation.isGlobalActor()) ||
+        declIsolation.isGlobalActor()) {
+
+      if (init->isDesignatedInit() && isStoredProperty(decl) &&
+          (!referencedActor || referencedActor->isSelf())) {
+        auto type = fromDC->mapTypeIntoEnvironment(decl->getInterfaceType());
+        if (!type->isSendableType()) {
+          // Treat the decl isolation as 'preconcurrency' to downgrade
+          // violations to warnings, because violating Sendable here is
+          // accepted by the Swift 5.9 compiler.
+          options |= Flags::CompatibilityDowngrade;
+          return forEntersActor(declIsolation, options);
+        }
       }
     }
   }

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -863,8 +863,7 @@ actor SomeActorWithInits {
   // expected-note@+1 4 {{mutation of this property is only permitted within the actor}}
   var mutableState: Int = 17
   var otherMutableState: Int
-  // expected-note@+1 {{mutation of this property is only permitted within the actor}}
-  let nonSendable: SomeClass
+  let nonSendable: SomeClass // expected-note {{mutation of this property is only permitted within the actor}}
 
   // Sema should not complain about referencing non-Sendable members
   // in an actor init or deinit, as those are diagnosed later by flow-isolation.
@@ -935,7 +934,7 @@ actor SomeActorWithInits {
   @MainActor init(i5 x: SomeClass) {
     self.mutableState = 42
     self.otherMutableState = 17
-    self.nonSendable = x // expected-warning {{actor-isolated property 'nonSendable' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.nonSendable = x // expected-warning {{actor-isolated property 'nonSendable' can not be mutated from the main actor}}
 
     self.isolated() // expected-warning{{actor-isolated instance method 'isolated()' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
     self.nonisolated()
@@ -1665,14 +1664,13 @@ actor ActorWithNonSendableLet: NonisolatedProtocol {
 }
 
 actor ProtectNonSendable {
-  // expected-note@+1 2 {{property declared here}}
-  let ns = NonSendable()
+  // expected-note@+1 {{property declared here}}
+  let ns = NonSendable() // expected-note {{property declared here}}
 
   init() {}
 
   @MainActor init(fromMain: Void) {
-    // expected-warning@+1 {{actor-isolated property 'ns' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
-    _ = self.ns
+    _ = self.ns // expected-warning {{actor-isolated property 'ns' can not be referenced from the main actor}}
   }
 }
 

--- a/test/Concurrency/actor_isolation_filecheck.swift
+++ b/test/Concurrency/actor_isolation_filecheck.swift
@@ -86,7 +86,7 @@ struct NonisolatedStruct {
   // CHECK-NEXT: Isolation: global_actor. type: CustomActor
   // CHECK: NonisolatedStruct.customActorField.setter
   // CHECK-NEXT: Isolation: global_actor. type: CustomActor
-  @CustomActor var customActorField = NonSendableKlass()
+  @CustomActor var customActorField = NonSendableKlass() // expected-error {{pattern that the region-based isolation checker does not understand how to check}}
 
   nonisolated init() {}
 }
@@ -135,7 +135,7 @@ struct NonisolatedKlass {
   // CHECK-NEXT: Isolation: global_actor. type: CustomActor
   // CHECK: NonisolatedKlass.customActorField.setter
   // CHECK-NEXT: Isolation: global_actor. type: CustomActor
-  @CustomActor var customActorField = NonSendableKlass()
+  @CustomActor var customActorField = NonSendableKlass() // expected-error {{pattern that the region-based isolation checker does not understand how to check}}
 
   nonisolated init() {}
 }

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -45,7 +45,7 @@ actor A2 {
 
   nonisolated init(nonisoAsync value: NotConcurrent, _ c: Int) async {
     if c == 0 {
-      await self.init(valueAsync: value) // expected-warning {{pattern that the region-based isolation checker does not understand how to check}}
+      await self.init(valueAsync: value) // expected-warning {{passing 'value' to 'self'-isolated initializer 'init(valueAsync:)' risks causing data races}}
     } else {
       self.init(value: value)
     }
@@ -255,7 +255,6 @@ protocol AsyncProto {
 
 extension A1: AsyncProto {
   func asyncMethod(_: NotConcurrent) async { } // expected-warning{{non-Sendable parameter type 'NotConcurrent' cannot be sent from caller of protocol requirement 'asyncMethod' into actor-isolated implementation}}
-  // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check}}
 }
 
 protocol MainActorProto {
@@ -265,7 +264,6 @@ protocol MainActorProto {
 class SomeClass: MainActorProto {
   @SomeGlobalActor
   func asyncMainMethod(_: NotConcurrent) async { } // expected-warning{{non-Sendable parameter type 'NotConcurrent' cannot be sent from caller of protocol requirement 'asyncMainMethod' into global actor 'SomeGlobalActor'-isolated implementation}}
-  // expected-warning @-1 2{{pattern that the region-based isolation checker does not understand how to check}}
 }
 
 // ----------------------------------------------------------------------

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -45,7 +45,7 @@ actor A2 {
 
   nonisolated init(nonisoAsync value: NotConcurrent, _ c: Int) async {
     if c == 0 {
-      await self.init(valueAsync: value)
+      await self.init(valueAsync: value) // expected-warning {{pattern that the region-based isolation checker does not understand how to check}}
     } else {
       self.init(value: value)
     }
@@ -255,6 +255,7 @@ protocol AsyncProto {
 
 extension A1: AsyncProto {
   func asyncMethod(_: NotConcurrent) async { } // expected-warning{{non-Sendable parameter type 'NotConcurrent' cannot be sent from caller of protocol requirement 'asyncMethod' into actor-isolated implementation}}
+  // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check}}
 }
 
 protocol MainActorProto {
@@ -264,6 +265,7 @@ protocol MainActorProto {
 class SomeClass: MainActorProto {
   @SomeGlobalActor
   func asyncMainMethod(_: NotConcurrent) async { } // expected-warning{{non-Sendable parameter type 'NotConcurrent' cannot be sent from caller of protocol requirement 'asyncMainMethod' into global actor 'SomeGlobalActor'-isolated implementation}}
+  // expected-warning @-1 2{{pattern that the region-based isolation checker does not understand how to check}}
 }
 
 // ----------------------------------------------------------------------

--- a/test/Concurrency/flow_isolation.swift
+++ b/test/Concurrency/flow_isolation.swift
@@ -863,7 +863,7 @@ struct MainActorStructWithMixedFields {
 
     trigger()
 
-    _ = self.nonisoField  // OK - explicitly nonisolated
+    _ = self.nonisoField
     self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
   }
@@ -875,7 +875,7 @@ struct MainActorStructWithMixedFields {
 
     trigger()
 
-    _ = self.nonisoField  // OK - explicitly nonisolated
+    _ = self.nonisoField
     self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
     self.mainField = NonSendableType()
   }
@@ -887,7 +887,7 @@ struct MainActorStructWithMixedFields {
 
     trigger()
 
-    _ = self.nonisoField  // OK - explicitly nonisolated
+    _ = self.nonisoField
     self.customField = NonSendableType()
     self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
   }
@@ -944,8 +944,8 @@ class MainActorClassWithMixedFields {
 
 @available(SwiftStdlib 5.1, *)
 actor ActorWithMixedIsolationFields {
-  @MainActor var mainField: NonSendableType // expected-note 2{{mutation of this property is only permitted within the actor}}
-  @CustomActor var customField: NonSendableType // expected-note 4{{mutation of this property is only permitted within the actor}}
+  @MainActor var mainField: NonSendableType
+  @CustomActor var customField: NonSendableType // expected-note 2{{mutation of this property is only permitted within the actor}}
   nonisolated let nonisoField: SendableType
   var actorField: NonSendableType // expected-note 2{{mutation of this property is only permitted within the actor}}
 
@@ -953,8 +953,8 @@ actor ActorWithMixedIsolationFields {
 
   init(v1: Void) {
     // Before decay: can assign all fields
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType()
+    self.customField = NonSendableType()
     self.nonisoField = SendableType()
     self.actorField = NonSendableType()
 
@@ -962,10 +962,8 @@ actor ActorWithMixedIsolationFields {
 
     // After decay: nonisolated field is accessible, others are not
     _ = self.nonisoField // OK
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{cannot access property 'mainField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{cannot access property 'customField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{cannot access property 'mainField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType() // expected-warning {{cannot access property 'customField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     self.actorField = NonSendableType() // expected-warning {{cannot access property 'actorField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
@@ -1002,9 +1000,9 @@ struct GADTStructWithMixedDefaultRequirements {
   // expected-note @-2 3{{mutation of this property is only permitted within the actor}}
   nonisolated let nonisoNoDefault: SendableType
   @CustomActor var customDefault: NonSendableType = requiresCustomActor() // expected-note 4{{property declared here}}
-  // expected-note @-1 3{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a main actor-isolated initializer}}
-  // expected-note @-2 3{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a nonisolated initializer}}
-  // expected-note @-3 2{{mutation of this property is only permitted within the actor}}
+  // expected-note @-1 2{{mutation of this property is only permitted within the actor}}
+  // expected-note @-2 3{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a main actor-isolated initializer}}
+  // expected-note @-3 3{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a nonisolated initializer}}
 
   nonisolated func trigger() {}
 
@@ -1178,17 +1176,17 @@ struct GADTStructWithMixedDefaultRequirementsNonIsolatedInits {
 
 @available(SwiftStdlib 5.5, *)
 actor ActorWithMixedDefaultRequirements {
-  @MainActor var mainDefault: NonSendableType = requiresMainActor() // expected-note 2{{main actor-isolated default value of 'self.mainDefault' cannot be used in a nonisolated initializer}}
-  // expected-note @-1 6{{property declared here}}
-  // expected-note @-2 4{{mutation of this property is only permitted within the actor}}
-  // expected-note @-3 2{{main actor-isolated default value of 'self.mainDefault' cannot be used in a global actor 'CustomActor'-isolated initializer}}
+  @MainActor var mainDefault: NonSendableType = requiresMainActor() // expected-note 2{{main actor-isolated default value of 'self.mainDefault' cannot be used in a global actor 'CustomActor'-isolated initializer}}
+  // expected-note @-1 2{{main actor-isolated default value of 'self.mainDefault' cannot be used in a nonisolated initializer}}
+  // expected-note @-2 2{{mutation of this property is only permitted within the actor}}
+  // expected-note @-3 3{{property declared here}}
   var actorField: NonSendableType // expected-note 6{{property declared here}}
   // expected-note @-1 6{{mutation of this property is only permitted within the actor}}
   nonisolated let nonisoNoDefault: SendableType
-  @CustomActor var customDefault: NonSendableType = requiresCustomActor() // expected-note 4{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a nonisolated initializer}}
-  // expected-note @-1 4{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a main actor-isolated initializer}}
-  // expected-note @-2 2{{mutation of this property is only permitted within the actor}}
-  // expected-note @-3 6{{property declared here}}
+  @CustomActor var customDefault: NonSendableType = requiresCustomActor() // expected-note 4{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a main actor-isolated initializer}}
+  // expected-note @-1 3{{property declared here}}
+  // expected-note @-2 4{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a nonisolated initializer}}
+  // expected-note @-3 {{mutation of this property is only permitted within the actor}}
 
   nonisolated func trigger() {}
 
@@ -1201,45 +1199,39 @@ actor ActorWithMixedDefaultRequirements {
 
     _ = self.mainDefault // expected-error {{variable 'self.mainDefault' used before being initialized}}
     // expected-warning @-1 {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-2 {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
     _ = self.actorField // expected-warning {{cannot access property 'actorField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     _ = self.nonisoNoDefault
     _ = self.customDefault // expected-error {{variable 'self.customDefault' used before being initialized}}
     // expected-warning @-1 {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-2 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
   } // expected-error {{return from initializer without initializing all stored properties}}
 
   init(v1a: Void) {
     self.nonisoNoDefault = SendableType()
     self.actorField = NonSendableType()
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType()
 
     trigger() // expected-error {{'self' used in method call 'trigger' before all stored properties are initialized}}
     // expected-note @-1 3{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
 
     _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
     _ = self.actorField // expected-warning {{cannot access property 'actorField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     _ = self.nonisoNoDefault
     _ = self.customDefault // expected-error {{variable 'self.customDefault' used before being initialized}}
     // expected-warning @-1 {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-2 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
   } // expected-error {{return from initializer without initializing all stored properties}}
 
   init(v1b: Void) {
     self.nonisoNoDefault = SendableType()
     self.actorField = NonSendableType()
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType()
+    self.customDefault = NonSendableType()
 
     trigger() // expected-note 3{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
 
     _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
     _ = self.actorField // expected-warning {{cannot access property 'actorField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     _ = self.nonisoNoDefault
     _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
   }
 
   @MainActor init(v2: Void) {

--- a/test/Concurrency/flow_isolation.swift
+++ b/test/Concurrency/flow_isolation.swift
@@ -522,8 +522,8 @@ struct CardboardBox<T> {
 
 @available(SwiftStdlib 5.1, *)
 var globalVar: EscapeArtist? // expected-warning {{var 'globalVar' is not concurrency-safe because it is nonisolated global shared mutable state; this is an error in the Swift 6 language mode}}
-// expected-note @-1 {{disable concurrency-safety checks if accesses are protected by an external synchronization mechanism}}
-// expected-note @-2 {{convert 'globalVar' to a 'let' constant to make 'Sendable' shared state immutable}}
+// expected-note @-1 {{convert 'globalVar' to a 'let' constant to make 'Sendable' shared state immutable}}
+// expected-note @-2 {{disable concurrency-safety checks if accesses are protected by an external synchronization mechanism}}
 // expected-note @-3 {{add '@MainActor' to make var 'globalVar' part of global actor 'MainActor'}}
 
 @available(SwiftStdlib 5.1, *)
@@ -945,44 +945,65 @@ class MainActorClassWithMixedFields {
 @available(SwiftStdlib 5.1, *)
 actor ActorWithMixedIsolationFields {
   @MainActor var mainField: NonSendableType
+  @MainActor var mainField_trivial: Int
   @CustomActor var customField: NonSendableType // expected-note 2{{mutation of this property is only permitted within the actor}}
+  @CustomActor var customField_trivial: Int
   nonisolated let nonisoField: SendableType
   var actorField: NonSendableType // expected-note 2{{mutation of this property is only permitted within the actor}}
+  var actorField_trivial: Int
 
   nonisolated func trigger() {}
 
   init(v1: Void) {
     // Before decay: can assign all fields
     self.mainField = NonSendableType()
+    self.mainField_trivial = 0
     self.customField = NonSendableType()
+    self.customField_trivial = 0
     self.nonisoField = SendableType()
     self.actorField = NonSendableType()
+    self.actorField_trivial = 0
 
-    trigger() // expected-note 3{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+    trigger() // expected-note 9{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
 
     // After decay: nonisolated field is accessible, others are not
     _ = self.nonisoField // OK
     self.mainField = NonSendableType() // expected-warning {{cannot access property 'mainField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.mainField_trivial = 0 // expected-warning {{cannot access property 'mainField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    logTransaction(self.mainField_trivial) // expected-warning {{cannot access property 'mainField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     self.customField = NonSendableType() // expected-warning {{cannot access property 'customField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.customField_trivial = 0 // expected-warning {{cannot access property 'customField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    logTransaction(self.customField_trivial) // expected-warning {{cannot access property 'customField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     self.actorField = NonSendableType() // expected-warning {{cannot access property 'actorField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.actorField_trivial = 0 // expected-warning {{cannot access property 'actorField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    logTransaction(self.actorField_trivial) // expected-warning {{cannot access property 'actorField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   @MainActor init(v2: Void) {
     // Before decay: can assign all fields
     self.mainField = NonSendableType()
+    self.mainField_trivial = 0
     self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customField_trivial = 0
     self.nonisoField = SendableType()
     self.actorField = NonSendableType() // expected-warning {{actor-isolated property 'actorField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.actorField_trivial = 0
 
-    trigger() // expected-note 3{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+    trigger() // expected-note 9{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
 
     // After decay: nonisolated field is accessible, others are not
     _ = self.nonisoField // OK
     self.mainField = NonSendableType() // expected-warning {{cannot access property 'mainField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.mainField_trivial = 0 // expected-warning {{cannot access property 'mainField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    logTransaction(self.mainField_trivial) // expected-warning {{cannot access property 'mainField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
     // expected-warning @-1 {{cannot access property 'customField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.customField_trivial = 0 // expected-warning {{cannot access property 'customField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    logTransaction(self.customField_trivial) // expected-warning {{cannot access property 'customField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     self.actorField = NonSendableType() // expected-warning {{actor-isolated property 'actorField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
     // expected-warning @-1 {{cannot access property 'actorField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.actorField_trivial = 0 // expected-warning {{cannot access property 'actorField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    logTransaction(self.actorField_trivial) // expected-warning {{cannot access property 'actorField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
 }
@@ -995,14 +1016,14 @@ actor ActorWithMixedIsolationFields {
 @available(SwiftStdlib 5.5, *)
 @MainActor
 struct GADTStructWithMixedDefaultRequirements {
-  var mainDefault: NonSendableType = requiresMainActor() // expected-note 7{{main actor-isolated default value of 'self.mainDefault' cannot be used in a global actor 'CustomActor'-isolated initializer}}
-  // expected-note @-1 6{{property declared here}}
+  var mainDefault: NonSendableType = requiresMainActor() // expected-note 6{{property declared here}}
+  // expected-note @-1 7{{main actor-isolated default value of 'self.mainDefault' cannot be used in a global actor 'CustomActor'-isolated initializer}}
   // expected-note @-2 3{{mutation of this property is only permitted within the actor}}
   nonisolated let nonisoNoDefault: SendableType
   @CustomActor var customDefault: NonSendableType = requiresCustomActor() // expected-note 4{{property declared here}}
-  // expected-note @-1 2{{mutation of this property is only permitted within the actor}}
-  // expected-note @-2 3{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a main actor-isolated initializer}}
-  // expected-note @-3 3{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a nonisolated initializer}}
+  // expected-note @-1 3{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a main actor-isolated initializer}}
+  // expected-note @-2 3{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a nonisolated initializer}}
+  // expected-note @-3 2{{mutation of this property is only permitted within the actor}}
 
   nonisolated func trigger() {}
 
@@ -1176,17 +1197,17 @@ struct GADTStructWithMixedDefaultRequirementsNonIsolatedInits {
 
 @available(SwiftStdlib 5.5, *)
 actor ActorWithMixedDefaultRequirements {
-  @MainActor var mainDefault: NonSendableType = requiresMainActor() // expected-note 2{{main actor-isolated default value of 'self.mainDefault' cannot be used in a global actor 'CustomActor'-isolated initializer}}
+  @MainActor var mainDefault: NonSendableType = requiresMainActor() // expected-note 3{{property declared here}}
   // expected-note @-1 2{{main actor-isolated default value of 'self.mainDefault' cannot be used in a nonisolated initializer}}
-  // expected-note @-2 2{{mutation of this property is only permitted within the actor}}
-  // expected-note @-3 3{{property declared here}}
-  var actorField: NonSendableType // expected-note 6{{property declared here}}
-  // expected-note @-1 6{{mutation of this property is only permitted within the actor}}
+  // expected-note @-2 2{{main actor-isolated default value of 'self.mainDefault' cannot be used in a global actor 'CustomActor'-isolated initializer}}
+  // expected-note @-3 2{{mutation of this property is only permitted within the actor}}
+  var actorField: NonSendableType // expected-note 6{{mutation of this property is only permitted within the actor}}
+  // expected-note @-1 6{{property declared here}}
   nonisolated let nonisoNoDefault: SendableType
-  @CustomActor var customDefault: NonSendableType = requiresCustomActor() // expected-note 4{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a main actor-isolated initializer}}
+  @CustomActor var customDefault: NonSendableType = requiresCustomActor() // expected-note {{mutation of this property is only permitted within the actor}}
   // expected-note @-1 3{{property declared here}}
   // expected-note @-2 4{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a nonisolated initializer}}
-  // expected-note @-3 {{mutation of this property is only permitted within the actor}}
+  // expected-note @-3 4{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a main actor-isolated initializer}}
 
   nonisolated func trigger() {}
 

--- a/test/Concurrency/nonisolated_rules.swift
+++ b/test/Concurrency/nonisolated_rules.swift
@@ -85,11 +85,9 @@ nonisolated struct StructRemovesGlobalActor: GloballyIsolated {
   }
 
   struct Nested: GloballyIsolated {
-    // expected-note@+1 {{mutation of this property is only permitted within the actor}}
-    var z: NonSendable
+    var z: NonSendable // expected-note {{mutation of this property is only permitted within the actor}}
     nonisolated init(z: NonSendable) {
-      // expected-error@+1 {{main actor-isolated property 'z' can not be mutated from a nonisolated context}}
-      self.z = z
+      self.z = z // expected-error {{main actor-isolated property 'z' can not be mutated from a nonisolated context}}
     }
   }
 }

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -145,15 +145,15 @@ protocol P {
         actor A : P {
   func foo(x : () -> ()) -> () {}
 
-  func bar(x : () -> ()) -> () {}
+  func bar(x : () -> ()) -> () {} // expected-tns-warning {{pattern that the region-based isolation checker does not understand how to check}}
   // expected-warning@-1 {{non-Sendable parameter type '() -> ()' cannot be sent from caller of protocol requirement 'bar(x:)' into actor-isolated implementation}}
 
   func foo2<T>(x : T) -> () {}
 
-  func bar2<T>(x : T) -> () {}
+  func bar2<T>(x : T) -> () {} // expected-tns-warning {{pattern that the region-based isolation checker does not understand how to check}}
   // expected-warning@-1 {{non-Sendable parameter type 'T' cannot be sent from caller of protocol requirement 'bar2(x:)' into actor-isolated implementation}}
 
-  func bar3<T: Equatable>(x : T) -> () {}
+  func bar3<T: Equatable>(x : T) -> () {} // expected-tns-warning {{pattern that the region-based isolation checker does not understand how to check}}
   // expected-warning@-1 {{non-Sendable parameter type 'T' cannot be sent from caller of protocol requirement 'bar3(x:)' into actor-isolated implementation}}
 }
 
@@ -297,10 +297,10 @@ final class NonSendable {
     // expected-tns-warning @-1 {{sending 'self' risks causing data races}}
     // expected-tns-note @-2 {{sending task-isolated 'self' to main actor-isolated instance method 'update()' risks causing data races between main actor-isolated and task-isolated uses}}
 
-    _ = await x
+    _ = await x // expected-tns-warning {{pattern that the region-based isolation checker does not understand how to check}}
     // expected-warning@-1 {{non-Sendable type 'NonSendable' cannot be sent into main actor-isolated context in call to property 'x'}}
 
-    _ = await self.x
+    _ = await self.x // expected-tns-warning {{pattern that the region-based isolation checker does not understand how to check}}
       // expected-warning@-1 {{non-Sendable type 'NonSendable' cannot be sent into main actor-isolated context in call to property 'x'}}
   }
 

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -145,15 +145,15 @@ protocol P {
         actor A : P {
   func foo(x : () -> ()) -> () {}
 
-  func bar(x : () -> ()) -> () {} // expected-tns-warning {{pattern that the region-based isolation checker does not understand how to check}}
+  func bar(x : () -> ()) -> () {}
   // expected-warning@-1 {{non-Sendable parameter type '() -> ()' cannot be sent from caller of protocol requirement 'bar(x:)' into actor-isolated implementation}}
 
   func foo2<T>(x : T) -> () {}
 
-  func bar2<T>(x : T) -> () {} // expected-tns-warning {{pattern that the region-based isolation checker does not understand how to check}}
+  func bar2<T>(x : T) -> () {}
   // expected-warning@-1 {{non-Sendable parameter type 'T' cannot be sent from caller of protocol requirement 'bar2(x:)' into actor-isolated implementation}}
 
-  func bar3<T: Equatable>(x : T) -> () {} // expected-tns-warning {{pattern that the region-based isolation checker does not understand how to check}}
+  func bar3<T: Equatable>(x : T) -> () {}
   // expected-warning@-1 {{non-Sendable parameter type 'T' cannot be sent from caller of protocol requirement 'bar3(x:)' into actor-isolated implementation}}
 }
 
@@ -297,10 +297,10 @@ final class NonSendable {
     // expected-tns-warning @-1 {{sending 'self' risks causing data races}}
     // expected-tns-note @-2 {{sending task-isolated 'self' to main actor-isolated instance method 'update()' risks causing data races between main actor-isolated and task-isolated uses}}
 
-    _ = await x // expected-tns-warning {{pattern that the region-based isolation checker does not understand how to check}}
+    _ = await x // expected-tns-warning {{passing 'self' to main actor-isolated getter for property 'x' risks causing data races}}
     // expected-warning@-1 {{non-Sendable type 'NonSendable' cannot be sent into main actor-isolated context in call to property 'x'}}
 
-    _ = await self.x // expected-tns-warning {{pattern that the region-based isolation checker does not understand how to check}}
+    _ = await self.x // expected-tns-warning {{passing 'self' to main actor-isolated getter for property 'x' risks causing data races}}
       // expected-warning@-1 {{non-Sendable type 'NonSendable' cannot be sent into main actor-isolated context in call to property 'x'}}
   }
 
@@ -479,9 +479,12 @@ struct DowngradeForPreconcurrency {
   var x: NonSendable
   func createStream() -> AsyncStream<NonSendable> {
     AsyncStream<NonSendable> {
-      self.x
-      // expected-warning@-1 {{main actor-isolated property 'x' cannot be accessed from outside of the actor; this is an error in the Swift 6 language mode}} {{7-7=await }}
-      // expected-warning@-2 {{non-Sendable type 'NonSendable' of property 'x' cannot exit main actor-isolated context; this is an error in the Swift 6 language mode}}
+      self.x // expected-tns-ni-warning {{assigning '$return_value' to task-isolated 'self.x.some' risks causing data races}}
+      // expected-tns-ni-note @-1 {{'$return_value' could become accessible to task-isolated code despite remaining accessible to code in the current task}}
+      // expected-tns-ni-ns-warning @-2 {{assigning '$return_value' to @concurrent task-isolated 'self.x.some' risks causing data races}}
+      // expected-tns-ni-ns-note @-3 {{'$return_value' could become accessible to @concurrent task-isolated code despite remaining accessible to code in the current task}}
+      // expected-warning @-4 {{main actor-isolated property 'x' cannot be accessed from outside of the actor; this is an error in the Swift 6 language mode}} {{7-7=await }}
+      // expected-warning @-5 {{non-Sendable type 'NonSendable' of property 'x' cannot exit main actor-isolated context; this is an error in the Swift 6 language mode}}
     }
   }
 }

--- a/test/Concurrency/sendable_metatype.swift
+++ b/test/Concurrency/sendable_metatype.swift
@@ -84,6 +84,12 @@ nonisolated func passMetaSmuggledAnyFromExistential(_ pqT: (P & Q).Type) {
   }
 }
 
+@MainActor func passMetaSmuggledAnyFromExistential2(_ pqT: (P & Q).Type) {
+  let x: P.Type = pqT
+  Task.detached { // expected-warning{{passing closure as a 'sending' parameter risks causing data races between main actor-isolated code and concurrent execution of the closure}}
+    acceptMeta(x) // expected-note{{closure captures 'x' which is accessible to main actor-isolated code}}
+  }
+}
 
 func testSendableMetatypeDowngrades() {
   @preconcurrency

--- a/test/Concurrency/silisolationinfo_inference.sil
+++ b/test/Concurrency/silisolationinfo_inference.sil
@@ -125,7 +125,7 @@ sil @useOptionalActor : $@convention(thin) (@sil_isolated @guaranteed Optional<M
 //
 // CHECK: begin running test 1 of 1 on actor_self_isolation_unknown: sil_isolation_info_inference with: @trace[0]
 // CHECK-NEXT: Input Value:   %0 = argument of bb0 : $MyActor
-// CHECK-NEXT: Isolation: unknown
+// CHECK-NEXT: Isolation: invalid
 // CHECK-NEXT: end running test 1 of 1 on actor_self_isolation_unknown: sil_isolation_info_inference with: @trace[0]
 sil [ossa] @actor_self_isolation_unknown : $@convention(thin) (@guaranteed MyActor) -> () {
 bb0(%0 : @guaranteed $MyActor):
@@ -1915,7 +1915,7 @@ bb0:
 
 // CHECK-LABEL: begin running test 1 of 1 on var_box_with_sendable_type_is_nonsendable_isolationinfo: sil_isolation_info_inference with: @trace[0]
 // CHECK: Input Value:   %0 = alloc_box ${ var MyActor }                 // user: %1
-// CHECK: Isolation: unknown
+// CHECK: Isolation: invalid
 // CHECK: end running test 1 of 1 on var_box_with_sendable_type_is_nonsendable_isolationinfo: sil_isolation_info_inference with: @trace[0]
 sil [ossa] @var_box_with_sendable_type_is_nonsendable_isolationinfo : $@convention(thin) () -> () {
 bb0:
@@ -1943,7 +1943,7 @@ bb0:
 
 // CHECK-LABEL: begin running test 1 of 1 on let_box_with_sendable_type_is_sendable_isolationinfo_inference: sil_isolation_info_inference with: @trace[0]
 // CHECK: Input Value:   %0 = alloc_box ${ let MyActor }                 // user: %1
-// CHECK: Isolation: unknown
+// CHECK: Isolation: invalid
 // CHECK: end running test 1 of 1 on let_box_with_sendable_type_is_sendable_isolationinfo_inference: sil_isolation_info_inference with: @trace[0]
 sil [ossa] @let_box_with_sendable_type_is_sendable_isolationinfo_inference : $@convention(thin) () -> () {
 bb0:
@@ -1971,7 +1971,7 @@ bb0:
 
 // CHECK-LABEL: begin running test 1 of 1 on var_box_with_nonsendable_type_is_nonsendable_isolationinfo_inference: sil_isolation_info_inference with: @trace[0]
 // CHECK: Input Value:   %0 = alloc_box ${ var NonSendableKlass }        // user: %1
-// CHECK: Isolation: unknown
+// CHECK: Isolation: invalid
 // CHECK: end running test 1 of 1 on var_box_with_nonsendable_type_is_nonsendable_isolationinfo_inference: sil_isolation_info_inference with: @trace[0]
 sil [ossa] @var_box_with_nonsendable_type_is_nonsendable_isolationinfo_inference : $@convention(thin) () -> () {
 bb0:
@@ -1999,7 +1999,7 @@ bb0:
 
 // CHECK-LABEL: begin running test 1 of 1 on let_box_with_nonsendable_type_is_nonsendable_isolationinfo_inference: sil_isolation_info_inference with: @trace[0]
 // CHECK: Input Value:   %0 = alloc_box ${ let NonSendableKlass }        // user: %1
-// CHECK: Isolation: unknown
+// CHECK: Isolation: invalid
 // CHECK: end running test 1 of 1 on let_box_with_nonsendable_type_is_nonsendable_isolationinfo_inference: sil_isolation_info_inference with: @trace[0]
 sil [ossa] @let_box_with_nonsendable_type_is_nonsendable_isolationinfo_inference : $@convention(thin) () -> () {
 bb0:

--- a/test/Concurrency/silisolationinfo_inference.sil
+++ b/test/Concurrency/silisolationinfo_inference.sil
@@ -116,6 +116,11 @@ sil @useUnmanagedNonSendableKlass : $@convention(thin) (@guaranteed @sil_unmanag
 sil @useActor : $@convention(thin) (@sil_isolated @guaranteed MyActor) -> @owned NonSendableKlass
 sil @useOptionalActor : $@convention(thin) (@sil_isolated @guaranteed Optional<MyActor>) -> @owned NonSendableKlass
 
+sil @useOptionalAnyActor : $@convention(thin) (@sil_isolated @guaranteed Optional<any Actor>) -> @owned NonSendableKlass
+sil @useOptionalAnyActorWithParam : $@convention(thin) (@sil_isolated @guaranteed Optional<any Actor>, @guaranteed NonSendableKlass) -> @owned NonSendableKlass
+
+sil [isolation "actor_instance"] @unappliedIsolatedAnyParameter : $@convention(method) @async (@sil_isolated @guaranteed Optional<any Actor>, @guaranteed NonSendableKlass) -> @owned NonSendableKlass
+
 ///////////////////////
 // MARK: Basic Tests //
 ///////////////////////
@@ -2007,6 +2012,115 @@ bb0:
   %0 = alloc_box ${ let NonSendableKlass }
   debug_value [trace] %0
   destroy_value %0
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on taskisolated_nonisolated_nonsending_test: sil_isolation_info_inference with: @trace[0]
+// CHECK-NEXT: Input Value: %1 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: Isolation: task-isolated: task_isolated_from_nonisolated_nonsending_parameter
+// CHECK-NEXT: end running test 1 of 1 on taskisolated_nonisolated_nonsending_test: sil_isolation_info_inference with: @trace[0]
+sil [ossa] [isolation "caller_isolation_inheriting"] @taskisolated_nonisolated_nonsending_test : $@convention(thin) (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $Builtin.ImplicitActor, %1 : @guaranteed $NonSendableKlass):
+  specify_test "sil_isolation_info_inference @trace[0]"
+  debug_value [trace] %1
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on builtin_implicit_actor_means_functionapplication_is_taskisolated: sil_isolation_info_inference with: @trace[0]
+// CHECK-NEXT: Input Value:   %3 = apply %2(%1) : $@convention(thin) (@sil_isolated @guaranteed Optional<any Actor>) -> @owned NonSendableKlass // user: %4
+// CHECK-NEXT: Isolation: task-isolated: task_isolated_from_nonisolated_nonsending_parameter
+// CHECK-NEXT: end running test 1 of 1 on builtin_implicit_actor_means_functionapplication_is_taskisolated: sil_isolation_info_inference with: @trace[0]
+sil [ossa] [isolation "caller_isolation_inheriting"] @builtin_implicit_actor_means_functionapplication_is_taskisolated : $@convention(thin) (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor) -> () {
+bb0(%0 : @guaranteed $Builtin.ImplicitActor):
+  specify_test "sil_isolation_info_inference @trace[0]"
+  %1 = implicitactor_to_opaqueisolation_cast %0
+  %f = function_ref @useOptionalAnyActor : $@convention(thin) (@sil_isolated @guaranteed Optional<any Actor>) -> @owned NonSendableKlass
+  %2 = apply %f(%1) : $@convention(thin) (@sil_isolated @guaranteed Optional<any Actor>) -> @owned NonSendableKlass
+  debug_value [trace] %2
+  destroy_value %2
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on builtin_implicit_actor_means_functionapplication_with_taskisolated_arg: sil_isolation_info_inference with: @trace[0]
+// CHECK-NEXT: Input Value:   %4 = apply %3(%2, %1) : $@convention(thin) (@sil_isolated @guaranteed Optional<any Actor>, @guaranteed NonSendableKlass) -> @owned NonSendableKlass // user: %5
+// CHECK-NEXT: Isolation: task-isolated: task_isolated_from_nonisolated_nonsending_parameter
+// CHECK-NEXT: end running test 1 of 1 on builtin_implicit_actor_means_functionapplication_with_taskisolated_arg: sil_isolation_info_inference with: @trace[0]
+sil [ossa] [isolation "caller_isolation_inheriting"] @builtin_implicit_actor_means_functionapplication_with_taskisolated_arg : $@convention(thin) (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $Builtin.ImplicitActor, %1 : @guaranteed $NonSendableKlass):
+  specify_test "sil_isolation_info_inference @trace[0]"
+  %2 = implicitactor_to_opaqueisolation_cast %0
+  %f = function_ref @useOptionalAnyActorWithParam : $@convention(thin) (@sil_isolated @guaranteed Optional<any Actor>, @guaranteed NonSendableKlass) -> @owned NonSendableKlass
+  %3 = apply %f(%2, %1) : $@convention(thin) (@sil_isolated @guaranteed Optional<any Actor>, @guaranteed NonSendableKlass) -> @owned NonSendableKlass
+  debug_value [trace] %3
+  destroy_value %3
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+sil [ossa] [isolation "caller_isolation_inheriting"] @merge_isolated_any_with_taskisolated_from_nonisolated_nonsending_parameter : $@convention(thin) (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $Builtin.ImplicitActor, %1 : @guaranteed $NonSendableKlass):
+  specify_test "sil_isolation_info_inference @trace[0]"
+  %2 = implicitactor_to_opaqueisolation_cast %0
+  %f = function_ref @useOptionalAnyActorWithParam : $@convention(thin) (@sil_isolated @guaranteed Optional<any Actor>, @guaranteed NonSendableKlass) -> @owned NonSendableKlass
+  %3 = apply %f(%2, %1) : $@convention(thin) (@sil_isolated @guaranteed Optional<any Actor>, @guaranteed NonSendableKlass) -> @owned NonSendableKlass
+  debug_value [trace] %3
+  destroy_value %3
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on unapplied_isolated_any_test: sil_isolation_info_inference with: @trace[0]
+// CHECK-NEXT: Input Value:   // function_ref unappliedIsolatedAnyParameter
+// CHECK-NEXT:   %0 = function_ref @unappliedIsolatedAnyParameter : $@convention(method) @async (@sil_isolated @guaranteed Optional<any Actor>, @guaranteed NonSendableKlass) -> @owned NonSendableKlass
+// CHECK-NEXT: Isolation: actor-isolated: unapplied_isolated_any_parameter
+// CHECK-NEXT: end running test 1 of 1 on unapplied_isolated_any_test: sil_isolation_info_inference with: @trace[0]
+sil [ossa] @unapplied_isolated_any_test : $@convention(thin) () -> () {
+bb0:
+  specify_test "sil_isolation_info_inference @trace[0]"
+  %f = function_ref @unappliedIsolatedAnyParameter : $@convention(method) @async (@sil_isolated @guaranteed Optional<any Actor>, @guaranteed NonSendableKlass) -> @owned NonSendableKlass
+  debug_value [trace] %f
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on unapplied_isolated_any_merge_test: sil-isolation-info-merged-inference with: @trace[0], @trace[1]
+// CHECK-NEXT: First Value:   // function_ref unappliedIsolatedAnyParameter
+// CHECK-NEXT:   %2 = function_ref @unappliedIsolatedAnyParameter : $@convention(method) @async (@sil_isolated @guaranteed Optional<any Actor>, @guaranteed NonSendableKlass) -> @owned NonSendableKlass
+// CHECK-NEXT: First Isolation: actor-isolated: unapplied_isolated_any_parameter
+// CHECK-NEXT: Second Value: %1 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: Second Isolation: task-isolated: task_isolated_from_nonisolated_nonsending_parameter
+// CHECK-NEXT: Merged Isolation: task-isolated: task_isolated_from_nonisolated_nonsending_parameter
+// CHECK-NEXT: end running test 1 of 1 on unapplied_isolated_any_merge_test: sil-isolation-info-merged-inference with: @trace[0], @trace[1]
+sil [ossa] [isolation "caller_isolation_inheriting"] @unapplied_isolated_any_merge_test : $@convention(thin) (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $Builtin.ImplicitActor, %1 : @guaranteed $NonSendableKlass):
+  specify_test "sil-isolation-info-merged-inference @trace[0] @trace[1]"
+  %f = function_ref @unappliedIsolatedAnyParameter : $@convention(method) @async (@sil_isolated @guaranteed Optional<any Actor>, @guaranteed NonSendableKlass) -> @owned NonSendableKlass
+  debug_value [trace] %f
+  debug_value [trace] %1
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on unapplied_isolated_any_merge_failure_test: sil-isolation-info-merged-inference with: @trace[0], @trace[1]
+// CHECK-NEXT: First Value:   %2 = alloc_stack $NonSendableKlass              // users: %6, %5, %4
+// CHECK-NEXT: First Isolation: global actor '<null>'-isolated
+// CHECK-NEXT: Second Value: %1 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: Second Isolation: task-isolated: task_isolated_from_nonisolated_nonsending_parameter
+// CHECK-NEXT: Merged Isolation: Merge failure!
+// CHECK-NEXT: end running test 1 of 1 on unapplied_isolated_any_merge_failure_test: sil-isolation-info-merged-inference with: @trace[0], @trace[1]
+sil [ossa] [isolation "caller_isolation_inheriting"] @unapplied_isolated_any_merge_failure_test : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $Builtin.ImplicitActor, %1 : @guaranteed $NonSendableKlass):
+  specify_test "sil-isolation-info-merged-inference @trace[0] @trace[1]"
+  %stack = alloc_stack $NonSendableKlass
+  %f = function_ref @constructNonSendableKlassIndirectAsync : $@convention(thin) @async () -> @out NonSendableKlass
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f(%stack) : $@convention(thin) @async () -> @out NonSendableKlass
+  debug_value [trace] %stack
+  debug_value [trace] %1
+  destroy_addr %stack : $*NonSendableKlass
+  dealloc_stack %stack : $*NonSendableKlass
   %9999 = tuple ()
   return %9999 : $()
 }

--- a/test/Concurrency/transfernonsendable_initializers.swift
+++ b/test/Concurrency/transfernonsendable_initializers.swift
@@ -36,7 +36,7 @@ actor ActorWithSynchronousNonIsolatedInit {
     // TODO: This should say actor isolated.
     let _ = { @MainActor in
       print(newK) // expected-error {{sending 'newK' risks causing data races}}
-      // expected-ni-note @-1 {{task-isolated 'newK' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-ni-note @-1 {{'self'-isolated 'newK' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
       // expected-ni-ns-note @-2 {{task-isolated 'newK' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
     }
   }

--- a/test/Concurrency/transfernonsendable_initializers.swift
+++ b/test/Concurrency/transfernonsendable_initializers.swift
@@ -37,7 +37,7 @@ actor ActorWithSynchronousNonIsolatedInit {
     let _ = { @MainActor in
       print(newK) // expected-error {{sending 'newK' risks causing data races}}
       // expected-ni-note @-1 {{'self'-isolated 'newK' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
-      // expected-ni-ns-note @-2 {{task-isolated 'newK' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-ni-ns-note @-2 {{'self'-isolated 'newK' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
     }
   }
 
@@ -47,7 +47,6 @@ actor ActorWithSynchronousNonIsolatedInit {
     helper(newK)
 
     let _ = { @MainActor in
-      // TODO: Second part should say later 'self'-isolated uses
       print(newK) // expected-error {{sending 'newK' risks causing data races}}
       // expected-note @-1 {{'self'-isolated 'newK' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
     }

--- a/test/Concurrency/transfernonsendable_nonisolated.swift
+++ b/test/Concurrency/transfernonsendable_nonisolated.swift
@@ -132,3 +132,18 @@ func callMainActorIsolatedFunction() async {
   await useValueAsync(x)
   useValueSync(x)
 }
+
+public final class LoggingScope {
+  fileprivate static let _subsystem: TaskLocal<String?>! = nil
+  fileprivate static let _scope: TaskLocal<String?>! = nil
+}
+
+public func withLoggingSubsystemAndScope<Result>(
+  subsystem: String,
+  scope: String?,
+  @_inheritActorContext _ operation: @Sendable @concurrent () async throws -> Result
+) async rethrows -> Result {
+  return try await LoggingScope._subsystem.withValue(subsystem) {
+    return try await LoggingScope._scope.withValue(scope, operation: operation)
+  }
+}

--- a/test/Concurrency/transfernonsendable_partitionop_translation.sil
+++ b/test/Concurrency/transfernonsendable_partitionop_translation.sil
@@ -1485,7 +1485,7 @@ bb0(%0 : @guaranteed $NonSendableKlass, %1 : @owned $NonSendableKlass):
 // CHECK-NEXT: require %%0:   %7 = apply %6(%1, %0, %3) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass, @in NonSendableStruct) -> ()
 // CHECK-NEXT: require %%4:   %7 = apply %6(%1, %0, %3) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass, @in NonSendableStruct) -> ()
 // CHECK-NEXT: merge %%1 with %%0:   %7 = apply %6(%1, %0, %3) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass, @in NonSendableStruct) -> ()
-// CHECK-NEXT: merge %%0 with %%4:   %7 = apply %6(%1, %0, %3) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass, @in NonSendableStruct) -> ()
+// CHECK-NEXT: merge %%1 with %%4:   %7 = apply %6(%1, %0, %3) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass, @in NonSendableStruct) -> ()
 // CHECK-NEXT: end running test {{.*}} on test_apply_three_mixed_params: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
 sil [ossa] @test_apply_three_mixed_params : $@convention(thin) (@guaranteed NonSendableKlass, @owned NonSendableKlass, @owned NonSendableKlass) -> () {
 bb0(%0 : @guaranteed $NonSendableKlass, %1 : @owned $NonSendableKlass, %2 : @owned $NonSendableKlass):
@@ -1524,8 +1524,8 @@ bb0(%0 : @guaranteed $NonSendableKlass, %1 : @owned $NonSendableKlass, %2 : @own
 // CHECK-NEXT: require %%5:   %11 = apply %10(%1, %0, %4, %7) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass, @inout NonSendableStruct, @in_guaranteed NonSendableStruct) -> ()
 // CHECK-NEXT: require %%6:   %11 = apply %10(%1, %0, %4, %7) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass, @inout NonSendableStruct, @in_guaranteed NonSendableStruct) -> ()
 // CHECK-NEXT: merge %%1 with %%0:   %11 = apply %10(%1, %0, %4, %7) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass, @inout NonSendableStruct, @in_guaranteed NonSendableStruct) -> ()
-// CHECK-NEXT: merge %%0 with %%5:   %11 = apply %10(%1, %0, %4, %7) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass, @inout NonSendableStruct, @in_guaranteed NonSendableStruct) -> ()
-// CHECK-NEXT: merge %%5 with %%6:   %11 = apply %10(%1, %0, %4, %7) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass, @inout NonSendableStruct, @in_guaranteed NonSendableStruct) -> ()
+// CHECK-NEXT: merge %%1 with %%5:   %11 = apply %10(%1, %0, %4, %7) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass, @inout NonSendableStruct, @in_guaranteed NonSendableStruct) -> ()
+// CHECK-NEXT: merge %%1 with %%6:   %11 = apply %10(%1, %0, %4, %7) : $@convention(thin) (@owned NonSendableKlass, @guaranteed NonSendableKlass, @inout NonSendableStruct, @in_guaranteed NonSendableStruct) -> ()
 // CHECK-NEXT: end running test {{.*}} on test_apply_four_mixed_params: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
 sil [ossa] @test_apply_four_mixed_params : $@convention(thin) (@guaranteed NonSendableKlass, @owned NonSendableKlass, @owned NonSendableKlass, @owned NonSendableKlass) -> () {
 bb0(%0 : @guaranteed $NonSendableKlass, %1 : @owned $NonSendableKlass, %2 : @owned $NonSendableKlass, %3 : @owned $NonSendableKlass):

--- a/test/Distributed/distributed_actor_transfernonsendable.swift
+++ b/test/Distributed/distributed_actor_transfernonsendable.swift
@@ -34,7 +34,7 @@ distributed actor MyDistributedActor {
     _ = { @MainActor in
       // TODO: This should error saying 'y' is actor isolated.
       print(y) // expected-error {{sending 'y' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'y' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'self'-isolated 'y' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
     }
   }
 

--- a/unittests/SILOptimizer/PartitionUtilsTest.cpp
+++ b/unittests/SILOptimizer/PartitionUtilsTest.cpp
@@ -100,10 +100,12 @@ struct MockedPartitionOpEvaluatorWithFailureCallback final
     case PartitionOpError::NonSendableIsolationCrossingResult:
     case PartitionOpError::InOutSendingReturned:
     case PartitionOpError::InOutSendingParametersInSameRegion:
+    case PartitionOpError::IncompatibleRegionMerge:
       llvm_unreachable("Unsupported");
     case PartitionOpError::LocalUseAfterSend: {
       auto state = std::move(error).getLocalUseAfterSendError();
       failureCallback(*state.op, state.sentElement, state.sendingOp);
+      break;
     }
     }
   }
@@ -258,22 +260,33 @@ TEST(PartitionUtilsTest, TestMergeAndJoin) {
     expect_join_eq();
   };
 
-  apply_to_p1_and_p3(PartitionOp::Merge(Element(1), Element(2)));
-  apply_to_p2_and_p3(PartitionOp::Merge(Element(7), Element(8)));
-  apply_to_p1_and_p3(PartitionOp::Merge(Element(2), Element(7)));
-  apply_to_p2_and_p3(PartitionOp::Merge(Element(1), Element(3)));
-  apply_to_p1_and_p3(PartitionOp::Merge(Element(3), Element(4)));
+  apply_to_p1_and_p3(
+      PartitionOp::Merge(Element(1), Element(2), RegionMergeReason::Unknown));
+  apply_to_p2_and_p3(
+      PartitionOp::Merge(Element(7), Element(8), RegionMergeReason::Unknown));
+  apply_to_p1_and_p3(
+      PartitionOp::Merge(Element(2), Element(7), RegionMergeReason::Unknown));
+  apply_to_p2_and_p3(
+      PartitionOp::Merge(Element(1), Element(3), RegionMergeReason::Unknown));
+  apply_to_p1_and_p3(
+      PartitionOp::Merge(Element(3), Element(4), RegionMergeReason::Unknown));
 
   EXPECT_FALSE(Partition::equals(p1, p2));
   EXPECT_FALSE(Partition::equals(p2, p3));
   EXPECT_FALSE(Partition::equals(p1, p3));
 
-  apply_to_p2_and_p3(PartitionOp::Merge(Element(2), Element(5)));
-  apply_to_p1_and_p3(PartitionOp::Merge(Element(5), Element(6)));
-  apply_to_p2_and_p3(PartitionOp::Merge(Element(1), Element(6)));
-  apply_to_p1_and_p3(PartitionOp::Merge(Element(2), Element(6)));
-  apply_to_p2_and_p3(PartitionOp::Merge(Element(3), Element(7)));
-  apply_to_p1_and_p3(PartitionOp::Merge(Element(7), Element(8)));
+  apply_to_p2_and_p3(
+      PartitionOp::Merge(Element(2), Element(5), RegionMergeReason::Unknown));
+  apply_to_p1_and_p3(
+      PartitionOp::Merge(Element(5), Element(6), RegionMergeReason::Unknown));
+  apply_to_p2_and_p3(
+      PartitionOp::Merge(Element(1), Element(6), RegionMergeReason::Unknown));
+  apply_to_p1_and_p3(
+      PartitionOp::Merge(Element(2), Element(6), RegionMergeReason::Unknown));
+  apply_to_p2_and_p3(
+      PartitionOp::Merge(Element(3), Element(7), RegionMergeReason::Unknown));
+  apply_to_p1_and_p3(
+      PartitionOp::Merge(Element(7), Element(8), RegionMergeReason::Unknown));
 }
 
 TEST(PartitionUtilsTest, Join1) {
@@ -919,7 +932,8 @@ TEST(PartitionUtilsTest, TestHistory_BuildNewRegionRepIsMergee) {
                 PartitionOp::AssignFresh(Element(0)),
                 PartitionOp::AssignDirect(Element(3), Element(2)),
                 PartitionOp::AssignDirect(Element(10), Element(2)),
-                PartitionOp::Merge(Element(2), Element(0))});
+                PartitionOp::Merge(Element(2), Element(0),
+                                   RegionMergeReason::Unknown)});
   }
 
   Partition pSnapshot = p;


### PR DESCRIPTION
This is part of a larger series of PRs that expands the flexibility of flow isolation. In this PR, we do the following:

  - [flow-isolation] Treat non-Sendable params of nonisolated sync actor inits as actor-isolated. This was not in the proposal specifically but after some thought we realized this ensures that nonisolated async actor inits and nonisolated sync actor inits would behave the same an important invariant in terms of avoiding extra special rules.
  - [rbi] Refactor/fix SILIsolationInfo lattice and merge logic. I took this as an opportunity to make the SILIsolationInfo lattice, a /real/ lattice and fixed the merge logic therein.
  - [rbi] Add IncompatibleRegionMerge error with contextual diagnostics. This then begin allowing us to handle incompatible region merge errors.
  - Finally, in the last commit I added the support in the title.

In a subsequent commit, I am going to extend this work so that we can initialize fields of GADT nominal types.