### PR TITLE
Suggest immutable witness

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6026,8 +6026,10 @@ GROUPED_ERROR(conformance_mismatched_isolation_common,ConformanceIsolation,none,
 NOTE(note_make_conformance_preconcurrency,none,
      "turn data races into runtime errors with '@preconcurrency'",
      ())
-NOTE(note_make_witnesses_nonisolated,none,
-     "mark all declarations used in the conformance 'nonisolated'", ())
+NOTE(note_make_witness_nonisolated,none,
+     "mark %kind0 'nonisolated'", (const ValueDecl *))
+NOTE(note_make_witness_immutable,none,
+     "change %kind0 to a 'nonisolated let' constant", (const ValueDecl *))
 
 ERROR(isolated_parameter_not_actor,none,
       "'isolated' parameter type %0 does not conform to 'Actor' "

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -49,6 +49,7 @@
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/RequirementMatch.h"
+#include "swift/AST/Type.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/TypeDeclFinder.h"
 #include "swift/AST/TypeMatcher.h"
@@ -5015,6 +5016,25 @@ static bool isolationsMatch(
   return false;
 }
 
+/// Whether a witness declaration could be marked 'nonisolated'.
+static bool couldApplyNonisolated(WitnessIsolationError const &witnessError) {
+  if (hasExplicitGlobalActorAttr(witnessError.witness) ||
+      witnessError.witness->getLoc().isInvalid())
+    return false;
+  if (auto *var = dyn_cast<VarDecl>(witnessError.witness)) {
+    if (var->hasStorage()) {
+      // Mutable VarDecl with storage, for an immutable requirement, can be
+      // converted to 'let nonisolated'.
+      return !var->isLet() && isa<VarDecl>(witnessError.requirement) &&
+             !cast<VarDecl>(witnessError.requirement)
+                  ->isSettable(/*useDC=*/nullptr);
+    }
+    // Computed VarDecl can be converted if no property wrapper is present.
+    return !var->hasAttachedPropertyWrapper();
+  }
+  return isa<AbstractFunctionDecl, SubscriptDecl>(witnessError.witness);
+}
+
 static void diagnoseConformanceIsolationErrors(
     const NormalProtocolConformance *conformance
 ) {
@@ -5076,10 +5096,7 @@ static void diagnoseConformanceIsolationErrors(
       }
 
       // If this is an entity where `nonisolated` would make sense, suggest it.
-      if ((isa<AbstractFunctionDecl>(witnessError.witness) ||
-           isa<SubscriptDecl>(witnessError.witness)) &&
-          !hasExplicitGlobalActorAttr(witnessError.witness) &&
-          witnessError.witness->getLoc().isValid()) {
+      if (couldApplyNonisolated(witnessError)) {
         potentialNonisolated.push_back(witnessError.witness);
       }
 
@@ -5157,18 +5174,6 @@ static void diagnoseConformanceIsolationErrors(
                                              "@" + globalActorTypeStr.str());
     }
 
-    // If marking witnesses as 'nonisolated' could work, suggest that.
-    if (!potentialNonisolated.empty() && !hasIsolatedConformances) {
-      auto diag = ctx.Diags.diagnose(
-          conformance->getLoc(),
-          diag::note_make_witnesses_nonisolated);
-      for (auto witness: potentialNonisolated) {
-        diag.fixItInsert(
-            witness->getAttributeInsertionLoc(/*forModifier=*/true),
-            "nonisolated ");
-      }
-    }
-
     // If the conformance could be @preconcurrency, suggest it.
     if (!conformance->isIsolated() && !conformance->isPreconcurrency() &&
         !hasIsolatedConformances) {
@@ -5198,6 +5203,29 @@ static void diagnoseConformanceIsolationErrors(
 
         if (!witnessError.isMissingDistributed)
           witnessError.diagnose(conformance);
+      }
+    }
+
+    // If marking a witness as 'nonisolated' could work, suggest that.
+    if (!hasIsolatedConformances) {
+      for (auto witness : potentialNonisolated) {
+        auto var = dyn_cast<VarDecl>(witness);
+        // Not a variable, or a computed property.
+        if (!var || !var->hasStorage()) {
+          ctx.Diags
+              .diagnose(witness, diag::note_make_witness_nonisolated, witness)
+              .fixItInsert(
+                  witness->getAttributeInsertionLoc(/*forModifier=*/true),
+                  "nonisolated ");
+          continue;
+        }
+        // Mutable variables (since we didn't add let witnesses), which can be
+        // converted to 'nonisolated let'.
+        auto loc = getFixItLocForVarToLet(var);
+        if (loc.isValid()) {
+          ctx.Diags.diagnose(var, diag::note_make_witness_immutable, var)
+              .fixItReplace(loc, "nonisolated let");
+        }
       }
     }
   }

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -1546,12 +1546,12 @@ protocol SGA_Proto {
 // try to override a MA method with inferred isolation from a protocol requirement
 // expected-warning@+1{{conformance of 'SGA_MA' to protocol 'SGA_Proto' involves isolation mismatches and can cause data races}}
 class SGA_MA: MA, SGA_Proto {
-  // expected-note@-1{{mark all declarations used in the conformance 'nonisolated'}}
-  // expected-note@-2{{turn data races into runtime errors with '@preconcurrency'}}
-  
+  // expected-note@-1{{turn data races into runtime errors with '@preconcurrency'}}
+
   // expected-error@+2 {{call to global actor 'SomeGlobalActor'-isolated global function 'onions_sga()' in a synchronous main actor-isolated context}}
   // expected-note@+1 {{main actor-isolated instance method 'method()' cannot satisfy global actor 'SomeGlobalActor'-isolated requirement}}
   override func method() { onions_sga() }
+  // expected-note@-1{{mark instance method 'method()' 'nonisolated'}}{{3-3=nonisolated }}
 }
 
 class None_MA: MA {

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -128,6 +128,7 @@ class Object: Interface {
   // expected-note@-2{{isolate this conformance to the main actor with '@MainActor'}}
 
   var baz: Int = 42 // expected-note{{main actor-isolated property 'baz' cannot satisfy nonisolated requirement}}
+  // expected-note@-1{{change property 'baz' to a 'nonisolated let' constant}}{{3-6=nonisolated let}}
 }
 
 

--- a/test/Concurrency/global_actor_inference_swift6.swift
+++ b/test/Concurrency/global_actor_inference_swift6.swift
@@ -170,8 +170,7 @@ struct S2: InferMainActorInherited {
 // expected-error@+2{{conformance of 'S3' to protocol 'InferMainActorInherited' involves isolation mismatches and can cause data races}}
 @SomeGlobalActor
 struct S3: InferenceConflict {
-  // expected-note@-1{{mark all declarations used in the conformance 'nonisolated'}}
-  // expected-note@-2{{turn data races into runtime errors with '@preconcurrency'}}
+  // expected-note@-1{{turn data races into runtime errors with '@preconcurrency'}}
   nonisolated func g() { }
 }
 
@@ -179,6 +178,7 @@ extension S3 {
 
   func f() { }
   // expected-note@-1{{global actor 'SomeGlobalActor'-isolated instance method 'f()' cannot satisfy main actor-isolated requirement}}
+  // expected-note@-2{{mark instance method 'f()' 'nonisolated'}}{{3-3=nonisolated }}
 }
 
 @MainActor
@@ -204,13 +204,13 @@ protocol InferenceConflictWithSuperclass: MainActorSuperclass, InferSomeGlobalAc
 // expected-error@+1{{conformance of 'C2' to protocol 'InferenceConflictWithSuperclass' crosses into main actor-isolated code and can cause data races}}
 class C2: MainActorSuperclass, InferenceConflictWithSuperclass {
   //expected-note@-1 {{turn data races into runtime errors with '@preconcurrency'}}
-  // expected-note@-2{{mark all declarations used in the conformance 'nonisolated'}}
-  // expected-note@-3{{isolate this conformance to the main actor with '@MainActor'}}
+  // expected-note@-2{{isolate this conformance to the main actor with '@MainActor'}}
 
   func f() {}
 
   func g() {}
   // expected-note@-1 {{main actor-isolated instance method 'g()' cannot satisfy nonisolated requirement}}
+  // expected-note@-2{{mark instance method 'g()' 'nonisolated'}}{{3-3=nonisolated }}
 }
 
 

--- a/test/Concurrency/isolated_conformance.swift
+++ b/test/Concurrency/isolated_conformance.swift
@@ -10,13 +10,13 @@ protocol P {
 // Definition of isolated conformances
 // ----------------------------------------------------------------------------
 
-// expected-warning@+4{{conformance of 'CWithNonIsolated' to protocol 'P' crosses into main actor-isolated code and can cause data races}}
-// expected-note@+3{{mark all declarations used in the conformance 'nonisolated'}}
+// expected-warning@+3{{conformance of 'CWithNonIsolated' to protocol 'P' crosses into main actor-isolated code and can cause data races}}
 // expected-note@+2{{isolate this conformance to the main actor with '@MainActor'}}{{25-25=@MainActor }}
 @MainActor
 class CWithNonIsolated: P {
   // expected-note@-1{{turn data races into runtime errors with '@preconcurrency'}}{{25-25=@preconcurrency }}
   func f() { } // expected-note{{main actor-isolated instance method 'f()' cannot satisfy nonisolated requirement}}
+  // expected-note@-1{{mark instance method 'f()' 'nonisolated'}}{{3-3=nonisolated }}
 }
 
 // Make sure we correctly apply the conformance attribute for more complex
@@ -28,42 +28,42 @@ do {
     protocol Q { func f() }
   }
   do {
-    // expected-warning@+4 {{conformance of 'S' to protocol 'P' crosses into main actor-isolated code and can cause data races}}
-    // expected-note@+3 {{mark all declarations used in the conformance 'nonisolated'}}
+    // expected-warning@+3 {{conformance of 'S' to protocol 'P' crosses into main actor-isolated code and can cause data races}}
     // expected-note@+2 {{isolate this conformance to the main actor with '@MainActor'}}{{26-26=@MainActor }}
     // expected-note@+1 {{turn data races into runtime errors with '@preconcurrency'}}{{26-26=@preconcurrency }}
     @MainActor struct S: Nested.P {
       func f() {} // expected-note {{main actor-isolated instance method 'f()' cannot satisfy nonisolated requirement}}
+      // expected-note@-1 {{mark instance method 'f()' 'nonisolated'}}{{7-7=nonisolated }}
     }
   }
   do {
     // Attribute inserted *before* '@unsafe'.
     @MainActor struct S: @unsafe Nested.P {
     // expected-warning@-1 {{conformance of 'S' to protocol 'P' crosses into main actor-isolated code and can cause data races}}
-    // expected-note@-2 {{mark all declarations used in the conformance 'nonisolated'}}
-    // expected-note@-3 {{isolate this conformance to the main actor with '@MainActor'}}{{26-26=@MainActor }}
-    // expected-note@-4 {{turn data races into runtime errors with '@preconcurrency'}}{{26-26=@preconcurrency }}
+    // expected-note@-2 {{isolate this conformance to the main actor with '@MainActor'}}{{26-26=@MainActor }}
+    // expected-note@-3 {{turn data races into runtime errors with '@preconcurrency'}}{{26-26=@preconcurrency }}
       func f() {} // expected-note {{main actor-isolated instance method 'f()' cannot satisfy nonisolated requirement}}
+      // expected-note@-1 {{mark instance method 'f()' 'nonisolated'}}{{7-7=nonisolated }}
     }
   }
   do {
-    // expected-warning@+5 {{conformance of 'S' to protocol 'Q' crosses into main actor-isolated code and can cause data races}}
-    // expected-warning@+4 {{conformance of 'S' to protocol 'P' crosses into main actor-isolated code and can cause data races}}
-    // expected-note@+3 2 {{mark all declarations used in the conformance 'nonisolated'}}
+    // expected-warning@+4 {{conformance of 'S' to protocol 'Q' crosses into main actor-isolated code and can cause data races}}
+    // expected-warning@+3 {{conformance of 'S' to protocol 'P' crosses into main actor-isolated code and can cause data races}}
     // expected-note@+2 2 {{isolate this conformance to the main actor with '@MainActor'}}{{26-26=@MainActor }}
     // expected-note@+1 2 {{turn data races into runtime errors with '@preconcurrency'}}{{26-26=@preconcurrency }}
     @MainActor struct S: Nested.P & Nested.Q {
       func f() {} // expected-note 2 {{main actor-isolated instance method 'f()' cannot satisfy nonisolated requirement}}
+      // expected-note@-1 2 {{mark instance method 'f()' 'nonisolated'}}{{7-7=nonisolated }}
     }
   }
   do {
     // FIXME: We shouldn't be applying nonisolated to both protocols.
-    // expected-warning@+4 {{conformance of 'S' to protocol 'P' crosses into main actor-isolated code and can cause data races}}
-    // expected-note@+3 {{mark all declarations used in the conformance 'nonisolated'}}
+    // expected-warning@+3 {{conformance of 'S' to protocol 'P' crosses into main actor-isolated code and can cause data races}}
     // expected-note@+2 {{isolate this conformance to the main actor with '@MainActor'}}{{26-26=@MainActor }}
     // expected-note@+1 {{turn data races into runtime errors with '@preconcurrency'}}{{26-26=@preconcurrency }}
     @MainActor struct S: Nested.P & EmptyP  {
       func f() {} // expected-note {{main actor-isolated instance method 'f()' cannot satisfy nonisolated requirement}}
+      // expected-note@-1 {{mark instance method 'f()' 'nonisolated'}}{{7-7=nonisolated }}
     }
   }
 }
@@ -252,4 +252,104 @@ struct MyHashable: @MainActor Hashable {
 
 @concurrent func testMyHashableSet() async {
   let _: Set<MyHashable> = [] // expected-warning{{main actor-isolated conformance of 'MyHashable' to 'Hashable' cannot be used in nonisolated context}}
+}
+
+// Like Identifiable!
+protocol Distinguishable {
+  associatedtype ID: Hashable
+  var id: Self.ID { get }
+}
+
+// expected-warning@+4{{conformance of 'MyDistinguishable' to protocol 'Distinguishable' crosses into main actor-isolated code and can cause data races}}
+// expected-note@+3{{isolate this conformance to the main actor with '@MainActor'}}{{26-26=@MainActor }}
+// expected-note@+2{{turn data races into runtime errors with '@preconcurrency'}}{{26-26=@preconcurrency }}
+@MainActor
+class MyDistinguishable: Distinguishable {
+  var id = "" // expected-note{{main actor-isolated property 'id' cannot satisfy nonisolated requirement}}
+  // expected-note@-1{{change property 'id' to a 'nonisolated let' constant}}{{3-6=nonisolated let}}
+  var name = "my distinguishable"
+}
+
+protocol HasMutableVar {
+  associatedtype Val
+  var val: Self.Val { get set }
+}
+
+// expected-warning@+7{{conformance of 'ImmutableWithSeparateMutable' to protocol 'Distinguishable' crosses into main actor-isolated code and can cause data races}}
+// expected-note@+6{{isolate this conformance to the main actor with '@MainActor'}}
+// expected-note@+5{{turn data races into runtime errors with '@preconcurrency'}}
+// expected-warning@+4{{conformance of 'ImmutableWithSeparateMutable' to protocol 'HasMutableVar' crosses into main actor-isolated code and can cause data races}}
+// expected-note@+3{{isolate this conformance to the main actor with '@MainActor'}}
+// expected-note@+2{{turn data races into runtime errors with '@preconcurrency'}}
+@MainActor
+class ImmutableWithSeparateMutable: Distinguishable, HasMutableVar {
+  var id = "" // expected-note{{main actor-isolated property 'id' cannot satisfy nonisolated requirement}}
+  // expected-note@-1{{change property 'id' to a 'nonisolated let' constant}}{{3-6=nonisolated let}}
+  var val = 42 // expected-note{{main actor-isolated property 'val' cannot satisfy nonisolated requirement}}
+}
+
+protocol MixedMutability {
+  var name: String { get }
+  var count: Int { get set }
+}
+
+// expected-warning@+4{{conformance of 'MixedMutabilityWitness' to protocol 'MixedMutability' crosses into main actor-isolated code and can cause data races}}
+// expected-note@+3{{isolate this conformance to the main actor with '@MainActor'}}
+// expected-note@+2{{turn data races into runtime errors with '@preconcurrency'}}
+@MainActor
+class MixedMutabilityWitness: MixedMutability {
+  var name = "hello" // expected-note{{main actor-isolated property 'name' cannot satisfy nonisolated requirement}}
+  // expected-note@-1{{change property 'name' to a 'nonisolated let' constant}}{{3-6=nonisolated let}}
+  var count = 0 // expected-note{{main actor-isolated property 'count' cannot satisfy nonisolated requirement}}
+}
+
+protocol MultipleReadOnly {
+  var first: String { get }
+  var second: Int { get }
+}
+
+// expected-warning@+4{{conformance of 'MultipleReadOnlyWitness' to protocol 'MultipleReadOnly' crosses into main actor-isolated code and can cause data races}}
+// expected-note@+3{{isolate this conformance to the main actor with '@MainActor'}}
+// expected-note@+2{{turn data races into runtime errors with '@preconcurrency'}}
+@MainActor
+class MultipleReadOnlyWitness: MultipleReadOnly {
+  var first = "a" // expected-note{{main actor-isolated property 'first' cannot satisfy nonisolated requirement}}
+  // expected-note@-1{{change property 'first' to a 'nonisolated let' constant}}{{3-6=nonisolated let}}
+  var second = 1 // expected-note{{main actor-isolated property 'second' cannot satisfy nonisolated requirement}}
+  // expected-note@-1{{change property 'second' to a 'nonisolated let' constant}}{{3-6=nonisolated let}}
+  var third = true
+}
+
+// expected-warning@+4{{conformance of 'ComputedWitness' to protocol 'Distinguishable' crosses into main actor-isolated code and can cause data races}}
+// expected-note@+3{{isolate this conformance to the main actor with '@MainActor'}}
+// expected-note@+2{{turn data races into runtime errors with '@preconcurrency'}}
+@MainActor
+class ComputedWitness: Distinguishable {
+  var id: String { "computed" } // expected-note{{main actor-isolated property 'id' cannot satisfy nonisolated requirement}}
+  // expected-note@-1{{mark property 'id' 'nonisolated'}}{{3-3=nonisolated }}
+}
+
+@propertyWrapper
+struct Wrapped<Value> {
+  var wrappedValue: Value
+}
+
+// expected-warning@+4{{conformance of 'WrappedWitness' to protocol 'Distinguishable' crosses into main actor-isolated code and can cause data races}}
+// expected-note@+3{{isolate this conformance to the main actor with '@MainActor'}}
+// expected-note@+2{{turn data races into runtime errors with '@preconcurrency'}}
+@MainActor
+class WrappedWitness: Distinguishable {
+  @Wrapped var id: String = "wrapped" // expected-note{{main actor-isolated property 'id' cannot satisfy nonisolated requirement}}
+}
+
+// expected-warning@+4{{conformance of 'ComputedGetSetWitness' to protocol 'HasMutableVar' crosses into main actor-isolated code and can cause data races}}
+// expected-note@+3{{isolate this conformance to the main actor with '@MainActor'}}
+// expected-note@+2{{turn data races into runtime errors with '@preconcurrency'}}
+@MainActor
+class ComputedGetSetWitness: HasMutableVar {
+  var val: Int { // expected-note{{main actor-isolated property 'val' cannot satisfy nonisolated requirement}}
+  // expected-note@-1{{mark property 'val' 'nonisolated'}}{{3-3=nonisolated }}
+    get { 42 }
+    set { }
+  }
 }

--- a/test/Concurrency/isolated_conformance_default_actor.swift
+++ b/test/Concurrency/isolated_conformance_default_actor.swift
@@ -14,12 +14,12 @@ protocol Q {
   func g()
 }
 
-// expected-note@+4{{turn data races into runtime errors with '@preconcurrency'}}
-// expected-note@+3{{isolate this conformance to the main actor with '@MainActor'}}
-// expected-note@+2{{mark all declarations used in the conformance 'nonisolated'}}
+// expected-note@+3{{turn data races into runtime errors with '@preconcurrency'}}
+// expected-note@+2{{isolate this conformance to the main actor with '@MainActor'}}
 // expected-error@+1{{conformance of 'CImplicitMainActorNonisolatedConformance' to protocol 'P' crosses into main actor-isolated code and can cause data races}}
 class CImplicitMainActorNonisolatedConformance: nonisolated P {
   func f() { // expected-note{{main actor-isolated instance method 'f()' cannot satisfy nonisolated requirement}}
+  // expected-note@-1{{mark instance method 'f()' 'nonisolated'}}{{3-3=nonisolated }}
     onMain() // okay, f is on @MainActor
   }
 }

--- a/test/Concurrency/preconcurrency_conformances.swift
+++ b/test/Concurrency/preconcurrency_conformances.swift
@@ -107,9 +107,9 @@ final class K : @preconcurrency Initializable {
 @MainActor
 final class MainActorK: Initializable {
   // expected-note@-1{{turn data races into runtime errors with '@preconcurrency'}}{{25-25=@preconcurrency }}
-  // expected-note@-2{{mark all declarations used in the conformance 'nonisolated'}}
-  // expected-note@-3{{isolate this conformance to the main actor with '@MainActor'}}
+  // expected-note@-2{{isolate this conformance to the main actor with '@MainActor'}}
   init() { } // expected-note{{main actor-isolated initializer 'init()' cannot satisfy nonisolated requirement}}
+  // expected-note@-1{{mark initializer 'init()' 'nonisolated'}}{{3-3=nonisolated }}
 }
 
 protocol WithAssoc {
@@ -236,19 +236,19 @@ do {
   @MainActor struct S4: @preconcurrency P3, P2 {
     // expected-warning@-1:21 {{'@preconcurrency' on conformance to 'P3' has no effect}}
     // expected-note@-2:45 {{turn data races into runtime errors with '@preconcurrency'}}
-    // expected-note@-3{{mark all declarations used in the conformance 'nonisolated'}}
-    // expected-note@-4{{isolate this conformance to the main actor with '@MainActor'}}
+    // expected-note@-3{{isolate this conformance to the main actor with '@MainActor'}}
     func foo() {}
     // expected-note@-1 {{main actor-isolated instance method 'foo()' cannot satisfy nonisolated requirement}}
+    // expected-note@-2{{mark instance method 'foo()' 'nonisolated'}}{{5-5=nonisolated }}
   }
   // expected-warning@+1{{conformance of 'S5' to protocol 'P2' crosses into main actor-isolated code and can cause data races; this is an error in the Swift 6 language mode}}
   @MainActor struct S5: P2, @preconcurrency P3 {
     // expected-warning@-1:21 {{'@preconcurrency' on conformance to 'P3' has no effect}}
     // expected-note@-2:25 {{turn data races into runtime errors with '@preconcurrency'}}
-    // expected-note@-3{{mark all declarations used in the conformance 'nonisolated'}}
-    // expected-note@-4{{isolate this conformance to the main actor with '@MainActor'}}
+    // expected-note@-3{{isolate this conformance to the main actor with '@MainActor'}}
     func foo() {}
     // expected-note@-1 {{main actor-isolated instance method 'foo()' cannot satisfy nonisolated requirement}}
+    // expected-note@-2{{mark instance method 'foo()' 'nonisolated'}}{{5-5=nonisolated }}
   }
   // expected-warning@+1 {{'@preconcurrency' on conformance to 'P3' has no effect}}
   @MainActor struct S6: @preconcurrency P2, @preconcurrency P3 {
@@ -306,10 +306,10 @@ do {
   @MainActor struct S4: P6, @preconcurrency P5 {
     // expected-warning@-1:21 {{'@preconcurrency' on conformance to 'P5' has no effect}}
     // expected-note@-2{{turn data races into runtime errors with '@preconcurrency'}}
-    // expected-note@-3{{mark all declarations used in the conformance 'nonisolated'}}
-    // expected-note@-4{{isolate this conformance to the main actor with '@MainActor'}}
+    // expected-note@-3{{isolate this conformance to the main actor with '@MainActor'}}
     func foo() {}
     // expected-note@-1 {{main actor-isolated instance method 'foo()' cannot satisfy nonisolated requirement}}
+    // expected-note@-2{{mark instance method 'foo()' 'nonisolated'}}{{5-5=nonisolated }}
   }
 }
 

--- a/test/Concurrency/predates_concurrency.swift
+++ b/test/Concurrency/predates_concurrency.swift
@@ -227,11 +227,11 @@ protocol NotIsolated {
 // expected-complete-warning@+1{{conformance of 'MainActorPreconcurrency' to protocol 'NotIsolated' crosses into main actor-isolated code and can cause data races}}
 extension MainActorPreconcurrency: NotIsolated {
   // expected-complete-note@-1{{turn data races into runtime errors with '@preconcurrency'}}{{36-36=@preconcurrency }}
-  // expected-complete-note@-2{{mark all declarations used in the conformance 'nonisolated'}}
-  // expected-complete-note@-3{{isolate this conformance to the main actor with '@MainActor'}}
+  // expected-complete-note@-2{{isolate this conformance to the main actor with '@MainActor'}}
   func requirement() {}
   // expected-complete-note@-1 {{main actor-isolated instance method 'requirement()' cannot satisfy nonisolated requirement}}
-  // expected-complete-note@-2 {{calls to instance method 'requirement()' from outside of its actor context are implicitly asynchronous}}
+  // expected-complete-note@-2 {{mark instance method 'requirement()' 'nonisolated'}}{{3-3=nonisolated }}
+  // expected-complete-note@-3 {{calls to instance method 'requirement()' from outside of its actor context are implicitly asynchronous}}
 
 
   class Nested {

--- a/test/Distributed/distributed_protocol_isolation.swift
+++ b/test/Distributed/distributed_protocol_isolation.swift
@@ -105,14 +105,16 @@ protocol StrictlyLocal {
 // expected-error@+1{{conformance of 'Nope1_StrictlyLocal' to protocol 'StrictlyLocal' crosses into actor-isolated code and can cause data races}}
 distributed actor Nope1_StrictlyLocal: StrictlyLocal {
   // expected-note@-1{{turn data races into runtime errors with '@preconcurrency'}}{{40-40=@preconcurrency }}
-  // expected-note@-2{{mark all declarations used in the conformance 'nonisolated'}}
 
   func local() {}
   // expected-note@-1{{actor-isolated instance method 'local()' cannot satisfy nonisolated requirement}}
+  // expected-note@-2{{mark instance method 'local()' 'nonisolated'}}{{3-3=nonisolated }}
   func localThrows() throws {}
   // expected-note@-1{{actor-isolated instance method 'localThrows()' cannot satisfy nonisolated requirement}}
+  // expected-note@-2{{mark instance method 'localThrows()' 'nonisolated'}}{{3-3=nonisolated }}
   func localAsync() async {}
   // expected-note@-1{{actor-isolated instance method 'localAsync()' cannot satisfy nonisolated requirement}}
+  // expected-note@-2{{mark instance method 'localAsync()' 'nonisolated'}}{{3-3=nonisolated }}
 }
 
 // expected-error@+1{{conformance of 'Nope2_StrictlyLocal' to protocol 'StrictlyLocal' involves isolation mismatches and can cause data races}}
@@ -204,10 +206,10 @@ func test_watching_A(a: A_TerminationWatchingA) async throws {
 // expected-error@+1{{conformance of 'DA_TerminationWatchingA' to protocol 'TerminationWatchingA' crosses into actor-isolated code and can cause data races}}
 distributed actor DA_TerminationWatchingA: TerminationWatchingA {
   // expected-note@-1{{turn data races into runtime errors with '@preconcurrency'}}
-  // expected-note@-2{{mark all declarations used in the conformance 'nonisolated'}}
 
   func terminated(a: String) { }
   // expected-note@-1{{actor-isolated instance method 'terminated(a:)' cannot satisfy nonisolated requirement}}
+  // expected-note@-2{{mark instance method 'terminated(a:)' 'nonisolated'}}{{3-3=nonisolated }}
 }
 
 distributed actor DA_TerminationWatchingDA: TerminationWatchingDA {

--- a/test/decl/class/actor/conformance.swift
+++ b/test/decl/class/actor/conformance.swift
@@ -37,31 +37,36 @@ protocol SyncProtocol {
 // expected-error@+1{{conformance of 'OtherActor' to protocol 'SyncProtocol' crosses into actor-isolated code and can cause data races}}
 actor OtherActor: SyncProtocol {
   // expected-note@-1{{turn data races into runtime errors with '@preconcurrency'}}{{19-19=@preconcurrency }}
-  // expected-note@-2{{mark all declarations used in the conformance 'nonisolated'}}
 
   var propertyB: Int = 17
   // expected-note@-1{{actor-isolated property 'propertyB' cannot satisfy nonisolated requirement}}
 
   var propertyA: Int { 17 }
   // expected-note@-1{{actor-isolated property 'propertyA' cannot satisfy nonisolated requirement}}
+  // expected-note@-2{{mark property 'propertyA' 'nonisolated'}}{{3-3=nonisolated }}
 
   func syncMethodA() { }
   // expected-note@-1{{actor-isolated instance method 'syncMethodA()' cannot satisfy nonisolated requirement}}
+  // expected-note@-2{{mark instance method 'syncMethodA()' 'nonisolated'}}{{3-3=nonisolated }}
 
   // nonisolated methods are okay.
   nonisolated func syncMethodC() -> Int { 5 }
 
   func syncMethodE() -> Void { }
   // expected-note@-1{{actor-isolated instance method 'syncMethodE()' cannot satisfy nonisolated requirement}}
+  // expected-note@-2{{mark instance method 'syncMethodE()' 'nonisolated'}}{{3-3=nonisolated }}
 
   func syncMethodF(param: String) -> Int { 5 }
   // expected-note@-1{{actor-isolated instance method 'syncMethodF(param:)' cannot satisfy nonisolated requirement}}
+  // expected-note@-2{{mark instance method 'syncMethodF(param:)' 'nonisolated'}}{{3-3=nonisolated }}
 
   func syncMethodG() { }
   // expected-note@-1{{actor-isolated instance method 'syncMethodG()' cannot satisfy nonisolated requirement}}
+  // expected-note@-2{{mark instance method 'syncMethodG()' 'nonisolated'}}{{3-3=nonisolated }}
 
   subscript (index: Int) -> String { "\(index)" }
   // expected-note@-1{{actor-isolated subscript 'subscript(_:)' cannot satisfy nonisolated requirement}}
+  // expected-note@-2{{mark subscript 'subscript(_:)' 'nonisolated'}}{{3-3=nonisolated }}
 
   // Static methods and properties are okay.
   static func staticMethod() { }

--- a/test/decl/class/actor/global_actor_conformance.swift
+++ b/test/decl/class/actor/global_actor_conformance.swift
@@ -57,10 +57,10 @@ protocol NonIsolatedRequirement {
 // expected-warning@+1{{conformance of 'OnMain' to protocol 'NonIsolatedRequirement' crosses into main actor-isolated code}}
 extension OnMain: NonIsolatedRequirement {
   // expected-note@-1{{turn data races into runtime errors with '@preconcurrency'}}
-  // expected-note@-2{{mark all declarations used in the conformance 'nonisolated'}}
-  // expected-note@-3{{isolate this conformance to the main actor with '@MainActor'}}
+  // expected-note@-2{{isolate this conformance to the main actor with '@MainActor'}}
   // expected-note@+1 {{main actor-isolated instance method 'requirement()' cannot satisfy nonisolated requirement}}
   func requirement() {}
+  // expected-note@-1{{mark instance method 'requirement()' 'nonisolated'}}{{3-3=nonisolated }}
 }
 
 // expected-note@+1 {{calls to global function 'downgrade()' from outside of its actor context are implicitly asynchronous}}

--- a/userdocs/diagnostics/conformance-isolation.md
+++ b/userdocs/diagnostics/conformance-isolation.md
@@ -20,15 +20,15 @@ struct MyData: P {
 This code will produce an error similar to:
 
 ```swift
-| @MainActor
-| struct MyData: P {
-|        |- error: conformance of 'MyData' to protocol 'P' crosses into main actor-isolated code and can cause data races
-|        |- note: isolate this conformance to the main actor with '@MainActor'
-|        |- note: mark all declarations used in the conformance 'nonisolated'
-|        `- note: turn data races into runtime errors with '@preconcurrency'
-|   func f() { }
-|        `- note: main actor-isolated instance method 'f()' cannot satisfy nonisolated requirement
-| }
+@MainActor
+struct MyData: P {
+            // |- error: conformance of 'MyData' to protocol 'P' crosses into main actor-isolated code and can cause data races
+            // |- note: isolate this conformance to the main actor with '@MainActor'
+            // `- note: turn data races into runtime errors with '@preconcurrency'
+  func f() { }
+    // |- note: main actor-isolated instance method 'f()' cannot satisfy nonisolated requirement
+    // `- note: mark instance method 'f()' 'nonisolated'
+}
 ```
 
 There are several options for resolving this error, as indicated by the notes:
@@ -41,6 +41,14 @@ There are several options for resolving this error, as indicated by the notes:
   }
   ```
 
+* If the protocol requirements themselves are meant to always be used from the correct isolation domain (for example, the main actor) but the protocol itself did not describe that requirement, the conformance can be marked with `@preconcurrency`. This approach moves isolation checking into a run-time assertion, which will produce a fatal error if an operation is called without already being on the right actor. A `@preconcurrency` conformance can be written as follows:
+  ```swift
+  @MainActor
+  struct MyData: @preconcurrency P {
+    func f() { }
+  }
+  ```
+
 * If the conformance needs to be usable anywhere, then each of the operations used to satisfy its requirements must be marked `nonisolated`. This means that they will not have access to any actor-specific operations or state, because these operations can be called concurrently from anywhere. The result would look like this:
   ```swift
   @MainActor
@@ -49,10 +57,30 @@ There are several options for resolving this error, as indicated by the notes:
   }
   ```
 
-* If the protocol requirements themselves are meant to always be used from the correct isolation domain (for example, the main actor) but the protocol itself did not describe that requirement, the conformance can be marked with `@preconcurrency`. This approach moves isolation checking into a run-time assertion, which will produce a fatal error if an operation is called without already being on the right actor. A `@preconcurrency` conformance can be written as follows:
-  ```swift
-  @MainActor
-  struct MyData: @preconcurrency P {
-    func f() { }
-  }
-  ```
+## Stored Properties
+
+When conforming to a protocol that has read only properties, there is an additional option; defining properties as `nonisolated let`. This makes them immutable and concurrently accessible. For example:
+
+```swift
+@MainActor
+class MyModel: ObservableObject, Identifiable {
+  var id = UUID()
+   // |- note: main actor-isolated property 'id' cannot satisfy nonisolated requirement
+   // `- note: change property 'id' to a 'nonisolated let' constant
+  var count = 0
+}
+```
+
+By changing `id` from `var` to `nonisolated let`, any generic code that works with `Identifiable` can safely read `id` from any isolation region:
+
+```swift
+@MainActor
+class MyModel: ObservableObject, Identifiable {
+  nonisolated let id = UUID()
+  var count = 0
+}
+```
+
+## See Also
+
+- [Isolated conformances](isolated-conformances.md)


### PR DESCRIPTION
Fixes rdar://89864078, a bug about not emitting a useful diagnostic or fix-it for `var id` on an `Identifiable` class that is also on the main actor, by checking if all the required vars are immutable, and suggesting mutable variables be converted to `nonisolated let` and presumably fix the isolation issue. Treats vardecls without storage or property wrappers as candidates for adding nonisolated, so we can handle the computed property case. Also updates user docs to highlight this slightly special case (may not be needed). Also moves the existing 'nonisolated' fix-it to be per witness instead of for the entire definition for consistency.

~~I added a check to not emit fix-its and the new note if _any_ of the witnesses for the conformance couldn't be converted to `nonisolated let`. This might be too conservative, since we don't have that restriction for the other fixes.~~

```swift
protocol Distinguishable {
  associatedtype ID: Hashable
  var id: Self.ID { get }
}

@MainActor
class MyModal: Distinguishable {
    var id = "hello"
}

@MainActor
class ComputedWitness: Distinguishable {
  var id: String {
    get { "hi" }
    set { }
  }
}
```

```
debug-files/main_actor_ident.swift:7:16: error: conformance of 'MyModal' to protocol 'Distinguishable' crosses into main actor-isolated code and can cause data races [#[ConformanceIsolation](https://docs.swift.org/compiler/documentation/diagnostics/conformance-isolation)]
 5 |
 6 | @MainActor
 7 | class MyModal: Distinguishable {
   |                |- error: conformance of 'MyModal' to protocol 'Distinguishable' crosses into main actor-isolated code and can cause data races [#[ConformanceIsolation](https://docs.swift.org/compiler/documentation/diagnostics/conformance-isolation)]
   |                |- note: isolate this conformance to the main actor with '@MainActor'
   |                `- note: turn data races into runtime errors with '@preconcurrency'
 8 |     var id = "hello"
   |         |- note: main actor-isolated property 'id' cannot satisfy nonisolated requirement
   |         `- note: change property 'id' to a 'nonisolated let' constant
 9 | }
10 |

debug-files/main_actor_ident.swift:12:24: error: conformance of 'ComputedWitness' to protocol 'Distinguishable' crosses into main actor-isolated code and can cause data races [#[ConformanceIsolation](https://docs.swift.org/compiler/documentation/diagnostics/conformance-isolation)]
10 |
11 | @MainActor
12 | class ComputedWitness: Distinguishable {
   |                        |- error: conformance of 'ComputedWitness' to protocol 'Distinguishable' crosses into main actor-isolated code and can cause data races [#[ConformanceIsolation](https://docs.swift.org/compiler/documentation/diagnostics/conformance-isolation)]
   |                        |- note: isolate this conformance to the main actor with '@MainActor'
   |                        `- note: turn data races into runtime errors with '@preconcurrency'
13 |   var id: String {
   |       |- note: main actor-isolated property 'id' cannot satisfy nonisolated requirement
   |       `- note: mark property 'id' 'nonisolated'
14 |     get { "hi" }
15 |     set { }

[#ConformanceIsolation]: <https://docs.swift.org/compiler/documentation/diagnostics/conformance-isolation>
```