### PR TITLE
[update-checkout] make --max-retries default to 3

### DIFF
--- a/utils/update_checkout/tests/test_clone.py
+++ b/utils/update_checkout/tests/test_clone.py
@@ -189,6 +189,38 @@ class CloneTestCase(scheme_mock.SchemeMockTestCase):
 
     @patch("update_checkout.update_checkout.obtain_all_additional_swift_sources")
     @patch("sys.exit", return_value=None)
+    def test_clone_retry_on_exception(self, mock_exit, mock_obtain):
+        """Test that an exception (e.g. concurrent.futures.TimeoutError) is
+        retried rather than propagating and crashing the process."""
+        import concurrent.futures
+
+        call_count = [0]
+
+        def side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] <= 1:
+                raise concurrent.futures.TimeoutError()
+            return obtain_all_additional_swift_sources(*args, **kwargs)
+
+        mock_obtain.side_effect = side_effect
+
+        sys.argv = [
+            "update-checkout",
+            "--config",
+            self.config_path,
+            "--source-root",
+            self.source_root,
+            "--clone",
+            "--max-retries",
+            "1",
+        ]
+        with contextlib.redirect_stdout(StringIO()):
+            main()
+
+        self.assertEqual(call_count[0], 2)
+
+    @patch("update_checkout.update_checkout.obtain_all_additional_swift_sources")
+    @patch("sys.exit", return_value=None)
     def test_clone_with_retry(self, mock_exit, mock_obtain):
         call_count = [0]
 

--- a/utils/update_checkout/update_checkout/cli_arguments.py
+++ b/utils/update_checkout/update_checkout/cli_arguments.py
@@ -136,7 +136,7 @@ repositories.
             " cloning of any repository failed. 0 for no retries, -1 for"
             " unlimited retries.",
             type=int,
-            default=0,
+            default=3,
         )
         parser.add_argument(
             "-j",

--- a/utils/update_checkout/update_checkout/retry.py
+++ b/utils/update_checkout/update_checkout/retry.py
@@ -2,7 +2,8 @@ import time
 import functools
 from typing import Callable, TypeVar, Any
 
-T = TypeVar('T')
+T = TypeVar("T")
+
 
 def exponential_retry(
     max_retries: int = 3,
@@ -11,39 +12,52 @@ def exponential_retry(
 ):
     """
     Retries with exponential backoff if the method returns a value > 0.
-    
+
     Args:
         max_retries (int): Maximum number of retry attempts. 0 is for no
                            retries, -1 is for an unlimited amount.
         base_delay (float): Initial delay in seconds.
         max_delay (float): Maximum delay between retries in seconds.
     """
+
     def decorator(func: Callable[..., T]) -> Callable[..., T]:
         @functools.wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> T:
             retries = 0
-            
+
             while max_retries == -1 or retries <= max_retries:
-                fail_count = func(*args, **kwargs)
-                
-                if fail_count <= 0:
+                caught_exception = None
+                try:
+                    fail_count = func(*args, **kwargs)
+                except Exception as e:
+                    caught_exception = e
+                    fail_count = 1
+
+                if caught_exception is None and fail_count <= 0:
                     return fail_count
-                
+
                 if retries == max_retries:
+                    if caught_exception is not None:
+                        raise caught_exception
                     return fail_count
-                
-                delay = min(base_delay * (4 ** retries), max_delay)
-                
-                print(f"Retry {retries + 1}/{max_retries}: There were {fail_count} failure", end="")
-                if fail_count > 1:
-                    print("s", end="")
-                print(".")
+
+                delay = min(base_delay * (4**retries), max_delay)
+
+                if caught_exception is not None:
+                    print(
+                        f"Retry {retries + 1}/{max_retries}: Caught exception: {caught_exception}"
+                    )
+                else:
+                    print(
+                        f"Retry {retries + 1}/{max_retries}: There were {fail_count} failure{'s' if fail_count > 1 else ''}."
+                    )
                 print(f"Waiting {delay:.2f}s before retrying...")
-                
+
                 time.sleep(delay)
                 retries += 1
-            
+
             return fail_count
-        
+
         return wrapper
+
     return decorator


### PR DESCRIPTION
Increase the default value of the `--max-retries` flag in `update-checkout` from 0 to 3.

This patch makes `update-checkout` retry exponentially 3 times if a failure is detected. This will allow to re-run PR tests if they fail due to a transitive network failure.