### PR TITLE
Sema: Support for metatype to existential metatype conversion in CSOptimizer.cpp [6.3]

### DIFF
--- a/lib/Sema/CSOptimizer.cpp
+++ b/lib/Sema/CSOptimizer.cpp
@@ -820,6 +820,50 @@ static std::optional<DisjunctionInfo> preserveFavoringOfUnlabeledUnaryArgument(
 
 } // end anonymous namespace
 
+/// Determine whether the candidate type is a subclass of the superclass type.
+static bool isSubclassOf(Type candidateType, Type superclassType) {
+  auto *superclassDecl = superclassType->getClassOrBoundGenericClass();
+  if (!superclassDecl)
+    return false;
+
+  auto *subclassDecl = candidateType->getClassOrBoundGenericClass();
+  if (!subclassDecl) {
+    candidateType = candidateType->getSuperclass();
+    if (!candidateType)
+      return false;
+    subclassDecl = candidateType->getClassOrBoundGenericClass();
+    if (!subclassDecl)
+      return false;
+  }
+
+  return superclassDecl->isSuperclassOf(subclassDecl);
+}
+
+/// Determine whether the candidate type can be erased to the given
+/// existential type. This check is approximate, because it disregards
+/// conditional conformance and parameterized protocol types.
+static bool isSubtypeOfExistentialType(Type candidateType,
+                                       Type existentialType) {
+  auto layout = existentialType->getExistentialLayout();
+
+  if (auto layoutConstraint = layout.getLayoutConstraint()) {
+    if (layoutConstraint->isClass() &&
+        !(candidateType->isClassExistentialType() ||
+          candidateType->mayHaveSuperclass()))
+      return false;
+  }
+
+  if (layout.explicitSuperclass &&
+      !isSubclassOf(candidateType, layout.explicitSuperclass))
+    return false;
+
+  return llvm::all_of(layout.getProtocols(), [&](ProtocolDecl *P) {
+    auto result = TypeChecker::containsProtocol(candidateType, P,
+                                                /*allowMissing=*/false);
+    return result.first || result.second;
+  });
+}
+
 /// Given a set of disjunctions, attempt to determine
 /// favored choices in the current context.
 static void determineBestChoicesInContext(
@@ -1441,6 +1485,20 @@ static void determineBestChoicesInContext(
               (candidateType->is<ExistentialMetatypeType>() ||
                candidateType->is<MetatypeType>()))
             return 1;
+        }
+      }
+
+      // Conversion from a metatype to an existential metatype.
+      if (auto *EMT = paramType->getAs<ExistentialMetatypeType>()) {
+        if (auto *candidateEMT = candidateType->getAs<AnyMetatypeType>()) {
+          auto instanceType = candidateEMT->getInstanceType();
+          // Concrete metatypes of existentials don't convert to existential
+          // metatypes.
+          if (candidateType->is<ExistentialMetatypeType>() ||
+              !instanceType->isExistentialType()) {
+            if (isSubtypeOfExistentialType(instanceType, EMT->getInstanceType()))
+              return 1;
+          }
         }
       }
 

--- a/test/Constraints/issue-87300.swift
+++ b/test/Constraints/issue-87300.swift
@@ -1,0 +1,33 @@
+// RUN: %target-typecheck-verify-swift
+
+// https://github.com/swiftlang/swift/issues/87300
+
+func f(_ t: Any) -> Int {}
+func f(_ t: AnyClass) -> String {}
+
+func f(t: Any) -> Int {}
+func f(t: AnyClass) -> String {}
+
+class T {}
+
+do {
+  let result = f(T.self)
+  let _: String = result
+}
+
+do {
+  let result = f(t: T.self)
+  let _: String = result
+}
+
+struct S: ~Copyable {}
+
+do {
+  let result = f(S.self)
+  let _: Int = result
+}
+
+do {
+  let result = f(t: S.self)
+  let _: Int = result
+}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -758,10 +758,10 @@ func invalidDictionaryLiteral() {
 //===----------------------------------------------------------------------===//
 // nil/metatype comparisons
 //===----------------------------------------------------------------------===//
-_ = Int.self == nil  // expected-warning {{comparing non-optional value of type 'Int.Type' to 'nil' always returns false}}
-_ = nil == Int.self  // expected-warning {{comparing non-optional value of type 'Int.Type' to 'nil' always returns false}}
-_ = Int.self != nil  // expected-warning {{comparing non-optional value of type 'Int.Type' to 'nil' always returns true}}
-_ = nil != Int.self  // expected-warning {{comparing non-optional value of type 'Int.Type' to 'nil' always returns true}}
+_ = Int.self == nil  // expected-warning {{comparing non-optional value of type 'any (~Copyable & ~Escapable).Type' to 'nil' always returns false}}
+_ = nil == Int.self  // expected-warning {{comparing non-optional value of type 'any (~Copyable & ~Escapable).Type' to 'nil' always returns false}}
+_ = Int.self != nil  // expected-warning {{comparing non-optional value of type 'any (~Copyable & ~Escapable).Type' to 'nil' always returns true}}
+_ = nil != Int.self  // expected-warning {{comparing non-optional value of type 'any (~Copyable & ~Escapable).Type' to 'nil' always returns true}}
 
 _ = Int.self == .none  // expected-warning {{comparing non-optional value of type 'any (~Copyable & ~Escapable).Type' to 'Optional.none' always returns false}}
 _ = .none == Int.self  // expected-warning {{comparing non-optional value of type 'any (~Copyable & ~Escapable).Type' to 'Optional.none' always returns false}}


### PR DESCRIPTION
This is a 6.3 backport of https://github.com/swiftlang/swift/pull/87309 in the lowest-risk way possible.

* **Description:** 6.3 would sometimes pick a less specific overload than desired, because the new favoring heuristic did not account for metatypes converting to existential metatypes. This code was significantly changed on `main` to add various other missing cases as well; this PR backports one specific check without changing any of the surrounding code.

* **Origination:** The behavior regressed in 6.3.

* **Risk:** Low. Could hypothetically slow down type checking or cause other type checking errors, but the original change has been on main for a while and seems fine.

* **Reviewed by:** @xedin 

* **Issue:** Fixes https://github.com/swiftlang/swift/issues/87300.