### PR TITLE
[Embedded] Stop diagnosing untyped throws in embedded mode

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8795,9 +8795,6 @@ GROUPED_ERROR(weak_unowned_in_embedded_swift, EmbeddedRestrictions, none,
               "attribute %0 cannot be used in Embedded Swift",
               (ReferenceOwnership))
 
-GROUPED_WARNING(untyped_throws_in_embedded_swift, EmbeddedRestrictions,
-                none,
-                "untyped throws is not available in Embedded Swift; add a thrown error type with '(type)'", ())
 GROUPED_WARNING(generic_nonfinal_in_embedded_swift, EmbeddedRestrictions,
                 none,
                 "generic %kind0 in a class %select{must be 'final'|cannot be 'required'}1 in Embedded Swift",

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1414,9 +1414,6 @@ FunctionType::ExtInfo ClosureEffectsRequest::evaluate(
   bool sendable = expr->getAttrs().hasAttribute<SendableAttr>();
 
   if (throws || async) {
-    if (expr->getThrowsLoc().isValid() && !expr->getExplicitThrownTypeRepr())
-      diagnoseUntypedThrowsInEmbedded(expr, expr->getThrowsLoc());
-
     return ASTExtInfoBuilder()
       .withThrows(throws, /*FIXME:*/Type())
       .withAsync(async)

--- a/lib/Sema/TypeCheckEmbedded.cpp
+++ b/lib/Sema/TypeCheckEmbedded.cpp
@@ -122,13 +122,6 @@ void swift::checkEmbeddedRestrictionsInSignature(
   if (!behavior)
     return;
 
-  // Untyped throws is not permitted.
-  SourceLoc throwsLoc = func->getThrowsLoc();
-  if (throwsLoc.isValid() && !func->getThrownTypeRepr() &&
-      !func->hasPolymorphicEffect(EffectKind::Throws)) {
-    diagnoseUntypedThrowsInEmbedded(func, throwsLoc);
-  }
-
   // If we're in a class, one cannot have a non-final generic function.
   if (auto classDecl = dyn_cast<ClassDecl>(func->getDeclContext())) {
     if (!classDecl->isSemanticallyFinal() &&
@@ -142,19 +135,6 @@ void swift::checkEmbeddedRestrictionsInSignature(
         .limitBehavior(defaultEmbeddedLimitationForError(func, func->getLoc()));
     }
   }
-}
-
-void swift::diagnoseUntypedThrowsInEmbedded(
-    const DeclContext *dc, SourceLoc throwsLoc) {
-  // If we are not supposed to diagnose Embedded Swift limitations, do nothing.
-  auto behavior = shouldDiagnoseEmbeddedLimitations(dc, throwsLoc);
-  if (!behavior)
-    return;
-
-  dc->getASTContext().Diags.diagnose(
-      throwsLoc, diag::untyped_throws_in_embedded_swift)
-    .limitBehavior(*behavior)
-    .fixItInsertAfter(throwsLoc, "(<#thrown error type#>)");
 }
 
 void swift::diagnoseGenericMemberOfExistentialInEmbedded(

--- a/lib/Sema/TypeCheckEmbedded.h
+++ b/lib/Sema/TypeCheckEmbedded.h
@@ -46,9 +46,6 @@ shouldDiagnoseEmbeddedLimitations(const DeclContext *dc, SourceLoc loc,
 /// Check embedded restrictions in the signature of the given function.
 void checkEmbeddedRestrictionsInSignature(const AbstractFunctionDecl *func);
 
-/// Diagnose a declaration of typed throws at the given location.
-void diagnoseUntypedThrowsInEmbedded(const DeclContext *dc, SourceLoc throwsLoc);
-
 /// Diagnose references to a generic member via an existential type, which are
 /// not available in Embedded Swift.
 void diagnoseGenericMemberOfExistentialInEmbedded(

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4637,8 +4637,6 @@ NeverNullType TypeResolver::resolveASTFunctionType(
             thrownTy);
       }
     }
-  } else if (repr->getThrowsLoc().isValid()) {
-    diagnoseUntypedThrowsInEmbedded(getDeclContext(), repr->getThrowsLoc());
   }
 
   bool hasSendingResult =
@@ -7347,7 +7345,6 @@ Type ExplicitCaughtTypeRequest::evaluate(
 
     // Explicit 'throws' implies that this throws 'any Error'.
     if (closure->getThrowsLoc().isValid()) {
-      diagnoseUntypedThrowsInEmbedded(closure, closure->getThrowsLoc());
       return ctx.getErrorExistentialType();
     }
 
@@ -7367,8 +7364,6 @@ Type ExplicitCaughtTypeRequest::evaluate(
 
     // If there is no explicitly-specified thrown error type, it's 'any Error'.
     if (!typeRepr) {
-      diagnoseUntypedThrowsInEmbedded(doCatch->getDeclContext(),
-                                      doCatch->getThrowsLoc());
       return ctx.getErrorExistentialType();
     }
 

--- a/test/embedded/restrictions.swift
+++ b/test/embedded/restrictions.swift
@@ -5,39 +5,32 @@
 // REQUIRES: swift_feature_Embedded
 
 // ---------------------------------------------------------------------------
-// Untyped throws
+// Untyped throws - we're not diagnosing this.
 // ---------------------------------------------------------------------------
 
 enum MyError: Error {
 case failed
 }
 
-// expected-warning@+1{{untyped throws is not available in Embedded Swift; add a thrown error type with '(type)'}}{{28-28=(<#thrown error type#>)}}
 func untypedThrows() throws { }
 
-// expected-warning@+1{{untyped throws is not available in Embedded Swift; add a thrown error type with '(type)'}}{{41-41=(<#thrown error type#>)}}
 func rethrowingFunction(param: () throws -> Void) rethrows { }
 
-// expected-warning@+1{{untyped throws is not available in Embedded Swift; add a thrown error type with '(type)'}}{{29-29=(<#thrown error type#>)}}
 typealias FnType = () throws -> Void
 
 func untypedThrowsInBody() {
-  // expected-warning@+1{{untyped throws is not available in Embedded Swift; add a thrown error type with '(type)'}}{{12-12=(<#thrown error type#>)}}
   do throws {
     throw MyError.failed
   } catch {
   }
 
-  // expected-warning@+1{{untyped throws is not available in Embedded Swift; add a thrown error type with '(type)'}}{{19-19=(<#thrown error type#>)}}
   _ = { (x) throws in x + 1 }
 }
 
 struct SomeStruct {
-  // expected-warning@+1{{untyped throws is not available in Embedded Swift; add a thrown error type with '(type)'}}{{16-16=(<#thrown error type#>)}}
   init() throws { }
 
   var value: Int {
-  // expected-warning@+1{{untyped throws is not available in Embedded Swift; add a thrown error type with '(type)'}}{{15-15=(<#thrown error type#>)}}
     get throws {
       0
     }
@@ -143,15 +136,27 @@ func dynamicCasting(object: AnyObject, cq: ConformsToQ) {
 
 #if $Embedded
 
-// expected-embedded-warning@+1{{untyped throws is not available in Embedded Swift; add a thrown error type with '(type)'}}{{31-31=(<#thrown error type#>)}}
-func stillProblematic() throws { }
+func stillProblematic(object: AnyObject) {
+  // expected-embedded-warning@+1{{cannot perform a dynamic cast to a type involving protocol 'Q' in Embedded Swift}}
+  if let q = object as? any AnyObject & Q {
+    _ = q
+  }
+}
 
 #else
 
-func notProblematicAtAll() throws { }
+func notProblematicAtAll(object: AnyObject) throws {
+  if let q = object as? any AnyObject & Q {
+    _ = q
+  }
+}
 
 #endif
 
 #if !hasFeature(Embedded)
-func stillNotProblematicAtAll() throws { }
+func stillNotProblematicAtAll(object: AnyObject) throws {
+  if let q = object as? any AnyObject & Q {
+    _ = q
+  }
+}
 #endif

--- a/userdocs/diagnostics/embedded-restrictions.md
+++ b/userdocs/diagnostics/embedded-restrictions.md
@@ -48,11 +48,6 @@ Diagnostics in the `EmbeddedRestrictions` group describe those language features
         value.doSomething(on: i) // warning: cannot use generic instance method 'doSomething(on:)' on a value of type 'any P' in Embedded Swift
       }
 
-* Use of untyped throws, which depends on `any Error` and is not available in Embedded Swift. Use typed throws instead:
-
-      func mayFail() throws { } // error: untyped throws is not available in Embedded Swift; add a thrown error type with '(type)'
-      func mayFail() throws(MyError) // okay
-
 ## See Also
 
 - [A Vision for Embedded Swift](https://github.com/swiftlang/swift-evolution/blob/main/visions/embedded-swift.md)


### PR DESCRIPTION
It is plausible that we will introduce support for untyped throws in Embedded Swift at some point, so don't diagnose its presence so eagerly now. Instead, leave it until later in the pipeline when it's actually used.

Fixes rdar://162071067, where we were getting entirely too many warnings about this.
