### PR TITLE
fix: Reconstruct constrained existential compositions more faithfully in ASTDemangler

### DIFF
--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -913,10 +913,33 @@ Type ASTBuilder::createExistentialMetatypeType(
                                       getMetatypeRepresentation(*repr));
 }
 
+/// Collect the inherited protocols not already present in memberProtocols into
+/// recoverableProtocols, in source order.
+static void collectRecoverableProtocols(
+    ProtocolDecl *proto,
+    const llvm::SmallDenseSet<ProtocolDecl *, 2> &memberProtocols,
+    llvm::SmallSetVector<ProtocolDecl *, 4> &recoverableProtocols,
+    llvm::SmallDenseSet<ProtocolDecl *, 4> &visitedInheritedProtocols) {
+  // Visiting inherited protocols depth-first preserves source order, where
+  // LIFO order in ProtocolDecl::walkInheritedProtocols() would cause them
+  // to be reconstructed in the wrong order.
+  for (auto *inheritedProto : proto->getInheritedProtocols()) {
+    if (!visitedInheritedProtocols.insert(inheritedProto).second)
+      continue;
+
+    if (!memberProtocols.contains(inheritedProto))
+      recoverableProtocols.insert(inheritedProto);
+
+    collectRecoverableProtocols(inheritedProto, memberProtocols,
+                                recoverableProtocols,
+                                visitedInheritedProtocols);
+  }
+}
+
 Type ASTBuilder::createConstrainedExistentialType(
     Type base, ArrayRef<BuiltRequirement> constraints,
     ArrayRef<BuiltInverseRequirement> inverseRequirements) {
-  llvm::SmallDenseMap<AssociatedTypeDecl *, Type> primaryAssociatedTypes;
+  llvm::SmallMapVector<AssociatedTypeDecl *, Type, 2> primaryAssociatedTypes;
   llvm::SmallDenseSet<AssociatedTypeDecl *> claimed;
 
   for (const auto &req : constraints) {
@@ -945,35 +968,100 @@ Type ASTBuilder::createConstrainedExistentialType(
     return Type();
   }
 
-  auto maybeFormParameterizedProtocolType = [&](ProtocolType *protoTy) -> Type {
-    auto *proto = protoTy->getDecl();
-
-    llvm::SmallVector<Type, 4> args;
-    for (auto *assocTy : proto->getPrimaryAssociatedTypes()) {
-      auto found = primaryAssociatedTypes.find(assocTy);
-      if (found != primaryAssociatedTypes.end()) {
-        args.push_back(found->second);
-        claimed.insert(found->first);
-        continue;
-      }
+  auto getPrimaryAssociatedTypeConstraint =
+      [&](AssociatedTypeDecl *assocTy,
+          bool allowAnchoredMatch)
+          -> std::optional<std::pair<Type, AssociatedTypeDecl *>> {
+    if (auto found = primaryAssociatedTypes.find(assocTy);
+        found != primaryAssociatedTypes.end()) {
+      return std::pair<Type, AssociatedTypeDecl *>(found->second, found->first);
     }
 
-    // We may not have any arguments because the constrained existential is a
-    // plain protocol with an inverse requirement.
-    if (args.empty())
+    if (!allowAnchoredMatch)
+      return std::nullopt;
+
+    auto *assocTyAnchor = assocTy->getAssociatedTypeAnchor();
+    for (const auto &entry : primaryAssociatedTypes) {
+      if (entry.first->getAssociatedTypeAnchor() == assocTyAnchor)
+        return std::pair<Type, AssociatedTypeDecl *>(entry.second, entry.first);
+    }
+
+    return std::nullopt;
+  };
+
+  struct ParameterizedProtocolTypeMatch {
+    Type type;
+    SmallVector<AssociatedTypeDecl *, 4> matchedAssocTypes;
+  };
+
+  auto maybeGetParameterizedProtocolTypeMatch =
+      [&](ProtocolType *protoTy, bool allowAnchoredMatch)
+          -> std::optional<ParameterizedProtocolTypeMatch> {
+    auto *proto = protoTy->getDecl();
+    auto primaryAssocTypes = proto->getPrimaryAssociatedTypes();
+
+    if (primaryAssocTypes.empty())
+      return std::nullopt;
+
+    llvm::SmallVector<Type, 4> args;
+    SmallVector<AssociatedTypeDecl *, 4> matchedAssocTypes;
+    for (auto *assocTy : primaryAssocTypes) {
+      auto found =
+          getPrimaryAssociatedTypeConstraint(assocTy, allowAnchoredMatch);
+      if (!found)
+        return std::nullopt;
+
+      args.push_back(found->first);
+      matchedAssocTypes.push_back(found->second);
+    }
+
+    ParameterizedProtocolTypeMatch match{
+        ParameterizedProtocolType::get(Ctx, protoTy, args), {}};
+    match.matchedAssocTypes.append(matchedAssocTypes.begin(),
+                                   matchedAssocTypes.end());
+    return match;
+  };
+
+  auto maybeFormParameterizedProtocolType =
+      [&](ProtocolType *protoTy, bool allowAnchoredMatch) -> Type {
+    auto match =
+        maybeGetParameterizedProtocolTypeMatch(protoTy, allowAnchoredMatch);
+    if (!match)
       return protoTy;
 
-    return ParameterizedProtocolType::get(Ctx, protoTy, args);
+    for (auto *assocTy : match->matchedAssocTypes)
+      claimed.insert(assocTy);
+
+    return match->type;
   };
 
   SmallVector<Type, 2> members;
+  llvm::SmallDenseSet<ProtocolDecl *, 2> memberProtocols;
   bool hasExplicitAnyObject = false;
   InvertibleProtocolSet inverses;
+
+  auto extractProtocolDecl = [](Type member) -> ProtocolDecl * {
+    if (auto *protoTy = member->getAs<ProtocolType>())
+      return protoTy->getDecl();
+
+    if (auto *paramProtoTy = member->getAs<ParameterizedProtocolType>())
+      return paramProtoTy->getProtocol();
+
+    return nullptr;
+  };
+
+  auto addMember = [&](Type member) {
+    members.push_back(member);
+
+    if (auto *proto = extractProtocolDecl(member))
+      memberProtocols.insert(proto);
+  };
 
   // We're given either a single protocol type, or a composition of protocol
   // types. Transform each protocol type to add arguments, if necessary.
   if (auto protoTy = base->getAs<ProtocolType>()) {
-    members.push_back(maybeFormParameterizedProtocolType(protoTy));
+    addMember(
+        maybeFormParameterizedProtocolType(protoTy, /*allowAnchoredMatch=*/false));
   } else {
     auto compositionTy = base->castTo<ProtocolCompositionType>();
     hasExplicitAnyObject = compositionTy->hasExplicitAnyObject();
@@ -981,12 +1069,97 @@ Type ASTBuilder::createConstrainedExistentialType(
 
     for (auto member : compositionTy->getMembers()) {
       if (auto *protoTy = member->getAs<ProtocolType>()) {
-        members.push_back(maybeFormParameterizedProtocolType(protoTy));
+        addMember(maybeFormParameterizedProtocolType(
+            protoTy, /*allowAnchoredMatch=*/false));
         continue;
       }
       ASSERT(member->getClassOrBoundGenericClass());
-      members.push_back(member);
+      addMember(member);
     }
+  }
+
+  // The mangled base type may canonicalize away an inherited protocol while the
+  // requirement list still constrains one of its primary associated types. In
+  // that case, reintroduce the inherited protocol member so we can faithfully
+  // reconstruct the original constrained existential shape.
+  llvm::SmallDenseSet<ProtocolDecl *, 2> protocolsToAdd;
+
+  // For each protocol, cache the anchors of its primary associated types so
+  // membership can be tested without rescanning the protocol on every
+  // candidate/constraint pair below.
+  llvm::DenseMap<ProtocolDecl *, llvm::SmallDenseSet<AssociatedTypeDecl *, 4>>
+      primaryAnchorSets;
+
+  auto protocolCanClaimAssociatedType =
+      [&](ProtocolDecl *proto, AssociatedTypeDecl *assocTy) {
+    auto [entry, inserted] = primaryAnchorSets.try_emplace(proto);
+    if (inserted) {
+      for (auto *primaryAssocTy : proto->getPrimaryAssociatedTypes())
+        entry->second.insert(primaryAssocTy->getAssociatedTypeAnchor());
+    }
+    return entry->second.count(assocTy->getAssociatedTypeAnchor()) != 0;
+  };
+
+  auto matchClaimsNewAssociatedType =
+      [&](const ParameterizedProtocolTypeMatch &match) {
+        return llvm::any_of(match.matchedAssocTypes,
+                            [&](AssociatedTypeDecl *assocTy) {
+                              return !claimed.contains(assocTy);
+                            });
+      };
+
+  llvm::SmallSetVector<ProtocolDecl *, 4> recoverableProtocolsInSourceOrder;
+  for (auto member : members) {
+    auto *memberProto = extractProtocolDecl(member);
+    if (!memberProto)
+      continue;
+
+    llvm::SmallDenseSet<ProtocolDecl *, 4> visitedInheritedProtocols;
+    collectRecoverableProtocols(memberProto, memberProtocols,
+                                recoverableProtocolsInSourceOrder,
+                                visitedInheritedProtocols);
+  }
+
+  for (const auto &entry : primaryAssociatedTypes) {
+    auto *assocTy = entry.first;
+    if (claimed.contains(assocTy))
+      continue;
+
+    SmallVector<ProtocolDecl *, 2> viableCandidateProtocols;
+    for (auto *candidateProto : recoverableProtocolsInSourceOrder) {
+      if (!protocolCanClaimAssociatedType(candidateProto, assocTy))
+        continue;
+
+      auto *candidateProtoTy =
+          candidateProto->getDeclaredInterfaceType()->castTo<ProtocolType>();
+      auto candidateMatch = maybeGetParameterizedProtocolTypeMatch(
+          candidateProtoTy, /*allowAnchoredMatch=*/true);
+      if (!candidateMatch || !matchClaimsNewAssociatedType(*candidateMatch))
+        continue;
+
+      viableCandidateProtocols.push_back(candidateProto);
+    }
+
+    // Keep only the most-derived candidates. canonicalizeProtocols also sorts,
+    // but order doesn't matter here: protocolsToAdd is a membership set and the
+    // members are emitted in source order below.
+    ProtocolType::canonicalizeProtocols(viableCandidateProtocols);
+    for (auto *candidateProto : viableCandidateProtocols)
+      protocolsToAdd.insert(candidateProto);
+  }
+
+  for (auto *proto : recoverableProtocolsInSourceOrder) {
+    if (!protocolsToAdd.count(proto))
+      continue;
+
+    auto claimedSize = claimed.size();
+    auto *protoTy = proto->getDeclaredInterfaceType()->castTo<ProtocolType>();
+    auto member =
+        maybeFormParameterizedProtocolType(protoTy, /*allowAnchoredMatch=*/true);
+    if (claimed.size() == claimedSize)
+      continue;
+
+    addMember(member);
   }
 
   // Make sure that all arguments were actually used.

--- a/test/TypeDecoder/constrained_existentials.swift
+++ b/test/TypeDecoder/constrained_existentials.swift
@@ -57,3 +57,154 @@ do {
 //   blackHole_noncopyable(consume e0)
 //   blackHole_noncopyable(consume e1)
 }
+
+// Constrained existential compositions where an inherited protocol is listed
+// explicitly alongside a constraint on one of its primary associated types.
+// The mangled base type canonicalizes away the redundant inherited member,
+// but the same-type constraint on its primary associated type survives in
+// the requirement list, so reconstruction must recover the inherited member
+// to claim it. (https://github.com/swiftlang/swift/issues/87358)
+//
+// The mangled names below are compiler-generated via...
+//
+//   swiftc -emit-ir -g -module-name constrained_existentials \
+//     -Xfrontend -disable-availability-checking \
+//     test/TypeDecoder/constrained_existentials.swift
+
+protocol Base<T> {
+  associatedtype T
+}
+
+protocol Derived: Base {}
+
+struct SDerived<T>: Derived {}
+
+do {
+  let e0: any Derived & Base<Int> = SDerived<Int>()
+  let e1: any (Derived & Base<Int>).Type = SDerived<Int>.self
+  let e2: (any Derived & Base<Int>).Type = (any Derived & Base<Int>).self
+
+  blackHole(e0, e1, e2)
+}
+
+// DEMANGLE: _$s24constrained_existentials7Derived_pSi1TAA4BasePRts_XPD
+// DEMANGLE: _$s24constrained_existentials7Derived_pSi1TAA4BasePRts_XPXmTD
+// DEMANGLE: _$s24constrained_existentials7Derived_pSi1TAA4BasePRts_XPXMtD
+
+// CHECK: any Derived & Base<Int>
+// CHECK: @thick any (Derived & Base<Int>).Type
+// CHECK: @thin (any Derived & Base<Int>).Type
+
+// Same shape, but the inherited base being recovered is one of two siblings
+// that both refine a common ancestor with two primary associated types; only
+// one sibling's associated type is actually constrained.
+protocol BaseProtocolUT {
+  associatedtype U
+  associatedtype T
+}
+
+protocol ProtocolGenericU<U>: BaseProtocolUT {}
+protocol ProtocolGenericT<T>: BaseProtocolUT {}
+protocol FullProtocol<U, T>: ProtocolGenericU, ProtocolGenericT {}
+
+struct SFull<U, T>: FullProtocol {}
+
+do {
+  let e0: any FullProtocol & ProtocolGenericU<Int> = SFull<Int, String>()
+  let e1: any (FullProtocol & ProtocolGenericU<Int>).Type = SFull<Int, String>.self
+  let e2: (any FullProtocol & ProtocolGenericU<Int>).Type =
+    (any FullProtocol & ProtocolGenericU<Int>).self
+
+  blackHole(e0, e1, e2)
+}
+
+// DEMANGLE: _$s24constrained_existentials12FullProtocol_pSi1UAA04BaseD2UTPRts_XPD
+// DEMANGLE: _$s24constrained_existentials12FullProtocol_pSi1UAA04BaseD2UTPRts_XPXmTD
+// DEMANGLE: _$s24constrained_existentials12FullProtocol_pSi1UAA04BaseD2UTPRts_XPXMtD
+
+// CHECK: any FullProtocol & ProtocolGenericU<Int>
+// CHECK: @thick any (FullProtocol & ProtocolGenericU<Int>).Type
+// CHECK: @thin (any FullProtocol & ProtocolGenericU<Int>).Type
+
+do {
+  let e0: any FullProtocol & ProtocolGenericT<String> = SFull<Int, String>()
+  let e1: any (FullProtocol & ProtocolGenericT<String>).Type = SFull<Int, String>.self
+  let e2: (any FullProtocol & ProtocolGenericT<String>).Type =
+    (any FullProtocol & ProtocolGenericT<String>).self
+
+  blackHole(e0, e1, e2)
+}
+
+// DEMANGLE: _$s24constrained_existentials12FullProtocol_pSS1TAA04BaseD2UTPRts_XPD
+// DEMANGLE: _$s24constrained_existentials12FullProtocol_pSS1TAA04BaseD2UTPRts_XPXmTD
+// DEMANGLE: _$s24constrained_existentials12FullProtocol_pSS1TAA04BaseD2UTPRts_XPXMtD
+
+// CHECK: any FullProtocol & ProtocolGenericT<String>
+// CHECK: @thick any (FullProtocol & ProtocolGenericT<String>).Type
+// CHECK: @thin (any FullProtocol & ProtocolGenericT<String>).Type
+
+// Multiple inherited protocols get canonicalized away at once; reconstruction
+// must recover all of them and re-add them in their original source order.
+protocol HopBase {
+  associatedtype Parent
+  associatedtype Successor
+  associatedtype Destination
+}
+
+protocol HopGenericParent<Parent>: HopBase {}
+protocol HopGenericSuccessor<Successor>: HopBase {}
+protocol HopGenericDestination<Destination>: HopBase {}
+protocol Hop<Parent, Successor>:
+  HopGenericParent, HopGenericSuccessor, HopGenericDestination {}
+
+struct SHop<Parent, Successor, Destination>: Hop {}
+
+do {
+  let e0: any Hop & HopGenericSuccessor<Int> & HopGenericDestination<String> =
+    SHop<Bool, Int, String>()
+  let e1: any (Hop & HopGenericSuccessor<Int> & HopGenericDestination<String>).Type =
+    SHop<Bool, Int, String>.self
+  let e2: (any Hop & HopGenericSuccessor<Int> & HopGenericDestination<String>).Type =
+    (any Hop & HopGenericSuccessor<Int> & HopGenericDestination<String>).self
+
+  blackHole(e0, e1, e2)
+}
+
+// DEMANGLE: _$s24constrained_existentials3Hop_pSS11DestinationAA0C4BasePRts_Si9SuccessorAERtsXPD
+// DEMANGLE: _$s24constrained_existentials3Hop_pSS11DestinationAA0C4BasePRts_Si9SuccessorAERtsXPXmTD
+// DEMANGLE: _$s24constrained_existentials3Hop_pSS11DestinationAA0C4BasePRts_Si9SuccessorAERtsXPXMtD
+
+// CHECK: any Hop & HopGenericSuccessor<Int> & HopGenericDestination<String>
+// CHECK: @thick any (Hop & HopGenericSuccessor<Int> & HopGenericDestination<String>).Type
+// CHECK: @thin (any Hop & HopGenericSuccessor<Int> & HopGenericDestination<String>).Type
+
+// The most-specific recoverable inherited protocol ("Full") needs both Root
+// and Value to parameterize, but only Root is actually constrained here, so
+// reconstruction must fall back to the less-specific "GenericRoot" instead.
+protocol TwoFieldBase {
+  associatedtype Root
+  associatedtype Value
+}
+
+protocol GenericRoot<Root>: TwoFieldBase {}
+protocol GenericValue<Value>: TwoFieldBase {}
+protocol Full<Root, Value>: GenericRoot, GenericValue {}
+protocol Writable<Root, Value>: Full {}
+
+struct SWritable<Root, Value>: Writable {}
+
+do {
+  let e0: any Writable & GenericRoot<Int> = SWritable<Int, String>()
+  let e1: any (Writable & GenericRoot<Int>).Type = SWritable<Int, String>.self
+  let e2: (any Writable & GenericRoot<Int>).Type = (any Writable & GenericRoot<Int>).self
+
+  blackHole(e0, e1, e2)
+}
+
+// DEMANGLE: _$s24constrained_existentials8Writable_pSi4RootAA12TwoFieldBasePRts_XPD
+// DEMANGLE: _$s24constrained_existentials8Writable_pSi4RootAA12TwoFieldBasePRts_XPXmTD
+// DEMANGLE: _$s24constrained_existentials8Writable_pSi4RootAA12TwoFieldBasePRts_XPXMtD
+
+// CHECK: any Writable & GenericRoot<Int>
+// CHECK: @thick any (Writable & GenericRoot<Int>).Type
+// CHECK: @thin (any Writable & GenericRoot<Int>).Type


### PR DESCRIPTION
## Summary

This PR fixes a DebugInfo round-tripping crash for constrained existential compositions that combine an inherited protocol with its parameterized base, such as `any Derived & Base<T>`.

It also adds a regression test covering value, metatype, and return-position uses of this shape.

Resolves https://github.com/swiftlang/swift/issues/87358.

## Problem

When DebugInfo round-trips a constrained existential through mangling/demangling, the mangled base type can canonicalize away an inherited protocol member while the requirement list still contains same-type constraints for that inherited protocol’s primary associated types.

In cases like:

```swift
protocol C: B {}
protocol B<T> { associatedtype T }

func foo<T>(_ x: any C & B<T>) {}
```
`ASTDemangler::createConstrainedExistentialType` could fail to claim all primary associated type requirements and hit this assertion: `ASSERT(claimed.size() == primaryAssociatedTypes.size());`

## Fix

Updates `ASTDemangler::createConstrainedExistentialType` to reconstruct constrained existential compositions more faithfully when the mangled base canonicalizes away inherited protocol members.

The demangler now:

- preserves the encounter order of constrained primary associated type requirements
- distinguishes exact associated type matches from anchor-based matches
- only parameterizes explicit composition members when all of their primary associated type requirements are available
- tracks which protocol members are already present in the reconstructed composition
- discovers omitted inherited protocols in source order
- selects recoverable inherited protocols based on viability, preferring more-specific protocols only when they can actually claim new constraints
- re-adds recovered inherited protocols in source order before validating the claimed requirements

This preserves the original constrained existential shape more accurately, fixes the `claimed.size()` assertion, and avoids DebugInfo round-trip mismatches for inherited and typealias-based constrained existential compositions.
