### PR TITLE
Only complain about "swift_" symbols defined outside the standard library

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2465,6 +2465,10 @@ static bool canDeclareSymbolName(StringRef symbol, ModuleDecl *fromModule) {
   if (ctx.LangOpts.hasFeature(Feature::AllowRuntimeSymbolDeclarations))
     return true;
 
+  // Only consider "swift_"-containing symbols.
+  if (!symbol.contains("swift_"))
+    return true;
+
   // Swift runtime functions are a private contract between the compiler and
   // runtime, and attempting to access them directly without going through
   // builtins or proper language features breaks the compiler in various hard

--- a/test/attr/attr_cdecl_official.swift
+++ b/test/attr/attr_cdecl_official.swift
@@ -209,3 +209,6 @@ func anyParam(e:Any) {}
 
 @c func swift_allocBox() {} // expected-warning {{symbol name 'swift_allocBox' is reserved for the Swift runtime and cannot be directly referenced without causing unpredictable behavior; this will become an error}}
 @c(swift_allocObject) func swift_allocObject_renamed() {} // expected-warning {{symbol name 'swift_allocObject' is reserved for the Swift runtime and cannot be directly referenced without causing unpredictable behavior; this will become an error}}
+
+// No warning
+@c func free(_: UnsafeMutableRawPointer?) { }


### PR DESCRIPTION
Specifically, don't warn about C standard library symbols that the compiler happens to know about, like "free".

Fixes #87239 / rdar://170390023.