### PR TITLE
APIDigester: Add support for anyAppleOS availability

### DIFF
--- a/include/swift/APIDigester/ModuleAnalyzerNodes.h
+++ b/include/swift/APIDigester/ModuleAnalyzerNodes.h
@@ -335,9 +335,10 @@ struct PlatformIntroVersion {
   StringRef watchos;
   StringRef visionos;
   StringRef swift;
+  StringRef anyappleos;
   bool hasOSAvailability() const {
     return !macos.empty() || !ios.empty() || !tvos.empty() ||
-      !watchos.empty() || !visionos.empty();
+           !watchos.empty() || !visionos.empty() || !anyappleos.empty();
   }
 };
 

--- a/include/swift/IDE/DigesterEnums.def
+++ b/include/swift/IDE/DigesterEnums.def
@@ -159,6 +159,7 @@ KEY_STRING(IntrotvOS, intro_tvOS)
 KEY_STRING(IntrowatchOS, intro_watchOS)
 KEY_STRING(IntrovisionOS, intro_visionOS)
 KEY_STRING(Introswift, intro_swift)
+KEY_STRING(IntroAnyAppleOS, intro_anyAppleOS)
 KEY_STRING(ObjCName, objc_name)
 KEY_STRING(InitKind, init_kind)
 

--- a/lib/APIDigester/ModuleAnalyzerNodes.cpp
+++ b/lib/APIDigester/ModuleAnalyzerNodes.cpp
@@ -115,25 +115,22 @@ SDKNodeRoot::SDKNodeRoot(SDKNodeInitInfo Info): SDKNode(Info, SDKNodeKind::Root)
   JsonFormatVer(Info.JsonFormatVer.has_value() ? *Info.JsonFormatVer : DIGESTER_JSON_DEFAULT_VERSION) {}
 
 SDKNodeDecl::SDKNodeDecl(SDKNodeInitInfo Info, SDKNodeKind Kind)
-      : SDKNode(Info, Kind), DKind(Info.DKind), Usr(Info.Usr),
-        MangledName(Info.MangledName), Loc(Info.Loc),
-        Location(Info.Location), ModuleName(Info.ModuleName),
-        DeclAttributes(Info.DeclAttrs),
-        SPIGroups(Info.SPIGroups),
-        IsImplicit(Info.IsImplicit),
-        IsStatic(Info.IsStatic), IsDeprecated(Info.IsDeprecated),
-        IsProtocolReq(Info.IsProtocolReq),
-        IsOverriding(Info.IsOverriding),
-        IsOpen(Info.IsOpen),
-        IsInternal(Info.IsInternal), IsABIPlaceholder(Info.IsABIPlaceholder),
-        IsFromExtension(Info.IsFromExtension),
-        ReferenceOwnership(uint8_t(Info.ReferenceOwnership)),
-        GenericSig(Info.GenericSig),
-        SugaredGenericSig(Info.SugaredGenericSig),
-        FixedBinaryOrder(Info.FixedBinaryOrder),
-        introVersions({Info.IntromacOS, Info.IntroiOS, Info.IntrotvOS,
-                       Info.IntrowatchOS, Info.IntrovisionOS, Info.Introswift}),
-        ObjCName(Info.ObjCName) {}
+    : SDKNode(Info, Kind), DKind(Info.DKind), Usr(Info.Usr),
+      MangledName(Info.MangledName), Loc(Info.Loc), Location(Info.Location),
+      ModuleName(Info.ModuleName), DeclAttributes(Info.DeclAttrs),
+      SPIGroups(Info.SPIGroups), IsImplicit(Info.IsImplicit),
+      IsStatic(Info.IsStatic), IsDeprecated(Info.IsDeprecated),
+      IsProtocolReq(Info.IsProtocolReq), IsOverriding(Info.IsOverriding),
+      IsOpen(Info.IsOpen), IsInternal(Info.IsInternal),
+      IsABIPlaceholder(Info.IsABIPlaceholder),
+      IsFromExtension(Info.IsFromExtension),
+      ReferenceOwnership(uint8_t(Info.ReferenceOwnership)),
+      GenericSig(Info.GenericSig), SugaredGenericSig(Info.SugaredGenericSig),
+      FixedBinaryOrder(Info.FixedBinaryOrder),
+      introVersions({Info.IntromacOS, Info.IntroiOS, Info.IntrotvOS,
+                     Info.IntrowatchOS, Info.IntrovisionOS, Info.Introswift,
+                     Info.IntroAnyAppleOS}),
+      ObjCName(Info.ObjCName) {}
 
 SDKNodeType::SDKNodeType(SDKNodeInitInfo Info, SDKNodeKind Kind):
   SDKNode(Info, Kind), TypeAttributes(Info.TypeAttrs),
@@ -1459,24 +1456,24 @@ static bool isDeclaredInExtension(Decl *D) {
   return false;
 }
 
-SDKNodeInitInfo::SDKNodeInitInfo(SDKContext &Ctx, Decl *D):
-      Ctx(Ctx), DKind(D->getKind()), Loc(D->getLoc()),
+SDKNodeInitInfo::SDKNodeInitInfo(SDKContext &Ctx, Decl *D)
+    : Ctx(Ctx), DKind(D->getKind()), Loc(D->getLoc()),
       Location(calculateLocation(Ctx, D)),
       ModuleName(D->getModuleContext()->getName().str()),
-      GenericSig(printGenericSignature(Ctx, D, /*Canonical*/Ctx.checkingABI())),
-      SugaredGenericSig(Ctx.checkingABI()?
-                        printGenericSignature(Ctx, D, /*Canonical*/false):
-                        StringRef()),
+      GenericSig(
+          printGenericSignature(Ctx, D, /*Canonical*/ Ctx.checkingABI())),
+      SugaredGenericSig(Ctx.checkingABI()
+                            ? printGenericSignature(Ctx, D, /*Canonical*/ false)
+                            : StringRef()),
       IntromacOS(Ctx.getPlatformIntroVersion(D, PlatformKind::macOS)),
       IntroiOS(Ctx.getPlatformIntroVersion(D, PlatformKind::iOS)),
       IntrotvOS(Ctx.getPlatformIntroVersion(D, PlatformKind::tvOS)),
       IntrowatchOS(Ctx.getPlatformIntroVersion(D, PlatformKind::watchOS)),
       IntrovisionOS(Ctx.getPlatformIntroVersion(D, PlatformKind::visionOS)),
       Introswift(Ctx.getLanguageIntroVersion(D)),
-      ObjCName(Ctx.getObjcName(D)),
-      InitKind(Ctx.getInitKind(D)),
-      IsImplicit(D->isImplicit()),
-      IsDeprecated(D->isDeprecated()),
+      IntroAnyAppleOS(Ctx.getPlatformIntroVersion(D, PlatformKind::anyAppleOS)),
+      ObjCName(Ctx.getObjcName(D)), InitKind(Ctx.getInitKind(D)),
+      IsImplicit(D->isImplicit()), IsDeprecated(D->isDeprecated()),
       IsABIPlaceholder(isABIPlaceholderRecursive(D)),
       IsFromExtension(isDeclaredInExtension(D)),
       DeclAttrs(collectDeclAttributes(D)) {
@@ -2160,6 +2157,7 @@ void SDKNodeDecl::jsonize(json::Output &out) {
   output(out, KeyKind::KK_intro_tvOS, introVersions.tvos);
   output(out, KeyKind::KK_intro_watchOS, introVersions.watchos);
   output(out, KeyKind::KK_intro_swift, introVersions.swift);
+  output(out, KeyKind::KK_intro_anyAppleOS, introVersions.anyappleos);
   output(out, KeyKind::KK_objc_name, ObjCName);
   out.mapOptional(getKeyContent(Ctx, KeyKind::KK_declAttributes).data(), DeclAttributes);
   out.mapOptional(getKeyContent(Ctx, KeyKind::KK_fixedbinaryorder).data(), FixedBinaryOrder);

--- a/test/api-digester/Inputs/cake.swift
+++ b/test/api-digester/Inputs/cake.swift
@@ -151,3 +151,12 @@ public func silgenNamedFunc() {}
 public class SinkingClass {
   public init() {}
 }
+
+@available(anyAppleOS 26, *)
+public func availableAnyAppleOS26() {}
+
+@available(anyAppleOS 26, macOS 26.4, *)
+public func availableAnyAppleOS26ButMacOS26_4() {}
+
+@available(anyAppleOS, unavailable)
+public func unavailableAnyAppleOS() {}

--- a/test/api-digester/Outputs/dump-module/cake-abi.json
+++ b/test/api-digester/Outputs/dump-module/cake-abi.json
@@ -1946,6 +1946,50 @@
         ]
       },
       {
+        "kind": "Function",
+        "name": "availableAnyAppleOS26",
+        "printedName": "availableAnyAppleOS26()",
+        "children": [
+          {
+            "kind": "TypeNominal",
+            "name": "Void",
+            "printedName": "()"
+          }
+        ],
+        "declKind": "Func",
+        "usr": "s:4cake21availableAnyAppleOS26yyF",
+        "mangledName": "$s4cake21availableAnyAppleOS26yyF",
+        "moduleName": "cake",
+        "intro_anyAppleOS": "26",
+        "declAttributes": [
+          "Available"
+        ],
+        "funcSelfKind": "NonMutating"
+      },
+      {
+        "kind": "Function",
+        "name": "availableAnyAppleOS26ButMacOS26_4",
+        "printedName": "availableAnyAppleOS26ButMacOS26_4()",
+        "children": [
+          {
+            "kind": "TypeNominal",
+            "name": "Void",
+            "printedName": "()"
+          }
+        ],
+        "declKind": "Func",
+        "usr": "s:4cake027availableAnyAppleOS26ButMacE2_4yyF",
+        "mangledName": "$s4cake027availableAnyAppleOS26ButMacE2_4yyF",
+        "moduleName": "cake",
+        "intro_Macosx": "26.4",
+        "intro_anyAppleOS": "26",
+        "declAttributes": [
+          "Available",
+          "Available"
+        ],
+        "funcSelfKind": "NonMutating"
+      },
+      {
         "kind": "TypeDecl",
         "name": "Int",
         "printedName": "Int",

--- a/test/api-digester/Outputs/dump-module/cake.json
+++ b/test/api-digester/Outputs/dump-module/cake.json
@@ -1833,6 +1833,50 @@
         ]
       },
       {
+        "kind": "Function",
+        "name": "availableAnyAppleOS26",
+        "printedName": "availableAnyAppleOS26()",
+        "children": [
+          {
+            "kind": "TypeNominal",
+            "name": "Void",
+            "printedName": "()"
+          }
+        ],
+        "declKind": "Func",
+        "usr": "s:4cake21availableAnyAppleOS26yyF",
+        "mangledName": "$s4cake21availableAnyAppleOS26yyF",
+        "moduleName": "cake",
+        "intro_anyAppleOS": "26",
+        "declAttributes": [
+          "Available"
+        ],
+        "funcSelfKind": "NonMutating"
+      },
+      {
+        "kind": "Function",
+        "name": "availableAnyAppleOS26ButMacOS26_4",
+        "printedName": "availableAnyAppleOS26ButMacOS26_4()",
+        "children": [
+          {
+            "kind": "TypeNominal",
+            "name": "Void",
+            "printedName": "()"
+          }
+        ],
+        "declKind": "Func",
+        "usr": "s:4cake027availableAnyAppleOS26ButMacE2_4yyF",
+        "mangledName": "$s4cake027availableAnyAppleOS26ButMacE2_4yyF",
+        "moduleName": "cake",
+        "intro_Macosx": "26.4",
+        "intro_anyAppleOS": "26",
+        "declAttributes": [
+          "Available",
+          "Available"
+        ],
+        "funcSelfKind": "NonMutating"
+      },
+      {
         "kind": "TypeDecl",
         "name": "Int",
         "printedName": "Int",

--- a/test/api-digester/availability.swift
+++ b/test/api-digester/availability.swift
@@ -1,0 +1,35 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-module -o %t/Foo.swiftmodule -emit-abi-descriptor-path %t/abi-before.json %S/../Inputs/empty.swift -enable-library-evolution -emit-tbd-path %t/abi-before.tbd -tbd-install_name Foo
+// RUN: %target-swift-frontend -emit-module -o %t/Foo.swiftmodule -emit-abi-descriptor-path %t/abi-after.json %s -enable-library-evolution -emit-tbd-path %t/abi-after.tbd -tbd-install_name Foo
+// RUN: %api-digester -diagnose-sdk --input-paths %t/abi-before.json -input-paths %t/abi-after.json -abi -o %t/result.txt
+// RUN: %FileCheck %s < %t/result.txt
+
+// REQUIRES: OS=macosx
+
+public func noAvailability() { }
+
+@available(macOS, unavailable)
+public func unavailableOnMacOS() { }
+
+@available(macOS 10.15, *)
+public func onlyMacOSAvailability() { }
+
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+public func allAppleOSAvailability() { }
+
+@available(macOS 9999, iOS 9999, watchOS 999, tvOS 9999, visionOS 9999, *)
+public func appleOSPlaceholderAvailability() { }
+
+@available(anyAppleOS 26.0, *)
+public func anyAppleOSAvailability() { }
+
+@available(anyAppleOS, unavailable)
+public func unavailableOnAnyAppleOS() { }
+
+@available(anyAppleOS 9999, *)
+public func anyAppleOSPlaceHolderAvailability() { }
+
+// CHECK-LABEL: /* Decl Attribute changes */
+// CHECK-NEXT: Func noAvailability() is a new API without '@available'
+// CHECK-NOT: is a new API without


### PR DESCRIPTION
Ensure declarations with `anyAppleOS` availability are accepted by the ABI checker.

Resolves rdar://170663253.