### PR TITLE
Update features.json and add `debug-info-explicit-dependency`

### DIFF
--- a/lib/Option/features.json
+++ b/lib/Option/features.json
@@ -56,6 +56,9 @@
     },
     {
        "name": "api-digester-Xcc"
+    },
+    {
+       "name": "debug-info-explicit-dependency"
     }
   ]
 }


### PR DESCRIPTION
The new feature added will use new mechanism to pass module
    dependencies in the debug info when explicit module build is used. This
    allows tools like lldb to load explicit module directly, with the need
    to embed all swift modules into dSYM or linked product.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
