### PR TITLE
[ClangImporter] add -Rclang-importer

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -445,5 +445,33 @@ REMARK(yes_safe_wrapper, none, "added safe interop wrapper", ())
 
 REMARK(no_safe_wrapper, none, "did not add safe interop wrapper", ())
 
+NOTE(safe_interop_disabled, none, "due to -disable-safe-interop-wrappers", ())
+NOTE(unsupported_function_kind, none, "unsupported function kind %0", (StringRef))
+NOTE(swiftify_macro_not_found, none, "@_SwiftifyImport macro not available", ())
+NOTE(no_safe_wrapper_attr, none, "function is annotated with swift_attr(\"no_safe_wrapper\")", ())
+NOTE(forward_declared_concrete_type, none, "clang function signature refers to concrete type without importing owning module", ())
+NOTE(clang_module_owner, none, "%0 is in module %1", (const clang::NamedDecl*,StringRef))
+NOTE(cf_ref_initializer, none, "Swift cannot define initializer for CoreFoundation style reference type", (Type))
+NOTE(ignoring_implicit_func, none, "implicit functions are ignored", ())
+NOTE(ignoring_non_public_func, none, "member function %0 is not public", (const Decl *))
+NOTE(module_without_stdlib, none, "module %0 does not import the Swift module", (StringRef))
+NOTE(ignoring_template_in_signature, none, "template specialization cannot be represented in Swift syntax; try hiding it behind a typedef", ())
+NOTE(mismatching_parameter_count, none, "the imported Swift signature and the clang function signature have mismatching parameter counts (%0 vs %1)", (unsigned, unsigned))
+NOTE(ignoring_lifetimebound, none, "lifetimebound support is not yet stabilized", ())
+NOTE(ignoring_nonescapable_return_without_lifetime, none, "function without lifetime information returns ~Escapable type %0", (Type))
+NOTE(no_bounds_or_lifetime, none, "no bounds or lifetime information found", ())
+
+REMARK(ignoring_counted_by, none, "ignoring %0 attribute", (StringRef))
+NOTE(non_portable_int_literal, none, "count parameter contains integer literal not supported in Swift syntax", ())
+NOTE(unknown_count_expr, none, "count parameter contains unsupported expression kind %0", (StringRef))
+NOTE(sized_by_on_non_pointer, none, "__sized_by attribute not on pointer type", ())
+NOTE(sized_by_on_autorelease, none, "__sized_by attribute on autoreleasing pointer", ())
+NOTE(sized_by_on_non_bytesized, none, "__sized_by attribute on pointer to type larger than a single byte", ())
+NOTE(type_has_size, none, "type %0 has size %1", (const clang::Type*, unsigned))
+NOTE(counted_by_incompatible_type, none, "__counted_by attribute not on pointer with known pointee size", ())
+
+REMARK(ignoring_lifetimebound_escapable_return, none, "ignoring lifetimebound attribute because return value is Escapable", ())
+REMARK(ignoring_lifetimebound_on_frt, none, "ignoring lifetimebound attribute on reference counted parameter", ())
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -437,5 +437,13 @@ ERROR(repeating_swift_attrs, none, "multiple %0 annotations found on %1",
 
 NOTE(annotation_here, none, "%0 annotation found here", (StringRef))
 
+//------------------------------------------------------------------------------
+// MARK: ClangImporter remark diagnostics
+//------------------------------------------------------------------------------
+
+REMARK(yes_safe_wrapper, none, "added safe interop wrapper", ())
+
+REMARK(no_safe_wrapper, none, "did not add safe interop wrapper", ())
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -648,6 +648,9 @@ namespace swift {
     /// Emits a remark with the content of each macro expansion line, for matching with -verify
     bool RemarkMacroExpansions = false;
 
+    /// Emits a remark with diagnosis for all imported functions without safe interop wrappers.
+    bool RemarkClangImporter = false;
+
     /// Enables dumping imports for each SourceFile.
     bool DumpSourceFileImports = false;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -193,6 +193,9 @@ def verify_generic_signatures : Separate<["-"], "verify-generic-signatures">,
 def expansion_remarks:  Flag<["-"], "Rmacro-expansions">,
   HelpText<"Show remarks for each line in macro expansions">;
 
+def clang_importer_remarks:  Flag<["-"], "Rclang-importer">,
+  HelpText<"Emit remarks on decisions taking while importing clang nodes">;
+
 def show_diagnostics_after_fatal : Flag<["-"], "show-diagnostics-after-fatal">,
   HelpText<"Keep emitting subsequent diagnostics after a fatal error">;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -194,7 +194,7 @@ def expansion_remarks:  Flag<["-"], "Rmacro-expansions">,
   HelpText<"Show remarks for each line in macro expansions">;
 
 def clang_importer_remarks:  Flag<["-"], "Rclang-importer">,
-  HelpText<"Emit remarks on decisions taking while importing clang nodes">;
+  HelpText<"Emit remarks on decisions taken while importing clang nodes">;
 
 def show_diagnostics_after_fatal : Flag<["-"], "show-diagnostics-after-fatal">,
   HelpText<"Keep emitting subsequent diagnostics after a fatal error">;

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -731,16 +731,21 @@ static bool diagnoseMissingMacroPlugin(ASTContext &SwiftContext,
 }
 
 void ClangImporter::Implementation::swiftify(AbstractFunctionDecl *MappedDecl) {
+  auto emitRemark = [this,MappedDecl]() {
+    if (SwiftContext.LangOpts.RemarkClangImporter)
+      diagnose(MappedDecl->getNameLoc(), diag::no_safe_wrapper);
+  };
+
   if (SwiftContext.LangOpts.DisableSafeInteropWrappers)
-    return;
+    return emitRemark();
   auto ClangDecl = dyn_cast_or_null<clang::FunctionDecl>(MappedDecl->getClangDecl());
   if (!ClangDecl)
-    return;
+    return emitRemark();
 
   MacroDecl *SwiftifyImportDecl = dyn_cast_or_null<MacroDecl>(getKnownSingleDecl(SwiftContext, "_SwiftifyImport"));
   if (!SwiftifyImportDecl) {
     DLOG("_SwiftifyImport macro not found\n");
-    return;
+    return emitRemark();
   }
 
   llvm::SmallString<128> MacroString;
@@ -753,7 +758,7 @@ void ClangImporter::Implementation::swiftify(AbstractFunctionDecl *MappedDecl) {
                                         *SwiftifyImportDecl, typeMapping);
     if (!swiftifyImpl(*this, printer, MappedDecl, ClangDecl)) {
       DLOG("No relevant bounds or lifetime info found\n");
-      return;
+      return emitRemark();
     }
     printer.printAvailability();
     printer.printTypeMapping();
@@ -761,9 +766,11 @@ void ClangImporter::Implementation::swiftify(AbstractFunctionDecl *MappedDecl) {
   }
 
   if (diagnoseMissingMacroPlugin(SwiftContext, "_SwiftifyImport", MappedDecl))
-    return;
+    return emitRemark();
 
   DLOG("Attaching safe interop macro: " << MacroString << "\n");
+  if (SwiftContext.LangOpts.RemarkClangImporter)
+    diagnose(MappedDecl->getNameLoc(), diag::yes_safe_wrapper);
   if (clang::RawComment *raw =
           getClangASTContext().getRawCommentForDeclNoCache(ClangDecl)) {
     // swift::RawDocCommentAttr doesn't contain its text directly, but instead

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -18,6 +18,7 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/DiagnosticsClangImporter.h"
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/Import.h"
@@ -26,7 +27,10 @@
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/TypeWalker.h"
 #include "swift/Basic/Defer.h"
+#include "swift/Basic/SourceLoc.h"
+#include "swift/ClangImporter/ClangImporter.h"
 #include "swift/ClangImporter/ClangImporterRequests.h"
+#include "swift/Strings.h"
 
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Attr.h"
@@ -37,6 +41,9 @@
 #include "clang/AST/StmtVisitor.h"
 #include "clang/AST/Type.h"
 #include "clang/Basic/Module.h"
+#include "clang/Basic/SourceLocation.h"
+#include <optional>
+#include <utility>
 
 using namespace swift;
 using namespace importer;
@@ -80,6 +87,51 @@ ValueDecl *getKnownSingleDecl(ASTContext &SwiftContext, StringRef DeclName) {
   if (decls.size() != 1) return nullptr;
   return decls[0];
 }
+
+class TentativeFailureRemark {
+  ClangImporter::Implementation &Impl;
+  Diagnostic failureRemark;
+  bool aborted;
+
+public:
+  explicit TentativeFailureRemark(ClangImporter::Implementation &Impl, SourceLoc loc, bool active)
+      : Impl(Impl), failureRemark(diag::no_safe_wrapper), aborted(!active) {
+    failureRemark.setLoc(loc);
+  }
+
+  void addNote(SourceLoc loc, Diagnostic &&note) {
+    if (!aborted) {
+      if (loc.isValid())
+        note.setLoc(loc);
+      else
+        // All notes have the right to a SourceLoc. If you do not have a
+        // SourceLoc of your own, one will be appointed for you.
+        note.setLoc(failureRemark.getLoc());
+      failureRemark.addChildNote(std::move(note));
+    }
+  }
+  void addNote(clang::SourceLocation loc, Diagnostic &&note) {
+    if (!aborted) {
+      note.setLoc(Impl.importSourceLoc(loc));
+      failureRemark.addChildNote(std::move(note));
+    }
+  }
+  template<typename L, typename ...ArgTypes>
+  void 
+  addNote(L Loc, Diag<ArgTypes...> ID,
+           typename detail::PassArgument<ArgTypes>::type... Args) {
+    return addNote(Loc, Diagnostic(ID, std::move(Args)...));
+  }
+
+  bool enabled() { return !aborted; }
+  void abort() { aborted = true; }
+
+  ~TentativeFailureRemark() {
+    if (!aborted) {
+      Impl.diagnose(failureRemark.getLoc(), failureRemark);
+    }
+  }
+};
 
 struct SwiftifyInfoPrinter {
   static const ssize_t SELF_PARAM_INDEX = -2;
@@ -220,6 +272,12 @@ private:
 
 struct CountedByExpressionValidator
     : clang::ConstStmtVisitor<CountedByExpressionValidator, bool> {
+  ClangImporter::Implementation &Impl;
+  bool diagnose;
+
+  CountedByExpressionValidator(ClangImporter::Implementation &Impl, bool diagnose)
+      : Impl(Impl), diagnose(diagnose) {}
+
   bool VisitDeclRefExpr(const clang::DeclRefExpr *e) { return true; }
 
   bool VisitIntegerLiteral(const clang::IntegerLiteral *IL) {
@@ -236,6 +294,8 @@ struct CountedByExpressionValidator
     case clang::BuiltinType::LongLong:
     case clang::BuiltinType::ULongLong:
       DLOG("Ignoring count parameter with non-portable integer literal\n");
+      if (diagnose)
+        Impl.diagnose(HeaderLoc{IL->getBeginLoc()}, diag::non_portable_int_literal);
       return false;
     default:
       return true;
@@ -274,8 +334,9 @@ struct CountedByExpressionValidator
   SUPPORTED_BINOP(Or)
 #undef SUPPORTED_BINOP
 
-  bool VisitStmt(const clang::Stmt *) {
-    DLOG("Ignoring count parameter with unsupported expression\n");
+  bool VisitStmt(const clang::Stmt *S) {
+    if (diagnose)
+      Impl.diagnose(HeaderLoc{S->getBeginLoc()}, diag::unknown_count_expr, S->getStmtClassName());
     return false;
   }
 };
@@ -292,15 +353,21 @@ static Type ConcretePointeeType(Type swiftType) {
 
 // Don't try to transform any Swift types that _SwiftifyImport doesn't know how
 // to handle.
-static bool SwiftifiableSizedByPointerType(const clang::ASTContext &ctx,
-                                           Type swiftType,
-                                           const clang::CountAttributedType *CAT) {
+static bool
+SwiftifiableSizedByPointerType(ClangImporter::Implementation &Impl,
+                               bool diagnose, const clang::ASTContext &ctx,
+                               Type swiftType,
+                               const clang::CountAttributedType *CAT) {
   Type nonnullType = swiftType->lookThroughSingleOptionalType();
+  // FIXME: fetch loc from TypeLoc once CountAttributedType supports it
+  HeaderLoc loc(CAT->getCountExpr()->getExprLoc());
   if (nonnullType->isOpaquePointer())
     return true;
   PointerTypeKind PTK;
   if (!nonnullType->getAnyPointerElementType(PTK)) {
     DLOG("Ignoring sized_by on non-pointer type\n");
+    if (diagnose)
+      Impl.diagnose(loc, diag::sized_by_on_non_pointer);
     return false;
   }
   if (PTK == PTK_UnsafeRawPointer || PTK == PTK_UnsafeMutableRawPointer)
@@ -308,23 +375,52 @@ static bool SwiftifiableSizedByPointerType(const clang::ASTContext &ctx,
   if (PTK != PTK_UnsafePointer && PTK != PTK_UnsafeMutablePointer) {
     DLOG("Ignoring sized_by on Autoreleasing pointer\n");
     CONDITIONAL_ASSERT(PTK == PTK_AutoreleasingUnsafeMutablePointer);
+    if (diagnose)
+      Impl.diagnose(loc, diag::sized_by_on_autorelease);
     return false;
   }
   // We have a pointer to a type with a size. Verify that it is char-sized.
   auto PtrT = CAT->getAs<clang::PointerType>();
   auto PointeeT = PtrT->getPointeeType();
-  bool isByteSized = ctx.getTypeSizeInChars(PointeeT).isOne();
-  if (!isByteSized)
-    DLOG("Ignoring sized_by on non-byte-sized pointer\n");
-  return isByteSized;
+  clang::CharUnits PointeeSize = ctx.getTypeSizeInChars(PointeeT);
+  if (!PointeeSize.isOne()) {
+    if (diagnose) {
+      Impl.diagnose(loc, diag::sized_by_on_non_bytesized);
+      Impl.diagnose(loc, diag::type_has_size, PointeeT.getTypePtr(), (unsigned)PointeeSize.getQuantity());
+    }
+    return false;
+  }
+  return true;
 }
-static bool SwiftifiableCAT(const clang::ASTContext &ctx,
+static bool SwiftifiableCAT(ClangImporter::Implementation &Impl,
+                            bool diagnose,
+                            const clang::ASTContext &ctx,
                             const clang::CountAttributedType *CAT,
                             Type swiftType) {
-  return CAT && CountedByExpressionValidator().Visit(CAT->getCountExpr()) &&
-    (CAT->isCountInBytes() ?
-       SwiftifiableSizedByPointerType(ctx, swiftType, CAT)
-     : !ConcretePointeeType(swiftType).isNull());
+  if (!CAT) return false;
+  std::optional<CompoundDiagnosticTransaction> transaction;
+  // FIXME: fetch loc from TypeLoc once CountAttributedType supports it
+  HeaderLoc loc(CAT->getCountExpr()->getExprLoc());
+  if (diagnose) {
+    transaction.emplace(Impl.SwiftContext.Diags);
+    Impl.diagnose(loc, diag::ignoring_counted_by, CAT->getAttributeName(true));
+  }
+
+  if (!CountedByExpressionValidator(Impl, diagnose).Visit(CAT->getCountExpr()))
+    return false;
+
+  if (CAT->isCountInBytes()) {
+    if (!SwiftifiableSizedByPointerType(Impl, diagnose, ctx, swiftType, CAT))
+      return false;
+  } else if (ConcretePointeeType(swiftType).isNull()) {
+    if (diagnose)
+      Impl.diagnose(loc, diag::counted_by_incompatible_type);
+    return false;
+  }
+
+  if (diagnose)
+    transaction->abort();
+  return true;
 }
 
 // Searches for template instantiations that are not behind type aliases.
@@ -332,13 +428,17 @@ static bool SwiftifiableCAT(const clang::ASTContext &ctx,
 // instantiations that are not behind type aliases.
 struct UnaliasedInstantiationVisitor
     : clang::RecursiveASTVisitor<UnaliasedInstantiationVisitor> {
-  bool hasUnaliasedInstantiation = false;
+  bool hasUnaliasedInstantiationFailure = false;
+  TentativeFailureRemark &emitter;
 
-  bool TraverseTypedefType(const clang::TypedefType *) { return true; }
+  UnaliasedInstantiationVisitor(TentativeFailureRemark &emitter) : emitter(emitter) {}
+
+  bool TraverseTypedefTypeLoc(clang::TypedefTypeLoc) { return true; }
 
   bool
-  VisitTemplateSpecializationType(const clang::TemplateSpecializationType *) {
-    hasUnaliasedInstantiation = true;
+  VisitTemplateSpecializationTypeLoc(clang::TemplateSpecializationTypeLoc TSTL) {
+    hasUnaliasedInstantiationFailure = true;
+    emitter.addNote(TSTL.getBeginLoc(), diag::ignoring_template_in_signature);
     DLOG("Signature contains raw template, skipping\n");
     return false;
   }
@@ -376,10 +476,19 @@ static clang::Module *getOwningModule(const clang::Decl *ClangDecl) {
 
 struct ForwardDeclaredConcreteTypeVisitor : public TypeWalker {
   bool hasForwardDeclaredConcreteType = false;
+  const clang::NamedDecl *F;
+  TentativeFailureRemark &emitter;
   const clang::Module *Owner;
 
-  explicit ForwardDeclaredConcreteTypeVisitor(const clang::Module *Owner)
-      : Owner(Owner){};
+  explicit ForwardDeclaredConcreteTypeVisitor(const AbstractFunctionDecl *MappedDecl,
+                                              const clang::NamedDecl *F,
+                                              TentativeFailureRemark &emitter)
+      : F(F), emitter(emitter) {
+    Owner = getOwningModule(F);
+    bool IsInBridgingHeader = MappedDecl->getModuleContext()->getName().str() ==
+                              CLANG_HEADER_MODULE_NAME;
+    ASSERT(Owner || IsInBridgingHeader);
+  };
 
   Action walkToTypePre(Type ty) override {
     DLOG("Walking type:\n");
@@ -406,16 +515,19 @@ struct ForwardDeclaredConcreteTypeVisitor : public TypeWalker {
       return Action::Continue;
     }
 
-    if (!Owner) {
+    if (!Owner || !Owner->isModuleVisible(M)) {
       hasForwardDeclaredConcreteType = true;
+      if (emitter.enabled()) {
+        auto &SwiftContext = Nom->getASTContext();
+        emitter.addNote(F->getLocation(), diag::forward_declared_concrete_type);
+        StringRef OwnerName =
+            Owner ? SwiftContext.AllocateCopy(Owner->getFullModuleName())
+                  : StringRef(CLANG_HEADER_MODULE_NAME);
+        emitter.addNote(F->getLocation(), diag::clang_module_owner, F, OwnerName);
+        StringRef MName = SwiftContext.AllocateCopy(M->getFullModuleName());
+        emitter.addNote(TD->getLocation(), diag::clang_module_owner, TD, MName);
+      }
       DLOG("Imported signature contains concrete type not available in bridging header, skipping\n");
-      if (const clang::TagDecl *Def = TD->getDefinition())
-        LLVM_DEBUG(DUMP(Def));
-      return Action::Stop;
-    }
-    if (!Owner->isModuleVisible(M)) {
-      hasForwardDeclaredConcreteType = true;
-      DLOG("Imported signature contains concrete type not available in clang module, skipping\n");
       if (const clang::TagDecl *Def = TD->getDefinition())
         LLVM_DEBUG(DUMP(Def));
       return Action::Stop;
@@ -447,7 +559,9 @@ static StringRef getAttributeName(const clang::CountAttributedType *CAT) {
   }
 }
 
-static bool wouldBeIllegalInitializer(const AbstractFunctionDecl *MappedDecl) {
+static bool
+wouldBeIllegalInitializer(TentativeFailureRemark &emitter,
+                          const AbstractFunctionDecl *MappedDecl) {
   if (!isa<ConstructorDecl>(MappedDecl))
     return false;
   const auto *Parent = MappedDecl->getParent();
@@ -458,7 +572,10 @@ static bool wouldBeIllegalInitializer(const AbstractFunctionDecl *MappedDecl) {
   if (!ParentClass)
     return false;
 
-  return ParentClass->getForeignClassKind() != ClassDecl::ForeignKind::Normal;
+  if (ParentClass->getForeignClassKind() == ClassDecl::ForeignKind::Normal)
+    return false;
+  emitter.addNote(ParentClass->getLoc(), diag::cf_ref_initializer, ParentClass->getDeclaredType());
+  return true;
 }
 
 template<typename T>
@@ -470,7 +587,7 @@ static size_t getNumParams(const clang::FunctionDecl* D) {
     return D->getNumParams();
 }
 
-static bool shouldSkipModule(ModuleDecl *M) {
+static bool shouldSkipModule(TentativeFailureRemark &emitter, ModuleDecl *M) {
   if (M->getName().str() == CLANG_HEADER_MODULE_NAME) {
     DLOG("is from bridging header (or C++ namespace)\n");
     return false;
@@ -478,6 +595,7 @@ static bool shouldSkipModule(ModuleDecl *M) {
 
   if (M->getImplicitImportInfo().StdlibKind != ImplicitStdlibKind::Stdlib) {
     DLOG("module " << M->getNameStr() << " does not import stdlib\n");
+    emitter.addNote(SourceLoc{}, diag::module_without_stdlib, M->getNameStr());
     return true;
   }
 
@@ -485,11 +603,12 @@ static bool shouldSkipModule(ModuleDecl *M) {
 }
 } // namespace
 
-template<typename T>
+template <typename T>
 static bool swiftifyImpl(ClangImporter::Implementation &Self,
-                         SwiftifyInfoFunctionPrinter &printer,
-                         const AbstractFunctionDecl *MappedDecl,
-                         const T *ClangDecl) {
+                           SwiftifyInfoFunctionPrinter &printer,
+                           const AbstractFunctionDecl *MappedDecl,
+                           const T *ClangDecl,
+                           TentativeFailureRemark &emitter) {
   DLOG_SCOPE("Checking '" << *ClangDecl << "' for bounds and lifetime info\n");
 
   if (ClangDecl->hasAttrs()) {
@@ -497,40 +616,41 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
       if (auto *swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr);
           swiftAttr && swiftAttr->getAttribute() == "no_safe_wrapper") {
         DLOG("skipping function with no_safe_wrapper\n");
+        emitter.addNote(swiftAttr->getLoc(), diag::no_safe_wrapper_attr);
         return false;
       }
     }
   }
 
-  if (shouldSkipModule(MappedDecl->getParentModule()))
+  if (shouldSkipModule(emitter, MappedDecl->getParentModule()))
     return false;
 
   {
-    UnaliasedInstantiationVisitor visitor;
-    visitor.TraverseType(ClangDecl->getType());
-    if (visitor.hasUnaliasedInstantiation)
+    UnaliasedInstantiationVisitor visitor(emitter);
+    visitor.TraverseTypeLoc(ClangDecl->getFunctionTypeLoc());
+    if (visitor.hasUnaliasedInstantiationFailure)
       return false;
   }
 
   // FIXME: for private macro generated functions we do not serialize the
   // SILFunction's body anywhere triggering assertions.
   if (ClangDecl->getAccess() == clang::AS_protected ||
-      ClangDecl->getAccess() == clang::AS_private)
+      ClangDecl->getAccess() == clang::AS_private) {
+    emitter.addNote(MappedDecl->getLoc(), diag::ignoring_non_public_func, MappedDecl);
     return false;
+  }
 
   if (ClangDecl->isImplicit()) {
     DLOG("implicit functions lack lifetime and bounds info\n");
+    emitter.addNote(MappedDecl->getLoc(), diag::ignoring_implicit_func);
     return false;
   }
 
   clang::ASTContext &clangASTContext = Self.getClangASTContext();
 
-  const clang::Module *OwningModule = getOwningModule(ClangDecl);
-  bool IsInBridgingHeader = MappedDecl->getModuleContext()->getName().str() == CLANG_HEADER_MODULE_NAME;
-  ASSERT(OwningModule || IsInBridgingHeader);
-  ForwardDeclaredConcreteTypeVisitor CheckForwardDecls(OwningModule);
+  ForwardDeclaredConcreteTypeVisitor CheckForwardDecls(MappedDecl, ClangDecl, emitter);
 
-  if (wouldBeIllegalInitializer(MappedDecl)) {
+  if (wouldBeIllegalInitializer(emitter, MappedDecl)) {
     DLOG("illegal initializer\n");
     return false;
   }
@@ -566,7 +686,7 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
         swiftReturnTy, clangReturnTy);
     bool returnHasBoundsInfo = returnIsStdSpan;
     auto *CAT = clangReturnTy->getAs<clang::CountAttributedType>();
-    if (SwiftifiableCAT(clangASTContext, CAT, swiftReturnTy)) {
+    if (SwiftifiableCAT(Self, emitter.enabled(), clangASTContext, CAT, swiftReturnTy)) {
       printer.printCountedBy(CAT, SwiftifyInfoPrinter::RETURN_VALUE_INDEX);
       DLOG("Found bounds info '" << clang::QualType(CAT, 0) << "' on return value\n");
       returnHasBoundsInfo = attachMacro = true;
@@ -577,7 +697,9 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
     bool returnValueIsNonEscapable = isNonEscapable(clangReturnTy);
     bool returnValueCanBeNonEscapable = returnValueIsNonEscapable || returnHasBoundsInfo;
     bool returnHasLifetimeInfo = false;
-    if (getImplicitObjectParamAnnotation<clang::LifetimeBoundAttr>(ClangDecl)) {
+    if (auto lifetimeboundAttr =
+            getImplicitObjectParamAnnotation<clang::LifetimeBoundAttr>(
+                ClangDecl)) {
       DLOG("Found lifetimebound attribute on implicit 'this'\n");
       if (!dependsOnClass(
               MappedDecl->getImplicitSelfDecl(/*createIfNeeded*/ true))) {
@@ -586,9 +708,13 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
                                            true);
           returnHasLifetimeInfo = true;
         } else {
+          if (emitter.enabled())
+            Self.diagnose(HeaderLoc{lifetimeboundAttr->getLoc()}, diag::ignoring_lifetimebound_escapable_return);
           DLOG("lifetimebound ignored because return value is escapable");
         }
       } else {
+        if (emitter.enabled())
+          Self.diagnose(HeaderLoc{lifetimeboundAttr->getLoc()}, diag::ignoring_lifetimebound_on_frt);
         DLOG("lifetimebound ignored because it depends on class with refcount\n");
       }
     }
@@ -605,7 +731,8 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
       ASSERT(MappedDecl->isImportAsInstanceMember());
       swiftNumParams += 1;
     }
-    if (getNumParams(ClangDecl) != swiftNumParams) {
+    size_t clangNumParams = getNumParams(ClangDecl);
+    if (clangNumParams != swiftNumParams) {
       DLOG("mismatching parameter lists");
       assert(
           ClangDecl->isVariadic() ||
@@ -613,6 +740,9 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
           MappedDecl->getForeignAsyncConvention().has_value() ||
           (swiftNumParams == 1 &&
            MappedDecl->getParameters()->get(0)->getInterfaceType()->isVoid()));
+      emitter.addNote(MappedDecl->getNameLoc(),
+                      diag::mismatching_parameter_count,
+                      (unsigned)swiftNumParams, (unsigned)clangNumParams);
       return false;
     }
 
@@ -648,7 +778,7 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
                "free function mapped to instance method without swift_name??");
         Self.diagnose(HeaderLoc(swiftName->getLocation()),
                  diag::note_swift_name_instance_method);
-      } else if (SwiftifiableCAT(clangASTContext, CAT, swiftParamTy)) {
+      } else if (SwiftifiableCAT(Self, emitter.enabled(), clangASTContext, CAT, swiftParamTy)) {
         printer.printCountedBy(CAT, mappedIndex);
         DLOG("Found bounds info '" << clangParamTy << "'\n");
         attachMacro = paramHasBoundsInfo = true;
@@ -663,7 +793,7 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
         printer.printNonEscaping(mappedIndex);
         paramHasLifetimeInfo = true;
       }
-      if (clangParam->template hasAttr<clang::LifetimeBoundAttr>()) {
+      if (auto lifetimeboundAttr = clangParam->template getAttr<clang::LifetimeBoundAttr>()) {
         if (Self.SwiftContext.LangOpts.hasFeature(
                 Feature::SafeInteropWrappers)) {
           DLOG("Found lifetimebound attribute\n");
@@ -679,14 +809,20 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
               paramHasLifetimeInfo = true;
               returnHasLifetimeInfo = true;
             } else {
+              if (emitter.enabled())
+                Self.diagnose(HeaderLoc{lifetimeboundAttr->getLoc()}, diag::ignoring_lifetimebound_escapable_return);
               DLOG("lifetimebound ignored because return value is escapable\n");
+              clangParam->dump();
             }
           } else {
+            if (emitter.enabled())
+              Self.diagnose(HeaderLoc{lifetimeboundAttr->getLoc()}, diag::ignoring_lifetimebound_on_frt);
             DLOG("lifetimebound ignored because it depends on class with "
                  "refcount\n");
           }
         } else {
           DLOG("lifetimebound not yet supported by stable feature-set - skipping\n");
+          emitter.addNote(lifetimeboundAttr->getLoc(), diag::ignoring_lifetimebound);
           return false;
         }
       }
@@ -697,6 +833,9 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
     }
     if (!returnHasLifetimeInfo && returnValueIsNonEscapable) {
       DLOG("~Escapable return value without lifetime info\n");
+      emitter.addNote(
+          ClangDecl->getFunctionTypeLoc().getReturnLoc().getBeginLoc(),
+          diag::ignoring_nonescapable_return_without_lifetime, swiftReturnTy);
       return false;
     }
     if (returnIsStdSpan && returnHasLifetimeInfo) {
@@ -704,7 +843,12 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
       attachMacro = true;
     }
   }
-  return attachMacro;
+
+  if (attachMacro)
+    return true;
+
+  emitter.addNote(MappedDecl->getNameLoc(), diag::no_bounds_or_lifetime);
+  return false;
 }
 
 static bool diagnoseMissingMacroPlugin(ASTContext &SwiftContext,
@@ -731,21 +875,25 @@ static bool diagnoseMissingMacroPlugin(ASTContext &SwiftContext,
 }
 
 void ClangImporter::Implementation::swiftify(AbstractFunctionDecl *MappedDecl) {
-  auto emitRemark = [this,MappedDecl]() {
-    if (SwiftContext.LangOpts.RemarkClangImporter)
-      diagnose(MappedDecl->getNameLoc(), diag::no_safe_wrapper);
-  };
+  // Load up a failure remark to be emitted unless aborted. This is passed
+  // around to collect notes to ensure they get aborted along with the remark.
+  // Note that this cannot be replaced by `CompoundDiagnosticTransaction`,
+  // because aborting this remark should not abort other remarks emitted by
+  // `swiftifyImpl`, only the notes associated with this remark.`
+  TentativeFailureRemark failureRemarkEmitter(
+      *this, MappedDecl->getNameLoc(),
+      SwiftContext.LangOpts.RemarkClangImporter);
 
   if (SwiftContext.LangOpts.DisableSafeInteropWrappers)
-    return emitRemark();
+    return failureRemarkEmitter.addNote(MappedDecl->getNameLoc(), diag::safe_interop_disabled);
   auto ClangDecl = dyn_cast_or_null<clang::FunctionDecl>(MappedDecl->getClangDecl());
   if (!ClangDecl)
-    return emitRemark();
+    return failureRemarkEmitter.addNote(MappedDecl->getNameLoc(), diag::unsupported_function_kind, MappedDecl->getClangDecl()->getDeclKindName());
 
   MacroDecl *SwiftifyImportDecl = dyn_cast_or_null<MacroDecl>(getKnownSingleDecl(SwiftContext, "_SwiftifyImport"));
   if (!SwiftifyImportDecl) {
     DLOG("_SwiftifyImport macro not found\n");
-    return emitRemark();
+    return failureRemarkEmitter.addNote(MappedDecl->getNameLoc(), diag::swiftify_macro_not_found);
   }
 
   llvm::SmallString<128> MacroString;
@@ -756,9 +904,9 @@ void ClangImporter::Implementation::swiftify(AbstractFunctionDecl *MappedDecl) {
     llvm::StringMap<std::string> typeMapping;
     SwiftifyInfoFunctionPrinter printer(getClangASTContext(), SwiftContext, out,
                                         *SwiftifyImportDecl, typeMapping);
-    if (!swiftifyImpl(*this, printer, MappedDecl, ClangDecl)) {
+    if (!swiftifyImpl(*this, printer, MappedDecl, ClangDecl, failureRemarkEmitter)) {
       DLOG("No relevant bounds or lifetime info found\n");
-      return emitRemark();
+      return;
     }
     printer.printAvailability();
     printer.printTypeMapping();
@@ -766,11 +914,13 @@ void ClangImporter::Implementation::swiftify(AbstractFunctionDecl *MappedDecl) {
   }
 
   if (diagnoseMissingMacroPlugin(SwiftContext, "_SwiftifyImport", MappedDecl))
-    return emitRemark();
+    return failureRemarkEmitter.addNote(MappedDecl->getNameLoc(), diag::swiftify_macro_not_found);
 
   DLOG("Attaching safe interop macro: " << MacroString << "\n");
-  if (SwiftContext.LangOpts.RemarkClangImporter)
+  if (SwiftContext.LangOpts.RemarkClangImporter) {
+    failureRemarkEmitter.abort();
     diagnose(MappedDecl->getNameLoc(), diag::yes_safe_wrapper);
+  }
   if (clang::RawComment *raw =
           getClangASTContext().getRawCommentForDeclNoCache(ClangDecl)) {
     // swift::RawDocCommentAttr doesn't contain its text directly, but instead

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -78,7 +78,50 @@ struct LogIndentTracker {
   }
 };
 thread_local uint8_t LogIndentTracker::LogIndent = 0;
+
+static bool loggingEnabled() {
+  bool debug = false;
+  LLVM_DEBUG(debug = true);
+  return debug;
+}
+
+/// Emit diag as logging when -Xllvm -debug-only=safe-interop-wrappers is
+/// enabled. This is useful because it provides a chronological order of
+/// diagnostics interspersed with any other logs, and unlike diagnostics the
+/// logging is emitted eagerly, so they're not swallowed when a crash occurs.
+static void log(ClangImporter::Implementation &Impl, Diagnostic &diag) {
+  ASSERT(loggingEnabled() && "logging not wrapped in LLVM_DEBUG");
+
+  auto formatString =
+      Impl.SwiftContext.Diags.getFormatStringForDiagnostic(diag, false);
+  DiagnosticEngine::formatDiagnosticText(llvm::dbgs(), formatString,
+                                         diag.getArgs());
+  llvm::dbgs() << "\n";
+}
 #endif
+
+// Macros wrapping function calls to properly log __LINE__ info.
+#define DEFERRED_NOTE(emitter, ...)                                            \
+  do {                                                                         \
+    DLOG("");                                                                  \
+    emitter.addNote(__VA_ARGS__);                                              \
+  } while (0)
+#define DIAGNOSE(impl, logOnly, loc, ...)                                      \
+  do {                                                                         \
+    DLOG("");                                                                  \
+    emitDiag(impl, logOnly, loc, Diagnostic(__VA_ARGS__));                     \
+  } while (0)
+
+/// This is the canonical function for emitting diagnostics in SwiftifyDecl.cpp
+/// (with the exception of TentativeFailureRemark::addNote). Should be called via
+/// the DIAGNOSE macro.
+template <typename Loc>
+static void emitDiag(ClangImporter::Implementation &Impl, bool logOnly, Loc loc,
+                     Diagnostic &&diag) {
+  LLVM_DEBUG(log(Impl, diag));
+  if (!logOnly)
+    Impl.diagnose(loc, diag);
+}
 
 ValueDecl *getKnownSingleDecl(ASTContext &SwiftContext, StringRef DeclName) {
   SmallVector<ValueDecl *, 1> decls;
@@ -100,6 +143,7 @@ public:
   }
 
   void addNote(SourceLoc loc, Diagnostic &&note) {
+    LLVM_DEBUG(log(Impl, note));
     if (!aborted) {
       if (loc.isValid())
         note.setLoc(loc);
@@ -107,19 +151,26 @@ public:
         // All notes have the right to a SourceLoc. If you do not have a
         // SourceLoc of your own, one will be appointed for you.
         note.setLoc(failureRemark.getLoc());
+      note.setIsChildNote(true);
       failureRemark.addChildNote(std::move(note));
     }
   }
   void addNote(clang::SourceLocation loc, Diagnostic &&note) {
+    LLVM_DEBUG(log(Impl, note));
     if (!aborted) {
       note.setLoc(Impl.importSourceLoc(loc));
+      note.setIsChildNote(true);
       failureRemark.addChildNote(std::move(note));
     }
   }
-  template<typename L, typename ...ArgTypes>
-  void 
-  addNote(L Loc, Diag<ArgTypes...> ID,
-           typename detail::PassArgument<ArgTypes>::type... Args) {
+  /// addNote provides additional context for why a safe wrapper was not added.
+  /// Multiple notes can be added, with and without arguments.
+  /// This function (and its overloads) should not be called directly.
+  /// Instead it should be called using the DEFERRED_NOTE() macro, to enable
+  /// debug logging with correct __LINE__ information.
+  template <typename L, typename... ArgTypes>
+  void addNote(L Loc, Diag<ArgTypes...> ID,
+               typename detail::PassArgument<ArgTypes>::type... Args) {
     return addNote(Loc, Diagnostic(ID, std::move(Args)...));
   }
 
@@ -128,7 +179,7 @@ public:
 
   ~TentativeFailureRemark() {
     if (!aborted) {
-      Impl.diagnose(failureRemark.getLoc(), failureRemark);
+      DIAGNOSE(Impl, false, failureRemark.getLoc(), std::move(failureRemark));
     }
   }
 };
@@ -293,9 +344,8 @@ struct CountedByExpressionValidator
     case clang::BuiltinType::ULong:
     case clang::BuiltinType::LongLong:
     case clang::BuiltinType::ULongLong:
-      DLOG("Ignoring count parameter with non-portable integer literal\n");
-      if (diagnose)
-        Impl.diagnose(HeaderLoc{IL->getBeginLoc()}, diag::non_portable_int_literal);
+      DIAGNOSE(Impl, !diagnose, HeaderLoc{IL->getBeginLoc()},
+               diag::non_portable_int_literal);
       return false;
     default:
       return true;
@@ -335,8 +385,8 @@ struct CountedByExpressionValidator
 #undef SUPPORTED_BINOP
 
   bool VisitStmt(const clang::Stmt *S) {
-    if (diagnose)
-      Impl.diagnose(HeaderLoc{S->getBeginLoc()}, diag::unknown_count_expr, S->getStmtClassName());
+    DIAGNOSE(Impl, !diagnose, HeaderLoc{S->getBeginLoc()},
+             diag::unknown_count_expr, S->getStmtClassName());
     return false;
   }
 };
@@ -365,18 +415,14 @@ SwiftifiableSizedByPointerType(ClangImporter::Implementation &Impl,
     return true;
   PointerTypeKind PTK;
   if (!nonnullType->getAnyPointerElementType(PTK)) {
-    DLOG("Ignoring sized_by on non-pointer type\n");
-    if (diagnose)
-      Impl.diagnose(loc, diag::sized_by_on_non_pointer);
+    DIAGNOSE(Impl, !diagnose, loc, diag::sized_by_on_non_pointer);
     return false;
   }
   if (PTK == PTK_UnsafeRawPointer || PTK == PTK_UnsafeMutableRawPointer)
     return true;
   if (PTK != PTK_UnsafePointer && PTK != PTK_UnsafeMutablePointer) {
-    DLOG("Ignoring sized_by on Autoreleasing pointer\n");
     CONDITIONAL_ASSERT(PTK == PTK_AutoreleasingUnsafeMutablePointer);
-    if (diagnose)
-      Impl.diagnose(loc, diag::sized_by_on_autorelease);
+    DIAGNOSE(Impl, !diagnose, loc, diag::sized_by_on_autorelease);
     return false;
   }
   // We have a pointer to a type with a size. Verify that it is char-sized.
@@ -384,10 +430,9 @@ SwiftifiableSizedByPointerType(ClangImporter::Implementation &Impl,
   auto PointeeT = PtrT->getPointeeType();
   clang::CharUnits PointeeSize = ctx.getTypeSizeInChars(PointeeT);
   if (!PointeeSize.isOne()) {
-    if (diagnose) {
-      Impl.diagnose(loc, diag::sized_by_on_non_bytesized);
-      Impl.diagnose(loc, diag::type_has_size, PointeeT.getTypePtr(), (unsigned)PointeeSize.getQuantity());
-    }
+    DIAGNOSE(Impl, !diagnose, loc, diag::sized_by_on_non_bytesized);
+    DIAGNOSE(Impl, !diagnose, loc, diag::type_has_size, PointeeT.getTypePtr(),
+             (unsigned)PointeeSize.getQuantity());
     return false;
   }
   return true;
@@ -401,10 +446,10 @@ static bool SwiftifiableCAT(ClangImporter::Implementation &Impl,
   std::optional<CompoundDiagnosticTransaction> transaction;
   // FIXME: fetch loc from TypeLoc once CountAttributedType supports it
   HeaderLoc loc(CAT->getCountExpr()->getExprLoc());
-  if (diagnose) {
+  if (diagnose)
     transaction.emplace(Impl.SwiftContext.Diags);
-    Impl.diagnose(loc, diag::ignoring_counted_by, CAT->getAttributeName(true));
-  }
+  DIAGNOSE(Impl, !diagnose, loc, diag::ignoring_counted_by,
+           CAT->getAttributeName(true));
 
   if (!CountedByExpressionValidator(Impl, diagnose).Visit(CAT->getCountExpr()))
     return false;
@@ -413,8 +458,7 @@ static bool SwiftifiableCAT(ClangImporter::Implementation &Impl,
     if (!SwiftifiableSizedByPointerType(Impl, diagnose, ctx, swiftType, CAT))
       return false;
   } else if (ConcretePointeeType(swiftType).isNull()) {
-    if (diagnose)
-      Impl.diagnose(loc, diag::counted_by_incompatible_type);
+    DIAGNOSE(Impl, !diagnose, loc, diag::counted_by_incompatible_type);
     return false;
   }
 
@@ -438,8 +482,7 @@ struct UnaliasedInstantiationVisitor
   bool
   VisitTemplateSpecializationTypeLoc(clang::TemplateSpecializationTypeLoc TSTL) {
     hasUnaliasedInstantiationFailure = true;
-    emitter.addNote(TSTL.getBeginLoc(), diag::ignoring_template_in_signature);
-    DLOG("Signature contains raw template, skipping\n");
+    DEFERRED_NOTE(emitter, TSTL.getBeginLoc(), diag::ignoring_template_in_signature);
     return false;
   }
 };
@@ -517,17 +560,16 @@ struct ForwardDeclaredConcreteTypeVisitor : public TypeWalker {
 
     if (!Owner || !Owner->isModuleVisible(M)) {
       hasForwardDeclaredConcreteType = true;
-      if (emitter.enabled()) {
+      if (emitter.enabled() || loggingEnabled()) {
         auto &SwiftContext = Nom->getASTContext();
-        emitter.addNote(F->getLocation(), diag::forward_declared_concrete_type);
+        DEFERRED_NOTE(emitter, F->getLocation(), diag::forward_declared_concrete_type);
         StringRef OwnerName =
             Owner ? SwiftContext.AllocateCopy(Owner->getFullModuleName())
                   : StringRef(CLANG_HEADER_MODULE_NAME);
-        emitter.addNote(F->getLocation(), diag::clang_module_owner, F, OwnerName);
+        DEFERRED_NOTE(emitter, F->getLocation(), diag::clang_module_owner, F, OwnerName);
         StringRef MName = SwiftContext.AllocateCopy(M->getFullModuleName());
-        emitter.addNote(TD->getLocation(), diag::clang_module_owner, TD, MName);
+        DEFERRED_NOTE(emitter, TD->getLocation(), diag::clang_module_owner, TD, MName);
       }
-      DLOG("Imported signature contains concrete type not available in bridging header, skipping\n");
       if (const clang::TagDecl *Def = TD->getDefinition())
         LLVM_DEBUG(DUMP(Def));
       return Action::Stop;
@@ -574,7 +616,8 @@ wouldBeIllegalInitializer(TentativeFailureRemark &emitter,
 
   if (ParentClass->getForeignClassKind() == ClassDecl::ForeignKind::Normal)
     return false;
-  emitter.addNote(ParentClass->getLoc(), diag::cf_ref_initializer, ParentClass->getDeclaredType());
+  DEFERRED_NOTE(emitter, ParentClass->getLoc(), diag::cf_ref_initializer,
+                ParentClass->getDeclaredType());
   return true;
 }
 
@@ -594,8 +637,8 @@ static bool shouldSkipModule(TentativeFailureRemark &emitter, ModuleDecl *M) {
   }
 
   if (M->getImplicitImportInfo().StdlibKind != ImplicitStdlibKind::Stdlib) {
-    DLOG("module " << M->getNameStr() << " does not import stdlib\n");
-    emitter.addNote(SourceLoc{}, diag::module_without_stdlib, M->getNameStr());
+    DEFERRED_NOTE(emitter, SourceLoc{}, diag::module_without_stdlib,
+                  M->getNameStr());
     return true;
   }
 
@@ -603,20 +646,19 @@ static bool shouldSkipModule(TentativeFailureRemark &emitter, ModuleDecl *M) {
 }
 } // namespace
 
+// Any path where this function returns 'false' should contain at least one call
+// to `DEFERRED_NOTE(emitter, ...)``, either directly in this function or in a callee.
 template <typename T>
 static bool swiftifyImpl(ClangImporter::Implementation &Self,
-                           SwiftifyInfoFunctionPrinter &printer,
-                           const AbstractFunctionDecl *MappedDecl,
-                           const T *ClangDecl,
-                           TentativeFailureRemark &emitter) {
-  DLOG_SCOPE("Checking '" << *ClangDecl << "' for bounds and lifetime info\n");
-
+                         SwiftifyInfoFunctionPrinter &printer,
+                         const AbstractFunctionDecl *MappedDecl,
+                         const T *ClangDecl, TentativeFailureRemark &emitter) {
+  LLVM_DEBUG(DUMP(ClangDecl));
   if (ClangDecl->hasAttrs()) {
     for (auto *attr : ClangDecl->getAttrs()) {
       if (auto *swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr);
           swiftAttr && swiftAttr->getAttribute() == "no_safe_wrapper") {
-        DLOG("skipping function with no_safe_wrapper\n");
-        emitter.addNote(swiftAttr->getLoc(), diag::no_safe_wrapper_attr);
+        DEFERRED_NOTE(emitter, swiftAttr->getLoc(), diag::no_safe_wrapper_attr);
         return false;
       }
     }
@@ -636,13 +678,13 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
   // SILFunction's body anywhere triggering assertions.
   if (ClangDecl->getAccess() == clang::AS_protected ||
       ClangDecl->getAccess() == clang::AS_private) {
-    emitter.addNote(MappedDecl->getLoc(), diag::ignoring_non_public_func, MappedDecl);
+    DEFERRED_NOTE(emitter, MappedDecl->getLoc(), diag::ignoring_non_public_func,
+                  MappedDecl);
     return false;
   }
 
   if (ClangDecl->isImplicit()) {
-    DLOG("implicit functions lack lifetime and bounds info\n");
-    emitter.addNote(MappedDecl->getLoc(), diag::ignoring_implicit_func);
+    DEFERRED_NOTE(emitter, MappedDecl->getLoc(), diag::ignoring_implicit_func);
     return false;
   }
 
@@ -651,7 +693,6 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
   ForwardDeclaredConcreteTypeVisitor CheckForwardDecls(MappedDecl, ClangDecl, emitter);
 
   if (wouldBeIllegalInitializer(emitter, MappedDecl)) {
-    DLOG("illegal initializer\n");
     return false;
   }
 
@@ -708,14 +749,14 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
                                            true);
           returnHasLifetimeInfo = true;
         } else {
-          if (emitter.enabled())
-            Self.diagnose(HeaderLoc{lifetimeboundAttr->getLoc()}, diag::ignoring_lifetimebound_escapable_return);
-          DLOG("lifetimebound ignored because return value is escapable");
+          DIAGNOSE(Self, !emitter.enabled(),
+                   HeaderLoc{lifetimeboundAttr->getLoc()},
+                   diag::ignoring_lifetimebound_escapable_return);
         }
       } else {
-        if (emitter.enabled())
-          Self.diagnose(HeaderLoc{lifetimeboundAttr->getLoc()}, diag::ignoring_lifetimebound_on_frt);
-        DLOG("lifetimebound ignored because it depends on class with refcount\n");
+        DIAGNOSE(Self, !emitter.enabled(),
+                 HeaderLoc{lifetimeboundAttr->getLoc()},
+                 diag::ignoring_lifetimebound_on_frt);
       }
     }
 
@@ -733,16 +774,15 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
     }
     size_t clangNumParams = getNumParams(ClangDecl);
     if (clangNumParams != swiftNumParams) {
-      DLOG("mismatching parameter lists");
       assert(
           ClangDecl->isVariadic() ||
           MappedDecl->getForeignErrorConvention().has_value() ||
           MappedDecl->getForeignAsyncConvention().has_value() ||
           (swiftNumParams == 1 &&
            MappedDecl->getParameters()->get(0)->getInterfaceType()->isVoid()));
-      emitter.addNote(MappedDecl->getNameLoc(),
-                      diag::mismatching_parameter_count,
-                      (unsigned)swiftNumParams, (unsigned)clangNumParams);
+      DEFERRED_NOTE(emitter, MappedDecl->getNameLoc(),
+                    diag::mismatching_parameter_count, (unsigned)swiftNumParams,
+                    (unsigned)clangNumParams);
       return false;
     }
 
@@ -771,14 +811,15 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
       bool paramHasBoundsInfo = false;
       auto *CAT = clangParamTy->getAs<clang::CountAttributedType>();
       if (CAT && mappedIndex == SwiftifyInfoPrinter::SELF_PARAM_INDEX) {
-        Self.diagnose(HeaderLoc(clangParam->getLocation()),
+        DIAGNOSE(Self, !emitter.enabled(), HeaderLoc(clangParam->getLocation()),
                  diag::warn_clang_ignored_bounds_on_self, getAttributeName(CAT));
         auto swiftName = ClangDecl->template getAttr<clang::SwiftNameAttr>();
         ASSERT(swiftName &&
                "free function mapped to instance method without swift_name??");
-        Self.diagnose(HeaderLoc(swiftName->getLocation()),
+        DIAGNOSE(Self, !emitter.enabled(), HeaderLoc(swiftName->getLocation()),
                  diag::note_swift_name_instance_method);
-      } else if (SwiftifiableCAT(Self, emitter.enabled(), clangASTContext, CAT, swiftParamTy)) {
+      } else if (SwiftifiableCAT(Self, emitter.enabled(), clangASTContext, CAT,
+                                 swiftParamTy)) {
         printer.printCountedBy(CAT, mappedIndex);
         DLOG("Found bounds info '" << clangParamTy << "'\n");
         attachMacro = paramHasBoundsInfo = true;
@@ -809,20 +850,18 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
               paramHasLifetimeInfo = true;
               returnHasLifetimeInfo = true;
             } else {
-              if (emitter.enabled())
-                Self.diagnose(HeaderLoc{lifetimeboundAttr->getLoc()}, diag::ignoring_lifetimebound_escapable_return);
-              DLOG("lifetimebound ignored because return value is escapable\n");
+              DIAGNOSE(Self, !emitter.enabled(),
+                       HeaderLoc{lifetimeboundAttr->getLoc()},
+                       diag::ignoring_lifetimebound_escapable_return);
               clangParam->dump();
             }
           } else {
-            if (emitter.enabled())
-              Self.diagnose(HeaderLoc{lifetimeboundAttr->getLoc()}, diag::ignoring_lifetimebound_on_frt);
-            DLOG("lifetimebound ignored because it depends on class with "
-                 "refcount\n");
+            DIAGNOSE(Self, !emitter.enabled(),
+                     HeaderLoc{lifetimeboundAttr->getLoc()},
+                     diag::ignoring_lifetimebound_on_frt);
           }
         } else {
-          DLOG("lifetimebound not yet supported by stable feature-set - skipping\n");
-          emitter.addNote(lifetimeboundAttr->getLoc(), diag::ignoring_lifetimebound);
+          DEFERRED_NOTE(emitter, lifetimeboundAttr->getLoc(), diag::ignoring_lifetimebound);
           return false;
         }
       }
@@ -832,9 +871,8 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
       }
     }
     if (!returnHasLifetimeInfo && returnValueIsNonEscapable) {
-      DLOG("~Escapable return value without lifetime info\n");
-      emitter.addNote(
-          ClangDecl->getFunctionTypeLoc().getReturnLoc().getBeginLoc(),
+      DEFERRED_NOTE(
+          emitter, ClangDecl->getFunctionTypeLoc().getReturnLoc().getBeginLoc(),
           diag::ignoring_nonescapable_return_without_lifetime, swiftReturnTy);
       return false;
     }
@@ -847,7 +885,7 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
   if (attachMacro)
     return true;
 
-  emitter.addNote(MappedDecl->getNameLoc(), diag::no_bounds_or_lifetime);
+  DEFERRED_NOTE(emitter, MappedDecl->getNameLoc(), diag::no_bounds_or_lifetime);
   return false;
 }
 
@@ -875,6 +913,7 @@ static bool diagnoseMissingMacroPlugin(ASTContext &SwiftContext,
 }
 
 void ClangImporter::Implementation::swiftify(AbstractFunctionDecl *MappedDecl) {
+  DLOG_SCOPE("Checking '" << MappedDecl->getName() << "' for bounds and lifetime info\n");
   // Load up a failure remark to be emitted unless aborted. This is passed
   // around to collect notes to ensure they get aborted along with the remark.
   // Note that this cannot be replaced by `CompoundDiagnosticTransaction`,
@@ -884,16 +923,24 @@ void ClangImporter::Implementation::swiftify(AbstractFunctionDecl *MappedDecl) {
       *this, MappedDecl->getNameLoc(),
       SwiftContext.LangOpts.RemarkClangImporter);
 
-  if (SwiftContext.LangOpts.DisableSafeInteropWrappers)
-    return failureRemarkEmitter.addNote(MappedDecl->getNameLoc(), diag::safe_interop_disabled);
+  if (SwiftContext.LangOpts.DisableSafeInteropWrappers) {
+    DEFERRED_NOTE(failureRemarkEmitter, MappedDecl->getNameLoc(),
+                  diag::safe_interop_disabled);
+    return;
+  }
   auto ClangDecl = dyn_cast_or_null<clang::FunctionDecl>(MappedDecl->getClangDecl());
-  if (!ClangDecl)
-    return failureRemarkEmitter.addNote(MappedDecl->getNameLoc(), diag::unsupported_function_kind, MappedDecl->getClangDecl()->getDeclKindName());
+  if (!ClangDecl) {
+    DEFERRED_NOTE(failureRemarkEmitter, MappedDecl->getNameLoc(),
+                  diag::unsupported_function_kind,
+                  MappedDecl->getClangDecl()->getDeclKindName());
+    return;
+  }
 
   MacroDecl *SwiftifyImportDecl = dyn_cast_or_null<MacroDecl>(getKnownSingleDecl(SwiftContext, "_SwiftifyImport"));
   if (!SwiftifyImportDecl) {
-    DLOG("_SwiftifyImport macro not found\n");
-    return failureRemarkEmitter.addNote(MappedDecl->getNameLoc(), diag::swiftify_macro_not_found);
+    DEFERRED_NOTE(failureRemarkEmitter, MappedDecl->getNameLoc(),
+                  diag::swiftify_macro_not_found);
+    return;
   }
 
   llvm::SmallString<128> MacroString;
@@ -905,7 +952,6 @@ void ClangImporter::Implementation::swiftify(AbstractFunctionDecl *MappedDecl) {
     SwiftifyInfoFunctionPrinter printer(getClangASTContext(), SwiftContext, out,
                                         *SwiftifyImportDecl, typeMapping);
     if (!swiftifyImpl(*this, printer, MappedDecl, ClangDecl, failureRemarkEmitter)) {
-      DLOG("No relevant bounds or lifetime info found\n");
       return;
     }
     printer.printAvailability();
@@ -913,14 +959,17 @@ void ClangImporter::Implementation::swiftify(AbstractFunctionDecl *MappedDecl) {
     out << ")";
   }
 
-  if (diagnoseMissingMacroPlugin(SwiftContext, "_SwiftifyImport", MappedDecl))
-    return failureRemarkEmitter.addNote(MappedDecl->getNameLoc(), diag::swiftify_macro_not_found);
+  if (diagnoseMissingMacroPlugin(SwiftContext, "_SwiftifyImport", MappedDecl)) {
+    DEFERRED_NOTE(failureRemarkEmitter, MappedDecl->getNameLoc(),
+                  diag::swiftify_macro_not_found);
+    return;
+  }
 
   DLOG("Attaching safe interop macro: " << MacroString << "\n");
-  if (SwiftContext.LangOpts.RemarkClangImporter) {
+  if (SwiftContext.LangOpts.RemarkClangImporter)
     failureRemarkEmitter.abort();
-    diagnose(MappedDecl->getNameLoc(), diag::yes_safe_wrapper);
-  }
+  DIAGNOSE(*this, !SwiftContext.LangOpts.RemarkClangImporter,
+           MappedDecl->getNameLoc(), diag::yes_safe_wrapper);
   if (clang::RawComment *raw =
           getClangASTContext().getRawCommentForDeclNoCache(ClangDecl)) {
     // swift::RawDocCommentAttr doesn't contain its text directly, but instead

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -180,7 +180,7 @@ public:
   ~TentativeFailureRemark() {
     if (!aborted) {
       SourceLoc loc = failureRemark.getLoc();
-      DIAGNOSE(Impl, false, loc, std::move(failureRemark));
+      DIAGNOSE(Impl, loc.isInvalid(), loc, std::move(failureRemark));
     }
   }
 };

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -54,13 +54,19 @@ using namespace importer;
 
 #ifndef NDEBUG
 #define DBGS llvm::dbgs() << "[swiftify:" << __LINE__ << "] "
-#define DUMP(x) DLOG(""); x->dump(llvm::errs())
+#define DUMP(x) do { DLOG(""); x->dump(llvm::errs()); } while(0)
 #define DLOG_SCOPE(x) DLOG(x); LogIndentTracker Scope
 #else
-#define DLOG_SCOPE(x) do {} while(false);
+#define DLOG_SCOPE(x) do {} while(false)
 #endif
 
 namespace {
+static bool loggingEnabled() {
+  bool debug = false;
+  LLVM_DEBUG(debug = true);
+  return debug;
+}
+
 #ifndef NDEBUG
 struct LogIndentTracker {
   static thread_local uint8_t LogIndent;
@@ -78,12 +84,6 @@ struct LogIndentTracker {
   }
 };
 thread_local uint8_t LogIndentTracker::LogIndent = 0;
-
-static bool loggingEnabled() {
-  bool debug = false;
-  LLVM_DEBUG(debug = true);
-  return debug;
-}
 
 /// Emit diag as logging when -Xllvm -debug-only=safe-interop-wrappers is
 /// enabled. This is useful because it provides a chronological order of
@@ -571,8 +571,7 @@ struct ForwardDeclaredConcreteTypeVisitor : public TypeWalker {
         StringRef MName = SwiftContext.AllocateCopy(M->getFullModuleName());
         DEFERRED_NOTE(emitter, TD->getLocation(), diag::clang_module_owner, TD, MName);
       }
-      if (const clang::TagDecl *Def = TD->getDefinition())
-        LLVM_DEBUG(DUMP(Def));
+      LLVM_DEBUG(if (const clang::TagDecl *Def = TD->getDefinition()) DUMP(Def));
       return Action::Stop;
     }
 

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -179,7 +179,8 @@ public:
 
   ~TentativeFailureRemark() {
     if (!aborted) {
-      DIAGNOSE(Impl, false, failureRemark.getLoc(), std::move(failureRemark));
+      SourceLoc loc = failureRemark.getLoc();
+      DIAGNOSE(Impl, false, loc, std::move(failureRemark));
     }
   }
 };

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -853,7 +853,6 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
               DIAGNOSE(Self, !emitter.enabled(),
                        HeaderLoc{lifetimeboundAttr->getLoc()},
                        diag::ignoring_lifetimebound_escapable_return);
-              clangParam->dump();
             }
           } else {
             DIAGNOSE(Self, !emitter.enabled(),

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1849,6 +1849,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.RemarkMacroExpansions = Args.hasArg(
       OPT_expansion_remarks);
 
+  Opts.RemarkClangImporter = Args.hasArg(
+      OPT_clang_importer_remarks);
+
   Opts.DumpSourceFileImports = Args.hasArg(
       OPT_dump_source_file_imports);
 

--- a/test/Interop/C/swiftify-import/bridging-header.swift
+++ b/test/Interop/C/swiftify-import/bridging-header.swift
@@ -2,7 +2,8 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -o %t/test.swiftmodule -I %t -import-objc-header %t/bridging.h -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast %t/test.swift -verify
+// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -o %t/test.swiftmodule -I %t -import-objc-header %t/bridging.h -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast %t/test.swift -verify \
+// RUN:   -verify-additional-file %t%{fs-sep}bridging.h -verify-additional-file %t%{fs-sep}b.h -verify-additional-file %t%{fs-sep}c.h -Rclang-importer
 // RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -o %t/test.swiftmodule -I %t -import-objc-header %t/bridging.h -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast %t/test.swift -dump-macro-expansions 2>&1 | %FileCheck --dry-run > %t/macro-expansions.out
 // RUN: %diff %t/macro-expansions.out %t/macro-expansions.expected
 // RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -o %t/test.swiftmodule -I %t -import-objc-header %t/bridging.h -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast %t/test.swift -dump-source-file-imports 2>&1 | %FileCheck --dry-run > %t/imports.out
@@ -65,11 +66,18 @@ func test3(p: UnsafeMutablePointer<CInt>, len: CInt, z: UnsafeMutablePointer<c_t
 #include "c.h"
 
 struct no_module_record_t;
+// expected-remark@+1{{added safe interop wrapper}}
 void foo(no_module_t len, const a_t * __counted_by(len) p __noescape, struct no_module_record_t *x);
 
 struct b_t;
+// expected-remark@+3{{did not add safe interop wrapper}}
+// expected-note@+2{{clang function signature refers to concrete type without importing owning module}}
+// expected-note@+1{{'bar' is in module __ObjC}}
 void bar(int len, const int * __counted_by(len) p __noescape, struct b_t *y);
 
+// expected-remark@+3{{did not add safe interop wrapper}}
+// expected-note@+2{{clang function signature refers to concrete type without importing owning module}}
+// expected-note@+1{{'baz' is in module __ObjC}}
 void baz(int len, const int * __counted_by(len) p __noescape, struct c_t *z);
 
 //--- no-module.h
@@ -82,11 +90,13 @@ struct no_module_record_t {
 typedef int a_t;
 
 //--- b.h
+// expected-note@+1{{'b_t' is in module B}}
 struct b_t {
   int placeholder;
 };
 
 //--- c.h
+// expected-note@+1{{'c_t' is in module C}}
 struct c_t {
   int placeholder;
 };

--- a/test/Interop/C/swiftify-import/bridging-header.swift
+++ b/test/Interop/C/swiftify-import/bridging-header.swift
@@ -2,11 +2,11 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -o %t/test.swiftmodule -I %t -import-objc-header %t/bridging.h -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast %t/test.swift -verify \
+// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -o %t/test.swiftmodule -I %t -import-objc-header %t%{fs-sep}bridging.h -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast %t/test.swift -verify \
 // RUN:   -verify-additional-file %t%{fs-sep}bridging.h -verify-additional-file %t%{fs-sep}b.h -verify-additional-file %t%{fs-sep}c.h -Rclang-importer
-// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -o %t/test.swiftmodule -I %t -import-objc-header %t/bridging.h -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast %t/test.swift -dump-macro-expansions 2>&1 | %FileCheck --dry-run > %t/macro-expansions.out
+// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -o %t/test.swiftmodule -I %t -import-objc-header %t%{fs-sep}bridging.h -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast %t/test.swift -dump-macro-expansions 2>&1 | %FileCheck --dry-run > %t/macro-expansions.out
 // RUN: %diff %t/macro-expansions.out %t/macro-expansions.expected
-// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -o %t/test.swiftmodule -I %t -import-objc-header %t/bridging.h -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast %t/test.swift -dump-source-file-imports 2>&1 | %FileCheck --dry-run > %t/imports.out
+// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -o %t/test.swiftmodule -I %t -import-objc-header %t%{fs-sep}bridging.h -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast %t/test.swift -dump-source-file-imports 2>&1 | %FileCheck --dry-run > %t/imports.out
 // RUN: %diff %t/imports.out %t/imports.expected
 
 //--- imports.expected

--- a/test/Interop/C/swiftify-import/clang-includes-no-swift.swift
+++ b/test/Interop/C/swiftify-import/clang-includes-no-swift.swift
@@ -4,7 +4,7 @@
 
 // RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -I %t%{fs-sep}Inputs %t/succeed.swift
 // RUN: not %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -I %t%{fs-sep}Inputs %t/fail.swift -dump-source-file-imports 2>&1 | %FileCheck %s
-// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -I %t%{fs-sep}Inputs %t/fail.swift -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}B1.h -verify-ignore-macro-note
+// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -I %t%{fs-sep}Inputs %t/fail.swift -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}B1.h -verify-ignore-macro-note -Rclang-importer
 
 // Tests that we don't try to import modules that don't work well with Swift
 
@@ -43,8 +43,10 @@ module A1 {
 #define __sized_by(s) __attribute__((__sized_by__(s)))
 
 // We can use bar without C1 causing errors
+// expected-remark@+1{{added safe interop wrapper}}
 void bar(void * _Nonnull __sized_by(size), int size);
 // foo causes an error when we try to refer to c1_t from the '!swift' module C1
+// expected-remark@+1{{added safe interop wrapper}}
 c1_t foo(void * _Nonnull __sized_by(size), int size);
 /*
 expected-note@-2{{'foo' declared here}}
@@ -67,6 +69,10 @@ public func callUnsafe(_ p: UnsafeMutableRawPointer) {
 public func callSafe(_ p: UnsafeMutableRawBufferPointer) {
   let _ = foo(p) // expected-error{{cannot convert value of type 'UnsafeMutableRawBufferPointer' to expected argument type 'UnsafeMutableRawPointer'}}
                  // expected-error@-1{{missing argument}}
+}
+
+public func callBar(_ p: UnsafeMutableRawPointer) {
+  bar(p, 13)
 }
 
 //--- succeed.swift

--- a/test/Interop/C/swiftify-import/conflicting-opaqueness.swift
+++ b/test/Interop/C/swiftify-import/conflicting-opaqueness.swift
@@ -1,9 +1,8 @@
-
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
 // RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/test.swiftmodule %t/test.swift -I %t -strict-memory-safety \
-// RUN:   -verify -verify-additional-file %t%{fs-sep}foo.h -verify-additional-file %t%{fs-sep}bar.h -verify-additional-file %t%{fs-sep}baz.h -verify-additional-file %t%{fs-sep}qux.h -Rmacro-expansions
+// RUN:   -verify -verify-additional-file %t%{fs-sep}foo.h -verify-additional-file %t%{fs-sep}bar.h -verify-additional-file %t%{fs-sep}baz.h -verify-additional-file %t%{fs-sep}qux.h -Rmacro-expansions -Rclang-importer
 
 // Macro expansions in foo.h do not have access to the definition of `struct qux`,
 // so don't attach macro on functions that use contain that type in foo.h.
@@ -16,22 +15,38 @@
 #define __counted_by(x) __attribute__((__counted_by__(x)))
 
 struct qux;
-// expected-note@+1{{'foo' declared here}}
+// expected-remark@+4{{did not add safe interop wrapper}}
+// expected-note@+3{{clang function signature refers to concrete type without importing owning module}}
+// expected-note@+2{{'foo' is in module Foo}}
+// expected-note@+1{{'foo' declared here}} // note: the "declared here" notes are related to the errors in test.swift, not the remarks
 void foo(struct qux *x, int * __counted_by(len) p, int len);
+// expected-remark@+4{{did not add safe interop wrapper}}
+// expected-note@+3{{clang function signature refers to concrete type without importing owning module}}
+// expected-note@+2{{'fooIndirect' is in module Foo}}
 // expected-note@+1{{'fooIndirect' declared here}}
 void fooIndirect(struct qux * * x, int * __counted_by(len) p, int len);
+// expected-remark@+4{{did not add safe interop wrapper}}
+// expected-note@+3{{clang function signature refers to concrete type without importing owning module}}
+// expected-note@+2{{'fooIndirectCompleteArray' is in module Foo}}
 // expected-note@+1{{'fooIndirectCompleteArray' declared here}}
 void fooIndirectCompleteArray(struct qux* (* x)[2], int * __counted_by(len) p, int len);
+// expected-remark@+4{{did not add safe interop wrapper}}
+// expected-note@+3{{clang function signature refers to concrete type without importing owning module}}
+// expected-note@+2{{'fooReturn' is in module Foo}}
 // expected-note@+1{{'fooReturn' declared here}}
 struct qux * fooReturn(int * __counted_by(len) p, int len);
 
 enum fwd_declared_enum : int;
+// expected-remark@+4{{did not add safe interop wrapper}}
+// expected-note@+3{{clang function signature refers to concrete type without importing owning module}}
+// expected-note@+2{{'testEnum' is in module Foo}}
 // expected-note@+1{{'testEnum' declared here}}
 void testEnum(enum fwd_declared_enum *x, int * __counted_by(len) p, int len);
 
 struct container_t {
   struct qux *item;
 };
+// expected-remark@+11{{added safe interop wrapper}}
 // expected-expansion@+10:6{{
 //   expected-note@1 5{{in expansion of macro '_SwiftifyImport' on global function 'fooWrapped' here}}
 // }}
@@ -48,9 +63,14 @@ typedef struct __attribute__((swift_attr("import_as_ref")))
 __attribute__((swift_attr("retain:foobar_retain")))
 __attribute__((swift_attr("release:foobar_release"))) foobar_t *foobar_ref;
 
+// expected-remark@+2{{did not add safe interop wrapper}}
+// expected-note@+1{{no bounds or lifetime information found}}
 void foobar_retain(foobar_ref x);
+// expected-remark@+2{{did not add safe interop wrapper}}
+// expected-note@+1{{no bounds or lifetime information found}}
 void foobar_release(foobar_ref x);
 
+// expected-remark@+11{{added safe interop wrapper}}
 // expected-expansion@+10:57{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func foobar(_ _foobar_param0: UnsafeMutableBufferPointer<Int32>, _ _foobar_param2: foobar_ref!) {|}}
@@ -69,6 +89,7 @@ void foobar(int * __counted_by(len), int len, foobar_ref);
 
 #define __counted_by(x) __attribute__((__counted_by__(x)))
 
+// expected-remark@+11{{added safe interop wrapper}}
 // expected-expansion@+10:59{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func bar(_ x: UnsafeMutablePointer<qux>!, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
@@ -80,6 +101,7 @@ void foobar(int * __counted_by(len), int len, foobar_ref);
 //   expected-note@1 5{{in expansion of macro '_SwiftifyImport' on global function 'bar' here}}
 // }}
 void bar(struct qux *x, int * __counted_by(len) p, int len);
+// expected-remark@+11{{added safe interop wrapper}}
 // expected-expansion@+10:58{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func barReturn(_ p: UnsafeMutableBufferPointer<Int32>) -> UnsafeMutablePointer<qux>! {|}}
@@ -99,6 +121,7 @@ struct qux * barReturn(int * __counted_by(len) p, int len);
 #include "bar.h"
 
 struct qux;
+// expected-remark@+11{{added safe interop wrapper}}
 // expected-expansion@+10:59{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func baz(_ x: UnsafeMutablePointer<qux>!, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
@@ -110,6 +133,7 @@ struct qux;
 //   expected-note@1 5{{in expansion of macro '_SwiftifyImport' on global function 'baz' here}}
 // }}
 void baz(struct qux *x, int * __counted_by(len) p, int len);
+// expected-remark@+11{{added safe interop wrapper}}
 // expected-expansion@+10:58{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func bazReturn(_ p: UnsafeMutableBufferPointer<Int32>) -> UnsafeMutablePointer<qux>! {|}}
@@ -126,8 +150,10 @@ struct qux * bazReturn(int * __counted_by(len) p, int len);
 //--- qux.h
 #pragma once
 
+// expected-note@+1 4{{'qux' is in module qux}}
 struct qux { int placeholder; };
 
+// expected-note@+1{{'fwd_declared_enum' is in module qux}}
 enum fwd_declared_enum : int {
   enum_member,
 };

--- a/test/Interop/C/swiftify-import/counted-by-lifetimebound.swift
+++ b/test/Interop/C/swiftify-import/counted-by-lifetimebound.swift
@@ -118,6 +118,7 @@ int * __counted_by(len) _Nonnull nonnull(int len, int len2, int * _Nonnull p __c
 int * __counted_by(len) _Nullable nullable(int len, int len2, int * _Nullable p __counted_by(len2) __lifetimebound);
 
 typedef struct foo opaque_t;
+// expected-experimental-remark@+1{{ignoring lifetimebound attribute because return value is Escapable}}
 opaque_t * __counted_by(len) opaque(int len, int len2, opaque_t * p __counted_by(len2) __lifetimebound);
 
 // expected-experimental-expansion@+6:60{{
@@ -155,6 +156,7 @@ int * __counted_by(13) _Nullable constant(int * _Nullable p __counted_by_or_null
 
 struct EscapableStruct {};
 // make sure __lifetimebound is ignored when return value is escapable
+// expected-experimental-remark@+8{{ignoring lifetimebound attribute because return value is Escapable}}
 // expected-experimental-expansion@+7:87{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func lifetimeboundEscapableReturn(_ p: UnsafeMutableBufferPointer<Int32>) -> EscapableStruct {|}}

--- a/test/Interop/C/swiftify-import/counted-by-lifetimebound.swift
+++ b/test/Interop/C/swiftify-import/counted-by-lifetimebound.swift
@@ -5,11 +5,11 @@
 // RUN: split-file %s %t
 
 // RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %t -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature Lifetimes -strict-memory-safety -Xcc -Wno-nullability-completeness \
-// RUN:   %t/test.swift -verify -verify-additional-file %t%{fs-sep}test.h -Rmacro-expansions -suppress-notes -verify-additional-prefix experimental-
+// RUN:   %t/test.swift -verify -verify-additional-file %t%{fs-sep}test.h -Rmacro-expansions -Rclang-importer -verify-ignore-macro-note -verify-additional-prefix experimental-
 
 // lifetimebound support is not stabilized yet. Don't generate _any_ overloads on functions with lifetimebound to prevent future sourcebreak.
 // RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %t -enable-experimental-feature Lifetimes -strict-memory-safety -Xcc -Wno-nullability-completeness \
-// RUN:   %t/test.swift -verify -verify-additional-file %t%{fs-sep}test.h -Rmacro-expansions -suppress-notes -verify-additional-prefix stable-
+// RUN:   %t/test.swift -verify -verify-additional-file %t%{fs-sep}test.h -Rmacro-expansions -Rclang-importer -verify-ignore-macro-note -verify-additional-prefix stable-
 
 // Check that ClangImporter correctly infers and expands @_SwiftifyImport macros for functions with __counted_by __lifetimebound parameters and return values.
 
@@ -20,6 +20,10 @@
 #define __counted_by_or_null(x) __attribute__((__counted_by_or_null__(x)))
 #define __lifetimebound __attribute__((lifetimebound))
 
+// expected-stable-note@+17{{'simple' declared here}}
+// expected-stable-remark@+16{{did not add safe interop wrapper}}
+// expected-stable-note@+15{{lifetimebound support is not yet stabilized}}
+// expected-experimental-remark@+14{{added safe interop wrapper}}
 // expected-experimental-expansion@+13:58{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public func simple(_ len: Int32, _ p: inout MutableSpan<Int32>) -> MutableSpan<Int32> {|}}
@@ -35,6 +39,10 @@
 // }}
 int * __counted_by(len) simple(int len, int len2, int * p __counted_by(len2) __lifetimebound);
 
+// expected-stable-note@+17{{'shared' declared here}}
+// expected-stable-remark@+16{{did not add safe interop wrapper}}
+// expected-stable-note@+15{{lifetimebound support is not yet stabilized}}
+// expected-experimental-remark@+14{{added safe interop wrapper}}
 // expected-experimental-expansion@+13:48{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public func shared(_ p: inout MutableSpan<Int32>) -> MutableSpan<Int32> {|}}
@@ -50,6 +58,10 @@ int * __counted_by(len) simple(int len, int len2, int * p __counted_by(len2) __l
 // }}
 int * __counted_by(len) shared(int len, int * p __counted_by(len) __lifetimebound);
 
+// expected-stable-note@+17{{'complexExpr' declared here}}
+// expected-stable-remark@+16{{did not add safe interop wrapper}}
+// expected-stable-note@+15{{lifetimebound support is not yet stabilized}}
+// expected-experimental-remark@+14{{added safe interop wrapper}}
 // expected-experimental-expansion@+13:84{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public func complexExpr(_ len: Int32, _ offset: Int32, _ p: inout MutableSpan<Int32>) -> MutableSpan<Int32> {|}}
@@ -65,6 +77,10 @@ int * __counted_by(len) shared(int len, int * p __counted_by(len) __lifetimeboun
 // }}
 int * __counted_by(len - offset) complexExpr(int len, int offset, int len2, int * p __counted_by(len2) __lifetimebound);
 
+// expected-stable-note@+17{{'nullUnspecified' declared here}}
+// expected-stable-remark@+16{{did not add safe interop wrapper}}
+// expected-stable-note@+15{{lifetimebound support is not yet stabilized}}
+// expected-experimental-remark@+14{{added safe interop wrapper}}
 // expected-experimental-expansion@+13:103{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public func nullUnspecified(_ len: Int32, _ p: inout MutableSpan<Int32>) -> MutableSpan<Int32> {|}}
@@ -80,6 +96,10 @@ int * __counted_by(len - offset) complexExpr(int len, int offset, int len2, int 
 // }}
 int * __counted_by(len) _Null_unspecified nullUnspecified(int len, int len2, int * _Null_unspecified p __counted_by(len2) __lifetimebound);
 
+// expected-stable-note@+17{{'nonnull' declared here}}
+// expected-stable-remark@+16{{did not add safe interop wrapper}}
+// expected-stable-note@+15{{lifetimebound support is not yet stabilized}}
+// expected-experimental-remark@+14{{added safe interop wrapper}}
 // expected-experimental-expansion@+13:77{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public func nonnull(_ len: Int32, _ p: inout MutableSpan<Int32>) -> MutableSpan<Int32> {|}}
@@ -95,6 +115,10 @@ int * __counted_by(len) _Null_unspecified nullUnspecified(int len, int len2, int
 // }}
 int * __counted_by(len) _Nonnull nonnull(int len, int len2, int * _Nonnull p __counted_by(len2) __lifetimebound);
 
+// expected-stable-note@+24{{'nullable' declared here}}
+// expected-stable-remark@+23{{did not add safe interop wrapper}}
+// expected-stable-note@+22{{lifetimebound support is not yet stabilized}}
+// expected-experimental-remark@+21{{added safe interop wrapper}}
 // expected-experimental-expansion@+20:80{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public func nullable(_ len: Int32, _ p: inout MutableSpan<Int32>?) -> MutableSpan<Int32>? {|}}
@@ -118,9 +142,18 @@ int * __counted_by(len) _Nonnull nonnull(int len, int len2, int * _Nonnull p __c
 int * __counted_by(len) _Nullable nullable(int len, int len2, int * _Nullable p __counted_by(len2) __lifetimebound);
 
 typedef struct foo opaque_t;
-// expected-experimental-remark@+1{{ignoring lifetimebound attribute because return value is Escapable}}
+// expected-remark@+7 2{{ignoring __counted_by attribute}}
+// expected-note@+6 2{{__counted_by attribute not on pointer with known pointee size}}
+// expected-stable-note@+5{{lifetimebound support is not yet stabilized}}
+// expected-stable-remark@+4{{did not add safe interop wrapper}}
+// expected-experimental-remark@+3{{ignoring lifetimebound attribute because return value is Escapable}}
+// expected-experimental-remark@+2{{did not add safe interop wrapper}}
+// expected-experimental-note@+1{{no bounds or lifetime information found}}
 opaque_t * __counted_by(len) opaque(int len, int len2, opaque_t * p __counted_by(len2) __lifetimebound);
 
+// expected-stable-remark@+9{{did not add safe interop wrapper}}
+// expected-stable-note@+8{{lifetimebound support is not yet stabilized}}
+// expected-experimental-remark@+7{{added safe interop wrapper}}
 // expected-experimental-expansion@+6:60{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(borrow p) @_disfavoredOverload public func noncountedLifetime(_ len: Int32, _ p: UnsafeMutablePointer<Int32>!) -> MutableSpan<Int32> {|}}
@@ -129,6 +162,9 @@ opaque_t * __counted_by(len) opaque(int len, int len2, opaque_t * p __counted_by
 // }}
 int * __counted_by(len) noncountedLifetime(int len, int * p __lifetimebound);
 
+// expected-stable-remark@+26{{did not add safe interop wrapper}}
+// expected-stable-note@+25{{lifetimebound support is not yet stabilized}}
+// expected-experimental-remark@+24{{added safe interop wrapper}}
 // expected-experimental-expansion@+23:60{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public func constant(_ p: inout MutableSpan<Int32>?) -> MutableSpan<Int32>? {|}}
@@ -156,7 +192,11 @@ int * __counted_by(13) _Nullable constant(int * _Nullable p __counted_by_or_null
 
 struct EscapableStruct {};
 // make sure __lifetimebound is ignored when return value is escapable
-// expected-experimental-remark@+8{{ignoring lifetimebound attribute because return value is Escapable}}
+// expected-stable-note@+12{{'lifetimeboundEscapableReturn' declared here}}
+// expected-stable-remark@+11{{did not add safe interop wrapper}}
+// expected-stable-note@+10{{lifetimebound support is not yet stabilized}}
+// expected-experimental-remark@+9{{ignoring lifetimebound attribute because return value is Escapable}}
+// expected-experimental-remark@+8{{added safe interop wrapper}}
 // expected-experimental-expansion@+7:87{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func lifetimeboundEscapableReturn(_ p: UnsafeMutableBufferPointer<Int32>) -> EscapableStruct {|}}
@@ -167,6 +207,10 @@ struct EscapableStruct {};
 struct EscapableStruct lifetimeboundEscapableReturn(int len, int * __counted_by(len) p __lifetimebound);
 
 struct __attribute__((swift_attr("~Escapable"))) NonescapableStruct {};
+// expected-stable-note@+17{{'lifetimeboundNonescapableReturn' declared here}}
+// expected-stable-remark@+16{{did not add safe interop wrapper}}
+// expected-stable-note@+15{{lifetimebound support is not yet stabilized}}
+// expected-experimental-remark@+14{{added safe interop wrapper}}
 // expected-experimental-expansion@+13:93{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public func lifetimeboundNonescapableReturn(_ p: inout MutableSpan<Int32>) -> NonescapableStruct {|}}
@@ -182,6 +226,10 @@ struct __attribute__((swift_attr("~Escapable"))) NonescapableStruct {};
 // }}
 struct NonescapableStruct lifetimeboundNonescapableReturn(int len, int * __counted_by(len) p __lifetimebound);
 
+// expected-stable-note@+17{{'lifetimeboundNonescapableReturnDoubleBounds' declared here}}
+// expected-stable-remark@+16{{did not add safe interop wrapper}}
+// expected-stable-note@+15{{lifetimebound support is not yet stabilized}}
+// expected-experimental-remark@+14{{added safe interop wrapper}}
 // expected-experimental-expansion@+13:150{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p, copy s) @_lifetime(p: copy p) @_disfavoredOverload public func lifetimeboundNonescapableReturnDoubleBounds(_ p: inout MutableSpan<Int32>, _ s: NonescapableStruct) -> NonescapableStruct {|}}
@@ -197,6 +245,10 @@ struct NonescapableStruct lifetimeboundNonescapableReturn(int len, int * __count
 // }}
 struct NonescapableStruct lifetimeboundNonescapableReturnDoubleBounds(int len, int * __counted_by(len) p __lifetimebound, struct NonescapableStruct s __lifetimebound);
 
+// expected-stable-note@+18{{'oneLifetimeboundOneEscapable' declared here}}
+// expected-stable-remark@+17{{did not add safe interop wrapper}}
+// expected-stable-note@+16{{lifetimebound support is not yet stabilized}}
+// expected-experimental-remark@+15{{added safe interop wrapper}}
 // expected-experimental-expansion@+14:135{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public func oneLifetimeboundOneEscapable(_ len: Int32, _ p: inout MutableSpan<Int32>, _ p2: UnsafeMutableBufferPointer<Int32>) -> MutableSpan<Int32> {|}}
@@ -290,6 +342,8 @@ func call_oneLifetimeboundOneEscapable(_ len: Int32, _ len2: Int32, _ p: UnsafeM
 @_lifetime(copy p)
 @_lifetime(p: copy p)
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_constant(_ p: inout MutableSpan<Int32>?) -> MutableSpan<Int32>? {
+  // expected-stable-note@+4{{arguments to generic parameter 'Pointee' ('MutableSpan<Int32>?' and 'Int32') are expected to be equal}}
+  // expected-stable-note@+3{{arguments to generic parameter 'Wrapped' ('UnsafeMutablePointer<Int32>' and 'MutableSpan<Int32>') are expected to be equal}}
   // expected-stable-error@+2{{cannot convert value of type 'UnsafeMutablePointer<MutableSpan<Int32>?>' to expected argument type 'UnsafeMutablePointer<Int32>'}}
   // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<Int32>?' to return type 'MutableSpan<Int32>?'}}
   return constant(&p)
@@ -305,6 +359,7 @@ func call_oneLifetimeboundOneEscapable(_ len: Int32, _ len2: Int32, _ p: UnsafeM
 @_lifetime(copy p)
 @_lifetime(p: copy p)
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_lifetimeboundNonescapableReturn(_ p: inout MutableSpan<Int32>) -> NonescapableStruct {
+  // expected-stable-note@+4{{arguments to generic parameter 'Pointee' ('MutableSpan<Int32>' and 'Int32') are expected to be equal}}
   // expected-stable-error@+3{{missing argument for parameter #2 in call}}
   // expected-stable-error@+2{{cannot convert value of type 'UnsafeMutablePointer<MutableSpan<Int32>>' to expected argument type 'UnsafeMutablePointer<Int32>'}}
   // expected-stable-error@+1{{cannot convert value of type 'MutableSpan<Int32>' to expected argument type 'Int32'}}
@@ -352,6 +407,7 @@ func call_oneLifetimeboundOneEscapable(_ len: Int32, _ len2: Int32, _ p: UnsafeM
 @_lifetime(copy p)
 @_lifetime(p: copy p)
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ len: Int32, _ p: inout MutableSpan<Int32>?) -> MutableSpan<Int32>? {
+  // expected-stable-note@+4{{arguments to generic parameter 'Wrapped' ('UnsafeMutablePointer<Int32>' and 'MutableSpan<Int32>') are expected to be equal}}
   // expected-stable-error@+3{{missing argument for parameter #3 in call}}
   // expected-stable-error@+2{{cannot convert value of type 'MutableSpan<Int32>?' to expected argument type 'Int32'}}
   // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<Int32>?' to return type 'MutableSpan<Int32>?'}}
@@ -373,6 +429,7 @@ func call_oneLifetimeboundOneEscapable(_ len: Int32, _ len2: Int32, _ p: UnsafeM
 @_lifetime(copy p)
 @_lifetime(p: copy p)
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_shared(_ p: inout MutableSpan<Int32>) -> MutableSpan<Int32> {
+  // expected-stable-note@+5{{arguments to generic parameter 'Pointee' ('MutableSpan<Int32>' and 'Int32') are expected to be equal}}
   // expected-stable-error@+4{{missing argument for parameter #2 in call}}
   // expected-stable-error@+3{{cannot convert value of type 'UnsafeMutablePointer<MutableSpan<Int32>>' to expected argument type 'UnsafeMutablePointer<Int32>'}}
   // expected-stable-error@+2{{cannot convert value of type 'MutableSpan<Int32>' to expected argument type 'Int32'}}

--- a/test/Interop/C/swiftify-import/counted-by.swift
+++ b/test/Interop/C/swiftify-import/counted-by.swift
@@ -2,269 +2,305 @@
 // RUN: split-file %s %t
 
 // RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %t -strict-memory-safety -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast \
-// RUN:   %t/test.swift -verify -verify-additional-file %t%{fs-sep}test.h -Rmacro-expansions -suppress-notes -Rclang-importer
+// RUN:   %t/test.swift -verify -verify-additional-file %t%{fs-sep}test.h -Rmacro-expansions -suppress-notes -verify-additional-prefix macro-
+// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -I %t -strict-memory-safety -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast \
+// RUN:   %t/test.swift -verify -verify-additional-file %t%{fs-sep}test.h -Rclang-importer -verify-additional-prefix diagnose-
 
 // Check that ClangImporter correctly infers and expands @_SwiftifyImport macros for functions with __counted_by parameters.
 
 //--- test.h
 #define __counted_by(x) __attribute__((__counted_by__(x)))
 
-// expected-remark@+8{{added safe interop wrapper}}
-// expected-expansion@+7:47{{
-//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func simple(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    return unsafe simple(len, p.baseAddress!)|}}
-//   expected-remark@5{{macro content: |}|}}
+// expected-diagnose-remark@+8{{added safe interop wrapper}}
+// expected-macro-expansion@+7:47{{
+//   expected-macro-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-macro-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func simple(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
+//   expected-macro-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
+//   expected-macro-remark@4{{macro content: |    return unsafe simple(len, p.baseAddress!)|}}
+//   expected-macro-remark@5{{macro content: |}|}}
 // }}
 void simple(int len, int * __counted_by(len) p);
 
-// expected-remark@+8{{added safe interop wrapper}}
-// expected-expansion@+7:54{{
-//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func simpleFlipped(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    return unsafe simpleFlipped(p.baseAddress!, len)|}}
-//   expected-remark@5{{macro content: |}|}}
+// expected-diagnose-remark@+8{{added safe interop wrapper}}
+// expected-macro-expansion@+7:54{{
+//   expected-macro-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-macro-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func simpleFlipped(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
+//   expected-macro-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
+//   expected-macro-remark@4{{macro content: |    return unsafe simpleFlipped(p.baseAddress!, len)|}}
+//   expected-macro-remark@5{{macro content: |}|}}
 // }}
 void simpleFlipped(int * __counted_by(len) p, int len);
 
-// expected-remark@+8{{did not add safe interop wrapper}}
-// expected-expansion@+7:31{{
-//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func swiftAttr(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    return unsafe swiftAttr(len, p.baseAddress!)|}}
-//   expected-remark@5{{macro content: |}|}}
+// expected-diagnose-remark@+9{{did not add safe interop wrapper}}
+// expected-diagnose-note@+8{{no bounds or lifetime information found}}
+// expected-macro-expansion@+7:31{{
+//   expected-macro-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-macro-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func swiftAttr(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
+//   expected-macro-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
+//   expected-macro-remark@4{{macro content: |    return unsafe swiftAttr(len, p.baseAddress!)|}}
+//   expected-macro-remark@5{{macro content: |}|}}
 // }}
 void swiftAttr(int len, int *p) __attribute__((
     swift_attr("@_SwiftifyImport(.countedBy(pointer: .param(2), count: \"len\"))")));
 
-// expected-remark@+11{{added safe interop wrapper}}
-// expected-expansion@+10:76{{
-//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func shared(_ p1: UnsafeMutableBufferPointer<Int32>, _ p2: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    let len = Int32(exactly: p1.count)!|}}
-//   expected-remark@4{{macro content: |    if p2.count != len {|}}
-//   expected-remark@5{{macro content: |      fatalError("bounds check failure in shared: expected \\(len) but got \\(p2.count)")|}}
-//   expected-remark@6{{macro content: |    }|}}
-//   expected-remark@7{{macro content: |    return unsafe shared(len, p1.baseAddress!, p2.baseAddress!)|}}
-//   expected-remark@8{{macro content: |}|}}
+// expected-diagnose-remark@+11{{added safe interop wrapper}}
+// expected-macro-expansion@+10:76{{
+//   expected-macro-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-macro-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func shared(_ p1: UnsafeMutableBufferPointer<Int32>, _ p2: UnsafeMutableBufferPointer<Int32>) {|}}
+//   expected-macro-remark@3{{macro content: |    let len = Int32(exactly: p1.count)!|}}
+//   expected-macro-remark@4{{macro content: |    if p2.count != len {|}}
+//   expected-macro-remark@5{{macro content: |      fatalError("bounds check failure in shared: expected \\(len) but got \\(p2.count)")|}}
+//   expected-macro-remark@6{{macro content: |    }|}}
+//   expected-macro-remark@7{{macro content: |    return unsafe shared(len, p1.baseAddress!, p2.baseAddress!)|}}
+//   expected-macro-remark@8{{macro content: |}|}}
 // }}
 void shared(int len, int * __counted_by(len) p1, int * __counted_by(len) p2);
 
-// expected-remark@+11{{added safe interop wrapper}}
-// expected-expansion@+10:73{{
-//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func complexExpr(_ len: Int32, _ offset: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    let _pCount = p.count|}}
-//   expected-remark@4{{macro content: |    if _pCount != len - offset {|}}
-//   expected-remark@5{{macro content: |      fatalError("bounds check failure in complexExpr: expected \\(len - offset) but got \\(_pCount)")|}}
-//   expected-remark@6{{macro content: |    }|}}
-//   expected-remark@7{{macro content: |    return unsafe complexExpr(len, offset, p.baseAddress!)|}}
-//   expected-remark@8{{macro content: |}|}}
+// expected-diagnose-remark@+11{{added safe interop wrapper}}
+// expected-macro-expansion@+10:73{{
+//   expected-macro-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-macro-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func complexExpr(_ len: Int32, _ offset: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
+//   expected-macro-remark@3{{macro content: |    let _pCount = p.count|}}
+//   expected-macro-remark@4{{macro content: |    if _pCount != len - offset {|}}
+//   expected-macro-remark@5{{macro content: |      fatalError("bounds check failure in complexExpr: expected \\(len - offset) but got \\(_pCount)")|}}
+//   expected-macro-remark@6{{macro content: |    }|}}
+//   expected-macro-remark@7{{macro content: |    return unsafe complexExpr(len, offset, p.baseAddress!)|}}
+//   expected-macro-remark@8{{macro content: |}|}}
 // }}
 void complexExpr(int len, int offset, int * __counted_by(len - offset) p);
 
-// expected-remark@+8{{added safe interop wrapper}}
-// expected-expansion@+7:74{{
-//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nullUnspecified(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    return unsafe nullUnspecified(len, p.baseAddress!)|}}
-//   expected-remark@5{{macro content: |}|}}
+// expected-diagnose-remark@+8{{added safe interop wrapper}}
+// expected-macro-expansion@+7:74{{
+//   expected-macro-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-macro-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nullUnspecified(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
+//   expected-macro-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
+//   expected-macro-remark@4{{macro content: |    return unsafe nullUnspecified(len, p.baseAddress!)|}}
+//   expected-macro-remark@5{{macro content: |}|}}
 // }}
 void nullUnspecified(int len, int * __counted_by(len) _Null_unspecified p);
 
-// expected-remark@+8{{added safe interop wrapper}}
-// expected-expansion@+7:57{{
-//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nonnull(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    return unsafe nonnull(len, p.baseAddress!)|}}
-//   expected-remark@5{{macro content: |}|}}
+// expected-diagnose-remark@+8{{added safe interop wrapper}}
+// expected-macro-expansion@+7:57{{
+//   expected-macro-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-macro-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nonnull(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
+//   expected-macro-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
+//   expected-macro-remark@4{{macro content: |    return unsafe nonnull(len, p.baseAddress!)|}}
+//   expected-macro-remark@5{{macro content: |}|}}
 // }}
 void nonnull(int len, int * __counted_by(len) _Nonnull p);
 
-// expected-remark@+8{{added safe interop wrapper}}
-// expected-expansion@+7:59{{
-//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nullable(_ p: UnsafeMutableBufferPointer<Int32>?) {|}}
-//   expected-remark@3{{macro content: |    let len = Int32(exactly: unsafe p?.count ?? 0)!|}}
-//   expected-remark@4{{macro content: |    return unsafe nullable(len, p?.baseAddress)|}}
-//   expected-remark@5{{macro content: |}|}}
+// expected-diagnose-remark@+8{{added safe interop wrapper}}
+// expected-macro-expansion@+7:59{{
+//   expected-macro-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-macro-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nullable(_ p: UnsafeMutableBufferPointer<Int32>?) {|}}
+//   expected-macro-remark@3{{macro content: |    let len = Int32(exactly: unsafe p?.count ?? 0)!|}}
+//   expected-macro-remark@4{{macro content: |    return unsafe nullable(len, p?.baseAddress)|}}
+//   expected-macro-remark@5{{macro content: |}|}}
 // }}
 void nullable(int len, int * __counted_by(len) _Nullable p);
 
-// expected-remark@+7{{added safe interop wrapper}}
-// expected-expansion@+6:46{{
-//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func returnPointer(_ len: Int32) -> UnsafeMutableBufferPointer<Int32> {|}}
-//   expected-remark@3{{macro content: |    return unsafe UnsafeMutableBufferPointer<Int32>(start: unsafe returnPointer(len), count: Int(len))|}}
-//   expected-remark@4{{macro content: |}|}}
+// expected-diagnose-remark@+7{{added safe interop wrapper}}
+// expected-macro-expansion@+6:46{{
+//   expected-macro-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-macro-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func returnPointer(_ len: Int32) -> UnsafeMutableBufferPointer<Int32> {|}}
+//   expected-macro-remark@3{{macro content: |    return unsafe UnsafeMutableBufferPointer<Int32>(start: unsafe returnPointer(len), count: Int(len))|}}
+//   expected-macro-remark@4{{macro content: |}|}}
 // }}
 int * __counted_by(len) returnPointer(int len);
 
-// expected-remark@+11{{added safe interop wrapper}}
-// expected-expansion@+10:53{{
-//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func offByOne(_ len: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    let _pCount = p.count|}}
-//   expected-remark@4{{macro content: |    if _pCount != len + 1 {|}}
-//   expected-remark@5{{macro content: |      fatalError("bounds check failure in offByOne: expected \\(len + 1) but got \\(_pCount)")|}}
-//   expected-remark@6{{macro content: |    }|}}
-//   expected-remark@7{{macro content: |    return unsafe offByOne(len, p.baseAddress!)|}}
-//   expected-remark@8{{macro content: |}|}}
+// expected-diagnose-remark@+11{{added safe interop wrapper}}
+// expected-macro-expansion@+10:53{{
+//   expected-macro-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-macro-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func offByOne(_ len: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
+//   expected-macro-remark@3{{macro content: |    let _pCount = p.count|}}
+//   expected-macro-remark@4{{macro content: |    if _pCount != len + 1 {|}}
+//   expected-macro-remark@5{{macro content: |      fatalError("bounds check failure in offByOne: expected \\(len + 1) but got \\(_pCount)")|}}
+//   expected-macro-remark@6{{macro content: |    }|}}
+//   expected-macro-remark@7{{macro content: |    return unsafe offByOne(len, p.baseAddress!)|}}
+//   expected-macro-remark@8{{macro content: |}|}}
 // }}
 void offByOne(int len, int * __counted_by(len + 1) p);
 
-// expected-remark@+11{{added safe interop wrapper}}
-// expected-expansion@+10:77{{
-//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func offBySome(_ len: Int32, _ offset: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    let _pCount = p.count|}}
-//   expected-remark@4{{macro content: |    if _pCount != len + (1 + offset) {|}}
-//   expected-remark@5{{macro content: |      fatalError("bounds check failure in offBySome: expected \\(len + (1 + offset)) but got \\(_pCount)")|}}
-//   expected-remark@6{{macro content: |    }|}}
-//   expected-remark@7{{macro content: |    return unsafe offBySome(len, offset, p.baseAddress!)|}}
-//   expected-remark@8{{macro content: |}|}}
+// expected-diagnose-remark@+11{{added safe interop wrapper}}
+// expected-macro-expansion@+10:77{{
+//   expected-macro-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-macro-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func offBySome(_ len: Int32, _ offset: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
+//   expected-macro-remark@3{{macro content: |    let _pCount = p.count|}}
+//   expected-macro-remark@4{{macro content: |    if _pCount != len + (1 + offset) {|}}
+//   expected-macro-remark@5{{macro content: |      fatalError("bounds check failure in offBySome: expected \\(len + (1 + offset)) but got \\(_pCount)")|}}
+//   expected-macro-remark@6{{macro content: |    }|}}
+//   expected-macro-remark@7{{macro content: |    return unsafe offBySome(len, offset, p.baseAddress!)|}}
+//   expected-macro-remark@8{{macro content: |}|}}
 // }}
 void offBySome(int len, int offset, int * __counted_by(len + (1 + offset)) p);
 
-// expected-remark@+11{{added safe interop wrapper}}
-// expected-expansion@+10:54{{
-//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func scalar(_ m: Int32, _ n: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    let _pCount = p.count|}}
-//   expected-remark@4{{macro content: |    if _pCount != m * n {|}}
-//   expected-remark@5{{macro content: |      fatalError("bounds check failure in scalar: expected \\(m * n) but got \\(_pCount)")|}}
-//   expected-remark@6{{macro content: |    }|}}
-//   expected-remark@7{{macro content: |    return unsafe scalar(m, n, p.baseAddress!)|}}
-//   expected-remark@8{{macro content: |}|}}
+// expected-diagnose-remark@+11{{added safe interop wrapper}}
+// expected-macro-expansion@+10:54{{
+//   expected-macro-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-macro-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func scalar(_ m: Int32, _ n: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
+//   expected-macro-remark@3{{macro content: |    let _pCount = p.count|}}
+//   expected-macro-remark@4{{macro content: |    if _pCount != m * n {|}}
+//   expected-macro-remark@5{{macro content: |      fatalError("bounds check failure in scalar: expected \\(m * n) but got \\(_pCount)")|}}
+//   expected-macro-remark@6{{macro content: |    }|}}
+//   expected-macro-remark@7{{macro content: |    return unsafe scalar(m, n, p.baseAddress!)|}}
+//   expected-macro-remark@8{{macro content: |}|}}
 // }}
 void scalar(int m, int n, int * __counted_by(m * n) p);
 
-// expected-remark@+11{{added safe interop wrapper}}
-// expected-expansion@+10:67{{
-//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func bitwise(_ m: Int32, _ n: Int32, _ o: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    let _pCount = p.count|}}
-//   expected-remark@4{{macro content: |    if _pCount != m & n | ~o {|}}
-//   expected-remark@5{{macro content: |      fatalError("bounds check failure in bitwise: expected \\(m & n | ~o) but got \\(_pCount)")|}}
-//   expected-remark@6{{macro content: |    }|}}
-//   expected-remark@7{{macro content: |    return unsafe bitwise(m, n, o, p.baseAddress!)|}}
-//   expected-remark@8{{macro content: |}|}}
+// expected-diagnose-remark@+11{{added safe interop wrapper}}
+// expected-macro-expansion@+10:67{{
+//   expected-macro-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-macro-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func bitwise(_ m: Int32, _ n: Int32, _ o: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
+//   expected-macro-remark@3{{macro content: |    let _pCount = p.count|}}
+//   expected-macro-remark@4{{macro content: |    if _pCount != m & n | ~o {|}}
+//   expected-macro-remark@5{{macro content: |      fatalError("bounds check failure in bitwise: expected \\(m & n | ~o) but got \\(_pCount)")|}}
+//   expected-macro-remark@6{{macro content: |    }|}}
+//   expected-macro-remark@7{{macro content: |    return unsafe bitwise(m, n, o, p.baseAddress!)|}}
+//   expected-macro-remark@8{{macro content: |}|}}
 // }}
 void bitwise(int m, int n, int o, int * __counted_by(m & n | ~o) p);
 
-// expected-remark@+11{{added safe interop wrapper}}
-// expected-expansion@+10:71{{
-//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func bitshift(_ m: Int32, _ n: Int32, _ o: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    let _pCount = p.count|}}
-//   expected-remark@4{{macro content: |    if _pCount != m << (n >> o) {|}}
-//   expected-remark@5{{macro content: |      fatalError("bounds check failure in bitshift: expected \\(m << (n >> o)) but got \\(_pCount)")|}}
-//   expected-remark@6{{macro content: |    }|}}
-//   expected-remark@7{{macro content: |    return unsafe bitshift(m, n, o, p.baseAddress!)|}}
-//   expected-remark@8{{macro content: |}|}}
+// expected-diagnose-remark@+11{{added safe interop wrapper}}
+// expected-macro-expansion@+10:71{{
+//   expected-macro-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-macro-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func bitshift(_ m: Int32, _ n: Int32, _ o: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
+//   expected-macro-remark@3{{macro content: |    let _pCount = p.count|}}
+//   expected-macro-remark@4{{macro content: |    if _pCount != m << (n >> o) {|}}
+//   expected-macro-remark@5{{macro content: |      fatalError("bounds check failure in bitshift: expected \\(m << (n >> o)) but got \\(_pCount)")|}}
+//   expected-macro-remark@6{{macro content: |    }|}}
+//   expected-macro-remark@7{{macro content: |    return unsafe bitshift(m, n, o, p.baseAddress!)|}}
+//   expected-macro-remark@8{{macro content: |}|}}
 // }}
 void bitshift(int m, int n, int o, int * __counted_by(m << (n >> o)) p);
 
-// expected-remark@+11{{added safe interop wrapper}}
-// expected-expansion@+10:44{{
-//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func constInt(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    let _pCount = p.count|}}
-//   expected-remark@4{{macro content: |    if _pCount != 420 {|}}
-//   expected-remark@5{{macro content: |      fatalError("bounds check failure in constInt: expected \\(420) but got \\(_pCount)")|}}
-//   expected-remark@6{{macro content: |    }|}}
-//   expected-remark@7{{macro content: |    return unsafe constInt(p.baseAddress!)|}}
-//   expected-remark@8{{macro content: |}|}}
+// expected-diagnose-remark@+11{{added safe interop wrapper}}
+// expected-macro-expansion@+10:44{{
+//   expected-macro-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-macro-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func constInt(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
+//   expected-macro-remark@3{{macro content: |    let _pCount = p.count|}}
+//   expected-macro-remark@4{{macro content: |    if _pCount != 420 {|}}
+//   expected-macro-remark@5{{macro content: |      fatalError("bounds check failure in constInt: expected \\(420) but got \\(_pCount)")|}}
+//   expected-macro-remark@6{{macro content: |    }|}}
+//   expected-macro-remark@7{{macro content: |    return unsafe constInt(p.baseAddress!)|}}
+//   expected-macro-remark@8{{macro content: |}|}}
 // }}
 void constInt(int * __counted_by(42 * 10) p);
 
-// expected-remark@+11{{added safe interop wrapper}}
-// expected-expansion@+10:66{{
-//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func constFloatCastedToInt(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    let _pCount = p.count|}}
-//   expected-remark@4{{macro content: |    if _pCount != 0 {|}}
-//   expected-remark@5{{macro content: |      fatalError("bounds check failure in constFloatCastedToInt: expected \\(0) but got \\(_pCount)")|}}
-//   expected-remark@6{{macro content: |    }|}}
-//   expected-remark@7{{macro content: |    return unsafe constFloatCastedToInt(p.baseAddress!)|}}
-//   expected-remark@8{{macro content: |}|}}
+// expected-diagnose-remark@+11{{added safe interop wrapper}}
+// expected-macro-expansion@+10:66{{
+//   expected-macro-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-macro-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func constFloatCastedToInt(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
+//   expected-macro-remark@3{{macro content: |    let _pCount = p.count|}}
+//   expected-macro-remark@4{{macro content: |    if _pCount != 0 {|}}
+//   expected-macro-remark@5{{macro content: |      fatalError("bounds check failure in constFloatCastedToInt: expected \\(0) but got \\(_pCount)")|}}
+//   expected-macro-remark@6{{macro content: |    }|}}
+//   expected-macro-remark@7{{macro content: |    return unsafe constFloatCastedToInt(p.baseAddress!)|}}
+//   expected-macro-remark@8{{macro content: |}|}}
 // }}
 void constFloatCastedToInt(int * __counted_by((int) (4.2 / 12)) p);
 
-// expected-remark@+1{{did not add safe interop wrapper}}
+// expected-diagnose-remark@+4{{ignoring __counted_by attribute}}
+// expected-diagnose-note@+3{{count parameter contains integer literal not supported in Swift syntax}}
+// expected-diagnose-remark@+2{{did not add safe interop wrapper}}
+// expected-diagnose-note@+1{{no bounds or lifetime information found}}
 void sizeofType(int * __counted_by(sizeof(int *)) p);
 
-// expected-remark@+1{{did not add safe interop wrapper}}
+// expected-diagnose-note@+4{{count parameter contains integer literal not supported in Swift syntax}}
+// expected-diagnose-remark@+3{{ignoring __counted_by attribute}}
+// expected-diagnose-note@+2{{no bounds or lifetime information found}}
+// expected-diagnose-remark@+1{{did not add safe interop wrapper}}
 void sizeofParam(int * __counted_by(sizeof(p)) p);
 
-// expected-remark@+1{{did not add safe interop wrapper}}
+// expected-diagnose-remark@+4{{ignoring __counted_by attribute}}
+// expected-diagnose-note@+3{{count parameter contains unsupported expression kind UnaryOperator}}
+// expected-diagnose-remark@+2{{did not add safe interop wrapper}}
+// expected-diagnose-note@+1{{no bounds or lifetime information found}}
 void derefLen(int * len, int * __counted_by(*len) p);
 
-// expected-remark@+1{{did not add safe interop wrapper}}
+// expected-diagnose-remark@+4{{ignoring __counted_by attribute}}
+// expected-diagnose-note@+3{{count parameter contains unsupported expression kind UnaryOperator}}
+// expected-diagnose-remark@+2{{did not add safe interop wrapper}}
+// expected-diagnose-note@+1{{no bounds or lifetime information found}}
 void lNot(int len, int * __counted_by(!len) p);
 
-// expected-remark@+1{{did not add safe interop wrapper}}
+// expected-diagnose-remark@+4{{ignoring __counted_by attribute}}
+// expected-diagnose-note@+3{{count parameter contains unsupported expression kind BinaryOperator}}
+// expected-diagnose-note@+2{{no bounds or lifetime information found}}
+// expected-diagnose-remark@+1{{did not add safe interop wrapper}}
 void lAnd(int len, int * __counted_by(len && len) p);
 
-// expected-remark@+1{{did not add safe interop wrapper}}
+// expected-diagnose-remark@+4{{ignoring __counted_by attribute}}
+// expected-diagnose-note@+3{{count parameter contains unsupported expression kind BinaryOperator}}
+// expected-diagnose-note@+2{{no bounds or lifetime information found}}
+// expected-diagnose-remark@+1{{did not add safe interop wrapper}}
 void lOr(int len, int * __counted_by(len || len) p);
 
-// expected-remark@+1{{did not add safe interop wrapper}}
+// expected-diagnose-remark@+4{{ignoring __counted_by attribute}}
+// expected-diagnose-note@+3{{count parameter contains unsupported expression kind CStyleCastExpr}}
+// expected-diagnose-remark@+2{{did not add safe interop wrapper}}
+// expected-diagnose-note@+1{{no bounds or lifetime information found}}
 void floatCastToInt(float meters, int * __counted_by((int) meters) p);
 
-// expected-remark@+1{{did not add safe interop wrapper}}
+// expected-diagnose-remark@+4{{ignoring __counted_by attribute}}
+// expected-diagnose-note@+3{{count parameter contains unsupported expression kind CStyleCastExpr}}
+// expected-diagnose-remark@+2{{did not add safe interop wrapper}}
+// expected-diagnose-note@+1{{no bounds or lifetime information found}}
 void pointerCastToInt(int *square, int * __counted_by((int) square) p);
 
-// expected-remark@+1{{did not add safe interop wrapper}}
+// expected-diagnose-remark@+4{{ignoring __counted_by attribute}}
+// expected-diagnose-note@+3{{count parameter contains unsupported expression kind CStyleCastExpr}}
+// expected-diagnose-remark@+2{{did not add safe interop wrapper}}
+// expected-diagnose-note@+1{{no bounds or lifetime information found}}
 void nanAsInt(int * __counted_by((int) (0 / 0)) p);
 
-// expected-remark@+1{{did not add safe interop wrapper}}
+// expected-diagnose-remark@+4{{ignoring __counted_by attribute}}
+// expected-diagnose-note@+3{{count parameter contains integer literal not supported in Swift syntax}}
+// expected-diagnose-remark@+2{{did not add safe interop wrapper}}
+// expected-diagnose-note@+1{{no bounds or lifetime information found}}
 void unsignedLiteral(int * __counted_by(2u) p);
 
-// expected-remark@+1{{did not add safe interop wrapper}}
+// expected-diagnose-remark@+4{{ignoring __counted_by attribute}}
+// expected-diagnose-note@+3{{count parameter contains integer literal not supported in Swift syntax}}
+// expected-diagnose-remark@+2{{did not add safe interop wrapper}}
+// expected-diagnose-note@+1{{no bounds or lifetime information found}}
 void longLiteral(int * __counted_by(2l) p);
 
-// expected-remark@+11{{added safe interop wrapper}}
-// expected-expansion@+10:43{{
-//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func hexLiteral(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    let _pCount = p.count|}}
-//   expected-remark@4{{macro content: |    if _pCount != 250 {|}}
-//   expected-remark@5{{macro content: |      fatalError("bounds check failure in hexLiteral: expected \\(250) but got \\(_pCount)")|}}
-//   expected-remark@6{{macro content: |    }|}}
-//   expected-remark@7{{macro content: |    return unsafe hexLiteral(p.baseAddress!)|}}
-//   expected-remark@8{{macro content: |}|}}
+// expected-diagnose-remark@+11{{added safe interop wrapper}}
+// expected-macro-expansion@+10:43{{
+//   expected-macro-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-macro-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func hexLiteral(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
+//   expected-macro-remark@3{{macro content: |    let _pCount = p.count|}}
+//   expected-macro-remark@4{{macro content: |    if _pCount != 250 {|}}
+//   expected-macro-remark@5{{macro content: |      fatalError("bounds check failure in hexLiteral: expected \\(250) but got \\(_pCount)")|}}
+//   expected-macro-remark@6{{macro content: |    }|}}
+//   expected-macro-remark@7{{macro content: |    return unsafe hexLiteral(p.baseAddress!)|}}
+//   expected-macro-remark@8{{macro content: |}|}}
 // }}
 void hexLiteral(int * __counted_by(0xfa) p);
 
-// expected-remark@+11{{added safe interop wrapper}}
-// expected-expansion@+10:46{{
-//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func binaryLiteral(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    let _pCount = p.count|}}
-//   expected-remark@4{{macro content: |    if _pCount != 2 {|}}
-//   expected-remark@5{{macro content: |      fatalError("bounds check failure in binaryLiteral: expected \\(2) but got \\(_pCount)")|}}
-//   expected-remark@6{{macro content: |    }|}}
-//   expected-remark@7{{macro content: |    return unsafe binaryLiteral(p.baseAddress!)|}}
-//   expected-remark@8{{macro content: |}|}}
+// expected-diagnose-remark@+11{{added safe interop wrapper}}
+// expected-macro-expansion@+10:46{{
+//   expected-macro-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-macro-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func binaryLiteral(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
+//   expected-macro-remark@3{{macro content: |    let _pCount = p.count|}}
+//   expected-macro-remark@4{{macro content: |    if _pCount != 2 {|}}
+//   expected-macro-remark@5{{macro content: |      fatalError("bounds check failure in binaryLiteral: expected \\(2) but got \\(_pCount)")|}}
+//   expected-macro-remark@6{{macro content: |    }|}}
+//   expected-macro-remark@7{{macro content: |    return unsafe binaryLiteral(p.baseAddress!)|}}
+//   expected-macro-remark@8{{macro content: |}|}}
 // }}
 void binaryLiteral(int * __counted_by(0b10) p);
 
-// expected-remark@+11{{added safe interop wrapper}}
-// expected-expansion@+10:45{{
-//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func octalLiteral(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    let _pCount = p.count|}}
-//   expected-remark@4{{macro content: |    if _pCount != 511 {|}}
-//   expected-remark@5{{macro content: |      fatalError("bounds check failure in octalLiteral: expected \\(511) but got \\(_pCount)")|}}
-//   expected-remark@6{{macro content: |    }|}}
-//   expected-remark@7{{macro content: |    return unsafe octalLiteral(p.baseAddress!)|}}
-//   expected-remark@8{{macro content: |}|}}
+// expected-diagnose-remark@+11{{added safe interop wrapper}}
+// expected-macro-expansion@+10:45{{
+//   expected-macro-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-macro-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func octalLiteral(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
+//   expected-macro-remark@3{{macro content: |    let _pCount = p.count|}}
+//   expected-macro-remark@4{{macro content: |    if _pCount != 511 {|}}
+//   expected-macro-remark@5{{macro content: |      fatalError("bounds check failure in octalLiteral: expected \\(511) but got \\(_pCount)")|}}
+//   expected-macro-remark@6{{macro content: |    }|}}
+//   expected-macro-remark@7{{macro content: |    return unsafe octalLiteral(p.baseAddress!)|}}
+//   expected-macro-remark@8{{macro content: |}|}}
 // }}
 void octalLiteral(int * __counted_by(0777) p);
 

--- a/test/Interop/C/swiftify-import/counted-by.swift
+++ b/test/Interop/C/swiftify-import/counted-by.swift
@@ -2,13 +2,14 @@
 // RUN: split-file %s %t
 
 // RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %t -strict-memory-safety -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast \
-// RUN:   %t/test.swift -verify -verify-additional-file %t%{fs-sep}test.h -Rmacro-expansions -suppress-notes
+// RUN:   %t/test.swift -verify -verify-additional-file %t%{fs-sep}test.h -Rmacro-expansions -suppress-notes -Rclang-importer
 
 // Check that ClangImporter correctly infers and expands @_SwiftifyImport macros for functions with __counted_by parameters.
 
 //--- test.h
 #define __counted_by(x) __attribute__((__counted_by__(x)))
 
+// expected-remark@+8{{added safe interop wrapper}}
 // expected-expansion@+7:47{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func simple(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
@@ -18,6 +19,7 @@
 // }}
 void simple(int len, int * __counted_by(len) p);
 
+// expected-remark@+8{{added safe interop wrapper}}
 // expected-expansion@+7:54{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func simpleFlipped(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
@@ -27,6 +29,7 @@ void simple(int len, int * __counted_by(len) p);
 // }}
 void simpleFlipped(int * __counted_by(len) p, int len);
 
+// expected-remark@+8{{did not add safe interop wrapper}}
 // expected-expansion@+7:31{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func swiftAttr(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
@@ -37,6 +40,7 @@ void simpleFlipped(int * __counted_by(len) p, int len);
 void swiftAttr(int len, int *p) __attribute__((
     swift_attr("@_SwiftifyImport(.countedBy(pointer: .param(2), count: \"len\"))")));
 
+// expected-remark@+11{{added safe interop wrapper}}
 // expected-expansion@+10:76{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func shared(_ p1: UnsafeMutableBufferPointer<Int32>, _ p2: UnsafeMutableBufferPointer<Int32>) {|}}
@@ -49,6 +53,7 @@ void swiftAttr(int len, int *p) __attribute__((
 // }}
 void shared(int len, int * __counted_by(len) p1, int * __counted_by(len) p2);
 
+// expected-remark@+11{{added safe interop wrapper}}
 // expected-expansion@+10:73{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func complexExpr(_ len: Int32, _ offset: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
@@ -61,6 +66,7 @@ void shared(int len, int * __counted_by(len) p1, int * __counted_by(len) p2);
 // }}
 void complexExpr(int len, int offset, int * __counted_by(len - offset) p);
 
+// expected-remark@+8{{added safe interop wrapper}}
 // expected-expansion@+7:74{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nullUnspecified(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
@@ -70,6 +76,7 @@ void complexExpr(int len, int offset, int * __counted_by(len - offset) p);
 // }}
 void nullUnspecified(int len, int * __counted_by(len) _Null_unspecified p);
 
+// expected-remark@+8{{added safe interop wrapper}}
 // expected-expansion@+7:57{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nonnull(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
@@ -79,6 +86,7 @@ void nullUnspecified(int len, int * __counted_by(len) _Null_unspecified p);
 // }}
 void nonnull(int len, int * __counted_by(len) _Nonnull p);
 
+// expected-remark@+8{{added safe interop wrapper}}
 // expected-expansion@+7:59{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nullable(_ p: UnsafeMutableBufferPointer<Int32>?) {|}}
@@ -88,6 +96,7 @@ void nonnull(int len, int * __counted_by(len) _Nonnull p);
 // }}
 void nullable(int len, int * __counted_by(len) _Nullable p);
 
+// expected-remark@+7{{added safe interop wrapper}}
 // expected-expansion@+6:46{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func returnPointer(_ len: Int32) -> UnsafeMutableBufferPointer<Int32> {|}}
@@ -96,6 +105,7 @@ void nullable(int len, int * __counted_by(len) _Nullable p);
 // }}
 int * __counted_by(len) returnPointer(int len);
 
+// expected-remark@+11{{added safe interop wrapper}}
 // expected-expansion@+10:53{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func offByOne(_ len: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
@@ -108,6 +118,7 @@ int * __counted_by(len) returnPointer(int len);
 // }}
 void offByOne(int len, int * __counted_by(len + 1) p);
 
+// expected-remark@+11{{added safe interop wrapper}}
 // expected-expansion@+10:77{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func offBySome(_ len: Int32, _ offset: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
@@ -120,6 +131,7 @@ void offByOne(int len, int * __counted_by(len + 1) p);
 // }}
 void offBySome(int len, int offset, int * __counted_by(len + (1 + offset)) p);
 
+// expected-remark@+11{{added safe interop wrapper}}
 // expected-expansion@+10:54{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func scalar(_ m: Int32, _ n: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
@@ -132,6 +144,7 @@ void offBySome(int len, int offset, int * __counted_by(len + (1 + offset)) p);
 // }}
 void scalar(int m, int n, int * __counted_by(m * n) p);
 
+// expected-remark@+11{{added safe interop wrapper}}
 // expected-expansion@+10:67{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func bitwise(_ m: Int32, _ n: Int32, _ o: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
@@ -144,6 +157,7 @@ void scalar(int m, int n, int * __counted_by(m * n) p);
 // }}
 void bitwise(int m, int n, int o, int * __counted_by(m & n | ~o) p);
 
+// expected-remark@+11{{added safe interop wrapper}}
 // expected-expansion@+10:71{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func bitshift(_ m: Int32, _ n: Int32, _ o: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
@@ -156,6 +170,7 @@ void bitwise(int m, int n, int o, int * __counted_by(m & n | ~o) p);
 // }}
 void bitshift(int m, int n, int o, int * __counted_by(m << (n >> o)) p);
 
+// expected-remark@+11{{added safe interop wrapper}}
 // expected-expansion@+10:44{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func constInt(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
@@ -168,6 +183,7 @@ void bitshift(int m, int n, int o, int * __counted_by(m << (n >> o)) p);
 // }}
 void constInt(int * __counted_by(42 * 10) p);
 
+// expected-remark@+11{{added safe interop wrapper}}
 // expected-expansion@+10:66{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func constFloatCastedToInt(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
@@ -180,28 +196,40 @@ void constInt(int * __counted_by(42 * 10) p);
 // }}
 void constFloatCastedToInt(int * __counted_by((int) (4.2 / 12)) p);
 
+// expected-remark@+1{{did not add safe interop wrapper}}
 void sizeofType(int * __counted_by(sizeof(int *)) p);
 
+// expected-remark@+1{{did not add safe interop wrapper}}
 void sizeofParam(int * __counted_by(sizeof(p)) p);
 
+// expected-remark@+1{{did not add safe interop wrapper}}
 void derefLen(int * len, int * __counted_by(*len) p);
 
+// expected-remark@+1{{did not add safe interop wrapper}}
 void lNot(int len, int * __counted_by(!len) p);
 
+// expected-remark@+1{{did not add safe interop wrapper}}
 void lAnd(int len, int * __counted_by(len && len) p);
 
+// expected-remark@+1{{did not add safe interop wrapper}}
 void lOr(int len, int * __counted_by(len || len) p);
 
+// expected-remark@+1{{did not add safe interop wrapper}}
 void floatCastToInt(float meters, int * __counted_by((int) meters) p);
 
+// expected-remark@+1{{did not add safe interop wrapper}}
 void pointerCastToInt(int *square, int * __counted_by((int) square) p);
 
+// expected-remark@+1{{did not add safe interop wrapper}}
 void nanAsInt(int * __counted_by((int) (0 / 0)) p);
 
+// expected-remark@+1{{did not add safe interop wrapper}}
 void unsignedLiteral(int * __counted_by(2u) p);
 
+// expected-remark@+1{{did not add safe interop wrapper}}
 void longLiteral(int * __counted_by(2l) p);
 
+// expected-remark@+11{{added safe interop wrapper}}
 // expected-expansion@+10:43{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func hexLiteral(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
@@ -214,6 +242,7 @@ void longLiteral(int * __counted_by(2l) p);
 // }}
 void hexLiteral(int * __counted_by(0xfa) p);
 
+// expected-remark@+11{{added safe interop wrapper}}
 // expected-expansion@+10:46{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func binaryLiteral(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
@@ -226,6 +255,7 @@ void hexLiteral(int * __counted_by(0xfa) p);
 // }}
 void binaryLiteral(int * __counted_by(0b10) p);
 
+// expected-remark@+11{{added safe interop wrapper}}
 // expected-expansion@+10:45{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func octalLiteral(_ p: UnsafeMutableBufferPointer<Int32>) {|}}

--- a/test/Interop/C/swiftify-import/counted-by.swift
+++ b/test/Interop/C/swiftify-import/counted-by.swift
@@ -265,6 +265,18 @@ void unsignedLiteral(int * __counted_by(2u) p);
 // expected-diagnose-note@+1{{no bounds or lifetime information found}}
 void longLiteral(int * __counted_by(2l) p);
 
+// expected-diagnose-remark@+10{{ignoring __counted_by attribute}}
+// expected-diagnose-note@+9{{count parameter contains unsupported expression kind UnaryOperator}}
+// expected-diagnose-remark@+8{{added safe interop wrapper}}
+// expected-macro-expansion@+7:108{{
+//   expected-macro-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-macro-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func oneIgnoredOneUnignored(_ len1: UnsafeMutablePointer<Int32>!, _ p1: UnsafeMutablePointer<Int32>!, _ p2: UnsafeMutableBufferPointer<Int32>) {|}}
+//   expected-macro-remark@3{{macro content: |    let len2 = Int32(exactly: p2.count)!|}}
+//   expected-macro-remark@4{{macro content: |    return unsafe oneIgnoredOneUnignored(len1, p1, len2, p2.baseAddress!)|}}
+//   expected-macro-remark@5{{macro content: |}|}}
+// }}
+void oneIgnoredOneUnignored(int * len1, int * __counted_by(*len1) p1, int len2, int * __counted_by(len2) p2);
+
 // expected-diagnose-remark@+11{{added safe interop wrapper}}
 // expected-macro-expansion@+10:43{{
 //   expected-macro-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
@@ -313,7 +325,7 @@ module Test {
 
 //--- test.swift
 // GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Test -plugin-path %swift-plugin-dir -I %t -source-filename=x -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast > %t/Test-interface.swift && %swift-function-caller-generator Test %t/Test-interface.swift
-// GENERATED-HASH: dc40e34e2ead0c5c89061ff84e7ecb31d97f258952fb2ff356304ee00b98cb00
+// GENERATED-HASH: 9eae98fc72dd60263d6faad327ecd37248f46330bd811e2446b77eafbf925e7c
 import Test
 
 func call_simple(_ len: Int32, _ p: UnsafeMutablePointer<Int32>!) {
@@ -424,6 +436,10 @@ func call_longLiteral(_ p: UnsafeMutablePointer<Int32>!) {
   return unsafe longLiteral(p)
 }
 
+func call_oneIgnoredOneUnignored(_ len1: UnsafeMutablePointer<Int32>!, _ p1: UnsafeMutablePointer<Int32>!, _ len2: Int32, _ p2: UnsafeMutablePointer<Int32>!) {
+  return unsafe oneIgnoredOneUnignored(len1, p1, len2, p2)
+}
+
 func call_hexLiteral(_ p: UnsafeMutablePointer<Int32>!) {
   return unsafe hexLiteral(p)
 }
@@ -486,6 +502,10 @@ func call_octalLiteral(_ p: UnsafeMutablePointer<Int32>!) {
 
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_offBySome(_ len: Int32, _ offset: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {
   return unsafe offBySome(len, offset, p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_oneIgnoredOneUnignored(_ len1: UnsafeMutablePointer<Int32>!, _ p1: UnsafeMutablePointer<Int32>!, _ p2: UnsafeMutableBufferPointer<Int32>) {
+  return unsafe oneIgnoredOneUnignored(len1, p1, p2)
 }
 
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_returnPointer(_ len: Int32) -> UnsafeMutableBufferPointer<Int32> {

--- a/test/Interop/C/swiftify-import/import-as-instance-method.swift
+++ b/test/Interop/C/swiftify-import/import-as-instance-method.swift
@@ -4,9 +4,9 @@
 // RUN: split-file %s %t
 
 // RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/Test.swiftmodule -I %t%{fs-sep}Inputs -enable-experimental-feature SafeInteropWrappers -strict-memory-safety \
-// RUN:    -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}instance.h %t/test.swift -I %bridging-path -DVERIFY
+// RUN:    -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}instance.h %t/test.swift -I %bridging-path -DVERIFY -verify-additional-prefix lifetimebound- -Rclang-importer
 // RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/Test.swiftmodule -I %t%{fs-sep}Inputs -strict-memory-safety \
-// RUN:    -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}instance.h %t/test.swift -I %bridging-path -DVERIFY -verify-additional-prefix nolifetimebound-
+// RUN:    -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}instance.h %t/test.swift -I %bridging-path -DVERIFY -verify-additional-prefix nolifetimebound- -Rclang-importer
 // RUN: env SWIFT_BACKTRACE="" %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/Test.swiftmodule -I %t/Inputs -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -warnings-as-errors -Xcc -Werror %t/test.swift -dump-macro-expansions -I %bridging-path 2> %t/out.txt
 // RUN: diff --strip-trailing-cr %t/out.txt %t/out.expected
 
@@ -61,10 +61,13 @@ struct SWIFT_NONESCAPABLE B {};
 struct SWIFT_IMMORTAL_REFERENCE C {};
 typedef struct __attribute__((objc_bridge(id))) D *DRef;
 
+// expected-remark@+1 2{{added safe interop wrapper}}
 void basic(struct A *a, int * __counted_by(len) p __noescape, int len) __attribute__((swift_name("A.basic(self:_:_:)")));
 
+// expected-remark@+1 2{{added safe interop wrapper}}
 void renamed(struct A *a, int * __counted_by(len) p __noescape, int len) __attribute__((swift_name("A.bar(self:_:_:)")));
 
+// expected-remark@+1 2{{added safe interop wrapper}}
 void countedSelf(struct A * __counted_by(len)
   a, // expected-warning{{bounds attribute '__counted_by' ignored on parameter mapped to 'self'}}
   int * __counted_by(len) p __noescape, int len)
@@ -72,29 +75,46 @@ void countedSelf(struct A * __counted_by(len)
   swift_name // expected-note{{swift_name maps free function to instance method here}}
   ("A.countedSelf(self:_:_:)")));
 
+// expected-remark@+1 2{{added safe interop wrapper}}
 void constSelf(const struct A *a, int * __counted_by(len) p __noescape, int len) __attribute__((swift_name("A.constSelf(self:_:_:)")));
 
+// expected-remark@+1 2{{added safe interop wrapper}}
 void valSelf(struct A a, int * __counted_by(len) p __noescape, int len) __attribute__((swift_name("A.valSelf(self:_:_:)")));
 
+// expected-remark@+1 2{{added safe interop wrapper}}
 void refSelf(struct C *c, int * __counted_by(len) p __noescape, int len) __attribute__((swift_name("C.refSelf(self:_:_:)")));
 
+// expected-remark@+1 2{{added safe interop wrapper}}
 void refSelfCF(DRef d, int * __counted_by(len) p __noescape, int len) __attribute__((swift_name("D.refSelf(self:_:_:)")));
 
+// expected-lifetimebound-remark@+3 2{{added safe interop wrapper}}
+// expected-nolifetimebound-remark@+2 2{{did not add safe interop wrapper}}
+// expected-nolifetimebound-note@+1 2{{lifetimebound support is not yet stabilized}}
 int * __counted_by(len) lifetimeBoundSelf(struct A a __lifetimebound, int len) __attribute__((swift_name("A.lifetimeBoundSelf(self:_:)")));
 
+// expected-remark@+1{{added safe interop wrapper}}
 void nonescaping(const struct B *d, int * __counted_by(len) p __noescape, int len) __attribute__((swift_name("B.nonescaping(self:_:_:)")));
 
+// expected-lifetimebound-remark@+3{{added safe interop wrapper}}
+// expected-nolifetimebound-remark@+2{{did not add safe interop wrapper}}
+// expected-nolifetimebound-note@+1{{lifetimebound support is not yet stabilized}}
 int * __counted_by(len) nonescapingLifetimebound(struct B *d __lifetimebound, int len) __attribute__((swift_name("B.nonescapingLifetimebound(self:_:)")));
 
+// expected-remark@+1 2{{added safe interop wrapper}}
 struct A * createA(int len, int * __counted_by(len) p) __attribute__((swift_name("A.init(countA:pointerA:)")));
+// expected-remark@+1 2{{added safe interop wrapper}}
 struct A * createA2(int len, int * __counted_by(len) p __noescape) __attribute__((swift_name("A.init(countA2:pointerA2:)")));
 
 // This crashes the compiler rdar://169580475
 // struct B * createB(int len, int * __counted_by(len) p __lifetimebound) __attribute__((swift_name("B.init(_:_:)")));
 
+// expected-remark@+1 2{{added safe interop wrapper}}
 struct C * createC(int len, int * __counted_by(len) p) __attribute__((swift_name("C.init(countC:pointerC:)")));
 
 // This should not generate an overload, because Swift does not allow user-defined initiailizers for CF-style foreign references
+// expected-remark@+4{{added safe interop wrapper}}
+// expected-note@+3{{Swift cannot define initializer for CoreFoundation style reference type}}
+// expected-remark@+2{{did not add safe interop wrapper}}
 // expected-note@+1{{'init(countD:pointerD:)' declared here}}
 DRef createD(int len, int * __counted_by(len) p) __attribute__((swift_name("D.init(countD:pointerD:)")));
 

--- a/test/Interop/C/swiftify-import/memcmp.swift
+++ b/test/Interop/C/swiftify-import/memcmp.swift
@@ -7,7 +7,7 @@
 // RUN: %empty-directory(%t/sdk)
 
 // RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -strict-memory-safety -sdk %t/sdk \
-// RUN:   -Xcc -Werror %t%{fs-sep}test.swift -import-objc-header %t%{fs-sep}test.h -verify -verify-additional-file %t%{fs-sep}test.h -Rmacro-expansions
+// RUN:   -Xcc -Werror %t%{fs-sep}test.swift -import-objc-header %t%{fs-sep}test.h -verify -verify-additional-file %t%{fs-sep}test.h -Rmacro-expansions -Rclang-importer
 
 // Check that ClangImporter does not try to apply _SwiftifyImport to functions in SwiftShims,
 // as it does not import the standard library types.
@@ -29,3 +29,5 @@ public func callMemCmp2(_ p1: UnsafeMutableRawPointer, _ p2: UnsafeMutableRawPoi
 
 // expected-note@+1{{'memcmp' declared here}}
 int memcmp(const void * _Nullable __sized_by(n) s1, const void * _Nullable __sized_by(n) s2, size_t n);
+// expected-remark@-1{{did not add safe interop wrapper}}
+// expected-note@-2{{module SwiftShims does not import the Swift module}}

--- a/test/Interop/C/swiftify-import/memcmp.swift
+++ b/test/Interop/C/swiftify-import/memcmp.swift
@@ -7,7 +7,7 @@
 // RUN: %empty-directory(%t/sdk)
 
 // RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -strict-memory-safety -sdk %t/sdk \
-// RUN:   -Xcc -Werror %t%{fs-sep}test.swift -import-objc-header %t%{fs-sep}test.h -verify -verify-additional-file %t%{fs-sep}test.h -Rmacro-expansions -Rclang-importer
+// RUN:   -Xcc -Werror %t%{fs-sep}test.swift -import-objc-header %t%{fs-sep}test.h -verify -verify-additional-file %t%{fs-sep}test.h -Rmacro-expansions -Rclang-importer -verify-additional-prefix %if OS=windows-msvc %{ windows- %} %else %{ nonwindows- %}
 
 // Check that ClangImporter does not try to apply _SwiftifyImport to functions in SwiftShims,
 // as it does not import the standard library types.
@@ -30,4 +30,5 @@ public func callMemCmp2(_ p1: UnsafeMutableRawPointer, _ p2: UnsafeMutableRawPoi
 // expected-note@+1{{'memcmp' declared here}}
 int memcmp(const void * _Nullable __sized_by(n) s1, const void * _Nullable __sized_by(n) s2, size_t n);
 // expected-remark@-1{{did not add safe interop wrapper}}
-// expected-note@-2{{module SwiftShims does not import the Swift module}}
+// expected-nonwindows-note@-2{{module SwiftShims does not import the Swift module}}
+// expected-windows-note@-2{{module vcruntime does not import the Swift module}}

--- a/test/Interop/C/swiftify-import/memcmp.swift
+++ b/test/Interop/C/swiftify-import/memcmp.swift
@@ -31,4 +31,4 @@ public func callMemCmp2(_ p1: UnsafeMutableRawPointer, _ p2: UnsafeMutableRawPoi
 int memcmp(const void * _Nullable __sized_by(n) s1, const void * _Nullable __sized_by(n) s2, size_t n);
 // expected-remark@-1{{did not add safe interop wrapper}}
 // expected-nonwindows-note@-2{{module SwiftShims does not import the Swift module}}
-// expected-windows-note@-2{{module vcruntime does not import the Swift module}}
+// expected-windows-note@-3{{module vcruntime does not import the Swift module}}

--- a/test/Interop/C/swiftify-import/nonescapable-return-without-lifetime.swift
+++ b/test/Interop/C/swiftify-import/nonescapable-return-without-lifetime.swift
@@ -3,7 +3,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 // RUN: %target-swift-frontend -emit-module -I %t -plugin-path %swift-plugin-dir -strict-memory-safety -enable-experimental-feature Lifetimes %t/test.swift \
-// RUN:    -Rmacro-expansions -verify -verify-additional-file %t%{fs-sep}test.h
+// RUN:    -Rmacro-expansions -verify -verify-additional-file %t%{fs-sep}test.h -Rclang-importer
 
 //--- module.modulemap
 module Test {
@@ -20,6 +20,8 @@ struct __attribute__((swift_attr("~Escapable"))) NonescapableStruct {};
 // expected-error@+2{{a function with a ~Escapable result requires '@_lifetime(...)'}}
 // expected-warning@+1{{the returned type 'struct NonescapableStruct' is annotated as non-escapable; its lifetime dependencies must be annotated}}
 struct NonescapableStruct nonescapableReturnNoLifetime(int len, int * __counted_by(len) p);
+// expected-remark@-1:27{{did not add safe interop wrapper}}
+// expected-note@-2:1{{function without lifetime information returns ~Escapable type 'NonescapableStruct'}}
 
 //--- test.swift
 import Test

--- a/test/Interop/C/swiftify-import/sized-by-lifetimebound.swift
+++ b/test/Interop/C/swiftify-import/sized-by-lifetimebound.swift
@@ -174,6 +174,7 @@ uint8_t *__sized_by(size)  bytesized(int size, const uint8_t * p __sized_by(size
 // }}
 char *__sized_by(size) charsized(char * p __sized_by(size) __lifetimebound, int size);
 
+// expected-experimental-remark@+1{{ignoring lifetimebound attribute because return value is Escapable}}
 const uint16_t *__sized_by(size)  doublebytesized(uint16_t * p __sized_by(size) __lifetimebound, int size);
 
 //--- module.modulemap

--- a/test/Interop/C/swiftify-import/sized-by-lifetimebound.swift
+++ b/test/Interop/C/swiftify-import/sized-by-lifetimebound.swift
@@ -5,11 +5,11 @@
 // RUN: split-file %s %t
 
 // RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %t -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature Lifetimes -strict-memory-safety -Xcc -Wno-nullability-completeness \
-// RUN:   %t/test.swift -verify -verify-additional-file %t%{fs-sep}test.h -verify-additional-prefix experimental- -Rmacro-expansions -suppress-notes
+// RUN:   %t/test.swift -verify -verify-additional-file %t%{fs-sep}test.h -verify-additional-prefix experimental- -Rmacro-expansions -Rclang-importer -verify-ignore-macro-note
 
 // lifetimebound support is not stabilized yet. Don't generate _any_ overloads on functions with lifetimebound to prevent future sourcebreak.
 // RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %t -enable-experimental-feature Lifetimes -strict-memory-safety -Xcc -Wno-nullability-completeness \
-// RUN:   %t/test.swift -verify -verify-additional-file %t%{fs-sep}test.h -verify-additional-prefix stable- -Rmacro-expansions -suppress-notes
+// RUN:   %t/test.swift -verify -verify-additional-file %t%{fs-sep}test.h -verify-additional-prefix stable- -Rmacro-expansions -Rclang-importer -verify-ignore-macro-note
 
 // Check that ClangImporter correctly infers and expands @_SwiftifyImport macros for functions with __sized_by __lifetimebound parameters and return values.
 
@@ -23,6 +23,10 @@
 #endif
 #define __lifetimebound __attribute__((lifetimebound))
 
+// expected-stable-note@+17{{'simple' declared here}}
+// expected-stable-remark@+16{{did not add safe interop wrapper}}
+// expected-stable-note@+15{{lifetimebound support is not yet stabilized}}
+// expected-experimental-remark@+14{{added safe interop wrapper}}
 // expected-experimental-expansion@+13:70{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload public func simple(_ len: Int32, _ p: RawSpan) -> RawSpan {|}}
@@ -38,6 +42,10 @@
 // }}
 const void * __sized_by(len) simple(int len, int len2, const void * p __sized_by(len2) __lifetimebound);
 
+// expected-stable-note@+17{{'shared' declared here}}
+// expected-stable-remark@+16{{did not add safe interop wrapper}}
+// expected-stable-note@+15{{lifetimebound support is not yet stabilized}}
+// expected-experimental-remark@+14{{added safe interop wrapper}}
 // expected-experimental-expansion@+13:60{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload public func shared(_ p: RawSpan) -> RawSpan {|}}
@@ -53,6 +61,10 @@ const void * __sized_by(len) simple(int len, int len2, const void * p __sized_by
 // }}
 const void * __sized_by(len) shared(int len, const void * p __sized_by(len) __lifetimebound);
 
+// expected-stable-note@+17{{'complexExpr' declared here}}
+// expected-stable-remark@+16{{did not add safe interop wrapper}}
+// expected-stable-note@+15{{lifetimebound support is not yet stabilized}}
+// expected-experimental-remark@+14{{added safe interop wrapper}}
 // expected-experimental-expansion@+13:96{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload public func complexExpr(_ len: Int32, _ offset: Int32, _ p: RawSpan) -> RawSpan {|}}
@@ -68,6 +80,10 @@ const void * __sized_by(len) shared(int len, const void * p __sized_by(len) __li
 // }}
 const void * __sized_by(len - offset) complexExpr(int len, int offset, int len2, const void * p __sized_by(len2) __lifetimebound);
 
+// expected-stable-note@+17{{'nullUnspecified' declared here}}
+// expected-stable-remark@+16{{did not add safe interop wrapper}}
+// expected-stable-note@+15{{lifetimebound support is not yet stabilized}}
+// expected-experimental-remark@+14{{added safe interop wrapper}}
 // expected-experimental-expansion@+13:115{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload public func nullUnspecified(_ len: Int32, _ p: RawSpan) -> RawSpan {|}}
@@ -83,6 +99,10 @@ const void * __sized_by(len - offset) complexExpr(int len, int offset, int len2,
 // }}
 const void * __sized_by(len) _Null_unspecified nullUnspecified(int len, int len2, const void * _Null_unspecified p __sized_by(len2) __lifetimebound);
 
+// expected-stable-note@+17{{'nonnull' declared here}}
+// expected-stable-remark@+16{{did not add safe interop wrapper}}
+// expected-stable-note@+15{{lifetimebound support is not yet stabilized}}
+// expected-experimental-remark@+14{{added safe interop wrapper}}
 // expected-experimental-expansion@+13:89{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload public func nonnull(_ len: Int32, _ p: RawSpan) -> RawSpan {|}}
@@ -98,6 +118,10 @@ const void * __sized_by(len) _Null_unspecified nullUnspecified(int len, int len2
 // }}
 const void * __sized_by(len) _Nonnull nonnull(int len, int len2, const void * _Nonnull p __sized_by(len2) __lifetimebound);
 
+// expected-stable-note@+24{{'nullable' declared here}}
+// expected-stable-remark@+23{{did not add safe interop wrapper}}
+// expected-stable-note@+22{{lifetimebound support is not yet stabilized}}
+// expected-experimental-remark@+21{{added safe interop wrapper}}
 // expected-experimental-expansion@+20:92{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload public func nullable(_ len: Int32, _ p: RawSpan?) -> RawSpan? {|}}
@@ -121,6 +145,10 @@ const void * __sized_by(len) _Nonnull nonnull(int len, int len2, const void * _N
 const void * __sized_by(len) _Nullable nullable(int len, int len2, const void * _Nullable p __sized_by(len2) __lifetimebound);
 
 typedef struct foo opaque_t;
+// expected-stable-note@+17{{'opaque' declared here}}
+// expected-stable-remark@+16{{did not add safe interop wrapper}}
+// expected-stable-note@+15{{lifetimebound support is not yet stabilized}}
+// expected-experimental-remark@+14{{added safe interop wrapper}}
 // expected-experimental-expansion@+13:66{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload public func opaque(_ len: Int32, _ p: RawSpan) -> RawSpan {|}}
@@ -136,6 +164,9 @@ typedef struct foo opaque_t;
 // }}
 opaque_t * __sized_by(len) opaque(int len, int len2, opaque_t * p __sized_by(len2) __lifetimebound);
 
+// expected-stable-remark@+9{{did not add safe interop wrapper}}
+// expected-stable-note@+8{{lifetimebound support is not yet stabilized}}
+// expected-experimental-remark@+7{{added safe interop wrapper}}
 // expected-experimental-expansion@+6:70{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(borrow p) @_disfavoredOverload public func nonsizedLifetime(_ len: Int32, _ p: UnsafeRawPointer!) -> RawSpan {|}}
@@ -144,6 +175,10 @@ opaque_t * __sized_by(len) opaque(int len, int len2, opaque_t * p __sized_by(len
 // }}
 const void * __sized_by(len) nonsizedLifetime(int len, const void * p __lifetimebound);
 
+// expected-stable-note@+17{{'bytesized' declared here}}
+// expected-stable-remark@+16{{did not add safe interop wrapper}}
+// expected-stable-note@+15{{lifetimebound support is not yet stabilized}}
+// expected-experimental-remark@+14{{added safe interop wrapper}}
 // expected-experimental-expansion@+13:65{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload public func bytesized(_ p: RawSpan) -> MutableRawSpan {|}}
@@ -159,6 +194,10 @@ const void * __sized_by(len) nonsizedLifetime(int len, const void * p __lifetime
 // }}
 uint8_t *__sized_by(size)  bytesized(int size, const uint8_t * p __sized_by(size) __lifetimebound);
 
+// expected-stable-note@+17{{'charsized' declared here}}
+// expected-stable-note@+16{{lifetimebound support is not yet stabilized}}
+// expected-stable-remark@+15{{did not add safe interop wrapper}}
+// expected-experimental-remark@+14{{added safe interop wrapper}}
 // expected-experimental-expansion@+13:85{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public func charsized(_ p: inout MutableRawSpan) -> MutableRawSpan {|}}
@@ -174,7 +213,14 @@ uint8_t *__sized_by(size)  bytesized(int size, const uint8_t * p __sized_by(size
 // }}
 char *__sized_by(size) charsized(char * p __sized_by(size) __lifetimebound, int size);
 
-// expected-experimental-remark@+1{{ignoring lifetimebound attribute because return value is Escapable}}
+// expected-remark@+8 2{{ignoring __sized_by attribute}}
+// expected-note@+7 2{{__sized_by attribute on pointer to type larger than a single byte}}
+// expected-note@+6 2{{type 'uint16_t' has size 2}}
+// expected-stable-remark@+5{{did not add safe interop wrapper}}
+// expected-stable-note@+4{{lifetimebound support is not yet stabilized}}
+// expected-experimental-remark@+3{{ignoring lifetimebound attribute because return value is Escapable}}
+// expected-experimental-remark@+2{{did not add safe interop wrapper}}
+// expected-experimental-note@+1{{no bounds or lifetime information found}}
 const uint16_t *__sized_by(size)  doublebytesized(uint16_t * p __sized_by(size) __lifetimebound, int size);
 
 //--- module.modulemap
@@ -288,6 +334,7 @@ func call_doublebytesized(_ p: UnsafeMutablePointer<UInt16>!, _ size: Int32) -> 
 @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 @_lifetime(copy p)
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ len: Int32, _ p: RawSpan?) -> RawSpan? {
+  // expected-stable-note@+4{{arguments to generic parameter 'Wrapped' ('UnsafeRawPointer' and 'RawSpan') are expected to be equal}}
   // expected-stable-error@+3{{missing argument for parameter #3 in call}}
   // expected-stable-error@+2{{cannot convert value of type 'RawSpan?' to expected argument type 'Int32'}}
   // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeRawPointer?' to return type 'RawSpan?'}}

--- a/test/Interop/Cxx/stdlib/Inputs/std-span.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-span.h
@@ -80,54 +80,81 @@ struct CaptureByReference {
     ConstSpanOfInt x;
 };
 
+// expected-remark@+1{{added safe interop wrapper}}
 inline void funcWithSafeWrapper(ConstSpanOfInt s [[clang::noescape]]) {}
 
+// expected-experimental-remark@+2{{added safe interop wrapper}}
+// expected-default-remark@+1{{did not add safe interop wrapper}}
 inline ConstSpanOfInt funcWithSafeWrapper2(ConstSpanOfInt s
+                                           // expected-default-note@+1{{lifetimebound support is not yet stabilized}}
                                            [[clang::lifetimebound]]) {
   return s;
 }
 
+// expected-experimental-remark@+2{{added safe interop wrapper}}
+// expected-default-remark@+1{{did not add safe interop wrapper}}
 inline ConstSpanOfInt funcWithSafeWrapper3(const VecOfInt &v
+                                           // expected-default-note@+1{{lifetimebound support is not yet stabilized}}
                                            [[clang::lifetimebound]]) {
   return ConstSpanOfInt(v.data(), v.size());
 }
 
+// expected-note@+2{{implicit functions are ignored}}
+// expected-remark@+1{{did not add safe interop wrapper}}
 struct X {
+  // expected-remark@+1{{added safe interop wrapper}}
   inline void methodWithSafeWrapper(ConstSpanOfInt s [[clang::noescape]]) {}
+  // expected-remark@+1{{added safe interop wrapper}}
   SpanOfInt getMutable(ConstSpanOfInt s [[clang::noescape]]) [[clang::lifetimebound]];
 };
 
+// expected-default-note@+3{{'mixedFuncWithSafeWrapper1' declared here}}
+// expected-experimental-remark@+2{{added safe interop wrapper}}
+// expected-default-remark@+1{{did not add safe interop wrapper}}
 inline ConstSpanOfInt mixedFuncWithSafeWrapper1(const int * __counted_by(len) p
+                                           // expected-default-note@+1{{lifetimebound support is not yet stabilized}}
                                            [[clang::lifetimebound]], int len) {
   return ConstSpanOfInt(p, len);
 }
 
+// expected-experimental-remark@+2{{added safe interop wrapper}}
+// expected-default-remark@+1{{did not add safe interop wrapper}}
 inline const int * __counted_by(len) mixedFuncWithSafeWrapper2(const VecOfInt &v
+                                           // expected-default-note@+1{{lifetimebound support is not yet stabilized}}
                                            [[clang::lifetimebound]], int len) {
   if (v.size() <= len)
     return v.data();
   return nullptr;
 }
 
+// expected-remark@+1{{added safe interop wrapper}}
 inline void mixedFuncWithSafeWrapper3(ConstSpanOfInt s [[clang::noescape]],
                                       int * __counted_by(len) p, int len) {}
 
+// expected-remark@+1{{added safe interop wrapper}}
 inline void mixedFuncWithSafeWrapper4(ConstSpanOfInt s [[clang::noescape]],
                                       const int * __counted_by(len) p [[clang::noescape]], int len) {}
 
+// expected-remark@+1{{added safe interop wrapper}}
 inline void mixedFuncWithSafeWrapper5(ConstSpanOfInt s,
                                       const int * __counted_by(len) p [[clang::noescape]], int len) {}
 
+// expected-remark@+1{{added safe interop wrapper}}
 inline void mixedFuncWithSafeWrapper6(ConstSpanOfInt s,
                                       int * __counted_by(len) p, int len) {}
 
+// expected-remark@+1{{added safe interop wrapper}}
 inline ConstSpanOfInt mixedFuncWithSafeWrapper7(const int * __counted_by(len) p, int len) {
   return ConstSpanOfInt(p, len);
 }
 
+// expected-remark@+1{{added safe interop wrapper}}
 inline void FuncWithMutableSafeWrapper(SpanOfInt s [[clang::noescape]]) {}
 
+// expected-experimental-remark@+2{{added safe interop wrapper}}
+// expected-default-remark@+1{{did not add safe interop wrapper}}
 inline SpanOfInt FuncWithMutableSafeWrapper2(SpanOfInt s
+                                           // expected-default-note@+1{{lifetimebound support is not yet stabilized}}
                                            [[clang::lifetimebound]]) {
   return s;
 }
@@ -141,48 +168,77 @@ struct Y {
   inline void methodWithMutableSafeWrapper(SpanOfInt s [[clang::noescape]]) {}
 };
 
+// expected-default-note@+3{{'MixedFuncWithMutableSafeWrapper1' declared here}}
+// expected-experimental-remark@+2{{added safe interop wrapper}}
+// expected-default-remark@+1{{did not add safe interop wrapper}}
 inline SpanOfInt MixedFuncWithMutableSafeWrapper1(int * __counted_by(len) p
+                                           // expected-default-note@+1{{lifetimebound support is not yet stabilized}}
                                            [[clang::lifetimebound]], int len) {
   return SpanOfInt(p, len);
 }
 
+// expected-experimental-remark@+2{{added safe interop wrapper}}
+// expected-default-remark@+1{{did not add safe interop wrapper}}
 inline int * __counted_by(len) MixedFuncWithMutableSafeWrapper2(VecOfInt &v
+                                           // expected-default-note@+1{{lifetimebound support is not yet stabilized}}
                                            [[clang::lifetimebound]], int len) {
   if (v.size() <= len)
     return v.data();
   return nullptr;
 }
 
+// expected-remark@+1{{added safe interop wrapper}}
 inline void MixedFuncWithMutableSafeWrapper3(SpanOfInt s [[clang::noescape]],
                                       int * __counted_by(len) p, int len) {}
 
+// expected-remark@+1{{added safe interop wrapper}}
 inline void MixedFuncWithMutableSafeWrapper4(SpanOfInt s [[clang::noescape]],
                                       int * __counted_by(len) p [[clang::noescape]], int len) {}
 
+// expected-remark@+1{{added safe interop wrapper}}
 inline void MixedFuncWithMutableSafeWrapper5(SpanOfInt s,
                                       int * __counted_by(len) p [[clang::noescape]], int len) {}
 
+// expected-remark@+1{{added safe interop wrapper}}
 inline void MixedFuncWithMutableSafeWrapper6(SpanOfInt s,
                                       int * __counted_by(len) p, int len) {}
 
+// expected-remark@+1{{added safe interop wrapper}}
 inline SpanOfInt MixedFuncWithMutableSafeWrapper7(int * __counted_by(len) p, int len) {
   return SpanOfInt(p, len);
 }
 
 template <typename X>
+// expected-remark@+2{{did not add safe interop wrapper}}
+// expected-note@+1{{implicit functions are ignored}}
 struct S {};
 
+// expected-remark@+2{{did not add safe interop wrapper}}
+// expected-note@+1{{implicit functions are ignored}}
 struct SpanWithoutTypeAlias {
+  // expected-remark@+2{{did not add safe interop wrapper}}
+  // expected-note@+1{{template specialization cannot be represented in Swift syntax; try hiding it behind a typedef}}
   std::span<const int> bar() [[clang::lifetimebound]];
+  // expected-note@+2{{template specialization cannot be represented in Swift syntax; try hiding it behind a typedef}}
+  // expected-remark@+1{{did not add safe interop wrapper}}
   void foo(std::span<const int> s [[clang::noescape]]);
+  // expected-note@+2{{template specialization cannot be represented in Swift syntax; try hiding it behind a typedef}}
+  // expected-remark@+1{{did not add safe interop wrapper}}
   void otherTemplatedType(ConstSpanOfInt copy [[clang::noescape]], S<int>);
+  // expected-note@+2{{template specialization cannot be represented in Swift syntax; try hiding it behind a typedef}}
+  // expected-remark@+1{{did not add safe interop wrapper}}
   void otherTemplatedType2(ConstSpanOfInt copy [[clang::noescape]], S<int> *);
 };
 
 inline void func(ConstSpanOfInt copy [[clang::noescape]]) {}
+// expected-remark@+1{{added safe interop wrapper}}
 inline void mutableKeyword(SpanOfInt copy [[clang::noescape]]) {}
 
+// expected-note@+2{{template specialization cannot be represented in Swift syntax; try hiding it behind a typedef}}
+// expected-remark@+1{{did not add safe interop wrapper}}
 inline void spanWithoutTypeAlias(std::span<const int> s [[clang::noescape]]) {}
+// expected-note@+2{{template specialization cannot be represented in Swift syntax; try hiding it behind a typedef}}
+// expected-remark@+1{{did not add safe interop wrapper}}
 inline void mutableSpanWithoutTypeAlias(std::span<int> s [[clang::noescape]]) {}
 
 #define IMMORTAL_FRT                                                           \

--- a/test/Interop/Cxx/stdlib/std-span-interface.swift
+++ b/test/Interop/Cxx/stdlib/std-span-interface.swift
@@ -7,9 +7,11 @@
 // RUN: %FileCheck %s --match-full-lines --check-prefixes=CHECK,CHECK-LEGACY < %t/interface-lifetimebound.swift
 
 // Make sure we trigger typechecking and SIL diagnostics
-// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %S/Inputs -enable-experimental-feature Lifetimes -cxx-interoperability-mode=default -strict-memory-safety -verify -Xcc -std=c++20 %s -verify-additional-prefix default- -suppress-notes
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %S/Inputs -enable-experimental-feature Lifetimes -cxx-interoperability-mode=default -strict-memory-safety -verify -Xcc -std=c++20 %s \
+// RUN:   -verify-additional-prefix default- -Rclang-importer -verify-additional-file %S%{fs-sep}Inputs%{fs-sep}std-span.h -verify-ignore-unrelated
 
-// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %S/Inputs -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature Lifetimes -cxx-interoperability-mode=default -strict-memory-safety -verify -Xcc -std=c++20 %s
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %S/Inputs -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature Lifetimes -cxx-interoperability-mode=default -strict-memory-safety -verify -Xcc -std=c++20 %s \
+// RUN:   -verify-additional-prefix experimental- -Rclang-importer -verify-additional-file %S%{fs-sep}Inputs%{fs-sep}std-span.h -verify-ignore-unrelated
 
 // REQUIRES: swift_feature_SafeInteropWrappers
 // REQUIRES: swift_feature_Lifetimes
@@ -184,8 +186,9 @@ func callFuncWithMutableSafeWrapper2(_ span: inout MutableSpan<CInt>, ) {
 
 @_lifetime(span: copy span)
 func callMixedFuncWithMutableSafeWrapper1(_ span: inout MutableSpan<CInt>, ) {
-    // expected-default-error@+3{{missing argument for parameter #2 in call}}
-    // expected-default-error@+2{{cannot convert value of type 'UnsafeMutablePointer<MutableSpan<CInt>>' (aka 'UnsafeMutablePointer<MutableSpan<Int32>>') to expected argument type 'UnsafeMutablePointer<Int32>'}}
+    // expected-default-error@+4{{missing argument for parameter #2 in call}}
+    // expected-default-error@+3{{cannot convert value of type 'UnsafeMutablePointer<MutableSpan<CInt>>' (aka 'UnsafeMutablePointer<MutableSpan<Int32>>') to expected argument type 'UnsafeMutablePointer<Int32>'}}
+    // expected-default-note@+2{{arguments to generic parameter 'Pointee' ('MutableSpan<CInt>' (aka 'MutableSpan<Int32>') and 'Int32') are expected to be equal}}
     // expected-default-error@+1{{cannot convert value of type 'SpanOfInt'}}
     let _: MutableSpan<CInt> = MixedFuncWithMutableSafeWrapper1(&span)
 }

--- a/test/Interop/Cxx/stdlib/std-span-interface.swift
+++ b/test/Interop/Cxx/stdlib/std-span-interface.swift
@@ -7,10 +7,10 @@
 // RUN: %FileCheck %s --match-full-lines --check-prefixes=CHECK,CHECK-LEGACY < %t/interface-lifetimebound.swift
 
 // Make sure we trigger typechecking and SIL diagnostics
-// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %S/Inputs -enable-experimental-feature Lifetimes -cxx-interoperability-mode=default -strict-memory-safety -verify -Xcc -std=c++20 %s \
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %S%{fs-sep}Inputs -enable-experimental-feature Lifetimes -cxx-interoperability-mode=default -strict-memory-safety -verify -Xcc -std=c++20 %s \
 // RUN:   -verify-additional-prefix default- -Rclang-importer -verify-additional-file %S%{fs-sep}Inputs%{fs-sep}std-span.h -verify-ignore-unrelated
 
-// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %S/Inputs -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature Lifetimes -cxx-interoperability-mode=default -strict-memory-safety -verify -Xcc -std=c++20 %s \
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %S%{fs-sep}Inputs -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature Lifetimes -cxx-interoperability-mode=default -strict-memory-safety -verify -Xcc -std=c++20 %s \
 // RUN:   -verify-additional-prefix experimental- -Rclang-importer -verify-additional-file %S%{fs-sep}Inputs%{fs-sep}std-span.h -verify-ignore-unrelated
 
 // REQUIRES: swift_feature_SafeInteropWrappers


### PR DESCRIPTION
This lays the groundwork for emitting more context about ClangImporter
decisions when requested. This context comes in the form of remarks, and
is intended to help people understand why ClangImporter behaves the way
it does.

This initial implementation only has a few remarks, all of them in SwiftifyDecl.cpp.
If this expands a lot we may want to add subcategories to allow filtering, e.g.
-Rclang-importer=safe-interop-wrappers.