### PR TITLE
Ddizman/member func call

### DIFF
--- a/include/swift/AST/ConstTypeInfo.h
+++ b/include/swift/AST/ConstTypeInfo.h
@@ -45,7 +45,8 @@ public:
     MemberReference,
     InterpolatedString,
     NilLiteral,
-    Runtime
+    Runtime,
+    MemberFunctionCall
   };
 
   ValueKind getKind() const { return Kind; }
@@ -457,6 +458,28 @@ public:
 private:
   std::string Label;
   swift::Type Type;
+  std::vector<FunctionParameter> Parameters;
+};
+
+/// A method invocation representation on an instance of a type
+/// let foo = Foo().someThing()
+///
+class MemberFunctionCallValue : public CompileTimeValue {
+public:
+  MemberFunctionCallValue(std::string Label, std::shared_ptr<CompileTimeValue> BaseValue, std::vector<FunctionParameter> Parameters) :
+  CompileTimeValue(ValueKind::MemberFunctionCall), Label(Label), BaseValue(BaseValue), Parameters(Parameters) {}
+
+  static bool classof(const CompileTimeValue *T) {
+    return T->getKind() == ValueKind::MemberFunctionCall;
+  }
+
+  std::string getLabel() const { return Label; }
+  std::shared_ptr<CompileTimeValue> getBaseValue() const { return BaseValue; }
+  std::vector<FunctionParameter> getParameters() const { return Parameters; }
+
+private:
+  std::string Label;
+  std::shared_ptr<CompileTimeValue> BaseValue;
   std::vector<FunctionParameter> Parameters;
 };
 

--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -334,15 +334,19 @@ extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
             return std::make_shared<EnumValue>(baseIdentifierName, parameters);
           }
 
-          case DeclKind::Func: {
-            auto identifier = declRefExpr->getDecl()
-                                  ->getName()
-                                  .getBaseIdentifier()
-                                  .str()
-                                  .str();
+            case DeclKind::Func: {
+              auto identifier = declRefExpr->getDecl()
+                                    ->getName()
+                                    .getBaseIdentifier()
+                                    .str()
+                                    .str();
 
-            return std::make_shared<StaticFunctionCallValue>(
-                identifier, callExpr->getType(), parameters);
+              if (auto funcDecl = dyn_cast<FuncDecl>(declRef.getDecl())) {
+                if (funcDecl->isStatic()) {
+                  return std::make_shared<StaticFunctionCallValue>(identifier, callExpr->getType(), parameters);
+                }
+              }
+              return std::make_shared<MemberFunctionCallValue>(identifier, extractCompileTimeValue(dotSyntaxCallExpr->getBase(), declContext), parameters);
           }
 
           default: {
@@ -920,6 +924,27 @@ void writeValue(llvm::json::OStream &JSON,
       JSON.attribute("memberLabel", staticFunctionCallValue->getLabel());
       JSON.attributeArray("arguments", [&] {
         for (auto FP : staticFunctionCallValue->getParameters()) {
+          JSON.object([&] {
+            JSON.attribute("label", FP.Label);
+            JSON.attribute("type", toFullyQualifiedTypeNameString(FP.Type));
+            writeValue(JSON, FP.Value);
+          });
+        }
+      });
+    });
+    break;
+  }
+
+  case CompileTimeValue::ValueKind::MemberFunctionCall: {
+    auto memberFunctionCallValue = cast<MemberFunctionCallValue>(value);
+    JSON.attribute("valueKind", "MemberFunctionCall");
+    JSON.attributeObject("value", [&]() {
+      JSON.attributeObject("baseValue", [&] {
+        writeValue(JSON, memberFunctionCallValue->getBaseValue());
+      });
+      JSON.attribute("memberLabel", memberFunctionCallValue->getLabel());
+      JSON.attributeArray("arguments", [&] {
+        for (auto FP : memberFunctionCallValue->getParameters()) {
           JSON.object([&] {
             JSON.attribute("label", FP.Label);
             JSON.attribute("type", toFullyQualifiedTypeNameString(FP.Type));

--- a/test/ConstExtraction/ExtractMemberFunctions.swift
+++ b/test/ConstExtraction/ExtractMemberFunctions.swift
@@ -1,0 +1,100 @@
+// RUN: %empty-directory(%t)
+// RUN: echo "[MyProto]" > %t/protocols.json
+
+// RUN: %target-swift-frontend -typecheck -emit-const-values-path %t/ExtractMemberFunctions.swiftconstvalues -const-gather-protocols-file %t/protocols.json -primary-file %s
+// RUN: cat %t/ExtractMemberFunctions.swiftconstvalues 2>&1 > /tmp/const.json
+// RUN: cat %t/ExtractMemberFunctions.swiftconstvalues 2>&1 | %FileCheck %s
+
+protocol MyProto {}
+
+
+struct MyStruct {
+    func myMethod(arg: String) -> String { 
+        "" 
+    }
+}
+
+class MyClass {
+    func myMethod(arg: String) -> Int {
+        5
+    }
+}
+
+struct Statics: MyProto {
+    var prop1 = MyStruct().myMethod(arg: "struct arg")
+    var prop2 = MyClass().myMethod(arg: "class arg")
+    var prop3 = MyStruct().myMethod(arg: "second struct").lowercased()
+}
+
+// CHECK:       "label": "prop1",
+// CHECK-NEXT:  "type": "Swift.String",
+// CHECK:       "valueKind": "MemberFunctionCall",
+// CHECK-NEXT:  "value": {
+// CHECK-NEXT:    "baseValue": {
+// CHECK-NEXT:        "valueKind": "InitCall",
+// CHECK-NEXT:        "value": {
+// CHECK-NEXT:          "type": "ExtractMemberFunctions.MyStruct",
+// CHECK-NEXT:          "arguments": []
+// CHECK-NEXT:        }
+// CHECK-NEXT:      },
+// CHECK-NEXT:      "memberLabel": "myMethod",
+// CHECK-NEXT:      "arguments": [
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "label": "arg",
+// CHECK-NEXT:          "type": "Swift.String",
+// CHECK-NEXT:          "valueKind": "RawLiteral",
+// CHECK-NEXT:          "value": "struct arg"
+// CHECK-NEXT:        }
+// CHECK-NEXT:      ]
+// CHECK-NEXT:    }
+
+// CHECK:       "label": "prop2",
+// CHECK-NEXT:  "type": "Swift.Int",
+// CHECK:       "valueKind": "MemberFunctionCall",
+// CHECK-NEXT:  "value": {
+// CHECK-NEXT:    "baseValue": {
+// CHECK-NEXT:      "valueKind": "InitCall",
+// CHECK-NEXT:      "value": {
+// CHECK-NEXT:        "type": "ExtractMemberFunctions.MyClass",
+// CHECK-NEXT:        "arguments": []
+// CHECK-NEXT:      }
+// CHECK-NEXT:    },
+// CHECK-NEXT:    "memberLabel": "myMethod",
+// CHECK-NEXT:    "arguments": [
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "arg",
+// CHECK-NEXT:        "type": "Swift.String",
+// CHECK-NEXT:        "valueKind": "RawLiteral",
+// CHECK-NEXT:        "value": "class arg"
+// CHECK-NEXT:      }
+// CHECK-NEXT:    ]
+// CHECK-NEXT:  }
+
+// CHECK:       "label": "prop3",
+// CHECK-NEXT:  "type": "Swift.String",
+// CHECK:       "valueKind": "MemberFunctionCall",
+// CHECK-NEXT:  "value": {
+// CHECK-NEXT:    "baseValue": {
+// CHECK-NEXT:      "valueKind": "MemberFunctionCall",
+// CHECK-NEXT:      "value": {
+// CHECK-NEXT:        "baseValue": {
+// CHECK-NEXT:          "valueKind": "InitCall",
+// CHECK-NEXT:          "value": {
+// CHECK-NEXT:            "type": "ExtractMemberFunctions.MyStruct",
+// CHECK-NEXT:            "arguments": []
+// CHECK-NEXT:          }
+// CHECK-NEXT:        },
+// CHECK-NEXT:        "memberLabel": "myMethod",
+// CHECK-NEXT:        "arguments": [
+// CHECK-NEXT:          {
+// CHECK-NEXT:            "label": "arg",
+// CHECK-NEXT:            "type": "Swift.String",
+// CHECK-NEXT:            "valueKind": "RawLiteral",
+// CHECK-NEXT:            "value": "second struct"
+// CHECK-NEXT:          }
+// CHECK-NEXT:        ]
+// CHECK-NEXT:      }
+// CHECK-NEXT:    },
+// CHECK-NEXT:    "memberLabel": "lowercased",
+// CHECK-NEXT:    "arguments": []
+// CHECK-NEXT:  }

--- a/test/ConstExtraction/ExtractMemberFunctions.swift
+++ b/test/ConstExtraction/ExtractMemberFunctions.swift
@@ -2,7 +2,6 @@
 // RUN: echo "[MyProto]" > %t/protocols.json
 
 // RUN: %target-swift-frontend -typecheck -emit-const-values-path %t/ExtractMemberFunctions.swiftconstvalues -const-gather-protocols-file %t/protocols.json -primary-file %s
-// RUN: cat %t/ExtractMemberFunctions.swiftconstvalues 2>&1 > /tmp/const.json
 // RUN: cat %t/ExtractMemberFunctions.swiftconstvalues 2>&1 | %FileCheck %s
 
 protocol MyProto {}

--- a/test/ConstExtraction/ExtractResultBuilders.swift
+++ b/test/ConstExtraction/ExtractResultBuilders.swift
@@ -17,6 +17,10 @@ public struct Foo {
         self.name = name
         self.baz = baz()
     }
+
+    public func me() -> Foo {
+        self
+    }
 }
 
 @resultBuilder
@@ -80,6 +84,11 @@ public struct MyFooProvider: FooProvider {
         Foo(name: "MyFooProvider.bars.1")
         Foo(name: "MyFooProvider.bars.2")
     }
+
+    @FooBuilder
+    public static var baz: [Foo] {
+        Foo(name: "MyFooProvider.bars.1").me()
+    }    
 }
 
 let someNumber = Int.random(in: 0...10)
@@ -142,7 +151,7 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:     "mangledTypeName": "21ExtractResultBuilders13MyFooProviderV",
 // CHECK-NEXT:     "kind": "struct",
 // CHECK-NEXT:     "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
-// CHECK-NEXT:     "line": 71,
+// CHECK-NEXT:     "line": 76,
 // CHECK-NEXT:     "conformances": [
 // CHECK-NEXT:       "ExtractResultBuilders.FooProvider"
 // CHECK-NEXT:     ],
@@ -161,7 +170,7 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:         "isStatic": "true",
 // CHECK-NEXT:         "isComputed": "true",
 // CHECK-NEXT:         "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
-// CHECK-NEXT:         "line": 73,
+// CHECK-NEXT:         "line": 78,
 // CHECK-NEXT:         "valueKind": "Builder",
 // CHECK-NEXT:         "value": {
 // CHECK-NEXT:           "type": "ExtractResultBuilders.FooBuilder",
@@ -210,7 +219,7 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:         "isStatic": "true",
 // CHECK-NEXT:         "isComputed": "true",
 // CHECK-NEXT:         "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
-// CHECK-NEXT:         "line": 79,
+// CHECK-NEXT:         "line": 84,
 // CHECK-NEXT:         "valueKind": "Builder",
 // CHECK-NEXT:         "value": {
 // CHECK-NEXT:           "type": "ExtractResultBuilders.FooBuilder",
@@ -251,6 +260,45 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:             }
 // CHECK-NEXT:           ]
 // CHECK-NEXT:         }
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "label": "baz",
+// CHECK-NEXT:         "type": "Swift.Array<ExtractResultBuilders.Foo>",
+// CHECK-NEXT:         "mangledTypeName": "n/a - deprecated",
+// CHECK-NEXT:         "isStatic": "true",
+// CHECK-NEXT:         "isComputed": "true",
+// CHECK-NEXT:         "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
+// CHECK-NEXT:         "line": 90,
+// CHECK-NEXT:         "valueKind": "Builder",
+// CHECK-NEXT:         "value": {
+// CHECK-NEXT:           "type": "ExtractResultBuilders.FooBuilder",
+// CHECK-NEXT:           "members": [
+// CHECK-NEXT:             {
+// CHECK-NEXT:               "kind": "buildExpression",
+// CHECK-NEXT:               "element": {
+// CHECK-NEXT:                 "valueKind": "MemberFunctionCall",
+// CHECK-NEXT:                 "value": {
+// CHECK-NEXT:                   "baseValue": {
+// CHECK-NEXT:                     "valueKind": "InitCall",
+// CHECK-NEXT:                     "value": {
+// CHECK-NEXT:                       "type": "ExtractResultBuilders.Foo",
+// CHECK-NEXT:                       "arguments": [
+// CHECK-NEXT:                         {
+// CHECK-NEXT:                           "label": "name",
+// CHECK-NEXT:                           "type": "Swift.String",
+// CHECK-NEXT:                           "valueKind": "RawLiteral",
+// CHECK-NEXT:                           "value": "MyFooProvider.bars.1"
+// CHECK-NEXT:                         }
+// CHECK-NEXT:                       ]
+// CHECK-NEXT:                     }
+// CHECK-NEXT:                   },
+// CHECK-NEXT:                   "memberLabel": "me",
+// CHECK-NEXT:                   "arguments": []
+// CHECK-NEXT:                 }
+// CHECK-NEXT:               }
+// CHECK-NEXT:             }
+// CHECK-NEXT:           ]
+// CHECK-NEXT:         }
 // CHECK-NEXT:       }
 // CHECK-NEXT:     ]
 // CHECK-NEXT:   },
@@ -259,7 +307,7 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:     "mangledTypeName": "21ExtractResultBuilders21MyFooProviderInferredV",
 // CHECK-NEXT:     "kind": "struct",
 // CHECK-NEXT:     "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
-// CHECK-NEXT:     "line": 87,
+// CHECK-NEXT:     "line": 97,
 // CHECK-NEXT:     "conformances": [
 // CHECK-NEXT:       "ExtractResultBuilders.FooProvider"
 // CHECK-NEXT:     ],
@@ -278,7 +326,7 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:         "isStatic": "true",
 // CHECK-NEXT:         "isComputed": "true",
 // CHECK-NEXT:         "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
-// CHECK-NEXT:         "line": 88,
+// CHECK-NEXT:         "line": 98,
 // CHECK-NEXT:         "valueKind": "Builder",
 // CHECK-NEXT:         "value": {
 // CHECK-NEXT:           "type": "ExtractResultBuilders.FooBuilder",
@@ -567,7 +615,7 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:     "mangledTypeName": "21ExtractResultBuilders44MyFooProviderInferredWithArrayInitializationV",
 // CHECK-NEXT:     "kind": "struct",
 // CHECK-NEXT:     "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
-// CHECK-NEXT:     "line": 120,
+// CHECK-NEXT:     "line": 130,
 // CHECK-NEXT:     "conformances": [
 // CHECK-NEXT:       "ExtractResultBuilders.FooProvider"
 // CHECK-NEXT:     ],
@@ -586,7 +634,7 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:         "isStatic": "true",
 // CHECK-NEXT:         "isComputed": "false",
 // CHECK-NEXT:         "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
-// CHECK-NEXT:         "line": 121,
+// CHECK-NEXT:         "line": 131,
 // CHECK-NEXT:         "valueKind": "Array",
 // CHECK-NEXT:         "value": [
 // CHECK-NEXT:           {
@@ -650,7 +698,7 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:     "mangledTypeName": "21ExtractResultBuilders36MyFooProviderInferredWithArrayReturnV",
 // CHECK-NEXT:     "kind": "struct",
 // CHECK-NEXT:     "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
-// CHECK-NEXT:     "line": 130,
+// CHECK-NEXT:     "line": 140,
 // CHECK-NEXT:     "conformances": [
 // CHECK-NEXT:       "ExtractResultBuilders.FooProvider"
 // CHECK-NEXT:     ],
@@ -669,7 +717,7 @@ public struct MyFooProviderInferredWithArrayReturn: FooProvider {
 // CHECK-NEXT:         "isStatic": "true",
 // CHECK-NEXT:         "isComputed": "true",
 // CHECK-NEXT:         "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
-// CHECK-NEXT:         "line": 131,
+// CHECK-NEXT:         "line": 141,
 // CHECK-NEXT:         "valueKind": "Array",
 // CHECK-NEXT:         "value": [
 // CHECK-NEXT:           {


### PR DESCRIPTION
Adds a new `MemberFuncCall` type to support `MyType().myfunc()` style call extraction.