### PR TITLE
Basic: Add support for `#if os(anyAppleOS)`

### DIFF
--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -263,12 +263,8 @@ LangOptions::getPlatformConditionValue(PlatformConditionKind Kind) const {
 
 bool LangOptions::
 checkPlatformCondition(PlatformConditionKind Kind, StringRef Value) const {
-  // Note: BridgedASTContext_enumerateBuildConfigurationEntries has a redundant
+  // Note: BridgedLangOptions_enumerateBuildConfigurationEntries has a redundant
   // copy of these special cases.
-
-  // Check a special case that "macOS" is an alias of "OSX".
-  if (Kind == PlatformConditionKind::OS && Value == "macOS")
-    return checkPlatformCondition(Kind, "OSX");
 
   // When compiling for iOS we consider "macCatalyst" to be a
   // synonym of "macabi". This enables the use of
@@ -523,24 +519,31 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
 
   bool UnsupportedOS = false;
 
+  auto addAppleOSPlatformConditionValues =
+      [this](ArrayRef<StringRef> platforms) {
+        for (auto platform : platforms) {
+          addPlatformConditionValue(PlatformConditionKind::OS, platform);
+        }
+        addPlatformConditionValue(PlatformConditionKind::OS, "anyAppleOS");
+      };
+
   // Set the "os" platform condition.
   switch (Target.getOS()) {
   case llvm::Triple::Darwin:
   case llvm::Triple::MacOSX:
-    addPlatformConditionValue(PlatformConditionKind::OS, "OSX");
+    addAppleOSPlatformConditionValues({"OSX", "macOS"});
     break;
   case llvm::Triple::TvOS:
-    addPlatformConditionValue(PlatformConditionKind::OS, "tvOS");
+    addAppleOSPlatformConditionValues({"tvOS"});
     break;
   case llvm::Triple::WatchOS:
-    addPlatformConditionValue(PlatformConditionKind::OS, "watchOS");
+    addAppleOSPlatformConditionValues({"watchOS"});
     break;
   case llvm::Triple::IOS:
-    addPlatformConditionValue(PlatformConditionKind::OS, "iOS");
+    addAppleOSPlatformConditionValues({"iOS"});
     break;
   case llvm::Triple::XROS:
-    addPlatformConditionValue(PlatformConditionKind::OS, "xrOS");
-    addPlatformConditionValue(PlatformConditionKind::OS, "visionOS");
+    addAppleOSPlatformConditionValues({"xrOS", "visionOS"});
     break;
   case llvm::Triple::Firmware:
     addPlatformConditionValue(PlatformConditionKind::OS, "Firmware");

--- a/lib/Basic/LangOptionsBridging.cpp
+++ b/lib/Basic/LangOptionsBridging.cpp
@@ -191,12 +191,6 @@ void BridgedLangOptions_enumerateBuildConfigurationEntries(
     switch (kind) {
       case PlatformConditionKind::OS:
         callback(cLangOpts, callbackContext, BCKTargetOSName, StringRef(value));
-
-        // Special case that macOS is an alias of OSX.
-        if (value == "OSX") {
-          callback(cLangOpts, callbackContext, BCKTargetOSName,
-                   StringRef("macOS"));
-        }
         break;
 
       case PlatformConditionKind::Arch:

--- a/test/Parse/ConditionalCompilation/aarch64AndroidTarget.swift
+++ b/test/Parse/ConditionalCompilation/aarch64AndroidTarget.swift
@@ -1,8 +1,8 @@
 // RUN: %swift -typecheck %s -verify -target aarch64-unknown-linux-android -disable-objc-interop -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target aarch64-unknown-linux-android
 
-#if os(Linux)
-// This block should not parse.
+#if os(Linux) || os(anyAppleOS)
+// This block should not be type checked.
 // os(Android) does not imply os(Linux).
 let i: Int = "Hello"
 #endif

--- a/test/Parse/ConditionalCompilation/arm64AppleTVOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/arm64AppleTVOSTarget.swift
@@ -2,7 +2,7 @@
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target arm64-apple-tvos9.0
 
 #if os(iOS)
-// This block should not parse.
+// This block should not be type checked.
 // os(tvOS) or os(watchOS) does not imply os(iOS).
 let i: Int = "Hello"
 #endif
@@ -14,3 +14,9 @@ var x = C()
 #endif
 #endif
 var y = x
+
+#if os(anyAppleOS)
+// os(tvOS) implies os(anyAppleOS)
+func hasAnyAppleOS() { }
+#endif
+hasAnyAppleOS()

--- a/test/Parse/ConditionalCompilation/arm64IOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/arm64IOSTarget.swift
@@ -2,7 +2,7 @@
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target arm64-apple-ios7.0
 
 #if os(tvOS) || os(watchOS)
-// This block should not parse.
+// This block should not be type checked.
 // os(iOS) does not imply os(TVOS) or os(watchOS).
 let i: Int = "Hello"
 #endif
@@ -14,3 +14,9 @@ var x = C()
 #endif
 #endif
 var y = x
+
+#if os(anyAppleOS)
+// os(iOS) implies os(anyAppleOS)
+func hasAnyAppleOS() { }
+#endif
+hasAnyAppleOS()

--- a/test/Parse/ConditionalCompilation/armAndroidTarget.swift
+++ b/test/Parse/ConditionalCompilation/armAndroidTarget.swift
@@ -1,8 +1,8 @@
 // RUN: %swift -typecheck %s -verify -target armv7-unknown-linux-androideabi -disable-objc-interop -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target armv7-unknown-linux-androideabi
 
-#if os(Linux)
-// This block should not parse.
+#if os(Linux) || os(anyAppleOS)
+// This block should not be type checked.
 // os(Android) does not imply os(Linux).
 let i: Int = "Hello"
 #endif

--- a/test/Parse/ConditionalCompilation/armIOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/armIOSTarget.swift
@@ -2,7 +2,7 @@
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target arm-apple-ios7.0
 
 #if os(tvOS) || os(watchOS)
-// This block should not parse.
+// This block should not be type checked.
 // os(iOS) does not imply os(tvOS) or os(watchOS).
 let i: Int = "Hello"
 #endif
@@ -14,3 +14,9 @@ var x = C()
 #endif
 #endif
 var y = x
+
+#if os(anyAppleOS)
+// os(iOS) implies os(anyAppleOS)
+func hasAnyAppleOS() { }
+#endif
+hasAnyAppleOS()

--- a/test/Parse/ConditionalCompilation/armWatchOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/armWatchOSTarget.swift
@@ -2,7 +2,7 @@
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target arm-apple-watchos2.0
 
 #if os(iOS)
-// This block should not parse.
+// This block should not be type checked.
 // os(tvOS) or os(watchOS) does not imply os(iOS).
 let i: Int = "Hello"
 #endif
@@ -14,3 +14,9 @@ var x = C()
 #endif
 #endif
 var y = x
+
+#if os(anyAppleOS)
+// os(watchOS) implies os(anyAppleOS)
+func hasAnyAppleOS() { }
+#endif
+hasAnyAppleOS()

--- a/test/Parse/ConditionalCompilation/i386AppleTVOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/i386AppleTVOSTarget.swift
@@ -2,7 +2,7 @@
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target i386-apple-tvos9.0
 
 #if os(iOS)
-// This block should not parse.
+// This block should not be type checked.
 // os(tvOS) or os(watchOS) does not imply os(iOS).
 let i: Int = "Hello"
 #endif
@@ -14,3 +14,9 @@ var x = C()
 #endif
 #endif
 var y = x
+
+#if os(anyAppleOS)
+// os(tvOS) implies os(anyAppleOS)
+func hasAnyAppleOS() { }
+#endif
+hasAnyAppleOS()

--- a/test/Parse/ConditionalCompilation/i386IOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/i386IOSTarget.swift
@@ -2,7 +2,7 @@
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target i386-apple-ios7.0
 
 #if os(tvOS) || os(watchOS)
-// This block should not parse.
+// This block should not be type checked.
 // os(tvOS) or os(watchOS) does not imply os(iOS).
 let i: Int = "Hello"
 #endif
@@ -14,3 +14,9 @@ var x = C()
 #endif
 #endif
 var y = x
+
+#if os(anyAppleOS)
+// os(iOS) implies os(anyAppleOS)
+func hasAnyAppleOS() { }
+#endif
+hasAnyAppleOS()

--- a/test/Parse/ConditionalCompilation/i386WatchOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/i386WatchOSTarget.swift
@@ -2,7 +2,7 @@
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target i386-apple-watchos2.0
 
 #if os(iOS)
-// This block should not parse.
+// This block should not be type checked.
 // os(tvOS) or os(watchOS) does not imply os(iOS).
 let i: Int = "Hello"
 #endif
@@ -14,3 +14,9 @@ var x = C()
 #endif
 #endif
 var y = x
+
+#if os(anyAppleOS)
+// os(watchOS) implies os(anyAppleOS)
+func hasAnyAppleOS() { }
+#endif
+hasAnyAppleOS()

--- a/test/Parse/ConditionalCompilation/simulatorTargetEnv.swift
+++ b/test/Parse/ConditionalCompilation/simulatorTargetEnv.swift
@@ -3,7 +3,7 @@
 // RUN: %swift-ide-test -swift-version 4 -test-input-complete -source-filename=%s -target x86_64-apple-ios7.0-simulator
 
 #if !targetEnvironment(simulator)
-// This block should not parse.
+// This block should not be type checked.
 let i: Int = "Hello"
 #endif
 

--- a/test/Parse/ConditionalCompilation/x64AppleTVOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64AppleTVOSTarget.swift
@@ -2,7 +2,7 @@
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target x86_64-apple-tvos9.0
 
 #if os(iOS)
-// This block should not parse.
+// This block should not be type checked.
 // os(tvOS) or os(watchOS) does not imply os(iOS).
 let i: Int = "Hello"
 #endif
@@ -14,3 +14,8 @@ var x = C()
 #endif
 #endif
 var y = x
+
+#if os(anyAppleOS)
+func hasAnyAppleOS() { }
+#endif
+hasAnyAppleOS()

--- a/test/Parse/ConditionalCompilation/x64IOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64IOSTarget.swift
@@ -2,7 +2,7 @@
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target x86_64-apple-ios7.0
 
 #if os(tvOS) || os(watchOS)
-// This block should not parse.
+// This block should not be type checked.
 // os(tvOS) or os(watchOS) does not imply os(iOS).
 let i: Int = "Hello"
 #endif
@@ -14,3 +14,8 @@ var x = C()
 #endif
 #endif
 var y = x
+
+#if os(anyAppleOS)
+func hasAnyAppleOS() { }
+#endif
+hasAnyAppleOS()

--- a/test/Parse/ConditionalCompilation/x86_64PS4Target.swift
+++ b/test/Parse/ConditionalCompilation/x86_64PS4Target.swift
@@ -2,7 +2,7 @@
 // RUN: %swift-ide-test -test-input-complete -source-filename %s -target x86_64-scei-ps4
 
 #if os(FreeBSD)
-// This block should not parse.
+// This block should not be type checked.
 // os(FreeBSD) does not imply os(PS4)
 let i: Int = "Hello"
 #endif


### PR DESCRIPTION
As a complement to `@available(anyAppleOS ...)`, evaluate `#if os(anyAppleOS)` to true when targeting Apple's operating systems.

Resolves rdar://172747814.
