### PR TITLE
[BridgingHeader] Improve bridging header scanning to fix corner cases

### DIFF
--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -1884,37 +1884,37 @@ llvm::Error ModuleDependencyScanner::performBridgingHeaderChaining(
   // a path-relative component into dependency scanning and defeat the purpose
   // of prefix mapping. Additionally, if everything is prefix mapped, the
   // embedded header path is also prefix mapped, thus it can't be found anyway.
-  bool useImportHeader = !hasPathMapping();
   auto FS = ScanASTContext.SourceMgr.getFileSystem();
 
   auto chainBridgingHeader = [&](StringRef moduleName, StringRef headerPath,
-                                 StringRef binaryModulePath,
-                                 bool useHeader) -> llvm::Error {
-    if (useHeader) {
-      if (auto buffer = FS->getBufferForFile(headerPath)) {
-        outOS << "#include \"" << headerPath << "\"\n";
-        return llvm::Error::success();
-      }
+                                 StringRef binaryModulePath) -> llvm::Error {
+    auto remapped = remapPath(headerPath);
+    outOS << "#if __has_include(\"" << remapped << "\")\n";
+    outOS << "#import \"" << remapped << "\"\n";
+    outOS << "#else\n";
+
+    if (binaryModulePath.empty()) {
+      outOS << "#error failed to find bridging header for module " << moduleName
+            << "\n";
+    } else {
+      // Extract the embedded bridging header
+      auto moduleBuf = FS->getBufferForFile(binaryModulePath);
+      if (!moduleBuf)
+        return llvm::errorCodeToError(moduleBuf.getError());
+
+      auto content = extractEmbeddedBridgingHeaderContent(
+          std::move(*moduleBuf), /*headerPath=*/"", ScanASTContext);
+      if (!content)
+        return llvm::createStringError("can't load embedded header from " +
+                                       binaryModulePath);
+
+      outOS << "# 1 \"<module-" << moduleName
+            << "-embedded-bridging-header>\" 1\n";
+      outOS << content->getBuffer() << "\n";
     }
 
-    if (binaryModulePath.empty())
-      return llvm::createStringError("failed to load bridging header " +
-                                     headerPath);
+    outOS << "#endif\n";
 
-    // Extract the embedded bridging header
-    auto moduleBuf = FS->getBufferForFile(binaryModulePath);
-    if (!moduleBuf)
-      return llvm::errorCodeToError(moduleBuf.getError());
-
-    auto content = extractEmbeddedBridgingHeaderContent(
-        std::move(*moduleBuf), /*headerPath=*/"", ScanASTContext);
-    if (!content)
-      return llvm::createStringError("can't load embedded header from " +
-                                     binaryModulePath);
-
-    outOS << "# 1 \"<module-" << moduleName
-          << "-embedded-bridging-header>\" 1\n";
-    outOS << content->getBuffer() << "\n";
     return llvm::Error::success();
   };
 
@@ -1931,9 +1931,9 @@ llvm::Error ModuleDependencyScanner::performBridgingHeaderChaining(
       if (binaryMod->headerImport.empty())
         continue;
 
-      if (auto E = chainBridgingHeader(
-              moduleID.ModuleName, binaryMod->headerImport,
-              binaryMod->compiledModulePath, useImportHeader))
+      if (auto E =
+              chainBridgingHeader(moduleID.ModuleName, binaryMod->headerImport,
+                                  binaryMod->compiledModulePath))
         return E;
     }
   }
@@ -1963,8 +1963,7 @@ llvm::Error ModuleDependencyScanner::performBridgingHeaderChaining(
     if (mainModule->textualModuleDetails.bridgingHeaderFile) {
       if (auto E = chainBridgingHeader(
               rootModuleID.ModuleName,
-              *mainModule->textualModuleDetails.bridgingHeaderFile, "",
-              /*useHeader=*/true))
+              *mainModule->textualModuleDetails.bridgingHeaderFile, ""))
         return E;
     }
 

--- a/test/CAS/bridging-header-dup.swift
+++ b/test/CAS/bridging-header-dup.swift
@@ -1,0 +1,63 @@
+// UNSUPPORTED: OS=windows-msvc
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   %t/test.swift -o %t/deps-1.json -auto-bridging-header-chaining -cache-compile-job -cas-path %t/cas \
+// RUN:   -scanner-prefix-map-paths %swift_src_root /^src -scanner-prefix-map-paths %t /^tmp \
+// RUN:   -scanner-output-dir %t -import-objc-header %t/Bridging.h
+
+// RUN: %{python} %S/../../utils/swift-build-modules.py --cas %t/cas %swift_frontend_plain %t/deps-1.json -o %t/Test.cmd -b %t/header.cmd
+
+// RUN: %target-swift-frontend-plain @%t/header.cmd /^tmp/Bridging.h -disable-implicit-swift-modules -O -o %t/bridging.pch
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
+// RUN:   %target-swift-frontend-plain @%t/header.cmd /^tmp/Bridging.h -disable-implicit-swift-modules -O -o %t/bridging.pch > %t/keys.json
+// RUN: %{python} %S/Inputs/ExtractOutputKey.py %t/keys.json > %t/key
+
+// RUN: echo "\"-disable-implicit-string-processing-module-import\"" >> %t/Test.cmd
+// RUN: echo "\"-disable-implicit-concurrency-module-import\"" >> %t/Test.cmd
+// RUN: echo "\"-import-objc-header\"" >> %t/Test.cmd
+// RUN: echo "\"/^tmp/Bridging.h\"" >> %t/Test.cmd
+// RUN: echo "\"-import-pch\"" >> %t/Test.cmd
+// RUN: echo "\"%t/bridging.pch\"" >> %t/Test.cmd
+// RUN: echo "\"-bridging-header-pch-key\"" >> %t/Test.cmd
+// RUN: echo "\"@%t/key\"" >> %t/Test.cmd
+// RUN: %target-swift-frontend-plain -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/Test.cmd /^tmp/test.swift \
+// RUN:   -emit-module -o %t/Test.swiftmodule
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name User -module-cache-path %t/clang-module-cache -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   %t/user.swift -o %t/deps-2.json -auto-bridging-header-chaining -cache-compile-job -cas-path %t/cas \
+// RUN:   -scanner-prefix-map-paths %swift_src_root /^src -scanner-prefix-map-paths %t /^tmp \
+// RUN:   -scanner-output-dir %t -import-objc-header %t/Bridging.h -I %t
+
+// RUN: %swift-scan-test -action get_chained_bridging_header -- %target-swift-frontend -scan-dependencies \
+// RUN:   -module-name User -module-cache-path %t/clang-module-cache -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   %t/user.swift -o %t/deps-2.json -auto-bridging-header-chaining -cache-compile-job -cas-path %t/cas \
+// RUN:   -scanner-prefix-map-paths %swift_src_root /^src -scanner-prefix-map-paths %t /^tmp \
+// RUN:   -scanner-output-dir %t -import-objc-header %t/Bridging.h -I %t > %t/bridging-header.h
+// RUN: %FileCheck %s --input-file=%t/bridging-header.h --check-prefix=HEADER
+
+// HEADER: # 1 "<module-Test-embedded-bridging-header>" 1
+
+// RUN: %{python} %S/../../utils/swift-build-modules.py --prefix-map %t /^tmp --cas %t/cas %swift_frontend_plain %t/deps-2.json -o %t/User.cmd -b %t/user-header.cmd
+// RUN: %target-swift-frontend-plain @%t/user-header.cmd -disable-implicit-swift-modules -O -o %t/bridging2.pch
+
+
+//--- test.swift
+public func test() {
+    b()
+}
+
+//--- user.swift
+import Test
+
+//--- Bridging.h
+#include "Foo.h"
+
+//--- Foo.h
+void b(void);
+int a = 10;

--- a/test/ScanDependencies/bridging-header-autochaining.swift
+++ b/test/ScanDependencies/bridging-header-autochaining.swift
@@ -41,13 +41,14 @@
 // RUN:   %t/user.swift -o %t/deps2.json -auto-bridging-header-chaining -scanner-output-dir %t -scanner-debug-write-output \
 // RUN:   -Xcc -fmodule-map-file=%t/a.modulemap -Xcc -fmodule-map-file=%t/b.modulemap -I %t -enable-library-evolution
 
-// RUN: %swift-scan-test -action get_chained_bridging_header -- %target-swift-frontend -emit-module \
+// RUN: %swift-scan-test -action get_chained_bridging_header -- %target-swift-frontend -scan-dependencies \
 // RUN:   -module-name User -module-cache-path %t/clang-module-cache -O \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   %t/user.swift -auto-bridging-header-chaining -o %t/User.swiftmodule \
 // RUN:   -Xcc -fmodule-map-file=%t/a.modulemap -Xcc -fmodule-map-file=%t/b.modulemap -I %t > %t/header1.h
 // RUN:   %FileCheck %s --check-prefix=HEADER1 --input-file=%t/header1.h
-// HEADER1: #include
+// HEADER1: #if __has_include
+// HEADER1-NEXT: #import
 // HEADER1-SAME: Bridging.h
 
 // RUN: %{python} %S/../../utils/swift-build-modules.py %swift_frontend_plain %t/deps2.json -o %t/User.cmd -b %t/header1.cmd
@@ -72,15 +73,17 @@
 // RUN:   -I %t %t/user2.swift -import-objc-header %t/Bridging2.h -auto-bridging-header-chaining -scanner-output-dir %t -scanner-debug-write-output \
 // RUN:   -o %t/deps3.json
 
-// RUN: %swift-scan-test -action get_chained_bridging_header -- %target-swift-frontend -emit-module \
+// RUN: %swift-scan-test -action get_chained_bridging_header -- %target-swift-frontend -scan-dependencies \
 // RUN:   -module-name User -module-cache-path %t/clang-module-cache -O \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   %t/user.swift -auto-bridging-header-chaining -o %t/User.swiftmodule -import-objc-header %t/Bridging2.h \
 // RUN:   -Xcc -fmodule-map-file=%t/a.modulemap -Xcc -fmodule-map-file=%t/b.modulemap -I %t > %t/header2.h
 // RUN:   %FileCheck %s --check-prefix=HEADER2 --input-file=%t/header2.h
-// HEADER2: #include
+// HEADER2: __has_include
+// HEADER2-NEXT: #import
 // HEADER2-SAME: Bridging.h
-// HEADER2: #include
+// HEADER2: __has_include
+// HEADER2-NEXT: #import
 // HEADER2-SAME: Bridging2.h
 
 // RUN: %FileCheck %s --check-prefix DEPS_JSON --input-file=%t/deps3.json

--- a/utils/swift-build-modules.py
+++ b/utils/swift-build-modules.py
@@ -18,6 +18,13 @@ def writeOutputResponseFile(filename, cmd):
             output.write('"{}"\n'.format(c))
 
 
+def apply_prefix_maps(path, prefix_maps):
+    for old, new in prefix_maps:
+        if path.startswith(old):
+            return new + path[len(old):]
+    return path
+
+
 def build_module(swift_frontend, mode, detail):
     cmd = [swift_frontend] + detail['details'][mode]['commandLine']
     subprocess.check_call(cmd)
@@ -33,6 +40,10 @@ def main():
                         help="output response file for building main module")
     parser.add_argument('-b', '--bridging-header-resp', metavar="<response file>",
                         help="output response file for building bridging header")
+    parser.add_argument('--prefix-map', metavar=("<old_path>", "<new_path>"), nargs=2,
+                        action='append', default=[],
+                        help="remap path prefix when writing chainedBridgingHeaderPath "
+                             "(may be specified multiple times)")
     args = parser.parse_args()
 
     with open(args.input, 'r') as file:
@@ -98,7 +109,8 @@ def main():
             cmd = info['bridgingHeader']['commandLine'][1:]
             # print input file name if using chained bridging header.
             if "chainedBridgingHeaderPath" in info:
-                cmd.append(info['chainedBridgingHeaderPath'])
+                path = apply_prefix_maps(info['chainedBridgingHeaderPath'], args.prefix_map)
+                cmd.append(path)
             writeOutputResponseFile(args.bridging_header_resp, cmd)
 
 


### PR DESCRIPTION
Improve bridging header chaining when prefix mapping is used so it matches the behavior of non-prefix-map and non-caching builds. This also fixes a corner case where the same bridging header is used by different modules in the dependency chain, preventing it from being imported twice.

The improvements are:
* Fully utilize the clang scanner prefix mapping option, which can restore prefix-mapped paths during scanning to find the real file on the file system. This allows the generated bridging header to always reference the header path without worrying about introducing path dependencies.
* Move the header existence check from a file system access in the Swift scanner to a `__has_include` check in the clang scanner. This allows direct header import even when the header path is previously prefix mapped.
* Use `#import` to chain bridging headers so the same header will not be imported twice.

rdar://172870182

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
