### PR TITLE
Fix ConditionForwarding OSSA violation with guaranteed forwarding results from local borrow scopes

### DIFF
--- a/lib/SILOptimizer/Transforms/ConditionForwarding.cpp
+++ b/lib/SILOptimizer/Transforms/ConditionForwarding.cpp
@@ -256,12 +256,20 @@ bool ConditionForwarding::tryOptimize(SwitchEnumInst *SEI) {
     return false;
 
   if (getFunction()->hasOwnership()) {
-    // TODO: Currently disabled because this case may need lifetime extension
-    // Disabling this conservatively for now.
+    // The terminator's condition will be moved to the location of the
+    // switch_enum. If the condition's operand is within a local borrow scope,
+    // moving it may violate OSSA lifetime rules.
     assert(Condition->getNumRealOperands() == 1);
-    BorrowedValue conditionOp(Condition->getOperand(0));
-    if (conditionOp && conditionOp.isLocalScope()) {
-      return false;
+    SILValue condOp = Condition->getOperand(0);
+    if (condOp->getOwnershipKind() == OwnershipKind::Guaranteed) {
+      if (!visitBorrowIntroducers(condOp, [&](SILValue introducer) {
+        if (BorrowedValue(introducer).isLocalScope()) {
+          return false;
+        }
+        return true;
+      })) {
+        return false;
+      }
     }
   }
   // Now do the transformation!

--- a/test/SILOptimizer/conditionforwarding_nontrivial_ossa.sil
+++ b/test/SILOptimizer/conditionforwarding_nontrivial_ossa.sil
@@ -433,3 +433,43 @@ bb6(%15 : @guaranteed $Optional<Klass>):
   %17 = copy_value %16
   return %17
 }
+
+struct Wrapper {
+  var value: E3
+}
+
+// CHECK-LABEL: sil [ossa] @no_forwarding_struct_extract_from_borrow :
+// CHECK: switch_enum
+// CHECK: switch_enum
+// CHECK-LABEL: } // end sil function 'no_forwarding_struct_extract_from_borrow'
+sil [ossa] @no_forwarding_struct_extract_from_borrow : $@convention(thin) (@owned Wrapper) -> () {
+bb0(%0 : @owned $Wrapper):
+  %borrow = begin_borrow %0 : $Wrapper
+  %value = struct_extract %borrow : $Wrapper, #Wrapper.value
+  switch_enum %value : $E3, case #E3.A!enumelt: bb1, default bb2
+
+bb1(%a : @guaranteed $Klass):
+  %e1 = enum $FakeOptional<Klass>, #FakeOptional.none!enumelt
+  br bb3(%e1 : $FakeOptional<Klass>)
+
+bb2(%c : @guaranteed $E3):
+  %e2 = enum $FakeOptional<Klass>, #FakeOptional.none!enumelt
+  br bb3(%e2 : $FakeOptional<Klass>)
+
+bb3(%14 : $FakeOptional<Klass>):
+  %15 = function_ref @callee : $@convention(thin) () -> ()
+  %16 = apply %15() : $@convention(thin) () -> ()
+  end_borrow %borrow : $Wrapper
+  destroy_value %0 : $Wrapper
+  switch_enum %14 : $FakeOptional<Klass>, case #FakeOptional.some!enumelt: bb4, case #FakeOptional.none!enumelt: bb5
+
+bb4(%some : $Klass):
+  br bb6
+
+bb5:
+  br bb6
+
+bb6:
+  %r = tuple ()
+  return %r : $()
+}


### PR DESCRIPTION
ConditionForwarding moves a condition terminator down to a switch_enum. The existing OSSA check only verified if the condition's operand was directly a BorrowedValue with a local scope, but missed cases where the operand is a guaranteed forwarding result from a local borrow scope. This caused the switch_enum to be moved past the end_borrow, producing an outside-of-lifetime use.

Use `visitBorrowIntroducers` to walk through forwarding instructions and find the actual borrow introducers, then bail out if any of them is a local scope.

Resolves rdar://172697777
