### PR TITLE
[build] Remove weird lldb note from build script help page

### DIFF
--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -1705,8 +1705,6 @@ Preparing to run this script
 
   See README.md for instructions on cloning Swift subprojects.
 
-If you intend to use the -l, -L, --lldb, or --debug-lldb options.
-
 That's it; you're ready to go!
 
 Examples


### PR DESCRIPTION
This incomplete sentence is not helping anyone, and certainly not the people desperate enough to read the build script help page.