### PR TITLE
[IRGen] Add typed allocations for embedded Swift

### DIFF
--- a/include/swift/AST/FeatureAvailability.def
+++ b/include/swift/AST/FeatureAvailability.def
@@ -89,6 +89,5 @@ FEATURE(ClearSensitive,                                 FUTURE)
 FEATURE(UpdatePureObjCClassMetadata,                    FUTURE)
 // TODO: CoroutineAccessors: Change to correct version number.
 FEATURE(CoroutineAccessors,                             FUTURE)
-
 #undef FEATURE
 #undef FUTURE

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -600,6 +600,9 @@ EXPERIMENTAL_FEATURE(EmbeddedExistentials, true)
 /// Allow enabling dynamic exclusivity in Embedded Swift.
 EXPERIMENTAL_FEATURE(EmbeddedDynamicExclusivity, true)
 
+/// Emit typed allocation calls in Embedded Swift.
+EXPERIMENTAL_FEATURE(TypedAllocation, true)
+
 /// Check @_implementationOnly imports in non-library-evolution mode.
 EXPERIMENTAL_FEATURE(CheckImplementationOnly, true)
 

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -96,6 +96,14 @@ FUNCTION(AllocObject, Swift, swift_allocObject, C_CC, AlwaysAvailable,
          EFFECT(RuntimeEffect::Allocating),
          UNKNOWN_MEMEFFECTS)
 
+// RefCounted *swift_allocObjectTyped(Metadata *type, size_t size, size_t alignMask, uint64_t typeId);
+FUNCTION(AllocObjectTyped, Swift, swift_allocObjectTyped, C_CC, AlwaysAvailable,
+         RETURNS(RefCountedPtrTy),
+         ARGS(TypeMetadataPtrTy, SizeTy, SizeTy, Int64Ty),
+         ATTRS(NoUnwind),
+         EFFECT(RuntimeEffect::Allocating),
+         UNKNOWN_MEMEFFECTS)
+
 // HeapObject *swift_initStackObject(HeapMetadata const *metadata,
 //                                   HeapObject *object);
 FUNCTION(InitStackObject, Swift, swift_initStackObject, C_CC, AlwaysAvailable,

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -131,6 +131,7 @@ UNINTERESTING_FEATURE(ImportMacroAliases)
 UNINTERESTING_FEATURE(NoExplicitNonIsolated)
 UNINTERESTING_FEATURE(EmbeddedExistentials)
 UNINTERESTING_FEATURE(EmbeddedDynamicExclusivity)
+UNINTERESTING_FEATURE(TypedAllocation)
 
 static bool usesFeatureUnderscoreOwned(Decl *D) {
   return D->getAttrs().hasAttribute<OwnedAttr>();

--- a/lib/IRGen/ClassLayout.h
+++ b/lib/IRGen/ClassLayout.h
@@ -221,6 +221,9 @@ public:
   bool hasObjCImplementation() const {
     return Options.contains(ClassMetadataFlags::ClassHasObjCImplementation);
   }
+
+  std::optional<uint64_t>
+  computeTypedMallocTypeDescriptor(IRGenModule &IGM, SILType selfType) const;
 };
 
 } // end namespace irgen

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -895,7 +895,12 @@ llvm::Value *irgen::emitClassAllocation(IRGenFunction &IGF, SILType selfType,
     // Allocate the object on the heap.
     std::tie(size, alignMask)
       = appendSizeForTailAllocatedArrays(IGF, size, alignMask, TailArrays);
-    val = IGF.emitAllocObjectCall(metadata, size, alignMask, "reference.new");
+
+    auto maybeDescriptor =
+        classLayout.computeTypedMallocTypeDescriptor(IGF.IGM, selfType);
+
+    val = IGF.emitAllocObjectCall(metadata, size, alignMask, maybeDescriptor,
+                                  "reference.new");
     StackAllocSize = -1;
   }
   return IGF.Builder.CreateBitCast(val, IGF.IGM.PtrTy);
@@ -941,7 +946,7 @@ llvm::Value *irgen::emitClassAllocationDynamic(IRGenFunction &IGF,
     = appendSizeForTailAllocatedArrays(IGF, size, alignMask, TailArrays);
 
   llvm::Value *val = IGF.emitAllocObjectCall(metadata, size, alignMask,
-                                             "reference.new");
+                                             std::nullopt, "reference.new");
   StackAllocSize = -1;
   return IGF.Builder.CreateBitCast(val, destType);
 }

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -15,13 +15,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "llvm/Support/ErrorHandling.h"
-#include "llvm/Support/Compiler.h"
-#include "llvm/Support/Path.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/GlobalVariable.h"
 #include "llvm/IR/Intrinsics.h"
+#include "llvm/Support/Compiler.h"
+#include "llvm/Support/EndianStream.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/SipHash.h"
 
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/SourceLoc.h"
@@ -45,6 +47,7 @@
 #include "IRGenModule.h"
 #include "IndirectTypeInfo.h"
 #include "MetadataRequest.h"
+#include "TypeLayout.h"
 
 #include "GenHeap.h"
 
@@ -564,6 +567,32 @@ HeapLayout::getPrivateMetadata(IRGenModule &IGM,
   return privateMetadata;
 }
 
+std::optional<uint64_t>
+HeapLayout::computeTypedMallocTypeDescriptor(IRGenModule &IGM) const {
+  if (!isAlwaysFixedSize()) {
+    return std::nullopt;
+  }
+  llvm::SmallVector<SILType> storageEntries;
+
+  auto rawPointerType = SILType::getRawPointerType(IGM.Context);
+
+  // Add the heap header as the first entry
+  storageEntries.push_back(rawPointerType);
+  storageEntries.push_back(rawPointerType);
+
+  for (auto elType : ElementTypes) {
+    if (!elType) {
+      // FIXME: In partial function application, the bindings get stored as
+      //        opaque storage with SILType(). Can we find a way to get a proper
+      //        type mapping instead?
+      return std::nullopt;
+    }
+    storageEntries.push_back(elType.getObjectType());
+  }
+
+  return ::computeTypedMallocTypeDescriptor(IGM, storageEntries);
+}
+
 llvm::Value *IRGenFunction::emitUnmanagedAlloc(const HeapLayout &layout,
                                                const llvm::Twine &name,
                                            llvm::Constant *captureDescriptor,
@@ -584,7 +613,8 @@ llvm::Value *IRGenFunction::emitUnmanagedAlloc(const HeapLayout &layout,
     alignMask = layout.emitAlignMask(IGM);
   }
 
-  return emitAllocObjectCall(metadata, size, alignMask, name);
+  auto maybeDescriptor = layout.computeTypedMallocTypeDescriptor(IGM);
+  return emitAllocObjectCall(metadata, size, alignMask, maybeDescriptor, name);
 }
 
 namespace {
@@ -2160,4 +2190,96 @@ IsaEncoding irgen::getIsaEncodingForType(IRGenModule &IGM,
   // Non-class heap objects should be pure Swift, so we can access their isas
   // directly.
   return IsaEncoding::Pointer;
+}
+
+namespace {
+uint64_t getTypedMemoryDescriptorStableSipHash(StringRef Str) {
+  static const uint8_t K[16] = {0xb5, 0xd4, 0xc9, 0xeb, 0x79, 0x10, 0x4a, 0x79,
+                                0x6f, 0xec, 0x8b, 0x1b, 0x42, 0x87, 0x81, 0xd4};
+
+  uint8_t RawHashBytes[8];
+  getSipHash_2_4_64(arrayRefFromStringRef(Str), K, RawHashBytes);
+  return llvm::support::endian::read64le(RawHashBytes);
+}
+} // namespace
+
+std::optional<uint64_t> irgen::computeTypedMallocTypeDescriptor(
+    IRGenModule &IGM, llvm::SmallVectorImpl<SILType> &fieldTypes) {
+  if (!IGM.isTypedAllocationAvailable()) {
+    return std::nullopt;
+  }
+
+  llvm::SmallVector<LayoutSemanticsSpan, 4> layoutProperties;
+  uint64_t offset = 0;
+  for (auto fieldType : fieldTypes) {
+    auto &fieldTI = IGM.getTypeInfo(fieldType);
+    auto *fieldTLE =
+        fieldTI.buildTypeLayoutEntry(IGM, fieldType, /*useStructLayouts*/ true);
+
+    if (!fieldTLE->isFixedSize(IGM)) {
+      return std::nullopt;
+    }
+
+    if (offset) {
+      uint64_t alignmentMask = fieldTLE->fixedAlignment(IGM)->getMaskValue();
+      uint64_t alignedOffset = offset + alignmentMask;
+      alignedOffset &= ~alignmentMask;
+      if (alignedOffset > offset) {
+        layoutProperties.push_back({offset, alignedOffset - offset,
+                                    TypedMemoryLayoutSemantics::GenericData});
+        offset = alignedOffset;
+      }
+    }
+
+    if (!fieldTLE->computeLayoutSemantics(IGM, /*currentOffset=*/offset,
+                                          layoutProperties)) {
+      return std::nullopt;
+    }
+
+    offset += fieldTLE->fixedSize(IGM)->getValue();
+  }
+
+  llvm::stable_sort(layoutProperties,
+                    [&](LayoutSemanticsSpan L, LayoutSemanticsSpan R) {
+                      return L.Offset < R.Offset;
+                    });
+
+  TypedMemoryLayoutSemantics layoutSemantics;
+  SmallVector<TypedMemoryLayoutSemantics> unfolded;
+  unfolded.resize(offset, TypedMemoryLayoutSemantics::None);
+  for (auto &cur : layoutProperties) {
+    for (size_t I = cur.Offset; I < cur.Offset + cur.Width; I++) {
+      unfolded[I] |= cur.Semantics;
+      layoutSemantics |= cur.Semantics;
+    }
+  }
+
+  SmallVector<LayoutSemanticsSpan> coalesced;
+  coalesced.push_back({0, 0, unfolded.front()});
+  for (size_t I = 0; I < unfolded.size(); I++) {
+    LayoutSemanticsSpan &last = coalesced.back();
+    if (unfolded[I] == last.Semantics) {
+      last.Width += 1;
+    } else {
+      coalesced.push_back({I, 1, unfolded[I]});
+    }
+  }
+
+  std::string layoutString;
+  llvm::raw_string_ostream layoutStream(layoutString);
+
+  for (auto &S : coalesced) {
+    layoutStream << "[" << S.Offset << "," << S.Width << ":"
+                 << static_cast<uint16_t>(S.Semantics) << "]";
+  }
+
+  uint64_t hash =
+      getTypedMemoryDescriptorStableSipHash(layoutString) & 0xffffffff;
+
+  uint64_t summary = 0; // Version 0
+  summary |= 1 << 6;    // Callsite flags: fixed size
+  summary |= 2 << 10;   // Type kind: Swift
+  summary |= ((uint64_t)layoutSemantics) << 16;
+
+  return hash | (summary << 32);
 }

--- a/lib/IRGen/GenHeap.h
+++ b/lib/IRGen/GenHeap.h
@@ -78,6 +78,9 @@ public:
   llvm::Constant *getPrivateMetadata(IRGenModule &IGM,
                                      llvm::Constant *captureDescriptor,
                                      const llvm::Twine &name) const;
+
+  std::optional<uint64_t>
+  computeTypedMallocTypeDescriptor(IRGenModule &IGM) const;
 };
 
 class HeapNonFixedOffsets : public NonFixedOffsetsImpl {
@@ -181,6 +184,10 @@ llvm::Value *emitHeapMetadataRefForHeapObject(IRGenFunction &IGF,
 
 /// What isa-encoding mechanism does a type use?
 IsaEncoding getIsaEncodingForType(IRGenModule &IGM, CanType type);
+
+std::optional<uint64_t>
+computeTypedMallocTypeDescriptor(IRGenModule &IGM,
+                                 llvm::SmallVectorImpl<SILType> &fieldTypes);
 
 } // end namespace irgen
 } // end namespace swift

--- a/lib/IRGen/IRGenFunction.cpp
+++ b/lib/IRGen/IRGenFunction.cpp
@@ -162,13 +162,26 @@ llvm::Value *IRGenFunction::emitAllocRawCall(llvm::Value *size,
 }
 
 /// Emit a heap allocation.
-llvm::Value *IRGenFunction::emitAllocObjectCall(llvm::Value *metadata,
-                                                llvm::Value *size,
-                                                llvm::Value *alignMask,
-                                                const llvm::Twine &name) {
+llvm::Value *IRGenFunction::emitAllocObjectCall(
+    llvm::Value *metadata, llvm::Value *size, llvm::Value *alignMask,
+    std::optional<uint64_t> mallocTypeId, const llvm::Twine &name) {
+  if (mallocTypeId) {
+    auto descriptorConst = llvm::ConstantInt::get(IGM.Int64Ty, *mallocTypeId);
+    return emitAllocObjectTypedCall(metadata, size, alignMask, descriptorConst,
+                                    name);
+  }
   // For now, all we have is swift_allocObject.
   return emitAllocatingCall(*this, IGM.getAllocObjectFunctionPointer(),
                             {metadata, size, alignMask}, name);
+}
+
+/// Emit a typed heap allocation.
+llvm::Value *IRGenFunction::emitAllocObjectTypedCall(
+    llvm::Value *metadata, llvm::Value *size, llvm::Value *alignMask,
+    llvm::Value *typeDescriptor, const llvm::Twine &name) {
+  // For now, all we have is swift_allocObjectTyped.
+  return emitAllocatingCall(*this, IGM.getAllocObjectTypedFunctionPointer(),
+                            {metadata, size, alignMask, typeDescriptor}, name);
 }
 
 llvm::Value *IRGenFunction::emitInitStackObjectCall(llvm::Value *metadata,

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -367,7 +367,13 @@ public:
 
   llvm::Value *emitAllocObjectCall(llvm::Value *metadata, llvm::Value *size,
                                    llvm::Value *alignMask,
+                                   std::optional<uint64_t> mallocTypeId,
                                    const llvm::Twine &name = "");
+  llvm::Value *emitAllocObjectTypedCall(llvm::Value *metadata,
+                                        llvm::Value *size,
+                                        llvm::Value *alignMask,
+                                        llvm::Value *typeDescriptor,
+                                        const llvm::Twine &name);
   llvm::Value *emitInitStackObjectCall(llvm::Value *metadata,
                                        llvm::Value *object,
                                        const llvm::Twine &name = "");

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -2393,6 +2393,12 @@ bool IRGenModule::isConcurrencyAvailable() {
   return deploymentAvailability.isContainedIn(ctx.getConcurrencyAvailability());
 }
 
+bool IRGenModule::isTypedAllocationAvailable() {
+  auto &langOpts = Context.LangOpts;
+  return langOpts.hasFeature(Feature::Embedded) &&
+         langOpts.hasFeature(Feature::TypedAllocation);
+}
+
 /// Pretend the other files that drivers/build systems expect exist by
 /// creating empty files. Used by UseSingleModuleLLVMEmission when
 /// num-threads > 0.

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -2091,6 +2091,7 @@ private:
   void emitSwiftAsyncExtendedFrameInfoWeakRef();
 public:
   bool isConcurrencyAvailable();
+  bool isTypedAllocationAvailable();
   void noteSwiftAsyncFunctionDef() {
     hasSwiftAsyncFunctionDef = true;
   }

--- a/lib/IRGen/TypeLayout.cpp
+++ b/lib/IRGen/TypeLayout.cpp
@@ -628,6 +628,13 @@ bool TypeLayoutEntry::refCountString(IRGenModule &IGM, LayoutStringBuilder &B,
   return true;
 }
 
+bool TypeLayoutEntry::computeLayoutSemantics(
+    IRGenModule &IGM, uint64_t currentOffset,
+    llvm::SmallVectorImpl<LayoutSemanticsSpan> &layoutProperties) const {
+  ASSERT(isEmpty());
+  return true;
+}
+
 llvm::Value *TypeLayoutEntry::extraInhabitantCount(IRGenFunction &IGF) const {
   assert(isEmpty());
   return llvm::ConstantInt::get(IGF.IGM.Int32Ty, 0);
@@ -1322,6 +1329,74 @@ bool ScalarTypeLayoutEntry::refCountString(IRGenModule &IGM,
   return true;
 }
 
+bool ScalarTypeLayoutEntry::computeLayoutSemantics(
+    IRGenModule &IGM, uint64_t currentOffset,
+    llvm::SmallVectorImpl<LayoutSemanticsSpan> &layoutProperties) const {
+  auto size = typeInfo.getFixedSize();
+  switch (scalarKind) {
+  case ScalarKind::ErrorReference:
+  case ScalarKind::NativeStrongReference:
+  case ScalarKind::NativeUnownedReference:
+  case ScalarKind::NativeWeakReference:
+  case ScalarKind::UnknownWeakReference:
+  case ScalarKind::UnknownReference:
+  case ScalarKind::UnknownUnownedReference:
+  case ScalarKind::BridgeReference:
+  case ScalarKind::BlockReference:
+  case ScalarKind::ObjCReference:
+    layoutProperties.push_back(
+        {currentOffset, size.getValue(),
+         TypedMemoryLayoutSemantics::StructPointer |
+             TypedMemoryLayoutSemantics::ReferenceCount});
+    break;
+  case ScalarKind::ThickFunc:
+    layoutProperties.push_back({currentOffset, IGM.getPointerSize().getValue(),
+                                TypedMemoryLayoutSemantics::AnonymousPointer});
+    layoutProperties.push_back(
+        {currentOffset + IGM.getPointerSize().getValue(),
+         IGM.getPointerSize().getValue(),
+         TypedMemoryLayoutSemantics::StructPointer |
+             TypedMemoryLayoutSemantics::ReferenceCount});
+    break;
+  case ScalarKind::TriviallyDestroyable:
+    if (typeInfo.getStorageType()->isPointerTy()) {
+      layoutProperties.push_back(
+          {currentOffset, size.getValue(),
+           TypedMemoryLayoutSemantics::AnonymousPointer});
+    } else {
+      layoutProperties.push_back({currentOffset, size.getValue(),
+                                  TypedMemoryLayoutSemantics::GenericData});
+    }
+    break;
+  case ScalarKind::ExistentialReference:
+    layoutProperties.push_back(
+        {currentOffset, IGM.getPointerSize().getValue(),
+         TypedMemoryLayoutSemantics::StructPointer |
+             TypedMemoryLayoutSemantics::ReferenceCount});
+    for (auto i = size - IGM.getPointerSize(); !i.isZero();
+         i -= IGM.getPointerSize()) {
+      layoutProperties.push_back(
+          {currentOffset, IGM.getPointerSize().getValue(),
+           TypedMemoryLayoutSemantics::AnonymousPointer});
+    }
+    break;
+  case ScalarKind::CustomReference:
+    if (size == IGM.getPointerSize()) {
+      layoutProperties.push_back(
+          {currentOffset, size.getValue(),
+           TypedMemoryLayoutSemantics::AnonymousPointer});
+    } else {
+      return false;
+    }
+    break;
+  case ScalarKind::Immovable:
+  case ScalarKind::BlockStorage:
+    return false;
+  }
+
+  return true;
+}
+
 void ScalarTypeLayoutEntry::destroy(IRGenFunction &IGF, Address addr) const {
   auto &IGM = IGF.IGM;
 
@@ -1781,6 +1856,34 @@ bool AlignedGroupEntry::refCountString(IRGenModule &IGM, LayoutStringBuilder &B,
   return true;
 }
 
+bool AlignedGroupEntry::computeLayoutSemantics(
+    IRGenModule &IGM, uint64_t currentOffset,
+    llvm::SmallVectorImpl<LayoutSemanticsSpan> &layoutProperties) const {
+  if (!isFixedSize(IGM)) {
+    return false;
+  }
+
+  uint64_t offset = currentOffset;
+  for (auto *entry : entries) {
+    if (offset) {
+      uint64_t alignmentMask = entry->fixedAlignment(IGM)->getMaskValue();
+      uint64_t alignedOffset = offset + alignmentMask;
+      alignedOffset &= ~alignmentMask;
+      if (alignedOffset > offset) {
+        layoutProperties.push_back({offset, alignedOffset - offset,
+                                    TypedMemoryLayoutSemantics::GenericData});
+        offset = alignedOffset;
+      }
+    }
+    if (!entry->computeLayoutSemantics(IGM, offset, layoutProperties)) {
+      return false;
+    }
+    offset += entry->fixedSize(IGM)->getValue();
+  }
+
+  return true;
+}
+
 static Address alignAddress(IRGenFunction &IGF, Address addr,
                             llvm::Value *alignMask) {
   auto &Builder = IGF.Builder;
@@ -2127,6 +2230,12 @@ bool ArchetypeLayoutEntry::refCountString(IRGenModule &IGM,
   return false;
 }
 
+bool ArchetypeLayoutEntry::computeLayoutSemantics(
+    IRGenModule &IGM, uint64_t currentOffset,
+    llvm::SmallVectorImpl<LayoutSemanticsSpan> &layoutProperties) const {
+  return false;
+}
+
 void ArchetypeLayoutEntry::destroy(IRGenFunction &IGF, Address addr) const {
   emitDestroyCall(IGF, archetype, addr);
 }
@@ -2405,7 +2514,6 @@ bool EnumTypeLayoutEntry::refCountString(IRGenModule &IGM,
   case CopyDestroyStrategy::ForwardToPayload:
     return cases[0]->refCountString(IGM, B, genericSig);
   case CopyDestroyStrategy::Normal: {
-
     if (isMultiPayloadEnum() &&
         buildMultiPayloadRefCountString(IGM, B, genericSig)) {
       return true;
@@ -2422,6 +2530,36 @@ bool EnumTypeLayoutEntry::refCountString(IRGenModule &IGM,
 
     auto *accessor = createMetatypeAccessorFunction(IGM, ty, genericSig);
     B.addFixedEnumRefCount(accessor);
+    return true;
+  }
+  }
+}
+
+bool EnumTypeLayoutEntry::computeLayoutSemantics(
+    IRGenModule &IGM, uint64_t currentOffset,
+    llvm::SmallVectorImpl<LayoutSemanticsSpan> &layoutProperties) const {
+  if (!isFixedSize(IGM))
+    return false;
+
+  switch (copyDestroyKind(IGM)) {
+  case CopyDestroyStrategy::TriviallyDestroyable: {
+    auto size = fixedSize(IGM);
+    assert(size && "POD should not have dynamic size");
+    layoutProperties.push_back({currentOffset, fixedSize(IGM)->getValue(),
+                                TypedMemoryLayoutSemantics::GenericData});
+    return true;
+  }
+  case CopyDestroyStrategy::NullableRefcounted:
+  case CopyDestroyStrategy::ForwardToPayload:
+    return cases[0]->computeLayoutSemantics(IGM, currentOffset,
+                                            layoutProperties);
+  case CopyDestroyStrategy::Normal: {
+    for (auto *c : cases) {
+      if (!c->computeLayoutSemantics(IGM, currentOffset, layoutProperties)) {
+        return false;
+      }
+    }
+
     return true;
   }
   }
@@ -3602,6 +3740,12 @@ bool ResilientTypeLayoutEntry::refCountString(
   return false;
 }
 
+bool ResilientTypeLayoutEntry::computeLayoutSemantics(
+    IRGenModule &IGM, uint64_t currentOffset,
+    llvm::SmallVectorImpl<LayoutSemanticsSpan> &layoutProperties) const {
+  return false;
+}
+
 void ResilientTypeLayoutEntry::computeProperties() {
   hasResilientField = true;
   if (ty.getASTType()->hasArchetype())
@@ -3835,6 +3979,12 @@ bool TypeInfoBasedTypeLayoutEntry::refCountString(
       return true;
     }
   }
+  return false;
+}
+
+bool TypeInfoBasedTypeLayoutEntry::computeLayoutSemantics(
+    IRGenModule &IGM, uint64_t currentOffset,
+    llvm::SmallVectorImpl<LayoutSemanticsSpan> &layoutProperties) const {
   return false;
 }
 
@@ -4102,6 +4252,51 @@ bool ArrayLayoutEntry::refCountString(
     IRGenModule &IGM, LayoutStringBuilder &B,
     GenericSignature genericSig) const {
   return false;
+}
+
+bool ArrayLayoutEntry::computeLayoutSemantics(
+    IRGenModule &IGM, uint64_t currentOffset,
+    llvm::SmallVectorImpl<LayoutSemanticsSpan> &layoutProperties) const {
+  if (!isFixedSize(IGM)) {
+    return false;
+  }
+
+  auto size = fixedSize(IGM).value();
+  if (isTriviallyDestroyable()) {
+    layoutProperties.push_back({currentOffset, size.getValue(),
+                                TypedMemoryLayoutSemantics::GenericData});
+    return true;
+  }
+
+  if (getKind() == TypeLayoutEntryKind::Scalar &&
+      size <= IGM.getPointerSize()) {
+    if (!elementLayout->computeLayoutSemantics(IGM, currentOffset,
+                                               layoutProperties)) {
+      return false;
+    }
+    auto semanticsSpan = layoutProperties.pop_back_val();
+
+    layoutProperties.push_back(
+        {semanticsSpan.Offset, size.getValue(), semanticsSpan.Semantics});
+    return true;
+  }
+
+  auto integer = countType->castTo<IntegerType>();
+
+  if (integer->isNegative()) {
+    return false;
+  }
+
+  auto &elementTypeInfo = cast<FixedTypeInfo>(IGM.getTypeInfo(elementType));
+  auto elementStride = elementTypeInfo.getFixedStride().getValue();
+  for (auto i = integer->getValue(); !i.isZero();
+       (void)i--, currentOffset += elementStride) {
+    if (!elementLayout->computeLayoutSemantics(IGM, currentOffset,
+                                               layoutProperties)) {
+      return false;
+    }
+  }
+  return true;
 }
 
 std::optional<const FixedTypeInfo *>ArrayLayoutEntry::getFixedTypeInfo() const {

--- a/lib/IRGen/TypeLayout.h
+++ b/lib/IRGen/TypeLayout.h
@@ -16,6 +16,7 @@
 #include "FixedTypeInfo.h"
 #include "TypeInfo.h"
 #include "swift/SIL/SILType.h"
+#include "llvm/ADT/BitmaskEnum.h"
 #include "llvm/ADT/FoldingSet.h"
 #include "llvm/Support/Debug.h"
 
@@ -53,6 +54,29 @@ enum class ScalarKind : uint8_t {
   ThickFunc,
   ExistentialReference,
   CustomReference,
+};
+
+LLVM_ENABLE_BITMASK_ENUMS_IN_NAMESPACE();
+// Represent properties of (a region of) the memory layout of a type.
+enum class TypedMemoryLayoutSemantics : uint16_t {
+  None = 0,
+  DataPointer = 1 << 0,
+  StructPointer = 1 << 1,
+  ImmutablePointer = 1 << 2,
+  AnonymousPointer = 1 << 3,
+  ReferenceCount = 1 << 4,
+  ResourceHandle = 1 << 5,
+  SpatialBounds = 1 << 6,
+  TaintedData = 1 << 7,
+  GenericData = 1 << 8,
+
+  LLVM_MARK_AS_BITMASK_ENUM(/* LargestFlag = */ GenericData)
+};
+
+struct LayoutSemanticsSpan {
+  uint64_t Offset;
+  uint64_t Width;
+  TypedMemoryLayoutSemantics Semantics;
 };
 
 /// Convert a ReferenceCounting into the appropriate Scalar reference
@@ -119,6 +143,10 @@ public:
                                        GenericSignature genericSig) const;
   virtual bool refCountString(IRGenModule &IGM, LayoutStringBuilder &B,
                               GenericSignature genericSig) const;
+
+  virtual bool computeLayoutSemantics(
+      IRGenModule &IGM, uint64_t currentOffset,
+      llvm::SmallVectorImpl<LayoutSemanticsSpan> &layoutProperties) const;
 
   virtual void destroy(IRGenFunction &IGF, Address addr) const;
 
@@ -218,6 +246,10 @@ public:
   bool refCountString(IRGenModule &IGM, LayoutStringBuilder &B,
                       GenericSignature genericSig) const override;
 
+  bool computeLayoutSemantics(IRGenModule &IGM, uint64_t currentOffset,
+                              llvm::SmallVectorImpl<LayoutSemanticsSpan>
+                                  &layoutProperties) const override;
+
   void destroy(IRGenFunction &IGF, Address addr) const override;
 
   void assignWithCopy(IRGenFunction &IGF, Address dest,
@@ -281,6 +313,10 @@ public:
   bool refCountString(IRGenModule &IGM, LayoutStringBuilder &B,
                       GenericSignature genericSig) const override;
 
+  bool computeLayoutSemantics(IRGenModule &IGM, uint64_t currentOffset,
+                              llvm::SmallVectorImpl<LayoutSemanticsSpan>
+                                  &layoutProperties) const override;
+
   void destroy(IRGenFunction &IGF, Address addr) const override;
 
   void assignWithCopy(IRGenFunction &IGF, Address dest,
@@ -340,6 +376,10 @@ public:
                                GenericSignature genericSig) const override;
   bool refCountString(IRGenModule &IGM, LayoutStringBuilder &B,
                       GenericSignature genericSig) const override;
+
+  bool computeLayoutSemantics(IRGenModule &IGM, uint64_t currentOffset,
+                              llvm::SmallVectorImpl<LayoutSemanticsSpan>
+                                  &layoutProperties) const override;
 
   void destroy(IRGenFunction &IGF, Address addr) const override;
 
@@ -409,6 +449,10 @@ public:
                                GenericSignature genericSig) const override;
   bool refCountString(IRGenModule &IGM, LayoutStringBuilder &B,
                       GenericSignature genericSig) const override;
+
+  bool computeLayoutSemantics(IRGenModule &IGM, uint64_t currentOffset,
+                              llvm::SmallVectorImpl<LayoutSemanticsSpan>
+                                  &layoutProperties) const override;
 
   void destroy(IRGenFunction &IGF, Address addr) const override;
 
@@ -535,6 +579,10 @@ public:
                                GenericSignature genericSig) const override;
   bool refCountString(IRGenModule &IGM, LayoutStringBuilder &B,
                       GenericSignature genericSig) const override;
+
+  bool computeLayoutSemantics(IRGenModule &IGM, uint64_t currentOffset,
+                              llvm::SmallVectorImpl<LayoutSemanticsSpan>
+                                  &layoutProperties) const override;
 
   void destroy(IRGenFunction &IGF, Address addr) const override;
 
@@ -716,6 +764,10 @@ public:
   bool refCountString(IRGenModule &IGM, LayoutStringBuilder &B,
                       GenericSignature genericSig) const override;
 
+  bool computeLayoutSemantics(IRGenModule &IGM, uint64_t currentOffset,
+                              llvm::SmallVectorImpl<LayoutSemanticsSpan>
+                                  &layoutProperties) const override;
+
   std::optional<const FixedTypeInfo *> getFixedTypeInfo() const override;
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
@@ -782,6 +834,10 @@ public:
                                GenericSignature genericSig) const override;
   bool refCountString(IRGenModule &IGM, LayoutStringBuilder &B,
                       GenericSignature genericSig) const override;
+
+  bool computeLayoutSemantics(IRGenModule &IGM, uint64_t currentOffset,
+                              llvm::SmallVectorImpl<LayoutSemanticsSpan>
+                                  &layoutProperties) const override;
 
   std::optional<const FixedTypeInfo *> getFixedTypeInfo() const override;
 

--- a/stdlib/public/EmbeddedPlatform/EmbeddedPlatformPOSIX.swift
+++ b/stdlib/public/EmbeddedPlatform/EmbeddedPlatformPOSIX.swift
@@ -36,3 +36,35 @@ public func _swift_generateRandomHashSeed(_ buf: UnsafeMutableRawPointer, _ nbyt
 public func _swift_writeCharToStandardOutput(_ c: CInt) -> CInt {
   putchar(c)
 }
+
+@implementation @c
+public func _swift_typedAllocate(_ buf: UnsafeMutablePointer<UnsafeMutableRawPointer?>, _ size: Int, _ alignMask: Int, _ typeId: UInt64) {
+  if (size == 0) {
+    return unsafe _swift_typedAllocate(buf, 1, alignMask, typeId)
+  }
+
+#if SWIFT_STDLIB_HAS_MALLOC_TYPE
+  if #available(macOS 15, iOS 17, tvOS 17, watchOS 10, *) {
+    // This check also forces "default" alignment to use malloc_memalign().
+    if (alignMask <= MALLOC_ALIGN_MASK) {
+      buf.pointee = unsafe malloc_type_malloc(size, typeId);
+    } else {
+      if alignMask == -1 {
+        alignment = _swift_MinAllocationAlignment
+      } else {
+        alignment = alignMask + 1
+      }
+
+      // Do not use malloc_type_aligned_alloc() here, because we want this
+      // to work if `size` is not an integer multiple of `alignment`, which
+      // was a requirement of the latter in C11 (but not C17 and later).
+      let err = unsafe malloc_type_posix_memalign(buf, alignment, size, typeId)
+      if (err != 0) {
+        buf.pointee = nil
+      }
+    }
+  }
+#else
+  buf.pointee = unsafe swift_slowAlloc(size, alignMask)
+#endif
+}

--- a/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h
+++ b/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h
@@ -83,6 +83,28 @@ int _swift_alignedAllocate(void * EMBEDDED_SWIFT_NULLABLE * EMBEDDED_SWIFT_NONNU
 void _swift_alignedFree(void * EMBEDDED_SWIFT_NONNULL ptr, __swift_size_t alignment, __swift_size_t size);
 
 /**
+ * Allocates memory and places the resulting pointer in `*memptr`.
+ *
+ * Parameters:
+ *   - `memptr`: the resulting pointer will be written into *memptr on success.
+ *   - `size`: the minimum number of bytes to allocate.
+ *   - `alignment`: the minimum alignment of the resulting pointer, which must
+ *     be a power of at least as large as `sizeof(void *)`.
+ *   - `typeId`: an identifier used by a typed allocator to e.g. place the
+ *     allocation in a particular bucket.
+ *
+ * This function is required when using any Embedded Swift facility that
+ * requires typed memory allocation from the heap, e.g. class instance
+ * allocations when the TypedAllocation feature is enabled.
+ *
+ * This function can be implemented as a direct call to `posix_memalign`,
+ * if the target platform does not support typed allocations.
+ */
+void _swift_typedAllocate(
+    void *EMBEDDED_SWIFT_NULLABLE *EMBEDDED_SWIFT_NONNULL ptr,
+    __swift_size_t size, __swift_size_t alignment, unsigned long long typeId);
+
+/**
  * Writes a single character to standard output.
  *
  * Parameters:

--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -149,6 +149,9 @@ public func _swift_generateRandomHashSeed(_ buf: UnsafeMutableRawPointer, _ nbyt
 @_extern(c, "_swift_writeCharToStandardOutput")
 public func _swift_writeCharToStandardOutput(_: CInt) -> CInt
 
+@_extern(c, "_swift_typedAllocate")
+public func _swift_typedAllocate(_ buf: UnsafeMutablePointer<UnsafeMutableRawPointer?>, _ size: Int, _ alignMask: Int, _ typeId: UInt64)
+
 #else
 // Interface that predates the introduction of swift/EmbeddedPlatform.h
 
@@ -214,6 +217,21 @@ func swift_allocObject(metadata: UnsafeMutablePointer<ClassMetadata>, requiredSi
   unsafe _swift_embedded_set_heap_object_metadata_pointer(object, metadata)
   unsafe object.pointee.refcount = 1
   return unsafe object
+}
+
+@c
+public func swift_allocObjectTyped(metadata: Builtin.RawPointer, requiredSize: Int, requiredAlignmentMask: Int, typeId: UInt64) -> Builtin.RawPointer {
+#if SWIFT_USE_EMBEDDED_SWIFT_PLATFORM
+  var _p: UnsafeMutableRawPointer? = nil
+  unsafe _swift_typedAllocate(&p, requiredSize, requiredAlignmentMask, typeId)
+  let p = p!
+  let object = unsafe p.assumingMemoryBound(to: HeapObject.self)
+  unsafe _swift_embedded_set_heap_object_metadata_pointer(object, UnsafeMutablePointer<ClassMetadata>(metadata))
+  unsafe object.pointee.refcount = 1
+  return unsafe p._rawValue
+#else
+  swift_allocObject(metadata: metadata, requiredSize: requiredSize, requiredAlignmentMask: requiredAlignmentMask)
+#endif
 }
 
 @c

--- a/test/IRGen/typed_allocation.swift
+++ b/test/IRGen/typed_allocation.swift
@@ -1,0 +1,72 @@
+// RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -enable-experimental-feature TypedAllocation -target arm64-apple-macos99.99 -wmo | %FileCheck %s
+
+// REQUIRES: OS=macosx
+// REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: swift_feature_TypedAllocation
+
+import Swift
+
+// CHECK: define swiftcc ptr @"$e16typed_allocation7MyClassC1x1yACSi_SitcfC"(i64 [[P0:%.*]], i64 [[P1:%.*]], ptr swiftself [[PSELF:%.*]])
+// CHECK:   call noalias ptr @swift_allocObjectTyped(ptr getelementptr inbounds (%swift.embedded_existential_type, ptr @"$e16typed_allocation7MyClassCMf", i32 0, i32 1), i64 {{.*}}, i64 {{.*}}, i64 {{.*}})
+// CHECK:   ret ptr {{%.*}}
+// CHECK: }
+public class MyClass {
+  let x: Int
+  let y: Int
+
+  init(x: Int, y: Int) {
+    self.x = x
+    self.y = y
+  }
+}
+
+// CHECK-LABEL: define swiftcc ptr @"$e16typed_allocation12MyOtherClassC1x1yACSi_AA0cE0CtcfC"(i64 %0, ptr %1, ptr swiftself %2)
+// CHECK:   call noalias ptr @swift_allocObjectTyped(ptr getelementptr inbounds (%swift.embedded_existential_type, ptr @"$e16typed_allocation12MyOtherClassCMf", i32 0, i32 1), i64 32, i64 7, i64 {{.*}})
+// CHECK:   ret ptr {{%.*}}
+// CHECK: }
+public class MyOtherClass {
+  let x: Int
+  let y: MyClass
+
+  init(x: Int, y: MyClass) {
+    self.x = x
+    self.y = y
+  }
+}
+
+// CHECK-LABEL: define swiftcc { ptr, ptr } @"$e16typed_allocation11makeClosure1x1yyycSi_AA7MyClassCtF"(i64 %0, ptr %1)
+// CHECK:   call noalias ptr @swift_allocObjectTyped(ptr @metadata, i64 32, i64 7, i64 {{.*}})
+// CHECK:   ret { ptr, ptr } {{%.*}}
+// CHECK: }
+@inline(never)
+public func makeClosure(x: Int, y: MyClass) -> () -> Void {
+  return {
+    _ = (MyClass(x: x, y: y.x), MyOtherClass(x: x, y: y))
+  }
+}
+
+public indirect enum Indirect {
+  case x(Int, Int)
+  case y(Int, Int)
+}
+
+// TODO: For some boxes we can't compute the typed malloc ID, because some of the fields are opaque,
+//       so this test would not pass right now.
+
+// DISABLED-CHECK-LABEL: define swiftcc i64 @"$e16typed_allocation8makeEnum1x1y1bAA8IndirectOSi_SiSbtF"(i64 %0, i64 %1, i1 %2) #0 {
+// DISABLED-CHECK: entry:
+// DISABLED-CHECK:   br i1 {{%.*}}, label %[[L1:.*]], label %[[L2:.*]]
+// DISABLED-CHECK: [[L1]]:
+// DISABLED-CHECK:   call noalias ptr @swift_allocObjectTyped(ptr getelementptr inbounds (%swift.full_boxmetadata, ptr @metadata{{.*}}, i32 0, i32 2), i64 {{.*}}, i64 7, i64 {{.*}})
+// DISABLED-CHECK: [[L2]]:
+// DISABLED-CHECK:   call noalias ptr @swift_allocObjectTyped(ptr getelementptr inbounds (%swift.full_boxmetadata, ptr @metadata{{.*}}, i32 0, i32 2), i64 {{.*}}, i64 7, i64 {{.*}})
+// DISABLED-CHECK:   ret i64 {{%.*}}
+// DISABLED-CHECK: }
+public func makeEnum(x: Int, y: Int, b: Bool) -> Indirect {
+  if b {
+    return .x(y, x)
+  }
+
+  return .y(x, y)
+}


### PR DESCRIPTION
rdar://158239258

This change adds logic in the compiler to compute malloc type ids and emit them together with typed allocation calls. It also adds the new runtime function swift_allocObjectTyped, which calls typed malloc.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
