### PR TITLE
[CS] Better handle rewriting implicit `callAsFunction` call splitting 

### DIFF
--- a/include/swift/Sema/CSTrail.def
+++ b/include/swift/Sema/CSTrail.def
@@ -78,7 +78,7 @@ LOCATOR_CHANGE(RecordedOpenedExistentialType, OpenedExistentialTypes)
 LOCATOR_CHANGE(RecordedDefaultedConstraint, DefaultedConstraints)
 LOCATOR_CHANGE(ResolvedOverload, ResolvedOverloads)
 LOCATOR_CHANGE(RecordedArgumentList, ArgumentLists)
-LOCATOR_CHANGE(RecordedImplicitCallAsFunctionRoot, ImplicitCallAsFunctionRoots)
+LOCATOR_CHANGE(RecordedImplicitCallAsFunction, ImplicitCallAsFunctions)
 LOCATOR_CHANGE(RecordedSynthesizedConformance, SynthesizedConformances)
 
 EXPR_CHANGE(AppliedPropertyWrapper)

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1086,11 +1086,11 @@ public:
   llvm::DenseMap<NominalTypeDecl *, DynamicCallableMethods>
       DynamicCallableCache;
 
-  /// A cache of implicitly generated dot-member expressions used as roots
+  /// A cache of implicitly generated dot-member expressions and argument lists
   /// for some `.callAsFunction` calls. The key here is "base" locator for
   /// the `.callAsFunction` member reference.
-  llvm::SmallDenseMap<ConstraintLocator *, UnresolvedDotExpr *, 2>
-      ImplicitCallAsFunctionRoots;
+  llvm::SmallDenseMap<ConstraintLocator *, ImplicitCallAsFunctionInfo, 2>
+      ImplicitCallAsFunctions;
 
   /// The set of conformances synthesized during solving (i.e. for
   /// ad-hoc distributed `SerializationRequirement` conformances).
@@ -2069,8 +2069,15 @@ public:
   void recordMatchCallArgumentResult(ConstraintLocator *locator,
                                      MatchCallArgumentResult result);
 
-  void recordImplicitCallAsFunctionRoot(
-      ConstraintLocator *locator, UnresolvedDotExpr *root);
+  /// Record a new implicit `callAsFunction` call for a split argument list
+  /// e.g `T(...) {}` -> `T(...).callAsFunction {}`
+  ///
+  /// \param root The member access to \c callAsFunction
+  /// \param baseArgs The new arguments for the base \c T(...) call. The
+  /// arguments for the \c callAsFunction call are recorded on the \c root
+  void recordImplicitCallAsFunction(ConstraintLocator *locator,
+                                    UnresolvedDotExpr *root,
+                                    ArgumentList *baseArgs);
 
   /// Record root, value, and declContext of keypath expression for use across
   /// constraint system, and add a change to the trail.

--- a/include/swift/Sema/Solution.h
+++ b/include/swift/Sema/Solution.h
@@ -337,6 +337,14 @@ struct CaseLabelItemInfo {
   Expr *guardExpr;
 };
 
+struct ImplicitCallAsFunctionInfo {
+  /// The implicit `callAsFunction` member.
+  UnresolvedDotExpr *Member;
+  /// The new set of arguments for the base expression that the `callAsFunction`
+  /// will be applied on top of, i.e the non-trailing arguments.
+  ArgumentList *BaseArgs;
+};
+
 /// A complete solution to a constraint system.
 ///
 /// A solution to a constraint system consists of type variable bindings to
@@ -492,9 +500,9 @@ public:
   /// constructions) to the argument lists for the call to that locator.
   llvm::DenseMap<ConstraintLocator *, ArgumentList *> argumentLists;
 
-  /// The set of implicitly generated `.callAsFunction` root expressions.
-  llvm::DenseMap<ConstraintLocator *, UnresolvedDotExpr *>
-      ImplicitCallAsFunctionRoots;
+  /// The info for implicitly generated `.callAsFunction` expressions.
+  llvm::DenseMap<ConstraintLocator *, ImplicitCallAsFunctionInfo>
+      ImplicitCallAsFunctions;
 
   /// The set of conformances synthesized during solving (i.e. for
   /// ad-hoc distributed `SerializationRequirement` conformances).

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8544,21 +8544,15 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
     return result;
   }
 
-  // We're constructing a value of nominal type. Look for the constructor or
-  // enum element to use.
-  auto *ctorLocator =
-      cs.getConstraintLocator(locator, {ConstraintLocator::ApplyFunction,
-                                        ConstraintLocator::ConstructorMember});
-  auto selected = solution.getOverloadChoice(ctorLocator);
-
+  // We're constructing a value of nominal type.
   assert(ty->getNominalOrBoundGenericNominal() || ty->is<DynamicSelfType>() ||
          ty->isExistentialType() || ty->is<ArchetypeType>());
 
   // Consider the constructor decl reference expr 'implicit', but the
   // constructor call expr itself has the apply's 'implicitness'.
   Expr *declRef = buildMemberRef(
-      fn, /*dotLoc=*/SourceLoc(), selected, DeclNameLoc(fn->getEndLoc()),
-      locator, ctorLocator, /*implicit=*/true, AccessSemantics::Ordinary);
+      fn, /*dotLoc=*/SourceLoc(), overload.value(), DeclNameLoc(fn->getEndLoc()),
+      locator, calleeLoc, /*implicit=*/true, AccessSemantics::Ordinary);
   if (!declRef)
     return nullptr;
 
@@ -8568,14 +8562,14 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
   apply->setFn(declRef);
 
   // Tail-recur to actually call the constructor.
-  auto *ctorCall = finishApply(apply, openedType, locator, ctorLocator);
+  auto *ctorCall = finishApply(apply, openedType, locator, calleeLoc);
 
   // Check whether this is a situation like `T(...) { ... }` where `T` is
   // a callable type and trailing closure(s) are associated with implicit
   // `.callAsFunction` instead of constructor.
   {
     auto callAsFunction =
-        solution.ImplicitCallAsFunctionRoots.find(ctorLocator);
+        solution.ImplicitCallAsFunctionRoots.find(calleeLoc);
     if (callAsFunction != solution.ImplicitCallAsFunctionRoots.end()) {
       auto *dotExpr = callAsFunction->second;
       auto resultTy = solution.getResolvedType(dotExpr);

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6257,6 +6257,18 @@ ArgumentList *ExprRewriter::coerceCallArguments(
     substitutedBindings = parameterBindings;
   }
 
+  // First verify the correct number of arguments are being bound.
+  {
+    SmallSetVector<unsigned, 4> boundArgs;
+    for (auto &boundArgIdxs : substitutedBindings) {
+      for (auto idx : boundArgIdxs) {
+        auto inserted = boundArgs.insert(idx);
+        ASSERT(inserted && "Passing same arg twice?");
+      }
+    }
+    ASSERT(boundArgs.size() == args->size() && "Args and params don't line up");
+  }
+
   SmallVector<Argument, 4> newArgs;
   for (unsigned paramIdx = 0, numParams = substitutedBindings.size();
        paramIdx != numParams; ++paramIdx) {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -715,10 +715,15 @@ namespace {
     /// A stack of expressions being walked, used to compute existential depth.
     llvm::SmallVector<Expr *, 8> ExprStack;
 
-    /// A map of apply exprs to their callee locators. This is necessary
-    /// because after rewriting an apply's function expr, its callee locator
-    /// will no longer be equivalent to the one stored in the solution.
-    llvm::DenseMap<ApplyExpr *, ConstraintLocator *> CalleeLocators;
+    struct CallLocatorInfo {
+      ConstraintLocator *callLoc;
+      ConstraintLocator *calleeLoc;
+    };
+
+    /// A map of apply exprs to their call locators. This is necessary
+    /// because after rewriting an apply's function expr, its locators may no
+    /// longer be equivalent to the ones stored in the solution.
+    llvm::DenseMap<ApplyExpr *, CallLocatorInfo> CallLocators;
 
     /// A cache of decl references with their contextual substitutions for a
     /// given callee locator.
@@ -4026,10 +4031,9 @@ namespace {
     }
 
     Expr *visitApplyExpr(ApplyExpr *expr) {
-      auto *calleeLoc = CalleeLocators[expr];
-      assert(calleeLoc);
-      return finishApply(expr, cs.getType(expr), cs.getConstraintLocator(expr),
-                         calleeLoc);
+      auto [callLoc, calleeLoc] = CallLocators[expr];
+      ASSERT(callLoc && calleeLoc);
+      return finishApply(expr, cs.getType(expr), callLoc, calleeLoc);
     }
 
     Expr *visitRebindSelfInConstructorExpr(RebindSelfInConstructorExpr *expr) {
@@ -5572,15 +5576,49 @@ namespace {
       return E;
     }
 
-    /// Interface for ExprWalker
-    void walkToExprPre(Expr *expr) {
-      // If we have an apply, make a note of its callee locator prior to
-      // rewriting.
-      if (auto *apply = dyn_cast<ApplyExpr>(expr)) {
-        auto *calleeLoc = cs.getCalleeLocator(cs.getConstraintLocator(expr));
-        CalleeLocators[apply] = calleeLoc;
+    ApplyExpr *preWalkApplyExpr(ApplyExpr *apply) {
+      // If we've already seen this apply, continue. This is necessary since
+      // we can nest the apply in an outer `callAsFunction` apply below.
+      if (CallLocators.contains(apply))
+        return apply;
+
+      // Make a note of its call/callee locator prior to rewriting.
+      auto *callLoc = cs.getConstraintLocator(apply);
+      auto *calleeLoc = cs.getCalleeLocator(callLoc);
+      CallLocators.insert({apply, {callLoc, calleeLoc}});
+
+      // Fix-up the apply if needed for an implicit `callAsFunction` for cases
+      // where we've split e.g `T(...) {}` into `T(...).callAsFunction({})`.
+      auto callAsFnIter = solution.ImplicitCallAsFunctions.find(calleeLoc);
+      if (callAsFnIter != solution.ImplicitCallAsFunctions.end()) {
+        // Update the argument list to only include the non-trailing args.
+        apply->setArgs(callAsFnIter->second.BaseArgs);
+
+        // Pull out the new args and form the call to `callAsFunction`.
+        auto *dotExpr = callAsFnIter->second.Member;
+        auto *newArgs = solution.getArgumentList(
+            cs.getConstraintLocator(dotExpr, ConstraintLocator::ApplyArgument));
+
+        auto *implicitCall = CallExpr::createImplicit(ctx, apply, newArgs);
+        cs.setType(implicitCall, solution.getResolvedType(dotExpr));
+
+        auto *memberLoc = cs.getConstraintLocator(dotExpr);
+        auto *memberCalleeLoc = cs.getConstraintLocator(
+            memberLoc, {LocatorPathElt::ApplyFunction(),
+                        LocatorPathElt::ImplicitCallAsFunction()});
+        CallLocators.insert({implicitCall, {memberLoc, memberCalleeLoc}});
+        return implicitCall;
       }
+      return apply;
+    }
+
+    /// Interface for ExprWalker
+    Expr *walkToExprPre(Expr *expr) {
+      if (auto *apply = dyn_cast<ApplyExpr>(expr))
+        expr = preWalkApplyExpr(apply);
+
       ExprStack.push_back(expr);
+      return expr;
     }
 
     Expr *walkToExprPost(Expr *expr) {
@@ -7774,7 +7812,7 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
 
           ConstraintLocator *calleeLoc = nullptr;
           if (auto *call = getAsExpr<ApplyExpr>(locator.getAnchor())) {
-            calleeLoc = CalleeLocators[call];
+            calleeLoc = CallLocators[call].calleeLoc;
           } else {
             calleeLoc =
                 solution.getCalleeLocator(cs.getConstraintLocator(locator));
@@ -8562,38 +8600,7 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
   apply->setFn(declRef);
 
   // Tail-recur to actually call the constructor.
-  auto *ctorCall = finishApply(apply, openedType, locator, calleeLoc);
-
-  // Check whether this is a situation like `T(...) { ... }` where `T` is
-  // a callable type and trailing closure(s) are associated with implicit
-  // `.callAsFunction` instead of constructor.
-  {
-    auto callAsFunction =
-        solution.ImplicitCallAsFunctionRoots.find(calleeLoc);
-    if (callAsFunction != solution.ImplicitCallAsFunctionRoots.end()) {
-      auto *dotExpr = callAsFunction->second;
-      auto resultTy = solution.getResolvedType(dotExpr);
-
-      auto *implicitCall = CallExpr::createImplicit(
-          ctx, ctorCall,
-          solution.getArgumentList(cs.getConstraintLocator(
-              dotExpr, ConstraintLocator::ApplyArgument)));
-
-      implicitCall->setType(resultTy);
-      cs.cacheType(implicitCall);
-
-      auto *memberCalleeLoc =
-          cs.getConstraintLocator(dotExpr,
-                                  {ConstraintLocator::ApplyFunction,
-                                   ConstraintLocator::ImplicitCallAsFunction},
-                                  /*summaryFlags=*/0);
-
-      return finishApply(implicitCall, resultTy, cs.getConstraintLocator(dotExpr),
-                         memberCalleeLoc);
-    }
-  }
-
-  return ctorCall;
+  return finishApply(apply, openedType, locator, calleeLoc);
 }
 
 bool ExprRewriter::isDistributedThunk(ConcreteDeclRef ref, Expr *context) {
@@ -8955,7 +8962,7 @@ namespace {
         }
       }
 
-      Rewriter.walkToExprPre(expr);
+      expr = Rewriter.walkToExprPre(expr);
       return Action::Continue(expr);
     }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -13242,10 +13242,9 @@ ConstraintSystem::simplifyKeyPathApplicationConstraint(
 
 /// Create an implicit dot-member reference expression to be used
 /// as a root for injected `.callAsFunction` call.
-static UnresolvedDotExpr *
-createImplicitRootForCallAsFunction(ConstraintSystem &cs, Type refType,
-                                    ArgumentList *arguments,
-                                    ConstraintLocator *calleeLocator) {
+static UnresolvedDotExpr *createImplicitRootForCallAsFunction(
+    ConstraintSystem &cs, Type refType, ArgumentList *baseArgs,
+    ArgumentList *trailingArgs, ConstraintLocator *calleeLocator) {
   auto &ctx = cs.getASTContext();
   auto *baseExpr = castToExpr(calleeLocator->getAnchor());
 
@@ -13254,17 +13253,17 @@ createImplicitRootForCallAsFunction(ConstraintSystem &cs, Type refType,
   // for new argument list that only has trailing closures in it.
   auto *implicitRef = UnresolvedDotExpr::createImplicit(
       ctx, baseExpr, {ctx.Id_callAsFunction},
-      arguments->getArgumentLabels(closureLabelsScratch));
+      trailingArgs->getArgumentLabels(closureLabelsScratch));
 
   {
     // Record a type of the new reference in the constraint system.
     cs.setType(implicitRef, refType);
     // Record new `.callAsFunction` in the constraint system.
-    cs.recordImplicitCallAsFunctionRoot(calleeLocator, implicitRef);
+    cs.recordImplicitCallAsFunction(calleeLocator, implicitRef, baseArgs);
 
     auto *implicitRefLocator = cs.getConstraintLocator(
         implicitRef, ConstraintLocator::ApplyArgument);
-    cs.associateArgumentList(implicitRefLocator, arguments);
+    cs.associateArgumentList(implicitRefLocator, trailingArgs);
   }
 
   return implicitRef;
@@ -13501,7 +13500,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyApplicableFnConstraint(
                                          /*firstTrailingClosureIndex=*/0);
 
         auto *implicitRef = createImplicitRootForCallAsFunction(
-            *this, callAsFunctionResultTy, implicitCallArgumentList, calleeLoc);
+            *this, callAsFunctionResultTy, newArgumentList,
+            implicitCallArgumentList, calleeLoc);
 
         auto callAsFunctionArguments =
             FunctionType::get(trailingClosureTypes, callAsFunctionResultTy,
@@ -15408,13 +15408,15 @@ void ConstraintSystem::recordMatchCallArgumentResult(
     recordChange(SolverTrail::Change::RecordedMatchCallArgumentResult(locator));
 }
 
-void ConstraintSystem::recordImplicitCallAsFunctionRoot(
-    ConstraintLocator *locator, UnresolvedDotExpr *root) {
-  bool inserted = ImplicitCallAsFunctionRoots.insert({locator, root}).second;
+void ConstraintSystem::recordImplicitCallAsFunction(ConstraintLocator *locator,
+                                                    UnresolvedDotExpr *root,
+                                                    ArgumentList *baseArgs) {
+  ImplicitCallAsFunctionInfo info{root, baseArgs};
+  bool inserted = ImplicitCallAsFunctions.insert({locator, info}).second;
   ASSERT(inserted);
 
   if (solverState)
-    recordChange(SolverTrail::Change::RecordedImplicitCallAsFunctionRoot(locator));
+    recordChange(SolverTrail::Change::RecordedImplicitCallAsFunction(locator));
 }
 
 void ConstraintSystem::recordKeyPath(const KeyPathExpr *keypath,

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -242,8 +242,8 @@ Solution ConstraintSystem::finalize() {
     solution.argumentLists.insert(argListMapping);
   }
 
-  for (const auto &implicitRoot : ImplicitCallAsFunctionRoots) {
-    solution.ImplicitCallAsFunctionRoots.insert(implicitRoot);
+  for (const auto &implicitInfo : ImplicitCallAsFunctions) {
+    solution.ImplicitCallAsFunctions.insert(implicitInfo);
   }
 
   for (const auto &env : PackExpansionEnvironments) {
@@ -440,9 +440,11 @@ void ConstraintSystem::replaySolution(const Solution &solution,
       recordArgumentList(argListMapping.first, argListMapping.second);
   }
 
-  for (auto &implicitRoot : solution.ImplicitCallAsFunctionRoots) {
-    if (ImplicitCallAsFunctionRoots.count(implicitRoot.first) == 0)
-      recordImplicitCallAsFunctionRoot(implicitRoot.first, implicitRoot.second);
+  for (auto &implicitInfo : solution.ImplicitCallAsFunctions) {
+    if (ImplicitCallAsFunctions.count(implicitInfo.first) == 0)
+      recordImplicitCallAsFunction(implicitInfo.first,
+                                   implicitInfo.second.Member,
+                                   implicitInfo.second.BaseArgs);
   }
 
   for (auto &synthesized : solution.SynthesizedConformances) {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1927,7 +1927,7 @@ size_t Solution::getTotalMemory() const {
          size_in_bytes(resultBuilderTransformed) +
          size_in_bytes(appliedPropertyWrappers) +
          size_in_bytes(argumentLists) +
-         size_in_bytes(ImplicitCallAsFunctionRoots) +
+         size_in_bytes(ImplicitCallAsFunctions) +
          size_in_bytes(SynthesizedConformances);
   // clang-format on
 

--- a/test/Constraints/callAsFunction.swift
+++ b/test/Constraints/callAsFunction.swift
@@ -105,7 +105,7 @@ func test_no_filtering_of_overloads() {
   }
 
   test {
-    _ = S() { // Ok
+    _ = S() { // expected-warning {{using '_' to ignore the result of a Void-returning function is redundant}}
       _ = 42
       print("Hello")
     }

--- a/test/Interpreter/callAsFunction_init_exec.swift
+++ b/test/Interpreter/callAsFunction_init_exec.swift
@@ -1,0 +1,49 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+// REQUIRES: executable_test
+
+struct S1: CustomStringConvertible {
+  var x: Int
+
+  init(_ x: Int = 1) {
+    self.x = x
+  }
+  func callAsFunction(_ y: Int = 2, _ fn: () -> Int) -> S1 {
+    S1(x + y + fn())
+  }
+  var description: String {
+    "S1: \(x)"
+  }
+}
+
+struct S2 {
+  var x: Int
+
+  init(_ x: Int = 1) {
+    self.x = x
+  }
+  func callAsFunction(_ y: Int = 2, _ fn: () -> Int) -> String {
+    "S2: \(x + y + fn())"
+  }
+}
+
+print(S1() { 4 })
+// CHECK: S1: 7
+print(S1.init() { 8 })
+// CHECK: S1: 11
+print(.init() { 16 } as S1)
+// CHECK: S1: 19
+print(S1(32) { 1 })
+// CHECK: S1: 35
+print(S1.init(64) { 1 })
+// CHECK: S1: 67
+print(.init(128) { 1 } as S1)
+// CHECK: S1: 131
+
+print(S2() { 4 })
+// CHECK: S2: 7
+print(S2.init() { 8 })
+// CHECK: S2: 11
+print(S2(32) { 1 })
+// CHECK: S2: 35
+print(S2.init(64) { 1 })
+// CHECK: S2: 67

--- a/validation-test/compiler_crashers_fixed/ExprRewriter-coerceToType-df86fa.swift
+++ b/validation-test/compiler_crashers_fixed/ExprRewriter-coerceToType-df86fa.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","signature":"(anonymous namespace)::ExprRewriter::coerceToType(swift::Expr*, swift::Type, swift::constraints::ConstraintLocatorBuilder)","signatureNext":"Solution::coerceToType"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 struct a {
     callAsFunction( () -> Void)
   _ = a.  init {


### PR DESCRIPTION
The previous logic was relying on doing `coerceCallArguments` with the full argument list instead of only the non-trailing args, and wasn't handling the non-shorthand-init case. Update the logic to fix-up the apply during the pre-walk, ensuring it gets applied consistently.

Resolves #87121
rdar://170076966