### PR TITLE
[build-windows-toolchain.bat] Add `AndroidSDKArgs` parameters to cross-compile Android SDKs

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -81,6 +81,22 @@ set "WindowsSDKArgs=-Windows"
 if "%INCLUDE_PACKAGING%"=="" set "WindowsSDKArgs=%WindowsSDKArgs% -WindowsSDKLinkModes dynamic"
 if not "%WINDOWS_SDKS%"=="" set "WindowsSDKArgs=%WindowsSDKArgs% -WindowsSDKArchitectures %WINDOWS_SDKS%"
 
+:: Build the arguments related to Android SDK cross-compilation, disabled by default
+set "AndroidSDKArgs="
+if not "%ANDROID_SDKS%"=="" goto Android
+if not "%ANDROID_SDK_VERSIONS%"=="" goto Android
+if not "%ANDROID_LINK_MODES%"=="" goto Android
+
+goto :Android_end
+
+:Android
+set "AndroidSDKArgs=-Android"
+if not "%ANDROID_SDKS%"=="" set "AndroidSDKArgs=%AndroidSDKArgs% -AndroidSDKArchitectures %ANDROID_SDKS%"
+if not "%ANDROID_SDK_VERSIONS%"=="" set "AndroidSDKArgs=%AndroidSDKArgs% -AndroidSDKVersions %ANDROID_SDK_VERSIONS%"
+if not "%ANDROID_LINK_MODES%"=="" set "AndroidSDKArgs=%AndroidSDKArgs% -AndroidSDKLinkModes %ANDROID_LINK_MODES%"
+
+:Android_end
+
 :: Build the -HostArchName argument, if any.
 set "HostArchNameArg="
 if not "%HOST_ARCH_NAME%"=="" set "HostArchNameArg=-HostArchName %HOST_ARCH_NAME%"
@@ -94,6 +110,7 @@ powershell.exe -ExecutionPolicy RemoteSigned -File %~dp0build.ps1 ^
   -BinaryCache %BuildRoot% ^
   -ImageRoot %BuildRoot% ^
   %WindowsSDKArgs% ^
+  %AndroidSDKArgs% ^
   %PackagingArg% ^
   %TestArg% ^
   -IncludeSBoM ^

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -5978,7 +5978,7 @@ if ($Android) {
 
   # Copy static dependencies
   foreach ($Build in $AndroidSDKBuilds) {
-    if (-not $Build.LinkModes.Contains("static")) { continue }
+    if (-not $Build.LinkModes.Contains("static") -or -not $AndroidSDKVersions.Contains("AndroidExperimental")) { continue }
 
     $SwiftResourceDir = "${SDKROOT}\usr\lib\swift_static\$($Build.OS.ToString().ToLowerInvariant())\$($Build.Architecture.LLVMName)"
     Copy-Item -Force -Path "$(Get-ProjectBinaryCache $Build brotli)\libbrotlicommon.a" -Destination "${SwiftResourceDir}\libbrotlicommon.a" | Out-Null


### PR DESCRIPTION
The @swiftlang/android-workgroup has been discussing adding Android SDK builds to the pre-commit Windows PR CI, so this is a new interface to add that Windows CI config.