### PR TITLE
Hoist bounds checks annotated with fixed storage semantics to appear together in a block

### DIFF
--- a/include/swift/SIL/InstWrappers.h
+++ b/include/swift/SIL/InstWrappers.h
@@ -396,10 +396,19 @@ struct FixedStorageSemanticsCall {
     }
   }
 
+  bool hasSelf() const { return apply->hasSelfArgument(); }
+
+  SILValue getSelf() const { return apply->getSelfArgument(); }
+
+  SILValue getIndex() const { return apply->getArgument(0); }
+
+  Operand &getIndexOperand() const { return apply->getArgumentRef(0); }
+
   FixedStorageSemanticsCallKind getKind() const { return kind; }
   explicit operator bool() const { return apply != nullptr; }
-  const ApplyInst *operator->() const { return apply; }
-  ApplyInst *operator->() { return apply; }
+  const ApplyInst* operator->() const { return apply; }
+  ApplyInst* operator->() { return apply; }
+  ApplyInst* operator*() const { return apply; }
 };
 
 bool isFixedStorageSemanticsCallKind(SILFunction *function);

--- a/include/swift/SIL/InstructionUtils.h
+++ b/include/swift/SIL/InstructionUtils.h
@@ -265,6 +265,9 @@ bool isIndirectArgumentMutated(SILFunctionArgument *arg, bool ignoreDestroys = f
 ///       concurrently.
 class InstructionIndices {
   NodeBitfield indices;
+  bool indicesOverflowed = false;
+
+  void indexBlock(SILBasicBlock &block);
 
 public:
   // Leave a few bits for other purposes (e.g. InstructionSet).
@@ -274,6 +277,12 @@ public:
                 "should at least be able to index 65536 instructions in a block");
 
   InstructionIndices(SILFunction *f);
+
+  InstructionIndices(SILBasicBlock *block);
+
+  /// Returns true if any block had more instructions than can be uniquely
+  /// indexed, causing some instructions to share the same maximum index.
+  bool hasOverflowedIndices() const { return indicesOverflowed; }
 
   unsigned get(SILInstruction *inst) {
     return indices.get(inst->asSILNode());

--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -1508,14 +1508,26 @@ bool swift::shouldExpand(SILModule &module, SILType ty) {
   return (numFields <= 6);
 }
 
+void InstructionIndices::indexBlock(SILBasicBlock &block) {
+  unsigned idx = 1;
+  for (SILInstruction &inst : block) {
+    indices.set(inst.asSILNode(), idx);
+    if (indices.fits(idx + 1)) {
+      idx += 1;
+    } else {
+      indicesOverflowed = true;
+    }
+  }
+}
+
 InstructionIndices::InstructionIndices(SILFunction *f)
     : indices(f, numIndexBits) {
   for (SILBasicBlock &block : *f) {
-    unsigned idx = 1;
-    for (SILInstruction &inst : block) {
-      indices.set(inst.asSILNode(), idx);
-      if (indices.fits(idx + 1))
-        idx += 1;
-    }
+    indexBlock(block);
   }
+}
+
+InstructionIndices::InstructionIndices(SILBasicBlock *block)
+    : indices(block->getFunction(), numIndexBits) {
+  indexBlock(*block);
 }

--- a/lib/SILOptimizer/LoopTransforms/BoundsCheckOpts.cpp
+++ b/lib/SILOptimizer/LoopTransforms/BoundsCheckOpts.cpp
@@ -17,6 +17,7 @@
 #include "swift/Basic/STLExtras.h"
 #include "swift/SIL/Dominance.h"
 #include "swift/SIL/InstructionUtils.h"
+#include "swift/SIL/NodeDatastructures.h"
 #include "swift/SIL/PatternMatch.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILBuilder.h"
@@ -38,6 +39,7 @@
 #include "swift/SILOptimizer/Utils/SILSSAUpdater.h"
 
 #include "llvm/ADT/DepthFirstIterator.h"
+#include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/PointerIntPair.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/StringExtras.h"
@@ -1022,6 +1024,11 @@ private:
   /// state after an instruction that may modify any array allowing removal of
   /// redundant checks up to that point and after that point.
   bool removeRedundantArrayChecksInBlock(SILBasicBlock &BB);
+
+  /// Hoists fixed storage bounds checks of the same self value to the earliest
+  /// check's position.
+  bool hoistFixedStorageBoundsChecksInBlock(SILBasicBlock &block);
+
   /// Hoist or remove redundant bound checks in \p Loop
   bool optimizeArrayBoundsCheckInLoop(SILLoop *Loop);
   /// Walk down the dominator tree inside the loop, removing redundant checks.
@@ -1045,6 +1052,18 @@ private:
       SILLoop *loop, DominanceInfoNode *currentNode,
       llvm::DenseSet<std::pair<SILValue, SILValue>> &dominatingSafeChecks,
       int recursionDepth);
+
+  /// Clone an index value and its operands, inserting them in correct order
+  /// at the given insertion position.
+  ///
+  /// \param indexValue The index value to clone
+  /// \param insertPos The position where cloned instructions should be inserted
+  /// \param instIndices Pre-computed instruction indices
+  /// \returns The cloned index value or std::nullopt if cloning was not
+  /// possible
+  std::optional<SILValue>
+  cloneFixedStorageIndex(SILValue indexValue, SILInstruction *insertPos,
+                         InstructionIndices &instIndices);
 
 public:
   void run() override {
@@ -1108,6 +1127,7 @@ bool BoundsCheckOpts::optimizeBoundsChecksInBlocks() {
   bool changed = false;
   for (auto &block : *getFunction()) {
     changed |= removeRedundantArrayChecksInBlock(block);
+    changed |= hoistFixedStorageBoundsChecksInBlock(block);
   }
   return changed;
 }
@@ -1192,6 +1212,79 @@ bool BoundsCheckOpts::removeRedundantArrayChecksInBlock(SILBasicBlock &BB) {
     Changed = true;
   }
   return Changed;
+}
+
+bool BoundsCheckOpts::hoistFixedStorageBoundsChecksInBlock(SILBasicBlock &block) {
+  bool changed = false;
+
+  // Map to track fixed storage checks grouped by self value.
+  llvm::MapVector<SILValue, SmallVector<FixedStorageSemanticsCall, 4>>
+      checksToMerge;
+
+  LLVM_DEBUG(llvm::dbgs() << "Merging fixed storage checks in BB"
+                          << block.getDebugID() << "\n");
+
+  // First pass: collect all fixed storage checks grouped by self value
+  for (auto &inst : block) {
+    FixedStorageSemanticsCall fixedStorageCall(&inst);
+    if (!fixedStorageCall ||
+        fixedStorageCall.getKind() !=
+            FixedStorageSemanticsCallKind::CheckIndex ||
+        fixedStorageCall->getNumArguments() < 2) {
+      continue;
+    }
+
+    auto selfValue = fixedStorageCall.getSelf();
+    auto indexValue = fixedStorageCall.getIndex();
+
+    // Add this check to the list for the self value
+    checksToMerge[selfValue].push_back(fixedStorageCall);
+
+    LLVM_DEBUG(llvm::dbgs() << "  Found fixed storage check: " << inst
+                            << " with self: " << *selfValue
+                            << " and index: " << *indexValue);
+  }
+
+  InstructionIndices instIndices(&block);
+
+  // If instruction indices have overflowed, the ordering comparisons are
+  // unreliable and can cause unnecessary cloning below in an already large
+  // block, bail out.
+  if (instIndices.hasOverflowedIndices()) {
+    return changed;
+  }
+
+  // Second pass: process each self group to place checks with same self next to
+  // each other, preserving their original relative order.
+  for (auto &entry : checksToMerge) {
+    auto &checks = entry.second;
+    if (checks.size() <= 1) {
+      continue;
+    }
+
+    SILInstruction *insertAfter = *checks[0];
+
+    for (unsigned i = 1, e = checks.size(); i < e; ++i) {
+      auto check = checks[i];
+
+      auto indexValue = check.getIndex();
+      auto clonedValue =
+          cloneFixedStorageIndex(indexValue, *checks[0], instIndices);
+      if (!clonedValue) {
+        continue;
+      }
+      check.getIndexOperand().set(*clonedValue);
+      check->getCalleeOperand()->set(checks[0]->getCallee());
+      check->moveAfter(insertAfter);
+      insertAfter = *check;
+
+      LLVM_DEBUG(llvm::dbgs()
+                 << "      Moved check to be adjacent: " << *check.apply);
+      changed = true;
+    }
+  }
+
+  return changed;
 }
 
 bool BoundsCheckOpts::removeRedundantArrayBoundsChecksInLoop(
@@ -1746,6 +1839,82 @@ bool BoundsCheckOpts::removeRedundantFixedStorageBoundsChecksInLoop(
                 });
 
   return changed;
+}
+
+static void mapOperands(SILInstruction *inst,
+                        const llvm::DenseMap<ValueBase *, SILValue> &valueMap) {
+  for (auto &operand : inst->getAllOperands()) {
+    SILValue origVal = operand.get();
+    ValueBase *origDef = origVal;
+    auto found = valueMap.find(origDef);
+    if (found != valueMap.end()) {
+      SILValue mappedVal = found->second;
+      operand.set(mappedVal);
+    }
+  }
+}
+
+static void mapValue(SILValue cloned, SILValue original,
+                     llvm::DenseMap<ValueBase *, SILValue> &valueMap) {
+  valueMap[original] = cloned;
+}
+
+static void mapResults(SILInstruction *cloned, SILInstruction *original,
+                       llvm::DenseMap<ValueBase *, SILValue> &valueMap) {
+  auto instResults = original->getResults();
+  auto clonedResults = cloned->getResults();
+  assert(instResults.size() == clonedResults.size());
+  for (auto i : indices(instResults)) {
+    mapValue(clonedResults[i], instResults[i], valueMap);
+  }
+}
+
+std::optional<SILValue>
+BoundsCheckOpts::cloneFixedStorageIndex(SILValue indexValue,
+                                        SILInstruction *insertPos,
+                                        InstructionIndices &instIndices) {
+  SmallVector<SILInstruction *, 8> toClone;
+  llvm::DenseMap<ValueBase *, SILValue> valueMap;
+
+  ValueWorklist worklist(getFunction());
+  worklist.push(indexValue);
+
+  while (auto value = worklist.pop()) {
+    auto *inst = value->getDefiningInstruction();
+
+    // If the value appears to be before the insertion point, cloning is not
+    // necessary, because we can just reuse the value. Note that if the value is
+    // in a different block it must come before the insertion point because the
+    // value dominates insertion point.
+    if (isa<SILArgument>(value) ||
+        inst->getParent() != insertPos->getParent() ||
+        instIndices.get(inst) < instIndices.get(insertPos)) {
+      mapValue(value, value, valueMap);
+      continue;
+    }
+
+    // Cannot clone if it's non-trivial or may have side-effects.
+    if (!inst->isTriviallyDuplicatable() || inst->mayHaveSideEffects()) {
+      return std::nullopt;
+    }
+
+    toClone.push_back(inst);
+
+    for (auto operand : inst->getOperandValues()) {
+      worklist.pushIfNotVisited(operand);
+    }
+  }
+
+  // Reverse the list to get topological order
+  std::reverse(toClone.begin(), toClone.end());
+
+  for (auto *inst : toClone) {
+    auto *cloned = inst->clone(insertPos);
+    mapOperands(cloned, valueMap);
+    mapResults(cloned, inst, valueMap);
+  }
+
+  return valueMap[indexValue];
 }
 
 } // end anonymous namespace

--- a/lib/SILOptimizer/LoopTransforms/BoundsCheckOpts.cpp
+++ b/lib/SILOptimizer/LoopTransforms/BoundsCheckOpts.cpp
@@ -1882,6 +1882,16 @@ BoundsCheckOpts::cloneFixedStorageIndex(SILValue indexValue,
   while (auto value = worklist.pop()) {
     auto *inst = value->getDefiningInstruction();
 
+    // In ossa, bailout when we have an instruction with lifetime ending
+    // operands to avoid creating a possible over-consume.
+    if (inst && getFunction()->hasOwnership()) {
+      for (auto &operand : inst->getAllOperands()) {
+        if (operand.isLifetimeEnding()) {
+          return std::nullopt;
+        }
+      }
+    }
+
     // If the value appears to be before the insertion point, cloning is not
     // necessary, because we can just reuse the value. Note that if the value is
     // in a different block it must come before the insertion point because the
@@ -1893,7 +1903,6 @@ BoundsCheckOpts::cloneFixedStorageIndex(SILValue indexValue,
       continue;
     }
 
-    // Cannot clone if it's non-trivial or may have side-effects.
     if (!inst->isTriviallyDuplicatable() || inst->mayHaveSideEffects()) {
       return std::nullopt;
     }

--- a/test/SILOptimizer/fixed_storage_bounds_check_hoisting.sil
+++ b/test/SILOptimizer/fixed_storage_bounds_check_hoisting.sil
@@ -1,0 +1,192 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -bcopts | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+class Klass {
+  init()
+}
+
+struct NonTrivialWrapper {
+  @_hasStorage let k: Klass { get }
+  @_hasStorage let i: Int { get }
+}
+
+sil [_semantics "fixed_storage.check_index"] @checkIndex : $@convention(method) (Int, @guaranteed Span<Int>) -> ()
+
+sil @use : $@convention(thin) (Int) -> ()
+
+// CHECK-LABEL: sil [ossa] @test_struct_extract_guaranteed_nontrivial :
+// CHECK: [[CHECK:%[0-9]+]] = function_ref @checkIndex
+// CHECK: apply [[CHECK]]
+// CHECK-NEXT: apply [[CHECK]]
+// CHECK-LABEL: } // end sil function 'test_struct_extract_guaranteed_nontrivial'
+sil [ossa] @test_struct_extract_guaranteed_nontrivial : $@convention(thin) (@guaranteed Span<Int>, @guaranteed NonTrivialWrapper, @guaranteed NonTrivialWrapper) -> () {
+bb0(%0 : @noImplicitCopy @guaranteed $Span<Int>, %1 : @guaranteed $NonTrivialWrapper, %2 : @guaranteed $NonTrivialWrapper):
+  %idx1 = struct_extract %1, #NonTrivialWrapper.i
+  %check_fn = function_ref @checkIndex : $@convention(method) (Int, @guaranteed Span<Int>) -> ()
+  %c1 = apply %check_fn(%idx1, %0) : $@convention(method) (Int, @guaranteed Span<Int>) -> ()
+  %use_fn = function_ref @use : $@convention(thin) (Int) -> ()
+  %u1 = apply %use_fn(%idx1) : $@convention(thin) (Int) -> ()
+  %idx2 = struct_extract %2, #NonTrivialWrapper.i
+  %c2 = apply %check_fn(%idx2, %0) : $@convention(method) (Int, @guaranteed Span<Int>) -> ()
+  %u2 = apply %use_fn(%idx2) : $@convention(thin) (Int) -> ()
+  %t = tuple ()
+  return %t : $()
+}
+
+// CHECK-LABEL: sil [ossa] @test_struct_extract_owned_borrow :
+// CHECK: [[CHECK:%[0-9]+]] = function_ref @checkIndex
+// CHECK: apply [[CHECK]]
+// CHECK-NOT: apply [[CHECK]]
+// CHECK: function_ref @use
+// CHECK: apply [[CHECK]]
+// CHECK-LABEL: } // end sil function 'test_struct_extract_owned_borrow'
+sil [ossa] @test_struct_extract_owned_borrow : $@convention(thin) (@guaranteed Span<Int>, @owned NonTrivialWrapper, @owned NonTrivialWrapper) -> () {
+bb0(%0 : @noImplicitCopy @guaranteed $Span<Int>, %1 : @owned $NonTrivialWrapper, %2 : @owned $NonTrivialWrapper):
+  %b1 = begin_borrow %1
+  %idx1 = struct_extract %b1, #NonTrivialWrapper.i
+  %check_fn = function_ref @checkIndex : $@convention(method) (Int, @guaranteed Span<Int>) -> ()
+  %c1 = apply %check_fn(%idx1, %0) : $@convention(method) (Int, @guaranteed Span<Int>) -> ()
+  end_borrow %b1
+  %use_fn = function_ref @use : $@convention(thin) (Int) -> ()
+  %u1 = apply %use_fn(%idx1) : $@convention(thin) (Int) -> ()
+  %b2 = begin_borrow %2
+  %idx2 = struct_extract %b2, #NonTrivialWrapper.i
+  %c2 = apply %check_fn(%idx2, %0) : $@convention(method) (Int, @guaranteed Span<Int>) -> ()
+  end_borrow %b2
+  %u2 = apply %use_fn(%idx2) : $@convention(thin) (Int) -> ()
+  destroy_value %1
+  destroy_value %2
+  %t = tuple ()
+  return %t : $()
+}
+
+// CHECK-LABEL: sil [ossa] @test_destructure_struct_owned :
+// CHECK: [[CHECK:%[0-9]+]] = function_ref @checkIndex
+// CHECK: apply [[CHECK]]
+// CHECK-NOT: apply [[CHECK]]
+// CHECK: function_ref @use
+// CHECK: apply [[CHECK]]
+// CHECK-LABEL: } // end sil function 'test_destructure_struct_owned'
+sil [ossa] @test_destructure_struct_owned : $@convention(thin) (@guaranteed Span<Int>, @owned NonTrivialWrapper, @owned NonTrivialWrapper) -> () {
+bb0(%0 : @noImplicitCopy @guaranteed $Span<Int>, %1 : @owned $NonTrivialWrapper, %2 : @owned $NonTrivialWrapper):
+  (%k1, %a1) = destructure_struct %1
+  %check_fn = function_ref @checkIndex : $@convention(method) (Int, @guaranteed Span<Int>) -> ()
+  %c1 = apply %check_fn(%a1, %0) : $@convention(method) (Int, @guaranteed Span<Int>) -> ()
+  %use_fn = function_ref @use : $@convention(thin) (Int) -> ()
+  %u1 = apply %use_fn(%a1) : $@convention(thin) (Int) -> ()
+  (%k2, %a2) = destructure_struct %2
+  %c2 = apply %check_fn(%a2, %0) : $@convention(method) (Int, @guaranteed Span<Int>) -> ()
+  %u2 = apply %use_fn(%a2) : $@convention(thin) (Int) -> ()
+  destroy_value %k1
+  destroy_value %k2
+  %t = tuple ()
+  return %t : $()
+}
+
+// CHECK-LABEL: sil [ossa] @test_destructure_struct_guaranteed :
+// CHECK: [[CHECK:%[0-9]+]] = function_ref @checkIndex
+// CHECK: apply [[CHECK]]
+// CHECK-NEXT: apply [[CHECK]]
+// CHECK-LABEL: } // end sil function 'test_destructure_struct_guaranteed'
+sil [ossa] @test_destructure_struct_guaranteed : $@convention(thin) (@guaranteed Span<Int>, @guaranteed NonTrivialWrapper, @guaranteed NonTrivialWrapper) -> () {
+bb0(%0 : @noImplicitCopy @guaranteed $Span<Int>, %1 : @guaranteed $NonTrivialWrapper, %2 : @guaranteed $NonTrivialWrapper):
+  (%k1, %a1) = destructure_struct %1
+  %check_fn = function_ref @checkIndex : $@convention(method) (Int, @guaranteed Span<Int>) -> ()
+  %c1 = apply %check_fn(%a1, %0) : $@convention(method) (Int, @guaranteed Span<Int>) -> ()
+  %use_fn = function_ref @use : $@convention(thin) (Int) -> ()
+  %u1 = apply %use_fn(%a1) : $@convention(thin) (Int) -> ()
+  (%k2, %a2) = destructure_struct %2
+  %c2 = apply %check_fn(%a2, %0) : $@convention(method) (Int, @guaranteed Span<Int>) -> ()
+  %u2 = apply %use_fn(%a2) : $@convention(thin) (Int) -> ()
+  %t = tuple ()
+  return %t : $()
+}
+
+// CHECK-LABEL: sil [ossa] @test_destructure_tuple_owned :
+// CHECK: [[CHECK:%[0-9]+]] = function_ref @checkIndex
+// CHECK: apply [[CHECK]]
+// CHECK-NOT: apply [[CHECK]]
+// CHECK: function_ref @use
+// CHECK: apply [[CHECK]]
+// CHECK-LABEL: } // end sil function 'test_destructure_tuple_owned'
+sil [ossa] @test_destructure_tuple_owned : $@convention(thin) (@guaranteed Span<Int>, @owned (Klass, Int), @owned (Klass, Int)) -> () {
+bb0(%0 : @noImplicitCopy @guaranteed $Span<Int>, %1 : @owned $(Klass, Int), %2 : @owned $(Klass, Int)):
+  (%k1, %a1) = destructure_tuple %1
+  %check_fn = function_ref @checkIndex : $@convention(method) (Int, @guaranteed Span<Int>) -> ()
+  %c1 = apply %check_fn(%a1, %0) : $@convention(method) (Int, @guaranteed Span<Int>) -> ()
+  %use_fn = function_ref @use : $@convention(thin) (Int) -> ()
+  %u1 = apply %use_fn(%a1) : $@convention(thin) (Int) -> ()
+  (%k2, %a2) = destructure_tuple %2
+  %c2 = apply %check_fn(%a2, %0) : $@convention(method) (Int, @guaranteed Span<Int>) -> ()
+  %u2 = apply %use_fn(%a2) : $@convention(thin) (Int) -> ()
+  destroy_value %k1
+  destroy_value %k2
+  %t = tuple ()
+  return %t : $()
+}
+
+// CHECK-LABEL: sil [ossa] @test_destructure_tuple_guaranteed :
+// CHECK: [[CHECK:%[0-9]+]] = function_ref @checkIndex
+// CHECK: apply [[CHECK]]
+// CHECK-NEXT: apply [[CHECK]]
+// CHECK-LABEL: } // end sil function 'test_destructure_tuple_guaranteed'
+sil [ossa] @test_destructure_tuple_guaranteed : $@convention(thin) (@guaranteed Span<Int>, @guaranteed (Klass, Int), @guaranteed (Klass, Int)) -> () {
+bb0(%0 : @noImplicitCopy @guaranteed $Span<Int>, %1 : @guaranteed $(Klass, Int), %2 : @guaranteed $(Klass, Int)):
+  (%k1, %a1) = destructure_tuple %1
+  %check_fn = function_ref @checkIndex : $@convention(method) (Int, @guaranteed Span<Int>) -> ()
+  %c1 = apply %check_fn(%a1, %0) : $@convention(method) (Int, @guaranteed Span<Int>) -> ()
+  %use_fn = function_ref @use : $@convention(thin) (Int) -> ()
+  %u1 = apply %use_fn(%a1) : $@convention(thin) (Int) -> ()
+  (%k2, %a2) = destructure_tuple %2
+  %c2 = apply %check_fn(%a2, %0) : $@convention(method) (Int, @guaranteed Span<Int>) -> ()
+  %u2 = apply %use_fn(%a2) : $@convention(thin) (Int) -> ()
+  %t = tuple ()
+  return %t : $()
+}
+
+// CHECK-LABEL: sil [ossa] @test_index_arithmetic_from_nontrivial_struct :
+// CHECK: [[CHECK:%[0-9]+]] = function_ref @checkIndex
+// CHECK: apply [[CHECK]]
+// CHECK-NEXT: apply [[CHECK]]
+// CHECK-LABEL: } // end sil function 'test_index_arithmetic_from_nontrivial_struct'
+sil [ossa] @test_index_arithmetic_from_nontrivial_struct : $@convention(thin) (@guaranteed Span<Int>, @guaranteed NonTrivialWrapper) -> () {
+bb0(%0 : @noImplicitCopy @guaranteed $Span<Int>, %1 : @guaranteed $NonTrivialWrapper):
+  %idx_base = struct_extract %1, #NonTrivialWrapper.i
+  %check_fn = function_ref @checkIndex : $@convention(method) (Int, @guaranteed Span<Int>) -> ()
+  %c1 = apply %check_fn(%idx_base, %0) : $@convention(method) (Int, @guaranteed Span<Int>) -> ()
+  %use_fn = function_ref @use : $@convention(thin) (Int) -> ()
+  %u1 = apply %use_fn(%idx_base) : $@convention(thin) (Int) -> ()
+  %idx_raw = struct_extract %idx_base, #Int._value
+  %one = integer_literal $Builtin.Int64, 1
+  %zero = integer_literal $Builtin.Int1, 0
+  %add_result = builtin "sadd_with_overflow_Int64"(%idx_raw : $Builtin.Int64, %one : $Builtin.Int64, %zero : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %sum = tuple_extract %add_result : $(Builtin.Int64, Builtin.Int1), 0
+  %idx2 = struct $Int (%sum : $Builtin.Int64)
+  %c2 = apply %check_fn(%idx2, %0) : $@convention(method) (Int, @guaranteed Span<Int>) -> ()
+  %u2 = apply %use_fn(%idx2) : $@convention(thin) (Int) -> ()
+  %t = tuple ()
+  return %t : $()
+}
+
+// CHECK-LABEL: sil [ossa] @test_no_clone_needed :
+// CHECK: [[CHECK:%[0-9]+]] = function_ref @checkIndex
+// CHECK: apply [[CHECK]]
+// CHECK-NEXT: apply [[CHECK]]
+// CHECK-LABEL: } // end sil function 'test_no_clone_needed'
+sil [ossa] @test_no_clone_needed : $@convention(thin) (@guaranteed Span<Int>, @guaranteed NonTrivialWrapper, @guaranteed NonTrivialWrapper) -> () {
+bb0(%0 : @noImplicitCopy @guaranteed $Span<Int>, %1 : @guaranteed $NonTrivialWrapper, %2 : @guaranteed $NonTrivialWrapper):
+  %idx1 = struct_extract %1, #NonTrivialWrapper.i
+  %idx2 = struct_extract %2, #NonTrivialWrapper.i
+  %check_fn = function_ref @checkIndex : $@convention(method) (Int, @guaranteed Span<Int>) -> ()
+  %c1 = apply %check_fn(%idx1, %0) : $@convention(method) (Int, @guaranteed Span<Int>) -> ()
+  %use_fn = function_ref @use : $@convention(thin) (Int) -> ()
+  %u1 = apply %use_fn(%idx1) : $@convention(thin) (Int) -> ()
+  %c2 = apply %check_fn(%idx2, %0) : $@convention(method) (Int, @guaranteed Span<Int>) -> ()
+  %u2 = apply %use_fn(%idx2) : $@convention(thin) (Int) -> ()
+  %t = tuple ()
+  return %t : $()
+}

--- a/test/SILOptimizer/mutable_span_bounds_check_tests.swift
+++ b/test/SILOptimizer/mutable_span_bounds_check_tests.swift
@@ -156,7 +156,7 @@ public func span_bubble_sort(_ span: inout MutableSpan<Int>) {
 // CHECK-SIL-LABEL: sil @$s31mutable_span_bounds_check_tests6sortedySbs11MutableSpanVySiGF :
 // CHECK-SIL: bb4:
 // CHECK-SIL: cond_fail {{.*}}, "index out of bounds"
-// CHECK-SIL: cond_fail {{.*}}, "index out of bounds"
+// CHECK-SIL-NOT: cond_fail {{.*}}, "index out of bounds"
 // CHECK-SIL: cond_br
 // CHECK-SIL-LABEL: } // end sil function '$s31mutable_span_bounds_check_tests6sortedySbs11MutableSpanVySiGF'
 public func sorted(_ span: borrowing MutableSpan<Int>) -> Bool {

--- a/test/SILOptimizer/span_bounds_check_tests.swift
+++ b/test/SILOptimizer/span_bounds_check_tests.swift
@@ -334,3 +334,45 @@ public func inout_span_sum_iterate_to_unknown_with_trap_dontopt(_ v: inout Span<
   return sum
 }
 
+// CHECK-SIL-LABEL: sil @$s23span_bounds_check_tests0A6_4_sum1p1iSis4SpanVySiG_SitF :
+// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-SIL-NOT: cond_fail
+// CHECK-SIL-LABEL: } // end sil function '$s23span_bounds_check_tests0A6_4_sum1p1iSis4SpanVySiG_SitF'
+// CHECK-IR: define {{.*}} @"$s23span_bounds_check_tests0A6_4_sum1p1iSis4SpanVySiG_SitF"
+// CHECK-IR: @llvm.vector.reduce.add
+public func span_4_sum(p: borrowing Span<Int>, i: Int) -> Int {
+    let a = p[i]
+    let b = p[i &+ 1]
+    let c = p[i &+ 2]
+    let d = p[i &+ 3]
+
+    return a &+ b &+ c &+ d
+}
+
+// CHECK-SIL-LABEL: sil {{.*}}@$ss4SpanV23span_bounds_check_testss5UInt8VRszlE16loadLittleEndian5indexs6UInt32VSi_tF :
+// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-SIL-NOT: cond_fail
+// CHECK-SIL-LABEL: } // end sil function '$ss4SpanV23span_bounds_check_testss5UInt8VRszlE16loadLittleEndian5indexs6UInt32VSi_tF'
+// TODO: LLVM should generate a wide load for this
+extension Span<UInt8> {
+  public func loadLittleEndian(index: Int) -> UInt32 {
+    precondition(index >= self.indices.lowerBound && index < self.indices.upperBound)
+    return (
+      UInt32(self[index]) |
+      UInt32(self[index &+ 1]) << 8 |
+      UInt32(self[index &+ 2]) << 16 |
+      UInt32(self[index &+ 3]) << 24
+    )
+  }
+}
+
+// CHECK-SIL-LABEL: sil @$s23span_bounds_check_tests0A19_different_self_sum1p1q1iSis4SpanVySiG_AHSitF :
+// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
+// CHECK-SIL-LABEL: } // end sil function
+public func span_different_self_sum(p: borrowing Span<Int>, q: borrowing Span<Int>, i: Int) -> Int {
+    let a = p[i]
+    let b = q[i]
+    return a &+ b
+}
+


### PR DESCRIPTION
This change introduces an optimization that hoists bounds checks with fixed storage semantics when they operate on the same self value, grouping them together within a basic block to enable downstream optimizations like partial vectorization.

Since the language guarantees the validity of underlying storage for types annotated with fixed storage semantics like Span, InlineArray etc, we don't need to consult alias analysis to perform this optimization.

We have always hoisted cond_fail instructions over side effects in loops. This change enables hoisting over side-effects in blocks.

rdar://164947648 and rdar://166409418