### PR TITLE
TempRValueElimination: delete `debug_value` instructions which are outside of the stack location's liverange

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/TempRValueElimination.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/TempRValueElimination.swift
@@ -109,12 +109,18 @@ private func tryEliminate(copy: CopyLikeInstruction, keepDebugInfo: Bool, _ cont
     return
   }
 
-  liverange.moveDebugValuesIntoLiverange(of: allocStack, after: copy.loadingInstruction)
+  liverange.moveDebugValuesIntoLiverange(debugUsers: allocStackUses.debugUsers, after: copy.loadingInstruction)
   liverange.extendAccessScopes()
 
   if !copy.isTakeOfSource {
     removeDestroys(users: allocStackUses.users, context)
   }
+
+  // Dead projection instructions can appear outside of the liverange in case they were only
+  // used by an (now deleted) `debug_value` or `destroy_addr` instruction.
+  // We need to delete such dead projections to avoid use-after-consume ownership violations.
+  var deadProjectionDeleter = DeadProjectionDeleter(context: context)
+  _ = deadProjectionDeleter.walkDownUses(ofAddress: allocStack, path: UnusedWalkingPath())
 
   allocStack.uses.ignore(usersOfType: DeallocStackInst.self).replaceAll(with: copy.sourceAddress, context)
 
@@ -183,10 +189,12 @@ private extension AllocStackInst {
 /// Collects all uses of the `alloc_stack`.
 private struct UseCollector : AddressDefUseWalker {
   private(set) var users: Stack<Instruction>
+  private(set) var debugUsers: Stack<DebugValueInst>
   private let copy: CopyLikeInstruction
 
   init(copy: CopyLikeInstruction, _ context: FunctionPassContext) {
     self.users = Stack(context)
+    self.debugUsers = Stack(context)
     self.copy = copy
   }
 
@@ -197,7 +205,7 @@ private struct UseCollector : AddressDefUseWalker {
     return true
   }
 
-  public mutating func walkDown(address operand: Operand, path: UnusedWalkingPath) -> WalkResult {
+  mutating func walkDown(address operand: Operand, path: UnusedWalkingPath) -> WalkResult {
     switch operand.instruction {
     case let openExistential as OpenExistentialAddrInst:
       if !openExistential.isImmutable {
@@ -284,7 +292,11 @@ private struct UseCollector : AddressDefUseWalker {
       users.append(address.instruction)
       return .continueWalk
 
-    case is DebugValueInst, is DeallocStackInst:
+    case let debugValue as DebugValueInst:
+      debugUsers.append(debugValue)
+      return .continueWalk
+
+    case is DeallocStackInst:
       return .continueWalk
 
     default:
@@ -302,12 +314,13 @@ private struct UseCollector : AddressDefUseWalker {
     return .continueWalk
   }
 
-  public mutating func unmatchedPath(address: Operand, path: UnusedWalkingPath) -> WalkResult {
+  mutating func unmatchedPath(address: Operand, path: UnusedWalkingPath) -> WalkResult {
     return .abortWalk
   }
 
   mutating func deinitialize() {
     users.deinitialize()
+    debugUsers.deinitialize()
   }
 }
 
@@ -419,17 +432,15 @@ private struct Liverange {
   }
 
   /// Move `debug_value` instructions, which are located _before_ the copy instruction, after the copy instruction.
-  func moveDebugValuesIntoLiverange(of allocStack: AllocStackInst, after: Instruction) {
-    for user in allocStack.users {
-      if !liverange.hasBeenPushed(user) {
-        switch user {
-        case let debugValue as DebugValueInst:
-          debugValue.move(before: after.next!, context)
-        case is DeallocStackInst, is DestroyAddrInst, is CopyAddrInst:
-          break
-        default:
-          fatalError("moving this kind of instruction is currently not supported")
-        }
+  func moveDebugValuesIntoLiverange(debugUsers: Stack<DebugValueInst>, after copy: Instruction) {
+    for debugValue in debugUsers where !liverange.hasBeenPushed(debugValue) {
+      if debugValue.operand.value is AllocStackInst {
+        debugValue.move(before: copy.next!, context)
+      } else {
+        // If the operand of the `debugValue` is a projection, the projection can be located after the `copy`.
+        // Therefore we cannot move the `debugValue` immediately after the `copy`.
+        // It's not ideal to delete the `debugValue`, however this is a very rare case.
+        context.erase(instruction: debugValue)
       }
     }
   }
@@ -490,6 +501,22 @@ private struct Liverange {
     }
   }
 
+}
+
+private struct DeadProjectionDeleter : AddressDefUseWalker {
+  let context: FunctionPassContext
+
+  mutating func walkDown(address operand: Operand, path: UnusedWalkingPath) -> WalkResult {
+    _ = walkDownDefault(address: operand, path: path)
+    if operand.instruction.isTriviallyDead {
+      context.erase(instruction: operand.instruction)
+    }
+    return .continueWalk
+  }
+
+  mutating func leafUse(address: Operand, path: UnusedWalkingPath) -> WalkResult {
+    return .continueWalk
+  }
 }
 
 private extension Instruction {

--- a/test/SILOptimizer/temp_rvalue_opt_ossa.sil
+++ b/test/SILOptimizer/temp_rvalue_opt_ossa.sil
@@ -1914,3 +1914,34 @@ bb0(%0 : $*Klass):
   return %r
 }
 
+// CHECK-LABEL: sil [ossa] @debug_value_outside_liverange :
+// CHECK-NOT:     alloc_stack
+// CHECK-NOT:     copy_addr
+// CHECK-LABEL: } // end sil function 'debug_value_outside_liverange'
+sil [ossa] @debug_value_outside_liverange : $@convention(thin) (@owned Klass) -> @owned S2 {
+bb0(%0 : @owned $Klass):
+  %1 = begin_borrow %0
+  %2 = ref_tail_addr [immutable] %1, $(Int, S2)
+  %3 = alloc_stack $(Int, S2)
+  copy_addr %2 to [init] %3
+  %5 = tuple_element_addr %3, 1
+  %6 = load [copy] %5
+  cond_br undef, bb1, bb2
+
+bb1:
+  end_borrow %1
+  destroy_value %0
+  %10 = struct_element_addr %5, #S2.ntv
+  %11 = struct_element_addr %10, #NonTrivialStruct.val
+  debug_value %11, let, name "x"
+  destroy_value [dead_end] %6
+  unreachable
+
+bb2:
+  destroy_addr %3
+  end_borrow %1
+  destroy_value %0
+  dealloc_stack %3
+  return %6
+}
+


### PR DESCRIPTION
We already move `debug_value` instructions into the liverange in such cases. But we didn't do this if the `debug_value`'s operand is a projection of the `alloc_stack`. The fix is to delete such `debug_value` instructions. It's not ideal, however this is a very rare case. Also, we need to delete dead projection instructions. Dead projection instructions can appear outside of the liverange in case they were only used by an (now deleted) `debug_value` or `destroy_addr` instruction.

Fixes a SIL ownership verification error
https://github.com/swiftlang/swift/issues/87980
rdar://172950559
