### PR TITLE
[RemoteInspection] Fix building existential type info for marker prot…

### DIFF
--- a/stdlib/public/RemoteInspection/TypeLowering.cpp
+++ b/stdlib/public/RemoteInspection/TypeLowering.cpp
@@ -1228,8 +1228,9 @@ class ExistentialTypeInfoBuilder {
       }
 
       auto FD = TC.getBuilder().getFieldDescriptor(P);
+      // If there is no field descriptor this could be a marker protocol
+      // (Sendable, Copyable, Escapable, etc).
       if (FD == nullptr) {
-        markInvalid("no field descriptor", P);
         continue;
       }
 


### PR DESCRIPTION
…ocols

Marker protocols, such as Sendable, don't have any metadata emitted.