### PR TITLE
Add support for body macros on variables and accessors

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -544,7 +544,7 @@ unsigned Decl::getAttachedMacroDiscriminator(DeclBaseName macroName,
     if (foundDiscriminator) {
       return *foundDiscriminator;
     }
-    
+
     // For computed properties with only an implicit get,
     // the attr is on the parent VarDecl.
     if (role == MacroRole::Body) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -550,7 +550,12 @@ unsigned Decl::getAttachedMacroDiscriminator(DeclBaseName macroName,
     if (role == MacroRole::Body) {
       if (auto *accessor = dyn_cast<AccessorDecl>(this)) {
         if (auto *var = dyn_cast<VarDecl>(accessor->getStorage())) {
-          return var->getAttachedMacroDiscriminator(macroName, role, attr);
+          if (!var->hasStorage() && !var->isSettable(/*useDC=*/nullptr)) {
+            auto *getter = var->getParsedAccessor(AccessorKind::Get);
+            if (!getter || getter->isImplicitGetter()) {
+              return var->getAttachedMacroDiscriminator(macroName, role, attr);
+            }
+          }
         }
       }
     }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -533,18 +533,7 @@ unsigned Decl::getAttachedMacroDiscriminator(DeclBaseName macroName,
     llvm::SmallDenseMap<Identifier, unsigned> nextDiscriminator;
     std::optional<unsigned> foundDiscriminator;
 
-    // For getter accessors with body macros, the attr is on the parent VarDecl.
-    const Decl *declToSearch = this;
-    if (role == MacroRole::Body) {
-      if (auto *accessor = dyn_cast<AccessorDecl>(this);
-          accessor && accessor->isGetter()) {
-        if (auto *var = dyn_cast<VarDecl>(accessor->getStorage())) {
-          declToSearch = var;
-        }
-      }
-    }
-
-    declToSearch->forEachAttachedMacro(
+    forEachAttachedMacro(
         role, [&](CustomAttr *foundAttr, MacroDecl *foundMacro) {
           unsigned discriminator =
               nextDiscriminator[foundMacro->getBaseIdentifier()]++;
@@ -552,8 +541,19 @@ unsigned Decl::getAttachedMacroDiscriminator(DeclBaseName macroName,
             foundDiscriminator = discriminator;
         });
 
-    if (foundDiscriminator)
+    if (foundDiscriminator) {
       return *foundDiscriminator;
+    }
+    
+    // For computed properties with only an implicit get,
+    // the attr is on the parent VarDecl.
+    if (role == MacroRole::Body) {
+      if (auto *accessor = dyn_cast<AccessorDecl>(this)) {
+        if (auto *var = dyn_cast<VarDecl>(accessor->getStorage())) {
+          return var->getAttachedMacroDiscriminator(macroName, role, attr);
+        }
+      }
+    }
   }
 
   // If that failed, conjure up a discriminator.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -533,7 +533,18 @@ unsigned Decl::getAttachedMacroDiscriminator(DeclBaseName macroName,
     llvm::SmallDenseMap<Identifier, unsigned> nextDiscriminator;
     std::optional<unsigned> foundDiscriminator;
 
-    forEachAttachedMacro(
+    // For getter accessors with body macros, the attr is on the parent VarDecl.
+    const Decl *declToSearch = this;
+    if (role == MacroRole::Body) {
+      if (auto *accessor = dyn_cast<AccessorDecl>(this);
+          accessor && accessor->isGetter()) {
+        if (auto *var = dyn_cast<VarDecl>(accessor->getStorage())) {
+          declToSearch = var;
+        }
+      }
+    }
+
+    declToSearch->forEachAttachedMacro(
         role, [&](CustomAttr *foundAttr, MacroDecl *foundMacro) {
           unsigned discriminator =
               nextDiscriminator[foundMacro->getBaseIdentifier()]++;

--- a/lib/ASTGen/Sources/MacroEvaluation/PluginHost.swift
+++ b/lib/ASTGen/Sources/MacroEvaluation/PluginHost.swift
@@ -396,6 +396,7 @@ extension PluginMessage.Syntax {
   init?(syntax: Syntax, in sourceFilePtr: UnsafePointer<ExportedSourceFile>) {
     let kind: PluginMessage.Syntax.Kind
     switch true {
+    case syntax.is(AccessorDeclSyntax.self): kind = .accessor
     case syntax.is(DeclSyntax.self): kind = .declaration
     case syntax.is(ExprSyntax.self): kind = .expression
     case syntax.is(StmtSyntax.self): kind = .statement

--- a/lib/ASTGen/Sources/MacroEvaluation/PluginHost.swift
+++ b/lib/ASTGen/Sources/MacroEvaluation/PluginHost.swift
@@ -427,6 +427,7 @@ extension PluginMessage.Syntax {
   init?(syntax: Syntax) {
     let kind: PluginMessage.Syntax.Kind
     switch true {
+    case syntax.is(AccessorDeclSyntax.self): kind = .accessor
     case syntax.is(DeclSyntax.self): kind = .declaration
     case syntax.is(ExprSyntax.self): kind = .expression
     case syntax.is(StmtSyntax.self): kind = .statement

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1973,12 +1973,14 @@ ExpandBodyMacroRequest::evaluate(Evaluator &evaluator,
 
   // Body macros on a computed getter-only var are attached to the VarDecl,
   // not to the implicit getter accessor.
-  if (auto *afd = fn.getAbstractFunctionDecl()) {
-    if (auto *accessor = dyn_cast<AccessorDecl>(afd);
-        accessor && accessor->isGetter()) {
+  if (auto *functionDecl = fn.getAbstractFunctionDecl()) {
+    if (auto *accessor = dyn_cast<AccessorDecl>(functionDecl)) {
       if (auto *var = dyn_cast<VarDecl>(accessor->getStorage())) {
         var->forEachAttachedMacro(MacroRole::Body, expandMacro);
-        return bufferID;
+        
+        if (bufferID) {
+          return bufferID;
+        }
       }
     }
   }

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -585,14 +585,20 @@ bool swift::isInvalidAttachedMacro(MacroRole role,
 
   case MacroRole::Preamble:
   case MacroRole::Body:
-    // Only function declarations or computed variables (with only a getter, but
-    // no setter)
+    // Only function declarations or computed variables with an implicit getter
+    // (no explicit getter, no setter).
     if (isa<AbstractFunctionDecl>(attachedTo))
       return false;
 
-    if (auto *var = dyn_cast<VarDecl>(attachedTo))
-      if (!var->hasStorage() && !var->isSettable(/*useDC=*/nullptr))
-        return false;
+    if (auto *var = dyn_cast<VarDecl>(attachedTo)) {
+      if (!var->hasStorage() && !var->isSettable(/*useDC=*/nullptr)) {
+        // Disallow body macros on vars with an explicit getter — the macro
+        // should be attached directly to the getter accessor instead.
+        auto *getter = var->getParsedAccessor(AccessorKind::Get);
+        if (!getter || getter->isImplicitGetter())
+          return false;
+      }
+    }
 
     break;
   }

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -585,9 +585,13 @@ bool swift::isInvalidAttachedMacro(MacroRole role,
 
   case MacroRole::Preamble:
   case MacroRole::Body:
-    // Only function declarations.
+    // Only function declarations or computed variables (with only a getter, but no setter)
     if (isa<AbstractFunctionDecl>(attachedTo))
       return false;
+
+    if (auto *var = dyn_cast<VarDecl>(attachedTo))
+      if (!var->hasStorage() && !var->isSettable(/*useDC=*/nullptr))
+        return false;
 
     break;
   }
@@ -1945,28 +1949,41 @@ std::optional<unsigned>
 ExpandBodyMacroRequest::evaluate(Evaluator &evaluator,
                                  AnyFunctionRef fn) const {
   std::optional<unsigned> bufferID;
-  fn.forEachAttachedMacro(
-      MacroRole::Body,
-      [&](CustomAttr *customAttr, MacroDecl *macro) {
-        // FIXME: Should we complain if we already expanded a body macro?
-        if (bufferID)
-          return;
 
-        SourceFile * macroSourceFile = nullptr;
-        if (auto *fnDecl = fn.getAbstractFunctionDecl()) {
-          macroSourceFile = ::evaluateAttachedMacro(
-              macro, fnDecl, customAttr, false, MacroRole::Body);
-        } else if (auto *closure =
-            dyn_cast_or_null<ClosureExpr>(fn.getAbstractClosureExpr())) {
-          macroSourceFile = ::evaluateAttachedMacro(
-              macro, closure, customAttr, MacroRole::Body);
-        }
+  auto expandMacro = [&](CustomAttr *customAttr, MacroDecl *macro) {
+    // FIXME: Should we complain if we already expanded a body macro?
+    if (bufferID)
+      return;
 
-        if (!macroSourceFile)
-          return;
+    SourceFile *macroSourceFile = nullptr;
+    if (auto *fnDecl = fn.getAbstractFunctionDecl()) {
+      macroSourceFile = ::evaluateAttachedMacro(
+          macro, fnDecl, customAttr, false, MacroRole::Body);
+    } else if (auto *closure =
+        dyn_cast_or_null<ClosureExpr>(fn.getAbstractClosureExpr())) {
+      macroSourceFile = ::evaluateAttachedMacro(
+          macro, closure, customAttr, MacroRole::Body);
+    }
 
-        bufferID = macroSourceFile->getBufferID();
-      });
+    if (!macroSourceFile)
+      return;
+
+    bufferID = macroSourceFile->getBufferID();
+  };
+
+  // Body macros on a computed getter-only var are attached to the VarDecl,
+  // not to the implicit getter accessor.
+  if (auto *afd = fn.getAbstractFunctionDecl()) {
+    if (auto *accessor = dyn_cast<AccessorDecl>(afd);
+        accessor && accessor->isGetter()) {
+      if (auto *var = dyn_cast<VarDecl>(accessor->getStorage())) {
+        var->forEachAttachedMacro(MacroRole::Body, expandMacro);
+        return bufferID;
+      }
+    }
+  }
+
+  fn.forEachAttachedMacro(MacroRole::Body, expandMacro);
 
   return bufferID;
 }

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -585,7 +585,8 @@ bool swift::isInvalidAttachedMacro(MacroRole role,
 
   case MacroRole::Preamble:
   case MacroRole::Body:
-    // Only function declarations or computed variables (with only a getter, but no setter)
+    // Only function declarations or computed variables (with only a getter, but
+    // no setter)
     if (isa<AbstractFunctionDecl>(attachedTo))
       return false;
 
@@ -1957,12 +1958,12 @@ ExpandBodyMacroRequest::evaluate(Evaluator &evaluator,
 
     SourceFile *macroSourceFile = nullptr;
     if (auto *fnDecl = fn.getAbstractFunctionDecl()) {
-      macroSourceFile = ::evaluateAttachedMacro(
-          macro, fnDecl, customAttr, false, MacroRole::Body);
+      macroSourceFile = ::evaluateAttachedMacro(macro, fnDecl, customAttr,
+                                                false, MacroRole::Body);
     } else if (auto *closure =
-        dyn_cast_or_null<ClosureExpr>(fn.getAbstractClosureExpr())) {
-      macroSourceFile = ::evaluateAttachedMacro(
-          macro, closure, customAttr, MacroRole::Body);
+                   dyn_cast_or_null<ClosureExpr>(fn.getAbstractClosureExpr())) {
+      macroSourceFile =
+          ::evaluateAttachedMacro(macro, closure, customAttr, MacroRole::Body);
     }
 
     if (!macroSourceFile)
@@ -1977,7 +1978,7 @@ ExpandBodyMacroRequest::evaluate(Evaluator &evaluator,
     if (auto *accessor = dyn_cast<AccessorDecl>(functionDecl)) {
       if (auto *var = dyn_cast<VarDecl>(accessor->getStorage())) {
         var->forEachAttachedMacro(MacroRole::Body, expandMacro);
-        
+
         if (bufferID) {
           return bufferID;
         }

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -2747,10 +2747,39 @@ public struct PrintBodyMacro: BodyMacro {
     providingBodyFor declaration: some DeclSyntaxProtocol & WithOptionalCodeBlockSyntax,
     in context: some MacroExpansionContext
   ) throws -> [CodeBlockItemSyntax] {
+    func nameFromContextNode(_ node: Syntax) -> String? {
+      if let varDecl = node.as(VariableDeclSyntax.self) {
+        return varDecl.bindings.first?.pattern.as(IdentifierPatternSyntax.self)?.identifier.text
+      }
+      if let binding = node.as(PatternBindingSyntax.self) {
+        return binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text
+      }
+      if let named = node.asProtocol(NamedDeclSyntax.self) {
+        return named.name.text
+      }
+      return nil
+    }
+
+    // Determine the declaration's own name component (for named decls like functions).
+    // For accessors, the name comes from the lexical context instead.
+    let ownName: String?
+    if let funcDecl = declaration.as(FunctionDeclSyntax.self) {
+      ownName = funcDecl.name.text
+    } else if let varDecl = declaration.as(VariableDeclSyntax.self) {
+      ownName = varDecl.bindings.first?.pattern.as(IdentifierPatternSyntax.self)?.identifier.text
+    } else {
+      ownName = nil
+    }
+
+    // Build the full dot-separated path from outermost to innermost context, then own name.
+    let contextNames = context.lexicalContext.compactMap { nameFromContextNode($0) }.reversed()
+    let allNames = Array(contextNames) + (ownName.map { [$0] } ?? [])
+    let name = allNames.isEmpty ? "unknown" : allNames.joined(separator: ".")
+
     let originalBody = declaration.body.map { Array($0.statements) } ?? []
     return [
-      #"print("start body (from macro)")"#,
-      #"defer { print("end body (from macro)") }"#,
+      "print(\"start body (from macro, \(raw: name))\")",
+      "defer { print(\"end body (from macro, \(raw: name))\") }",
     ] + originalBody
   }
 }

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -2741,6 +2741,20 @@ struct EmptyBodyMacro: BodyMacro {
   }
 }
 
+public struct PrintBodyMacro: BodyMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingBodyFor declaration: some DeclSyntaxProtocol & WithOptionalCodeBlockSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [CodeBlockItemSyntax] {
+    let originalBody = declaration.body.map { Array($0.statements) } ?? []
+    return [
+      #"print("start body (from macro)")"#,
+      #"defer { print("end body (from macro)") }"#,
+    ] + originalBody
+  }
+}
+
 @_spi(ExperimentalLanguageFeatures)
 public struct TracedPreambleMacro: PreambleMacro {
   public static func expansion(

--- a/test/Macros/macro_expand_body.swift
+++ b/test/Macros/macro_expand_body.swift
@@ -14,6 +14,9 @@
 @attached(body)
 macro Remote() = #externalMacro(module: "MacroDefinition", type: "RemoteBodyMacro")
 
+@attached(body)
+macro Print() = #externalMacro(module: "MacroDefinition", type: "PrintBodyMacro")
+
 @attached(preamble)
 macro Traced() = #externalMacro(module: "MacroDefinition", type: "TracedPreambleMacro")
 
@@ -103,3 +106,27 @@ print(try await g(a: 5, b: "World"))
 // CHECK: --- use it
 // CHECK: Logger exiting useLogger()
 useLogger()
+
+@Print
+var computedVar: Bool {
+  print("hello from computedVar")
+  return true
+}
+
+var computedVarWithMacroOnGetter: Bool {
+  @Print
+  get {
+    print("hello from computedVarWithMacroOnGetter")
+    return true
+  }
+}
+
+// CHECK: start body (from macro)
+// CHECK-NEXT: hello from computedVar
+// CHECK-NEXT: end body (from macro)
+_ = computedVar
+
+// CHECK: start body (from macro)
+// CHECK-NEXT: hello from computedVarWithMacroOnGetter
+// CHECK-NEXT: end body (from macro)
+_ = computedVarWithMacroOnGetter

--- a/test/Macros/macro_expand_body.swift
+++ b/test/Macros/macro_expand_body.swift
@@ -184,59 +184,59 @@ struct UniqueBorrow: ~Copyable {
   }
 }
 
-// CHECK: start body (from macro)
+// CHECK: start body (from macro, computedVar)
 // CHECK-NEXT: hello from computedVar
-// CHECK-NEXT: end body (from macro)
+// CHECK-NEXT: end body (from macro, computedVar)
 _ = computedVar
 
-// CHECK: start body (from macro)
+// CHECK: start body (from macro, computedVarWithExplicitGetter)
 // CHECK-NEXT: hello from computedVarWithExplicitGetter
-// CHECK-NEXT: end body (from macro)
+// CHECK-NEXT: end body (from macro, computedVarWithExplicitGetter)
 _ = computedVarWithExplicitGetter
 
-// CHECK: start body (from macro)
+// CHECK: start body (from macro, storedVarWithExplicitGetAndAttachedMacro)
 // CHECK-NEXT: Hello from storedVarWithGetAndAttachedMacro
-// CHECK-NEXT: end body (from macro)
+// CHECK-NEXT: end body (from macro, storedVarWithExplicitGetAndAttachedMacro)
 _ = storedVarWithExplicitGetAndAttachedMacro
 
-// CHECK: start body (from macro)
+// CHECK: start body (from macro, computedVarWithGetterAndSetter)
 // CHECK-NEXT: hello from computedVarWithGetterAndSetter
-// CHECK-NEXT: end body (from macro)
+// CHECK-NEXT: end body (from macro, computedVarWithGetterAndSetter)
 _ = computedVarWithGetterAndSetter
 
-// CHECK: start body (from macro)
+// CHECK: start body (from macro, computedVarWithGetterAndSetter)
 // CHECK-NEXT: Hello from setter: false
-// CHECK-NEXT: end body (from macro)
+// CHECK-NEXT: end body (from macro, computedVarWithGetterAndSetter)
 computedVarWithGetterAndSetter = false
 
-// CHECK: start body (from macro)
+// CHECK: start body (from macro, storedVarWithWillSetDidSet)
 // CHECK-NEXT: hello from storedVarWithWillSetDidSet willSet: true
-// CHECK-NEXT: end body (from macro)
-// CHECK-NEXT: start body (from macro)
+// CHECK-NEXT: end body (from macro, storedVarWithWillSetDidSet)
+// CHECK-NEXT: start body (from macro, storedVarWithWillSetDidSet)
 // CHECK-NEXT: hello from storedVarWithWillSetDidSet didSet: true
-// CHECK-NEXT: end body (from macro)
+// CHECK-NEXT: end body (from macro, storedVarWithWillSetDidSet)
 storedVarWithWillSetDidSet = true
 
 var uniqueBorrow = UniqueBorrow(x: 10)
 
-// CHECK: start body (from macro)
+// CHECK: start body (from macro, UniqueBorrow.propertyWithYieldingBorrowYieldingMutate)
 // CHECK-NEXT: Hello from yielding borrow
-// CHECK-NEXT: end body (from macro)
+// CHECK-NEXT: end body (from macro, UniqueBorrow.propertyWithYieldingBorrowYieldingMutate)
 _ = uniqueBorrow.propertyWithYieldingBorrowYieldingMutate
 
-// CHECK: start body (from macro)
+// CHECK: start body (from macro, UniqueBorrow.propertyWithYieldingBorrowYieldingMutate)
 // CHECK-NEXT: Hello from yielding mutate
-// CHECK-NEXT: end body (from macro)
+// CHECK-NEXT: end body (from macro, UniqueBorrow.propertyWithYieldingBorrowYieldingMutate)
 uniqueBorrow.propertyWithYieldingBorrowYieldingMutate = 10
 
-// CHECK: start body (from macro)
+// CHECK: start body (from macro, UniqueBorrow.propertyWithBorrowMutate)
 // CHECK-NEXT: Hello from borrow
-// CHECK-NEXT: end body (from macro)
+// CHECK-NEXT: end body (from macro, UniqueBorrow.propertyWithBorrowMutate)
 _ = uniqueBorrow.propertyWithBorrowMutate
 
-// CHECK: start body (from macro)
+// CHECK: start body (from macro, UniqueBorrow.propertyWithBorrowMutate)
 // CHECK-NEXT: Hello from mutate
-// CHECK-NEXT: end body (from macro)
+// CHECK-NEXT: end body (from macro, UniqueBorrow.propertyWithBorrowMutate)
 uniqueBorrow.propertyWithBorrowMutate = 10
 
 #if compiler(>=6.0) && TEST_DIAGNOSTICS

--- a/test/Macros/macro_expand_body.swift
+++ b/test/Macros/macro_expand_body.swift
@@ -232,12 +232,12 @@ uniqueBorrow.propertyWithYieldingBorrowYieldingMutate = 10
 // CHECK: start body (from macro)
 // CHECK-NEXT: Hello from borrow
 // CHECK-NEXT: end body (from macro)
-_ = uniqueBorrow.propertyWithYieldingBorrowYieldingMutate
+_ = uniqueBorrow.propertyWithBorrowMutate
 
 // CHECK: start body (from macro)
 // CHECK-NEXT: Hello from mutate
 // CHECK-NEXT: end body (from macro)
-uniqueBorrow.propertyWithYieldingBorrowYieldingMutate = 10
+uniqueBorrow.propertyWithBorrowMutate = 10
 
 #if compiler(>=6.0) && TEST_DIAGNOSTICS
 @Print // expected-error {{'body' macro cannot be attached to var ('storedVar')}}
@@ -256,7 +256,7 @@ var storedVarWithWillSetDidSetAttachedMacro = false {
   }
 }
 
-@Print // expected-error {{'body' macro cannot be attached to var ('storedVarWithExplicitGetAndAttachedMacro')}}
+@Print // expected-error {{'body' macro cannot be attached to var ('storedVarWithExplicitGetSetAndAttachedMacro'}}
 var storedVarWithExplicitGetSetAndAttachedMacro: Bool {
   get {
     print("Hello from storedVarWithGetAndAttachedMacro")
@@ -280,7 +280,7 @@ struct InvalidUniqueBorrow: ~Copyable {
     }
   }
   
-  @Print // expected-error {{unexpected error produced: 'body' macro cannot be attached to property ('propertyWithBorrowMutate')}}
+  @Print // expected-error {{'body' macro cannot be attached to property ('propertyWithBorrowMutate'}}
   var propertyWithBorrowMutate: Int {
     borrow {
       return x

--- a/test/Macros/macro_expand_body.swift
+++ b/test/Macros/macro_expand_body.swift
@@ -1,13 +1,15 @@
 // REQUIRES: swift_swift_parser, executable_test, asserts, concurrency, concurrency_runtime
 // REQUIRES: swift_feature_PreambleMacros
+// REQUIRES: swift_feature_CoroutineAccessors
+// REQUIRES: swift_feature_BorrowAndMutateAccessors
 // RUN: %empty-directory(%t)
-// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath -swift-version 5
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath -swift-version 5 -enable-experimental-feature BorrowAndMutateAccessors -enable-experimental-feature CoroutineAccessors
 
 // Diagnostics testing
-// RUN: %target-typecheck-verify-swift -swift-version 5 -enable-experimental-feature PreambleMacros -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS
+// RUN: %target-typecheck-verify-swift -swift-version 5 -enable-experimental-feature PreambleMacros -enable-experimental-feature BorrowAndMutateAccessors -enable-experimental-feature CoroutineAccessors -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS
 
 // Execution testing
-// RUN: %target-build-swift -swift-version 5 -g -enable-experimental-feature PreambleMacros -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser
+// RUN: %target-build-swift -swift-version 5 -g -enable-experimental-feature PreambleMacros -enable-experimental-feature BorrowAndMutateAccessors -enable-experimental-feature CoroutineAccessors -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 
@@ -121,6 +123,14 @@ var computedVarWithExplicitGetter: Bool {
   }
 }
 
+@Print
+var storedVarWithExplicitGetAndAttachedMacro: Bool {
+  get {
+    print("Hello from storedVarWithGetAndAttachedMacro")
+    return true
+  }
+}
+
 var computedVarWithGetterAndSetter: Bool {
   @Print
   get {
@@ -130,6 +140,47 @@ var computedVarWithGetterAndSetter: Bool {
   @Print
   set {
     print("Hello from setter: \(newValue)")
+  }
+}
+
+var storedVarWithWillSetDidSet = false {
+  @Print
+  willSet {
+    print("hello from storedVarWithWillSetDidSet willSet: \(newValue)")
+  }
+  @Print
+  didSet {
+    print("hello from storedVarWithWillSetDidSet didSet: \(storedVarWithWillSetDidSet)")
+  }
+}
+
+struct UniqueBorrow: ~Copyable {
+  var x: Int
+
+  var propertyWithYieldingBorrowYieldingMutate: Int {
+    @Print
+    yielding borrow {
+      print("Hello from yielding borrow")
+      yield x
+    }
+    @Print
+    yielding mutate {
+      print("Hello from yielding mutate")
+      yield &x
+    }
+  }
+  
+  var propertyWithBorrowMutate: Int {
+    @Print
+    borrow {
+      print("Hello from borrow")
+      return x
+    }
+    @Print
+    mutate {
+      print("Hello from mutate")
+      return &x
+    }
   }
 }
 
@@ -144,6 +195,11 @@ _ = computedVar
 _ = computedVarWithExplicitGetter
 
 // CHECK: start body (from macro)
+// CHECK-NEXT: Hello from storedVarWithGetAndAttachedMacro
+// CHECK-NEXT: end body (from macro)
+_ = storedVarWithExplicitGetAndAttachedMacro
+
+// CHECK: start body (from macro)
 // CHECK-NEXT: hello from computedVarWithGetterAndSetter
 // CHECK-NEXT: end body (from macro)
 _ = computedVarWithGetterAndSetter
@@ -152,3 +208,86 @@ _ = computedVarWithGetterAndSetter
 // CHECK-NEXT: Hello from setter: false
 // CHECK-NEXT: end body (from macro)
 computedVarWithGetterAndSetter = false
+
+// CHECK: start body (from macro)
+// CHECK-NEXT: hello from storedVarWithWillSetDidSet willSet: true
+// CHECK-NEXT: end body (from macro)
+// CHECK-NEXT: start body (from macro)
+// CHECK-NEXT: hello from storedVarWithWillSetDidSet didSet: true
+// CHECK-NEXT: end body (from macro)
+storedVarWithWillSetDidSet = true
+
+var uniqueBorrow = UniqueBorrow(x: 10)
+
+// CHECK: start body (from macro)
+// CHECK-NEXT: Hello from yielding borrow
+// CHECK-NEXT: end body (from macro)
+_ = uniqueBorrow.propertyWithYieldingBorrowYieldingMutate
+
+// CHECK: start body (from macro)
+// CHECK-NEXT: Hello from yielding mutate
+// CHECK-NEXT: end body (from macro)
+uniqueBorrow.propertyWithYieldingBorrowYieldingMutate = 10
+
+// CHECK: start body (from macro)
+// CHECK-NEXT: Hello from borrow
+// CHECK-NEXT: end body (from macro)
+_ = uniqueBorrow.propertyWithYieldingBorrowYieldingMutate
+
+// CHECK: start body (from macro)
+// CHECK-NEXT: Hello from mutate
+// CHECK-NEXT: end body (from macro)
+uniqueBorrow.propertyWithYieldingBorrowYieldingMutate = 10
+
+#if compiler(>=6.0) && TEST_DIAGNOSTICS
+@Print // expected-error {{'body' macro cannot be attached to var ('storedVar')}}
+var storedVar: Bool
+
+@Print // expected-error {{'body' macro cannot be attached to var ('storedVarWithDefault')}}
+var storedVarWithDefault = false
+
+@Print // expected-error {{'body' macro cannot be attached to var ('storedVarWithWillSetDidSetAttachedMacro')}}
+var storedVarWithWillSetDidSetAttachedMacro = false {
+  willSet {
+    print("hello from storedVarWithWillSetDidSetAttachedMacro willSet")
+  }
+  didSet {
+    print("hello from storedVarWithWillSetDidSetAttachedMacro didSet")
+  }
+}
+
+@Print // expected-error {{'body' macro cannot be attached to var ('storedVarWithExplicitGetAndAttachedMacro')}}
+var storedVarWithExplicitGetSetAndAttachedMacro: Bool {
+  get {
+    print("Hello from storedVarWithGetAndAttachedMacro")
+    return true
+  }
+  set {
+    print("Hello from storedVarWithExplicitGetAndAttachedMacro setter: \(newValue)")
+  }
+}
+
+struct InvalidUniqueBorrow: ~Copyable {
+  var x: Int
+
+  @Print // expected-error {{'body' macro cannot be attached to property ('propertyWithYieldingBorrowYieldingMutate')}}
+  var propertyWithYieldingBorrowYieldingMutate: Int {
+    yielding borrow {
+      yield x
+    }
+    yielding mutate {
+      yield &x
+    }
+  }
+  
+  @Print // expected-error {{unexpected error produced: 'body' macro cannot be attached to property ('propertyWithBorrowMutate')}}
+  var propertyWithBorrowMutate: Int {
+    borrow {
+      return x
+    }
+    mutate {
+      return &x
+    }
+  }
+}
+#endif

--- a/test/Macros/macro_expand_body.swift
+++ b/test/Macros/macro_expand_body.swift
@@ -3,7 +3,7 @@
 // REQUIRES: swift_feature_CoroutineAccessors
 // REQUIRES: swift_feature_BorrowAndMutateAccessors
 // RUN: %empty-directory(%t)
-// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath -swift-version 5 -enable-experimental-feature BorrowAndMutateAccessors -enable-experimental-feature CoroutineAccessors
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath -swift-version 5
 
 // Diagnostics testing
 // RUN: %target-typecheck-verify-swift -swift-version 5 -enable-experimental-feature PreambleMacros -enable-experimental-feature BorrowAndMutateAccessors -enable-experimental-feature CoroutineAccessors -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS

--- a/test/Macros/macro_expand_body.swift
+++ b/test/Macros/macro_expand_body.swift
@@ -123,14 +123,6 @@ var computedVarWithExplicitGetter: Bool {
   }
 }
 
-@Print
-var storedVarWithExplicitGetAndAttachedMacro: Bool {
-  get {
-    print("Hello from storedVarWithGetAndAttachedMacro")
-    return true
-  }
-}
-
 var computedVarWithGetterAndSetter: Bool {
   @Print
   get {
@@ -194,11 +186,6 @@ _ = computedVar
 // CHECK-NEXT: end body (from macro, computedVarWithExplicitGetter)
 _ = computedVarWithExplicitGetter
 
-// CHECK: start body (from macro, storedVarWithExplicitGetAndAttachedMacro)
-// CHECK-NEXT: Hello from storedVarWithGetAndAttachedMacro
-// CHECK-NEXT: end body (from macro, storedVarWithExplicitGetAndAttachedMacro)
-_ = storedVarWithExplicitGetAndAttachedMacro
-
 // CHECK: start body (from macro, computedVarWithGetterAndSetter)
 // CHECK-NEXT: hello from computedVarWithGetterAndSetter
 // CHECK-NEXT: end body (from macro, computedVarWithGetterAndSetter)
@@ -256,14 +243,22 @@ var storedVarWithWillSetDidSetAttachedMacro = false {
   }
 }
 
-@Print // expected-error {{'body' macro cannot be attached to var ('storedVarWithExplicitGetSetAndAttachedMacro'}}
-var storedVarWithExplicitGetSetAndAttachedMacro: Bool {
+@Print // expected-error {{'body' macro cannot be attached to var ('varWithExplicitGetAndAttachedMacro')}}
+var varWithExplicitGetAndAttachedMacro: Bool {
   get {
-    print("Hello from storedVarWithGetAndAttachedMacro")
+    print("Hello from varWithExplicitGetAndAttachedMacro")
+    return true
+  }
+}
+
+@Print // expected-error {{'body' macro cannot be attached to var ('varWithGetSetAndAttachedMacro'}}
+var varWithGetSetAndAttachedMacro: Bool {
+  get {
+    print("Hello from varWithGetSetAndAttachedMacro")
     return true
   }
   set {
-    print("Hello from storedVarWithExplicitGetAndAttachedMacro setter: \(newValue)")
+    print("Hello from varWithGetSetAndAttachedMacro setter: \(newValue)")
   }
 }
 

--- a/test/Macros/macro_expand_body.swift
+++ b/test/Macros/macro_expand_body.swift
@@ -113,11 +113,23 @@ var computedVar: Bool {
   return true
 }
 
-var computedVarWithMacroOnGetter: Bool {
+var computedVarWithExplicitGetter: Bool {
   @Print
   get {
-    print("hello from computedVarWithMacroOnGetter")
+    print("hello from computedVarWithExplicitGetter")
     return true
+  }
+}
+
+var computedVarWithGetterAndSetter: Bool {
+  @Print
+  get {
+    print("hello from computedVarWithGetterAndSetter")
+    return true
+  }
+  @Print
+  set {
+    print("Hello from setter: \(newValue)")
   }
 }
 
@@ -127,6 +139,16 @@ var computedVarWithMacroOnGetter: Bool {
 _ = computedVar
 
 // CHECK: start body (from macro)
-// CHECK-NEXT: hello from computedVarWithMacroOnGetter
+// CHECK-NEXT: hello from computedVarWithExplicitGetter
 // CHECK-NEXT: end body (from macro)
-_ = computedVarWithMacroOnGetter
+_ = computedVarWithExplicitGetter
+
+// CHECK: start body (from macro)
+// CHECK-NEXT: hello from computedVarWithGetterAndSetter
+// CHECK-NEXT: end body (from macro)
+_ = computedVarWithGetterAndSetter
+
+// CHECK: start body (from macro)
+// CHECK-NEXT: Hello from setter: false
+// CHECK-NEXT: end body (from macro)
+computedVarWithGetterAndSetter = false


### PR DESCRIPTION
Corresponding Swift Syntax PR: https://github.com/swiftlang/swift-syntax/pull/3298

---

According to [SE-0415](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0415-function-body-macros.md), body macros should be supported on variables and accessors:

> Function body macros can be applied to accessors as well, in which case they go on the accessor itself, e.g.,
> 
> ```swift
> var area: Double {
>   @Logged get {
>     return length * width
>   }
> }
> ```
> When using the shorthand syntax for get-only properties, a function body macro can be applied to the property itself:
> 
> ```swift
> @Logged var area: Double {
>   return length * width
> }
> ```

However, both forms are currently [unsupported](https://github.com/swiftlang/swift/issues/75715) with errors like `error: 'body' macro cannot be attached to var ('area')` or `error: Declaration is not a type with an optional code block`.

This PR adds supports for both of these use cases.

 - To support body macros on accessors, we only have to fix an issue where the SwiftSyntax plugin did not properly parse the `AccessorDeclSyntax` received via a plugin message. 
- To support body macros on computed property declarations, we have to update the compiler to pass through the `VariableDeclSyntax`, and then within Swift Syntax synthesize an implicit `AccessorDeclSyntax` to use in the `expansion(of:providingBodyFor:in:)` call (which needs a `WithOptionalCodeBlockSyntax`).

At Airbnb, we'd like to use this functionality to enable adding instrumentation to SwiftUI view bodies, like:

```swift
struct MyView: View {
  @Instrumented // Enabled by this fix :)
  var body: some View {
    Text("Hello world!")
  }
}
```

Fixes https://github.com/swiftlang/swift/issues/75715.

Please review: @DougGregor @ahoppen

----

Context for including change in Swift 6.4 release:

- **Explanation**:
  - Fixes a bug where body macros are unexpectedly not allowed on variables and accessors, despite being documented as supported in [SE-0415](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0415-function-body-macros.md).
- **Scope**:
   - Accepts code that was previously incorrectly rejected as invalid
- **Issues**:
   - https://github.com/swiftlang/swift/issues/75715
- **Risk**:
    - Low, minor tweaks to type checking logic for body macros. 
- **Testing**:
    - Extensive unit tests, source compatibility tests
- **Reviewers**:
  - @rintaro

-----
