### PR TITLE
[build] libdispatch hasn't used `ENABLE_TESTING` in awhile

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2547,11 +2547,13 @@ for host in "${ALL_HOSTS[@]}"; do
 
                     -DSwift_DIR="${SWIFT_BUILD_PATH}/lib/cmake/swift"
 
-                    -DENABLE_TESTING=YES
                     -DBUILD_SHARED_LIBS=$([[ ${product} == libdispatch_static ]] && echo "NO" || echo "YES")
                   )
                   if [[ $(is_cross_tools_host ${host}) ]] ; then
-                      cmake_options+=("${SWIFT_TARGET_CMAKE_OPTIONS[@]}")
+                      cmake_options+=(
+                          "${SWIFT_TARGET_CMAKE_OPTIONS[@]}"
+                          -DBUILD_TESTING=NO
+                      )
                   fi
                 ;;
                 esac


### PR DESCRIPTION
Properly use `BUILD_TESTING` to disable when cross-compiling instead.

swiftlang/swift-corelibs-libdispatch#518 switched to `BUILD_TESTING` used by CMake almost seven years ago, so this `ENABLE_TESTING` flag did nothing since. Don't build Dispatch tests when cross-compiling because we have no support for running them cross-compiled, and they don't always cross-compile.