### PR TITLE
SILGen: fix failure for typed -> untyped throws conversion

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3311,6 +3311,13 @@ static bool canEmitSpecializedClosureFunction(CanAnyFunctionType closureType,
        closureType.getThrownError() != destType.getThrownError()))
     return false;
 
+  // If the closure has a different thrown error type than the destination,
+  // we cannot emit the closure directly because the SIL function type
+  // (derived from the closure's own type) will have a different error
+  // type than what the body expects (derived from the destination type).
+  if (closureType.getThrownError() != destType.getThrownError())
+    return false;
+
   return true;
 }
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3294,7 +3294,8 @@ static bool canEmitClosureFunctionUnderConversion(
 ///
 /// TODO: ideally, our prolog/epilog emission would be able to handle
 /// all possible subtype and reabstraction conversions.
-static bool canEmitSpecializedClosureFunction(CanAnyFunctionType closureType,
+static bool canEmitSpecializedClosureFunction(const AbstractClosureExpr *closure,
+                                        CanAnyFunctionType closureType,
                                         const FunctionTypeInfo &contextInfo) {
   auto destType = contextInfo.FormalType;
 
@@ -3315,7 +3316,8 @@ static bool canEmitSpecializedClosureFunction(CanAnyFunctionType closureType,
   // we cannot emit the closure directly because the SIL function type
   // (derived from the closure's own type) will have a different error
   // type than what the body expects (derived from the destination type).
-  if (closureType.getThrownError() != destType.getThrownError())
+  if (closureType.getThrownError() != destType.getThrownError() &&
+      !isa<ClosureExpr>(closure))
     return false;
 
   return true;
@@ -3333,7 +3335,7 @@ ManagedValue RValueEmitter::tryEmitConvertedClosure(AbstractClosureExpr *e,
 
   // If we can emit the closure with all of the specialized type information,
   // that's great.
-  if (canEmitSpecializedClosureFunction(closureType, *info)) {
+  if (canEmitSpecializedClosureFunction(e, closureType, *info)) {
     return emitClosureReference(e, *info);
   }
 
@@ -3353,7 +3355,7 @@ ManagedValue RValueEmitter::tryEmitConvertedClosure(AbstractClosureExpr *e,
     auto erasureInfo = SGF.getFunctionTypeInfo(erasedClosureType);
 
     // Emit the closure under that conversion.  This should always succeed.
-    assert(canEmitSpecializedClosureFunction(closureType, erasureInfo));
+    assert(canEmitSpecializedClosureFunction(e, closureType, erasureInfo));
     auto erasedResult = emitClosureReference(e, erasureInfo);
 
     // Narrow the original conversion to start from the erased closure type.

--- a/test/SILGen/typed_throws_conversion.swift
+++ b/test/SILGen/typed_throws_conversion.swift
@@ -1,5 +1,10 @@
 // RUN: %target-swift-emit-silgen -swift-version 6 %s | %FileCheck %s
 
+// https://github.com/swiftlang/swift/issues/87893
+// rdar://172703741
+// SIL verification failure when a static method with typed throws is passed
+// as a function reference to a generic parameter expecting untyped throws.
+
 struct E: Error {}
 struct S {
   static func src(_ x: Int) throws(E) -> Int { x }

--- a/test/SILGen/typed_throws_conversion.swift
+++ b/test/SILGen/typed_throws_conversion.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-emit-silgen -swift-version 6 %s | %FileCheck %s
+
+struct E: Error {}
+struct S {
+  static func src(_ x: Int) throws(E) -> Int { x }
+}
+
+func sink<T: Equatable>(_ fn: (T) throws -> T, _ v: [T]) throws {
+  for x in v { _ = try fn(x) }
+}
+
+// CHECK-LABEL: sil {{.*}} @$s{{.*}}test
+func test() throws {
+  try sink(S.src, [1])
+}

--- a/test/SILGen/typed_throws_conversion.swift
+++ b/test/SILGen/typed_throws_conversion.swift
@@ -15,6 +15,19 @@ func sink<T: Equatable>(_ fn: (T) throws -> T, _ v: [T]) throws {
 }
 
 // CHECK-LABEL: sil {{.*}} @$s{{.*}}test
+// CHECK:         function_ref @$s{{.*}}test{{.*}}fu_
+// CHECK:         // function_ref thunk for
+// CHECK:         function_ref @$s{{.*}}_TR
+// CHECK:         partial_apply
 func test() throws {
   try sink(S.src, [1])
+}
+
+// Verify that an explicit closure literal with typed throws assigned to an
+// untyped-throws context is emitted directly without a thunk.
+// CHECK-LABEL: sil private {{.*}} @$s{{.*}}testExplicitClosure{{.*}}fU_ :
+// CHECK-SAME:    -> @error any Error
+func testExplicitClosure() {
+    var callback: (() throws -> Void)?
+    callback = { () throws(E) in }
 }


### PR DESCRIPTION
**Explanation**: When a static method with typed throws is passed as a function reference to a generic parameter expecting untyped throws, `canEmitSpecializedClosureFunction` allows emitting the closure directly under the conversion.

The fix rejects the optimization whenever the closure's thrown error type differs from the destination's, forcing a thunk instead.

Resolves https://github.com/swiftlang/swift/issues/87893 compiler crash.

**Scope**: limited to code with typed throws.
**Risk**: low due to extensive test suite passing (ran `@swift-ci test` here as opposed to `@swift-ci smoke test`) and new test coverage added
**Testing**: lit test suite expanded in this PR to cover the regression.
**Issue**: rdar://172703741
**Reviewer**: @DougGregor 
