### PR TITLE
[DebugInfo] Disable SILMem2Reg debug info salvaging temporarily

### DIFF
--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -1981,10 +1981,13 @@ void MemoryToRegisters::removeSingleBlockAllocation(AllocStackInst *asi) {
             LiveValues::toReplace(asi,
                                   /*replacement=*/initialValue),
             /*isStorageValid=*/!doesLoadInvalidateStorage(inst)};
+// Disabled to work around a compiler crash. See rdar://171023691
+#if 0
         if (auto varInfo = asi->getVarInfo()) {
           SILBuilderWithScope(inst, ctx).createDebugValue(
               inst->getLoc(), initialValue, *varInfo);
         }
+#endif
       }
       auto *loadInst = dyn_cast<LoadInst>(inst);
       if (loadInst &&


### PR DESCRIPTION
This currently exposes invalid debug info generated by a previous pass. This patch disables this specific transformation until we have a fix for the other issue (see rdar://171023691 ).