### PR TITLE
Optimizer: don't assume fixed lifetimes in diagnostic constant folding and ForEachLoopUnroll

### DIFF
--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -89,7 +89,8 @@ unsigned getNumInOutArguments(FullApplySite applySite);
 ///
 /// \p callbacks.onDelete() is invoked to delete each instruction.
 void eliminateDeadInstruction(SILInstruction *inst,
-                              InstModCallbacks callbacks = InstModCallbacks());
+                              InstModCallbacks callbacks = InstModCallbacks(),
+                              bool assumeFixedLifetimes = true);
 
 /// For each of the given instructions, if they are dead delete them
 /// along with their dead operands. Note this utility must be phased out and

--- a/lib/SILOptimizer/LoopTransforms/ForEachLoopUnroll.cpp
+++ b/lib/SILOptimizer/LoopTransforms/ForEachLoopUnroll.cpp
@@ -668,7 +668,7 @@ class ForEachLoopUnroller : public SILFunctionTransform {
     if (!fun.hasOwnership())
       return;
 
-    InstructionDeleter deleter;
+    InstructionDeleter deleter(/*assumeFixedLifetimes=*/ false);
     for (SILBasicBlock &bb : fun) {
       for (auto instIter = bb.begin(); instIter != bb.end();) {
         SILInstruction *inst = &*instIter;

--- a/lib/SILOptimizer/Utils/ConstantFolding.cpp
+++ b/lib/SILOptimizer/Utils/ConstantFolding.cpp
@@ -1816,7 +1816,7 @@ ConstantFolder::processWorkList() {
         InvalidateInstructions = true;
         instToDelete->eraseFromParent();
       });
-  InstructionDeleter deleter(std::move(callbacks));
+  InstructionDeleter deleter(std::move(callbacks), /*assumeFixedLifetimes=*/ !EnableDiagnostics);
 
   // An out parameter array that we use to return new simplified results from
   // constantFoldInstruction.
@@ -1840,7 +1840,8 @@ ConstantFolder::processWorkList() {
           // Schedule users for constant folding.
           WorkList.insert(AssertConfInt);
           // Delete the call.
-          eliminateDeadInstruction(BI, deleter.getCallbacks());
+          eliminateDeadInstruction(BI, deleter.getCallbacks(),
+                                   /*assumeFixedLifetimes=*/ !EnableDiagnostics);
           continue;
         }
 
@@ -1861,7 +1862,8 @@ ConstantFolder::processWorkList() {
         SILBuilderWithScope B(I);
         auto tru = B.createIntegerLiteral(apply->getLoc(), apply->getType(), 1);
         apply->replaceAllUsesWith(tru);
-        eliminateDeadInstruction(I, deleter.getCallbacks());
+        eliminateDeadInstruction(I, deleter.getCallbacks(),
+                                 /*assumeFixedLifetimes=*/ !EnableDiagnostics);
         WorkList.insert(tru);
         InvalidateInstructions = true;
       }
@@ -1910,7 +1912,8 @@ ConstantFolder::processWorkList() {
       if (constantFoldGlobalStringTablePointerBuiltin(cast<BuiltinInst>(I),
                                                       EnableDiagnostics)) {
         // Here, the builtin instruction got folded, so clean it up.
-        eliminateDeadInstruction(I, deleter.getCallbacks());
+        eliminateDeadInstruction(I, deleter.getCallbacks(),
+                                 /*assumeFixedLifetimes=*/ !EnableDiagnostics);
       }
       continue;
     }
@@ -1959,7 +1962,8 @@ ConstantFolder::processWorkList() {
             SILType::getBuiltinIntegerType(1, builder.getASTContext()), val);
         BI->replaceAllUsesWith(inst);
 
-        eliminateDeadInstruction(I, deleter.getCallbacks());
+        eliminateDeadInstruction(I, deleter.getCallbacks(),
+                                 /*assumeFixedLifetimes=*/ !EnableDiagnostics);
         continue;
       }
     }

--- a/lib/SILOptimizer/Utils/InstructionDeleter.cpp
+++ b/lib/SILOptimizer/Utils/InstructionDeleter.cpp
@@ -414,8 +414,9 @@ void InstructionDeleter::recursivelyForceDeleteUsersAndFixLifetimes(
 }
 
 void swift::eliminateDeadInstruction(SILInstruction *inst,
-                                     InstModCallbacks callbacks) {
-  InstructionDeleter deleter(std::move(callbacks));
+                                     InstModCallbacks callbacks,
+                                     bool assumeFixedLifetimes) {
+  InstructionDeleter deleter(std::move(callbacks), assumeFixedLifetimes);
   deleter.trackIfDead(inst);
   deleter.cleanupDeadInstructions();
 }

--- a/test/SILOptimizer/constant_propagation_ownership.sil
+++ b/test/SILOptimizer/constant_propagation_ownership.sil
@@ -1,5 +1,5 @@
-// RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all %s -diagnostic-constant-propagation | %FileCheck %s
-// RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all %s -performance-constant-propagation | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all %s -diagnostic-constant-propagation | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-DIAG
+// RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all %s -performance-constant-propagation | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-PERF
 
 import Swift
 import Builtin
@@ -1199,3 +1199,38 @@ bb0(%arg : @owned $Builtin.NativeObject):
   %9999 = tuple()
   return %9999 : $()
 }
+
+sil [heuristic_always_inline] [readonly] [_semantics "string.makeUTF8"] @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+
+// CHECK-LABEL: sil [ossa] @remove_dead_string :
+// CHECK-DIAG-NOT:     apply
+// CHECK-DIAG-NOT:     copy_value
+// CHECK-DIAG-NOT:     begin_borrow
+// CHECK-DIAG-NOT:     destroy_value
+// CHECK-PERF:         apply
+// CHECK-PERF:         copy_value
+// CHECK-PERF:         begin_borrow
+// CHECK-PERF:         destroy_value
+// CHECK: } // end sil function 'remove_dead_string'
+sil [ossa] @remove_dead_string : $@convention(thin) () -> () {
+bb0:
+  %0 = string_literal oslog "%s - %s"
+  %1 = integer_literal $Builtin.Word, 7
+  %2 = integer_literal $Builtin.Int1, 0
+  %3 = metatype $@thin String.Type
+  %4 = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+  %5 = apply %4(%0, %1, %2, %3) : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+  %6 = begin_borrow %5
+  %7 = copy_value %6
+  end_borrow %6
+  destroy_value %5
+  %10 = move_value [var_decl] %7
+  %11 = begin_borrow %10
+  %12 = builtin "globalStringTablePointer"(%11) : $Builtin.RawPointer
+  %13 = struct $UnsafePointer<Int8> (%12)
+  end_borrow %11
+  destroy_value %10
+  %16 = tuple ()
+  return %16
+}
+

--- a/test/SILOptimizer/for_each_loop_unroll_test.sil
+++ b/test/SILOptimizer/for_each_loop_unroll_test.sil
@@ -228,6 +228,58 @@ bb2(%39 : @owned $Error):
   unreachable
 }
 
+// Test that dead instructions (specifically a begin_borrow of the array used
+// for the forEach call) are cleaned up after unrolling.
+//
+// CHECK-LABEL: @testDeadInstructionCleanupAfterUnroll
+// CHECK-NOT: forEach
+// CHECK: @_finalizeArray
+// CHECK-NOT: begin_borrow
+// CHECK: end sil function 'testDeadInstructionCleanupAfterUnroll'
+sil hidden [ossa] @testDeadInstructionCleanupAfterUnroll : $@convention(thin) () -> () {
+bb0:
+  %0 = integer_literal $Builtin.Word, 2
+  %1 = function_ref @_allocateUninitializedArray : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned MyArray<τ_0_0>, Builtin.RawPointer)
+  %2 = apply %1<Builtin.Int64>(%0) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned MyArray<τ_0_0>, Builtin.RawPointer)
+  (%3, %4a) = destructure_tuple %2 : $(MyArray<Builtin.Int64>, Builtin.RawPointer)
+  %4 = begin_borrow %3
+  %b = struct_extract %4, #MyArray.buffer
+  %5 = ref_tail_addr %b, $Builtin.Int64
+  %6 = integer_literal $Builtin.Int64, 10
+  store %6 to [trivial] %5 : $*Builtin.Int64
+  %12 = integer_literal $Builtin.Word, 1
+  %13 = index_addr %5 : $*Builtin.Int64, %12 : $Builtin.Word
+  %14 = integer_literal $Builtin.Int64, 20
+  store %14 to [trivial] %13 : $*Builtin.Int64
+  end_borrow %4
+  %f = function_ref @_finalizeArray : $@convention(thin) <τ_0_0> (@owned MyArray<τ_0_0>) -> @owned MyArray<τ_0_0>
+  %a2 = apply %f<Builtin.Int64>(%3) : $@convention(thin) <τ_0_0> (@owned MyArray<τ_0_0>) -> @owned MyArray<τ_0_0>
+  // Set up a begin_borrow/store_borrow/alloc_stack for the forEach call.
+  // After unrolling, this begin_borrow becomes dead and should be cleaned up.
+  %21 = begin_borrow %a2
+  %22 = alloc_stack $MyArray<Builtin.Int64>
+  %23 = store_borrow %21 to %22 : $*MyArray<Builtin.Int64>
+  %24 = function_ref @forEachBody : $@convention(thin) (@in_guaranteed Builtin.Int64) -> @error any Error
+  %25 = convert_function %24 : $@convention(thin) (@in_guaranteed Builtin.Int64) -> @error any Error to $@convention(thin) @noescape (@in_guaranteed Builtin.Int64) -> @error any Error
+  %26 = thin_to_thick_function %25 : $@convention(thin) @noescape (@in_guaranteed Builtin.Int64) -> @error any Error to $@noescape @callee_guaranteed (@in_guaranteed Builtin.Int64) -> @error any Error
+  %30 = function_ref @forEach : $@convention(method) <τ_0_0 where τ_0_0 : Sequence> (@noescape @callee_guaranteed (@in_guaranteed τ_0_0.Element) -> @error Error, @in_guaranteed τ_0_0) -> @error Error
+  try_apply %30<MyArray<Builtin.Int64>>(%26, %23) : $@convention(method) <τ_0_0 where τ_0_0 : Sequence> (@noescape @callee_guaranteed (@in_guaranteed τ_0_0.Element) -> @error Error, @in_guaranteed τ_0_0) -> @error Error, normal bb1, error bb2
+
+bb1(%32 : $()):
+  end_borrow %23 : $*MyArray<Builtin.Int64>
+  dealloc_stack %22 : $*MyArray<Builtin.Int64>
+  end_borrow %21 : $MyArray<Builtin.Int64>
+  destroy_value %a2
+  %37 = tuple ()
+  return %37 : $()
+
+bb2(%39 : @owned $Error):
+  destroy_value [dead_end] %39
+  end_borrow %21
+  destroy_value [dead_end] %a2
+  unreachable
+}
+
 // CHECK-LABEL: @testUnrollOfArrayWithPhiArguments
 // CHECK-NOT: function_ref @forEach : $@convention(method) <τ_0_0 where τ_0_0 : Sequence> (@noescape @callee_guaranteed (@in_guaranteed τ_0_0.Element) -> @error any Error, @in_guaranteed τ_0_0) -> @error any Error
 // CHECK: end sil function 'testUnrollOfArrayWithPhiArguments'


### PR DESCRIPTION
In the mandatory pipeline optimizations are allowed to shrink non-lexical lifetimes.
This is needed to remove dead strings which are a result of OSLogOptimization.

rdar://169095733