### PR TITLE
AST: Remove `*` as the bottom `AvailabilityDomain`

### DIFF
--- a/include/swift/AST/AvailabilityContext.h
+++ b/include/swift/AST/AvailabilityContext.h
@@ -93,8 +93,10 @@ public:
   /// Returns true if this context contains any unavailable domains.
   bool isUnavailable() const;
 
-  /// Returns true if \p domain is unavailable in this context.
-  bool containsUnavailableDomain(AvailabilityDomain domain) const;
+  /// Returns true if this context is unavailable with respect to contexts in
+  /// which \p domain is available. Note that contexts that are unavailable in
+  /// `*` are always unavailable.
+  bool isUnavailableForDomain(AvailabilityDomain domain) const;
 
   /// Returns true if this context is deprecated on the current platform.
   bool isDeprecated() const;

--- a/include/swift/AST/AvailabilityDomain.h
+++ b/include/swift/AST/AvailabilityDomain.h
@@ -292,15 +292,16 @@ public:
   ModuleDecl *getModule() const;
 
   /// Returns true if availability in `other` is a subset of availability in
-  /// this domain. The set of all availability domains form a lattice where the
-  /// universal domain (`*`) is the bottom element.
+  /// this domain or `this == other`.
   bool contains(const AvailabilityDomain &other) const;
 
   /// Returns true if availability in `other` is a subset of availability in
-  /// this domain or vice-versa.
-  bool isRelated(const AvailabilityDomain &other) const {
-    return contains(other) || other.contains(*this);
-  }
+  /// this domain and `this != other`.
+  bool isSupersetOf(const AvailabilityDomain &other) const;
+
+  /// Returns true if availability in `other` is a subset of availability in
+  /// this domain or vice-versa, or `this == other`.
+  bool isRelated(const AvailabilityDomain &other) const;
 
   /// Returns true for domains that are not contained by any domain other than
   /// the universal domain.

--- a/include/swift/AST/AvailabilityDomain.h
+++ b/include/swift/AST/AvailabilityDomain.h
@@ -49,7 +49,24 @@ enum class AvailabilityVersionKind {
 };
 
 /// Represents a dimension of availability (e.g. macOS platform or Swift
-/// language mode).
+/// language mode). The `Swift` domain is the bottom element of a lattice
+/// containing the platform domains representing ABI stable platforms like
+/// `macOS` and `iOS`:
+///
+///      *────────Swift──────SwiftLang──────Windows──...
+///  (universal)    │           Mode
+///                 │
+///             anyAppleOS
+///        ┌──────┬─┴──┬──────────────┐
+///        │      │    │              │
+///     watchOS macOS tvOS           iOS
+///        │      │    │       ┌──────┼───────────┐
+///     watchOS macOS tvOS     │      │           │
+///     AppExt AppExt AppExt iOS   visionOS   macCatalyst
+///                         AppExt    │           │
+///                                visionOS   macCatalyst
+///                                 AppExt      AppExt
+///
 class AvailabilityDomain final {
 public:
   enum class Kind : uint8_t {

--- a/lib/AST/AvailabilityConstraint.cpp
+++ b/lib/AST/AvailabilityConstraint.cpp
@@ -123,10 +123,16 @@ DeclAvailabilityConstraints::getPrimaryConstraint() const {
     if (lhs.getReason() != rhs.getReason())
       return lhs.getReason() < rhs.getReason();
 
-    // Pick the constraint from the broader domain.
-    if (lhs.getDomain() != rhs.getDomain())
-      return rhs.getDomain().contains(lhs.getDomain());
-    
+    if (lhs.getDomain() != rhs.getDomain()) {
+      // Constraints in the universal domain are the strongest.
+      if (rhs.getDomain().isUniversal())
+        return true;
+
+      // Otherwise, pick the constraint from the broader domain.
+      if (lhs.getDomain() != rhs.getDomain())
+        return rhs.getDomain().contains(lhs.getDomain());
+    }
+
     return false;
   };
 
@@ -189,7 +195,7 @@ shouldIgnoreConstraintInContext(const Decl *decl,
   if (!canIgnoreConstraintInUnavailableContexts(decl, constraint, flags))
     return false;
 
-  return context.containsUnavailableDomain(constraint.getDomain());
+  return context.isUnavailableForDomain(constraint.getDomain());
 }
 
 /// Returns the `AvailabilityConstraint` that describes how \p attr restricts

--- a/lib/AST/AvailabilityContext.cpp
+++ b/lib/AST/AvailabilityContext.cpp
@@ -277,10 +277,13 @@ bool AvailabilityContext::isUnavailable() const {
   return false;
 }
 
-bool AvailabilityContext::containsUnavailableDomain(
+bool AvailabilityContext::isUnavailableForDomain(
     AvailabilityDomain domain) const {
   for (auto domainInfo : storage->getDomainInfos()) {
     if (domainInfo.isUnavailable()) {
+      if (domainInfo.getDomain().isUniversal())
+        return true;
+
       if (domainInfo.getDomain().contains(domain))
         return true;
     }

--- a/lib/AST/AvailabilityDomain.cpp
+++ b/lib/AST/AvailabilityDomain.cpp
@@ -363,9 +363,6 @@ static bool domainIsStrictSubsetOf(const AvailabilityDomain &child,
                                    const AvailabilityDomain &parent) {
   switch (parent.getKind()) {
   case AvailabilityDomain::Kind::Universal:
-    // The universal domain is the bottom element of the lattice so every domain
-    // is a child of it.
-    return true;
   case AvailabilityDomain::Kind::SwiftLanguageMode:
   case AvailabilityDomain::Kind::StandaloneSwiftRuntime:
   case AvailabilityDomain::Kind::PackageDescription:
@@ -417,6 +414,7 @@ bool AvailabilityDomain::isRoot() const {
 }
 
 AvailabilityDomain AvailabilityDomain::getRootDomain() const {
+  // Currently, all non-platform domains are root domains.
   if (!isPlatform())
     return *this;
 

--- a/lib/AST/AvailabilityDomain.cpp
+++ b/lib/AST/AvailabilityDomain.cpp
@@ -358,22 +358,46 @@ ModuleDecl *AvailabilityDomain::getModule() const {
   return nullptr;
 }
 
-bool AvailabilityDomain::contains(const AvailabilityDomain &other) const {
-  switch (getKind()) {
-  case Kind::Universal:
+/// Returns true if `child` is a strict subset of `parent`.
+static bool domainIsStrictSubsetOf(const AvailabilityDomain &child,
+                                   const AvailabilityDomain &parent) {
+  switch (parent.getKind()) {
+  case AvailabilityDomain::Kind::Universal:
+    // The universal domain is the bottom element of the lattice so every domain
+    // is a child of it.
     return true;
-  case Kind::SwiftLanguageMode:
-  case Kind::StandaloneSwiftRuntime:
-  case Kind::PackageDescription:
-  case Kind::Embedded:
-  case Kind::Custom:
-    return other == *this;
-  case Kind::Platform:
-    if (getPlatformKind() == other.getPlatformKind())
-      return true;
-    return inheritsAvailabilityFromPlatform(other.getPlatformKind(),
-                                            getPlatformKind());
+  case AvailabilityDomain::Kind::SwiftLanguageMode:
+  case AvailabilityDomain::Kind::StandaloneSwiftRuntime:
+  case AvailabilityDomain::Kind::PackageDescription:
+  case AvailabilityDomain::Kind::Embedded:
+    // These domains do not have any children in the lattice.
+    return false;
+  case AvailabilityDomain::Kind::Platform:
+    return inheritsAvailabilityFromPlatform(child.getPlatformKind(),
+                                            parent.getPlatformKind());
+  case AvailabilityDomain::Kind::Custom:
+    // Custom domains do not yet support inheritance relationships.
+    return false;
   }
+}
+
+bool AvailabilityDomain::contains(const AvailabilityDomain &other) const {
+  if (other == *this)
+    return true;
+  return domainIsStrictSubsetOf(other, *this);
+}
+
+bool AvailabilityDomain::isSupersetOf(const AvailabilityDomain &other) const {
+  if (other == *this)
+    return false;
+  return domainIsStrictSubsetOf(other, *this);
+}
+
+bool AvailabilityDomain::isRelated(const AvailabilityDomain &other) const {
+  if (other == *this)
+    return true;
+  return domainIsStrictSubsetOf(other, *this) ||
+         domainIsStrictSubsetOf(*this, other);
 }
 
 bool AvailabilityDomain::isRoot() const {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5529,7 +5529,7 @@ void AttributeChecker::checkBackDeployedAttrs(
         D->getLoc(), D->getInnermostDeclContext());
 
     // Unavailable decls cannot be back deployed.
-    if (availability.containsUnavailableDomain(Domain)) {
+    if (availability.isUnavailableForDomain(Domain)) {
       diagnose(AtLoc, diag::attr_has_no_effect_on_unavailable_decl, Attr, VD,
                Domain.getRemappedDomain(Ctx));
 

--- a/test/Availability/availability_custom_domains.swift
+++ b/test/Availability/availability_custom_domains.swift
@@ -242,6 +242,8 @@ func testAlwaysEnabledDomainUnavailable() {
 
 @available(*, unavailable)
 func testUniversallyUnavailable() {
+  // expected-note@-1 {{add '@available' attribute to enclosing global function}}{{243:1-1=@available(EnabledDomain)\n}}
+  // expected-note@-2 {{add '@available' attribute to enclosing global function}}{{243:1-1=@available(DynamicDomain)\n}}
   alwaysAvailable()
   // FIXME: [availability] Diagnostic consistency: potentially unavailable declaration shouldn't be diagnosed
   // in contexts that are unavailable to broader domains

--- a/test/Availability/availability_scopes.swift
+++ b/test/Availability/availability_scopes.swift
@@ -402,7 +402,7 @@ extension SomeEnum {
 // CHECK-NEXT: {{^}}    (decl version=50 unavailable=macOS decl=extension.SomeEnum
 // CHECK-NEXT: {{^}}      (decl_implicit version=50 unavailable=macOS decl=availableMacOS_52
 // CHECK-NEXT: {{^}}        (decl version=50 unavailable=macOS decl=availableMacOS_52
-// CHECK-NEXT: {{^}}      (decl version=50 unavailable=* decl=neverAvailable()
+// CHECK-NEXT: {{^}}      (decl version=50 unavailable=*,macOS decl=neverAvailable()
 
 @available(macOS, unavailable)
 extension SomeEnum {

--- a/unittests/AST/AvailabilityContextTests.cpp
+++ b/unittests/AST/AvailabilityContextTests.cpp
@@ -74,9 +74,9 @@ TEST_F(AvailabilityContextTest, UnavailableDomains) {
 
   auto macOS10_9 = AvailabilityContext::forDeploymentTarget(ctx);
   EXPECT_FALSE(macOS10_9.isUnavailable());
-  EXPECT_FALSE(macOS10_9.containsUnavailableDomain(domains.macOS));
-  EXPECT_FALSE(macOS10_9.containsUnavailableDomain(domains.macOSAppExt));
-  EXPECT_FALSE(macOS10_9.containsUnavailableDomain(domains.universal));
+  EXPECT_FALSE(macOS10_9.isUnavailableForDomain(domains.macOS));
+  EXPECT_FALSE(macOS10_9.isUnavailableForDomain(domains.macOSAppExt));
+  EXPECT_FALSE(macOS10_9.isUnavailableForDomain(domains.universal));
 
   // Constrain the deployment target context by adding unavailability on macOS.
   // The resulting context should be a new context that is less available than
@@ -84,10 +84,9 @@ TEST_F(AvailabilityContextTest, UnavailableDomains) {
   auto unavailableOnMacOS = macOS10_9;
   unavailableOnMacOS.constrainWithUnavailableDomain(domains.macOS, ctx);
   EXPECT_TRUE(unavailableOnMacOS.isUnavailable());
-  EXPECT_TRUE(unavailableOnMacOS.containsUnavailableDomain(domains.macOS));
-  EXPECT_TRUE(
-      unavailableOnMacOS.containsUnavailableDomain(domains.macOSAppExt));
-  EXPECT_FALSE(unavailableOnMacOS.containsUnavailableDomain(domains.universal));
+  EXPECT_TRUE(unavailableOnMacOS.isUnavailableForDomain(domains.macOS));
+  EXPECT_TRUE(unavailableOnMacOS.isUnavailableForDomain(domains.macOSAppExt));
+  EXPECT_FALSE(unavailableOnMacOS.isUnavailableForDomain(domains.universal));
   EXPECT_NE(unavailableOnMacOS, macOS10_9);
   EXPECT_TRUE(unavailableOnMacOS.isContainedIn(macOS10_9));
   EXPECT_FALSE(macOS10_9.isContainedIn(unavailableOnMacOS));
@@ -111,11 +110,10 @@ TEST_F(AvailabilityContextTest, UnavailableDomains) {
   auto unavailableUniversally = unavailableOnMacOS;
   unavailableUniversally.constrainWithUnavailableDomain(domains.universal, ctx);
   EXPECT_TRUE(unavailableUniversally.isUnavailable());
-  EXPECT_TRUE(unavailableUniversally.containsUnavailableDomain(domains.macOS));
+  EXPECT_TRUE(unavailableUniversally.isUnavailableForDomain(domains.macOS));
   EXPECT_TRUE(
-      unavailableUniversally.containsUnavailableDomain(domains.macOSAppExt));
-  EXPECT_TRUE(
-      unavailableUniversally.containsUnavailableDomain(domains.universal));
+      unavailableUniversally.isUnavailableForDomain(domains.macOSAppExt));
+  EXPECT_TRUE(unavailableUniversally.isUnavailableForDomain(domains.universal));
   EXPECT_NE(unavailableUniversally, unavailableOnMacOS);
   EXPECT_TRUE(unavailableUniversally.isContainedIn(unavailableOnMacOS));
   EXPECT_TRUE(unavailableUniversally.isContainedIn(macOS10_9));

--- a/unittests/AST/AvailabilityDomainTests.cpp
+++ b/unittests/AST/AvailabilityDomainTests.cpp
@@ -38,29 +38,30 @@ public:
   AvailabilityDomain visionOS = domainForPlatform(PlatformKind::visionOS);
   AvailabilityDomain visionOSAppExt =
       domainForPlatform(PlatformKind::visionOSApplicationExtension);
+  AvailabilityDomain Windows = domainForPlatform(PlatformKind::Windows);
+  AvailabilityDomain Android = domainForPlatform(PlatformKind::Android);
 
   std::vector<AvailabilityDomain> all() const {
-    return {
-        Universal,   Swift,         Package,   Embedded,    macOS,
-        macOSAppExt, iOS,           iOSAppExt, macCatalyst, macCatalystAppExt,
-        visionOS,    visionOSAppExt};
+    return {Universal,   Swift,
+            Package,     Embedded,
+            macOS,       macOSAppExt,
+            iOS,         iOSAppExt,
+            macCatalyst, macCatalystAppExt,
+            visionOS,    visionOSAppExt,
+            Windows,     Android};
   }
 };
 
 TEST_F(AvailabilityDomainLattice, Containment) {
-  auto terminalDomains = {Swift, Package, Embedded};
+  auto independentDomains = {Universal, Swift,   Package,
+                             Embedded,  Windows, Android};
 
-  for (auto const &domain : all()) {
-    // The universal domain is the bottom domain and contains all others.
-    EXPECT_TRUE(Universal.contains(domain));
-    EXPECT_EQ(Universal.isSupersetOf(domain), !domain.isUniversal());
-    EXPECT_TRUE(Universal.isRelated(domain));
-
-    // The terminal domains only contain themselves.
-    for (auto const &terminal : terminalDomains) {
-      EXPECT_EQ(terminal.contains(domain), domain == terminal);
-      EXPECT_FALSE(terminal.isSupersetOf(domain));
-      EXPECT_EQ(terminal.isRelated(domain), domain == terminal || domain.isUniversal());
+  // The independent domains only contain themselves.
+  for (auto const &anyDomain : all()) {
+    for (auto const &domain : independentDomains) {
+      EXPECT_EQ(domain.contains(anyDomain), anyDomain == domain);
+      EXPECT_FALSE(domain.isSupersetOf(anyDomain));
+      EXPECT_EQ(domain.isRelated(anyDomain), anyDomain == domain);
     }
   }
 

--- a/unittests/AST/AvailabilityDomainTests.cpp
+++ b/unittests/AST/AvailabilityDomainTests.cpp
@@ -47,81 +47,247 @@ public:
   }
 };
 
-TEST_F(AvailabilityDomainLattice, Contains) {
+TEST_F(AvailabilityDomainLattice, Containment) {
+  auto terminalDomains = {Swift, Package, Embedded};
+
   for (auto const &domain : all()) {
     // The universal domain is the bottom domain and contains all others.
     EXPECT_TRUE(Universal.contains(domain));
+    EXPECT_EQ(Universal.isSupersetOf(domain), !domain.isUniversal());
+    EXPECT_TRUE(Universal.isRelated(domain));
 
-    // These domains only contain themselves.
-    EXPECT_EQ(Swift.contains(domain), domain.isSwiftLanguageMode());
-    EXPECT_EQ(Package.contains(domain), domain.isPackageDescription());
-    EXPECT_EQ(Embedded.contains(domain), domain.isEmbedded());
+    // The terminal domains only contain themselves.
+    for (auto const &terminal : terminalDomains) {
+      EXPECT_EQ(terminal.contains(domain), domain == terminal);
+      EXPECT_FALSE(terminal.isSupersetOf(domain));
+      EXPECT_EQ(terminal.isRelated(domain), domain == terminal || domain.isUniversal());
+    }
   }
 
   // Platform kind domains form their own lattice in which app extension domains
   // are contained within the domain of the same platform.
   EXPECT_TRUE(macOS.contains(macOS));
+  EXPECT_FALSE(macOS.isSupersetOf(macOS));
+  EXPECT_TRUE(macOS.isRelated(macOS));
+
   EXPECT_FALSE(macOS.contains(iOS));
+  EXPECT_FALSE(macOS.isSupersetOf(iOS));
+  EXPECT_FALSE(macOS.isRelated(iOS));
+
   EXPECT_TRUE(macOS.contains(macOSAppExt));
+  EXPECT_TRUE(macOS.isSupersetOf(macOSAppExt));
+  EXPECT_TRUE(macOS.isRelated(macOSAppExt));
+
   EXPECT_FALSE(macOSAppExt.contains(macOS));
+  EXPECT_FALSE(macOSAppExt.isSupersetOf(macOS));
+  EXPECT_TRUE(macOSAppExt.isRelated(macOS));
+
   EXPECT_FALSE(macOS.contains(macCatalyst));
+  EXPECT_FALSE(macOS.isSupersetOf(macCatalyst));
+  EXPECT_FALSE(macOS.isRelated(macCatalyst));
+
   EXPECT_FALSE(macCatalyst.contains(macOS));
+  EXPECT_FALSE(macCatalyst.isSupersetOf(macOS));
+  EXPECT_FALSE(macCatalyst.isRelated(macOS));
 
   // iOS is the ABI platform for macCatalyst and visionOS, so it contain those
   // domains.
   EXPECT_TRUE(iOS.contains(iOS));
+  EXPECT_FALSE(iOS.isSupersetOf(iOS));
+  EXPECT_TRUE(iOS.isRelated(iOS));
+
   EXPECT_TRUE(iOS.contains(iOSAppExt));
+  EXPECT_TRUE(iOS.isSupersetOf(iOSAppExt));
+  EXPECT_TRUE(iOS.isRelated(iOSAppExt));
+
   EXPECT_TRUE(iOS.contains(macCatalyst));
+  EXPECT_TRUE(iOS.isSupersetOf(macCatalyst));
+  EXPECT_TRUE(iOS.isRelated(macCatalyst));
+
   EXPECT_TRUE(iOS.contains(macCatalystAppExt));
+  EXPECT_TRUE(iOS.isSupersetOf(macCatalystAppExt));
+  EXPECT_TRUE(iOS.isRelated(macCatalystAppExt));
+
   EXPECT_TRUE(iOS.contains(visionOS));
+  EXPECT_TRUE(iOS.isSupersetOf(visionOS));
+  EXPECT_TRUE(iOS.isRelated(visionOS));
+
   EXPECT_TRUE(iOS.contains(visionOSAppExt));
+  EXPECT_TRUE(iOS.isSupersetOf(visionOSAppExt));
+  EXPECT_TRUE(iOS.isRelated(visionOSAppExt));
+
   EXPECT_FALSE(iOS.contains(macOS));
+  EXPECT_FALSE(iOS.isSupersetOf(macOS));
+  EXPECT_FALSE(iOS.isRelated(macOS));
+
   EXPECT_FALSE(iOS.contains(macOSAppExt));
+  EXPECT_FALSE(iOS.isSupersetOf(macOSAppExt));
+  EXPECT_FALSE(iOS.isRelated(macOSAppExt));
 
+  // iOSApplicationExtension
   EXPECT_TRUE(iOSAppExt.contains(iOSAppExt));
+  EXPECT_FALSE(iOSAppExt.isSupersetOf(iOSAppExt));
+  EXPECT_TRUE(iOSAppExt.isRelated(iOSAppExt));
+
   EXPECT_FALSE(iOSAppExt.contains(iOS));
+  EXPECT_FALSE(iOSAppExt.isSupersetOf(iOS));
+  EXPECT_TRUE(iOSAppExt.isRelated(iOS));
+
   EXPECT_FALSE(iOSAppExt.contains(macCatalyst));
+  EXPECT_FALSE(iOSAppExt.isSupersetOf(macCatalyst));
+  EXPECT_FALSE(iOSAppExt.isRelated(macCatalyst));
+
   EXPECT_TRUE(iOSAppExt.contains(macCatalystAppExt));
+  EXPECT_TRUE(iOSAppExt.isSupersetOf(macCatalystAppExt));
+  EXPECT_TRUE(iOSAppExt.isRelated(macCatalystAppExt));
+
   EXPECT_FALSE(iOSAppExt.contains(visionOS));
+  EXPECT_FALSE(iOSAppExt.isSupersetOf(visionOS));
+  EXPECT_FALSE(iOSAppExt.isRelated(visionOS));
+
   EXPECT_TRUE(iOSAppExt.contains(visionOSAppExt));
+  EXPECT_TRUE(iOSAppExt.isSupersetOf(visionOSAppExt));
+  EXPECT_TRUE(iOSAppExt.isRelated(visionOSAppExt));
+
   EXPECT_FALSE(iOSAppExt.contains(macOS));
+  EXPECT_FALSE(iOSAppExt.isSupersetOf(macOS));
+  EXPECT_FALSE(iOSAppExt.isRelated(macOS));
+
   EXPECT_FALSE(iOSAppExt.contains(macOSAppExt));
+  EXPECT_FALSE(iOSAppExt.isSupersetOf(macOSAppExt));
+  EXPECT_FALSE(iOSAppExt.isRelated(macOSAppExt));
 
+  // macCatalyst
   EXPECT_TRUE(macCatalyst.contains(macCatalyst));
+  EXPECT_FALSE(macCatalyst.isSupersetOf(macCatalyst));
+  EXPECT_TRUE(macCatalyst.isRelated(macCatalyst));
+
   EXPECT_TRUE(macCatalyst.contains(macCatalystAppExt));
+  EXPECT_TRUE(macCatalyst.isSupersetOf(macCatalystAppExt));
+  EXPECT_TRUE(macCatalyst.isRelated(macCatalystAppExt));
+
   EXPECT_FALSE(macCatalyst.contains(iOS));
+  EXPECT_FALSE(macCatalyst.isSupersetOf(iOS));
+  EXPECT_TRUE(macCatalyst.isRelated(iOS));
+
   EXPECT_FALSE(macCatalyst.contains(iOSAppExt));
+  EXPECT_FALSE(macCatalyst.isSupersetOf(iOSAppExt));
+  EXPECT_FALSE(macCatalyst.isRelated(iOSAppExt));
+
   EXPECT_FALSE(macCatalyst.contains(visionOS));
+  EXPECT_FALSE(macCatalyst.isSupersetOf(visionOS));
+  EXPECT_FALSE(macCatalyst.isRelated(visionOS));
+
   EXPECT_FALSE(macCatalyst.contains(visionOSAppExt));
+  EXPECT_FALSE(macCatalyst.isSupersetOf(visionOSAppExt));
+  EXPECT_FALSE(macCatalyst.isRelated(visionOSAppExt));
+
   EXPECT_FALSE(macCatalyst.contains(macOS));
+  EXPECT_FALSE(macCatalyst.isSupersetOf(macOS));
+  EXPECT_FALSE(macCatalyst.isRelated(macOS));
+
   EXPECT_FALSE(macCatalyst.contains(macOSAppExt));
+  EXPECT_FALSE(macCatalyst.isSupersetOf(macOSAppExt));
+  EXPECT_FALSE(macCatalyst.isRelated(macOSAppExt));
 
+  // macCatalystApplicationExtension
   EXPECT_TRUE(macCatalystAppExt.contains(macCatalystAppExt));
+  EXPECT_FALSE(macCatalystAppExt.isSupersetOf(macCatalystAppExt));
+  EXPECT_TRUE(macCatalystAppExt.isRelated(macCatalystAppExt));
+
   EXPECT_FALSE(macCatalystAppExt.contains(macCatalyst));
+  EXPECT_FALSE(macCatalystAppExt.isSupersetOf(macCatalyst));
+  EXPECT_TRUE(macCatalystAppExt.isRelated(macCatalyst));
+
   EXPECT_FALSE(macCatalystAppExt.contains(iOS));
+  EXPECT_FALSE(macCatalystAppExt.isSupersetOf(iOS));
+  EXPECT_TRUE(macCatalystAppExt.isRelated(iOS));
+
   EXPECT_FALSE(macCatalystAppExt.contains(iOSAppExt));
+  EXPECT_FALSE(macCatalystAppExt.isSupersetOf(iOSAppExt));
+  EXPECT_TRUE(macCatalystAppExt.isRelated(iOSAppExt));
+
   EXPECT_FALSE(macCatalystAppExt.contains(visionOS));
+  EXPECT_FALSE(macCatalystAppExt.isSupersetOf(visionOS));
+  EXPECT_FALSE(macCatalystAppExt.isRelated(visionOS));
+
   EXPECT_FALSE(macCatalystAppExt.contains(visionOSAppExt));
+  EXPECT_FALSE(macCatalystAppExt.isSupersetOf(visionOSAppExt));
+  EXPECT_FALSE(macCatalystAppExt.isRelated(visionOSAppExt));
+
   EXPECT_FALSE(macCatalystAppExt.contains(macOS));
+  EXPECT_FALSE(macCatalystAppExt.isSupersetOf(macOS));
+  EXPECT_FALSE(macCatalystAppExt.isRelated(macOS));
+
   EXPECT_FALSE(macCatalystAppExt.contains(macOSAppExt));
+  EXPECT_FALSE(macCatalystAppExt.isSupersetOf(macOSAppExt));
+  EXPECT_FALSE(macCatalystAppExt.isRelated(macOSAppExt));
 
+  // visionOS
   EXPECT_TRUE(visionOS.contains(visionOS));
-  EXPECT_TRUE(visionOS.contains(visionOSAppExt));
-  EXPECT_FALSE(visionOS.contains(iOS));
-  EXPECT_FALSE(visionOS.contains(iOSAppExt));
-  EXPECT_FALSE(visionOS.contains(macCatalyst));
-  EXPECT_FALSE(visionOS.contains(macCatalystAppExt));
-  EXPECT_FALSE(visionOS.contains(macOS));
-  EXPECT_FALSE(visionOS.contains(macOSAppExt));
+  EXPECT_FALSE(visionOS.isSupersetOf(visionOS));
+  EXPECT_TRUE(visionOS.isRelated(visionOS));
 
+  EXPECT_TRUE(visionOS.contains(visionOSAppExt));
+  EXPECT_TRUE(visionOS.isSupersetOf(visionOSAppExt));
+  EXPECT_TRUE(visionOS.isRelated(visionOSAppExt));
+
+  EXPECT_FALSE(visionOS.contains(iOS));
+  EXPECT_FALSE(visionOS.isSupersetOf(iOS));
+  EXPECT_TRUE(visionOS.isRelated(iOS));
+
+  EXPECT_FALSE(visionOS.contains(iOSAppExt));
+  EXPECT_FALSE(visionOS.isSupersetOf(iOSAppExt));
+  EXPECT_FALSE(visionOS.isRelated(iOSAppExt));
+
+  EXPECT_FALSE(visionOS.contains(macCatalyst));
+  EXPECT_FALSE(visionOS.isSupersetOf(macCatalyst));
+  EXPECT_FALSE(visionOS.isRelated(macCatalyst));
+
+  EXPECT_FALSE(visionOS.contains(macCatalystAppExt));
+  EXPECT_FALSE(visionOS.isSupersetOf(macCatalystAppExt));
+  EXPECT_FALSE(visionOS.isRelated(macCatalystAppExt));
+
+  EXPECT_FALSE(visionOS.contains(macOS));
+  EXPECT_FALSE(visionOS.isSupersetOf(macOS));
+  EXPECT_FALSE(visionOS.isRelated(macOS));
+
+  EXPECT_FALSE(visionOS.contains(macOSAppExt));
+  EXPECT_FALSE(visionOS.isSupersetOf(macOSAppExt));
+  EXPECT_FALSE(visionOS.isRelated(macOSAppExt));
+
+  // visionOSApplicationExtension
   EXPECT_TRUE(visionOSAppExt.contains(visionOSAppExt));
+  EXPECT_FALSE(visionOSAppExt.isSupersetOf(visionOSAppExt));
+  EXPECT_TRUE(visionOSAppExt.isRelated(visionOSAppExt));
+
   EXPECT_FALSE(visionOSAppExt.contains(visionOS));
+  EXPECT_FALSE(visionOSAppExt.isSupersetOf(visionOS));
+  EXPECT_TRUE(visionOSAppExt.isRelated(visionOS));
+
   EXPECT_FALSE(visionOSAppExt.contains(iOS));
+  EXPECT_FALSE(visionOSAppExt.isSupersetOf(iOS));
+  EXPECT_TRUE(visionOSAppExt.isRelated(iOS));
+
   EXPECT_FALSE(visionOSAppExt.contains(iOSAppExt));
+  EXPECT_FALSE(visionOSAppExt.isSupersetOf(iOSAppExt));
+  EXPECT_TRUE(visionOSAppExt.isRelated(iOSAppExt));
+
   EXPECT_FALSE(visionOSAppExt.contains(macCatalyst));
+  EXPECT_FALSE(visionOSAppExt.isSupersetOf(macCatalyst));
+  EXPECT_FALSE(visionOSAppExt.isRelated(macCatalyst));
+
   EXPECT_FALSE(visionOSAppExt.contains(macCatalystAppExt));
+  EXPECT_FALSE(visionOSAppExt.isSupersetOf(macCatalystAppExt));
+  EXPECT_FALSE(visionOSAppExt.isRelated(macCatalystAppExt));
+
   EXPECT_FALSE(visionOSAppExt.contains(macOS));
+  EXPECT_FALSE(visionOSAppExt.isSupersetOf(macOS));
+  EXPECT_FALSE(visionOSAppExt.isRelated(macOS));
+
   EXPECT_FALSE(visionOSAppExt.contains(macOSAppExt));
+  EXPECT_FALSE(visionOSAppExt.isSupersetOf(macOSAppExt));
+  EXPECT_FALSE(visionOSAppExt.isRelated(macOSAppExt));
 }
 
 TEST_F(AvailabilityDomainLattice, RootDomain) {


### PR DESCRIPTION
Modeling the universal AvailabilityDomain as the bottom element of a lattice containing all domains was useful for checking unavailability, but it makes some other algorithms harder to write elegantly using availability domain algebra. Instead, special case `*` in unavailability computations and only form an availability domain lattice with the ABI stable platform domains, `anyAppleOS`, and `Swift`.