### PR TITLE
update-checkout: bump wasi-sdk to 31

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -190,7 +190,7 @@
                 "swift-nio": "2.92.2",
                 "swift-experimental-string-processing": "main",
                 "swift-sdk-generator": "main",
-                "wasi-libc": "wasi-sdk-27",
+                "wasi-libc": "wasi-sdk-31",
                 "wasmkit": "0.2.0",
                 "curl": "curl-8_9_1",
                 "libxml2": "v2.11.5",


### PR DESCRIPTION
Update the WASI libc version to the latest release. This is required to enable building the WASI SDK on Windows.