### PR TITLE
Fix stack nesting issues with async lets

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ConstantCapturePropagation.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ConstantCapturePropagation.swift
@@ -228,11 +228,13 @@ private func rewritePartialApply(_ partialApply: PartialApplyInst, withSpecializ
     newClosure = builder.createThinToThickFunction(thinFunction: fri, resultType: partialApply.type)
     context.erase(instructions: partialApply.uses.users(ofType: DeallocStackInst.self))
   } else {
-    newClosure = builder.createPartialApply(
+    let newPartialApply = builder.createPartialApply(
       function: fri,
       substitutionMap: specialized.genericSignature.isEmpty ? SubstitutionMap() : partialApply.substitutionMap,
       capturedArguments: arguments, calleeConvention: partialApply.calleeConvention,
       hasUnknownResultIsolation: partialApply.hasUnknownResultIsolation, isOnStack: partialApply.isOnStack)
+    newPartialApply.isNested = partialApply.isNested
+    newClosure = newPartialApply
   }
   partialApply.uses.replaceAll(with: newClosure, context)
 

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -261,6 +261,7 @@ extension ApplySite {
                                                 calleeConvention: partialAp.calleeConvention,
                                                 hasUnknownResultIsolation: partialAp.hasUnknownResultIsolation,
                                                 isOnStack: partialAp.isOnStack)
+      newApply.isNested = partialAp.isNested
       partialAp.replace(with: newApply, context)
 
     case let tryApply as TryApplyInst:

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -1412,6 +1412,10 @@ final public class PartialApplyInst : SingleValueInstruction, ApplySite {
   public var hasUnknownResultIsolation: Bool { bridged.PartialApplyInst_hasUnknownResultIsolation() }
   public var unappliedArgumentCount: Int { bridged.PartialApply_getCalleeArgIndexOfFirstAppliedArg() }
   public var calleeConvention: ArgumentConvention { type.bridged.getCalleeConvention().convention }
+  public var isNested: Bool {
+    get { bridged.PartialApplyInst_isStackAllocationNested() }
+    set { bridged.PartialApplyInst_setStackAllocationIsNested(newValue) }
+  }
 }
 
 final public class ApplyInst : SingleValueInstruction, FullApplySite {

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -2335,7 +2335,7 @@ FUNCTION(TaskAlloc,
          ARGS(SizeTy),
          ATTRS(NoUnwind),
          EFFECT(RuntimeEffect::Concurrency),
-         MEMEFFECTS(ArgMemOnly))
+         MEMEFFECTS(InaccessibleMemOnly))
 
 // void swift_task_dealloc(void *ptr);
 FUNCTION(TaskDealloc,
@@ -2345,7 +2345,7 @@ FUNCTION(TaskDealloc,
          ARGS(Int8PtrTy),
          ATTRS(NoUnwind),
          EFFECT(RuntimeEffect::Concurrency),
-         MEMEFFECTS(ArgMemOnly))
+         MEMEFFECTS(InaccessibleMemOnly))
 
 // void swift_task_dealloc_through(void *ptr);
 FUNCTION(TaskDeallocThrough,
@@ -2355,7 +2355,7 @@ FUNCTION(TaskDeallocThrough,
          ARGS(Int8PtrTy),
          ATTRS(NoUnwind),
          EFFECT(RuntimeEffect::Concurrency),
-         MEMEFFECTS(ArgMemOnly))
+         MEMEFFECTS(InaccessibleMemOnly))
 
 // void swift_task_cancel(AsyncTask *task);
 FUNCTION(TaskCancel,
@@ -2365,7 +2365,7 @@ FUNCTION(TaskCancel,
          ARGS(SwiftTaskPtrTy),
          ATTRS(NoUnwind),
          EFFECT(RuntimeEffect::Concurrency),
-         MEMEFFECTS(ArgMemOnly))
+         MEMEFFECTS(InaccessibleMemOnly))
 
 // AsyncTaskAndContext swift_task_create(
 //     size_t taskCreateFlags,

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -867,6 +867,8 @@ struct BridgedInstruction {
   BRIDGED_INLINE SwiftInt PartialApply_getCalleeArgIndexOfFirstAppliedArg() const;
   BRIDGED_INLINE bool PartialApplyInst_isOnStack() const;
   BRIDGED_INLINE bool PartialApplyInst_hasUnknownResultIsolation() const;
+  BRIDGED_INLINE bool PartialApplyInst_isStackAllocationNested() const;
+  BRIDGED_INLINE void PartialApplyInst_setStackAllocationIsNested(bool) const;
   BRIDGED_INLINE bool AllocStackInst_hasDynamicLifetime() const;
   BRIDGED_INLINE bool AllocStackInst_isFromVarDecl() const;
   BRIDGED_INLINE bool AllocStackInst_usesMoveableValueDebugInfo() const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -1517,6 +1517,16 @@ bool BridgedInstruction::PartialApplyInst_hasUnknownResultIsolation() const {
          swift::SILFunctionTypeIsolation::forUnknown();
 }
 
+bool BridgedInstruction::PartialApplyInst_isStackAllocationNested() const {
+  return getAs<swift::PartialApplyInst>()->isStackAllocationNested();
+}
+
+void BridgedInstruction::PartialApplyInst_setStackAllocationIsNested(bool isNested) const {
+  return getAs<swift::PartialApplyInst>()->setStackAllocationIsNested(
+           swift::StackAllocationIsNested_t(isNested));
+}
+
+
 bool BridgedInstruction::AllocStackInst_hasDynamicLifetime() const {
   return getAs<swift::AllocStackInst>()->hasDynamicLifetime();
 }

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1229,14 +1229,16 @@ void
 SILCloner<ImplClass>::visitPartialApplyInst(PartialApplyInst *Inst) {
   auto Args = getOpValueArray<8>(Inst->getArguments());
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
-  recordClonedInstruction(
-      Inst, getBuilder().createPartialApply(
+  auto NewInst = getBuilder().createPartialApply(
                 getOpLocation(Inst->getLoc()), getOpValue(Inst->getCallee()),
                 getOpSubstitutionMap(Inst->getSubstitutionMap()), Args,
                 Inst->getCalleeConvention(),
                 Inst->getResultIsolation(),
                 Inst->isOnStack(),
-                GenericSpecializationInformation::create(Inst, getBuilder())));
+                GenericSpecializationInformation::create(Inst, getBuilder()));
+  NewInst->setStackAllocationIsNested(Inst->isStackAllocationNested());
+
+  recordClonedInstruction(Inst, NewInst);
 }
 
 template<typename ImplClass>

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -132,6 +132,8 @@ class SILType;
 class SILArgument;
 class SILPhiArgument;
 class SILUndef;
+class StackAllocation;
+class StackDeallocation;
 class Stmt;
 class StringLiteralExpr;
 class ValueDecl;
@@ -873,8 +875,9 @@ public:
   /// instruction.
   bool isAllocatingStack() const;
 
-  /// The stack allocation produced by the instruction, if any.
-  SILValue getStackAllocation() const;
+  /// Return the kind of stack allocation instruction this is, or std::nullopt
+  /// if it is not a stack allocation instruction.
+  std::optional<StackAllocation> getStackAllocation() const;
 
   /// Returns the kind of stack memory that should be allocated. There are
   /// certain (unfortunate) situations in which "stack" allocations may become
@@ -888,6 +891,10 @@ public:
   /// Returns true if this is the deallocation of a stack allocating instruction.
   /// The first operand must be the allocating instruction.
   bool isDeallocatingStack() const;
+
+  /// Return the kind of stack deallocation instruction this is, or
+  /// std::nullopt if it is not a stack deallocation instruction.
+  std::optional<StackDeallocation> getStackDeallocation() const;
 
   /// Whether IRGen lowering of this instruction may result in emitting packs of
   /// metadata or witness tables.

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -3247,6 +3247,8 @@ class PartialApplyInst final
                              ApplyInstBase<PartialApplyInst,
                                            SingleValueInstruction>>,
       public llvm::TrailingObjects<PartialApplyInst, Operand> {
+  USE_SHARED_UINT8;
+
   friend SILBuilder;
 
 public:
@@ -3287,6 +3289,13 @@ public:
 
   OnStackKind isOnStack() const {
     return getFunctionType()->isNoEscape() ? OnStack : NotOnStack;
+  }
+
+  StackAllocationIsNested_t isStackAllocationNested() const {
+    return StackAllocationIsNested_t(sharedUInt8().PartialApplyInst.isNested);
+  }
+  void setStackAllocationIsNested(StackAllocationIsNested_t isNested) {
+    sharedUInt8().PartialApplyInst.isNested = bool(isNested);
   }
   
   /// Visit the instructions that end the lifetime of an OSSA on-stack closure.

--- a/include/swift/SIL/SILNode.h
+++ b/include/swift/SIL/SILNode.h
@@ -245,6 +245,9 @@ protected:
       isBare : 1,   // Only used in AllocRefInst
       numTailTypes: NumAllocRefTailTypesBits);
 
+    SHARED_FIELD(PartialApplyInst, uint8_t
+                 isNested : 1);
+
     SHARED_FIELD(BeginBorrowInst, uint8_t
                  lexical : 1,
                  pointerEscape : 1,

--- a/include/swift/SIL/StackAllocation.h
+++ b/include/swift/SIL/StackAllocation.h
@@ -1,0 +1,140 @@
+//===--- StackAllocation.h - Utility for stack allocations ------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines classes for working with stack allocations and
+// deallocations.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_STACKALLOCATION_H
+#define SWIFT_SIL_STACKALLOCATION_H
+
+#include "swift/SIL/SILInstruction.h"
+
+namespace swift {
+
+enum class StackAllocationKind : uint8_t {
+  /// An AllocStackInst.
+  AllocStack,
+
+  /// An AllocPackInst.
+  AllocPack,
+
+  /// An AllocPackMetadataInst.
+  AllocPackMetadata,
+
+  /// An on-stack AllocRefInst.
+  AllocRef,
+
+  /// An on-stack AllocRefDynamicInst.
+  AllocRefDynamic,
+
+  /// An on-stack PartialApplyInst outside of OSSA.
+  PartialApply,
+
+  /// A callee-allocated BeginApplyInst.
+  CalleeAllocatedBeginApply,
+
+  /// A BuiltinInst for the StackAlloc builtin.
+  BuiltinStackAlloc,
+
+  /// A BuiltinInst for the UnprotectedStackAlloc builtin.
+  BuiltinUnprotectedStackAlloc,
+};
+
+class StackAllocation {
+  SILValue value;
+  StackAllocationKind kind;
+
+  StackAllocation(SILValue value, StackAllocationKind kind)
+    : value(value), kind(kind) {}
+
+public:
+  // This should only be used by the core implementation.
+  static StackAllocation getUnchecked(SILValue value,
+                                      StackAllocationKind kind) {
+    return {value, kind};
+  }
+
+  StackAllocationKind getKind() const {
+    return kind;
+  }
+
+  /// The value which abstractly represents the stack allocation. Most of
+  /// the allocation kinds are the results of single-value instructions, but
+  /// for the values that are not, this is the value that is used by all the
+  /// deallocations.
+  SILValue getValue() const {
+    return value;
+  }
+
+  SILInstruction *getInstruction() const {
+    if (kind != StackAllocationKind::CalleeAllocatedBeginApply)
+      return cast<SingleValueInstruction>(value);
+    return cast<MultipleValueInstructionResult>(value)->getParent();
+  }
+
+  StackAllocationIsNested_t isNested() const {
+    return getInstruction()->isStackAllocationNested();
+  }
+};
+
+class StackDeallocation {
+  SILValue alloc;
+  SILInstruction *dealloc;
+  StackAllocationKind kind;
+
+  StackDeallocation(SILValue alloc, SILInstruction *dealloc,
+                    StackAllocationKind kind)
+    : alloc(alloc), dealloc(dealloc), kind(kind) {}
+
+public:
+  // This should only be used by the core implementation.
+  static StackDeallocation getUnchecked(SILValue alloc,
+                                        const SILInstruction *dealloc,
+                                        StackAllocationKind kind) {
+    return {alloc, const_cast<SILInstruction*>(dealloc), kind};
+  }
+
+  /// Return the kind of allocation that this deallocates.
+  StackAllocationKind getKind() const {
+    return kind;
+  }
+
+  /// Return the deallocating instruction.
+  SILInstruction *getInstruction() const {
+    return dealloc;
+  }
+
+  /// Return the StackAllocation for this deallocation.
+  /// The kind is always the same.
+  StackAllocation getAllocation() const {
+    return StackAllocation::getUnchecked(alloc, kind);
+  }
+
+  /// Find the allocation for the given deallocation.
+  static SILValue getAllocationOperand(const SILInstruction *dealloc) {
+    // NOTE: If you're adding a new kind of deallocating instruction,
+    // there are several places scattered around the SIL optimizer which
+    // assume that the allocating instruction of a deallocating instruction
+    // is referenced by operand 0. Keep that true if you can.
+    auto op = dealloc->getOperand(0);
+    while (auto *mvi = dyn_cast<MoveValueInst>(op)) {
+      op = mvi->getOperand();
+    }
+    return op;
+  }
+};
+
+}
+
+#endif

--- a/include/swift/SIL/StackAllocation.h
+++ b/include/swift/SIL/StackAllocation.h
@@ -23,32 +23,41 @@
 namespace swift {
 
 enum class StackAllocationKind : uint8_t {
-  /// An AllocStackInst.
+  /// An AllocStackInst. The deallocation is a DeallocStackInst.
   AllocStack,
 
-  /// An AllocPackInst.
+  /// An AllocPackInst. The deallocation is a DeallocPackInst.
   AllocPack,
 
-  /// An AllocPackMetadataInst.
+  /// An AllocPackMetadataInst. The deallocation is a DeallocPackMetadataInst.
   AllocPackMetadata,
 
-  /// An on-stack AllocRefInst.
+  /// An on-stack AllocRefInst. The deallocation is DeallocStackRefInst.
   AllocRef,
 
-  /// An on-stack AllocRefDynamicInst.
+  /// An on-stack AllocRefDynamicInst. The deallocation is a
+  /// DeallocStackRefInst.
   AllocRefDynamic,
 
-  /// An on-stack PartialApplyInst outside of OSSA.
+  /// An on-stack PartialApplyInst outside of OSSA. The deallocation is a
+  /// DeallocStackInst.
   PartialApply,
 
-  /// A callee-allocated BeginApplyInst.
+  /// A callee-allocated BeginApplyInst. The deallocation is a
+  /// DeallocStackInst.
   CalleeAllocatedBeginApply,
 
-  /// A BuiltinInst for the StackAlloc builtin.
+  /// A BuiltinInst for the StackAlloc builtin. The deallocation is
+  /// a BuiltinInst for the StackDealloc builtin.
   BuiltinStackAlloc,
 
-  /// A BuiltinInst for the UnprotectedStackAlloc builtin.
+  /// A BuiltinInst for the UnprotectedStackAlloc builtin. The deallocation is
+  /// a BuiltinInst for the StackDealloc builtin.
   BuiltinUnprotectedStackAlloc,
+
+  /// A BuiltinInst for the StartAsyncLetWithLocalBuffer builtin. The
+  /// deallocation is a BuiltinInst for the FinishAsyncLet builtin.
+  BuiltinStartAsyncLet,
 };
 
 class StackAllocation {

--- a/lib/IRGen/Address.h
+++ b/lib/IRGen/Address.h
@@ -119,36 +119,60 @@ public:
   bool isValid() const { return Addr.isValid(); }
 };
 
-/// An address on the stack together with an optional stack pointer reset
-/// location.
+/// An address on the stack together with enough information to correctly
+/// deallocate it.
 class StackAddress {
+public:
+  enum Kind {
+    /// The memory was allocated using a static (i.e. constant size and in
+    /// the entry block) LLVM alloca. The extra info is an llvm::ConstantInt*
+    /// for the size of the allocation which can be passed to
+    /// CreateLifetimeEnd.
+    StaticAlloca,
+
+    /// The memory was allocated using a dynamic LLVM alloca. The extra info
+    /// is the result of calling llvm.stacksave.
+    DynamicAlloca,
+
+    /// The memory was allocated with the task allocator. The extra info is
+    /// the result of swift_task_alloc.
+    TaskAlloc,
+
+    /// The memory was allocated with llvm.coro.alloca.alloc. The extra info
+    /// is the token result of the intrinsic.
+    CoroAlloc,
+
+    /// The memory was allocated using non-nested allocation.
+    /// The extra info is the original result of the allocator call.
+    NonNested,
+  };
+
   /// The address of an object of type T.
   Address Addr;
 
-  /// In a normal function, the result of llvm.stacksave or null.
-  /// In a coroutine, the result of llvm.coro.alloca.alloc.
-  /// In an async function, the result of the taskAlloc call.
-  llvm::Value *ExtraInfo;
+  llvm::PointerIntPair<llvm::Value*, 3, Kind> ExtraInfoAndKind;
 
 public:
-  StackAddress() : ExtraInfo(nullptr) {}
-  StackAddress(Address address, llvm::Value *extraInfo = nullptr)
-    : Addr(address), ExtraInfo(extraInfo) {}
+  StackAddress() : ExtraInfoAndKind(nullptr, StaticAlloca) {}
+
+  explicit StackAddress(Address address, Kind kind, llvm::Value *extraInfo = nullptr)
+    : Addr(address), ExtraInfoAndKind(extraInfo, kind) {}
 
   /// Return a StackAddress with the address changed in some superficial way.
   StackAddress withAddress(Address addr) const {
-    return StackAddress(addr, ExtraInfo);
+    return StackAddress(addr, getKind(), getExtraInfo());
   }
 
   llvm::Value *getAddressPointer() const { return Addr.getAddress(); }
   Alignment getAlignment() const { return Addr.getAlignment(); }
   Address getAddress() const { return Addr; }
-  llvm::Value *getExtraInfo() const { return ExtraInfo; }
+  Kind getKind() const { return ExtraInfoAndKind.getInt(); }
+  llvm::Value *getExtraInfo() const { return ExtraInfoAndKind.getPointer(); }
 
   bool isValid() const { return Addr.isValid(); }
 
   bool operator==(StackAddress RHS) const {
-    return Addr == RHS.Addr && ExtraInfo == RHS.ExtraInfo;
+    return Addr == RHS.Addr && ExtraInfoAndKind == RHS.ExtraInfoAndKind;
   }
   bool operator!=(StackAddress RHS) const { return !(*this == RHS); }
 };
@@ -186,11 +210,13 @@ struct DenseMapInfo<swift::irgen::StackAddress> {
   static swift::irgen::StackAddress getEmptyKey() {
     return swift::irgen::StackAddress(
         DenseMapInfo<swift::irgen::Address>::getEmptyKey(),
+        swift::irgen::StackAddress::StaticAlloca,
         DenseMapInfo<llvm::Value *>::getEmptyKey());
   }
   static swift::irgen::StackAddress getTombstoneKey() {
     return swift::irgen::StackAddress(
         DenseMapInfo<swift::irgen::Address>::getTombstoneKey(),
+        swift::irgen::StackAddress::StaticAlloca,
         DenseMapInfo<llvm::Value *>::getTombstoneKey());
   }
   static unsigned getHashValue(swift::irgen::StackAddress address) {

--- a/lib/IRGen/FixedTypeInfo.h
+++ b/lib/IRGen/FixedTypeInfo.h
@@ -86,9 +86,8 @@ public:
                              const llvm::Twine &name,
                              StackAllocationIsNested_t isNested =
                                  StackAllocationIsNested) const override;
-  void deallocateStack(IRGenFunction &IGF, StackAddress addr, SILType T,
-                       StackAllocationIsNested_t isNested =
-                           StackAllocationIsNested) const override;
+  void deallocateStack(IRGenFunction &IGF, StackAddress addr,
+                       SILType T) const override;
   void destroyStack(IRGenFunction &IGF, StackAddress addr, SILType T,
                     bool isOutlined) const override;
 

--- a/lib/IRGen/GenArray.cpp
+++ b/lib/IRGen/GenArray.cpp
@@ -657,17 +657,16 @@ public:
     return alloca.withAddress(getAddressForPointer(alloca.getAddressPointer()));
   }
 
-  void deallocateStack(IRGenFunction &IGF, StackAddress stackAddress, SILType T,
-                       StackAllocationIsNested_t isNested) const override {
+  void deallocateStack(IRGenFunction &IGF, StackAddress stackAddress,
+                       SILType T) const override {
     IGF.Builder.CreateLifetimeEnd(stackAddress.getAddress().getAddress());
-    IGF.emitDynamicStackDeallocation(stackAddress, isNested);
+    IGF.emitDynamicStackDeallocation(stackAddress);
   }
 
   void destroyStack(IRGenFunction &IGF, StackAddress stackAddress, SILType T,
                     bool isOutlined) const override {
     emitDestroyCall(IGF, T, stackAddress.getAddress());
-    // For now, just always do nested.
-    deallocateStack(IGF, stackAddress, T, StackAllocationIsNested);
+    deallocateStack(IGF, stackAddress, T);
   }
 
   TypeLayoutEntry *

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -4399,19 +4399,18 @@ static void emitDirectExternalArgument(IRGenFunction &IGF, SILType argType,
   }
 
   // Otherwise, we need to coerce through memory.
-  Address temporary;
-  Size tempSize;
-  std::tie(temporary, tempSize) =
-      allocateForCoercion(IGF, argTI.getStorageType(), coercedTy, "coerced-arg");
-  IGF.Builder.CreateLifetimeStart(temporary, tempSize);
+  StackAddress temporary =
+    allocateForCoercion(IGF, argTI.getStorageType(), coercedTy, "coerced-arg");
 
   // Store to a temporary.
   Address tempOfArgTy =
-      IGF.Builder.CreateElementBitCast(temporary, argTI.getStorageType());
+      IGF.Builder.CreateElementBitCast(temporary.getAddress(),
+                                       argTI.getStorageType());
   argTI.initializeFromParams(IGF, in, tempOfArgTy, argType, isOutlined);
 
   // Bitcast the temporary to the expected type.
-  Address coercedAddr = IGF.Builder.CreateElementBitCast(temporary, coercedTy);
+  Address coercedAddr =
+    IGF.Builder.CreateElementBitCast(temporary.getAddress(), coercedTy);
 
   if (IsDirectFlattened && isa<llvm::StructType>(coercedTy)) {
     // Project out individual elements if necessary.
@@ -4427,7 +4426,7 @@ static void emitDirectExternalArgument(IRGenFunction &IGF, SILType argType,
     out.add(IGF.Builder.CreateLoad(coercedAddr));
   }
 
-  IGF.Builder.CreateLifetimeEnd(temporary, tempSize);
+  IGF.emitDeallocateStaticAlloca(temporary);
 }
 
 namespace {
@@ -4928,15 +4927,12 @@ static void emitDirectForeignParameter(IRGenFunction &IGF, Explosion &in,
 
   // Otherwise, we need to traffic through memory.
   // Create a temporary.
-  Address temporary; Size tempSize;
-  std::tie(temporary, tempSize) = allocateForCoercion(IGF,
-                                          coercionTy,
-                                          paramTI.getStorageType(),
-                                          "");
-  IGF.Builder.CreateLifetimeStart(temporary, tempSize);
+  StackAddress temporary =
+    allocateForCoercion(IGF, coercionTy, paramTI.getStorageType(), "");
 
   // Write the input parameters into the temporary:
-  Address coercedAddr = IGF.Builder.CreateElementBitCast(temporary, coercionTy);
+  Address coercedAddr =
+    IGF.Builder.CreateElementBitCast(temporary.getAddress(), coercionTy);
 
   // Break down a struct expansion if necessary.
   if (IsDirectFlattened && isa<llvm::StructType>(coercionTy)) {
@@ -4954,13 +4950,14 @@ static void emitDirectForeignParameter(IRGenFunction &IGF, Explosion &in,
   }
 
   // Pull out the elements.
-  temporary =
-      IGF.Builder.CreateElementBitCast(temporary, paramTI.getStorageType());
-  paramTI.loadAsTake(IGF, temporary, out);
+  auto paramAddress =
+      IGF.Builder.CreateElementBitCast(temporary.getAddress(),
+                                       paramTI.getStorageType());
+  paramTI.loadAsTake(IGF, paramAddress, out);
 
   // Deallocate the temporary.
   // `deallocateStack` emits the lifetime.end marker for us.
-  paramTI.deallocateStack(IGF, StackAddress(temporary), paramType);
+  IGF.emitDeallocateStaticAlloca(temporary);
 }
 
 void irgen::emitForeignParameter(IRGenFunction &IGF, Explosion &params,
@@ -5306,7 +5303,7 @@ StackAddress irgen::emitAllocCoroStaticFrame(IRGenFunction &IGF,
 }
 void irgen::emitDeallocCoroStaticFrame(IRGenFunction &IGF, StackAddress frame) {
   IGF.Builder.CreateLifetimeEnd(frame.getAddress(), Size(-1) /*dynamic size*/);
-  IGF.emitDeallocateDynamicAlloca(frame, /*allowTaskAlloc*/ true,
+  IGF.emitDeallocateDynamicAlloca(frame,
                                   /*useTaskDeallocThrough*/ true,
                                   /*forCalleeCoroutineFrame*/ true);
 }
@@ -5709,11 +5706,10 @@ void IRGenFunction::emitEpilogue() {
     CurFn->insert(CurFn->end(), bb);
 }
 
-std::pair<Address, Size>
-irgen::allocateForCoercion(IRGenFunction &IGF,
-                           llvm::Type *fromTy,
-                           llvm::Type *toTy,
-                           const llvm::Twine &basename) {
+StackAddress irgen::allocateForCoercion(IRGenFunction &IGF,
+                                        llvm::Type *fromTy,
+                                        llvm::Type *toTy,
+                                        const llvm::Twine &basename) {
   auto &DL = IGF.IGM.DataLayout;
   
   auto fromSize = DL.getTypeSizeInBits(fromTy);
@@ -5725,11 +5721,12 @@ irgen::allocateForCoercion(IRGenFunction &IGF,
   llvm::Align alignment =
       std::max(DL.getABITypeAlign(fromTy), DL.getABITypeAlign(toTy));
 
-  auto buffer = IGF.createAlloca(bufferTy, Alignment(alignment.value()),
-                                 basename + ".coerced");
-  
   Size size(std::max(fromSize, toSize));
-  return {buffer, size};
+  auto buffer = IGF.emitStaticAlloca(bufferTy, size,
+                                     Alignment(alignment.value()),
+                                     basename + ".coerced");
+
+  return buffer;
 }
 
 llvm::Value* IRGenFunction::coerceValue(llvm::Value *value, llvm::Type *toTy,
@@ -5755,15 +5752,14 @@ llvm::Value* IRGenFunction::coerceValue(llvm::Value *value, llvm::Type *toTy,
   }
 
   // Otherwise we need to store, bitcast, and load.
-  Address address; Size size;
-  std::tie(address, size) = allocateForCoercion(*this, fromTy, toTy,
-                                                value->getName() + ".coercion");
-  Builder.CreateLifetimeStart(address, size);
+  StackAddress temporary = allocateForCoercion(*this, fromTy, toTy,
+                                               value->getName() + ".coercion");
+  auto address = temporary.getAddress();
   auto orig = Builder.CreateElementBitCast(address, fromTy);
   Builder.CreateStore(value, orig);
   auto coerced = Builder.CreateElementBitCast(address, toTy);
   auto loaded = Builder.CreateLoad(coerced);
-  Builder.CreateLifetimeEnd(address, size);
+  emitDeallocateStaticAlloca(temporary);
   return loaded;
 }
 
@@ -5961,20 +5957,19 @@ Explosion NativeConventionSchema::mapFromNative(IRGenModule &IGM,
                                          : overlappedCoercionTy;
 
   // Allocate a temporary for the coercion.
-  Address temporary;
-  Size tempSize;
-  std::tie(temporary, tempSize) = allocateForCoercion(
+  auto temporary = allocateForCoercion(
       IGF, largerCoercion, loadableTI.getStorageType(), "temp-coercion");
 
   // Make sure we have sufficiently large alignment.
-  adjustAllocaAlignment(DataLayout, temporary, coercionTy);
-  adjustAllocaAlignment(DataLayout, temporary, overlappedCoercionTy);
+  adjustAllocaAlignment(DataLayout, temporary.getAddress(), coercionTy);
+  adjustAllocaAlignment(DataLayout, temporary.getAddress(),
+                        overlappedCoercionTy);
 
   auto &Builder = IGF.Builder;
-  Builder.CreateLifetimeStart(temporary, tempSize);
 
   // Store the expanded type elements.
-  auto coercionAddr = Builder.CreateElementBitCast(temporary, coercionTy);
+  auto coercionAddr =
+    Builder.CreateElementBitCast(temporary.getAddress(), coercionTy);
   unsigned expandedMapIdx = 0;
 
   auto eltsArray = native.claimAll();
@@ -5999,16 +5994,18 @@ Explosion NativeConventionSchema::mapFromNative(IRGenModule &IGM,
   storeToFn(coercionTy, coercionAddr);
   if (!overlappedCoercionTy->isEmptyTy()) {
     auto overlappedCoercionAddr =
-        Builder.CreateElementBitCast(temporary, overlappedCoercionTy);
+        Builder.CreateElementBitCast(temporary.getAddress(),
+                                     overlappedCoercionTy);
     storeToFn(overlappedCoercionTy, overlappedCoercionAddr);
   }
 
   // Reload according to the types schema.
   Address storageAddr =
-      Builder.CreateElementBitCast(temporary, loadableTI.getStorageType());
+      Builder.CreateElementBitCast(temporary.getAddress(),
+                                   loadableTI.getStorageType());
   loadableTI.loadAsTake(IGF, storageAddr, nonNativeExplosion);
 
-  Builder.CreateLifetimeEnd(temporary, tempSize);
+  IGF.emitDeallocateStaticAlloca(temporary);
 
   return nonNativeExplosion;
 }
@@ -6174,25 +6171,24 @@ Explosion NativeConventionSchema::mapIntoNative(IRGenModule &IGM,
   }
 
   // Allocate a temporary for the coercion.
-  Address temporary;
-  Size tempSize;
-  std::tie(temporary, tempSize) = allocateForCoercion(
+  StackAddress temporary = allocateForCoercion(
       IGF, largerCoercion, loadableTI.getStorageType(), "temp-coercion");
 
   // Make sure we have sufficiently large alignment.
-  adjustAllocaAlignment(DataLayout, temporary, coercionTy);
-  adjustAllocaAlignment(DataLayout, temporary, overlappedCoercionTy);
+  adjustAllocaAlignment(DataLayout, temporary.getAddress(), coercionTy);
+  adjustAllocaAlignment(DataLayout, temporary.getAddress(), overlappedCoercionTy);
 
   auto &Builder = IGF.Builder;
-  Builder.CreateLifetimeStart(temporary, tempSize);
 
   // Initialize the memory of the temporary.
   Address storageAddr =
-      Builder.CreateElementBitCast(temporary, loadableTI.getStorageType());
+      Builder.CreateElementBitCast(temporary.getAddress(),
+                                   loadableTI.getStorageType());
   loadableTI.initialize(IGF, fromNonNative, storageAddr, isOutlined);
 
   // Load the expanded type elements from memory.
-  auto coercionAddr = Builder.CreateElementBitCast(temporary, coercionTy);
+  auto coercionAddr =
+    Builder.CreateElementBitCast(temporary.getAddress(), coercionTy);
 
   unsigned expandedMapIdx = 0;
   SmallVector<llvm::Value *, 8> expandedElts(expandedTys.size(), nullptr);
@@ -6216,11 +6212,12 @@ Explosion NativeConventionSchema::mapIntoNative(IRGenModule &IGM,
   loadFromFn(coercionTy, coercionAddr);
   if (!overlappedCoercionTy->isEmptyTy()) {
     auto overlappedCoercionAddr =
-        Builder.CreateElementBitCast(temporary, overlappedCoercionTy);
+        Builder.CreateElementBitCast(temporary.getAddress(),
+                                     overlappedCoercionTy);
     loadFromFn(overlappedCoercionTy, overlappedCoercionAddr);
   }
 
-  Builder.CreateLifetimeEnd(temporary, tempSize);
+  IGF.emitDeallocateStaticAlloca(temporary);
 
   // Add the values to the explosion.
   for (auto *val : expandedElts)

--- a/lib/IRGen/GenCall.h
+++ b/lib/IRGen/GenCall.h
@@ -190,12 +190,12 @@ namespace irgen {
                          bool isOutlined);
 
   /// Allocate a stack buffer of the appropriate size to bitwise-coerce a value
-  /// between two LLVM types.
-  std::pair<Address, Size>
-  allocateForCoercion(IRGenFunction &IGF,
-                      llvm::Type *fromTy,
-                      llvm::Type *toTy,
-                      const llvm::Twine &basename);
+  /// between two LLVM types. The address can be deallocated with
+  /// emitDeallocateStaticAlloca.
+  StackAddress allocateForCoercion(IRGenFunction &IGF,
+                                   llvm::Type *fromTy,
+                                   llvm::Type *toTy,
+                                   const llvm::Twine &basename);
 
   void extractScalarResults(IRGenFunction &IGF, llvm::Type *bodyType,
                             llvm::Value *call, Explosion &out);

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -2299,7 +2299,7 @@ std::optional<StackAddress> irgen::emitFunctionPartialApplication(
     llvm::Value *fnContext, Explosion &args, ArrayRef<SILParameterInfo> params,
     SubstitutionMap subs, CanSILFunctionType origType,
     CanSILFunctionType substType, CanSILFunctionType outType, Explosion &out,
-    bool isOutlined) {
+    bool isOutlined, StackAllocationIsNested_t isNested) {
   // If we have a single Swift-refcounted context value, we can adopt it
   // directly as our closure context without creating a box and thunk.
   enum HasSingleSwiftRefcountedContext { Maybe, Yes, No, Thunkable }
@@ -2575,7 +2575,7 @@ std::optional<StackAddress> irgen::emitFunctionPartialApplication(
     if (outType->isNoEscape()) {
       stackAddr = IGF.emitStackAllocation(
         layout.isFixedLayout() ? layout.emitSize(IGF.IGM) : offsets.getSize(),
-        Alignment(MaximumAlignment));
+        Alignment(MaximumAlignment), isNested);
       stackAddr = stackAddr->withAddress(IGF.Builder.CreateElementBitCast(
           stackAddr->getAddress(), IGF.IGM.OpaqueTy));
       data = stackAddr->getAddress().getAddress();

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -997,7 +997,7 @@ protected:
 
   // Create a new explosion for potentially reabstracted parameters.
   Explosion args;
-  Address resultValueAddr;
+  StackAddress resultValueAddr;
 
   PartialApplicationForwarderEmission(
       IRGenModule &IGM, IRGenFunction &subIGF, llvm::Function *fwd,
@@ -1044,13 +1044,13 @@ public:
       useSRet = false;
     } else if (origNativeSchema.requiresIndirect()) {
       assert(!nativeResultSchema.requiresIndirect());
-      auto stackAddr = outResultTI.allocateStack(
+      resultValueAddr = outResultTI.allocateStack(
           subIGF,
           outConv.getSILResultType(IGM.getMaximalTypeExpansionContext()),
           "return.temp");
-      resultValueAddr = stackAddr.getAddress();
       auto resultAddr = subIGF.Builder.CreateElementBitCast(
-          resultValueAddr, IGM.getStorageType(origConv.getSILResultType(
+          resultValueAddr.getAddress(),
+          IGM.getStorageType(origConv.getSILResultType(
                                IGM.getMaximalTypeExpansionContext())));
       args.add(resultAddr.getAddress());
       useSRet = false;
@@ -1258,7 +1258,7 @@ public:
         assert(!nativeResultSchema.requiresIndirect());
         Explosion loadedResult;
         cast<LoadableTypeInfo>(outResultTI)
-            .loadAsTake(subIGF, resultValueAddr, loadedResult);
+            .loadAsTake(subIGF, resultValueAddr.getAddress(), loadedResult);
         Explosion nativeResult = nativeResultSchema.mapIntoNative(
             IGM, subIGF, loadedResult,
             outConv.getSILResultType(IGM.getMaximalTypeExpansionContext()),
@@ -2573,10 +2573,9 @@ std::optional<StackAddress> irgen::emitFunctionPartialApplication(
     // Allocate a new object on the heap or stack.
     HeapNonFixedOffsets offsets(IGF, layout);
     if (outType->isNoEscape()) {
-      stackAddr = IGF.emitDynamicAlloca(
-          IGF.IGM.Int8Ty,
-          layout.isFixedLayout() ? layout.emitSize(IGF.IGM) : offsets.getSize(),
-          Alignment(16));
+      stackAddr = IGF.emitStackAllocation(
+        layout.isFixedLayout() ? layout.emitSize(IGF.IGM) : offsets.getSize(),
+        Alignment(MaximumAlignment));
       stackAddr = stackAddr->withAddress(IGF.Builder.CreateElementBitCast(
           stackAddr->getAddress(), IGF.IGM.OpaqueTy));
       data = stackAddr->getAddress().getAddress();

--- a/lib/IRGen/GenFunc.h
+++ b/lib/IRGen/GenFunc.h
@@ -26,6 +26,8 @@ namespace llvm {
 }
 
 namespace swift {
+  enum StackAllocationIsNested_t : bool;
+
 namespace irgen {
   class Address;
   class Explosion;
@@ -58,7 +60,8 @@ namespace irgen {
       llvm::Value *fnContext, Explosion &args,
       ArrayRef<SILParameterInfo> argTypes, SubstitutionMap subs,
       CanSILFunctionType origType, CanSILFunctionType substType,
-      CanSILFunctionType outType, Explosion &out, bool isOutlined);
+      CanSILFunctionType outType, Explosion &out, bool isOutlined,
+      StackAllocationIsNested_t isNested);
   CanType getArgumentLoweringType(CanType type, SILParameterInfo paramInfo,
                                   bool isNoEscape);
 

--- a/lib/IRGen/GenInit.cpp
+++ b/lib/IRGen/GenInit.cpp
@@ -65,14 +65,11 @@ FixedTypeInfo::allocateStack(IRGenFunction &IGF, SILType T, const Twine &name,
   // If the type is known to be empty, don't actually allocate anything.
   if (isKnownEmpty(ResilienceExpansion::Maximal)) {
     auto addr = getUndefAddress();
-    return { addr };
+    return StackAddress(addr, StackAddress::StaticAlloca, nullptr);
   }
 
-  Address alloca =
-    IGF.createAlloca(getStorageType(), getFixedAlignment(), name);
-  IGF.Builder.CreateLifetimeStart(alloca, getFixedSize());
-  
-  return { alloca };
+  return IGF.emitStaticAlloca(getStorageType(), getFixedSize(),
+                              getFixedAlignment(), name);
 }
 
 void FixedTypeInfo::destroyStack(IRGenFunction &IGF, StackAddress addr,
@@ -82,8 +79,7 @@ void FixedTypeInfo::destroyStack(IRGenFunction &IGF, StackAddress addr,
 }
 
 void FixedTypeInfo::deallocateStack(IRGenFunction &IGF, StackAddress addr,
-                                    SILType T,
-                                    StackAllocationIsNested_t isNested) const {
+                                    SILType T) const {
   if (isKnownEmpty(ResilienceExpansion::Maximal))
     return;
   IGF.Builder.CreateLifetimeEnd(addr.getAddress(), getFixedSize());

--- a/lib/IRGen/GenOpaque.cpp
+++ b/lib/IRGen/GenOpaque.cpp
@@ -553,34 +553,129 @@ irgen::emitInitializeBufferWithCopyOfBufferCall(IRGenFunction &IGF,
   return call;
 }
 
+StackAddress
+IRGenFunction::emitStackAllocation(llvm::Value *size, Alignment align,
+                                   StackAllocationIsNested_t isNested,
+                                   const llvm::Twine &name) {
+  // Allocate constant-sized allocations directly in the LLVM frame.
+  // We limit this to 16 words unless we're emitting in the entry block.
+  if (auto constantSize = dyn_cast<llvm::ConstantInt>(size)) {
+    bool isInEntryBlock = (Builder.GetInsertBlock() == &*CurFn->begin());
+    if (isInEntryBlock ||
+        constantSize->getValue().ule(16 * IGM.getPointerSize().getValue())) {
+      return emitStaticByteArrayAlloca(constantSize, align, name);
+    }
+  }
+
+  // If this code is properly-nested, use a dynamic allocation path.
+  if (isNested) {
+    return emitDynamicAlloca(IGM.Int8Ty, size, align, AllowsTaskAlloc,
+                             /*mallocTypeId=*/nullptr, name);
+  }
+
+  // Otherwise, use the non-nested dynamic allocation method (generally
+  // malloc).
+  return emitNonNestedStackAllocation(size, align, name);
+}
+
+void IRGenFunction::emitStackDeallocation(StackAddress address) {
+  switch (address.getKind()) {
+  case StackAddress::StaticAlloca:
+    emitDeallocateStaticAlloca(address);
+    return;
+
+  case StackAddress::DynamicAlloca:
+  case StackAddress::TaskAlloc:
+  case StackAddress::CoroAlloc:
+    emitDeallocateDynamicAlloca(address);
+    return;
+
+  case StackAddress::NonNested:
+    emitNonNestedStackDeallocation(address);
+    return;
+  }
+  llvm_unreachable("bad stack address kind");
+}
+
+StackAddress
+IRGenFunction::emitStaticAlloca(llvm::Type *ty, Size size,
+                                Alignment align, const llvm::Twine &name) {
+  auto addr = createAlloca(ty, align, name);
+
+  // LLVM IR requires the size to be an i64.
+  auto sizeForLifetime = llvm::ConstantInt::get(IGM.Int64Ty, size.getValue());
+  Builder.CreateLifetimeStart(addr, sizeForLifetime);
+
+  return StackAddress(addr, StackAddress::StaticAlloca, sizeForLifetime);
+}
+
+StackAddress
+IRGenFunction::emitStaticByteArrayAlloca(llvm::ConstantInt *size,
+                                         Alignment align,
+                                         const llvm::Twine &name) {
+  auto addr = createAlloca(IGM.Int8Ty, size, align, name);
+
+  // The lifetime intrinsics require an i64 on all targets.
+  auto sizeForLifetime = size;
+  if (size->getType() != IGM.Int64Ty) {
+    sizeForLifetime = llvm::ConstantInt::get(IGM.Int64Ty, size->getZExtValue());
+  }
+
+  Builder.CreateLifetimeStart(addr, sizeForLifetime);
+
+  return StackAddress(addr, StackAddress::StaticAlloca, sizeForLifetime);
+}
+
+void
+IRGenFunction::emitDeallocateStaticAlloca(StackAddress address) {
+  assert(address.isValid());
+  assert(address.getKind() == StackAddress::StaticAlloca);
+
+  auto csize = address.getExtraInfo();
+  assert(csize || isa<llvm::UndefValue>(address.getAddressPointer()));
+  if (!csize) return;
+
+  Builder.CreateLifetimeEnd(address.getAddress(),
+                            cast<llvm::ConstantInt>(csize));
+}
+
 StackAddress IRGenFunction::emitDynamicStackAllocation(
     SILType T, StackAllocationIsNested_t isNested, const llvm::Twine &name) {
   if (isNested) {
     return emitDynamicAlloca(T, name);
   }
 
+  // TODO: Alignment should be platform specific.
+  auto *size = emitLoadOfSize(*this, T);
+  auto align = Alignment(MaximumAlignment);
+  return emitNonNestedStackAllocation(size, align, name);
+}
+
+void IRGenFunction::emitDynamicStackDeallocation(StackAddress address) {
+  assert(address.getKind() != StackAddress::StaticAlloca);
+  if (address.getKind() != StackAddress::NonNested) {
+    return emitDeallocateDynamicAlloca(address);
+  }
+
+  return emitNonNestedStackDeallocation(address);
+}
+
+StackAddress IRGenFunction::emitNonNestedStackAllocation(
+    llvm::Value *size, Alignment align, const llvm::Twine &name) {
   // First malloc the memory.
   auto mallocFn = IGM.getMallocFunctionPointer();
-  auto *size = emitLoadOfSize(*this, T);
   auto *call = Builder.CreateCall(mallocFn, {size});
   call->setDoesNotThrow();
   call->setCallingConv(IGM.C_CC);
 
-  // Then create the dynamic alloca to store the malloc pointer into.
-
-  // TODO: Alignment should be platform specific.
-  auto address = Address(call, IGM.Int8Ty, Alignment(16));
-  return StackAddress{address};
+  auto address = Address(call, IGM.Int8Ty, align);
+  return StackAddress(address, StackAddress::NonNested, call);
 }
 
-void IRGenFunction::emitDynamicStackDeallocation(
-    StackAddress address, StackAllocationIsNested_t isNested) {
-  if (isNested) {
-    return emitDeallocateDynamicAlloca(address);
-  }
-
+void IRGenFunction::emitNonNestedStackDeallocation(StackAddress address) {
+  assert(address.getKind() == StackAddress::NonNested);
   auto *call = Builder.CreateCall(IGM.getFreeFunctionPointer(),
-                                  {address.getAddressPointer()});
+                                  {address.getExtraInfo()});
   call->setDoesNotThrow();
   call->setCallingConv(IGM.C_CC);
 }
@@ -591,7 +686,8 @@ void IRGenFunction::emitDynamicStackDeallocation(
 StackAddress IRGenFunction::emitDynamicAlloca(SILType T,
                                               const llvm::Twine &name) {
   llvm::Value *size = emitLoadOfSize(*this, T);
-  return emitDynamicAlloca(IGM.Int8Ty, size, Alignment(16), AllowsTaskAlloc,
+  return emitDynamicAlloca(IGM.Int8Ty, size, Alignment(MaximumAlignment),
+                           AllowsTaskAlloc,
                            /*mallocTypeId=*/nullptr, name);
 }
 
@@ -613,12 +709,12 @@ StackAddress IRGenFunction::emitDynamicAlloca(llvm::Type *eltTy,
     // The task allocator wants size increments in the multiple of
     // MaximumAlignment.
     byteCount = alignUpToMaximumAlignment(IGM.SizeTy, byteCount);
-    auto address = emitTaskAlloc(byteCount, align);
-    auto stackAddress = StackAddress{address, address.getAddress()};
-    stackAddress = stackAddress.withAddress(
-        Builder.CreateElementBitCast(stackAddress.getAddress(), eltTy));
-    return stackAddress;
-    // In coroutines, call llvm.coro.alloca.alloc.
+    auto allocation = emitTaskAlloc(byteCount, align);
+    auto address = Builder.CreateElementBitCast(allocation, eltTy);
+    return StackAddress(address, StackAddress::TaskAlloc,
+                        allocation.getAddress());
+
+  // In coroutines, call llvm.coro.alloca.alloc.
   } else if (isCoroutine()) {
     // NOTE: llvm does not support dynamic allocas in coroutines.
 
@@ -647,11 +743,9 @@ StackAddress IRGenFunction::emitDynamicAlloca(llvm::Type *eltTy,
     auto ptr = Builder.CreateIntrinsicCall(llvm::Intrinsic::coro_alloca_get,
                                            {allocToken});
 
-    auto stackAddress =
-        StackAddress{Address(ptr, IGM.Int8Ty, align), allocToken};
-    stackAddress = stackAddress.withAddress(
-        Builder.CreateElementBitCast(stackAddress.getAddress(), eltTy));
-    return stackAddress;
+    auto address =
+      Builder.CreateElementBitCast(Address(ptr, IGM.Int8Ty, align), eltTy);
+    return StackAddress(address, StackAddress::CoroAlloc, allocToken);
   }
 
   // Otherwise, use a dynamic alloca.
@@ -666,7 +760,10 @@ StackAddress IRGenFunction::emitDynamicAlloca(llvm::Type *eltTy,
         {IGM.DataLayout.getAllocaPtrType(IGM.getLLVMContext())}, {}, "spsave");
   }
 
-  // Emit the dynamic alloca.
+  // Emit the dynamic alloca. We delete CreateAlloca on our IRBuilder
+  // subclass because we don't want code to naively create dynamic allocas,
+  // but in this case we really do want to use it, so we have to look
+  // around that.
   auto *alloca = Builder.IRBuilderBase::CreateAlloca(eltTy, arraySize, name);
   alloca->setAlignment(llvm::MaybeAlign(align.getValue()).valueOrOne());
 
@@ -674,17 +771,25 @@ StackAddress IRGenFunction::emitDynamicAlloca(llvm::Type *eltTy,
          getActiveDominancePoint().isUniversal() &&
              "Must be in entry block if we insert dynamic alloca's without "
              "stackrestores");
-  return {Address(alloca, eltTy, align), stackRestorePoint};
+  auto addr = Address(alloca, eltTy, align);
+  return StackAddress(addr, StackAddress::DynamicAlloca, stackRestorePoint);
 }
 
 /// Deallocate dynamic alloca's memory if requested by restoring the stack
 /// location before the dynamic alloca's call.
 void IRGenFunction::emitDeallocateDynamicAlloca(StackAddress address,
-                                                bool allowTaskDealloc,
                                                 bool useTaskDeallocThrough,
                                                 bool forCalleeCoroutineFrame) {
+  assert(address.getKind() == StackAddress::DynamicAlloca ||
+         address.getKind() == StackAddress::TaskAlloc ||
+         address.getKind() == StackAddress::CoroAlloc);
+
+  if (!address.getAddress().isValid())
+    return;
+
   // Async function use taskDealloc.
-  if (allowTaskDealloc && isAsync() && address.getAddress().isValid()) {
+  if (address.getKind() == StackAddress::TaskAlloc) {
+    assert(isAsync());
     if (useTaskDeallocThrough) {
       emitTaskDeallocThrough(
           Address(address.getExtraInfo(), IGM.Int8Ty, address.getAlignment()));
@@ -694,12 +799,13 @@ void IRGenFunction::emitDeallocateDynamicAlloca(StackAddress address,
         Address(address.getExtraInfo(), IGM.Int8Ty, address.getAlignment()));
     return;
   }
+
   // In coroutines, unconditionally call llvm.coro.alloca.free.
   // Except if the address is invalid, this happens when this is a StackAddress
   // for a partial_apply [stack] that did not need a context object on the
   // stack.
-  else if (isCoroutine() && address.getAddress().isValid()) {
-    // NOTE: llvm does not support dynamic allocas in coroutines.
+  if (address.getKind() == StackAddress::CoroAlloc) {
+    assert(isCoroutine());
 
     auto allocToken = address.getExtraInfo();
     if (!allocToken) {
@@ -716,7 +822,9 @@ void IRGenFunction::emitDeallocateDynamicAlloca(StackAddress address,
                                 allocToken);
     return;
   }
-  // Otherwise, call llvm.stackrestore if an address was saved.
+
+  // Otherwise, call llvm.stackrestore if we performed a stacksave.
+  assert(address.getKind() == StackAddress::DynamicAlloca);
   auto savedSP = address.getExtraInfo();
   if (savedSP == nullptr)
     return;

--- a/lib/IRGen/GenPack.cpp
+++ b/lib/IRGen/GenPack.cpp
@@ -193,22 +193,22 @@ irgen::emitPackArchetypeMetadataRef(IRGenFunction &IGF,
   return response;
 }
 
-static Address emitFixedSizeMetadataPackRef(IRGenFunction &IGF,
-                                            CanPackType packType,
-                                            DynamicMetadataRequest request) {
+static StackAddress
+emitFixedSizeMetadataPackRef(IRGenFunction &IGF, CanPackType packType,
+                             DynamicMetadataRequest request) {
   assert(!packType->containsPackExpansionType());
 
   unsigned elementCount = packType->getNumElements();
   auto allocType = llvm::ArrayType::get(
       IGF.IGM.TypeMetadataPtrTy, elementCount);
 
-  auto pack = IGF.createAlloca(allocType, IGF.IGM.getPointerAlignment());
-  IGF.Builder.CreateLifetimeStart(pack,
-                              IGF.IGM.getPointerSize() * elementCount);
+  auto pack = IGF.emitStaticAlloca(allocType,
+                                   IGF.IGM.getPointerSize() * elementCount,
+                                   IGF.IGM.getPointerAlignment());
 
   for (unsigned i : indices(packType->getElementTypes())) {
     Address slot = IGF.Builder.CreateStructGEP(
-        pack, i, IGF.IGM.getPointerSize());
+        pack.getAddress(), i, IGF.IGM.getPointerSize());
 
     auto metadata = IGF.emitTypeMetadataRef(
         packType.getElementType(i), request).getMetadata();
@@ -460,8 +460,7 @@ irgen::emitTypeMetadataPack(IRGenFunction &IGF, CanPackType packType,
 
   if (auto *constantInt = dyn_cast<llvm::ConstantInt>(shape)) {
     assert(packType->getNumElements() == constantInt->getValue());
-    auto pack =
-        StackAddress(emitFixedSizeMetadataPackRef(IGF, packType, request));
+    auto pack = emitFixedSizeMetadataPackRef(IGF, packType, request);
     IGF.recordStackPackMetadataAlloc(pack, constantInt);
     return {pack, constantInt};
   }
@@ -502,12 +501,6 @@ irgen::emitTypeMetadataPack(IRGenFunction &IGF, CanPackType packType,
   return {pack, shape};
 }
 
-static std::optional<unsigned> countForShape(llvm::Value *shape) {
-  if (auto *constant = dyn_cast<llvm::ConstantInt>(shape))
-    return constant->getValue().getZExtValue();
-  return std::nullopt;
-}
-
 MetadataResponse
 irgen::emitTypeMetadataPackRef(IRGenFunction &IGF, CanPackType packType,
                                DynamicMetadataRequest request) {
@@ -534,22 +527,24 @@ irgen::emitTypeMetadataPackRef(IRGenFunction &IGF, CanPackType packType,
   return response;
 }
 
-static Address emitFixedSizeWitnessTablePack(IRGenFunction &IGF,
-                                             CanPackType packType,
-                                             PackConformance *packConformance) {
+static StackAddress
+emitFixedSizeWitnessTablePack(IRGenFunction &IGF,
+                              CanPackType packType,
+                              PackConformance *packConformance) {
   assert(!packType->containsPackExpansionType());
 
   unsigned elementCount = packType->getNumElements();
   auto allocType =
       llvm::ArrayType::get(IGF.IGM.WitnessTablePtrTy, elementCount);
 
-  auto pack = IGF.createAlloca(allocType, IGF.IGM.getPointerAlignment());
-  IGF.Builder.CreateLifetimeStart(pack,
-                                  IGF.IGM.getPointerSize() * elementCount);
+  auto pack = IGF.emitStaticAlloca(allocType,
+                                   IGF.IGM.getPointerSize() * elementCount,
+                                   IGF.IGM.getPointerAlignment());
 
   for (unsigned i : indices(packType->getElementTypes())) {
     Address slot =
-        IGF.Builder.CreateStructGEP(pack, i, IGF.IGM.getPointerSize());
+        IGF.Builder.CreateStructGEP(pack.getAddress(), i,
+                                    IGF.IGM.getPointerSize());
 
     auto conformance = packConformance->getPatternConformances()[i];
     llvm::Value *_metadata = nullptr;
@@ -605,8 +600,7 @@ irgen::emitWitnessTablePack(IRGenFunction &IGF, CanPackType packType,
 
   if (auto *constantInt = dyn_cast<llvm::ConstantInt>(shape)) {
     assert(packType->getNumElements() == constantInt->getValue());
-    auto pack = StackAddress(
-        emitFixedSizeWitnessTablePack(IGF, packType, packConformance));
+    auto pack = emitFixedSizeWitnessTablePack(IGF, packType, packConformance);
     IGF.recordStackPackWitnessTableAlloc(pack, constantInt);
     return {pack, constantInt};
   }
@@ -651,13 +645,7 @@ irgen::emitWitnessTablePack(IRGenFunction &IGF, CanPackType packType,
 
 static void cleanupWitnessTablePackImpl(IRGenFunction &IGF, StackAddress pack,
                                         llvm::Value *shape) {
-
-  if (pack.getExtraInfo()) {
-    IGF.emitDeallocateDynamicAlloca(pack);
-  } else if (auto count = countForShape(shape)) {
-    IGF.Builder.CreateLifetimeEnd(pack.getAddress(),
-                                  IGF.IGM.getPointerSize() * (count.value()));
-  }
+  IGF.emitStackDeallocation(pack);
 }
 
 void irgen::cleanupWitnessTablePack(IRGenFunction &IGF, StackAddress pack,
@@ -1131,12 +1119,7 @@ void irgen::bindOpenedElementArchetypesAtIndex(IRGenFunction &IGF,
 
 static void cleanupTypeMetadataPackImpl(IRGenFunction &IGF, StackAddress pack,
                                         llvm::Value *shape) {
-  if (pack.getExtraInfo()) {
-    IGF.emitDeallocateDynamicAlloca(pack);
-  } else if (auto count = countForShape(shape)) {
-    IGF.Builder.CreateLifetimeEnd(pack.getAddress(),
-                                  IGF.IGM.getPointerSize() * (*count));
-  }
+  IGF.emitStackDeallocation(pack);
 }
 
 void irgen::cleanupTypeMetadataPack(IRGenFunction &IGF, StackAddress pack,
@@ -1175,12 +1158,13 @@ StackAddress irgen::allocatePack(IRGenFunction &IGF, CanSILPackType packType) {
     auto allocType = llvm::ArrayType::get(
         IGF.IGM.OpaquePtrTy, elementCount);
 
-    auto addr = IGF.createAlloca(allocType, IGF.IGM.getPointerAlignment());
-    IGF.Builder.CreateLifetimeStart(addr, elementSize * elementCount);
+    auto temporary = IGF.emitStaticAlloca(allocType, elementSize * elementCount,
+                                          IGF.IGM.getPointerAlignment());
 
     // We have an [N x opaque*]*; we need an opaque**.
-    addr = IGF.Builder.CreateElementBitCast(addr, IGF.IGM.OpaquePtrTy);
-    return addr;
+    auto addr = IGF.Builder.CreateElementBitCast(temporary.getAddress(),
+                                                 IGF.IGM.OpaquePtrTy);
+    return temporary.withAddress(addr);
   }
 
   assert(packType->containsPackExpansionType());

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1395,8 +1395,8 @@ namespace {
                   StackAllocationIsNested_t isNested) const override {
       llvm_unreachable("should not call on an immovable opaque type");
     }
-    void deallocateStack(IRGenFunction &IGF, StackAddress addr, SILType T,
-                         StackAllocationIsNested_t isNested) const override {
+    void deallocateStack(IRGenFunction &IGF, StackAddress addr,
+                         SILType T) const override {
       llvm_unreachable("should not call on an immovable opaque type");
     }
     void destroyStack(IRGenFunction &IGF, StackAddress addr, SILType T,

--- a/lib/IRGen/IRBuilder.h
+++ b/lib/IRGen/IRBuilder.h
@@ -296,14 +296,20 @@ public:
   
   using IRBuilderBase::CreateLifetimeStart;
   llvm::CallInst *CreateLifetimeStart(Address buf, Size size) {
-    return CreateLifetimeStart(buf.getAddress(),
+    return CreateLifetimeStart(buf,
                    llvm::ConstantInt::get(Context, APInt(64, size.getValue())));
+  }
+  llvm::CallInst *CreateLifetimeStart(Address buf, llvm::ConstantInt *size) {
+    return CreateLifetimeStart(buf.getAddress(), size);
   }
   
   using IRBuilderBase::CreateLifetimeEnd;
   llvm::CallInst *CreateLifetimeEnd(Address buf, Size size) {
-    return CreateLifetimeEnd(buf.getAddress(),
+    return CreateLifetimeEnd(buf,
                    llvm::ConstantInt::get(Context, APInt(64, size.getValue())));
+  }
+  llvm::CallInst *CreateLifetimeEnd(Address buf, llvm::ConstantInt *size) {
+    return CreateLifetimeEnd(buf.getAddress(), size);
   }
 
   // We're intentionally not allowing direct use of

--- a/lib/IRGen/IRGenFunction.cpp
+++ b/lib/IRGen/IRGenFunction.cpp
@@ -662,7 +662,7 @@ static Address emitAddrOfContinuationErrorResultPointer(IRGenFunction &IGF,
 }
 
 void IRGenFunction::emitGetAsyncContinuation(SILType resumeTy,
-                                             StackAddress resultAddr,
+                                             Address resultAddr,
                                              Explosion &out,
                                              bool canThrow) {
   // A continuation is just a reference to the current async task,
@@ -708,13 +708,14 @@ void IRGenFunction::emitGetAsyncContinuation(SILType resumeTy,
   //   lifetime.end within the await after we take from the slot.
   auto normalResultAddr =
     emitAddrOfContinuationNormalResultPointer(*this, continuationContext);
-  if (!resultAddr.getAddress().isValid()) {
+  if (!resultAddr.isValid()) {
     auto &resumeTI = getTypeInfo(resumeTy);
     resultAddr =
-      resumeTI.allocateStack(*this, resumeTy, "async.continuation.result");
+      resumeTI.allocateStack(*this, resumeTy, "async.continuation.result")
+        .getAddress();
   }
   Builder.CreateStore(Builder.CreateBitOrPointerCast(
-                            resultAddr.getAddress().getAddress(),
+                            resultAddr.getAddress(),
                             IGM.OpaquePtrTy),
                       normalResultAddr);
 

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -214,7 +214,7 @@ public:
                                         ArrayRef<llvm::Type *> argTypes);
 
   void emitGetAsyncContinuation(SILType resumeTy,
-                                StackAddress optionalResultAddr,
+                                Address optionalResultAddr,
                                 Explosion &out,
                                 bool canThrow);
 
@@ -304,27 +304,107 @@ public:
   void setupAsync(unsigned asyncContextIndex);
   bool isAsync() const { return asyncContextLocation.isValid(); }
 
+  /// Allocate memory using whatever the current function's notion of
+  /// the stack is. This may perform either static or dynamic allocation
+  /// depending on the size. If `isNested` is true, this allocation must
+  /// use stack discipline w.r.t all other dynamic allocations.
+  ///
+  /// Always returns an address with i8 element type.
+  ///
+  /// The memory should be deallocated with emitStackDeallocation.
+  StackAddress emitStackAllocation(llvm::Value *size, Alignment align,
+                                   StackAllocationIsNested_t isNested =
+                                     StackAllocationIsNested,
+                                   const llvm::Twine &name = "");
+
+  /// Deallocate memory that was allocated with emitStackAllocation.
+  ///
+  /// Calling this is equivalent to calling whichever the appropriate
+  /// deallocation routine was for the kind of allocation that was
+  /// performed, so it should be safe to call it for any allocation.
+  void emitStackDeallocation(StackAddress address);
+
+  /// Create an alloca instruction at the static alloca insertion point
+  /// in the entry block of the function.
+  ///
+  /// You should generally prefer emitStaticAlloca and
+  /// emitDeallocateStaticAlloca instead, which also insert the
+  /// lifetime start and end intrinsics.
   Address createAlloca(llvm::Type *ty, Alignment align,
                        const llvm::Twine &name = "");
   Address createAlloca(llvm::Type *ty, llvm::Value *arraySize, Alignment align,
                        const llvm::Twine &name = "");
 
+  /// Allocate memory statically in the stack frame by creating an alloca
+  /// instruction in the entry block and calling the llvm.lifetime.start
+  /// intrinsic for it at the current IP.
+  ///
+  /// Static memory allocations in the stack frame do not need to use
+  /// stack discipline; LLVM will perform a reaching analysis for the
+  /// start/finish intrinsics when deciding whether to reuse the memory.
+  ///
+  /// Always returns an address with the given element type.
+  ///
+  /// The memory should be deallocated with emitDeallocateStaticAlloca.
+  StackAddress emitStaticAlloca(llvm::Type *ty, Size size, Alignment align,
+                                const llvm::Twine &name = "");
+  StackAddress emitStaticByteArrayAlloca(llvm::ConstantInt *size,
+                                         Alignment align,
+                                         const llvm::Twine &name = "");
+
+  /// Deallocate memory that was allocated statically in the stack frame by
+  /// calling the llvm.lifetime.end intrinsic for it at the current IP.
+  void emitDeallocateStaticAlloca(StackAddress address);
+
+  /// Like emitStackAllocation, but do not try to allocate statically.
+  ///
+  /// Always returns an address with i8 element type.
+  ///
+  /// The memory should be deallocated with emitDynamicStackDeallocation.
+  StackAddress emitDynamicStackAllocation(SILType type,
+                                          StackAllocationIsNested_t isNested,
+                                          const llvm::Twine &name = "");
+  void emitDynamicStackDeallocation(StackAddress address);
+
+  /// Allocate memory dynamically in whatever the current function's notion
+  /// of the stack is. In a synchronous, non-coroutine function, this will
+  /// use LLVM's alloca instruction together with a stacksave; other
+  /// approaches are used in other contexts.
+  ///
+  /// Always returns an address with i8 element type.
+  ///
+  /// All such allocations must use proper stack discipline, i.e. FIFO
+  /// ordering on alloc + dealloc operations.
   StackAddress emitDynamicAlloca(SILType type, const llvm::Twine &name = "");
+
+  /// Allocate memory dynamically in whatever the current function's notion
+  /// of the stack is. In a synchronous, non-coroutine function, this will
+  /// use LLVM's alloca instruction together with a stacksave; other
+  /// approaches are used in other contexts.
+  ///
+  /// Always returns an address with the given element type.
+  ///
+  /// All such allocations must use proper stack discipline, i.e. FIFO
+  /// ordering on alloc + dealloc operations.
   StackAddress
   emitDynamicAlloca(llvm::Type *eltTy, llvm::Value *arraySize, Alignment align,
                     AllowsTaskAlloc_t allowTaskAlloc = AllowsTaskAlloc,
                     llvm::Value *mallocTypeId = nullptr,
                     const llvm::Twine &name = "");
   void emitDeallocateDynamicAlloca(StackAddress address,
-                                   bool allowTaskDealloc = true,
                                    bool useTaskDeallocThrough = false,
                                    bool forCalleeCoroutineFrame = false);
 
-  StackAddress emitDynamicStackAllocation(SILType type,
-                                          StackAllocationIsNested_t isNested,
-                                          const llvm::Twine &name = "");
-  void emitDynamicStackDeallocation(StackAddress address,
-                                    StackAllocationIsNested_t isNested);
+  /// Perform a dynamic "stack" allocation that may not be properly nested.
+  /// Currently, this just calls malloc/free.
+  ///
+  /// Always returns an address with i8 element type.
+  ///
+  /// The memory should be deallocated with emitNonNestedStackDeallocation.
+  StackAddress emitNonNestedStackAllocation(llvm::Value *size,
+                                            Alignment align,
+                                            const llvm::Twine &name = "");
+  void emitNonNestedStackDeallocation(StackAddress address);
 
   llvm::BasicBlock *createBasicBlock(const llvm::Twine &Name);
   const TypeInfo &getTypeInfoForUnlowered(Type subst);

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -788,6 +788,7 @@ namespace RuntimeConstants {
   const auto ReadOnly = llvm::MemoryEffects::readOnly();
   const auto ArgMemOnly = llvm::MemoryEffects::argMemOnly();
   const auto ArgMemReadOnly = llvm::MemoryEffects::argMemOnly(llvm::ModRefInfo::Ref);
+  const auto InaccessibleMemOnly = llvm::MemoryEffects::inaccessibleMemOnly();
   const auto NoReturn = llvm::Attribute::NoReturn;
   const auto NoUnwind = llvm::Attribute::NoUnwind;
   const auto ZExt = llvm::Attribute::ZExt;

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -4396,7 +4396,8 @@ void IRGenSILFunction::visitPartialApplyInst(swift::PartialApplyInst *i) {
   auto closureStackAddr = emitFunctionPartialApplication(
       *this, *CurSILFn, calleeFn, innerContext, llArgs, params,
       i->getSubstitutionMap(), origCalleeTy, i->getSubstCalleeType(),
-      i->getType().castTo<SILFunctionType>(), function, false);
+      i->getType().castTo<SILFunctionType>(), function, false,
+      i->isStackAllocationNested());
   setLoweredExplosion(v, function);
 
   if (closureStackAddr) {

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -154,13 +154,11 @@ public:
   enum class Kind {
     /// The first three LoweredValue kinds correspond to a SIL address value.
 
-    /// The LoweredValue of a resilient, generic, or loadable typed alloc_stack
-    /// keeps an optional stackrestore point in addition to the address of the
-    /// allocated buffer. For all other address values the stackrestore point is
-    /// just null.
-    /// If the stackrestore point is set (currently, this might happen for
-    /// opaque types: generic and resilient) the deallocation of the stack must
-    /// reset the stack pointer to this point.
+    /// An address.
+    Address,
+
+    /// The address of a local state allocation, together with enough
+    /// information to deallocate it.
     StackAddress,
 
     /// A @box together with the address of the box value.
@@ -196,7 +194,8 @@ private:
   using ExplosionVector = SmallVector<llvm::Value *, 4>;
   using SingletonExplosion = llvm::Value*;
 
-  using Members = ExternalUnionMembers<StackAddress,
+  using Members = ExternalUnionMembers<Address,
+                                       StackAddress,
                                        OwnedAddress,
                                        DynamicallyEnforcedAddress,
                                        ExplosionVector,
@@ -208,6 +207,7 @@ private:
   
   static Members::Index getMemberIndexForKind(Kind kind) {
     switch (kind) {
+    case Kind::Address: return Members::indexOf<Address>();
     case Kind::StackAddress: return Members::indexOf<StackAddress>();
     case Kind::OwnedAddress: return Members::indexOf<OwnedAddress>();
     case Kind::DynamicallyEnforcedAddress: return Members::indexOf<DynamicallyEnforcedAddress>();
@@ -231,8 +231,8 @@ public:
 
   /// Create an address value without a stack restore point.
   LoweredValue(const Address &address)
-      : kind(Kind::StackAddress) {
-    Storage.emplace<StackAddress>(kind, address);
+      : kind(Kind::Address) {
+    Storage.emplace<Address>(kind, address);
   }
 
   /// Create an address value with an optional stack restore point.
@@ -301,7 +301,8 @@ public:
   }
   
   bool isAddress() const {
-    return (kind == Kind::StackAddress ||
+    return (kind == Kind::Address ||
+            kind == Kind::StackAddress ||
             kind == Kind::DynamicallyEnforcedAddress);
   }
   bool isBoxWithAddress() const {
@@ -319,7 +320,9 @@ public:
   }
 
   Address getAnyAddress() const {
-    if (kind == LoweredValue::Kind::StackAddress) {
+    if (kind == LoweredValue::Kind::Address) {
+      return Storage.get<Address>(kind);
+    } else if (kind == LoweredValue::Kind::StackAddress) {
       return Storage.get<StackAddress>(kind).getAddress();
     } else {
       return getDynamicallyEnforcedAddress().Addr;
@@ -1848,6 +1851,10 @@ getCOrObjCEntryPointArgumentEmission(IRGenSILFunction &IGF,
 void LoweredValue::getExplosion(IRGenFunction &IGF, SILType type,
                                 Explosion &ex) const {
   switch (kind) {
+  case Kind::Address:
+    ex.add(Storage.get<Address>(kind).getAddress());
+    return;
+
   case Kind::StackAddress:
     ex.add(Storage.get<StackAddress>(kind).getAddressPointer());
     return;
@@ -1886,6 +1893,7 @@ void LoweredValue::getExplosion(IRGenFunction &IGF, SILType type,
 llvm::Value *LoweredValue::getSingletonExplosion(IRGenFunction &IGF,
                                                  SILType type) const {
   switch (kind) {
+  case Kind::Address:
   case Kind::StackAddress:
   case Kind::DynamicallyEnforcedAddress:
   case Kind::CoroutineState:
@@ -3598,6 +3606,7 @@ Callee LoweredValue::getCallee(IRGenFunction &IGF,
   }
 
   case LoweredValue::Kind::EmptyExplosion:
+  case LoweredValue::Kind::Address:
   case LoweredValue::Kind::OwnedAddress:
   case LoweredValue::Kind::StackAddress:
   case LoweredValue::Kind::DynamicallyEnforcedAddress:
@@ -3746,9 +3755,9 @@ static void emitBuiltinStackAlloc(IRGenSILFunction &IGF,
 
   // Emit a static alloca if the size is constant.
   if (auto *constSize = dyn_cast<llvm::ConstantInt>(size)) {
-    auto stackAddress = IGF.createAlloca(IGF.IGM.Int8Ty, constSize, align,
-                                         "temp_alloc");
-    IGF.setLoweredStackAddress(i, {stackAddress});
+    auto stackAddress =
+      IGF.emitStaticByteArrayAlloca(constSize, align, "temp_alloc");
+    IGF.setLoweredStackAddress(i, stackAddress);
     return;
   }
 
@@ -3766,7 +3775,7 @@ static void emitBuiltinStackDealloc(IRGenSILFunction &IGF,
   auto stackAddress = IGF.getLoweredStackAddress(address);
 
   if (stackAddress.getAddress().isValid()) {
-    IGF.emitDeallocateDynamicAlloca(stackAddress, false);
+    IGF.emitStackDeallocation(stackAddress);
   }
 }
 
@@ -4150,6 +4159,7 @@ getPartialApplicationFunction(IRGenSILFunction &IGF, SILValue v,
   auto fnType = v->getType().castTo<SILFunctionType>();
 
   switch (lv.kind) {
+  case LoweredValue::Kind::Address:
   case LoweredValue::Kind::StackAddress:
   case LoweredValue::Kind::DynamicallyEnforcedAddress:
   case LoweredValue::Kind::OwnedAddress:
@@ -6753,7 +6763,9 @@ void IRGenSILFunction::visitDeallocStackInst(swift::DeallocStackInst *i) {
   if (auto *closure = dyn_cast<PartialApplyInst>(i->getOperand())) {
     assert(closure->isOnStack());
     auto stackAddr = LoweredPartialApplyAllocations[i->getOperand()];
-    emitDeallocateDynamicAlloca(stackAddr, closure->isStackAllocationNested());
+    if (stackAddr.isValid()) {
+      emitStackDeallocation(stackAddr);
+    }
     return;
   }
   if (isaResultOf<BeginApplyInst>(i->getOperand())) {
@@ -6771,9 +6783,8 @@ void IRGenSILFunction::visitDeallocStackInst(swift::DeallocStackInst *i) {
   auto allocatedType = asi->getType();
   const TypeInfo &allocatedTI = getTypeInfo(allocatedType);
   StackAddress stackAddr = getLoweredStackAddress(asi);
-  auto isNested = asi->isStackAllocationNested();
 
-  allocatedTI.deallocateStack(*this, stackAddr, allocatedType, isNested);
+  allocatedTI.deallocateStack(*this, stackAddr, allocatedType);
 }
 
 void IRGenSILFunction::visitDeallocStackRefInst(DeallocStackRefInst *i) {
@@ -7915,7 +7926,7 @@ void IRGenSILFunction::visitKeyPathInst(swift::KeyPathInst *I) {
       argsBufAlign = Builder.CreateOr(argsBufAlign, alignMask);
     }
 
-    dynamicArgsBuf = emitDynamicAlloca(IGM.Int8Ty, argsBufSize, Alignment(16));
+    dynamicArgsBuf = emitStackAllocation(argsBufSize, Alignment(16));
     
     Address argsBuf = dynamicArgsBuf->getAddress();
     
@@ -7953,7 +7964,7 @@ void IRGenSILFunction::visitKeyPathInst(swift::KeyPathInst *I) {
   call->setDoesNotThrow();
 
   if (dynamicArgsBuf) {
-    emitDeallocateDynamicAlloca(*dynamicArgsBuf);
+    emitStackDeallocation(*dynamicArgsBuf);
   }
 
   auto loweredKeyPathTy = IGM.getLoweredType(I->getKeyPathType());
@@ -8642,14 +8653,14 @@ void IRGenSILFunction::visitObjCMethodInst(swift::ObjCMethodInst *i) {
 void IRGenSILFunction::visitGetAsyncContinuationInst(
     GetAsyncContinuationInst *i) {
   Explosion out;
-  emitGetAsyncContinuation(i->getLoweredResumeType(), StackAddress(), out,
+  emitGetAsyncContinuation(i->getLoweredResumeType(), Address(), out,
                            i->throws());
   setLoweredExplosion(i, out);
 }
 
 void IRGenSILFunction::visitGetAsyncContinuationAddrInst(
     GetAsyncContinuationAddrInst *i) {
-  auto resultAddr = getLoweredStackAddress(i->getOperand());
+  auto resultAddr = getLoweredAddress(i->getOperand());
   Explosion out;
   emitGetAsyncContinuation(i->getLoweredResumeType(), resultAddr, out,
                            i->throws());

--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -2712,6 +2712,7 @@ void LoadableByAddress::recreateSingleApply(
     auto newApply = applyBuilder.createPartialApply(
         castedApply->getLoc(), callee, applySite.getSubstitutionMap(), callArgs,
         partialApplyConvention, resultIsolation, castedApply->isOnStack());
+    newApply->setStackAllocationIsNested(castedApply->isStackAllocationNested());
     castedApply->replaceAllUsesWith(newApply);
     break;
   }

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -1491,11 +1491,9 @@ emitFunctionTypeMetadataParams(IRGenFunction &IGF,
   if (!params.empty()) {
     auto arrayTy =
         llvm::ArrayType::get(IGF.IGM.TypeMetadataPtrTy, info.numParams);
-    info.parameters = StackAddress(IGF.createAlloca(
-        arrayTy, IGF.IGM.getTypeMetadataAlignment(), "function-parameters"));
-
-    IGF.Builder.CreateLifetimeStart(info.parameters.getAddress(),
-                                    IGF.IGM.getPointerSize() * info.numParams);
+    info.parameters = IGF.emitStaticAlloca(
+        arrayTy, IGF.IGM.getPointerSize() * info.numParams,
+        IGF.IGM.getTypeMetadataAlignment(), "function-parameters");
 
     for (unsigned i : indices(params)) {
       auto param = params[i];
@@ -1561,12 +1559,7 @@ emitDynamicFunctionTypeMetadataParams(IRGenFunction &IGF,
 static void cleanupFunctionTypeMetadataParams(IRGenFunction &IGF,
                                               FunctionTypeMetadataParamInfo info) {
   if (info.parameters.isValid()) {
-    if (info.parameters.getExtraInfo()) {
-      IGF.emitDeallocateDynamicAlloca(info.parameters);
-    } else {
-      IGF.Builder.CreateLifetimeEnd(info.parameters.getAddress(),
-                                    IGF.IGM.getPointerSize() * info.numParams);
-    }
+    IGF.emitStackDeallocation(info.parameters);
   }
 }
 

--- a/lib/IRGen/NonFixedTypeInfo.h
+++ b/lib/IRGen/NonFixedTypeInfo.h
@@ -73,11 +73,10 @@ public:
              getAsBitCastAddress(IGF, alloca.getAddressPointer()));
   }
 
-  void deallocateStack(IRGenFunction &IGF, StackAddress stackAddress, SILType T,
-                       StackAllocationIsNested_t isNested =
-                           StackAllocationIsNested) const override {
+  void deallocateStack(IRGenFunction &IGF, StackAddress stackAddress,
+                       SILType T) const override {
     IGF.Builder.CreateLifetimeEnd(stackAddress.getAddress().getAddress());
-    IGF.emitDynamicStackDeallocation(stackAddress, isNested);
+    IGF.emitDynamicStackDeallocation(stackAddress);
   }
 
   void destroyStack(IRGenFunction &IGF, StackAddress stackAddress, SILType T,

--- a/lib/IRGen/TypeInfo.h
+++ b/lib/IRGen/TypeInfo.h
@@ -363,8 +363,7 @@ public:
 
   /// Deallocate a variable of this type.
   virtual void deallocateStack(
-      IRGenFunction &IGF, StackAddress addr, SILType T,
-      StackAllocationIsNested_t isNested = StackAllocationIsNested) const = 0;
+      IRGenFunction &IGF, StackAddress addr, SILType T) const = 0;
 
   /// Destroy the value of a variable of this type, then deallocate its
   /// memory.

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -1339,12 +1339,13 @@ SILInstruction::getStackAllocation() const {
     // FIXME: BuiltinValueKind::StartAsyncLetWithLocalBuffer
     if (auto BK = BI->getBuiltinKind()) {
       switch (*BK) {
-#define BUILTIN_CASE(KIND)                                               \
-      case BuiltinValueKind::KIND:                                       \
+#define BUILTIN_CASE(ID, KIND)                                           \
+      case BuiltinValueKind::ID:                                         \
         return StackAllocation::getUnchecked(BI,                         \
                                     StackAllocationKind::Builtin##KIND);
-      BUILTIN_CASE(StackAlloc)
-      BUILTIN_CASE(UnprotectedStackAlloc)
+      BUILTIN_CASE(StackAlloc, StackAlloc)
+      BUILTIN_CASE(UnprotectedStackAlloc, UnprotectedStackAlloc)
+      BUILTIN_CASE(StartAsyncLetWithLocalBuffer, StartAsyncLet)
 #undef BUILTIN_CASE
 
       default:
@@ -1371,7 +1372,6 @@ void SILInstruction::setStackAllocationIsNested(
     StackAllocationIsNested_t nested) {
   assert(isAllocatingStack());
   if (auto ASI = dyn_cast<AllocStackInst>(this)) {
-    assert(nested == StackAllocationIsNested);
     ASI->setStackAllocationIsNested(nested);
   } else if (!nested) {
     llvm_unreachable("unimplemented");
@@ -1420,7 +1420,6 @@ SILInstruction::getStackDeallocation() const {
   }
 
   if (auto *BI = dyn_cast<BuiltinInst>(this)) {
-    // FIXME: BuiltinValueKind::FinishAsyncLet
     if (auto BK = BI->getBuiltinKind()) {
       switch (*BK) {
       case BuiltinValueKind::StackDealloc: {
@@ -1434,6 +1433,12 @@ SILInstruction::getStackDeallocation() const {
                  *allocKind == BuiltinValueKind::StackAlloc
                    ? StackAllocationKind::BuiltinStackAlloc
                    : StackAllocationKind::BuiltinUnprotectedStackAlloc);
+      }
+
+      case BuiltinValueKind::FinishAsyncLet: {
+        auto alloc = StackDeallocation::getAllocationOperand(BI);
+        return StackDeallocation::getUnchecked(alloc, BI,
+                             StackAllocationKind::BuiltinStartAsyncLet);
       }
 
       default:

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -1359,9 +1359,10 @@ SILInstruction::getStackAllocation() const {
 }
 
 StackAllocationIsNested_t SILInstruction::isStackAllocationNested() const {
-  assert(isAllocatingStack());
   if (auto ASI = dyn_cast<AllocStackInst>(this)) {
     return ASI->isStackAllocationNested();
+  } else if (auto PAI = dyn_cast<PartialApplyInst>(this)) {
+    return PAI->isStackAllocationNested();
   } else {
     // TODO: implement for all remaining allocations
     return StackAllocationIsNested;
@@ -1370,9 +1371,10 @@ StackAllocationIsNested_t SILInstruction::isStackAllocationNested() const {
 
 void SILInstruction::setStackAllocationIsNested(
     StackAllocationIsNested_t nested) {
-  assert(isAllocatingStack());
   if (auto ASI = dyn_cast<AllocStackInst>(this)) {
     ASI->setStackAllocationIsNested(nested);
+  } else if (auto PAI = dyn_cast<PartialApplyInst>(this)) {
+    PAI->setStackAllocationIsNested(nested);
   } else if (!nested) {
     llvm_unreachable("unimplemented");
   }

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -31,6 +31,7 @@
 #include "swift/SIL/SILDebugScope.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/SIL/SILVisitor.h"
+#include "swift/SIL/StackAllocation.h"
 #include "swift/SIL/Test.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/SmallString.h"
@@ -1292,14 +1293,27 @@ namespace {
 } // end anonymous namespace
 
 bool SILInstruction::isAllocatingStack() const {
-  if (isa<AllocStackInst>(this) ||
-      isa<AllocPackInst>(this) ||
-      isa<AllocPackMetadataInst>(this))
-    return true;
+  return getStackAllocation().has_value();
+}
+
+std::optional<StackAllocation>
+SILInstruction::getStackAllocation() const {
+#define SIMPLE_CASE(KIND)                                               \
+  if (auto I = dyn_cast<KIND##Inst>(this)) {                            \
+    return StackAllocation::getUnchecked(I, StackAllocationKind::KIND); \
+  }
+  SIMPLE_CASE(AllocStack)
+  SIMPLE_CASE(AllocPack)
+  SIMPLE_CASE(AllocPackMetadata)
+#undef SIMPLE_CASE
 
   if (auto *ARI = dyn_cast<AllocRefInstBase>(this)) {
     if (ARI->canAllocOnStack())
-      return true;
+      return StackAllocation::getUnchecked(ARI,
+               isa<AllocRefInst>(ARI)
+                 ? StackAllocationKind::AllocRef
+                 : StackAllocationKind::AllocRefDynamic);
+    return std::nullopt;
   }
 
   // In OSSA, PartialApply is modeled as a value which borrows its operands
@@ -1308,35 +1322,39 @@ bool SILInstruction::isAllocatingStack() const {
   // After OSSA, we make the memory allocation and dependencies explicit again,
   // with a `dealloc_stack` ending the closure's lifetime.
   if (auto *PA = dyn_cast<PartialApplyInst>(this)) {
-    return PA->isOnStack()
-      && !PA->getFunction()->hasOwnership();
+    if (PA->isOnStack() && !PA->getFunction()->hasOwnership())
+      return StackAllocation::getUnchecked(PA,
+                                           StackAllocationKind::PartialApply);
+    return std::nullopt;
   }
 
   if (auto *BAI = dyn_cast<BeginApplyInst>(this)) {
-    return BAI->isCalleeAllocated();
+    if (BAI->isCalleeAllocated())
+      return StackAllocation::getUnchecked(BAI->getCalleeAllocationResult(),
+               StackAllocationKind::CalleeAllocatedBeginApply);
+    return std::nullopt;
   }
 
   if (auto *BI = dyn_cast<BuiltinInst>(this)) {
     // FIXME: BuiltinValueKind::StartAsyncLetWithLocalBuffer
-    if (auto BK = BI->getBuiltinKind();
-        BK && (*BK == BuiltinValueKind::StackAlloc ||
-               *BK == BuiltinValueKind::UnprotectedStackAlloc)) {
-      return true;
+    if (auto BK = BI->getBuiltinKind()) {
+      switch (*BK) {
+#define BUILTIN_CASE(KIND)                                               \
+      case BuiltinValueKind::KIND:                                       \
+        return StackAllocation::getUnchecked(BI,                         \
+                                    StackAllocationKind::Builtin##KIND);
+      BUILTIN_CASE(StackAlloc)
+      BUILTIN_CASE(UnprotectedStackAlloc)
+#undef BUILTIN_CASE
+
+      default:
+        return std::nullopt;
+      }
     }
+    return std::nullopt;
   }
 
-  return false;
-}
-
-SILValue SILInstruction::getStackAllocation() const {
-  if (!isAllocatingStack()) {
-    return {};
-  }
-
-  if (auto *bai = dyn_cast<BeginApplyInst>(this)) {
-    return bai->getCalleeAllocationResult();
-  }
-  return cast<SingleValueInstruction>(this);
+  return std::nullopt;
 }
 
 StackAllocationIsNested_t SILInstruction::isStackAllocationNested() const {
@@ -1361,26 +1379,71 @@ void SILInstruction::setStackAllocationIsNested(
 }
 
 bool SILInstruction::isDeallocatingStack() const {
-  // NOTE: If you're adding a new kind of deallocating instruction,
-  // there are several places scattered around the SIL optimizer which
-  // assume that the allocating instruction of a deallocating instruction
-  // is referenced by operand 0. Keep that true if you can.
+  return getStackDeallocation().has_value();
+}
 
-  if (isa<DeallocStackInst>(this) ||
-      isa<DeallocStackRefInst>(this) ||
-      isa<DeallocPackInst>(this) ||
-      isa<DeallocPackMetadataInst>(this))
-    return true;
+std::optional<StackDeallocation>
+SILInstruction::getStackDeallocation() const {
+  if (auto DSI = dyn_cast<DeallocStackInst>(this)) {
+    auto alloc = StackDeallocation::getAllocationOperand(DSI);
+    if (isa<AllocStackInst>(alloc))
+      return StackDeallocation::getUnchecked(alloc, DSI,
+                                             StackAllocationKind::AllocStack);
+    if (isa<PartialApplyInst>(alloc))
+      return StackDeallocation::getUnchecked(alloc, DSI,
+                                           StackAllocationKind::PartialApply);
+    assert(isa<BeginApplyInst>(alloc->getDefiningInstruction()));
+    return StackDeallocation::getUnchecked(alloc, DSI,
+                              StackAllocationKind::CalleeAllocatedBeginApply);
+  }
+
+  if (auto DSRI = dyn_cast<DeallocStackRefInst>(this)) {
+    auto alloc = StackDeallocation::getAllocationOperand(DSRI);
+    if (isa<AllocRefInst>(alloc))
+      return StackDeallocation::getUnchecked(alloc, DSRI,
+                                             StackAllocationKind::AllocRef);
+    assert(isa<AllocRefDynamicInst>(alloc));
+    return StackDeallocation::getUnchecked(alloc, DSRI,
+                                      StackAllocationKind::AllocRefDynamic);
+  }
+
+  if (auto DPI = dyn_cast<DeallocPackInst>(this)) {
+    auto alloc = StackDeallocation::getAllocationOperand(DPI);
+    return StackDeallocation::getUnchecked(alloc, DPI,
+                                           StackAllocationKind::AllocPack);
+  }
+
+  if (auto DPMI = dyn_cast<DeallocPackMetadataInst>(this)) {
+    auto alloc = StackDeallocation::getAllocationOperand(DPMI);
+    return StackDeallocation::getUnchecked(alloc, DPMI,
+                                      StackAllocationKind::AllocPackMetadata);
+  }
 
   if (auto *BI = dyn_cast<BuiltinInst>(this)) {
     // FIXME: BuiltinValueKind::FinishAsyncLet
-    if (auto BK = BI->getBuiltinKind();
-        BK && (*BK == BuiltinValueKind::StackDealloc)) {
-      return true;
+    if (auto BK = BI->getBuiltinKind()) {
+      switch (*BK) {
+      case BuiltinValueKind::StackDealloc: {
+        auto alloc =
+          cast<BuiltinInst>(StackDeallocation::getAllocationOperand(BI));
+        auto allocKind = alloc->getBuiltinKind();
+        assert(allocKind);
+        assert(*allocKind == BuiltinValueKind::StackAlloc ||
+               *allocKind == BuiltinValueKind::UnprotectedStackAlloc);
+        return StackDeallocation::getUnchecked(alloc, BI,
+                 *allocKind == BuiltinValueKind::StackAlloc
+                   ? StackAllocationKind::BuiltinStackAlloc
+                   : StackAllocationKind::BuiltinUnprotectedStackAlloc);
+      }
+
+      default:
+        return std::nullopt;
+      }
     }
+    return std::nullopt;
   }
 
-  return false;
+  return std::nullopt;
 }
 
 static bool typeOrLayoutInvolvesPack(SILType ty, SILFunction const &F) {

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -751,7 +751,9 @@ PartialApplyInst::PartialApplyInst(
     // should derive the type of its result by partially applying the callee's
     // type.
     : InstructionBase(Loc, Callee, SubstCalleeTy, Subs, Args,
-                      TypeDependentOperands, SpecializationInfo, ClosureType) {}
+                      TypeDependentOperands, SpecializationInfo, ClosureType) {
+  sharedUInt8().PartialApplyInst.isNested = true;
+}
 
 PartialApplyInst *PartialApplyInst::create(
     SILDebugLocation Loc, SILValue Callee, ArrayRef<SILValue> Args,

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1830,8 +1830,11 @@ public:
       *this << "[isolated_any] ";
       break;
     }
-    if (CI->isOnStack())
+    if (CI->isOnStack()) {
       *this << "[on_stack] ";
+      if (!CI->isStackAllocationNested())
+        *this << "[non_nested] ";
+    }
     visitApplyInstBase(CI);
   }
 

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -6929,6 +6929,7 @@ bool SILParser::parseCallInstruction(SILLocation InstLoc,
   SILOptionalAttrValue AttrValue;
   SourceLoc AttrValueLoc;
   std::optional<ApplyIsolationCrossing> isolationCrossing;
+  std::optional<StackAllocationIsNested_t> isNested;
 
   while (parseSILOptional(AttrName, AttrLoc, AttrValue, AttrValueLoc, *this)) {
     if (AttrName == "nothrow") {
@@ -6958,6 +6959,12 @@ bool SILParser::parseCallInstruction(SILLocation InstLoc,
     if (AttrName == "on_stack") {
       assert(!bool(AttrValue));
       IsNoEscape = true;
+      continue;
+    }
+
+    if (AttrName == "non_nested") {
+      assert(!bool(AttrValue));
+      isNested = StackAllocationIsNotNested;
       continue;
     }
 
@@ -7140,11 +7147,17 @@ bool SILParser::parseCallInstruction(SILLocation InstLoc,
     }
 
     // FIXME: Why the arbitrary order difference in IRBuilder type argument?
-    ResultVal = B.createPartialApply(
+    auto PA = B.createPartialApply(
         InstLoc, FnVal, subs, Args, PartialApplyConvention,
         PartialApplyIsolation,
         IsNoEscape ? PartialApplyInst::OnStackKind::OnStack
                    : PartialApplyInst::OnStackKind::NotOnStack);
+
+    if (isNested) {
+      PA->setStackAllocationIsNested(*isNested);
+    }
+
+    ResultVal = PA;
     break;
   }
   case SILInstructionKind::TryApplyInst: {

--- a/lib/SIL/Verifier/FlowSensitiveVerifier.cpp
+++ b/lib/SIL/Verifier/FlowSensitiveVerifier.cpp
@@ -15,6 +15,7 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/SIL/BasicBlockUtils.h"
 #include "swift/SIL/SILFunction.h"
+#include "swift/SIL/StackAllocation.h"
 
 using namespace swift;
 using namespace swift::silverifier;
@@ -326,14 +327,14 @@ void swift::silverifier::verifyFlowSensitiveRules(SILFunction *F) {
         }
       }
 
-      if (i.isAllocatingStack()) {
+      if (auto allocation = i.getStackAllocation()) {
         // Nested stack allocations are pushed on the stack. Non-nested stack
         // allocations are treated as active ops so that we can at least
         // verify their joint post-dominance.
         if (i.isStackAllocationNested()) {
-          state.Stack.push_back(i.getStackAllocation());
+          state.Stack.push_back(allocation->getValue());
         } else {
-          state.handleScopeInst(i.getStackAllocation());
+          state.handleScopeInst(allocation->getValue());
         }
 
         // Also track begin_apply's token as an ActiveOp so we can also verify

--- a/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
@@ -337,11 +337,14 @@ public:
   SingleValueInstruction *
   createNewClosure(SILBuilder &B, SILValue V,
                    llvm::SmallVectorImpl<SILValue> &Args) const {
-    if (auto *PA = dyn_cast<PartialApplyInst>(getClosure()))
-      return B.createPartialApply(getClosure()->getLoc(), V, {}, Args,
-                                  PA->getCalleeConvention(),
-                                  PA->getResultIsolation(),
-                                  PA->isOnStack());
+    if (auto *PA = dyn_cast<PartialApplyInst>(getClosure())) {
+      auto NPA = B.createPartialApply(getClosure()->getLoc(), V, {}, Args,
+                                      PA->getCalleeConvention(),
+                                      PA->getResultIsolation(),
+                                      PA->isOnStack());
+      NPA->setStackAllocationIsNested(PA->isStackAllocationNested());
+      return NPA;
+    }
 
     assert(isa<ThinToThickFunctionInst>(getClosure()) &&
            "We only support partial_apply and thin_to_thick_function");
@@ -883,6 +886,7 @@ SILValue ClosureSpecCloner::cloneCalleeConversion(
         CallSiteDesc.getLoc(), FunRef, {}, {calleeValue},
         PAI->getCalleeConvention(), PAI->getResultIsolation(),
         PAI->isOnStack());
+    NewPA->setStackAllocationIsNested(PAI->isStackAllocationNested());
     // If the partial_apply is on stack we will emit a dealloc_stack in the
     // epilog.
     NeedsRelease.push_back(NewPA);

--- a/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
+++ b/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
@@ -1564,6 +1564,7 @@ processPartialApplyInst(SILOptFunctionBuilder &funcBuilder,
       pai->getLoc(), fnVal, pai->getSubstitutionMap(), args,
       pai->getCalleeConvention(), pai->getResultIsolation(),
       pai->isOnStack());
+  newPAI->setStackAllocationIsNested(pai->isStackAllocationNested());
   pai->replaceAllUsesWith(newPAI);
   pai->eraseFromParent();
   if (fri->use_empty()) {

--- a/lib/SILOptimizer/SILCombiner/SILCombinerCastVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerCastVisitors.cpp
@@ -930,6 +930,7 @@ SILCombiner::visitConvertFunctionInst(ConvertFunctionInst *cfi) {
             pa->getLoc(), cfi->getOperand(), pa->getSubstitutionMap(), args,
             pa->getFunctionType()->getCalleeConvention(),
             pa->getResultIsolation());
+        newPA->setStackAllocationIsNested(pa->isStackAllocationNested());
         auto newConvert = Builder.createConvertFunction(pa->getLoc(), newPA,
                                                         partialApplyTy, false);
         replaceInstUsesWith(*pa, newConvert);
@@ -952,6 +953,7 @@ SILCombiner::visitConvertFunctionInst(ConvertFunctionInst *cfi) {
           pa->getLoc(), newValue, pa->getSubstitutionMap(), args,
           pa->getFunctionType()->getCalleeConvention(),
           pa->getResultIsolation());
+      newPA->setStackAllocationIsNested(pa->isStackAllocationNested());
       if (!use->isLifetimeEnding()) {
         localBuilder.emitDestroyValueOperation(pa->getLoc(), newValue);
       }

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -1198,10 +1198,12 @@ specializeApplySite(SILOptFunctionBuilder &FuncBuilder, ApplySite Apply,
   switch (Apply.getKind()) {
   case ApplySiteKind::PartialApplyInst: {
     auto *PAI = cast<PartialApplyInst>(ApplyInst);
-    return Builder.createPartialApply(
+    auto NewPAI = Builder.createPartialApply(
         Apply.getLoc(), FunctionRef, Apply.getSubstitutionMap(), Args,
         PAI->getCalleeConvention(), PAI->getResultIsolation(), PAI->isOnStack(),
         GenericSpecializationInformation::create(ApplyInst, Builder));
+    NewPAI->setStackAllocationIsNested(PAI->isStackAllocationNested());
+    return NewPAI;
   }
   case ApplySiteKind::ApplyInst:
     return Builder.createApply(

--- a/lib/SILOptimizer/Transforms/PartialApplySimplification.cpp
+++ b/lib/SILOptimizer/Transforms/PartialApplySimplification.cpp
@@ -392,10 +392,12 @@ rewriteKnownCalleeConventionOnly(SILFunction *callee,
     switch (site.getKind()) {
     case ApplySiteKind::PartialApplyInst: {
       auto pa = cast<PartialApplyInst>(site.getInstruction());
-      newInst = B.createPartialApply(loc, fr, site.getSubstitutionMap(), args,
-                                     pa->getCalleeConvention(),
-                                     pa->getResultIsolation(),
-                                     pa->isOnStack());
+      auto newPA = B.createPartialApply(loc, fr, site.getSubstitutionMap(), args,
+                                        pa->getCalleeConvention(),
+                                        pa->getResultIsolation(),
+                                        pa->isOnStack());
+      newPA->setStackAllocationIsNested(pa->isStackAllocationNested());
+      newInst = newPA;
       break;
     }
     case ApplySiteKind::ApplyInst:
@@ -840,6 +842,7 @@ rewriteKnownCalleeWithExplicitContext(SILFunction *callee,
                                      paConvention,
                                      paIsolation,
                                      paOnStack);
+      newPA->setStackAllocationIsNested(oldPA->isStackAllocationNested());
       assert(isSimplePartialApply(newPA)
              && "partial apply wasn't simple after transformation?");
       newInst = newPA;

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -662,6 +662,7 @@ replacePartialApplyInst(SILBuilder &builder, SILPassManager *pm, SILLocation loc
   auto *newPAI =
       builder.createPartialApply(loc, newFn, newSubs, newArgs, convention,
                                  isolation);
+  newPAI->setStackAllocationIsNested(oldPAI->isStackAllocationNested());
 
   // Check if any casting is required for the partially-applied function.
   // A non-guaranteed cast needs no usePoints.

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -2666,6 +2666,7 @@ swift::replaceWithSpecializedCallee(ApplySite applySite, SILValue callee,
         loc, callee, subs, arguments,
         pai->getCalleeConvention(), pai->getResultIsolation(),
         pai->isOnStack());
+    newPAI->setStackAllocationIsNested(pai->isStackAllocationNested());
     pai->replaceAllUsesWith(newPAI);
     return newPAI;
   }
@@ -3528,6 +3529,7 @@ void swift::trySpecializeApplyOfGeneric(
       PAI->getLoc(), FRI, Subs, Arguments,
       PAI->getCalleeConvention(), PAI->getResultIsolation(),
       PAI->isOnStack());
+    newPAI->setStackAllocationIsNested(PAI->isStackAllocationNested());
     PAI->replaceAllUsesWith(newPAI);
     DeadApplies.insert(PAI);
     return;

--- a/lib/SILOptimizer/Utils/LoopUtils.cpp
+++ b/lib/SILOptimizer/Utils/LoopUtils.cpp
@@ -22,6 +22,7 @@
 #include "swift/SIL/SILBasicBlock.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILModule.h"
+#include "swift/SIL/StackAllocation.h"
 #include "swift/SILOptimizer/Utils/CFGOptUtils.h"
 #include "llvm/Support/Debug.h"
 
@@ -245,7 +246,7 @@ bool swift::canDuplicateLoopInstruction(SILLoop *L, SILInstruction *I, DeadEndBl
   // The deallocation of a stack allocation must be in the loop, otherwise the
   // deallocation will be fed by a phi node of two allocations.
   if (auto allocation = I->getStackAllocation()) {
-    for (auto *UI : allocation->getUses()) {
+    for (auto *UI : allocation->getValue()->getUses()) {
       if (UI->getUser()->isDeallocatingStack()) {
         if (!L->contains(UI->getUser()->getParent()))
           return false;
@@ -253,19 +254,9 @@ bool swift::canDuplicateLoopInstruction(SILLoop *L, SILInstruction *I, DeadEndBl
     }
     return true;
   }
-  if (I->isDeallocatingStack()) {
-    SILInstruction *alloc = nullptr;
-    if (auto *dealloc = dyn_cast<DeallocStackInst>(I)) {
-      SILValue address = dealloc->getOperand();
-      if (isa<AllocStackInst>(address) || isa<PartialApplyInst>(address))
-        alloc = cast<SingleValueInstruction>(address);
-      else if (isaResultOf<BeginApplyInst>(address))
-        alloc = cast<MultipleValueInstructionResult>(address)->getParent();
-    }
-    if (auto *dealloc = dyn_cast<DeallocStackRefInst>(I))
-      alloc = dealloc->getAllocRef();
-
-    return alloc && L->contains(alloc);
+  if (auto deallocation = I->getStackDeallocation()) {
+    SILInstruction *alloc = deallocation->getAllocation().getInstruction();
+    return L->contains(alloc);
   }
   // In OSSA, partial_apply is not considered stack allocating. Nonetheless,
   // prevent it from being cloned so OSSA lowering can directly convert it to a

--- a/lib/SILOptimizer/Utils/StackNesting.cpp
+++ b/lib/SILOptimizer/Utils/StackNesting.cpp
@@ -190,16 +190,17 @@ static void createDealloc(SILBuilder &B, SILLocation loc, SILInstruction *alloc)
     return;
   case StackAllocationKind::BuiltinStackAlloc:
   case StackAllocationKind::BuiltinUnprotectedStackAlloc: {
-    auto *bi = cast<BuiltinInst>(alloc);
     auto &ctx = alloc->getFunction()->getModule().getASTContext();
-
     auto identifier =
       ctx.getIdentifier(getBuiltinName(BuiltinValueKind::StackDealloc));
     B.createBuiltin(loc, identifier,
                     SILType::getEmptyTupleType(ctx),
-                    SubstitutionMap(), {bi});
+                    SubstitutionMap(), {allocation->getValue()});
     return;
   }
+  case StackAllocationKind::BuiltinStartAsyncLet:
+    llvm_unreachable("cannot insert finishAsyncLet builtin; not safely reorderable");
+    return;
   case StackAllocationKind::AllocPackMetadata:
     B.createDeallocPackMetadata(loc, allocation->getValue());
     return;
@@ -225,6 +226,10 @@ static bool isUnreorderableAllocation(StackAllocation allocation) {
   // is specifically the callee allocation, which *can* be reordered.
   case StackAllocationKind::CalleeAllocatedBeginApply:
     return false;
+
+  // The finish of an async let cannot be reordered across.
+  case StackAllocationKind::BuiltinStartAsyncLet:
+    return true;
   }
   llvm_unreachable("unknown stack allocation");
 }

--- a/lib/SILOptimizer/Utils/StackNesting.cpp
+++ b/lib/SILOptimizer/Utils/StackNesting.cpp
@@ -264,7 +264,7 @@ class ActiveAllocation {
   llvm::PointerIntPair<SILInstruction*, 2, AllocationStatus> valueAndStatus;
 
 public:
-  ActiveAllocation(SILInstruction *value)
+  explicit ActiveAllocation(SILInstruction *value)
     : valueAndStatus(value, AllocationStatus::Allocated) {}
 
   SILInstruction *getValue() const {
@@ -470,18 +470,32 @@ void State::collectAllocationsAbove(SILInstruction *alloc,
   auto stack = ArrayRef(allocations);
   assert(!stack.empty());
   for (size_t i = stack.size() - 1; true; --i) {
-    if (stack[i] == alloc) break;
-    set.insert(stack[i].getValue());
+    // If we reach the target allocation, we've processed all the
+    // allocations above it, so we're done.
+    if (stack[i].getValue() == alloc) break;
+
+    // Add the allocation to the set unless it's flagged as already
+    // deallocated.
+    if (stack[i].getStatus() != AllocationStatus::DeallocatedOutOfOrder) {
+#ifndef NDEBUG
+      auto sa = stack[i].getValue()->getStackAllocation();
+      assert(sa && !isUnreorderableAllocation(*sa));
+#endif
+      set.insert(stack[i].getValue());
+    }
+
     assert(i != 0 && "didn't find allocation in stack");
   }
 }
 
 /// Pop and emit deallocations for any allocations on top of the
-/// active allocations stack that are pending deallocation.
+/// active allocations stack that are pending deallocation. Also pop
+/// allocations in the deallocated-out-of-order state, but do not
+/// emit them.
 ///
 /// This operation is called whenever we pop an allocation; it
 /// restores the invariant that the top of the stack is never in a
-/// pending state.
+/// pending or deallocated-out-of-order state.
 static void emitPendingDeallocations(State &state,
                                      SILInstruction *insertAfterDealloc,
                                      bool &madeChanges) {
@@ -650,7 +664,7 @@ StackNesting::Changes StackNesting::fixNesting(SILFunction *F) {
       if (auto alloc = I->getStackAllocation()) {
         // Only handle nested stack allocations.
         if (I->isStackAllocationNested() == StackAllocationIsNested)
-          state.allocations.push_back(I);
+          state.allocations.emplace_back(I);
         continue;
       }
 
@@ -710,10 +724,11 @@ StackNesting::Changes StackNesting::fixNesting(SILFunction *F) {
         auto status = entry.getStatus();
         assert(isAllocatedOrUndeallocatable(status));
 
-        // If the allocation has allocated status but cannot be reordered,
-        // mark the allocation as deallocated out of order, then add all
-        // the allocations above it to the allocated-out-of-order set.
-        // Do not remove the allocation itself.
+        // If the allocation has allocated status but its deallocation
+        // cannot be reordered, mark the allocation as deallocated out
+        // of order, then add all the allocations above it to the
+        // allocated-out-of-order set. Do not remove the deallocation.
+        //
         // FIXME: We really need to do this even for allocations with
         // undeallocatable status. The problem is that we'd need to collect
         // the *union* of the active allocations on entry to this dead-end

--- a/lib/SILOptimizer/Utils/StackNesting.cpp
+++ b/lib/SILOptimizer/Utils/StackNesting.cpp
@@ -16,6 +16,7 @@
 #include "swift/SIL/Dominance.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILFunction.h"
+#include "swift/SIL/StackAllocation.h"
 #include "swift/SIL/Test.h"
 #include "llvm/Support/Debug.h"
 
@@ -161,16 +162,6 @@ void runInDominanceOrder(SILFunction &F, State &&state, const Fn &fn) {
   }
 }
 
-/// Returns the stack allocation instruction for a stack deallocation
-/// instruction.
-static SILInstruction *getAllocForDealloc(SILInstruction *dealloc) {
-  SILValue op = dealloc->getOperand(0);
-  while (auto *mvi = dyn_cast<MoveValueInst>(op)) {
-    op = mvi->getOperand();
-  }
-  return op->getDefiningInstruction();
-}
-
 /// Create a dealloc for a particular allocation.
 ///
 /// This is expected to work for all allocations that don't have
@@ -182,88 +173,60 @@ static SILInstruction *getAllocForDealloc(SILInstruction *dealloc) {
 /// Only allocations whose deallocations return true from canMoveDealloc
 /// need to support this.
 static void createDealloc(SILBuilder &B, SILLocation loc, SILInstruction *alloc) {
-  switch (alloc->getKind()) {
-  case SILInstructionKind::PartialApplyInst:
-  case SILInstructionKind::AllocStackInst:
-    assert((isa<AllocStackInst>(alloc) ||
-            cast<PartialApplyInst>(alloc)->isOnStack()) &&
-           "wrong instruction");
-    B.createDeallocStack(loc, cast<SingleValueInstruction>(alloc));
+  auto allocation = alloc->getStackAllocation();
+  assert(allocation);
+  switch (allocation->getKind()) {
+  case StackAllocationKind::PartialApply:
+  case StackAllocationKind::AllocStack:
+  case StackAllocationKind::CalleeAllocatedBeginApply:
+    B.createDeallocStack(loc, allocation->getValue());
     return;
-  case SILInstructionKind::BeginApplyInst: {
-    auto *bai = cast<BeginApplyInst>(alloc);
-    assert(bai->isCalleeAllocated());
-    B.createDeallocStack(loc, bai->getCalleeAllocationResult());
+  case StackAllocationKind::AllocRefDynamic:
+  case StackAllocationKind::AllocRef:
+    B.createDeallocStackRef(loc, allocation->getValue());
     return;
-  }
-  case SILInstructionKind::AllocRefDynamicInst:
-  case SILInstructionKind::AllocRefInst:
-    assert(cast<AllocRefInstBase>(alloc)->canAllocOnStack());
-    B.createDeallocStackRef(loc, cast<AllocRefInstBase>(alloc));
+  case StackAllocationKind::AllocPack:
+    B.createDeallocPack(loc, allocation->getValue());
     return;
-  case SILInstructionKind::AllocPackInst:
-    B.createDeallocPack(loc, cast<AllocPackInst>(alloc));
-    return;
-  case SILInstructionKind::BuiltinInst: {
+  case StackAllocationKind::BuiltinStackAlloc:
+  case StackAllocationKind::BuiltinUnprotectedStackAlloc: {
     auto *bi = cast<BuiltinInst>(alloc);
     auto &ctx = alloc->getFunction()->getModule().getASTContext();
 
-    switch (*bi->getBuiltinKind()) {
-    case BuiltinValueKind::StackAlloc:
-    case BuiltinValueKind::UnprotectedStackAlloc: {
-      auto identifier =
-        ctx.getIdentifier(getBuiltinName(BuiltinValueKind::StackDealloc));
-      B.createBuiltin(loc, identifier,
-                      SILType::getEmptyTupleType(ctx),
-                      SubstitutionMap(), {bi});
-      return;
-    }
-    default:
-      llvm_unreachable("unknown stack allocation builtin");
-    }
-  }
-  case SILInstructionKind::AllocPackMetadataInst:
-    B.createDeallocPackMetadata(loc, cast<AllocPackMetadataInst>(alloc));
+    auto identifier =
+      ctx.getIdentifier(getBuiltinName(BuiltinValueKind::StackDealloc));
+    B.createBuiltin(loc, identifier,
+                    SILType::getEmptyTupleType(ctx),
+                    SubstitutionMap(), {bi});
     return;
-  default:
-    llvm_unreachable("unknown stack allocation");
   }
+  case StackAllocationKind::AllocPackMetadata:
+    B.createDeallocPackMetadata(loc, allocation->getValue());
+    return;
+  }
+  llvm_unreachable("unknown stack allocation");
 }
 
-static bool isUnreorderableAllocation(SILInstruction *alloc) {
-  switch (alloc->getKind()) {
+static bool isUnreorderableAllocation(StackAllocation allocation) {
+  switch (allocation.getKind()) {
   // These are all simple allocations for which the deallocation can
   // always be sunk.
-  case SILInstructionKind::PartialApplyInst:
-  case SILInstructionKind::AllocStackInst:
-  case SILInstructionKind::AllocRefDynamicInst:
-  case SILInstructionKind::AllocRefInst:
-  case SILInstructionKind::AllocPackInst:
-  case SILInstructionKind::AllocPackMetadataInst:
+  case StackAllocationKind::PartialApply:
+  case StackAllocationKind::AllocStack:
+  case StackAllocationKind::AllocRefDynamic:
+  case StackAllocationKind::AllocRef:
+  case StackAllocationKind::AllocPack:
+  case StackAllocationKind::AllocPackMetadata:
+  case StackAllocationKind::BuiltinStackAlloc:
+  case StackAllocationKind::BuiltinUnprotectedStackAlloc:
     return false;
 
   // end_apply is side-effectful in general, but the allocation here
   // is specifically the callee allocation, which *can* be reordered.
-  case SILInstructionKind::BeginApplyInst:
+  case StackAllocationKind::CalleeAllocatedBeginApply:
     return false;
-
-  case SILInstructionKind::BuiltinInst: {
-    auto *bi = cast<BuiltinInst>(alloc);
-    switch (*bi->getBuiltinKind()) {
-    // These are simple allocations for which the deallocation can always
-    // be sunk.
-    case BuiltinValueKind::StackAlloc:
-    case BuiltinValueKind::UnprotectedStackAlloc:
-      return false;
-
-    default:
-      llvm_unreachable("unknown stack allocation builtin");
-    }
   }
-
-  default:
-    llvm_unreachable("unknown stack allocation");
-  }
+  llvm_unreachable("unknown stack allocation");
 }
 
 namespace {
@@ -679,7 +642,7 @@ StackNesting::Changes StackNesting::fixNesting(SILFunction *F) {
       //
       // In the formal presentation, the state change is
       //   state = STATE_PUSH(state, alloc)
-      if (I->isAllocatingStack()) {
+      if (auto alloc = I->getStackAllocation()) {
         // Only handle nested stack allocations.
         if (I->isStackAllocationNested() == StackAllocationIsNested)
           state.allocations.push_back(I);
@@ -687,20 +650,23 @@ StackNesting::Changes StackNesting::fixNesting(SILFunction *F) {
       }
 
       // Ignore instructions other than allocations and deallocations.
-      if (!I->isDeallocatingStack()) {
+      auto deallocation = I->getStackDeallocation();
+      if (!deallocation) {
         continue;
       }
 
       // Get the allocation for the deallocation. The allocation should be
       // in the state, and it should not have pending status; see
       // [deallocation-preconditions] in the proof.
-      SILInstruction *dealloc = I;
-      SILInstruction *alloc = getAllocForDealloc(dealloc);
+      auto allocation = deallocation->getAllocation();
 
       // Since we only processed nested allocations above, ignore deallocations
       // from non-nested allocations.
-      if (alloc->isStackAllocationNested() == StackAllocationIsNotNested)
+      if (allocation.isNested() == StackAllocationIsNotNested)
         continue;
+
+      auto dealloc = deallocation->getInstruction();
+      auto alloc = allocation.getInstruction();
 
 #ifndef NDEBUG
       if (state.allocations.empty()) {
@@ -749,7 +715,7 @@ StackNesting::Changes StackNesting::fixNesting(SILFunction *F) {
         // region in order to force the allocation to remain deallocatable
         // here, and we don't have that information easily at hand.
         if (status == AllocationStatus::Allocated &&
-            isUnreorderableAllocation(alloc)) {
+            isUnreorderableAllocation(allocation)) {
           state.collectAllocationsAbove(alloc, unnestedAllocations);
           entry.setDeallocatedOutOfOrder();
           continue;

--- a/lib/SILOptimizer/Utils/StackNesting.cpp
+++ b/lib/SILOptimizer/Utils/StackNesting.cpp
@@ -230,10 +230,67 @@ static void createDealloc(SILBuilder &B, SILLocation loc, SILInstruction *alloc)
   }
 }
 
+static bool isUnreorderableAllocation(SILInstruction *alloc) {
+  switch (alloc->getKind()) {
+  // These are all simple allocations for which the deallocation can
+  // always be sunk.
+  case SILInstructionKind::PartialApplyInst:
+  case SILInstructionKind::AllocStackInst:
+  case SILInstructionKind::AllocRefDynamicInst:
+  case SILInstructionKind::AllocRefInst:
+  case SILInstructionKind::AllocPackInst:
+  case SILInstructionKind::AllocPackMetadataInst:
+    return false;
+
+  // end_apply is side-effectful in general, but the allocation here
+  // is specifically the callee allocation, which *can* be reordered.
+  case SILInstructionKind::BeginApplyInst:
+    return false;
+
+  case SILInstructionKind::BuiltinInst: {
+    auto *bi = cast<BuiltinInst>(alloc);
+    switch (*bi->getBuiltinKind()) {
+    // These are simple allocations for which the deallocation can always
+    // be sunk.
+    case BuiltinValueKind::StackAlloc:
+    case BuiltinValueKind::UnprotectedStackAlloc:
+      return false;
+
+    default:
+      llvm_unreachable("unknown stack allocation builtin");
+    }
+  }
+
+  default:
+    llvm_unreachable("unknown stack allocation");
+  }
+}
+
 namespace {
 enum class AllocationStatus {
-  Allocated, Pending, Undeallocatable
+  /// No deallocation has been processed for this allocation.
+  Allocated,
+  /// A deallocation has been processed for this allocation, but the
+  /// allocation was not at the top of the stack, so the deallocation
+  /// has been deferred.
+  Pending,
+  /// A deallocation has been processed for this allocation, but the
+  /// allocation was not at the top of the stack. The deallocation could
+  /// not be deferred, so it was just deallocated out of order, and all
+  /// the active allocations above it were marked as non-nested.
+  /// (This state is not described in the correctness proof.)
+  DeallocatedOutOfOrder,
+  /// The allocation cannot be deallocated because there was a stack
+  /// mismatch on a branch into the current region (which is dead-end).
+  /// Whether a deallocation has been processed for this allocation is
+  /// no longer known.
+  Undeallocatable,
 };
+
+static bool isAllocatedOrUndeallocatable(AllocationStatus status) {
+  return status == AllocationStatus::Allocated ||
+         status == AllocationStatus::Undeallocatable;
+}
 
 class ActiveAllocation {
   llvm::PointerIntPair<SILInstruction*, 2, AllocationStatus> valueAndStatus;
@@ -253,6 +310,11 @@ public:
   void setPending() {
     assert(getStatus() == AllocationStatus::Allocated);
     valueAndStatus.setInt(AllocationStatus::Pending);
+  }
+
+  void setDeallocatedOutOfOrder() {
+    assert(getStatus() == AllocationStatus::Allocated);
+    valueAndStatus.setInt(AllocationStatus::DeallocatedOutOfOrder);
   }
 
   void setUndeallocatable() {
@@ -276,6 +338,9 @@ struct State {
   ActiveAllocation &getEntryForNonTop(SILInstruction *alloc,
                                       SILInstruction *dealloc,
                                       IndexForAllocationMap &indexForAllocation);
+
+  void collectAllocationsAbove(SILInstruction *alloc,
+                               SmallPtrSetImpl<SILInstruction*> &set) const;
 
   /// Given that these are the end states of two blocks with edges into
   /// a dead-end region R, merge them.
@@ -432,6 +497,17 @@ State::getEntryForNonTop(SILInstruction *alloc,
   return stack[*foundIndexForAlloc];
 }
 
+void State::collectAllocationsAbove(SILInstruction *alloc,
+                         llvm::SmallPtrSetImpl<SILInstruction*> &set) const {
+  auto stack = ArrayRef(allocations);
+  assert(!stack.empty());
+  for (size_t i = stack.size() - 1; true; --i) {
+    if (stack[i] == alloc) break;
+    set.insert(stack[i].getValue());
+    assert(i != 0 && "didn't find allocation in stack");
+  }
+}
+
 /// Pop and emit deallocations for any allocations on top of the
 /// active allocations stack that are pending deallocation.
 ///
@@ -447,22 +523,41 @@ static void emitPendingDeallocations(State &state,
   // correctly w.r.t each other.
   std::optional<SILBuilderWithScope> builder;
 
-  while (!state.allocations.empty() &&
-         state.allocations.back().getStatus() == AllocationStatus::Pending) {
-    auto entry = state.allocations.pop_back_val();
-    SILInstruction *alloc = entry.getValue();
+  while (!state.allocations.empty()) {
+    switch (state.allocations.back().getStatus()) {
+    // Pop and emit a deallocation for an allocation with pending status.
+    case AllocationStatus::Pending: {
+      auto entry = state.allocations.pop_back_val();
+      SILInstruction *alloc = entry.getValue();
 
-    // Create a builder if necessary.
-    if (!builder) {
-      // We want to use the location of (and inherit debug scopes from)
-      // the initial dealloc that we're inserting after.
-      builder.emplace(/*insertion point*/
-                        std::next(insertAfterDealloc->getIterator()),
-                      /*inherit scope from*/insertAfterDealloc);
+      // Create a builder if necessary.
+      if (!builder) {
+        // We want to use the location of (and inherit debug scopes from)
+        // the initial dealloc that we're inserting after.
+        builder.emplace(/*insertion point*/
+                          std::next(insertAfterDealloc->getIterator()),
+                        /*inherit scope from*/insertAfterDealloc);
+      }
+
+      createDealloc(*builder, insertAfterDealloc->getLoc(), alloc);
+      madeChanges = true;
+      continue;
     }
 
-    createDealloc(*builder, insertAfterDealloc->getLoc(), alloc);
-    madeChanges = true;
+    // Pop allocations with deallocated-out-of-order status, but don't
+    // emit a deallocation for them because we left the original
+    // deallocation in place.
+    case AllocationStatus::DeallocatedOutOfOrder: {
+      state.allocations.pop_back();
+      continue;
+    }
+
+    // Stop if we see an allocation with a different status.
+    case AllocationStatus::Allocated:
+    case AllocationStatus::Undeallocatable:
+      return;
+    }
+    llvm_unreachable("bad state");
   }
 }
 
@@ -552,6 +647,11 @@ static void emitPendingDeallocations(State &state,
 StackNesting::Changes StackNesting::fixNesting(SILFunction *F) {
   bool madeChanges = false;
 
+  // The set of allocations that we need to flag as unnested.
+  // We can't do this live because we might run across more
+  // deallocations of the allocation.
+  SmallPtrSet<SILInstruction*, 8> unnestedAllocations;
+
   // The index in the allocation stack for each allocation.
   // This function never uses this directly; it's just a cache for
   // setAllocationAsPending.
@@ -570,9 +670,10 @@ StackNesting::Changes StackNesting::fixNesting(SILFunction *F) {
       SILInstruction *I = &*II;
       ++II;
 
-      // Invariant: the top of the stack is never pending.
+      // Invariant: the top of the stack is either allocated or
+      // undeallocatable.
       assert(state.allocations.empty() ||
-             state.allocations.back().getStatus() != AllocationStatus::Pending);
+             isAllocatedOrUndeallocatable(state.allocations.back().getStatus()));
 
       // Push allocations onto the current stack in the non-pending state.
       //
@@ -610,8 +711,7 @@ StackNesting::Changes StackNesting::fixNesting(SILFunction *F) {
       // If the allocation is the top of the allocations stack:
       if (alloc == state.allocations.back().getValue()) {
         auto status = state.allocations.back().getStatus();
-        assert(status == AllocationStatus::Allocated ||
-               status == AllocationStatus::Undeallocatable);
+        assert(isAllocatedOrUndeallocatable(status));
 
         // If the allocation has allocated status, leave the deallocation
         // alone, pop the record of it off the stack, and pop and emit any
@@ -637,8 +737,23 @@ StackNesting::Changes StackNesting::fixNesting(SILFunction *F) {
                                               indexForAllocation);
 
         auto status = entry.getStatus();
-        assert(status == AllocationStatus::Allocated ||
-               status == AllocationStatus::Undeallocatable);
+        assert(isAllocatedOrUndeallocatable(status));
+
+        // If the allocation has allocated status but cannot be reordered,
+        // mark the allocation as deallocated out of order, then add all
+        // the allocations above it to the allocated-out-of-order set.
+        // Do not remove the allocation itself.
+        // FIXME: We really need to do this even for allocations with
+        // undeallocatable status. The problem is that we'd need to collect
+        // the *union* of the active allocations on entry to this dead-end
+        // region in order to force the allocation to remain deallocatable
+        // here, and we don't have that information easily at hand.
+        if (status == AllocationStatus::Allocated &&
+            isUnreorderableAllocation(alloc)) {
+          state.collectAllocationsAbove(alloc, unnestedAllocations);
+          entry.setDeallocatedOutOfOrder();
+          continue;
+        }
 
         // If the allocation has allocated status, remove the deallocation
         // and update the allocation status to pending.
@@ -658,6 +773,13 @@ StackNesting::Changes StackNesting::fixNesting(SILFunction *F) {
       }
     }
   });
+
+  // Now that we're done traversing the CFG, record all of the allocations
+  // as unnested that we need to.
+  for (auto alloc : unnestedAllocations) {
+    alloc->setStackAllocationIsNested(StackAllocationIsNotNested);
+    madeChanges = true;
+  }
 
   // We never make changes to the CFG.
   return (madeChanges ? Changes::Instructions : Changes::None);

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -2358,10 +2358,17 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
                        ? PartialApplyInst::OnStackKind::OnStack
                        : PartialApplyInst::OnStackKind::NotOnStack;
 
+    unsigned flags = ApplyCallerIsolation;
+    auto isNested = StackAllocationIsNested_t(
+      IsNestedEncoding((flags >> 0) & 1) == IsNestedEncoding::IsNested);
+
     // FIXME: Why the arbitrary order difference in IRBuilder type argument?
-    ResultInst = Builder.createPartialApply(
+    auto PAI = Builder.createPartialApply(
         Loc, FnVal, Substitutions, Args,
         closureTy->getCalleeConvention(), closureTy->getIsolation(), onStack);
+    PAI->setStackAllocationIsNested(isNested);
+
+    ResultInst = PAI;
     break;
   }
   case SILInstructionKind::BuiltinInst: {

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -92,6 +92,11 @@ enum class ExtraStringFlavor : uint8_t {
   WasmImportName,
 };
 
+enum class IsNestedEncoding : uint8_t {
+  IsNotNested,
+  IsNested,
+};
+
 /// The record types within the "sil-index" block.
 ///
 /// \sa SIL_INDEX_BLOCK_ID

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1503,6 +1503,10 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     for (auto Arg: PAI->getArguments()) {
       Args.push_back(addValueRef(Arg));
     }
+    unsigned flags = 0;
+    flags |= unsigned(PAI->isStackAllocationNested()
+                        ? IsNestedEncoding::IsNested
+                        : IsNestedEncoding::IsNotNested) << 0;
     SILInstApplyLayout::emitRecord(
         Out, ScratchRecord, SILAbbrCodes[SILInstApplyLayout::Code],
         SIL_PARTIAL_APPLY, 0,
@@ -1510,7 +1514,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
         S.addTypeRef(PAI->getCallee()->getType().getRawASTType()),
         S.addTypeRef(PAI->getType().getRawASTType()),
         addValueRef(PAI->getCallee()),
-        unsigned(swift::ActorIsolation::Unspecified),
+        flags,
         unsigned(swift::ActorIsolation::Unspecified), Args);
     break;
   }

--- a/test/IRGen/keypaths.sil
+++ b/test/IRGen/keypaths.sil
@@ -406,23 +406,30 @@ struct Foo<T> {
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @stored_property_generics(ptr %T, ptr %U)
 sil @stored_property_generics : $@convention(thin) <T, U> () -> () {
 entry:
-  // CHECK: [[ARGS:%.*]] = alloca i{{.*}}
-  // CHECK: store ptr %T, ptr [[ARGS]]
-  // CHECK: call ptr @swift_getKeyPath(ptr [[KP_I]], ptr [[ARGS]])
+  // CHECK: [[ARGS1:%.*]] = alloca i{{.*}}
+  // CHECK: [[ARGS2:%.*]] = alloca i{{.*}}
+  // CHECK: [[ARGS3:%.*]] = alloca i{{.*}}
+
+  // CHECK: call void @llvm.lifetime.start.p0(i64 {{.*}}, ptr [[ARGS1]])
+  // CHECK: store ptr %T, ptr [[ARGS1]]
+  // CHECK: call ptr @swift_getKeyPath(ptr [[KP_I]], ptr [[ARGS1]])
+  // CHECK: call void @llvm.lifetime.end.p0(i64 {{.*}}, ptr [[ARGS1]])
   %i = keypath $KeyPath<Gen<T,T>, T>, <A> (root $Gen<A, A>; stored_property #Gen.x : $A) <T>
   strong_retain %i : $KeyPath<Gen<T,T>, T>
 
-  // CHECK: [[ARGS:%.*]] = alloca i{{.*}}
-  // CHECK: store ptr %U, ptr [[ARGS]]
-  // CHECK: call ptr @swift_getKeyPath(ptr [[KP_J]], ptr [[ARGS]])
+  // CHECK: call void @llvm.lifetime.start.p0(i64 {{.*}}, ptr [[ARGS2]])
+  // CHECK: store ptr %U, ptr [[ARGS2]]
+  // CHECK: call ptr @swift_getKeyPath(ptr [[KP_J]], ptr [[ARGS2]])
+  // CHECK: call void @llvm.lifetime.end.p0(i64 {{.*}}, ptr [[ARGS2]])
   %j = keypath $KeyPath<Gen<U,U>, U>, <A> (root $Gen<A, A>; stored_property #Gen.y : $A) <U>
   strong_retain %j : $KeyPath<Gen<U,U>, U>
 
-  // CHECK: [[ARGS:%.*]] = alloca i{{.*}}
+  // CHECK: call void @llvm.lifetime.start.p0(i64 {{.*}}, ptr [[ARGS3]])
   // CHECK: [[T0:%.*]] = call swiftcc %swift.metadata_response @"$s8keypaths3FooVMa"([[WORD]] 0, ptr %T)
   // CHECK: [[FOO_T:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
-  // CHECK: store ptr [[FOO_T]], ptr [[ARGS]]
-  // CHECK: call ptr @swift_getKeyPath(ptr [[KP_I]], ptr [[ARGS]])
+  // CHECK: store ptr [[FOO_T]], ptr [[ARGS3]]
+  // CHECK: call ptr @swift_getKeyPath(ptr [[KP_I]], ptr [[ARGS3]])
+  // CHECK: call void @llvm.lifetime.end.p0(i64 {{.*}}, ptr [[ARGS3]])
   %i2 = keypath $KeyPath<Gen<Foo<T>,Foo<T>>, Foo<T>>, <A> (root $Gen<A, A>; stored_property #Gen.x : $A) <Foo<T>>
   strong_retain %i2 : $KeyPath<Gen<Foo<T>,Foo<T>>, Foo<T>>
 
@@ -432,21 +439,28 @@ entry:
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @tuple_generics(ptr %T, ptr %U, ptr %V)
 sil @tuple_generics : $@convention(thin) <T, U, V> () -> () {
 entry:
-  // CHECK: [[ARGS:%.*]] = alloca i{{.*}}
-  // CHECK: store ptr %T, ptr [[ARGS]]
-  // CHECK: call ptr @swift_getKeyPath(ptr [[KP_TG0]], ptr [[ARGS]])
+  // CHECK: [[ARGS1:%.*]] = alloca i{{.*}}
+  // CHECK: [[ARGS2:%.*]] = alloca i{{.*}}
+  // CHECK: [[ARGS3:%.*]] = alloca i{{.*}}
+
+  // CHECK: call void @llvm.lifetime.start.p0(i64 {{.*}}, ptr [[ARGS1]])
+  // CHECK: store ptr %T, ptr [[ARGS1]]
+  // CHECK: call ptr @swift_getKeyPath(ptr [[KP_TG0]], ptr [[ARGS1]])
+  // CHECK: call void @llvm.lifetime.end.p0(i64 {{.*}}, ptr [[ARGS1]])
   %tg0 = keypath $KeyPath<TG<T,U,V>, T>, <A,B,C> (root $TG<A,B,C>; stored_property #TG.a : $(A,B,C); tuple_element #0 : $A) <T,U,V>
   strong_retain %tg0 : $KeyPath<TG<T,U,V>, T>
 
-  // CHECK: [[ARGS:%.*]] = alloca i{{.*}}
-  // CHECK: store ptr %T, ptr [[ARGS]]
-  // CHECK: call ptr @swift_getKeyPath(ptr [[KP_TG1]], ptr [[ARGS]])
+  // CHECK: call void @llvm.lifetime.start.p0(i64 {{.*}}, ptr [[ARGS2]])
+  // CHECK: store ptr %T, ptr [[ARGS2]]
+  // CHECK: call ptr @swift_getKeyPath(ptr [[KP_TG1]], ptr [[ARGS2]])
+  // CHECK: call void @llvm.lifetime.end.p0(i64 {{.*}}, ptr [[ARGS2]])
   %tg1 = keypath $KeyPath<TG<T,U,V>, V>, <A,B,C> (root $TG<A,B,C>; stored_property #TG.a : $(A,B,C); tuple_element #2 : $C) <T,U,V>
   strong_retain %tg1 : $KeyPath<TG<T,U,V>, V>
 
-  // CHECK: [[ARGS:%.*]] = alloca i{{.*}}
-  // CHECK: store ptr %T, ptr [[ARGS]]
-  // CHECK: call ptr @swift_getKeyPath(ptr [[KP_TG2]], ptr [[ARGS]])
+  // CHECK: call void @llvm.lifetime.start.p0(i64 {{.*}}, ptr [[ARGS3]])
+  // CHECK: store ptr %T, ptr [[ARGS3]]
+  // CHECK: call ptr @swift_getKeyPath(ptr [[KP_TG2]], ptr [[ARGS3]])
+  // CHECK: call void @llvm.lifetime.end.p0(i64 {{.*}}, ptr [[ARGS3]])
   %tg2 = keypath $KeyPath<TGA<T,U>, U>, <A,B> (root $TGA<A,B>; tuple_element #1 : $B) <T,U>
   strong_retain %tg2 : $KeyPath<TGA<T,U>, U>
 

--- a/test/IRGen/partial_apply.sil
+++ b/test/IRGen/partial_apply.sil
@@ -16,6 +16,7 @@ sil @$s13partial_apply10SwiftClassCfD : $@convention(method) (SwiftClass) -> ()
 
 sil @partially_applyable_to_class : $@convention(thin) (@guaranteed SwiftClass) -> ()
 sil @partially_applyable_to_two_classes : $@convention(thin) (@guaranteed SwiftClass, @guaranteed SwiftClass) -> ()
+sil @partially_applyable_to_twenty_classes : $@convention(thin) (@guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass) -> ()
 
 sil @use_closure : $@convention(thin) (@noescape @callee_guaranteed () -> ()) -> ()
 
@@ -75,6 +76,96 @@ entry(%a : $SwiftClass, %b: $SwiftClass):
   %t = tuple()
   return %t : $()
 }
+
+//   A [non_nested] partial application can still allocate the context
+//   with a static alloca if it's fixed size.
+// CHECK: define{{.*}} swiftcc void @partial_apply_two_classes_on_stack_non_nested(ptr %0, ptr %1)
+// CHECK: entry:
+// CHECK:   [[CTX:%.*]] = alloca i8, i64 32, align 16
+// CHECK:   [[CAPTURE1:%.*]] = getelementptr inbounds{{.*}} <{ %swift.refcounted, ptr, ptr }>, ptr [[CTX]], i32 0, i32 1
+// CHECK:   store ptr %0, ptr [[CAPTURE1]], align 8
+// CHECK:   [[CAPTURE2:%.*]] = getelementptr inbounds{{.*}} <{ %swift.refcounted, ptr, ptr }>, ptr [[CTX]], i32 0, i32 2
+// CHECK:   store ptr %1, ptr [[CAPTURE2]], align 8
+// CHECK:   call swiftcc void @use_closure(ptr @"$s34partially_applyable_to_two_classesTA.2", ptr [[CTX]])
+// CHECK:   call void @swift_release(ptr %0)
+// CHECK:   call void @swift_release(ptr %1)
+// CHECK:   ret void
+// CHECK: }
+
+sil @partial_apply_two_classes_on_stack_non_nested : $@convention(thin) (@owned SwiftClass, @owned SwiftClass) -> () {
+entry(%a : $SwiftClass, %b: $SwiftClass):
+  %f = function_ref @partially_applyable_to_two_classes : $@convention(thin) (@guaranteed SwiftClass, @guaranteed SwiftClass) -> ()
+  %c = partial_apply [callee_guaranteed] [on_stack] [non_nested] %f(%a, %b) : $@convention(thin) (@guaranteed SwiftClass, @guaranteed SwiftClass) -> ()
+  %use = function_ref @use_closure : $@convention(thin) (@noescape @callee_guaranteed () -> ()) -> ()
+  apply %use(%c) : $@convention(thin) (@noescape @callee_guaranteed () -> ()) -> ()
+  dealloc_stack %c : $@noescape @callee_guaranteed () ->()
+  strong_release %a : $SwiftClass
+  strong_release %b : $SwiftClass
+  %t = tuple()
+  return %t : $()
+}
+
+//   This exceeds the limit of what we're willing to allocate on the
+//   stack, so we fall over to the heap, which makes it use malloc because
+//   it's non-nested.
+// CHECK: define{{.*}} swiftcc void @partial_apply_twenty_classes_on_stack_non_nested(ptr %0, ptr %1, ptr %2, ptr %3, ptr %4, ptr %5, ptr %6, ptr %7, ptr %8, ptr %9, ptr %10, ptr %11, ptr %12, ptr %13, ptr %14, ptr %15, ptr %16, ptr %17, ptr %18, ptr %19, i1 %20)
+// CHECK: entry:
+// CHECK:   br i1 %20, label %[[YES:[0-9]+]],
+// CHECK: [[YES]]:
+// CHECK:   [[CTX:%.*]] = call ptr @malloc(i64 176)
+// CHECK:   [[CAPTURE0:%.*]] = getelementptr inbounds{{.*}} <{ %swift.refcounted, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr }>, ptr [[CTX]], i32 0, i32 1
+// CHECK:   store ptr %0, ptr [[CAPTURE0]], align 8
+// CHECK:   [[CAPTURE1:%.*]] = getelementptr inbounds{{.*}} <{ %swift.refcounted, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr }>, ptr [[CTX]], i32 0, i32 2
+// CHECK:   store ptr %1, ptr [[CAPTURE1]], align 8
+//          ...
+// CHECK:   call swiftcc void @use_closure(ptr @"$s37partially_applyable_to_twenty_classesTA", ptr [[CTX]])
+// CHECK:   call void @free(ptr [[CTX]])
+// CHECK:   br label %[[DONE:[0-9]+]]
+// CHECK: [[DONE]]:
+// CHECK:   call void @swift_release(ptr %0)
+//          ...
+// CHECK:   ret void
+// CHECK: }
+
+sil @partial_apply_twenty_classes_on_stack_non_nested : $@convention(thin) (@owned SwiftClass, @owned SwiftClass, @owned SwiftClass, @owned SwiftClass, @owned SwiftClass, @owned SwiftClass, @owned SwiftClass, @owned SwiftClass, @owned SwiftClass, @owned SwiftClass, @owned SwiftClass, @owned SwiftClass, @owned SwiftClass, @owned SwiftClass, @owned SwiftClass, @owned SwiftClass, @owned SwiftClass, @owned SwiftClass, @owned SwiftClass, @owned SwiftClass, Builtin.Int1) -> () {
+entry(%a : $SwiftClass, %b: $SwiftClass, %c: $SwiftClass, %d: $SwiftClass, %e: $SwiftClass, %f: $SwiftClass, %g: $SwiftClass, %h: $SwiftClass, %i: $SwiftClass, %j: $SwiftClass, %k: $SwiftClass, %l: $SwiftClass, %m: $SwiftClass, %n: $SwiftClass, %o: $SwiftClass, %p: $SwiftClass, %q: $SwiftClass, %r: $SwiftClass, %s: $SwiftClass, %t: $SwiftClass, %cond: $Builtin.Int1):
+  // We don't limit the size in the entry block, so we also need control flow
+  // to trigger the malloc case.
+  cond_br %cond, bb1, bb2
+
+bb1:
+  %function = function_ref @partially_applyable_to_twenty_classes : $@convention(thin) (@guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass) -> ()
+  %closure = partial_apply [callee_guaranteed] [on_stack] [non_nested] %function(%a, %b, %c, %d, %e, %f, %g, %h, %i, %j, %k, %l, %m, %n, %o, %p, %q, %r, %s, %t) : $@convention(thin) (@guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass, @guaranteed SwiftClass) -> ()
+  %use = function_ref @use_closure : $@convention(thin) (@noescape @callee_guaranteed () -> ()) -> ()
+  apply %use(%closure) : $@convention(thin) (@noescape @callee_guaranteed () -> ()) -> ()
+  dealloc_stack %closure : $@noescape @callee_guaranteed () ->()
+  br bb2
+
+bb2:
+  strong_release %a : $SwiftClass
+  strong_release %b : $SwiftClass
+  strong_release %c : $SwiftClass
+  strong_release %d : $SwiftClass
+  strong_release %e : $SwiftClass
+  strong_release %f : $SwiftClass
+  strong_release %g : $SwiftClass
+  strong_release %h : $SwiftClass
+  strong_release %i : $SwiftClass
+  strong_release %j : $SwiftClass
+  strong_release %k : $SwiftClass
+  strong_release %l : $SwiftClass
+  strong_release %m : $SwiftClass
+  strong_release %n : $SwiftClass
+  strong_release %o : $SwiftClass
+  strong_release %p : $SwiftClass
+  strong_release %q : $SwiftClass
+  strong_release %r : $SwiftClass
+  strong_release %s : $SwiftClass
+  strong_release %t : $SwiftClass
+  %ret = tuple()
+  return %ret : $()
+}
+
 //
 // Check that partially applied generic parameters are correctly substituted
 // in the forwarder.

--- a/test/IRGen/partial_apply_coro.sil
+++ b/test/IRGen/partial_apply_coro.sil
@@ -2203,8 +2203,8 @@ sil public_external @use_closure2 : $@yield_once @convention(thin) (@noescape @y
 // CHECK-LABEL: define {{.*}} @partial_apply_stack_callee_guaranteed_indirect_guaranteed_class_pair_param
 // CHECK-SAME: (ptr noalias captures(none) dereferenceable([[ARG_SIZE:(8|16)]]) %[[ARG:.*]])
 // CHECK: entry:
+// CHECK:   %[[BOX:.*]] = alloca i8,
 // CHECK:   %[[CTX:.*]] = alloca [[[BUFFER_SIZE]] x i8]
-// CHECK:   %[[BOX:.*]] = alloca i8
 // CHECK:   %[[BOXPTR:.*]] = getelementptr inbounds{{.*}} <{ %swift.refcounted, ptr }>, ptr %[[BOX]], i32 0, i32 1
 // CHECK:   store ptr %[[ARG]], ptr %[[BOXPTR]]
 // CHECK:   %[[CTXPTR:.*]] = getelementptr inbounds{{.*}} [[[BUFFER_SIZE]] x i8], ptr %[[CTX]], i32 0, i32 0
@@ -2286,8 +2286,8 @@ entry(%i : $Int, %p : $*SwiftClassPair):
 // CHECK-LABEL: define {{.*}} void @partial_apply_stack_callee_guaranteed_indirect_in_class_pair_param
 // CHECK-SAME: (ptr noalias captures(none) dereferenceable([[PAIR_SIZE]]) %[[ARG:.*]])
 // CHECK: entry:
+// CHECK:   %[[BOX:.*]] = alloca i8,
 // CHECK:   %[[CTX:.*]] = alloca [[[BUFFER_SIZE]] x i8],
-// CHECK:   %[[BOX:.*]] = alloca i8
 // CHECK:   %[[BOXPTR:.*]] = getelementptr inbounds{{.*}} <{ %swift.refcounted, ptr }>, ptr %[[BOX]], i32 0, i32 1
 // CHECK:   store ptr %[[ARG]], ptr %[[BOXPTR]]
 // CHECK:   %[[CTXPTR:.*]] = getelementptr inbounds{{.*}} [[[BUFFER_SIZE]] x i8], ptr %[[CTX]], i32 0, i32 0
@@ -2487,8 +2487,8 @@ entry(%i : $Int, %ic : $*SwiftClassPair):
 // CHECK-LABEL: define {{.*}} void @partial_apply_stack_callee_guaranteed_indirect_in_constant_class_pair_param
 // CHECK-SAME: (ptr noalias captures(none) dereferenceable([[PAIR_SIZE]]) %[[ARG:.*]])
 // CHECK: entry:
+// CHECK:   %[[BOX:.*]] = alloca i8,
 // CHECK:   %[[CTX:.*]] = alloca [[[BUFFER_SIZE]] x i8]
-// CHECK:   %[[BOX:.*]] = alloca i8
 // CHECK:   %[[BOXPTR:.*]] = getelementptr inbounds{{.*}} <{ %swift.refcounted, ptr }>, ptr %[[BOX]], i32 0, i32 1
 // CHECK:   store ptr %[[ARG]], ptr %[[BOXPTR]]
 // CHECK:   %[[CTXPTR:.*]] = getelementptr inbounds{{.*}} [[[BUFFER_SIZE]] x i8], ptr %[[CTX]], i32 0, i32 0

--- a/test/SIL/Parser/basic.sil
+++ b/test/SIL/Parser/basic.sil
@@ -1030,6 +1030,17 @@ bb0(%0 : $Float):
   return %2 : $@callee_owned (Int) -> ()
 }
 
+// CHECK-LABEL: sil @test_partial_apply_non_nested : $@convention(thin) (Float) -> () {
+sil @test_partial_apply_non_nested : $@convention(thin)  (Float) -> () {
+bb0(%0 : $Float):
+  %1 = function_ref @takes_int64_float32 : $@convention(thin) (Int, Float) -> ()
+  // CHECK: partial_apply [on_stack] [non_nested] %{{.*}}(%{{.*}}) : $@convention(thin) (Int, Float) -> ()
+  %2 = partial_apply [on_stack] [non_nested] %1(%0) : $@convention(thin) (Int, Float) -> ()
+  dealloc_stack %2
+  %3 = tuple ()
+  return %3
+}
+
 class X {
   @objc func f() { }
 }

--- a/test/SILOptimizer/stack-nesting.sil
+++ b/test/SILOptimizer/stack-nesting.sil
@@ -309,3 +309,54 @@ bb0(%cond: $Builtin.Int1):
   %ret = tuple ()
   return %ret : $()
 }
+
+sil private @async_let_helper : $@convention(thin) @Sendable @async () -> (@out Int, @error any Error) {
+bb0(%out : $*Int):
+  unreachable
+}
+
+// b and c must be marked as non-nested
+// CHECK-LABEL: sil [ossa] @test_async_let_non_nested
+// CHECK:         integer_literal $Builtin.Int32, 1
+// CHECK-NEXT:    [[A:%.*]] = alloc_stack $Int
+// CHECK:         [[PTR:%.*]] = address_to_pointer [[A]] to $Builtin.RawPointer
+// CHECK-NEXT:    [[LET:%.*]] = builtin "startAsyncLetWithLocalBuffer"<Int>({{%.*}}, {{%.*}}, [[PTR]])
+// CHECK-NEXT:    integer_literal $Builtin.Int32, 2
+// CHECK-NEXT:    [[B:%.*]] = alloc_stack [non_nested] $Int
+// CHECK-NEXT:    [[C:%.*]] = alloc_stack [non_nested] $Int
+// CHECK-NEXT:    integer_literal $Builtin.Int32, 3
+// CHECK-NEXT:    builtin "finishAsyncLet"([[LET]], [[PTR]])
+// CHECK-NEXT:    dealloc_stack [[C]]
+// CHECK-NEXT:    dealloc_stack [[B]]
+// CHECK-NEXT:    dealloc_stack [[A]]
+// CHECK-NEXT:    integer_literal $Builtin.Int32, 4
+// CHECK-LABEL: // end sil function 'test_async_let_non_nested'
+sil [ossa] @test_async_let_non_nested : $@convention(thin) @async (Builtin.Int1) -> () {
+bb0(%cond: $Builtin.Int1):
+  specify_test "stack_nesting_fixup"
+  integer_literal $Builtin.Int32, 1
+  %a = alloc_stack $Int
+
+  %fn = function_ref @async_let_helper : $@convention(thin) @Sendable @async () -> (@out Int, @error any Error)
+  %async_let_fn = thin_to_thick_function %fn to $@Sendable @async () -> (@out Int, @error any Error)
+  %scratch = enum $Optional<Builtin.RawPointer>, #Optional.none!enumelt
+  %resultPtr = address_to_pointer %a to $Builtin.RawPointer
+  %al = builtin "startAsyncLetWithLocalBuffer"<Int>(%scratch, %fn, %resultPtr) : $Builtin.RawPointer
+
+  integer_literal $Builtin.Int32, 2
+
+  %b = alloc_stack $Int
+  %c = alloc_stack $Int
+
+  dealloc_stack %b
+
+  integer_literal $Builtin.Int32, 3
+
+  %out = builtin "finishAsyncLet"(%al, %resultPtr) : $()
+
+  dealloc_stack %a
+  dealloc_stack %c
+  integer_literal $Builtin.Int32, 4
+  %ret = tuple ()
+  return %ret : $()
+}

--- a/test/SILOptimizer/stack-nesting.sil
+++ b/test/SILOptimizer/stack-nesting.sil
@@ -360,3 +360,57 @@ bb0(%cond: $Builtin.Int1):
   %ret = tuple ()
   return %ret : $()
 }
+
+// Make sure we don't panic when there's still an already-deallocated
+// async let on the state stack.
+// CHECK-LABEL: sil [ossa] @test_two_async_lets :
+// CHECK:         integer_literal $Builtin.Int32, 1
+// CHECK-NEXT:    [[A:%.*]] = alloc_stack $Int
+// CHECK:         [[PTR:%.*]] = address_to_pointer [[A]] to $Builtin.RawPointer
+// CHECK-NEXT:    [[LET1:%.*]] = builtin "startAsyncLetWithLocalBuffer"<Int>({{%.*}}, {{%.*}}, [[PTR]])
+// CHECK-NEXT:    [[LET2:%.*]] = builtin "startAsyncLetWithLocalBuffer"<Int>({{%.*}}, {{%.*}}, [[PTR]])
+// CHECK-NEXT:    integer_literal $Builtin.Int32, 2
+// CHECK-NEXT:    [[B:%.*]] = alloc_stack [non_nested] $Int
+// CHECK-NEXT:    [[C:%.*]] = alloc_stack $Int
+// CHECK-NEXT:    dealloc_stack [[C]]
+// CHECK-NEXT:    integer_literal $Builtin.Int32, 3
+// CHECK-NEXT:    builtin "finishAsyncLet"([[LET2]], [[PTR]])
+// CHECK-NEXT:    builtin "finishAsyncLet"([[LET1]], [[PTR]])
+// CHECK-NEXT:    dealloc_stack [[B]]
+// CHECK-NEXT:    dealloc_stack [[A]]
+// CHECK-NEXT:    integer_literal $Builtin.Int32, 4
+// CHECK-LABEL: // end sil function 'test_two_async_lets'
+sil [ossa] @test_two_async_lets : $@convention(thin) @async (Builtin.Int1) -> () {
+bb0(%cond: $Builtin.Int1):
+  specify_test "stack_nesting_fixup"
+  integer_literal $Builtin.Int32, 1
+  %a = alloc_stack $Int
+
+  // Reusing result pointers and passing nil as the scratch space are not
+  // actually legitimate at runtime, but it's convenient and doesn't affect
+  // what we're testing.
+  %fn = function_ref @async_let_helper : $@convention(thin) @Sendable @async () -> (@out Int, @error any Error)
+  %async_let_fn = thin_to_thick_function %fn to $@Sendable @async () -> (@out Int, @error any Error)
+  %scratch = enum $Optional<Builtin.RawPointer>, #Optional.none!enumelt
+  %resultPtr = address_to_pointer %a to $Builtin.RawPointer
+
+  %al1 = builtin "startAsyncLetWithLocalBuffer"<Int>(%scratch, %fn, %resultPtr) : $Builtin.RawPointer
+  %al2 = builtin "startAsyncLetWithLocalBuffer"<Int>(%scratch, %fn, %resultPtr) : $Builtin.RawPointer
+
+  integer_literal $Builtin.Int32, 2
+
+  %b = alloc_stack $Int
+  %c = alloc_stack $Int
+  dealloc_stack %c
+
+  integer_literal $Builtin.Int32, 3
+
+  %out2 = builtin "finishAsyncLet"(%al2, %resultPtr) : $()
+  %out1 = builtin "finishAsyncLet"(%al1, %resultPtr) : $()
+
+  dealloc_stack %b
+  dealloc_stack %a
+  integer_literal $Builtin.Int32, 4
+  %ret = tuple ()
+  return %ret : $()
+}


### PR DESCRIPTION
There are quite a few parts of this fix, which is why it's been dragging out for so long.

- `async let` needs to use builtins to enter and exit the scope. I made that change several months ago.
- Those builtins need to be flagged as participating in the stack allocation scheme. That's done in this PR.
- The `StackNesting` utility needs to flag allocations that improperly nest with the `async let` builtins as non-nested. That's done in this PR for `alloc_stack` only.
- IRGen needs to emit non-nested `alloc_stack`s as malloc/free. That was done by @gottesmm several months ago.
- LLVM needs to be less aggressive about moving `swift_task_alloc` and `swift_task_dealloc` around. That's done in this PR by flagging the calls as using inaccessible memory. Credit for this observation goes to @WeZZard and their #87571.

I will have follow-up PRs that do the first two points for some other concurrency runtime operations that use the task stack. The last point does go a long way towards explaining why we've been seeing this problem in some cases that don't seem to involve those operations, though.