### PR TITLE
[cxx-interop] Fix a missing offset adjustment when calling FRTs

### DIFF
--- a/include/swift/AST/ClangModuleLoader.h
+++ b/include/swift/AST/ClangModuleLoader.h
@@ -223,6 +223,10 @@ public:
   /// Returns the original method if \param decl is a clone from a base class
   virtual ValueDecl *getOriginalForClonedMember(const ValueDecl *decl) = 0;
 
+  /// Returns the forwarding method in the derived class that calls the base
+  /// method.
+  virtual ValueDecl *getCalledBaseCxxMethod(const ValueDecl *decl) = 0;
+
   /// Returns true if we synthesize this member for every type so no need to
   /// clone it for the derived classes.
   virtual bool isMemberSynthesizedPerType(const ValueDecl *decl) = 0;

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -688,6 +688,7 @@ public:
                                   ClangInheritanceInfo inheritance) override;
 
   ValueDecl *getOriginalForClonedMember(const ValueDecl *decl) override;
+  ValueDecl *getCalledBaseCxxMethod(const ValueDecl *decl) override;
   bool isMemberSynthesizedPerType(const ValueDecl *decl) override;
 
   /// Emits diagnostics for any declarations named name

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5754,7 +5754,7 @@ MemberRefExpr *getSelfInteropStaticCast(FuncDecl *funcDecl,
 // to the imported base member, or it's the synthesized C++ method thunk
 // used in another synthesized derived thunk that acts as a base member here.
 static const clang::CXXMethodDecl *
-getCalledBaseCxxMethod(FuncDecl *baseMember) {
+getCalledBaseCxxMethod(const FuncDecl *baseMember) {
   if (baseMember->getClangDecl())
     return dyn_cast<clang::CXXMethodDecl>(baseMember->getClangDecl());
   // Another synthesized derived thunk is used as a base member here,
@@ -7954,6 +7954,11 @@ ClangImporter::importBaseMemberDecl(ValueDecl *decl, DeclContext *newContext,
 
 ValueDecl *ClangImporter::getOriginalForClonedMember(const ValueDecl *decl) {
   return Impl.getOriginalForClonedMember(decl);
+}
+
+ValueDecl *ClangImporter::getCalledBaseCxxMethod(const ValueDecl *decl) {
+  return cast<ValueDecl>(
+      importDeclDirectly(::getCalledBaseCxxMethod(cast<FuncDecl>(decl))));
 }
 
 bool ClangImporter::isMemberSynthesizedPerType(const ValueDecl *decl) {

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -1735,10 +1735,9 @@ void IRGenFunction::emitBlockRelease(llvm::Value *value) {
 
 void IRGenFunction::emitForeignReferenceTypeLifetimeOperation(
     ValueDecl *fn, llvm::Value *value, bool needsNullCheck) {
-  if (auto originalDecl = fn->getASTContext()
-                              .getClangModuleLoader()
-                              ->getOriginalForClonedMember(fn))
-    fn = originalDecl;
+  auto loader = fn->getASTContext().getClangModuleLoader();
+  if (loader->getOriginalForClonedMember(fn))
+    fn = loader->getCalledBaseCxxMethod(fn);
 
   assert(fn->getClangDecl() && isa<clang::FunctionDecl>(fn->getClangDecl()));
 

--- a/test/Interop/Cxx/foreign-reference/Inputs/logging-frts.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/logging-frts.h
@@ -29,6 +29,13 @@ public:
     logMsg("retain");
   }
 
+  void nonFriendReleaseFRT() {
+    --_refCount;
+    logMsg("release");
+    if (_refCount == 0)
+      delete this;
+  }
+
   friend void releaseSharedFRT(SharedFRT *_Nonnull);
 } SWIFT_SHARED_REFERENCE(.retainSharedFRT, releaseSharedFRT);
 
@@ -92,7 +99,14 @@ struct FirstBase {
   virtual ~FirstBase() {}
 };
 
+// Inferred case.
 struct DerivedFRT : FirstBase, SharedFRT {
   SWIFT_RETURNS_RETAINED
   DerivedFRT() = default;
 };
+
+// Explicitly annotated case.
+struct DerivedFRT2 : FirstBase, SharedFRT {
+  SWIFT_RETURNS_RETAINED
+  DerivedFRT2() = default;
+} SWIFT_SHARED_REFERENCE(.retainSharedFRT, .nonFriendReleaseFRT);

--- a/test/Interop/Cxx/foreign-reference/frt-non-primary-base.swift
+++ b/test/Interop/Cxx/foreign-reference/frt-non-primary-base.swift
@@ -8,9 +8,18 @@ func go() {
     let frt = DerivedFRT()
     let copy = frt
 }
-
 go()
+// CHECK: RefCount: 1, message: Ctor
+// CHECK: RefCount: 2, message: retain
+// CHECK: RefCount: 1, message: release
+// CHECK: RefCount: 0, message: release
+// CHECK: RefCount: 0, message: Dtor
 
+func go2() {
+    let frt = DerivedFRT2()
+    let copy = frt
+}
+go2()
 // CHECK: RefCount: 1, message: Ctor
 // CHECK: RefCount: 2, message: retain
 // CHECK: RefCount: 1, message: release


### PR DESCRIPTION
We already generate forwarding methods that can fix up the base offset when we call base methods. Unfortunately, these forwarding methods were not used when we emitted a call to a refcount operation of a foreign reference type where the annotation is on the type itself but the operation was inherited from a base.

rdar://173210238
