### PR TITLE
[Frontend] SE-0518: Turn `TildeSendable` into a language feature

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -9138,10 +9138,6 @@ ERROR(attr_inline_always_on_accessor,none,
 //===----------------------------------------------------------------------===//
 // MARK: `~Sendable`
 //===----------------------------------------------------------------------===//
-ERROR(tilde_sendable_requires_feature_flag,none,
-      "'~Sendable' requires -enable-experimental-feature TildeSendable",
-      ())
-
 NOTE(sendable_conformance_is_suppressed, none,
      "%kind0 explicitly suppresses conformance to 'Sendable' protocol",
      (const NominalTypeDecl *))

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -282,6 +282,7 @@ LANGUAGE_FEATURE(ClosureLifetimes, 0, "Support @_lifetime on function types")
 BASELINE_LANGUAGE_FEATURE(ExcludePrivateFromMemberwiseInit, 502, "Exclude private initialized properties from memberwise init")
 LANGUAGE_FEATURE(BuiltinMarkDependence, 0, "markDependence Builtin")
 LANGUAGE_FEATURE(BuiltinAddTaskLocalValue, 0, "addTaskLocalValue and removeTaskLocalValue builtins")
+SUPPRESSIBLE_LANGUAGE_FEATURE(TildeSendable, 518, "~Sendable for explicitly marking non-Sendable types")
 
 // TEMPORARY: Never use this, because it is only meant to allow us to model
 // suppression of @c in Swift interfaces as a temporary measure.
@@ -588,9 +589,6 @@ EXPERIMENTAL_FEATURE(SwiftRuntimeAvailability, true)
 /// 'Swift' availability is always standalone, even when targeting platforms
 /// that have a built-in Swift runtime. Implies 'SwiftRuntimeAvailability'.
 EXPERIMENTAL_FEATURE(StandaloneSwiftAvailability, true)
-
-/// Allow use of `~Sendable`.
-SUPPRESSIBLE_EXPERIMENTAL_FEATURE(TildeSendable, false)
 
 /// Allow use of protocol typed values in Embedded mode (`Any` and friends)
 EXPERIMENTAL_FEATURE(EmbeddedExistentials, true)

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1491,8 +1491,7 @@ void swift::diagnoseMissingExplicitSendable(NominalTypeDecl *nominal) {
     }
   }
 
-  // Note to supress Sendable conformance is feature is enabled.
-  if (ctx.LangOpts.hasFeature(Feature::TildeSendable)) {
+  {
     auto note = nominal->diagnose(diag::suppress_sendable_conformance);
     auto inheritance = nominal->getInherited();
     if (inheritance.empty()) {

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1495,7 +1495,12 @@ void swift::diagnoseMissingExplicitSendable(NominalTypeDecl *nominal) {
     auto note = nominal->diagnose(diag::suppress_sendable_conformance);
     auto inheritance = nominal->getInherited();
     if (inheritance.empty()) {
-      note.fixItInsertAfter(nominal->getNameLoc(), ": ~Sendable");
+      // If a nominal has any generic params, insert new conformance right
+      // after them.
+      auto *genericParams = nominal->getGenericParams();
+      auto insertionLoc =
+          genericParams ? genericParams->getRAngleLoc() : nominal->getNameLoc();
+      note.fixItInsertAfter(insertionLoc, ": ~Sendable");
     } else {
       note.fixItInsertAfter(inheritance.getEndLoc(), ", ~Sendable");
     }

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -124,14 +124,6 @@ public:
       return Type();
     }
 
-    if (rpk == RepressibleProtocolKind::Sendable) {
-      if (!ctx.LangOpts.hasFeature(Feature::TildeSendable)) {
-        diagnoseInvalid(repr, repr.getLoc(),
-                        diag::tilde_sendable_requires_feature_flag);
-        return Type();
-      }
-    }
-
     if (auto *TD = dyn_cast<const TypeDecl *>(decl)) {
       if (rpk == RepressibleProtocolKind::Sendable) {
         auto *C = dyn_cast<ClassDecl>(TD);

--- a/test/Concurrency/objc_require_explicit_sendable.swift
+++ b/test/Concurrency/objc_require_explicit_sendable.swift
@@ -16,4 +16,5 @@ open class Y: X { }
 
 
 open class Z: NSObject { } // expected-warning{{public class 'Z' does not specify whether it is 'Sendable' or not}}
-// expected-note@-1{{make class 'Z' explicitly non-Sendable to suppress this warning}}
+// expected-note@-1{{consider suppressing conformance to 'Sendable' protocol}}
+// expected-note@-2{{make class 'Z' explicitly non-Sendable to suppress this warning}}

--- a/test/Concurrency/require-explicit-sendable.swift
+++ b/test/Concurrency/require-explicit-sendable.swift
@@ -3,6 +3,7 @@
 
 public protocol P { }
 
+// expected-note@+3{{consider suppressing conformance to 'Sendable' protocol}} {{17-17=: ~Sendable}}
 // expected-note@+2{{consider making struct 'S1' conform to the 'Sendable' protocol}}{{18-18=: Sendable}}
 // expected-note@+1{{make struct 'S1' explicitly non-Sendable to suppress this warning}}{{+2:2-2=\n\n@available(*, unavailable)\nextension S1: Sendable { \}\n}}
 public struct S1 { // expected-warning{{public struct 'S1' does not specify whether it is 'Sendable' or not}}
@@ -11,28 +12,33 @@ public struct S1 { // expected-warning{{public struct 'S1' does not specify whet
 
 class C { }
 
+// expected-note@+2{{consider suppressing conformance to 'Sendable' protocol}} {{17-17=: ~Sendable}}
 // expected-note@+1{{make struct 'S2' explicitly non-Sendable to suppress this warning}}{{+2:2-2=\n\n@available(*, unavailable)\nextension S2: Sendable { \}\n}}
 public struct S2 { // expected-warning{{public struct 'S2' does not specify whether it is 'Sendable' or not}}
   var c: C
 }
 
+// expected-note@+3{{consider suppressing conformance to 'Sendable' protocol}} {{25-25=, ~Sendable}}
 // expected-note@+2{{consider making class 'C1' conform to the 'Sendable' protocol}}{{25-25=, Sendable}}
 // expected-note@+1{{make class 'C1' explicitly non-Sendable to suppress this warning}}{{+2:2-2=\n\n@available(*, unavailable)\nextension C1: Sendable { \}\n}}
 final public class C1: P { // expected-warning{{public class 'C1' does not specify whether it is 'Sendable' or not}}
   let str: String = ""
 }
 
+// expected-note@+2{{consider suppressing conformance to 'Sendable' protocol}} {{16-16=: ~Sendable}}
 // expected-note@+1{{make class 'C2' explicitly non-Sendable to suppress this warning}}{{+2:2-2=\n\n@available(*, unavailable)\nextension C2: Sendable { \}\n}}
 public class C2 { // expected-warning{{public class 'C2' does not specify whether it is 'Sendable' or not}}
   var str: String = ""
 }
 
+// expected-note@+3{{consider suppressing conformance to 'Sendable' protocol}}
 // expected-note@+2{{consider making generic struct 'S3' conform to the 'Sendable' protocol}}{{+2:2-2=\n\nextension S3: Sendable where T: Sendable { \}\n}}
 // expected-note@+1{{make generic struct 'S3' explicitly non-Sendable to suppress this warning}}{{+2:2-2=\n\n@available(*, unavailable)\nextension S3: Sendable { \}\n}}
 public struct S3<T> { // expected-warning{{public generic struct 'S3' does not specify whether it is 'Sendable' or not}}
   var t: T
 }
 
+// expected-note@+2{{consider suppressing conformance to 'Sendable' protocol}}
 // expected-note@+1{{make generic struct 'S4' explicitly non-Sendable to suppress this warning}}{{+3:2-2=\n\n@available(*, unavailable)\nextension S4: Sendable { \}\n}}
 public struct S4<T> { // expected-warning{{public generic struct 'S4' does not specify whether it is 'Sendable' or not}}
   var t: T
@@ -69,6 +75,7 @@ func testMe(s5: S5, s7: S7) {
   acceptSendable(s7) // expected-warning{{conformance of 'S7' to 'Sendable' is unavailable}}
 }
 
+// expected-note@+3{{consider suppressing conformance to 'Sendable' protocol}}
 // expected-note@+2{{consider making generic struct 'S8' conform to the 'Sendable' protocol}}{{+2:2-2=\n\nextension S8: Sendable where T: Sendable, U: Sendable, V: Sendable { \}\n}}
 // expected-note@+1{{make generic struct 'S8' explicitly non-Sendable to suppress this warning}}
 public struct S8<T: Hashable, U, V> { // expected-warning{{public generic struct 'S8' does not specify whether it is 'Sendable' or not}}
@@ -79,6 +86,7 @@ public protocol P2 {
   associatedtype A
 }
 
+// expected-note@+4{{consider suppressing conformance to 'Sendable' protocol}}
 // expected-warning@+3{{public generic struct 'S9' does not specify whether it is 'Sendable' or not}}
 // expected-note@+2{{consider making generic struct 'S9' conform to the 'Sendable' protocol}}{{+2:2-2=\n\nextension S9: Sendable where T: Sendable, T.A: Sendable { \}\n}}
 // expected-note@+1{{make generic struct 'S9' explicitly non-Sendable to suppress this warning}}
@@ -86,6 +94,7 @@ public struct S9<T: P2 & Hashable> {
   var dict: [T : T.A] = [:]
 }
 
+// expected-note@+1{{consider suppressing conformance to 'Sendable' protocol}} {{18-18=: ~Sendable}}
 public struct S10 { // expected-warning{{public struct 'S10' does not specify whether it is 'Sendable' or not}}
   // expected-note@-1{{make struct 'S10' explicitly non-Sendable to suppress this warning}}
   var s7: S7

--- a/test/Concurrency/require-explicit-sendable.swift
+++ b/test/Concurrency/require-explicit-sendable.swift
@@ -31,14 +31,14 @@ public class C2 { // expected-warning{{public class 'C2' does not specify whethe
   var str: String = ""
 }
 
-// expected-note@+3{{consider suppressing conformance to 'Sendable' protocol}}
+// expected-note@+3{{consider suppressing conformance to 'Sendable' protocol}} {{20-20=: ~Sendable}}
 // expected-note@+2{{consider making generic struct 'S3' conform to the 'Sendable' protocol}}{{+2:2-2=\n\nextension S3: Sendable where T: Sendable { \}\n}}
 // expected-note@+1{{make generic struct 'S3' explicitly non-Sendable to suppress this warning}}{{+2:2-2=\n\n@available(*, unavailable)\nextension S3: Sendable { \}\n}}
 public struct S3<T> { // expected-warning{{public generic struct 'S3' does not specify whether it is 'Sendable' or not}}
   var t: T
 }
 
-// expected-note@+2{{consider suppressing conformance to 'Sendable' protocol}}
+// expected-note@+2{{consider suppressing conformance to 'Sendable' protocol}} {{20-20=: ~Sendable}}
 // expected-note@+1{{make generic struct 'S4' explicitly non-Sendable to suppress this warning}}{{+3:2-2=\n\n@available(*, unavailable)\nextension S4: Sendable { \}\n}}
 public struct S4<T> { // expected-warning{{public generic struct 'S4' does not specify whether it is 'Sendable' or not}}
   var t: T
@@ -75,7 +75,7 @@ func testMe(s5: S5, s7: S7) {
   acceptSendable(s7) // expected-warning{{conformance of 'S7' to 'Sendable' is unavailable}}
 }
 
-// expected-note@+3{{consider suppressing conformance to 'Sendable' protocol}}
+// expected-note@+3{{consider suppressing conformance to 'Sendable' protocol}} {{36-36=: ~Sendable}}
 // expected-note@+2{{consider making generic struct 'S8' conform to the 'Sendable' protocol}}{{+2:2-2=\n\nextension S8: Sendable where T: Sendable, U: Sendable, V: Sendable { \}\n}}
 // expected-note@+1{{make generic struct 'S8' explicitly non-Sendable to suppress this warning}}
 public struct S8<T: Hashable, U, V> { // expected-warning{{public generic struct 'S8' does not specify whether it is 'Sendable' or not}}
@@ -86,7 +86,7 @@ public protocol P2 {
   associatedtype A
 }
 
-// expected-note@+4{{consider suppressing conformance to 'Sendable' protocol}}
+// expected-note@+4{{consider suppressing conformance to 'Sendable' protocol}} {{35-35=: ~Sendable}}
 // expected-warning@+3{{public generic struct 'S9' does not specify whether it is 'Sendable' or not}}
 // expected-note@+2{{consider making generic struct 'S9' conform to the 'Sendable' protocol}}{{+2:2-2=\n\nextension S9: Sendable where T: Sendable, T.A: Sendable { \}\n}}
 // expected-note@+1{{make generic struct 'S9' explicitly non-Sendable to suppress this warning}}

--- a/test/Concurrency/tilde_sendable_objc.swift
+++ b/test/Concurrency/tilde_sendable_objc.swift
@@ -5,11 +5,9 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %t/src/main.swift \
 // RUN:   -import-objc-header %t/src/Test.h \
 // RUN:   -swift-version 6 \
-// RUN:   -enable-experimental-feature TildeSendable \
 // RUN:   -module-name main -I %t -verify -verify-ignore-unrelated
 
 // REQUIRES: objc_interop
-// REQUIRES: swift_feature_TildeSendable
 
 //--- Test.h
 #define SWIFT_SENDABLE __attribute__((__swift_attr__("@Sendable")))

--- a/test/ModuleInterface/tilde_sendable.swift
+++ b/test/ModuleInterface/tilde_sendable.swift
@@ -1,9 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -module-name Library -enable-experimental-feature TildeSendable
+// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -module-name Library
 // RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -module-name Library
 // RUN: %FileCheck %s < %t/Library.swiftinterface
-
-// REQUIRES: swift_feature_TildeSendable
 
 // CHECK: #if compiler(>=5.3) && $TildeSendable
 // CHECK: public class A : ~Swift::Sendable {

--- a/test/Sema/tilde_sendable.swift
+++ b/test/Sema/tilde_sendable.swift
@@ -1,6 +1,4 @@
-// RUN: %target-typecheck-verify-swift -strict-concurrency=complete -swift-version 5 -enable-experimental-feature TildeSendable -Wwarning ExplicitSendable
-
-// REQUIRES: swift_feature_TildeSendable
+// RUN: %target-typecheck-verify-swift -strict-concurrency=complete -swift-version 5 -Wwarning ExplicitSendable
 
 protocol P: ~Sendable { // expected-error {{conformance to 'Sendable' can only be suppressed on structs, classes, and enums}}
 }


### PR DESCRIPTION
The proposal has been accepted and `~Sendable` doesn't require
an explicitly enabled experimental flag.

This change also slightly adjusts the fix-it location for types with
generic parameter lists.

Resolves: rdar://119695934

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
