### PR TITLE
Support `-sanitize=fuzzer-no-link`.

### DIFF
--- a/include/swift/Basic/Sanitizers.def
+++ b/include/swift/Basic/Sanitizers.def
@@ -20,11 +20,12 @@
 
 // SANITIZER(enum_bit, kind, name, file)
 
-SANITIZER(0, Address,     address,      asan)
-SANITIZER(1, Thread,      thread,       tsan)
-SANITIZER(2, Undefined,   undefined,    ubsan)
-SANITIZER(3, Fuzzer,      fuzzer,       fuzzer)
-SANITIZER(4, Scudo,       scudo,        scudo_standalone)
-SANITIZER(5, MemTagStack, memtag-stack, memtag-stack)
+SANITIZER(0, Address,      address,        asan)
+SANITIZER(1, Thread,       thread,         tsan)
+SANITIZER(2, Undefined,    undefined,      ubsan)
+SANITIZER(3, Fuzzer,       fuzzer,         fuzzer)
+SANITIZER(4, Scudo,        scudo,          scudo_standalone)
+SANITIZER(5, MemTagStack,  memtag-stack,   memtag-stack)
+SANITIZER(6, FuzzerNoLink, fuzzer-no-link, fuzzer)
 
 #undef SANITIZER

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3846,7 +3846,8 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
   if (const Arg *A = Args.getLastArg(options::OPT_sanitize_coverage_EQ)) {
     Opts.SanitizeCoverage =
         parseSanitizerCoverageArgValue(A, Triple, Diags, Opts.Sanitizers);
-  } else if (Opts.Sanitizers & SanitizerKind::Fuzzer) {
+  } else if ((Opts.Sanitizers & SanitizerKind::Fuzzer) ||
+             (Opts.Sanitizers & SanitizerKind::FuzzerNoLink)) {
 
     // Automatically set coverage flags, unless coverage type was explicitly
     // requested.

--- a/lib/Option/SanitizerOptions.cpp
+++ b/lib/Option/SanitizerOptions.cpp
@@ -149,13 +149,18 @@ OptionSet<SanitizerKind> swift::parseSanitizerArgValues(
 
     // Support is determined by existence of the sanitizer library.
     auto fileName = toFileName(kind);
-    bool isShared = (kind != SanitizerKind::Fuzzer);
+    bool isShared =
+        (kind != SanitizerKind::Fuzzer && kind != SanitizerKind::FuzzerNoLink);
     bool sanitizerSupported = sanitizerRuntimeLibExists(fileName, isShared);
 
     if (kind == SanitizerKind::MemTagStack)
       // MemTagStack requires no runtime, so ignore library check above
       sanitizerSupported =
           Triple.isOSDarwin() && Triple.getArch() == llvm::Triple::aarch64;
+    else if (kind == SanitizerKind::FuzzerNoLink)
+      // Assume fuzzing is supported if using fuzzer-no-link; the user is
+      // expected to provide the library.
+      sanitizerSupported = true;
 
     // TSan is explicitly not supported for 32 bits.
     if (kind == SanitizerKind::Thread && !Triple.isArch64Bit())

--- a/test/Driver/sanitizers.swift
+++ b/test/Driver/sanitizers.swift
@@ -2,7 +2,6 @@
  * Address Sanitizer Tests  (asan)
  */
 // RUN: %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address -target x86_64-apple-macosx10.9 %s | %FileCheck -check-prefix=ASAN -check-prefix=ASAN_OSX %s
-// RUN: not %swiftc_driver -sdk '""' -driver-print-jobs -sanitize=fuzzer -target x86_64-apple-macosx10.9 -resource-dir %S/Inputs/nonexistent-resource-dir %s 2>&1 | %FileCheck -check-prefix=FUZZER_NONEXISTENT %s
 // RUN: %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address -target x86_64-apple-ios7.1-simulator %s | %FileCheck -check-prefix=ASAN -check-prefix=ASAN_IOSSIM %s
 // RUN: %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address -target arm64-apple-ios7.1 %s  | %FileCheck -check-prefix=ASAN -check-prefix=ASAN_IOS %s
 // RUN: %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address -target x86_64-apple-tvos9.0-simulator %s | %FileCheck -check-prefix=ASAN -check-prefix=ASAN_tvOS_SIM %s
@@ -55,6 +54,12 @@
 // RUN: not %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=memtag-stack -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck -check-prefix=MEMTAGSAN_LINUX %s
 
 /*
+ * Fuzzer Sanitizer Tests
+ */
+// RUN: not %swiftc_driver -sdk '""' -driver-print-jobs -sanitize=fuzzer -target x86_64-apple-macosx10.9 -resource-dir %S/Inputs/nonexistent-resource-dir %s 2>&1 | %FileCheck -check-prefix=FUZZER_NONEXISTENT %s
+// RUN: %swiftc_driver -sdk '""' -driver-print-jobs -sanitize=fuzzer-no-link -target x86_64-apple-macosx10.9 -resource-dir %S/Inputs/nonexistent-resource-dir %s 2>&1 | %FileCheck -check-prefix=FUZZER_NO_LINK %s
+
+/*
  * Multiple Sanitizers At Once
  */
 // RUN: %swiftc_driver -sdk '""' -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address,undefined,fuzzer -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck -check-prefix=MULTIPLE_SAN_LINUX %s
@@ -101,7 +106,6 @@
 // TSAN_tvOS: unsupported option '-sanitize=thread' for target 'arm64-apple-tvos9.0'
 // TSAN_watchOS_SIM: unsupported option '-sanitize=thread' for target 'i386-apple-watchos2.0-simulator'
 // TSAN_watchOS: unsupported option '-sanitize=thread' for target 'armv7k-apple-watchos2.0'
-// FUZZER_NONEXISTENT: unsupported option '-sanitize=fuzzer' for target 'x86_64-apple-macosx10.9'
 // TSAN_LINUX: -fsanitize=thread -lBlocksRuntime -ldispatch
 // TSAN_WINDOWS: unsupported option '-sanitize=thread' for target 'x86_64-unknown-windows-msvc'
 
@@ -136,6 +140,10 @@
 // MEMTAGSAN_watchOS: unsupported option '-sanitize=memtag-stack' for target 'armv7k-apple-watchos2.0'
 // MEMTAGSAN_LINUX: unsupported option '-sanitize=memtag-stack' for target 'x86_64-unknown-linux-gnu'
 // MEMTAGSAN_WINDOWS: unsupported option '-sanitize=memtag-stack' for target 'x86_64-unknown-windows-msvc'
+
+// FUZZER_NONEXISTENT: unsupported option '-sanitize=fuzzer' for target 'x86_64-apple-macosx10.9'
+// FUZZER_NO_LINK: swift
+// FUZZER_NO_LINK-NOT: unsupported option '-sanitize=fuzzer-no-link' for target 'x86_64-apple-macosx10.9'
 
 // MULTIPLE_SAN_LINUX: -fsanitize=address,undefined,fuzzer
 


### PR DESCRIPTION
This mirrors Clang's `-fsanitize=fuzzer-no-link`, which applies the appropriate instrumentations but does not attempt to link to the runtime library. More importantly, this suppresses the check in the driver that fails the build if the library cannot be found. Since libfuzzer is not distributed with Xcode, this allows users to build it themselves or take it from a swift.org toolchain and use it without having to physically copy/link it into their toolchain's runtime directory.

Corresponding swift-driver change is in https://github.com/swiftlang/swift-driver/pull/2100.