### PR TITLE
TempRValueElimination: bail in non-OSSA if the stack liverange has exit edges

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/TempRValueElimination.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/TempRValueElimination.swift
@@ -158,6 +158,11 @@ private extension AllocStackInst {
 
     liferange.insert(contentsOf: uses.ignore(usersOfType: DeallocStackInst.self).lazy.map { $0.instruction })
 
+    guard liferange.exitBlocks.isEmpty else {
+      // If there is no use on a path leaving the liverange, we don't know how the value is destroyed there.
+      return false
+    }
+
     for use in uses {
       switch use.instruction {
       case is DeallocStackInst, is DestroyAddrInst:

--- a/test/SILOptimizer/temp_rvalue_opt.sil
+++ b/test/SILOptimizer/temp_rvalue_opt.sil
@@ -856,3 +856,31 @@ bb0(%0 : $*NC):
   return %r
 }
 
+// CHECK-LABEL: sil @unknown_last_use_on_liverange_exit
+// CHECK:         copy_addr %1 to [init] %3
+// CHECK-LABEL: } // end sil function 'unknown_last_use_on_liverange_exit'
+sil @unknown_last_use_on_liverange_exit : $@convention(thin) (@in_guaranteed (AnyObject, Klass), @inout Klass) -> @out AnyObject {
+bb0(%0 : $*AnyObject, %1 : $*(AnyObject, Klass), %2 : $*Klass):
+  %3 = alloc_stack [lexical] [var_decl] $(AnyObject, Klass)
+  copy_addr %1 to [init] %3
+  %5 = tuple_element_addr %3, 0
+  %6 = tuple_element_addr %3, 1
+  cond_br undef, bb1, bb2
+
+bb1:
+  %8 = load %6
+  copy_addr [take] %5 to [init] %0
+  store %8 to %2
+  br bb3
+
+bb2:
+  destroy_addr %3
+  br bb3
+
+bb3:
+  dealloc_stack %3
+  %15 = tuple ()
+  return %15
+}
+
+


### PR DESCRIPTION
If there is no use on a path leaving the liverange, we don't know how the value is destroyed there.

Fixes a miscompile
rdar://171676249
