### PR TITLE
[LoadedModuleTrace] Fix a fatal error that can be triggered

### DIFF
--- a/lib/FrontendTool/LoadedModuleTrace.cpp
+++ b/lib/FrontendTool/LoadedModuleTrace.cpp
@@ -914,6 +914,9 @@ bool swift::emitLoadedModuleTraceIfNeeded(const ModuleDependencyID &mainModule,
     if (!allLoadedModules.insert(mod).second)
       continue; // already visited.
 
+    if (mod.Kind == ModuleDependencyKind::Clang)
+      continue; // ignore clang dependencies.
+
     auto deps = cache.getAllSwiftDependencies(mod);
     workList.append(deps.begin(), deps.end());
   }
@@ -924,6 +927,7 @@ bool swift::emitLoadedModuleTraceIfNeeded(const ModuleDependencyID &mainModule,
 
   std::vector<SwiftModuleTraceInfo> swiftModules;
   for (auto &mod : allLoadedModules) {
+    // Record swift module dependencies and ignore other dependencies.
     auto &info = cache.findKnownDependency(mod);
     if (auto *binary = info.getAsSwiftBinaryModule())
       swiftModules.push_back({mod.ModuleName, binary->getDefiningModulePath(),
@@ -933,8 +937,6 @@ bool swift::emitLoadedModuleTraceIfNeeded(const ModuleDependencyID &mainModule,
       swiftModules.push_back(
           {mod.ModuleName, textual->swiftInterfaceFile, isDirectImport(mod),
            /*isResilient=*/true, textual->isStrictMemorySafety});
-    else
-      llvm::report_fatal_error("unexpected dependency kind");
   }
 
   std::vector<SwiftMacroTraceInfo> swiftMacros;

--- a/test/ScanDependencies/loaded_module_trace.swift
+++ b/test/ScanDependencies/loaded_module_trace.swift
@@ -13,14 +13,14 @@
 // RUN: %target-swift-frontend -scan-dependencies %t/test.swift -emit-loaded-module-trace -emit-loaded-module-trace-path %t/trace.json \
 // RUN:   -enable-upcoming-feature RegionBasedIsolation -strict-memory-safety -module-name Test -dependency-only-import B \
 // RUN:   -I %t -module-cache-path %t/cache -load-plugin-library %t/%target-library-name(Plugin) \
-// RUN:   -serialize-dependency-scan-cache -dependency-scan-cache-path %t/scan-cache -o %t/deps.json
+// RUN:   -serialize-dependency-scan-cache -dependency-scan-cache-path %t/scan-cache -o %t/deps.json -enable-cross-import-overlays
 
 // RUN: %FileCheck %s < %t/trace.json
 
 // RUN: %target-swift-frontend -scan-dependencies %t/test.swift -emit-loaded-module-trace -emit-loaded-module-trace-path %t/trace2.json \
 // RUN:   -enable-upcoming-feature RegionBasedIsolation -strict-memory-safety -module-name Test -dependency-only-import B \
 // RUN:   -I %t -module-cache-path %t/cache -load-plugin-library %t/%target-library-name(Plugin) \
-// RUN:   -load-dependency-scan-cache -dependency-scan-cache-path %t/scan-cache -o %t/deps2.json
+// RUN:   -load-dependency-scan-cache -dependency-scan-cache-path %t/scan-cache -o %t/deps2.json -enable-cross-import-overlays
 
 // RUN: diff %t/trace.json %t/trace2.json
 
@@ -39,6 +39,7 @@
 
 //--- test.swift
 import Module2
+import C
 import A
 
 @freestanding(expression) macro echo<T>(_: T) -> T = #externalMacro(module: "Plugin", type: "EchoMacro")
@@ -53,3 +54,24 @@ public func funcA() { }
 // swift-interface-format-version: 1.0
 // swift-module-flags: -module-name B
 public func funcB() { }
+
+//--- C.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name C
+public func funcC() { }
+
+//--- module.modulemap
+module _C_A {
+  header "c_a.h"
+  export *
+}
+
+//--- c_a.h
+void c_a(void);
+
+//--- C.swiftcrossimport/A.swiftoverlay
+%YAML 1.2
+---
+version: 1
+modules:
+  - name: _C_A


### PR DESCRIPTION
Fix a bug that fatal error can be triggered from valid inputs when emiting loaded_module_trace from dependency scanner. The reason is that it is currently untrue that querying `getAllSwiftDependencies` will return only swift dependencies, which is a separate bug that needs to be fixed. For now, make sure we handle the case that a clang module is returned inside.

rdar://171977001

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
