### PR TITLE
Replace use of unsafeFlags with headerSearchPaths in benchmarks

### DIFF
--- a/benchmark/Package.swift
+++ b/benchmark/Package.swift
@@ -127,9 +127,8 @@ targets.append(
     dependencies: swiftBenchDeps,
     path: "utils",
     sources: ["main.swift"],
-    swiftSettings: [.interoperabilityMode(.Cxx),
-                    .unsafeFlags(["-I",
-                                  "utils/CxxTests"])]))
+    cxxSettings: [.headerSearchPath("../utils/CxxTests")],
+    swiftSettings: [.interoperabilityMode(.Cxx)]))
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 targets.append(
@@ -165,10 +164,9 @@ targets += cxxSingleSourceLibraries.map { name in
     dependencies: singleSourceDeps,
     path: "cxx-source",
     sources: ["\(name).swift"],
+    cxxSettings: [.headerSearchPath("../utils/CxxTests")],
     swiftSettings: [.interoperabilityMode(.Cxx),
-                    .unsafeFlags(["-I",
-                                  "utils/CxxTests",
-                                  // FIXME: https://github.com/apple/swift/issues/61453
+                    .unsafeFlags([// FIXME: https://github.com/apple/swift/issues/61453
                                   "-Xfrontend", "-validate-tbd-against-ir=none"])])
 }
 

--- a/benchmark/scripts/build_script_helper.py
+++ b/benchmark/scripts/build_script_helper.py
@@ -39,7 +39,12 @@ def perform_build(args, swiftbuild_path, config, binary_name, opt_flag):
     subprocess.call(swiftbuild_args)
 
     # Copy the benchmark file into the final ./bin directory.
-    binpath = os.path.join(inner_build_dir, config, "SwiftBench")
+    bindir = subprocess.check_output(
+        swiftbuild_args + ["--show-bin-path"],
+        stderr=False,
+        universal_newlines=True,
+    ).strip()
+    binpath = os.path.join(bindir, "SwiftBench")
     finalpath = os.path.join(args.build_path, "bin", binary_name)
     shutil.copy(binpath, finalpath)
 


### PR DESCRIPTION
The compiler working directory used when building a package is undefined, which cause compatibility issues when switching between --build-system native and the new --build-system swiftbuild. Replace the header search paths passed via unsafeFlags with cxxSettings-based header search paths, which are resolved relative to the target being built and will be passed to Swift compilations via -Xcc

Also, use --show-bin-dir when appropriate instead of hardcoding paths to the built binaries