### PR TITLE
tests: disable IRGen/exactcast.sil for arm64e

### DIFF
--- a/test/IRGen/exactcast.sil
+++ b/test/IRGen/exactcast.sil
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend -enable-objc-interop -emit-ir %s | %FileCheck %s -check-prefix CHECK -check-prefix CHECK-%target-import-type
 
 // REQUIRES: PTRSIZE=64
+// UNSUPPORTED: CPU=arm64e
 
 sil_stage canonical
 


### PR DESCRIPTION
Match lines don't consider ptrauth

rdar://172272905
