### PR TITLE
[lldb] Encode marker annotation for protocols in debug info.

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1228,7 +1228,8 @@ private:
     llvm::DINodeArray BoundParams = collectGenericParams(Type);
     llvm::DICompositeType *DITy = createStruct(
         Scope, Name, File, Line, SizeInBits, AlignInBits, Flags, MangledName,
-        DBuilder.getOrCreateArray(Members), BoundParams, SpecificationOf);
+        DBuilder.getOrCreateArray(Members), BoundParams, SpecificationOf,
+        /*Annotations=*/nullptr);
     return DBuilder.replaceTemporary(std::move(FwdDecl), DITy);
   }
 
@@ -1874,12 +1875,13 @@ private:
                unsigned Line, unsigned SizeInBits, unsigned AlignInBits,
                llvm::DINode::DIFlags Flags, StringRef MangledName,
                llvm::DINodeArray Elements, llvm::DINodeArray BoundParams,
-               llvm::DIType *SpecificationOf) {
+               llvm::DIType *SpecificationOf, llvm::DINodeArray Annotations) {
 
     auto StructType = DBuilder.createStructType(
         Scope, Name, File, Line, SizeInBits, AlignInBits, Flags,
         /* DerivedFrom */ nullptr, Elements, llvm::dwarf::DW_LANG_Swift,
-        nullptr, MangledName, SpecificationOf);
+        nullptr, MangledName, SpecificationOf,
+        /*NumExtraInhabitants=*/0, Annotations);
 
     if (BoundParams)
       DBuilder.replaceArrays(StructType, nullptr, BoundParams);
@@ -1891,9 +1893,11 @@ private:
                      unsigned Line, unsigned SizeInBits, unsigned AlignInBits,
                      llvm::DINode::DIFlags Flags, StringRef MangledName,
                      llvm::DINodeArray BoundParams = {},
-                     llvm::DIType *SpecificationOf = nullptr) {
+                     llvm::DIType *SpecificationOf = nullptr,
+                     llvm::DINodeArray Annotations = nullptr) {
     return createStruct(Scope, Name, File, Line, SizeInBits, AlignInBits, Flags,
-                        MangledName, {}, BoundParams, SpecificationOf);
+                        MangledName, {}, BoundParams, SpecificationOf,
+                        Annotations);
   }
 
   bool shouldCacheDIType(llvm::DIType *DITy, DebugTypeInfo &DbgTy) {
@@ -2157,9 +2161,25 @@ private:
       auto *Decl = DbgTy.getDecl();
       auto L = getFileAndLocation(Decl);
       unsigned FwdDeclLine = 0;
+
+      llvm::DINodeArray Annotations = nullptr;
+      if (auto *PD = dyn_cast_or_null<ProtocolDecl>(Decl)) {
+        if (PD->isMarkerProtocol()) {
+          llvm::Metadata *Ops[2] = {
+              llvm::MDString::get(IGM.getLLVMContext(),
+                                  StringRef("swift.MarkerProtocol")),
+              llvm::ConstantAsMetadata::get(llvm::ConstantInt::get(
+                  llvm::Type::getInt1Ty(IGM.getLLVMContext()), true))};
+          SmallVector<llvm::Metadata *, 1> Annots;
+          Annots.push_back(llvm::MDNode::get(IGM.getLLVMContext(), Ops));
+          Annotations = DBuilder.getOrCreateArray(Annots);
+        }
+      }
+
       return createOpaqueStruct(Scope, Decl ? Decl->getNameStr() : MangledName,
                                 L.File, FwdDeclLine, SizeInBits, AlignInBits,
-                                Flags, MangledName);
+                                Flags, MangledName, /*BoundParams=*/{},
+                                /*SpecificationOf=*/nullptr, Annotations);
     }
 
     case TypeKind::UnboundGeneric: {

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -2150,13 +2150,54 @@ private:
       }
       // If the existential is just a protocol type it shares its mangled name
       // with it, so we can just represent it directly as a protocol.
-      BaseTy = TyPtr;
+      auto ProtoDbgTy = DebugTypeInfo::getFromTypeInfo(
+          TyPtr, IGM.getTypeInfoForUnlowered(TyPtr), IGM);
+      return getOrCreateType(ProtoDbgTy);
     }
-      LLVM_FALLTHROUGH;
+
+    case TypeKind::ProtocolComposition: {
+      auto *CompTy = BaseTy->castTo<ProtocolCompositionType>();
+
+      // A composition's mangled name will always be that of the canonical
+      // composition type. This means that a composition can be canonicalized
+      // into a single protocol type. For example, given:
+      //
+      // protocol P {}
+      // typealias P2 = P
+      // func f(param: (any P & P2)) {}
+      //
+      // The canonical type of "param" is simply P. To make sure we don't have
+      // two conflicting types with the same mangled name (one being the
+      // protocol composition, the other being only the protocol), In that case,
+      // emit debug info as only the protocol type.
+      auto CanTy = BaseTy->getCanonicalType();
+      if (!isa<ProtocolCompositionType>(CanTy)) {
+        return getOrCreateDesugaredType(CanTy, DbgTy);
+      }
+
+      llvm::TempDICompositeType FwdDecl(DBuilder.createReplaceableCompositeType(
+          llvm::dwarf::DW_TAG_structure_type, MangledName, Scope, nullptr, 0,
+          llvm::dwarf::DW_LANG_Swift, SizeInBits, AlignInBits, Flags));
+
+      SmallVector<llvm::Metadata *, 4> Members;
+      for (const Type MemberTy : CompTy->getMembers()) {
+        auto MemberDbgTy = DebugTypeInfo::getFromTypeInfo(
+            MemberTy, IGM.getTypeInfoForUnlowered(MemberTy), IGM);
+        auto *MemberDITy = getOrCreateType(MemberDbgTy);
+        Members.push_back(
+            DBuilder.createInheritance(FwdDecl.get(), MemberDITy, 0, 0, Flags));
+      }
+
+      auto *DITy = DBuilder.createStructType(
+          Scope, MangledName, nullptr, 0, SizeInBits, AlignInBits, Flags,
+          nullptr, DBuilder.getOrCreateArray(Members),
+          llvm::dwarf::DW_LANG_Swift, /*VTableHolder=*/nullptr, MangledName);
+
+      return DBuilder.replaceTemporary(std::move(FwdDecl), DITy);
+    }
 
     // FIXME: (LLVM branch) This should probably be a DW_TAG_interface_type.
     case TypeKind::Protocol:
-    case TypeKind::ProtocolComposition:
     case TypeKind::ParameterizedProtocol: {
       auto *Decl = DbgTy.getDecl();
       auto L = getFileAndLocation(Decl);
@@ -2170,8 +2211,8 @@ private:
                                   StringRef("swift.MarkerProtocol")),
               llvm::ConstantAsMetadata::get(llvm::ConstantInt::get(
                   llvm::Type::getInt1Ty(IGM.getLLVMContext()), true))};
-          SmallVector<llvm::Metadata *, 1> Annots;
-          Annots.push_back(llvm::MDNode::get(IGM.getLLVMContext(), Ops));
+          SmallVector<llvm::Metadata *, 1> Annots = {
+              llvm::MDNode::get(IGM.getLLVMContext(), Ops)};
           Annotations = DBuilder.getOrCreateArray(Annots);
         }
       }

--- a/test/DebugInfo/marker_protocol.swift
+++ b/test/DebugInfo/marker_protocol.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend %s -emit-ir -g -o - | %FileCheck %s
+
+
+@_marker protocol MyMarker {}
+
+struct ConformingType: MyMarker {
+}
+
+func f() {
+  let x: any MyMarker = ConformingType()
+}
+
+// Marker protocol should have the swift_marker annotation.
+// CHECK-DAG: ![[MARKER:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "MyMarker"{{.*}}annotations: ![[ANNOT:[0-9]+]]
+// CHECK-DAG: ![[ANNOT]] = !{![[ENTRY:[0-9]+]]}
+// CHECK-DAG: ![[ENTRY]] = !{!"swift.MarkerProtocol", i1 true}

--- a/test/DebugInfo/protocol_composition.swift
+++ b/test/DebugInfo/protocol_composition.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend %s -emit-ir -g -o - | %FileCheck %s
+
+protocol P1 {}
+protocol P2 {}
+
+func f() {
+  let x: any P1 & P2
+}
+
+// The protocol composition type should have DW_TAG_inheritance members
+// referencing each constituent protocol.
+// CHECK-DAG: ![[COMP:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "$s20protocol_composition2P1_AA2P2pD"{{.*}}elements: ![[ELTS:[0-9]+]]
+// CHECK-DAG: ![[ELTS]] = !{![[INH1:[0-9]+]], ![[INH2:[0-9]+]]}
+// CHECK-DAG: ![[INH1]] = !DIDerivedType(tag: DW_TAG_inheritance, scope: ![[COMP]], baseType: ![[P1:[0-9]+]]
+// CHECK-DAG: ![[INH2]] = !DIDerivedType(tag: DW_TAG_inheritance, scope: ![[COMP]], baseType: ![[P2:[0-9]+]]
+// CHECK-DAG: ![[P1]] = !DICompositeType(tag: DW_TAG_structure_type, name: "P1"
+// CHECK-DAG: ![[P2]] = !DICompositeType(tag: DW_TAG_structure_type, name: "P2"

--- a/test/DebugInfo/sugared-composition-with-inverses.swift
+++ b/test/DebugInfo/sugared-composition-with-inverses.swift
@@ -7,4 +7,9 @@ public typealias PP = P
 // Make sure this doesn't crash:
 public func withProto(_ e: borrowing any PP & ~Copyable) {}
 
-// CHECK: !{{[0-9]+}} = !DICompositeType(tag: DW_TAG_structure_type, name: "$s4main1P_pRi_s_XPD", size: {{[0-9]+}}, runtimeLang: DW_LANG_Swift, identifier: "$s4main1P_pRi_s_XPD")
+// CHECK-DAG: ![[COMP:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "$s4main1P_pRi_s_XPD", size: {{[0-9]+}}, elements: ![[MEMBERS:[0-9]+]], runtimeLang: DW_LANG_Swift, identifier: "$s4main1P_pRi_s_XPD")
+// CHECK-DAG: ![[MEMBERS]] = !{![[INH1:[0-9]+]], ![[INH2:[0-9]+]]}
+// CHECK-DAG: ![[INH1]] = !DIDerivedType(tag: DW_TAG_inheritance, scope: ![[COMP]], baseType: ![[PP:[0-9]+]]
+// CHECK-DAG: ![[PP]] = !DIDerivedType(tag: DW_TAG_typedef, name: "$s4main2PPaD"
+// CHECK-DAG: ![[INH2]] = !DIDerivedType(tag: DW_TAG_inheritance, scope: ![[COMP]], baseType: ![[NC:[0-9]+]]
+// CHECK-DAG: ![[NC]] = !DICompositeType(tag: DW_TAG_structure_type, name: "$sypRi_s_XPD"


### PR DESCRIPTION
Marker protocols are a compile time concept only, and emit no metadata. RemoteInspection does not know how to handle existentials with these types.

This patch emits debug info for marker protocols, so LLDB can handle them properly before querying RemoteInspection for type information.

rdar://172847891

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
