### PR TITLE
[cxx-interop] Fix @implementation not detecting ownership mismatch

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1984,6 +1984,11 @@ ERROR(objc_implementation_sendability_mismatch,none,
       "type %2 declared by the header",
       (ValueDecl *, Type, Type))
 
+ERROR(objc_implementation_ownership_mismatch,none,
+      "%kind0 has a parameter ownership modifier that does not match "
+      "the declaration in the header",
+      (ValueDecl *))
+
 ERROR(objc_implementation_required_attr_mismatch,none,
       "%kind0 should%select{ not|}2 be 'required' to match %kindonly1 declared "
       "by the header",

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2550,6 +2550,10 @@ ClangImporter::Implementation::importParameterType(
   bool isConsuming = false;
   bool isParamTypeImplicitlyUnwrapped = false;
 
+  if (param->hasAttr<clang::NSConsumedAttr>() ||
+      param->hasAttr<clang::CFConsumedAttr>())
+    isConsuming = true;
+
   if (paramIsCompletionHandler &&
       isSendableInferenceOnCompletionHandlerParameterAllowed(dc, parent)) {
     attrs |= ImportTypeAttr::DefaultsToSendable;

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -3565,6 +3565,7 @@ private:
     WrongWritability,
     WrongRequiredAttr,
     WrongForeignErrorConvention,
+    WrongParameterOwnership,
     WrongSendability,
 
     Match,
@@ -3897,10 +3898,17 @@ private:
       if (reqCtor->isRequired() != cast<ConstructorDecl>(cand)->isRequired())
         return MatchOutcome::WrongRequiredAttr;
 
-    if (auto reqAFD = dyn_cast<AbstractFunctionDecl>(req))
+    if (auto reqAFD = dyn_cast<AbstractFunctionDecl>(req)) {
+      auto candAFD = cast<AbstractFunctionDecl>(cand);
       if (reqAFD->getForeignErrorConvention() !=
-              cast<AbstractFunctionDecl>(cand)->getForeignErrorConvention())
+          candAFD->getForeignErrorConvention())
         return MatchOutcome::WrongForeignErrorConvention;
+      for (auto [reqParam, candParam] :
+           llvm::zip(*reqAFD->getParameters(), *candAFD->getParameters())) {
+        if (reqParam->getValueOwnership() != candParam->getValueOwnership())
+          return MatchOutcome::WrongParameterOwnership;
+      }
+    }
 
     // If we got here, everything matched. But at what quality?
     if (explicitObjCName)
@@ -4017,6 +4025,10 @@ private:
     case MatchOutcome::WrongType:
       diagnose(cand, diag::objc_implementation_type_mismatch,
                cand, getMemberType(cand), getMemberType(req));
+      return;
+
+    case MatchOutcome::WrongParameterOwnership:
+      diagnose(cand, diag::objc_implementation_ownership_mismatch, cand);
       return;
 
     case MatchOutcome::WrongWritability:

--- a/test/SILGen/cf.swift
+++ b/test/SILGen/cf.swift
@@ -23,7 +23,7 @@ func useEmAll(_ model: CCMagnetismModel) {
 // CHECK: function_ref @$sSo19CCRefrigeratorCloneySo0A3RefaSgADFTo : $@convention(c) (Optional<CCRefrigerator>) -> @autoreleased Optional<CCRefrigerator>
   let clone = CCRefrigeratorClone(managedFridge)
 
-// CHECK: function_ref @$sSo21CCRefrigeratorDestroyyySo0A3RefaSgFTo : $@convention(c) (@owned Optional<CCRefrigerator>) -> ()
+// CHECK: function_ref @$sSo21CCRefrigeratorDestroyyySo0A3RefaSgnFTo : $@convention(c) (@owned Optional<CCRefrigerator>) -> ()
   CCRefrigeratorDestroy(clone)
 
 // CHECK: objc_method [[ARG]] : $CCMagnetismModel, #CCMagnetismModel.refrigerator!foreign : (CCMagnetismModel) -> () -> Unmanaged<CCRefrigerator>?, $@convention(objc_method) (CCMagnetismModel) -> @unowned_inner_pointer Optional<Unmanaged<CCRefrigerator>>
@@ -41,7 +41,7 @@ func useEmAll(_ model: CCMagnetismModel) {
 // CHECK: objc_method [[ARG]] : $CCMagnetismModel, #CCMagnetismModel.setRefrigerator!foreign : (CCMagnetismModel) -> (CCRefrigerator?) -> (), $@convention(objc_method) (Optional<CCRefrigerator>, CCMagnetismModel) -> ()
   model.setRefrigerator(copy)
 
-// CHECK: objc_method [[ARG]] : $CCMagnetismModel, #CCMagnetismModel.giveRefrigerator!foreign : (CCMagnetismModel) -> (CCRefrigerator?) -> (), $@convention(objc_method) (@owned Optional<CCRefrigerator>, CCMagnetismModel) -> ()
+// CHECK: objc_method [[ARG]] : $CCMagnetismModel, #CCMagnetismModel.giveRefrigerator!foreign : (CCMagnetismModel) -> (consuming CCRefrigerator?) -> (), $@convention(objc_method) (@owned Optional<CCRefrigerator>, CCMagnetismModel) -> ()
   model.giveRefrigerator(copy)
 
   // rdar://16846555

--- a/test/decl/ext/Inputs/objc_implementation.h
+++ b/test/decl/ext/Inputs/objc_implementation.h
@@ -160,6 +160,14 @@
 
 @end
 
+@interface ObjCClass (OwnershipTests)
+
+- (void)consumingMismatchMethod:(id)param;
+- (void)consumingMismatchMethod2:(__attribute__((ns_consumed)) id)param;
+- (void)consumingMethod:(__attribute__((ns_consumed)) id)param;
+
+@end
+
 @interface ObjCClass (TypeMatchOptionality)
 
 - (nullable id)nullableResultAndArg:(nullable id)arg;

--- a/test/decl/ext/objc_implementation.swift
+++ b/test/decl/ext/objc_implementation.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -import-objc-header %S/Inputs/objc_implementation.h -enable-experimental-feature ObjCImplementation -target %target-stable-abi-triple
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -import-objc-header %S/Inputs/objc_implementation.h -enable-experimental-feature ObjCImplementation -target %target-stable-abi-triple -Xcc -Wno-nullability-completeness
 // REQUIRES: objc_interop
 // REQUIRES: swift_feature_ObjCImplementation
 
@@ -426,6 +426,17 @@ protocol EmptySwiftProto {}
   func requiredMethod1() {}
 
   func optionalMethod1() {}
+}
+
+@objc(OwnershipTests) @implementation extension ObjCClass {
+  func consumingMismatchMethod(_ param: consuming Any?) {
+    // expected-error@-1 {{instance method 'consumingMismatchMethod' has a parameter ownership modifier that does not match the declaration in the header}}
+  }
+  func consumingMismatchMethod2(_ param: Any?) {
+    // expected-error@-1 {{instance method 'consumingMismatchMethod2' has a parameter ownership modifier that does not match the declaration in the header}}
+  }
+  func consumingMethod(_ param: consuming Any?) {
+  }
 }
 
 @objc(TypeMatchOptionality) @implementation extension ObjCClass {


### PR DESCRIPTION
@objc @implementation annotated Swift methods did not check whether the ownership conventions of the Swift function match the Obj-C(++) declaration. A mismatch can result in use after free errors or leaks.

This PR adds some extra check for the ownership conventions and also makes sure the imported Swift declaration is has the right parameter ownership for `NSConusming` and `CFConsuming` annotated parameters.

rdar://168929333