### PR TITLE
[cxx-interop] [NFCi] Clean up reference type analysis logic

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -758,9 +758,9 @@ getCxxReferencePointeeTypeOrNone(const clang::Type *type);
 /// Returns true if the given type is a C++ `const` reference type.
 bool isCxxConstReferenceType(const clang::Type *type);
 
-/// Determine whether the given Clang record declaration has one of the
-/// attributes that makes it import as a reference types.
-bool hasImportAsRefAttr(const clang::RecordDecl *decl);
+/// Determine whether the given Clang record declaration has an attribute that
+/// makes it import as a reference types. Does not check its bases, if any.
+bool hasImportReferenceAttr(const clang::RecordDecl *decl);
 
 /// Determine whether this typedef is a CF type.
 bool isCFTypeDecl(const clang::TypedefNameDecl *Decl);

--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -28,6 +28,7 @@
 #include "clang/AST/Type.h"
 #include "clang/Basic/Specifiers.h"
 #include "llvm/ADT/Hashing.h"
+#include "llvm/ADT/PointerIntPair.h"
 #include "llvm/ADT/TinyPtrVector.h"
 
 namespace swift {
@@ -343,6 +344,120 @@ private:
    bool isCached() const { return true; }
    std::optional<ObjCInterfaceAndImplementation> getCachedResult() const;
    void cacheResult(ObjCInterfaceAndImplementation value) const;
+};
+
+/// Information describing a possible foreign reference type, produced by the
+/// analysis performed by a ForeignReferenceTypeInfoRequest.
+///
+/// This information incorporates several independent dimensions for "foreign
+/// reference typedness," including the notion of an "invalid" foreign reference
+/// type that can result from, say, a derived type inheriting from multiple FRT
+/// bases (invalid due to ambiguous retain/release functions).
+///
+/// For valid shared reference types, this info also tracks the "canonical"
+/// FRT base which signifies which retain/release functions are to be used.
+class ForeignReferenceTypeInfo {
+  enum Flag {
+    /// This type has (or inherits) valid reference type attributes, if any
+    FlagIsValid = 1 << 0,
+    /// This type is a foreign reference type
+    FlagIsRef = 1 << 1,
+  };
+
+  llvm::PointerIntPair<const clang::RecordDecl *, 2> BaseAndFlags;
+
+  ForeignReferenceTypeInfo(const clang::RecordDecl *decl, bool isValid,
+                           bool isRef)
+      : BaseAndFlags{decl} {
+    unsigned int flags = 0;
+    flags |= isValid ? FlagIsValid : 0;
+    flags |= isRef ? FlagIsRef : 0;
+    BaseAndFlags.setInt(flags);
+  }
+
+public:
+  /// Not a reference type, not valid
+  ForeignReferenceTypeInfo() : BaseAndFlags{nullptr, 0} {}
+
+  /// Not a reference type
+  static ForeignReferenceTypeInfo Value(bool isValid = true) {
+    return {nullptr, isValid, /*isRef=*/false};
+  }
+
+  /// A shared reference type using the retain/release functions from \a decl.
+  static ForeignReferenceTypeInfo Shared(const clang::RecordDecl *decl,
+                                         bool isValid = true) {
+    ASSERT(decl && "shared reference must have a non-null base decl");
+    return {decl, isValid, /*isRef=*/true};
+  }
+
+  /// The base decl that is annotated with the retain/release functions that
+  /// this reference type uses.
+  ///
+  /// If this is an invalid reference type, this returns an arbitrary FRT base
+  /// (there may be multiple FRT bases that cause this to be invalid due to
+  /// ambiguity about which retain/release values to use).
+  ///
+  /// Returns \c nullptr for non-shared references.
+  const clang::RecordDecl *getDecl() const { return BaseAndFlags.getPointer(); }
+
+  /// All of its (and its bases') foreign reference type attributes (if any)
+  /// are valid.
+  ///
+  /// This is independent of whether this foreign type should be actually be
+  /// imported with reference semantics.
+  bool isValid() const { return BaseAndFlags.getInt() & FlagIsValid; }
+
+  /// Whether this type or its bases have attributes that ask for it to be
+  /// imported as a reference type.
+  ///
+  /// This is independent of whether those attributes are actually valid.
+  bool isReference() const { return BaseAndFlags.getInt() & FlagIsRef; }
+};
+
+struct ForeignReferenceTypeInfoDescriptor {
+  const clang::RecordDecl *decl;
+
+  ForeignReferenceTypeInfoDescriptor(const clang::RecordDecl *decl)
+      : decl{decl} {}
+
+  friend llvm::hash_code
+  hash_value(const ForeignReferenceTypeInfoDescriptor &desc) {
+    return llvm::hash_combine(desc.decl);
+  }
+
+  friend bool operator==(const ForeignReferenceTypeInfoDescriptor &lhs,
+                         const ForeignReferenceTypeInfoDescriptor &rhs) {
+    return lhs.decl == rhs.decl;
+  }
+
+  friend bool operator!=(const ForeignReferenceTypeInfoDescriptor &lhs,
+                         const ForeignReferenceTypeInfoDescriptor &rhs) {
+    return !(lhs == rhs);
+  }
+};
+
+void simple_display(llvm::raw_ostream &out,
+                    const ForeignReferenceTypeInfoDescriptor &desc);
+SourceLoc
+extractNearestSourceLoc(const ForeignReferenceTypeInfoDescriptor &desc);
+
+class ForeignReferenceTypeInfoRequest
+    : public SimpleRequest<ForeignReferenceTypeInfoRequest,
+                           ForeignReferenceTypeInfo(
+                               ForeignReferenceTypeInfoDescriptor),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+  SourceLoc getNearestLoc() const { return SourceLoc(); };
+  bool isCached() const { return true; }
+
+private:
+  friend SimpleRequest;
+
+  ForeignReferenceTypeInfo evaluate(Evaluator &evaluator,
+                                    ForeignReferenceTypeInfoDescriptor) const;
 };
 
 enum class CxxRecordSemanticsKind {

--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -471,11 +471,9 @@ enum class CxxRecordSemanticsKind {
 struct CxxRecordSemanticsDescriptor final {
   const clang::RecordDecl *decl;
   ASTContext &ctx;
-  ClangImporter::Implementation *importerImpl;
 
-  CxxRecordSemanticsDescriptor(const clang::RecordDecl *decl, ASTContext &ctx,
-                               ClangImporter::Implementation *importerImpl)
-      : decl(decl), ctx(ctx), importerImpl(importerImpl) {}
+  CxxRecordSemanticsDescriptor(const clang::RecordDecl *decl, ASTContext &ctx)
+      : decl(decl), ctx(ctx) {}
 
   friend llvm::hash_code hash_value(const CxxRecordSemanticsDescriptor &desc) {
     return llvm::hash_combine(desc.decl);

--- a/include/swift/ClangImporter/ClangImporterTypeIDZone.def
+++ b/include/swift/ClangImporter/ClangImporterTypeIDZone.def
@@ -31,7 +31,7 @@ SWIFT_REQUEST(ClangImporter, ObjCInterfaceAndImplementationRequest,
               ObjCInterfaceAndImplementation(Decl *), SeparatelyCached,
               NoLocationInfo)
 SWIFT_REQUEST(ClangImporter, CxxRecordSemantics,
-              CxxRecordSemanticsKind(const clang::CXXRecordDecl *), Cached,
+              CxxRecordSemanticsKind(CxxRecordSemanticsDescriptor), Cached,
               NoLocationInfo)
 SWIFT_REQUEST(ClangImporter, CxxRecordAsSwiftType,
               ValueDecl *(CxxRecordSemanticsDescriptor), Cached,

--- a/include/swift/ClangImporter/ClangImporterTypeIDZone.def
+++ b/include/swift/ClangImporter/ClangImporterTypeIDZone.def
@@ -30,6 +30,9 @@ SWIFT_REQUEST(ClangImporter, ClangCategoryLookupRequest,
 SWIFT_REQUEST(ClangImporter, ObjCInterfaceAndImplementationRequest,
               ObjCInterfaceAndImplementation(Decl *), SeparatelyCached,
               NoLocationInfo)
+SWIFT_REQUEST(ClangImporter, ForeignReferenceTypeInfoRequest,
+              ForeignReferenceTypeInfo(ForeignReferenceTypeInfoDescriptor), Cached,
+              NoLocationInfo)
 SWIFT_REQUEST(ClangImporter, CxxRecordSemantics,
               CxxRecordSemanticsKind(CxxRecordSemanticsDescriptor), Cached,
               NoLocationInfo)

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7165,12 +7165,10 @@ bool ClassDecl::isForeignReferenceType() const {
   if (!clangRecordDecl)
     return false;
 
-  // `importerImpl` is set to nullptr here to avoid diagnostics during this
-  // CxxRecordSemantics evaluation.
-  CxxRecordSemanticsKind kind = evaluateOrDefault(
-      getASTContext().evaluator,
-      CxxRecordSemantics({clangRecordDecl, getASTContext(), nullptr}), {});
-  return kind == CxxRecordSemanticsKind::Reference;
+  auto info =
+      evaluateOrDefault(getASTContext().evaluator,
+                        ForeignReferenceTypeInfoRequest({clangRecordDecl}), {});
+  return info.isReference();
 }
 
 bool ClassDecl::hasRefCountingAnnotations() const {

--- a/lib/ClangImporter/CMakeLists.txt
+++ b/lib/ClangImporter/CMakeLists.txt
@@ -8,6 +8,7 @@ add_gyb_target(generated_sorted_cf_database
 add_swift_host_library(swiftClangImporter STATIC
   CFTypeInfo.cpp
   ClangAdapter.cpp
+  ClangAnalysis.cpp
   ClangClassTemplateNamePrinter.cpp
   ClangDerivedConformances.cpp
   ClangDiagnosticConsumer.cpp

--- a/lib/ClangImporter/ClangAnalysis.cpp
+++ b/lib/ClangImporter/ClangAnalysis.cpp
@@ -1,0 +1,223 @@
+#include "ImporterImpl.h"
+#include "swift/AST/DiagnosticsClangImporter.h"
+#include "swift/ClangImporter/ClangImporter.h"
+#include "swift/ClangImporter/ClangImporterRequests.h"
+#include "clang/AST/DeclCXX.h"
+#include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
+
+using namespace swift;
+
+bool importer::hasImportReferenceAttr(const clang::RecordDecl *decl) {
+  return decl->hasAttrs() && llvm::any_of(decl->getAttrs(), [](auto *attr) {
+           if (auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr))
+             return swiftAttr->getAttribute() == "import_reference" ||
+                    // TODO: Remove this once libSwift hosttools no longer
+                    // requires it.
+                    swiftAttr->getAttribute() == "import_as_ref";
+           return false;
+         });
+}
+
+/// This routine determines whether \a decl is a foreign reference type, and
+/// whether its foreign reference type attributes are valid. This determinition
+/// considers attributes annotated on both \a decl itself as well as its
+/// transitive bases.
+///
+/// When \a Impl is non-null, this function will use it to emit diagnostics for
+/// invalid attributes; when \a Impl is null, those diagnostics are not emitted
+/// (but the returned ForeignReferenceTypeInfo will still indicate \a decl has
+/// invalid attributes). This function is designed this way to keep the site
+/// where diagnostics are emitted close to the logic that leads to them.
+static ForeignReferenceTypeInfo
+checkForeignReferenceType(const clang::CXXRecordDecl *decl,
+                          ClangImporter::Implementation *Impl) {
+  // This was explicitly annotated. Just trust the annotation.
+  if (importer::hasImportReferenceAttr(decl))
+    return ForeignReferenceTypeInfo::Shared(decl);
+
+  if (!decl->hasDefinition())
+    // If this doesn't have a definition, there's no inheritance info to check.
+    return ForeignReferenceTypeInfo::Value();
+
+  // Keep track of base classes that are marked as FRTs, with set semantics
+  // because we cannot have multiple copies of the same base FRT.
+  llvm::SmallSetVector<const clang::CXXRecordDecl *, 1> FRTBases;
+
+  // Keep track of virtual bases, which we only need to visit once.
+  llvm::SmallPtrSet<const clang::CXXRecordDecl *, 1> virtualBases;
+
+  // Bases we have yet to visit. Each base class instance should appear
+  // in this container exactly once.
+  llvm::SmallVector<const clang::CXXRecordDecl *, 4> unvisitedBases;
+
+  // N.B. our definition of "base" also includes the origin class itself,
+  //      i.e., decl
+  unvisitedBases.push_back(decl);
+
+  bool multipleFRTs = false;
+
+  while (!unvisitedBases.empty()) {
+    auto *rec = unvisitedBases.pop_back_val();
+
+    if (importer::hasImportReferenceAttr(rec)) {
+      if (!FRTBases.insert(rec)) {
+        // The same base FRT appears multiple times in the class hierarchy
+        // (i.e., due to diamond inheritance), which is not valid. Bail.
+        multipleFRTs = true;
+        break;
+      }
+    }
+
+    for (auto recBase : rec->bases()) {
+      auto *ty = recBase.getType()->getAs<clang::RecordType>();
+      if (!ty)
+        // inheriting from something that isn't a record?
+        return ForeignReferenceTypeInfo::Value(/*isValid=*/false);
+
+      auto *base = dyn_cast_or_null<clang::CXXRecordDecl>(
+          ty->getDecl()->getDefinition());
+
+      if (!base ||
+          (base->isDependentContext() && !base->isCurrentInstantiation(decl)))
+        // inheriting from a dependent type?
+        return ForeignReferenceTypeInfo::Value(/*isValid=*/false);
+
+      if (recBase.isVirtual()) {
+        if (virtualBases.insert(base).second)
+          // First time seeing this virtual base. Visit it later.
+          unvisitedBases.push_back(base);
+      } else {
+        // Visit this non-virtual base class later.
+        unvisitedBases.push_back(base);
+      }
+    }
+  }
+
+  if (FRTBases.empty())
+    // Did not encounter any FRTs in the class hierarchy
+    return ForeignReferenceTypeInfo::Value();
+
+  // This is the first FRT we encountered during our base traversal,
+  // so we shall use it as our "canonical" FRT base.
+  auto *baseFRT = FRTBases.front();
+
+  if (multipleFRTs) {
+    // The same FRT base appears multiple times in the class hierarchy
+    if (Impl)
+      Impl->diagnose(HeaderLoc{decl->getLocation()},
+                     diag::cant_infer_frt_in_cxx_inheritance, decl);
+
+    // decl inherits from FRT base, so we should treat it as a reference
+    // type, albeit an invalid one (due to ambiguity).
+    //
+    // return ForeignReferenceTypeInfo::Shared(baseFRT, /*isValid=*/false);
+    //
+    // However, in honor the existing behavior, (for now) we will report that
+    // this is an (invalid) value type.
+    return ForeignReferenceTypeInfo::Value(/*isValid=*/false);
+  }
+
+  constexpr StringRef retainPrefix = "retain:", releasePrefix = "release:";
+  std::optional<StringRef> retain = std::nullopt, release = std::nullopt;
+  bool multipleOps = false;
+
+  for (auto *base : FRTBases) {
+    for (auto *attr : base->getAttrs()) {
+      auto *swiftAttr = llvm::dyn_cast<clang::SwiftAttrAttr>(attr);
+      if (!swiftAttr)
+        continue;
+      auto attrStr = swiftAttr->getAttribute();
+      if (attrStr.consume_front(retainPrefix)) {
+        if (retain.has_value() && retain.value() != attrStr) {
+          multipleOps = true;
+          break;
+        }
+        retain = attrStr;
+      } else if (attrStr.consume_front(releasePrefix)) {
+        if (release.has_value() && release.value() != attrStr) {
+          multipleOps = true;
+          break;
+        }
+        release = attrStr;
+      }
+    }
+
+    if (multipleOps)
+      break;
+  }
+
+  if (multipleOps) {
+    if (Impl)
+      Impl->diagnose(HeaderLoc{decl->getLocation()},
+                     diag::cant_infer_frt_in_cxx_inheritance, decl);
+
+    // decl inherits from FRT base, so we should treat it as a reference
+    // type, albeit an invalid one (due to ambiguity).
+    //
+    // return ForeignReferenceTypeInfo::Shared(baseFRT, /*isValid=*/false);
+    //
+    // However, in honor the existing behavior, (for now) we will report that
+    // this is an (invalid) value type.
+    return ForeignReferenceTypeInfo::Value(/*isValid=*/false);
+  }
+
+  return ForeignReferenceTypeInfo::Shared(baseFRT);
+}
+
+void swift::simple_display(llvm::raw_ostream &out,
+                           const ForeignReferenceTypeInfoDescriptor &desc) {
+  out << "Checking foreign reference type info for '";
+  if (desc.decl->getIdentifier())
+    out << desc.decl->getName();
+  else if (desc.decl->isAnonymousStructOrUnion())
+    out << "(anonymous record)";
+  else
+    out << "(unnamed record)";
+  out << "'\n";
+}
+
+SourceLoc
+swift::extractNearestSourceLoc(const ForeignReferenceTypeInfoDescriptor &desc) {
+  return SourceLoc();
+}
+
+ForeignReferenceTypeInfo ForeignReferenceTypeInfoRequest::evaluate(
+    Evaluator &evaluator, ForeignReferenceTypeInfoDescriptor desc) const {
+  auto *decl = desc.decl;
+
+  if (auto *cxxDecl = dyn_cast<clang::CXXRecordDecl>(decl))
+    return checkForeignReferenceType(cxxDecl, nullptr);
+
+  // If this isn't a C++ record, then there's no inheritance (nor any of the
+  // associated complications) to worry about. Just look for ref attributes.
+
+  if (importer::hasImportReferenceAttr(decl))
+    return ForeignReferenceTypeInfo::Shared(decl);
+
+  return ForeignReferenceTypeInfo::Value();
+}
+
+bool importer::diagnoseForeignReferenceType(
+    const clang::CXXRecordDecl *decl, ClangImporter::Implementation &Impl) {
+
+  // First, evaluate as a request. This does not emit diagnostics, but caches
+  // the result for future requests. This ensures that we perform the checkFRT()
+  // routine at most once for valid decls.
+  auto info = evaluateOrDefault(Impl.SwiftContext.evaluator,
+                                ForeignReferenceTypeInfoRequest({decl}), {});
+  if (info.isValid())
+    return true;
+
+  if (!Impl.DiagnosedCxxRefDecls.insert(decl).second)
+    // Already diagnosed this decl. No need to emit diagnostics again.
+    return false;
+
+  // If the result was invalid, we need to run the underlying check again, but
+  // this time with ClangImporter::Implemention in order to emit diagnostics.
+  // This slow path does redundant work but only for invalid decls.
+  auto infoAgain = checkForeignReferenceType(decl, &Impl);
+  ASSERT(!infoAgain.isValid() && "FRT check validity should be deterministic");
+  return false;
+}

--- a/lib/ClangImporter/ClangAnalysis.cpp
+++ b/lib/ClangImporter/ClangAnalysis.cpp
@@ -3,6 +3,7 @@
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/ClangImporter/ClangImporterRequests.h"
 #include "clang/AST/DeclCXX.h"
+#include "clang/AST/Type.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
@@ -71,18 +72,16 @@ checkForeignReferenceType(const clang::CXXRecordDecl *decl,
     }
 
     for (auto recBase : rec->bases()) {
-      auto *ty = recBase.getType()->getAs<clang::RecordType>();
-      if (!ty)
-        // inheriting from something that isn't a record?
+      auto *base = recBase.getType()->getAsCXXRecordDecl();
+      if (!base)
+        // It is possible to encounter clang::TemplateSpecializationType.
+        // In such cases, just bail and report this as an invalid value type
         return ForeignReferenceTypeInfo::Value(/*isValid=*/false);
 
-      auto *base = dyn_cast_or_null<clang::CXXRecordDecl>(
-          ty->getDecl()->getDefinition());
+      ASSERT(base->hasDefinition() && "base record should be complete");
+      base = base->getDefinition();
 
-      if (!base ||
-          (base->isDependentContext() && !base->isCurrentInstantiation(decl)))
-        // inheriting from a dependent type?
-        return ForeignReferenceTypeInfo::Value(/*isValid=*/false);
+      ASSERT(!base->isDependentContext() && "base should not be dependent");
 
       if (recBase.isVirtual()) {
         if (virtualBases.insert(base).second)

--- a/lib/ClangImporter/ClangAnalysis.cpp
+++ b/lib/ClangImporter/ClangAnalysis.cpp
@@ -210,10 +210,6 @@ bool importer::diagnoseForeignReferenceType(
   if (info.isValid())
     return true;
 
-  if (!Impl.DiagnosedCxxRefDecls.insert(decl).second)
-    // Already diagnosed this decl. No need to emit diagnostics again.
-    return false;
-
   // If the result was invalid, we need to run the underlying check again, but
   // this time with ClangImporter::Implemention in order to emit diagnostics.
   // This slow path does redundant work but only for invalid decls.

--- a/lib/ClangImporter/ClangAnalysis.cpp
+++ b/lib/ClangImporter/ClangAnalysis.cpp
@@ -13,10 +13,7 @@ using namespace swift;
 bool importer::hasImportReferenceAttr(const clang::RecordDecl *decl) {
   return decl->hasAttrs() && llvm::any_of(decl->getAttrs(), [](auto *attr) {
            if (auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr))
-             return swiftAttr->getAttribute() == "import_reference" ||
-                    // TODO: Remove this once libSwift hosttools no longer
-                    // requires it.
-                    swiftAttr->getAttribute() == "import_as_ref";
+             return swiftAttr->getAttribute() == "import_reference";
            return false;
          });
 }

--- a/lib/ClangImporter/ClangClassTemplateNamePrinter.cpp
+++ b/lib/ClangImporter/ClangClassTemplateNamePrinter.cpp
@@ -13,6 +13,7 @@
 #include "ClangClassTemplateNamePrinter.h"
 #include "ImporterImpl.h"
 #include "swift/ClangImporter/ClangImporter.h"
+#include "swift/ClangImporter/ClangImporterRequests.h"
 #include "clang/AST/TemplateArgumentVisitor.h"
 #include "clang/AST/Type.h"
 #include "clang/AST/TypeVisitor.h"
@@ -133,10 +134,11 @@ struct TemplateInstantiationNamePrinter
     // it in Unsafe(Mutable)?Pointer, since it will be imported as a class
     // in Swift.
     bool isReferenceType = false;
-    if (auto tagDecl = pointee->getAsTagDecl()) {
-      if (auto *rd = dyn_cast<clang::RecordDecl>(tagDecl))
-        isReferenceType = recordHasReferenceSemantics(rd, importerImpl);
-    }
+    if (auto *rd = pointee->getAsRecordDecl())
+      isReferenceType =
+          evaluateOrDefault(swiftCtx.evaluator,
+                            ForeignReferenceTypeInfoRequest({rd}), {})
+              .isReference();
 
     llvm::SmallString<128> storage;
     llvm::raw_svector_ostream buffer(storage);

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -8075,21 +8075,16 @@ importer::getValueDeclsForName(NominalTypeDecl *decl, StringRef name) {
 }
 
 /// Is this a pointer or a reference to a foreign reference type.
-static bool isForeignReferenceType(const clang::QualType type,
-                                   ASTContext &ctx) {
+static bool clangTypeIsForeignReference(const clang::QualType type,
+                                        ASTContext &ctx) {
   if (!type->isPointerOrReferenceType())
     return false;
-
-  auto pointeeType =
-      dyn_cast<clang::RecordType>(type->getPointeeType().getCanonicalType());
-  if (pointeeType == nullptr)
+  auto *pointee = type->getPointeeType().getCanonicalType()->getAsRecordDecl();
+  if (!pointee)
     return false;
-  auto pointeeDecl = pointeeType->getAsRecordDecl();
-
-  auto semanticsKind = evaluateOrDefault(
-      ctx.evaluator,
-      CxxRecordSemantics({pointeeDecl, ctx, /*importerImpl=*/nullptr}), {});
-  return semanticsKind == CxxRecordSemanticsKind::Reference;
+  auto info = evaluateOrDefault(ctx.evaluator,
+                                ForeignReferenceTypeInfoRequest({pointee}), {});
+  return info.isReference();
 }
 
 bool importer::hasSwiftAttribute(const clang::Decl *decl, StringRef attr) {
@@ -8537,7 +8532,7 @@ bool IsSafeUseOfCxxDecl::evaluate(Evaluator &evaluator,
         isa<clang::CXXConstructorDecl>(decl))
       return true;
 
-    if (isForeignReferenceType(method->getReturnType(), desc.ctx))
+    if (clangTypeIsForeignReference(method->getReturnType(), desc.ctx))
       return true;
 
     // begin and end methods likely return an interator, so they're unsafe. This
@@ -8550,7 +8545,7 @@ bool IsSafeUseOfCxxDecl::evaluate(Evaluator &evaluator,
       ->getParent()->getTypeForDecl()->getCanonicalTypeUnqualified();
 
     bool parentIsSelfContained =
-        !isForeignReferenceType(parentQualType, desc.ctx) &&
+        !clangTypeIsForeignReference(parentQualType, desc.ctx) &&
         anySubobjectsSelfContained(method->getParent());
 
     // If it returns a pointer or reference from an owned parent, that's a

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -8025,69 +8025,6 @@ ClangImporter::createEmbeddedBridgingHeaderCacheKey(
                    "ChainedHeaderIncludeTree -> EmbeddedHeaderIncludeTree");
 }
 
-bool importer::hasImportAsRefAttr(const clang::RecordDecl *decl) {
-  return decl->hasAttrs() && llvm::any_of(decl->getAttrs(), [](auto *attr) {
-           if (auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr))
-             return swiftAttr->getAttribute() == "import_reference" ||
-                    // TODO: Remove this once libSwift hosttools no longer
-                    // requires it.
-                    swiftAttr->getAttribute() == "import_as_ref";
-           return false;
-         });
-}
-
-static bool hasDiamondInheritanceRefType(const clang::CXXRecordDecl *decl) {
-  if (!decl->hasDefinition() || decl->isDependentType())
-    return false;
-
-  llvm::DenseSet<const clang::CXXRecordDecl *> seenBases;
-  bool hasRefDiamond = false;
-
-  decl->forallBases([&](const clang::CXXRecordDecl *Base) {
-    if (hasImportAsRefAttr(Base) && !seenBases.insert(Base).second &&
-        !decl->isVirtuallyDerivedFrom(Base))
-      hasRefDiamond = true;
-    return true;
-  });
-
-  return hasRefDiamond;
-}
-
-// Returns the given declaration along with all its parent declarations that are
-// reference types.
-static llvm::SmallVector<const clang::RecordDecl *, 4>
-getRefParentDecls(const clang::RecordDecl *decl, ASTContext &ctx,
-                  ClangImporter::Implementation *importerImpl) {
-  assert(decl && "decl is null inside getRefParentDecls");
-
-  llvm::SmallVector<const clang::RecordDecl *, 4> matchingDecls;
-
-  if (hasImportAsRefAttr(decl))
-    matchingDecls.push_back(decl);
-
-  if (const auto *cxxRecordDecl = llvm::dyn_cast<clang::CXXRecordDecl>(decl)) {
-    if (!cxxRecordDecl->hasDefinition())
-      return matchingDecls;
-    if (hasDiamondInheritanceRefType(cxxRecordDecl)) {
-      if (importerImpl) {
-        if (importerImpl->DiagnosedCxxRefDecls.insert(decl).second) {
-          HeaderLoc loc(decl->getLocation());
-          importerImpl->diagnose(loc, diag::cant_infer_frt_in_cxx_inheritance,
-                                 decl);
-        }
-      }
-      return matchingDecls;
-    }
-    cxxRecordDecl->forallBases([&](const clang::CXXRecordDecl *baseDecl) {
-      if (hasImportAsRefAttr(baseDecl))
-        matchingDecls.push_back(baseDecl);
-      return true;
-    });
-  }
-
-  return matchingDecls;
-}
-
 llvm::SmallVector<ValueDecl *, 1>
 importer::getValueDeclsForName(NominalTypeDecl *decl, StringRef name) {
   // If the name is empty, don't try to find any decls.
@@ -8135,46 +8072,6 @@ importer::getValueDeclsForName(NominalTypeDecl *decl, StringRef name) {
     results.erase(newEnd, results.end());
   }
   return results;
-}
-
-const clang::RecordDecl *
-importer::getRefParentOrDiag(const clang::RecordDecl *decl, ASTContext &ctx,
-                             ClangImporter::Implementation *importerImpl) {
-  auto refParentDecls = getRefParentDecls(decl, ctx, importerImpl);
-  if (refParentDecls.empty())
-    return nullptr;
-
-  std::set<StringRef> uniqueRetainDecls{}, uniqueReleaseDecls{};
-  constexpr StringRef retainPrefix = "retain:";
-  constexpr StringRef releasePrefix = "release:";
-
-  for (const auto *refParentDecl : refParentDecls) {
-    assert(refParentDecl && "refParentDecl is null inside getRefParentOrDiag");
-    for (const auto *attr : refParentDecl->getAttrs()) {
-      if (const auto swiftAttr = llvm::dyn_cast<clang::SwiftAttrAttr>(attr)) {
-        auto attribute = swiftAttr->getAttribute();
-        if (attribute.consume_front(retainPrefix))
-          uniqueRetainDecls.insert(attribute);
-        else if (attribute.consume_front(releasePrefix))
-          uniqueReleaseDecls.insert(attribute);
-      }
-    }
-  }
-
-  // Ensure that exactly one unique retain function and one unique release
-  // function are found.
-  if (uniqueRetainDecls.size() != 1 || uniqueReleaseDecls.size() != 1) {
-    if (importerImpl) {
-      if (importerImpl->DiagnosedCxxRefDecls.insert(decl).second) {
-        HeaderLoc loc(decl->getLocation());
-        importerImpl->diagnose(loc, diag::cant_infer_frt_in_cxx_inheritance,
-                               decl);
-      }
-    }
-    return nullptr;
-  }
-
-  return refParentDecls.front();
 }
 
 /// Is this a pointer or a reference to a foreign reference type.
@@ -8257,7 +8154,7 @@ static bool hasPointerInSubobjects(const clang::CXXRecordDecl *decl) {
     if (auto recordType = dyn_cast<clang::RecordType>(t.getCanonicalType())) {
       if (auto cxxRecord =
               dyn_cast<clang::CXXRecordDecl>(recordType->getDecl())) {
-        if (hasImportAsRefAttr(cxxRecord) || hasOwnedValueAttr(cxxRecord) ||
+        if (hasImportReferenceAttr(cxxRecord) || hasOwnedValueAttr(cxxRecord) ||
             hasUnsafeAPIAttr(cxxRecord))
           return false;
 
@@ -8383,9 +8280,8 @@ CxxRecordSemanticsKind
 CxxRecordSemantics::evaluate(Evaluator &evaluator,
                              CxxRecordSemanticsDescriptor desc) const {
   const auto *decl = desc.decl;
-  ClangImporter::Implementation *importerImpl = desc.importerImpl;
-  if (hasImportAsRefAttr(decl) ||
-      getRefParentOrDiag(decl, desc.ctx, importerImpl))
+  if (evaluateOrDefault(evaluator, ForeignReferenceTypeInfoRequest({decl}), {})
+          .isReference())
     return CxxRecordSemanticsKind::Reference;
 
   auto cxxDecl = dyn_cast<clang::CXXRecordDecl>(decl);
@@ -8464,7 +8360,9 @@ CxxValueSemantics::evaluate(Evaluator &evaluator,
       // When a reference type is copied, the pointer’s value is copied rather
       // than the object’s storage. This means reference types can be imported
       // as copyable to Swift, even when they are non-copyable in C++.
-      if (recordHasReferenceSemantics(recordDecl, importerImpl))
+      if (evaluateOrDefault(evaluator,
+                            ForeignReferenceTypeInfoRequest({recordDecl}), {})
+              .isReference())
         return;
 
       if (recordDecl->isInStdNamespace()) {
@@ -8810,7 +8708,7 @@ ExplicitSafety ClangDeclExplicitSafety::evaluate(
       if (pointeeType->isFunctionType())
         return false; // Function pointers are not unsafe
       auto *recordDecl = pointeeType->getAsRecordDecl();
-      if (recordDecl && hasImportAsRefAttr(recordDecl))
+      if (recordDecl && hasImportReferenceAttr(recordDecl))
         return false; // Pointers are ok if imported as foreign reference types
       return true; // All other pointers are considered unsafe.
     }

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3393,7 +3393,7 @@ namespace {
 
       auto cxxRecordsemanticsKind = evaluateOrDefault(
           Impl.SwiftContext.evaluator,
-          CxxRecordSemantics({decl, Impl.SwiftContext, nullptr}), {});
+          CxxRecordSemantics({decl, Impl.SwiftContext}), {});
 
       if (cxxRecordsemanticsKind == CxxRecordSemanticsKind::SwiftClassType) {
         // FIXME: add a diagnostic here for unsupported imported use of Swift

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -175,22 +175,6 @@ void ClangImporter::Implementation::makeComputed(AbstractStorageDecl *storage,
   }
 }
 
-bool importer::recordHasReferenceSemantics(
-    const clang::RecordDecl *decl,
-    ClangImporter::Implementation *importerImpl) {
-  // At this point decl might not be fully imported into Swift yet, which
-  // means we might not have asked Clang to generate its implicit members, such
-  // as copy or move constructors. This would cause CxxRecordSemanticsRequest to
-  // return MissingLifetimeOperation if the type is not a foreign reference
-  // type. Note that this doesn't affect the correctness of this function, since
-  // those implicit members aren't required for foreign reference types.
-  auto semanticsKind = evaluateOrDefault(
-      importerImpl->SwiftContext.evaluator,
-      CxxRecordSemantics({decl, importerImpl->SwiftContext, importerImpl}),
-      {});
-  return semanticsKind == CxxRecordSemanticsKind::Reference;
-}
-
 bool importer::hasImmortalAttrs(const clang::RecordDecl *decl) {
   return decl->hasAttrs() && llvm::any_of(decl->getAttrs(), [](auto *attr) {
            if (auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr))
@@ -2198,7 +2182,9 @@ namespace {
     }
 
     bool recordHasReferenceSemantics(const clang::RecordDecl *decl) {
-      return importer::recordHasReferenceSemantics(decl, &Impl);
+      return evaluateOrDefault(Impl.SwiftContext.evaluator,
+                               ForeignReferenceTypeInfoRequest({decl}), {})
+          .isReference();
     }
 
     bool recordIsCopyable(const clang::RecordDecl *decl) {
@@ -2322,8 +2308,11 @@ namespace {
       auto clangDecl = dyn_cast<clang::CXXRecordDecl>(clangType);
       if (!clangDecl)
         return nonInheritedRefCountingOperations();
-      auto baseClangDecl = dyn_cast_or_null<clang::CXXRecordDecl>(
-          getRefParentOrDiag(clangDecl, context, nullptr));
+
+      auto frtInfo = evaluateOrDefault(
+          context.evaluator, ForeignReferenceTypeInfoRequest({clangDecl}), {});
+      auto *baseClangDecl =
+          dyn_cast_or_null<clang::CXXRecordDecl>(frtInfo.getDecl());
       if (!baseClangDecl || baseClangDecl == clangDecl)
         return nonInheritedRefCountingOperations();
 
@@ -3400,9 +3389,11 @@ namespace {
         return nullptr;
       }
 
+      diagnoseForeignReferenceType(decl, Impl);
+
       auto cxxRecordsemanticsKind = evaluateOrDefault(
           Impl.SwiftContext.evaluator,
-          CxxRecordSemantics({decl, Impl.SwiftContext, &Impl}), {});
+          CxxRecordSemantics({decl, Impl.SwiftContext, nullptr}), {});
 
       if (cxxRecordsemanticsKind == CxxRecordSemanticsKind::SwiftClassType) {
         // FIXME: add a diagnostic here for unsupported imported use of Swift

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2375,10 +2375,7 @@ ImportedType ClangImporter::Implementation::importFunctionReturnType(
     if (auto recordType = returnType->getAsCXXRecordDecl()) {
       if (auto *vd = evaluateOrDefault(
               SwiftContext.evaluator,
-              // `importerImpl` is set to nullptr here to avoid diagnostics
-              // during this CxxRecordSemantics evaluation.
-              CxxRecordAsSwiftType({recordType, SwiftContext, nullptr}),
-              nullptr)) {
+              CxxRecordAsSwiftType({recordType, SwiftContext}), nullptr)) {
         if (auto *cd = dyn_cast<ClassDecl>(vd)) {
           Type t = ClassType::get(cd, Type(), SwiftContext);
           return ImportedType(t, /*implicitlyUnwraps=*/false);
@@ -2650,10 +2647,7 @@ ClangImporter::Implementation::importParameterType(
 
       if (auto *vd = evaluateOrDefault(
               SwiftContext.evaluator,
-              // `importerImpl` is set to nullptr here to avoid diagnostics
-              // during this CxxRecordSemantics evaluation.
-              CxxRecordAsSwiftType({recordType, SwiftContext, nullptr}),
-              nullptr)) {
+              CxxRecordAsSwiftType({recordType, SwiftContext}), nullptr)) {
 
         if (auto *cd = dyn_cast<ClassDecl>(vd)) {
 

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -469,10 +469,6 @@ public:
   std::unordered_set<ImportDiagnostic, ImportDiagnosticHasher>
       CollectedDiagnostics;
 
-  // Keeps track of `clang::RecordDecl`s where diagnostics have already been
-  // emitted due to failed SWIFT_SHARED_REFERENCE inference.
-  std::unordered_set<const clang::RecordDecl *> DiagnosedCxxRefDecls;
-
   // Tracks which function templates have already had a diagnostic emitted,
   // to avoid duplicate diagnostics across instantiations.
   llvm::DenseSet<std::pair<const clang::FunctionDecl *, DiagID>>
@@ -2241,8 +2237,6 @@ getImplicitObjectParamAnnotation(const clang::FunctionDecl *FD) {
 }
 
 /// Emit diagnostics related to foreign reference types for \a decl.
-///
-/// This operation is idempotent.
 bool diagnoseForeignReferenceType(const clang::CXXRecordDecl *decl,
                                   ClangImporter::Implementation &Impl);
 

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1987,12 +1987,6 @@ public:
 };
 
 namespace importer {
-
-/// Returns true if the given C/C++ record should be imported as a reference
-/// type into Swift.
-bool recordHasReferenceSemantics(const clang::RecordDecl *decl,
-                                 ClangImporter::Implementation *importerImpl);
-
 /// Whether this is a forward declaration of a type. We ignore forward
 /// declarations in certain cases, and instead process the real declarations.
 bool isForwardDeclOfType(const clang::Decl *decl);
@@ -2246,11 +2240,11 @@ getImplicitObjectParamAnnotation(const clang::FunctionDecl *FD) {
   return nullptr;
 }
 
-/// Find a unique base class that is annotated as SHARED_REFERENCE if any.
-const clang::RecordDecl *
-getRefParentOrDiag(const clang::RecordDecl *decl, ASTContext &ctx,
-                   ClangImporter::Implementation *importerImpl);
-
+/// Emit diagnostics related to foreign reference types for \a decl.
+///
+/// This operation is idempotent.
+bool diagnoseForeignReferenceType(const clang::CXXRecordDecl *decl,
+                                  ClangImporter::Implementation &Impl);
 
 /// Returns the module \p Node comes from, or \c nullptr if \p Node does not
 /// have a valid owning module.

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -3491,7 +3491,7 @@ FuncDecl *SwiftDeclSynthesizer::findExplicitDestroy(
     return nullptr;
 
   auto cxxRecordSemanticsKind = evaluateOrDefault(
-      ctx.evaluator, CxxRecordSemantics({clangType, ctx, &ImporterImpl}), {});
+      ctx.evaluator, CxxRecordSemantics({clangType, ctx}), {});
   switch (cxxRecordSemanticsKind) {
   case CxxRecordSemanticsKind::Value:
   case CxxRecordSemanticsKind::Reference:

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -3380,7 +3380,7 @@ static bool isSufficientlyTrivial(const clang::CXXRecordDecl *decl) {
     if (auto recordType = dyn_cast<clang::RecordType>(t.getCanonicalType())) {
       if (auto cxxRecord =
               dyn_cast<clang::CXXRecordDecl>(recordType->getDecl())) {
-        if (hasImportAsRefAttr(cxxRecord) || hasOwnedValueAttr(cxxRecord) ||
+        if (hasImportReferenceAttr(cxxRecord) || hasOwnedValueAttr(cxxRecord) ||
             hasUnsafeAPIAttr(cxxRecord))
           return true;
 

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -1910,7 +1910,7 @@ void importer::addEntryToLookupTable(SwiftLookupTable &table,
     if (!isa<clang::ClassTemplateSpecializationDecl>(named) &&
         !tagDecl->getDefinition() &&
         !(isa<clang::RecordDecl>(tagDecl) &&
-          hasImportAsRefAttr(cast<clang::RecordDecl>(tagDecl)))) {
+          hasImportReferenceAttr(cast<clang::RecordDecl>(tagDecl)))) {
       return;
     }
   }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -4250,10 +4250,8 @@ void MissingMemberFailure::diagnoseUnsafeCxxMethod(SourceLoc loc,
     } else if (cxxMethod->getReturnType()->isRecordType()) {
       if (auto cxxRecord = dyn_cast<clang::CXXRecordDecl>(
               cxxMethod->getReturnType()->getAsRecordDecl())) {
-        // `importerImpl` is set to nullptr here to avoid diagnostics during
-        // this CxxRecordSemantics evaluation.
         auto methodSemantics = evaluateOrDefault(
-            ctx.evaluator, CxxRecordSemantics({cxxRecord, ctx, nullptr}), {});
+            ctx.evaluator, CxxRecordSemantics({cxxRecord, ctx}), {});
         if (methodSemantics == CxxRecordSemanticsKind::Iterator) {
           ctx.Diags.diagnose(loc, diag::iterator_method_unavailable,
                              name.getBaseIdentifier().str());

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -6591,8 +6591,9 @@ static void diagnoseMissingMemberImports(const Expr *E, const DeclContext *DC) {
   const_cast<Expr *>(E)->walk(walker);
 }
 
-static bool isReturningFRT(const clang::NamedDecl *ND,
-                           clang::QualType &outReturnType, ASTContext &Ctx) {
+static bool isReturningSharedFRT(const clang::NamedDecl *ND,
+                                 clang::QualType &outReturnType,
+                                 ASTContext &Ctx) {
   if (auto *CD = dyn_cast<clang::CXXConstructorDecl>(ND))
     outReturnType =
         CD->getParent()->getTypeForDecl()->getCanonicalTypeUnqualified();
@@ -6611,10 +6612,12 @@ static bool isReturningFRT(const clang::NamedDecl *ND,
   if (!recordDecl)
     return false;
 
-  return !importer::hasImmortalAttrs(recordDecl) &&
-         evaluateOrDefault(Ctx.evaluator,
-                           CxxRecordSemantics({recordDecl, Ctx, nullptr}),
-                           {}) == CxxRecordSemanticsKind::Reference;
+  if (importer::hasImmortalAttrs(recordDecl))
+    return false;
+
+  auto info = evaluateOrDefault(
+      Ctx.evaluator, ForeignReferenceTypeInfoRequest({recordDecl}), {});
+  return info.isReference();
 }
 
 static bool shouldDiagnoseMissingReturnsRetained(const clang::NamedDecl *ND,
@@ -6691,7 +6694,7 @@ static void diagnoseCxxFunctionCalls(const Expr *E, const DeclContext *DC) {
         return Action::Continue(E);
 
       clang::QualType retType;
-      if (!isReturningFRT(ND, retType, Ctx))
+      if (!isReturningSharedFRT(ND, retType, Ctx))
         return Action::Continue(E);
 
       if (shouldDiagnoseMissingReturnsRetained(ND, retType, Ctx)) {

--- a/test/Interop/C/struct/Inputs/foreign-reference.h
+++ b/test/Interop/C/struct/Inputs/foreign-reference.h
@@ -27,7 +27,7 @@
 SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
 
 struct
-    __attribute__((swift_attr("import_as_ref")))
+    __attribute__((swift_attr("import_reference")))
     __attribute__((swift_attr("retain:LCRetain")))
     __attribute__((swift_attr("release:LCRelease")))
 LocalCount {
@@ -46,7 +46,7 @@ static inline void LCRelease(struct LocalCount *x) { x->value--; }
 static int globalCount = 0;
 
 struct
-    __attribute__((swift_attr("import_as_ref")))
+    __attribute__((swift_attr("import_reference")))
     __attribute__((swift_attr("retain:GCRetain")))
     __attribute__((swift_attr("release:GCRelease")))
 GlobalCount {};

--- a/test/Interop/C/swiftify-import/conflicting-opaqueness.swift
+++ b/test/Interop/C/swiftify-import/conflicting-opaqueness.swift
@@ -44,7 +44,7 @@ struct container_t {
 // }}
 void fooWrapped(struct container_t * x, int * __counted_by(len) p, int len);
 
-typedef struct __attribute__((swift_attr("import_as_ref")))
+typedef struct __attribute__((swift_attr("import_reference")))
 __attribute__((swift_attr("retain:foobar_retain")))
 __attribute__((swift_attr("release:foobar_release"))) foobar_t *foobar_ref;
 

--- a/test/Interop/Cxx/foreign-reference/Inputs/reference-counted.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/reference-counted.h
@@ -17,7 +17,7 @@ static int finalLocalRefCount = 100;
 
 namespace NS {
 
-struct __attribute__((swift_attr("import_as_ref")))
+struct __attribute__((swift_attr("import_reference")))
 __attribute__((swift_attr("retain:LCRetain")))
 __attribute__((swift_attr("release:LCRelease"))) LocalCount final {
   int value = 0;
@@ -43,7 +43,7 @@ inline void LCRelease(NS::LocalCount *x) {
 
 static int globalCount = 0;
 
-struct __attribute__((swift_attr("import_as_ref")))
+struct __attribute__((swift_attr("import_reference")))
 __attribute__((swift_attr("retain:GCRetain")))
 __attribute__((swift_attr("release:GCRelease"))) GlobalCount {
   static GlobalCount *create() {
@@ -54,7 +54,7 @@ __attribute__((swift_attr("release:GCRelease"))) GlobalCount {
 inline void GCRetain(GlobalCount *x) { globalCount++; }
 inline void GCRelease(GlobalCount *x) { globalCount--; }
 
-struct __attribute__((swift_attr("import_as_ref")))
+struct __attribute__((swift_attr("import_reference")))
 __attribute__((swift_attr("retain:GCRetainNullableInit")))
 __attribute__((swift_attr("release:GCReleaseNullableInit")))
 GlobalCountNullableInit {
@@ -69,7 +69,7 @@ GlobalCountNullableInit {
 inline void GCRetainNullableInit(GlobalCountNullableInit *x) { globalCount++; }
 inline void GCReleaseNullableInit(GlobalCountNullableInit *x) { globalCount--; }
 
-struct __attribute__((swift_attr("import_as_ref")))
+struct __attribute__((swift_attr("import_reference")))
 __attribute__((swift_attr("retain:RCRetain")))
 __attribute__((swift_attr("release:RCRelease"))) HasOpsReturningRefCount final {
   int refCount = 0;
@@ -85,7 +85,7 @@ inline unsigned RCRelease(HasOpsReturningRefCount *x) { return --x->refCount; }
 
 #endif
 
-typedef struct __attribute__((swift_attr("import_as_ref")))
+typedef struct __attribute__((swift_attr("import_reference")))
 __attribute__((swift_attr("retain:INRetain")))
 __attribute__((swift_attr("release:INRelease"))) IncompleteImpl *Incomplete;
 

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
@@ -52,7 +52,7 @@ namespace ns {
     };
 
     #define IMMORTAL_REF                                \
-         __attribute__((swift_attr("import_as_ref")))   \
+         __attribute__((swift_attr("import_reference")))   \
          __attribute__((swift_attr("retain:immortal"))) \
          __attribute__((swift_attr("release:immortal")))
     struct IMMORTAL_REF Immortal {


### PR DESCRIPTION
This patch set gets rid of getRefParentOrDiag() and replaces it with two
well-defined entry points: a request that does not emit diagnostics, and
a function that does.

It also cleans up various aspects of the reference type analysis logic.

rdar://170858418

