### PR TITLE
[Sema] Fix type-checker assertion for SourceKit

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -526,6 +526,10 @@ namespace swift {
     /// prevents files from being written.
     bool OpenSourcesAsVolatile = false;
 
+    /// Whether the AST is being built for SourceKit.
+    /// FIXME: Eliminate this, it's a layering violation.
+    bool IsForSourceKit = false;
+
     /// Load swiftmodule files in memory as volatile and avoid mmap.
     bool EnableVolatileModules = false;
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2733,7 +2733,11 @@ NamingPatternRequest::evaluate(Evaluator &evaluator, VarDecl *VD) const {
       // or lazy type-checking, regular type-checking should go through the
       // StmtChecker and assign types before querying this, otherwise we could
       // end up double-type-checking.
+      // FIXME: The check for 'IsForSourceKit' is a hack to workaround cases
+      // where we're doing cursor info in an invalid extension, we ought to
+      // still be type-checking decls in invalid extensions.
       ASSERT(Context.SourceMgr.hasIDEInspectionTargetBuffer() ||
+             Context.LangOpts.IsForSourceKit ||
              Context.TypeCheckerOpts.EnableLazyTypecheck &&
              "Querying VarDecl's type before type-checking parent stmt");
 

--- a/test/SourceKit/CursorInfo/in_invalid_ext.swift
+++ b/test/SourceKit/CursorInfo/in_invalid_ext.swift
@@ -1,0 +1,13 @@
+// Check that we don't crash.
+extension Undefined {
+  func foo() {
+    guard let x
+    // RUN: %sourcekitd-test -req=cursor -pos=%(line-1):15 %s -- %s | %FileCheck --check-prefix ONE %s
+    // ONE: s:14in_invalid_ext3fooyXeXeF1xL_Xevp
+  }
+  func bar() {{
+    guard let x
+    // RUN: %sourcekitd-test -req=cursor -pos=%(line-1):15 %s -- %s | %FileCheck --check-prefix TWO %s
+    // TWO: s:14in_invalid_ext3baryXeXeFXefU_1xL_Xevp
+  }}
+}

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -1146,6 +1146,7 @@ ASTUnitRef ASTBuildOperation::buildASTUnit(std::string &Error) {
       Invocation, convertFileContentsToInputs(getFileContents()));
 
   Invocation.getLangOptions().CollectParsedToken = true;
+  Invocation.getLangOptions().IsForSourceKit = true;
   CompIns.getSourceMgr().setFileSystem(FileSystem);
 
   if (CompIns.setup(Invocation, Error)) {


### PR DESCRIPTION
We ought to properly fix this, but for now let's avoid asserting for SourceKit.