### PR TITLE
Sema: Some improvements to bindings

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -1068,6 +1068,10 @@ namespace swift {
     /// Enable experimental optimization to skip contradictory disjunction
     /// choices.
     bool SolverPruneDisjunctions = true;
+
+    /// Enable an inefficient form of inference, which will sometimes prevent
+    /// exact binding promotion from taking place.
+    bool SolverEnableEnumerateSupertypes = true;
   };
 
   /// Options for controlling the behavior of the Clang importer.

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -996,8 +996,14 @@ def solver_disable_performance_hacks : Flag<["-"], "solver-disable-performance-h
            "subsumed by subsequent improvements">;
 
 def solver_enable_performance_hacks : Flag<["-"], "solver-enable-performance-hacks">,
-  HelpText<"Enble various constraint solver performance optimizations that have been "
+  HelpText<"Enable various constraint solver performance optimizations that have been "
            "subsumed by subsequent improvements">;
+
+def solver_disable_enumerate_supertypes : Flag<["-"], "solver-disable-enumerate-supertypes">,
+  HelpText<"Disable an inefficient form of inference in the solver, which allows certain optimizations">;
+
+def solver_enable_enumerate_supertypes : Flag<["-"], "solver-enable-enumerate-supertypes">,
+  HelpText<"Enable an inefficient form of inference in the solver, which prevents certain optimizations">;
 
 def solver_disable_splitter : Flag<["-"], "solver-disable-splitter">,
   HelpText<"Disable the component splitter phase of expression type checking">;

--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -768,6 +768,9 @@ private:
   SubsumeBindingResult subsumeBinding(const PotentialBinding &binding,
                                       const PotentialBinding &existing);
 
+  void inferTransitiveKeyPathBindingFrom(const PotentialBinding &binding,
+                                         TypeVariableType *keyPathTy);
+
   void addDefault(Constraint *constraint);
 
   StringRef getLiteralBindingKind(LiteralBindingKind K) const {

--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -664,12 +664,6 @@ public:
   void forEachLiteralRequirement(
       llvm::function_ref<void(KnownProtocolKind)> callback) const;
 
-  void forEachAdjacentVariable(
-      llvm::function_ref<void(TypeVariableType *)> callback) const {
-    for (auto *typeVar : AdjacentVars)
-      callback(typeVar);
-  }
-
   /// Return a literal requirement that has the most impact on the binding
   /// score.
   LiteralBindingKind getLiteralForScore() const;

--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -346,6 +346,8 @@ struct PotentialBindings {
   void reset();
 
   void dump(llvm::raw_ostream &out, unsigned indent) const;
+
+  void printVars(llvm::raw_ostream &out, unsigned indent, bool showVia) const;
 };
 
 

--- a/include/swift/Sema/ConstraintGraph.h
+++ b/include/swift/Sema/ConstraintGraph.h
@@ -101,6 +101,11 @@ public:
     return *Set;
   }
 
+  const inference::BindingSet &getBindingSet() const {
+    ASSERT(hasBindingSet());
+    return *Set;
+  }
+
   bool hasBindingSet() const {
     return Set.has_value();
   }

--- a/include/swift/Sema/Subtyping.h
+++ b/include/swift/Sema/Subtyping.h
@@ -110,6 +110,26 @@ enum class ConversionBehavior : unsigned {
 /// Classify the possible conversions having this type as result type.
 ConversionBehavior getConversionBehavior(Type type);
 
+struct TypeVarOccurrences {
+  // Covariant position, eg () -> $T0 or Array<$T0>.
+  SmallPtrSet<TypeVariableType *, 2> covariant;
+
+  // Contravariant position, eg ($T0) -> ().
+  SmallPtrSet<TypeVariableType *, 2> contravariant;
+
+  // Invariant position, eg G<$T0> where G is some user-defined type.
+  SmallPtrSet<TypeVariableType *, 2> invariant;
+
+  // Type variables that occur as the base of a dependent member type,
+  // eg $T0.A.
+  SmallPtrSet<TypeVariableType *, 1> base;
+};
+
+void getTypeVariablesWithVariance(
+    TypeVarOccurrences *result,
+    Type type, TypePosition pos,
+    bool funcResultIsInvariant=false);
+
 /// Suppose we are given a type T and a protocol P, and T conv U for
 /// some type U; if U conforms to P, does it follow that T conforms to P?
 bool checkTransitiveSupertypeConformance(ConstraintSystem &cs,

--- a/include/swift/Sema/TypeVariableType.h
+++ b/include/swift/Sema/TypeVariableType.h
@@ -331,9 +331,7 @@ public:
   /// Assign a fixed type to this equivalence class.
   void assignFixedType(Type type,
                        constraints::SolverTrail *trail) {
-    assert((!getFixedType(nullptr) ||
-            getFixedType(nullptr)->isEqual(type)) &&
-           "Already has a fixed type!");
+    DEBUG_ASSERT(!getFixedType(nullptr) && "Already has a fixed type!");
     auto rep = getRepresentative(trail);
     if (trail)
       rep->getImpl().recordBinding(*trail);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2147,6 +2147,11 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
                    OPT_solver_disable_performance_hacks,
                    Opts.SolverEnablePerformanceHacks);
 
+  Opts.SolverEnableEnumerateSupertypes =
+      Args.hasFlag(OPT_solver_enable_enumerate_supertypes,
+                   OPT_solver_disable_enumerate_supertypes,
+                   Opts.SolverEnableEnumerateSupertypes);
+
   if (FrontendOpts.RequestedAction == FrontendOptions::ActionType::Immediate)
     Opts.DeferToRuntime = true;
 

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -940,11 +940,18 @@ Type swift::tryMergeBaseTypeForCompletionLookup(Type ty1, Type ty2,
       return Type();
   }
 
-  // In general we want to prefer a subtype over a supertype.
-  if (isSubtypeOf(ty1, ty2, dc))
+  auto lt = isSubtypeOf(ty1, ty2, dc);
+  auto gt = isSubtypeOf(ty2, ty1, dc);
+
+  if (lt && gt) {
+    // The two types convert to each other, but they're distinct. Give up.
+    return Type();
+  } else if (lt) {
+    // Otherwise, prefer a subtype over a supertype.
     return ty1;
-  if (isSubtypeOf(ty2, ty1, dc))
+  } else if (gt) {
     return ty2;
+  }
 
   // Incomparable, return null.
   return Type();

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -955,6 +955,46 @@ ManagedValue SILGenFunction::emitProtocolMetatypeToObject(SILLocation loc,
   return emitManagedRValueWithCleanup(value);
 }
 
+ManagedValue SILGenFunction::emitDoubleToCGFloat(SILLocation loc,
+                                                 SILValue doubleValue, SGFContext C) {
+  // Call CGFloat.init(_:)
+  ASTContext &ctx = getASTContext();
+  auto init = ctx.getCGFloatInitDecl();
+  auto argType = CanType(ctx.getDoubleType());
+  RValue arg(*this,
+             ManagedValue::forObjectRValueWithoutOwnership(doubleValue),
+             argType);
+
+  PreparedArguments args((AnyFunctionType::Param(argType)));
+  args.add(loc, std::move(arg));
+
+  auto result =
+    emitApplyAllocatingInitializer(loc, ConcreteDeclRef(init),
+                                   std::move(args), Type(), C);
+
+  return std::move(result).getScalarValue();
+}
+
+ManagedValue SILGenFunction::emitCGFloatToDouble(SILLocation loc,
+                                                 SILValue cgfloatValue, SGFContext C) {
+  // Call Double.init(_:)
+  ASTContext &ctx = getASTContext();
+  auto init = ctx.getDoubleInitDecl();
+  auto argType = CanType(ctx.getCGFloatType());
+  RValue arg(*this,
+             ManagedValue::forObjectRValueWithoutOwnership(cgfloatValue),
+             argType);
+
+  PreparedArguments args((AnyFunctionType::Param(argType)));
+  args.add(loc, std::move(arg));
+
+  auto result =
+    emitApplyAllocatingInitializer(loc, ConcreteDeclRef(init),
+                                   std::move(args), Type(), C);
+
+  return std::move(result).getScalarValue();
+}
+
 ManagedValue
 SILGenFunction::emitOpenExistential(
        SILLocation loc,

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1759,6 +1759,12 @@ public:
                                             CanType inputTy,
                                             SILType resultTy);
 
+  ManagedValue emitDoubleToCGFloat(SILLocation loc,
+                                   SILValue doubleValue, SGFContext C);
+
+  ManagedValue emitCGFloatToDouble(SILLocation loc,
+                                   SILValue cgfloatValue, SGFContext C);
+
   ManagedValue manageOpaqueValue(ManagedValue value,
                                  SILLocation loc,
                                  SGFContext C);

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -652,7 +652,13 @@ ManagedValue Transform::transform(ManagedValue v,
       } else if (inputSubstType->isSet()) {
         fn = SGF.SGM.getSetUpCast(Loc);
       } else {
-        llvm::report_fatal_error("unsupported collection upcast kind");
+        ABORT([&](llvm::raw_ostream &out) {
+          out << "Unsupported collection upcast kind\n";
+          v.dump(out);
+          loweredResultTy.getASTType()->dump(out);
+          inputSubstType->dump(out);
+          outputSubstType->dump(out);
+        });
       }
 
       return SGF.emitCollectionConversion(Loc, fn, inputSubstType,
@@ -762,6 +768,18 @@ ManagedValue Transform::transform(ManagedValue v,
                      outputSubstType,
                      loweredResultTy,
                      ctxt);
+  }
+
+  // CGFloat to Double.
+  if (inputSubstType->isCGFloat() &&
+      outputSubstType->isDouble()) {
+    return SGF.emitCGFloatToDouble(Loc, v.getUnmanagedValue(), ctxt);
+  }
+
+  // Double to CGFloat.
+  if (inputSubstType->isDouble() &&
+      outputSubstType->isCGFloat()) {
+    return SGF.emitDoubleToCGFloat(Loc, v.getUnmanagedValue(), ctxt);
   }
 
   // - T.TangentVector to Optional<T>.TangentVector

--- a/lib/Sema/BindingProducer.cpp
+++ b/lib/Sema/BindingProducer.cpp
@@ -17,6 +17,7 @@
 #include "swift/Sema/BindingProducer.h"
 #include "swift/Sema/Constraint.h"
 #include "swift/Sema/ConstraintSystem.h"
+#include "swift/Sema/Subtyping.h"
 #include "swift/Sema/TypeVariableType.h"
 
 using namespace swift;
@@ -294,6 +295,8 @@ bool TypeVarBindingProducer::computeNext() {
     // Allow solving for T even for a binding kind where that's invalid
     // if fixes are allowed, because that gives us the opportunity to
     // match T? values to the T binding by adding an unwrap fix.
+    //
+    // FIXME: Remove this.
     if (binding.Kind == BindingKind::Subtypes || CS.shouldAttemptFixes()) {
       // If we were unsuccessful solving for T?, try solving for T.
       if (auto objTy = type->getOptionalObjectType()) {
@@ -338,6 +341,7 @@ bool TypeVarBindingProducer::computeNext() {
       }
     }
 
+    // FIXME: Remove this.
     auto srcLocator = binding.getLocator();
     if (srcLocator &&
         (srcLocator->isLastElement<LocatorPathElt::ApplyArgToParam>() ||
@@ -651,6 +655,9 @@ bool TypeVariableBinding::attempt(ConstraintSystem &cs) const {
     type = cs.replaceInferableTypesWithTypeVars(type, dstLocator);
     type = type->reconstituteSugar(/*recursive=*/false);
   }
+
+  if (type->hasJoinOrMeet())
+    type = openTypeJoinsAndMeets(cs, type, dstLocator);
 
   // If type variable has been marked as a possible hole due to
   // e.g. reference to a missing member. Let's propagate that

--- a/lib/Sema/BindingProducer.cpp
+++ b/lib/Sema/BindingProducer.cpp
@@ -23,9 +23,7 @@ using namespace swift;
 using namespace constraints;
 using namespace inference;
 
-// Given a possibly-Optional type, return the direct superclass of the
-// (underlying) type wrapped in the same number of optional levels as
-// type.
+/// FIXME: Remove this.
 static Type getOptionalSuperclass(Type type) {
   int optionalLevels = 0;
   while (auto underlying = type->getOptionalObjectType()) {
@@ -80,10 +78,7 @@ static Type getOptionalSuperclass(Type type) {
   return superclass;
 }
 
-/// Enumerates all of the 'direct' supertypes of the given type.
-///
-/// The direct supertype S of a type T is a supertype of T (e.g., T < S)
-/// such that there is no type U where T < U and U < S.
+/// FIXME: Remove this.
 static SmallVector<Type, 4> enumerateDirectSupertypes(Type type) {
   SmallVector<Type, 4> result;
 
@@ -390,15 +385,17 @@ bool TypeVarBindingProducer::computeNext() {
         addNewBinding(binding.withSameSource(voidType, BindingKind::Exact));
       }
 
-      for (auto supertype : enumerateDirectSupertypes(type)) {
-        // If we're not allowed to try this binding, skip it.
-        if (checkTypeOfBinding(TypeVar, supertype)) {
-          // A key path type cannot be bound to type-erased key path variants.
-          if (TypeVar->getImpl().isKeyPathType() &&
-              isTypeErasedKeyPathType(supertype))
-            continue;
+      if (CS.getASTContext().TypeCheckerOpts.SolverEnableEnumerateSupertypes) {
+        for (auto supertype : enumerateDirectSupertypes(type)) {
+          // If we're not allowed to try this binding, skip it.
+          if (checkTypeOfBinding(TypeVar, supertype)) {
+            // A key path type cannot be bound to type-erased key path variants.
+            if (TypeVar->getImpl().isKeyPathType() &&
+                isTypeErasedKeyPathType(supertype))
+              continue;
 
-          addNewBinding(binding.withType(supertype));
+            addNewBinding(binding.withType(supertype));
+          }
         }
       }
     }

--- a/lib/Sema/BindingProducer.cpp
+++ b/lib/Sema/BindingProducer.cpp
@@ -284,19 +284,6 @@ bool TypeVarBindingProducer::computeNext() {
       }
     }
 
-    if (getLocator()->directlyAt<ForceValueExpr>() &&
-        TypeVar->getImpl().canBindToLValue() &&
-        !binding.BindingType->is<LValueType>()) {
-      // Result of force unwrap is always connected to its base
-      // optional type via `OptionalObject` constraint which
-      // preserves l-valueness, so in case where object type got
-      // inferred before optional type (because it got the
-      // type from context e.g. parameter type of a function call),
-      // we need to test type with and without l-value after
-      // delaying bindings for as long as possible.
-      addNewBinding(binding.withType(LValueType::get(binding.BindingType)));
-    }
-
     // There is a tailored fix for optional key path root references,
     // let's not create ambiguity by attempting unwrap when it's
     // not allowed.

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2365,6 +2365,17 @@ namespace {
             llvm_unreachable("unknown key path class!");
           }
         } else {
+          if (keyPathTy->is<ArchetypeType>()) {
+            keyPathTy = keyPathTy->getSuperclass();
+            ASSERT(keyPathTy);
+          }
+
+          // Situations like `any KeyPath<...> & Sendable`.
+          if (keyPathTy->isExistentialType()) {
+            keyPathTy = keyPathTy->getSuperclass();
+            ASSERT(keyPathTy);
+          }
+
           auto keyPathBGT = keyPathTy->castTo<BoundGenericType>();
           baseTy = keyPathBGT->getGenericArgs()[0];
 

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -2673,51 +2673,6 @@ PotentialBindings::inferFromRelational(Constraint *constraint) {
     return std::nullopt;
   }
 
-  if (TypeVar->getImpl().isKeyPathType()) {
-    auto objectTy = type->lookThroughAllOptionalTypes();
-
-    // If contextual type is an existential with a superclass
-    // constraint, let's try to infer a key path type from it.
-    if (kind == AllowedBindingKind::Subtypes) {
-      if (type->isExistentialType()) {
-        auto layout = type->getExistentialLayout();
-        if (auto superclass = layout.explicitSuperclass) {
-          if (superclass->isKnownKeyPathType()) {
-            type = superclass;
-            objectTy = superclass;
-          }
-        }
-      }
-    }
-
-    if (!(objectTy->isKnownKeyPathType() || objectTy->is<AnyFunctionType>())) {
-      DEBUG_BAILOUT("Bad key path type (1)");
-      return std::nullopt;
-    }
-  }
-
-  if (TypeVar->getImpl().isKeyPathSubscriptIndex()) {
-    // Key path subscript index can only be a r-value non-optional
-    // type that is a subtype of a known KeyPath type.
-    type = type->getRValueType()->lookThroughAllOptionalTypes();
-
-    // If argument to a key path subscript is an existential,
-    // we can erase it to superclass (if any) here and solver
-    // will perform the opening if supertype turns out to be
-    // a valid key path type of its subtype.
-    if (kind == AllowedBindingKind::Supertypes) {
-      if (type->isExistentialType()) {
-        auto layout = type->getExistentialLayout();
-        if (auto superclass = layout.explicitSuperclass) {
-          type = superclass;
-        } else if (!CS.shouldAttemptFixes()) {
-          DEBUG_BAILOUT("Bad key path type (2)");
-          return std::nullopt;
-        }
-      }
-    }
-  }
-
   // Situations like `v.<member> = { ... }` where member is overloaded.
   // We need to wait until member is resolved otherwise there is a risk
   // of losing some of the contextual attributes important for the closure
@@ -2808,23 +2763,6 @@ PotentialBindings::inferFromRelational(Constraint *constraint) {
     return std::nullopt;
   }
 
-  // If our binding choice is a function type and we're attempting
-  // to bind to a type variable that is the result of opening a
-  // generic parameter, strip the noescape bit so that we only allow
-  // bindings of escaping functions in this position. We do this
-  // because within the generic function we have no indication of
-  // whether the parameter is a function type and if so whether it
-  // should be allowed to escape. As a result we allow anything
-  // passed in to escape.
-  if (auto *fnTy = type->getAs<AnyFunctionType>()) {
-    // Since inference now happens during constraint generation,
-    // this hack should be allowed in both `Solving`
-    // (during non-diagnostic mode) and `ConstraintGeneration` phases.
-    if (isGenericParameter(TypeVar) && !CS.inSalvageMode()) {
-      type = fnTy->withExtInfo(fnTy->getExtInfo().withNoEscape(false));
-    }
-  }
-
   // Check whether we can perform this binding.
   if (!checkTypeOfBinding(TypeVar, type)) {
     auto *bindingTypeVar = type->getRValueType()->getAs<TypeVariableType>();
@@ -2899,6 +2837,68 @@ PotentialBindings::inferFromRelational(Constraint *constraint) {
     }
 
     return std::nullopt;
+  }
+
+  if (TypeVar->getImpl().isKeyPathType()) {
+    auto objectTy = type->lookThroughAllOptionalTypes();
+
+    // If contextual type is an existential with a superclass
+    // constraint, let's try to infer a key path type from it.
+    if (kind == AllowedBindingKind::Subtypes) {
+      if (type->isExistentialType()) {
+        auto layout = type->getExistentialLayout();
+        if (auto superclass = layout.explicitSuperclass) {
+          if (superclass->isKnownKeyPathType()) {
+            type = superclass;
+            objectTy = superclass;
+          }
+        }
+      }
+    }
+
+    if (!(objectTy->isKnownKeyPathType() || objectTy->is<AnyFunctionType>())) {
+      DEBUG_BAILOUT("Bad key path type (1)");
+      return std::nullopt;
+    }
+  }
+
+  if (TypeVar->getImpl().isKeyPathSubscriptIndex()) {
+    // Key path subscript index can only be a r-value non-optional
+    // type that is a subtype of a known KeyPath type.
+    type = type->getRValueType()->lookThroughAllOptionalTypes();
+
+    // If argument to a key path subscript is an existential,
+    // we can erase it to superclass (if any) here and solver
+    // will perform the opening if supertype turns out to be
+    // a valid key path type of its subtype.
+    if (kind == AllowedBindingKind::Supertypes) {
+      if (type->isExistentialType()) {
+        auto layout = type->getExistentialLayout();
+        if (auto superclass = layout.explicitSuperclass) {
+          type = superclass;
+        } else if (!CS.shouldAttemptFixes()) {
+          DEBUG_BAILOUT("Bad key path type (2)");
+          return std::nullopt;
+        }
+      }
+    }
+  }
+
+  // If our binding choice is a function type and we're attempting
+  // to bind to a type variable that is the result of opening a
+  // generic parameter, strip the noescape bit so that we only allow
+  // bindings of escaping functions in this position. We do this
+  // because within the generic function we have no indication of
+  // whether the parameter is a function type and if so whether it
+  // should be allowed to escape. As a result we allow anything
+  // passed in to escape.
+  if (auto *fnTy = type->getAs<AnyFunctionType>()) {
+    // Since inference now happens during constraint generation,
+    // this hack should be allowed in both `Solving`
+    // (during non-diagnostic mode) and `ConstraintGeneration` phases.
+    if (isGenericParameter(TypeVar) && !CS.inSalvageMode()) {
+      type = fnTy->withExtInfo(fnTy->getExtInfo().withNoEscape(false));
+    }
   }
 
   // Make sure we aren't trying to equate type variables with different

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -802,111 +802,140 @@ static AllowedBindingKind flipBindingKind(AllowedBindingKind kind) {
   }
 }
 
-void BindingSet::inferTransitiveKeyPathBindings() {
-  // If the current type variable represents a key path root type
-  // let's try to transitively infer its type through bindings of
-  // a key path type.
-  if (TypeVar->getImpl().isKeyPathRoot()) {
-    auto *locator = TypeVar->getImpl().getLocator();
-    if (auto *keyPathTy =
-            CS.getType(locator->getAnchor())->getAs<TypeVariableType>()) {
-      auto &keyPathNode = CS.getConstraintGraph()[keyPathTy];
-      if (keyPathNode.hasBindingSet()) {
-        const auto &keyPathBindings = keyPathNode.getBindingSet();
+void BindingSet::inferTransitiveKeyPathBindingFrom(
+    const PotentialBinding &binding, TypeVariableType *keyPathTy) {
+  auto bindingTy = binding.BindingType->lookThroughAllOptionalTypes();
 
-        // Look through all of the keypath type's bindings.
-        for (auto &binding : keyPathBindings.Bindings) {
-          auto bindingTy = binding.BindingType->lookThroughAllOptionalTypes();
+  auto inferredRootKind = AllowedBindingKind::Exact;
+  Type inferredRootTy;
+  if (bindingTy->isKnownKeyPathType()) {
+    // AnyKeyPath doesn't have a root type.
+    if (bindingTy->isAnyKeyPath())
+      return;
 
-          auto inferredRootKind = AllowedBindingKind::Exact;
-          Type inferredRootTy;
-          if (bindingTy->isKnownKeyPathType()) {
-            // AnyKeyPath doesn't have a root type.
-            if (bindingTy->isAnyKeyPath())
-              continue;
+    auto *BGT = bindingTy->castTo<BoundGenericType>();
+    inferredRootTy = BGT->getGenericArgs()[0];
 
-            auto *BGT = bindingTy->castTo<BoundGenericType>();
-            inferredRootTy = BGT->getGenericArgs()[0];
-
-            // The generic argument of a keypath type is invariant.
-            inferredRootKind = AllowedBindingKind::Exact;
-          } else if (auto *fnType = bindingTy->getAs<FunctionType>()) {
-            if (fnType->getNumParams() == 1) {
-              inferredRootTy = fnType->getParams()[0].getParameterType();
-
-              // The parameter of a function type is contravariant.
-              inferredRootKind = flipBindingKind(binding.Kind);
-            }
-          }
-
-          if (inferredRootTy) {
-            // If contextual root is not yet resolved, let's try to see if
-            // there are any bindings in its set.
-            if (auto *contextualRootVar = inferredRootTy->getAs<TypeVariableType>()) {
-              auto &contextualRootNode = CS.getConstraintGraph()[contextualRootVar];
-              if (contextualRootNode.hasBindingSet()) {
-                const auto &contextualRootBindings = contextualRootNode.getBindingSet();
-
-                // Don't infer if root is not yet fully resolved.
-                if (contextualRootBindings.isDelayed())
-                  continue;
-
-                // Look at all of the inferred root type's bindings, and copy
-                // them over to our binding set.
-                for (const auto &binding : contextualRootBindings.Bindings) {
-                  AllowedBindingKind newKind;
-
-                  // Only consider bindings with the correct variance.
-
-                  // If we're looking at an exact binding, add a new binding
-                  // with the variance of the binding we're using to look
-                  // through.
-                  if (binding.Kind == AllowedBindingKind::Exact)
-                    newKind = inferredRootKind;
-                  // If the binding we're using to look through is exact,
-                  // preserve the variance.
-                  else if (inferredRootKind == AllowedBindingKind::Exact)
-                    newKind = binding.Kind;
-                  // If the binding we're using to look through has the
-                  // same variance as the binding we're looking at, add
-                  // it and preserve its variance.
-                  else if (inferredRootKind == binding.Kind)
-                    newKind = inferredRootKind;
-                  // Skip the binding if it has the opposite variance of
-                  // the one we're looking through.
-                  else
-                    continue;
-
-                  auto newBinding = binding.withSameSource(
-                      binding.BindingType, newKind);
-                  addBinding(newBinding.asTransitiveFrom(contextualRootVar));
-                }
-
-                // Make a note that the key path root is transitively adjacent
-                // to contextual root type variable and all of its variables.
-                // This is important for ranking.
-                AdjacentVars.insert(contextualRootVar);
-                AdjacentVars.insert(contextualRootBindings.AdjacentVars.begin(),
-                                    contextualRootBindings.AdjacentVars.end());
-
-                // Note the fact that we modified the binding set.
-                markDirty();
-              }
-            } else {
-
-              // We have a concrete root type. Add a binding for it to
-              // our binding set.
-              auto newBinding = binding.withSameSource(
-                  inferredRootTy, inferredRootKind);
-              addBinding(newBinding.asTransitiveFrom(keyPathTy));
-
-              // Note the fact that we modified the binding set.
-              markDirty();
-            }
-          }
-        }
-      }
+    // The generic argument of a keypath type is invariant.
+    inferredRootKind = AllowedBindingKind::Exact;
+  } else if (auto *fnType = bindingTy->getAs<FunctionType>()) {
+    // If we're going to perform a key path to function conversion, infer the
+    // root type from the function type.
+    if (fnType->getNumParams() != 1) {
+      // Looks like an invalid function conversion, will be diagnosed later.
+      return;
     }
+
+    inferredRootTy = fnType->getParams()[0].getParameterType();
+
+    // The parameter of a function type is contravariant.
+    inferredRootKind = flipBindingKind(binding.Kind);
+  } else {
+    // Something else is going on, perhaps the code is invalid, bail out.
+    return;
+  }
+
+  // If contextual root is not yet resolved, let's try to see if
+  // there are any bindings in its set.
+  if (auto *contextualRootVar = inferredRootTy->getAs<TypeVariableType>()) {
+    auto &contextualRootNode = CS.getConstraintGraph()[contextualRootVar];
+    if (!contextualRootNode.hasBindingSet())
+      return;
+
+    const auto &contextualRootBindings = contextualRootNode.getBindingSet();
+
+    // Don't infer if root is not yet fully resolved.
+    if (contextualRootBindings.isDelayed())
+      return;
+
+    // Look at all of the inferred root type's bindings, and copy
+    // them over to our binding set.
+    for (const auto &binding : contextualRootBindings.Bindings) {
+      AllowedBindingKind newKind;
+
+      // Only consider bindings with the correct variance.
+
+      // If we're looking at an exact binding, add a new binding with the
+      // variance of the binding we're using to look through.
+      if (binding.Kind == AllowedBindingKind::Exact)
+        newKind = inferredRootKind;
+      // If the binding we're using to look through is exact, preserve the
+      // variance.
+      else if (inferredRootKind == AllowedBindingKind::Exact)
+        newKind = binding.Kind;
+      // If the binding we're using to look through has the same variance as
+      // the binding we're looking at, add it and preserve its variance.
+      else if (inferredRootKind == binding.Kind)
+        newKind = inferredRootKind;
+      // Skip the binding if it has the opposite variance of the one we're
+      // looking through.
+      else
+        continue;
+
+      auto newBinding = binding.withSameSource(binding.BindingType, newKind);
+      addBinding(newBinding.asTransitiveFrom(contextualRootVar));
+    }
+
+    // Make a note that the key path root is transitively adjacent
+    // to contextual root type variable and all of its variables.
+    // This is important for ranking.
+    AdjacentVars.insert(contextualRootVar);
+    AdjacentVars.insert(contextualRootBindings.AdjacentVars.begin(),
+                        contextualRootBindings.AdjacentVars.end());
+  } else {
+    // We have a concrete root type. Add a binding for it to our binding set.
+    auto newBinding = binding.withSameSource(inferredRootTy, inferredRootKind);
+    addBinding(newBinding.asTransitiveFrom(keyPathTy));
+  }
+
+  // Note the fact that we modified the binding set.
+  markDirty();
+}
+
+/// Infers bindings for a key path root type from the bindings of
+/// the key path type.
+///
+/// The setup is this. Suppose we have:
+///
+///   $T0 keypath $T1 -> $T2
+///   KeyPath<X, Y> conv $T0
+///
+/// where $T0 is the keypath type, $T1 is the root type and $T2 is
+/// the value type, and further suppose we're currently computing
+/// bindings for $T1.
+///
+/// In this situation, we can infer a potential binding of $T1 to X.
+///
+/// A generalization is when the root type X is actually another
+/// type variable $T3:
+///
+///   $T0 keypath $T1 -> $T2
+///   KeyPath<$T3, Y> conv $T0
+///
+/// In this case, we copy bindings from $T3 to $T1.
+void BindingSet::inferTransitiveKeyPathBindings() {
+  if (!TypeVar->getImpl().isKeyPathRoot())
+    return;
+
+  auto *locator = TypeVar->getImpl().getLocator();
+  auto *keyPathTy =
+      CS.getType(locator->getAnchor())->getAs<TypeVariableType>();
+  if (!keyPathTy)
+    return;
+
+  const auto &keyPathNode = CS.getConstraintGraph()[keyPathTy];
+
+  // If it doesn't have a binding set, it was fixed to a concrete type, and
+  // we're about to solve the relevant constraints anyway, so don't attempt
+  // anything below.
+  if (!keyPathNode.hasBindingSet())
+    return;
+
+  const auto &keyPathBindings = keyPathNode.getBindingSet();
+
+  // Look through all of the keypath type's bindings.
+  for (auto &binding : keyPathBindings.Bindings) {
+    inferTransitiveKeyPathBindingFrom(binding, keyPathTy);
   }
 }
 

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1116,9 +1116,6 @@ bool BindingSet::finalizeKeyPathBindings() {
       for (const auto &binding : Bindings) {
         auto bindingTy = binding.BindingType->lookThroughAllOptionalTypes();
 
-        assert(bindingTy->isKnownKeyPathType() ||
-               bindingTy->is<FunctionType>());
-
         // Functions don't have capability so we can simply add them.
         if (auto *fnType = bindingTy->getAs<FunctionType>()) {
           auto extInfo = fnType->getExtInfo();
@@ -1131,9 +1128,11 @@ bool BindingSet::finalizeKeyPathBindings() {
 
           updatedBindings.push_back(binding.withType(fnType));
           isContextualTypeReadOnly = true;
-        } else if (!(bindingTy->isWritableKeyPath() ||
-                     bindingTy->isReferenceWritableKeyPath())) {
-          isContextualTypeReadOnly = true;
+        } else if (bindingTy->isKnownKeyPathType()) {
+          if (!bindingTy->isWritableKeyPath() &&
+              !bindingTy->isReferenceWritableKeyPath()) {
+            isContextualTypeReadOnly = true;
+          }
         }
       }
 
@@ -2840,8 +2839,6 @@ PotentialBindings::inferFromRelational(Constraint *constraint) {
   }
 
   if (TypeVar->getImpl().isKeyPathType()) {
-    auto objectTy = type->lookThroughAllOptionalTypes();
-
     // If contextual type is an existential with a superclass
     // constraint, let's try to infer a key path type from it.
     if (kind == AllowedBindingKind::Subtypes) {
@@ -2850,22 +2847,16 @@ PotentialBindings::inferFromRelational(Constraint *constraint) {
         if (auto superclass = layout.explicitSuperclass) {
           if (superclass->isKnownKeyPathType()) {
             type = superclass;
-            objectTy = superclass;
           }
         }
       }
-    }
-
-    if (!(objectTy->isKnownKeyPathType() || objectTy->is<AnyFunctionType>())) {
-      DEBUG_BAILOUT("Bad key path type (1)");
-      return std::nullopt;
     }
   }
 
   if (TypeVar->getImpl().isKeyPathSubscriptIndex()) {
     // Key path subscript index can only be a r-value non-optional
     // type that is a subtype of a known KeyPath type.
-    type = type->getRValueType()->lookThroughAllOptionalTypes();
+    type = type->getRValueType();
 
     // If argument to a key path subscript is an existential,
     // we can erase it to superclass (if any) here and solver
@@ -2876,9 +2867,6 @@ PotentialBindings::inferFromRelational(Constraint *constraint) {
         auto layout = type->getExistentialLayout();
         if (auto superclass = layout.explicitSuperclass) {
           type = superclass;
-        } else if (!CS.shouldAttemptFixes()) {
-          DEBUG_BAILOUT("Bad key path type (2)");
-          return std::nullopt;
         }
       }
     }

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -3311,6 +3311,49 @@ void PotentialBindings::reset() {
   AssociatedCodeCompletionToken = ASTNode();
 }
 
+void PotentialBindings::printVars(llvm::raw_ostream &out, unsigned indent,
+                                  bool showVia) const {
+  auto printVars = [&](ArrayRef<std::pair<TypeVariableType *, Constraint *>> pairs) {
+    interleave(
+        pairs,
+        [&](std::pair<TypeVariableType *, Constraint *> pair) {
+          out << pair.first->getString(PrintOptions::forDebugging());
+          if (pair.first->getImpl().getFixedType(/*record=*/nullptr))
+            out << " (fixed)";
+          if (showVia) {
+            out << " via ";
+            pair.second->print(out, &CS.getASTContext().SourceMgr, indent,
+                               /*skipLocator=*/true);
+          }
+        },
+        [&out]() { out << ", "; });
+  };
+
+  if (!AdjacentVars.empty()) {
+    out << "[adjacent to: ";
+    printVars(AdjacentVars);
+    out << "] ";
+  }
+
+  if (!SupertypeOf.empty()) {
+    out << "[supertype of: ";
+    printVars(SupertypeOf);
+    out << "] ";
+  }
+
+  if (!SubtypeOf.empty()) {
+    out << "[subtype of: ";
+    printVars(SubtypeOf);
+    out << "] ";
+  }
+
+  if (!EquivalentTo.empty()) {
+    out << "[equivalent to: ";
+    printVars(SubtypeOf);
+    out << "] ";
+  }
+}
+
 void PotentialBindings::dump(llvm::raw_ostream &out, unsigned indent) const {
   if (TypeVar) {
     out << "Potential bindings for ";
@@ -3332,27 +3375,7 @@ void PotentialBindings::dump(llvm::raw_ostream &out, unsigned indent) const {
       [&out]() { out << ", "; });
   out << "] ";
 
-  if (!AdjacentVars.empty()) {
-    out << "[adjacent to: ";
-    SmallVector<std::pair<TypeVariableType *, Constraint *>> adjacentVars(
-        AdjacentVars.begin(), AdjacentVars.end());
-    llvm::sort(adjacentVars,
-               [](auto lhs, auto rhs) {
-                   return lhs.first->getID() < rhs.first->getID();
-               });
-    interleave(
-        adjacentVars,
-        [&](std::pair<TypeVariableType *, Constraint *> pair) {
-          out << pair.first->getString(PrintOptions::forDebugging());
-          if (pair.first->getImpl().getFixedType(/*record=*/nullptr))
-            out << " (fixed)";
-          out << " via ";
-          pair.second->print(out, &CS.getASTContext().SourceMgr, indent,
-                             /*skipLocator=*/true);
-        },
-        [&out]() { out << ", "; });
-    out << "] ";
-  }
+  printVars(out, indent, /*skipVia=*/false);
 }
 
 void BindingSet::forEachLiteralRequirement(

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -933,9 +933,51 @@ void BindingSet::inferTransitiveKeyPathBindings() {
 
   const auto &keyPathBindings = keyPathNode.getBindingSet();
 
-  // Look through all of the keypath type's bindings.
-  for (auto &binding : keyPathBindings.Bindings) {
-    inferTransitiveKeyPathBindingFrom(binding, keyPathTy);
+  // Check if the key path type has bindings at all.
+  if (!keyPathBindings.Bindings.empty()) {
+    // If so, look through all of the keypath type's bindings.
+    for (auto &binding : keyPathBindings.Bindings)
+      inferTransitiveKeyPathBindingFrom(binding, keyPathTy);
+
+    return;
+  }
+
+  // If not, attempt a more advanced analysis to cope with
+  // cases such as [\A.foo, \.bar]. Here, the setup is this:
+  //
+  // KeyPath<A, Foo> conv $T0
+  // $T1 conv $T0
+  //
+  // Where $T0 is the type of the array, and $T1 is the key
+  // path type of \.bar. To infer the root type of \.bar,
+  // we check if it is a subtype of another type variable.
+  // If so, we repeat the above with this type variable
+  // instead.
+  const auto &keyPathPotentialBindings = keyPathNode.getPotentialBindings();
+
+  // We can only reason about the case of just one adjacent conversion
+  // constraint.
+  if (keyPathPotentialBindings.SubtypeOf.size() != 1)
+    return;
+
+  auto pair = keyPathPotentialBindings.SubtypeOf[0];
+  auto *superKeyPathTy = pair.first;
+
+  const auto &superKeyPathNode = CS.getConstraintGraph()[superKeyPathTy];
+  if (!superKeyPathNode.hasBindingSet())
+    return;
+
+  const auto &superKeyPathBindings = superKeyPathNode.getBindingSet();
+  for (auto &binding : superKeyPathBindings.Bindings) {
+    // FIXME: Remove the check.
+    //
+    // The 'if' statement makes this analysis a bit more conservative to
+    // work around the issue with duplicate solutions, that will persist
+    // until more bindings are promoted properly.
+    if (binding.Kind == AllowedBindingKind::Exact ||
+        binding.Kind == AllowedBindingKind::Supertypes) {
+      inferTransitiveKeyPathBindingFrom(binding, superKeyPathTy);
+    }
   }
 }
 

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -2489,16 +2489,26 @@ bool swift::constraints::inference::checkTypeOfBinding(
   }
 
   {
-    auto objType = type->getWithoutSpecifierType();
+    auto objectTy = type->getWithoutSpecifierType();
 
-    // If the type is a type variable itself, don't permit the binding.
-    if (objType->is<TypeVariableType>())
+    // We don't allow binding type variables to other type variables, or
+    // to type variables wrapped in lvalue types.
+    if (objectTy->is<TypeVariableType>())
       return false;
+
+    // If the type is a one-element tuple containing a type variable,
+    // don't try binding it, instead wait until the pack is expanded.
+    if (auto *tupleTy = objectTy->getAs<TupleType>()) {
+      if (tupleTy->getNumElements() == 1 &&
+          tupleTy->getElementType(0)->isTypeVariableOrMember()) {
+        return false;
+      }
+    }
 
     // Don't bind to a dependent member type, even if it's currently
     // wrapped in any number of optionals, because binding producer
     // might unwrap and try to attempt it directly later.
-    if (objType->lookThroughAllOptionalTypes()->is<DependentMemberType>())
+    if (objectTy->lookThroughAllOptionalTypes()->is<DependentMemberType>())
       return false;
   }
 

--- a/lib/Sema/CSOptimizer.cpp
+++ b/lib/Sema/CSOptimizer.cpp
@@ -1404,18 +1404,21 @@ static DisjunctionInfo computeDisjunctionInfo(
       resultTypes.push_back(binding.BindingType);
     }
 
-    // Infer bindings for each side of a ternary condition.
-    bindingSet.forEachAdjacentVariable(
-        [&cs, &resultTypes](TypeVariableType *adjacentVar) {
-          auto *adjacentLoc = adjacentVar->getImpl().getLocator();
-          // This is one of the sides of a ternary operator.
-          if (adjacentLoc->directlyAt<TernaryExpr>()) {
-            auto adjacentBindings = cs.getBindingsFor(adjacentVar);
+    const auto &potentialBindings = cs.getConstraintGraph()[typeVar]
+        .getPotentialBindings();
 
-            for (const auto &binding : adjacentBindings.Bindings)
-              resultTypes.push_back(binding.BindingType);
-          }
-        });
+    // Infer bindings for each side of a ternary condition.
+    for (auto pair : potentialBindings.SubtypeOf) {
+      auto *adjacentVar = pair.first;
+      auto *adjacentLoc = adjacentVar->getImpl().getLocator();
+      // This is one of the sides of a ternary operator.
+      if (adjacentLoc->directlyAt<TernaryExpr>()) {
+        auto adjacentBindings = cs.getBindingsFor(adjacentVar);
+
+        for (const auto &binding : adjacentBindings.Bindings)
+          resultTypes.push_back(binding.BindingType);
+      }
+    }
   } else {
     resultTypes.push_back(resultType);
   }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -13022,16 +13022,25 @@ ConstraintSystem::simplifyKeyPathConstraint(
     if (contextualTy->isPlaceholder())
       return true;
 
+    if (contextualTy->is<ArchetypeType>()) {
+      contextualTy = contextualTy->getSuperclass();
+      if (!contextualTy)
+        return true;
+    }
+
     // Situations like `any KeyPath<...> & Sendable`.
     if (contextualTy->isExistentialType()) {
-      contextualTy = contextualTy->getExistentialLayout().explicitSuperclass;
-      assert(contextualTy);
+      contextualTy = contextualTy->getSuperclass();
+      if (!contextualTy)
+        return true;
     }
 
     if (auto bgt = contextualTy->getAs<BoundGenericType>()) {
       // We can get root and value from a concrete key path type.
-      assert(bgt->isKeyPath() || bgt->isWritableKeyPath() ||
-             bgt->isReferenceWritableKeyPath());
+      if (!(bgt->isKeyPath() || bgt->isWritableKeyPath() ||
+            bgt->isReferenceWritableKeyPath())) {
+        return true;
+      }
 
       contextualRootTy = bgt->getGenericArgs()[0];
       contextualValueTy = bgt->getGenericArgs()[1];
@@ -13169,6 +13178,17 @@ ConstraintSystem::simplifyKeyPathApplicationConstraint(
   // key path application.
   if (locator.endsWith<LocatorPathElt::KeyPathDynamicMember>())
     return SolutionKind::Error;
+
+  if (keyPathTy->is<ArchetypeType>()) {
+    if (auto superclassTy = keyPathTy->getSuperclass())
+      keyPathTy = superclassTy;
+  }
+
+  // Situations like `any KeyPath<...> & Sendable`.
+  if (keyPathTy->isExistentialType()) {
+    if (auto superclassTy = keyPathTy->getSuperclass())
+      keyPathTy = superclassTy;
+  }
 
   if (keyPathTy->isAnyKeyPath()) {
     // Read-only keypath, whose projected value is upcast to `Any?`.

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -13163,7 +13163,8 @@ ConstraintSystem::simplifyKeyPathApplicationConstraint(
                                         ConstraintLocatorBuilder locator) {
   TypeMatchOptions subflags = getDefaultDecompositionOptions(flags);
   keyPathTy = getFixedTypeRecursive(keyPathTy, flags, /*wantRValue=*/true);
-  
+  valueTy = getFixedTypeRecursive(valueTy, flags, /*wantRValue=*/false);
+
   auto unsolved = [&]() -> SolutionKind {
     if (flags.contains(TMF_GenerateConstraints)) {
       addUnsolvedConstraint(Constraint::create(*this,
@@ -13246,6 +13247,9 @@ ConstraintSystem::simplifyKeyPathApplicationConstraint(
       return SolutionKind::Error;
     auto kpValueTy = bgt->getGenericArgs()[1];
 
+    bool isKnownRValue = !valueTy->isTypeVariableOrMember() &&
+                         !valueTy->is<LValueType>();
+
     /// Solve for an rvalue base.
     auto solveRValue = [&]() -> ConstraintSystem::SolutionKind {
       // An rvalue base can be converted to a supertype.
@@ -13264,7 +13268,7 @@ ConstraintSystem::simplifyKeyPathApplicationConstraint(
       return matchTypes(LValueType::get(kpValueTy), valueTy,
                         ConstraintKind::Bind, subflags, locator);
     };
-  
+
     if (bgt->isKeyPath()) {
       // Read-only keypath.
       if (!matchRoot(ConstraintKind::Conversion))
@@ -13273,23 +13277,45 @@ ConstraintSystem::simplifyKeyPathApplicationConstraint(
       return solveRValue();
     }
     if (bgt->isWritableKeyPath()) {
+      kpRootTy = getFixedTypeRecursive(kpRootTy, flags, /*wantRValueType=*/true);
+
+      // We might not know if the value is ultimately going to be used as an
+      // lvalue or rvalue yet, but this determines whether we can convert the
+      // base. To avoid introducing a disjunction, just guess if the keypath
+      // root type is already bound, and conservatively assume we will not
+      // convert the base if the keypath root type is not bound.
+      if (!kpRootTy->isTypeVariableOrMember()) {
+        auto result = isLikelyExactMatch(rootTy->getRValueType(), kpRootTy);
+        if (result && !*result) {
+          // Proceed as in the read-only case.
+          if (!matchRoot(ConstraintKind::Conversion))
+            return SolutionKind::Error;
+
+          return solveRValue();
+        }
+      }
+
       // Writable keypath. The result can be an lvalue if the root was.
       // We can't convert the base without giving up lvalue-ness, though.
       if (!matchRoot(ConstraintKind::Equal))
         return SolutionKind::Error;
 
+      if (isKnownRValue)
+        return solveRValue();
       if (rootTy->is<LValueType>())
         return solveLValue();
       if (rootTy->isTypeVariableOrMember())
-        // We don't know whether the value is an lvalue yet.
         return solveUnknown();
+
       return solveRValue();
     }
     if (bgt->isReferenceWritableKeyPath()) {
       if (!matchRoot(ConstraintKind::Conversion))
         return SolutionKind::Error;
 
-      // Reference-writable keypath. The result can always be an lvalue.
+      if (isKnownRValue)
+        return solveRValue();
+
       return solveLValue();
     }
     // Otherwise, we don't have a key path type at all.

--- a/lib/Sema/Subtyping.cpp
+++ b/lib/Sema/Subtyping.cpp
@@ -32,6 +32,129 @@
 using namespace swift;
 using namespace constraints;
 
+void swift::constraints::getTypeVariablesWithVariance(
+    TypeVarOccurrences *result,
+    Type type, TypePosition pos,
+    bool funcResultIsInvariant) {
+  if (!type->hasTypeVariable())
+    return;
+
+  auto rec = [&](Type type, TypePosition pos) {
+    getTypeVariablesWithVariance(result, type, pos,
+                                 /*funcResultIsInvariant=*/false);
+  };
+
+  switch (pos) {
+  case TypePosition::Covariant:
+  case TypePosition::Contravariant: {
+    if (auto *typeVar = type->getAs<TypeVariableType>()) {
+      switch (pos) {
+      case TypePosition::Covariant:
+        result->covariant.insert(typeVar);
+        break;
+      case TypePosition::Contravariant:
+        result->contravariant.insert(typeVar);
+        break;
+      case TypePosition::Shape:
+      case TypePosition::Invariant:
+        ASSERT(false && "Handled above");
+        break;
+      }
+
+      return;
+    } else if (auto *funcTy = type->getAs<FunctionType>()) {
+      for (auto param : funcTy->getParams()) {
+        auto paramTy = param.getOldType();
+        if (param.isInOut())
+          rec(paramTy, TypePosition::Invariant);
+        else
+          rec(paramTy, pos.flipped());
+      }
+
+      auto resultTy = funcTy->getResult();
+      if (funcResultIsInvariant)
+        rec(resultTy, TypePosition::Invariant);
+      else
+        rec(resultTy, pos);
+
+      // FIXME: Error type variance?
+      if (auto thrownError = funcTy->getThrownError())
+        rec(thrownError, TypePosition::Invariant);
+
+      return;
+    } else if (auto *tupleTy = type->getAs<TupleType>()) {
+      for (auto eltTy : tupleTy->getElementTypes())
+        rec(eltTy, pos);
+
+      return;
+    } else if (auto *metatypeTy = type->getAs<MetatypeType>()) {
+      auto instanceTy = metatypeTy->getInstanceType();
+      rec(instanceTy, pos);
+
+      return;
+    } else if (auto objectTy = type->getOptionalObjectType()) {
+      rec(objectTy, pos);
+
+      return;
+    } else if (auto elementTy = type->getArrayElementType()) {
+      rec(elementTy, pos);
+
+      return;
+    } else if (auto elementTy = ConstraintSystem::isSetType(type)) {
+      // FIXME: This differs from TypeTransform.h because we say that
+      // the Set element type is covariant, which is correct.
+      rec(*elementTy, pos);
+
+      return;
+    } else if (auto pair = ConstraintSystem::isDictionaryType(type)) {
+      // FIXME: This differs from TypeTransform.h because we say that
+      // the Dictionary key type is covariant, which is correct.
+      rec(pair->first, pos);
+      rec(pair->second, pos);
+
+      return;
+    }
+
+    // We return upon encountering a known case above.
+    break;
+  }
+  case TypePosition::Invariant:
+  case TypePosition::Shape:
+    break;
+  }
+
+  // Handle all remaining occurrences.
+  class Walker : public TypeWalker {
+    SmallPtrSetImpl<TypeVariableType *> &invariant;
+    SmallPtrSetImpl<TypeVariableType *> &base;
+
+  public:
+    explicit Walker(SmallPtrSetImpl<TypeVariableType *> &invariant,
+                    SmallPtrSetImpl<TypeVariableType *> &base)
+        : invariant(invariant), base(base) {}
+
+    Action walkToTypePre(Type ty) override {
+      // Skip children that don't contain type variables.
+      if (!ty->hasTypeVariable())
+        return Action::SkipNode;
+
+      if (ty->is<DependentMemberType>()) {
+        if (auto *tv = ty->getDependentMemberRoot()->getAs<TypeVariableType>())
+          base.insert(tv);
+
+        return Action::SkipNode;
+      } else if (auto *tv = dyn_cast<TypeVariableType>(ty.getPointer())) {
+        invariant.insert(tv);
+      }
+
+      return Action::Continue;
+    }
+  };
+
+  Walker walker(result->invariant, result->base);
+  type.walk(walker);
+}
+
 /// Determine whether the candidate type is a subclass of the superclass type.
 bool swift::constraints::isSubclassOf(Type candidateType, Type superclassType) {
   if (!superclassType->getClassOrBoundGenericClass())

--- a/test/ASTGen/keypath.swift
+++ b/test/ASTGen/keypath.swift
@@ -8,6 +8,7 @@
 // should end up with the same type-checked AST.
 
 // RUN: %empty-directory(%t)
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature ParserASTGen -solver-disable-enumerate-supertypes
 // RUN: %target-swift-frontend-dump-ast -enable-experimental-feature ParserASTGen -verify \
 // RUN:   | %sanitize-address > %t/astgen.ast
 // RUN: not %target-swift-frontend-dump-ast \

--- a/test/Concurrency/sendable_keypaths.swift
+++ b/test/Concurrency/sendable_keypaths.swift
@@ -1,4 +1,5 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -enable-upcoming-feature InferSendableFromCaptures -strict-concurrency=complete -enable-upcoming-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -enable-upcoming-feature InferSendableFromCaptures -strict-concurrency=complete -enable-upcoming-feature GlobalActorIsolatedTypesUsability -solver-enable-enumerate-supertypes
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -enable-upcoming-feature InferSendableFromCaptures -strict-concurrency=complete -enable-upcoming-feature GlobalActorIsolatedTypesUsability -solver-disable-enumerate-supertypes
 
 // REQUIRES: concurrency
 // REQUIRES: swift_feature_GlobalActorIsolatedTypesUsability

--- a/test/Constraints/argument_matching.swift
+++ b/test/Constraints/argument_matching.swift
@@ -1725,12 +1725,18 @@ do {
 
   let baz: Int? = nil
 
-  func foo<T: Equatable>(
-    _ a: @autoclosure () throws -> T,
-    _ b: @autoclosure () throws -> T
+  func foo1<T: Equatable>(
+    _ a: @autoclosure () -> T,
+    _ b: @autoclosure () -> T
   ) {}
 
-  foo(Foo().bar, [baz])
+  func foo2<T: Equatable>(
+    _ a: T,
+    _ b: T
+  ) {}
+
+  foo1(Foo().bar, [baz])
+  foo2(Foo().bar, [baz])
 }
 
 // https://github.com/apple/swift/issues/55681

--- a/test/Constraints/binding_order.swift
+++ b/test/Constraints/binding_order.swift
@@ -2,10 +2,13 @@
 // RUN: not --crash %target-typecheck-verify-swift -verify-ignore-unrelated -DSALVAGE
 
 // The next two sets of examples cause difficulties because our
-// subtype lattice is not distributive. We cannot always compute
-// an accurate upper bound, because of existential types; if
-// we pick the wrong upper bound too early, certain expressions
-// will fail.
+// subtype lattice is not actually a lattice; existentials fail
+// to satisfy the absorbtion laws. In other words, given two
+// concrete types, we cannot always compute an accurate upper
+// bound, because we don't know what protocol conformances they
+// might have in common; all we can fall back on is their
+// superclass. So if we bind the join type too soon, certain
+// expressions will fail.
 
 protocol Command {
   var name: String { get }
@@ -62,12 +65,12 @@ do {
   func perform4<S: Sequence>(_: S) where S.Element == Any.Type? {}
   perform4([Undo.self, Cut.self, Copy.self])
 
-  let _: [Int: any Command] = Dictionary(
+  let _: [String: any Command] = Dictionary(
     uniqueKeysWithValues: [Undo(), Cut(), Copy(), Paste()].map { ($0.name, $0) })
   // expected-error@-1 {{value of type 'Any' has no member 'name'}}
   // expected-note@-2 {{cast 'Any' to 'AnyObject' or use 'as!' to force downcast to a more specific type to access members}}
 
-  let _: [Int: (any Command)?] = Dictionary(
+  let _: [String: (any Command)?] = Dictionary(
     uniqueKeysWithValues: [Undo(), Cut(), Copy(), Paste()].map { ($0.name, $0) })
   // expected-error@-1 {{value of type 'Any' has no member 'name}}
   // expected-note@-2 {{cast 'Any' to 'AnyObject' or use 'as!' to force downcast to a more specific type to access members}}

--- a/test/Constraints/binding_order.swift
+++ b/test/Constraints/binding_order.swift
@@ -149,6 +149,40 @@ do {
   let _: Dictionary<Double, StaticString> = .init(uniqueKeysWithValues: [(10, "hello"), (20, "world")])
 }
 
+// Another contentsOf: funny case.
+do {
+  let x = ""
+  var s1: [(a: String, b: String)] = []
+  s1.append(contentsOf: [(x, "")])
+  s1.append(contentsOf: [(x, ""), (x, "")])
+  s1.append(contentsOf: [(x, ""), (x, ""), (x, "")])
+
+  var s2: [(a: String, b: Int?)] = []
+  s2.append(contentsOf: [(x, 3)])
+  s2.append(contentsOf: [(x, 3), (x, 4)])
+  s2.append(contentsOf: [(x, 3), (x, 4), (x, 4)])
+
+  var s3: [(a: String?, b: Int)] = []
+  s3.append(contentsOf: [(x, 3)])
+  s3.append(contentsOf: [(x, 3), (x, 4)])
+  s3.append(contentsOf: [(x, 3), (x, 4), (x, 4)])
+}
+
+do {
+  struct S {
+    let a = 0.0
+    let b = 0.0
+    let c = 0.0
+    let d = 0.0
+
+    var customMirror: Mirror {
+      Mirror(self, children: [("a", a), ("b", b), ("c", c), ("d", d)],
+             displayStyle: .struct,
+             ancestorRepresentation: .suppressed)
+    }
+  }
+}
+
 // Tests for a special form of inference where we have both a
 // subtype and a supertype binding for a type variable, and the
 // subtype binding contains a type variable but the supertype

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -solver-disable-enumerate-supertypes
 
 protocol P {
   associatedtype SomeType
@@ -1591,4 +1591,24 @@ do {
   _ = {
     let x: String = 0 // expected-error {{cannot convert value of type 'Int' to specified type 'String'}}
   }. // expected-error {{expected member name following '.'}}
+}
+
+// rdar://169736579
+do {
+  class C {}
+
+  class D: C {
+   var bar: Int = 0
+  }
+
+  func foo<T>(_ x: T, _ fn: (T) -> Void) {}
+
+  func bar(_ x: D) {
+    foo(x) { y in
+      let x = y.bar
+      bar(0, 0)
+      // expected-error@-1 {{extra argument in call}}
+      // expected-error@-2 {{cannot convert value of type 'Int' to expected argument type 'D'}}
+    }
+  }
 }

--- a/test/Constraints/enumerate_supertypes.swift
+++ b/test/Constraints/enumerate_supertypes.swift
@@ -1,0 +1,233 @@
+// RUN: %target-typecheck-verify-swift -solver-disable-enumerate-supertypes
+// RUN: %target-swift-frontend -typecheck %s -solver-enable-enumerate-supertypes
+
+// These examples were held up by the enumerateDirectSupertypes() hack
+// which would attempt superclasses of a supertype binding.
+
+do {
+  class Base {
+    var next: Base?
+  }
+
+  class Derived: Base {}
+
+  func g<T>(_: T, _: (T) -> T?) {}
+
+  func f1(d: Derived) {
+    g(d, { $0.next })
+    // expected-error@-1 {{cannot convert value of type 'Base?' to closure result type 'Derived?'}}
+  }
+
+  // Upcasting the base of the member reference expression in one of various
+  // ways is sufficient to make this type check.
+  func f2(d: Derived) {
+    g(d as Base, { $0.next })
+  }
+
+  func f4(d: Derived) {
+    g(d, { ($0 as Base).next })
+  }
+
+  func f3(d: Derived) {
+    g(d, { (x: Base) in x.next })
+  }
+}
+
+// This is a similar setup to the above.
+do {
+  class NSObject: Hashable {
+    func hash(into: inout Hasher) {}
+    static func ==(lhs: NSObject, rhs: NSObject) -> Bool { return false }
+  }
+
+  class TreeNode: NSObject {
+    let childrenNodes: [TreeNode] = []
+    var parent: TreeNode? = nil
+  }
+
+  class FirstNode: TreeNode {}
+
+  class OtherNode: TreeNode {}
+
+  func f<Node>(_: Node, _: (Node) -> Node?, _: ((Node) -> Bool)) -> Node? {
+    return nil
+  }
+
+  func g<Node>(_: Node, _: (Node) -> [Node]) -> Set<Node> {
+    return []
+  }
+
+  func test1(node: FirstNode) -> (TreeNode?, Set<TreeNode>) {
+    let x = f(node, \.parent) { $0 is OtherNode }
+    // expected-error@-1 {{failed to produce diagnostic for expression}}
+    let y = g(node, \.childrenNodes)
+    // expected-error@-1 {{failed to produce diagnostic for expression}}
+    return (x, y)
+  }
+
+  func test2(node: FirstNode) -> (TreeNode?, Set<TreeNode>) {
+    let x = f(node, \TreeNode.parent) { $0 is OtherNode }
+    let y = g(node, \TreeNode.childrenNodes)
+    return (x, y)
+  }
+
+  func test3(node: FirstNode) -> (TreeNode?, Set<TreeNode>) {
+    let x = f(node, \FirstNode.parent) { $0 is OtherNode }
+    // expected-error@-1 {{failed to produce diagnostic for expression}}
+    let y = g(node, \FirstNode.childrenNodes)
+    // expected-error@-1 {{failed to produce diagnostic for expression}}
+    return (x, y)
+  }
+
+  func test4(node: FirstNode) -> (TreeNode?, Set<TreeNode>) {
+    let x = f(node as TreeNode, \.parent) { $0 is OtherNode }
+    let y = g(node as TreeNode, \.childrenNodes)
+    return (x, y)
+  }
+}
+
+// This one might be solvable without supertype enumeration, but that remains TBD.
+do {
+  class Base {
+      static func updateAll() -> First { fatalError() }
+  }
+
+  class First: Base {}
+
+  class Second: Base {
+      init(_: Int) {}
+  }
+
+  func f0(array: [Int], b: Bool) -> [Base] {
+      return [[Second(0)], [.updateAll()]].flatMap { $0 }
+  }
+
+
+  func f1(array: [Int], b: Bool) -> [Base] {
+      return [[.updateAll()], [Second(0)]].flatMap { $0 }
+  }
+
+  func f2(array: [Int], b: Bool) -> [Base] {
+      return [[.updateAll()], array.map { Second($0) }].flatMap { $0 }
+      // expected-error@-1 {{member 'updateAll()' in 'Second' produces result of type 'First', but context expects 'Second'}}
+  }
+
+  func f3(array: [Int], b: Bool) -> [Base] {
+      return [array.map { Second($0) }, [.updateAll()]].flatMap { $0 }
+      // expected-error@-1 {{member 'updateAll()' in 'Second' produces result of type 'First', but context expects 'Second'}}
+  }
+
+  func f4(array: [Int], b: Bool) -> [Base] {
+      return [b ? [.updateAll()] : [], array.map { Second($0) }].flatMap { $0 }
+      // expected-error@-1 {{member 'updateAll()' in 'Second' produces result of type 'First', but context expects 'Second'}}
+  }
+
+  func f5(array: [Int], b: Bool) -> [Base] {
+      return [b ? [] : [.updateAll()], array.map { Second($0) }].flatMap { $0 }
+      // expected-error@-1 {{member 'updateAll()' in 'Second' produces result of type 'First', but context expects 'Second'}}
+  }
+
+  func f6(array: [Int], b: Bool) -> [Base] {
+      return [array.map { Second($0) }, b ? [.updateAll()] : []].flatMap { $0 }
+      // expected-error@-1 {{member 'updateAll()' in 'Second' produces result of type 'First', but context expects 'Second'}}
+  }
+
+  func f7(array: [Int], b: Bool) -> [Base] {
+      return [array.map { Second($0) }, b ? [] : [.updateAll()]].flatMap { $0 }
+      // expected-error@-1 {{member 'updateAll()' in 'Second' produces result of type 'First', but context expects 'Second'}}
+  }
+}
+
+// This example is actually invalid, but it used to type check.
+do {
+  func f1(_ property: First) {
+    switch property {
+    case .property1: break
+    case .property2: break // expected-error {{member 'property2' in 'First' produces result of type 'Second<Int>', but context expects 'First'}}
+    case .property3: break // expected-error {{member 'property3' in 'First' produces result of type 'Second<Bool>', but context expects 'First'}}
+    case .property4: break
+    default: break
+    }
+  }
+
+  // Now, upcasting the switch expression to the base class allows the code to
+  // type check as before; the two middle cases are unreachable.
+  func f2(_ property: First) {
+    switch property as Base {
+    case .property1: break
+    case .property2: break
+    case .property3: break
+    case .property4: break
+    default: break
+    }
+  }
+
+  class Base: Equatable {
+    static func ==(_: Base, _: Base) -> Bool {
+      fatalError()
+    }
+
+    static let property1 = First()
+    static let property2 = Second<Int>()
+    static let property3 = Second<Bool>()
+    static let property4 = First()
+  }
+
+  class First: Base {}
+
+  class Second<Value>: Base {}
+}
+
+// Another invalid case we used to accept.
+do {
+  func f<T: AnyObject, U>(_: T, _: ReferenceWritableKeyPath<T, U>, _: U) {}
+  func f<T, U>(_: inout T, _: WritableKeyPath<T, U>, _: U) {}
+
+  class D {}
+
+  class E: C {}
+
+  class C {
+    var d: AnyObject?
+
+    func g(d: D) {
+      f(self, \E.d, d)
+      // expected-error@-1 {{cannot convert value of type 'C' to expected argument type 'E'}}
+
+      f(self, \Self.d, d)
+      // expected-error@-1 {{cannot convert value of type 'C' to expected argument type 'Self'}}
+    }
+  }
+}
+
+// Another invalid keypath root.
+do {
+  struct SortDescriptor<Compared> {
+    init(_: KeyPath<Compared, String>) {}
+    init(_: KeyPath<Compared, String?>) {}
+    init(_: KeyPath<Compared, Int>) {}
+    init(_: KeyPath<Compared, Int?>) {}
+    init(_: KeyPath<Compared, Int8>) {}
+    init(_: KeyPath<Compared, Int8?>) {}
+  }
+
+  class Base {
+    var x: Int? = nil
+  }
+  class Derived: Base {}
+
+  struct G<T: Base> {
+    init(_: [GG<T>], _: [SortDescriptor<T>]) {}
+  }
+
+  struct GG<T: Base> {
+    static func f() -> GG<Base> { fatalError() }
+  }
+
+  func test() {
+    let gg = GG.f()
+    let _ = G([gg], [SortDescriptor(\Derived.x)])
+    // expected-error@-1 {{cannot convert value of type 'KeyPath<Derived, Int?>' to expected argument type 'KeyPath<Base, Int?>'}}
+    // expected-note@-2 {{arguments to generic parameter 'Root' ('Derived' and 'Base') are expected to be equal}}
+  }
+}

--- a/test/Constraints/implicit_double_cgfloat_conversion.swift
+++ b/test/Constraints/implicit_double_cgfloat_conversion.swift
@@ -460,3 +460,18 @@ func test_joins_requiring_optional_to_optional_conversion(_ x1: Double, _ x2: CG
   if y2 != x1 {}
   if y2 != x2 {}
 }
+
+// Unapplied references to operators
+func test_unapplied_1(_ x: [CGFloat], y: Double) {
+  let _ = x.reduce(0, +) / y
+  let _ = x.reduce(0, *) / y
+  let _ = x.reduce(0, -) / y
+  let _ = x.reduce(0, /) / y
+}
+
+func test_unapplied_2(_ x: [Double], y: CGFloat) {
+  let _ = x.reduce(0, +) / y
+  let _ = x.reduce(0, *) / y
+  let _ = x.reduce(0, -) / y
+  let _ = x.reduce(0, /) / y
+}

--- a/test/Constraints/keypath.swift
+++ b/test/Constraints/keypath.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend -enable-experimental-feature KeyPathWithMethodMembers -typecheck -verify %S/Inputs/keypath.swift -primary-file %s
+// RUN: %target-swift-frontend -enable-experimental-feature KeyPathWithMethodMembers -typecheck -verify %S/Inputs/keypath.swift -primary-file %s -solver-disable-enumerate-supertypes
+// RUN: %target-swift-frontend -enable-experimental-feature KeyPathWithMethodMembers -typecheck -verify %S/Inputs/keypath.swift -primary-file %s -solver-enable-enumerate-supertypes
 // REQUIRES: swift_feature_KeyPathWithMethodMembers
 
 struct S {

--- a/test/Constraints/keypath_dynamic_member_lookup.swift
+++ b/test/Constraints/keypath_dynamic_member_lookup.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend -Xllvm -sil-print-types -emit-sil -verify -Xllvm -sil-disable-pass=simplification %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-print-types -emit-sil -verify -Xllvm -sil-disable-pass=simplification -solver-disable-enumerate-supertypes %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-print-types -emit-sil -verify -Xllvm -sil-disable-pass=simplification -solver-enable-enumerate-supertypes %s | %FileCheck %s
 
 struct Point {
   let x: Int

--- a/test/Constraints/keypath_root_inference.swift
+++ b/test/Constraints/keypath_root_inference.swift
@@ -1,0 +1,99 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5
+// RUN: %target-typecheck-verify-swift -swift-version 6
+
+// Test case for transitive key path root inference vs. keypath to function
+// conversion
+protocol Wrapper {
+  associatedtype Value
+}
+
+struct _MapWrapper<T, U>: Wrapper {
+  typealias Value = U
+}
+
+extension Wrapper {
+  func map<T>(_: (Value) -> T) -> _MapWrapper<Self, T> {
+    fatalError()
+  }
+}
+
+extension Optional: Wrapper where Wrapped: Wrapper {
+  typealias Value = Wrapped.Value
+}
+
+protocol Shape {}
+
+struct Empty: Shape {}
+
+struct Polygon {
+  init(_: Int) {}
+
+  var shape: any Shape {
+    fatalError()
+  }
+}
+
+func test_transitive_key_path_root_inference1(x: Int?) -> (any Shape)? {
+  return x.map(Polygon.init).map(\.shape)
+}
+
+func test_transitive_key_path_root_inference2(x: Int?) -> any Shape {
+  let shape = x.map(Polygon.init).map(\.shape) ?? Empty()
+  return shape
+}
+
+// More root inference edge cases
+func test_transitive_key_path_root_inference3() {
+  @propertyWrapper
+  class Wrapped<T> {
+    var wrappedValue: T
+    var projectedValue: Wrapped<T> { fatalError() }
+
+    init(wrappedValue: T) { fatalError() }
+  }
+
+  struct Wrapper {
+    @Wrapped var value: Int
+  }
+
+  struct Unwrapper<T> {
+    func f1<U>(_: KeyPath<T, U>) {}
+    func f2<U, V>(_: V) where V: KeyPath<T, U> {}
+    func f3<U>(_: KeyPath<T, Wrapped<U>>) {}
+    func f4<U, V>(_: V) where V: KeyPath<T, Wrapped<U>> {}
+  }
+
+  func id<T>(_: T) -> T { fatalError() }
+
+  Unwrapper<Wrapper>().f1(\.value)
+  Unwrapper<Wrapper>().f1(id(\.value))
+  Unwrapper<Wrapper>().f1(id(id(\.value)))
+
+  Unwrapper<Wrapper>().f2(\.value)
+  Unwrapper<Wrapper>().f2(id(\.value))
+  Unwrapper<Wrapper>().f2(id(id(\.value)))
+
+  Unwrapper<Wrapper>().f3(\.$value)
+  Unwrapper<Wrapper>().f3(id(\.$value))
+  Unwrapper<Wrapper>().f3(id(id(\.$value)))
+
+  Unwrapper<Wrapper>().f4(\.$value)
+  Unwrapper<Wrapper>().f4(id(\.$value))
+  Unwrapper<Wrapper>().f4(id(id(\.$value)))
+}
+
+func test_transitive_key_path_root_inference4() {
+  class C {}
+
+  class G<T, U> {}
+
+  func fn<Input, Output, KeyPath: WritableKeyPath<Container, G<Input, Output>?>>(_: KeyPath, _: (Input) -> Output) {}
+
+  struct Container {
+    var value: G<C, Void>? = nil
+  }
+
+  func test(_ block: (C) -> Void) {
+    fn(\.value, block)
+  }
+}

--- a/test/SILGen/keypaths.swift
+++ b/test/SILGen/keypaths.swift
@@ -1,7 +1,5 @@
-// RUN: %target-swift-emit-silgen -enable-experimental-feature KeyPathWithMethodMembers -Xllvm -sil-print-types -target %target-swift-5.1-abi-triple -parse-stdlib -module-name keypaths %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -enable-experimental-feature KeyPathWithMethodMembers -Xllvm -sil-print-types -target %target-swift-5.1-abi-triple -module-name keypaths %s | %FileCheck %s
 // REQUIRES: swift_feature_KeyPathWithMethodMembers
-
-import Swift
 
 struct S<T> {
   var x: T
@@ -825,4 +823,43 @@ class DynamicSelfTypeTestClass {
 
 func testDynamicSelfType() {
   DynamicSelfTypeTestClass.staticFunc()
+}
+
+// More regression tests
+do {
+  struct Root {}
+
+  protocol P: AnyObject {
+    var root: Root { get set }
+  }
+
+  func f1<T: P, Value>(t: T, keyPath: WritableKeyPath<Root, [Value]?>, value: Value) {
+    t.root[keyPath: keyPath]?.append(value)
+    t.root[keyPath: keyPath]?.removeLast()
+    t.root[keyPath: keyPath] = nil
+    if t.root[keyPath: keyPath]?.count == 0 {}
+    if t.root[keyPath: keyPath]?.count ?? 0 > 0 {}
+  }
+
+  func f2<T: P>(t: T, keyPath: ReferenceWritableKeyPath<T, Task<Void, any Error>?>) {
+    _ = t[keyPath: keyPath]!
+    t[keyPath: keyPath]?.cancel()
+  }
+
+  struct S {
+    func copy() -> Self { return self }
+  }
+
+  class C {
+    var root = Root()
+  }
+
+  func f3(c1: C, c2: C, keyPath: WritableKeyPath<Root, S?>) {
+      c1.root[keyPath: keyPath] = (c2.root[keyPath: keyPath]?.copy())
+  }
+
+  func f4(c: C, keyPath: ReferenceWritableKeyPath<C, Int?>) -> Int {
+    let a = c[keyPath: keyPath]!
+    return a
+  }
 }

--- a/test/SILGen/opaque_values_silgen.swift
+++ b/test/SILGen/opaque_values_silgen.swift
@@ -718,13 +718,13 @@ func FormClassKeyPath() {
 
 // CHECK-LABEL: sil {{.*}}[ossa] @UseGetterOnInout : {{.*}} {
 // CHECK:       bb0([[CONTAINER_ADDR:%[^,]+]] :
-// CHECK:         [[CONTAINER_ACCESS:%[^,]+]] = begin_access [read] [unknown] [[CONTAINER_ADDR]]
-// CHECK:         [[CONTAINER:%[^,]+]] = load [trivial] [[CONTAINER_ACCESS]]
-// CHECK:         end_access [[CONTAINER_ACCESS]]
 // CHECK:         [[KEYPATH:%[^,]+]] = keypath $WritableKeyPath<MyInt, Int>, (root $MyInt; stored_property #MyInt.int : $Int)
+// CHECK:         [[CONTAINER_ACCESS:%[^,]+]] = begin_access [read] [unknown] [[CONTAINER_ADDR]]
 // CHECK:         [[KEYPATH_UP:%[^,]+]] = upcast [[KEYPATH]]
+// CHECK:         [[CONTAINER:%[^,]+]] = load [trivial] [[CONTAINER_ACCESS]]
 // CHECK:         [[GETTER:%[^,]+]] = function_ref @swift_getAtKeyPath
 // CHECK:         [[VALUE:%[^,]+]] = apply [[GETTER]]<MyInt, Int>([[CONTAINER]], [[KEYPATH_UP]])
+// CHECK:         end_access [[CONTAINER_ACCESS]]
 // CHECK:         destroy_value [[KEYPATH_UP]]
 // CHECK:         return [[VALUE]] : $Int                                
 // CHECK-LABEL: } // end sil function 'UseGetterOnInout'

--- a/test/SILOptimizer/keypath_opt_crash.swift
+++ b/test/SILOptimizer/keypath_opt_crash.swift
@@ -1,5 +1,7 @@
-// RUN: %target-swift-frontend -O -emit-sil %s | %FileCheck %s
-// RUN: %target-swift-frontend -O -emit-sil -enable-sil-opaque-values %s | %FileCheck %s
+// RUN: %target-swift-frontend -O -emit-sil %s -solver-disable-enumerate-supertypes | %FileCheck %s
+// RUN: %target-swift-frontend -O -emit-sil -enable-sil-opaque-values %s -solver-disable-enumerate-supertypes | %FileCheck %s
+// RUN: %target-swift-frontend -O -emit-sil %s -solver-enable-enumerate-supertypes | %FileCheck %s
+// RUN: %target-swift-frontend -O -emit-sil -enable-sil-opaque-values %s -solver-enable-enumerate-supertypes | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILOptimizer/optimize_keypath.swift
+++ b/test/SILOptimizer/optimize_keypath.swift
@@ -1,24 +1,24 @@
 // RUN: %empty-directory(%t) 
-// RUN: %target-swift-frontend -primary-file %s -O -sil-verify-all -Xllvm -sil-print-types -emit-sil >%t/output.sil
+// RUN: %target-swift-frontend -primary-file %s -O -sil-verify-all -Xllvm -sil-print-types -emit-sil -solver-disable-enumerate-supertypes >%t/output.sil
 // RUN: %FileCheck --check-prefix=CHECK --check-prefix=CHECK1 %s < %t/output.sil
 // RUN: %FileCheck -check-prefix=CHECK-ALL %s < %t/output.sil
 
 // RUN: %empty-directory(%t) 
-// RUN: %target-swift-frontend -primary-file %s -O -sil-verify-all -Xllvm -sil-print-types -emit-sil -enable-sil-opaque-values >%t/output.sil
+// RUN: %target-swift-frontend -primary-file %s -O -sil-verify-all -Xllvm -sil-print-types -emit-sil -solver-disable-enumerate-supertypes -enable-sil-opaque-values >%t/output.sil
 // RUN: %FileCheck --check-prefix=CHECK --check-prefix=CHECK1 %s < %t/output.sil
 // RUN: %FileCheck -check-prefix=CHECK-ALL %s < %t/output.sil
 
-// RUN: %target-swift-frontend -primary-file %s -O -sil-verify-all -swift-version 6 -Xllvm -sil-print-types -emit-sil >%t/output6.sil
+// RUN: %target-swift-frontend -primary-file %s -O -sil-verify-all -swift-version 6 -Xllvm -sil-print-types -emit-sil -solver-disable-enumerate-supertypes >%t/output6.sil
 // RUN: %FileCheck --check-prefix=CHECK --check-prefix=CHECK2 %s < %t/output6.sil
 // RUN: %FileCheck -check-prefix=CHECK-ALL %s < %t/output6.sil
 
-// RUN: %target-swift-frontend -primary-file %s -O -sil-verify-all -swift-version 6 -Xllvm -sil-print-types -emit-sil -enable-sil-opaque-values >%t/output6.sil
+// RUN: %target-swift-frontend -primary-file %s -O -sil-verify-all -swift-version 6 -Xllvm -sil-print-types -emit-sil -enable-sil-opaque-values -solver-disable-enumerate-supertypes >%t/output6.sil
 // RUN: %FileCheck --check-prefix=CHECK --check-prefix=CHECK2 %s < %t/output6.sil
 // RUN: %FileCheck -check-prefix=CHECK-ALL %s < %t/output6.sil
 
 // Turning on force verification of analyses is exposing:
 // rdar://175520775 (RegionAnalysis crashes saying it cannot handle `assign` instruction)
-// TODO: %target-swift-frontend -primary-file %s -O -Xllvm -sil-verify-force-analysis=true -swift-version 6 -Xllvm -sil-print-types -emit-sil >%t/output2.sil
+// TODO: %target-swift-frontend -primary-file %s -O -Xllvm -sil-verify-force-analysis=true -swift-version 6 -Xllvm -sil-print-types -emit-sil -solver-disable-enumerate-supertypes >%t/output2.sil
 // TODO: %FileCheck --check-prefix=CHECK --check-prefix=CHECK2 %s < %t/output2.sil
 // TODO: %FileCheck -check-prefix=CHECK-ALL %s < %t/output2.sil
 

--- a/test/SILOptimizer/optimize_keypath.swift
+++ b/test/SILOptimizer/optimize_keypath.swift
@@ -338,8 +338,8 @@ func testNestedModify<T : P>(_ s: inout GenStruct<GenClass<GenClass<T>>>) {
 // CHECK-LABEL: sil {{.*}}testTuple
 // CHECK: [[E:%[0-9]+]] = struct_element_addr
 // CHECK: [[T1:%[0-9]+]] = tuple_element_addr [[E]]
-// CHECK: [[T2:%[0-9]+]] = tuple_element_addr [[E]]
 // CHECK: [[I:%[0-9]+]] = load [[T1]]
+// CHECK: [[T2:%[0-9]+]] = tuple_element_addr [[E]]
 // CHECK: store [[I]] to [[T2]]
 // CHECK: return
 @inline(never)

--- a/test/SILOptimizer/optimize_keypath_bug.swift
+++ b/test/SILOptimizer/optimize_keypath_bug.swift
@@ -1,5 +1,7 @@
-// RUN: %target-swift-frontend -emit-sil -O -sil-verify-all %s
-// RUN: %target-swift-frontend -emit-sil -O -sil-verify-all -enable-sil-opaque-values %s
+// RUN: %target-swift-frontend -emit-sil -O -sil-verify-all -solver-disable-enumerate-supertypes %s
+// RUN: %target-swift-frontend -emit-sil -O -sil-verify-all -solver-disable-enumerate-supertypes -enable-sil-opaque-values %s
+// RUN: %target-swift-frontend -emit-sil -O -sil-verify-all -solver-enable-enumerate-supertypes %s
+// RUN: %target-swift-frontend -emit-sil -O -sil-verify-all -solver-enable-enumerate-supertypes -enable-sil-opaque-values %s
 // REQUIRES: OS=macosx
 
 import Foundation

--- a/test/Sema/common_supertype.swift
+++ b/test/Sema/common_supertype.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -solver-disable-enumerate-supertypes
 
 class A {}
 class B: A {}
@@ -31,7 +31,7 @@ func testClass1(x: C, y: E) -> Exactly<B> {
 }
 
 func testClass2(x: E, y: F) {
-  _ = test(x, y) // expected-error {{conflicting arguments to generic parameter 'T' ('E' vs. 'F' vs. 'D' vs. 'B' vs. 'A')}}
+  _ = test(x, y) // expected-error {{conflicting arguments to generic parameter 'T' ('E' vs. 'F')}}
 }
 
 func testClass3(x: A, y: AnyObject) -> Exactly<AnyObject> {

--- a/test/Sema/object_literals_osx.swift
+++ b/test/Sema/object_literals_osx.swift
@@ -31,8 +31,7 @@ let p1: Path = #fileLiteral(resourceName: "what.txt")
 let p2 = #fileLiteral(resourceName: "what.txt") // expected-error{{could not infer type of file reference literal}}
 // expected-note@-1{{import Foundation to use 'URL' as the default file reference literal type}}
 
-let text = #fileLiteral(resourceName: "TextFile.txt").relativeString! // expected-error{{could not infer type of file reference literal}}
-// expected-note@-1{{import Foundation to use 'URL' as the default file reference literal type}}
+let text = #fileLiteral(resourceName: "TextFile.txt").relativeString! // expected-error{{failed to produce diagnostic for expression; please submit a bug report (https://swift.org/contributing/#reporting-bugs)}}
 
 // rdar://problem/49861813
 #fileLiteral()

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature KeyPathWithMethodMembers -verify-additional-prefix non-resilient-
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature KeyPathWithMethodMembers -enable-library-evolution -verify-additional-prefix resilient-
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature KeyPathWithMethodMembers -solver-disable-enumerate-supertypes -verify-additional-prefix non-resilient-
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature KeyPathWithMethodMembers -solver-disable-enumerate-supertypes -enable-library-evolution -verify-additional-prefix resilient-
 // REQUIRES: swift_feature_KeyPathWithMethodMembers
 
 var global = 42

--- a/test/embedded/keypath-crash.swift
+++ b/test/embedded/keypath-crash.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-emit-ir %s -module-name=main -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -module-name=main -enable-experimental-feature Embedded -solver-disable-enumerate-supertypes | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -module-name=main -enable-experimental-feature Embedded -solver-enable-enumerate-supertypes | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_Embedded

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -466,7 +466,7 @@ func testKeyPathSubscriptExistentialBase(concreteBase: inout B,
   _ = concreteBase[keyPath: pkp]
 
   concreteBase[keyPath: kp] = s // expected-error {{cannot assign through subscript: 'kp' is a read-only key path}}
-  concreteBase[keyPath: wkp] = s // expected-error {{key path with root type 'any P' cannot be applied to a base of type 'B'}}
+  concreteBase[keyPath: wkp] = s // expected-error {{cannot assign through subscript: 'concreteBase' is immutable}}
   concreteBase[keyPath: rkp] = s
   concreteBase[keyPath: pkp] = s // expected-error {{cannot assign through subscript: 'pkp' is a read-only key path}}
 

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-feature KeyPathWithMethodMembers -typecheck -parse-as-library %s -verify
+// RUN: %target-swift-frontend -enable-experimental-feature KeyPathWithMethodMembers -typecheck -parse-as-library %s -verify -solver-disable-enumerate-supertypes
 // REQUIRES: swift_feature_KeyPathWithMethodMembers
 
 struct Sub: Hashable {
@@ -305,6 +305,7 @@ func tupleGeneric<T, U>(_ v: (T, U)) {
   // expected-note@-12 {{}}
   // expected-error@-2 {{generic parameter 'T' could not be inferred}}
   // expected-error@-3 {{generic parameter 'U' could not be inferred}}
+  // expected-error@-4 {{key path with root type '(T, U)' cannot be applied to a base of type '(String, String, String)'}}
 }
 
 struct Z { }

--- a/test/stdlib/KeyPath.swift
+++ b/test/stdlib/KeyPath.swift
@@ -1,4 +1,5 @@
 // RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck %s -solver-disable-enumerate-supertypes -import-objc-header %S/Inputs/tail_allocated_c_array.h -swift-version 5
 // RUN: %target-build-swift -import-objc-header %S/Inputs/tail_allocated_c_array.h -swift-version 5 -g %s -o %t/a.out %if !legacy_swift_driver && !CPU=wasm32 %{ -explicit-module-build %}
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out

--- a/unittests/Sema/BindingInferenceTests.cpp
+++ b/unittests/Sema/BindingInferenceTests.cpp
@@ -449,11 +449,7 @@ TEST_F(SemaTest, TestSupertypeInferenceWithDefaults) {
   // The inference should produce 4 types: KeyPath<String, Int>,
   // PartialKeyPath<String>, AnyKeyPath and Any - in that order.
 
-  ASSERT_EQ(inferredTypes.size(), 4);
+  ASSERT_EQ(inferredTypes.size(), 2);
   ASSERT_TRUE(inferredTypes[0]->isEqual(keyPath));
-  ASSERT_TRUE(inferredTypes[1]->isEqual(
-      BoundGenericType::get(Context.getPartialKeyPathDecl(),
-                            /*parent=*/Type(), {getStdlibType("String")})));
-  ASSERT_TRUE(inferredTypes[2]->isEqual(getStdlibType("AnyKeyPath")));
-  ASSERT_TRUE(inferredTypes[3]->isEqual(Context.TheAnyType));
+  ASSERT_TRUE(inferredTypes[1]->isEqual(Context.TheAnyType));
 }

--- a/unittests/Sema/SemaFixture.h
+++ b/unittests/Sema/SemaFixture.h
@@ -53,6 +53,7 @@ public:
 
   SemaTestBase() : Diags(SourceMgr) {
     LangOpts.Target = llvm::Triple(llvm::sys::getDefaultTargetTriple());
+    TypeCheckerOpts.SolverEnableEnumerateSupertypes = false;
 
     llvm::SmallString<128> libDir(SWIFTLIB_DIR);
     llvm::sys::path::append(libDir, getPlatformNameForTriple(LangOpts.Target));

--- a/validation-test/IDE/crashers_fixed/LValueType-get-7d05ea.swift
+++ b/validation-test/IDE/crashers_fixed/LValueType-get-7d05ea.swift
@@ -1,5 +1,5 @@
 // {"kind":"complete","original":"9815e2ce","signature":"swift::LValueType::get(swift::Type)","signatureAssert":"Assertion failed: (!objectTy->is<LValueType>() && !objectTy->is<InOutType>() && \"cannot have 'inout' or @lvalue wrapped inside an @lvalue\"), function get","signatureNext":"TypeVarBindingProducer::computeNext"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
 // REQUIRES: OS=macosx
 import Foundation .a
 {

--- a/validation-test/Sema/SwiftUI/rdar169736579.swift
+++ b/validation-test/Sema/SwiftUI/rdar169736579.swift
@@ -1,0 +1,35 @@
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx12 -verify-ignore-unrelated -solver-disable-enumerate-supertypes
+
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+import Foundation
+import SwiftUI
+
+class MyClass: NSObject, Identifiable {
+    let dataType = "test"
+}
+
+struct ContentView: View {
+    let array = [MyClass]()
+    let value = 5
+    var body: some View {
+        ForEach(array) { element in
+            switch element.dataType {
+            case "test":
+                ChildView(element: element, extraArg: value)
+                // expected-error@-1 {{extra argument 'extraArg' in call}}
+            default:
+                Text("unrecognized value")
+            }
+        }
+    }
+}
+
+struct ChildView: View {
+    let element: MyClass
+
+    var body: some View {
+        Text("...")
+    }
+}

--- a/validation-test/Sema/type_checker_crashers_fixed/issue-56254.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/issue-56254.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -solver-disable-enumerate-supertypes
 
 // https://github.com/apple/swift/issues/56254
 
@@ -41,4 +41,6 @@ struct DefaultsAdapter<KeyStore: DefaultsKeyStore> {
 
 
 var Defaults = DefaultsAdapter<DefaultsKeys>()
-Defaults[\.missingKey] = "" // expected-error {{}}
+Defaults[\.missingKey] = ""
+// expected-error@-1 {{missing argument label 'keyPath:' in subscript}}
+// expected-error@-2 {{cannot assign value of type 'String' to subscript of type 'Never'}}

--- a/validation-test/Sema/type_checker_perf/fast/operator_chains_separated_by_ternary.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/operator_chains_separated_by_ternary.swift.gyb
@@ -1,10 +1,39 @@
 // RUN: %scale-test --begin 1 --end 12 --step 1 --select NumLeafScopes %s
 // REQUIRES: asserts,no_asan
 
-func compute(_: UInt32) {
+func test1(cond: Bool) {
+    func compute(_: Int) {}
+
+    compute(cond
+       ? 1
+%for i in range(1, N):
+         + 1
+%end
+       : 1
+%for i in range(1, N):
+         * 1
+%end
+    )
 }
 
-func test(cond: Bool) {
+func test2(cond: Bool) {
+    func compute(_: UInt32) {}
+
+    compute(cond
+       ? 1
+%for i in range(1, N):
+         + 1
+%end
+       : 1
+%for i in range(1, N):
+         * 1
+%end
+    )
+}
+
+func test3(cond: Bool) {
+    func compute(_: Double) {}
+
     compute(cond
        ? 1
 %for i in range(1, N):

--- a/validation-test/Sema/type_checker_perf/slow/rdar175379862.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/slow/rdar175379862.swift.gyb
@@ -1,0 +1,58 @@
+// RUN: %scale-test --invert --begin 1 --end 5 --step 1 --select NumConstraintScopes %s
+// REQUIRES: asserts,no_asan
+
+struct MultipleMembers: Animatable {
+  typealias AnimatableData = Double
+
+  var animatableData: Double = 0
+
+  var a: Angle
+
+  func foo() {
+    _ = AnimatableValues(
+%for i in range(0, N):
+       self[_animatableValue: \.a],
+%end
+    )
+  }
+}
+
+struct AnimatableValues<each Value>: VectorArithmetic where repeat each Value: VectorArithmetic {
+  init(_: repeat each Value) {}
+  init(_: repeat (each Value).Type) {}
+}
+
+struct Angle: Animatable {
+  typealias AnimatableData = Double
+}
+
+protocol Animatable {
+  associatedtype AnimatableData: VectorArithmetic
+}
+
+protocol VectorArithmetic {}
+
+extension Double : VectorArithmetic {}
+
+struct EmptyAnimatableData {}
+
+extension Animatable {
+  subscript<T>(_animatableValue k: WritableKeyPath<Self, T>) -> T where T: VectorArithmetic {
+    fatalError()
+  }
+  @_disfavoredOverload subscript<T>(_animatableValue k: WritableKeyPath<Self, T>) -> T.AnimatableData
+      where T: Animatable {
+    fatalError()
+  }
+  @_disfavoredOverload subscript<T>(_animatableValue k: WritableKeyPath<Self, T>) -> EmptyAnimatableData {
+    fatalError()
+  }
+  subscript<T>(_animatableValue k: ReferenceWritableKeyPath<Self, T>) -> T
+      where T: VectorArithmetic {
+    fatalError()
+  }
+  @_disfavoredOverload subscript<T>(_animatableValue k: ReferenceWritableKeyPath<Self, T>) -> T.AnimatableData
+      where T : Animatable {
+    fatalError()
+  }
+}

--- a/validation-test/compiler_crashers_fixed/ConstraintSystem-compareSolutions-dcf902.swift
+++ b/validation-test/compiler_crashers_fixed/ConstraintSystem-compareSolutions-dcf902.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"2e9096bf","signature":"swift::constraints::ConstraintSystem::compareSolutions(swift::constraints::ConstraintSystem&, llvm::ArrayRef<swift::constraints::Solution>, swift::constraints::SolutionDiff const&, unsigned int, unsigned int)","signatureAssert":"Assertion failed: (isa<To>(Val) && \"cast<Ty>() argument of incompatible type!\"), function cast","signatureNext":"ConstraintSystem::findBestSolution"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 extension Sequence {
     b<c, d: KeyPath<Element, c>>(d )
   {

--- a/validation-test/compiler_crashers_fixed/ConstraintSystem-simplifyKeyPathConstraint-56777e.swift
+++ b/validation-test/compiler_crashers_fixed/ConstraintSystem-simplifyKeyPathConstraint-56777e.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"bb182de2","signature":"swift::constraints::ConstraintSystem::simplifyKeyPathConstraint(swift::Type, swift::Type, swift::Type, llvm::ArrayRef<swift::TypeVariableType*>, swift::optionset::OptionSet<swift::constraints::ConstraintSystem::TypeMatchFlags, unsigned int>, swift::constraints::ConstraintLocatorBuilder)","signatureAssert":"Assertion failed: (contextualRootTy && contextualValueTy), function operator()","signatureNext":"ConstraintSystem::simplifyConstraint"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 struct a < each b > {
   var
     c : (repeat each b) {

--- a/validation-test/compiler_crashers_fixed/ConstraintSystem-simplifyKeyPathConstraint-9601e1.swift
+++ b/validation-test/compiler_crashers_fixed/ConstraintSystem-simplifyKeyPathConstraint-9601e1.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","signature":"swift::constraints::ConstraintSystem::simplifyKeyPathConstraint(swift::Type, swift::Type, swift::Type, llvm::ArrayRef<swift::TypeVariableType*>, swift::optionset::OptionSet<swift::constraints::ConstraintSystem::TypeMatchFlags, unsigned int>, swift::constraints::ConstraintLocatorBuilder)","signatureAssert":"Assertion failed: (bgt->isKeyPath() || bgt->isWritableKeyPath() || bgt->isReferenceWritableKeyPath()), function operator()","signatureNext":"ConstraintSystem::simplifyConstraint"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 func a<each b>() -> (repeat Array<each b>) {
   (repeat \ [<#type#>])
 }

--- a/validation-test/compiler_crashers_fixed/LValueType-get-ed0d39.swift
+++ b/validation-test/compiler_crashers_fixed/LValueType-get-ed0d39.swift
@@ -1,3 +1,3 @@
 // {"kind":"typecheck","signature":"swift::LValueType::get(swift::Type)","signatureAssert":"Assertion failed: (!objectTy->is<LValueType>() && !objectTy->is<InOutType>() && \"cannot have 'inout' or @lvalue wrapped inside an @lvalue\"), function get","signatureNext":"ConstraintSystem::simplifyOptionalObjectConstraint"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 a!!= 1


### PR DESCRIPTION
Followup to https://github.com/swiftlang/swift/pull/89856.

## Transitive keypath root inference

An interesting example appears in our test suite, an array literal whose first element is a fully qualified keypath, and subsequent elements are leading dots, like `[\A.foo, \.bar, \.baz]`. Previously, we would incorrectly bind the array result type first to the type of `\A.foo`, which gives us a root type for `\.bar` and `\.baz`, but those have different value types so would fail, and then attempt the superclasses of `\A.foo`'s type, which would eventually succeed with `PartialKeyPath<A>`. I expanded the analysis in `inferTransitiveKeyPathBindings()` to be able to directly infer the root type in this situation.

## Experimental flag to turn off supertype enumeration

Sometimes if a supertype binding would fail, we would attempt to enumerate some of its supertypes, and attempt those too. There are very few cases where a type does not satisfy adjacent constraints but its _supertype_ does, because usually those have fewer protocol conformances and so on. It seems that this was required primarily to work around some issues with keypath constraints, which I have attempted to fix.

I added a new `-solver-disable-enumerate-supertypes` flag to disable this form of inference. **For now, supertype enumeration is on by default and there is no behavior change.**

There were a couple of difficult behaviors I was not able to fully maintain. They appear in `test/Constraints/enumerate_supertypes.swift`.

### Keypath base conversion

When applying a `WritableKeyPath` with a keypath subscript, we expect the base to be invariant so that we can project an lvalue. But a `KeyPath` can be applied with a converted base. Previously, enumerating supertypes served as a sort of disjunction here, attempting both possibilities when solving the keypath subscript. I replcaed this with a hack, which does a bit of lookahead to guess if the base should be converted or not. This won't work if the constraint system is sufficiently abstract that the types involved are type variables at the time, but it seems to be sufficient in the examples I've seen so far.

### Order dependency with member reference expression

The following expression no longer type checks:
```
class Base {
  var next: Base?
}
class Derived: Base {}

func g<T>(_: T, _: (T) -> T?) {}

func f1(d: Derived) {
  g(d, { $0.next })
  // expected-error@-1 {{cannot convert value of type 'Base?' to closure result type 'Derived?'}}
}
```
The reason this worked in the first place is we would attempt binding `T` to `Base` after the binding to `Derived` failed. There's no way to solve this expression without this form of backtracking, because the member reference cannot be resolved until we bind a fixed type to the base; we don't do any speculative resolution based on supertype bindings or anything like that.

When supertype enumeration is off, you need to upcast the base explicitly, like `g(d as Base, { $0.next })`.

### Switch statement with unreachable cases

In this example, disabling supertype enumeration makes us diagnose the two cases in the switch that have the wrong type, because `Second` is actually disjoint from the type of the expression being switched over, which is `First`:
```
func f1(_ property: First) {
  switch property {
  case .property1: break
  case .property2: break // expected-error {{member 'property2' in 'First' produces result of type 'Second<Int>', but context expects 'First'}}
  case .property3: break // expected-error {{member 'property3' in 'First' produces result of type 'Second<Bool>', but context expects 'First'}}
  case .property4: break
  default: break
  }
}
class Base: Equatable {
  static func ==(_: Base, _: Base) -> Bool {
    fatalError()
  }

  static let property1 = First()
  static let property2 = Second<Int>()
  static let property3 = Second<Bool>()
  static let property4 = First()
}

class First: Base {}
class Second<Value>: Base {}
```

This only worked because the first attempt to bind the type of `property` to `First` would fail, and then we would try `Base`.

It is technically possible to have valid code written this way, if the implementation of `Base.==` can return true even when the two sides are instances of different subclasses. If this behavior is truly desired, the switch needs an upcast, like `switch property as Base`.

### Keypath with invalid root type

With supertype enumeration off, we no longer accept this example:
```
func f<T: AnyObject, U>(_: T, _: ReferenceWritableKeyPath<T, U>, _: U) {}
func f<T, U>(_: inout T, _: WritableKeyPath<T, U>, _: U) {}

class D {}
class E: C {}

class C {
  var d: AnyObject?

  func g(d: D) {
    f(self, \E.d, d)
  }
}
```

The key path expression `\E.d` is invalid, because `self` has type `C` here, not `E`.