### PR TITLE
Reparenting: disallow overriding by inheritees

### DIFF
--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -915,9 +915,15 @@ OverrideMatcher::OverrideMatcher(ValueDecl *decl, bool ignoreMissingImports)
     if (auto superclassDecl = classDecl->getSuperclassDecl())
       superContexts.push_back(superclassDecl);
   } else if (auto protocol = dyn_cast<ProtocolDecl>(dc)) {
-    auto inheritedProtocols = protocol->getInheritedProtocols();
-    superContexts.insert(superContexts.end(), inheritedProtocols.begin(),
-                         inheritedProtocols.end());
+    for (auto inherited : protocol->getInheritedProtocols()) {
+      // Reparentable protocol members are never overridden by any members of
+      // protocols inheriting from it. This preserves the witness tables of
+      // those inheriting protocols.
+      if (inherited->getAttrs().hasAttribute<ReparentableAttr>())
+        continue;
+
+      superContexts.push_back(inherited);
+    }
   }
 }
 

--- a/test/Sema/reparenting.swift
+++ b/test/Sema/reparenting.swift
@@ -88,3 +88,12 @@ protocol MultiReparenting2: R, Q {}
 extension MultiReparenting2: @reparented R {} // expected-note {{previously '@reparented' by 'R' here}}
 extension MultiReparenting2: @reparented Q {}
 extension MultiReparenting2: @reparented R {} // expected-error {{cannot have multiple declarations of 'MultiReparenting2' being '@reparented' by 'R'}}
+
+
+@reparentable
+protocol Turtle {
+  func hello()
+}
+protocol LilTurtle: Turtle {
+  override func hello() // expected-error {{method does not override any method from its parent protocol}}
+}

--- a/validation-test/Evolution/Inputs/protocol_add_reparented.swift
+++ b/validation-test/Evolution/Inputs/protocol_add_reparented.swift
@@ -10,6 +10,7 @@ public func libraryVersion() -> Int {
 
 public protocol Bird {
   func eat(_ food: Int) -> Int
+  func containsChirps() -> Bool
 }
 
 #else
@@ -21,10 +22,16 @@ public protocol SeedEater {
   associatedtype Kind: AsInt
 
   var seedKinds: Kind { get }
+  func containsChirps() -> Bool
+}
+
+extension SeedEater {
+  public func containsChirps() -> Bool { return false }
 }
 
 public protocol Bird: SeedEater {
   func eat(_ food: Int) -> Int
+  func containsChirps() -> Bool
 }
 
 extension Bird : @reparented SeedEater where Kind == Int {
@@ -45,11 +52,18 @@ extension Int: AsInt {
 
 #endif
 
+extension Bird {
+  public func containsChirps() -> Bool { return true }
+}
+
 public struct SomeType {
   public static func feed(_ b: some Bird, _ clientVersion: Int) -> Int {
+  precondition(b.containsChirps())
+
   #if BEFORE
     return b.eat(clientVersion)
   #else
+    precondition(asBase(b).containsChirps())
     let ans1 = asBase(b).eatSeed(clientVersion)
     let ans2 = feedAsBase_Param(b, clientVersion)
     precondition(ans1 == ans2)
@@ -78,9 +92,12 @@ public struct SomeType {
 
 public struct ExistentialType {
   public static func feed(_ b: any Bird, _ clientVersion: Int) -> Int {
+  precondition(b.containsChirps())
+
   #if BEFORE
     return b.eat(clientVersion)
   #else
+    precondition(asExtBase(b).containsChirps())
     return asExtBase(b).eatSeed(clientVersion)
   #endif
   }
@@ -98,4 +115,8 @@ public struct ExistentialType {
   #endif
 }
 
-
+#if !BEFORE
+public func willChirp(_ e: some SeedEater) -> Bool {
+  return e.containsChirps()
+}
+#endif

--- a/validation-test/Evolution/Inputs/protocol_add_reparented_seq.swift
+++ b/validation-test/Evolution/Inputs/protocol_add_reparented_seq.swift
@@ -29,6 +29,9 @@ public protocol Seq<Element> {
   associatedtype Element
   associatedtype Iterator: Iterable
   func makeIterator() -> Iterator
+
+  var underestimatedCount: Int { get }
+  func _customContainsEquality(_ e: Element) -> Bool?
 }
 #else
 public protocol Seq<Element>: BorrowingSeq {
@@ -37,6 +40,9 @@ public protocol Seq<Element>: BorrowingSeq {
   func makeIterator() -> Iterator
 
   associatedtype BorrowingSeqIter: BorrowingIter<Element>, ~Copyable, ~Escapable = Adapter<Iterator>
+
+  var underestimatedCount: Int { get }
+  func _customContainsEquality(_ e: Element) -> Bool?
 }
 
 @reparentable
@@ -46,6 +52,14 @@ public protocol BorrowingSeq<Element>: ~Copyable, ~Escapable {
 
   @_lifetime(borrow self)
   func makeBorrowingSeqIter() -> BorrowingSeqIter
+
+  var underestimatedCount: Int { get }
+  func _customContainsEquality(_ e: borrowing Element) -> Bool?
+}
+
+extension BorrowingSeq {
+  public var underestimatedCount: Int { 1 }
+  public func _customContainsEquality(_ e: borrowing Element) -> Bool? { nil }
 }
 
 extension Seq : @reparented BorrowingSeq
@@ -81,9 +95,15 @@ extension LibraryConformer {
 }
 #endif
 
+extension Seq {
+  public var underestimatedCount: Int { 0 }
+  public func _customContainsEquality(_ e: Element) -> Bool? { nil }
+}
+
 public func libraryTest(_ x: some Seq) {
   var iter = x.makeIterator()
   print(iter.next()!)
+  print("underestimatedCount = \(x.underestimatedCount)")
 #if !BEFORE
   libraryTestNew(x)
 #endif
@@ -94,5 +114,6 @@ public func libraryTestNew(_ x: some BorrowingSeq) {
   var borrowingIter = x.makeBorrowingSeqIter()
   let answer = borrowingIter.nextThing()!
   print(answer)
+  print("underestimatedCount = \(x.underestimatedCount)")
 }
 #endif

--- a/validation-test/Evolution/test_protocol_add_reparented.swift
+++ b/validation-test/Evolution/test_protocol_add_reparented.swift
@@ -51,6 +51,15 @@ struct Plus100Eagle: Bird {
   }
 }
 
+// A non-bird seed eater. Relies on the default implementation for containsChirps.
+struct Human: SeedEater {
+  public func eatSeed(_ food: Int) -> Int { 0 }
+  public typealias Kind = UInt
+  public var seedKinds: UInt {
+    get { 0 }
+  }
+}
+
 extension UInt: @retroactive AsInt {
   public func asInt() -> Int { return Int(self) }
 }
@@ -76,6 +85,11 @@ ProtocolAddReparentedTest.test("Some Types") {
     let 💯 = Plus100Eagle()
     expectEqual(SomeType.feed(💯, clientVersion), base + 100)
     expectEqual(SomeType.count(💯, clientVersion), base + 100)
+  }
+
+  do {
+    expectEqual(willChirp(Human()), false)
+    expectEqual(willChirp(Plus100Eagle()), true)
   }
   #endif
 }


### PR DESCRIPTION
If an inheriting protocol IP declares a requirement that exactly matches one in the reparentable protocol P, we cannot consider it to be an override. They need to have independent witness table entries in both IP and P.

Otherwise, reparenting IP would cause those overriding decls to have witness table entries moved from IP to P, causing an ABI break.

resolves rdar://171928937
