### PR TITLE
[Sema] Attach actor attributes to synthesized lazy storage

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6309,16 +6309,6 @@ static InferredActorIsolation computeActorIsolation(Evaluator &evaluator,
       };
   }
 
-  // If this declaration is lazy storage, it has the same isolation as the
-  // original variable. Use the evaluator to cache and avoid running
-  // addAttributesForActorIsolation on the original variable a second time,
-  // duplicating attributes.
-  if (auto var = dyn_cast<VarDecl>(value))
-    if (var->isLazyStorageProperty())
-      if (auto originalVar = var->getOriginalVarForBackingStorage())
-        return evaluateOrDefault(evaluator, ActorIsolationRequest{originalVar},
-                                 InferredActorIsolation::forUnspecified());
-
   auto isolationFromAttr = getIsolationFromAttributes(value);
   ASTContext &ctx = value->getASTContext();
 
@@ -6470,6 +6460,17 @@ static InferredActorIsolation computeActorIsolation(Evaluator &evaluator,
   // non-accessor functions.
   if (auto accessor = dyn_cast<AccessorDecl>(value)) {
     return getInferredActorIsolation(accessor->getStorage());
+  }
+
+  // If this is a lazy storage property, use the actor isolation of its original
+  // variable, but ensure the actor attributes get attached to the storage.
+  if (auto var = dyn_cast<VarDecl>(value)) {
+    if (var->isLazyStorageProperty()) {
+      if (auto originalVar = var->getOriginalVarForBackingStorage()) {
+        auto inferred = getInferredActorIsolation(originalVar);
+        return {inferredIsolation(inferred.isolation), inferred.source};
+      }
+    }
   }
 
   // If this is a local function, inherit the actor isolation from its

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -1491,6 +1491,11 @@ final class Exponentiator: Sendable {
   }()
 }
 
+final class NumberHolder: Sendable {
+  // expected-warning@+1 {{stored property 'numbers' of 'Sendable'-conforming class 'NumberHolder' is mutable; this is an error in the Swift 6 language mode}}
+  lazy var numbers = [1, 2, 3]
+}
+
 actor DunkTracker {
   private var lebron: Int?
   private var curry: Int? // expected-note {{property declared here}}

--- a/test/Concurrency/lazy-vars-actor.swift
+++ b/test/Concurrency/lazy-vars-actor.swift
@@ -1,0 +1,76 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -language-mode 6 -typecheck -module-name Test -emit-module-interface-path %t/Test.swiftinterface %s
+// RUN: %FileCheck %s < %t/Test.swiftinterface --check-prefix CHECK --check-prefix NONRESILIENT
+// RUN: %target-swift-frontend -language-mode 6 -compile-module-from-interface %t/Test.swiftinterface -o %t/Test.swiftmodule
+// RUN: %target-swift-frontend -language-mode 6 -emit-module -o /dev/null -merge-modules -emit-module-interface-path - %t/Test.swiftmodule -module-name Test | %FileCheck %s --check-prefix CHECK --check-prefix NONRESILIENT
+
+// RUN: %target-swift-frontend -language-mode 6 -typecheck -module-name TestResilient -emit-module-interface-path %t/TestResilient.swiftinterface -enable-library-evolution %s
+// RUN: %FileCheck %s < %t/TestResilient.swiftinterface
+
+// RUN: %target-swift-frontend -language-mode 6 -compile-module-from-interface %t/TestResilient.swiftinterface -o %t/TestResilient.swiftmodule
+// RUN: %target-swift-frontend -language-mode 6 -emit-module -o /dev/null -merge-modules -emit-module-interface-path - %t/TestResilient.swiftmodule -module-name TestResilient | %FileCheck %s
+
+// REQUIRE: concurrency
+
+// CHECK: public struct HasMainActorLazyVars {
+// CHECK-NEXT: @_Concurrency::MainActor public var foo: Swift::Int {
+// CHECK-NEXT:   mutating get
+// CHECK-NEXT:   set
+// CHECK-NEXT: }
+// NONRESILIENT: @_Concurrency::MainActor @_hasInitialValue private var $__lazy_storage_$_foo: Swift::Int?
+// CHECK-NOT: private var bar
+// NONRESILIENT: @_Concurrency::MainActor @_hasInitialValue private var $__lazy_storage_$_bar: Swift::Int?
+// CHECK-NEXT: }
+public struct HasMainActorLazyVars {
+  @MainActor public lazy var foo: Int = 0
+  @MainActor private lazy var bar: Int = 0
+}
+
+
+// CHECK: public struct PreconcurrencyHasMainActorLazyVars {
+// CHECK-NEXT: {{(@preconcurrency @_Concurrency::MainActor|@_Concurrency::MainActor @preconcurrency)}} public var foo: Swift::Int {
+// CHECK-NEXT:   mutating get
+// CHECK-NEXT:   set
+// CHECK-NEXT: }
+// NONRESILIENT: @_Concurrency::MainActor @preconcurrency @_hasInitialValue private var $__lazy_storage_$_foo: Swift::Int?
+// CHECK-NOT: private var bar
+// NONRESILIENT: @_Concurrency::MainActor @preconcurrency @_hasInitialValue private var $__lazy_storage_$_bar: Swift::Int?
+// CHECK-NEXT: }
+public struct PreconcurrencyHasMainActorLazyVars {
+  @preconcurrency @MainActor public lazy var foo: Int = 0
+  @preconcurrency @MainActor private lazy var bar: Int = 0
+}
+
+
+// CHECK: @_Concurrency::MainActor public struct MainActorHasLazyVars {
+// CHECK-NEXT: @_Concurrency::MainActor public var foo: Swift::Int {
+// CHECK-NEXT:   mutating get
+// CHECK-NEXT:   set
+// CHECK-NEXT: }
+// NONRESILIENT: @_Concurrency::MainActor @_hasInitialValue private var $__lazy_storage_$_foo: Swift::Int?
+// CHECK-NOT: private var bar
+// NONRESILIENT: @_Concurrency::MainActor @_hasInitialValue private var $__lazy_storage_$_bar: Swift::Int?
+// CHECK-NEXT: }
+@MainActor
+public struct MainActorHasLazyVars {
+  public lazy var foo: Int = 0
+  private lazy var bar: Int = 0
+}
+
+
+// CHECK: {{(@preconcurrency @_Concurrency::MainActor|@_Concurrency::MainActor @preconcurrency)}} public struct PreconcurrencyMainActorHasLazyVars {
+// CHECK-NEXT: {{(@preconcurrency @_Concurrency::MainActor|@_Concurrency::MainActor @preconcurrency)}} public var foo: Swift::Int {
+// CHECK-NEXT:   mutating get
+// CHECK-NEXT:   set
+// CHECK-NEXT: }
+// NONRESILIENT: @_Concurrency::MainActor @preconcurrency @_hasInitialValue private var $__lazy_storage_$_foo: Swift::Int?
+// CHECK-NOT: private var bar
+// NONRESILIENT: @_Concurrency::MainActor @preconcurrency @_hasInitialValue private var $__lazy_storage_$_bar: Swift::Int?
+// CHECK-NEXT: }
+@preconcurrency @MainActor
+public struct PreconcurrencyMainActorHasLazyVars {
+  public lazy var foo: Int = 0
+  private lazy var bar: Int = 0
+}
+


### PR DESCRIPTION
Finishes fixing rdar://156415458, by handling lazy storage lower in computeActorIsolation so that the attribute can be attached to the lazy storage. Adds tests to ensure the isolation is printed on public and private lazy storage. Also adds one more case to actor_isolation tests.

#87584 returned too early and didn't add the attribute to the lazy storage.