### PR TITLE
[Diagnostics] PropertyWrappers: Allow enclosing-self subscript to acc…

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7703,9 +7703,8 @@ GROUPED_ERROR(property_wrapper_ambiguous_enclosing_self_subscript,PropertyWrappe
       "property wrapper type %0 has multiple enclosing-self subscripts %1",
       (Type, DeclName))
 GROUPED_ERROR(property_wrapper_enclosing_self_subscript_keypath_type,PropertyWrappers,none,
-      "parameter %0 of enclosing-self subscript should have either "
-      "'WritableKeyPath<...>' or 'ReferenceWritableKeyPath<...>' type "
-      "(got %1)",
+      "parameter %0 of enclosing-self subscript should have read-only or "
+      "writable key path type (got %1)",
       (Identifier, Type))
 GROUPED_ERROR(property_wrapper_dynamic_self_type,PropertyWrappers,none,
       "property wrapper %select{wrapped value|projected value}0 cannot have "

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -341,9 +341,11 @@ static bool validateEnclosingSelfSubscript(SubscriptDecl *subscript) {
     if (paramTy->hasError())
       return true;
 
-    if (!paramTy->isWritableKeyPath() && !paramTy->isReferenceWritableKeyPath()) {
-      param->diagnose(diag::property_wrapper_enclosing_self_subscript_keypath_type,
-                      param->getArgumentName(), paramTy);
+    if (!(paramTy->isKeyPath() || paramTy->isWritableKeyPath() ||
+          paramTy->isReferenceWritableKeyPath())) {
+      param->diagnose(
+          diag::property_wrapper_enclosing_self_subscript_keypath_type,
+          param->getArgumentName(), paramTy);
       return false;
     }
     return true;

--- a/test/decl/var/property_wrappers_invalid.swift
+++ b/test/decl/var/property_wrappers_invalid.swift
@@ -14,12 +14,13 @@ public class Store {
     set {}
   }
   public static subscript(_enclosingInstance object: Any,
-                          wrapped wrappedKeyPath: Any, // expected-error {{parameter 'wrapped' of enclosing-self subscript should have either 'WritableKeyPath<...>' or 'ReferenceWritableKeyPath<...>' type (got 'Any')}}
-                          storage storageKeyPath: Any) // expected-error {{parameter 'storage' of enclosing-self subscript should have either 'WritableKeyPath<...>' or 'ReferenceWritableKeyPath<...>' type (got 'Any')}}
+                          wrapped wrappedKeyPath: Any, // expected-error {{parameter 'wrapped' of enclosing-self subscript should have read-only or writable key path type (got 'Any')}}
+                          storage storageKeyPath: Any) // expected-error {{parameter 'storage' of enclosing-self subscript should have read-only or writable key path type (got 'Any')}}
       -> Value {
     get { fatalError() }
     set {}
   }
+
   public struct Publisher {}
   public var projectedValue: Publisher {
     mutating get { fatalError() }


### PR DESCRIPTION
…ept a read-only keypath

This is a follow-up to https://github.com/swiftlang/swift/pull/87403 which allows existing code that uses `KeyPath` to be accepted by the compiler.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
