### PR TITLE
[CSRanking] Account for thrown types as part as specialization compar…

### DIFF
--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -18,7 +18,6 @@
 #include "Relation.h"
 #include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/GenericSignature.h"
-#include "swift/AST/ParameterList.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/Basic/Assertions.h"
@@ -735,6 +734,21 @@ bool CompareDeclSpecializationRequest::evaluate(
                      cast<ProtocolDecl>(outerDC1)->getDeclaredInterfaceType(),
                      locator);
     break;
+  }
+
+  // throws vs. typed throws. We are calling decl2 by passing parameters from
+  // decl1 as arguments, decl1 is affectively a context for decl2 call, let's
+  // see if that's well-formed in presence of typed throws.
+  if (isa<AbstractFunctionDecl>(decl1) && isa<AbstractFunctionDecl>(decl2)) {
+    auto thrownError1 =
+        openedType1->castTo<FunctionType>()->getEffectiveThrownErrorType();
+    auto thrownError2 =
+        openedType2->castTo<FunctionType>()->getEffectiveThrownErrorType();
+
+    if (thrownError1 && thrownError2) {
+      cs.addConstraint(ConstraintKind::Subtype, *thrownError2, *thrownError1,
+                       locator);
+    }
   }
 
   bool fewerEffectiveParameters = false;

--- a/test/Sema/typed_throws_witness_matching.swift
+++ b/test/Sema/typed_throws_witness_matching.swift
@@ -1,0 +1,89 @@
+// RUN: %empty-directory(%t/src)
+// RUN: split-file %s %t/src
+
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
+
+/// Build the library A
+// RUN: %target-swift-frontend -emit-module %t/src/A.swift \
+// RUN:   -module-name A -swift-version 6 -enable-library-evolution \
+// RUN:   -enable-upcoming-feature NonisolatedNonsendingByDefault \
+// RUN:   -emit-module-path %t/A.swiftmodule \
+// RUN:   -emit-module-interface-path %t/A.swiftinterface
+
+// RN: %FileCheck %t/src/A.swift --input-file %t/A.swiftinterface
+
+// RUN: %target-swift-typecheck-module-from-interface(%t/A.swiftinterface) -module-name A
+
+// Build the client using module
+// RUN: %target-swift-emit-sil -verify -module-name Client -I %t %t/src/Client.swift | %FileCheck %t/src/Client.swift
+
+// RUN: rm %t/A.swiftmodule
+
+// Re-build the client using interface
+// RN: %target-swift-emit-sil -verify -module-name Client -I %t %t/src/Client.swift | %FileCheck %t/src/Client.swift
+
+//--- A.swift
+public protocol P {
+  func doSomething<T>(_ body: () throws -> T) rethrows -> T
+}
+
+public struct Test {
+}
+
+extension Test: P {
+  public func doSomething<E, R>(_ body: () throws(E) -> R) throws(E) -> R { fatalError() }
+}
+
+public enum MyError: Error {
+}
+
+public struct TestWithConcreteError {
+}
+
+extension TestWithConcreteError: P {
+  public func doSomething<E, R>(_ body: () throws(E) -> R) throws(E) -> R { fatalError() }
+}
+
+//--- Client.swift
+import A
+
+// Check that neither regular `rethrows` nor typed throws declared in the current module create witness ambiguity with a typed throw witness of protocol `P` declared in module `A`
+
+protocol Q {
+  func doSomething<T>(_ body: () throws -> T) rethrows -> T
+}
+
+// protocol witness for Q.doSomething<A>(_:) in conformance Test
+// CHECK-LABEL: sil private [transparent] [thunk] @$s1A4TestV6Client1QA2dEP11doSomethingyqd__qd__yKXEKlFTW
+// CHECK: [[WITNESS:%.*]] = function_ref @$s1A4TestV6ClientE11doSomethingyxxyKXEKlF
+// CHECK: try_apply [[WITNESS]]<τ_0_0>({{.*}})
+// CHECK: } // end sil function '$s1A4TestV6Client1QA2dEP11doSomethingyqd__qd__yKXEKlFTW'
+extension Test: Q {
+  func doSomething<T>(_ body: () throws -> T) rethrows -> T { fatalError() }
+}
+
+protocol W {
+  func doSomething<T, E>(_ body: () throws -> T) throws(E) -> T
+}
+
+// protocol witness for W.doSomething<A, B>(_:) in conformance Test
+// CHECK-LABEL: sil private [transparent] [thunk] @$s1A4TestV6Client1WA2dEP11doSomethingyqd__qd__yKXEqd_0_YKs5ErrorRd_0_r0_lFTW
+// CHECK: [[WITNESS:%.*]] = function_ref @$s1A4TestV6ClientE11doSomethingyxxyKXEq_YKs5ErrorR_r0_lF
+// CHECK: try_apply [[WITNESS]]<τ_0_0, τ_0_1>({{.*}})
+// CHECK: } // end sil function '$s1A4TestV6Client1WA2dEP11doSomethingyqd__qd__yKXEqd_0_YKs5ErrorRd_0_r0_lFTW'
+extension Test: W {
+  func doSomething<T, E>(_ body: () throws -> T) throws(E) -> T { fatalError() }
+}
+
+protocol U {
+  func doSomething<T>(_ body: () throws -> T) throws(MyError) -> T  
+}
+
+// protocol witness for U.doSomething<A>(_:) in conformance TestWithConcreteError
+// CHECK-LABEL: sil private [transparent] [thunk] @$s1A21TestWithConcreteErrorV6Client1UA2dEP11doSomethingyqd__qd__yKXEAA02MyD0OYKlFTW
+// CHECK: [[WITNESS:%.*]] = function_ref @$s1A21TestWithConcreteErrorV6ClientE11doSomethingyxxyKXEAA02MyD0OYKlF
+// CHECK: try_apply [[WITNESS]]<τ_0_0>({{.*}})
+// CHECK: } // end sil function '$s1A21TestWithConcreteErrorV6Client1UA2dEP11doSomethingyqd__qd__yKXEAA02MyD0OYKlFTW'
+extension TestWithConcreteError: U {
+  func doSomething<T>(_ body: () throws -> T) throws(MyError) -> T { fatalError() }
+}


### PR DESCRIPTION
…ison

When comparing two function declarations for specialization ordering, add a subtype constraint between their effective thrown error types. This ensures that a typed-throws witness (e.g. `throws(E) -> R`) is correctly ranked as more specific than a plain-`rethrows` when both are candidates match. This, for example, helps to disambiguate witnesses for a `rethrows` protocol requirement when one is `rethrows` and another adopted typed throws.

Resolves: rdar://171666700

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
