### PR TITLE
Sema: allow @_originallyDefinedIn with unavailable platforms

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -102,14 +102,34 @@ public:
   /// Emits a diagnostic if there is no availability specified for the given
   /// platform, as required by the given attribute. Returns true if a diagnostic
   /// was emitted.
-  bool diagnoseMissingAvailability(DeclAttribute *attr, PlatformKind platform) {
+  bool diagnoseMissingAvailability(OriginallyDefinedInAttr *attr, PlatformKind platform) {
     auto IntroVer = D->getIntroducedOSVersion(platform);
-    if (IntroVer.has_value())
-      return false;
-
-    diagnose(attr->AtLoc, diag::attr_requires_decl_availability_for_platform,
-             attr, D, prettyPlatformString(platform));
-    return true;
+    if (IntroVer.has_value()) {
+      if (IntroVer.value() > attr->getMovedVersion()) {
+        diagnose(attr->AtLoc,
+                 diag::originally_definedin_must_not_before_available_version);
+        return true;
+      }
+    } else {
+      // Also accept explicit unconditional unavailability as sufficient
+      // availability annotation. This handles the case where @_spi_available is
+      // rewritten to @available(platform, unavailable) in the public
+      // swiftinterface. Only apply this relaxation when parsing a textual
+      // interface file, since meaningful introductory version is necessary for us
+      // to emit linker directives while compiling source code.
+      if (D->getDeclContext()->isInSwiftinterface()) {
+        for (auto semanticAttr :
+             D->getSemanticAvailableAttrs(/*includeInactive=*/true)) {
+          if (semanticAttr.getPlatform() == platform &&
+              semanticAttr.isUnconditionallyUnavailable())
+            return false;
+        }
+      }
+      diagnose(attr->AtLoc, diag::attr_requires_decl_availability_for_platform,
+               attr, D, prettyPlatformString(platform));
+      return true;
+    }
+    return false;
   }
 
   void checkIsolatedDeinitAttr(DeclAttribute *attr) {
@@ -5254,13 +5274,6 @@ void AttributeChecker::checkOriginalDefinedInAttrs(
 
     if (diagnoseMissingAvailability(Attr, Platform))
       return;
-
-    auto IntroVer = D->getIntroducedOSVersion(Platform);
-    if (IntroVer.value() > Attr->getMovedVersion()) {
-      diagnose(AtLoc,
-               diag::originally_definedin_must_not_before_available_version);
-      return;
-    }
   }
 }
 

--- a/test/Sema/diag_originally_definedin.swift
+++ b/test/Sema/diag_originally_definedin.swift
@@ -60,3 +60,7 @@ public func incorrectPlatformNotSimilar() {}
 @available(macOS 10.9, *)
 @_originallyDefinedIn(module: "original", swift 5.1) // expected-warning {{unknown platform 'swift' for attribute '@_originallyDefinedIn'}}
 public func swiftVersionMacro() {}
+
+@available(macOS, unavailable)
+@_originallyDefinedIn(module: "original", macOS 10.15) // expected-error {{'@_originallyDefinedIn' requires that 'unavailableWithODI()' have explicit availability for macOS}}
+public func unavailableWithODI() {}

--- a/test/Sema/originally_defined_in_unavailable_interface.swift
+++ b/test/Sema/originally_defined_in_unavailable_interface.swift
@@ -1,0 +1,15 @@
+// REQUIRES: OS=macosx
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-typecheck-module-from-interface(%t/Lib.swiftinterface) -module-name Lib
+
+//--- Lib.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name Lib -enable-library-evolution
+
+// @_spi_available(macOS 10.15, *) gets rewritten to @available(macOS, unavailable)
+// in the public swiftinterface; the ODI check must not fire here.
+@available(macOS, unavailable)
+@_originallyDefinedIn(module: "original", macOS 10.15)
+public func unavailableWithODI() {}


### PR DESCRIPTION
@_spi_available is rewritten to @available(platform, unavailable) in public swiftinterfaces, causing the @_originallyDefinedIn validity check to spuriously fire for missing introductory OS versions. We should accept explicit unconditional unavailability as sufficient availability annotation.

rdar://172856603
