### PR TITLE
[Test] Fix nonisolated_nonsending_metadata.swift on older runtimes

### DIFF
--- a/test/Interpreter/nonisolated_nonsending_metadata.swift
+++ b/test/Interpreter/nonisolated_nonsending_metadata.swift
@@ -8,7 +8,32 @@ func testNonisolatedNonsendingMetadata() {
 
   let nonisolatedType = NonisolatedNonsendingFn.self
 
-  // CHECK: nonisolated(nonsending) type: {{.*}}() async throws -> Int
+  // We are just testing that we do not crash but we want to make sure we emit
+  // output. Some notes:
+  //
+  // 1. Given a new enough runtime, we should print out:
+  //
+  //    nonisolated(nonsending) () async throws -> Int
+  //
+  // 2. Given a semi-old runtime (before Swift 6), we should print out:
+  //
+  //    () async throws -> Int
+  //
+  // 3. Given a very old runtime (before Swift 5.5), we should due to the usage
+  // of the concurrency compatibility print out:
+  //
+  //    () throws -> Int
+
+  if #available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *) {
+    print("Result: nonisolated(nonsending) () async throws -> Int")
+  } else if #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) {
+    print("Result: () async throws -> Int")
+  } else {
+    print("Result: () throws -> Int")
+  }
+  // CHECK: Result: [[RESULT:.*]]
+
+  // CHECK: nonisolated(nonsending) type: [[RESULT]]
   print("nonisolated(nonsending) type: \(nonisolatedType)")
 }
 


### PR DESCRIPTION
The test was hardcoding the expected metadata string as `() async throws -> Int`, but the reflected type description varies by OS/runtime version:

- macOS 15+ (Swift 6 runtime): `nonisolated(nonsending) () async throws -> Int`
- macOS 12–14 (Swift 5.5+ runtime): `() async throws -> Int`
- macOS 10.15–11 (pre-Swift 5.5 via back-deployment): `() throws -> Int`

When we tested with backdeployment, the old runtime produced `() throws -> Int` which didn't match the CHECK line which only ignored nonisolated(nonsending).

Fix by using `#available` to compute the expected string for the running OS, printing it as a reference line, and capturing it with a FileCheck variable so the actual metadata output is checked against the version-appropriate expectation. This is correct on all runtimes and more importantly tests exactly the relevant output even on newer OSes instead of potentially matching an invalid string via a {{.*}}.

rdar://169588274