### PR TITLE
Sema: Alway print decl description in diags for `@_originallyDefinedIn`

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7341,11 +7341,7 @@ ERROR(public_decl_needs_availability, none,
 
 ERROR(attr_requires_decl_availability_for_platform,none,
       "'%0' requires that %1 have explicit availability for %2",
-      (DeclAttribute, DeclName, StringRef))
-
-ERROR(attr_requires_availability_for_platform,none,
-      "'%0' requires explicit availability for %1",
-      (DeclAttribute, StringRef))
+      (DeclAttribute, const Decl *, StringRef))
 
 // This doesn't display as an availability diagnostic, but it's
 // implemented there and fires when these subscripts are marked

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -107,13 +107,8 @@ public:
     if (IntroVer.has_value())
       return false;
 
-    if (auto *VD = dyn_cast<ValueDecl>(D)) {
-      diagnose(attr->AtLoc, diag::attr_requires_decl_availability_for_platform,
-               attr, VD->getName(), prettyPlatformString(platform));
-    } else {
-      diagnose(attr->AtLoc, diag::attr_requires_availability_for_platform, attr,
-               prettyPlatformString(platform));
-    }
+    diagnose(attr->AtLoc, diag::attr_requires_decl_availability_for_platform,
+             attr, D, prettyPlatformString(platform));
     return true;
   }
 

--- a/test/Parse/original_defined_in_attr.swift
+++ b/test/Parse/original_defined_in_attr.swift
@@ -67,3 +67,16 @@ public class ToplevelClass10 {}
 @available(macOS 15, iOS 18, watchOS 11, tvOS 18, visionOS 2, *)
 @_originallyDefinedIn(module: "foo", macOS 26, iOS 26, watchOS 26, tvOS 26, visionOS 26)
 public class ToplevelClass11 {}
+
+public class ToplevelClass12 {}
+
+@_originallyDefinedIn(module: "foo", OSX 13.13) // expected-error {{'@_originallyDefinedIn' requires that extension of 'ToplevelClass12' have explicit availability for macOS}}
+extension ToplevelClass12 {
+  public func extensionMember1() {}
+}
+
+@available(OSX 13.10, *)
+@_originallyDefinedIn(module: "foo", OSX 13.13)
+extension ToplevelClass12 {
+  public func extensionMember2() {}
+}


### PR DESCRIPTION
The diagnostic engine is now capable of appropriately describing any `Decl *` so it is no longer necessary to have a different, inferior diagnostic for decls that are not a `ValueDecl`.
