### PR TITLE
AST: Allow `anyAppleOS` availability without an experimental feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@
 
 ## Swift (next)
 
+* To simplify writing cross-platform code for Apple platforms while adopting
+  new APIs, availability on macOS, iOS, tvOS, watchOS, and visionOS can now be
+  specified implicitly using `anyAppleOS` for operating system versions starting
+  with `26.0`:
+
+  ```swift
+  @available(anyAppleOS 26.0, *)
+  func functionAvailableOnVersion26() {
+    // ...
+  }
+
+  if #available(anyAppleOS 26.0, *) {
+    // Executes on macOS 26, iOS 26, watchOS 26, tvOS 26, and visionOS 26.
+    functionAvailableOnVersion26()
+  }
+  ```
+
+  If availability for a specific platform is specified simultaneously with
+  `anyAppleOS`, availability for the specific platform takes precedence when
+  building for that platform:
+
+  ```swift
+  if #available(anyAppleOS 26.0, macOS 26.4, *) {
+    // Executes on macOS 26.4 and version 26 of all other Apple OSes.
+  }
+  ```
+
 * [SE-0504][]:
   Introduced Task Cancellation Shields which temporarily prevent the observation of task
   cancellation in a given scope. This functionality is intended for use with cleanup actions which

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -286,6 +286,8 @@ LANGUAGE_FEATURE(BuiltinMarkDependence, 0, "markDependence Builtin")
 // suppression of @c in Swift interfaces as a temporary measure.
 SUPPRESSIBLE_LANGUAGE_FEATURE(CAttribute, 495, "@c attribute")
 
+BASELINE_LANGUAGE_FEATURE(AnyAppleOSAvailability, 0, "Support `anyAppleOS` availability")
+
 //===----------------------------------------------------------------------===//
 // MARK: - Swift 6 features
 //===----------------------------------------------------------------------===//
@@ -597,9 +599,6 @@ EXPERIMENTAL_FEATURE(EmbeddedExistentials, true)
 
 /// Allow enabling dynamic exclusivity in Embedded Swift.
 EXPERIMENTAL_FEATURE(EmbeddedDynamicExclusivity, true)
-
-/// Allow use of the 'anyAppleOS' availability domain.
-EXPERIMENTAL_FEATURE(AnyAppleOSAvailability, true)
 
 /// Check @_implementationOnly imports in non-library-evolution mode.
 EXPERIMENTAL_FEATURE(CheckImplementationOnly, true)

--- a/lib/AST/AvailabilityDomain.cpp
+++ b/lib/AST/AvailabilityDomain.cpp
@@ -664,13 +664,6 @@ AvailabilityDomainOrIdentifier::lookUpInDeclContext(
     return std::nullopt;
   }
 
-  if (domain->getPlatformKind() == PlatformKind::anyAppleOS &&
-      !ctx.LangOpts.hasFeature(Feature::AnyAppleOSAvailability)) {
-    diags.diagnose(loc, diag::availability_domain_requires_feature, *domain,
-                   "AnyAppleOSAvailability");
-    return std::nullopt;
-  }
-
   // Use of the 'Swift' domain requires the 'SwiftRuntimeAvailability' feature.
   if (!hasSwiftRuntimeAvailability && domain->isStandaloneSwiftRuntime()) {
     diags.diagnose(loc, diag::availability_domain_requires_feature, *domain,

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -598,7 +598,6 @@ static bool usesFeatureReparenting(Decl *decl) {
   return false;
 }
 
-UNINTERESTING_FEATURE(AnyAppleOSAvailability)
 UNINTERESTING_FEATURE(StrictAccessControl)
 UNINTERESTING_FEATURE(BorrowInout)
 

--- a/test/Availability/availability_any_apple_os.swift
+++ b/test/Availability/availability_any_apple_os.swift
@@ -1,12 +1,10 @@
-// RUN: %target-typecheck-verify-swift -parse-stdlib -enable-experimental-feature AnyAppleOSAvailability -target %target-cpu-apple-macos26 -verify-additional-prefix apple- -verify-additional-prefix macos-
-// RUN: %target-typecheck-verify-swift -parse-stdlib -enable-experimental-feature AnyAppleOSAvailability -target %target-cpu-apple-ios26 -verify-additional-prefix apple- -verify-additional-prefix ios-
-// RUN: %target-typecheck-verify-swift -parse-stdlib -enable-experimental-feature AnyAppleOSAvailability -target %target-cpu-apple-watchos26 -verify-additional-prefix apple- -verify-additional-prefix watchos-
-// RUN: %target-typecheck-verify-swift -parse-stdlib -enable-experimental-feature AnyAppleOSAvailability -target %target-cpu-apple-tvos26 -verify-additional-prefix apple- -verify-additional-prefix tvos-
-// RUN: %target-typecheck-verify-swift -parse-stdlib -enable-experimental-feature AnyAppleOSAvailability -target %target-cpu-apple-visionos26 -verify-additional-prefix apple- -verify-additional-prefix visionos-
-// RUN: %target-typecheck-verify-swift -parse-stdlib -enable-experimental-feature AnyAppleOSAvailability -target x86_64-unknown-linux-gnu
-// RUN: %target-typecheck-verify-swift -parse-stdlib -enable-experimental-feature AnyAppleOSAvailability -target x86_64-unknown-windows-msvc
-
-// REQUIRES: swift_feature_AnyAppleOSAvailability
+// RUN: %target-typecheck-verify-swift -parse-stdlib -target %target-cpu-apple-macos26 -verify-additional-prefix apple- -verify-additional-prefix macos-
+// RUN: %target-typecheck-verify-swift -parse-stdlib -target %target-cpu-apple-ios26 -verify-additional-prefix apple- -verify-additional-prefix ios-
+// RUN: %target-typecheck-verify-swift -parse-stdlib -target %target-cpu-apple-watchos26 -verify-additional-prefix apple- -verify-additional-prefix watchos-
+// RUN: %target-typecheck-verify-swift -parse-stdlib -target %target-cpu-apple-tvos26 -verify-additional-prefix apple- -verify-additional-prefix tvos-
+// RUN: %target-typecheck-verify-swift -parse-stdlib -target %target-cpu-apple-visionos26 -verify-additional-prefix apple- -verify-additional-prefix visionos-
+// RUN: %target-typecheck-verify-swift -parse-stdlib -target x86_64-unknown-linux-gnu
+// RUN: %target-typecheck-verify-swift -parse-stdlib -target x86_64-unknown-windows-msvc
 
 @available(anyAppleOS 26.1, *)
 func availableInAnyAppleOS26_1() { }

--- a/test/Interpreter/borrow_layout.swift
+++ b/test/Interpreter/borrow_layout.swift
@@ -2,7 +2,6 @@
 //
 // RUN: %target-build-swift -enable-experimental-feature BuiltinModule \
 // RUN:   -enable-experimental-feature Lifetimes \
-// RUN:   -enable-experimental-feature AnyAppleOSAvailability \
 // RUN:   -Xfrontend -verify-type-layout -Xfrontend LoanPointer \
 // RUN:   -Xfrontend -verify-type-layout -Xfrontend OptionalLoanPointer \
 // RUN:   -Xfrontend -verify-type-layout -Xfrontend Optional2LoanPointer \
@@ -41,7 +40,6 @@
 //
 // REQUIRES: swift_feature_Lifetimes
 // REQUIRES: swift_feature_BuiltinModule
-// REQUIRES: swift_feature_AnyAppleOSAvailability
 
 // CHECK-NOT: Type verification
 

--- a/test/PrintAsObjC/anyAppleOS_availability.swift
+++ b/test/PrintAsObjC/anyAppleOS_availability.swift
@@ -1,10 +1,8 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-feature AnyAppleOSAvailability -typecheck %s -emit-objc-header-path %t/anyAppleOS.h -target arm64-apple-macos26 -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s -emit-objc-header-path %t/anyAppleOS.h -target arm64-apple-macos26 -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/anyAppleOS.h
 
 // REQUIRES: objc_interop
-// REQUIRES: swift_feature_AnyAppleOSAvailability
-// REQUIRES: asserts
 
 import Foundation
 

--- a/test/attr/attr_availability.swift
+++ b/test/attr/attr_availability.swift
@@ -45,7 +45,7 @@ func swift6_2() {}
 @available(SwiftLanguageMode 6.0, *) // expected-error {{Swift requires '-enable-experimental-feature SwiftRuntimeAvailability'}}
 func swiftLanguageMode6_0() {}
 
-@available(anyAppleOS 26, *) // expected-error {{any Apple OS requires '-enable-experimental-feature AnyAppleOSAvailability'}}
+@available(anyAppleOS 26, *)
 func anyAppleOS26() {}
 
 // <rdar://problem/17669805> Availability can't appear on a typealias

--- a/test/attr/attr_availability_any_apple_os.swift
+++ b/test/attr/attr_availability_any_apple_os.swift
@@ -1,6 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 5 -parse-as-library -enable-experimental-feature AnyAppleOSAvailability
-
-// REQUIRES: swift_feature_AnyAppleOSAvailability
+// RUN: %target-typecheck-verify-swift -swift-version 5 -parse-as-library
 
 @available(anyAppleOS 26, *)
 func availableIn26Short() { }


### PR DESCRIPTION
Resolves rdar://170988964.