### PR TITLE
[cxx-interop] Emit more info why functions cannot be exported to C++

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -51,6 +51,7 @@
 #include "clang/AST/DeclObjC.h"
 #include "clang/Basic/CharInfo.h"
 #include "clang/Basic/SourceManager.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -1126,7 +1127,10 @@ private:
       // same arity are ambiguous in C++.
       if (selfArity == arity) {
         owningPrinter.getCxxDeclEmissionScope()
-            .additionalUnrepresentableDeclarations.push_back(funcDecl);
+            .additionalUnrepresentableDeclarations.insert(
+                {funcDecl,
+                 "An overload with the same number of parameters already "
+                 "exists"});
         return false;
       }
     }
@@ -1578,6 +1582,38 @@ private:
     return representation;
   }
 
+  /// Returns a reason string describing why a function's signature can't be
+  /// represented in C++, identifying the specific unsupported type if possible.
+  std::string getUnsupportedTypeReason(AbstractFunctionDecl *FD) {
+    auto &mod = owningPrinter.M;
+    auto isUnsupported = [&](Type ty) {
+      return DeclAndTypeClangFunctionPrinter::getTypeRepresentation(
+                 owningPrinter.typeMapping, owningPrinter.interopContext,
+                 owningPrinter, &mod, ty)
+          .isUnsupported();
+    };
+
+    if (auto *funcDecl = dyn_cast<FuncDecl>(FD)) {
+      auto resultTy = funcDecl->getResultInterfaceType();
+      if (resultTy && !resultTy->isVoid() && isUnsupported(resultTy))
+        return "Return type '" + resultTy->getString() +
+               "' is not representable in C++";
+    }
+
+    for (auto [i, param] : llvm::enumerate(*FD->getParameters())) {
+      auto paramTy = param->getInterfaceType();
+      if (isUnsupported(paramTy)) {
+        auto name = param->getNameStr();
+        if (name.empty() || name == "_")
+          return "Parameter #" + std::to_string(i) + " of type '" +
+                 paramTy->getString() + "' is not representable in C++";
+        return "Parameter '" + name.str() + "' of type '" +
+               paramTy->getString() + "' is not representable in C++";
+      }
+    }
+    return "";
+  }
+
   // Print out the extern C Swift ABI function signature.
   std::optional<FunctionSwiftABIInformation>
   printSwiftABIFunctionSignatureAsCxxFunction(
@@ -1927,7 +1963,8 @@ private:
                          .printSwiftABIFunctionSignatureAsCxxFunction(FD);
       if (!funcABI) {
         owningPrinter.getCxxDeclEmissionScope()
-            .additionalUnrepresentableDeclarations.push_back(FD);
+            .additionalUnrepresentableDeclarations.insert(
+                {FD, getUnsupportedTypeReason(FD)});
         return;
       }
       if (!canPrintOverloadOfFunction(FD))

--- a/lib/PrintAsClang/DeclAndTypePrinter.h
+++ b/lib/PrintAsClang/DeclAndTypePrinter.h
@@ -39,7 +39,11 @@ class SwiftToClangInteropContext;
 /// C++ scope.
 struct CxxDeclEmissionScope {
   /// Additional Swift declarations that are unrepresentable in C++.
-  std::vector<const ValueDecl *> additionalUnrepresentableDeclarations;
+  /// The string holds a reason why the declaration is unrepresentable;
+  /// empty string means the reason should be acqured from
+  /// 'getDeclRepresentation'.
+  llvm::DenseMap<const ValueDecl *, std::string>
+      additionalUnrepresentableDeclarations;
   /// Records the C++ declaration names already emitted in this lexical scope.
   llvm::StringSet<> emittedDeclarationNames;
   /// Records the names of the function overloads already emitted in this

--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -41,6 +41,7 @@
 #include "clang/Basic/Module.h"
 
 #include "llvm/Support/raw_ostream.h"
+#include <utility>
 
 using namespace swift;
 using namespace swift::objc_translation;
@@ -1005,8 +1006,8 @@ public:
         else if (auto SD = dyn_cast<StructDecl>(D))
           success = writeStruct(SD);
         else if (auto *vd = dyn_cast<ValueDecl>(D))
-          topLevelEmissionScope.additionalUnrepresentableDeclarations.push_back(
-              vd);
+          topLevelEmissionScope.additionalUnrepresentableDeclarations.insert(
+              {vd, ""});
       } else if (isa<ValueDecl>(D)) {
         if (auto PD = dyn_cast<ProtocolDecl>(D))
           success = writeProtocol(PD);
@@ -1053,9 +1054,10 @@ public:
     if (outputLangMode != OutputLanguageMode::Cxx)
       return;
     auto &emissionScope = topLevelEmissionScope;
+
     auto removedVDList = std::vector<const ValueDecl *>(
         removedValueDecls.begin(), removedValueDecls.end());
-    for (const auto *removedVD :
+    for (const auto &[removedVD, reason] :
          emissionScope.additionalUnrepresentableDeclarations)
       removedVDList.push_back(removedVD);
 
@@ -1095,24 +1097,29 @@ public:
     for (const auto *vd : removedVDList) {
       assert(!vd->isObjC());
       os << "\n";
-      auto emitStubComment = [&]() {
-        // Emit a generic comment for an handled declaration.
+      auto emitStubComment = [&](StringRef reason = "") {
         os << "// Unavailable in C++: Swift "
-           << vd->getDescriptiveKindName(vd->getDescriptiveKind()) << " '";
+           << Decl::getDescriptiveKindName(vd->getDescriptiveKind()) << " '";
         vd->getName().print(os);
-        os << "'.\n";
+        os << "'.";
+        if (!reason.empty())
+          os << " " << reason << ".";
+        os << "\n";
       };
 
       // Do not emit a C++ declaration with a specific C++ name more than once.
       auto cxxName = cxx_translation::getNameForCxx(vd);
-      if (emissionScope.emittedDeclarationNames.contains(cxxName)) {
-        emitStubComment();
-        continue;
-      }
-      emissionScope.emittedDeclarationNames.insert(cxxName);
+      bool isDuplicateName =
+          !emissionScope.emittedDeclarationNames.insert(cxxName).second;
 
       // Emit an unavailable stub for a Swift type.
       if (auto *nmtd = dyn_cast<NominalTypeDecl>(vd)) {
+        // Do not emit a C++ class stub if a declaration with this name was
+        // already emitted; just emit the comment.
+        if (isDuplicateName) {
+          emitStubComment();
+          continue;
+        }
         auto representation = cxx_translation::getDeclRepresentation(
             vd, [this](const NominalTypeDecl *decl) {
               return printer.isZeroSized(decl);
@@ -1144,10 +1151,33 @@ public:
         continue;
       }
 
-      // FIXME: Emit an unavailable stub for a function / function overload set
-      // / variable.
-      // FIXME: Note unrepresented type aliases too.
-      emitStubComment();
+      // Emit a comment with a reason for functions, variables, and other
+      // non-type value decls.
+      auto reasonIt =
+          emissionScope.additionalUnrepresentableDeclarations.find(vd);
+      if (reasonIt !=
+              emissionScope.additionalUnrepresentableDeclarations.end() &&
+          !reasonIt->second.empty()) {
+        emitStubComment(reasonIt->second);
+      } else {
+        auto representation = cxx_translation::getDeclRepresentation(
+            vd, [this](const NominalTypeDecl *decl) {
+              return printer.isZeroSized(decl);
+            });
+        std::string reasonStr;
+        if (representation.isUnsupported() &&
+            representation.error.has_value()) {
+          auto diag = cxx_translation::diagnoseRepresenationError(
+              *representation.error, const_cast<ValueDecl *>(vd));
+          auto diagString =
+              M.getASTContext().Diags.getFormatStringForDiagnostic(
+                  diag.getID());
+          llvm::raw_string_ostream reasonOS(reasonStr);
+          DiagnosticEngine::formatDiagnosticText(
+              reasonOS, diagString, diag.getArgs(), DiagnosticFormatOptions());
+        }
+        emitStubComment(reasonStr);
+      }
     }
   }
 };

--- a/lib/PrintAsClang/PrintClangValueType.cpp
+++ b/lib/PrintAsClang/PrintClangValueType.cpp
@@ -215,7 +215,7 @@ void ClangValueTypePrinter::printValueTypeDecl(
     if (typeSizeAlign && typeSizeAlign->size == 0) {
       // FIXME: How to represent 0 sized structs?
       declAndTypePrinter.getCxxDeclEmissionScope()
-          .additionalUnrepresentableDeclarations.push_back(typeDecl);
+          .additionalUnrepresentableDeclarations.insert({typeDecl, ""});
       return;
     }
   }

--- a/test/Interop/SwiftToCxx/cross-module-refs/do-not-expose-imported-api-by-default.swift
+++ b/test/Interop/SwiftToCxx/cross-module-refs/do-not-expose-imported-api-by-default.swift
@@ -24,4 +24,4 @@ public func unavailableInHeaderFunc(_ x: StructSeveralI64) -> StructSeveralI64 {
     return Structs.passThroughStructSeveralI64(i: 0, x, j: 2)
 }
 
-// CHECK: // Unavailable in C++: Swift global function 'unavailableInHeaderFunc(_:)'.
+// CHECK: // Unavailable in C++: Swift global function 'unavailableInHeaderFunc(_:)'. Return type 'StructSeveralI64' is not representable in C++.

--- a/test/Interop/SwiftToCxx/functions/swift-function-overloads.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-function-overloads.swift
@@ -13,6 +13,6 @@ public func overloadedFuncArgLabel(y _: Float) { }
 // CHECK: void overloadedFunc(swift::Int x) noexcept
 // CHECK: void overloadedFuncArgLabel(swift::Int  _1) noexcept
 
-// CHECK: // Unavailable in C++: Swift global function 'overloadedFunc(_:)'.
+// CHECK: // Unavailable in C++: Swift global function 'overloadedFunc(_:)'. An overload with the same number of parameters already exists.
 
-// CHECK: // Unavailable in C++: Swift global function 'overloadedFuncArgLabel(y:)'.
+// CHECK: // Unavailable in C++: Swift global function 'overloadedFuncArgLabel(y:)'. An overload with the same number of parameters already exists.

--- a/test/Interop/SwiftToCxx/functions/swift-function-unsupported-cxx-type.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-function-unsupported-cxx-type.swift
@@ -13,4 +13,4 @@ public func c() {}
 
 // CHECK: SWIFT_INLINE_THUNK void a() noexcept SWIFT_SYMBOL("s:9Functions1ayyF") {
 // CHECK: SWIFT_INLINE_THUNK void c() noexcept SWIFT_SYMBOL("s:9Functions1cyyF") {
-// CHECK: // Unavailable in C++: Swift global function 'b(_:)'.
+// CHECK: // Unavailable in C++: Swift global function 'b(_:)'. Parameter 'x' of type '(Int) -> ()' is not representable in C++.

--- a/test/Interop/SwiftToCxx/functions/swift-no-expose-unsupported-alwaysEmitInClient-func.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-no-expose-unsupported-alwaysEmitInClient-func.swift
@@ -9,7 +9,7 @@
 // CHECK:       namespace Functions SWIFT_PRIVATE_ATTR SWIFT_SYMBOL_MODULE("Functions") {
 // CHECK-EMPTY:
 // CHECK-EMPTY:
-// CHECK-NEXT: // Unavailable in C++: Swift global function 'alwaysEmitIntoClientFunc(_:)'.
+// CHECK-NEXT: // Unavailable in C++: Swift global function 'alwaysEmitIntoClientFunc(_:)'.{{.*}}can not be exposed to C++ as it requires code to be emitted into client.
 // CHECK-EMPTY:
 // CHECK-NEXT:  } // namespace Functions
 

--- a/test/Interop/SwiftToCxx/functions/swift-no-expose-unsupported-async-func.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-no-expose-unsupported-async-func.swift
@@ -9,7 +9,7 @@
 // CHECK:       namespace Functions SWIFT_PRIVATE_ATTR SWIFT_SYMBOL_MODULE("Functions") {
 // CHECK-EMPTY:
 // CHECK-EMPTY:
-// CHECK: // Unavailable in C++: Swift global function 'asyncFunc(_:)'.
+// CHECK: // Unavailable in C++: Swift global function 'asyncFunc(_:)'.{{.*}}can not be exposed to C++.
 // CHECK-EMPTY:
 // CHECK-NEXT:  } // namespace Functions
 

--- a/test/Interop/SwiftToCxx/macros/macro-name-collision.swift
+++ b/test/Interop/SwiftToCxx/macros/macro-name-collision.swift
@@ -14,5 +14,5 @@ public macro myLogMacro(error: String) = #externalMacro(module: "CompilerPlugin"
 public macro myLogMacro(fault: String) = #externalMacro(module: "CompilerPlugin", type: "LogMacro")
 // expected-warning@-1 {{plugin for module 'CompilerPlugin' not found}}
 
-// CHECK: // Unavailable in C++: Swift macro 'myLogMacro(error:)'
-// CHECK: // Unavailable in C++: Swift macro 'myLogMacro(fault:)'
+// CHECK: // Unavailable in C++: Swift macro 'myLogMacro(error:)'. Swift macro can not yet be represented in C++.
+// CHECK: // Unavailable in C++: Swift macro 'myLogMacro(fault:)'. Swift macro can not yet be represented in C++.

--- a/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
@@ -133,7 +133,7 @@
 // CHECK: class AnyKeyPath { } SWIFT_UNAVAILABLE_MSG("class 'AnyKeyPath' is not yet exposed to C++");
 // CHECK: class Comparable { } SWIFT_UNAVAILABLE_MSG("protocol 'Comparable' can not yet be represented in C++");
 // CHECK: class FloatingPointSign { } SWIFT_UNAVAILABLE_MSG("enum 'FloatingPointSign' is not yet exposed to C++");
-// CHECK: // Unavailable in C++: Swift global function 'abs(_:)'.
+// CHECK: // Unavailable in C++: Swift global function 'abs(_:)'.{{.*}}can not yet be {{.*}} in C++.
 
 // CHECK: #pragma clang diagnostic push
 // CHECK: #pragma clang diagnostic ignored "-Wnon-modular-include-in-framework-module"

--- a/test/Interop/SwiftToCxx/structs/zero-sized-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/zero-sized-struct-in-cxx.swift
@@ -45,8 +45,8 @@ public func g(x: ZeroSizedStruct) {
 
 // CHECK: class ZeroSizedStruct2 { } SWIFT_UNAVAILABLE_MSG("'ZeroSizedStruct2' is a zero sized value type, it cannot be exposed to C++ yet");
 
-// CHECK: // Unavailable in C++: Swift global function 'f()'.
+// CHECK: // Unavailable in C++: Swift global function 'f()'. Return type 'ZeroSizedStruct' is not representable in C++.
 
-// CHECK: // Unavailable in C++: Swift global function 'g(x:)'.
+// CHECK: // Unavailable in C++: Swift global function 'g(x:)'. Parameter 'x' of type 'ZeroSizedStruct' is not representable in C++.
 
 // CHECK: } // namespace Structs

--- a/test/Interop/SwiftToCxx/unsupported/unsupported-existentials-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/unsupported/unsupported-existentials-in-cxx.swift
@@ -12,4 +12,4 @@ public struct Foo {
 public func useExistential(_ x: KeyPath<Foo, CInt> & Sendable) {
 }
 
-// CHECK: Unavailable in C++: Swift global function 'useExistential(_:)'.
+// CHECK: Unavailable in C++: Swift global function 'useExistential(_:)'. Parameter 'x' of type {{.*}} is not representable in C++.

--- a/test/Interop/SwiftToCxx/unsupported/unsupported-funcs-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/unsupported/unsupported-funcs-in-cxx.swift
@@ -45,6 +45,6 @@ public struct HasMethods {
 // CHECK: HasMethods
 // CHECK: supported
 
-// CHECK: // Unavailable in C++: Swift global function 'unsupportedAEIC()'.
+// CHECK: // Unavailable in C++: Swift global function 'unsupportedAEIC()'.{{.*}}can not be exposed to C++ as it requires code to be emitted into client.
 // CHECK-EMPTY:
-// CHECK-NEXT: // Unavailable in C++: Swift global function 'unsupportedThrows()'.
+// CHECK-NEXT: // Unavailable in C++: Swift global function 'unsupportedThrows()'.{{.*}}can not yet be represented in C++ as it may throw an error.

--- a/test/Interop/SwiftToCxx/unsupported/unsupported-generics-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/unsupported/unsupported-generics-in-cxx.swift
@@ -86,7 +86,7 @@ public func makeQueryResult() -> QueryResult<UInt32> { .init(glyphIDs: []) }
 
 // CHECK: class Struct1 { } SWIFT_UNAVAILABLE_MSG("generic requirements for generic struct 'Struct1' can not yet be represented in C++");
 
-// CHECK: // Unavailable in C++: Swift global function 'unsupportedFunc(_:)'.
+// CHECK: // Unavailable in C++: Swift global function 'unsupportedFunc(_:)'.{{.*}}can not yet be represented in C++.
 
 // CHECK: template<class T_0_0>
 // CHECK-NEXT: #ifdef __cpp_concepts

--- a/test/Interop/SwiftToCxx/unsupported/unsupported-types-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/unsupported/unsupported-types-in-cxx.swift
@@ -28,8 +28,8 @@ public protocol TestProtocol {}
 
 // CHECK: class TestProtocol { } SWIFT_UNAVAILABLE_MSG("protocol 'TestProtocol' can not yet be represented in C++");
 
-// CHECK: // Unavailable in C++: Swift global function 'takesTuple(_:)'.
-// CHECK: // Unavailable in C++: Swift global function 'takesVoid(_:)'.
+// CHECK: // Unavailable in C++: Swift global function 'takesTuple(_:)'. Parameter 'x' of type '(Float, Float)' is not representable in C++.
+// CHECK: // Unavailable in C++: Swift global function 'takesVoid(_:)'. Parameter 'x' of type '()' is not representable in C++.
 
 public typealias unsupportedTypeAlias = () -> (Float, Float)
 


### PR DESCRIPTION
We already emitted some information but that was often a generic message without any detail. This PR adds more context to these comments. This can be helpful for users to work around some limitations and for us to debug some issues.

There are still some omissions, we do not emit such comments for all the methods at the moment. Hopefully, we can add this in a follow-up PR.

rdar://172204501
