### PR TITLE
Revert "[Concurrency] Clock.measure adopt nonisolated nonsending type…

### DIFF
--- a/stdlib/public/Concurrency/Clock.swift
+++ b/stdlib/public/Concurrency/Clock.swift
@@ -135,18 +135,6 @@ extension Clock {
   ///       }
   @available(StdlibDeploymentTarget 5.7, *)
   @_alwaysEmitIntoClient
-  public nonisolated(nonsending) func measure<Failure>(
-    _ work: nonisolated(nonsending) () async throws(Failure) -> Void
-  ) async throws(Failure) -> Instant.Duration {
-    let start = now
-    try await work()
-    let end = now
-    return start.duration(to: end)
-  }
-
-  @available(StdlibDeploymentTarget 5.7, *)
-  @_alwaysEmitIntoClient
-  @_disfavoredOverload
   public func measure(
     isolation: isolated (any Actor)? = #isolation,
     _ work: () async throws -> Void


### PR DESCRIPTION
…d throws (#87642)"

This reverts commit 18db1e8ba1d9e53f3ae2728539842484c1f71d89.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
