### PR TITLE
Fix the stack nesting of task-local values

### DIFF
--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -1228,15 +1228,31 @@ BUILTIN_MISC_OPERATION_WITH_SILGEN(TaskAddPriorityEscalationHandler,
 BUILTIN_MISC_OPERATION(TaskRemovePriorityEscalationHandler,
                        "taskRemovePriorityEscalationHandler", "", Special)
 
-/// Equivalent to calling swift_task_localValuePush.
+/// Equivalent to calling swift_task_localValuePush. Deprecated because
+/// it doesn't properly pair the allocation and deallocation with a
+/// use-def relationship. We no longer use this in the standard library,
+/// but it can't just be removed because it shares a feature test
+/// (BuiltinConcurrencyStackNesting) with other builtins that aren't
+/// deprecated.
 ///
 /// Signature: <Value> (key: Builtin.RawPointer, value: __owned Value) -> ()
 BUILTIN_MISC_OPERATION(TaskLocalValuePush, "taskLocalValuePush", "", Special)
 
-/// Equivalent to calling swift_task_localValuePop.
+/// Equivalent to calling swift_task_localValuePop. Deprecated; see
+/// TaskLocalValuePush.
 ///
 /// Signature: () -> ()
 BUILTIN_MISC_OPERATION(TaskLocalValuePop, "taskLocalValuePop", "", Special)
+
+/// Add a task-local binding within a scope.
+///
+/// Signature: <Value> (UnsafeRawPointer, value: __owned Value) -> UnsafeRawPointer
+BUILTIN_MISC_OPERATION(AddTaskLocalValue, "addTaskLocalValue", "", Special)
+
+/// End the scope of a task-local binding.
+///
+/// Signature: (UnsafeRawPointer) -> ()
+BUILTIN_MISC_OPERATION(RemoveTaskLocalValue, "removeTaskLocalValue", "", Special)
 
 /// Equivalent to calling swift_task_cancellationShieldPush.
 ///

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -281,6 +281,7 @@ LANGUAGE_FEATURE(BuiltinConcurrencyStackNesting, 0, "Concurrency Stack Nesting B
 LANGUAGE_FEATURE(ClosureLifetimes, 0, "Support @_lifetime on function types")
 BASELINE_LANGUAGE_FEATURE(ExcludePrivateFromMemberwiseInit, 502, "Exclude private initialized properties from memberwise init")
 LANGUAGE_FEATURE(BuiltinMarkDependence, 0, "markDependence Builtin")
+LANGUAGE_FEATURE(BuiltinAddTaskLocalValue, 0, "addTaskLocalValue and removeTaskLocalValue builtins")
 
 // TEMPORARY: Never use this, because it is only meant to allow us to model
 // suppression of @c in Swift interfaces as a temporary measure.

--- a/include/swift/SIL/AddressWalker.h
+++ b/include/swift/SIL/AddressWalker.h
@@ -291,6 +291,7 @@ TransitiveAddressWalker<Impl>::walk(SILValue projectedAddress) {
         case BuiltinValueKind::FlowSensitiveSelfIsolation:
         case BuiltinValueKind::FlowSensitiveDistributedSelfIsolation:
         case BuiltinValueKind::TaskLocalValuePush:
+        case BuiltinValueKind::AddTaskLocalValue:
         case BuiltinValueKind::TaskCancellationShieldPush:
         case BuiltinValueKind::TaskCancellationShieldPop:
           callVisitUse(op);

--- a/include/swift/SIL/StackAllocation.h
+++ b/include/swift/SIL/StackAllocation.h
@@ -59,12 +59,9 @@ enum class StackAllocationKind : uint8_t {
   /// deallocation is a BuiltinInst for the FinishAsyncLet builtin.
   BuiltinStartAsyncLet,
 
-  /// A BuiltinInst for the TaskLocalValuePush builtin. The deallocation
-  /// is a BuiltinInst for the TaskLocalValuePop builtin.
-  ///
-  /// FIXME: this one doesn't work because we didn't actually give it a use/def
-  /// relationship!
-  BuiltinTaskLocalValuePush,
+  /// A BuiltinInst for the AddTaskLocalValue builtin. The deallocation
+  /// is a BuiltinInst for the RemoveTaskLocalValue builtin.
+  BuiltinAddTaskLocalValue,
 
   /// A BuiltinInst for the TaskAddPriorityEscalationHandler builtin. The
   /// deallocation is a BuiltinInst for the TaskRemovePriorityEscalationHandler

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -2430,6 +2430,16 @@ static ValueDecl *getTaskLocalValuePop(ASTContext &ctx, Identifier id) {
   return getBuiltinFunction(ctx, id, _thin, _parameters(), _void);
 }
 
+static ValueDecl *getAddTaskLocalValue(ASTContext &ctx, Identifier id) {
+  return getBuiltinFunction(ctx, id, _thin, _generics(_unrestricted),
+                            _parameters(_rawPointer, _consuming(_typeparam(0))),
+                            _rawPointer);
+}
+
+static ValueDecl *getRemoveTaskLocalValue(ASTContext &ctx, Identifier id) {
+  return getBuiltinFunction(ctx, id, _thin, _parameters(_rawPointer), _void);
+}
+
 static ValueDecl *getMakeBorrow(ASTContext &ctx, Identifier id) {
   BuiltinFunctionBuilder builder(ctx, /* genericParamCount */ 1);
 
@@ -3564,6 +3574,12 @@ ValueDecl *swift::getBuiltinValueDecl(ASTContext &Context, Identifier Id) {
 
   case BuiltinValueKind::TaskLocalValuePop:
     return getTaskLocalValuePop(Context, Id);
+
+  case BuiltinValueKind::AddTaskLocalValue:
+    return getAddTaskLocalValue(Context, Id);
+
+  case BuiltinValueKind::RemoveTaskLocalValue:
+    return getRemoveTaskLocalValue(Context, Id);
 
   case BuiltinValueKind::MakeBorrow:
     return getMakeBorrow(Context, Id);

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -418,6 +418,10 @@ static bool usesFeatureBuiltinConcurrencyStackNesting(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureBuiltinAddTaskLocalValue(Decl *decl) {
+  return false;
+}
+
 UNINTERESTING_FEATURE(CompileTimeValuesPreview)
 UNINTERESTING_FEATURE(LiteralExpressions)
 UNINTERESTING_FEATURE(StrictMemorySafety)

--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -1582,14 +1582,22 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &Builtin,
     out.add(emitBuiltinTaskAddHandler(IGF, Builtin.ID, func, context));
     return;
   }
+  case BuiltinValueKind::RemoveTaskLocalValue:
   case BuiltinValueKind::TaskLocalValuePop:
+    // removeTaskLocalValue technically takes an argument, but we ignore
+    // it because it's really just an abstract token.
     return emitBuiltinTaskLocalValuePop(IGF);
+  case BuiltinValueKind::AddTaskLocalValue:
   case BuiltinValueKind::TaskLocalValuePush: {
     auto *key = args.claimNext();
     auto *value = args.claimNext();
     // Grab T from the builtin.
     auto *valueMetatype = IGF.emitTypeMetadataRef(argTypes[1].getASTType());
-    return emitBuiltinTaskLocalValuePush(IGF, key, value, valueMetatype);
+    emitBuiltinTaskLocalValuePush(IGF, key, value, valueMetatype);
+
+    // The output value is not used for anything, so we don't actually set
+    // anything.
+    return;
   }
   case BuiltinValueKind::TaskCancellationShieldPush:
     out.add(emitBuiltinTaskCancellationShieldPush(IGF));

--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -1079,6 +1079,9 @@ BUILTIN_OPERAND_OWNERSHIP(TrivialUse, TaskRemovePriorityEscalationHandler)
 // This is a trivial use since our first operand is a Builtin.RawPointer and our
 // second is an address to our generic Value.
 BUILTIN_OPERAND_OWNERSHIP(TrivialUse, TaskLocalValuePush)
+BUILTIN_OPERAND_OWNERSHIP(TrivialUse, AddTaskLocalValue)
+// Trivial use of the token result of AddTaskLocalValue.
+BUILTIN_OPERAND_OWNERSHIP(TrivialUse, RemoveTaskLocalValue)
 
 BUILTIN_OPERAND_OWNERSHIP(TrivialUse, TaskCancellationShieldPush)
 BUILTIN_OPERAND_OWNERSHIP(TrivialUse, TaskCancellationShieldPop)

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -1346,7 +1346,7 @@ SILInstruction::getStackAllocation() const {
       BUILTIN_CASE(StackAlloc, StackAlloc)
       BUILTIN_CASE(UnprotectedStackAlloc, UnprotectedStackAlloc)
       BUILTIN_CASE(StartAsyncLetWithLocalBuffer, StartAsyncLet)
-      //BUILTIN_CASE(TaskLocalValuePush, TaskLocalValuePush)
+      BUILTIN_CASE(AddTaskLocalValue, AddTaskLocalValue)
       BUILTIN_CASE(TaskAddPriorityEscalationHandler,
                    TaskAddPriorityEscalationHandler)
       BUILTIN_CASE(TaskAddCancellationHandler, TaskAddCancellationHandler)
@@ -1453,7 +1453,7 @@ SILInstruction::getStackDeallocation() const {
                                                StackAllocationKind::ID); \
       }
       BUILTIN_CASE(FinishAsyncLet, BuiltinStartAsyncLet)
-      //BUILTIN_CASE(TaskLocalValuePop, BuiltinTaskLocalValuePush)
+      BUILTIN_CASE(RemoveTaskLocalValue, BuiltinAddTaskLocalValue)
       BUILTIN_CASE(TaskRemovePriorityEscalationHandler,
                    BuiltinTaskAddPriorityEscalationHandler)
       BUILTIN_CASE(TaskRemoveCancellationHandler,

--- a/lib/SIL/IR/ValueOwnership.cpp
+++ b/lib/SIL/IR/ValueOwnership.cpp
@@ -674,6 +674,8 @@ CONSTANT_OWNERSHIP_BUILTIN(None, TaskAddPriorityEscalationHandler)
 CONSTANT_OWNERSHIP_BUILTIN(None, TaskRemovePriorityEscalationHandler)
 CONSTANT_OWNERSHIP_BUILTIN(None, TaskLocalValuePush)
 CONSTANT_OWNERSHIP_BUILTIN(None, TaskLocalValuePop)
+CONSTANT_OWNERSHIP_BUILTIN(None, AddTaskLocalValue)
+CONSTANT_OWNERSHIP_BUILTIN(None, RemoveTaskLocalValue)
 CONSTANT_OWNERSHIP_BUILTIN(None, TaskCancellationShieldPush)
 CONSTANT_OWNERSHIP_BUILTIN(None, TaskCancellationShieldPop)
 

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -5799,10 +5799,17 @@ CallEmission::applySpecializedEmitter(SpecializedEmitter &specializedEmitter,
     }
   }
 
-  SILValue rawResult = SGF.B.createBuiltin(
+  auto rawResult = SGF.B.createBuiltin(
       loc, builtinName,
       substConv.getSILResultType(SGF.getTypeExpansionContext()),
       callee.getSubstitutions(), rawArgs);
+
+  // Handle some special cases for specific builtins.
+  if (builtinName.is(getBuiltinName(BuiltinValueKind::AddTaskLocalValue))) {
+    SGF.addEmissionFinalizer([rawResult](SILGenFunction &SGF) {
+      SGF.finalizeAddTaskLocalValue(rawResult);
+    });
+  }
 
   if (argScope.has_value())
     std::move(argScope)->pop();

--- a/lib/SILGen/SILGenConcurrency.cpp
+++ b/lib/SILGen/SILGenConcurrency.cpp
@@ -21,6 +21,7 @@
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/Range.h"
+#include "swift/SILOptimizer/Utils/StackNesting.h"
 
 using namespace swift;
 using namespace Lowering;
@@ -916,4 +917,44 @@ SILGenFunction::emitDistributedActorAsAnyActor(SILLocation loc,
       loc, distributedActorCanType, distributedActorTL, anyActorTL,
       ctx.AllocateCopy(conformances), SGFContext(),
       [actorValue](SGFContext) { return actorValue; });
+}
+
+void SILGenFunction::finalizeAddTaskLocalValue(BuiltinInst *BI) {
+  // SILGen creates a temporary as part of emitting the argument, and there
+  // doesn't seem to be a way to avoid that without messing with the consume
+  // passes. Unfortunately, that temporary is not properly nested with the
+  // builtin, so we have to fix that nesting as a finalization step.
+  //
+  // Basically, the code we get out of SILGen is this:
+  //
+  //   %0 = alloc_stack
+  //   ...
+  //   %1 = builtin "addTaskLocalValue"<T>(..., %0)
+  //   ...
+  //   dealloc_stack %0
+  //   ...
+  //   builtin "removeTaskLocalValue"(%1)
+  //
+  // We need that to be:
+  //
+  //   %0 = alloc_stack
+  //   ...
+  //   %1 = builtin "addTaskLocalValue"<T>(..., %0)
+  //   ...
+  //   builtin "removeTaskLocalValue"(%1)
+  //   dealloc_stack %0
+  //
+  // Using StackNesting is better than doing some kind of more specific hack
+  // that would essentially hard-code the code patterns of specific stdlib
+  // functions. The overhead is okay because we only trigger it on the
+  // functions that directly call to this builtin.
+  //
+  // It would be better to not need this at all, of course. One option would be
+  // to make the builtin model fully safe, which would require some kind of
+  // higher-order builtin that SILGen would lower to the two SIL builtins.
+  // That might be a better approach in the long term, especially once we don't
+  // need some of the compatibility hacks to make the swiftinterface parseable
+  // by old compilers. Another would be to just find a way to guarantee that
+  // SILGen emits the argument without a temporary.
+  StackNesting::fixNesting(&F);
 }

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -1854,7 +1854,7 @@ void SILGenFunction::emitInitAccessor(AccessorDecl *accessor) {
 
   emitEpilog(accessor);
 
-  mergeCleanupBlocks();
+  finalizeEmission();
 }
 
 void SILGenFunction::emitPropertyWrappedFieldInitAccessor(
@@ -1964,5 +1964,5 @@ void SILGenFunction::emitPropertyWrappedFieldInitAccessor(
 
   // Emit epilog/cleanups
   emitEpilog(Loc);
-  mergeCleanupBlocks();
+  finalizeEmission();
 }

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -125,6 +125,14 @@ SILGenFunction::~SILGenFunction() {
 // Function emission
 //===----------------------------------------------------------------------===//
 
+void SILGenFunction::finalizeEmission() {
+  mergeCleanupBlocks();
+
+  for (auto &finalizer : EmissionFinalizers) {
+    finalizer(*this);
+  }
+}
+
 // Get the #function name for a declaration.
 DeclName SILGenModule::getMagicFunctionName(DeclContext *dc) {
   // For closures, use the parent name.
@@ -1149,7 +1157,7 @@ void SILGenFunction::emitFunction(FuncDecl *fd) {
     emitEpilog(fd);
   }
 
-  mergeCleanupBlocks();
+  finalizeEmission();
 }
 
 void SILGenFunction::emitClosure(AbstractClosureExpr *ace) {
@@ -1673,7 +1681,7 @@ void SILGenFunction::emitGeneratorFunction(SILDeclRef function, Expr *value,
   }
 
   emitEpilog(Loc);
-  mergeCleanupBlocks();
+  finalizeEmission();
 }
 
 void SILGenFunction::emitGeneratorFunction(SILDeclRef function, VarDecl *var) {
@@ -1766,7 +1774,7 @@ void SILGenFunction::emitGeneratorFunction(
   emitStmt(body);
 
   emitEpilog(loc);
-  mergeCleanupBlocks();
+  finalizeEmission();
 }
 
 InitializationPtr SILGenFunction::getSingleValueStmtInit(Expr *E) {

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -449,6 +449,10 @@ public:
   /// This records information about the currently active cleanups.
   CleanupManager Cleanups;
 
+  /// Features that might require cleanup at the end of emission.
+  using EmissionFinalizer = std::function<void(SILGenFunction&)>;
+  std::vector<EmissionFinalizer> EmissionFinalizers;
+
   /// The current context where formal evaluation cleanups are managed.
   FormalEvaluationContext FormalEvalContext;
 
@@ -1325,6 +1329,31 @@ public:
   void eraseBasicBlock(SILBasicBlock *block);
 
   void mergeCleanupBlocks();
+
+  void finalizeEmission();
+  void finalizeAddTaskLocalValue(BuiltinInst *builtin);
+
+  /// Add a callback that will run when emission is complete for the
+  /// current function. The callback is expected to have signature:
+  ///
+  ///   void (SILGenFunction &)
+  ///
+  /// The callback escapes the local scope and therefore must not capture
+  /// local variables by reference (i.e. do not use `[&]` in your lambda).
+  ///
+  /// Using this is generally a sign of a hack. Most "clean-up" work
+  /// should be handled by inserting instructions normally, either
+  /// immediately during emission or using a Cleanup object that will
+  /// insert code along exits from the current language-level scope. And
+  /// if the clean-up requires any kind of sophisticated analysis, it
+  /// probably deserves to go in a proper pass. An emission finalizer
+  /// might be appropriate for a hack that solves a narrow problem that
+  /// you can't justify solving in a more principled way, like patching
+  /// up scopes around a specific builtin call.
+  template <class Fn>
+  void addEmissionFinalizer(Fn &&fn) {
+    EmissionFinalizers.emplace_back(std::forward<Fn>(fn));
+  }
 
   //===--------------------------------------------------------------------===//
   // Concurrency

--- a/lib/SILOptimizer/Transforms/AccessEnforcementReleaseSinking.cpp
+++ b/lib/SILOptimizer/Transforms/AccessEnforcementReleaseSinking.cpp
@@ -221,6 +221,8 @@ static bool isBarrier(SILInstruction *inst) {
     case BuiltinValueKind::TaskRemovePriorityEscalationHandler:
     case BuiltinValueKind::TaskLocalValuePush:
     case BuiltinValueKind::TaskLocalValuePop:
+    case BuiltinValueKind::AddTaskLocalValue:
+    case BuiltinValueKind::RemoveTaskLocalValue:
     case BuiltinValueKind::TaskCancellationShieldPush:
     case BuiltinValueKind::TaskCancellationShieldPop:
       return true;

--- a/lib/SILOptimizer/Utils/StackNesting.cpp
+++ b/lib/SILOptimizer/Utils/StackNesting.cpp
@@ -199,7 +199,7 @@ static void createDealloc(SILBuilder &B, SILLocation loc, SILInstruction *alloc)
     return;
   }
   case StackAllocationKind::BuiltinStartAsyncLet:
-  case StackAllocationKind::BuiltinTaskLocalValuePush:
+  case StackAllocationKind::BuiltinAddTaskLocalValue:
   case StackAllocationKind::BuiltinTaskAddPriorityEscalationHandler:
   case StackAllocationKind::BuiltinTaskAddCancellationHandler:
     llvm_unreachable("cannot insert this builtin; not safely reorderable");
@@ -230,9 +230,10 @@ static bool isUnreorderableAllocation(StackAllocation allocation) {
   case StackAllocationKind::CalleeAllocatedBeginApply:
     return false;
 
-  // The finish of an async let cannot be reordered across.
+  // These deallocations cannot be reordered across because they are
+  // associated with semantic effects.
   case StackAllocationKind::BuiltinStartAsyncLet:
-  case StackAllocationKind::BuiltinTaskLocalValuePush:
+  case StackAllocationKind::BuiltinAddTaskLocalValue:
   case StackAllocationKind::BuiltinTaskAddPriorityEscalationHandler:
   case StackAllocationKind::BuiltinTaskAddCancellationHandler:
     return true;

--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -235,22 +235,22 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
 
   /// Implementation for withValue that consumes valueDuringOperation.
   ///
-  /// Because Builtin.taskLocalValuePush and Builtin.taskLocalValuePop involve
+  /// Because Builtin.addTaskLocalValue and Builtin.removeTaskLocalValue involve
   /// calls to swift_task_alloc/swift_task_dealloc respectively unbeknownst to
   /// the compiler, compiler-emitted calls to swift_task_de/alloc must be
   /// avoided in a function that calls them.
   ///
   /// A copy of valueDuringOperation is required because withValue borrows its
-  /// argument but Builtin.taskLocalValuePush consumes its.  Because
+  /// argument but Builtin.addTaskLocalValue consumes it.  Because
   /// valueDuringOperation is of generic type, its size is not generally known,
   /// so such a copy entails a stack allocation and a copy to that allocation.
   /// That stack traffic gets lowered to calls to
   /// swift_task_alloc/swift_task_deallloc.
   ///
-  /// Split the calls Builtin.taskLocalValuePush/Pop from the compiler-emitted calls
-  /// to swift_task_de/alloc for the copy as follows:
+  /// Split the calls Builtin.{add,remove}TaskLocalValue from the compiler-emitted
+  /// calls to swift_task_de/alloc for the copy as follows:
   /// - withValue contains the compiler-emitted calls swift_task_de/alloc.
-  /// - withValueImpl contains the calls to Builtin.taskLocalValuePush/Pop
+  /// - withValueImpl contains the calls to Builtin.{add,remove}TaskLocalValue
   @inlinable
   @discardableResult
   @available(SwiftStdlib 5.1, *)
@@ -259,9 +259,9 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
                                  operation: () async throws -> R,
                                  isolation: isolated (any Actor)?,
                                  file: String = #fileID, line: UInt = #line) async rethrows -> R {
-#if $BuiltinConcurrencyStackNesting
-    Builtin.taskLocalValuePush(key, consume valueDuringOperation)
-    defer { Builtin.taskLocalValuePop() }
+#if $BuiltinAddTaskLocalValue
+    let binding = Builtin.addTaskLocalValue(key, consume valueDuringOperation)
+    defer { Builtin.removeTaskLocalValue(binding) }
 #else
     _taskLocalValuePush(key: key, value: consume valueDuringOperation)
     defer { _taskLocalValuePop() }
@@ -280,9 +280,9 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
     operation: () async throws -> R,
     file: String = #fileID, line: UInt = #line
   ) async rethrows -> R {
-#if $BuiltinConcurrencyStackNesting
-    Builtin.taskLocalValuePush(key, consume valueDuringOperation)
-    defer { Builtin.taskLocalValuePop() }
+#if $BuiltinAddTaskLocalValue
+    let binding = Builtin.addTaskLocalValue(key, consume valueDuringOperation)
+    defer { Builtin.removeTaskLocalValue(binding) }
 #else
     _taskLocalValuePush(key: key, value: consume valueDuringOperation)
     defer { _taskLocalValuePop() }
@@ -309,9 +309,9 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   @discardableResult
   public func withValue<R>(_ valueDuringOperation: Value, operation: () throws -> R,
                            file: String = #fileID, line: UInt = #line) rethrows -> R {
-#if $BuiltinConcurrencyStackNesting
-    Builtin.taskLocalValuePush(key, valueDuringOperation)
-    defer { Builtin.taskLocalValuePop() }
+#if $BuiltinAddTaskLocalValue
+    let binding = Builtin.addTaskLocalValue(key, valueDuringOperation)
+    defer { Builtin.removeTaskLocalValue(binding) }
 #else
     _taskLocalValuePush(key: key, value: valueDuringOperation)
     defer { _taskLocalValuePop() }

--- a/test/IRGen/builtins.swift
+++ b/test/IRGen/builtins.swift
@@ -979,7 +979,17 @@ nonisolated(nonsending) func testTaskLocalValuePush<Value>(_ key: Builtin.RawPoi
 // CHECK: call swiftcc {} @swift_task_localValuePop()
 nonisolated(nonsending) func testTaskLocalValuePop() async {
   Builtin.taskLocalValuePop()
-} 
+}
+
+// CHECK-LABEL: define {{.*}}void @"$s8builtins18testTaskLocalValueyyBp_xntYalF"(ptr swiftasync %0, i64 %1, i64 %2, ptr %3, ptr noalias %4, ptr %Value)
+// CHECK: [[TASK_VAR:%.*]] = call swiftcc ptr @swift_task_alloc({{.*}}
+// CHECK: call ptr %InitializeWithTake(ptr noalias [[TASK_VAR]], ptr noalias {{%.*}}, ptr %Value)
+// CHECK: call swiftcc {} @swift_task_localValuePush(ptr %3, ptr [[TASK_VAR]], ptr %Value)
+// CHECK: call swiftcc {} @swift_task_localValuePop()
+nonisolated(nonsending) func testTaskLocalValue<Value>(_ key: Builtin.RawPointer, _ value: consuming Value) async {
+  let binding = Builtin.addTaskLocalValue(key, value)
+  Builtin.removeTaskLocalValue(binding)
+}
 
 // CHECK-LABEL: define {{.*}}void @"$s8builtins30testTaskCancellationShieldPushyyYaF"(ptr swiftasync %0, i64 %1, i64 %2)
 // CHECK: call swiftcc i1 @swift_task_cancellationShieldPush()

--- a/test/SILGen/builtins.swift
+++ b/test/SILGen/builtins.swift
@@ -964,6 +964,26 @@ func testTaskAddPriorityEscalationHandlerWithDefer() async {
   defer { Builtin.taskRemovePriorityEscalationHandler(record: result) }
 }
 
+// CHECK-LABEL: sil hidden [ossa] @$s8builtins18testTaskLocalValueyyBp_xntYalF : $@convention(thin) @async <Value> (Builtin.RawPointer, @in Value) -> () {
+// CHECK: bb0([[PTR_ARG:%.*]] : $Builtin.RawPointer, [[VALUE:%.*]] : @noImplicitCopy @_eagerMove $*Value):
+// CHECK:   [[CONSUME_BOX:%.*]] = alloc_box $<τ_0_0> { var @moveOnly τ_0_0 } <Value>, var, name "value"
+// CHECK:   [[BORROW_BOX:%.*]] = begin_borrow [var_decl] [[CONSUME_BOX]]
+// CHECK:   [[PROJECT_BOX:%.*]] = project_box [[BORROW_BOX]]
+// CHECK:   [[WRAPPER:%.*]] = moveonlywrapper_to_copyable_addr [[PROJECT_BOX]]
+// CHECK:   copy_addr [take] [[VALUE]] to [init] [[WRAPPER]]
+// CHECK:   [[DEINIT_ADDR:%.*]] = begin_access [deinit] [unknown] [[PROJECT_BOX]]
+// CHECK:   [[MOVE_ONLY_ADDR:%.*]] = mark_unresolved_non_copyable_value [assignable_but_not_consumable] [[DEINIT_ADDR]]
+// CHECK:   [[STACK:%.*]] = alloc_stack $@moveOnly Value
+// CHECK:   copy_addr [[MOVE_ONLY_ADDR]] to [init] [[STACK]]
+// CHECK:   [[BINDING:%.*]] = builtin "addTaskLocalValue"<Value>([[PTR_ARG]] : $Builtin.RawPointer, [[STACK]] : $*@moveOnly Value) : $Builtin.RawPointer
+// CHECK:   [[MOVE_BINDING:%.*]] = move_value [var_decl] [[BINDING]]
+// CHECK:   builtin "removeTaskLocalValue"([[MOVE_BINDING]] : $Builtin.RawPointer) : $()
+// CHECK: } // end sil function '$s8builtins18testTaskLocalValueyyBp_xntYalF'
+func testTaskLocalValue<Value>(_ key: Builtin.RawPointer, _ value: consuming Value) async {
+  let binding = Builtin.addTaskLocalValue(key, value)
+  Builtin.removeTaskLocalValue(binding)
+}
+
 // CHECK-LABEL: sil hidden [ossa] @$s8builtins22testTaskLocalValuePushyyBp_xntYalF : $@convention(thin) @async <Value> (Builtin.RawPointer, @in Value) -> () {
 // CHECK: bb0([[PTR_ARG:%.*]] : $Builtin.RawPointer, [[VALUE:%.*]] : @noImplicitCopy @_eagerMove $*Value):
 // CHECK:   [[CONSUME_BOX:%.*]] = alloc_box $<τ_0_0> { var @moveOnly τ_0_0 } <Value>, var, name "value"

--- a/test/SILGen/builtins.swift
+++ b/test/SILGen/builtins.swift
@@ -978,6 +978,7 @@ func testTaskAddPriorityEscalationHandlerWithDefer() async {
 // CHECK:   [[BINDING:%.*]] = builtin "addTaskLocalValue"<Value>([[PTR_ARG]] : $Builtin.RawPointer, [[STACK]] : $*@moveOnly Value) : $Builtin.RawPointer
 // CHECK:   [[MOVE_BINDING:%.*]] = move_value [var_decl] [[BINDING]]
 // CHECK:   builtin "removeTaskLocalValue"([[MOVE_BINDING]] : $Builtin.RawPointer) : $()
+// CHECK:   dealloc_stack [[STACK]]
 // CHECK: } // end sil function '$s8builtins18testTaskLocalValueyyBp_xntYalF'
 func testTaskLocalValue<Value>(_ key: Builtin.RawPointer, _ value: consuming Value) async {
   let binding = Builtin.addTaskLocalValue(key, value)

--- a/test/SILOptimizer/stack-nesting.sil
+++ b/test/SILOptimizer/stack-nesting.sil
@@ -601,3 +601,49 @@ bb0:
   %ret = tuple ()
   return %ret : $()
 }
+
+// The task local value builtins cannot be reordered.
+// CHECK-LABEL: sil [ossa] @test_task_local_non_nested :
+// CHECK:         integer_literal $Builtin.Int32, 1
+// CHECK-NEXT:    [[A:%.*]] = alloc_stack $Int
+// CHECK:         [[BINDING:%.*]] = builtin "addTaskLocalValue"<Int>({{.*}}, [[A]])
+// CHECK-NEXT:    integer_literal $Builtin.Int32, 2
+// CHECK-NEXT:    [[B:%.*]] = alloc_stack [non_nested] $Int
+// CHECK-NEXT:    [[C:%.*]] = alloc_stack [non_nested] $Int
+// CHECK-NEXT:    [[D:%.*]] = alloc_stack $Int
+// CHECK-NEXT:    dealloc_stack [[D]]
+// CHECK-NEXT:    integer_literal $Builtin.Int32, 3
+// CHECK-NEXT:    builtin "removeTaskLocalValue"([[BINDING]])
+// CHECK-NEXT:    dealloc_stack [[C]]
+// CHECK-NEXT:    dealloc_stack [[B]]
+// CHECK-NEXT:    dealloc_stack [[A]]
+// CHECK-NEXT:    integer_literal $Builtin.Int32, 4
+// CHECK-LABEL: // end sil function 'test_task_local_non_nested'
+sil [ossa] @test_task_local_non_nested : $@convention(thin) @async () -> () {
+bb0:
+  specify_test "stack_nesting_fixup"
+  integer_literal $Builtin.Int32, 1
+  %a = alloc_stack $Int
+
+  %key = address_to_pointer %a to $Builtin.RawPointer
+  %binding = builtin "addTaskLocalValue"<Int>(%key, %a) : $Builtin.RawPointer
+
+  integer_literal $Builtin.Int32, 2
+
+  %b = alloc_stack $Int
+  %c = alloc_stack $Int
+  %d = alloc_stack $Int
+
+  dealloc_stack %d
+  dealloc_stack %b
+
+  integer_literal $Builtin.Int32, 3
+
+  %out = builtin "removeTaskLocalValue"(%binding) : $()
+
+  dealloc_stack %a
+  dealloc_stack %c
+  integer_literal $Builtin.Int32, 4
+  %ret = tuple ()
+  return %ret : $()
+}


### PR DESCRIPTION
This requires introducing new builtins because the existing builtins are not properly paired with a use-def relationship.

The existing builtins need to stick around for a while so that we can parse old `swiftinterface`s for the `_Concurrency` module: the existing interfaces expect these builtins to be usable if the `BuiltinConcurrencyStackNesting` feature is available, and we can't just remove that feature because it's also used to control the existence of some other builtins. Hopefully the window for that is fairly short, though, because we will continue to not model the stack-allocation effects of those builtins.

The biggest challenge here is that, unlike all of the other allocating builtins we've been dealing with, `addTaskLocalValue` takes a `consuming` argument of an arbitrary type. That means that SILGen naturally ends up creating a temporary as part of argument emission, and that temporary is not properly nested w.r.t. to the builtins. The temporary must be removed by a mandatory pass or something, because otherwise we'd have badly-nested allocations every time, but it still leaves us briefly with an incorrect stack coming out of SILGen. I hacked SILGen to run `StackNesting` for any function that contains a use of these builtins; there are cleaner options available, but this one works without perturbing the library code too much.