### PR TITLE
Add diagnostic group and note to explain mutating async function issues

### DIFF
--- a/include/swift/AST/DiagnosticGroups.def
+++ b/include/swift/AST/DiagnosticGroups.def
@@ -41,6 +41,7 @@
 GROUP(no_group,none,"")
 
 GROUP(ActorIsolatedCall,none,"actor-isolated-call")
+GROUP(ActorIsolatedMutatingAsync,none,"actor-isolated-mutating-async")
 GROUP(AlwaysAvailableDomain,none,"always-available-domain")
 GROUP(AvailabilityUnrecognizedName,none,"availability-unrecognized-name")
 GROUP(ClangDeclarationImport,none,"clang-declaration-import")

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5846,9 +5846,12 @@ ERROR(actor_isolated_inout_state,none,
       "actor-isolated %kind0 cannot be passed 'inout' to"
       "%select{| implicitly}1 'async' function call",
       (const ValueDecl *, bool))
-ERROR(actor_isolated_mutating_func,none,
+GROUPED_ERROR(actor_isolated_mutating_func,ActorIsolatedMutatingAsync,none,
       "cannot call mutating async function %0 on actor-isolated %kind1",
       (DeclName, const ValueDecl *))
+NOTE(actor_isolated_mutating_func_note,none,
+      "%0 can be concurrently accessed during mutation, risking data races",
+      (const ValueDecl *))
 GROUPED_ERROR(actor_isolated_call,ActorIsolatedCall,none,
       "call to %0 function in a synchronous %1 context",
       (ActorIsolation, ActorIsolation))

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3749,11 +3749,13 @@ namespace {
           if (auto partialApply = dyn_cast<ApplyExpr>(apply->getFn())) {
             if (auto declRef = dyn_cast<DeclRefExpr>(partialApply->getFn())) {
               ValueDecl *fnDecl = declRef->getDecl();
-              ctx.Diags.diagnose(apply->getLoc(),
-                                 diag::actor_isolated_mutating_func,
-                                 fnDecl->getName(), decl)
+              ctx.Diags
+                  .diagnose(apply->getLoc(), diag::actor_isolated_mutating_func,
+                            fnDecl->getName(), decl)
                   .warnUntilLanguageModeIf(downgradeToWarning,
                                            LanguageMode::v6);
+              ctx.Diags.diagnose(partialApply->getArgs()->get(0).getStartLoc(),
+                                 diag::actor_isolated_mutating_func_note, decl);
               result = true;
               return;
             }

--- a/test/Concurrency/actor_inout_isolation.swift
+++ b/test/Concurrency/actor_inout_isolation.swift
@@ -131,12 +131,14 @@ extension TestActor {
   }
 
   func callMutatingFunctionOnStruct() async {
-    // expected-error@+3:20{{cannot call mutating async function 'setComponents(x:y:)' on actor-isolated property 'position'}}
+    // expected-error@+4:20{{cannot call mutating async function 'setComponents(x:y:)' on actor-isolated property 'position'}}
+    // expected-note@+3:11{{'position' can be concurrently accessed during mutation, risking data races}}
     // expected-error@+2:38{{actor-isolated property 'nextPosition' cannot be passed 'inout' to 'async' function call}}
     // expected-error@+1:58{{actor-isolated property 'nextPosition' cannot be passed 'inout' to 'async' function call}}
     await position.setComponents(x: &nextPosition.x, y: &nextPosition.y)
 
-    // expected-error@+3:20{{cannot call mutating async function 'setComponents(x:y:)' on actor-isolated property 'position'}}
+    // expected-error@+4:20{{cannot call mutating async function 'setComponents(x:y:)' on actor-isolated property 'position'}}
+    // expected-note@+3:11{{'position' can be concurrently accessed during mutation, risking data races}}
     // expected-error@+2:38{{actor-isolated property 'value1' cannot be passed 'inout' to 'async' function call}}
     // expected-error@+1:50{{actor-isolated property 'value2' cannot be passed 'inout' to 'async' function call}}
     await position.setComponents(x: &value1, y: &value2)
@@ -314,5 +316,6 @@ actor ProtectDictionary {
   func invalid() async {
     await dict[0].mutate()
     // expected-warning@-1 {{cannot call mutating async function 'mutate()' on actor-isolated property 'dict'; this is an error in the Swift 6 language mode}}
+    // expected-note@-2{{'dict' can be concurrently accessed during mutation, risking data races}}
   }
 }

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -1528,7 +1528,8 @@ actor DeinitMutatingAsync {
 
   deinit {
     s.doWork() // expected-error {{cannot call mutating async function 'doWork()' on actor-isolated property 's'}}
-    // expected-error@-1 {{'async' call in a function that does not support concurrency}}
+    // expected-note@-1 {{'s' can be concurrently accessed during mutation, risking data races}}
+    // expected-error@-2 {{'async' call in a function that does not support concurrency}}
   }
 }
 

--- a/userdocs/diagnostics/actor-isolated-mutating-async.md
+++ b/userdocs/diagnostics/actor-isolated-mutating-async.md
@@ -1,0 +1,82 @@
+# Calling a mutating async actor-isolated method (ActorIsolatedMutatingAsync)
+
+## Overview
+
+Calling a mutating async method on actor-isolated state allows concurrent access to that state during mutation, risking data races. To resolve this error, copy the state to a local variable, call the mutating async method on the copy, then write it back. This will overwrite concurrent changes.
+
+For example:
+
+```swift
+struct Backpack {
+  var snacks = 5
+  mutating func refill() async {
+    snacks += await purchaseSnacks(current: snacks)
+  }
+}
+
+@MainActor
+class Hiker {
+  var backpack = Backpack()
+
+  func getReady() async {
+    await backpack.refill()
+  }
+
+  func eatSnack() {
+    backpack.snacks -= 1
+  }
+}
+```
+
+Building the above code produces an error about calling a mutating async function on an actor-isolated property:
+
+```
+|   func getReady() async {
+|     await backpack.refill()
+|           |        `- error: cannot call mutating async function 'refill()' on actor-isolated property 'backpack' [#ActorIsolatedMutatingAsync]
+|           `- note: 'backpack' can be concurrently accessed during mutation, risking data races
+|   }
+```
+
+A `mutating async` function takes `self` as `inout`. This means that the value of `backpack` will be copied into `refill`, then copied out when the method returns. While `refill` is suspended, the main actor is free to do other work. This is a data race, since `refill` is still mutating `backpack`. If `eatSnack` ran before `refill` finished, it would decrement `snacks`, but the eaten snack reappears when `refill` writes back the stale copy. 
+
+```swift
+// Task 1: getReady()                  | // Task 2
+await backpack.refill()
+// copies backpack (snacks: 5)         |
+// suspends...                         |
+                                         eatSnack()
+//                                     | // backpack.snacks is now 4
+// resumes                             |
+// purchaseSnacks returns 0            |
+// writes back backpack (snacks: 5)    |
+// backpack.snacks is 5                |
+// eatSnack() was silently lost!       |
+```
+
+When possible, you can structure code to avoid the need for mutating async functions by separating async computation and mutation:
+
+```swift
+func getReady() async {
+  // await the asynchronous computation
+  let refill = await backpack.computeRefill()
+  // apply the mutation synchronously
+  backpack.apply(refill)
+}
+```
+
+Because the mutation is synchronous, no concurrent changes can occur between reading and writing `backpack` as part of `apply`. If `eatSnack` is called concurrently while `computeRefill` is suspended, the `Hiker` may purchase too few snacks, but the decrement from eating a snack won't be lost.
+
+If restructuring isn't appropriate, copy `backpack` to a local variable to make the potential overwrite explicit at the call site. This way, the call site shows that `backpack` is overwritten after `await`, rather than happening implicitly due to `inout`. Because `copy` is a local variable, it is not shared with other tasks and can be safely mutated.
+
+```swift
+func getReady() async {
+  var copy = backpack
+  await copy.refill()
+  backpack = copy
+}
+```
+
+## See also
+
+- [Overlapping accesses, but operation requires exclusive access (ExclusivityViolation)](exclusivity-violation.md)

--- a/userdocs/diagnostics/diagnostic-groups.md
+++ b/userdocs/diagnostics/diagnostic-groups.md
@@ -52,6 +52,7 @@ Or upgrade all warnings except deprecated declaration to errors:
 - <doc:dynamic-callable-requirements>
 - <doc:always-available-domain>
 - <doc:trailing-closure-matching>
+- <doc:actor-isolated-mutating-async>
 - <doc:actor-isolated-call>
 - <doc:sendable-closure-captures>
 - <doc:compilation-caching>


### PR DESCRIPTION
Fixes rdar://145127274 by adding a note that hints at why awaiting a mutating function cannot be accepted, and a diagnostic group that spells out the correctness problem created by the implicit inout self from mutating async methods.

```swift
struct Backpack {
  var snacks = 5
  mutating func refill() async {
    snacks += await purchaseSnacks(current: snacks)
  }
}

@MainActor
class Hiker {
  var backpack = Backpack()

  func getReady() async {
    await backpack.refill()
  }

  func eatSnack() {
    backpack.snacks -= 1
  }
}
```

```
error: cannot call mutating async function 'refill()' on actor-isolated property 'backpack' [#ActorIsolatedMutatingAsync]
|   func getReady() async {
|     await backpack.refill()
|           |        `- error: cannot call mutating async function 'refill()' on actor-isolated property 'backpack' [#ActorIsolatedMutatingAsync]
|           `- note: 'backpack' can be concurrently accessed during mutation, risking data races
|   }
```

Going to add a diagnostic group for inout in a second PR.

Super open to feedback, edits, nitpicks on the language and style of the diagnostic group (never written one before and I'd like to get a good sense of the voice for them), I'm not sold on the cutesy example or using an example that is vulnerable to reentrancy even after splitting computation and mutation, but I think it helps to highlight the underlying problem and what splitting can actually achieve.