### PR TITLE
[DebugInfo][Caching] Using CASID for bridging header PCH

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -284,6 +284,9 @@ public:
   /// Use self key as swift module cacke key
   bool DebugModuleSelfKey = false;
 
+  /// The cache key for PCH.
+  std::string BridgingPCHCacheKey;
+
   /// The compilation directory for the debug info.
   std::string DebugCompilationDir;
 

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -450,9 +450,6 @@ namespace swift {
     bool EnableDeserializationSafety =
       ::getenv("SWIFT_ENABLE_DESERIALIZATION_SAFETY");
 
-    /// Disable injecting deserializes module paths into the explict module map.
-    bool DisableDeserializationOfExplicitPaths = false;
-
     /// Attempt to recover for imported modules with broken modularization
     /// in an unsafe way. Currently applies only to xrefs where the target
     /// decl moved to a different module that is already loaded.

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -204,14 +204,17 @@ public:
   /// \param swiftPCHHash A hash of Swift's various options in a compiler
   /// invocation, used to create a unique Bridging PCH if requested.
   ///
+  /// \param casidForPCH The CASID for the PCH buffer, used to create CASID
+  /// reference to PCH in debug info.
+  ///
   /// \param tracker The object tracking files this compilation depends on.
   ///
   /// \returns a new Clang module importer, or null (with a diagnostic) if
   /// an error occurred.
   static std::unique_ptr<ClangImporter>
   create(ASTContext &ctx, const IRGenOptions *IRGenOpts = nullptr,
-         std::string swiftPCHHash = "", DependencyTracker *tracker = nullptr,
-         bool ignoreFileMapping = false);
+         std::string swiftPCHHash = "", std::string casidForPCH = "",
+         DependencyTracker *tracker = nullptr, bool ignoreFileMapping = false);
 
   static std::string getClangSystemOverlayFile(const SearchPathOptions &Opts);
 

--- a/include/swift/Frontend/CachingUtils.h
+++ b/include/swift/Frontend/CachingUtils.h
@@ -69,6 +69,11 @@ std::unique_ptr<llvm::MemoryBuffer> loadCachedCompileResultFromCacheKey(
     DiagnosticEngine &Diag, llvm::StringRef CacheKey, file_types::ID Type,
     llvm::StringRef Filename = "");
 
+llvm::Expected<std::optional<llvm::cas::ObjectProxy>>
+loadCachedCompileResultProxy(llvm::cas::ObjectStore &CAS,
+                             llvm::cas::ActionCache &Cache,
+                             llvm::StringRef CacheKey, file_types::ID Type);
+
 llvm::Expected<llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>>
 createCASFileSystem(llvm::cas::ObjectStore &CAS,
                     const std::string &IncludeTreeRoot,

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -506,6 +506,7 @@ class CompilerInstance {
   std::shared_ptr<llvm::cas::ObjectStore> CAS;
   std::shared_ptr<llvm::cas::ActionCache> ResultCache;
   std::optional<llvm::cas::ObjectRef> CompileJobBaseKey;
+  std::string CASIDForPCH;
 
   SourceManager SourceMgr;
   DiagnosticEngine Diagnostics{SourceMgr};

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -26,6 +26,7 @@
 #include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/DiagnosticsClangImporter.h"
+#include "swift/AST/DiagnosticsFrontend.h"
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/Evaluator.h"
 #include "swift/AST/ImportCache.h"
@@ -48,6 +49,7 @@
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/ClangImporter/ClangImporterRequests.h"
 #include "swift/ClangImporter/ClangModule.h"
+#include "swift/Frontend/CachingUtils.h"
 #include "swift/Parse/ParseVersion.h"
 #include "swift/Strings.h"
 #include "swift/Subsystems.h"
@@ -167,6 +169,14 @@ namespace {
       if (Impl.IsReadingBridgingPCH) {
         Impl.PCHImportedSubmodules.push_back(ID);
       }
+    }
+
+    void ReaderInitialized(clang::ASTReader *Reader) override {
+      if (!Impl.IsReadingBridgingPCH)
+        return;
+
+      if (Impl.CASIDForPCH)
+        Reader->getModuleManager().getPrimaryModule().CASID = *Impl.CASIDForPCH;
     }
   };
 
@@ -1417,8 +1427,8 @@ std::unique_ptr<clang::CompilerInvocation> ClangImporter::createClangInvocation(
 
 std::unique_ptr<ClangImporter>
 ClangImporter::create(ASTContext &ctx, const IRGenOptions *IRGenOpts,
-                      std::string swiftPCHHash, DependencyTracker *tracker,
-                      bool ignoreFileMapping) {
+                      std::string swiftPCHHash, std::string casidForPCH,
+                      DependencyTracker *tracker, bool ignoreFileMapping) {
   std::unique_ptr<ClangImporter> importer{new ClangImporter(ctx, tracker)};
   auto &importerOpts = ctx.ClangImporterOpts;
 
@@ -1590,7 +1600,11 @@ ClangImporter::create(ASTContext &ctx, const IRGenOptions *IRGenOpts,
     // avoid a Clang crash when attempting to emit coverage for decls without
     // source locations (rdar://100172217).
     CGO.CoverageMapping = false;
+
   }
+
+  // Set up PCH content CASID.
+  importer->Impl.CASIDForPCH = casidForPCH;
 
   // Create the associated action.
   importer->Impl.Action.reset(new ParsingAction(*importer,

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -919,6 +919,9 @@ public:
   /// Tracks included headers from the bridging header.
   llvm::DenseSet<clang::FileEntryRef> BridgeHeaderFiles;
 
+  /// The CASID for PCH file if applicable. Otherwise, it should be std::nullopt.
+  std::optional<std::string> CASIDForPCH = std::nullopt;
+
   void addBridgeHeaderTopLevelDecls(clang::Decl *D);
   bool shouldIgnoreBridgeHeaderTopLevelDecl(clang::Decl *D);
 

--- a/lib/DriverTool/modulewrap_main.cpp
+++ b/lib/DriverTool/modulewrap_main.cpp
@@ -201,7 +201,7 @@ int modulewrap_main(ArrayRef<const char *> Args, const char *Argv0,
 
   IRGenOptions IRGenOpts;
   ASTCtx.addModuleLoader(
-      ClangImporter::create(ASTCtx, &IRGenOpts, "", nullptr, true), true);
+      ClangImporter::create(ASTCtx, &IRGenOpts, "", "", nullptr, true), true);
   ModuleDecl *M =
       ModuleDecl::createEmpty(ASTCtx.getIdentifier("swiftmodule"), ASTCtx);
   std::unique_ptr<Lowering::TypeConverter> TC(

--- a/lib/Frontend/CachingUtils.cpp
+++ b/lib/Frontend/CachingUtils.cpp
@@ -444,6 +444,45 @@ loadCachedCompileResultFromCacheKey(ObjectStore &CAS, ActionCache &Cache,
   return Buffer;
 }
 
+llvm::Expected<std::optional<llvm::cas::ObjectProxy>>
+loadCachedCompileResultProxy(llvm::cas::ObjectStore &CAS,
+                             llvm::cas::ActionCache &Cache,
+                             llvm::StringRef CacheKey, file_types::ID Kind) {
+
+  auto ID = CAS.parseID(CacheKey);
+  if (!ID)
+    return ID.takeError();
+
+  auto Ref = CAS.getReference(*ID);
+  if (!Ref)
+    return std::nullopt;
+
+  auto OutputRef = lookupCacheKey(CAS, Cache, *Ref);
+  if (!OutputRef)
+    return OutputRef.takeError();
+
+  if (!*OutputRef)
+    return std::nullopt;
+
+  CachedResultLoader Loader(CAS, **OutputRef);
+  std::optional<llvm::cas::ObjectProxy> Result;
+  if (auto Err =
+          Loader.replay([&](file_types::ID Type, ObjectRef Ref) -> Error {
+            if (Kind != Type)
+              return Error::success();
+
+            auto Proxy = CAS.getProxy(Ref);
+            if (!Proxy)
+              return Proxy.takeError();
+
+            Result = std::move(*Proxy);
+            return Error::success();
+          }))
+    return std::move(Err);
+
+  return Result;
+}
+
 static llvm::Error createCASObjectNotFoundError(const llvm::cas::CASID &ID) {
   return createStringError(llvm::inconvertibleErrorCode(),
                            "CASID missing from Object Store " + ID.toString());

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3655,6 +3655,9 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
       Opts.DebugModulePath = A->getValue();
   }
 
+  if (Opts.DebugModuleSelfKey || !Opts.DebugModulePath.empty())
+    Opts.BridgingPCHCacheKey = CASOpts.BridgingHeaderPCHCacheKey;
+
   for (auto A : Args.getAllArgValues(options::OPT_file_prefix_map)) {
     auto SplitMap = StringRef(A).split('=');
     Opts.FilePrefixMap.addMapping(SplitMap.first, SplitMap.second);

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -676,16 +676,23 @@ bool CompilerInstance::setUpVirtualFileSystemOverlays() {
     const auto &ClangOpts = getInvocation().getClangImporterOptions();
 
     if (!CASOpts.BridgingHeaderPCHCacheKey.empty()) {
-      if (auto loadedBuffer = loadCachedCompileResultFromCacheKey(
-              getObjectStore(), getActionCache(), Diagnostics,
-              CASOpts.BridgingHeaderPCHCacheKey, file_types::ID::TY_PCH,
-              ClangOpts.getPCHInputPath()))
-        MemFS->addFile(Invocation.getClangImporterOptions().getPCHInputPath(),
-                       0, std::move(loadedBuffer));
-      else
-        Diagnostics.diagnose(
-            SourceLoc(), diag::error_load_input_from_cas,
-            Invocation.getClangImporterOptions().getPCHInputPath());
+      auto Proxy = loadCachedCompileResultProxy(
+          getObjectStore(), getActionCache(), CASOpts.BridgingHeaderPCHCacheKey,
+          file_types::ID::TY_PCH);
+
+      if (!Proxy) {
+        Diagnostics.diagnose(SourceLoc(), diag::error_cas, "loading pch file",
+                             llvm::toString(Proxy.takeError()));
+        return true;
+      }
+      if (!*Proxy) {
+        Diagnostics.diagnose(SourceLoc(), diag::error_load_input_from_cas,
+                             ClangOpts.getPCHInputPath());
+        return true;
+      }
+      MemFS->addFile(ClangOpts.getPCHInputPath(), 0,
+                     (*Proxy)->getMemoryBuffer());
+      CASIDForPCH = (*Proxy)->getID().toString();
     }
     if (!CASOpts.InputFileKey.empty()) {
       if (Invocation.getFrontendOptions()
@@ -852,10 +859,9 @@ bool CompilerInstance::setUpModuleLoaders() {
   // Wire up the Clang importer. If the user has specified an SDK, use it.
   // Otherwise, we just keep it around as our interface to Clang's ABI
   // knowledge.
-  std::unique_ptr<ClangImporter> clangImporter =
-    ClangImporter::create(*Context, &Invocation.getIRGenOptions(),
-                          Invocation.getPCHHash(),
-                          getDependencyTracker());
+  std::unique_ptr<ClangImporter> clangImporter = ClangImporter::create(
+      *Context, &Invocation.getIRGenOptions(), Invocation.getPCHHash(),
+      CASIDForPCH, getDependencyTracker());
   if (!clangImporter) {
     Diagnostics.diagnose(SourceLoc(), diag::error_clang_importer_create_fail);
     return true;

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -968,6 +968,10 @@ private:
     // the module on disk is Bar (.swiftmodule or .swiftinterface), and is used
     // for loading and mangling.
     StringRef Name = M->getRealName().str();
+    // Handle bridging header imports. If there is a cache key, use cache key as
+    // path if debug module path is specified.
+    if (Name == CLANG_HEADER_MODULE_NAME && !Opts.BridgingPCHCacheKey.empty())
+      Path = Opts.BridgingPCHCacheKey;
     return getOrCreateModule(M, TheCU, Name, Path);
   }
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1344,20 +1344,6 @@ static void flattenImportPath(const ImportedModule &import,
   outStream << accessPathElem.Item.str();
 }
 
-/// Heuristic to detect a path like "llvmcas://12345ABCDE"
-static bool isURI(StringRef path) { return path.contains("://"); }
-static StringRef getFileName(StringRef path) {
-  if (isURI(path))
-    return path;
-  return llvm::sys::path::filename(path);
-}
-
-static StringRef getDirectory(StringRef path) {
-  if (isURI(path))
-    return path;
-  return llvm::sys::path::parent_path(path);
-}
-
 static llvm::SmallString<1024>
 flattenModuleMapEntry(StringRef name,
                       const ExplicitSwiftModuleInputInfo &info) {
@@ -1365,10 +1351,11 @@ flattenModuleMapEntry(StringRef name,
   {
     llvm::raw_svector_ostream s(out);
     s << name << '\0';
-    s << getFileName(info.modulePath) << '\0';
+    s << llvm::sys::path::filename(info.modulePath) << '\0';
     s << info.moduleAlias.value_or("") << '\0';
-    s << getFileName(info.moduleDocPath.value_or("")) << '\0';
-    s << getFileName(info.moduleSourceInfoPath.value_or("")) << '\0';
+    s << llvm::sys::path::filename(info.moduleDocPath.value_or("")) << '\0';
+    s << llvm::sys::path::filename(info.moduleSourceInfoPath.value_or(""))
+      << '\0';
     s << info.moduleCacheKey.value_or("") << '\0';
     s << '\0'; // clangModuleMap
     if (info.headerDependencyPaths)
@@ -1385,12 +1372,12 @@ flattenModuleMapEntry(StringRef name,
   {
     llvm::raw_svector_ostream s(out);
     s << name << '\0';
-    s << getFileName(info.modulePath) << '\0';
+    s << llvm::sys::path::filename(info.modulePath) << '\0';
     s << info.moduleAlias.value_or("") << '\0';
     s << '\0'; // moduleDocPath
     s << '\0'; // moduleSourceInfoPath
     s << info.moduleCacheKey.value_or("") << '\0';
-    s << getFileName(info.moduleMapPath) << '\0';
+    s << llvm::sys::path::filename(info.moduleMapPath) << '\0';
   }
   return out;
 }
@@ -1443,7 +1430,7 @@ void Serializer::writeInputBlock() {
   llvm::DenseMap<StringRef, unsigned> dependencyDirectories;
 
   auto getOrCreateDependencyDir = [&](llvm::StringRef path) -> unsigned {
-    StringRef directoryName = getDirectory(path);
+    StringRef directoryName = llvm::sys::path::parent_path(path);
     unsigned &dependencyDirectoryIndex = dependencyDirectories[directoryName];
     if (!dependencyDirectoryIndex) {
       // This name must be newly-added. Give it a new ID (and skip 0).
@@ -1457,7 +1444,8 @@ void Serializer::writeInputBlock() {
     unsigned dependencyDirectoryIndex = getOrCreateDependencyDir(dep.getPath());
     FileDependency.emit(ScratchRecord, dep.getSize(), getRawModTimeOrHash(dep),
                         dep.isHashBased(), dep.isSDKRelative(),
-                        dependencyDirectoryIndex, getFileName(dep.getPath()));
+                        dependencyDirectoryIndex,
+                        llvm::sys::path::filename(dep.getPath()));
   }
 
   if (!Options.ModuleInterface.empty())

--- a/test/CAS/bridging-header-debug-info.swift
+++ b/test/CAS/bridging-header-debug-info.swift
@@ -1,0 +1,81 @@
+// REQUIRES: objc_interop
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   %t/test.swift -o %t/deps.json -auto-bridging-header-chaining -cache-compile-job -cas-path %t/cas \
+// RUN:   -Xcc -fmodule-map-file=%t/a.modulemap -Xcc -fmodule-map-file=%t/b.modulemap -import-objc-header %t/Bridging.h
+
+// RUN: %{python} %S/../../utils/swift-build-modules.py --cas %t/cas %swift_frontend_plain %t/deps.json -b %t/Test-bridging.cmd -o %t/Test.cmd
+
+// RUN: %target-swift-frontend-plain @%t/Test-bridging.cmd %t/Bridging.h -disable-implicit-swift-modules -o %t/objc.pch
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
+// RUN:   %target-swift-frontend-plain @%t/Test-bridging.cmd %t/Bridging.h -disable-implicit-swift-modules -o %t/objc.pch > %t/keys.json
+// RUN: %{python} %S/Inputs/ExtractOutputKey.py %t/keys.json > %t/key
+
+// RUN: echo "\"-import-objc-header\"" >> %t/Test.cmd
+// RUN: echo "\"%t/Bridging.h\"" >> %t/Test.cmd
+// RUN: echo "\"-import-pch\"" >> %t/Test.cmd
+// RUN: echo "\"%t/objc.pch\"" >> %t/Test.cmd
+// RUN: echo "\"-bridging-header-pch-key\"" >> %t/Test.cmd
+// RUN: echo "\"@%t/key\"" >> %t/Test.cmd
+
+// RUN: %target-swift-frontend-plain  -cache-compile-job -module-name Test -g -cas-path %t/cas @%t/Test.cmd \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   -emit-module-path %t/Test.swiftmodule %t/test.swift -debug-module-self-key -emit-ir -o %t/test.ll
+
+// RUN: %FileCheck %s --input-file %t/test.ll
+
+// CHECK-DAG: !DIModule(scope: null, name: "Test", includePath: "llvmcas://{{.*}}")
+// CHECK-DAG: !DIModule(scope: null, name: "__ObjC", configMacros: "{{.*}}", includePath: "llvmcas://{{.*}}")
+// CHECK-DAG: !DICompileUnit(language: DW_LANG_ObjC, file: {{.*}}, producer: {{.*}}, splitDebugFilename: "llvmcas://{{.*}}"
+
+//--- test.swift
+public func test() {
+    b()
+    let test = Bridge()
+}
+public class TestB: B {}
+
+//--- Bridging.h
+#include "Foo.h"
+#include "Foo2.h"
+
+struct Bridge {};
+
+//--- Foo.h
+#import "a.h"
+#ifndef IMPORT_FOO
+#define IMPORT_FOO
+int Foo = 0;
+#endif
+
+//--- Foo2.h
+#ifndef IMPORT_FOO2
+#define IMPORT_FOO2
+int Foo2 = 0;
+#endif
+
+//--- a.h
+#include "b.h"
+struct A {
+  int a;
+};
+
+//--- b.h
+void b(void);
+@interface B
+@end
+
+//--- a.modulemap
+module A {
+  header "a.h"
+  export *
+}
+
+//--- b.modulemap
+module B {
+  header "b.h"
+  export *
+}


### PR DESCRIPTION
Fix the debug info emitted for bridging header PCH when compilation
caching is used. This includes:
* Bridging header should have the correct dwo_name that uses CASID
* The search_path for PCH should be the cache key that can load the PCH
  just like other modules.