### PR TITLE
[Backtracing] Fix struct packing for PE-COFF definitions.

### DIFF
--- a/stdlib/public/RuntimeModule/modules/ImageFormats/PeCoff/pe-coff.h
+++ b/stdlib/public/RuntimeModule/modules/ImageFormats/PeCoff/pe-coff.h
@@ -24,6 +24,8 @@
 
 #include <inttypes.h>
 
+#pragma pack(push, 1)
+
 namespace swift {
 namespace runtime {
 
@@ -408,6 +410,8 @@ struct pe_symbol {
 
 } // namespace runtime
 } // namespace swift
+
+#pragma pack(pop)
 
 #endif // SWIFT_PE_COFF_H_
 


### PR DESCRIPTION
Due to unfortunate structure packing rules in C, `struct pe_symbol` ends up being 20 bytes instead of 18. The upshot is that when presented with a PE-COFF binary that contains symbols (noting that this is actually a spec violation), the backtracer will crash.

Unfortunately we often generate such binaries. We shouldn’t crash, though, and the fix is to get the correct size for `struct pe_symbol`.

rdar://171711254
