### PR TITLE
[SILGen] Fix key path lowering for existential components

### DIFF
--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -446,7 +446,8 @@ public:
       ResilienceExpansion expansion, unsigned &baseOperand,
       bool &needsGenericContext, SubstitutionMap subs, ValueDecl *decl,
       ArrayRef<ProtocolConformanceRef> indexHashables, CanType baseTy,
-      DeclContext *useDC, bool forPropertyDescriptor, bool isApplied = false);
+      DeclContext *useDC, bool forPropertyDescriptor, bool isApplied = false,
+      Type resolvedComponentType = Type());
 
   /// Emit all differentiability witnesses for the given function, visiting its
   /// `@differentiable` and `@derivative` attributes.

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -4698,7 +4698,8 @@ KeyPathPatternComponent SILGenModule::emitKeyPathComponentForDecl(
     ResilienceExpansion expansion, unsigned &baseOperand,
     bool &needsGenericContext, SubstitutionMap subs, ValueDecl *decl,
     ArrayRef<ProtocolConformanceRef> indexHashables, CanType baseTy,
-    DeclContext *useDC, bool forPropertyDescriptor, bool isApplied) {
+    DeclContext *useDC, bool forPropertyDescriptor, bool isApplied,
+    Type resolvedComponentType) {
   if (auto *storage = dyn_cast<AbstractFunctionDecl>(decl)) {
     // ABI-compatible overrides do not have property descriptors, so we need
     // to reference the overridden declaration instead.
@@ -4895,12 +4896,19 @@ KeyPathPatternComponent SILGenModule::emitKeyPathComponentForDecl(
 
     if (auto var = dyn_cast<VarDecl>(storage)) {
       CanType componentTy;
-      if (!var->getDeclContext()->isTypeContext()) {
+      if (resolvedComponentType) {
+        componentTy = resolvedComponentType->getRValueType()
+            ->mapTypeOutOfEnvironment()
+            ->getCanonicalType();
+      } else if (!var->getDeclContext()->isTypeContext()) {
         componentTy = var->getInterfaceType()->getCanonicalType();
       } else if (var->getDeclContext()->getSelfProtocolDecl() &&
                  baseTy->isExistentialType()) {
-        componentTy = var->getValueInterfaceType()->getCanonicalType();
-        ASSERT(!componentTy->hasTypeParameter());
+        componentTy =
+            var->getValueInterfaceType()
+                .subst(baseTy->getContextSubstitutionMap(var->getDeclContext()))
+                ->mapTypeOutOfEnvironment()
+                ->getCanonicalType();
       } else {
         // The mapTypeIntoEnvironment() / mapTypeOutOfEnvironment() dance is there
         // to handle the case where baseTy being a type parameter subject
@@ -4916,7 +4924,7 @@ KeyPathPatternComponent SILGenModule::emitKeyPathComponentForDecl(
 
       // The component type for an @objc optional requirement needs to be
       // wrapped in an optional.
-      if (var->getAttrs().hasAttribute<OptionalAttr>()) {
+      if (!resolvedComponentType && var->getAttrs().hasAttribute<OptionalAttr>()) {
         componentTy = OptionalType::get(componentTy)->getCanonicalType();
       }
 
@@ -5048,7 +5056,8 @@ RValue RValueEmitter::visitKeyPathExpr(KeyPathExpr *E, SGFContext C) {
           SGF.F.getResilienceExpansion(), numOperands, needsGenericContext,
           component.getDeclRef().getSubstitutions(), decl,
           argComponent.getIndexHashableConformances(), baseTy, SGF.FunctionDC,
-          /*for descriptor*/ false, /*is applied func*/ isApplied));
+          /*for descriptor*/ false, /*is applied func*/ isApplied,
+          component.getComponentType()));
       baseTy = loweredComponents.back().getComponentType();
       if ((kind == KeyPathExpr::Component::Kind::Member &&
            !dyn_cast<FuncDecl>(decl) && !dyn_cast<ConstructorDecl>(decl)) ||

--- a/test/SILGen/issue-76984.swift
+++ b/test/SILGen/issue-76984.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+func f(_ c: [any RandomAccessCollection<Int>]) {
+  let _ = c.compactMap(\.last)
+}
+
+// CHECK: keypath $KeyPath<any RandomAccessCollection<Int>, Optional<Int>>
+// CHECK: @$s{{.*}}SgvpSk_pSiABSkRts_XPTK : $@convention(keypath_accessor_getter) (@in_guaranteed any RandomAccessCollection<Int>) -> @out Optional<Int>


### PR DESCRIPTION
Fixes #76984

## Repro

```swift
func f(_ c: [any RandomAccessCollection<Int>]) {
    let _ = c.compactMap(\\.last)
}
```

This was crashing in SILGen while lowering the key path on an existential collection.

The original issue report included this stack shape on Apple Swift 6.0:

```text
While silgen emitFunction SIL function "@$s11Swift6Tests1fyySaySk_pSi7ElementSkRts_XPGF"
...
Transform::transform
getOrCreateKeyPathGetter
SILGenModule::emitKeyPathComponentForDecl
RValueEmitter::visitKeyPathExpr
```

On a current local asserts build, the same repro still hit the existential member path in `emitKeyPathComponentForDecl`, first tripping:

```text
Assertion failed: (!componentTy->hasTypeParameter()),
function emitKeyPathComponentForDecl
```

## Root Cause

`KeyPathExpr` already carries the resolved component type from type checking. For this repro, the AST component type is `Optional<Int>`.

SILGen was ignoring that resolved type and recomputing the component type from the storage declaration. In the existential protocol-member path, that reconstruction preserved a dependent member style type like `Self.Element?` / `RandomAccessCollection<Int>.Element?` instead of the resolved `Int?`. That mismatch then broke key-path getter lowering.

## Fix

Thread the resolved component type through `emitKeyPathComponentForDecl` when lowering a `KeyPathExpr`, strip any lvalue-ness with `getRValueType()`, and use that as the key-path component type.

Non-AST callers such as property descriptor emission continue to use the existing fallback logic.

## Tests

Added `test/SILGen/issue-76984.swift`.

Validated with:

```text
llvm-lit -sv \
  --param swift_site_config=.../test-macosx-arm64/lit.site.cfg \
  --param swift_src_root=/Users/nachosoto/code/other/swift-76984 \
  test/SILGen/issue-76984.swift
```

Also reran nearby SILGen coverage:

- `test/SILGen/keypaths.swift`
- `test/SILGen/keypath_application.swift`
- `test/SILGen/keypath_accessors_reabstraction.swift`
- `test/SILGen/keypath_witness_overrides.swift`
- `test/SILGen/parameterized_existentials.swift`
