### PR TITLE
Enable custom coroutine derivatives

### DIFF
--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -251,12 +251,31 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &s,
 /// semantic result (an `inout`) parameter type. Used in derivative function type
 /// calculation.
 struct AutoDiffSemanticFunctionResultType {
+  enum class ResultKind : uint8_t {
+    Result = 0x0,
+    SemanticResultParameter = 0x1,
+    DirectYield = 0x2,
+    IndirectYield = 0x3,
+  };
+
   Type type;
   unsigned index : 30;
-  bool isSemanticResultParameter : 1;
+  uint8_t kind : 2;
 
-  AutoDiffSemanticFunctionResultType(Type t, unsigned idx, bool param)
-    : type(t), index(idx), isSemanticResultParameter(param) { }
+  AutoDiffSemanticFunctionResultType(Type t, unsigned idx, ResultKind kind)
+      : type(t), index(idx), kind(uint8_t(kind)) {}
+
+  ResultKind getKind() const { return ResultKind(kind); }
+  bool isResult() const { return kind == uint8_t(ResultKind::Result); }
+  bool isSemanticResultParameter() const {
+    return kind == uint8_t(ResultKind::SemanticResultParameter);
+  }
+  bool isDirectYield() const {
+    return kind == uint8_t(ResultKind::DirectYield);
+  }
+  bool isIndirectYield() const {
+    return kind == uint8_t(ResultKind::IndirectYield);
+  }
 };
 
 /// Key for caching SIL derivative function types.
@@ -412,7 +431,9 @@ public:
     /// A differentiability parameter does not conform to `Differentiable`.
     NonDifferentiableDifferentiabilityParameter,
     /// The original result type does not conform to `Differentiable`.
-    NonDifferentiableResult
+    NonDifferentiableResult,
+    /// Non-differentiable (direct) yield
+    NonDifferentiableYield
   };
 
   static const char ID;
@@ -449,12 +470,14 @@ public:
                                        TypeAndIndex nonDiffTypeAndIndex)
       : functionType(functionType), kind(kind), value(nonDiffTypeAndIndex) {
     assert(kind == Kind::NonDifferentiableDifferentiabilityParameter ||
-           kind == Kind::NonDifferentiableResult);
+           kind == Kind::NonDifferentiableResult ||
+           kind == Kind::NonDifferentiableYield);
   };
 
   TypeAndIndex getNonDifferentiableTypeAndIndex() const {
     assert(kind == Kind::NonDifferentiableDifferentiabilityParameter ||
-           kind == Kind::NonDifferentiableResult);
+           kind == Kind::NonDifferentiableResult ||
+           kind == Kind::NonDifferentiableYield);
     return value.typeAndIndex;
   }
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4654,6 +4654,9 @@ ERROR(autodiff_attr_original_void_result,none,
 ERROR(autodiff_attr_result_not_differentiable,none,
       "can only differentiate functions with results that conform to "
       "'Differentiable', but %0 does not conform to 'Differentiable'", (Type))
+ERROR(autodiff_attr_yield_not_differentiable,none,
+      "can only differentiate coroutines with indirect yields that conform to "
+      "'Differentiable', but %0 either does not conform to 'Differentiable or is a direct yield'", (Type))
 ERROR(autodiff_attr_opaque_result_type_unsupported,none,
       "cannot differentiate functions returning opaque result types", ())
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4542,6 +4542,10 @@ ERROR(derivative_attr_invalid_result_tuple_func_label,none,
       "'@derivative(of:)' attribute requires function to return a two-element "
       "tuple; second element must have label 'pullback:' or 'differential:'",
       ())
+ERROR(derivative_attr_expected_coro_result,none,
+      "'@derivative(of:)' attribute requires coroutine function to return a  "
+      "linear map", ())
+
 ERROR(derivative_attr_result_func_type_mismatch,none,
       "function result's %0 type does not match %1",
       (Identifier, const ValueDecl *))

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -18,6 +18,7 @@
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/Assertions.h"
+#include "llvm/ADT/STLExtras.h"
 
 using namespace swift;
 
@@ -203,12 +204,14 @@ void autodiff::getFunctionSemanticResults(
     // Separate tuple elements into individual results.
     if (formalResultType->is<TupleType>()) {
       for (auto elt : formalResultType->castTo<TupleType>()->getElements()) {
-        resultTypes.emplace_back(elt.getType(), resultIdx++,
-                                 /*isParameter*/ false);
+        resultTypes.emplace_back(
+            elt.getType(), resultIdx++,
+            AutoDiffSemanticFunctionResultType::ResultKind::Result);
       }
     } else {
-      resultTypes.emplace_back(formalResultType, resultIdx++,
-                               /*isParameter*/ false);
+      resultTypes.emplace_back(
+          formalResultType, resultIdx++,
+          AutoDiffSemanticFunctionResultType::ResultKind::Result);
     }
   }
 
@@ -225,7 +228,9 @@ void autodiff::getFunctionSemanticResults(
              "invalid parameter index");
       if (parameterIndices->contains(idx))
         resultTypes.emplace_back(paramAndIndex.value().getPlainType(),
-                                 resultIdx, /*isParameter*/ true);
+                                 resultIdx,
+                                 AutoDiffSemanticFunctionResultType::
+                                     ResultKind::SemanticResultParameter);
       resultIdx += 1;
     }
   };
@@ -239,6 +244,21 @@ void autodiff::getFunctionSemanticResults(
     collectSemanticResults(functionType, resultFnType->getNumParams());
   } else
     collectSemanticResults(functionType);
+
+  // All yields are considered as results for the purposes of autodiff
+  ArrayRef<AnyFunctionType::Yield> yields;
+  if (auto *resultFnType =
+          functionType->getResult()->getAs<AnyFunctionType>()) {
+    assert(functionType->getNumYields() == 0 && "unexpected coroutine type");
+    yields = resultFnType->getYields();
+  } else
+    yields = functionType->getYields();
+  for (const auto &yield : yields)
+    resultTypes.emplace_back(
+        yield.getType(), resultIdx++,
+        yield.isInOut()
+            ? AutoDiffSemanticFunctionResultType::ResultKind::IndirectYield
+            : AutoDiffSemanticFunctionResultType::ResultKind::DirectYield);
 }
 
 IndexSubset *
@@ -304,7 +324,7 @@ autodiff::getLoweredParameterIndices(IndexSubset *parameterIndices,
 
 /// Collects the semantic results of the given function type in
 /// `originalResults`. The semantic results are formal results followed by
-/// semantic result parameters, in type order.
+/// semantic result parameters, folowed by yields, in type order.
 void
 autodiff::getSemanticResults(SILFunctionType *functionType,
                              IndexSubset *parameterIndices,
@@ -320,6 +340,14 @@ autodiff::getSemanticResults(SILFunctionType *functionType,
       continue;
     if (!param.hasOption(SILParameterInfo::NotDifferentiable))
       originalResults.emplace_back(param.getInterfaceType(), ResultConvention::Indirect);
+  }
+
+  for (const auto &yield : functionType->getYields()) {
+    if (!yield.isAutoDiffSemanticResult())
+      continue;
+    if (!yield.hasOption(SILParameterInfo::NotDifferentiable))
+      originalResults.emplace_back(yield.getInterfaceType(),
+                                   ResultConvention::Indirect);
   }
 }
 
@@ -521,6 +549,12 @@ void DerivativeFunctionTypeError::log(raw_ostream &OS) const {
     auto nonDiffResult = getNonDifferentiableTypeAndIndex();
     OS << "has non-differentiable result " << nonDiffResult.second << ": "
        << nonDiffResult.first;
+    break;
+  }
+  case Kind::NonDifferentiableYield: {
+    auto nonDiffYield = getNonDifferentiableTypeAndIndex();
+    OS << "has non-differentiable yield " << nonDiffYield.second << ": "
+       << nonDiffYield.first;
     break;
   }
   }

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -5135,7 +5135,7 @@ AnyFunctionType::getAutoDiffDerivativeFunctionLinearMapType(
         this, DerivativeFunctionTypeError::Kind::NoSemanticResults);
 
   // Accumulate non-semantic result tangent spaces.
-  SmallVector<Type, 1> resultTanTypes, inoutTanTypes;
+  SmallVector<Type, 1> resultTanTypes, inoutTanTypes, yieldTanTypes;
   for (auto i : range(originalResults.size())) {
     auto originalResult = originalResults[i];
     auto originalResultType = originalResult.type;
@@ -5154,12 +5154,28 @@ AnyFunctionType::getAutoDiffDerivativeFunctionLinearMapType(
         DerivativeFunctionTypeError::TypeAndIndex(
           originalResultType, unsigned(originalResult.index)));
 
-    if (!originalResult.isSemanticResultParameter)
+    if (originalResult.isResult())
       resultTanTypes.push_back(resultTan->getType());
+    else if (originalResult.isIndirectYield())
+      yieldTanTypes.push_back(resultTan->getType());
+    else if (originalResult.isDirectYield())
+      return llvm::make_error<DerivativeFunctionTypeError>(
+          this, DerivativeFunctionTypeError::Kind::NonDifferentiableYield,
+          DerivativeFunctionTypeError::TypeAndIndex(
+              originalResultType, unsigned(originalResult.index)));
   }
 
   // Compute the result linear map function type.
   FunctionType *linearMapType;
+  // FIXME: Verify ExtInfo state is correct, not working by accident.
+  FunctionType::ExtInfo info;
+
+  SmallVector<AnyFunctionType::Yield, 1> differentialYields;
+  for (auto yieldTy : yieldTanTypes)
+    differentialYields.emplace_back(yieldTy, YieldTypeFlags().withInOut(true));
+  if (differentialYields.size())
+    info = info.withCoroutine();
+
   switch (kind) {
   case AutoDiffLinearMapKind::Differential: {
     // Compute the differential type, returned by JVP functions.
@@ -5171,6 +5187,9 @@ AnyFunctionType::getAutoDiffDerivativeFunctionLinearMapType(
     // Case 2: original function has a wrt `inout` parameter.
     // - Original:      `(T0, inout T1, ...) -> Void`
     // - Differential:  `(T0.Tan, inout T1.Tan, ...) -> Void`
+    //
+    // Yields are on their own. We do support only indirect (inout) yields
+    // therefore we will just yield corresponding tangents.
     SmallVector<AnyFunctionType::Param, 4> differentialParams;
     for (auto i : range(diffParams.size())) {
       auto diffParam = diffParams[i];
@@ -5187,6 +5206,7 @@ AnyFunctionType::getAutoDiffDerivativeFunctionLinearMapType(
       differentialParams.push_back(AnyFunctionType::Param(
           paramTan->getType(), Identifier(), diffParam.getParameterFlags()));
     }
+
     Type differentialResult;
     if (resultTanTypes.empty()) {
       differentialResult = ctx.TheEmptyTupleType;
@@ -5202,10 +5222,8 @@ AnyFunctionType::getAutoDiffDerivativeFunctionLinearMapType(
       differentialResult = TupleType::get(differentialResults, ctx);
     }
 
-    // FIXME: Verify ExtInfo state is correct, not working by accident.
-    FunctionType::ExtInfo info;
-    linearMapType =
-        FunctionType::get(differentialParams, {}, differentialResult, info);
+    linearMapType = FunctionType::get(differentialParams, differentialYields,
+                                      differentialResult, info);
     break;
   }
   case AutoDiffLinearMapKind::Pullback: {
@@ -5218,6 +5236,8 @@ AnyFunctionType::getAutoDiffDerivativeFunctionLinearMapType(
     // Case 2: original function has wrt `inout` parameters.
     // - Original: `(T0, inout T1, ...) -> R`
     // - Pullback: `(R.Tan, inout T1.Tan) -> (T0.Tan, ...)`
+    // Yields are on their own. We do support only indirect (inout) yields
+    // therefore we will just yield corresponding tangents.
     SmallVector<TupleTypeElt, 4> pullbackResults;
     SmallVector<AnyFunctionType::Param, 2> semanticResultParams;
     for (auto i : range(diffParams.size())) {
@@ -5266,9 +5286,8 @@ AnyFunctionType::getAutoDiffDerivativeFunctionLinearMapType(
       pullbackParams.push_back(AnyFunctionType::Param(
           semanticResultParamTan->getType(), Identifier(), flags));
     }
-    // FIXME: Verify ExtInfo state is correct, not working by accident.
-    FunctionType::ExtInfo info;
-    linearMapType = FunctionType::get(pullbackParams, {}, pullbackResult, info);
+    linearMapType = FunctionType::get(pullbackParams, differentialYields,
+                                      pullbackResult, info);
     break;
   }
   }

--- a/lib/AST/Yield.cpp
+++ b/lib/AST/Yield.cpp
@@ -92,6 +92,7 @@ SourceRange YieldList::getSourceRange() const {
 Type Yield::getInterfaceType(const FuncDecl *parent) const {
   // Figure out our position in parent's yield list
   size_t idx = std::distance(parent->getYields()->getArray().data(), this);
+  // This assertion will likely fail if Yield is not from this parent.
   ASSERT(idx < parent->getYields()->size());
 
   auto mutableParent = const_cast<FuncDecl *>(parent);

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -6514,14 +6514,78 @@ ManagedValue SILGenFunction::getThunkedAutoDiffLinearMap(
   }
 
   auto *linearMapArg = thunk->getArgumentsWithoutIndirectResults().back();
-  auto *apply = thunkSGF.B.createApply(loc, linearMapArg, SubstitutionMap(),
-                                       arguments);
+  // Extract all direct & indirect results.
+  SmallVector<SILValue, 4> directResults;
+  OperandValueArrayRef indirectResults;
+
+  if (fromType->isCoroutine()) {
+    SmallVector<SILValue, 1> yields;
+    // Start inner coroutine execution till the suspend point
+    SubstitutionMap subs = thunk->getForwardingSubstitutionMap();
+    SILType substFnType = linearMapArg->getType().substGenericArgs(
+        thunkSGF.getModule(), subs, thunk->getTypeExpansionContext());
+    auto tokenAndCleanups = thunkSGF.emitBeginApplyWithRethrow(
+        loc, linearMapArg, substFnType, /* canUnwind */ true, SubstitutionMap(),
+        arguments, yields);
+    auto token = std::get<0>(tokenAndCleanups);
+    auto abortCleanup = std::get<1>(tokenAndCleanups);
+    auto allocation = std::get<2>(tokenAndCleanups);
+    auto deallocCleanup = std::get<3>(tokenAndCleanups);
+
+    {
+      SmallVector<ManagedValue, 1> yieldMVs;
+
+      // Prepare a destination for the unwind; use the current cleanup stack
+      // as the depth so that we branch right to it.
+      SILBasicBlock *unwindBB =
+          thunkSGF.createBasicBlock(FunctionSection::Postmatter);
+      JumpDest unwindDest(unwindBB, thunkSGF.Cleanups.getCleanupsDepth(),
+                          CleanupLocation(loc));
+
+      manageYields(thunkSGF, yields,
+                   substFnType.castTo<SILFunctionType>()->getYields(),
+                   yieldMVs);
+
+      // Emit the yield.
+      thunkSGF.emitRawYield(loc, yieldMVs, unwindDest, /*unique*/ true);
+
+      // Emit the unwind block.
+      {
+        SILGenSavedInsertionPoint savedIP(thunkSGF, unwindBB,
+                                          FunctionSection::Postmatter);
+
+        // Emit all active cleanups.
+        thunkSGF.Cleanups.emitCleanupsForReturn(CleanupLocation(loc),
+                                                IsForUnwind);
+        thunkSGF.B.createUnwind(loc);
+      }
+    }
+
+    // Kill the normal abort cleanup without emitting it.
+    thunkSGF.Cleanups.setCleanupState(abortCleanup, CleanupState::Dead);
+    if (allocation) {
+      thunkSGF.Cleanups.setCleanupState(deallocCleanup, CleanupState::Dead);
+    }
+
+    // End the inner coroutine normally.
+    auto resultTy =
+        thunk->mapTypeIntoEnvironment(fromType->getAllResultsSubstType(
+            thunkSGF.getModule(), thunkSGF.getTypeExpansionContext()));
+    auto endApply =
+        thunkSGF.emitEndApplyWithRethrow(loc, token, allocation, resultTy);
+
+    extractAllElements(endApply, loc, thunkSGF.B, directResults);
+    auto *beginApply = token->getParent<BeginApplyInst>();
+    indirectResults = beginApply->getIndirectSILResults();
+  } else {
+    auto *apply =
+        thunkSGF.B.createApply(loc, linearMapArg, SubstitutionMap(), arguments);
+    extractAllElements(apply, loc, thunkSGF.B, directResults);
+    indirectResults = apply->getIndirectSILResults();
+  }
 
   // Get return elements.
   SmallVector<SILValue, 4> results;
-  // Extract all direct results.
-  SmallVector<SILValue, 4> directResults;
-  extractAllElements(apply, loc, thunkSGF.B, directResults);
 
   // Handle self reordering.
   // For pullbacks: rotate direct results if self is direct.
@@ -6540,7 +6604,7 @@ ManagedValue SILGenFunction::getThunkedAutoDiffLinearMap(
   }
 
   auto fromDirResultsIter = directResults.begin();
-  auto fromIndResultsIter = apply->getIndirectSILResults().begin();
+  auto fromIndResultsIter = indirectResults.begin();
   auto toIndResultsIter = thunkIndirectResults.begin();
   // Reabstract results.
   for (unsigned resIdx : range(toType->getNumResults())) {

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3022,16 +3022,20 @@ namespace {
               CanSILFunctionType loweredType, SubstitutionMap subs) {
       LoweredInfos = loweredType->getUnsubstitutedType(SGM.M)->getYields();
 
-      auto accessor = cast<AccessorDecl>(function.getDecl());
-      auto storage = accessor->getStorage();
+      auto origFd = cast<FuncDecl>(function.getDecl());
+      auto sig = origFd->getGenericSignatureOfContext().getCanonicalSignature();
 
-      OrigTypes.push_back(
-        SGM.Types.getAbstractionPattern(storage, /*nonobjc*/ true));
+      for (const auto &yield : *origFd->getYields()) {
+        auto origYieldType = yield.getInterfaceType(origFd)->getInOutObjectType();
+        auto reducedYieldType = sig.getReducedType(origYieldType);
+        OrigTypes.emplace_back(sig, reducedYieldType);
+      }
 
       SmallVector<AnyFunctionType::Yield, 1> yieldsBuffer;
-      auto yields = AnyFunctionRef(accessor).getYieldResults(yieldsBuffer);
-      assert(yields.size() == 1);
-      Yields.push_back(yields[0].getCanonical().subst(subs).asParam());
+      auto yields = AnyFunctionRef(origFd).getYieldResults(yieldsBuffer);
+      assert(yields.size() == 1 && "only single yield is supported by silgen");
+      for (auto yield : yields)
+        Yields.push_back(yield.getCanonical().subst(subs).asParam());
     }
 
     ArrayRef<AbstractionPattern> getOrigTypes() const { return OrigTypes; }
@@ -6692,10 +6696,6 @@ SILFunction *SILGenModule::getOrCreateCustomDerivativeThunk(
   SILType substFnType = fnRef->getType().substGenericArgs(
       M, subs, thunk->getTypeExpansionContext());
 
-  // Apply function argument.
-  auto apply =
-      thunkSGF.emitApplyWithRethrow(loc, fnRef, substFnType, subs, arguments);
-
   // Self reordering thunk is necessary if wrt at least two parameters,
   // including self.
   auto shouldReorderSelf = [&]() {
@@ -6732,18 +6732,66 @@ SILFunction *SILGenModule::getOrCreateCustomDerivativeThunk(
     thunkSGF.B.createReturn(loc, retValue);
   };
 
-  if (!reorderSelf && linearMapFnType == targetLinearMapFnType) {
-    SmallVector<SILValue, 8> results;
+  SmallVector<SILValue, 8> results;
+  if (customDerivativeFnTy->isCoroutine()) {
+    assert(kind == AutoDiffDerivativeFunctionKind::VJP &&
+           "only support VJP custom coroutine derivatives");
+
+    SmallVector<SILValue, 1> yields;
+    // Start inner coroutine execution till the suspend point
+    auto tokenAndCleanups = thunkSGF.emitBeginApplyWithRethrow(
+        loc, fnRef, substFnType /*fnRef->getType()*/, /* canUnwind */ true,
+        subs, arguments, yields);
+    auto token = std::get<0>(tokenAndCleanups);
+    auto abortCleanup = std::get<1>(tokenAndCleanups);
+    auto allocation = std::get<2>(tokenAndCleanups);
+    auto deallocCleanup = std::get<3>(tokenAndCleanups);
+
+    // Forward yields
+    auto *customDerivativeAFD = cast<AbstractFunctionDecl>(
+        customDerivativeFn->getDeclContext()->getAsDecl());
+    auto thunkTy = thunkSGF.F.getLoweredFunctionType();
+    YieldInfo innerYieldInfo(*this, SILDeclRef(customDerivativeAFD), fnRefType,
+                             subs);
+    // FIXME: We do not have Decl for the thunk as it is generated entirely at
+    // SIL level. Fix the yield info in case when reabstraction of yields would
+    // be required
+    YieldInfo outerYieldInfo(*this, SILDeclRef(customDerivativeAFD), thunkTy,
+                             thunk->getForwardingSubstitutionMap());
+    translateYields(thunkSGF, loc, yields, innerYieldInfo, outerYieldInfo);
+
+    // Kill the normal abort cleanup without emitting it. translateYields() will
+    // produce proper abort_apply & cleanups for inner coroutine call in the
+    // unwind block, and for normal return we're doing it manually below
+    thunkSGF.Cleanups.setCleanupState(abortCleanup, CleanupState::Dead);
+    if (allocation) {
+      thunkSGF.Cleanups.setCleanupState(deallocCleanup, CleanupState::Dead);
+    }
+
+    // End the inner coroutine normally.
+    auto resultTy =
+        thunk->mapTypeIntoEnvironment(fnRefType->getAllResultsSubstType(
+            M, thunkSGF.getTypeExpansionContext()));
+    auto endApply =
+        thunkSGF.emitEndApplyWithRethrow(loc, token, allocation, resultTy);
+
+    extractAllElements(endApply, loc, thunkSGF.B, results);
+  } else {
+    // Apply function argument.
+    auto apply =
+        thunkSGF.emitApplyWithRethrow(loc, fnRef, substFnType, subs, arguments);
+
     extractAllElements(apply, loc, thunkSGF.B, results);
-    auto result = joinElements(results, thunkSGF.B, apply.getLoc());
+  }
+
+  if (!reorderSelf && linearMapFnType == targetLinearMapFnType) {
+    auto result = joinElements(results, thunkSGF.B, loc);
     createReturn(result);
     return thunk;
   }
 
   // Otherwise, apply reabstraction/self reordering thunk to linear map.
-  SmallVector<SILValue, 8> directResults;
-  extractAllElements(apply, loc, thunkSGF.B, directResults);
-  auto linearMap = thunkSGF.emitManagedRValueWithCleanup(directResults.back());
+  auto linearMap = thunkSGF.emitManagedRValueWithCleanup(results.back());
   assert(linearMap.getType().castTo<SILFunctionType>() == linearMapFnType);
   auto linearMapKind = kind.getLinearMapKind();
   linearMap = thunkSGF.getThunkedAutoDiffLinearMap(
@@ -6773,10 +6821,10 @@ SILFunction *SILGenModule::getOrCreateCustomDerivativeThunk(
   }
 
   // Return original results and thunked differential/pullback.
-  if (directResults.size() > 1) {
-    auto originalDirectResults = ArrayRef<SILValue>(directResults).drop_back(1);
+  if (results.size() > 1) {
+    auto originalDirectResults = ArrayRef<SILValue>(results).drop_back(1);
     auto originalDirectResult =
-        joinElements(originalDirectResults, thunkSGF.B, apply.getLoc());
+        joinElements(originalDirectResults, thunkSGF.B, loc);
     auto thunkResult = joinElements(
         {originalDirectResult, linearMap.forward(thunkSGF)}, thunkSGF.B, loc);
     createReturn(thunkResult);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -6514,7 +6514,9 @@ static AbstractFunctionDecl *findAutoDiffOriginalFunctionDecl(
     // the matching accessor isn't a supported kind.
     if (maybeAccessorKind.has_value() &&
         maybeAccessorKind != AccessorKind::Get &&
-        maybeAccessorKind != AccessorKind::Set) {
+        maybeAccessorKind != AccessorKind::Set &&
+        maybeAccessorKind != AccessorKind::Modify &&
+        maybeAccessorKind != AccessorKind::YieldingMutate) {
       invalidCandidates.push_back(
           {decl, LookupErrorKind::CandidateUnsupportedAccessor});
       continue;
@@ -6657,6 +6659,23 @@ static bool checkFunctionSignature(
        !required->getThrownError()->isEqual(candidateFnTy->getThrownError())))
     return false;
 
+  // Check that either both are coroutines or none
+  if (required->isCoroutine() != candidateFnTy->isCoroutine())
+    return false;
+  // Check that yields match
+  if (required->getNumYields() != candidateFnTy->getNumYields())
+    return false;
+  if (!std::equal(required->getYields().begin(), required->getYields().end(),
+                  candidateFnTy->getYields().begin(),
+                  [&](AnyFunctionType::Yield x, AnyFunctionType::Yield y) {
+                    auto xInstanceTy = x.getType()->getMetatypeInstanceType();
+                    auto yInstanceTy = y.getType()->getMetatypeInstanceType();
+                    return xInstanceTy->isEqual(
+                               requiredGenSig.getReducedType(yInstanceTy)) &&
+                           x.getFlags() == y.getFlags();
+                  }))
+    return false;
+
   // Check that parameter types match, disregarding labels.
   if (required->getNumParams() != candidateFnTy->getNumParams())
     return false;
@@ -6695,23 +6714,18 @@ static bool checkFunctionSignature(
   return checkFunctionSignature(requiredResultFnTy, candidateResultTy);
 }
 
-/// Returns an `AnyFunctionType` from the given parameters, result type, and
-/// generic signature.
+/// Returns an `AnyFunctionType` from the given parameters, result type,
+/// generic signature, and ExtInfo
 static AnyFunctionType *
 makeFunctionType(ArrayRef<AnyFunctionType::Param> parameters,
                  ArrayRef<AnyFunctionType::Yield> yields, Type resultType,
-                 bool throws, Type thrownError,
-                 GenericSignature genericSignature) {
-  // FIXME: Verify ExtInfo state is correct, not working by accident.
+                 GenericSignature genericSignature,
+                 AnyFunctionType::ExtInfo extInfo) {
   if (genericSignature) {
-    GenericFunctionType::ExtInfo info;
-    info = info.withThrows(throws, thrownError);
     return GenericFunctionType::get(genericSignature, parameters, yields,
-                                    resultType, info);
+                                    resultType, extInfo);
   }
-  FunctionType::ExtInfo info;
-  info = info.withThrows(throws, thrownError);
-  return FunctionType::get(parameters, yields, resultType, info);
+  return FunctionType::get(parameters, yields, resultType, extInfo);
 }
 
 /// Computes the original function type corresponding to the given derivative
@@ -6730,16 +6744,22 @@ getDerivativeOriginalFunctionType(AnyFunctionType *derivativeFnTy) {
     currentLevel = currentLevel->getResult()->getAs<AnyFunctionType>();
   }
 
-  auto derivativeResult = curryLevels.back()->getResult()->getAs<TupleType>();
-  assert(derivativeResult && derivativeResult->getNumElements() == 2 &&
-         "Expected derivative result to be a two-element tuple");
-  auto originalResult = derivativeResult->getElement(0).getType();
+  AnyFunctionType *lastType = curryLevels.back();
+  Type originalResult;
+  if (lastType->isCoroutine()) {
+    originalResult = derivativeFnTy->getASTContext().getVoidType();
+  } else {
+    auto derivativeResult = lastType->getResult()->getAs<TupleType>();
+    assert(derivativeResult && derivativeResult->getNumElements() == 2 &&
+           "Expected derivative result to be a two-element tuple");
+    originalResult = derivativeResult->getElement(0).getType();
+  }
+
   auto *originalType = makeFunctionType(
-      curryLevels.back()->getParams(), curryLevels.back()->getYields(),
-      originalResult, curryLevels.back()->isThrowing(),
-      curryLevels.back()->getThrownError(),
+      lastType->getParams(), lastType->getYields(), originalResult,
       curryLevels.size() == 1 ? derivativeFnTy->getOptGenericSignature()
-                              : nullptr);
+                              : nullptr,
+      lastType->getExtInfo());
 
   // Wrap the derivative function type in additional curry levels.
   auto curryLevelsWithoutLast =
@@ -6749,10 +6769,10 @@ getDerivativeOriginalFunctionType(AnyFunctionType *derivativeFnTy) {
     AnyFunctionType *curryLevel = pair.value();
     originalType = makeFunctionType(
         curryLevel->getParams(), curryLevel->getYields(), originalType,
-        curryLevel->isThrowing(), curryLevel->getThrownError(),
         i == curryLevelsWithoutLast.size() - 1
             ? derivativeFnTy->getOptGenericSignature()
-            : nullptr);
+            : nullptr,
+        curryLevel->getExtInfo());
   }
   return originalType;
 }
@@ -6770,10 +6790,12 @@ getTransposeOriginalFunctionType(AnyFunctionType *transposeFnType,
   auto transposeParams = transposeFnType->getParams();
   auto transposeResult = transposeFnType->getResult();
   bool isCurried = transposeResult->is<AnyFunctionType>();
+  AnyFunctionType::ExtInfo innerInfo;
   if (isCurried) {
     auto methodType = transposeResult->castTo<AnyFunctionType>();
     transposeParams = methodType->getParams();
     transposeResult = methodType->getResult();
+    innerInfo = methodType->getExtInfo();
   }
 
   // Get the original function's result type.
@@ -6843,20 +6865,18 @@ getTransposeOriginalFunctionType(AnyFunctionType *transposeFnType,
   if (isCurried) {
     assert(selfType && "`Self` type should be resolved");
     originalType = makeFunctionType(originalParams, {}, originalResult,
-                                    transposeFnType->isThrowing(),
-                                    transposeFnType->getThrownError(),
-                                    /*genericSignature=*/nullptr);
-    originalType = makeFunctionType(
-        AnyFunctionType::Param(selfType), {}, originalType,
-        /*throws=*/false, Type(), transposeFnType->getOptGenericSignature());
+                                    /*genericSignature=*/nullptr, innerInfo);
+    originalType =
+        makeFunctionType(AnyFunctionType::Param(selfType), {}, originalType,
+                         transposeFnType->getOptGenericSignature(),
+                         transposeFnType->getExtInfo());
   }
   // Otherwise, the original function type is simply:
   // `(<original parameters>) -> <original result>`.
   else {
     originalType = makeFunctionType(originalParams, {}, originalResult,
-                                    transposeFnType->isThrowing(),
-                                    transposeFnType->getThrownError(),
-                                    transposeFnType->getOptGenericSignature());
+                                    transposeFnType->getOptGenericSignature(),
+                                    transposeFnType->getExtInfo());
   }
   return originalType;
 }
@@ -7340,31 +7360,49 @@ static bool typeCheckDerivativeAttr(DerivativeAttr *attr) {
   //     (value: R, pullback: (R.TangentVector) -> (T.TangentVector...)
   // Or a value and differential:
   //     (value: R, differential: (T.TangentVector...) -> (R.TangentVector)
-  auto derivativeResultType = derivative->getResultInterfaceType();
-  auto derivativeResultTupleType = derivativeResultType->getAs<TupleType>();
-  if (!derivativeResultTupleType ||
-      derivativeResultTupleType->getNumElements() != 2) {
-    diags.diagnose(attr->getLocation(),
-                   diag::derivative_attr_expected_result_tuple);
-    return true;
-  }
-  auto valueResultElt = derivativeResultTupleType->getElement(0);
-  auto funcResultElt = derivativeResultTupleType->getElement(1);
-  // Get derivative kind and derivative function identifier.
+  // Derivatives of coroutines are different: they yield the result and return
+  // the pullback, so we cannot reasonably check them here.
   AutoDiffDerivativeFunctionKind kind;
-  if (valueResultElt.getName().str() != "value") {
-    diags.diagnose(attr->getLocation(),
-                   diag::derivative_attr_invalid_result_tuple_value_label);
-    return true;
-  }
-  if (funcResultElt.getName().str() == "differential") {
-    kind = AutoDiffDerivativeFunctionKind::JVP;
-  } else if (funcResultElt.getName().str() == "pullback") {
+  if (derivative->isCoroutine()) {
+    auto derivativeResultType = derivative->getResultInterfaceType();
+    // Coroutines derivatives must return VJP / JVP. We do not support normal
+    // results.
+    if (!derivativeResultType->getAs<AnyFunctionType>()) {
+      diags.diagnose(attr->getLocation(),
+                     diag::derivative_attr_expected_coro_result);
+      return true;
+    }
+
+    // TODO: Invent a way to specify JVPs
     kind = AutoDiffDerivativeFunctionKind::VJP;
   } else {
-    diags.diagnose(attr->getLocation(),
-                   diag::derivative_attr_invalid_result_tuple_func_label);
-    return true;
+    auto derivativeResultType = derivative->getResultInterfaceType();
+    auto derivativeResultTupleType = derivativeResultType->getAs<TupleType>();
+    if (!derivativeResultTupleType ||
+        derivativeResultTupleType->getNumElements() != 2) {
+      diags.diagnose(attr->getLocation(),
+                     diag::derivative_attr_expected_result_tuple);
+      return true;
+    }
+
+    auto valueResultElt = derivativeResultTupleType->getElement(0);
+    if (valueResultElt.getName().str() != "value") {
+      diags.diagnose(attr->getLocation(),
+                     diag::derivative_attr_invalid_result_tuple_value_label);
+      return true;
+    }
+
+    // Get derivative kind and derivative function identifier.
+    auto funcResultElt = derivativeResultTupleType->getElement(1);
+    if (funcResultElt.getName().str() == "differential") {
+      kind = AutoDiffDerivativeFunctionKind::JVP;
+    } else if (funcResultElt.getName().str() == "pullback") {
+      kind = AutoDiffDerivativeFunctionKind::VJP;
+    } else {
+      diags.diagnose(attr->getLocation(),
+                     diag::derivative_attr_invalid_result_tuple_func_label);
+      return true;
+    }
   }
   attr->setDerivativeKind(kind);
 
@@ -7661,29 +7699,52 @@ static bool typeCheckDerivativeAttr(DerivativeAttr *attr) {
   // expected type. We must canonicalize the derivative interface type before
   // extracting the differential/pullback type from it so that types are
   // simplified via the canonical generic signature.
-  CanType canActualResultType = derivativeInterfaceType->getCanonicalType();
-  while (isa<AnyFunctionType>(canActualResultType)) {
-    canActualResultType =
-        cast<AnyFunctionType>(canActualResultType).getResult();
+  CanType actualLinearMapType;
+  if (derivative->isCoroutine()) {
+    CanType canActualResultType = derivativeInterfaceType->getCanonicalType();
+    // Coroutines return their linear maps (they yield values).
+    do {
+      actualLinearMapType = canActualResultType;
+      canActualResultType =
+          cast<AnyFunctionType>(canActualResultType).getResult();
+    } while (isa<AnyFunctionType>(canActualResultType));
+  } else {
+    CanType canActualResultType = derivativeInterfaceType->getCanonicalType();
+    while (isa<AnyFunctionType>(canActualResultType)) {
+      canActualResultType =
+          cast<AnyFunctionType>(canActualResultType).getResult();
+    }
+    actualLinearMapType =
+        cast<TupleType>(canActualResultType).getElementType(1);
   }
-  CanType actualLinearMapType =
-      cast<TupleType>(canActualResultType).getElementType(1);
 
   // Check if differential/pullback type matches expected type.
   if (!actualLinearMapType->isEqual(expectedLinearMapType)) {
     // Emit differential/pullback type mismatch error on attribute.
     diags.diagnose(attr->getLocation(),
                    diag::derivative_attr_result_func_type_mismatch,
-                   funcResultElt.getName(), originalAFD);
+                   Ctx.getIdentifier(kind == AutoDiffDerivativeFunctionKind::VJP
+                                         ? "pullback"
+                                         : "differential"),
+                   originalAFD);
     // Emit note with expected differential/pullback type on actual type
     // location.
-    auto *tupleReturnTypeRepr =
-        cast<TupleTypeRepr>(derivative->getResultTypeRepr());
-    auto *funcEltTypeRepr = tupleReturnTypeRepr->getElementType(1);
+    TypeRepr *funcEltTypeRepr;
+    if (derivative->isCoroutine()) {
+      funcEltTypeRepr = derivative->getResultTypeRepr();
+    } else {
+      auto *tupleReturnTypeRepr =
+          cast<TupleTypeRepr>(derivative->getResultTypeRepr());
+      funcEltTypeRepr = tupleReturnTypeRepr->getElementType(1);
+    }
+
     diags
         .diagnose(funcEltTypeRepr->getStartLoc(),
                   diag::derivative_attr_result_func_type_mismatch_note,
-                  funcResultElt.getName(), expectedLinearMapType)
+                  Ctx.getIdentifier(kind == AutoDiffDerivativeFunctionKind::VJP
+                                        ? "pullback"
+                                        : "differential"),
+                  expectedLinearMapType)
         .highlight(funcEltTypeRepr->getSourceRange());
     // Emit note showing original function location, if possible.
     if (originalAFD->getLoc().isValid())

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -7034,12 +7034,20 @@ bool resolveDifferentiableAttrDifferentiabilityParameters(
                      nonDiffParam.first);
       return;
     }
-    case DerivativeFunctionTypeError::Kind::NonDifferentiableResult:
+    case DerivativeFunctionTypeError::Kind::NonDifferentiableResult: {
       auto nonDiffResult = error.getNonDifferentiableTypeAndIndex();
       diags.diagnose(attr->getLocation(),
                      diag::autodiff_attr_result_not_differentiable,
                      nonDiffResult.first);
       return;
+    }
+    case DerivativeFunctionTypeError::Kind::NonDifferentiableYield: {
+      auto nonDiffYield = error.getNonDifferentiableTypeAndIndex();
+      diags.diagnose(attr->getLocation(),
+                     diag::autodiff_attr_yield_not_differentiable,
+                     nonDiffYield.first);
+      return;
+    }
     }
   };
   // Diagnose any derivative function type errors.
@@ -7674,12 +7682,20 @@ static bool typeCheckDerivativeAttr(DerivativeAttr *attr) {
                      nonDiffParam.first);
       return;
     }
-    case DerivativeFunctionTypeError::Kind::NonDifferentiableResult:
+    case DerivativeFunctionTypeError::Kind::NonDifferentiableResult: {
       auto nonDiffResult = error.getNonDifferentiableTypeAndIndex();
       diags.diagnose(attr->getLocation(),
                      diag::autodiff_attr_result_not_differentiable,
                      nonDiffResult.first);
       return;
+    }
+    case DerivativeFunctionTypeError::Kind::NonDifferentiableYield: {
+      auto nonDiffYield = error.getNonDifferentiableTypeAndIndex();
+      diags.diagnose(attr->getLocation(),
+                     diag::autodiff_attr_yield_not_differentiable,
+                     nonDiffYield.first);
+      return;
+    }
     }
   };
   // Diagnose any derivative function type errors.

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -5428,7 +5428,8 @@ SILDeserializer::readDifferentiabilityWitness(DeclID DId) {
                        ArrayRef<unsigned>(parameterAndResultIndices)
                            .take_front(numParameterIndices));
   auto numResults = originalFnType->getNumResults() +
-                    originalFnType->getNumIndirectMutatingParameters();
+                    originalFnType->getNumIndirectMutatingParameters() +
+                    originalFnType->getNumYields();
   auto *resultIndices =
       IndexSubset::get(MF->getContext(), numResults,
                        ArrayRef<unsigned>(parameterAndResultIndices)

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -3760,12 +3760,10 @@ void SILSerializer::writeSILDifferentiabilityWitness(
              dw.getParameterIndices()->getCapacity() &&
          "Original function parameter count should match differentiability "
          "witness parameter indices capacity");
-  unsigned numInoutParameters = llvm::count_if(
-      originalFnType->getParameters(), [](SILParameterInfo paramInfo) {
-        return paramInfo.isIndirectMutating();
-      });
-  assert(originalFnType->getNumResults() + numInoutParameters ==
-             dw.getResultIndices()->getCapacity() &&
+  assert(originalFnType->getNumResults() +
+         originalFnType->getNumIndirectMutatingParameters() +
+         originalFnType->getNumYields() ==
+         dw.getResultIndices()->getCapacity() &&
          "Original function result count should match differentiability "
          "witness result indices capacity");
 

--- a/stdlib/public/Differentiation/ArrayDifferentiation.swift
+++ b/stdlib/public/Differentiation/ArrayDifferentiation.swift
@@ -170,10 +170,15 @@ where Element: AdditiveArithmetic & Differentiable {
 
   @inlinable
   public subscript(_ index: Int) -> Element {
-    if index < base.count {
-      return base[index]
-    } else {
-      return Element.zero
+    get {
+      if index < base.count {
+        return base[index]
+      } else {
+        return Element.zero
+      }
+    }
+    _modify {
+      yield &base[index]
     }
   }
 }
@@ -226,6 +231,21 @@ extension Array where Element: Differentiable {
       return v[index]
     }
     return (self[index], differential)
+  }
+
+  @inlinable
+  @derivative(of: subscript._modify)
+  @yield_once
+  mutating func _vjpModify(index: Int) yields (inout Element) ->
+    @yield_once (inout TangentVector) yields (inout Element.TangentVector) -> ()
+  {
+    yield &self[index]
+
+    @yield_once
+    func pullback(_ v: inout TangentVector) yields (inout Element.TangentVector) -> () {
+      yield &v[index]
+    }
+    return pullback
   }
 
   @inlinable

--- a/stdlib/public/Differentiation/CMakeLists.txt
+++ b/stdlib/public/Differentiation/CMakeLists.txt
@@ -45,6 +45,7 @@ add_swift_target_library(swift_Differentiation ${SWIFT_STDLIB_LIBRARY_BUILD_TYPE
     -Dswift_Differentiation_EXPORTS
   SWIFT_COMPILE_FLAGS
     ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
+    -enable-experimental-feature CoroutineFunctions
     -parse-stdlib
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
   INSTALL_IN_COMPONENT stdlib

--- a/test/AutoDiff/SILGen/coro_differentiability_witness.swift
+++ b/test/AutoDiff/SILGen/coro_differentiability_witness.swift
@@ -1,0 +1,66 @@
+// RUN: %target-swift-frontend -emit-silgen -verify -enable-experimental-feature CoroutineFunctions %s | %FileCheck %s
+
+// REQUIRES: swift_feature_CoroutineFunctions
+
+import _Differentiation
+
+struct StructWithModifyAccessor {
+  private var _x : Float
+
+  var x: Float {
+    get { _x }
+    _modify { yield &_x }
+  }
+}
+
+extension StructWithModifyAccessor : Differentiable {
+  @yield_once
+  @derivative(of: x._modify)
+  mutating func vjpModify() yields (inout Float) -> @yield_once (inout TangentVector) yields (inout Float) -> () {
+    yield &x
+
+    @yield_once func pb(_ x : inout TangentVector) yields (inout Float) -> () {
+      var _x = Float(0.0)
+      yield &_x
+      x = TangentVector(_x : _x)
+    }
+
+    return pb
+  }
+}
+
+// CHECK-LABEL: // differentiability witness for StructWithModifyAccessor.x.modify
+// CHECK-NEXT: sil_differentiability_witness hidden [reverse] [parameters 0] [results 0 1] @$s30coro_differentiability_witness24StructWithModifyAccessorV1xSfvM : $@yield_once @convention(method) (@inout StructWithModifyAccessor) -> @yields @inout Float {
+// CHECK-NEXT:  vjp
+// CHECK-NEXT: }
+
+// CHECK-NOT: // differentiability witness for StructWithModifyAccessor.x.modify
+
+
+// TODO: Enable then thunked coroutine linear maps will be added
+/*
+struct GenStructWithModifyAccessor<T> {
+  private var _x : T
+
+  var x: T {
+    get { _x }
+    _modify { yield &_x }
+  }
+}
+
+extension GenStructWithModifyAccessor : Differentiable where T : Differentiable, T == T.TangentVector {
+  @yield_once
+  @derivative(of: x._modify)
+  mutating func vjpModify() yields (inout T) -> @yield_once (inout TangentVector) yields (inout T.TangentVector) -> () {
+    yield &x
+
+    @yield_once func pb(_ x : inout TangentVector) yields (inout T) -> () {
+      var _x : T.TangentVector
+      yield &_x
+      x = TangentVector(_x : _x)
+    }
+
+    return pb
+  }
+}
+*/

--- a/test/AutoDiff/SILGen/coro_differentiability_witness.swift
+++ b/test/AutoDiff/SILGen/coro_differentiability_witness.swift
@@ -36,9 +36,13 @@ extension StructWithModifyAccessor : Differentiable {
 
 // CHECK-NOT: // differentiability witness for StructWithModifyAccessor.x.modify
 
+// CHECK-LABEL: // differentiability witness for GenStructWithModifyAccessor.x.modify
+// CHECK-NEXT: sil_differentiability_witness hidden [reverse] [parameters 0] [results 0 1] <T where T : Differentiable, T == T.TangentVector> @$s30coro_differentiability_witness27GenStructWithModifyAccessorV1xxvM : $@yield_once @convention(method) <T> (@inout GenStructWithModifyAccessor<T>) -> @yields @inout T {
+// CHECK-NEXT:   vjp
+// CHECK-NEXT: }
 
-// TODO: Enable then thunked coroutine linear maps will be added
-/*
+// CHECK-NOT: // differentiability witness for GenStructWithModifyAccessor.x.modify
+
 struct GenStructWithModifyAccessor<T> {
   private var _x : T
 
@@ -63,4 +67,3 @@ extension GenStructWithModifyAccessor : Differentiable where T : Differentiable,
     return pb
   }
 }
-*/

--- a/test/AutoDiff/SILOptimizer/activity_analysis.swift
+++ b/test/AutoDiff/SILOptimizer/activity_analysis.swift
@@ -642,8 +642,6 @@ func testAccessorCoroutinesModify(_ x: HasCoroutineModifyAccessors) -> Float {
 func testBeginApplyActiveInoutArgument(array: [Float], x: Float) -> Float {
   var array = array
   // Array subscript assignment below calls `Array.subscript.modify`.
-  // expected-error @+2 {{expression is not differentiable}}  
-  // expected-note @+1 {{cannot differentiate functions that have not been marked '@differentiable' and that are defined in other files}}
   array[0] = x
   return array[0]
 }
@@ -679,8 +677,6 @@ func testBeginApplyActiveButInitiallyNonactiveInoutArgument(x: Float) -> Float {
   // `var array` is initially non-active.
   var array: [Float] = [0]
   // Array subscript assignment below calls `Array.subscript.modify`.
-  // expected-error @+2 {{expression is not differentiable}}  
-  // expected-note @+1 {{cannot differentiate functions that have not been marked '@differentiable' and that are defined in other files}}
   array[0] = x
   return array[0]
 }

--- a/test/AutoDiff/SILOptimizer/differentiation_diagnostics.swift
+++ b/test/AutoDiff/SILOptimizer/differentiation_diagnostics.swift
@@ -786,7 +786,7 @@ public func fragileDifferentiable(_ x: Float) -> Float {
 }
 
 //===----------------------------------------------------------------------===//
-// Coroutines (SIL function yields, `begin_apply`) (not yet supported)
+// Coroutines (SIL function yields, `begin_apply`)
 //===----------------------------------------------------------------------===//
 
 struct HasReadAccessors: Differentiable {
@@ -826,8 +826,6 @@ func testModifyAccessorCoroutines(_ x: HasModifyAccessors) -> Float {
 func TF_1078(array: [Float], x: Float) -> Float {
   var array = array
   // Array subscript assignment below calls `Array.subscript.modify`.
-  // expected-error @+2 {{expression is not differentiable}}
-  // expected-note @+1 {{cannot differentiate functions that have not been marked '@differentiable' and that are defined in other files}}
   array[0] = x
   return array[0]
 }
@@ -837,8 +835,6 @@ func TF_1078(array: [Float], x: Float) -> Float {
 func TF_1115(_ x: Float) -> Float {
   var array: [Float] = [0]
   // Array subscript assignment below calls `Array.subscript.modify`.
-  // expected-error @+2 {{expression is not differentiable}}
-  // expected-note @+1 {{cannot differentiate functions that have not been marked '@differentiable' and that are defined in other files}}
   array[0] = x
   return array[0]
 }

--- a/test/AutoDiff/Sema/derivative_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/derivative_attr_type_checking.swift
@@ -1,9 +1,10 @@
-// RUN: %target-swift-frontend-typecheck -verify -verify-ignore-unrelated -target %target-swift-5.1-abi-triple %s -package-name myPkg -enable-experimental-feature CoroutineAccessors
-// RUN: %target-swift-frontend-typecheck -enable-testing -verify -verify-ignore-unrelated -target %target-swift-5.1-abi-triple %s -package-name myPkg -enable-experimental-feature CoroutineAccessors
+// RUN: %target-swift-frontend-typecheck -verify -verify-ignore-unrelated -target %target-swift-5.1-abi-triple %s -package-name myPkg -enable-experimental-feature CoroutineAccessors -enable-experimental-feature CoroutineFunctions
+// RUN: %target-swift-frontend-typecheck -enable-testing -verify -verify-ignore-unrelated -target %target-swift-5.1-abi-triple %s -package-name myPkg -enable-experimental-feature CoroutineAccessors -enable-experimental-feature CoroutineFunctions
 
 // Swift.AdditiveArithmetic:3:17: note: cannot yet register derivative default implementation for protocol requirements
 
 // REQUIRES: swift_feature_CoroutineAccessors
+// REQUIRES: swift_feature_CoroutineFunctions
 
 import _Differentiation
 
@@ -429,7 +430,6 @@ extension Class: Differentiable where T: Differentiable {}
 // Test computed properties.
 
 extension Struct {
-  // expected-note @+1 {{cannot register derivative for _modify accessor}}
   var computedProperty: T {
     get { x }
     set { x = newValue }
@@ -437,15 +437,13 @@ extension Struct {
   }
   // The `@derivative(of:)` annotations below specify
   // .`yielding borrow` and .`yielding mutate`
-  // expected-note @+2 {{cannot register derivative for yielding borrow accessor}}
-  // expected-note @+1 {{cannot register derivative for yielding mutate accessor}}
+  // expected-note @+1 {{cannot register derivative for yielding borrow accessor}}
   var computedProperty2: T {
     yielding borrow { yield x }
     yielding mutate { yield &x }
   }
   // The `@derivative(of:)` annotations below specify .borrow and .mutate
-  // expected-note @+2 {{cannot register derivative for yielding borrow accessor}}
-  // expected-note @+1 {{cannot register derivative for yielding mutate accessor}}
+  // expected-note @+1 {{cannot register derivative for yielding borrow accessor}}
   var computedProperty2a: T {
     yielding borrow { yield x }
     yielding mutate { yield &x }
@@ -475,11 +473,10 @@ extension Struct where T: Differentiable & AdditiveArithmetic {
     fatalError()
   }
 
-  // expected-error @+1 {{referenced declaration 'computedProperty' could not be resolved}}
   @derivative(of: computedProperty._modify)
-  mutating func vjpPropertyModify(_ newValue: T) -> (
-    value: (), pullback: (inout TangentVector) -> T.TangentVector
-  ) {
+  @yield_once
+  mutating func vjpPropertyModify() yields(inout T) -> @yield_once (inout TangentVector) yields(inout T.TangentVector) -> ()
+  {
     fatalError()
   }
 
@@ -491,12 +488,10 @@ extension Struct where T: Differentiable & AdditiveArithmetic {
     fatalError()
   }
 
-
-  // expected-error @+1 {{referenced declaration 'computedProperty2' could not be resolved}}
   @derivative(of: computedProperty2.`yielding mutate`)
-  mutating func vjpPropertyYieldingMutate(_ newValue: T) -> (
-    value: (), pullback: (inout TangentVector) -> T.TangentVector
-  ) {
+  @yield_once
+  mutating func vjpPropertyYieldingMutate() yields(inout T) -> @yield_once (inout TangentVector) yields(inout T.TangentVector) -> ()
+  {
     fatalError()
   }
 
@@ -510,11 +505,10 @@ extension Struct where T: Differentiable & AdditiveArithmetic {
   }
 
   // We can match `.borrow` or `.mutate` to a yielding borrow or mutate
-  // expected-error @+1 {{referenced declaration 'computedProperty2a' could not be resolved}}
   @derivative(of: computedProperty2a.mutate)
-  mutating func vjpProperty2Mutate(_ newValue: T) -> (
-    value: (), pullback: (inout TangentVector) -> T.TangentVector
-  ) {
+  @yield_once
+  mutating func vjpProperty2Mutate() yields(inout T) -> @yield_once (inout TangentVector) yields(inout T.TangentVector) -> ()
+  {
     fatalError()
   }
 

--- a/test/AutoDiff/validation-test/array.swift
+++ b/test/AutoDiff/validation-test/array.swift
@@ -36,9 +36,24 @@ ArrayAutoDiffTests.test("ArraySubscript") {
     return array[0] + array[1] + array[2]
   }
 
+  func modifyArray(_ array: [Float]) -> Float {
+    var array = array
+    var result: Float = 0
+    for index in withoutDerivative(at: 0 ..< array.count) {
+      let multiplier = 1.0 + Float(index)
+      array[index] *= multiplier
+      result += array[index]
+    }
+
+    return result
+  }
+
   expectEqual(
     FloatArrayTan([1, 1, 1, 0, 0, 0]),
     gradient(at: [2, 3, 4, 5, 6, 7], of: sumFirstThree))
+  expectEqual(
+    FloatArrayTan([1, 2, 3]),
+    gradient(at: [1, 1, 1], of: modifyArray))
 }
 
 ArrayAutoDiffTests.test("ArrayLiteral") {


### PR DESCRIPTION
This is a stacked PR (after https://github.com/swiftlang/swift/pull/87783) including support for custom coroutine derivatives.

Use them to enable Array subscript modify accessor differentiation.