### PR TITLE
[cxx-interop] Use `%target-typecheck-verify-swift` in a `std::optional` test

### DIFF
--- a/test/Interop/Cxx/stdlib/use-std-optional-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-optional-typechecker.swift
@@ -1,11 +1,9 @@
-// RUN: not %target-swift-frontend %s -typecheck -I %S/Inputs -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default
 
 import StdOptional
 import CxxStdlib
 
-func takeCopyable<T: Copyable>(_ x: T) {} 
+func takeCopyable<T: Copyable>(_ x: T) {} // expected-note {{'where T: Copyable' is implicit here}}
 
 let nonNilOptNonCopyable = getNonNilOptionalHasDeletedCopyCtor()
-takeCopyable(nonNilOptNonCopyable)
-// CHECK: error: global function 'takeCopyable' requires that 'StdOptionalHasDeletedCopyCtor' {{.*}} conform to 'Copyable'
-// CHECK: note: 'where T: Copyable' is implicit here
+takeCopyable(nonNilOptNonCopyable) // expected-error {{conform to 'Copyable'}}


### PR DESCRIPTION
This makes the test easier to extend to cover other usages of `std::optional`.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
