### PR TITLE
Exclude types that contain primary archetypes from mangled name caching

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1901,7 +1901,7 @@ private:
       // FIXME: Primary archetypes carry all sorts of auxiliary information
       // that isn't contained in their mangled name.  See also
       // getMangledName().
-      return Ty->getKind() != swift::TypeKind::PrimaryArchetype;
+      return !Ty->hasPrimaryArchetype();
     return true;
   }
 

--- a/test/DebugInfo/async-boxed-arg.swift
+++ b/test/DebugInfo/async-boxed-arg.swift
@@ -17,5 +17,6 @@ extension Collection where Element: Sendable {
   }
 }
 
-// CHECK: ![[BOXTY:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "$s5IndexSlQzz_x_SlRzs8Sendable7ElementSTRpzlXXD"
-// CHECK: !DILocalVariable(name: "i", arg: 3, {{.*}}type: ![[BOXTY]]
+
+// CHECK: !DILocalVariable(name: "i", arg: 3, {{.*}} type: ![[BOXTY:[0-9]+]]
+// CHECK: ![[BOXTY]] = !DICompositeType(tag: DW_TAG_structure_type, name: "$s5IndexSlQzz_x_SlRzs8Sendable7ElementSTRpzlXXD"

--- a/test/DebugInfo/generic_args.swift
+++ b/test/DebugInfo/generic_args.swift
@@ -44,9 +44,9 @@ struct Wrapper<T: AProtocol> {
   }
 }
 
-// CHECK-DAG: ![[FNTY:.*]] = !DICompositeType({{.*}}identifier: "$sxq_Ignr_D"
-// CHECK-DAG: ![[LET_FNTY:.*]] = !DIDerivedType(tag: DW_TAG_const_type, baseType: ![[FNTY]])
-// CHECK-DAG: !DILocalVariable(name: "f", {{.*}}, line: [[@LINE+1]], type: ![[LET_FNTY]])
+// CHECK-DAG: !DILocalVariable(name: "f", {{.*}}, line: [[@LINE+3]], type: ![[LET_FNTY:.*]])
+// CHECK-DAG: ![[LET_FNTY]] = !DIDerivedType(tag: DW_TAG_const_type, baseType: ![[FNTY:.*]])
+// CHECK-DAG: ![[FNTY]] = !DICompositeType({{.*}}identifier: "$sxq_Ignr_D"
 func apply<T, U> (_ x: T, f: (T) -> (U)) -> U {
   return f(x)
 }

--- a/test/DebugInfo/tuple-containing-primary-archetype.swift
+++ b/test/DebugInfo/tuple-containing-primary-archetype.swift
@@ -1,0 +1,31 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -O -g -o - | %FileCheck %s
+
+// Check that the tuple sizes aren't mixed up between the two functions
+
+open class C {
+}
+
+public protocol P {
+  associatedtype S
+}
+
+extension Array {
+  public func fill<B: P>(b: B) where Element == B.S? {
+    for (_, _) in enumerated() {
+    }
+  }
+  public func fill<B: P>(a: UnsafeMutablePointer<B?>) where Element == B.S?, B.S: C {
+    for (i, _) in enumerated() {
+      a[i] = nil
+    }
+  }
+}
+
+// CHECK-DAG: !DILocalVariable(name: "$element", {{.*}} type: ![[DT1:[0-9]+]])
+// CHECK-DAG: ![[DT1]] = !DIDerivedType(tag: DW_TAG_const_type, baseType: ![[CT1:[0-9]+]])
+// CHECK-DAG: ![[CT1]] = !DICompositeType(tag: DW_TAG_structure_type, name: "$sSi6offset_1S4main1PPQyd__Sg7elementtD", {{.*}} size: {{64|32}}, runtimeLang: DW_LANG_Swift, identifier: "$sSi6offset_1S4main1PPQyd__Sg7elementtD")
+
+// CHECK-DAG: !DILocalVariable(name: "$element", {{.*}} type: ![[DT2:[0-9]+]])
+// CHECK-DAG: ![[DT2]] = !DIDerivedType(tag: DW_TAG_const_type, baseType: ![[CT2:[0-9]+]])
+// CHECK-DAG: ![[CT2]] = !DICompositeType(tag: DW_TAG_structure_type, name: "$sSi6offset_1S4main1PPQyd__Sg7elementtD", {{.*}} size: 128, runtimeLang: DW_LANG_Swift, identifier: "$sSi6offset_1S4main1PPQyd__Sg7elementtD")
+


### PR DESCRIPTION
Mangled names for primary archtypes don't carry information like sizes and caching based onmangled names could mix up different debug info types.

This should avoid assert failures from https://github.com/swiftlang/swift/issues/87290

