### PR TITLE
[cxx-interop] Better support overloading in reverse interop

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -1102,6 +1102,32 @@ private:
            sel.getSelectorPieces().front().str() == "init";
   }
 
+  /// Returns the C++ parameter type strings for a function as they would
+  /// appear in the C++ inline thunk signature.
+  llvm::SmallVector<std::string, 4>
+  getCxxParamTypes(const AbstractFunctionDecl *funcDecl) const {
+    llvm::SmallVector<std::string, 4> result;
+    auto *params = funcDecl->getParameters();
+    if (!params)
+      return result;
+    auto *emittedModule = funcDecl->getModuleContext();
+    for (auto *param : *params) {
+      auto type = param->getInterfaceType();
+      // In C++ different integer types have different bitwidths. To
+      // avoid producing redefinition errors, we are conservative with
+      // these types and consider all integral types the same.
+      if (type->isStdlibInteger()) {
+        result.push_back("int");
+      } else {
+        std::string typeStr;
+        llvm::raw_string_ostream typeOS(typeStr);
+        owningPrinter.printTypeName(typeOS, type, emittedModule);
+        result.push_back(typeStr);
+      }
+    }
+    return result;
+  }
+
   /// Returns true if the given function overload is safe to emit in the current
   /// C++ lexical scope.
   bool canPrintOverloadOfFunction(const AbstractFunctionDecl *funcDecl) const {
@@ -1109,32 +1135,24 @@ private:
     auto &overloads =
         owningPrinter.getCxxDeclEmissionScope().emittedFunctionOverloads;
     auto cxxName = cxx_translation::getNameForCxx(funcDecl);
-    auto overloadIt = overloads.find(cxxName);
-    if (overloadIt == overloads.end()) {
-      overloads.insert(std::make_pair(
-          cxxName,
-          llvm::SmallVector<const AbstractFunctionDecl *>({funcDecl})));
+    auto paramTypes = getCxxParamTypes(funcDecl);
+    auto [overloadIt, inserted] = overloads.try_emplace(
+        cxxName,
+        llvm::SmallVector<CxxDeclEmissionScope::EmittedFunctionOverload, 2>(
+            {{funcDecl, paramTypes}}));
+    if (inserted)
       return true;
-    }
-    auto selfArity =
-        funcDecl->getParameters() ? funcDecl->getParameters()->size() : 0;
-    for (const auto *overload : overloadIt->second) {
-      auto arity =
-          overload->getParameters() ? overload->getParameters()->size() : 0;
-      // Avoid printing out an overload with the same and arity, as that might
-      // be an ambiguous overload on the C++ side.
-      // FIXME: we should take types into account, not all overloads with the
-      // same arity are ambiguous in C++.
-      if (selfArity == arity) {
+    for (const auto &overload : overloadIt->second) {
+      if (overload.cxxParamTypes == paramTypes) {
         owningPrinter.getCxxDeclEmissionScope()
             .additionalUnrepresentableDeclarations.insert(
                 {funcDecl,
-                 "An overload with the same number of parameters already "
+                 "An overload with the same C++ parameter types already "
                  "exists"});
         return false;
       }
     }
-    overloadIt->second.push_back(funcDecl);
+    overloadIt->second.push_back({funcDecl, paramTypes});
     return true;
   }
 

--- a/lib/PrintAsClang/DeclAndTypePrinter.h
+++ b/lib/PrintAsClang/DeclAndTypePrinter.h
@@ -38,6 +38,14 @@ class SwiftToClangInteropContext;
 /// Tracks which C++ declarations have been emitted in a lexical
 /// C++ scope.
 struct CxxDeclEmissionScope {
+  /// Records information about an emitted C++ function overload.
+  struct EmittedFunctionOverload {
+    const AbstractFunctionDecl *funcDecl;
+    /// The C++ parameter types as they appear in the C++ inline thunk
+    /// signature, used to detect genuinely ambiguous overloads.
+    llvm::SmallVector<std::string, 4> cxxParamTypes;
+  };
+
   /// Additional Swift declarations that are unrepresentable in C++.
   /// The string holds a reason why the declaration is unrepresentable;
   /// empty string means the reason should be acqured from
@@ -48,7 +56,7 @@ struct CxxDeclEmissionScope {
   llvm::StringSet<> emittedDeclarationNames;
   /// Records the names of the function overloads already emitted in this
   /// lexical scope.
-  llvm::StringMap<llvm::SmallVector<const AbstractFunctionDecl *, 2>>
+  llvm::StringMap<llvm::SmallVector<EmittedFunctionOverload, 2>>
       emittedFunctionOverloads;
   llvm::StringMap<const AccessorDecl *> emittedAccessorMethodNames;
 };

--- a/test/Interop/SwiftToCxx/functions/swift-function-overloads.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-function-overloads.swift
@@ -4,15 +4,22 @@
 
 // RUN: %check-interop-cxx-header-in-clang(%t/functions.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
+// Different arity should always work.
+public func arityOverload() { }
+public func arityOverload(_ x: Int) { }
+
+// CHECK: void arityOverload() noexcept
+// CHECK: void arityOverload(swift::Int x) noexcept
+
+// Same-arity overloads with different C++ types should both be emitted.
 public func overloadedFunc(_ x: Int) { }
 public func overloadedFunc(_ y: Float) { }
 
 public func overloadedFuncArgLabel(x _: Int) { }
-public func overloadedFuncArgLabel(y _: Float) { }
+public func overloadedFuncArgLabel(y _: Int) { }
 
 // CHECK: void overloadedFunc(swift::Int x) noexcept
-// CHECK: void overloadedFuncArgLabel(swift::Int  _1) noexcept
+// CHECK: void overloadedFunc(float y) noexcept
 
-// CHECK: // Unavailable in C++: Swift global function 'overloadedFunc(_:)'. An overload with the same number of parameters already exists.
+// CHECK: // Unavailable in C++: Swift global function 'overloadedFuncArgLabel(y:)'. An overload with the same C++ parameter types already exists.
 
-// CHECK: // Unavailable in C++: Swift global function 'overloadedFuncArgLabel(y:)'. An overload with the same number of parameters already exists.

--- a/test/Interop/SwiftToCxx/initializers/init-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/initializers/init-in-cxx.swift
@@ -138,8 +138,8 @@ public struct WrapOverloadedInits {
     }
 }
 
-// CHECK: static SWIFT_INLINE_THUNK WrapOverloadedInits init
-// CHECK-SAME: (swift::Int x) SWIFT_SYMBOL("s:4Init19WrapOverloadedInitsVyACSicfc");
+// CHECK: static SWIFT_INLINE_THUNK WrapOverloadedInits init(swift::Int x) SWIFT_SYMBOL("s:4Init19WrapOverloadedInitsVyACSicfc");
+// CHECK-NEXT: static SWIFT_INLINE_THUNK WrapOverloadedInits init(float
 // CHECK-NOT: WrapOverloadedInits init(
 
 // CHECK: BaseClass BaseClass::init(swift::Int x, swift::Int y) {

--- a/test/Interop/SwiftToCxx/methods/method-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/methods/method-in-cxx.swift
@@ -126,8 +126,8 @@ public struct WrapOverloadedMethods {
 }
 
 // CHECK: WrapOverloadedMethods final {
-// CHECK: SWIFT_INLINE_THUNK void method
-// CHECK-SAME: (swift::Int x) const SWIFT_SYMBOL("s:7Methods014WrapOverloadedA0V6methodyySiF");
+// CHECK: SWIFT_INLINE_THUNK void method(swift::Int x) const
+// CHECK: SWIFT_INLINE_THUNK void method(float x) const
 // CHECK-NEXT: private:
 
 public struct WrapOverloadedMethodsSibling {


### PR DESCRIPTION
The overloading rules in Swift and C++ are quite different. We were very conservative, and did not emit functions in an overload set that have the same arity. This PR relaxes this restriction by checking if the emitted C++ types would differ.

rdar://157673175