### PR TITLE
[6.3][CMake] Avoid 'swiftc -parse' with stdin to check compiler capability

### DIFF
--- a/cmake/modules/SwiftCompilerCapability.cmake
+++ b/cmake/modules/SwiftCompilerCapability.cmake
@@ -2,8 +2,7 @@
 function(swift_supports_compiler_arguments out_var)
   file(WRITE "${CMAKE_BINARY_DIR}/tmp/dummy.swift" "")
   execute_process(
-    COMMAND "${CMAKE_Swift_COMPILER}" -parse ${ARGN} -
-    INPUT_FILE "${CMAKE_BINARY_DIR}/tmp/dummy.swift"
+    COMMAND "${CMAKE_Swift_COMPILER}" -parse ${ARGN} "${CMAKE_BINARY_DIR}/tmp/dummy.swift"
     OUTPUT_QUIET ERROR_QUIET
     RESULT_VARIABLE result
   )


### PR DESCRIPTION
Cherry-pick #87653 into release/6.3

* **Explanation**: Previously, we checked the host compiler's capabilities by invoking: `swiftc -parse -` with a dummy input via stdin. However, when the host compiler is built with assertions enabled, this triggers an assertion failure, causing all capability checks to fail. Although this is technically a compiler bug, this change works around the issue by using a regular file input instead `swiftc -parse dummy.swift`
* **Scope**: swift-syntax libraries in the compiler
* **Risk**: Low. The macOS toolchain has already been built with correct capabilities, because the host compiler is not assertion enabled.
* **Testing**: Passes the existing test-suite
* **Issue**: rdar://171655848
* **Reviewer**: Hamish Knight (@hamishknight)