### PR TITLE
AST: Introduce JoinType and MeetType

### DIFF
--- a/include/swift/AST/TypeNodes.def
+++ b/include/swift/AST/TypeNodes.def
@@ -210,6 +210,8 @@ TYPE(PackExpansion, Type)
 TYPE(PackElement, Type)
 UNCHECKED_TYPE(TypeVariable, Type)
 UNCHECKED_TYPE(ErrorUnion, Type)
+UNCHECKED_TYPE(Join, Type)
+UNCHECKED_TYPE(Meet, Type)
 TYPE(Integer, Type)
 ABSTRACT_SUGARED_TYPE(Sugar, Type)
   SUGARED_TYPE(TypeAlias, SugarType)
@@ -242,6 +244,8 @@ SINGLETON_TYPE(UnsafeValueBuffer, BuiltinUnsafeValueBuffer)
 SINGLETON_TYPE(DefaultActorStorage, BuiltinDefaultActorStorage)
 SINGLETON_TYPE(NonDefaultDistributedActorStorage, BuiltinNonDefaultDistributedActorStorage)
 SINGLETON_TYPE(SILToken, SILToken)
+SINGLETON_TYPE(Join, Join)
+SINGLETON_TYPE(Meet, Meet)
 #undef SINGLETON_TYPE
 #endif
 

--- a/include/swift/AST/TypeTransform.h
+++ b/include/swift/AST/TypeTransform.h
@@ -117,6 +117,8 @@ case TypeKind::Id:
     case TypeKind::Module:
     case TypeKind::BuiltinTuple:
     case TypeKind::Integer:
+    case TypeKind::Join:
+    case TypeKind::Meet:
       return t;
 
     // BuiltinGenericType subclasses

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -164,6 +164,9 @@ public:
     /// This type contains an Error type without an underlying original type.
     HasBareError         = 0x100,
 
+    /// Whether this type contains a JoinType or MeetType.
+    HasJoinOrMeet        = 0x200,
+
     /// This type contains an OpaqueTypeArchetype.
     HasOpaqueArchetype   = 0x400,
 
@@ -278,6 +281,8 @@ public:
   bool hasPackArchetype() const { return Bits & HasPackArchetype; }
 
   bool isUnsafe() const { return Bits & IsUnsafe; }
+
+  bool hasJoinOrMeet() const { return Bits & HasJoinOrMeet; }
 
   /// Does a type with these properties structurally contain a
   /// parameterized existential type?
@@ -810,6 +815,10 @@ public:
   bool hasParameterizedExistential() const {
     return getRecursiveProperties().hasParameterizedExistential();
   }
+
+  /// Determine whether the type involves the 'join' or 'meet' type, produced by
+  /// the algorithms in lib/Sema/Subtyping.cpp.
+  bool hasJoinOrMeet() const { return getRecursiveProperties().hasJoinOrMeet(); }
 
   /// Determine whether the type involves a local archetype from the given
   /// environment.
@@ -8005,6 +8014,42 @@ public:
   }
 };
 DEFINE_EMPTY_CAN_TYPE_WRAPPER(PlaceholderType, Type)
+
+/// A type to represent a type join between a type variable and a concrete type.
+///
+/// For now, this is a singleton type that does not store the constituent parts
+/// of the join. If we want, we can add this in the future, in service of
+/// diagnostics for example.
+class JoinType final : public TypeBase {
+  friend class ASTContext;
+  JoinType(const ASTContext &C)
+    : TypeBase(TypeKind::Join, &C, RecursiveTypeProperties::HasJoinOrMeet) {}
+public:
+  // The singleton instance of this type is ASTContext::TheJoinType.
+
+  static bool classof(const TypeBase *T) {
+    return T->getKind() == TypeKind::Join;
+  }
+};
+DEFINE_EMPTY_CAN_TYPE_WRAPPER(JoinType, Type)
+
+/// A type to represent a type meet between a type variable and a concrete type.
+///
+/// For now, this is a singleton type that does not store the constituent parts
+/// of the meet. If we want, we can add this in the future, in service of
+/// diagnostics for example.
+class MeetType final : public TypeBase {
+  friend class ASTContext;
+  MeetType(const ASTContext &C)
+    : TypeBase(TypeKind::Meet, &C, RecursiveTypeProperties::HasJoinOrMeet) {}
+public:
+  // The singleton instance of this type is ASTContext::TheMeetType.
+
+  static bool classof(const TypeBase *T) {
+    return T->getKind() == TypeKind::Meet;
+  }
+};
+DEFINE_EMPTY_CAN_TYPE_WRAPPER(MeetType, Type)
 
 /// PackType - The type of a pack of arguments provided to a
 /// \c PackExpansionType to guide the pack expansion process.

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -164,9 +164,6 @@ public:
     /// This type contains an Error type without an underlying original type.
     HasBareError         = 0x100,
 
-    /// This type contains a DependentMemberType.
-    HasDependentMember   = 0x200,
-
     /// This type contains an OpaqueTypeArchetype.
     HasOpaqueArchetype   = 0x400,
 
@@ -237,10 +234,6 @@ public:
 
   /// Does this type contain an error without an original type?
   bool hasBareError() const { return Bits & HasBareError; }
-
-  /// Does this type contain a dependent member type, possibly with a
-  /// non-type parameter base, such as a type variable or concrete type?
-  bool hasDependentMember() const { return Bits & HasDependentMember; }
 
   /// Does a type with these properties structurally contain an
   /// opened existential archetype?
@@ -315,11 +308,6 @@ public:
   /// Remove the HasTypeParameter property from this set.
   void removeHasTypeParameter() {
     Bits &= ~HasTypeParameter;
-  }
-
-  /// Remove the HasDependentMember property from this set.
-  void removeHasDependentMember() {
-    Bits &= ~HasDependentMember;
   }
 
   /// Remove the IsUnsafe property from this set.
@@ -958,12 +946,6 @@ public:
   /// Whether this is a top-level ErrorType without an underlying original
   /// type, i.e prints as `_`.
   bool isBareErrorType() const;
-
-  /// Does this type contain a dependent member type, possibly with a
-  /// non-type parameter base, such as a type variable or concrete type?
-  bool hasDependentMember() const {
-    return getRecursiveProperties().hasDependentMember();
-  }
 
   /// Whether this type represents a generic constraint.
   bool isConstraintType() const;

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -5693,7 +5693,6 @@ CanSILFunctionType SILFunctionType::get(
   // revisit this.
   if (genericSig || patternSubs) {
     properties.removeHasTypeParameter();
-    properties.removeHasDependentMember();
   }
 
   auto outerSubs = genericSig ? invocationSubs : patternSubs;
@@ -5863,7 +5862,6 @@ InOutType *InOutType::get(Type objectTy) {
 
 DependentMemberType *DependentMemberType::get(Type base, Identifier name) {
   auto properties = base->getRecursiveProperties();
-  properties |= RecursiveTypeProperties::HasDependentMember;
   auto arena = getArena(properties);
 
   llvm::PointerUnion<Identifier, AssociatedTypeDecl *> stored(name);
@@ -5882,7 +5880,6 @@ DependentMemberType *DependentMemberType::get(Type base,
                                               AssociatedTypeDecl *assocType) {
   assert(assocType && "Missing associated type");
   auto properties = base->getRecursiveProperties();
-  properties |= RecursiveTypeProperties::HasDependentMember;
   auto arena = getArena(properties);
 
   llvm::PointerUnion<Identifier, AssociatedTypeDecl *> stored(assocType);

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -6263,6 +6263,8 @@ namespace {
     TRIVIAL_TYPE_PRINTER(BuiltinImplicitActor, builtin_implicit_isolated_actor)
     TRIVIAL_TYPE_PRINTER(BuiltinUnsafeValueBuffer, builtin_unsafe_value_buffer)
     TRIVIAL_TYPE_PRINTER(SILToken, sil_token)
+    TRIVIAL_TYPE_PRINTER(Join, join)
+    TRIVIAL_TYPE_PRINTER(Meet, meet)
 
     void visitBuiltinVectorType(BuiltinVectorType *T, Label label) {
       printCommon("builtin_vector_type", label);

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1395,13 +1395,21 @@ void ASTMangler::appendType(Type type, GenericSignature sig,
   TypeBase *tybase = type.getPointer();
   switch (type->getKind()) {
     case TypeKind::TypeVariable:
-      llvm_unreachable("mangling type variable");
-
+    case TypeKind::Join:
+    case TypeKind::Meet:
     case TypeKind::ErrorUnion:
-      llvm_unreachable("Error unions should not persist to mangling");
-
     case TypeKind::Module:
-      llvm_unreachable("Cannot mangle module type yet");
+    case TypeKind::BuiltinUnboundGeneric:
+    case TypeKind::PrimaryArchetype:
+    case TypeKind::PackArchetype:
+    case TypeKind::ElementArchetype:
+    case TypeKind::ExistentialArchetype:
+    case TypeKind::SILMoveOnlyWrapped:
+    case TypeKind::SILBlockStorage:
+      ABORT([&](llvm::raw_ostream &out) {
+        out << "Cannot mangle this kind of type:\n";
+        type->dump(out);
+      });
 
     case TypeKind::Error:
     case TypeKind::Placeholder:
@@ -1452,8 +1460,6 @@ void ASTMangler::appendType(Type type, GenericSignature sig,
       return appendOperator("Bb");
     case TypeKind::BuiltinUnsafeValueBuffer:
       return appendOperator("BB");
-    case TypeKind::BuiltinUnboundGeneric:
-      ABORT("Don't know how to mangle a BuiltinUnboundGenericType");
     case TypeKind::Locatable: {
       auto loc = cast<LocatableType>(tybase);
       return appendType(loc->getSinglyDesugaredType(), sig, forDecl);
@@ -1765,15 +1771,6 @@ void ASTMangler::appendType(Type type, GenericSignature sig,
                                     forDecl);
 
       // type ::= archetype
-    case TypeKind::PrimaryArchetype:
-    case TypeKind::PackArchetype:
-    case TypeKind::ElementArchetype:
-    case TypeKind::ExistentialArchetype:
-      ABORT([&](auto &out) {
-        out << "Cannot mangle free-standing archetype: ";
-        tybase->dump(out);
-      });
-
     case TypeKind::OpaqueTypeArchetype: {
       auto opaqueType = cast<OpaqueTypeArchetypeType>(tybase);
       auto opaqueDecl = opaqueType->getDecl();
@@ -1893,12 +1890,6 @@ void ASTMangler::appendType(Type type, GenericSignature sig,
 
       return;
     }
-
-    case TypeKind::SILMoveOnlyWrapped:
-      // If we hit this, we just mangle the underlying name and move on.
-      llvm_unreachable("should never be mangled?");
-    case TypeKind::SILBlockStorage:
-      llvm_unreachable("should never be mangled");
   }
   llvm_unreachable("bad type kind");
 }

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -4045,7 +4045,7 @@ ASTMangler::dropProtocolsFromAssociatedTypes(Type type,
   if (!OptimizeProtocolNames || !sig)
     return type;
 
-  if (!type->hasDependentMember())
+  if (!type->hasTypeParameter())
     return type;
 
   return type.transformRec([&](TypeBase *t) -> std::optional<Type> {

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -8199,6 +8199,16 @@ public:
     Printer << "_";
   }
 
+  void visitJoinType(JoinType *T,
+                     NonRecursivePrintOptions nrOptions) {
+    Printer << "∨";
+  }
+
+  void visitMeetType(MeetType *T,
+                     NonRecursivePrintOptions nrOptions) {
+    Printer << "∧";
+  }
+
   void visitIntegerType(IntegerType *T, NonRecursivePrintOptions nrOptions) {
     if (T->isNegative()) {
       Printer << "-";

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -234,7 +234,7 @@ Type swift::getDistributedActorSerializationType(
 
   // Protocols are allowed to either not provide a `SerializationRequirement`
   // at all or provide it in a conformance requirement.
-  if (resultTy->hasDependentMember() &&
+  if (resultTy->isTypeParameter() &&
       actorOrExtension->getSelfProtocolDecl()) {
     auto sig = actorOrExtension->getGenericSignatureOfContext();
 

--- a/lib/AST/ExistentialGeneralization.cpp
+++ b/lib/AST/ExistentialGeneralization.cpp
@@ -182,6 +182,8 @@ private:
   INVALID_TO_GENERALIZE(SILPack)
   INVALID_TO_GENERALIZE(SILToken)
   INVALID_TO_GENERALIZE(SILMoveOnlyWrapped)
+  INVALID_TO_GENERALIZE(Join)
+  INVALID_TO_GENERALIZE(Meet)
 #undef INVALID_TO_GENERALIZE
 
   /// Generalize the generic arguments of the given generic type.s

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -273,6 +273,8 @@ bool CanType::isReferenceTypeImpl(CanType type, const GenericSignatureImpl *sig,
   case TypeKind::BuiltinUnboundGeneric:
   case TypeKind::BuiltinFixedArray:
   case TypeKind::BuiltinBorrow:
+  case TypeKind::Join:
+  case TypeKind::Meet:
 #define REF_STORAGE(Name, ...) \
   case TypeKind::Name##Storage:
 #include "swift/AST/ReferenceStorage.def"
@@ -1849,7 +1851,17 @@ CanType TypeBase::computeCanonicalType() {
   case TypeKind::TypeVariable:
   case TypeKind::Placeholder:
   case TypeKind::BuiltinTuple:
-    llvm_unreachable("these types are always canonical");
+  case TypeKind::SILBlockStorage:
+  case TypeKind::SILBox:
+  case TypeKind::SILFunction:
+  case TypeKind::SILToken:
+  case TypeKind::SILMoveOnlyWrapped:
+  case TypeKind::Join:
+  case TypeKind::Meet:
+    ABORT([&](llvm::raw_ostream &out) {
+      out << "Should be already canonical:\n";
+      dump(out);
+    });
 
 #define SUGARED_TYPE(id, parent) \
   case TypeKind::id: \
@@ -1994,14 +2006,6 @@ CanType TypeBase::computeCanonicalType() {
     assert(Result->isCanonical());
     break;
   }
-
-  case TypeKind::SILBlockStorage:
-  case TypeKind::SILBox:
-  case TypeKind::SILFunction:
-  case TypeKind::SILToken:
-  case TypeKind::SILMoveOnlyWrapped:
-    llvm_unreachable("SIL-only types are always canonical!");
-
   case TypeKind::ProtocolComposition: {
     auto *PCT = cast<ProtocolCompositionType>(this);
     SmallVector<Type, 4> CanProtos;
@@ -4746,6 +4750,8 @@ ReferenceCounting TypeBase::getReferenceCounting() {
   case TypeKind::BuiltinUnboundGeneric:
   case TypeKind::BuiltinFixedArray:
   case TypeKind::BuiltinBorrow:
+  case TypeKind::Join:
+  case TypeKind::Meet:
 #define REF_STORAGE(Name, ...) \
   case TypeKind::Name##Storage:
 #include "swift/AST/ReferenceStorage.def"

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3893,7 +3893,6 @@ RecursiveTypeProperties ArchetypeType::archetypeProperties(
   if (superclass) {
     auto superclassProps = superclass->getRecursiveProperties();
     superclassProps.removeHasTypeParameter();
-    superclassProps.removeHasDependentMember();
     properties |= superclassProps;
   }
 
@@ -4772,7 +4771,6 @@ static RecursiveTypeProperties getBoxRecursiveProperties(
   for (auto &field : Layout->getFields()) {
     auto fieldProps = field.getLoweredType()->getRecursiveProperties();
     fieldProps.removeHasTypeParameter();
-    fieldProps.removeHasDependentMember();
     props |= fieldProps;
   }
   for (auto replacementType : subMap.getReplacementTypes()) {

--- a/lib/AST/TypeWalker.cpp
+++ b/lib/AST/TypeWalker.cpp
@@ -39,6 +39,8 @@ class Traversal : public TypeVisitor<Traversal, bool>
   bool visitPlaceholderType(PlaceholderType *ty) { return false; }
   bool visitBuiltinType(BuiltinType *ty) { return false; }
   bool visitIntegerType(IntegerType *ty) { return false; }
+  bool visitJoinType(JoinType *ty) { return false; }
+  bool visitMeetType(MeetType *ty) { return false; }
   bool visitTypeAliasType(TypeAliasType *ty) {
     if (auto parent = ty->getParent())
       if (doIt(parent)) return true;

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2157,6 +2157,8 @@ private:
   NEVER_VISIT(PackElementType)
   NEVER_VISIT(TypeVariableType)
   NEVER_VISIT(ErrorUnionType)
+  NEVER_VISIT(JoinType)
+  NEVER_VISIT(MeetType)
 
   VISIT(SugarType, recurse)
 

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1957,13 +1957,20 @@ private:
 
     // Here goes!
     switch (BaseTy->getKind()) {
+    case TypeKind::LValue:
+    case TypeKind::TypeVariable:
+    case TypeKind::ErrorUnion:
+    case TypeKind::Placeholder:
+    case TypeKind::Join:
+    case TypeKind::Meet:
+    case TypeKind::Module:
     case TypeKind::BuiltinUnboundGeneric:
-      llvm_unreachable("not a real type");
+    case TypeKind::BuiltinBorrow:
+      ABORT([&](llvm::raw_ostream &out) {
+        out << "Don't know how to emit debug info for type:\n";
+        BaseTy->dump(out);
+      });
 
-    case TypeKind::BuiltinBorrow: {
-      llvm_unreachable("todo");
-
-    }
     case TypeKind::BuiltinFixedArray: {
       if (Opts.DebugInfoLevel > IRGenDebugInfoLevel::ASTTypes) {
         auto *FixedArray = llvm::cast<swift::BuiltinFixedArrayType>(BaseTy);
@@ -2416,11 +2423,6 @@ private:
     // The following types exist primarily for internal use by the type
     // checker.
     case TypeKind::Error:
-    case TypeKind::LValue:
-    case TypeKind::TypeVariable:
-    case TypeKind::ErrorUnion:
-    case TypeKind::Placeholder:
-    case TypeKind::Module:
     case TypeKind::SILBlockStorage:
     case TypeKind::SILToken:
     case TypeKind::BuiltinUnsafeValueBuffer:

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -1875,6 +1875,15 @@ namespace {
       return emitDirectMetadataRef(type);
     }
 
+#define UNSUPPORTED_METADATA(type)                                              \
+    MetadataResponse                                                            \
+    visit##type##Type(Can##type##Type t, DynamicMetadataRequest request) {      \
+      ABORT([&](llvm::raw_ostream &out) {                                       \
+        out << "Cannot emit metadata for type:\n";                              \
+        t->dump(out);                                                           \
+      });                                                                       \
+    }
+
     MetadataResponse
     visitBuiltinIntegerLiteralType(CanBuiltinIntegerLiteralType type,
                                    DynamicMetadataRequest request) {
@@ -1934,11 +1943,7 @@ namespace {
       return emitDirectMetadataRef(type);
     }
 
-    MetadataResponse
-    visitBuiltinPackIndexType(CanBuiltinPackIndexType type,
-                              DynamicMetadataRequest request) {
-      llvm_unreachable("metadata unsupported for this builtin type");
-    }
+    UNSUPPORTED_METADATA(BuiltinPackIndex)
 
     MetadataResponse
     visitBuiltinFloatType(CanBuiltinFloatType type,
@@ -1951,12 +1956,8 @@ namespace {
                            DynamicMetadataRequest request) {
       return emitDirectMetadataRef(type);
     }
-    
-    MetadataResponse
-    visitBuiltinUnboundGenericType(CanBuiltinUnboundGenericType type,
-                                   DynamicMetadataRequest request) {
-      llvm_unreachable("not a real type");
-    }
+
+    UNSUPPORTED_METADATA(BuiltinUnboundGeneric)
 
     MetadataResponse
     visitBuiltinBorrowType(CanBuiltinBorrowType type,
@@ -1997,20 +1998,9 @@ namespace {
       return emitTypeMetadataPackRef(IGF, type, request);
     }
 
-    MetadataResponse visitSILPackType(CanSILPackType type,
-                                      DynamicMetadataRequest request) {
-      llvm_unreachable("cannot emit metadata for a SIL pack type");
-    }
-
-    MetadataResponse visitPackExpansionType(CanPackExpansionType type,
-                                            DynamicMetadataRequest request) {
-      llvm_unreachable("cannot emit metadata for a pack expansion by itself");
-    }
-
-    MetadataResponse visitPackElementType(CanPackElementType type,
-                                          DynamicMetadataRequest request) {
-      llvm_unreachable("cannot emit metadata for a pack element by itself");
-    }
+    UNSUPPORTED_METADATA(SILPack)
+    UNSUPPORTED_METADATA(PackExpansion)
+    UNSUPPORTED_METADATA(PackElement)
 
     MetadataResponse visitTupleType(CanTupleType type,
                                     DynamicMetadataRequest request) {
@@ -2022,12 +2012,7 @@ namespace {
       return setLocal(type, response);
     }
 
-    MetadataResponse visitGenericFunctionType(CanGenericFunctionType type,
-                                              DynamicMetadataRequest request) {
-      IGF.unimplemented(SourceLoc(),
-                        "metadata ref for generic function type");
-      return MetadataResponse::getUndef(IGF);
-    }
+    UNSUPPORTED_METADATA(GenericFunction)
 
     MetadataResponse visitFunctionType(CanFunctionType type,
                                        DynamicMetadataRequest request) {
@@ -2087,11 +2072,7 @@ namespace {
       return setLocal(type, MetadataResponse::forComplete(call));
     }
 
-    MetadataResponse visitModuleType(CanModuleType type,
-                                     DynamicMetadataRequest request) {
-      IGF.unimplemented(SourceLoc(), "metadata ref for module type");
-      return MetadataResponse::getUndef(IGF);
-    }
+    UNSUPPORTED_METADATA(Module)
 
     MetadataResponse visitDynamicSelfType(CanDynamicSelfType type,
                                           DynamicMetadataRequest request) {
@@ -2278,31 +2259,22 @@ namespace {
       return setLocal(type, MetadataResponse::forComplete(metadata));
     }
 
-    MetadataResponse
-    visitParameterizedProtocolType(CanParameterizedProtocolType type,
-                                   DynamicMetadataRequest request) {
-      llvm_unreachable("constraint type should be wrapped in existential type");
-    }
 
-    MetadataResponse visitReferenceStorageType(CanReferenceStorageType type,
-                                               DynamicMetadataRequest request) {
-      llvm_unreachable("reference storage type should have been converted by "
-                       "SILGen");
-    }
-    MetadataResponse visitSILFunctionType(CanSILFunctionType type,
-                                          DynamicMetadataRequest request) {
-      llvm_unreachable("should not be asking for metadata of a lowered SIL "
-                       "function type--SILGen should have used the AST type");
-    }
-    MetadataResponse visitSILTokenType(CanSILTokenType type,
-                                          DynamicMetadataRequest request) {
-      llvm_unreachable("should not be asking for metadata of a SILToken type");
-    }
-    MetadataResponse
-    visitSILMoveOnlyWrappedType(CanSILMoveOnlyWrappedType type,
-                                DynamicMetadataRequest request) {
-      llvm_unreachable("should not be asking for metadata of a move only type");
-    }
+    UNSUPPORTED_METADATA(ParameterizedProtocol)
+    UNSUPPORTED_METADATA(ReferenceStorage)
+    UNSUPPORTED_METADATA(SILFunction)
+    UNSUPPORTED_METADATA(SILToken)
+    UNSUPPORTED_METADATA(SILMoveOnlyWrapped)
+    UNSUPPORTED_METADATA(GenericTypeParam)
+    UNSUPPORTED_METADATA(DependentMember)
+    UNSUPPORTED_METADATA(LValue)
+    UNSUPPORTED_METADATA(InOut)
+    UNSUPPORTED_METADATA(Error)
+    UNSUPPORTED_METADATA(Integer)
+    UNSUPPORTED_METADATA(SILBlockStorage)
+    UNSUPPORTED_METADATA(BuiltinDefaultActorStorage)
+    UNSUPPORTED_METADATA(BuiltinNonDefaultDistributedActorStorage)
+
     MetadataResponse visitArchetypeType(CanArchetypeType type,
                                         DynamicMetadataRequest request) {
       if (auto packArchetypeType = dyn_cast<PackArchetypeType>(type))
@@ -2310,46 +2282,6 @@ namespace {
 
       return emitArchetypeTypeMetadataRef(IGF, type, request);
     }
-
-    MetadataResponse visitGenericTypeParamType(CanGenericTypeParamType type,
-                                               DynamicMetadataRequest request) {
-      llvm_unreachable("dependent type should have been substituted by Sema or SILGen");
-    }
-
-    MetadataResponse visitDependentMemberType(CanDependentMemberType type,
-                                              DynamicMetadataRequest request) {
-      llvm_unreachable("dependent type should have been substituted by Sema or SILGen");
-    }
-
-    MetadataResponse visitLValueType(CanLValueType type,
-                                     DynamicMetadataRequest request) {
-      llvm_unreachable("lvalue type should have been lowered by SILGen");
-    }
-    MetadataResponse visitInOutType(CanInOutType type,
-                                    DynamicMetadataRequest request) {
-      llvm_unreachable("inout type should have been lowered by SILGen");
-    }
-    MetadataResponse visitErrorType(CanErrorType type,
-                                    DynamicMetadataRequest request) {
-      llvm_unreachable("error type should not appear in IRGen");
-    }
-
-    MetadataResponse visitIntegerType(CanIntegerType type,
-                                      DynamicMetadataRequest request) {
-      llvm_unreachable("integer type should not appear in IRGen");
-    }
-
-    // These types are artificial types used for internal purposes and
-    // should never appear in a metadata request.
-#define INTERNAL_ONLY_TYPE(ID)                                               \
-    MetadataResponse visit##ID##Type(Can##ID##Type type,                     \
-                                     DynamicMetadataRequest request) {       \
-      llvm_unreachable("cannot ask for metadata of compiler-internal type"); \
-    }
-    INTERNAL_ONLY_TYPE(SILBlockStorage)
-    INTERNAL_ONLY_TYPE(BuiltinDefaultActorStorage)
-    INTERNAL_ONLY_TYPE(BuiltinNonDefaultDistributedActorStorage)
-#undef INTERNAL_ONLY_TYPE
 
     MetadataResponse visitSILBoxType(CanSILBoxType type,
                                      DynamicMetadataRequest request) {
@@ -2367,6 +2299,8 @@ namespace {
       IGF.setScopedLocalTypeMetadata(type, response);
       return response;
     }
+
+#undef UNSUPPORTED_METADATA
   };
 } // end anonymous namespace
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -9287,9 +9287,6 @@ applySolutionToInitialization(SyntacticElementTarget target, Expr *initializer,
       finalPatternType = computeWrappedValueType(wrappedVar, finalPatternType);
   }
 
-  if (finalPatternType->hasDependentMember())
-    return std::nullopt;
-
   finalPatternType = finalPatternType->reconstituteSugar(/*recursive =*/false);
 
   auto tryRewritePattern = [&](Pattern *EP, Type ty) {

--- a/lib/Sema/CSOptimizer.cpp
+++ b/lib/Sema/CSOptimizer.cpp
@@ -762,7 +762,7 @@ static std::optional<DisjunctionInfo> preserveFavoringOfUnlabeledUnaryArgument(
 
   ASSERT(argumentType);
 
-  if (argumentType->hasTypeVariable() || argumentType->hasDependentMember())
+  if (argumentType->hasTypeVariable())
     return DisjunctionInfo::none();
 
   SmallVector<Constraint *, 2> favoredChoices;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -7383,7 +7383,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
     case ConstraintKind::BridgingConversion:
     case ConstraintKind::CheckedCast:
     case ConstraintKind::SubclassOf:
-  case ConstraintKind::NonisolatedConformsTo:
+    case ConstraintKind::NonisolatedConformsTo:
     case ConstraintKind::ConformsTo:
     case ConstraintKind::TransitivelyConformsTo:
     case ConstraintKind::Defaultable:
@@ -7506,17 +7506,21 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
   if (desugar1->getKind() == desugar2->getKind()) {
     switch (desugar1->getKind()) {
 #define SUGARED_TYPE(id, parent) case TypeKind::id:
-#define TYPE(id, parent)
-#include "swift/AST/TypeNodes.def"
-      llvm_unreachable("Type has not been desugared completely");
-
 #define ARTIFICIAL_TYPE(id, parent) case TypeKind::id:
 #define TYPE(id, parent)
 #include "swift/AST/TypeNodes.def"
-      llvm_unreachable("artificial type in constraint");
-
     case TypeKind::BuiltinTuple:
-      llvm_unreachable("BuiltinTupleType in constraint");
+    case TypeKind::Join:
+    case TypeKind::Meet:
+    case TypeKind::Error:
+    case TypeKind::GenericTypeParam:
+    case TypeKind::TypeVariable:
+    case TypeKind::GenericFunction:
+    case TypeKind::UnboundGeneric:
+      ABORT([&](llvm::raw_ostream &out) {
+        out << "Bad type in matchTypes():\n";
+        desugar1->dump(out);
+      });
 
     // Mismatched builtin types
 #define BUILTIN_GENERIC_TYPE(id, parent)
@@ -7524,9 +7528,6 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
 #define TYPE(id, parent)
 #include "swift/AST/TypeNodes.def"
       return getTypeMatchFailure(locator);
-
-    case TypeKind::Error:
-      llvm_unreachable("Rejected above");
 
     // BuiltinGenericType subclasses
     case TypeKind::BuiltinBorrow:
@@ -7563,12 +7564,6 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
 
       return getTypeMatchFailure(locator);
     }
-
-    case TypeKind::GenericTypeParam:
-      llvm_unreachable("unmapped dependent type in type checker");
-
-    case TypeKind::TypeVariable:
-      llvm_unreachable("type variables should have already been handled by now");
 
     case TypeKind::DependentMember: {
       // If types are identical, let's consider this constraint solved
@@ -7860,9 +7855,6 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       return result;
     }
 
-    case TypeKind::GenericFunction:
-      llvm_unreachable("Polymorphic function type should have been opened");
-
     case TypeKind::Existential:
     case TypeKind::ProtocolComposition:
     case TypeKind::ParameterizedProtocol:
@@ -7909,9 +7901,6 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
                         cast<InOutType>(desugar2)->getObjectType(),
                         ConstraintKind::Bind, subflags,
                   locator.withPathElement(ConstraintLocator::LValueConversion));
-
-    case TypeKind::UnboundGeneric:
-      llvm_unreachable("Unbound generic type should have been opened");
 
     case TypeKind::BoundGenericClass:
     case TypeKind::BoundGenericEnum:
@@ -8534,25 +8523,24 @@ ConstraintSystem::simplifyConstructionConstraint(
 
   switch (desugarValueType->getKind()) {
 #define SUGARED_TYPE(id, parent) case TypeKind::id:
-#define TYPE(id, parent)
-#include "swift/AST/TypeNodes.def"
-    llvm_unreachable("Type has not been desugared completely");
-
 #define ARTIFICIAL_TYPE(id, parent) case TypeKind::id:
 #define TYPE(id, parent)
 #include "swift/AST/TypeNodes.def"
-      llvm_unreachable("artificial type in constraint");
-
   case TypeKind::BuiltinTuple:
-    llvm_unreachable("BuiltinTupleType in constraint");
+  case TypeKind::GenericFunction:
+  case TypeKind::GenericTypeParam:
+  case TypeKind::UnboundGeneric:
+  case TypeKind::Integer:
+  case TypeKind::Join:
+  case TypeKind::Meet:
+    ABORT([&](llvm::raw_ostream &out) {
+      out << "Bad type in simplifyConstructionConstraint():\n";
+      desugarValueType->dump(out);
+    });
     
   case TypeKind::Error:
   case TypeKind::Placeholder:
     return SolutionKind::Error;
-
-  case TypeKind::GenericFunction:
-  case TypeKind::GenericTypeParam:
-    llvm_unreachable("unmapped dependent type");
 
   case TypeKind::TypeVariable:
   case TypeKind::DependentMember:
@@ -8636,9 +8624,6 @@ ConstraintSystem::simplifyConstructionConstraint(
     // Break out to handle the actual construction below.
     break;
 
-  case TypeKind::UnboundGeneric:
-    llvm_unreachable("Unbound generic type should have been opened");
-
 #define BUILTIN_TYPE(id, parent) case TypeKind::id:
 #define TYPE(id, parent)
 #include "swift/AST/TypeNodes.def"
@@ -8657,10 +8642,6 @@ ConstraintSystem::simplifyConstructionConstraint(
       break;
 
     return SolutionKind::Error;
-  }
-
-  case TypeKind::Integer: {
-    llvm_unreachable("implement me");
   }
   }
 

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -735,7 +735,7 @@ static bool canSynthesizeDistributedThunk(AbstractFunctionDecl *distributedTarge
 
   auto serializationTy =
       getDistributedActorSerializationType(distributedTarget->getDeclContext());
-  return !serializationTy->hasError() && !serializationTy->hasDependentMember();
+  return !serializationTy->hasError() && !serializationTy->isTypeParameter();
 }
 
 /******************************************************************************/

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1077,7 +1077,7 @@ Type ConstraintSystem::getFixedTypeRecursive(Type type, TypeMatchOptions &flags,
 
   if (auto depMemType = type->getAs<DependentMemberType>()) {
     auto baseTy = depMemType->getBase();
-    if (!baseTy->hasTypeVariable() && !baseTy->hasDependentMember())
+    if (!baseTy->hasTypeVariable())
       return type;
 
     // FIXME: Perform a more limited simplification?

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -5743,7 +5743,7 @@ public:
                                   S.addTypeRef(ty->getOriginalType()));
       return;
     }
-    llvm_unreachable("should not serialize an ErrorType");
+    ABORT("should not serialize an ErrorType");
   }
 
   void visitPlaceholderType(const PlaceholderType *) {
@@ -5754,28 +5754,26 @@ public:
           cast<ErrorType>(ErrorType::get(S.getASTContext()).getPointer()));
       return;
     }
-    llvm_unreachable("should not serialize a PlaceholderType");
+    ABORT("should not serialize a PlaceholderType");
   }
 
-  void visitModuleType(const ModuleType *) {
-    llvm_unreachable("modules are currently not first-class values");
-  }
+#define UNSUPPORTED_TYPE(type)                                                  \
+    void visit##type##Type(const type##Type *t) {                               \
+      ABORT([&](llvm::raw_ostream &out) {                                       \
+        out << "Don't know how to serialize this kind of type:\n";              \
+        t->dump(out);                                                           \
+      });                                                                       \
+    }
 
-  void visitInOutType(const InOutType *) {
-    llvm_unreachable("inout types are only used in function type parameters");
-  }
+  UNSUPPORTED_TYPE(Module)
+  UNSUPPORTED_TYPE(InOut)
+  UNSUPPORTED_TYPE(LValue)
+  UNSUPPORTED_TYPE(TypeVariable)
+  UNSUPPORTED_TYPE(ErrorUnion)
+  UNSUPPORTED_TYPE(Join)
+  UNSUPPORTED_TYPE(Meet)
 
-  void visitLValueType(const LValueType *) {
-    llvm_unreachable("lvalue types are only used in function bodies");
-  }
-
-  void visitTypeVariableType(const TypeVariableType *) {
-    llvm_unreachable("type variables should not escape the type checker");
-  }
-
-  void visitErrorUnionType(const ErrorUnionType *) {
-    llvm_unreachable("error union types do not persist in the AST");
-  }
+#undef UNSUPPORTED_TYPE
 
   void visitLocatableType(const LocatableType *LT) {
     visit(LT->getSinglyDesugaredType());

--- a/test/Constraints/binding_order.swift
+++ b/test/Constraints/binding_order.swift
@@ -1,4 +1,11 @@
 // RUN: %target-typecheck-verify-swift -verify-ignore-unrelated
+// RUN: not --crash %target-typecheck-verify-swift -verify-ignore-unrelated -DSALVAGE
+
+// The next two sets of examples cause difficulties because our
+// subtype lattice is not distributive. We cannot always compute
+// an accurate upper bound, because of existential types; if
+// we pick the wrong upper bound too early, certain expressions
+// will fail.
 
 // Originally from rdar://35088384:
 //
@@ -54,6 +61,39 @@ do {
   perform4([Undo.self, Cut.self, Copy.self])
 }
 
+// rdar://problem/38159133
+// https://github.com/apple/swift/issues/49673
+// Swift 4.1 Xcode 9.3b4 regression
+
+do {
+  protocol Command {}
+
+  class Super {}
+  class A: Super, Command {}
+  class B: Super, Command {}
+
+  func rdar38159133(a: A, b: B, aOpt: A?, bOpt: B?) {
+    let _ = Array<any Command>([a, b])
+    let _: [any Command] = [a, b]
+    let _: [any Command] = Array([a, b])
+    let _: [any Command] = [a, b].filter { _ in true }
+    let _: [any Command] = [aOpt, bOpt].compactMap { $0 }
+
+    // Some of these might be hard to resolve, but we should produce better diagnostics.
+
+    let _: [any Command] = [aOpt, bOpt].filter { $0 != nil }
+    // expected-error@-1 {{no exact matches in call to instance method 'filter'}}
+    let _: [any Command] = [a, b].map { $0 }
+    // expected-error@-1 {{failed to produce diagnostic for expression}}
+    let _: [any Command] = [a, b].flatMap { [$0] }
+    // expected-error@-1 {{cannot convert value of type 'Super' to expected element type 'any Command'}}
+
+    #if SALVAGE
+    let _: [any Command] = [[a], [b]].flatMap { $0 }
+    #endif
+  }
+}
+
 do {
   // This works!
   let _: [ObjectIdentifier: Bool] = .init(uniqueKeysWithValues: [
@@ -94,22 +134,6 @@ do {
   let _: Dictionary<Double, StaticString> = .init(uniqueKeysWithValues: [(10, "hello"), (20, "world")])
 }
 
-// rdar://problem/38159133
-// https://github.com/apple/swift/issues/49673
-// Swift 4.1 Xcode 9.3b4 regression
-
-protocol P_38159133 {}
-
-do {
-  class Super {}
-  class A: Super, P_38159133 {}
-  class B: Super, P_38159133 {}
-
-  func rdar38159133(_ a: A?, _ b: B?) {
-    let _: [P_38159133] = [a, b].compactMap { $0 } // Ok
-  }
-}
-
 // Tests for a special form of inference where we have both a
 // subtype and a supertype binding for a type variable, and the
 // subtype binding contains a type variable but the supertype
@@ -132,6 +156,105 @@ do {
     let _: [(String, String)] = v + Array(v)
     let _: [(String, String)] = Array(v) + v
     let _: [(String, String)] = Array(v) + Array(v)
+  }
+}
+
+protocol P {}
+
+extension String: P {}
+extension Int: P {}
+extension Optional: P where Wrapped: P {}
+
+do {
+  class C {
+    var string = ""
+    var integer = 0
+    var data = Data()
+    var optData: Data? = nil
+    var optOptData: Data?? = nil
+    var dictionary: [AnyHashable: Any]? = nil
+
+    static func _data(_: [AnyHashable: Any]?) -> Data {
+      return Data()
+    }
+
+    static func _optData(_: [AnyHashable: Any]?) -> Data? {
+      return nil
+    }
+  }
+
+  struct Data: P {}
+
+  func f1<T: Collection, U: Collection>(_: T)
+    where T.Element == U, U.Element == any P {}
+  // expected-note@-2 5{{where 'U.Element' = 'Any'}}
+
+  func test1(_ elts: [C]) {
+    f1(elts.map { c in [c.string] })
+
+    f1(elts.map { c in [c.string, c.integer] })
+    // expected-error@-1 {{local function 'f1' requires the types 'Any' and 'any P' be equivalent}}
+
+    f1(elts.map { c in [c.string, c.integer, c.data] })
+    // expected-error@-1 {{local function 'f1' requires the types 'Any' and 'any P' be equivalent}}
+
+    f1(elts.map { c in [c.string, c.integer, c.optData] })
+    // expected-error@-1 {{local function 'f1' requires the types 'Any' and 'any P' be equivalent}}
+
+    f1(elts.map { c in [c.string, c.integer, c.optOptData] })
+
+    f1(elts.map { c in [c.string, c.integer, c.data, c.optData] })
+    // expected-error@-1 {{local function 'f1' requires the types 'Any' and 'any P' be equivalent}}
+
+    f1(elts.map { c in [c.string, c.integer, c.data, c.optData, c.optOptData] })
+
+    f1(elts.map { c in [c.string, c.integer, c.dictionary.map { C._data($0) }] })
+    // expected-error@-1 {{local function 'f1' requires the types 'Any' and 'any P' be equivalent}}
+
+    f1(elts.map { c in [c.string, c.integer, c.dictionary.map { C._optData($0) }] })
+  }
+
+  struct Literal: ExpressibleByStringInterpolation {
+    init(stringInterpolation: Interpolation) {}
+    init(stringLiteral: String) {}
+
+    struct Interpolation: StringInterpolationProtocol {
+      typealias StringLiteralType = String
+
+      init(literalCapacity: Int, interpolationCount: Int) {}
+
+      func appendLiteral(_: String) {}
+      func appendInterpolation<T: Collection, U: Collection>(_: T)
+        where T.Element == U, U.Element == any P {}
+        // expected-note@-2 5{{where 'U.Element' = 'Any'}}
+    }
+  }
+
+  func f2(_: Literal) {}
+
+  func test2(_ elts: [C]) {
+    f2("\(elts.map { c in [c.string] })")
+
+    f2("\(elts.map { c in [c.string, c.integer] })")
+    // expected-error@-1 {{instance method 'appendInterpolation' requires the types 'Any' and 'any P' be equivalent}}
+
+    f2("\(elts.map { c in [c.string, c.integer, c.data] })")
+    // expected-error@-1 {{instance method 'appendInterpolation' requires the types 'Any' and 'any P' be equivalent}}
+
+    f2("\(elts.map { c in [c.string, c.integer, c.optData] })")
+    // expected-error@-1 {{instance method 'appendInterpolation' requires the types 'Any' and 'any P' be equivalent}}
+
+    f2("\(elts.map { c in [c.string, c.integer, c.optOptData ] })")
+
+    f2("\(elts.map { c in [c.string, c.integer, c.data, c.optData] })")
+    // expected-error@-1 {{instance method 'appendInterpolation' requires the types 'Any' and 'any P' be equivalent}}
+
+    f2("\(elts.map { c in [c.string, c.integer, c.data, c.optData, c.optOptData] })")
+
+    f2("\(elts.map { c in [c.string, c.integer, c.dictionary.map { C._data($0) }] })")
+    // expected-error@-1 {{instance method 'appendInterpolation' requires the types 'Any' and 'any P' be equivalent}}
+
+    f2("\(elts.map { c in [c.string, c.integer, c.dictionary.map { C._optData($0) }] })")
   }
 }
 

--- a/test/Constraints/issue-87300.swift
+++ b/test/Constraints/issue-87300.swift
@@ -15,6 +15,11 @@ do {
   let _: String = result
 }
 
+do {
+  let result = f(t: T.self)
+  let _: String = result
+}
+
 struct S: ~Copyable {}
 
 do {

--- a/validation-test/IDE/crashers_fixed/RewriteContext-getMutableTermForType-f98762.swift
+++ b/validation-test/IDE/crashers_fixed/RewriteContext-getMutableTermForType-f98762.swift
@@ -1,5 +1,5 @@
 // {"kind":"complete","signature":"swift::rewriting::RewriteContext::getMutableTermForType(swift::CanType, swift::ProtocolDecl const*)","signatureAssert":"Assertion failed: (paramType->isTypeParameter()), function getMutableTermForType","signatureNext":"RequirementMachine::isValidTypeParameter"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
 protocol a { associatedtype b }
 protocol c { associatedtype b }
 extension c { compose<d where d ==a, d.b == b { #^COMPLETE^#


### PR DESCRIPTION
These will be used internally by bindings to represent joins and meets of concrete types with type variables. For now, it's unused.

To free up a bit in the RecursiveTypeProperties, I removed `hasDependentMember()`, which seems to be no longer necessary.

Also add some unrelated type checker tests while we're here to save CI cycles.