### PR TITLE
[Literal Expressions] New Parser Support For Integer Generic Parameter Expressions

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/SourceFile.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceFile.swift
@@ -93,6 +93,7 @@ extension Parser.ExperimentalFeatures {
     mapFeature(.KeyPathWithMethodMembers, to: .keypathWithMethodMembers)
     mapFeature(.DefaultIsolationPerFile, to: .defaultIsolationPerFile)
     mapFeature(.BorrowAndMutateAccessors, to: .borrowAndMutateAccessors)
+    mapFeature(.LiteralExpressions, to: .literalExpressions)
   }
 }
 

--- a/lib/Sema/PreCheckTarget.cpp
+++ b/lib/Sema/PreCheckTarget.cpp
@@ -1939,7 +1939,7 @@ TypeExpr *TypeExprSimplifier::simplifyNestedTypeExpr(UnresolvedDotExpr *UDE) {
     return nullptr;
   }
 
-  auto *TyExpr = simplifyTypeExpr(UDE->getBase());
+  auto *TyExpr = dyn_cast<TypeExpr>(UDE->getBase());
   if (!TyExpr)
     return nullptr;
 
@@ -2273,14 +2273,6 @@ TypeExpr *TypeExprSimplifier::simplifyTypeExpr(Expr *E) {
     return simplifyNestedTypeExpr(UDE);
   }
 
-  // Fold unresolved named referencs
-  if (auto *UDRE = dyn_cast<UnresolvedDeclRefExpr>(E)) {
-    if (auto resolvedExpr = TypeChecker::resolveDeclRefExpr(UDRE, DC))
-      return simplifyTypeExpr(resolvedExpr);
-    else
-      return nullptr;
-  }
-
   // In a generic argument context, a value generic parameter reference
   // (TypeValueExpr) can be treated as a type — its inner TypeRepr
   // resolves to a GenericTypeParamType through normal type resolution.
@@ -2288,25 +2280,19 @@ TypeExpr *TypeExprSimplifier::simplifyTypeExpr(Expr *E) {
     return new (Ctx) TypeExpr(TVE->getRepr());
   }
 
-  // Fold unresolved specializations
+  // Fold unresolved specializations.
+  // The base is expected to already be a TypeExpr.
   if (auto *USE = dyn_cast<UnresolvedSpecializeExpr>(E)) {
-    if (auto simplifiedSubExpr = simplifyTypeExpr(USE->getSubExpr())) {
-      // If this is a reference type a specialized type, form a TypeExpr.
-      // The base should be a TypeExpr that we already resolved.
-      if (auto *te = dyn_cast_or_null<TypeExpr>(simplifiedSubExpr)) {
-        if (auto *declRefTR =
-                dyn_cast_or_null<DeclRefTypeRepr>(te->getTypeRepr())) {
-          return TypeExpr::createForSpecializedDecl(
-              declRefTR, USE->getUnresolvedParams(),
-              SourceRange(USE->getLAngleLoc(), USE->getRAngleLoc()),
-              getASTContext());
-        }
-      } else {
-        return nullptr;
+    if (auto *te = dyn_cast<TypeExpr>(USE->getSubExpr())) {
+      if (auto *declRefTR =
+              dyn_cast_or_null<DeclRefTypeRepr>(te->getTypeRepr())) {
+        return TypeExpr::createForSpecializedDecl(
+            declRefTR, USE->getUnresolvedParams(),
+            SourceRange(USE->getLAngleLoc(), USE->getRAngleLoc()),
+            getASTContext());
       }
-    } else {
-      return nullptr;
     }
+    return nullptr;
   }
 
   // Fold '_' into a placeholder type, if we're allowed.
@@ -2326,7 +2312,7 @@ TypeExpr *TypeExprSimplifier::simplifyTypeExpr(Expr *E) {
       TyExpr = dyn_cast<TypeExpr>(OOE->getSubExpr());
       QuestionLoc = OOE->getLoc();
     } else {
-      TyExpr = simplifyTypeExpr(cast<BindOptionalExpr>(E)->getSubExpr());
+      TyExpr = dyn_cast<TypeExpr>(cast<BindOptionalExpr>(E)->getSubExpr());
       QuestionLoc = cast<BindOptionalExpr>(E)->getQuestionLoc();
     }
     if (!TyExpr) return nullptr;
@@ -2363,7 +2349,7 @@ TypeExpr *TypeExprSimplifier::simplifyTypeExpr(Expr *E) {
 
   // Fold (T) into a type T with parens around it.
   if (auto *PE = dyn_cast<ParenExpr>(E)) {
-    auto *TyExpr = simplifyTypeExpr(PE->getSubExpr());
+    auto *TyExpr = dyn_cast<TypeExpr>(PE->getSubExpr());
     if (!TyExpr) return nullptr;
 
     TupleTypeReprElement InnerTypeRepr[] = { TyExpr->getTypeRepr() };
@@ -2908,11 +2894,45 @@ Expr *PreCheckTarget::wrapMemberChainIfNeeded(Expr *E) {
 
 TypeExpr *TypeChecker::simplifyGenericArgumentTypeExpr(DeclContext *DC,
                                                        Expr *E) {
-  auto canSimplifyDiscardAssignmentExpr = [&](DiscardAssignmentExpr *DAE) {
-    return true;
+  /// An ASTWalker for simplifying type expressions inside generic argument
+  /// positions.
+  /// The inner expression of a GenericArgumentExprTypeRepr is not walked by
+  /// the outer PreCheckTarget (to avoid exposing it to CSGen/CSApply walkers),
+  /// so we use this walker to resolve names and fold type sugar.
+  class GenericArgumentSimplifierWalker : public ASTWalker {
+    DeclContext *DC;
+  public:
+    GenericArgumentSimplifierWalker(DeclContext *dc) : DC(dc) {}
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::ArgumentsAndExpansion;
+    }
+    PreWalkResult<Expr *> walkToExprPre(Expr *expr) override {
+      // Resolve unqualified name references
+      if (auto *unresolved = dyn_cast<UnresolvedDeclRefExpr>(expr)) {
+        auto *resolved = TypeChecker::resolveDeclRefExpr(unresolved, DC);
+        if (!resolved)
+          return Action::Stop();
+        return Action::Continue(resolved);
+      }
+      return Action::Continue(expr);
+    }
+
+    PostWalkResult<Expr *> walkToExprPost(Expr *expr) override {
+      auto canSimplifyDiscardAssignmentExpr =
+          [](DiscardAssignmentExpr *DAE) { return true; };
+      if (auto *simplified = TypeExprSimplifier::simplify(
+              expr, DC, canSimplifyDiscardAssignmentExpr,
+              /*inGenericArgumentContext=*/true))
+        return Action::Continue(simplified);
+      return Action::Continue(expr);
+    }
   };
-  return TypeExprSimplifier::simplify(E, DC, canSimplifyDiscardAssignmentExpr,
-                                      true);
+
+  GenericArgumentSimplifierWalker walker(DC);
+  auto *walked = E->walk(walker);
+  if (!walked)
+    return nullptr;
+  return dyn_cast<TypeExpr>(walked);
 }
 
 bool ConstraintSystem::preCheckTarget(SyntacticElementTarget &target) {

--- a/test/LiteralExpressions/IntegerGenericArithmetic.swift
+++ b/test/LiteralExpressions/IntegerGenericArithmetic.swift
@@ -1,6 +1,6 @@
 // Literal expressions in integer generic parameter values
 // REQUIRES: swift_feature_LiteralExpressions
-// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature LiteralExpressions -disable-experimental-parser-round-trip -verify
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature LiteralExpressions -verify
 
 // =============================================================================
 // Arithmetic operators

--- a/test/LiteralExpressions/IntegerGenericConstantFolding.swift
+++ b/test/LiteralExpressions/IntegerGenericConstantFolding.swift
@@ -1,6 +1,6 @@
 // Complex literal expressions in integer generic parameter values with AST verification
 // REQUIRES: swift_feature_LiteralExpressions
-// RUN: %target-swift-frontend -typecheck -dump-ast %s -disable-availability-checking -enable-experimental-feature LiteralExpressions -disable-experimental-parser-round-trip | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -dump-ast %s -disable-availability-checking -enable-experimental-feature LiteralExpressions | %FileCheck %s
 
 let foldAdd: InlineArray<(2 + 3), Int> = [1, 2, 3, 4, 5]
 // CHECK-LABEL: (pattern_named type="InlineArray<5, Int>" "foldAdd")

--- a/test/LiteralExpressions/IntegerGenericErrors.swift
+++ b/test/LiteralExpressions/IntegerGenericErrors.swift
@@ -1,6 +1,6 @@
 // Error cases for literal expressions in integer generic parameter values
 // REQUIRES: swift_feature_LiteralExpressions
-// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature LiteralExpressions -disable-experimental-parser-round-trip
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature LiteralExpressions
 
 let wrongCount1: InlineArray<(2 + 3), Int> = [1, 2, 3]
 // expected-error@-1 {{expected '5' elements in inline array literal, but got '3'}}

--- a/test/LiteralExpressions/IntegerGenericExpressionInterface.swift
+++ b/test/LiteralExpressions/IntegerGenericExpressionInterface.swift
@@ -1,6 +1,6 @@
 // Integer generic expression interface printingEnum case raw value expressions
 // REQUIRES: swift_feature_LiteralExpressions
-// RUN: %target-swift-frontend -emit-module -module-name IntegerGenericExpressionInterface -emit-module-interface-path %t/IntegerGenericExpressionInterface.swiftinterface -enable-library-evolution -swift-version 5 -disable-availability-checking -disable-experimental-parser-round-trip %s -enable-experimental-feature LiteralExpressions
+// RUN: %target-swift-frontend -emit-module -module-name IntegerGenericExpressionInterface -emit-module-interface-path %t/IntegerGenericExpressionInterface.swiftinterface -enable-library-evolution -swift-version 5 -disable-availability-checking %s -enable-experimental-feature LiteralExpressions
 
 // RUN: %FileCheck %s < %t/IntegerGenericExpressionInterface.swiftinterface
 

--- a/test/LiteralExpressions/IntegerGenericExpressionRequirementErrors.swift
+++ b/test/LiteralExpressions/IntegerGenericExpressionRequirementErrors.swift
@@ -1,6 +1,6 @@
 // Error cases for literal expressions in integer generic parameter values
 // REQUIRES: swift_feature_LiteralExpressions
-// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature LiteralExpressions -disable-experimental-parser-round-trip
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature LiteralExpressions
 
 struct V<let N: Int, let M: Int> {}
 // expected-note@-1 {{arguments to generic parameter 'N' ('2' and '5') are expected to be equal}}


### PR DESCRIPTION
Companion change to: https://github.com/swiftlang/swift-syntax/pull/3275
-----------------------
- Map the `LiteralExpressions` experimental feature to the corresponding swift-syntax feature.
- Remove `-disable-experimental-parser-round-trip` from integer generic value literal expression tests.
- Address prior change feedback about recursive call to `simplifyTypeExpr` from `simplifyNestedTypeExpr`: `simplifyTypeExpr` is called in the post-walk of `PreCheckTarget`, where children are expected to already be transformed. The [previous approach](https://github.com/swiftlang/swift/pull/87006) made `simplifyTypeExpr` recursive to handle the generic argument context (where inner expressions are not walked by the outer `PreCheckTarget`), causing redundant work when called from the regular pre-check path. This change refactors `simplifyGenericArgumentTypeExpr` to instead use an `ASTWalker` that mirrors the parts of `PreCheckTarget` only relevant in this contest (resolving `UnresolvedDeclRefExpr` in the pre-walk, folding type expressions via `simplifyTypeExpr` in the post-walk).