### PR TITLE
[Concurrency] Block exception propagation through swift_job_run.

### DIFF
--- a/include/swift/Runtime/Exception.h
+++ b/include/swift/Runtime/Exception.h
@@ -29,14 +29,24 @@
 namespace swift {
 
 SWIFT_RUNTIME_STDLIB_API _Unwind_Reason_Code
-swift_exceptionPersonality(int version,
-                           _Unwind_Action actions,
-                           uint64_t exceptionClass,
-                           struct _Unwind_Exception *exceptionObject,
-                           struct _Unwind_Context *context);
+_swift_exceptionPersonality(int version,
+                            _Unwind_Action actions,
+                            uint64_t exceptionClass,
+                            struct _Unwind_Exception *exceptionObject,
+                            struct _Unwind_Context *context);
+
+#if __has_attribute(__personality__)
+#define SWIFT_RUNTIME_EXCEPTION_PERSONALITY                                    \
+  __attribute__((__personality__(_swift_exceptionPersonality)))
+#endif
 
 } // end namespace swift
 
-#endif // defined(__ELF__) || defined(__APPLE__)
+#endif
+
+// Make SWIFT_RUNTIME_EXCEPTION_PERSONALITY a no-op when it's not available
+#ifndef SWIFT_RUNTIME_EXCEPTION_PERSONALITY
+#define SWIFT_RUNTIME_EXCEPTION_PERSONALITY
+#endif
 
 #endif // SWIFT_RUNTIME_EXCEPTION_H

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -36,6 +36,7 @@
 #include "swift/Runtime/Casting.h"
 #include "swift/Runtime/DispatchShims.h"
 #include "swift/Runtime/EnvironmentVariables.h"
+#include "swift/Runtime/Exception.h"
 #include "swift/Runtime/Heap.h"
 #include "swift/Threading/Mutex.h"
 #include "swift/Threading/Once.h"
@@ -2206,6 +2207,7 @@ void DefaultActorImpl::releaseLock() {
 #endif
 
 SWIFT_CC(swift)
+SWIFT_RUNTIME_EXCEPTION_PERSONALITY
 static void swift_job_runImpl(Job *job, SerialExecutorRef executor) {
   ExecutorTrackingInfo trackingInfo;
 

--- a/test/Concurrency/Runtime/Inputs/ObjCExceptionHelpers.h
+++ b/test/Concurrency/Runtime/Inputs/ObjCExceptionHelpers.h
@@ -1,0 +1,16 @@
+#import <Foundation/Foundation.h>
+
+static inline id _Nullable CatchingException(void (^_Nonnull block)(void)) {
+  @try {
+    block();
+  } @catch (id e) {
+    return e;
+  }
+  return nil;
+}
+
+static inline void ThrowObjCException(void) {
+  @throw [NSException exceptionWithName:@"test"
+                                 reason:@"I feel like it"
+                               userInfo:nil];
+}

--- a/test/Concurrency/Runtime/objc_exception_in_task.swift
+++ b/test/Concurrency/Runtime/objc_exception_in_task.swift
@@ -1,0 +1,32 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -import-objc-header %S/Inputs/ObjCExceptionHelpers.h %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+// REQUIRES: objc_interop
+
+// UNSUPPORTED: back_deployment_runtime
+
+import Foundation
+import StdlibUnittest
+
+var tests = TestSuite("ObjCExceptionInTask")
+
+tests.test("exception terminates in swift_job_runImpl") {
+  expectCrashLater()
+
+  Task { @MainActor in
+    ThrowObjCException()
+  }
+
+  _ = CatchingException {
+    RunLoop.current.run()
+  }
+
+  expectUnreachable("Exception should not propagate through swift_job_runImpl")
+}
+
+runAllTests()


### PR DESCRIPTION
When an exception is thrown through swift_job_run, it leaves the Concurrency runtime in an inconsistent state, which can lead to misbehavior or crashes later on. It's very difficult to work out what the cause is when this happens. Since the program state is doomed once this happens, prevent exceptions from propagating through swift_job_run at all, and terminate immediately when throwing.

rdar://171909991