### PR TITLE
Optimizer: fix the enum tag comparison optimization

### DIFF
--- a/SwiftCompilerSources/Sources/AST/Declarations.swift
+++ b/SwiftCompilerSources/Sources/AST/Declarations.swift
@@ -99,7 +99,7 @@ public class NominalTypeDecl: GenericTypeDecl {
 }
 
 final public class EnumDecl: NominalTypeDecl {
-  public var hasRawType: Bool { bridged.Enum_hasRawType() }
+  public var rawType: Type? { Type(bridgedOrNil: bridged.Enum_getRawType()) }
 
   public static func create(
     declContext: DeclContext, enumKeywordLoc: SourceLoc?, name: String,

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyApply.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyApply.swift
@@ -135,7 +135,9 @@ private func tryOptimizeEnumComparison(apply: ApplyInst, _ context: SimplifyCont
   let lhs = apply.arguments[0]
   let rhs = apply.arguments[1]
   guard let enumDecl = lhs.type.nominal as? EnumDecl,
-        enumDecl.hasRawType,
+        // A custom raw type can implement the case comparison in a way that comparing different cases
+        // will return `true`. Therefore only do the optimization for known stdlib raw value types.
+        enumDecl.hasKnownRawType(context),
         !enumDecl.isResilient(in: apply.parentFunction),
         !enumDecl.hasClangNode,
         lhs.type.isAddress,
@@ -305,5 +307,31 @@ private extension Type {
   func optionalPayloadType(in function: Function) -> Type {
     let subs = contextSubstitutionMap
     return subs.replacementTypes[0].loweredType(in: function)
+  }
+}
+
+private extension EnumDecl {
+  func hasKnownRawType(_ context: SimplifyContext) -> Bool {
+    guard let rawType,
+          let rawTypeDecl = rawType.nominal
+    else {
+      return false
+    }
+    switch rawTypeDecl {
+    case context.swiftIntDecl,
+         context.swiftInt64Decl,
+         context.swiftInt32Decl,
+         context.swiftInt16Decl,
+         context.swiftInt8Decl,
+         context.swiftUIntDecl,
+         context.swiftUInt64Decl,
+         context.swiftUInt32Decl,
+         context.swiftUInt16Decl,
+         context.swiftUInt8Decl,
+         context.swiftStringDecl:
+      return true
+    default:
+      return false
+    }
   }
 }

--- a/SwiftCompilerSources/Sources/SIL/Context.swift
+++ b/SwiftCompilerSources/Sources/SIL/Context.swift
@@ -65,9 +65,18 @@ extension Context {
       AST.`Type`(bridged: _bridged.getTupleTypeWithLabels(types, labels))}}
   }
 
-  public var swiftArrayDecl: NominalTypeDecl {
-    _bridged.getSwiftArrayDecl().getAs(NominalTypeDecl.self)
-  }
+  public var swiftArrayDecl: NominalTypeDecl { _bridged.getSwiftArrayDecl().getAs(NominalTypeDecl.self) }
+  public var swiftIntDecl: NominalTypeDecl { _bridged.getSwiftIntDecl().getAs(NominalTypeDecl.self) }
+  public var swiftInt64Decl: NominalTypeDecl { _bridged.getSwiftInt64Decl().getAs(NominalTypeDecl.self) }
+  public var swiftInt32Decl: NominalTypeDecl { _bridged.getSwiftInt32Decl().getAs(NominalTypeDecl.self) }
+  public var swiftInt16Decl: NominalTypeDecl { _bridged.getSwiftInt16Decl().getAs(NominalTypeDecl.self) }
+  public var swiftInt8Decl: NominalTypeDecl { _bridged.getSwiftInt8Decl().getAs(NominalTypeDecl.self) }
+  public var swiftUIntDecl: NominalTypeDecl { _bridged.getSwiftUIntDecl().getAs(NominalTypeDecl.self) }
+  public var swiftUInt64Decl: NominalTypeDecl { _bridged.getSwiftUInt64Decl().getAs(NominalTypeDecl.self) }
+  public var swiftUInt32Decl: NominalTypeDecl { _bridged.getSwiftUInt32Decl().getAs(NominalTypeDecl.self) }
+  public var swiftUInt16Decl: NominalTypeDecl { _bridged.getSwiftUInt16Decl().getAs(NominalTypeDecl.self) }
+  public var swiftUInt8Decl: NominalTypeDecl { _bridged.getSwiftUInt8Decl().getAs(NominalTypeDecl.self) }
+  public var swiftStringDecl: NominalTypeDecl { _bridged.getSwiftStringDecl().getAs(NominalTypeDecl.self) }
 
   public var swiftMutableSpan: NominalTypeDecl {
     _bridged.getSwiftMutableSpanDecl().getAs(NominalTypeDecl.self)

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -347,7 +347,7 @@ struct BridgedDeclObj {
   NominalType_getDeclaredInterfaceType() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType NominalType_getSelfInterfaceType() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE OptionalBridgedDeclObj NominalType_getValueTypeDestructor() const;
-  BRIDGED_INLINE bool Enum_hasRawType() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType Enum_getRawType() const;
   BRIDGED_INLINE bool Struct_hasUnreferenceableStorage() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType Class_getSuperclass() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedDeclObj Class_getDestructor() const;

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -240,8 +240,11 @@ OptionalBridgedDeclObj BridgedDeclObj::NominalType_getValueTypeDestructor() cons
   return {getAs<swift::NominalTypeDecl>()->getValueTypeDestructor()};
 }
 
-bool BridgedDeclObj::Enum_hasRawType() const {
-  return getAs<swift::EnumDecl>()->hasRawType();
+BridgedASTType BridgedDeclObj::Enum_getRawType() const {
+  swift::Type rawTy = getAs<swift::EnumDecl>()->getRawType();
+  if (rawTy)
+    return {rawTy.getPointer()};
+  return {nullptr};
 }
 
 bool BridgedDeclObj::Struct_hasUnreferenceableStorage() const {

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -1537,6 +1537,17 @@ struct BridgedContext {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType getTupleTypeWithLabels(
       BridgedArrayRef elementTypes, BridgedArrayRef labels) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedDeclObj getSwiftArrayDecl() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedDeclObj getSwiftIntDecl() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedDeclObj getSwiftInt64Decl() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedDeclObj getSwiftInt32Decl() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedDeclObj getSwiftInt16Decl() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedDeclObj getSwiftInt8Decl() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedDeclObj getSwiftUIntDecl() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedDeclObj getSwiftUInt64Decl() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedDeclObj getSwiftUInt32Decl() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedDeclObj getSwiftUInt16Decl() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedDeclObj getSwiftUInt8Decl() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedDeclObj getSwiftStringDecl() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedDeclObj getSwiftMutableSpanDecl() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedValue getSILUndef(BridgedType type) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -3197,6 +3197,50 @@ BridgedDeclObj BridgedContext::getSwiftArrayDecl() const {
   return {context->getModule()->getASTContext().getArrayDecl()};
 }
 
+BridgedDeclObj BridgedContext::getSwiftIntDecl() const {
+  return {context->getModule()->getASTContext().getIntDecl()};
+}
+
+BridgedDeclObj BridgedContext::getSwiftInt64Decl() const {
+  return {context->getModule()->getASTContext().getInt64Decl()};
+}
+
+BridgedDeclObj BridgedContext::getSwiftInt32Decl() const {
+  return {context->getModule()->getASTContext().getInt32Decl()};
+}
+
+BridgedDeclObj BridgedContext::getSwiftInt16Decl() const {
+  return {context->getModule()->getASTContext().getInt16Decl()};
+}
+
+BridgedDeclObj BridgedContext::getSwiftInt8Decl() const {
+  return {context->getModule()->getASTContext().getInt8Decl()};
+}
+
+BridgedDeclObj BridgedContext::getSwiftUIntDecl() const {
+  return {context->getModule()->getASTContext().getUIntDecl()};
+}
+
+BridgedDeclObj BridgedContext::getSwiftUInt64Decl() const {
+  return {context->getModule()->getASTContext().getUInt64Decl()};
+}
+
+BridgedDeclObj BridgedContext::getSwiftUInt32Decl() const {
+  return {context->getModule()->getASTContext().getUInt32Decl()};
+}
+
+BridgedDeclObj BridgedContext::getSwiftUInt16Decl() const {
+  return {context->getModule()->getASTContext().getUInt16Decl()};
+}
+
+BridgedDeclObj BridgedContext::getSwiftUInt8Decl() const {
+  return {context->getModule()->getASTContext().getUInt8Decl()};
+}
+
+BridgedDeclObj BridgedContext::getSwiftStringDecl() const {
+  return {context->getModule()->getASTContext().getStringDecl()};
+}
+
 BridgedDeclObj BridgedContext::getSwiftMutableSpanDecl() const {
   return {context->getModule()->getASTContext().getMutableSpanDecl()};
 }

--- a/test/SILOptimizer/enum-comparison.swift
+++ b/test/SILOptimizer/enum-comparison.swift
@@ -103,6 +103,21 @@ func compare5(_ x: CustomRawValue) -> Bool {
   return x == .b
 }
 
+struct NonUnqiueRawValue: Equatable, ExpressibleByStringLiteral {
+  init() {}
+  init(stringLiteral _: String) {}
+}
+
+enum NU: NonUnqiueRawValue {
+  case a = "a"
+  case b = "b"
+}
+
+@inline(never)
+func compare6() -> Bool {
+  return NU.a == NU.b
+}
+
 // OUT: 1: false
 print("1: \(compareeq(.c, .long_case_name_for_testing))")
 
@@ -141,4 +156,7 @@ print("12: \(compare4(.e3(27)))")
 
 // OUT: 13: true
 print("13: \(compare5(.a))")
+
+// OUT: 14: true
+print("14: \(compare6())")
 

--- a/test/SILOptimizer/simplify_apply.sil
+++ b/test/SILOptimizer/simplify_apply.sil
@@ -30,6 +30,17 @@ enum E: String {
   case a, b, c, d, e
 }
 
+struct NonUnqiueRawValue: Equatable, ExpressibleByStringLiteral {
+  init() {}
+  init(stringLiteral _: String) {}
+}
+
+enum NU: NonUnqiueRawValue {
+  case a = "a"
+  case b = "b"
+}
+
+
 protocol P2 {
   associatedtype A: Q
 }
@@ -231,6 +242,17 @@ sil [ossa] @string_enum_is_equal_wrong_convention : $@convention(thin) (E, E) ->
 bb0(%0 : $E, %1 : $E):
   %2 = function_ref @rawrepresentable_is_equal_wrong_convention : $@convention(thin) (E, E) -> Bool
   %3 = apply %2(%0, %1) : $@convention(thin) (E, E) -> Bool
+  return %3
+}
+
+// CHECK-LABEL: sil [ossa] @custom_rawvalue_enum_is_equal :
+// CHECK:         function_ref
+// CHECK:         apply
+// CHECK:       } // end sil function 'custom_rawvalue_enum_is_equal'
+sil [ossa] @custom_rawvalue_enum_is_equal : $@convention(thin) (@in_guaranteed NU, @in_guaranteed NU) -> Bool {
+bb0(%0 : $*NU, %1 : $*NU):
+  %2 = function_ref @rawrepresentable_is_equal : $@convention(thin) <T where T : RawRepresentable, T.RawValue : Equatable> (@in_guaranteed T, @in_guaranteed T) -> Bool
+  %3 = apply %2<NU>(%0, %1) : $@convention(thin) <τ_0_0 where τ_0_0 : RawRepresentable, τ_0_0.RawValue : Equatable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0) -> Bool
   return %3
 }
 


### PR DESCRIPTION
This optimization replaces (the very inefficient) RawRepresentable comparison to a simple compare of enum tags. However if the raw type is a custom type we don't know how the comparison is implemented. A custom raw type can implement the case comparison in a way that comparing different cases will return `true`. Therefore only do the optimization for known stdlib raw value types.

Fixes a mis-compile
https://github.com/swiftlang/swift/issues/87906
rdar://172746003
