### PR TITLE
[SILOptimizer] NFC: Add missing flag to `SILIsolationInfo::printOptions`

### DIFF
--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -1220,6 +1220,12 @@ void SILIsolationInfo::printOptions(llvm::raw_ostream &os) const {
     opts -= Flag::UnappliedIsolatedAnyParameter;
   }
 
+  if (opts.contains(Flag::NonisolatedNonsendingTaskIsolated)) {
+    data.push_back(
+        StringLiteral("task_isolated_from_nonisolated_nonsending_parameter"));
+    opts -= Flag::NonisolatedNonsendingTaskIsolated;
+  }
+
   assert(!opts && "Unhandled flag?!");
   assert(data.size() < unsigned(Flag::MaxNumBits) &&
          "Please update MaxNumBits so that we can avoid heap allocations in "


### PR DESCRIPTION
`NonisolatedNonsendingTaskIsolated` wasn't handled which results in a crash on `assert(!opts && "Unhandled flag?!");`

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
