### PR TITLE
[cmo] [aggresive] Don't attach the usableFromInline attribute

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -778,7 +778,7 @@ protected:
     HasLazyUnderlyingSubstitutions : 1
   );
 
-  SWIFT_INLINE_BITFIELD(ModuleDecl, TypeDecl, 1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+8,
+  SWIFT_INLINE_BITFIELD(ModuleDecl, TypeDecl, 1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+8+1,
     /// If the module is compiled as static library.
     StaticLibrary : 1,
 
@@ -850,7 +850,11 @@ protected:
     StrictMemorySafety : 1,
 
     /// Whether this module uses deferred code generation in Embedded Swift.
-    DeferredCodeGen : 1
+    DeferredCodeGen : 1,
+
+    /// Whether this module was compile with "aggressive" CMO i.e
+    /// the flag: -cross-module-optimization.
+    AggressiveCMOEnabled : 1
   );
 
   SWIFT_INLINE_BITFIELD(PrecedenceGroupDecl, Decl, 1+2,

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -795,6 +795,17 @@ public:
   void setSerializePackageEnabled(bool flag = true) {
     Bits.ModuleDecl.SerializePackageEnabled = flag;
   }
+  // Returns true if aggressive cross-module-optimzation was enabled.
+  // Aggressive CMO assumes non-public types are accessible from outside the
+  // module (in contrast to default CMO which only assumes public types are
+  // accessible) .
+  bool isAggressiveCMOEnabled() const {
+    return Bits.ModuleDecl.AggressiveCMOEnabled;
+  }
+
+  void setAggressiveCMOEnabled(bool flag = true) {
+    Bits.ModuleDecl.AggressiveCMOEnabled = flag;
+  }
 
   /// Returns true if this module is a non-Swift module that was imported into
   /// Swift.

--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -148,6 +148,7 @@ class ExtendedValidationInfo {
     unsigned SerializePackageEnabled: 1;
     unsigned StrictMemorySafety: 1;
     unsigned DeferredCodeGen: 1;
+    unsigned AggressiveCMOEnabled : 1;
   } Bits;
 
 public:
@@ -263,6 +264,13 @@ public:
   }
   void setDeferredCodeGen(bool val = true) {
     Bits.DeferredCodeGen = val;
+  }
+
+  bool isAggressiveCMOEnabled() const {
+    return Bits.AggressiveCMOEnabled;
+  }
+  void setAggressiveCMOEnabled(bool val = true) {
+    Bits.AggressiveCMOEnabled = val;
   }
 
   bool hasCxxInteroperability() const { return Bits.HasCxxInteroperability; }

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -782,6 +782,7 @@ ModuleDecl::ModuleDecl(Identifier name, ASTContext &ctx,
   Bits.ModuleDecl.SerializePackageEnabled = 0;
   Bits.ModuleDecl.StrictMemorySafety = 0;
   Bits.ModuleDecl.DeferredCodeGen = 0;
+  Bits.ModuleDecl.AggressiveCMOEnabled = 0;
 
   // Populate the module's files.
   SmallVector<FileUnit *, 2> files;

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1552,6 +1552,9 @@ ModuleDecl *CompilerInstance::getMainModule() const {
     if (Invocation.getLangOptions().hasFeature(Feature::Embedded) &&
         Invocation.getLangOptions().hasFeature(Feature::DeferredCodeGen))
       MainModule->setDeferredCodeGen(true);
+    if (Invocation.getSILOptions().CMOMode ==
+        CrossModuleOptimizationMode::Aggressive)
+      MainModule->setAggressiveCMOEnabled(true);
 
     configureAvailabilityDomains(getASTContext(),
                                  Invocation.getFrontendOptions(), MainModule);

--- a/lib/SIL/IR/SIL.cpp
+++ b/lib/SIL/IR/SIL.cpp
@@ -44,6 +44,9 @@ FormalLinkage swift::getDeclLinkage(const ValueDecl *D) {
   if (SILDeclRef::declHasNonUniqueDefinition(D))
     return FormalLinkage::PublicUnique;
 
+  if (D->getModuleContext()->isAggressiveCMOEnabled())
+    return FormalLinkage::PublicUnique;
+
   switch (D->getEffectiveAccess()) {
   case AccessLevel::Package:
     return FormalLinkage::PackageUnique;
@@ -93,6 +96,12 @@ swift::getLinkageForProtocolConformance(const ProtocolConformance *C,
   auto typeDecl = C->getDeclContext()->getSelfNominalTypeDecl();
   AccessLevel access = std::min(C->getProtocol()->getEffectiveAccess(),
                                 typeDecl->getEffectiveAccess());
+
+  // Aggressive CMO "makes" all types "public".
+  if (typeDecl->getModuleContext()->isAggressiveCMOEnabled()) {
+    access = AccessLevel::Public;
+  }
+
   switch (access) {
     case AccessLevel::Private:
     case AccessLevel::FilePrivate:

--- a/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
+++ b/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
@@ -1045,9 +1045,10 @@ void CrossModuleOptimization::makeDeclUsableFromInline(ValueDecl *decl) {
   if (decl->getEffectiveAccess() >= AccessLevel::Package)
     return;  
 
-  // In Embedded Swift every ValueDecl is usableFromInline. (see
-  // ValueDecl::isUsableFromInline.
-  if (decl->getASTContext().LangOpts.hasFeature(Feature::Embedded))
+  // In Embedded Swift every ValueDecl is "usableFromInline". There is code that
+  // makes sure that the ABI linkage is public.
+  if (decl->getASTContext().LangOpts.hasFeature(Feature::Embedded) ||
+      decl->getModuleContext()->isAggressiveCMOEnabled())
     return;
 
   // This function should not be called in Package CMO mode.

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -717,6 +717,11 @@ public:
   /// \c true if this module uses deferred code generation.
   bool deferredCodeGen() const { return Core->deferredCodeGen(); }
 
+
+  /// \c true if this module was built with aggressive CMO
+  /// (the flag -cross-module-optimization).
+  bool isAggressiveCMOEnabled() const { return Core->isAggressiveCMOEnabled(); }
+
   /// Associates this module file with the AST node representing it.
   ///
   /// Checks that the file is compatible with the AST module it's being loaded

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -234,6 +234,9 @@ static bool readOptionsBlock(llvm::BitstreamCursor &cursor,
     case options_block::OSLOG_STRING_SECTION_NAME:
       extendedInfo.setOSLogStringSectionName(blobData);
       break;
+    case options_block::AGGRESSIVE_CMO:
+      extendedInfo.setAggressiveCMOEnabled(true);
+      break;
     default:
       // Unknown options record, possibly for use by a future version of the
       // module format.
@@ -1588,6 +1591,7 @@ ModuleFileSharedCore::ModuleFileSharedCore(
       Bits.SerializePackageEnabled = extInfo.serializePackageEnabled();
       Bits.StrictMemorySafety = extInfo.strictMemorySafety();
       Bits.DeferredCodeGen = extInfo.deferredCodeGen();
+      Bits.AggressiveCMOEnabled = extInfo.isAggressiveCMOEnabled();
       MiscVersion = info.miscVersion;
       SDKVersion = info.sdkVersion;
       ModuleABIName = extInfo.getModuleABIName();

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -422,8 +422,10 @@ private:
     /// Whether this module used deferred code generation.
     unsigned DeferredCodeGen : 1;
 
-    // Explicitly pad out to the next word boundary.
-    unsigned : 1;
+    /// Whether this module used deferred code generation.
+    unsigned AggressiveCMOEnabled : 1;
+
+    // Explicitly pad out to the next word boundary if neccessary.
   } Bits = {};
   static_assert(sizeof(ModuleBits) <= 8, "The bit set should be small");
 
@@ -695,6 +697,8 @@ public:
   bool strictMemorySafety() const { return Bits.StrictMemorySafety; }
 
   bool deferredCodeGen() const { return Bits.DeferredCodeGen; }
+
+  bool isAggressiveCMOEnabled() const { return Bits.AggressiveCMOEnabled; }
 
   /// How should \p dependency be loaded for a transitive import via \c this?
   ///

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 988; // re-order platform kinds
+const uint16_t SWIFTMODULE_VERSION_MINOR = 989; // cmo immutable ast fix
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1003,6 +1003,7 @@ namespace options_block {
     STRICT_MEMORY_SAFETY,
     DEFERRED_CODE_GEN,
     OSLOG_STRING_SECTION_NAME,
+    AGGRESSIVE_CMO,
   };
 
   using SDKPathLayout = BCRecordLayout<
@@ -1105,6 +1106,10 @@ namespace options_block {
 
   using DeferredCodeGenLayout = BCRecordLayout<
     DEFERRED_CODE_GEN
+  >;
+
+  using AggressiveCMOEnabledLayout = BCRecordLayout<
+    AGGRESSIVE_CMO
   >;
 
   using PublicModuleNameLayout = BCRecordLayout<

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -889,6 +889,7 @@ void Serializer::writeBlockInfoBlock() {
   BLOCK_RECORD(options_block, SERIALIZE_PACKAGE_ENABLED);
   BLOCK_RECORD(options_block, STRICT_MEMORY_SAFETY);
   BLOCK_RECORD(options_block, DEFERRED_CODE_GEN);
+  BLOCK_RECORD(options_block, AGGRESSIVE_CMO);
   BLOCK_RECORD(options_block, CXX_STDLIB_KIND);
   BLOCK_RECORD(options_block, PUBLIC_MODULE_NAME);
   BLOCK_RECORD(options_block, SWIFT_INTERFACE_COMPILER_VERSION);
@@ -1220,6 +1221,11 @@ void Serializer::writeHeader() {
         options_block::CXXStdlibKindLayout CXXStdlibKind(Out);
         CXXStdlibKind.emit(ScratchRecord,
                            static_cast<uint8_t>(M->getCXXStdlibKind()));
+      }
+
+      if (M->isAggressiveCMOEnabled()) {
+        options_block::AggressiveCMOEnabledLayout AggressiveCMOEnabled(Out);
+        AggressiveCMOEnabled.emit(ScratchRecord);
       }
 
       if (Options.SerializeOptionsForDebugging) {

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -991,6 +991,8 @@ LoadedFile *SerializedModuleLoaderBase::loadAST(
       M.setStrictMemorySafety();
     if (loadedModuleFile->deferredCodeGen())
       M.setDeferredCodeGen();
+    if (loadedModuleFile->isAggressiveCMOEnabled())
+      M.setAggressiveCMOEnabled();
     if (loadedModuleFile->hasCxxInteroperability()) {
       M.setHasCxxInteroperability();
       M.setCXXStdlibKind(loadedModuleFile->getCXXStdlibKind());

--- a/test/SILOptimizer/cross-module-optimization.swift
+++ b/test/SILOptimizer/cross-module-optimization.swift
@@ -26,6 +26,19 @@
 // RUN: %FileCheck %s -check-prefix=CHECK-SIL < %t/out.sil
 // RUN: %FileCheck %s -check-prefix=CHECK-SIL2 < %t/out.sil
 
+// With -enable-experimental-feature CoroutineAccessors.
+
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -O -wmo -parse-as-library -cross-module-optimization -emit-module -emit-module-path=%t/Submodule.swiftmodule -module-name=Submodule %S/Inputs/cross-module/cross-submodule.swift -c -o %t/submodule.o -enable-experimental-feature CoroutineAccessors
+// RUN: %target-build-swift -O -wmo -parse-as-library -cross-module-optimization -emit-module -emit-module-path=%t/PrivateSubmodule.swiftmodule -module-name=PrivateSubmodule %S/Inputs/cross-module/cross-private-submodule.swift -c -o %t/privatesubmodule.o -enable-experimental-feature CoroutineAccessors
+// RUN: %target-clang -c --language=c %S/Inputs/cross-module/c-module.c -o %t/c-module.o
+// RUN: %target-build-swift -O -wmo -parse-as-library -cross-module-optimization -emit-module -emit-module-path=%t/Test.swiftmodule -module-name=Test -I%t -I%S/Inputs/cross-module %S/Inputs/cross-module/cross-module.swift -c -o %t/test.o -enable-experimental-feature CoroutineAccessors
+// RUN: %target-build-swift -O -wmo -module-name=Main -I%t %s -c -o %t/main.o -enable-experimental-feature CoroutineAccessors
+// RUN: %target-swiftc_driver %t/main.o %t/test.o %t/submodule.o %t/privatesubmodule.o %t/c-module.o -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s -check-prefix=CHECK-OUTPUT
+
+
 import Test
 
 // CHECK-SIL: sil_global public_external [serialized] @_swiftEmptySetSingleton : $_SwiftEmptySetSingleton
@@ -33,19 +46,19 @@ import Test
 func testNestedTypes() {
   let c = Container()
 
-  // CHECK-OUTPUT: [Test.Container.Base]
+  // CHECK-OUTPUT: [Test.Container.(unknown context at{{[^)]*}}).Base]
   // CHECK-OUTPUT: 27
   // CHECK-SIL-DAG: sil shared [noinline] @$s4Test9ContainerV9testclassyxxlFSi_Tg5
   print(c.testclass(27))
-  // CHECK-OUTPUT: [Test.Container.Base]
+  // CHECK-OUTPUT: [Test.Container.(unknown context at{{[^)]*}}).Base]
   // CHECK-OUTPUT: 27
   // CHECK-SIL-DAG: sil public_external {{.*}} @$s4Test9ContainerV13testclass_genyxxlF
   print(c.testclass_gen(27))
-  // CHECK-OUTPUT: [Test.PE<Swift.Int>.B(27)]
+  // CHECK-OUTPUT: [Test.(unknown context at{{[^)]*}}).PE<Swift.Int>.B(27)]
   // CHECK-OUTPUT: 27
   // CHECK-SIL-DAG: sil shared [noinline] @$s4Test9ContainerV8testenumyxxlFSi_Tg5
   print(c.testenum(27))
-  // CHECK-OUTPUT: [Test.PE<Swift.Int>.B(27)]
+  // CHECK-OUTPUT: [Test.(unknown context at{{[^)]*}}).PE<Swift.Int>.B(27)]
   // CHECK-OUTPUT: 27
   // CHECK-SIL-DAG: sil public_external {{.*}} @$s4Test9ContainerV12testenum_genyxxlF
   print(c.testenum_gen(27))

--- a/test/SILOptimizer/cross-module-optimization.swift
+++ b/test/SILOptimizer/cross-module-optimization.swift
@@ -20,6 +20,7 @@
 // REQUIRES: executable_test
 // REQUIRES: swift_in_compiler
 
+
 // Second test: check if CMO really imports the SIL of functions in other modules.
 
 // RUN: %target-build-swift -O -wmo -module-name=Main -I%t %s -Xllvm -sil-disable-pass=FunctionSignatureOpts -emit-sil -o %t/out.sil
@@ -27,6 +28,7 @@
 // RUN: %FileCheck %s -check-prefix=CHECK-SIL2 < %t/out.sil
 
 // With -enable-experimental-feature CoroutineAccessors.
+// REQUIRES: swift_feature_CoroutineAccessors
 
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -O -wmo -parse-as-library -cross-module-optimization -emit-module -emit-module-path=%t/Submodule.swiftmodule -module-name=Submodule %S/Inputs/cross-module/cross-submodule.swift -c -o %t/submodule.o -enable-experimental-feature CoroutineAccessors


### PR DESCRIPTION
  in the CMO pass in aggressive mode

Changing the AST mid-pipeline is probably not a good idea.

rdar://173172456