### PR TITLE
embedded: correctly compute base protocol conformances when specializing witness tables

### DIFF
--- a/SwiftCompilerSources/Sources/AST/Declarations.swift
+++ b/SwiftCompilerSources/Sources/AST/Declarations.swift
@@ -89,6 +89,10 @@ public class NominalTypeDecl: GenericTypeDecl {
     Type(bridged: bridged.NominalType_getDeclaredInterfaceType())
   }
 
+  public var selfInterfaceType: Type {
+    Type(bridged: bridged.NominalType_getSelfInterfaceType())
+  }
+
   public func add(member: Decl) {
     bridged.NominalTypeDecl_addMember(member.bridged)
   }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/GenericSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/GenericSpecialization.swift
@@ -164,10 +164,9 @@ func specializeWitnessTable(for conformance: Conformance, _ context: ModulePassC
         return origEntry
       }
       return .method(requirement: requirement, witness: specializedMethod)
-    case .baseProtocol(let requirement, let witness):
-      let baseConf = context.getSpecializedConformance(of: witness,
-                                                       for: conformance.type,
-                                                       substitutions: conformance.specializedSubstitutions)
+    case .baseProtocol(let requirement, _):
+      let selfTy = requirement.selfInterfaceType
+      let baseConf = conformance.getAssociatedConformance(ofAssociatedType: selfTy, to: requirement)
       specializeWitnessTable(for: baseConf, context)
       return .baseProtocol(requirement: requirement, witness: baseConf)
     case .associatedType(let requirement, let witness):

--- a/SwiftCompilerSources/Sources/SIL/Context.swift
+++ b/SwiftCompilerSources/Sources/SIL/Context.swift
@@ -100,14 +100,6 @@ extension Context {
       return _bridged.lookupStdlibFunction(nameStr).function
     }
   }
-
-  public func getSpecializedConformance(of genericConformance: Conformance,
-                                        for type: AST.`Type`,
-                                        substitutions: SubstitutionMap) -> Conformance
-  {
-    let c = _bridged.getSpecializedConformance(genericConformance.bridged, type.bridged, substitutions.bridged)
-    return Conformance(bridged: c)
-  }
 }
 
 extension MutatingContext {

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -345,6 +345,7 @@ struct BridgedDeclObj {
   BRIDGED_INLINE bool NominalType_isGlobalActor() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType
   NominalType_getDeclaredInterfaceType() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType NominalType_getSelfInterfaceType() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE OptionalBridgedDeclObj NominalType_getValueTypeDestructor() const;
   BRIDGED_INLINE bool Enum_hasRawType() const;
   BRIDGED_INLINE bool Struct_hasUnreferenceableStorage() const;

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -299,6 +299,10 @@ BridgedASTType BridgedDeclObj::NominalType_getDeclaredInterfaceType() const {
       getAs<swift::NominalTypeDecl>()->getDeclaredInterfaceType().getPointer()};
 }
 
+BridgedASTType BridgedDeclObj::NominalType_getSelfInterfaceType() const {
+  return { getAs<swift::NominalTypeDecl>()->getSelfInterfaceType().getPointer()};
+}
+
 void BridgedDeclObj::GenericContext_setGenericSignature(BridgedGenericSignature genericSignature) const {
   getAs<swift::GenericContext>()->setGenericSignature(genericSignature.unbridged());
 }

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -1531,10 +1531,6 @@ struct BridgedContext {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedDeclObj getSwiftMutableSpanDecl() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedValue getSILUndef(BridgedType type) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE
-  BridgedConformance getSpecializedConformance(BridgedConformance genericConformance,
-                                                       BridgedASTType type,
-                                                       BridgedSubstitutionMap substitutions) const;
-  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE
   OptionalBridgedWitnessTable lookupWitnessTable(BridgedConformance conformance) const;
   BRIDGED_INLINE bool calleesAreStaticallyKnowable(BridgedDeclRef method) const;
 

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -3174,16 +3174,6 @@ BridgedValue BridgedContext::getSILUndef(BridgedType type) const {
   return {swift::SILUndef::get(context->getFunction(), type.unbridged())};
 }
 
-BridgedConformance BridgedContext::getSpecializedConformance(
-                                                     BridgedConformance genericConformance,
-                                                     BridgedASTType type,
-                                                     BridgedSubstitutionMap substitutions) const {
-  auto &ctxt = context->getModule()->getASTContext();
-  auto *genConf = llvm::cast<swift::NormalProtocolConformance>(genericConformance.unbridged().getConcrete());
-  auto *c = ctxt.getSpecializedConformance(type.unbridged(), genConf, substitutions.unbridged());
-  return swift::ProtocolConformanceRef(c);
-}
-
 OptionalBridgedWitnessTable BridgedContext::lookupWitnessTable(BridgedConformance conformance) const {
   swift::ProtocolConformanceRef ref = conformance.unbridged();
   if (!ref.isConcrete()) {

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -1476,6 +1476,16 @@ public:
   }
 };
 
+static bool isSpecializedConformance(ProtocolConformance *c) {
+  if (isa<SpecializedProtocolConformance>(c))
+    return true;
+
+  if (auto *ic = dyn_cast<InheritedProtocolConformance>(c))
+    return isa<SpecializedProtocolConformance>(ic->getInheritedConformance());
+
+  return false;
+}
+
   /// A base class for some code shared between fragile and resilient witness
   /// table layout.
   class WitnessTableBuilderBase {
@@ -1624,9 +1634,8 @@ public:
 
       // Look for conformance info.
       ProtocolConformance *astConf = nullptr;
-      if (isa<SpecializedProtocolConformance>(SILWT->getConformance())) {
+      if (isSpecializedConformance(SILWT->getConformance())) {
         astConf = entry.getBaseProtocolWitness().Witness;
-        ASSERT(isa<SpecializedProtocolConformance>(astConf));
       } else {
         astConf = ConformanceInContext.getInheritedConformance(baseProto);
         assert(astConf->getType()->isEqual(ConcreteType));

--- a/test/embedded/existential-class-bound4.swift
+++ b/test/embedded/existential-class-bound4.swift
@@ -23,12 +23,19 @@ extension MyGenericClass: ClassBound {
     func bar() { print("MyGenericClass<\(typ)>.bar()") }
 }
 
+final class Derived: MyGenericClass<Int> {
+    init() {
+      super.init(typ: "Int")
+    }
+}
+
 @main
 struct Main {
     static func main() {
         var array: [any ClassBound] = []
         array.append(MyGenericClass<Int>(typ: "Int"))
         array.append(MyGenericClass<String>(typ: "String"))
+        array.append(Derived())
 
         for e in array {
             e.foo()
@@ -40,6 +47,9 @@ struct Main {
 
         // CHECK: MyGenericClass<String>.foo()
         // CHECK: MyGenericClass<String>.bar()
+
+        // CHECK: MyGenericClass<Int>.foo()
+        // CHECK: MyGenericClass<Int>.bar()
     }
 }
 

--- a/test/embedded/general-existentials1.swift
+++ b/test/embedded/general-existentials1.swift
@@ -248,6 +248,22 @@ func testP4() -> any P4 {
   return C4(t: K4(x: 437))
 }
 
+protocol QD: Q {
+}
+
+class MyGenericClass<T>: QD {
+  func bar() {
+    print("MyGenericClass.bar")
+  }
+}
+
+final class Derived: MyGenericClass<Int> {
+}
+
+func testInheritedSpecialized(e: QD) {
+  e.bar()
+}
+
 @main
 struct Main {
   static func main() {
@@ -292,6 +308,9 @@ struct Main {
 
     testP4().foo()
     // CHECK: 437
+
+    testInheritedSpecialized(e: Derived())
+    // CHECK: MyGenericClass.bar
   }
 }
 


### PR DESCRIPTION
This didn't work in case the base conformance is both, specialized and inherited.
Also, fix a similar issue in IRGen.

rdar://170096756