### PR TITLE
[cxx-interop] Fixup ownership mismatch between ObjC and Swift in thunks

### DIFF
--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1519,6 +1519,12 @@ public:
     case ValueOwnership::Shared:
       return ParameterConvention::Direct_Guaranteed;
     case ValueOwnership::Owned:
+      if (kind == ConventionsKind::ObjCSelectorFamily ||
+          kind == ConventionsKind::ObjCMethod) {
+        if (forSelf)
+          return getDirectSelfParameter(type);
+        return getDirectParameter(index, type, substTL);
+      }
       return ParameterConvention::Direct_Owned;
     }
     llvm_unreachable("unhandled ownership");

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -3905,7 +3905,10 @@ private:
         return MatchOutcome::WrongForeignErrorConvention;
       for (auto [reqParam, candParam] :
            llvm::zip(*reqAFD->getParameters(), *candAFD->getParameters())) {
-        if (reqParam->getValueOwnership() != candParam->getValueOwnership())
+        // In case the ObjC owership is unowned and the swift is owned, the ObjC
+        // thunk will make the necessary adjustment.
+        if (reqParam->getValueOwnership() != candParam->getValueOwnership() &&
+            reqParam->getValueOwnership() != ValueOwnership::Default)
           return MatchOutcome::WrongParameterOwnership;
       }
     }

--- a/test/Interop/ObjC/implementation-in-swift/Inputs/objc_implementation_consuming.h
+++ b/test/Interop/ObjC/implementation-in-swift/Inputs/objc_implementation_consuming.h
@@ -1,0 +1,18 @@
+#pragma once
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ObjCClass : NSObject
+
+- (void)take:(NSObject *)obj;
++ (void)runTests;
+
+@end
+
+// Helper to call -takeObject: from ObjC, ensuring we go through objc_msgSend.
+static inline void callTakeObjectFromObjC(ObjCClass *self, NSObject *obj) {
+  [self take:obj];
+}
+
+NS_ASSUME_NONNULL_END

--- a/test/Interop/ObjC/implementation-in-swift/objc_implementation_consuming.swift
+++ b/test/Interop/ObjC/implementation-in-swift/objc_implementation_consuming.swift
@@ -1,0 +1,43 @@
+// RUN: %target-run-simple-swift(-import-objc-header %S/Inputs/objc_implementation_consuming.h) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import Foundation
+
+// A class whose deallocation we can observe.
+class Witness : NSObject {
+  var label: String
+
+  init(label: String) {
+    self.label = label
+  }
+
+  deinit {
+    print("\(label) deinit")
+  }
+}
+
+@objc @implementation extension ObjCClass {
+  // The ObjC header declares takeObject: as a regular (non-consuming) method.
+  // The Swift implementation uses 'consuming' ownership. The ObjC thunk must
+  // copy the argument so the Swift function consumes the copy, not the
+  // caller's original reference.
+  func take(_ obj: consuming NSObject) {
+    _ = obj
+  }
+
+  class func runTests() {
+    let c = ObjCClass()
+    let w = Witness(label: "witness")
+    // Call through ObjC dispatch. The ObjC caller passes 'w' at +0.
+    // If the thunk incorrectly treats it as +1 (consumed), it will
+    // over-release 'w', causing a crash on the next access.
+    callTakeObjectFromObjC(c, w)
+    // CHECK: after takeObject: witness
+    print("after takeObject: \(w.label)")
+  }
+}
+
+// CHECK: witness deinit
+ObjCClass.runTests()

--- a/test/decl/ext/objc_implementation.swift
+++ b/test/decl/ext/objc_implementation.swift
@@ -430,7 +430,6 @@ protocol EmptySwiftProto {}
 
 @objc(OwnershipTests) @implementation extension ObjCClass {
   func consumingMismatchMethod(_ param: consuming Any?) {
-    // expected-error@-1 {{instance method 'consumingMismatchMethod' has a parameter ownership modifier that does not match the declaration in the header}}
   }
   func consumingMismatchMethod2(_ param: Any?) {
     // expected-error@-1 {{instance method 'consumingMismatchMethod2' has a parameter ownership modifier that does not match the declaration in the header}}


### PR DESCRIPTION
The ObjC thunk already attempted to do fixup for ownership mismatches but it derived the wrong parameter convention for the ObjC thunk itself so this fixup did not happen. This PR makes sure we have the correct ownership convention for the ObjC thunk so the fixup actually happens.

Furthermore, this PR relaxes the type checker so we no longer error out on the ownership convention mismatch.

rdar://172701291