### PR TITLE
[IRGen] Fix a test to require `embedded_stdlib`

### DIFF
--- a/test/IRGen/typed_allocation.swift
+++ b/test/IRGen/typed_allocation.swift
@@ -1,10 +1,10 @@
 // RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -enable-experimental-feature TypedAllocation -target arm64-apple-macos99.99 -wmo | %FileCheck %s
 
 // REQUIRES: OS=macosx
+// REQUIRES: embedded_stdlib
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: swift_feature_TypedAllocation
-// REQUIRES: embedded_stdlib
 
 import Swift
 

--- a/test/IRGen/typed_allocation.swift
+++ b/test/IRGen/typed_allocation.swift
@@ -4,6 +4,7 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: swift_feature_TypedAllocation
+// REQUIRES: embedded_stdlib
 
 import Swift
 


### PR DESCRIPTION
- **Explanation**: A minor fix to the test introduced in https://github.com/swiftlang/swift/pull/87663, since the test `import Swift`, it should `REQUIRES: embedded_stdlib` in case some dependencies are not built
This test is failing our CI because we didn't build that
- **Scope**: Tests in `embedded_stdlib`
- **Issues**: N/A
- **Original PRs**: N/A
- **Risk**: None
- **Testing**: CI