### PR TITLE
Make the OSLog string section name configuration via `-oslog-string-section-name`

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -644,6 +644,9 @@ public:
   /// Generate verbose assembly output with comments.
   bool VerboseAsm = true;
 
+  /// Which section to emit OSLog strings into.
+  std::string OSLogStringSectionName = "__TEXT,__oslogstring,cstring_literals";
+
   IRGenOptions()
       : OutputKind(IRGenOutputKind::LLVMAssemblyAfterOptimization),
         Verify(true), VerifyEach(false), OptMode(OptimizationMode::NotSet),

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -2457,4 +2457,11 @@ def enable_deterministic_check :
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild, CacheInvariant]>,
   HelpText<"Check compiler output determinism by running it twice">;
 
+def oslog_string_section_name:
+  Separate<["-"], "oslog-string-section-name">,
+  Flags<[FrontendOption]>,
+  HelpText<"Section name to use for OSLog string literals. "
+           "Defaults to '__TEXT,__oslogstring',cstring_literals">,
+  MetaVarName<"<section-name>">;
+
 include "FrontendOptions.td"

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -4193,6 +4193,10 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
     Diags.diagnose(SourceLoc(), diag::warn_flag_deprecated,
                    "-mergeable-symbols");
 
+  if (Arg *A = Args.getLastArg(OPT_oslog_string_section_name)) {
+    Opts.OSLogStringSectionName = A->getValue();
+  }
+
   return false;
 }
 

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -6154,7 +6154,7 @@ IRGenModule::getAddrOfGlobalString(StringRef data, CStringSectionType type,
     sectionName = ObjCMethodTypeSectionName;
     break;
   case CStringSectionType::OSLogString:
-    sectionName = OSLogStringSectionName;
+    sectionName = getOptions().OSLogStringSectionName;
     break;
   case CStringSectionType::NumTypes:
     llvm_unreachable("invalid type");

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1573,8 +1573,6 @@ public:
       "__TEXT,__objc_methname,cstring_literals";
   static constexpr const char ObjCMethodTypeSectionName[] =
       "__TEXT,__objc_methtype,cstring_literals";
-  static constexpr const char OSLogStringSectionName[] =
-      "__TEXT,__oslogstring,cstring_literals";
 
   /// Returns the special builtin types that should be emitted in the stdlib
   /// module.

--- a/test/IRGen/oslog_literals.sil
+++ b/test/IRGen/oslog_literals.sil
@@ -1,8 +1,11 @@
 // RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
 
+// RUN: %target-swift-frontend -emit-ir -oslog-string-section-name __TEXT,__logit %s | %FileCheck -check-prefix OTHER-SECTION %s
+
 // REQUIRES: OS=macosx || OS=ios || OS=watchos
 
 // CHECK: [[U8_0:@.*]] = private unnamed_addr constant [8 x i8] c"help\09me\00", section "__TEXT,__oslogstring,cstring_literals"
+// OTHER-SECTION: [[U8_0:@.*]] = private unnamed_addr constant [8 x i8] c"help\09me\00", section "__TEXT,__logit"
 
 sil_stage canonical
 


### PR DESCRIPTION
Other platforms might choose to use different sections, so let them configure appropriately. Implements rdar://171571056