### PR TITLE
[Distributed] Prevent dead code elimination of distributed funcs, thunks, witnesses

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -59,6 +59,7 @@ enum IsThunk_t {
   IsReabstractionThunk,
   IsSignatureOptimizedThunk,
   IsBackDeployedThunk,
+  IsDistributedThunk,
 };
 enum IsDynamicallyReplaceable_t {
   IsNotDynamic,
@@ -498,6 +499,7 @@ private:
     case IsThunk:
     case IsReabstractionThunk:
     case IsBackDeployedThunk:
+    case IsDistributedThunk:
       thunkCanHaveSubclassScope = false;
       break;
     }

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -3747,6 +3747,7 @@ void SILFunction::print(SILPrintContext &PrintCtx) const {
     OS << "[signature_optimized_thunk] ";
     break;
   case IsReabstractionThunk: OS << "[reabstraction_thunk] "; break;
+  case IsDistributedThunk: OS << "[distributed_thunk] "; break;
   }
   if (isDynamicallyReplaceable()) {
     OS << "[dynamically_replacable] ";

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -746,6 +746,8 @@ static bool parseDeclSILOptional(
       *isThunk = IsReabstractionThunk;
     else if (isThunk && SP.P.Tok.getText() == "back_deployed_thunk")
       *isThunk = IsBackDeployedThunk;
+    else if (isThunk && SP.P.Tok.getText() == "distributed_thunk")
+      *isThunk = IsDistributedThunk;
     else if (isWithoutActuallyEscapingThunk
              && SP.P.Tok.getText() == "without_actually_escaping")
       *isWithoutActuallyEscapingThunk = true;

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -876,12 +876,18 @@ SILFunction *SILGenModule::emitProtocolWitness(
     return f;
   ASSERT(!f);
 
+  // Distributed: Carry the distributed thunk kind from the requirement.
+  // Distributed accessors dispatch through the witness table at runtime,
+  // so `DeadFunctionElimination` must keep these entries alive even though
+  // they have no SIL callers.
+  auto thunkKind = requirement.isDistributedThunk() ? IsDistributedThunk : IsThunk;
+
   SILGenFunctionBuilder builder(*this);
   f = builder.createFunction(
       linkage, nameBuffer, witnessSILFnType, genericEnv,
       SILLocation(witnessRef.getDecl()), IsNotBare, IsTransparent,
       serializedKind, IsNotDynamic, IsNotDistributed, IsNotRuntimeAccessible,
-      ProfileCounter(), IsThunk, SubclassScope::NotApplicable, InlineStrategy);
+      ProfileCounter(), thunkKind, SubclassScope::NotApplicable, InlineStrategy);
 
   f->setDebugScope(new (M)
                    SILDebugScope(RegularLocation(witnessRef.getDecl()), f));

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -106,6 +106,13 @@ class DeadFunctionAndGlobalElimination {
     if (F->isPossiblyUsedExternally())
       return true;
 
+    // Distributed functions are looked up by name at runtime via the
+    // accessible-function registry. Distributed thunks (TWTE) are dispatched
+    // through the witness table by the distributed accessor. Neither kind
+    // is necessarily referenced from SIL, so both must be kept alive.
+    if (F->isDistributed() || F->isThunk() == IsDistributedThunk)
+      return true;
+
     if (F->getDynamicallyReplacedFunction())
       return true;
 
@@ -196,8 +203,19 @@ class DeadFunctionAndGlobalElimination {
           SILFunction *F = methodWitness.Witness;
           if (F) {
             MethodInfo *MI = getMethodInfo(fd, /*isWitnessMethod*/ true);
-            if (MI->methodIsCalled || !F->isDefinition())
+            if (MI->methodIsCalled || !F->isDefinition()) {
               ensureAlive(F);
+            } else if (fd->isDistributed()
+                       || F->isDistributed()
+                       || F->isThunk() == IsDistributedThunk) {
+              // Distributed method witnesses must be kept alive.
+              // Distributed function accessors dispatch through the witness
+              // table at runtime, which is invisible to static call-site
+              // analysis. So if we wouldn't keep alive the func explicitly here,
+              // the witness thunk can be eliminated (especially with -O + WMO),
+              // and IRGen replaces it with swift_deletedAsyncMethodError.
+              ensureAlive(F);
+            }
           }
         } break;
 
@@ -677,6 +695,18 @@ class DeadFunctionAndGlobalElimination {
       WT->clearMethods_if([this, &changedTable]
                           (const SILWitnessTable::MethodWitness &MW) -> bool {
         if (!isAlive(MW.Witness)) {
+          auto *fd = cast<AbstractFunctionDecl>(MW.Requirement.getDecl());
+          // Distributed method witnesses must never be cleared: the
+          // distributed accessor dispatches through the witness table at
+          // runtime. This is a safety net; makeAlive() should already have
+          // kept the witness alive. rdar://168881945
+          if (fd->isDistributed()
+              || MW.Witness->isDistributed()
+              || MW.Witness->isThunk() == IsDistributedThunk) {
+            LLVM_DEBUG(llvm::dbgs() << "  prevent dead code elimination for distributed/distributed_thunk "
+                                    << MW.Witness->getName() << "\n");
+            return false;
+          }
           LLVM_DEBUG(llvm::dbgs() << "  erase dead witness method "
                                   << MW.Witness->getName() << "\n");
           changedTable = true;

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -1110,6 +1110,7 @@ class MandatoryInlining : public SILModuleTransform {
       case IsThunk_t::IsThunk:
       case IsThunk_t::IsReabstractionThunk:
       case IsThunk_t::IsSignatureOptimizedThunk:
+      case IsThunk_t::IsDistributedThunk:
         // Don't inline into most thunks, even transparent callees.
         continue;
 

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -809,19 +809,23 @@ bool swift::canDevirtualizeClassMethod(FullApplySite applySite, ClassDecl *cd,
     return false;
   }
 
-  // A narrow fix for https://github.com/swiftlang/swift/issues/79318
-  // to make sure that uses of distributed requirement witnesses are
-  // not devirtualized because that results in a loss of the ad-hoc
-  // requirement infomation in the re-created substitution map.
-  //
-  // We have a similar check in `canSpecializeFunction` which presents
-  // specialization for exactly the same reason.
-  //
-  // TODO: A better way to fix this would be to record the ad-hoc conformance
-  // requirement in `RequirementEnvironment` and adjust IRGen to handle it.
   if (f->hasLocation()) {
     if (auto *funcDecl =
             dyn_cast_or_null<FuncDecl>(f->getLocation().getAsDeclContext())) {
+      // Do not devirtualize distributed functions.
+      if (funcDecl->isDistributed())
+        return false;
+
+      // A narrow fix for https://github.com/swiftlang/swift/issues/79318
+      // to make sure that uses of distributed requirement witnesses are
+      // not devirtualized because that results in a loss of the ad-hoc
+      // requirement information in the re-created substitution map.
+      //
+      // We have a similar check in `canSpecializeFunction` which prevents
+      // specialization for exactly the same reason.
+      //
+      // TODO: A better way to fix this would be to record the ad-hoc conformance
+      //       requirement in `RequirementEnvironment` and adjust IRGen to handle it.
       if (funcDecl->isDistributedWitnessWithAdHocSerializationRequirement())
         return false;
     }

--- a/test/Distributed/SIL/distributed_thunk.swift
+++ b/test/Distributed/SIL/distributed_thunk.swift
@@ -82,6 +82,6 @@ distributed actor DA5: Server2 {
   // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s17distributed_thunk3DA5CAA7Server2A2aDP8sayHelloyyFTW
   // CHECK: function_ref @$s17distributed_thunk7Server2PAA11Distributed012LocalTestingD11ActorSystemC0gH0RtzrlE8sayHelloyyF
 
-  // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s17distributed_thunk3DA5CAA7Server2A2aDP8sayHelloyyYaKFTWTE
+  // CHECK-LABEL: sil private [transparent] [distributed_thunk] [ossa] @$s17distributed_thunk3DA5CAA7Server2A2aDP8sayHelloyyYaKFTWTE
   // CHECK: function_ref @$s17distributed_thunk7Server2PAA11Distributed012LocalTestingD11ActorSystemC0gH0RtzrlE8sayHelloyyYaKFTE
 }

--- a/test/SILOptimizer/dead_function_elimination_distributed.swift
+++ b/test/SILOptimizer/dead_function_elimination_distributed.swift
@@ -1,0 +1,44 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-5.7-abi-triple %S/../Distributed/Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-swift-frontend %s -O -emit-sil -target %target-swift-5.7-abi-triple -I %t | %FileCheck %s --dump-input=always
+
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+// Verify that dead function elimination does NOT remove distributed thunks,
+// distributed method bodies, or their witness table entries. These are invoked
+// at runtime via function pointer from the IRGen-generated distributed accessor,
+// so they have no direct SIL callers. DFE must treat them as alive.
+//
+// rdar://168881945
+
+import Distributed
+import FakeDistributedActorSystems
+
+protocol MyService: DistributedActor where ActorSystem == FakeActorSystem {
+  distributed func distributedMethod() async throws -> String
+  func nonDistributedMethod()
+}
+
+distributed actor MyServiceImpl: MyService {
+  typealias ActorSystem = FakeActorSystem
+
+  distributed func distributedMethod() async throws -> String { "hello" }
+  func nonDistributedMethod() {}
+}
+
+// The distributed thunk (TE suffix) must survive DFE:
+// CHECK: sil hidden [thunk] [distributed] [ref_adhoc_requirement_witness "$s27FakeDistributedActorSystems0A17InvocationDecoderC18decodeNextArgumentxyKSeRzSERzlF"] @$s37dead_function_elimination_distributed13MyServiceImplC0D6MethodSSyYaKFTE : $@convention(method) @async (@guaranteed MyServiceImpl) -> (@owned String, @error any Error) {
+
+// The distributed method body must survive DFE:
+// CHECK: sil hidden [distributed] @$s37dead_function_elimination_distributed13MyServiceImplC0D6MethodSSyYaKF : $@convention(method) @async (@sil_isolated @guaranteed MyServiceImpl) -> (@owned String, @error any Error) {
+
+// The witness table must still contain entries for the distributed func and thunk:
+// CHECK-LABEL: sil_witness_table hidden MyServiceImpl: MyService module dead_function_elimination_distributed {
+// protocol witness (TW):
+// CHECK:   method #MyService.distributedMethod!distributed({{.*}}): <Self where Self : MyService> (isolated Self) -> () async throws -> String : @$s37dead_function_elimination_distributed13MyServiceImplCAA0eF0A2aDP0D6MethodSSyYaKFTW
+// protocol thunk witness (TWTE):
+// CHECK:   method #MyService.distributedMethod!distributed_thunk({{.*}}): <Self where Self : MyService> (Self) -> () async throws -> String : @$s37dead_function_elimination_distributed13MyServiceImplCAA0eF0A2aDP0D6MethodSSyYaKFTWTE
+
+// The not used not-distributed method witness was dead eliminated:
+// CHECK:   method #MyService.nonDistributedMethod: <Self where Self : MyService> (isolated Self) -> () -> () : nil


### PR DESCRIPTION
Dead code elimination is not aware of the fact that distributed function accessors and witnesses are actually used by the runtime, and therefore may remove them. 🧟 

This seems to have flown under the radar however when whole module optimization is enabled in release mode this can trigger reliably and result in pointing at deleted witnesses.

This PR mades a few cleanups in the way we mark and handle distributed accessors so they don't get optimized away.

This is an additional fix on top of https://github.com/swiftlang/swift/pull/87453

Resolves rdar://168881945