### PR TITLE
[Tests] NFC: Add a few tests for ranking of `@Sendable` vs. non-`Send…

### DIFF
--- a/test/Concurrency/sendable_checking_swift6.swift
+++ b/test/Concurrency/sendable_checking_swift6.swift
@@ -14,3 +14,40 @@ func checkOpaqueType() -> some Sendable {
   UnavailableSendable()
   // expected-error@-1 {{conformance of 'UnavailableSendable' to 'Sendable' is unavailable}}
 }
+
+// Make sure that there is no ambiguity betweeen async and sync versions when the difference is `@Sendable` and `async`.
+// `withError` has to be generic and have two overloads because this test is exercising the interaction between
+// `@Sendable` subtyping and a performance hack that checks specialization without considering arguments if
+// there are only two generic overloads.
+do {
+  func withError<T>(_ body: () throws -> T) throws -> T {
+  }
+
+  func withError<T>(_ body: @Sendable () async throws -> T) async throws -> T {
+  }
+
+  func compute() throws {}
+  @Sendable func longCompute() async throws {}
+
+  // The context is async here to make sure that the synchronous version of `withError` could still be selected.
+  func test() async throws {
+    try withError { // Ok
+    }
+
+    try await withError {
+      // expected-warning@-1 {{no 'async' operations occur within 'await' expression}}
+    }
+
+    try withError { // Ok
+      try compute()
+    }
+
+    try withError { // expected-error {{expression is 'async' but is not marked with 'await'}} expected-note {{call is 'async'}}
+      try await longCompute()
+    }
+
+    try await withError { // Ok
+      try await longCompute()
+    }
+  }
+}


### PR DESCRIPTION
…able` overloads

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
