### PR TITLE
Sema: Introduce an opt-in `UseAnyAppleOSAvailability` diagnostic group

### DIFF
--- a/include/swift/AST/DiagnosticGroups.def
+++ b/include/swift/AST/DiagnosticGroups.def
@@ -91,6 +91,7 @@ GROUP(TemporaryPointers,none,"temporary-pointers")
 GROUP(TrailingClosureMatching,none,"trailing-closure-matching")
 GROUP(UnknownWarningGroup,none,"unknown-warning-group")
 GROUP(UntypedThrows,DefaultIgnoreWarnings,"untyped-throws")
+GROUP(UseAnyAppleOSAvailability,DefaultIgnoreWarnings,"use-any-apple-os-availability")
 GROUP(WeakMutability,none,"weak-mutability")
 
 GROUP_LINK(PerformanceHints,ExistentialType)

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7417,6 +7417,16 @@ ERROR(conformance_availability_not_available, none,
       "conformance of %0 to %1 is only available in %2",
       (Type, Type, AvailabilityDomain))
 
+GROUPED_WARNING(availability_use_any_apple_os,
+                UseAnyAppleOSAvailability, none,
+                "use '@available(anyAppleOS %0, *)' instead of platform "
+                "specific '@available' attributes with the same version",
+                (llvm::VersionTuple))
+
+NOTE(availability_decl_is_available_in, none,
+     "%0 is available in %1 %2 or newer",
+     (const Decl *, AvailabilityDomain, llvm::VersionTuple))
+
 //------------------------------------------------------------------------------
 // MARK: if #available(...)
 //------------------------------------------------------------------------------

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5292,6 +5292,165 @@ getAvailableAttrGroups(ArrayRef<const AvailableAttr *> attrs) {
   return results;
 }
 
+/// Check for platform availability attributes that could be consolidated using
+/// a single `@available(anyAppleOS ...)` attribute.
+void suggestAnyAppleOSAvailability(const Decl *D,
+                                   ArrayRef<AvailableAttr *> attrs,
+                                   ASTContext &ctx) {
+  auto &diags = ctx.Diags;
+  SourceFile *sf = D->getDeclContext()->getParentSourceFile();
+  if (!sf)
+    return;
+
+  if (!diags.isDiagnosticGroupEnabled(sf,
+                                      DiagGroupID::UseAnyAppleOSAvailability))
+    return;
+
+  // Collect the attributes that could be replaced with an anyAppleOS attribute.
+  llvm::SmallDenseMap<llvm::VersionTuple,
+                      llvm::SmallVector<const AvailableAttr *, 6>>
+      attrsByIntroVersion;
+  llvm::SmallSet<PlatformKind, 8> seenPlatforms;
+
+  for (const AvailableAttr *attr : attrs) {
+    auto semAttr = D->getSemanticAvailableAttr(attr);
+    if (!semAttr || !semAttr->isPlatformSpecific())
+      continue;
+
+    if (attr->getKind() != AvailableAttr::Kind::Default)
+      continue;
+
+    auto platform = semAttr->getPlatform();
+
+    // Don't diagnose any declaration that already has an anyAppleOS attribute.
+    if (platform == PlatformKind::anyAppleOS)
+      return;
+
+    if (!inheritsAvailabilityFromPlatform(platform, PlatformKind::anyAppleOS))
+      continue;
+
+    if (isApplicationExtensionPlatform(platform))
+      continue;
+
+    seenPlatforms.insert(platform);
+
+    // anyAppleOS only supports versions 26 and later.
+    auto rawIntroduced = attr->getRawIntroduced();
+    if (!rawIntroduced || rawIntroduced->getMajor() < 26)
+      continue;
+
+    attrsByIntroVersion[rawIntroduced->normalize()].push_back(attr);
+  }
+
+  if (attrsByIntroVersion.empty())
+    return;
+
+  // Don't suggest anyAppleOS unless there are existing availability attributes
+  // for each of the base Apple platforms.
+  static const PlatformKind requiredPlatforms[] = {
+      PlatformKind::macOS, PlatformKind::iOS, PlatformKind::tvOS,
+      PlatformKind::watchOS};
+  if (!llvm::all_of(requiredPlatforms,
+                    [&](PlatformKind p) { return seenPlatforms.contains(p); }))
+    return;
+
+  llvm::VersionTuple commonVersion;
+  llvm::SmallVector<const AvailableAttr *, 6> attrsToReplace;
+  for (auto &[version, attrList] : attrsByIntroVersion) {
+    // Prefer replacing the longest list of attributes.
+    if (attrList.size() < attrsToReplace.size())
+      continue;
+
+    // If the lists have the same length, prefer the earlier version.
+    if (attrList.size() == attrsToReplace.size()) {
+      if (version > commonVersion)
+        continue;
+    }
+
+    commonVersion = version;
+    attrsToReplace = attrList;
+  }
+
+  if (attrsToReplace.size() < 2)
+    return;
+
+  // Check whether the attributes have any fields besides 'introduced:' and skip
+  // if they do since we don't attempt to judge whether those fields match and
+  // could be consolidated.
+  // FIXME: This is conservative; attrs with matching fields could be merged.
+  for (auto *attr : attrsToReplace) {
+    if (attr->getRawDeprecated() || attr->getRawObsoleted() ||
+        !attr->getMessage().empty() || !attr->getRename().empty())
+      return;
+  }
+
+  auto diag = diags.diagnose(D->getLoc(), diag::availability_use_any_apple_os,
+                             commonVersion);
+
+  // Note each introduced version that could be replaced.
+  for (auto *attr : attrsToReplace) {
+    auto semAttr = D->getSemanticAvailableAttr(attr);
+    if (!semAttr)
+      continue;
+
+    diags.diagnose(semAttr->getIntroducedSourceRange().Start,
+                   diag::availability_decl_is_available_in, D,
+                   semAttr->getDomain(), *semAttr->getIntroduced());
+  }
+
+  auto attrGroups = getAvailableAttrGroups(attrs);
+  if (attrGroups.empty()) {
+    // The attributes are all written in long-form.
+    // FIXME: Generate fix-its for this pattern if it is common enough.
+    return;
+  }
+
+  if (attrGroups.size() > 1) {
+    // The attributes are written in multiple short-form groups.
+    return;
+  }
+
+  // The attributes include a single short-form. If they all belong
+  // to the same group we can emit a fix-it to update it.
+  llvm::SmallSet<const AvailableAttr *, 8> remainingAttrsToSkip;
+  for (auto *attr : attrsToReplace)
+    remainingAttrsToSkip.insert(attr);
+
+  llvm::SmallString<128> replacement;
+  llvm::raw_svector_ostream os(replacement);
+  os << "anyAppleOS " << commonVersion;
+
+  auto groupHead = attrGroups.front();
+  SourceLoc groupEndLoc = groupHead->getEndLoc();
+  for (auto *member = groupHead; member != nullptr;
+       member = member->getNextGroupedAvailableAttr()) {
+    groupEndLoc = member->getEndLoc();
+    if (remainingAttrsToSkip.erase(member))
+      continue;
+    if (auto semAttr = D->getSemanticAvailableAttr(member)) {
+      os << ", " << platformString(semAttr->getPlatform());
+      if (auto v = member->getRawIntroduced())
+        os << " " << *v;
+    }
+  }
+  os << ", *";
+
+  // Only emit the fix-it if all of the attributes to replace were found in
+  // the group.
+  if (remainingAttrsToSkip.empty()) {
+    // Make sure we have a valid source range in a single buffer. We might not
+    // if some attributes were expanded from an availability macro.
+    auto range = SourceRange(groupHead->getDomainLoc(), groupEndLoc);
+    auto startBuffer = ctx.SourceMgr.findBufferContainingLoc(range.Start);
+    auto endBuffer = ctx.SourceMgr.findBufferContainingLoc(range.End);
+    if (startBuffer != endBuffer)
+      return;
+
+    diag.fixItReplace(SourceRange(groupHead->getDomainLoc(), groupEndLoc),
+                      replacement);
+  }
+}
+
 void AttributeChecker::checkAvailableAttrs(ArrayRef<AvailableAttr *> attrs) {
   if (attrs.empty())
     return;
@@ -5360,6 +5519,8 @@ void AttributeChecker::checkAvailableAttrs(ArrayRef<AvailableAttr *> attrs) {
           .fixItInsert(groupEndLoc, ", *");
     }
   }
+
+  suggestAnyAppleOSAvailability(D, attrs, Ctx);
 
   if (Ctx.LangOpts.DisableAvailabilityChecking)
     return;

--- a/test/Availability/availability_suggest_any_apple_os.swift
+++ b/test/Availability/availability_suggest_any_apple_os.swift
@@ -1,0 +1,180 @@
+// RUN: %target-typecheck-verify-swift -Wwarning UseAnyAppleOSAvailability \
+// RUN:   -define-availability 'FourOSesAligned 26:macOS 26, iOS 26, tvOS 26, watchOS 26' \
+// RUN:   -verify-ignore-unrelated
+
+@available(macOS 26, iOS 26, tvOS 26, watchOS 26, *)
+// expected-note@-1 {{'allFourOSesAligned()' is available in macOS 26 or newer}}
+// expected-note@-2 {{'allFourOSesAligned()' is available in iOS 26 or newer}}
+// expected-note@-3 {{'allFourOSesAligned()' is available in tvOS 26 or newer}}
+// expected-note@-4 {{'allFourOSesAligned()' is available in watchOS 26 or newer}}
+func allFourOSesAligned() { } // expected-warning {{use '@available(anyAppleOS 26, *)' instead of platform specific '@available' attributes with the same version}}{{-5:39-53=anyAppleOS 26, *}}
+
+@available(macOS 26.0, iOS 26.0, tvOS 26.0, watchOS 26.0, *)
+// expected-note@-1 {{'allFourOSesAlignedTrailingZeroes()' is available in macOS 26.0 or newer}}
+// expected-note@-2 {{'allFourOSesAlignedTrailingZeroes()' is available in iOS 26.0 or newer}}
+// expected-note@-3 {{'allFourOSesAlignedTrailingZeroes()' is available in tvOS 26.0 or newer}}
+// expected-note@-4 {{'allFourOSesAlignedTrailingZeroes()' is available in watchOS 26.0 or newer}}
+func allFourOSesAlignedTrailingZeroes() { } // expected-warning {{use '@available(anyAppleOS 26, *)' instead of platform specific '@available' attributes with the same version}}{{-5:45-61=anyAppleOS 26, *}}
+
+@available(watchOS 26, tvOS 26, iOS 26, macOS 26, *)
+// expected-note@-1 {{'allFourOSesAlignedReversed()' is available in macOS 26 or newer}}
+// expected-note@-2 {{'allFourOSesAlignedReversed()' is available in iOS 26 or newer}}
+// expected-note@-3 {{'allFourOSesAlignedReversed()' is available in tvOS 26 or newer}}
+// expected-note@-4 {{'allFourOSesAlignedReversed()' is available in watchOS 26 or newer}}
+func allFourOSesAlignedReversed() { } // expected-warning {{use '@available(anyAppleOS 26, *)' instead of platform specific '@available' attributes with the same version}}{{-5:41-53=anyAppleOS 26, *}}
+
+@available(macOS 26, iOS 26.0, tvOS 26, watchOS 26.0, *)
+// expected-note@-1 {{'allFourOSesAlignedSomeTrailingZeroes()' is available in macOS 26 or newer}}
+// expected-note@-2 {{'allFourOSesAlignedSomeTrailingZeroes()' is available in iOS 26.0 or newer}}
+// expected-note@-3 {{'allFourOSesAlignedSomeTrailingZeroes()' is available in tvOS 26 or newer}}
+// expected-note@-4 {{'allFourOSesAlignedSomeTrailingZeroes()' is available in watchOS 26.0 or newer}}
+func allFourOSesAlignedSomeTrailingZeroes() { } // expected-warning {{use '@available(anyAppleOS 26, *)' instead of platform specific '@available' attributes with the same version}}{{-5:41-57=anyAppleOS 26, *}}
+
+@available(FourOSesAligned 26, *)
+func allFourOSesAlignedMacro() { } // expected-warning {{use '@available(anyAppleOS 26, *)' instead of platform specific '@available' attributes with the same version}}
+
+@available(macOS 26, iOS 26, tvOS 26, watchOS 26, visionOS 26, macCatalyst 26, *)
+// expected-note@-1 {{'allSixOSesAligned()' is available in macOS 26 or newer}}
+// expected-note@-2 {{'allSixOSesAligned()' is available in iOS 26 or newer}}
+// expected-note@-3 {{'allSixOSesAligned()' is available in tvOS 26 or newer}}
+// expected-note@-4 {{'allSixOSesAligned()' is available in watchOS 26 or newer}}
+// expected-note@-5 {{'allSixOSesAligned()' is available in visionOS 26 or newer}}
+// expected-note@-6 {{'allSixOSesAligned()' is available in Mac Catalyst 26 or newer}}
+func allSixOSesAligned() { } // expected-warning {{use '@available(anyAppleOS 26, *)' instead of platform specific '@available' attributes with the same version}}{{-7:64-82=anyAppleOS 26, *}}
+
+@available(macOS 26.4, iOS 26.4, tvOS 26.4, watchOS 26.4, *)
+// expected-note@-1 {{'allFourOSesAlignedMinorVersion()' is available in macOS 26.4 or newer}}
+// expected-note@-2 {{'allFourOSesAlignedMinorVersion()' is available in iOS 26.4 or newer}}
+// expected-note@-3 {{'allFourOSesAlignedMinorVersion()' is available in tvOS 26.4 or newer}}
+// expected-note@-4 {{'allFourOSesAlignedMinorVersion()' is available in watchOS 26.4 or newer}}
+func allFourOSesAlignedMinorVersion() { } // expected-warning {{use '@available(anyAppleOS 26.4, *)' instead of platform specific '@available' attributes with the same version}}{{-5:45-61=anyAppleOS 26.4, *}}
+
+@available(macOS 26, iOS 26, tvOS 26, watchOS 26.4, *)
+// expected-note@-1 {{'threeOSesAlignedOneUnaligned()' is available in macOS 26 or newer}}
+// expected-note@-2 {{'threeOSesAlignedOneUnaligned()' is available in iOS 26 or newer}}
+// expected-note@-3 {{'threeOSesAlignedOneUnaligned()' is available in tvOS 26 or newer}}
+func threeOSesAlignedOneUnaligned() { } // expected-warning {{use '@available(anyAppleOS 26, *)' instead of platform specific '@available' attributes with the same version}}{{-4:39-55=anyAppleOS 26, watchOS 26.4, *}}
+
+@available(macOS 26, iOS 26, tvOS 26, watchOS 26, visionOS 26.4, *)
+// expected-note@-1 {{'fourOSesAlignedOneUnaligned()' is available in macOS 26 or newer}}
+// expected-note@-2 {{'fourOSesAlignedOneUnaligned()' is available in iOS 26 or newer}}
+// expected-note@-3 {{'fourOSesAlignedOneUnaligned()' is available in tvOS 26 or newer}}
+// expected-note@-4 {{'fourOSesAlignedOneUnaligned()' is available in watchOS 26 or newer}}
+func fourOSesAlignedOneUnaligned() { } // expected-warning {{use '@available(anyAppleOS 26, *)' instead of platform specific '@available' attributes with the same version}}{{-5:51-68=anyAppleOS 26, visionOS 26.4, *}}
+
+@available(macOS 26, iOS 26, tvOS 26.4, watchOS 26.4, *)
+// expected-note@-1 {{'twoAlignedVersions()' is available in macOS 26 or newer}}
+// expected-note@-2 {{'twoAlignedVersions()' is available in iOS 26 or newer}}
+func twoAlignedVersions() { } // expected-warning {{use '@available(anyAppleOS 26, *)' instead of platform specific '@available' attributes with the same version}}{{-3:41-57=anyAppleOS 26, watchOS 26.4, tvOS 26.4, *}}
+
+@available(macOS 26.4, iOS 26.4, tvOS 26, watchOS 26, *)
+// expected-note@-1 {{'twoAlignedVersionsSwapped()' is available in tvOS 26 or newer}}
+// expected-note@-2 {{'twoAlignedVersionsSwapped()' is available in watchOS 26 or newer}}
+func twoAlignedVersionsSwapped() { } // expected-warning {{use '@available(anyAppleOS 26, *)' instead of platform specific '@available' attributes with the same version}}{{-3:43-57=anyAppleOS 26, iOS 26.4, macOS 26.4, *}}
+
+@available(macOS 26, iOS 26, *)
+// expected-note@-1 {{'alignedVersionsSplitIntoMultipleGropus()' is available in macOS 26 or newer}}
+// expected-note@-2 {{'alignedVersionsSplitIntoMultipleGropus()' is available in iOS 26 or newer}}
+@available(tvOS 26, watchOS 26, *)
+// expected-note@-1 {{'alignedVersionsSplitIntoMultipleGropus()' is available in tvOS 26 or newer}}
+// expected-note@-2 {{'alignedVersionsSplitIntoMultipleGropus()' is available in watchOS 26 or newer}}
+func alignedVersionsSplitIntoMultipleGropus() { } // expected-warning {{use '@available(anyAppleOS 26, *)' instead of platform specific '@available' attributes with the same version}}{{none}}
+
+@available(macOS, introduced: 26) // expected-note {{'fourOSesAlignedLongForm()' is available in macOS 26 or newer}}
+@available(iOS, introduced: 26) // expected-note {{'fourOSesAlignedLongForm()' is available in iOS 26 or newer}}
+@available(tvOS, introduced: 26) // expected-note {{'fourOSesAlignedLongForm()' is available in tvOS 26 or newer}}
+@available(watchOS, introduced: 26) // expected-note {{'fourOSesAlignedLongForm()' is available in watchOS 26 or newer}}
+func fourOSesAlignedLongForm() { } // expected-warning {{use '@available(anyAppleOS 26, *)' instead of platform specific '@available' attributes with the same version}}{{none}}
+
+@available(macOS, introduced: 26.4) // expected-note {{'fourOSesAlignedLongFormMinorVersion()' is available in macOS 26.4 or newer}}
+@available(iOS, introduced: 26.4) // expected-note {{'fourOSesAlignedLongFormMinorVersion()' is available in iOS 26.4 or newer}}
+@available(tvOS, introduced: 26.4) // expected-note {{'fourOSesAlignedLongFormMinorVersion()' is available in tvOS 26.4 or newer}}
+@available(watchOS, introduced: 26.4) // expected-note {{'fourOSesAlignedLongFormMinorVersion()' is available in watchOS 26.4 or newer}}
+func fourOSesAlignedLongFormMinorVersion() { } // expected-warning {{use '@available(anyAppleOS 26.4, *)' instead of platform specific '@available' attributes with the same version}}{{none}}
+
+@available(macOS, introduced: 26.0) // expected-note {{'fourOSesAlignedLongFormTrailingZeroes()' is available in macOS 26.0 or newer}}
+@available(iOS, introduced: 26.0) // expected-note {{'fourOSesAlignedLongFormTrailingZeroes()' is available in iOS 26.0 or newer}}
+@available(tvOS, introduced: 26.0) // expected-note {{'fourOSesAlignedLongFormTrailingZeroes()' is available in tvOS 26.0 or newer}}
+@available(watchOS, introduced: 26.0) // expected-note {{'fourOSesAlignedLongFormTrailingZeroes()' is available in watchOS 26.0 or newer}}
+func fourOSesAlignedLongFormTrailingZeroes() { } // expected-warning {{use '@available(anyAppleOS 26, *)' instead of platform specific '@available' attributes with the same version}}{{none}}
+
+@available(macOS, introduced: 26.0) // expected-note {{'fourOSesAlignedLongFormSomeTrailingZeroes()' is available in macOS 26.0 or newer}}
+@available(iOS, introduced: 26) // expected-note {{'fourOSesAlignedLongFormSomeTrailingZeroes()' is available in iOS 26 or newer}}
+@available(tvOS, introduced: 26.0) // expected-note {{'fourOSesAlignedLongFormSomeTrailingZeroes()' is available in tvOS 26.0 or newer}}
+@available(watchOS, introduced: 26) // expected-note {{'fourOSesAlignedLongFormSomeTrailingZeroes()' is available in watchOS 26 or newer}}
+func fourOSesAlignedLongFormSomeTrailingZeroes() { } // expected-warning {{use '@available(anyAppleOS 26, *)' instead of platform specific '@available' attributes with the same version}}{{none}}
+
+@available(macOS, introduced: 26) // expected-note {{'fiveOSesAlignedLongForm()' is available in macOS 26 or newer}}
+@available(iOS, introduced: 26) // expected-note {{'fiveOSesAlignedLongForm()' is available in iOS 26 or newer}}
+@available(tvOS, introduced: 26) // expected-note {{'fiveOSesAlignedLongForm()' is available in tvOS 26 or newer}}
+@available(watchOS, introduced: 26) // expected-note {{'fiveOSesAlignedLongForm()' is available in watchOS 26 or newer}}
+@available(visionOS, introduced: 26) // expected-note {{'fiveOSesAlignedLongForm()' is available in visionOS 26 or newer}}
+func fiveOSesAlignedLongForm() { } // expected-warning {{use '@available(anyAppleOS 26, *)' instead of platform specific '@available' attributes with the same version}}{{none}}
+
+@available(macOS 26, iOS 26, *)
+// expected-note@-1 {{'fourOSesAlignedMixedShortFormAndLongForm()' is available in macOS 26 or newer}}
+// expected-note@-2 {{'fourOSesAlignedMixedShortFormAndLongForm()' is available in iOS 26 or newer}}
+@available(tvOS, introduced: 26) // expected-note {{'fourOSesAlignedMixedShortFormAndLongForm()' is available in tvOS 26 or newer}}
+@available(watchOS, introduced: 26) // expected-note {{'fourOSesAlignedMixedShortFormAndLongForm()' is available in watchOS 26 or newer}}
+func fourOSesAlignedMixedShortFormAndLongForm() { } // expected-warning {{use '@available(anyAppleOS 26, *)' instead of platform specific '@available' attributes with the same version}}{{none}}
+
+@available(macOS, introduced: 26) // expected-note {{'fourOSesAlignedMixedShortFormAndLongFormSwapped()' is available in macOS 26 or newer}}
+@available(iOS, introduced: 26) // expected-note {{'fourOSesAlignedMixedShortFormAndLongFormSwapped()' is available in iOS 26 or newer}}
+@available(tvOS 26, watchOS 26, *)
+// expected-note@-1 {{'fourOSesAlignedMixedShortFormAndLongFormSwapped()' is available in tvOS 26 or newer}}
+// expected-note@-2 {{'fourOSesAlignedMixedShortFormAndLongFormSwapped()' is available in watchOS 26 or newer}}
+func fourOSesAlignedMixedShortFormAndLongFormSwapped() { } // expected-warning {{use '@available(anyAppleOS 26, *)' instead of platform specific '@available' attributes with the same version}}{{none}}
+
+@available(macOS, introduced: 26, deprecated: 26.4)
+@available(iOS, introduced: 26, deprecated: 26.4)
+@available(tvOS, introduced: 26, deprecated: 26.4)
+@available(watchOS, introduced: 26, deprecated: 26.4)
+func fourOSesAlignedLongFormAndDeprecated() { }
+
+@available(macOS, introduced: 26, obsoleted: 26.4)
+@available(iOS, introduced: 26, obsoleted: 26.4)
+@available(tvOS, introduced: 26, obsoleted: 26.4)
+@available(watchOS, introduced: 26, obsoleted: 26.4)
+func fourOSesAlignedLongFormAndObsoleted() { }
+
+@available(macOS, introduced: 26, message: "use something else")
+@available(iOS, introduced: 26, message: "use something else")
+@available(tvOS, introduced: 26, message: "use something else")
+@available(watchOS, introduced: 26, message: "use something else")
+func fourOSesAlignedLongFormWithMessage() { }
+
+@available(anyAppleOS 26, *)
+func alreadyUsesAnyAppleOS() { }
+
+@available(anyAppleOS 26, watchOS 26.4, tvOS 26.4, *)
+func alreadyUsesAnyAppleOSWithExceptions() { }
+
+@available(macOS 26, iOS 26, tvOS 26, *)
+func onlyThreePlatforms() { }
+
+@available(macOS 26, iOS 26.1, tvOS 26.2, watchOS 26.3, *)
+func noCommonVersions() { }
+
+@available(macOS 11, iOS 11, tvOS 11, watchOS 11, *)
+func versionsTooOld() { }
+
+@available(macOS, unavailable)
+@available(iOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+func fourOSesAlwaysUnavailable() { }
+
+@available(macOS, deprecated)
+@available(iOS, deprecated)
+@available(tvOS, deprecated)
+@available(watchOS, deprecated)
+func fourOSesAlwaysDeprecated() { }
+
+@available(macOSApplicationExtension 26, iOSApplicationExtension 26, tvOSApplicationExtension 26, watchOSApplicationExtension 26, *)
+func fourAppExtensionVersions() { }
+
+@available(macOSApplicationExtension, introduced: 26)
+@available(iOSApplicationExtension, introduced: 26)
+@available(tvOSApplicationExtension, introduced: 26)
+@available(watchOSApplicationExtension, introduced: 26)
+func fourAppExtensionVersionsLongForm() { }

--- a/userdocs/diagnostics/diagnostic-groups.md
+++ b/userdocs/diagnostics/diagnostic-groups.md
@@ -50,6 +50,7 @@ Or upgrade all warnings except deprecated declaration to errors:
 - <doc:strict-memory-safety>
 - <doc:unknown-warning-group>
 - <doc:untyped-throws>
+- <doc:use-any-apple-os-availability>
 
 
 ## Topics
@@ -98,4 +99,5 @@ Or upgrade all warnings except deprecated declaration to errors:
 - <doc:availability-unrecognized-name>
 - <doc:mutable-global-variable>
 - <doc:untyped-throws>
+- <doc:use-any-apple-os-availability>
 - <doc:existential-member-access-limitations>

--- a/userdocs/diagnostics/use-any-apple-os-availability.md
+++ b/userdocs/diagnostics/use-any-apple-os-availability.md
@@ -1,0 +1,33 @@
+# Use anyAppleOS availability (UseAnyAppleOSAvailability)
+
+An opt-in warning that suggests replacing a group of per-platform
+`@available` specifications with a single `anyAppleOS` specification when the
+platforms share the same introduced version.
+
+## Overview
+
+`anyAppleOS` is a meta-platform that covers all Apple platforms using unified
+versioning starting at 26.0. When a declaration is available on at least
+`macOS`, `iOS`, `tvOS`, and `watchOS` at the same introduced version, a single
+`anyAppleOS` specification expresses the same intent more concisely.
+
+This warning is opt-in and disabled by default. Enable it with:
+
+```
+-Wwarning UseAnyAppleOSAvailability
+```
+
+or promote it to an error with `-Werror UseAnyAppleOSAvailability`.
+
+## Examples
+
+Short-form grouped availability:
+
+```swift
+@available(macOS 26, iOS 26, tvOS 26, watchOS 26, *)
+func foo() {} // warning: use '@available(anyAppleOS 26, *)' instead of platform specific '@available' attributes with the same version
+
+// Suggested replacement
+@available(anyAppleOS 26, *)
+func foo() {}
+```


### PR DESCRIPTION
Enabling `UseAnyAppleOSAvailability` diagnostics will cause the compiler to diagnose declarations where `anyAppleOS` availability can be used as a concise replacement for platform-specific availability annotations.

Resolves rdar://163819878.
