### PR TITLE
[Sema] Clarify sendable cannot inherit diagnostic

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6099,9 +6099,12 @@ ERROR(concurrent_value_outside_source_file,none,
 ERROR(concurrent_value_nonfinal_class,none,
       "non-final class %0 cannot conform to the 'Sendable' protocol", (DeclName))
 ERROR(concurrent_value_inherit,none,
-      "'Sendable' class %1 cannot inherit from another class"
+      "'Sendable' class %1 cannot inherit from a non-Sendable class"
       "%select{| other than 'NSObject'}0",
       (bool, DeclName))
+NOTE(does_not_conform_sendable,none,
+      "%kind0 does not conform to the 'Sendable' protocol",
+      (const ValueDecl *))
 ERROR(non_sendable_type,none,
       "type %0 does not conform to the 'Sendable' protocol", (Type))
 GROUPED_ERROR(non_sendable_metatype_type,SendableMetatypes,none,

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -7394,8 +7394,9 @@ bool swift::checkSendableConformance(
     }
 
     if (!isInherited) {
-      // A 'Sendable' class cannot inherit from another class, although
-      // we allow `NSObject` for Objective-C interoperability.
+      // A 'Sendable' class cannot inherit from another class unless it is
+      // sendable, although we allow `NSObject` for Objective-C
+      // interoperability.
       if (auto superclassDecl = classDecl->getSuperclassDecl()) {
         if (!superclassDecl->isNSObject()) {
           classDecl
@@ -7403,7 +7404,8 @@ bool swift::checkSendableConformance(
                          nominal->getASTContext().LangOpts.EnableObjCInterop,
                          classDecl->getName())
               .limitBehaviorUntilLanguageMode(behavior, LanguageMode::v6);
-
+          superclassDecl->diagnose(diag::does_not_conform_sendable,
+                                   superclassDecl);
           if (behavior == DiagnosticBehavior::Unspecified)
             return true;
         }

--- a/test/Concurrency/sendable_objc_protocol_attr.swift
+++ b/test/Concurrency/sendable_objc_protocol_attr.swift
@@ -66,10 +66,10 @@ protocol Q : Sendable {
 }
 
 do {
-  class A : NSObject {}
+  class A : NSObject {} // expected-note 3 {{class 'A' does not conform to the 'Sendable' protocol}}
 
   final class B : A, P {
-    // expected-warning@-1 {{'Sendable' class 'B' cannot inherit from another class other than 'NSObject'}}
+    // expected-warning@-1 {{'Sendable' class 'B' cannot inherit from a non-Sendable class other than 'NSObject'}}
   }
 
   final class UncheckedB : A, P, @unchecked Sendable { // Ok
@@ -77,7 +77,7 @@ do {
 
   class C : A, MyObjCProtocol {
     // expected-warning@-1 {{non-final class 'C' cannot conform to the 'Sendable' protocol; this is an error in the Swift 6 language mode}}
-    // expected-warning@-2 {{'Sendable' class 'C' cannot inherit from another class other than 'NSObject'}}
+    // expected-warning@-2 {{'Sendable' class 'C' cannot inherit from a non-Sendable class other than 'NSObject'}}
     let test: String = "c"
   }
 
@@ -87,7 +87,7 @@ do {
 
   // A warning until `-swift-version 6`
   final class D : A, Q {
-    // expected-warning@-1 {{'Sendable' class 'D' cannot inherit from another class other than 'NSObject'}}
+    // expected-warning@-1 {{'Sendable' class 'D' cannot inherit from a non-Sendable class other than 'NSObject'}}
   }
 
   final class UncheckedD : A, Q, @unchecked Sendable { // Ok


### PR DESCRIPTION
Fixes rdar://101593470 by adding clarity on exactly what kind of inheritance isn't allowed, and noting where the non-Sendable class being inherited was defined.

```swift
class ClassA {}

final class ClassB : ClassA, Sendable {}
```
```
error: 'Sendable' class 'ClassB' cannot inherit from a non-Sendable class other than 'NSObject'
1 | class ClassA {}
  |       `- note: class 'ClassA' does not conform to the 'Sendable' protocol
2 |
3 | final class ClassB : ClassA, Sendable {}
  |             `- error: 'Sendable' class 'ClassB' cannot inherit from a non-Sendable class other than 'NSObject'
4 |
```
vs `cannot inherit from another class`, which is untrue. While its not easy to make a class that is sendable and can be inherited (since you can't inherit a final class), a class marked `@unchecked Sendable` would be legitimate to extend in a class marked sendable, although you would a warning about "must restate inherited '@unchecked Sendable' conformance".

Besides offering `@unchecked Sendable` as a fix-it, which is probably a bad idea, we could offer isolating to a global actor for implicit isolation, maybe with a placeholder for an actor, although I think that's not super likely to be helpful? My sense is that this would be better served by an error group in the future than a fix-it that leads you to more issues, since extending a sendable class without isolation isn't a very happy path as far as I can tell.