### PR TITLE
ModuleInterface: Don't print imports for any bridging header

### DIFF
--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -330,7 +330,8 @@ static void printImports(raw_ostream &out,
 
   for (auto import : allImports) {
     auto importedModule = import.importedModule;
-    if (importedModule->isOnoneSupportModule()) {
+    if (importedModule->isOnoneSupportModule() ||
+        importedModule->isClangHeaderImportModule()) {
       continue;
     }
 

--- a/test/ClangImporter/InternalBridgingHeader/interface.swift
+++ b/test/ClangImporter/InternalBridgingHeader/interface.swift
@@ -2,9 +2,12 @@
 
 // RUN: %target-swift-emit-module-interface(%t/MyModule.swiftinterface) %s -module-name MyModule -internal-import-bridging-header %S/../Inputs/c-bridging-header.h -sdk %clang-importer-sdk -enable-library-evolution
 
+// RUN: %target-swift-typecheck-module-from-interface(%t/MyModule.swiftinterface)
+
 // RUN: %FileCheck %s < %t/MyModule.swiftinterface
 
 // CHECK-NOT: internal-import-bridging-header
+// CHECK-NOT: __ObjC
 
 // CHECK: public func g()
 


### PR DESCRIPTION
Bridging headers are incompatible with module interfaces, we should never print an import for it. This becomes much more an issue with the internal bridging header that can be used in library-evolution mode but still needs to be hidden from clients.

rdar://171658976