### PR TITLE
Sema: fix effects checking in witness matching

### DIFF
--- a/include/swift/AST/Effects.h
+++ b/include/swift/AST/Effects.h
@@ -42,7 +42,18 @@ enum class EffectKind : uint8_t {
   Throws = 1 << 0,
   Async  = 1 << 1,
   Unsafe = 1 << 2,
+  LAST_EFFECT = Unsafe,
 };
+namespace EffectKinds {
+constexpr std::array<EffectKind, 3> all() {
+  return {
+      EffectKind::Throws,
+      EffectKind::Async,
+      EffectKind::Unsafe,
+  };
+}
+static_assert(EffectKinds::all().back() == EffectKind::LAST_EFFECT);
+} // namespace EffectKinds
 using PossibleEffects = OptionSet<EffectKind>;
 
 void simple_display(llvm::raw_ostream &out, const EffectKind kind);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -762,6 +762,8 @@ bool swift::TypeChecker::witnessStructureMatches(ValueDecl *req,
       == std::nullopt;
 }
 
+static PossibleEffects getEffects(ValueDecl *value);
+
 RequirementMatch swift::matchWitness(
     DeclContext *dc, ValueDecl *req, ValueDecl *witness,
     llvm::function_ref<
@@ -950,6 +952,26 @@ RequirementMatch swift::matchWitness(
 
     if (auto result = matchTypes(reqType, witnessType)) {
       return std::move(result.value());
+    }
+  }
+
+  {
+    // The witness must have the same or fewer effects than the requirement.
+    auto reqEff = getEffects(req);
+    auto witnessEff = getEffects(witness);
+    if (auto invalidEffects = witnessEff - reqEff) {
+      for (auto kind : EffectKinds::all()) {
+        if (invalidEffects.contains(kind)) {
+          switch (kind) {
+          case EffectKind::Unsafe:
+            continue;  // This is diagnosed as a warning elsewhere.
+          case EffectKind::Throws:
+            return RequirementMatch(witness, MatchKind::ThrowsConflict);
+          case EffectKind::Async:
+            return RequirementMatch(witness, MatchKind::AsyncConflict);
+          }
+        }
+      }
     }
   }
 

--- a/test/decl/protocol/conforms/effects.swift
+++ b/test/decl/protocol/conforms/effects.swift
@@ -1,0 +1,42 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated
+
+// https://github.com/swiftlang/swift/issues/86105
+protocol P {
+    func perform(_ body: () -> Void) -> Void
+    // expected-note@-1 {{protocol requires function 'perform' with type '(() -> Void) -> Void'}}
+}
+
+struct S {
+    func perform<E: Error>(_ body: () throws(E) -> Void) throws(E) -> Void {
+    // expected-note@-1 {{candidate throws, but protocol does not allow it}}
+        try body()
+    }
+}
+
+extension S: P {}
+// expected-error@-1 {{type 'S' does not conform to protocol 'P'}}
+// expected-note@-2 {{add stubs for conformance}}
+
+
+
+// https://github.com/swiftlang/swift/issues/73479
+protocol P1: AsyncIteratorProtocol {
+    mutating func next() async -> Element?
+}
+struct S2: P1 {
+    mutating func next() async -> Int? {
+        return nil
+    }
+}
+
+
+public protocol Functor<A> {
+  associatedtype FA: Functor = Self
+  associatedtype A
+  func map<B>(_ f: (A) -> B) -> FA where FA.A == B  // expected-note {{protocol requires function 'map' with type}}
+}
+extension Optional : Functor {
+  // expected-error@-1 {{type 'Optional<Wrapped>' does not conform to protocol 'Functor'}}
+  // expected-note@-2 {{add stubs for conformance}}
+  public typealias A = Wrapped
+}

--- a/validation-test/compiler_crashers_fixed/RequirementMatch-7f49d1.swift
+++ b/validation-test/compiler_crashers_fixed/RequirementMatch-7f49d1.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"19b50bfb","signature":"swift::RequirementMatch llvm::function_ref<swift::RequirementMatch (bool, llvm::ArrayRef<swift::OptionalAdjustment>)>::callback_fn<swift::matchWitness(llvm::DenseMap<std::__1::pair<swift::GenericSignatureImpl const*, swift::ClassDecl const*>, swift::RequirementEnvironment, llvm::DenseMapInfo<std::__1::pair<swift::GenericSignatureImpl const*, swift::ClassDecl const*>, void>, llvm::detail::DenseMapPair<std::__1::pair<swift::GenericSignatureImpl const*, swift::ClassDecl const*>, swift::RequirementEnvironment>>&, swift::ProtocolDecl*, swift::RootProtocolConformance*, swift::DeclContext*, swift::ValueDecl*, swift::ValueDecl*)::$_2>(long, bool, llvm::ArrayRef<swift::OptionalAdjustment>)","signatureAssert":"Assertion failed: (getEffects(req).contains(getEffects(witness)) && \"witness has more effects than requirement?\"), function operator()"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 protocol a {
   associatedtype Element
   ::


### PR DESCRIPTION
A requirement defines the maximal effects that a witness can have.

In some cases, we'd fail to properly reject such a witness with more effects, when that witness is valid for another requirement within that protocol. Thus, we'd hit an assertion failure in that case rather than permitting the valid program to compile.

In a non-asserts compiler, we could end up failing to diagnose an invalid chosen witness and crash in IRGen.

https://github.com/apple/swift/issues/73479
rdar://127669069