### PR TITLE
SwiftBasicTests: Support linking against LLVM.dll

### DIFF
--- a/unittests/Basic/CMakeLists.txt
+++ b/unittests/Basic/CMakeLists.txt
@@ -55,9 +55,20 @@ target_link_libraries(SwiftBasicTests
   swiftOption
   swiftThreading
   clangBasic
-  LLVMOption
   LLVMTestingSupport
   )
+
+if(LLVM_LINK_LLVM_DYLIB)
+  target_link_libraries(SwiftBasicTests
+    PRIVATE
+    LLVM
+    )
+else()
+  target_link_libraries(SwiftBasicTests
+    PRIVATE
+    LLVMOption
+    )
+endif()
 
 if(SWIFT_HOST_VARIANT STREQUAL "windows")
   target_link_libraries(SwiftBasicTests PRIVATE Synchronization)


### PR DESCRIPTION
SwiftBasicTests depends on LLVMOption. When building LLVM as a DLL on Windows, this results in LLVMOption being included twice in the binary. To work around the issue, depend on LLVM when building LLVM as a DLL.

This effort is tracked in #85241.