### PR TITLE
[AST] Expand extension macros before enumerating all protocol conformances

### DIFF
--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -1359,6 +1359,14 @@ NominalTypeDecl::getAllProtocols(bool sorted) const {
          "For inherited protocols, use ProtocolDecl::inheritsFrom() or "
          "ProtocolDecl::getInheritedProtocols()");
 
+  // Expand conformances added by extension macros so that the
+  // conformance table includes macro-generated extensions and their
+  // implied (transitive) conformances.
+  auto &ctx = getASTContext();
+  (void)evaluateOrDefault(
+      ctx.evaluator, ExpandExtensionMacros{const_cast<NominalTypeDecl *>(this)},
+      {});
+
   prepareConformanceTable();
   SmallVector<ProtocolDecl *, 2> result;
   ConformanceTable->getAllProtocols(const_cast<NominalTypeDecl *>(this), result,
@@ -1369,6 +1377,13 @@ NominalTypeDecl::getAllProtocols(bool sorted) const {
 SmallVector<ProtocolConformance *, 2> NominalTypeDecl::getAllConformances(
                                         bool sorted) const
 {
+  // Expand conformances added by extension macros so that the
+  // conformance table includes macro-generated extensions.
+  auto &ctx = getASTContext();
+  (void)evaluateOrDefault(
+      ctx.evaluator, ExpandExtensionMacros{const_cast<NominalTypeDecl *>(this)},
+      {});
+
   prepareConformanceTable();
   SmallVector<ProtocolConformance *, 2> result;
   ConformanceTable->getAllConformances(const_cast<NominalTypeDecl *>(this),

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -1674,6 +1674,30 @@ public struct BadExtensionMacro: ExtensionMacro {
   }
 }
 
+public struct TransitiveConformanceViaExtensionMacro: ExtensionMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo decl: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [ExtensionDeclSyntax] {
+    if protocols.isEmpty {
+      return []
+    }
+
+    let decl: DeclSyntax =
+      """
+      extension \(raw: type.trimmedDescription): DerivedProto {
+      }
+      """
+
+    return [
+      decl.cast(ExtensionDeclSyntax.self)
+    ]
+  }
+}
+
 public struct ConformanceViaExtensionMacro: ExtensionMacro {
   public static func expansion(
     of node: AttributeSyntax,

--- a/test/Macros/macro_expand_conformances_transitive.swift
+++ b/test/Macros/macro_expand_conformances_transitive.swift
@@ -1,0 +1,48 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+
+// Verify that transitive conformances from extension macros are visible
+// from other files in the same module. An extension macro generating
+// conformance to DerivedProto (which inherits BaseProto) should make
+// BaseProto's members accessible from any file.
+
+// Primary file mode:
+// RUN: %target-swift-frontend -typecheck -verify -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser %t/a.swift -primary-file %t/b.swift
+
+// Whole-module mode:
+// RUN: %target-swift-frontend -typecheck -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser %t/a.swift %t/b.swift
+
+//--- a.swift
+
+protocol BaseProto {
+  static var tableName: String { get }
+}
+
+extension BaseProto {
+  static func deleteOne(key: String) -> Bool {
+    return true
+  }
+}
+
+protocol DerivedProto: BaseProto {}
+
+@attached(extension, conformances: DerivedProto)
+macro TransitiveConformance() = #externalMacro(module: "MacroDefinition", type: "TransitiveConformanceViaExtensionMacro")
+
+@TransitiveConformance
+struct Item {
+  static let tableName = "items"
+}
+
+//--- b.swift
+
+// The conformance to DerivedProto (and transitively BaseProto) is generated
+// by the extension macro applied to Item in a.swift. Calling a method
+// available through BaseProto should work here.
+func test() {
+  _ = Item.deleteOne(key: "item-1")
+}


### PR DESCRIPTION
Transitive conformances implied by macro-generated extensions were never properly resolved when accessed from other files in the same module, since `NominalTypeDecl::getAllProtocols()` and `getAllConformances()` did not trigger `ExpandExtensionMacros` before building the conformance table.

This caused qualified member lookup which discovers protocol extension methods via `getAllProtocols()` to build the conformance table with only `PreMacroExpansion` placeholder entries, where the added conformances aren't available yet.

The fix adds `ExpandExtensionMacros` evaluation in both methods, matching the pattern already used in `LookupConformanceRequest::evaluate()`.

Fixes https://github.com/swiftlang/swift/issues/87872

