### PR TITLE
Add fix-it for escaping inout capture

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -185,6 +185,8 @@ NOTE(copy_inout_captured_by_autoclosure,none, "pass a copy of %0", (Identifier))
 
 NOTE(copy_self_captured_by_autoclosure,none, "pass a copy of 'self'", ())
 
+NOTE(copy_inout_captured_by_escaping_closure,none,"capture '%0' explicitly to copy it into the closure", (Identifier))
+
 #undef SELECT_ESCAPING_CLOSURE_KIND
 
 NOTE(value_captured_transitively,none,

--- a/lib/SILOptimizer/Mandatory/DiagnoseInvalidEscapingCaptures.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseInvalidEscapingCaptures.cpp
@@ -701,12 +701,12 @@ static void checkPartialApply(ASTContext &Context, DeclContext *DC,
           if (CE->getBracketRange().isValid()) {
             SourceLoc insertLoc = CE->getBracketRange().Start.getAdvancedLoc(1);
             bool isEmpty = (insertLoc == CE->getBracketRange().End);
-            std::string capture = name.str() + " = " + name.str();
+            std::string capture = name.str();
             diagnose(Context, PAI->getLoc(),
                      diag::copy_inout_captured_by_escaping_closure, name)
                 .fixItInsert(insertLoc, isEmpty ? capture : capture + ", ");
           } else {
-            std::string fix = " [" + name.str() + " = " + name.str() + "]";
+            std::string fix = " [" + name.str() + "]";
             if (CE->getInLoc().isInvalid())
               fix += " in";
             diagnose(Context, PAI->getLoc(),

--- a/lib/SILOptimizer/Mandatory/DiagnoseInvalidEscapingCaptures.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseInvalidEscapingCaptures.cpp
@@ -695,6 +695,13 @@ static void checkPartialApply(ASTContext &Context, DeclContext *DC,
                  functionKind, param->getName());
         diagnose(Context, param->getLoc(), diag::inout_param_defined_here,
                  param->getName());
+
+        auto name = param->getName();
+        std::string fixItStr = "[" + name.str() + " = " + name.str() + "] ";
+
+        diagnose(Context, PAI->getLoc(),
+                    diag::copy_inout_captured_by_escaping_closure, name)
+                    .fixItInsertAfter(PAI->getLoc().getSourceLoc(), fixItStr);
       }
     }
     if (functionKind != EscapingAutoClosure) {

--- a/lib/SILOptimizer/Mandatory/DiagnoseInvalidEscapingCaptures.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseInvalidEscapingCaptures.cpp
@@ -697,11 +697,26 @@ static void checkPartialApply(ASTContext &Context, DeclContext *DC,
                  param->getName());
 
         auto name = param->getName();
-        std::string fixItStr = "[" + name.str() + " = " + name.str() + "] ";
-
-        diagnose(Context, PAI->getLoc(),
-                    diag::copy_inout_captured_by_escaping_closure, name)
-                    .fixItInsertAfter(PAI->getLoc().getSourceLoc(), fixItStr);
+        if (auto *CE = PAI->getLoc().getAsASTNode<ClosureExpr>()) {
+          if (CE->getBracketRange().isValid()) {
+            SourceLoc insertLoc = CE->getBracketRange().Start.getAdvancedLoc(1);
+            bool isEmpty = (insertLoc == CE->getBracketRange().End);
+            std::string capture = name.str() + " = " + name.str();
+            diagnose(Context, PAI->getLoc(),
+                     diag::copy_inout_captured_by_escaping_closure, name)
+                .fixItInsert(insertLoc, isEmpty ? capture : capture + ", ");
+          } else {
+            std::string fix = " [" + name.str() + " = " + name.str() + "]";
+            if (CE->getInLoc().isInvalid())
+              fix += " in";
+            diagnose(Context, PAI->getLoc(),
+                     diag::copy_inout_captured_by_escaping_closure, name)
+                .fixItInsertAfter(CE->getLoc(), fix);
+          }
+        } else {
+          diagnose(Context, PAI->getLoc(),
+                   diag::copy_inout_captured_by_escaping_closure, name);
+        }
       }
     }
     if (functionKind != EscapingAutoClosure) {

--- a/test/SILOptimizer/invalid_escaping_captures.swift
+++ b/test/SILOptimizer/invalid_escaping_captures.swift
@@ -6,14 +6,17 @@ func takesNonEscaping(_ fn: () -> ()) { fn() }
 
 func badClosureCaptureInOut1(x: inout Int) { // expected-note {{parameter 'x' is declared 'inout'}}
   takesEscaping { // expected-error {{escaping closure captures 'inout' parameter 'x'}}
+  // expected-note@-1 {{capture 'x' explicitly to copy it into the closure}} {{18-18= [x = x] in}}
     x += 1 // expected-note {{captured here}}
   }
 }
 
 func badClosureCaptureInOut2(x: inout Int, b: Bool) { // expected-note 2{{parameter 'x' is declared 'inout'}}
   takesEscaping(b ? { // expected-error {{escaping closure captures 'inout' parameter 'x'}}
+  // expected-note@-1 {{capture 'x' explicitly to copy it into the closure}} {{21-21= [x = x] in}}
                   x += 1 // expected-note {{captured here}}
                 } : { // expected-error {{escaping closure captures 'inout' parameter 'x'}}
+  // expected-note@-1 {{capture 'x' explicitly to copy it into the closure}} {{21-21= [x = x] in}}
                   x -= 1 // expected-note {{captured here}}
                 })
 }
@@ -141,6 +144,7 @@ func takesEscapingGeneric<T>(_: @escaping () -> T) {}
 
 func testGenericClosureReabstraction(x: inout Int) { // expected-note {{parameter 'x' is declared 'inout'}}
   takesEscapingGeneric { () -> Int in // expected-error {{escaping closure captures 'inout' parameter 'x'}}
+    // expected-note@-1 {{capture 'x' explicitly to copy it into the closure}} {{24-24= [x = x]}}
     x += 1 // expected-note {{captured here}}
     return 0
   }
@@ -169,12 +173,14 @@ func ~> <Target, Arg0, Result>(x: inout Target, f: @escaping (_: inout Target, _
   // expected-note@-1 {{parameter 'x' is declared 'inout'}}
   return { f(&x, $0) } // expected-note {{captured here}}
   // expected-error@-1 {{escaping closure captures 'inout' parameter 'x'}}
+  // expected-note@-2 {{capture 'x' explicitly to copy it into the closure}} {{10-10= [x = x] in}}
 }
 
 func ~> (x: inout Int, f: @escaping (_: inout Int, _: Target) -> Target) -> (Target) -> Target {
   // expected-note@-1 {{parameter 'x' is declared 'inout'}}
   return { f(&x, $0) } // expected-note {{captured here}}
   // expected-error@-1 {{escaping closure captures 'inout' parameter 'x'}}
+  // expected-note@-2 {{capture 'x' explicitly to copy it into the closure}} {{10-10= [x = x] in}}
 }
 
 func addHandler(_: @escaping () -> ()) {}
@@ -221,7 +227,7 @@ func badTransitiveCaptureInClosures(x: inout Int) -> ((Int) -> Void) {
   // Test capture of x by an autoclosure within an escaping closure.
   let escapingClosure = { (y: Int) in
       // expected-error@-1 {{escaping closure captures 'inout' parameter 'x'}}
-
+      // expected-note@-2 {{capture 'x' explicitly to copy it into the closure}} {{25-25= [x = x]}}
     autoclosureTakesEscaping(x + y)
       // expected-note@-1 {{captured indirectly by this call}}
       // expected-note@-2 {{captured here}}

--- a/test/SILOptimizer/invalid_escaping_captures.swift
+++ b/test/SILOptimizer/invalid_escaping_captures.swift
@@ -6,17 +6,17 @@ func takesNonEscaping(_ fn: () -> ()) { fn() }
 
 func badClosureCaptureInOut1(x: inout Int) { // expected-note {{parameter 'x' is declared 'inout'}}
   takesEscaping { // expected-error {{escaping closure captures 'inout' parameter 'x'}}
-  // expected-note@-1 {{capture 'x' explicitly to copy it into the closure}} {{18-18= [x = x] in}}
+  // expected-note@-1 {{capture 'x' explicitly to copy it into the closure}} {{18-18= [x] in}}
     x += 1 // expected-note {{captured here}}
   }
 }
 
 func badClosureCaptureInOut2(x: inout Int, b: Bool) { // expected-note 2{{parameter 'x' is declared 'inout'}}
   takesEscaping(b ? { // expected-error {{escaping closure captures 'inout' parameter 'x'}}
-  // expected-note@-1 {{capture 'x' explicitly to copy it into the closure}} {{21-21= [x = x] in}}
+  // expected-note@-1 {{capture 'x' explicitly to copy it into the closure}} {{21-21= [x] in}}
                   x += 1 // expected-note {{captured here}}
                 } : { // expected-error {{escaping closure captures 'inout' parameter 'x'}}
-  // expected-note@-1 {{capture 'x' explicitly to copy it into the closure}} {{21-21= [x = x] in}}
+  // expected-note@-1 {{capture 'x' explicitly to copy it into the closure}} {{21-21= [x] in}}
                   x -= 1 // expected-note {{captured here}}
                 })
 }
@@ -144,7 +144,7 @@ func takesEscapingGeneric<T>(_: @escaping () -> T) {}
 
 func testGenericClosureReabstraction(x: inout Int) { // expected-note {{parameter 'x' is declared 'inout'}}
   takesEscapingGeneric { () -> Int in // expected-error {{escaping closure captures 'inout' parameter 'x'}}
-    // expected-note@-1 {{capture 'x' explicitly to copy it into the closure}} {{24-24= [x = x]}}
+    // expected-note@-1 {{capture 'x' explicitly to copy it into the closure}} {{24-24= [x]}}
     x += 1 // expected-note {{captured here}}
     return 0
   }
@@ -173,14 +173,14 @@ func ~> <Target, Arg0, Result>(x: inout Target, f: @escaping (_: inout Target, _
   // expected-note@-1 {{parameter 'x' is declared 'inout'}}
   return { f(&x, $0) } // expected-note {{captured here}}
   // expected-error@-1 {{escaping closure captures 'inout' parameter 'x'}}
-  // expected-note@-2 {{capture 'x' explicitly to copy it into the closure}} {{10-10= [x = x] in}}
+  // expected-note@-2 {{capture 'x' explicitly to copy it into the closure}} {{10-10= [x] in}}
 }
 
 func ~> (x: inout Int, f: @escaping (_: inout Int, _: Target) -> Target) -> (Target) -> Target {
   // expected-note@-1 {{parameter 'x' is declared 'inout'}}
   return { f(&x, $0) } // expected-note {{captured here}}
   // expected-error@-1 {{escaping closure captures 'inout' parameter 'x'}}
-  // expected-note@-2 {{capture 'x' explicitly to copy it into the closure}} {{10-10= [x = x] in}}
+  // expected-note@-2 {{capture 'x' explicitly to copy it into the closure}} {{10-10= [x] in}}
 }
 
 func addHandler(_: @escaping () -> ()) {}
@@ -227,7 +227,7 @@ func badTransitiveCaptureInClosures(x: inout Int) -> ((Int) -> Void) {
   // Test capture of x by an autoclosure within an escaping closure.
   let escapingClosure = { (y: Int) in
       // expected-error@-1 {{escaping closure captures 'inout' parameter 'x'}}
-      // expected-note@-2 {{capture 'x' explicitly to copy it into the closure}} {{25-25= [x = x]}}
+      // expected-note@-2 {{capture 'x' explicitly to copy it into the closure}} {{25-25= [x]}}
     autoclosureTakesEscaping(x + y)
       // expected-note@-1 {{captured indirectly by this call}}
       // expected-note@-2 {{captured here}}


### PR DESCRIPTION
This PR adds a fix-it suggestion for the `escaping_inout_capture` diagnostic.

When an escaping closure captures an `inout` parameter, the compiler now suggests capturing a copy using a capture list (e.g. `[i = i]`).

This follows the pattern used in similar diagnostics. Feedback on the insertion location or formatting of the fix-it is welcome.

Resolves https://github.com/swiftlang/swift/issues/87830
