### PR TITLE
[test][android] Fix one test and disable others for NDK 28 and API 24

### DIFF
--- a/test/IRGen/availability_android.swift
+++ b/test/IRGen/availability_android.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -target aarch64-unknown-linux-android24 -primary-file %s -emit-ir | %FileCheck %s --check-prefix=CHECK-24
-// RUN: %target-swift-frontend -target aarch64-unknown-linux-android28 -primary-file %s -emit-ir | %FileCheck %s --check-prefix=CHECK-28
+// RUN: %target-swift-frontend -target %target-triple24 -primary-file %s -emit-ir | %FileCheck %s --check-prefix=CHECK-24
+// RUN: %target-swift-frontend -target %target-triple28 -primary-file %s -emit-ir | %FileCheck %s --check-prefix=CHECK-28
 
 // CHECK-24-LABEL: define{{.*}}$s20availability_android0A5CheckyyF
 // CHECK-24: call swiftcc i1 @"$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF"(
@@ -7,7 +7,7 @@
 // CHECK-28-LABEL: define{{.*}}$s20availability_android0A5CheckyyF
 // CHECK-28-NOT: call swiftcc i1 @"$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF"(
 
-// REQUIRES: OS=linux-android || OS=linux-androideabi
+// REQUIRES: OS=linux-android
 
 public func availabilityCheck() {
   if #available(Android 28, *) {

--- a/test/Interop/Cxx/class/invalid-members/stdlib-containers-of-incomplete.swift
+++ b/test/Interop/Cxx/class/invalid-members/stdlib-containers-of-incomplete.swift
@@ -30,6 +30,9 @@
 //
 // REQUIRES: swift_feature_ImportCxxMembersLazily
 
+// Requires specifying the Android API when compiling
+// UNSUPPORTED: OS=linux-android, OS=linux-androideabi
+
 //--- Inputs/module.modulemap
 module StdContain {
   header "std-contain-incomplete.h"

--- a/test/Reflection/typeref_decoding_packs.swift
+++ b/test/Reflection/typeref_decoding_packs.swift
@@ -17,6 +17,9 @@
 // RUN: %target-swift-reflection-dump %t/%target-library-name(TypesToReflect) | %FileCheck %s
 // RUN: %target-swift-reflection-dump %t/TypesToReflect | %FileCheck %s
 
+// Fails only with Android NDK 28 because of an lld issue
+// UNSUPPORTED: OS=linux-android
+
 // CHECK: FIELDS:
 // CHECK: =======
 // CHECK: TypesToReflect.Packed

--- a/test/Reflection/typeref_lowering_packs.swift
+++ b/test/Reflection/typeref_lowering_packs.swift
@@ -16,6 +16,9 @@
 
 // REQUIRES: PTRSIZE=64
 
+// Fails only with Android NDK 28 because of an lld issue
+// UNSUPPORTED: OS=linux-android
+
 12TypeLowering6SimpleV
 
 // CHECK: (struct TypeLowering.Simple)


### PR DESCRIPTION
Check if this fixes the failing IRGen test after swiftlang/swift-docker#528 and bring those disabled tests for NDK 28 here instead.