### PR TITLE
[CSSimplify] Increase score when erasing typed throws into `throws`

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -42,6 +42,7 @@
 #include "swift/Sema/ConstraintSystem.h"
 #include "swift/Sema/IDETypeChecking.h"
 #include "swift/Sema/PreparedOverload.h"
+#include "swift/Sema/Score.h"
 #include "swift/Sema/Subtyping.h"
 #include "swift/Sema/TypeVariableType.h"
 #include "llvm/ADT/ArrayRef.h"
@@ -2829,6 +2830,16 @@ matchFunctionThrowing(ConstraintSystem &cs,
   Type thrownError2 = func2->getEffectiveThrownErrorTypeOrNever();
   if (!thrownError1 || !thrownError2)
     return cs.getTypeMatchSuccess();
+
+  // An attempt to erase typed throws into `throws` requires a function
+  // conversion and a heap allocation for the error type, so if there is an
+  // overload that takes typed throws it should be preferred.
+  if (func1->getThrownError() && !func2->getThrownError() &&
+      thrownError2->isErrorExistentialType()) {
+    cs.increaseScore(
+        SK_FunctionConversion,
+        locator.withPathElement(LocatorPathElt::ThrownErrorType()));
+  }
 
   switch (compareThrownErrorsForSubtyping(thrownError1, thrownError2, cs.DC)) {
   case ThrownErrorSubtyping::DropsThrows: {

--- a/test/SILGen/typed_throws.swift
+++ b/test/SILGen/typed_throws.swift
@@ -376,6 +376,43 @@ extension TypedThrowsProto where Err == Never {
   }
 }
 
+func testErasureWithOverloading() {
+  func simple(_: () throws -> Void) {}
+  func simple<E>(_: () throws(E) -> Void) {}
+
+  // CHECK-LABEL: sil private [ossa] @$s12typed_throws26testErasureWithOverloadingyyF0C0L_2fnyyyxYKXE_ts5ErrorRzlF
+  // CHECK: [[SIMPLE_WITH_TYPED_THROWS:%.*]] = function_ref @$s12typed_throws26testErasureWithOverloadingyyF6simpleL0_yyyyxYKXEs5ErrorRzlF
+  // CHECK: apply [[SIMPLE_WITH_TYPED_THROWS]]<E>(%0)
+  // CHECK: } // end sil function '$s12typed_throws26testErasureWithOverloadingyyF0C0L_2fnyyyxYKXE_ts5ErrorRzlF'
+  func test<E>(fn: () throws(E) -> Void) {
+    simple(fn)
+  }
+}
+
+// More complicated overloading scenario where typed throws overload should be preferred when argument is also typed throws.
+struct Data { 
+  var _storage: ArraySlice<UInt8>
+
+  // CHECK-LABEL: sil hidden [ossa] @$s12typed_throws4DataV15withUnsafeBytesyxxSWq_YKXEq_YKs5ErrorR_r0_lF
+  // CHECK: bb0([[RESULT:%.*]] : $*R, [[E:%.*]] : $*E, [[BODY:%.*]] : @guaranteed $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (UnsafeRawBufferPointer) -> (@out τ_0_1, @error_indirect τ_0_0) for <E, R>, [[SELF:%.*]] : @guaranteed $Data):
+  // CHECK: [[ARRAY_SLICE:%.*]] = copy_value {{.*}} : $ArraySlice<UInt8>
+  // CHECK: [[ARRAYSLICE_WITH_UNSAFE_BYTES:%.*]] = function_ref @$ss10ArraySliceV12typed_throwss5UInt8VRszlE15withUnsafeBytesyqd__qd__SWqd_0_YKXEqd_0_YKs5ErrorRd_0_r0_lF
+  // CHECK: [[ERROR:%.*]] = alloc_stack $E
+  // CHECK: try_apply [[ARRAYSLICE_WITH_UNSAFE_BYTES]]<UInt8, R, E>([[RESULT]], [[ERROR]], %2, [[ARRAY_SLICE]])
+  // CHECK: } // end sil function '$s12typed_throws4DataV15withUnsafeBytesyxxSWq_YKXEq_YKs5ErrorR_r0_lF'
+  func withUnsafeBytes<R, E: Error>(
+    _ body: (UnsafeRawBufferPointer) throws(E) -> R
+  ) throws(E) -> R {
+    try _storage.withUnsafeBytes(body)
+  }
+}
+
+extension ArraySlice where Element == UInt8 {
+  func withUnsafeBytes<R, E: Error>(
+    _ body: (UnsafeRawBufferPointer) throws(E) -> R
+  ) throws(E) -> R { fatalError() }
+}
+
 // CHECK-LABEL:      sil_vtable MySubclass {
 // CHECK-NEXT:   #MyClass.init!allocator: <E where E : Error> (MyClass.Type) -> (() throws(E) -> ()) throws(E) -> MyClass : @$s12typed_throws10MySubclassC4bodyACyyxYKXE_txYKcs5ErrorRzlufC [override]
 // CHECK-NEXT:  #MyClass.f: (MyClass) -> () throws -> () : @$s12typed_throws10MySubclassC1fyyAA0C5ErrorOYKFAA0C5ClassCADyyKFTV [override]


### PR DESCRIPTION
This erasure requires a function conversion and a heap allocation so if there is an overload that adopted typed throws it should be preferred over the one with regular `throws`.

Resolves: rdar://172779708

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
