### PR TITLE
[cas] Adapt to clang::CASOptions change to remove internal cache of instances

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -24,13 +24,13 @@
 #include "swift/Basic/CXXStdlibKind.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Serialization/Validation.h"
-#include "clang/CAS/CASOptions.h"
 #include "clang/Tooling/DependencyScanning/DependencyScanningService.h"
 #include "clang/Tooling/DependencyScanning/DependencyScanningTool.h"
 #include "clang/Tooling/DependencyScanning/ModuleDepCollector.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/StringSet.h"
+#include "llvm/CAS/CASConfiguration.h"
 #include "llvm/Support/Mutex.h"
 #include "llvm/Support/StringSaver.h"
 #include <optional>
@@ -1061,8 +1061,8 @@ class SwiftDependencyScanningService {
   /// StringSaver for data matching the life-time of ScanningService.
   llvm::StringSaver Saver;
 
-  /// The CASOption created the Scanning Service if used.
-  std::optional<clang::CASOptions> CASOpts;
+  /// The CAS configuration created the Scanning Service if used.
+  std::optional<llvm::cas::CASConfiguration> CASConfig;
 
   /// The persistent Clang dependency scanner service
   std::optional<clang::tooling::dependencies::DependencyScanningService>

--- a/include/swift/Basic/CASOptions.h
+++ b/include/swift/Basic/CASOptions.h
@@ -20,6 +20,7 @@
 
 #include "clang/CAS/CASOptions.h"
 #include "llvm/ADT/Hashing.h"
+#include "llvm/CAS/CASConfiguration.h"
 
 namespace swift {
 
@@ -37,8 +38,8 @@ public:
   /// Import modules from CAS.
   bool ImportModuleFromCAS = false;
 
-  /// CASOptions
-  clang::CASOptions CASOpts;
+  /// CAS Configuration.
+  llvm::cas::CASConfiguration Config;
 
   /// Clang Include Trees.
   std::string ClangIncludeTree;

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -214,7 +214,9 @@ public:
   static std::unique_ptr<ClangImporter>
   create(ASTContext &ctx, const IRGenOptions *IRGenOpts = nullptr,
          std::string swiftPCHHash = "", std::string casidForPCH = "",
-         DependencyTracker *tracker = nullptr, bool ignoreFileMapping = false);
+         DependencyTracker *tracker = nullptr, bool ignoreFileMapping = false,
+         std::shared_ptr<llvm::cas::ObjectStore> CAS = nullptr,
+         std::shared_ptr<llvm::cas::ActionCache> Cache = nullptr);
 
   static std::string getClangSystemOverlayFile(const SearchPathOptions &Opts);
 

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -605,6 +605,11 @@ public:
   std::shared_ptr<llvm::cas::ObjectStore> getSharedCASInstance() const {
     return CAS;
   }
+  void setSharedCASInstances(std::shared_ptr<llvm::cas::ObjectStore> CAS,
+                             std::shared_ptr<llvm::cas::ActionCache> Cache) {
+    this->CAS = std::move(CAS);
+    this->ResultCache = std::move(Cache);
+  }
   std::optional<llvm::cas::ObjectRef> getCompilerBaseKey() const {
     return CompileJobBaseKey;
   }
@@ -726,7 +731,9 @@ public:
 
   /// The fast setup function for cache replay.
   bool setupForReplay(const CompilerInvocation &Invocation, std::string &Error,
-                      ArrayRef<const char *> Args = {});
+                      ArrayRef<const char *> Args,
+                      std::shared_ptr<llvm::cas::ObjectStore> CAS,
+                      std::shared_ptr<llvm::cas::ActionCache> Cache);
 
   const CompilerInvocation &getInvocation() const { return Invocation; }
 

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -651,6 +651,8 @@ private:
   llvm::StringSaver ArgSaver;
   std::vector<StringRef> GenericArgs;
   CompilerInvocation genericSubInvocation;
+  std::shared_ptr<llvm::cas::ObjectStore> CAS;
+  std::shared_ptr<llvm::cas::ActionCache> ActionCache;
 
   template<typename ...ArgTypes>
   InFlightDiagnostic diagnose(StringRef interfacePath,
@@ -683,7 +685,9 @@ public:
       StringRef backupModuleInterfaceDir,
       ArrayRef<std::pair<std::string, std::string>> replayPrefixMap,
       bool serializeDependencyHashes,
-      bool trackSystemDependencies);
+      bool trackSystemDependencies,
+      std::shared_ptr<llvm::cas::ObjectStore> CAS = nullptr,
+      std::shared_ptr<llvm::cas::ActionCache> ActionCache = nullptr);
 
   template<typename ...ArgTypes>
   static InFlightDiagnostic diagnose(StringRef interfacePath,

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -658,9 +658,9 @@ bool SwiftDependencyScanningService::setupCachingDependencyScanningService(
   if (!Instance.getInvocation().getCASOptions().EnableCaching)
     return false;
 
-  if (CASOpts) {
+  if (CASConfig) {
     // If CASOption matches, the service is initialized already.
-    if (*CASOpts == Instance.getInvocation().getCASOptions().CASOpts)
+    if (*CASConfig == Instance.getInvocation().getCASOptions().Config)
       return false;
 
     // CASOption mismatch, return error.
@@ -669,13 +669,18 @@ bool SwiftDependencyScanningService::setupCachingDependencyScanningService(
   }
 
   // Setup CAS.
-  CASOpts = Instance.getInvocation().getCASOptions().CASOpts;
+  CASConfig = Instance.getInvocation().getCASOptions().Config;
+
+  clang::CASOptions CASOpts;
+  CASOpts.CASPath = CASConfig->CASPath;
+  CASOpts.PluginPath = CASConfig->PluginPath;
+  CASOpts.PluginOptions = CASConfig->PluginOptions;
 
   ClangScanningService.emplace(
       clang::tooling::dependencies::ScanningMode::DependencyDirectivesScan,
       clang::tooling::dependencies::ScanningOutputFormat::FullIncludeTree,
-      Instance.getInvocation().getCASOptions().CASOpts,
-      Instance.getSharedCASInstance(), Instance.getSharedCacheInstance(),
+      CASOpts, Instance.getSharedCASInstance(),
+      Instance.getSharedCacheInstance(),
       // The current working directory optimization (off by default)
       // should not impact CAS. We set the optization to all to be
       // consistent with the non-CAS case.

--- a/lib/Basic/CASOptions.cpp
+++ b/lib/Basic/CASOptions.cpp
@@ -23,14 +23,14 @@ void CASOptions::enumerateCASConfigurationFlags(
       llvm::function_ref<void(llvm::StringRef)> Callback) const {
   if (EnableCaching) {
     Callback("-cache-compile-job");
-    if (!CASOpts.CASPath.empty()) {
+    if (!Config.CASPath.empty()) {
       Callback("-cas-path");
-      Callback(CASOpts.CASPath);
+      Callback(Config.CASPath);
     }
-    if (!CASOpts.PluginPath.empty()) {
+    if (!Config.PluginPath.empty()) {
       Callback("-cas-plugin-path");
-      Callback(CASOpts.PluginPath);
-      for (auto Opt : CASOpts.PluginOptions) {
+      Callback(Config.PluginPath);
+      for (auto Opt : Config.PluginOptions) {
         Callback("-cas-plugin-option");
         Callback((llvm::Twine(Opt.first) + "=" + Opt.second).str());
       }

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1046,6 +1046,9 @@ bool ClangImporter::canReadPCH(StringRef PCHFilename) {
   CI.setDiagnostics(&*clang::CompilerInstance::createDiagnostics(
       Impl.Instance->getVirtualFileSystem(), diagOpts));
 
+  if (Impl.CAS)
+    CI.setCASDatabases(Impl.CAS, Impl.ResultCache);
+
   // Note: Reusing the file manager is safe; this is a component that's already
   // reused when building PCM files for the module cache.
   CI.setVirtualFileSystem(Impl.Instance->getVirtualFileSystemPtr());
@@ -1364,7 +1367,8 @@ std::optional<std::vector<std::string>> ClangImporter::getClangCC1Arguments(
   // to missing files and report the error that clang would throw manually.
   // rdar://77516546 is tracking that the clang importer should be more
   // resilient and provide a module even if there were building it.
-  auto TempVFS = clang::createVFSFromCompilerInvocation(*CI, *clangDiags, VFS);
+  auto TempVFS = clang::createVFSFromCompilerInvocation(*CI, *clangDiags, VFS,
+                                                        Impl.CAS);
 
   std::vector<std::string> FilteredModuleMapFiles;
   for (const auto &ModuleMapFile : CI->getFrontendOpts().ModuleMapFiles) {
@@ -1428,9 +1432,14 @@ std::unique_ptr<clang::CompilerInvocation> ClangImporter::createClangInvocation(
 std::unique_ptr<ClangImporter>
 ClangImporter::create(ASTContext &ctx, const IRGenOptions *IRGenOpts,
                       std::string swiftPCHHash, std::string casidForPCH,
-                      DependencyTracker *tracker, bool ignoreFileMapping) {
+                      DependencyTracker *tracker, bool ignoreFileMapping,
+                      std::shared_ptr<llvm::cas::ObjectStore> CAS,
+                      std::shared_ptr<llvm::cas::ActionCache> Cache) {
   std::unique_ptr<ClangImporter> importer{new ClangImporter(ctx, tracker)};
   auto &importerOpts = ctx.ClangImporterOpts;
+
+  importer->Impl.CAS = std::move(CAS);
+  importer->Impl.ResultCache = std::move(Cache);
 
   auto bridgingPCH = importerOpts.getPCHInputPath();
   if (!bridgingPCH.empty()) {
@@ -1516,6 +1525,9 @@ ClangImporter::create(ASTContext &ctx, const IRGenOptions *IRGenOpts,
   auto &instance = *importer->Impl.Instance;
   if (tracker)
     instance.addDependencyCollector(tracker->getClangCollector());
+
+  if (importer->Impl.CAS)
+    instance.setCASDatabases(importer->Impl.CAS, importer->Impl.ResultCache);
 
   // Now set up the real client for Clang diagnostics---configured with proper
   // options---as opposed to the temporary one we made above.
@@ -2036,12 +2048,9 @@ bool ClangImporter::bindBridgingHeader(ModuleDecl *adapter, SourceLoc diagLoc) {
 
 static llvm::Expected<llvm::cas::ObjectRef>
 setupIncludeTreeInput(clang::CompilerInvocation &invocation,
-                      StringRef headerPath, StringRef pchIncludeTree) {
-  auto DB = invocation.getCASOpts().getOrCreateDatabases();
-  if (!DB)
-    return DB.takeError();
-  auto CAS = DB->first;
-  auto Cache = DB->second;
+                      StringRef headerPath, StringRef pchIncludeTree,
+                      std::shared_ptr<llvm::cas::ObjectStore> CAS,
+                      std::shared_ptr<llvm::cas::ActionCache> Cache) {
   auto ID = CAS->parseID(pchIncludeTree);
   if (!ID)
     return ID.takeError();
@@ -2086,7 +2095,8 @@ std::string ClangImporter::getBridgingHeaderContents(
     invocation->getFrontendOpts().Inputs.push_back(
         clang::FrontendInputFile(headerPath, clang::Language::ObjC));
   else if (auto err =
-               setupIncludeTreeInput(*invocation, headerPath, pchIncludeTree)
+               setupIncludeTreeInput(*invocation, headerPath, pchIncludeTree,
+                                     Impl.CAS, Impl.ResultCache)
                    .moveInto(includeTreeRef)) {
     Impl.diagnose({}, diag::err_rewrite_bridging_header,
                   toString(std::move(err)));
@@ -2098,6 +2108,10 @@ std::string ClangImporter::getBridgingHeaderContents(
   clang::CompilerInstance rewriteInstance(
       std::move(invocation), Impl.Instance->getPCHContainerOperations(),
       &Impl.Instance->getModuleCache());
+
+  if (Impl.CAS)
+    rewriteInstance.setCASDatabases(Impl.CAS, Impl.ResultCache);
+
   rewriteInstance.setVirtualFileSystem(
       Impl.Instance->getVirtualFileSystemPtr());
   rewriteInstance.setFileManager(Impl.Instance->getFileManagerPtr());
@@ -2202,6 +2216,9 @@ ClangImporter::cloneCompilerInstanceForPrecompiling() {
   auto clonedInstance = std::make_unique<clang::CompilerInstance>(
       std::move(invocation), Impl.Instance->getPCHContainerOperations(),
       &Impl.Instance->getModuleCache());
+
+  if (Impl.CAS)
+    clonedInstance->setCASDatabases(Impl.CAS, Impl.ResultCache);
   clonedInstance->setVirtualFileSystem(
       Impl.Instance->getVirtualFileSystemPtr());
   clonedInstance->setFileManager(Impl.Instance->getFileManagerPtr());

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1300,7 +1300,9 @@ std::optional<std::vector<std::string>> ClangImporter::getClangCC1Arguments(
     // compiler can be more efficient to compute swift cache key without having
     // the knowledge about clang command-line options.
     if (ctx.CASOpts.EnableCaching || ctx.CASOpts.ImportModuleFromCAS) {
-      CI->getCASOpts() = ctx.CASOpts.CASOpts;
+      CI->getCASOpts().CASPath = ctx.CASOpts.Config.CASPath;
+      CI->getCASOpts().PluginPath = ctx.CASOpts.Config.PluginPath;
+      CI->getCASOpts().PluginOptions = ctx.CASOpts.Config.PluginOptions;
       // When clangImporter is used to compile (generate .pcm or .pch), need to
       // inherit the include tree from swift args (last one wins) and clear the
       // input file.

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -459,6 +459,11 @@ public:
   /// Swift AST context.
   ASTContext &SwiftContext;
 
+  /// Shared CAS instance from the swift CompilerInstance.
+  std::shared_ptr<llvm::cas::ObjectStore> CAS;
+  /// Shared ActionCache instance from the swift CompilerInstance.
+  std::shared_ptr<llvm::cas::ActionCache> ResultCache;
+
   // Associates a vector of import diagnostics with a ClangNode
   std::unordered_map<ImportDiagnosticTarget, std::vector<ImportDiagnostic>,
                      ImportDiagnosticTargetHasher>

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -259,7 +259,8 @@ ModuleDependencyScanningWorker::ModuleDependencyScanningWorker(
       workerCompilerInvocation->getFrontendOptions()
           .SerializeModuleInterfaceDependencyHashes,
       workerCompilerInvocation->getFrontendOptions()
-          .shouldTrackSystemDependencies()
+          .shouldTrackSystemDependencies(),
+      CAS, ActionCache
       );
 
   auto loader = std::make_unique<PluginLoader>(

--- a/lib/DriverTool/swift_cache_tool_main.cpp
+++ b/lib/DriverTool/swift_cache_tool_main.cpp
@@ -379,7 +379,7 @@ readOutputEntriesFromFile(StringRef Path) {
 }
 
 int SwiftCacheToolInvocation::validateOutputs() {
-  auto DB = CASOpts.getOrCreateDatabases();
+  auto DB = CASOpts.CASConfiguration::createDatabases();
   if (!DB)
     report_fatal_error(DB.takeError());
 
@@ -507,7 +507,7 @@ int SwiftCacheToolInvocation::printIncludeTreeList() {
     llvm::errs() << llvm::toString(std::move(err)) << "\n";
     return 1;
   };
-  auto DB = CASOpts.getOrCreateDatabases();
+  auto DB = CASOpts.CASConfiguration::createDatabases();
   if (!DB) {
     return error(DB.takeError());
   }
@@ -544,7 +544,7 @@ int SwiftCacheToolInvocation::printCompileCacheKey() {
     llvm::errs() << "expect 1 CASID as input\n";
     return 1;
   }
-  auto DB = CASOpts.getOrCreateDatabases();
+  auto DB = CASOpts.CASConfiguration::createDatabases();
   if (!DB) {
     return error(DB.takeError());
   }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -837,15 +837,15 @@ static bool ParseCASArgs(CASOptions &Opts, ArgList &Args,
   Opts.EnableCachingRemarks |= Args.hasArg(OPT_cache_remarks);
   Opts.CacheSkipReplay |= Args.hasArg(OPT_cache_disable_replay);
   if (const Arg *A = Args.getLastArg(OPT_cas_path))
-    Opts.CASOpts.CASPath = A->getValue();
+    Opts.Config.CASPath = A->getValue();
 
   if (const Arg *A = Args.getLastArg(OPT_cas_plugin_path))
-    Opts.CASOpts.PluginPath = A->getValue();
+    Opts.Config.PluginPath = A->getValue();
 
   for (StringRef Opt : Args.getAllArgValues(OPT_cas_plugin_option)) {
     StringRef Name, Value;
     std::tie(Name, Value) = Opt.split('=');
-    Opts.CASOpts.PluginOptions.emplace_back(std::string(Name),
+    Opts.Config.PluginOptions.emplace_back(std::string(Name),
                                             std::string(Value));
   }
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -476,19 +476,21 @@ bool CompilerInstance::setupCASIfNeeded(ArrayRef<const char *> Args) {
   if (!getInvocation().requiresCAS())
     return false;
 
-  const auto &Opts = getInvocation().getCASOptions();
-  if (Opts.CASOpts.CASPath.empty() && Opts.CASOpts.PluginPath.empty()) {
-    Diagnostics.diagnose(SourceLoc(), diag::error_cas_initialization,
-                         "no CAS options provided");
-    return true;
+  if (!CAS) {
+    const auto &Opts = getInvocation().getCASOptions();
+    if (Opts.CASOpts.CASPath.empty() && Opts.CASOpts.PluginPath.empty()) {
+      Diagnostics.diagnose(SourceLoc(), diag::error_cas_initialization,
+                           "no CAS options provided");
+      return true;
+    }
+    auto MaybeDB = Opts.CASOpts.CASConfiguration::createDatabases();
+    if (!MaybeDB) {
+      Diagnostics.diagnose(SourceLoc(), diag::error_cas_initialization,
+                           toString(MaybeDB.takeError()));
+      return true;
+    }
+    std::tie(CAS, ResultCache) = *MaybeDB;
   }
-  auto MaybeDB = Opts.CASOpts.getOrCreateDatabases();
-  if (!MaybeDB) {
-    Diagnostics.diagnose(SourceLoc(), diag::error_cas_initialization,
-                         toString(MaybeDB.takeError()));
-    return true;
-  }
-  std::tie(CAS, ResultCache) = *MaybeDB;
 
   // create baseline key.
   auto BaseKey = createCompileJobBaseCacheKey(*CAS, Args);
@@ -633,11 +635,14 @@ bool CompilerInstance::setup(const CompilerInvocation &Invoke,
 
 bool CompilerInstance::setupForReplay(const CompilerInvocation &Invoke,
                                       std::string &Error,
-                                      ArrayRef<const char *> Args) {
+                                      ArrayRef<const char *> Args,
+                                      std::shared_ptr<llvm::cas::ObjectStore> CAS,
+                                      std::shared_ptr<llvm::cas::ActionCache> Cache) {
   // This is the fast path for setup an instance for replay but cannot run
   // regular compilation.
   Invocation = Invoke;
 
+  setSharedCASInstances(CAS, Cache);
   if (setupCASIfNeeded(Args)) {
     Error = "Setting up CAS failed";
     return true;
@@ -861,7 +866,8 @@ bool CompilerInstance::setUpModuleLoaders() {
   // knowledge.
   std::unique_ptr<ClangImporter> clangImporter = ClangImporter::create(
       *Context, &Invocation.getIRGenOptions(), Invocation.getPCHHash(),
-      CASIDForPCH, getDependencyTracker());
+      CASIDForPCH, getDependencyTracker(), /*ignoreFileMapping=*/false,
+      getSharedCASInstance(), getSharedCacheInstance());
   if (!clangImporter) {
     Diagnostics.diagnose(SourceLoc(), diag::error_clang_importer_create_fail);
     return true;
@@ -917,7 +923,8 @@ bool CompilerInstance::setUpModuleLoaders() {
         FEOpts.PrebuiltModuleCachePath, FEOpts.BackupModuleInterfaceDir,
         FEOpts.CacheReplayPrefixMap,
         FEOpts.SerializeModuleInterfaceDependencyHashes,
-        FEOpts.shouldTrackSystemDependencies());
+        FEOpts.shouldTrackSystemDependencies(),
+        getSharedCASInstance(), getSharedCacheInstance());
   }
 
   return false;

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -478,12 +478,12 @@ bool CompilerInstance::setupCASIfNeeded(ArrayRef<const char *> Args) {
 
   if (!CAS) {
     const auto &Opts = getInvocation().getCASOptions();
-    if (Opts.CASOpts.CASPath.empty() && Opts.CASOpts.PluginPath.empty()) {
+    if (Opts.Config.CASPath.empty() && Opts.Config.PluginPath.empty()) {
       Diagnostics.diagnose(SourceLoc(), diag::error_cas_initialization,
                            "no CAS options provided");
       return true;
     }
-    auto MaybeDB = Opts.CASOpts.CASConfiguration::createDatabases();
+    auto MaybeDB = Opts.Config.createDatabases();
     if (!MaybeDB) {
       Diagnostics.diagnose(SourceLoc(), diag::error_cas_initialization,
                            toString(MaybeDB.takeError()));

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1856,8 +1856,11 @@ InterfaceSubContextDelegateImpl::InterfaceSubContextDelegateImpl(
     StringRef moduleCachePath, StringRef prebuiltCachePath,
     StringRef backupModuleInterfaceDir,
     ArrayRef<std::pair<std::string, std::string>> replayPrefixMap,
-    bool serializeDependencyHashes, bool trackSystemDependencies)
-    : SM(SM), Diags(Diags), ArgSaver(Allocator) {
+    bool serializeDependencyHashes, bool trackSystemDependencies,
+    std::shared_ptr<llvm::cas::ObjectStore> CAS,
+    std::shared_ptr<llvm::cas::ActionCache> ActionCache)
+    : SM(SM), Diags(Diags), ArgSaver(Allocator),
+      CAS(std::move(CAS)), ActionCache(std::move(ActionCache)) {
   genericSubInvocation.setMainExecutablePath(LoaderOpts.mainExecutablePath);
   inheritOptionsForBuildingInterface(LoaderOpts.requestedAction, searchPathOpts,
                                      langOpts, clangImporterOpts, casOpts,
@@ -2184,6 +2187,8 @@ InterfaceSubContextDelegateImpl::runInSubCompilerInstance(StringRef moduleName,
   subInstance.getSourceMgr().setFileSystem(SM.getFileSystem());
 
   std::string InstanceSetupError;
+  if (CAS)
+    subInstance.setSharedCASInstances(CAS, ActionCache);
   if (subInstance.setup(subInvocation, InstanceSetupError)) {
     return std::make_error_code(std::errc::not_supported);
   }

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1803,7 +1803,7 @@ void InterfaceSubContextDelegateImpl::inheritOptionsForBuildingInterface(
 
   if (casOpts.EnableCaching) {
     genericSubInvocation.getCASOptions().EnableCaching = casOpts.EnableCaching;
-    genericSubInvocation.getCASOptions().CASOpts = casOpts.CASOpts;
+    genericSubInvocation.getCASOptions().Config = casOpts.Config;
     genericSubInvocation.getCASOptions().HasImmutableFileSystem =
         casOpts.HasImmutableFileSystem;
     casOpts.enumerateCASConfigurationFlags(

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1483,7 +1483,7 @@ static bool generateReproducer(CompilerInstance &Instance,
   newCAS.CASPath = casPath.str();
   newCAS.PluginPath = casOpts.CASOpts.PluginPath;
   newCAS.PluginOptions = casOpts.CASOpts.PluginOptions;
-  auto db = newCAS.getOrCreateDatabases();
+  auto db = newCAS.CASConfiguration::createDatabases();
   if (!db) {
     diags.diagnose(SourceLoc(), diag::error_cas_initialization,
                    toString(db.takeError()));

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1481,8 +1481,8 @@ static bool generateReproducer(CompilerInstance &Instance,
   llvm::sys::path::append(casPath, "cas");
   clang::CASOptions newCAS;
   newCAS.CASPath = casPath.str();
-  newCAS.PluginPath = casOpts.CASOpts.PluginPath;
-  newCAS.PluginOptions = casOpts.CASOpts.PluginOptions;
+  newCAS.PluginPath = casOpts.Config.PluginPath;
+  newCAS.PluginOptions = casOpts.Config.PluginOptions;
   auto db = newCAS.CASConfiguration::createDatabases();
   if (!db) {
     diags.diagnose(SourceLoc(), diag::error_cas_initialization,

--- a/lib/Tooling/libSwiftScan/SwiftCaching.cpp
+++ b/lib/Tooling/libSwiftScan/SwiftCaching.cpp
@@ -57,6 +57,8 @@ class SwiftScanCAS {
 public:
   llvm::cas::ObjectStore &getCAS() const { return *CAS; }
   llvm::cas::ActionCache &getCache() const { return *Cache; }
+  std::shared_ptr<llvm::cas::ObjectStore> getSharedCAS() const { return CAS; }
+  std::shared_ptr<llvm::cas::ActionCache> getSharedCache() const { return Cache; }
 
   // Construct SwiftScanCAS.
   static llvm::Expected<SwiftScanCAS *>
@@ -910,7 +912,8 @@ static llvm::Error replayCompilation(SwiftScanReplayInstance &Instance,
 
   std::string InstanceSetupError;
   if (Inst.setupForReplay(Instance.Invocation, InstanceSetupError,
-                          Instance.Args))
+                          Instance.Args,
+                          Comp.DB.getSharedCAS(), Comp.DB.getSharedCache()))
     return createStringError(inconvertibleErrorCode(), InstanceSetupError);
 
   auto *CDP = Inst.getCachingDiagnosticsProcessor();
@@ -990,7 +993,7 @@ SwiftScanCAS::createSwiftScanCAS(llvm::StringRef Path) {
 
 llvm::Expected<SwiftScanCAS *>
 SwiftScanCAS::createSwiftScanCAS(clang::CASOptions &CASOpts) {
-  auto DB = CASOpts.getOrCreateDatabases();
+  auto DB = CASOpts.CASConfiguration::createDatabases();
   if (!DB)
     return DB.takeError();
 


### PR DESCRIPTION
Migrate all callers of getOrCreateDatabases to either create their own CAS instances using createDatabases() or to use the ones stored in the CompilerInstance. Also forwards the instances into the ClangImporter and its various clang::CompilerInstance instances.

Validated locally that this does not result in any additional calls to createDatabases across all the swift tests. In fact, there are fewer due to an improvement on the clange side, so I also checked that the overall reduction doesn't hide any issues. Looking at individual cas paths that are opened, which are per-test paths, there are none that open more than before.