### PR TITLE
[Concurrency] Clock.measure adopt nonisolated nonsending typed throws

### DIFF
--- a/stdlib/public/Concurrency/Clock.swift
+++ b/stdlib/public/Concurrency/Clock.swift
@@ -129,6 +129,18 @@ extension Clock {
   ///       }
   @available(StdlibDeploymentTarget 5.7, *)
   @_alwaysEmitIntoClient
+  public nonisolated(nonsending) func measure<Failure>(
+    _ work: nonisolated(nonsending) () async throws(Failure) -> Void
+  ) async throws(Failure) -> Instant.Duration {
+    let start = now
+    try await work()
+    let end = now
+    return start.duration(to: end)
+  }
+
+  @available(StdlibDeploymentTarget 5.7, *)
+  @_alwaysEmitIntoClient
+  @_disfavoredOverload
   public func measure(
     isolation: isolated (any Actor)? = #isolation,
     _ work: () async throws -> Void


### PR DESCRIPTION
The func was AEIC so this is a simple change

Part of rdar://163327630

resolves rdar://134413931