### PR TITLE
Fix BorrowingSequence availability check

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9911,7 +9911,7 @@ ConstraintSystem::simplifyForEachElementConstraint(
   auto *seqProto = contextualTy->castTo<ProtocolType>()->getDecl();
   auto isAsync = seqProto->isSpecificProtocol(KnownProtocolKind::AsyncSequence);
   auto isBorrowing =
-      shouldUseBorrowingSequence(ctx, seqTy, isAsync, anchor.getStartLoc());
+      shouldUseBorrowingSequence(ctx, seqTy, isAsync, anchor.getStartLoc(), DC);
 
   if (isBorrowing) {
     seqProto = ctx.getProtocol(KnownProtocolKind::BorrowingSequence);

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -3440,7 +3440,8 @@ FuncDecl *TypeChecker::getForEachIteratorNextFunction(
 }
 
 bool swift::shouldUseBorrowingSequence(ASTContext &ctx, Type seqTy,
-                                       bool isAsync, SourceLoc loc) {
+                                       bool isAsync, SourceLoc loc,
+                                       const DeclContext *dc) {
   if (!ctx.LangOpts.hasFeature(Feature::BorrowingForLoop)) {
     return false;
   }
@@ -3469,9 +3470,8 @@ bool swift::shouldUseBorrowingSequence(ASTContext &ctx, Type seqTy,
     return false;
   }
 
-  if (auto *conformance = seqConformanceRef.getConcrete()) {
+  if (seqConformanceRef.getConcrete()) {
     auto protoAvail = AvailabilityContext::forDeclSignature(borrowingSeqProto);
-    auto *dc = conformance->getDeclContext();
     auto availability = AvailabilityContext::forLocation(loc, dc);
     if (!availability.isContainedIn(protoAvail))
       return false;
@@ -3513,7 +3513,7 @@ public:
       return nullptr;
 
     isBorrowing = shouldUseBorrowingSequence(ctx, seqType, isAsync,
-                                             sequence->getStartLoc());
+                                             sequence->getStartLoc(), dc);
 
     sequenceProto =
         isAsync ? ctx.getProtocol(KnownProtocolKind::AsyncSequence)

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1564,7 +1564,7 @@ void diagnoseMissingImports(SourceFile &sf);
 // protocol should be used, thus enabling Borrowing iteration for a given
 // sequence type.
 bool shouldUseBorrowingSequence(ASTContext &ctx, Type seqTy, bool isAsync,
-                                SourceLoc loc);
+                                SourceLoc loc, const DeclContext *dc);
 
 } // end namespace swift
 

--- a/test/Availability/foreach_borrowing.swift
+++ b/test/Availability/foreach_borrowing.swift
@@ -1,0 +1,87 @@
+// RUN: %target-typecheck-verify-swift \
+// RUN:     -enable-experimental-feature BorrowingForLoop \
+// RUN:     -enable-experimental-feature BorrowingSequence \
+// RUN:     -verify-ignore-unrelated
+
+// REQUIRES: swift_feature_BorrowingForLoop
+// REQUIRES: swift_feature_BorrowingSequence
+// REQUIRES: OS=macosx
+
+// Tests for the availability check in shouldUseBorrowingSequence.
+//
+// BorrowingSequence is @available(SwiftStdlib 6.4, *). When a for-in loop
+// over a BorrowingSequence-conforming type appears in a context whose
+// availability does not cover SwiftStdlib 6.4, the compiler falls back to
+// treating the sequence as a Sequence. If the type does not also conform to
+// Sequence this produces a diagnostic.
+
+// Without @available(SwiftStdlib 6.4, *) on the enclosing function the
+// availability context does not cover SwiftStdlib 6.4.
+// The compiler tries the Sequence path, and because Span<Int> does not conform 
+// to Sequence a diagnostic is emitted.
+func testForLoopOverSpanWithoutAvailability(_ seq: Span<Int>) {
+  for x in seq { // expected-error {{for-in loop requires 'Span<Int>' to conform to 'Sequence'}}
+    _ = x
+  }
+}
+
+// With @available(SwiftStdlib 6.4, *), the availability context covers the
+// protocol, and the loop desugars via the BorrowingSequence path.
+@available(SwiftStdlib 6.4, *)
+func testForLoopOverSpanWithAvailability(_ seq: Span<Int>) {
+  for x in seq {
+    _ = x
+  }
+}
+
+// Inside an if #available(SwiftStdlib 6.4, *) block, the availability context
+// is also sufficient.
+func testForLoopInsideAvailabilityGuard() {
+  let arr: [Int] = [0, 1, 2, 3]
+  if #available(SwiftStdlib 6.4, *) {
+    let seq = arr.span
+    for x in seq {
+      _ = x
+    }
+  }
+}
+
+// A type that unconditionally conforms to Sequence but whose BorrowingSequence
+// conformance is only available under SwiftStdlib 6.4. In a context without
+// that availability, the BorrowingSequence conformance is unavailable.
+// The loop uses Sequence.
+struct BorrowingFallbackWithSequence: Sequence {
+  typealias Element = Int
+  func makeIterator() -> IndexingIterator<[Int]> { return [].makeIterator() }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension BorrowingFallbackWithSequence: BorrowingSequence {
+  typealias BorrowingIterator = BorrowingIteratorAdapter<IndexingIterator<[Int]>>
+}
+
+func testInvalidBorrowingWithSequence(seq: BorrowingFallbackWithSequence) {
+  for x in seq {
+    _ = x
+  }
+}
+
+// A type whose only sequence conformance is BorrowingSequence, available under
+// SwiftStdlib 6.4. In a context without that availability, the compiler falls
+// back to Sequence, finds no conformance, and emits a diagnostic.
+struct BorrowingFallbackNoSequence {}
+
+@available(SwiftStdlib 6.4, *)
+extension BorrowingFallbackNoSequence: BorrowingSequence {
+  typealias Element = Int
+  typealias BorrowingIterator = BorrowingIteratorAdapter<IndexingIterator<[Int]>>
+  func makeBorrowingIterator() -> BorrowingIteratorAdapter<IndexingIterator<[Int]>> {
+    BorrowingIteratorAdapter(iterator: [1, 2, 3].makeIterator())
+  }
+}
+
+func testInvalidBorrowingNoSequence(seq: BorrowingFallbackNoSequence) {
+  for x in seq { // expected-error {{for-in loop requires 'BorrowingFallbackNoSequence' to conform to 'Sequence'}}
+    _ = x
+  }
+}

--- a/test/SILGen/foreach_borrowing.swift
+++ b/test/SILGen/foreach_borrowing.swift
@@ -1,9 +1,11 @@
 // RUN: %target-swift-emit-silgen -Xllvm -sil-print-types \
 // RUN:     -g -Xllvm -sil-print-debuginfo-verbose \
 // RUN:     -enable-experimental-feature BorrowingForLoop \
+// RUN:     -enable-experimental-feature BorrowingSequence \
 // RUN:     %s | %FileCheck %s
 
 // REQUIRES: swift_feature_BorrowingForLoop
+// REQUIRES: swift_feature_BorrowingSequence
 
 struct NoncopyableInt: ~Copyable {
   var value: Int
@@ -186,3 +188,56 @@ func testForEachNonCopyableSILDebugInfo(seq: borrowing Span<NoncopyableInt>){
       }
   }
 }
+
+// A struct conforming to both Sequence and BorrowingSequence. The default
+// makeBorrowingIterator() is provided by the Sequence where Self: BorrowingSequence
+// extension in BorrowingSequence.swift.
+@available(SwiftStdlib 6.4, *)
+struct DualSeq: Sequence, BorrowingSequence {
+  typealias Element = Int
+  typealias BorrowingIterator = BorrowingIteratorAdapter<IndexingIterator<[Int]>>
+
+  func makeIterator() -> IndexingIterator<[Int]> {
+    return [1, 2, 3].makeIterator()
+  }
+}
+
+// CHECK-LABEL: sil hidden {{.*}}[ossa] @$s17foreach_borrowing34testSequencePreferredOverBorrowing3seqyAA7DualSeqV_tF : $@convention(thin) (DualSeq) -> () {
+@available(SwiftStdlib 6.4, *)
+func testSequencePreferredOverBorrowing(seq: borrowing DualSeq) {
+  // DualSeq conforms to Sequence, so shouldUseBorrowingSequence returns false.
+  // CHECK: = function_ref @$s17foreach_borrowing7DualSeqV12makeIterators08IndexingF0VySaySiGGyF : $@convention(method) (DualSeq) -> @owned IndexingIterator<Array<Int>>
+  // CHECK: } // end sil function '$s17foreach_borrowing34testSequencePreferredOverBorrowing3seqyAA7DualSeqV_tF'
+  for element in seq {
+    print(element)
+  }
+}
+
+// A type that unconditionally conforms to Sequence but whose BorrowingSequence
+// conformance is only available under SwiftStdlib 6.4. When a for-in loop over
+// this type appears in a context without that availability,
+// shouldUseBorrowingSequence returns false at the Sequence check, and the loop
+// desugars via the Sequence path (makeIterator), not the BorrowingSequence path.
+struct BorrowingFallbackWithSequence: Sequence {
+  typealias Element = Int
+  func makeIterator() -> IndexingIterator<[Int]> {
+    return [1, 2, 3].makeIterator()
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension BorrowingFallbackWithSequence: BorrowingSequence {
+  typealias BorrowingIterator = BorrowingIteratorAdapter<IndexingIterator<[Int]>>
+}
+
+// CHECK-LABEL: sil hidden {{.*}}[ossa] @$s17foreach_borrowing36testUnavailableBorrowingWithSequence3seqyAA0e8FallbackfG0V_tF : $@convention(thin) (BorrowingFallbackWithSequence) -> () {
+func testUnavailableBorrowingWithSequence(seq: BorrowingFallbackWithSequence) {
+  // BorrowingFallbackWithSequence conforms to Sequence, so
+  // shouldUseBorrowingSequence returns false and makeIterator() is called.
+  // CHECK: = function_ref @$s17foreach_borrowing29BorrowingFallbackWithSequenceV12makeIterators08IndexingH0VySaySiGGyF : $@convention(method) (BorrowingFallbackWithSequence) -> @owned IndexingIterator<Array<Int>>
+  // CHECK: } // end sil function '$s17foreach_borrowing36testUnavailableBorrowingWithSequence3seqyAA0e8FallbackfG0V_tF'
+  for element in seq {
+    _ = element
+  }
+}
+

--- a/test/Sema/foreach_borrowing.swift
+++ b/test/Sema/foreach_borrowing.swift
@@ -1,0 +1,57 @@
+// RUN: %target-typecheck-verify-swift \
+// RUN:     -enable-experimental-feature BorrowingForLoop \
+// RUN:     -enable-experimental-feature BorrowingSequence \
+// RUN:     -verify-ignore-unrelated
+
+// REQUIRES: swift_feature_BorrowingForLoop
+// REQUIRES: swift_feature_BorrowingSequence
+
+@available(SwiftStdlib 6.4, *)
+struct DualConformanceSeq: Sequence, BorrowingSequence {
+  typealias Element = Int
+  typealias BorrowingIterator = BorrowingIteratorAdapter<IndexingIterator<[Int]>>
+  func makeIterator() -> IndexingIterator<[Int]> { return [].makeIterator() }
+}
+
+@available(SwiftStdlib 6.4, *)
+func testSequencePreferredOverBorrowingSequence(seq: DualConformanceSeq) {
+  for x in seq {
+    _ = x
+  }
+}
+
+// A BorrowingSequence conformance that is incomplete because the declared
+// BorrowingIterator type does not conform to BorrowingIteratorProtocol.
+// The type also conforms to Sequence.
+@available(SwiftStdlib 6.4, *)
+struct IncompleteBorrowingWithSequence: Sequence, BorrowingSequence { // expected-error {{type 'IncompleteBorrowingWithSequence' does not conform to protocol 'BorrowingSequence'}} expected-note {{add stubs for conformance}}
+  typealias Element = Int
+  typealias BorrowingIterator = Int // expected-note {{possibly intended match 'IncompleteBorrowingWithSequence.BorrowingIterator' (aka 'Int') does not conform to 'BorrowingIteratorProtocol'}}
+  func makeIterator() -> IndexingIterator<[Int]> { return [].makeIterator() }
+}
+
+@available(SwiftStdlib 6.4, *)
+func testIncompleteBorrowingWithSequence(seq: IncompleteBorrowingWithSequence) {
+  for x in seq {
+    _ = x
+  }
+}
+
+// A BorrowingSequence conformance that is incomplete because a required member
+// (makeBorrowingIterator) is not provided. The type has no Sequence
+// conformance. Because the conformance is still registered, the compiler
+// attempts the BorrowingSequence desugar path, and fails to infer the element
+// type from the incomplete conformance.
+@available(SwiftStdlib 6.4, *)
+struct IncompleteBorrowingNoSequence: BorrowingSequence { // expected-error {{type 'IncompleteBorrowingNoSequence' does not conform to protocol 'BorrowingSequence'}} expected-note {{add stubs for conformance}}
+  typealias Element = Int
+  typealias BorrowingIterator = SpanIterator<Int>
+  // makeBorrowingIterator() intentionally omitted
+}
+
+@available(SwiftStdlib 6.4, *)
+func testIncompleteBorrowingNoSequence(seq: IncompleteBorrowingNoSequence) {
+  for x in seq { // expected-error {{generic parameter 'Element' could not be inferred}}
+    _ = x
+  }
+}


### PR DESCRIPTION
Follow up to https://github.com/swiftlang/swift/pull/87308.

Resolves rdar://165954597.