### PR TITLE
[AST] Ensure `Type` diagnostic args are not solver allocated

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -1410,6 +1410,11 @@ public:
   /// Otherwise, it returns the type itself.
   Type getReferenceStorageReferent();
 
+  /// Replace all type variables and placeholders in the type with ErrorType.
+  /// This is necessary in a small number of cases where we need to ensure that
+  /// a type isn't solver allocated, for e.g diagnostic printing.
+  Type replaceTypeVariablesAndPlaceholdersWithErrors();
+
   /// Assumes this is a nominal type. Returns a substitution map that sends each
   /// generic parameter of the declaration's generic signature to the corresponding
   /// generic argument of this nominal type.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3689,37 +3689,12 @@ void LocatableType::Profile(llvm::FoldingSetNodeID &id, SourceLoc loc,
 // Simple accessors.
 Type ErrorType::get(const ASTContext &C) { return C.TheErrorType; }
 
-static Type replacingTypeVariablesAndPlaceholders(Type ty) {
-  if (!ty || !ty->hasTypeVariableOrPlaceholder())
-    return ty;
-
-  struct Transform : public TypeTransform<Transform> {
-    Transform(ASTContext &ctx) : TypeTransform(ctx) {}
-
-    std::optional<Type> transform(TypeBase *ty, TypePosition) {
-      if (!ty->hasTypeVariableOrPlaceholder())
-        return ty;
-
-      if (isa<TypeVariableType>(ty) || isa<PlaceholderType>(ty))
-        return ErrorType::get(ctx);
-
-      return std::nullopt;
-    }
-    std::pair<Type, /*sendable*/ bool> transformSendableDependentType(Type ty) {
-      // Fold away the sendable dependence if present, the function type will
-      // just become non-Sendable.
-      return std::make_pair(Type(), false);
-    }
-  };
-  return Transform(ty->getASTContext()).doIt(ty, TypePosition::Invariant);
-}
-
 Type ErrorType::get(Type originalType) {
   // The original type is only used for printing/debugging, and we don't support
   // solver-allocated ErrorTypes. As such, fold any type variables and
   // placeholders into ErrorTypes. If we have a top-level one, we can return
   // that directly.
-  originalType = replacingTypeVariablesAndPlaceholders(originalType);
+  originalType = originalType->replaceTypeVariablesAndPlaceholdersWithErrors();
   if (isa<ErrorType>(originalType.getPointer()))
     return originalType;
 

--- a/lib/AST/DiagnosticArgument.cpp
+++ b/lib/AST/DiagnosticArgument.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/AST/DiagnosticArgument.h"
+#include "swift/AST/Types.h"
 #include "swift/Basic/Assertions.h"
 
 using namespace swift;
@@ -43,7 +44,16 @@ DiagnosticArgument::DiagnosticArgument(const Decl *VD)
     : Kind(DiagnosticArgumentKind::Decl), TheDecl(VD) {}
 
 DiagnosticArgument::DiagnosticArgument(Type T)
-    : Kind(DiagnosticArgumentKind::Type), TypeVal(T) {}
+    : Kind(DiagnosticArgumentKind::Type), TypeVal(T) {
+  // Make sure we fold away any potentially solver-allocated types since this
+  // diagnostic may be captured by a DiagnosticTransaction and escape the solver
+  // arena. Ideally we'd assert that we never get solver-allocated types here,
+  // but unfortunately type resolution can end up passing types with type
+  // variables to diagnostics and we can't realistically handle every one of
+  // those. We'll just print the type variable as '_' instead.
+  if (TypeVal)
+    TypeVal = TypeVal->replaceTypeVariablesAndPlaceholdersWithErrors();
+}
 
 DiagnosticArgument::DiagnosticArgument(TypeRepr *T)
     : Kind(DiagnosticArgumentKind::TypeRepr), TyR(T) {}

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1472,6 +1472,31 @@ Type TypeBase::withCovariantResultType() {
                            fnType->getExtInfo());
 }
 
+Type TypeBase::replaceTypeVariablesAndPlaceholdersWithErrors() {
+  if (!hasTypeVariableOrPlaceholder())
+    return Type(this);
+
+  struct Transform : public TypeTransform<Transform> {
+    Transform(ASTContext &ctx) : TypeTransform(ctx) {}
+
+    std::optional<Type> transform(TypeBase *ty, TypePosition) {
+      if (!ty->hasTypeVariableOrPlaceholder())
+        return ty;
+
+      if (isa<TypeVariableType>(ty) || isa<PlaceholderType>(ty))
+        return ErrorType::get(ctx);
+
+      return std::nullopt;
+    }
+    std::pair<Type, /*sendable*/ bool> transformSendableDependentType(Type ty) {
+      // Fold away the sendable dependence if present, the function type will
+      // just become non-Sendable.
+      return std::make_pair(Type(), false);
+    }
+  };
+  return Transform(getASTContext()).doIt(this, TypePosition::Invariant);
+}
+
 /// Whether this parameter accepts an unlabeled trailing closure argument
 /// using the more-restrictive forward-scan rule.
 static bool allowsUnlabeledTrailingClosureParameter(const ParamDecl *param) {

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6256,8 +6256,8 @@ bool ExtraneousArgumentsFailure::diagnoseAsNote() {
                      (numArgs == 1));
   } else {
     emitDiagnosticAt(decl, diag::candidate_with_extraneous_args,
-                     overload->adjustedOpenedType, numArgs, ContextualType,
-                     ContextualType->getNumParams());
+                     resolveType(overload->adjustedOpenedType), numArgs,
+                     ContextualType, ContextualType->getNumParams());
   }
   return true;
 }

--- a/validation-test/compiler_crashers_fixed/TypeBase-computeCanonicalType-3c6a4c.swift
+++ b/validation-test/compiler_crashers_fixed/TypeBase-computeCanonicalType-3c6a4c.swift
@@ -1,0 +1,5 @@
+// {"kind":"typecheck","original":"e63729a4","signature":"swift::TypeBase::computeCanonicalType()","signatureAssert":"Assertion failed: (originalTy && \"The bare ErrorType singleton is already canonical\"), function computeCanonicalType"}
+// RUN: not %target-swift-frontend -typecheck %s
+func c<b >( d a b -> String = {
+"\($0)" func c( value : UInt64) {
+buffer += String(e : "" value) "\()"

--- a/validation-test/compiler_crashers_fixed/formatDiagnosticArgument-492c5c.swift
+++ b/validation-test/compiler_crashers_fixed/formatDiagnosticArgument-492c5c.swift
@@ -1,0 +1,8 @@
+// {"kind":"typecheck","original":"e63729a4","signature":"formatDiagnosticArgument(llvm::StringRef, llvm::StringRef, llvm::ArrayRef<swift::DiagnosticArgument>, unsigned int, swift::DiagnosticFormatOptions, llvm::raw_ostream&)"}
+// RUN: not %target-swift-frontend -typecheck %s
+func a<b>(
+  b  -> String = {
+    "\($0)"
+    func a(c: UInt64) {
+      String(d: ""
+      c


### PR DESCRIPTION
Replace any type variables or placeholders with ErrorType, which will just print as `_`.