### PR TITLE
SILCombine: fix an ownership violation when trying to eliminate a forwarding instruction

### DIFF
--- a/lib/SILOptimizer/Utils/CanonicalizeInstruction.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeInstruction.cpp
@@ -521,8 +521,15 @@ eliminateUnneededForwardingUnarySingleValueInst(SingleValueInstruction *inst,
     }
     return next;
   }
-  deleteAllDebugUses(inst, pass.callbacks);
   SILValue op = inst->getOperand(0);
+
+  // If a forwarding instruction doesn't forward the same ownership we cannot delete it.
+  // This can happen if e.g. a `struct` instruction constructs a non-copyable struct
+  // out of trivial arguments.
+  if (op->getOwnershipKind() != inst->getOwnershipKind())
+    return next;
+
+  deleteAllDebugUses(inst, pass.callbacks);
   inst->replaceAllUsesWith(op);
   pass.notifyHasNewUsers(op);
   return killInstruction(inst, next, pass);

--- a/test/SILOptimizer/sil_combine_ossa.sil
+++ b/test/SILOptimizer/sil_combine_ossa.sil
@@ -106,6 +106,11 @@ struct MoveOnlyStruct: ~Copyable {
   var value: MyInt
 }
 
+struct S1 {
+  var i: MyInt
+  var o: AnyObject
+}
+
 enum NoncopyableEnum : ~Copyable {
 case i(CopyableStruct)
 }
@@ -5664,3 +5669,16 @@ bb2:
   destroy_value [dead_end] %0
   unreachable
 }
+
+// Just check that this doesn't produce illegal SIL
+sil [ossa] @test_forwarding_from_trivial_to_non_copyable : $@convention(thin) (@owned S1) -> () {
+bb0(%0 : @owned $S1):
+  %1 = begin_borrow %0
+  %2 = struct_extract %1, #S1.i
+  end_borrow %1
+  destroy_value %0
+  %5 = struct $MoveOnlyStruct (%2), forwarding: @owned
+  destroy_value [dead_end] %5
+  unreachable
+}
+


### PR DESCRIPTION
If a forwarding instruction doesn't forward the same ownership we cannot delete it. This can happen if e.g. a `struct` instruction constructs a non-copyable struct out of trivial arguments.

rdar://172074176
