### PR TITLE
Fix MergeCondFails pass to handle different failure messages correctly

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/MergeCondFails.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/MergeCondFails.swift
@@ -44,7 +44,10 @@ private func runMergeCondFails(function: Function, context: FunctionPassContext)
 
         // Do not process arithmetic overflow checks. We typically generate more
         // efficient code with separate jump-on-overflow.
-        if !hasOverflowConditionOperand(cfi) && (messageIsSame || forceAllowMerge) {
+        if !hasOverflowConditionOperand(cfi) {
+          if !messageIsSame && !forceAllowMerge {
+            mergeCondFails(&condFailToMerge, context: context)
+          }
           condFailToMerge.push(cfi)
         }
       } else if inst.mayHaveSideEffects || inst.mayReadFromMemory {

--- a/test/SILOptimizer/inlinearray_bounds_check_tests.swift
+++ b/test/SILOptimizer/inlinearray_bounds_check_tests.swift
@@ -204,7 +204,6 @@ public func inlinearray_element_sum<let N: Int>(_ v: InlineArray<N, Int>, _ i: I
 // CHECK-SIL-LABEL: sil @$s30inlinearray_bounds_check_tests0A7_searchySiSgs11InlineArrayVyq_xG_xtSiRV_SQRzr0_lF :
 // CHECK-SIL: bb3:
 // CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
-// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: cond_br
 // CHECK-SIL-LABEL: } // end sil function '$s30inlinearray_bounds_check_tests0A7_searchySiSgs11InlineArrayVyq_xG_xtSiRV_SQRzr0_lF'
 public func inlinearray_search<T : Equatable, let N: Int>(_ v: InlineArray<N, T>, _ elem: T) -> Int? {
@@ -220,7 +219,6 @@ public func inlinearray_search<T : Equatable, let N: Int>(_ v: InlineArray<N, T>
 
 // CHECK-SIL-LABEL: sil @$s30inlinearray_bounds_check_tests0A11_search_splySiSgs11InlineArrayVyxSiG_SitSiRVzlF :
 // CHECK-SIL: bb3:
-// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: cond_br
 // CHECK-SIL-LABEL: } // end sil function '$s30inlinearray_bounds_check_tests0A11_search_splySiSgs11InlineArrayVyxSiG_SitSiRVzlF'

--- a/test/SILOptimizer/merge_cond_fail.sil
+++ b/test/SILOptimizer/merge_cond_fail.sil
@@ -80,3 +80,20 @@ bb0 (%0 : $Builtin.Int1, %1 : $Builtin.Int1, %2 : $Builtin.Int1, %3: $Builtin.In
   cond_fail %10 : $Builtin.Int1, "message5"
   return %9 : $Builtin.Int64
 }
+
+// CHECK: sil @merge_cond_fail_different_messages : $@convention(thin) (Builtin.Int1, Builtin.Int1, Builtin.Int1, Builtin.Int1) -> () {
+// CHECK:  [[TMP1:%.*]] = builtin "or_Int1"(%1, %2) : $Builtin.Int1
+// CHECK:  [[TMP2:%.*]] = builtin "or_Int1"([[TMP1]], %3) : $Builtin.Int1
+// CHECK:   cond_fail [[TMP2]], "Index out of bounds"
+// CHECK-NOT: cond_fail {{.*}}, "Index out of bounds"
+// CHECK: } // end sil function 'merge_cond_fail_different_messages'
+sil @merge_cond_fail_different_messages : $@convention(thin) (Builtin.Int1, Builtin.Int1, Builtin.Int1, Builtin.Int1) -> () {
+bb0 (%0 : $Builtin.Int1, %1 : $Builtin.Int1, %2 : $Builtin.Int1, %3: $Builtin.Int1):
+  cond_fail %0 : $Builtin.Int1, "precondition failure"
+  cond_fail %1 : $Builtin.Int1, "Index out of bounds"
+  cond_fail %2 : $Builtin.Int1, "Index out of bounds"
+  cond_fail %3 : $Builtin.Int1, "Index out of bounds"
+  %t = tuple ()
+  return %t
+}
+

--- a/test/SILOptimizer/span_bounds_check_tests.swift
+++ b/test/SILOptimizer/span_bounds_check_tests.swift
@@ -56,7 +56,6 @@ public func span_sum_iterate_to_count_with_trap(_ v: Span<Int>) -> Int {
 // CHECK-SIL-LABEL: sil @$s23span_bounds_check_tests0A31_sum_iterate_to_unknown_wo_trapySis4SpanVySiG_SitF :
 // CHECK-SIL: bb1
 // CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
-// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: bb3
 // CHECK-SIL-NOT: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: cond_br
@@ -77,7 +76,6 @@ public func span_sum_iterate_to_unknown_wo_trap(_ v: Span<Int>, _ n: Int) -> Int
 
 // CHECK-SIL-LABEL: sil @$s23span_bounds_check_tests0A33_sum_iterate_to_unknown_with_trapySis4SpanVySiG_SitF :
 // CHECK-SIL: bb1
-// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: bb3
 // CHECK-SIL-NOT: cond_fail {{.*}}, "Index out of bounds"
@@ -117,7 +115,6 @@ public func span_sum_iterate_to_deducible_count1_wo_trap(_ v: Span<Int>, _ n: In
 // CHECK-SIL-LABEL: sil @$s23span_bounds_check_tests0A42_sum_iterate_to_deducible_count1_with_trapySis4SpanVySiG_SitF :
 // CHECK-SIL: bb1
 // CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
-// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: bb3
 // CHECK-SIL-NOT: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: cond_br
@@ -136,7 +133,6 @@ public func span_sum_iterate_to_deducible_count1_with_trap(_ v: Span<Int>, _ n: 
 
 // CHECK-SIL-LABEL: sil @$s23span_bounds_check_tests0A40_sum_iterate_to_deducible_count2_wo_trapySis4SpanVySiG_SitF :
 // CHECK-SIL: bb1
-// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: bb3
 // CHECK-SIL-NOT: cond_fail {{.*}}, "Index out of bounds"
@@ -159,7 +155,6 @@ public func span_sum_iterate_to_deducible_count2_wo_trap(_ v: Span<Int>, _ n: In
 
 // CHECK-SIL-LABEL: sil @$s23span_bounds_check_tests0A42_sum_iterate_to_deducible_count2_with_trapySis4SpanVySiG_SitF :
 // CHECK-SIL: bb1
-// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: bb3
 // CHECK-SIL-NOT: cond_fail {{.*}}, "Index out of bounds"
@@ -232,7 +227,6 @@ public func span_element_sum(_ v: Span<Int>, _ i: Int) -> Int {
 // CHECK-SIL-LABEL: sil @$s23span_bounds_check_tests0A7_searchySiSgs4SpanVyxG_xtSQRzlF :
 // CHECK-SIL: bb3:
 // CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
-// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: cond_br
 // CHECK-SIL-LABEL: } // end sil function '$s23span_bounds_check_tests0A7_searchySiSgs4SpanVyxG_xtSQRzlF'
 public func span_search<T : Equatable>(_ v: Span<T>, _ elem: T) -> Int? {
@@ -292,7 +286,6 @@ public struct Wrapper<Int> : ~Escapable {
 // CHECK-SIL-LABEL: sil @$s23span_bounds_check_tests0A41_wrapper_sum_iterate_to_unknown_with_trapySiAA7WrapperVySiG_SitF :
 // CHECK-SIL: bb1
 // CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
-// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: bb3
 // CHECK-SIL-NOT: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: cond_br
@@ -311,7 +304,6 @@ public func span_wrapper_sum_iterate_to_unknown_with_trap(_ w: Wrapper<Int>, _ n
 public func mutate_span(_ v: inout Span<Int>) { }
 // CHECK-SIL-LABEL: sil @$s23span_bounds_check_tests06inout_A33_sum_iterate_to_unknown_with_trapySis4SpanVySiGz_SitF :
 // CHECK-SIL: bb1
-// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: bb3
 // CHECK-SIL-NOT: cond_fail {{.*}}, "Index out of bounds"


### PR DESCRIPTION
On encountering a cond_fail with differing message, merge the accumulated cond_fail instructions and begin new merge set.

Partially resolves rdar://164947648

