### PR TITLE
ModuleInterface: Improve availability inference for synthesized conformances

### DIFF
--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -453,18 +453,21 @@ class InheritedProtocolCollector {
       return cache.value();
 
     cache.emplace();
+    llvm::SmallVector<SemanticAvailableAttr, 8> pendingAttrs;
     while (D) {
       for (auto nextAttr : D->getSemanticAvailableAttrs()) {
         // FIXME: This is just approximating the effects of nested availability
         // attributes for the same platform; formally they'd need to be merged.
         bool alreadyHasMoreSpecificAttrForThisPlatform = llvm::any_of(
             *cache, [nextAttr](SemanticAvailableAttr existingAttr) {
-              return existingAttr.getDomain() == nextAttr.getDomain();
+              return existingAttr.getDomain().contains(nextAttr.getDomain());
             });
         if (alreadyHasMoreSpecificAttrForThisPlatform)
           continue;
-        cache->push_back(nextAttr);
+        pendingAttrs.push_back(nextAttr);
       }
+      cache->append(pendingAttrs);
+      pendingAttrs.clear();
       D = D->getDeclContext()->getAsDecl();
     }
 

--- a/test/ModuleInterface/synthesized-conformances.swift
+++ b/test/ModuleInterface/synthesized-conformances.swift
@@ -14,9 +14,9 @@ public enum HasRawValue: Int {
   // CHECK-DAG: }
 } // CHECK: {{^}$}}
 
-// CHECK-LABEL: @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+// CHECK-LABEL: @available(macOS 14, iOS 17, watchOS 10, tvOS 17, *)
 // CHECK-NEXT: public enum HasRawValueAndAvailability : Swift::Int {
-@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+@available(macOS 14, iOS 17, watchOS 10, tvOS 17, *)
 public enum HasRawValueAndAvailability: Int {
   // CHECK-NEXT: case a, b, c
   case a, b, c
@@ -26,6 +26,49 @@ public enum HasRawValueAndAvailability: Int {
   // CHECK-DAG:   get{{$}}
   // CHECK-DAG: }
 } // CHECK: {{^}$}}
+
+// CHECK-LABEL: @available(macOS 14, iOS 17, watchOS 10, tvOS 17, *)
+// CHECK-NEXT: public struct HasNestedTypesAndAvailability {
+@available(macOS 14, iOS 17, watchOS 10, tvOS 17, *)
+public struct HasNestedTypesAndAvailability {
+  // CHECK-LABEL: public enum HasRawValue : Swift::Int {
+  public enum HasRawValue: Int {
+    // CHECK-NEXT: case a
+    case a
+  }
+
+  // CHECK-LABEL: @available(macOS 15, iOS 18, watchOS 11, tvOS 18, visionOS 2, *)
+  // CHECK-NEXT: public enum HasRawValueAndRefinedAvailability : Swift::Int {
+  @available(macOS 15, iOS 18, watchOS 11, tvOS 18, visionOS 2, *)
+  public enum HasRawValueAndRefinedAvailability: Int {
+    // CHECK-NEXT: case a
+    case a
+  }
+
+  // CHECK-LABEL: @available(visionOS 2.1, iOS 18, *)
+  // CHECK-NEXT: public enum HasRawValueAndVisionOSAvailabilityFirst : Swift::Int {
+  @available(visionOS 2.1, iOS 18, *)
+  public enum HasRawValueAndVisionOSAvailabilityFirst: Int {
+    // CHECK-NEXT: case a
+    case a
+  }
+
+  // CHECK-LABEL: @available(anyAppleOS 26, *)
+  // CHECK-NEXT: public enum HasRawValueAndAnyAppleOSAvailability : Swift::Int {
+  @available(anyAppleOS 26, *)
+  public enum HasRawValueAndAnyAppleOSAvailability: Int {
+    // CHECK-NEXT: case a
+    case a
+  }
+
+  // CHECK-LABEL: @available(*, deprecated, message: "Use something else")
+  // CHECK-NEXT: public enum HasRawValueUniversallyDeprecated : Swift::Int {
+  @available(*, deprecated, message: "Use something else")
+  public enum HasRawValueUniversallyDeprecated: Int {
+    // CHECK-NEXT: case a
+    case a
+  }
+}
 
 @objc public enum ObjCEnum: Int32 {
   case a, b = 5, c
@@ -62,12 +105,51 @@ extension NoRawValueWithExplicitHashable : Hashable {
 // CHECK: extension synthesized::HasRawValue : Swift::Hashable {}
 // CHECK: extension synthesized::HasRawValue : Swift::RawRepresentable {}
 
-// CHECK: @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+// CHECK: @available(macOS 14, iOS 17, watchOS 10, tvOS 17, *)
 // CHECK-NEXT: extension synthesized::HasRawValueAndAvailability : Swift::Equatable {}
-// CHECK: @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+// CHECK: @available(macOS 14, iOS 17, watchOS 10, tvOS 17, *)
 // CHECK-NEXT: extension synthesized::HasRawValueAndAvailability : Swift::Hashable {}
-// CHECK: @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+// CHECK: @available(macOS 14, iOS 17, watchOS 10, tvOS 17, *)
 // CHECK-NEXT: extension synthesized::HasRawValueAndAvailability : Swift::RawRepresentable {}
+
+// CHECK: @available(macOS 14, iOS 17, watchOS 10, tvOS 17, *)
+// CHECK-NEXT: extension synthesized::HasNestedTypesAndAvailability.synthesized::HasRawValue : Swift::Equatable {}
+// CHECK: @available(macOS 14, iOS 17, watchOS 10, tvOS 17, *)
+// CHECK-NEXT: extension synthesized::HasNestedTypesAndAvailability.synthesized::HasRawValue : Swift::Hashable {}
+// CHECK: @available(macOS 14, iOS 17, watchOS 10, tvOS 17, *)
+// CHECK-NEXT: extension synthesized::HasNestedTypesAndAvailability.synthesized::HasRawValue : Swift::RawRepresentable {}
+
+// CHECK: @available(macOS 15, iOS 18, watchOS 11, tvOS 18, visionOS 2, *)
+// CHECK-NEXT: extension synthesized::HasNestedTypesAndAvailability.synthesized::HasRawValueAndRefinedAvailability : Swift::Equatable {}
+// CHECK: @available(macOS 15, iOS 18, watchOS 11, tvOS 18, visionOS 2, *)
+// CHECK-NEXT: extension synthesized::HasNestedTypesAndAvailability.synthesized::HasRawValueAndRefinedAvailability : Swift::Hashable {}
+// CHECK: @available(macOS 15, iOS 18, watchOS 11, tvOS 18, visionOS 2, *)
+// CHECK-NEXT: extension synthesized::HasNestedTypesAndAvailability.synthesized::HasRawValueAndRefinedAvailability : Swift::RawRepresentable {}
+
+// CHECK: @available(macOS 14, watchOS 10, tvOS 17, visionOS 2.1, iOS 18, *)
+// CHECK-NEXT: extension synthesized::HasNestedTypesAndAvailability.synthesized::HasRawValueAndVisionOSAvailabilityFirst : Swift::Equatable {}
+// CHECK: @available(macOS 14, watchOS 10, tvOS 17, visionOS 2.1, iOS 18, *)
+// CHECK-NEXT: extension synthesized::HasNestedTypesAndAvailability.synthesized::HasRawValueAndVisionOSAvailabilityFirst : Swift::Hashable {}
+// CHECK: @available(macOS 14, watchOS 10, tvOS 17, visionOS 2.1, iOS 18, *)
+// CHECK-NEXT: extension synthesized::HasNestedTypesAndAvailability.synthesized::HasRawValueAndVisionOSAvailabilityFirst : Swift::RawRepresentable {}
+
+// CHECK: @available(anyAppleOS 26, *)
+// CHECK-NEXT: extension synthesized::HasNestedTypesAndAvailability.synthesized::HasRawValueAndAnyAppleOSAvailability : Swift::Equatable {}
+// CHECK: @available(anyAppleOS 26, *)
+// CHECK-NEXT: extension synthesized::HasNestedTypesAndAvailability.synthesized::HasRawValueAndAnyAppleOSAvailability : Swift::Hashable {}
+// CHECK: @available(anyAppleOS 26, *)
+// CHECK-NEXT: extension synthesized::HasNestedTypesAndAvailability.synthesized::HasRawValueAndAnyAppleOSAvailability : Swift::RawRepresentable {}
+
+// CHECK: @available(macOS 14, iOS 17, watchOS 10, tvOS 17, *)
+// CHECK-NEXT: @available(*, deprecated, message: "Use something else")
+// CHECK-NEXT: extension synthesized::HasNestedTypesAndAvailability.synthesized::HasRawValueUniversallyDeprecated : Swift::Equatable {}
+// CHECK: @available(macOS 14, iOS 17, watchOS 10, tvOS 17, *)
+// CHECK-NEXT: @available(*, deprecated, message: "Use something else")
+// CHECK-NEXT: extension synthesized::HasNestedTypesAndAvailability.synthesized::HasRawValueUniversallyDeprecated : Swift::Hashable {}
+// CHECK: @available(macOS 14, iOS 17, watchOS 10, tvOS 17, *)
+// CHECK-NEXT: @available(*, deprecated, message: "Use something else")
+// CHECK-NEXT: extension synthesized::HasNestedTypesAndAvailability.synthesized::HasRawValueUniversallyDeprecated : Swift::RawRepresentable {}
+
 
 // CHECK: extension synthesized::ObjCEnum : Swift::Equatable {}
 // CHECK: extension synthesized::ObjCEnum : Swift::Hashable {}


### PR DESCRIPTION
When printing `.swiftinterface` files, implicit conformances may need to be printed with inferred availability attributes. The existing algorithm for determining which availability attributes to print needed a few updates to better handle `anyAppleOS` availability attributes:

- `@available(anyAppleOS, ...)` attributes attached to a nested declaration should take priority over platform-specific `@available` attributes on outer declarations.
- At the same time, `@available(anyAppleOS, ...)` attributes attached to the _same_ declaration as a platform-specific `@available` attribute should not take priority. Instead, both attributes should be included in the inferred set.