### PR TITLE
Introduce performance hints for untyped throws

### DIFF
--- a/include/swift/AST/DiagnosticGroups.def
+++ b/include/swift/AST/DiagnosticGroups.def
@@ -89,10 +89,12 @@ GROUP(StringInterpolationConformance,none,"string-interpolation-conformance")
 GROUP(TemporaryPointers,none,"temporary-pointers")
 GROUP(TrailingClosureMatching,none,"trailing-closure-matching")
 GROUP(UnknownWarningGroup,none,"unknown-warning-group")
+GROUP(UntypedThrows,DefaultIgnoreWarnings,"untyped-throws")
 GROUP(WeakMutability,none,"weak-mutability")
 
 GROUP_LINK(PerformanceHints,ExistentialType)
 GROUP_LINK(PerformanceHints,ReturnTypeImplicitCopy)
+GROUP_LINK(PerformanceHints,UntypedThrows)
 
 GROUP_LINK(RegionIsolation,SendingClosureRisksDataRace)
 GROUP_LINK(RegionIsolation,SendingRisksDataRace)

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -9157,6 +9157,10 @@ GROUPED_WARNING(perf_hint_typealias_uses_existential,ExistentialType,none,
                 "and dynamic dispatch. Consider using generic constraints or concrete types instead.",
                 (const TypeAliasDecl *))
 
+GROUPED_WARNING(perf_hint_untyped_throws, UntypedThrows,
+                none,
+                "untyped throws performs heap allocation on each 'throw'; add a thrown error type with '(type)'", ())
+
 ERROR(unsafe_self_dependent_result_attr_on_invalid_decl,none,
       "invalid use of @_unsafeSelfDependentResult", ())
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -9159,7 +9159,9 @@ GROUPED_WARNING(perf_hint_typealias_uses_existential,ExistentialType,none,
 
 GROUPED_WARNING(perf_hint_untyped_throws, UntypedThrows,
                 none,
-                "untyped throws performs heap allocation on each 'throw'; add a thrown error type with '(type)'", ())
+                "untyped throws performs heap allocation on each 'throw'", ())
+NOTE(perf_hint_add_thrown_error_type,none,
+     "consider adding a thrown error type with '(type)'", ())
 
 ERROR(unsafe_self_dependent_result_attr_on_invalid_decl,none,
       "invalid use of @_unsafeSelfDependentResult", ())

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -17,10 +17,10 @@
 //===----------------------------------------------------------------------===//
 #include "swift/Sema/ConstraintSystem.h"
 #include "CSDiagnostics.h"
+#include "MiscDiagnostics.h"
 #include "OpenedExistentials.h"
 #include "TypeCheckAvailability.h"
 #include "TypeCheckConcurrency.h"
-#include "TypeCheckEmbedded.h"
 #include "TypeCheckMacros.h"
 #include "TypeCheckType.h"
 #include "TypeChecker.h"
@@ -1414,6 +1414,9 @@ FunctionType::ExtInfo ClosureEffectsRequest::evaluate(
   bool sendable = expr->getAttrs().hasAttribute<SendableAttr>();
 
   if (throws || async) {
+    if (expr->getThrowsLoc().isValid() && !expr->getExplicitThrownTypeRepr())
+      diagnoseUntypedThrows(expr, expr->getThrowsLoc());
+
     return ASTExtInfoBuilder()
       .withThrows(throws, /*FIXME:*/Type())
       .withAsync(async)

--- a/lib/Sema/MiscDiagnostics.h
+++ b/lib/Sema/MiscDiagnostics.h
@@ -187,6 +187,9 @@ namespace swift {
                      llvm::function_ref<Type(Expr *)> getType = [](Expr *E) {
                        return E->getType();
                      });
+
+  /// Diagnose a declaration of typed throws at the given location.
+  void diagnoseUntypedThrows(const DeclContext *dc, SourceLoc throwsLoc);
 } // namespace swift
 
 #endif // SWIFT_SEMA_MISC_DIAGNOSTICS_H

--- a/lib/Sema/PerformanceHints.cpp
+++ b/lib/Sema/PerformanceHints.cpp
@@ -164,6 +164,7 @@ evaluator::SideEffect EmitPerformanceHints::evaluate(Evaluator &evaluator,
 void swift::diagnoseUntypedThrows(
     const DeclContext *dc, SourceLoc throwsLoc) {
   dc->getASTContext().Diags.diagnose(
-      throwsLoc, diag::perf_hint_untyped_throws)
-    .fixItInsertAfter(throwsLoc, "(<#thrown error type#>)");
+      throwsLoc, diag::perf_hint_untyped_throws);
+  dc->getASTContext().Diags.diagnose(throwsLoc, diag::perf_hint_add_thrown_error_type)
+    .fixItInsertAfter(throwsLoc, "(<#any Error#>)");
 }

--- a/lib/Sema/PerformanceHints.cpp
+++ b/lib/Sema/PerformanceHints.cpp
@@ -160,3 +160,10 @@ evaluator::SideEffect EmitPerformanceHints::evaluate(Evaluator &evaluator,
   PerformanceHintDiagnosticWalker::check(SF);
   return {};
 }
+
+void swift::diagnoseUntypedThrows(
+    const DeclContext *dc, SourceLoc throwsLoc) {
+  dc->getASTContext().Diags.diagnose(
+      throwsLoc, diag::perf_hint_untyped_throws)
+    .fixItInsertAfter(throwsLoc, "(<#thrown error type#>)");
+}

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -3571,6 +3571,13 @@ public:
     TypeChecker::checkDistributedFunc(FD);
     checkEmbeddedRestrictionsInSignature(FD);
 
+    // Untyped throws might need to be diagnosed.
+    SourceLoc throwsLoc = FD->getThrowsLoc();
+    if (throwsLoc.isValid() && !FD->getThrownTypeRepr() &&
+        !FD->hasPolymorphicEffect(EffectKind::Throws)) {
+      diagnoseUntypedThrows(FD, throwsLoc);
+    }
+
     if (!checkOverrides(FD)) {
       // If a method has an 'override' keyword but does not
       // override anything, complain.
@@ -3957,6 +3964,13 @@ public:
 
     if (CD->getAsyncLoc().isValid())
       TypeChecker::checkConcurrencyAvailability(CD->getAsyncLoc(), CD);
+
+    // Untyped throws might need to be diagnosed.
+    SourceLoc throwsLoc = CD->getThrowsLoc();
+    if (throwsLoc.isValid() && !CD->getThrownTypeRepr() &&
+        !CD->hasPolymorphicEffect(EffectKind::Throws)) {
+      diagnoseUntypedThrows(CD, throwsLoc);
+    }
 
     // Check whether this initializer overrides an initializer in its
     // superclass.

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -16,10 +16,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "TypeCheckType.h"
+#include "MiscDiagnostics.h"
 #include "NonisolatedNonsendingByDefaultMigration.h"
 #include "TypeCheckAvailability.h"
 #include "TypeCheckConcurrency.h"
-#include "TypeCheckEmbedded.h"
 #include "TypeCheckInvertible.h"
 #include "TypeCheckProtocol.h"
 #include "TypeChecker.h"
@@ -4637,6 +4637,8 @@ NeverNullType TypeResolver::resolveASTFunctionType(
             thrownTy);
       }
     }
+  } else if (repr->getThrowsLoc().isValid()) {
+    diagnoseUntypedThrows(getDeclContext(), repr->getThrowsLoc());
   }
 
   bool hasSendingResult =
@@ -7345,6 +7347,7 @@ Type ExplicitCaughtTypeRequest::evaluate(
 
     // Explicit 'throws' implies that this throws 'any Error'.
     if (closure->getThrowsLoc().isValid()) {
+      diagnoseUntypedThrows(closure, closure->getThrowsLoc());
       return ctx.getErrorExistentialType();
     }
 
@@ -7364,6 +7367,8 @@ Type ExplicitCaughtTypeRequest::evaluate(
 
     // If there is no explicitly-specified thrown error type, it's 'any Error'.
     if (!typeRepr) {
+      diagnoseUntypedThrows(doCatch->getDeclContext(),
+                                      doCatch->getThrowsLoc());
       return ctx.getErrorExistentialType();
     }
 

--- a/test/PerformanceHints/untyped-throws.swift
+++ b/test/PerformanceHints/untyped-throws.swift
@@ -7,32 +7,35 @@ enum MyError: Error {
 case failed
 }
 
-// expected-perfhints-warning@+1{{untyped throws performs heap allocation on each 'throw'; add a thrown error type with '(type)'}}
+// expected-perfhints-warning@+2{{untyped throws performs heap allocation on each 'throw'}}
+// expected-perfhints-note@+1{{consider adding a thrown error type with '(type)'}}{{28-28=(<#any Error#>)}}
 func untypedThrows() throws { }
 
-// expected-perfhints-warning@+1{{untyped throws performs heap allocation on each 'throw'; add a thrown error type with '(type)'}}
-func rethrowingFunction(param: () throws -> Void) rethrows { }
-
-// expected-perfhints-warning@+1{{untyped throws performs heap allocation on each 'throw'; add a thrown error type with '(type)'}}
+// expected-perfhints-warning@+2{{untyped throws performs heap allocation on each 'throw'}}
+// expected-perfhints-note@+1{{consider adding a thrown error type with '(type)'}}{{29-29=(<#any Error#>)}}
 typealias FnType = () throws -> Void
 
 func untypedThrowsInBody() {
-  // expected-perfhints-warning@+1{{untyped throws performs heap allocation on each 'throw'; add a thrown error type with '(type)'}}
+  // expected-perfhints-warning@+2{{untyped throws performs heap allocation on each 'throw'}}
+// expected-perfhints-note@+1{{consider adding a thrown error type with '(type)'}}{{12-12=(<#any Error#>)}}
   do throws {
     throw MyError.failed
   } catch {
   }
 
-  // expected-perfhints-warning@+1{{untyped throws performs heap allocation on each 'throw'; add a thrown error type with '(type)'}}
+  // expected-perfhints-warning@+2{{untyped throws performs heap allocation on each 'throw'}}
+  // expected-perfhints-note@+1{{consider adding a thrown error type with '(type)'}}{{19-19=(<#any Error#>)}}
   _ = { (x) throws in x + 1 }
 }
 
 struct SomeStruct {
-  // expected-perfhints-warning@+1{{untyped throws performs heap allocation on each 'throw'; add a thrown error type with '(type)'}}
+  // expected-perfhints-warning@+2{{untyped throws performs heap allocation on each 'throw'}}
+// expected-perfhints-note@+1{{consider adding a thrown error type with '(type)'}}{{16-16=(<#any Error#>)}}
   init() throws { }
 
   var value: Int {
-    // expected-perfhints-warning@+1{{untyped throws performs heap allocation on each 'throw'; add a thrown error type with '(type)'}}
+    // expected-perfhints-warning@+2{{untyped throws performs heap allocation on each 'throw'}}
+  // expected-perfhints-note@+1{{consider adding a thrown error type with '(type)'}}{{15-15=(<#any Error#>)}}
     get throws {
       0
     }

--- a/test/PerformanceHints/untyped-throws.swift
+++ b/test/PerformanceHints/untyped-throws.swift
@@ -1,0 +1,40 @@
+// RUN: %target-typecheck-verify-swift %s
+
+// RUN: %target-typecheck-verify-swift -Wwarning PerformanceHints -verify-additional-prefix perfhints-
+// RUN: %target-typecheck-verify-swift -Wwarning UntypedThrows -verify-additional-prefix perfhints-
+
+enum MyError: Error {
+case failed
+}
+
+// expected-perfhints-warning@+1{{untyped throws performs heap allocation on each 'throw'; add a thrown error type with '(type)'}}
+func untypedThrows() throws { }
+
+// expected-perfhints-warning@+1{{untyped throws performs heap allocation on each 'throw'; add a thrown error type with '(type)'}}
+func rethrowingFunction(param: () throws -> Void) rethrows { }
+
+// expected-perfhints-warning@+1{{untyped throws performs heap allocation on each 'throw'; add a thrown error type with '(type)'}}
+typealias FnType = () throws -> Void
+
+func untypedThrowsInBody() {
+  // expected-perfhints-warning@+1{{untyped throws performs heap allocation on each 'throw'; add a thrown error type with '(type)'}}
+  do throws {
+    throw MyError.failed
+  } catch {
+  }
+
+  // expected-perfhints-warning@+1{{untyped throws performs heap allocation on each 'throw'; add a thrown error type with '(type)'}}
+  _ = { (x) throws in x + 1 }
+}
+
+struct SomeStruct {
+  // expected-perfhints-warning@+1{{untyped throws performs heap allocation on each 'throw'; add a thrown error type with '(type)'}}
+  init() throws { }
+
+  var value: Int {
+    // expected-perfhints-warning@+1{{untyped throws performs heap allocation on each 'throw'; add a thrown error type with '(type)'}}
+    get throws {
+      0
+    }
+  }
+}

--- a/userdocs/diagnostics/diagnostic-groups.md
+++ b/userdocs/diagnostics/diagnostic-groups.md
@@ -47,6 +47,7 @@ Or upgrade all warnings except deprecated declaration to errors:
 - <doc:strict-language-features>
 - <doc:strict-memory-safety>
 - <doc:unknown-warning-group>
+- <doc:untyped-throws>
 
 
 ## Topics
@@ -91,4 +92,5 @@ Or upgrade all warnings except deprecated declaration to errors:
 - <doc:unknown-warning-group>
 - <doc:availability-unrecognized-name>
 - <doc:mutable-global-variable>
+- <doc:untyped-throws>
 - <doc:existential-member-access-limitations>

--- a/userdocs/diagnostics/untyped-throws.md
+++ b/userdocs/diagnostics/untyped-throws.md
@@ -1,0 +1,14 @@
+# Untyped throws (UntypedThrows)
+
+A Swift function can declare that it can throw an error using `throws`, optionally providing a specific thrown error type:
+
+```swift
+func canThrowAnything() throws { ... }          // untyped throws
+func canThrowMyError() throws(MyError) { ... }  // typed throws (only throws MyError)
+```
+
+When a specific thrown error type is omitted, `any Error` will be used instead. Throwing an error of type `any Error` involves a heap allocation as well as reference-counting overhead. Therefore, highly performance-sensitive code should prefer to use typed throws over untyped throws.
+
+## See Also
+
+- [SE-0413: Typed Throws](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0413-typed-throws.md)


### PR DESCRIPTION
Untyped throws requires a heap allocation and reference counting for thrown errors, which can be unacceptable in very
performancce-constrained environments. Introduce a new subgroup of performance hints, UntypedThrows, to report uses of untyped throws.

This resurrects the code we were using for diagnosing untyped throws in Embedded Swift, repurposing it as a performance hint, which is more appropriate.
