### PR TITLE
Adjust AsyncIteratorProtocol default next() availability

### DIFF
--- a/stdlib/public/Concurrency/AsyncIteratorProtocol.swift
+++ b/stdlib/public/Concurrency/AsyncIteratorProtocol.swift
@@ -130,7 +130,7 @@ extension AsyncIteratorProtocol {
   /// Default implementation of `next()` in terms of `next(isolation:)`, which
   /// is required to maintain backward compatibility with existing async
   /// iterators.
-  @available(SwiftStdlib 6.0, *)
+  @available(SwiftStdlib 6.1, *)
   @inlinable
   public mutating func next() async throws(Failure) -> Element? {
     return try await next(isolation: nil)

--- a/test/Concurrency/async_iterator_default_next_availability.swift
+++ b/test/Concurrency/async_iterator_default_next_availability.swift
@@ -1,0 +1,26 @@
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx15.0 -swift-version 6
+
+// REQUIRES: OS=macosx, concurrency
+
+struct Counter: AsyncIteratorProtocol {
+  typealias Element = Int
+  typealias Failure = Never
+
+  mutating func next(isolation actor: isolated (any Actor)?) async -> Int? {
+    0
+  }
+}
+
+func testDefaultNext() async {
+  var iterator = Counter()
+  _ = await iterator.next() // expected-error {{'next()' is only available in SwiftStdlib 6.1 or newer}}
+  // expected-note@-1 {{add @available attribute to enclosing global function}}
+  // expected-note@-2 {{add 'if #available' version check}}
+}
+
+func testDefaultNextWithAvailabilityCheck() async {
+  var iterator = Counter()
+  if #available(SwiftStdlib 6.1, *) {
+    _ = await iterator.next()
+  }
+}

--- a/test/Concurrency/sending_asynciteratornext_typechecker_error.swift
+++ b/test/Concurrency/sending_asynciteratornext_typechecker_error.swift
@@ -49,7 +49,7 @@ extension AsyncIteratorProtocol {
   /// Default implementation of `next()` in terms of `next(isolation:)`, which
   /// is required to maintain backward compatibility with existing async
   /// iterators.
-  @available(SwiftStdlib 6.0, *)
+  @available(SwiftStdlib 6.1, *)
   @inlinable
   public mutating func next() async throws(Failure) -> sending Element? {
     return try await next(isolation: nil)
@@ -70,4 +70,3 @@ public struct FakeMapSequence<T> : AsyncIteratorProtocol {
     fatalError()
   }
 }
-


### PR DESCRIPTION
Fixes #87849

## Summary
- change the default AsyncIteratorProtocol.next() wrapper to SwiftStdlib 6.1 availability
- keep the mirrored availability test declaration in sync
- add a regression test for iterators that only implement next(isolation:)

## Testing
- git diff --check
- full in-tree Swift test execution was not available in this checkout