### PR TITLE
SimplifyApply: insert the correct cast instruction when propagating the concrete type of an existential

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyApply.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyApply.swift
@@ -173,12 +173,14 @@ private func tryReplaceExistentialArchetype(of apply: ApplyInst, _ context: Simp
   if let concreteType = apply.concreteTypeOfDependentExistentialArchetype,
      apply.canReplaceExistentialArchetype()
   {
+    let newArgs = apply.replaceExistentialArchetypeInArguments(withConcreteType: concreteType, context)
+
     let builder = Builder(after: apply, context)
 
     let newApply = builder.createApply(
       function: apply.callee,
       apply.replaceOpenedArchetypeInSubstitutions(withConcreteType: concreteType, context),
-      arguments: apply.replaceExistentialArchetypeInArguments(withConcreteType: concreteType, context),
+      arguments: newArgs,
       isNonThrowing: apply.isNonThrowing, isNonAsync: apply.isNonAsync,
       specializationInfo: apply.specializationInfo)
     apply.replace(with: newApply, context)
@@ -193,12 +195,14 @@ private func tryReplaceExistentialArchetype(of tryApply: TryApplyInst, _ context
   if let concreteType = tryApply.concreteTypeOfDependentExistentialArchetype,
      tryApply.canReplaceExistentialArchetype()
   {
+    let newArgs = tryApply.replaceExistentialArchetypeInArguments(withConcreteType: concreteType, context)
+
     let builder = Builder(before: tryApply, context)
 
     builder.createTryApply(
       function: tryApply.callee,
       tryApply.replaceOpenedArchetypeInSubstitutions(withConcreteType: concreteType, context),
-      arguments: tryApply.replaceExistentialArchetypeInArguments(withConcreteType: concreteType, context),
+      arguments: newArgs,
       normalBlock: tryApply.normalBlock, errorBlock: tryApply.errorBlock,
       isNonAsync: tryApply.isNonAsync,
       specializationInfo: tryApply.specializationInfo)
@@ -250,13 +254,26 @@ private extension FullApplySite {
     withConcreteType concreteType: CanonicalType,
     _ context: SimplifyContext
   ) -> [Value] {
-    let newArgs = arguments.map { (arg) -> Value in
+    let newArgs = argumentOperands.map { (argOp) -> Value in
+      let arg = argOp.value
       if arg.type.isExistentialArchetype {
         // case 1. the argument _is_ the existential archetype:
         //         just insert an address cast to satisfy type equivalence.
         let builder = Builder(before: self, context)
         let concreteSILType = concreteType.loweredType(in: self.parentFunction)
-        return builder.createUncheckedAddrCast(from: arg, to: concreteSILType.addressType)
+        if arg.type.isAddress {
+          return builder.createUncheckedAddrCast(from: arg, to: concreteSILType.addressType)
+        } else {
+          if convention(of: argOp) == .directGuaranteed, arg.ownership == .owned {
+            let beginBorrow = builder.createBeginBorrow(of: arg)
+            Builder.insert(after: self, location: self.location, context) { endBuilder in
+              endBuilder.createEndBorrow(of: beginBorrow)
+            }
+            return builder.createUncheckedRefCast(from: beginBorrow, to: concreteSILType)
+          } else {
+            return builder.createUncheckedRefCast(from: arg, to: concreteSILType)
+          }
+        }
       }
       if arg.type.isMetatype, arg.type.canonicalType.instanceTypeOfMetatype.isExistentialArchetype {
         // case 2. the argument _is_ a metatype of the existential archetype:

--- a/test/SILOptimizer/simplify_apply.sil
+++ b/test/SILOptimizer/simplify_apply.sil
@@ -44,6 +44,11 @@ public struct S2: P2 {
   }
 }
 
+protocol CP : AnyObject {
+}
+
+final class C : CP {
+}
 
 sil @cl : $@convention(thin) () -> Int
 
@@ -227,5 +232,71 @@ bb0(%0 : $E, %1 : $E):
   %2 = function_ref @rawrepresentable_is_equal_wrong_convention : $@convention(thin) (E, E) -> Bool
   %3 = apply %2(%0, %1) : $@convention(thin) (E, E) -> Bool
   return %3
+}
+
+sil @callee_guaranteed : $@convention(thin) <τ_0_0 where τ_0_0 : CP> (@guaranteed τ_0_0) -> ()
+sil @callee_owned : $@convention(thin) <τ_0_0 where τ_0_0 : CP> (@owned τ_0_0) -> ()
+
+// CHECK-LABEL: sil @propagate_class_existential_non_ossa :
+// CHECKO:         [[E:%.*]] = end_init_let_ref
+// CHECKO:         [[C:%.*]] = unchecked_ref_cast [[E]] to $@opened
+// CHECKO:         [[C2:%.*]] = unchecked_ref_cast [[C]] to $C
+// CHECKO:         apply {{%[0-9]+}}<C>([[C2]])
+// CHECK:       } // end sil function 'propagate_class_existential_non_ossa'
+sil @propagate_class_existential_non_ossa : $@convention(thin) () -> () {
+bb0:
+  %0 = metatype $@thick C.Type
+  %1 = init_existential_metatype %0, $@thick any CP.Type
+  %2 = open_existential_metatype %1 to $@thick (@opened("A3FC8EAA-2207-11F1-A49D-0EA13E3AABB3", any CP) Self).Type
+  %3 = alloc_ref $C
+  %4 = end_init_let_ref %3
+  %5 = unchecked_ref_cast %4 to $@opened("A3FC8EAA-2207-11F1-A49D-0EA13E3AABB3", any CP) Self
+  %6 = function_ref @callee_guaranteed : $@convention(thin) <τ_0_0 where τ_0_0 : CP> (@guaranteed τ_0_0) -> ()
+  %7 = apply %6<@opened("A3FC8EAA-2207-11F1-A49D-0EA13E3AABB3", any CP) Self>(%5) : $@convention(thin) <τ_0_0 where τ_0_0 : CP> (@guaranteed τ_0_0) -> ()
+  %8 = tuple ()
+  return %8
+}
+
+// CHECK-LABEL: sil [ossa] @propagate_class_existential :
+// CHECKO:         [[E:%.*]] = end_init_let_ref
+// CHECKO:         [[C:%.*]] = unchecked_ref_cast [[E]] to $@opened
+// CHECKO:         [[B:%.*]] = begin_borrow [[C]]
+// CHECKO:         [[C2:%.*]] = unchecked_ref_cast [[B]] to $C
+// CHECKO:         apply {{%[0-9]+}}<C>([[C2]])
+// CHECKO-NEXT:    end_borrow [[B]]
+// CHECK:       } // end sil function 'propagate_class_existential'
+sil [ossa] @propagate_class_existential : $@convention(thin) () -> () {
+bb0:
+  %0 = metatype $@thick C.Type
+  %1 = init_existential_metatype %0, $@thick any CP.Type
+  %2 = open_existential_metatype %1 to $@thick (@opened("A3FC8EAA-2207-11F1-A49D-0EA13E3AABB3", any CP) Self).Type
+  %3 = alloc_ref $C
+  %4 = end_init_let_ref %3
+  %5 = unchecked_ref_cast %4 to $@opened("A3FC8EAA-2207-11F1-A49D-0EA13E3AABB3", any CP) Self
+  %6 = function_ref @callee_guaranteed : $@convention(thin) <τ_0_0 where τ_0_0 : CP> (@guaranteed τ_0_0) -> ()
+  %7 = apply %6<@opened("A3FC8EAA-2207-11F1-A49D-0EA13E3AABB3", any CP) Self>(%5) : $@convention(thin) <τ_0_0 where τ_0_0 : CP> (@guaranteed τ_0_0) -> ()
+  destroy_value %5
+  %9 = tuple ()
+  return %9
+}
+
+// CHECK-LABEL: sil [ossa] @propagate_class_existential_owned :
+// CHECKO:         [[E:%.*]] = end_init_let_ref
+// CHECKO:         [[C:%.*]] = unchecked_ref_cast [[E]] to $@opened
+// CHECKO:         [[C2:%.*]] = unchecked_ref_cast [[C]] to $C
+// CHECKO:         apply {{%[0-9]+}}<C>([[C2]])
+// CHECKO:       } // end sil function 'propagate_class_existential_owned'
+sil [ossa] @propagate_class_existential_owned : $@convention(thin) () -> () {
+bb0:
+  %0 = metatype $@thick C.Type
+  %1 = init_existential_metatype %0, $@thick any CP.Type
+  %2 = open_existential_metatype %1 to $@thick (@opened("A3FC8EAA-2207-11F1-A49D-0EA13E3AABB3", any CP) Self).Type
+  %3 = alloc_ref $C
+  %4 = end_init_let_ref %3
+  %5 = unchecked_ref_cast %4 to $@opened("A3FC8EAA-2207-11F1-A49D-0EA13E3AABB3", any CP) Self
+  %6 = function_ref @callee_owned : $@convention(thin) <τ_0_0 where τ_0_0 : CP> (@owned τ_0_0) -> ()
+  %7 = apply %6<@opened("A3FC8EAA-2207-11F1-A49D-0EA13E3AABB3", any CP) Self>(%5) : $@convention(thin) <τ_0_0 where τ_0_0 : CP> (@owned τ_0_0) -> ()
+  %9 = tuple ()
+  return %9
 }
 

--- a/test/SILOptimizer/simplify_try_apply.sil
+++ b/test/SILOptimizer/simplify_try_apply.sil
@@ -28,6 +28,12 @@ struct GenError<T>: Error {
   var x: Int
 }
 
+protocol CP : AnyObject {
+}
+
+final class C : CP {
+}
+
 // CHECK-LABEL: sil @devirt_class_method :
 // CHECK:         [[F:%.*]] = function_ref @bar_foo
 // CHECK:         try_apply [[F]]
@@ -117,3 +123,39 @@ bb2(%10 : $GenError<@opened("0FC03D78-E9DB-11EF-B47C-0EA13E3AABB3", any P) Self>
   unreachable
 }
 
+sil @callee_guaranteed : $@convention(thin) <τ_0_0 where τ_0_0 : CP> (@guaranteed τ_0_0) -> (Int, @error any Error)
+
+// CHECK-LABEL: sil [ossa] @propagate_class_existential :
+// CHECKO:         [[E:%.*]] = end_init_let_ref
+// CHECKO:         [[C:%.*]] = unchecked_ref_cast [[E]] to $@opened
+// CHECKO:         [[B:%.*]] = begin_borrow [[C]]
+// CHECKO:         [[C2:%.*]] = unchecked_ref_cast [[B]] to $C
+// CHECKO:         try_apply {{%[0-9]+}}<C>([[C2]])
+// CHECKO:       bb1({{.*}}):
+// CHECKO-NEXT:    end_borrow [[B]]
+// CHECKO:       bb2({{.*}}):
+// CHECKO-NEXT:    end_borrow [[B]]
+// CHECK:       } // end sil function 'propagate_class_existential'
+sil [ossa] @propagate_class_existential : $@convention(thin) () -> () {
+bb0:
+  %0 = metatype $@thick C.Type
+  %1 = init_existential_metatype %0, $@thick any CP.Type
+  %2 = open_existential_metatype %1 to $@thick (@opened("A3FC8EAA-2207-11F1-A49D-0EA13E3AABB3", any CP) Self).Type
+  %3 = alloc_ref $C
+  %4 = end_init_let_ref %3
+  %5 = unchecked_ref_cast %4 to $@opened("A3FC8EAA-2207-11F1-A49D-0EA13E3AABB3", any CP) Self
+  %6 = function_ref @callee_guaranteed : $@convention(thin) <τ_0_0 where τ_0_0 : CP> (@guaranteed τ_0_0) -> (Int, @error any Error)
+  try_apply %6<@opened("A3FC8EAA-2207-11F1-A49D-0EA13E3AABB3", any CP) Self>(%5) : $@convention(thin) <τ_0_0 where τ_0_0 : CP> (@guaranteed τ_0_0) -> (Int, @error any Error), normal bb1, error bb2
+
+bb1(%8: $Int):
+  br bb3
+
+bb2(%10 : $Error):
+  destroy_value %10
+  br bb3
+
+bb3:
+  destroy_value %5
+  %9 = tuple ()
+  return %9
+}


### PR DESCRIPTION
When propagating a concrete type of an existential to an apply/try_apply instruction, we need to insert either an `unchecked_addr_cast` for address-only (= general) existentials or an `unchecked_ref_cast` for class existentials.

Fixes a SIL verification crash
rdar://172758483
