### PR TITLE
[PropertyWrappers] Allow out-of-line init for read-only wrappers

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -8196,6 +8196,25 @@ VarDecl::mutability(const DeclContext *UseDC,
       }
     }
 
+    // A wrapped property can be initialized through 'self.prop = value' in a
+    // designated initializer when every wrapper in the chain supports
+    // init(wrappedValue:), even if regular mutation is unavailable.
+    if (!supportsMutation() && hasAttachedPropertyWrapper() &&
+        allAttachedPropertyWrappersHaveWrappedValueInit()) {
+      if (auto *CD = dyn_cast_or_null<ConstructorDecl>(UseDC)) {
+        auto *CDC = CD->getDeclContext();
+        if (CDC->getSelfNominalTypeDecl() ==
+            getDeclContext()->getSelfNominalTypeDecl()) {
+          auto initKindAndExpr = CD->getDelegatingOrChainedInitKind();
+          if (initKindAndExpr.initKind != BodyInitKind::Delegating) {
+            if (!base ||
+                (*base && CD->getImplicitSelfDecl() == (*base)->getDecl()))
+              return StorageMutability::Initializable;
+          }
+        }
+      }
+    }
+
     return storageIsMutable(supportsMutation());
   }
 

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -652,6 +652,15 @@ struct UseBox {
   var x = 17 // expected-note{{'_x' declared here}}
 }
 
+struct UseBoxOutOfLineInit {
+  @Box
+  var x: Int
+
+  init(x: Int) {
+    self.x = x
+  }
+}
+
 func testBox(ub: UseBox) {
   _ = ub.x
   ub.x = 5 // expected-error{{cannot assign to property: 'x' is a get-only property}}


### PR DESCRIPTION
## Summary
Allow out-of-line initialization of wrapped properties in initializers even when the wrapper's `wrappedValue` setter is read-only/inaccessible, as long as the wrapper chain supports `init(wrappedValue:)`.

## Problem
For code like:

```swift
@propertyWrapper
struct DummyWrapper<T> {
  private(set) var wrappedValue: T
  init(wrappedValue: T) { self.wrappedValue = wrappedValue }
}

struct Test {
  @DummyWrapper var x: Int
  init(x: Int) {
    self.x = x
  }
}
```

`self.x = x` was diagnosed as `cannot assign to property: 'x' is a get-only property`.

This is out-of-line initialization in an initializer and should be accepted per SE-0258 when `init(wrappedValue:)` is available.

## Fix
- In `VarDecl::mutability`, add an `Initializable` path for wrapped properties when:
  - accessed from a designated initializer,
  - through `self`,
  - same nominal context,
  - and all attached wrappers support `init(wrappedValue:)`.
- This path is only used when regular mutation is unavailable (`!supportsMutation()`), so it does not broaden normal setter-based mutation.

## Tests
- Added regression coverage in `test/decl/var/property_wrappers.swift` (`UseBoxOutOfLineInit`).
- Verified issue repro now typechecks.
- Ran:
  - `ninja -j2 swiftAST swiftSema swift-frontend`
  - `ninja -j2 stdlib/swift-stdlib-linux-x86_64`
  - `python3 llvm/utils/lit/lit.py -sv --param swift_test_mode=optimize_none --param swift_test_subset=primary -a build/87601-linux/swift-linux-x86_64/test-linux-x86_64/decl/var/property_wrappers.swift`

Fixes #63261.