### PR TITLE
Disable device testing: Interpreter/bitwise_borrowable_layout.swift

### DIFF
--- a/test/Interpreter/bitwise_borrowable_layout.swift
+++ b/test/Interpreter/bitwise_borrowable_layout.swift
@@ -18,6 +18,9 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
+// rdar://169663198: test crashes when running on device
+// UNSUPPORTED: remote_run || device_run
+
 import BitwiseBorrowableLayoutResilientTypes
 
 struct NonBitwiseTakable {


### PR DESCRIPTION
Workaround for rdar://169663198: test crashes when running on device

