### PR TITLE
[Concurrency] Only use immediate task in bridged methods if deployment new enough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,8 @@
   (by enqueueing on the global pool before calling the async target), and can improve performance
   and ordering predictability of calling async code through these bridged APIs.
 
+  This is only in effect if the minimum deployment target of an application on apple platforms is later than Fall 2025 (excluding Fall 2025). This is in order to ensure consistent concurrency behavior of the app, regardless of platform it is running on. Once the app raises the minimum deployment target, it will get the new and improved behavior.
+
 * The raw span accessor properties of `Span` and `MutableSpan` (`bytes` and
   `mutableBytes`) as well as the two generic `append()` methods of
   `OutputRawSpan` are newly marked with `@unsafe`. These changes are corrections

--- a/include/swift/Runtime/Bincompat.h
+++ b/include/swift/Runtime/Bincompat.h
@@ -84,6 +84,12 @@ bool useLegacySwiftObjCHashing();
 SWIFT_RUNTIME_STDLIB_SPI
 bool swift_bincompat_useLegacyNonCrashingExecutorChecks();
 
+/// Returns true if bridged async functions (from ObjC) should use the legacy
+/// `Task.init` behavior. Returns false if the app's deployment target is
+/// Fall 2025+, meaning `Task.immediate` can be used instead.
+SWIFT_RUNTIME_STDLIB_SPI
+bool swift_bincompat_useLegacyTaskForBridgedAsyncMethod();
+
 } // namespace bincompat
 
 } // namespace runtime

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -1056,7 +1056,7 @@ bool swift_task_isCurrentExecutor(SerialExecutorRef executor);
 enum swift_task_is_current_executor_flag : uint64_t {
   /// We aren't passing any flags.
   /// Effectively this is a backwards compatible mode.
-  None = 0x0,
+  IsCurrentTaskExecutorFlag_None = 0x0,
 
   /// This is not used today, but is just future ABI reservation.
   ///
@@ -1065,24 +1065,58 @@ enum swift_task_is_current_executor_flag : uint64_t {
   /// dereference and then have further extended behavior controlled by a
   /// different enum. By placing this here, we ensure that we will have a tagged
   /// pointer compatible flag for this purpose.
-  TaggedPointer = 0x1,
+  IsCurrentTaskExecutorFlag_TaggedPointer = 0x1,
 
   /// This is not used today, but is just future ABI reservation.
   ///
   /// \see swift_task_is_current_executor_flag::TaggedPointer
-  TaggedPointer2 = 0x2,
+  IsCurrentTaskExecutorFlag_TaggedPointer2 = 0x2,
 
   /// This is not used today, but is just future ABI reservation.
   ///
   /// \see swift_task_is_current_executor_flag::TaggedPointer
-  TaggedPointer3 = 0x4,
+  IsCurrentTaskExecutorFlag_TaggedPointer3 = 0x4,
 
   /// The routine should assert on failure.
-  Assert = 0x8,
+  IsCurrentTaskExecutorFlag_Assert = 0x8,
 
   /// The routine MUST NOT assert on failure.
   /// Even at the cost of not calling 'checkIsolated' if it is available.
-  MustNotAssert = 0x10,
+  IsCurrentTaskExecutorFlag_MustNotAssert = 0x10,
+};
+
+/// This is an options enum that configures if a Task.immediate can be used in bridged async methods (from obj-c).
+///
+/// Since this is an options enum, so all values should be powers of 2.
+///
+/// NOTE: We are purposely leaving this as a uint64_t so that on all platforms
+/// this could be a pointer to a different enum instance if we need it to be.
+enum swift_task_run_task_for_bridged_async_method_flag : uint64_t {
+  /// We aren't passing any flags.
+  /// Effectively this is a backwards compatible mode, create a plain `Task {}`
+  BridgedAsyncMethodFlag_None = 0x0,
+
+  /// This is not used today, but is just future ABI reservation.
+  ///
+  /// The intention is that we may want the ability to tell future versions of
+  /// the runtime that this uint64_t is actually a pointer that it should
+  /// dereference and then have further extended behavior controlled by a
+  /// different enum. By placing this here, we ensure that we will have a tagged
+  /// pointer compatible flag for this purpose.
+  BridgedAsyncMethodFlag_TaggedPointer = 0x1,
+
+  /// This is not used today, but is just future ABI reservation.
+  ///
+  /// \see swift_task_run_task_for_bridged_async_method_flag::TaggedPointer
+  BridgedAsyncMethodFlag_TaggedPointer2 = 0x2,
+
+  /// This is not used today, but is just future ABI reservation.
+  ///
+  /// \see swift_task_run_task_for_bridged_async_method_flag::TaggedPointer
+  BridgedAsyncMethodFlag_TaggedPointer3 = 0x4,
+
+  /// Use an `Task.immediate` in the bridging implementation
+  BridgedAsyncMethodFlag_TaskImmediate = 0x8,
 };
 
 SWIFT_EXPORT_FROM(swift_Concurrency)
@@ -1106,6 +1140,13 @@ void swift_task_startOnMainActor(AsyncTask* job);
 
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_immediate(AsyncTask* job, SerialExecutorRef targetExecutor);
+
+/// Determine if the deployment target is at least release targeting Fall 2025.
+///
+/// This is used to guard runtime behavior based on when a change was introduced,
+/// so we keep "old" behavior until the deployment target is raised to a recent enough one.
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+size_t swift_task_RunTaskForBridgedAsyncMethodMode();
 
 /// Donate this thread to the global executor until either the
 /// given condition returns true or we've run out of cooperative

--- a/include/swift/Runtime/EnvironmentVariables.h
+++ b/include/swift/Runtime/EnvironmentVariables.h
@@ -66,6 +66,10 @@ SWIFT_RUNTIME_STDLIB_SPI bool concurrencyValidateUncheckedContinuations();
 // Concurrency library can call.
 SWIFT_RUNTIME_STDLIB_SPI const char *concurrencyIsCurrentExecutorLegacyModeOverride();
 
+// Wrapper around SWIFT_BRIDGED_ASYNC_METHOD_MODE_OVERRIDE that the
+// Concurrency library can call.
+SWIFT_RUNTIME_STDLIB_SPI const char *concurrencyBridgedAsyncMethodModeOverride();
+
 // Wrapper around SWIFT_DEBUG_ENABLE_TASK_SLAB_ALLOCATOR that the Concurrency
 // library can call.
 SWIFT_RUNTIME_STDLIB_SPI bool concurrencyEnableTaskSlabAllocator();

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -388,36 +388,70 @@ enum IsCurrentExecutorCheckMode : unsigned {
 namespace {
 using SwiftTaskIsCurrentExecutorOptions =
     OptionSet<swift_task_is_current_executor_flag>;
+using SwiftBridgedAsyncMethodOptions =
+    OptionSet<swift_task_run_task_for_bridged_async_method_flag>;
 }
 
 static void _swift_task_debug_dumpIsCurrentExecutorFlags(
     const char *hint,
     swift_task_is_current_executor_flag flags) {
-  if (flags == swift_task_is_current_executor_flag::None) {
+  if (flags == IsCurrentTaskExecutorFlag_None) {
     SWIFT_TASK_DEBUG_LOG("%s swift_task_is_current_executor_flag::%s",
                          hint, "None");
     return;
   }
 
   auto options = SwiftTaskIsCurrentExecutorOptions(flags);
-  if (options.contains(swift_task_is_current_executor_flag::Assert))
+  if (options.contains(IsCurrentTaskExecutorFlag_Assert))
     SWIFT_TASK_DEBUG_LOG("%s swift_task_is_current_executor_flag::%s",
                          hint, "Assert");
+}
+
+static void _swift_task_debug_dumpBridgedAsyncMethodModeFlags(
+    const char *hint,
+    swift_task_run_task_for_bridged_async_method_flag flags) {
+  if (flags == BridgedAsyncMethodFlag_None) {
+    SWIFT_TASK_DEBUG_LOG("%s swift_task_run_task_for_bridged_async_method_flag::%s",
+                         hint, "None");
+    return;
+  }
+
+  auto options = SwiftBridgedAsyncMethodOptions(flags);
+  if (options.contains(BridgedAsyncMethodFlag_TaskImmediate))
+    SWIFT_TASK_DEBUG_LOG("%s swift_task_run_task_for_bridged_async_method_flag::%s",
+                         hint, "TaskImmediate");
 }
 
 // Shimming call to Swift runtime because Swift Embedded does not have
 // these symbols defined.
 swift_task_is_current_executor_flag
 __swift_bincompat_useLegacyNonCrashingExecutorChecks() {
-  swift_task_is_current_executor_flag options = swift_task_is_current_executor_flag::None;
+  swift_task_is_current_executor_flag options = IsCurrentTaskExecutorFlag_None;
 #if !SWIFT_CONCURRENCY_EMBEDDED
   if (!swift::runtime::bincompat::
       swift_bincompat_useLegacyNonCrashingExecutorChecks()) {
     options = swift_task_is_current_executor_flag(
-        options | swift_task_is_current_executor_flag::Assert);
+        options | IsCurrentTaskExecutorFlag_Assert);
   }
 #endif
   _swift_task_debug_dumpIsCurrentExecutorFlags("runtime linking determined default mode", options);
+  return options;
+}
+
+// Shimming call to Swift runtime because Swift Embedded does not have
+// these symbols defined.
+swift_task_run_task_for_bridged_async_method_flag
+__swift_bincompat_getRunTaskForBridgedAsyncMethodMode() {
+  swift_task_run_task_for_bridged_async_method_flag options =
+    BridgedAsyncMethodFlag_None;
+#if !SWIFT_CONCURRENCY_EMBEDDED
+  if (!swift::runtime::bincompat::
+      swift_bincompat_useLegacyTaskForBridgedAsyncMethod()) {
+    options = swift_task_run_task_for_bridged_async_method_flag(
+        options | BridgedAsyncMethodFlag_TaskImmediate);
+  }
+#endif
+  _swift_task_debug_dumpBridgedAsyncMethodModeFlags("runtime linking determined default mode", options);
   return options;
 }
 
@@ -428,6 +462,18 @@ const char *__swift_runtime_env_useLegacyNonCrashingExecutorChecks() {
 #if SWIFT_STDLIB_HAS_ENVIRON && !SWIFT_CONCURRENCY_EMBEDDED
   return swift::runtime::environment::
       concurrencyIsCurrentExecutorLegacyModeOverride();
+#else
+  return nullptr;
+#endif
+}
+
+// Shimming call to Swift runtime because Swift Embedded does not have
+// these symbols defined.
+const char *__swift_runtime_env_getRunTaskForBridgedAsyncMethodMode() {
+  // Potentially, override the platform detected mode, primarily used in tests.
+#if SWIFT_STDLIB_HAS_ENVIRON && !SWIFT_CONCURRENCY_EMBEDDED
+  return swift::runtime::environment::
+      concurrencyBridgedAsyncMethodModeOverride();
 #else
   return nullptr;
 #endif
@@ -459,11 +505,40 @@ swift_task_is_current_executor_flag swift_bincompat_selectDefaultIsCurrentExecut
       // Since we're in nocrash/legacy mode:
       // Remove the assert option which is what would cause the "crash" mode
       options = swift_task_is_current_executor_flag(
-        options & ~swift_task_is_current_executor_flag::Assert);
+        options & ~IsCurrentTaskExecutorFlag_Assert);
     } else if (strcmp(modeStr, "crash") == 0 ||
                strcmp(modeStr, "swift6") == 0) {
       options = swift_task_is_current_executor_flag(
-        options | swift_task_is_current_executor_flag::Assert);
+        options | IsCurrentTaskExecutorFlag_Assert);
+    } // else, just use the platform detected mode
+  } // no override, use the default mode
+
+  return options;
+}
+
+swift_task_run_task_for_bridged_async_method_flag swift_bincompat_runTaskForBridgeAsyncMethodMode() {
+  // Default options as determined by the app's minimum deployment target (minos).
+  // Apps targeting Fall 2025+ get Task.immediate; older apps get Task.init.
+  swift_task_run_task_for_bridged_async_method_flag options =
+      __swift_bincompat_getRunTaskForBridgedAsyncMethodMode();
+
+  // Potentially, override the platform detected mode, primarily used in tests.
+  if (const char *modeStr =
+          __swift_runtime_env_getRunTaskForBridgedAsyncMethodMode()) {
+
+    if (strlen(modeStr) == 0) {
+      _swift_task_debug_dumpBridgedAsyncMethodModeFlags("mode override is empty", options);
+      return options;
+    }
+
+    if (strcmp(modeStr, "legacy") == 0) {
+      // Since we're in legacy mode:
+      // Remove the "immediate" option, and any other behavioral option we might add in the future
+      options = swift_task_run_task_for_bridged_async_method_flag(
+        options & ~BridgedAsyncMethodFlag_TaskImmediate);
+    } else if (strcmp(modeStr, "immediate") == 0) {
+      options = swift_task_run_task_for_bridged_async_method_flag(
+        options | BridgedAsyncMethodFlag_TaskImmediate);
     } // else, just use the platform detected mode
   } // no override, use the default mode
 
@@ -540,7 +615,7 @@ static bool swift_task_isCurrentExecutorWithFlagsImpl(
 
     // Otherwise, as last resort, let the expected executor check using
     // external means, as it may "know" this thread is managed by it etc.
-    if (options.contains(swift_task_is_current_executor_flag::Assert)) {
+    if (options.contains(IsCurrentTaskExecutorFlag_Assert)) {
       SWIFT_TASK_DEBUG_LOG("executor checking mode option: Assert; invoke (%p).expectedExecutor",
                            expectedExecutor.getIdentity());
       swift_task_checkIsolated(expectedExecutor); // will crash if not same context
@@ -549,7 +624,7 @@ static bool swift_task_isCurrentExecutorWithFlagsImpl(
       return true;
     }
 
-    assert(!options.contains(swift_task_is_current_executor_flag::Assert));
+    assert(!options.contains(IsCurrentTaskExecutorFlag_Assert));
     return false;
   }
 
@@ -587,7 +662,7 @@ static bool swift_task_isCurrentExecutorWithFlagsImpl(
   // the crashing 'dispatch_assert_queue(main queue)' which will either crash
   // or confirm we actually are on the main queue; or the custom expected
   // executor has a chance to implement a similar queue check.
-  if (!options.contains(swift_task_is_current_executor_flag::Assert)) {
+  if (!options.contains(IsCurrentTaskExecutorFlag_Assert)) {
     if ((expectedExecutor.isMainExecutor() && !currentExecutor.isMainExecutor())) {
       SWIFT_TASK_DEBUG_LOG("executor checking: expected executor %p%s is main executor, and current executor %p%s is NOT => fail",
                  expectedExecutor.getIdentity(), expectedExecutor.getIdentityDebugName(),
@@ -681,7 +756,7 @@ static bool swift_task_isCurrentExecutorWithFlagsImpl(
   // Note that this only works because the closure in assumeIsolated is
   // synchronous, and will not cause suspensions, as that would require the
   // presence of a Task.
-  if (options.contains(swift_task_is_current_executor_flag::Assert)) {
+  if (options.contains(IsCurrentTaskExecutorFlag_Assert)) {
     SWIFT_TASK_DEBUG_LOG("executor checking: call (%p).checkIsolated",
       expectedExecutor.getIdentity());
     swift_task_checkIsolated(expectedExecutor); // will crash if not same context
@@ -697,7 +772,7 @@ static bool swift_task_isCurrentExecutorWithFlagsImpl(
 
   // In the end, since 'checkIsolated' could not be used, so we must assume
   // that the executors are not the same context.
-  assert(!options.contains(swift_task_is_current_executor_flag::Assert));
+  assert(!options.contains(IsCurrentTaskExecutorFlag_Assert));
   return false;
 }
 
@@ -706,12 +781,24 @@ static void swift_task_setDefaultExecutorCheckingFlags(void *context) {
   auto *options = static_cast<swift_task_is_current_executor_flag *>(context);
 
   auto modeOverride = swift_bincompat_selectDefaultIsCurrentExecutorCheckingMode();
-  if (modeOverride != swift_task_is_current_executor_flag::None) {
+  if (modeOverride != IsCurrentTaskExecutorFlag_None) {
     *options = modeOverride;
   }
 
   SWIFT_TASK_DEBUG_LOG("executor checking: resulting options = %d", *options);
   _swift_task_debug_dumpIsCurrentExecutorFlags(__FUNCTION__, *options);
+}
+
+static void swift_task_setRunTaskForBridgedAsyncMethodMode(void *context) {
+  auto *options = static_cast<swift_task_run_task_for_bridged_async_method_flag *>(context);
+
+  auto modeOverride = swift_bincompat_runTaskForBridgeAsyncMethodMode();
+  if (modeOverride != BridgedAsyncMethodFlag_None) {
+    *options = modeOverride;
+  }
+
+  SWIFT_TASK_DEBUG_LOG("async method bridging: resulting options = %d", *options);
+  _swift_task_debug_dumpBridgedAsyncMethodModeFlags(__FUNCTION__, *options);
 }
 
 SWIFT_CC(swift)
@@ -735,6 +822,18 @@ swift_task_isCurrentExecutorImpl(SerialExecutorRef expectedExecutor) {
                                                isCurrentExecutorFlag);
 }
 
+SWIFT_CC(swift)
+static size_t
+swift_task_RunTaskForBridgedAsyncMethodMode() {
+  static swift_task_run_task_for_bridged_async_method_flag runBridgedAsyncMethodFlag;
+  static swift::once_t runBridgedAsyncMethodFlagToken;
+  swift::once(runBridgedAsyncMethodFlagToken,
+              swift_task_setRunTaskForBridgedAsyncMethodMode,
+              &runBridgedAsyncMethodFlag);
+
+  return runBridgedAsyncMethodFlag;
+}
+
 /// Logging level for unexpected executors:
 /// 0 - no logging -- will be IGNORED when Swift6 mode of isCurrentExecutor is used
 /// 1 - warn on each instance -- will be IGNORED when Swift6 mode of isCurrentExecutor is used
@@ -744,7 +843,7 @@ swift_task_isCurrentExecutorImpl(SerialExecutorRef expectedExecutor) {
 /// an application was linked to. Since Swift 6 the default is to crash,
 /// and the logging behavior is no longer available.
 static unsigned unexpectedExecutorLogLevel =
-    (swift_bincompat_selectDefaultIsCurrentExecutorCheckingMode() == swift_task_is_current_executor_flag::None)
+    (swift_bincompat_selectDefaultIsCurrentExecutorCheckingMode() == IsCurrentTaskExecutorFlag_None)
         ? 1 // legacy apps default to the logging mode, and cannot use `checkIsolated`
         : 2; // new apps will only crash upon concurrency violations, and will call into `checkIsolated`
 
@@ -758,7 +857,7 @@ static void checkUnexpectedExecutorLogLevel(void *context) {
   if (level >= 0 && level < 3) {
     auto options = SwiftTaskIsCurrentExecutorOptions(
         swift_bincompat_selectDefaultIsCurrentExecutorCheckingMode());
-    if (options.contains(swift_task_is_current_executor_flag::Assert)) {
+    if (options.contains(IsCurrentTaskExecutorFlag_Assert)) {
       // We are in swift6/crash mode of isCurrentExecutor which means that
       // rather than returning false, that method will always CRASH when an
       // executor mismatch is discovered.
@@ -2614,7 +2713,7 @@ static void swift_task_deinitOnExecutorImpl(void *object,
   // Note that isCurrentExecutor() returns true for @MainActor
   // when running on the main thread without any executor.
   if (swift_task_isCurrentExecutorWithFlags(
-          newExecutor, swift_task_is_current_executor_flag::None)) {
+          newExecutor, IsCurrentTaskExecutorFlag_None)) {
     TaskLocal::StopLookupScope scope;
     return work(object);
   }

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -1151,6 +1151,15 @@ extension Task where Failure == Error {
 
 #if _runtime(_ObjC)
 
+@usableFromInline
+internal enum RunTaskForBridgedAsyncMethodMode: Int {
+  case legacy = 0
+  case _reserved_TaggedPointer = 0x1
+  case _reserved_TaggedPointer2 = 0x2
+  case _reserved_TaggedPointer3 = 0x4
+  case immediate = 0x8
+}
+
 #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
 /// Intrinsic used by SILGen to launch a task for bridging a Swift async method
 /// which was called through its ObjC-exported completion-handler-based API.
@@ -1159,7 +1168,8 @@ extension Task where Failure == Error {
 @usableFromInline
 internal func _runTaskForBridgedAsyncMethod(@_inheritActorContext _ body: __owned @Sendable @escaping () async -> Void) {
 #if compiler(>=5.6)
-  if #available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *) {
+  if #available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *),
+    (_swift_task_RunTaskForBridgedAsyncMethodMode() & RunTaskForBridgedAsyncMethodMode.immediate.rawValue) > 0 {
     Task.immediate(operation: body)
   } else {
     Task(operation: body)
@@ -1172,6 +1182,11 @@ internal func _runTaskForBridgedAsyncMethod(@_inheritActorContext _ body: __owne
 #endif
 }
 #endif
+
+@available(SwiftStdlib 6.2, *)
+@usableFromInline
+@_silgen_name("swift_task_RunTaskForBridgedAsyncMethodMode")
+internal func _swift_task_RunTaskForBridgedAsyncMethodMode() -> Int
 
 #endif
 

--- a/stdlib/public/runtime/Bincompat.cpp
+++ b/stdlib/public/runtime/Bincompat.cpp
@@ -72,6 +72,27 @@ static enum sdk_test isAppAtLeastFall2024() {
     const dyld_build_version_t fall_2024_os_versions = {0xffffffff, 0x007e80000};
     return isAppAtLeast(fall_2024_os_versions);
 }
+
+// Like isAppAtLeast, but checks the minimum deployment target (minos) rather
+// than SDK version. Use this when behavior should be gated on what OS versions
+// the app claims to support, so it behaves consistently across all of them.
+static enum sdk_test isMinosAtLeast(dyld_build_version_t version) {
+  if (__builtin_available(macOS 11.3, iOS 14.5, tvOS 14.5, watchOS 7.4, *)) {
+    // Query the minimum deployment target of the currently-running executable
+    if (dyld_program_minos_at_least(version)) {
+      return newApp;
+    } else {
+      return oldApp;
+    }
+  }
+  // Older Apple OS lack the ability to test the deployment target
+  return oldOS;
+}
+
+static enum sdk_test isMinosAtLeastFall2025() {
+    const dyld_build_version_t fall_2025_os_versions = {0xffffffff, 0x007e90000};
+    return isMinosAtLeast(fall_2025_os_versions);
+}
 #endif
 
 static _SwiftStdlibVersion binCompatVersionOverride = { 0 };
@@ -301,6 +322,23 @@ bool swift_bincompat_useLegacyNonCrashingExecutorChecks() {
   case oldOS: return true; // Legacy behavior on old OS
   case oldApp: return true; // Legacy behavior for old apps
   case newApp: return false; // New behavior for new apps
+  }
+#else
+  return false; // Always use the new behavior on non-Apple OSes
+#endif
+}
+
+// Returns true if bridged async methods (from ObjC) should use the legacy
+// Task.init behavior. Returns false (= use Task.immediate) when the app's
+// minimum deployment target is >= Fall 2025 (macOS 26, iOS 26, etc.).
+// Gated on minos rather than SDK version so the app behaves consistently
+// across all OS versions it supports.
+bool swift_bincompat_useLegacyTaskForBridgedAsyncMethod() {
+#if BINARY_COMPATIBILITY_APPLE
+  switch (isMinosAtLeastFall2025()) {
+  case oldOS: return true; // Legacy behavior on old OS
+  case oldApp: return true; // Legacy behavior for old deployment targets
+  case newApp: return false; // New behavior for apps targeting Fall 2025+
   }
 #else
   return false; // Always use the new behavior on non-Apple OSes

--- a/stdlib/public/runtime/EnvironmentVariables.cpp
+++ b/stdlib/public/runtime/EnvironmentVariables.cpp
@@ -320,6 +320,10 @@ SWIFT_RUNTIME_STDLIB_SPI const char *concurrencyIsCurrentExecutorLegacyModeOverr
   return runtime::environment::SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE();
 }
 
+SWIFT_RUNTIME_STDLIB_SPI const char *concurrencyBridgedAsyncMethodModeOverride() {
+  return runtime::environment::SWIFT_BRIDGED_ASYNC_METHOD_MODE_OVERRIDE();
+}
+
 SWIFT_RUNTIME_STDLIB_SPI bool concurrencyEnableTaskSlabAllocator() {
   return runtime::environment::SWIFT_DEBUG_ENABLE_TASK_SLAB_ALLOCATOR();
 }

--- a/stdlib/public/runtime/EnvironmentVariables.def
+++ b/stdlib/public/runtime/EnvironmentVariables.def
@@ -144,6 +144,12 @@ VARIABLE(SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE, string, "",
          " 'swift6' (Swift 6.0-6.1 behavior)"
          " 'isIsolatingCurrentContext' (Swift 6.2 behavior)")
 
+VARIABLE(SWIFT_BRIDGED_ASYNC_METHOD_MODE_OVERRIDE, string, "",
+        "Allows for overriding the mode in which async methods bridged from obj-c are handled. "
+        "Legal values are: "
+        " 'legacy' (Legacy behavior: Task.init), "
+        " 'immediate' (Swift 6.2+ behavior: Task.immediate)")
+
 VARIABLE(SWIFT_DUMP_ACCESSIBLE_FUNCTIONS, bool, false,
          "Dump a listing of all 'AccessibleFunctionRecord's upon first access. "
          "These are used to obtain function pointers from accessible function "


### PR DESCRIPTION
This ensures that we don't accidentally change behavior, but changing
the deployment target opts into the new behavior. This way the behavior
is more deterministic and only apps with minimum deployment target >
Fall 2025 get the new behavior (i.e. from the upcoming release onwards).

rdar://171674319

