### PR TITLE
Fix OSSA utility GuaranteedOwnershipExtension

### DIFF
--- a/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
@@ -101,16 +101,19 @@ class GuaranteedOwnershipExtension {
   DeadEndBlocks &deBlocks;
 
   // --- analysis state
+  SmallVector<SILBasicBlock *> guaranteedLivenessBlocks;
   MultiDefPrunedLiveness guaranteedLiveness;
+  SmallVector<SILBasicBlock *> ownedLifetimeBlocks;
   SSAPrunedLiveness ownedLifetime;
-  SmallVector<SILBasicBlock *, 4> ownedConsumeBlocks;
   BeginBorrowInst *beginBorrow = nullptr;
 
 public:
   GuaranteedOwnershipExtension(InstructionDeleter &deleter,
                                DeadEndBlocks &deBlocks, SILFunction *function)
     : deleter(deleter), deBlocks(deBlocks),
-      guaranteedLiveness(function), ownedLifetime(function) {}
+      guaranteedLiveness(function, &guaranteedLivenessBlocks),
+      ownedLifetime(function, &ownedLifetimeBlocks)
+  {}
 
   /// Invalid indicates that the current guaranteed scope is insufficient, and
   /// it does not meet the precondition for scope extension.

--- a/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
@@ -252,7 +252,6 @@ GuaranteedOwnershipExtension::checkLifetimeExtension(
     auto *user = use->getUser();
     if (use->isConsuming()) {
       ownedLifetime.updateForUse(user, true);
-      ownedConsumeBlocks.push_back(user->getParent());
     }
   }
   if (ownedLifetime.areUsesWithinBoundary(newUses, &deBlocks))
@@ -268,17 +267,17 @@ void GuaranteedOwnershipExtension::transform(Status status) {
     return;
   case ExtendBorrow: {
     PrunedLivenessBoundary guaranteedBoundary;
-    guaranteedLiveness.computeBoundary(guaranteedBoundary, ownedConsumeBlocks);
+    guaranteedLiveness.computeBoundary(guaranteedBoundary);
     extendLocalBorrow(beginBorrow, guaranteedBoundary, deleter);
     break;
   }
   case ExtendLifetime: {
     ownedLifetime.extendAcrossLiveness(guaranteedLiveness);
     PrunedLivenessBoundary ownedBoundary;
-    ownedLifetime.computeBoundary(ownedBoundary, ownedConsumeBlocks);
+    ownedLifetime.computeBoundary(ownedBoundary);
     extendOwnedLifetime(beginBorrow->getOperand(), ownedBoundary, deleter);
     PrunedLivenessBoundary guaranteedBoundary;
-    guaranteedLiveness.computeBoundary(guaranteedBoundary, ownedConsumeBlocks);
+    guaranteedLiveness.computeBoundary(guaranteedBoundary);
     extendLocalBorrow(beginBorrow, guaranteedBoundary, deleter);
     break;
   }

--- a/test/SILOptimizer/access_enforcement_opts_ossa.sil
+++ b/test/SILOptimizer/access_enforcement_opts_ossa.sil
@@ -1930,3 +1930,46 @@ bb0(%1 : @guaranteed $RefElemClass):
   %11 = tuple ()
   return %11
 }
+
+// rdar://172778316 Found a leak due to a consuming post-dominance failure
+//
+// When merging two accesses from independent copies (%1 and %2), test the lifetime extension of the first copy when it
+// is originally destroyed in an earlier block.
+//
+// CHECK-LABEL: sil [ossa] @test_extend_lifetime_cross_block : $@convention(thin) () -> () {
+// CHECK:   begin_access [read] [static] [no_nested_conflict]
+// CHECK-NOT: end_access
+// CHECK: bb1:
+// CHECK:   end_access
+// CHECK:   end_borrow
+// CHECK:   destroy_value
+// CHECK:   end_borrow
+// CHECK:   destroy_value
+// CHECK:   destroy_value
+// CHECK-LABEL: } // end sil function 'test_extend_lifetime_cross_block'
+sil [ossa] @test_extend_lifetime_cross_block : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_box ${ var X }, var, name "s"
+  %1 = copy_value %0 : ${ var X }
+  %2 = copy_value %0 : ${ var X }
+  %3 = begin_borrow %1 : ${ var X }
+  %4 = project_box %3 : ${ var X }, 0
+  %5 = begin_access [read] [dynamic] %4 : $*X
+  %6 = load [trivial] %5 : $*X
+  end_access %5 : $*X
+  end_borrow %3 : ${ var X }
+  destroy_value %1 : ${ var X }
+  br bb1
+
+bb1:
+  %11 = begin_borrow %2 : ${ var X }
+  %12 = project_box %11 : ${ var X }, 0
+  %13 = begin_access [read] [dynamic] %12 : $*X
+  %14 = load [trivial] %13 : $*X
+  end_access %13 : $*X
+  end_borrow %11 : ${ var X }
+  destroy_value %2 : ${ var X }
+  destroy_value %0 : ${ var X }
+  %19 = tuple ()
+  return %19 : $()
+}


### PR DESCRIPTION
OSSA utilities have a compile-time micro-optimization for computing the liveness
boundary. It takes advantage of the OSSA property that the consuming uses
post-dominate all uses. But when we extend liveness to incorporate new uses of a
guaranteed value, that optimization no longer applies. As a result, we end up
deleting a destroy_value that is in the middle of the new live range without
creating a new compensating destroy_value. Simply remove the optimization in
this case.

Fixes rdar://172778316: Found a leak due to a consuming
post-dominance failure
