### PR TITLE
[Runtime] Adjust demangle API availability to SwiftStdlib 6.4

### DIFF
--- a/stdlib/public/RuntimeModule/Mangling.swift
+++ b/stdlib/public/RuntimeModule/Mangling.swift
@@ -40,7 +40,7 @@ internal import BacktracingImpl.Runtime
 /// - Throws: When the demangling fails for any reason.
 /// - Warning: The demangled output is lossy is not not guaranteed to be stable across Swift versions.
 ///            Future versions of Swift may choose to print more (or less) information in the demangled format.
-@available(SwiftStdlib 6.3, *)
+@available(SwiftStdlib 6.4, *)
 public func demangle(_ mangledName: String) throws(DemanglingError) -> String {
   var demangledLength: size_t = 0
 
@@ -82,7 +82,7 @@ public func demangle(_ mangledName: String) throws(DemanglingError) -> String {
 /// - Throws: When the demangling failed entirely, and the output span will not have been written to.
 /// - Warning: The demangled output is lossy is not not guaranteed to be stable across Swift versions.
 ///            Future versions of Swift may choose to print more (or less) information in the demangled format.
-@available(SwiftStdlib 6.3, *)
+@available(SwiftStdlib 6.4, *)
 public func demangle(
   _ mangledName: borrowing UTF8Span,
   into output: inout OutputSpan<UTF8.CodeUnit>
@@ -117,7 +117,7 @@ public func demangle(
 }
 
 /// Error thrown to indicate failure to demangle a Swift symbol.
-@available(SwiftStdlib 6.3, *)
+@available(SwiftStdlib 6.4, *)
 public enum DemanglingError: Error {
   /// Demangling resulted in truncating the result. The payload value is the
   /// number of bytes necessary for a full demangle.

--- a/test/Concurrency/Runtime/RuntimeDemangle.swift
+++ b/test/Concurrency/Runtime/RuntimeDemangle.swift
@@ -15,7 +15,7 @@ import StdlibUnittest
 
 var DemangleTests = TestSuite("Demangle")
 
-if #available(SwiftStdlib 6.3, *) {
+if #available(SwiftStdlib 6.4, *) {
   DemangleTests.test("basic string return API") {
     // First, test that we get back 'nil' with invalid input.
     expectEqual(try? demangle("abc123"), nil)


### PR DESCRIPTION
The demangle API (`demangle()`) didn't make it into release/6.3, so its availability should be 6.4.
