### PR TITLE
RuntimeModule: add fuzzer for ELF support

### DIFF
--- a/Runtimes/Supplemental/Runtime/CMakeLists.txt
+++ b/Runtimes/Supplemental/Runtime/CMakeLists.txt
@@ -74,6 +74,8 @@ option(${PROJECT_NAME}_ENABLE_LIBRARY_EVOLUTION "Generate ABI resilient runtime 
 option(${PROJECT_NAME}_ENABLE_PRESPECIALIZATION "Enable generic metadata prespecialization"
   ${SwiftCore_ENABLE_PRESPECIALIZATION})
 
+option(${PROJECT_NAME}_ENABLE_SANITIZE_COVERAGE "Enable sanitizer coverage for fuzzing" OFF)
+
 add_compile_options(
   $<$<COMPILE_LANGUAGE:Swift>:-explicit-module-build>
   $<$<COMPILE_LANGUAGE:Swift>:-nostdlibimport>
@@ -210,6 +212,12 @@ set_target_properties(swiftRuntime PROPERTIES
   Swift_MODULE_NAME Runtime)
 target_compile_definitions(swiftRuntime PRIVATE
   SWIFT_ASM_AVAILABLE)
+
+if(${PROJECT_NAME}_ENABLE_SANITIZE_COVERAGE)
+  target_compile_options(swiftRuntime PRIVATE
+    "$<$<COMPILE_LANGUAGE:Swift>:-sanitize=fuzzer>"
+    "$<$<COMPILE_LANGUAGE:Swift>:-DLLVM_USE_SANITIZE_COVERAGE>")
+endif()
 target_compile_options(swiftRuntime PUBLIC
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fmodule-map-file=${CMAKE_CURRENT_SOURCE_DIR}/modules/module.modulemap>")
 # FIXME: We should split out the parts that are needed by the runtime to avoid

--- a/stdlib/public/RuntimeModule/CMakeLists.txt
+++ b/stdlib/public/RuntimeModule/CMakeLists.txt
@@ -106,6 +106,12 @@ set(runtime_compile_flags
   "-disable-upcoming-feature;MemberImportVisibility"
   "-enable-experimental-feature;Reparenting")
 
+if(LLVM_USE_SANITIZE_COVERAGE)
+  list(APPEND runtime_compile_flags
+    "-sanitize=fuzzer"
+    "-DLLVM_USE_SANITIZE_COVERAGE")
+endif()
+
 ###TODO: Add these when we add static linking support
 #
 #list(APPEND runtime_compile_flags

--- a/stdlib/public/RuntimeModule/Elf.swift
+++ b/stdlib/public/RuntimeModule/Elf.swift
@@ -1993,3 +1993,84 @@ public func testElfImageAt(path: String) -> Bool {
     return false
   }
 }
+
+// .. Fuzzing ...................................................................
+
+#if LLVM_USE_SANITIZE_COVERAGE
+
+@available(Backtracing 6.2, *)
+@c
+public func swift_fuzz_elf_image(_ data: UnsafeRawPointer, _ size: Int) -> CInt {
+  let buffer = UnsafeRawBufferPointer(start: data, count: size)
+  let source = ImageSource(unowned: buffer, isMappedImage: false)
+
+  if let image = try? Elf32Image(source: source) {
+    _exerciseElfImage(image)
+  }
+  if let image = try? Elf64Image(source: source) {
+    _exerciseElfImage(image)
+  }
+
+  return 0
+}
+
+@available(Backtracing 6.2, *)
+private func _exerciseElfImage<Traits: ElfTraits>(_ image: ElfImage<Traits>) {
+  _ = image.uuid
+  _ = image.debugLinkCRC
+  _ = image.ehFrameInfo
+  _ = image.imageName
+  _ = image.getSection(".text")
+  _ = image.getSection(".symtab")
+  _ = image.getSection(".strtab")
+  _ = image.getSection(".debug_info")
+  _ = image.getSection(".debug_line")
+  _ = image.getDebugLink()
+  _ = image.getDebugAltLink()
+  _ = image.getSectionAsString(".comment")
+  for _ in image.notes {}
+
+  // Symbol table: construction and merge
+  do {
+    if let symtab = ElfSymbolTable(image: image) {
+      if let symtab2 = ElfSymbolTable(image: image) {
+        _ = symtab.merged(with: symtab2)
+      }
+    }
+  }
+
+  // Collect addresses from the fuzzed image's own headers to exercise lookup
+  // paths with values that actually fall within the image's address ranges.
+  var addresses: [SymbolSource.Address] = [0]
+  for phdr in image.programHeaders where phdr.p_type == .PT_LOAD {
+    let vaddr = SymbolSource.Address(phdr.p_vaddr)
+    addresses.append(vaddr)
+    addresses.append(vaddr &+ SymbolSource.Address(phdr.p_memsz) / 2)
+  }
+  if let sections = image.sectionHeaders {
+    for shdr in sections where shdr.sh_addr != 0 {
+      addresses.append(SymbolSource.Address(shdr.sh_addr))
+    }
+  }
+
+  let symtab = ElfSymbolTable(image: image)
+  for addr in addresses {
+    _ = symtab?.lookupSymbol(address: Traits.Address(truncatingIfNeeded: addr))
+    _ = image.lookupSymbol(address: addr)
+    _ = image.sourceLocation(for: addr)
+    _ = image.inlineCallSites(at: addr)
+  }
+
+  // DWARF section access
+  _ = image.getDwarfSection(.debugInfo)
+  _ = image.getDwarfSection(.debugLine)
+  _ = image.getDwarfSection(.debugAbbrev)
+  _ = image.getDwarfSection(.debugStr)
+  _ = image.getDwarfSection(.debugRanges)
+  _ = image.getDwarfSection(.debugRngLists)
+  _ = image.getDwarfSection(.debugAddr)
+  _ = image.getDwarfSection(.debugStrOffsets)
+  _ = image.getDwarfSection(.debugLineStr)
+}
+
+#endif // LLVM_USE_SANITIZE_COVERAGE

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -38,6 +38,7 @@ endif()
 if(LLVM_USE_SANITIZE_COVERAGE)
 add_swift_tool_subdirectory(swift-demangle-fuzzer)
 add_swift_tool_subdirectory(swift-reflection-fuzzer)
+add_swift_tool_subdirectory(swift-elf-fuzzer)
 endif()
 
 if(SWIFT_BUILD_SOURCEKIT)

--- a/tools/swift-elf-fuzzer/CMakeLists.txt
+++ b/tools/swift-elf-fuzzer/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_swift_fuzzer_host_tool(swift-elf-fuzzer
+  swift-elf-fuzzer.c
+  SWIFT_COMPONENT compiler
+  )
+
+set(sdk "${SWIFT_HOST_VARIANT_SDK}")
+set(arch "${SWIFT_HOST_VARIANT_ARCH}")
+set(variant_suffix "-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}")
+
+target_link_libraries(swift-elf-fuzzer
+                      PRIVATE
+                        "swiftRuntime${variant_suffix}")
+add_dependencies(swift-elf-fuzzer "swiftRuntime${variant_suffix}")

--- a/tools/swift-elf-fuzzer/swift-elf-fuzzer.c
+++ b/tools/swift-elf-fuzzer/swift-elf-fuzzer.c
@@ -1,0 +1,30 @@
+//===--- swift-elf-fuzzer.c - ELF image parser fuzzer ---------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This program fuzzes the ELF image parser in the Swift RuntimeModule.
+// For this to work you need to pass --enable-sanitizer-coverage to build-script
+// otherwise the fuzzer doesn't have coverage information to make progress
+// (making the whole fuzzing operation really ineffective).
+// It is recommended to use the tool together with another sanitizer to expose
+// more bugs (asan, lsan, etc...)
+//
+//===----------------------------------------------------------------------===//
+
+#include <stddef.h>
+#include <stdint.h>
+
+extern int32_t swift_fuzz_elf_image(const void *data, long size);
+
+int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
+  swift_fuzz_elf_image(Data, (long)Size);
+  return 0;
+}

--- a/utils/swift_build_support/swift_build_support/products/llvm.py
+++ b/utils/swift_build_support/swift_build_support/products/llvm.py
@@ -352,7 +352,7 @@ class LLVM(cmake_product.CMakeProduct):
                 f'RUNTIMES_{builtins_runtimes_target_for_darwin}_'
                 'COMPILER_RT_SANITIZERS_TO_BUILD',
                 'asan;dfsan;msan;hwasan;tsan;safestack;cfi;scudo_standalone;'
-                'ubsan_minimal;gwp_asan;nsan;asan_abi')
+                'ubsan_minimal;gwp_asan;nsan;asan_abi;fuzzer')
 
         if self.args.build_embedded_stdlib and system() == "Darwin":
             # Ask for Mach-O cross-compilation builtins (for Embedded Swift)


### PR DESCRIPTION
Add barebones fuzzer for RuntimeModule's ELF parsing support. (Same as for the vendored copy of this code in https://github.com/apple/swift-profile-recorder/blob/main/FuzzTesting/Sources/FuzzELF/main.swift)

Example invocation:

```
DYLD_LIBRARY_PATH=../build/Ninja-RelWithDebInfoAssert+asan/swift-macosx-arm64/lib/swift/macosx/arm64/ ../build/Ninja-RelWithDebInfoAssert+asan/swift-macosx-arm64/bin/swift-elf-fuzzer
```

after build using

```
utils/build-script --release-debuginfo --enable-asan --enable-sanitize-coverage
ninja -C ../build/Ninja-RelWithDebInfoAssert+asan/swift-macosx-arm64/ swift-elf-fuzzer swiftRuntime-macosx-arm64
```

---

AI acknowledgement: Created with the help of Claude Code -- Opus 4.6.