### PR TITLE
[flow-isolation] Add support for global-actor-isolated nominal type initializers

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -746,11 +746,15 @@ WARNING(warning_int_to_fp_inexact, none,
 // Flow-isolation diagnostics
 ERROR(isolated_after_nonisolated, none,
       "cannot access %kind1 here in "
-      "%select{nonisolated initializer|deinitializer}0",
-      (bool, const ValueDecl *))
+      "%select{%2 initializer|deinitializer}0",
+      (bool, const ValueDecl *, StringRef))
+ERROR(isolated_after_nonisolated_identifier, none,
+      "cannot access %1 here in "
+      "%select{%2 initializer|deinitializer}0",
+      (bool, Identifier, StringRef))
 NOTE(nonisolated_blame, none, "after %1%2 %3, "
-     "only nonisolated properties of 'self' can be accessed from "
-     "%select{this init|a deinit}0", (bool, StringRef, StringRef, DeclName))
+     "only %4 properties of 'self' can be accessed from "
+     "%select{this init|a deinit}0", (bool, StringRef, StringRef, DeclName, StringRef))
 ERROR(isolated_property_mutation_in_nonisolated_context,none,
       "actor-isolated %kind0 can not be %select{referenced|mutated}1 "
       "from a nonisolated context",

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -31,8 +31,6 @@
 #include <algorithm>
 #include <variant>
 
-#define DEBUG_TYPE "send-non-sendable"
-
 namespace swift {
 
 namespace PartitionPrimitives {

--- a/lib/SILOptimizer/Mandatory/FlowIsolation.cpp
+++ b/lib/SILOptimizer/Mandatory/FlowIsolation.cpp
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#define DEBUG_TYPE "send-non-sendable"
+#define DEBUG_TYPE "sil-flow-isolation"
 
 #include "DiagnosticHelpers.h"
 

--- a/lib/SILOptimizer/Mandatory/FlowIsolation.cpp
+++ b/lib/SILOptimizer/Mandatory/FlowIsolation.cpp
@@ -10,22 +10,24 @@
 //
 //===----------------------------------------------------------------------===//
 
-#define DEBUG_TYPE "flow-isolation"
+#define DEBUG_TYPE "send-non-sendable"
 
 #include "DiagnosticHelpers.h"
 
-#include "swift/AST/Expr.h"
 #include "swift/AST/ActorIsolation.h"
 #include "swift/AST/DiagnosticsSIL.h"
+#include "swift/AST/Expr.h"
 #include "swift/Basic/Assertions.h"
-#include "swift/Sema/Concurrency.h"
 #include "swift/SIL/ApplySite.h"
-#include "swift/SIL/BitDataflow.h"
 #include "swift/SIL/BasicBlockBits.h"
-#include "swift/SIL/DebugUtils.h"
 #include "swift/SIL/BasicBlockDatastructures.h"
-#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SIL/BitDataflow.h"
+#include "swift/SIL/DebugUtils.h"
 #include "swift/SIL/OperandDatastructures.h"
+#include "swift/SILOptimizer/Analysis/RegionAnalysis.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/VariableNameUtils.h"
+#include "swift/Sema/Concurrency.h"
 
 #include "llvm/Support/WithColor.h"
 
@@ -47,6 +49,22 @@ static SILFunction* getCallee(SILInstruction *someInst) {
     if (SILFunction *callee = apply.getCalleeFunction())
       return callee;
   return nullptr;
+}
+
+template <typename... T, typename... U>
+static InFlightDiagnostic
+loggedDiagnoseErrorAndHighlight(const SILInstruction *inst, Diag<T...> diag,
+                                U &&...args) {
+  LLVM_DEBUG(llvm::dbgs() << "Emitting error at: " << *inst);
+  return diagnoseErrorAndHighlight(inst, std::move(diag), std::move(args)...);
+}
+
+template <typename... T, typename... U>
+static InFlightDiagnostic
+loggedDiagnoseNoteAndHighlight(const SILInstruction *inst, Diag<T...> diag,
+                               U &&...args) {
+  LLVM_DEBUG(llvm::dbgs() << "Emitting note at: " << *inst);
+  return diagnoseNoteAndHighlight(inst, std::move(diag), std::move(args)...);
 }
 
 //===----------------------------------------------------------------------===//
@@ -170,6 +188,130 @@ static bool isWithinDeinit(SILFunction *fn) {
 
 namespace {
 
+class IsolationInfoCache {
+  RegionAnalysisFunctionInfo *rafi;
+  llvm::DenseMap<std::pair<SILInstruction *, SILValue>,
+                 SILDynamicMergedIsolationInfo>
+      cache;
+
+  struct ComputeEvaluator final
+      : public PartitionOpEvaluatorBaseImpl<ComputeEvaluator> {
+    RegionAnalysisFunctionInfo *rafi;
+    ComputeEvaluator(RegionAnalysisFunctionInfo *rafi,
+                     Partition &workingPartition)
+        : PartitionOpEvaluatorBaseImpl(workingPartition,
+                                       rafi->getOperandSetFactory(),
+                                       rafi->getSendingOperandToStateMap()),
+          rafi(rafi) {}
+
+    SILIsolationInfo getIsolationRegionInfo(Element elt) const {
+      return rafi->getValueMap().getIsolationRegion(elt);
+    }
+
+    std::optional<Element> getElement(SILValue value) const {
+      auto trackableValue = rafi->getValueMap().getTrackableValue(value);
+      if (trackableValue.value.isSendable())
+        return {};
+      return trackableValue.value.getID();
+    }
+
+    regionanalysisimpl::TrackableValueLookupResult
+    lookupValue(SILValue value) const {
+      return rafi->getValueMap().getTrackableValue(value);
+    }
+
+    SILValue getRepresentative(SILValue value) const {
+      return rafi->getValueMap()
+          .getTrackableValue(value)
+          .value.getRepresentative()
+          .maybeGetValue();
+    }
+
+    SILDynamicMergedIsolationInfo getIsolation(Region reg) const {
+      return PartitionOpEvaluator<ComputeEvaluator>::getIsolationRegionInfo(
+          reg);
+    }
+
+    RepresentativeValue getRepresentativeValue(Element element) const {
+      return rafi->getValueMap().getRepresentativeValue(element);
+    }
+
+    bool isClosureCaptured(Element elt, Operand *op) const {
+      auto iter = rafi->getValueMap().maybeGetRepresentative(elt);
+      if (!iter)
+        return false;
+      return rafi->isClosureCaptured(iter, op);
+    }
+  };
+
+public:
+  IsolationInfoCache(RegionAnalysisFunctionInfo *rafi) : rafi(rafi) {}
+
+  SILDynamicMergedIsolationInfo getIsolationInfoAtInst(SILInstruction *inst,
+                                                       SILValue value) const {
+    // If we are not in a supported function, just return invalid always.
+    if (!rafi->isSupportedFunction())
+      return {};
+
+    // First try_emplace with a default value.
+    auto *self = const_cast<IsolationInfoCache *>(this);
+    auto iter = self->cache.try_emplace({inst, value}, SILIsolationInfo());
+
+    // If we failed to insert, we already have a value... just return that.
+    if (!iter.second)
+      return iter.first->second;
+
+    // Otherwise, we need to find the actual isolation of the value.
+    auto blockState = rafi->getBlockState(inst->getParent());
+    if (blockState.isNull() || !blockState.get()->getLiveness()) {
+      // If our block state is null or we have a dead block, just return
+      // invalid.
+      iter.first->getSecond() = SILIsolationInfo();
+      return iter.first->getSecond();
+    }
+
+    // Grab its entry partition and setup an evaluator for the partition that
+    // has callbacks that emit diagnsotics...
+    Partition workingPartition = blockState.get()->getEntryPartition();
+    ComputeEvaluator eval(rafi, workingPartition);
+
+    // And then evaluate all of our partition ops on the entry partition until
+    // we hit our instruction.
+    auto partitionOps = blockState.get()->getPartitionOps();
+    while (!partitionOps.empty()) {
+      const auto &next = partitionOps.front();
+      if (next.getSourceInst() == inst)
+        break;
+      partitionOps = partitionOps.drop_front();
+      eval.apply(next);
+    }
+
+    // Now look up our trackable value lookup result.
+    auto lookupResult = eval.lookupValue(value);
+
+    // First see if our lookup result is Sendable...
+    if (lookupResult.value.isSendable()) {
+      // In such a case, see if we have a base value that is non-Sendable. If
+      // so, use its isolation.
+      if (auto base = lookupResult.base) {
+        auto isolation =
+            eval.getIsolation(workingPartition.getRegion(base->getID()));
+        iter.first->getSecond() = isolation;
+        return iter.first->getSecond();
+      }
+
+      // Otherwise, return an invalid isolation.
+      iter.first->getSecond() = SILIsolationInfo();
+      return iter.first->getSecond();
+    }
+
+    auto isolation = eval.getIsolation(
+        workingPartition.getRegion(lookupResult.value.getID()));
+    iter.first->getSecond() = isolation;
+    return iter.first->getSecond();
+  }
+};
+
 /// Carries the state of analysis for an entire SILFunction.
 class FunctionInfo : public BasicBlockData<BlockInfo> {
 private:
@@ -194,16 +336,24 @@ public:
   std::optional<std::pair<SILBasicBlock *, LatticeState::Kind>> normalReturn =
       std::nullopt;
 
-  /// indicates whether the SILFunction is (or contained in) a deinit.
+  RegionAnalysis *ra;
+  RegionAnalysisFunctionInfo *rafi;
+
+  IsolationInfoCache isolationInfoCache;
+
+  /// Indicates whether the SILFunction is (or contained in) a deinit.
   bool forDeinit;
 
-  FunctionInfo(SILFunction *fn)
-      : BasicBlockData<BlockInfo>(fn), flow(fn, LatticeState::NumStates) {
-    forDeinit = isWithinDeinit(fn);
-  }
+  // Use a worklist to track the uses left to be searched.
+  std::optional<OperandWorklist> worklist;
+
+  FunctionInfo(SILFunction *fn, RegionAnalysis *ra)
+      : BasicBlockData<BlockInfo>(fn), flow(fn, LatticeState::NumStates),
+        ra(ra), rafi(ra->get(fn)), isolationInfoCache(rafi),
+        forDeinit(isWithinDeinit(fn)), worklist(fn) {}
 
   // analyzes the function for uses of `self`.
-  void analyze(const SILArgument* selfParam);
+  void analyze(SILValue selfParam);
 
   // Solves the data-flow problem, assuming analysis has been performed.
   void solve();
@@ -256,7 +406,7 @@ public:
       return *(deferBlocks[someFn]);
 
     // otherwise, insert fresh info and retry.
-    deferBlocks.insert({someFn, std::make_unique<FunctionInfo>(someFn)});
+    deferBlocks.insert({someFn, std::make_unique<FunctionInfo>(someFn, ra)});
     return getOrCreateDeferInfo(someFn);
   }
 
@@ -276,16 +426,91 @@ public:
     return startingIsolation == LatticeState::Nonisolated;
   }
 
+  void lookThroughInst(SILInstruction *i) {
+    LLVM_DEBUG(llvm::dbgs() << "Looking through: " << *i);
+    worklist->pushResultOperandsIfNotVisited(i);
+  }
+
+  void lookThroughValue(SILValue v) {
+    LLVM_DEBUG(llvm::dbgs() << "Looking through: " << v);
+    worklist->pushResultOperandsIfNotVisited(v);
+  }
+
+  void markIgnored(SILInstruction *i) {
+    LLVM_DEBUG(llvm::dbgs() << "Ignoring: " << *i);
+  }
+
   /// Records that the instruction accesses an isolated property.
-  void markPropertyUse(Operand *i) {
-    LLVM_DEBUG(llvm::dbgs() << "marking as isolated: " << *i);
+  void markPropertyUse(Operand *i, bool isDefault = false) {
+    // If we have an actor isolated function and the isolation of our value at
+    // out user matches the function, we should not error.
+    //
+    // E.x.:
+    //
+    // @MainActor
+    // struct S {
+    //   @MainActor var x: NS
+    //   @CustomActor var y: NS
+    //
+    //   nonisolated func trigger() {}
+    //
+    //   @CustomActor init() {
+    //     x = NS()
+    //     y = NS()
+    //     trigger()
+    //     _ = x // Error here.
+    //     _ = y // But not here b/c y is @CustomActor.
+    //   }
+    //
+    if (auto funcIsolation = rafi->getFunction()->getActorIsolation();
+        funcIsolation && funcIsolation->isActorIsolated()) {
+      // If our use is Non-Sendable, then we can rely on region isolation.
+      if (SILIsolationInfo::isNonSendable(i->get())) {
+        if (auto iso = isolationInfoCache.getIsolationInfoAtInst(i->getUser(),
+                                                                 i->get())) {
+          if (iso->isActorIsolated() &&
+              iso->getActorIsolation() == *funcIsolation) {
+            LLVM_DEBUG(llvm::dbgs() << "isolated use that is safe b/c value is "
+                                       "isolated to same as constructor: "
+                                    << "Op Num. " << i->getOperandNumber()
+                                    << ". User: " << *i->getUser());
+            return;
+          }
+        }
+      } else {
+        // If our operand was Sendable, we may have our traversal at a
+        // projection. See if we can find a VarDecl for it.
+        if (auto *svi = dyn_cast<SingleValueInstruction>(i->getUser());
+            llvm::isa_and_present<StructElementAddrInst, RefElementAddrInst>(
+                svi)) {
+          Projection proj(svi);
+          if (auto *decl = proj.getVarDecl(svi->getOperand(0)->getType())) {
+            if (auto declIsolation = swift::getActorIsolation(decl);
+                declIsolation && declIsolation.isActorIsolated() &&
+                declIsolation == *funcIsolation) {
+              LLVM_DEBUG(llvm::dbgs()
+                         << "isolated use that is safe b/c value is "
+                            "isolated to same as constructor. Op Num: "
+                         << i->getOperandNumber()
+                         << ". User: " << *i->getUser());
+              return;
+            }
+          }
+        }
+      }
+    }
+
+    LLVM_DEBUG(llvm::dbgs()
+               << (isDefault ? "Default pattern match. " : "")
+               << "Marking as isolated: OpNum: " << i->getOperandNumber()
+               << ". User: " << *i->getUser());
     auto &blockData = this->operator[](i->getParentBlock());
     blockData.propertyUses.insert(i);
   }
 
   /// Records that the instruction causes 'self' to become nonisolated.
   void markNonIsolated(SILInstruction *i) {
-    LLVM_DEBUG(llvm::dbgs() << "marking as non-isolated: " << *i);
+    LLVM_DEBUG(llvm::dbgs() << "Marking as non-isolated: " << *i);
     auto &blockData = this->operator[](i->getParent());
     blockData.nonisolatedUses.insert(i);
   }
@@ -447,10 +672,10 @@ describe(SILInstruction *blame) {
 
   // handle other non-call blames.
   switch (blame->getKind()) {
-    case SILInstructionKind::CopyValueInst:
-      return std::make_tuple("making a copy of", "", ctx.Id_self);
-    default:
-      return std::make_tuple("this use of", "", ctx.Id_self);
+  case SILInstructionKind::CopyValueInst:
+    return std::make_tuple("making a copy of", "", ctx.Id_self);
+  default:
+    return std::make_tuple("this use of", "", ctx.Id_self);
   }
 }
 
@@ -505,22 +730,43 @@ void BlockInfo::diagnoseAll(FunctionInfo &info, bool forDeinit,
       // Init accessor `setter` use.
       auto *accessor =
           cast<AccessorDecl>(callee->getLocation().getAsDeclContext());
-      diagnoseError(use,
-                    diag::isolated_property_mutation_in_nonisolated_context,
-                    accessor->getStorage(), accessor->isSetter())
+      loggedDiagnoseErrorAndHighlight(
+          use->getUser(),
+          diag::isolated_property_mutation_in_nonisolated_context,
+          accessor->getStorage(), accessor->isSetter())
           .warnUntilLanguageMode(LanguageMode::v6);
       continue;
     }
 
     auto *user = use->getUser();
-    assert(isa<RefElementAddrInst>(user) &&
-           "only expecting one kind of instr.");
+    StringRef isolation = "nonisolated";
+    if (auto functionIsolation = user->getFunction()->getActorIsolation();
+        functionIsolation && functionIsolation->isActorIsolated()) {
+      SmallString<64> temp;
+      {
+        llvm::raw_svector_ostream os(temp);
+        functionIsolation->printForDiagnostics(os);
+      }
 
-    VarDecl *var = cast<RefElementAddrInst>(user)->getField();
+      isolation =
+          user->getFunction()->getASTContext().getIdentifier(temp).str();
+    }
 
-    diagnoseErrorAndHighlight(user, diag::isolated_after_nonisolated, forDeinit,
-                              var)
-        .warnUntilLanguageMode(LanguageMode::v6);
+    if (auto *rfi = dyn_cast<RefElementAddrInst>(user)) {
+      loggedDiagnoseErrorAndHighlight(rfi, diag::isolated_after_nonisolated,
+                                      forDeinit, rfi->getField(), isolation)
+          .warnUntilLanguageMode(LanguageMode::v6);
+    } else if (auto *seai = dyn_cast<StructElementAddrInst>(user)) {
+      loggedDiagnoseErrorAndHighlight(seai, diag::isolated_after_nonisolated,
+                                      forDeinit, seai->getField(), isolation)
+          .warnUntilLanguageMode(LanguageMode::v6);
+    } else {
+      auto name = VariableNameInferrer::inferName(use->get());
+      loggedDiagnoseErrorAndHighlight(
+          user, diag::isolated_after_nonisolated_identifier, forDeinit, *name,
+          isolation)
+          .warnUntilLanguageMode(LanguageMode::v6);
+    }
 
     // after <verb><adjective> <subject>, ... can't use self anymore, etc ...
     //   example:
@@ -529,8 +775,8 @@ void BlockInfo::diagnoseAll(FunctionInfo &info, bool forDeinit,
     StringRef adjective;
     DeclName subject;
     std::tie(verb, adjective, subject) = describe(blame);
-    diagnoseNoteAndHighlight(blame, diag::nonisolated_blame, forDeinit, verb,
-                             adjective, subject);
+    loggedDiagnoseNoteAndHighlight(blame, diag::nonisolated_blame, forDeinit,
+                                   verb, adjective, subject, isolation);
   }
 }
 
@@ -540,12 +786,10 @@ void BlockInfo::diagnoseAll(FunctionInfo &info, bool forDeinit,
 
 /// \returns true iff the access is concurrency-safe in a nonisolated context
 /// without an await.
-static bool accessIsConcurrencySafe(ModuleDecl *module,
-                                    RefElementAddrInst *inst) {
-  VarDecl *var = inst->getField();
-
+static bool accessIsConcurrencySafe(SILInstruction *inst, VarDecl *var) {
   // must be accessible from nonisolated.
-  return isLetAccessibleAnywhere(module, var);
+  return isLetAccessibleAnywhere(
+      inst->getFunction()->getModule().getSwiftModule(), var);
 }
 
 /// \returns true iff the ref_element_addr instruction is only used
@@ -581,18 +825,18 @@ static bool diagnoseNonSendableFromDeinit(RefElementAddrInst *inst) {
 /// required.
 /// \param selfParam the parameter of \c getFunction() that should be
 /// treated as \c self
-void FunctionInfo::analyze(const SILArgument *selfParam) {
-  assert(selfParam && "analyzing a function with no self?");
+void FunctionInfo::analyze(SILValue selfParam) {
+  if (!selfParam) {
+    LLVM_DEBUG(llvm::dbgs() << "Analysis. Nullptr selfParam. Skipping!\n");
+    return;
+  }
 
-  ModuleDecl *module = getFunction()->getModule().getSwiftModule();
-
-  // Use a worklist to track the uses left to be searched.
-  OperandWorklist worklist(getFunction());
+  LLVM_DEBUG(llvm::dbgs() << "Analysis. Starting value: " << selfParam);
 
   // Seed with direct users of `self`
-  worklist.pushResultOperandsIfNotVisited(selfParam);
+  worklist->pushResultOperandsIfNotVisited(selfParam);
 
-  while (Operand *operand = worklist.pop()) {
+  while (Operand *operand = worklist->pop()) {
     // A type-dependent use of `self` is an instruction that contains the
     // DynamicSelfType. These instructions do not access any protected
     // state.
@@ -693,21 +937,37 @@ void FunctionInfo::analyze(const SILArgument *selfParam) {
         RefElementAddrInst *refInst = cast<RefElementAddrInst>(user);
 
         // skip auto-generated deinit accesses.
-        if (onlyDeinitAccess(refInst))
+        if (onlyDeinitAccess(refInst)) {
+          markIgnored(user);
           continue;
+        }
 
         // skip known-safe accesses.
-        if (accessIsConcurrencySafe(module, refInst))
+        if (accessIsConcurrencySafe(refInst, refInst->getField())) {
+          markIgnored(user);
           continue;
+        }
 
         // emit a diagnostic and skip if it's non-sendable in a deinit
-        if (forDeinit && diagnoseNonSendableFromDeinit(refInst))
+        if (forDeinit && diagnoseNonSendableFromDeinit(refInst)) {
+          markIgnored(user);
           continue;
+        }
 
         markPropertyUse(operand);
-        break;
+        continue;
       }
+      case SILInstructionKind::StructElementAddrInst: {
+        auto *seai = cast<StructElementAddrInst>(user);
 
+        if (accessIsConcurrencySafe(seai, seai->getField())) {
+          markIgnored(user);
+          continue;
+        }
+
+        markPropertyUse(operand);
+        continue;
+      }
       // Look through certian kinds of single-value instructions.
       case SILInstructionKind::CopyValueInst:
         // TODO: If we had some actual escape analysis information, we could
@@ -715,29 +975,87 @@ void FunctionInfo::analyze(const SILArgument *selfParam) {
         // actually escape the function. We have to be conservative here
         // and assume it might.
         markNonIsolated(user);
-        break;
+        continue;
 
+      // Treat any load as a nonisolated use. (We are treating this as an
+      // escape).
+      case SILInstructionKind::LoadInst:
+      case SILInstructionKind::LoadBorrowInst:
+        markNonIsolated(user);
+        continue;
+
+      case SILInstructionKind::StoreInst:
+      case SILInstructionKind::StoreBorrowInst:
+      case SILInstructionKind::StoreUnownedInst:
+      case SILInstructionKind::StoreWeakInst:
+      case SILInstructionKind::CopyAddrInst: {
+        // If we are the dest of a copy addr inst, treat it as a property
+        // use. If we are the src of a copy addr inst, treat it as a nonisolated
+        // use.
+        if (operand->getOperandNumber() == CopyLikeInstruction::Src) {
+          markNonIsolated(user);
+          continue;
+        }
+        markPropertyUse(operand);
+        continue;
+      }
+      case SILInstructionKind::MarkUnresolvedMoveAddrInst:
+      case SILInstructionKind::MarkUnresolvedNonCopyableValueInst:
+      case SILInstructionKind::MarkUnresolvedReferenceBindingInst:
+      case SILInstructionKind::UncheckedRefCastInst:
+      case SILInstructionKind::UnconditionalCheckedCastInst:
+      case SILInstructionKind::UncheckedOwnershipConversionInst:
       case SILInstructionKind::BeginAccessInst:
       case SILInstructionKind::BeginBorrowInst:
       case SILInstructionKind::EndInitLetRefInst: {
-        auto *svi = cast<SingleValueInstruction>(user);
-        worklist.pushResultOperandsIfNotVisited(svi);
-        break;
+        lookThroughInst(user);
+        continue;
       }
 
-      case SILInstructionKind::BranchInst: {
-        auto *arg = cast<BranchInst>(user)->getArgForOperand(operand);
-        worklist.pushResultOperandsIfNotVisited(arg);
-        break;
+      case SILInstructionKind::BuiltinInst: {
+        auto *bi = cast<BuiltinInst>(user);
+        if (auto bk = bi->getBuiltinKind()) {
+          switch (*bk) {
+          case BuiltinValueKind::DestroyDefaultActor:
+          case BuiltinValueKind::InitializeDefaultActor:
+            markIgnored(user);
+            continue;
+          default:
+            break;
+          }
+        }
+        markPropertyUse(operand, true /*default*/);
+        continue;
       }
 
+      case SILInstructionKind::BranchInst:
+        lookThroughValue(cast<BranchInst>(user)->getArgForOperand(operand));
+        continue;
 
+        // We ignore return inst. We rely on the type checker to make sure that
+        // this is safe.
+      case SILInstructionKind::ReturnInst:
+        markIgnored(user);
+        continue;
+
+      case SILInstructionKind::DestroyAddrInst:
+      case SILInstructionKind::DestroyValueInst:
+      case SILInstructionKind::DeallocStackInst:
+      case SILInstructionKind::DebugValueInst:
+      case SILInstructionKind::EndBorrowInst:
+      case SILInstructionKind::EndAccessInst:
+      case SILInstructionKind::EndLifetimeInst:
+      case SILInstructionKind::ClassMethodInst:
+      case SILInstructionKind::ValueMetatypeInst:
+        markIgnored(user);
+        // Ignore these.
+        continue;
       default:
-        // don't follow this instruction.
-        LLVM_DEBUG(llvm::dbgs() << DEBUG_TYPE << " def-use walk skipping: "
-                       << *user);
-        break;
-    }
+        // Anything we do not understand mark as a property use to be
+        // conservative.
+        markPropertyUse(operand, true /*default*/);
+        continue;
+      }
   }
 }
 
@@ -861,13 +1179,46 @@ void FunctionInfo::emitDiagnostics() {
 //                            MARK: Top Level Code
 //===----------------------------------------------------------------------===//
 
+/// If \p arg is not a metatype, just wrap it in a SILValue and return
+/// it. Otherwise, we need to go look for the alloc_stack that is storing self.
+static SILValue findSelf(const SILArgument *arg) {
+  if (!arg->getType().isMetatype())
+    return arg;
+  // Self will always be defined in the first block. So if we have a metatype,
+  // just walk the first block to find the stack, ref, box that contains it.
+  for (auto &ii : *arg->getParent()) {
+    // TODO: Can we for a non-copyable type use an alloc_box if it is captured?
+    if (auto *abi = dyn_cast<AllocStackInst>(&ii)) {
+      if (auto *decl = abi->getDecl(); decl && decl->isSelfParameter()) {
+        return abi;
+      }
+      continue;
+    }
+
+    if (auto *ari = dyn_cast<AllocRefInst>(&ii)) {
+      if (auto *decl = ari->getDecl(); decl && decl->isSelfParameter())
+        return ari;
+      continue;
+    }
+
+    if (auto *abi = dyn_cast<AllocBoxInst>(&ii)) {
+      if (auto *decl = abi->getDecl(); decl && decl->isSelfParameter())
+        return abi;
+      continue;
+    }
+  }
+  return SILValue();
+}
+
 /// Performs flow-sensitive actor-isolation checking on the given SILFunction.
-void checkFlowIsolation(SILFunction *fn) {
+static void checkFlowIsolation(SILFunction *fn, RegionAnalysis *ra) {
   assert(fn->hasSelfParam() && "cannot analyze without a self param!");
+  LLVM_DEBUG(llvm::dbgs() << "**** CHECKING FLOW ISOLATION: " << fn->getName()
+                          << '\n');
 
   // Step 1 -- Analyze uses of `self` within the function.
-  FunctionInfo info(fn);
-  info.analyze(fn->getSelfArgument());
+  FunctionInfo info(fn, ra);
+  info.analyze(findSelf(fn->getSelfArgument()));
 
   // Step 2 -- Initialize and solve the dataflow problem.
   info.solve();
@@ -903,9 +1254,7 @@ class FlowIsolation : public SILFunctionTransform {
     if (auto *dc = fn->getDeclContext())
       if (auto *afd = dyn_cast_or_null<AbstractFunctionDecl>(dc->getAsDecl()))
         if (usesFlowSensitiveIsolation(afd))
-          checkFlowIsolation(fn);
-
-    return;
+          checkFlowIsolation(fn, getAnalysis<RegionAnalysis>());
   }
 
 }; // class

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -126,7 +126,6 @@ static bool isolatedConstructorRequiresFlowIsolation(ActorIsolation typeIso,
 
   // Otherwise, if it's an actor instance, then it depends on async-ness.
   switch (typeIso.getKind()) {
-  case ActorIsolation::GlobalActor:
   case ActorIsolation::Unspecified:
   case ActorIsolation::Nonisolated:
   case ActorIsolation::NonisolatedUnsafe:
@@ -139,6 +138,10 @@ static bool isolatedConstructorRequiresFlowIsolation(ActorIsolation typeIso,
   case ActorIsolation::Erased:
     llvm_unreachable("constructor cannot have erased isolation");
 
+  case ActorIsolation::GlobalActor:
+    return ctor->getASTContext().LangOpts.StrictConcurrencyLevel >=
+               StrictConcurrency::Complete &&
+           !ctor->hasAsync();
   case ActorIsolation::ActorInstance:
     return !ctor->hasAsync(); // need flow-isolation for non-async.
   };
@@ -8577,8 +8580,6 @@ ActorReferenceResult ActorReferenceResult::Builder::build() {
     if (fromDC->getASTContext().LangOpts.StrictConcurrencyLevel >=
             StrictConcurrency::Complete &&
         referencedActor && referencedActor->isSelf() &&
-        referencedActor->actor->isActorSelf() &&
-        !contextIsolation.isGlobalActor() &&
         checkedByFlowIsolation(fromDC, *referencedActor, decl, declRefLoc,
                                useKind))
       return forSameConcurrencyDomain(declIsolation, options);

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -863,7 +863,7 @@ actor SomeActorWithInits {
   // expected-note@+1 4 {{mutation of this property is only permitted within the actor}}
   var mutableState: Int = 17
   var otherMutableState: Int
-  let nonSendable: SomeClass // expected-note {{mutation of this property is only permitted within the actor}}
+  let nonSendable: SomeClass
 
   // Sema should not complain about referencing non-Sendable members
   // in an actor init or deinit, as those are diagnosed later by flow-isolation.
@@ -934,7 +934,7 @@ actor SomeActorWithInits {
   @MainActor init(i5 x: SomeClass) {
     self.mutableState = 42
     self.otherMutableState = 17
-    self.nonSendable = x // expected-warning {{actor-isolated property 'nonSendable' can not be mutated from the main actor}}
+    self.nonSendable = x
 
     self.isolated() // expected-warning{{actor-isolated instance method 'isolated()' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
     self.nonisolated()
@@ -1665,12 +1665,12 @@ actor ActorWithNonSendableLet: NonisolatedProtocol {
 
 actor ProtectNonSendable {
   // expected-note@+1 {{property declared here}}
-  let ns = NonSendable() // expected-note {{property declared here}}
+  let ns = NonSendable()
 
   init() {}
 
   @MainActor init(fromMain: Void) {
-    _ = self.ns // expected-warning {{actor-isolated property 'ns' can not be referenced from the main actor}}
+    _ = self.ns
   }
 }
 

--- a/test/Concurrency/flow_isolation.swift
+++ b/test/Concurrency/flow_isolation.swift
@@ -30,6 +30,10 @@ class NonSendableType { // expected-note 8{{class 'NonSendableType' does not con
 @available(SwiftStdlib 5.1, *)
 struct SendableType: Sendable {}
 
+struct NonSendableAOStruct<T> {
+  var value: T
+}
+
 struct Money {
   var dollars: Int
   var euros: Int {
@@ -1352,3 +1356,1609 @@ actor ActorWithMixedDefaultRequirements {
   }
 }
 
+////////////////////////////////////////////////////
+// MARK: Address Only Struct Variants             //
+////////////////////////////////////////////////////
+
+@available(SwiftStdlib 5.1, *)
+@MainActor
+struct MainActorStructWithMixedFields_AO<T> {
+  var _addressOnly: T // expected-note 4{{mutation of this property is only permitted within the actor}}
+  nonisolated let nonisoField: SendableType
+  nonisolated let nonisoSendableField: SendableType
+  @CustomActor var customField: NonSendableType // expected-note 8{{mutation of this property is only permitted within the actor}}
+  @CustomActor var customFieldAO: NonSendableAOStruct<T> // expected-note 8{{mutation of this property is only permitted within the actor}}
+  var mainField: NonSendableType // expected-note 8{{mutation of this property is only permitted within the actor}}
+  var mainFieldAO: NonSendableAOStruct<T> // expected-note 8{{mutation of this property is only permitted within the actor}}
+
+  nonisolated func trigger() {}
+
+  nonisolated init(v1: Void, t: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.nonisoField = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoField
+    _ = self.nonisoSendableField
+    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+  }
+
+  nonisolated init?(v1_failable: Void, t: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.nonisoField = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoField
+    _ = self.nonisoSendableField
+    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+  }
+
+  @MainActor init(v2: Void, t: sending T) {
+    self._addressOnly = t
+    self.nonisoField = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType()
+    self.mainFieldAO = NonSendableAOStruct(value: t)
+
+    trigger()
+
+    _ = self.nonisoField
+    _ = self.nonisoSendableField
+    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType()
+    self.mainFieldAO = NonSendableAOStruct(value: t)
+  }
+
+  @MainActor init?(v2_failable: Void, t: sending T) {
+    self._addressOnly = t
+    self.nonisoField = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType()
+    self.mainFieldAO = NonSendableAOStruct(value: t)
+
+    trigger()
+
+    _ = self.nonisoField
+    _ = self.nonisoSendableField
+    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType()
+    self.mainFieldAO = NonSendableAOStruct(value: t)
+  }
+
+  @CustomActor init(v3: Void, t: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.nonisoField = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.customField = NonSendableType()
+    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoField
+    _ = self.nonisoSendableField
+    self.customField = NonSendableType()
+    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+  }
+
+  @CustomActor init?(v3_failable: Void, t: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.nonisoField = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.customField = NonSendableType()
+    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoField
+    _ = self.nonisoSendableField
+    self.customField = NonSendableType()
+    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+  }
+}
+
+@available(SwiftStdlib 5.5, *)
+@MainActor
+struct GADTStructWithMixedDefaultRequirements_AO<T> {
+  var _addressOnly: T // expected-note 7{{mutation of this property is only permitted within the actor}}
+  var mainDefault: NonSendableType = requiresMainActor() // expected-note 5{{main actor-isolated default value of 'self.mainDefault' cannot be used in a global actor 'CustomActor'-isolated initializer}}
+  // expected-note @-1 8{{property declared here}}
+  // expected-note @-2 5{{mutation of this property is only permitted within the actor}}
+  var mainDefaultAO: NonSendableAOStruct<T> // expected-note 5{{mutation of this property is only permitted within the actor}}
+  // expected-note @-1 8{{property declared here}}
+  // expected-note @-2 2{{'self.mainDefaultAO' not initialized}}
+  nonisolated let nonisoNoDefault: SendableType
+  nonisolated let nonisoSendableField: SendableType
+  @CustomActor var customDefault: NonSendableType = requiresCustomActor() // expected-note 7{{property declared here}}
+  // expected-note @-1 3{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a main actor-isolated initializer}}
+  // expected-note @-2 2{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a nonisolated initializer}}
+  // expected-note @-3 4{{mutation of this property is only permitted within the actor}}
+
+  @CustomActor var customDefaultAO: NonSendableAOStruct<T> // expected-note 7{{property declared here}}
+  // expected-note @-1 4{{mutation of this property is only permitted within the actor}}
+  // expected-note @-2 2{{'self.customDefaultAO' not initialized}}
+
+  nonisolated func trigger() {}
+
+  // We do not completely initialize since we cannot run the default init of
+  // customDefault its initializer actually requires us to be on CustomActor.
+  @MainActor init(v1: NonSendableType, t: sending T) {
+    self._addressOnly = t
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
+    _ = self.mainDefault
+
+    trigger() // expected-error {{variable 'self.customDefault' used before being initialized}}
+
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault
+    _ = self.mainDefaultAO
+    _ = self.customDefault // expected-error {{'self' used before all stored properties are initialized}}
+    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+
+    _ = self.customDefaultAO // expected-error {{variable 'self.customDefaultAO' used before being initialized}}
+    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+
+  } // expected-error {{return from initializer without initializing all stored properties}}
+
+  @MainActor init?(v1_failable: NonSendableType, t: sending T) {
+    self._addressOnly = t
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
+    _ = self.mainDefault
+
+    trigger() // expected-error {{variable 'self.customDefault' used before being initialized}}
+
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault
+    _ = self.mainDefaultAO
+    _ = self.customDefault // expected-error {{'self' used before all stored properties are initialized}}
+    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+
+    _ = self.customDefaultAO // expected-error {{variable 'self.customDefaultAO' used before being initialized}}
+    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+
+  } // expected-error {{variable 'self.customDefault' used before being initialized}}
+
+  // We do completely initialize. With future changes, we should be able to do
+  // this.
+  @MainActor init(v1a: NonSendableType, t: sending T) {
+    self._addressOnly = t
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
+    _ = self.mainDefault
+    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault
+    _ = self.mainDefaultAO
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+  }
+
+  @MainActor init?(v1a_failable: NonSendableType, t: sending T) {
+    self._addressOnly = t
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
+    _ = self.mainDefault
+    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault
+    _ = self.mainDefaultAO
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+  }
+
+  // We do not completely initialize since we cannot run the default init of
+  // mainDefault its initializer actually requires us to be on MainDefault.
+  @CustomActor init(v1b: NonSendableType, t: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
+
+    trigger() // expected-error {{variable 'self.mainDefault' used before being initialized}}
+
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-error {{'self' used before all stored properties are initialized}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+
+    _ = self.mainDefaultAO // expected-error {{variable 'self.mainDefaultAO' used before being initialized}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+
+    _ = self.customDefault
+    _ = self.customDefaultAO
+  } // expected-error {{return from initializer without initializing all stored properties}}
+
+  // We do not completely initialize since we cannot run the default init of
+  // mainDefault its initializer actually requires us to be on MainDefault.
+  @CustomActor init(v1bb: NonSendableType, t: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
+    _ = self.mainDefault // expected-error {{'self' used before all stored properties are initialized}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-error {{variable 'self.mainDefaultAO' used before being initialized}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+
+    trigger() // expected-error {{variable 'self.mainDefault' used before being initialized}}
+
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-error {{'self' used before all stored properties are initialized}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+
+    _ = self.mainDefaultAO // expected-error {{variable 'self.mainDefaultAO' used before being initialized}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+
+    _ = self.customDefault
+    _ = self.customDefaultAO
+  } // expected-error {{return from initializer without initializing all stored properties}}
+
+  // We do completely initialize. With future changes, we should be able to do
+  // this.
+  @CustomActor init(v1c: NonSendableType, t: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
+    _ = self.customDefaultAO
+  }
+
+  @CustomActor init?(v1c_failable: NonSendableType, t: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
+    _ = self.customDefaultAO
+  }
+
+  nonisolated init(v2: Void, t: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+
+    trigger() // expected-error {{variable 'self.customDefault' used before being initialized}}
+
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-error {{'self' used before all stored properties are initialized}}
+    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+
+    _ = self.customDefaultAO // expected-error {{variable 'self.customDefaultAO' used before being initialized}}
+    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+
+  } // expected-error {{return from initializer without initializing all stored properties}}
+
+  nonisolated init(v3: Void, t: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+  }
+
+  nonisolated init?(v3_failable: Void, t: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+  }
+}
+
+@available(SwiftStdlib 5.5, *)
+@MainActor
+struct GADTStructWithMixedDefaultRequirementsNonIsolatedInits_AO<T> {
+  var _addressOnly: T // expected-note 6{{mutation of this property is only permitted within the actor}}
+  var mainDefault = NonSendableType() // expected-note 3{{mutation of this property is only permitted within the actor}}
+  // expected-note @-1 7{{property declared here}}
+  var mainDefaultAO: NonSendableAOStruct<T> // expected-note 6{{property declared here}}
+  // expected-note @-1 6{{mutation of this property is only permitted within the actor}}
+  nonisolated let nonisoNoDefault: SendableType
+  nonisolated let nonisoSendableField: SendableType
+  @CustomActor var customDefault = NonSendableType() // expected-note 7{{property declared here}}
+  // expected-note @-1 {{mutation of this property is only permitted within the actor}}
+  @CustomActor var customDefaultAO: NonSendableAOStruct<T> // expected-note 5{{mutation of this property is only permitted within the actor}}
+  // expected-note @-1 5{{property declared here}}
+
+  nonisolated func trigger() {}
+
+  @MainActor init(v1: Void, t: sending T) {
+    self._addressOnly = t
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
+    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault
+    _ = self.mainDefaultAO
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+  }
+
+  @MainActor init?(v1_failable: Void, t: sending T) {
+    self._addressOnly = t
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
+    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault
+    _ = self.mainDefaultAO
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+  }
+
+  // OK: explicitly initializes all fields
+  @CustomActor init(v1a: Void, t: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
+    _ = self.customDefaultAO
+  }
+
+  @CustomActor init(v1b: Void, t: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.customDefault = NonSendableType()
+    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
+    _ = self.customDefaultAO
+  }
+
+  @CustomActor init?(v1b_failable: Void, t: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.customDefault = NonSendableType()
+    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
+    _ = self.customDefaultAO
+  }
+
+  nonisolated init(v2: Void, t: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+  }
+
+  nonisolated init?(v2_failable: Void, t: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+  }
+
+  nonisolated init(v2a: Void, t: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+  }
+}
+
+////////////////////////////////////////////////////
+// MARK: Noncopyable Struct Variants              //
+////////////////////////////////////////////////////
+
+@available(SwiftStdlib 5.1, *)
+@MainActor
+struct MainActorStructWithMixedFields_NC: ~Copyable {
+  nonisolated let nonisoField: SendableType
+  @CustomActor var customField: NonSendableType // expected-note 4{{mutation of this property is only permitted within the actor}}
+  var mainField: NonSendableType // expected-note 4{{mutation of this property is only permitted within the actor}}
+
+  nonisolated func trigger() {}
+
+  nonisolated init(v1: Void) {
+    self.nonisoField = SendableType()
+    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoField
+    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+  }
+
+  @MainActor init(v2: Void) {
+    self.nonisoField = SendableType()
+    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType()
+
+    trigger()
+
+    _ = self.nonisoField
+    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType()
+  }
+
+  @CustomActor init(v3: Void) {
+    self.nonisoField = SendableType()
+    self.customField = NonSendableType()
+    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoField
+    self.customField = NonSendableType()
+    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+  }
+}
+
+@available(SwiftStdlib 5.5, *)
+@MainActor
+struct GADTStructWithMixedDefaultRequirements_NC: ~Copyable {
+  var mainDefault: NonSendableType = requiresMainActor() // expected-note 6{{property declared here}}
+  // expected-note @-1 7{{main actor-isolated default value of 'self.mainDefault' cannot be used in a global actor 'CustomActor'-isolated initializer}}
+  // expected-note @-2 3{{mutation of this property is only permitted within the actor}}
+
+
+  nonisolated let nonisoNoDefault: SendableType
+  @CustomActor var customDefault: NonSendableType = requiresCustomActor() // expected-note 3{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a nonisolated initializer}}
+  // expected-note @-1 4{{property declared here}}
+  // expected-note @-2 3{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a main actor-isolated initializer}}
+  // expected-note @-3 2{{mutation of this property is only permitted within the actor}}
+
+
+
+
+  nonisolated func trigger() {}
+
+  // We do not completely initialize since we cannot run the default init of
+  // customDefault its initializer actually requires us to be on CustomActor.
+  @MainActor init(v1: NonSendableType) {
+    self.nonisoNoDefault = SendableType()
+    _ = self.mainDefault
+
+    trigger() // expected-error {{'self' used before all stored properties are initialized}}
+
+    _ = self.nonisoNoDefault
+    _ = self.mainDefault
+    _ = self.customDefault // expected-error {{'self' used before all stored properties are initialized}}
+    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+
+  } // expected-error {{return from initializer without initializing all stored properties}}
+
+  // We do completely initialize. With future changes, we should be able to do
+  // this.
+  @MainActor init(v1a: NonSendableType) {
+    self.nonisoNoDefault = SendableType()
+    _ = self.mainDefault
+    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.mainDefault
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+  }
+
+  // We do not completely initialize since we cannot run the default init of
+  // mainDefault its initializer actually requires us to be on MainDefault.
+  @CustomActor init(v1b: NonSendableType) {
+    self.nonisoNoDefault = SendableType()
+    _ = self.customDefault
+
+    trigger() // expected-error {{'self' used before all stored properties are initialized}}
+
+    _ = self.nonisoNoDefault
+    _ = self.mainDefault // expected-error {{'self' used before all stored properties are initialized}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+
+    _ = self.customDefault
+  } // expected-error {{return from initializer without initializing all stored properties}}
+
+  // We do not completely initialize since we cannot run the default init of
+  // mainDefault its initializer actually requires us to be on MainDefault.
+  @CustomActor init(v1bb: NonSendableType) {
+    self.nonisoNoDefault = SendableType()
+    _ = self.customDefault
+    _ = self.mainDefault // expected-error {{'self' used before all stored properties are initialized}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+
+
+    trigger() // expected-error {{'self' used before all stored properties are initialized}}
+
+    _ = self.nonisoNoDefault
+    _ = self.mainDefault // expected-error {{'self' used before all stored properties are initialized}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+
+    _ = self.customDefault
+  } // expected-error {{return from initializer without initializing all stored properties}}
+
+  // We do completely initialize. With future changes, we should be able to do
+  // this.
+  @CustomActor init(v1c: NonSendableType) {
+    self.nonisoNoDefault = SendableType()
+    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
+  }
+
+  nonisolated init(v2: Void) {
+    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+
+    trigger() // expected-error {{'self' used before all stored properties are initialized}}
+
+    _ = self.nonisoNoDefault
+    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-error {{'self' used before all stored properties are initialized}}
+    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+
+  } // expected-error {{return from initializer without initializing all stored properties}}
+
+  nonisolated init(v3: Void) {
+    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+  }
+}
+
+@available(SwiftStdlib 5.5, *)
+@MainActor
+struct GADTStructWithMixedDefaultRequirementsNonIsolatedInits_NC: ~Copyable {
+  var mainDefault = NonSendableType() // expected-note 5{{property declared here}}
+  // expected-note @-1 2{{mutation of this property is only permitted within the actor}}
+
+  nonisolated let nonisoNoDefault: SendableType
+  @CustomActor var customDefault = NonSendableType() // expected-note 4{{property declared here}}
+  // expected-note @-1 {{mutation of this property is only permitted within the actor}}
+
+
+  nonisolated func trigger() {}
+
+  @MainActor init(v1: Void) {
+    self.nonisoNoDefault = SendableType()
+    _ = self.mainDefault
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.mainDefault
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+  }
+
+  // OK: explicitly initializes all fields
+  @CustomActor init(v1a: Void) {
+    self.nonisoNoDefault = SendableType()
+    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
+  }
+
+  @CustomActor init(v1b: Void) {
+    self.nonisoNoDefault = SendableType()
+    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.customDefault = NonSendableType()
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
+  }
+
+  nonisolated init(v2: Void) {
+    self.nonisoNoDefault = SendableType()
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+  }
+
+  nonisolated init(v2a: Void) {
+    self.nonisoNoDefault = SendableType()
+    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+  }
+}
+
+//////////////////////////////////////////////////////////////
+// MARK: Address Only Noncopyable Struct Variants            //
+//////////////////////////////////////////////////////////////
+
+@available(SwiftStdlib 5.1, *)
+@MainActor
+struct MainActorStructWithMixedFields_AO_NC<T>: ~Copyable {
+  var _addressOnly: T // expected-note 4{{mutation of this property is only permitted within the actor}}
+  nonisolated let nonisoField: SendableType
+  nonisolated let nonisoSendableField: SendableType
+  @CustomActor var customField: NonSendableType // expected-note 8{{mutation of this property is only permitted within the actor}}
+  @CustomActor var customFieldAO: NonSendableAOStruct<T> // expected-note 8{{mutation of this property is only permitted within the actor}}
+  var mainField: NonSendableType // expected-note 8{{mutation of this property is only permitted within the actor}}
+  var mainFieldAO: NonSendableAOStruct<T> // expected-note 8{{mutation of this property is only permitted within the actor}}
+
+  nonisolated func trigger() {}
+
+  nonisolated init(v1: Void, t: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.nonisoField = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoField
+    _ = self.nonisoSendableField
+    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+  }
+
+  nonisolated init?(v1_failable: Void, t: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.nonisoField = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoField
+    _ = self.nonisoSendableField
+    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+  }
+
+  @MainActor init(v2: Void, t: sending T) {
+    self._addressOnly = t
+    self.nonisoField = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType()
+    self.mainFieldAO = NonSendableAOStruct(value: t)
+
+    trigger()
+
+    _ = self.nonisoField
+    _ = self.nonisoSendableField
+    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType()
+    self.mainFieldAO = NonSendableAOStruct(value: t)
+  }
+
+  @MainActor init?(v2_failable: Void, t: sending T) {
+    self._addressOnly = t
+    self.nonisoField = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType()
+    self.mainFieldAO = NonSendableAOStruct(value: t)
+
+    trigger()
+
+    _ = self.nonisoField
+    _ = self.nonisoSendableField
+    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType()
+    self.mainFieldAO = NonSendableAOStruct(value: t)
+  }
+
+  @CustomActor init(v3: Void, t: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.nonisoField = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.customField = NonSendableType()
+    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoField
+    _ = self.nonisoSendableField
+    self.customField = NonSendableType()
+    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+  }
+
+  @CustomActor init?(v3_failable: Void, t: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.nonisoField = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.customField = NonSendableType()
+    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoField
+    _ = self.nonisoSendableField
+    self.customField = NonSendableType()
+    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+  }
+}
+
+@available(SwiftStdlib 5.5, *)
+@MainActor
+struct GADTStructWithMixedDefaultRequirements_AO_NC<T>: ~Copyable {
+  var _addressOnly: T // expected-note 7{{mutation of this property is only permitted within the actor}}
+  var mainDefault: NonSendableType = requiresMainActor() // expected-note 5{{mutation of this property is only permitted within the actor}}
+  // expected-note @-1 8{{property declared here}}
+  // expected-note @-2 {{main actor-isolated default value of 'self.mainDefault' cannot be used in a global actor 'CustomActor'-isolated initializer}}
+  var mainDefaultAO: NonSendableAOStruct<T> // expected-note 8{{property declared here}}
+  // expected-note @-1 5{{mutation of this property is only permitted within the actor}}
+  nonisolated let nonisoNoDefault: SendableType
+  nonisolated let nonisoSendableField: SendableType
+  @CustomActor var customDefault: NonSendableType = requiresCustomActor() // expected-note 4{{mutation of this property is only permitted within the actor}}
+  // expected-note @-1 7{{property declared here}}
+
+  @CustomActor var customDefaultAO: NonSendableAOStruct<T> // expected-note 4{{mutation of this property is only permitted within the actor}}
+  // expected-note @-1 7{{property declared here}}
+
+  nonisolated func trigger() {}
+
+  // We do not completely initialize since we cannot run the default init of
+  // customDefault its initializer actually requires us to be on CustomActor.
+  @MainActor init(v1: NonSendableType, t: sending T) {
+    self._addressOnly = t
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
+    _ = self.mainDefault
+
+    trigger() // expected-error {{variable 'self.customDefault' used before being initialized}}
+
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault
+    _ = self.mainDefaultAO
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+
+    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+
+  }
+
+  @MainActor init?(v1_failable: NonSendableType, t: sending T) {
+    self._addressOnly = t
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
+    _ = self.mainDefault
+
+    trigger() // expected-error {{variable 'self.customDefault' used before being initialized}}
+
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault
+    _ = self.mainDefaultAO
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+
+    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+
+  }
+
+  // We do completely initialize. With future changes, we should be able to do
+  // this.
+  @MainActor init(v1a: NonSendableType, t: sending T) {
+    self._addressOnly = t
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
+    _ = self.mainDefault
+    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault
+    _ = self.mainDefaultAO
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+  }
+
+  @MainActor init?(v1a_failable: NonSendableType, t: sending T) {
+    self._addressOnly = t
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
+    _ = self.mainDefault
+    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault
+    _ = self.mainDefaultAO
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+  }
+
+  // We do not completely initialize since we cannot run the default init of
+  // mainDefault its initializer actually requires us to be on MainDefault.
+  @CustomActor init(v1b: NonSendableType, t: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
+
+    trigger() // expected-error {{variable 'self.mainDefault' used before being initialized}}
+
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+
+    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+
+    _ = self.customDefault
+    _ = self.customDefaultAO
+  }
+
+  // We do not completely initialize since we cannot run the default init of
+  // mainDefault its initializer actually requires us to be on MainDefault.
+  @CustomActor init(v1bb: NonSendableType, t: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
+    _ = self.mainDefault // expected-error {{'self' used before all stored properties are initialized}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-error {{variable 'self.mainDefaultAO' used before being initialized}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+
+    trigger() // expected-error {{variable 'self.mainDefault' used before being initialized}}
+
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+
+    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+
+    _ = self.customDefault
+    _ = self.customDefaultAO
+  }
+
+  // We do completely initialize. With future changes, we should be able to do
+  // this.
+  @CustomActor init(v1c: NonSendableType, t: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
+    _ = self.customDefaultAO
+  }
+
+  @CustomActor init?(v1c_failable: NonSendableType, t: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
+    _ = self.customDefaultAO
+  }
+
+  nonisolated init(v2: Void, t: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+
+    trigger() // expected-error {{variable 'self.customDefault' used before being initialized}}
+
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+
+    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+
+  }
+
+  nonisolated init(v3: Void, t: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+  }
+
+  nonisolated init?(v3_failable: Void, t: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+  }
+}
+
+@available(SwiftStdlib 5.5, *)
+@MainActor
+struct GADTStructWithMixedDefaultRequirementsNonIsolatedInits_AO_NC<T>: ~Copyable {
+  var _addressOnly: T // expected-note 6{{mutation of this property is only permitted within the actor}}
+  var mainDefault = NonSendableType() // expected-note 7{{property declared here}}
+  // expected-note @-1 3{{mutation of this property is only permitted within the actor}}
+  var mainDefaultAO: NonSendableAOStruct<T> // expected-note 6{{property declared here}}
+  // expected-note @-1 6{{mutation of this property is only permitted within the actor}}
+  nonisolated let nonisoNoDefault: SendableType
+  nonisolated let nonisoSendableField: SendableType
+  @CustomActor var customDefault = NonSendableType() // expected-note 7{{property declared here}}
+  // expected-note @-1 {{mutation of this property is only permitted within the actor}}
+  @CustomActor var customDefaultAO: NonSendableAOStruct<T> // expected-note 5{{property declared here}}
+  // expected-note @-1 5{{mutation of this property is only permitted within the actor}}
+
+  nonisolated func trigger() {}
+
+  @MainActor init(v1: Void, t: sending T) {
+    self._addressOnly = t
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
+    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault
+    _ = self.mainDefaultAO
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+  }
+
+  @MainActor init?(v1_failable: Void, t: sending T) {
+    self._addressOnly = t
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
+    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault
+    _ = self.mainDefaultAO
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+  }
+
+  // OK: explicitly initializes all fields
+  @CustomActor init(v1a: Void, t: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
+    _ = self.customDefaultAO
+  }
+
+  @CustomActor init(v1b: Void, t: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.customDefault = NonSendableType()
+    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
+    _ = self.customDefaultAO
+  }
+
+  @CustomActor init?(v1b_failable: Void, t: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.customDefault = NonSendableType()
+    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
+    _ = self.customDefaultAO
+  }
+
+  nonisolated init(v2: Void, t: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+  }
+
+  nonisolated init?(v2_failable: Void, t: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+  }
+
+  nonisolated init(v2a: Void, t: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+  }
+}
+
+
+////////////////////////////////////////////////////
+// MARK: Enum Variants                            //
+////////////////////////////////////////////////////
+
+@available(SwiftStdlib 5.1, *)
+@MainActor
+enum MainActorEnumWithPayloads {
+  case sendable(SendableType)
+  case nonSendable(NonSendableType)
+
+  nonisolated func trigger() {}
+  nonisolated var nonisoComputed: Int { 0 }
+
+  nonisolated init(v1: Void) {
+    self = .nonSendable(NonSendableType())
+
+    trigger()
+
+    _ = self.nonisoComputed
+    self = .nonSendable(NonSendableType())
+  }
+
+  @MainActor init(v2: Void) {
+    self = .nonSendable(NonSendableType())
+
+    trigger()
+
+    _ = self.nonisoComputed
+    self = .nonSendable(NonSendableType())
+  }
+
+  @CustomActor init(v3: Void) {
+    self = .nonSendable(NonSendableType())
+
+    trigger()
+
+    _ = self.nonisoComputed
+    self = .nonSendable(NonSendableType())
+  }
+}
+
+////////////////////////////////////////////////////
+// MARK: Noncopyable Enum Variants                //
+////////////////////////////////////////////////////
+
+@available(SwiftStdlib 5.1, *)
+@MainActor
+enum MainActorEnumWithPayloads_NC: ~Copyable {
+  case sendable(SendableType)
+  case nonSendable(NonSendableType)
+
+  nonisolated func trigger() {}
+  nonisolated var nonisoComputed: Int { 0 }
+
+  nonisolated init(v1: Void) {
+    self = .nonSendable(NonSendableType())
+
+    trigger()
+
+    _ = self.nonisoComputed
+    self = .nonSendable(NonSendableType())
+  }
+
+  @MainActor init(v2: Void) {
+    self = .nonSendable(NonSendableType())
+
+    trigger()
+
+    _ = self.nonisoComputed
+    self = .nonSendable(NonSendableType())
+  }
+
+  @CustomActor init(v3: Void) {
+    self = .nonSendable(NonSendableType())
+
+    trigger()
+
+    _ = self.nonisoComputed
+    self = .nonSendable(NonSendableType())
+  }
+}
+
+////////////////////////////////////////////////////
+// MARK: Address Only Enum Variants               //
+////////////////////////////////////////////////////
+
+@available(SwiftStdlib 5.1, *)
+@MainActor
+enum MainActorEnumWithPayloads_AO<T> {
+  case sendable(SendableType)
+  case nonSendable(NonSendableType)
+  case addressOnly(NonSendableAOStruct<T>)
+
+  nonisolated func trigger() {}
+  nonisolated var nonisoComputed: Int { 0 }
+
+  nonisolated init(v1: Void, t: sending T) {
+    self = .addressOnly(NonSendableAOStruct(value: t))
+
+    trigger()
+
+    _ = self.nonisoComputed
+    self = .nonSendable(NonSendableType())
+  }
+
+  nonisolated init?(v1_failable: Void, t: sending T) {
+    self = .addressOnly(NonSendableAOStruct(value: t))
+
+    trigger()
+
+    _ = self.nonisoComputed
+    self = .nonSendable(NonSendableType())
+  }
+
+  @MainActor init(v2: Void, t: sending T) {
+    self = .addressOnly(NonSendableAOStruct(value: t))
+
+    trigger()
+
+    _ = self.nonisoComputed
+    self = .nonSendable(NonSendableType())
+  }
+
+  @MainActor init?(v2_failable: Void, t: sending T) {
+    self = .addressOnly(NonSendableAOStruct(value: t))
+
+    trigger()
+
+    _ = self.nonisoComputed
+    self = .nonSendable(NonSendableType())
+  }
+
+  @CustomActor init(v3: Void, t: sending T) {
+    self = .addressOnly(NonSendableAOStruct(value: t))
+
+    trigger()
+
+    _ = self.nonisoComputed
+    self = .nonSendable(NonSendableType())
+  }
+
+  @CustomActor init?(v3_failable: Void, t: sending T) {
+    self = .addressOnly(NonSendableAOStruct(value: t))
+
+    trigger()
+
+    _ = self.nonisoComputed
+    self = .nonSendable(NonSendableType())
+  }
+}
+
+////////////////////////////////////////////////////
+// MARK: Address Only Noncopyable Enum Variants   //
+////////////////////////////////////////////////////
+
+@available(SwiftStdlib 5.1, *)
+@MainActor
+enum MainActorEnumWithPayloads_AO_NC<T>: ~Copyable {
+  case sendable(SendableType)
+  case nonSendable(NonSendableType)
+  case addressOnly(NonSendableAOStruct<T>)
+
+  nonisolated func trigger() {}
+  nonisolated var nonisoComputed: Int { 0 }
+
+  nonisolated init(v1: Void, t: sending T) {
+    self = .addressOnly(NonSendableAOStruct(value: t))
+
+    trigger()
+
+    _ = self.nonisoComputed
+    self = .nonSendable(NonSendableType())
+  }
+
+  nonisolated init?(v1_failable: Void, t: sending T) {
+    self = .addressOnly(NonSendableAOStruct(value: t))
+
+    trigger()
+
+    _ = self.nonisoComputed
+    self = .nonSendable(NonSendableType())
+  }
+
+  @MainActor init(v2: Void, t: sending T) {
+    self = .addressOnly(NonSendableAOStruct(value: t))
+
+    trigger()
+
+    _ = self.nonisoComputed
+    self = .nonSendable(NonSendableType())
+  }
+
+  @MainActor init?(v2_failable: Void, t: sending T) {
+    self = .addressOnly(NonSendableAOStruct(value: t))
+
+    trigger()
+
+    _ = self.nonisoComputed
+    self = .nonSendable(NonSendableType())
+  }
+
+  @CustomActor init(v3: Void, t: sending T) {
+    self = .addressOnly(NonSendableAOStruct(value: t))
+
+    trigger()
+
+    _ = self.nonisoComputed
+    self = .nonSendable(NonSendableType())
+  }
+
+  @CustomActor init?(v3_failable: Void, t: sending T) {
+    self = .addressOnly(NonSendableAOStruct(value: t))
+
+    trigger()
+
+    _ = self.nonisoComputed
+    self = .nonSendable(NonSendableType())
+  }
+}

--- a/test/Concurrency/flow_isolation_actor.swift
+++ b/test/Concurrency/flow_isolation_actor.swift
@@ -46,10 +46,10 @@ struct NonSendableAOStruct<T> {
 actor ActorWithMixedIsolationFields {
   @MainActor var mainField: NonSendableType
   @MainActor var mainField_trivial: Int
-  @CustomActor var customField: NonSendableType // expected-note 2{{mutation of this property is only permitted within the actor}}
+  @CustomActor var customField: NonSendableType
   @CustomActor var customField_trivial: Int
   nonisolated let nonisoField: SendableType
-  var actorField: NonSendableType // expected-note 2{{mutation of this property is only permitted within the actor}}
+  var actorField: NonSendableType
   var actorField_trivial: Int
 
   nonisolated func trigger() {}
@@ -83,27 +83,25 @@ actor ActorWithMixedIsolationFields {
     // Before decay: can assign all fields
     self.mainField = NonSendableType()
     self.mainField_trivial = 0
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType()
     self.customField_trivial = 0
     self.nonisoField = SendableType()
-    self.actorField = NonSendableType() // expected-warning {{actor-isolated property 'actorField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.actorField = NonSendableType()
     self.actorField_trivial = 0
 
-    trigger() // expected-note 9{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+    trigger() // expected-note 6{{after calling instance method 'trigger()', only main actor-isolated properties of 'self' can be accessed from this init}}
 
     // After decay: nonisolated field is accessible, others are not
     _ = self.nonisoField // OK
-    self.mainField = NonSendableType() // expected-warning {{cannot access property 'mainField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    self.mainField_trivial = 0 // expected-warning {{cannot access property 'mainField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    logTransaction(self.mainField_trivial) // expected-warning {{cannot access property 'mainField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{cannot access property 'customField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    self.customField_trivial = 0 // expected-warning {{cannot access property 'customField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    logTransaction(self.customField_trivial) // expected-warning {{cannot access property 'customField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    self.actorField = NonSendableType() // expected-warning {{actor-isolated property 'actorField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{cannot access property 'actorField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    self.actorField_trivial = 0 // expected-warning {{cannot access property 'actorField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    logTransaction(self.actorField_trivial) // expected-warning {{cannot access property 'actorField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType()
+    self.mainField_trivial = 0
+    logTransaction(self.mainField_trivial)
+    self.customField = NonSendableType() // expected-warning {{cannot access property 'customField' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.customField_trivial = 0 // expected-warning {{cannot access property 'customField_trivial' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    logTransaction(self.customField_trivial) // expected-warning {{cannot access property 'customField_trivial' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.actorField = NonSendableType() // expected-warning {{cannot access property 'actorField' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.actorField_trivial = 0 // expected-warning {{cannot access property 'actorField_trivial' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    logTransaction(self.actorField_trivial) // expected-warning {{cannot access property 'actorField_trivial' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
 }
@@ -111,16 +109,11 @@ actor ActorWithMixedIsolationFields {
 @available(SwiftStdlib 5.5, *)
 actor ActorWithMixedDefaultRequirements {
   @MainActor var mainDefault: NonSendableType = requiresMainActor() // expected-note 2{{main actor-isolated default value of 'self.mainDefault' cannot be used in a global actor 'CustomActor'-isolated initializer}}
-  // expected-note @-1 2{{mutation of this property is only permitted within the actor}}
-  // expected-note @-2 3{{property declared here}}
-  // expected-note @-3 2{{main actor-isolated default value of 'self.mainDefault' cannot be used in a nonisolated initializer}}
-  var actorField: NonSendableType // expected-note 6{{mutation of this property is only permitted within the actor}}
-  // expected-note @-1 6{{property declared here}}
+  // expected-note @-1 2{{main actor-isolated default value of 'self.mainDefault' cannot be used in a nonisolated initializer}}
+  var actorField: NonSendableType
   nonisolated let nonisoNoDefault: SendableType
-  @CustomActor var customDefault: NonSendableType = requiresCustomActor() // expected-note {{mutation of this property is only permitted within the actor}}
-  // expected-note @-1 3{{property declared here}}
-  // expected-note @-2 4{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a main actor-isolated initializer}}
-  // expected-note @-3 4{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a nonisolated initializer}}
+  @CustomActor var customDefault: NonSendableType = requiresCustomActor() // expected-note 4{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a main actor-isolated initializer}}
+  // expected-note @-1 4{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a nonisolated initializer}}
 
   nonisolated func trigger() {}
 
@@ -170,97 +163,85 @@ actor ActorWithMixedDefaultRequirements {
 
   @MainActor init(v2: Void) {
     self.nonisoNoDefault = SendableType()
-    self.actorField = NonSendableType() // expected-warning {{actor-isolated property 'actorField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.actorField = NonSendableType()
 
     trigger() // expected-error {{'self' used in method call 'trigger' before all stored properties are initialized}}
-    // expected-note @-1 3{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+    // expected-note @-1 2{{after calling instance method 'trigger()', only main actor-isolated properties of 'self' can be accessed from this init}}
 
-    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    _ = self.actorField // expected-warning {{cannot access property 'actorField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{actor-isolated property 'actorField' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault
+    _ = self.actorField // expected-warning {{cannot access property 'actorField' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     _ = self.nonisoNoDefault
     _ = self.customDefault // expected-error {{variable 'self.customDefault' used before being initialized}}
-    // expected-warning @-1 {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-2 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{cannot access property 'customDefault' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   } // expected-error {{return from initializer without initializing all stored properties}}
 
   @MainActor init(v2a: Void) {
     self.nonisoNoDefault = SendableType()
-    self.actorField = NonSendableType() // expected-warning {{actor-isolated property 'actorField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.actorField = NonSendableType()
     self.mainDefault = NonSendableType()
 
     trigger() // expected-error {{'self' used in method call 'trigger' before all stored properties are initialized}}
-    // expected-note @-1 3{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+    // expected-note @-1 2{{after calling instance method 'trigger()', only main actor-isolated properties of 'self' can be accessed from this init}}
 
-    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    _ = self.actorField // expected-warning {{cannot access property 'actorField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{actor-isolated property 'actorField' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault
+    _ = self.actorField // expected-warning {{cannot access property 'actorField' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     _ = self.nonisoNoDefault
     _ = self.customDefault // expected-error {{variable 'self.customDefault' used before being initialized}}
-    // expected-warning @-1 {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-2 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{cannot access property 'customDefault' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   } // expected-error {{return from initializer without initializing all stored properties}}
 
   @MainActor init(v2b: Void) {
     self.nonisoNoDefault = SendableType()
-    self.actorField = NonSendableType() // expected-warning {{actor-isolated property 'actorField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.actorField = NonSendableType()
     self.mainDefault = NonSendableType()
-    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customDefault = NonSendableType()
 
-    trigger() // expected-note 3{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+    trigger() // expected-note 2{{after calling instance method 'trigger()', only main actor-isolated properties of 'self' can be accessed from this init}}
 
-    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    _ = self.actorField // expected-warning {{cannot access property 'actorField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{actor-isolated property 'actorField' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault
+    _ = self.actorField // expected-warning {{cannot access property 'actorField' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     _ = self.nonisoNoDefault
-    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   @CustomActor init(v3: Void) {
     self.nonisoNoDefault = SendableType()
-    self.actorField = NonSendableType() // expected-warning {{actor-isolated property 'actorField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.actorField = NonSendableType()
 
     trigger() // expected-error {{'self' used in method call 'trigger' before all stored properties are initialized}}
-    // expected-note @-1 3{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+    // expected-note @-1 2{{after calling instance method 'trigger()', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.mainDefault // expected-error {{variable 'self.mainDefault' used before being initialized}}
-    // expected-warning @-1 {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-2 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    _ = self.actorField // expected-warning {{cannot access property 'actorField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{actor-isolated property 'actorField' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{cannot access property 'mainDefault' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.actorField // expected-warning {{cannot access property 'actorField' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     _ = self.nonisoNoDefault
-    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
   } // expected-error {{return from initializer without initializing all stored properties}}
 
   @CustomActor init(v3a: Void) {
     self.nonisoNoDefault = SendableType()
-    self.actorField = NonSendableType() // expected-warning {{actor-isolated property 'actorField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.actorField = NonSendableType()
+    self.mainDefault = NonSendableType()
 
-    trigger() // expected-note 3{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+    trigger() // expected-note 2{{after calling instance method 'trigger()', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
-    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    _ = self.actorField // expected-warning {{cannot access property 'actorField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{actor-isolated property 'actorField' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.actorField // expected-warning {{cannot access property 'actorField' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     _ = self.nonisoNoDefault
-    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
   }
 
   @CustomActor init(v3b: Void) {
     self.nonisoNoDefault = SendableType()
-    self.actorField = NonSendableType() // expected-warning {{actor-isolated property 'actorField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.actorField = NonSendableType()
+    self.mainDefault = NonSendableType()
     self.customDefault = NonSendableType()
 
-    trigger() // expected-note 3{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+    trigger() // expected-note 2{{after calling instance method 'trigger()', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
-    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    _ = self.actorField // expected-warning {{cannot access property 'actorField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{actor-isolated property 'actorField' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.actorField // expected-warning {{cannot access property 'actorField' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     _ = self.nonisoNoDefault
-    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
   }
 }

--- a/test/Concurrency/flow_isolation_actor.swift
+++ b/test/Concurrency/flow_isolation_actor.swift
@@ -1,0 +1,266 @@
+// RUN: %target-swift-frontend -strict-concurrency=complete -swift-version 5 -parse-as-library -emit-sil -verify %s -o /dev/null
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+@globalActor
+actor CustomActor {
+  static let shared = CustomActor()
+}
+
+@CustomActor func requiresCustomActor() -> NonSendableType { NonSendableType() }
+@MainActor func requiresMainActor() -> NonSendableType { NonSendableType() }
+
+func randomBool() -> Bool { return false }
+func logTransaction(_ i: Int) {}
+
+enum Color: Error {
+  case red
+  case yellow
+  case blue
+}
+
+func takeNonSendable<T>(_ ns: T) {}
+
+@available(SwiftStdlib 5.1, *)
+func takeSendable<T : Sendable>(_ s: T) {}
+
+class NonSendableType {
+  var x: Int = 0
+  func f() {}
+}
+
+@available(SwiftStdlib 5.1, *)
+struct SendableType: Sendable {}
+
+struct NonSendableAOStruct<T> {
+  var value: T
+}
+
+/////////////////
+// MARK: Tests //
+/////////////////
+
+@available(SwiftStdlib 5.1, *)
+actor ActorWithMixedIsolationFields {
+  @MainActor var mainField: NonSendableType
+  @MainActor var mainField_trivial: Int
+  @CustomActor var customField: NonSendableType // expected-note 2{{mutation of this property is only permitted within the actor}}
+  @CustomActor var customField_trivial: Int
+  nonisolated let nonisoField: SendableType
+  var actorField: NonSendableType // expected-note 2{{mutation of this property is only permitted within the actor}}
+  var actorField_trivial: Int
+
+  nonisolated func trigger() {}
+
+  init(v1: Void) {
+    // Before decay: can assign all fields
+    self.mainField = NonSendableType()
+    self.mainField_trivial = 0
+    self.customField = NonSendableType()
+    self.customField_trivial = 0
+    self.nonisoField = SendableType()
+    self.actorField = NonSendableType()
+    self.actorField_trivial = 0
+
+    trigger() // expected-note 9{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+
+    // After decay: nonisolated field is accessible, others are not
+    _ = self.nonisoField // OK
+    self.mainField = NonSendableType() // expected-warning {{cannot access property 'mainField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.mainField_trivial = 0 // expected-warning {{cannot access property 'mainField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    logTransaction(self.mainField_trivial) // expected-warning {{cannot access property 'mainField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType() // expected-warning {{cannot access property 'customField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.customField_trivial = 0 // expected-warning {{cannot access property 'customField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    logTransaction(self.customField_trivial) // expected-warning {{cannot access property 'customField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.actorField = NonSendableType() // expected-warning {{cannot access property 'actorField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.actorField_trivial = 0 // expected-warning {{cannot access property 'actorField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    logTransaction(self.actorField_trivial) // expected-warning {{cannot access property 'actorField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+  }
+
+  @MainActor init(v2: Void) {
+    // Before decay: can assign all fields
+    self.mainField = NonSendableType()
+    self.mainField_trivial = 0
+    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customField_trivial = 0
+    self.nonisoField = SendableType()
+    self.actorField = NonSendableType() // expected-warning {{actor-isolated property 'actorField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.actorField_trivial = 0
+
+    trigger() // expected-note 9{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+
+    // After decay: nonisolated field is accessible, others are not
+    _ = self.nonisoField // OK
+    self.mainField = NonSendableType() // expected-warning {{cannot access property 'mainField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.mainField_trivial = 0 // expected-warning {{cannot access property 'mainField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    logTransaction(self.mainField_trivial) // expected-warning {{cannot access property 'mainField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{cannot access property 'customField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.customField_trivial = 0 // expected-warning {{cannot access property 'customField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    logTransaction(self.customField_trivial) // expected-warning {{cannot access property 'customField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.actorField = NonSendableType() // expected-warning {{actor-isolated property 'actorField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{cannot access property 'actorField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.actorField_trivial = 0 // expected-warning {{cannot access property 'actorField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    logTransaction(self.actorField_trivial) // expected-warning {{cannot access property 'actorField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+  }
+
+}
+
+@available(SwiftStdlib 5.5, *)
+actor ActorWithMixedDefaultRequirements {
+  @MainActor var mainDefault: NonSendableType = requiresMainActor() // expected-note 2{{main actor-isolated default value of 'self.mainDefault' cannot be used in a global actor 'CustomActor'-isolated initializer}}
+  // expected-note @-1 2{{mutation of this property is only permitted within the actor}}
+  // expected-note @-2 3{{property declared here}}
+  // expected-note @-3 2{{main actor-isolated default value of 'self.mainDefault' cannot be used in a nonisolated initializer}}
+  var actorField: NonSendableType // expected-note 6{{mutation of this property is only permitted within the actor}}
+  // expected-note @-1 6{{property declared here}}
+  nonisolated let nonisoNoDefault: SendableType
+  @CustomActor var customDefault: NonSendableType = requiresCustomActor() // expected-note {{mutation of this property is only permitted within the actor}}
+  // expected-note @-1 3{{property declared here}}
+  // expected-note @-2 4{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a main actor-isolated initializer}}
+  // expected-note @-3 4{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a nonisolated initializer}}
+
+  nonisolated func trigger() {}
+
+  init(v1: Void) {
+    self.nonisoNoDefault = SendableType()
+    self.actorField = NonSendableType()
+
+    trigger() // expected-error {{'self' used in method call 'trigger' before all stored properties are initialized}}
+    // expected-note @-1 3{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+
+    _ = self.mainDefault // expected-error {{variable 'self.mainDefault' used before being initialized}}
+    // expected-warning @-1 {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.actorField // expected-warning {{cannot access property 'actorField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.nonisoNoDefault
+    _ = self.customDefault // expected-error {{variable 'self.customDefault' used before being initialized}}
+    // expected-warning @-1 {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+  } // expected-error {{return from initializer without initializing all stored properties}}
+
+  init(v1a: Void) {
+    self.nonisoNoDefault = SendableType()
+    self.actorField = NonSendableType()
+    self.mainDefault = NonSendableType()
+
+    trigger() // expected-error {{'self' used in method call 'trigger' before all stored properties are initialized}}
+    // expected-note @-1 3{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.actorField // expected-warning {{cannot access property 'actorField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.nonisoNoDefault
+    _ = self.customDefault // expected-error {{variable 'self.customDefault' used before being initialized}}
+    // expected-warning @-1 {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+  } // expected-error {{return from initializer without initializing all stored properties}}
+
+  init(v1b: Void) {
+    self.nonisoNoDefault = SendableType()
+    self.actorField = NonSendableType()
+    self.mainDefault = NonSendableType()
+    self.customDefault = NonSendableType()
+
+    trigger() // expected-note 3{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.actorField // expected-warning {{cannot access property 'actorField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.nonisoNoDefault
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+  }
+
+  @MainActor init(v2: Void) {
+    self.nonisoNoDefault = SendableType()
+    self.actorField = NonSendableType() // expected-warning {{actor-isolated property 'actorField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+
+    trigger() // expected-error {{'self' used in method call 'trigger' before all stored properties are initialized}}
+    // expected-note @-1 3{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.actorField // expected-warning {{cannot access property 'actorField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{actor-isolated property 'actorField' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.nonisoNoDefault
+    _ = self.customDefault // expected-error {{variable 'self.customDefault' used before being initialized}}
+    // expected-warning @-1 {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-2 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+  } // expected-error {{return from initializer without initializing all stored properties}}
+
+  @MainActor init(v2a: Void) {
+    self.nonisoNoDefault = SendableType()
+    self.actorField = NonSendableType() // expected-warning {{actor-isolated property 'actorField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType()
+
+    trigger() // expected-error {{'self' used in method call 'trigger' before all stored properties are initialized}}
+    // expected-note @-1 3{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.actorField // expected-warning {{cannot access property 'actorField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{actor-isolated property 'actorField' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.nonisoNoDefault
+    _ = self.customDefault // expected-error {{variable 'self.customDefault' used before being initialized}}
+    // expected-warning @-1 {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-2 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+  } // expected-error {{return from initializer without initializing all stored properties}}
+
+  @MainActor init(v2b: Void) {
+    self.nonisoNoDefault = SendableType()
+    self.actorField = NonSendableType() // expected-warning {{actor-isolated property 'actorField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType()
+    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+
+    trigger() // expected-note 3{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.actorField // expected-warning {{cannot access property 'actorField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{actor-isolated property 'actorField' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.nonisoNoDefault
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+  }
+
+  @CustomActor init(v3: Void) {
+    self.nonisoNoDefault = SendableType()
+    self.actorField = NonSendableType() // expected-warning {{actor-isolated property 'actorField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+
+    trigger() // expected-error {{'self' used in method call 'trigger' before all stored properties are initialized}}
+    // expected-note @-1 3{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+
+    _ = self.mainDefault // expected-error {{variable 'self.mainDefault' used before being initialized}}
+    // expected-warning @-1 {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-2 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.actorField // expected-warning {{cannot access property 'actorField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{actor-isolated property 'actorField' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.nonisoNoDefault
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+  } // expected-error {{return from initializer without initializing all stored properties}}
+
+  @CustomActor init(v3a: Void) {
+    self.nonisoNoDefault = SendableType()
+    self.actorField = NonSendableType() // expected-warning {{actor-isolated property 'actorField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+
+    trigger() // expected-note 3{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.actorField // expected-warning {{cannot access property 'actorField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{actor-isolated property 'actorField' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.nonisoNoDefault
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+  }
+
+  @CustomActor init(v3b: Void) {
+    self.nonisoNoDefault = SendableType()
+    self.actorField = NonSendableType() // expected-warning {{actor-isolated property 'actorField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.customDefault = NonSendableType()
+
+    trigger() // expected-note 3{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.actorField // expected-warning {{cannot access property 'actorField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{actor-isolated property 'actorField' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.nonisoNoDefault
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+  }
+}

--- a/test/Concurrency/flow_isolation_basic.swift
+++ b/test/Concurrency/flow_isolation_basic.swift
@@ -1,0 +1,852 @@
+// RUN: %target-swift-frontend -strict-concurrency=complete -swift-version 5 -parse-as-library -emit-sil -verify %s -o /dev/null
+
+// NOTE: This test is for general testing of how flow isolation handles control
+// flow and basic errors. For specific testing related to
+// actors/structs/enums/classes, please use the relevant flow_sensitive_*.swift
+// test.
+
+@globalActor
+actor CustomActor {
+  static let shared = CustomActor()
+}
+
+@CustomActor func requiresCustomActor() -> NonSendableType { NonSendableType() }
+@MainActor func requiresMainActor() -> NonSendableType { NonSendableType() }
+
+func randomBool() -> Bool { return false }
+func logTransaction(_ i: Int) {}
+
+enum Color: Error {
+  case red
+  case yellow
+  case blue
+}
+
+func takeNonSendable<T>(_ ns: T) {}
+
+@available(SwiftStdlib 5.1, *)
+func takeSendable<T : Sendable>(_ s: T) {}
+
+class NonSendableType { // expected-note 8{{class 'NonSendableType' does not conform to the 'Sendable' protocol}}
+  var x: Int = 0
+  func f() {}
+}
+
+@available(SwiftStdlib 5.1, *)
+struct SendableType: Sendable {}
+
+struct NonSendableAOStruct<T> {
+  var value: T
+}
+
+struct Money {
+  var dollars: Int
+  var euros: Int {
+    return dollars * 2
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+func takeBob(_ b: Bob) {}
+
+@available(SwiftStdlib 5.1, *)
+actor Bob {
+  var x: Int
+
+  nonisolated func speak() { }
+  nonisolated var cherry : String {
+        get { "black cherry" }
+    }
+
+  init(v0 initial: Int) {
+    self.x = 0
+    speak() // expected-note {{after calling instance method 'speak()', only nonisolated properties of 'self' can be accessed from this init}}
+    speak()
+    self.x = 1 // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    speak()
+  }
+
+  init(v1 _: Void) {
+    self.x = 0
+    _ = cherry // expected-note {{after accessing property 'cherry', only nonisolated properties of 'self' can be accessed from this init}}
+    self.x = 1 // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+  }
+
+  init(v2 callBack: (Bob) -> Void) {
+    self.x = 0
+    callBack(self) // expected-note {{after a call involving 'self', only nonisolated properties of 'self' can be accessed from this init}}
+    self.x = 1 // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+  }
+
+  init(v3 _: Void) {
+    self.x = 1
+    takeBob(self) // expected-note {{after calling global function 'takeBob', only nonisolated properties of 'self' can be accessed from this init}}
+    self.x = 1 // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+  }
+
+
+
+  // ensure noniso does not flow out of a defer's unreachable block
+  init(spice doesNotFlow: Int) {
+    if true {
+      defer {
+        if randomBool() {
+          speak()
+          fatalError("oops")
+        }
+      }
+      self.x = 0
+    }
+    self.x = 20
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+actor Casey {
+  var money: Money
+
+  nonisolated func speak(_ msg: String) { print("Casey: \(msg)") }
+  nonisolated func cashUnderMattress() -> Int { return 0 }
+
+  init() {
+    money = Money(dollars: 100)
+    defer { logTransaction(money.euros) } // expected-warning {{cannot access property 'money' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.speak("Yay, I have $\(money.dollars)!") // expected-note {{after calling instance method 'speak', only nonisolated properties of 'self' can be accessed from this init}}
+  }
+
+  init(with start: Int) {
+    money = Money(dollars: start)
+
+    if (money.dollars < 0) {
+      self.speak("Oh no, I'm in debt!") // expected-note 3{{after calling instance method 'speak', only nonisolated properties of 'self' can be accessed from this init}}
+    }
+    logTransaction(money.euros) // expected-warning {{cannot access property 'money' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+
+    money.dollars = money.dollars + 1 // expected-warning 2{{cannot access property 'money' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+
+    if randomBool() {
+      money.dollars += cashUnderMattress() // expected-warning {{cannot access property 'money' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+      // expected-note @-1 {{after calling instance method 'cashUnderMattress()', only nonisolated properties of 'self' can be accessed from this init}}
+    }
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+actor Demons {
+  let ns: NonSendableType
+
+  init(_ x: NonSendableType) {
+    self.ns = x
+  }
+
+  deinit { // expected-note {{add 'isolated' to run isolated to 'Demons', which may be later than 'nonisolated deinit'}}
+    let _ = self.ns // expected-warning {{cannot access property 'ns' with a non-Sendable type 'NonSendableType' from nonisolated deinit; this is an error in the Swift 6 language mode}}
+  }
+}
+
+func pass<T>(_ t: T) {}
+
+@available(SwiftStdlib 5.1, *)
+actor ExampleFromProposal {
+  let immutableSendable = SendableType()
+  var mutableSendable = SendableType()
+  let nonSendable = NonSendableType()
+  nonisolated(unsafe) let unsafeNonSendable = NonSendableType()
+  var nsItems: [NonSendableType] = []
+  var sItems: [SendableType] = []
+
+  init() {
+    _ = self.immutableSendable  // ok
+    _ = self.mutableSendable    // ok
+    _ = self.nonSendable        // ok
+    _ = self.unsafeNonSendable
+
+    f() // expected-note 2{{after calling instance method 'f()', only nonisolated properties of 'self' can be accessed from this init}}
+
+    _ = self.immutableSendable  // ok
+    _ = self.mutableSendable // expected-warning {{cannot access property 'mutableSendable' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.nonSendable // expected-warning {{cannot access property 'nonSendable' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.unsafeNonSendable // ok
+  }
+
+
+  deinit { // expected-note 2{{add 'isolated' to run isolated to 'ExampleFromProposal', which may be later than 'nonisolated deinit'}}
+    _ = self.immutableSendable  // ok
+    _ = self.mutableSendable    // ok
+    _ = self.nonSendable // expected-warning {{cannot access property 'nonSendable' with a non-Sendable type 'NonSendableType' from nonisolated deinit; this is an error in the Swift 6 language mode}}
+
+    f() // expected-note {{after calling instance method 'f()', only nonisolated properties of 'self' can be accessed from a deinit}}
+
+    _ = self.immutableSendable  // ok
+    _ = self.mutableSendable // expected-warning {{cannot access property 'mutableSendable' here in deinitializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.nonSendable // expected-warning {{cannot access property 'nonSendable' with a non-Sendable type 'NonSendableType' from nonisolated deinit; this is an error in the Swift 6 language mode}}
+  }
+
+  nonisolated func f() {}
+}
+
+@available(SwiftStdlib 5.1, *)
+@MainActor
+class CheckGAIT1 {
+  var silly = 10
+  var ns = NonSendableType()
+
+  nonisolated func f() {}
+
+  nonisolated init(_ c: Color) {
+    silly += 0
+    repeat {
+      switch c {
+        case .red:
+          continue
+        case .yellow:
+          silly += 1
+          continue
+        case .blue:
+          f() // expected-note {{after calling instance method 'f()', only nonisolated properties of 'self' can be accessed from this init}}
+      }
+      break
+    } while true
+    silly += 2 // expected-warning {{cannot access property 'silly' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+  }
+
+  deinit { // expected-note {{add 'isolated' to run isolated to 'MainActor', which may be later than 'nonisolated deinit'}}
+    _ = ns // expected-warning {{cannot access property 'ns' with a non-Sendable type 'NonSendableType' from nonisolated deinit; this is an error in the Swift 6 language mode}}
+    f() // expected-note {{after calling instance method 'f()', only nonisolated properties of 'self' can be accessed from a deinit}}
+    _ = silly // expected-warning {{cannot access property 'silly' here in deinitializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+actor ControlFlowTester {
+  let ns: NonSendableType = NonSendableType()
+  let s: SendableType = SendableType()
+  var count: Int = 0
+
+  nonisolated func noniso() {}
+
+  init(v1: Void) {
+    noniso() // expected-note {{after calling instance method 'noniso()', only nonisolated properties of 'self' can be accessed from this init}}
+    takeNonSendable(self.ns) // expected-warning {{cannot access property 'ns' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    takeSendable(self.s)
+  }
+
+  init(v2 c: Color) throws {
+    if c == .red {
+      noniso()
+      throw c
+    } else if c == .blue {
+      noniso()
+      fatalError("soul")
+    }
+    count += 1
+  }
+
+  init(v3 c: Color) {
+    do {
+      defer { noniso() } // expected-note 3{{after calling instance method 'noniso()', only nonisolated properties of 'self' can be accessed from this init}}
+      switch c {
+      case .red:
+        throw Color.red
+      case .blue:
+        throw Color.blue
+      case .yellow:
+        count = 0
+        throw Color.yellow
+      }
+    } catch Color.blue {
+      count += 1 // expected-warning {{cannot access property 'count' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    } catch {
+      count += 1 // expected-warning {{cannot access property 'count' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    }
+    count = 42 // expected-warning {{cannot access property 'count' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+  }
+
+
+  init(v4 c: Color) {
+    defer { count += 1 } // expected-warning {{cannot access property 'count' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    noniso() // expected-note {{after calling instance method 'noniso()', only nonisolated properties of 'self' can be accessed from this init}}
+  }
+
+  init?(v5 c: Color) throws {
+    if c != .red {
+      noniso()
+      return nil
+    }
+    count += 1
+    noniso() // expected-note {{after calling instance method 'noniso()', only nonisolated properties of 'self' can be accessed from this init}}
+    if c == .blue {
+      throw c
+    }
+    count += 1 // expected-warning {{cannot access property 'count' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+  }
+
+  init(v5 c: Color?) {
+    if let c = c {
+      switch c {
+      case .red:
+        defer { noniso() } // expected-note 5{{after calling instance method 'noniso()', only nonisolated properties of 'self' can be accessed from this init}}
+        count = 0 // OK
+        fallthrough
+      case .blue:
+        count = 1 // expected-warning {{cannot access property 'count' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+        fallthrough
+      case .yellow:
+        count = 2 // expected-warning {{cannot access property 'count' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+        break
+      }
+    }
+    switch c {
+    case .some(.red):
+      count += 1 // expected-warning {{cannot access property 'count' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    case .some(.blue):
+      count += 2 // expected-warning {{cannot access property 'count' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    case .some(.yellow):
+      count += 3 // expected-warning {{cannot access property 'count' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    case .none:
+      break
+    }
+  }
+}
+
+enum BogusError: Error {
+    case blah
+}
+
+@available(SwiftStdlib 5.1, *)
+actor Convenient {
+    var x: Int
+    var y: Convenient?
+
+    init(val: Int) {
+        self.x = val
+    }
+
+    init(bigVal: Int) {
+        if bigVal < 0 {
+            self.init(val: 0)
+            say(msg: "hello from actor!")
+        }
+        say(msg: "said this too early!") // expected-error {{'self' used before 'self.init' call or assignment to 'self'}}
+        self.init(val: bigVal)
+
+        Task { await self.mutateIsolatedState() }
+    }
+
+    init!(biggerVal1 biggerVal: Int) {
+        guard biggerVal < 1234567 else { return nil }
+        self.init(bigVal: biggerVal)
+        say(msg: "hello?")
+    }
+
+    @MainActor
+    init?(biggerVal2 biggerVal: Int) async {
+        guard biggerVal < 1234567 else { return nil }
+        self.init(bigVal: biggerVal)
+        say(msg: "hello?")
+        await mutateIsolatedState()
+    }
+
+    init() async {
+        self.init(val: 10)
+        self.x += 1
+        mutateIsolatedState()
+    }
+
+    init(throwyDesignated val: Int) throws {
+        guard val > 0 else { throw BogusError.blah }
+        self.x = 10
+        say(msg: "hello?")
+
+        Task { self }
+    }
+
+    init(asyncThrowyDesignated val: Int) async throws {
+        guard val > 0 else { throw BogusError.blah }
+        self.x = 10
+        say(msg: "hello?")
+        Task { self }
+    }
+
+    init(throwyConvenient val: Int) throws {
+        try self.init(throwyDesignated: val)
+        say(msg: "hello?")
+        Task { self }
+    }
+
+    func mutateIsolatedState() {
+        self.y = self
+    }
+
+    nonisolated func say(msg: String) {
+        print(msg)
+    }
+}
+
+func randomInt() -> Int { return 4 }
+
+@available(SwiftStdlib 5.1, *)
+func callMethod(_ a: MyActor) {}
+
+@available(SwiftStdlib 5.1, *)
+func passInout<T>(_ a: inout T) {}
+
+@available(SwiftStdlib 5.1, *)
+actor MyActor {
+    var x: Int
+    var y: Int
+    var hax: MyActor?
+
+    var computedProp : Int {
+        get { 0 }
+        set { }
+    }
+
+    func helloWorld() {}
+
+    init(ci1 c: Bool) {
+        self.init(i1: c)
+        Task { self }
+        callMethod(self)
+    }
+
+    init(ci2 c: Bool) async {
+      self.init(i1: c)
+      self.x = 1
+      callMethod(self)
+      self.x = 0
+    }
+
+    init(i1 c:  Bool) {
+        self.x = 0
+        _ = self.x
+        self.y = self.x
+
+        Task { self } // expected-note 2{{after making a copy of 'self', only nonisolated properties of 'self' can be accessed from this init}}
+
+        self.x = randomInt() // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+
+        callMethod(self) // expected-note 5{{after calling global function 'callMethod', only nonisolated properties of 'self' can be accessed from this init}}
+
+        passInout(&self.x) // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+
+        if c {
+          self.x = self.y // expected-warning {{cannot access property 'y' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+          // expected-warning @-1 {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+        }
+
+        (_, _) = (self.x, self.y) // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+        // expected-warning @-1 {{cannot access property 'y' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+        _ = self.x == 0 // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+
+        while c {
+          self.hax = self // expected-warning {{cannot access property 'hax' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+          // expected-note @-1 2{{after making a copy of 'self', only nonisolated properties of 'self' can be accessed from this init}}
+          _ = self.hax // expected-warning {{cannot access property 'hax' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+        }
+
+        Task {
+            _ = await self.hax
+            await self.helloWorld()
+        }
+
+        { _ = self }()
+    }
+
+    @MainActor
+    init(i2 c:  Bool) {
+        self.x = 0
+        self.y = self.x
+
+        Task { self } // expected-note {{after making a copy of 'self', only nonisolated properties of 'self' can be accessed from this init}}
+
+        callMethod(self)
+
+        passInout(&self.x) // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    }
+
+    init(i3 c:  Bool) async {
+        self.x = 0
+        self.y = self.x
+
+        Task { self }
+
+        self.helloWorld()
+        callMethod(self)
+        passInout(&self.x)
+
+        self.x = self.y
+
+        self.hax = self
+        _ = Optional.some(self)
+
+        _ = computedProp
+        computedProp = 1
+
+        Task {
+            _ = self.hax
+            self.helloWorld()
+        }
+
+      { _ = self }()
+    }
+
+    @MainActor
+    init(i4 c:  Bool) async {
+      self.x = 0
+      self.y = self.x
+
+      Task { self } // expected-note {{after making a copy of 'self', only nonisolated properties of 'self' can be accessed from this init}}
+
+      callMethod(self)
+
+      passInout(&self.x) // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    }
+}
+
+
+@available(SwiftStdlib 5.1, *)
+actor X {
+    var counter: Int
+
+    init(v1 start: Int) {
+        self.counter = start
+        Task { await self.setCounter(start + 1) } // expected-note {{after making a copy of 'self', only nonisolated properties of 'self' can be accessed from this init}}
+
+        if self.counter != start { // expected-warning {{cannot access property 'counter' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+            fatalError("where's my protection?")
+        }
+    }
+
+    func setCounter(_ x : Int) {
+        self.counter = x
+    }
+}
+
+struct CardboardBox<T> {
+    public let item: T
+}
+
+
+@available(SwiftStdlib 5.1, *)
+var globalVar: EscapeArtist? // expected-warning {{var 'globalVar' is not concurrency-safe because it is nonisolated global shared mutable state; this is an error in the Swift 6 language mode}}
+// expected-note @-1 {{convert 'globalVar' to a 'let' constant to make 'Sendable' shared state immutable}}
+// expected-note @-2 {{disable concurrency-safety checks if accesses are protected by an external synchronization mechanism}}
+// expected-note @-3 {{add '@MainActor' to make var 'globalVar' part of global actor 'MainActor'}}
+
+@available(SwiftStdlib 5.1, *)
+actor EscapeArtist {
+    var x: Int
+
+    init(attempt1: Bool) {
+        self.x = 0
+
+        globalVar = self // expected-note {{after making a copy of 'self', only nonisolated properties of 'self' can be accessed from this init}}
+
+        Task { await globalVar!.isolatedMethod() }
+
+        if self.x == 0 { // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+            fatalError("race detected.")
+        }
+    }
+
+    init(attempt2: Bool) {
+        self.x = 0
+
+        let wrapped: EscapeArtist? = .some(self) // expected-note {{after making a copy of 'self', only nonisolated properties of 'self' can be accessed from this init}}
+        let selfUnchained = wrapped!
+
+        Task { await selfUnchained.isolatedMethod() }
+        if self.x == 0 { // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+            fatalError("race detected.")
+        }
+    }
+
+    init(attempt3: Bool) {
+        self.x = 0
+
+        let unchainedSelf = self
+
+        unchainedSelf.nonisolated()
+    }
+
+    init(attempt4: Bool) {
+        self.x = 0
+
+        let unchainedSelf = self
+
+        unchainedSelf.nonisolated()
+
+        let _ = { unchainedSelf.nonisolated() }()
+    }
+
+    init(attempt5: Bool) {
+        self.x = 0
+
+        let box = CardboardBox(item: self)
+        box.item.nonisolated()
+    }
+
+    init(attempt6: Bool) {
+        self.x = 0
+        func fn() {
+            self.nonisolated()
+        }
+        fn()
+    }
+
+    func isolatedMethod() { x += 1 }
+    nonisolated func nonisolated() {}
+}
+
+@available(SwiftStdlib 5.5, *)
+actor Ahmad {
+  nonisolated func f() {}
+  var prop: Int = 0
+  var computedProp: Int { 10 } // expected-note {{property declared here}}
+
+  init(v1: Void) {
+    Task.detached { self.f() } // expected-note {{after making a copy of 'self', only nonisolated properties of 'self' can be accessed from this init}}
+    f()
+    prop += 1 // expected-warning {{cannot access property 'prop' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+  }
+
+  nonisolated init(v2: Void) async {
+    Task.detached { self.f() } // expected-note {{after making a copy of 'self', only nonisolated properties of 'self' can be accessed from this init}}
+    f()
+    prop += 1 // expected-warning {{cannot access property 'prop' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+  }
+
+  nonisolated init(v3: Void) async {
+    prop = 10
+    f() // expected-note {{after calling instance method 'f()', only nonisolated properties of 'self' can be accessed from this init}}
+    prop += 1 // expected-warning {{cannot access property 'prop' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+  }
+
+  @MainActor init(v4: Void) async {
+    prop = 10
+    f() // expected-note {{after calling instance method 'f()', only nonisolated properties of 'self' can be accessed from this init}}
+    prop += 1 // expected-warning {{cannot access property 'prop' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+  }
+
+  deinit { // expected-note {{add 'isolated' to run isolated to 'Ahmad', which may be later than 'nonisolated deinit'}}
+    let x = computedProp // expected-warning {{actor-isolated property 'computedProp' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    // expected-note @-1 {{after accessing property 'computedProp', only nonisolated properties of 'self' can be accessed from a deinit}}
+
+    prop = x // expected-warning {{cannot access property 'prop' here in deinitializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+  }
+}
+
+@available(SwiftStdlib 5.5, *)
+actor Rain {
+  var x: Int = 0
+  nonisolated func f() {}
+
+  init(_ hollerBack: (Rain) -> () -> Void) {
+    defer { self.f() }
+
+    defer { _ = self.x } // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+
+    defer { Task { self.f() } }
+
+    defer { _ = hollerBack(self) } // expected-note {{after a call involving 'self', only nonisolated properties of 'self' can be accessed from this init}}
+  }
+
+  init(_ hollerBack: (Rain) -> () -> Void) async {
+    defer { self.f() }
+
+    defer { _ = self.x }
+
+    defer { Task { self.f() } }
+
+    defer { _ = hollerBack(self) }
+  }
+
+  deinit {
+    x = 1
+  }
+}
+
+@available(SwiftStdlib 5.5, *)
+actor NonIsolatedDeinitExceptionForSwift5 {
+  var x: Int = 0
+
+  func cleanup() { // expected-note {{calls to instance method 'cleanup()' from outside of its actor context are implicitly asynchronous}}
+    x = 0
+  }
+
+  deinit { // expected-note {{add 'isolated' to run isolated to 'NonIsolatedDeinitExceptionForSwift5', which may be later than 'nonisolated deinit'}}
+    cleanup() // expected-warning {{actor-isolated instance method 'cleanup()' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    // expected-note @-1 {{after calling instance method 'cleanup()', only nonisolated properties of 'self' can be accessed from a deinit}}
+
+    x = 1 // expected-warning {{cannot access property 'x' here in deinitializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+  }
+}
+
+@available(SwiftStdlib 6.1, *)
+actor IsolatedDeinitExceptionForSwift5 {
+  var x: Int = 0
+
+  func cleanup() {
+    x = 0
+  }
+
+  isolated deinit {
+    cleanup() // ok
+
+    x = 1 // ok
+  }
+}
+
+
+@available(SwiftStdlib 5.5, *)
+actor OhBrother {
+  private var giver: (OhBrother) -> Int
+  private var whatever: Int = 0
+
+  static var DefaultResult: Int { 10 }
+
+  init() {
+    // this is OK: we're using DynamicSelfType but that doesn't access protected state.
+    self.giver = { (x: OhBrother) -> Int in Self.DefaultResult }
+  }
+
+  init(v2: Void) {
+    giver = { (x: OhBrother) -> Int in 0 }
+
+    // make sure we don't call this a closure, which is the more common situation.
+
+    _ = giver(self) // expected-note {{after a call involving 'self', only nonisolated properties of 'self' can be accessed from this init}}
+
+    whatever = 1 // expected-warning {{cannot access property 'whatever' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+  }
+
+  init(v3: Void) {
+    let blah = { (x: OhBrother) -> Int in 0 }
+    giver = blah
+
+    _ = blah(self) // expected-note {{after a call involving 'self', only nonisolated properties of 'self' can be accessed from this init}}
+
+    whatever = 2 // expected-warning {{cannot access property 'whatever' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+@MainActor class AwesomeUIView {}
+
+@available(SwiftStdlib 5.1, *)
+class CheckDeinitFromClass: AwesomeUIView {
+  var ns: NonSendableType?
+  deinit { // expected-note 2{{add 'isolated' to run isolated to 'MainActor', which may be later than 'nonisolated deinit'}}
+    ns?.f() // expected-warning {{cannot access property 'ns' with a non-Sendable type 'NonSendableType?' from nonisolated deinit; this is an error in the Swift 6 language mode}}
+    ns = nil // expected-warning {{cannot access property 'ns' with a non-Sendable type 'NonSendableType?' from nonisolated deinit; this is an error in the Swift 6 language mode}}
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+actor CheckDeinitFromActor {
+  var ns: NonSendableType?
+  deinit { // expected-note 2{{add 'isolated' to run isolated to 'CheckDeinitFromActor', which may be later than 'nonisolated deinit'}}
+    ns?.f() // expected-warning {{cannot access property 'ns' with a non-Sendable type 'NonSendableType?' from nonisolated deinit; this is an error in the Swift 6 language mode}}
+    ns = nil // expected-warning {{cannot access property 'ns' with a non-Sendable type 'NonSendableType?' from nonisolated deinit; this is an error in the Swift 6 language mode}}
+  }
+}
+
+// https://github.com/apple/swift/issues/70550
+func testActorWithInitAccessorInit() {
+  @available(SwiftStdlib 5.1, *)
+  actor Angle {
+    var degrees: Double
+    var radians: Double = 0 {
+      @storageRestrictions(initializes: degrees)
+      init(initialValue)  {
+        degrees = initialValue * 180 / .pi
+      }
+
+      get { degrees * .pi / 180 }
+      set { degrees = newValue * 180 / .pi }
+    }
+
+    init(degrees: Double) {
+      self.degrees = degrees // Ok
+    }
+
+    init(radians: Double) {
+      self.radians = radians // Ok
+    }
+
+    init(value: Double) {
+      let escapingSelf: (Angle) -> Void = { _ in }
+
+      // degrees are initialized here via default value associated with radians
+
+      escapingSelf(self)
+
+      self.radians = 0 // expected-warning {{actor-isolated property 'radians' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    }
+  }
+
+  @available(SwiftStdlib 5.1, *)
+  actor EscapeBeforeFullInit {
+    var _a: Int // expected-note {{'self._a' not initialized}}
+
+    var a: Int {
+      @storageRestrictions(initializes: _a)
+      init {
+        _a = newValue
+      }
+
+      get { _a }
+      set { _a = newValue }
+    }
+
+    init(v: Int) {
+      let escapingSelf: (EscapeBeforeFullInit) -> Void = { _ in }
+
+      escapingSelf(self) // expected-error {{'self' used before all stored properties are initialized}}
+      // expected-note @-1 {{after a call involving 'self', only nonisolated properties of 'self' can be accessed from this init}}
+
+      self.a = v // expected-warning {{cannot access property '_a' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    }
+  }
+
+  @available(SwiftStdlib 5.1, *)
+  actor NonisolatedAccessors {
+    nonisolated var a: Int = 0 {
+      init {
+      }
+
+      get { 0 }
+      set {}
+    }
+
+    init(value: Int) {
+      let escapingSelf: (NonisolatedAccessors) -> Void = { _ in }
+
+      // a is initialized here via default value
+
+      escapingSelf(self)
+
+      self.a = value // Ok (nonisolated)
+      print(a) // Ok (nonisolated)
+    }
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+actor TestNonisolatedUnsafe {
+  private nonisolated(unsafe) var child: OtherActor!
+  init() {
+    child = OtherActor(parent: self)
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+actor OtherActor {
+  unowned nonisolated let parent: any Actor
+
+  init(parent: any Actor) {
+    self.parent = parent
+  }
+}

--- a/test/Concurrency/flow_isolation_basic.swift
+++ b/test/Concurrency/flow_isolation_basic.swift
@@ -459,11 +459,11 @@ actor MyActor {
         self.x = 0
         self.y = self.x
 
-        Task { self } // expected-note {{after making a copy of 'self', only nonisolated properties of 'self' can be accessed from this init}}
+        Task { self } // expected-note {{after making a copy of 'self', only main actor-isolated properties of 'self' can be accessed from this init}}
 
         callMethod(self)
 
-        passInout(&self.x) // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+        passInout(&self.x) // expected-warning {{cannot access property 'x' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     }
 
     init(i3 c:  Bool) async {
@@ -497,11 +497,11 @@ actor MyActor {
       self.x = 0
       self.y = self.x
 
-      Task { self } // expected-note {{after making a copy of 'self', only nonisolated properties of 'self' can be accessed from this init}}
+      Task { self } // expected-note {{after making a copy of 'self', only main actor-isolated properties of 'self' can be accessed from this init}}
 
       callMethod(self)
 
-      passInout(&self.x) // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+      passInout(&self.x) // expected-warning {{cannot access property 'x' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     }
 }
 
@@ -626,8 +626,8 @@ actor Ahmad {
 
   @MainActor init(v4: Void) async {
     prop = 10
-    f() // expected-note {{after calling instance method 'f()', only nonisolated properties of 'self' can be accessed from this init}}
-    prop += 1 // expected-warning {{cannot access property 'prop' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    f() // expected-note {{after calling instance method 'f()', only main actor-isolated properties of 'self' can be accessed from this init}}
+    prop += 1 // expected-warning {{cannot access property 'prop' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   deinit { // expected-note {{add 'isolated' to run isolated to 'Ahmad', which may be later than 'nonisolated deinit'}}

--- a/test/Concurrency/flow_isolation_class.swift
+++ b/test/Concurrency/flow_isolation_class.swift
@@ -1,0 +1,899 @@
+// RUN: %target-swift-frontend -strict-concurrency=complete -swift-version 5 -parse-as-library -emit-sil -verify %s -o /dev/null
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+@globalActor
+actor CustomActor {
+  static let shared = CustomActor()
+}
+
+@CustomActor func requiresCustomActor() -> NonSendableType { NonSendableType() }
+@MainActor func requiresMainActor() -> NonSendableType { NonSendableType() }
+
+func randomBool() -> Bool { return false }
+func logTransaction(_ i: Int) {}
+
+enum Color: Error {
+  case red
+  case yellow
+  case blue
+}
+
+func takeNonSendable<T>(_ ns: T) {}
+
+@available(SwiftStdlib 5.1, *)
+func takeSendable<T : Sendable>(_ s: T) {}
+
+class NonSendableType {
+  var x: Int = 0
+  func f() {}
+}
+
+@available(SwiftStdlib 5.1, *)
+struct SendableType: Sendable {}
+
+struct NonSendableAOStruct<T> {
+  var value: T
+}
+
+/////////////////
+// MARK: Tests //
+/////////////////
+
+@available(SwiftStdlib 5.1, *)
+@MainActor
+class MainActorClassWithMixedFields {
+  nonisolated let nonisoField: SendableType
+  @CustomActor var customField: NonSendableType // expected-note 4{{mutation of this property is only permitted within the actor}}
+  var mainField: NonSendableType // expected-note 4{{mutation of this property is only permitted within the actor}}
+
+  nonisolated func trigger() {}
+
+  nonisolated init(v1: Void) {
+    self.nonisoField = SendableType()
+    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+
+    trigger() // expected-note 2{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+
+    _ = self.nonisoField  // OK - explicitly nonisolated
+    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{cannot access property 'customField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{cannot access property 'mainField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+  }
+
+  @MainActor init(v2: Void) {
+    self.nonisoField = SendableType()
+    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType()
+
+    trigger()
+
+    _ = self.nonisoField  // OK - explicitly nonisolated
+    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType()
+  }
+
+  @CustomActor init(v3: Void) {
+    self.nonisoField = SendableType()
+    self.customField = NonSendableType()
+    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+
+    trigger() // expected-note 2{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+
+    _ = self.nonisoField  // OK - explicitly nonisolated
+    self.customField = NonSendableType() // expected-warning {{cannot access property 'customField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{cannot access property 'mainField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+  }
+}
+
+//////////////////////////////////////////////////////////////////////////////////
+// MARK: Mixed Default Requirements with Different Default Value Initialization //
+// Isolation                                                                    //
+//////////////////////////////////////////////////////////////////////////////////
+
+// This test has fields that have an explicitly isolated initializer (e.x.:
+// requiresMainActor).
+@available(SwiftStdlib 5.5, *)
+@MainActor
+class GADTStructWithMixedDefaultRequirements {
+  var mainDefault: NonSendableType = requiresMainActor() // expected-note 4{{main actor-isolated default value of 'self.mainDefault' cannot be used in a global actor 'CustomActor'-isolated initializer}}
+  // expected-note @-1 6{{property declared here}}
+  // expected-note @-2 3{{mutation of this property is only permitted within the actor}}
+  nonisolated let nonisoNoDefault: SendableType
+  @CustomActor var customDefault: NonSendableType = requiresCustomActor() // expected-note 2{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a nonisolated initializer}}
+  // expected-note @-1 2{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a main actor-isolated initializer}}
+  // expected-note @-2 2{{mutation of this property is only permitted within the actor}}
+  // expected-note @-3 4{{property declared here}}
+
+  nonisolated func trigger() {}
+
+  // We do not completely initialize since we cannot run the default init of
+  // customDefault its initializer actually requires us to be on CustomActor.
+  @MainActor init(v1: NonSendableType) {
+    self.nonisoNoDefault = SendableType()
+    _ = self.mainDefault
+
+    trigger() // expected-error {{'self' used in method call 'trigger' before all stored properties are initialized}}
+
+    _ = self.nonisoNoDefault
+    _ = self.mainDefault
+    _ = self.customDefault // expected-error {{variable 'self.customDefault' used before being initialized}}
+    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+  } // expected-error {{return from initializer without initializing all stored properties}}
+
+  // We do completely initialize. With future changes, we should be able to do
+  // this.
+  @MainActor init(v1a: NonSendableType) {
+    self.nonisoNoDefault = SendableType()
+    _ = self.mainDefault
+    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.mainDefault
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+  }
+
+  // We do not completely initialize since we cannot run the default init of
+  // mainDefault its initializer actually requires us to be on MainDefault.
+  @CustomActor init(v1b: NonSendableType) {
+    self.nonisoNoDefault = SendableType()
+    _ = self.customDefault
+
+    trigger() // expected-error {{'self' used in method call 'trigger' before all stored properties are initialized}}
+    // expected-note @-1 2{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+
+    _ = self.nonisoNoDefault
+    _ = self.mainDefault // expected-error {{variable 'self.mainDefault' used before being initialized}}
+    // expected-warning @-1 {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-2 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+  } // expected-error {{return from initializer without initializing all stored properties}}
+
+  // We do not completely initialize since we cannot run the default init of
+  // mainDefault its initializer actually requires us to be on MainDefault.
+  @CustomActor init(v1bb: NonSendableType) {
+    self.nonisoNoDefault = SendableType()
+    _ = self.customDefault
+    _ = self.mainDefault // expected-error {{variable 'self.mainDefault' used before being initialized}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+
+    trigger() // expected-error {{'self' used in method call 'trigger' before all stored properties are initialized}}
+    // expected-note @-1 2{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+
+    _ = self.nonisoNoDefault
+    _ = self.mainDefault // expected-error {{variable 'self.mainDefault' used before being initialized}}
+    // expected-warning @-1 {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-2 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+  } // expected-error {{return from initializer without initializing all stored properties}}
+
+  // We do completely initialize. With future changes, we should be able to do
+  // this.
+  @CustomActor init(v1c: NonSendableType) {
+    self.nonisoNoDefault = SendableType()
+    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
+
+    trigger() // expected-note 2{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+
+    _ = self.nonisoNoDefault
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+  }
+
+  nonisolated init(v2: Void) {
+    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+
+    trigger() // expected-error {{'self' used in method call 'trigger' before all stored properties are initialized}}
+    // expected-note @-1 2{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+
+    _ = self.nonisoNoDefault
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-error {{variable 'self.customDefault' used before being initialized}}
+    // expected-warning @-1 {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-2 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+  } // expected-error {{return from initializer without initializing all stored properties}}
+
+  nonisolated init(v3: Void) {
+    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+
+    trigger() // expected-note 2{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+
+    _ = self.nonisoNoDefault
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+  }
+}
+
+@available(SwiftStdlib 5.5, *)
+@MainActor
+class GADTStructWithMixedDefaultRequirementsNonIsolatedInits {
+  var mainDefault = NonSendableType() // expected-note 2{{mutation of this property is only permitted within the actor}}
+  // expected-note @-1 5{{property declared here}}
+  nonisolated let nonisoNoDefault: SendableType
+  @CustomActor var customDefault = NonSendableType() // expected-note 4{{property declared here}}
+  // expected-note @-1 {{mutation of this property is only permitted within the actor}}
+
+  nonisolated func trigger() {}
+
+  @MainActor init(v1: Void) {
+    self.nonisoNoDefault = SendableType()
+    _ = self.mainDefault
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.mainDefault
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+  }
+
+  // OK: explicitly initializes all fields
+  @CustomActor init(v1a: Void) {
+    self.nonisoNoDefault = SendableType()
+    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
+
+    trigger() // expected-note 2{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+
+    _ = self.nonisoNoDefault
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+  }
+
+  @CustomActor init(v1b: Void) {
+    self.nonisoNoDefault = SendableType()
+    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.customDefault = NonSendableType()
+
+    trigger() // expected-note 2{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+
+    _ = self.nonisoNoDefault
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+  }
+
+  nonisolated init(v2: Void) {
+    self.nonisoNoDefault = SendableType()
+
+    trigger() // expected-note 2{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+
+    _ = self.nonisoNoDefault
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+  }
+
+  nonisolated init(v2a: Void) {
+    self.nonisoNoDefault = SendableType()
+    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+
+    trigger() // expected-note 2{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+
+    _ = self.nonisoNoDefault
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+  }
+}
+
+////////////////////////////////////////////////////
+// MARK: Address Only Struct Variants             //
+////////////////////////////////////////////////////
+
+@available(SwiftStdlib 5.1, *)
+@MainActor
+struct MainActorStructWithMixedFields_AO<T> {
+  var _addressOnly: T // expected-note 4{{mutation of this property is only permitted within the actor}}
+  nonisolated let nonisoField: SendableType
+  nonisolated let nonisoSendableField: SendableType
+  @CustomActor var customField: NonSendableType // expected-note 8{{mutation of this property is only permitted within the actor}}
+  @CustomActor var customFieldAO: NonSendableAOStruct<T> // expected-note 8{{mutation of this property is only permitted within the actor}}
+  var mainField: NonSendableType // expected-note 8{{mutation of this property is only permitted within the actor}}
+  var mainFieldAO: NonSendableAOStruct<T> // expected-note 8{{mutation of this property is only permitted within the actor}}
+
+  nonisolated func trigger() {}
+
+  nonisolated init(v1: Void, t: sending T, t2: sending T, t3: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.nonisoField = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoField
+    _ = self.nonisoSendableField
+    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t3) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+  }
+
+  nonisolated init?(v1_failable: Void, t: sending T, t2: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.nonisoField = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoField
+    _ = self.nonisoSendableField
+    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+  }
+
+  @MainActor init(v2: Void, t: sending T, t2: sending T) {
+    self._addressOnly = t
+    self.nonisoField = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType()
+    self.mainFieldAO = NonSendableAOStruct(value: t)
+
+    trigger()
+
+    _ = self.nonisoField
+    _ = self.nonisoSendableField
+    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType()
+    self.mainFieldAO = NonSendableAOStruct(value: t)
+  }
+
+  @MainActor init?(v2_failable: Void, t: sending T, t2: sending T) {
+    self._addressOnly = t
+    self.nonisoField = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType()
+    self.mainFieldAO = NonSendableAOStruct(value: t)
+
+    trigger()
+
+    _ = self.nonisoField
+    _ = self.nonisoSendableField
+    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType()
+    self.mainFieldAO = NonSendableAOStruct(value: t)
+  }
+
+  @CustomActor init(v3: Void, t: sending T, t2: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.nonisoField = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.customField = NonSendableType()
+    self.customFieldAO = NonSendableAOStruct(value: t2)
+    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoField
+    _ = self.nonisoSendableField
+    self.customField = NonSendableType()
+    self.customFieldAO = NonSendableAOStruct(value: t2)
+    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+  }
+
+  @CustomActor init?(v3_failable: Void, t: sending T, t2: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.nonisoField = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.customField = NonSendableType()
+    self.customFieldAO = NonSendableAOStruct(value: t2)
+    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoField
+    _ = self.nonisoSendableField
+    self.customField = NonSendableType()
+    self.customFieldAO = NonSendableAOStruct(value: t2)
+    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+  }
+}
+
+@available(SwiftStdlib 5.5, *)
+@MainActor
+class GADTStructWithMixedDefaultRequirements_AO<T> {
+  var _addressOnly: T // expected-note 7{{mutation of this property is only permitted within the actor}}
+  var mainDefault: NonSendableType = requiresMainActor() // expected-note 4{{main actor-isolated default value of 'self.mainDefault' cannot be used in a global actor 'CustomActor'-isolated initializer}}
+  // expected-note @-1 8{{property declared here}}
+  // expected-note @-2 5{{mutation of this property is only permitted within the actor}}
+  var mainDefaultAO: NonSendableAOStruct<T> // expected-note 5{{mutation of this property is only permitted within the actor}}
+  // expected-note @-1 8{{property declared here}}
+  // expected-note @-2 4{{'self.mainDefaultAO' not initialized}}
+  nonisolated let nonisoNoDefault: SendableType
+  nonisolated let nonisoSendableField: SendableType
+  @CustomActor var customDefault: NonSendableType = requiresCustomActor() // expected-note 3{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a main actor-isolated initializer}}
+  // expected-note @-1 7{{property declared here}}
+  // expected-note @-2 4{{mutation of this property is only permitted within the actor}}
+  // expected-note @-3 2{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a nonisolated initializer}}
+
+  @CustomActor var customDefaultAO: NonSendableAOStruct<T> // expected-note 7{{property declared here}}
+  // expected-note @-1 5{{'self.customDefaultAO' not initialized}}
+  // expected-note @-2 4{{mutation of this property is only permitted within the actor}}
+
+  nonisolated func trigger() {}
+
+  // We do not completely initialize since we cannot run the default init of
+  // customDefault its initializer actually requires us to be on CustomActor.
+  @MainActor init(v1: NonSendableType, t: sending T) {
+    self._addressOnly = t
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
+    _ = self.mainDefault
+
+    trigger() // expected-error {{'self' used in method call 'trigger' before all stored properties are initialized}}
+
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault
+    _ = self.mainDefaultAO
+    _ = self.customDefault // expected-error {{variable 'self.customDefault' used before being initialized}}
+    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+
+    _ = self.customDefaultAO // expected-error {{variable 'self.customDefaultAO' used before being initialized}}
+    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+
+  } // expected-error {{return from initializer without initializing all stored properties}}
+
+  @MainActor init?(v1_failable: NonSendableType, t: sending T) {
+    self._addressOnly = t
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
+    _ = self.mainDefault
+
+    trigger() // expected-error {{'self' used in method call 'trigger' before all stored properties are initialized}}
+
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault
+    _ = self.mainDefaultAO
+    _ = self.customDefault // expected-error {{variable 'self.customDefault' used before being initialized}}
+    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+
+    _ = self.customDefaultAO // expected-error {{variable 'self.customDefaultAO' used before being initialized}}
+    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+
+  } // expected-error {{variable 'self.customDefault' used before being initialized}}
+
+  // We do completely initialize. With future changes, we should be able to do
+  // this.
+  @MainActor init(v1a: NonSendableType, t: sending T, t2: sending T) {
+    self._addressOnly = t
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
+    _ = self.mainDefault
+    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault
+    _ = self.mainDefaultAO
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+  }
+
+  @MainActor init?(v1a_failable: NonSendableType, t: sending T, t2: sending T) {
+    self._addressOnly = t
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
+    _ = self.mainDefault
+    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault
+    _ = self.mainDefaultAO
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+  }
+
+  // We do not completely initialize since we cannot run the default init of
+  // mainDefault its initializer actually requires us to be on MainDefault.
+  @CustomActor init(v1b: NonSendableType, t: sending T, t2: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
+    _ = self.customDefault
+
+    trigger() // expected-error {{'self' used in method call 'trigger' before all stored properties are initialized}}
+    // expected-note @-1 4{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-error {{variable 'self.mainDefault' used before being initialized}}
+    // expected-warning @-1 {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-2 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+
+    _ = self.mainDefaultAO // expected-error {{variable 'self.mainDefaultAO' used before being initialized}}
+    // expected-warning @-1 {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-2 {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+  } // expected-error {{return from initializer without initializing all stored properties}}
+
+  // We do not completely initialize since we cannot run the default init of
+  // mainDefault its initializer actually requires us to be on MainDefault.
+  @CustomActor init(v1bb: NonSendableType, t: sending T, t2: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
+    _ = self.customDefault
+    _ = self.mainDefault // expected-error {{variable 'self.mainDefault' used before being initialized}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-error {{variable 'self.mainDefaultAO' used before being initialized}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+
+    trigger() // expected-error {{'self' used in method call 'trigger' before all stored properties are initialized}}
+    // expected-note @-1 4{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-error {{variable 'self.mainDefault' used before being initialized}}
+    // expected-warning @-1 {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-2 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+
+    _ = self.mainDefaultAO // expected-error {{variable 'self.mainDefaultAO' used before being initialized}}
+    // expected-warning @-1 {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-2 {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+  } // expected-error {{return from initializer without initializing all stored properties}}
+
+  // We do completely initialize. With future changes, we should be able to do
+  // this.
+  @CustomActor init(v1c: NonSendableType, t: sending T, t2: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
+    _ = self.customDefault
+
+    trigger() // expected-note 4{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+  }
+
+  @CustomActor init?(v1c_failable: NonSendableType, t: sending T, t2: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
+    _ = self.customDefault
+
+    trigger() // expected-note 4{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+  }
+
+  nonisolated init(v2: Void, t: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+
+    trigger() // expected-error {{'self' used in method call 'trigger' before all stored properties are initialized}}
+    // expected-note @-1 4{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-error {{variable 'self.customDefault' used before being initialized}}
+    // expected-warning @-1 {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-2 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+
+    _ = self.customDefaultAO // expected-error {{variable 'self.customDefaultAO' used before being initialized}}
+    // expected-warning @-1 {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-2 {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+
+  } // expected-error {{return from initializer without initializing all stored properties}}
+
+  nonisolated init(v3: Void, t: sending T, t2: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+
+    trigger() // expected-note 4{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+  }
+
+  nonisolated init?(v3_failable: Void, t: sending T, t2: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+
+    trigger() // expected-note 4{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+  }
+}
+
+@available(SwiftStdlib 5.5, *)
+@MainActor
+class GADTStructWithMixedDefaultRequirementsNonIsolatedInits_AO<T> {
+  var _addressOnly: T // expected-note 6{{mutation of this property is only permitted within the actor}}
+  var mainDefault = NonSendableType() // expected-note 3{{mutation of this property is only permitted within the actor}}
+  // expected-note @-1 7{{property declared here}}
+  var mainDefaultAO: NonSendableAOStruct<T> // expected-note 6{{property declared here}}
+  // expected-note @-1 6{{mutation of this property is only permitted within the actor}}
+  nonisolated let nonisoNoDefault: SendableType
+  nonisolated let nonisoSendableField: SendableType
+  @CustomActor var customDefault = NonSendableType() // expected-note 7{{property declared here}}
+  // expected-note @-1 {{mutation of this property is only permitted within the actor}}
+  @CustomActor var customDefaultAO: NonSendableAOStruct<T> // expected-note 5{{property declared here}}
+  // expected-note @-1 5{{mutation of this property is only permitted within the actor}}
+
+  nonisolated func trigger() {}
+
+  @MainActor init(v1: Void, t: sending T, t2: sending T) {
+    self._addressOnly = t
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
+    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault
+    _ = self.mainDefaultAO
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+  }
+
+  @MainActor init?(v1_failable: Void, t: sending T, t2: sending T) {
+    self._addressOnly = t
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
+    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault
+    _ = self.mainDefaultAO
+    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+  }
+
+  // OK: explicitly initializes all fields
+  @CustomActor init(v1a: Void, t: sending T, t2: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
+    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
+
+    trigger() // expected-note 4{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+  }
+
+  @CustomActor init(v1b: Void, t: sending T, t2: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.customDefault = NonSendableType()
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
+
+    trigger() // expected-note 4{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+  }
+
+  @CustomActor init?(v1b_failable: Void, t: sending T, t2: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.customDefault = NonSendableType()
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
+
+    trigger() // expected-note 4{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+  }
+
+  nonisolated init(v2: Void, t: sending T, t2: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+
+    trigger() // expected-note 4{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+  }
+
+  nonisolated init?(v2_failable: Void, t: sending T, t2: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+
+    trigger() // expected-note 4{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+  }
+
+  nonisolated init(v2a: Void, t: sending T, t2: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+
+    trigger() // expected-note 4{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{main actor-isolated property 'mainDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+  }
+}

--- a/test/Concurrency/flow_isolation_class.swift
+++ b/test/Concurrency/flow_isolation_class.swift
@@ -46,48 +46,45 @@ struct NonSendableAOStruct<T> {
 @MainActor
 class MainActorClassWithMixedFields {
   nonisolated let nonisoField: SendableType
-  @CustomActor var customField: NonSendableType // expected-note 4{{mutation of this property is only permitted within the actor}}
-  var mainField: NonSendableType // expected-note 4{{mutation of this property is only permitted within the actor}}
+  @CustomActor var customField: NonSendableType
+  var mainField: NonSendableType
 
   nonisolated func trigger() {}
 
   nonisolated init(v1: Void) {
     self.nonisoField = SendableType()
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType()
+    self.mainField = NonSendableType()
 
     trigger() // expected-note 2{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoField  // OK - explicitly nonisolated
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{cannot access property 'customField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{cannot access property 'mainField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType() // expected-warning {{cannot access property 'customField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{cannot access property 'mainField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   @MainActor init(v2: Void) {
     self.nonisoField = SendableType()
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType()
     self.mainField = NonSendableType()
 
-    trigger()
+    trigger() // expected-note {{after calling instance method 'trigger()', only main actor-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoField  // OK - explicitly nonisolated
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType() // expected-warning {{cannot access property 'customField' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     self.mainField = NonSendableType()
   }
 
   @CustomActor init(v3: Void) {
     self.nonisoField = SendableType()
     self.customField = NonSendableType()
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType()
 
-    trigger() // expected-note 2{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+    trigger() // expected-note {{after calling instance method 'trigger()', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoField  // OK - explicitly nonisolated
-    self.customField = NonSendableType() // expected-warning {{cannot access property 'customField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{cannot access property 'mainField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType()
+    self.mainField = NonSendableType() // expected-warning {{cannot access property 'mainField' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 }
 
@@ -102,13 +99,9 @@ class MainActorClassWithMixedFields {
 @MainActor
 class GADTStructWithMixedDefaultRequirements {
   var mainDefault: NonSendableType = requiresMainActor() // expected-note 4{{main actor-isolated default value of 'self.mainDefault' cannot be used in a global actor 'CustomActor'-isolated initializer}}
-  // expected-note @-1 6{{property declared here}}
-  // expected-note @-2 3{{mutation of this property is only permitted within the actor}}
   nonisolated let nonisoNoDefault: SendableType
-  @CustomActor var customDefault: NonSendableType = requiresCustomActor() // expected-note 2{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a nonisolated initializer}}
-  // expected-note @-1 2{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a main actor-isolated initializer}}
-  // expected-note @-2 2{{mutation of this property is only permitted within the actor}}
-  // expected-note @-3 4{{property declared here}}
+  @CustomActor var customDefault: NonSendableType = requiresCustomActor() // expected-note 2{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a main actor-isolated initializer}}
+  // expected-note @-1 2{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a nonisolated initializer}}
 
   nonisolated func trigger() {}
 
@@ -119,11 +112,12 @@ class GADTStructWithMixedDefaultRequirements {
     _ = self.mainDefault
 
     trigger() // expected-error {{'self' used in method call 'trigger' before all stored properties are initialized}}
+    // expected-note @-1 {{after calling instance method 'trigger()', only main actor-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.mainDefault
     _ = self.customDefault // expected-error {{variable 'self.customDefault' used before being initialized}}
-    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{cannot access property 'customDefault' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   } // expected-error {{return from initializer without initializing all stored properties}}
 
   // We do completely initialize. With future changes, we should be able to do
@@ -131,13 +125,13 @@ class GADTStructWithMixedDefaultRequirements {
   @MainActor init(v1a: NonSendableType) {
     self.nonisoNoDefault = SendableType()
     _ = self.mainDefault
-    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customDefault = NonSendableType()
 
-    trigger()
+    trigger() // expected-note {{after calling instance method 'trigger()', only main actor-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.mainDefault
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   // We do not completely initialize since we cannot run the default init of
@@ -147,13 +141,12 @@ class GADTStructWithMixedDefaultRequirements {
     _ = self.customDefault
 
     trigger() // expected-error {{'self' used in method call 'trigger' before all stored properties are initialized}}
-    // expected-note @-1 2{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+    // expected-note @-1 {{after calling instance method 'trigger()', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.mainDefault // expected-error {{variable 'self.mainDefault' used before being initialized}}
-    // expected-warning @-1 {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-2 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{cannot access property 'mainDefault' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
   } // expected-error {{return from initializer without initializing all stored properties}}
 
   // We do not completely initialize since we cannot run the default init of
@@ -162,35 +155,32 @@ class GADTStructWithMixedDefaultRequirements {
     self.nonisoNoDefault = SendableType()
     _ = self.customDefault
     _ = self.mainDefault // expected-error {{variable 'self.mainDefault' used before being initialized}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
 
     trigger() // expected-error {{'self' used in method call 'trigger' before all stored properties are initialized}}
-    // expected-note @-1 2{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+    // expected-note @-1 {{after calling instance method 'trigger()', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.mainDefault // expected-error {{variable 'self.mainDefault' used before being initialized}}
-    // expected-warning @-1 {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-2 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{cannot access property 'mainDefault' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
   } // expected-error {{return from initializer without initializing all stored properties}}
 
   // We do completely initialize. With future changes, we should be able to do
   // this.
   @CustomActor init(v1c: NonSendableType) {
     self.nonisoNoDefault = SendableType()
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType()
     _ = self.customDefault
 
-    trigger() // expected-note 2{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+    trigger() // expected-note {{after calling instance method 'trigger()', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
-    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
   }
 
   nonisolated init(v2: Void) {
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType()
     self.nonisoNoDefault = SendableType()
 
     trigger() // expected-error {{'self' used in method call 'trigger' before all stored properties are initialized}}
@@ -198,75 +188,67 @@ class GADTStructWithMixedDefaultRequirements {
 
     _ = self.nonisoNoDefault
     _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
     _ = self.customDefault // expected-error {{variable 'self.customDefault' used before being initialized}}
     // expected-warning @-1 {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-2 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
   } // expected-error {{return from initializer without initializing all stored properties}}
 
   nonisolated init(v3: Void) {
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType()
+    self.customDefault = NonSendableType()
     self.nonisoNoDefault = SendableType()
 
     trigger() // expected-note 2{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
     _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
   }
 }
 
 @available(SwiftStdlib 5.5, *)
 @MainActor
 class GADTStructWithMixedDefaultRequirementsNonIsolatedInits {
-  var mainDefault = NonSendableType() // expected-note 2{{mutation of this property is only permitted within the actor}}
-  // expected-note @-1 5{{property declared here}}
+  var mainDefault = NonSendableType()
   nonisolated let nonisoNoDefault: SendableType
-  @CustomActor var customDefault = NonSendableType() // expected-note 4{{property declared here}}
-  // expected-note @-1 {{mutation of this property is only permitted within the actor}}
+  @CustomActor var customDefault = NonSendableType()
 
   nonisolated func trigger() {}
 
   @MainActor init(v1: Void) {
     self.nonisoNoDefault = SendableType()
     _ = self.mainDefault
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
 
-    trigger()
+    trigger() // expected-note {{after calling instance method 'trigger()', only main actor-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.mainDefault
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   // OK: explicitly initializes all fields
   @CustomActor init(v1a: Void) {
     self.nonisoNoDefault = SendableType()
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault
     _ = self.customDefault
 
-    trigger() // expected-note 2{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+    trigger() // expected-note {{after calling instance method 'trigger()', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
-    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
   }
 
   @CustomActor init(v1b: Void) {
     self.nonisoNoDefault = SendableType()
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType()
     self.customDefault = NonSendableType()
 
-    trigger() // expected-note 2{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+    trigger() // expected-note {{after calling instance method 'trigger()', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
-    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
   }
 
   nonisolated init(v2: Void) {
@@ -276,23 +258,19 @@ class GADTStructWithMixedDefaultRequirementsNonIsolatedInits {
 
     _ = self.nonisoNoDefault
     _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
     _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
   }
 
   nonisolated init(v2a: Void) {
     self.nonisoNoDefault = SendableType()
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType()
+    self.customDefault = NonSendableType()
 
     trigger() // expected-note 2{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
     _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
   }
 }
 
@@ -303,69 +281,69 @@ class GADTStructWithMixedDefaultRequirementsNonIsolatedInits {
 @available(SwiftStdlib 5.1, *)
 @MainActor
 struct MainActorStructWithMixedFields_AO<T> {
-  var _addressOnly: T // expected-note 4{{mutation of this property is only permitted within the actor}}
+  var _addressOnly: T
   nonisolated let nonisoField: SendableType
   nonisolated let nonisoSendableField: SendableType
-  @CustomActor var customField: NonSendableType // expected-note 8{{mutation of this property is only permitted within the actor}}
-  @CustomActor var customFieldAO: NonSendableAOStruct<T> // expected-note 8{{mutation of this property is only permitted within the actor}}
-  var mainField: NonSendableType // expected-note 8{{mutation of this property is only permitted within the actor}}
-  var mainFieldAO: NonSendableAOStruct<T> // expected-note 8{{mutation of this property is only permitted within the actor}}
+  @CustomActor var customField: NonSendableType
+  @CustomActor var customFieldAO: NonSendableAOStruct<T>
+  var mainField: NonSendableType
+  var mainFieldAO: NonSendableAOStruct<T>
 
   nonisolated func trigger() {}
 
   nonisolated init(v1: Void, t: sending T, t2: sending T, t3: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
     self.nonisoField = SendableType()
     self.nonisoSendableField = SendableType()
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType()
+    self.customFieldAO = NonSendableAOStruct(value: t2)
+    self.mainField = NonSendableType()
+    self.mainFieldAO = NonSendableAOStruct(value: t)
 
-    trigger()
+    trigger() // expected-note 4{{after this use of 'self', only nonisolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoField
     _ = self.nonisoSendableField
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t3) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType() // expected-warning {{cannot access property 'customField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t3) // expected-warning {{cannot access property 'customFieldAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{cannot access property 'mainField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{cannot access property 'mainFieldAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   nonisolated init?(v1_failable: Void, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
     self.nonisoField = SendableType()
     self.nonisoSendableField = SendableType()
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType()
+    self.customFieldAO = NonSendableAOStruct(value: t2)
+    self.mainField = NonSendableType()
+    self.mainFieldAO = NonSendableAOStruct(value: t)
 
-    trigger()
+    trigger() // expected-note 4{{after this use of 'self', only nonisolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoField
     _ = self.nonisoSendableField
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType() // expected-warning {{cannot access property 'customField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{cannot access property 'customFieldAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{cannot access property 'mainField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{cannot access property 'mainFieldAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   @MainActor init(v2: Void, t: sending T, t2: sending T) {
     self._addressOnly = t
     self.nonisoField = SendableType()
     self.nonisoSendableField = SendableType()
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType()
+    self.customFieldAO = NonSendableAOStruct(value: t2)
     self.mainField = NonSendableType()
     self.mainFieldAO = NonSendableAOStruct(value: t)
 
-    trigger()
+    trigger() // expected-note 2{{after this use of 'self', only main actor-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoField
     _ = self.nonisoSendableField
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType() // expected-warning {{cannot access property 'customField' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{cannot access property 'customFieldAO' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     self.mainField = NonSendableType()
     self.mainFieldAO = NonSendableAOStruct(value: t)
   }
@@ -374,80 +352,72 @@ struct MainActorStructWithMixedFields_AO<T> {
     self._addressOnly = t
     self.nonisoField = SendableType()
     self.nonisoSendableField = SendableType()
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType()
+    self.customFieldAO = NonSendableAOStruct(value: t2)
     self.mainField = NonSendableType()
     self.mainFieldAO = NonSendableAOStruct(value: t)
 
-    trigger()
+    trigger() // expected-note 2{{after this use of 'self', only main actor-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoField
     _ = self.nonisoSendableField
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType() // expected-warning {{cannot access property 'customField' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{cannot access property 'customFieldAO' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     self.mainField = NonSendableType()
     self.mainFieldAO = NonSendableAOStruct(value: t)
   }
 
   @CustomActor init(v3: Void, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
     self.nonisoField = SendableType()
     self.nonisoSendableField = SendableType()
     self.customField = NonSendableType()
     self.customFieldAO = NonSendableAOStruct(value: t2)
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType()
+    self.mainFieldAO = NonSendableAOStruct(value: t)
 
-    trigger()
+    trigger() // expected-note 2{{after this use of 'self', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoField
     _ = self.nonisoSendableField
     self.customField = NonSendableType()
     self.customFieldAO = NonSendableAOStruct(value: t2)
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{cannot access property 'mainField' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{cannot access property 'mainFieldAO' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   @CustomActor init?(v3_failable: Void, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
     self.nonisoField = SendableType()
     self.nonisoSendableField = SendableType()
     self.customField = NonSendableType()
     self.customFieldAO = NonSendableAOStruct(value: t2)
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType()
+    self.mainFieldAO = NonSendableAOStruct(value: t)
 
-    trigger()
+    trigger() // expected-note 2{{after this use of 'self', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoField
     _ = self.nonisoSendableField
     self.customField = NonSendableType()
     self.customFieldAO = NonSendableAOStruct(value: t2)
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{cannot access property 'mainField' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{cannot access property 'mainFieldAO' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 }
 
 @available(SwiftStdlib 5.5, *)
 @MainActor
 class GADTStructWithMixedDefaultRequirements_AO<T> {
-  var _addressOnly: T // expected-note 7{{mutation of this property is only permitted within the actor}}
+  var _addressOnly: T
   var mainDefault: NonSendableType = requiresMainActor() // expected-note 4{{main actor-isolated default value of 'self.mainDefault' cannot be used in a global actor 'CustomActor'-isolated initializer}}
-  // expected-note @-1 8{{property declared here}}
-  // expected-note @-2 5{{mutation of this property is only permitted within the actor}}
-  var mainDefaultAO: NonSendableAOStruct<T> // expected-note 5{{mutation of this property is only permitted within the actor}}
-  // expected-note @-1 8{{property declared here}}
-  // expected-note @-2 4{{'self.mainDefaultAO' not initialized}}
+  var mainDefaultAO: NonSendableAOStruct<T> // expected-note 4{{'self.mainDefaultAO' not initialized}}
   nonisolated let nonisoNoDefault: SendableType
   nonisolated let nonisoSendableField: SendableType
   @CustomActor var customDefault: NonSendableType = requiresCustomActor() // expected-note 3{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a main actor-isolated initializer}}
-  // expected-note @-1 7{{property declared here}}
-  // expected-note @-2 4{{mutation of this property is only permitted within the actor}}
-  // expected-note @-3 2{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a nonisolated initializer}}
+  // expected-note @-1 2{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a nonisolated initializer}}
 
-  @CustomActor var customDefaultAO: NonSendableAOStruct<T> // expected-note 7{{property declared here}}
-  // expected-note @-1 5{{'self.customDefaultAO' not initialized}}
-  // expected-note @-2 4{{mutation of this property is only permitted within the actor}}
+  @CustomActor var customDefaultAO: NonSendableAOStruct<T> // expected-note 5{{'self.customDefaultAO' not initialized}}
 
   nonisolated func trigger() {}
 
@@ -461,6 +431,7 @@ class GADTStructWithMixedDefaultRequirements_AO<T> {
     _ = self.mainDefault
 
     trigger() // expected-error {{'self' used in method call 'trigger' before all stored properties are initialized}}
+    // expected-note @-1 2{{after calling instance method 'trigger()', only main actor-isolated properties of 'self' can be accessed from this init}}
 
 
     _ = self.nonisoNoDefault
@@ -468,10 +439,10 @@ class GADTStructWithMixedDefaultRequirements_AO<T> {
     _ = self.mainDefault
     _ = self.mainDefaultAO
     _ = self.customDefault // expected-error {{variable 'self.customDefault' used before being initialized}}
-    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{cannot access property 'customDefault' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
 
     _ = self.customDefaultAO // expected-error {{variable 'self.customDefaultAO' used before being initialized}}
-    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{cannot access property 'customDefaultAO' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
 
   } // expected-error {{return from initializer without initializing all stored properties}}
 
@@ -483,6 +454,7 @@ class GADTStructWithMixedDefaultRequirements_AO<T> {
     _ = self.mainDefault
 
     trigger() // expected-error {{'self' used in method call 'trigger' before all stored properties are initialized}}
+    // expected-note @-1 2{{after calling instance method 'trigger()', only main actor-isolated properties of 'self' can be accessed from this init}}
 
 
     _ = self.nonisoNoDefault
@@ -490,10 +462,10 @@ class GADTStructWithMixedDefaultRequirements_AO<T> {
     _ = self.mainDefault
     _ = self.mainDefaultAO
     _ = self.customDefault // expected-error {{variable 'self.customDefault' used before being initialized}}
-    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{cannot access property 'customDefault' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
 
     _ = self.customDefaultAO // expected-error {{variable 'self.customDefaultAO' used before being initialized}}
-    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{cannot access property 'customDefaultAO' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
 
   } // expected-error {{variable 'self.customDefault' used before being initialized}}
 
@@ -505,17 +477,17 @@ class GADTStructWithMixedDefaultRequirements_AO<T> {
     self.nonisoSendableField = SendableType()
     self.mainDefaultAO = NonSendableAOStruct(value: t)
     _ = self.mainDefault
-    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customDefault = NonSendableType()
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
 
-    trigger()
+    trigger() // expected-note 2{{after calling instance method 'trigger()', only main actor-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
     _ = self.mainDefault
     _ = self.mainDefaultAO
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
-    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   @MainActor init?(v1a_failable: NonSendableType, t: sending T, t2: sending T) {
@@ -524,125 +496,115 @@ class GADTStructWithMixedDefaultRequirements_AO<T> {
     self.nonisoSendableField = SendableType()
     self.mainDefaultAO = NonSendableAOStruct(value: t)
     _ = self.mainDefault
-    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customDefault = NonSendableType()
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
 
-    trigger()
+    trigger() // expected-note 2{{after calling instance method 'trigger()', only main actor-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
     _ = self.mainDefault
     _ = self.mainDefaultAO
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
-    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   // We do not completely initialize since we cannot run the default init of
   // mainDefault its initializer actually requires us to be on MainDefault.
   @CustomActor init(v1b: NonSendableType, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
     self.customDefaultAO = NonSendableAOStruct(value: t2)
     _ = self.customDefault
 
     trigger() // expected-error {{'self' used in method call 'trigger' before all stored properties are initialized}}
-    // expected-note @-1 4{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+    // expected-note @-1 2{{after calling instance method 'trigger()', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
     _ = self.mainDefault // expected-error {{variable 'self.mainDefault' used before being initialized}}
-    // expected-warning @-1 {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-2 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{cannot access property 'mainDefault' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
 
     _ = self.mainDefaultAO // expected-error {{variable 'self.mainDefaultAO' used before being initialized}}
-    // expected-warning @-1 {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-2 {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{cannot access property 'mainDefaultAO' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
 
-    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
+    _ = self.customDefaultAO
   } // expected-error {{return from initializer without initializing all stored properties}}
 
   // We do not completely initialize since we cannot run the default init of
   // mainDefault its initializer actually requires us to be on MainDefault.
   @CustomActor init(v1bb: NonSendableType, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
     self.customDefaultAO = NonSendableAOStruct(value: t2)
     _ = self.customDefault
     _ = self.mainDefault // expected-error {{variable 'self.mainDefault' used before being initialized}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
     _ = self.mainDefaultAO // expected-error {{variable 'self.mainDefaultAO' used before being initialized}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
 
     trigger() // expected-error {{'self' used in method call 'trigger' before all stored properties are initialized}}
-    // expected-note @-1 4{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+    // expected-note @-1 2{{after calling instance method 'trigger()', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
     _ = self.mainDefault // expected-error {{variable 'self.mainDefault' used before being initialized}}
-    // expected-warning @-1 {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-2 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{cannot access property 'mainDefault' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
 
     _ = self.mainDefaultAO // expected-error {{variable 'self.mainDefaultAO' used before being initialized}}
-    // expected-warning @-1 {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-2 {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{cannot access property 'mainDefaultAO' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
 
-    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
+    _ = self.customDefaultAO
   } // expected-error {{return from initializer without initializing all stored properties}}
 
   // We do completely initialize. With future changes, we should be able to do
   // this.
   @CustomActor init(v1c: NonSendableType, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
     self.customDefaultAO = NonSendableAOStruct(value: t2)
     _ = self.customDefault
 
-    trigger() // expected-note 4{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+    trigger() // expected-note 2{{after calling instance method 'trigger()', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
-    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
+    _ = self.customDefaultAO
   }
 
   @CustomActor init?(v1c_failable: NonSendableType, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
     self.customDefaultAO = NonSendableAOStruct(value: t2)
     _ = self.customDefault
 
-    trigger() // expected-note 4{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+    trigger() // expected-note 2{{after calling instance method 'trigger()', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
-    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
+    _ = self.customDefaultAO
   }
 
   nonisolated init(v2: Void, t: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
+    self.mainDefault = NonSendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
 
@@ -653,25 +615,21 @@ class GADTStructWithMixedDefaultRequirements_AO<T> {
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
     _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
     _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
     _ = self.customDefault // expected-error {{variable 'self.customDefault' used before being initialized}}
     // expected-warning @-1 {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-2 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
 
     _ = self.customDefaultAO // expected-error {{variable 'self.customDefaultAO' used before being initialized}}
     // expected-warning @-1 {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-2 {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
 
   } // expected-error {{return from initializer without initializing all stored properties}}
 
   nonisolated init(v3: Void, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
+    self.mainDefault = NonSendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
+    self.customDefault = NonSendableType()
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
 
@@ -680,21 +638,17 @@ class GADTStructWithMixedDefaultRequirements_AO<T> {
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
     _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
     _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
     _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
     _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
   }
 
   nonisolated init?(v3_failable: Void, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
+    self.mainDefault = NonSendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
+    self.customDefault = NonSendableType()
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
 
@@ -703,30 +657,22 @@ class GADTStructWithMixedDefaultRequirements_AO<T> {
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
     _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
     _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
     _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
     _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
   }
 }
 
 @available(SwiftStdlib 5.5, *)
 @MainActor
 class GADTStructWithMixedDefaultRequirementsNonIsolatedInits_AO<T> {
-  var _addressOnly: T // expected-note 6{{mutation of this property is only permitted within the actor}}
-  var mainDefault = NonSendableType() // expected-note 3{{mutation of this property is only permitted within the actor}}
-  // expected-note @-1 7{{property declared here}}
-  var mainDefaultAO: NonSendableAOStruct<T> // expected-note 6{{property declared here}}
-  // expected-note @-1 6{{mutation of this property is only permitted within the actor}}
+  var _addressOnly: T
+  var mainDefault = NonSendableType()
+  var mainDefaultAO: NonSendableAOStruct<T>
   nonisolated let nonisoNoDefault: SendableType
   nonisolated let nonisoSendableField: SendableType
-  @CustomActor var customDefault = NonSendableType() // expected-note 7{{property declared here}}
-  // expected-note @-1 {{mutation of this property is only permitted within the actor}}
-  @CustomActor var customDefaultAO: NonSendableAOStruct<T> // expected-note 5{{property declared here}}
-  // expected-note @-1 5{{mutation of this property is only permitted within the actor}}
+  @CustomActor var customDefault = NonSendableType()
+  @CustomActor var customDefaultAO: NonSendableAOStruct<T>
 
   nonisolated func trigger() {}
 
@@ -735,18 +681,18 @@ class GADTStructWithMixedDefaultRequirementsNonIsolatedInits_AO<T> {
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
     self.mainDefaultAO = NonSendableAOStruct(value: t)
-    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
     _ = self.mainDefault
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
 
-    trigger()
+    trigger() // expected-note 2{{after calling instance method 'trigger()', only main actor-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
     _ = self.mainDefault
     _ = self.mainDefaultAO
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
-    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   @MainActor init?(v1_failable: Void, t: sending T, t2: sending T) {
@@ -754,69 +700,118 @@ class GADTStructWithMixedDefaultRequirementsNonIsolatedInits_AO<T> {
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
     self.mainDefaultAO = NonSendableAOStruct(value: t)
-    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
     _ = self.mainDefault
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
 
-    trigger()
+    trigger() // expected-note 2{{after calling instance method 'trigger()', only main actor-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
     _ = self.mainDefault
     _ = self.mainDefaultAO
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
-    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   // OK: explicitly initializes all fields
   @CustomActor init(v1a: Void, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
-    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
     self.customDefaultAO = NonSendableAOStruct(value: t2)
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault
     _ = self.customDefault
 
-    trigger() // expected-note 4{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+    trigger() // expected-note 2{{after calling instance method 'trigger()', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
-    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
+    _ = self.customDefaultAO
   }
 
   @CustomActor init(v1b: Void, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
     self.customDefault = NonSendableType()
     self.customDefaultAO = NonSendableAOStruct(value: t2)
 
-    trigger() // expected-note 4{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+    trigger() // expected-note 2{{after calling instance method 'trigger()', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
-    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
+    _ = self.customDefaultAO
   }
 
   @CustomActor init?(v1b_failable: Void, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
+    self.customDefault = NonSendableType()
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
+
+    trigger() // expected-note 2{{after calling instance method 'trigger()', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
+    _ = self.customDefaultAO
+  }
+
+  nonisolated init(v2: Void, t: sending T, t2: sending T) {
+    self._addressOnly = t
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
+
+    trigger() // expected-note 4{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+  }
+
+  nonisolated init?(v2_failable: Void, t: sending T, t2: sending T) {
+    self._addressOnly = t
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
+
+    trigger() // expected-note 4{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+  }
+
+  nonisolated init(v2a: Void, t: sending T, t2: sending T) {
+    self._addressOnly = t
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefault = NonSendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
     self.customDefault = NonSendableType()
     self.customDefaultAO = NonSendableAOStruct(value: t2)
 
@@ -825,75 +820,8 @@ class GADTStructWithMixedDefaultRequirementsNonIsolatedInits_AO<T> {
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
     _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
     _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
     _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-  }
-
-  nonisolated init(v2: Void, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.nonisoNoDefault = SendableType()
-    self.nonisoSendableField = SendableType()
-    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-
-    trigger() // expected-note 4{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
-
-    _ = self.nonisoNoDefault
-    _ = self.nonisoSendableField
-    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-  }
-
-  nonisolated init?(v2_failable: Void, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.nonisoNoDefault = SendableType()
-    self.nonisoSendableField = SendableType()
-    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-
-    trigger() // expected-note 4{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
-
-    _ = self.nonisoNoDefault
-    _ = self.nonisoSendableField
-    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-  }
-
-  nonisolated init(v2a: Void, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.nonisoNoDefault = SendableType()
-    self.nonisoSendableField = SendableType()
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-
-    trigger() // expected-note 4{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
-
-    _ = self.nonisoNoDefault
-    _ = self.nonisoSendableField
-    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
   }
 }

--- a/test/Concurrency/flow_isolation_enum.swift
+++ b/test/Concurrency/flow_isolation_enum.swift
@@ -55,28 +55,28 @@ enum MainActorEnumWithPayloads {
   nonisolated init(v1: Void) {
     self = .nonSendable(NonSendableType())
 
-    trigger()
+    trigger() // expected-note {{after this use of 'self', only nonisolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoComputed
-    self = .nonSendable(NonSendableType())
+    self = .nonSendable(NonSendableType()) // expected-warning {{cannot access 'self' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   @MainActor init(v2: Void) {
     self = .nonSendable(NonSendableType())
 
-    trigger()
+    trigger() // expected-note {{after this use of 'self', only main actor-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoComputed
-    self = .nonSendable(NonSendableType())
+    self = .nonSendable(NonSendableType()) // expected-warning {{cannot access 'self' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   @CustomActor init(v3: Void) {
     self = .nonSendable(NonSendableType())
 
-    trigger()
+    trigger() // expected-note {{after this use of 'self', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoComputed
-    self = .nonSendable(NonSendableType())
+    self = .nonSendable(NonSendableType()) // expected-warning {{cannot access 'self' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 }
 
@@ -96,28 +96,28 @@ enum MainActorEnumWithPayloads_NC: ~Copyable {
   nonisolated init(v1: Void) {
     self = .nonSendable(NonSendableType())
 
-    trigger()
+    trigger() // expected-note {{after this use of 'self', only nonisolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoComputed
-    self = .nonSendable(NonSendableType())
+    self = .nonSendable(NonSendableType()) // expected-warning {{cannot access 'self' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   @MainActor init(v2: Void) {
     self = .nonSendable(NonSendableType())
 
-    trigger()
+    trigger() // expected-note {{after this use of 'self', only main actor-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoComputed
-    self = .nonSendable(NonSendableType())
+    self = .nonSendable(NonSendableType()) // expected-warning {{cannot access 'self' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   @CustomActor init(v3: Void) {
     self = .nonSendable(NonSendableType())
 
-    trigger()
+    trigger() // expected-note {{after this use of 'self', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoComputed
-    self = .nonSendable(NonSendableType())
+    self = .nonSendable(NonSendableType()) // expected-warning {{cannot access 'self' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 }
 
@@ -138,55 +138,55 @@ enum MainActorEnumWithPayloads_AO<T> {
   nonisolated init(v1: Void, t: sending T) {
     self = .addressOnly(NonSendableAOStruct(value: t))
 
-    trigger()
+    trigger() // expected-note {{after this use of 'self', only nonisolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoComputed
-    self = .nonSendable(NonSendableType())
+    self = .nonSendable(NonSendableType()) // expected-warning {{cannot access 'self' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   nonisolated init?(v1_failable: Void, t: sending T) {
     self = .addressOnly(NonSendableAOStruct(value: t))
 
-    trigger()
+    trigger() // expected-note {{after this use of 'self', only nonisolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoComputed
-    self = .nonSendable(NonSendableType())
+    self = .nonSendable(NonSendableType()) // expected-warning {{cannot access 'self' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   @MainActor init(v2: Void, t: sending T) {
     self = .addressOnly(NonSendableAOStruct(value: t))
 
-    trigger()
+    trigger() // expected-note {{after this use of 'self', only main actor-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoComputed
-    self = .nonSendable(NonSendableType())
+    self = .nonSendable(NonSendableType()) // expected-warning {{cannot access 'self' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   @MainActor init?(v2_failable: Void, t: sending T) {
     self = .addressOnly(NonSendableAOStruct(value: t))
 
-    trigger()
+    trigger() // expected-note {{after this use of 'self', only main actor-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoComputed
-    self = .nonSendable(NonSendableType())
+    self = .nonSendable(NonSendableType()) // expected-warning {{cannot access 'self' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   @CustomActor init(v3: Void, t: sending T) {
     self = .addressOnly(NonSendableAOStruct(value: t))
 
-    trigger()
+    trigger() // expected-note {{after this use of 'self', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoComputed
-    self = .nonSendable(NonSendableType())
+    self = .nonSendable(NonSendableType()) // expected-warning {{cannot access 'self' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   @CustomActor init?(v3_failable: Void, t: sending T) {
     self = .addressOnly(NonSendableAOStruct(value: t))
 
-    trigger()
+    trigger() // expected-note {{after this use of 'self', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoComputed
-    self = .nonSendable(NonSendableType())
+    self = .nonSendable(NonSendableType()) // expected-warning {{cannot access 'self' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 }
 
@@ -207,54 +207,54 @@ enum MainActorEnumWithPayloads_AO_NC<T>: ~Copyable {
   nonisolated init(v1: Void, t: sending T) {
     self = .addressOnly(NonSendableAOStruct(value: t))
 
-    trigger()
+    trigger() // expected-note {{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoComputed
-    self = .nonSendable(NonSendableType())
+    self = .nonSendable(NonSendableType()) // expected-warning {{cannot access 'self' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   nonisolated init?(v1_failable: Void, t: sending T) {
     self = .addressOnly(NonSendableAOStruct(value: t))
 
-    trigger()
+    trigger() // expected-note {{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoComputed
-    self = .nonSendable(NonSendableType())
+    self = .nonSendable(NonSendableType()) // expected-warning {{cannot access 'self' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   @MainActor init(v2: Void, t: sending T) {
     self = .addressOnly(NonSendableAOStruct(value: t))
 
-    trigger()
+    trigger() // expected-note {{after calling instance method 'trigger()', only main actor-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoComputed
-    self = .nonSendable(NonSendableType())
+    self = .nonSendable(NonSendableType()) // expected-warning {{cannot access 'self' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   @MainActor init?(v2_failable: Void, t: sending T) {
     self = .addressOnly(NonSendableAOStruct(value: t))
 
-    trigger()
+    trigger() // expected-note {{after calling instance method 'trigger()', only main actor-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoComputed
-    self = .nonSendable(NonSendableType())
+    self = .nonSendable(NonSendableType()) // expected-warning {{cannot access 'self' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   @CustomActor init(v3: Void, t: sending T) {
     self = .addressOnly(NonSendableAOStruct(value: t))
 
-    trigger()
+    trigger() // expected-note {{after calling instance method 'trigger()', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoComputed
-    self = .nonSendable(NonSendableType())
+    self = .nonSendable(NonSendableType()) // expected-warning {{cannot access 'self' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   @CustomActor init?(v3_failable: Void, t: sending T) {
     self = .addressOnly(NonSendableAOStruct(value: t))
 
-    trigger()
+    trigger() // expected-note {{after calling instance method 'trigger()', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoComputed
-    self = .nonSendable(NonSendableType())
+    self = .nonSendable(NonSendableType()) // expected-warning {{cannot access 'self' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 }

--- a/test/Concurrency/flow_isolation_enum.swift
+++ b/test/Concurrency/flow_isolation_enum.swift
@@ -1,0 +1,260 @@
+// RUN: %target-swift-frontend -strict-concurrency=complete -swift-version 5 -parse-as-library -emit-sil -verify %s -o /dev/null
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+@globalActor
+actor CustomActor {
+  static let shared = CustomActor()
+}
+
+@CustomActor func requiresCustomActor() -> NonSendableType { NonSendableType() }
+@MainActor func requiresMainActor() -> NonSendableType { NonSendableType() }
+
+func randomBool() -> Bool { return false }
+func logTransaction(_ i: Int) {}
+
+enum Color: Error {
+  case red
+  case yellow
+  case blue
+}
+
+func takeNonSendable<T>(_ ns: T) {}
+
+@available(SwiftStdlib 5.1, *)
+func takeSendable<T : Sendable>(_ s: T) {}
+
+class NonSendableType {
+  var x: Int = 0
+  func f() {}
+}
+
+@available(SwiftStdlib 5.1, *)
+struct SendableType: Sendable {}
+
+struct NonSendableAOStruct<T> {
+  var value: T
+}
+
+/////////////////
+// MARK: Tests //
+/////////////////
+
+
+@available(SwiftStdlib 5.1, *)
+@MainActor
+enum MainActorEnumWithPayloads {
+  case sendable(SendableType)
+  case nonSendable(NonSendableType)
+
+  nonisolated func trigger() {}
+  nonisolated var nonisoComputed: Int { 0 }
+
+  nonisolated init(v1: Void) {
+    self = .nonSendable(NonSendableType())
+
+    trigger()
+
+    _ = self.nonisoComputed
+    self = .nonSendable(NonSendableType())
+  }
+
+  @MainActor init(v2: Void) {
+    self = .nonSendable(NonSendableType())
+
+    trigger()
+
+    _ = self.nonisoComputed
+    self = .nonSendable(NonSendableType())
+  }
+
+  @CustomActor init(v3: Void) {
+    self = .nonSendable(NonSendableType())
+
+    trigger()
+
+    _ = self.nonisoComputed
+    self = .nonSendable(NonSendableType())
+  }
+}
+
+////////////////////////////////////////////////////
+// MARK: Noncopyable Enum Variants                //
+////////////////////////////////////////////////////
+
+@available(SwiftStdlib 5.1, *)
+@MainActor
+enum MainActorEnumWithPayloads_NC: ~Copyable {
+  case sendable(SendableType)
+  case nonSendable(NonSendableType)
+
+  nonisolated func trigger() {}
+  nonisolated var nonisoComputed: Int { 0 }
+
+  nonisolated init(v1: Void) {
+    self = .nonSendable(NonSendableType())
+
+    trigger()
+
+    _ = self.nonisoComputed
+    self = .nonSendable(NonSendableType())
+  }
+
+  @MainActor init(v2: Void) {
+    self = .nonSendable(NonSendableType())
+
+    trigger()
+
+    _ = self.nonisoComputed
+    self = .nonSendable(NonSendableType())
+  }
+
+  @CustomActor init(v3: Void) {
+    self = .nonSendable(NonSendableType())
+
+    trigger()
+
+    _ = self.nonisoComputed
+    self = .nonSendable(NonSendableType())
+  }
+}
+
+////////////////////////////////////////////////////
+// MARK: Address Only Enum Variants               //
+////////////////////////////////////////////////////
+
+@available(SwiftStdlib 5.1, *)
+@MainActor
+enum MainActorEnumWithPayloads_AO<T> {
+  case sendable(SendableType)
+  case nonSendable(NonSendableType)
+  case addressOnly(NonSendableAOStruct<T>)
+
+  nonisolated func trigger() {}
+  nonisolated var nonisoComputed: Int { 0 }
+
+  nonisolated init(v1: Void, t: sending T) {
+    self = .addressOnly(NonSendableAOStruct(value: t))
+
+    trigger()
+
+    _ = self.nonisoComputed
+    self = .nonSendable(NonSendableType())
+  }
+
+  nonisolated init?(v1_failable: Void, t: sending T) {
+    self = .addressOnly(NonSendableAOStruct(value: t))
+
+    trigger()
+
+    _ = self.nonisoComputed
+    self = .nonSendable(NonSendableType())
+  }
+
+  @MainActor init(v2: Void, t: sending T) {
+    self = .addressOnly(NonSendableAOStruct(value: t))
+
+    trigger()
+
+    _ = self.nonisoComputed
+    self = .nonSendable(NonSendableType())
+  }
+
+  @MainActor init?(v2_failable: Void, t: sending T) {
+    self = .addressOnly(NonSendableAOStruct(value: t))
+
+    trigger()
+
+    _ = self.nonisoComputed
+    self = .nonSendable(NonSendableType())
+  }
+
+  @CustomActor init(v3: Void, t: sending T) {
+    self = .addressOnly(NonSendableAOStruct(value: t))
+
+    trigger()
+
+    _ = self.nonisoComputed
+    self = .nonSendable(NonSendableType())
+  }
+
+  @CustomActor init?(v3_failable: Void, t: sending T) {
+    self = .addressOnly(NonSendableAOStruct(value: t))
+
+    trigger()
+
+    _ = self.nonisoComputed
+    self = .nonSendable(NonSendableType())
+  }
+}
+
+////////////////////////////////////////////////////
+// MARK: Address Only Noncopyable Enum Variants   //
+////////////////////////////////////////////////////
+
+@available(SwiftStdlib 5.1, *)
+@MainActor
+enum MainActorEnumWithPayloads_AO_NC<T>: ~Copyable {
+  case sendable(SendableType)
+  case nonSendable(NonSendableType)
+  case addressOnly(NonSendableAOStruct<T>)
+
+  nonisolated func trigger() {}
+  nonisolated var nonisoComputed: Int { 0 }
+
+  nonisolated init(v1: Void, t: sending T) {
+    self = .addressOnly(NonSendableAOStruct(value: t))
+
+    trigger()
+
+    _ = self.nonisoComputed
+    self = .nonSendable(NonSendableType())
+  }
+
+  nonisolated init?(v1_failable: Void, t: sending T) {
+    self = .addressOnly(NonSendableAOStruct(value: t))
+
+    trigger()
+
+    _ = self.nonisoComputed
+    self = .nonSendable(NonSendableType())
+  }
+
+  @MainActor init(v2: Void, t: sending T) {
+    self = .addressOnly(NonSendableAOStruct(value: t))
+
+    trigger()
+
+    _ = self.nonisoComputed
+    self = .nonSendable(NonSendableType())
+  }
+
+  @MainActor init?(v2_failable: Void, t: sending T) {
+    self = .addressOnly(NonSendableAOStruct(value: t))
+
+    trigger()
+
+    _ = self.nonisoComputed
+    self = .nonSendable(NonSendableType())
+  }
+
+  @CustomActor init(v3: Void, t: sending T) {
+    self = .addressOnly(NonSendableAOStruct(value: t))
+
+    trigger()
+
+    _ = self.nonisoComputed
+    self = .nonSendable(NonSendableType())
+  }
+
+  @CustomActor init?(v3_failable: Void, t: sending T) {
+    self = .addressOnly(NonSendableAOStruct(value: t))
+
+    trigger()
+
+    _ = self.nonisoComputed
+    self = .nonSendable(NonSendableType())
+  }
+}

--- a/test/Concurrency/flow_isolation_struct.swift
+++ b/test/Concurrency/flow_isolation_struct.swift
@@ -46,45 +46,84 @@ struct NonSendableAOStruct<T> {
 @MainActor
 struct MainActorStructWithMixedFields {
   nonisolated let nonisoField: SendableType
-  @CustomActor var customField: NonSendableType // expected-note 4{{mutation of this property is only permitted within the actor}}
-  var mainField: NonSendableType // expected-note 4{{mutation of this property is only permitted within the actor}}
+  @CustomActor var customField: NonSendableType
+  var mainField: NonSendableType
 
   nonisolated func trigger() {}
 
   nonisolated init(v1: Void) {
     self.nonisoField = SendableType()
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType()
+    self.mainField = NonSendableType()
 
-    trigger()
+    trigger() // expected-note 2{{after this use of 'self', only nonisolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoField
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType() // expected-warning {{cannot access property 'customField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{cannot access property 'mainField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   @MainActor init(v2: Void) {
     self.nonisoField = SendableType()
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType()
     self.mainField = NonSendableType()
 
-    trigger()
+    trigger() // expected-note {{after this use of 'self', only main actor-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoField
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType() // expected-warning {{cannot access property 'customField' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     self.mainField = NonSendableType()
   }
 
   @CustomActor init(v3: Void) {
     self.nonisoField = SendableType()
     self.customField = NonSendableType()
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType()
 
-    trigger()
+    trigger() // expected-note {{after this use of 'self', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoField
     self.customField = NonSendableType()
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{cannot access property 'mainField' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+@MainActor
+struct MainActorStructWithMixedFieldsAllVar {
+  @CustomActor var customField: NonSendableType
+  var mainField: NonSendableType
+
+  nonisolated func trigger() {}
+
+  nonisolated init(v1: Void) {
+    self.customField = NonSendableType()
+    self.mainField = NonSendableType()
+  }
+
+  @MainActor init(v2: Void) {
+    self.customField = NonSendableType()
+    self.mainField = NonSendableType()
+
+    trigger() // expected-note {{after this use of 'self', only main actor-isolated properties of 'self' can be accessed from this init}}
+
+    self = .init(v1: ()) // expected-warning {{cannot access 'self' here in main actor-isolated initializer}}
+  }
+
+  @MainActor init(v3: Void) {
+    self = .init(v1: ())
+
+    trigger() // expected-note {{after this use of 'self', only main actor-isolated properties of 'self' can be accessed from this init}}
+
+    self = .init(v1: ()) // expected-warning {{cannot access 'self' here in main actor-isolated initializer}}
+  }
+
+  @MainActor init(v4: Void) {
+    self = .init(v1: ())
+
+    trigger() // expected-note {{after this use of 'self', only main actor-isolated properties of 'self' can be accessed from this init}}
+
+    self = .init(v2: ()) // expected-warning {{cannot access 'self' here in main actor-isolated initializer}}
   }
 }
 
@@ -98,14 +137,10 @@ struct MainActorStructWithMixedFields {
 @available(SwiftStdlib 5.5, *)
 @MainActor
 struct GADTStructWithMixedDefaultRequirements {
-  var mainDefault: NonSendableType = requiresMainActor() // expected-note 6{{property declared here}}
-  // expected-note @-1 3{{mutation of this property is only permitted within the actor}}
-  // expected-note @-2 7{{main actor-isolated default value of 'self.mainDefault' cannot be used in a global actor 'CustomActor'-isolated initializer}}
+  var mainDefault: NonSendableType = requiresMainActor() // expected-note 7{{main actor-isolated default value of 'self.mainDefault' cannot be used in a global actor 'CustomActor'-isolated initializer}}
   nonisolated let nonisoNoDefault: SendableType
-  @CustomActor var customDefault: NonSendableType = requiresCustomActor() // expected-note 4{{property declared here}}
+  @CustomActor var customDefault: NonSendableType = requiresCustomActor() // expected-note 3{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a main actor-isolated initializer}}
   // expected-note @-1 3{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a nonisolated initializer}}
-  // expected-note @-2 3{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a main actor-isolated initializer}}
-  // expected-note @-3 2{{mutation of this property is only permitted within the actor}}
 
   nonisolated func trigger() {}
 
@@ -116,11 +151,12 @@ struct GADTStructWithMixedDefaultRequirements {
     _ = self.mainDefault
 
     trigger() // expected-error {{'self' used before all stored properties are initialized}}
+    // expected-note @-1 {{after this use of 'self', only main actor-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.mainDefault
     _ = self.customDefault // expected-error {{'self' used before all stored properties are initialized}}
-    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{cannot access property 'customDefault' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   } // expected-error {{return from initializer without initializing all stored properties}}
 
   // We do completely initialize. With future changes, we should be able to do
@@ -128,13 +164,13 @@ struct GADTStructWithMixedDefaultRequirements {
   @MainActor init(v1a: NonSendableType) {
     self.nonisoNoDefault = SendableType()
     _ = self.mainDefault
-    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customDefault = NonSendableType()
 
-    trigger()
+    trigger() // expected-note {{after this use of 'self', only main actor-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.mainDefault
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   // We do not completely initialize since we cannot run the default init of
@@ -144,10 +180,11 @@ struct GADTStructWithMixedDefaultRequirements {
     _ = self.customDefault
 
     trigger() // expected-error {{'self' used before all stored properties are initialized}}
+    // expected-note @-1 {{after this use of 'self', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.mainDefault // expected-error {{'self' used before all stored properties are initialized}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{cannot access property 'mainDefault' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     _ = self.customDefault
   } // expected-error {{return from initializer without initializing all stored properties}}
 
@@ -157,13 +194,13 @@ struct GADTStructWithMixedDefaultRequirements {
     self.nonisoNoDefault = SendableType()
     _ = self.customDefault
     _ = self.mainDefault // expected-error {{'self' used before all stored properties are initialized}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
 
     trigger() // expected-error {{'self' used before all stored properties are initialized}}
+    // expected-note @-1 {{after this use of 'self', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.mainDefault // expected-error {{'self' used before all stored properties are initialized}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{cannot access property 'mainDefault' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     _ = self.customDefault
   } // expected-error {{return from initializer without initializing all stored properties}}
 
@@ -171,109 +208,108 @@ struct GADTStructWithMixedDefaultRequirements {
   // this.
   @CustomActor init(v1c: NonSendableType) {
     self.nonisoNoDefault = SendableType()
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType()
     _ = self.customDefault
 
-    trigger()
+    trigger() // expected-note {{after this use of 'self', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     _ = self.customDefault
   }
 
   nonisolated init(v2: Void) {
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType()
     self.nonisoNoDefault = SendableType()
 
     trigger() // expected-error {{'self' used before all stored properties are initialized}}
+    // expected-note @-1 2{{after this use of 'self', only nonisolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     _ = self.customDefault // expected-error {{'self' used before all stored properties are initialized}}
-    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   } // expected-error {{return from initializer without initializing all stored properties}}
 
   nonisolated init(v3: Void) {
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType()
+    self.customDefault = NonSendableType()
     self.nonisoNoDefault = SendableType()
 
-    trigger()
+    trigger() // expected-note 2{{after this use of 'self', only nonisolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 }
 
 @available(SwiftStdlib 5.5, *)
 @MainActor
 struct GADTStructWithMixedDefaultRequirementsNonIsolatedInits {
-  var mainDefault = NonSendableType() // expected-note 5{{property declared here}}
-  // expected-note @-1 2{{mutation of this property is only permitted within the actor}}
+  var mainDefault = NonSendableType()
   nonisolated let nonisoNoDefault: SendableType
-  @CustomActor var customDefault = NonSendableType() // expected-note 4{{property declared here}}
-  // expected-note @-1 {{mutation of this property is only permitted within the actor}}
+  @CustomActor var customDefault = NonSendableType()
 
   nonisolated func trigger() {}
 
   @MainActor init(v1: Void) {
     self.nonisoNoDefault = SendableType()
     _ = self.mainDefault
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
 
-    trigger()
+    trigger() // expected-note {{after this use of 'self', only main actor-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.mainDefault
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   // OK: explicitly initializes all fields
   @CustomActor init(v1a: Void) {
     self.nonisoNoDefault = SendableType()
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault
     _ = self.customDefault
 
-    trigger()
+    trigger() // expected-note {{after this use of 'self', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     _ = self.customDefault
   }
 
   @CustomActor init(v1b: Void) {
     self.nonisoNoDefault = SendableType()
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType()
     self.customDefault = NonSendableType()
 
-    trigger()
+    trigger() // expected-note {{after this use of 'self', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     _ = self.customDefault
   }
 
   nonisolated init(v2: Void) {
     self.nonisoNoDefault = SendableType()
 
-    trigger()
+    trigger() // expected-note 2{{after this use of 'self', only nonisolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   nonisolated init(v2a: Void) {
     self.nonisoNoDefault = SendableType()
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType()
+    self.customDefault = NonSendableType()
 
-    trigger()
+    trigger() // expected-note 2{{after this use of 'self', only nonisolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 }
 
@@ -285,69 +321,79 @@ struct GADTStructWithMixedDefaultRequirementsNonIsolatedInits {
 @available(SwiftStdlib 5.1, *)
 @MainActor
 struct MainActorStructWithMixedFields_AO<T> {
-  var _addressOnly: T // expected-note 4{{mutation of this property is only permitted within the actor}}
+  var _addressOnly: T
   nonisolated let nonisoField: SendableType
   nonisolated let nonisoSendableField: SendableType
-  @CustomActor var customField: NonSendableType // expected-note 8{{mutation of this property is only permitted within the actor}}
-  @CustomActor var customFieldAO: NonSendableAOStruct<T> // expected-note 8{{mutation of this property is only permitted within the actor}}
-  var mainField: NonSendableType // expected-note 8{{mutation of this property is only permitted within the actor}}
-  var mainFieldAO: NonSendableAOStruct<T> // expected-note 8{{mutation of this property is only permitted within the actor}}
+  @CustomActor var customField: NonSendableType
+  @CustomActor var customFieldAO: NonSendableAOStruct<T>
+  var mainField: NonSendableType
+  var mainFieldAO: NonSendableAOStruct<T>
 
   nonisolated func trigger() {}
 
   nonisolated init(v1: Void, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
     self.nonisoField = SendableType()
     self.nonisoSendableField = SendableType()
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType()
+    self.customFieldAO = NonSendableAOStruct(value: t2)
+    self.mainField = NonSendableType()
+    self.mainFieldAO = NonSendableAOStruct(value: t)
 
-    trigger()
+    trigger() // expected-note 4{{after this use of 'self', only nonisolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoField
     _ = self.nonisoSendableField
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType() // expected-warning {{cannot access property 'customField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{cannot access property 'customFieldAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{cannot access property 'mainField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{cannot access property 'mainFieldAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   nonisolated init?(v1_failable: Void, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
     self.nonisoField = SendableType()
     self.nonisoSendableField = SendableType()
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType()
+    self.customFieldAO = NonSendableAOStruct(value: t2)
+    self.mainField = NonSendableType()
+    self.mainFieldAO = NonSendableAOStruct(value: t)
 
-    trigger()
+    if randomBool() {
+      _ = self.nonisoField
+      _ = self.nonisoSendableField
+      _ = self.customField
+      _ = self.customFieldAO
+      _ = self.mainField
+      _ = self.mainFieldAO
+      return nil
+    }
+
+    trigger() // expected-note 4{{after this use of 'self', only nonisolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoField
     _ = self.nonisoSendableField
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType() // expected-warning {{cannot access property 'customField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{cannot access property 'customFieldAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{cannot access property 'mainField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{cannot access property 'mainFieldAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   @MainActor init(v2: Void, t: sending T, t2: sending T) {
     self._addressOnly = t
     self.nonisoField = SendableType()
     self.nonisoSendableField = SendableType()
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType()
+    self.customFieldAO = NonSendableAOStruct(value: t2)
     self.mainField = NonSendableType()
     self.mainFieldAO = NonSendableAOStruct(value: t)
 
-    trigger()
+    trigger() // expected-note 2{{after this use of 'self', only main actor-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoField
     _ = self.nonisoSendableField
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType() // expected-warning {{cannot access property 'customField' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{cannot access property 'customFieldAO' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     self.mainField = NonSendableType()
     self.mainFieldAO = NonSendableAOStruct(value: t)
   }
@@ -356,80 +402,72 @@ struct MainActorStructWithMixedFields_AO<T> {
     self._addressOnly = t
     self.nonisoField = SendableType()
     self.nonisoSendableField = SendableType()
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType()
+    self.customFieldAO = NonSendableAOStruct(value: t2)
     self.mainField = NonSendableType()
     self.mainFieldAO = NonSendableAOStruct(value: t)
 
-    trigger()
+    trigger() // expected-note 2{{after this use of 'self', only main actor-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoField
     _ = self.nonisoSendableField
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType() // expected-warning {{cannot access property 'customField' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{cannot access property 'customFieldAO' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     self.mainField = NonSendableType()
     self.mainFieldAO = NonSendableAOStruct(value: t)
   }
 
   @CustomActor init(v3: Void, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
     self.nonisoField = SendableType()
     self.nonisoSendableField = SendableType()
     self.customField = NonSendableType()
     self.customFieldAO = NonSendableAOStruct(value: t2)
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType()
+    self.mainFieldAO = NonSendableAOStruct(value: t)
 
-    trigger()
+    trigger() // expected-note 2{{after this use of 'self', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoField
     _ = self.nonisoSendableField
     self.customField = NonSendableType()
     self.customFieldAO = NonSendableAOStruct(value: t2)
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{cannot access property 'mainField' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{cannot access property 'mainFieldAO' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   @CustomActor init?(v3_failable: Void, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
     self.nonisoField = SendableType()
     self.nonisoSendableField = SendableType()
     self.customField = NonSendableType()
     self.customFieldAO = NonSendableAOStruct(value: t2)
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType()
+    self.mainFieldAO = NonSendableAOStruct(value: t)
 
-    trigger()
+    trigger() // expected-note 2{{after this use of 'self', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoField
     _ = self.nonisoSendableField
     self.customField = NonSendableType()
     self.customFieldAO = NonSendableAOStruct(value: t2)
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{cannot access property 'mainField' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{cannot access property 'mainFieldAO' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 }
 
 @available(SwiftStdlib 5.5, *)
 @MainActor
 struct GADTStructWithMixedDefaultRequirements_AO<T> {
-  var _addressOnly: T // expected-note 7{{mutation of this property is only permitted within the actor}}
-  var mainDefault: NonSendableType = requiresMainActor() // expected-note 8{{property declared here}}
-  // expected-note @-1 5{{mutation of this property is only permitted within the actor}}
-  // expected-note @-2 5{{main actor-isolated default value of 'self.mainDefault' cannot be used in a global actor 'CustomActor'-isolated initializer}}
-  var mainDefaultAO: NonSendableAOStruct<T> // expected-note 5{{mutation of this property is only permitted within the actor}}
-  // expected-note @-1 8{{property declared here}}
-  // expected-note @-2 2{{'self.mainDefaultAO' not initialized}}
+  var _addressOnly: T
+  var mainDefault: NonSendableType = requiresMainActor() // expected-note 5{{main actor-isolated default value of 'self.mainDefault' cannot be used in a global actor 'CustomActor'-isolated initializer}}
+  var mainDefaultAO: NonSendableAOStruct<T> // expected-note 2{{'self.mainDefaultAO' not initialized}}
   nonisolated let nonisoNoDefault: SendableType
   nonisolated let nonisoSendableField: SendableType
-  @CustomActor var customDefault: NonSendableType = requiresCustomActor() // expected-note 7{{property declared here}}
-  // expected-note @-1 4{{mutation of this property is only permitted within the actor}}
-  // expected-note @-2 2{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a nonisolated initializer}}
-  // expected-note @-3 3{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a main actor-isolated initializer}}
+  @CustomActor var customDefault: NonSendableType = requiresCustomActor() // expected-note 2{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a nonisolated initializer}}
+  // expected-note @-1 3{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a main actor-isolated initializer}}
 
-  @CustomActor var customDefaultAO: NonSendableAOStruct<T> // expected-note 4{{mutation of this property is only permitted within the actor}}
-  // expected-note @-1 7{{property declared here}}
-  // expected-note @-2 2{{'self.customDefaultAO' not initialized}}
+  @CustomActor var customDefaultAO: NonSendableAOStruct<T> // expected-note 2{{'self.customDefaultAO' not initialized}}
 
   nonisolated func trigger() {}
 
@@ -443,6 +481,7 @@ struct GADTStructWithMixedDefaultRequirements_AO<T> {
     _ = self.mainDefault
 
     trigger() // expected-error {{variable 'self.customDefault' used before being initialized}}
+    // expected-note @-1 2{{after this use of 'self', only main actor-isolated properties of 'self' can be accessed from this init}}
 
 
     _ = self.nonisoNoDefault
@@ -450,10 +489,10 @@ struct GADTStructWithMixedDefaultRequirements_AO<T> {
     _ = self.mainDefault
     _ = self.mainDefaultAO
     _ = self.customDefault // expected-error {{'self' used before all stored properties are initialized}}
-    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{cannot access property 'customDefault' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
 
     _ = self.customDefaultAO // expected-error {{variable 'self.customDefaultAO' used before being initialized}}
-    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{cannot access property 'customDefaultAO' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
 
   } // expected-error {{return from initializer without initializing all stored properties}}
 
@@ -465,6 +504,7 @@ struct GADTStructWithMixedDefaultRequirements_AO<T> {
     _ = self.mainDefault
 
     trigger() // expected-error {{variable 'self.customDefault' used before being initialized}}
+    // expected-note @-1 2{{after this use of 'self', only main actor-isolated properties of 'self' can be accessed from this init}}
 
 
     _ = self.nonisoNoDefault
@@ -472,32 +512,30 @@ struct GADTStructWithMixedDefaultRequirements_AO<T> {
     _ = self.mainDefault
     _ = self.mainDefaultAO
     _ = self.customDefault // expected-error {{'self' used before all stored properties are initialized}}
-    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{cannot access property 'customDefault' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
 
     _ = self.customDefaultAO // expected-error {{variable 'self.customDefaultAO' used before being initialized}}
-    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{cannot access property 'customDefaultAO' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
 
   } // expected-error {{variable 'self.customDefault' used before being initialized}}
 
-  // We do completely initialize. With future changes, we should be able to do
-  // this.
   @MainActor init(v1a: NonSendableType, t: sending T, t2: sending T) {
     self._addressOnly = t
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
     self.mainDefaultAO = NonSendableAOStruct(value: t)
     _ = self.mainDefault
-    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customDefault = NonSendableType()
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
 
-    trigger()
+    trigger() // expected-note 2{{after this use of 'self', only main actor-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
     _ = self.mainDefault
     _ = self.mainDefaultAO
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
-    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   @MainActor init?(v1a_failable: NonSendableType, t: sending T, t2: sending T) {
@@ -506,38 +544,39 @@ struct GADTStructWithMixedDefaultRequirements_AO<T> {
     self.nonisoSendableField = SendableType()
     self.mainDefaultAO = NonSendableAOStruct(value: t)
     _ = self.mainDefault
-    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customDefault = NonSendableType()
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
 
-    trigger()
+    trigger() // expected-note 2{{after this use of 'self', only main actor-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
     _ = self.mainDefault
     _ = self.mainDefaultAO
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
-    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   // We do not completely initialize since we cannot run the default init of
   // mainDefault its initializer actually requires us to be on MainDefault.
   @CustomActor init(v1b: NonSendableType, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
     self.customDefaultAO = NonSendableAOStruct(value: t2)
     _ = self.customDefault
 
     trigger() // expected-error {{variable 'self.mainDefault' used before being initialized}}
+    // expected-note @-1 2{{after this use of 'self', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
     _ = self.mainDefault // expected-error {{'self' used before all stored properties are initialized}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{cannot access property 'mainDefault' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
 
     _ = self.mainDefaultAO // expected-error {{variable 'self.mainDefaultAO' used before being initialized}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{cannot access property 'mainDefaultAO' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
 
     _ = self.customDefault
     _ = self.customDefaultAO
@@ -546,26 +585,25 @@ struct GADTStructWithMixedDefaultRequirements_AO<T> {
   // We do not completely initialize since we cannot run the default init of
   // mainDefault its initializer actually requires us to be on MainDefault.
   @CustomActor init(v1bb: NonSendableType, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
     self.customDefaultAO = NonSendableAOStruct(value: t2)
     _ = self.customDefault
     _ = self.mainDefault // expected-error {{'self' used before all stored properties are initialized}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
     _ = self.mainDefaultAO // expected-error {{variable 'self.mainDefaultAO' used before being initialized}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
 
     trigger() // expected-error {{variable 'self.mainDefault' used before being initialized}}
+    // expected-note @-1 2{{after this use of 'self', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
     _ = self.mainDefault // expected-error {{'self' used before all stored properties are initialized}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{cannot access property 'mainDefault' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
 
     _ = self.mainDefaultAO // expected-error {{variable 'self.mainDefaultAO' used before being initialized}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{cannot access property 'mainDefaultAO' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
 
     _ = self.customDefault
     _ = self.customDefaultAO
@@ -574,118 +612,115 @@ struct GADTStructWithMixedDefaultRequirements_AO<T> {
   // We do completely initialize. With future changes, we should be able to do
   // this.
   @CustomActor init(v1c: NonSendableType, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
     self.customDefaultAO = NonSendableAOStruct(value: t2)
     _ = self.customDefault
 
-    trigger()
+    trigger() // expected-note 2{{after this use of 'self', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     _ = self.customDefault
     _ = self.customDefaultAO
   }
 
   @CustomActor init?(v1c_failable: NonSendableType, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
     self.customDefaultAO = NonSendableAOStruct(value: t2)
     _ = self.customDefault
 
-    trigger()
+    trigger() // expected-note 2{{after this use of 'self', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     _ = self.customDefault
     _ = self.customDefaultAO
   }
 
   nonisolated init(v2: Void, t: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
+    self.mainDefault = NonSendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
 
     trigger() // expected-error {{variable 'self.customDefault' used before being initialized}}
+    // expected-note @-1 4{{after this use of 'self', only nonisolated properties of 'self' can be accessed from this init}}
 
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     _ = self.customDefault // expected-error {{'self' used before all stored properties are initialized}}
-    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
 
     _ = self.customDefaultAO // expected-error {{variable 'self.customDefaultAO' used before being initialized}}
-    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
 
   } // expected-error {{return from initializer without initializing all stored properties}}
 
   nonisolated init(v3: Void, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
+    self.mainDefault = NonSendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
+    self.customDefault = NonSendableType()
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
 
-    trigger()
+    trigger() // expected-note 4{{after this use of 'self', only nonisolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   nonisolated init?(v3_failable: Void, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
+    self.mainDefault = NonSendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
+    self.customDefault = NonSendableType()
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
 
-    trigger()
+    trigger() // expected-note 4{{after this use of 'self', only nonisolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 }
 
 @available(SwiftStdlib 5.5, *)
 @MainActor
 struct GADTStructWithMixedDefaultRequirementsNonIsolatedInits_AO<T> {
-  var _addressOnly: T // expected-note 6{{mutation of this property is only permitted within the actor}}
-  var mainDefault = NonSendableType() // expected-note 7{{property declared here}}
-  // expected-note @-1 3{{mutation of this property is only permitted within the actor}}
-  var mainDefaultAO: NonSendableAOStruct<T> // expected-note 6{{mutation of this property is only permitted within the actor}}
-  // expected-note @-1 6{{property declared here}}
+  var _addressOnly: T
+  var mainDefault = NonSendableType()
+  var mainDefaultAO: NonSendableAOStruct<T>
   nonisolated let nonisoNoDefault: SendableType
   nonisolated let nonisoSendableField: SendableType
-  @CustomActor var customDefault = NonSendableType() // expected-note 7{{property declared here}}
-  // expected-note @-1 {{mutation of this property is only permitted within the actor}}
-  @CustomActor var customDefaultAO: NonSendableAOStruct<T> // expected-note 5{{property declared here}}
-  // expected-note @-1 5{{mutation of this property is only permitted within the actor}}
+  @CustomActor var customDefault = NonSendableType()
+  @CustomActor var customDefaultAO: NonSendableAOStruct<T>
 
   nonisolated func trigger() {}
 
@@ -694,18 +729,18 @@ struct GADTStructWithMixedDefaultRequirementsNonIsolatedInits_AO<T> {
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
     self.mainDefaultAO = NonSendableAOStruct(value: t)
-    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
     _ = self.mainDefault
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
 
-    trigger()
+    trigger() // expected-note 2{{after this use of 'self', only main actor-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
     _ = self.mainDefault
     _ = self.mainDefaultAO
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
-    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   @MainActor init?(v1_failable: Void, t: sending T, t2: sending T) {
@@ -713,129 +748,129 @@ struct GADTStructWithMixedDefaultRequirementsNonIsolatedInits_AO<T> {
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
     self.mainDefaultAO = NonSendableAOStruct(value: t)
-    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
     _ = self.mainDefault
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
 
-    trigger()
+    trigger() // expected-note 2{{after this use of 'self', only main actor-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
     _ = self.mainDefault
     _ = self.mainDefaultAO
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
-    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   // OK: explicitly initializes all fields
   @CustomActor init(v1a: Void, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
-    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
     self.customDefaultAO = NonSendableAOStruct(value: t2)
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault
     _ = self.customDefault
 
-    trigger()
+    trigger() // expected-note 2{{after this use of 'self', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     _ = self.customDefault
     _ = self.customDefaultAO
   }
 
   @CustomActor init(v1b: Void, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
     self.customDefault = NonSendableType()
     self.customDefaultAO = NonSendableAOStruct(value: t2)
 
-    trigger()
+    trigger() // expected-note 2{{after this use of 'self', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     _ = self.customDefault
     _ = self.customDefaultAO
   }
 
   @CustomActor init?(v1b_failable: Void, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
     self.customDefault = NonSendableType()
     self.customDefaultAO = NonSendableAOStruct(value: t2)
 
-    trigger()
+    trigger() // expected-note 2{{after this use of 'self', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     _ = self.customDefault
     _ = self.customDefaultAO
   }
 
   nonisolated init(v2: Void, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
-    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
 
-    trigger()
+    trigger() // expected-note 4{{after this use of 'self', only nonisolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   nonisolated init?(v2_failable: Void, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
-    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
 
-    trigger()
+    trigger() // expected-note 4{{after this use of 'self', only nonisolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   nonisolated init(v2a: Void, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
+    self.customDefault = NonSendableType()
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
 
-    trigger()
+    trigger() // expected-note 4{{after this use of 'self', only nonisolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 }
 
@@ -847,61 +882,57 @@ struct GADTStructWithMixedDefaultRequirementsNonIsolatedInits_AO<T> {
 @MainActor
 struct MainActorStructWithMixedFields_NC: ~Copyable {
   nonisolated let nonisoField: SendableType
-  @CustomActor var customField: NonSendableType // expected-note 4{{mutation of this property is only permitted within the actor}}
-  var mainField: NonSendableType // expected-note 4{{mutation of this property is only permitted within the actor}}
+  @CustomActor var customField: NonSendableType
+  var mainField: NonSendableType
 
   nonisolated func trigger() {}
 
   nonisolated init(v1: Void) {
     self.nonisoField = SendableType()
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType()
+    self.mainField = NonSendableType()
 
-    trigger()
+    trigger() // expected-note 2{{after this use of 'self', only nonisolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoField
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType() // expected-warning {{cannot access property 'customField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{cannot access property 'mainField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   @MainActor init(v2: Void) {
     self.nonisoField = SendableType()
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType()
     self.mainField = NonSendableType()
 
-    trigger()
+    trigger() // expected-note {{after this use of 'self', only main actor-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoField
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType() // expected-warning {{cannot access property 'customField' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     self.mainField = NonSendableType()
   }
 
   @CustomActor init(v3: Void) {
     self.nonisoField = SendableType()
     self.customField = NonSendableType()
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType()
 
-    trigger()
+    trigger() // expected-note {{after this use of 'self', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoField
     self.customField = NonSendableType()
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{cannot access property 'mainField' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 }
 
 @available(SwiftStdlib 5.5, *)
 @MainActor
 struct GADTStructWithMixedDefaultRequirements_NC: ~Copyable {
-  var mainDefault: NonSendableType = requiresMainActor() // expected-note 6{{property declared here}}
-  // expected-note @-1 7{{main actor-isolated default value of 'self.mainDefault' cannot be used in a global actor 'CustomActor'-isolated initializer}}
-  // expected-note @-2 3{{mutation of this property is only permitted within the actor}}
+  var mainDefault: NonSendableType = requiresMainActor() // expected-note 7{{main actor-isolated default value of 'self.mainDefault' cannot be used in a global actor 'CustomActor'-isolated initializer}}
 
 
   nonisolated let nonisoNoDefault: SendableType
-  @CustomActor var customDefault: NonSendableType = requiresCustomActor() // expected-note 4{{property declared here}}
-  // expected-note @-1 3{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a main actor-isolated initializer}}
-  // expected-note @-2 2{{mutation of this property is only permitted within the actor}}
-  // expected-note @-3 3{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a nonisolated initializer}}
+  @CustomActor var customDefault: NonSendableType = requiresCustomActor() // expected-note 3{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a main actor-isolated initializer}}
+  // expected-note @-1 3{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a nonisolated initializer}}
 
 
 
@@ -915,11 +946,12 @@ struct GADTStructWithMixedDefaultRequirements_NC: ~Copyable {
     _ = self.mainDefault
 
     trigger() // expected-error {{'self' used before all stored properties are initialized}}
+    // expected-note @-1 {{after this use of 'self', only main actor-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.mainDefault
     _ = self.customDefault // expected-error {{'self' used before all stored properties are initialized}}
-    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{cannot access property 'customDefault' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
 
   } // expected-error {{return from initializer without initializing all stored properties}}
 
@@ -928,13 +960,13 @@ struct GADTStructWithMixedDefaultRequirements_NC: ~Copyable {
   @MainActor init(v1a: NonSendableType) {
     self.nonisoNoDefault = SendableType()
     _ = self.mainDefault
-    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customDefault = NonSendableType()
 
-    trigger()
+    trigger() // expected-note {{after this use of 'self', only main actor-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.mainDefault
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   // We do not completely initialize since we cannot run the default init of
@@ -944,10 +976,11 @@ struct GADTStructWithMixedDefaultRequirements_NC: ~Copyable {
     _ = self.customDefault
 
     trigger() // expected-error {{'self' used before all stored properties are initialized}}
+    // expected-note @-1 {{after this use of 'self', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.mainDefault // expected-error {{'self' used before all stored properties are initialized}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{cannot access property 'mainDefault' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
 
     _ = self.customDefault
   } // expected-error {{return from initializer without initializing all stored properties}}
@@ -958,14 +991,14 @@ struct GADTStructWithMixedDefaultRequirements_NC: ~Copyable {
     self.nonisoNoDefault = SendableType()
     _ = self.customDefault
     _ = self.mainDefault // expected-error {{'self' used before all stored properties are initialized}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
 
 
     trigger() // expected-error {{'self' used before all stored properties are initialized}}
+    // expected-note @-1 {{after this use of 'self', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.mainDefault // expected-error {{'self' used before all stored properties are initialized}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{cannot access property 'mainDefault' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
 
     _ = self.customDefault
   } // expected-error {{return from initializer without initializing all stored properties}}
@@ -974,51 +1007,50 @@ struct GADTStructWithMixedDefaultRequirements_NC: ~Copyable {
   // this.
   @CustomActor init(v1c: NonSendableType) {
     self.nonisoNoDefault = SendableType()
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType()
     _ = self.customDefault
 
-    trigger()
+    trigger() // expected-note {{after this use of 'self', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     _ = self.customDefault
   }
 
   nonisolated init(v2: Void) {
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType()
     self.nonisoNoDefault = SendableType()
 
     trigger() // expected-error {{'self' used before all stored properties are initialized}}
+    // expected-note @-1 2{{after this use of 'self', only nonisolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     _ = self.customDefault // expected-error {{'self' used before all stored properties are initialized}}
-    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    // expected-warning @-1 {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
 
   } // expected-error {{return from initializer without initializing all stored properties}}
 
   nonisolated init(v3: Void) {
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType()
+    self.customDefault = NonSendableType()
     self.nonisoNoDefault = SendableType()
 
-    trigger()
+    trigger() // expected-note 2{{after this use of 'self', only nonisolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 }
 
 @available(SwiftStdlib 5.5, *)
 @MainActor
 struct GADTStructWithMixedDefaultRequirementsNonIsolatedInits_NC: ~Copyable {
-  var mainDefault = NonSendableType() // expected-note 2{{mutation of this property is only permitted within the actor}}
-  // expected-note @-1 5{{property declared here}}
+  var mainDefault = NonSendableType()
 
   nonisolated let nonisoNoDefault: SendableType
-  @CustomActor var customDefault = NonSendableType() // expected-note 4{{property declared here}}
-  // expected-note @-1 {{mutation of this property is only permitted within the actor}}
+  @CustomActor var customDefault = NonSendableType()
 
 
   nonisolated func trigger() {}
@@ -1026,60 +1058,60 @@ struct GADTStructWithMixedDefaultRequirementsNonIsolatedInits_NC: ~Copyable {
   @MainActor init(v1: Void) {
     self.nonisoNoDefault = SendableType()
     _ = self.mainDefault
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
 
-    trigger()
+    trigger() // expected-note {{after this use of 'self', only main actor-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.mainDefault
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   // OK: explicitly initializes all fields
   @CustomActor init(v1a: Void) {
     self.nonisoNoDefault = SendableType()
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault
     _ = self.customDefault
 
-    trigger()
+    trigger() // expected-note {{after this use of 'self', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     _ = self.customDefault
   }
 
   @CustomActor init(v1b: Void) {
     self.nonisoNoDefault = SendableType()
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType()
     self.customDefault = NonSendableType()
 
-    trigger()
+    trigger() // expected-note {{after this use of 'self', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     _ = self.customDefault
   }
 
   nonisolated init(v2: Void) {
     self.nonisoNoDefault = SendableType()
 
-    trigger()
+    trigger() // expected-note 2{{after this use of 'self', only nonisolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   nonisolated init(v2a: Void) {
     self.nonisoNoDefault = SendableType()
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType()
+    self.customDefault = NonSendableType()
 
-    trigger()
+    trigger() // expected-note 2{{after this use of 'self', only nonisolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 }
 
@@ -1090,69 +1122,69 @@ struct GADTStructWithMixedDefaultRequirementsNonIsolatedInits_NC: ~Copyable {
 @available(SwiftStdlib 5.1, *)
 @MainActor
 struct MainActorStructWithMixedFields_AO_NC<T>: ~Copyable {
-  var _addressOnly: T // expected-note 4{{mutation of this property is only permitted within the actor}}
+  var _addressOnly: T
   nonisolated let nonisoField: SendableType
   nonisolated let nonisoSendableField: SendableType
-  @CustomActor var customField: NonSendableType // expected-note 8{{mutation of this property is only permitted within the actor}}
-  @CustomActor var customFieldAO: NonSendableAOStruct<T> // expected-note 8{{mutation of this property is only permitted within the actor}}
-  var mainField: NonSendableType // expected-note 8{{mutation of this property is only permitted within the actor}}
-  var mainFieldAO: NonSendableAOStruct<T> // expected-note 8{{mutation of this property is only permitted within the actor}}
+  @CustomActor var customField: NonSendableType
+  @CustomActor var customFieldAO: NonSendableAOStruct<T>
+  var mainField: NonSendableType
+  var mainFieldAO: NonSendableAOStruct<T>
 
   nonisolated func trigger() {}
 
   nonisolated init(v1: Void, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
     self.nonisoField = SendableType()
     self.nonisoSendableField = SendableType()
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType()
+    self.customFieldAO = NonSendableAOStruct(value: t2)
+    self.mainField = NonSendableType()
+    self.mainFieldAO = NonSendableAOStruct(value: t)
 
-    trigger()
+    trigger() // expected-note 4{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoField
     _ = self.nonisoSendableField
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType() // expected-warning {{cannot access property 'customField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{cannot access property 'customFieldAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{cannot access property 'mainField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{cannot access property 'mainFieldAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   nonisolated init?(v1_failable: Void, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
     self.nonisoField = SendableType()
     self.nonisoSendableField = SendableType()
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType()
+    self.customFieldAO = NonSendableAOStruct(value: t2)
+    self.mainField = NonSendableType()
+    self.mainFieldAO = NonSendableAOStruct(value: t)
 
-    trigger()
+    trigger() // expected-note 4{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoField
     _ = self.nonisoSendableField
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType() // expected-warning {{cannot access property 'customField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{cannot access property 'customFieldAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{cannot access property 'mainField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{cannot access property 'mainFieldAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   @MainActor init(v2: Void, t: sending T, t2: sending T) {
     self._addressOnly = t
     self.nonisoField = SendableType()
     self.nonisoSendableField = SendableType()
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType()
+    self.customFieldAO = NonSendableAOStruct(value: t2)
     self.mainField = NonSendableType()
     self.mainFieldAO = NonSendableAOStruct(value: t)
 
-    trigger()
+    trigger() // expected-note 2{{after calling instance method 'trigger()', only main actor-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoField
     _ = self.nonisoSendableField
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType() // expected-warning {{cannot access property 'customField' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{cannot access property 'customFieldAO' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     self.mainField = NonSendableType()
     self.mainFieldAO = NonSendableAOStruct(value: t)
   }
@@ -1161,76 +1193,71 @@ struct MainActorStructWithMixedFields_AO_NC<T>: ~Copyable {
     self._addressOnly = t
     self.nonisoField = SendableType()
     self.nonisoSendableField = SendableType()
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType()
+    self.customFieldAO = NonSendableAOStruct(value: t2)
     self.mainField = NonSendableType()
     self.mainFieldAO = NonSendableAOStruct(value: t)
 
-    trigger()
+    trigger() // expected-note 2{{after calling instance method 'trigger()', only main actor-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoField
     _ = self.nonisoSendableField
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customField = NonSendableType() // expected-warning {{cannot access property 'customField' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{cannot access property 'customFieldAO' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     self.mainField = NonSendableType()
     self.mainFieldAO = NonSendableAOStruct(value: t)
   }
 
   @CustomActor init(v3: Void, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
     self.nonisoField = SendableType()
     self.nonisoSendableField = SendableType()
     self.customField = NonSendableType()
     self.customFieldAO = NonSendableAOStruct(value: t2)
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType()
+    self.mainFieldAO = NonSendableAOStruct(value: t)
 
-    trigger()
+    trigger() // expected-note 2{{after calling instance method 'trigger()', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoField
     _ = self.nonisoSendableField
     self.customField = NonSendableType()
     self.customFieldAO = NonSendableAOStruct(value: t2)
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{cannot access property 'mainField' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{cannot access property 'mainFieldAO' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   @CustomActor init?(v3_failable: Void, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
     self.nonisoField = SendableType()
     self.nonisoSendableField = SendableType()
     self.customField = NonSendableType()
     self.customFieldAO = NonSendableAOStruct(value: t2)
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType()
+    self.mainFieldAO = NonSendableAOStruct(value: t)
 
-    trigger()
+    trigger() // expected-note 2{{after calling instance method 'trigger()', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoField
     _ = self.nonisoSendableField
     self.customField = NonSendableType()
     self.customFieldAO = NonSendableAOStruct(value: t2)
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainField = NonSendableType() // expected-warning {{cannot access property 'mainField' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{cannot access property 'mainFieldAO' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 }
 
 @available(SwiftStdlib 5.5, *)
 @MainActor
 struct GADTStructWithMixedDefaultRequirements_AO_NC<T>: ~Copyable {
-  var _addressOnly: T // expected-note 7{{mutation of this property is only permitted within the actor}}
-  var mainDefault: NonSendableType = requiresMainActor() // expected-note 5{{mutation of this property is only permitted within the actor}}
-  // expected-note @-1 8{{property declared here}}
-  // expected-note @-2 {{main actor-isolated default value of 'self.mainDefault' cannot be used in a global actor 'CustomActor'-isolated initializer}}
-  var mainDefaultAO: NonSendableAOStruct<T> // expected-note 8{{property declared here}}
-  // expected-note @-1 5{{mutation of this property is only permitted within the actor}}
+  var _addressOnly: T
+  var mainDefault: NonSendableType = requiresMainActor() // expected-note {{main actor-isolated default value of 'self.mainDefault' cannot be used in a global actor 'CustomActor'-isolated initializer}}
+  var mainDefaultAO: NonSendableAOStruct<T>
   nonisolated let nonisoNoDefault: SendableType
   nonisolated let nonisoSendableField: SendableType
-  @CustomActor var customDefault: NonSendableType = requiresCustomActor() // expected-note 4{{mutation of this property is only permitted within the actor}}
-  // expected-note @-1 7{{property declared here}}
+  @CustomActor var customDefault: NonSendableType = requiresCustomActor()
 
-  @CustomActor var customDefaultAO: NonSendableAOStruct<T> // expected-note 7{{property declared here}}
-  // expected-note @-1 4{{mutation of this property is only permitted within the actor}}
+  @CustomActor var customDefaultAO: NonSendableAOStruct<T>
 
   nonisolated func trigger() {}
 
@@ -1244,15 +1271,16 @@ struct GADTStructWithMixedDefaultRequirements_AO_NC<T>: ~Copyable {
     _ = self.mainDefault
 
     trigger() // expected-error {{variable 'self.customDefault' used before being initialized}}
+    // expected-note @-1 2{{after calling instance method 'trigger()', only main actor-isolated properties of 'self' can be accessed from this init}}
 
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
     _ = self.mainDefault
     _ = self.mainDefaultAO
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
 
-    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
 
   }
 
@@ -1264,15 +1292,16 @@ struct GADTStructWithMixedDefaultRequirements_AO_NC<T>: ~Copyable {
     _ = self.mainDefault
 
     trigger() // expected-error {{variable 'self.customDefault' used before being initialized}}
+    // expected-note @-1 2{{after calling instance method 'trigger()', only main actor-isolated properties of 'self' can be accessed from this init}}
 
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
     _ = self.mainDefault
     _ = self.mainDefaultAO
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
 
-    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
 
   }
 
@@ -1284,17 +1313,17 @@ struct GADTStructWithMixedDefaultRequirements_AO_NC<T>: ~Copyable {
     self.nonisoSendableField = SendableType()
     self.mainDefaultAO = NonSendableAOStruct(value: t)
     _ = self.mainDefault
-    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customDefault = NonSendableType()
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
 
-    trigger()
+    trigger() // expected-note 2{{after calling instance method 'trigger()', only main actor-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
     _ = self.mainDefault
     _ = self.mainDefaultAO
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
-    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   @MainActor init?(v1a_failable: NonSendableType, t: sending T, t2: sending T) {
@@ -1303,36 +1332,37 @@ struct GADTStructWithMixedDefaultRequirements_AO_NC<T>: ~Copyable {
     self.nonisoSendableField = SendableType()
     self.mainDefaultAO = NonSendableAOStruct(value: t)
     _ = self.mainDefault
-    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customDefault = NonSendableType()
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
 
-    trigger()
+    trigger() // expected-note 2{{after calling instance method 'trigger()', only main actor-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
     _ = self.mainDefault
     _ = self.mainDefaultAO
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
-    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   // We do not completely initialize since we cannot run the default init of
   // mainDefault its initializer actually requires us to be on MainDefault.
   @CustomActor init(v1b: NonSendableType, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
     self.customDefaultAO = NonSendableAOStruct(value: t2)
     _ = self.customDefault
 
     trigger() // expected-error {{variable 'self.mainDefault' used before being initialized}}
+    // expected-note @-1 2{{after calling instance method 'trigger()', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
 
-    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
 
     _ = self.customDefault
     _ = self.customDefaultAO
@@ -1341,24 +1371,23 @@ struct GADTStructWithMixedDefaultRequirements_AO_NC<T>: ~Copyable {
   // We do not completely initialize since we cannot run the default init of
   // mainDefault its initializer actually requires us to be on MainDefault.
   @CustomActor init(v1bb: NonSendableType, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
     self.customDefaultAO = NonSendableAOStruct(value: t2)
     _ = self.customDefault
     _ = self.mainDefault // expected-error {{'self' used before all stored properties are initialized}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
     _ = self.mainDefaultAO // expected-error {{variable 'self.mainDefaultAO' used before being initialized}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
 
     trigger() // expected-error {{variable 'self.mainDefault' used before being initialized}}
+    // expected-note @-1 2{{after calling instance method 'trigger()', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
 
-    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
 
     _ = self.customDefault
     _ = self.customDefaultAO
@@ -1367,116 +1396,113 @@ struct GADTStructWithMixedDefaultRequirements_AO_NC<T>: ~Copyable {
   // We do completely initialize. With future changes, we should be able to do
   // this.
   @CustomActor init(v1c: NonSendableType, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
     self.customDefaultAO = NonSendableAOStruct(value: t2)
     _ = self.customDefault
 
-    trigger()
+    trigger() // expected-note 2{{after calling instance method 'trigger()', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     _ = self.customDefault
     _ = self.customDefaultAO
   }
 
   @CustomActor init?(v1c_failable: NonSendableType, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
     self.customDefaultAO = NonSendableAOStruct(value: t2)
     _ = self.customDefault
 
-    trigger()
+    trigger() // expected-note 2{{after calling instance method 'trigger()', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     _ = self.customDefault
     _ = self.customDefaultAO
   }
 
   nonisolated init(v2: Void, t: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
+    self.mainDefault = NonSendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
 
     trigger() // expected-error {{variable 'self.customDefault' used before being initialized}}
+    // expected-note @-1 4{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
 
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
 
-    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
 
   }
 
   nonisolated init(v3: Void, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
+    self.mainDefault = NonSendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
+    self.customDefault = NonSendableType()
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
 
-    trigger()
+    trigger() // expected-note 4{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   nonisolated init?(v3_failable: Void, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
+    self.mainDefault = NonSendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
+    self.customDefault = NonSendableType()
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
 
-    trigger()
+    trigger() // expected-note 4{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 }
 
 @available(SwiftStdlib 5.5, *)
 @MainActor
 struct GADTStructWithMixedDefaultRequirementsNonIsolatedInits_AO_NC<T>: ~Copyable {
-  var _addressOnly: T // expected-note 6{{mutation of this property is only permitted within the actor}}
-  var mainDefault = NonSendableType() // expected-note 3{{mutation of this property is only permitted within the actor}}
-  // expected-note @-1 7{{property declared here}}
-  var mainDefaultAO: NonSendableAOStruct<T> // expected-note 6{{property declared here}}
-  // expected-note @-1 6{{mutation of this property is only permitted within the actor}}
+  var _addressOnly: T
+  var mainDefault = NonSendableType()
+  var mainDefaultAO: NonSendableAOStruct<T>
   nonisolated let nonisoNoDefault: SendableType
   nonisolated let nonisoSendableField: SendableType
-  @CustomActor var customDefault = NonSendableType() // expected-note 7{{property declared here}}
-  // expected-note @-1 {{mutation of this property is only permitted within the actor}}
-  @CustomActor var customDefaultAO: NonSendableAOStruct<T> // expected-note 5{{mutation of this property is only permitted within the actor}}
-  // expected-note @-1 5{{property declared here}}
+  @CustomActor var customDefault = NonSendableType()
+  @CustomActor var customDefaultAO: NonSendableAOStruct<T>
 
   nonisolated func trigger() {}
 
@@ -1485,18 +1511,18 @@ struct GADTStructWithMixedDefaultRequirementsNonIsolatedInits_AO_NC<T>: ~Copyabl
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
     self.mainDefaultAO = NonSendableAOStruct(value: t)
-    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
     _ = self.mainDefault
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
 
-    trigger()
+    trigger() // expected-note 2{{after calling instance method 'trigger()', only main actor-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
     _ = self.mainDefault
     _ = self.mainDefaultAO
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
-    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   @MainActor init?(v1_failable: Void, t: sending T, t2: sending T) {
@@ -1504,129 +1530,129 @@ struct GADTStructWithMixedDefaultRequirementsNonIsolatedInits_AO_NC<T>: ~Copyabl
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
     self.mainDefaultAO = NonSendableAOStruct(value: t)
-    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
     _ = self.mainDefault
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
 
-    trigger()
+    trigger() // expected-note 2{{after calling instance method 'trigger()', only main actor-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
     _ = self.mainDefault
     _ = self.mainDefaultAO
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
-    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in main actor-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   // OK: explicitly initializes all fields
   @CustomActor init(v1a: Void, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
-    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
     self.customDefaultAO = NonSendableAOStruct(value: t2)
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault
     _ = self.customDefault
 
-    trigger()
+    trigger() // expected-note 2{{after calling instance method 'trigger()', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     _ = self.customDefault
     _ = self.customDefaultAO
   }
 
   @CustomActor init(v1b: Void, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
     self.customDefault = NonSendableType()
     self.customDefaultAO = NonSendableAOStruct(value: t2)
 
-    trigger()
+    trigger() // expected-note 2{{after calling instance method 'trigger()', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     _ = self.customDefault
     _ = self.customDefaultAO
   }
 
   @CustomActor init?(v1b_failable: Void, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
     self.customDefault = NonSendableType()
     self.customDefaultAO = NonSendableAOStruct(value: t2)
 
-    trigger()
+    trigger() // expected-note 2{{after calling instance method 'trigger()', only global actor 'CustomActor'-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in global actor 'CustomActor'-isolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     _ = self.customDefault
     _ = self.customDefaultAO
   }
 
   nonisolated init(v2: Void, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
-    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
 
-    trigger()
+    trigger() // expected-note 4{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   nonisolated init?(v2_failable: Void, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
-    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
 
-    trigger()
+    trigger() // expected-note 4{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 
   nonisolated init(v2a: Void, t: sending T, t2: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self._addressOnly = t
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+    self.mainDefault = NonSendableType()
+    self.mainDefaultAO = NonSendableAOStruct(value: t)
+    self.customDefault = NonSendableType()
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
 
-    trigger()
+    trigger() // expected-note 4{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
 
     _ = self.nonisoNoDefault
     _ = self.nonisoSendableField
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{cannot access property 'mainDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+    _ = self.customDefaultAO // expected-warning {{cannot access property 'customDefaultAO' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
   }
 }
 

--- a/test/Concurrency/flow_isolation_struct.swift
+++ b/test/Concurrency/flow_isolation_struct.swift
@@ -1,4 +1,8 @@
-// RUN: %target-swift-frontend -strict-concurrency=complete -swift-version 5 -parse-as-library -emit-sil -verify %s
+// RUN: %target-swift-frontend -strict-concurrency=complete -swift-version 5 -parse-as-library -emit-sil -verify %s -o /dev/null
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
 
 @globalActor
 actor CustomActor {
@@ -22,7 +26,7 @@ func takeNonSendable<T>(_ ns: T) {}
 @available(SwiftStdlib 5.1, *)
 func takeSendable<T : Sendable>(_ s: T) {}
 
-class NonSendableType { // expected-note 8{{class 'NonSendableType' does not conform to the 'Sendable' protocol}}
+class NonSendableType {
   var x: Int = 0
   func f() {}
 }
@@ -34,822 +38,9 @@ struct NonSendableAOStruct<T> {
   var value: T
 }
 
-struct Money {
-  var dollars: Int
-  var euros: Int {
-    return dollars * 2
-  }
-}
-
-@available(SwiftStdlib 5.1, *)
-func takeBob(_ b: Bob) {}
-
-@available(SwiftStdlib 5.1, *)
-actor Bob {
-  var x: Int
-
-  nonisolated func speak() { }
-  nonisolated var cherry : String {
-        get { "black cherry" }
-    }
-
-  init(v0 initial: Int) {
-    self.x = 0
-    speak() // expected-note {{after calling instance method 'speak()', only nonisolated properties of 'self' can be accessed from this init}}
-    speak()
-    self.x = 1 // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    speak()
-  }
-
-  init(v1 _: Void) {
-    self.x = 0
-    _ = cherry // expected-note {{after accessing property 'cherry', only nonisolated properties of 'self' can be accessed from this init}}
-    self.x = 1 // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-  }
-
-  init(v2 callBack: (Bob) -> Void) {
-    self.x = 0
-    callBack(self) // expected-note {{after a call involving 'self', only nonisolated properties of 'self' can be accessed from this init}}
-    self.x = 1 // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-  }
-
-  init(v3 _: Void) {
-    self.x = 1
-    takeBob(self) // expected-note {{after calling global function 'takeBob', only nonisolated properties of 'self' can be accessed from this init}}
-    self.x = 1 // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-  }
-
-
-
-  // ensure noniso does not flow out of a defer's unreachable block
-  init(spice doesNotFlow: Int) {
-    if true {
-      defer {
-        if randomBool() {
-          speak()
-          fatalError("oops")
-        }
-      }
-      self.x = 0
-    }
-    self.x = 20
-  }
-}
-
-@available(SwiftStdlib 5.1, *)
-actor Casey {
-  var money: Money
-
-  nonisolated func speak(_ msg: String) { print("Casey: \(msg)") }
-  nonisolated func cashUnderMattress() -> Int { return 0 }
-
-  init() {
-    money = Money(dollars: 100)
-    defer { logTransaction(money.euros) } // expected-warning {{cannot access property 'money' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    self.speak("Yay, I have $\(money.dollars)!") // expected-note {{after calling instance method 'speak', only nonisolated properties of 'self' can be accessed from this init}}
-  }
-
-  init(with start: Int) {
-    money = Money(dollars: start)
-
-    if (money.dollars < 0) {
-      self.speak("Oh no, I'm in debt!") // expected-note 3{{after calling instance method 'speak', only nonisolated properties of 'self' can be accessed from this init}}
-    }
-    logTransaction(money.euros) // expected-warning {{cannot access property 'money' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-
-    money.dollars = money.dollars + 1 // expected-warning 2{{cannot access property 'money' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-
-    if randomBool() {
-      money.dollars += cashUnderMattress() // expected-warning {{cannot access property 'money' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-      // expected-note @-1 {{after calling instance method 'cashUnderMattress()', only nonisolated properties of 'self' can be accessed from this init}}
-    }
-  }
-}
-
-@available(SwiftStdlib 5.1, *)
-actor Demons {
-  let ns: NonSendableType
-
-  init(_ x: NonSendableType) {
-    self.ns = x
-  }
-
-  deinit { // expected-note {{add 'isolated' to run isolated to 'Demons', which may be later than 'nonisolated deinit'}} {{3-3=isolated }}
-    let _ = self.ns // expected-warning {{cannot access property 'ns' with a non-Sendable type 'NonSendableType' from nonisolated deinit; this is an error in the Swift 6 language mode}}
-  }
-}
-
-func pass<T>(_ t: T) {}
-
-@available(SwiftStdlib 5.1, *)
-actor ExampleFromProposal {
-  let immutableSendable = SendableType()
-  var mutableSendable = SendableType()
-  let nonSendable = NonSendableType()
-  nonisolated(unsafe) let unsafeNonSendable = NonSendableType()
-  var nsItems: [NonSendableType] = []
-  var sItems: [SendableType] = []
-
-  init() {
-    _ = self.immutableSendable  // ok
-    _ = self.mutableSendable    // ok
-    _ = self.nonSendable        // ok
-    _ = self.unsafeNonSendable
-
-    f() // expected-note 2{{after calling instance method 'f()', only nonisolated properties of 'self' can be accessed from this init}}
-
-    _ = self.immutableSendable  // ok
-    _ = self.mutableSendable // expected-warning {{cannot access property 'mutableSendable' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    _ = self.nonSendable // expected-warning {{cannot access property 'nonSendable' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    _ = self.unsafeNonSendable // ok
-  }
-
-
-  deinit { // expected-note 2 {{add 'isolated' to run isolated to 'ExampleFromProposal', which may be later than 'nonisolated deinit'}} {{3-3=isolated }}
-    _ = self.immutableSendable  // ok
-    _ = self.mutableSendable    // ok
-    _ = self.nonSendable // expected-warning {{cannot access property 'nonSendable' with a non-Sendable type 'NonSendableType' from nonisolated deinit; this is an error in the Swift 6 language mode}}
-
-    f() // expected-note {{after calling instance method 'f()', only nonisolated properties of 'self' can be accessed from a deinit}}
-
-    _ = self.immutableSendable  // ok
-    _ = self.mutableSendable // expected-warning {{cannot access property 'mutableSendable' here in deinitializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    _ = self.nonSendable // expected-warning {{cannot access property 'nonSendable' with a non-Sendable type 'NonSendableType' from nonisolated deinit; this is an error in the Swift 6 language mode}}
-  }
-
-  nonisolated func f() {}
-}
-
-@available(SwiftStdlib 5.1, *)
-@MainActor
-class CheckGAIT1 {
-  var silly = 10
-  var ns = NonSendableType()
-
-  nonisolated func f() {}
-
-  nonisolated init(_ c: Color) {
-    silly += 0
-    repeat {
-      switch c {
-        case .red:
-          continue
-        case .yellow:
-          silly += 1
-          continue
-        case .blue:
-          f() // expected-note {{after calling instance method 'f()', only nonisolated properties of 'self' can be accessed from this init}}
-      }
-      break
-    } while true
-    silly += 2 // expected-warning {{cannot access property 'silly' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-  }
-
-  deinit { // expected-note {{add 'isolated' to run isolated to 'MainActor', which may be later than 'nonisolated deinit'}} {{3-3=isolated }}
-    _ = ns // expected-warning {{cannot access property 'ns' with a non-Sendable type 'NonSendableType' from nonisolated deinit; this is an error in the Swift 6 language mode}}
-    f() // expected-note {{after calling instance method 'f()', only nonisolated properties of 'self' can be accessed from a deinit}}
-    _ = silly // expected-warning {{cannot access property 'silly' here in deinitializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-
-  }
-}
-
-@available(SwiftStdlib 5.1, *)
-actor ControlFlowTester {
-  let ns: NonSendableType = NonSendableType()
-  let s: SendableType = SendableType()
-  var count: Int = 0
-
-  nonisolated func noniso() {}
-
-  init(v1: Void) {
-    noniso() // expected-note {{after calling instance method 'noniso()', only nonisolated properties of 'self' can be accessed from this init}}
-    takeNonSendable(self.ns) // expected-warning {{cannot access property 'ns' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    takeSendable(self.s)
-  }
-
-  init(v2 c: Color) throws {
-    if c == .red {
-      noniso()
-      throw c
-    } else if c == .blue {
-      noniso()
-      fatalError("soul")
-    }
-    count += 1
-  }
-
-  init(v3 c: Color) {
-    do {
-      defer { noniso() } // expected-note 3{{after calling instance method 'noniso()', only nonisolated properties of 'self' can be accessed from this init}}
-      switch c {
-      case .red:
-        throw Color.red
-      case .blue:
-        throw Color.blue
-      case .yellow:
-        count = 0
-        throw Color.yellow
-      }
-    } catch Color.blue {
-      count += 1 // expected-warning {{cannot access property 'count' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    } catch {
-      count += 1 // expected-warning {{cannot access property 'count' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    }
-    count = 42 // expected-warning {{cannot access property 'count' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-  }
-
-
-  init(v4 c: Color) {
-    defer { count += 1 } // expected-warning {{cannot access property 'count' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    noniso() // expected-note {{after calling instance method 'noniso()', only nonisolated properties of 'self' can be accessed from this init}}
-  }
-
-  init?(v5 c: Color) throws {
-    if c != .red {
-      noniso()
-      return nil
-    }
-    count += 1
-    noniso() // expected-note {{after calling instance method 'noniso()', only nonisolated properties of 'self' can be accessed from this init}}
-    if c == .blue {
-      throw c
-    }
-    count += 1 // expected-warning {{cannot access property 'count' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-  }
-
-  init(v5 c: Color?) {
-    if let c = c {
-      switch c {
-      case .red:
-        defer { noniso() } // expected-note 5{{after calling instance method 'noniso()', only nonisolated properties of 'self' can be accessed from this init}}
-        count = 0 // OK
-        fallthrough
-      case .blue:
-        count = 1 // expected-warning {{cannot access property 'count' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-        fallthrough
-      case .yellow:
-        count = 2 // expected-warning {{cannot access property 'count' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-        break
-      }
-    }
-    switch c {
-    case .some(.red):
-      count += 1 // expected-warning {{cannot access property 'count' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    case .some(.blue):
-      count += 2 // expected-warning {{cannot access property 'count' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    case .some(.yellow):
-      count += 3 // expected-warning {{cannot access property 'count' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    case .none:
-      break
-    }
-  }
-}
-
-enum BogusError: Error {
-    case blah
-}
-
-@available(SwiftStdlib 5.1, *)
-actor Convenient {
-    var x: Int
-    var y: Convenient?
-
-    init(val: Int) {
-        self.x = val
-    }
-
-    init(bigVal: Int) {
-        if bigVal < 0 {
-            self.init(val: 0)
-            say(msg: "hello from actor!")
-        }
-        say(msg: "said this too early!") // expected-error {{'self' used before 'self.init' call or assignment to 'self'}}
-        self.init(val: bigVal)
-
-        Task { await self.mutateIsolatedState() }
-    }
-
-    init!(biggerVal1 biggerVal: Int) {
-        guard biggerVal < 1234567 else { return nil }
-        self.init(bigVal: biggerVal)
-        say(msg: "hello?")
-    }
-
-    @MainActor
-    init?(biggerVal2 biggerVal: Int) async {
-        guard biggerVal < 1234567 else { return nil }
-        self.init(bigVal: biggerVal)
-        say(msg: "hello?")
-        await mutateIsolatedState()
-    }
-
-    init() async {
-        self.init(val: 10)
-        self.x += 1
-        mutateIsolatedState()
-    }
-
-    init(throwyDesignated val: Int) throws {
-        guard val > 0 else { throw BogusError.blah }
-        self.x = 10
-        say(msg: "hello?")
-
-        Task { self }
-    }
-
-    init(asyncThrowyDesignated val: Int) async throws {
-        guard val > 0 else { throw BogusError.blah }
-        self.x = 10
-        say(msg: "hello?")
-        Task { self }
-    }
-
-    init(throwyConvenient val: Int) throws {
-        try self.init(throwyDesignated: val)
-        say(msg: "hello?")
-        Task { self }
-    }
-
-    func mutateIsolatedState() {
-        self.y = self
-    }
-
-    nonisolated func say(msg: String) {
-        print(msg)
-    }
-}
-
-func randomInt() -> Int { return 4 }
-
-@available(SwiftStdlib 5.1, *)
-func callMethod(_ a: MyActor) {}
-
-@available(SwiftStdlib 5.1, *)
-func passInout<T>(_ a: inout T) {}
-
-@available(SwiftStdlib 5.1, *)
-actor MyActor {
-    var x: Int
-    var y: Int
-    var hax: MyActor?
-
-    var computedProp : Int {
-        get { 0 }
-        set { }
-    }
-
-    func helloWorld() {}
-
-    init(ci1 c: Bool) {
-        self.init(i1: c)
-        Task { self }
-        callMethod(self)
-    }
-
-    init(ci2 c: Bool) async {
-      self.init(i1: c)
-      self.x = 1
-      callMethod(self)
-      self.x = 0
-    }
-
-    init(i1 c:  Bool) {
-        self.x = 0
-        _ = self.x
-        self.y = self.x
-
-        Task { self } // expected-note 2{{after making a copy of 'self', only nonisolated properties of 'self' can be accessed from this init}}
-
-        self.x = randomInt() // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-
-        callMethod(self) // expected-note 5{{after calling global function 'callMethod', only nonisolated properties of 'self' can be accessed from this init}}
-
-        passInout(&self.x) // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-
-        if c {
-          self.x = self.y // expected-warning {{cannot access property 'y' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-          // expected-warning @-1 {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-        }
-
-        (_, _) = (self.x, self.y) // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-        // expected-warning @-1 {{cannot access property 'y' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-        _ = self.x == 0 // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-
-        while c {
-          self.hax = self // expected-warning {{cannot access property 'hax' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-          // expected-note @-1 2{{after making a copy of 'self', only nonisolated properties of 'self' can be accessed from this init}}
-          _ = self.hax // expected-warning {{cannot access property 'hax' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-        }
-
-        Task {
-            _ = await self.hax
-            await self.helloWorld()
-        }
-
-        { _ = self }()
-    }
-
-    @MainActor
-    init(i2 c:  Bool) {
-        self.x = 0
-        self.y = self.x
-
-        Task { self } // expected-note {{after making a copy of 'self', only nonisolated properties of 'self' can be accessed from this init}}
-
-        callMethod(self)
-
-        passInout(&self.x) // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    }
-
-    init(i3 c:  Bool) async {
-        self.x = 0
-        self.y = self.x
-
-        Task { self }
-
-        self.helloWorld()
-        callMethod(self)
-        passInout(&self.x)
-
-        self.x = self.y
-
-        self.hax = self
-        _ = Optional.some(self)
-
-        _ = computedProp
-        computedProp = 1
-
-        Task {
-            _ = self.hax
-            self.helloWorld()
-        }
-
-      { _ = self }()
-    }
-
-    @MainActor
-    init(i4 c:  Bool) async {
-      self.x = 0
-      self.y = self.x
-
-      Task { self } // expected-note {{after making a copy of 'self', only nonisolated properties of 'self' can be accessed from this init}}
-
-      callMethod(self)
-
-      passInout(&self.x) // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    }
-}
-
-
-@available(SwiftStdlib 5.1, *)
-actor X {
-    var counter: Int
-
-    init(v1 start: Int) {
-        self.counter = start
-        Task { await self.setCounter(start + 1) } // expected-note {{after making a copy of 'self', only nonisolated properties of 'self' can be accessed from this init}}
-
-        if self.counter != start { // expected-warning {{cannot access property 'counter' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-            fatalError("where's my protection?")
-        }
-    }
-
-    func setCounter(_ x : Int) {
-        self.counter = x
-    }
-}
-
-struct CardboardBox<T> {
-    public let item: T
-}
-
-
-@available(SwiftStdlib 5.1, *)
-var globalVar: EscapeArtist? // expected-warning {{var 'globalVar' is not concurrency-safe because it is nonisolated global shared mutable state; this is an error in the Swift 6 language mode}}
-// expected-note @-1 {{convert 'globalVar' to a 'let' constant to make 'Sendable' shared state immutable}}
-// expected-note @-2 {{disable concurrency-safety checks if accesses are protected by an external synchronization mechanism}}
-// expected-note @-3 {{add '@MainActor' to make var 'globalVar' part of global actor 'MainActor'}}
-
-@available(SwiftStdlib 5.1, *)
-actor EscapeArtist {
-    var x: Int
-
-    init(attempt1: Bool) {
-        self.x = 0
-
-        globalVar = self // expected-note {{after making a copy of 'self', only nonisolated properties of 'self' can be accessed from this init}}
-
-        Task { await globalVar!.isolatedMethod() }
-
-        if self.x == 0 { // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-            fatalError("race detected.")
-        }
-    }
-
-    init(attempt2: Bool) {
-        self.x = 0
-
-        let wrapped: EscapeArtist? = .some(self) // expected-note {{after making a copy of 'self', only nonisolated properties of 'self' can be accessed from this init}}
-        let selfUnchained = wrapped!
-
-        Task { await selfUnchained.isolatedMethod() }
-        if self.x == 0 { // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-            fatalError("race detected.")
-        }
-    }
-
-    init(attempt3: Bool) {
-        self.x = 0
-
-        let unchainedSelf = self
-
-        unchainedSelf.nonisolated()
-    }
-
-    init(attempt4: Bool) {
-        self.x = 0
-
-        let unchainedSelf = self
-
-        unchainedSelf.nonisolated()
-
-        let _ = { unchainedSelf.nonisolated() }()
-    }
-
-    init(attempt5: Bool) {
-        self.x = 0
-
-        let box = CardboardBox(item: self)
-        box.item.nonisolated()
-    }
-
-    init(attempt6: Bool) {
-        self.x = 0
-        func fn() {
-            self.nonisolated()
-        }
-        fn()
-    }
-
-    func isolatedMethod() { x += 1 }
-    nonisolated func nonisolated() {}
-}
-
-@available(SwiftStdlib 5.5, *)
-actor Ahmad {
-  nonisolated func f() {}
-  var prop: Int = 0
-  var computedProp: Int { 10 } // expected-note {{property declared here}}
-
-  init(v1: Void) {
-    Task.detached { self.f() } // expected-note {{after making a copy of 'self', only nonisolated properties of 'self' can be accessed from this init}}
-    f()
-    prop += 1 // expected-warning {{cannot access property 'prop' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-  }
-
-  nonisolated init(v2: Void) async {
-    Task.detached { self.f() } // expected-note {{after making a copy of 'self', only nonisolated properties of 'self' can be accessed from this init}}
-    f()
-    prop += 1 // expected-warning {{cannot access property 'prop' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-  }
-
-  nonisolated init(v3: Void) async {
-    prop = 10
-    f() // expected-note {{after calling instance method 'f()', only nonisolated properties of 'self' can be accessed from this init}}
-    prop += 1 // expected-warning {{cannot access property 'prop' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-  }
-
-  @MainActor init(v4: Void) async {
-    prop = 10
-    f() // expected-note {{after calling instance method 'f()', only nonisolated properties of 'self' can be accessed from this init}}
-    prop += 1 // expected-warning {{cannot access property 'prop' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-  }
-
-  deinit { // expected-note {{add 'isolated' to run isolated to 'Ahmad', which may be later than 'nonisolated deinit'}} {{3-3=isolated }}
-    let x = computedProp // expected-warning {{actor-isolated property 'computedProp' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    // expected-note @-1 {{after accessing property 'computedProp', only nonisolated properties of 'self' can be accessed from a deinit}}
-
-    prop = x // expected-warning {{cannot access property 'prop' here in deinitializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-  }
-}
-
-@available(SwiftStdlib 5.5, *)
-actor Rain {
-  var x: Int = 0
-  nonisolated func f() {}
-
-  init(_ hollerBack: (Rain) -> () -> Void) {
-    defer { self.f() }
-
-    defer { _ = self.x } // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-
-    defer { Task { self.f() } }
-
-    defer { _ = hollerBack(self) } // expected-note {{after a call involving 'self', only nonisolated properties of 'self' can be accessed from this init}}
-  }
-
-  init(_ hollerBack: (Rain) -> () -> Void) async {
-    defer { self.f() }
-
-    defer { _ = self.x }
-
-    defer { Task { self.f() } }
-
-    defer { _ = hollerBack(self) }
-  }
-
-  deinit {
-    x = 1
-  }
-}
-
-@available(SwiftStdlib 5.5, *)
-actor NonIsolatedDeinitExceptionForSwift5 {
-  var x: Int = 0
-
-  func cleanup() { // expected-note {{calls to instance method 'cleanup()' from outside of its actor context are implicitly asynchronous}}
-    x = 0
-  }
-
-  deinit { // expected-note {{add 'isolated' to run isolated to 'NonIsolatedDeinitExceptionForSwift5', which may be later than 'nonisolated deinit'}} {{3-3=isolated }}
-    // expected-warning@+2 {{actor-isolated instance method 'cleanup()' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
-    // expected-note@+1 {{after calling instance method 'cleanup()', only nonisolated properties of 'self' can be accessed from a deinit}}
-    cleanup()
-
-    x = 1 // expected-warning {{cannot access property 'x' here in deinitializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-  }
-}
-
-@available(SwiftStdlib 6.1, *)
-actor IsolatedDeinitExceptionForSwift5 {
-  var x: Int = 0
-
-  func cleanup() {
-    x = 0
-  }
-
-  isolated deinit {
-    cleanup() // ok
-
-    x = 1 // ok
-  }
-}
-
-
-@available(SwiftStdlib 5.5, *)
-actor OhBrother {
-  private var giver: (OhBrother) -> Int
-  private var whatever: Int = 0
-
-  static var DefaultResult: Int { 10 }
-
-  init() {
-    // this is OK: we're using DynamicSelfType but that doesn't access protected state.
-    self.giver = { (x: OhBrother) -> Int in Self.DefaultResult }
-  }
-
-  init(v2: Void) {
-    giver = { (x: OhBrother) -> Int in 0 }
-
-    // make sure we don't call this a closure, which is the more common situation.
-
-    _ = giver(self) // expected-note {{after a call involving 'self', only nonisolated properties of 'self' can be accessed from this init}}
-
-    whatever = 1 // expected-warning {{cannot access property 'whatever' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-  }
-
-  init(v3: Void) {
-    let blah = { (x: OhBrother) -> Int in 0 }
-    giver = blah
-
-    _ = blah(self) // expected-note {{after a call involving 'self', only nonisolated properties of 'self' can be accessed from this init}}
-
-    whatever = 2 // expected-warning {{cannot access property 'whatever' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-  }
-}
-
-@available(SwiftStdlib 5.1, *)
-@MainActor class AwesomeUIView {}
-
-@available(SwiftStdlib 5.1, *)
-class CheckDeinitFromClass: AwesomeUIView {
-  var ns: NonSendableType?
-  deinit { // expected-note 2 {{add 'isolated' to run isolated to 'MainActor', which may be later than 'nonisolated deinit'}} {{3-3=isolated }}
-    ns?.f() // expected-warning {{cannot access property 'ns' with a non-Sendable type 'NonSendableType?' from nonisolated deinit; this is an error in the Swift 6 language mode}}
-    ns = nil // expected-warning {{cannot access property 'ns' with a non-Sendable type 'NonSendableType?' from nonisolated deinit; this is an error in the Swift 6 language mode}}
-  }
-}
-
-@available(SwiftStdlib 5.1, *)
-actor CheckDeinitFromActor {
-  var ns: NonSendableType?
-  deinit { // expected-note 2 {{add 'isolated' to run isolated to 'CheckDeinitFromActor', which may be later than 'nonisolated deinit'}} {{3-3=isolated }}
-    ns?.f() // expected-warning {{cannot access property 'ns' with a non-Sendable type 'NonSendableType?' from nonisolated deinit; this is an error in the Swift 6 language mode}}
-    ns = nil // expected-warning {{cannot access property 'ns' with a non-Sendable type 'NonSendableType?' from nonisolated deinit; this is an error in the Swift 6 language mode}}
-  }
-}
-
-// https://github.com/apple/swift/issues/70550
-func testActorWithInitAccessorInit() {
-  @available(SwiftStdlib 5.1, *)
-  actor Angle {
-    var degrees: Double
-    var radians: Double = 0 {
-      @storageRestrictions(initializes: degrees)
-      init(initialValue)  {
-        degrees = initialValue * 180 / .pi
-      }
-
-      get { degrees * .pi / 180 }
-      set { degrees = newValue * 180 / .pi }
-    }
-
-    init(degrees: Double) {
-      self.degrees = degrees // Ok
-    }
-
-    init(radians: Double) {
-      self.radians = radians // Ok
-    }
-
-    init(value: Double) {
-      let escapingSelf: (Angle) -> Void = { _ in }
-
-      // degrees are initialized here via default value associated with radians
-
-      escapingSelf(self)
-
-      self.radians = 0 // expected-warning {{actor-isolated property 'radians' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    }
-  }
-
-  @available(SwiftStdlib 5.1, *)
-  actor EscapeBeforeFullInit {
-    var _a: Int // expected-note {{'self._a' not initialized}}
-
-    var a: Int {
-      @storageRestrictions(initializes: _a)
-      init {
-        _a = newValue
-      }
-
-      get { _a }
-      set { _a = newValue }
-    }
-
-    init(v: Int) {
-      let escapingSelf: (EscapeBeforeFullInit) -> Void = { _ in }
-
-      escapingSelf(self) // expected-error {{'self' used before all stored properties are initialized}}
-      // expected-note @-1 {{after a call involving 'self', only nonisolated properties of 'self' can be accessed from this init}}
-
-      self.a = v // expected-warning {{cannot access property '_a' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    }
-  }
-
-  @available(SwiftStdlib 5.1, *)
-  actor NonisolatedAccessors {
-    nonisolated var a: Int = 0 {
-      init {
-      }
-
-      get { 0 }
-      set {}
-    }
-
-    init(value: Int) {
-      let escapingSelf: (NonisolatedAccessors) -> Void = { _ in }
-
-      // a is initialized here via default value
-
-      escapingSelf(self)
-
-      self.a = value // Ok (nonisolated)
-      print(a) // Ok (nonisolated)
-    }
-  }
-}
-
-@available(SwiftStdlib 5.1, *)
-actor TestNonisolatedUnsafe {
-  private nonisolated(unsafe) var child: OtherActor!
-  init() {
-    child = OtherActor(parent: self)
-  }
-}
-
-@available(SwiftStdlib 5.1, *)
-actor OtherActor {
-  unowned nonisolated let parent: any Actor
-
-  init(parent: any Actor) {
-    self.parent = parent
-  }
-}
-
-////////////////////////////
-// MARK: Mixed Isolations //
-////////////////////////////
+/////////////////
+// MARK: Tests //
+/////////////////
 
 @available(SwiftStdlib 5.1, *)
 @MainActor
@@ -897,123 +88,10 @@ struct MainActorStructWithMixedFields {
   }
 }
 
-@available(SwiftStdlib 5.1, *)
-@MainActor
-class MainActorClassWithMixedFields {
-  nonisolated let nonisoField: SendableType
-  @CustomActor var customField: NonSendableType // expected-note 4{{mutation of this property is only permitted within the actor}}
-  var mainField: NonSendableType // expected-note 4{{mutation of this property is only permitted within the actor}}
-
-  nonisolated func trigger() {}
-
-  nonisolated init(v1: Void) {
-    self.nonisoField = SendableType()
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-
-    trigger() // expected-note 2{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
-
-    _ = self.nonisoField  // OK - explicitly nonisolated
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{cannot access property 'customField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{cannot access property 'mainField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-  }
-
-  @MainActor init(v2: Void) {
-    self.nonisoField = SendableType()
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    self.mainField = NonSendableType()
-
-    trigger()
-
-    _ = self.nonisoField  // OK - explicitly nonisolated
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    self.mainField = NonSendableType()
-  }
-
-  @CustomActor init(v3: Void) {
-    self.nonisoField = SendableType()
-    self.customField = NonSendableType()
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-
-    trigger() // expected-note 2{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
-
-    _ = self.nonisoField  // OK - explicitly nonisolated
-    self.customField = NonSendableType() // expected-warning {{cannot access property 'customField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{cannot access property 'mainField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-  }
-}
-
-@available(SwiftStdlib 5.1, *)
-actor ActorWithMixedIsolationFields {
-  @MainActor var mainField: NonSendableType
-  @MainActor var mainField_trivial: Int
-  @CustomActor var customField: NonSendableType // expected-note 2{{mutation of this property is only permitted within the actor}}
-  @CustomActor var customField_trivial: Int
-  nonisolated let nonisoField: SendableType
-  var actorField: NonSendableType // expected-note 2{{mutation of this property is only permitted within the actor}}
-  var actorField_trivial: Int
-
-  nonisolated func trigger() {}
-
-  init(v1: Void) {
-    // Before decay: can assign all fields
-    self.mainField = NonSendableType()
-    self.mainField_trivial = 0
-    self.customField = NonSendableType()
-    self.customField_trivial = 0
-    self.nonisoField = SendableType()
-    self.actorField = NonSendableType()
-    self.actorField_trivial = 0
-
-    trigger() // expected-note 9{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
-
-    // After decay: nonisolated field is accessible, others are not
-    _ = self.nonisoField // OK
-    self.mainField = NonSendableType() // expected-warning {{cannot access property 'mainField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    self.mainField_trivial = 0 // expected-warning {{cannot access property 'mainField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    logTransaction(self.mainField_trivial) // expected-warning {{cannot access property 'mainField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    self.customField = NonSendableType() // expected-warning {{cannot access property 'customField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    self.customField_trivial = 0 // expected-warning {{cannot access property 'customField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    logTransaction(self.customField_trivial) // expected-warning {{cannot access property 'customField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    self.actorField = NonSendableType() // expected-warning {{cannot access property 'actorField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    self.actorField_trivial = 0 // expected-warning {{cannot access property 'actorField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    logTransaction(self.actorField_trivial) // expected-warning {{cannot access property 'actorField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-  }
-
-  @MainActor init(v2: Void) {
-    // Before decay: can assign all fields
-    self.mainField = NonSendableType()
-    self.mainField_trivial = 0
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    self.customField_trivial = 0
-    self.nonisoField = SendableType()
-    self.actorField = NonSendableType() // expected-warning {{actor-isolated property 'actorField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    self.actorField_trivial = 0
-
-    trigger() // expected-note 9{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
-
-    // After decay: nonisolated field is accessible, others are not
-    _ = self.nonisoField // OK
-    self.mainField = NonSendableType() // expected-warning {{cannot access property 'mainField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    self.mainField_trivial = 0 // expected-warning {{cannot access property 'mainField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    logTransaction(self.mainField_trivial) // expected-warning {{cannot access property 'mainField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{cannot access property 'customField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    self.customField_trivial = 0 // expected-warning {{cannot access property 'customField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    logTransaction(self.customField_trivial) // expected-warning {{cannot access property 'customField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    self.actorField = NonSendableType() // expected-warning {{actor-isolated property 'actorField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{cannot access property 'actorField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    self.actorField_trivial = 0 // expected-warning {{cannot access property 'actorField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    logTransaction(self.actorField_trivial) // expected-warning {{cannot access property 'actorField_trivial' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-  }
-
-}
-
-// MARK: Mixed Default Requirements with Different Default Value Initialization
-// Isolation
+//////////////////////////////////////////////////////////////////////////////////
+// MARK: Mixed Default Requirements with Different Default Value Initialization //
+// Isolation                                                                    //
+//////////////////////////////////////////////////////////////////////////////////
 
 // This test has fields that have an explicitly isolated initializer (e.x.:
 // requiresMainActor).
@@ -1021,12 +99,12 @@ actor ActorWithMixedIsolationFields {
 @MainActor
 struct GADTStructWithMixedDefaultRequirements {
   var mainDefault: NonSendableType = requiresMainActor() // expected-note 6{{property declared here}}
-  // expected-note @-1 7{{main actor-isolated default value of 'self.mainDefault' cannot be used in a global actor 'CustomActor'-isolated initializer}}
-  // expected-note @-2 3{{mutation of this property is only permitted within the actor}}
+  // expected-note @-1 3{{mutation of this property is only permitted within the actor}}
+  // expected-note @-2 7{{main actor-isolated default value of 'self.mainDefault' cannot be used in a global actor 'CustomActor'-isolated initializer}}
   nonisolated let nonisoNoDefault: SendableType
   @CustomActor var customDefault: NonSendableType = requiresCustomActor() // expected-note 4{{property declared here}}
-  // expected-note @-1 3{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a main actor-isolated initializer}}
-  // expected-note @-2 3{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a nonisolated initializer}}
+  // expected-note @-1 3{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a nonisolated initializer}}
+  // expected-note @-2 3{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a main actor-isolated initializer}}
   // expected-note @-3 2{{mutation of this property is only permitted within the actor}}
 
   nonisolated func trigger() {}
@@ -1199,162 +277,6 @@ struct GADTStructWithMixedDefaultRequirementsNonIsolatedInits {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
-actor ActorWithMixedDefaultRequirements {
-  @MainActor var mainDefault: NonSendableType = requiresMainActor() // expected-note 3{{property declared here}}
-  // expected-note @-1 2{{main actor-isolated default value of 'self.mainDefault' cannot be used in a nonisolated initializer}}
-  // expected-note @-2 2{{main actor-isolated default value of 'self.mainDefault' cannot be used in a global actor 'CustomActor'-isolated initializer}}
-  // expected-note @-3 2{{mutation of this property is only permitted within the actor}}
-  var actorField: NonSendableType // expected-note 6{{mutation of this property is only permitted within the actor}}
-  // expected-note @-1 6{{property declared here}}
-  nonisolated let nonisoNoDefault: SendableType
-  @CustomActor var customDefault: NonSendableType = requiresCustomActor() // expected-note {{mutation of this property is only permitted within the actor}}
-  // expected-note @-1 3{{property declared here}}
-  // expected-note @-2 4{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a nonisolated initializer}}
-  // expected-note @-3 4{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a main actor-isolated initializer}}
-
-  nonisolated func trigger() {}
-
-  init(v1: Void) {
-    self.nonisoNoDefault = SendableType()
-    self.actorField = NonSendableType()
-
-    trigger() // expected-error {{'self' used in method call 'trigger' before all stored properties are initialized}}
-    // expected-note @-1 3{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
-
-    _ = self.mainDefault // expected-error {{variable 'self.mainDefault' used before being initialized}}
-    // expected-warning @-1 {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    _ = self.actorField // expected-warning {{cannot access property 'actorField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    _ = self.nonisoNoDefault
-    _ = self.customDefault // expected-error {{variable 'self.customDefault' used before being initialized}}
-    // expected-warning @-1 {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-  } // expected-error {{return from initializer without initializing all stored properties}}
-
-  init(v1a: Void) {
-    self.nonisoNoDefault = SendableType()
-    self.actorField = NonSendableType()
-    self.mainDefault = NonSendableType()
-
-    trigger() // expected-error {{'self' used in method call 'trigger' before all stored properties are initialized}}
-    // expected-note @-1 3{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
-
-    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    _ = self.actorField // expected-warning {{cannot access property 'actorField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    _ = self.nonisoNoDefault
-    _ = self.customDefault // expected-error {{variable 'self.customDefault' used before being initialized}}
-    // expected-warning @-1 {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-  } // expected-error {{return from initializer without initializing all stored properties}}
-
-  init(v1b: Void) {
-    self.nonisoNoDefault = SendableType()
-    self.actorField = NonSendableType()
-    self.mainDefault = NonSendableType()
-    self.customDefault = NonSendableType()
-
-    trigger() // expected-note 3{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
-
-    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    _ = self.actorField // expected-warning {{cannot access property 'actorField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    _ = self.nonisoNoDefault
-    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-  }
-
-  @MainActor init(v2: Void) {
-    self.nonisoNoDefault = SendableType()
-    self.actorField = NonSendableType() // expected-warning {{actor-isolated property 'actorField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-
-    trigger() // expected-error {{'self' used in method call 'trigger' before all stored properties are initialized}}
-    // expected-note @-1 3{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
-
-    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    _ = self.actorField // expected-warning {{cannot access property 'actorField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{actor-isolated property 'actorField' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
-    _ = self.nonisoNoDefault
-    _ = self.customDefault // expected-error {{variable 'self.customDefault' used before being initialized}}
-    // expected-warning @-1 {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-2 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
-  } // expected-error {{return from initializer without initializing all stored properties}}
-
-  @MainActor init(v2a: Void) {
-    self.nonisoNoDefault = SendableType()
-    self.actorField = NonSendableType() // expected-warning {{actor-isolated property 'actorField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    self.mainDefault = NonSendableType()
-
-    trigger() // expected-error {{'self' used in method call 'trigger' before all stored properties are initialized}}
-    // expected-note @-1 3{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
-
-    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    _ = self.actorField // expected-warning {{cannot access property 'actorField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{actor-isolated property 'actorField' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
-    _ = self.nonisoNoDefault
-    _ = self.customDefault // expected-error {{variable 'self.customDefault' used before being initialized}}
-    // expected-warning @-1 {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-2 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
-  } // expected-error {{return from initializer without initializing all stored properties}}
-
-  @MainActor init(v2b: Void) {
-    self.nonisoNoDefault = SendableType()
-    self.actorField = NonSendableType() // expected-warning {{actor-isolated property 'actorField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    self.mainDefault = NonSendableType()
-    self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-
-    trigger() // expected-note 3{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
-
-    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    _ = self.actorField // expected-warning {{cannot access property 'actorField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{actor-isolated property 'actorField' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
-    _ = self.nonisoNoDefault
-    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
-  }
-
-  @CustomActor init(v3: Void) {
-    self.nonisoNoDefault = SendableType()
-    self.actorField = NonSendableType() // expected-warning {{actor-isolated property 'actorField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-
-    trigger() // expected-error {{'self' used in method call 'trigger' before all stored properties are initialized}}
-    // expected-note @-1 3{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
-
-    _ = self.mainDefault // expected-error {{variable 'self.mainDefault' used before being initialized}}
-    // expected-warning @-1 {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-2 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    _ = self.actorField // expected-warning {{cannot access property 'actorField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{actor-isolated property 'actorField' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    _ = self.nonisoNoDefault
-    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-  } // expected-error {{return from initializer without initializing all stored properties}}
-
-  @CustomActor init(v3a: Void) {
-    self.nonisoNoDefault = SendableType()
-    self.actorField = NonSendableType() // expected-warning {{actor-isolated property 'actorField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-
-    trigger() // expected-note 3{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
-
-    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    _ = self.actorField // expected-warning {{cannot access property 'actorField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{actor-isolated property 'actorField' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    _ = self.nonisoNoDefault
-    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-  }
-
-  @CustomActor init(v3b: Void) {
-    self.nonisoNoDefault = SendableType()
-    self.actorField = NonSendableType() // expected-warning {{actor-isolated property 'actorField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.customDefault = NonSendableType()
-
-    trigger() // expected-note 3{{after calling instance method 'trigger()', only nonisolated properties of 'self' can be accessed from this init}}
-
-    _ = self.mainDefault // expected-warning {{cannot access property 'mainDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    _ = self.actorField // expected-warning {{cannot access property 'actorField' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{actor-isolated property 'actorField' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    _ = self.nonisoNoDefault
-    _ = self.customDefault // expected-warning {{cannot access property 'customDefault' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
-  }
-}
 
 ////////////////////////////////////////////////////
 // MARK: Address Only Struct Variants             //
@@ -1373,13 +295,12 @@ struct MainActorStructWithMixedFields_AO<T> {
 
   nonisolated func trigger() {}
 
-  nonisolated init(v1: Void, t: sending T) {
+  nonisolated init(v1: Void, t: sending T, t2: sending T) {
     self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.nonisoField = SendableType()
     self.nonisoSendableField = SendableType()
     self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
 
@@ -1388,19 +309,17 @@ struct MainActorStructWithMixedFields_AO<T> {
     _ = self.nonisoField
     _ = self.nonisoSendableField
     self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
   }
 
-  nonisolated init?(v1_failable: Void, t: sending T) {
+  nonisolated init?(v1_failable: Void, t: sending T, t2: sending T) {
     self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.nonisoField = SendableType()
     self.nonisoSendableField = SendableType()
     self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
 
@@ -1409,19 +328,17 @@ struct MainActorStructWithMixedFields_AO<T> {
     _ = self.nonisoField
     _ = self.nonisoSendableField
     self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
   }
 
-  @MainActor init(v2: Void, t: sending T) {
+  @MainActor init(v2: Void, t: sending T, t2: sending T) {
     self._addressOnly = t
     self.nonisoField = SendableType()
     self.nonisoSendableField = SendableType()
     self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
     self.mainField = NonSendableType()
     self.mainFieldAO = NonSendableAOStruct(value: t)
 
@@ -1430,19 +347,17 @@ struct MainActorStructWithMixedFields_AO<T> {
     _ = self.nonisoField
     _ = self.nonisoSendableField
     self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
     self.mainField = NonSendableType()
     self.mainFieldAO = NonSendableAOStruct(value: t)
   }
 
-  @MainActor init?(v2_failable: Void, t: sending T) {
+  @MainActor init?(v2_failable: Void, t: sending T, t2: sending T) {
     self._addressOnly = t
     self.nonisoField = SendableType()
     self.nonisoSendableField = SendableType()
     self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
     self.mainField = NonSendableType()
     self.mainFieldAO = NonSendableAOStruct(value: t)
 
@@ -1451,18 +366,17 @@ struct MainActorStructWithMixedFields_AO<T> {
     _ = self.nonisoField
     _ = self.nonisoSendableField
     self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
     self.mainField = NonSendableType()
     self.mainFieldAO = NonSendableAOStruct(value: t)
   }
 
-  @CustomActor init(v3: Void, t: sending T) {
+  @CustomActor init(v3: Void, t: sending T, t2: sending T) {
     self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
     self.nonisoField = SendableType()
     self.nonisoSendableField = SendableType()
     self.customField = NonSendableType()
-    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2)
     self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
     self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
 
@@ -1471,17 +385,17 @@ struct MainActorStructWithMixedFields_AO<T> {
     _ = self.nonisoField
     _ = self.nonisoSendableField
     self.customField = NonSendableType()
-    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2)
     self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
     self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
   }
 
-  @CustomActor init?(v3_failable: Void, t: sending T) {
+  @CustomActor init?(v3_failable: Void, t: sending T, t2: sending T) {
     self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
     self.nonisoField = SendableType()
     self.nonisoSendableField = SendableType()
     self.customField = NonSendableType()
-    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2)
     self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
     self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
 
@@ -1490,7 +404,7 @@ struct MainActorStructWithMixedFields_AO<T> {
     _ = self.nonisoField
     _ = self.nonisoSendableField
     self.customField = NonSendableType()
-    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2)
     self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
     self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
   }
@@ -1500,21 +414,21 @@ struct MainActorStructWithMixedFields_AO<T> {
 @MainActor
 struct GADTStructWithMixedDefaultRequirements_AO<T> {
   var _addressOnly: T // expected-note 7{{mutation of this property is only permitted within the actor}}
-  var mainDefault: NonSendableType = requiresMainActor() // expected-note 5{{main actor-isolated default value of 'self.mainDefault' cannot be used in a global actor 'CustomActor'-isolated initializer}}
-  // expected-note @-1 8{{property declared here}}
-  // expected-note @-2 5{{mutation of this property is only permitted within the actor}}
+  var mainDefault: NonSendableType = requiresMainActor() // expected-note 8{{property declared here}}
+  // expected-note @-1 5{{mutation of this property is only permitted within the actor}}
+  // expected-note @-2 5{{main actor-isolated default value of 'self.mainDefault' cannot be used in a global actor 'CustomActor'-isolated initializer}}
   var mainDefaultAO: NonSendableAOStruct<T> // expected-note 5{{mutation of this property is only permitted within the actor}}
   // expected-note @-1 8{{property declared here}}
   // expected-note @-2 2{{'self.mainDefaultAO' not initialized}}
   nonisolated let nonisoNoDefault: SendableType
   nonisolated let nonisoSendableField: SendableType
   @CustomActor var customDefault: NonSendableType = requiresCustomActor() // expected-note 7{{property declared here}}
-  // expected-note @-1 3{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a main actor-isolated initializer}}
-  // expected-note @-2 2{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a nonisolated initializer}}
-  // expected-note @-3 4{{mutation of this property is only permitted within the actor}}
-
-  @CustomActor var customDefaultAO: NonSendableAOStruct<T> // expected-note 7{{property declared here}}
   // expected-note @-1 4{{mutation of this property is only permitted within the actor}}
+  // expected-note @-2 2{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a nonisolated initializer}}
+  // expected-note @-3 3{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a main actor-isolated initializer}}
+
+  @CustomActor var customDefaultAO: NonSendableAOStruct<T> // expected-note 4{{mutation of this property is only permitted within the actor}}
+  // expected-note @-1 7{{property declared here}}
   // expected-note @-2 2{{'self.customDefaultAO' not initialized}}
 
   nonisolated func trigger() {}
@@ -1567,15 +481,14 @@ struct GADTStructWithMixedDefaultRequirements_AO<T> {
 
   // We do completely initialize. With future changes, we should be able to do
   // this.
-  @MainActor init(v1a: NonSendableType, t: sending T) {
+  @MainActor init(v1a: NonSendableType, t: sending T, t2: sending T) {
     self._addressOnly = t
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
     self.mainDefaultAO = NonSendableAOStruct(value: t)
     _ = self.mainDefault
     self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
 
     trigger()
 
@@ -1587,15 +500,14 @@ struct GADTStructWithMixedDefaultRequirements_AO<T> {
     _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
   }
 
-  @MainActor init?(v1a_failable: NonSendableType, t: sending T) {
+  @MainActor init?(v1a_failable: NonSendableType, t: sending T, t2: sending T) {
     self._addressOnly = t
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
     self.mainDefaultAO = NonSendableAOStruct(value: t)
     _ = self.mainDefault
     self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
 
     trigger()
 
@@ -1609,11 +521,11 @@ struct GADTStructWithMixedDefaultRequirements_AO<T> {
 
   // We do not completely initialize since we cannot run the default init of
   // mainDefault its initializer actually requires us to be on MainDefault.
-  @CustomActor init(v1b: NonSendableType, t: sending T) {
+  @CustomActor init(v1b: NonSendableType, t: sending T, t2: sending T) {
     self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
-    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
     _ = self.customDefault
 
     trigger() // expected-error {{variable 'self.mainDefault' used before being initialized}}
@@ -1633,11 +545,11 @@ struct GADTStructWithMixedDefaultRequirements_AO<T> {
 
   // We do not completely initialize since we cannot run the default init of
   // mainDefault its initializer actually requires us to be on MainDefault.
-  @CustomActor init(v1bb: NonSendableType, t: sending T) {
+  @CustomActor init(v1bb: NonSendableType, t: sending T, t2: sending T) {
     self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
-    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
     _ = self.customDefault
     _ = self.mainDefault // expected-error {{'self' used before all stored properties are initialized}}
     // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
@@ -1661,13 +573,13 @@ struct GADTStructWithMixedDefaultRequirements_AO<T> {
 
   // We do completely initialize. With future changes, we should be able to do
   // this.
-  @CustomActor init(v1c: NonSendableType, t: sending T) {
+  @CustomActor init(v1c: NonSendableType, t: sending T, t2: sending T) {
     self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
     self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
     self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
     _ = self.customDefault
 
     trigger()
@@ -1680,13 +592,13 @@ struct GADTStructWithMixedDefaultRequirements_AO<T> {
     _ = self.customDefaultAO
   }
 
-  @CustomActor init?(v1c_failable: NonSendableType, t: sending T) {
+  @CustomActor init?(v1c_failable: NonSendableType, t: sending T, t2: sending T) {
     self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
     self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
     self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
     _ = self.customDefault
 
     trigger()
@@ -1721,13 +633,12 @@ struct GADTStructWithMixedDefaultRequirements_AO<T> {
 
   } // expected-error {{return from initializer without initializing all stored properties}}
 
-  nonisolated init(v3: Void, t: sending T) {
+  nonisolated init(v3: Void, t: sending T, t2: sending T) {
     self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
 
@@ -1741,13 +652,12 @@ struct GADTStructWithMixedDefaultRequirements_AO<T> {
     _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
   }
 
-  nonisolated init?(v3_failable: Void, t: sending T) {
+  nonisolated init?(v3_failable: Void, t: sending T, t2: sending T) {
     self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
 
@@ -1766,26 +676,25 @@ struct GADTStructWithMixedDefaultRequirements_AO<T> {
 @MainActor
 struct GADTStructWithMixedDefaultRequirementsNonIsolatedInits_AO<T> {
   var _addressOnly: T // expected-note 6{{mutation of this property is only permitted within the actor}}
-  var mainDefault = NonSendableType() // expected-note 3{{mutation of this property is only permitted within the actor}}
-  // expected-note @-1 7{{property declared here}}
-  var mainDefaultAO: NonSendableAOStruct<T> // expected-note 6{{property declared here}}
-  // expected-note @-1 6{{mutation of this property is only permitted within the actor}}
+  var mainDefault = NonSendableType() // expected-note 7{{property declared here}}
+  // expected-note @-1 3{{mutation of this property is only permitted within the actor}}
+  var mainDefaultAO: NonSendableAOStruct<T> // expected-note 6{{mutation of this property is only permitted within the actor}}
+  // expected-note @-1 6{{property declared here}}
   nonisolated let nonisoNoDefault: SendableType
   nonisolated let nonisoSendableField: SendableType
   @CustomActor var customDefault = NonSendableType() // expected-note 7{{property declared here}}
   // expected-note @-1 {{mutation of this property is only permitted within the actor}}
-  @CustomActor var customDefaultAO: NonSendableAOStruct<T> // expected-note 5{{mutation of this property is only permitted within the actor}}
-  // expected-note @-1 5{{property declared here}}
+  @CustomActor var customDefaultAO: NonSendableAOStruct<T> // expected-note 5{{property declared here}}
+  // expected-note @-1 5{{mutation of this property is only permitted within the actor}}
 
   nonisolated func trigger() {}
 
-  @MainActor init(v1: Void, t: sending T) {
+  @MainActor init(v1: Void, t: sending T, t2: sending T) {
     self._addressOnly = t
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
     self.mainDefaultAO = NonSendableAOStruct(value: t)
-    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
     _ = self.mainDefault
     _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
 
@@ -1799,13 +708,12 @@ struct GADTStructWithMixedDefaultRequirementsNonIsolatedInits_AO<T> {
     _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
   }
 
-  @MainActor init?(v1_failable: Void, t: sending T) {
+  @MainActor init?(v1_failable: Void, t: sending T, t2: sending T) {
     self._addressOnly = t
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
     self.mainDefaultAO = NonSendableAOStruct(value: t)
-    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
     _ = self.mainDefault
     _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
 
@@ -1820,12 +728,12 @@ struct GADTStructWithMixedDefaultRequirementsNonIsolatedInits_AO<T> {
   }
 
   // OK: explicitly initializes all fields
-  @CustomActor init(v1a: Void, t: sending T) {
+  @CustomActor init(v1a: Void, t: sending T, t2: sending T) {
     self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
     self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
     _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
     _ = self.customDefault
 
@@ -1839,33 +747,14 @@ struct GADTStructWithMixedDefaultRequirementsNonIsolatedInits_AO<T> {
     _ = self.customDefaultAO
   }
 
-  @CustomActor init(v1b: Void, t: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.nonisoNoDefault = SendableType()
-    self.nonisoSendableField = SendableType()
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.customDefault = NonSendableType()
-    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
-
-    trigger()
-
-    _ = self.nonisoNoDefault
-    _ = self.nonisoSendableField
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    _ = self.customDefault
-    _ = self.customDefaultAO
-  }
-
-  @CustomActor init?(v1b_failable: Void, t: sending T) {
+  @CustomActor init(v1b: Void, t: sending T, t2: sending T) {
     self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
     self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
     self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
     self.customDefault = NonSendableType()
-    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
 
     trigger()
 
@@ -1877,13 +766,31 @@ struct GADTStructWithMixedDefaultRequirementsNonIsolatedInits_AO<T> {
     _ = self.customDefaultAO
   }
 
-  nonisolated init(v2: Void, t: sending T) {
+  @CustomActor init?(v1b_failable: Void, t: sending T, t2: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.customDefault = NonSendableType()
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
+    _ = self.customDefaultAO
+  }
+
+  nonisolated init(v2: Void, t: sending T, t2: sending T) {
     self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
     self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
 
     trigger()
 
@@ -1895,13 +802,12 @@ struct GADTStructWithMixedDefaultRequirementsNonIsolatedInits_AO<T> {
     _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
   }
 
-  nonisolated init?(v2_failable: Void, t: sending T) {
+  nonisolated init?(v2_failable: Void, t: sending T, t2: sending T) {
     self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
     self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
 
     trigger()
 
@@ -1913,15 +819,14 @@ struct GADTStructWithMixedDefaultRequirementsNonIsolatedInits_AO<T> {
     _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
   }
 
-  nonisolated init(v2a: Void, t: sending T) {
+  nonisolated init(v2a: Void, t: sending T, t2: sending T) {
     self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
     self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
 
     trigger()
 
@@ -1993,10 +898,10 @@ struct GADTStructWithMixedDefaultRequirements_NC: ~Copyable {
 
 
   nonisolated let nonisoNoDefault: SendableType
-  @CustomActor var customDefault: NonSendableType = requiresCustomActor() // expected-note 3{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a nonisolated initializer}}
-  // expected-note @-1 4{{property declared here}}
-  // expected-note @-2 3{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a main actor-isolated initializer}}
-  // expected-note @-3 2{{mutation of this property is only permitted within the actor}}
+  @CustomActor var customDefault: NonSendableType = requiresCustomActor() // expected-note 4{{property declared here}}
+  // expected-note @-1 3{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a main actor-isolated initializer}}
+  // expected-note @-2 2{{mutation of this property is only permitted within the actor}}
+  // expected-note @-3 3{{global actor 'CustomActor'-isolated default value of 'self.customDefault' cannot be used in a nonisolated initializer}}
 
 
 
@@ -2108,8 +1013,8 @@ struct GADTStructWithMixedDefaultRequirements_NC: ~Copyable {
 @available(SwiftStdlib 5.5, *)
 @MainActor
 struct GADTStructWithMixedDefaultRequirementsNonIsolatedInits_NC: ~Copyable {
-  var mainDefault = NonSendableType() // expected-note 5{{property declared here}}
-  // expected-note @-1 2{{mutation of this property is only permitted within the actor}}
+  var mainDefault = NonSendableType() // expected-note 2{{mutation of this property is only permitted within the actor}}
+  // expected-note @-1 5{{property declared here}}
 
   nonisolated let nonisoNoDefault: SendableType
   @CustomActor var customDefault = NonSendableType() // expected-note 4{{property declared here}}
@@ -2195,13 +1100,12 @@ struct MainActorStructWithMixedFields_AO_NC<T>: ~Copyable {
 
   nonisolated func trigger() {}
 
-  nonisolated init(v1: Void, t: sending T) {
+  nonisolated init(v1: Void, t: sending T, t2: sending T) {
     self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.nonisoField = SendableType()
     self.nonisoSendableField = SendableType()
     self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
 
@@ -2210,19 +1114,17 @@ struct MainActorStructWithMixedFields_AO_NC<T>: ~Copyable {
     _ = self.nonisoField
     _ = self.nonisoSendableField
     self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
   }
 
-  nonisolated init?(v1_failable: Void, t: sending T) {
+  nonisolated init?(v1_failable: Void, t: sending T, t2: sending T) {
     self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.nonisoField = SendableType()
     self.nonisoSendableField = SendableType()
     self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
 
@@ -2231,19 +1133,17 @@ struct MainActorStructWithMixedFields_AO_NC<T>: ~Copyable {
     _ = self.nonisoField
     _ = self.nonisoSendableField
     self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
   }
 
-  @MainActor init(v2: Void, t: sending T) {
+  @MainActor init(v2: Void, t: sending T, t2: sending T) {
     self._addressOnly = t
     self.nonisoField = SendableType()
     self.nonisoSendableField = SendableType()
     self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
     self.mainField = NonSendableType()
     self.mainFieldAO = NonSendableAOStruct(value: t)
 
@@ -2252,19 +1152,17 @@ struct MainActorStructWithMixedFields_AO_NC<T>: ~Copyable {
     _ = self.nonisoField
     _ = self.nonisoSendableField
     self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
     self.mainField = NonSendableType()
     self.mainFieldAO = NonSendableAOStruct(value: t)
   }
 
-  @MainActor init?(v2_failable: Void, t: sending T) {
+  @MainActor init?(v2_failable: Void, t: sending T, t2: sending T) {
     self._addressOnly = t
     self.nonisoField = SendableType()
     self.nonisoSendableField = SendableType()
     self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
     self.mainField = NonSendableType()
     self.mainFieldAO = NonSendableAOStruct(value: t)
 
@@ -2273,18 +1171,17 @@ struct MainActorStructWithMixedFields_AO_NC<T>: ~Copyable {
     _ = self.nonisoField
     _ = self.nonisoSendableField
     self.customField = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customField' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customFieldAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
     self.mainField = NonSendableType()
     self.mainFieldAO = NonSendableAOStruct(value: t)
   }
 
-  @CustomActor init(v3: Void, t: sending T) {
+  @CustomActor init(v3: Void, t: sending T, t2: sending T) {
     self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
     self.nonisoField = SendableType()
     self.nonisoSendableField = SendableType()
     self.customField = NonSendableType()
-    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2)
     self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
     self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
 
@@ -2293,17 +1190,17 @@ struct MainActorStructWithMixedFields_AO_NC<T>: ~Copyable {
     _ = self.nonisoField
     _ = self.nonisoSendableField
     self.customField = NonSendableType()
-    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2)
     self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
     self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
   }
 
-  @CustomActor init?(v3_failable: Void, t: sending T) {
+  @CustomActor init?(v3_failable: Void, t: sending T, t2: sending T) {
     self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
     self.nonisoField = SendableType()
     self.nonisoSendableField = SendableType()
     self.customField = NonSendableType()
-    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2)
     self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
     self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
 
@@ -2312,7 +1209,7 @@ struct MainActorStructWithMixedFields_AO_NC<T>: ~Copyable {
     _ = self.nonisoField
     _ = self.nonisoSendableField
     self.customField = NonSendableType()
-    self.customFieldAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customFieldAO = NonSendableAOStruct(value: t2)
     self.mainField = NonSendableType() // expected-warning {{main actor-isolated property 'mainField' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
     self.mainFieldAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainFieldAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
   }
@@ -2332,8 +1229,8 @@ struct GADTStructWithMixedDefaultRequirements_AO_NC<T>: ~Copyable {
   @CustomActor var customDefault: NonSendableType = requiresCustomActor() // expected-note 4{{mutation of this property is only permitted within the actor}}
   // expected-note @-1 7{{property declared here}}
 
-  @CustomActor var customDefaultAO: NonSendableAOStruct<T> // expected-note 4{{mutation of this property is only permitted within the actor}}
-  // expected-note @-1 7{{property declared here}}
+  @CustomActor var customDefaultAO: NonSendableAOStruct<T> // expected-note 7{{property declared here}}
+  // expected-note @-1 4{{mutation of this property is only permitted within the actor}}
 
   nonisolated func trigger() {}
 
@@ -2381,15 +1278,14 @@ struct GADTStructWithMixedDefaultRequirements_AO_NC<T>: ~Copyable {
 
   // We do completely initialize. With future changes, we should be able to do
   // this.
-  @MainActor init(v1a: NonSendableType, t: sending T) {
+  @MainActor init(v1a: NonSendableType, t: sending T, t2: sending T) {
     self._addressOnly = t
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
     self.mainDefaultAO = NonSendableAOStruct(value: t)
     _ = self.mainDefault
     self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
 
     trigger()
 
@@ -2401,15 +1297,14 @@ struct GADTStructWithMixedDefaultRequirements_AO_NC<T>: ~Copyable {
     _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
   }
 
-  @MainActor init?(v1a_failable: NonSendableType, t: sending T) {
+  @MainActor init?(v1a_failable: NonSendableType, t: sending T, t2: sending T) {
     self._addressOnly = t
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
     self.mainDefaultAO = NonSendableAOStruct(value: t)
     _ = self.mainDefault
     self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
 
     trigger()
 
@@ -2423,11 +1318,11 @@ struct GADTStructWithMixedDefaultRequirements_AO_NC<T>: ~Copyable {
 
   // We do not completely initialize since we cannot run the default init of
   // mainDefault its initializer actually requires us to be on MainDefault.
-  @CustomActor init(v1b: NonSendableType, t: sending T) {
+  @CustomActor init(v1b: NonSendableType, t: sending T, t2: sending T) {
     self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
-    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
     _ = self.customDefault
 
     trigger() // expected-error {{variable 'self.mainDefault' used before being initialized}}
@@ -2445,11 +1340,11 @@ struct GADTStructWithMixedDefaultRequirements_AO_NC<T>: ~Copyable {
 
   // We do not completely initialize since we cannot run the default init of
   // mainDefault its initializer actually requires us to be on MainDefault.
-  @CustomActor init(v1bb: NonSendableType, t: sending T) {
+  @CustomActor init(v1bb: NonSendableType, t: sending T, t2: sending T) {
     self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
-    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
     _ = self.customDefault
     _ = self.mainDefault // expected-error {{'self' used before all stored properties are initialized}}
     // expected-warning @-1 {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
@@ -2471,13 +1366,13 @@ struct GADTStructWithMixedDefaultRequirements_AO_NC<T>: ~Copyable {
 
   // We do completely initialize. With future changes, we should be able to do
   // this.
-  @CustomActor init(v1c: NonSendableType, t: sending T) {
+  @CustomActor init(v1c: NonSendableType, t: sending T, t2: sending T) {
     self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
     self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
     self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
     _ = self.customDefault
 
     trigger()
@@ -2490,13 +1385,13 @@ struct GADTStructWithMixedDefaultRequirements_AO_NC<T>: ~Copyable {
     _ = self.customDefaultAO
   }
 
-  @CustomActor init?(v1c_failable: NonSendableType, t: sending T) {
+  @CustomActor init?(v1c_failable: NonSendableType, t: sending T, t2: sending T) {
     self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
     self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
     self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
     _ = self.customDefault
 
     trigger()
@@ -2529,13 +1424,12 @@ struct GADTStructWithMixedDefaultRequirements_AO_NC<T>: ~Copyable {
 
   }
 
-  nonisolated init(v3: Void, t: sending T) {
+  nonisolated init(v3: Void, t: sending T, t2: sending T) {
     self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
 
@@ -2549,13 +1443,12 @@ struct GADTStructWithMixedDefaultRequirements_AO_NC<T>: ~Copyable {
     _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
   }
 
-  nonisolated init?(v3_failable: Void, t: sending T) {
+  nonisolated init?(v3_failable: Void, t: sending T, t2: sending T) {
     self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
 
@@ -2574,26 +1467,25 @@ struct GADTStructWithMixedDefaultRequirements_AO_NC<T>: ~Copyable {
 @MainActor
 struct GADTStructWithMixedDefaultRequirementsNonIsolatedInits_AO_NC<T>: ~Copyable {
   var _addressOnly: T // expected-note 6{{mutation of this property is only permitted within the actor}}
-  var mainDefault = NonSendableType() // expected-note 7{{property declared here}}
-  // expected-note @-1 3{{mutation of this property is only permitted within the actor}}
+  var mainDefault = NonSendableType() // expected-note 3{{mutation of this property is only permitted within the actor}}
+  // expected-note @-1 7{{property declared here}}
   var mainDefaultAO: NonSendableAOStruct<T> // expected-note 6{{property declared here}}
   // expected-note @-1 6{{mutation of this property is only permitted within the actor}}
   nonisolated let nonisoNoDefault: SendableType
   nonisolated let nonisoSendableField: SendableType
   @CustomActor var customDefault = NonSendableType() // expected-note 7{{property declared here}}
   // expected-note @-1 {{mutation of this property is only permitted within the actor}}
-  @CustomActor var customDefaultAO: NonSendableAOStruct<T> // expected-note 5{{property declared here}}
-  // expected-note @-1 5{{mutation of this property is only permitted within the actor}}
+  @CustomActor var customDefaultAO: NonSendableAOStruct<T> // expected-note 5{{mutation of this property is only permitted within the actor}}
+  // expected-note @-1 5{{property declared here}}
 
   nonisolated func trigger() {}
 
-  @MainActor init(v1: Void, t: sending T) {
+  @MainActor init(v1: Void, t: sending T, t2: sending T) {
     self._addressOnly = t
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
     self.mainDefaultAO = NonSendableAOStruct(value: t)
-    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
     _ = self.mainDefault
     _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
 
@@ -2607,13 +1499,12 @@ struct GADTStructWithMixedDefaultRequirementsNonIsolatedInits_AO_NC<T>: ~Copyabl
     _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
   }
 
-  @MainActor init?(v1_failable: Void, t: sending T) {
+  @MainActor init?(v1_failable: Void, t: sending T, t2: sending T) {
     self._addressOnly = t
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
     self.mainDefaultAO = NonSendableAOStruct(value: t)
-    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
     _ = self.mainDefault
     _ = self.customDefault // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
 
@@ -2628,12 +1519,12 @@ struct GADTStructWithMixedDefaultRequirementsNonIsolatedInits_AO_NC<T>: ~Copyabl
   }
 
   // OK: explicitly initializes all fields
-  @CustomActor init(v1a: Void, t: sending T) {
+  @CustomActor init(v1a: Void, t: sending T, t2: sending T) {
     self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
     self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
     _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
     _ = self.customDefault
 
@@ -2647,33 +1538,14 @@ struct GADTStructWithMixedDefaultRequirementsNonIsolatedInits_AO_NC<T>: ~Copyabl
     _ = self.customDefaultAO
   }
 
-  @CustomActor init(v1b: Void, t: sending T) {
-    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.nonisoNoDefault = SendableType()
-    self.nonisoSendableField = SendableType()
-    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    self.customDefault = NonSendableType()
-    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
-
-    trigger()
-
-    _ = self.nonisoNoDefault
-    _ = self.nonisoSendableField
-    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
-    _ = self.customDefault
-    _ = self.customDefaultAO
-  }
-
-  @CustomActor init?(v1b_failable: Void, t: sending T) {
+  @CustomActor init(v1b: Void, t: sending T, t2: sending T) {
     self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
     self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
     self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
     self.customDefault = NonSendableType()
-    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
 
     trigger()
 
@@ -2685,13 +1557,31 @@ struct GADTStructWithMixedDefaultRequirementsNonIsolatedInits_AO_NC<T>: ~Copyabl
     _ = self.customDefaultAO
   }
 
-  nonisolated init(v2: Void, t: sending T) {
+  @CustomActor init?(v1b_failable: Void, t: sending T, t2: sending T) {
+    self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.nonisoNoDefault = SendableType()
+    self.nonisoSendableField = SendableType()
+    self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    self.customDefault = NonSendableType()
+    self.customDefaultAO = NonSendableAOStruct(value: t2)
+
+    trigger()
+
+    _ = self.nonisoNoDefault
+    _ = self.nonisoSendableField
+    _ = self.mainDefault // expected-warning {{main actor-isolated property 'mainDefault' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.mainDefaultAO // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be referenced from global actor 'CustomActor'; this is an error in the Swift 6 language mode}}
+    _ = self.customDefault
+    _ = self.customDefaultAO
+  }
+
+  nonisolated init(v2: Void, t: sending T, t2: sending T) {
     self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
     self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
 
     trigger()
 
@@ -2703,13 +1593,12 @@ struct GADTStructWithMixedDefaultRequirementsNonIsolatedInits_AO_NC<T>: ~Copyabl
     _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
   }
 
-  nonisolated init?(v2_failable: Void, t: sending T) {
+  nonisolated init?(v2_failable: Void, t: sending T, t2: sending T) {
     self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
     self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
 
     trigger()
 
@@ -2721,15 +1610,14 @@ struct GADTStructWithMixedDefaultRequirementsNonIsolatedInits_AO_NC<T>: ~Copyabl
     _ = self.customDefaultAO // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
   }
 
-  nonisolated init(v2a: Void, t: sending T) {
+  nonisolated init(v2a: Void, t: sending T, t2: sending T) {
     self._addressOnly = t // expected-warning {{main actor-isolated property '_addressOnly' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.nonisoNoDefault = SendableType()
     self.nonisoSendableField = SendableType()
     self.mainDefault = NonSendableType() // expected-warning {{main actor-isolated property 'mainDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.mainDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{main actor-isolated property 'mainDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.customDefault = NonSendableType() // expected-warning {{global actor 'CustomActor'-isolated property 'customDefault' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.customDefaultAO = NonSendableAOStruct(value: t) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    // expected-warning @-1 {{pattern that the region-based isolation checker does not understand how to check. Please file a bug; this is an error in the Swift 6 language mode}}
+    self.customDefaultAO = NonSendableAOStruct(value: t2) // expected-warning {{global actor 'CustomActor'-isolated property 'customDefaultAO' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
 
     trigger()
 
@@ -2742,223 +1630,3 @@ struct GADTStructWithMixedDefaultRequirementsNonIsolatedInits_AO_NC<T>: ~Copyabl
   }
 }
 
-
-////////////////////////////////////////////////////
-// MARK: Enum Variants                            //
-////////////////////////////////////////////////////
-
-@available(SwiftStdlib 5.1, *)
-@MainActor
-enum MainActorEnumWithPayloads {
-  case sendable(SendableType)
-  case nonSendable(NonSendableType)
-
-  nonisolated func trigger() {}
-  nonisolated var nonisoComputed: Int { 0 }
-
-  nonisolated init(v1: Void) {
-    self = .nonSendable(NonSendableType())
-
-    trigger()
-
-    _ = self.nonisoComputed
-    self = .nonSendable(NonSendableType())
-  }
-
-  @MainActor init(v2: Void) {
-    self = .nonSendable(NonSendableType())
-
-    trigger()
-
-    _ = self.nonisoComputed
-    self = .nonSendable(NonSendableType())
-  }
-
-  @CustomActor init(v3: Void) {
-    self = .nonSendable(NonSendableType())
-
-    trigger()
-
-    _ = self.nonisoComputed
-    self = .nonSendable(NonSendableType())
-  }
-}
-
-////////////////////////////////////////////////////
-// MARK: Noncopyable Enum Variants                //
-////////////////////////////////////////////////////
-
-@available(SwiftStdlib 5.1, *)
-@MainActor
-enum MainActorEnumWithPayloads_NC: ~Copyable {
-  case sendable(SendableType)
-  case nonSendable(NonSendableType)
-
-  nonisolated func trigger() {}
-  nonisolated var nonisoComputed: Int { 0 }
-
-  nonisolated init(v1: Void) {
-    self = .nonSendable(NonSendableType())
-
-    trigger()
-
-    _ = self.nonisoComputed
-    self = .nonSendable(NonSendableType())
-  }
-
-  @MainActor init(v2: Void) {
-    self = .nonSendable(NonSendableType())
-
-    trigger()
-
-    _ = self.nonisoComputed
-    self = .nonSendable(NonSendableType())
-  }
-
-  @CustomActor init(v3: Void) {
-    self = .nonSendable(NonSendableType())
-
-    trigger()
-
-    _ = self.nonisoComputed
-    self = .nonSendable(NonSendableType())
-  }
-}
-
-////////////////////////////////////////////////////
-// MARK: Address Only Enum Variants               //
-////////////////////////////////////////////////////
-
-@available(SwiftStdlib 5.1, *)
-@MainActor
-enum MainActorEnumWithPayloads_AO<T> {
-  case sendable(SendableType)
-  case nonSendable(NonSendableType)
-  case addressOnly(NonSendableAOStruct<T>)
-
-  nonisolated func trigger() {}
-  nonisolated var nonisoComputed: Int { 0 }
-
-  nonisolated init(v1: Void, t: sending T) {
-    self = .addressOnly(NonSendableAOStruct(value: t))
-
-    trigger()
-
-    _ = self.nonisoComputed
-    self = .nonSendable(NonSendableType())
-  }
-
-  nonisolated init?(v1_failable: Void, t: sending T) {
-    self = .addressOnly(NonSendableAOStruct(value: t))
-
-    trigger()
-
-    _ = self.nonisoComputed
-    self = .nonSendable(NonSendableType())
-  }
-
-  @MainActor init(v2: Void, t: sending T) {
-    self = .addressOnly(NonSendableAOStruct(value: t))
-
-    trigger()
-
-    _ = self.nonisoComputed
-    self = .nonSendable(NonSendableType())
-  }
-
-  @MainActor init?(v2_failable: Void, t: sending T) {
-    self = .addressOnly(NonSendableAOStruct(value: t))
-
-    trigger()
-
-    _ = self.nonisoComputed
-    self = .nonSendable(NonSendableType())
-  }
-
-  @CustomActor init(v3: Void, t: sending T) {
-    self = .addressOnly(NonSendableAOStruct(value: t))
-
-    trigger()
-
-    _ = self.nonisoComputed
-    self = .nonSendable(NonSendableType())
-  }
-
-  @CustomActor init?(v3_failable: Void, t: sending T) {
-    self = .addressOnly(NonSendableAOStruct(value: t))
-
-    trigger()
-
-    _ = self.nonisoComputed
-    self = .nonSendable(NonSendableType())
-  }
-}
-
-////////////////////////////////////////////////////
-// MARK: Address Only Noncopyable Enum Variants   //
-////////////////////////////////////////////////////
-
-@available(SwiftStdlib 5.1, *)
-@MainActor
-enum MainActorEnumWithPayloads_AO_NC<T>: ~Copyable {
-  case sendable(SendableType)
-  case nonSendable(NonSendableType)
-  case addressOnly(NonSendableAOStruct<T>)
-
-  nonisolated func trigger() {}
-  nonisolated var nonisoComputed: Int { 0 }
-
-  nonisolated init(v1: Void, t: sending T) {
-    self = .addressOnly(NonSendableAOStruct(value: t))
-
-    trigger()
-
-    _ = self.nonisoComputed
-    self = .nonSendable(NonSendableType())
-  }
-
-  nonisolated init?(v1_failable: Void, t: sending T) {
-    self = .addressOnly(NonSendableAOStruct(value: t))
-
-    trigger()
-
-    _ = self.nonisoComputed
-    self = .nonSendable(NonSendableType())
-  }
-
-  @MainActor init(v2: Void, t: sending T) {
-    self = .addressOnly(NonSendableAOStruct(value: t))
-
-    trigger()
-
-    _ = self.nonisoComputed
-    self = .nonSendable(NonSendableType())
-  }
-
-  @MainActor init?(v2_failable: Void, t: sending T) {
-    self = .addressOnly(NonSendableAOStruct(value: t))
-
-    trigger()
-
-    _ = self.nonisoComputed
-    self = .nonSendable(NonSendableType())
-  }
-
-  @CustomActor init(v3: Void, t: sending T) {
-    self = .addressOnly(NonSendableAOStruct(value: t))
-
-    trigger()
-
-    _ = self.nonisoComputed
-    self = .nonSendable(NonSendableType())
-  }
-
-  @CustomActor init?(v3_failable: Void, t: sending T) {
-    self = .addressOnly(NonSendableAOStruct(value: t))
-
-    trigger()
-
-    _ = self.nonisoComputed
-    self = .nonSendable(NonSendableType())
-  }
-}

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -334,14 +334,12 @@ struct WrapperOnActor<Wrapped: Sendable> {
 public struct WrapperOnMainActor<Wrapped> {
   // Make sure inference of @MainActor on wrappedValue doesn't crash.
   
-  // expected-note@+1 {{mutation of this property is only permitted within the actor}}
-  public var wrappedValue: Wrapped
+  public var wrappedValue: Wrapped // expected-minimal-targeted-note {{mutation of this property is only permitted within the actor}}
 
   public var accessCount: Int
 
   nonisolated public init(wrappedValue: Wrapped) {
-    // expected-warning@+1 {{main actor-isolated property 'wrappedValue' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-    self.wrappedValue = wrappedValue
+    self.wrappedValue = wrappedValue // expected-minimal-targeted-warning {{main actor-isolated property 'wrappedValue' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
   }
 }
 

--- a/test/Concurrency/global_actor_inference_swift6.swift
+++ b/test/Concurrency/global_actor_inference_swift6.swift
@@ -67,13 +67,11 @@ struct WrapperOnActor<Wrapped: Sendable> {
 public struct WrapperOnMainActor<Wrapped> {
   // Make sure inference of @MainActor on wrappedValue doesn't crash.
 
-  // expected-note@+1 {{mutation of this property is only permitted within the actor}}
   public var wrappedValue: Wrapped // expected-note {{property declared here}}
 
   public var accessCount: Int
 
   nonisolated public init(wrappedValue: Wrapped) {
-    // expected-error@+1 {{main actor-isolated property 'wrappedValue' can not be mutated from a nonisolated context}}
     self.wrappedValue = wrappedValue
   }
 }

--- a/test/Concurrency/nonisolated_rules.swift
+++ b/test/Concurrency/nonisolated_rules.swift
@@ -85,9 +85,9 @@ nonisolated struct StructRemovesGlobalActor: GloballyIsolated {
   }
 
   struct Nested: GloballyIsolated {
-    var z: NonSendable // expected-note {{mutation of this property is only permitted within the actor}}
+    var z: NonSendable
     nonisolated init(z: NonSendable) {
-      self.z = z // expected-error {{main actor-isolated property 'z' can not be mutated from a nonisolated context}}
+      self.z = z
     }
   }
 }


### PR DESCRIPTION
[flow-isolation] Add support for global-actor-isolated nominal type initializers

Previously, flow-sensitive isolation checking only applied to actor instance
initializers. This extends it to cover initializers of global-actor-isolated
nominal types (structs, classes).

rdar://131136194

