### PR TITLE
Relax this test to accomodate changes between Python 3.9 and 3.14

### DIFF
--- a/benchmark/scripts/test_compare_perf_tests.py
+++ b/benchmark/scripts/test_compare_perf_tests.py
@@ -838,7 +838,7 @@ class Test_parse_args(unittest.TestCase):
     def test_required_input_arguments(self):
         with captured_output() as (_, err):
             self.assertRaises(SystemExit, parse_args, [])
-        self.assertIn("usage: compare_perf_tests.py", err.getvalue())
+        self.assertIn("usage:", err.getvalue())
 
         args = parse_args(self.required)
         self.assertEqual(args.old_file, "old.log")


### PR DESCRIPTION
It seems that unittest changed between Python 3.9 and Python 3.14 to alter how argument parsing tests work.

In Python 3.14, the argument parsing tests see
```
usage: python3.14 -m unittest [-h] --old-file OLD_FILE --new-file NEW_FILE [--format {markdown,git,html}] [--output OUTPUT] [--changes-only] [--single-table]
```

Instead of the message in Python 3.9:
```
usage: test_compare_perf_tests.py [-h] --old-file OLD_FILE --new-file NEW_FILE [--format {markdown,git,html}] [--output OUTPUT] [--changes-only] [--single-table]
```

What we really need here is just a check that the usage string is being printed; we can get that by checking for just `usage:`.