### PR TITLE
[6.3][Concurrency] Fix `stripConcurrency` to avoid dropping parameter isol…

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1004,8 +1004,16 @@ Type TypeBase::stripConcurrency(bool recurse, bool dropGlobalActor,
     if (dropGlobalActor && extInfo.getGlobalActor())
       extInfo = extInfo.withoutIsolation();
 
-    if (dropIsolation)
-      extInfo = extInfo.withoutIsolation();
+    if (dropIsolation) {
+      // Special case for `isolated` parameters, because even though
+      // the isolation was dropped, the parameter itself was left with
+      // `isolated` bit set. `dropIsolation` is intended only for
+      // mangling of `@preconcurrency` declarations and isolated parameters
+      // don't contribute to the type so it's save to keep the original
+      // isolation here.
+      if (!extInfo.getIsolation().isParameter())
+        extInfo = extInfo.withoutIsolation();
+    }
 
     ArrayRef<AnyFunctionType::Param> params = fnType->getParams();
     Type resultType = fnType->getResult();

--- a/test/Concurrency/preconcurrency_isolation_erasure.swift
+++ b/test/Concurrency/preconcurrency_isolation_erasure.swift
@@ -21,3 +21,9 @@ struct S {
   init(_: [Data<nonisolated(nonsending) @Sendable () async -> Void>]? = nil) {}
   // CHECK-LABEL: sil hidden [ossa] @$s32preconcurrency_isolation_erasure1SVyACSayAA4DataVyyyYacGGSgcfC
 }
+
+// CHECK: sil [ossa] @$s32preconcurrency_isolation_erasure17testIsolatedParam0B0yScA_pSgYi_tF
+@preconcurrency public func testIsolatedParam(isolation: isolated (any Actor)? = nil) {}
+
+// CHECK: sil [ossa] @$s32preconcurrency_isolation_erasure019testIsolatedParamInF02fnyyScA_pSgYiXE_tF
+@preconcurrency public func testIsolatedParamInParam(fn: (isolated (any Actor)?) -> Void) {}


### PR DESCRIPTION
…ation

- Explanation:

  Special case for `isolated` parameters, because even though the isolation was dropped, the parameter itself was left with `isolated` bit set. `dropIsolation` is intended only for mangling of `@preconcurrency` declarations and isolated parameters don't contribute to the type so it's save to keep the original isolation here.

- Resolves: rdar://171075466

- Main Branch PR: https://github.com/swiftlang/swift/pull/87626

- Risk: Very Low. A very narrow change that covers only mangling computation for declarations with `isolated` parameters that appear in `@preconcurrency` declarations and doesn't change the mangling itself in any way.

- Reviewed By: @hborla  

- Testing: Added new test-cases to the suite.

(cherry picked from commit 19d05abf88e18e36f79bf80e1a64d39641883101)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
