### PR TITLE
sourcekitd-test: Remove dependency on private APIs

### DIFF
--- a/tools/SourceKit/tools/sourcekitd-test/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd-test/CMakeLists.txt
@@ -7,11 +7,6 @@ add_sourcekit_executable(sourcekitd-test
   TestOptions.cpp
   LLVM_LINK_COMPONENTS option coverage lto
 )
-target_link_libraries(sourcekitd-test PRIVATE
-  SourceKitSupport
-  clangRewrite
-  clangLex
-  clangBasic)
 if(SWIFT_SOURCEKIT_USE_INPROC_LIBRARY)
   target_link_libraries(sourcekitd-test PRIVATE sourcekitdInProc)
 else()

--- a/tools/SourceKit/tools/sourcekitd-test/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd-test/CMakeLists.txt
@@ -2,6 +2,14 @@ set(LLVM_TARGET_DEFINITIONS Options.td)
 swift_tablegen(Options.inc -gen-opt-parser-defs)
 swift_add_public_tablegen_target(sourcekitdTestOptionsTableGen)
 
+# sourcekitd-test must only depend on DLL-exported APIs (sourcekitd,
+# libdispatch, LLVM ...). Of particular note, bringing in swiftBasic directly or
+# indirectly will cause the tests to crash at runtime with an LLVM dylib build.
+# This is because swiftBasic has static cl::opt initializers in
+# lib/Basic/Assertions.cpp. swiftBasic is already embedded in sourcekitdInProc,
+# which this test loads, and in an LLVM dylib build, the static initializers
+# will register twice against the single shared LLVM dylib cl::opt registry,
+# causing a crash at startup.
 add_sourcekit_executable(sourcekitd-test
   sourcekitd-test.cpp
   TestOptions.cpp

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -269,10 +269,21 @@ static void skt_main(skt_args *args) {
     llvm::SmallString<256> tmpDir;
     auto errCode = llvm::sys::fs::createUniqueDirectory("sourcekitd-test-cwd",
                                                         tmpDir);
-    assert(!errCode && "Failed to create temporary dir for sourcekitd-test");
+    if (errCode) {
+      llvm::report_fatal_error(
+          llvm::Twine("Failed to create temporary dir for sourcekitd-test: ") +
+          errCode.message());
+    }
     errCode = realFS->getRealPath(tmpDir, tmpWorkingDir);
-    assert(!errCode && !tmpWorkingDir.empty() &&
-           "Failed to resolve temporary dir real path");
+    if (errCode) {
+      llvm::report_fatal_error(
+          llvm::Twine("Failed to resolve temporary dir real path: ") +
+          errCode.message());
+    }
+    if (tmpWorkingDir.empty()) {
+      llvm::report_fatal_error(
+          "Failed to resolve temporary dir real path: empty path");
+    }
     realFS->setCurrentWorkingDirectory(tmpWorkingDir);
   }
   SWIFT_DEFER {

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -12,9 +12,7 @@
 
 #include "sourcekitd/sourcekitd.h"
 
-#include "SourceKit/Support/Concurrency.h"
 #include "TestOptions.h"
-#include "swift/Basic/Assertions.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Demangling/ManglingMacros.h"
 #include "llvm/ADT/ArrayRef.h"
@@ -46,6 +44,38 @@
 
 // FIXME: Platform compatibility.
 #include <dispatch/dispatch.h>
+
+namespace {
+
+class Semaphore {
+  dispatch_semaphore_t sem;
+
+public:
+  Semaphore() : sem(dispatch_semaphore_create(0)) {}
+  ~Semaphore() {
+    if (sem)
+      dispatch_release(sem);
+  }
+  void signal() { dispatch_semaphore_signal(sem); }
+  bool wait(long milliseconds) {
+    return dispatch_semaphore_wait(
+        sem, dispatch_time(DISPATCH_TIME_NOW, milliseconds * NSEC_PER_MSEC));
+  }
+  Semaphore(Semaphore &&other) : sem(other.sem) { other.sem = nullptr; }
+  Semaphore(const Semaphore &) = delete;
+  Semaphore &operator=(const Semaphore &) = delete;
+};
+
+struct AsyncResponseInfo {
+  Semaphore semaphore;
+  sourcekitd_response_t response = nullptr;
+  sourcekitd_test::TestOptions options;
+  std::string sourceFilename;
+  std::unique_ptr<llvm::MemoryBuffer> sourceBuffer;
+  sourcekitd_request_handle_t requestHandle;
+};
+
+} // anonymous namespace
 
 using namespace llvm;
 
@@ -138,23 +168,12 @@ static SourceKitRequest ActiveRequest = SourceKitRequest::None;
 static sourcekitd_uid_t SemaDiagnosticStage;
 
 static sourcekitd_uid_t NoteDocUpdate;
-static SourceKit::Semaphore semaSemaphore(0);
+static Semaphore semaSemaphore;
 static sourcekitd_response_t semaResponse;
 static const char *semaName;
 
 static sourcekitd_uid_t NoteTest;
-static SourceKit::Semaphore noteSyncSemaphore(0);
-
-namespace {
-struct AsyncResponseInfo {
-  SourceKit::Semaphore semaphore{0};
-  sourcekitd_response_t response = nullptr;
-  TestOptions options;
-  std::string sourceFilename;
-  std::unique_ptr<llvm::MemoryBuffer> sourceBuffer;
-  sourcekitd_request_handle_t requestHandle;
-};
-} // end anonymous namespace
+static Semaphore noteSyncSemaphore;
 
 static std::vector<AsyncResponseInfo> asyncResponses;
 
@@ -250,21 +269,20 @@ static void skt_main(skt_args *args) {
     llvm::SmallString<256> tmpDir;
     auto errCode = llvm::sys::fs::createUniqueDirectory("sourcekitd-test-cwd",
                                                         tmpDir);
-    ASSERT(!errCode && "Failed to create temporary dir for sourcekitd-test");
+    assert(!errCode && "Failed to create temporary dir for sourcekitd-test");
     errCode = realFS->getRealPath(tmpDir, tmpWorkingDir);
-    ASSERT(!errCode && !tmpWorkingDir.empty() &&
+    assert(!errCode && !tmpWorkingDir.empty() &&
            "Failed to resolve temporary dir real path");
     realFS->setCurrentWorkingDirectory(tmpWorkingDir);
   }
   SWIFT_DEFER {
     auto cwd = realFS->getCurrentWorkingDirectory().get();
     if (tmpWorkingDir != cwd) {
-      ABORT([&](auto &out) {
-        out << "Working directory of the *process* was set to ";
-        out << "'" << cwd << "'; SourceKit does not support this. ";
-        out << "Make sure to use `llvm::vfs::createPhysicalFileSystem` ";
-        out << "instead of `llvm::vfs::getRealFileSystem`.";
-      });
+      llvm::report_fatal_error(
+          llvm::Twine("Working directory of the *process* was set to '") + cwd +
+          "'; SourceKit does not support this. " +
+          "Make sure to use `llvm::vfs::createPhysicalFileSystem` " +
+          "instead of `llvm::vfs::getRealFileSystem`.");
     }
     realFS->setCurrentWorkingDirectory(origWorkingDir);
     llvm::sys::fs::remove_directories(tmpWorkingDir);


### PR DESCRIPTION
sourcekitd-test depends on SourceKit::Semaphore, which is an internal, not exported API. This change removes the dependency and replaces it with a small class using the public exported dispatch_semaphore C API instead.

This is necessary to have the test suite run and pass when building LLVM as a DLL on Windows. See #85241 for details.
