### PR TITLE
Fix objcImpl type metadata accessor issue

### DIFF
--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -1082,6 +1082,21 @@ MetadataAccessStrategy irgen::getTypeMetadataAccessStrategy(CanType type) {
     if (requiresForeignTypeMetadata(nominal))
       return MetadataAccessStrategy::ForeignAccessor;
 
+    // @objc @implementation classes *should* be treated like imported ObjC
+    // classes, meaning they should use non-unique accessors. However, previous
+    // versions of the Swift compiler incorrectly emitted a public unique
+    // accessor, and clients which knew about the implementation (i.e. which had
+    // a swiftmodule that hadn't been generated from a swiftinterface) could
+    // sometimes use it.
+    //
+    // To improve this situation without breaking ABI, we'll use a non-unique
+    // accessor for classes implemented outside the main module, and fall
+    // through otherwise.
+    if (isa<ClassDecl>(nominal) && nominal->getObjCImplementationDecl()
+          && !nominal->getObjCImplementationDecl()
+                ->getModuleContext()->isMainModule())
+      return MetadataAccessStrategy::NonUniqueAccessor;
+
     // If the type doesn't guarantee that it has an access function,
     // we might have to use a non-unique accessor.
 

--- a/test/IRGen/objc_implementation_client.swift
+++ b/test/IRGen/objc_implementation_client.swift
@@ -1,0 +1,20 @@
+// Test doesn't pass on all platforms (rdar://101420862)
+// REQUIRES: OS=macosx
+
+// Note: This test employs test/IRGen/objc_implementation.swift as the
+// implementation it's trying to use.
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/abi -F %clang-importer-sdk-path/frameworks -import-objc-header %S/Inputs/objc_implementation.h -emit-module-path %t/objc_implementation.swiftmodule -target %target-future-triple %S/objc_implementation.swift
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t -I %S/Inputs/abi -F %clang-importer-sdk-path/frameworks %s -emit-ir -target %target-future-triple > %t.ir
+// RUN: %FileCheck --input-file %t.ir %s
+// REQUIRES: objc_interop
+
+import objc_implementation
+
+public func fn() {
+  _ = ImplClass()
+}
+
+// Should emit a non-unique metadata accessor for this module's private use
+// CHECK: define{{.*}} hidden {{.*}}@"$sSo9ImplClassCMa"


### PR DESCRIPTION
Classes that use `@objc @implementation` should be treated exactly like native Objective-C classes. Among other things, this means that rather than the defining module exposing a public type metadata accessor for them, each client should emit its own hidden accessor.

Unfortunately, Swift has not been doing this correctly—the defining module may expose an accessor and any clients which know the class is objcImpl will use it. (Clients using a swiftinterface module, or a swiftmodule built from a swiftinterface, won’t know the class is objcImpl, but clients using the original swiftmodule file will know.) Because existing binaries may be calling this symbol, we can’t remove it, but we *can* at least stop using it.

~~WIP: Needs tests~~