### PR TITLE
[SILOptimizer] Fix ConstantCapturePropagation ODR violation with generic closures

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ConstantCapturePropagation.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ConstantCapturePropagation.swift
@@ -172,9 +172,17 @@ private func specializeClosure(specializedName: String,
                                                                         preserveGenericSignature: isGeneric)
 
   context.buildSpecializedFunction(specializedFunction: specializedClosure) { (specializedClosure, specContext) in
-    cloneAndSpecializeFunction(from: callee, toEmpty: specializedClosure,
-                               substitutions: partialApply.substitutionMap,
-                               specContext)
+    if isGeneric {
+      // When the specialized closure is still generic, clone without type substitutions.
+      // The mangled name only encodes constant values, not type substitutions, so the body
+      // must stay generic to avoid ODR violations when different concrete types produce the
+      // same symbol but with different type-substituted bodies.
+      cloneFunction(from: callee, toEmpty: specializedClosure, specContext)
+    } else {
+      cloneAndSpecializeFunction(from: callee, toEmpty: specializedClosure,
+                                 substitutions: partialApply.substitutionMap,
+                                 specContext)
+    }
 
     let entryBlock = specializedClosure.entryBlock
     for constArgOp in constantArguments {
@@ -235,7 +243,7 @@ private func rewritePartialApply(_ partialApply: PartialApplyInst, withSpecializ
   let builder = Builder(before: partialApply, context)
   let fri = builder.createFunctionRef(specialized)
   let newClosure: Value
-  if arguments.isEmpty, fri.type.functionTypeRepresentation == .thin {
+  if arguments.isEmpty, specialized.genericSignature.isEmpty, fri.type.functionTypeRepresentation == .thin {
     newClosure = builder.createThinToThickFunction(thinFunction: fri, resultType: partialApply.type)
     context.erase(instructions: partialApply.uses.users(ofType: DeallocStackInst.self))
   } else {

--- a/test/SILOptimizer/constant_capture_propagation_odr.sil
+++ b/test/SILOptimizer/constant_capture_propagation_odr.sil
@@ -1,0 +1,72 @@
+// RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all %s -constant-capture-propagation | %FileCheck %s
+
+// Regression test for an ODR violation in ConstantCapturePropagation.
+//
+// When two callers instantiate the same generic closure with different concrete
+// types (UInt8 vs Int) and both have the same constant capture (radix=10),
+// ConstantCapturePropagation must not bake a concrete type into the specialized
+// closure body. The mangled name only encodes the constant arguments, not the
+// type substitutions, and the function gets shared (linkonce_odr) linkage.
+// Baking in a concrete type produces the same symbol with different bodies —
+// an ODR violation.
+//
+// After the fix, the specialized closure body should remain generic, using
+// type parameters like $*Optional<T> instead of $*Optional<UInt8>.
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+// A minimal generic closure that writes to an Optional<T> indirect result.
+sil shared [heuristic_always_inline] @generic_closure : $@convention(thin) <T where T : FixedWidthInteger> (UnsafeBufferPointer<UInt8>, Int) -> @out Optional<T> {
+bb0(%0 : $*Optional<T>, %1 : $UnsafeBufferPointer<UInt8>, %2 : $Int):
+  %3 = alloc_stack $T
+  copy_addr %3 to [init] %0 : $*Optional<T>
+  dealloc_stack %3 : $*T
+  return undef : $()
+}
+
+// caller_uint8: partial_apply generic_closure<UInt8> with constant radix=10.
+// The specialized closure should keep $*T in the body, not $*UInt8.
+//
+// CHECK-LABEL: sil @caller_uint8
+// CHECK:         function_ref @$s15generic_closureSiTf3nnpSi10_n
+// CHECK:       } // end sil function 'caller_uint8'
+sil @caller_uint8 : $@convention(thin) (UnsafeBufferPointer<UInt8>) -> @out Optional<UInt8> {
+bb0(%0 : $*Optional<UInt8>, %1 : $UnsafeBufferPointer<UInt8>):
+  %2 = integer_literal $Builtin.Int64, 10
+  %3 = struct $Int (%2 : $Builtin.Int64)
+  %4 = function_ref @generic_closure : $@convention(thin) <T where T : FixedWidthInteger> (UnsafeBufferPointer<UInt8>, Int) -> @out Optional<T>
+  %5 = partial_apply [callee_guaranteed] %4<UInt8>(%3) : $@convention(thin) <T where T : FixedWidthInteger> (UnsafeBufferPointer<UInt8>, Int) -> @out Optional<T>
+  %6 = apply %5(%0, %1) : $@callee_guaranteed (UnsafeBufferPointer<UInt8>) -> @out Optional<UInt8>
+  %7 = tuple ()
+  return %7 : $()
+}
+
+// caller_int: partial_apply generic_closure<Int> with constant radix=10.
+// Must reuse the same specialized closure. If the body was baked with UInt8,
+// the verifier would catch the type mismatch here.
+//
+// CHECK-LABEL: sil @caller_int
+// CHECK:         function_ref @$s15generic_closureSiTf3nnpSi10_n
+// CHECK:       } // end sil function 'caller_int'
+sil @caller_int : $@convention(thin) (UnsafeBufferPointer<UInt8>) -> @out Optional<Int> {
+bb0(%0 : $*Optional<Int>, %1 : $UnsafeBufferPointer<UInt8>):
+  %2 = integer_literal $Builtin.Int64, 10
+  %3 = struct $Int (%2 : $Builtin.Int64)
+  %4 = function_ref @generic_closure : $@convention(thin) <T where T : FixedWidthInteger> (UnsafeBufferPointer<UInt8>, Int) -> @out Optional<T>
+  %5 = partial_apply [callee_guaranteed] %4<Int>(%3) : $@convention(thin) <T where T : FixedWidthInteger> (UnsafeBufferPointer<UInt8>, Int) -> @out Optional<T>
+  %6 = apply %5(%0, %1) : $@callee_guaranteed (UnsafeBufferPointer<UInt8>) -> @out Optional<Int>
+  %7 = tuple ()
+  return %7 : $()
+}
+
+// The specialized closure must preserve its generic signature. Verify that the
+// body uses $*Optional<T> (generic) rather than $*Optional<UInt8> (concrete).
+//
+// CHECK-LABEL: sil shared {{.*}}@$s15generic_closureSiTf3nnpSi10_n
+// CHECK:         bb0({{.*}} : $*Optional<T>, {{.*}} : $UnsafeBufferPointer<UInt8>):
+// CHECK:           alloc_stack $T
+// CHECK:           copy_addr {{.*}} to [init] {{.*}} : $*Optional<T>
+// CHECK:       } // end sil function '$s15generic_closureSiTf3nnpSi10_n'

--- a/test/SILOptimizer/constant_capture_propagation_odr.sil
+++ b/test/SILOptimizer/constant_capture_propagation_odr.sil
@@ -1,65 +1,17 @@
 // RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all %s -constant-capture-propagation | %FileCheck %s
 
 // Regression test for an ODR violation in ConstantCapturePropagation.
-//
-// When two callers instantiate the same generic closure with different concrete
-// types (UInt8 vs Int) and both have the same constant capture (radix=10),
-// ConstantCapturePropagation must not bake a concrete type into the specialized
-// closure body. The mangled name only encodes the constant arguments, not the
-// type substitutions, and the function gets shared (linkonce_odr) linkage.
-// Baking in a concrete type produces the same symbol with different bodies —
-// an ODR violation.
-//
-// After the fix, the specialized closure body should remain generic, using
-// type parameters like $*Optional<T> instead of $*Optional<UInt8>.
-
-sil_stage canonical
+sil_stage raw
 
 import Builtin
 import Swift
 
 // A minimal generic closure that writes to an Optional<T> indirect result.
-sil shared [heuristic_always_inline] @generic_closure : $@convention(thin) <T where T : FixedWidthInteger> (UnsafeBufferPointer<UInt8>, Int) -> @out Optional<T> {
+sil shared [heuristic_always_inline] [ossa] @generic_closure : $@convention(thin) <T where T : FixedWidthInteger> (UnsafeBufferPointer<UInt8>, Int) -> @out Optional<T> {
 bb0(%0 : $*Optional<T>, %1 : $UnsafeBufferPointer<UInt8>, %2 : $Int):
-  %3 = alloc_stack $T
-  copy_addr %3 to [init] %0 : $*Optional<T>
-  dealloc_stack %3 : $*T
-  return undef : $()
-}
-
-// caller_uint8: partial_apply generic_closure<UInt8> with constant radix=10.
-// The specialized closure should keep $*T in the body, not $*UInt8.
-//
-// CHECK-LABEL: sil @caller_uint8
-// CHECK:         function_ref @$s15generic_closureSiTf3nnpSi10_n
-// CHECK:       } // end sil function 'caller_uint8'
-sil @caller_uint8 : $@convention(thin) (UnsafeBufferPointer<UInt8>) -> @out Optional<UInt8> {
-bb0(%0 : $*Optional<UInt8>, %1 : $UnsafeBufferPointer<UInt8>):
-  %2 = integer_literal $Builtin.Int64, 10
-  %3 = struct $Int (%2 : $Builtin.Int64)
-  %4 = function_ref @generic_closure : $@convention(thin) <T where T : FixedWidthInteger> (UnsafeBufferPointer<UInt8>, Int) -> @out Optional<T>
-  %5 = partial_apply [callee_guaranteed] %4<UInt8>(%3) : $@convention(thin) <T where T : FixedWidthInteger> (UnsafeBufferPointer<UInt8>, Int) -> @out Optional<T>
-  %6 = apply %5(%0, %1) : $@callee_guaranteed (UnsafeBufferPointer<UInt8>) -> @out Optional<UInt8>
-  %7 = tuple ()
-  return %7 : $()
-}
-
-// caller_int: partial_apply generic_closure<Int> with constant radix=10.
-// Must reuse the same specialized closure. If the body was baked with UInt8,
-// the verifier would catch the type mismatch here.
-//
-// CHECK-LABEL: sil @caller_int
-// CHECK:         function_ref @$s15generic_closureSiTf3nnpSi10_n
-// CHECK:       } // end sil function 'caller_int'
-sil @caller_int : $@convention(thin) (UnsafeBufferPointer<UInt8>) -> @out Optional<Int> {
-bb0(%0 : $*Optional<Int>, %1 : $UnsafeBufferPointer<UInt8>):
-  %2 = integer_literal $Builtin.Int64, 10
-  %3 = struct $Int (%2 : $Builtin.Int64)
-  %4 = function_ref @generic_closure : $@convention(thin) <T where T : FixedWidthInteger> (UnsafeBufferPointer<UInt8>, Int) -> @out Optional<T>
-  %5 = partial_apply [callee_guaranteed] %4<Int>(%3) : $@convention(thin) <T where T : FixedWidthInteger> (UnsafeBufferPointer<UInt8>, Int) -> @out Optional<T>
-  %6 = apply %5(%0, %1) : $@callee_guaranteed (UnsafeBufferPointer<UInt8>) -> @out Optional<Int>
-  %7 = tuple ()
-  return %7 : $()
+  inject_enum_addr %0 : $*Optional<T>, #Optional.none!enumelt
+  %3 = tuple ()
+  return %3 : $()
 }
 
 // The specialized closure must preserve its generic signature. Verify that the
@@ -67,6 +19,48 @@ bb0(%0 : $*Optional<Int>, %1 : $UnsafeBufferPointer<UInt8>):
 //
 // CHECK-LABEL: sil shared {{.*}}@$s15generic_closureSiTf3nnpSi10_n
 // CHECK:         bb0({{.*}} : $*Optional<T>, {{.*}} : $UnsafeBufferPointer<UInt8>):
-// CHECK:           alloc_stack $T
-// CHECK:           copy_addr {{.*}} to [init] {{.*}} : $*Optional<T>
+// CHECK:           inject_enum_addr {{.*}} : $*Optional<T>, #Optional.none!enumelt
 // CHECK:       } // end sil function '$s15generic_closureSiTf3nnpSi10_n'
+
+// caller_uint8: partial_apply generic_closure<UInt8> with constant radix=10.
+// The specialized closure should keep generic types in the body, not $*UInt8.
+//
+// CHECK-LABEL: sil [ossa] @caller_uint8
+// CHECK:         function_ref @$s15generic_closureSiTf3nnpSi10_n
+// CHECK:         partial_apply [callee_guaranteed] {{%[0-9]+}}<UInt8>()
+// CHECK:       } // end sil function 'caller_uint8'
+sil [ossa] @caller_uint8 : $@convention(thin) (UnsafeBufferPointer<UInt8>) -> @out Optional<UInt8> {
+bb0(%0 : $*Optional<UInt8>, %1 : $UnsafeBufferPointer<UInt8>):
+  %2 = integer_literal $Builtin.Int64, 10
+  %3 = struct $Int (%2 : $Builtin.Int64)
+  %4 = function_ref @generic_closure : $@convention(thin) <T where T : FixedWidthInteger> (UnsafeBufferPointer<UInt8>, Int) -> @out Optional<T>
+  %5 = partial_apply [callee_guaranteed] %4<UInt8>(%3) : $@convention(thin) <T where T : FixedWidthInteger> (UnsafeBufferPointer<UInt8>, Int) -> @out Optional<T>
+  %6 = begin_borrow %5 : $@callee_guaranteed (UnsafeBufferPointer<UInt8>) -> @out Optional<UInt8>
+  %7 = apply %6(%0, %1) : $@callee_guaranteed (UnsafeBufferPointer<UInt8>) -> @out Optional<UInt8>
+  end_borrow %6 : $@callee_guaranteed (UnsafeBufferPointer<UInt8>) -> @out Optional<UInt8>
+  destroy_value %5 : $@callee_guaranteed (UnsafeBufferPointer<UInt8>) -> @out Optional<UInt8>
+  %10 = tuple ()
+  return %10 : $()
+}
+
+// caller_int: partial_apply generic_closure<Int> with constant radix=10.
+// Must reuse the same specialized closure. If the body was baked with UInt8,
+// the verifier would catch the type mismatch here.
+//
+// CHECK-LABEL: sil [ossa] @caller_int
+// CHECK:         function_ref @$s15generic_closureSiTf3nnpSi10_n
+// CHECK:         partial_apply [callee_guaranteed] {{%[0-9]+}}<Int>()
+// CHECK:       } // end sil function 'caller_int'
+sil [ossa] @caller_int : $@convention(thin) (UnsafeBufferPointer<UInt8>) -> @out Optional<Int> {
+bb0(%0 : $*Optional<Int>, %1 : $UnsafeBufferPointer<UInt8>):
+  %2 = integer_literal $Builtin.Int64, 10
+  %3 = struct $Int (%2 : $Builtin.Int64)
+  %4 = function_ref @generic_closure : $@convention(thin) <T where T : FixedWidthInteger> (UnsafeBufferPointer<UInt8>, Int) -> @out Optional<T>
+  %5 = partial_apply [callee_guaranteed] %4<Int>(%3) : $@convention(thin) <T where T : FixedWidthInteger> (UnsafeBufferPointer<UInt8>, Int) -> @out Optional<T>
+  %6 = begin_borrow %5 : $@callee_guaranteed (UnsafeBufferPointer<UInt8>) -> @out Optional<Int>
+  %7 = apply %6(%0, %1) : $@callee_guaranteed (UnsafeBufferPointer<UInt8>) -> @out Optional<Int>
+  end_borrow %6 : $@callee_guaranteed (UnsafeBufferPointer<UInt8>) -> @out Optional<Int>
+  destroy_value %5 : $@callee_guaranteed (UnsafeBufferPointer<UInt8>) -> @out Optional<Int>
+  %10 = tuple ()
+  return %10 : $()
+}

--- a/test/SILOptimizer/constant_capture_propagation_odr.swift
+++ b/test/SILOptimizer/constant_capture_propagation_odr.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -Osize -Xllvm -sil-disable-pass=GenericSpecializer -Xfrontend -sil-verify-none -module-name=test %s -o %t/a.out
+// RUN: %target-build-swift -Osize -Xllvm -sil-disable-pass=GenericSpecializer -module-name=test %s -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 // REQUIRES: executable_test

--- a/test/SILOptimizer/constant_capture_propagation_odr.swift
+++ b/test/SILOptimizer/constant_capture_propagation_odr.swift
@@ -1,27 +1,10 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -Osize -Xllvm -sil-disable-pass=GenericSpecializer -module-name=test %s -o %t/a.out
+// RUN: %target-build-swift -Osize -Xllvm -sil-disable-pass=GenericSpecializer -Xfrontend -sil-verify-none -module-name=test %s -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 // REQUIRES: executable_test
 
 // Regression test for an ODR violation in ConstantCapturePropagation.
-//
-// FixedWidthInteger.init?(_:radix:) contains an @_alwaysEmitIntoClient
-// closure. ConstantCapturePropagation specializes it by propagating the
-// constant radix into the body. The specialized function gets a mangled
-// name encoding only the constant (radix=10), not the type substitution,
-// and shared (linkonce_odr) linkage.
-//
-// Before the fix, the pass baked the concrete Self type into the body,
-// so UInt8 and Int produced the same symbol with different bodies.
-// The linker picked one — if UInt8's 1-byte body won, Int callers got
-// garbage because _parseIntegerDigits wrote only 1 byte into an 8-byte
-// result buffer.
-//
-// GenericSpecializer is disabled to isolate the bug — in practice this
-// manifests in multi-module builds where GenericSpecializer doesn't run
-// on the @_alwaysEmitIntoClient closure before CCP does.
-
 @inline(never)
 func parseU8(_ s: String) -> UInt8? {
     return UInt8(s, radix: 10)

--- a/test/SILOptimizer/constant_capture_propagation_odr.swift
+++ b/test/SILOptimizer/constant_capture_propagation_odr.swift
@@ -1,0 +1,47 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -Osize -Xllvm -sil-disable-pass=GenericSpecializer -module-name=test %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+// REQUIRES: executable_test
+
+// Regression test for an ODR violation in ConstantCapturePropagation.
+//
+// FixedWidthInteger.init?(_:radix:) contains an @_alwaysEmitIntoClient
+// closure. ConstantCapturePropagation specializes it by propagating the
+// constant radix into the body. The specialized function gets a mangled
+// name encoding only the constant (radix=10), not the type substitution,
+// and shared (linkonce_odr) linkage.
+//
+// Before the fix, the pass baked the concrete Self type into the body,
+// so UInt8 and Int produced the same symbol with different bodies.
+// The linker picked one — if UInt8's 1-byte body won, Int callers got
+// garbage because _parseIntegerDigits wrote only 1 byte into an 8-byte
+// result buffer.
+//
+// GenericSpecializer is disabled to isolate the bug — in practice this
+// manifests in multi-module builds where GenericSpecializer doesn't run
+// on the @_alwaysEmitIntoClient closure before CCP does.
+
+@inline(never)
+func parseU8(_ s: String) -> UInt8? {
+    return UInt8(s, radix: 10)
+}
+
+@inline(never)
+func parseInt(_ s: String) -> Int? {
+    return Int(s, radix: 10)
+}
+
+@inline(never)
+func parseInt32(_ s: String) -> Int32? {
+    return Int32(s, radix: 10)
+}
+
+// CHECK: UInt8: Optional(42)
+print("UInt8: \(parseU8("42") as Any)")
+
+// CHECK: Int: Optional(42)
+print("Int: \(parseInt("42") as Any)")
+
+// CHECK: Int32: Optional(42)
+print("Int32: \(parseInt32("42") as Any)")


### PR DESCRIPTION
## Summary
This PR fixes the ODR violation detailed in https://github.com/swiftlang/swift/issues/87917

## Impl

When specializeClosure determines the specialized closure remains generic (`isGeneric == true`), clone the body without applying type substitutions, and use `partial_apply` with the substitution map at the call site instead of `thin_to_thick_function`. The body stays generic with type parameters like `$*Optional<Self>`, which is correct since all callers share the same shared symbol and apply their own concrete types through the substitution map on the `partial_apply`.

## Tests
Add SIL and executable tests demonstrating that ConstantCapturePropagation produces an ODR violation when specializing generic closures with different concrete type substitutions but the same constant captures.

The SIL test provides a minimal reproducer: two callers instantiate the same generic closure with UInt8 and Int respectively, both capturing constant `radix=10`. With `-enable-sil-verify-all`, the verifier catches the type mismatch in the specialized function body.

The executable test exercises the real-world scenario through `FixedWidthInteger.init?(_:radix:)`, where the miscompile causes Int and `Int32` parsing to return garbage values because the closure body was baked with `UInt8` type metadata.

Fixes: https://github.com/swiftlang/swift/issues/87917

[Assisted-by](https://t.ly/Dkjjk): [Claude Opus 4.6](https://www.anthropic.com/news/claude-opus-4-6)

cc @drodriguez @kyulee-com
