### PR TITLE
[TEST-ONLY] Fix CAS/swift-scan-test

### DIFF
--- a/test/CAS/swift-scan-test.swift
+++ b/test/CAS/swift-scan-test.swift
@@ -36,17 +36,17 @@
 // RUN: diff %t/Test.swiftmodule %t/Test2.swiftmodule
 // RUN: diff %t/test.o %t/test2.o
 
-// RUN: stat %t/Test.swiftmodule > %t/before.module.stat
-// RUN: stat %t/test.o > %t/before.object.stat
+// RUN: %{python} %S/../Inputs/getmtime.py %t/Test.swiftmodule > %t/before.module.mtime
+// RUN: %{python} %S/../Inputs/getmtime.py %t/test.o > %t/before.object.mtime
 // RUN: %swift-scan-test -action replay_result -cas-path %t/cas -id @%t/key.casid -- \
 // RUN:   %target-swift-frontend-plain -cache-compile-job -Rcache-compile-job %s \
 // RUN:   -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies -module-name Test -o %t/test.o -cas-path %t/cas \
 // RUN:   @%t/MyApp.cmd
-// RUN: stat %t/Test.swiftmodule > %t/after.module.stat
-// RUN: stat %t/test.o > %t/after.object.stat
+// RUN: %{python} %S/../Inputs/getmtime.py %t/Test.swiftmodule > %t/after.module.mtime
+// RUN: %{python} %S/../Inputs/getmtime.py %t/test.o > %t/after.object.mtime
 
-// RUN: diff %t/before.module.stat %t/after.module.stat
-// RUN: diff %t/before.object.stat %t/after.object.stat
+// RUN: diff %t/before.module.mtime %t/after.module.mtime
+// RUN: diff %t/before.object.mtime %t/after.object.mtime
 
 // CHECK-QUERY-NOT-FOUND: cached output not found
 // CHECK-QUERY: Cached Compilation for key "llvmcas://{{.*}}" has 4 outputs:


### PR DESCRIPTION
Don't diff `stat` output, which might be different due to last access time. Using `getmtime` script to compare mtime only to make sure the output is not updated.

rdar://172853933

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
