### PR TITLE
build.ps1: disable cross-compiling the Dispatch tests for Android, matching `build-script`

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3045,6 +3045,14 @@ function Write-SDKSettings([OS] $OS, [string] $Identifier = $OS.ToString()) {
 
 function Build-Dispatch([Hashtable] $Platform) {
   $SwiftSDK = Get-SwiftSDK -OS $Platform.OS -Identifier $Platform.DefaultSDK
+  $PlatformDefines = @{}
+
+  if ($Platform.OS -eq [OS]::Android) {
+    $PlatformDefines += @{
+      BUILD_TESTING = "NO";
+    }
+  }
+
   Build-CMakeProject `
     -Src $SourceCache\swift-corelibs-libdispatch `
     -Bin (Get-ProjectBinaryCache $Platform Dispatch) `
@@ -3052,10 +3060,10 @@ function Build-Dispatch([Hashtable] $Platform) {
     -Platform $Platform `
     -UseBuiltCompilers C,CXX,Swift `
     -SwiftSDK $SwiftSDK `
-    -Defines @{
+    -Defines ($PlatformDefines + @{
       ENABLE_SWIFT = "YES";
       dispatch_INSTALL_ARCH_SUBDIR = "YES";
-    }
+    })
 }
 
 function Test-Dispatch {
@@ -3350,6 +3358,14 @@ function Build-ExperimentalSDK([Hashtable] $Platform) {
 
   $SDKROOT = Get-SwiftSDK -OS $Platform.OS -Identifier "$($Platform.OS)Experimental"
 
+  $PlatformDefines = @{}
+
+  if ($Platform.OS -eq [OS]::Android) {
+    $PlatformDefines += @{
+      BUILD_TESTING = "NO";
+    }
+  }
+
   if ($Platform.LinkModes.Contains("dynamic")) {
     Record-OperationTime $Platform "Build-ExperimentalDynamicDispatch" {
       Build-CMakeProject `
@@ -3359,13 +3375,13 @@ function Build-ExperimentalSDK([Hashtable] $Platform) {
         -Platform $Platform `
         -UseBuiltCompilers C,CXX,Swift `
         -SwiftSDK "${SDKROOT}" `
-        -Defines @{
+        -Defines ($PlatformDefines + @{
           BUILD_SHARED_LIBS = "YES";
           CMAKE_FIND_PACKAGE_PREFER_CONFIG = "YES";
           CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";
 
           ENABLE_SWIFT = "YES";
-        }
+        })
     }
 
     Record-OperationTime $Platform "Build-ExperimentalDynamicFoundation" {
@@ -3411,13 +3427,13 @@ function Build-ExperimentalSDK([Hashtable] $Platform) {
         -Platform $Platform `
         -UseBuiltCompilers C,CXX,Swift `
         -SwiftSDK "${SDKROOT}" `
-        -Defines @{
+        -Defines ($PlatformDefines + @{
           BUILD_SHARED_LIBS = "NO";
           CMAKE_Swift_FLAGS = @("-static-stdlib", "-Xfrontend", "-use-static-resource-dir");
           CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";
 
           ENABLE_SWIFT = "YES";
-        }
+        })
     }
 
     Record-OperationTime $Platform "Build-ExperimentalStaticFoundation" {


### PR DESCRIPTION
swiftlang/swift-corelibs-libdispatch#934 just [broke the Windows toolchain CI when cross-compiling that new test for Android](https://ci-external.swift.org/job/swift-main-windows-toolchain/1978/console), but it had no effect on the Android CI on linux that is built by `build-script` (well, [the CI run that would check it flaked when checking out source](https://ci.swift.org/job/oss-swift-package-swift-sdk-for-android/328/), as did the next one 🤷‍♂️), as cross-compiling these tests is already disabled there, #87767.

Alright, confirmed that [the libdispatch pull had no effect on the Android CI that runs on linux](https://ci.swift.org/job/oss-swift-package-swift-sdk-for-android/330/console).