### PR TITLE
test: correct `%plugin` definition

### DIFF
--- a/test/CAS/lit.local.cfg
+++ b/test/CAS/lit.local.cfg
@@ -1,14 +1,10 @@
 # Make a local copy of the substitutions.
 config.substitutions = list(config.substitutions)
 
-def get_target_os():
-    import re
-    (run_cpu, run_vendor, run_os, run_version) = re.match('([^-]+)-([^-]+)-([^0-9]+)(.*)', config.variant_triple).groups()
-    return run_os
-
 import os
+import platform
 
-if get_target_os() in ('windows-msvc',):
+if platform.system() == 'Windows':
     config.substitutions.insert(0, (r'%plugin\(([^)]+)\)', SubstituteCaptures(os.path.join(config.llvm_tools_dir, r'%target-library-name(\1)'))))
 else:
     config.substitutions.insert(0, (r'%plugin\(([^)]+)\)', SubstituteCaptures(os.path.join(config.llvm_libs_dir, r'%target-library-name(\1)'))))


### PR DESCRIPTION
This is a host property, not a target property. When cross-testing a Unix-like environment on Windows, we find that we load the plugin from the wrong location. Correct the definition to use the toolchain host as the basis for the decision.