### PR TITLE
Support location markers in DiagnosticVerifier

### DIFF
--- a/docs/Diagnostics.md
+++ b/docs/Diagnostics.md
@@ -188,6 +188,15 @@ An expected diagnostic is denoted by a comment which begins with `expected-error
 
 - (Optional) Location information. By default, the comment will match any diagnostic emitted on the same line. However, it's possible to override this behavior and/or specify column information as well. `// expected-error@-1 ...` looks for an error on the previous line, `// expected-warning@+1:3 ...` looks for a warning on the next line at the third column, and `// expected-note@:7 ...` looks for a note on the same line at the seventh column.
 
+  Named location markers can also be used instead of line offsets. A marker is defined by placing `// #name` in a comment (where `name` consists of alphanumeric characters, hyphens, or underscores, and must be the only content in the comment). The marker can then be referenced with `@#name`:
+
+  ```swift
+  let x: Int = "hello" // #myMarker
+  // expected-error@#myMarker {{cannot convert value}}
+  ```
+
+  Markers are especially useful when the diagnostic and its expectation are far apart, when lines are frequently added or removed nearby, or when referring to diagnostics in a different file. An optional column can also be specified: `// expected-error@#myMarker:14 ...`.
+
 - (Optional) A match count which specifies how many times the diagnostic is expected to appear. This may be a positive integer or `*`, which allows for zero or more matches. The match count must be surrounded by whitespace if present. For example, `// expected-error 2 ...` looks for two matching errors, and `// expected-warning * ...` looks for any number of matching warnings.
 
 - (Required) The expected error message. The message should be enclosed in double curly braces and should not include the `error:`/`warning:`/`note:`/`remark:` prefix. For example, `// expected-error {{invalid redeclaration of 'y'}}` would match an error with that message on the same line. The expected message does not need to match the emitted message verbatim. As long as the expected message is a substring of the original message, they will match.

--- a/include/swift/Frontend/DiagnosticVerifier.h
+++ b/include/swift/Frontend/DiagnosticVerifier.h
@@ -20,6 +20,7 @@
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/StringMap.h"
 #include "swift/AST/DiagnosticConsumer.h"
 #include "swift/Basic/LLVM.h"
 
@@ -172,6 +173,25 @@ private:
                            unsigned BufferID, unsigned DiagnosticLineNo) const;
 
   llvm::DenseMap<SourceLoc, unsigned> Expansions;
+
+  struct MarkerLocation {
+    unsigned BufferID;
+    unsigned Line;
+  };
+
+  /// Map from location marker names to their buffer and line number.
+  /// Populated by scanForMarkers() before parsing expected diagnostics.
+  llvm::StringMap<MarkerLocation> LocationMarkers;
+
+  /// Scan the buffer for location marker definitions (// #name).
+  void scanForMarkers(unsigned BufferID);
+
+  /// Check whether any location marker is defined at the given buffer and line.
+  bool hasMarkerAtLine(unsigned BufferID, unsigned Line) const;
+
+  /// Report any remaining diagnostics on lines with markers that were deferred
+  /// during per-file verification. Returns true if any were found.
+  bool verifyDeferredMarkerDiagnostics();
 
   void printRemainingDiagnostics() const;
 };

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -768,7 +768,7 @@ unsigned DiagnosticVerifier::parseExpectedDiagInfo(
   bool AbsoluteLine = false;
 
   if (TextStartIdx > 0 && MatchStart[0] == '@') {
-    if (MatchStart[1] != '+' && MatchStart[1] != '-' && MatchStart[1] != ':' && (MatchStart[1] < '0' || MatchStart[1] > '9')) {
+    if (MatchStart[1] != '#' && MatchStart[1] != '+' && MatchStart[1] != '-' && MatchStart[1] != ':' && (MatchStart[1] < '0' || MatchStart[1] > '9')) {
       StringRef TargetBufferName;
       if (!parseTargetBufferName(MatchStart, TargetBufferName, TextStartIdx)) {
         addError(MatchStart.data(), "expected '+'/'-' for line offset, ':' "
@@ -787,10 +787,42 @@ unsigned DiagnosticVerifier::parseExpectedDiagInfo(
         return 0;
       }
     }
+
+    // Location marker reference: @#markerName or @#markerName:col
     StringRef Offs;
-    if (MatchStart[1] == '+')
+    if (MatchStart[0] == '@' && MatchStart[1] == '#') {
+      size_t NameStart = 2;
+      size_t NameEnd = NameStart;
+      while (NameEnd < TextStartIdx &&
+             (isalnum(MatchStart[NameEnd]) ||
+              MatchStart[NameEnd] == '_' || MatchStart[NameEnd] == '-'))
+        ++NameEnd;
+
+      if (NameEnd == NameStart) {
+        addError(MatchStart.data() + 1,
+                 "expected marker name after '#'");
+        return 0;
+      }
+
+      StringRef MarkerName = MatchStart.slice(NameStart, NameEnd);
+      auto It = LocationMarkers.find(MarkerName);
+      if (It == LocationMarkers.end()) {
+        addError(MatchStart.data() + 1,
+                 "use of undefined location marker '#" + MarkerName + "'");
+        return 0;
+      }
+
+      LineOffset = It->second.Line;
+      AbsoluteLine = true;
+      if (It->second.BufferID != BufferID)
+        Expected.TargetBufferID = It->second.BufferID;
+
+      // Extract the remainder after the marker name (e.g. ":col" or empty)
+      // and let the shared column-parsing code below handle it.
+      Offs = MatchStart.slice(NameEnd, TextStartIdx).rtrim();
+    } else if (MatchStart[1] == '+') {
       Offs = MatchStart.slice(2, TextStartIdx).rtrim();
-    else {
+    } else {
       Offs = MatchStart.slice(1, TextStartIdx).rtrim();
       if (Offs[0] >= '0' && Offs[0] <= '9')
         AbsoluteLine = true;
@@ -808,8 +840,8 @@ unsigned DiagnosticVerifier::parseExpectedDiagInfo(
     }
 
     size_t ColonIndex = Offs.find(':');
-    // Check whether a line offset was provided
-    if (ColonIndex != 0) {
+    // Check whether a line offset was provided (not applicable for markers).
+    if (!LineOffset && ColonIndex != 0) {
       StringRef LineOffs = Offs.slice(0, ColonIndex);
       if (LineOffs.getAsInteger(10, LineOffset)) {
         addError(MatchStart.data(), "expected line offset before '{{'");
@@ -1354,6 +1386,98 @@ void DiagnosticVerifier::addError(const char *Loc, const Twine &message,
   Errors.push_back(diag);
 }
 
+/// Scan the buffer for location marker definitions of the form "// #name".
+/// A marker definition is a comment whose only content is "#name", e.g.:
+///   code // #marker1
+///   // #marker2
+/// The marker name consists of alphanumeric characters, hyphens, or
+/// underscores. Nothing else may appear in the comment after the marker name
+/// (except trailing whitespace). This prevents false positives from comments
+/// like "// #available(...)" or stack traces containing "// #10 0x...".
+void DiagnosticVerifier::scanForMarkers(unsigned BufferID) {
+  StringRef InputFile = SM.getEntireTextForBuffer(BufferID);
+  const SourceLoc BufferStartLoc = SM.getLocForBufferStart(BufferID);
+
+  for (size_t Pos = InputFile.find("//"); Pos != StringRef::npos;
+       Pos = InputFile.find("//", Pos + 2)) {
+    size_t Cur = Pos + 2;
+    while (Cur < InputFile.size() && (InputFile[Cur] == ' ' ||
+                                       InputFile[Cur] == '\t'))
+      ++Cur;
+
+    if (Cur >= InputFile.size() || InputFile[Cur] != '#')
+      continue;
+
+    size_t HashPos = Cur;
+    size_t NameStart = HashPos + 1;
+    size_t NameEnd = NameStart;
+    while (NameEnd < InputFile.size() &&
+           (isalnum(InputFile[NameEnd]) || InputFile[NameEnd] == '_' ||
+            InputFile[NameEnd] == '-'))
+      ++NameEnd;
+
+    if (NameEnd == NameStart)
+      continue;
+
+    // Only trailing whitespace is allowed after the marker name until EOL.
+    size_t Rest = NameEnd;
+    while (Rest < InputFile.size() && (InputFile[Rest] == ' ' ||
+                                        InputFile[Rest] == '\t'))
+      ++Rest;
+    if (Rest < InputFile.size() && InputFile[Rest] != '\n' &&
+        InputFile[Rest] != '\r' && InputFile[Rest] != '\0')
+      continue;
+
+    StringRef MarkerName = InputFile.slice(NameStart, NameEnd);
+    unsigned Line =
+        SM.getLineAndColumnInBuffer(
+              BufferStartLoc.getAdvancedLoc(HashPos), BufferID)
+            .first;
+
+    auto Result =
+        LocationMarkers.try_emplace(MarkerName, MarkerLocation{BufferID, Line});
+    if (!Result.second) {
+      addError(InputFile.data() + HashPos,
+               "location marker '#" + MarkerName + "' already defined");
+    }
+  }
+}
+
+bool DiagnosticVerifier::hasMarkerAtLine(unsigned BufferID,
+                                         unsigned Line) const {
+  for (const auto &Entry : LocationMarkers) {
+    if (Entry.second.BufferID == BufferID && Entry.second.Line == Line)
+      return true;
+  }
+  return false;
+}
+
+bool DiagnosticVerifier::verifyDeferredMarkerDiagnostics() {
+  Errors.clear();
+  bool HadError = false;
+  auto CapturedDiagIter = CapturedDiagnostics.begin();
+  while (CapturedDiagIter != CapturedDiagnostics.end()) {
+    if (!CapturedDiagIter->SourceBufferID ||
+        !hasMarkerAtLine(*CapturedDiagIter->SourceBufferID,
+                         CapturedDiagIter->Line)) {
+      ++CapturedDiagIter;
+      continue;
+    }
+    HadError = true;
+    std::string Message =
+        ("unexpected " +
+         getDiagKindString(CapturedDiagIter->Classification) +
+         " produced: " + CapturedDiagIter->Message)
+            .str();
+    addError(getRawLoc(CapturedDiagIter->Loc).getPointer(), Message);
+    CapturedDiagIter = CapturedDiagnostics.erase(CapturedDiagIter);
+  }
+  for (auto &Err : Errors)
+    printDiagnostic(Err);
+  Errors.clear();
+  return HadError;
+}
+
 /// After the file has been processed, check to see if we got all of
 /// the expected diagnostics and check to see if there were any unexpected
 /// ones.
@@ -1460,6 +1584,13 @@ DiagnosticVerifier::Result DiagnosticVerifier::verifyFile(unsigned BufferID) {
         ++CapturedDiagIter;
         continue;
       }
+    }
+
+    // Defer reporting unexpected diagnostics on lines with location markers,
+    // because another file may have an expected-error@#marker for this line.
+    if (hasMarkerAtLine(BufferID, CapturedDiagIter->Line)) {
+      ++CapturedDiagIter;
+      continue;
     }
 
     HadUnexpectedDiag = true;
@@ -1603,13 +1734,35 @@ bool DiagnosticVerifier::finishProcessing() {
 
   processExpansions(SM, Expansions, CapturedDiagnostics);
 
+  // Scan all buffers for location marker definitions before verifying, so
+  // that markers defined in one file can be referenced from another.
   ArrayRef<unsigned> BufferIDLists[2] = { BufferIDs, additionalBufferIDs };
+  for (ArrayRef<unsigned> BufferIDList : BufferIDLists)
+    for (auto &BufferID : BufferIDList)
+      scanForMarkers(BufferID);
+
+  // Emit any errors from marker scanning (e.g. duplicate marker definitions)
+  // before verifyFile() clears the Errors vector.
+  for (auto &Err : Errors)
+    printDiagnostic(Err);
+  if (!Errors.empty())
+    Result.HadError = true;
+  Errors.clear();
+
   for (ArrayRef<unsigned> BufferIDList : BufferIDLists)
     for (auto &BufferID : BufferIDList) {
       DiagnosticVerifier::Result FileResult = verifyFile(BufferID);
       Result.HadError |= FileResult.HadError;
       Result.HadUnexpectedDiag |= FileResult.HadUnexpectedDiag;
     }
+
+  // Now that all files have been verified, check for any remaining diagnostics
+  // on lines with markers that were deferred during per-file verification.
+  if (verifyDeferredMarkerDiagnostics()) {
+    Result.HadError = true;
+    Result.HadUnexpectedDiag = true;
+  }
+
   if (!IgnoreUnknown) {
     bool HadError = verifyUnknown(CapturedDiagnostics);
     Result.HadError |= HadError;

--- a/test/Frontend/DiagnosticVerifier/verify-marker-clang-header.swift
+++ b/test/Frontend/DiagnosticVerifier/verify-marker-clang-header.swift
@@ -1,0 +1,37 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -typecheck -verify %t/test.swift \
+// RUN:   -I %t \
+// RUN:   -verify-additional-file %t%{fs-sep}header.h
+
+//--- header.h
+struct
+__attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:MyRetain")))
+__attribute__((swift_attr("release:MyRelease")))
+MyFRT {
+  int value;
+};
+
+void MyRetain(struct MyFRT *x);
+void MyRelease(struct MyFRT *x);
+
+struct MyFRT *getConflicting() // #hdrMarker1
+    __attribute__((swift_attr("returns_retained")))
+    __attribute__((swift_attr("returns_unretained")));
+
+//--- module.modulemap
+module TestClangMarker {
+  header "header.h"
+  export *
+}
+
+//--- test.swift
+import TestClangMarker
+
+// Marker defined in the C header, referenced from Swift file.
+// expected-error@#hdrMarker1 {{cannot be annotated with both}}
+
+// Trigger the diagnostic by using the function.
+let _ = getConflicting()

--- a/test/Frontend/DiagnosticVerifier/verify-marker-cross-file.swift
+++ b/test/Frontend/DiagnosticVerifier/verify-marker-cross-file.swift
@@ -1,0 +1,14 @@
+// Tests for cross-file location markers in the Swift frontend's `-verify` mode.
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -typecheck -verify %t/file1.swift %t/file2.swift
+
+//--- file1.swift
+let x: Int = "hello" // #marker1
+// expected-error@#marker2{{cannot convert value of type '()' to specified type 'String'}}
+
+//--- file2.swift
+// expected-error@#marker1 {{cannot convert value of type 'String' to specified type 'Int'}}
+let y: String = () // #marker2

--- a/test/Frontend/DiagnosticVerifier/verify-marker-negative.swift
+++ b/test/Frontend/DiagnosticVerifier/verify-marker-negative.swift
@@ -1,0 +1,22 @@
+// Tests for location marker error handling in the Swift frontend's `-verify` mode.
+
+// RUN: not %target-typecheck-verify-swift 2>&1 | %FileCheck %s
+
+// Duplicate marker definition.
+// Marker scan errors are emitted before expected-diagnostic parsing errors.
+func dup1() {} // #dup
+// CHECK: [[@LINE+1]]:19: error: location marker '#dup' already defined
+func dup2() {} // #dup
+
+// Use of undefined marker.
+// CHECK: [[@LINE+1]]:19: error: use of undefined location marker '#undefined'
+// expected-error@#undefined {{some error}}
+
+// Empty marker name after '#'.
+// CHECK: [[@LINE+1]]:19: error: expected marker name after '#'
+// expected-error@# {{some error}}
+
+// Comment with extra text after #name is NOT a marker definition.
+// #notAMarker this has extra text
+// CHECK: [[@LINE+1]]:19: error: use of undefined location marker '#notAMarker'
+// expected-error@#notAMarker {{some error}}

--- a/test/Frontend/DiagnosticVerifier/verify-marker.swift
+++ b/test/Frontend/DiagnosticVerifier/verify-marker.swift
@@ -1,0 +1,23 @@
+// Tests for location markers in the Swift frontend's `-verify` mode.
+
+// Positive tests: these should all pass verification.
+// RUN: %target-typecheck-verify-swift
+
+// Basic marker usage: marker on same line as diagnostic-producing code.
+let x: Int = "hello" // #marker1
+// expected-error@#marker1 {{cannot convert value of type 'String' to specified type 'Int'}}
+
+// Marker referenced before definition (forward reference).
+// expected-error@#marker2 {{cannot convert value of type 'String' to specified type 'Int'}}
+let y: Int = "world" // #marker2
+
+// Marker with column specifier and fix-it.
+func fn() {}
+fn(()) // #marker3
+// expected-error@#marker3:4 {{argument passed to call that takes no arguments}} {{4-6=}}
+
+// Multiple diagnostics referencing the same marker.
+func bar(_ x: Int, _ y: Int) {}
+bar("a", "b") // #marker4
+// expected-error@#marker4 {{cannot convert value of type 'String' to expected argument type 'Int'}}
+// expected-error@#marker4 {{cannot convert value of type 'String' to expected argument type 'Int'}}


### PR DESCRIPTION
Resolves https://github.com/swiftlang/swift/issues/87759

Add support for location markers in `DiagnosticVerifier`, matching the functionality already available in Clang's `VerifyDiagnosticConsumer`.

Currently, referencing diagnostics on other lines requires fragile numeric offsets (`@+2`, `@-1`) that break when lines are added or removed. This change introduces named location markers that decouple expected-diagnostic directives from exact line numbers:

```swift
let x = bad   // #marker1
// expected-error@#marker1 {{some error message}}
