### PR TITLE
[Observation] Correct the dirty bit tracking such that only accessed dirty properties contribute to same isolation change events

### DIFF
--- a/stdlib/public/Observation/Sources/Observation/ObservationRegistrar.swift
+++ b/stdlib/public/Observation/Sources/Observation/ObservationRegistrar.swift
@@ -246,7 +246,7 @@ public struct ObservationRegistrar: Sendable {
         if let ptr = _ThreadLocal.value {
           flagDirty = !$0.trackingLists.contains(ptr)
         } else {
-          flagDirty = true
+          flagDirty = false
         }
         if flagDirty, case .clean = $0.dirty {
           $0.dirty = .willSet(keyPath) 
@@ -267,7 +267,7 @@ public struct ObservationRegistrar: Sendable {
         if let ptr = _ThreadLocal.value {
           flagDirty = !$0.trackingLists.contains(ptr)
         } else {
-          flagDirty = true
+          flagDirty = false
         }
         if flagDirty, case .clean = $0.dirty {
           $0.dirty = .didSet(keyPath)

--- a/test/stdlib/Observation/Observable.swift
+++ b/test/stdlib/Observation/Observable.swift
@@ -287,6 +287,48 @@ final class CowTest {
   var container = CowContainer()
 }
 
+
+@Observable
+final class DirtyBitContainer {
+  var observableProperty1 = 42
+  var observableProperty2: NotEquatable?
+  @ObservationIgnored var changed = 0
+  
+  init(isolation: isolated any Actor = #isolation) {
+    self.observationTask = observeAndReconfigureContentChanges()
+  }
+  var observationTask: Task<Void, Never>?
+  deinit {
+    observationTask?.cancel()
+  }
+  
+  private func observeAndReconfigureContentChanges(isolation: isolated any Actor = #isolation) -> Task<Void, Never> {
+    let observationsAsyncSequence = Observations.untilFinished { [weak self] in
+      _ = isolation // establish isolation
+
+      if let strongSelf = self {
+        return .next(strongSelf.observableProperty1)
+      } else {
+        return .finish
+      }
+    }
+
+    return Task { [weak self] in
+      _ = isolation // establish isolation
+
+      for await _ in observationsAsyncSequence {
+        guard let strongSelf = self else { break }
+        strongSelf.observableProperty2 = nil
+        strongSelf.changed += 1
+      }
+    }
+  }
+}
+
+struct NotEquatable {
+}
+
+
 @main
 struct Validator {
   @MainActor
@@ -602,6 +644,12 @@ struct Validator {
       test.firstName = "e"
       try! await Task.sleep(for: .seconds(0.1))
       expectEqual(changed.state, 3)
+    }
+
+    suite.test("dirty bit tracking") {
+      let container = DirtyBitContainer()
+      try? await Task.sleep(for: .seconds(0.1))
+      expectEqual(container.changed, 1)
     }
 
     await runAllTestsAsync()

--- a/test/stdlib/Observation/Observable.swift
+++ b/test/stdlib/Observation/Observable.swift
@@ -287,7 +287,7 @@ final class CowTest {
   var container = CowContainer()
 }
 
-
+@available(SwiftStdlib 6.2, *)
 @Observable
 final class DirtyBitContainer {
   var observableProperty1 = 42
@@ -647,6 +647,7 @@ struct Validator {
     }
 
     suite.test("dirty bit tracking") {
+      guard #available(SwiftStdlib 6.2, *) else { return }
       let container = DirtyBitContainer()
       try? await Task.sleep(for: .seconds(0.1))
       expectEqual(container.changed, 1)


### PR DESCRIPTION
The internal dirty bit tracking state incorrectly flagged all changes as participation when the mutation during observation occurred. This lead to un-releated mutations filtering into same-isolation based changes causing extra events to occur.