### PR TITLE
[silgen] Ensure that properly insert ignored_read before LValue evaluation scopes end and never use IgnoredRead results of LValue operations.

### DIFF
--- a/lib/SILGen/LValue.h
+++ b/lib/SILGen/LValue.h
@@ -105,6 +105,7 @@ public:
     AddressorKind,              // var/subscript addressor
     CoroutineAccessorKind,      // coroutine accessor
     ValueKind,                  // random base pointer as an lvalue
+    OptionalAddressKind,            // optional address projection
     PhysicalKeyPathApplicationKind, // applying a key path
     BorrowValueKind,            // load_borrow the base rvalue for a projection
     BorrowMutateKind,           // borrow and mutate accessor
@@ -127,6 +128,7 @@ public:
     FirstLogicalKind = GetterSetterKind,
     FirstTranslationKind = OrigToSubstKind,
   };
+
 private:
   const KindTy Kind : 8;
 
@@ -496,6 +498,10 @@ public:
   /// abstraction pattern, make an l-value trafficking in values
   /// following the substituted abstraction pattern.
   void addOrigToSubstComponent(SILType loweredResultType);
+
+  /// Add a force value expr component that will apply a force value expr to the
+  /// LValue.
+  void addForceValueComponent(bool isObject, bool isImplicitOptional);
 
   typedef std::vector<std::unique_ptr<PathComponent>>::iterator iterator;
   typedef std::vector<std::unique_ptr<PathComponent>>::const_iterator

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -5998,31 +5998,7 @@ static void emitSimpleAssignment(SILGenFunction &SGF, SILLocation loc,
         FormalEvaluationScope writeback(SGF);
         auto srcLV = SGF.emitLValue(srcLoad->getSubExpr(),
                                     SGFAccessKind::IgnoredRead);
-        RValue rv = SGF.emitLoadOfLValue(loc, std::move(srcLV), SGFContext());
-        // If we have a move only type, we need to implode and perform a move to
-        // ensure we consume our argument as part of the assignment. Otherwise,
-        // we don't do anything.
-        if (rv.getLoweredType(SGF).isMoveOnly()) {
-          ManagedValue value = std::move(rv).getAsSingleValue(SGF, loc);
-          // If we have an address, then ensure plus one will create a temporary
-          // copy which will act as a consume of the address value. If we have
-          // an object, we need to insert our own move though.
-          value = value.ensurePlusOne(SGF, loc);
-          if (value.getType().isObject())
-            value = SGF.B.createMoveValue(loc, value);
-          SGF.B.createIgnoredUse(loc, value.getValue());
-          return;
-        }
-
-        // Emit the ignored use instruction like we would do in emitIgnoredExpr.
-        if (!rv.isNull()) {
-          SmallVector<ManagedValue, 16> values;
-          std::move(rv).getAll(values);
-          for (auto v : values) {
-            SGF.B.createIgnoredUse(loc, v.getValue());
-          }
-        }
-
+        (void)SGF.emitLoadOfLValue(loc, std::move(srcLV), SGFContext());
         return;
       }
 
@@ -7758,18 +7734,17 @@ void SILGenFunction::emitIgnoredExpr(Expr *E) {
 
     ManagedValue value;
     if (lv.isLastComponentPhysical()) {
-      value = emitAddressOfLValue(LE, std::move(lv));
+      for (auto *unwrap : llvm::reverse(forceValueExprs)) {
+        lv.addForceValueComponent(
+            false /*object*/, unwrap->isForceOfImplicitlyUnwrappedOptional());
+      }
+      emitAddressOfLValue(LE, std::move(lv));
     } else {
-      value = emitLoadOfLValue(LE, std::move(lv),
-          SGFContext::AllowImmediatePlusZero).getAsSingleValue(*this, LE);
-    }
-
-    for (auto &FVE : llvm::reverse(forceValueExprs)) {
-      const TypeLowering &optTL = getTypeLowering(FVE->getSubExpr()->getType());
-      bool isImplicitUnwrap = FVE->isImplicit() &&
-          FVE->isForceOfImplicitlyUnwrappedOptional();
-      value = emitCheckedGetOptionalValueFrom(
-          FVE, value, isImplicitUnwrap, optTL, SGFContext::AllowImmediatePlusZero);
+      for (auto *unwrap : llvm::reverse(forceValueExprs)) {
+        lv.addForceValueComponent(
+            true /*object*/, unwrap->isForceOfImplicitlyUnwrappedOptional());
+      }
+      emitLoadOfLValue(LE, std::move(lv), SGFContext::AllowImmediatePlusZero);
     }
     return;
   }

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -986,6 +986,32 @@ namespace {
     }
   };
 
+  /// A physical path component which force-projects the address of
+  /// the value of an optional address l-value. Always pure.
+  class ForceOptionalAddressComponent : public PhysicalPathComponent {
+    bool isImplicitUnwrap;
+
+  public:
+    ForceOptionalAddressComponent(LValueTypeData typeData,
+                                  bool isImplicitUnwrap)
+        : PhysicalPathComponent(typeData, OptionalAddressKind,
+                                /*actorIsolation=*/std::nullopt),
+          isImplicitUnwrap(isImplicitUnwrap) {}
+
+    virtual bool isLoadingPure() const override { return true; }
+
+    ManagedValue project(SILGenFunction &SGF, SILLocation loc,
+                         ManagedValue base) &&
+        override {
+      return SGF.emitPreconditionOptionalHasValue(loc, base, isImplicitUnwrap);
+    }
+
+    void dump(raw_ostream &OS, unsigned indent) const override {
+      OS.indent(indent) << "ForceOptionalAddressComponent(" << isImplicitUnwrap
+                        << ")\n";
+    }
+  };
+
   /// A physical path component which projects out an opened archetype
   /// from an existential.
   class OpenOpaqueExistentialComponent : public PhysicalPathComponent {
@@ -1277,6 +1303,18 @@ namespace {
     }
   };
 } // end anonymous namespace
+
+void LValue::addForceValueComponent(bool isObject, bool isImplicitOptional) {
+  auto substFormalType = getSubstFormalType();
+  LValueTypeData typeData = {
+      getAccessKind(), AbstractionPattern(substFormalType), substFormalType,
+      substFormalType.getOptionalObjectType()};
+
+  if (isObject)
+    add<ForceOptionalObjectComponent>(typeData, isImplicitOptional);
+  else
+    add<ForceOptionalAddressComponent>(typeData, isImplicitOptional);
+}
 
 static bool isReadNoneFunction(const Expr *e) {
   // If this is a curried call to an integer literal conversion operations, then
@@ -2965,6 +3003,7 @@ LValue SILGenFunction::emitLValue(Expr *e, SGFAccessKind accessKind,
     assert(r.isLastComponentPhysical());
     r.addOrigToSubstComponent(loweredSubstType);
   }
+
   return r;
 }
 
@@ -5638,6 +5677,38 @@ RValue SILGenFunction::emitLoadOfLValue(SILLocation loc, LValue &&src,
     } else {
       // If the last component is logical, emit a get.
       result = std::move(component.asLogical()).get(*this, loc, addr, C);
+    }
+
+    // Check if we have an ignored read. If we do, insert the relevant uses to
+    // end the lifetime (if noncopyable) and or ignored_use to provide a use for
+    // diagnostic passes and set result to be an empty RValue. We do not want to
+    // allow for our caller to use the RValue since the RValue could contain
+    // things whose lifetimes are scoped to within the formal evaluation scope.
+    if (src.getAccessKind() == SGFAccessKind::IgnoredRead && !result.isNull()) {
+      SmallVector<ManagedValue, 16> values;
+      std::move(result).getAll(values);
+
+      for (auto mv : values) {
+        // If we have a move only type, we need to perform a move on each
+        // element to ensure we consume our arguments as part of the
+        // assignment.
+        if (mv.getType().isMoveOnly()) {
+          mv = mv.ensurePlusOne(*this, loc);
+          // If we have an address, then ensure plus one will create a temporary
+          // copy which will act as a consume of the address value. If we have
+          // an object, we need to insert our own move though.
+          if (mv.getType().isObject())
+            mv = B.createMoveValue(loc, mv);
+        }
+
+        // Then regardless if we are noncopyable or copyable, then we insert
+        // an ignored_use for diagnostics.
+        B.createIgnoredUse(loc, mv.getValue());
+      }
+
+      // Then set result to be an empty RValue so that our caller cannot use the
+      // RValue.
+      result = RValue();
     }
   } // End the evaluation scope before any hop back to the current executor.
 

--- a/test/SILGen/class_bound_protocols.swift
+++ b/test/SILGen/class_bound_protocols.swift
@@ -183,9 +183,9 @@ func takesInheritsMutatingMethod(x: inout InheritsMutatingMethod,
   // CHECK-NEXT: store [[X_PAYLOAD]] to [init] [[TEMPORARY]] : $*@opened("{{.*}}", any InheritsMutatingMethod) Self
   // CHECK-NEXT: [[METHOD:%.*]] = witness_method $@opened("{{.*}}", any InheritsMutatingMethod) Self, #HasMutatingMethod.mutatingCounter!getter : <Self where Self : HasMutatingMethod> (Self) -> () -> Value, [[X_PAYLOAD]] : $@opened("{{.*}}", any InheritsMutatingMethod) Self : $@convention(witness_method: HasMutatingMethod) <τ_0_0 where τ_0_0 : HasMutatingMethod> (@in_guaranteed τ_0_0) -> Value
   // CHECK-NEXT: [[RESULT_VALUE:%.*]] = apply [[METHOD]]<@opened("{{.*}}", any InheritsMutatingMethod) Self>([[TEMPORARY]]) : $@convention(witness_method: HasMutatingMethod) <τ_0_0 where τ_0_0 : HasMutatingMethod> (@in_guaranteed τ_0_0) -> Value
+  // CHECK-NEXT: ignored_use [[RESULT_VALUE]]
   // CHECK-NEXT: destroy_addr
   // CHECK-NEXT: end_access [[X_ADDR]] : $*any InheritsMutatingMethod
-  // CHECK-NEXT: ignored_use [[RESULT_VALUE]]
   // CHECK-NEXT: dealloc_stack [[TEMPORARY]] : $*@opened("{{.*}}", any InheritsMutatingMethod) Self
   _ = x.mutatingCounter
 

--- a/test/SILGen/expressions.swift
+++ b/test/SILGen/expressions.swift
@@ -596,11 +596,12 @@ func loadIgnoredLValueForceUnwrap(_ a: inout NonTrivialStruct) -> NonTrivialStru
 // CHECK-NEXT: [[GETTER:%[0-9]+]] = function_ref @$s{{[_0-9a-zA-Z]*}}vg : $@convention(method) (@guaranteed NonTrivialStruct) -> @owned Optional<NonTrivialStruct>
 // CHECK-NEXT: [[X:%[0-9]+]] = apply [[GETTER]]([[BORROW]])
 // CHECK-NEXT: end_borrow [[BORROW]]
-// CHECK-NEXT: end_access [[READ]]
 // CHECK-NEXT: switch_enum [[X]] : $Optional<NonTrivialStruct>, case #Optional.some!enumelt: bb2, case #Optional.none!enumelt: bb1
 // CHECK: bb1:
 // CHECK: unreachable
 // CHECK: bb2([[UNWRAPPED_X:%[0-9]+]] : @owned $NonTrivialStruct):
+// CHECK-NEXT: ignored_use [[UNWRAPPED_X]]
+// CHECK-NEXT: end_access [[READ]]
 // CHECK-NEXT: destroy_value [[UNWRAPPED_X]]
 // CHECK-NEXT: [[METATYPE:%[0-9]+]] = metatype $@thin NonTrivialStruct.Type
 // CHECK-NEXT: return [[METATYPE]]
@@ -622,11 +623,12 @@ func loadIgnoredLValueThroughForceUnwrap(_ a: inout NonTrivialStruct?) -> NonTri
 // CHECK-NEXT: [[GETTER:%[0-9]+]] = function_ref @$s{{[_0-9a-zA-Z]*}}vg : $@convention(method) (@guaranteed NonTrivialStruct) -> @owned Optional<NonTrivialStruct>
 // CHECK-NEXT: [[X:%[0-9]+]] = apply [[GETTER]]([[BORROW]])
 // CHECK-NEXT: end_borrow [[BORROW]]
-// CHECK-NEXT: end_access [[READ]]
 // CHECK-NEXT: switch_enum [[X]] : $Optional<NonTrivialStruct>, case #Optional.some!enumelt: bb4, case #Optional.none!enumelt: bb3
 // CHECK: bb3:
 // CHECK: unreachable
 // CHECK: bb4([[UNWRAPPED_X:%[0-9]+]] : @owned $NonTrivialStruct):
+// CHECK-NEXT: ignored_use [[UNWRAPPED_X]]
+// CHECK-NEXT: end_access [[READ]]
 // CHECK-NEXT: destroy_value [[UNWRAPPED_X]]
 // CHECK-NEXT: [[METATYPE:%[0-9]+]] = metatype $@thin NonTrivialStruct.Type
 // CHECK-NEXT: return [[METATYPE]]
@@ -647,7 +649,8 @@ func evaluateIgnoredKeyPathExpr(_ s: inout NonTrivialStruct, _ kp: WritableKeyPa
 // CHECK-NEXT: [[PROJECT_FN:%[0-9]+]] = function_ref @swift_getAtKeyPath :
 // CHECK-NEXT: [[RESULT:%[0-9]+]] = alloc_stack $Int
 // CHECK-NEXT: apply [[PROJECT_FN]]<NonTrivialStruct, Int>([[RESULT]], [[S_TEMP]], [[KP]])
-// CHECK-NEXT: load [trivial] [[RESULT]]
+// CHECK-NEXT: [[RESULT_LOAD:%.*]] = load [trivial] [[RESULT]]
+// CHECK-NEXT: ignored_use [[RESULT_LOAD]]
 // CHECK-NEXT: end_access [[S_READ]]
 // CHECK-NEXT: dealloc_stack [[RESULT]]
 // CHECK-NEXT: destroy_addr [[S_TEMP]]
@@ -698,3 +701,27 @@ func test21886435() {
   () = ()
 }
 
+class IgnoredUseComputedGetterWithDiscardedResult {
+   struct S {
+       var x: String
+   }
+
+   var s: S {
+       get { S(x: "") }
+       set {}
+   }
+
+   // CHECK-LABEL: sil hidden [ossa] @$s11expressions43IgnoredUseComputedGetterWithDiscardedResultC1fyyACF : $@convention(method) (@guaranteed IgnoredUseComputedGetterWithDiscardedResult, @guaranteed IgnoredUseComputedGetterWithDiscardedResult) -> () {
+   // CHECK: bb0([[ARG:%.*]] : @guaranteed $IgnoredUseComputedGetterWithDiscardedResult,
+   // CHECK:   [[METHOD:%.*]] = class_method [[ARG]]
+   // CHECK:   [[RESULT:%.*]] = apply [[METHOD]]([[ARG]])
+   // CHECK:   [[BORROW:%.*]] = begin_borrow [[RESULT]]
+   // CHECK:   [[EXTRACT:%.*]] = struct_extract [[BORROW]]
+   // CHECK:   ignored_use [[EXTRACT]]
+   // CHECK:   end_borrow [[BORROW]]
+   // CHECK:   destroy_value [[RESULT]]
+   // CHECK: } // end sil function '$s11expressions43IgnoredUseComputedGetterWithDiscardedResultC1fyyACF'
+   func f(_ o: IgnoredUseComputedGetterWithDiscardedResult) {
+     _ = o.s.x
+   }
+}


### PR DESCRIPTION
This commit fixes two issues:

1. When emitting an IgnoredRead LValue, we were emitting an access to the LValue, closing its formal evaluation scope, and then placing the ignored_use. This is incorrect since LValue assumes that it can produce borrowed values for an IgnoredRead. If we attempt to use an ignored_use on those, we will get a use after free since the borrowed value's lifetime has eneded. I changed LValue's emission so that we insert the ignored_use inside of LValue within the formal evaluation scope.

2. After some thought, I realized that the /real/ reason that this is even possible is that we return RValues for IgnoredRead ignoring that it is possibly unsafe to use it. Rather than do that, I changed LValue so that if an IgnoredRead is used, an empty RValue is returned enforcing at compile time that we can never make this same mistake. If a user actually wants to use the resulting RValue, they should use a different SGFAccessKind that guarantees a valid value. To do this though, I found that there was an additional case involving force value exprs where were doing the same incorrect thing with IgnoredRead but just had gotten lucky for a long time. To fix that, I added a new way to just add the force value expr as an LValue component so that the force value expr happens inside the LValue machinery instead of outside it.

rdar://173152507
