### PR TITLE
[Sema] Fix failing to diagnose unused attrs, improve alias attribute diagnostic, preserve alias sugar

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1801,6 +1801,18 @@ ERROR(attribute_requires_experimental_feature,none,
 ERROR(nominal_type_not_attribute,none,
       "%kind0 cannot be used as an attribute", (const ValueDecl *))
 
+ERROR(attribute_part_of_type,none,
+      "attribute %0 cannot be applied to a type alias", (const TypeAttribute *))
+NOTE(add_attribute_to_alias_def,none,
+      "add %0 to the definition of %1",
+      (const TypeAttribute *, Type))
+NOTE(redundant_attribute_on_alias,none,
+      "%0 is redundant on %1",
+      (const TypeAttribute *, Type))
+NOTE(expand_type_alias,none,
+      "expand %0 to apply %1",
+      (Type, const TypeAttribute *))
+
 ERROR(mutating_invalid_global_scope,none, "%0 is only valid on methods",
       (SelfAccessKind))
 ERROR(mutating_invalid_classes,none, "%0 is not valid on %kindonly1s in "

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3475,10 +3475,10 @@ void TypeAttrSet::diagnoseUnclaimed(const TypeResolution &resolution,
   }
 
   // Type attributes
-  size_t i = 0;
-  for (auto const &attrVector : typeAttrs) {
-    if (claimedTypeAttrs.contains(i)) continue;
-    i++;
+  for (const auto &[i, attrVector] :
+       llvm::enumerate(std::as_const(typeAttrs))) {
+    if (claimedTypeAttrs.contains(i))
+      continue;
 
     for (auto attr : attrVector)
       diagnoseUnclaimed(attr, resolution, options, resolvedType);

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -29,6 +29,8 @@
 #include "swift/AST/ASTDemangler.h"
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/ASTWalker.h"
+#include "swift/AST/Attr.h"
+#include "swift/AST/AttrKind.h"
 #include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/DiagnosticsParse.h"
 #include "swift/AST/DiagnosticsSema.h"
@@ -65,6 +67,7 @@
 #include "clang/AST/DeclBase.h"
 #include "clang/AST/DeclTemplate.h"
 #include "llvm/ADT/APInt.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringSwitch.h"
@@ -2560,6 +2563,10 @@ namespace {
     llvm::SmallBitVector claimedCustomAttrs;
     FixedBitSet<NumTypeAttrKinds> claimedTypeAttrs;
 
+    /// The use-site TypeRepr after stripping attributes. Set by \c accumulate
+    /// to enable inline expansion fix-its for aliases in diagnostics.
+    TypeRepr *useSiteRepr = nullptr;
+
 #ifndef NDEBUG
     bool diagnosedUnclaimed = false;
 #endif
@@ -3387,7 +3394,10 @@ TypeRepr *TypeAttrSet::accumulate(AttributedTypeRepr *attrRepr) {
     accumulate(attrRepr->getAttrs());
     auto underlyingRepr = attrRepr->getTypeRepr();
     attrRepr = dyn_cast<AttributedTypeRepr>(underlyingRepr);
-    if (!attrRepr) return underlyingRepr;
+    if (!attrRepr) {
+      useSiteRepr = underlyingRepr;
+      return underlyingRepr;
+    }
   }
 }
 
@@ -3503,7 +3513,7 @@ void TypeAttrSet::diagnoseUnclaimed(CustomAttr *attr,
   diagnose(attr->getLocation(), diag::unknown_attr_name, typeName);
 }
 
-static bool isFunctionAttribute(TypeAttrKind attrKind) {
+static bool isFunctionAttribute(const TypeAttribute *attr) {
   static const TypeAttrKind FunctionAttrs[] = {
       TypeAttrKind::Convention,
       TypeAttrKind::Pseudogeneric,
@@ -3519,8 +3529,19 @@ static bool isFunctionAttribute(TypeAttrKind attrKind) {
       TypeAttrKind::YieldOnce2,
       TypeAttrKind::YieldMany,
       TypeAttrKind::Async,
+      TypeAttrKind::Isolated,
   };
-  return llvm::any_of(FunctionAttrs, [attrKind](TypeAttrKind functionAttr) {
+  return llvm::any_of(FunctionAttrs,
+                      [attrKind = attr->getKind()](TypeAttrKind functionAttr) {
+                        return functionAttr == attrKind;
+                      });
+}
+
+static bool isConcurrencyAttribute(const TypeAttribute *attr) {
+  static const TypeAttrKind ConcurrencyAttrs[] = {TypeAttrKind::Sendable,
+                                                  TypeAttrKind::Isolated};
+  return llvm::any_of(ConcurrencyAttrs,
+                      [attrKind = attr->getKind()](TypeAttrKind functionAttr) {
                         return functionAttr == attrKind;
                       });
 }
@@ -3541,29 +3562,86 @@ void TypeAttrSet::diagnoseUnclaimed(TypeAttribute *attr,
   }
 
   // Recognize function attributes being applied to non-functions.
-  if (isFunctionAttribute(attr->getKind()) &&
-      !resolvedType->is<AnyFunctionType>()) {
-    auto escapingAttr = dyn_cast<EscapingTypeAttr>(attr);
+  if (isFunctionAttribute(attr)) {
+    if (!resolvedType->is<AnyFunctionType>()) {
+      auto escapingAttr = dyn_cast<EscapingTypeAttr>(attr);
 
-    // Try to recognize `@escaping` placed on optional types.
-    if (escapingAttr) {
-      Type optionalObjectType = resolvedType->getOptionalObjectType();
-      if (optionalObjectType && optionalObjectType->is<AnyFunctionType>()) {
-        diagnose(escapingAttr->getAttrLoc(),
-                 diag::escaping_optional_type_argument)
-          .fixItRemove(attr->getSourceRange());
-        return;
+      // Try to recognize `@escaping` placed on optional types.
+      if (escapingAttr) {
+        Type optionalObjectType = resolvedType->getOptionalObjectType();
+        if (optionalObjectType && optionalObjectType->is<AnyFunctionType>()) {
+          diagnose(escapingAttr->getAttrLoc(),
+                   diag::escaping_optional_type_argument)
+              .fixItRemove(attr->getSourceRange());
+          return;
+        }
       }
-    }
 
-    auto diagnostic = diagnose(attr->getStartLoc(),
-                               diag::type_attr_requires_function_type, attr);
-    if (isa<EscapingTypeAttr>(attr))
-      diagnostic.fixItRemove(attr->getSourceRange());
-    return;
+      auto diagnostic = diagnose(attr->getStartLoc(),
+                                 diag::type_attr_requires_function_type, attr);
+      if (isa<EscapingTypeAttr>(attr))
+        diagnostic.fixItRemove(attr->getSourceRange());
+      return;
+    }
+    // If the function attribute is on an alias of a function type, emit a
+    // tailored diagnostic.
+    if (auto *alias =
+            dyn_cast<TypeAliasType>(resolvedType.get().getPointer())) {
+      diagnose(attr->getStartLoc(), diag::attribute_part_of_type, attr);
+
+      auto *aliasDecl = alias->getDecl();
+
+      // Suggest editing the typealias declaration when we can find it.
+      if (auto *aliasTypeRepr = aliasDecl->getUnderlyingTypeRepr()) {
+        // Unless the attribute is already on the type alias, then simply
+        // suggest removing it and bail.
+        auto *attributed = dyn_cast<AttributedTypeRepr>(aliasTypeRepr);
+        if (attributed && attributed->has(attr->getKind())) {
+          diagnose(attr->getStartLoc(), diag::redundant_attribute_on_alias,
+                   attr, alias)
+              .fixItRemove(attr->getSourceRange());
+          return;
+        }
+
+        auto note = diagnose(aliasDecl->getLoc(),
+                             diag::add_attribute_to_alias_def, attr, alias);
+
+        // Remove the attribute from the use of the alias.
+        note.fixItRemove(attr->getSourceRange());
+
+        // We need to get the underlying string to handle cases like
+        // @isolated(any)
+        auto &SM = ctx.SourceMgr;
+        auto CSR = Lexer::getCharSourceRangeFromSourceRange(
+            SM, attr->getSourceRange());
+        if (CSR.isValid()) {
+          auto attrText = SM.extractText(CSR);
+
+          // Add the attribute to the alias type.
+          note.fixItInsert(aliasTypeRepr->getStartLoc(),
+                           (attrText + " ").str());
+        }
+
+        // Fix-it should include preconcurrency to not change mangling when
+        // adding concurrency attributes.
+        if (isConcurrencyAttribute(attr) && !aliasDecl->preconcurrency()) {
+          note.fixItInsert(
+              aliasDecl->getAttributeInsertionLoc(/*forModifier=*/false),
+              "@preconcurrency ");
+        }
+      }
+      // Suggest inlining the alias if we got a use site.
+      if (useSiteRepr) {
+        diagnose(useSiteRepr->getLoc(), diag::expand_type_alias, alias, attr)
+            .fixItReplace(useSiteRepr->getSourceRange(),
+                          resolvedType->getDesugaredType()->getString());
+      }
+      return;
+    }
   }
 
-  ctx.Diags.diagnose(attr->getStartLoc(), diag::attribute_does_not_apply_to_type);
+  ctx.Diags.diagnose(attr->getStartLoc(),
+                     diag::attribute_does_not_apply_to_type);
 }
 
 Type TypeResolver::resolveGlobalActor(SourceLoc loc, TypeResolutionOptions options,

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -16,15 +16,16 @@
 //===----------------------------------------------------------------------===//
 
 #include "TypeCheckType.h"
+#include "LiteralExpressionFolding.h"
 #include "MiscDiagnostics.h"
 #include "NonisolatedNonsendingByDefaultMigration.h"
+#include "TypeCheckAccess.h"
 #include "TypeCheckAvailability.h"
 #include "TypeCheckConcurrency.h"
 #include "TypeCheckInvertible.h"
 #include "TypeCheckProtocol.h"
 #include "TypeChecker.h"
 #include "TypoCorrection.h"
-#include "LiteralExpressionFolding.h"
 
 #include "swift/AST/ASTDemangler.h"
 #include "swift/AST/ASTVisitor.h"
@@ -55,6 +56,7 @@
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/EnumMap.h"
 #include "swift/Basic/FixedBitSet.h"
+#include "swift/Basic/LanguageMode.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Basic/Statistic.h"
 #include "swift/Basic/StringExtras.h"
@@ -2673,7 +2675,8 @@ namespace {
     void diagnoseUnclaimed(TypeAttribute *attr,
                            const TypeResolution &resolution,
                            TypeResolutionOptions options,
-                           NeverNullType resolvedType);
+                           NeverNullType resolvedType,
+                           bool downgradeToWarning = false);
 
     template<typename ...ArgTypes>
     InFlightDiagnostic diagnose(ArgTypes &&...Args) const {
@@ -3480,14 +3483,30 @@ void TypeAttrSet::diagnoseUnclaimed(const TypeResolution &resolution,
     diagnoseUnclaimed(customAttr, resolution, options, resolvedType);
   }
 
+  // NOTE: In a previous version of this function, the index to claimedTypeAttrs
+  // was conditionally incremented only when an unclaimed type attr was found at
+  // i. The index would not be incremented if a claimed attribute was at i. This
+  // resulted in behavior where unclaimed attributes would only be reported if
+  // they preceded a claimed attribute; once i pointed to a claimed attribute,
+  // it would no longer get incremented and subsequent unclaimed attributes
+  // would be incorrectly skipped as though they were claimed and accepted. To
+  // avoid breaking previously accepted code in dependencies, unclaimed
+  // attributes that follow a claimed attribute need to be downgraded to a
+  // warning.
+
+  bool followsClaimed = false;
+
   // Type attributes
   for (const auto &[i, attrVector] :
        llvm::enumerate(std::as_const(typeAttrs))) {
-    if (claimedTypeAttrs.contains(i))
+    if (claimedTypeAttrs.contains(i)) {
+      followsClaimed = true;
       continue;
+    }
 
     for (auto attr : attrVector)
-      diagnoseUnclaimed(attr, resolution, options, resolvedType);
+      diagnoseUnclaimed(attr, resolution, options, resolvedType,
+                        followsClaimed);
   }
 }
 
@@ -3549,15 +3568,18 @@ static bool isConcurrencyAttribute(const TypeAttribute *attr) {
 void TypeAttrSet::diagnoseUnclaimed(TypeAttribute *attr,
                                     const TypeResolution &resolution,
                                     TypeResolutionOptions options,
-                                    NeverNullType resolvedType) {
-  if (attr->isInvalid()) return;
+                                    NeverNullType resolvedType,
+                                    bool downgradeToWarning) {
+  if (attr->isInvalid())
+    return;
 
   attr->setInvalid();
 
   // Use a special diagnostic for SIL attributes.
   if (!(options & TypeResolutionFlags::SILType) &&
       TypeAttribute::isSilOnly(attr->getKind())) {
-    diagnose(attr->getStartLoc(), diag::unknown_type_attr, attr);
+    diagnose(attr->getStartLoc(), diag::unknown_type_attr, attr)
+        .warnUntilLanguageModeIf(downgradeToWarning, LanguageMode::future);
     return;
   }
 
@@ -3572,6 +3594,7 @@ void TypeAttrSet::diagnoseUnclaimed(TypeAttribute *attr,
         if (optionalObjectType && optionalObjectType->is<AnyFunctionType>()) {
           diagnose(escapingAttr->getAttrLoc(),
                    diag::escaping_optional_type_argument)
+              .warnUntilLanguageModeIf(downgradeToWarning, LanguageMode::future)
               .fixItRemove(attr->getSourceRange());
           return;
         }
@@ -3579,6 +3602,8 @@ void TypeAttrSet::diagnoseUnclaimed(TypeAttribute *attr,
 
       auto diagnostic = diagnose(attr->getStartLoc(),
                                  diag::type_attr_requires_function_type, attr);
+      diagnostic.warnUntilLanguageModeIf(downgradeToWarning,
+                                         LanguageMode::future);
       if (isa<EscapingTypeAttr>(attr))
         diagnostic.fixItRemove(attr->getSourceRange());
       return;
@@ -3587,7 +3612,8 @@ void TypeAttrSet::diagnoseUnclaimed(TypeAttribute *attr,
     // tailored diagnostic.
     if (auto *alias =
             dyn_cast<TypeAliasType>(resolvedType.get().getPointer())) {
-      diagnose(attr->getStartLoc(), diag::attribute_part_of_type, attr);
+      diagnose(attr->getStartLoc(), diag::attribute_part_of_type, attr)
+          .warnUntilLanguageModeIf(downgradeToWarning, LanguageMode::future);
 
       auto *aliasDecl = alias->getDecl();
 
@@ -3640,8 +3666,9 @@ void TypeAttrSet::diagnoseUnclaimed(TypeAttribute *attr,
     }
   }
 
-  ctx.Diags.diagnose(attr->getStartLoc(),
-                     diag::attribute_does_not_apply_to_type);
+  ctx.Diags
+      .diagnose(attr->getStartLoc(), diag::attribute_does_not_apply_to_type)
+      .warnUntilLanguageModeIf(downgradeToWarning, LanguageMode::future);
 }
 
 Type TypeResolver::resolveGlobalActor(SourceLoc loc, TypeResolutionOptions options,

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -43,11 +43,13 @@
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/SILLayout.h"
 #include "swift/AST/SourceFile.h"
+#include "swift/AST/Type.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/TypeLoc.h"
 #include "swift/AST/TypeMatcher.h"
 #include "swift/AST/TypeRepr.h"
 #include "swift/AST/TypeResolutionStage.h"
+#include "swift/AST/Types.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/EnumMap.h"
 #include "swift/Basic/FixedBitSet.h"
@@ -2240,22 +2242,16 @@ static Type applyNonEscapingIfNecessary(Type ty,
                                         TypeResolutionOptions options) {
   bool defaultNoEscape = isDefaultNoEscapeContext(options);
 
-  // Desugar here
-  auto *funcTy = ty->castTo<FunctionType>();
-  auto extInfo = funcTy->getExtInfo();
-  if (defaultNoEscape && !extInfo.isNoEscape()) {
-    extInfo = extInfo.withNoEscape();
+  if (!defaultNoEscape)
+    return ty;
 
-    // We lost the sugar to flip the isNoEscape bit.
-    //
-    // FIXME(https://github.com/apple/swift/issues/45125): It would be better
-    // to add a new AttributedType sugared type, which would wrap the
-    // TypeAliasType and apply the isNoEscape bit when de-sugaring.
-    return FunctionType::get(funcTy->getParams(), funcTy->getResult(), extInfo);
-  }
+  return ty.transformRec([](TypeBase *ty) -> std::optional<Type> {
+    // dyn_cast (not castTo) to avoid desugaring through type alias.
+    if (auto fnTy = dyn_cast<FunctionType>(ty))
+      return fnTy->withExtInfo(fnTy->getExtInfo().withNoEscape());
 
-  // Note: original sugared type
-  return ty;
+    return std::nullopt;
+  });
 }
 
 /// Validate whether type associated with @autoclosure attribute is correct,

--- a/test/Concurrency/attr_execution/nonisolated_cross_module_with_flag_enabled.swift
+++ b/test/Concurrency/attr_execution/nonisolated_cross_module_with_flag_enabled.swift
@@ -86,7 +86,7 @@ public typealias G<T> = () async -> T
 public func testTypeAlias(_: @escaping F) {}
 
 // CHECK: public struct TestGenericTypeAlias {
-// CHECK:   public subscript<U>(_: nonisolated(nonsending) () async -> U) -> Swift::Bool {
+// CHECK:   public subscript<U>(_: A::G<U>) -> Swift::Bool {
 // CHECK:     get
 // CHECK:   }
 // CHECK: }

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -633,7 +633,7 @@ func rdar_50467583_and_50909555() {
     // expected-error@-1 {{no exact matches in call to subscript}}
     // expected-note@-2 {{found candidate with type '(Int) -> Int'}}
     // expected-note@-3 {{found candidate with type '(Range<Int>) -> ArraySlice<Int>'}}
-    // expected-note@-4 {{found candidate with type '((UnboundedRange_) -> ()) -> ArraySlice<Int>'}}
+    // expected-note@-4 {{found candidate with type '(UnboundedRange) -> ArraySlice<Int>' (aka '((UnboundedRange_) -> ()) -> ArraySlice<Int>')}}
     // expected-note@-5 * {{found candidate with type '(RangeSet<Array<Int>.Index>) -> DiscontiguousSlice<[Int]>' (aka '(RangeSet<Int>) -> DiscontiguousSlice<Array<Int>>')}}
   }
   

--- a/test/IDE/complete_with_closure_param.swift
+++ b/test/IDE/complete_with_closure_param.swift
@@ -20,7 +20,7 @@ FooStruct().#^COMPLETE^#
 // CHECK-DAG: Decl[InstanceMethod]/CurrNominal: instanceMethod2({#(callback): ((Int, Int) -> Void)?##(Int, Int) -> Void#})[#Void#]{{; name=.+$}}
 // CHECK-DAG: Decl[InstanceMethod]/CurrNominal: instanceMethod3({#(callback): ((Int, Int) -> Void)??##(Int, Int) -> Void#})[#Void#]{{; name=.+$}}
 // CHECK-DAG: Decl[InstanceMethod]/CurrNominal: instanceMethod4({#(callback): ((Int, Int) -> Void)!##(Int, Int) -> Void#})[#Void#]{{; name=.+$}}
-// CHECK-DAG: Decl[InstanceMethod]/CurrNominal: instanceMethod5({#(callback): (Int, Int) -> Bool##(Int, Int) -> Bool#})[#Void#]{{; name=.+$}}
+// CHECK-DAG: Decl[InstanceMethod]/CurrNominal: instanceMethod5({#(callback): FunctionTypealias##(Int, Int) -> Bool#})[#Void#]{{; name=.+$}}
 // CHECK-DAG: Decl[InstanceMethod]/CurrNominal: instanceMethod6({#(callback): FunctionTypealias?##(Int, Int) -> Bool#})[#Void#]{{; name=.+$}}
 // CHECK-DAG: Decl[InstanceMethod]/CurrNominal: instanceMethod7({#(callback): OptionalFunctionTypealias##(Int, Int) -> Bool#})[#Void#]{{; name=.+$}}
 // CHECK-DAG: Keyword[self]/CurrNominal: self[#FooStruct#]; name=self

--- a/test/ModuleInterface/lifetime_underscored_dependence_test.swift
+++ b/test/ModuleInterface/lifetime_underscored_dependence_test.swift
@@ -147,7 +147,7 @@ import lifetime_underscored_dependence
 // CHECK-NEXT: #endif
 
 // CHECK: #if compiler(>=5.3) && $ClosureLifetimes
-// CHECK-NEXT: @inlinable public func takeExplicitNestedType(f: @_lifetime(copy ne0) @_lifetime(ne1: copy ne0, copy ne1) ((lifetime_underscored_dependence::AnotherView) -> lifetime_underscored_dependence::AnotherView, _ ne0: consuming lifetime_underscored_dependence::AnotherView, _ ne1: inout lifetime_underscored_dependence::AnotherView) -> lifetime_underscored_dependence::AnotherView) {} 
+// CHECK-NEXT: @inlinable public func takeExplicitNestedType(f: lifetime_underscored_dependence::ExplicitNestedType) {}
 // CHECK-NEXT: #endif
 
 // CHECK: #if compiler(>=5.3) && $Lifetimes

--- a/test/PrintAsObjC/imported-block-typedefs.swift
+++ b/test/PrintAsObjC/imported-block-typedefs.swift
@@ -15,23 +15,14 @@ import ObjectiveC
 // CHECK-LABEL: @interface Typedefs
 @objc class Typedefs {
   
-  // FIXME: The imported typedefs should be printed directly as the param types,
-  // but one level of sugar is currently lost when applying @noescape. The importer
-  // also loses __attribute__((noescape)) for params of imported function types.
-  // https://github.com/apple/swift/issues/45125
+  // FIXME: The importer loses __attribute__((noescape)) for params of imported function types.
   // https://github.com/apple/swift/issues/45134
   
-  // CHECK-NEXT: - (void)noescapeParam1:(SWIFT_NOESCAPE void (^ _Nonnull)(void))input;
-  // CHECK-NEXT: - (void)noescapeParam2:(SWIFT_NOESCAPE void (^ _Nonnull)(PlainBlock _Nullable))input;
-  // CHECK-NEXT: - (void)noescapeParam3:(SWIFT_NOESCAPE void (^ _Nonnull)(PlainBlock _Nullable))input;
-  // CHECK-NEXT: - (void)noescapeParam4:(SWIFT_NOESCAPE BlockWithEscapingParam _Nullable (^ _Nonnull)(void))input;
-  // CHECK-NEXT: - (void)noescapeParam5:(SWIFT_NOESCAPE BlockWithNoescapeParam _Nullable (^ _Nonnull)(void))input;
-  // Ideally should be:
-  // - (void)noescapeParam1:(SWIFT_NOESCAPE PlainBlock _Nonnull)input;
-  // - (void)noescapeParam2:(SWIFT_NOESCAPE BlockWithEscapingParam _Nonnull)input;
-  // - (void)noescapeParam3:(SWIFT_NOESCAPE BlockWithNoescapeParam _Nonnull)input;
-  // - (void)noescapeParam4:(SWIFT_NOESCAPE BlockReturningBlockWithEscapingParam _Nonnull)input;
-  // - (void)noescapeParam5:(SWIFT_NOESCAPE BlockReturningBlockWithNoescapeParam _Nonnull)input;
+  // CHECK-NEXT: - (void)noescapeParam1:(SWIFT_NOESCAPE PlainBlock _Nonnull)input;
+  // CHECK-NEXT: - (void)noescapeParam2:(SWIFT_NOESCAPE BlockWithEscapingParam _Nonnull)input;
+  // CHECK-NEXT: - (void)noescapeParam3:(SWIFT_NOESCAPE BlockWithNoescapeParam _Nonnull)input;
+  // CHECK-NEXT: - (void)noescapeParam4:(SWIFT_NOESCAPE BlockReturningBlockWithEscapingParam _Nonnull)input;
+  // CHECK-NEXT: - (void)noescapeParam5:(SWIFT_NOESCAPE BlockReturningBlockWithNoescapeParam _Nonnull)input;
   @objc func noescapeParam1(_ input: PlainBlock) {}
   @objc func noescapeParam2(_ input: BlockWithEscapingParam) {}
   @objc func noescapeParam3(_ input: BlockWithNoescapeParam) {}
@@ -49,17 +40,11 @@ import ObjectiveC
   @objc func escapingParam4(_ input: @escaping BlockReturningBlockWithEscapingParam) {}
   @objc func escapingParam5(_ input: @escaping BlockReturningBlockWithNoescapeParam) {}
   
-  // CHECK-NEXT: - (void (^ _Nonnull)(SWIFT_NOESCAPE void (^ _Nonnull)(void)))resultHasNoescapeParam1 SWIFT_WARN_UNUSED_RESULT;
-  // CHECK-NEXT: - (void (^ _Nonnull)(SWIFT_NOESCAPE void (^ _Nonnull)(PlainBlock _Nullable)))resultHasNoescapeParam2 SWIFT_WARN_UNUSED_RESULT;
-  // CHECK-NEXT: - (void (^ _Nonnull)(SWIFT_NOESCAPE void (^ _Nonnull)(PlainBlock _Nullable)))resultHasNoescapeParam3 SWIFT_WARN_UNUSED_RESULT;
-  // CHECK-NEXT: - (void (^ _Nonnull)(SWIFT_NOESCAPE BlockWithEscapingParam _Nullable (^ _Nonnull)(void)))resultHasNoescapeParam4 SWIFT_WARN_UNUSED_RESULT;
-  // CHECK-NEXT: - (void (^ _Nonnull)(SWIFT_NOESCAPE BlockWithNoescapeParam _Nullable (^ _Nonnull)(void)))resultHasNoescapeParam5 SWIFT_WARN_UNUSED_RESULT;
-  // Ideally should be:
-  //  - (void (^ _Nonnull)(SWIFT_NOESCAPE PlainBlock _Nonnull))resultHasNoescapeParam1 SWIFT_WARN_UNUSED_RESULT;
-  //  - (void (^ _Nonnull)(SWIFT_NOESCAPE BlockWithEscapingParam _Nonnull))resultHasNoescapeParam2 SWIFT_WARN_UNUSED_RESULT;
-  //  - (void (^ _Nonnull)(SWIFT_NOESCAPE BlockWithNoescapeParam _Nonnull))resultHasNoescapeParam3 SWIFT_WARN_UNUSED_RESULT;
-  //  - (void (^ _Nonnull)(SWIFT_NOESCAPE BlockReturningBlockWithEscapingParam _Nonnull))resultHasNoescapeParam4 SWIFT_WARN_UNUSED_RESULT;
-  //  - (void (^ _Nonnull)(SWIFT_NOESCAPE BlockReturningBlockWithNoescapeParam _Nonnull))resultHasNoescapeParam5 SWIFT_WARN_UNUSED_RESULT;
+  // CHECK-NEXT: - (void (^ _Nonnull)(SWIFT_NOESCAPE PlainBlock _Nonnull))resultHasNoescapeParam1 SWIFT_WARN_UNUSED_RESULT;
+  // CHECK-NEXT: - (void (^ _Nonnull)(SWIFT_NOESCAPE BlockWithEscapingParam _Nonnull))resultHasNoescapeParam2 SWIFT_WARN_UNUSED_RESULT;
+  // CHECK-NEXT: - (void (^ _Nonnull)(SWIFT_NOESCAPE BlockWithNoescapeParam _Nonnull))resultHasNoescapeParam3 SWIFT_WARN_UNUSED_RESULT;
+  // CHECK-NEXT: - (void (^ _Nonnull)(SWIFT_NOESCAPE BlockReturningBlockWithEscapingParam _Nonnull))resultHasNoescapeParam4 SWIFT_WARN_UNUSED_RESULT;
+  // CHECK-NEXT: - (void (^ _Nonnull)(SWIFT_NOESCAPE BlockReturningBlockWithNoescapeParam _Nonnull))resultHasNoescapeParam5 SWIFT_WARN_UNUSED_RESULT;
   @objc func resultHasNoescapeParam1() -> (PlainBlock) -> () { fatalError() }
   @objc func resultHasNoescapeParam2() -> (BlockWithEscapingParam) -> () { fatalError() }
   @objc func resultHasNoescapeParam3() -> (BlockWithNoescapeParam) -> () { fatalError() }

--- a/test/SourceKit/CodeComplete/complete_with_closure_param.swift
+++ b/test/SourceKit/CodeComplete/complete_with_closure_param.swift
@@ -16,5 +16,5 @@ C().
 
 // CHECK:      key.kind: source.lang.swift.decl.function.method.instance,
 // CHECK-NEXT: key.name: "foo2(:)",
-// CHECK-NEXT: key.description: "foo2(x: (Int) -> Int)",
-// CHECK: key.sourcetext: "foo2(<#T##x: (Int) -> Int##(Int) -> Int#>)"
+// CHECK-NEXT: key.description: "foo2(x: MyFnTy)",
+// CHECK: key.sourcetext: "foo2(<#T##x: MyFnTy##MyFnTy##(Int) -> Int#>)"

--- a/test/attr/attr_alias_imported.swift
+++ b/test/attr/attr_alias_imported.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify %s
+
+import ctypes
+
+// Don't crash or try to suggest editing an alias we can't access.
+func takeSendable(_ fn: @Sendable fptr) { } // expected-error{{attribute '@Sendable' cannot be applied to a type alias}}
+// expected-note@-1{{expand 'fptr' (aka '@convention(c) (Int32) -> Int32') to apply '@Sendable'}}{{35-39=@convention(c) (Int32) -> Int32}}

--- a/test/attr/attr_concurrent.swift
+++ b/test/attr/attr_concurrent.swift
@@ -18,9 +18,58 @@ func onEscapingAutoclosure(_ fn: @Sendable @autoclosure @escaping () -> Int) { }
 func onEscapingAutoclosure2(_ fn: @escaping @autoclosure @Sendable () -> Int) { }
 
 typealias IntFn = () -> Int
-func onAlias(_ fn: @Sendable IntFn) { } // expected-error@:20{{attribute does not apply to type}}
-func onEscapingAlias(_ fn: @escaping @Sendable IntFn) { } // expected-error@:38{{attribute does not apply to type}}
-func onEscapingAlias2(_ fn: @Sendable @escaping IntFn) { } // expected-error@:29{{attribute does not apply to type}}
+// expected-note@-1{{add '@Sendable' to the definition of 'IntFn' (aka '() -> Int')}}{{1-1=@preconcurrency }}{{19-19=@Sendable }}{{+4:20-30=}}
+// expected-note@-2{{add '@Sendable' to the definition of 'IntFn' (aka '() -> Int')}}{{1-1=@preconcurrency }}{{19-19=@Sendable }}{{+6:38-48=}}
+// expected-note@-3{{add '@Sendable' to the definition of 'IntFn' (aka '() -> Int')}}{{1-1=@preconcurrency }}{{19-19=@Sendable }}{{+8:29-39=}}
+func onAlias(_ fn: @Sendable IntFn) { } // expected-error@:20{{attribute '@Sendable' cannot be applied to a type alias}}
+// expected-note@-1{{expand 'IntFn' (aka '() -> Int') to apply '@Sendable'}}{{30-35=() -> Int}}
+func onEscapingAlias(_ fn: @escaping @Sendable IntFn) { } // expected-error@:38{{attribute '@Sendable' cannot be applied to a type alias}}
+// expected-note@-1{{expand 'IntFn' (aka '() -> Int') to apply '@Sendable'}}{{48-53=() -> Int}}
+func onEscapingAlias2(_ fn: @Sendable @escaping IntFn) { } // expected-error@:29{{attribute '@Sendable' cannot be applied to a type alias}}
+// expected-note@-1{{expand 'IntFn' (aka '() -> Int') to apply '@Sendable'}}{{49-54=() -> Int}}
+
+typealias VoidFn = () -> Void
+// expected-note@-1{{add '@isolated' to the definition of 'VoidFn' (aka '() -> ()')}}{{1-1=@preconcurrency }}{{20-20=@isolated(any) }}{{+3:28-43=}}
+// expected-note@-2{{add '@isolated' to the definition of 'VoidFn' (aka '() -> ()')}}{{1-1=@preconcurrency }}{{20-20=@isolated(any) }}{{+5:46-61=}}
+func onIsolatedAlias(_ fn: @isolated(any) VoidFn) { } // expected-error@:28{{attribute '@isolated' cannot be applied to a type alias}}
+// expected-note@-1{{expand 'VoidFn' (aka '() -> ()') to apply '@isolated'}}{{43-49=() -> Void}}
+func onEscapingIsolatedAlias(_ fn: @escaping @isolated(any) VoidFn) { } // expected-error@:46{{attribute '@isolated' cannot be applied to a type alias}}
+// expected-note@-1{{expand 'VoidFn' (aka '() -> ()') to apply '@isolated'}}{{61-67=() -> Void}}
+
+// Alias that already has the attribute should not suggest adding it again.
+typealias SendableFn = @Sendable () -> Int
+func onAlreadySendable(_ fn: @Sendable SendableFn) { } // expected-error{{attribute '@Sendable' cannot be applied to a type alias}}
+// expected-note@-1{{'@Sendable' is redundant on 'SendableFn' (aka '@Sendable () -> Int')}}{{30-40=}}{{none}}
+
+// Multiple function attrs on alias.
+typealias PlainFn = () -> ()
+// expected-note@-1{{add '@Sendable' to the definition of 'PlainFn' (aka '() -> ()')}}{{1-1=@preconcurrency }}{{21-21=@Sendable }}{{+3:28-38=}}
+// expected-note@-2{{add '@isolated' to the definition of 'PlainFn' (aka '() -> ()')}}{{1-1=@preconcurrency }}{{21-21=@isolated(any) }}{{+3:38-53=}}
+func onMultipleAttrs(_ fn: @Sendable @isolated(any) PlainFn) { }
+// expected-error@-1:28{{attribute '@Sendable' cannot be applied to a type alias}}
+// expected-error@-2:38{{attribute '@isolated' cannot be applied to a type alias}}
+// expected-note@-3{{expand 'PlainFn' (aka '() -> ()') to apply '@Sendable'}}{{53-60=() -> ()}}
+// expected-note@-4{{expand 'PlainFn' (aka '() -> ()') to apply '@isolated'}}{{53-60=() -> ()}}
+
+// Generic alias.
+typealias GenericFn<T> = (T) -> T
+// expected-note@-1{{add '@Sendable' to the definition of 'GenericFn<Int>' (aka '(Int) -> Int')}}{{1-1=@preconcurrency }}{{26-26=@Sendable }}{{+2:27-37=}}
+func onGenericAlias(_ fn: @Sendable GenericFn<Int>) { } // expected-error@:27{{attribute '@Sendable' cannot be applied to a type alias}}
+// expected-note@-1{{expand 'GenericFn<Int>' (aka '(Int) -> Int') to apply '@Sendable'}}{{37-51=(Int) -> Int}}
+
+@preconcurrency typealias PreconcurrencyFn = () -> ()
+// expected-note@-1{{add '@Sendable' to the definition of 'PreconcurrencyFn' (aka '() -> ()')}}{{46-46=@Sendable }}{{+2:34-44=}}{{none}}
+func onPreconcurrencyAlias(_ fn: @Sendable PreconcurrencyFn) { } // expected-error@:34{{attribute '@Sendable' cannot be applied to a type alias}}
+// expected-note@-1{{expand 'PreconcurrencyFn' (aka '() -> ()') to apply '@Sendable'}}{{44-60=() -> ()}}
+
+typealias OptionalFn = (() -> ())?
+func onOptionalAlias(_ fn: @Sendable OptionalFn) { } // expected-error{{'@Sendable' only applies to function types}}
+
+// Parenthesized function type alias — expansion should drop the parens.
+typealias ParenFn = (() -> ())
+// expected-note@-1{{add '@Sendable' to the definition of 'ParenFn' (aka '() -> ()')}}{{1-1=@preconcurrency }}{{21-21=@Sendable }}{{+2:25-35=}}
+func onParenAlias(_ fn: @Sendable ParenFn) { } // expected-error@:25{{attribute '@Sendable' cannot be applied to a type alias}}
+// expected-note@-1{{expand 'ParenFn' (aka '() -> ()') to apply '@Sendable'}}{{35-42=() -> ()}}
 
 func acceptsConcurrent(_ fn: @Sendable (Int) -> Int) { }
 func acceptsNonConcurrent(_ fn: (Int) -> Int) { }

--- a/test/attr/attr_concurrent.swift
+++ b/test/attr/attr_concurrent.swift
@@ -23,7 +23,7 @@ typealias IntFn = () -> Int
 // expected-note@-3{{add '@Sendable' to the definition of 'IntFn' (aka '() -> Int')}}{{1-1=@preconcurrency }}{{19-19=@Sendable }}{{+8:29-39=}}
 func onAlias(_ fn: @Sendable IntFn) { } // expected-error@:20{{attribute '@Sendable' cannot be applied to a type alias}}
 // expected-note@-1{{expand 'IntFn' (aka '() -> Int') to apply '@Sendable'}}{{30-35=() -> Int}}
-func onEscapingAlias(_ fn: @escaping @Sendable IntFn) { } // expected-error@:38{{attribute '@Sendable' cannot be applied to a type alias}}
+func onEscapingAlias(_ fn: @escaping @Sendable IntFn) { } // expected-warning@:38{{attribute '@Sendable' cannot be applied to a type alias}}
 // expected-note@-1{{expand 'IntFn' (aka '() -> Int') to apply '@Sendable'}}{{48-53=() -> Int}}
 func onEscapingAlias2(_ fn: @Sendable @escaping IntFn) { } // expected-error@:29{{attribute '@Sendable' cannot be applied to a type alias}}
 // expected-note@-1{{expand 'IntFn' (aka '() -> Int') to apply '@Sendable'}}{{49-54=() -> Int}}
@@ -33,7 +33,7 @@ typealias VoidFn = () -> Void
 // expected-note@-2{{add '@isolated' to the definition of 'VoidFn' (aka '() -> ()')}}{{1-1=@preconcurrency }}{{20-20=@isolated(any) }}{{+5:46-61=}}
 func onIsolatedAlias(_ fn: @isolated(any) VoidFn) { } // expected-error@:28{{attribute '@isolated' cannot be applied to a type alias}}
 // expected-note@-1{{expand 'VoidFn' (aka '() -> ()') to apply '@isolated'}}{{43-49=() -> Void}}
-func onEscapingIsolatedAlias(_ fn: @escaping @isolated(any) VoidFn) { } // expected-error@:46{{attribute '@isolated' cannot be applied to a type alias}}
+func onEscapingIsolatedAlias(_ fn: @escaping @isolated(any) VoidFn) { } // expected-warning@:46{{attribute '@isolated' cannot be applied to a type alias}}
 // expected-note@-1{{expand 'VoidFn' (aka '() -> ()') to apply '@isolated'}}{{61-67=() -> Void}}
 
 // Alias that already has the attribute should not suggest adding it again.
@@ -50,6 +50,16 @@ func onMultipleAttrs(_ fn: @Sendable @isolated(any) PlainFn) { }
 // expected-error@-2:38{{attribute '@isolated' cannot be applied to a type alias}}
 // expected-note@-3{{expand 'PlainFn' (aka '() -> ()') to apply '@Sendable'}}{{53-60=() -> ()}}
 // expected-note@-4{{expand 'PlainFn' (aka '() -> ()') to apply '@isolated'}}{{53-60=() -> ()}}
+
+// @Sendable is error (before claimed @escaping), @isolated(any) is warning (after claimed @escaping).
+typealias MixedFn = () -> ()
+// expected-note@-1{{add '@Sendable' to the definition of 'MixedFn' (aka '() -> ()')}}{{1-1=@preconcurrency }}{{21-21=@Sendable }}{{+3:25-35=}}
+// expected-note@-2{{add '@isolated' to the definition of 'MixedFn' (aka '() -> ()')}}{{1-1=@preconcurrency }}{{21-21=@isolated(any) }}{{+3:45-60=}}
+func onMixedAttrs(_ fn: @Sendable @escaping @isolated(any) MixedFn) { }
+// expected-error@-1:25{{attribute '@Sendable' cannot be applied to a type alias}}
+// expected-warning@-2:45{{attribute '@isolated' cannot be applied to a type alias}}
+// expected-note@-3{{expand 'MixedFn' (aka '() -> ()') to apply '@Sendable'}}{{60-67=() -> ()}}
+// expected-note@-4{{expand 'MixedFn' (aka '() -> ()') to apply '@isolated'}}{{60-67=() -> ()}}
 
 // Generic alias.
 typealias GenericFn<T> = (T) -> T

--- a/test/attr/attr_concurrent.swift
+++ b/test/attr/attr_concurrent.swift
@@ -17,6 +17,11 @@ func onAutoclosure2(_ fn: @Sendable @autoclosure () -> Int) { }
 func onEscapingAutoclosure(_ fn: @Sendable @autoclosure @escaping () -> Int) { }
 func onEscapingAutoclosure2(_ fn: @escaping @autoclosure @Sendable () -> Int) { }
 
+typealias IntFn = () -> Int
+func onAlias(_ fn: @Sendable IntFn) { } // expected-error@:20{{attribute does not apply to type}}
+func onEscapingAlias(_ fn: @escaping @Sendable IntFn) { } // expected-error@:38{{attribute does not apply to type}}
+func onEscapingAlias2(_ fn: @Sendable @escaping IntFn) { } // expected-error@:29{{attribute does not apply to type}}
+
 func acceptsConcurrent(_ fn: @Sendable (Int) -> Int) { }
 func acceptsNonConcurrent(_ fn: (Int) -> Int) { }
 

--- a/test/type/implicit_some/opaque_parameters.swift
+++ b/test/type/implicit_some/opaque_parameters.swift
@@ -59,7 +59,7 @@ func testInOut() {
 typealias FnType<T> = (T) -> Void
 
 func consumingA(fn: (P) -> Void) { } // expected-error{{'some' cannot appear in parameter position in parameter type '(P) -> Void'}}
-func consumingB(fn: FnType<P>) { } // expected-error{{'some' cannot appear in parameter position in parameter type '(P) -> Void'}}
+func consumingB(fn: FnType<P>) { } // expected-error{{'some' cannot appear in parameter position in parameter type 'FnType<P>' (aka '(P) -> ()')}}
 
 
 func takePrimaryCollections(

--- a/test/type/opaque_parameters.swift
+++ b/test/type/opaque_parameters.swift
@@ -114,7 +114,7 @@ func testPrimaries(
 typealias FnType<T> = (T) -> Void
 
 func consumingA(fn: (some P) -> Void) { } // expected-error{{'some' cannot appear in parameter position in parameter type '(some P) -> Void'}}
-func consumingB(fn: FnType<some P>) { } // expected-error{{'some' cannot appear in parameter position in parameter type '(some P) -> Void'}}
+func consumingB(fn: FnType<some P>) { } // expected-error{{'some' cannot appear in parameter position in parameter type 'FnType<some P>' (aka '(some P) -> ()')}}
 
 // https://github.com/apple/swift/issues/61387
 struct I61387 {


### PR DESCRIPTION
This PR fixes rdar://152866923, a bug around failing to diagnose unused attrs that follow used attrs. This bug, in conjunction with not supporting attributes on type aliases, led to confusing behavior for concurrency attributes like `@Sendable` placed on type aliases not being diagnosed when used in an interface, and emitting confusing diagnostics when the parameter is used in a way that requires sending, since `@Sendable` was not put on the type, but no diagnostic flagged it as unused.

This PR also adds tailored diagnostics to make this case more clear, along with fix-its to place the attribute on the type alias decl or expand the alias inline.

As part of fixing that bug, this PR also attempts to preserve alias sugar when removing escaping. This fixes rdar://172417385, #45125. This is relevant for ensuring we can consistently detect when attributes are being placed on an alias to trigger the new tailored diagnostic. Otherwise, a no escape type alias of a function would be represented as a function type rather than a type alias with an underlying function type and we cannot tailor a diagnostic.

One cause for concern here is that there is existing code writing `@escaping @Sendable MyFunctionType`. If we just support Sendable on type aliases, we will change how this is interpreted and change mangling. A programmer in this situation would need to use `@preconcurrency` to preserve their interface, since their code is being interpreted as `@escaping MyFunctionType` silently.

Consider the following code:
```swift
typealias F = () async -> ()
func foo(_ fn: @escaping @Sendable F) {}
func bar(_ fn: @escaping @isolated(any) F) {}
func baz(_ fn: @Sendable F) {}
```

Prior to this PR:
```
alias_iso.swift:4:16: error: attribute does not apply to type
2 | func foo(_ fn: @escaping @Sendable F) {}
3 | func bar(_ fn: @escaping @isolated(any) F) {}
4 | func baz(_ fn: @Sendable F) {}
  |                `- error: attribute does not apply to type
5 |
```

Even though `@Sendable` and `@isolated(any)` are not actually being applied to fn.

With this PR:

```
debug-files/alias_iso.swift:2:26: warning: attribute '@Sendable' cannot be applied to a type alias; this will be an error in a future Swift language mode
1 | typealias F = () async -> ()
  |           `- note: add '@Sendable' to the definition of 'F' (aka '() async -> ()')
2 | func foo(_ fn: @escaping @Sendable F) {}
  |                          |         `- note: expand 'F' (aka '() async -> ()') to apply '@Sendable'
  |                          `- warning: attribute '@Sendable' cannot be applied to a type alias; this will be an error in a future Swift language mode
3 | func bar(_ fn: @escaping @isolated(any) F) {}
4 | func baz(_ fn: @Sendable F) {}

debug-files/alias_iso.swift:3:26: warning: attribute '@isolated' cannot be applied to a type alias; this will be an error in a future Swift language mode
1 | typealias F = () async -> ()
  |           `- note: add '@isolated' to the definition of 'F' (aka '() async -> ()')
2 | func foo(_ fn: @escaping @Sendable F) {}
3 | func bar(_ fn: @escaping @isolated(any) F) {}
  |                          |              `- note: expand 'F' (aka '() async -> ()') to apply '@isolated'
  |                          `- warning: attribute '@isolated' cannot be applied to a type alias; this will be an error in a future Swift language mode
4 | func baz(_ fn: @Sendable F) {}
5 |

debug-files/alias_iso.swift:4:16: error: attribute '@Sendable' cannot be applied to a type alias
1 | typealias F = () async -> ()
  |           `- note: add '@Sendable' to the definition of 'F' (aka '() async -> ()')
2 | func foo(_ fn: @escaping @Sendable F) {}
3 | func bar(_ fn: @escaping @isolated(any) F) {}
4 | func baz(_ fn: @Sendable F) {}
  |                |         `- note: expand 'F' (aka '() async -> ()') to apply '@Sendable'
  |                `- error: attribute '@Sendable' cannot be applied to a type alias
5 |
```

Note that the bug regarding unclaimed attributes is not restricted to swift 6 or concurrency, there may be other cases that this affects.