### PR TITLE
Basic, Sema: adjust for LLDB (NFC)

### DIFF
--- a/include/swift/Basic/Located.h
+++ b/include/swift/Basic/Located.h
@@ -59,20 +59,21 @@ template <typename T, typename Enable> struct DenseMapInfo;
 
 template<typename T>
 struct DenseMapInfo<swift::Located<T>> {
+  using SourceLoc = swift::SourceLoc;
 
   static inline swift::Located<T> getEmptyKey() {
     return swift::Located<T>(DenseMapInfo<T>::getEmptyKey(),
-                             DenseMapInfo<swift::SourceLoc>::getEmptyKey());
+                             DenseMapInfo<SourceLoc>::getEmptyKey());
   }
 
   static inline swift::Located<T> getTombstoneKey() {
     return swift::Located<T>(DenseMapInfo<T>::getTombstoneKey(),
-                             DenseMapInfo<swift::SourceLoc>::getTombstoneKey());
+                             DenseMapInfo<SourceLoc>::getTombstoneKey());
   }
 
   static unsigned getHashValue(const swift::Located<T> &LocatedVal) {
     return detail::combineHashValue(DenseMapInfo<T>::getHashValue(LocatedVal.Item),
-                            DenseMapInfo<swift::SourceLoc>::getHashValue(LocatedVal.Loc));
+                            DenseMapInfo<SourceLoc>::getHashValue(LocatedVal.Loc));
   }
 
   static bool isEqual(const swift::Located<T> &LHS, const swift::Located<T> &RHS) {

--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -154,19 +154,19 @@ public:
     /// subclass, returning \c None if unsuccessful.
     template <class T>
     std::optional<T> getAs() const {
-      if (auto *result = dyn_cast<T>(this))
+      if (auto *result = llvm::dyn_cast<T>(this))
         return *result;
       return std::nullopt;
     }
 
     /// Cast the path element to a specific \c LocatorPathElt subclass.
     template <class T>
-    T castTo() const { return *cast<T>(this); }
+    T castTo() const { return *llvm::cast<T>(this); }
 
     /// Checks whether the path element is a specific \c LocatorPathElt
     /// subclass.
     template <class T>
-    bool is() const { return isa<T>(this); }
+    bool is() const { return llvm::isa<T>(this); }
 
     /// Return the summary flags for this particular element.
     unsigned getNewSummaryFlags() const;


### PR DESCRIPTION
LLDB defines `lldb::private::swift::` which causes ambiguity for lookups. Use aliases and fully qualified names to avoid the ambiguity. This fixes some errors with building on Windows with the GNU driver.