### PR TITLE
AST: Relax availability checking for decls in unavailable contexts

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -681,6 +681,10 @@ struct ASTContext::Implementation {
   /// The set of unique custom availability domains.
   llvm::FoldingSet<CustomAvailabilityDomain> CustomAvailabilityDomains;
 
+  /// The most specific platform AvailabilityDomain that corresponds to the
+  /// compilation's `-target`.
+  std::optional<AvailabilityDomain> TargetAvailabilityDomain;
+
   /// A cache of information about whether particular nominal types
   /// are representable in a foreign language.
   llvm::DenseMap<NominalTypeDecl *, ForeignRepresentationInfo>
@@ -7465,13 +7469,21 @@ ValueOwnership swift::asValueOwnership(ParameterOwnership o) {
   llvm_unreachable("exhaustive switch");
 }
 
-AvailabilityDomain ASTContext::getTargetAvailabilityDomain() const {
-  auto platform = swift::targetPlatform(LangOpts);
+static AvailabilityDomain
+targetAvailabilityDomainForPlatform(PlatformKind platform) {
   if (platform != PlatformKind::none)
     return AvailabilityDomain::forPlatform(platform);
 
   // Fall back to the universal domain for triples without a platform.
   return AvailabilityDomain::forUniversal();
+}
+
+AvailabilityDomain ASTContext::getTargetAvailabilityDomain() const {
+  if (!getImpl().TargetAvailabilityDomain) {
+    getImpl().TargetAvailabilityDomain =
+        targetAvailabilityDomainForPlatform(swift::targetPlatform(LangOpts));
+  }
+  return *getImpl().TargetAvailabilityDomain;
 }
 
 GenericSignature &

--- a/lib/AST/AvailabilityConstraint.cpp
+++ b/lib/AST/AvailabilityConstraint.cpp
@@ -195,7 +195,18 @@ shouldIgnoreConstraintInContext(const Decl *decl,
   if (!canIgnoreConstraintInUnavailableContexts(decl, constraint, flags))
     return false;
 
-  return context.isUnavailableForDomain(constraint.getDomain());
+  // If the constraint's domain is a superset of the compilation's target
+  // availability domain, use the more specific target availability domain
+  // instead. This allows declarations that are @available(macOS, unavailable)
+  // to be used in contexts that are @available(macOSApplicationExtension,
+  // unavailable), for example.
+  auto &ctx = decl->getASTContext();
+  auto domain = constraint.getDomain();
+  auto targetDomain = ctx.getTargetAvailabilityDomain();
+  if (domain.isSupersetOf(targetDomain))
+    domain = targetDomain;
+
+  return context.isUnavailableForDomain(domain);
 }
 
 /// Returns the `AvailabilityConstraint` that describes how \p attr restricts

--- a/test/Availability/availability_any_apple_os.swift
+++ b/test/Availability/availability_any_apple_os.swift
@@ -29,8 +29,25 @@ func availableInMacOS26_1AndAnyAppleOS26() { }
 @available(macOS 26.1, iOS 26.1, watchOS 26.1, tvOS 26.1, visionOS 26.1, *)
 func availableInEveryAppleOS26_1() { }
 
+@available(macOS, unavailable)
+@available(iOS, unavailable)
+@available(watchOS, unavailable)
+@available(tvOS, unavailable)
+@available(visionOS, unavailable)
+func unavailableInEveryAppleOS() {
+  availableInAnyAppleOS26_1()
+  availableInMacOS26_1AndAnyAppleOS26()
+  availableInEveryAppleOS26_1()
+  unavailableInAnyAppleOS()
+}
+
 @available(anyAppleOS, unavailable)
-func unavailableInAnyAppleOS() { } // expected-apple-note {{'unavailableInAnyAppleOS()' has been explicitly marked unavailable here}}
+func unavailableInAnyAppleOS() { // expected-apple-note {{'unavailableInAnyAppleOS()' has been explicitly marked unavailable here}}
+  availableInAnyAppleOS26_1()
+  availableInMacOS26_1AndAnyAppleOS26()
+  availableInEveryAppleOS26_1()
+  unavailableInEveryAppleOS()
+}
 
 // FIXME: [availability] Ensure the fix-it suggests @available(anyAppleOS ...) rdar://163819878
 func availableAtDeploymentTarget() {

--- a/test/SILGen/back_deployed_attr.swift
+++ b/test/SILGen/back_deployed_attr.swift
@@ -112,3 +112,15 @@ public func backDeployedBeforeVersionMappingTo26() -> Int {
   // CHECK: cond_br [[AVAIL]]
   return 0
 }
+
+// CHECK-LABEL: sil non_abi [serialized] [back_deployed_thunk] [ossa] @$s11back_deploy0A33DeployedBeforeVersionAnyAppleOS26SiyFTwb :
+@backDeployed(before: anyAppleOS 26)
+public func backDeployedBeforeVersionAnyAppleOS26() -> Int {
+  // CHECK: [[MAJOR:%.*]] = integer_literal $Builtin.Word, 26
+  // CHECK: [[MINOR:%.*]] = integer_literal $Builtin.Word, 0
+  // CHECK: [[PATCH:%.*]] = integer_literal $Builtin.Word, 0
+  // CHECK: [[OSVFN:%.*]] = function_ref @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
+  // CHECK: [[AVAIL:%.*]] = apply [[OSVFN]]([[MAJOR]], [[MINOR]], [[PATCH]]) : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
+  // CHECK: cond_br [[AVAIL]]
+  return 0
+}

--- a/test/attr/attr_availability_android.swift
+++ b/test/attr/attr_availability_android.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -typecheck -verify -parse-stdlib -target aarch64-unknown-linux-android28 %s
+// RUN: %target-typecheck-verify-swift -parse-stdlib -target aarch64-unknown-linux-android28 %s
 
 @available(Android, introduced: 1.0, deprecated: 2.0, obsoleted: 28.0,
               message: "you don't want to do that anyway")

--- a/test/attr/attr_availability_maccatalyst.swift
+++ b/test/attr/attr_availability_maccatalyst.swift
@@ -163,7 +163,7 @@ extension AvailableOnMacCatalystButUnavailableOniOS { } // ok
 @available(macCatalyst, unavailable)
 extension UnavailableOnMacCatalyst {
   func extensionMethod() {
-    takesAnything(UnavailableOniOS()) // expected-error {{'UnavailableOniOS' is unavailable in iOS}}
+    takesAnything(UnavailableOniOS())
     takesAnything(UnavailableOnMacCatalyst())
     takesAnything(AvailableOnMacCatalystButUnavailableOniOS())
   }
@@ -177,7 +177,7 @@ extension UnavailableOnMacCatalyst {
 
   @available(iOS, introduced: 15)
   func extensionMethodIntroducedOniOS() {
-    takesAnything(UnavailableOniOS()) // expected-error {{'UnavailableOniOS' is unavailable in iOS}}
+    takesAnything(UnavailableOniOS())
     takesAnything(UnavailableOnMacCatalyst())
     takesAnything(AvailableOnMacCatalystButUnavailableOniOS())
   }
@@ -218,7 +218,7 @@ extension AvailableOnMacCatalystButUnavailableOniOS {
 
   @available(macCatalyst, unavailable)
   func extensionMethodUnavailableOnMacCatalyst() {
-    takesAnything(UnavailableOniOS()) // expected-error {{'UnavailableOniOS' is unavailable in iOS}}
+    takesAnything(UnavailableOniOS())
     takesAnything(UnavailableOnMacCatalyst())
     takesAnything(AvailableOnMacCatalystButUnavailableOniOS())
   }

--- a/test/attr/attr_availability_transitive_ios.swift
+++ b/test/attr/attr_availability_transitive_ios.swift
@@ -1,5 +1,4 @@
-// RUN: %target-typecheck-verify-swift
-// REQUIRES: OS=ios
+// RUN: %target-typecheck-verify-swift -parse-stdlib -target arm64-apple-ios13.0
 
 // Allow referencing unavailable API in situations where the caller is marked unavailable in the same circumstances.
 

--- a/test/attr/attr_availability_transitive_ios_appext.swift
+++ b/test/attr/attr_availability_transitive_ios_appext.swift
@@ -1,11 +1,10 @@
-// RUN: %target-typecheck-verify-swift -application-extension
-// RUN: %target-typecheck-verify-swift -application-extension-library
-// REQUIRES: OS=ios
+// RUN: %target-typecheck-verify-swift -application-extension -parse-stdlib -target arm64-apple-ios13.0
+// RUN: %target-typecheck-verify-swift -application-extension-library -parse-stdlib -target arm64-apple-ios13.0
 
 // Allow referencing unavailable API in situations where the caller is marked unavailable in the same circumstances.
 
 @available(iOS, unavailable)
-func ios() {} // expected-note 2{{'ios()' has been explicitly marked unavailable here}}
+func ios() {} // expected-note {{'ios()' has been explicitly marked unavailable here}}
 
 @available(iOSApplicationExtension, unavailable)
 func ios_extension() {} // expected-note {{'ios_extension()' has been explicitly marked unavailable here}}
@@ -34,5 +33,5 @@ func ios_extension_call_ios_extension() {
 
 @available(iOSApplicationExtension, unavailable)
 func ios_extension_call_ios() {
-    ios() // expected-error {{'ios()' is unavailable}}
+    ios()
 }

--- a/test/attr/attr_availability_transitive_nested.swift
+++ b/test/attr/attr_availability_transitive_nested.swift
@@ -1,5 +1,4 @@
-// RUN: %target-typecheck-verify-swift
-// REQUIRES: OS=macosx
+// RUN: %target-typecheck-verify-swift -parse-stdlib -target arm64-apple-macos11
 
 // Make sure that a compatible unavailable wrapping doesn't allow referencing declarations that are completely unavailable.
 

--- a/test/attr/attr_availability_transitive_osx.swift
+++ b/test/attr/attr_availability_transitive_osx.swift
@@ -1,5 +1,4 @@
-// RUN: %target-typecheck-verify-swift -parse-as-library
-// REQUIRES: OS=macosx
+// RUN: %target-typecheck-verify-swift -parse-as-library  -parse-stdlib -target arm64-apple-macos11
 
 // Allow referencing unavailable API in situations where the caller is marked unavailable in the same circumstances.
 
@@ -10,6 +9,9 @@ struct NeverAvailable {} // expected-note * {{'NeverAvailable' has been explicit
 
 @available(OSX 99, *)
 struct OSXFutureAvailable {}
+
+@available(anyAppleOS 99, *)
+struct AnyAppleOSFutureAvailable {}
 
 @available(OSX, unavailable)
 struct OSXUnavailable {} // expected-note * {{'OSXUnavailable' has been explicitly marked unavailable here}}
@@ -38,6 +40,12 @@ func osx_future() -> OSXFutureAvailable {
   OSXFutureAvailable()
 }
 
+@available(anyAppleOS 99, *)
+@discardableResult
+func any_apple_os_future() -> AnyAppleOSFutureAvailable {
+  AnyAppleOSFutureAvailable()
+}
+
 @available(OSX, unavailable)
 @discardableResult
 func osx() -> OSXUnavailable { // expected-note * {{'osx()' has been explicitly marked unavailable here}}
@@ -63,6 +71,7 @@ func available_func( // expected-note * {{add '@available' attribute to enclosin
   _: AlwaysAvailable,
   _: NeverAvailable, // expected-error {{'NeverAvailable' is unavailable}}
   _: OSXFutureAvailable, // expected-error {{'OSXFutureAvailable' is only available in macOS 99 or newer}}
+  _: AnyAppleOSFutureAvailable, // expected-error {{'AnyAppleOSFutureAvailable' is only available in macOS 99 or newer}}
   _: OSXUnavailable, // expected-error {{'OSXUnavailable' is unavailable in macOS}}
   _: MultiPlatformUnavailable, // expected-error {{'MultiPlatformUnavailable' is unavailable in macOS}}
   _: OSXAppExtensionsUnavailable
@@ -70,6 +79,8 @@ func available_func( // expected-note * {{add '@available' attribute to enclosin
   always()
   never() // expected-error {{'never()' is unavailable}}
   osx_future() // expected-error {{'osx_future()' is only available in macOS 99 or newer}}
+  // expected-note@-1 {{add 'if #available' version check}}
+  any_apple_os_future() // expected-error {{'any_apple_os_future()' is only available in macOS 99 or newer}}
   // expected-note@-1 {{add 'if #available' version check}}
   osx() // expected-error {{'osx()' is unavailable}}
   osx_ios() // expected-error {{'osx_ios()' is unavailable}}
@@ -81,6 +92,7 @@ func never_available_func(
   _: AlwaysAvailable,
   _: NeverAvailable,
   _: OSXFutureAvailable,
+  _: AnyAppleOSFutureAvailable,
   _: OSXUnavailable,
   _: MultiPlatformUnavailable,
   _: OSXAppExtensionsUnavailable
@@ -88,6 +100,7 @@ func never_available_func(
   always()
   never() // expected-error {{'never()' is unavailable}}
   osx_future()
+  any_apple_os_future()
   osx()
   osx_ios()
   osx_extension()
@@ -98,6 +111,7 @@ func osx_func(
   _: AlwaysAvailable,
   _: NeverAvailable, // expected-error {{'NeverAvailable' is unavailable}}
   _: OSXFutureAvailable,
+  _: AnyAppleOSFutureAvailable,
   _: OSXUnavailable,
   _: MultiPlatformUnavailable,
   _: OSXAppExtensionsUnavailable
@@ -105,16 +119,18 @@ func osx_func(
   always()
   never() // expected-error {{'never()' is unavailable}}
   osx_future()
+  any_apple_os_future()
   osx()
   osx_ios()
   osx_extension()
 }
 
 @available(OSXApplicationExtension, unavailable)
-func osx_extension_func( // expected-note 2 {{add '@available' attribute to enclosing global function}}
+func osx_extension_func( // expected-note 4 {{add '@available' attribute to enclosing global function}}
   _: AlwaysAvailable,
   _: NeverAvailable, // expected-error {{'NeverAvailable' is unavailable}}
   _: OSXFutureAvailable, // expected-error {{'OSXFutureAvailable' is only available in macOS 99 or newer}}
+  _: AnyAppleOSFutureAvailable, // expected-error {{'AnyAppleOSFutureAvailable' is only available in macOS 99 or newer}}
   _: OSXUnavailable, // expected-error {{'OSXUnavailable' is unavailable in macOS}}
   _: MultiPlatformUnavailable, // expected-error {{'MultiPlatformUnavailable' is unavailable in macOS}}
   _: OSXAppExtensionsUnavailable
@@ -123,6 +139,8 @@ func osx_extension_func( // expected-note 2 {{add '@available' attribute to encl
   never() // expected-error {{'never()' is unavailable}}
   osx_future() // expected-error {{'osx_future()' is only available in macOS 99 or newer}}
   // expected-note@-1 {{add 'if #available' version check}}
+  any_apple_os_future() // expected-error {{'any_apple_os_future()' is only available in macOS 99 or newer}}
+  // expected-note@-1 {{add 'if #available' version check}}
   osx() // expected-error {{'osx()' is unavailable}}
   osx_ios() // expected-error {{'osx_ios()' is unavailable}}
   osx_extension()
@@ -130,10 +148,11 @@ func osx_extension_func( // expected-note 2 {{add '@available' attribute to encl
 
 // MARK: Global vars
 
-var always_var: ( // expected-note 2 {{add '@available' attribute to enclosing var}}
+var always_var: ( // expected-note 4 {{add '@available' attribute to enclosing var}}
   AlwaysAvailable,
   NeverAvailable, // expected-error {{'NeverAvailable' is unavailable}}
   OSXFutureAvailable, // expected-error {{'OSXFutureAvailable' is only available in macOS 99 or newer}}
+  AnyAppleOSFutureAvailable, // expected-error {{'AnyAppleOSFutureAvailable' is only available in macOS 99 or newer}}
   OSXUnavailable, // expected-error {{'OSXUnavailable' is unavailable in macOS}}
   MultiPlatformUnavailable, // expected-error {{'MultiPlatformUnavailable' is unavailable in macOS}}
   OSXAppExtensionsUnavailable
@@ -141,6 +160,7 @@ var always_var: ( // expected-note 2 {{add '@available' attribute to enclosing v
   always(),
   never(), // expected-error {{'never()' is unavailable}}
   osx_future(), // expected-error {{'osx_future()' is only available in macOS 99 or newer}}
+  any_apple_os_future(), // expected-error {{'any_apple_os_future()' is only available in macOS 99 or newer}}
   osx(), // expected-error {{'osx()' is unavailable}}
   osx_ios(), // expected-error {{'osx_ios()' is unavailable}}
   osx_extension()
@@ -151,6 +171,7 @@ var never_var: (
   AlwaysAvailable,
   NeverAvailable,
   OSXFutureAvailable,
+  AnyAppleOSFutureAvailable,
   OSXUnavailable,
   MultiPlatformUnavailable,
   OSXAppExtensionsUnavailable
@@ -158,6 +179,7 @@ var never_var: (
   always(),
   never(), // expected-error {{'never()' is unavailable}}
   osx_future(),
+  any_apple_os_future(),
   osx(),
   osx_ios(),
   osx_extension()
@@ -168,6 +190,7 @@ var osx_var: (
   AlwaysAvailable,
   NeverAvailable, // expected-error {{'NeverAvailable' is unavailable}}
   OSXFutureAvailable,
+  AnyAppleOSFutureAvailable,
   OSXUnavailable,
   MultiPlatformUnavailable,
   OSXAppExtensionsUnavailable
@@ -175,16 +198,18 @@ var osx_var: (
   always(),
   never(), // expected-error {{'never()' is unavailable}}
   osx_future(),
+  any_apple_os_future(),
   osx(),
   osx_ios(),
   osx_extension()
 )
 
 @available(OSXApplicationExtension, unavailable)
-var osx_extension_var: ( // expected-note 2 {{add '@available' attribute to enclosing var}}
+var osx_extension_var: ( // expected-note 4 {{add '@available' attribute to enclosing var}}
   AlwaysAvailable,
   NeverAvailable, // expected-error {{'NeverAvailable' is unavailable}}
   OSXFutureAvailable, // expected-error {{'OSXFutureAvailable' is only available in macOS 99 or newer}}
+  AnyAppleOSFutureAvailable, // expected-error {{'AnyAppleOSFutureAvailable' is only available in macOS 99 or newer}}
   OSXUnavailable, // expected-error {{'OSXUnavailable' is unavailable in macOS}}
   MultiPlatformUnavailable, // expected-error {{'MultiPlatformUnavailable' is unavailable in macOS}}
   OSXAppExtensionsUnavailable
@@ -192,6 +217,7 @@ var osx_extension_var: ( // expected-note 2 {{add '@available' attribute to encl
   always(),
   never(), // expected-error {{'never()' is unavailable}}
   osx_future(), // expected-error {{'osx_future()' is only available in macOS 99 or newer}}
+  any_apple_os_future(), // expected-error {{'any_apple_os_future()' is only available in macOS 99 or newer}}
   osx(), // expected-error {{'osx()' is unavailable}}
   osx_ios(), // expected-error {{'osx_ios()' is unavailable}}
   osx_extension()
@@ -199,12 +225,14 @@ var osx_extension_var: ( // expected-note 2 {{add '@available' attribute to encl
 
 // MARK: Properties
 
-struct AlwaysAvailableContainer { // expected-note 2 {{add '@available' attribute to enclosing struct}}
+struct AlwaysAvailableContainer { // expected-note 4 {{add '@available' attribute to enclosing struct}}
   let always_var: AlwaysAvailable = always()
   let never_var: NeverAvailable = never() // expected-error {{'never()' is unavailable}}
   // expected-error@-1 {{'NeverAvailable' is unavailable}}
   let osx_future_var: OSXFutureAvailable = osx_future() // expected-error {{'osx_future()' is only available in macOS 99 or newer}}
   // expected-error@-1 {{'OSXFutureAvailable' is only available in macOS 99 or newer}}
+  let any_apple_os_future_var: AnyAppleOSFutureAvailable = any_apple_os_future() // expected-error {{'any_apple_os_future()' is only available in macOS 99 or newer}}
+  // expected-error@-1 {{'AnyAppleOSFutureAvailable' is only available in macOS 99 or newer}}
   let osx_var: OSXUnavailable = osx() // expected-error {{'osx()' is unavailable}}
   // expected-error@-1 {{'OSXUnavailable' is unavailable in macOS}}
   let osx_ios_var: MultiPlatformUnavailable = osx_ios() // expected-error {{'osx_ios()' is unavailable}}
@@ -217,6 +245,7 @@ struct NeverAvailableContainer { // expected-note 3 {{'NeverAvailableContainer' 
   let always_var: AlwaysAvailable = always()
   let never_var: NeverAvailable = never() // expected-error {{'never()' is unavailable}}
   let osx_future_var: OSXFutureAvailable = osx_future()
+  let any_apple_os_future_var: AnyAppleOSFutureAvailable = any_apple_os_future()
   let osx_var: OSXUnavailable = osx()
   let osx_ios_var: MultiPlatformUnavailable = osx_ios()
   let osx_extension_var: OSXAppExtensionsUnavailable = osx_extension()
@@ -228,18 +257,21 @@ struct OSXUnavailableContainer { // expected-note 2 {{'OSXUnavailableContainer' 
   let never_var: NeverAvailable = never() // expected-error {{'never()' is unavailable}}
   // expected-error@-1 {{'NeverAvailable' is unavailable}}
   let osx_future_var: OSXFutureAvailable = osx_future()
+  let any_apple_os_future_var: AnyAppleOSFutureAvailable = any_apple_os_future()
   let osx_var: OSXUnavailable = osx()
   let osx_ios_var: MultiPlatformUnavailable = osx_ios()
   let osx_extension_var: OSXAppExtensionsUnavailable = osx_extension()
 }
 
 @available(OSXApplicationExtension, unavailable)
-struct OSXAppExtensionsUnavailableContainer { // expected-note 2 {{add '@available' attribute to enclosing struct}}
+struct OSXAppExtensionsUnavailableContainer { // expected-note 4 {{add '@available' attribute to enclosing struct}}
   let always_var: AlwaysAvailable = always()
   let never_var: NeverAvailable = never() // expected-error {{'never()' is unavailable}}
   // expected-error@-1 {{'NeverAvailable' is unavailable}}
   let osx_future_var: OSXFutureAvailable = osx_future() // expected-error {{'osx_future()' is only available in macOS 99 or newer}}
   // expected-error@-1 {{'OSXFutureAvailable' is only available in macOS 99 or newer}}
+  let any_apple_os_future_var: AnyAppleOSFutureAvailable = any_apple_os_future() // expected-error {{'any_apple_os_future()' is only available in macOS 99 or newer}}
+  // expected-error@-1 {{'AnyAppleOSFutureAvailable' is only available in macOS 99 or newer}}
   let osx_var: OSXUnavailable = osx() // expected-error {{'osx()' is unavailable}}
   // expected-error@-1 {{'OSXUnavailable' is unavailable in macOS}}
   let osx_ios_var: MultiPlatformUnavailable = osx_ios() // expected-error {{'osx_ios()' is unavailable}}
@@ -294,6 +326,7 @@ extension ExtendMe {
     _: AlwaysAvailable,
     _: NeverAvailable,
     _: OSXFutureAvailable,
+    _: AnyAppleOSFutureAvailable,
     _: OSXUnavailable,
     _: MultiPlatformUnavailable,
     _: OSXAppExtensionsUnavailable
@@ -301,6 +334,7 @@ extension ExtendMe {
     always()
     never() // expected-error {{'never()' is unavailable}}
     osx_future()
+    any_apple_os_future()
     osx()
     osx_ios()
     osx_extension()
@@ -311,6 +345,7 @@ extension ExtendMe {
     _: AlwaysAvailable,
     _: NeverAvailable,
     _: OSXFutureAvailable,
+    _: AnyAppleOSFutureAvailable,
     _: OSXUnavailable,
     _: MultiPlatformUnavailable,
     _: OSXAppExtensionsUnavailable
@@ -318,6 +353,7 @@ extension ExtendMe {
     always()
     never() // expected-error {{'never()' is unavailable}}
     osx_future()
+    any_apple_os_future()
     osx()
     osx_ios()
     osx_extension()
@@ -328,6 +364,7 @@ extension ExtendMe {
     _: AlwaysAvailable,
     _: NeverAvailable,
     _: OSXFutureAvailable,
+    _: AnyAppleOSFutureAvailable,
     _: OSXUnavailable,
     _: MultiPlatformUnavailable,
     _: OSXAppExtensionsUnavailable
@@ -335,6 +372,7 @@ extension ExtendMe {
     always()
     never() // expected-error {{'never()' is unavailable}}
     osx_future()
+    any_apple_os_future()
     osx()
     osx_ios()
     osx_extension()
@@ -345,6 +383,7 @@ extension ExtendMe {
     _: AlwaysAvailable,
     _: NeverAvailable,
     _: OSXFutureAvailable,
+    _: AnyAppleOSFutureAvailable,
     _: OSXUnavailable,
     _: MultiPlatformUnavailable,
     _: OSXAppExtensionsUnavailable
@@ -352,6 +391,7 @@ extension ExtendMe {
     always()
     never() // expected-error {{'never()' is unavailable}}
     osx_future()
+    any_apple_os_future()
     osx()
     osx_ios()
     osx_extension()
@@ -369,6 +409,7 @@ extension ExtendMe {
     _: AlwaysAvailable,
     _: NeverAvailable, // expected-error {{'NeverAvailable' is unavailable}}
     _: OSXFutureAvailable,
+    _: AnyAppleOSFutureAvailable,
     _: OSXUnavailable,
     _: MultiPlatformUnavailable,
     _: OSXAppExtensionsUnavailable
@@ -376,6 +417,7 @@ extension ExtendMe {
     always()
     never() // expected-error {{'never()' is unavailable}}
     osx_future()
+    any_apple_os_future()
     osx()
     osx_ios()
     osx_extension()
@@ -386,6 +428,7 @@ extension ExtendMe {
     _: AlwaysAvailable,
     _: NeverAvailable,
     _: OSXFutureAvailable,
+    _: AnyAppleOSFutureAvailable,
     _: OSXUnavailable,
     _: MultiPlatformUnavailable,
     _: OSXAppExtensionsUnavailable
@@ -393,6 +436,7 @@ extension ExtendMe {
     always()
     never() // expected-error {{'never()' is unavailable}}
     osx_future()
+    any_apple_os_future()
     osx()
     osx_ios()
     osx_extension()
@@ -403,6 +447,7 @@ extension ExtendMe {
     _: AlwaysAvailable,
     _: NeverAvailable, // expected-error {{'NeverAvailable' is unavailable}}
     _: OSXFutureAvailable,
+    _: AnyAppleOSFutureAvailable,
     _: OSXUnavailable,
     _: MultiPlatformUnavailable,
     _: OSXAppExtensionsUnavailable
@@ -410,6 +455,7 @@ extension ExtendMe {
     always()
     never() // expected-error {{'never()' is unavailable}}
     osx_future()
+    any_apple_os_future()
     osx()
     osx_ios()
     osx_extension()
@@ -420,6 +466,7 @@ extension ExtendMe {
     _: AlwaysAvailable,
     _: NeverAvailable, // expected-error {{'NeverAvailable' is unavailable}}
     _: OSXFutureAvailable,
+    _: AnyAppleOSFutureAvailable,
     _: OSXUnavailable,
     _: MultiPlatformUnavailable,
     _: OSXAppExtensionsUnavailable
@@ -427,6 +474,7 @@ extension ExtendMe {
     always()
     never() // expected-error {{'never()' is unavailable}}
     osx_future()
+    any_apple_os_future()
     osx()
     osx_ios()
     osx_extension()
@@ -444,6 +492,7 @@ extension ExtendMe { // expected-note * {{add '@available' attribute to enclosin
     _: AlwaysAvailable,
     _: NeverAvailable, // expected-error {{'NeverAvailable' is unavailable}}
     _: OSXFutureAvailable, // expected-error {{'OSXFutureAvailable' is only available in macOS 99 or newer}}
+    _: AnyAppleOSFutureAvailable, // expected-error {{'AnyAppleOSFutureAvailable' is only available in macOS 99 or newer}}
     _: OSXUnavailable, // expected-error {{'OSXUnavailable' is unavailable in macOS}}
     _: MultiPlatformUnavailable, // expected-error {{'MultiPlatformUnavailable' is unavailable in macOS}}
     _: OSXAppExtensionsUnavailable
@@ -451,6 +500,8 @@ extension ExtendMe { // expected-note * {{add '@available' attribute to enclosin
     always()
     never() // expected-error {{'never()' is unavailable}}
     osx_future() // expected-error {{'osx_future()' is only available in macOS 99 or newer}}
+    // expected-note@-1 {{add 'if #available' version check}}
+    any_apple_os_future() // expected-error {{'any_apple_os_future()' is only available in macOS 99 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
     osx() // expected-error {{'osx()' is unavailable}}
     osx_ios() // expected-error {{'osx_ios()' is unavailable}}
@@ -462,6 +513,7 @@ extension ExtendMe { // expected-note * {{add '@available' attribute to enclosin
     _: AlwaysAvailable,
     _: NeverAvailable,
     _: OSXFutureAvailable,
+    _: AnyAppleOSFutureAvailable,
     _: OSXUnavailable,
     _: MultiPlatformUnavailable,
     _: OSXAppExtensionsUnavailable
@@ -469,6 +521,7 @@ extension ExtendMe { // expected-note * {{add '@available' attribute to enclosin
     always()
     never() // expected-error {{'never()' is unavailable}}
     osx_future()
+    any_apple_os_future()
     osx()
     osx_ios()
     osx_extension()
@@ -479,6 +532,7 @@ extension ExtendMe { // expected-note * {{add '@available' attribute to enclosin
     _: AlwaysAvailable,
     _: NeverAvailable, // expected-error {{'NeverAvailable' is unavailable}}
     _: OSXFutureAvailable,
+    _: AnyAppleOSFutureAvailable,
     _: OSXUnavailable,
     _: MultiPlatformUnavailable,
     _: OSXAppExtensionsUnavailable
@@ -486,16 +540,18 @@ extension ExtendMe { // expected-note * {{add '@available' attribute to enclosin
     always()
     never() // expected-error {{'never()' is unavailable}}
     osx_future()
+    any_apple_os_future()
     osx()
     osx_ios()
     osx_extension()
   }
 
   @available(OSXApplicationExtension, unavailable)
-  func osx_app_extension_extension_osx_app_extension_method( // expected-note 2 {{add '@available' attribute to enclosing instance method}}
+  func osx_app_extension_extension_osx_app_extension_method( // expected-note 4 {{add '@available' attribute to enclosing instance method}}
     _: AlwaysAvailable,
     _: NeverAvailable, // expected-error {{'NeverAvailable' is unavailable}}
     _: OSXFutureAvailable, // expected-error {{'OSXFutureAvailable' is only available in macOS 99 or newer}}
+    _: AnyAppleOSFutureAvailable, // expected-error {{'AnyAppleOSFutureAvailable' is only available in macOS 99 or newer}}
     _: OSXUnavailable, // expected-error {{'OSXUnavailable' is unavailable in macOS}}
     _: MultiPlatformUnavailable, // expected-error {{'MultiPlatformUnavailable' is unavailable in macOS}}
     _: OSXAppExtensionsUnavailable
@@ -503,6 +559,8 @@ extension ExtendMe { // expected-note * {{add '@available' attribute to enclosin
     always()
     never() // expected-error {{'never()' is unavailable}}
     osx_future() // expected-error {{'osx_future()' is only available in macOS 99 or newer}}
+    // expected-note@-1 {{add 'if #available' version check}}
+    any_apple_os_future() // expected-error {{'any_apple_os_future()' is only available in macOS 99 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
     osx() // expected-error {{'osx()' is unavailable}}
     osx_ios() // expected-error {{'osx_ios()' is unavailable}}
@@ -521,6 +579,8 @@ func available_func_call_extension_methods(_ e: ExtendMe) { // expected-note {{a
   e.osx_app_extension_extension_osx_future_method() // expected-error {{'osx_app_extension_extension_osx_future_method()' is only available in macOS 99 or newer}}
   // expected-note@-1 {{add 'if #available' version check}}
 }
+
+func takesAnything<T>(_ t: T) { }
 
 @available(OSX, obsoleted: 10.9)
 struct OSXObsoleted {}
@@ -550,11 +610,11 @@ func osx_unavailable_func(
   OSXUnavailableAndIntroducedInFutureSameAttribute,
   OSXIntroducedInFutureAndUnavailable
 ) {
-  _ = OSXFutureAvailable()
-  _ = OSXObsoleted()
-  _ = OSXUnavailableAndIntroducedInFuture()
-  _ = OSXUnavailableAndIntroducedInFutureSameAttribute()
-  _ = OSXIntroducedInFutureAndUnavailable()
+  takesAnything(OSXFutureAvailable())
+  takesAnything(OSXObsoleted())
+  takesAnything(OSXUnavailableAndIntroducedInFuture())
+  takesAnything(OSXUnavailableAndIntroducedInFutureSameAttribute())
+  takesAnything(OSXIntroducedInFutureAndUnavailable())
 
   func takesType<T>(_ t: T.Type) {}
   takesType(OSXFutureAvailable.self)
@@ -580,11 +640,11 @@ func osx_unavailable_and_introduced_func(
   OSXUnavailableAndIntroducedInFutureSameAttribute,
   OSXIntroducedInFutureAndUnavailable
 ) {
-  _ = OSXFutureAvailable()
-  _ = OSXObsoleted()
-  _ = OSXUnavailableAndIntroducedInFuture()
-  _ = OSXUnavailableAndIntroducedInFutureSameAttribute()
-  _ = OSXIntroducedInFutureAndUnavailable()
+  takesAnything(OSXFutureAvailable())
+  takesAnything(OSXObsoleted())
+  takesAnything(OSXUnavailableAndIntroducedInFuture())
+  takesAnything(OSXUnavailableAndIntroducedInFutureSameAttribute())
+  takesAnything(OSXIntroducedInFutureAndUnavailable())
 
   func takesType<T>(_ t: T.Type) {}
   takesType(OSXFutureAvailable.self)

--- a/test/attr/attr_availability_transitive_osx_appext.swift
+++ b/test/attr/attr_availability_transitive_osx_appext.swift
@@ -1,5 +1,4 @@
-// RUN: %target-typecheck-verify-swift -parse-as-library -application-extension
-// REQUIRES: OS=macosx
+// RUN: %target-typecheck-verify-swift -parse-as-library -application-extension -parse-stdlib -target arm64-apple-macos11
 
 // Allow referencing unavailable API in situations where the caller is marked unavailable in the same circumstances.
 
@@ -67,11 +66,11 @@ func osx_func(
 @available(OSXApplicationExtension, unavailable)
 func osx_extension_func(
   _: NeverAvailable, // expected-error {{'NeverAvailable' is unavailable}}
-  _: OSXUnavailable, // expected-error {{'OSXUnavailable' is unavailable in macOS}}
+  _: OSXUnavailable,
   _: OSXAppExtensionsUnavailable
 ) {
   never() // expected-error {{'never()' is unavailable}}
-  osx() // expected-error {{'osx()' is unavailable}}
+  osx()
   osx_extension()
 }
 
@@ -112,11 +111,11 @@ var osx_var: (
 @available(OSXApplicationExtension, unavailable)
 var osx_extension_var: (
   NeverAvailable, // expected-error {{'NeverAvailable' is unavailable}}
-  OSXUnavailable, // expected-error {{'OSXUnavailable' is unavailable in macOS}}
+  OSXUnavailable,
   OSXAppExtensionsUnavailable
 ) = (
   never(), // expected-error {{'never()' is unavailable}}
-  osx(), // expected-error {{'osx()' is unavailable}}
+  osx(),
   osx_extension()
 )
 
@@ -139,7 +138,7 @@ struct NeverAvailableContainer { // expected-note 3 {{'NeverAvailableContainer' 
 }
 
 @available(OSX, unavailable)
-struct OSXUnavailableContainer { // expected-note 2 {{'OSXUnavailableContainer' has been explicitly marked unavailable here}}
+struct OSXUnavailableContainer { // expected-note {{'OSXUnavailableContainer' has been explicitly marked unavailable here}}
   let never_var: NeverAvailable = never() // expected-error {{'never()' is unavailable}}
   // expected-error@-1 {{'NeverAvailable' is unavailable}}
   let osx_var: OSXUnavailable = osx()
@@ -150,8 +149,7 @@ struct OSXUnavailableContainer { // expected-note 2 {{'OSXUnavailableContainer' 
 struct OSXAppExtensionsUnavailableContainer { // expected-note {{'OSXAppExtensionsUnavailableContainer' has been explicitly marked unavailable here}}
   let never_var: NeverAvailable = never() // expected-error {{'never()' is unavailable}}
   // expected-error@-1 {{'NeverAvailable' is unavailable}}
-  let osx_var: OSXUnavailable = osx() // expected-error {{'osx()' is unavailable}}
-  // expected-error@-1 {{'OSXUnavailable' is unavailable in macOS}}
+  let osx_var: OSXUnavailable = osx()
   let osx_extension_var: OSXAppExtensionsUnavailable = osx_extension()
 }
 
@@ -185,7 +183,7 @@ extension AlwaysAvailabileContainer {}
 @available(OSXApplicationExtension, unavailable)
 extension NeverAvailableContainer {} // expected-error {{'NeverAvailableContainer' is unavailable}}
 @available(OSXApplicationExtension, unavailable)
-extension OSXUnavailableContainer {} // expected-error {{'OSXUnavailableContainer' is unavailable in macOS}}
+extension OSXUnavailableContainer {}
 @available(OSXApplicationExtension, unavailable)
 extension OSXAppExtensionsUnavailableContainer {}
 
@@ -244,19 +242,19 @@ extension ExtendMe {
 
 @available(OSX, unavailable)
 extension ExtendMe {
-  func osx_extension_available_method() {} // expected-note 2 {{has been explicitly marked unavailable here}}
+  func osx_extension_available_method() {} // expected-note {{has been explicitly marked unavailable here}}
 
   @available(OSX 99, *)
-  func osx_extension_osx_future_method() {} // expected-note 2 {{has been explicitly marked unavailable here}}
+  func osx_extension_osx_future_method() {} // expected-note {{has been explicitly marked unavailable here}}
 
   @available(*, unavailable)
   func osx_extension_never_available_method() {} // expected-note 3 {{'osx_extension_never_available_method()' has been explicitly marked unavailable here}}
 
   @available(OSX, unavailable)
-  func osx_extension_osx_method() {} // expected-note 2 {{'osx_extension_osx_method()' has been explicitly marked unavailable here}}
+  func osx_extension_osx_method() {} // expected-note {{'osx_extension_osx_method()' has been explicitly marked unavailable here}}
 
   @available(OSXApplicationExtension, unavailable)
-  func osx_extension_osx_app_extension_method() {} // expected-note 2 {{'osx_extension_osx_app_extension_method()' has been explicitly marked unavailable here}}
+  func osx_extension_osx_app_extension_method() {} // expected-note {{'osx_extension_osx_app_extension_method()' has been explicitly marked unavailable here}}
 
   func osx_extension_available_method(
     _: NeverAvailable, // expected-error {{'NeverAvailable' is unavailable}}
@@ -313,18 +311,18 @@ extension ExtendMe {
   func osx_app_extension_extension_never_available_method() {} // expected-note 3 {{'osx_app_extension_extension_never_available_method()' has been explicitly marked unavailable here}}
 
   @available(OSX, unavailable)
-  func osx_app_extension_extension_osx_method() {} // expected-note 2 {{'osx_app_extension_extension_osx_method()' has been explicitly marked unavailable here}}
+  func osx_app_extension_extension_osx_method() {} // expected-note {{'osx_app_extension_extension_osx_method()' has been explicitly marked unavailable here}}
 
   @available(OSXApplicationExtension, unavailable)
   func osx_app_extension_extension_osx_app_extension_method() {} // expected-note {{'osx_app_extension_extension_osx_app_extension_method()' has been explicitly marked unavailable here}}
 
   func osx_app_extension_extension_available_method(
     _: NeverAvailable, // expected-error {{'NeverAvailable' is unavailable}}
-    _: OSXUnavailable, // expected-error {{'OSXUnavailable' is unavailable in macOS}}
+    _: OSXUnavailable,
     _: OSXAppExtensionsUnavailable
   ) {
     never() // expected-error {{'never()' is unavailable}}
-    osx() // expected-error {{'osx()' is unavailable}}
+    osx()
     osx_extension()
   }
 
@@ -353,11 +351,11 @@ extension ExtendMe {
   @available(OSXApplicationExtension, unavailable)
   func osx_app_extension_extension_osx_app_extension_method(
     _: NeverAvailable, // expected-error {{'NeverAvailable' is unavailable}}
-    _: OSXUnavailable, // expected-error {{'OSXUnavailable' is unavailable in macOS}}
+    _: OSXUnavailable,
     _: OSXAppExtensionsUnavailable
   ) {
     never() // expected-error {{'never()' is unavailable}}
-    osx() // expected-error {{'osx()' is unavailable}}
+    osx()
     osx_extension()
   }
 }
@@ -398,18 +396,17 @@ func osx_func_call_extension_methods(_ e: ExtendMe) {
 @available(OSXApplicationExtension, unavailable)
 func osx_app_ext_func_call_extension_methods(_ e: ExtendMe) {
   e.never_available_extension_available_method() // expected-error {{'never_available_extension_available_method()' is unavailable}}
-  e.osx_extension_available_method() // expected-error {{'osx_extension_available_method()' is unavailable in macOS}}
+  e.osx_extension_available_method()
   e.osx_app_extension_extension_available_method()
-  e.osx_extension_never_available_method() // expected-error {{'osx_extension_never_available_method()' is unavailable in macOS}}
-  e.osx_extension_osx_method() // expected-error {{'osx_extension_osx_method()' is unavailable in macOS}}
-  e.osx_extension_osx_app_extension_method() // expected-error {{'osx_extension_osx_app_extension_method()' is unavailable in macOS}}
+  e.osx_extension_never_available_method() // expected-error {{'osx_extension_never_available_method()' is unavailable}}
+  e.osx_extension_osx_method()
+  e.osx_extension_osx_app_extension_method()
 
   e.never_available_extension_osx_future_method() // expected-error {{'never_available_extension_osx_future_method()' is unavailable}}
-  e.osx_extension_osx_future_method() // expected-error {{'osx_extension_osx_future_method()' is unavailable in macOS}}
-  e.osx_app_extension_extension_osx_future_method() // expected-error {{'osx_app_extension_extension_osx_future_method()' is only available in macOS 99 or newer}}
-  // expected-note@-1 {{add 'if #available' version check}}
+  e.osx_extension_osx_future_method()
+  e.osx_app_extension_extension_osx_future_method()
   e.osx_app_extension_extension_never_available_method() // expected-error {{'osx_app_extension_extension_never_available_method()' is unavailable}}
-  e.osx_app_extension_extension_osx_method() // expected-error {{'osx_app_extension_extension_osx_method()' is unavailable in macOS}}
+  e.osx_app_extension_extension_osx_method()
   e.osx_app_extension_extension_osx_app_extension_method()
 }
 

--- a/test/attr/attr_availability_tvos.swift
+++ b/test/attr/attr_availability_tvos.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -typecheck -verify -parse-stdlib -target i386-apple-tvos9.0 %s
+// RUN: %target-typecheck-verify-swift -parse-stdlib -target i386-apple-tvos9.0 %s
 
 @available(tvOS, introduced: 1.0, deprecated: 2.0, obsoleted: 9.0,
               message: "you don't want to do that anyway")

--- a/test/attr/attr_availability_vision.swift
+++ b/test/attr/attr_availability_vision.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -typecheck -verify -parse-stdlib -target arm64-apple-xros2.0 %s
+// RUN: %target-typecheck-verify-swift -parse-stdlib -target arm64-apple-xros2.0 %s
 
 @available(visionOS, introduced: 1.0, deprecated: 1.5, obsoleted: 2.0,
            message: "you don't want to do that anyway")

--- a/test/attr/attr_availability_watchos.swift
+++ b/test/attr/attr_availability_watchos.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -typecheck -verify -parse-stdlib -target i386-apple-watchos2.0 %s
+// RUN: %target-typecheck-verify-swift -parse-stdlib -target i386-apple-watchos2.0 %s
 
 @available(watchOS, introduced: 1.0, deprecated: 1.5, obsoleted: 2.0,
               message: "you don't want to do that anyway")

--- a/test/attr/attr_backDeployed_availability.swift
+++ b/test/attr/attr_backDeployed_availability.swift
@@ -19,9 +19,25 @@ extension TopLevelStruct {
 @backDeployed(before: macOS 12) // Ok, introduced availability is earlier than macOS 12
 public func availableBeforeBackDeployment() {}
 
+@available(anyAppleOS 26, *)
+@backDeployed(before: anyAppleOS 26.4) // Ok, introduced availability is earlier on all Apple platforms
+public func availableAnyAppleOS26BackDeployedBeforeAnyAppleOS26_4() {}
+
+@available(anyAppleOS 26, *)
+@backDeployed(before: macOS 26.4) // Ok, introduced availability is earlier on all Apple platforms
+public func availableAnyAppleOS26BackDeployedBeforeMacOS26_4() {}
+
 @available(macOS 12, *) // expected-note {{'availableSameVersionAsBackDeployment()' was introduced in macOS 12}}
 @backDeployed(before: macOS 12) // expected-error {{'@backDeployed' has no effect because 'availableSameVersionAsBackDeployment()' is not available before macOS 12}}
 public func availableSameVersionAsBackDeployment() {}
+
+@available(anyAppleOS 26, *) // expected-note {{'availableSameAnyAppleOSVersionAsMacOSBackDeployment()' was introduced in macOS 26}}
+@backDeployed(before: macOS 26) // expected-error {{'@backDeployed' has no effect because 'availableSameAnyAppleOSVersionAsMacOSBackDeployment()' is not available before macOS 26}}
+public func availableSameAnyAppleOSVersionAsMacOSBackDeployment() {}
+
+@available(macOS 26, *) // expected-note {{'availableSameAnyAppleVersionAsBackDeploymentAnyAppleOS()' was introduced in macOS 26}}
+@backDeployed(before: anyAppleOS 26) // expected-error {{'@backDeployed' has no effect because 'availableSameAnyAppleVersionAsBackDeploymentAnyAppleOS()' is not available before macOS 26}}
+public func availableSameAnyAppleVersionAsBackDeploymentAnyAppleOS() {}
 
 @available(macOS 12.1, *) // expected-note {{'availableAfterBackDeployment()' was introduced in macOS 12.1}}
 @backDeployed(before: macOS 12) // expected-error {{'@backDeployed' has no effect because 'availableAfterBackDeployment()' is not available before macOS 12}}


### PR DESCRIPTION
Loosen availability checking to allow references to a decl that is unavailable in a broader platform context in contexts which are unavailable in a more specific platform context. For example, `@available(macOS, unavailable)` decls should be allowed in `@available(macOSApplicationExtension, unavailable)` contexts. This enhancement, which has always been desirable but wasn't high priority, became more important with the introduction of `anyAppleOS`. Some library authors may replace platform-specific availability annotations with `anyAppleOS` availability and without this behavior change those attribute updates would be source breaking.

Test updates assisted by claude.