### PR TITLE
Observation: Suppress warnings about unsupported function type casts

### DIFF
--- a/stdlib/public/Observation/Sources/Observation/ContinuousObservation.swift
+++ b/stdlib/public/Observation/Sources/Observation/ContinuousObservation.swift
@@ -178,10 +178,7 @@ extension ContinuousObservation.State {
             return
           }
           withObservationTracking(options: options) {
-            // This is safe since we have already been isolated to the tracking isolation.
-            // It can be asserted to be isolated by
-            apply.isolation?.assertIsolated()
-            let fn = apply as @Sendable (borrowing ObservationTracking.Event) -> Void
+            let fn = TrackingClosure(apply).toSynchronous()
             // This ends up also being how the `didSet` is called because this will occur
             // on the next iteration of the while loop from `trackingLoop` after the
             // onChange.
@@ -206,6 +203,23 @@ extension ContinuousObservation.State {
       },
       isolation: apply.isolation
     )
+  }
+
+  // Workaround for "converting @isolated(any) function of type ... to
+  // synchronous function type ... is not allowed".
+  fileprivate struct TrackingClosure {
+    typealias Event = ObservationTracking.Event
+    typealias Isolated = @isolated(any) @Sendable (borrowing Event) -> Void
+    typealias Synchronous = @Sendable (borrowing Event) -> Void
+    let fn: Isolated
+    init(_ fn: @escaping Isolated) {
+      self.fn = fn
+    }
+    func toSynchronous() -> Synchronous {
+      // This is safe since we have already been isolated to the tracking isolation.
+      fn.isolation?.assertIsolated()
+      return unsafeBitCast(self, to: Synchronous.self)
+    }
   }
 }
 

--- a/stdlib/public/Observation/Sources/Observation/Observations.swift
+++ b/stdlib/public/Observation/Sources/Observation/Observations.swift
@@ -181,10 +181,10 @@ public struct Observations<Element: Sendable, Failure: Error>: AsyncSequence, Se
         return try withObservationTracking(options: [.willSet, .deinit]) { () throws(Failure) -> Observations<Element, Failure>.Iteration in
           switch emit {
           case .element(let element):
-            let extracted: () throws(Failure) -> Element = element
+            let extracted = ElementClosure(element).toSynchronous()
             return try Iteration.next(extracted())
           case .iteration(let iteration):
-            let extracted: () throws(Failure) -> Iteration = iteration
+            let extracted = IterationClosure(iteration).toSynchronous()
             return try extracted()
           }
         } onChange: { [state] (event) in
@@ -197,10 +197,10 @@ public struct Observations<Element: Sendable, Failure: Error>: AsyncSequence, Se
           do {
             switch emit {
             case .element(let element):
-              let extracted: () throws(Failure) -> Element = element
+              let extracted = ElementClosure(element).toSynchronous()
               return .success(try Iteration.next(extracted()))
             case .iteration(let iteration):
-              let extracted: () throws(Failure) -> Iteration = iteration
+              let extracted = IterationClosure(iteration).toSynchronous()
               return .success(try extracted())
             }
           } catch {
@@ -272,6 +272,34 @@ public struct Observations<Element: Sendable, Failure: Error>: AsyncSequence, Se
       } catch {
         // the user threw a failure in the closure so propagate that outwards and terminate the sequence
         return try terminate(throwing: error, id: id)
+      }
+    }
+
+    // Workaround for "converting @isolated(any) function of type ... to
+    // synchronous function type ... is not allowed".
+    fileprivate struct ElementClosure {
+      typealias Isolated = @isolated(any) @Sendable () throws(Failure) -> Element
+      typealias Synchronous = () throws(Failure) -> Element
+      let fn: Isolated
+      init(_ fn: @escaping Isolated) {
+        self.fn = fn
+      }
+      func toSynchronous() -> Synchronous {
+        return unsafeBitCast(self, to: Synchronous.self)
+      }
+    }
+
+    // Workaround for "converting @isolated(any) function of type ... to
+    // synchronous function type ... is not allowed".
+    fileprivate struct IterationClosure {
+      typealias Isolated = @isolated(any) @Sendable () throws(Failure) -> Iteration
+      typealias Synchronous = () throws(Failure) -> Iteration
+      let fn: Isolated
+      init(_ fn: @escaping Isolated) {
+        self.fn = fn
+      }
+      func toSynchronous() -> Synchronous {
+        return unsafeBitCast(self, to: Synchronous.self)
       }
     }
   }


### PR DESCRIPTION
Use the workaround discussed in https://forums.swift.org/t/83207/ to avoid warnings like this:

```
../ContinuousObservation.swift:184:22: warning: converting @isolated(any) function of type '@isolated(any) @Sendable (borrowing ObservationTracking.Event) -> Void' to synchronous function type '@Sendable (borrowing ObservationTracking.Event) -> Void' is not allowed; this will be an error in a future Swift language mode
```

Resolves rdar://153094492.