### PR TITLE
tests: increase the timeout of SILOptimizer/large_string_array.swift.gyb for assert-enabled stdlib

### DIFF
--- a/validation-test/SILOptimizer/large_string_array_assert_stdlib.swift.gyb
+++ b/validation-test/SILOptimizer/large_string_array_assert_stdlib.swift.gyb
@@ -5,14 +5,14 @@
 // UNSUPPORTED: OS=linux-gnu
 
 // The compiler should finish in less than 1 minute. To give some slack,
-// specify a timeout of 5 minutes.
-// If the compiler needs more than 5 minutes, there is probably a real problem.
+// specify a timeout of 10 minutes.
+// If the compiler needs more than 10 minutes, there is probably a real problem.
 // So please don't just increase the timeout in case this fails.
 
-// RUN: %{python} %S/../../test/Inputs/timeout.py 300 %target-swift-frontend -O -parse-as-library -emit-sil %t/main.swift | %FileCheck %s
+// RUN: %{python} %S/../../test/Inputs/timeout.py 600 %target-swift-frontend -O -parse-as-library -emit-sil %t/main.swift | %FileCheck %s
 
-// There is a separate test for an assert-enabled stdlib
-// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
+// There is a separate test for an no-assert stdlib
+// REQUIRES: swift_stdlib_asserts,optimized_stdlib
 
 // REQUIRES: long_test
 // REQUIRES: CPU=arm64 || CPU=x86_64 || CPU=aarch64


### PR DESCRIPTION
In https://github.com/swiftlang/swift/pull/87315/changes/d1bf8430c0e1955b65d0b550482168c6a02d2232 I enabled this test for an assert-enabled stdlib. However, with an assert-enabled stdlib this test takes a bit longer. So separate this variant into a new test which has a higher timeout.

Fixes sporadic timeouts in CI.
rdar://172853948
