### PR TITLE
[Caching] Do not update file if the same when cache replay

### DIFF
--- a/lib/Frontend/CachingUtils.cpp
+++ b/lib/Frontend/CachingUtils.cpp
@@ -145,6 +145,20 @@ struct CacheInputEntry {
 };
 } // namespace
 
+// Get the output config type from the output file type.
+static llvm::vfs::OutputConfig getOutputConfig(file_types::ID Type) {
+  llvm::vfs::OutputConfig Config;
+  switch(Type) {
+    case file_types::ID::TY_ModuleTrace:
+      // ModuleTrace always appends.
+      return Config.setAtomicWrite().setAppend();
+    default:
+      // By default, only write to the output file when different. This matches
+      // the behavior in `swift::withOutputPath()`.
+      return Config.setAtomicWrite().setOnlyIfDifferent();
+  }
+}
+
 static bool replayCachedCompilerOutputsImpl(
     ArrayRef<CacheInputEntry> Inputs, ObjectStore &CAS, DiagnosticEngine &Diag,
     const FrontendOptions &Opts, CachingDiagnosticsProcessor &CDP,
@@ -291,7 +305,7 @@ static bool replayCachedCompilerOutputsImpl(
 
   // Replay the result only when everything is resolved.
   for (auto &Output : OutputProxies) {
-    auto File = Backend.createFile(Output.Path);
+    auto File = Backend.createFile(Output.Path, getOutputConfig(Output.Kind));
     if (!File) {
       Diag.diagnose(SourceLoc(), diag::error_opening_output, Output.Path,
                     toString(File.takeError()));

--- a/test/CAS/swift-scan-test.swift
+++ b/test/CAS/swift-scan-test.swift
@@ -36,6 +36,18 @@
 // RUN: diff %t/Test.swiftmodule %t/Test2.swiftmodule
 // RUN: diff %t/test.o %t/test2.o
 
+// RUN: stat %t/Test.swiftmodule > %t/before.module.stat
+// RUN: stat %t/test.o > %t/before.object.stat
+// RUN: %swift-scan-test -action replay_result -cas-path %t/cas -id @%t/key.casid -- \
+// RUN:   %target-swift-frontend-plain -cache-compile-job -Rcache-compile-job %s \
+// RUN:   -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies -module-name Test -o %t/test.o -cas-path %t/cas \
+// RUN:   @%t/MyApp.cmd
+// RUN: stat %t/Test.swiftmodule > %t/after.module.stat
+// RUN: stat %t/test.o > %t/after.object.stat
+
+// RUN: diff %t/before.module.stat %t/after.module.stat
+// RUN: diff %t/before.object.stat %t/after.object.stat
+
 // CHECK-QUERY-NOT-FOUND: cached output not found
 // CHECK-QUERY: Cached Compilation for key "llvmcas://{{.*}}" has 4 outputs:
 // CHECK-QUERY-NEXT: object: llvmcas://


### PR DESCRIPTION
Make sure cache replay matches the same behavior as normal compilation that the output is not written (timestamp preserved) when replaying cache hits. This make sure the downstream dependencies are not invalidated on a cache hit but the output doesn't change.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
