### PR TITLE
[Concurrency] Don't infer `@MainActor` by default on associated types

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6014,6 +6014,11 @@ computeDefaultInferredActorIsolation(ValueDecl *value) {
       if (isa<TypeAliasDecl>(value))
         return {};
 
+      // Associated types cannot have custom isolation, they are tied to
+      // their protocol declaration.
+      if (isa<AssociatedTypeDecl>(value))
+        return {};
+
       // Members and nested types must check the isolation of the enclosing
       // nominal type.
       auto *dc = value->getInnermostDeclContext();

--- a/test/Concurrency/default_isolation_MainActor_cross_module.swift
+++ b/test/Concurrency/default_isolation_MainActor_cross_module.swift
@@ -35,6 +35,13 @@ public protocol P {
 nonisolated public protocol Q: Sendable {
 }
 
+// CHECK: @_Concurrency::MainActor @preconcurrency public protocol IsolatedProto<T> {
+// CHECK:   associatedtype T
+// CHECK: }
+public protocol IsolatedProto<T> {
+  associatedtype T
+}
+
 // CHECK: @_Concurrency::MainActor @preconcurrency public struct S : A::P {
 public struct S: P {
   // CHECK: @_Concurrency::MainActor @preconcurrency public enum E : Swift::String {
@@ -60,8 +67,22 @@ public struct S: P {
     public init() {}
   }
   // CHECK: }
+
+  // CHECK: @_Concurrency::MainActor @preconcurrency public subscript(x: Swift::Int) -> Swift::Int {
+  public subscript(x: Int) -> Int {
+    // CHECK: get
+    get { x }
+    // CHECK: set
+    set { }
+  }
+  // CHECK: }
 }
 // CHECK: }
+
+// CHECK: @_Concurrency::MainActor @preconcurrency public func opaqueTest() -> some A::P
+public func opaqueTest() -> some P {
+  S()
+}
 
 // CHECK: public struct R : A::Q {
 public struct R: Q {


### PR DESCRIPTION
Global actor attribute cannot appear on such declarations and SE-0466 explicitly prohibits such inference as well.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
