### PR TITLE
[Concurrency] Reject isolated conformances escaping through async callees

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8997,9 +8997,9 @@ GROUPED_ERROR(isolated_conformance_to_sendable_metatype,IsolatedConformances,non
     "cannot form %0 conformance of %1 to SendableMetatype-inheriting %kind2",
     (ActorIsolation, Type, const ValueDecl *))
 GROUPED_ERROR(isolated_conformance_may_cross_isolation,IsolatedConformances,none,
-    "conformance of %select{generic parameter|%0}0 to %1 may be isolated and "
-    "cannot be used in %2 context",
-    (Identifier, DeclName, ActorIsolation))
+    "conformance of %select{underlying type of 'some %1'|%0}0 to protocol "
+    "'%1' may be isolated and cannot be passed to %2 context",
+    (Identifier, StringRef, ActorIsolation))
 
 //===----------------------------------------------------------------------===//
 // MARK: @_inheritActorContext

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8996,6 +8996,10 @@ GROUPED_WARNING(isolated_conformance_will_become_nonisolated,IsolatedConformance
 GROUPED_ERROR(isolated_conformance_to_sendable_metatype,IsolatedConformances,none,
     "cannot form %0 conformance of %1 to SendableMetatype-inheriting %kind2",
     (ActorIsolation, Type, const ValueDecl *))
+GROUPED_ERROR(isolated_conformance_may_cross_isolation,IsolatedConformances,none,
+    "conformance of %select{generic parameter|%0}0 to %1 may be isolated and "
+    "cannot be used in %2 context",
+    (Identifier, DeclName, ActorIsolation))
 
 //===----------------------------------------------------------------------===//
 // MARK: @_inheritActorContext

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4539,11 +4539,30 @@ namespace {
       if (!declRef)
         return false;
 
+      auto *const decl = declRef.getDecl();
+
       // Make sure isolated conformances are formed in the right context.
       checkIsolatedConformancesInContext(declRef, loc, getDeclContext(),
                                          RefineConformances{*this});
 
-      auto *const decl = declRef.getDecl();
+      // Also, prevent isolated conformances to "escape" the isolated context through
+      // calls to async functions because these may either run on a different executor
+      // (escaped-to-func is @concurrent), or may pass the conformance along to another
+      // function which would then violate safety even if the first method we called did
+      // dynamically inherit the right context (escaped-to-func is nonisolated(nonsending)).
+      //
+      // This applies to every async callee whose isolation differs from the conformance — nonisolated,
+      // nonisolated(nonsending), and even callees isolated to a *different* global actor.
+      //
+      // Synchronous callees are safe because they cannot change the executor, and they can't escape the
+      // passed parameter without hitting Sendable safeguards.
+      if (auto *funcDecl = dyn_cast<AbstractFunctionDecl>(decl)) {
+        if (funcDecl->hasAsync()) {
+          checkIsolatedConformancesInContext(declRef, loc,
+                                             funcDecl,
+                                             RefineConformances{*this});
+        }
+      }
 
       // If this declaration is a callee from the enclosing application,
       // it's already been checked via the call.

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "TypeCheckConcurrency.h"
+#include "../AST/AbstractConformance.h"
 #include "MiscDiagnostics.h"
 #include "NonisolatedNonsendingByDefaultMigration.h"
 #include "TypeCheckDistributed.h"
@@ -9079,46 +9080,39 @@ bool swift::checkIsolatedConformancesForIsolationCrossing(
   if (diagnosed)
     return diagnosed;
 
+  auto &ctx = dc->getASTContext();
+  auto *sendableMetatypeProto =
+      ctx.getProtocol(KnownProtocolKind::SendableMetatype);
+
   // Also check for abstract conformances, since if we can't prove they are nonisolated,
   // we must conservatively reject them.
-  //
-  // For protocol member calls, the Self conformance is used for witness
-  // dispatch and doesn't escape to another context, so we skip it.
-  // However, any other generic parameters on the method ARE forwarded.
   if (auto subs = declRef.getSubstitutions()) {
-    auto &ctx = dc->getASTContext();
-    auto *sendableMetatypeProto =
-        ctx.getProtocol(KnownProtocolKind::SendableMetatype);
-
-    // Determine if the callee is a protocol member, in which case
-    // the Self conformance is used for dispatch, not forwarding.
+    // For protocol member calls, the Self conformance is used for witness
+    // dispatch and doesn't escape to another context, so we skip it.
     Type selfInterfaceType;
     if (auto *calleeProto =
             declRef.getDecl()->getDeclContext()->getSelfProtocolDecl()) {
       selfInterfaceType = calleeProto->getSelfInterfaceType();
     }
 
-    auto genericSig = subs.getGenericSignature();
-    auto conformances = subs.getConformances();
-    unsigned confIdx = 0;
-    for (auto req : genericSig.getRequirements()) {
-      if (req.getKind() != RequirementKind::Conformance)
-        continue;
-
-      auto conf = conformances[confIdx++];
-
+    for (auto conf : subs.getConformances()) {
       // We're only checking abstract conformances here; concrete ones
       // were checked above already.
       if (!conf.isAbstract())
         continue;
 
+      auto *abstract = conf.getAbstract();
+      auto *proto = abstract->getProtocol();
+      Type conformingType = abstract->getType();
+
       // Skip Self conformances for protocol members — these are used
       // for witness dispatch, not forwarded to the callee body.
-      if (selfInterfaceType &&
-          req.getFirstType()->isEqual(selfInterfaceType))
-        continue;
-
-      auto *proto = conf.getProtocol();
+      if (selfInterfaceType) {
+        if (auto *archetype = conformingType->getAs<ArchetypeType>()) {
+          if (archetype->getInterfaceType()->isEqual(selfInterfaceType))
+            continue;
+        }
+      }
 
       // Marker protocols have no requirements and can never be isolated.
       if (proto->isMarkerProtocol())
@@ -9130,27 +9124,18 @@ bool swift::checkIsolatedConformancesForIsolationCrossing(
           proto->inheritsFrom(sendableMetatypeProto))
         continue;
 
-      // Get the generic type parameter unless it's a 'some' type
+      // Get the name of the generic type parameter for the diagnostic.
+      // For opaque types ('some Protocol'), we leave the name empty so
+      // the diagnostic uses "underlying type of 'some Proto'" instead.
       Identifier genericParamName;
-      if (auto *gp = req.getFirstType()->getAs<GenericTypeParamType>()) {
-        if (auto *genericCtx =
-                dyn_cast<GenericContext>(declRef.getDecl())) {
-          if (auto *paramList = genericCtx->getGenericParams()) {
-            for (auto *paramDecl : paramList->getParams()) {
-              if (paramDecl->getDepth() == gp->getDepth() &&
-                  paramDecl->getIndex() == gp->getIndex() &&
-                  !paramDecl->isOpaqueType()) {
-                genericParamName = paramDecl->getName();
-                break;
-              }
-            }
-          }
-        }
+      if (auto *archetype = conformingType->getAs<ArchetypeType>()) {
+        if (!archetype->getAs<OpaqueTypeArchetypeType>())
+          genericParamName = archetype->getName();
       }
 
       ctx.Diags
           .diagnose(loc, diag::isolated_conformance_may_cross_isolation,
-                    genericParamName, proto->getName(), targetIsolation)
+                    genericParamName, proto->getName().str(), targetIsolation)
           .warnUntilLanguageMode(LanguageMode::v6);
       diagnosed = true;
     }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -9105,8 +9105,7 @@ bool swift::checkIsolatedConformancesForIsolationCrossing(
       auto *proto = abstract->getProtocol();
       Type conformingType = abstract->getType();
 
-      // Skip Self conformances for protocol members — these are used
-      // for witness dispatch, not forwarded to the callee body.
+      // Skip Self conformances; these should be diagnosed already in other ways
       if (selfInterfaceType) {
         if (auto *archetype = conformingType->getAs<ArchetypeType>()) {
           if (archetype->getInterfaceType()->isEqual(selfInterfaceType))
@@ -9123,6 +9122,21 @@ bool swift::checkIsolatedConformancesForIsolationCrossing(
       if (sendableMetatypeProto &&
           proto->inheritsFrom(sendableMetatypeProto))
         continue;
+
+      // If the conforming type is Sendable, its conformances cannot be
+      // isolated — isolated conformances require non-Sendable types.
+      if (auto *archetype = conformingType->getAs<ArchetypeType>()) {
+        if (auto *sendableProto =
+                ctx.getProtocol(KnownProtocolKind::Sendable)) {
+          bool isSendable =
+              llvm::any_of(archetype->getConformsTo(), [&](ProtocolDecl *p) {
+                return p == sendableProto || p->inheritsFrom(sendableProto);
+              });
+
+          if (isSendable)
+            continue;
+        }
+      }
 
       // Get the name of the generic type parameter for the diagnostic.
       // For opaque types ('some Protocol'), we leave the name empty so

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4100,6 +4100,24 @@ namespace {
       if (!unsatisfiedIsolation)
         return false;
 
+      // Check for isolated conformances escaping through the callee's
+      // generic substitutions across the isolation boundary.
+      {
+        std::optional<std::pair<ConcreteDeclRef, SourceLoc>> calleeDeclRef;
+        if (auto *selfApply = dyn_cast<SelfApplyExpr>(apply->getFn()->getValueProvidingExpr())) {
+          calleeDeclRef = findReference(selfApply->getFn()->getValueProvidingExpr());
+        } else {
+          calleeDeclRef = findReference(apply->getFn());
+        }
+
+        if (calleeDeclRef) {
+          checkIsolatedConformancesForIsolationCrossing(
+              calleeDeclRef->first, apply->getLoc(),
+              *unsatisfiedIsolation, getDeclContext(),
+              RefineConformances{*this});
+        }
+      }
+
       // Record whether the callee isolation or the context isolation
       // is preconcurrency, which is used later to downgrade errors to
       // warnings in minimal checking.
@@ -4544,25 +4562,6 @@ namespace {
       // Make sure isolated conformances are formed in the right context.
       checkIsolatedConformancesInContext(declRef, loc, getDeclContext(),
                                          RefineConformances{*this});
-
-      // Also, prevent isolated conformances to "escape" the isolated context through
-      // calls to async functions because these may either run on a different executor
-      // (escaped-to-func is @concurrent), or may pass the conformance along to another
-      // function which would then violate safety even if the first method we called did
-      // dynamically inherit the right context (escaped-to-func is nonisolated(nonsending)).
-      //
-      // This applies to every async callee whose isolation differs from the conformance — nonisolated,
-      // nonisolated(nonsending), and even callees isolated to a *different* global actor.
-      //
-      // Synchronous callees are safe because they cannot change the executor, and they can't escape the
-      // passed parameter without hitting Sendable safeguards.
-      if (auto *funcDecl = dyn_cast<AbstractFunctionDecl>(decl)) {
-        if (funcDecl->hasAsync()) {
-          checkIsolatedConformancesInContext(declRef, loc,
-                                             funcDecl,
-                                             RefineConformances{*this});
-        }
-      }
 
       // If this declaration is a callee from the enclosing application,
       // it's already been checked via the call.
@@ -8943,7 +8942,10 @@ namespace {
     llvm::TinyPtrVector<ProtocolConformance *> badIsolatedConformances;
     DeclContext *fromDC;
     HandleConformanceIsolationFn handleBad;
-    mutable std::optional<ActorIsolation> fromIsolation;
+
+    // Isolation can either be set explicitly,
+    // or will be lazy loaded from the 'fromDC' context otherwise.
+    mutable std::optional<ActorIsolation> isolation;
 
   public:
     MismatchedIsolatedConformances(const DeclContext *fromDC,
@@ -8951,11 +8953,20 @@ namespace {
       : fromDC(const_cast<DeclContext *>(fromDC)),
         handleBad(handleBad) { }
 
-    ActorIsolation getContextIsolation() const {
-      if (!fromIsolation)
-        fromIsolation = getActorIsolationOfContext(fromDC);
+    MismatchedIsolatedConformances(ActorIsolation targetIsolation,
+                                   const DeclContext *fromDC,
+                                   HandleConformanceIsolationFn handleBad)
+      : fromDC(const_cast<DeclContext *>(fromDC)),
+        handleBad(handleBad),
+        isolation(targetIsolation) { }
 
-      return *fromIsolation;
+    /// Lazy compute the isolation of the context 'fromDC',
+    /// unless the isolation was set explicitly already.
+    ActorIsolation getIsolation() const {
+      if (!isolation)
+        isolation = getActorIsolationOfContext(fromDC);
+
+      return *isolation;
     }
 
     ArrayRef<ProtocolConformance *> getBadIsolatedConformances() const {
@@ -8976,7 +8987,12 @@ namespace {
 
       auto conformanceIsolation = concrete->getIsolation();
       if (!conformanceIsolation.isGlobalActor() ||
-          conformanceIsolation == getContextIsolation())
+          conformanceIsolation == getIsolation())
+        return true;
+
+      // In a nonisolated(nonsending) context the conformance is valid because
+      // effectively always is on the caller's isolation.
+      if (getIsolation().isCallerIsolationInheriting())
         return true;
 
       badIsolatedConformances.push_back(concrete);
@@ -9005,7 +9021,7 @@ namespace {
           .diagnose(
               loc, diag::isolated_conformance_wrong_domain,
               firstConformance->getIsolation(), firstConformance->getType(),
-              firstConformance->getProtocol()->getName(), getContextIsolation())
+              firstConformance->getProtocol()->getName(), getIsolation())
           .warnUntilLanguageMode(LanguageMode::v6);
       return true;
     }
@@ -9049,4 +9065,96 @@ bool swift::checkIsolatedConformancesInContext(
   MismatchedIsolatedConformances mismatched(dc, handleBad);
   forEachConformance(type, mismatched);
   return mismatched.diagnose(loc);
+}
+
+bool swift::checkIsolatedConformancesForIsolationCrossing(
+    ConcreteDeclRef declRef, SourceLoc loc,
+    ActorIsolation targetIsolation, const DeclContext *dc,
+    HandleConformanceIsolationFn handleBad) {
+  MismatchedIsolatedConformances mismatched(targetIsolation, dc, handleBad);
+  forEachConformance(declRef, mismatched);
+  bool diagnosed = mismatched.diagnose(loc);
+
+  // Return early, we already found a problem
+  if (diagnosed)
+    return diagnosed;
+
+  // Also check for abstract conformances, since if we can't prove they are nonisolated,
+  // we must conservatively reject them.
+  //
+  // For protocol member calls, the Self conformance is used for witness
+  // dispatch and doesn't escape to another context, so we skip it.
+  // However, any other generic parameters on the method ARE forwarded.
+  if (auto subs = declRef.getSubstitutions()) {
+    auto &ctx = dc->getASTContext();
+    auto *sendableMetatypeProto =
+        ctx.getProtocol(KnownProtocolKind::SendableMetatype);
+
+    // Determine if the callee is a protocol member, in which case
+    // the Self conformance is used for dispatch, not forwarding.
+    Type selfInterfaceType;
+    if (auto *calleeProto =
+            declRef.getDecl()->getDeclContext()->getSelfProtocolDecl()) {
+      selfInterfaceType = calleeProto->getSelfInterfaceType();
+    }
+
+    auto genericSig = subs.getGenericSignature();
+    auto conformances = subs.getConformances();
+    unsigned confIdx = 0;
+    for (auto req : genericSig.getRequirements()) {
+      if (req.getKind() != RequirementKind::Conformance)
+        continue;
+
+      auto conf = conformances[confIdx++];
+
+      // We're only checking abstract conformances here; concrete ones
+      // were checked above already.
+      if (!conf.isAbstract())
+        continue;
+
+      // Skip Self conformances for protocol members — these are used
+      // for witness dispatch, not forwarded to the callee body.
+      if (selfInterfaceType &&
+          req.getFirstType()->isEqual(selfInterfaceType))
+        continue;
+
+      auto *proto = conf.getProtocol();
+
+      // Marker protocols have no requirements and can never be isolated.
+      if (proto->isMarkerProtocol())
+        continue;
+
+      // Protocols inheriting from SendableMetatype cannot have isolated
+      // conformances.
+      if (sendableMetatypeProto &&
+          proto->inheritsFrom(sendableMetatypeProto))
+        continue;
+
+      // Get the generic type parameter unless it's a 'some' type
+      Identifier genericParamName;
+      if (auto *gp = req.getFirstType()->getAs<GenericTypeParamType>()) {
+        if (auto *genericCtx =
+                dyn_cast<GenericContext>(declRef.getDecl())) {
+          if (auto *paramList = genericCtx->getGenericParams()) {
+            for (auto *paramDecl : paramList->getParams()) {
+              if (paramDecl->getDepth() == gp->getDepth() &&
+                  paramDecl->getIndex() == gp->getIndex() &&
+                  !paramDecl->isOpaqueType()) {
+                genericParamName = paramDecl->getName();
+                break;
+              }
+            }
+          }
+        }
+      }
+
+      ctx.Diags
+          .diagnose(loc, diag::isolated_conformance_may_cross_isolation,
+                    genericParamName, proto->getName(), targetIsolation)
+          .warnUntilLanguageMode(LanguageMode::v6);
+      diagnosed = true;
+    }
+  }
+
+  return diagnosed;
 }

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -792,6 +792,18 @@ bool checkIsolatedConformancesInContext(
     Type type, SourceLoc loc, const DeclContext *dc,
     HandleConformanceIsolationFn handleBad = doNotDiagnoseConformanceIsolation);
 
+/// Check for isolated conformances escaping through a call that crosses
+/// an isolation boundary. The conformances in the 'declRef' are checked against
+/// the given target isolation of the call rather than the isolation of its
+/// DeclContext.
+///
+/// Also checks for abstract (generic) conformances that may be isolated,
+/// skipping Self conformances for protocol members (used only for dispatch).
+bool checkIsolatedConformancesForIsolationCrossing(
+    ConcreteDeclRef declRef, SourceLoc loc,
+    ActorIsolation targetIsolation, const DeclContext *dc,
+    HandleConformanceIsolationFn handleBad = doNotDiagnoseConformanceIsolation);
+
 /// For a protocol conformance that does not have a "raw" isolation, infer its isolation.
 ///
 /// - hasKnownIsolatedWitness: indicates when it is known that there is an actor-isolated witness, meaning

--- a/test/Concurrency/isolated_conformance_generic_escape.swift
+++ b/test/Concurrency/isolated_conformance_generic_escape.swift
@@ -1,5 +1,4 @@
-// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple -swift-version 6 -verify-additional-prefix swift6-
-// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple -swift-version 5 -strict-concurrency=complete -verify-additional-prefix swift5-
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple -swift-version 6
 
 // REQUIRES: concurrency
 
@@ -14,11 +13,19 @@ import _Concurrency
 
 protocol MyProtocol {
   func doSomething()
+
+  @MainActor
+  func doSomethingOnMainActor()
 }
 
 @MainActor
-class MySyncClass: @MainActor MyProtocol {
+class MyClass: @MainActor MyProtocol {
   func doSomething() {
+    MainActor.shared.assertIsolated()
+  }
+
+  @MainActor
+  func doSomethingOnMainActor() {
     MainActor.shared.assertIsolated()
   }
 }
@@ -27,19 +34,87 @@ class MySyncClass: @MainActor MyProtocol {
 // MARK: @concurrent callees — disallowed
 
 @concurrent
-func callDoSomething(_ p: some MyProtocol) async {
+func callDoSomethingConcurrent(_ p: some MyProtocol) async {
   p.doSomething() // bad, would call actor synchronously from other context
 }
 
 // ==== -----------------------------------------------------------------------
-// MARK: nonisolated(nonsending) callees — inherits caller's executor but could forward and break isolation
+// MARK: nonisolated(nonsending) callees — inherits caller's executor
 
 nonisolated(nonsending) func callDoSomethingNonisolatedNonsending(_ p: some MyProtocol) async {
-  p.doSomething() // may or may not be bad, depending who the caller was
+  p.doSomething() // ok, inherits caller's isolation
 }
 
-@concurrent func whoopsThisWouldHaveBeenBad(_ p: some MyProtocol) async {
+// ==== -----------------------------------------------------------------------
+// MARK: nonisolated(nonsending) that forwards to @concurrent — error in body
+
+// When the conformance is concrete (not generic), the error is caught at the
+// forwarding call site inside the nonisolated(nonsending) function body.
+nonisolated(nonsending) func nonsendingForwardToConcurrent(_ p: MyClass) async {
+  // expected-error@+1{{main actor-isolated conformance of 'MyClass' to 'MyProtocol' cannot be used in nonisolated context}}
+  await callDoSomethingConcurrent(p)
+}
+
+// When the conformance is abstract (generic), we reject it because the concrete
+// conformance may be isolated.
+nonisolated(nonsending) func nonsendingForwardToConcurrentGeneric(_ p: some MyProtocol) async {
+  // expected-error@+1{{conformance of generic parameter to 'MyProtocol' may be isolated and cannot be used in nonisolated context}}
+  await callDoSomethingConcurrent(p)
+}
+
+// Sendable protocols cannot have isolated conformances, so forwarding is safe.
+protocol SendableProtocol: Sendable {
+  func doSomething()
+}
+
+@concurrent
+func callSendableProtocol(_ p: some SendableProtocol) async {
   p.doSomething()
+}
+
+@concurrent
+func callSendableProtocolComp(_ p: some (MyProtocol & Sendable)) async {
+  p.doSomething()
+}
+
+nonisolated(nonsending) func nonsendingForwardSendableGeneric(_ p: some SendableProtocol) async {
+  await callSendableProtocol(p) // ok, Sendable protocols can't have isolated conformances
+}
+
+nonisolated(nonsending) func nonsendingForwardSendableGenericComp<P: MyProtocol>(_ p: P) async { // expected-note{{consider making generic parameter 'P' conform to the 'Sendable' protocol}}
+  // expected-error@+2{{conformance of generic parameter to 'MyProtocol' may be isolated and cannot be used in nonisolated context}}
+  // expected-error@+1{{type 'P' does not conform to the 'Sendable' protocol}}
+  await callSendableProtocolComp(p)
+}
+
+final class Caller {
+  @concurrent func call(first p: some MyProtocol, second fine: String) async { p.doSomething() }
+}
+nonisolated(nonsending) func nonsendingForwardSendableGeneric(caller: Caller, _ p: some MyProtocol) async {
+  // expected-error@+1{{conformance of generic parameter to 'MyProtocol' may be isolated and cannot be used in nonisolated context}}
+  await caller.call(first: p, second: "this is fine")
+}
+
+// Callee with explicit generic parameter — the name appears in the diagnostic.
+@concurrent
+func callDoSomethingConcurrentExplicit<ItsMe: MyProtocol>(_ p: ItsMe) async {
+  p.doSomething()
+}
+
+nonisolated(nonsending) func nonsendingForwardExplicitGeneric<TheProblemIsNotHere: MyProtocol>(_ p: TheProblemIsNotHere) async {
+  // expected-error@+1{{conformance of 'ItsMe' to 'MyProtocol' may be isolated and cannot be used in nonisolated context}}
+  await callDoSomethingConcurrentExplicit(p)
+}
+
+@concurrent func nonsendingForwardSendableGeneric(_ p: some MyProtocol) async {
+  await p.doSomethingOnMainActor() // this explicitly hops to MainActor and is fine
+}
+
+// @MainActor forwarding generic to @concurrent — same issue, rejected.
+@MainActor
+func mainActorForwardToConcurrentGeneric(_ p: some MyProtocol) async {
+  // expected-error@+1{{conformance of generic parameter to 'MyProtocol' may be isolated and cannot be used in nonisolated context}}
+  await callDoSomethingConcurrent(p)
 }
 
 // ==== -----------------------------------------------------------------------
@@ -65,24 +140,24 @@ func callDoSomethingFromMainActor(_ p: some MyProtocol) async {
 // ==== -----------------------------------------------------------------------
 // MARK: Tests
 
-@available(SwiftStdlib 6.2, *)
 @MainActor
 func test() async {
   // @concurrent async - don't allow changing execution context, would allow synchronous call on actor
-  // expected-swift6-error@+2{{main actor-isolated conformance of 'MySyncClass' to 'MyProtocol' cannot be used in nonisolated context}}
-  // expected-swift5-warning@+1{{main actor-isolated conformance of 'MySyncClass' to 'MyProtocol' cannot be used in nonisolated context; this is an error in the Swift 6 language mode}}
-  await callDoSomething(MySyncClass())
+  // expected-error@+1{{main actor-isolated conformance of 'MyClass' to 'MyProtocol' cannot be used in nonisolated context}}
+  await callDoSomethingConcurrent(MyClass())
 
-  // nonisolated(nonsending) - is not allowed either, it could escape the value to another @concurrent method and break isolation there
-  // expected-swift6-error@+2{{main actor-isolated conformance of 'MySyncClass' to 'MyProtocol' cannot be used in caller isolation inheriting-isolated context}}
-  // expected-swift5-warning@+1{{main actor-isolated conformance of 'MySyncClass' to 'MyProtocol' cannot be used in caller isolation inheriting-isolated context; this is an error in the Swift 6 language mode}}
-  await callDoSomethingNonisolatedNonsending(MySyncClass())
+  // nonisolated(nonsending) — inherits caller's isolation, this is allowed
+  await callDoSomethingNonisolatedNonsending(MyClass())
+
+  // nonisolated(nonsending) that forwards to @concurrent — the error is
+  // caught at the forwarding call site inside the func, not here
+  await nonsendingForwardToConcurrent(MyClass())
+  await nonsendingForwardToConcurrentGeneric(MyClass())
 
   // Different global actor callee — not allowed, same as hopping to global executor, we don't allow ANY other isolation
-  // expected-swift6-error@+2{{main actor-isolated conformance of 'MySyncClass' to 'MyProtocol' cannot be used in global actor 'OtherActor'-isolated context}}
-  // expected-swift5-warning@+1{{main actor-isolated conformance of 'MySyncClass' to 'MyProtocol' cannot be used in global actor 'OtherActor'-isolated context; this is an error in the Swift 6 language mode}}
-  await callDoSomethingFromOtherActor(MySyncClass())
+  // expected-error@+1{{main actor-isolated conformance of 'MyClass' to 'MyProtocol' cannot be used in global actor 'OtherActor'-isolated context}}
+  await callDoSomethingFromOtherActor(MyClass())
 
   // @MainActor callee — same caller isolation, this is allowed
-  await callDoSomethingFromMainActor(MySyncClass())
+  await callDoSomethingFromMainActor(MyClass())
 }

--- a/test/Concurrency/isolated_conformance_generic_escape.swift
+++ b/test/Concurrency/isolated_conformance_generic_escape.swift
@@ -58,8 +58,15 @@ nonisolated(nonsending) func nonsendingForwardToConcurrent(_ p: MyClass) async {
 // When the conformance is abstract (generic), we reject it because the concrete
 // conformance may be isolated.
 nonisolated(nonsending) func nonsendingForwardToConcurrentGeneric(_ p: some MyProtocol) async {
-  // expected-error@+1{{conformance of generic parameter to 'MyProtocol' may be isolated and cannot be used in nonisolated context}}
+  // expected-error@+1{{conformance of underlying type of 'some MyProtocol' to protocol 'MyProtocol' may be isolated and cannot be passed to nonisolated context}}
   await callDoSomethingConcurrent(p)
+}
+
+struct Container<T: MyProtocol> {
+  nonisolated(nonsending) func nonsendingForwardToConcurrentGeneric(_ p: T) async {
+    // expected-error@+1{{conformance of 'T' to protocol 'MyProtocol' may be isolated and cannot be passed to nonisolated context}}
+    await callDoSomethingConcurrent(p)
+  }
 }
 
 // Sendable protocols cannot have isolated conformances, so forwarding is safe.
@@ -129,6 +136,13 @@ func callDoSomethingFromOtherActor(_ p: some MyProtocol) async {
   p.doSomething()
 }
 
+@MainActor
+func test1() async {
+  // Different global actor callee — not allowed, same as hopping to global executor, we don't allow ANY other isolation
+  // expected-error@+1{{main actor-isolated conformance of 'MyClass' to 'MyProtocol' cannot be used in global actor 'OtherActor'-isolated context}}
+  await callDoSomethingFromOtherActor(MyClass())
+}
+
 // ==== -----------------------------------------------------------------------
 // MARK: @MainActor callee — same isolation domain, ok
 
@@ -153,10 +167,6 @@ func test() async {
   // caught at the forwarding call site inside the func, not here
   await nonsendingForwardToConcurrent(MyClass())
   await nonsendingForwardToConcurrentGeneric(MyClass())
-
-  // Different global actor callee — not allowed, same as hopping to global executor, we don't allow ANY other isolation
-  // expected-error@+1{{main actor-isolated conformance of 'MyClass' to 'MyProtocol' cannot be used in global actor 'OtherActor'-isolated context}}
-  await callDoSomethingFromOtherActor(MyClass())
 
   // @MainActor callee — same caller isolation, this is allowed
   await callDoSomethingFromMainActor(MyClass())

--- a/test/Concurrency/isolated_conformance_generic_escape.swift
+++ b/test/Concurrency/isolated_conformance_generic_escape.swift
@@ -89,7 +89,7 @@ nonisolated(nonsending) func nonsendingForwardSendableGeneric(_ p: some Sendable
 }
 
 nonisolated(nonsending) func nonsendingForwardSendableGenericComp<P: MyProtocol>(_ p: P) async { // expected-note{{consider making generic parameter 'P' conform to the 'Sendable' protocol}}
-  // expected-error@+2{{conformance of generic parameter to 'MyProtocol' may be isolated and cannot be used in nonisolated context}}
+  // expected-error@+2{{conformance of 'P' to protocol 'MyProtocol' may be isolated and cannot be passed to nonisolated context}}
   // expected-error@+1{{type 'P' does not conform to the 'Sendable' protocol}}
   await callSendableProtocolComp(p)
 }
@@ -98,7 +98,7 @@ final class Caller {
   @concurrent func call(first p: some MyProtocol, second fine: String) async { p.doSomething() }
 }
 nonisolated(nonsending) func nonsendingForwardSendableGeneric(caller: Caller, _ p: some MyProtocol) async {
-  // expected-error@+1{{conformance of generic parameter to 'MyProtocol' may be isolated and cannot be used in nonisolated context}}
+  // expected-error@+1{{conformance of underlying type of 'some MyProtocol' to protocol 'MyProtocol' may be isolated and cannot be passed to nonisolated context}}
   await caller.call(first: p, second: "this is fine")
 }
 
@@ -109,18 +109,18 @@ func callDoSomethingConcurrentExplicit<ItsMe: MyProtocol>(_ p: ItsMe) async {
 }
 
 nonisolated(nonsending) func nonsendingForwardExplicitGeneric<TheProblemIsNotHere: MyProtocol>(_ p: TheProblemIsNotHere) async {
-  // expected-error@+1{{conformance of 'ItsMe' to 'MyProtocol' may be isolated and cannot be used in nonisolated context}}
+  // expected-error@+1{{conformance of 'TheProblemIsNotHere' to protocol 'MyProtocol' may be isolated and cannot be passed to nonisolated context}}
   await callDoSomethingConcurrentExplicit(p)
 }
 
 @concurrent func nonsendingForwardSendableGeneric(_ p: some MyProtocol) async {
-  await p.doSomethingOnMainActor() // this explicitly hops to MainActor and is fine
+  await p.doSomethingOnMainActor() // ok: requirement is @MainActor, hop is explicit
 }
 
 // @MainActor forwarding generic to @concurrent — same issue, rejected.
 @MainActor
 func mainActorForwardToConcurrentGeneric(_ p: some MyProtocol) async {
-  // expected-error@+1{{conformance of generic parameter to 'MyProtocol' may be isolated and cannot be used in nonisolated context}}
+  // expected-error@+1{{conformance of underlying type of 'some MyProtocol' to protocol 'MyProtocol' may be isolated and cannot be passed to nonisolated context}}
   await callDoSomethingConcurrent(p)
 }
 

--- a/test/Concurrency/isolated_conformance_generic_escape.swift
+++ b/test/Concurrency/isolated_conformance_generic_escape.swift
@@ -1,0 +1,88 @@
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple -swift-version 6 -verify-additional-prefix swift6-
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple -swift-version 5 -strict-concurrency=complete -verify-additional-prefix swift5-
+
+// REQUIRES: concurrency
+
+// This verifies additional enforcement of Rule (1) from the
+// isolated conformances proposal: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0470-isolated-conformances.md
+// We must not allow escaping an isolated conformance through generic parameters
+// into a context that is isolated differently, because we may then end up calling e.g.
+// a synchronous requirement from the wrong isolated context and violate actor isolation.
+// rdar://173120506
+
+import _Concurrency
+
+protocol MyProtocol {
+  func doSomething()
+}
+
+@MainActor
+class MySyncClass: @MainActor MyProtocol {
+  func doSomething() {
+    MainActor.shared.assertIsolated()
+  }
+}
+
+// ==== -----------------------------------------------------------------------
+// MARK: @concurrent callees — disallowed
+
+@concurrent
+func callDoSomething(_ p: some MyProtocol) async {
+  p.doSomething() // bad, would call actor synchronously from other context
+}
+
+// ==== -----------------------------------------------------------------------
+// MARK: nonisolated(nonsending) callees — inherits caller's executor but could forward and break isolation
+
+nonisolated(nonsending) func callDoSomethingNonisolatedNonsending(_ p: some MyProtocol) async {
+  p.doSomething() // may or may not be bad, depending who the caller was
+}
+
+@concurrent func whoopsThisWouldHaveBeenBad(_ p: some MyProtocol) async {
+  p.doSomething()
+}
+
+// ==== -----------------------------------------------------------------------
+// MARK: Different global actor callee - disallowed
+
+@globalActor actor OtherActor {
+  static let shared = OtherActor()
+}
+
+@OtherActor
+func callDoSomethingFromOtherActor(_ p: some MyProtocol) async {
+  p.doSomething()
+}
+
+// ==== -----------------------------------------------------------------------
+// MARK: @MainActor callee — same isolation domain, ok
+
+@MainActor
+func callDoSomethingFromMainActor(_ p: some MyProtocol) async {
+  p.doSomething()
+}
+
+// ==== -----------------------------------------------------------------------
+// MARK: Tests
+
+@available(SwiftStdlib 6.2, *)
+@MainActor
+func test() async {
+  // @concurrent async - don't allow changing execution context, would allow synchronous call on actor
+  // expected-swift6-error@+2{{main actor-isolated conformance of 'MySyncClass' to 'MyProtocol' cannot be used in nonisolated context}}
+  // expected-swift5-warning@+1{{main actor-isolated conformance of 'MySyncClass' to 'MyProtocol' cannot be used in nonisolated context; this is an error in the Swift 6 language mode}}
+  await callDoSomething(MySyncClass())
+
+  // nonisolated(nonsending) - is not allowed either, it could escape the value to another @concurrent method and break isolation there
+  // expected-swift6-error@+2{{main actor-isolated conformance of 'MySyncClass' to 'MyProtocol' cannot be used in caller isolation inheriting-isolated context}}
+  // expected-swift5-warning@+1{{main actor-isolated conformance of 'MySyncClass' to 'MyProtocol' cannot be used in caller isolation inheriting-isolated context; this is an error in the Swift 6 language mode}}
+  await callDoSomethingNonisolatedNonsending(MySyncClass())
+
+  // Different global actor callee — not allowed, same as hopping to global executor, we don't allow ANY other isolation
+  // expected-swift6-error@+2{{main actor-isolated conformance of 'MySyncClass' to 'MyProtocol' cannot be used in global actor 'OtherActor'-isolated context}}
+  // expected-swift5-warning@+1{{main actor-isolated conformance of 'MySyncClass' to 'MyProtocol' cannot be used in global actor 'OtherActor'-isolated context; this is an error in the Swift 6 language mode}}
+  await callDoSomethingFromOtherActor(MySyncClass())
+
+  // @MainActor callee — same caller isolation, this is allowed
+  await callDoSomethingFromMainActor(MySyncClass())
+}


### PR DESCRIPTION
This fixes holes in "rule 1" checking of [SE-470](https://swiftlang.github.io/swift-evolution/#?proposal=SE-470) which was supposed to
protect escaping isolated conformances to other execution contexts:

> An isolated conformance can only be used within its isolation domain.

When using an async method with a generic parameter we allowed an
isolated conformance to escape to it; and then allowed, wrongly, to call
synchronous protocol requirements on it. This horribly violates actor
isolation since the actual type is actor isolated yet we SYNCHRONOUSLY
called a method on it, resulting in actor isolation violations.

This is even worse in accessible concurrency because isolated
conformances are *inferred* and you don't even know you're using them,
yet the compiler happily allows you to call synchronous methods on
actors from wrong isolations due to this problem.

The solution is to more carefully check async methods for crossing
isolation boundaries.

Synchronous methods are safe because the're always strictly on the same
context AND if they wanted to escape the passed parameter to another
context, Sendable checking (rule 2) would prevent this from happening.

resolves: rdar://173120506