### PR TITLE
[Backtracing] Fix function entry table processing during unwind.

### DIFF
--- a/Runtimes/Supplemental/Runtime/CMakeLists.txt
+++ b/Runtimes/Supplemental/Runtime/CMakeLists.txt
@@ -99,7 +99,7 @@ add_compile_options(
 
 # Generate BacktracingDT 6.2
 set(backgtracingdt62_version)
-if(NOT SwiftCore_ENABLE_STRICT_AVAILABILITY AND CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS "26.0")
+if(NOT SwiftCore_ENABLE_STRICT_AVAILABILITY AND CMAKE_OSX_DEPLOYMENT_TARGET AND CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS "26.0")
   set(backtracingdt62_version "macOS ${CMAKE_OSX_DEPLOYMENT_TARGET}")
 else()
   set(backtracingdt62_version "macOS 26.0")

--- a/stdlib/public/RuntimeModule/DefaultSymbolLocator.swift
+++ b/stdlib/public/RuntimeModule/DefaultSymbolLocator.swift
@@ -132,7 +132,7 @@ open class DefaultSymbolLocator: SymbolLocator {
       return source
     }
 
-    if let uuid = image.uuid, let (imagePath, result) =
+    if let uuid = image.uuid, let (_, result) =
       findElf(image: image, paths: findElfSymbolPaths(image: image)) {
       let source = toSymbolSource(result)
       cache[.uuid(uuid)] = source

--- a/stdlib/public/RuntimeModule/ImageMap+Win32.swift
+++ b/stdlib/public/RuntimeModule/ImageMap+Win32.swift
@@ -20,6 +20,7 @@ import Swift
 
 internal import WinSDK
 internal import BacktracingImpl.ImageFormats.CodeView
+internal import BacktracingImpl.OS.Windows
 
 typealias CV_PDB70_INFO = swift.runtime.CV_PDB70_INFO
 typealias RTL_GET_VERSION_FN = @convention(c) (UnsafeMutablePointer<RTL_OSVERSIONINFOW>) -> NTSTATUS
@@ -459,7 +460,7 @@ extension ImageMap {
         if let table = fetchExceptionTable(hProcess: hProcess,
                               from: Address(tableAddress),
                               size: UInt64(exceptionEntry.Size),
-                              as: IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY.self) {
+                              as: WIN32_IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY.self) {
           exceptionTable = .arm64(table)
         } else {
           exceptionTable = nil

--- a/stdlib/public/RuntimeModule/ImageMap.swift
+++ b/stdlib/public/RuntimeModule/ImageMap.swift
@@ -24,6 +24,7 @@ internal import BacktracingImpl.OS.Darwin
 
 #if os(Windows)
 internal import WinSDK
+internal import BacktracingImpl.OS.Windows
 #endif
 
 /// Holds a map of the process's address space.
@@ -51,7 +52,7 @@ public struct ImageMap: Collection, Sendable, Hashable {
 
   #if os(Windows)
   enum ExceptionTable {
-    case arm64(ExceptionTableWrapper<IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY>)
+    case arm64(ExceptionTableWrapper<WIN32_IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY>)
     case amd64(ExceptionTableWrapper<_IMAGE_RUNTIME_FUNCTION_ENTRY>)
     case i386(ExceptionTableWrapper<FPO_DATA>)
   }

--- a/stdlib/public/RuntimeModule/Win32Unwinder.swift
+++ b/stdlib/public/RuntimeModule/Win32Unwinder.swift
@@ -266,7 +266,7 @@ extension Win32Unwinder: Win32UnwinderSupport {
         }
 
         // ARM64 stores function lengths in words; we have to compute end
-        let end: DWORD
+        let end: UInt32
         if table[mid].Flag != 0 {
           end = table[mid].BeginAddress + table[mid].FunctionLength * 4
         } else {

--- a/stdlib/public/RuntimeModule/Win32Unwinder.swift
+++ b/stdlib/public/RuntimeModule/Win32Unwinder.swift
@@ -18,6 +18,16 @@
 
 import Swift
 internal import WinSDK
+internal import BacktracingImpl.OS.Windows
+
+extension WIN32_IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY {
+  var Flag: UInt32 { UnwindData & 0x3 }
+  var FunctionLength: UInt32 { (UnwindData >> 2) & 0x3ff }
+}
+
+extension WIN32_IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_XDATA {
+  var FunctionLength: UInt32 { PackedFields & 0x3ffff }
+}
 
 // We use this protocol to work around the problem of not being able to
 // pass a function as a C function if it has captured generic parameters.
@@ -238,7 +248,8 @@ extension Win32Unwinder: Win32UnwinderSupport {
       return nil
     }
 
-    let addrOffset = addrBase - DWORD64(self.images[ndx].baseAddress)!
+    let baseAddress = self.images[ndx].baseAddress
+    let addrOffset = addrBase - DWORD64(baseAddress)!
 
     switch self.images.exceptionTable(at: ndx) {
     case .arm64(let wrapper):
@@ -254,12 +265,36 @@ extension Win32Unwinder: Win32UnwinderSupport {
           continue
         }
 
-        if mid == table.count - 1 || table[mid + 1].BeginAddress > addrOffset {
+        // ARM64 stores function lengths in words; we have to compute end
+        let end: DWORD
+        if table[mid].Flag != 0 {
+          end = table[mid].BeginAddress + table[mid].FunctionLength * 4
+        } else {
+          // Don't fetch XDATA if we don't have to
+          if mid + 1 < table.count && table[mid + 1].BeginAddress <= addrOffset {
+            min = mid + 1
+            continue
+          }
+
+          // Fetch the XDATA to find the length in words
+          let xDataPtr = M.Address(baseAddress)!
+            + M.Address(table[mid].UnwindData)
+          if let xData = try? self.reader.fetch(
+               from: xDataPtr,
+               as: WIN32_IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_XDATA.self
+             ) {
+            end = table[mid].BeginAddress + xData.FunctionLength * 4
+          } else {
+            end = table[mid].BeginAddress
+          }
+        }
+
+        if addrOffset < end {
           let ptr = UnsafeRawPointer(table.baseAddress! + mid)!
           return UnsafeMutableRawPointer(mutating: ptr)
         }
 
-        min = mid
+        min = mid + 1
       }
       return nil
     case .amd64(let wrapper):
@@ -275,12 +310,12 @@ extension Win32Unwinder: Win32UnwinderSupport {
           continue
         }
 
-        if mid == table.count - 1 || table[mid + 1].BeginAddress > addrOffset {
+        if table[mid].EndAddress > addrOffset {
           let ptr = UnsafeRawPointer(table.baseAddress! + mid)!
           return UnsafeMutableRawPointer(mutating: ptr)
         }
 
-        min = mid
+        min = mid + 1
       }
       return nil
     case .i386(let wrapper):
@@ -315,7 +350,7 @@ extension Win32Unwinder: Win32UnwinderSupport {
           return UnsafeMutableRawPointer(mutating: ptr)
         }
 
-        min = mid
+        min = mid + 1
       }
       return nil
     default:

--- a/stdlib/public/RuntimeModule/modules/OS/Windows.h
+++ b/stdlib/public/RuntimeModule/modules/OS/Windows.h
@@ -257,6 +257,18 @@ typedef struct {
   uint32_t Padding2[2];
 } WIN32_ARM_CONTEXT;
 
+// Swift has trouble with the original versions of these, so bring in our
+// own, simpler, definitions.
+typedef struct {
+  uint32_t BeginAddress;
+  uint32_t UnwindData;
+} WIN32_IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY;
+
+typedef struct {
+  uint32_t HeaderData;
+  uint32_t PackedFields;
+} WIN32_IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_XDATA;
+
 #ifdef __cplusplus
 } // extern "C"
 #endif


### PR DESCRIPTION
The Win32 unwinder has to locate function entry records for the `StackWalk64()` API to use; the code that was doing this was incorrect and sometimes found the wrong record, which would result in a corrupted stack walk.

Fixes #87955

rdar://172911008
