### PR TITLE
RemoteInspection: Add a helper to `BorrowTypeInfo` to get the type representation.

### DIFF
--- a/include/swift/RemoteInspection/TypeLowering.h
+++ b/include/swift/RemoteInspection/TypeLowering.h
@@ -421,6 +421,13 @@ public:
   static bool classof(const TypeInfo *TI) {
     return TI->getKind() == TypeInfoKind::Borrow;
   }
+
+  // True if values of this borrow type contain a bitwise copy of their target
+  // values.
+  // False if values of this borrow type are pointers to their target values.
+  bool usesValueRepresentation() const {
+    return ReferentTI == RepresentationTI;
+  }
 };
 
 /// This class owns the memory for all TypeInfo instances that it vends.


### PR DESCRIPTION
Make it straightforward to check whether a borrow type uses value or pointer representation.