### PR TITLE
utils: push DocC up in the build order

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -4488,16 +4488,16 @@ if (-not $SkipBuild) {
 Install-HostToolchain
 
 if (-not $SkipBuild) {
+  Invoke-BuildStep Build-SymbolKit $HostPlatform
+  Invoke-BuildStep Build-DocC $HostPlatform
+}
+
+if (-not $SkipBuild) {
   Invoke-BuildStep Build-mimalloc $HostPlatform
 }
 
 if (-not $SkipBuild -and $IncludeNoAsserts) {
   Build-NoAssertsToolchain
-}
-
-if (-not $SkipBuild) {
-  Invoke-BuildStep Build-SymbolKit $HostPlatform
-  Invoke-BuildStep Build-DocC $HostPlatform
 }
 
 if (-not $SkipBuild) {


### PR DESCRIPTION
Ensure that we build DocC before we do the mimalloc transition. This is important to ensure that we are able to build a full NoAsserts toolchain.