### PR TITLE
[ReflectionContext] Save Task's parent in TaskInfo

### DIFF
--- a/include/swift/RemoteInspection/ReflectionContext.h
+++ b/include/swift/RemoteInspection/ReflectionContext.h
@@ -213,6 +213,7 @@ public:
     uint64_t Id;
     StoredPointer RunJob;
     StoredPointer AllocatorSlabPtr;
+    StoredPointer ParentTask;
     std::vector<StoredPointer> ChildTasks;
     std::vector<StoredPointer> AsyncBacktraceFrames;
     StoredPointer ResumeAsyncContext;
@@ -2122,6 +2123,16 @@ private:
         AsyncTaskObj->Id | ((uint64_t)AsyncTaskObj->PrivateStorage.Id << 32);
     Info.AllocatorSlabPtr = AsyncTaskObj->PrivateStorage.Allocator.FirstSlab;
     Info.RunJob = getRunJob(AsyncTaskObj.get());
+
+    Info.ParentTask = 0;
+    if (Info.IsChildTask && asyncTaskSize != 0) {
+      // Parent information ("child fragment") is right after the task itself.
+      RemoteAddress ChildFragmentAddr = AsyncTaskPtr + asyncTaskSize;
+      auto ChildFragmentObj =
+          readObj<ChildFragment<Runtime>>(ChildFragmentAddr);
+      if (ChildFragmentObj)
+        Info.ParentTask = ChildFragmentObj->Parent;
+    }
 
     // Find all child tasks.
     unsigned ChildTaskLoopCount = 0;


### PR DESCRIPTION
This exposes the parent of a Task in the information provided by the ReflectionContext class.

We can't test this here without the corresponding SwiftRemoteMirror
change, but that would have binary compat issues (adding a new field),
so this commit does not attempt to test it in this repo. However, LLDB
will be making use of this extensively and test it there.

rdar://147450876