### PR TITLE
[Macros] Propagate lexical context for nested macros

### DIFF
--- a/lib/ASTGen/Sources/MacroEvaluation/Macros.swift
+++ b/lib/ASTGen/Sources/MacroEvaluation/Macros.swift
@@ -634,16 +634,36 @@ func expandAttachedMacro(
 
 /// Produce the full lexical context of the given node to pass along to
 /// macro expansion.
-private func lexicalContext(of node: some SyntaxProtocol) -> [Syntax] {
+private func lexicalContext(
+  of node: some SyntaxProtocol,
+  parentDeclNode: DeclSyntax? = nil
+) -> [Syntax] {
   // FIXME: Should we query the source manager to get the macro expansion
   // information?
-  node.allMacroLexicalContexts()
+  guard let parentDeclNode else {
+    return node.allMacroLexicalContexts()
+  }
+
+  var didInjectParentDecl = false
+  return node.allMacroLexicalContexts { _ in
+    guard !didInjectParentDecl else {
+      return nil
+    }
+
+    didInjectParentDecl = true
+    return Syntax(parentDeclNode)
+  }
 }
 
 /// Produce the full lexical context of the given node to pass along to
 /// macro expansion.
-private func pluginLexicalContext(of node: some SyntaxProtocol) -> [PluginMessage.Syntax] {
-  lexicalContext(of: node).compactMap { .init(syntax: $0) }
+private func pluginLexicalContext(
+  of node: some SyntaxProtocol,
+  parentDeclNode: DeclSyntax? = nil
+) -> [PluginMessage.Syntax] {
+  lexicalContext(of: node, parentDeclNode: parentDeclNode).compactMap {
+    .init(syntax: $0)
+  }
 }
 
 func expandAttachedMacroImpl(
@@ -730,7 +750,10 @@ func expandAttachedMacroImpl(
       parentDeclSyntax: parentDeclSyntax,
       extendedTypeSyntax: extendedTypeSyntax,
       conformanceListSyntax: conformanceListSyntax,
-      lexicalContext: pluginLexicalContext(of: declarationNode),
+      lexicalContext: pluginLexicalContext(
+        of: declarationNode,
+        parentDeclNode: parentDeclNode
+      ),
       staticBuildConfiguration: try cContext.staticBuildConfiguration.asJSON
     )
     let expandedSource: String?

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1384,6 +1384,14 @@ static SourceFile *evaluateAttachedMacro(MacroDecl *macro, Decl *attachedTo,
                                          bool passParentContext, MacroRole role,
                                          ArrayRef<ProtocolDecl *> conformances = {},
                                          StringRef discriminatorStr = "") {
+  // Decls produced by attached macros are parsed in a top-level macro buffer.
+  // For nested attached macros, recover the original lexical parent so
+  // ASTGen can stitch lexicalContext across expansion boundaries.
+  if (!passParentContext && attachedTo->isInMacroExpansionInContext() &&
+      attachedTo->getDeclContext()->getAsDecl()) {
+    passParentContext = true;
+  }
+
   DeclContext *dc;
   if (role == MacroRole::Peer) {
     dc = attachedTo->getDeclContext();

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -3014,3 +3014,54 @@ public struct CustomConditionCheckMacro: ExpressionMacro {
     return "\(literal: isSet)"
   }
 }
+
+public struct LexicalContextOuterMacro: MemberMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf decl: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return [
+      """
+      @LexicalContextInner
+      func generated() {}
+      """
+    ]
+  }
+}
+
+public struct LexicalContextInnerMacro: PeerMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf decl: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    var types: [String] = []
+    for syntax in context.lexicalContext {
+      if let decl = syntax.as(StructDeclSyntax.self) {
+        types.append("struct \(decl.name.text)")
+      } else if let decl = syntax.as(ClassDeclSyntax.self) {
+        types.append("class \(decl.name.text)")
+      } else if let decl = syntax.as(EnumDeclSyntax.self) {
+        types.append("enum \(decl.name.text)")
+      } else if let decl = syntax.as(ExtensionDeclSyntax.self) {
+         types.append("extension \(decl.extendedType.trimmedDescription)")
+      } else if let decl = syntax.as(FunctionDeclSyntax.self) {
+         types.append("func \(decl.name.text)")
+      } else {
+        types.append("\(syntax.kind)")
+      }
+    }
+
+    context.diagnose(Diagnostic(
+      node: Syntax(node),
+      message: SimpleDiagnosticMessage(
+        message: "lexicalContext: \(types.joined(separator: " -> "))",
+        diagnosticID: MessageID(domain: "test", id: "lexicalContext"),
+        severity: .warning
+      )
+    ))
+
+    return []
+  }
+}

--- a/test/Macros/macro_lexical_context_nested.swift
+++ b/test/Macros/macro_lexical_context_nested.swift
@@ -1,0 +1,42 @@
+// RUN: %empty-directory(%t)
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+// RUN: not %target-swift-frontend -typecheck -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser %s 2>&1 | %FileCheck %s
+
+@attached(member, names: arbitrary)
+macro LexicalContextOuter() = #externalMacro(module: "MacroDefinition", type: "LexicalContextOuterMacro")
+
+@attached(peer, names: arbitrary)
+macro LexicalContextInner() = #externalMacro(module: "MacroDefinition", type: "LexicalContextInnerMacro")
+
+@LexicalContextOuter
+struct StructA {
+  @LexicalContextOuter
+  struct StructB {}
+
+  @LexicalContextOuter
+  class ClassA {}
+
+  @LexicalContextOuter
+  enum EnumA {}
+}
+
+// CHECK: lexicalContext: struct StructA
+// CHECK: lexicalContext: struct StructB -> struct StructA
+// CHECK: lexicalContext: class ClassA -> struct StructA
+// CHECK: lexicalContext: enum EnumA -> struct StructA
+
+extension StructA {
+  @LexicalContextOuter
+  struct StructC {}
+
+  func funcA() {
+    @LexicalContextInner
+    func funcB() {}
+  }
+}
+
+// CHECK: lexicalContext: struct StructC -> extension StructA
+// CHECK: lexicalContext: func funcA -> extension StructA
+
+@LexicalContextInner
+func check() {}


### PR DESCRIPTION
When expanding an attached macro that is nested within another macro expansion,
the parent was not included in the macro plugin leaving an incomplete lexical
context.

This commit updates the type checking to pass the parent context when expanding
attached macros that are part of a macro expansion.

Resolves: https://github.com/swiftlang/swift/issues/79447