### PR TITLE
[swift][build-script] Enable split-dwarf for RelWithDebInfo on Linux and FreeBSD

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/llvm.py
+++ b/utils/swift_build_support/swift_build_support/products/llvm.py
@@ -246,10 +246,12 @@ class LLVM(cmake_product.CMakeProduct):
                 platform, arch,
                 crosscompiling=self.is_cross_compile_target(host_target))
             llvm_cmake_options.define('CMAKE_TOOLCHAIN_FILE:PATH', toolchain_file)
-            if not self.is_release():
-                # On Linux build LLVM and subprojects with -gsplit-dwarf which is more
-                # space/time efficient than -g on that platform.
-                llvm_cmake_options.define('LLVM_USE_SPLIT_DWARF:BOOL', 'YES')
+
+        target_supports_split_dwarf = host_target.startswith(('linux', 'freebsd'))
+        if target_supports_split_dwarf and self.is_debug_info():
+            # On platforms that support split-dwarf, build LLVM and subprojects with
+            #  -gsplit-dwarf which is more space/time efficient than -g on that platform.
+            llvm_cmake_options.define('LLVM_USE_SPLIT_DWARF:BOOL', 'YES')
 
         build = True
         if not self.args._build_llvm or (not self.args.cross_compile_build_swift_tools


### PR DESCRIPTION
split-dwarf is enabled by default on non-release builds instead of builds with debug info, which incorrectly excludes `RelWithDebInfo` builds.

Support split-dwarf on FreeBSD

