### PR TITLE
AST: Factor out ASTContext::get{CGFloat,Double}InitDecl() from CSApply.cpp

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -761,6 +761,12 @@ public:
   /// promises to return non-null.
   bool hasArrayLiteralIntrinsics() const;
 
+  /// Retrieve the declaration of Swift.CGFloat.init(_: Double).
+  ConcreteDeclRef getCGFloatInitDecl() const;
+
+  /// Retrieve the declaration of Swift.Double.init(_: CGFloat).
+  ConcreteDeclRef getDoubleInitDecl() const;
+
   /// Retrieve the declaration of Swift.Bool.init(_builtinBooleanLiteral:)
   ConcreteDeclRef getBoolBuiltinInitDecl() const;
 

--- a/include/swift/AST/KnownSDKTypes.def
+++ b/include/swift/AST/KnownSDKTypes.def
@@ -30,7 +30,7 @@ KNOWN_SDK_TYPE_DECL(Foundation, NSCopying, ProtocolDecl, 0)
 KNOWN_SDK_TYPE_DECL(Foundation, NSError, ClassDecl, 0)
 KNOWN_SDK_TYPE_DECL(Foundation, NSNumber, ClassDecl, 0)
 KNOWN_SDK_TYPE_DECL(Foundation, NSValue, ClassDecl, 0)
-KNOWN_SDK_TYPE_DECL(Foundation, CGFloat, StructDecl, 0)
+KNOWN_SDK_TYPE_DECL(CoreFoundation, CGFloat, StructDecl, 0)
 
 KNOWN_SDK_TYPE_DECL(ObjectiveC, NSObject, ClassDecl, 0)
 KNOWN_SDK_TYPE_DECL(ObjectiveC, Selector, StructDecl, 0)

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1772,6 +1772,48 @@ ConcreteDeclRef ASTContext::getRegexInitDecl(Type regexType) const {
   return ConcreteDeclRef(foundDecl, subs);
 }
 
+
+static ConcreteDeclRef getCGFloatOrDoubleInitDecl(
+    ASTContext &ctx, Type fromType, Type toType) {
+  if (!toType || !fromType)
+    return ConcreteDeclRef();
+
+  // OK: Implicit conversion, no module selector to drop here.
+  DeclNameRef initRef(ctx, /*module selector=*/Identifier(),
+                      DeclBaseName::createConstructor(), { Identifier() });
+
+  auto *toDecl = toType->getAnyNominal();
+  SmallVector<ValueDecl *, 2> candidates;
+
+  // Using the nominal type as the declaration context bypasses access
+  // control. But there is only going to be one overload that exactly
+  // with no label and the right argument type.
+  toDecl->lookupQualified(toDecl, initRef, SourceLoc(),
+                          NL_QualifiedDefault, candidates);
+
+  for (auto *candidate : candidates) {
+    auto *ctor = cast<ConstructorDecl>(candidate);
+    auto fnType = ctor->getMethodInterfaceType()->castTo<FunctionType>();
+    if (fnType->getNumParams() == 1 &&
+        fnType->getParams()[0] == AnyFunctionType::Param(fromType) &&
+        fnType->getResult()->isEqual(toType)) {
+      return ConcreteDeclRef(ctor);
+    }
+  }
+
+  return ConcreteDeclRef();
+}
+
+ConcreteDeclRef ASTContext::getCGFloatInitDecl() const {
+  return getCGFloatOrDoubleInitDecl(const_cast<ASTContext &>(*this),
+                                    getDoubleType(), getCGFloatType());
+}
+
+ConcreteDeclRef ASTContext::getDoubleInitDecl() const {
+  return getCGFloatOrDoubleInitDecl(const_cast<ASTContext &>(*this),
+                                    getCGFloatType(), getDoubleType());
+}
+
 static
 FuncDecl *getBinaryComparisonOperatorIntDecl(const ASTContext &C, StringRef op,
                                              FuncDecl *&cached) {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7330,26 +7330,10 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
 
     case ConversionRestrictionKind::CGFloatToDouble:
     case ConversionRestrictionKind::DoubleToCGFloat: {
-      // OK: Implicit conversion, no module selector to drop here.
-      DeclNameRef initRef(ctx, /*module selector=*/Identifier(),
-                          DeclBaseName::createConstructor(), { Identifier() });
+      auto decl = (knownRestriction->second == ConversionRestrictionKind::CGFloatToDouble
+                    ? ctx.getDoubleInitDecl() : ctx.getCGFloatInitDecl());
 
-      ConstructorDecl *decl = nullptr;
-      SmallVector<ValueDecl *, 2> candidates;
-      dc->lookupQualified(toType->getAnyNominal(), initRef, SourceLoc(),
-                          NL_QualifiedDefault, candidates);
-      for (auto *candidate : candidates) {
-        auto *ctor = cast<ConstructorDecl>(candidate);
-        auto fnType = ctor->getMethodInterfaceType()->castTo<FunctionType>();
-        if (fnType->getNumParams() == 1 &&
-            fnType->getParams()[0].getPlainType()->isEqual(fromType) &&
-            fnType->getResult()->isEqual(toType)) {
-          decl = ctor;
-          break;
-        }
-      }
-
-      if (decl == nullptr) {
+      if (!decl) {
         ctx.Diags.diagnose(expr->getLoc(), diag::broken_stdlib_type,
                            toType->getAnyNominal()->getName().str());
         auto *errorExpr = new (ctx) ErrorExpr(SourceRange(), toType);
@@ -7358,11 +7342,13 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
         return errorExpr;
       }
 
+      auto *initType = decl.getDecl()->getInterfaceType()->castTo<FunctionType>();
+
       auto *ctorRefExpr =  new (ctx) DeclRefExpr(decl, DeclNameLoc(), /*Implicit=*/true);
-      ctorRefExpr->setType(decl->getInterfaceType());
+      ctorRefExpr->setType(initType);
       auto *typeExpr = TypeExpr::createImplicit(toType, ctx);
       auto *innerCall = ConstructorRefCallExpr::create(ctx, ctorRefExpr, typeExpr,
-                                                       decl->getMethodInterfaceType());
+                                                       initType->getResult());
       cs.cacheExprTypes(innerCall);
 
       auto *argList = ArgumentList::forImplicitUnlabeled(ctx, {cs.coerceToRValue(expr)});

--- a/test/Constraints/if_switch_expr_cgfloat_double_conversion.swift
+++ b/test/Constraints/if_switch_expr_cgfloat_double_conversion.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift %clang-importer-sdk
+// RUN: %target-typecheck-verify-swift -swift-version 5
 
 // REQUIRES: objc_interop
 

--- a/test/Constraints/implicit_double_cgfloat_conversion.swift
+++ b/test/Constraints/implicit_double_cgfloat_conversion.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift %clang-importer-sdk
-// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -swift-version 5 -verify %s | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -swift-version 5
+// RUN: %target-swift-emit-silgen -swift-version 5 -verify %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 
@@ -46,10 +46,9 @@ func test_various_situations_converting_to_cgfloat() {
 
   // CHECK: function_ref @$sSd12CoreGraphicsEySdAA7CGFloatVcfC : $@convention(method) (CGFloat, @thin Double.Type) -> Double
   // CHECK: function_ref @$sSd1poiyS2d_SdtFZ : $@convention(method) (Double, Double, @thin Double.Type) -> Double
-  // CHECK: function_ref @$sSd12CoreGraphicsEySdAA7CGFloatVcfC : $@convention(method) (CGFloat, @thin Double.Type) -> Double
-  // CHECK: function_ref @$sSd1soiyS2d_SdtFZ : $@convention(method) (Double, Double, @thin Double.Type) -> Double
   // CHECK: function_ref @$s12CoreGraphics7CGFloatVyACSdcfC : $@convention(method) (Double, @thin CGFloat.Type) -> CGFloat
-  test_to_cgfloat(d + cgf - cgf) // Double is always preferred over CGFloat, so three conversion here.
+  // CHECK: function_ref @$s12CoreGraphics7CGFloatV1soiyA2C_ACtFZ : $@convention(method) (CGFloat, CGFloat, @thin CGFloat.Type) -> CGFloat
+  test_to_cgfloat(d + cgf - cgf) // FIXME: We convert 'cgf' to Double, and then 'd + cgf' back to CGFloat here.
 
   // CHECK: function_ref @$s12CoreGraphics7CGFloatVyACSdcfC : $@convention(method) (Double, @thin CGFloat.Type) -> CGFloat
   // CHECK: function_ref @$s34implicit_double_cgfloat_conversion013test_returns_B0ySd12CoreGraphics7CGFloatVF : $@convention(thin) (CGFloat) -> Double
@@ -139,19 +138,31 @@ func test_narrowing_is_delayed(x: Double, y: CGFloat) {
   // CHECK: function_ref @$sSd1doiyS2d_SdtFZ
   // CHECK: function_ref @$s12CoreGraphics7CGFloatVyACSdcfC
   let _: CGFloat = x / y // CGFloat.init(x / Double.init(y))
+
+  // FIXME: The original intent here was to produce:
+  //
+  //    CGFloat.init(x / Double(y) + 1 as Double)
+  //
+  // But we actually get this with the real SDK:
+  //
+  //    CGFloat(x / Double(y)) + CGFloat(1 as Int)
+  //
   // CHECK: function_ref @$sSd12CoreGraphicsEySdAA7CGFloatVcfC
   // CHECK: function_ref @$sSd1doiyS2d_SdtFZ
-  // CHECK: function_ref @$sSd22_builtinIntegerLiteralSdBI_tcfC
-  // CHECK: function_ref @$sSd1poiyS2d_SdtFZ
   // CHECK: function_ref @$s12CoreGraphics7CGFloatVyACSdcfC
-  let _: CGFloat = x / y + 1 // CGFloat.init(x / Double(y) + 1 as Double)
+  // CHECK: function_ref @$sSi22_builtinIntegerLiteralSiBI_tcfC
+  // CHECK: function_ref @$s12CoreGraphics7CGFloatV14integerLiteralACSi_tcfC
+  // CHECK: function_ref @$s12CoreGraphics7CGFloatV1poiyA2C_ACtFZ
+  let _: CGFloat = x / y + 1
+
   // CHECK: function_ref @$sSd12CoreGraphicsEySdAA7CGFloatVcfC
   // CHECK: function_ref @$s34implicit_double_cgfloat_conversion25test_narrowing_is_delayed1x1yySd_12CoreGraphics7CGFloatVtF10overloadedL_yS2d_SdtF
   // CHECK: function_ref @$s12CoreGraphics7CGFloatVyACSdcf
   let _: CGFloat = overloaded(x, y) // Prefers `overloaded(Double, Double) -> Double`
+
   // CHECK: function_ref @$sSd12CoreGraphicsEySdAA7CGFloatVcfC
   // CHECK: function_ref @$s34implicit_double_cgfloat_conversion25test_narrowing_is_delayed1x1yySd_12CoreGraphics7CGFloatVtF10overloadedL_yS2d_SdtF
-  // CHECK: @$s34implicit_double_cgfloat_conversion25test_narrowing_is_delayed1x1yySd_12CoreGraphics7CGFloatVtF10overloadedL_yS2d_SdtF
+  // CHECK: function_ref @$s34implicit_double_cgfloat_conversion25test_narrowing_is_delayed1x1yySd_12CoreGraphics7CGFloatVtF10overloadedL_yS2d_SdtF
   // CHECK: function_ref @$s12CoreGraphics7CGFloatVyACSdcf
   let _: CGFloat = overloaded(x, overloaded(x, y)) // Prefers `overloaded(Double, Double) -> Double` in both occurrences.
 
@@ -160,28 +171,30 @@ func test_narrowing_is_delayed(x: Double, y: CGFloat) {
   // CHECK: function_ref @$sSd12CoreGraphicsEySdAA7CGFloatVcfC
   // CHECK: function_ref @$sSd1doiyS2d_SdtFZ
   // CHECK: function_ref @$s12CoreGraphics7CGFloatVyACSdcfC
+  // CHECK: function_ref @$s34implicit_double_cgfloat_conversion25test_narrowing_is_delayed1x1yySd_12CoreGraphics7CGFloatVtF0E0L_yyAGF
   test(x / y)
+
   // CHECK: function_ref @$sSd12CoreGraphicsEySdAA7CGFloatVcfC
   // CHECK: function_ref @$sSd1doiyS2d_SdtFZ
-  // CHECK: function_ref @$sSd22_builtinIntegerLiteralSdBI_tcfC
-  // CHECK: function_ref @$sSd1poiyS2d_SdtFZ
   // CHECK: function_ref @$s12CoreGraphics7CGFloatVyACSdcfC
+  // CHECK: function_ref @$sSi22_builtinIntegerLiteralSiBI_tcfC
+  // CHECK: function_ref @$s12CoreGraphics7CGFloatV14integerLiteralACSi_tcfC
+  // CHECK: function_ref @$s12CoreGraphics7CGFloatV1poiyA2C_ACtFZ
+  // CHECK: function_ref @$s34implicit_double_cgfloat_conversion25test_narrowing_is_delayed1x1yySd_12CoreGraphics7CGFloatVtF0E0L_yyAGF
   test(x / y + 1)
+
   // CHECK: function_ref @$sSd12CoreGraphicsEySdAA7CGFloatVcfC
   // CHECK: function_ref @$s34implicit_double_cgfloat_conversion25test_narrowing_is_delayed1x1yySd_12CoreGraphics7CGFloatVtF10overloadedL_yS2d_SdtF
   // CHECK: function_ref @$s12CoreGraphics7CGFloatVyACSdcf
+  // CHECK: function_ref @$s34implicit_double_cgfloat_conversion25test_narrowing_is_delayed1x1yySd_12CoreGraphics7CGFloatVtF0E0L_yyAGF
   test(overloaded(x, y))
+
   // CHECK: function_ref @$sSd12CoreGraphicsEySdAA7CGFloatVcfC
   // CHECK: function_ref @$s34implicit_double_cgfloat_conversion25test_narrowing_is_delayed1x1yySd_12CoreGraphics7CGFloatVtF10overloadedL_yS2d_SdtF
   // CHECK: @$s34implicit_double_cgfloat_conversion25test_narrowing_is_delayed1x1yySd_12CoreGraphics7CGFloatVtF10overloadedL_yS2d_SdtF
   // CHECK: function_ref @$s12CoreGraphics7CGFloatVyACSdcf
+  // CHECK: function_ref @$s34implicit_double_cgfloat_conversion25test_narrowing_is_delayed1x1yySd_12CoreGraphics7CGFloatVtF0E0L_yyAGF
   test(overloaded(x, overloaded(x, y)))
-}
-
-extension CGFloat {
-  static func /(_: CGFloat, _: CGFloat) -> CGFloat { fatalError() }
-
-  static prefix func -(_: Self) -> Self { fatalError() }
 }
 
 // Make sure that solution with no Double/CGFloat conversions is preferred
@@ -193,7 +206,13 @@ func test_no_ambiguity_with_unary_operators(width: CGFloat, height: CGFloat) {
     init(x: Int,     y: Int,     width: Int,     height: Int) {}
   }
 
-  // CHECK: function_ref @$s12CoreGraphics7CGFloatV34implicit_double_cgfloat_conversionE1doiyA2C_ACtFZ
+  // CHECK: function_ref @$sSi22_builtinIntegerLiteralSiBI_tcfC
+  // CHECK: function_ref @$s12CoreGraphics7CGFloatV14integerLiteralACSi_tcfC
+  // CHECK: function_ref @$s12CoreGraphics7CGFloatV1doiyA2C_ACtFZ
+  // CHECK: witness_method $CGFloat, #SignedNumeric."-" : <Self where Self : SignedNumeric> (Self.Type) -> (Self) -> Self
+  // CHECK: function_ref @$sSi22_builtinIntegerLiteralSiBI_tcfC
+  // CHECK: function_ref @$s12CoreGraphics7CGFloatV14integerLiteralACSi_tcfC
+  // CHECK: function_ref @$s12CoreGraphics7CGFloatV1doiyA2C_ACtFZ
   // CHECK: function_ref @$s34implicit_double_cgfloat_conversion38test_no_ambiguity_with_unary_operators5width6heighty12CoreGraphics7CGFloatV_AGtF1RL_V1x1yAcdiG_A3GtcfC
   _ = R(x: width / 4, y: -height / 2, width: width, height: height)
 }
@@ -221,10 +240,6 @@ func test_multi_argument_conversion_with_optional(d: Double, cgf: CGFloat) {
   func test(_: Double, _: CGFloat?) {}
 
   test(cgf, d) // Ok (CGFloat -> Double and Double? -> CGFloat?)
-}
-
-extension CGFloat: @retroactive Hashable {
-  public func hash(into hasher: inout Hasher) { fatalError() }
 }
 
 func test_collection_literals_as_call_arguments() {
@@ -371,7 +386,7 @@ do {
 func test_cgfloat_operator_is_attempted_with_literal_arguments(v: CGFloat?) {
   // Make sure that @autoclosure thunk calls CGFloat./ and not Double./
   // CHECK-LABEL: sil private [transparent] [ossa] @$s34implicit_double_cgfloat_conversion05test_C45_operator_is_attempted_with_literal_arguments1vy12CoreGraphics7CGFloatVSg_tFAFyKXEfu_
-  // CHECK: [[CGFLOAT_DIV_OP:%.*]] = function_ref @$s12CoreGraphics7CGFloatV34implicit_double_cgfloat_conversionE1doiyA2C_ACtFZ : $@convention(method) (CGFloat, CGFloat, @thin CGFloat.Type) -> CGFloat
+  // CHECK: [[CGFLOAT_DIV_OP:%.*]] = function_ref @$s12CoreGraphics7CGFloatV1doiyA2C_ACtFZ : $@convention(method) (CGFloat, CGFloat, @thin CGFloat.Type) -> CGFloat
   // CHECK-NEXT: {{.*}} = apply [[CGFLOAT_DIV_OP]]({{.*}}, %2) : $@convention(method) (CGFloat, CGFloat, @thin CGFloat.Type) -> CGFloat
   let ratio = v ?? (2.0 / 16.0)
   let _: CGFloat = ratio // Ok
@@ -379,6 +394,13 @@ func test_cgfloat_operator_is_attempted_with_literal_arguments(v: CGFloat?) {
 
 // Make sure that optimizer doesn't favor CGFloat -> Double conversion
 // in presence of CGFloat initializer, otherwise it could lead to ambiguities.
+//
+// FIXME: This regressed with the real CGFloat.init overload set from the
+// SDK, but this test file previously used the mock SDK which masked the
+// regression.
+//
+// See implicit_double_cgfloat_conversion_hacks.swift -- the test case passes
+// with -enable-solver-performance-hacks.
 func test_explicit_cgfloat_use_avoids_ambiguity(v: Int) {
   func test(_: CGFloat) -> CGFloat { 0 }
   func test(_: Double) -> Double { 0 }
@@ -387,9 +409,6 @@ func test_explicit_cgfloat_use_avoids_ambiguity(v: Int) {
 
   let arr = [test(CGFloat(v))]
   hasCGFloatElement(arr) // Ok
-
-  var total = 0.0 // This is Double by default
-  total += test(CGFloat(v)) + CGFloat(v) // Ok
 }
 
 // rdar://99352676

--- a/test/Constraints/implicit_double_cgfloat_conversion_hacks.swift
+++ b/test/Constraints/implicit_double_cgfloat_conversion_hacks.swift
@@ -1,0 +1,22 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5
+// RUN: %target-swift-frontend -swift-version 5 -typecheck %s -solver-enable-performance-hacks
+// RUN: %target-swift-emit-silgen -swift-version 5 -solver-enable-performance-hacks %s
+
+// REQUIRES: objc_interop
+import Foundation
+
+// Move this back to implicit_double_cgfloat_conversion.swift when fixed.
+
+func test_explicit_cgfloat_use_avoids_ambiguity(v: Int) {
+  func test(_: CGFloat) -> CGFloat { 0 } // expected-note {{found this candidate}}
+  func test(_: Double) -> Double { 0 } // expected-note {{found this candidate}}
+
+  func hasCGFloatElement<C: Collection>(_: C) where C.Element == CGFloat {}
+
+  let arr = [test(CGFloat(v))]
+  hasCGFloatElement(arr) // Ok
+
+  var total = 0.0 // This is Double by default
+  total += test(CGFloat(v)) + CGFloat(v)
+  // expected-error@-1 {{ambiguous use of 'test'}}
+}

--- a/test/Constraints/implicit_last_exprs_double_cgfloat_conversion.swift
+++ b/test/Constraints/implicit_last_exprs_double_cgfloat_conversion.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature ImplicitLastExprResults %clang-importer-sdk
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature ImplicitLastExprResults
 
 // REQUIRES: objc_interop
 // REQUIRES: swift_feature_ImplicitLastExprResults

--- a/test/Serialization/transitive_conformances_and_cgfloat_double.swift
+++ b/test/Serialization/transitive_conformances_and_cgfloat_double.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module %s -o %t -solver-enable-crash-on-valid-salvage -solver-disable-transitive-conformance
+// RUN: %target-swift-frontend -emit-module %s -o %t -solver-enable-crash-on-valid-salvage -solver-disable-transitive-conformance
 
 // REQUIRES: objc_interop
 

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar83666783.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar83666783.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck -verify
+// RUN: %target-swift-frontend %s -typecheck -verify
 // REQUIRES: objc_interop
 
 import Foundation

--- a/validation-test/Sema/type_checker_perf/fast/issue-52629.swift
+++ b/validation-test/Sema/type_checker_perf/fast/issue-52629.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck -verify -solver-scope-threshold=100
+// RUN: %target-swift-frontend %s -typecheck -verify -solver-scope-threshold=100
 // REQUIRES: objc_interop
 
 // https://github.com/swiftlang/swift/issues/52629


### PR DESCRIPTION
Also, since the mock SDK's implementation of CGFloat is wrong, update some existing tests to use the real SDK instead. This exposed a few instances where the behavior was not as intended; I added FIXME comments explaining what's going on.