### PR TITLE
fix: Stable ABI debu release mode

### DIFF
--- a/Runtimes/Core/runtime/CMakeLists.txt
+++ b/Runtimes/Core/runtime/CMakeLists.txt
@@ -197,7 +197,20 @@ elseif("${SwiftCore_OBJECT_FORMAT}" STREQUAL "coffx")
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/swift/${SwiftCore_PLATFORM_SUBDIR}/${SwiftCore_ARCH_SUBDIR}"
     RENAME swiftrt.obj)
 
-  install(TARGETS swiftrtT swiftrt
+  # Debug variant for Windows: stable ABI differs between debug and release;
+  # provide swiftrtd.obj so the driver can link it for debug builds.
+  add_library(swiftrtd OBJECT SwiftRT-COFF.cpp)
+  target_compile_definitions(swiftrtd PRIVATE _DEBUG)
+  target_link_libraries(swiftrtd PRIVATE swiftShims)
+  if(MSVC)
+    set_property(TARGET swiftrtd PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreadedDebugDLL")
+  endif()
+  install(FILES $<TARGET_OBJECTS:swiftrtd>
+    COMPONENT SwiftCore_runtime
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/swift/${SwiftCore_PLATFORM_SUBDIR}/${SwiftCore_ARCH_SUBDIR}"
+    RENAME swiftrtd.obj)
+
+  install(TARGETS swiftrtT swiftrt swiftrtd
     EXPORT SwiftCoreTargets
     COMPONENT SwiftCore_runtime)
 elseif(NOT "${SwiftCore_OBJECT_FORMAT}" STREQUAL "x")

--- a/lib/Driver/WindowsToolChains.cpp
+++ b/lib/Driver/WindowsToolChains.cpp
@@ -152,7 +152,14 @@ toolchains::Windows::constructInvocation(const DynamicLinkJobAction &job,
     SmallString<128> swiftrtPath = SharedResourceDirPath;
     llvm::sys::path::append(swiftrtPath,
                             swift::getMajorArchitectureName(getTriple()));
-    llvm::sys::path::append(swiftrtPath, "swiftrt.obj");
+    // Windows does not provide a stable ABI between debug and release; use
+    // swiftrtd.obj for debug runtime variants to avoid _ITERATOR_DEBUG_LEVEL
+    // mismatches.
+    bool useDebugSwiftRT =
+        context.OI.RuntimeVariant == OutputInfo::MSVCRuntime::MultiThreadedDebug ||
+        context.OI.RuntimeVariant == OutputInfo::MSVCRuntime::MultiThreadedDebugDLL;
+    llvm::sys::path::append(swiftrtPath,
+                           useDebugSwiftRT ? "swiftrtd.obj" : "swiftrt.obj");
     Arguments.push_back(context.Args.MakeArgString(swiftrtPath));
   }
 

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -201,6 +201,29 @@ add_swift_target_library(swiftImageRegistrationObjectCOFF
                   SWIFT_COMPILE_FLAGS ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
                   INSTALL_IN_COMPONENT none)
 
+# Debug variant of COFF swiftrt for Windows (swiftrtd.obj); avoids
+# _ITERATOR_DEBUG_LEVEL ABI mismatch when linking debug builds.
+add_swift_target_library(swiftImageRegistrationObjectCOFFDebug
+                  OBJECT_LIBRARY IS_STDLIB IS_STDLIB_CORE
+                  SwiftRT-COFF.cpp
+                  C_COMPILE_FLAGS
+                    ${SWIFT_RUNTIME_CORE_CXX_FLAGS}
+                    ${swift_enable_backtracing}
+                    -D_DEBUG
+                  LINK_FLAGS ${SWIFT_RUNTIME_CORE_LINK_FLAGS}
+                  TARGET_SDKS ${COFF_SDKS}
+                  SWIFT_COMPILE_FLAGS ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
+                  INSTALL_IN_COMPONENT none)
+foreach(sdk ${COFF_SDKS})
+  foreach(arch ${SWIFT_SDK_${sdk}_ARCHITECTURES})
+    set(arch_suffix "${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}")
+    if(MSVC)
+      set_target_properties(swiftImageRegistrationObjectCOFFDebug-${arch_suffix}
+        PROPERTIES MSVC_RUNTIME_LIBRARY "MultiThreadedDebugDLL")
+    endif()
+  endforeach()
+endforeach()
+
 add_swift_target_library(swiftImageRegistrationObjectWASM
                   OBJECT_LIBRARY IS_STDLIB IS_STDLIB_CORE
                   SwiftRT-ELF-WASM.cpp
@@ -239,16 +262,29 @@ foreach(sdk ${SWIFT_SDKS})
       set(shared_runtime_registrar "${SWIFTLIB_DIR}/${arch_subdir}/swiftrt${extension}")
       set(static_runtime_registrar "${SWIFTSTATICLIB_DIR}/${arch_subdir}/swiftrt${extension}")
 
+      set(swiftrt_outputs "${shared_runtime_registrar}" "${static_runtime_registrar}")
+      set(swiftrt_commands
+        COMMAND "${CMAKE_COMMAND}" -E copy "${swiftrtObject}" "${shared_runtime_registrar}"
+        COMMAND "${CMAKE_COMMAND}" -E copy "${swiftrtObject}" "${static_runtime_registrar}")
+      set(swiftrt_depends "${swiftrtObject}")
+
+      if(sdk STREQUAL "WINDOWS")
+        set(swiftrtdObject ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/swiftImageRegistrationObjectCOFFDebug-${arch_suffix}.dir/SwiftRT-COFF.cpp${CMAKE_C_OUTPUT_EXTENSION})
+        set(shared_runtime_registrar_debug "${SWIFTLIB_DIR}/${arch_subdir}/swiftrtd.obj")
+        set(static_runtime_registrar_debug "${SWIFTSTATICLIB_DIR}/${arch_subdir}/swiftrtd.obj")
+        list(APPEND swiftrt_outputs "${shared_runtime_registrar_debug}" "${static_runtime_registrar_debug}")
+        list(APPEND swiftrt_commands
+          COMMAND "${CMAKE_COMMAND}" -E copy "${swiftrtdObject}" "${shared_runtime_registrar_debug}"
+          COMMAND "${CMAKE_COMMAND}" -E copy "${swiftrtdObject}" "${static_runtime_registrar_debug}")
+        list(APPEND swiftrt_depends "${swiftrtdObject}")
+      endif()
+
       add_custom_command_target(swiftImageRegistration-${arch_suffix}
-                                COMMAND
-                                  "${CMAKE_COMMAND}" -E copy "${swiftrtObject}" "${shared_runtime_registrar}"
-                                COMMAND
-                                  "${CMAKE_COMMAND}" -E copy "${swiftrtObject}" "${static_runtime_registrar}"
+                                ${swiftrt_commands}
                                 OUTPUT
-                                  "${shared_runtime_registrar}"
-                                  "${static_runtime_registrar}"
+                                  ${swiftrt_outputs}
                                 DEPENDS
-                                  "${swiftrtObject}")
+                                  ${swiftrt_depends})
       if(SWIFT_BUILD_DYNAMIC_STDLIB AND NOT SWIFT_SDK_${sdk}_STATIC_ONLY)
         swift_install_in_component(FILES
                                      "${shared_runtime_registrar}"
@@ -256,6 +292,14 @@ foreach(sdk ${SWIFT_SDKS})
                                      "lib/swift/${arch_subdir}"
                                    COMPONENT
                                      stdlib)
+        if(sdk STREQUAL "WINDOWS")
+          swift_install_in_component(FILES
+                                     "${shared_runtime_registrar_debug}"
+                                   DESTINATION
+                                     "lib/swift/${arch_subdir}"
+                                   COMPONENT
+                                     stdlib)
+        endif()
       endif()
       if(SWIFT_BUILD_STATIC_STDLIB OR SWIFT_SDK_${sdk}_STATIC_ONLY)
         swift_install_in_component(FILES
@@ -264,9 +308,21 @@ foreach(sdk ${SWIFT_SDKS})
                                      "lib/swift_static/${arch_subdir}"
                                    COMPONENT
                                      stdlib)
+        if(sdk STREQUAL "WINDOWS")
+          swift_install_in_component(FILES
+                                     "${static_runtime_registrar_debug}"
+                                   DESTINATION
+                                     "lib/swift_static/${arch_subdir}"
+                                   COMPONENT
+                                     stdlib)
+        endif()
       endif()
 
       add_dependencies(swift-stdlib-${arch_suffix} ${swiftImageRegistration-${arch_suffix}})
+      if(sdk STREQUAL "WINDOWS")
+        add_dependencies(${swiftImageRegistration-${arch_suffix}}
+          swiftImageRegistrationObjectCOFFDebug-${arch_suffix})
+      endif()
 
       add_custom_target(swiftImageRegistration-${arch_suffix}
                         ALL DEPENDS

--- a/test/Driver/sdk.swift
+++ b/test/Driver/sdk.swift
@@ -42,7 +42,7 @@
 // WINDOWS: -sdk {{.*}}/Inputs/clang-importer-sdk
 // WINDOWS-NEXT: bin{{/|\\\\}}swift
 // WINDOWS: -sdk {{.*}}/Inputs/clang-importer-sdk
-// WINDOWS: {{.*}}Inputs/clang-importer-sdk{{.*}}swiftrt.o
+// WINDOWS: {{.*}}Inputs/clang-importer-sdk{{.*}}swiftrt{{d?}}.obj
 // WINDOWS: {{-I}} {{.*}}/Inputs/clang-importer-sdk
 
 // WASI-NOT: warning: no such SDK:

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2321,12 +2321,18 @@ function Test-Compilers([Hashtable] $Platform, [string] $Variant, [switch] $Test
         -Path $RuntimeBinaryCache\bin\swiftCore.dll `
         -Destination "$(Get-ProjectBinaryCache $BuildPlatform Compilers)\lib\site-packages\lldb"
 
-      # Runtime dependencies of repl_swift.exe
+      # Runtime dependencies of repl_swift.exe (release and debug swiftrt for Windows ABI)
       $SwiftRTSubdir = "lib\swift\windows"
-      Write-Host "Copying '$RuntimeBinaryCache\$SwiftRTSubdir\$($Platform.Architecture.LLVMName)\swiftrt.obj' to '$(Get-ProjectBinaryCache $BuildPlatform Compilers)\$SwiftRTSubdir'"
+      $SwiftRTArchDir = "$SwiftRTSubdir\$($Platform.Architecture.LLVMName)"
+      $SwiftRTDestDir = "$(Get-ProjectBinaryCache $BuildPlatform Compilers)\$SwiftRTArchDir"
+      Write-Host "Copying '$RuntimeBinaryCache\$SwiftRTArchDir\swiftrt.obj' and 'swiftrtd.obj' to '$SwiftRTDestDir'"
+      New-Item -ItemType Directory -Force -Path $SwiftRTDestDir | Out-Null
       Copy-Item `
-        -Path "$RuntimeBinaryCache\$SwiftRTSubdir\$($Platform.Architecture.LLVMName)\swiftrt.obj" `
-        -Destination "$(Get-ProjectBinaryCache $BuildPlatform Compilers)\$SwiftRTSubdir"
+        -Path "$RuntimeBinaryCache\$SwiftRTArchDir\swiftrt.obj" `
+        -Destination $SwiftRTDestDir
+      Copy-Item `
+        -Path "$RuntimeBinaryCache\$SwiftRTArchDir\swiftrtd.obj" `
+        -Destination $SwiftRTDestDir
       Write-Host "Copying '$RuntimeBinaryCache\bin\swiftCore.dll' to '$(Get-ProjectBinaryCache $BuildPlatform Compilers)\bin'"
       Copy-Item `
         -Path "$RuntimeBinaryCache\bin\swiftCore.dll" `

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2321,7 +2321,7 @@ function Test-Compilers([Hashtable] $Platform, [string] $Variant, [switch] $Test
         -Path $RuntimeBinaryCache\bin\swiftCore.dll `
         -Destination "$(Get-ProjectBinaryCache $BuildPlatform Compilers)\lib\site-packages\lldb"
 
-      # Runtime dependencies of repl_swift.exe (release and debug swiftrt for Windows ABI)
+      # Runtime dependencies of repl_swift.exe
       $SwiftRTSubdir = "lib\swift\windows"
       $SwiftRTArchDir = "$SwiftRTSubdir\$($Platform.Architecture.LLVMName)"
       $SwiftRTDestDir = "$(Get-ProjectBinaryCache $BuildPlatform Compilers)\$SwiftRTArchDir"


### PR DESCRIPTION
## Description

The C/C++ runtime does not provide a stable ABI between debug and release builds. The driver previously always linked the same `swiftrt.obj`, which caused ABI mismatches when building in Debug configurations.

This change adds a debug variant of the Swift runtime registration object (`swiftrtd.obj`) and updates the driver to choose the correct object when linking:

- **Driver** (`lib/Driver/WindowsToolChains.cpp`): When the MSVC runtime is a debug variant (`MultiThreadedDebug` or `MultiThreadedDebugDLL`), the driver now passes `swiftrtd.obj` instead of `swiftrt.obj`.
- **Runtimes** (`Runtimes/Core/runtime/CMakeLists.txt`): Add an OBJECT target `swiftrtd` built from `SwiftRT-COFF.cpp` with `_DEBUG` and the debug MSVC runtime; install its object as `swiftrtd.obj` alongside `swiftrt.obj`.
- **Stdlib** (`stdlib/public/runtime/CMakeLists.txt`): Add `swiftImageRegistrationObjectCOFFDebug` for Windows COFF, producing and installing `swiftrtd.obj` for shared and static stdlib.
- **Build script** (`utils/build.ps1`): Copy both `swiftrt.obj` and `swiftrtd.obj` from the Runtime build into the Compilers resource directory (under `lib\swift\windows\<arch>\`).
- **Test** (`test/Driver/sdk.swift`): Update the WINDOWS check to accept either `swiftrt.obj` or `swiftrtd.obj` in the driver output.

With this, Debug builds on Windows can link against the debug runtime object and avoid `_ITERATOR_DEBUG_LEVEL` mismatches. The existing `_ITERATOR_DEBUG_LEVEL=0` workaround in the top-level CMakeLists.txt can be revisited in a follow-up once this is validated.

## Resolves

Resolves https://github.com/apple/swift/issues/87468