### PR TITLE
[Diagnostics] Suppress result-builder inference follow-up errors

### DIFF
--- a/lib/Sema/BindingProducer.cpp
+++ b/lib/Sema/BindingProducer.cpp
@@ -23,6 +23,28 @@ using namespace swift;
 using namespace constraints;
 using namespace inference;
 
+static bool callHasClosureWithResultBuilderBodyFix(ConstraintSystem &cs,
+                                                   Expr *anchorExpr) {
+  auto *applyExpr = dyn_cast_or_null<ApplyExpr>(cs.getParentExpr(anchorExpr));
+  if (!applyExpr)
+    return false;
+
+  for (auto argument : *applyExpr->getArgs()) {
+    auto *closure =
+        dyn_cast<ClosureExpr>(argument.getExpr()->getValueProvidingExpr());
+    if (!closure)
+      continue;
+
+    auto *closureLoc = cs.getConstraintLocator(closure);
+    if (cs.hasFixFor(closureLoc, FixKind::IgnoreInvalidResultBuilderBody) ||
+        cs.hasFixFor(closureLoc,
+                     FixKind::IgnoreResultBuilderWithReturnStmts))
+      return true;
+  }
+
+  return false;
+}
+
 // Given a possibly-Optional type, return the direct superclass of the
 // (underlying) type wrapped in the same number of optional levels as
 // type.
@@ -463,6 +485,11 @@ TypeVariableBinding::fixForHole(ConstraintSystem &cs) const {
   unsigned defaultImpact = 1;
 
   if (auto *GP = TypeVar->getImpl().getGenericParameter()) {
+    if (auto *anchorExpr = getAsExpr(dstLocator->getAnchor())) {
+      if (callHasClosureWithResultBuilderBodyFix(cs, anchorExpr))
+        return std::nullopt;
+    }
+
     // If it is representative for a key path root, let's emit a more
     // specific diagnostic.
     auto *keyPathRoot =

--- a/test/Constraints/issue-55293.swift
+++ b/test/Constraints/issue-55293.swift
@@ -1,0 +1,35 @@
+// RUN: %target-typecheck-verify-swift
+
+// https://github.com/swiftlang/swift/issues/55293
+
+@resultBuilder
+struct Builder {
+  static func buildBlock<T>(_ value: T) -> T { value }
+
+  static func buildEither<T, F>(first: T) -> Either<T, F> { .first(first) }
+
+  static func buildEither<T, F>(second: F) -> Either<T, F> { .second(second) }
+}
+
+enum Either<T, F> {
+  case first(T)
+  case second(F)
+}
+
+struct A {}
+struct B {}
+
+func build<Content>(@Builder _ content: () -> Content) -> Content {
+  content()
+}
+
+func testReturnStatementsInResultBuilderClosure() {
+  let _ = build {
+    if Bool.random() {
+      return A() // expected-error {{cannot use explicit 'return' statement in the body of result builder 'Builder'}}
+      // expected-note@-1 {{remove 'return' statements to apply the result builder}}
+    } else {
+      return B()
+    }
+  }
+}


### PR DESCRIPTION
Fixes #55293

## Repro

A minimal result-builder closure reproduces the problem without SwiftUI:

```swift
@resultBuilder
struct Builder {
  static func buildBlock<T>(_ value: T) -> T { value }
  static func buildEither<T, F>(first: T) -> Either<T, F> { .first(first) }
  static func buildEither<T, F>(second: F) -> Either<T, F> { .second(second) }
}

enum Either<T, F> {
  case first(T)
  case second(F)
}

struct A {}
struct B {}

func build<Content>(@Builder _ content: () -> Content) -> Content {
  content()
}

func test() {
  let _ = build {
    if Bool.random() {
      return A()
    } else {
      return B()
    }
  }
}
```

Before this change, the compiler diagnosed the explicit `return`, but also
emitted bogus follow-up diagnostics on the outer call:

```text
generic parameter 'Content' could not be inferred
note: in call to function 'build'
```

The original SwiftUI-shaped repro from the issue behaved the same way:

```swift
struct WTF: View {
  var body: some View {
    Group {
      if Bool.random() {
        return Circle()
      } else {
        return Rectangle()
      }
    }
  }
}
```

That produced both the correct `return` diagnostic and the unrelated
`generic parameter 'Content' could not be inferred` error on `Group`.

## Root cause

When the solver records `IgnoreInvalidResultBuilderBody` (or
`IgnoreResultBuilderWithReturnStmts`) for a closure argument, it already has the
real reason the call failed.

However, recovery still allowed `DefaultGenericArgument` to fire for generic
parameters on the outer call. In this case that defaulted `Content` to `Any`,
which produced the misleading generic-parameter inference error after the
result-builder body had already been diagnosed.

## Fix

Suppress `DefaultGenericArgument` recovery for a call when one of its closure
arguments already carries an invalid-result-builder-body fix. That keeps the
real result-builder diagnostic and avoids the unrelated follow-up inference
error.

## Tests

Added `test/Constraints/issue-55293.swift`.

Validated with:

```bash
llvm-lit -sv \
  --param swift_site_config=/Users/nachosoto/code/other/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/test-macosx-arm64/lit.site.cfg \
  --param swift_src_root=/Users/nachosoto/code/other/swift-55293 \
  /Users/nachosoto/code/other/swift-55293/test/Constraints/issue-55293.swift \
  /Users/nachosoto/code/other/swift-55293/test/Constraints/result_builder.swift \
  /Users/nachosoto/code/other/swift-55293/test/Constraints/result_builder_infer.swift \
  /Users/nachosoto/code/other/swift-55293/test/decl/result_builder_fixits.swift
```
