### PR TITLE
Enforce the stack nesting of cancellation and priority-escalation handlers

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyAllocRefDynamic.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyAllocRefDynamic.swift
@@ -39,7 +39,7 @@ extension AllocRefDynamicInst : OnoneSimplifiable {
     }
 
     let builder = Builder(before: self, context)
-    let newAlloc = builder.createAllocRef(type, isObjC: self.isObjC, canAllocOnStack: self.canAllocOnStack, isBare: false,
+    let newAlloc = builder.createAllocRef(type, isObjC: self.isObjC, canAllocOnStack: self.canAllocOnStack, isBare: false, isNested: self.isStackAllocationNested,
       tailAllocatedTypes: self.tailAllocatedTypes, tailAllocatedCounts: Array(self.tailAllocatedCounts.values))
     
     let result: Value

--- a/SwiftCompilerSources/Sources/SIL/Builder.swift
+++ b/SwiftCompilerSources/Sources/SIL/Builder.swift
@@ -224,10 +224,10 @@ public struct Builder {
     return createIntegerLiteral(integerValue, type: boolType)
   }
 
-  public func createAllocRef(_ type: Type, isObjC: Bool = false, canAllocOnStack: Bool = false, isBare: Bool = false,
+  public func createAllocRef(_ type: Type, isObjC: Bool = false, canAllocOnStack: Bool = false, isBare: Bool = false, isNested: Bool = false,
                              tailAllocatedTypes: TypeArray, tailAllocatedCounts: [Value]) -> AllocRefInst {
     return tailAllocatedCounts.withBridgedValues { countsRef in
-      let dr = bridged.createAllocRef(type.bridged, isObjC, canAllocOnStack, isBare, tailAllocatedTypes.bridged, countsRef)
+      let dr = bridged.createAllocRef(type.bridged, isObjC, canAllocOnStack, isBare, isNested, tailAllocatedTypes.bridged, countsRef)
       return notifyNew(dr.getAs(AllocRefInst.self))
     }
   }

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -1587,6 +1587,17 @@ public class AllocRefInstBase : SingleValueInstruction, Allocation {
     context.notifyInstructionChanged(self)
   }
 
+  public final var isStackAllocationNested: Bool {
+    bridged.AllocRefInstBase_isStackAllocationNested();
+  }
+
+  public final func setStackAllocationNested(_ isNested: Bool,
+                                             _ context: some MutatingContext) {
+    context.notifyInstructionsChanged()
+    bridged.AllocRefInstBase_setStackAllocationIsNested(isNested)
+    context.notifyInstructionChanged(self)
+  }
+
   final public var tailAllocatedCounts: OperandArray {
     let numTailTypes = bridged.AllocRefInstBase_getNumTailTypes()
     return operands[0..<numTailTypes]

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -876,6 +876,8 @@ struct BridgedInstruction {
   BRIDGED_INLINE bool AllocBoxInst_hasDynamicLifetime() const;
   BRIDGED_INLINE bool AllocRefInstBase_isObjc() const;
   BRIDGED_INLINE bool AllocRefInstBase_canAllocOnStack() const;
+  BRIDGED_INLINE bool AllocRefInstBase_isStackAllocationNested() const;
+  BRIDGED_INLINE void AllocRefInstBase_setStackAllocationIsNested(bool) const;
   BRIDGED_INLINE SwiftInt AllocRefInstBase_getNumTailTypes() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedSILTypeArray AllocRefInstBase_getTailAllocatedTypes() const;
   BRIDGED_INLINE bool AllocRefDynamicInst_isDynamicTypeDeinitAndSizeKnownEquivalentToBaseType() const;
@@ -1257,7 +1259,7 @@ struct BridgedBuilder{
       BridgedType type, SwiftInt value, bool treatAsSigned) const;
 
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createAllocRef(BridgedType type,
-    bool objc, bool canAllocOnStack, bool isBare,
+    bool objc, bool canAllocOnStack, bool isBare, bool isNested,
     BridgedSILTypeArray elementTypes, BridgedValueArray elementCountOperands) const;
 
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -1526,7 +1526,6 @@ void BridgedInstruction::PartialApplyInst_setStackAllocationIsNested(bool isNest
            swift::StackAllocationIsNested_t(isNested));
 }
 
-
 bool BridgedInstruction::AllocStackInst_hasDynamicLifetime() const {
   return getAs<swift::AllocStackInst>()->hasDynamicLifetime();
 }
@@ -1553,6 +1552,15 @@ bool BridgedInstruction::AllocRefInstBase_isObjc() const {
 
 bool BridgedInstruction::AllocRefInstBase_canAllocOnStack() const {
   return getAs<swift::AllocRefInstBase>()->canAllocOnStack();
+}
+
+bool BridgedInstruction::AllocRefInstBase_isStackAllocationNested() const {
+  return getAs<swift::AllocRefInstBase>()->isStackAllocationNested();
+}
+
+void BridgedInstruction::AllocRefInstBase_setStackAllocationIsNested(bool isNested) const {
+  return getAs<swift::AllocRefInstBase>()->setStackAllocationIsNested(
+           swift::StackAllocationIsNested_t(isNested));
 }
 
 SwiftInt BridgedInstruction::AllocRefInstBase_getNumTailTypes() const {
@@ -2411,11 +2419,12 @@ BridgedBuilder::createIntegerLiteral(BridgedType type, SwiftInt value,
 }
 
 BridgedInstruction BridgedBuilder::createAllocRef(BridgedType type,
-    bool objc, bool canAllocOnStack, bool isBare,
+    bool objc, bool canAllocOnStack, bool isBare, bool isNested,
     BridgedSILTypeArray elementTypes, BridgedValueArray elementCountOperands) const {
   llvm::SmallVector<swift::SILValue, 16> elementCountOperandsValues;
   return {unbridged().createAllocRef(
       regularLoc(), type.unbridged(), objc, canAllocOnStack, isBare,
+      swift::StackAllocationIsNested_t(isNested),
       elementTypes.typeArray.unbridged<swift::SILType>(),
       elementCountOperands.getValues(elementCountOperandsValues)
       )};

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -2757,16 +2757,15 @@ BridgedInstruction BridgedBuilder::createPartialApply(BridgedValue funcRef,
                                                       bool isOnStack,
                                                       bool isNested) const {
   llvm::SmallVector<swift::SILValue, 8> capturedArgs;
-  auto *pai = unbridged().createPartialApply(
+  return {unbridged().createPartialApply(
       regularLoc(), funcRef.getSILValue(), bridgedSubstitutionMap.unbridged(),
       bridgedCapturedArgs.getValues(capturedArgs),
       getParameterConvention(calleeConvention),
       hasUnknownIsolation ? swift::SILFunctionTypeIsolation::forUnknown()
                           : swift::SILFunctionTypeIsolation::forErased(),
       isOnStack ? swift::PartialApplyInst::OnStack
-                : swift::PartialApplyInst::NotOnStack);
-  pai->setStackAllocationIsNested(isNested ? swift::StackAllocationIsNested : swift::StackAllocationIsNotNested);
-  return {pai};
+                : swift::PartialApplyInst::NotOnStack,
+      swift::StackAllocationIsNested_t(isNested))};
 }
 
 BridgedInstruction BridgedBuilder::createBranch(BridgedBasicBlock destBlock, BridgedValueArray arguments) const {

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -458,6 +458,7 @@ public:
 
   AllocRefInst *createAllocRef(SILLocation Loc, SILType ObjectType,
                                bool objc, bool canAllocOnStack, bool isBare,
+                               StackAllocationIsNested_t isNested,
                                ArrayRef<SILType> ElementTypes,
                                ArrayRef<SILValue> ElementCountOperands) {
     // AllocRefInsts expand to function calls and can therefore not be
@@ -465,12 +466,14 @@ public:
     ASSERT(!Loc.isInPrologue());
     return insert(AllocRefInst::create(getSILDebugLocation(Loc), getFunction(),
                                        ObjectType, objc, canAllocOnStack, isBare,
+                                       isNested,
                                        ElementTypes, ElementCountOperands));
   }
 
   AllocRefDynamicInst *createAllocRefDynamic(SILLocation Loc, SILValue operand,
                                              SILType type, bool objc,
                                              bool canAllocOnStack,
+                                             StackAllocationIsNested_t isNested,
                                     ArrayRef<SILType> ElementTypes,
                                     ArrayRef<SILValue> ElementCountOperands) {
     // AllocRefDynamicInsts expand to function calls and can therefore
@@ -478,7 +481,7 @@ public:
     ASSERT(!Loc.isInPrologue());
     return insert(AllocRefDynamicInst::create(
         getSILDebugLocation(Loc), *F, operand, type, objc, canAllocOnStack,
-        ElementTypes, ElementCountOperands));
+        isNested, ElementTypes, ElementCountOperands));
   }
 
   /// Helper function that calls \p createAllocBox after constructing a

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -572,6 +572,7 @@ public:
           SILFunctionTypeIsolation::forUnknown(),
       PartialApplyInst::OnStackKind OnStack =
           PartialApplyInst::OnStackKind::NotOnStack,
+      StackAllocationIsNested_t IsNested = StackAllocationIsNested,
       const GenericSpecializationInformation *SpecializationInfo = nullptr) {
     ASSERT(OnStack == PartialApplyInst::OnStackKind::OnStack ||
            llvm::all_of(Args,
@@ -582,7 +583,7 @@ public:
                "Must have an owned compatible object");
     return insert(PartialApplyInst::create(
         getSILDebugLocation(Loc), Fn, Args, Subs, CalleeConvention,
-        ResultIsolation, *F, SpecializationInfo, OnStack));
+        ResultIsolation, *F, SpecializationInfo, OnStack, IsNested));
   }
 
   BeginApplyInst *createBeginApply(

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1235,9 +1235,8 @@ SILCloner<ImplClass>::visitPartialApplyInst(PartialApplyInst *Inst) {
                 Inst->getCalleeConvention(),
                 Inst->getResultIsolation(),
                 Inst->isOnStack(),
+                Inst->isStackAllocationNested(),
                 GenericSpecializationInformation::create(Inst, getBuilder()));
-  NewInst->setStackAllocationIsNested(Inst->isStackAllocationNested());
-
   recordClonedInstruction(Inst, NewInst);
 }
 

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1112,7 +1112,8 @@ SILCloner<ImplClass>::visitAllocRefInst(AllocRefInst *Inst) {
   }
   auto *NewInst = getBuilder().createAllocRef(getOpLocation(Inst->getLoc()),
                                       getOpType(Inst->getType()),
-                                      Inst->isObjC(), Inst->canAllocOnStack(), Inst->isBare(),
+                                      Inst->isObjC(), Inst->canAllocOnStack(),
+                                      Inst->isBare(), Inst->isStackAllocationNested(),
                                       ElemTypes, CountArgs);
   recordClonedInstruction(Inst, NewInst);
 }
@@ -1133,6 +1134,7 @@ SILCloner<ImplClass>::visitAllocRefDynamicInst(AllocRefDynamicInst *Inst) {
                                       getOpType(Inst->getType()),
                                       Inst->isObjC(),
                                       Inst->canAllocOnStack(),
+                                      Inst->isStackAllocationNested(),
                                       ElemTypes, CountArgs);
   recordClonedInstruction(Inst, NewInst);
 }

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -2341,6 +2341,7 @@ protected:
                    SILDebugLocation DebugLoc,
                    SILType ObjectType,
                    bool objc, bool canBeOnStack, bool isBare,
+                   StackAllocationIsNested_t isNested,
                    ArrayRef<SILType> ElementTypes);
 
   SILType *getTypeStorage();
@@ -2367,6 +2368,14 @@ public:
 
   void setStackAllocatable(bool OnStack = true) {
     sharedUInt8().AllocRefInstBase.onStack = OnStack;
+  }
+
+  StackAllocationIsNested_t isStackAllocationNested() const {
+    return StackAllocationIsNested_t(sharedUInt8().AllocRefInstBase.isNested);
+  }
+
+  void setStackAllocationIsNested(StackAllocationIsNested_t isNested) {
+    sharedUInt8().AllocRefInstBase.isNested = bool(isNested);
   }
 
   ArrayRef<SILType> getTailAllocatedTypes() const {
@@ -2428,10 +2437,11 @@ class AllocRefInst final
   AllocRefInst(SILDebugLocation DebugLoc, SILFunction &F,
                SILType ObjectType,
                bool objc, bool canBeOnStack, bool isBare,
+               StackAllocationIsNested_t isNested,
                ArrayRef<SILType> ElementTypes,
                ArrayRef<SILValue> AllOperands)
       : InstructionBaseWithTrailingOperands(AllOperands, DebugLoc, ObjectType,
-                        objc, canBeOnStack, isBare, ElementTypes) {
+                        objc, canBeOnStack, isBare, isNested, ElementTypes) {
     assert(AllOperands.size() >= ElementTypes.size());
     std::uninitialized_copy(ElementTypes.begin(), ElementTypes.end(),
                             getTrailingObjects<SILType>());
@@ -2440,6 +2450,7 @@ class AllocRefInst final
   static AllocRefInst *create(SILDebugLocation DebugLoc, SILFunction &F,
                               SILType ObjectType,
                               bool objc, bool canBeOnStack, bool isBare,
+                              StackAllocationIsNested_t isNested,
                               ArrayRef<SILType> ElementTypes,
                               ArrayRef<SILValue> ElementCountOperands);
 
@@ -2479,10 +2490,12 @@ class AllocRefDynamicInst final
                       SILType ty,
                       bool objc,
                       bool canBeOnStack,
+                      StackAllocationIsNested_t isNested,
                       ArrayRef<SILType> ElementTypes,
                       ArrayRef<SILValue> AllOperands)
       : InstructionBaseWithTrailingOperands(AllOperands, DebugLoc, ty, objc,
-                                            canBeOnStack, /*isBare=*/ false, ElementTypes) {
+                                            canBeOnStack, /*isBare=*/ false,
+                                            isNested, ElementTypes) {
     assert(AllOperands.size() >= ElementTypes.size() + 1);
     std::uninitialized_copy(ElementTypes.begin(), ElementTypes.end(),
                             getTrailingObjects<SILType>());
@@ -2491,7 +2504,7 @@ class AllocRefDynamicInst final
   static AllocRefDynamicInst *
   create(SILDebugLocation DebugLoc, SILFunction &F,
          SILValue metatypeOperand, SILType ty, bool objc,
-         bool canBeOnStack,
+         bool canBeOnStack, StackAllocationIsNested_t isNested,
          ArrayRef<SILType> ElementTypes,
          ArrayRef<SILValue> ElementCountOperands);
 

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -3263,6 +3263,7 @@ private:
                    ArrayRef<SILValue> Args,
                    ArrayRef<SILValue> TypeDependentOperands,
                    SILType ClosureType,
+                   StackAllocationIsNested_t IsNested,
                    const GenericSpecializationInformation *SpecializationInfo);
 
   static PartialApplyInst *
@@ -3270,7 +3271,7 @@ private:
          SubstitutionMap Substitutions, ParameterConvention CalleeConvention,
          SILFunctionTypeIsolation ResultIsolation, SILFunction &F,
          const GenericSpecializationInformation *SpecializationInfo,
-         OnStackKind onStack);
+         OnStackKind onStack, StackAllocationIsNested_t isNested);
 
 public:
   /// Return the result function type of this partial apply.

--- a/include/swift/SIL/SILNode.h
+++ b/include/swift/SIL/SILNode.h
@@ -242,6 +242,7 @@ protected:
     SHARED_FIELD(AllocRefInstBase, uint8_t
       objC : 1,
       onStack : 1,
+      isNested : 1,
       isBare : 1,   // Only used in AllocRefInst
       numTailTypes: NumAllocRefTailTypesBits);
 

--- a/include/swift/SIL/StackAllocation.h
+++ b/include/swift/SIL/StackAllocation.h
@@ -58,6 +58,23 @@ enum class StackAllocationKind : uint8_t {
   /// A BuiltinInst for the StartAsyncLetWithLocalBuffer builtin. The
   /// deallocation is a BuiltinInst for the FinishAsyncLet builtin.
   BuiltinStartAsyncLet,
+
+  /// A BuiltinInst for the TaskLocalValuePush builtin. The deallocation
+  /// is a BuiltinInst for the TaskLocalValuePop builtin.
+  ///
+  /// FIXME: this one doesn't work because we didn't actually give it a use/def
+  /// relationship!
+  BuiltinTaskLocalValuePush,
+
+  /// A BuiltinInst for the TaskAddPriorityEscalationHandler builtin. The
+  /// deallocation is a BuiltinInst for the TaskRemovePriorityEscalationHandler
+  /// builtin.
+  BuiltinTaskAddPriorityEscalationHandler,
+
+  /// A BuiltinInst for the TaskAddCancellationHandler builtin. The
+  /// deallocation is a BuiltinInst for the TaskRemoveCancellationHandler
+  /// builtin.
+  BuiltinTaskAddCancellationHandler,
 };
 
 class StackAllocation {

--- a/include/swift/SIL/TypeSubstCloner.h
+++ b/include/swift/SIL/TypeSubstCloner.h
@@ -222,7 +222,7 @@ protected:
         getOpLocation(Inst->getLoc()), Helper.getCallee(),
         Helper.getSubstitutions(), Helper.getArguments(),
         Inst->getCalleeConvention(), Inst->getResultIsolation(),
-        Inst->isOnStack(),
+        Inst->isOnStack(), Inst->isStackAllocationNested(),
         GenericSpecializationInformation::create(Inst, getBuilder()));
     recordClonedInstruction(Inst, N);
   }

--- a/lib/IRGen/Address.h
+++ b/lib/IRGen/Address.h
@@ -119,8 +119,31 @@ public:
   bool isValid() const { return Addr.isValid(); }
 };
 
-/// An address on the stack together with enough information to correctly
-/// deallocate it.
+/// An address allocated on the "stack", together with enough information
+/// to correctly deallocate it.
+///
+/// In non-coroutine functions, we can generally just allocate the memory
+/// with the LLVM alloca instruction. For static allocas (see below), LLVM
+/// is expected to just inline this into the C stack frame. For dynamic
+/// allocas, LLVM will perform a dynamic change to SP, and we may need
+/// to do a stacksave so that we can reset that adjustment on deallocation.
+///
+/// In coroutines, static allocas are still generally okay; the coroutine
+/// pass will just rewrite them to be part of the coroutine frame. The
+/// coroutine pass doesn't handle dynamic allocas well, however, so we
+/// generally need to turn those into something else --- either an intrinsic
+/// that preserves enough structure that the coroutine pass can more
+/// usefully lower it, or just a direct use of the stack allocator that we
+/// know the coroutine uses (e.g. the task allocator in async functions).
+///
+/// SIL also (for complicated reasons) supports non-nested "stack"
+/// allocations, where the allocation and deallocation are not necessarily
+/// FIFO w.r.t other stack allocations. Static allocas are still fine for
+/// these, because LLVM's algorithms for reusing space in the C stack /
+/// coroutine frame are based on overlap and don't assume a tree structure.
+/// Anything that would need dynamic stack allocation, however, generally
+/// cannot use a FIFO allocator and must use the appropriate non-nested
+/// allocator instead. Currently this is just malloc.
 class StackAddress {
 public:
   enum Kind {

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -6708,6 +6708,11 @@ buildTailArrays(IRGenSILFunction &IGF,
 }
 
 void IRGenSILFunction::visitAllocRefInst(swift::AllocRefInst *i) {
+  // We can ignore isStackAllocationNested() here because we currently only
+  // use static allocas for the stack promotion optimization. If we ever do
+  // want to try dynamic allocations, we'll need to pay attention
+  // (probably by just disabling the optimization).
+
   int StackAllocSize = -1;
   if (i->canAllocOnStack()) {
     estimateStackSize();
@@ -6731,6 +6736,11 @@ void IRGenSILFunction::visitAllocRefInst(swift::AllocRefInst *i) {
 }
 
 void IRGenSILFunction::visitAllocRefDynamicInst(swift::AllocRefDynamicInst *i) {
+  // We can ignore isStackAllocationNested() here because we currently only
+  // use static allocas for the stack promotion optimization. If we ever do
+  // want to try dynamic allocations, we'll need to pay attention
+  // (probably by just disabling the optimization).
+
   int StackAllocSize = -1;
   if (i->canAllocOnStack()) {
     assert(i->isDynamicTypeDeinitAndSizeKnownEquivalentToBaseType());

--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -2711,8 +2711,8 @@ void LoadableByAddress::recreateSingleApply(
     }
     auto newApply = applyBuilder.createPartialApply(
         castedApply->getLoc(), callee, applySite.getSubstitutionMap(), callArgs,
-        partialApplyConvention, resultIsolation, castedApply->isOnStack());
-    newApply->setStackAllocationIsNested(castedApply->isStackAllocationNested());
+        partialApplyConvention, resultIsolation, castedApply->isOnStack(),
+        castedApply->isStackAllocationNested());
     castedApply->replaceAllUsesWith(newApply);
     break;
   }

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -1367,6 +1367,8 @@ StackAllocationIsNested_t SILInstruction::isStackAllocationNested() const {
     return ASI->isStackAllocationNested();
   } else if (auto PAI = dyn_cast<PartialApplyInst>(this)) {
     return PAI->isStackAllocationNested();
+  } else if (auto ARI = dyn_cast<AllocRefInstBase>(this)) {
+    return ARI->isStackAllocationNested();
   } else {
     // TODO: implement for all remaining allocations
     return StackAllocationIsNested;
@@ -1379,6 +1381,8 @@ void SILInstruction::setStackAllocationIsNested(
     ASI->setStackAllocationIsNested(nested);
   } else if (auto PAI = dyn_cast<PartialApplyInst>(this)) {
     PAI->setStackAllocationIsNested(nested);
+  } else if (auto ARI = dyn_cast<AllocRefInstBase>(this)) {
+    ARI->setStackAllocationIsNested(nested);
   } else if (!nested) {
     verificationFailure("setStackAllocationIsNested unimplemented for instruction",
                         this, [](SILPrintContext &ctx) {});

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -1346,6 +1346,10 @@ SILInstruction::getStackAllocation() const {
       BUILTIN_CASE(StackAlloc, StackAlloc)
       BUILTIN_CASE(UnprotectedStackAlloc, UnprotectedStackAlloc)
       BUILTIN_CASE(StartAsyncLetWithLocalBuffer, StartAsyncLet)
+      //BUILTIN_CASE(TaskLocalValuePush, TaskLocalValuePush)
+      BUILTIN_CASE(TaskAddPriorityEscalationHandler,
+                   TaskAddPriorityEscalationHandler)
+      BUILTIN_CASE(TaskAddCancellationHandler, TaskAddCancellationHandler)
 #undef BUILTIN_CASE
 
       default:
@@ -1437,11 +1441,19 @@ SILInstruction::getStackDeallocation() const {
                    : StackAllocationKind::BuiltinUnprotectedStackAlloc);
       }
 
-      case BuiltinValueKind::FinishAsyncLet: {
-        auto alloc = StackDeallocation::getAllocationOperand(BI);
-        return StackDeallocation::getUnchecked(alloc, BI,
-                             StackAllocationKind::BuiltinStartAsyncLet);
+#define BUILTIN_CASE(FINISH_BUILTIN_ID, ID)                              \
+      case BuiltinValueKind::FINISH_BUILTIN_ID: {                        \
+        auto alloc = StackDeallocation::getAllocationOperand(BI);        \
+        return StackDeallocation::getUnchecked(alloc, BI,                \
+                                               StackAllocationKind::ID); \
       }
+      BUILTIN_CASE(FinishAsyncLet, BuiltinStartAsyncLet)
+      //BUILTIN_CASE(TaskLocalValuePop, BuiltinTaskLocalValuePush)
+      BUILTIN_CASE(TaskRemovePriorityEscalationHandler,
+                   BuiltinTaskAddPriorityEscalationHandler)
+      BUILTIN_CASE(TaskRemoveCancellationHandler,
+                   BuiltinTaskAddCancellationHandler)
+#undef BUILTIN_CASE
 
       default:
         return std::nullopt;

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -1380,7 +1380,8 @@ void SILInstruction::setStackAllocationIsNested(
   } else if (auto PAI = dyn_cast<PartialApplyInst>(this)) {
     PAI->setStackAllocationIsNested(nested);
   } else if (!nested) {
-    llvm_unreachable("unimplemented");
+    verificationFailure("setStackAllocationIsNested unimplemented for instruction",
+                        this, [](SILPrintContext &ctx) {});
   }
 }
 

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -317,11 +317,13 @@ AllocRefInstBase::AllocRefInstBase(SILInstructionKind Kind,
                                    SILDebugLocation Loc,
                                    SILType ObjectType,
                                    bool objc, bool canBeOnStack, bool isBare,
+                                   StackAllocationIsNested_t isNested,
                                    ArrayRef<SILType> ElementTypes)
     : AllocationInst(Kind, Loc, ObjectType) {
   sharedUInt8().AllocRefInstBase.objC = objc;
   sharedUInt8().AllocRefInstBase.onStack = canBeOnStack;
   sharedUInt8().AllocRefInstBase.isBare = isBare;
+  sharedUInt8().AllocRefInstBase.isNested = bool(isNested);
   sharedUInt8().AllocRefInstBase.numTailTypes = ElementTypes.size();
   assert(sharedUInt8().AllocRefInstBase.numTailTypes ==
          ElementTypes.size() && "Truncation");
@@ -331,6 +333,7 @@ AllocRefInstBase::AllocRefInstBase(SILInstructionKind Kind,
 AllocRefInst *AllocRefInst::create(SILDebugLocation Loc, SILFunction &F,
                                    SILType ObjectType,
                                    bool objc, bool canBeOnStack, bool isBare,
+                                   StackAllocationIsNested_t isNested,
                                    ArrayRef<SILType> ElementTypes,
                                    ArrayRef<SILValue> ElementCountOperands) {
   assert(ElementTypes.size() == ElementCountOperands.size());
@@ -342,13 +345,14 @@ AllocRefInst *AllocRefInst::create(SILDebugLocation Loc, SILFunction &F,
                                                         ElementTypes.size());
   auto Buffer = F.getModule().allocateInst(Size, alignof(AllocRefInst));
   return ::new (Buffer) AllocRefInst(Loc, F, ObjectType, objc, canBeOnStack, isBare,
-                                     ElementTypes, AllOperands);
+                                     isNested, ElementTypes, AllOperands);
 }
 
 AllocRefDynamicInst *
 AllocRefDynamicInst::create(SILDebugLocation DebugLoc, SILFunction &F,
                             SILValue metatypeOperand, SILType ty, bool objc,
                             bool canBeOnStack,
+                            StackAllocationIsNested_t isNested,
                             ArrayRef<SILType> ElementTypes,
                             ArrayRef<SILValue> ElementCountOperands) {
   SmallVector<SILValue, 8> AllOperands(ElementCountOperands.begin(),
@@ -359,8 +363,8 @@ AllocRefDynamicInst::create(SILDebugLocation DebugLoc, SILFunction &F,
                                                         ElementTypes.size());
   auto Buffer = F.getModule().allocateInst(Size, alignof(AllocRefDynamicInst));
   return ::new (Buffer)
-      AllocRefDynamicInst(DebugLoc, ty, objc, canBeOnStack, ElementTypes,
-                          AllOperands);
+      AllocRefDynamicInst(DebugLoc, ty, objc, canBeOnStack, isNested,
+                          ElementTypes, AllOperands);
 }
 
 bool AllocRefDynamicInst::isDynamicTypeDeinitAndSizeKnownEquivalentToBaseType() const {

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -745,6 +745,7 @@ PartialApplyInst::PartialApplyInst(
     SILDebugLocation Loc, SILValue Callee, SILType SubstCalleeTy,
     SubstitutionMap Subs, ArrayRef<SILValue> Args,
     ArrayRef<SILValue> TypeDependentOperands, SILType ClosureType,
+    StackAllocationIsNested_t IsNested,
     const GenericSpecializationInformation *SpecializationInfo)
     // FIXME: the callee should have a lowered SIL function type, and
     // PartialApplyInst
@@ -752,15 +753,15 @@ PartialApplyInst::PartialApplyInst(
     // type.
     : InstructionBase(Loc, Callee, SubstCalleeTy, Subs, Args,
                       TypeDependentOperands, SpecializationInfo, ClosureType) {
-  sharedUInt8().PartialApplyInst.isNested = true;
+  sharedUInt8().PartialApplyInst.isNested = uint8_t(IsNested);
 }
 
 PartialApplyInst *PartialApplyInst::create(
     SILDebugLocation Loc, SILValue Callee, ArrayRef<SILValue> Args,
     SubstitutionMap Subs, ParameterConvention calleeConvention,
     SILFunctionTypeIsolation resultIsolation, SILFunction &F,
-    const GenericSpecializationInformation *SpecializationInfo,
-    OnStackKind onStack) {
+    const GenericSpecializationInformation *specializationInfo,
+    OnStackKind onStack, StackAllocationIsNested_t isNested) {
   SILType SubstCalleeTy = Callee->getType().substGenericArgs(
       F.getModule(), Subs, F.getTypeExpansionContext());
 
@@ -777,7 +778,7 @@ PartialApplyInst *PartialApplyInst::create(
   return ::new(Buffer) PartialApplyInst(Loc, Callee, SubstCalleeTy,
                                         Subs, Args,
                                         TypeDependentOperands, ClosureType,
-                                        SpecializationInfo);
+                                        isNested, specializationInfo);
 }
 
 TryApplyInstBase::TryApplyInstBase(SILInstructionKind kind,

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1678,6 +1678,8 @@ public:
       *this << "[objc] ";
     if (ARI->canAllocOnStack())
       *this << "[stack] ";
+    if (!ARI->isStackAllocationNested())
+      *this << "[non_nested] ";
     auto Types = ARI->getTailAllocatedTypes();
     auto Counts = ARI->getTailAllocatedCounts();
     for (unsigned Idx = 0, NumTypes = Types.size(); Idx < NumTypes; ++Idx) {

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -5076,6 +5076,7 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
     bool IsObjC = false;
     bool OnStack = false;
     bool isBare = false;
+    auto isNested = StackAllocationIsNested;
     SmallVector<SILType, 2> ElementTypes;
     SmallVector<SILValue, 2> ElementCounts;
     while (P.consumeIf(tok::l_square)) {
@@ -5088,6 +5089,8 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
         OnStack = true;
       } else if (Optional == "bare" && Opcode == SILInstructionKind::AllocRefInst) {
         isBare = true;
+      } else if (Optional == "non_nested") {
+        isNested = StackAllocationIsNotNested;
       } else if (Optional == "tail_elems") {
         SILType ElemTy;
         if (parseSILType(ElemTy) || !P.Tok.isAnyOperator() ||
@@ -5126,11 +5129,11 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
     }
     if (Opcode == SILInstructionKind::AllocRefDynamicInst) {
       ResultVal = B.createAllocRefDynamic(InstLoc, Metadata, ObjectType, IsObjC,
-                                          OnStack,
+                                          OnStack, isNested,
                                           ElementTypes, ElementCounts);
     } else {
       ResultVal = B.createAllocRef(InstLoc, ObjectType, IsObjC, OnStack, isBare,
-                                   ElementTypes, ElementCounts);
+                                   isNested, ElementTypes, ElementCounts);
     }
     break;
   }

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -7147,17 +7147,12 @@ bool SILParser::parseCallInstruction(SILLocation InstLoc,
     }
 
     // FIXME: Why the arbitrary order difference in IRBuilder type argument?
-    auto PA = B.createPartialApply(
+    ResultVal = B.createPartialApply(
         InstLoc, FnVal, subs, Args, PartialApplyConvention,
         PartialApplyIsolation,
         IsNoEscape ? PartialApplyInst::OnStackKind::OnStack
-                   : PartialApplyInst::OnStackKind::NotOnStack);
-
-    if (isNested) {
-      PA->setStackAllocationIsNested(*isNested);
-    }
-
-    ResultVal = PA;
+                   : PartialApplyInst::OnStackKind::NotOnStack,
+        isNested ? *isNested : StackAllocationIsNested);
     break;
   }
   case SILInstructionKind::TryApplyInst: {

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -268,6 +268,7 @@ ManagedValue SILGenBuilder::createAllocRef(
                   [](ManagedValue mv) -> SILValue { return mv.getValue(); });
 
   AllocRefInst *i = createAllocRef(loc, refType, objc, false, false,
+                                   StackAllocationIsNested,
                                    elementTypes, elementCountOperands);
   return SGF.emitManagedRValueWithCleanup(i);
 }
@@ -285,6 +286,7 @@ ManagedValue SILGenBuilder::createAllocRefDynamic(
 
   AllocRefDynamicInst *i =
       createAllocRefDynamic(loc, operand.getValue(), refType, objc, false,
+                            StackAllocationIsNested,
                             elementTypes, elementCountOperands);
   return SGF.emitManagedRValueWithCleanup(i);
 }

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -1042,7 +1042,8 @@ void SILGenFunction::emitClassConstructorAllocator(ConstructorDecl *ctor) {
     }
 
     selfValue = B.createAllocRefDynamic(Loc, allocArg, selfTy,
-                                        useObjCAllocation, false, {}, {});
+                                        useObjCAllocation, false,
+                                        StackAllocationIsNested, {}, {});
   } else {
     assert(ctor->isDesignatedInit());
     // For a designated initializer, we know that the static type being
@@ -1050,6 +1051,7 @@ void SILGenFunction::emitClassConstructorAllocator(ConstructorDecl *ctor) {
     // initializer.
     F.setIsExactSelfClass(IsExactSelfClass);
     selfValue = B.createAllocRef(Loc, selfTy, useObjCAllocation, false, false,
+                                 StackAllocationIsNested,
                                  ArrayRef<SILType>(), ArrayRef<SILValue>());
   }
   args.push_back(selfValue);

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -1053,6 +1053,40 @@ void StmtEmitter::visitPoundAssertStmt(PoundAssertStmt *stmt) {
       SGF.getLoweredType(resultType), {}, {i1Value, message});
 }
 
+/// Should we use "inline defer", which avoids emitting a separate
+/// defer function and instead just emits the body inline as a cleanup?
+///
+/// This is arguably a superior emission approach in general for small
+/// defer bodies, and even for large defer bodies if we found a way to
+/// avoid duplicating the code. But for now, limit to cases where we
+/// truly need it, like when there's a use/def relationship that we
+/// need to build in SIL. Those should all involve builtin calls.
+static bool shouldUseInlineDefer(FuncDecl *deferDecl) {
+  auto body = deferDecl->getBody();
+  assert(body);
+
+  // Require the body to have the exact form:
+  //   defer { Builtin.foo(...) }
+  // (possibly with try/unsafe/await markers)
+
+  auto expr = body->getSingleActiveExpression();
+  if (!expr) return false;
+  expr = expr->getSemanticsProvidingExpr();
+  auto call = dyn_cast<CallExpr>(expr);
+  if (!call) return false;
+  auto memberRef = dyn_cast<DotSyntaxBaseIgnoredExpr>(call->getFn());
+  if (!memberRef) return false;
+  auto fnRef = dyn_cast<DeclRefExpr>(memberRef->getRHS());
+  if (!fnRef) return false;
+  auto builtinFn = dyn_cast<FuncDecl>(fnRef->getDecl());
+  if (!builtinFn) return false;
+  if (!builtinFn->getModuleContext()->isBuiltinModule()) return false;
+
+  // We could limit this to specific builtins at this point, but that
+  // seems unnecessary.
+  return true;
+}
+
 namespace {
   // This is a little cleanup that ensures that there are no jumps out of a
   // defer body.  The cleanup is only active and installed when emitting the
@@ -1072,10 +1106,31 @@ namespace {
 #endif
     }
   };
-} // end anonymous namespace
 
+  class InlineDeferCleanup : public Cleanup {
+    SourceLoc deferLoc;
+    FuncDecl *deferDecl;
+  public:
+    InlineDeferCleanup(SourceLoc deferLoc, FuncDecl *deferDecl)
+      : deferLoc(deferLoc), deferDecl(deferDecl) {}
+    void emit(SILGenFunction &SGF, CleanupLocation l, ForUnwind_t forUnwind) override {
+      SGF.Cleanups.pushCleanup<DeferEscapeCheckerCleanup>(deferLoc);
+      auto TheCleanup = SGF.Cleanups.getTopCleanup();
 
-namespace {
+      auto body = deferDecl->getBody()->getSingleActiveExpression();
+      SGF.emitIgnoredExpr(body);
+      
+      if (SGF.B.hasValidInsertionPoint())
+        SGF.Cleanups.setCleanupState(TheCleanup, CleanupState::Dead);
+    }
+    void dump(SILGenFunction &) const override {
+#ifndef NDEBUG
+      llvm::errs() << "InlineDeferCleanup\n"
+                   << "State: " << getState() << "\n";
+#endif
+    }
+  };
+
   class DeferCleanup : public Cleanup {
     SourceLoc deferLoc;
     Expr *call;
@@ -1100,12 +1155,18 @@ namespace {
   };
 } // end anonymous namespace
 
-
 void StmtEmitter::visitDeferStmt(DeferStmt *S) {
+  FuncDecl *deferDecl = S->getTempDecl();
+
+  // Check if the defer should use the inline defer mechanism.
+  if (shouldUseInlineDefer(deferDecl)) {
+    SGF.Cleanups.pushCleanup<InlineDeferCleanup>(S->getDeferLoc(), deferDecl);
+    return;
+  }
+
   // Emit the closure for the defer, along with its binding.
   // If the defer is at the top-level code, insert 'mark_escape_inst'
-  // to the top-level code to check initialization of any captured globals.
-  FuncDecl *deferDecl = S->getTempDecl();
+  // to the top-level code to check initialization of any captured globals.  
   auto *Ctx = deferDecl->getDeclContext();
   if (isa<TopLevelCodeDecl>(Ctx) && SGF.isEmittingTopLevelCode()) {
       auto Captures = deferDecl->getCaptureInfo();

--- a/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
@@ -341,8 +341,8 @@ public:
       auto NPA = B.createPartialApply(getClosure()->getLoc(), V, {}, Args,
                                       PA->getCalleeConvention(),
                                       PA->getResultIsolation(),
-                                      PA->isOnStack());
-      NPA->setStackAllocationIsNested(PA->isStackAllocationNested());
+                                      PA->isOnStack(),
+                                      PA->isStackAllocationNested());
       return NPA;
     }
 
@@ -885,8 +885,7 @@ SILValue ClosureSpecCloner::cloneCalleeConversion(
     auto NewPA = Builder.createPartialApply(
         CallSiteDesc.getLoc(), FunRef, {}, {calleeValue},
         PAI->getCalleeConvention(), PAI->getResultIsolation(),
-        PAI->isOnStack());
-    NewPA->setStackAllocationIsNested(PAI->isStackAllocationNested());
+        PAI->isOnStack(), PAI->isStackAllocationNested());
     // If the partial_apply is on stack we will emit a dealloc_stack in the
     // epilog.
     NeedsRelease.push_back(NewPA);

--- a/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
+++ b/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
@@ -1563,8 +1563,7 @@ processPartialApplyInst(SILOptFunctionBuilder &funcBuilder,
   auto *newPAI = builder.createPartialApply(
       pai->getLoc(), fnVal, pai->getSubstitutionMap(), args,
       pai->getCalleeConvention(), pai->getResultIsolation(),
-      pai->isOnStack());
-  newPAI->setStackAllocationIsNested(pai->isStackAllocationNested());
+      pai->isOnStack(), pai->isStackAllocationNested());
   pai->replaceAllUsesWith(newPAI);
   pai->eraseFromParent();
   if (fri->use_empty()) {

--- a/lib/SILOptimizer/SILCombiner/SILCombinerCastVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerCastVisitors.cpp
@@ -926,11 +926,11 @@ SILCombiner::visitConvertFunctionInst(ConvertFunctionInst *cfi) {
         SmallVector<SILValue, 4> args(pa->getArguments().begin(),
                                       pa->getArguments().end());
 
+        // FIXME: should this be preserving escapingness and nestedness?
         auto newPA = Builder.createPartialApply(
             pa->getLoc(), cfi->getOperand(), pa->getSubstitutionMap(), args,
             pa->getFunctionType()->getCalleeConvention(),
             pa->getResultIsolation());
-        newPA->setStackAllocationIsNested(pa->isStackAllocationNested());
         auto newConvert = Builder.createConvertFunction(pa->getLoc(), newPA,
                                                         partialApplyTy, false);
         replaceInstUsesWith(*pa, newConvert);
@@ -949,11 +949,11 @@ SILCombiner::visitConvertFunctionInst(ConvertFunctionInst *cfi) {
           makeCopiedValueAvailable(cfi->getOperand(), pa->getParent());
 
       SILBuilderWithScope localBuilder(std::next(pa->getIterator()), Builder);
+      // FIXME: should this be preserving escapingness and nestedness?
       auto *newPA = localBuilder.createPartialApply(
           pa->getLoc(), newValue, pa->getSubstitutionMap(), args,
           pa->getFunctionType()->getCalleeConvention(),
           pa->getResultIsolation());
-      newPA->setStackAllocationIsNested(pa->isStackAllocationNested());
       if (!use->isLifetimeEnding()) {
         localBuilder.emitDestroyValueOperation(pa->getLoc(), newValue);
       }

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -1513,6 +1513,7 @@ visitAllocRefDynamicInst(AllocRefDynamicInst *ARDI) {
     NewInst = Builder.createAllocRef(ARDI->getLoc(), SILInstanceTy,
                                      ARDI->isObjC(), ARDI->canAllocOnStack(),
                                      /*isBare=*/ false,
+                                     ARDI->isStackAllocationNested(),
                                      ARDI->getTailAllocatedTypes(),
                                      getCounts(ARDI));
 
@@ -1539,6 +1540,7 @@ visitAllocRefDynamicInst(AllocRefDynamicInst *ARDI) {
       NewInst = Builder.createAllocRef(ARDI->getLoc(), SILInstanceTy,
                                        ARDI->isObjC(), ARDI->canAllocOnStack(),
                                        /*isBare=*/ false,
+                                       ARDI->isStackAllocationNested(),
                                        ARDI->getTailAllocatedTypes(),
                                        getCounts(ARDI));
     }
@@ -1566,7 +1568,7 @@ visitAllocRefDynamicInst(AllocRefDynamicInst *ARDI) {
       return nullptr;
     NewInst = Builder.createAllocRef(
         ARDI->getLoc(), *instanceTy, ARDI->isObjC(), false,
-        /*isBare=*/ false,
+        /*isBare=*/ false, StackAllocationIsNested,
         ARDI->getTailAllocatedTypes(), getCounts(ARDI));
     NewInst = Builder.createUncheckedRefCast(ARDI->getLoc(), NewInst,
                                              ARDI->getType());

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -1198,12 +1198,11 @@ specializeApplySite(SILOptFunctionBuilder &FuncBuilder, ApplySite Apply,
   switch (Apply.getKind()) {
   case ApplySiteKind::PartialApplyInst: {
     auto *PAI = cast<PartialApplyInst>(ApplyInst);
-    auto NewPAI = Builder.createPartialApply(
+    return Builder.createPartialApply(
         Apply.getLoc(), FunctionRef, Apply.getSubstitutionMap(), Args,
         PAI->getCalleeConvention(), PAI->getResultIsolation(), PAI->isOnStack(),
+        PAI->isStackAllocationNested(),
         GenericSpecializationInformation::create(ApplyInst, Builder));
-    NewPAI->setStackAllocationIsNested(PAI->isStackAllocationNested());
-    return NewPAI;
   }
   case ApplySiteKind::ApplyInst:
     return Builder.createApply(

--- a/lib/SILOptimizer/Transforms/PartialApplySimplification.cpp
+++ b/lib/SILOptimizer/Transforms/PartialApplySimplification.cpp
@@ -392,12 +392,11 @@ rewriteKnownCalleeConventionOnly(SILFunction *callee,
     switch (site.getKind()) {
     case ApplySiteKind::PartialApplyInst: {
       auto pa = cast<PartialApplyInst>(site.getInstruction());
-      auto newPA = B.createPartialApply(loc, fr, site.getSubstitutionMap(), args,
-                                        pa->getCalleeConvention(),
-                                        pa->getResultIsolation(),
-                                        pa->isOnStack());
-      newPA->setStackAllocationIsNested(pa->isStackAllocationNested());
-      newInst = newPA;
+      newInst = B.createPartialApply(loc, fr, site.getSubstitutionMap(), args,
+                                     pa->getCalleeConvention(),
+                                     pa->getResultIsolation(),
+                                     pa->isOnStack(),
+                                     pa->isStackAllocationNested());
       break;
     }
     case ApplySiteKind::ApplyInst:
@@ -836,13 +835,16 @@ rewriteKnownCalleeWithExplicitContext(SILFunction *callee,
                                      : contextParam.getConvention();
       auto paOnStack = isNoEscape ? PartialApplyInst::OnStack
                                   : PartialApplyInst::NotOnStack;
+      auto paIsNested = (paOnStack && oldPA->isOnStack())
+                          ? oldPA->isStackAllocationNested()
+                          : StackAllocationIsNested;
       auto newPA = B.createPartialApply(loc, newFunctionRef,
                                      site.getSubstitutionMap(),
                                      newArgs,
                                      paConvention,
                                      paIsolation,
-                                     paOnStack);
-      newPA->setStackAllocationIsNested(oldPA->isStackAllocationNested());
+                                     paOnStack,
+                                     paIsNested);
       assert(isSimplePartialApply(newPA)
              && "partial apply wasn't simple after transformation?");
       newInst = newPA;

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -2665,8 +2665,7 @@ swift::replaceWithSpecializedCallee(ApplySite applySite, SILValue callee,
     auto *newPAI = builder.createPartialApply(
         loc, callee, subs, arguments,
         pai->getCalleeConvention(), pai->getResultIsolation(),
-        pai->isOnStack());
-    newPAI->setStackAllocationIsNested(pai->isStackAllocationNested());
+        pai->isOnStack(), pai->isStackAllocationNested());
     pai->replaceAllUsesWith(newPAI);
     return newPAI;
   }
@@ -3528,8 +3527,7 @@ void swift::trySpecializeApplyOfGeneric(
     SingleValueInstruction *newPAI = Builder.createPartialApply(
       PAI->getLoc(), FRI, Subs, Arguments,
       PAI->getCalleeConvention(), PAI->getResultIsolation(),
-      PAI->isOnStack());
-    newPAI->setStackAllocationIsNested(PAI->isStackAllocationNested());
+      PAI->isOnStack(), PAI->isStackAllocationNested());
     PAI->replaceAllUsesWith(newPAI);
     DeadApplies.insert(PAI);
     return;

--- a/lib/SILOptimizer/Utils/StackNesting.cpp
+++ b/lib/SILOptimizer/Utils/StackNesting.cpp
@@ -199,7 +199,10 @@ static void createDealloc(SILBuilder &B, SILLocation loc, SILInstruction *alloc)
     return;
   }
   case StackAllocationKind::BuiltinStartAsyncLet:
-    llvm_unreachable("cannot insert finishAsyncLet builtin; not safely reorderable");
+  case StackAllocationKind::BuiltinTaskLocalValuePush:
+  case StackAllocationKind::BuiltinTaskAddPriorityEscalationHandler:
+  case StackAllocationKind::BuiltinTaskAddCancellationHandler:
+    llvm_unreachable("cannot insert this builtin; not safely reorderable");
     return;
   case StackAllocationKind::AllocPackMetadata:
     B.createDeallocPackMetadata(loc, allocation->getValue());
@@ -229,6 +232,9 @@ static bool isUnreorderableAllocation(StackAllocation allocation) {
 
   // The finish of an async let cannot be reordered across.
   case StackAllocationKind::BuiltinStartAsyncLet:
+  case StackAllocationKind::BuiltinTaskLocalValuePush:
+  case StackAllocationKind::BuiltinTaskAddPriorityEscalationHandler:
+  case StackAllocationKind::BuiltinTaskAddCancellationHandler:
     return true;
   }
   llvm_unreachable("unknown stack allocation");

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -2363,12 +2363,10 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
       IsNestedEncoding((flags >> 0) & 1) == IsNestedEncoding::IsNested);
 
     // FIXME: Why the arbitrary order difference in IRBuilder type argument?
-    auto PAI = Builder.createPartialApply(
+    ResultInst = Builder.createPartialApply(
         Loc, FnVal, Substitutions, Args,
-        closureTy->getCalleeConvention(), closureTy->getIsolation(), onStack);
-    PAI->setStackAllocationIsNested(isNested);
-
-    ResultInst = PAI;
+        closureTy->getCalleeConvention(), closureTy->getIsolation(), onStack,
+        isNested);
     break;
   }
   case SILInstructionKind::BuiltinInst: {

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -2213,6 +2213,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     unsigned Flags = ListOfValues[0];
     bool isObjC = (bool)(Flags & 1);
     bool canAllocOnStack = (bool)((Flags >> 1) & 1);
+    bool isBare = (bool)((Flags >> 2) & 1);
+    auto isNested = StackAllocationIsNested_t((bool) ((Flags >> 3) & 1));
     SILType ClassTy =
         getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn);
     SmallVector<SILValue, 4> Counts;
@@ -2236,12 +2238,12 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
                                           ListOfValues[i], MetadataType);
       ResultInst = Builder.createAllocRefDynamic(Loc, MetadataOp, ClassTy,
                                                  isObjC, canAllocOnStack,
+                                                 isNested,
                                                  TailTypes, Counts);
     } else {
       assert(i == NumVals);
-      bool isBare = (bool)((Flags >> 2) & 1);
       ResultInst = Builder.createAllocRef(Loc, ClassTy, isObjC, canAllocOnStack, isBare,
-                                          TailTypes, Counts);
+                                          isNested, TailTypes, Counts);
     }
     break;
   }

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1318,7 +1318,8 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
       isBare = ar->isBare();
     Args.push_back((unsigned)ARI->isObjC() |
                    ((unsigned)ARI->canAllocOnStack() << 1) |
-                   ((unsigned)isBare << 2));
+                   ((unsigned)isBare << 2) |
+                   ((unsigned)ARI->isStackAllocationNested() << 3));
     ArrayRef<SILType> TailTypes = ARI->getTailAllocatedTypes();
     ArrayRef<Operand> AllOps = ARI->getAllOperands();
     unsigned NumTailAllocs = TailTypes.size();

--- a/test/IRGen/builtins.swift
+++ b/test/IRGen/builtins.swift
@@ -928,32 +928,31 @@ func allocateVector<Element>(elementType: Element.Type, capacity: Builtin.Word) 
   return Builtin.allocVector(elementType, capacity)
 }
 
-// CHECK-LABEL: define{{.*}} void @"$s8builtins30testTaskAddCancellationHandlerSV_SVtyYaF"(ptr swiftasync %0, i64 %1, i64 %2)
-// CHECK: [[RESULT:%.*]] = call{{.*}} @swift_task_addCancellationHandler(ptr @"$s8builtins30testTaskAddCancellationHandlerSV_SVtyYaFyyXEfU_{{(.ptrauth)?}}", ptr null)
+// CHECK-LABEL: define{{.*}} void @"$s8builtins30testTaskAddCancellationHandleryyYaF"(ptr swiftasync %0, i64 %1, i64 %2)
+// CHECK: [[RESULT:%.*]] = call{{.*}} @swift_task_addCancellationHandler(ptr @"$s8builtins30testTaskAddCancellationHandleryyYaFyyXEfU_{{(.ptrauth)?}}", ptr null)
 // CHECK: [[CONTEXT:%.*]] = call{{.*}} @swift_allocObject(ptr getelementptr inbounds (%swift.full_boxmetadata, ptr @metadata, i32 0, i32 2), i64 32, i64 7)
-// CHECK: [[RESULT_2:%.*]] = call {{.*}} @swift_task_addCancellationHandler(ptr @"$s8builtins30testTaskAddCancellationHandlerSV_SVtyYaFyyXEfU0_TA{{(.ptrauth)?}}", ptr [[CONTEXT]])
-// CHECK: musttail call swifttailcc void {{%.*}}(ptr swiftasync {{.*}}, ptr [[RESULT]], ptr [[RESULT_2]])
-nonisolated(nonsending) func testTaskAddCancellationHandler() async -> (UnsafeRawPointer, UnsafeRawPointer) {
+// CHECK: [[RESULT_2:%.*]] = call {{.*}} @swift_task_addCancellationHandler(ptr @"$s8builtins30testTaskAddCancellationHandleryyYaFyyXEfU0_TA{{(.ptrauth)?}}", ptr [[CONTEXT]])
+// CHECK: call{{.*}} void @swift_task_removeCancellationHandler(ptr [[RESULT_2]])
+// CHECK: call{{.*}} void @swift_task_removeCancellationHandler(ptr [[RESULT]])
+// CHECK: musttail call swifttailcc void {{%.*}}(ptr swiftasync {{.*}})
+nonisolated(nonsending) func testTaskAddCancellationHandler() async {
   let result = Builtin.taskAddCancellationHandler {}
   let x = "123" 
   let result2 = Builtin.taskAddCancellationHandler {
     print(x)
   }
-  return (result, result2)
+  Builtin.taskRemoveCancellationHandler(record: result2)
+  Builtin.taskRemoveCancellationHandler(record: result)
 }
 
-// CHECK-LABEL: define {{.*}}void @"$s8builtins33testTaskRemoveCancellationHandleryySVYaF"(ptr swiftasync %0, i64 %1, i64 %2, ptr %3)
-// CHECK: call{{.*}} @swift_task_removeCancellationHandler(ptr %3)
-nonisolated(nonsending) func testTaskRemoveCancellationHandler(_ x: UnsafeRawPointer) async {
-  Builtin.taskRemoveCancellationHandler(record: x)
-}
-
-// CHECK-LABEL: define {{.*}}void @"$s8builtins36testTaskAddPriorityEscalationHandlerSV_SVtyYaF"(ptr swiftasync %0, i64 %1, i64 %2)
-// CHECK: [[RESULT:%.*]] = call{{.*}} @swift_task_addPriorityEscalationHandler(ptr @"$s8builtins36testTaskAddPriorityEscalationHandlerSV_SVtyYaFys5UInt8V_ADtXEfU_{{(.ptrauth)?}}", ptr null)
+// CHECK-LABEL: define {{.*}}void @"$s8builtins36testTaskAddPriorityEscalationHandleryyYaF"(ptr swiftasync %0, i64 %1, i64 %2)
+// CHECK: [[RESULT:%.*]] = call{{.*}} @swift_task_addPriorityEscalationHandler(ptr @"$s8builtins36testTaskAddPriorityEscalationHandleryyYaFys5UInt8V_ADtXEfU_{{(.ptrauth)?}}", ptr null)
 // CHECK: [[CONTEXT:%.*]] = call {{.*}}@swift_allocObject(ptr getelementptr inbounds (%swift.full_boxmetadata, ptr @metadata.3, i32 0, i32 2), i64 32, i64 7)
-// CHECK: [[RESULT_2:%.*]] = call{{.*}} @swift_task_addPriorityEscalationHandler(ptr @"$s8builtins36testTaskAddPriorityEscalationHandlerSV_SVtyYaFys5UInt8V_ADtXEfU0_TA{{(.ptrauth)?}}", ptr [[CONTEXT]])
-// CHECK: musttail call swifttailcc void {{%.*}}(ptr swiftasync {{%.*}}, ptr [[RESULT]], ptr [[RESULT_2]])
-nonisolated(nonsending) func testTaskAddPriorityEscalationHandler() async -> (UnsafeRawPointer, UnsafeRawPointer) {
+// CHECK: [[RESULT_2:%.*]] = call{{.*}} @swift_task_addPriorityEscalationHandler(ptr @"$s8builtins36testTaskAddPriorityEscalationHandleryyYaFys5UInt8V_ADtXEfU0_TA{{(.ptrauth)?}}", ptr [[CONTEXT]])
+// CHECK: call{{.*}} @swift_task_removePriorityEscalationHandler(ptr [[RESULT_2]])
+// CHECK: call{{.*}} @swift_task_removePriorityEscalationHandler(ptr [[RESULT]])
+// CHECK: musttail call swifttailcc void {{%.*}}(ptr swiftasync {{%.*}})
+nonisolated(nonsending) func testTaskAddPriorityEscalationHandler() async {
   let result = Builtin.taskAddPriorityEscalationHandler { (x: UInt8, y: UInt8) in
     _ = x
     _ = y
@@ -964,13 +963,8 @@ nonisolated(nonsending) func testTaskAddPriorityEscalationHandler() async -> (Un
     _ = x
     _ = y
   }
-  return (result, result2)
-}
-
-// CHECK-LABEL: define {{.*}}void @"$s8builtins39testTaskRemovePriorityEscalationHandleryySVYaF"(ptr swiftasync %0, i64 %1, i64 %2, ptr %3)
-// CHECK: call{{.*}} @swift_task_removePriorityEscalationHandler(ptr %3)
-nonisolated(nonsending) func testTaskRemovePriorityEscalationHandler(_ x: UnsafeRawPointer) async {
-  Builtin.taskRemovePriorityEscalationHandler(record: x)
+  Builtin.taskRemovePriorityEscalationHandler(record: result2)
+  Builtin.taskRemovePriorityEscalationHandler(record: result)
 }
 
 // CHECK-LABEL: define {{.*}}void @"$s8builtins22testTaskLocalValuePushyyBp_xntYalF"(ptr swiftasync %0, i64 %1, i64 %2, ptr %3, ptr noalias %4, ptr %Value)

--- a/test/SIL/Parser/basic.sil
+++ b/test/SIL/Parser/basic.sil
@@ -265,6 +265,23 @@ bb0:
   return %6 : $()
 }
 
+// CHECK-LABEL: sil @test_alloc_ref_non_nested : $@convention(thin) () -> () {
+sil @test_alloc_ref_non_nested : $@convention(thin)  () -> () {
+bb0:
+  // CHECK: %0 = alloc_ref [stack] [non_nested] $C
+  %0 = alloc_ref [stack] [non_nested] $C
+  dealloc_stack_ref %0
+
+  %2 = metatype $@thick C.Type
+
+  // CHECK: %3 = alloc_ref_dynamic [stack] [non_nested] %2 : $@thick C.Type, $C
+  %3 = alloc_ref_dynamic [stack] [non_nested] %2 : $@thick C.Type, $C
+  dealloc_stack_ref %3
+
+  %result = tuple ()
+  return %result
+}
+
 sil @optional_upcasts : $@convention(thin) (Optional<D>) -> () {
 bb0(%0: $Optional<D>):
   // CHECK: upcast {{.*}} : $Optional<D> to $Optional<C>

--- a/test/SIL/Serialization/basic.sil
+++ b/test/SIL/Serialization/basic.sil
@@ -12,6 +12,8 @@ class TestArrayStorage {
   init()
 }
 
+class C {}
+
 struct TestArray2 {
   var storage : TestArrayStorage
   var someValue : Int32
@@ -27,6 +29,23 @@ struct EmptyStruct {}
 struct MoveOnlyStruct: ~Copyable {
   @_hasStorage var i: Int32
   deinit
+}
+
+// CHECK-LABEL: sil @alloc_ref_non_nested : $@convention(thin) () -> ()
+sil @alloc_ref_non_nested : $@convention(thin)  () -> () {
+bb0:
+  // CHECK: %0 = alloc_ref [stack] [non_nested] $C
+  %0 = alloc_ref [stack] [non_nested] $C
+  dealloc_stack_ref %0
+
+  %2 = metatype $@thick C.Type
+
+  // CHECK: %3 = alloc_ref_dynamic [stack] [non_nested] %2 : $@thick C.Type, $C
+  %3 = alloc_ref_dynamic [stack] [non_nested] %2 : $@thick C.Type, $C
+  dealloc_stack_ref %3
+
+  %result = tuple ()
+  return %result
 }
 
 // CHECK-LABEL: sil @async_test : $@convention(thin) @async

--- a/test/SILGen/builtins.swift
+++ b/test/SILGen/builtins.swift
@@ -904,56 +904,64 @@ func injectEnumTag<T>(_ x: inout T, tag: Builtin.Int32) {
   Builtin.injectEnumTag(&x, tag)
 }
 
-// CHECK-LABEL: sil hidden [ossa] @$s8builtins30testTaskAddCancellationHandlerSV_SVtyYaF : $@convention(thin) @async () -> (UnsafeRawPointer, UnsafeRawPointer) {
-// CHECK:   [[CLOSURE_FN:%.*]] = function_ref @$s8builtins30testTaskAddCancellationHandlerSV_SVtyYaFyyXEfU_ : $@convention(thin) () -> ()
+// CHECK-LABEL: sil hidden [ossa] @$s8builtins30testTaskAddCancellationHandleryyYaF : $@convention(thin) @async () -> () {
+// CHECK:   [[CLOSURE_FN:%.*]] = function_ref @$s8builtins30testTaskAddCancellationHandleryyYaFyyXEfU_ : $@convention(thin) () -> ()
 // CHECK:   [[CLOSURE:%.*]] = thin_to_thick_function [[CLOSURE_FN]]
 // CHECK:   [[RESULT_VALUE:%.*]] = builtin "taskAddCancellationHandler"([[CLOSURE]] : $@noescape @callee_guaranteed () -> ()) : $UnsafeRawPointer
 // CHECK:   [[RESULT:%.*]] = move_value [var_decl] [[RESULT_VALUE]]
-// CHECK:   [[CLOSURE_FN_2:%.*]] = function_ref @$s8builtins30testTaskAddCancellationHandlerSV_SVtyYaFyyXEfU0_ : $@convention(thin) (@guaranteed String) -> ()
+// CHECK:   [[CLOSURE_FN_2:%.*]] = function_ref @$s8builtins30testTaskAddCancellationHandleryyYaFyyXEfU0_ : $@convention(thin) (@guaranteed String) -> ()
 // CHECK:   [[CLOSURE_PA:%.*]] = partial_apply [callee_guaranteed] [[CLOSURE_FN_2]]({{%.*}}) :
 // CHECK:   [[CLOSURE_CVT:%.*]] = convert_escape_to_noescape [not_guaranteed] [[CLOSURE_PA]]
 // CHECK:   [[RESULT_VALUE_2:%.*]] = builtin "taskAddCancellationHandler"([[CLOSURE_CVT]] : $@noescape @callee_guaranteed () -> ()) : $UnsafeRawPointer
 // CHECK:   [[RESULT_2:%.*]] = move_value [var_decl] [[RESULT_VALUE_2]]
-// CHECK:   [[TUPLE:%.*]] = tuple ([[RESULT]] : $UnsafeRawPointer, [[RESULT_2]] : $UnsafeRawPointer)
+// CHECK:   builtin "taskRemoveCancellationHandler"([[RESULT_2]] : $UnsafeRawPointer)
+// CHECK:   builtin "taskRemoveCancellationHandler"([[RESULT]] : $UnsafeRawPointer)
+// CHECK:   [[TUPLE:%.*]] = tuple ()
 // CHECK:   return [[TUPLE]]
-// CHECK: } // end sil function '$s8builtins30testTaskAddCancellationHandlerSV_SVtyYaF'
-func testTaskAddCancellationHandler() async -> (UnsafeRawPointer, UnsafeRawPointer) {
+// CHECK: } // end sil function '$s8builtins30testTaskAddCancellationHandleryyYaF'
+func testTaskAddCancellationHandler() async {
   let result = Builtin.taskAddCancellationHandler {
   }
   let x = "123"
   let result2 = Builtin.taskAddCancellationHandler { print(x) }
-  return (result, result2)
+  Builtin.taskRemoveCancellationHandler(record: result2)
+  Builtin.taskRemoveCancellationHandler(record: result)
 }
 
-// CHECK-LABEL: sil hidden [ossa] @$s8builtins33testTaskRemoveCancellationHandleryySVYaF : $@convention(thin) @async (UnsafeRawPointer) -> ()
-// CHECK: bb0([[PTR:%.*]] : $UnsafeRawPointer):
-// CHECK:   builtin "taskRemoveCancellationHandler"([[PTR]] : $UnsafeRawPointer) : $()
-// CHECK: } // end sil function '$s8builtins33testTaskRemoveCancellationHandleryySVYaF'
-func testTaskRemoveCancellationHandler(_ x: UnsafeRawPointer) async {
-  Builtin.taskRemoveCancellationHandler(record: x)
-}
-
-// CHECK-LABEL: sil hidden [ossa] @$s8builtins36testTaskAddPriorityEscalationHandlerSVyYaF : $@convention(thin) @async () -> UnsafeRawPointer {
-// CHECK:   [[CLOSURE_FN:%.*]] = function_ref @$s8builtins36testTaskAddPriorityEscalationHandlerSVyYaFys5UInt8V_ADtXEfU_ : $@convention(thin) (UInt8, UInt8) -> ()
+// CHECK-LABEL: sil hidden [ossa] @$s8builtins36testTaskAddPriorityEscalationHandleryyYaF : $@convention(thin) @async () -> () {
+// CHECK:   [[CLOSURE_FN:%.*]] = function_ref @$s8builtins36testTaskAddPriorityEscalationHandleryyYaFys5UInt8V_ADtXEfU_ : $@convention(thin) (UInt8, UInt8) -> ()
 // CHECK:   [[CLOSURE:%.*]] = thin_to_thick_function [[CLOSURE_FN]]
 // CHECK:   [[RESULT_VALUE:%.*]] = builtin "taskAddPriorityEscalationHandler"([[CLOSURE]] : $@noescape @callee_guaranteed (UInt8, UInt8) -> ()) : $UnsafeRawPointer
 // CHECK:   [[RESULT:%.*]] = move_value [var_decl] [[RESULT_VALUE]]
-// CHECK:   return [[RESULT]]
-// CHECK: } // end sil function '$s8builtins36testTaskAddPriorityEscalationHandlerSVyYaF'
-func testTaskAddPriorityEscalationHandler() async -> UnsafeRawPointer {
+// CHECK:   builtin "taskRemovePriorityEscalationHandler"([[RESULT]] : $UnsafeRawPointer) : $()
+// CHECK:   [[TUPLE:%.*]] = tuple ()
+// CHECK:   return [[TUPLE]]
+// CHECK: } // end sil function '$s8builtins36testTaskAddPriorityEscalationHandleryyYaF'
+func testTaskAddPriorityEscalationHandler() async {
   let result = Builtin.taskAddPriorityEscalationHandler { (x: UInt8, y: UInt8) in
     _ = x
     _ = y
   }
-  return result
+  Builtin.taskRemovePriorityEscalationHandler(record: result)
 }
 
-// CHECK-LABEL: sil hidden [ossa] @$s8builtins39testTaskRemovePriorityEscalationHandleryySVYaF : $@convention(thin) @async (UnsafeRawPointer) -> () {
-// CHECK: bb0([[PTR:%.*]] : $UnsafeRawPointer):
-// CHECK:   builtin "taskRemovePriorityEscalationHandler"(%0 : $UnsafeRawPointer) : $()
-// CHECK: } // end sil function '$s8builtins39testTaskRemovePriorityEscalationHandleryySVYaF'
-func testTaskRemovePriorityEscalationHandler(_ x: UnsafeRawPointer) async {
-  Builtin.taskRemovePriorityEscalationHandler(record: x)
+//   Same as above, but checking the special case to emit defers that call
+//   builtin functions immediately.
+// CHECK-LABEL: sil hidden [ossa] @$s8builtins45testTaskAddPriorityEscalationHandlerWithDeferyyYaF : $@convention(thin) @async () -> () {
+// CHECK:   [[CLOSURE_FN:%.*]] = function_ref @$s8builtins45testTaskAddPriorityEscalationHandlerWithDeferyyYaFys5UInt8V_ADtXEfU_ : $@convention(thin) (UInt8, UInt8) -> ()
+// CHECK:   [[CLOSURE:%.*]] = thin_to_thick_function [[CLOSURE_FN]]
+// CHECK:   [[RESULT_VALUE:%.*]] = builtin "taskAddPriorityEscalationHandler"([[CLOSURE]] : $@noescape @callee_guaranteed (UInt8, UInt8) -> ()) : $UnsafeRawPointer
+// CHECK:   [[RESULT:%.*]] = move_value [var_decl] [[RESULT_VALUE]]
+// CHECK:   builtin "taskRemovePriorityEscalationHandler"([[RESULT]] : $UnsafeRawPointer) : $()
+// CHECK:   [[TUPLE:%.*]] = tuple ()
+// CHECK:   return [[TUPLE]]
+// CHECK: } // end sil function '$s8builtins45testTaskAddPriorityEscalationHandlerWithDeferyyYaF'
+func testTaskAddPriorityEscalationHandlerWithDefer() async {
+  let result = Builtin.taskAddPriorityEscalationHandler { (x: UInt8, y: UInt8) in
+    _ = x
+    _ = y
+  }
+  defer { Builtin.taskRemovePriorityEscalationHandler(record: result) }
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s8builtins22testTaskLocalValuePushyyBp_xntYalF : $@convention(thin) @async <Value> (Builtin.RawPointer, @in Value) -> () {

--- a/test/SILOptimizer/stack-nesting.sil
+++ b/test/SILOptimizer/stack-nesting.sil
@@ -3,6 +3,8 @@
 import Builtin
 import Swift
 
+class MyClass {}
+
 // CHECK-LABEL: sil [ossa] @test_simple
 // CHECK:         integer_literal $Builtin.Int32, 1
 // CHECK-NEXT:    [[A:%.*]] = alloc_stack $Int
@@ -515,6 +517,87 @@ bb0:
   dealloc_stack %a
   dealloc_stack %c
   integer_literal $Builtin.Int32, 4
+  %ret = tuple ()
+  return %ret : $()
+}
+
+sil [ossa] @partial_apply_helper : $@convention(thin) (@in_guaranteed Int) -> () {
+bb0(%0: $*Int):
+  unreachable
+}
+
+// partial_apply [on_stack] must be markable as non-nested
+// CHECK-LABEL: sil @test_mark_partial_apply_non_nested :
+// CHECK:         [[FN:%.*]] = function_ref @partial_apply_helper
+// CHECK:         partial_apply [callee_guaranteed] [on_stack] [non_nested] [[FN]](
+// CHECK-LABEL: // end sil function 'test_mark_partial_apply_non_nested'
+sil @test_mark_partial_apply_non_nested : $@convention(thin) @async () -> () {
+bb0:
+  specify_test "stack_nesting_fixup"
+
+  %a = alloc_stack $Int
+
+  %fn = function_ref @priority_helper : $@convention(thin) (UInt8, UInt8) -> ()
+  %thick_fn = thin_to_thick_function %fn to $@noescape @callee_guaranteed (UInt8, UInt8) -> ()
+  %handler = builtin "taskAddPriorityEscalationHandler"(%thick_fn) : $UnsafeRawPointer
+
+  %pafn = function_ref @partial_apply_helper : $@convention(thin) (@in_guaranteed Int) -> ()
+  %b = partial_apply [callee_guaranteed] [on_stack] %pafn(%a) : $@convention(thin) (@in_guaranteed Int) -> ()
+
+  %out = builtin "taskRemovePriorityEscalationHandler"(%handler) : $()
+
+  dealloc_stack %b
+  dealloc_stack %a
+
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// alloc_ref [stack] must be markable as non-nested
+// CHECK-LABEL: sil [ossa] @test_mark_alloc_ref_non_nested :
+// CHECK:         alloc_ref [stack] [non_nested] $MyClass
+// CHECK-LABEL: // end sil function 'test_mark_alloc_ref_non_nested'
+sil [ossa] @test_mark_alloc_ref_non_nested : $@convention(thin) @async () -> () {
+bb0:
+  specify_test "stack_nesting_fixup"
+
+  %fn = function_ref @priority_helper : $@convention(thin) (UInt8, UInt8) -> ()
+  %thick_fn = thin_to_thick_function %fn to $@noescape @callee_guaranteed (UInt8, UInt8) -> ()
+  %handler = builtin "taskAddPriorityEscalationHandler"(%thick_fn) : $UnsafeRawPointer
+
+  %b = alloc_ref [stack] $MyClass
+
+  %out = builtin "taskRemovePriorityEscalationHandler"(%handler) : $()
+
+  destroy_value %b
+  dealloc_stack_ref %b
+
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// alloc_ref_dynamic [stack] must be markable as non-nested
+// CHECK-LABEL: sil [ossa] @test_mark_alloc_ref_dynamic_non_nested :
+// CHECK:         [[METATYPE:%.*]] = metatype $@thick MyClass.Type
+// CHECK:         alloc_ref_dynamic [stack] [non_nested] [[METATYPE]]
+// CHECK-LABEL: // end sil function 'test_mark_alloc_ref_dynamic_non_nested'
+sil [ossa] @test_mark_alloc_ref_dynamic_non_nested : $@convention(thin) @async () -> () {
+bb0:
+  specify_test "stack_nesting_fixup"
+
+  %fn = function_ref @priority_helper : $@convention(thin) (UInt8, UInt8) -> ()
+  %thick_fn = thin_to_thick_function %fn to $@noescape @callee_guaranteed (UInt8, UInt8) -> ()
+  %handler = builtin "taskAddPriorityEscalationHandler"(%thick_fn) : $UnsafeRawPointer
+
+  %metatype = metatype $@thick MyClass.Type
+
+  %b = alloc_ref_dynamic [stack] %metatype, $MyClass
+
+  %out = builtin "taskRemovePriorityEscalationHandler"(%handler) : $()
+
+  destroy_value %b
+  dealloc_stack_ref %b
+
   %ret = tuple ()
   return %ret : $()
 }

--- a/test/SILOptimizer/stack-nesting.sil
+++ b/test/SILOptimizer/stack-nesting.sil
@@ -414,3 +414,107 @@ bb0(%cond: $Builtin.Int1):
   %ret = tuple ()
   return %ret : $()
 }
+
+sil private @cancellation_helper : $@convention(thin) () -> () {
+bb0:
+  unreachable
+}
+
+// The cancellation handler builtins cannot be reordered.
+// CHECK-LABEL: sil [ossa] @test_cancellation_non_nested :
+// CHECK:         integer_literal $Builtin.Int32, 1
+// CHECK-NEXT:    [[A:%.*]] = alloc_stack $Int
+// CHECK:         [[HANDLER:%.*]] = builtin "taskAddCancellationHandler"({{%.*}})
+// CHECK-NEXT:    integer_literal $Builtin.Int32, 2
+// CHECK-NEXT:    [[B:%.*]] = alloc_stack [non_nested] $Int
+// CHECK-NEXT:    [[C:%.*]] = alloc_stack [non_nested] $Int
+// CHECK-NEXT:    [[D:%.*]] = alloc_stack $Int
+// CHECK-NEXT:    dealloc_stack [[D]]
+// CHECK-NEXT:    integer_literal $Builtin.Int32, 3
+// CHECK-NEXT:    builtin "taskRemoveCancellationHandler"([[HANDLER]])
+// CHECK-NEXT:    dealloc_stack [[C]]
+// CHECK-NEXT:    dealloc_stack [[B]]
+// CHECK-NEXT:    dealloc_stack [[A]]
+// CHECK-NEXT:    integer_literal $Builtin.Int32, 4
+// CHECK-LABEL: // end sil function 'test_cancellation_non_nested'
+sil [ossa] @test_cancellation_non_nested : $@convention(thin) @async () -> () {
+bb0:
+  specify_test "stack_nesting_fixup"
+  integer_literal $Builtin.Int32, 1
+  %a = alloc_stack $Int
+
+  %fn = function_ref @cancellation_helper : $@convention(thin) () -> ()
+  %thick_fn = thin_to_thick_function %fn to $@noescape @callee_guaranteed () -> ()
+  %handler = builtin "taskAddCancellationHandler"(%thick_fn : $@noescape @callee_guaranteed () -> ()) : $UnsafeRawPointer
+
+  integer_literal $Builtin.Int32, 2
+
+  %b = alloc_stack $Int
+  %c = alloc_stack $Int
+  %d = alloc_stack $Int
+
+  dealloc_stack %d
+  dealloc_stack %b
+
+  integer_literal $Builtin.Int32, 3
+
+  %out = builtin "taskRemoveCancellationHandler"(%handler) : $()
+
+  dealloc_stack %a
+  dealloc_stack %c
+  integer_literal $Builtin.Int32, 4
+  %ret = tuple ()
+  return %ret : $()
+}
+
+sil private @priority_helper : $@convention(thin) (UInt8, UInt8) -> () {
+bb0(%0 : $UInt8, %1 : $UInt8):
+  unreachable
+}
+
+// The priority escalation handler builtins cannot be reordered.
+// CHECK-LABEL: sil [ossa] @test_priority_non_nested :
+// CHECK:         integer_literal $Builtin.Int32, 1
+// CHECK-NEXT:    [[A:%.*]] = alloc_stack $Int
+// CHECK:         [[HANDLER:%.*]] = builtin "taskAddPriorityEscalationHandler"({{%.*}})
+// CHECK-NEXT:    integer_literal $Builtin.Int32, 2
+// CHECK-NEXT:    [[B:%.*]] = alloc_stack [non_nested] $Int
+// CHECK-NEXT:    [[C:%.*]] = alloc_stack [non_nested] $Int
+// CHECK-NEXT:    [[D:%.*]] = alloc_stack $Int
+// CHECK-NEXT:    dealloc_stack [[D]]
+// CHECK-NEXT:    integer_literal $Builtin.Int32, 3
+// CHECK-NEXT:    builtin "taskRemovePriorityEscalationHandler"([[HANDLER]])
+// CHECK-NEXT:    dealloc_stack [[C]]
+// CHECK-NEXT:    dealloc_stack [[B]]
+// CHECK-NEXT:    dealloc_stack [[A]]
+// CHECK-NEXT:    integer_literal $Builtin.Int32, 4
+// CHECK-LABEL: // end sil function 'test_priority_non_nested'
+sil [ossa] @test_priority_non_nested : $@convention(thin) @async () -> () {
+bb0:
+  specify_test "stack_nesting_fixup"
+  integer_literal $Builtin.Int32, 1
+  %a = alloc_stack $Int
+
+  %fn = function_ref @priority_helper : $@convention(thin) (UInt8, UInt8) -> ()
+  %thick_fn = thin_to_thick_function %fn to $@noescape @callee_guaranteed (UInt8, UInt8) -> ()
+  %handler = builtin "taskAddPriorityEscalationHandler"(%thick_fn) : $UnsafeRawPointer
+
+  integer_literal $Builtin.Int32, 2
+
+  %b = alloc_stack $Int
+  %c = alloc_stack $Int
+  %d = alloc_stack $Int
+
+  dealloc_stack %d
+  dealloc_stack %b
+
+  integer_literal $Builtin.Int32, 3
+
+  %out = builtin "taskRemovePriorityEscalationHandler"(%handler) : $()
+
+  dealloc_stack %a
+  dealloc_stack %c
+  integer_literal $Builtin.Int32, 4
+  %ret = tuple ()
+  return %ret : $()
+}


### PR DESCRIPTION
I really wanted to get task locals in here, too, just to finish this off, but the builtins aren't modeled properly, so it'll have to wait.