### PR TITLE
[update-checkout] add --partial-clone

### DIFF
--- a/utils/update_checkout/tests/test_ci_optimizations.py
+++ b/utils/update_checkout/tests/test_ci_optimizations.py
@@ -1,0 +1,330 @@
+# ===--- test_ci_optimizations.py -----------------------------------------===#
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ===----------------------------------------------------------------------===#
+
+"""
+Tests for CI clone optimizations:
+  - Shallow clone (--skip-history → --depth 1)
+  - Single branch  (--skip-history → --single-branch)
+  - Partial clone  (--partial-clone → --filter=blob:none)
+  - Shallow fetch  (--skip-history propagated to update_single_repository)
+"""
+
+import os
+
+from . import scheme_mock
+
+def _add_branch_to_remotes(remote_path, repo_names, branch_name):
+    """Create *branch_name* on every bare remote repo."""
+    for repo_name in repo_names:
+        remote_repo = os.path.join(remote_path, repo_name)
+        scheme_mock.call_quietly(
+            ["git", "branch", branch_name, "main"],
+            cwd=remote_repo,
+        )
+
+
+def _add_commit_to_repos(local_path, repo_names, filename, content):
+    """Commit a new file to each local clone and push it to origin."""
+    for repo_name in repo_names:
+        local_repo = os.path.join(local_path, repo_name)
+        filepath = os.path.join(local_repo, filename)
+        with open(filepath, "w") as f:
+            f.write(content)
+        scheme_mock.call_quietly(["git", "add", filename], cwd=local_repo)
+        scheme_mock.call_quietly(
+            ["git", "commit", "-m", f"Add {filename}"], cwd=local_repo
+        )
+        scheme_mock.call_quietly(["git", "push", "origin", "main"], cwd=local_repo)
+
+
+class ShallowCloneTestCase(scheme_mock.SchemeMockTestCase):
+    """--skip-history should produce depth-1, single-branch clones."""
+
+    def setUp(self):
+        super().setUp()
+        # Add a second branch to every bare remote so single-branch tests are
+        # meaningful.
+        _add_branch_to_remotes(self.remote_path, self.get_all_repos(), "other-branch")
+
+    def test_skip_history_produces_shallow_clone(self):
+        """Repos cloned with --skip-history must be depth-1 shallow clones."""
+        self.call(
+            [
+                self.update_checkout_path,
+                "--config",
+                self.config_path,
+                "--source-root",
+                self.source_root,
+                "--clone",
+                "--scheme",
+                "main",
+                "--skip-history",
+            ]
+        )
+
+        for repo in self.get_all_repos():
+            repo_path = os.path.join(self.source_root, repo)
+            is_shallow = self.call(
+                ["git", "rev-parse", "--is-shallow-repository"], cwd=repo_path
+            ).strip()
+            self.assertEqual(
+                is_shallow,
+                "true",
+                f"'{repo}' should be a shallow clone after --skip-history",
+            )
+
+    def test_skip_history_fetches_only_single_branch(self):
+        """--skip-history must not fetch unrelated remote branches."""
+        self.call(
+            [
+                self.update_checkout_path,
+                "--config",
+                self.config_path,
+                "--source-root",
+                self.source_root,
+                "--clone",
+                "--scheme",
+                "main",
+                "--skip-history",
+            ]
+        )
+
+        for repo in self.get_all_repos():
+            repo_path = os.path.join(self.source_root, repo)
+            remote_branches = self.call(["git", "branch", "-r"], cwd=repo_path).strip()
+            self.assertIn("origin/main", remote_branches)
+            self.assertNotIn(
+                "origin/other-branch",
+                remote_branches,
+                f"'{repo}' should not have fetched 'other-branch' (--single-branch)",
+            )
+
+    def test_regular_clone_fetches_all_branches(self):
+        """A regular clone (no --skip-history) should fetch all remote branches."""
+        self.call(
+            [
+                self.update_checkout_path,
+                "--config",
+                self.config_path,
+                "--source-root",
+                self.source_root,
+                "--clone",
+                "--scheme",
+                "main",
+            ]
+        )
+
+        for repo in self.get_all_repos():
+            repo_path = os.path.join(self.source_root, repo)
+            remote_branches = self.call(["git", "branch", "-r"], cwd=repo_path).strip()
+            self.assertIn("origin/main", remote_branches)
+            self.assertIn(
+                "origin/other-branch",
+                remote_branches,
+                f"'{repo}' should have all branches without --skip-history",
+            )
+
+    def test_regular_clone_is_not_shallow(self):
+        """A regular clone must have full history (not shallow)."""
+        self.call(
+            [
+                self.update_checkout_path,
+                "--config",
+                self.config_path,
+                "--source-root",
+                self.source_root,
+                "--clone",
+                "--scheme",
+                "main",
+            ]
+        )
+
+        for repo in self.get_all_repos():
+            repo_path = os.path.join(self.source_root, repo)
+            is_shallow = self.call(
+                ["git", "rev-parse", "--is-shallow-repository"], cwd=repo_path
+            ).strip()
+            self.assertEqual(
+                is_shallow,
+                "false",
+                f"'{repo}' should have full history without --skip-history",
+            )
+
+class PartialCloneTestCase(scheme_mock.SchemeMockTestCase):
+    """--partial-clone should configure --filter=blob:none on every repo."""
+
+    def _get_partial_clone_filter(self, repo_path):
+        """Return the configured partialclonefilter, or None if not set."""
+        try:
+            return self.call(
+                ["git", "config", "remote.origin.partialclonefilter"],
+                cwd=repo_path,
+            ).strip()
+        except scheme_mock.CallQuietlyException:
+            return None
+
+    def test_partial_clone_sets_filter(self):
+        """--partial-clone must set remote.origin.partialclonefilter=blob:none."""
+        self.call(
+            [
+                self.update_checkout_path,
+                "--config",
+                self.config_path,
+                "--source-root",
+                self.source_root,
+                "--clone",
+                "--scheme",
+                "main",
+                "--partial-clone",
+            ]
+        )
+
+        for repo in self.get_all_repos():
+            repo_path = os.path.join(self.source_root, repo)
+            filter_value = self._get_partial_clone_filter(repo_path)
+            self.assertEqual(
+                filter_value,
+                "blob:none",
+                f"'{repo}' should have partialclonefilter=blob:none",
+            )
+
+    def test_regular_clone_has_no_filter(self):
+        """Without --partial-clone the filter config key must not be set."""
+        self.call(
+            [
+                self.update_checkout_path,
+                "--config",
+                self.config_path,
+                "--source-root",
+                self.source_root,
+                "--clone",
+                "--scheme",
+                "main",
+            ]
+        )
+
+        for repo in self.get_all_repos():
+            repo_path = os.path.join(self.source_root, repo)
+            filter_value = self._get_partial_clone_filter(repo_path)
+            self.assertIsNone(
+                filter_value,
+                f"'{repo}' should not have a partial clone filter without --partial-clone",
+            )
+
+    def test_partial_clone_combined_with_skip_history(self):
+        """--partial-clone and --skip-history together: shallow AND filter."""
+        self.call(
+            [
+                self.update_checkout_path,
+                "--config",
+                self.config_path,
+                "--source-root",
+                self.source_root,
+                "--clone",
+                "--scheme",
+                "main",
+                "--partial-clone",
+                "--skip-history",
+            ]
+        )
+
+        for repo in self.get_all_repos():
+            repo_path = os.path.join(self.source_root, repo)
+
+            is_shallow = self.call(
+                ["git", "rev-parse", "--is-shallow-repository"], cwd=repo_path
+            ).strip()
+            self.assertEqual(
+                is_shallow,
+                "true",
+                f"'{repo}' should be shallow with --skip-history",
+            )
+
+            filter_value = self._get_partial_clone_filter(repo_path)
+            self.assertEqual(
+                filter_value,
+                "blob:none",
+                f"'{repo}' should have partialclonefilter with --partial-clone",
+            )
+
+
+class ShallowUpdateTestCase(scheme_mock.SchemeMockTestCase):
+    """update_single_repository must honor --skip-history when fetching."""
+
+    _NEW_FILE = "ci_update_file.txt"
+
+    def _push_new_commits(self):
+        _add_commit_to_repos(
+            self.local_path,
+            self.get_all_repos(),
+            self._NEW_FILE,
+            "added by CI update test",
+        )
+
+    def test_update_with_skip_history_stays_shallow(self):
+        """Repos must remain shallow after an update run with --skip-history."""
+        base_cmd = [
+            self.update_checkout_path,
+            "--config",
+            self.config_path,
+            "--source-root",
+            self.source_root,
+            "--scheme",
+            "main",
+            "--skip-history",
+            "--reset-to-remote",
+        ]
+
+        self.call(base_cmd + ["--clone"])
+        self._push_new_commits()
+        self.call(base_cmd)
+
+        for repo in self.get_all_repos():
+            repo_path = os.path.join(self.source_root, repo)
+            is_shallow = self.call(
+                ["git", "rev-parse", "--is-shallow-repository"], cwd=repo_path
+            ).strip()
+            self.assertEqual(
+                is_shallow,
+                "true",
+                f"'{repo}' should remain shallow after update with --skip-history",
+            )
+
+    def test_update_with_skip_history_tracks_latest_commit(self):
+        """After an update with --skip-history, HEAD must match the remote tip."""
+        base_cmd = [
+            self.update_checkout_path,
+            "--config",
+            self.config_path,
+            "--source-root",
+            self.source_root,
+            "--scheme",
+            "main",
+            "--skip-history",
+            "--reset-to-remote",
+        ]
+
+        self.call(base_cmd + ["--clone"])
+        self._push_new_commits()
+        self.call(base_cmd)
+
+        for repo in self.get_all_repos():
+            repo_path = os.path.join(self.source_root, repo)
+            local_head = self.call(["git", "rev-parse", "HEAD"], cwd=repo_path).strip()
+            remote_tip = self.call(
+                ["git", "rev-parse", "origin/main"], cwd=repo_path
+            ).strip()
+            self.assertEqual(
+                local_head,
+                remote_tip,
+                f"'{repo}' HEAD should equal origin/main after shallow update",
+            )

--- a/utils/update_checkout/tests/test_clone.py
+++ b/utils/update_checkout/tests/test_clone.py
@@ -5,8 +5,8 @@
 # Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
-# See https:#swift.org/LICENSE.txt for license information
-# See https:#swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 #
 # ===----------------------------------------------------------------------===#
 

--- a/utils/update_checkout/tests/test_locked_repository.py
+++ b/utils/update_checkout/tests/test_locked_repository.py
@@ -21,6 +21,8 @@ def _update_arguments_with_fake_path(repo_name: str, path: Path) -> UpdateArgume
         clean=False,
         stash=False,
         cross_repos_pr={},
+        skip_history=False,
+        partial_clone=False,
         output_prefix="",
         verbose=False,
     )

--- a/utils/update_checkout/update_checkout/cli_arguments.py
+++ b/utils/update_checkout/update_checkout/cli_arguments.py
@@ -10,6 +10,7 @@ class CliArguments(argparse.Namespace):
     clone_with_ssh: bool
     skip_history: bool
     skip_tags: bool
+    partial_clone: bool
     skip_repository_list: List[str]
     all_repositories: bool
     scheme: Optional[str]
@@ -55,6 +56,13 @@ repositories.
         )
         parser.add_argument(
             "--skip-tags", help="Skip tags when obtaining sources", action="store_true"
+        )
+        parser.add_argument(
+            "--partial-clone",
+            help="Use partial clones (--filter=blob:none) to fetch only commits and "
+            "trees, deferring blob downloads until they are needed. Significantly "
+            "reduces clone size for CI. Requires Git 2.19 or later.",
+            action="store_true",
         )
         parser.add_argument(
             "--skip-repository",

--- a/utils/update_checkout/update_checkout/runner_arguments.py
+++ b/utils/update_checkout/update_checkout/runner_arguments.py
@@ -24,6 +24,8 @@ class UpdateArguments(RunnerArguments):
     clean: bool
     stash: bool
     cross_repos_pr: Dict[str, str]
+    skip_history: bool
+    partial_clone: bool
 
 
 @dataclass

--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -160,6 +160,12 @@ def update_single_repository(pool_args: UpdateArguments):
         if verbose:
             print(f"{prefix}Updating '{repo_path}'")
 
+        fetch_extra_args = []
+        if pool_args.skip_history:
+            fetch_extra_args.extend(["--depth", "1"])
+        if pool_args.partial_clone:
+            fetch_extra_args.extend(["--filter", "blob:none"])
+
         cross_repo = False
         checkout_target = None
         if pool_args.tag:
@@ -225,7 +231,7 @@ def update_single_repository(pool_args: UpdateArguments):
             except Exception:
                 Git.run(
                     repo_path,
-                    ["fetch", "--recurse-submodules=yes", "--tags"],
+                    ["fetch", "--recurse-submodules=yes", "--tags"] + fetch_extra_args,
                     echo=verbose,
                     prefix=prefix,
                 )
@@ -251,7 +257,7 @@ def update_single_repository(pool_args: UpdateArguments):
         # which branch was checked out during the fetch.
         Git.run(
             repo_path,
-            ["fetch", "--recurse-submodules=yes", "--tags"],
+            ["fetch", "--recurse-submodules=yes", "--tags"] + fetch_extra_args,
             echo=verbose,
             prefix=prefix,
         )
@@ -495,6 +501,8 @@ def update_all_repositories(
             clean=args.clean,
             stash=args.stash,
             cross_repos_pr=cross_repos_pr,
+            skip_history=args.skip_history,
+            partial_clone=args.partial_clone,
             output_prefix="Updating",
             verbose=args.verbose,
         )
@@ -528,6 +536,7 @@ def obtain_additional_swift_sources(pool_args: AdditionalSwiftSourcesArguments):
         print("Cloning '" + pool_args.repo_name + "'")
 
     if args.skip_history:
+        filter_args = ["--filter", "blob:none"] if args.partial_clone else []
         if is_commit_hash(repo_branch):
             Git.run(
                 args.source_root,
@@ -542,6 +551,7 @@ def obtain_additional_swift_sources(pool_args: AdditionalSwiftSourcesArguments):
                     remote,
                     repo_name,
                 ]
+                + filter_args
                 + (["--no-tags"] if skip_tags else []),
                 env=env,
                 echo=verbose,
@@ -549,7 +559,7 @@ def obtain_additional_swift_sources(pool_args: AdditionalSwiftSourcesArguments):
             repo_path = args.source_root.joinpath(repo_name)
             Git.run(
                 repo_path,
-                ["fetch", "--depth", "1", "origin", repo_branch],
+                ["fetch", "--depth", "1", "origin", repo_branch] + filter_args,
                 env=env,
                 echo=verbose,
             )
@@ -566,11 +576,13 @@ def obtain_additional_swift_sources(pool_args: AdditionalSwiftSourcesArguments):
                     "--recursive",
                     "--depth",
                     "1",
+                    "--single-branch",
                     "--branch",
                     repo_branch,
                     remote,
                     repo_name,
                 ]
+                + filter_args
                 + (["--no-tags"] if skip_tags else []),
                 env=env,
                 echo=verbose,
@@ -584,6 +596,7 @@ def obtain_additional_swift_sources(pool_args: AdditionalSwiftSourcesArguments):
             echo=verbose,
         )
     else:
+        filter_args = ["--filter", "blob:none"] if args.partial_clone else []
         Git.run(
             args.source_root,
             [
@@ -596,6 +609,7 @@ def obtain_additional_swift_sources(pool_args: AdditionalSwiftSourcesArguments):
                 remote,
                 repo_name,
             ]
+            + filter_args
             + (["--no-tags"] if skip_tags else []),
             env=env,
             echo=verbose,


### PR DESCRIPTION
This patch adds ways to speed up a fresh clone by doing 2 things:

1. Doing a shallow clone (`--depth 1`) and only cloning one branch (`--single-branch`) when using the `--skip-history` flag.
2. Fetch blobs on demand with `--filter=blob:none` with the `--partial-clone` flag.

This yields a 3x performance improvement when cloning all the repositories at desk:
```
./swift/utils/update-checkout --clone --clone-with-ssh --scheme main --skip-history --partial-clone
56.76s user 65.67s system 78% cpu 2:36.42 total

./swift/utils/update-checkout --clone --clone-with-ssh --scheme main 
471.02s user 184.06s system 156% cpu 6:58.65 total
```