### PR TITLE
[Concurrency] Improve performance of task groups

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -209,6 +209,7 @@ set(SWIFT_BENCH_MODULES
     single-source/SubstringTest
     single-source/Suffix
     single-source/SuperChars
+    single-source/TaskGroups
     single-source/TwoSum
     single-source/TypeFlood
     single-source/UTF8Decode

--- a/benchmark/single-source/TaskGroups.swift
+++ b/benchmark/single-source/TaskGroups.swift
@@ -1,0 +1,64 @@
+//===--- TaskGroup.swift --------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import TestsUtils
+import Dispatch
+
+public var benchmarks: [BenchmarkInfo] {
+  guard #available(macOS 14, iOS 17, tvOS 17, watchOS 10, *) else {
+    return []
+  }
+  return [
+    BenchmarkInfo(
+      name: "TaskGroups.1000",
+      runFunction: run_TaskGroup(groupSize: 1000),
+      tags: [.concurrency]
+    ),
+    BenchmarkInfo(
+      name: "TaskGroups.5000",
+      runFunction: run_TaskGroup(groupSize: 5000),
+      tags: [.concurrency]
+    )
+  ]
+}
+
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
+private func run_TaskGroup(groupSize: Int) -> (Int) -> Void {
+  return { n in
+    let g = DispatchGroup()
+    g.enter()
+    Task {
+      for _ in 0..<n {
+        var task: Task<Void, Never>! = nil
+
+        let cont: UnsafeContinuation<Void, Never> = await withUnsafeContinuation { cont in
+          task = Task {
+            await withUnsafeContinuation {
+              cont.resume(returning: $0)
+            }
+          }
+        }
+
+        await withDiscardingTaskGroup(returning: Void.self) { group in
+          for i in 0..<groupSize {
+            group.addTask {
+              await task.value
+            }
+          }
+          cont.resume()
+        }
+      }
+      g.leave()
+    }
+    g.wait()
+  }
+}

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -214,6 +214,7 @@ import StringWalk
 import SubstringTest
 import Suffix
 import SuperChars
+import TaskGroups
 import TwoSum
 import TypeFlood
 import UTF8Decode
@@ -427,6 +428,7 @@ register(StringWalk.benchmarks)
 register(SubstringTest.benchmarks)
 register(Suffix.benchmarks)
 register(SuperChars.benchmarks)
+register(TaskGroups.benchmarks)
 register(TwoSum.benchmarks)
 register(TypeFlood.benchmarks)
 register(UTF8Decode.benchmarks)

--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -552,7 +552,7 @@ public:
 
     // TODO: Document more how this is used from the `TaskGroupTaskStatusRecord`
 
-    /// The next task in the singly-linked list of child tasks.
+    /// The next task in the doubly-linked list of child tasks.
     /// The list must start in a `ChildTaskStatusRecord` registered
     /// with the parent task.
     ///
@@ -560,6 +560,11 @@ public:
     ///
     /// WARNING: Access can only be performed by the `Parent` of this task.
     AsyncTask *NextChild = nullptr;
+
+    /// The previous task in the doubly-linked list of child tasks.
+    ///
+    /// WARNING: Access can only be performed by the `Parent` of this task.
+    AsyncTask *PrevChild = nullptr;
 
   public:
     ChildFragment(AsyncTask *parent) : Parent(parent) {}
@@ -572,13 +577,21 @@ public:
       return NextChild;
     }
 
-    /// Set the `NextChild` to to the passed task.
+    AsyncTask *getPrevChild() const { return PrevChild; }
+
+    /// Set the `NextChild` to the passed task.
     ///
     /// WARNING: This must ONLY be invoked from the parent of both
     /// (this and the passed-in) tasks for thread-safety reasons.
     void setNextChild(AsyncTask *task) {
       NextChild = task;
     }
+
+    /// Set the `PrevChild` to the passed task.
+    ///
+    /// WARNING: This must ONLY be invoked from the parent of both
+    /// (this and the passed-in) tasks for thread-safety reasons.
+    void setPrevChild(AsyncTask *task) { PrevChild = task; }
   };
 
   bool hasChildFragment() const {

--- a/include/swift/ABI/TaskStatus.h
+++ b/include/swift/ABI/TaskStatus.h
@@ -115,9 +115,9 @@ public:
 /// the task group.  It may also hold references to completed children
 /// which have not yet been found by `next()`.
 ///
-/// The child tasks are stored as an invasive single-linked list, starting
-/// from `FirstChild` and continuing through the `NextChild` pointers of all
-/// the linked children.
+/// The child tasks are stored as an invasive doubly-linked list, starting
+/// from `FirstChild` and continuing through the `NextChild` and `PrevChild`
+/// pointers of all the linked children.
 ///
 /// This list structure should only ever be modified:
 /// - while holding the status record lock of the owning task, so that
@@ -170,6 +170,9 @@ public:
     auto oldLastChild = LastChild;
     LastChild = child;
 
+    // Set the prev pointer of the new child to the old last child.
+    child->childFragment()->setPrevChild(oldLastChild);
+
     if (!getFirstChild()) {
       // This is the first child we ever attach, so store it as FirstChild.
       FirstChild.store(child, std::memory_order_relaxed);
@@ -182,37 +185,26 @@ public:
   void detachChild(AsyncTask *child) {
     assert(child && "cannot remove a null child from group");
 
-    AsyncTask *prev = getFirstChild();
+    auto *childFragment = child->childFragment();
+    auto *prev = childFragment->getPrevChild();
+    auto *next = childFragment->getNextChild();
 
-    if (prev == child) {
-      AsyncTask *next = getNextChildTask(child);
+    if (prev) {
+      prev->childFragment()->setNextChild(next);
+    } else {
+      // child is the first in the list.
       FirstChild.store(next, std::memory_order_relaxed);
-      if (next == nullptr) {
-        LastChild = nullptr;
-      }
-      return;
     }
 
-    // Remove the child from the linked list, i.e.:
-    //     prev -> afterPrev -> afterChild
-    //                 ==
-    //               child   -> afterChild
-    // Becomes:
-    //     prev --------------> afterChild
-    while (prev) {
-      auto afterPrev = getNextChildTask(prev);
-
-      if (afterPrev == child) {
-        auto afterChild = getNextChildTask(child);
-        prev->childFragment()->setNextChild(afterChild);
-        if (child == LastChild) {
-          LastChild = prev;
-        }
-        return;
-      }
-
-      prev = afterPrev;
+    if (next) {
+      next->childFragment()->setPrevChild(prev);
+    } else {
+      // child is the last in the list.
+      LastChild = prev;
     }
+
+    childFragment->setPrevChild(nullptr);
+    childFragment->setNextChild(nullptr);
   }
 
   static AsyncTask *getNextChildTask(AsyncTask *task) {


### PR DESCRIPTION
rdar://172192966

The tasks of a task group were stored in a singly linked list, causing a linear scan for a task to find its predecessor, whenever a task completed and had to be removed from the list. This change turns it into a doubly linked list, so the linear scan is avoided completely.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
