### PR TITLE
[rbi] Teach SIL that isolated conformances that are let through by the type checker should always match the isolation of the SILFunction where they are created.

### DIFF
--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -208,22 +208,9 @@ public:
     return ActorIsolation(Erased);
   }
 
-  static std::optional<ActorIsolation> forSILString(StringRef string) {
-    auto kind =
-        llvm::StringSwitch<std::optional<ActorIsolation::Kind>>(string)
-            .Case("unspecified", ActorIsolation::Unspecified)
-            .Case("actor_instance", ActorIsolation::ActorInstance)
-            .Case("nonisolated", ActorIsolation::Nonisolated)
-            .Case("nonisolated_unsafe", ActorIsolation::NonisolatedUnsafe)
-            .Case("global_actor", ActorIsolation::GlobalActor)
-            .Case("global_actor_unsafe", ActorIsolation::GlobalActor)
-            .Case("caller_isolation_inheriting",
-                  ActorIsolation::CallerIsolationInheriting)
-            .Default(std::nullopt);
-    if (kind == std::nullopt)
-      return std::nullopt;
-    return ActorIsolation(*kind, true /*is sil parsed*/);
-  }
+  /// Defined in lib/SIL/IR/ActorIsolation.cpp
+  static std::optional<ActorIsolation> forSILString(SILModule &mod,
+                                                    StringRef string);
 
   Kind getKind() const { return (Kind)kind; }
 

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -1246,7 +1246,6 @@ ERROR(regionbasedisolation_merge_region_failure_error_functionisolation, none,
 ERROR(regionbasedisolation_merge_region_failure_error_functionisolation_type, none,
       "passing %select{%0|%1 %0}4 to %3 %kind2 risks causing data races",
       (Type, StringRef, const ValueDecl *, StringRef, bool))
-
 ERROR(regionbasedisolation_merge_region_failure_error_functionisolation_sil, none,
       "passing %1 %0 to %3 %2 risks causing data races",
       (Identifier, StringRef, Identifier, StringRef))
@@ -1257,6 +1256,10 @@ ERROR(regionbasedisolation_merge_region_failure_error_nonisolatedfunction, none,
       (Identifier, StringRef, Identifier, StringRef, const ValueDecl *, bool))
 NOTE(regionbasedisolation_merge_region_failure_error_nonisolatedfunction_note, none,
      "%2 could begin referencing %0 allowing concurrent access to %0 by %3 code and %select{code in the current task|%1 code}5", (Identifier, StringRef, Identifier, StringRef, const ValueDecl *, bool))
+
+ERROR(regionbasedisolation_merge_region_failure_error_cast, none,
+      "casting %select{%0|%1 %0}4 to %3 %2 risks causing data races",
+      (Identifier, StringRef, Type, StringRef, bool))
 
 // Concurrency related diagnostics
 ERROR(cannot_find_executor_factory_type, none,

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -97,12 +97,22 @@ enum class RegionMergeReason : uint8_t {
   /// task-isolated value is merged into one of those fields.
   Assign = 1,
 
-  /// dstRegionElt is an ActorIsolated introducing value from a function
-  /// with isolation. srcRegionElt is a value that is in a region with some
-  /// other incompatible isolation.
+  /// dstRegionElt is a fake value used by an instruction without a result to
+  /// introduce ActorIsolation into a region of one of its
+  /// parameters. srcRegionElt is a value that is in a region with some other
+  /// incompatible isolation.
   ///
-  /// E.x.: Passing a task-isolated value to a MainActor isolated function.
-  IsolatedFunction = 2,
+  /// E.x.:
+  ///
+  /// 1. Passing a task-isolated value to a MainActor isolated function that
+  /// does not have a result. In this case, the MainActor isolated function will
+  /// create a dstRegionElt that is an ActorIntroducingInst and merge it into
+  /// its operand's regions causing the error.
+  ///
+  /// 2. Casting a value using checked_cast_br_addr to a protocol that is
+  /// potentially an isolated conformance to a value with a conflicting
+  /// isolation.
+  ActorIntroducingInst = 2,
 
   /// Regions are being merged as a result of capturing values in a
   /// nonisolated closure. This occurs when a closure with no isolation
@@ -127,8 +137,14 @@ enum class RegionMergeReason : uint8_t {
   /// nonisolated function.
   NonisolatedFunction = 5,
 
+  /// Regions are being merged since we are performing some sort of cast. The
+  /// cast could result in a merge failure if the cast results in a value
+  /// isolated to an isolated conformance and the isolated conformance conflicts
+  /// with the isolation of the input value.
+  Cast = 6,
+
   First = Assign,
-  Last = NonisolatedFunction,
+  Last = Cast,
 };
 
 /// The representative value of the equivalence class that makes up a tracked
@@ -627,7 +643,7 @@ public:
   RegionMergeReason##NAME = uint8_t(RegionMergeReason::NAME)                   \
                             << RegionMergeReasonBitStart
     REGION_MERGE_REASON_DEF(Assign),
-    REGION_MERGE_REASON_DEF(IsolatedFunction),
+    REGION_MERGE_REASON_DEF(ActorIntroducingInst),
     REGION_MERGE_REASON_DEF(NonisolatedClosure),
     REGION_MERGE_REASON_DEF(Builtin),
     REGION_MERGE_REASON_DEF(NonisolatedFunction),

--- a/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
+++ b/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
@@ -486,30 +486,38 @@ public:
 
   static SILIsolationInfo
   getActorInstanceIsolated(SILValue isolatedValue,
-                           const SILFunctionArgument *actorInstance) {
+                           const SILFunctionArgument *actorInstance,
+                           ProtocolDecl *isolatedConformance = nullptr) {
     assert(actorInstance);
     auto *varDecl =
         llvm::dyn_cast_if_present<VarDecl>(actorInstance->getDecl());
     if (!varDecl)
       return {};
-    return {isolatedValue, actorInstance,
+    return {isolatedValue,
+            actorInstance,
             actorInstance->isSelf()
                 ? ActorIsolation::forActorInstanceSelf(varDecl)
                 : ActorIsolation::forActorInstanceParameter(
-                      varDecl, actorInstance->getIndex())};
+                      varDecl, actorInstance->getIndex()),
+            {},
+            isolatedConformance};
   }
 
-  static SILIsolationInfo getActorInstanceIsolated(SILValue isolatedValue,
-                                                   ActorInstance actorInstance,
-                                                   NominalTypeDecl *typeDecl) {
+  static SILIsolationInfo
+  getActorInstanceIsolated(SILValue isolatedValue, ActorInstance actorInstance,
+                           NominalTypeDecl *typeDecl,
+                           ProtocolDecl *isolatedConformance = nullptr) {
     assert(actorInstance);
     if (!typeDecl->isAnyActor()) {
       assert(!swift::getActorIsolation(typeDecl).isGlobalActor() &&
              "Should have called getGlobalActorIsolated");
       return {};
     }
-    return {isolatedValue, actorInstance,
-            ActorIsolation::forActorInstanceSelf(typeDecl)};
+    return {isolatedValue,
+            actorInstance,
+            ActorIsolation::forActorInstanceSelf(typeDecl),
+            {},
+            isolatedConformance};
   }
 
   /// A special actor instance isolated for partial apply cases where we do not

--- a/lib/SIL/IR/ActorIsolation.cpp
+++ b/lib/SIL/IR/ActorIsolation.cpp
@@ -1,0 +1,61 @@
+//===--- ActorIsolation.cpp -----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/ActorIsolation.h"
+#include "swift/AST/NameLookup.h"
+#include "swift/AST/NameLookupRequests.h"
+#include "swift/SIL/SILModule.h"
+
+using namespace swift;
+
+static std::optional<ActorIsolation>
+getIsolationForExplicitActor(SILModule &mod, StringRef string) {
+  auto &ctx = mod.getASTContext();
+
+  if (!string.starts_with("global_actor(") || !string.ends_with(")"))
+    return {};
+
+  auto actor =
+      string.drop_front(StringLiteral("global_actor(").size()).drop_back();
+  auto declName = DeclName(ctx.getIdentifier(actor));
+  auto descriptor = UnqualifiedLookupDescriptor(
+      DeclNameRef(declName), mod.getSwiftModule(), SourceLoc(),
+      UnqualifiedLookupFlags::TypeLookup);
+  auto lookup = evaluateOrDefault(ctx.evaluator,
+                                  UnqualifiedLookupRequest{descriptor}, {});
+  if (lookup.size() != 1)
+    return {};
+
+  auto *decl = dyn_cast<NominalTypeDecl>(lookup.back().getValueDecl());
+  if (!decl || !decl->isGlobalActor())
+    return {};
+  return ActorIsolation::forGlobalActor(decl->getDeclaredType());
+}
+
+std::optional<ActorIsolation> ActorIsolation::forSILString(SILModule &mod,
+                                                           StringRef string) {
+  if (auto result = getIsolationForExplicitActor(mod, string))
+    return result;
+  auto kind = llvm::StringSwitch<std::optional<ActorIsolation::Kind>>(string)
+                  .Case("unspecified", ActorIsolation::Unspecified)
+                  .Case("actor_instance", ActorIsolation::ActorInstance)
+                  .Case("nonisolated", ActorIsolation::Nonisolated)
+                  .Case("nonisolated_unsafe", ActorIsolation::NonisolatedUnsafe)
+                  .Case("global_actor", ActorIsolation::GlobalActor)
+                  .Case("global_actor_unsafe", ActorIsolation::GlobalActor)
+                  .Case("caller_isolation_inheriting",
+                        ActorIsolation::CallerIsolationInheriting)
+                  .Default(std::nullopt);
+  if (kind == std::nullopt)
+    return std::nullopt;
+  return ActorIsolation(*kind, true /*is sil parsed*/);
+}

--- a/lib/SIL/IR/CMakeLists.txt
+++ b/lib/SIL/IR/CMakeLists.txt
@@ -1,5 +1,6 @@
 target_sources(swiftSIL PRIVATE
   AbstractionPattern.cpp
+  ActorIsolation.cpp
   ApplySite.cpp
   Bridging.cpp
   Linker.cpp

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -2070,9 +2070,7 @@ ActorIsolation SILDeclRef::getActorIsolation() const {
   // If we have a stored property initializer for a VarDecl with an explicit
   // isolation, match that explicit isolation.
   if (isStoredPropertyInitializer()) {
-    if (auto isolation = swift::getActorIsolation(cast<VarDecl>(getDecl()));
-        isolation &&  isolation.isGlobalActor())
-      return isolation;
+    return cast<VarDecl>(getDecl())->getInitializerIsolation();
   }
 
   return getActorIsolationOfContext(getInnermostDeclContext());

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -3794,9 +3794,8 @@ void SILFunction::print(SILPrintContext &PrintCtx) const {
     OS << "[available " << availability.getVersionString() << "] ";
   }
 
-  // This is here only for testing purposes.
-  if (SILPrintFunctionIsolationInfo) {
-    if (auto isolation = getActorIsolation()) {
+  if (auto isolation = getActorIsolation()) {
+    if (isolation->isSILParsed() || SILPrintFunctionIsolationInfo) {
       OS << "[isolation \"";
       isolation->printForSIL(OS);
       OS << "\"] ";

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -812,7 +812,7 @@ static bool parseDeclSILOptional(
       // representation of an actor that can be parsed back. For now this is
       // just a quick hack so we can write tests.
       auto optIsolation = ActorIsolation::forSILString(
-          SP.P.Context.getIdentifier(rawString).str());
+          M, SP.P.Context.getIdentifier(rawString).str());
       if (!optIsolation) {
         SP.P.diagnose(SP.P.Tok, diag::expected_in_attribute_list);
         return true;
@@ -6974,8 +6974,8 @@ bool SILParser::parseCallInstruction(SILLocation InstLoc,
     }
 
     if (AttrName == "callee_isolation") {
-      auto applyIsolation =
-          ActorIsolation::forSILString(std::get<StringRef>(*AttrValue));
+      auto applyIsolation = ActorIsolation::forSILString(
+          B.getModule(), std::get<StringRef>(*AttrValue));
       if (!applyIsolation) {
         P.diagnose(AttrValueLoc, diag::expected_in_attribute_list);
         return true;
@@ -6987,8 +6987,8 @@ bool SILParser::parseCallInstruction(SILLocation InstLoc,
     }
 
     if (AttrName == "caller_isolation") {
-      auto applyIsolation =
-          ActorIsolation::forSILString(std::get<StringRef>(*AttrValue));
+      auto applyIsolation = ActorIsolation::forSILString(
+          B.getModule(), std::get<StringRef>(*AttrValue));
       if (!applyIsolation) {
         P.diagnose(AttrValueLoc, diag::expected_in_attribute_list);
         return true;

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -1903,9 +1903,22 @@ struct PartitionOpBuilder {
     auto elt = getActorIntroducingRepresentative(actorIsolation);
     currentInstPartitionOps->emplace_back(
         PartitionOp::AssignFresh(elt, currentInst));
+    currentInstPartitionOps->emplace_back(PartitionOp::Merge(
+        elt, sourceValue.getID(), RegionMergeReason::ActorIntroducingInst,
+        sourceOperand));
+  }
+
+  void addActorIntroducingInst(
+      ArrayRef<std::pair<Operand *, TrackableValue>> sourceOperandTVPairs,
+      SILIsolationInfo actorIsolation) {
+    auto elt = getActorIntroducingRepresentative(actorIsolation);
     currentInstPartitionOps->emplace_back(
-        PartitionOp::Merge(elt, sourceValue.getID(),
-                           RegionMergeReason::IsolatedFunction, sourceOperand));
+        PartitionOp::AssignFresh(elt, currentInst));
+    for (auto pair : sourceOperandTVPairs) {
+      currentInstPartitionOps->emplace_back(PartitionOp::Merge(
+          elt, pair.second.getID(), RegionMergeReason::ActorIntroducingInst,
+          pair.first));
+    }
   }
 
   void addRequire(TrackableValueLookupResult value);
@@ -2123,6 +2136,10 @@ getPartitionOpsForInstruction(PartitionOpTranslator *translator,
                               SILInstruction *inst,
                               std::vector<PartitionOp> &foundPartitionOps);
 
+static void
+getPartitionOpsForBlock(PartitionOpTranslator *translator, SILBasicBlock *block,
+                        std::vector<PartitionOp> &foundPartitionOps);
+
 /// PartitionOpTranslator is responsible for performing the translation from
 /// SILInstructions to PartitionOps. Not all SILInstructions have an effect on
 /// the region partition, and some have multiple effects - such as an
@@ -2144,6 +2161,8 @@ class PartitionOpTranslator {
   friend void(getPartitionOpsForInstruction)(PartitionOpTranslator *,
                                              SILInstruction *,
                                              std::vector<PartitionOp> &);
+  friend void(getPartitionOpsForBlock)(PartitionOpTranslator *, SILBasicBlock *,
+                                       std::vector<PartitionOp> &);
   SILFunction *function;
 
   /// The initial partition of the entry block.
@@ -2421,21 +2440,6 @@ public:
       }
     }
 
-    // Merge all srcs if we have any.
-    if (sourceOperandTVPairs.size()) {
-      // NOTE: A merge can fail if we have multiple operands with incompatible
-      // regions. We will dynamically emit an error in such a case and not merge
-      // that value into our region... we do want to merge /all/ other operands
-      // though so we merge as much as possible. To ensure that this happens, we
-      // merge all operands into the first operand's region to ensure that we
-      // are always accumulating into a value that we haven't skipped since we
-      // never skip the firstValue.
-      auto firstValue = sourceOperandTVPairs[0].second;
-      for (unsigned i = 1; i < sourceOperandTVPairs.size(); i++) {
-        builder.addMerge(firstValue, sourceOperandTVPairs[i].first, reason);
-      }
-    }
-
     // Then process our direct results.
     for (SILValue result : directResultValues) {
       // If we had isolation info explicitly passed in... use our
@@ -2462,25 +2466,26 @@ public:
 
     // Finally, process our indirect results.
     for (Operand *result : indirectResultAddresses) {
-      // If we had isolation info explicitly passed in... use our
-      // resultIsolationInfoError. Otherwise, we want to infer.
-      if (resultIsolationInfoOverride) {
-        // We only get back result if it is non-Sendable.
-        if (auto nonSendableValue = initializeTrackedValue(
-                result->get(), resultIsolationInfoOverride)) {
-          // If we did not insert, emit an unknown patten error.
-          if (!nonSendableValue->second) {
-            builder.addUnknownPatternError(result->get());
-          }
-          indirectResultTVPairs.emplace_back(result, nonSendableValue->first);
-        }
-      } else {
-        if (auto lookupResult = tryToTrackValue(result->get())) {
-          if (lookupResult->value.isSendable())
-            continue;
-          auto value = lookupResult->value;
-          indirectResultTVPairs.emplace_back(result, value);
-        }
+      if (auto lookupResult = tryToTrackValue(result->get())) {
+        if (lookupResult->value.isSendable())
+          continue;
+        auto value = lookupResult->value;
+        indirectResultTVPairs.emplace_back(result, value);
+      }
+    }
+
+    // Merge all srcs if we have any.
+    if (sourceOperandTVPairs.size()) {
+      // NOTE: A merge can fail if we have multiple operands with incompatible
+      // regions. We will dynamically emit an error in such a case and not merge
+      // that value into our region... we do want to merge /all/ other operands
+      // though so we merge as much as possible. To ensure that this happens, we
+      // merge all operands into the first operand's region to ensure that we
+      // are always accumulating into a value that we haven't skipped since we
+      // never skip the firstValue.
+      auto firstValue = sourceOperandTVPairs[0].second;
+      for (unsigned i = 1; i < sourceOperandTVPairs.size(); i++) {
+        builder.addMerge(firstValue, sourceOperandTVPairs[i].first, reason);
       }
     }
 
@@ -2512,10 +2517,17 @@ public:
           [](const std::pair<Operand *, TrackableValue> &pair) {
             return pair.second;
           });
+      // TODO: How can we inject if there isn't an operand? I think we may need
+      // to make a cheating way to do it.
       builder.addAssignFresh(
           llvm::concat<TrackableValue>(directResultTVs, transformRange));
       return;
     }
+
+    if (resultIsolationInfoOverride)
+      builder.addActorIntroducingInst(sourceOperandTVPairs.back().second,
+                                      sourceOperandTVPairs.back().first,
+                                      resultIsolationInfoOverride);
 
     // Otherwise, we need to assign all of the results to be in the same region
     // as the operands. Without losing generality, we just use the first
@@ -3346,6 +3358,44 @@ public:
     builder.addUnknownPatternError(value);
   }
 
+  void translatePredTransformingTerminator(
+      SILBasicBlock *basicBlock, std::vector<PartitionOp> &foundPartitionOps) {
+    // Always just use front for this purpose.
+    builder.reset(&basicBlock->front());
+    auto *singlePred = basicBlock->getSinglePredecessorBlock();
+    if (!singlePred)
+      return;
+
+    auto *termInst =
+        dyn_cast<CheckedCastBranchInst>(singlePred->getTerminator());
+    if (!termInst)
+      return;
+
+    auto castValue = tryToTrackValue(termInst->getOperand());
+
+    if (termInst->getSuccessBB() == basicBlock) {
+      if (auto argValue =
+              tryToTrackValue(basicBlock->getSILPhiArguments()[0])) {
+        builder.addAssignFresh(argValue->value);
+        if (castValue) {
+          builder.addMerge(argValue->value, &termInst->getOperandRef(),
+                           RegionMergeReason::Cast);
+        }
+      }
+      return;
+    }
+
+    // Along the non-success path for simplicity today, we just assign fresh and
+    // assign. TODO: We could make this lookthrough.
+    if (auto argValue = tryToTrackValue(basicBlock->getSILPhiArguments()[0])) {
+      builder.addAssignFresh(argValue->value);
+      if (castValue) {
+        builder.addAssignDirectResult(argValue->value,
+                                      &termInst->getOperandRef());
+      }
+    }
+  }
+
   /// Translate the instruction's in \p basicBlock to a vector of PartitionOps
   /// that define the block's dataflow.
   void translateSILBasicBlock(SILBasicBlock *basicBlock,
@@ -3360,6 +3410,14 @@ public:
     // Translate each SIL instruction to the PartitionOps that it represents if
     // any.
     builder.initialize(foundPartitionOps);
+
+    // First perform any operations that are sunk from terminators from previous
+    // blocks.
+    //
+    // E.x.: If we cast, we want to only merge each of the SIL phi parameters
+    // along their respective paths.
+    translatePredTransformingTerminator(basicBlock, foundPartitionOps);
+
     for (auto &instruction : *basicBlock) {
       REGIONBASEDISOLATION_LOG(llvm::dbgs() << "Visiting: " << instruction);
       translateSILInstruction(&instruction);
@@ -3480,6 +3538,13 @@ void regionanalysisimpl::getPartitionOpsForInstruction(
     std::vector<PartitionOp> &foundPartitionOps) {
   translator->builder.initialize(foundPartitionOps);
   translator->translateSILInstruction(inst);
+}
+
+void regionanalysisimpl::getPartitionOpsForBlock(
+    PartitionOpTranslator *translator, SILBasicBlock *block,
+    std::vector<PartitionOp> &foundPartitionOps) {
+  translator->builder.initialize(foundPartitionOps);
+  translator->translateSILBasicBlock(block, foundPartitionOps);
 }
 
 Element PartitionOpBuilder::lookupValueID(SILValue value) {
@@ -3843,7 +3908,6 @@ CONSTANT_TRANSLATION(YieldInst, Require)
 // Terminators that act as phis.
 CONSTANT_TRANSLATION(BranchInst, TerminatorPhi)
 CONSTANT_TRANSLATION(CondBranchInst, TerminatorPhi)
-CONSTANT_TRANSLATION(CheckedCastBranchInst, TerminatorPhi)
 CONSTANT_TRANSLATION(DynamicMethodBranchInst, TerminatorPhi)
 
 // Function exiting terminators.
@@ -4465,10 +4529,18 @@ TranslationSemantics PartitionOpTranslator::visitCheckedCastAddrBranchInst(
   // differently depending on what the result of checked_cast_addr_br
   // is. For now just keep the current behavior. It is more conservative,
   // but still correct.
-  translateSILMultiAssign(ArrayRef<SILValue>(), ArrayRef<Operand *>(),
-                          makeOperandRefRange(ccabi->getAllOperands()),
+  translateSILMultiAssign(ArrayRef<SILValue>(),
+                          TinyPtrVector<Operand *>(&ccabi->getAllOperands()[1]),
+                          TinyPtrVector<Operand *>(&ccabi->getAllOperands()[0]),
                           RegionMergeReason::Unknown,
                           SILIsolationInfo::getConformanceIsolation(ccabi));
+  return TranslationSemantics::Special;
+}
+
+TranslationSemantics PartitionOpTranslator::visitCheckedCastBranchInst(
+    CheckedCastBranchInst *ccabi) {
+  // Just require the operand. We perform merging/etc in the destination blocks.
+  translateSILRequire(ccabi->getOperand());
   return TranslationSemantics::Special;
 }
 
@@ -4777,6 +4849,33 @@ static FunctionTest PartitionOpsTest(
       assert(valueInst);
       std::vector<PartitionOp> blockPartitionOps;
       getPartitionOpsForInstruction(&translator, valueInst, blockPartitionOps);
+      // First dump the value map.
+      valueMap.print(llvm::outs());
+      // Then dump the instructions.
+      for (auto &partitionOp : blockPartitionOps) {
+        partitionOp.print(llvm::outs());
+      }
+    });
+
+// Arguments:
+// - SILBasicBlock: the block that we are lowering.
+// Dumps:
+// - The inferred isolation.
+static FunctionTest PartitionOpsBlockLoweringTest(
+    "sil_regionanalysis_partitionoptranslation_block",
+    [](auto &function, auto &arguments, auto &test) {
+      llvm::BumpPtrAllocator allocator;
+      IsolationHistory::Factory historyFactory(allocator);
+      RegionAnalysisValueMap valueMap(&function);
+      PartitionOpTranslator translator(
+          &function,
+          test.template getAnalysis<PostOrderAnalysis>()->get(&function),
+          valueMap, historyFactory);
+
+      auto *blockInst = arguments.takeBlock();
+      assert(blockInst);
+      std::vector<PartitionOp> blockPartitionOps;
+      getPartitionOpsForBlock(&translator, blockInst, blockPartitionOps);
       // First dump the value map.
       valueMap.print(llvm::outs());
       // Then dump the instructions.

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -3779,6 +3779,7 @@ private:
   void emitAssign();
   void emitNonisolatedFunction();
   void emitIsolatedFunction();
+  void emitCast();
 };
 
 void IncompatibleRegionMergeDiagnosticEmitter::emitUnknown() {
@@ -3915,26 +3916,20 @@ void IncompatibleRegionMergeDiagnosticEmitter::emitNonisolatedFunction() {
 }
 
 void IncompatibleRegionMergeDiagnosticEmitter::emitIsolatedFunction() {
-
+  // The dstRegionValue is always going to be the actor introducing inst.
   auto dstRegionValue = valueMap.getRepresentativeValue(dstRegionValueElt);
   assert(dstRegionValue.hasRegionIntroducingInst());
-
-  auto declRef = ApplySite::isa(dstRegionValue.getActorRegionIntroducingInst())
-                     .getCalleeDeclRef();
-  if (!declRef)
-    return emitUnknownPatternError();
 
   auto srcRegionValue = valueMap.getRepresentativeValue(srcRegionValueElt);
   auto srcIsolation = srcIsolationInfo;
   auto dstIsolation = dstIsolationInfo;
 
-  // Canonicalize so that srcRegionValue is always the task-isolated value. We
-  // do this only here since in this case, we can get away with doing this to
-  // implement a simpler diagnostic. E.x.: This doesn't work for assign.
-  if (!srcIsolation->isTaskIsolated() && dstIsolation->isTaskIsolated()) {
-    std::swap(srcIsolation, dstIsolation);
-    std::swap(srcRegionValue, dstRegionValue);
-  }
+  auto as = ApplySite::isa(dstRegionValue.getActorRegionIntroducingInst());
+  if (!as)
+    return emitUnknownPatternError();
+  auto declRef = as.getCalleeDeclRef();
+  if (!declRef)
+    return emitUnknownPatternError();
 
   auto srcIsolationStr = srcIsolation.printForDiagnostics(getFunction());
   auto dstIsolationStr = dstIsolation.printForDiagnostics(getFunction());
@@ -3976,6 +3971,49 @@ void IncompatibleRegionMergeDiagnosticEmitter::emitIsolatedFunction() {
       .limitBehaviorIf(getBehaviorLimit());
 }
 
+void IncompatibleRegionMergeDiagnosticEmitter::emitCast() {
+  // The dstRegionValue is always going to be the actor introducing inst.
+  auto dstRegionValue = valueMap.getRepresentativeValue(dstRegionValueElt);
+
+  auto cast = [&]() {
+    // Check if we have a region introducing inst.
+    if (dstRegionValue.hasRegionIntroducingInst())
+      return SILDynamicCastInst::getAs(
+          dstRegionValue.getActorRegionIntroducingInst());
+
+    // Then see if we have a phi argument.
+    if (auto *phiArg =
+            dyn_cast_or_null<SILPhiArgument>(dstRegionValue.maybeGetValue())) {
+      if (auto *termInst = dyn_cast_or_null<CheckedCastBranchInst>(
+              phiArg->getSingleTerminator());
+          termInst && termInst->getSuccessBB() == phiArg->getParent()) {
+        return SILDynamicCastInst::getAs(termInst);
+      }
+    }
+
+    return SILDynamicCastInst();
+  }();
+  if (!cast)
+    return emitUnknownPatternError();
+
+  auto srcRegionValue = valueMap.getRepresentativeValue(srcRegionValueElt);
+  auto srcIsolation = srcIsolationInfo;
+  auto dstIsolation = dstIsolationInfo;
+  auto srcIsolationStr = srcIsolation.printForDiagnostics(getFunction());
+  auto dstIsolationStr = dstIsolation.printForDiagnostics(getFunction());
+
+  // We should always be able to find a name for an inout sending param. If we
+  // do not, emit an unknown pattern error.
+  auto srcName = inferNameHelper(srcRegionValue.getValue());
+  if (!srcName)
+    return emitUnknownPatternError();
+  diagnoseError(op->getUser(),
+                diag::regionbasedisolation_merge_region_failure_error_cast,
+                *srcName, srcIsolationStr, cast.getTargetFormalType(),
+                dstIsolationStr, !srcIsolation->isTaskIsolated())
+      .limitBehaviorIf(getBehaviorLimit());
+}
+
 void IncompatibleRegionMergeDiagnosticEmitter::emit() {
   switch (reason) {
   case RegionMergeReason::NonisolatedFunction:
@@ -3986,8 +4024,16 @@ void IncompatibleRegionMergeDiagnosticEmitter::emit() {
     return emitUnknown();
   case RegionMergeReason::Assign:
     return emitAssign();
-  case RegionMergeReason::IsolatedFunction:
-    return emitIsolatedFunction();
+  case RegionMergeReason::ActorIntroducingInst: {
+    auto dstRegionValue = valueMap.getRepresentativeValue(dstRegionValueElt);
+    assert(dstRegionValue.hasRegionIntroducingInst());
+    if (ApplySite::isa(dstRegionValue.getActorRegionIntroducingInst()))
+      return emitIsolatedFunction();
+    return emitCast();
+  }
+  case RegionMergeReason::Cast: {
+    return emitCast();
+  }
   }
   llvm_unreachable("Unhandled case");
 }

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -3812,6 +3812,11 @@ void IncompatibleRegionMergeDiagnosticEmitter::emitUnknown() {
     return emitUnknownPatternError();
   }
 
+  if (!srcIsolationInfo)
+    return emitUnknownPatternError();
+  if (!dstIsolationInfo)
+    return emitUnknownPatternError();
+
   auto srcIsolationStr = srcIsolation.printForDiagnostics(getFunction());
   auto dstIsolationStr = dstIsolation.printForDiagnostics(getFunction());
 
@@ -3828,6 +3833,11 @@ void IncompatibleRegionMergeDiagnosticEmitter::emitUnknown() {
 }
 
 void IncompatibleRegionMergeDiagnosticEmitter::emitAssign() {
+  if (!srcIsolationInfo)
+    return emitUnknownPatternError();
+  if (!dstIsolationInfo)
+    return emitUnknownPatternError();
+
   auto srcRegionValue = valueMap.getRepresentativeValue(srcRegionValueElt);
   auto dstRegionValue = valueMap.getRepresentativeValue(dstRegionValueElt);
 
@@ -3868,6 +3878,11 @@ void IncompatibleRegionMergeDiagnosticEmitter::emitAssign() {
 }
 
 void IncompatibleRegionMergeDiagnosticEmitter::emitNonisolatedFunction() {
+  if (!srcIsolationInfo)
+    return emitUnknownPatternError();
+  if (!dstIsolationInfo)
+    return emitUnknownPatternError();
+
   auto srcIsolation = srcIsolationInfo;
   auto dstIsolation = dstIsolationInfo;
   auto srcRegionValue = valueMap.getRepresentativeValue(srcRegionValueElt);
@@ -3916,6 +3931,11 @@ void IncompatibleRegionMergeDiagnosticEmitter::emitNonisolatedFunction() {
 }
 
 void IncompatibleRegionMergeDiagnosticEmitter::emitIsolatedFunction() {
+  if (!srcIsolationInfo)
+    return emitUnknownPatternError();
+  if (!dstIsolationInfo)
+    return emitUnknownPatternError();
+
   // The dstRegionValue is always going to be the actor introducing inst.
   auto dstRegionValue = valueMap.getRepresentativeValue(dstRegionValueElt);
   assert(dstRegionValue.hasRegionIntroducingInst());
@@ -3972,6 +3992,11 @@ void IncompatibleRegionMergeDiagnosticEmitter::emitIsolatedFunction() {
 }
 
 void IncompatibleRegionMergeDiagnosticEmitter::emitCast() {
+  if (!srcIsolationInfo)
+    return emitUnknownPatternError();
+  if (!dstIsolationInfo)
+    return emitUnknownPatternError();
+
   // The dstRegionValue is always going to be the actor introducing inst.
   auto dstRegionValue = valueMap.getRepresentativeValue(dstRegionValueElt);
 

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -138,7 +138,7 @@ void PartitionOpError::IncompatibleRegionMergeError::print(
   case Reason::Assign:
     os << "assign\n";
     return;
-  case Reason::IsolatedFunction:
+  case Reason::ActorIntroducingInst:
     os << "isolated_function\n";
     return;
   case Reason::NonisolatedClosure:
@@ -149,6 +149,9 @@ void PartitionOpError::IncompatibleRegionMergeError::print(
     return;
   case Reason::NonisolatedFunction:
     os << "nonisolated_function\n";
+    return;
+  case Reason::Cast:
+    os << "cast\n";
     return;
   }
   llvm_unreachable("Unhandled case");

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -1184,9 +1184,21 @@ SILIsolationInfo SILIsolationInfo::getForCastConformances(
     // function is dynamically executing. If that's known (i.e., because we're
     // on a global actor), the value is isolated to that global actor.
     // Otherwise, it's task-isolated.
-    if (functionIsolation && functionIsolation->isGlobalActor()) {
-      return SILIsolationInfo::getGlobalActorIsolated(
-          value, functionIsolation->getGlobalActor(), proto);
+    if (functionIsolation) {
+      if (functionIsolation->isGlobalActor()) {
+        return SILIsolationInfo::getGlobalActorIsolated(
+            value, functionIsolation->getGlobalActor(), proto);
+      }
+
+      if (functionIsolation->isActorInstanceIsolated()) {
+        if (auto isolatedParam = cast_or_null<SILFunctionArgument>(
+                value->getFunction()->maybeGetIsolatedArgument())) {
+          if (auto result = SILIsolationInfo::getActorInstanceIsolated(
+                  value, isolatedParam, proto)) {
+            return result;
+          }
+        }
+      }
     }
 
     // Consider the cast to be task-isolated, because the runtime could find

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -1139,6 +1139,24 @@ SILIsolationInfo SILIsolationInfo::getFromConformances(
       if (sendableMetatype &&
           lookupConformance(conformance.getType(), sendableMetatype,
                             /*allowMissing=*/false).isInvalid()) {
+        if (auto functionIsolation =
+                value->getFunction()->getActorIsolation()) {
+          if (functionIsolation->isGlobalActor()) {
+            return SILIsolationInfo::getGlobalActorIsolated(
+                value, functionIsolation->getGlobalActor(),
+                conformance.getProtocol());
+          }
+          if (functionIsolation->isActorInstanceIsolated()) {
+            if (auto isolatedParam = cast_or_null<SILFunctionArgument>(
+                    value->getFunction()->maybeGetIsolatedArgument())) {
+              if (auto result = SILIsolationInfo::getActorInstanceIsolated(
+                      value, isolatedParam, conformance.getProtocol())) {
+                return result;
+              }
+            }
+          }
+        }
+
         return SILIsolationInfo::getTaskIsolated(value,
                                                  conformance.getProtocol());
       }
@@ -1252,7 +1270,7 @@ SILIsolationInfo SILIsolationInfo::getConformanceIsolation(SILInstruction *inst)
 
 void SILIsolationInfo::printOptions(llvm::raw_ostream &os) const {
   if (isolatedConformance) {
-    os << "isolated-conformance-to(" << isolatedConformance->getName() << ")";
+    os << " isolated-conformance-to(" << isolatedConformance->getName() << ")";
   }
 
   auto opts = getOptions();
@@ -2041,5 +2059,24 @@ static FunctionTest IsolationMergeTest(
       }
       llvm::outs() << "\n";
     });
+
+// Arguments:
+// - SILValue: value to look up isolation for.
+// Dumps:
+// - The inferred isolation.
+static FunctionTest
+    GetConformanceIsolationInferrence("sil_isolation_info_get_conformance_isolation_inferrence",
+                            [](auto &function, auto &arguments, auto &test) {
+                              auto value = arguments.takeValue();
+
+                              SILIsolationInfo info =
+                                SILIsolationInfo::getConformanceIsolation(cast<SingleValueInstruction>(value));
+                              llvm::outs() << "Input Value: " << *value;
+                              llvm::outs() << "Isolation: ";
+                              info.printForOneLineLogging(&function,
+                                                          llvm::outs());
+                              llvm::outs() << "\n";
+                            });
+
 
 } // namespace swift::test

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -952,16 +952,27 @@ SILIsolationInfo SILIsolationInfo::get(SILArgument *arg) {
   if (!SILIsolationInfo::isNonSendable(arg))
     return {};
 
-  // Handle a switch_enum from a global-actor-isolated type.
   if (auto *phiArg = dyn_cast<SILPhiArgument>(arg)) {
     if (auto *singleTerm = phiArg->getSingleTerminator()) {
+      // Handle a switch_enum from a global-actor-isolated type.
       if (auto *swi = dyn_cast<SwitchEnumInst>(singleTerm)) {
         auto enumDecl =
             swi->getOperand()->getType().getEnumOrBoundGenericEnum();
         return SILIsolationInfo::getGlobalActorIsolated(arg, enumDecl);
       }
+
+      // Handle a checked_cast_br argument that involves an isolated
+      // conformance. The conformance only changes for the first element.
+      if (auto *ccbi = dyn_cast<CheckedCastBranchInst>(singleTerm);
+          ccbi && ccbi->getSuccessBB() == phiArg->getParent()) {
+        if (auto isolation = SILIsolationInfo::getConformanceIsolation(ccbi)) {
+          return isolation;
+        }
+      }
     }
-    return SILIsolationInfo();
+
+    // Otherwise assume that we are disconnected. We will rely on merging.
+    return SILIsolationInfo::getDisconnected(false /*nonisolated(unsafe)*/);
   }
 
   auto *fArg = cast<SILFunctionArgument>(arg);
@@ -1200,8 +1211,15 @@ SILIsolationInfo SILIsolationInfo::getForCastConformances(
 
     // The cast can produce a conformance with the same isolation as this
     // function is dynamically executing. If that's known (i.e., because we're
-    // on a global actor), the value is isolated to that global actor.
-    // Otherwise, it's task-isolated.
+    // on a global actor or in a an actor instance method), the value could be
+    // isolated to that actor. Otherwise, if we are nonisolated, it's
+    // task-isolated.
+    //
+    // DISCUSSION: We assume that if it were not possible to get a conformance
+    // that is isolated to the current context, then we would emit an error in
+    // the type checker. The fact that we were let through means that the
+    // runtime will return nil or produce a value that is isolated to the
+    // current isolation domain.
     if (functionIsolation) {
       if (functionIsolation->isGlobalActor()) {
         return SILIsolationInfo::getGlobalActorIsolated(

--- a/test/Concurrency/Inputs/isolated_conformance_other.swift
+++ b/test/Concurrency/Inputs/isolated_conformance_other.swift
@@ -3,3 +3,9 @@ public protocol P {
 }
 
 public protocol PDerived: P {}
+
+public protocol MyObject: AnyObject {}
+public protocol MyCommand: AnyObject {}
+public protocol ClientBoundCommand: AnyObject {}
+public protocol ServerBoundCommand: AnyObject {}
+public protocol BaseCommand: AnyObject {}

--- a/test/Concurrency/actor_isolation_filecheck.swift
+++ b/test/Concurrency/actor_isolation_filecheck.swift
@@ -45,7 +45,7 @@ class NonSendableKlass {}
 @MainActor
 struct MainActorStruct {
   // CHECK: variable initialization expression of MainActorStruct.mainActorField
-  // CHECK-NEXT: Isolation: global_actor. type: MainActor
+  // CHECK-NEXT: Isolation: unspecified
   // CHECK: MainActorStruct.mainActorField.getter
   // CHECK-NEXT: Isolation: global_actor. type: MainActor
   // CHECK: MainActorStruct.mainActorField.setter
@@ -53,7 +53,7 @@ struct MainActorStruct {
   var mainActorField = NonSendableKlass()
 
   // CHECK: variable initialization expression of MainActorStruct.customActorField
-  // CHECK-NEXT: Isolation: global_actor. type: CustomActor
+  // CHECK-NEXT: Isolation: unspecified
   // CHECK: MainActorStruct.customActorField.getter
   // CHECK-NEXT: Isolation: global_actor. type: CustomActor
   // CHECK: MainActorStruct.customActorField.setter
@@ -73,7 +73,7 @@ struct NonisolatedStruct {
   var nonisolatedField = NonSendableKlass()
 
   // CHECK: variable initialization expression of NonisolatedStruct.mainActorField
-  // CHECK-NEXT: Isolation: global_actor. type: MainActor
+  // CHECK-NEXT: Isolation: unspecified
   // CHECK: NonisolatedStruct.mainActorField.getter
   // CHECK-NEXT: Isolation: global_actor. type: MainActor
   // CHECK: NonisolatedStruct.mainActorField.setter
@@ -81,12 +81,12 @@ struct NonisolatedStruct {
   @MainActor var mainActorField = NonSendableKlass()
 
   // CHECK: variable initialization expression of NonisolatedStruct.customActorField
-  // CHECK-NEXT: Isolation: global_actor. type: CustomActor
+  // CHECK-NEXT: Isolation: unspecified
   // CHECK: NonisolatedStruct.customActorField.getter
   // CHECK-NEXT: Isolation: global_actor. type: CustomActor
   // CHECK: NonisolatedStruct.customActorField.setter
   // CHECK-NEXT: Isolation: global_actor. type: CustomActor
-  @CustomActor var customActorField = NonSendableKlass() // expected-error {{pattern that the region-based isolation checker does not understand how to check}}
+  @CustomActor var customActorField = NonSendableKlass()
 
   nonisolated init() {}
 }
@@ -94,7 +94,7 @@ struct NonisolatedStruct {
 @MainActor
 struct MainActorKlass {
   // CHECK: variable initialization expression of MainActorKlass.mainActorField
-  // CHECK-NEXT: Isolation: global_actor. type: MainActor
+  // CHECK-NEXT: Isolation: unspecified
   // CHECK: MainActorKlass.mainActorField.getter
   // CHECK-NEXT: Isolation: global_actor. type: MainActor
   // CHECK: MainActorKlass.mainActorField.setter
@@ -102,7 +102,7 @@ struct MainActorKlass {
   var mainActorField = NonSendableKlass()
 
   // CHECK: variable initialization expression of MainActorKlass.customActorField
-  // CHECK-NEXT: Isolation: global_actor. type: CustomActor
+  // CHECK-NEXT: Isolation: unspecified
   // CHECK: MainActorKlass.customActorField.getter
   // CHECK-NEXT: Isolation: global_actor. type: CustomActor
   // CHECK: MainActorKlass.customActorField.setter
@@ -122,7 +122,7 @@ struct NonisolatedKlass {
   var nonisolatedField = NonSendableKlass()
 
   // CHECK: variable initialization expression of NonisolatedKlass.mainActorField
-  // CHECK-NEXT: Isolation: global_actor. type: MainActor
+  // CHECK-NEXT: Isolation: unspecified
   // CHECK: NonisolatedKlass.mainActorField.getter
   // CHECK-NEXT: Isolation: global_actor. type: MainActor
   // CHECK: NonisolatedKlass.mainActorField.setter
@@ -130,12 +130,12 @@ struct NonisolatedKlass {
   @MainActor var mainActorField = NonSendableKlass()
 
   // CHECK: variable initialization expression of NonisolatedKlass.customActorField
-  // CHECK-NEXT: Isolation: global_actor. type: CustomActor
+  // CHECK-NEXT: Isolation: unspecified
   // CHECK: NonisolatedKlass.customActorField.getter
   // CHECK-NEXT: Isolation: global_actor. type: CustomActor
   // CHECK: NonisolatedKlass.customActorField.setter
   // CHECK-NEXT: Isolation: global_actor. type: CustomActor
-  @CustomActor var customActorField = NonSendableKlass() // expected-error {{pattern that the region-based isolation checker does not understand how to check}}
+  @CustomActor var customActorField = NonSendableKlass()
 
   nonisolated init() {}
 }

--- a/test/Concurrency/assume_mainactor.swift
+++ b/test/Concurrency/assume_mainactor.swift
@@ -30,7 +30,7 @@ class Klass {
 
 struct StructContainingKlass {
   // CHECK: // variable initialization expression of StructContainingKlass.k
-  // CHECK-NEXT: // Isolation: global_actor. type: MainActor
+  // CHECK-NEXT: // Isolation: unspecified
   // CHECK-NEXT: sil hidden [transparent] [ossa] @$s16assume_mainactor21StructContainingKlassV1kAA0E0Cvpfi : $@convention(thin) () -> @owned Klass {
 
   // CHECK: // StructContainingKlass.k.getter
@@ -50,7 +50,7 @@ struct StructContainingKlass {
 // TODO: Allow for nonisolated to be applied to structs.
 struct NonIsolatedStructContainingKlass {
   // CHECK: // variable initialization expression of NonIsolatedStructContainingKlass.k
-  // CHECK-NEXT: // Isolation: global_actor. type: MainActor
+  // CHECK-NEXT: // Isolation: unspecified
   // CHECK-NEXT: sil hidden [transparent] [ossa] @$s16assume_mainactor32NonIsolatedStructContainingKlassV1kAA0G0Cvpfi : $@convention(thin) () -> @owned Klass {
 
   // CHECK: // NonIsolatedStructContainingKlass.k.getter
@@ -102,14 +102,13 @@ nonisolated func nonisolatedAsync<T>(_ t: T) async {}
 // CHECK-NEXT: sil hidden [ossa] @$s16assume_mainactor16customActorAsyncyyxYalF : $@convention(thin) @async <T> (@in_guaranteed T) -> () {
 @CustomActor func customActorAsync<T>(_ t: T) async {}
 
+@CustomActor func requiresCustomActor() -> Klass { fatalError() }
+
 
 @CustomActor
 struct CustomActorStruct {
-  // Variable expression is custom actor... but since we have a nonisolated
-  // init, we should be fine?
-  //
   // CHECK: // variable initialization expression of CustomActorStruct.k
-  // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
+  // CHECK-NEXT: // Isolation: unspecified
   // CHECK-NEXT: sil hidden [transparent] [ossa] @$s16assume_mainactor17CustomActorStructV1kAA5KlassCvpfi : $@convention(thin) () -> @owned Klass {
 
   // CHECK: // CustomActorStruct.k.getter
@@ -120,6 +119,19 @@ struct CustomActorStruct {
   // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
   // CHECK-NEXT: sil hidden [transparent] [ossa] @$s16assume_mainactor17CustomActorStructV1kAA5KlassCvs : $@convention(method) (@owned Klass, @inout CustomActorStruct) -> () {
   var k = Klass()
+
+  // CHECK: // variable initialization expression of CustomActorStruct.k2
+  // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
+  // CHECK-NEXT: sil hidden [transparent] [ossa] @$s16assume_mainactor17CustomActorStructV2k2AA5KlassCvpfi : $@convention(thin) () -> @owned Klass {
+
+  // CHECK: // CustomActorStruct.k2.getter
+  // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
+  // CHECK-NEXT: sil hidden [transparent] [ossa] @$s16assume_mainactor17CustomActorStructV2k2AA5KlassCvg : $@convention(method) (@guaranteed CustomActorStruct) -> @owned Klass {
+
+  // CHECK: // CustomActorStruct.k2.setter
+  // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
+  // CHECK-NEXT: sil hidden [transparent] [ossa] @$s16assume_mainactor17CustomActorStructV2k2AA5KlassCvs : $@convention(method) (@owned Klass, @inout CustomActorStruct) -> () {
+  var k2 = requiresCustomActor()
 }
 
 // CHECK: // unspecifiedFunctionTest()

--- a/test/Concurrency/sendable_metatype.swift
+++ b/test/Concurrency/sendable_metatype.swift
@@ -136,10 +136,10 @@ func acceptSendingAnyObjectR(_ s: sending AnyObject & R) { }
   // expected-note@-1{{Passing main actor-isolated value of non-Sendable type 'SC' as a 'sending' parameter to global function 'acceptSendingAnyObjectP' risks causing races}}' risks causing data races}}
   // expected-note@-2{{isolated conformance to protocol 'P' can be introduced here}}
   acceptSendingP(t) // expected-warning{{sending 't' risks causing data races}}
-  // expected-note@-1{{task-isolated 't' is passed as a 'sending' parameter; Uses in callee may race with later task-isolated uses}}
+  // expected-note@-1{{main actor-isolated 't' is passed as a 'sending' parameter; Uses in callee may race with later main actor-isolated uses}}
   // expected-note@-2{{isolated conformance to protocol 'P' can be introduced he}}
   acceptSendingAnyObjectP(u) // expected-warning{{sending value of non-Sendable type 'U' risks causing data races}}
-  // expected-note@-1{{task-isolated value of non-Sendable type 'U'}}
+  // expected-note@-1{{Passing main actor-isolated value of non-Sendable type 'U' as a 'sending' parameter to global function 'acceptSendingAnyObjectP' risks causing races inbetween main actor-isolated uses and uses reachable from 'acceptSendingAnyObjectP'}}
   // expected-note@-2{{isolated conformance to protocol 'P' can be introduced here}}
   // All of these are okay, because there are no isolated conformances to R.
   acceptSendingR(S())

--- a/test/Concurrency/silisolationinfo_inference.sil
+++ b/test/Concurrency/silisolationinfo_inference.sil
@@ -121,9 +121,6 @@ sil @useOptionalAnyActorWithParam : $@convention(thin) (@sil_isolated @guarantee
 
 sil [isolation "actor_instance"] @unappliedIsolatedAnyParameter : $@convention(method) @async (@sil_isolated @guaranteed Optional<any Actor>, @guaranteed NonSendableKlass) -> @owned NonSendableKlass
 
-@objc protocol MyObjCProtocol {
-}
-
 protocol MyProtocol {
 }
 
@@ -2140,38 +2137,6 @@ bb0(%0 : @guaranteed $Builtin.ImplicitActor, %1 : @guaranteed $NonSendableKlass)
 
 // These currently use a different entrypoint to merge in the information. It
 // should be changed to use ::get like everything else, but this is ok for now.
-
-// CHECK-LABEL: begin running test 1 of 1 on init_existential_ref_get_conformance_test_globalactor: sil_isolation_info_get_conformance_isolation_inferrence with: @trace[0]
-// CHECK-NEXT: Input Value:   %3 = init_existential_ref %2 : $Self : $Self, $any MyObjCProtocol // user: %4
-// CHECK-NEXT: Isolation: global actor 'CustomActor'-isolated isolated-conformance-to(MyObjCProtocol)
-// CHECK-NEXT: end running test 1 of 1 on init_existential_ref_get_conformance_test_globalactor: sil_isolation_info_get_conformance_isolation_inferrence with: @trace[0]
-sil [isolation "global_actor(CustomActor)"] [ossa] @init_existential_ref_get_conformance_test_globalactor : $@convention(method) <Self where Self : MyObjCProtocol> (@guaranteed Self) -> () {
-bb0(%0 : @guaranteed $Self):
-  specify_test "sil_isolation_info_get_conformance_isolation_inferrence @trace[0]"
-  debug_value %0, let, name "self", argno 1
-  %2 = copy_value %0
-  %3 = init_existential_ref %2 : $Self : $Self, $any MyObjCProtocol
-  debug_value [trace] %3
-  destroy_value %3
-  %8 = tuple ()
-  return %8
-}
-
-// CHECK-LABEL: begin running test 1 of 1 on init_existential_ref_get_conformance_test_nonisolated: sil_isolation_info_get_conformance_isolation_inferrence with: @trace[0]
-// CHECK-NEXT: Input Value:   %3 = init_existential_ref %2 : $Self : $Self, $any MyObjCProtocol // user: %4
-// CHECK-NEXT: Isolation: task-isolated isolated-conformance-to(MyObjCProtocol)
-// CHECK-NEXT: end running test 1 of 1 on init_existential_ref_get_conformance_test_nonisolated: sil_isolation_info_get_conformance_isolation_inferrence with: @trace[0]
-sil [isolation "nonisolated"] [ossa] @init_existential_ref_get_conformance_test_nonisolated : $@convention(method) <Self where Self : MyObjCProtocol> (@guaranteed Self) -> () {
-bb0(%0 : @guaranteed $Self):
-  specify_test "sil_isolation_info_get_conformance_isolation_inferrence @trace[0]"
-  debug_value %0, let, name "self", argno 1
-  %2 = copy_value %0
-  %3 = init_existential_ref %2 : $Self : $Self, $any MyObjCProtocol
-  debug_value [trace] %3
-  destroy_value %3
-  %8 = tuple ()
-  return %8
-}
 
 // CHECK-LABEL: begin running test 1 of 1 on init_existential_addr_get_conformance_test: sil_isolation_info_get_conformance_isolation_inferrence with: @trace[0]
 // CHECK-NEXT: Input Value:   %3 = init_existential_addr %2 : $*any MyProtocol, $Self // user: %4

--- a/test/Concurrency/silisolationinfo_inference.sil
+++ b/test/Concurrency/silisolationinfo_inference.sil
@@ -121,6 +121,12 @@ sil @useOptionalAnyActorWithParam : $@convention(thin) (@sil_isolated @guarantee
 
 sil [isolation "actor_instance"] @unappliedIsolatedAnyParameter : $@convention(method) @async (@sil_isolated @guaranteed Optional<any Actor>, @guaranteed NonSendableKlass) -> @owned NonSendableKlass
 
+@objc protocol MyObjCProtocol {
+}
+
+protocol MyProtocol {
+}
+
 ///////////////////////
 // MARK: Basic Tests //
 ///////////////////////
@@ -2123,4 +2129,61 @@ bb0(%0 : @guaranteed $Builtin.ImplicitActor, %1 : @guaranteed $NonSendableKlass)
   dealloc_stack %stack : $*NonSendableKlass
   %9999 = tuple ()
   return %9999 : $()
+}
+
+//////////////////////////////////////////
+// MARK: Isolated Conformance Inference //
+//////////////////////////////////////////
+
+// These currently use a different entrypoint to merge in the information. It
+// should be changed to use ::get like everything else, but this is ok for now.
+
+// CHECK-LABEL: begin running test 1 of 1 on init_existential_ref_get_conformance_test_globalactor: sil_isolation_info_get_conformance_isolation_inferrence with: @trace[0]
+// CHECK-NEXT: Input Value:   %3 = init_existential_ref %2 : $Self : $Self, $any MyObjCProtocol // user: %4
+// CHECK-NEXT: Isolation: global actor 'CustomActor'-isolated isolated-conformance-to(MyObjCProtocol)
+// CHECK-NEXT: end running test 1 of 1 on init_existential_ref_get_conformance_test_globalactor: sil_isolation_info_get_conformance_isolation_inferrence with: @trace[0]
+sil [isolation "global_actor(CustomActor)"] [ossa] @init_existential_ref_get_conformance_test_globalactor : $@convention(method) <Self where Self : MyObjCProtocol> (@guaranteed Self) -> () {
+bb0(%0 : @guaranteed $Self):
+  specify_test "sil_isolation_info_get_conformance_isolation_inferrence @trace[0]"
+  debug_value %0, let, name "self", argno 1
+  %2 = copy_value %0
+  %3 = init_existential_ref %2 : $Self : $Self, $any MyObjCProtocol
+  debug_value [trace] %3
+  destroy_value %3
+  %8 = tuple ()
+  return %8
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on init_existential_ref_get_conformance_test_nonisolated: sil_isolation_info_get_conformance_isolation_inferrence with: @trace[0]
+// CHECK-NEXT: Input Value:   %3 = init_existential_ref %2 : $Self : $Self, $any MyObjCProtocol // user: %4
+// CHECK-NEXT: Isolation: task-isolated isolated-conformance-to(MyObjCProtocol)
+// CHECK-NEXT: end running test 1 of 1 on init_existential_ref_get_conformance_test_nonisolated: sil_isolation_info_get_conformance_isolation_inferrence with: @trace[0]
+sil [isolation "nonisolated"] [ossa] @init_existential_ref_get_conformance_test_nonisolated : $@convention(method) <Self where Self : MyObjCProtocol> (@guaranteed Self) -> () {
+bb0(%0 : @guaranteed $Self):
+  specify_test "sil_isolation_info_get_conformance_isolation_inferrence @trace[0]"
+  debug_value %0, let, name "self", argno 1
+  %2 = copy_value %0
+  %3 = init_existential_ref %2 : $Self : $Self, $any MyObjCProtocol
+  debug_value [trace] %3
+  destroy_value %3
+  %8 = tuple ()
+  return %8
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on init_existential_addr_get_conformance_test: sil_isolation_info_get_conformance_isolation_inferrence with: @trace[0]
+// CHECK-NEXT: Input Value:   %3 = init_existential_addr %2 : $*any MyProtocol, $Self // user: %4
+// CHECK-NEXT: Isolation: global actor 'CustomActor'-isolated isolated-conformance-to(MyProtocol)
+// CHECK-NEXT: end running test 1 of 1 on init_existential_addr_get_conformance_test: sil_isolation_info_get_conformance_isolation_inferrence with: @trace[0]
+sil [isolation "global_actor(CustomActor)"] [ossa] @init_existential_addr_get_conformance_test : $@convention(method) <Self where Self : MyProtocol> (@in_guaranteed Self) -> () {
+bb0(%0 : $*Self):
+  specify_test "sil_isolation_info_get_conformance_isolation_inferrence @trace[0]"
+  debug_value %0, let, name "self", argno 1
+  %alloc = alloc_stack $any MyProtocol
+  %addr = init_existential_addr %alloc : $*any MyProtocol, $Self
+  debug_value [trace] %addr
+  copy_addr %0 to [init] %addr
+  destroy_addr %alloc
+  dealloc_stack %alloc
+  %8 = tuple ()
+  return %8
 }

--- a/test/Concurrency/silisolationinfo_inference.sil
+++ b/test/Concurrency/silisolationinfo_inference.sil
@@ -127,6 +127,9 @@ sil [isolation "actor_instance"] @unappliedIsolatedAnyParameter : $@convention(m
 protocol MyProtocol {
 }
 
+protocol MyKlassProtocol : AnyObject {
+}
+
 ///////////////////////
 // MARK: Basic Tests //
 ///////////////////////
@@ -2186,4 +2189,88 @@ bb0(%0 : $*Self):
   dealloc_stack %alloc
   %8 = tuple ()
   return %8
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on checked_cast_br_phi_arg_test: sil_isolation_info_inference with: @trace[0]
+// CHECK-NEXT: Input Value: %2 = argument of bb1 : $any MyKlassProtocol
+// CHECK-NEXT: Isolation: global actor 'CustomActor'-isolated isolated-conformance-to(MyKlassProtocol)
+// CHECK-NEXT: end running test 1 of 1 on checked_cast_br_phi_arg_test: sil_isolation_info_inference with: @trace[0]
+sil [isolation "global_actor(CustomActor)"] [ossa] @checked_cast_br_phi_arg_test : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  specify_test "sil_isolation_info_inference @trace[0]"
+  checked_cast_br NonSendableKlass in %0 to MyKlassProtocol, bb1, bb2
+
+bb1(%casted : @guaranteed $MyKlassProtocol):
+  debug_value [trace] %casted
+  br bb3
+
+bb2(%original : @guaranteed $NonSendableKlass):
+  br bb3
+
+bb3:
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on checked_cast_br_phi_arg_test_2: sil_isolation_info_inference with: @trace[0]
+// CHECK-NEXT: Input Value: %4 = argument of bb2 : $NonSendableKlass
+// CHECK-NEXT: Isolation: disconnected
+// CHECK-NEXT: end running test 1 of 1 on checked_cast_br_phi_arg_test_2: sil_isolation_info_inference with: @trace[0]
+sil [isolation "global_actor(CustomActor)"] [ossa] @checked_cast_br_phi_arg_test_2 : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  specify_test "sil_isolation_info_inference @trace[0]"
+  checked_cast_br NonSendableKlass in %0 to MyKlassProtocol, bb1, bb2
+
+bb1(%casted : @guaranteed $MyKlassProtocol):
+  br bb3
+
+bb2(%original : @guaranteed $NonSendableKlass):
+  debug_value [trace] %original
+  br bb3
+
+bb3:
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on checked_cast_br_phi_arg_test_3: sil_isolation_info_inference with: @trace[0]
+// CHECK-NEXT: Input Value: %2 = argument of bb1 : $any MyKlassProtocol
+// CHECK-NEXT: Isolation: task-isolated isolated-conformance-to(MyKlassProtocol)
+// CHECK-NEXT: end running test 1 of 1 on checked_cast_br_phi_arg_test_3: sil_isolation_info_inference with: @trace[0]
+sil [ossa] @checked_cast_br_phi_arg_test_3 : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  specify_test "sil_isolation_info_inference @trace[0]"
+  checked_cast_br NonSendableKlass in %0 to MyKlassProtocol, bb1, bb2
+
+bb1(%casted : @guaranteed $MyKlassProtocol):
+  debug_value [trace] %casted
+  br bb3
+
+bb2(%original : @guaranteed $NonSendableKlass):
+  br bb3
+
+bb3:
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on checked_cast_br_phi_arg_test_4: sil_isolation_info_inference with: @trace[0]
+// CHECK-NEXT: Input Value: %4 = argument of bb2 : $NonSendableKlass
+// CHECK-NEXT: Isolation: disconnected
+// CHECK-NEXT: end running test 1 of 1 on checked_cast_br_phi_arg_test_4: sil_isolation_info_inference with: @trace[0]
+sil [ossa] @checked_cast_br_phi_arg_test_4 : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  specify_test "sil_isolation_info_inference @trace[0]"
+  checked_cast_br NonSendableKlass in %0 to MyKlassProtocol, bb1, bb2
+
+bb1(%casted : @guaranteed $MyKlassProtocol):
+  br bb3
+
+bb2(%original : @guaranteed $NonSendableKlass):
+  debug_value [trace] %original
+  br bb3
+
+bb3:
+  %9999 = tuple ()
+  return %9999 : $()
 }

--- a/test/Concurrency/silisolationinfo_inference_objc.sil
+++ b/test/Concurrency/silisolationinfo_inference_objc.sil
@@ -1,0 +1,69 @@
+// RUN: %target-sil-opt -module-name infer --test-runner %s 2>&1 | %FileCheck %s
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+// REQUIRES: objc_interop
+
+// PLEASE READ THIS!
+//
+// This test is specifically meant to test how we infer isolation for specific
+// values that depend on objc
+
+sil_stage raw
+
+import Swift
+import Builtin
+import _Concurrency
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+actor CustomActorInstance {}
+
+@globalActor
+struct CustomActor {
+  static let shared = CustomActorInstance()
+}
+
+@objc protocol MyObjCProtocol {
+}
+
+//////////////////////////////////////////
+// MARK: Isolated Conformance Inference //
+//////////////////////////////////////////
+
+// These currently use a different entrypoint to merge in the information. It
+// should be changed to use ::get like everything else, but this is ok for now.
+
+// CHECK-LABEL: begin running test 1 of 1 on init_existential_ref_get_conformance_test_globalactor: sil_isolation_info_get_conformance_isolation_inferrence with: @trace[0]
+// CHECK-NEXT: Input Value:   %3 = init_existential_ref %2 : $Self : $Self, $any MyObjCProtocol // user: %4
+// CHECK-NEXT: Isolation: global actor 'CustomActor'-isolated isolated-conformance-to(MyObjCProtocol)
+// CHECK-NEXT: end running test 1 of 1 on init_existential_ref_get_conformance_test_globalactor: sil_isolation_info_get_conformance_isolation_inferrence with: @trace[0]
+sil [isolation "global_actor(CustomActor)"] [ossa] @init_existential_ref_get_conformance_test_globalactor : $@convention(method) <Self where Self : MyObjCProtocol> (@guaranteed Self) -> () {
+bb0(%0 : @guaranteed $Self):
+  specify_test "sil_isolation_info_get_conformance_isolation_inferrence @trace[0]"
+  debug_value %0, let, name "self", argno 1
+  %2 = copy_value %0
+  %3 = init_existential_ref %2 : $Self : $Self, $any MyObjCProtocol
+  debug_value [trace] %3
+  destroy_value %3
+  %8 = tuple ()
+  return %8
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on init_existential_ref_get_conformance_test_nonisolated: sil_isolation_info_get_conformance_isolation_inferrence with: @trace[0]
+// CHECK-NEXT: Input Value:   %3 = init_existential_ref %2 : $Self : $Self, $any MyObjCProtocol // user: %4
+// CHECK-NEXT: Isolation: task-isolated isolated-conformance-to(MyObjCProtocol)
+// CHECK-NEXT: end running test 1 of 1 on init_existential_ref_get_conformance_test_nonisolated: sil_isolation_info_get_conformance_isolation_inferrence with: @trace[0]
+sil [isolation "nonisolated"] [ossa] @init_existential_ref_get_conformance_test_nonisolated : $@convention(method) <Self where Self : MyObjCProtocol> (@guaranteed Self) -> () {
+bb0(%0 : @guaranteed $Self):
+  specify_test "sil_isolation_info_get_conformance_isolation_inferrence @trace[0]"
+  debug_value %0, let, name "self", argno 1
+  %2 = copy_value %0
+  %3 = init_existential_ref %2 : $Self : $Self, $any MyObjCProtocol
+  debug_value [trace] %3
+  destroy_value %3
+  %8 = tuple ()
+  return %8
+}

--- a/test/Concurrency/silisolationinfo_inference_opaquevalues.sil
+++ b/test/Concurrency/silisolationinfo_inference_opaquevalues.sil
@@ -1,0 +1,51 @@
+// RUN: %target-sil-opt -enable-sil-opaque-values -module-name infer --test-runner %s 2>&1 | %FileCheck %s
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+// PLEASE READ THIS!
+//
+// This test is specifically meant to test how we infer isolation for specific
+// values.
+
+sil_stage raw
+
+import Swift
+import Builtin
+import _Concurrency
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+class NonSendableKlass {}
+
+actor CustomActorInstance {}
+
+@globalActor
+struct CustomActor {
+  static let shared = CustomActorInstance()
+}
+
+protocol MyProtocol {
+}
+
+/////////////////
+// MARK: Tests //
+/////////////////
+
+// CHECK-LABEL: begin running test 1 of 1 on init_existential_addr_get_conformance_test: sil_isolation_info_get_conformance_isolation_inferrence with: @trace[0]
+// CHECK-NEXT: Input Value:   %3 = init_existential_value %2 : $Self, $Self, $any MyProtocol // user: %4
+// CHECK-NEXT: Isolation: global actor 'CustomActor'-isolated isolated-conformance-to(MyProtocol)
+// CHECK-NEXT: end running test 1 of 1 on init_existential_addr_get_conformance_test: sil_isolation_info_get_conformance_isolation_inferrence with: @trace[0]
+sil [isolation "global_actor(CustomActor)"] [ossa] @init_existential_addr_get_conformance_test : $@convention(method) <Self where Self : MyProtocol> (@in_guaranteed Self) -> () {
+bb0(%0 : @guaranteed $Self):
+  specify_test "sil_isolation_info_get_conformance_isolation_inferrence @trace[0]"
+  debug_value %0, let, name "self", argno 1
+  %1 = copy_value %0
+  %addr = init_existential_value %1 : $Self, $Self, $MyProtocol
+  debug_value [trace] %addr
+  destroy_value %addr
+  %8 = tuple ()
+  return %8
+}

--- a/test/Concurrency/transfernonsendable_isolated_conformances.swift
+++ b/test/Concurrency/transfernonsendable_isolated_conformances.swift
@@ -1,0 +1,87 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module %t/ExternalTypes.swift -module-name ExternalTypes -o %t/ExternalTypes.swiftmodule
+// RUN: %target-swift-frontend -emit-sil -swift-version 6 -I %t %t/test.swift
+
+// REQUIRES: concurrency
+
+//--- ExternalTypes.swift
+
+// ExternalTypes module - simulates non-Sendable ObjC-like protocols
+// from a framework imported with @preconcurrency
+
+public protocol MyObject: AnyObject {}
+public protocol MyCommand: AnyObject {}
+public protocol ClientBoundCommand: AnyObject {}
+public protocol ServerBoundCommand: AnyObject {}
+public protocol BaseCommand: AnyObject {}
+
+//--- test.swift
+
+@preconcurrency import ExternalTypes
+
+protocol Command: Sendable {}
+
+enum SpecificCommand: Command, @unchecked Sendable {
+    case myCommand(any MyObject & MyCommand)
+    case text(String)
+}
+
+typealias ClientBound = BaseCommand & ClientBoundCommand
+typealias ServerBound = BaseCommand & ServerBoundCommand
+
+protocol CommandPerformer: Sendable {
+    func performCommand(_ command: any Command) async throws
+    func canPerformCommand(_ command: any Command) async -> Bool
+}
+
+protocol ServiceItemProvider: Sendable {}
+
+protocol Connection: Actor, ServiceItemProvider, CommandPerformer {
+    var isActive: Bool { get }
+    func submit(request: String) async throws
+    func deactivate() async
+}
+
+// MARK: - Crashing actor
+
+actor MyConnection: Connection {
+    var isActive: Bool { false }
+
+    func submit(request: String) async throws {}
+    func deactivate() async {}
+
+    func canPerformCommand(_ command: any Command) async -> Bool {
+        return command is SpecificCommand
+    }
+
+    func performCommand(_ command: any Command) async throws {
+        guard await canPerformCommand(command) else { return }
+        guard let specific = command as? SpecificCommand else { return }
+
+        switch specific {
+        case .myCommand(let myCommand):
+            var commandToSend: ServerBound?
+
+            if let clientBoundCommand = myCommand as? ClientBound {
+                commandToSend = await handleClientBound(clientBoundCommand)
+            } else if let serverBoundCommand = myCommand as? ServerBound {
+                commandToSend = serverBoundCommand
+            }
+
+            if let commandToSend {
+                send(commandToSend)
+            }
+
+        case .text(let prompt):
+            try await submit(request: prompt)
+        }
+    }
+
+    private func handleClientBound(_ command: any ClientBound) async -> ServerBound? {
+        return nil
+    }
+
+    private func send(_ command: ServerBound) {}
+}

--- a/test/Concurrency/transfernonsendable_isolated_conformances.swift
+++ b/test/Concurrency/transfernonsendable_isolated_conformances.swift
@@ -1,25 +1,19 @@
 // RUN: %empty-directory(%t)
-// RUN: split-file %s %t
-
-// RUN: %target-swift-frontend -emit-module %t/ExternalTypes.swift -module-name ExternalTypes -o %t/ExternalTypes.swiftmodule
-// RUN: %target-swift-frontend -emit-sil -swift-version 6 -I %t %t/test.swift
+// RUN: %target-swift-frontend -emit-module %S/Inputs/isolated_conformance_other.swift -module-name ExternalTypes -o %t/ExternalTypes.swiftmodule
+// RUN: %target-swift-frontend -emit-sil -swift-version 5 -strict-concurrency=complete -I %t %s -verify -verify-additional-prefix swift5- -enable-upcoming-feature InferIsolatedConformances -o /dev/null
+// RUN: %target-swift-frontend -emit-sil -swift-version 6 -I %t %s -verify -verify-additional-prefix swift6- -enable-upcoming-feature InferIsolatedConformances -o /dev/null
 
 // REQUIRES: concurrency
 
-//--- ExternalTypes.swift
-
-// ExternalTypes module - simulates non-Sendable ObjC-like protocols
-// from a framework imported with @preconcurrency
-
-public protocol MyObject: AnyObject {}
-public protocol MyCommand: AnyObject {}
-public protocol ClientBoundCommand: AnyObject {}
-public protocol ServerBoundCommand: AnyObject {}
-public protocol BaseCommand: AnyObject {}
-
-//--- test.swift
-
 @preconcurrency import ExternalTypes
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+protocol NonSendableProtocol {}
+protocol NonSendableKlassProtocol : AnyObject {}
+class NonSendableKlass {} // expected-note 4{{class 'NonSendableKlass' does not conform to the 'Sendable' protocol}}
 
 protocol Command: Sendable {}
 
@@ -44,7 +38,9 @@ protocol Connection: Actor, ServiceItemProvider, CommandPerformer {
     func deactivate() async
 }
 
-// MARK: - Crashing actor
+/////////////////
+// MARK: Tests //
+/////////////////
 
 actor MyConnection: Connection {
     var isActive: Bool { false }
@@ -84,4 +80,108 @@ actor MyConnection: Connection {
     }
 
     private func send(_ command: ServerBound) {}
+}
+
+actor CastTest<T, U : NonSendableProtocol, V : AnyObject, V2 : NonSendableKlassProtocol> { // expected-note 8{{}}
+  @MainActor var cnx: NonSendableKlass?
+  @MainActor var cnx2: T?
+  @MainActor var cnx3: U?
+  @MainActor var cnx4: V?
+  @MainActor var cnx5: V2?
+
+  func f() async -> NonSendableProtocol {
+    guard let c = await cnx else { fatalError() } // expected-swift5-warning {{non-Sendable type 'NonSendableKlass?' of property 'cnx' cannot exit main actor-isolated context}}
+    // expected-swift6-error @-1 {{non-Sendable type 'NonSendableKlass?' of property 'cnx' cannot exit main actor-isolated context}}
+    guard let q = c as? NonSendableProtocol else { fatalError() } // expected-swift5-warning {{casting main actor-isolated 'c' to 'self'-isolated 'any NonSendableProtocol' risks causing data races; this is an error in the Swift 6 language mode}}
+    return q // expected-swift5-warning {{assigning main actor-isolated 'q' to 'self'-isolated '$return_value' risks causing data races}}
+    // expected-swift5-note @-1 {{'q' could become accessible to 'self'-isolated code despite remaining accessible to main actor-isolated code}}
+  }
+
+  func f2() async -> NonSendableProtocol {
+    guard let c = await cnx2 else { fatalError() } // expected-swift5-warning {{non-Sendable type 'T?' of property 'cnx2' cannot exit main actor-isolated context}}
+    // expected-swift6-error @-1 {{non-Sendable type 'T?' of property 'cnx2' cannot exit main actor-isolated context}}
+    guard let q = c as? NonSendableProtocol else { fatalError() } // expected-swift5-warning {{casting main actor-isolated 'c' to 'self'-isolated 'any NonSendableProtocol' risks causing data races; this is an error in the Swift 6 language mode}}
+    return q // expected-swift5-warning {{assigning main actor-isolated 'q' to 'self'-isolated '$return_value' risks causing data races}}
+    // expected-swift5-note @-1 {{'q' could become accessible to 'self'-isolated code despite remaining accessible to main actor-isolated code}}
+  }
+
+  func f3() async -> NonSendableProtocol {
+    guard let c = await cnx3 else { fatalError() } // expected-swift5-warning {{non-Sendable type 'U?' of property 'cnx3' cannot exit main actor-isolated context}}
+    // expected-swift6-error @-1 {{non-Sendable type 'U?' of property 'cnx3' cannot exit main actor-isolated context}}
+    guard let q = c as? NonSendableProtocol else { fatalError() } // expected-warning {{conditional cast from 'U' to 'any NonSendableProtocol' always succeeds}}
+    return q // expected-swift5-warning {{assigning main actor-isolated 'q' to 'self'-isolated '$return_value' risks causing data races; this is an error in the Swift 6 language mode}}
+    // expected-swift5-note @-1 {{'q' could become accessible to 'self'-isolated code despite remaining accessible to main actor-isolated code}}
+  }
+
+  func g() async -> NonSendableProtocol {
+    guard let c = await cnx else { fatalError() } // expected-swift5-warning {{non-Sendable type 'NonSendableKlass?' of property 'cnx' cannot exit main actor-isolated context}}
+    // expected-swift6-error @-1 {{non-Sendable type 'NonSendableKlass?' of property 'cnx' cannot exit main actor-isolated context}}
+    let q = c as! NonSendableProtocol // expected-swift5-warning {{assigning main actor-isolated 'c' to 'self'-isolated 'q' risks causing data races}}
+    // expected-swift5-note @-1 {{'c' could become accessible to 'self'-isolated code despite remaining accessible to main actor-isolated code}}
+    return q
+  }
+
+  func g2() async -> NonSendableProtocol {
+    guard let c = await cnx2 else { fatalError() } // expected-swift5-warning {{non-Sendable type 'T?' of property 'cnx2' cannot exit main actor-isolated context}}
+    // expected-swift6-error @-1 {{non-Sendable type 'T?' of property 'cnx2' cannot exit main actor-isolated context}}
+    let q = c as! NonSendableProtocol // expected-swift5-warning {{assigning main actor-isolated 'c' to 'self'-isolated 'q' risks causing data races}}
+    // expected-swift5-note @-1 {{'c' could become accessible to 'self'-isolated code despite remaining accessible to main actor-isolated code}}
+    return q
+  }
+
+  func g3() async -> NonSendableProtocol {
+    guard let c = await cnx3 else { fatalError() } // expected-swift5-warning {{non-Sendable type 'U?' of property 'cnx3' cannot exit main actor-isolated context}}
+    // expected-swift6-error @-1 {{non-Sendable type 'U?' of property 'cnx3' cannot exit main actor-isolated context}}
+    let q = c as! NonSendableProtocol // expected-warning {{forced cast from 'U' to 'any NonSendableProtocol' always succeeds; did you mean to use 'as'}}
+    return q // expected-swift5-warning {{assigning main actor-isolated 'q' to 'self'-isolated '$return_value' risks causing data races; this is an error in the Swift 6 language mode}}
+    // expected-swift5-note @-1 {{'q' could become accessible to 'self'-isolated code despite remaining accessible to main actor-isolated code}}
+  }
+
+
+  func h() async -> NonSendableKlassProtocol {
+    guard let c = await cnx else { fatalError() } // expected-swift5-warning {{non-Sendable type 'NonSendableKlass?' of property 'cnx' cannot exit main actor-isolated context}}
+    // expected-swift6-error @-1 {{non-Sendable type 'NonSendableKlass?' of property 'cnx' cannot exit main actor-isolated context}}
+    guard let q = c as? NonSendableKlassProtocol else { fatalError() } // expected-swift5-warning {{casting main actor-isolated 'c' to 'self'-isolated 'any NonSendableKlassProtocol' risks causing data races}}
+    return q
+  }
+
+  func h2() async -> NonSendableKlassProtocol {
+    guard let c = await cnx4 else { fatalError() } // expected-swift5-warning {{non-Sendable type 'V?' of property 'cnx4' cannot exit main actor-isolated context}}
+    // expected-swift6-error @-1 {{non-Sendable type 'V?' of property 'cnx4' cannot exit main actor-isolated context}}
+    guard let q = c as? NonSendableKlassProtocol else { fatalError() } // expected-swift5-warning {{casting main actor-isolated 'c' to 'self'-isolated 'any NonSendableKlassProtocol' risks causing data races}}
+    return q
+  }
+
+  func h3() async -> NonSendableKlassProtocol {
+    guard let c = await cnx5 else { fatalError() } // expected-swift5-warning {{non-Sendable type 'V2?' of property 'cnx5' cannot exit main actor-isolated context}}
+    // expected-swift6-error @-1 {{non-Sendable type 'V2?' of property 'cnx5' cannot exit main actor-isolated context}}
+    guard let q = c as? NonSendableKlassProtocol else { fatalError() } // expected-warning {{conditional cast from 'V2' to 'any NonSendableKlassProtocol' always succeeds}}
+    return q
+  }
+
+  func k() async -> NonSendableKlassProtocol {
+    guard let c = await cnx else { fatalError() } // expected-swift5-warning {{non-Sendable type 'NonSendableKlass?' of property 'cnx' cannot exit main actor-isolated context}}
+    // expected-swift6-error @-1 {{non-Sendable type 'NonSendableKlass?' of property 'cnx' cannot exit main actor-isolated context}}
+    let q = c as! NonSendableKlassProtocol // expected-swift5-warning {{assigning main actor-isolated 'c' to 'self'-isolated 'q' risks causing data races}}
+    // expected-swift5-note @-1 {{'c' could become accessible to 'self'-isolated code despite remaining accessible to main actor-isolated code}}
+    // expected-swift5-warning @-2 {{casting main actor-isolated 'c' to 'self'-isolated 'any NonSendableKlassProtocol' risks causing data races}}
+    return q
+  }
+
+  func k2() async -> NonSendableKlassProtocol {
+    guard let c = await cnx4 else { fatalError() } // expected-swift5-warning {{non-Sendable type 'V?' of property 'cnx4' cannot exit main actor-isolated context}}
+    // expected-swift6-error @-1 {{non-Sendable type 'V?' of property 'cnx4' cannot exit main actor-isolated context}}
+    let q = c as! NonSendableKlassProtocol // expected-swift5-warning {{assigning main actor-isolated 'c' to 'self'-isolated 'q' risks causing data races}}
+    // expected-swift5-note @-1 {{'c' could become accessible to 'self'-isolated code despite remaining accessible to main actor-isolated code}}
+    // expected-swift5-warning @-2 {{casting main actor-isolated 'c' to 'self'-isolated 'any NonSendableKlassProtocol' risks causing data races}}
+    return q
+  }
+
+  func k3() async -> NonSendableKlassProtocol {
+    guard let c = await cnx5 else { fatalError() } // expected-swift5-warning {{non-Sendable type 'V2?' of property 'cnx5' cannot exit main actor-isolated context}}
+    // expected-swift6-error @-1 {{non-Sendable type 'V2?' of property 'cnx5' cannot exit main actor-isolated context}}
+    let q = c as! NonSendableKlassProtocol // expected-warning {{forced cast from 'V2' to 'any NonSendableKlassProtocol' always succeeds}}
+    return q
+  }
+
 }

--- a/test/Concurrency/transfernonsendable_isolated_conformances.swift
+++ b/test/Concurrency/transfernonsendable_isolated_conformances.swift
@@ -4,6 +4,7 @@
 // RUN: %target-swift-frontend -emit-sil -swift-version 6 -I %t %s -verify -verify-additional-prefix swift6- -enable-upcoming-feature InferIsolatedConformances -o /dev/null
 
 // REQUIRES: concurrency
+// REQUIRES: swift_feature_InferIsolatedConformances
 
 @preconcurrency import ExternalTypes
 

--- a/test/Concurrency/transfernonsendable_library_evolution.swift
+++ b/test/Concurrency/transfernonsendable_library_evolution.swift
@@ -1,0 +1,26 @@
+// RUN: %target-swift-frontend -primary-file %s -swift-version 6 -enable-library-evolution -verify -c
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+class NonSendableKlass {}
+
+struct NonSendable<T> {
+  var x: T? = nil
+}
+
+public enum NonSendableEnum {
+case case1
+case case2
+}
+
+/////////////////
+// MARK: Tests //
+/////////////////
+
+@MainActor struct DefaultArgumentInitializerTest<T> {
+  var strategy: NonSendableEnum = .case1
+  var strategy2 = NonSendable<T>()
+  var strategy3 = NonSendableKlass()
+}

--- a/test/Concurrency/transfernonsendable_partitionop_translation.sil
+++ b/test/Concurrency/transfernonsendable_partitionop_translation.sil
@@ -2040,10 +2040,7 @@ bb3:
 // CHECK-LABEL: begin running test {{.*}} on test_checked_cast_br: sil_regionanalysis_partitionoptranslation with: @instruction
 // CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
 // CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $AnyObject
-// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
-// CHECK-NEXT:     Rep Value: %2 = argument of bb1 : $NonSendableKlass
 // CHECK-NEXT: require %%0:   checked_cast_br AnyObject in %0 : $AnyObject to NonSendableKlass, bb1, bb2
-// CHECK-NEXT: assign_direct %%1 = %%0:   checked_cast_br AnyObject in %0 : $AnyObject to NonSendableKlass, bb1, bb2
 // CHECK-NEXT: end running test {{.*}} on test_checked_cast_br: sil_regionanalysis_partitionoptranslation with: @instruction
 sil [ossa] @test_checked_cast_br : $@convention(thin) (@owned AnyObject) -> () {
 bb0(%0 : @owned $AnyObject):
@@ -2055,6 +2052,58 @@ bb1(%casted : @owned $NonSendableKlass):
   br bb3
 
 bb2(%original : @owned $AnyObject):
+  destroy_value %original
+  br bb3
+
+bb3:
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on test_checked_cast_br_success_block: sil_regionanalysis_partitionoptranslation_block with: @block
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $AnyObject                 // user: %1
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: %2 = argument of bb1 : $NonSendableKlass          // user: %3
+// CHECK-NEXT: assign_fresh %%1:   destroy_value %2 : $NonSendableKlass            // id: %3
+// CHECK-NEXT: merge %%1 with %%0:   checked_cast_br AnyObject in %0 : $AnyObject to NonSendableKlass, bb1, bb2 // id: %1
+// CHECK-NEXT: end running test 1 of 1 on test_checked_cast_br_success_block: sil_regionanalysis_partitionoptranslation_block with: @block
+sil [ossa] @test_checked_cast_br_success_block : $@convention(thin) (@owned AnyObject) -> () {
+bb0(%0 : @owned $AnyObject):
+  checked_cast_br AnyObject in %0 : $AnyObject to NonSendableKlass, bb1, bb2
+
+bb1(%casted : @owned $NonSendableKlass):
+  specify_test "sil_regionanalysis_partitionoptranslation_block @block"
+  destroy_value %casted
+  br bb3
+
+bb2(%original : @owned $AnyObject):
+  destroy_value %original
+  br bb3
+
+bb3:
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on test_checked_cast_br_failure_block: sil_regionanalysis_partitionoptranslation_block with: @block
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $AnyObject                 // user: %1
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value: %5 = argument of bb2 : $AnyObject                 // user: %6
+// CHECK-NEXT: assign_fresh %%1:   destroy_value %5 : $AnyObject                   // id: %6
+// CHECK-NEXT: assign_direct %%1 = %%0:   checked_cast_br AnyObject in %0 : $AnyObject to NonSendableKlass, bb1, bb2 // id: %1
+// CHECK-NEXT: end running test 1 of 1 on test_checked_cast_br_failure_block: sil_regionanalysis_partitionoptranslation_block with: @block
+sil [ossa] @test_checked_cast_br_failure_block : $@convention(thin) (@owned AnyObject) -> () {
+bb0(%0 : @owned $AnyObject):
+  checked_cast_br AnyObject in %0 : $AnyObject to NonSendableKlass, bb1, bb2
+
+bb1(%casted : @owned $NonSendableKlass):
+  destroy_value %casted
+  br bb3
+
+bb2(%original : @owned $AnyObject):
+  specify_test "sil_regionanalysis_partitionoptranslation_block @block"
   destroy_value %original
   br bb3
 

--- a/test/SIL/Parser/basic2.sil
+++ b/test/SIL/Parser/basic2.sil
@@ -516,3 +516,12 @@ bb0(%0 : @inferredImmutable @guaranteed $Klass):
   %9999 = tuple ()
   return %9999 : $()
 }
+
+// Make sure that we roundtrip if the isolation is specified in SIL.
+//
+// CHECK-LABEL: sil [isolation "nonisolated"] @isolation_test : $@convention(thin) () -> () {
+sil [isolation "nonisolated"] @isolation_test : $@convention(thin) () -> () {
+bb0:
+  %9999 = tuple ()
+  return %9999 : $()
+}


### PR DESCRIPTION
Previously, getForCastConformances would only use the SILFunction information if the SILFunction was isolated to a global actor. If the SILFunction was isolated to an actor instance though, it would return that the cast was task-isolated causing mismerges.

The way this works overall is that the AST and the TypeChecker decide where these can be created... but once they are created it is the job of SendNonSendable to make sure they do not escape that isolation domain, meaning that they should match the isolation domain of the SILFunction where they are created.

rdar://172941821
