### PR TITLE
SILMem2Reg: Fix debug scope of inlined instructions

### DIFF
--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -1981,9 +1981,12 @@ void MemoryToRegisters::removeSingleBlockAllocation(AllocStackInst *asi) {
             LiveValues::toReplace(asi,
                                   /*replacement=*/initialValue),
             /*isStorageValid=*/!doesLoadInvalidateStorage(inst)};
-        if (auto varInfo = asi->getVarInfo()) {
-          SILBuilderWithScope(inst, ctx).createDebugValue(
-              inst->getLoc(), initialValue, *varInfo);
+        if (auto var = asi->getVarInfo()) {
+          SILBuilder Builder(inst, ctx);
+          // Force the debug_value to be in the same scope as the alloc_stack
+          // so it refers to the correct variable.
+          Builder.setCurrentDebugScope(asi->getDebugScope());
+          Builder.createDebugValue(inst->getLoc(), initialValue, *var);
         }
       }
       auto *loadInst = dyn_cast<LoadInst>(inst);

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -1981,13 +1981,10 @@ void MemoryToRegisters::removeSingleBlockAllocation(AllocStackInst *asi) {
             LiveValues::toReplace(asi,
                                   /*replacement=*/initialValue),
             /*isStorageValid=*/!doesLoadInvalidateStorage(inst)};
-// Disabled to work around a compiler crash. See rdar://171023691
-#if 0
         if (auto varInfo = asi->getVarInfo()) {
           SILBuilderWithScope(inst, ctx).createDebugValue(
               inst->getLoc(), initialValue, *varInfo);
         }
-#endif
       }
       auto *loadInst = dyn_cast<LoadInst>(inst);
       if (loadInst &&

--- a/test/DebugInfo/mem2reg-inlined-empty-tuple.sil
+++ b/test/DebugInfo/mem2reg-inlined-empty-tuple.sil
@@ -1,0 +1,32 @@
+// RUN: %target-sil-opt -sil-print-debuginfo -mem2reg -verify %s | %FileCheck %s
+
+// Check that SILMem2Reg on empty tuples.
+
+// See rdar://171023691
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+sil_scope 1 { loc "outer.swift":1:1 parent @testMem2RegInlinedScope : $@convention(thin) () -> () }
+sil_scope 2 { loc "inner.swift":2:2 parent @inlinedCallee : $@convention(thin) () -> () }
+sil_scope 3 { loc "inner.swift":3:3 parent 2 inlined_at 1 }
+
+sil @testMem2RegInlinedScope : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $(), var, name "local", loc "outer.swift":10:9, scope 1
+
+  // CHECK: sil_scope [[OUTER_SCOPE:[0-9]+]] { {{.*}} @testMem2RegInlinedScope
+  // CHECK-LABEL: sil @testMem2RegInlinedScope
+  // CHECK: debug_value {{.*}} scope [[OUTER_SCOPE]]
+  // CHECK: return %0
+
+  // This is a load from a different alloca that is now directly accessing the
+  // alloca above (e.g., because of inlining). This should not be used to
+  // describe "local" as it actually loads from a different local.
+  %1 = load %0 : $*(), loc "inner.swift":3:3, scope 3
+
+  dealloc_stack %0 : $*()
+  return %1
+}


### PR DESCRIPTION


Commit 0ef2094279969bc8af96d5e3108d2443b5980c8e salvages more debug information
in Mem2Reg. It propagates the information from the alloc_stack to the replaced
load instructions.

However, there are cases where the loads from an alloca are not actually
representing loads from the respective local variable. One such case is
when there is mandatory inlining happening at the start of the pipeline.

For example, consider the example below where an identity function is inlined.
The resulting SIL will contain an alloca from the outer `result` and a load
that is the leftover after the closure (which is just a load of the passed
argument). The load that is created has its debug scope (correctly) in the
closure scope, but the loaded alloc_stack is actually the outer local variable.
The intermediate `result` that is passed to the closure is getting eliminated
by the inliner.

```
  let result = try await ... // becomes empty tuple.
  return withExtendedLifetime((...)) {
     result
  }
```

This patch just guards against this case in the SILMem2Reg transformation
by checking whether the scope and debug variable are from the same function
(before inlining).

Fixes rdar://171023691