### PR TITLE
[DebugInfo] Emit marker protocol existentials as 'Any' in debug info

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -2724,6 +2724,25 @@ private:
       return DITy;
     }
 
+    // Marker protocols have no runtime representation (no field descriptors).
+    // An existential of only marker protocols (e.g., "any Sendable") has the
+    // same layout as "Any", so emit it as "Any" in debug info.
+    if (auto *ExTy = dyn_cast<ExistentialType>(DbgTy.getType())) {
+      auto Constraint = ExTy->getConstraintType();
+      if (auto *PT = dyn_cast<ProtocolType>(Constraint.getPointer())) {
+        if (PT->getDecl()->isMarkerProtocol()) {
+          CanType AnyTy =
+              IGM.getSILModule().getASTContext().getAnyExistentialType();
+          auto &TI = IGM.getTypeInfoForUnlowered(AnyTy);
+          auto *DITy = getOrCreateType(
+              DebugTypeInfo::getFromTypeInfo(AnyTy, TI, IGM), Scope);
+          // Cache under the original type so subsequent lookups are fast.
+          DITypeCache.insert({DbgTy.getType(), llvm::TrackingMDNodeRef(DITy)});
+          return DITy;
+        }
+      }
+    }
+
     // Use a separate DIRefMap cache for existential typealiases
     // because they have identical mangled names as their inner
     // protocol types and cause conflicts in the cache. For example,


### PR DESCRIPTION
The compiler already strips marker protocols from reflection metadata, since they have no runtime representation (no witness tables or field descriptors). This change does the same in debug info: when an existential type uses only a marker protocol (e.g., "any Sendable"), emit it as "Any" instead, since the layout is identical and there is no DWARF representation for the marker protocol itself.