### PR TITLE
update_checkout: bump brotli to 1.2.0

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -195,7 +195,7 @@
                 "curl": "curl-8_9_1",
                 "libxml2": "v2.11.5",
                 "zlib": "v1.3.1",
-                "brotli": "v1.1.0",
+                "brotli": "v1.2.0",
                 "mimalloc": "v3.0.3",
                 "swift-subprocess": "0.3",
                 "boringssl": "817ab07ebb53da35afea409ab9328f578492832d"
@@ -689,7 +689,7 @@
                 "curl": "curl-8_9_1",
                 "libxml2": "v2.11.5",
                 "zlib": "v1.3.1",
-                "brotli": "v1.1.0",
+                "brotli": "v1.2.0",
                 "mimalloc": "v3.0.3",
                 "swift-subprocess": "0.3"
             }
@@ -750,7 +750,7 @@
                 "curl": "curl-8_9_1",
                 "libxml2": "v2.11.5",
                 "zlib": "v1.3.1",
-                "brotli": "v1.1.0",
+                "brotli": "v1.2.0",
                 "mimalloc": "v3.0.3",
                 "swift-subprocess": "0.3"
             }


### PR DESCRIPTION
This updates the brotli checkout to 1.2.0 which includes fixes from upstream and allows us to trim the build a slight bit.