### PR TITLE
[cxx-interop] Honor "requires cplusplus17" similarly to "requires cplusplus"

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3063,7 +3063,7 @@ ClangModuleUnit *ClangImporter::Implementation::getWrapperForModule(
           llvm::any_of(M->Requirements, [cxx](const auto &Req) {
             if (Req.FeatureName == "swift")
               return !Req.RequiredState;
-            if (Req.FeatureName == "cplusplus")
+            if (StringRef(Req.FeatureName).starts_with("cplusplus"))
               return Req.RequiredState != cxx;
             return false;
           });
@@ -8962,7 +8962,7 @@ bool importer::requiresCPlusPlus(const clang::Module *module) {
   }
 
   return llvm::any_of(module->Requirements, [](clang::Module::Requirement req) {
-    return req.FeatureName == "cplusplus";
+    return StringRef(req.FeatureName).starts_with("cplusplus");
   });
 }
 

--- a/test/Interop/Cxx/stdlib/overlay/Inputs/cxx-requirement-specific-standard-version.h
+++ b/test/Interop/Cxx/stdlib/overlay/Inputs/cxx-requirement-specific-standard-version.h
@@ -1,0 +1,5 @@
+struct BoolBox {
+  bool value;
+  
+  operator bool() const { return value; }
+};

--- a/test/Interop/Cxx/stdlib/overlay/Inputs/module.modulemap
+++ b/test/Interop/Cxx/stdlib/overlay/Inputs/module.modulemap
@@ -22,3 +22,15 @@ module CustomBorrowingSequence {
   requires cplusplus
   export *
 }
+
+module NoCxxRequirement {
+  header "no-cxx-requirement.h"
+  // NO requires cplusplus
+  export *
+}
+
+module CxxRequirementSpecificStandardVersion {
+  header "cxx-requirement-specific-standard-version.h"
+  requires cplusplus14
+  export *
+}

--- a/test/Interop/Cxx/stdlib/overlay/Inputs/no-cxx-requirement.h
+++ b/test/Interop/Cxx/stdlib/overlay/Inputs/no-cxx-requirement.h
@@ -1,0 +1,5 @@
+struct BoolBox {
+  bool value;
+  
+  operator bool() const { return value; }
+};

--- a/test/Interop/Cxx/stdlib/overlay/cxx-requirement-specific-standard-version-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/cxx-requirement-specific-standard-version-module-interface.swift
@@ -1,0 +1,3 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=CxxRequirementSpecificStandardVersion -source-filename=x -I %S/Inputs -cxx-interoperability-mode=default | %FileCheck %s
+
+// CHECK: CxxConvertibleToBool

--- a/test/Interop/Cxx/stdlib/overlay/no-cxx-requirement-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/no-cxx-requirement-module-interface.swift
@@ -1,0 +1,3 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=NoCxxRequirement -source-filename=x -I %S/Inputs -cxx-interoperability-mode=default | %FileCheck %s
+
+// CHECK-NOT: CxxConvertibleToBool


### PR DESCRIPTION
If a C++ random access container type is defined in a module that declares “requires cplusplus”, the type is conformed to `CxxRandomAccessCollection`. However, if the module declares “requires cplusplus17” or “requires cplusplus20”, it is not conformed.

This teaches Swift to honor versioned `requires cplusplusXY` directives.

rdar://172826565

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
