### PR TITLE
[CSSimplify] Don't transfer typed throws onto the closure

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1979,6 +1979,15 @@ namespace {
         if (closure->getThrowsLoc().isValid())
           return Type();
 
+        // Thrown type inferred from context.
+        if (auto contextualType =
+                CS.getContextualType(closure, /*forConstraint=*/false)) {
+          if (auto fnType = contextualType->getAs<AnyFunctionType>()) {
+            if (Type thrownErrorTy = fnType->getThrownError())
+              return thrownErrorTy;
+          }
+        }
+
         // We do not try to infer a thrown error type if one isn't immediately
         // available.
         return Type();

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -12391,23 +12391,6 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
         closureExtInfo = closureExtInfo.withSendable();
       }
     }
-
-    auto inferredThrownErrorType =
-        inferredClosureType->getEffectiveThrownErrorTypeOrNever();
-    // In a typed throws context a throwing closure (as determined from the
-    // body or an explicit type) assumes an error type of the context if it's
-    // fully resolved. Do nothing if closure is either non-throwing
-    // or has an explicit typed throws annotation.
-    if (inferredThrownErrorType->isErrorExistentialType()) {
-      auto errorTy = contextualFnType->getEffectiveThrownErrorTypeOrNever();
-      // Don't propagate if the contextual error type:
-      //   - requires inference;
-      //   - is `Never` which means the contextu is non-throwing;
-      //   - is `any Error` which already matches the inferred type of the closure.
-      if (!(errorTy->hasTypeVariable() || errorTy->isNever() ||
-            errorTy->isErrorExistentialType()))
-        closureExtInfo = closureExtInfo.withThrows(/*throws=*/true, errorTy);
-    }
   }
 
   // Propagate sending result from the contextual type to the closure.

--- a/test/SILGen/typed_throws.swift
+++ b/test/SILGen/typed_throws.swift
@@ -413,6 +413,28 @@ extension ArraySlice where Element == UInt8 {
   ) throws(E) -> R { fatalError() }
 }
 
+func testOverloadingWithConcreteErrorType() throws {
+  func test<E>(_: () throws(E) -> Void) throws(E) {
+  }
+
+  struct S<T> {
+    init(_: () throws -> T) throws {}
+    init(_: () throws(MyError) -> T) throws(MyError) {}
+  }
+
+  struct Q {
+    init() throws {}
+  }
+
+  // CHECK-LABEL: sil private [ossa] @$s12typed_throws36testOverloadingWithConcreteErrorTypeyyKFyyKXEfU_ : $@convention(thin) @substituted <τ_0_0> () -> @error_indirect τ_0_0 for <any Error>
+  try test {
+    // CHECK-LABEL: sil private [ossa] @$s12typed_throws36testOverloadingWithConcreteErrorTypeyyKFyyKXEfU_AaByyKF1QL_VyKXEfU_ : $@convention(thin) @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <Q>
+    _ = try S {
+      try Q() // Ok
+    }
+  }
+}
+
 // CHECK-LABEL:      sil_vtable MySubclass {
 // CHECK-NEXT:   #MyClass.init!allocator: <E where E : Error> (MyClass.Type) -> (() throws(E) -> ()) throws(E) -> MyClass : @$s12typed_throws10MySubclassC4bodyACyyxYKXE_txYKcs5ErrorRzlufC [override]
 // CHECK-NEXT:  #MyClass.f: (MyClass) -> () throws -> () : @$s12typed_throws10MySubclassC1fyyAA0C5ErrorOYKFAA0C5ClassCADyyKFTV [override]

--- a/test/expr/closure/typed_throws.swift
+++ b/test/expr/closure/typed_throws.swift
@@ -41,8 +41,7 @@ func testClosures() {
   // expected-error@-1 {{invalid conversion from throwing function of type '() throws -> Void' to non-throwing function type '() throws(Never) -> Void'}}
 
   let _: () throws(Never) -> Void = {
-    // expected-error@-1 {{invalid conversion from throwing function of type '() throws -> Void' to non-throwing function type '() throws(Never) -> Void'}}
-    throw MyError.fail
+    throw MyError.fail // expected-error {{thrown expression type 'MyError' cannot be converted to error type 'Never'}}
   }
 
   let _: () throws(Never) -> Void = { () throws in
@@ -71,4 +70,24 @@ func testThrowsMismatch(fn: () throws -> Void) {
 
   test(fn)
   // expected-error@-1 {{invalid conversion from throwing function of type '() throws -> Void' to non-throwing function type '() throws(Never) -> Void'}}
+}
+
+func testOverloadingWithConcreteErrorType() throws {
+  func test<E>(_: () throws(E) -> Void) throws(E) {
+  }
+
+  struct S<T> {
+    init(_: () throws -> T) throws {}
+    init(_: () throws(MyError) -> T) throws(MyError) {}
+  }
+
+  struct Q {
+    init() throws {}
+  }
+
+  try test {
+    _ = try S {
+      try Q() // Ok
+    }
+  }
 }


### PR DESCRIPTION
This is a partial revert of https://github.com/swiftlang/swift/pull/87360

The change attempted to infer a concrete thrown error type onto the closure but that leads to incorrect solutions when closure is passed as an argument to an overloaded declaration because the solver doesn't check whether calls in the body do throw the expected type even with `FullTypedThrows` feature enabled and so the safest option is still to assume un-typed `throws` unless typed throws comes from a concrete contextual type.

Resolves: rdar://173132715

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
