### PR TITLE
SILGen: Workaround for mismatch in expected level of opaque archetype erasure when emitting function conversions

### DIFF
--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -705,9 +705,22 @@ ManagedValue Transform::transform(ManagedValue v,
 
   //  - existentials
   if (outputSubstType->isAnyExistentialType()) {
-    // We have to re-abstract payload if its a metatype or a function
-    v = SGF.emitSubstToOrigValue(Loc, v, AbstractionPattern::getOpaque(),
-                                 inputSubstType);
+    // We might have to re-abstract the payload if its a metatype, function,
+    // tuple, or optional.
+
+    auto loweredTy = v.getType();
+    auto inputLoweredTy = SGF.getLoweredType(AbstractionPattern::getOpaque(),
+                                             inputSubstType);
+    // FIXME: Gross workaround for incorrect opaque type erasure
+    if (loweredTy.getNominalOrBoundGenericNominal() &&
+        inputLoweredTy.is<OpaqueTypeArchetypeType>()) {
+      // Woohoo!
+      inputSubstType = loweredTy.getASTType();
+    } else {
+      v = SGF.emitSubstToOrigValue(Loc, v, AbstractionPattern::getOpaque(),
+                                   inputSubstType);
+    }
+
     return SGF.emitTransformExistential(Loc, v,
                                         inputSubstType, outputSubstType,
                                         ctxt);

--- a/test/SILGen/function_conversion_opaque.swift
+++ b/test/SILGen/function_conversion_opaque.swift
@@ -1,0 +1,44 @@
+// RUN: %target-swift-emit-silgen %s
+
+func f0<V>(_: () -> any P<V>) {}
+func f1<V>(_: V.Type, _: () -> any P<V>) {}
+func f2<V>(_: (V) -> (), _: () -> any P<V>) {}
+
+protocol P<A> {
+  associatedtype A
+}
+
+struct G<A>: P {}
+
+func g1() -> some P<Int> {
+  return G<Int>()
+}
+
+class B {}
+class C: B {}
+class D: C, P {
+  typealias A = Bool
+}
+
+func g2() -> some C & P {
+  return D()
+}
+
+func g3() -> (some P<Bool>, some C & P) {
+  return (G<Bool>(), D())
+}
+
+func test() {
+  let _: () -> any P<Int> = g1
+  let _: () -> B = g2
+  let _: () -> (any P, B) = g3
+
+  f0(g1)
+  f1(Int.self, g1)
+  f2({ $0 as Int }, g1)
+
+  f0({ g1() })
+  f1(Int.self, { g1() })
+  f2({ $0 as Int }, { g1() })
+}
+


### PR DESCRIPTION
The TypeExpansionContext of a function that emits a reabstraction thunk might differ from the TypeExpansionContext of the thunk itself.

This seems to cause a problem in one case at least, when emitting a function conversion from () -> some P to () -> any P where we can see the underlying type of the some P, we end up with a mismatch where the SIL type of the value was unwrapped, but the lowering of the formal type in the context of the thunk remains an opaque archetype.

One of the examples in the test was uncovered by binding inference changes producing a different but equivalent constraint system solution, but the remaining cases were already broken prior.

My change here is just a horrible workaround for this mismatch; the representational problem needs to be addressed properly elsewhere.

Fixes rdar://172130660.