### PR TITLE
[Macro][Caching] Improve macro plugin verification

### DIFF
--- a/lib/AST/PluginLoader.cpp
+++ b/lib/AST/PluginLoader.cpp
@@ -120,10 +120,16 @@ PluginLoader::getPluginMap() {
       return remappedPath;
 
     auto currentStat = fs->status(remappedPath);
+    auto goldStat = Ctx.SourceMgr.getFileSystem()->status(path);
+    // If both scanner and compiler cannot find the plugin, ignore the error and
+    // let plugin loader to diagnose since missing the plugin is just a warning
+    // from swift-frontend.
+    if (!goldStat && !currentStat)
+      return remappedPath;
+
     if (!currentStat)
       return llvm::createFileError(remappedPath, currentStat.getError());
 
-    auto goldStat = Ctx.SourceMgr.getFileSystem()->status(path);
     if (!goldStat)
       return llvm::createStringError(
           "cannot open gold reference library to compare");

--- a/test/CAS/macro_plugin.swift
+++ b/test/CAS/macro_plugin.swift
@@ -17,7 +17,9 @@
 
 // RUN: %target-swift-frontend-plain -scan-dependencies -module-load-mode prefer-serialized -module-name MyApp -module-cache-path %t/clang-module-cache -O \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
-// RUN:   %s -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas -load-plugin-library %t/plugins/%target-library-name(MacroDefinition)
+// RUN:   %s -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas \
+// RUN:   -load-plugin-library %t/plugins/%target-library-name(MacroDefinition) \
+// RUN:   -load-plugin-library %t/plugins/%target-library-name(NonExisting)
 
 // RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json MyApp casFSRootID > %t/fs.casid
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-include-tree-list @%t/fs.casid | %FileCheck %s --check-prefix=FS
@@ -28,12 +30,15 @@
 // RUN: %target-swift-frontend-plain \
 // RUN:   -typecheck -verify -cache-compile-job -cas-path %t/cas \
 // RUN:   -swift-version 5 -module-name MyApp -O \
-// RUN:   -load-plugin-library %t/plugins/%target-library-name(MacroDefinition) \
+// RUN:   -resolved-plugin-verification \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   %s @%t/MyApp.cmd
 
 @attached(extension, conformances: P, names: named(requirement))
 macro DelegatedConformance() = #externalMacro(module: "MacroDefinition", type: "DelegatedConformanceViaExtensionMacro")
+
+@attached(extension, conformances: P, names: named(requirement))
+macro NonExisting() = #externalMacro(module: "NonExisting", type: "DelegatedConformanceViaExtensionMacro") // expected-warning {{external macro implementation type 'NonExisting.DelegatedConformanceViaExtensionMacro' could not be found for macro 'NonExisting()'; plugin for module 'NonExisting' not found}}
 
 protocol P {
   static func requirement()


### PR DESCRIPTION
In order to achieve sound caching, plugin loader double checks the plugin loaded is the same as what dependency scanner sees during compilation. However, user can pass a non-existing macro plugin to the compiler and that should trigger a warning during compilation. Improve the plugin verification to handle the case where the plugin is passed but missing on the file system.

rdar://172930632

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
