### PR TITLE
stdlib: Remove superfluous SwiftStdlib 6.3 availability checks

### DIFF
--- a/stdlib/public/Concurrency/ContinuousClock.swift
+++ b/stdlib/public/Concurrency/ContinuousClock.swift
@@ -113,13 +113,9 @@ extension ContinuousClock: Clock {
   public func sleep(
     until deadline: Instant, tolerance: Swift.Duration? = nil
   ) async throws {
-    if #available(StdlibDeploymentTarget 6.3, *) {
-      try await Task._sleep(until: deadline,
-                            tolerance: tolerance,
-                            clock: self)
-    } else {
-      fatalError("we should never get here; if we have, availability is broken")
-    }
+    try await Task._sleep(until: deadline,
+                          tolerance: tolerance,
+                          clock: self)
   }
 #else
   @available(StdlibDeploymentTarget 5.7, *)

--- a/stdlib/public/Concurrency/ExecutorImpl.swift
+++ b/stdlib/public/Concurrency/ExecutorImpl.swift
@@ -24,12 +24,8 @@ import Swift
 @_silgen_name("swift_task_asyncMainDrainQueueImpl")
 internal func drainMainQueue() {
   #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
-  if #available(StdlibDeploymentTarget 6.3, *) {
-    try! MainActor.executor.run()
-    _exit(result: 0)
-  } else {
-    fatalError("this should never happen")
-  }
+  try! MainActor.executor.run()
+  _exit(result: 0)
   #else
   fatalError("swift_task_asyncMainDrainQueue() not supported with task-to-thread")
   #endif
@@ -41,36 +37,24 @@ internal func donateToGlobalExecutor(
   condition: @convention(c) (_ ctx: UnsafeMutableRawPointer) -> CBool,
   context: UnsafeMutableRawPointer
 ) {
-  if #available(StdlibDeploymentTarget 6.3, *) {
-    if let runnableExecutor = Task.defaultExecutor as? RunLoopExecutor {
-      try! runnableExecutor.runUntil { unsafe Bool(condition(context)) }
-    } else {
-      fatalError("Global executor does not support thread donation")
-    }
+  if let runnableExecutor = Task.defaultExecutor as? RunLoopExecutor {
+    try! runnableExecutor.runUntil { unsafe Bool(condition(context)) }
   } else {
-    fatalError("this should never happen")
+    fatalError("Global executor does not support thread donation")
   }
 }
 
 @available(SwiftStdlib 6.2, *)
 @_silgen_name("swift_task_getMainExecutorImpl")
 internal func getMainExecutor() -> UnownedSerialExecutor {
-  if #available(StdlibDeploymentTarget 6.3, *) {
-    return unsafe _getMainExecutorAsSerialExecutor()
-  } else {
-    fatalError("this should never happen")
-  }
+  return unsafe _getMainExecutorAsSerialExecutor()
 }
 
 @available(SwiftStdlib 6.2, *)
 @_silgen_name("swift_task_enqueueMainExecutorImpl")
 internal func enqueueOnMainExecutor(job unownedJob: UnownedJob) {
   #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
-  if #available(StdlibDeploymentTarget 6.3, *) {
-    MainActor.executor.enqueue(unownedJob)
-  } else {
-    fatalError("this should never happen")
-  }
+  MainActor.executor.enqueue(unownedJob)
   #else
   fatalError("swift_task_enqueueMainExecutor() not supported for task-to-thread")
   #endif
@@ -79,11 +63,7 @@ internal func enqueueOnMainExecutor(job unownedJob: UnownedJob) {
 @available(SwiftStdlib 6.2, *)
 @_silgen_name("swift_task_enqueueGlobalImpl")
 internal func enqueueOnGlobalExecutor(job unownedJob: UnownedJob) {
-  if #available(StdlibDeploymentTarget 6.3, *) {
-    Task.defaultExecutor.enqueue(unownedJob)
-  } else {
-    fatalError("this should never happen")
-  }
+  Task.defaultExecutor.enqueue(unownedJob)
 }
 
 #if !$Embedded
@@ -92,13 +72,9 @@ internal func enqueueOnGlobalExecutor(job unownedJob: UnownedJob) {
 internal func enqueueOnGlobalExecutor(delay: CUnsignedLongLong,
                                       job unownedJob: UnownedJob) {
   #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
-  if #available(StdlibDeploymentTarget 6.3, *) {
-    Task.defaultExecutor.asSchedulingExecutor!.enqueue(ExecutorJob(unownedJob),
-                                                       after: .nanoseconds(delay),
-                                                       clock: .continuous)
-  } else {
-    fatalError("this should never happen")
-  }
+  Task.defaultExecutor.asSchedulingExecutor!.enqueue(ExecutorJob(unownedJob),
+                                                     after: .nanoseconds(delay),
+                                                     clock: .continuous)
   #else
   fatalError("swift_task_enqueueGlobalWithDelay() not supported for task-to-thread")
   #endif
@@ -115,27 +91,23 @@ internal func enqueueOnGlobalExecutor(seconds: CLongLong,
   #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
   let delay = Duration.seconds(seconds) + Duration.nanoseconds(nanoseconds)
   let leeway = Duration.seconds(leewaySeconds) + Duration.nanoseconds(leewayNanoseconds)
-  if #available(StdlibDeploymentTarget 6.3, *) {
-    switch clock {
-      case _ClockID.suspending.rawValue:
-        Task.defaultExecutor.asSchedulingExecutor!.enqueue(
-          ExecutorJob(unownedJob),
-          after: delay,
-          tolerance: leeway,
-          clock: .suspending
-        )
-      case _ClockID.continuous.rawValue:
-        Task.defaultExecutor.asSchedulingExecutor!.enqueue(
-          ExecutorJob(unownedJob),
-          after: delay,
-          tolerance: leeway,
-          clock: .continuous
-        )
-      default:
-        fatalError("Unknown clock ID \(clock)")
-    }
-  } else {
-    fatalError("this should never happen")
+  switch clock {
+    case _ClockID.suspending.rawValue:
+      Task.defaultExecutor.asSchedulingExecutor!.enqueue(
+        ExecutorJob(unownedJob),
+        after: delay,
+        tolerance: leeway,
+        clock: .suspending
+      )
+    case _ClockID.continuous.rawValue:
+      Task.defaultExecutor.asSchedulingExecutor!.enqueue(
+        ExecutorJob(unownedJob),
+        after: delay,
+        tolerance: leeway,
+        clock: .continuous
+      )
+    default:
+      fatalError("Unknown clock ID \(clock)")
   }
   #else
   fatalError("swift_task_enqueueGlobalWithDeadline() not supported for task-to-thread")

--- a/stdlib/public/Concurrency/GlobalConcurrentExecutor.swift
+++ b/stdlib/public/Concurrency/GlobalConcurrentExecutor.swift
@@ -34,11 +34,7 @@ import Swift
 @_unavailableInEmbedded
 public var globalConcurrentExecutor: any TaskExecutor {
   get {
-    if #available(StdlibDeploymentTarget 6.3, *) {
-      return Task.defaultExecutor
-    } else {
-      fatalError("we shouldn't get here; if we have, availability is broken")
-    }
+    Task.defaultExecutor
   }
 }
 

--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -87,13 +87,7 @@ public struct UnownedJob: Sendable {
   /// The priority of this job.
   @available(StdlibDeploymentTarget 5.9, *)
   public var priority: JobPriority {
-    let raw: UInt8
-    if #available(StdlibDeploymentTarget 6.3, *) {
-      raw = _jobGetPriority(context)
-    } else {
-      fatalError("we shouldn't get here; if we have, availability is broken")
-    }
-    return JobPriority(rawValue: raw)
+    JobPriority(rawValue: _jobGetPriority(context))
   }
 
   @available(StdlibDeploymentTarget 5.9, *)
@@ -226,13 +220,7 @@ public struct Job: Sendable, ~Copyable {
   }
 
   public var priority: JobPriority {
-    let raw: UInt8
-    if #available(StdlibDeploymentTarget 6.3, *) {
-      raw = _jobGetPriority(self.context)
-    } else {
-      fatalError("we shouldn't get here; if we have, availability is broken")
-    }
-    return JobPriority(rawValue: raw)
+    return JobPriority(rawValue: _jobGetPriority(self.context))
   }
 
   // TODO: move only types cannot conform to protocols, so we can't conform to CustomStringConvertible;
@@ -300,20 +288,10 @@ public struct ExecutorJob: Sendable, ~Copyable {
 
   internal(set) public var priority: JobPriority {
     get {
-      let raw: UInt8
-      if #available(StdlibDeploymentTarget 6.3, *) {
-        raw = _jobGetPriority(self.context)
-      } else {
-        fatalError("we shouldn't get here; if we have, availability is broken")
-      }
-      return JobPriority(rawValue: raw)
+      JobPriority(rawValue: _jobGetPriority(self.context))
     }
     set {
-      if #available(StdlibDeploymentTarget 6.3, *) {
-        _jobSetPriority(self.context, newValue.rawValue)
-      } else {
-        fatalError("we shouldn't get here; if we have, availability is broken")
-      }
+      _jobSetPriority(self.context, newValue.rawValue)
     }
   }
 

--- a/stdlib/public/Concurrency/SuspendingClock.swift
+++ b/stdlib/public/Concurrency/SuspendingClock.swift
@@ -101,13 +101,9 @@ extension SuspendingClock: Clock {
   public func sleep(
     until deadline: Instant, tolerance: Swift.Duration? = nil
   ) async throws {
-    if #available(StdlibDeploymentTarget 6.3, *) {
-      try await Task._sleep(until: deadline,
-                            tolerance: tolerance,
-                            clock: self)
-    } else {
-      fatalError("we shouldn't get here; if we have, availability is broken")
-    }
+    try await Task._sleep(until: deadline,
+                          tolerance: tolerance,
+                          clock: self)
   }
 #else
   @available(StdlibDeploymentTarget 5.7, *)

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -658,13 +658,9 @@ extension Task where Success == Never, Failure == Never {
           continuation: continuation)
 
       #if !$Embedded && !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
-      if #available(StdlibDeploymentTarget 6.3, *) {
-        let executor = Task.currentExecutor
+      let executor = Task.currentExecutor
 
-        executor.enqueue(ExecutorJob(context: job))
-      } else {
-        fatalError("we shouldn't get here; if we have, availability is broken")
-      }
+      executor.enqueue(ExecutorJob(context: job))
       #else
       _enqueueJobGlobal(job)
       #endif
@@ -992,11 +988,7 @@ internal func _runAsyncMain(_ asyncFun: @Sendable @escaping () async throws -> (
   }
 
   let job = Builtin.convertTaskToJob(theTask)
-  if #available(StdlibDeploymentTarget 6.3, *) {
-    MainActor.executor.enqueue(ExecutorJob(context: job))
-  } else {
-    fatalError("we shouldn't get here; if we have, availability is broken")
-  }
+  MainActor.executor.enqueue(ExecutorJob(context: job))
 
   _asyncMainDrainQueue()
 }

--- a/stdlib/public/Concurrency/TaskSleep.swift
+++ b/stdlib/public/Concurrency/TaskSleep.swift
@@ -28,16 +28,14 @@ extension Task where Success == Never, Failure == Never {
           priority: Int(Task.currentPriority.rawValue),
           continuation: continuation)
 
-      if #available(StdlibDeploymentTarget 6.3, *) {
-        #if !$Embedded
-        if let executor = Task.currentSchedulingExecutor {
-          executor.enqueue(ExecutorJob(context: job),
-                           after: .nanoseconds(duration),
-                           clock: .continuous)
-          return
-        }
-        #endif
+      #if !$Embedded
+      if let executor = Task.currentSchedulingExecutor {
+        executor.enqueue(ExecutorJob(context: job),
+                         after: .nanoseconds(duration),
+                         clock: .continuous)
+        return
       }
+      #endif
 
       // If there is no current scheduling executor, fall back to
       // _enqueueJobGlobalWithDelay()
@@ -272,16 +270,14 @@ extension Task where Success == Never, Failure == Never {
 
               let job = Builtin.convertTaskToJob(sleepTask)
 
-              if #available(StdlibDeploymentTarget 6.3, *) {
-                #if !$Embedded
-                if let executor = Task.currentSchedulingExecutor {
-                  executor.enqueue(ExecutorJob(context: job),
-                                   after: .nanoseconds(duration),
-                                   clock: .continuous)
-                  return
-                }
-                #endif
+              #if !$Embedded
+              if let executor = Task.currentSchedulingExecutor {
+                executor.enqueue(ExecutorJob(context: job),
+                                 after: .nanoseconds(duration),
+                                 clock: .continuous)
+                return
               }
+              #endif
 
               // If there is no current scheduling executor, fall back to
               // _enqueueJobGlobalWithDelay()

--- a/stdlib/public/Concurrency/TaskSleepDuration.swift
+++ b/stdlib/public/Concurrency/TaskSleepDuration.swift
@@ -116,19 +116,15 @@ extension Task where Success == Never, Failure == Never {
 
               let job = Builtin.convertTaskToJob(sleepTask)
 
-              if #available(StdlibDeploymentTarget 6.3, *) {
-                #if !$Embedded
-                if let executor = Task.currentSchedulingExecutor {
-                  executor.enqueue(ExecutorJob(context: job),
-                                   at: instant,
-                                   tolerance: tolerance,
-                                   clock: clock)
-                  return
-                }
-                #endif
-              } else {
-                fatalError("we shouldn't get here; if we have, availability is broken")
+              #if !$Embedded
+              if let executor = Task.currentSchedulingExecutor {
+                executor.enqueue(ExecutorJob(context: job),
+                                 at: instant,
+                                 tolerance: tolerance,
+                                 clock: clock)
+                return
               }
+              #endif
 
               // If there is no current scheduling executor, fall back to
               // calling _enqueueJobGlobalWithDeadline().
@@ -136,26 +132,18 @@ extension Task where Success == Never, Failure == Never {
                                                               clock: clock)
               let toleranceSeconds: Int64
               let toleranceNanoseconds: Int64
-              if #available(StdlibDeploymentTarget 6.3, *) {
-                if let tolerance = tolerance {
-                  (toleranceSeconds, toleranceNanoseconds)
-                    = durationComponents(for: tolerance, clock: clock)
-                } else {
-                  toleranceSeconds = 0
-                  toleranceNanoseconds = -1
-                }
+              if let tolerance = tolerance {
+                (toleranceSeconds, toleranceNanoseconds)
+                  = durationComponents(for: tolerance, clock: clock)
               } else {
-                fatalError("we shouldn't get here; if we have, availability is broken")
+                toleranceSeconds = 0
+                toleranceNanoseconds = -1
               }
 
-              if #available(StdlibDeploymentTarget 5.9, *) {
-                _enqueueJobGlobalWithDeadline(
-                  seconds, nanoseconds,
-                  toleranceSeconds, toleranceNanoseconds,
-                  clockID.rawValue, UnownedJob(context: job))
-              } else {
-                fatalError("we shouldn't get here; if we have, availability is broken")
-              }
+              _enqueueJobGlobalWithDeadline(
+                seconds, nanoseconds,
+                toleranceSeconds, toleranceNanoseconds,
+                clockID.rawValue, UnownedJob(context: job))
               return
 
             case .activeContinuation, .finished:

--- a/stdlib/public/core/StringWordBreaking.swift
+++ b/stdlib/public/core/StringWordBreaking.swift
@@ -707,9 +707,6 @@ extension String {
   /// - Returns: The first word break strictly following `i` in the string.
   @available(StdlibDeploymentTarget 5.7, *)
   public func _wordIndex(after i: String.Index) -> String.Index {
-    guard #available(StdlibDeploymentTarget 6.3, *) else {
-      fatalError("Unreachable")
-    }
     let i = _guts.validateScalarIndex(i)
     if _slowPath(_guts.isForeign) {
       return _guts._nextForeignWordIndex(after: i)
@@ -719,7 +716,6 @@ extension String {
 }
 
 extension _StringGuts {
-  @available(StdlibDeploymentTarget 6.3, *)
   @inline(never)
   @_effects(releasenone)
   internal func _nextUTF8WordIndex(after index: Index) -> Index {
@@ -752,7 +748,6 @@ extension _StringGuts {
     return Index(_encodedOffset: result)._scalarAligned._knownUTF8
   }
 
-  @available(StdlibDeploymentTarget 6.3, *)
   @inline(never)
   internal func _nextForeignWordIndex(after index: Index) -> Index {
     #if _runtime(_ObjC)


### PR DESCRIPTION
After https://github.com/swiftlang/swift/pull/87510, `if #available(StdlibDeploymentTarget 6.3, *)` checks inside the implementation of the stdlib are no longer necessary to satisfy the availability checker and instead cause warnings to be emitted. Remove the now superfluous checks.