### PR TITLE
docs: Add build-script instructions to build SwiftPM in GettingStarted.md

### DIFF
--- a/docs/HowToGuides/GettingStarted.md
+++ b/docs/HowToGuides/GettingStarted.md
@@ -166,9 +166,9 @@ versions for you that are verified to work, so installing different versions of 
    * [CentOS 7](https://github.com/swiftlang/swift-docker/blob/main/swift-ci/main/centos/7/Dockerfile)
    * [Amazon Linux 2](https://github.com/swiftlang/swift-docker/blob/main/swift-ci/main/amazon-linux/2/Dockerfile)
 
-   Note that [a prebuilt Swift release toolchain](https://www.swift.org/download/)
+   Note that [a prebuilt Swift release toolchain](https://www.swift.org/install/)
    is installed and added to the `PATH` in all these Docker containers: it is
-   recommended that you do the same, in order to build the portions of the Swift
+   required that you do the same, in order to build the portions of the Swift
    compiler written in Swift.
 
 2. To install [Sccache][] (optional):
@@ -261,8 +261,7 @@ Build the toolchain with optimizations, debuginfo, and assertions, using Ninja:
   ```sh
   utils/build-script --skip-build-benchmarks \
     --swift-darwin-supported-archs "$(uname -m)" \
-    --release-debuginfo --swift-disable-dead-stripping \
-    --bootstrapping=hosttools
+    --release-debuginfo --swift-disable-dead-stripping
   ```
 - Linux:
   ```sh
@@ -284,6 +283,27 @@ If the build fails, see [Troubleshooting build issues](#troubleshooting-build-is
 In the following sections, for simplicity, we will assume that you are using a
 `Ninja-RelWithDebInfoAssert` build on macOS, unless explicitly mentioned otherwise.
 You will need to slightly tweak the paths for other build configurations.
+
+While the compiler alone is useful for some initial exploration and testing, you
+will want the Testing library and Swift package manager to build most Swift
+packages. To build those, you must add the following `build-script` flags on macOS:
+```sh
+--install-llvm --install-swift --swift-testing-macros --swift-testing \
+--install-swift-testing-macros --install-swift-testing -b -p --install-swiftpm \
+--swift-driver --install-swift-driver
+```
+On Linux, you will also need to add these flags to that list to build and
+install the core libraries:
+```sh
+--xctest --install-libdispatch --install-foundation --install-xctest
+```
+This will produce a working toolchain in the above build directory, which
+you can then use to build and test Swift packages:
+```sh
+cd swift-crypto/
+../build/Ninja-RelWithDebInfoAssert/toolchain-macosx-arm64/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift build
+../build/Ninja-RelWithDebInfoAssert/toolchain-macosx-arm64/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift test
+```
 
 ### Troubleshooting build issues
 


### PR DESCRIPTION
Also update to latest download URL, require a prebuilt compiler, and remove a now unneeded bootstrapping flag.

These are flags I regularly use to build and test a trunk toolchain on macOS, linux, and natively on Android, as can be seen in [step 4 of this forum post](https://forums.swift.org/t/building-a-linux-aarch64-toolchain-on-macos-with-containerization/84347), though I left off the internal testing flags here.

Most new devs are going to want to build a minimal toolchain with SwiftPM that can build packages, always struck me as a deficiency that we only showed them how to build the compiler itself early on.