### PR TITLE
Runtime: Set "addressable for dependencies" flag correctly for `Builtin.FixedArray` metadata.

### DIFF
--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -1695,10 +1695,12 @@ swift::swift_getFixedArrayTypeMetadata(MetadataRequest request,
                             MetadataState::Complete};
   }
   
-  // If the element type has no tail padding, then its metadata is good enough
+  // If the element type has no tail padding, and is already addressable-for-
+  // dependencies, then its metadata is good enough
   // to hold space for the vector.
   if (count == 1
-      && element->getValueWitnesses()->size == element->getValueWitnesses()->stride) {
+      && element->getValueWitnesses()->size == element->getValueWitnesses()->stride
+      && element->getValueWitnesses()->isAddressableForDependencies()) {
     return MetadataResponse{element, MetadataState::Complete};
   }
   
@@ -1889,12 +1891,14 @@ FixedArrayCacheEntry::tryInitialize(Metadata *metadata,
   auto arraySize
     = Witnesses.size = Witnesses.stride = eltWitnesses->stride * count;
   // We take on most of the properties of the element type, except that an array
-  // of elements might end up larger than an inline buffer.
+  // of elements might end up larger than an inline buffer, and the array is
+  // always addressable for dependencies.
   Witnesses.flags = eltWitnesses->flags
     .withInlineStorage(
               ValueWitnessTable::isValueInline(eltWitnesses->isBitwiseTakable(),
                                                arraySize,
-                                               eltWitnesses->getAlignment()));
+                                               eltWitnesses->getAlignment()))
+    .withAddressableForDependencies(true);
   // We get extra inhabitants from the first element.
   Witnesses.extraInhabitantCount = eltWitnesses->extraInhabitantCount;
   

--- a/test/Interpreter/borrow_layout.swift
+++ b/test/Interpreter/borrow_layout.swift
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
 //
-// RUN: %target-build-swift -enable-experimental-feature BuiltinModule \
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking \
+// RUN:   -enable-experimental-feature BuiltinModule \
 // RUN:   -enable-experimental-feature Lifetimes \
 // RUN:   -Xfrontend -verify-type-layout -Xfrontend LoanPointer \
 // RUN:   -Xfrontend -verify-type-layout -Xfrontend OptionalLoanPointer \
@@ -26,6 +27,15 @@
 // RUN:   -Xfrontend -verify-type-layout -Xfrontend LoanGrainy \
 // RUN:   -Xfrontend -verify-type-layout -Xfrontend OptionalLoanGrainy \
 // RUN:   -Xfrontend -verify-type-layout -Xfrontend Optional2LoanGrainy \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend LoanArray1 \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend OptionalLoanArray1 \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend Optional2LoanArray1 \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend LoanArray3 \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend OptionalLoanArray3 \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend Optional2LoanArray3 \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend LoanString \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend OptionalLoanString \
+// RUN:   -Xfrontend -verify-type-layout -Xfrontend Optional2LoanString \
 // RUN:   -o %t/a.out \
 // RUN:   %s
 // RUN: %target-codesign %t/a.out
@@ -115,6 +125,18 @@ struct Grainy { var x, y, z, w, v: Bool }
 typealias LoanGrainy = Loan<Grainy>
 typealias OptionalLoanGrainy = Optional<Loan<Grainy>>
 typealias Optional2LoanGrainy = Optional<Optional<Loan<Grainy>>>
+
+typealias LoanArray1 = Loan<[1 of Int]>
+typealias OptionalLoanArray1 = Optional<Loan<[1 of Int]>>
+typealias Optional2LoanArray1 = Optional<Optional<Loan<[1 of Int]>>>
+
+typealias LoanArray3 = Loan<[3 of Int]>
+typealias OptionalLoanArray3 = Optional<Loan<[3 of Int]>>
+typealias Optional2LoanArray3 = Optional<Optional<Loan<[3 of Int]>>>
+
+typealias LoanString = Loan<String>
+typealias OptionalLoanString = Optional<Loan<String>>
+typealias Optional2LoanString = Optional<Optional<Loan<String>>>
 
 // CHECK-NOT: *** Type verification
 // CHECK: ok!


### PR DESCRIPTION
This fixes a discrepancy in runtime and compile-time `Borrow` layout when the target of the borrow is an `InlineArray`.