### PR TITLE
Embedded Swift stdlib: ensure archives are properly generated...

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -3545,3 +3545,26 @@ function(add_swift_target_executable name)
 
   endforeach()
 endfunction()
+
+function(embedded_amend_archive_commands_on_darwin_host target triple)
+  # This is a temporary solution while we work on porting the build
+  # on the Embedded stdlib to the Runtime build system, where each platform
+  # is built by a separate CMake invocation, thus allowing to set the archiver
+  # properly in the toolchain file.
+  if(SWIFT_HOST_VARIANT STREQUAL "macosx" AND SWIFT_EMBEDDED_STDLIB_ARCHIVER_FOR_NON_DARWIN_PLATFORMS_UNDER_MACOS)
+    if(triple MATCHES "-elf$" OR triple MATCHES "-eabi$" OR triple MATCHES "-wasm$")
+      # There is no way to change the archive commands only for a few targets, so
+      # we resort going double work (and assume the previous commands exit successfully)
+      add_custom_command(TARGET ${target}
+        POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E rm $<TARGET_FILE:${target}>
+        COMMAND ${SWIFT_EMBEDDED_STDLIB_ARCHIVER_FOR_NON_DARWIN_PLATFORMS_UNDER_MACOS}
+          $<TARGET_FILE:${target}>
+          "$<LIST:JOIN,$<TARGET_PROPERTY:${target},STATIC_LIBRARY_OPTIONS>,;>"
+          "$<LIST:JOIN,$<TARGET_OBJECTS:${target}>,;>"
+        COMMAND ${CMAKE_COMMAND} -E touch $<TARGET_FILE:${target}>
+        VERBATIM
+        COMMAND_EXPAND_LISTS)
+    endif()
+  endif()
+endfunction()

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -159,6 +159,19 @@ set(SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES "" CACHE STRING
     "List of SDKs to use for target triples, in the form triple@sdkpath.
     Using this variable precludes setting directly the value for  SWIFT_SDK_embedded_ARCH_\$\{ARCH\}_PATH")
 
+set(SWIFT_EMBEDDED_STDLIB_ARCHIVER_FOR_NON_DARWIN_PLATFORMS_UNDER_MACOS "${SWIFT_NATIVE_LLVM_TOOLS_PATH}/llvm-ar";crsU
+    CACHE STRING
+    "Archiver to use when building static archives for non Darwin platform targeting the macOS SDK.
+    This is required when using Xcode 26.4 beta 1 and later.")
+
+if(SWIFT_HOST_VARIANT STREQUAL "macosx")
+  list(GET SWIFT_EMBEDDED_STDLIB_ARCHIVER_FOR_NON_DARWIN_PLATFORMS_UNDER_MACOS 0 ARCHIVER_EXECUTABLE)
+  if(NOT IS_EXECUTABLE "${ARCHIVER_EXECUTABLE}")
+    message(WARNING "'${ARCHIVER_EXECUTABLE}' is not a valid program, unsetting SWIFT_EMBEDDED_STDLIB_ARCHIVER_FOR_NON_DARWIN_PLATFORMS_UNDER_MACOS to be able to pick up a different value at next run.")
+    unset(SWIFT_EMBEDDED_STDLIB_ARCHIVER_FOR_NON_DARWIN_PLATFORMS_UNDER_MACOS CACHE)
+  endif()
+endif()
+
 if((NOT SWIFT_HOST_VARIANT STREQUAL "macosx") AND
   (NOT SWIFT_HOST_VARIANT STREQUAL "linux") AND
   (NOT SWIFT_HOST_VARIANT STREQUAL "wasi") AND

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -394,6 +394,9 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
     if(NOT "${arch}" MATCHES "wasm32")
       set_property(TARGET embedded-concurrency-${mod} PROPERTY OSX_ARCHITECTURES "${arch}")
     endif()
+
+    embedded_amend_archive_commands_on_darwin_host(embedded-concurrency-${mod} ${triple})
+
     add_dependencies(embedded-concurrency embedded-concurrency-${mod})
 
     # lib/swift/embedded/<triple>/libswift_ConcurrencyDefaultExecutor.a
@@ -424,6 +427,9 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
       PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
       )
     set_property(TARGET embedded-concurrency-default-executor-${mod} PROPERTY OSX_ARCHITECTURES "${arch}")
+
+    embedded_amend_archive_commands_on_darwin_host(embedded-concurrency-default-executor-${mod} ${triple})
+
     add_dependencies(embedded-concurrency embedded-concurrency-default-executor-${mod})
   endforeach()
 

--- a/stdlib/public/stubs/Exclusivity/CMakeLists.txt
+++ b/stdlib/public/stubs/Exclusivity/CMakeLists.txt
@@ -69,6 +69,8 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
         )
       set_property(TARGET embedded-exclusivity-${impl}-${mod} PROPERTY OSX_ARCHITECTURES "${arch}")
 
+      embedded_amend_archive_commands_on_darwin_host(embedded-exclusivity-${impl}-${mod} ${triple})
+
       add_dependencies(embedded-exclusivity embedded-exclusivity-${impl}-${mod})
     endforeach()
   endforeach()

--- a/stdlib/public/stubs/Unicode/CMakeLists.txt
+++ b/stdlib/public/stubs/Unicode/CMakeLists.txt
@@ -65,6 +65,8 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
       )
     set_property(TARGET embedded-unicode-${mod} PROPERTY OSX_ARCHITECTURES "${arch}")
 
+    embedded_amend_archive_commands_on_darwin_host(embedded-unicode-${mod} ${triple})
+
     add_dependencies(embedded-unicode embedded-unicode-${mod})
   endforeach()
 endif()


### PR DESCRIPTION
when building non Darwin architectures with Xcode 26.4 beta 1 and later -- the archiver that ships in Xcode is guaranteed to work only on MachO object files, and will generate empty archives for other executable formats.

This is a temporary solution while we add the support to build the Embedded Swift stdlib in the new Runtimes build system.

Addresses rdar://171007411