### PR TITLE
[Windows] Fix LNK1104 race in Test-Compilers by linking stdlib DLLs first

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2273,6 +2273,7 @@ function Test-Compilers([Hashtable] $Platform, [string] $Variant, [switch] $Test
       Write-Warning "Test-Compilers invoked without specifying test target(s)."
     }
 
+    # TODO(roman-bcny): Workaround for https://github.com/swiftlang/swift/issues/87970
     # Stdlib DLLs must be fully linked before swift-frontend compilations
     # that load them, otherwise the linker races with memory-mapped DLLs
     # causing LNK1104. Separate ninja invocations enforce ordering.

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2273,6 +2273,11 @@ function Test-Compilers([Hashtable] $Platform, [string] $Variant, [switch] $Test
       Write-Warning "Test-Compilers invoked without specifying test target(s)."
     }
 
+    # Stdlib DLLs must be fully linked before swift-frontend compilations
+    # that load them, otherwise the linker races with memory-mapped DLLs
+    # causing LNK1104. Separate ninja invocations enforce ordering.
+    $Targets = @("swift-test-stdlib") + $Targets
+
     Build-CMakeProject `
       -Src $SourceCache\llvm-project\llvm `
       -Bin $(Get-ProjectBinaryCache $Platform Compilers) `


### PR DESCRIPTION
On Windows, swift-frontend.exe loads stdlib DLLs (swiftCore.dll and others) at startup. When ninja links a stdlib DLL concurrently with a swift-frontend invocation that has it loaded, the linker fails with LNK1104 because Windows locks loaded DLLs.

Fix by building swift-test-stdlib as a separate ninja invocation before the test targets in Test-Compilers. Since Build-CMakeProject iterates -BuildTargets with separate cmake --build calls, this ensures all stdlib DLLs are fully linked before any swift-frontend process can load them.

This is a workaround for https://github.com/swiftlang/swift/issues/87970.

Observed on Jenkins swift-main-windows-toolchain and reproduced on a dev VM.