### PR TITLE
[ClangImporter] Fix SafeInteropWrappers for non-span templates

### DIFF
--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -327,8 +327,10 @@ static bool SwiftifiableCAT(const clang::ASTContext &ctx,
      : !ConcretePointeeType(swiftType).isNull());
 }
 
-// Searches for template instantiations that are not behind type aliases.
-// FIXME: make sure the generated code compiles for template
+// Searches for unaliased std::span template instantiations.  Other unaliased
+// templates (e.g. std::optional) are harmless and must not block wrapper
+// generation.
+// FIXME: make sure the generated code compiles for std::span
 // instantiations that are not behind type aliases.
 struct UnaliasedInstantiationVisitor
     : clang::RecursiveASTVisitor<UnaliasedInstantiationVisitor> {
@@ -337,10 +339,18 @@ struct UnaliasedInstantiationVisitor
   bool TraverseTypedefType(const clang::TypedefType *) { return true; }
 
   bool
-  VisitTemplateSpecializationType(const clang::TemplateSpecializationType *) {
-    hasUnaliasedInstantiation = true;
-    DLOG("Signature contains raw template, skipping\n");
-    return false;
+  VisitTemplateSpecializationType(const clang::TemplateSpecializationType *T) {
+    // Only flag unaliased std::span instantiations.
+    auto templateName = T->getTemplateName();
+    if (auto *templateDecl = templateName.getAsTemplateDecl()) {
+      if (templateDecl->isInStdNamespace() &&
+          templateDecl->getName() == "span") {
+        hasUnaliasedInstantiation = true;
+        DLOG("Signature contains raw std::span, skipping\n");
+        return false;
+      }
+    }
+    return true;
   }
 };
 

--- a/test/Interop/Cxx/swiftify-import/non-span-template-in-signature.swift
+++ b/test/Interop/Cxx/swiftify-import/non-span-template-in-signature.swift
@@ -14,7 +14,7 @@
 // RUN:   -enable-experimental-feature Lifetimes \
 // RUN:   -cxx-interoperability-mode=default \
 // RUN:   -Rmacro-expansions -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}api.h \
-// RUN:   -suppress-notes \
+// RUN:   -suppress-notes -eager-macro-checking \
 // RUN:   %t/test.swift
 
 //--- Inputs/module.modulemap

--- a/test/Interop/Cxx/swiftify-import/non-span-template-in-signature.swift
+++ b/test/Interop/Cxx/swiftify-import/non-span-template-in-signature.swift
@@ -1,0 +1,64 @@
+// Regression test: SafeInteropWrappers must generate Span wrappers even when
+// non-span templates like std::optional appear in the function signature, and
+// when std::span type aliases are defined at class scope.
+
+// REQUIRES: std_span
+// REQUIRES: swift_feature_SafeInteropWrappers
+// REQUIRES: swift_feature_Lifetimes
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -c -plugin-path %swift-plugin-dir -I %t%{fs-sep}Inputs \
+// RUN:   -Xcc -std=c++20 \
+// RUN:   -enable-experimental-feature SafeInteropWrappers \
+// RUN:   -enable-experimental-feature Lifetimes \
+// RUN:   -cxx-interoperability-mode=default \
+// RUN:   %t/test.swift
+
+//--- Inputs/module.modulemap
+module TestApi {
+    header "api.h"
+    requires cplusplus
+}
+
+//--- Inputs/api.h
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <lifetimebound.h>
+
+using ByteSpan = std::span<const uint8_t>;
+using MutableByteSpan = std::span<uint8_t>;
+
+// Non-span templates in the return type must not block wrapper generation.
+struct Foo {
+  std::optional<size_t> process(ByteSpan input __noescape,
+                                MutableByteSpan output __noescape) const;
+};
+
+// Class-member type aliases for std::span must also work.
+struct Bar {
+  using ConstSpan = std::span<const uint8_t>;
+  using MutSpan = std::span<uint8_t>;
+
+  void readData(ConstSpan data __noescape) const;
+  void writeData(MutSpan output __noescape) const;
+};
+
+//--- test.swift
+import CxxStdlib
+import TestApi
+
+@_lifetime(output: copy output)
+func testProcess(_ foo: borrowing Foo, _ input: Span<UInt8>,
+                 _ output: inout MutableSpan<UInt8>) {
+  _ = foo.process(input, &output)
+}
+
+func testRead(_ bar: borrowing Bar, _ data: Span<UInt8>) {
+  bar.readData(data)
+}
+
+func testWrite(_ bar: borrowing Bar, _ output: inout MutableSpan<UInt8>) {
+  bar.writeData(&output)
+}

--- a/test/Interop/Cxx/swiftify-import/non-span-template-in-signature.swift
+++ b/test/Interop/Cxx/swiftify-import/non-span-template-in-signature.swift
@@ -13,6 +13,8 @@
 // RUN:   -enable-experimental-feature SafeInteropWrappers \
 // RUN:   -enable-experimental-feature Lifetimes \
 // RUN:   -cxx-interoperability-mode=default \
+// RUN:   -Rmacro-expansions -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}api.h \
+// RUN:   -suppress-notes \
 // RUN:   %t/test.swift
 
 //--- Inputs/module.modulemap
@@ -32,8 +34,16 @@ using MutableByteSpan = std::span<uint8_t>;
 
 // Non-span templates in the return type must not block wrapper generation.
 struct Foo {
-  std::optional<size_t> process(ByteSpan input __noescape,
-                                MutableByteSpan output __noescape) const;
+  // expected-expansion@+9:82{{
+  //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+  //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(output: copy output) @_disfavoredOverload|}}
+  //   expected-remark@3{{macro content: |public func process(_ input: Span<CUnsignedChar>, _ output: inout MutableSpan<CUnsignedChar>) -> std.__1.optional<CUnsignedLong> {|}}
+  //   expected-remark@4{{macro content: |    return unsafe output.withUnsafeMutableBufferPointer { _outputPtr in|}}
+  //   expected-remark@5{{macro content: |      return unsafe process(ByteSpan(input), MutableByteSpan(_outputPtr))|}}
+  //   expected-remark@6{{macro content: |    }|}}
+  //   expected-remark@7{{macro content: |}|}}
+  // }}
+  std::optional<size_t> process(ByteSpan input __noescape, MutableByteSpan output __noescape) const;
 };
 
 // Class-member type aliases for std::span must also work.
@@ -41,7 +51,24 @@ struct Bar {
   using ConstSpan = std::span<const uint8_t>;
   using MutSpan = std::span<uint8_t>;
 
+  // expected-expansion@+7:31{{
+  //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+  //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_disfavoredOverload|}}
+  //   expected-remark@3{{macro content: |public func readData(_ data: Span<CUnsignedChar>) {|}}
+  //   expected-remark@4{{macro content: |    return unsafe readData(Bar.ConstSpan(data))|}}
+  //   expected-remark@5{{macro content: |}|}}
+  // }}
   void readData(ConstSpan data __noescape) const;
+
+  // expected-expansion@+9:32{{
+  //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+  //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(output: copy output) @_disfavoredOverload|}}
+  //   expected-remark@3{{macro content: |public func writeData(_ output: inout MutableSpan<CUnsignedChar>) {|}}
+  //   expected-remark@4{{macro content: |    return unsafe output.withUnsafeMutableBufferPointer { _outputPtr in|}}
+  //   expected-remark@5{{macro content: |      return unsafe writeData(Bar.MutSpan(_outputPtr))|}}
+  //   expected-remark@6{{macro content: |    }|}}
+  //   expected-remark@7{{macro content: |}|}}
+  // }}
   void writeData(MutSpan output __noescape) const;
 };
 


### PR DESCRIPTION
## Summary

Fix for `SafeInteropWrappers` wrapper generation in `SwiftifyDecl.cpp`:

**Non-span templates blocking wrapper generation**: `UnaliasedInstantiationVisitor` rejected any function whose signature contained an unaliased `TemplateSpecializationType`, including harmless templates like `std::optional<size_t>` in the return type. A function like:

   ```cpp
   std::optional<size_t> process(ByteSpan input __noescape,
                                 MutableByteSpan output __noescape) const;
   ```

   would not get `Span`/`MutableSpan` wrappers generated. This change narrows `VisitTemplateSpecializationType` to only flag unaliased `std::span` instantiations.

## Test plan
- Added `test/Interop/Cxx/swiftify-import/non-span-template-in-signature.swift` covering both cases
- @swift-ci please test


<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
