### PR TITLE
[6.3][IRGen] Sign protocol witnesses in relative witness table access

### DIFF
--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -4396,6 +4396,8 @@ static FunctionPointer emitRelativeProtocolWitnessTableAccess(IRGenFunction &IGF
     IGF.IGM.getMaximalTypeExpansionContext(), member);
   Signature signature = IGF.IGM.getSignature(fnType);
 
+  auto authInfo = PointerAuthInfo::forFunctionPointer(IGF.IGM, fnType);
+
   auto helperFn = cast<llvm::Function>(IGM.getOrCreateHelperFunction(
     fnName, IGM.Int8PtrTy, {witnessTableTy},
     [&](IRGenFunction &subIGF) {
@@ -4406,10 +4408,13 @@ static FunctionPointer emitRelativeProtocolWitnessTableAccess(IRGenFunction &IGF
     auto slot = slotForLoadOfOpaqueWitness(subIGF, wtable,
                                            index.forProtocolWitnessTable(),
                                            true);
+
     llvm::Value *witnessFnPtr = emitWTableSlotLoad(subIGF, wtable, member, slot,
                                                    true);
+    auto witnessFnPtrSigned =
+        emitPointerAuthSign(subIGF, witnessFnPtr, authInfo);
 
-    subIGF.Builder.CreateRet(witnessFnPtr);
+    subIGF.Builder.CreateRet(witnessFnPtrSigned);
 
   }, true /*noinline*/));
 
@@ -4418,7 +4423,7 @@ static FunctionPointer emitRelativeProtocolWitnessTableAccess(IRGenFunction &IGF
   call->setCallingConv(IGF.IGM.DefaultCC);
   call->setDoesNotThrow();
   auto fn = IGF.Builder.CreateBitCast(call, IGM.PtrTy);
-  return FunctionPointer::createUnsigned(fnType, fn, signature, true);
+  return FunctionPointer::createSigned(fnType, fn, authInfo, signature);
 }
 
 FunctionPointer irgen::emitWitnessMethodValue(IRGenFunction &IGF,

--- a/test/IRGen/relative_protocol_witness_table.swift
+++ b/test/IRGen/relative_protocol_witness_table.swift
@@ -218,6 +218,7 @@ func instantiate_conditional_conformance_2nd<T>(_ t : T)  where T: Sub, T.S == T
 // CHECK:[[ENTRY:.*]]:
 // CHECK:  [[T4:%.*]] = call ptr @"__swift_relative_protocol_witness_table_access_1_$s1A8FuncOnlyP1ayyFTq"(ptr [[PWT]])
 // CHECK:  call{{.*}} swiftcc void [[T4]]
+// CHECK-arm64e: [ "ptrauth"(i32 0, i64 18589) ]
 
 // CHECK: define{{.*}} hidden ptr @"__swift_relative_protocol_witness_table_access_1_$s1A8FuncOnlyP1ayyFTq"(ptr [[PWT:%.*]])
 // CHECK:   [[T0:%.*]] = ptrtoint ptr [[PWT]] to i64
@@ -242,6 +243,9 @@ func instantiate_conditional_conformance_2nd<T>(_ t : T)  where T: Sub, T.S == T
 // CHECK:   [[T2:%.*]] = ptrtoint ptr [[SLOT]] to i64
 // CHECK:   [[T3:%.*]] = add i64 [[T2]], [[T1]]
 // CHECK:   [[T4:%.*]] = inttoptr i64 [[T3]] to ptr
+// CHECK-arm64e: [[T5:%.*]] = ptrtoint ptr [[T4]] to i64
+// CHECK-arm64e: [[T6:%.*]] = call i64 @llvm.ptrauth.sign(i64 [[T5]], i32 0, i64 18589)
+// CHECK-arm64e: [[T4:%.*]] = inttoptr i64 [[T6]] to ptr
 // CHECK:   ret ptr [[T4]]
 
 // Parent witness entry access.


### PR DESCRIPTION


- **Explanation**: When protocol witnesses get spilled to the stack, they should be signed and authenticated when used afterwards. This change ensures that they are.
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: PAC when spilling to stack. This is very unlikely to break existing code.
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Issues**: rdar://168676432
  <!--
  References to issues the changes resolve, if any.
  -->
- **Original PRs**: https://github.com/swiftlang/swift/pull/87718
  <!--
  Links to mainline branch pull requests in which the changes originated.
  -->
- **Risk**: Low. Only affects protocol witnesses that are spilled to the stack, which rarely happens and would lead to runtime crashes on PAC, so would be immediately visible.
  <!--
  The (specific) risk to the release for taking the changes.
  -->
- **Testing**: Added regression testing
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->
- **Reviewers**: @aschwaighofer 
  <!--
  The code owners that GitHub-approved the original changes in the mainline
  branch pull requests. If an original change has not been GitHub-approved by
  a respective code owner, provide a reason. Technical review can be delegated
  by a code owner or otherwise requested as deemed appropriate or useful.
  -->