### PR TITLE
[UVT] support -verify-ignore-unrelated

### DIFF
--- a/test/Utils/update-verify-tests/diagnostic-produced-elsewhere.swift
+++ b/test/Utils/update-verify-tests/diagnostic-produced-elsewhere.swift
@@ -1,0 +1,27 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: not %target-swift-frontend -typecheck -import-bridging-header %t/test.h -verify -verify-ignore-unrelated %t/test.swift 2> %t/output.txt
+// RUN: %update-verify-tests < %t/output.txt
+// RUN: %diff %t/test.swift %t/test.swift.expected
+// RUN: %target-swift-frontend -typecheck -import-bridging-header %t/test.h -verify -verify-ignore-unrelated %t/test.swift
+// RUN: not %target-swift-frontend -typecheck -import-bridging-header %t/test.h -verify %t/test.swift
+
+//--- test.h
+static inline int bar() {
+  return 0/0;
+}
+
+//--- test.swift
+func foo() {
+  a = 2
+  let b = bar()
+}
+
+//--- test.swift.expected
+func foo() {
+  // expected-error@+1{{cannot find 'a' in scope}}
+  a = 2
+  let b = bar()
+}
+

--- a/utils/update_verify_tests/core.py
+++ b/utils/update_verify_tests/core.py
@@ -679,6 +679,19 @@ diag_not_parsed_note_re = re.compile(
     r"(\S+):(\d+):(\d+): note: file '(\S+)' is not parsed for 'expected' statements"
 )
 
+"""
+ex:
+/path/to/sdk/file.h:19:29: remark: diagnostic produced elsewhere: did not add safe interop wrapper
+struct _LIBCPP_TEMPLATE_VIS input_iterator_tag {};
+                            ^
+/path/to/sdk/file.h:19:29: note: diagnostic produced elsewhere: implicit functions are ignored
+struct _LIBCPP_TEMPLATE_VIS input_iterator_tag {};
+                            ^
+"""
+diag_produced_elsewhere_re = re.compile(
+    r"(\S+):(\d+):(\d+): (?:note|remark|warning): diagnostic produced elsewhere: (.*)"
+)
+
 
 class NotFoundDiag:
     def __init__(self, file, line, col, category, content, prefix):
@@ -739,7 +752,12 @@ def check_expectations(tool_output, prefix):
 
             curr = []
             dprint(f"line: {line.strip()}")
-            if not "error:" in line:
+            if diag_produced_elsewhere_re.match(line.strip()):
+                dprint(
+                    f"diagnostic produced elsewhere (ignored): {line.strip()}"
+                )
+                extra_lines = tool_output[i + 1 : i + 3]
+            elif not "error:" in line:
                 if "note:" in line:
                     if m := diag_not_parsed_note_re.match(line.strip()):
                         dprint(f"unparsed file: {m.group(4)}")


### PR DESCRIPTION
swift-frontend -verify -verify-ignore-unrelated does not expect matchers for files in unchecked files, but it still emits diagnostic output like this:
```
/path/to/sdk/file.h:19:29: remark: diagnostic produced elsewhere: did not add safe interop wrapper
struct _LIBCPP_TEMPLATE_VIS input_iterator_tag {};
```

update-verify-tests errors on unexpected input to ensure nothing is accidentally missed. This adds the pattern above to the set of expected inputs.