### PR TITLE
[Dependency Scanner] Speculative fix for diagnostic consumer use-after-destroy in compiler sub-instances

### DIFF
--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -2151,9 +2151,11 @@ InterfaceSubContextDelegateImpl::runInSubCompilerInstance(StringRef moduleName,
   subInvocation.getFrontendOptions().InputsAndOutputs
     .setMainAndSupplementaryOutputs(outputFiles, ModuleOutputPaths);
 
-  CompilerInstance subInstance;
+  // Diagnostic consumers must outlive subInstance, since subInstance's
+  // DiagnosticEngine holds raw pointers to them.
   ForwardingDiagnosticConsumer FDC(*Diags);
   NullDiagnosticConsumer noopConsumer;
+  CompilerInstance subInstance;
   if (!silenceErrors) {
     subInstance.addDiagnosticConsumer(&FDC);
   } else {


### PR DESCRIPTION
In `runInSubCompilerInstance`, the `CompilerInstance` was declared before its diagnostic consumers (`ForwardingDiagnosticConsumer` and `NullDiagnosticConsumer`). C++ destroys local variables in reverse declaration order, so the consumers were destroyed before `~CompilerInstance` ran. During `ASTContext` cleanup, code emitting diagnostics would likely try to access the potentially-already-destroyed consumers via dangling pointers in the `DiagnosticEngine`, possibly causing undefined behaviour that may manifest as heap corruption and a crash.

Fix by declaring the diagnostic consumers before the CompilerInstance so they outlive it.

Resolves rdar://172440435.
