### PR TITLE
[Concurrency] Add missing source compat overload for withUnsafeThrowingContinuation

### DIFF
--- a/stdlib/public/Concurrency/CheckedContinuation.swift
+++ b/stdlib/public/Concurrency/CheckedContinuation.swift
@@ -312,9 +312,12 @@ public nonisolated(nonsending) func withCheckedContinuation<T>(
   }
 }
 
+/// Source-compatibility overload; replaced by
+/// ``withCheckedContinuation(function:_:)``.
 @inlinable
 @available(SwiftStdlib 5.1, *)
 @backDeployed(before: SwiftStdlib 6.0)
+@_disfavoredOverload
 @available(*, deprecated, message: "Replaced by nonisolated(nonsending) overload")
 public func withCheckedContinuation<T>( // source-compatibility overload
   isolation: isolated (any Actor)?,
@@ -423,9 +426,12 @@ public nonisolated(nonsending) func withCheckedThrowingContinuation<T>( // nonse
   }
 }
 
+/// Source-compatibility overload; replaced by
+/// ``withCheckedThrowingContinuation(function:_:)``.
 @inlinable
 @available(SwiftStdlib 5.1, *)
 @backDeployed(before: SwiftStdlib 6.0)
+@_disfavoredOverload
 @available(*, deprecated, message: "Replaced by nonisolated(nonsending) overload")
 public func withCheckedThrowingContinuation<T>(
   isolation: isolated (any Actor)?,

--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -903,9 +903,12 @@ public nonisolated(nonsending) func withUnsafeContinuation<T>(
   }
 }
 
+/// Source-compatibility overload; replaced by
+/// ``withUnsafeContinuation(_:)``.
 @available(SwiftStdlib 5.1, *)
 @_alwaysEmitIntoClient
 @unsafe
+@_disfavoredOverload
 @available(*, deprecated, message: "Replaced by nonisolated(nonsending) overload")
 public func withUnsafeContinuation<T>( // source-compatibility overload
   isolation: isolated (any Actor)?,
@@ -962,6 +965,22 @@ public nonisolated(nonsending) func withUnsafeThrowingContinuation<T, E>(
 public nonisolated(nonsending) func withUnsafeThrowingContinuation<T>(
   _ fn: (UnsafeContinuation<T, Error>) -> Void
 ) async throws(Error) -> sending T {
+  return try await Builtin.withUnsafeThrowingContinuation {
+    unsafe fn(UnsafeContinuation<T, Error>($0))
+  }
+}
+
+/// Source-compatibility overload; replaced by
+/// ``withUnsafeThrowingContinuation(_:)``.
+@available(SwiftStdlib 5.1, *)
+@_alwaysEmitIntoClient
+@unsafe
+@_disfavoredOverload
+@available(*, deprecated, message: "Replaced by nonisolated(nonsending) overload")
+public func withUnsafeThrowingContinuation<T>( // source-compatibility overload
+  isolation: isolated (any Actor)?,
+  _ fn: (UnsafeContinuation<T, Error>) -> Void
+) async throws -> sending T {
   return try await Builtin.withUnsafeThrowingContinuation {
     unsafe fn(UnsafeContinuation<T, Error>($0))
   }

--- a/test/Concurrency/continuation_isolation_source_compat.swift
+++ b/test/Concurrency/continuation_isolation_source_compat.swift
@@ -1,0 +1,26 @@
+// RUN: %target-swift-frontend -typecheck -swift-version 6 -target %target-swift-5.1-abi-triple -verify %s -parse-as-library
+// REQUIRES: concurrency
+
+func testWithUnsafeContinuation(isolation: isolated (any Actor)?) async -> Int {
+  await withUnsafeContinuation(isolation: isolation) { continuation in // expected-warning {{'withUnsafeContinuation(isolation:_:)' is deprecated: Replaced by nonisolated(nonsending) overload}}
+    continuation.resume(returning: 42)
+  }
+}
+
+func testWithUnsafeThrowingContinuation(isolation: isolated (any Actor)?) async throws -> Int {
+  try await withUnsafeThrowingContinuation(isolation: isolation) { continuation in // expected-warning {{'withUnsafeThrowingContinuation(isolation:_:)' is deprecated: Replaced by nonisolated(nonsending) overload}}
+    continuation.resume(returning: 42)
+  }
+}
+
+func testWithCheckedContinuation(isolation: isolated (any Actor)?) async -> Int {
+  await withCheckedContinuation(isolation: isolation) { continuation in // expected-warning {{'withCheckedContinuation(isolation:function:_:)' is deprecated: Replaced by nonisolated(nonsending) overload}}
+    continuation.resume(returning: 42)
+  }
+}
+
+func testWithCheckedThrowingContinuation(isolation: isolated (any Actor)?) async throws -> Int {
+  try await withCheckedThrowingContinuation(isolation: isolation) { continuation in // expected-warning {{'withCheckedThrowingContinuation(isolation:function:_:)' is deprecated: Replaced by nonisolated(nonsending) overload}}
+    continuation.resume(returning: 42)
+  }
+}


### PR DESCRIPTION
Other continuations had them in place just fine but seems we dropped the withUnsafeThrowingContinuation one somehow.

This also makes all the source compat overloads disfavored.

rdar://172416034
