### PR TITLE
FreeBSD: Re-enable typechecker perf test

### DIFF
--- a/validation-test/Sema/type_checker_perf/fast/rdar23620262.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar23620262.swift
@@ -4,8 +4,9 @@
 
 // UNSUPPORTED: OS=linux-gnu
 
-// rdar://170773776
-// XFAIL: OS=freebsd
+// FIXME: this test is flaky (expression too complex to typecheck) on FreeBSD
+//        (very infrequent failure) rdar://170773776
+// ALLOW_RETRIES: 1
 
 let a: [Double] = []
 _ = a.map { $0 - 1.0 }


### PR DESCRIPTION
This test fails very infrequently, so the XFail is actually resulting in the test suite failing because the test is unexpectedly passing. This is blocking us from getting visibility on other regressions. Re-enabling it on FreeBSD and allowing retires for when it does fail.

rdar://170773776 is assigned to Slava for investigation into the occasional "expression too complex to typecheck" failure.