### PR TITLE
utils: stage the binary log for the installer

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -4128,6 +4128,8 @@ function Build-Installer([Hashtable] $Platform) {
 }
 
 function Copy-BuildArtifactsToStage([Hashtable] $Platform) {
+  # Save the installer binary log
+  Copy-File "$BinaryCache\$($Platform.Triple)\msi\$($Platform.Architecture.VSName)-$([System.IO.Path]::GetFileNameWithoutExtension($FileName)).binlog" $Stage
   Copy-File "$BinaryCache\$($Platform.Triple)\installer\Release\$($Platform.Architecture.VSName)\*.cab" $Stage
   Copy-File "$BinaryCache\$($Platform.Triple)\installer\Release\$($Platform.Architecture.VSName)\*.msi" $Stage
   foreach ($Build in $WindowsSDKBuilds) {


### PR DESCRIPTION
This contains the detailed build log that can be viewed with https://msbuildlog.com/. This is very helpful when debugging issues with the installer.