### PR TITLE
[Concurrency] Fix lazy Sendable property diagnostic

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -7120,6 +7120,8 @@ static bool checkSendableInstanceStorage(
 
     /// Handle a stored property.
     bool operator()(VarDecl *property, Type propertyType) override {
+      auto [propertyForDiagnostics, propertyTypeForDiagnostics] =
+          getPropertyForDiagnostics(property, propertyType);
       ActorIsolation isolation = getActorIsolation(property);
 
       // 'nonisolated' properties are always okay in 'Sendable' types because
@@ -7140,9 +7142,9 @@ static bool checkSendableInstanceStorage(
           auto preconcurrency =
               check == SendableCheck::ImpliedByPreconcurrencyProtocol;
           if (behavior != DiagnosticBehavior::Ignore) {
-            property
+            propertyForDiagnostics
                 ->diagnose(diag::concurrent_value_class_mutable_property,
-                           property->getName(), nominal)
+                           propertyForDiagnostics->getName(), nominal)
                 .limitBehaviorWithPreconcurrency(behavior, preconcurrency);
           }
           invalid = invalid || (behavior == DiagnosticBehavior::Unspecified);
@@ -7154,7 +7156,8 @@ static bool checkSendableInstanceStorage(
         }
       }
 
-      return checkSendabilityOfMemberType(property, propertyType);
+      return checkSendabilityOfMemberType(
+          propertyForDiagnostics, propertyTypeForDiagnostics);
     }
 
     /// Handle an enum associated value.
@@ -7163,6 +7166,20 @@ static bool checkSendableInstanceStorage(
     }
 
   private:
+    std::pair<VarDecl *, Type> getPropertyForDiagnostics(VarDecl *property,
+                                                         Type propertyType) {
+      if (!property->isLazyStorageProperty())
+        return {property, propertyType};
+
+      auto *originalProperty = property->getOriginalVarForBackingStorage();
+      if (!originalProperty)
+        return {property, propertyType};
+
+      auto originalPropertyType =
+          dc->mapTypeIntoEnvironment(originalProperty->getValueInterfaceType());
+      return {originalProperty, originalPropertyType};
+    }
+
     bool checkSendabilityOfMemberType(ValueDecl *member, Type memberType) {
       SendableCheckContext context(dc, check);
       diagnoseNonSendableTypes(

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -332,6 +332,10 @@ final class C1: Sendable {
   let i: Int = 0
 }
 
+final class C1Lazy: Sendable {
+  lazy var a: Int = 0 // expected-warning{{stored property 'a' of 'Sendable'-conforming class 'C1Lazy' is mutable}}
+}
+
 final class C2: Sendable {
   let x: Int = 0
 }


### PR DESCRIPTION
Fixes #60417

## Repro

```swift
final class A: Sendable {
  lazy var a: String = "test"
}
```

Before this change, Swift diagnosed the synthesized backing storage instead of the
property the user actually wrote:

```text
stored property '$__lazy_storage_$_a' of 'Sendable'-conforming class 'A' is mutable
```

With this change, the diagnostic points at the declared property name:

```text
stored property 'a' of 'Sendable'-conforming class 'A' is mutable
```

## Root cause

`StorageVisitor` visits the synthesized storage for `lazy` properties. The
Sendable checking logic in `TypeCheckConcurrency.cpp` used that `VarDecl`
directly for diagnostics, so the mutable-property diagnostic exposed the
implementation detail instead of the user-facing property.

## Fix

When Sendable checking visits a synthesized `lazy` storage property, remap the
diagnostic declaration and type to the original declared property via
`getOriginalVarForBackingStorage()`. The actual mutability check still runs on
the storage property; only the user-facing diagnostic uses the original decl.

## Tests

Added a regression to `test/Concurrency/concurrent_value_checking.swift`.

Validated with:

```bash
llvm-lit -sv \
  --param swift_site_config=/Users/nachosoto/code/other/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/test-macosx-arm64/lit.site.cfg \
  --param swift_src_root=/Users/nachosoto/code/other/swift-60417 \
  /Users/nachosoto/code/other/swift-60417/test/Concurrency/concurrent_value_checking.swift \
  /Users/nachosoto/code/other/swift-60417/test/Concurrency/weak_ref_sendability.swift
```
