### PR TITLE
[cxx-interop] Allow DereferenceResult to be an UnsafeMutablePointer

### DIFF
--- a/stdlib/public/Cxx/CxxBorrowingSequence.swift
+++ b/stdlib/public/Cxx/CxxBorrowingSequence.swift
@@ -24,7 +24,9 @@ public protocol CxxBorrowingSequence<Element> : BorrowingSequence, ~Copyable, ~E
   override associatedtype Element: ~Copyable
   override associatedtype BorrowingIterator: BorrowingIteratorProtocol<Element> & ~Copyable & ~Escapable = CxxBorrowingIterator<Self>
   associatedtype RawIterator: UnsafeCxxInputIterator
-    where RawIterator.Pointee == Element, RawIterator.DereferenceResult == UnsafePointer<Element>
+    where RawIterator.Pointee == Element,
+          RawIterator.DereferenceResult: _Pointer,
+          RawIterator.DereferenceResult.Pointee == Element
 
   /// Do not implement this function manually in Swift.
   func __beginUnsafe() -> RawIterator
@@ -60,10 +62,10 @@ extension CxxBorrowingIterator where T: ~Copyable & ~Escapable, T.Element: ~Copy
       return Span()
     }
 
-    let ptr = unsafe self.current.__operatorStar()
+    let rawPtr = unsafe self.current.__operatorStar()._rawValue
     self.current = self.current.successor()
     return unsafe _cxxOverrideLifetime(
-        Span(_unsafeStart: ptr, count: 1),
+        Span(_unsafeStart: UnsafePointer(rawPtr), count: 1),
         borrowing: self)
   }
 }
@@ -88,11 +90,11 @@ extension CxxBorrowingIterator where T: ~Copyable & ~Escapable, T.RawIterator: U
       return Span()
     }
 
-    let ptr = unsafe self.current.__operatorStar()
+    let rawPtr = unsafe self.current.__operatorStar()._rawValue
     let distance = min(count, maximumCount)
     self.current += T.RawIterator.Distance(distance)
     return unsafe _cxxOverrideLifetime(
-        Span(_unsafeStart: ptr, count: distance),
+        Span(_unsafeStart: UnsafePointer(rawPtr), count: distance),
         borrowing: self)
   }
 }

--- a/stdlib/public/Cxx/UnsafeCxxIterators.swift
+++ b/stdlib/public/Cxx/UnsafeCxxIterators.swift
@@ -51,10 +51,10 @@ where Pointee: ~Copyable {
 
 extension UnsafeMutablePointer: @unsafe UnsafeCxxInputIterator
 where Pointee: ~Copyable {
-  public typealias DereferenceResult = UnsafePointer<Self.Pointee>
+  public typealias DereferenceResult = Self
   @inlinable
   public func __operatorStar() -> DereferenceResult {
-    return unsafe UnsafePointer(self)
+    return unsafe self
   }
 }
 

--- a/test/Interop/Cxx/stdlib/use-std-span.swift
+++ b/test/Interop/Cxx/stdlib/use-std-span.swift
@@ -1,11 +1,15 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20)
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20 -Xcc -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20 -enable-experimental-feature BorrowingForLoop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20 -Xcc -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG -enable-experimental-feature BorrowingForLoop)
+
 
 // TODO: test failed in macOS PR testing but passes locally: rdar://163049442
 // UNSUPPORTED: OS_FAMILY=darwin && !CPU=arm64
 
 // REQUIRES: executable_test
 // REQUIRES: std_span
+// REQUIRES: swift_feature_BorrowingForLoop
 
 import StdlibUnittest
 #if !BRIDGING_HEADER
@@ -710,5 +714,63 @@ StdSpanTestSuite.test("Convert between Swift and C++ span types")
     }
   }
 }
+
+StdSpanTestSuite.test("CxxSpan conforms to CxxBorrowingSequence")
+.require(.stdlib_6_4).code {
+  guard #available(SwiftStdlib 6.4, *) else { return }
+
+  let s = initSpan()
+  let arr : [Int32] = [1, 2, 3]
+
+  var iterator = s.makeBorrowingIterator()
+  var counter = 0
+  while true {
+    var span = iterator.nextSpan()
+    if (span.count == 0) { break }
+    for i in 0..<span.count {
+      expectEqual(span[i], arr[counter])
+      counter += 1
+    }
+  }
+  expectEqual(counter, 3)
+}
+
+#if hasFeature(BorrowingForLoop)
+
+StdSpanTestSuite.test("CxxSpan of noncopyable conforms to CxxBorrowingSequence")
+.require(.stdlib_6_4).code {
+  guard #available(SwiftStdlib 6.4, *) else { return }
+
+  let s = makeSpanOfNonCopyable()
+  let arr : [Int32] = [1, 2, 3]
+
+  var iterator = s.makeBorrowingIterator()
+  var counter = 0
+  while true {
+    var span = iterator.nextSpan()
+    if (span.count == 0) { break }
+    for i in 0..<span.count {
+      expectEqual(span[i].number, arr[counter])
+      counter += 1
+    }
+  }
+  expectEqual(counter, 3)
+}
+
+StdSpanTestSuite.test("Borrowing for loop")
+.require(.stdlib_6_4).code {
+  guard #available(SwiftStdlib 6.4, *) else { return }
+
+  let span = makeSpanOfNonCopyable()
+  let arr : [Int32] = [1, 2, 3]
+  var counter = 0
+  for el in span {
+    expectEqual(el.number, arr[counter])
+    counter += 1
+  }
+  expectEqual(counter, 3)
+}
+
+#endif
 
 runAllTests()


### PR DESCRIPTION
The `DereferenceResult` in `CxxBorrowingSequence` was required to be a `UnsafePointer`. However, the `__operatorStar` from `std::span` returns an `UnsafeMutablePointer`, which meant that the conformance of `std::span` to `CxxBorrowingSequence` would be invalid. 

We relax this requirement by instead constraining `DereferenceResult` to be a `_Pointer`, which includes `UnsafeMutablePointer` and `UnsafePointer`, but also `UnsafeRawPointer`, `UnsafeMutableRawPointer`, and `AutoreleasingUnsafeMutablePointer`. 