### PR TITLE
Revert "Concurrency: Remove superfluous SwiftStdlib 6.3 availability checks"

### DIFF
--- a/stdlib/public/Concurrency/ContinuousClock.swift
+++ b/stdlib/public/Concurrency/ContinuousClock.swift
@@ -113,9 +113,13 @@ extension ContinuousClock: Clock {
   public func sleep(
     until deadline: Instant, tolerance: Swift.Duration? = nil
   ) async throws {
-    try await Task._sleep(until: deadline,
-                          tolerance: tolerance,
-                          clock: self)
+    if #available(StdlibDeploymentTarget 6.3, *) {
+      try await Task._sleep(until: deadline,
+                            tolerance: tolerance,
+                            clock: self)
+    } else {
+      fatalError("we should never get here; if we have, availability is broken")
+    }
   }
 #else
   @available(StdlibDeploymentTarget 5.7, *)

--- a/stdlib/public/Concurrency/ExecutorImpl.swift
+++ b/stdlib/public/Concurrency/ExecutorImpl.swift
@@ -24,8 +24,12 @@ import Swift
 @_silgen_name("swift_task_asyncMainDrainQueueImpl")
 internal func drainMainQueue() {
   #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
-  try! MainActor.executor.run()
-  _exit(result: 0)
+  if #available(StdlibDeploymentTarget 6.3, *) {
+    try! MainActor.executor.run()
+    _exit(result: 0)
+  } else {
+    fatalError("this should never happen")
+  }
   #else
   fatalError("swift_task_asyncMainDrainQueue() not supported with task-to-thread")
   #endif
@@ -37,24 +41,36 @@ internal func donateToGlobalExecutor(
   condition: @convention(c) (_ ctx: UnsafeMutableRawPointer) -> CBool,
   context: UnsafeMutableRawPointer
 ) {
-  if let runnableExecutor = Task.defaultExecutor as? RunLoopExecutor {
-    try! runnableExecutor.runUntil { unsafe Bool(condition(context)) }
+  if #available(StdlibDeploymentTarget 6.3, *) {
+    if let runnableExecutor = Task.defaultExecutor as? RunLoopExecutor {
+      try! runnableExecutor.runUntil { unsafe Bool(condition(context)) }
+    } else {
+      fatalError("Global executor does not support thread donation")
+    }
   } else {
-    fatalError("Global executor does not support thread donation")
+    fatalError("this should never happen")
   }
 }
 
 @available(SwiftStdlib 6.2, *)
 @_silgen_name("swift_task_getMainExecutorImpl")
 internal func getMainExecutor() -> UnownedSerialExecutor {
-  return unsafe _getMainExecutorAsSerialExecutor()
+  if #available(StdlibDeploymentTarget 6.3, *) {
+    return unsafe _getMainExecutorAsSerialExecutor()
+  } else {
+    fatalError("this should never happen")
+  }
 }
 
 @available(SwiftStdlib 6.2, *)
 @_silgen_name("swift_task_enqueueMainExecutorImpl")
 internal func enqueueOnMainExecutor(job unownedJob: UnownedJob) {
   #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
-  MainActor.executor.enqueue(unownedJob)
+  if #available(StdlibDeploymentTarget 6.3, *) {
+    MainActor.executor.enqueue(unownedJob)
+  } else {
+    fatalError("this should never happen")
+  }
   #else
   fatalError("swift_task_enqueueMainExecutor() not supported for task-to-thread")
   #endif
@@ -63,7 +79,11 @@ internal func enqueueOnMainExecutor(job unownedJob: UnownedJob) {
 @available(SwiftStdlib 6.2, *)
 @_silgen_name("swift_task_enqueueGlobalImpl")
 internal func enqueueOnGlobalExecutor(job unownedJob: UnownedJob) {
-  Task.defaultExecutor.enqueue(unownedJob)
+  if #available(StdlibDeploymentTarget 6.3, *) {
+    Task.defaultExecutor.enqueue(unownedJob)
+  } else {
+    fatalError("this should never happen")
+  }
 }
 
 #if !$Embedded
@@ -72,9 +92,13 @@ internal func enqueueOnGlobalExecutor(job unownedJob: UnownedJob) {
 internal func enqueueOnGlobalExecutor(delay: CUnsignedLongLong,
                                       job unownedJob: UnownedJob) {
   #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
-  Task.defaultExecutor.asSchedulingExecutor!.enqueue(ExecutorJob(unownedJob),
-                                                     after: .nanoseconds(delay),
-                                                     clock: .continuous)
+  if #available(StdlibDeploymentTarget 6.3, *) {
+    Task.defaultExecutor.asSchedulingExecutor!.enqueue(ExecutorJob(unownedJob),
+                                                       after: .nanoseconds(delay),
+                                                       clock: .continuous)
+  } else {
+    fatalError("this should never happen")
+  }
   #else
   fatalError("swift_task_enqueueGlobalWithDelay() not supported for task-to-thread")
   #endif
@@ -91,23 +115,27 @@ internal func enqueueOnGlobalExecutor(seconds: CLongLong,
   #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
   let delay = Duration.seconds(seconds) + Duration.nanoseconds(nanoseconds)
   let leeway = Duration.seconds(leewaySeconds) + Duration.nanoseconds(leewayNanoseconds)
-  switch clock {
-    case _ClockID.suspending.rawValue:
-      Task.defaultExecutor.asSchedulingExecutor!.enqueue(
-        ExecutorJob(unownedJob),
-        after: delay,
-        tolerance: leeway,
-        clock: .suspending
-      )
-    case _ClockID.continuous.rawValue:
-      Task.defaultExecutor.asSchedulingExecutor!.enqueue(
-        ExecutorJob(unownedJob),
-        after: delay,
-        tolerance: leeway,
-        clock: .continuous
-      )
-    default:
-      fatalError("Unknown clock ID \(clock)")
+  if #available(StdlibDeploymentTarget 6.3, *) {
+    switch clock {
+      case _ClockID.suspending.rawValue:
+        Task.defaultExecutor.asSchedulingExecutor!.enqueue(
+          ExecutorJob(unownedJob),
+          after: delay,
+          tolerance: leeway,
+          clock: .suspending
+        )
+      case _ClockID.continuous.rawValue:
+        Task.defaultExecutor.asSchedulingExecutor!.enqueue(
+          ExecutorJob(unownedJob),
+          after: delay,
+          tolerance: leeway,
+          clock: .continuous
+        )
+      default:
+        fatalError("Unknown clock ID \(clock)")
+    }
+  } else {
+    fatalError("this should never happen")
   }
   #else
   fatalError("swift_task_enqueueGlobalWithDeadline() not supported for task-to-thread")

--- a/stdlib/public/Concurrency/GlobalConcurrentExecutor.swift
+++ b/stdlib/public/Concurrency/GlobalConcurrentExecutor.swift
@@ -34,7 +34,11 @@ import Swift
 @_unavailableInEmbedded
 public var globalConcurrentExecutor: any TaskExecutor {
   get {
-    Task.defaultExecutor
+    if #available(StdlibDeploymentTarget 6.3, *) {
+      return Task.defaultExecutor
+    } else {
+      fatalError("we shouldn't get here; if we have, availability is broken")
+    }
   }
 }
 

--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -87,7 +87,13 @@ public struct UnownedJob: Sendable {
   /// The priority of this job.
   @available(StdlibDeploymentTarget 5.9, *)
   public var priority: JobPriority {
-    JobPriority(rawValue: _jobGetPriority(context))
+    let raw: UInt8
+    if #available(StdlibDeploymentTarget 6.3, *) {
+      raw = _jobGetPriority(context)
+    } else {
+      fatalError("we shouldn't get here; if we have, availability is broken")
+    }
+    return JobPriority(rawValue: raw)
   }
 
   @available(StdlibDeploymentTarget 5.9, *)
@@ -220,7 +226,13 @@ public struct Job: Sendable, ~Copyable {
   }
 
   public var priority: JobPriority {
-    return JobPriority(rawValue: _jobGetPriority(self.context))
+    let raw: UInt8
+    if #available(StdlibDeploymentTarget 6.3, *) {
+      raw = _jobGetPriority(self.context)
+    } else {
+      fatalError("we shouldn't get here; if we have, availability is broken")
+    }
+    return JobPriority(rawValue: raw)
   }
 
   // TODO: move only types cannot conform to protocols, so we can't conform to CustomStringConvertible;
@@ -288,10 +300,20 @@ public struct ExecutorJob: Sendable, ~Copyable {
 
   internal(set) public var priority: JobPriority {
     get {
-      JobPriority(rawValue: _jobGetPriority(self.context))
+      let raw: UInt8
+      if #available(StdlibDeploymentTarget 6.3, *) {
+        raw = _jobGetPriority(self.context)
+      } else {
+        fatalError("we shouldn't get here; if we have, availability is broken")
+      }
+      return JobPriority(rawValue: raw)
     }
     set {
-      _jobSetPriority(self.context, newValue.rawValue)
+      if #available(StdlibDeploymentTarget 6.3, *) {
+        _jobSetPriority(self.context, newValue.rawValue)
+      } else {
+        fatalError("we shouldn't get here; if we have, availability is broken")
+      }
     }
   }
 

--- a/stdlib/public/Concurrency/SuspendingClock.swift
+++ b/stdlib/public/Concurrency/SuspendingClock.swift
@@ -101,9 +101,13 @@ extension SuspendingClock: Clock {
   public func sleep(
     until deadline: Instant, tolerance: Swift.Duration? = nil
   ) async throws {
-    try await Task._sleep(until: deadline,
-                          tolerance: tolerance,
-                          clock: self)
+    if #available(StdlibDeploymentTarget 6.3, *) {
+      try await Task._sleep(until: deadline,
+                            tolerance: tolerance,
+                            clock: self)
+    } else {
+      fatalError("we shouldn't get here; if we have, availability is broken")
+    }
   }
 #else
   @available(StdlibDeploymentTarget 5.7, *)

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -658,9 +658,13 @@ extension Task where Success == Never, Failure == Never {
           continuation: continuation)
 
       #if !$Embedded && !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
-      let executor = Task.currentExecutor
+      if #available(StdlibDeploymentTarget 6.3, *) {
+        let executor = Task.currentExecutor
 
-      executor.enqueue(ExecutorJob(context: job))
+        executor.enqueue(ExecutorJob(context: job))
+      } else {
+        fatalError("we shouldn't get here; if we have, availability is broken")
+      }
       #else
       _enqueueJobGlobal(job)
       #endif
@@ -988,7 +992,11 @@ internal func _runAsyncMain(_ asyncFun: @Sendable @escaping () async throws -> (
   }
 
   let job = Builtin.convertTaskToJob(theTask)
-  MainActor.executor.enqueue(ExecutorJob(context: job))
+  if #available(StdlibDeploymentTarget 6.3, *) {
+    MainActor.executor.enqueue(ExecutorJob(context: job))
+  } else {
+    fatalError("we shouldn't get here; if we have, availability is broken")
+  }
 
   _asyncMainDrainQueue()
 }

--- a/stdlib/public/Concurrency/TaskSleep.swift
+++ b/stdlib/public/Concurrency/TaskSleep.swift
@@ -28,14 +28,16 @@ extension Task where Success == Never, Failure == Never {
           priority: Int(Task.currentPriority.rawValue),
           continuation: continuation)
 
-      #if !$Embedded
-      if let executor = Task.currentSchedulingExecutor {
-        executor.enqueue(ExecutorJob(context: job),
-                         after: .nanoseconds(duration),
-                         clock: .continuous)
-        return
+      if #available(StdlibDeploymentTarget 6.3, *) {
+        #if !$Embedded
+        if let executor = Task.currentSchedulingExecutor {
+          executor.enqueue(ExecutorJob(context: job),
+                           after: .nanoseconds(duration),
+                           clock: .continuous)
+          return
+        }
+        #endif
       }
-      #endif
 
       // If there is no current scheduling executor, fall back to
       // _enqueueJobGlobalWithDelay()
@@ -270,14 +272,16 @@ extension Task where Success == Never, Failure == Never {
 
               let job = Builtin.convertTaskToJob(sleepTask)
 
-              #if !$Embedded
-              if let executor = Task.currentSchedulingExecutor {
-                executor.enqueue(ExecutorJob(context: job),
-                                 after: .nanoseconds(duration),
-                                 clock: .continuous)
-                return
+              if #available(StdlibDeploymentTarget 6.3, *) {
+                #if !$Embedded
+                if let executor = Task.currentSchedulingExecutor {
+                  executor.enqueue(ExecutorJob(context: job),
+                                   after: .nanoseconds(duration),
+                                   clock: .continuous)
+                  return
+                }
+                #endif
               }
-              #endif
 
               // If there is no current scheduling executor, fall back to
               // _enqueueJobGlobalWithDelay()

--- a/stdlib/public/Concurrency/TaskSleepDuration.swift
+++ b/stdlib/public/Concurrency/TaskSleepDuration.swift
@@ -116,15 +116,19 @@ extension Task where Success == Never, Failure == Never {
 
               let job = Builtin.convertTaskToJob(sleepTask)
 
-              #if !$Embedded
-              if let executor = Task.currentSchedulingExecutor {
-                executor.enqueue(ExecutorJob(context: job),
-                                 at: instant,
-                                 tolerance: tolerance,
-                                 clock: clock)
-                return
+              if #available(StdlibDeploymentTarget 6.3, *) {
+                #if !$Embedded
+                if let executor = Task.currentSchedulingExecutor {
+                  executor.enqueue(ExecutorJob(context: job),
+                                   at: instant,
+                                   tolerance: tolerance,
+                                   clock: clock)
+                  return
+                }
+                #endif
+              } else {
+                fatalError("we shouldn't get here; if we have, availability is broken")
               }
-              #endif
 
               // If there is no current scheduling executor, fall back to
               // calling _enqueueJobGlobalWithDeadline().
@@ -132,18 +136,26 @@ extension Task where Success == Never, Failure == Never {
                                                               clock: clock)
               let toleranceSeconds: Int64
               let toleranceNanoseconds: Int64
-              if let tolerance = tolerance {
-                (toleranceSeconds, toleranceNanoseconds)
-                  = durationComponents(for: tolerance, clock: clock)
+              if #available(StdlibDeploymentTarget 6.3, *) {
+                if let tolerance = tolerance {
+                  (toleranceSeconds, toleranceNanoseconds)
+                    = durationComponents(for: tolerance, clock: clock)
+                } else {
+                  toleranceSeconds = 0
+                  toleranceNanoseconds = -1
+                }
               } else {
-                toleranceSeconds = 0
-                toleranceNanoseconds = -1
+                fatalError("we shouldn't get here; if we have, availability is broken")
               }
 
-              _enqueueJobGlobalWithDeadline(
-                seconds, nanoseconds,
-                toleranceSeconds, toleranceNanoseconds,
-                clockID.rawValue, UnownedJob(context: job))
+              if #available(StdlibDeploymentTarget 5.9, *) {
+                _enqueueJobGlobalWithDeadline(
+                  seconds, nanoseconds,
+                  toleranceSeconds, toleranceNanoseconds,
+                  clockID.rawValue, UnownedJob(context: job))
+              } else {
+                fatalError("we shouldn't get here; if we have, availability is broken")
+              }
               return
 
             case .activeContinuation, .finished:


### PR DESCRIPTION
This reverts commit 074fceca283af600fc76581cc7ce93d9834cd3a6.

Resolves rdar://172222846.