### PR TITLE
[update-checkout] be explicit about what ref to fetch when updating repository

### DIFF
--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -229,12 +229,70 @@ def update_single_repository(pool_args: UpdateArguments):
                     repo_path, ["rev-parse", "--verify", checkout_target], echo=verbose
                 )
             except Exception:
-                Git.run(
+                # The target isn't known locally. This can happen when the
+                # repo was cloned with --single-branch (e.g. via
+                # --skip-history) and we now need a different branch or tag.
+                # Fetch the ref explicitly.
+                is_tag, _, _ = Git.run(
                     repo_path,
-                    ["fetch", "--recurse-submodules=yes", "--tags"] + fetch_extra_args,
-                    echo=verbose,
-                    prefix=prefix,
+                    ["ls-remote", "--tags", "origin", checkout_target],
                 )
+                if is_tag:
+                    Git.run(
+                        repo_path,
+                        [
+                            "fetch",
+                            "--recurse-submodules=yes",
+                            "origin",
+                            f"+refs/tags/{checkout_target}"
+                            f":refs/tags/{checkout_target}",
+                        ]
+                        + fetch_extra_args,
+                        echo=verbose,
+                        prefix=prefix,
+                    )
+                elif not is_commit_hash(checkout_target):
+                    Git.run(
+                        repo_path,
+                        [
+                            "fetch",
+                            "--recurse-submodules=yes",
+                            "--tags",
+                            "origin",
+                            f"+refs/heads/{checkout_target}"
+                            f":refs/remotes/origin/{checkout_target}",
+                        ]
+                        + fetch_extra_args,
+                        echo=verbose,
+                        prefix=prefix,
+                    )
+                    # Shallow clones do not auto-create a local tracking branch
+                    # on checkout. Check if it exists if not set up tracking.
+                    # --list output is empty string if the branch doesn't exist,
+                    # non-empty if it does.
+                    existing_branch, _, _ = Git.run(
+                        repo_path,
+                        ["branch", "--list", checkout_target],
+                    )
+                    if not existing_branch:
+                        Git.run(
+                            repo_path,
+                            [
+                                "branch",
+                                checkout_target,
+                                f"refs/remotes/origin/{checkout_target}",
+                            ],
+                            echo=verbose,
+                            prefix=prefix,
+                        )
+                else:
+                    Git.run(
+                        repo_path,
+                        ["fetch", "--recurse-submodules=yes", "--tags"]
+                        + fetch_extra_args,
+                        echo=verbose,
+                        prefix=prefix,
+                    )
 
             try:
                 Git.run(


### PR DESCRIPTION
When update-checkout is called when a repo was cloned with a shallow clone, it will currently try to checkout the rev for the given scheme when update-checkout is called but that ref will not exist.

This patch does the following: When `update_single_repository` is called, check if the target ref exists in the repo, if it does check it out. If it doesn't as is the case with a shallow clone, call the appropriate git function to add the ref to the local repo
* tag -> `git fetch --tags`
* branch -> `git fetch +refs/heads/{checkout_target}:refs/remotes/origin/{checkout_target}`

which will then allow the script to checkout the ref.

Reproducer:
```
git clone https://github.com/swiftlang/swift.git --depth=1 --single-branch --branch main
cd swift
python3 ./utils/update-checkout --scheme release/6.3 --skip-repository llvm-project --skip-repository sourcekit-lsp --skip-repository ninja --skip-repository swift-integration-tests --skip-repository swift-stress-tester --skip-repository swift-xcode-playground-support --reset-to-remote --clean --clone --skip-history
```