### PR TITLE
[rbi] Expand d38c759afc8d0e93c12d9a8d5217dae0d5bd37cb so we handle getFromConformance in the same way.

### DIFF
--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -208,22 +208,9 @@ public:
     return ActorIsolation(Erased);
   }
 
-  static std::optional<ActorIsolation> forSILString(StringRef string) {
-    auto kind =
-        llvm::StringSwitch<std::optional<ActorIsolation::Kind>>(string)
-            .Case("unspecified", ActorIsolation::Unspecified)
-            .Case("actor_instance", ActorIsolation::ActorInstance)
-            .Case("nonisolated", ActorIsolation::Nonisolated)
-            .Case("nonisolated_unsafe", ActorIsolation::NonisolatedUnsafe)
-            .Case("global_actor", ActorIsolation::GlobalActor)
-            .Case("global_actor_unsafe", ActorIsolation::GlobalActor)
-            .Case("caller_isolation_inheriting",
-                  ActorIsolation::CallerIsolationInheriting)
-            .Default(std::nullopt);
-    if (kind == std::nullopt)
-      return std::nullopt;
-    return ActorIsolation(*kind, true /*is sil parsed*/);
-  }
+  /// Defined in lib/SIL/IR/ActorIsolation.cpp
+  static std::optional<ActorIsolation> forSILString(SILModule &mod,
+                                                    StringRef string);
 
   Kind getKind() const { return (Kind)kind; }
 

--- a/lib/AST/ActorIsolation.cpp
+++ b/lib/AST/ActorIsolation.cpp
@@ -15,6 +15,8 @@
 #include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Expr.h"
+#include "swift/AST/NameLookup.h"
+#include "swift/AST/NameLookupRequests.h"
 
 using namespace swift;
 

--- a/lib/SIL/IR/ActorIsolation.cpp
+++ b/lib/SIL/IR/ActorIsolation.cpp
@@ -1,0 +1,61 @@
+//===--- ActorIsolation.cpp -----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/ActorIsolation.h"
+#include "swift/AST/NameLookup.h"
+#include "swift/AST/NameLookupRequests.h"
+#include "swift/SIL/SILModule.h"
+
+using namespace swift;
+
+static std::optional<ActorIsolation>
+getIsolationForExplicitActor(SILModule &mod, StringRef string) {
+  auto &ctx = mod.getASTContext();
+
+  if (!string.starts_with("global_actor(") || !string.ends_with(")"))
+    return {};
+
+  auto actor =
+      string.drop_front(StringLiteral("global_actor(").size()).drop_back();
+  auto declName = DeclName(ctx.getIdentifier(actor));
+  auto descriptor = UnqualifiedLookupDescriptor(
+      DeclNameRef(declName), mod.getSwiftModule(), SourceLoc(),
+      UnqualifiedLookupFlags::TypeLookup);
+  auto lookup = evaluateOrDefault(ctx.evaluator,
+                                  UnqualifiedLookupRequest{descriptor}, {});
+  if (lookup.size() != 1)
+    return {};
+
+  auto *decl = dyn_cast<NominalTypeDecl>(lookup.back().getValueDecl());
+  if (!decl || !decl->isGlobalActor())
+    return {};
+  return ActorIsolation::forGlobalActor(decl->getDeclaredType());
+}
+
+std::optional<ActorIsolation> ActorIsolation::forSILString(SILModule &mod,
+                                                           StringRef string) {
+  if (auto result = getIsolationForExplicitActor(mod, string))
+    return result;
+  auto kind = llvm::StringSwitch<std::optional<ActorIsolation::Kind>>(string)
+                  .Case("unspecified", ActorIsolation::Unspecified)
+                  .Case("actor_instance", ActorIsolation::ActorInstance)
+                  .Case("nonisolated", ActorIsolation::Nonisolated)
+                  .Case("nonisolated_unsafe", ActorIsolation::NonisolatedUnsafe)
+                  .Case("global_actor", ActorIsolation::GlobalActor)
+                  .Case("global_actor_unsafe", ActorIsolation::GlobalActor)
+                  .Case("caller_isolation_inheriting",
+                        ActorIsolation::CallerIsolationInheriting)
+                  .Default(std::nullopt);
+  if (kind == std::nullopt)
+    return std::nullopt;
+  return ActorIsolation(*kind, true /*is sil parsed*/);
+}

--- a/lib/SIL/IR/CMakeLists.txt
+++ b/lib/SIL/IR/CMakeLists.txt
@@ -1,5 +1,6 @@
 target_sources(swiftSIL PRIVATE
   AbstractionPattern.cpp
+  ActorIsolation.cpp
   ApplySite.cpp
   Bridging.cpp
   Linker.cpp

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -3794,9 +3794,8 @@ void SILFunction::print(SILPrintContext &PrintCtx) const {
     OS << "[available " << availability.getVersionString() << "] ";
   }
 
-  // This is here only for testing purposes.
-  if (SILPrintFunctionIsolationInfo) {
-    if (auto isolation = getActorIsolation()) {
+  if (auto isolation = getActorIsolation()) {
+    if (isolation->isSILParsed() || SILPrintFunctionIsolationInfo) {
       OS << "[isolation \"";
       isolation->printForSIL(OS);
       OS << "\"] ";

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -812,7 +812,7 @@ static bool parseDeclSILOptional(
       // representation of an actor that can be parsed back. For now this is
       // just a quick hack so we can write tests.
       auto optIsolation = ActorIsolation::forSILString(
-          SP.P.Context.getIdentifier(rawString).str());
+          M, SP.P.Context.getIdentifier(rawString).str());
       if (!optIsolation) {
         SP.P.diagnose(SP.P.Tok, diag::expected_in_attribute_list);
         return true;
@@ -6974,8 +6974,8 @@ bool SILParser::parseCallInstruction(SILLocation InstLoc,
     }
 
     if (AttrName == "callee_isolation") {
-      auto applyIsolation =
-          ActorIsolation::forSILString(std::get<StringRef>(*AttrValue));
+      auto applyIsolation = ActorIsolation::forSILString(
+          B.getModule(), std::get<StringRef>(*AttrValue));
       if (!applyIsolation) {
         P.diagnose(AttrValueLoc, diag::expected_in_attribute_list);
         return true;
@@ -6987,8 +6987,8 @@ bool SILParser::parseCallInstruction(SILLocation InstLoc,
     }
 
     if (AttrName == "caller_isolation") {
-      auto applyIsolation =
-          ActorIsolation::forSILString(std::get<StringRef>(*AttrValue));
+      auto applyIsolation = ActorIsolation::forSILString(
+          B.getModule(), std::get<StringRef>(*AttrValue));
       if (!applyIsolation) {
         P.diagnose(AttrValueLoc, diag::expected_in_attribute_list);
         return true;

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -1139,6 +1139,24 @@ SILIsolationInfo SILIsolationInfo::getFromConformances(
       if (sendableMetatype &&
           lookupConformance(conformance.getType(), sendableMetatype,
                             /*allowMissing=*/false).isInvalid()) {
+        if (auto functionIsolation =
+                value->getFunction()->getActorIsolation()) {
+          if (functionIsolation->isGlobalActor()) {
+            return SILIsolationInfo::getGlobalActorIsolated(
+                value, functionIsolation->getGlobalActor(),
+                conformance.getProtocol());
+          }
+          if (functionIsolation->isActorInstanceIsolated()) {
+            if (auto isolatedParam = cast_or_null<SILFunctionArgument>(
+                    value->getFunction()->maybeGetIsolatedArgument())) {
+              if (auto result = SILIsolationInfo::getActorInstanceIsolated(
+                      value, isolatedParam, conformance.getProtocol())) {
+                return result;
+              }
+            }
+          }
+        }
+
         return SILIsolationInfo::getTaskIsolated(value,
                                                  conformance.getProtocol());
       }
@@ -1240,7 +1258,7 @@ SILIsolationInfo SILIsolationInfo::getConformanceIsolation(SILInstruction *inst)
 
 void SILIsolationInfo::printOptions(llvm::raw_ostream &os) const {
   if (isolatedConformance) {
-    os << "isolated-conformance-to(" << isolatedConformance->getName() << ")";
+    os << " isolated-conformance-to(" << isolatedConformance->getName() << ")";
   }
 
   auto opts = getOptions();
@@ -2029,5 +2047,24 @@ static FunctionTest IsolationMergeTest(
       }
       llvm::outs() << "\n";
     });
+
+// Arguments:
+// - SILValue: value to look up isolation for.
+// Dumps:
+// - The inferred isolation.
+static FunctionTest
+    GetConformanceIsolationInferrence("sil_isolation_info_get_conformance_isolation_inferrence",
+                            [](auto &function, auto &arguments, auto &test) {
+                              auto value = arguments.takeValue();
+
+                              SILIsolationInfo info =
+                                SILIsolationInfo::getConformanceIsolation(cast<SingleValueInstruction>(value));
+                              llvm::outs() << "Input Value: " << *value;
+                              llvm::outs() << "Isolation: ";
+                              info.printForOneLineLogging(&function,
+                                                          llvm::outs());
+                              llvm::outs() << "\n";
+                            });
+
 
 } // namespace swift::test

--- a/test/Concurrency/silisolationinfo_inference.sil
+++ b/test/Concurrency/silisolationinfo_inference.sil
@@ -121,6 +121,12 @@ sil @useOptionalAnyActorWithParam : $@convention(thin) (@sil_isolated @guarantee
 
 sil [isolation "actor_instance"] @unappliedIsolatedAnyParameter : $@convention(method) @async (@sil_isolated @guaranteed Optional<any Actor>, @guaranteed NonSendableKlass) -> @owned NonSendableKlass
 
+@objc protocol MyObjCProtocol {
+}
+
+protocol MyProtocol {
+}
+
 ///////////////////////
 // MARK: Basic Tests //
 ///////////////////////
@@ -2123,4 +2129,61 @@ bb0(%0 : @guaranteed $Builtin.ImplicitActor, %1 : @guaranteed $NonSendableKlass)
   dealloc_stack %stack : $*NonSendableKlass
   %9999 = tuple ()
   return %9999 : $()
+}
+
+//////////////////////////////////////////
+// MARK: Isolated Conformance Inference //
+//////////////////////////////////////////
+
+// These currently use a different entrypoint to merge in the information. It
+// should be changed to use ::get like everything else, but this is ok for now.
+
+// CHECK-LABEL: begin running test 1 of 1 on init_existential_ref_get_conformance_test_globalactor: sil_isolation_info_get_conformance_isolation_inferrence with: @trace[0]
+// CHECK-NEXT: Input Value:   %3 = init_existential_ref %2 : $Self : $Self, $any MyObjCProtocol // user: %4
+// CHECK-NEXT: Isolation: global actor 'CustomActor'-isolated isolated-conformance-to(MyObjCProtocol)
+// CHECK-NEXT: end running test 1 of 1 on init_existential_ref_get_conformance_test_globalactor: sil_isolation_info_get_conformance_isolation_inferrence with: @trace[0]
+sil [isolation "global_actor(CustomActor)"] [ossa] @init_existential_ref_get_conformance_test_globalactor : $@convention(method) <Self where Self : MyObjCProtocol> (@guaranteed Self) -> () {
+bb0(%0 : @guaranteed $Self):
+  specify_test "sil_isolation_info_get_conformance_isolation_inferrence @trace[0]"
+  debug_value %0, let, name "self", argno 1
+  %2 = copy_value %0
+  %3 = init_existential_ref %2 : $Self : $Self, $any MyObjCProtocol
+  debug_value [trace] %3
+  destroy_value %3
+  %8 = tuple ()
+  return %8
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on init_existential_ref_get_conformance_test_nonisolated: sil_isolation_info_get_conformance_isolation_inferrence with: @trace[0]
+// CHECK-NEXT: Input Value:   %3 = init_existential_ref %2 : $Self : $Self, $any MyObjCProtocol // user: %4
+// CHECK-NEXT: Isolation: task-isolated isolated-conformance-to(MyObjCProtocol)
+// CHECK-NEXT: end running test 1 of 1 on init_existential_ref_get_conformance_test_nonisolated: sil_isolation_info_get_conformance_isolation_inferrence with: @trace[0]
+sil [isolation "nonisolated"] [ossa] @init_existential_ref_get_conformance_test_nonisolated : $@convention(method) <Self where Self : MyObjCProtocol> (@guaranteed Self) -> () {
+bb0(%0 : @guaranteed $Self):
+  specify_test "sil_isolation_info_get_conformance_isolation_inferrence @trace[0]"
+  debug_value %0, let, name "self", argno 1
+  %2 = copy_value %0
+  %3 = init_existential_ref %2 : $Self : $Self, $any MyObjCProtocol
+  debug_value [trace] %3
+  destroy_value %3
+  %8 = tuple ()
+  return %8
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on init_existential_addr_get_conformance_test: sil_isolation_info_get_conformance_isolation_inferrence with: @trace[0]
+// CHECK-NEXT: Input Value:   %3 = init_existential_addr %2 : $*any MyProtocol, $Self // user: %4
+// CHECK-NEXT: Isolation: global actor 'CustomActor'-isolated isolated-conformance-to(MyProtocol)
+// CHECK-NEXT: end running test 1 of 1 on init_existential_addr_get_conformance_test: sil_isolation_info_get_conformance_isolation_inferrence with: @trace[0]
+sil [isolation "global_actor(CustomActor)"] [ossa] @init_existential_addr_get_conformance_test : $@convention(method) <Self where Self : MyProtocol> (@in_guaranteed Self) -> () {
+bb0(%0 : $*Self):
+  specify_test "sil_isolation_info_get_conformance_isolation_inferrence @trace[0]"
+  debug_value %0, let, name "self", argno 1
+  %alloc = alloc_stack $any MyProtocol
+  %addr = init_existential_addr %alloc : $*any MyProtocol, $Self
+  debug_value [trace] %addr
+  copy_addr %0 to [init] %addr
+  destroy_addr %alloc
+  dealloc_stack %alloc
+  %8 = tuple ()
+  return %8
 }

--- a/test/Concurrency/silisolationinfo_inference_opaquevalues.sil
+++ b/test/Concurrency/silisolationinfo_inference_opaquevalues.sil
@@ -1,0 +1,51 @@
+// RUN: %target-sil-opt -enable-sil-opaque-values -module-name infer --test-runner %s 2>&1 | %FileCheck %s
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+// PLEASE READ THIS!
+//
+// This test is specifically meant to test how we infer isolation for specific
+// values.
+
+sil_stage raw
+
+import Swift
+import Builtin
+import _Concurrency
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+class NonSendableKlass {}
+
+actor CustomActorInstance {}
+
+@globalActor
+struct CustomActor {
+  static let shared = CustomActorInstance()
+}
+
+protocol MyProtocol {
+}
+
+/////////////////
+// MARK: Tests //
+/////////////////
+
+// CHECK-LABEL: begin running test 1 of 1 on init_existential_addr_get_conformance_test: sil_isolation_info_get_conformance_isolation_inferrence with: @trace[0]
+// CHECK-NEXT: Input Value:   %3 = init_existential_value %2 : $Self, $Self, $any MyProtocol // user: %4
+// CHECK-NEXT: Isolation: global actor 'CustomActor'-isolated isolated-conformance-to(MyProtocol)
+// CHECK-NEXT: end running test 1 of 1 on init_existential_addr_get_conformance_test: sil_isolation_info_get_conformance_isolation_inferrence with: @trace[0]
+sil [isolation "global_actor(CustomActor)"] [ossa] @init_existential_addr_get_conformance_test : $@convention(method) <Self where Self : MyProtocol> (@in_guaranteed Self) -> () {
+bb0(%0 : @guaranteed $Self):
+  specify_test "sil_isolation_info_get_conformance_isolation_inferrence @trace[0]"
+  debug_value %0, let, name "self", argno 1
+  %1 = copy_value %0
+  %addr = init_existential_value %1 : $Self, $Self, $MyProtocol
+  debug_value [trace] %addr
+  destroy_value %addr
+  %8 = tuple ()
+  return %8
+}

--- a/test/SIL/Parser/basic2.sil
+++ b/test/SIL/Parser/basic2.sil
@@ -516,3 +516,12 @@ bb0(%0 : @inferredImmutable @guaranteed $Klass):
   %9999 = tuple ()
   return %9999 : $()
 }
+
+// Make sure that we roundtrip if the isolation is specified in SIL.
+//
+// CHECK-LABEL: sil [isolation "nonisolated"] @isolation_test : $@convention(thin) () -> () {
+sil [isolation "nonisolated"] @isolation_test : $@convention(thin) () -> () {
+bb0:
+  %9999 = tuple ()
+  return %9999 : $()
+}

--- a/test/SIL/Serialization/basic2.sil
+++ b/test/SIL/Serialization/basic2.sil
@@ -43,6 +43,15 @@ bb0(%0 : @inferredImmutable @guaranteed $Klass):
   return %9999 : $()
 }
 
+// Make sure that we roundtrip if the isolation is specified in SIL.
+//
+// CHECK-LABEL: sil [isolation "nonisolated"] @isolation_test : $@convention(thin) () -> () {
+sil [isolation "nonisolated"] @isolation_test : $@convention(thin) () -> () {
+bb0:
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
 // CHECK-LABEL: sil [ossa] @merge_isolation_region : $@convention(thin) (@guaranteed Klass) -> () {
 // CHECK: merge_isolation_region %0 : $Klass, %1 : $*C
 // CHECK: merge_isolation_region %1 : $*C, %0 : $Klass, %0 : $Klass


### PR DESCRIPTION
I don't have a specific test for this, but it is obvious it needs to be updated in the same way, so I added some SIL code that can be used to explicitly test this.

rdar://172941821