### PR TITLE
SuppAssocTypes: add deprecation warning of legacy version

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8293,6 +8293,8 @@ ERROR(inverse_generic_but_also_conforms, none,
 ERROR(inverse_associatedtype_restriction, none,
       "cannot suppress '%0' requirement of an associated type",
       (StringRef))
+WARNING(legacy_suppressed_assoc_types, none,
+      "experimental feature 'SuppressedAssociatedTypes' is deprecated; see SE-0503 for the official version", ())
 ERROR(inverse_on_class, none,
       "%select{classes|actors}1 cannot be '~%0'",
       (StringRef, bool))

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2021,6 +2021,20 @@ static void diagnoseWrittenPlaceholderTypes(ASTContext &Ctx,
   }
 }
 
+static void checkDeprecatedSuppressedAssociatedTypes(ProtocolDecl *proto) {
+  auto &ctx = proto->getASTContext();
+
+  if (!ctx.LangOpts.hasFeature(SuppressedAssociatedTypes))
+    return;
+
+  for (auto req : proto->getInverseRequirements()) {
+    if (req.subject->getCanonicalType() == ctx.TheSelfType)
+      continue;
+
+    ctx.Diags.diagnose(req.loc, diag::legacy_suppressed_assoc_types);
+  }
+}
+
 /// Make sure that every protocol conformance requirement on 'Self' is
 /// directly stated in the protocol's inheritance clause.
 ///
@@ -3517,6 +3531,8 @@ public:
     // Copyable that will appear as if deserialized, so skip checking those.
     if (PD->getParentSourceFile())
       TypeChecker::checkConformancesInContext(PD);
+
+    checkDeprecatedSuppressedAssociatedTypes(PD);
   }
 
   void visitVarDecl(VarDecl *VD) {

--- a/test/Generics/inverse_conditional_conformance_restriction.swift
+++ b/test/Generics/inverse_conditional_conformance_restriction.swift
@@ -1,9 +1,9 @@
 // RUN: %target-typecheck-verify-swift \ 
 // RUN:   -enable-experimental-feature LifetimeDependence  \
-// RUN:   -enable-experimental-feature SuppressedAssociatedTypes
+// RUN:   -enable-experimental-feature SuppressedAssociatedTypesWithDefaults
 
 // REQUIRES: swift_feature_LifetimeDependence
-// REQUIRES: swift_feature_SuppressedAssociatedTypes
+// REQUIRES: swift_feature_SuppressedAssociatedTypesWithDefaults
 
 protocol P {}
 protocol Q {}

--- a/test/Generics/inverse_extensions.swift
+++ b/test/Generics/inverse_extensions.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift \
-// RUN:   -enable-experimental-feature SuppressedAssociatedTypes
+// RUN:   -enable-experimental-feature SuppressedAssociatedTypesWithDefaults
 
-// REQUIRES: swift_feature_SuppressedAssociatedTypes
+// REQUIRES: swift_feature_SuppressedAssociatedTypesWithDefaults
 
 struct Turtle<T> {}
 extension Turtle where T: ~Copyable {} // expected-error {{'T' required to be 'Copyable' but is marked with '~Copyable'}}

--- a/test/Generics/inverse_generics.swift
+++ b/test/Generics/inverse_generics.swift
@@ -1,9 +1,9 @@
 // RUN: %target-typecheck-verify-swift \
 // RUN: -enable-experimental-feature Lifetimes \
-// RUN: -enable-experimental-feature SuppressedAssociatedTypes
+// RUN: -enable-experimental-feature SuppressedAssociatedTypesWithDefaults
 
 // REQUIRES: swift_feature_Lifetimes
-// REQUIRES: swift_feature_SuppressedAssociatedTypes
+// REQUIRES: swift_feature_SuppressedAssociatedTypesWithDefaults
 
 // expected-note@+1 {{'T' has '~Copyable' constraint preventing implicit 'Copyable' conformance}}
 struct AttemptImplicitConditionalConformance<T: ~Copyable>: ~Copyable {

--- a/test/Generics/inverse_scoping_assoc_types_old.swift
+++ b/test/Generics/inverse_scoping_assoc_types_old.swift
@@ -7,13 +7,13 @@ protocol NoCopyReq: ~Copyable {}
 protocol P {
   associatedtype AT where Self: ~Copyable // expected-error {{constraint with subject type of 'Self' is not supported; consider adding requirement to protocol inheritance clause instead}}
 
-  associatedtype Bob where Alice: NoCopyReq & ~Copyable
-  associatedtype Alice where Bob: ~Copyable
+  associatedtype Bob where Alice: NoCopyReq & ~Copyable // expected-warning {{experimental feature 'SuppressedAssociatedTypes' is deprecated}}
+  associatedtype Alice where Bob: ~Copyable // expected-warning {{experimental feature 'SuppressedAssociatedTypes' is deprecated}}
 }
 
 protocol Q<Primary>: ~Copyable {
-  associatedtype Primary: ~Copyable
-  associatedtype Secondary: ~Copyable
+  associatedtype Primary: ~Copyable // expected-warning {{experimental feature 'SuppressedAssociatedTypes' is deprecated}}
+  associatedtype Secondary: ~Copyable // expected-warning {{experimental feature 'SuppressedAssociatedTypes' is deprecated}}
 }
 
 extension Q {

--- a/test/Generics/inverse_signatures_assoc_types_old.swift
+++ b/test/Generics/inverse_signatures_assoc_types_old.swift
@@ -15,22 +15,22 @@ protocol P2_IC: ~Copyable { associatedtype A }
 
 // CHECK-LABEL: .P2_CI@
 // CHECK: Requirement signature: <Self where Self : Copyable, Self : Escapable, Self.[P2_CI]A : Escapable>
-protocol P2_CI { associatedtype A: ~Copyable }
+protocol P2_CI { associatedtype A: ~Copyable } // expected-warning {{experimental feature 'SuppressedAssociatedTypes' is deprecated}}
 
 // CHECK-LABEL: .P2_II@
 // CHECK: Requirement signature: <Self where Self : Escapable, Self.[P2_II]A : Escapable>
-protocol P2_II: ~Copyable { associatedtype A: ~Copyable }
+protocol P2_II: ~Copyable { associatedtype A: ~Copyable } // expected-warning {{experimental feature 'SuppressedAssociatedTypes' is deprecated}}
 
 // CHECK-LABEL: .P3@
 // CHECK: Requirement signature: <Self where Self.[P3]B : Copyable>
-protocol P3 where Self: (~Copyable & ~Escapable) { associatedtype B: ~Escapable }
+protocol P3 where Self: (~Copyable & ~Escapable) { associatedtype B: ~Escapable }  // expected-warning {{experimental feature 'SuppressedAssociatedTypes' is deprecated}}
 
 // CHECK-LABEL: .P4@
 // CHECK: Requirement signature: <Self where Self : Copyable, Self.[P4]B : Copyable, Self.[P4]C : Escapable>
 protocol P4<B, D>: ~Escapable {
-  associatedtype B: ~Escapable
-  associatedtype C: ~Copyable
-  associatedtype D: ~Escapable, ~Copyable
+  associatedtype B: ~Escapable  // expected-warning {{experimental feature 'SuppressedAssociatedTypes' is deprecated}}
+  associatedtype C: ~Copyable   // expected-warning {{experimental feature 'SuppressedAssociatedTypes' is deprecated}}
+  associatedtype D: ~Escapable, ~Copyable   // expected-warning 2{{experimental feature 'SuppressedAssociatedTypes' is deprecated}}
 }
 
 // CHECK-LABEL: .test3@

--- a/test/IRGen/existential_shape_metadata_noncopyable.swift
+++ b/test/IRGen/existential_shape_metadata_noncopyable.swift
@@ -1,10 +1,10 @@
 // RUN: %target-swift-frontend \
 // RUN:    -emit-ir %s -swift-version 5 \
 // RUN:   -disable-availability-checking \
-// RUN:     -enable-experimental-feature SuppressedAssociatedTypes \
+// RUN:     -enable-experimental-feature SuppressedAssociatedTypesWithDefaults \
 // RUN:   -module-name existential_shape_metadata | %IRGenFileCheck %s
 
-// REQUIRES: swift_feature_SuppressedAssociatedTypes
+// REQUIRES: swift_feature_SuppressedAssociatedTypesWithDefaults
 
 // NOTE: Once noncopyable generics are enabled by default, merge this back into existential_shape_metadata.swift
 

--- a/test/IRGen/mangling_inverse_generics_evolution.swift
+++ b/test/IRGen/mangling_inverse_generics_evolution.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-ir -o - %s -module-name test \
-// RUN:   -enable-experimental-feature SuppressedAssociatedTypes \
+// RUN:   -enable-experimental-feature SuppressedAssociatedTypesWithDefaults \
 // RUN:   -parse-as-library \
 // RUN:   -enable-library-evolution \
 // RUN:   -g \
@@ -8,7 +8,7 @@
 
 // RUN: %FileCheck %s < %t/test.irgen
 
-// REQUIRES: swift_feature_SuppressedAssociatedTypes
+// REQUIRES: swift_feature_SuppressedAssociatedTypesWithDefaults
 
 public protocol P: ~Copyable { }
 

--- a/test/IRGen/noncopyable_runtime_back_compat.swift
+++ b/test/IRGen/noncopyable_runtime_back_compat.swift
@@ -1,6 +1,6 @@
-// RUN: %target-run-simple-swift(-enable-experimental-feature SuppressedAssociatedTypes)
+// RUN: %target-run-simple-swift(-enable-experimental-feature SuppressedAssociatedTypesWithDefaults)
 // REQUIRES: executable_test
-// REQUIRES: swift_feature_SuppressedAssociatedTypes
+// REQUIRES: swift_feature_SuppressedAssociatedTypesWithDefaults
 
 // Noncopyable types are suppressed in field metadata in runtimes lacking
 // reflection support for them (currently all runtimes). However, we want

--- a/test/Interpreter/moveonly_generics_associatedtype.swift
+++ b/test/Interpreter/moveonly_generics_associatedtype.swift
@@ -1,9 +1,9 @@
-// RUN: %target-swift-emit-sil %s -DBAD_COPY -verify -sil-verify-all -enable-experimental-feature SuppressedAssociatedTypes
-// RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all -enable-experimental-feature SuppressedAssociatedTypes) | %FileCheck %s
-// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all -enable-experimental-feature SuppressedAssociatedTypes) | %FileCheck %s
+// RUN: %target-swift-emit-sil %s -DBAD_COPY -verify -sil-verify-all -enable-experimental-feature SuppressedAssociatedTypesWithDefaults
+// RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all -enable-experimental-feature SuppressedAssociatedTypesWithDefaults) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all -enable-experimental-feature SuppressedAssociatedTypesWithDefaults) | %FileCheck %s
 
 // REQUIRES: executable_test
-// REQUIRES: swift_feature_SuppressedAssociatedTypes
+// REQUIRES: swift_feature_SuppressedAssociatedTypesWithDefaults
 
 
 class Backend {

--- a/test/Interpreter/moveonly_generics_casting_assoctypes.swift
+++ b/test/Interpreter/moveonly_generics_casting_assoctypes.swift
@@ -1,8 +1,8 @@
-// RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all -enable-experimental-feature SuppressedAssociatedTypes)
-// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all -enable-experimental-feature SuppressedAssociatedTypes)
+// RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all -enable-experimental-feature SuppressedAssociatedTypesWithDefaults)
+// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all -enable-experimental-feature SuppressedAssociatedTypesWithDefaults)
 
 // REQUIRES: executable_test
-// REQUIRES: swift_feature_SuppressedAssociatedTypes
+// REQUIRES: swift_feature_SuppressedAssociatedTypesWithDefaults
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime

--- a/test/Interpreter/moveonly_swiftskell.swift
+++ b/test/Interpreter/moveonly_swiftskell.swift
@@ -7,7 +7,7 @@
 // RUN:    -enable-library-evolution \
 // RUN:    -parse-as-library \
 // RUN:    %S/../Inputs/Swiftskell.swift \
-// RUN:   -enable-experimental-feature SuppressedAssociatedTypes 
+// RUN:   -enable-experimental-feature SuppressedAssociatedTypesWithDefaults
 
 // RUN: %target-build-swift -I%t -L%t -lSwiftskell -parse-as-library %s \
 // RUN:                     -module-name E -o %t/E %target-rpath(%t)
@@ -22,7 +22,7 @@
 // RUN: %target-run %t/Opt %t/%target-library-name(Swiftskell) | %FileCheck %s --implicit-check-not destroy
 
 // REQUIRES: executable_test
-// REQUIRES: swift_feature_SuppressedAssociatedTypes
+// REQUIRES: swift_feature_SuppressedAssociatedTypesWithDefaults
 
 // Temporarily disable for back-deployment (rdar://128544927)
 // UNSUPPORTED: back_deployment_runtime

--- a/test/ModuleInterface/noncopyable_generics.swift
+++ b/test/ModuleInterface/noncopyable_generics.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution -emit-module \
-// RUN:     -enable-experimental-feature SuppressedAssociatedTypes \
+// RUN:     -enable-experimental-feature SuppressedAssociatedTypesWithDefaults \
 // RUN:     -enable-experimental-feature LifetimeDependence \
 // RUN:     -enable-experimental-feature SE427NoInferenceOnExtension \
 // RUN:     -o %t/NoncopyableGenerics_Misc.swiftmodule \
@@ -9,7 +9,7 @@
 // RUN:     %S/Inputs/NoncopyableGenerics_Misc.swift
 
 // RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution -emit-module \
-// RUN:     -enable-experimental-feature SuppressedAssociatedTypes \
+// RUN:     -enable-experimental-feature SuppressedAssociatedTypesWithDefaults \
 // RUN:     -enable-experimental-feature LifetimeDependence \
 // RUN:     -enable-experimental-feature SE427NoInferenceOnExtension \
 // RUN:     -o %t/Swiftskell.swiftmodule \
@@ -24,19 +24,19 @@
 // See if we can compile a module through just the interface and typecheck using it.
 
 // RUN: %target-swift-frontend -compile-module-from-interface \
-// RUN:     -enable-experimental-feature SuppressedAssociatedTypes \
+// RUN:     -enable-experimental-feature SuppressedAssociatedTypesWithDefaults \
 // RUN:     -enable-experimental-feature LifetimeDependence \
 // RUN:     -enable-experimental-feature SE427NoInferenceOnExtension \
 // RUN:    %t/NoncopyableGenerics_Misc.swiftinterface -o %t/NoncopyableGenerics_Misc.swiftmodule
 
 // RUN: %target-swift-frontend -compile-module-from-interface \
-// RUN:     -enable-experimental-feature SuppressedAssociatedTypes \
+// RUN:     -enable-experimental-feature SuppressedAssociatedTypesWithDefaults \
 // RUN:     -enable-experimental-feature LifetimeDependence \
 // RUN:     -enable-experimental-feature SE427NoInferenceOnExtension \
 // RUN:    %t/Swiftskell.swiftinterface -o %t/Swiftskell.swiftmodule
 
 // RUN: %target-swift-frontend -emit-silgen -I %t %s \
-// RUN:     -enable-experimental-feature SuppressedAssociatedTypes \
+// RUN:     -enable-experimental-feature SuppressedAssociatedTypesWithDefaults \
 // RUN:    -enable-experimental-feature LifetimeDependence \
 // RUN:     -enable-experimental-feature SE427NoInferenceOnExtension \
 // RUN:    -o %t/final.silgen
@@ -45,7 +45,7 @@
 
 // REQUIRES: swift_feature_LifetimeDependence
 // REQUIRES: swift_feature_SE427NoInferenceOnExtension
-// REQUIRES: swift_feature_SuppressedAssociatedTypes
+// REQUIRES: swift_feature_SuppressedAssociatedTypesWithDefaults
 
 
 

--- a/test/Parse/inverses.swift
+++ b/test/Parse/inverses.swift
@@ -1,6 +1,6 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature SuppressedAssociatedTypes -solver-enable-optimize-operator-defaults
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature SuppressedAssociatedTypesWithDefaults -solver-enable-optimize-operator-defaults
 
-// REQUIRES: swift_feature_SuppressedAssociatedTypes
+// REQUIRES: swift_feature_SuppressedAssociatedTypesWithDefaults
 
 protocol U {}
 

--- a/test/SIL/lifetime_dependence_generics.swift
+++ b/test/SIL/lifetime_dependence_generics.swift
@@ -1,11 +1,11 @@
 // RUN: %target-swift-frontend %s -emit-sil \
 // RUN:   -enable-experimental-feature Lifetimes \
-// RUN:   -enable-experimental-feature SuppressedAssociatedTypes \
+// RUN:   -enable-experimental-feature SuppressedAssociatedTypesWithDefaults \
 // RUN: | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_Lifetimes
-// REQUIRES: swift_feature_SuppressedAssociatedTypes
+// REQUIRES: swift_feature_SuppressedAssociatedTypesWithDefaults
 
 protocol P {
   associatedtype E: ~Escapable

--- a/test/SILGen/borrow_accessor_synthesis.swift
+++ b/test/SILGen/borrow_accessor_synthesis.swift
@@ -1,7 +1,7 @@
-// RUN:%target-swift-frontend -emit-silgen %s -enable-experimental-feature BorrowAndMutateAccessors -enable-experimental-feature SuppressedAssociatedTypes -enable-library-evolution | %FileCheck %s
+// RUN:%target-swift-frontend -emit-silgen %s -enable-experimental-feature BorrowAndMutateAccessors -enable-experimental-feature SuppressedAssociatedTypesWithDefaults -enable-library-evolution | %FileCheck %s
 
 // REQUIRES: swift_feature_BorrowAndMutateAccessors
-// REQUIRES: swift_feature_SuppressedAssociatedTypes
+// REQUIRES: swift_feature_SuppressedAssociatedTypesWithDefaults
 
 public protocol P {
   associatedtype Element

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_generic.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_generic.swift
@@ -3,12 +3,12 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -enable-experimental-feature Lifetimes \
-// RUN:   -enable-experimental-feature SuppressedAssociatedTypes \
+// RUN:   -enable-experimental-feature SuppressedAssociatedTypesWithDefaults \
 // RUN:   -parse-stdlib -module-name Swift
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_Lifetimes
-// REQUIRES: swift_feature_SuppressedAssociatedTypes
+// REQUIRES: swift_feature_SuppressedAssociatedTypesWithDefaults
 
 @_marker public protocol Escapable {}
 

--- a/test/Sema/lifetime_depend_infer.swift
+++ b/test/Sema/lifetime_depend_infer.swift
@@ -1,9 +1,9 @@
 // RUN: %target-typecheck-verify-swift \
 // RUN:   -enable-experimental-feature Lifetimes \
-// RUN:   -enable-experimental-feature SuppressedAssociatedTypes
+// RUN:   -enable-experimental-feature SuppressedAssociatedTypesWithDefaults
 
 // REQUIRES: swift_feature_Lifetimes
-// REQUIRES: swift_feature_SuppressedAssociatedTypes
+// REQUIRES: swift_feature_SuppressedAssociatedTypesWithDefaults
 
 // Coverage testing for LifetimeDependence inferrence logic. The tests are sorted and grouped according to
 // docs/ReferenceGuides/LifetimeAnnotation.md. To find the cases that cover the default lifetime

--- a/test/Sema/lifetime_depend_infer_defaults.swift
+++ b/test/Sema/lifetime_depend_infer_defaults.swift
@@ -1,12 +1,12 @@
 // RUN: %target-swift-emit-silgen -primary-file %s \
 // RUN:   -enable-experimental-feature Lifetimes \
-// RUN:   -enable-experimental-feature SuppressedAssociatedTypes \
+// RUN:   -enable-experimental-feature SuppressedAssociatedTypesWithDefaults \
 // RUN:  | %FileCheck %s
 //
 // -primary-file is required to synthesize accessors.
 
 // REQUIRES: swift_feature_Lifetimes
-// REQUIRES: swift_feature_SuppressedAssociatedTypes
+// REQUIRES: swift_feature_SuppressedAssociatedTypesWithDefaults
 
 // Check that all the DEFAULT cases in Sema/lifetime_depend_infer_defaults.swift generate the correct function
 // signature. Checking the SILGen output seems like the easiest way.

--- a/test/Serialization/noncopyable_generics.swift
+++ b/test/Serialization/noncopyable_generics.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %S/Inputs/ncgenerics.swift                      \
-// RUN:     -enable-experimental-feature SuppressedAssociatedTypes             \
+// RUN:     -enable-experimental-feature SuppressedAssociatedTypesWithDefaults \
 // RUN:     -emit-module -module-name ncgenerics                               \
 // RUN:     -o %t
 
@@ -9,12 +9,12 @@
 // RUN: %target-typecheck-verify-swift -I %t
 
 // RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk)                  \
-// RUN:     -enable-experimental-feature SuppressedAssociatedTypes             \
+// RUN:     -enable-experimental-feature SuppressedAssociatedTypesWithDefaults \
 // RUN:    -print-module -module-to-print=ncgenerics                           \
 // RUN:    -I %t -source-filename=%s                                           \
 // RUN:    | %FileCheck -check-prefix=CHECK-PRINT %s
 
-// REQUIRES: swift_feature_SuppressedAssociatedTypes
+// REQUIRES: swift_feature_SuppressedAssociatedTypesWithDefaults
 
 // CHECK-NOT: UnknownCode
 


### PR DESCRIPTION
We need to start moving people over to using the version of suppressed associated types that has the officially accepted behavior according to SE-503, and that is via
`SuppressedAssociatedTypesWithDefaults`.

To allow for time to migrate to the new version, I'm introducing the deprecation message as a warning for now.

This set of changes also moves most of the test suite over to using the officially accepted version.

rdar://172231663
