### PR TITLE
[SILGen] Mark sending as Direct_Unowned for objc bridges

### DIFF
--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1456,6 +1456,14 @@ public:
   getIndirectSelfParameter(const AbstractionPattern &type) const = 0;
   virtual ParameterConvention
   getDirectSelfParameter(const AbstractionPattern &type) const = 0;
+  // Returns the convention for a parameter with explicit Owned ownership
+  // (e.g. `sending`). Defaults to Direct_Owned; ObjC conventions override
+  // to Direct_Unowned because objc_msgSend always delivers at +0.
+  virtual ParameterConvention
+  getDirectOwnedParameter(unsigned index, const AbstractionPattern &type,
+                          const TypeLowering &substTL) const {
+    return ParameterConvention::Direct_Owned;
+  }
   virtual ParameterConvention getPackParameter(unsigned index) const = 0;
 
   // Helpers that branch based on a value ownership.
@@ -1519,7 +1527,7 @@ public:
     case ValueOwnership::Shared:
       return ParameterConvention::Direct_Guaranteed;
     case ValueOwnership::Owned:
-      return ParameterConvention::Direct_Owned;
+      return getDirectOwnedParameter(index, type, substTL);
     }
     llvm_unreachable("unhandled ownership");
   }
@@ -2164,20 +2172,6 @@ private:
       convention = Convs.getDirect(ownership, forSelf, origParamIndex, origType,
                                    substTLConv);
       assert(!isIndirectFormalParameter(convention));
-    }
-
-    // ObjC methods deliver arguments at +0. When a `sending` parameter 
-    // promotes ownership to Owned, the thunk would receive `@owned` butt the 
-    // caller (objc_msgSend) passes +0, causing a double-free.
-    //
-    // Override to Direct_Unowned so the thunk emits a copy_value before
-    // forwarding to the Swift body.
-    if (origFlags.isSending() &&
-        ownership == ValueOwnership::Owned &&
-        convention == ParameterConvention::Direct_Owned &&
-        (Convs.getKind() == ConventionsKind::ObjCSelectorFamily ||
-         Convs.getKind() == ConventionsKind::ObjCMethod)) {
-      convention = ParameterConvention::Direct_Unowned;
     }
 
     addParameter(formalParamIndex, loweredType, convention, origFlags);
@@ -3870,6 +3864,15 @@ public:
     return getDirectCParameterConvention(Method->param_begin()[index]);
   }
 
+  // ObjC methods deliver all arguments at +0 via objc_msgSend.
+  // Swift-only ownership annotations like `sending` promote to
+  // ValueOwnership::Owned, but the ObjC caller doesn't know about them.
+  ParameterConvention getDirectOwnedParameter(
+      unsigned index, const AbstractionPattern &type,
+      const TypeLowering &substTL) const override {
+    return ParameterConvention::Direct_Unowned;
+  }
+
   ParameterConvention getPackParameter(unsigned index) const override {
     llvm_unreachable("objc methods do not have pack parameters");
   }
@@ -4420,6 +4423,13 @@ public:
   ParameterConvention getDirectParameter(unsigned index,
                                          const AbstractionPattern &type,
                                  const TypeLowering &substTL) const override {
+    return ParameterConvention::Direct_Unowned;
+  }
+
+  // ObjC methods deliver all arguments at +0 via objc_msgSend.
+  ParameterConvention getDirectOwnedParameter(
+      unsigned index, const AbstractionPattern &type,
+      const TypeLowering &substTL) const override {
     return ParameterConvention::Direct_Unowned;
   }
 

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -2166,6 +2166,20 @@ private:
       assert(!isIndirectFormalParameter(convention));
     }
 
+    // ObjC methods deliver arguments at +0. When a `sending` parameter 
+    // promotes ownership to Owned, the thunk would receive `@owned` butt the 
+    // caller (objc_msgSend) passes +0, causing a double-free.
+    //
+    // Override to Direct_Unowned so the thunk emits a copy_value before
+    // forwarding to the Swift body.
+    if (origFlags.isSending() &&
+        ownership == ValueOwnership::Owned &&
+        convention == ParameterConvention::Direct_Owned &&
+        (Convs.getKind() == ConventionsKind::ObjCSelectorFamily ||
+         Convs.getKind() == ConventionsKind::ObjCMethod)) {
+      convention = ParameterConvention::Direct_Unowned;
+    }
+
     addParameter(formalParamIndex, loweredType, convention, origFlags);
   }
 

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1459,9 +1459,7 @@ public:
   // Returns the convention for a parameter with explicit Owned ownership
   // (e.g. `sending`). Defaults to Direct_Owned; ObjC conventions override
   // to Direct_Unowned because objc_msgSend always delivers at +0.
-  virtual ParameterConvention
-  getDirectOwnedParameter(unsigned index, const AbstractionPattern &type,
-                          const TypeLowering &substTL) const {
+  virtual ParameterConvention getDirectOwnedParameter() const {
     return ParameterConvention::Direct_Owned;
   }
   virtual ParameterConvention getPackParameter(unsigned index) const = 0;
@@ -1527,7 +1525,7 @@ public:
     case ValueOwnership::Shared:
       return ParameterConvention::Direct_Guaranteed;
     case ValueOwnership::Owned:
-      return getDirectOwnedParameter(index, type, substTL);
+      return getDirectOwnedParameter();
     }
     llvm_unreachable("unhandled ownership");
   }
@@ -3867,9 +3865,7 @@ public:
   // ObjC methods deliver all arguments at +0 via objc_msgSend.
   // Swift-only ownership annotations like `sending` promote to
   // ValueOwnership::Owned, but the ObjC caller doesn't know about them.
-  ParameterConvention getDirectOwnedParameter(
-      unsigned index, const AbstractionPattern &type,
-      const TypeLowering &substTL) const override {
+  ParameterConvention getDirectOwnedParameter() const override {
     return ParameterConvention::Direct_Unowned;
   }
 
@@ -4427,9 +4423,7 @@ public:
   }
 
   // ObjC methods deliver all arguments at +0 via objc_msgSend.
-  ParameterConvention getDirectOwnedParameter(
-      unsigned index, const AbstractionPattern &type,
-      const TypeLowering &substTL) const override {
+  ParameterConvention getDirectOwnedParameter() const override {
     return ParameterConvention::Direct_Unowned;
   }
 

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1456,13 +1456,12 @@ public:
   getIndirectSelfParameter(const AbstractionPattern &type) const = 0;
   virtual ParameterConvention
   getDirectSelfParameter(const AbstractionPattern &type) const = 0;
-  // Returns the convention for a parameter with explicit Owned ownership
-  // (e.g. `sending`). Defaults to Direct_Owned; ObjC conventions override
-  // to Direct_Unowned because objc_msgSend always delivers at +0.
-  virtual ParameterConvention getDirectOwnedParameter() const {
-    return ParameterConvention::Direct_Owned;
-  }
   virtual ParameterConvention getPackParameter(unsigned index) const = 0;
+
+  bool isObjCConvention() const {
+    return kind == ConventionsKind::ObjCMethod ||
+           kind == ConventionsKind::ObjCSelectorFamily;
+  }
 
   // Helpers that branch based on a value ownership.
   ParameterConvention getIndirect(ValueOwnership ownership, bool forSelf,
@@ -1525,7 +1524,7 @@ public:
     case ValueOwnership::Shared:
       return ParameterConvention::Direct_Guaranteed;
     case ValueOwnership::Owned:
-      return getDirectOwnedParameter();
+      return ParameterConvention::Direct_Owned;
     }
     llvm_unreachable("unhandled ownership");
   }
@@ -2170,6 +2169,16 @@ private:
       convention = Convs.getDirect(ownership, forSelf, origParamIndex, origType,
                                    substTLConv);
       assert(!isIndirectFormalParameter(convention));
+    }
+
+    // ObjC methods deliver all arguments at +0 via objc_msgSend. `sending`
+    // is a Swift-only annotation invisible to ObjC, so a `sending` parameter
+    // that was promoted to Direct_Owned must be lowered to Direct_Unowned
+    // for ObjC thunks. The thunk will then emit the necessary copy_value.
+    // Note: regular `consuming` (ns_consumed) parameters stay Direct_Owned.
+    if (convention == ParameterConvention::Direct_Owned &&
+        origFlags.isSending() && Convs.isObjCConvention()) {
+      convention = ParameterConvention::Direct_Unowned;
     }
 
     addParameter(formalParamIndex, loweredType, convention, origFlags);
@@ -3862,13 +3871,6 @@ public:
     return getDirectCParameterConvention(Method->param_begin()[index]);
   }
 
-  // ObjC methods deliver all arguments at +0 via objc_msgSend.
-  // Swift-only ownership annotations like `sending` promote to
-  // ValueOwnership::Owned, but the ObjC caller doesn't know about them.
-  ParameterConvention getDirectOwnedParameter() const override {
-    return ParameterConvention::Direct_Unowned;
-  }
-
   ParameterConvention getPackParameter(unsigned index) const override {
     llvm_unreachable("objc methods do not have pack parameters");
   }
@@ -4419,11 +4421,6 @@ public:
   ParameterConvention getDirectParameter(unsigned index,
                                          const AbstractionPattern &type,
                                  const TypeLowering &substTL) const override {
-    return ParameterConvention::Direct_Unowned;
-  }
-
-  // ObjC methods deliver all arguments at +0 via objc_msgSend.
-  ParameterConvention getDirectOwnedParameter() const override {
     return ParameterConvention::Direct_Unowned;
   }
 

--- a/test/SILGen/Inputs/objc_sending.h
+++ b/test/SILGen/Inputs/objc_sending.h
@@ -1,0 +1,9 @@
+@import Foundation;
+
+#define SWIFT_SENDABLE __attribute__((swift_attr("@Sendable")))
+#define SWIFT_SENDING __attribute__((swift_attr("sending")))
+
+SWIFT_SENDABLE
+@protocol ObjCHandlerWithSending <NSObject>
+- (void)handle:(NSObject * SWIFT_SENDING)value;
+@end

--- a/test/SILGen/Inputs/objc_sending.h
+++ b/test/SILGen/Inputs/objc_sending.h
@@ -1,4 +1,4 @@
-@import Foundation;
+@import ObjectiveC;
 
 #define SWIFT_SENDABLE __attribute__((swift_attr("@Sendable")))
 #define SWIFT_SENDING __attribute__((swift_attr("sending")))

--- a/test/SILGen/objc_sending.swift
+++ b/test/SILGen/objc_sending.swift
@@ -2,42 +2,77 @@
 
 // REQUIRES: objc_interop
 
-// The @objc thunk incorrectly declares the `sending` parameter as @owned
-// (because `sending` promotes to ValueOwnership::Owned → Direct_Owned).
-// But ObjC delivers all arguments at +0 via objc_msgSend, so the thunk
-// forwards a +0 value where the native Swift body expects +1 → double-free.
+// Regression test for S623392: double-free when ObjC calls an @objc thunk
+// for a method with a `sending` parameter.
 //
-// This test captures the BUGGY behavior: the thunk receives %0 as @owned
-// but only emits copy_value for self (%1), not for the sending argument (%0).
-// The sending argument is forwarded directly without a retain — unbalanced.
+// Root cause: the type checker promotes `sending` → ImplicitlyCopyableConsuming
+// → ValueOwnership::Owned → Direct_Owned convention. But ObjC doesn't know
+// about `sending` and always delivers at +0. The thunk saw @owned, skipped the
+// retain, and forwarded +0 to the Swift entry point expecting +1 → double-free.
+//
+// Fix (SILFunctionType.cpp): override Direct_Owned → Direct_Unowned for ObjC
+// methods with `sending` parameters. The thunk parameter becomes @unowned, so
+// emitObjCUnconsumedArgument emits a copy_value (retain) before forwarding.
+
+// ============================================================================
+// Case 1: Swift class conforming to ObjC protocol with `sending` parameter.
+// This exercises ObjCMethodConventions (the Clang declaration exists).
+// ============================================================================
 
 class Handler: NSObject, ObjCHandlerWithSending {
   func handle(_ value: sending NSObject) {}
 }
 
-// The native Swift entry point correctly expects @sil_sending @owned.
+// The native Swift entry point expects @sil_sending @owned.
 // CHECK-LABEL: sil hidden [ossa] @$s12objc_sending7HandlerC6handleyySo8NSObjectCnF : $@convention(method) (@sil_sending @owned NSObject, @guaranteed Handler) -> ()
 
-// The @objc thunk — this is where the bug manifests.
+// The @objc thunk must receive the sending param as @unowned and retain it.
 //
-// BUG: The thunk declares @sil_sending @owned, but ObjC delivers at +0.
-//      Only self gets copy_value; the sending param does NOT.
-//      The sending param is forwarded to the native body without a retain,
-//      causing a double-free when the native body consumes it.
+// Before the fix, the thunk was:
+//   bb0(%0 : @owned $NSObject, %1 : @unowned $Handler):
+//     %2 = copy_value %1           // only self copied — no retain on %0
+//     apply %4(%0, %3)             // forwards +0 where +1 expected — BUG
 //
-// CHECK-LABEL: sil private [thunk] [ossa] @$s12objc_sending7HandlerC6handleyySo8NSObjectCnFTo : $@convention(objc_method) (@sil_sending @owned NSObject, Handler) -> () {
+// After the fix:
+//   bb0(%0 : @unowned $NSObject, %1 : @unowned $Handler):
+//     %2 = copy_value %0           // retain sending param +0 → +1
+//     %3 = copy_value %1           // retain self
+//     apply %5(%2, %4)             // forwards +1 copy — correct
 //
-//   %0 is @owned — but ObjC actually delivered it at +0. This is the bug.
-// CHECK: bb0(%0 : @owned $NSObject, %1 : @unowned $Handler):
-//
-//   Only self (%1) gets a copy_value. The sending param (%0) does NOT.
-// CHECK-NEXT:   [[SELF_COPY:%.*]] = copy_value %1 : $Handler
+// CHECK-LABEL: sil private [thunk] [ossa] @$s12objc_sending7HandlerC6handleyySo8NSObjectCnFTo : $@convention(objc_method) (@sil_sending NSObject, Handler) -> () {
+// CHECK: bb0([[SENDING_ARG:%.*]] : @unowned $NSObject, [[SELF_ARG:%.*]] : @unowned $Handler):
+// CHECK-NEXT:   [[SENDING_COPY:%.*]] = copy_value [[SENDING_ARG]] : $NSObject
+// CHECK-NEXT:   [[SELF_COPY:%.*]] = copy_value [[SELF_ARG]] : $Handler
 // CHECK-NEXT:   [[SELF_BORROW:%.*]] = begin_borrow [[SELF_COPY]] : $Handler
-//
-//   %0 is forwarded directly to the native body without any retain.
-//   The native body will consume it (release), over-releasing the +0 value.
-// CHECK:        [[NATIVE:%.*]] = function_ref @$s12objc_sending7HandlerC6handleyySo8NSObjectCnF
-// CHECK-NEXT:   apply [[NATIVE]](%0, [[SELF_BORROW]])
+// CHECK:        [[NATIVE_FN:%.*]] = function_ref @$s12objc_sending7HandlerC6handleyySo8NSObjectCnF : $@convention(method) (@sil_sending @owned NSObject, @guaranteed Handler) -> ()
+// CHECK-NEXT:   apply [[NATIVE_FN]]([[SENDING_COPY]], [[SELF_BORROW]]) : $@convention(method) (@sil_sending @owned NSObject, @guaranteed Handler) -> ()
 // CHECK-NEXT:   end_borrow [[SELF_BORROW]] : $Handler
 // CHECK-NEXT:   destroy_value [[SELF_COPY]] : $Handler
+// CHECK:      } // end sil function
+
+// ============================================================================
+// Case 2: Pure Swift @objc method with `sending` — no ObjC header involved.
+// This exercises ObjCSelectorFamilyConventions (no clang::ObjCMethodDecl).
+// The same bug applies: ObjC callers deliver at +0, thunk must not assume +1.
+// ============================================================================
+
+import Foundation
+
+class Processor: NSObject {
+  @objc func process(_ value: sending NSObject) {}
+}
+
+// The native Swift entry point expects @sil_sending @owned.
+// CHECK-LABEL: sil hidden [ossa] @$s12objc_sending9ProcessorC7processyySo8NSObjectCnF : $@convention(method) (@sil_sending @owned NSObject, @guaranteed Processor) -> ()
+
+// The @objc thunk — same fix applies: sending param must be @unowned, not @owned.
+// CHECK-LABEL: sil private [thunk] [ossa] @$s12objc_sending9ProcessorC7processyySo8NSObjectCnFTo : $@convention(objc_method) (@sil_sending NSObject, Processor) -> () {
+// CHECK: bb0([[SENDING_ARG:%.*]] : @unowned $NSObject, [[SELF_ARG:%.*]] : @unowned $Processor):
+// CHECK-NEXT:   [[SENDING_COPY:%.*]] = copy_value [[SENDING_ARG]] : $NSObject
+// CHECK-NEXT:   [[SELF_COPY:%.*]] = copy_value [[SELF_ARG]] : $Processor
+// CHECK-NEXT:   [[SELF_BORROW:%.*]] = begin_borrow [[SELF_COPY]] : $Processor
+// CHECK:        [[NATIVE_FN:%.*]] = function_ref @$s12objc_sending9ProcessorC7processyySo8NSObjectCnF : $@convention(method) (@sil_sending @owned NSObject, @guaranteed Processor) -> ()
+// CHECK-NEXT:   apply [[NATIVE_FN]]([[SENDING_COPY]], [[SELF_BORROW]]) : $@convention(method) (@sil_sending @owned NSObject, @guaranteed Processor) -> ()
+// CHECK-NEXT:   end_borrow [[SELF_BORROW]] : $Processor
+// CHECK-NEXT:   destroy_value [[SELF_COPY]] : $Processor
 // CHECK:      } // end sil function

--- a/test/SILGen/objc_sending.swift
+++ b/test/SILGen/objc_sending.swift
@@ -1,0 +1,43 @@
+// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -Xllvm -sil-print-types -import-objc-header %S/Inputs/objc_sending.h %s | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+// The @objc thunk incorrectly declares the `sending` parameter as @owned
+// (because `sending` promotes to ValueOwnership::Owned → Direct_Owned).
+// But ObjC delivers all arguments at +0 via objc_msgSend, so the thunk
+// forwards a +0 value where the native Swift body expects +1 → double-free.
+//
+// This test captures the BUGGY behavior: the thunk receives %0 as @owned
+// but only emits copy_value for self (%1), not for the sending argument (%0).
+// The sending argument is forwarded directly without a retain — unbalanced.
+
+class Handler: NSObject, ObjCHandlerWithSending {
+  func handle(_ value: sending NSObject) {}
+}
+
+// The native Swift entry point correctly expects @sil_sending @owned.
+// CHECK-LABEL: sil hidden [ossa] @$s12objc_sending7HandlerC6handleyySo8NSObjectCnF : $@convention(method) (@sil_sending @owned NSObject, @guaranteed Handler) -> ()
+
+// The @objc thunk — this is where the bug manifests.
+//
+// BUG: The thunk declares @sil_sending @owned, but ObjC delivers at +0.
+//      Only self gets copy_value; the sending param does NOT.
+//      The sending param is forwarded to the native body without a retain,
+//      causing a double-free when the native body consumes it.
+//
+// CHECK-LABEL: sil private [thunk] [ossa] @$s12objc_sending7HandlerC6handleyySo8NSObjectCnFTo : $@convention(objc_method) (@sil_sending @owned NSObject, Handler) -> () {
+//
+//   %0 is @owned — but ObjC actually delivered it at +0. This is the bug.
+// CHECK: bb0(%0 : @owned $NSObject, %1 : @unowned $Handler):
+//
+//   Only self (%1) gets a copy_value. The sending param (%0) does NOT.
+// CHECK-NEXT:   [[SELF_COPY:%.*]] = copy_value %1 : $Handler
+// CHECK-NEXT:   [[SELF_BORROW:%.*]] = begin_borrow [[SELF_COPY]] : $Handler
+//
+//   %0 is forwarded directly to the native body without any retain.
+//   The native body will consume it (release), over-releasing the +0 value.
+// CHECK:        [[NATIVE:%.*]] = function_ref @$s12objc_sending7HandlerC6handleyySo8NSObjectCnF
+// CHECK-NEXT:   apply [[NATIVE]](%0, [[SELF_BORROW]])
+// CHECK-NEXT:   end_borrow [[SELF_BORROW]] : $Handler
+// CHECK-NEXT:   destroy_value [[SELF_COPY]] : $Handler
+// CHECK:      } // end sil function


### PR DESCRIPTION
##  Problem (see more in https://github.com/swiftlang/swift/issues/87659)

When a Swift method with a `sending` parameter is exposed to ObjC (either by conforming to an ObjC protocol or via @objc), the generated @objc thunk incorrectly declares the parameter as @owned. But objc_msgSend always delivers arguments at +0 — sending is a Swift-only annotation invisible to ObjC. The thunk forwards the +0 value to the native Swift body, which expects +1 and consumes (releases) it, causing a double-free.

##  Root cause chain:
  1. sending → ImplicitlyCopyableConsuming → ValueOwnership::Owned
  2. getDirect() in the Conventions base class hardcodes Owned → ParameterConvention::Direct_Owned
  3. This bypasses the virtual dispatch that ObjC convention subclasses use to return Direct_Unowned

##  Fix (SILFunctionType.cpp)

Add a virtual method getDirectOwnedParameter() to the Conventions base class, defaulting to Direct_Owned. Override it in ObjCMethodConventions and ObjCSelectorFamilyConventions to return Direct_Unowned, matching the +0 ABI of objc_msgSend. Change getDirect() to call this virtual method instead of hardcoding Direct_Owned.

This mirrors the existing pattern where getDirectParameter() is already virtual and overridden by ObjC conventions — the fix extends this to the Owned case.

##  Test

  Two test cases covering both code paths:
  - Case 1 (Handler): Swift class conforming to an ObjC protocol with sending — exercises ObjCMethodConventions
  - Case 2 (Processor): Pure Swift @objc method with sending — exercises ObjCSelectorFamilyConventions

Both verify the thunk receives the sending parameter as @unowned and emits copy_value before forwarding.

[Assisted-by](https://t.ly/Dkjjk): [Claude Opus 4.6](https://www.anthropic.com/news/claude-opus-4-6)


Resolves #87659 