### PR TITLE
utils: log installer build command

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1956,6 +1956,7 @@ function Build-WiXProject() {
   $MSBuildArgs += "-binaryLogger:$BinaryCache\$($Platform.Triple)\msi\$($Platform.Architecture.VSName)-$([System.IO.Path]::GetFileNameWithoutExtension($FileName)).binlog"
   $MSBuildArgs += "-detailedSummary:False"
 
+  Write-Host "$msbuild $MSBuildArgs"
   Invoke-Program $msbuild @MSBuildArgs
 }
 


### PR DESCRIPTION
Display the command used to build the installer which contains vital information such as the architectures, paths, and included content paths.