### PR TITLE
[Backtracing] Decrease minimum availability version.

### DIFF
--- a/Runtimes/Supplemental/Runtime/CMakeLists.txt
+++ b/Runtimes/Supplemental/Runtime/CMakeLists.txt
@@ -97,6 +97,18 @@ add_compile_options(
   "$<$<AND:$<BOOL:${${PROJECT_NAME}_ENABLE_LIBRARY_EVOLUTION}>,$<COMPILE_LANGUAGE:Swift>>:-enable-library-evolution>"
   "$<$<AND:$<BOOL:${${PROJECT_NAME}_ENABLE_PRESPECIALIZATION}>,$<COMPILE_LANGUAGE:Swift>>:SHELL:-Xfrontend -prespecialize-generic-metadata>")
 
+# Generate BacktracingDT 6.2
+set(backgtracingdt62_version)
+if(NOT SwiftCore_ENABLE_STRICT_AVAILABILITY AND CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS "26.0")
+  set(backtracingdt62_version "macOS ${CMAKE_OSX_DEPLOYMENT_TARGET}")
+else()
+  set(backtracingdt62_version "macOS 26.0")
+endif()
+
+add_compile_options(
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -define-availability>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend BacktracingDT 6.2:${backtracingdt62_version}>")
+
 if(WIN32 AND CMAKE_SYSTEM_PROCESSOR MATCHES "X86")
   # Turn on /safeseh for 32-bit x86 or we won't be able to link
   add_compile_options($<$<COMPILE_LANGUAGE:ASM_MASM>:/safeseh>)

--- a/Runtimes/Supplemental/Runtime/CMakeLists.txt
+++ b/Runtimes/Supplemental/Runtime/CMakeLists.txt
@@ -107,7 +107,7 @@ endif()
 
 add_compile_options(
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -define-availability>"
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend BacktracingDT 6.2:${backtracingdt62_version}>")
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend 'BacktracingDT 6.2:${backtracingdt62_version}'>")
 
 if(WIN32 AND CMAKE_SYSTEM_PROCESSOR MATCHES "X86")
   # Turn on /safeseh for 32-bit x86 or we won't be able to link

--- a/stdlib/public/RuntimeModule/Address.swift
+++ b/stdlib/public/RuntimeModule/Address.swift
@@ -20,7 +20,7 @@ import Swift
 
 // .. Comparable .............................................................
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 extension Backtrace.Address {
   fileprivate var widestRepresentation: UInt64 {
     switch representation {
@@ -36,7 +36,7 @@ extension Backtrace.Address {
   }
 }
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 extension Backtrace.Address: Comparable {
   /// Return true if `lhs` is lower than `rhs`
   public static func < (lhs: Backtrace.Address, rhs: Backtrace.Address) -> Bool {
@@ -50,7 +50,7 @@ extension Backtrace.Address: Comparable {
 
 // .. LosslessStringConvertible ..............................................
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 extension Backtrace.Address: LosslessStringConvertible {
   /// Create an Backtrace.Address from its string representation
   public init?(_ s: String) {
@@ -123,7 +123,7 @@ extension Backtrace.Address: LosslessStringConvertible {
 
 // .. ExpressibleByIntegerLiteral ............................................
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 extension Backtrace.Address: ExpressibleByIntegerLiteral {
   public typealias IntegerLiteralType = UInt64
 
@@ -143,7 +143,7 @@ extension Backtrace.Address: ExpressibleByIntegerLiteral {
 
 // .. FixedWidthInteger conversions ..........................................
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 extension Backtrace.Address {
   fileprivate func toFixedWidth<T: FixedWidthInteger>(
     type: T.Type = T.self
@@ -169,7 +169,7 @@ extension FixedWidthInteger {
   ///
   /// This initializer will return nil if the address width is larger than the
   /// type you are attempting to convert into.
-  @available(Backtracing 6.2, *)
+  @available(BacktracingDT 6.2, *)
   public init?(_ address: Backtrace.Address) {
     guard let result = address.toFixedWidth(type: Self.self) else {
       return nil
@@ -178,7 +178,7 @@ extension FixedWidthInteger {
   }
 }
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 extension Backtrace.Address {
   /// Convert from a UInt16.
   public init(_ value: UInt16) {
@@ -224,7 +224,7 @@ extension Backtrace.Address {
 
 // -- Arithmetic -------------------------------------------------------------
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 extension Backtrace.Address {
   static func - (lhs: Backtrace.Address, rhs: Backtrace.Address) -> Int64 {
     let ulhs = UInt64(lhs)!

--- a/stdlib/public/RuntimeModule/Backtrace+Codable.swift
+++ b/stdlib/public/RuntimeModule/Backtrace+Codable.swift
@@ -25,7 +25,7 @@ func stringFrom(sequence: some Sequence<UTF8.CodeUnit>) -> String? {
   }
 }
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 extension Backtrace: Codable {
 
   enum CodingKeys: CodingKey {

--- a/stdlib/public/RuntimeModule/Backtrace.swift
+++ b/stdlib/public/RuntimeModule/Backtrace.swift
@@ -27,7 +27,7 @@ import Swift
 // #endif
 
 /// Holds a backtrace.
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 public struct Backtrace: CustomStringConvertible, Sendable {
   /// The type of an address.
   ///
@@ -438,7 +438,7 @@ public struct Backtrace: CustomStringConvertible, Sendable {
 
 // -- Capture Implementation -------------------------------------------------
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 extension Backtrace {
 
   // ###FIXME: There is a problem with @_specialize here that results in the

--- a/stdlib/public/RuntimeModule/BacktraceFormatter.swift
+++ b/stdlib/public/RuntimeModule/BacktraceFormatter.swift
@@ -30,7 +30,7 @@ internal import Musl
 
 /// A backtrace formatting theme.
 @_spi(Formatting)
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 public protocol BacktraceFormattingTheme {
   func frameIndex(_ s: String) -> String
   func programCounter(_ s: String) -> String
@@ -49,7 +49,7 @@ public protocol BacktraceFormattingTheme {
   func imagePath(_ s: String) -> String
 }
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 extension BacktraceFormattingTheme {
   public func frameIndex(_ s: String) -> String { return s }
   public func programCounter(_ s: String) -> String { return s }
@@ -72,7 +72,7 @@ extension BacktraceFormattingTheme {
 ///
 /// This is used by chaining modifiers, e.g. .theme(.color).showSourceCode().
 @_spi(Formatting)
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 public struct BacktraceFormattingOptions {
   var _theme: BacktraceFormattingTheme = BacktraceFormatter.Themes.plain
   var _showSourceCode: Bool = false
@@ -431,7 +431,7 @@ private func measure<S: StringProtocol>(_ s: S) -> Int {
 }
 
 /// Pad the given string to the given width using spaces.
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 private func pad(_ s: String, to width: Int,
                  aligned alignment: BacktraceFormatter.Alignment = .left)
   -> String {
@@ -517,7 +517,7 @@ private func rtrim<S: StringProtocol>(_ s: S) -> S.SubSequence {
 
 /// Responsible for formatting backtraces.
 @_spi(Formatting)
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 public struct BacktraceFormatter {
 
   /// The formatting options to apply when formatting data.

--- a/stdlib/public/RuntimeModule/BacktraceJSONFormatter.swift
+++ b/stdlib/public/RuntimeModule/BacktraceJSONFormatter.swift
@@ -50,7 +50,7 @@ public protocol BacktraceJSONWriter {
 }
 
 @_spi(Formatting)
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 public struct BacktraceJSONFormatter<
 Address: FixedWidthInteger,
 Writer: BacktraceJSONWriter> {
@@ -78,7 +78,7 @@ Writer: BacktraceJSONWriter> {
   }
 }
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 internal extension BacktraceJSONFormatter {
   func write(_ string: String, flush: Bool) {
     writer.write(string, flush: flush)
@@ -105,7 +105,7 @@ internal extension BacktraceJSONFormatter {
 }
 
 @_spi(Formatting)
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 public extension BacktraceJSONFormatter {
   mutating func writeCrashLog(now: String) {
     writePreamble(now: now)
@@ -117,7 +117,7 @@ public extension BacktraceJSONFormatter {
 }
 
 @_spi(Formatting)
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 public extension BacktraceJSONFormatter {
   func writePreamble(now: String) {
     guard let description = getDescription(),
@@ -226,7 +226,7 @@ public extension BacktraceJSONFormatter {
   }
 }
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 internal extension BacktraceJSONFormatter {
   func writeThreadRegisters(thread: Log.Thread) {
     guard let registers = thread.registers else { return }

--- a/stdlib/public/RuntimeModule/BacktracerThreadLocals.swift
+++ b/stdlib/public/RuntimeModule/BacktracerThreadLocals.swift
@@ -26,7 +26,7 @@ internal import Glibc
 internal import Musl
 #endif
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 final class BacktracerThreadLocals {
   lazy var elfImageCache = ElfImageCache()
   lazy var peImageCache = PeImageCache()

--- a/stdlib/public/RuntimeModule/Base64.swift
+++ b/stdlib/public/RuntimeModule/Base64.swift
@@ -119,7 +119,7 @@ fileprivate func reverse(at char: UTF8.CodeUnit) -> UInt8? {
 }
 
 @_spi(Base64)
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 public struct Base64Encoder<S: Sequence>: Sequence
   where S.Element == UInt8
 {
@@ -215,7 +215,7 @@ public struct Base64Encoder<S: Sequence>: Sequence
 }
 
 @_spi(Base64)
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 public struct Base64Decoder<S: Sequence>: Sequence
   where S.Element == UTF8.CodeUnit
 {

--- a/stdlib/public/RuntimeModule/CMakeLists.txt
+++ b/stdlib/public/RuntimeModule/CMakeLists.txt
@@ -126,12 +126,19 @@ set(LLVM_OPTIONAL_SOURCES
   ${backtracing_sources}
 )
 
-# Make the minimum build version for macOS 26.0, so we don't need to
-# add extra annotations.
-if(SWIFT_DARWIN_DEPLOYMENT_VERSION_OSX VERSION_LESS "26.0")
-  set(osx_deployment_target "26.0")
+# Force the minimum deployment target to 15.0
+if(SWIFT_DARWIN_DEPLOYMENT_VERSION_OSX VERSION_LESS "15.0")
+  set(osx_deployment_target "15.0")
 else()
   set(osx_deployment_target "${SWIFT_DARWIN_DEPLOYMENT_VERSION_OSX}")
+endif()
+
+# Generate BacktracingDT 6.2
+set(backtracing_availability)
+if(NOT SWIFT_STDLIB_ENABLE_STRICT_AVAILABILITY AND SWIFT_DARWIN_DEPLOYMENT_VERSION_OSX VERSION_LESS "26.0")
+  list(APPEND backtracing_availability "-Xfrontend" "-define-availability" "-Xfrontend" "BacktracingDT 6.2:macOS ${SWIFT_DARWIN_DEPLOYMENT_VERSION_OSX}")
+else()
+  list(APPEND backtracing_availability "-Xfrontend" "-define-availability" "-Xfrontend" "BacktracingDT 6.2:macOS 26.0")
 endif()
 
 add_swift_target_library(swiftRuntime ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
@@ -154,6 +161,7 @@ add_swift_target_library(swiftRuntime ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STD
 
   SWIFT_COMPILE_FLAGS
     ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
+    ${backtracing_availability}
     ${runtime_compile_flags}
     -parse-stdlib
 

--- a/stdlib/public/RuntimeModule/CachingMemoryReader.swift
+++ b/stdlib/public/RuntimeModule/CachingMemoryReader.swift
@@ -24,7 +24,7 @@ fileprivate let pageMask = pageSize - 1
 fileprivate let maxCachedSize = pageSize * 8
 
 @_spi(MemoryReaders)
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 public class CachingMemoryReader<Reader: MemoryReader>: MemoryReader {
   private var reader: Reader
   private var cache: [Address:UnsafeRawBufferPointer]
@@ -99,10 +99,10 @@ extension CachingMemoryReader where Reader == UncachedMemserverMemoryReader {
 
 #if os(Linux) || os(macOS) || os(Windows)
 @_spi(MemoryReaders)
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 public typealias RemoteMemoryReader = CachingMemoryReader<UncachedRemoteMemoryReader>
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 extension CachingMemoryReader where Reader == UncachedRemoteMemoryReader {
   #if os(macOS)
   convenience public init(task: Any) {
@@ -120,10 +120,10 @@ extension CachingMemoryReader where Reader == UncachedRemoteMemoryReader {
 }
 
 @_spi(MemoryReaders)
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 public typealias LocalMemoryReader = CachingMemoryReader<UncachedLocalMemoryReader>
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 extension CachingMemoryReader where Reader == UncachedLocalMemoryReader {
   convenience public init() {
     self.init(for: UncachedLocalMemoryReader())

--- a/stdlib/public/RuntimeModule/CompactBacktrace.swift
+++ b/stdlib/public/RuntimeModule/CompactBacktrace.swift
@@ -16,7 +16,7 @@
 
 import Swift
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 enum CompactBacktraceFormat {
   /// Tells us what size of machine words were used when generating the
   /// backtrace.
@@ -618,7 +618,7 @@ enum CompactBacktraceFormat {
   }
 }
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 extension CompactBacktraceFormat.Instruction: Comparable {
   public static func < (lhs: Self, rhs: Self) -> Bool {
     return lhs.rawValue < rhs.rawValue
@@ -628,7 +628,7 @@ extension CompactBacktraceFormat.Instruction: Comparable {
   }
 }
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 extension CompactBacktraceFormat.Instruction {
   func decoded() -> CompactBacktraceFormat.DecodedInstruction? {
     switch self {

--- a/stdlib/public/RuntimeModule/CompactImageMap.swift
+++ b/stdlib/public/RuntimeModule/CompactImageMap.swift
@@ -20,7 +20,7 @@ private let slash = UInt8(ascii: "/")
 private let backslash = UInt8(ascii: "\\")
 
 @_spi(Internal)
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 public enum CompactImageMapFormat {
 
   /// The list of fixed prefixes used to encode paths.

--- a/stdlib/public/RuntimeModule/Compression.swift
+++ b/stdlib/public/RuntimeModule/Compression.swift
@@ -331,7 +331,7 @@ struct LZMAStream: CompressedStream {
 
 // .. Image Sources ............................................................
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 fileprivate func decompress<S: CompressedStream>(
   stream: S,
   source: ImageSource,
@@ -357,7 +357,7 @@ fileprivate func decompress<S: CompressedStream>(
   output.used(bytes: Int(totalBytes))
 }
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 fileprivate func decompressChunked<S: CompressedStream>(
   stream: S,
   source: ImageSource,
@@ -392,7 +392,7 @@ fileprivate func decompressChunked<S: CompressedStream>(
   )
 }
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 extension ImageSource {
   @_specialize(kind: full, where Traits == Elf32Traits)
   @_specialize(kind: full, where Traits == Elf64Traits)

--- a/stdlib/public/RuntimeModule/CrashLog.swift
+++ b/stdlib/public/RuntimeModule/CrashLog.swift
@@ -17,7 +17,7 @@
 import Swift
 
 @_spi(CrashLog)
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 public struct CrashLog<Address: FixedWidthInteger>: Codable {
     public struct Frame: Codable {
         enum CodingKeys: String, CodingKey {
@@ -217,14 +217,14 @@ public struct CrashLog<Address: FixedWidthInteger>: Codable {
     }
 }
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 extension Backtrace.Address {
     func hexRepresentation<Address:FixedWidthInteger>(nullAs: Address.Type) -> String {
         return hex(Address(self) ?? 0)
     }
 }
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 extension CrashLog.Frame.SourceLocation {
     init?(_ symbol: SymbolicatedBacktrace.SourceLocation?) {
         guard let symbol else { return nil }
@@ -239,7 +239,7 @@ extension CrashLog.Frame.SourceLocation {
     }
 }
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 extension CrashLog.Frame {
     func richFrame() -> RichFrame<Address>? {
         switch (kind, CrashLog.addressFromString(address), count) {
@@ -360,7 +360,7 @@ extension CrashLog.Frame {
     }
 }
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 extension CrashLog.Image {
     func imageMapImage() -> ImageMap.Image {
         return .init(
@@ -384,7 +384,7 @@ extension CrashLog.Image {
     }
 }
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 public extension CrashLog.Thread {
     func backtrace(architecture: String, images: ImageMap?) -> Backtrace {
         let frames = self.frames.compactMap { $0.richFrame() }
@@ -413,12 +413,12 @@ public extension CrashLog.Thread {
     }
 }
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 extension Context {
   static var addressType: any FixedWidthInteger.Type { Address.self }
 }
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 extension CrashLog {
     private static func context(forArchitecture arch: String) -> (any Context.Type)? {
         switch arch {

--- a/stdlib/public/RuntimeModule/CrashLogCapture.swift
+++ b/stdlib/public/RuntimeModule/CrashLogCapture.swift
@@ -17,7 +17,7 @@
 import Swift
 
 @_spi(CrashLog)
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 public class CrashLogCapture<Address: FixedWidthInteger> {
   public typealias Thread = CrashLog<Address>.Thread
 

--- a/stdlib/public/RuntimeModule/Dwarf.swift
+++ b/stdlib/public/RuntimeModule/Dwarf.swift
@@ -302,7 +302,7 @@ private enum DwarfError: Error {
 
 // .. Dwarf utilities for ImageSource ..........................................
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 extension ImageSource {
 
   func fetchULEB128(from a: Address) throws -> (Address, UInt64) {
@@ -429,7 +429,7 @@ extension ImageSource {
 
 // .. Dwarf utilities for ImageSourceCursor .....................................
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 extension ImageSourceCursor {
 
   mutating func readULEB128() throws -> UInt64 {
@@ -498,7 +498,7 @@ enum DwarfSection {
   case debugTuIndex
 }
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 protocol DwarfSource {
 
   static var pathSeparator: String { get }
@@ -507,7 +507,7 @@ protocol DwarfSource {
 
 }
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 class DwarfReader<S: DwarfSource & AnyObject> {
   typealias Source = S
   typealias Address = UInt64
@@ -1997,7 +1997,7 @@ struct DwarfLineNumberState: CustomStringConvertible {
   }
 }
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 struct DwarfLineNumberInfo {
   typealias Address = UInt64
 
@@ -2208,7 +2208,7 @@ struct DwarfLineNumberInfo {
 // .. Testing ..................................................................
 
 @_spi(DwarfTest)
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 public func testDwarfReaderFor(path: String) -> Bool {
   guard let source = try? ImageSource(path: path) else {
     print("\(path) was not accessible")

--- a/stdlib/public/RuntimeModule/Elf.swift
+++ b/stdlib/public/RuntimeModule/Elf.swift
@@ -952,7 +952,7 @@ struct Elf64Traits: ElfTraits {
 
 // .. ElfStringSection .........................................................
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 struct ElfStringSection {
   let source: ImageSource
 
@@ -998,7 +998,7 @@ protocol ElfSymbolTableProtocol {
   func lookupSymbol(address: Traits.Address) -> Symbol?
 }
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 struct ElfSymbolTable<SomeElfTraits: ElfTraits>: ElfSymbolTableProtocol {
   typealias Traits = SomeElfTraits
 
@@ -1146,7 +1146,7 @@ struct ElfSymbolTable<SomeElfTraits: ElfTraits>: ElfSymbolTableProtocol {
   }
 }
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 final class ElfImage<SomeElfTraits: ElfTraits> : DwarfSource {
   typealias Traits = SomeElfTraits
   typealias SymbolTable = ElfSymbolTable<SomeElfTraits>
@@ -1701,10 +1701,10 @@ final class ElfImage<SomeElfTraits: ElfTraits> : DwarfSource {
   }
 }
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 typealias Elf32Image = ElfImage<Elf32Traits>
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 typealias Elf64Image = ElfImage<Elf64Traits>
 
 // .. Checking for ELF images ..................................................
@@ -1718,7 +1718,7 @@ typealias Elf64Image = ElfImage<Elf64Traits>
 #if os(Linux)
 @_specialize(kind: full, where R == MemserverMemoryReader)
 #endif
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 func getElfImageInfo<R: MemoryReader>(at address: R.Address,
                                       using reader: R)
   -> (endOfText: R.Address, uuid: [UInt8]?)?
@@ -1759,7 +1759,7 @@ func getElfImageInfo<R: MemoryReader>(at address: R.Address,
 @_specialize(kind: full, where R == MemserverMemoryReader, Traits == Elf32Traits)
 @_specialize(kind: full, where R == MemserverMemoryReader, Traits == Elf64Traits)
 #endif
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 func getElfImageInfo<R: MemoryReader, Traits: ElfTraits>(
   at address: R.Address,
   using reader: R,
@@ -1933,7 +1933,7 @@ extension ElfImage: SymbolLocator.Image {
 // .. Testing ..................................................................
 
 @_spi(ElfTest)
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 public func testElfImageAt(path: String) -> Bool {
   guard let source = try? ImageSource(path: path) else {
     print("\(path) was not accessible")

--- a/stdlib/public/RuntimeModule/ElfImageCache.swift
+++ b/stdlib/public/RuntimeModule/ElfImageCache.swift
@@ -20,7 +20,7 @@ import Swift
 /// Provides a per-thread image cache for ELF image processing.  This means
 /// if you take multiple backtraces from a thread, you won't load the same
 /// image multiple times.
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 final class ElfImageCache {
   var elf32: [String: Elf32Image] = [:]
   var elf64: [String: Elf64Image] = [:]

--- a/stdlib/public/RuntimeModule/FramePointerUnwinder.swift
+++ b/stdlib/public/RuntimeModule/FramePointerUnwinder.swift
@@ -17,7 +17,7 @@
 import Swift
 
 @_spi(Unwinders)
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 public struct FramePointerUnwinder<C: Context, M: MemoryReader>: Sequence, IteratorProtocol {
   public typealias Context = C
   public typealias MemoryReader = M

--- a/stdlib/public/RuntimeModule/Image.swift
+++ b/stdlib/public/RuntimeModule/Image.swift
@@ -22,7 +22,7 @@ struct ImageSymbol {
   var offset: Int
 }
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 protocol Image {
   typealias UUID = [UInt8]
   typealias Address = ImageSource.Address
@@ -68,7 +68,7 @@ protocol Image {
   func lookupSymbol(address: Address) -> ImageSymbol?
 }
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 extension Image {
   public func swapIfRequired<T: FixedWidthInteger>(_ x: T) -> T {
     if shouldByteSwap {

--- a/stdlib/public/RuntimeModule/ImageMap+Darwin.swift
+++ b/stdlib/public/RuntimeModule/ImageMap+Darwin.swift
@@ -38,7 +38,7 @@ fileprivate func getSysCtlString(_ name: String) -> String? {
   }
 }
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 extension ImageMap {
 
   private static let platform = {

--- a/stdlib/public/RuntimeModule/ImageMap.swift
+++ b/stdlib/public/RuntimeModule/ImageMap.swift
@@ -27,7 +27,7 @@ internal import WinSDK
 #endif
 
 /// Holds a map of the process's address space.
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 public struct ImageMap: Collection, Sendable, Hashable {
 
   /// A type representing the sequence's elements.
@@ -156,7 +156,7 @@ public struct ImageMap: Collection, Sendable, Hashable {
   }
 }
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 extension ImageMap: CustomStringConvertible {
   /// Generate a description of an ImageMap
   public var description: String {
@@ -187,7 +187,7 @@ extension ImageMap: CustomStringConvertible {
   }
 }
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 extension Backtrace.Image {
   /// Convert an ImageMap.Image to a Backtrace.Image.
   ///
@@ -225,7 +225,7 @@ extension Backtrace.Image {
   }
 }
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 extension ImageMap: Codable {
 
   public func encode(to encoder: any Encoder) throws {

--- a/stdlib/public/RuntimeModule/ImageSource.swift
+++ b/stdlib/public/RuntimeModule/ImageSource.swift
@@ -36,7 +36,7 @@ enum ImageSourceError: Error {
   #endif
 }
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 struct ImageSource: CustomStringConvertible {
 
   private class Storage: CustomStringConvertible {
@@ -411,7 +411,7 @@ struct ImageSource: CustomStringConvertible {
 }
 
 // MemoryReader support
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 extension ImageSource: MemoryReader {
   public func fetch(from address: Address,
                     into buffer: UnsafeMutableRawBufferPointer) throws {
@@ -448,7 +448,7 @@ extension ImageSource: MemoryReader {
 }
 
 /// Used as a cursor by the DWARF code
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 struct ImageSourceCursor {
   typealias Address = ImageSource.Address
   typealias Size = ImageSource.Size

--- a/stdlib/public/RuntimeModule/MemoryReader.swift
+++ b/stdlib/public/RuntimeModule/MemoryReader.swift
@@ -33,7 +33,7 @@ internal import BacktracingImpl.OS.Darwin
 #endif
 
 @_spi(MemoryReaders)
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 public protocol MemoryReader {
   typealias Address = UInt64
   typealias Size = UInt64
@@ -65,7 +65,7 @@ public protocol MemoryReader {
   func fetchString(from addr: Address, length: Int) throws -> String?
 }
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 extension MemoryReader {
 
   public func fetch<T>(from address: Address,
@@ -120,7 +120,7 @@ extension MemoryReader {
 }
 
 @_spi(MemoryReaders)
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 public struct UnsafeLocalMemoryReader: MemoryReader {
   public init() {}
 
@@ -145,13 +145,13 @@ public struct UnsafeLocalMemoryReader: MemoryReader {
 
 #if os(macOS)
 @_spi(MemoryReaders)
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 public struct MachError: Error {
   var result: kern_return_t
 }
 
 @_spi(MemoryReaders)
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 public struct UncachedRemoteMemoryReader: MemoryReader {
   private var task: task_t
 
@@ -179,7 +179,7 @@ public struct UncachedRemoteMemoryReader: MemoryReader {
 }
 
 @_spi(MemoryReaders)
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 public struct UncachedLocalMemoryReader: MemoryReader {
   public typealias Address = UInt64
   public typealias Size = UInt64

--- a/stdlib/public/RuntimeModule/RichFrame.swift
+++ b/stdlib/public/RuntimeModule/RichFrame.swift
@@ -17,7 +17,7 @@
 import Swift
 
 @_spi(Internal)
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 public enum RichFrame<T: FixedWidthInteger>: CustomStringConvertible, Equatable {
   public typealias Address = T
 
@@ -122,7 +122,7 @@ public enum RichFrame<T: FixedWidthInteger>: CustomStringConvertible, Equatable 
   }
 }
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 extension RichFrame: LimitableElement {
   // LimitableElement wants to call this "omitted"
   public static func omitted(_ count: Int) -> Self {
@@ -130,7 +130,7 @@ extension RichFrame: LimitableElement {
   }
 }
 
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 extension Backtrace.Frame {
   init<T>(_ frame: RichFrame<T>) {
     switch frame {

--- a/stdlib/public/RuntimeModule/SymbolicatedBacktrace.swift
+++ b/stdlib/public/RuntimeModule/SymbolicatedBacktrace.swift
@@ -33,7 +33,7 @@ internal import Musl
 internal import BacktracingImpl.Runtime
 
 /// A symbolicated backtrace
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 public struct SymbolicatedBacktrace: CustomStringConvertible {
   /// The `Backtrace` from which this was constructed
   public var backtrace: Backtrace

--- a/stdlib/public/RuntimeModule/Utils.swift
+++ b/stdlib/public/RuntimeModule/Utils.swift
@@ -162,7 +162,7 @@ func realPath(_ path: String) -> String? {
 
 #if os(Linux)
 @_spi(Utils)
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 public func readString(from file: String) -> String? {
   let fd = open(file, O_RDONLY, 0)
   if fd < 0 {
@@ -190,7 +190,7 @@ public func readString(from file: String) -> String? {
 #endif
 
 @_spi(Utils)
-@available(Backtracing 6.2, *)
+@available(BacktracingDT 6.2, *)
 public func stripWhitespace<S: StringProtocol>(_ s: S)
     -> S.SubSequence {
   guard let firstNonWhitespace = s.firstIndex(where: { !$0.isWhitespace })


### PR DESCRIPTION
We need a minimum target of 15.7 or below because of CI, so add a new `BacktracingDT 6.2` define.  This is a bit of a hack for now to unblock CI upgrades; we can go and clean things up and perhaps generalise this mechanism later.

rdar://172129091
