### PR TITLE
[Caching] Fix a module build regression in #86881

### DIFF
--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -481,11 +481,6 @@ SwiftDependencyTracker::SwiftDependencyTracker(
   StringRef AccessNotePath = CI.getLangOptions().AccessNotesPath;
   if (!AccessNotePath.empty())
     addCommonFile(AccessNotePath);
-
-  // const-gather-protocols-file
-  StringRef ConstProtocolFile = SearchPathOpts.ConstGatherProtocolListFilePath;
-  if (!ConstProtocolFile.empty())
-    addCommonFile(ConstProtocolFile);
 }
 
 void SwiftDependencyTracker::startTracking(bool includeCommonDeps) {

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -498,6 +498,13 @@ private:
           commandline.push_back("-read-legacy-type-info-path=" +
                                 scanner.remapPath(legacyLayoutPath));
       }
+      // const-gather-protocols-file
+      StringRef ConstProtocolFile = instance.getInvocation()
+                                        .getSearchPathOptions()
+                                        .ConstGatherProtocolListFilePath;
+      if (!ConstProtocolFile.empty())
+        tracker->trackFile(ConstProtocolFile);
+
       auto root = tracker->createTreeFromDependencies();
       if (!root)
         return diagnoseCASFSCreationError(root.takeError());

--- a/test/CAS/const-protocol-values.swift
+++ b/test/CAS/const-protocol-values.swift
@@ -5,7 +5,15 @@
 // RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache -O \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   %t/main.swift -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas -const-gather-protocols-file %t/protocols.json \
-// RUN:   -scanner-prefix-map-paths %t /^tmp
+// RUN:   -scanner-prefix-map-paths %t /^tmp -I %t/include
+
+// RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json A casFSRootID > %t/A.casid
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-include-tree-list @%t/A.casid | %FileCheck %s --check-prefix=A-FS
+// A-FS-NOT: protocols.json
+
+// RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json Test casFSRootID > %t/test.casid
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-include-tree-list @%t/test.casid | %FileCheck %s --check-prefix=TEST-FS
+// TEST-FS: protocols.json
 
 // RUN: %{python} %S/../../utils/swift-build-modules.py --cas %t/cas %swift_frontend_plain %t/deps.json -o %t/MyApp.cmd
 
@@ -15,7 +23,12 @@
 // RUN:   -module-name Test -cache-replay-prefix-map /^tmp %t -const-gather-protocols-file /^tmp/protocols.json \
 // RUN:   /^tmp/main.swift @%t/MyApp.cmd -emit-const-values-path %t/main.module.swiftconstvalues
 
+//--- include/A.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name A -O -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib
+
 //--- main.swift
+import A
 print("Hello")
 
 //--- protocols.json


### PR DESCRIPTION
Fix a module build regression in PR86881 that causes an increase of swift interface compilation tasks due to including the const-gather-protocol list files into the build dependencies for swiftinterface files. This causes targets cannot sharing module dependencies.

This make sures the CASFS system only captures the const-gather-protocol list in the tasks for main module, not for any of its module dependencies.

rdar://171506799

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
