### PR TITLE
ARCSequenceOpt: bail if the function is too large

### DIFF
--- a/lib/SILOptimizer/ARC/ARCSequenceOpts.cpp
+++ b/lib/SILOptimizer/ARC/ARCSequenceOpts.cpp
@@ -259,6 +259,17 @@ class ARCSequenceOpts : public SILFunctionTransform {
     if (F->hasOwnership())
       return;
 
+    // Bail if the function is too large. ARCSequenceOpt has quadratic
+    // complexity and for some large functions it takes too long to run.
+    int numInsts = 0;
+    for (auto &b : *F) {
+      for (auto &i : b) {
+        (void)i;
+        if (++numInsts > 10000)
+          return;
+      }
+    }
+
     if (!EnableLoopARC) {
       auto *AA = getAnalysis<AliasAnalysis>(F);
       auto *POTA = getAnalysis<PostOrderAnalysis>();

--- a/validation-test/SILOptimizer/many_trys.swift
+++ b/validation-test/SILOptimizer/many_trys.swift
@@ -2,7 +2,7 @@
 // If the compiler needs more than that, there is probably a real problem.
 // So please don't just increase the timeout in case this fails.
 
-// RUN: %{python} %S/../../test/Inputs/timeout.py 30 %target-swift-frontend -O -parse-as-library -sil-verify-none %s -emit-sil | %FileCheck %s
+// RUN: %{python} %S/../../test/Inputs/timeout.py 30 %target-swift-frontend -O -parse-as-library %s -emit-sil | %FileCheck %s
 
 // REQUIRES: tools-release,no_asan
 


### PR DESCRIPTION
ARCSequenceOpt has quadratic complexity and for some large functions it takes too long to run.
Adding this simple cut-off based on the instruction count is not ideal. However, once we have OSSA throughout the pass pipeline, ARCSequenceOpt will be removed anyway.

rdar://172744963
