### PR TITLE
TempLValueElimination: don't insert an early destroy in non-OSSA

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/TempLValueElimination.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/TempLValueElimination.swift
@@ -95,6 +95,17 @@ private func tryEliminate(copy: CopyLikeInstruction, _ context: FunctionPassCont
   // ```
   let needDestroyEarly = !copy.isInitializationOfDestination && !isTrivial
 
+  if needDestroyEarly && !copy.parentFunction.hasOwnership {
+    // In non-OSSA we cannot insert an early `destroy_addr`, because a loaded value could be retained later, e.g.
+    // ```
+    //   %1 = load %destination
+    //   ...                     // we cannot insert a `destroy_addr %destination` here!
+    //   stores to %temp
+    //   strong_retain %1
+    // ```
+    return
+  }
+
   let firstUseOfAllocStack = InstructionList(first: allocStack).first(where: { $0.isUsing(allocStack) }) ??
                                // The conservative default, if the fist use is not in the alloc_stack's block.
                                allocStack.parentBlock.terminator

--- a/test/SILOptimizer/templvalueopt.sil
+++ b/test/SILOptimizer/templvalueopt.sil
@@ -26,11 +26,7 @@ bb0(%0 : $*Optional<Any>, %1 : $*Any):
 
 // CHECK-LABEL: sil @test_enum_without_initialize :
 // CHECK:      bb0(%0 : $*Optional<Any>, %1 : $*Any):
-// CHECK-NEXT:   destroy_addr %0
-// CHECK-NEXT:   [[E:%[0-9]+]] = init_enum_data_addr %0
-// CHECK-NEXT:   copy_addr [take] %1 to [init] [[E]]
-// CHECK-NEXT:   inject_enum_addr %0 : $*Optional<Any>, #Optional.some!enumelt
-// CHECK-NOT:    copy_addr
+// CHECK-NOT:    destroy_addr
 // CHECK: } // end sil function 'test_enum_without_initialize'
 sil @test_enum_without_initialize : $@convention(thin) (@in Any) -> @out Optional<Any> {
 bb0(%0 : $*Optional<Any>, %1 : $*Any):
@@ -311,3 +307,22 @@ bb0(%0 : $*FakeOptional):
   %13 = tuple ()
   return %13
 }
+
+// CHECK-LABEL: sil @dont_insert_destroy_before_retain
+// CHECK-NOT:     destroy_addr
+// CHECK-LABEL: } // end sil function 'dont_insert_destroy_before_retain'
+sil @dont_insert_destroy_before_retain : $@convention(thin) (@owned AnyObject, @inout Either<AnyObject, AnyObject>) -> () {
+bb0(%0 : $AnyObject, %1 : $*Either<AnyObject, AnyObject>):
+  %2 = unchecked_take_enum_data_addr %1, #Either.left!enumelt
+  %3 = load %2
+  %4 = alloc_stack $Either<AnyObject, AnyObject>
+  %5 = init_enum_data_addr %4, #Either.left!enumelt
+  strong_retain %3
+  store %0 to %5
+  inject_enum_addr %4, #Either.left!enumelt
+  copy_addr [take] %4 to %1
+  dealloc_stack %4
+  %11 = tuple ()
+  return %11
+}
+


### PR DESCRIPTION
In non-OSSA we cannot insert an early `destroy_addr`, because a loaded value could be retained later, e.g.
```
  %1 = load %destination
  ...                     // we cannot insert a `destroy_addr %destination` here!
  stores to %temp
  strong_retain %1
```

fixes a miscompile
rdar://172223667
