### PR TITLE
swift-scan-test: Rename threads option

### DIFF
--- a/test/CAS/swift-scan-test-llvm-args.swift
+++ b/test/CAS/swift-scan-test-llvm-args.swift
@@ -21,7 +21,7 @@
 
 // RUN: %swift-scan-test -action cache_query -id @%t/key.casid -cas-path %t/cas | %FileCheck %s --check-prefix=CHECK-QUERY
 
-// RUN: %swift-scan-test -action replay_result -cas-path %t/cas -id @%t/key.casid -threads 10 -- \
+// RUN: %swift-scan-test -action replay_result -cas-path %t/cas -id @%t/key.casid -scan-threads 10 -- \
 // RUN:   %target-swift-frontend-plain -cache-compile-job -Rcache-compile-job %s \
 // RUN:   -emit-module -emit-module-path %t/Test2.swiftmodule -c -emit-dependencies -module-name Test -o %t/test2.o -cas-path %t/cas \
 // RUN:   @%t/MyApp.cmd -Xllvm -aarch64-use-tbi

--- a/test/ScanDependencies/scanner_api_working_dir.swift
+++ b/test/ScanDependencies/scanner_api_working_dir.swift
@@ -13,7 +13,7 @@
 // CHECK: "mainModuleName": "Test"
 
 // RUN: cd %t
-// RUN: %swift-scan-test -action scan_dependency -threads 2  -- %target-swift-frontend -emit-module -module-name Test \
+// RUN: %swift-scan-test -action scan_dependency -scan-threads 2  -- %target-swift-frontend -emit-module -module-name Test \
 // RUN:   -swift-version 5 -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
 // RUN:   -I include %t/test.swift | %FileCheck %s
 

--- a/tools/swift-scan-test/swift-scan-test.cpp
+++ b/tools/swift-scan-test/swift-scan-test.cpp
@@ -48,7 +48,7 @@ llvm::cl::opt<std::string> CASID("id", llvm::cl::desc("<casid>"),
                                  llvm::cl::cat(Category));
 llvm::cl::opt<std::string> Input("input", llvm::cl::desc("<file|index>"),
                                  llvm::cl::cat(Category));
-llvm::cl::opt<unsigned> Threads("threads",
+llvm::cl::opt<unsigned> Threads("scan-threads",
                                 llvm::cl::desc("<number of threads>"),
                                 llvm::cl::cat(Category), cl::init(1));
 llvm::cl::opt<std::string> WorkingDirectory("cwd", llvm::cl::desc("<path>"),


### PR DESCRIPTION
The `--threads` command line option conflicts with the one defined in LLVM in ThinLTOCodeGenerator. This renames the option to `--scan-threads` in the `swift-scan-test` binary to work around the conflict.

This is to work around a dual initialization issue when building LLVM as a DLL on Windows. This effort is tracked in #85241.
