### PR TITLE
[Parser] Fix buffer overrun in `rangeContainsPlaceholderEnd`

### DIFF
--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -857,7 +857,7 @@ static bool isRightBound(const char *tokEnd, bool isLeftBound,
 
 static bool rangeContainsPlaceholderEnd(const char *CurPtr,
                                         const char *End) {
-  for (auto SubStr = CurPtr; SubStr != End - 1; ++SubStr) {
+  for (auto SubStr = CurPtr; SubStr < End - 1; ++SubStr) {
     if (SubStr[0] == '\n') {
       return false;
     }

--- a/validation-test/compiler_crashers_fixed/Lexer-lexOperatorIdentifier-01ba47.swift
+++ b/validation-test/compiler_crashers_fixed/Lexer-lexOperatorIdentifier-01ba47.swift
@@ -1,7 +1,7 @@
 // {"kind":"typecheck","original":"48b7f3ec","signature":"swift::Lexer::lexOperatorIdentifier()","useGuardMalloc":true}
 // RUN: %empty-directory(%t)
 // RUN: echo -n '><#' > %t/main.swift
-// RUN: env DYLD_INSERT_LIBRARIES=/usr/lib/libgmalloc.dylib not --crash %target-swift-frontend -typecheck %t/main.swift
+// RUN: env DYLD_INSERT_LIBRARIES=/usr/lib/libgmalloc.dylib not %target-swift-frontend -typecheck %t/main.swift
 // REQUIRES: OS=macosx
 // REQUIRES: no_asan
 // REQUIRES: target-same-as-host


### PR DESCRIPTION
The loop condition `SubStr != End - 1` caused a buffer overrun when `CurPtr` starts at or past `End`. Use `<` instead.
