### PR TITLE
[TypeChecker] PropertyWrappers: Accept key path with marker protocols…

### DIFF
--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -23,6 +23,7 @@
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/PropertyWrappers.h"
 #include "swift/AST/TypeCheckRequests.h"
+#include "swift/AST/Types.h"
 #include "swift/Basic/Assertions.h"
 using namespace swift;
 
@@ -340,6 +341,21 @@ static bool validateEnclosingSelfSubscript(SubscriptDecl *subscript) {
     auto paramTy = param->getInterfaceType();
     if (paramTy->hasError())
       return true;
+
+    // Strip off marker protocols from the type, other APIs associated with
+    // key paths allow compositions with `Sendable` and custom marker protocols
+    // so we need to follow suit here as well.
+    if (auto *existential = paramTy->getAs<ExistentialType>()) {
+      if (auto *compositionTy = existential->getConstraintType()
+                                    ->getAs<ProtocolCompositionType>()) {
+        auto newType = compositionTy->withoutMarkerProtocols();
+        if (!newType->isEqual(compositionTy)) {
+          paramTy = newType->getClassOrBoundGenericClass()
+                        ? newType
+                        : ExistentialType::get(newType);
+        }
+      }
+    }
 
     if (!(paramTy->isKeyPath() || paramTy->isWritableKeyPath() ||
           paramTy->isReferenceWritableKeyPath())) {

--- a/test/Concurrency/sendable_keypaths.swift
+++ b/test/Concurrency/sendable_keypaths.swift
@@ -313,3 +313,28 @@ public final class TestSetterRef {
   // expected-swift5-warning@-1 {{setter for property 'v' is internal and should not be referenced from a default argument value}}
   // expected-swift6-error@-2 {{setter for property 'v' is internal and cannot be referenced from a default argument value}}
 }
+
+// Property wrapper declaration with Sendable key paths
+do {
+  @propertyWrapper
+  struct Wrapper<Value> {
+    public init(wrappedValue: Value) {}
+    public var wrappedValue: Value {
+      get { fatalError() }
+      set {}
+    }
+
+    static subscript<EnclosingSelf>(
+      _enclosingInstance object: EnclosingSelf,
+      wrapped wrappedKeyPath: KeyPath<EnclosingSelf, Int> & Sendable,
+      storage storageKeyPath: any WritableKeyPath<EnclosingSelf, Wrapper<Int>> & Sendable
+    ) -> Value {
+      get { fatalError() }
+      set {}
+    }
+  }
+
+  final class Test: @unchecked Sendable {
+    @Wrapper var value: Int = 0 // Ok
+  }
+}


### PR DESCRIPTION
… in parameter of enclosing-self subscript

It should be possible to spell `& Sendable` and custom marker protocols on the `wrapped:` and `storage:` parameters just like we allow in dynamic members, we discovered some existing code that relies on that as well.

Resolves: rdar://172490802

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
