### PR TITLE
[Concurrency] Assume `nonisolated(nonsending)` onto a `@Sendable` closure more aggressively

### DIFF
--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -2473,7 +2473,13 @@ lowerCaptureContextParameters(TypeConverter &TC, SILDeclRef function,
       }
 
       if (isolatedParam == varDecl) {
-        options |= SILParameterInfo::Isolated;
+        auto isolation = function.getActorIsolation();
+        // The function has to be isolated to this capture for it to be marked
+        // as `isolated`. It's possible to i.e. have a `nonisolated(nonsending)`
+        // closure that captures and isolated parameter.
+        if (isolation.isActorInstanceIsolated() &&
+            isolation.getActorInstance() == isolatedParam)
+          options |= SILParameterInfo::Isolated;
         isolatedParam = nullptr;
       }
     }

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -413,6 +413,19 @@ public:
       Flags |= CapturedValue::IsNoEscape;
 
     addCapture(CapturedValue(D, Flags, DRE->getStartLoc()));
+
+    // Check is the local function captures and isolated parameter, and if so
+    // propagate it up.
+    if (auto *F = dyn_cast<FuncDecl>(D)) {
+      auto isolation = getActorIsolation(F);
+
+      if (isolation.isActorInstanceIsolated() &&
+          isolation.isActorInstanceForCapture()) {
+        addCapture(CapturedValue(isolation.getActorInstance(), Flags,
+                                 DRE->getStartLoc()));
+      }
+    }
+
     return Action::SkipNode(DRE);
   }
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4891,16 +4891,12 @@ ActorIsolationChecker::determineClosureIsolation(AbstractClosureExpr *closure,
     // global actor, nonisolated/@concurrent attributes and doesn't have
     // isolated parameters. If our closure is nonisolated and we have a
     // conversion to nonisolated(nonsending), then we should respect that.
-    if (auto *explicitClosure = dyn_cast<ClosureExpr>(closure);
-        isIsolationBoundary || !normalIsolation.isGlobalActor()) {
+    if (isIsolationBoundary || normalIsolation.isNonisolated()) {
       if (auto *fce = dyn_cast_or_null<FunctionConversionExpr>(context)) {
         auto expectedIsolation =
             fce->getType()->castTo<FunctionType>()->getIsolation();
-        if (expectedIsolation.isNonIsolatedCaller()) {
-          auto captureInfo = explicitClosure->getCaptureInfo();
-          if (!captureInfo.getIsolatedParamCapture())
-            return ActorIsolation::forCallerIsolationInheriting();
-        }
+        if (expectedIsolation.isNonIsolatedCaller())
+          return ActorIsolation::forCallerIsolationInheriting();
       }
     }
 

--- a/test/Concurrency/attr_execution/conversions_silgen.swift
+++ b/test/Concurrency/attr_execution/conversions_silgen.swift
@@ -713,3 +713,74 @@ nonisolated(nonsending) func localVariableAssignmentConversion() async {
   let c2 = globalCallerFunc
   await c2()
 }
+
+// Make sure that when an isolated parameter is captured it's not marked as `isolated` when a closure is not isolated to it.
+func testConversionsToSendable() {
+  func compute(_: nonisolated(nonsending) () async -> Void) async {}
+  func sendableCompute(_: nonisolated(nonsending) @Sendable () async -> Void) async {}
+
+  func testActorCapture(a: A) {
+    // CHECK: // closure #1 in testActorCapture #1 (a:) in testConversionsToSendable()
+    // CHECK: // Isolation: caller_isolation_inheriting
+    // CHECK: sil private [ossa] @$s21attr_execution_silgen25testConversionsToSendableyyF0D12ActorCaptureL_1ayAaByyF1AL_C_tFyyYaYbYCcfU_ : $@convention(thin) @Sendable @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed A) -> ()
+    let _: nonisolated(nonsending) @Sendable () async -> Void = {
+      _ = await a.test()
+    }
+  }
+
+  func testIsolatedParameter(isolation: isolated (any Actor)?) async {
+    // CHECK: // closure #1 in testIsolatedParameter #1 (isolation:) in testConversionsToSendable()
+    // CHECK: // Isolation: caller_isolation_inheriting
+    // CHECK: sil private [ossa] @$s21attr_execution_silgen25testConversionsToSendableyyF0D17IsolatedParameterL_9isolationyScA_pSgYi_tYaFyyYaYbYCcfU_ : $@convention(thin) @Sendable @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed Optional<any Actor>) -> ()
+    let _: nonisolated(nonsending) @Sendable () async -> Void = {
+      _ = isolation
+    }
+
+    // Passing a closure to a non-Sendable parameter doesn't make it "boundary" and so allows it to be isolated to the capture.
+    // CHECK: // closure #2 in testIsolatedParameter #1 (isolation:) in testConversionsToSendable()
+    // CHECK: // Isolation: actor_instance. name: 'isolation'
+    // CHECK: sil private [ossa] @$s21attr_execution_silgen25testConversionsToSendableyyF0D17IsolatedParameterL_9isolationyScA_pSgYi_tYaFyyYaXEfU0_ : $@convention(thin) @async (@sil_isolated @guaranteed Optional<any Actor>) -> ()
+    await compute {
+      _ = isolation
+    }
+
+    // Here on the other hand the parameter is `@Sendable` which means that closure cannot be isolated to its parent context and can assume `nonisolated(nonsending)` isolation.
+    // CHECK: // closure #3 in testIsolatedParameter #1 (isolation:) in testConversionsToSendable()
+    // CHECK: // Isolation: caller_isolation_inheriting
+    // CHECK: sil private [ossa] @$s21attr_execution_silgen25testConversionsToSendableyyF0D17IsolatedParameterL_9isolationyScA_pSgYi_tYaFyyYaYbYCXEfU1_ : $@convention(thin) @Sendable @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed Optional<any Actor>) -> ()
+    await sendableCompute {
+      _ = isolation
+    }
+  }
+
+  actor A {
+    func test() {}
+
+    func testLocalCapture() async {
+      func local() {}
+
+      // CHECK: // closure #1 in testLocalCapture() in A #1 in testConversionsToSendable()
+      // CHECK: // Isolation: caller_isolation_inheriting
+      // CHECK: sil private [ossa] @$s21attr_execution_silgen25testConversionsToSendableyyF1AL_C0D12LocalCaptureyyYaFyyYaYCXEfU_ : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed A) -> ()
+      await compute {
+        local()
+      }
+    }
+
+    func testSelfCapture() async {
+      // CHECK: // closure #1 in testSelfCapture() in A #1 in testConversionsToSendable()
+      // CHECK: // Isolation: caller_isolation_inheriting
+      // CHECK: sil private [ossa] @$s21attr_execution_silgen25testConversionsToSendableyyF1AL_C0D11SelfCaptureyyYaFyyYaYbYCXEfU_ : $@convention(thin) @Sendable @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed A) -> ()
+      await sendableCompute {
+        _ = self
+      }
+
+      // CHECK: // closure #2 in testSelfCapture() in A #1 in testConversionsToSendable()
+      // CHECK: // Isolation: global_actor. type: MainActor
+      // CHECK: sil private [ossa] @$s21attr_execution_silgen25testConversionsToSendableyyF1AL_C0D11SelfCaptureyyYaFyyYaYbScMYcXEfU0_ : $@convention(thin) @Sendable @async (@guaranteed A) -> ()
+      await sendableCompute { @MainActor in
+        _ = self
+      }
+    }
+  }
+}

--- a/test/Concurrency/attr_execution/conversions_silgen.swift
+++ b/test/Concurrency/attr_execution/conversions_silgen.swift
@@ -753,15 +753,45 @@ func testConversionsToSendable() {
     }
   }
 
+  func testCaptureWithParameter(isolation: isolated (any Actor)? = nil) async {
+    // CHECK: // local #1 @Sendable (_:) in testCaptureWithParameter #1 (isolation:) in testConversionsToSendable()
+    // CHECK: // Isolation: actor_instance. name: '_'
+    // CHECK: sil private [ossa] @$s21attr_execution_silgen25testConversionsToSendableyyF0D20CaptureWithParameterL_9isolationyScA_pSgYi_tYaF5localL_yyAEYiYaYbF : $@convention(thin) @Sendable @async (@sil_isolated @guaranteed Optional<any Actor>) -> ()
+    @Sendable func local(_: isolated (any Actor)? = nil) async { }
+
+    // CHECK: // closure #1 in testCaptureWithParameter #1 (isolation:) in testConversionsToSendable()
+    // CHECK: // Isolation: caller_isolation_inheriting
+    // CHECK: sil private [ossa] @$s21attr_execution_silgen25testConversionsToSendableyyF0D20CaptureWithParameterL_9isolationyScA_pSgYi_tYaFyyYaYbYCXEfU_ : $@convention(thin) @Sendable @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor) -> () {
+    // CHECK: hop_to_executor %0
+    // CHECK: [[GENERIC_EXEC:%.*]] = enum $Optional<any Actor>, #Optional.none!enumelt
+    // CHECK: [[LOCAL:%.*]] = function_ref @$s21attr_execution_silgen25testConversionsToSendableyyF0D20CaptureWithParameterL_9isolationyScA_pSgYi_tYaF5localL_yyAEYiYaYbF
+    // CHECK: apply [[LOCAL]]([[GENERIC_EXEC]]) : $@convention(thin) @Sendable @async (@sil_isolated @guaranteed Optional<any Actor>) -> ()
+    // CHECK: hop_to_executor %0
+    // CHECK: } // end sil function '$s21attr_execution_silgen25testConversionsToSendableyyF0D20CaptureWithParameterL_9isolationyScA_pSgYi_tYaFyyYaYbYCXEfU_'
+    await sendableCompute {
+      await local()
+    }
+
+    // CHECK: // closure #2 in testCaptureWithParameter #1 (isolation:) in testConversionsToSendable()
+    // CHECK: // Isolation: caller_isolation_inheriting
+    // CHECK: sil private [ossa] @$s21attr_execution_silgen25testConversionsToSendableyyF0D20CaptureWithParameterL_9isolationyScA_pSgYi_tYaFyyYaYbYCXEfU0_ : $@convention(thin) @Sendable @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed Optional<any Actor>) -> ()
+    // CHECK: hop_to_executor %0
+    // CHECK: [[LOCAL:%.*]] = function_ref @$s21attr_execution_silgen25testConversionsToSendableyyF0D20CaptureWithParameterL_9isolationyScA_pSgYi_tYaF5localL_yyAEYiYaYbF
+    // CHECK: apply [[LOCAL]](%1) : $@convention(thin) @Sendable @async (@sil_isolated @guaranteed Optional<any Actor>) -> ()
+    // CHECK: } // end sil function '$s21attr_execution_silgen25testConversionsToSendableyyF0D20CaptureWithParameterL_9isolationyScA_pSgYi_tYaFyyYaYbYCXEfU0_'
+    await sendableCompute {
+      await local(isolation)
+    }
+  }
+
   actor A {
     func test() {}
 
     func testLocalCapture() async {
-      func local() {}
+      @Sendable func local() {}
 
       // CHECK: // closure #1 in testLocalCapture() in A #1 in testConversionsToSendable()
-      // CHECK: // Isolation: caller_isolation_inheriting
-      // CHECK: sil private [ossa] @$s21attr_execution_silgen25testConversionsToSendableyyF1AL_C0D12LocalCaptureyyYaFyyYaYCXEfU_ : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed A) -> ()
+      // CHECK: // Isolation: actor_instance. name: 'self'
       await compute {
         local()
       }

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -strict-concurrency=complete %s -emit-sil -o /dev/null -verify
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -strict-concurrency=complete %s -emit-sil -verify | %FileCheck %s
 
 // REQUIRES: asserts
 // REQUIRES: concurrency
@@ -342,4 +342,27 @@ struct WritableActorKeyPath<Root: Actor, Value>: Sendable {
         get { getter(root) }
         nonmutating set { setter(root, newValue) }
     }
+}
+
+func testLocalFunctionAndAutoclosure() {
+  func check(_: @autoclosure () -> Void) {}
+  func checkWithClosure(_: () -> Void) {}
+
+  func test(isolation: isolated (any Actor)? = #isolation) async {
+    let result: Int = 0
+
+    func local() {
+      _ = result
+    }
+
+    // CHECK: // implicit closure #1 in test #1 (isolation:) in testLocalFunctionAndAutoclosure()
+    // CHECK: // Isolation: actor_instance. name: 'isolation'
+    // CHECK: sil private [transparent] @$s19isolated_parameters31testLocalFunctionAndAutoclosureyyF0C0L_9isolationyScA_pSgYi_tYaFyyXEfu_ : $@convention(thin) (Int, @sil_isolated @guaranteed Optional<any Actor>) -> ()
+    check(local()) // Ok
+
+    // CHECK: // closure #1 in test #1 (isolation:) in testLocalFunctionAndAutoclosure()
+    // CHECK: // Isolation: actor_instance. name: 'isolation'
+    // CHECK: sil private @$s19isolated_parameters31testLocalFunctionAndAutoclosureyyF0C0L_9isolationyScA_pSgYi_tYaFyyXEfU_ : $@convention(thin) (Int, @sil_isolated @guaranteed Optional<any Actor>) -> ()
+    checkWithClosure { local() } // Ok
+  }
 }

--- a/test/Concurrency/transfernonsendable_closureliterals_isolationinference.swift
+++ b/test/Concurrency/transfernonsendable_closureliterals_isolationinference.swift
@@ -378,11 +378,11 @@ extension MyActor {
         normalAcceptsAsyncClosure { print(self) }
 
         // CHECK-LABEL: closure #2 in MyActor.test_CallerSyncNormal_CalleeAsyncNonIsolated()
-        // CHECK-NEXT: Isolation: nonisolated
+        // CHECK-NEXT: Isolation: {{nonisolated|caller_isolation_inheriting}}
         normalAcceptsSendingAsyncClosure { print(self) }
 
         // CHECK-LABEL: // closure #3 in MyActor.test_CallerSyncNormal_CalleeAsyncNonIsolated()
-        // CHECK-NEXT: // Isolation: nonisolated
+        // CHECK-NEXT: // Isolation: {{nonisolated|caller_isolation_inheriting}}
         normalAcceptsSendableAsyncClosure { print(self) }
     }
 
@@ -410,11 +410,11 @@ extension MyActor {
         // expected-ni-ns-note @-4 {{sending 'self'-isolated value of non-Sendable type '@concurrent () async -> ()' to main actor-isolated global function 'normalGlobalActorAcceptsAsyncClosure' risks causing races in between 'self'-isolated and main actor-isolated uses}}
 
         // CHECK-LABEL: // closure #2 in MyActor.test_CallerSyncNormal_CalleeAsyncMainActorIsolated()
-        // CHECK-NEXT: // Isolation: nonisolated
+        // CHECK-NEXT: // Isolation: {{nonisolated|caller_isolation_inheriting}}
         await normalGlobalActorAcceptsSendingAsyncClosure { print(self) }
 
         // CHECK-LABEL: // closure #3 in MyActor.test_CallerSyncNormal_CalleeAsyncMainActorIsolated()
-        // CHECK-NEXT: // Isolation: nonisolated
+        // CHECK-NEXT: // Isolation: {{nonisolated|caller_isolation_inheriting}}
         await normalGlobalActorAcceptsSendableAsyncClosure { print(self) }
     }
 
@@ -489,11 +489,11 @@ extension MyActor {
         // expected-ni-note @-1 {{sending 'self'-isolated value of non-Sendable type '() async -> ()' to nonisolated global function 'asyncNormalAcceptsAsyncClosure' risks causing races in between 'self'-isolated and nonisolated uses}}
 
         // CHECK-LABEL: closure #2 in MyActor.test_CallerAsyncNormal_CalleeAsyncNonIsolated()
-        // CHECK-NEXT: Isolation: nonisolated
+        // CHECK-NEXT: Isolation: {{nonisolated|caller_isolation_inheriting}}
         await asyncNormalAcceptsSendingAsyncClosure { print(self) }
 
         // CHECK-LABEL: // closure #3 in MyActor.test_CallerAsyncNormal_CalleeAsyncNonIsolated()
-        // CHECK-NEXT: // Isolation: nonisolated
+        // CHECK-NEXT: // Isolation: {{nonisolated|caller_isolation_inheriting}}
         await asyncNormalAcceptsSendableAsyncClosure { print(self) }
     }
 
@@ -529,11 +529,11 @@ extension MyActor {
         // expected-ni-ns-note @-4 {{sending 'self'-isolated value of non-Sendable type '@concurrent () async -> ()' to main actor-isolated global function 'asyncNormalGlobalActorAcceptsAsyncClosure' risks causing races in between 'self'-isolated and main actor-isolated uses}}
 
         // CHECK-LABEL: // closure #2 in MyActor.test_CallerAsyncNormal_CalleeAsyncMainActorIsolated()
-        // CHECK-NEXT: // Isolation: nonisolated
+        // CHECK-NEXT: // Isolation: {{nonisolated|caller_isolation_inheriting}}
         await asyncNormalGlobalActorAcceptsSendingAsyncClosure { print(self) }
 
         // CHECK-LABEL: // closure #3 in MyActor.test_CallerAsyncNormal_CalleeAsyncMainActorIsolated()
-        // CHECK-NEXT: // Isolation: nonisolated
+        // CHECK-NEXT: // Isolation: {{nonisolated|caller_isolation_inheriting}}
         await asyncNormalGlobalActorAcceptsSendableAsyncClosure { print(self) }
     }
 


### PR DESCRIPTION
`@Sendable` closures don't assume isolation from their parent context,
which means that i.e. they cannot be isolated to an isolated parameter
or `self` capture and it's possible to assume contextual `nonisolated(nonsending)`
isolation on them directly (if none other is specified explicitly) instead
of using a conversion.

Resolves: rdar://172172582
Resolves: https://github.com/swiftlang/swift/issues/86170
Resolves: https://github.com/swiftlang/swift/issues/87768

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
