### PR TITLE
[Serialization] Write Decls' lifetimes, not their types' lifetimes

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -532,7 +532,7 @@ getLifetimeDependenceSpecifier(unsigned index,
   case LifetimeDependenceKind::Inherit:
     return "copy ";
   case LifetimeDependenceKind::Scope:
-    if (params[index].isInOut()) {
+    if (index < params.size() && params[index].isInOut()) {
       return "&";
     }
     return "borrow ";
@@ -7078,7 +7078,7 @@ public:
     }
 
     // Print lifetime dependencies using Swift syntax.
-    if (!Options.PrintInSILBody && fnType->hasLifetimeDependencies()) {
+    if (fnType->hasLifetimeDependencies()) {
       ArrayRef<AnyFunctionType::Param> params = fnType->getParams();
 
       for (const auto &lifetimeDependence : info.getLifetimeDependencies()) {
@@ -7324,10 +7324,6 @@ public:
         Printer << ": ";
       }
 
-      if (Options.PrintInSILBody) {
-        Printer.printLifetimeDependenceAt(lifetimeDependencies, i);
-      }
-
       auto type = Param.getPlainType();
       if (Param.isVariadic()) {
         visit(type);
@@ -7387,11 +7383,6 @@ public:
       Printer.printKeyword("sending ", Options);
     }
 
-    if (Options.PrintInSILBody) {
-      Printer.printLifetimeDependenceAt(T->getLifetimeDependencies(),
-                                        T->getParams().size());
-    }
-
     Printer.callPrintStructurePre(PrintStructureKind::FunctionReturnType);
     T->getResult().print(Printer, Options);
     Printer.printStructurePost(PrintStructureKind::FunctionReturnType);
@@ -7448,11 +7439,6 @@ public:
    }
 
     Printer << " -> ";
-
-    if (Options.PrintInSILBody) {
-      Printer.printLifetimeDependenceAt(T->getLifetimeDependencies(),
-                                        T->getParams().size());
-    }
 
     Printer.callPrintStructurePre(PrintStructureKind::FunctionReturnType);
     T->getResult().print(Printer, Options);

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,9 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 986; // explicit module map
+const uint16_t SWIFTMODULE_VERSION_MINOR =
+    987; // Serialize decl lifetimes instead of their their function types'
+         // lifetimes
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4186,6 +4186,33 @@ private:
     InlinableBodyTextLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode, body);
   }
 
+  /// For some functions, notably (static) methods, the lifetime dependencies on
+  /// the function type may differ from the lifetimes of the function
+  /// declaration.
+  ///
+  /// For example, given some ~Escapable type NE, static method S.f has type
+  /// (S.Type) -> @_lifetime(copy x) (_ x: NE) -> NE. The function type is
+  /// curried, and the outer type has no lifetime dependencies.
+  ///
+  ///   struct S {
+  ///     @_lifetime(copy x) static func f(x: NE) -> NE { x }
+  ///   }
+  ///
+  /// This means that when writing a function decl's lifetime dependencies, we
+  /// must write the dependencies of the decl itself, and not those of its type.
+  template <typename D>
+  void writeLifetimeDependenciesIfNeeded(const D *Decl) {
+    static_assert(std::is_base_of_v<AbstractFunctionDecl, D> ||
+                  std::is_same_v<EnumElementDecl, D>);
+    if (auto lifetimeDependencies = evaluateOrDefault(
+            S.M->getASTContext().evaluator,
+            LifetimeDependenceInfoRequest{
+                const_cast<ValueDecl *>(cast<ValueDecl>(Decl))},
+            std::nullopt)) {
+      S.writeLifetimeDependencies(*lifetimeDependencies);
+    }
+  }
+
   static bool getNeedsNewTableEntry(const AbstractFunctionDecl *func) {
     if (isa_and_nonnull<ProtocolDecl>(func->getDeclContext()))
       return func->requiresNewWitnessTableEntry();
@@ -4973,13 +5000,7 @@ public:
     // Write the body parameters.
     writeParameterList(fn->getParameters());
 
-    auto fnType = ty->getAs<AnyFunctionType>();
-    if (fnType) {
-      auto lifetimeDependencies = fnType->getLifetimeDependencies();
-      if (!lifetimeDependencies.empty()) {
-        S.writeLifetimeDependencies(lifetimeDependencies);
-      }
-    }
+    writeLifetimeDependenciesIfNeeded(fn);
 
     if (auto errorConvention = fn->getForeignErrorConvention())
       writeForeignErrorConvention(*errorConvention);
@@ -5116,13 +5137,7 @@ public:
     // Write the body parameters.
     writeParameterList(fn->getParameters());
 
-    auto fnType = ty->getAs<AnyFunctionType>();
-    if (fnType) {
-      auto lifetimeDependencies = fnType->getLifetimeDependencies();
-      if (!lifetimeDependencies.empty()) {
-        S.writeLifetimeDependencies(lifetimeDependencies);
-      }
-    }
+    writeLifetimeDependenciesIfNeeded(fn);
 
     if (auto errorConvention = fn->getForeignErrorConvention())
       writeForeignErrorConvention(*errorConvention);
@@ -5176,13 +5191,7 @@ public:
     if (auto *PL = elem->getParameterList())
       writeParameterList(PL);
 
-    auto fnType = ty->getAs<AnyFunctionType>();
-    if (fnType) {
-      auto lifetimeDependencies = fnType->getLifetimeDependencies();
-      if (!lifetimeDependencies.empty()) {
-        S.writeLifetimeDependencies(lifetimeDependencies);
-      }
-    }
+    writeLifetimeDependenciesIfNeeded(elem);
   }
 
   void visitSubscriptDecl(const SubscriptDecl *subscript) {
@@ -5294,13 +5303,7 @@ public:
     writeGenericParams(ctor->getGenericParams());
     writeParameterList(ctor->getParameters());
 
-    auto fnType = ty->getAs<AnyFunctionType>();
-    if (fnType) {
-      auto lifetimeDependencies = fnType->getLifetimeDependencies();
-      if (!lifetimeDependencies.empty()) {
-        S.writeLifetimeDependencies(lifetimeDependencies);
-      }
-    }
+    writeLifetimeDependenciesIfNeeded(ctor);
 
     if (auto errorConvention = ctor->getForeignErrorConvention())
       writeForeignErrorConvention(*errorConvention);

--- a/test/Serialization/Inputs/def_explicit_lifetime_dependence.swift
+++ b/test/Serialization/Inputs/def_explicit_lifetime_dependence.swift
@@ -92,3 +92,25 @@ extension FakeOptional where Wrapped: ~Escapable {
   }
 }
 
+// Static methods (rdar://171315715)
+public struct GCM {
+  @inlinable
+  @_lifetime(message: copy message)
+  public static func open(
+    inPlace message: inout MutableRawSpan,
+    tag: RawSpan
+  ) {}
+  public
+    var x: RawSpan {
+    @inlinable
+    @_lifetime(borrow self)
+    get {
+      fatalError()
+    }
+  }
+  @inlinable
+  @_lifetime(copy message)
+  public static func propagate(message: consuming MutableRawSpan) -> MutableRawSpan {
+    return message
+  }
+}

--- a/test/Serialization/Inputs/def_implicit_lifetime_dependence.swift
+++ b/test/Serialization/Inputs/def_implicit_lifetime_dependence.swift
@@ -73,3 +73,15 @@ public struct Wrapper : ~Escapable {
   }
 }
 
+// Static methods (rdar://171315715)
+public struct GCM {
+  @inlinable
+  public static func open(
+    inPlace message: inout MutableRawSpan,
+    tag: RawSpan
+  ) {}
+  @inlinable
+  public static func propagate(message: consuming MutableRawSpan) -> MutableRawSpan {
+    return message
+  }
+}

--- a/test/Serialization/explicit_lifetime_dependence.swift
+++ b/test/Serialization/explicit_lifetime_dependence.swift
@@ -51,8 +51,19 @@ func testFakeOptional() {
   _ = FakeOptional<Int>(())
 }
 
+func testStaticMethod(
+  inPlace message: inout MutableRawSpan,
+  tag: RawSpan, gcm: GCM) {
+  GCM.open(inPlace: &message, tag: tag)
+  let propagatedMessage = GCM.propagate(message: message)
+  let gcmX = gcm.x
+  message = propagatedMessage
+}
 // CHECK: sil @$s32def_explicit_lifetime_dependence6deriveyAA10BufferViewVADF : $@convention(thin) (@guaranteed BufferView) -> @lifetime(borrow 0) @owned BufferView
 // CHECK: sil @$s32def_explicit_lifetime_dependence16consumeAndCreateyAA10BufferViewVADnF : $@convention(thin) (@owned BufferView) -> @lifetime(copy 0) @owned BufferView
 // CHECK: sil @$s32def_explicit_lifetime_dependence15borrowAndCreateyAA10BufferViewVADF : $@convention(thin) (@guaranteed BufferView) -> @lifetime(borrow 0) @owned BufferView
 // CHECK: sil @$s32def_explicit_lifetime_dependence16deriveThisOrThatyAA10BufferViewVAD_ADtF : $@convention(thin) (@guaranteed BufferView, @guaranteed BufferView) -> @lifetime(copy 1, borrow 0) @owned BufferView
 // CHECK: sil @$s32def_explicit_lifetime_dependence10BufferViewVyACSW_SaySiGhtcfC : $@convention(method) (UnsafeRawBufferPointer, @guaranteed Array<Int>, @thin BufferView.Type) -> @lifetime(borrow 1) @owned BufferView
+// CHECK-LABEL: sil @$s32def_explicit_lifetime_dependence3GCMV4open7inPlace3tagys14MutableRawSpanVz_s0kL0VtFZ : $@convention(method) (@lifetime(copy 0) @inout MutableRawSpan, @guaranteed RawSpan, @thin GCM.Type) -> ()
+// CHECK-LABEL: sil @$s32def_explicit_lifetime_dependence3GCMV9propagate7messages14MutableRawSpanVAGn_tFZ : $@convention(method) (@owned MutableRawSpan, @thin GCM.Type) -> @lifetime(copy 0) @owned MutableRawSpan
+// CHECK-LABEL: sil @$s32def_explicit_lifetime_dependence3GCMV1xs7RawSpanVvg : $@convention(method) (GCM) -> @lifetime(borrow 0) @owned RawSpan

--- a/test/Serialization/implicit_lifetime_dependence.swift
+++ b/test/Serialization/implicit_lifetime_dependence.swift
@@ -63,9 +63,19 @@ func testReadMutateAccessors() {
   }
 }
 
+func testStaticMethod(
+  inPlace message: inout MutableRawSpan,
+  tag: RawSpan) {
+  GCM.open(inPlace: &message, tag: tag)
+  let propagatedMessage = GCM.propagate(message: message)
+  message = propagatedMessage
+}
+
 // CHECK-LABEL: sil @$s32def_implicit_lifetime_dependence10BufferViewVyACSW_SitcfC : $@convention(method) (UnsafeRawBufferPointer, Int, @thin BufferView.Type) -> @lifetime(borrow 0) @owned BufferView
 // CHECK-LABEL: sil @$s32def_implicit_lifetime_dependence6deriveyAA10BufferViewVADF : $@convention(thin) (@guaranteed BufferView) -> @lifetime(copy 0) @owned BufferView
 // CHECK-LABEL: sil @$s32def_implicit_lifetime_dependence16consumeAndCreateyAA10BufferViewVADnF : $@convention(thin) (@owned BufferView) -> @lifetime(copy 0) @owned BufferView
 // CHECK-LABEL: sil @$s32def_implicit_lifetime_dependence15borrowAndCreateyAA10BufferViewVADF : $@convention(thin) (@guaranteed BufferView) -> @lifetime(copy 0) @owned BufferView
 // CHECK-LABEL: sil @$s32def_implicit_lifetime_dependence9ContainerV4viewAA10BufferViewVvg : $@convention(method) (@guaranteed Container) -> @lifetime(borrow 0) @owned BufferView
 // CHECK-LABEL: sil @$s32def_implicit_lifetime_dependence7WrapperV4viewAA10BufferViewVvr : $@yield_once @convention(method) (@guaranteed Wrapper) -> @lifetime(copy 0) @yields @guaranteed BufferView
+// CHECK-LABEL: sil @$s32def_implicit_lifetime_dependence3GCMV4open7inPlace3tagys14MutableRawSpanVz_s0kL0VtFZ : $@convention(method) (@lifetime(copy 0) @inout MutableRawSpan, @guaranteed RawSpan, @thin GCM.Type) -> ()
+// CHECK-LABEL: sil @$s32def_implicit_lifetime_dependence3GCMV9propagate7messages14MutableRawSpanVAGn_tFZ : $@convention(method) (@owned MutableRawSpan, @thin GCM.Type) -> @lifetime(copy 0) @owned MutableRawSpan


### PR DESCRIPTION
Fixes: rdar://171315715

For some functions, notably (static) methods, the lifetime dependencies on
the function type may differ from the lifetimes of the function
declaration.

For example, given some ~Escapable type NE, static method S.f has type
`(S.Type) -> @_lifetime(copy x) (_ x: NE) -> NE`. The function type is
curried, and the outer type has no lifetime dependencies.

    struct S {
        @_lifetime(copy x) static func f(x: NE) -> NE { x }
    }

This means that when writing a function decl's lifetime dependencies, we
must write the dependencies of the decl itself, and not those of its type.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
