### PR TITLE
Extend borrow accessor support in enums and classes 

### DIFF
--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -281,7 +281,7 @@ ERROR(lookup_outputs_dont_match,none,
 //------------------------------------------------------------------------------
 
 ERROR(borrow_mutate_accessor_not_supported_in_decl, none,
-      "%0 is supported only on a struct", (StringRef))      
+      "%0 is unsupported here", (StringRef))
 
 //------------------------------------------------------------------------------
 // MARK: bridged diagnostics

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7071,12 +7071,12 @@ ArtificialMainKind Decl::getArtificialMainKind() const {
 }
 
 bool Decl::canSupportBorrowAccessors() const {
-  if (isa<StructDecl>(this)) {
+  if (isa<StructDecl>(this) || isa<EnumDecl>(this) || isa<ClassDecl>(this)) {
     return true;
   }
   if (auto *extension = dyn_cast<ExtensionDecl>(this)) {
     auto *extendedNominal = extension->getExtendedNominal();
-    if (extendedNominal && isa<StructDecl>(extendedNominal)) {
+    if (extendedNominal && extendedNominal->canSupportBorrowAccessors()) {
       return true;
     }
   }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -8283,7 +8283,7 @@ bool Parser::parseAccessorAfterIntroducer(
 
   if (Kind == AccessorKind::Borrow || Kind == AccessorKind::Mutate) {
     if (!Flags.contains(PD_InStruct) && !Flags.contains(PD_InEnum) &&
-    !Flags.contains(PD_InExtension) &&
+        !Flags.contains(PD_InClass) && !Flags.contains(PD_InExtension) &&
         !Flags.contains(PD_InProtocol)) {
       diagnose(Tok, diag::borrow_mutate_accessor_not_supported_in_decl,
                getAccessorNameForDiagnostic(Kind, /*article*/ true,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -8282,7 +8282,8 @@ bool Parser::parseAccessorAfterIntroducer(
   }
 
   if (Kind == AccessorKind::Borrow || Kind == AccessorKind::Mutate) {
-    if (!Flags.contains(PD_InStruct) && !Flags.contains(PD_InExtension) &&
+    if (!Flags.contains(PD_InStruct) && !Flags.contains(PD_InEnum) &&
+    !Flags.contains(PD_InExtension) &&
         !Flags.contains(PD_InProtocol)) {
       diagnose(Tok, diag::borrow_mutate_accessor_not_supported_in_decl,
                getAccessorNameForDiagnostic(Kind, /*article*/ true,

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -5612,13 +5612,15 @@ public:
     // function argument or Builtin.Borrow.
     if (F.getModule().getStage() >= SILStage::Canonical &&
         functionResultType.isAddress()) {
-      auto base = getAccessBase(RI->getOperand());
-      require(!base->getType().isAddress() || isa<SILFunctionArgument>(base) ||
-                  isa<DereferenceAddrBorrowInst>(base) ||
-                  isa<DereferenceBorrowAddrInst>(base) ||
-                  (isa<ApplyInst>(base) &&
-                       cast<ApplyInst>(base)->hasAddressResult() ||
-                   isa<GlobalAddrInst>(base)),
+      auto base = AccessBase::compute(RI->getOperand());
+      auto root = base ? base.isReference() ? base.getOwnershipReferenceRoot()
+                                            : base.getBaseAddress()
+                       : SILValue();
+      require(!root || !root->getType().isAddress() ||
+                  isa<SILFunctionArgument>(root) ||
+                  (isa<ApplyInst>(root) &&
+                       cast<ApplyInst>(root)->hasAddressResult() ||
+                   isa<GlobalAddrInst>(root)),
               "unidentified address return");
     }
   }

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -4451,7 +4451,8 @@ StorageImplInfoRequest::evaluate(Evaluator &evaluator,
   if (borrow || mutate) {
     if (auto *extDecl = dyn_cast<ExtensionDecl>(DC)) {
       auto extNominal = extDecl->getExtendedNominal();
-      if (!isa<StructDecl>(extNominal) && !isa<EnumDecl>(extNominal)) {
+      if (!isa<StructDecl>(extNominal) && !isa<EnumDecl>(extNominal) &&
+          !isa<ClassDecl>(extNominal)) {
         if (borrow) {
           storage->getASTContext().Diags.diagnose(
               borrow->getLoc(),

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -4451,7 +4451,7 @@ StorageImplInfoRequest::evaluate(Evaluator &evaluator,
   if (borrow || mutate) {
     if (auto *extDecl = dyn_cast<ExtensionDecl>(DC)) {
       auto extNominal = extDecl->getExtendedNominal();
-      if (!isa<StructDecl>(extNominal)) {
+      if (!isa<StructDecl>(extNominal) && !isa<EnumDecl>(extNominal)) {
         if (borrow) {
           storage->getASTContext().Diags.diagnose(
               borrow->getLoc(),

--- a/test/Parse/borrow_and_mutate_accessors.swift
+++ b/test/Parse/borrow_and_mutate_accessors.swift
@@ -121,20 +121,3 @@ var i_accessor: Int {
   }
 }
 
-class KlassWrapper {
-  var _k: Klass
-
-  init(_ k: Klass) {
-    self._k = k
-  }
-
-  var k: Klass {
-    borrow {// expected-error{{a 'borrow' accessor is unsupported here}}
-      return _k
-    }
-    mutate {// expected-error{{a 'mutate' accessor is unsupported here}}
-      return &_k
-    }
-  }
-}
-

--- a/test/Parse/borrow_and_mutate_accessors.swift
+++ b/test/Parse/borrow_and_mutate_accessors.swift
@@ -113,10 +113,10 @@ struct Wrapper {
 var i: Int
 
 var i_accessor: Int {
-  borrow { // expected-error{{a 'borrow' accessor is supported only on a struct}}
+  borrow { // expected-error{{a 'borrow' accessor is unsupported here}}
     fatalError()
   }
-  mutate { // expected-error{{a 'mutate' accessor is supported only on a struct}}
+  mutate { // expected-error{{a 'mutate' accessor is unsupported here}}
     return &i // expected-error{{'&' may only be used to pass an argument to inout parameter}}
   }
 }
@@ -129,10 +129,10 @@ class KlassWrapper {
   }
 
   var k: Klass {
-    borrow {// expected-error{{a 'borrow' accessor is supported only on a struct}}
+    borrow {// expected-error{{a 'borrow' accessor is unsupported here}}
       return _k
     }
-    mutate {// expected-error{{a 'mutate' accessor is supported only on a struct}}
+    mutate {// expected-error{{a 'mutate' accessor is unsupported here}}
       return &_k
     }
   }

--- a/test/SILGen/borrow_accessor.swift
+++ b/test/SILGen/borrow_accessor.swift
@@ -1022,3 +1022,38 @@ public struct SafeContainer<Element: ~Copyable >: ~Copyable {
   }
 }
 
+public enum E<T> {
+  case none
+  case some(T)
+
+  var global_int_prop: Int {
+    borrow {
+      return global_int
+    }
+  }
+
+  var global_k1: Klass {
+    borrow {
+      return global_klass
+    }
+  }
+
+  var global_k2: Klass {
+    borrow {
+      return global_wrapper._k
+    }
+  }
+
+  var global_k3: Klass {
+    borrow {
+      return global_wrapper.k
+    }
+  }
+
+  var global_k4: AnyObject {
+    borrow {
+      return global_generic
+    }
+  }
+}
+

--- a/test/SILGen/borrow_accessor.swift
+++ b/test/SILGen/borrow_accessor.swift
@@ -1057,3 +1057,172 @@ public enum E<T> {
   }
 }
 
+class KlassBorrowLet {
+  let _k: Klass
+
+  init(_ k: Klass) {
+    self._k = k
+  }
+
+  var k: Klass {
+    borrow {
+      return _k
+    }
+  }
+}
+
+class KlassBorrowGlobalLet {
+  var k: Klass {
+    borrow {
+      return global_klass
+    }
+  }
+}
+
+class KlassBorrowMutateUMBP<Element> {
+  let _storage: UnsafeMutableBufferPointer<Element>
+
+  init(_ storage: UnsafeMutableBufferPointer<Element>) {
+    self._storage = storage
+  }
+
+  var first: Element {
+    @_unsafeSelfDependentResult
+    borrow {
+      return unsafe _storage.baseAddress.unsafelyUnwrapped.pointee
+    }
+    @_unsafeSelfDependentResult
+    mutate {
+      return unsafe &_storage.baseAddress.unsafelyUnwrapped.pointee
+    }
+  }
+}
+
+// CHECK: sil hidden [ossa] @$s15borrow_accessor14KlassBorrowLetC1kAA0C0Cvb : $@convention(method) (@guaranteed KlassBorrowLet) -> @guaranteed Klass {
+// CHECK: bb0([[REG0:%.*]] : @guaranteed $KlassBorrowLet):
+// CHECK:   [[REG2:%.*]] = ref_element_addr [[REG0]], #KlassBorrowLet._k
+// CHECK:   [[REG3:%.*]] = load_borrow [[REG2]]
+// CHECK:   [[REG4:%.*]] = unchecked_ownership [[REG3]]
+// CHECK:   end_borrow [[REG3]]
+// CHECK:   return [[REG4]]
+// CHECK: }
+
+// CHECK: sil hidden [ossa] @$s15borrow_accessor20KlassBorrowGlobalLetC1kAA0C0Cvb : $@convention(method) (@guaranteed KlassBorrowGlobalLet) -> @guaranteed Klass {
+// CHECK: bb0([[REG0:%.*]] : @guaranteed $KlassBorrowGlobalLet):
+// CHECK:   [[REG1:%.*]] = global_addr @$s15borrow_accessor12global_klassAA5KlassCvp : $*Klass
+// CHECK:   [[REG3:%.*]] = load_borrow [[REG1]]
+// CHECK:   [[REG4:%.*]] = unchecked_ownership [[REG3]]
+// CHECK:   end_borrow [[REG3]]
+// CHECK:   return [[REG4]]
+// CHECK: }
+
+// CHECK: sil hidden [ossa] @$s15borrow_accessor21KlassBorrowMutateUMBPC5firstxvb : $@convention(method) <Element> (@guaranteed KlassBorrowMutateUMBP<Element>) -> @guaranteed_address Element {
+// CHECK: bb0([[REG0:%.*]] : @guaranteed $KlassBorrowMutateUMBP<Element>):
+// CHECK:   [[REG2:%.*]] = ref_element_addr [[REG0]], #KlassBorrowMutateUMBP._storage
+// CHECK:   [[REG3:%.*]] = alloc_stack $Optional<UnsafeMutablePointer<Element>>
+// CHECK:   [[REG4:%.*]] = load [trivial] [[REG2]]
+// CHECK:   [[REG5:%.*]] = function_ref @$sSr11baseAddressSpyxGSgvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
+// CHECK:   [[REG6:%.*]] = apply [[REG5]]<Element>([[REG4]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
+// CHECK:   store [[REG6]] to [trivial] [[REG3]]
+// CHECK:   [[REG8:%.*]] = alloc_stack $UnsafeMutablePointer<Element>
+// CHECK:   [[REG9:%.*]] = function_ref @$sSq17unsafelyUnwrappedxvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Escapable> (@in_guaranteed Optional<τ_0_0>) -> @lifetime(copy 0) @out τ_0_0
+// CHECK:   [[REG10:%.*]] = apply [[REG9]]<UnsafeMutablePointer<Element>>([[REG8]], [[REG3]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Escapable> (@in_guaranteed Optional<τ_0_0>) -> @lifetime(copy 0) @out τ_0_0
+// CHECK:   [[REG11:%.*]] = load [trivial] [[REG8]]
+// CHECK:   [[REG12:%.*]] = function_ref @$sSpsRi_zrlE7pointeexvlu : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
+// CHECK:   [[REG13:%.*]] = apply [[REG12]]<Element>([[REG11]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
+// CHECK:   [[REG14:%.*]] = struct_extract [[REG13]], #UnsafePointer._rawValue
+// CHECK:   [[REG15:%.*]] = pointer_to_address [[REG14]] to [strict] $*Element
+// CHECK:   [[REG16:%.*]] = mark_dependence [unresolved] [[REG15]] on [[REG11]]
+// CHECK:   [[REG17:%.*]] = begin_access [read] [unsafe] [[REG16]]
+// CHECK:   end_access [[REG17]]
+// CHECK:   dealloc_stack [[REG8]]
+// CHECK:   dealloc_stack [[REG3]]
+// CHECK:   return [[REG17]]
+// CHECK: }
+
+// CHECK: sil hidden [ossa] @$s15borrow_accessor21KlassBorrowMutateUMBPC5firstxvz : $@convention(method) <Element> (@guaranteed KlassBorrowMutateUMBP<Element>) -> @inout Element {
+// CHECK: bb0([[REG0:%.*]] : @guaranteed $KlassBorrowMutateUMBP<Element>):
+// CHECK:   [[REG2:%.*]] = ref_element_addr [[REG0]], #KlassBorrowMutateUMBP._storage
+// CHECK:   [[REG3:%.*]] = alloc_stack $Optional<UnsafeMutablePointer<Element>>
+// CHECK:   [[REG4:%.*]] = load [trivial] [[REG2]]
+// CHECK:   [[REG5:%.*]] = function_ref @$sSr11baseAddressSpyxGSgvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
+// CHECK:   [[REG6:%.*]] = apply [[REG5]]<Element>([[REG4]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
+// CHECK:   store [[REG6]] to [trivial] [[REG3]]
+// CHECK:   [[REG8:%.*]] = alloc_stack $UnsafeMutablePointer<Element>
+// CHECK:   [[REG9:%.*]] = function_ref @$sSq17unsafelyUnwrappedxvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Escapable> (@in_guaranteed Optional<τ_0_0>) -> @lifetime(copy 0) @out τ_0_0
+// CHECK:   [[REG10:%.*]] = apply [[REG9]]<UnsafeMutablePointer<Element>>([[REG8]], [[REG3]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Escapable> (@in_guaranteed Optional<τ_0_0>) -> @lifetime(copy 0) @out τ_0_0
+// CHECK:   [[REG11:%.*]] = load [trivial] [[REG8]]
+// CHECK:   [[REG12:%.*]] = function_ref @$sSpsRi_zrlE7pointeexvlu : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
+// CHECK:   [[REG13:%.*]] = apply [[REG12]]<Element>([[REG11]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
+// CHECK:   [[REG14:%.*]] = struct_extract [[REG13]], #UnsafePointer._rawValue
+// CHECK:   [[REG15:%.*]] = pointer_to_address [[REG14]] to [strict] $*Element
+// CHECK:   [[REG16:%.*]] = mark_dependence [unresolved] [[REG15]] on [[REG11]]
+// CHECK:   [[REG17:%.*]] = begin_access [read] [unsafe] [[REG16]]
+// CHECK:   end_access [[REG17]]
+// CHECK:   dealloc_stack [[REG8]]
+// CHECK:   dealloc_stack [[REG3]]
+// CHECK:   return [[REG17]]
+// CHECK: }
+
+// CHECK-SIL: sil hidden [ossa] @$s15borrow_accessor14KlassBorrowLetC1kAA0C0Cvb : $@convention(method) (@guaranteed KlassBorrowLet) -> @guaranteed Klass {
+// CHECK-SIL: bb0([[REG0:%.*]] : @guaranteed $KlassBorrowLet):
+// CHECK-SIL:   [[REG2:%.*]] = ref_element_addr [[REG0]], #KlassBorrowLet._k
+// CHECK-SIL:   [[REG3:%.*]] = load_borrow [[REG2]]
+// CHECK-SIL:   return_borrow [[REG3]] from_scopes ([[REG3]])
+// CHECK-SIL: }
+
+// CHECK-SIL: sil hidden [ossa] @$s15borrow_accessor20KlassBorrowGlobalLetC1kAA0C0Cvb : $@convention(method) (@guaranteed KlassBorrowGlobalLet) -> @guaranteed Klass {
+// CHECK-SIL: bb0([[REG0:%.*]] : @guaranteed $KlassBorrowGlobalLet):
+// CHECK-SIL:   [[REG1:%.*]] = global_addr @$s15borrow_accessor12global_klassAA5KlassCvp : $*Klass
+// CHECK-SIL:   [[REG3:%.*]] = load_borrow [[REG1]]
+// CHECK-SIL:   return_borrow [[REG3]] from_scopes ([[REG3]])
+// CHECK-SIL: }
+
+// CHECK-SIL: sil hidden [ossa] @$s15borrow_accessor21KlassBorrowMutateUMBPC5firstxvb : $@convention(method) <Element> (@guaranteed KlassBorrowMutateUMBP<Element>) -> @guaranteed_address Element {
+// CHECK-SIL: bb0([[REG0:%.*]] : @guaranteed $KlassBorrowMutateUMBP<Element>):
+// CHECK-SIL:   [[REG2:%.*]] = ref_element_addr [[REG0]], #KlassBorrowMutateUMBP._storage
+// CHECK-SIL:   [[REG3:%.*]] = alloc_stack $Optional<UnsafeMutablePointer<Element>>
+// CHECK-SIL:   [[REG4:%.*]] = load [trivial] [[REG2]]
+// CHECK-SIL:   [[REG5:%.*]] = function_ref @$sSr11baseAddressSpyxGSgvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
+// CHECK-SIL:   [[REG6:%.*]] = apply [[REG5]]<Element>([[REG4]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
+// CHECK-SIL:   store [[REG6]] to [trivial] [[REG3]]
+// CHECK-SIL:   [[REG8:%.*]] = alloc_stack $UnsafeMutablePointer<Element>
+// CHECK-SIL:   [[REG9:%.*]] = function_ref @$sSq17unsafelyUnwrappedxvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Escapable> (@in_guaranteed Optional<τ_0_0>) -> @lifetime(copy 0) @out τ_0_0
+// CHECK-SIL:   [[REG10:%.*]] = apply [[REG9]]<UnsafeMutablePointer<Element>>([[REG8]], [[REG3]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Escapable> (@in_guaranteed Optional<τ_0_0>) -> @lifetime(copy 0) @out τ_0_0
+// CHECK-SIL:   [[REG11:%.*]] = load [trivial] [[REG8]]
+// CHECK-SIL:   [[REG12:%.*]] = function_ref @$sSpsRi_zrlE7pointeexvlu : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
+// CHECK-SIL:   [[REG13:%.*]] = apply [[REG12]]<Element>([[REG11]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
+// CHECK-SIL:   [[REG14:%.*]] = struct_extract [[REG13]], #UnsafePointer._rawValue
+// CHECK-SIL:   [[REG15:%.*]] = pointer_to_address [[REG14]] to [strict] $*Element
+// CHECK-SIL:   [[REG16:%.*]] = mark_dependence [unresolved] [[REG15]] on [[REG11]]
+// CHECK-SIL:   [[REG17:%.*]] = begin_access [read] [unsafe] [[REG16]]
+// CHECK-SIL:   end_access [[REG17]]
+// CHECK-SIL:   dealloc_stack [[REG8]]
+// CHECK-SIL:   dealloc_stack [[REG3]]
+// CHECK-SIL:   return [[REG17]]
+// CHECK-SIL: }
+
+// CHECK-SIL: sil hidden [ossa] @$s15borrow_accessor21KlassBorrowMutateUMBPC5firstxvz : $@convention(method) <Element> (@guaranteed KlassBorrowMutateUMBP<Element>) -> @inout Element {
+// CHECK-SIL: bb0([[REG0:%.*]] : @guaranteed $KlassBorrowMutateUMBP<Element>):
+// CHECK-SIL:   [[REG2:%.*]] = ref_element_addr [[REG0]], #KlassBorrowMutateUMBP._storage
+// CHECK-SIL:   [[REG3:%.*]] = alloc_stack $Optional<UnsafeMutablePointer<Element>>
+// CHECK-SIL:   [[REG4:%.*]] = load [trivial] [[REG2]]
+// CHECK-SIL:   [[REG5:%.*]] = function_ref @$sSr11baseAddressSpyxGSgvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
+// CHECK-SIL:   [[REG6:%.*]] = apply [[REG5]]<Element>([[REG4]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutableBufferPointer<τ_0_0>) -> Optional<UnsafeMutablePointer<τ_0_0>>
+// CHECK-SIL:   store [[REG6]] to [trivial] [[REG3]]
+// CHECK-SIL:   [[REG8:%.*]] = alloc_stack $UnsafeMutablePointer<Element>
+// CHECK-SIL:   [[REG9:%.*]] = function_ref @$sSq17unsafelyUnwrappedxvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Escapable> (@in_guaranteed Optional<τ_0_0>) -> @lifetime(copy 0) @out τ_0_0
+// CHECK-SIL:   [[REG10:%.*]] = apply [[REG9]]<UnsafeMutablePointer<Element>>([[REG8]], [[REG3]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Escapable> (@in_guaranteed Optional<τ_0_0>) -> @lifetime(copy 0) @out τ_0_0
+// CHECK-SIL:   [[REG11:%.*]] = load [trivial] [[REG8]]
+// CHECK-SIL:   [[REG12:%.*]] = function_ref @$sSpsRi_zrlE7pointeexvlu : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
+// CHECK-SIL:   [[REG13:%.*]] = apply [[REG12]]<Element>([[REG11]]) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafeMutablePointer<τ_0_0>) -> UnsafePointer<τ_0_0>
+// CHECK-SIL:   [[REG14:%.*]] = struct_extract [[REG13]], #UnsafePointer._rawValue
+// CHECK-SIL:   [[REG15:%.*]] = pointer_to_address [[REG14]] to [strict] $*Element
+// CHECK-SIL:   [[REG16:%.*]] = mark_dependence [unresolved] [[REG15]] on [[REG11]]
+// CHECK-SIL:   [[REG17:%.*]] = begin_access [read] [unsafe] [[REG16]]
+// CHECK-SIL:   end_access [[REG17]]
+// CHECK-SIL:   dealloc_stack [[REG8]]
+// CHECK-SIL:   dealloc_stack [[REG3]]
+// CHECK-SIL:   return [[REG17]]
+// CHECK-SIL: }
+

--- a/test/SILGen/borrow_accessor_failures.swift
+++ b/test/SILGen/borrow_accessor_failures.swift
@@ -315,3 +315,21 @@ public struct Container<Element: ~Copyable >: ~Copyable {
   }
 }
 
+enum OrderStatus: ~Copyable {
+  case processing(trackingNumber: String)
+  case cancelled(reason: String)
+
+  var description: String {
+    borrow {
+      switch self {
+        case .processing(let trackingNumber):
+          return trackingNumber // expected-error{{invalid return value from a borrow accessor}} // expected-note{{borrow accessors can return stored properties, computed properties with borrow accessors or global 'let' declarations}}
+
+        case .cancelled(let reason):
+          return reason // expected-error{{invalid return value from a borrow accessor}} // expected-note{{borrow accessors can return stored properties, computed properties with borrow accessors or global 'let' declarations}}
+
+      }
+    }
+  }
+}
+

--- a/test/SILGen/borrow_accessor_failures.swift
+++ b/test/SILGen/borrow_accessor_failures.swift
@@ -333,3 +333,20 @@ enum OrderStatus: ~Copyable {
   }
 }
 
+class KlassWrapper {
+  var _k: Klass
+
+  init(_ k: Klass) {
+    self._k = k
+  }
+
+  var k: Klass {
+    borrow {
+      return _k // expected-error{{invalid return value from a borrow accessor}} // expected-note{{borrow accessors can return stored properties, computed properties with borrow accessors or global 'let' declarations}}
+    }
+    mutate {
+      return &_k // expected-error{{invalid return value from a mutate accessor}} // expected-note{{mutate accessors can return stored properties, computed properties with mutate accessors or global 'let' declarations}}
+    }
+  }
+}
+

--- a/test/SILGen/borrow_accessor_protocol.swift
+++ b/test/SILGen/borrow_accessor_protocol.swift
@@ -8,10 +8,12 @@ public protocol P {
   var id: NonTrivial { borrow mutate }
 }
 
-public class Klass {}
+public class Klass {
+  public init() {}
+}
 
 public struct NonTrivial {
-  public var k: Klass
+  public var k = Klass()
 }
 
 // Protocol requirements witnessed via borrow/mutate accessors
@@ -149,7 +151,7 @@ public protocol Q {
 
 @frozen
 public struct FrozenNonTrivial {
-  public var k: Klass
+  public var k = Klass()
 }
 
 public struct S6 : Q {
@@ -161,6 +163,54 @@ public struct S6 : Q {
     }
     mutate {
       return &_id
+    }
+  }
+}
+
+public protocol R {
+  var id: NonTrivial { borrow }
+}
+
+public class K1 : R {
+  public let id: NonTrivial
+
+  init(_ id: NonTrivial) {
+    self.id = id
+  }
+}
+
+public class K2 : R {
+  let _id = NonTrivial()
+
+  public var id: NonTrivial {
+    borrow {
+      return _id
+    }
+  }
+}
+
+public class K3 : R {
+  let _id = NonTrivial()
+}
+
+extension K3 {
+  public var id: NonTrivial {
+    borrow  {
+      return _id
+    }
+  }
+}
+
+public protocol S {
+  var id: FrozenNonTrivial { borrow }
+}
+
+public class K4 : S {
+  let _id = FrozenNonTrivial()
+
+  public var id: FrozenNonTrivial {
+    borrow {
+      return _id
     }
   }
 }
@@ -197,6 +247,220 @@ public struct S6 : Q {
 // CHECK-EVO:   return [[REG2]]
 // CHECK-EVO: }
 
+// CHECK: sil shared [transparent] [serialized] [thunk] [ossa] @$s24borrow_accessor_protocol2K1CAA1RA2aDP2idAA10NonTrivialVvbTW : $@convention(witness_method: R) (@in_guaranteed K1) -> @guaranteed NonTrivial {
+// CHECK: bb0([[REG0:%.*]] : $*K1):
+// CHECK:   [[REG1:%.*]] = load_borrow [[REG0]]
+// CHECK:   [[REG2:%.*]] = function_ref @$s24borrow_accessor_protocol2K1C2idAA10NonTrivialVvb : $@convention(method) (@guaranteed K1) -> @guaranteed NonTrivial
+// CHECK:   [[REG3:%.*]] = unchecked_ownership [[REG1]]
+// CHECK:   [[REG4:%.*]] = apply [[REG2]]([[REG3]]) : $@convention(method) (@guaranteed K1) -> @guaranteed NonTrivial
+// CHECK:   end_borrow [[REG1]]
+// CHECK:   return [[REG4]]
+// CHECK: }
+
+// CHECK: sil shared [serialized] [ossa] @$s24borrow_accessor_protocol2K1C2idAA10NonTrivialVvb : $@convention(method) (@guaranteed K1) -> @guaranteed NonTrivial {
+// CHECK: bb0([[REG0:%.*]] : @guaranteed $K1):
+// CHECK:   debug_value [[REG0]], let, name "self", argno 1
+// CHECK:   [[REG2:%.*]] = ref_element_addr [[REG0]], #K1.id
+// CHECK:   [[REG3:%.*]] = load_borrow [[REG2]]
+// CHECK:   [[REG4:%.*]] = unchecked_ownership [[REG3]]
+// CHECK:   end_borrow [[REG3]]
+// CHECK:   return [[REG4]]
+// CHECK: }
+
+// CHECK: sil [ossa] @$s24borrow_accessor_protocol2K2C2idAA10NonTrivialVvb : $@convention(method) (@guaranteed K2) -> @guaranteed NonTrivial {
+// CHECK: bb0([[REG0:%.*]] : @guaranteed $K2):
+// CHECK:   debug_value [[REG0]], let, name "self", argno 1
+// CHECK:   [[REG2:%.*]] = ref_element_addr [[REG0]], #K2._id
+// CHECK:   [[REG3:%.*]] = load_borrow [[REG2]]
+// CHECK:   [[REG4:%.*]] = unchecked_ownership [[REG3]]
+// CHECK:   end_borrow [[REG3]]
+// CHECK:   return [[REG4]]
+// CHECK: }
+
+// CHECK: sil shared [transparent] [serialized] [thunk] [ossa] @$s24borrow_accessor_protocol2K2CAA1RA2aDP2idAA10NonTrivialVvbTW : $@convention(witness_method: R) (@in_guaranteed K2) -> @guaranteed NonTrivial {
+// CHECK: bb0([[REG0:%.*]] : $*K2):
+// CHECK:   [[REG1:%.*]] = load_borrow [[REG0]]
+// CHECK:   [[REG2:%.*]] = class_method [[REG1]], #K2.id!borrow : (K2) -> () -> NonTrivial, $@convention(method) (@guaranteed K2) -> @guaranteed NonTrivial
+// CHECK:   [[REG3:%.*]] = unchecked_ownership [[REG1]]
+// CHECK:   [[REG4:%.*]] = apply [[REG2]]([[REG3]]) : $@convention(method) (@guaranteed K2) -> @guaranteed NonTrivial
+// CHECK:   end_borrow [[REG1]]
+// CHECK:   return [[REG4]]
+// CHECK: }
+
+// CHECK: sil shared [transparent] [serialized] [thunk] [ossa] @$s24borrow_accessor_protocol2K3CAA1RA2aDP2idAA10NonTrivialVvbTW : $@convention(witness_method: R) (@in_guaranteed K3) -> @guaranteed NonTrivial {
+// CHECK: bb0([[REG0:%.*]] : $*K3):
+// CHECK:   [[REG1:%.*]] = load_borrow [[REG0]]
+// CHECK:   [[REG2:%.*]] = function_ref @$s24borrow_accessor_protocol2K3C2idAA10NonTrivialVvb : $@convention(method) (@guaranteed K3) -> @guaranteed NonTrivial
+// CHECK:   [[REG3:%.*]] = unchecked_ownership [[REG1]]
+// CHECK:   [[REG4:%.*]] = apply [[REG2]]([[REG3]]) : $@convention(method) (@guaranteed K3) -> @guaranteed NonTrivial
+// CHECK:   end_borrow [[REG1]]
+// CHECK:   return [[REG4]]
+// CHECK: }
+
+// CHECK: sil [ossa] @$s24borrow_accessor_protocol2K3C2idAA10NonTrivialVvb : $@convention(method) (@guaranteed K3) -> @guaranteed NonTrivial {
+// CHECK: bb0([[REG0:%.*]] : @guaranteed $K3):
+// CHECK:   debug_value [[REG0]], let, name "self", argno 1
+// CHECK:   [[REG2:%.*]] = ref_element_addr [[REG0]], #K3._id
+// CHECK:   [[REG3:%.*]] = load_borrow [[REG2]]
+// CHECK:   [[REG4:%.*]] = unchecked_ownership [[REG3]]
+// CHECK:   end_borrow [[REG3]]
+// CHECK:   return [[REG4]]
+// CHECK: }
+
+// CHECK: sil [ossa] @$s24borrow_accessor_protocol2K4C2idAA16FrozenNonTrivialVvb : $@convention(method) (@guaranteed K4) -> @guaranteed FrozenNonTrivial {
+// CHECK: bb0([[REG0:%.*]] : @guaranteed $K4):
+// CHECK:   debug_value [[REG0]], let, name "self", argno 1
+// CHECK:   [[REG2:%.*]] = ref_element_addr [[REG0]], #K4._id
+// CHECK:   [[REG3:%.*]] = load_borrow [[REG2]]
+// CHECK:   [[REG4:%.*]] = unchecked_ownership [[REG3]]
+// CHECK:   end_borrow [[REG3]]
+// CHECK:   return [[REG4]]
+// CHECK: }
+
+// CHECK: sil shared [transparent] [serialized] [thunk] [ossa] @$s24borrow_accessor_protocol2K4CAA1SA2aDP2idAA16FrozenNonTrivialVvbTW : $@convention(witness_method: S) (@in_guaranteed K4) -> @guaranteed FrozenNonTrivial {
+// CHECK: bb0([[REG0:%.*]] : $*K4):
+// CHECK:   [[REG1:%.*]] = load_borrow [[REG0]]
+// CHECK:   [[REG2:%.*]] = class_method [[REG1]], #K4.id!borrow : (K4) -> () -> FrozenNonTrivial, $@convention(method) (@guaranteed K4) -> @guaranteed FrozenNonTrivial
+// CHECK:   [[REG3:%.*]] = unchecked_ownership [[REG1]]
+// CHECK:   [[REG4:%.*]] = apply [[REG2]]([[REG3]]) : $@convention(method) (@guaranteed K4) -> @guaranteed FrozenNonTrivial
+// CHECK:   end_borrow [[REG1]]
+// CHECK:   return [[REG4]]
+// CHECK: }
+
+// CHECK-SIL: sil shared [transparent] [serialized] [thunk] [ossa] @$s24borrow_accessor_protocol2K1CAA1RA2aDP2idAA10NonTrivialVvbTW : $@convention(witness_method: R) (@in_guaranteed K1) -> @guaranteed NonTrivial {
+// CHECK-SIL: bb0([[REG0:%.*]] : $*K1):
+// CHECK-SIL:   [[REG1:%.*]] = load_borrow [[REG0]]
+// CHECK-SIL:   [[REG2:%.*]] = function_ref @$s24borrow_accessor_protocol2K1C2idAA10NonTrivialVvb : $@convention(method) (@guaranteed K1) -> @guaranteed NonTrivial
+// CHECK-SIL:   [[REG3:%.*]] = apply [[REG2]]([[REG1]]) : $@convention(method) (@guaranteed K1) -> @guaranteed NonTrivial
+// CHECK-SIL:   return_borrow [[REG3]] from_scopes ([[REG1]])
+// CHECK-SIL: }
+
+// CHECK-SIL: sil shared [serialized] [ossa] @$s24borrow_accessor_protocol2K1C2idAA10NonTrivialVvb : $@convention(method) (@guaranteed K1) -> @guaranteed NonTrivial {
+// CHECK-SIL: bb0([[REG0:%.*]] : @guaranteed $K1):
+// CHECK-SIL:   debug_value [[REG0]], let, name "self", argno 1
+// CHECK-SIL:   [[REG2:%.*]] = ref_element_addr [[REG0]], #K1.id
+// CHECK-SIL:   [[REG3:%.*]] = load_borrow [[REG2]]
+// CHECK-SIL:   return_borrow [[REG3]] from_scopes ([[REG3]])
+// CHECK-SIL: }
+
+// CHECK-SIL: sil [ossa] @$s24borrow_accessor_protocol2K2C2idAA10NonTrivialVvb : $@convention(method) (@guaranteed K2) -> @guaranteed NonTrivial {
+// CHECK-SIL: bb0([[REG0:%.*]] : @guaranteed $K2):
+// CHECK-SIL:   debug_value [[REG0]], let, name "self", argno 1
+// CHECK-SIL:   [[REG2:%.*]] = ref_element_addr [[REG0]], #K2._id
+// CHECK-SIL:   [[REG3:%.*]] = load_borrow [[REG2]]
+// CHECK-SIL:   return_borrow [[REG3]] from_scopes ([[REG3]])
+// CHECK-SIL: }
+
+// CHECK-SIL: sil shared [transparent] [serialized] [thunk] [ossa] @$s24borrow_accessor_protocol2K2CAA1RA2aDP2idAA10NonTrivialVvbTW : $@convention(witness_method: R) (@in_guaranteed K2) -> @guaranteed NonTrivial {
+// CHECK-SIL: bb0([[REG0:%.*]] : $*K2):
+// CHECK-SIL:   [[REG1:%.*]] = load_borrow [[REG0]]
+// CHECK-SIL:   [[REG2:%.*]] = class_method [[REG1]], #K2.id!borrow : (K2) -> () -> NonTrivial, $@convention(method) (@guaranteed K2) -> @guaranteed NonTrivial
+// CHECK-SIL:   [[REG3:%.*]] = apply [[REG2]]([[REG1]]) : $@convention(method) (@guaranteed K2) -> @guaranteed NonTrivial
+// CHECK-SIL:   return_borrow [[REG3]] from_scopes ([[REG1]])
+// CHECK-SIL: }
+
+// CHECK-SIL: sil shared [transparent] [serialized] [thunk] [ossa] @$s24borrow_accessor_protocol2K3CAA1RA2aDP2idAA10NonTrivialVvbTW : $@convention(witness_method: R) (@in_guaranteed K3) -> @guaranteed NonTrivial {
+// CHECK-SIL: bb0([[REG0:%.*]] : $*K3):
+// CHECK-SIL:   [[REG1:%.*]] = load_borrow [[REG0]]
+// CHECK-SIL:   [[REG2:%.*]] = function_ref @$s24borrow_accessor_protocol2K3C2idAA10NonTrivialVvb : $@convention(method) (@guaranteed K3) -> @guaranteed NonTrivial
+// CHECK-SIL:   [[REG3:%.*]] = apply [[REG2]]([[REG1]]) : $@convention(method) (@guaranteed K3) -> @guaranteed NonTrivial
+// CHECK-SIL:   return_borrow [[REG3]] from_scopes ([[REG1]])
+// CHECK-SIL: }
+
+// CHECK-SIL: sil [ossa] @$s24borrow_accessor_protocol2K3C2idAA10NonTrivialVvb : $@convention(method) (@guaranteed K3) -> @guaranteed NonTrivial {
+// CHECK-SIL: bb0([[REG0:%.*]] : @guaranteed $K3):
+// CHECK-SIL:   debug_value [[REG0]], let, name "self", argno 1
+// CHECK-SIL:   [[REG2:%.*]] = ref_element_addr [[REG0]], #K3._id
+// CHECK-SIL:   [[REG3:%.*]] = load_borrow [[REG2]]
+// CHECK-SIL:   return_borrow [[REG3]] from_scopes ([[REG3]])
+// CHECK-SIL: }
+
+// CHECK-SIL: sil [ossa] @$s24borrow_accessor_protocol2K4C2idAA16FrozenNonTrivialVvb : $@convention(method) (@guaranteed K4) -> @guaranteed FrozenNonTrivial {
+// CHECK-SIL: bb0([[REG0:%.*]] : @guaranteed $K4):
+// CHECK-SIL:   debug_value [[REG0]], let, name "self", argno 1
+// CHECK-SIL:   [[REG2:%.*]] = ref_element_addr [[REG0]], #K4._id
+// CHECK-SIL:   [[REG3:%.*]] = load_borrow [[REG2]]
+// CHECK-SIL:   return_borrow [[REG3]] from_scopes ([[REG3]])
+// CHECK-SIL: }
+
+// CHECK-SIL: sil shared [transparent] [serialized] [thunk] [ossa] @$s24borrow_accessor_protocol2K4CAA1SA2aDP2idAA16FrozenNonTrivialVvbTW : $@convention(witness_method: S) (@in_guaranteed K4) -> @guaranteed FrozenNonTrivial {
+// CHECK-SIL: bb0([[REG0:%.*]] : $*K4):
+// CHECK-SIL:   [[REG1:%.*]] = load_borrow [[REG0]]
+// CHECK-SIL:   [[REG2:%.*]] = class_method [[REG1]], #K4.id!borrow : (K4) -> () -> FrozenNonTrivial, $@convention(method) (@guaranteed K4) -> @guaranteed FrozenNonTrivial
+// CHECK-SIL:   [[REG3:%.*]] = apply [[REG2]]([[REG1]]) : $@convention(method) (@guaranteed K4) -> @guaranteed FrozenNonTrivial
+// CHECK-SIL:   return_borrow [[REG3]] from_scopes ([[REG1]])
+// CHECK-SIL: }
+
+// CHECK-EVO: sil private [transparent] [thunk] [ossa] @$s24borrow_accessor_protocol2K1CAA1RA2aDP2idAA10NonTrivialVvbTW : $@convention(witness_method: R) (@in_guaranteed K1) -> @guaranteed_address NonTrivial {
+
+// CHECK-EVO: bb0([[REG0:%.*]] : $*K1):
+// CHECK-EVO:   [[REG1:%.*]] = load_borrow [[REG0]]
+// CHECK-EVO:   [[REG2:%.*]] = function_ref @$s24borrow_accessor_protocol2K1C2idAA10NonTrivialVvb : $@convention(method) (@guaranteed K1) -> @guaranteed_address NonTrivial
+// CHECK-EVO:   [[REG3:%.*]] = apply [[REG2]]([[REG1]]) : $@convention(method) (@guaranteed K1) -> @guaranteed_address NonTrivial
+// CHECK-EVO:   end_borrow [[REG1]]
+// CHECK-EVO:   return [[REG3]]
+// CHECK-EVO: }
+
+// CHECK-EVO: sil shared [ossa] @$s24borrow_accessor_protocol2K1C2idAA10NonTrivialVvb : $@convention(method) (@guaranteed K1) -> @guaranteed_address NonTrivial {
+// CHECK-EVO: bb0([[REG0:%.*]] : @guaranteed $K1):
+// CHECK-EVO:   debug_value [[REG0]], let, name "self", argno 1
+// CHECK-EVO:   [[REG2:%.*]] = ref_element_addr [[REG0]], #K1.id
+// CHECK-EVO:   return [[REG2]]
+// CHECK-EVO: }
+
+// CHECK-EVO: sil [ossa] @$s24borrow_accessor_protocol2K2C2idAA10NonTrivialVvb : $@convention(method) (@guaranteed K2) -> @guaranteed_address NonTrivial {
+
+// CHECK-EVO: bb0([[REG0:%.*]] : @guaranteed $K2):
+// CHECK-EVO:   debug_value [[REG0]], let, name "self", argno 1
+// CHECK-EVO:   [[REG2:%.*]] = ref_element_addr [[REG0]], #K2._id
+// CHECK-EVO:   return [[REG2]]
+// CHECK-EVO: }
+
+// CHECK-EVO: sil private [transparent] [thunk] [ossa] @$s24borrow_accessor_protocol2K2CAA1RA2aDP2idAA10NonTrivialVvbTW : $@convention(witness_method: R) (@in_guaranteed K2) -> @guaranteed_address NonTrivial {
+// CHECK-EVO: bb0([[REG0:%.*]] : $*K2):
+// CHECK-EVO:   [[REG1:%.*]] = load_borrow [[REG0]]
+// CHECK-EVO:   [[REG2:%.*]] = class_method [[REG1]], #K2.id!borrow : (K2) -> () -> NonTrivial, $@convention(method) (@guaranteed K2) -> @guaranteed_address NonTrivial
+// CHECK-EVO:   [[REG3:%.*]] = apply [[REG2]]([[REG1]]) : $@convention(method) (@guaranteed K2) -> @guaranteed_address NonTrivial
+// CHECK-EVO:   end_borrow [[REG1]]
+// CHECK-EVO:   return [[REG3]]
+// CHECK-EVO: }
+
+// CHECK-EVO: sil private [transparent] [thunk] [ossa] @$s24borrow_accessor_protocol2K3CAA1RA2aDP2idAA10NonTrivialVvbTW : $@convention(witness_method: R) (@in_guaranteed K3) -> @guaranteed_address NonTrivial {
+// CHECK-EVO: bb0([[REG0:%.*]] : $*K3):
+// CHECK-EVO:   [[REG1:%.*]] = load_borrow [[REG0]]
+// CHECK-EVO:   [[REG2:%.*]] = function_ref @$s24borrow_accessor_protocol2K3C2idAA10NonTrivialVvb : $@convention(method) (@guaranteed K3) -> @guaranteed_address NonTrivial
+// CHECK-EVO:   [[REG3:%.*]] = apply [[REG2]]([[REG1]]) : $@convention(method) (@guaranteed K3) -> @guaranteed_address NonTrivial
+// CHECK-EVO:   end_borrow [[REG1]]
+// CHECK-EVO:   return [[REG3]]
+// CHECK-EVO: }
+
+// CHECK-EVO: sil [ossa] @$s24borrow_accessor_protocol2K3C2idAA10NonTrivialVvb : $@convention(method) (@guaranteed K3) -> @guaranteed_address NonTrivial {
+// CHECK-EVO: bb0([[REG0:%.*]] : @guaranteed $K3):
+// CHECK-EVO:   debug_value [[REG0]], let, name "self", argno 1
+// CHECK-EVO:   [[REG2:%.*]] = ref_element_addr [[REG0]], #K3._id
+// CHECK-EVO:   return [[REG2]]
+// CHECK-EVO: }
+
+// CHECK-EVO: sil [ossa] @$s24borrow_accessor_protocol2K4C2idAA16FrozenNonTrivialVvb : $@convention(method) (@guaranteed K4) -> @guaranteed FrozenNonTrivial {
+// CHECK-EVO: bb0([[REG0:%.*]] : @guaranteed $K4):
+// CHECK-EVO:   debug_value [[REG0]], let, name "self", argno 1
+// CHECK-EVO:   [[REG2:%.*]] = ref_element_addr [[REG0]], #K4._id
+// CHECK-EVO:   [[REG3:%.*]] = load_borrow [[REG2]]
+// CHECK-EVO:   [[REG4:%.*]] = unchecked_ownership [[REG3]]
+// CHECK-EVO:   end_borrow [[REG3]]
+// CHECK-EVO:   return [[REG4]]
+// CHECK-EVO: }
+
+// CHECK-EVO: sil private [transparent] [thunk] [ossa] @$s24borrow_accessor_protocol2K4CAA1SA2aDP2idAA16FrozenNonTrivialVvbTW : $@convention(witness_method: S) (@in_guaranteed K4) -> @guaranteed FrozenNonTrivial {
+// CHECK-EVO: bb0([[REG0:%.*]] : $*K4):
+// CHECK-EVO:   [[REG1:%.*]] = load_borrow [[REG0]]
+// CHECK-EVO:   [[REG2:%.*]] = class_method [[REG1]], #K4.id!borrow : (K4) -> () -> FrozenNonTrivial, $@convention(method) (@guaranteed K4) -> @guaranteed FrozenNonTrivial
+// CHECK-EVO:   [[REG3:%.*]] = unchecked_ownership [[REG1]]
+// CHECK-EVO:   [[REG4:%.*]] = apply [[REG2]]([[REG3]]) : $@convention(method) (@guaranteed K4) -> @guaranteed FrozenNonTrivial
+// CHECK-EVO:   end_borrow [[REG1]]
+// CHECK-EVO:   return [[REG4]]
+// CHECK-EVO: }
+
 // CHECK: sil_witness_table [serialized] S1: P module borrow_accessor_protocol {
 // CHECK:   method #P.id!borrow: <Self where Self : P> (Self) -> () -> NonTrivial : @$s24borrow_accessor_protocol2S1VAA1PA2aDP2idAA10NonTrivialVvbTW	// protocol witness for P.id.borrow in conformance S1
 // CHECK:   method #P.id!mutate: <Self where Self : P> (inout Self) -> () -> NonTrivial : @$s24borrow_accessor_protocol2S1VAA1PA2aDP2idAA10NonTrivialVvzTW	// protocol witness for P.id.mutate in conformance S1
@@ -222,6 +486,22 @@ public struct S6 : Q {
 // CHECK:   method #P.id!mutate: <Self where Self : P> (inout Self) -> () -> NonTrivial : @$s24borrow_accessor_protocol2S5VAA1PA2aDP2idAA10NonTrivialVvzTW	// protocol witness for P.id.mutate in conformance S5
 // CHECK: }
 
+// CHECK: sil_witness_table [serialized] K1: R module borrow_accessor_protocol {
+// CHECK:   method #R.id!borrow: <Self where Self : R> (Self) -> () -> NonTrivial : @$s24borrow_accessor_protocol2K1CAA1RA2aDP2idAA10NonTrivialVvbTW
+// CHECK: }
+
+// CHECK: sil_witness_table [serialized] K2: R module borrow_accessor_protocol {
+// CHECK:   method #R.id!borrow: <Self where Self : R> (Self) -> () -> NonTrivial : @$s24borrow_accessor_protocol2K2CAA1RA2aDP2idAA10NonTrivialVvbTW
+// CHECK: }
+
+// CHECK: sil_witness_table [serialized] K3: R module borrow_accessor_protocol {
+// CHECK:   method #R.id!borrow: <Self where Self : R> (Self) -> () -> NonTrivial : @$s24borrow_accessor_protocol2K3CAA1RA2aDP2idAA10NonTrivialVvbTW
+// CHECK: }
+
+// CHECK: sil_witness_table [serialized] K4: S module borrow_accessor_protocol {
+// CHECK:   method #S.id!borrow: <Self where Self : S> (Self) -> () -> FrozenNonTrivial : @$s24borrow_accessor_protocol2K4CAA1SA2aDP2idAA16FrozenNonTrivialVvbTW
+// CHECK: }
+
 // CHECK-EVO: sil_witness_table S1: P module borrow_accessor_protocol {
 // CHECK-EVO:   method #P.id!borrow: <Self where Self : P> (Self) -> () -> NonTrivial : @$s24borrow_accessor_protocol2S1VAA1PA2aDP2idAA10NonTrivialVvbTW	// protocol witness for P.id.borrow in conformance S1
 // CHECK-EVO:   method #P.id!mutate: <Self where Self : P> (inout Self) -> () -> NonTrivial : @$s24borrow_accessor_protocol2S1VAA1PA2aDP2idAA10NonTrivialVvzTW	// protocol witness for P.id.mutate in conformance S1
@@ -245,5 +525,21 @@ public struct S6 : Q {
 // CHECK-EVO: sil_witness_table [serialized] S5: P module borrow_accessor_protocol {
 // CHECK-EVO:   method #P.id!borrow: <Self where Self : P> (Self) -> () -> NonTrivial : @$s24borrow_accessor_protocol2S5VAA1PA2aDP2idAA10NonTrivialVvbTW	// protocol witness for P.id.borrow in conformance S5
 // CHECK-EVO:   method #P.id!mutate: <Self where Self : P> (inout Self) -> () -> NonTrivial : @$s24borrow_accessor_protocol2S5VAA1PA2aDP2idAA10NonTrivialVvzTW	// protocol witness for P.id.mutate in conformance S5
+// CHECK-EVO: }
+
+// CHECK-EVO: sil_witness_table K1: R module borrow_accessor_protocol {
+// CHECK-EVO:   method #R.id!borrow: <Self where Self : R> (Self) -> () -> NonTrivial : @$s24borrow_accessor_protocol2K1CAA1RA2aDP2idAA10NonTrivialVvbTW
+// CHECK-EVO: }
+
+// CHECK-EVO: sil_witness_table K2: R module borrow_accessor_protocol {
+// CHECK-EVO:   method #R.id!borrow: <Self where Self : R> (Self) -> () -> NonTrivial : @$s24borrow_accessor_protocol2K2CAA1RA2aDP2idAA10NonTrivialVvbTW
+// CHECK-EVO: }
+
+// CHECK-EVO: sil_witness_table K3: R module borrow_accessor_protocol {
+// CHECK-EVO:   method #R.id!borrow: <Self where Self : R> (Self) -> () -> NonTrivial : @$s24borrow_accessor_protocol2K3CAA1RA2aDP2idAA10NonTrivialVvbTW
+// CHECK-EVO: }
+
+// CHECK-EVO: sil_witness_table K4: S module borrow_accessor_protocol {
+// CHECK-EVO:   method #S.id!borrow: <Self where Self : S> (Self) -> () -> FrozenNonTrivial : @$s24borrow_accessor_protocol2K4CAA1SA2aDP2idAA16FrozenNonTrivialVvbTW
 // CHECK-EVO: }
 

--- a/test/Sema/borrow_and_mutate_accessors.swift
+++ b/test/Sema/borrow_and_mutate_accessors.swift
@@ -41,10 +41,10 @@ struct Struct {
 
 extension Klass {
   var i: Int {
-    borrow { // expected-error{{a 'borrow' accessor is supported only on a struct}}
+    borrow { // expected-error{{a 'borrow' accessor is unsupported here}}
       return 0
     }
-    mutate { // expected-error{{a 'mutate' accessor is supported only on a struct}}
+    mutate { // expected-error{{a 'mutate' accessor is unsupported here}}
       return &_i
     }
   }
@@ -61,26 +61,24 @@ extension Struct {
   }
 }
 
+let global_klass = Klass()
+
+enum E {
+
+}
+
+extension E {
+  var global_k: Klass {
+    borrow {
+      return global_klass
+    }
+  }
+}
+
 protocol P {
   var name: String { borrow }
   var phone: String { borrow mutate }
   var address: String { mutate } // expected-error{{variable with a 'mutate' accessor must also have a 'borrow' accessor}}
-}
-
-enum OrderStatus: ~Copyable {
-  case processing(trackingNumber: String)
-  case cancelled(reason: String)
-  
-  var description: String {
-    borrow { // expected-error{{a 'borrow' accessor is supported only on a struct}}
-      switch self {
-        case .processing(let trackingNumber):
-          return trackingNumber
-        case .cancelled(let reason):
-          return reason
-      }
-    }
-  }
 }
 
 public protocol Q {

--- a/test/Sema/borrow_and_mutate_accessors.swift
+++ b/test/Sema/borrow_and_mutate_accessors.swift
@@ -39,17 +39,6 @@ struct Struct {
   }
 }
 
-extension Klass {
-  var i: Int {
-    borrow { // expected-error{{a 'borrow' accessor is unsupported here}}
-      return 0
-    }
-    mutate { // expected-error{{a 'mutate' accessor is unsupported here}}
-      return &_i
-    }
-  }
-}
-
 extension Struct {
   var i: Int {
     borrow {
@@ -82,7 +71,7 @@ protocol P {
 }
 
 public protocol Q {
-  var id: NonTrivial { borrow mutate } // expected-note{{protocol requires property 'id' with type 'NonTrivial'}} // expected-note{{}} // expected-note{{}} // expected-note{{}} // expected-note{{}}
+  var id: NonTrivial { borrow mutate } // expected-note{{protocol requires property 'id' with type 'NonTrivial'}} // expected-note{{}} // expected-note{{}} // expected-note{{}}
 
 }
 
@@ -216,9 +205,5 @@ struct S10 {
       return _i
     }
   }
-}
-
-final class C : Q { // expected-error {{type 'C' does not conform to protocol 'Q'}} // expected-note{{add stubs for conformance}}
-  var id: NonTrivial = NonTrivial(k: Klass()) // expected-error{{borrow/mutate protocol requirements can only be witnessed in a struct}}
 }
 


### PR DESCRIPTION
Until now, borrow accessors were completely disabled in enums and classes. This PR removes this blanket restriction and enables writing borrow accessors that return global let declarations, let properties and unsafe pointers in enums and classes.

 