### PR TITLE
[SILOptimizer] Exclude a test from 32bit targets

### DIFF
--- a/test/SILOptimizer/constant_capture_propagation_odr.sil
+++ b/test/SILOptimizer/constant_capture_propagation_odr.sil
@@ -1,4 +1,5 @@
 // RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all %s -constant-capture-propagation | %FileCheck %s
+// REQUIRES: PTRSIZE=64
 
 // Regression test for an ODR violation in ConstantCapturePropagation.
 sil_stage raw


### PR DESCRIPTION
`SILOptimizer/constant_capture_propagation_odr.sil` introduced in https://github.com/swiftlang/swift/pull/87916 assumed it will run on 64bit targets, as a result, lines like `%3 = struct $Int (%2 : $Builtin.Int64)` is automatically invalid on 32bit targets, as reported by @finagolfin, shown in the [logs here](https://ci.swift.org/job/swift-PR-swift-sdk-for-android/18/consoleText). 

This change adds `REQUIRES: PTRSIZE=64` to exclude the sil test from 32bit targets. The functionality can still be tested through `constant_capture_propagation_odr.swift`

cc @drodriguez 

