### PR TITLE
Disable the lldb and playground support test in non-assertion preset too

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1560,6 +1560,14 @@ lldb-test-swift-only
 
 lit-args=-v --time-tests
 
+# SKIP LLDB TESTS (67923799)
+skip-test-lldb
+skip-test-playgroundsupport
+
+# Don't configure LLDB tests either since that
+# would require us to build libcxx (rdar://109774179)
+lldb-configure-tests=0
+
 # Path to the .tar.gz package we would create.
 installable-package=%(installable_package)s
 
@@ -1581,14 +1589,6 @@ mixin-preset=
     mixin_osx_package_base
     mixin_osx_package_test
     mixin_lightweight_assertions,no-stdlib-asserts
-
-# SKIP LLDB TESTS (67923799)
-skip-test-lldb
-skip-test-playgroundsupport
-
-# Don't configure LLDB tests either since that
-# would require us to build libcxx (rdar://109774179)
-lldb-configure-tests=0
 
 [preset: buildbot_osx_package,use_os_runtime]
 mixin-preset=


### PR DESCRIPTION
- **Explanation**:
  lldb and swift playground support tests are disabled in assertions enabled preset. We also need these tests disabled in non-assertions preset to produce toolchain.
- **Scope**:
Disable lldb and swift playground support tests 
- **Issues**: N/A
- **Original PRs**:
https://github.com/swiftlang/swift/pull/87994
- **Risk**:
  low, this is disabling the tests. 
- **Testing**:
 Verify by building non-assertion toolchain. 
- **Reviewers**:
@etcwilde @edymtt 