### PR TITLE
Diagnose use of `async` without the _Concurrency library

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1417,6 +1417,15 @@ FunctionType::ExtInfo ClosureEffectsRequest::evaluate(
     if (expr->getThrowsLoc().isValid() && !expr->getExplicitThrownTypeRepr())
       diagnoseUntypedThrows(expr, expr->getThrowsLoc());
 
+    // If we don't have the concurrency library, reject the use of 'async'.
+    ASTContext &ctx = expr->getASTContext();
+    if (async &&
+        !ctx.getLoadedModule(ctx.Id_Concurrency) &&
+        !ctx.SILOpts.ParseStdlib) {
+      ctx.Diags.diagnose(expr->getAsyncLoc(),
+                         diag::no_concurrency_module, "async");
+    }
+
     return ASTExtInfoBuilder()
       .withThrows(throws, /*FIXME:*/Type())
       .withAsync(async)

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3164,7 +3164,7 @@ synthesizeMainBody(AbstractFunctionDecl *fn, void *arg) {
     if (!concurrencyModule) {
       context.Diags.diagnose(mainFunction->getAsyncLoc(),
                              diag::no_concurrency_module, "async main");
-      auto result = new (context) ErrorExpr(mainFunction->getSourceRange());
+      auto result = new (context) ErrorExpr(mainFunction->getSourceRange(), ErrorType::get(context));
       ASTNode stmts[] = {result};
       auto body = BraceStmt::create(context, SourceLoc(), stmts, SourceLoc(),
                                     /*Implicit*/ true);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2549,6 +2549,16 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
       SmallVector<AnyFunctionType::Param, 4> argTy;
       AFD->getParameters()->getParams(argTy);
 
+      // If we don't have the concurrency library, reject the use of 'async'.
+      ASTContext &ctx = AFD->getASTContext();
+      if (AFD->hasAsync() &&
+          AFD->getLoc(/*SerializedOK=*/false).isValid() &&
+          !ctx.getLoadedModule(ctx.Id_Concurrency) &&
+          !ctx.SILOpts.ParseStdlib) {
+        ctx.Diags.diagnose(
+            AFD->getAsyncLoc(), diag::no_concurrency_module, "async");
+      }
+
       maybeAddParameterIsolation(infoBuilder, argTy);
       infoBuilder = infoBuilder.withAsync(AFD->hasAsync());
       infoBuilder = infoBuilder.withSendable(AFD->isSendable());

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -3320,6 +3320,13 @@ public:
       }
     }
 
+    // Actors require the concurrency module.
+    if (CD->isActor() && !Ctx.getLoadedModule(Ctx.Id_Concurrency)) {
+      auto sourceFile = CD->getParentSourceFile();
+      if (sourceFile && sourceFile->Kind != SourceFileKind::SIL)
+        CD->diagnose(diag::no_concurrency_module, "actor");
+    }
+
     // Check distributed actors
     TypeChecker::checkDistributedActor(SF, CD);
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4548,6 +4548,15 @@ NeverNullType TypeResolver::resolveASTFunctionType(
     }
   }
 
+  // If we don't have the concurrency library, reject the use of 'async'.
+  if (repr->isAsync() &&
+      !ctx.getLoadedModule(ctx.Id_Concurrency) &&
+      !ctx.SILOpts.ParseStdlib) {
+    diagnoseInvalid(repr, repr->getAsyncLoc(),
+                    diag::no_concurrency_module,
+                    "async");
+  }
+
   // Diagnose a couple of things that we can parse in SIL mode but we don't
   // allow in formal types.
   if (auto patternParams = repr->getPatternGenericParams()) {

--- a/test/Concurrency/async_main_no_concurrency.swift
+++ b/test/Concurrency/async_main_no_concurrency.swift
@@ -2,7 +2,7 @@
 // RUN: %target-typecheck-verify-swift -parse-as-library -target %target-swift-5.1-abi-triple -parse-stdlib
 
 @main struct Main {
-  // expected-error@+1:22{{'_Concurrency' module not imported, required for async main}}
+  // expected-error@+1:22 *{{'_Concurrency' module not imported, required for async}}
   static func main() async {
   }
 }

--- a/test/Concurrency/async_without_concurrency.swift
+++ b/test/Concurrency/async_without_concurrency.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -emit-ir -o - -disable-implicit-concurrency-module-import %s -verify
+
+// REQUIRES: concurrency
+
+struct ConcurrencyTest {
+  func test() async {  // expected-error{{'_Concurrency' module not imported, required for async}}
+  }
+
+  func test2() {
+    _ = { () async in  // expected-error{{'_Concurrency' module not imported, required for async}}
+    }
+  }
+}
+
+typealias Fn = () async -> String // expected-error{{'_Concurrency' module not imported, required for async}}

--- a/test/IRGen/async/partial_apply_forwarder.sil
+++ b/test/IRGen/async/partial_apply_forwarder.sil
@@ -7,6 +7,7 @@ sil_stage canonical
 
 import Builtin
 import Swift
+import _Concurrency
 
 public protocol P {}
 public class C : P {}

--- a/test/SILOptimizer/retain_release_code_motion.sil
+++ b/test/SILOptimizer/retain_release_code_motion.sil
@@ -3,9 +3,11 @@
 // RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all -retain-sinking -retain-sinking -late-release-hoisting %s | %FileCheck --check-prefix=CHECK-MULTIPLE-RS-ROUNDS %s
 
 // REQUIRES: swift_in_compiler
+// REQUIRES: concurrency
 
 import Builtin
 import Swift
+import _Concurrency
 
 struct Int {
   var value : Builtin.Int64

--- a/test/Serialization/Inputs/def_concurrency.sil
+++ b/test/Serialization/Inputs/def_concurrency.sil
@@ -2,6 +2,7 @@ sil_stage raw // CHECK: sil_stage canonical
 
 import Builtin
 import Swift
+import _Concurrency
 
 actor Act { }
 

--- a/test/embedded/availability-macos.swift
+++ b/test/embedded/availability-macos.swift
@@ -8,6 +8,9 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: OS=macosx
+// REQUIRES: concurrency
+
+import _Concurrency
 
 public protocol P { }
 struct S: P { }


### PR DESCRIPTION
Code generation passes can crash if `async` is used without the _Concurrency library present. Diagnose this in the type checker to prevent us from going further.

Fixes issue #87068 / rdar://169919137
