### PR TITLE
Revert: Task.immediate used in bridging objc to async calls _runTaskForBridgedAsyncMethod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,11 +109,6 @@
   }
   ```
 
-* Calling from Objective-C into into asynchronous Swift APIs will now attempt use `Task.immediate`
-  instead of `Task` when available. This reduces the initial enqueue delay which Task would incur
-  (by enqueueing on the global pool before calling the async target), and can improve performance
-  and ordering predictability of calling async code through these bridged APIs.
-
 * The raw span accessor properties of `Span` and `MutableSpan` (`bytes` and
   `mutableBytes`) as well as the two generic `append()` methods of
   `OutputRawSpan` are newly marked with `@unsafe`. These changes are corrections

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -1167,11 +1167,7 @@ extension Task where Failure == Error {
 @usableFromInline
 internal func _runTaskForBridgedAsyncMethod(@_inheritActorContext _ body: __owned @Sendable @escaping () async -> Void) {
 #if compiler(>=5.6)
-  if #available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *) {
-    Task.immediate(operation: body)
-  } else {
-    Task(operation: body)
-  }
+  Task(operation: body)
 #else
   Task<Int, Error> {
     await body()


### PR DESCRIPTION
This change is causing too much fallout and we're not able to just introduce it without careful staging it.


resolves rdar://172878882 rdar://172852111
refs rdar://172878476