### PR TITLE
AST: Reorder platforms in `PlatformKinds.def`

### DIFF
--- a/include/swift/AST/PlatformKinds.def
+++ b/include/swift/AST/PlatformKinds.def
@@ -21,24 +21,30 @@
 #define AVAILABILITY_PLATFORM(X, PrettyName)
 #endif
 
-// Reordering these platforms will break serialization.
+// NOTE: This enum effects serialization. Update SWIFTMODULE_VERSION_MINOR
+// whenever you add a platform or update the ordering.
+
+/// A meta-platform representing the built-in Swift runtime.
+AVAILABILITY_PLATFORM(Swift, "Swift")
+
+/// A meta-platform for Apple operating systems with unified versioning.
+AVAILABILITY_PLATFORM(anyAppleOS, "any Apple OS")
+
+AVAILABILITY_PLATFORM(macOS, "macOS")
 AVAILABILITY_PLATFORM(iOS, "iOS")
 AVAILABILITY_PLATFORM(tvOS, "tvOS")
 AVAILABILITY_PLATFORM(watchOS, "watchOS")
+AVAILABILITY_PLATFORM(macCatalyst, "Mac Catalyst")
 AVAILABILITY_PLATFORM(visionOS, "visionOS")
-AVAILABILITY_PLATFORM(macOS, "macOS")
+AVAILABILITY_PLATFORM(DriverKit, "DriverKit")
+
+AVAILABILITY_PLATFORM(macOSApplicationExtension, "application extensions for macOS")
 AVAILABILITY_PLATFORM(iOSApplicationExtension, "application extensions for iOS")
 AVAILABILITY_PLATFORM(tvOSApplicationExtension, "application extensions for tvOS")
 AVAILABILITY_PLATFORM(watchOSApplicationExtension, "application extensions for watchOS")
-AVAILABILITY_PLATFORM(visionOSApplicationExtension, "application extensions for visionOS")
-AVAILABILITY_PLATFORM(macOSApplicationExtension, "application extensions for macOS")
-AVAILABILITY_PLATFORM(macCatalyst, "Mac Catalyst")
 AVAILABILITY_PLATFORM(macCatalystApplicationExtension, "application extensions for Mac Catalyst")
-AVAILABILITY_PLATFORM(DriverKit, "DriverKit")
-/// A meta-platform representing the built-in Swift runtime.
-AVAILABILITY_PLATFORM(Swift, "Swift")
-/// A meta-platform for Apple operating systems with unified versioning.
-AVAILABILITY_PLATFORM(anyAppleOS, "any Apple OS")
+AVAILABILITY_PLATFORM(visionOSApplicationExtension, "application extensions for visionOS")
+
 AVAILABILITY_PLATFORM(FreeBSD, "FreeBSD")
 AVAILABILITY_PLATFORM(OpenBSD, "OpenBSD")
 AVAILABILITY_PLATFORM(Windows, "Windows")

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 987; // Serialize decl lifetimes instead of their their function types' lifetimes
+const uint16_t SWIFTMODULE_VERSION_MINOR = 988; // re-order platform kinds
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -71,21 +71,21 @@ actor MyGenericGlobalActor<T> {
 
 // AVAILABILITY1: Begin completions
 // AVAILABILITY1-NEXT: Keyword/None:                       *[#Platform#]; name=*{{$}}
+// AVAILABILITY1-NEXT: Keyword/None:                       Swift[#Platform#]; name=Swift{{$}}
+// AVAILABILITY1-NEXT: Keyword/None:                       anyAppleOS[#Platform#]; name=anyAppleOS{{$}}
+// AVAILABILITY1-NEXT: Keyword/None:                       macOS[#Platform#]; name=macOS{{$}}
 // AVAILABILITY1-NEXT: Keyword/None:                       iOS[#Platform#]; name=iOS{{$}}
 // AVAILABILITY1-NEXT: Keyword/None:                       tvOS[#Platform#]; name=tvOS{{$}}
 // AVAILABILITY1-NEXT: Keyword/None:                       watchOS[#Platform#]; name=watchOS{{$}}
+// AVAILABILITY1-NEXT: Keyword/None:                       macCatalyst[#Platform#]; name=macCatalyst
 // AVAILABILITY1-NEXT: Keyword/None:                       visionOS[#Platform#]; name=visionOS{{$}}
-// AVAILABILITY1-NEXT: Keyword/None:                       macOS[#Platform#]; name=macOS{{$}}
+// AVAILABILITY1-NEXT: Keyword/None:                       DriverKit[#Platform#]; name=DriverKit{{$}}
+// AVAILABILITY1-NEXT: Keyword/None:                       macOSApplicationExtension[#Platform#]; name=macOSApplicationExtension{{$}}
 // AVAILABILITY1-NEXT: Keyword/None:                       iOSApplicationExtension[#Platform#]; name=iOSApplicationExtension{{$}}
 // AVAILABILITY1-NEXT: Keyword/None:                       tvOSApplicationExtension[#Platform#]; name=tvOSApplicationExtension{{$}}
 // AVAILABILITY1-NEXT: Keyword/None:                       watchOSApplicationExtension[#Platform#]; name=watchOSApplicationExtension{{$}}
-// AVAILABILITY1-NEXT: Keyword/None:                       visionOSApplicationExtension[#Platform#]; name=visionOSApplicationExtension{{$}}
-// AVAILABILITY1-NEXT: Keyword/None:                       macOSApplicationExtension[#Platform#]; name=macOSApplicationExtension{{$}}
-// AVAILABILITY1-NEXT: Keyword/None:                       macCatalyst[#Platform#]; name=macCatalyst
 // AVAILABILITY1-NEXT: Keyword/None:                       macCatalystApplicationExtension[#Platform#]; name=macCatalystApplicationExtension
-// AVAILABILITY1-NEXT: Keyword/None:                       DriverKit[#Platform#]; name=DriverKit{{$}}
-// AVAILABILITY1-NEXT: Keyword/None:                       Swift[#Platform#]; name=Swift{{$}}
-// AVAILABILITY1-NEXT: Keyword/None:                       anyAppleOS[#Platform#]; name=anyAppleOS{{$}}
+// AVAILABILITY1-NEXT: Keyword/None:                       visionOSApplicationExtension[#Platform#]; name=visionOSApplicationExtension{{$}}
 // AVAILABILITY1-NEXT: Keyword/None:                       FreeBSD[#Platform#]; name=FreeBSD{{$}}
 // AVAILABILITY1-NEXT: Keyword/None:                       OpenBSD[#Platform#]; name=OpenBSD{{$}}
 // AVAILABILITY1-NEXT: Keyword/None:                       Windows[#Platform#]; name=Windows{{$}}

--- a/test/ModuleInterface/actor_availability.swift
+++ b/test/ModuleInterface/actor_availability.swift
@@ -10,7 +10,7 @@
 // CHECK-NOT: #if compiler(>=5.3) && $Actors
 // CHECK:     public actor ActorWithImplicitAvailability {
 public actor ActorWithImplicitAvailability {
-  // CHECK:      @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  // CHECK:      @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
   // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency::UnownedSerialExecutor {
   // CHECK-NEXT:   get
   // CHECK-NEXT: }
@@ -21,7 +21,7 @@ public actor ActorWithImplicitAvailability {
 // CHECK-NEXT: public actor ActorWithExplicitAvailability {
 @available(SwiftStdlib 5.2, *)
 public actor ActorWithExplicitAvailability {
-  // CHECK:      @available(iOS 13.4, tvOS 13.4, watchOS 6.2, macOS 10.15.4, *)
+  // CHECK:      @available(macOS 10.15.4, iOS 13.4, tvOS 13.4, watchOS 6.2, *)
   // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency::UnownedSerialExecutor {
   // CHECK-NEXT:   get
   // CHECK-NEXT: }
@@ -45,7 +45,7 @@ public actor UnavailableActor {
 @available(*, deprecated, message: "Will be unavailable Swift 6")
 @available(swift, obsoleted: 6)
 public actor DeprecatedAndObsoleteInSwift6Actor {
-  // CHECK:      @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  // CHECK:      @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
   // CHECK-NEXT: @available(*, deprecated, message: "Will be unavailable Swift 6")
   // CHECK-NEXT: @available(swift, obsoleted: 6)
   // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency::UnownedSerialExecutor {
@@ -60,7 +60,7 @@ public enum Enum {
   // CHECK-NOT:   #if compiler(>=5.3) && $Actors
   // CHECK:       @_hasMissingDesignatedInitializers public actor NestedActor {
   public actor NestedActor {
-    // CHECK: @available(iOS 13.4, tvOS 13.4, watchOS 6.2, macOS 10.15.4, *)
+    // CHECK: @available(macOS 10.15.4, iOS 13.4, tvOS 13.4, watchOS 6.2, *)
     // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency::UnownedSerialExecutor {
     // CHECK-NEXT:   get
     // CHECK-NEXT: }
@@ -72,7 +72,7 @@ extension Enum {
   // CHECK-NOT: #if compiler(>=5.3) && $Actors
   // CHECK:     @_hasMissingDesignatedInitializers public actor ExtensionNestedActor {
   public actor ExtensionNestedActor {
-    // CHECK:      @available(iOS 13.4, tvOS 13.4, watchOS 6.2, macOS 10.15.4, *)
+    // CHECK:      @available(macOS 10.15.4, iOS 13.4, tvOS 13.4, watchOS 6.2, *)
     // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency::UnownedSerialExecutor {
     // CHECK-NEXT:   get
     // CHECK-NEXT: }
@@ -108,15 +108,15 @@ public struct SPIAvailableStruct {
   // CHECK-NEXT: public actor UnavailableNestedActor
   @available(macOS, unavailable)
   public actor UnavailableNestedActor {
-    // CHECK-PUBLIC:      @available(iOS, unavailable)
+    // CHECK-PUBLIC:      @available(macOS, unavailable)
+    // CHECK-PUBLIC-NEXT: @available(iOS, unavailable)
     // CHECK-PUBLIC-NEXT: @available(tvOS, unavailable)
     // CHECK-PUBLIC-NEXT: @available(watchOS, unavailable)
-    // CHECK-PUBLIC-NEXT: @available(macOS, unavailable)
     // CHECK-PUBLIC-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency::UnownedSerialExecutor
-    // CHECK-PRIVATE: @_spi_available(iOS, introduced: 13.4)
+    // CHECK-PRIVATE:     @_spi_available(macOS, unavailable, introduced: 10.15.4)
+    // CHECK-PRIVATE-NEXT: @_spi_available(iOS, introduced: 13.4)
     // CHECK-PRIVATE-NEXT: @_spi_available(tvOS, introduced: 13.4)
     // CHECK-PRIVATE-NEXT: @_spi_available(watchOS, introduced: 6.2)
-    // CHECK-PRIVATE-NEXT: @_spi_available(macOS, unavailable, introduced: 10.15.4)
     // CHECK-PRIVATE-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency::UnownedSerialExecutor
   }
 }
@@ -128,7 +128,7 @@ public class MacCatalystAvailableClass {
   // CHECK-NOT: #if compiler(>=5.3) && $Actors
   // CHECK:     @_hasMissingDesignatedInitializers public actor NestedActor
   public actor NestedActor {
-    // CHECK:      @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, macCatalyst 13.1, *)
+    // CHECK:      @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0,  macCatalyst 13.1, *)
     // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency::UnownedSerialExecutor
   }
 
@@ -137,7 +137,7 @@ public class MacCatalystAvailableClass {
   // CHECK-NEXT: public actor LessAvailableMacCatalystActor
   @available(macCatalyst 14, *)
   public actor LessAvailableMacCatalystActor {
-    // CHECK:      @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, macCatalyst 14, *)
+    // CHECK:      @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, macCatalyst 14, *)
     // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency::UnownedSerialExecutor
   }
 
@@ -146,7 +146,7 @@ public class MacCatalystAvailableClass {
   // CHECK-NEXT: public actor AvailableiOSAndMacOSNestedActor {
   @available(iOS 15.0, macOS 12.0, *)
   public actor AvailableiOSAndMacOSNestedActor {
-    // CHECK:      @available(iOS 15.0, tvOS 13.0, watchOS 6.0, macOS 12.0, *)
+    // CHECK:      @available(macOS 12.0, iOS 15.0, tvOS 13.0, watchOS 6.0, *)
     // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency::UnownedSerialExecutor
   }
 
@@ -155,7 +155,7 @@ public class MacCatalystAvailableClass {
   // CHECK-NEXT: public actor UnavailableiOSNestedActor
   @available(iOS, unavailable)
   public actor UnavailableiOSNestedActor {
-    // CHECK:      @available(tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+    // CHECK:      @available(macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     // CHECK-NEXT: @available(iOS, unavailable, introduced: 13.0)
     // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency::UnownedSerialExecutor
   }

--- a/test/ModuleInterface/distributed-actor.swift
+++ b/test/ModuleInterface/distributed-actor.swift
@@ -45,7 +45,7 @@ public distributed actor DA {
   // CHECK-NEXT:    get
   // CHECK-NEXT:  }
   // CHECK:       public init(actorSystem system: Library::DA.Library::ActorSystem)
-  // CHECK:       @available(iOS 16.0, tvOS 16.0, watchOS 9.0, macOS 13.0, *)
+  // CHECK:       @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
   // CHECK-NEXT:  @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency::UnownedSerialExecutor {
   // CHECK-NEXT:    get
   // CHECK-NEXT:  }
@@ -67,7 +67,7 @@ public distributed actor DAG<ActorSystem> where ActorSystem: DistributedActorSys
 // CHECK:   get
 // CHECK: }
 // CHECK: public init(actorSystem system: ActorSystem)
-// CHECK: @available(iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, macOS 15.0, *)
+// CHECK: @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 // CHECK: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency::UnownedSerialExecutor {
 // CHECK:   get
 // CHECK: }

--- a/test/ModuleInterface/property_wrapper_availability.swift
+++ b/test/ModuleInterface/property_wrapper_availability.swift
@@ -31,9 +31,9 @@ public struct HasWrappers {
   // CHECK: @available(macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4, *)
   // CHECK-NEXT: @Library::ConditionallyAvailableWrapper<Swift::Int> public var x: Swift::Int {
   // CHECK-NEXT:   get
-  // CHECK-NEXT:   @available(iOS 13.4, tvOS 13.4, watchOS 6.2, macOS 10.15.4, *)
+  // CHECK-NEXT:   @available(macOS 10.15.4, iOS 13.4, tvOS 13.4, watchOS 6.2, *)
   // CHECK-NEXT:   set
-  // CHECK-NEXT:   @available(iOS 13.4, tvOS 13.4, watchOS 6.2, macOS 10.15.4, *)
+  // CHECK-NEXT:   @available(macOS 10.15.4, iOS 13.4, tvOS 13.4, watchOS 6.2, *)
   // CHECK-NEXT:   _modify
   // CHECK-NEXT: }
   @available(SwiftStdlib 5.2, *)
@@ -52,15 +52,15 @@ public struct HasWrappers {
 public struct UnavailableHasWrappers {
   // CHECK-LABEL:   @Library::UnavailableWrapper<Swift::Int> public var x: Swift::Int {
   // CHECK-NEXT:      get
+  // CHECK-NEXT:      @available(macOS, unavailable)
   // CHECK-NEXT:      @available(iOS, unavailable)
   // CHECK-NEXT:      @available(tvOS, unavailable)
   // CHECK-NEXT:      @available(watchOS, unavailable)
-  // CHECK-NEXT:      @available(macOS, unavailable)
   // CHECK-NEXT:      set
+  // CHECK-NEXT:      @available(macOS, unavailable)
   // CHECK-NEXT:      @available(iOS, unavailable)
   // CHECK-NEXT:      @available(tvOS, unavailable)
   // CHECK-NEXT:      @available(watchOS, unavailable)
-  // CHECK-NEXT:      @available(macOS, unavailable)
   // CHECK-NEXT:      _modify
   // CHECK-NEXT:    }
   @UnavailableWrapper public var x: Int


### PR DESCRIPTION
This allows stable sorting of availability domains to result in an order that looks more natural when printed in swiftinterface files.
