### PR TITLE
Embedded: Check exportability of default inits and arguments in embedded mode

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6789,12 +6789,19 @@ public:
   /// @frozen and resides in a resilient module.
   bool isInitExposedToClients() const;
 
+  /// Returns the export level of this var initializer expression.
+  ExportedLevel getInitExposedLevel() const;
+
   /// Determines if this var is exposed as part of the layout of a
-  /// @frozen struct.
+  /// @frozen struct or implicitly in non-library-evolution mode.
   ///
   /// From the standpoint of access control and exportability checking, this
   /// var will behave as if it was public, even if it is internal or private.
-  ExportedLevel isLayoutExposedToClients() const;
+  ///
+  /// If \p forceCheckClasses, don't exclude non-open classes. We use this
+  /// to look at properties with a default value in embedded mode, otherwise
+  /// we can mostly ignore stored properties in classes.
+  ExportedLevel isLayoutExposedToClients(bool forceCheckClasses = false) const;
 
   /// Is this a special debugger variable?
   bool isDebuggerVar() const { return Bits.VarDecl.IsDebuggerVar; }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2801,17 +2801,27 @@ Expr *PatternBindingDecl::getExecutableInit(unsigned i) const {
   return idxInit;
 }
 
-bool VarDecl::isInitExposedToClients() const {
+ExportedLevel VarDecl::getInitExposedLevel() const {
   // 'lazy' initializers are emitted inside the getter, which is never
   // @inlinable.
   if (getAttrs().hasAttribute<LazyAttr>())
-    return false;
+    return ExportedLevel::None;
 
-  return hasInitialValue() &&
-         isLayoutExposedToClients() == ExportedLevel::Exported;
+  if (!hasInitialValue())
+    return ExportedLevel::None;
+
+  return isLayoutExposedToClients(/*forceCheckClasses=*/true);
 }
 
-ExportedLevel VarDecl::isLayoutExposedToClients() const {
+bool VarDecl::isInitExposedToClients() const {
+  auto level = getInitExposedLevel();
+  auto minToBeExported = getASTContext().LangOpts.hasFeature(Feature::Embedded)
+                         ? ExportedLevel::ImplicitlyExported
+                         : ExportedLevel::Exported;
+  return level >= minToBeExported;
+}
+
+ExportedLevel VarDecl::isLayoutExposedToClients(bool forceCheckClasses) const {
   auto parent = dyn_cast<NominalTypeDecl>(getDeclContext());
   if (!parent) return ExportedLevel::None;
   if (isStatic()) return ExportedLevel::None;
@@ -2838,7 +2848,8 @@ ExportedLevel VarDecl::isLayoutExposedToClients() const {
     return ExportedLevel::None;
 
   // Class layouts are not exposed to clients, except for subclassing.
-  if (isa<ClassDecl>(parent) &&
+  if (!forceCheckClasses &&
+      isa<ClassDecl>(parent) &&
       !parent->hasOpenAccess(getDeclContext())) {
 
     if (!parent->getASTContext().LangOpts.hasFeature(Feature::Embedded))

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -544,11 +544,18 @@ swift::FragileFunctionKindRequest::evaluate(Evaluator &evaluator,
     // Stored property initializer contexts use minimal resilience expansion
     // if the type is formally fixed layout.
     if (auto *init = dyn_cast <PatternBindingInitializer>(dc)) {
-      auto bindingIndex = init->getBindingIndex();
-      if (auto *varDecl = init->getBinding()->getAnchoringVarDecl(bindingIndex)) {
-        if (varDecl->isInitExposedToClients()) {
+      auto index = init->getBindingIndex();
+      if (auto *varDecl = init->getBinding()->getAnchoringVarDecl(index)) {
+        switch (varDecl->getInitExposedLevel()) {
+        case ExportedLevel::Exported:
           return {FragileFunctionKind::PropertyInitializer};
-        }
+        case ExportedLevel::ImplicitlyExported:
+          if (init->getASTContext().LangOpts.hasFeature(Feature::Embedded))
+            return {FragileFunctionKind::EmbeddedAlwaysEmitIntoClient};
+          break;
+        case ExportedLevel::None:
+          break;
+        };
       }
 
       return {FragileFunctionKind::None};

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -17,6 +17,7 @@
 #include "swift/AST/AvailabilityConstraint.h"
 #include "swift/AST/AvailabilityContext.h"
 #include "swift/AST/ClangModuleLoader.h"
+#include "swift/AST/DeclExportabilityVisitor.h"
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/FileUnit.h"
@@ -534,6 +535,9 @@ swift::FragileFunctionKindRequest::evaluate(Evaluator &evaluator,
         return {FragileFunctionKind::DefaultArgument};
       }
 
+      if (VD->getASTContext().LangOpts.hasFeature(Feature::Embedded) &&
+          !VD->isNeverEmittedIntoClient())
+        return {FragileFunctionKind::EmbeddedAlwaysEmitIntoClient};
       return {FragileFunctionKind::None};
     }
 
@@ -569,7 +573,7 @@ swift::FragileFunctionKindRequest::evaluate(Evaluator &evaluator,
         // Accessors are implicitly EmbeddedAlwaysEmitIntoClient if neither the
         // accessor or starage is marked @_neverEmitIntoClient.
         if (!funcIsNEIC && !storageIsNEIC)
-            return FragileFunctionKind::EmbeddedAlwaysEmitIntoClient;
+          return FragileFunctionKind::EmbeddedAlwaysEmitIntoClient;
         return FragileFunctionKind::None;
       };
 

--- a/test/Sema/access-level-and-implementation-only-import-embedded.swift
+++ b/test/Sema/access-level-and-implementation-only-import-embedded.swift
@@ -85,6 +85,8 @@ public func implicitlyInlinablePublic(arg: StructFromDirect = StructFromDirect()
 private func implicitlyInlinablePrivate(arg: StructFromDirect = StructFromDirect()) {
 // expected-error @-1 {{struct 'StructFromDirect' cannot be used in an embedded function not marked '@export(interface)' because 'directs' was imported implementation-only}}
 // expected-note @-2 {{global function 'implicitlyInlinablePrivate(arg:)' is not '@usableFromInline' or public}}
+// expected-error @-3 {{struct 'StructFromDirect' cannot be used in an embedded function not marked '@export(interface)' because 'directs' was imported implementation-only}}
+// expected-error @-4 {{nitializer 'init()' cannot be used in an embedded function not marked '@export(interface)' because 'directs' was imported implementation-only}}
   _ = StructFromDirect() // expected-error {{initializer 'init()' cannot be used in an embedded function not marked '@export(interface)' because 'directs' was imported implementation-only}}
   // expected-error@-1 {{struct 'StructFromDirect' cannot be used in an embedded function not marked '@export(interface)' because 'directs' was imported implementation-only}}
 

--- a/test/Sema/embedded-implicit-init.swift
+++ b/test/Sema/embedded-implicit-init.swift
@@ -44,6 +44,9 @@ extension HiddenType: LocalType {}
 public struct FrozenStruct {
   let propertyWithDefaultInit: LocalType = HiddenType() // expected-error {{struct 'HiddenType' cannot be used in a property initializer in a '@frozen' type because 'Lib' was imported implementation-only}}
   // expected-error @-1 {{initializer 'init()' cannot be used in a property initializer in a '@frozen' type because 'Lib' was imported implementation-only}}
+
+  func funcWithDefaultArg(a: LocalType = HiddenType()) {} // expected-embedded-error {{struct 'HiddenType' cannot be used in an embedded function not marked '@export(interface)' because 'Lib' was imported implementation-only}}
+  // expected-embedded-error @-1 {{initializer 'init()' cannot be used in an embedded function not marked '@export(interface)' because 'Lib' was imported implementation-only}}
 }
 
 public class PublicClass {
@@ -52,10 +55,16 @@ public class PublicClass {
 
   func funcWithDefaultArg(a: LocalType = HiddenType()) {} // expected-embedded-error {{struct 'HiddenType' cannot be used in an embedded function not marked '@export(interface)' because 'Lib' was imported implementation-only}}
   // expected-embedded-error @-1 {{initializer 'init()' cannot be used in an embedded function not marked '@export(interface)' because 'Lib' was imported implementation-only}}
+
+  @export(interface)
+  func funcWithDefaultArgExportInterface(a: LocalType = HiddenType()) {}
 }
 
 internal struct InternalStruct {
   let propertyWithDefaultInit: LocalType = HiddenType() // expected-embedded-error {{struct 'HiddenType' cannot be used in an embedded function not marked '@export(interface)' because 'Lib' was imported implementation-only}}
+  // expected-embedded-error @-1 {{initializer 'init()' cannot be used in an embedded function not marked '@export(interface)' because 'Lib' was imported implementation-only}}
+
+  func funcWithDefaultArg(a: LocalType = HiddenType()) {} // expected-embedded-error {{struct 'HiddenType' cannot be used in an embedded function not marked '@export(interface)' because 'Lib' was imported implementation-only}}
   // expected-embedded-error @-1 {{initializer 'init()' cannot be used in an embedded function not marked '@export(interface)' because 'Lib' was imported implementation-only}}
 
   @export(interface)

--- a/test/Sema/embedded-implicit-init.swift
+++ b/test/Sema/embedded-implicit-init.swift
@@ -1,0 +1,63 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t --leading-lines
+
+// RUN: %target-swift-frontend -emit-module %t/Lib.swift -o %t/Lib.swiftmodule \
+// RUN:   -swift-version 6
+
+// RUN: %target-swift-frontend -emit-module %t/Client.swift -I %t \
+// RUN:   -verify -verify-ignore-unrelated \
+// RUN:   -swift-version 6 \
+// RUN:   -enable-experimental-feature CheckImplementationOnly
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t --leading-lines
+
+// RUN: %target-swift-frontend -emit-module %t/Lib.swift -o %t/Lib.swiftmodule \
+// RUN:   -swift-version 6 -target arm64-apple-none-macho \
+// RUN:   -enable-experimental-feature Embedded
+
+// RUN: %target-swift-frontend -emit-module %t/Client.swift -I %t \
+// RUN:   -verify -verify-ignore-unrelated \
+// RUN:   -swift-version 6 -target arm64-apple-none-macho \
+// RUN:   -verify-additional-prefix embedded- \
+// RUN:   -enable-experimental-feature Embedded \
+// RUN:   -enable-experimental-feature CheckImplementationOnly
+
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: swift_feature_CheckImplementationOnly
+// REQUIRES: embedded_stdlib_cross_compiling
+
+//--- Lib.swift
+
+public struct HiddenType {
+    public init() {}
+}
+
+//--- Client.swift
+
+@_implementationOnly import Lib
+
+public protocol LocalType {}
+extension HiddenType: LocalType {}
+
+@frozen
+public struct FrozenStruct {
+  let propertyWithDefaultInit: LocalType = HiddenType() // expected-error {{struct 'HiddenType' cannot be used in a property initializer in a '@frozen' type because 'Lib' was imported implementation-only}}
+  // expected-error @-1 {{initializer 'init()' cannot be used in a property initializer in a '@frozen' type because 'Lib' was imported implementation-only}}
+}
+
+public class PublicClass {
+  let propertyWithDefaultInit: LocalType = HiddenType() // expected-embedded-error {{struct 'HiddenType' cannot be used in an embedded function not marked '@export(interface)' because 'Lib' was imported implementation-only}}
+  // expected-embedded-error @-1 {{initializer 'init()' cannot be used in an embedded function not marked '@export(interface)' because 'Lib' was imported implementation-only}}
+
+  func funcWithDefaultArg(a: LocalType = HiddenType()) {} // expected-embedded-error {{struct 'HiddenType' cannot be used in an embedded function not marked '@export(interface)' because 'Lib' was imported implementation-only}}
+  // expected-embedded-error @-1 {{initializer 'init()' cannot be used in an embedded function not marked '@export(interface)' because 'Lib' was imported implementation-only}}
+}
+
+internal struct InternalStruct {
+  let propertyWithDefaultInit: LocalType = HiddenType() // expected-embedded-error {{struct 'HiddenType' cannot be used in an embedded function not marked '@export(interface)' because 'Lib' was imported implementation-only}}
+  // expected-embedded-error @-1 {{initializer 'init()' cannot be used in an embedded function not marked '@export(interface)' because 'Lib' was imported implementation-only}}
+
+  @export(interface)
+  func funcWithDefaultArgExportInterface(a: LocalType = HiddenType()) {}
+}

--- a/test/Sema/hidden-memory-layout.swift
+++ b/test/Sema/hidden-memory-layout.swift
@@ -109,8 +109,8 @@ private class HiddenClass {
 
 @_implementationOnly
 private struct HiddenLayout {
-// expected-note @-1 2 {{struct 'HiddenLayout' is not '@usableFromInline' or public}}
-// expected-note @-2 1 {{initializer 'init()' is not '@usableFromInline' or public}}
+// expected-note @-1 4 {{struct 'HiddenLayout' is not '@usableFromInline' or public}}
+// expected-note @-2 3 {{initializer 'init()' is not '@usableFromInline' or public}}
 // expected-note @-3 9 {{struct declared here}}
 // expected-note @-4 4 {{type declared here}}
 // expected-embedded-note @-5 1 {{struct declared here}}
@@ -163,6 +163,10 @@ private protocol HiddenProtocol {
 
 @_spi(S) public struct SPIStruct {}
 // expected-note @-1 {{struct declared here}}
+
+public protocol PublicProto {}
+extension StructFromDirect : PublicProto {}
+extension HiddenLayout : PublicProto {}
 
 /// Function use sites
 
@@ -344,6 +348,10 @@ public struct ExposedLayoutFrozenUser: ProtocolFromDirect {
   // expected-error @-1 {{cannot use protocol 'HiddenProtocol' in a property declaration marked public or in a '@frozen' or '@usableFromInline' context; 'HiddenProtocol' is marked '@_implementationOnly'}}
   // expected-error @-2 {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
 
+  private var hiddenInit: PublicProto = HiddenLayout()
+  // expected-error @-1 {{struct 'HiddenLayout' is private and cannot be referenced from a property initializer in a '@frozen' type}}
+  // expected-error @-2 {{initializer 'init()' is private and cannot be referenced from a property initializer in a '@frozen' type}}
+
   private func privateFunc(h: HiddenLayout) {}
   // expected-embedded-error @-1 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
   private func privateFuncClass(h: HiddenClass) {}
@@ -399,6 +407,9 @@ public struct ExposedLayoutPublicUser: ProtocolFromDirect {
   // expected-embedded-error @-1 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
   private func privateFuncClass(h: HiddenClass) {}
   // expected-embedded-error @-1 {{class 'HiddenClass' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenClass' is marked '@_implementationOnly'}}
+
+  private func defaultArgFunc(arg: PublicProto = HiddenLayout()) {}
+  // expected-embedded-error @-1 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
 
   @_spi(S) public var s: SPIStruct
 }
@@ -667,6 +678,12 @@ public class PublicClassUser: ProtocolFromDirect {
   private var i: ExposedProtocolPrivate
   private var j: HiddenProtocol
 
+  private var importedInit: PublicProto = StructFromDirect()
+  // expected-embedded-error @-1 {{struct 'StructFromDirect' cannot be used in an embedded function not marked '@export(interface)' because 'directs' was imported implementation-only}}
+  // expected-embedded-error @-2 {{initializer 'init()' cannot be used in an embedded function not marked '@export(interface)' because 'directs' was imported implementation-only}}
+  private var hiddenInit: PublicProto = HiddenLayout()
+  // expected-embedded-error @-1 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
+
   @export(interface)
   private func privateFunc(h: HiddenLayout) {}
 
@@ -706,6 +723,12 @@ public class PublicClassUserWithoutDeinit: ProtocolFromDirect {
   private var i: ExposedProtocolPrivate
   private var j: HiddenProtocol
   // expected-embedded-error @-1 {{cannot use protocol 'HiddenProtocol' in a property declaration member of a class without the required '@export(interface)' deinit in Embedded; 'HiddenProtocol' is marked '@_implementationOnly'}}
+
+  private var importedInit: PublicProto = StructFromDirect()
+  // expected-embedded-error @-1 {{struct 'StructFromDirect' cannot be used in an embedded function not marked '@export(interface)' because 'directs' was imported implementation-only}}
+  // expected-embedded-error @-2 {{initializer 'init()' cannot be used in an embedded function not marked '@export(interface)' because 'directs' was imported implementation-only}}
+  private var hiddenInit: PublicProto = HiddenLayout()
+  // expected-embedded-error @-1 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
 }
 
 open class OpenClassUser: ProtocolFromDirect {
@@ -740,6 +763,11 @@ open class OpenClassUser: ProtocolFromDirect {
   private var j: HiddenProtocol
   // expected-error @-1 {{cannot use protocol 'HiddenProtocol' in a property declaration member of an open class; 'HiddenProtocol' is marked '@_implementationOnly'}}
 
+  private var importedInit: PublicProto = StructFromDirect()
+  // expected-embedded-error @-1 {{struct 'StructFromDirect' cannot be used in an embedded function not marked '@export(interface)' because 'directs' was imported implementation-only}}
+  // expected-embedded-error @-2 {{initializer 'init()' cannot be used in an embedded function not marked '@export(interface)' because 'directs' was imported implementation-only}}
+  private var hiddenInit: PublicProto = HiddenLayout()
+  // expected-embedded-error @-1 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
   @export(interface)
   private func privateFunc(h: HiddenLayout) {}
 
@@ -787,6 +815,13 @@ public class FixedClassUser: ProtocolFromDirect {
   // expected-error @-1 {{cannot use protocol 'HiddenProtocol' in a property declaration marked public or in a '@frozen' or '@usableFromInline' context; 'HiddenProtocol' is marked '@_implementationOnly'}}
   // expected-error @-2 {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
 
+  private var importedInit: PublicProto = StructFromDirect()
+  // expected-error @-1 {{struct 'StructFromDirect' cannot be used in a property initializer in a '@frozen' type because 'directs' was imported implementation-only}}
+  // expected-error @-2 {{initializer 'init()' cannot be used in a property initializer in a '@frozen' type because 'directs' was imported implementation-only}}
+  private var hiddenInit: PublicProto = HiddenLayout()
+  // expected-error @-1 {{struct 'HiddenLayout' is private and cannot be referenced from a property initializer in a '@frozen' type}}
+  // expected-error @-2 {{initializer 'init()' is private and cannot be referenced from a property initializer in a '@frozen' type}}
+
   @export(interface)
   private func privateFunc(h: HiddenLayout) {}
 }
@@ -815,6 +850,12 @@ internal class InternalClassUser: ProtocolFromDirect {
   private var h: ExposedProtocolInternal
   private var i: ExposedProtocolPrivate
   private var j: HiddenProtocol
+
+  private var importedInit: PublicProto = StructFromDirect()
+  // expected-embedded-error @-1 {{struct 'StructFromDirect' cannot be used in an embedded function not marked '@export(interface)' because 'directs' was imported implementation-only}}
+  // expected-embedded-error @-2 {{initializer 'init()' cannot be used in an embedded function not marked '@export(interface)' because 'directs' was imported implementation-only}}
+  private var hiddenInit: PublicProto = HiddenLayout()
+  // expected-embedded-error @-1 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
 
   private func privateFunc(h: HiddenLayout) {} // expected-embedded-error {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
 
@@ -846,6 +887,12 @@ private class PrivateClassUser: ProtocolFromDirect {
   private var h: ExposedProtocolInternal
   private var i: ExposedProtocolPrivate
   private var j: HiddenProtocol
+
+  private var importedInit: PublicProto = StructFromDirect()
+  // expected-embedded-error @-1 {{struct 'StructFromDirect' cannot be used in an embedded function not marked '@export(interface)' because 'directs' was imported implementation-only}}
+  // expected-embedded-error @-2 {{initializer 'init()' cannot be used in an embedded function not marked '@export(interface)' because 'directs' was imported implementation-only}}
+  private var hiddenInit: PublicProto = HiddenLayout()
+  // expected-embedded-error @-1 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
 
   private func privateFunc(h: HiddenLayout) {} // expected-embedded-error {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
 
@@ -880,6 +927,9 @@ internal class HiddenClassUser: ProtocolFromDirect {
   private var h: ExposedProtocolInternal
   private var i: ExposedProtocolPrivate
   private var j: HiddenProtocol
+
+  private var importedInit: PublicProto = StructFromDirect()
+  private var hiddenInit: PublicProto = HiddenLayout()
 }
 
 @_implementationOnly // expected-error {{'@_implementationOnly' may not be used on public declarations}}

--- a/test/Sema/hidden-memory-layout.swift
+++ b/test/Sema/hidden-memory-layout.swift
@@ -357,6 +357,9 @@ public struct ExposedLayoutFrozenUser: ProtocolFromDirect {
   private func privateFuncClass(h: HiddenClass) {}
   // expected-embedded-error @-1 {{class 'HiddenClass' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenClass' is marked '@_implementationOnly'}}
 
+  private func defaultArgFunc(arg: PublicProto = HiddenLayout()) {}
+  // expected-embedded-error @-1 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
+
   @_spi(S) public var s: SPIStruct
   // expected-error @-1 {{stored property 's' cannot be declared '@_spi' in a '@frozen' struct}}
   // expected-error @-2 {{cannot use struct 'SPIStruct' in a property declaration marked public or in a '@frozen' or '@usableFromInline' context; it is SPI}}
@@ -729,6 +732,9 @@ public class PublicClassUserWithoutDeinit: ProtocolFromDirect {
   // expected-embedded-error @-2 {{initializer 'init()' cannot be used in an embedded function not marked '@export(interface)' because 'directs' was imported implementation-only}}
   private var hiddenInit: PublicProto = HiddenLayout()
   // expected-embedded-error @-1 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
+
+  private func defaultArgFunc(arg: PublicProto = HiddenLayout()) {}
+  // expected-embedded-error @-1 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
 }
 
 open class OpenClassUser: ProtocolFromDirect {
@@ -768,6 +774,10 @@ open class OpenClassUser: ProtocolFromDirect {
   // expected-embedded-error @-2 {{initializer 'init()' cannot be used in an embedded function not marked '@export(interface)' because 'directs' was imported implementation-only}}
   private var hiddenInit: PublicProto = HiddenLayout()
   // expected-embedded-error @-1 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
+
+  private func defaultArgFunc(arg: PublicProto = HiddenLayout()) {}
+  // expected-embedded-error @-1 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
+
   @export(interface)
   private func privateFunc(h: HiddenLayout) {}
 
@@ -859,6 +869,9 @@ internal class InternalClassUser: ProtocolFromDirect {
 
   private func privateFunc(h: HiddenLayout) {} // expected-embedded-error {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
 
+  private func defaultArgFunc(arg: PublicProto = HiddenLayout()) {}
+  // expected-embedded-error @-1 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
+
   @export(interface)
   deinit {}
 }
@@ -895,6 +908,9 @@ private class PrivateClassUser: ProtocolFromDirect {
   // expected-embedded-error @-1 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
 
   private func privateFunc(h: HiddenLayout) {} // expected-embedded-error {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
+
+  private func defaultArgFunc(arg: PublicProto = HiddenLayout()) {}
+  // expected-embedded-error @-1 {{struct 'HiddenLayout' cannot be used in an embedded function not marked '@export(interface)' because 'HiddenLayout' is marked '@_implementationOnly'}}
 
   @export(interface)
   deinit {}

--- a/test/Sema/implementation-only-import-embedded.swift
+++ b/test/Sema/implementation-only-import-embedded.swift
@@ -89,8 +89,9 @@ public func implicitlyInlinablePublic(arg: StructFromDirect = StructFromDirect()
 }
 
 private func implicitlyInlinablePrivate(arg: StructFromDirect = StructFromDirect()) {
-// expected-error @-1 {{struct 'StructFromDirect' cannot be used in an embedded function not marked '@export(interface)' because 'directs' was imported implementation-only}}
+// expected-error @-1 2 {{struct 'StructFromDirect' cannot be used in an embedded function not marked '@export(interface)' because 'directs' was imported implementation-only}}
 // expected-note @-2 {{global function 'implicitlyInlinablePrivate(arg:)' is not '@usableFromInline' or public}}
+// expected-error @-3 {{initializer 'init()' cannot be used in an embedded function not marked '@export(interface)' because 'directs' was imported implementation-only}}
 
   _ = StructFromDirect() // expected-error {{initializer 'init()' cannot be used in an embedded function not marked '@export(interface)' because 'directs' was imported implementation-only}}
   // expected-error@-1 {{struct 'StructFromDirect' cannot be used in an embedded function not marked '@export(interface)' because 'directs' was imported implementation-only}}


### PR DESCRIPTION
Without library-evolution we can be more permissive about references to hidden dependencies from classes properties. However, lifting these checks broke other checks on properties. Here we fix this hole and ensure that while we allow references from stored properties we still checking implicit initializers and default arguments.

Followup to #87582.

rdar://173011223