### PR TITLE
utils: avoid building tests for dispatch

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3045,14 +3045,6 @@ function Write-SDKSettings([OS] $OS, [string] $Identifier = $OS.ToString()) {
 
 function Build-Dispatch([Hashtable] $Platform) {
   $SwiftSDK = Get-SwiftSDK -OS $Platform.OS -Identifier $Platform.DefaultSDK
-  $PlatformDefines = @{}
-
-  if ($Platform.OS -eq [OS]::Android) {
-    $PlatformDefines += @{
-      BUILD_TESTING = "NO";
-    }
-  }
-
   Build-CMakeProject `
     -Src $SourceCache\swift-corelibs-libdispatch `
     -Bin (Get-ProjectBinaryCache $Platform Dispatch) `
@@ -3060,10 +3052,10 @@ function Build-Dispatch([Hashtable] $Platform) {
     -Platform $Platform `
     -UseBuiltCompilers C,CXX,Swift `
     -SwiftSDK $SwiftSDK `
-    -Defines ($PlatformDefines + @{
+    -Defines @{
       ENABLE_SWIFT = "YES";
       dispatch_INSTALL_ARCH_SUBDIR = "YES";
-    })
+    }
 }
 
 function Test-Dispatch {
@@ -3358,14 +3350,6 @@ function Build-ExperimentalSDK([Hashtable] $Platform) {
 
   $SDKROOT = Get-SwiftSDK -OS $Platform.OS -Identifier "$($Platform.OS)Experimental"
 
-  $PlatformDefines = @{}
-
-  if ($Platform.OS -eq [OS]::Android) {
-    $PlatformDefines += @{
-      BUILD_TESTING = "NO";
-    }
-  }
-
   if ($Platform.LinkModes.Contains("dynamic")) {
     Record-OperationTime $Platform "Build-ExperimentalDynamicDispatch" {
       Build-CMakeProject `
@@ -3375,13 +3359,13 @@ function Build-ExperimentalSDK([Hashtable] $Platform) {
         -Platform $Platform `
         -UseBuiltCompilers C,CXX,Swift `
         -SwiftSDK "${SDKROOT}" `
-        -Defines ($PlatformDefines + @{
+        -Defines @{
           BUILD_SHARED_LIBS = "YES";
           CMAKE_FIND_PACKAGE_PREFER_CONFIG = "YES";
           CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";
 
           ENABLE_SWIFT = "YES";
-        })
+        }
     }
 
     Record-OperationTime $Platform "Build-ExperimentalDynamicFoundation" {
@@ -3427,13 +3411,13 @@ function Build-ExperimentalSDK([Hashtable] $Platform) {
         -Platform $Platform `
         -UseBuiltCompilers C,CXX,Swift `
         -SwiftSDK "${SDKROOT}" `
-        -Defines ($PlatformDefines + @{
+        -Defines @{
           BUILD_SHARED_LIBS = "NO";
           CMAKE_Swift_FLAGS = @("-static-stdlib", "-Xfrontend", "-use-static-resource-dir");
           CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";
 
           ENABLE_SWIFT = "YES";
-        })
+        }
     }
 
     Record-OperationTime $Platform "Build-ExperimentalStaticFoundation" {

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3053,6 +3053,7 @@ function Build-Dispatch([Hashtable] $Platform) {
     -UseBuiltCompilers C,CXX,Swift `
     -SwiftSDK $SwiftSDK `
     -Defines @{
+      BUILD_TESTING = "NO";
       ENABLE_SWIFT = "YES";
       dispatch_INSTALL_ARCH_SUBDIR = "YES";
     }
@@ -3070,6 +3071,7 @@ function Test-Dispatch {
       -SwiftSDK (Get-SwiftSDK -OS $BuildPlatform.OS -Identifier $BuildPlatform.DefaultSDK) `
       -BuildTargets default,ExperimentalTest `
       -Defines @{
+        BUILD_TESTING = "YES";
         ENABLE_SWIFT = "YES";
       }
   }
@@ -3360,6 +3362,7 @@ function Build-ExperimentalSDK([Hashtable] $Platform) {
         -UseBuiltCompilers C,CXX,Swift `
         -SwiftSDK "${SDKROOT}" `
         -Defines @{
+          BUILD_TESTING = "NO";
           BUILD_SHARED_LIBS = "YES";
           CMAKE_FIND_PACKAGE_PREFER_CONFIG = "YES";
           CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";
@@ -3412,6 +3415,7 @@ function Build-ExperimentalSDK([Hashtable] $Platform) {
         -UseBuiltCompilers C,CXX,Swift `
         -SwiftSDK "${SDKROOT}" `
         -Defines @{
+          BUILD_TESTING = "NO";
           BUILD_SHARED_LIBS = "NO";
           CMAKE_Swift_FLAGS = @("-static-stdlib", "-Xfrontend", "-use-static-resource-dir");
           CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";


### PR DESCRIPTION
This disables building the tests for Dispatch when building the toolchain. We re-configure when running tests and can enable them then.