### PR TITLE
build: skip CMake Swift compiler ID detection on Windows

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1671,6 +1671,8 @@ function Build-CMakeProject {
 
           Add-KeyValueIfNew $Defines CMAKE_Swift_COMPILER $SWIFTC
           Add-KeyValueIfNew $Defines CMAKE_Swift_COMPILER_TARGET $Platform.Triple
+          # Skip compiler ID detection: avoids compiling+scanning a multi-MB test binary on every configure.
+          Add-KeyValueIfNew $Defines CMAKE_Swift_COMPILER_ID "Apple"
 
           [string[]] $SwiftFlags = @();
 
@@ -1787,6 +1789,8 @@ function Build-CMakeProject {
           }
           Add-KeyValueIfNew $Defines CMAKE_Swift_COMPILER $SWIFTC
           Add-KeyValueIfNew $Defines CMAKE_Swift_COMPILER_TARGET $Platform.Triple
+          # Skip compiler ID detection: avoids compiling+scanning a multi-MB test binary on every configure.
+          Add-KeyValueIfNew $Defines CMAKE_Swift_COMPILER_ID "Apple"
 
           [string[]] $SwiftFlags = @()
 


### PR DESCRIPTION
Pre-set CMAKE_Swift_COMPILER_ID to avoid CMake's default detection which compiles a test binary and scans it byte-by-byte for compiler info strings. On Windows the test binary is statically linked and multi-MB, making this a significant overhead on every configure step that enables Swift. CMake still queries the compiler version via "swiftc -version" which is fast.

Measured on a 64-core Azure VM: ExperimentalStaticDispatch configure dropped from ~110s to <20s, with noticeable improvements across other configure steps as well.