### PR TITLE
SIL: Fix a wrong assert in `ValueOwnershipKind::forwardToInit`

### DIFF
--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -372,7 +372,7 @@ struct ValueOwnershipKind {
         return OwnershipKind::Owned;
       case OwnershipKind::Guaranteed:
       case OwnershipKind::Unowned:
-        ABORT("Cannot initialize a nonCopyable type with a guaranteed value");
+        return *this;
       }
     }
     return *this;

--- a/test/SILOptimizer/semanticarc_and_inlining.sil
+++ b/test/SILOptimizer/semanticarc_and_inlining.sil
@@ -1,0 +1,36 @@
+// RUN: %target-sil-opt -semantic-arc-opts -inline %s | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+struct NC : ~Copyable {
+  var o: AnyObject
+}
+
+sil [ossa] @testit : $@convention(thin) (@guaranteed AnyObject) -> () {
+bb0(%0: @guaranteed $AnyObject):
+  %1 = copy_value %0
+  %2 = struct $NC (%1)
+  %3 = destructure_struct %2
+  destroy_value %3
+  %r = tuple ()
+  return %r
+}
+
+// Check that the compiler doesn't crash
+
+// CHECK-LABEL: sil [ossa] @caller :
+// CHECK-NOT:     copy_value
+// CHECK-NOT:     apply
+// CHECK:       } // end sil function 'caller'
+sil [ossa] @caller : $@convention(thin) (@guaranteed AnyObject) -> () {
+bb0(%0: @guaranteed $AnyObject):
+  %1 = function_ref @testit : $@convention(thin) (@guaranteed AnyObject) -> ()
+  %2 = apply %1(%0) : $@convention(thin) (@guaranteed AnyObject) -> ()
+  %r = tuple ()
+  return %r
+}
+


### PR DESCRIPTION
The assert implies that non-copyable struct instructions must not have "guaranteed" ownership. However, this is not enforced in the SIL verifier are anywhere else. SemanticARCOpt converts this owned struct into a guaranteed struct, which is a legal transformation. The fix is to remove the assert.

Fixes a compiler crash
rdar://172675080
