### PR TITLE
6.3 Embedded Swift stdlib: ensures non Darwin triples build under macOS with Xcode 26.4

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -3541,3 +3541,26 @@ function(add_swift_target_executable name)
 
   endforeach()
 endfunction()
+
+function(embedded_amend_archive_commands_on_darwin_host target triple)
+  # This is a temporary solution while we work on porting the build
+  # on the Embedded stdlib to the Runtime build system, where each platform
+  # is built by a separate CMake invocation, thus allowing to set the archiver
+  # properly in the toolchain file.
+  if(SWIFT_HOST_VARIANT STREQUAL "macosx" AND SWIFT_EMBEDDED_STDLIB_ARCHIVER_FOR_NON_DARWIN_PLATFORMS_UNDER_MACOS)
+    if(triple MATCHES "-elf$" OR triple MATCHES "-eabi$" OR triple MATCHES "-wasm$")
+      # There is no way to change the archive commands only for a few targets, so
+      # we resort going double work (and assume the previous commands exit successfully)
+      add_custom_command(TARGET ${target}
+        POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E rm $<TARGET_FILE:${target}>
+        COMMAND ${SWIFT_EMBEDDED_STDLIB_ARCHIVER_FOR_NON_DARWIN_PLATFORMS_UNDER_MACOS}
+          $<TARGET_FILE:${target}>
+          "$<LIST:JOIN,$<TARGET_PROPERTY:${target},STATIC_LIBRARY_OPTIONS>,;>"
+          "$<LIST:JOIN,$<TARGET_OBJECTS:${target}>,;>"
+        COMMAND ${CMAKE_COMMAND} -E touch $<TARGET_FILE:${target}>
+        VERBATIM
+        COMMAND_EXPAND_LISTS)
+    endif()
+  endif()
+endfunction()

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -159,6 +159,19 @@ set(SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES "" CACHE STRING
     "List of SDKs to use for target triples, in the form triple@sdkpath.
     Using this variable precludes setting directly the value for  SWIFT_SDK_embedded_ARCH_\$\{ARCH\}_PATH")
 
+set(SWIFT_EMBEDDED_STDLIB_ARCHIVER_FOR_NON_DARWIN_PLATFORMS_UNDER_MACOS "${SWIFT_NATIVE_LLVM_TOOLS_PATH}/llvm-ar";crsU
+    CACHE STRING
+    "Archiver to use when building static archives for non Darwin platform targeting the macOS SDK.
+    This is required when using Xcode 26.4 beta 1 and later.")
+
+if(SWIFT_HOST_VARIANT STREQUAL "macosx")
+  list(GET SWIFT_EMBEDDED_STDLIB_ARCHIVER_FOR_NON_DARWIN_PLATFORMS_UNDER_MACOS 0 ARCHIVER_EXECUTABLE)
+  if(NOT IS_EXECUTABLE "${ARCHIVER_EXECUTABLE}")
+    message(WARNING "'${ARCHIVER_EXECUTABLE}' is not a valid program, unsetting SWIFT_EMBEDDED_STDLIB_ARCHIVER_FOR_NON_DARWIN_PLATFORMS_UNDER_MACOS to be able to pick up a different value at next run.")
+    unset(SWIFT_EMBEDDED_STDLIB_ARCHIVER_FOR_NON_DARWIN_PLATFORMS_UNDER_MACOS CACHE)
+  endif()
+endif()
+
 if((NOT SWIFT_HOST_VARIANT STREQUAL "macosx") AND
   (NOT SWIFT_HOST_VARIANT STREQUAL "linux") AND
   (NOT SWIFT_HOST_VARIANT STREQUAL "wasi") AND

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -312,6 +312,15 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
         # Host is macOS with a macOS SDK. To be able to build the C++ Concurrency runtime for non-Darwin targets using the macOS SDK,
         # we need to pass some extra flags and search paths.
         set(extra_c_compile_flags -stdlib=libc++ -isystem${SWIFT_SDK_OSX_PATH}/usr/include/c++/v1 -isystem${SWIFT_SDK_OSX_PATH}/usr/include -D__APPLE__)
+        # Before Xcode 26.4, we were getting these macros from TargetConditionals.h
+        # now it's on us to define those to keep using the macOS SDK for non Darwin targets
+        if("${arch}" MATCHES "armv7")
+          list(APPEND extra_c_compile_flags -DTARGET_CPU_ARM=1)
+        elseif("${arch}" MATCHES "arm64")
+          list(APPEND extra_c_compile_flags -DTARGET_CPU_ARM64=1)
+        elseif("${arch}" MATCHES "x86_64")
+          list(APPEND extra_c_compile_flags -DTARGET_CPU_X86_64=1)
+        endif()
       endif()
     endif()
 

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -394,6 +394,9 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
     if(NOT "${arch}" MATCHES "wasm32")
       set_property(TARGET embedded-concurrency-${mod} PROPERTY OSX_ARCHITECTURES "${arch}")
     endif()
+
+    embedded_amend_archive_commands_on_darwin_host(embedded-concurrency-${mod} ${triple})
+
     add_dependencies(embedded-concurrency embedded-concurrency-${mod})
 
     # lib/swift/embedded/<triple>/libswift_ConcurrencyDefaultExecutor.a
@@ -424,6 +427,9 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
       PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
       )
     set_property(TARGET embedded-concurrency-default-executor-${mod} PROPERTY OSX_ARCHITECTURES "${arch}")
+
+    embedded_amend_archive_commands_on_darwin_host(embedded-concurrency-default-executor-${mod} ${triple})
+
     add_dependencies(embedded-concurrency embedded-concurrency-default-executor-${mod})
   endforeach()
 

--- a/stdlib/public/stubs/Unicode/CMakeLists.txt
+++ b/stdlib/public/stubs/Unicode/CMakeLists.txt
@@ -65,6 +65,8 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
       )
     set_property(TARGET embedded-unicode-${mod} PROPERTY OSX_ARCHITECTURES "${arch}")
 
+    embedded_amend_archive_commands_on_darwin_host(embedded-unicode-${mod} ${triple})
+
     add_dependencies(embedded-unicode embedded-unicode-${mod})
   endforeach()
 endif()


### PR DESCRIPTION
**Explanation**:
When building non Darwin triples for Embedded Swift stdlib:
* define explicitly some macros that the macOS SDK shipped as part of Xcode 26.4 does not provide anymore 
* use `llvm-ar` to create static archives -- the `ar` from Xcode 26.4 would create empty archive instead

 **Scope**:
CMake targets for Embedded Swift stdlib building under macOS for elf, eabi and wasm triple

 **Issues**:
https://github.com/swiftlang/swift/issues/87327
rdar://172219475

**Original PRs**:
#87433
#87627

**Risk**:
Low
* these fixes are targeted for builds happening under macOS
* at worst we will keep having build issues for the same targets only for macOS, which could be worked around by disabling the build of the Embedded Swift stdlib

**Testing**:
* build Embedded Stdlib at desk using Xcode 26.4 Beta 2 and checked that elf, eabi and wasm archives are not empy
* CI testing (including toolchain generation) to ensure we are not regressing existing configurations

**Reviewers**:
@etcwilde 