### PR TITLE
[Typed throws] Fix replay of potential throw sites

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -401,7 +401,7 @@ void ConstraintSystem::replaySolution(const Solution &solution,
   auto sites = ArrayRef(solution.potentialThrowSites);
   ASSERT(sites.size() >= potentialThrowSites.size());
   for (const auto &site : sites.slice(potentialThrowSites.size())) {
-    potentialThrowSites.push_back(site);
+    recordPotentialThrowSite(site.first, site.second);
   }
 
   for (auto param : solution.isolatedParams) {

--- a/test/stmt/typed_throws.swift
+++ b/test/stmt/typed_throws.swift
@@ -205,6 +205,19 @@ func testDoCatchErrorTypedInClosure(cond: Bool) {
   }
 }
 
+// issue-77718
+func testDoCatchErrorTypedInAsyncClosure<T, E: Error>(
+  work: @escaping @Sendable () async throws(E) -> T,
+) -> Task<Result<T, E>, Never> {
+  .init {
+    do {
+      return .success(try await work())
+    } catch {
+      return .failure(error)
+    }
+  }
+}
+
 struct ThrowingMembers {
   subscript(i: Int) -> Int {
     get throws(MyError) { i }


### PR DESCRIPTION
Fixes #77718

The failure here was in `ConstraintSystem::replaySolution` when replaying `potentialThrowSites`.

Those entries are normally tracked through `recordPotentialThrowSite(...)`, which records trail state so nested solver scopes can roll them back. `replaySolution` was bypassing that helper and mutating `potentialThrowSites` directly, which could leave stale throw sites behind across solver attempts and trip the `sites.size() >= potentialThrowSites.size()` assertion when a later solution was replayed.

This changes `replaySolution` to replay potential throw sites through the trailed helper instead of pushing them directly, and keeps the new typed-throws regression test that exercises the crash.

Smoke-tested:
- `test/stmt/typed_throws.swift` with the rebuilt local `swift-frontend` and `-verify`
- `test/stmt/typed_throws_ast.swift` with `-dump-ast | FileCheck`
- `test/expr/closure/typed_throws.swift` via `llvm-lit`
- `test/decl/func/typed_throws.swift` via `llvm-lit`
- `test/Concurrency/typed_throws.swift` via `llvm-lit`
