### PR TITLE
[cxx-interop] Support pointers to C types in reverse interop

### DIFF
--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -67,8 +67,7 @@ KnownTypeKind isKnownType(Type t, PrimitiveTypeMapping &typeMapping,
   }
 
   const TypeDecl *typeDecl;
-  auto *tPtr = t->isOptional() ? t->getOptionalObjectType()->getDesugaredType()
-                               : t->getDesugaredType();
+  auto *tPtr = t->lookThroughSingleOptionalType()->getDesugaredType();
   if (auto *bgt = dyn_cast<BoundGenericStructType>(tPtr)) {
     return (bgt->isUnsafePointer() || bgt->isUnsafeMutablePointer())
                ? KnownTypeKind::Known
@@ -82,9 +81,7 @@ KnownTypeKind isKnownType(Type t, PrimitiveTypeMapping &typeMapping,
                                 : KnownTypeKind::Known;
   }
   if (auto *classType = dyn_cast<ClassType>(tPtr)) {
-    return (classType->getClassOrBoundGenericClass()->hasClangNode() &&
-            isa<clang::ObjCInterfaceDecl>(
-                classType->getClassOrBoundGenericClass()->getClangDecl()))
+    return (classType->getClassOrBoundGenericClass()->hasClangNode())
                ? KnownTypeKind::Known
                : KnownTypeKind::Unknown;
   }
@@ -491,15 +488,23 @@ public:
 
     auto args = BGT->getGenericArgs();
     assert(args.size() == 1);
-    llvm::SaveAndRestore<FunctionSignatureTypeUse> typeUseNormal(
-        typeUseKind, FunctionSignatureTypeUse::TypeReference);
-    // FIXME: We can definitely support pointers to known Clang types.
-    if (isKnownCType(args.front(), typeMapping, BGT->getASTContext()) ==
-        KnownTypeKind::Unknown)
-      return ClangRepresentation(ClangRepresentation::unsupported);
-    auto partRepr = visitPart(args.front(), OTK_None, /*isInOutParam=*/false);
-    if (partRepr.isUnsupported())
-      return partRepr;
+    auto arg = args.front();
+    if (const auto *structDecl = arg->getStructOrBoundGenericStruct();
+        structDecl && structDecl->getClangDecl()) {
+      ClangTypeHandler handler(structDecl->getClangDecl());
+      if (!handler.isRepresentable())
+        return ClangRepresentation::unsupported;
+      handler.printTypeName(structDecl->getASTContext(), os);
+    } else {
+      llvm::SaveAndRestore<FunctionSignatureTypeUse> typeUseNormal(
+          typeUseKind, FunctionSignatureTypeUse::TypeReference);
+      if (isKnownCType(arg, typeMapping, BGT->getASTContext()) ==
+          KnownTypeKind::Unknown)
+        return ClangRepresentation(ClangRepresentation::unsupported);
+      auto partRepr = visitPart(arg, OTK_None, /*isInOutParam=*/false);
+      if (partRepr.isUnsupported())
+        return partRepr;
+    }
     if (isConst)
       os << " const";
     os << " *";
@@ -524,6 +529,10 @@ public:
   visitBoundGenericEnumType(BoundGenericEnumType *BGT,
                             std::optional<OptionalTypeKind> optionalKind,
                             bool isInOutParam) {
+    if (optionalKind == OTK_None) {
+      if (auto objTy = BGT->getOptionalObjectType())
+        return visitPart(objTy, OTK_Optional, isInOutParam);
+    }
     return visitValueType(BGT, BGT->getDecl(), optionalKind, isInOutParam,
                           BGT->getGenericArgs());
   }

--- a/test/Interop/CxxToSwiftToObjC/bridge-cxx-types-to-objc.swift
+++ b/test/Interop/CxxToSwiftToObjC/bridge-cxx-types-to-objc.swift
@@ -7,5 +7,4 @@ import CxxModule
 
 public func bar(x: Foo, y: UnsafeMutablePointer<UnsafeMutableRawPointer?>) {}
 
-// CHECK: // Unavailable in C++: Swift global function 'bar(x:y:)'.
-// TODO: the message above is not correct, this is actually unavailable in Obj-C.
+// CHECK: void bar(const Foo& x, void * _Nullable * _Nonnull y) noexcept

--- a/test/Interop/SwiftToCxx/functions/Inputs/c-pointer-types.h
+++ b/test/Interop/SwiftToCxx/functions/Inputs/c-pointer-types.h
@@ -1,0 +1,15 @@
+#pragma once
+
+struct CGImageBlock {
+    int width;
+    int height;
+};
+
+typedef struct CGImageBlock *CGImageBlockRef;
+
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:Retain")))
+__attribute__((swift_attr("release:Release"))) FRT {};
+
+static inline void Retain(struct FRT *x) {}
+static inline void Release(struct FRT *x) {}

--- a/test/Interop/SwiftToCxx/functions/Inputs/module.modulemap
+++ b/test/Interop/SwiftToCxx/functions/Inputs/module.modulemap
@@ -1,0 +1,4 @@
+module CPointerTypes {
+  header "c-pointer-types.h"
+  export *
+}

--- a/test/Interop/SwiftToCxx/functions/swift-pointer-to-optional-c-typedef-cxx-bridging.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-pointer-to-optional-c-typedef-cxx-bridging.swift
@@ -1,0 +1,27 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name Functions -cxx-interoperability-mode=default -clang-header-expose-decls=all-public -I %S/Inputs/ -typecheck -verify -emit-clang-header-path %t/functions.h -disable-availability-checking
+
+// RUN: %FileCheck %s < %t/functions.h
+
+import CPointerTypes
+
+public func takesPointerToStruct(_ x: UnsafeMutablePointer<CGImageBlock>) {
+}
+
+public func takesPointerToOptionalRef(_ x: UnsafeMutablePointer<CGImageBlockRef?>) {
+}
+
+public func takesPointerToOptionalForeignRef(_ x: UnsafeMutablePointer<FRT?>) {
+}
+
+public func takesOptionalRef(_ x: CGImageBlockRef?) {
+}
+
+public func takesOptionalForeignRef(_ x: FRT?) {
+}
+
+// CHECK: SWIFT_INLINE_THUNK void takesOptionalForeignRef(FRT *_Nullable x) noexcept
+// CHECK: SWIFT_INLINE_THUNK void takesOptionalRef(CGImageBlock * _Nullable x) noexcept
+// CHECK: SWIFT_INLINE_THUNK void takesPointerToOptionalForeignRef(FRT *_Nullable * _Nonnull x) noexcept
+// CHECK: SWIFT_INLINE_THUNK void takesPointerToOptionalRef(CGImageBlock * _Nullable * _Nonnull x) noexcept
+// CHECK: SWIFT_INLINE_THUNK void takesPointerToStruct(CGImageBlock * _Nonnull x) noexcept


### PR DESCRIPTION
Previously, we never exported Swift functions that have pointers to C or C++ structs in their signature. These pointers are always safe to pass, we have declarations on the C/C++ side and we have no ABI issues.

rdar://172205792
