### PR TITLE
[stdlib/CMakeLists.txt] Use `-external-plugin-path` for building stdlib instead of `-plugin-path`

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -359,7 +359,7 @@ else()
 endif()
 
 # For `@DebugDescription`.
-list(APPEND swift_stdlib_compile_flags "-plugin-path" "${swift_lib_dir}/swift/host/plugins")
+list(APPEND swift_stdlib_compile_flags "-external-plugin-path" "${swift_lib_dir}/swift/host/plugins#${swift_bin_dir}/swift-plugin-server")
 
 set(swift_core_incorporate_object_libraries)
 list(APPEND swift_core_incorporate_object_libraries swiftRuntimeCore)


### PR DESCRIPTION
This allows stdlib compilation to work with `SWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER`.