### PR TITLE
Dedup diags from non-primary files

### DIFF
--- a/include/swift/AST/DiagnosticConsumer.h
+++ b/include/swift/AST/DiagnosticConsumer.h
@@ -294,6 +294,11 @@ private:
 
   bool HasAnErrorBeenConsumed = false;
 
+  /// True when more than one subconsumer has a real (non-null) consumer,
+  /// i.e. we are in batch-mode where multiple primaries share one invocation.
+  /// False in single-primary-per-job mode where there is exactly one primary.
+  bool HasMultiplePrimaryConsumers = false;
+
   /// Takes ownership of the DiagnosticConsumers specified in \p consumers.
   ///
   /// There must not be two consumers for the same file (i.e., having the same

--- a/lib/AST/DiagnosticConsumer.cpp
+++ b/lib/AST/DiagnosticConsumer.cpp
@@ -83,6 +83,11 @@ FileSpecificDiagnosticConsumer::FileSpecificDiagnosticConsumer(
          "don't waste time handling diagnostics that will never get emitted");
   assert(!hasDuplicateFileNames(Subconsumers) &&
          "having multiple subconsumers for the same file is not implemented");
+  size_t realConsumerCount =
+      llvm::count_if(Subconsumers, [](const Subconsumer &s) {
+        return s.getConsumer() != nullptr;
+      });
+  HasMultiplePrimaryConsumers = realConsumerCount > 1;
 }
 
 void FileSpecificDiagnosticConsumer::computeConsumersOrderedByRange(
@@ -218,7 +223,14 @@ FileSpecificDiagnosticConsumer::findSubconsumerForNonNote(
     return std::nullopt; // No place to put it; might be in an imported module
   if ((*subconsumer)->getConsumer())
     return subconsumer; // A primary file with a .dia file
-  // Try to put it in the responsible primary input
+  // Found a null/eater subconsumer for a non-primary file.
+  // In single-primary-per-job mode (only one real consumer exists), return the
+  // eater so the diagnostic is silently discarded: it will be reported by the
+  // separate job that compiles that file as its primary.
+  // In batch mode (multiple real consumers), route to the responsible primary.
+  if (!HasMultiplePrimaryConsumers)
+    return subconsumer; // eat
+  // Batch mode: route to the responsible primary input.
   if (Info.BufferIndirectlyCausingDiagnostic.isInvalid())
     return std::nullopt;
   const auto currentPrimarySubconsumer =

--- a/lib/Frontend/DiagnosticHelper.cpp
+++ b/lib/Frontend/DiagnosticHelper.cpp
@@ -70,10 +70,29 @@ private:
   llvm::StringMap<std::vector<std::string>> FileSpecificDiagnostics;
   std::unique_ptr<DiagnosticConsumer> FileSpecificAccumulatingConsumer;
   std::unique_ptr<DiagnosticConsumer> SerializedConsumerDispatcher;
+  std::unique_ptr<DiagnosticConsumer> PrintingConsumerDispatcher;
   std::unique_ptr<DiagnosticConsumer> FixItsConsumer;
 };
 
 namespace {
+
+/// Forwards handleDiagnostic to a PrintingDiagnosticConsumer, temporarily
+/// unsuppressing it so that primary-file diagnostics are printed even though
+/// the PDC is otherwise suppressed to prevent non-primary-file diagnostics
+/// from reaching stderr.
+class UnsuppressedPDCForwarder : public DiagnosticConsumer {
+  PrintingDiagnosticConsumer &PDC;
+public:
+  explicit UnsuppressedPDCForwarder(PrintingDiagnosticConsumer &pdc)
+      : PDC(pdc) {}
+  void handleDiagnostic(SourceManager &SM, const DiagnosticInfo &Info) override {
+    PDC.setSuppressOutput(false);
+    PDC.handleDiagnostic(SM, Info);
+    PDC.setSuppressOutput(true);
+  }
+  // Don't forward finishProcessing: PDC is also directly registered with
+  // DiagnosticEngine and will have finishProcessing() called on it separately.
+};
 
 /// If there is an error with fixits it writes the fixits as edits in json
 /// format.
@@ -149,18 +168,21 @@ createDispatchingDiagnosticConsumerIfNeeded(
           subconsumers.emplace_back(input.getFileName(), std::move(consumer));
         return false;
       });
-  // For batch mode, the compiler must sometimes swallow diagnostics pertaining
-  // to non-primary files in order to avoid Xcode showing the same diagnostic
-  // multiple times. So, create a diagnostic "eater" for those non-primary
-  // files.
+  // The compiler must sometimes swallow diagnostics pertaining to non-primary
+  // files in order to avoid Xcode/SwiftPM showing the same diagnostic multiple
+  // times. So, create a diagnostic "eater" for those non-primary files.
   //
   // This routine gets called in cases where no primary subconsumers are
   // created. Don't bother to create non-primary subconsumers if there aren't
   // any primary ones.
   //
-  // To avoid introducing bugs into WMO or single-file modes, test for multiple
-  // primaries.
-  if (!subconsumers.empty() && inputsAndOutputs.hasMultiplePrimaryInputs()) {
+  // Guard on hasPrimaryInputs() (any primary exists) rather than
+  // hasMultiplePrimaryInputs() so that single-primary-per-job mode also gets
+  // eaters for its non-primary inputs. WMO (no primaries) is unaffected
+  // because hasPrimaryInputs() returns false there. Single-file mode
+  // (one file that is also the primary) is unaffected because
+  // forEachNonPrimaryInput produces zero iterations.
+  if (!subconsumers.empty() && inputsAndOutputs.hasPrimaryInputs()) {
     inputsAndOutputs.forEachNonPrimaryInput(
         [&](const InputFile &input) -> bool {
           subconsumers.emplace_back(input.getFileName(), nullptr);
@@ -209,6 +231,21 @@ static std::unique_ptr<DiagnosticConsumer> createAccumulatingDiagnosticConsumer(
         auto &DiagBufferRef = FileSpecificDiagnostics[Input.getFileName()];
         return std::make_unique<AccumulatingFileDiagnosticConsumer>(
             DiagBufferRef);
+      });
+}
+
+/// Creates a dispatching consumer that forwards primary-file diagnostics to
+/// \p printingConsumer (temporarily unsuppressing it) and silently eats
+/// non-primary-file diagnostics.
+/// Returns null if no dispatching is needed (WMO, single-file, etc.).
+static std::unique_ptr<DiagnosticConsumer>
+createDispatchingPrintingConsumerIfNeeded(
+    const FrontendInputsAndOutputs &inputsAndOutputs,
+    PrintingDiagnosticConsumer &printingConsumer) {
+  return createDispatchingDiagnosticConsumerIfNeeded(
+      inputsAndOutputs,
+      [&](const InputFile &) -> std::unique_ptr<DiagnosticConsumer> {
+        return std::make_unique<UnsuppressedPDCForwarder>(printingConsumer);
       });
 }
 
@@ -374,6 +411,19 @@ void DiagnosticHelper::Implementation::beginMessage() {
   if (FixItsConsumer)
     instance.addDiagnosticConsumer(FixItsConsumer.get());
 
+  // In non-parseable-output mode, PDC writes directly to stderr and is not
+  // filtered by any file-specific consumer. Wrap it in a dispatcher so that
+  // non-primary-file diagnostics are eaten rather than printed to stderr
+  // (where the driver would capture them and SwiftPM would display them).
+  if (!invocation.getFrontendOptions().FrontendParseableOutput) {
+    PrintingConsumerDispatcher = createDispatchingPrintingConsumerIfNeeded(
+        invocation.getFrontendOptions().InputsAndOutputs, PDC);
+    if (PrintingConsumerDispatcher) {
+      PDC.setSuppressOutput(true);
+      instance.addDiagnosticConsumer(PrintingConsumerDispatcher.get());
+    }
+  }
+
   if (invocation.getDiagnosticOptions().UseColor)
     PDC.forceColors();
 
@@ -489,6 +539,9 @@ void DiagnosticHelper::Implementation::diagnoseFatalError(const char *reason,
       {}, StringRef(), SourceLoc(), {}, {}, {}, false);
   DiagnosticInfo noteInfo(DiagID(0), SourceLoc(), DiagnosticKind::Note, reason,
                           {}, StringRef(), SourceLoc(), {}, {}, {}, false);
+  // Ensure PDC is not suppressed: fatal errors must always be visible,
+  // even when PDC is otherwise suppressed in single-primary-per-job mode.
+  PDC.setSuppressOutput(false);
   PDC.handleDiagnostic(dummyMgr, errorInfo);
   PDC.handleDiagnostic(dummyMgr, noteInfo);
   if (shouldCrash)

--- a/test/Misc/Inputs/serialized-diagnostics-single-primary-helper.swift
+++ b/test/Misc/Inputs/serialized-diagnostics-single-primary-helper.swift
@@ -1,0 +1,8 @@
+// Helper file with a deliberate type error triggered when another file
+// references HelperWrapper (causing the compiler to type-check this file's
+// body during the primary file's type-checking session).
+struct HelperWrapper {
+    // References NonExistentHelperType so that type-checking this struct body
+    // produces an error.
+    private let x: NonExistentHelperType = ()
+}

--- a/test/Misc/serialized-diagnostics-single-primary.swift
+++ b/test/Misc/serialized-diagnostics-single-primary.swift
@@ -1,0 +1,52 @@
+// Test that in single-primary-per-job mode, diagnostics from a non-primary
+// file are NOT written into the primary file's .dia output — even when the
+// primary's type-checking triggers type-checking of the non-primary's body
+// (i.e. the realistic cross-file-reference scenario).
+//
+// We simulate two separate swift-frontend jobs, each with one primary file:
+//
+//  Job A: primary = this file (no errors, but uses HelperWrapper from helper),
+//         non-primary = helper (has error in HelperWrapper's body).
+//         After fix: helper's error is triggered during Job A's type-checking
+//         but is eaten → job succeeds, .dia has no errors from helper.
+//
+//  Job B: primary = helper (has error), non-primary = this file.
+//         helper's error goes into helper's .dia.
+//
+// RUN: rm -f %t.*
+
+// ---------- Job A: this file is primary, helper is non-primary ----------
+// The primary uses HelperWrapper, which forces the compiler to type-check
+// the helper's body and triggers the helper's error.  After the fix the error
+// is eaten, so compilation succeeds (no `not` prefix).
+// RUN: %target-swift-frontend -typecheck \
+// RUN:   -primary-file %s \
+// RUN:   -serialize-diagnostics-path %t.main.dia \
+// RUN:   %S/Inputs/serialized-diagnostics-single-primary-helper.swift \
+// RUN:   2> %t.jobA.stderr.txt
+
+// RUN: c-index-test -read-diagnostics %t.main.dia 2> %t.main.txt
+
+// The helper's error must NOT appear in Job A's diagnostics.
+// NEGATIVE-MAIN-NOT: serialized-diagnostics-single-primary-helper.swift
+
+// ---------- Job B: helper is primary, this file is non-primary ----------
+// The helper has a type error so compilation fails.
+// RUN: not %target-swift-frontend -typecheck \
+// RUN:   -primary-file %S/Inputs/serialized-diagnostics-single-primary-helper.swift \
+// RUN:   -serialize-diagnostics-path %t.helper.dia \
+// RUN:   %s \
+// RUN:   2> %t.jobB.stderr.txt
+
+// RUN: c-index-test -read-diagnostics %t.helper.dia 2> %t.helper.txt
+
+// The helper's error MUST appear in Job B's diagnostics.
+// CHECK-HELPER: serialized-diagnostics-single-primary-helper.swift:{{[0-9]+}}:{{[0-9]+}}: error:
+
+// RUN: %FileCheck -check-prefix=NEGATIVE-MAIN %s < %t.main.txt
+// RUN: %FileCheck -check-prefix=CHECK-HELPER %s < %t.helper.txt
+// RUN: %FileCheck --allow-empty -check-prefix=NEGATIVE-STDERR %s < %t.jobA.stderr.txt
+// NEGATIVE-STDERR-NOT: serialized-diagnostics-single-primary-helper.swift
+
+// Use HelperWrapper so the compiler must type-check the helper's body.
+func usesHelper(_ h: HelperWrapper) {}


### PR DESCRIPTION

I'm looking at ways to reduce duplicate diagnostics output in swiftpm, and it seems this could help, although I'm not familiar enough with the infra to fully judge how hacky this is. It did seem a bit weird we're emitting into a null consumer and this just emitting the diagnostic rather than swallow them if we're in a non-primary file... Either this has very good reasons™ or it may be an easy way to reduce the dupes of diagnostics we're emitting.

Long story on background here: A trivial swiftpm project with one error prints the error as many as 4-8 times, depending how many jobs we start for compilation. Each of them prints the error, making simple mistakes look like a wall of doom of errors, scaring away developers considering Swift as well as wasting tokens for AI tools which need to parse 4x more output.

This is paired with a SwiftPM side naive de-dup on the tail end, rather than on the emission end: https://github.com/swiftlang/swift-package-manager/pull/9796

Disclosure, this poc was very claude assisted.

This would resolve rdar://84599581