### PR TITLE
[rbi] A few small fixes before landing more of flow isolation

### DIFF
--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -908,10 +908,14 @@ private:
   /// multi map here. The implication of this is that when we are performing
   /// dataflow we use a union operation to combine CFG elements and just take
   /// the first instruction that we see.
+  ///
+  /// NOTE: This should never be touched directly without canonicalizing!
   llvm::SmallMapVector<Region, SendingOperandSet *, 2> regionToSendingOpMap;
 
   /// Label each index with a non-negative (unsigned) label if it is associated
   /// with a valid region.
+  ///
+  /// NOTE: This should never be touched directly without canonicalizing!
   std::map<Element, Region> elementToRegionMap;
 
   /// Track a label that is guaranteed to be strictly larger than all in use,
@@ -966,6 +970,7 @@ public:
   }
 
   bool isTrackingElement(Element val) const {
+    // This is safe to perform without canonicalizing.
     return elementToRegionMap.count(val);
   }
 
@@ -986,16 +991,34 @@ public:
   /// Assigns \p oldElt to the region associated with \p newElt.
   void assignElement(Element oldElt, Element newElt, bool updateHistory = true);
 
-  bool areElementsInSameRegion(Element firstElt, Element secondElt) const {
+  bool areElementsInSameRegion(Element firstElt, Element secondElt) {
+    canonicalize();
     return elementToRegionMap.at(firstElt) == elementToRegionMap.at(secondElt);
   }
 
-  Region getRegion(Element elt) const { return elementToRegionMap.at(elt); }
+  Region getRegion(Element elt) {
+    canonicalize();
+    return elementToRegionMap.at(elt);
+  }
 
   using iterator = std::map<Element, Region>::iterator;
+
+private:
   iterator begin() { return elementToRegionMap.begin(); }
   iterator end() { return elementToRegionMap.end(); }
-  llvm::iterator_range<iterator> range() { return {begin(), end()}; }
+
+public:
+  /// Return an iterator over the element/range in this partition. Will
+  /// canonicalize the region if necessary to ensure that elements are matched
+  /// to their canonical region.
+  ///
+  /// NOTE: To work with iterators without canonicalizing, please use begin/end
+  /// directly. This should only be done internally to the Partition
+  /// implementation. We never want to expose
+  llvm::iterator_range<iterator> range() {
+    canonicalize();
+    return {begin(), end()};
+  }
 
   void clearSendingOperandState() { regionToSendingOpMap.clear(); }
 
@@ -1054,33 +1077,6 @@ public:
   /// Runs in quadratic time.
   static Partition join(const Partition &fst, Partition &snd);
 
-  /// Return a vector of the sent values in this partition.
-  std::vector<Element> getSentValues() const {
-    // For effeciency, this could return an iterator not a vector.
-    std::vector<Element> sentVals;
-    for (auto [i, _] : elementToRegionMap)
-      if (isSent(i))
-        sentVals.push_back(i);
-    return sentVals;
-  }
-
-  /// Return a vector of the non-sent regions in this partition, each
-  /// represented as a vector of values.
-  std::vector<std::vector<Element>> getNonSentRegions() const {
-    // For effeciency, this could return an iterator not a vector.
-    std::map<Region, std::vector<Element>> buckets;
-
-    for (auto [i, label] : elementToRegionMap)
-      buckets[label].push_back(i);
-
-    std::vector<std::vector<Element>> doubleVec;
-
-    for (auto [_, bucket] : buckets)
-      doubleVec.push_back(bucket);
-
-    return doubleVec;
-  }
-
   void dump_labels() const LLVM_ATTRIBUTE_USED {
     llvm::dbgs() << "Partition";
     if (canonical)
@@ -1093,7 +1089,16 @@ public:
 
   SWIFT_DEBUG_DUMP { print(llvm::dbgs()); }
 
-  void print(llvm::raw_ostream &os) const;
+  /// Print out this partition.
+  ///
+  /// If passed in printRegionIsolation is expected to print to the passed in
+  /// stream a representation of the region and return true if it actually
+  /// printed anything. If it returns true, we will emit a ' :' afterwards. If
+  /// false, we will not emit anything. The suggestion would be to just print
+  /// for non-disconnected isolations.
+  void print(llvm::raw_ostream &os,
+             std::function<bool(llvm::raw_ostream &, Region)>
+                 printRegionIsolation = nullptr) const;
 
   SWIFT_DEBUG_DUMPER(dumpVerbose()) { printVerbose(llvm::dbgs()); }
 
@@ -1107,20 +1112,30 @@ public:
     return history.pushHistorySequenceBoundary(loc);
   }
 
-  bool isSent(Element val) const {
-    auto iter = elementToRegionMap.find(val);
+private:
+  /// Return region if we have it. Will canonicalize the partition b
+  std::optional<Region> maybeGetRegion(Element elt) {
+    canonicalize();
+    auto iter = elementToRegionMap.find(elt);
     if (iter == elementToRegionMap.end())
-      return false;
-    return regionToSendingOpMap.count(iter->second);
+      return {};
+    return iter->second;
+  }
+
+public:
+  bool isSent(Element val) {
+    if (auto r = maybeGetRegion(val))
+      return regionToSendingOpMap.count(*r);
+    return false;
   }
 
   /// Return the instruction that sent \p val's region or nullptr
   /// otherwise.
-  SendingOperandSet *getSentOperandSet(Element val) const {
-    auto iter = elementToRegionMap.find(val);
-    if (iter == elementToRegionMap.end())
+  SendingOperandSet *getSentOperandSet(Element val) {
+    auto region = maybeGetRegion(val);
+    if (!region)
       return nullptr;
-    auto iter2 = regionToSendingOpMap.find(iter->second);
+    auto iter2 = regionToSendingOpMap.find(*region);
     if (iter2 == regionToSendingOpMap.end())
       return nullptr;
     auto *set = iter2->second;
@@ -1132,8 +1147,9 @@ public:
   /// elementToRegionMap.
   ///
   /// Asserts when NDEBUG is set. Does nothing otherwise.
-  void validateRegionToSendingOpMapRegions() const {
+  void validateRegionToSendingOpMapRegions() {
 #ifndef NDEBUG
+    canonicalize();
     llvm::SmallSet<Region, 8> regions;
     for (auto [eltNo, regionNo] : elementToRegionMap) {
       regions.insert(regionNo);
@@ -1146,7 +1162,7 @@ public:
 
   /// Used only in assertions, check that Partitions promised to be canonical
   /// are actually canonical
-  bool is_canonical_correct() const;
+  bool is_canonical_correct();
 
   /// Merge the regions of two indices while maintaining canonicality. Returns
   /// the final region used.
@@ -1623,7 +1639,7 @@ public:
   /// The bool result is if it is captured by a closure element. That only is
   /// computed if \p sourceOp is non-null.
   std::optional<std::pair<SILDynamicMergedIsolationInfo, bool>>
-  getIsolationRegionInfo(Region region, Operand *sourceOp) const {
+  getIsolationRegionInfo(Region region, Operand *sourceOp) {
     bool isClosureCapturedElt = false;
     std::optional<SILDynamicMergedIsolationInfo> isolationRegionInfo;
 
@@ -1670,7 +1686,7 @@ public:
   }
 
   /// Overload of \p getIsolationRegionInfo without an Operand.
-  SILDynamicMergedIsolationInfo getIsolationRegionInfo(Region region) const {
+  SILDynamicMergedIsolationInfo getIsolationRegionInfo(Region region) {
     if (auto opt = getIsolationRegionInfo(region, nullptr))
       return opt->first;
     return SILDynamicMergedIsolationInfo();
@@ -1832,13 +1848,28 @@ public:
     if (shouldEmitVerboseLogging()) {
       REGIONBASEDISOLATION_VERBOSE_LOG(llvm::dbgs() << "Applying: ";
                                        op.print(llvm::dbgs()));
-      REGIONBASEDISOLATION_VERBOSE_LOG(llvm::dbgs() << "    Before: ";
-                                       p.print(llvm::dbgs()));
+      REGIONBASEDISOLATION_VERBOSE_LOG(llvm::dbgs() << "    Before: "; p.print(
+          llvm::dbgs(), [&](llvm::raw_ostream &os, Region region) -> bool {
+            auto regionInfo = getIsolationRegionInfo(region);
+            if (regionInfo.isDisconnected())
+              return false;
+            regionInfo.printForOneLineLogging(op.getSourceInst()->getFunction(),
+                                              os);
+            return true;
+          }));
     }
     SWIFT_DEFER {
       if (shouldEmitVerboseLogging()) {
-        REGIONBASEDISOLATION_VERBOSE_LOG(llvm::dbgs() << "    After:  ";
-                                         p.print(llvm::dbgs()));
+        REGIONBASEDISOLATION_VERBOSE_LOG(
+            llvm::dbgs() << "    After:  ";
+            p.print(llvm::dbgs(), [&](llvm::raw_ostream &os, Region region) {
+              auto regionInfo = getIsolationRegionInfo(region);
+              if (regionInfo.isDisconnected())
+                return false;
+              regionInfo.printForOneLineLogging(
+                  op.getSourceInst()->getFunction(), os);
+              return true;
+            }));
       }
       assert(p.is_canonical_correct());
     };

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -916,7 +916,7 @@ private:
 
   /// Track a label that is guaranteed to be strictly larger than all in use,
   /// and therefore safe for use as a fresh label.
-  Region freshLabel = Region(0);
+  Region nextAvailableRegionNum = Region(0);
 
   /// An immutable data structure that we use to push/pop isolation history.
   IsolationHistory history;
@@ -1085,7 +1085,7 @@ public:
     llvm::dbgs() << "Partition";
     if (canonical)
       llvm::dbgs() << "(canonical)";
-    llvm::dbgs() << "(fresh=" << freshLabel << "){";
+    llvm::dbgs() << "(fresh=" << nextAvailableRegionNum << "){";
     for (const auto &[i, label] : elementToRegionMap)
       llvm::dbgs() << "[" << i << ": " << label << "] ";
     llvm::dbgs() << "}\n";

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -1891,6 +1891,33 @@ public:
       // a sending result.
       handleAssignNonDisconnectedIntoSendingResult(op);
 
+      // Check if our actual destElement is directly actor isolated in a way
+      // that does not match our srcElement's region. In that case, the memory
+      // itself is actor isolated and we have to emit an incompatible merge
+      // error.
+      auto destIsolation = getIsolationRegionInfo(destElement);
+      auto srcRegIsolation = getIsolationRegionInfo(p.getRegion(srcElement));
+      if (!srcRegIsolation.merge(destIsolation)) {
+        // If we are not tracking dest yet, we need to start tracking it. We do
+        // not need to do this in the general case since the assign will handle
+        // it. But since we are not assigning, we need to do this now.
+        if (!p.isTrackingElement(destElement)) {
+          p.trackNewElement(destElement);
+        }
+
+        // See if either of our elements are nonisolated(unsafe). In such a
+        // case, we need to avoid emitting the error. We still do not merge
+        // since regions can only have one isolation and we would break that
+        // invariant when looking at other values in the region that are not
+        // marked as nonisolated(unsafe).
+        if (getIsolationRegionInfo(srcElement).isUnsafeNonIsolated() ||
+            getIsolationRegionInfo(destElement).isUnsafeNonIsolated())
+          return;
+        return handleError(IncompatibleRegionMergeError(
+            op, srcElement, srcRegIsolation, destElement, destIsolation,
+            RegionMergeReason::Assign));
+      }
+
       // Then perform the actual assignment.
       //
       // NOTE: This does not emit any errors on purpose. We rely on requires and

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -4354,8 +4354,8 @@ TranslationSemantics PartitionOpTranslator::visitUnconditionalCheckedCastInst(
 // ref_element_addr to be merged into.
 TranslationSemantics
 PartitionOpTranslator::visitRefElementAddrInst(RefElementAddrInst *reai) {
-  // If our field is a NonSendableType...
-  if (!SILIsolationInfo::isNonSendable(reai)) {
+  // If our field is a Sendable type.
+  if (SILIsolationInfo::isSendable(reai)) {
     // And the field is a let... then ignore it. We know that we cannot race on
     // any writes to the field.
     if (reai->getField()->isLet()) {
@@ -4369,6 +4369,32 @@ PartitionOpTranslator::visitRefElementAddrInst(RefElementAddrInst *reai) {
     return TranslationSemantics::Require;
   }
 
+  // Ok, our field is non-Sendable.
+
+  // See if our field has a specific isolation and our parent doesn't match that
+  // explicitly. In such a case, we need to do the following:
+  //
+  // 1. Require the operand.
+  // 2. AssignFresh the field.
+  //
+  // The reason why this is safe is that The field will be isolated to whatever
+  // actor isolation it has at the AST level. So any time we escape it or send
+  // it, we will properly get an error. Any other ref_element_addr to the same
+  // field will be a different region, but that doesn't matter since they all
+  // will still be isolated ot the same actor isolation meaning merges will not
+  // cause problems.
+  if (auto fieldIsolation = SILIsolationInfo::get(reai);
+      fieldIsolation && fieldIsolation.isActorIsolated()) {
+    if (auto parentIsolation = SILIsolationInfo::get(reai->getOperand());
+        !parentIsolation || !parentIsolation.hasSameIsolation(fieldIsolation)) {
+      // Require the Operand.
+      translateSILRequire(reai->getOperand());
+      translateSILAssignFresh(reai);
+      return TranslationSemantics::Special;
+    }
+  }
+
+  // Otherwise, we want to treat it as an assign direct.
   return TranslationSemantics::AssignDirect;
 }
 

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -1566,6 +1566,7 @@ public:
   }
 
   void emitUnknownPatternError() {
+    emittedErrorDiagnostic = true;
     EMIT_UNKNOWN_PATTERN_ERROR(SendNeverSentDiagnosticEmitter,
                                getOperand()->getUser(), getBehaviorLimit());
   }
@@ -2394,6 +2395,7 @@ public:
   }
 
   void emitUnknownPatternError() {
+    emittedErrorDiagnostic = true;
     EMIT_UNKNOWN_PATTERN_ERROR(InOutSendingReturnedDiagnosticEmitter,
                                functionExitingInst, getBehaviorLimit());
   }
@@ -3446,6 +3448,7 @@ struct NonSendableIsolationCrossingResultDiagnosticEmitter {
   }
 
   void emitUnknownPatternError() {
+    emittedErrorDiagnostic = true;
     EMIT_UNKNOWN_PATTERN_ERROR(
         NonSendableIsolationCrossingResultDiagnosticEmitter,
         error.op->getSourceInst(), getBehaviorLimit());

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -248,7 +248,7 @@ Partition Partition::singleRegion(SILLocation loc, ArrayRef<Element> indices,
     // region takes.
     Element repElement = *std::min_element(indices.begin(), indices.end());
     Region repElementRegion = Region(repElement);
-    p.freshLabel = Region(repElementRegion + 1);
+    p.nextAvailableRegionNum = Region(repElementRegion + 1);
 
     // Place all of the operations until end of scope into one history
     // sequence.
@@ -287,7 +287,7 @@ Partition Partition::separateRegions(SILLocation loc, ArrayRef<Element> indices,
     p.pushNewElementRegion(index);
     maxIndex = Element(std::max(maxIndex, index));
   }
-  p.freshLabel = Region(maxIndex + 1);
+  p.nextAvailableRegionNum = Region(maxIndex + 1);
   assert(p.is_canonical_correct());
   return p;
 }
@@ -296,10 +296,10 @@ void Partition::markSent(Element val, SendingOperandSet *sendingOperandSet) {
   // First see if our val is tracked. If it is not tracked, insert it and mark
   // its new region as sent.
   if (!isTrackingElement(val)) {
-    elementToRegionMap.insert_or_assign(val, freshLabel);
+    elementToRegionMap.insert_or_assign(val, nextAvailableRegionNum);
     pushNewElementRegion(val);
-    regionToSendingOpMap.insert({freshLabel, sendingOperandSet});
-    freshLabel = Region(freshLabel + 1);
+    regionToSendingOpMap.insert({nextAvailableRegionNum, sendingOperandSet});
+    nextAvailableRegionNum = Region(nextAvailableRegionNum + 1);
     canonical = false;
     return;
   }
@@ -320,9 +320,9 @@ void Partition::markSent(Element val, SendingOperandSet *sendingOperandSet) {
 bool Partition::undoSend(Element val) {
   // First see if our val is tracked. If it is not tracked, insert it.
   if (!isTrackingElement(val)) {
-    elementToRegionMap.insert_or_assign(val, freshLabel);
+    elementToRegionMap.insert_or_assign(val, nextAvailableRegionNum);
     pushNewElementRegion(val);
-    freshLabel = Region(freshLabel + 1);
+    nextAvailableRegionNum = Region(nextAvailableRegionNum + 1);
     canonical = false;
     return true;
   }
@@ -338,7 +338,7 @@ void Partition::trackNewElement(Element newElt, bool updateHistory) {
   SWIFT_DEFER { validateRegionToSendingOpMapRegions(); };
 
   // First try to emplace newElt with fresh_label.
-  auto iter = elementToRegionMap.try_emplace(newElt, freshLabel);
+  auto iter = elementToRegionMap.try_emplace(newElt, nextAvailableRegionNum);
 
   // If we did insert, then we know that the value is completely new. We can
   // just update the fresh_label, set canonical to false, and return.
@@ -349,7 +349,7 @@ void Partition::trackNewElement(Element newElt, bool updateHistory) {
       pushNewElementRegion(newElt);
 
     // Increment the fresh label so it remains fresh.
-    freshLabel = Region(freshLabel + 1);
+    nextAvailableRegionNum = Region(nextAvailableRegionNum + 1);
     canonical = false;
     return;
   }
@@ -365,7 +365,7 @@ void Partition::trackNewElement(Element newElt, bool updateHistory) {
   // This is important to ensure that every region in the sendingOpMap is
   // also in elementToRegionMap.
   auto oldRegion = iter.first->second;
-  iter.first->second = freshLabel;
+  iter.first->second = nextAvailableRegionNum;
 
   auto getValueFromOtherRegion = [&]() -> std::optional<Element> {
     for (auto pair : elementToRegionMap) {
@@ -388,7 +388,7 @@ void Partition::trackNewElement(Element newElt, bool updateHistory) {
     pushNewElementRegion(newElt);
 
   // Increment the fresh label so it remains fresh.
-  freshLabel = Region(freshLabel + 1);
+  nextAvailableRegionNum = Region(nextAvailableRegionNum + 1);
   canonical = false;
 }
 
@@ -532,8 +532,8 @@ Partition Partition::join(const Partition &fst, Partition &mutableSnd) {
         result.pushMergeElementRegions(sndEltNumber, Element(sndRegionNumber));
         // We want fresh_label to always be one element larger than our
         // maximum element.
-        if (result.freshLabel <= Region(sndEltNumber))
-          result.freshLabel = Region(sndEltNumber + 1);
+        if (result.nextAvailableRegionNum <= Region(sndEltNumber))
+          result.nextAvailableRegionNum = Region(sndEltNumber + 1);
         continue;
       }
     }
@@ -553,8 +553,8 @@ Partition Partition::join(const Partition &fst, Partition &mutableSnd) {
       if (!fstIter.second)
         fstIter.first->second = fstIter.first->second->merge(sndIter->second);
     }
-    if (result.freshLabel <= sndRegionNumber)
-      result.freshLabel = Region(sndEltNumber + 1);
+    if (result.nextAvailableRegionNum <= sndRegionNumber)
+      result.nextAvailableRegionNum = Region(sndEltNumber + 1);
   }
 
   // We should have preserved canonicality during the computation above. It
@@ -719,7 +719,7 @@ bool Partition::is_canonical_correct() const {
 
   for (auto &[eltNo, regionNo] : elementToRegionMap) {
     // Labels should not exceed fresh_label.
-    if (regionNo >= freshLabel)
+    if (regionNo >= nextAvailableRegionNum)
       return fail(eltNo, 0);
 
     // The label of a region should be at most as large as each index in it.
@@ -789,25 +789,37 @@ void Partition::canonicalize() {
   canonical = true;
 
   validateRegionToSendingOpMapRegions();
-  std::map<Region, Region> oldRegionToRelabeledMap;
+  SmallVector<std::pair<Region, Region>, 8> oldRegionToRelabeledRegionMap;
 
-  // We rely on in-order traversal of labels to ensure that we always take the
-  // lowest eltNumber.
+  // Walk over elementToRegionMap, mapping regionNo to region(eltNo). Since we
+  // are walking linearly in order, we know that lower eltNo should be before
+  // earlier.
   for (auto &[eltNo, regionNo] : elementToRegionMap) {
-    if (!oldRegionToRelabeledMap.count(regionNo)) {
-      // if this is the first time encountering this region label,
-      // then this region label should be relabelled to this index,
-      // so enter that into the map
-      oldRegionToRelabeledMap.insert_or_assign(regionNo, Region(eltNo));
-    }
+    oldRegionToRelabeledRegionMap.emplace_back(regionNo, Region(eltNo));
 
-    // Update this label with either its own index, or a prior index that
-    // shared a region with it.
-    regionNo = oldRegionToRelabeledMap.at(regionNo);
+    // After canonicalization, all region labels are element numbers, so the
+    // max region label in use is at most maxEltNo. Setting this to eltNo + 1
+    // (which after the loop equals maxEltNo + 1) is sufficient.
+    nextAvailableRegionNum = Region(eltNo + 1);
+  }
 
-    // The maximum index iterated over will be used here to appropriately
-    // set fresh_label.
-    freshLabel = Region(eltNo + 1);
+  // Sort the array by (oldRegion, newRegion). This ensures that for each
+  // oldRegion, the smallest newRegion (i.e., the smallest element) comes first.
+  llvm::sort(oldRegionToRelabeledRegionMap);
+
+  // Now walk our map again and update the eltRegionNo with the new element.
+  // Since we sorted by (oldRegion, newRegion), lower_bound finds the first
+  // entry for each oldRegion, which has the smallest newRegion.
+  for (auto &[eltNo, eltRegionNo] : elementToRegionMap) {
+    auto iter =
+        std::lower_bound(oldRegionToRelabeledRegionMap.begin(),
+                         oldRegionToRelabeledRegionMap.end(), eltRegionNo,
+                         [](const std::pair<Region, Region> &lhs, Region rhs) {
+                           return lhs.first < rhs;
+                         });
+    assert(iter != oldRegionToRelabeledRegionMap.end() &&
+           iter->first == eltRegionNo);
+    eltRegionNo = iter->second;
   }
 
   // Then relabel our regionToSendingOpMap map if we need to by swapping out the
@@ -817,8 +829,12 @@ void Partition::canonicalize() {
   // re-sort and not have to deal with potential allocations.
   decltype(regionToSendingOpMap) oldMap = std::move(regionToSendingOpMap);
   for (auto &[oldReg, op] : oldMap) {
-    auto iter = oldRegionToRelabeledMap.find(oldReg);
-    assert(iter != oldRegionToRelabeledMap.end());
+    auto iter = std::lower_bound(oldRegionToRelabeledRegionMap.begin(),
+                                 oldRegionToRelabeledRegionMap.end(), oldReg,
+                                 [](const std::pair<Region, Region> &lhs,
+                                    Region rhs) { return lhs.first < rhs; });
+    assert(iter != oldRegionToRelabeledRegionMap.end() &&
+           iter->first == oldReg);
     regionToSendingOpMap[iter->second] = op;
   }
 

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -304,6 +304,9 @@ void Partition::markSent(Element val, SendingOperandSet *sendingOperandSet) {
     return;
   }
 
+  // Canonicalize so that our elementToRegionMap.
+  canonicalize();
+
   // Otherwise, we already have this value in the map. Try to insert it.
   auto iter1 = elementToRegionMap.find(val);
   assert(iter1 != elementToRegionMap.end());
@@ -318,6 +321,8 @@ void Partition::markSent(Element val, SendingOperandSet *sendingOperandSet) {
 }
 
 bool Partition::undoSend(Element val) {
+  canonicalize();
+
   // First see if our val is tracked. If it is not tracked, insert it.
   if (!isTrackingElement(val)) {
     elementToRegionMap.insert_or_assign(val, nextAvailableRegionNum);
@@ -588,7 +593,23 @@ bool Partition::popHistory(
   return history.getHead();
 }
 
-void Partition::print(llvm::raw_ostream &os) const {
+void Partition::print(llvm::raw_ostream &os,
+                      std::function<bool(llvm::raw_ostream &, Region)>
+                          printRegionIsolation) const {
+  // If we are asked to printRegionIsolation, we need to canonicalize before we
+  // can get the correct regions. So, check if we are canonicalized. If we are
+  // not then we can continue printing below. Otherwise, we copy ourselves,
+  // canonicalize the copy, and then print that. We do this since the whole
+  // point of printing this type of information is to help us understand how the
+  // program flowed normally and if we canonicalize this partition to print, we
+  // would change the compiler state.
+  if (printRegionIsolation && !canonical) {
+    auto other = *this;
+    other.canonicalize();
+    other.print(os, printRegionIsolation);
+    return;
+  }
+
   SmallFrozenMultiMap<Region, Element, 8> multimap;
 
   for (auto [eltNo, regionNo] : elementToRegionMap)
@@ -604,6 +625,10 @@ void Partition::print(llvm::raw_ostream &os) const {
       os << '{';
     } else {
       os << '(';
+    }
+
+    if (printRegionIsolation && printRegionIsolation(os, regionNo)) {
+      os << ": ";
     }
 
     int j = 0;
@@ -704,7 +729,7 @@ void Partition::printHistory(llvm::raw_ostream &os) const {
   } while ((head = head->getParent()));
 }
 
-bool Partition::is_canonical_correct() const {
+bool Partition::is_canonical_correct() {
 #ifdef NDEBUG
   return true;
 #else
@@ -743,6 +768,8 @@ bool Partition::is_canonical_correct() const {
 }
 
 Region Partition::merge(Element fst, Element snd, bool updateHistory) {
+  canonicalize();
+
   assert(elementToRegionMap.count(fst) && elementToRegionMap.count(snd));
 
   // Remember: fstRegion and sndRegion are actually elements in

--- a/test/Concurrency/transfernonsendable.sil
+++ b/test/Concurrency/transfernonsendable.sil
@@ -459,12 +459,8 @@ sil [ossa] @regionMergeAssignMismerge : $@convention(thin) (@guaranteed Nonisola
 bb0(%0 : @guaranteed $NonisolatedClassWithMixedFields):
   debug_value %0 : $NonisolatedClassWithMixedFields, var, name "self"
   %1 = ref_element_addr %0 : $NonisolatedClassWithMixedFields, #NonisolatedClassWithMixedFields.mainField
-  // expected-warning @-1 {{assigning 'self' to main actor-isolated 'self.mainField' risks causing data races}}
-  // expected-note @-2 {{'self' could become accessible to main actor-isolated code despite remaining accessible to code in the current task}}
   %2 = load [copy] %1
   %3 = ref_element_addr %0 : $NonisolatedClassWithMixedFields, #NonisolatedClassWithMixedFields.customField
-  // expected-warning @-1 {{assigning 'self' to global actor 'CustomActor'-isolated 'self.customField' risks causing data races}}
-  // expected-note @-2 {{'self' could become accessible to global actor 'CustomActor'-isolated code despite remaining accessible to code in the current task}}
   store %2 to [assign] %3 // expected-warning {{assigning main actor-isolated 'self.mainField' to global actor 'CustomActor'-isolated 'self.customField' risks causing data races}}
   // expected-note @-1 {{'self.mainField' could become accessible to global actor 'CustomActor'-isolated code despite remaining accessible to main actor-isolated code}}
   %9999 = tuple ()

--- a/test/Concurrency/transfernonsendable.sil
+++ b/test/Concurrency/transfernonsendable.sil
@@ -102,6 +102,18 @@ actor MyActor {
   var klass: NonSendableKlass { get set }
 }
 
+actor CustomActorInstance {}
+
+@globalActor
+struct CustomActor {
+  static let shared: CustomActorInstance
+}
+
+class NonisolatedClassWithMixedFields {
+  @MainActor var mainField: NonSendableKlass
+  @CustomActor var customField: NonSendableKlass
+}
+
 sil @beginApplyMultipleResultCallee : $@yield_once @convention(thin) () -> (@yields @guaranteed NonSendableKlass, @yields @guaranteed NonSendableKlass)
 
 /////////////////
@@ -439,6 +451,22 @@ bb0:
   %0 = function_ref @beginApplyMultipleResultCallee : $@yield_once @convention(thin) () -> (@yields @guaranteed NonSendableKlass, @yields @guaranteed NonSendableKlass)
   (%1, %2, %3) = begin_apply %0() : $@yield_once @convention(thin) () -> (@yields @guaranteed NonSendableKlass, @yields @guaranteed NonSendableKlass)
   end_apply %3 as $()
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+sil [ossa] @regionMergeAssignMismerge : $@convention(thin) (@guaranteed NonisolatedClassWithMixedFields) -> () {
+bb0(%0 : @guaranteed $NonisolatedClassWithMixedFields):
+  debug_value %0 : $NonisolatedClassWithMixedFields, var, name "self"
+  %1 = ref_element_addr %0 : $NonisolatedClassWithMixedFields, #NonisolatedClassWithMixedFields.mainField
+  // expected-warning @-1 {{assigning 'self' to main actor-isolated 'self.mainField' risks causing data races}}
+  // expected-note @-2 {{'self' could become accessible to main actor-isolated code despite remaining accessible to code in the current task}}
+  %2 = load [copy] %1
+  %3 = ref_element_addr %0 : $NonisolatedClassWithMixedFields, #NonisolatedClassWithMixedFields.customField
+  // expected-warning @-1 {{assigning 'self' to global actor 'CustomActor'-isolated 'self.customField' risks causing data races}}
+  // expected-note @-2 {{'self' could become accessible to global actor 'CustomActor'-isolated code despite remaining accessible to code in the current task}}
+  store %2 to [assign] %3 // expected-warning {{assigning main actor-isolated 'self.mainField' to global actor 'CustomActor'-isolated 'self.customField' risks causing data races}}
+  // expected-note @-1 {{'self.mainField' could become accessible to global actor 'CustomActor'-isolated code despite remaining accessible to main actor-isolated code}}
   %9999 = tuple ()
   return %9999 : $()
 }

--- a/unittests/SILOptimizer/PartitionUtilsTest.cpp
+++ b/unittests/SILOptimizer/PartitionUtilsTest.cpp
@@ -31,6 +31,9 @@ struct Partition::PartitionTester {
   unsigned getRegion(unsigned elt) const {
     return unsigned(p.elementToRegionMap.at(Element(elt)));
   }
+
+  auto begin() const { return p.elementToRegionMap.begin(); }
+  auto end() const { return p.elementToRegionMap.end(); }
 };
 
 namespace {
@@ -1001,7 +1004,8 @@ TEST(PartitionUtilsTest, TestHistory_JoiningTwoEmpty) {
   Partition p2(historyFactory.get());
 
   auto result = Partition::join(p1, p2);
-  EXPECT_TRUE(result.begin() == result.end());
+  PartitionTester resultTester(result);
+  EXPECT_TRUE(resultTester.begin() == resultTester.end());
   EXPECT_FALSE(result.hasHistory());
 }
 
@@ -1024,7 +1028,8 @@ TEST(PartitionUtilsTest, TestHistory_JoiningNotEmptyAndEmpty) {
   EXPECT_TRUE(p1.historySize() == 2);
   EXPECT_TRUE(p2.historySize() == 0);
   auto result = Partition::join(p1, p2);
-  EXPECT_TRUE(std::next(result.begin()) == result.end());
+  PartitionTester resultTester(result);
+  EXPECT_TRUE(std::next(resultTester.begin()) == resultTester.end());
   // Since p2 doesn't have any history, we do not actually perform any join and
   // thus do not insert a CFGHistory change.
   EXPECT_TRUE(result.historySize() == 2);
@@ -1049,7 +1054,8 @@ TEST(PartitionUtilsTest, TestHistory_JoiningEmptyAndNotEmpty) {
   EXPECT_TRUE(p1.historySize() == 2);
   EXPECT_TRUE(p2.historySize() == 0);
   auto result = Partition::join(p1, p2);
-  EXPECT_TRUE(std::next(result.begin()) == result.end());
+  PartitionTester resultTester(result);
+  EXPECT_TRUE(std::next(resultTester.begin()) == resultTester.end());
   // Since p2 doesn't have any history, we do not actually perform any join and
   // thus do not insert a CFGHistory change.
   EXPECT_TRUE(result.historySize() == 2);


### PR DESCRIPTION
Specifically:

1. I noticed that we were emitting "unknown error" diagnostic twice in certain cases. This occurred since we would for a different reason emit the "unknown error" diagnostic but not set the I emitted a diagnostic flag. This then in the destructor of certain emitters would cause us to emit another "unknown error". The first change causes the "unknown error" diagnostic to set that flag to suppress the second emission in the destructor.
2. I discovered while looking at some bugs that we were not canonicalizing regions in certain places before attempting to map an element -> region. The result is that we would get weird results since different elements in the same region would actually be mapped to different region numbers. In this change, I added the missing canonicalizations.
3. I found while working on flow isolation that AssignDirect was not checking for region merging differences. The result is that we would merge regions isolated to different actors and then if we later attempted to determine the isolation of the region would get an invalid isolation. This would then cause us to crash when we attempted to print out the isolation in an error. The fix was to just add the check that we already performed in AssignIndirect also in AssignDirect.