### PR TITLE
[cxx-interop] Refactor __operatorStar() lookup

### DIFF
--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -255,23 +255,6 @@ static FuncDecl *getPlusEqualOperator(NominalTypeDecl *decl, Type distanceTy) {
   return dyn_cast_or_null<FuncDecl>(result);
 }
 
-static FuncDecl *getNonMutatingDereferenceOperator(NominalTypeDecl *decl) {
-  auto isValid = [](ValueDecl *starOperator) -> bool {
-    auto starOp = dyn_cast<FuncDecl>(starOperator);
-    if (!starOp || starOp->isMutating())
-      return false;
-    auto params = starOp->getParameters();
-    if (params->size() != 0)
-      return false;
-    auto returnTy = starOp->getResultInterfaceType();
-    return static_cast<bool>(returnTy->getAnyPointerElementType());
-  };
-
-  ValueDecl *result = lookupOperator(
-      decl, decl->getASTContext().getIdentifier("__operatorStar"), isValid);
-  return dyn_cast_or_null<FuncDecl>(result);
-}
-
 static clang::FunctionDecl *
 instantiateTemplatedOperator(ClangImporter::Implementation &impl,
                              const clang::CXXRecordDecl *classDecl,
@@ -684,11 +667,9 @@ conformToCxxIteratorIfNeeded(ClangImporter::Implementation &impl,
 
   // Look for __operatorStar(), which must be non-mutating and return a
   // reference. This makes sure we use the const operator* overload.
-  auto operatorStar = getNonMutatingDereferenceOperator(decl);
+  auto *operatorStar = impl.lookupAndImportOperatorStar(decl);
   Type dereferenceResultTy = pointeeTy;
-  if (operatorStar) {
-    assert(!operatorStar->isMutating() &&
-           "this __operatorStar can't be mutating");
+  if (operatorStar && !operatorStar->isMutating()) {
     auto operatorStarReturnTy = operatorStar->getResultInterfaceType();
     assert(operatorStarReturnTy &&
            "__operatorStar doesn't have a return type?");
@@ -898,7 +879,7 @@ static void conformToCxxOptional(ClangImporter::Implementation &impl,
   decl->addMember(importedConstructor);
 }
 
-static void conformToCxxBorrowingSequenceIfNedded(
+static void conformToCxxBorrowingSequenceIfNeeded(
     ClangImporter::Implementation &impl, NominalTypeDecl *decl,
     const clang::CXXRecordDecl *clangDecl,
     const ProtocolConformance *rawIteratorConformance) {
@@ -1001,7 +982,7 @@ conformToCxxSequenceIfNeeded(ClangImporter::Implementation &impl,
   impl.addSynthesizedTypealias(decl, ctx.getIdentifier("RawIterator"),
                                rawIteratorTy);
 
-  conformToCxxBorrowingSequenceIfNedded(impl, decl, clangDecl,
+  conformToCxxBorrowingSequenceIfNeeded(impl, decl, clangDecl,
                                         rawIteratorConformance);
 
   // `CxxSequence` and `CxxRandomAccessCollection` protocols require `Element`

--- a/lib/ClangImporter/ClangLookup.cpp
+++ b/lib/ClangImporter/ClangLookup.cpp
@@ -519,9 +519,10 @@ ClangImporter::Implementation::lookupAndImportPointee(NominalTypeDecl *Struct) {
   if (!CXXRecord)
     return nullptr;
 
-  if (auto [it, inserted] = importedPointeeCache.try_emplace(Struct, nullptr);
+  if (auto [it, inserted] = importedPointeeCache.try_emplace(
+          Struct, std::make_tuple(nullptr, nullptr, nullptr));
       !inserted)
-    return it->second;
+    return std::get<0>(it->second);
 
   // From this point onward, if we encounter some error and return, future calls
   // to this function will pick up the nullptr we cached using try_emplace. Note
@@ -604,8 +605,27 @@ ClangImporter::Implementation::lookupAndImportPointee(NominalTypeDecl *Struct) {
   importAttributes(CXXGetter ? CXXGetter : CXXSetter, pointee);
 
   Struct->addMember(pointee);
-  importedPointeeCache[Struct] = pointee;
+  importedPointeeCache[Struct] =
+      std::make_tuple(pointee, getter ? getter : setter, setter);
   return pointee;
+}
+
+FuncDecl *ClangImporter::Implementation::lookupAndImportOperatorStar(
+    NominalTypeDecl *Struct) {
+  auto it = importedPointeeCache.find(Struct);
+  if (it != importedPointeeCache.end())
+    return std::get<1>(it->second);
+
+  // __operatorStar() is synthesized when importing the .pointee computed
+  // property.
+  if (!lookupAndImportPointee(Struct)) {
+    importedPointeeCache.try_emplace(
+        Struct, std::make_tuple(nullptr, nullptr, nullptr));
+    return nullptr;
+  }
+
+  it = importedPointeeCache.find(Struct);
+  return it != importedPointeeCache.end() ? std::get<1>(it->second) : nullptr;
 }
 
 FuncDecl *ClangImporter::Implementation::lookupAndImportSuccessor(

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -708,26 +708,41 @@ private:
       unavailableMethods;
 
 public:
-  // Attempt to lookup and import the synthesized .pointee computed property.
+  /// Attempt to lookup and import the synthesized, non-mutating,
+  /// .__operatorStar() method.
   //
-  // Requires that \a Record is a (Swift) StructDecl and is import from
-  // a CXXRecordDecl.
+  /// Requires that \a Record is a (Swift) StructDecl and is imported from
+  /// a CXXRecordDecl.
   //
-  // This function is idempotent, and if successful, ensures the synthesized
-  // .pointee that it returns is a mamber of \a Record.
+  /// This function is idempotent, and if successful, ensures the synthesized
+  /// .__operatorStar() that it returns is a member of \a Record.
+  FuncDecl *lookupAndImportOperatorStar(NominalTypeDecl *Record);
+  /// Attempt to lookup and import the synthesized .pointee computed property.
+  /// It also synthesizes __operatorStar(), which is used as the getter and
+  /// setter for .pointee.
+  //
+  /// Requires that \a Record is a (Swift) StructDecl and is imported from
+  /// a CXXRecordDecl.
+  //
+  /// This function is idempotent, and if successful, ensures the synthesized
+  /// .pointee and __operatorStar() methods that it returns are members of \a
+  /// Record.
   VarDecl *lookupAndImportPointee(NominalTypeDecl *Record);
 
-  // Attempt to lookup and import the synthesized .successor() method.
+  /// Attempt to lookup and import the synthesized .successor() method.
   //
-  // Requires that \a Record is a (Swift) StructDecl and is import from
-  // a CXXRecordDecl.
+  /// Requires that \a Record is a (Swift) StructDecl and is imported from
+  /// a CXXRecordDecl.
   //
-  // This function is idempotent, and if successful, ensures the synthesized
-  // .successor() that it returns is a mamber of \a Record.
+  /// This function is idempotent, and if successful, ensures the synthesized
+  /// .successor() that it returns is a member of \a Record.
   FuncDecl *lookupAndImportSuccessor(NominalTypeDecl *Record);
 
 private:
-  llvm::DenseMap<NominalTypeDecl *, VarDecl *> importedPointeeCache;
+  /// Stores <.pointee, func __operatorStar(), mutating func __operatorStar()>
+  llvm::DenseMap<NominalTypeDecl *,
+                 std::tuple<VarDecl *, FuncDecl *, FuncDecl *>>
+      importedPointeeCache;
   llvm::DenseMap<NominalTypeDecl *, FuncDecl *> importedSuccessorCache;
 
 public:

--- a/stdlib/public/Cxx/CxxBorrowingSequence.swift
+++ b/stdlib/public/Cxx/CxxBorrowingSequence.swift
@@ -35,8 +35,7 @@ public protocol CxxBorrowingSequence<Element> : BorrowingSequence, ~Copyable, ~E
 
 @frozen
 @available(SwiftStdlib 6.4, *)
-public struct CxxBorrowingIterator<T>: BorrowingIteratorProtocol, ~Escapable, ~Copyable where T: CxxBorrowingSequence & ~Copyable & ~Escapable, T.Element: ~Copyable {
-  public typealias Element = T.RawIterator.Pointee
+public struct CxxBorrowingIterator<T>: BorrowingIteratorProtocol<T.Element>, ~Escapable, ~Copyable where T: CxxBorrowingSequence & ~Copyable & ~Escapable, T.Element: ~Copyable {
 
   @usableFromInline
   internal var current: T.RawIterator
@@ -49,30 +48,11 @@ public struct CxxBorrowingIterator<T>: BorrowingIteratorProtocol, ~Escapable, ~C
     self.current = begin
     self.end = end
   }
-
-  @inlinable
-  public mutating func skip(by offset: Int) -> Int {
-    var remainder = offset
-    while remainder > 0 {
-      let span = nextSpan(maximumCount: remainder)
-      if span.isEmpty { break }
-      remainder &-= span.count
-    }
-    return offset &- remainder
-  }
 }
 
 // For non-contiguous iterators, we create a span of size one for each element
 @available(SwiftStdlib 6.4, *)
 extension CxxBorrowingIterator where T: ~Copyable & ~Escapable, T.Element: ~Copyable {
-  // FIXME methods `skip(by:)` and `nextSpan()` should be inherited from BorrowingSequence,
-  // but currently are not because of a bug. These will be removed once it gets fixed. 
-  @inlinable
-  @_lifetime(&self)
-  public mutating func nextSpan() -> Span<Element> {
-    nextSpan(maximumCount: Int.max)
-  }
-
   @inlinable
   @_lifetime(&self)
   public mutating func nextSpan(maximumCount: Int) -> Span<Element> {
@@ -104,7 +84,7 @@ extension CxxBorrowingIterator where T: ~Copyable & ~Escapable, T.RawIterator: U
   @inlinable
   @_lifetime(&self)
   public mutating func nextSpan(maximumCount: Int) -> Span<Element> {
-    if self.current == self.end {
+    if maximumCount < 1 || self.current == self.end {
       return Span()
     }
 
@@ -123,6 +103,6 @@ extension CxxBorrowingSequence where Element: ~Copyable, Self: ~Copyable {
   @_lifetime(borrow self)
   public borrowing func makeBorrowingIterator() -> CxxBorrowingIterator<Self> {
     let iterator = CxxBorrowingIterator<Self>(begin: __beginUnsafe(), end: __endUnsafe(), sequence: self)
-    return unsafe _cxxOverrideLifetime(iterator, borrowing: self)
+    return iterator
   }
 }

--- a/test/Interop/Cxx/stdlib/Inputs/std-map.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-map.h
@@ -20,13 +20,23 @@ inline Map initEmptyMap() { return {}; }
 inline UnorderedMap initEmptyUnorderedMap() { return {}; }
 
 struct NonCopyable {
-  NonCopyable() = default;
+  NonCopyable(int n) : number(n) {}
   NonCopyable(const NonCopyable &other) = delete;
   NonCopyable(NonCopyable &&other) = default;
   ~NonCopyable() {}
+
+  int number;
 };
 
 using MapNonCopyableKey = std::map<NonCopyable, int>;
 using MapNonCopyableValue = std::map<int, NonCopyable>;
+
+inline MapNonCopyableValue initMapNonCopyableValue() {
+  MapNonCopyableValue m;
+  m.emplace(1, 1);
+  m.emplace(3, 3);
+  m.emplace(7, 7);
+  return m;
+}
 
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_MAP_H

--- a/test/Interop/Cxx/stdlib/Inputs/std-set.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-set.h
@@ -13,10 +13,12 @@ inline UnorderedSetOfCInt initUnorderedSetOfCInt() { return {2, 4, 6}; }
 inline MultisetOfCInt initMultisetOfCInt() { return {2, 2, 4, 6}; }
 
 struct NonCopyable {
-  NonCopyable() = default;
+  NonCopyable(int n) : number(n) {}
   NonCopyable(const NonCopyable &other) = delete;
   NonCopyable(NonCopyable &&other) = default;
   ~NonCopyable() {}
+
+  int number;
 };
 
 using SetOfNonCopyable = std::set<NonCopyable>;

--- a/test/Interop/Cxx/stdlib/overlay/Inputs/custom-borrowing-sequence.h
+++ b/test/Interop/Cxx/stdlib/overlay/Inputs/custom-borrowing-sequence.h
@@ -50,4 +50,41 @@ struct SWIFT_NONCOPYABLE ContiguousNonCopyableSequence {
 };
 #endif
 
+struct NonInlineDereferenceOperatorSequence {
+  NonInlineDereferenceOperator begin() const {
+    return NonInlineDereferenceOperator(1);
+  }
+  NonInlineDereferenceOperator end() const {
+    return NonInlineDereferenceOperator(5);
+  }
+};
+
+struct NoConstDereferenceOperatorSequence {
+  NoConstDereferenceOperator begin() const {
+    return NoConstDereferenceOperator(1);
+  }
+  NoConstDereferenceOperator end() const {
+    return NoConstDereferenceOperator(5);
+  }
+};
+
+struct DifferentResultsDereferenceOperatorSequence {
+  DifferentResultsDereferenceOperator begin() const {
+    return DifferentResultsDereferenceOperator(1, 42);
+  }
+  DifferentResultsDereferenceOperator end() const {
+    return DifferentResultsDereferenceOperator(5, 56);
+  }
+};
+
+struct ConstRACButNotBorrowingIteratorSequence {
+  int arr[5] = {2, 1, 2, 7, 5};
+  ConstRACButNotBorrowingIterator begin() const {
+    return ConstRACButNotBorrowingIterator(&arr[0]);
+  }
+  ConstRACButNotBorrowingIterator end() const {
+    return ConstRACButNotBorrowingIterator(&arr[5]);
+  }
+};
+
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_CUSTOM_BORROWING_SEQUENCE_H

--- a/test/Interop/Cxx/stdlib/overlay/Inputs/custom-iterator.h
+++ b/test/Interop/Cxx/stdlib/overlay/Inputs/custom-iterator.h
@@ -365,29 +365,26 @@ public:
   }
 };
 
-struct NonReferenceDereferenceOperator {
-private:
-  int value;
-
-public:
+struct DifferentResultsDereferenceOperator {
   using iterator_category = std::input_iterator_tag;
   using value_type = int;
   using pointer = int *;
   using reference = const int &;
   using difference_type = int;
 
-  NonReferenceDereferenceOperator(int value) : value(value) {}
-  NonReferenceDereferenceOperator(
-      const NonReferenceDereferenceOperator &other) = default;
+  int value;
+  long ghost;
 
-  int operator*() const { return value; }
+  DifferentResultsDereferenceOperator(int value, long ghost)
+      : value(value), ghost(ghost) {}
 
-  NonReferenceDereferenceOperator &operator++() {
+  long &operator*() { return ghost; }
+  const int &operator*() const { return value; }
+  DifferentResultsDereferenceOperator &operator++() {
     value++;
     return *this;
   }
-
-  bool operator==(const NonReferenceDereferenceOperator &other) const {
+  bool operator==(const DifferentResultsDereferenceOperator &other) const {
     return value == other.value;
   }
 };
@@ -618,6 +615,144 @@ public:
   }
 };
 #endif
+
+// MARK: Iterators with dereference operators that prevent conformance to
+// CxxBorrowingSequence.
+
+struct NonInlineDereferenceOperator {
+  using iterator_category = std::input_iterator_tag;
+  using value_type = int;
+  using pointer = int *;
+  using reference = const int &;
+  using difference_type = int;
+
+  NonInlineDereferenceOperator(int value) : value(value) {}
+  NonInlineDereferenceOperator(const NonInlineDereferenceOperator &other) =
+      default;
+
+  NonInlineDereferenceOperator &operator++() {
+    value++;
+    return *this;
+  }
+
+  bool operator==(const NonInlineDereferenceOperator &other) const {
+    return value == other.value;
+  }
+
+  int value;
+};
+
+inline int &operator*(NonInlineDereferenceOperator &s) { return s.value; }
+
+struct NonReferenceDereferenceOperator {
+private:
+  int value;
+
+public:
+  using iterator_category = std::input_iterator_tag;
+  using value_type = int;
+  using pointer = int *;
+  using reference = const int &;
+  using difference_type = int;
+
+  NonReferenceDereferenceOperator(int value) : value(value) {}
+  NonReferenceDereferenceOperator(
+      const NonReferenceDereferenceOperator &other) = default;
+
+  int operator*() const { return value; }
+
+  NonReferenceDereferenceOperator &operator++() {
+    value++;
+    return *this;
+  }
+
+  bool operator==(const NonReferenceDereferenceOperator &other) const {
+    return value == other.value;
+  }
+};
+
+struct NoConstDereferenceOperator {
+  using iterator_category = std::input_iterator_tag;
+  using value_type = int;
+  using pointer = int *;
+  using reference = const int &;
+  using difference_type = int;
+
+  int value;
+  NoConstDereferenceOperator(int value) : value(value) {}
+
+  int &operator*() { return value; }
+
+  // This is the binary variant of operator* (i.e., multiply) and should be
+  // accessible via the synthesized static func *(lhs, rhs) operator. Since
+  // there's no const deref operator, NoConstDereferenceOperator shouldn't
+  // conform to UnsafeCxxInputIterator.
+  int operator*(const NoConstDereferenceOperator &other) const {
+    return other.value;
+  }
+  NoConstDereferenceOperator &operator++() {
+    value++;
+    return *this;
+  }
+  bool operator==(const NoConstDereferenceOperator &other) const {
+    return value == other.value;
+  }
+};
+
+struct ConstRACButNotBorrowingIterator {
+private:
+  const int *value;
+
+public:
+  using iterator_category = std::random_access_iterator_tag;
+  using value_type = int;
+  using pointer = int *;
+  using reference = const int &;
+  using difference_type = int;
+
+  ConstRACButNotBorrowingIterator(const int *value) : value(value) {}
+  ConstRACButNotBorrowingIterator(
+      const ConstRACButNotBorrowingIterator &other) = default;
+
+  int operator*() const { return *value; }
+
+  ConstRACButNotBorrowingIterator &operator++() {
+    value++;
+    return *this;
+  }
+  ConstRACButNotBorrowingIterator operator++(int) {
+    auto tmp = ConstRACButNotBorrowingIterator(value);
+    value++;
+    return tmp;
+  }
+
+  void operator+=(difference_type v) { value += v; }
+  void operator-=(difference_type v) { value -= v; }
+  ConstRACButNotBorrowingIterator operator+(difference_type v) const {
+    return ConstRACButNotBorrowingIterator(value + v);
+  }
+  ConstRACButNotBorrowingIterator operator-(difference_type v) const {
+    return ConstRACButNotBorrowingIterator(value - v);
+  }
+  friend ConstRACButNotBorrowingIterator
+  operator+(difference_type v, const ConstRACButNotBorrowingIterator &it) {
+    return it + v;
+  }
+  int operator-(const ConstRACButNotBorrowingIterator &other) const {
+    return value - other.value;
+  }
+
+  bool operator<(const ConstRACButNotBorrowingIterator &other) const {
+    return value < other.value;
+  }
+
+  bool operator==(const ConstRACButNotBorrowingIterator &other) const {
+    return value == other.value;
+  }
+  bool operator!=(const ConstRACButNotBorrowingIterator &other) const {
+    return value != other.value;
+  }
+};
 
 // MARK: Types that are not actually iterators
 

--- a/test/Interop/Cxx/stdlib/overlay/custom-borrowing-sequence-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-borrowing-sequence-module-interface.swift
@@ -28,3 +28,31 @@
 // CHECK:   typealias RawIterator = NonReferenceDereferenceOperator
 // CHECK:   typealias Iterator = CxxIterator<NonReferenceDereferenceOperatorSequence>
 // CHECK: }
+
+// CHECK: struct NonInlineDereferenceOperatorSequence {
+// CHECK-NOT:   typealias Element
+// CHECK-NOT:   typealias RawIterator
+// CHECK-NOT:   typealias Iterator
+// CHECK: }
+
+// CHECK: struct NoConstDereferenceOperatorSequence {
+// CHECK-NOT:   typealias Element
+// CHECK-NOT:   typealias RawIterator
+// CHECK-NOT:   typealias Iterator
+// CHECK: }
+
+// CHECK: struct DifferentResultsDereferenceOperatorSequence : CxxConvertibleToCollection, CxxBorrowingSequence {
+// CHECK:   typealias Element = DifferentResultsDereferenceOperator.Pointee
+// CHECK:   typealias RawIterator = DifferentResultsDereferenceOperator
+// CHECK:   typealias BorrowingIterator = CxxBorrowingIterator<DifferentResultsDereferenceOperatorSequence>
+// CHECK:   typealias Iterator = CxxIterator<DifferentResultsDereferenceOperatorSequence>
+// CHECK: }
+
+// CHECK: struct ConstRACButNotBorrowingIteratorSequence : CxxRandomAccessCollection {
+// CHECK:   typealias Element = ConstRACButNotBorrowingIterator.Pointee
+// CHECK:   typealias RawIterator = ConstRACButNotBorrowingIterator
+// CHECK:   typealias Iterator = CxxIterator<ConstRACButNotBorrowingIteratorSequence>
+// CHECK:   typealias Index = Int
+// CHECK:   typealias Indices = Range<Int>
+// CHECK:   typealias SubSequence = Slice<ConstRACButNotBorrowingIteratorSequence>
+// CHECK: }

--- a/test/Interop/Cxx/stdlib/overlay/custom-borrowing-sequence-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-borrowing-sequence-typechecker.swift
@@ -3,11 +3,29 @@
 import CustomBorrowingSequence
 
 func checkBorrowingSequence<S>(_ seq: borrowing S) where S: CxxBorrowingSequence, S: ~Copyable {
-  // expected-note@-1 {{where 'S' = 'NonReferenceDereferenceOperatorSequence'}}
+  // expected-note@-1 {{where 'S' = 'NonInlineDereferenceOperatorSequence'}}
+  // expected-note@-2 {{where 'S' = 'NonReferenceDereferenceOperatorSequence'}}
+  // expected-note@-3 {{where 'S' = 'NoConstDereferenceOperatorSequence'}}
+  // expected-note@-4 {{where 'S' = 'ConstRACButNotBorrowingIteratorSequence'}}
   var _ = seq.makeBorrowingIterator()
 }
+
+func checkRandomAccessCollection<S>(_ seq: borrowing S) where S: CxxRandomAccessCollection {}
+
+checkBorrowingSequence(NonInlineDereferenceOperatorSequence())
+// expected-error@-1 {{global function 'checkBorrowingSequence' requires that 'NonInlineDereferenceOperatorSequence' conform to 'CxxBorrowingSequence'}}
 
 // NonReferenceDereferenceOperatorSequence doesn't conform to CxxBorrowingSequence because operator* 
 // (the dereference operator) doesn't return a reference
 checkBorrowingSequence(NonReferenceDereferenceOperatorSequence()) 
 // expected-error@-1 {{global function 'checkBorrowingSequence' requires that 'NonReferenceDereferenceOperatorSequence' conform to 'CxxBorrowingSequence'}}
+
+// NoConstDereferenceOperatorSequence doesn't conform to CxxBorrowingSequence because there is no const operator* (the dereference operator)
+checkBorrowingSequence(NoConstDereferenceOperatorSequence()) 
+// expected-error@-1 {{global function 'checkBorrowingSequence' requires that 'NoConstDereferenceOperatorSequence' conform to 'CxxBorrowingSequence'}}
+
+// ConstRACButNotBorrowingIteratorSequence doesn't conform to CxxBorrowingSequence because operator* 
+// (the dereference operator) doesn't return a reference. However, it still conforms to CxxRandomAccessCollection.
+checkBorrowingSequence(ConstRACButNotBorrowingIteratorSequence()) 
+// expected-error@-1 {{global function 'checkBorrowingSequence' requires that 'ConstRACButNotBorrowingIteratorSequence' conform to 'CxxBorrowingSequence'}}
+checkRandomAccessCollection(ConstRACButNotBorrowingIteratorSequence())

--- a/test/Interop/Cxx/stdlib/overlay/custom-borrowing-sequence.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-borrowing-sequence.swift
@@ -1,6 +1,8 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=default -I %swift_src_root/lib/ClangImporter/SwiftBridging -Xcc -std=c++20)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=default -I %swift_src_root/lib/ClangImporter/SwiftBridging -Xcc -std=c++20 -enable-experimental-feature BorrowingForLoop -DBORROWING_ITERATOR_PROTOCOL)
 //
 // REQUIRES: executable_test
+// REQUIRES: swift_feature_BorrowingForLoop
 // Ubuntu 20.04 ships with an old version of libstdc++, which does not provide
 // std::contiguous_iterator_tag from C++20.
 // UNSUPPORTED: LinuxDistribution=ubuntu-20.04
@@ -11,6 +13,11 @@ import CustomBorrowingSequence
 
 var CxxBorrowingSequenceTestSuite = TestSuite("CxxSequence")
 
+// FIXME https://github.com/swiftlang/swift/issues/87260
+// Currently, `Sequence` doesn't conform to `BorrowingSequence`, which means that types like `Range` don't
+// automatically conform to `BorrowingSequence`. When we enable the experimental feature `BorrowingForLoop`,
+// all for-in loops use the new borrowing iterators, which means that all range iterations will be invalid.
+#if !BORROWING_ITERATOR_PROTOCOL
 CxxBorrowingSequenceTestSuite.test("SimpleNonCopyableSequence as Swift.BorrowingSequence") {
   guard #available(SwiftStdlib 6.4, *) else { return }
 
@@ -18,16 +25,16 @@ CxxBorrowingSequenceTestSuite.test("SimpleNonCopyableSequence as Swift.Borrowing
   let arr : [Int32] = [2, 3, 4, 5]
 
   var iterator = seq.makeBorrowingIterator()
-    var counter = 0
-    while true {
-        let span = iterator.nextSpan()
-        if (span.count == 0) { break }
-        for i in 0..<span.count {
-            expectEqual(span[i], arr[counter])
-            counter += 1
-        }
+  var counter = 0
+  while true {
+    let span = iterator.nextSpan()
+    if (span.count == 0) { break }
+    for i in 0..<span.count {
+      expectEqual(span[i], arr[counter])
+      counter += 1
     }
-    expectEqual(counter, 4)
+  }
+  expectEqual(counter, 4)
 }
 
 CxxBorrowingSequenceTestSuite.test("SimpleNonCopArrayWrapper as Swift.BorrowingSequence") {
@@ -36,16 +43,16 @@ CxxBorrowingSequenceTestSuite.test("SimpleNonCopArrayWrapper as Swift.BorrowingS
   let arr : [Int32] = [10, 20, 30, 40, 50]
 
   var iterator = seq.makeBorrowingIterator()
-    var counter = 0
-    while true {
-        let span = iterator.nextSpan()
-        if (span.count == 0) { break }
-        for i in 0..<span.count {
-            expectEqual(span[i].number, arr[counter])
-            counter += 1
-        }
+  var counter = 0
+  while true {
+    let span = iterator.nextSpan()
+    if (span.count == 0) { break }
+    for i in 0..<span.count {
+      expectEqual(span[i].number, arr[counter])
+      counter += 1
     }
-    expectEqual(counter, 5)
+  }
+  expectEqual(counter, 5)
 }
 
 CxxBorrowingSequenceTestSuite.test("ContiguousNonCopyableSequence as Swift.BorrowingSequence") {
@@ -57,14 +64,14 @@ CxxBorrowingSequenceTestSuite.test("ContiguousNonCopyableSequence as Swift.Borro
   var innerCounter = 0
   var outerCounter = 0
   while true {
-      let span = iterator.nextSpan()
-      if (span.count == 0) { break }
-      expectEqual(span.count, 5)
-      for i in 0..<span.count {
-          expectEqual(span[i], arr[innerCounter])
-          innerCounter += 1
-      }
-      outerCounter += 1
+    let span = iterator.nextSpan()
+    if (span.count == 0) { break }
+    expectEqual(span.count, 5)
+    for i in 0..<span.count {
+      expectEqual(span[i], arr[innerCounter])
+      innerCounter += 1
+    }
+    outerCounter += 1
   }
   expectEqual(innerCounter, 5)
   expectEqual(outerCounter, 1)
@@ -79,16 +86,46 @@ CxxBorrowingSequenceTestSuite.test("ContiguousNonCopyableSequence as Swift.Borro
   var innerCounter = 0
   var outerCounter = 0
   while true {
-      let span = iterator.nextSpan(maximumCount: 3)
-      if (span.count == 0) { break }
-      for i in 0..<span.count {
-          expectEqual(span[i], arr[innerCounter])
-          innerCounter += 1
-      }
-      outerCounter += 1
+    let span = iterator.nextSpan(maximumCount: 3)
+    if (span.count == 0) { break }
+    for i in 0..<span.count {
+      expectEqual(span[i], arr[innerCounter])
+      innerCounter += 1
+    }
+    outerCounter += 1
   }
   expectEqual(innerCounter, 5)
   expectEqual(outerCounter, 2)
 }
+
+#else // !BORROWING_ITERATOR_PROTOCOL
+
+CxxBorrowingSequenceTestSuite.test("ContiguousNonCopyableSequence borrowing for loop") {
+  guard #available(SwiftStdlib 6.4, *) else { return }
+  let seq = ContiguousNonCopyableSequence()
+  let arr : [Int32] = [10, 20, 30, 40, 50]
+
+  var counter = 0
+  for el in seq {
+    expectEqual(el, arr[counter])
+    counter += 1
+  }
+  expectEqual(counter, 5)
+}
+
+CxxBorrowingSequenceTestSuite.test("DifferentResultsDereferenceOperatorSequence borrowing for loop") {
+  guard #available(SwiftStdlib 6.4, *) else { return }
+  let seq = DifferentResultsDereferenceOperatorSequence()
+  let arr : [Int32] = [2, 3, 4, 5]
+
+  var counter = 0
+  for el in seq {
+    expectEqual(el, arr[counter])
+    counter += 1
+  }
+  expectEqual(counter, 4)
+}
+
+#endif // !BORROWING_ITERATOR_PROTOCOL
 
 runAllTests()

--- a/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=CustomIterator -source-filename=x -I %S/Inputs -cxx-interoperability-mode=default | %FileCheck %s
 
 // CHECK: struct ConstIterator : UnsafeCxxInputIterator {
+// CHECK:   func __operatorStar() -> UnsafePointer<Int32>
 // CHECK:   func successor() -> ConstIterator
 // CHECK:   typealias Pointee = Int32
 // CHECK:   static func == (lhs: ConstIterator, other: ConstIterator) -> Bool
@@ -99,6 +100,52 @@
 // CHECK:   func successor() -> MutableRACIterator
 // CHECK:   typealias Pointee = Int32
 // CHECK:   typealias Distance = Int32
+// CHECK: }
+
+// CHECK: struct DifferentResultsDereferenceOperator : UnsafeCxxMutableInputIterator {
+// CHECK:   mutating func __operatorStar() -> UnsafeMutablePointer<Int>
+// CHECK:   func __operatorStar() -> UnsafePointer<Int32>
+// CHECK:   func successor() -> DifferentResultsDereferenceOperator
+// CHECK:   typealias Pointee = Int32
+// CHECK:   typealias DereferenceResult = UnsafePointer<Int32>
+// CHECK:   static func == (lhs: DifferentResultsDereferenceOperator, other: DifferentResultsDereferenceOperator) -> Bool
+// CHECK:   var pointee: Int32
+// CHECK: }
+
+// CHECK: struct NonInlineDereferenceOperator {
+// CHECK-NOT:   func __operatorStar()
+// CHECK:   func successor() -> NonInlineDereferenceOperator
+// CHECK-NOT:   typealias Pointee
+// CHECK-NOT:   typealias DereferenceResult
+// CHECK-NOT:   var pointee
+// CHECK: }
+
+// CHECK: struct NonReferenceDereferenceOperator : UnsafeCxxInputIterator {
+// CHECK:   func __operatorStar() -> Int32
+// CHECK:   func successor() -> NonReferenceDereferenceOperator
+// CHECK:   typealias Pointee = Int32
+// CHECK:   typealias DereferenceResult = Int32
+// CHECK:   var pointee: Int32 { get }
+// CHECK: }
+
+// CHECK: struct NoConstDereferenceOperator {
+// CHECK:   mutating func __operatorStar() -> UnsafeMutablePointer<Int32>
+// CHECK:   static func * (lhs: NoConstDereferenceOperator, other: NoConstDereferenceOperator) -> Int32
+// CHECK:   static func == (lhs: NoConstDereferenceOperator, other: NoConstDereferenceOperator) -> Bool
+// CHECK:   func successor() -> NoConstDereferenceOperator
+// CHECK:   var pointee: Int32 { mutating get set }
+// CHECK: }
+
+// CHECK: struct ConstRACButNotBorrowingIterator : UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
+// CHECK:   func __operatorStar() -> Int32
+// CHECK:   func successor() -> ConstRACButNotBorrowingIterator
+// CHECK:   typealias Pointee = Int32
+// CHECK:   typealias DereferenceResult = Int32
+// CHECK:   typealias Distance = Int32
+// CHECK:   static func += (lhs: inout ConstRACButNotBorrowingIterator, v: ConstRACButNotBorrowingIterator.difference_type)
+// CHECK:   static func - (lhs: ConstRACButNotBorrowingIterator, other: ConstRACButNotBorrowingIterator) -> Int32
+// CHECK:   static func == (lhs: ConstRACButNotBorrowingIterator, other: ConstRACButNotBorrowingIterator) -> Bool
+// CHECK:   var pointee: Int32 { get }
 // CHECK: }
 
 // CHECK-NOT: struct HasNoIteratorCategory : UnsafeCxxInputIterator

--- a/test/Interop/Cxx/stdlib/overlay/custom-iterator-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-iterator-typechecker.swift
@@ -6,9 +6,12 @@
 // contiguous iterators.
 //
 // RUN: %if !(LinuxDistribution=ubuntu-20.04 || LinuxDistribution=amzn-2) %{ \
-// RUN:   %target-typecheck-verify-swift -verify-ignore-unrelated -suppress-notes -I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++20 -DCPP20 -verify-additional-prefix cpp20- \
+// RUN:   %target-typecheck-verify-swift -verify-ignore-unrelated -suppress-notes -I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++20 -enable-experimental-feature SuppressedAssociatedTypesWithDefaults -enable-experimental-feature BorrowingSequence -DCPP20 -verify-additional-prefix cpp20- \
 // RUN: %}
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -suppress-notes -I %S/Inputs -cxx-interoperability-mode=default
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -suppress-notes -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature SuppressedAssociatedTypesWithDefaults -enable-experimental-feature BorrowingSequence
+
+// REQUIRES: swift_feature_SuppressedAssociatedTypesWithDefaults
+// REQUIRES: swift_feature_BorrowingSequence
 
 import CustomIterator
 
@@ -18,6 +21,8 @@ func checkContiguous<It: UnsafeCxxContiguousIterator>(_ _: It) {}
 func checkMutableInput<It: UnsafeCxxMutableInputIterator>(_ _: It) {}
 func checkMutableRandomAccess<It: UnsafeCxxMutableRandomAccessIterator>(_ _: It) {}
 func checkMutableContiguous<It: UnsafeCxxMutableContiguousIterator>(_ _: It) {}
+@available(SwiftStdlib 6.4, *)
+func checkBorrowingIterator<It: BorrowingIteratorProtocol>(_ _: It) {}
 
 func check(it: ConstIterator) {
   checkInput(it)
@@ -26,6 +31,7 @@ func check(it: ConstIterator) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: ConstRACIterator) {
@@ -35,6 +41,7 @@ func check(it: ConstRACIterator) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: ConstRACIteratorRefPlusEq) {
@@ -44,6 +51,7 @@ func check(it: ConstRACIteratorRefPlusEq) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: ConstIteratorOutOfLineEq) {
@@ -53,6 +61,7 @@ func check(it: ConstIteratorOutOfLineEq) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: MinimalIterator) {
@@ -62,6 +71,7 @@ func check(it: MinimalIterator) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: ForwardIterator) {
@@ -71,6 +81,7 @@ func check(it: ForwardIterator) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: HasCustomIteratorTag) {
@@ -80,6 +91,7 @@ func check(it: HasCustomIteratorTag) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: HasCustomRACIteratorTag) {
@@ -89,6 +101,7 @@ func check(it: HasCustomRACIteratorTag) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: HasCustomInheritedRACIteratorTag) {
@@ -98,6 +111,7 @@ func check(it: HasCustomInheritedRACIteratorTag) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: HasCustomIteratorTagInline) {
@@ -107,6 +121,7 @@ func check(it: HasCustomIteratorTagInline) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: HasTypedefIteratorTag) {
@@ -116,6 +131,7 @@ func check(it: HasTypedefIteratorTag) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: MutableRACIterator) {
@@ -125,15 +141,17 @@ func check(it: MutableRACIterator) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
-func check(it: NonReferenceDereferenceOperator) {
+func check(it: DifferentResultsDereferenceOperator) {
   checkInput(it)
   checkRandomAccess(it)         // expected-error {{requires}}
   checkContiguous(it)           // expected-error {{requires}}
-  checkMutableInput(it)         // expected-error {{requires}}
+  checkMutableInput(it)
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 #if CPP20
@@ -145,6 +163,7 @@ func check(it: ConstContiguousIterator) {
   checkMutableInput(it)         // expected-cpp20-error {{requires}}
   checkMutableRandomAccess(it)  // expected-cpp20-error {{requires}}
   checkMutableContiguous(it)    // expected-cpp20-error {{requires}}
+  checkBorrowingIterator(it)    // expected-cpp20-error {{requires}}
 }
 
 func check(it: HasCustomContiguousIteratorTag) {
@@ -154,6 +173,7 @@ func check(it: HasCustomContiguousIteratorTag) {
   checkMutableInput(it)         // expected-cpp20-error {{requires}}
   checkMutableRandomAccess(it)  // expected-cpp20-error {{requires}}
   checkMutableContiguous(it)    // expected-cpp20-error {{requires}}
+  checkBorrowingIterator(it)    // expected-cpp20-error {{requires}}
 }
 
 func check(it: MutableContiguousIterator) {
@@ -163,6 +183,7 @@ func check(it: MutableContiguousIterator) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)
   checkMutableContiguous(it)
+  checkBorrowingIterator(it)    // expected-cpp20-error {{requires}}
 }
 
 func check(it: HasNoContiguousIteratorConcept) {
@@ -172,9 +193,51 @@ func check(it: HasNoContiguousIteratorConcept) {
   checkMutableInput(it)         // expected-cpp20-error {{requires}}
   checkMutableRandomAccess(it)  // expected-cpp20-error {{requires}}
   checkMutableContiguous(it)    // expected-cpp20-error {{requires}}
+  checkBorrowingIterator(it)    // expected-cpp20-error {{requires}}
 }
 
 #endif
+
+func check(it: NonInlineDereferenceOperator) {
+  checkInput(it)                // expected-error {{requires}}
+  checkRandomAccess(it)         // expected-error {{requires}}
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)         // expected-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
+}
+
+func check(it: NonReferenceDereferenceOperator) {
+  checkInput(it)
+  checkRandomAccess(it)         // expected-error {{requires}}
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)         // expected-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
+}
+
+func check(it: NoConstDereferenceOperator) {
+  checkInput(it)                // expected-error {{requires}}
+  checkRandomAccess(it)         // expected-error {{requires}}
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)         // expected-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
+}
+
+func check(it: ConstRACButNotBorrowingIterator) {
+  checkInput(it)
+  checkRandomAccess(it)
+  checkContiguous(it)           // expected-error {{requires}}
+  checkMutableInput(it)         // expected-error {{requires}}
+  checkMutableRandomAccess(it)  // expected-error {{requires}}
+  checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
+}
+
 
 func check(it: HasNoIteratorCategory) {
   checkInput(it)                // expected-error {{requires}}
@@ -183,6 +246,7 @@ func check(it: HasNoIteratorCategory) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: HasInvalidIteratorCategory) {
@@ -192,6 +256,7 @@ func check(it: HasInvalidIteratorCategory) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: HasNoEqualEqual) {
@@ -201,6 +266,7 @@ func check(it: HasNoEqualEqual) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: HasInvalidEqualEqual) {
@@ -210,6 +276,7 @@ func check(it: HasInvalidEqualEqual) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: HasNoIncrementOperator) {
@@ -219,6 +286,7 @@ func check(it: HasNoIncrementOperator) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: HasNoPreIncrementOperator) {
@@ -228,6 +296,7 @@ func check(it: HasNoPreIncrementOperator) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: HasNoDereferenceOperator) {
@@ -237,6 +306,7 @@ func check(it: HasNoDereferenceOperator) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: TemplatedIteratorInt) {
@@ -246,6 +316,7 @@ func check(it: TemplatedIteratorInt) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 
@@ -256,6 +327,7 @@ func check(it: TemplatedIteratorOutOfLineEqInt) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 
@@ -266,6 +338,7 @@ func check(it: TemplatedRACIteratorOutOfLineEqInt) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: BaseIntIterator) {
@@ -275,6 +348,7 @@ func check(it: BaseIntIterator) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: InheritedConstIterator) {
@@ -284,6 +358,7 @@ func check(it: InheritedConstIterator) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: InheritedTemplatedConstIteratorInt) {
@@ -293,6 +368,7 @@ func check(it: InheritedTemplatedConstIteratorInt) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: InheritedTemplatedConstRACIteratorInt) {
@@ -302,6 +378,7 @@ func check(it: InheritedTemplatedConstRACIteratorInt) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: InheritedTemplatedConstRACIteratorOutOfLineOpsInt) {
@@ -311,6 +388,7 @@ func check(it: InheritedTemplatedConstRACIteratorOutOfLineOpsInt) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: InputOutputIterator) {
@@ -320,6 +398,7 @@ func check(it: InputOutputIterator) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: InputOutputConstIterator) {
@@ -329,6 +408,7 @@ func check(it: InputOutputConstIterator) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: ProtectedIteratorBase) {
@@ -338,6 +418,7 @@ func check(it: ProtectedIteratorBase) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: HasInheritedProtectedCopyConstructor) {
@@ -347,6 +428,7 @@ func check(it: HasInheritedProtectedCopyConstructor) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: TaglessNewPtr) {
@@ -356,6 +438,7 @@ func check(it: TaglessNewPtr) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: InputCategoryNewPtr) {
@@ -365,6 +448,7 @@ func check(it: InputCategoryNewPtr) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: ForwardCategoryNewPtr) {
@@ -374,6 +458,7 @@ func check(it: ForwardCategoryNewPtr) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: RandomAccessCategoryNewPtr) {
@@ -383,6 +468,7 @@ func check(it: RandomAccessCategoryNewPtr) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 #if CPP20
@@ -394,6 +480,7 @@ func check(it: ContiguousCategoryNewPtr) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)
   checkMutableContiguous(it)
+  checkBorrowingIterator(it)    // expected-cpp20-error {{requires}}
 }
 
 func check(it: InputConceptNewPtr) {
@@ -403,6 +490,7 @@ func check(it: InputConceptNewPtr) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)  // expected-cpp20-error {{requires}}
   checkMutableContiguous(it)    // expected-cpp20-error {{requires}}
+  checkBorrowingIterator(it)    // expected-cpp20-error {{requires}}
 }
 
 func check(it: ForwardConceptNewPtr) {
@@ -421,6 +509,7 @@ func check(it: RandomAccessConceptNewPtr) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)
   checkMutableContiguous(it)    // expected-cpp20-error {{requires}}
+  checkBorrowingIterator(it)    // expected-cpp20-error {{requires}}
 }
 
 func check(it: ContiguousConceptNewPtr) {
@@ -430,6 +519,7 @@ func check(it: ContiguousConceptNewPtr) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)
   checkMutableContiguous(it)
+  checkBorrowingIterator(it)    // expected-cpp20-error {{requires}}
 }
 
 func check(it: InvalidContiguousCategoryNewPtr) {
@@ -439,6 +529,7 @@ func check(it: InvalidContiguousCategoryNewPtr) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)
   checkMutableContiguous(it)    // expected-cpp20-error {{requires}}
+  checkBorrowingIterator(it)    // expected-cpp20-error {{requires}}
 }
 
 #endif // CPP20
@@ -450,6 +541,7 @@ func check(it: IteratorTagOfMemberTypedef) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: IteratorTagOfNonMemberTypedef) {
@@ -459,6 +551,7 @@ func check(it: IteratorTagOfNonMemberTypedef) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: BasicLegacyPtr) {
@@ -468,6 +561,7 @@ func check(it: BasicLegacyPtr) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: NotALegacyPtr) {
@@ -477,6 +571,7 @@ func check(it: NotALegacyPtr) {
   checkMutableInput(it)         // expected-error {{requires}}
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 func check(it: InputCategoryLegacyPtr) {
@@ -486,6 +581,7 @@ func check(it: InputCategoryLegacyPtr) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)  // expected-error {{requires}}
   checkMutableContiguous(it)    // expected-error {{requires}}
+  checkBorrowingIterator(it)    // expected-error {{requires}}
 }
 
 #if CPP20
@@ -497,6 +593,7 @@ func check(it: InputConceptLegacyPtr) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)  // expected-cpp20-error {{requires}}
   checkMutableContiguous(it)    // expected-cpp20-error {{requires}}
+  checkBorrowingIterator(it)    // expected-cpp20-error {{requires}}
 }
 
 func check(it: ContiguousConceptLegacyPtr) {
@@ -506,6 +603,7 @@ func check(it: ContiguousConceptLegacyPtr) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)
   checkMutableContiguous(it)
+  checkBorrowingIterator(it)    // expected-cpp20-error {{requires}}
 }
 
 func check(it: InputCategoryContiguousConceptLegacyPtr) {
@@ -515,6 +613,7 @@ func check(it: InputCategoryContiguousConceptLegacyPtr) {
   checkMutableInput(it)
   checkMutableRandomAccess(it)
   checkMutableContiguous(it)
+  checkBorrowingIterator(it)    // expected-cpp20-error {{requires}}
 }
 
 #endif // CPP20

--- a/test/Interop/Cxx/stdlib/use-std-list.swift
+++ b/test/Interop/Cxx/stdlib/use-std-list.swift
@@ -1,6 +1,9 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
+// Test iterating through a list using the borrowing iterators (currently behind a feature flag).
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -enable-experimental-feature BorrowingForLoop -DBORROWING_ITERATOR_PROTOCOL)
 
 // REQUIRES: executable_test
+// REQUIRES: swift_feature_BorrowingForLoop
 
 import StdlibUnittest
 import StdList
@@ -11,6 +14,12 @@ var StdListTestSuite = TestSuite("StdList")
 func getNumber(_ x: borrowing NonCopyable) -> Int32 {
     return x.number
 }
+
+// FIXME https://github.com/swiftlang/swift/issues/87260
+// Currently, `Sequence` doesn't conform to `BorrowingSequence`, which means that types like `Range` don't
+// automatically conform to `BorrowingSequence`. When we enable the experimental feature `BorrowingForLoop`,
+// all for-in loops use the new borrowing iterators, which means that all range iterations will be invalid.
+#if !BORROWING_ITERATOR_PROTOCOL
 
 StdListTestSuite.test("ListOfInt conforms to CxxBorrowingSequence") {
     guard #available(SwiftStdlib 6.4, *) else { return }
@@ -51,5 +60,37 @@ StdListTestSuite.test("ListOfNonCopyable conforms to CxxBorrowingSequence") {
     }
     expectEqual(counter, lst.size())
 }
+
+#else // !BORROWING_ITERATOR_PROTOCOL
+
+StdListTestSuite.test("ListOfInt borrowing for loop") {
+    guard #available(SwiftStdlib 6.4, *) else { return }
+    let arr : [Int32] = [1, 2, 3]
+    let lst = makeListInt()
+    expectEqual(lst.size(), 3)
+    expectFalse(lst.empty())
+    var counter = 0
+    for el in lst {
+        expectEqual(el, arr[counter])
+        counter += 1
+    }
+    expectEqual(counter, lst.size())
+}
+
+StdListTestSuite.test("ListOfNonCopyable borrowing for loop") {
+    guard #available(SwiftStdlib 6.4, *) else { return }
+    let arr : [Int32] = [1, 2, 3]
+    var lst = makeListOfNonCopyable()
+    expectEqual(lst.size(), 3)
+    expectFalse(lst.empty())
+    var counter = 0
+    for el in lst {
+        expectEqual(getNumber(el), arr[counter])
+        counter += 1
+    }
+    expectEqual(counter, lst.size())
+}
+
+#endif // !BORROWING_ITERATOR_PROTOCOL
 
 runAllTests()

--- a/test/Interop/Cxx/stdlib/use-std-map.swift
+++ b/test/Interop/Cxx/stdlib/use-std-map.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-6)
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20 -enable-experimental-feature BorrowingForLoop -DBORROWING_ITERATOR_PROTOCOL)
 
 // Also test this with a bridging header instead of the StdMap module.
 // RUN: %empty-directory(%t2)
@@ -8,8 +9,10 @@
 // RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-map-bridging-header.h -Xfrontend -enable-experimental-cxx-interop)
 // RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-map-bridging-header.h -cxx-interoperability-mode=swift-6)
 // RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-map-bridging-header.h -cxx-interoperability-mode=upcoming-swift)
+// RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-map-bridging-header.h -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20 -enable-experimental-feature BorrowingForLoop -DBORROWING_ITERATOR_PROTOCOL)
 
 // REQUIRES: executable_test
+// REQUIRES: swift_feature_BorrowingForLoop
 //
 // REQUIRES: OS=macosx || OS=linux-gnu || OS=freebsd
 
@@ -25,6 +28,12 @@ import CxxStdlib
 import Cxx
 
 var StdMapTestSuite = TestSuite("StdMap")
+
+// FIXME https://github.com/swiftlang/swift/issues/87260
+// Currently, `Sequence` doesn't conform to `BorrowingSequence`, which means that types like `Range` don't
+// automatically conform to `BorrowingSequence`. When we enable the experimental feature `BorrowingForLoop`,
+// all for-in loops use the new borrowing iterators, which means that all range iterations will be invalid.
+#if !BORROWING_ITERATOR_PROTOCOL
 
 StdMapTestSuite.test("init") {
   let m = Map()
@@ -639,6 +648,25 @@ StdMapTestSuite.test("UnorderedMap.merge(CxxDictionary)") {
   expectEqual(map[3], 6)
   expectEqual(map[4], 7)
 }
+
+#else // !BORROWING_ITERATOR_PROTOCOL
+
+// FIXME importing a move-only std::pair into Swift causes a crash in the MoveOnlyChecker, in Linux
+#if os(macOS) || os(Windows)
+StdMapTestSuite.test("MapNonCopyableValue Borrowing Iterators").require(.stdlib_6_4).code {
+  guard #available(SwiftStdlib 6.4, *) else { return }
+
+  let map = initMapNonCopyableValue()
+  var counter = 0
+  for el in map {
+    expectEqual(el.first, el.second.number)
+    counter += 1
+  }
+  expectEqual(counter, 3)
+}
+#endif
+
+#endif // !BORROWING_ITERATOR_PROTOCOL
 
 // `merging` is implemented by calling `merge`, so we can skip this test
 

--- a/test/Interop/Cxx/stdlib/use-std-set.swift
+++ b/test/Interop/Cxx/stdlib/use-std-set.swift
@@ -4,6 +4,7 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++14)
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++17)
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20 -enable-experimental-feature BorrowingForLoop -DBORROWING_ITERATOR_PROTOCOL)
 
 // Also test this with a bridging header instead of the StdSet module.
 // RUN: %empty-directory(%t2)
@@ -13,6 +14,7 @@
 // RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-set-bridging-header.h -cxx-interoperability-mode=upcoming-swift)
 
 // REQUIRES: executable_test
+// REQUIRES: swift_feature_BorrowingForLoop
 //
 // Enable this everywhere once we have a solution for modularizing other C++ stdlibs: rdar://87654514
 // REQUIRES: OS=macosx || OS=linux-gnu
@@ -26,6 +28,12 @@ import CxxStdlib
 import Cxx
 
 var StdSetTestSuite = TestSuite("StdSet")
+
+// FIXME https://github.com/swiftlang/swift/issues/87260
+// Currently, `Sequence` doesn't conform to `BorrowingSequence`, which means that types like `Range` don't
+// automatically conform to `BorrowingSequence`. When we enable the experimental feature `BorrowingForLoop`,
+// all for-in loops use the new borrowing iterators, which means that all range iterations will be invalid.
+#if !BORROWING_ITERATOR_PROTOCOL
 
 StdSetTestSuite.test("iterate over Swift.Array") {
     let s = Array(initSetOfCInt())
@@ -182,5 +190,43 @@ StdSetTestSuite.test("UnorderedSetOfCInt.remove") {
     expectEqual(s.remove(2), nil)
     expectFalse(s.contains(2))
 }
+
+#else // !BORROWING_ITERATOR_PROTOCOL
+
+StdSetTestSuite.test("SetOfCInt Borrowing Iterators").require(.stdlib_6_4).code {
+    guard #available(SwiftStdlib 6.4, *) else { return }
+
+    let s = initSetOfCInt()
+    expectTrue(s.contains(1))
+    expectFalse(s.contains(2))
+    expectTrue(s.contains(3))
+
+    let arr : [Int32] = [1, 3, 5]
+    var counter = 0
+    for el in s {
+        expectEqual(el, arr[counter])
+        counter += 1
+    }
+    expectEqual(counter, 3)
+}
+
+StdSetTestSuite.test("MultisetOfCInt Borrowing Iterators").require(.stdlib_6_4).code {
+    guard #available(SwiftStdlib 6.4, *) else { return }
+
+    let s = initMultisetOfCInt()
+    expectTrue(s.contains(2))
+    expectFalse(s.contains(3))
+    expectTrue(s.contains(4))
+
+    let arr : [Int32] = [2, 2, 4, 6]
+    var counter = 0
+    for el in s {
+        expectEqual(el, arr[counter])
+        counter += 1
+    }
+    expectEqual(counter, 4)
+}
+
+#endif // !BORROWING_ITERATOR_PROTOCOL
 
 runAllTests()

--- a/test/Interop/Cxx/stdlib/use-std-span.swift
+++ b/test/Interop/Cxx/stdlib/use-std-span.swift
@@ -1,11 +1,13 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20)
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20 -Xcc -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20 -enable-experimental-feature BorrowingForLoop -DBORROWING_ITERATOR_PROTOCOL)
 
 // TODO: test failed in macOS PR testing but passes locally: rdar://163049442
 // UNSUPPORTED: OS_FAMILY=darwin && !CPU=arm64
 
 // REQUIRES: executable_test
 // REQUIRES: std_span
+// REQUIRES: swift_feature_BorrowingForLoop
 
 import StdlibUnittest
 #if !BRIDGING_HEADER
@@ -14,6 +16,12 @@ import StdSpan
 import CxxStdlib
 
 var StdSpanTestSuite = TestSuite("StdSpan")
+
+// FIXME https://github.com/swiftlang/swift/issues/87260
+// Currently, `Sequence` doesn't conform to `BorrowingSequence`, which means that types like `Range` don't
+// automatically conform to `BorrowingSequence`. When we enable the experimental feature `BorrowingForLoop`,
+// all for-in loops use the new borrowing iterators, which means that all range iterations will be invalid.
+#if !BORROWING_ITERATOR_PROTOCOL
 
 func checkSpan<T: RandomAccessCollection, E: Equatable>(_ s : T, _ arr: [E]) 
                     where T.Index == Int, T.Element == E {
@@ -710,5 +718,63 @@ StdSpanTestSuite.test("Convert between Swift and C++ span types")
     }
   }
 }
+
+StdSpanTestSuite.test("CxxSpan conforms to CxxBorrowingSequence")
+.require(.stdlib_6_4).code {
+  guard #available(SwiftStdlib 6.4, *) else { return }
+
+  let s = initSpan()
+  let arr : [Int32] = [1, 2, 3]
+
+  var iterator = s.makeBorrowingIterator()
+  var counter = 0
+  while true {
+    var span = iterator.nextSpan()
+    if (span.count == 0) { break }
+    for i in 0..<span.count {
+      expectEqual(span[i], arr[counter])
+      counter += 1
+    }
+  }
+  expectEqual(counter, 3)
+}
+
+StdSpanTestSuite.test("CxxSpan of noncopyable conforms to CxxBorrowingSequence")
+.require(.stdlib_6_4).code {
+  guard #available(SwiftStdlib 6.4, *) else { return }
+
+  let s = makeSpanOfNonCopyable()
+  let arr : [Int32] = [1, 2, 3]
+
+  var iterator = s.makeBorrowingIterator()
+  var counter = 0
+  while true {
+    var span = iterator.nextSpan()
+    if (span.count == 0) { break }
+    for i in 0..<span.count {
+      expectEqual(span[i].number, arr[counter])
+      counter += 1
+    }
+  }
+  expectEqual(counter, 3)
+}
+
+#else // !BORROWING_ITERATOR_PROTOCOL
+
+StdSpanTestSuite.test("Borrowing for loop")
+.require(.stdlib_6_4).code {
+  guard #available(SwiftStdlib 6.4, *) else { return }
+
+  let span = makeSpanOfNonCopyable()
+  let arr : [Int32] = [1, 2, 3]
+  var counter = 0
+  for el in span {
+    expectEqual(el.number, arr[counter])
+    counter += 1
+  }
+  expectEqual(counter, 3)
+}
+
+#endif // !BORROWING_ITERATOR_PROTOCOL
 
 runAllTests()

--- a/test/Interop/Cxx/stdlib/use-std-vector-borrowing-iterators.swift
+++ b/test/Interop/Cxx/stdlib/use-std-vector-borrowing-iterators.swift
@@ -9,11 +9,16 @@
 // RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-vector-bridging-header.h -cxx-interoperability-mode=swift-6 -Xcc -std=c++20)
 // RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-vector-bridging-header.h -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20)
 
+// Test iterating through a vector using the borrowing iterators (currently behind a feature flag).
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20 -enable-experimental-feature BorrowingForLoop -DBORROWING_ITERATOR_PROTOCOL)
+// RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-vector-bridging-header.h -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20 -enable-experimental-feature BorrowingForLoop -DBORROWING_ITERATOR_PROTOCOL)
+
 // Ubuntu 20.04 ships with an old version of libstdc++, which does not provide
 // std::contiguous_iterator_tag from C++20.
 // REQUIRES: OS=macosx || OS=windows-msvc
 
 // REQUIRES: executable_test
+// REQUIRES: swift_feature_BorrowingForLoop
 
 import StdlibUnittest
 #if !BRIDGING_HEADER
@@ -22,6 +27,12 @@ import StdVector
 import CxxStdlib
 
 var StdVectorBorrowingIteratorTestSuite = TestSuite("StdVectorBorrowingIterator")
+
+// FIXME https://github.com/swiftlang/swift/issues/87260
+// Currently, `Sequence` doesn't conform to `BorrowingSequence`, which means that types like `Range` don't
+// automatically conform to `BorrowingSequence`. When we enable the experimental feature `BorrowingForLoop`,
+// all for-in loops use the new borrowing iterators, which means that all range iterations will be invalid.
+#if !BORROWING_ITERATOR_PROTOCOL
 
 StdVectorBorrowingIteratorTestSuite.test("VecOfInt has contiguous iterator").require(.stdlib_6_4).code {
     guard #available(SwiftStdlib 6.4, *) else { return }
@@ -53,5 +64,35 @@ StdVectorBorrowingIteratorTestSuite.test("VectorOfNonCopyable has contiguous ite
     }
     expectEqual(counter, 1)
 }
+
+#else // !BORROWING_ITERATOR_PROTOCOL
+
+StdVectorBorrowingIteratorTestSuite.test("VectorOfInt borrowing for loop").require(.stdlib_6_4).code {
+    guard #available(SwiftStdlib 6.4, *) else { return }
+    let arr : [Int32] = [1, 2, 3]
+    let v = Vector(arr)
+    expectEqual(v.size(), arr.count)
+    var counter = 0
+    for el in v {
+        expectEqual(el, arr[counter])
+        counter += 1
+    }
+    expectEqual(counter, 3)
+}
+
+StdVectorBorrowingIteratorTestSuite.test("VectorOfNonCopyable borrowing for loop").require(.stdlib_6_4).code {
+    guard #available(SwiftStdlib 6.4, *) else { return }
+    let v = makeVectorOfNonCopyable()
+    let arr : [Int32] = [1, 2, 3]
+    expectEqual(v.size(), arr.count)
+    var counter = 0
+    for el in v {
+        expectEqual(el.number, arr[counter])
+        counter += 1
+    }
+    expectEqual(counter, 3)
+}
+
+#endif // !BORROWING_ITERATOR_PROTOCOL
 
 runAllTests()


### PR DESCRIPTION
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
