### PR TITLE
Reparenting: sign the conformance descriptor

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1240,14 +1240,28 @@ namespace {
 
     void emitReparentedAssociatedConformanceAccessBody(
         IRGenFunction &IGF, ProtocolConformance *conf,
-        llvm::Value *associatedTypeMetadata, llvm::Value *wtable) {
+        llvm::Value *selfMetadata, llvm::Value *wtable) {
       assert(conf->isReparented());
       assert(conf->getDeclContext()->getSelfProtocolDecl() == Proto);
       assert(conf->getProtocol() != Proto);
 
+      // This is similar to emitWitnessTableAccessorCall, but with one fixed
+      // instantiation argument: the witness table passed to the accessor.
+
       // Get the protocol conformance descriptor.
-      auto *descriptor = IGM.getAddrOfProtocolConformanceDescriptor(
+      llvm::Value *descriptor = IGM.getAddrOfProtocolConformanceDescriptor(
           conf->getRootConformance());
+
+      // Sign the descriptor.
+      auto schema = IGF.IGM.getOptions()
+                        .PointerAuth.ProtocolConformanceDescriptorsAsArguments;
+      if (schema) {
+        auto authInfo =
+            PointerAuthInfo::emit(IGF, schema, nullptr,
+                                  PointerAuthEntity::Special::
+                                      ProtocolConformanceDescriptorAsArgument);
+        descriptor = emitPointerAuthSign(IGF, descriptor, authInfo);
+      }
 
       unsigned argumentCount = 0;
       SILWitnessTable::enumerateWitnessTableConditionalConformances(
@@ -1272,12 +1286,17 @@ namespace {
       // swift_getWitnessTable(descriptor,
       //                       associatedTypeMetadata,
       //                       &instantiationArgs)
-      auto *func = IGM.getGetWitnessTableFn();
-      auto *funcTy = IGM.getGetWitnessTableFnType();
-      auto thisTable = IGF.Builder.CreateCall(
-          funcTy, func,
-          {descriptor, associatedTypeMetadata, alloca.getAddress()});
-      IGF.Builder.CreateRet(thisTable);
+      auto call = IGF.IGM.IRGen.Opts.UseRelativeProtocolWitnessTables ?
+      IGF.Builder.CreateCall(
+        IGF.IGM.getGetWitnessTableRelativeFunctionPointer(),
+        {descriptor, selfMetadata, alloca.getAddress()}) :
+      IGF.Builder.CreateCall(
+        IGF.IGM.getGetWitnessTableFunctionPointer(),
+        {descriptor, selfMetadata, alloca.getAddress()});
+
+      call->setCallingConv(IGF.IGM.DefaultCC);
+      call->setDoesNotThrow();
+      IGF.Builder.CreateRet(call);
     }
 
     void defineDefaultAssociatedConformanceAccessFunction(

--- a/test/IRGen/reparenting.swift
+++ b/test/IRGen/reparenting.swift
@@ -1,0 +1,41 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -enable-library-evolution -module-name A -primary-file %s -emit-ir -enable-experimental-feature Reparenting -o %t/out.ll
+// RUN: %FileCheck %s --check-prefix=CHECK-%target-cpu --check-prefix=CHECK < %t/out.ll
+
+// RUN: %target-swift-frontend -enable-relative-protocol-witness-tables -enable-library-evolution -module-name A -primary-file %s -emit-ir -enable-experimental-feature Reparenting -o %t/relative.ll
+// RUN: %FileCheck %s --check-prefix=RELATIVE --check-prefix=CHECK < %t/relative.ll
+
+// REQUIRES: swift_feature_Reparenting
+// REQUIRES: CPU=x86_64 || CPU=arm64 || CPU=arm64e
+
+@reparentable public protocol NewProto {
+  associatedtype Thing: Equatable
+  func new() -> Thing
+}
+
+extension Existing: @reparented NewProto where Thing == String {
+  public func new() -> Thing { return "new" }
+}
+
+public protocol Existing: NewProto {
+  associatedtype Thing: Equatable = String
+  func existing() -> Thing
+}
+
+// CHECK: @"default associated conformance1A8NewProto" = linkonce_odr hidden constant
+// CHECK-SAME:  ptr @"$s1A8ExistingPxAA8NewProtoTN"
+
+// CHECK: @"$s1A8ExistingMp" =
+// CHECK-SAME: @"default associated conformance1A8NewProto"
+
+// CHECK-LABEL: define internal swiftcc ptr @"$s1A8ExistingPxAA8NewProtoTN"(ptr %0, ptr %1, ptr %2){{.*}} {
+// CHECK:  %instantiationArgs = alloca ptr, align 8
+// CHECK:  store ptr %2, ptr %instantiationArgs, align 8
+
+// CHECK-x86_64:  %3 = call ptr @swift_getWitnessTable(ptr @"$s1A8Existing_pAA8NewProtoAASS5ThingRtzrlMc", ptr %0, ptr %instantiationArgs)
+// CHECK-arm64:   %3 = call ptr @swift_getWitnessTable(ptr @"$s1A8Existing_pAA8NewProtoAASS5ThingRtzrlMc", ptr %0, ptr %instantiationArgs)
+// CHECK-arm64e:  %3 = call ptr @swift_getWitnessTable(ptr @"$s1A8Existing_pAA8NewProtoAASS5ThingRtzrlMc.ptrauth", ptr %0, ptr %instantiationArgs)
+// RELATIVE:      %3 = call ptr @swift_getWitnessTableRelative(ptr @"$s1A8Existing_pAA8NewProtoAASS5ThingRtzrlMc
+
+// CHECK:  ret ptr %3
+// CHECK:  }


### PR DESCRIPTION
The protocol conformance descriptor passed to swift_getWitnessTable needs to be signed on arm64e. When reparenting a protocol P with new parent Q, we emit a small "default conformance accessor" function that instantiates the type's witness table for Q using its witness table for P, at runtime. This accessor is only used if the type conforming to P comes from a module that hasn't been rebuilt since the reparenting happened.

resolves rdar://171661924