### PR TITLE
[cxx-interop] Improve interface of `std::optional`

### DIFF
--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -858,12 +858,9 @@ static void conformToCxxOptional(ClangImporter::Implementation &impl,
   if (!Wrapped)
     return;
 
-  if (!impl.lookupAndImportPointee(decl))
+  auto pointee = impl.lookupAndImportPointee(decl);
+  if (!pointee)
     return;
-
-  impl.addSynthesizedTypealias(decl, ctx.getIdentifier("Wrapped"),
-                               Wrapped->getUnderlyingType());
-  impl.addSynthesizedProtocolAttrs(decl, {KnownProtocolKind::CxxOptional});
 
   // `std::optional` has a C++ constructor that takes the wrapped value as a
   // parameter. Unfortunately this constructor has templated parameter type, so
@@ -918,6 +915,18 @@ static void conformToCxxOptional(ClangImporter::Implementation &impl,
   if (!importedConstructor)
     return;
   decl->addMember(importedConstructor);
+
+  // Mark `var pointee` as deprecated to direct users towards `var value`, which
+  // is provided by the Cxx overlay. It supports mutation and is UB-safe. Only
+  // do so if `value` is actually available, i.e. if the conformance to
+  // CxxOptional was synthesized.
+  auto pointeeDeprecatedAttr = AvailableAttr::createUniversallyDeprecated(
+      ctx, "use 'value' instead for instances of 'std.optional'", "value");
+  pointee->addAttribute(pointeeDeprecatedAttr);
+
+  impl.addSynthesizedTypealias(decl, ctx.getIdentifier("Wrapped"),
+                               Wrapped->getUnderlyingType());
+  impl.addSynthesizedProtocolAttrs(decl, {KnownProtocolKind::CxxOptional});
 }
 
 static void conformToCxxBorrowingSequenceIfNeeded(

--- a/stdlib/public/Cxx/CxxOptional.swift
+++ b/stdlib/public/Cxx/CxxOptional.swift
@@ -15,6 +15,8 @@ public protocol CxxOptional<Wrapped>: ExpressibleByNilLiteral {
 
   init()
 
+  init(_ value: Wrapped)
+
   func __convertToBool() -> Bool
 
   var pointee: Wrapped { get }
@@ -37,6 +39,13 @@ extension CxxOptional {
     get {
       guard hasValue else { return nil }
       return pointee
+    }
+    set(newValue) {
+      if let newValueNonNull = newValue {
+        self = Self.init(newValueNonNull)
+      } else {
+        self = Self.init()
+      }
     }
   }
 }

--- a/test/Interop/Cxx/stdlib/use-std-optional-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-optional-typechecker.swift
@@ -5,5 +5,16 @@ import CxxStdlib
 
 func takeCopyable<T: Copyable>(_ x: T) {} // expected-note {{'where T: Copyable' is implicit here}}
 
+func takeCxxOptional<T: CxxOptional>(_ x: T) {
+  _ = x.hasValue
+}
+
+let nonNilCopyable = getNonNilOptional()
+takeCxxOptional(nonNilCopyable)
+takeCopyable(nonNilCopyable)
+var _ = nonNilCopyable.pointee // expected-warning {{'pointee' is deprecated: use 'value' instead}}
+// expected-note@-1 {{use 'value' instead}}
+
 let nonNilOptNonCopyable = getNonNilOptionalHasDeletedCopyCtor()
 takeCopyable(nonNilOptNonCopyable) // expected-error {{conform to 'Copyable'}}
+var _ = nonNilOptNonCopyable.pointee

--- a/test/Interop/Cxx/stdlib/use-std-optional.swift
+++ b/test/Interop/Cxx/stdlib/use-std-optional.swift
@@ -22,12 +22,6 @@ StdOptionalTestSuite.test("pointee") {
   let pointee = nonNilOpt.pointee
   expectEqual(123, pointee)
 
-#if !os(Linux) && !os(FreeBSD) // crashes on Ubuntu 18.04 (rdar://113414160)
-  var modifiedOpt = getNilOptional()
-  modifiedOpt.pointee = 777
-  expectEqual(777, modifiedOpt.pointee)
-#endif
-
   let nonNilOptNonCopyable = getNonNilOptionalHasDeletedCopyCtor()
   expectEqual(654, nonNilOptNonCopyable.pointee.value)
 }
@@ -51,6 +45,20 @@ StdOptionalTestSuite.test("std::optional hasValue/value") {
   let nilOpt = getNilOptional()
   expectFalse(nilOpt.hasValue)
   expectNil(nilOpt.value)
+}
+
+StdOptionalTestSuite.test("std::optional value setter") {
+  var nonNilOpt = getNonNilOptional()
+  nonNilOpt.value = 321
+  expectEqual(321, nonNilOpt.value!)
+  nonNilOpt.value = 456
+  expectEqual(456, nonNilOpt.value!)
+  nonNilOpt.value = nil
+  expectNil(nonNilOpt.value)
+
+  var nilOpt = getNilOptional()
+  nilOpt.value = 321
+  expectEqual(321, nilOpt.value!)
 }
 
 StdOptionalTestSuite.test("std::optional as ExpressibleByNilLiteral") {


### PR DESCRIPTION
We've seen multiple reports of `std::optional`'s behavior in Swift being confusing. In particular, creating an instance of `std::optional` without a value, and then assigning a value to it via `myOpt.pointee = ...` does not actually persist the non-nil value inside of the `std::optional`.

This behavior was consistent with the design: the setter for `var pointee` in Swift is synthesized from `operator*()` imported from C++. In C++, if `std::optional` does not contain a value, the behavior of its `operator*()` is undefined.

https://en.cppreference.com/w/cpp/utility/optional/operator%252A.html

Swift already conforms instantiations of `std::optional` to `protocol CxxOptional`, which declares `var value` property that provides UB-safe access to the wrapped element. That property was immutable. This change makes it mutable by adding a setter, and introduces a deprecation annotation to direct users to use `value` instead of `pointee`.

Note that currently `CxxOptional` does not support non-copyable types.

rdar://129159672 / resolves https://github.com/swiftlang/swift/issues/74090

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
