### PR TITLE
Implement SIL generation for coroutine functions and function types

### DIFF
--- a/include/swift/SIL/AbstractionPattern.h
+++ b/include/swift/SIL/AbstractionPattern.h
@@ -1574,6 +1574,15 @@ public:
   /// a substituted error type.
   CanType getEffectiveThrownErrorType() const;
 
+  /// Given that the value being abstracted is a function, return the
+  /// abstraction pattern for its yield type.
+  AbstractionPattern getFunctionYieldType(unsigned index) const;
+
+  /// Given that the value being abstracted is a function type, and that
+  /// this is not an opaque abstraction pattern, return the yield flags
+  /// for one of its yields.
+  YieldTypeFlags getFunctionYieldFlags(unsigned index) const;
+
   /// Given that the value being abstracted is a function type, return
   /// the abstraction pattern for one of its parameter types.
   AbstractionPattern getFunctionParamType(unsigned index) const;

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4726,7 +4726,7 @@ void PrintAST::visitFuncDecl(FuncDecl *decl) {
       SWIFT_DEFER {
         Printer.printStructurePost(PrintStructureKind::CoroutineYieldsTypes);
       };
-      Printer << " " << tok::kw_yield << " (";
+      Printer << " yields (";
 
       for (auto [idx, yield] : llvm::enumerate(yields)) {
         if (idx > 0)
@@ -4746,6 +4746,7 @@ void PrintAST::visitFuncDecl(FuncDecl *decl) {
 
         printTypeLoc(TheTypeLoc, getNonRecursiveOptions(decl));
       }
+      Printer << ")";
     }
 
     Type ResultTy = decl->getResultInterfaceType();

--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -1557,6 +1557,31 @@ unsigned AbstractionPattern::getFlattenedValueCount() const {
 }
 
 AbstractionPattern
+AbstractionPattern::getFunctionYieldType(unsigned index) const {
+  switch (getKind()) {
+  case Kind::Opaque:
+    return *this;
+  case Kind::Type: {
+    if (isTypeParameterOrOpaqueArchetype())
+      return getOpaque();
+
+    auto yieldType =
+        cast<AnyFunctionType>(getType()).getYields()[index].getType();
+    return AbstractionPattern(getGenericSubstitutions(),
+                              getGenericSignatureForFunctionComponent(),
+                              yieldType->getCanonicalType());
+  }
+  case Kind::OpaqueFunction:
+  case Kind::OpaqueDerivativeFunction:
+    return getOpaque();
+  default:
+    llvm_unreachable("does not have function yields");
+  }
+
+  llvm_unreachable("bad kind");
+}
+
+AbstractionPattern
 AbstractionPattern::getFunctionParamType(unsigned index) const {
   switch (getKind()) {
   case Kind::Opaque:
@@ -1709,6 +1734,10 @@ ParameterTypeFlags
 AbstractionPattern::getFunctionParamFlags(unsigned index) const {
   return cast<AnyFunctionType>(getType()).getParams()[index]
            .getParameterFlags();
+}
+
+YieldTypeFlags AbstractionPattern::getFunctionYieldFlags(unsigned index) const {
+  return cast<AnyFunctionType>(getType()).getYields()[index].getFlags();
 }
 
 bool

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -2799,7 +2799,10 @@ static CanSILFunctionType getSILFunctionType(
 
     // Coroutines are always native, so fetch the native abstraction pattern.
     auto sig = origFd->getGenericSignatureOfContext().getCanonicalSignature();
-    auto origYieldType = origFd->getYieldsInterfaceType();
+    const auto *origYL = origFd->getYields();
+    assert(origYL->size() == 1 && "only support a single yield type");
+    
+    auto origYieldType = origYL->front().getInterfaceType(origFd);
     if (auto inoutTy = origYieldType->getAs<InOutType>()) {
       isInOutYield = true;
       origYieldType = inoutTy->getObjectType();
@@ -2807,7 +2810,7 @@ static CanSILFunctionType getSILFunctionType(
     auto reducedYieldType = sig.getReducedType(origYieldType);
     coroutineOrigYieldType = AbstractionPattern(sig, reducedYieldType);
 
-    Type valueType = fd->getYieldsInterfaceType();
+    Type valueType = fd->getYields()->front().getInterfaceType(fd);
     if (isInOutYield)
       valueType = valueType->castTo<InOutType>()->getObjectType();
 
@@ -2821,7 +2824,25 @@ static CanSILFunctionType getSILFunctionType(
     }
   } else if (substFnInterfaceType
                  ->isCoroutine()) { // Derive yield type for function type
-    assert(0 && "Does not support coroutine function types yet");
+    coroutineKind = SILCoroutineKind::YieldOnce;
+    assert(substFnInterfaceType->getYields().size() == 1 &&
+           "only support a single yield type");
+
+    auto sig = origType.hasGenericSignature() ? origType.getGenericSignature()
+                                              : genericSig;
+    auto origYieldType = origType.getFunctionYieldType(0);
+    auto reducedYieldType = sig.getReducedType(origYieldType.getType());
+    coroutineOrigYieldType = AbstractionPattern(sig, reducedYieldType);
+
+    auto yieldType = substFnInterfaceType->getYields().front();
+    auto valueType = yieldType.getType();
+    isInOutYield = yieldType.isInOut();
+    assert(isInOutYield == origType.getFunctionYieldFlags(0).isInOut());
+
+    if (reqtSubs)
+      valueType = valueType.subst(*reqtSubs);
+
+    coroutineSubstYieldType = valueType->getReducedType(genericSig);
   }
 
   bool shouldBuildSubstFunctionType = [&]{

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -2590,16 +2590,15 @@ lowerCaptureContextParameters(TypeConverter &TC, SILDeclRef function,
          "iterating over loweredCaptures.getCaptures().");
 }
 
-static AccessorDecl *
-getAsCoroutineAccessor(std::optional<SILDeclRef> constant) {
+static FuncDecl *getAsCoroutine(std::optional<SILDeclRef> constant) {
   if (!constant || !constant->hasDecl())
     return nullptr;;
 
-  auto accessor = dyn_cast<AccessorDecl>(constant->getDecl());
-  if (!accessor || !accessor->isCoroutine())
+  auto fd = dyn_cast<FuncDecl>(constant->getDecl());
+  if (!fd || !fd->isCoroutine())
     return nullptr;
 
-  return accessor;
+  return fd;
 }
 
 static void destructureYieldsForReadAccessor(TypeConverter &TC,
@@ -2636,19 +2635,13 @@ static void destructureYieldsForReadAccessor(TypeConverter &TC,
                                 convention));
 }
 
-static void destructureYieldsForCoroutine(TypeConverter &TC,
-                                          TypeExpansionContext expansion,
-                                          std::optional<SILDeclRef> constant,
-                                          AbstractionPattern origType,
-                                          CanType canValueType,
-                                          SmallVectorImpl<SILYieldInfo> &yields,
-                                          SILCoroutineKind &coroutineKind) {
-  auto accessor = getAsCoroutineAccessor(constant);
-  if (!accessor)
-    return;
-
+static void
+destructureYieldsForCoroutine(TypeConverter &TC, TypeExpansionContext expansion,
+                              AbstractionPattern origType, CanType canValueType,
+                              bool isInOutYield,
+                              SmallVectorImpl<SILYieldInfo> &yields) {
   // 'modify' yields an inout of the target type.
-  if (isYieldingMutableAccessor(accessor->getAccessorKind())) {
+  if (isInOutYield) {
     auto loweredValueTy =
         TC.getLoweredType(origType, canValueType, expansion);
     yields.push_back(SILYieldInfo(loweredValueTy.getASTType(),
@@ -2656,7 +2649,6 @@ static void destructureYieldsForCoroutine(TypeConverter &TC,
   } else {
     // 'read' yields a borrowed value of the target type, destructuring
     // tuples as necessary.
-    assert(isYieldingImmutableAccessor(accessor->getAccessorKind()));
     destructureYieldsForReadAccessor(TC, expansion, origType, canValueType,
                                      yields);
   }
@@ -2784,38 +2776,52 @@ static CanSILFunctionType getSILFunctionType(
 
   bool hasSendingResult = substFnInterfaceType->getExtInfo().hasSendingResult();
 
-  // Get the yield type for an accessor coroutine.
+  // Get the yield type for coroutine.
   SILCoroutineKind coroutineKind = SILCoroutineKind::None;
   AbstractionPattern coroutineOrigYieldType = AbstractionPattern::getInvalid();
   CanType coroutineSubstYieldType;
-  
-  if (auto accessor = getAsCoroutineAccessor(constant)) {
-    auto origAccessor = cast<AccessorDecl>(origConstant->getDecl());
-    auto &ctx = origAccessor->getASTContext();
-    coroutineKind =
-        (requiresFeatureCoroutineAccessors(accessor->getAccessorKind()) &&
-         ctx.SILOpts.CoroutineAccessorsUseYieldOnce2)
-            ? SILCoroutineKind::YieldOnce2
-            : SILCoroutineKind::YieldOnce;
 
-    // Coroutine accessors are always native, so fetch the native
-    // abstraction pattern.
-    auto origStorage = origAccessor->getStorage();
-    coroutineOrigYieldType = TC.getAbstractionPattern(origStorage,
-                                                      /*nonobjc*/ true)
-                               .getReferenceStorageReferentType();
+  bool isInOutYield = false;
+  if (auto fd = getAsCoroutine(constant)) { // Derive yield type for declaration
+    auto origFd = cast<FuncDecl>(origConstant->getDecl());
+    auto &ctx = origFd->getASTContext();
+    if (auto accessor = dyn_cast<AccessorDecl>(origFd)) {
+      coroutineKind =
+          (requiresFeatureCoroutineAccessors(accessor->getAccessorKind()) &&
+           ctx.SILOpts.CoroutineAccessorsUseYieldOnce2)
+              ? SILCoroutineKind::YieldOnce2
+              : SILCoroutineKind::YieldOnce;
+    } else {
+      // FIXME: Decide we'd directly go to YieldOnce2 for non-accessor
+      // coroutines
+      coroutineKind = SILCoroutineKind::YieldOnce;
+    }
 
-    auto storage = accessor->getStorage();
-    auto valueType = storage->getValueInterfaceType();
+    // Coroutines are always native, so fetch the native abstraction pattern.
+    auto sig = origFd->getGenericSignatureOfContext().getCanonicalSignature();
+    auto origYieldType = origFd->getYieldsInterfaceType();
+    if (auto inoutTy = origYieldType->getAs<InOutType>()) {
+      isInOutYield = true;
+      origYieldType = inoutTy->getObjectType();
+    }
+    auto reducedYieldType = sig.getReducedType(origYieldType);
+    coroutineOrigYieldType = AbstractionPattern(sig, reducedYieldType);
+
+    Type valueType = fd->getYieldsInterfaceType();
+    if (isInOutYield)
+      valueType = valueType->castTo<InOutType>()->getObjectType();
 
     if (reqtSubs) {
       valueType = valueType.subst(*reqtSubs);
       coroutineSubstYieldType = valueType->getReducedType(
           genericSig);
     } else {
-      coroutineSubstYieldType = valueType->getReducedType(
-          accessor->getGenericSignature());
+      coroutineSubstYieldType =
+          valueType->getReducedType(fd->getGenericSignature());
     }
+  } else if (substFnInterfaceType
+                 ->isCoroutine()) { // Derive yield type for function type
+    assert(0 && "Does not support coroutine function types yet");
   }
 
   bool shouldBuildSubstFunctionType = [&]{
@@ -2839,7 +2845,7 @@ static CanSILFunctionType getSILFunctionType(
     // for class override thunks.  This is required to make the yields
     // match in abstraction to the base method's yields, which is necessary
     // to make the extracted continuation-function signatures match.
-    if (constant != origConstant && getAsCoroutineAccessor(constant))
+    if (constant != origConstant && getAsCoroutine(constant))
       return true;
 
     // We don't currently use substituted function types for generic function
@@ -2955,9 +2961,11 @@ static CanSILFunctionType getSILFunctionType(
 
   // Destructure the coroutine yields.
   SmallVector<SILYieldInfo, 8> yields;
-  destructureYieldsForCoroutine(TC, expansionContext, constant,
-                                coroutineOrigYieldType, coroutineSubstYieldType,
-                                yields, coroutineKind);
+  if (coroutineKind != SILCoroutineKind::None) {
+    destructureYieldsForCoroutine(TC, expansionContext, coroutineOrigYieldType,
+                                  coroutineSubstYieldType, isInOutYield,
+                                  yields);
+  }
 
   // Destructure the result tuple type.
   SmallVector<SILResultInfo, 8> results;

--- a/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
+++ b/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
@@ -625,6 +625,7 @@ void MemoryLifetimeVerifier::checkFunction(BitDataflow &dataFlow) {
   // Collect the bits which we require to be set at function exits.
   Bits expectedReturnBits(locations.getNumLocations());
   Bits expectedThrowBits(locations.getNumLocations());
+  Bits expectedUnwindBits(locations.getNumLocations());
   for (SILArgument *arg : function->getArguments()) {
     SILFunctionArgument *funcArg = cast<SILFunctionArgument>(arg);
     switch (funcArg->getArgumentConvention()) {
@@ -632,6 +633,7 @@ void MemoryLifetimeVerifier::checkFunction(BitDataflow &dataFlow) {
     case SILArgumentConvention::Indirect_In_Guaranteed:
       locations.setBits(expectedReturnBits, funcArg);
       locations.setBits(expectedThrowBits, funcArg);
+      locations.setBits(expectedUnwindBits, funcArg);
       break;
     case SILArgumentConvention::Indirect_Out:
       if (funcArg->isIndirectErrorResult()) {
@@ -670,24 +672,30 @@ void MemoryLifetimeVerifier::checkFunction(BitDataflow &dataFlow) {
     TermInst *term = bs.block.getTerminator();
     assert(bits == bs.data.exitSet || isa<TryApplyInst>(term));
     switch (term->getKind()) {
-      case SILInstructionKind::ReturnInst:
-      case SILInstructionKind::UnwindInst:
-        require(expectedReturnBits & ~bs.data.exitSet,
-          "indirect argument is not alive at function return", term);
-        require(bs.data.exitSet & ~expectedReturnBits & nonTrivialLocations,
-                "memory is initialized at function return but shouldn't be",
-                term,
-                /*excludeTrivialEnums*/ true);
-        break;
-      case SILInstructionKind::ThrowInst:
-        require(expectedThrowBits & ~bs.data.exitSet,
-          "indirect argument is not alive at throw", term);
-        require(bs.data.exitSet & ~expectedThrowBits & nonTrivialLocations,
-                "memory is initialized at throw but shouldn't be", term,
-                /*excludeTrivialEnums*/ true);
-        break;
-      default:
-        break;
+    case SILInstructionKind::ReturnInst:
+      require(expectedReturnBits & ~bs.data.exitSet,
+              "indirect argument is not alive at function return", term);
+      require(bs.data.exitSet & ~expectedReturnBits & nonTrivialLocations,
+              "memory is initialized at function return but shouldn't be", term,
+              /*excludeTrivialEnums*/ true);
+      break;
+    case SILInstructionKind::UnwindInst:
+      require(expectedUnwindBits & ~bs.data.exitSet,
+              "indirect argument is not alive at coroutine return", term);
+      require(bs.data.exitSet & ~expectedUnwindBits & nonTrivialLocations,
+              "memory is initialized at coroutine return but shouldn't be",
+              term,
+              /*excludeTrivialEnums*/ true);
+      break;
+    case SILInstructionKind::ThrowInst:
+      require(expectedThrowBits & ~bs.data.exitSet,
+              "indirect argument is not alive at throw", term);
+      require(bs.data.exitSet & ~expectedThrowBits & nonTrivialLocations,
+              "memory is initialized at throw but shouldn't be", term,
+              /*excludeTrivialEnums*/ true);
+      break;
+    default:
+      break;
     }
   }
 }

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -5390,6 +5390,7 @@ public:
     if (forUnwind && CanUnwind) {
       SGF.B.createAbortApply(l, ApplyToken);
     } else {
+      // TODO: This is not correct when coroutine has a normal result
       SGF.B.createEndApply(l, ApplyToken,
                            SILType::getEmptyTupleType(SGF.getASTContext()));
     }
@@ -6577,17 +6578,17 @@ SILGenFunction::emitBeginApplyWithRethrow(SILLocation loc, SILValue fn,
   return {token, abortCleanup, allocation, deallocCleanup};
 }
 
-void SILGenFunction::emitEndApplyWithRethrow(
+SILValue SILGenFunction::emitEndApplyWithRethrow(
     SILLocation loc, MultipleValueInstructionResult *token,
-    SILValue allocation) {
+    SILValue allocation, SILType resultType) {
   // TODO: adjust this to handle results of TryBeginApplyInst.
   assert(token->isBeginApplyToken());
 
-  B.createEndApply(loc, token,
-                   SILType::getEmptyTupleType(getASTContext()));
+  SILValue result = B.createEndApply(loc, token, resultType);
   if (allocation) {
     B.createDeallocStack(loc, allocation);
   }
+  return result;
 }
 
 void SILGenFunction::emitYield(SILLocation loc,

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -2420,9 +2420,10 @@ public:
                             bool canUnwind, SubstitutionMap subs,
                             ArrayRef<SILValue> args,
                             SmallVectorImpl<SILValue> &yields);
-  void emitEndApplyWithRethrow(SILLocation loc,
-                               MultipleValueInstructionResult *token,
-                               SILValue allocation);
+  SILValue emitEndApplyWithRethrow(SILLocation loc,
+                                   MultipleValueInstructionResult *token,
+                                   SILValue allocation,
+                                   SILType resultType);
 
   ManagedValue emitExtractFunctionIsolation(SILLocation loc,
                                         ArgumentSource &&fnValue);

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -7285,9 +7285,8 @@ SILGenFunction::emitVTableThunk(SILDeclRef base,
     }
 
     // End the inner coroutine normally.
-    emitEndApplyWithRethrow(loc, token, allocation);
-
-    result = B.createTuple(loc, {});
+    result = emitEndApplyWithRethrow(loc, token, allocation,
+                                     SILType::getEmptyTupleType(getASTContext()));
     break;
   }
 
@@ -7785,9 +7784,8 @@ void SILGenFunction::emitProtocolWitness(
     }
 
     // End the inner coroutine normally.
-    emitEndApplyWithRethrow(loc, token, allocation);
-
-    reqtResultValue = B.createTuple(loc, {});
+    reqtResultValue = emitEndApplyWithRethrow(loc, token, allocation,
+                                             SILType::getEmptyTupleType(getASTContext()));
     break;
   }
 

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -2855,6 +2855,14 @@ public:
       return translateSILBuiltin(bi);
     }
 
+    if (auto *eai = dyn_cast<EndApplyInst>(inst)) {
+      // FIXME: This might not be not entirely correct.
+      auto *bai = eai->getBeginApply();
+      return translateSILMultiAssign(
+          eai->getResults(), ArrayRef<Operand *>(),
+          makeOperandRefRange(bai->getAllOperands()), {});
+    }
+
     auto fas = FullApplySite::isa(inst);
     assert(bool(fas) && "Builtins should be handled above");
 
@@ -3863,7 +3871,6 @@ CONSTANT_TRANSLATION(EndUnpairedAccessInst, Ignored)
 CONSTANT_TRANSLATION(HopToExecutorInst, Ignored)
 CONSTANT_TRANSLATION(InjectEnumAddrInst, Ignored)
 CONSTANT_TRANSLATION(DestroyNotEscapedClosureInst, Ignored)
-CONSTANT_TRANSLATION(EndApplyInst, Ignored)
 CONSTANT_TRANSLATION(AbortApplyInst, Ignored)
 CONSTANT_TRANSLATION(DebugStepInst, Ignored)
 CONSTANT_TRANSLATION(IncrementProfilerCounterInst, Ignored)
@@ -3985,6 +3992,7 @@ CONSTANT_TRANSLATION(ApplyInst, Apply)
 CONSTANT_TRANSLATION(BeginApplyInst, Apply)
 CONSTANT_TRANSLATION(BuiltinInst, Apply)
 CONSTANT_TRANSLATION(TryApplyInst, Apply)
+CONSTANT_TRANSLATION(EndApplyInst, Apply)
 
 //===---
 // Asserting

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -296,11 +296,23 @@ public:
       for (auto calleeYield : BeginApply->getYieldedValues()) {
         calleeYield->replaceAllUsesWith(SILUndef::get(calleeYield));
       }
+
+      if (EndApply)
+        EndApply->replaceAllUsesWith(SILUndef::get(EndApply));
     }
 
     // Remove the resumption sites.
-    if (EndApply)
+    if (EndApply) {
+      // All potential users of end_apply should've been replaced above. The
+      // only case where we might end with more users is when end_apply itself
+      // is unreachable. Make sure the function is well-formed and replace the
+      // results with undef.
+      if (!EndApply->use_empty())
+        EndApply->replaceAllUsesWith(SILUndef::get(EndApply));
+
       EndApply->eraseFromParent();
+    }
+
     if (AbortApply)
       AbortApply->eraseFromParent();
 

--- a/test/Concurrency/transfernonsendable_partitionop_translation.sil
+++ b/test/Concurrency/transfernonsendable_partitionop_translation.sil
@@ -2310,14 +2310,19 @@ bb0:
 // CHECK-LABEL: begin running test {{.*}} on test_end_apply: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
 // CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
 // CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: // function_ref coro_callee
+// CHECK-NEXT:       %1 = function_ref @coro_callee : $@yield_once @convention(thin) (@guaranteed NonSendableKlass) -> @yields @inout NonSendableKlass
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: %4 = end_apply %3 as $()
+// CHECK-NEXT: require %%0: %4 = end_apply %3 as $()
 // CHECK-NEXT: end running test {{.*}} on test_end_apply: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
 sil [ossa] @test_end_apply : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
 bb0(%0 : @guaranteed $NonSendableKlass):
   %f = function_ref @coro_callee : $@yield_once @convention(thin) (@guaranteed NonSendableKlass) -> @yields @inout NonSendableKlass
   (%1, %token) = begin_apply %f(%0) : $@yield_once @convention(thin) (@guaranteed NonSendableKlass) -> @yields @inout NonSendableKlass
-  end_apply %token as $()
+  %r = end_apply %token as $()
   specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
-  %r = tuple ()
   return %r : $()
 }
 

--- a/test/SILGen/coroutines.swift
+++ b/test/SILGen/coroutines.swift
@@ -1,0 +1,97 @@
+// RUN: %target-swift-emit-silgen -module-name coro %s -enable-experimental-feature CoroutineFunctions | %FileCheck %s
+
+// REQUIRES: swift_feature_CoroutineFunctions
+
+// CHECK: @yield_once func coro(_ x: inout Float) yields (inout Float)
+// CHECK: func retCoro() -> @yield_once (inout Float) yields (inout Float) -> ()
+// CHECK: @yield_once func coroWithResult(_ x: Float) yields (inout Float) -> Float
+// CHECK: func retCoroWithResult() -> @yield_once (Float) yields (inout Float) -> Float
+// CHECK: @yield_once func coroGen<T>(_ x: inout T) yields (inout T)
+// CHECK: func retGenCoro<T>() -> @yield_once (inout T) yields (inout T) -> ()
+// CHECK: @yield_once func coroGenWithResult<T>(_ x: T) yields (inout T) -> T
+// CHECK: func retCoroGenWithResult<T>() -> @yield_once (T) yields (inout T) -> T
+
+// CHECK-LABEL: sil hidden [ossa] @$s4coroAAyySfzXySfzF : $@yield_once @convention(thin) (@inout Float) -> @yields @inout Float {
+@yield_once func coro(_ x : inout Float) yields (inout Float) -> () {
+  var _x = Float(0.0)
+  yield &_x
+  x = Float(_x)
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s4coro7retCoroySfzXySfzcyF : $@convention(thin) () -> @owned @yield_once @callee_guaranteed (@inout Float) -> @yields @inout Float {
+func retCoro() -> @yield_once (inout Float) yields (inout Float) -> () {
+  return coro
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s4coro0A10WithResultyS2fzXySfF : $@yield_once @convention(thin) (Float) -> (@yields @inout Float, Float) {
+@yield_once func coroWithResult(_ x : Float) yields (inout Float) -> Float {
+  var _x = Float(0.0)
+  yield &_x
+  return _x
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s4coro17retCoroWithResultS2fzXySfcyF : $@convention(thin) () -> @owned @yield_once @callee_guaranteed (Float) -> (@yields @inout Float, Float) {
+func retCoroWithResult() -> @yield_once (Float) yields (inout Float) -> Float {
+  return coroWithResult
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s4coro0A3GenyyxzXyxzlF : $@yield_once @convention(thin) <T> (@inout T) -> @yields @inout T {
+@yield_once func coroGen<T>(_ x : inout T) yields (inout T) -> () {
+  var _x = x
+  yield &_x
+  x = _x
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s4coro10retGenCoroyxzXyxzcylF : $@convention(thin) <T> () -> @owned @yield_once @callee_guaranteed @substituted <τ_0_0, τ_0_1> (@inout τ_0_0) -> @yields @inout τ_0_1 for <T, T> {
+func retGenCoro<T>() -> @yield_once (inout T) yields (inout T) -> () {
+  return coroGen
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s4coro0A13GenWithResultyxxzXyxlF : $@yield_once @convention(thin) <T> (@in_guaranteed T) -> (@yields @inout T, @out T) {
+@yield_once func coroGenWithResult<T>(_ x : T) yields (inout T) -> T {
+  var _x = x
+  yield &_x
+  return _x
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s4coro20retCoroGenWithResultxxzXyxcylF : $@convention(thin) <T> () -> @owned @yield_once @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@yields @inout τ_0_1, @out τ_0_2) for <T, T, T> {
+func retCoroGenWithResult<T>() -> @yield_once (T) yields (inout T) -> T {
+  return coroGenWithResult
+}
+
+// Real-world case: yield a value and return a pullback closure (coroutine itself)
+struct S {
+  private var _x : Float
+
+  var x: Float {
+    get{_x}
+    _modify { yield &_x }
+  }
+}
+
+extension S {
+  struct TangentVector : AdditiveArithmetic {
+    @_hasStorage var _x: Float
+    typealias TangentVector = S.TangentVector
+    static func + (lhs: S.TangentVector, rhs: S.TangentVector) -> S.TangentVector { fatalError() }
+    static func - (lhs: S.TangentVector, rhs: S.TangentVector) -> S.TangentVector { fatalError() }    
+    static var zero: S.TangentVector = TangentVector(_x : 0)
+  }
+
+  // CHECK-LABEL: sil hidden [ossa] @$s4coro1SV9vjpModifyySfzXyAC13TangentVectorVzcSfzXyyF : $@yield_once @convention(method) (@inout S) -> (@yields @inout Float, @owned @yield_once @callee_guaranteed (@inout S.TangentVector) -> @yields @inout Float) {
+  @yield_once
+  mutating func vjpModify() yields (inout Float) -> @yield_once (inout S.TangentVector) yields (inout Float) -> () {
+    yield &x
+
+    @yield_once func pb(_ x : inout S.TangentVector) yields (inout Float) -> () {
+      var _x = Float(0.0)
+      yield &_x
+      x = S.TangentVector(_x : _x)
+    }
+
+    // CHECK: %[[PB:.*]] = function_ref @$s4coro1SV9vjpModifyySfzXyAC13TangentVectorVzcSfzXyyF2pbL_yySfzXyAFzF : $@yield_once @convention(thin) (@inout S.TangentVector) -> @yields @inout Float
+    // CHECK: %[[FNCONV:.*]] = thin_to_thick_function %[[PB]] to $@yield_once @callee_guaranteed (@inout S.TangentVector) -> @yields @inout Float
+    // CHECK: return %[[FNCONV]]
+    return pb
+  }
+}

--- a/test/SILGen/modify.swift
+++ b/test/SILGen/modify.swift
@@ -80,8 +80,7 @@ extension Derived : Abstractable {}
 // CHECK-NEXT: [[T1:%.*]] = partial_apply [callee_guaranteed] [[REABSTRACTOR]]([[CVT_FN]])
 // CHECK-NEXT: store [[T1]] to [init] [[SUPER_ADDR]]
 // CHECK-NEXT: dealloc_stack [[SUB_ADDR]]
-// CHECK-NEXT: end_apply [[TOKEN]]
-// CHECK-NEXT: tuple ()
+// CHECK-NEXT: end_apply [[TOKEN]] as $()
 // CHECK-NEXT: end_borrow [[T0]]
 // CHECK-NEXT: return
 
@@ -108,8 +107,7 @@ extension Derived : Abstractable {}
 // CHECK-NEXT: [[T1:%.*]] = partial_apply [callee_guaranteed] [[REABSTRACTOR]]([[CVT_FN]])
 // CHECK-NEXT: store [[T1]] to [init] [[SUPER_ADDR]]
 // CHECK-NEXT: dealloc_stack [[SUB_ADDR]]
-// CHECK-NEXT: end_apply [[TOKEN]]
-// CHECK-NEXT: tuple ()
+// CHECK-NEXT: end_apply [[TOKEN]] as $()
 // CHECK-NEXT: end_borrow [[T0]]
 // CHECK-NEXT: return
 
@@ -135,8 +133,7 @@ extension Derived : Abstractable {}
 // CHECK-NEXT: [[T1:%.*]] = partial_apply [callee_guaranteed] [[REABSTRACTOR]]([[CVT_FN]])
 // CHECK-NEXT: store [[T1]] to [init] [[SUPER_ADDR]]
 // CHECK-NEXT: dealloc_stack [[SUB_ADDR]]
-// CHECK-NEXT: end_apply [[TOKEN]]
-// CHECK-NEXT: tuple ()
+// CHECK-NEXT: end_apply [[TOKEN]] as $()
 // CHECK-NEXT: return
 
 protocol ClassAbstractable : class {
@@ -298,8 +295,7 @@ struct Bill : Totalled {
 // CHECK-NEXT:     ([[T1:%.*]], [[TOKEN:%.*]]) = begin_apply [[T0]]([[SELF]])
 // CHECK-NEXT:     yield [[T1]] : $*Int, resume bb1, unwind bb2
 // CHECK:        bb1:
-// CHECK-NEXT:     end_apply [[TOKEN]]
-// CHECK-NEXT:     [[T1:%.*]] = tuple ()
+// CHECK-NEXT:     [[T1:%.*]] = end_apply [[TOKEN]] as $()
 // CHECK-NEXT:     return [[T1]] :
 
 protocol AddressOnlySubscript {

--- a/test/SILGen/witnesses.swift
+++ b/test/SILGen/witnesses.swift
@@ -464,8 +464,7 @@ class PropertyRequirementWitnessFromBase : PropertyRequirementBase, PropertyRequ
   // CHECK-NEXT: [[METH:%.*]] = class_method [[CAST_ARG2_LOADED]] : $PropertyRequirementBase, #PropertyRequirementBase.width!modify
   // CHECK-NEXT: ([[RES:%.*]], [[TOKEN:%.*]]) = begin_apply [[METH]]([[CAST_ARG2_LOADED]]) : $@yield_once @convention(method) (@guaranteed PropertyRequirementBase) -> @yields @inout Int
   // CHECK-NEXT: yield [[RES]]
-  // CHECK:      end_apply [[TOKEN]]
-  // CHECK-NEXT: [[TUPLE:%.*]] = tuple ()
+  // CHECK:      [[TUPLE:%.*]] = end_apply [[TOKEN]] as $()
   // CHECK-NEXT: end_borrow [[ARG2_LOADED]]
   // CHECK-NEXT: return [[TUPLE]]
 
@@ -474,8 +473,7 @@ class PropertyRequirementWitnessFromBase : PropertyRequirementBase, PropertyRequ
   // CHECK: [[METH:%.*]] = function_ref @$s9witnesses23PropertyRequirementBaseC6heightSivMZ
   // CHECK-NEXT: ([[RES:%.*]], [[TOKEN:%.*]]) = begin_apply [[METH]]
   // CHECK-NEXT: yield [[RES]]
-  // CHECK:      end_apply [[TOKEN]]
-  // CHECK-NEXT: [[TUPLE:%.*]] = tuple ()
+  // CHECK:      [[TUPLE:%.*]] = end_apply [[TOKEN]] as $()
   // CHECK-NEXT: return [[TUPLE]]
 
  // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s9witnesses34PropertyRequirementWitnessFromBaseCAA0bC0A2aDP5depthSivMTW
@@ -484,8 +482,7 @@ class PropertyRequirementWitnessFromBase : PropertyRequirementBase, PropertyRequ
   // CHECK: [[METH:%.*]] = class_method [[ARG2_LOADED]] : $PropertyRequirementWitnessFromBase, #PropertyRequirementWitnessFromBase.depth!modify
   // CHECK-NEXT: ([[RES:%.*]], [[TOKEN:%.*]]) = begin_apply [[METH]]([[ARG2_LOADED]]) : $@yield_once @convention(method) (@guaranteed PropertyRequirementWitnessFromBase) -> @yields @inout Int
   // CHECK-NEXT: yield [[RES]]
-  // CHECK:      end_apply [[TOKEN]]
-  // CHECK-NEXT: [[TUPLE:%.*]] = tuple ()
+  // CHECK:      [[TUPLE:%.*]] = end_apply [[TOKEN]] as $()
   // CHECK-NEXT: end_borrow [[ARG2_LOADED]]
   // CHECK-NEXT: return [[TUPLE]]
 }

--- a/test/SILOptimizer/access_marker_verify.swift
+++ b/test/SILOptimizer/access_marker_verify.swift
@@ -791,8 +791,7 @@ class C : Abstractable {
 // CHECK-NEXT:   [[THUNKED_NEW_FN:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]([[NEW_FN_CONV]])
 // CHECK-NEXT:   store [[THUNKED_NEW_FN]] to [init] [[ADDR]] :
 // CHECK-NEXT:   dealloc_stack [[TEMP]]
-// CHECK-NEXT:   end_apply [[TOKEN]]
-// CHECK-NEXT:   [[TUPLE:%.*]] = tuple ()
+// CHECK-NEXT:   [[TUPLE:%.*]] = end_apply [[TOKEN]] as $()
 // CHECK-NEXT:   end_borrow [[SELF]] : $C
 // CHECK-NEXT:   return [[TUPLE]]
 


### PR DESCRIPTION
This is a stacked PR (following https://github.com/swiftlang/swift/pull/85372) including SILGen changes for coroutines and coroutine function types. Coroutine accessors use common coroutine silgen path, they are not special-cased anymore