### PR TITLE
SILGen: add PrettyStackTraceDecl at top-level decl visitor

### DIFF
--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -880,6 +880,8 @@ bool SILGenModule::shouldSkipDecl(Decl *D) {
 }
 
 void SILGenModule::visit(Decl *D) {
+  PrettyStackTraceDecl debugStack("silgen visitDecl", D);
+
   if (shouldSkipDecl(D))
     return;
 


### PR DESCRIPTION
This is a non-functional change to improve descriptions in compiler backtraces.