### PR TITLE
[Concurrency] SE-0434: Member types should get `@Sendable` together w…

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -1715,6 +1715,12 @@ public:
         auto globalActor = newFnTy->getGlobalActor();
         auto addedActor = oldFnTy->getExtInfo().withGlobalActor(globalActor);
 
+        // With `GlobalActorIsolatedTypesUsability` enabled `@MainActor` always
+        // implies `@Sendable`.
+        if (oldFnTy->getASTContext().LangOpts.hasFeature(
+                Feature::GlobalActorIsolatedTypesUsability))
+          addedActor = addedActor.withSendable();
+
         return oldFnTy->withExtInfo(addedActor) == newFnTy;
       }
     }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3281,9 +3281,13 @@ SynthesizeMainFunctionRequest::evaluate(Evaluator &evaluator,
 
     Type mainActor = context.getMainActorType();
     if (mainActor) {
-      auto extInfo = ASTExtInfoBuilder().withIsolation(
-          FunctionTypeIsolation::forGlobalActor(mainActor))
-        .withThrows(true, throwsTypeVar);
+      auto extInfo =
+          ASTExtInfoBuilder()
+              .withIsolation(FunctionTypeIsolation::forGlobalActor(mainActor))
+              .withThrows(true, throwsTypeVar)
+              .withSendable(context.LangOpts.hasFeature(
+                  Feature::GlobalActorIsolatedTypesUsability));
+
       mainTypes.push_back(FunctionType::get(
           /*params*/ {}, context.TheEmptyTupleType,
           extInfo.build()));

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -7970,6 +7970,17 @@ AnyFunctionType *swift::adjustFunctionTypeForConcurrency(
   innerFnType = innerFnType->withExtInfo(
       innerFnType->getExtInfo().withIsolation(*funcIsolation));
 
+  // When `GlobalActorIsolatedTypesUsability` feature is enabled, inner type
+  // should be marked as `@Sendable` when inferred to be global-actor isolated.
+  {
+    auto &ctx = decl->getASTContext();
+    if (ctx.LangOpts.hasFeature(Feature::GlobalActorIsolatedTypesUsability) &&
+        funcIsolation->isGlobalActor()) {
+      innerFnType =
+          innerFnType->withExtInfo(innerFnType->getExtInfo().withSendable());
+    }
+  }
+
   // Rebuild the outer function type around it.
   if (auto genericFnType = dyn_cast<GenericFunctionType>(fnType)) {
     return GenericFunctionType::get(

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -1766,8 +1766,7 @@ struct ReferenceSelfDotMethods {
   nonisolated
   private func testCurry() -> (Self) -> (@MainActor () -> Void) {
     let functionRef = Self.mainActorAffinedFunction
-    // warning goes away with InferSendableFromCaptures, see actor_isolation_swift6.swift
-    return functionRef // expected-warning {{converting non-Sendable function value to '@MainActor @Sendable () -> Void' may introduce data races}}
+    return functionRef // Ok
   }
 
   @MainActor

--- a/test/Concurrency/global_actor_isolated_completion_handlers.swift
+++ b/test/Concurrency/global_actor_isolated_completion_handlers.swift
@@ -61,7 +61,7 @@ func testFromSuperclass(v: TestSubclass) {
 
 func testFromMethod(v: TestFromMethod, t: TestFromMethod.Type) {
   let _: Int = v.compute
-  // expected-error@-1 {{cannot convert value of type '@MainActor (@escaping () -> Void) -> Void' to specified type 'Int'}}
+  // expected-error@-1 {{cannot convert value of type '@MainActor @Sendable (@escaping () -> Void) -> Void' to specified type 'Int'}}
 
   let _: Int = t.computeStatic
   // expected-error@-1 {{cannot convert value of type '@MainActor @Sendable (@escaping () -> Void) -> Void' to specified type 'Int'}}

--- a/test/Concurrency/sendable_methods.swift
+++ b/test/Concurrency/sendable_methods.swift
@@ -1,8 +1,9 @@
 // RUN: %target-typecheck-verify-swift -enable-upcoming-feature InferSendableFromCaptures -disable-availability-checking -strict-concurrency=complete
-// RUN: %target-swift-emit-silgen %s -verify -enable-upcoming-feature InferSendableFromCaptures -disable-availability-checking -module-name sendable_methods -strict-concurrency=complete | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s -verify -enable-upcoming-feature InferSendableFromCaptures -enable-upcoming-feature GlobalActorIsolatedTypesUsability -disable-availability-checking -module-name sendable_methods -strict-concurrency=complete | %FileCheck %s
 
 // REQUIRES: concurrency
 // REQUIRES: swift_feature_InferSendableFromCaptures
+// REQUIRES: swift_feature_GlobalActorIsolatedTypesUsability
 
 func outer() {
     @Sendable func sendable() {}
@@ -341,4 +342,26 @@ func testClosureSendableDependence(_ x: NonSendable, _ fn: @Sendable () -> Void)
   // This is fine since we resolve the closure before we bind T.
   func foo<T>(_ x: T, _ y: T) {}
   foo(GenericE.a.foo, { (x, 0).1 })
+}
+
+@MainActor
+public protocol Q {
+    associatedtype V
+}
+
+// The base captures non-SendableMetatype `V` but it's also @MainActor isolated.
+public struct TestGlobalActorAndSendable<V: Q> : Q {
+  // Infers @MainActor
+  func test1() {
+  }
+
+  // Explicitly @MainActor
+  @MainActor func test2() {}
+
+  func compute(_: @MainActor () -> Void) {}
+
+  func compute() {
+    compute(test1) // Ok
+    compute(test2) // Ok
+  }
 }

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -2003,11 +2003,9 @@ func inferLocationOfCapturedTaskIsolatedSelfCorrectly() {
     let a = A()
 
     func d() {
-      a.block = c // expected-warning {{converting non-Sendable function value to '@MainActor @Sendable () -> Void' may introduce data races}}
-      // expected-warning @-1 {{non-Sendable '@MainActor () -> ()'-typed result can not be returned from main actor-isolated function to nonisolated context}}
-      // expected-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-      // expected-warning @-3 {{sending 'self' risks causing data races}}
-      // expected-note @-4 {{task-isolated 'self' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      a.block = c
+      // expected-warning @-1 {{sending 'self' risks causing data races}}
+      // expected-note @-2 {{task-isolated 'self' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
     }
 
     @MainActor

--- a/test/Concurrency/transfernonsendable_global_actor.swift
+++ b/test/Concurrency/transfernonsendable_global_actor.swift
@@ -352,9 +352,7 @@ func inferLocationOfCapturedActorIsolatedSelfCorrectly() {
     let a = A()
 
     func d() {
-      a.block = c // expected-warning {{converting non-Sendable function value to '@MainActor @Sendable () -> Void' may introduce data races}}
-      // expected-warning @-1 {{non-Sendable '@MainActor () -> ()'-typed result can not be returned from main actor-isolated function to global actor 'CustomActor'-isolated context}}
-      // expected-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+      a.block = c // Ok
     }
 
     @MainActor


### PR DESCRIPTION
…ith global-actor isolation

Previously an inner type only got the isolation but not `@Sendable` when `GlobalActorIsolatedTypesUsability` is enabled, this is incorrect because with the feature enabled global-actor isolation always implies `@Sendable` for functions and closures.

Resolves: rdar://problem/171967902

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
