### PR TITLE
SIL: Lower typed error as untyped `any Error` in untyped throwing abstraction contexts.

### DIFF
--- a/include/swift/SIL/AbstractionPattern.h
+++ b/include/swift/SIL/AbstractionPattern.h
@@ -1633,7 +1633,7 @@ public:
   /// it.
   AbstractionPattern getReferenceStorageReferentType() const;
 
-  /// Give that the value being abstracted is an existential, return the
+  /// Given that the value being abstracted is an existential, return the
   /// underlying constraint type.
   AbstractionPattern getExistentialConstraintType() const;
 

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -2887,6 +2887,16 @@ static CanSILFunctionType getSILFunctionType(
 
     auto origErrorType = optPair->first;
     auto errorType = optPair->second;
+
+    // If the abstraction pattern asks for an existential error, that becomes
+    // the return type of the abstracted function. Any concrete error type
+    // thrown by the concrete function will be type erased.
+    if (!origErrorType.isTypeParameterOrOpaqueArchetype()
+        && !origErrorType.isTuple()
+        && origErrorType.getType()->isExistentialType()) {
+      errorType = origErrorType.getType();
+    }
+    
     auto &errorTLConv = TC.getTypeLowering(origErrorType, errorType,
                                            TypeExpansionContext::minimal());
 

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -329,6 +329,8 @@ namespace {
 
     RetTy visit(CanType substType, AbstractionPattern origType,
                 IsTypeExpansionSensitive_t isSensitive) {
+      // A variadic tuple substituted with exactly one element in the expansion
+      // becomes the scalar type.
       if (auto origEltType = origType.getVanishingTupleElementPatternType()) {
         return visit(substType, *origEltType, isSensitive);
       }

--- a/test/SILGen/typed_throws_closure_untyped_throws_abstraction_pattern.swift
+++ b/test/SILGen/typed_throws_closure_untyped_throws_abstraction_pattern.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+public enum MyError: Error {
+	case myError
+}
+
+func assignTypedThrowsClosureInUntypedContext() {
+	var callback: (() throws(Error) -> ())?
+	// Even though the closure literal here throws a concrete error type,
+	// since we are assigning it directly to a function type context throwing
+	// untyped `Error`, we peephole away the conversion to avoid a thunk and
+	// emit the closure literal as throwing untyped `Error`.
+	// CHECK-LABEL: sil {{.*}}@$s{{.*}}assignTypedThrowsClosureInUntypedContext{{.*}}7MyErrorOYKcfU_ :
+	// CHECK-SAME:    -> @error any Error
+	// CHECK:         [[CONCRETE_ERROR_BUF:%.*]] = alloc_stack $MyError
+	// CHECK:         [[CONCRETE_ERROR:%.*]] = load [trivial] [[CONCRETE_ERROR_BUF]]
+	// CHECK:         [[ABSTRACT_ERROR:%.*]] = alloc_existential_box
+	// CHECK:         [[ABSTRACT_ERROR_PAYLOAD:%.*]] = project_existential_box $MyError in [[ABSTRACT_ERROR]]
+	// CHECK:         store [[ABSTRACT_ERROR]] to [init] [[ABSTRACT_ERROR_BUF:%[0-9]+]]
+	// CHECK:         store [[CONCRETE_ERROR]] to [trivial] [[ABSTRACT_ERROR_PAYLOAD]]
+	// CHECK:         [[ERROR_TO_THROW:%.*]] = load [take] [[ABSTRACT_ERROR_BUF]]
+	// CHECK:         throw [[ERROR_TO_THROW]]
+	callback = {() throws(MyError) in
+			throw .myError
+	}
+}
+


### PR DESCRIPTION
Other parts of SILGen were set up to deal with this situation, where for example a closure literal with a concrete error type is used in a type context that wants an untyped `throws` function, avoiding the thunk by lowering the closure literal directly as the context type with an untyped error. However, SILFunctionType lowering itself did not account for this situation, leading to a type mismatch in SILGen where the body would be emitted with an untyped error but the function would still be declared with a type error. Fix this oversight, addressing rdar://171121086.
