### PR TITLE
[Diagnostics] Guard the user-controlled behavior warning logic behind experimental feature

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -628,6 +628,9 @@ namespace swift {
     /// Don't emit any remarks
     bool suppressRemarks = false;
 
+    /// Check for `@warn` diagnostic group behavior controls
+    bool checkSyntacticControls = false;
+
     /// A mapping from `DiagGroupID` identifiers to `WarningGroupBehaviorRule`
     /// values indicating how warnings belonging to the respective diagnostic groups
     /// should be emitted. While there is duplication between this data structure
@@ -671,6 +674,13 @@ namespace swift {
     }
     bool getShowDiagnosticsAfterFatalError() {
       return showDiagnosticsAfterFatalError;
+    }
+
+    void setCheckSyntacticControls(bool val = true) {
+      checkSyntacticControls = val;
+    }
+    bool getCheckSyntacticControls() const {
+      return checkSyntacticControls;
     }
 
     /// Whether to skip emitting warnings
@@ -942,6 +952,14 @@ namespace swift {
     void setSuppressRemarks(bool val) { state.setSuppressRemarks(val); }
     bool getSuppressRemarks() const {
       return state.getSuppressRemarks();
+    }
+
+    /// Whether to check syntactic `@warn` controls
+    void setCheckSyntacticControls(bool val = true) {
+      state.setCheckSyntacticControls(val);
+    }
+    bool getCheckSyntacticControls() const {
+      return state.getCheckSyntacticControls();
     }
 
     /// Apply rules specifing what warnings should or shouldn't be treated as

--- a/include/swift/Basic/DiagnosticOptions.h
+++ b/include/swift/Basic/DiagnosticOptions.h
@@ -75,6 +75,9 @@ public:
   /// Suppress all remarks
   bool SuppressRemarks = false;
 
+  /// Check for `@warn` diagnostic group behavior controls
+  bool CheckSyntacticControls = false;
+
   /// Rules for escalating warnings to errors
   llvm::SmallVector<WarningGroupBehaviorRule, 4> WarningGroupControlRules;
 

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -589,13 +589,17 @@ bool DiagnosticEngine::finishProcessing() {
 
 bool DiagnosticEngine::isDiagnosticGroupEnabled(SourceFile *sf, DiagGroupID groupID) const {
 #if SWIFT_BUILD_SWIFT_SYNTAX
-  if (!sf || !sf->getExportedSourceFile())
+  if (getCheckSyntacticControls()) {
+    if (!sf || !sf->getExportedSourceFile())
+      return !state.isIgnoredDiagnosticGroupTree(groupID);
+    auto ruleRefArray = getWarningGroupBehaviorControlRefArray();
+    return swift_ASTGen_isWarningGroupEnabledInFile(
+            sf->getExportedSourceFile(),
+            BridgedArrayRef(ruleRefArray.data(), ruleRefArray.size()),
+            StringRef(getDiagGroupInfoByID(groupID).name));
+  } else {
     return !state.isIgnoredDiagnosticGroupTree(groupID);
-  auto ruleRefArray = getWarningGroupBehaviorControlRefArray();
-  return swift_ASTGen_isWarningGroupEnabledInFile(
-         sf->getExportedSourceFile(),
-         BridgedArrayRef(ruleRefArray.data(), ruleRefArray.size()),
-         StringRef(getDiagGroupInfoByID(groupID).name));
+  }
 #else
   // Fallback to checking only the command-line configuration
   return !state.isIgnoredDiagnosticGroupTree(groupID);
@@ -1349,6 +1353,9 @@ DiagnosticState::determineUserControlledWarningBehavior(
     }
   } else
     userControlledBehavior = std::nullopt;
+
+  if (!checkSyntacticControls)
+    return userControlledBehavior;
 
 #if SWIFT_BUILD_SWIFT_SYNTAX
   // Use the combined global controls (command-line flags such as `-Werror`)

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2753,6 +2753,18 @@ static bool ParseDiagnosticArgs(DiagnosticOptions &Opts, ArgList &Args,
   Opts.ShowDiagnosticsAfterFatalError |=
     Args.hasArg(OPT_show_diagnostics_after_fatal);
 
+  auto enablesSyntacticWarningControl = [&](const Arg *A) {
+    if (!A->getOption().matches(options::OPT_enable_experimental_feature))
+      return false;
+    if (auto feature = Feature::getExperimentalFeature(A->getValue())) {
+      return feature == Feature::InnerKind::SourceWarningControl;
+    }
+    return false;
+  };
+  if (llvm::any_of(Args, enablesSyntacticWarningControl)) {
+    Opts.CheckSyntacticControls = true;
+  }
+
   for (Arg *A : Args.filtered(OPT_verify_additional_file))
     Opts.AdditionalVerifierFiles.push_back(A->getValue());
   for (Arg *A : Args.filtered(OPT_verify_additional_prefix))
@@ -2909,6 +2921,9 @@ static void configureDiagnosticEngine(
     StringRef mainExecutablePath, DiagnosticEngine &Diagnostics) {
   if (Options.ShowDiagnosticsAfterFatalError) {
     Diagnostics.setShowDiagnosticsAfterFatalError();
+  }
+  if (Options.CheckSyntacticControls) {
+    Diagnostics.setCheckSyntacticControls();
   }
   if (Options.SuppressWarnings) {
     Diagnostics.setSuppressWarnings(true);

--- a/test/attr/warn_no_feature.swift
+++ b/test/attr/warn_no_feature.swift
@@ -1,0 +1,16 @@
+// RUN: %target-typecheck-verify-swift 
+
+@available(*, deprecated)
+func bar() -> [Int] { return [1,2,3] }
+
+// Ensure feature SourceWarningControl has no effect until enabled
+
+@warn(DeprecatedDeclaration, as: error)
+func foo() -> [Int] { 
+    return bar() // expected-warning {{'bar()' is deprecated}}
+}
+
+@warn(DeprecatedDeclaration, as: ignored)
+func baz() -> [Int] { 
+    return bar() // expected-warning {{'bar()' is deprecated}}
+}


### PR DESCRIPTION
`-enable-experimental-feature SourceWarningControl` guards the actual *use* of `@warn` attribute, but it did not guard this logic which queries it, which is meant to be general in the absense of the attribute as well.

We are seeing some unintended compile time performance implications from this logic, so for now guard it behind the same experimental feature flag.

Related to rdar://171506799
