### PR TITLE
test: adjust CAS tests to be a bit more relaxed

### DIFF
--- a/test/CAS/block-list.swift
+++ b/test/CAS/block-list.swift
@@ -12,9 +12,9 @@
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json A > %t/A.cmd
 // RUN: %FileCheck %s -check-prefix CMD -input-file=%t/A.cmd
 // CMD: -blocklist-file
-// CMD-NEXT: /^tmp{{/|\\}}blocklist.yml
+// CMD-NEXT: {{/|\\}}^tmp{{/|\\}}blocklist.yml
 // CMD-NEXT: -blocklist-file
-// CMD-NEXT: /^tmp{{/|\\}}empty.yml
+// CMD-NEXT: {{/|\\}}^tmp{{/|\\}}empty.yml
 
 // RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json Test casFSRootID > %t/fs.casid
 // DISABLE: llvm-cas --cas %t/cas --ls-tree-recursive @%t/fs.casid | %FileCheck %s -check-prefix FS

--- a/test/CAS/macro_plugin_external.swift
+++ b/test/CAS/macro_plugin_external.swift
@@ -6,8 +6,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/plugins)
 // RUN: split-file %s %t
-//
-//== Build the plugin library
+
+/// Build the plugin library
 // RUN: %host-build-swift \
 // RUN:   -swift-version 5 \
 // RUN:   -emit-library \
@@ -50,7 +50,7 @@
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-include-tree-list @%t/fs.casid | %FileCheck %s --check-prefix=FS-REMAP -DLIB=%target-library-name(MacroDefinition)
 
 /// CASFS is remapped.
-// FS-REMAP: /^test{{/|\\}}plugins{{/|\\}}[[LIB]]
+// FS-REMAP: {{/|\\}}^test{{/|\\}}plugins{{/|\\}}[[LIB]]
 
 // RUN: %{python} %S/../../utils/swift-build-modules.py --cas %t/cas %swift_frontend_plain %t/deps2.json -o %t/MyApp2.cmd
 
@@ -59,7 +59,7 @@
 
 // CMD-REMAP: -resolved-plugin-verification
 // CMD-REMAP-NEXT: -load-resolved-plugin
-// CMD-REMAP-NEXT: /^test{{/|\\}}plugins{{/|\\}}[[LIB]]#/^bin{{/|\\}}swift-plugin-server{{(.exe)?}}#MacroDefinition
+// CMD-REMAP-NEXT: {{/|\\}}^test{{/|\\}}plugins{{/|\\}}[[LIB]]#{{/|\\}}^bin{{/|\\}}swift-plugin-server{{(.exe)?}}#MacroDefinition
 
 // RUN: %target-swift-frontend-plain \
 // RUN:   -emit-module -o %t/Macro.swiftmodule -cache-compile-job -cas-path %t/cas \
@@ -74,7 +74,7 @@
 /// Encoded PLUGIN_SEARCH_OPTION is remapped.
 // RUN: llvm-bcanalyzer -dump %t/Macro.swiftmodule | %FileCheck %s --check-prefix=MOD -DLIB=%target-library-name(MacroDefinition)
 
-// MOD: <PLUGIN_SEARCH_OPTION abbrevid=7 op0=4/> blob data = '/^test{{/|\\}}plugins{{/|\\}}[[LIB]]#/^bin{{/|\\}}swift-plugin-server{{(.exe)?}}#MacroDefinition'
+// MOD: <PLUGIN_SEARCH_OPTION abbrevid=7 op0=4/> blob data = '/^test{{/|\\}}plugins{{/|\\}}[[LIB]]#{{/|\\}}^bin{{/|\\}}swift-plugin-server{{(.exe)?}}#MacroDefinition'
 
 /// Cache hit has no macro-loading remarks because no macro is actually loaded and the path might not be correct due to different mapping.
 // RUN: %target-swift-frontend-plain \


### PR DESCRIPTION
With further refinements to LLVM, we are normalising more aggressively. Be more relaxed about the path separator.