### PR TITLE
Refactor Conformance struct by removing methods sample

### DIFF
--- a/SwiftCompilerSources/Sources/AST/Conformance.swift
+++ b/SwiftCompilerSources/Sources/AST/Conformance.swift
@@ -20,22 +20,7 @@ import ASTBridging
 public struct Conformance: CustomStringConvertible, Hashable, NoReflectionChildren {
   public let bridged: BridgedConformance
 
-  public init(bridged: BridgedConformance) {
-    self.bridged = bridged
-  }
-
-  public var description: String {
-    return String(taking: bridged.getDebugDescription())
-  }
-
-  public func hash(into hasher: inout Hasher) {
-    hasher.combine(bridged.opaqueValue)
-  }
-
-  public static func ==(lhs: Conformance, rhs: Conformance) -> Bool {
-    lhs.bridged.opaqueValue == rhs.bridged.opaqueValue
-  }
-
+ 
   public var isConcrete: Bool { bridged.isConcrete() }
 
   public var isValid: Bool { bridged.isValid() }


### PR DESCRIPTION
Removed initializer, description, hash, and equality methods from Conformance struct.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
