### PR TITLE
[android] Revert change to look for CGFloat in CoreFoundation from #88004

### DIFF
--- a/include/swift/AST/KnownSDKTypes.def
+++ b/include/swift/AST/KnownSDKTypes.def
@@ -30,7 +30,7 @@ KNOWN_SDK_TYPE_DECL(Foundation, NSCopying, ProtocolDecl, 0)
 KNOWN_SDK_TYPE_DECL(Foundation, NSError, ClassDecl, 0)
 KNOWN_SDK_TYPE_DECL(Foundation, NSNumber, ClassDecl, 0)
 KNOWN_SDK_TYPE_DECL(Foundation, NSValue, ClassDecl, 0)
-KNOWN_SDK_TYPE_DECL(CoreFoundation, CGFloat, StructDecl, 0)
+KNOWN_SDK_TYPE_DECL(Foundation, CGFloat, StructDecl, 0)
 
 KNOWN_SDK_TYPE_DECL(ObjectiveC, NSObject, ClassDecl, 0)
 KNOWN_SDK_TYPE_DECL(ObjectiveC, Selector, StructDecl, 0)


### PR DESCRIPTION
This [broke cross-compiling Foundation on the Android CI](https://ci.swift.org/job/oss-swift-package-swift-sdk-for-android/343/console), so reverting to fix CI till we can investigate more:
```
21:02:07  /source/swift-project/swift-corelibs-foundation/Sources/Foundation/NSDate.swift:33:43: error: standard library type 'CGFloat' is missing or broken; this is a compiler bug
21:02:07   31 | extension timeval {
21:02:07   32 |     internal init(_timeIntervalSince1970: TimeInterval) {
21:02:07   33 |         let (integral, fractional) = modf(_timeIntervalSince1970)
21:02:07      |                                           `- error: standard library type 'CGFloat' is missing or broken; this is a compiler bug
```