### PR TITLE
[IRGen] Fix visbility of private symbols when compiling with testing en…

### DIFF
--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -629,6 +629,20 @@ SILDeclRef LinkEntity::getSILDeclRef() const {
   return ref;
 }
 
+/// When a module is compiled with -enable-testing, private type metadata may
+/// be referenced cross-module by @testable importers (e.g. via outline destroy
+/// helpers that instantiate generic metadata for types using private nested
+/// types). Promote Private linkage to HiddenUnique so the metadata is exported
+/// from the defining module and correctly declared as external in the importing
+/// module.
+static FormalLinkage adjustDeclLinkageForTesting(FormalLinkage linkage,
+                                                 const ValueDecl *D) {
+  if (linkage == FormalLinkage::Private &&
+      D->getModuleContext()->isTestingEnabled())
+    return FormalLinkage::HiddenUnique;
+  return linkage;
+}
+
 static bool isLazyEmissionOfPublicSymbolInMultipleModulesPossible(CanType ty) {
   // In embedded existenitals mode we generate lazy public metadata on demand
   // which makes it non unique.
@@ -732,18 +746,22 @@ SILLinkage LinkEntity::getLinkage(ForDefinition_t forDefinition) const {
       if (getDeclLinkage(nominal) == FormalLinkage::PublicNonUnique)
         return SILLinkage::Shared;
 
-      // Prespecialization of the same generic metadata may be requested 
+      // Prespecialization of the same generic metadata may be requested
       // multiple times within the same module, so it needs to be uniqued.
       if (nominal->isGenericContext())
         return SILLinkage::Shared;
 
-      // The full metadata object is private to the containing module.
-      return SILLinkage::Private;
+      // The full metadata object is private to the containing module,
+      // but must be exported when -enable-testing is active.
+      return getSILLinkage(
+          adjustDeclLinkageForTesting(FormalLinkage::Private, nominal),
+          forDefinition);
     case TypeMetadataAddress::AddressPoint: {
-      return getSILLinkage(nominal
-                           ? getDeclLinkage(nominal)
-                           : FormalLinkage::PublicUnique,
-                           forDefinition);
+      auto linkage =
+          nominal
+              ? adjustDeclLinkageForTesting(getDeclLinkage(nominal), nominal)
+              : FormalLinkage::PublicUnique;
+      return getSILLinkage(linkage, forDefinition);
     }
     }
     llvm_unreachable("bad kind");
@@ -772,8 +790,12 @@ SILLinkage LinkEntity::getLinkage(ForDefinition_t forDefinition) const {
       return getSILLinkage(FormalLinkage::PackageUnique, forDefinition);
     case MetadataAccessStrategy::HiddenUniqueAccessor:
       return getSILLinkage(FormalLinkage::HiddenUnique, forDefinition);
-    case MetadataAccessStrategy::PrivateAccessor:
-      return getSILLinkage(FormalLinkage::Private, forDefinition);
+    case MetadataAccessStrategy::PrivateAccessor: {
+      auto *nominal = getType().getAnyNominal();
+      auto linkage =
+          adjustDeclLinkageForTesting(FormalLinkage::Private, nominal);
+      return getSILLinkage(linkage, forDefinition);
+    }
     case MetadataAccessStrategy::ForeignAccessor:
     case MetadataAccessStrategy::NonUniqueAccessor:
       return SILLinkage::Shared;
@@ -872,8 +894,11 @@ SILLinkage LinkEntity::getLinkage(ForDefinition_t forDefinition) const {
   case Kind::OpaqueTypeDescriptorAccessor:
   case Kind::OpaqueTypeDescriptorAccessorImpl:
   case Kind::OpaqueTypeDescriptorAccessorKey:
-  case Kind::OpaqueTypeDescriptorAccessorVar:
-    return getSILLinkage(getDeclLinkage(getDecl()), forDefinition);
+  case Kind::OpaqueTypeDescriptorAccessorVar: {
+    auto linkage =
+        adjustDeclLinkageForTesting(getDeclLinkage(getDecl()), getDecl());
+    return getSILLinkage(linkage, forDefinition);
+  }
 
   case Kind::CanonicalSpecializedGenericSwiftMetaclassStub:
     // Prespecialization of the same generic class' metaclass may be requested

--- a/test/IRGen/testing-enabled-private-type-descriptor.swift
+++ b/test/IRGen/testing-enabled-private-type-descriptor.swift
@@ -1,0 +1,51 @@
+// Verify that a private nested type's descriptor gets correct linkage when
+// compiled with -enable-testing, so that @testable importers can use the
+// enclosing ~Copyable type without hitting "Global is external, but doesn't
+// have external or weak linkage!" from the LLVM verifier.
+//
+// When the test module needs to destroy Foo, the outline destroy helper
+// instantiates Mutex<State> metadata via a symbolic mangled type string that
+// contains a reference to State's nominal type descriptor. Because State is
+// private, its descriptor gets SILLinkage::Private → InternalLinkage, which
+// is invalid for a cross-module declaration.
+
+// REQUIRES: synchronization
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module \
+// RUN:   -enable-testing \
+// RUN:   -disable-availability-checking \
+// RUN:   -swift-version 6 \
+// RUN:   -parse-as-library \
+// RUN:   -module-name Lib \
+// RUN:   %t/Lib.swift \
+// RUN:   -emit-module-path %t/Lib.swiftmodule
+
+// RUN: %target-swift-frontend -c \
+// RUN:   -enable-testing \
+// RUN:   -disable-availability-checking \
+// RUN:   -swift-version 6 \
+// RUN:   -parse-as-library \
+// RUN:   -I %t \
+// RUN:   %t/Test.swift \
+// RUN:   -module-name Test \
+// RUN:   -o /dev/null
+
+//--- Lib.swift
+import Synchronization
+
+struct Foo: ~Copyable {
+  private struct State {
+    var data: [Int] = []
+  }
+  private let mutex = Mutex(State())
+}
+
+//--- Test.swift
+@testable import Lib
+
+func test() {
+  var foo = Foo()
+}


### PR DESCRIPTION
…abled

rdar://171371956

Private type descriptors and metadata retained internal linkage even with -enable-testing, causing cross-module references from outline destroy helpers to fail with "Global is external, but doesn't have external or weak linkage!". Promote private/fileprivate effective access under -enable-testing, matching the existing internal promotion.

Fixes: https://github.com/swiftlang/swift/issues/87573
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
