### PR TITLE
[build-script] Add default link-jobs support on linux and freebsd. 

### DIFF
--- a/utils/build_swift/build_swift/defaults.py
+++ b/utils/build_swift/build_swift/defaults.py
@@ -14,6 +14,7 @@ Default option value definitions.
 import os
 import platform
 import re
+from typing import Optional
 
 from . import shell
 from .versions import Version
@@ -68,7 +69,7 @@ DARWIN_INSTALL_PREFIX = ('/Applications/Xcode.app/Contents/Developer/'
 DSYMUTIL_JOBS = 1
 
 
-def _system_memory() -> int | None:
+def _system_memory() -> Optional[int]:
     """Returns the system memory as an int in bytes. None if the system memory cannot
     be determined.
 

--- a/utils/build_swift/build_swift/defaults.py
+++ b/utils/build_swift/build_swift/defaults.py
@@ -13,6 +13,7 @@ Default option value definitions.
 
 import os
 import platform
+import re
 
 from . import shell
 from .versions import Version
@@ -67,19 +68,41 @@ DARWIN_INSTALL_PREFIX = ('/Applications/Xcode.app/Contents/Developer/'
 DSYMUTIL_JOBS = 1
 
 
-def _system_memory():
-    """Returns the system memory as an int. None if the system memory cannot
+def _system_memory() -> int | None:
+    """Returns the system memory as an int in bytes. None if the system memory cannot
     be determined.
 
-    TODO: Support Linux and Windows platforms.
+    TODO: Support Windows platforms.
     """
 
-    if platform.platform() == 'Darwin':
-        try:
-            output = shell.check_output(['sysctl', 'hw.memsize']).strip()
-            return int(output.split(' ')[1])
-        except shell.CalledProcessError:
-            return None
+    try:
+        platform_system = platform.system()
+
+        if platform_system == "Darwin":
+            output = shell.check_output(["sysctl", "-n", "hw.memsize"]).strip()
+            return int(output)
+        elif platform_system == "FreeBSD":
+            output = shell.check_output(["sysctl", "-n", "hw.physmem"]).strip()
+            return int(output)
+        elif platform_system == "Linux":
+            with open("/proc/meminfo", "r") as file:
+                meminfo_data = file.read()
+                # Line to match "MemTotal: 239402943 kB"
+                matched = re.search(r"^MemTotal:\s+(\d+)\s+(\w*)?", meminfo_data)
+                if not matched:
+                    return None
+                total_memory, meminfo_unit = matched.groups()
+                total_memory = int(total_memory)
+                unit_multiplier = {
+                    "kb": 1024,
+                    "mb": 1024 * 1024,
+                    "gb": 1024 * 1024 * 1024,
+                }
+                memory_unit = unit_multiplier.get(meminfo_unit.lower(), 1024)
+                return total_memory * memory_unit
+
+    except (shell.CalledProcessError, FileNotFoundError, ValueError):
+        return None
 
     return None
 

--- a/utils/build_swift/build_swift/defaults.py
+++ b/utils/build_swift/build_swift/defaults.py
@@ -88,12 +88,13 @@ def _system_memory() -> int | None:
             with open("/proc/meminfo", "r") as file:
                 meminfo_data = file.read()
                 # Line to match "MemTotal: 239402943 kB"
-                matched = re.search(r"^MemTotal:\s+(\d+)\s+(\w*)?", meminfo_data)
+                matched = re.search(r"^MemTotal:\s+(\d+)\s*(\w*)?", meminfo_data)
                 if not matched:
                     return None
                 total_memory, meminfo_unit = matched.groups()
                 total_memory = int(total_memory)
                 unit_multiplier = {
+                    "b": 1,
                     "kb": 1024,
                     "mb": 1024 * 1024,
                     "gb": 1024 * 1024 * 1024,

--- a/utils/build_swift/tests/build_swift/test_defaults.py
+++ b/utils/build_swift/tests/build_swift/test_defaults.py
@@ -18,7 +18,7 @@ from .. import utils
 try:
     # Python 3.3
     from unittest import mock
-    from unittest.mock import patch, MagicMock
+    from unittest.mock import patch, mock_open, MagicMock
 except ImportError:
     mock = None
 
@@ -34,7 +34,7 @@ except ImportError:
 # Constants
 
 _SYSCTL_HW_MEMSIZE = 17179869184
-_SYSCTL_HW_MEMSIZE_OUTPUT = 'hw.memsize: {}'.format(_SYSCTL_HW_MEMSIZE)
+_SYSCTL_HW_MEMSIZE_OUTPUT = str(_SYSCTL_HW_MEMSIZE)
 
 # Safe upper bound to soundness check the LTO link job heuristics.
 _LTO_LINK_JOBS_UPPER_BOUND = 100
@@ -50,7 +50,7 @@ class TestDefaults(unittest.TestCase):
     # _system_memory
 
     @utils.requires_module('unittest.mock')
-    @patch('platform.platform', MagicMock(return_value='Darwin'))
+    @patch('platform.system', MagicMock(return_value='Darwin'))
     def test_system_memory_darwin_platform(self):
         with mock.patch.object(shell, 'check_output') as mock_check_output:
             mock_check_output.return_value = _SYSCTL_HW_MEMSIZE_OUTPUT
@@ -59,24 +59,37 @@ class TestDefaults(unittest.TestCase):
                 defaults._system_memory(), _SYSCTL_HW_MEMSIZE)
 
     @utils.requires_module('unittest.mock')
-    @patch('platform.platform', MagicMock(return_value='Darwin'))
+    @patch('platform.system', MagicMock(return_value='Darwin'))
     def test_system_memory_darwin_platform_when_sysctl_fails(self):
         with mock.patch.object(shell, 'check_output') as mock_check_output:
             mock_check_output.side_effect = shell.CalledProcessError(
                 returncode=1,
-                cmd=['sysctl', 'hw.memsize'])
+                cmd=['sysctl', '-n', 'hw.memsize'])
 
             self.assertIsNone(defaults._system_memory())
 
     @utils.requires_module('unittest.mock')
-    @patch('platform.platform', MagicMock(return_value='Linux'))
+    @patch('platform.system', MagicMock(return_value='Linux'))
+    @patch(
+        'builtins.open',
+        mock_open(read_data=f'MemTotal: {_SYSCTL_HW_MEMSIZE // 1024} kB'),
+    )
     def test_system_memory_linux_platform(self):
+        self.assertEqual(defaults._system_memory(), _SYSCTL_HW_MEMSIZE)
+
+    @utils.requires_module('unittest.mock')
+    @patch('platform.system', MagicMock(return_value='Windows'))
+    def test_system_memory_windows_platform(self):
         self.assertIsNone(defaults._system_memory())
 
     @utils.requires_module('unittest.mock')
-    @patch('platform.platform', MagicMock(return_value='Windows'))
-    def test_system_memory_windows_platform(self):
-        self.assertIsNone(defaults._system_memory())
+    @patch('platform.system', MagicMock(return_value='FreeBSD'))
+    def test_system_memory_freebsd_platform(self):
+        with mock.patch.object(shell, 'check_output') as mock_check_output:
+            mock_check_output.return_value = _SYSCTL_HW_MEMSIZE_OUTPUT
+
+            self.assertEqual(
+                defaults._system_memory(), _SYSCTL_HW_MEMSIZE)
 
     # ------------------------------------------------------------------------
     # _default_llvm_lto_link_jobs


### PR DESCRIPTION
The link_jobs uses `_system_memory` to set the default link jobs. 
Implement `_system_memory` for linux

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
