### PR TITLE
Disable Interpreter/bitwise_borrowable_layout.swift back-deployment

### DIFF
--- a/test/Interpreter/bitwise_borrowable_layout.swift
+++ b/test/Interpreter/bitwise_borrowable_layout.swift
@@ -16,6 +16,7 @@
 // REQUIRES: swift_feature_RawLayout
 // REQUIRES: swift_feature_AddressableTypes
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
 
 import BitwiseBorrowableLayoutResilientTypes
 


### PR DESCRIPTION
This test never passed on-device testing. I suspect it's because the test was never intended to back-deploy. Most runtime layout don't.

Fixes rdar://169663198 (Swift CI: test: Interpreter/bitwise_borrowable_layout.swift (exit code 2))
