### PR TITLE
[Backtracing][Linux] Fix fault address for `SIGABRT`/`SIGQUIT`.

### DIFF
--- a/stdlib/public/runtime/CrashHandlerLinux.cpp
+++ b/stdlib/public/runtime/CrashHandlerLinux.cpp
@@ -264,15 +264,7 @@ handle_fatal_signal(int signum,
   for (unsigned n = 0; n < lengthof(signalsToHandle); ++n)
     reset_signal(signalsToHandle[n]);
 
-  // Fill in crash info
-  crashInfo.crashing_thread = self.tid;
-  crashInfo.signal = signum;
-  crashInfo.fault_address = (uint64_t)pinfo->si_addr;
-
-  // Start the memory server
-  int fd = memserver_start();
-
-  // Display a progress message
+  // Find the program counter
   void *pc = 0;
   ucontext_t *ctx = (ucontext_t *)uctx;
 
@@ -290,12 +282,31 @@ handle_fatal_signal(int signum,
 #endif
 #endif
 
+  // Fill in crash info
+  crashInfo.crashing_thread = self.tid;
+  crashInfo.signal = signum;
+  switch (signum) {
+  case SIGILL:
+  case SIGFPE:
+  case SIGSEGV:
+  case SIGBUS:
+  case SIGTRAP:
+    crashInfo.fault_address = (uint64_t)pinfo->si_addr;
+    break;
+  default:
+    crashInfo.fault_address = (uint64_t)pc;
+  }
+
+  // Start the memory server
+  int fd = memserver_start();
+
+  // Display a progress message
   _swift_displayCrashMessage(signum, pc);
 
   if (_swift_backtraceSettings.closeFds) {
     closeFds(fd);
   }
-  
+
   // Actually start the backtracer
   if (!_swift_spawnBacktracer(&crashInfo, fd)) {
     const char *message = _swift_backtraceSettings.color == OnOffTty::On


### PR DESCRIPTION
POSIX says the `si_addr` field is valid for `SIGILL`, `SIGFPE`, `SIGSEGV`, `SIGBUS` and `SIGTRAP`; it doesn't say it's invalid otherwise, but in practice Linux doesn't always fill it out in other cases.

For `SIGABRT` and `SIGQUIT` it makes sense to use the program counter value instead.

Fixes #80730 

rdar://149007223
