### PR TITLE
[Sema] Diagnose likely-unsound script var forward references

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2762,6 +2762,11 @@ public:
     return getPatternList()[i].getOriginalInitRange();
   }
 
+  /// Retrieve the SourceRange for the pattern binding entry at a given index.
+  SourceRange getEntrySourceRange(unsigned i) const {
+    return getPatternList()[i].getSourceRange();
+  }
+
   void setInit(unsigned i, Expr *E) {
     getMutablePatternList()[i].setInit(E);
   }

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1233,6 +1233,8 @@ NOTE(object_literal_resolve_import,none,
 
 ERROR(use_local_before_declaration,none,
       "use of local variable %0 before its declaration", (DeclNameRef))
+ERROR(use_global_before_declaration,none,
+      "use of global variable %0 before its declaration", (DeclNameRef))
 
 ERROR(decl_does_not_exist_in_module,none,
       "%select{%error|type|struct|class|enum|protocol|variable|function}0 "

--- a/lib/Sema/PreCheckTarget.cpp
+++ b/lib/Sema/PreCheckTarget.cpp
@@ -308,8 +308,13 @@ static bool findNonMembers(ArrayRef<LookupResultEntry> lookupResults,
     }
 
     ValueDecl *D = Result.getValueDecl();
-    if (!isValid(D))
+    if (!isValid(D)) {
+      // If this is a non-local variable, continue looking for a viable
+      // candidate.
+      if (!D->getDeclContext()->isLocalContext())
+        continue;
       return false;
+    }
 
     if (matchesDeclRefKind(D, refKind))
       ResultValues.push_back(D);
@@ -392,16 +397,55 @@ static bool isMemberChainTail(Expr *expr, Expr *parent, MemberChainKind kind) {
   return !parent || getMemberChainSubExpr(parent, kind) != expr;
 }
 
+/// If `VD` is a script mode global var, checks whether a reference to it should
+/// be considered a use-before-declaration.
+static bool isGlobalScriptVarForwardRef(VarDecl *VD, DeclContext *useDC,
+                                        SourceLoc useLoc) {
+  if (!useLoc || !VD->isTopLevelGlobal() || !VD->hasStorage())
+    return false;
+
+  SourceLoc varLoc = VD->getLoc(/*serialized*/ false);
+  if (!varLoc)
+    return false;
+
+  // The reference must be in the same SourceFile.
+  if (useDC->getOutermostParentSourceFile() !=
+      VD->getDeclContext()->getOutermostParentSourceFile()) {
+    return false;
+  }
+
+  // A valid reference must appear after the variable's location. If we have
+  // a PatternBindingDecl, then move the location to the end of the entry to
+  // catch e.g `let x: Int = x`.
+  if (auto *PBD = VD->getParentPatternBinding()) {
+    auto idx = PBD->getPatternEntryIndexForVarDecl(VD);
+    if (auto range = PBD->getEntrySourceRange(idx))
+      varLoc = range.End;
+  }
+  auto &SM = VD->getASTContext().SourceMgr;
+  return SM.isAtOrBefore(useLoc, varLoc);
+}
+
 static bool isValidForwardReference(ValueDecl *D, DeclContext *DC,
-                                    ValueDecl *&localDeclAfterUse) {
-  // Only VarDecls require declaration before use.
+                                    SourceLoc useLoc,
+                                    bool scriptVarForwardRefIsError,
+                                    VarDecl *&localDeclAfterUse) {
+  // Only non-debugger VarDecls require declaration before use.
   auto *VD = dyn_cast<VarDecl>(D);
-  if (!VD)
+  if (!VD || VD->isDebuggerVar())
     return true;
 
-  // Non-local and variables injected by lldb are always valid.
+  // Check to see if we have a forward reference to a global script-mode var.
+  if (isGlobalScriptVarForwardRef(VD, DC, useLoc)) {
+    // Prefer the VarDecl that is an actual error.
+    if (!localDeclAfterUse || scriptVarForwardRefIsError)
+      localDeclAfterUse = VD;
+    return !scriptVarForwardRefIsError;
+  }
+
+  // Non-local are otherwise always valid.
   auto *varDC = VD->getDeclContext();
-  if (!varDC->isLocalContext() || VD->isDebuggerVar())
+  if (!varDC->isLocalContext())
     return true;
 
   while (true) {
@@ -585,12 +629,39 @@ static Expr *resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *DC,
 
     Lookup = TypeChecker::lookupUnqualified(DC, LookupName, Loc, lookupOptions);
 
-    ValueDecl *localDeclAfterUse = nullptr;
+    // If a script-mode forward reference is not in a TopLevelCodeDecl (e.g in a
+    // closure or function), downgrade to a warning since it has a non-trivial
+    // source compatibility impact. We ought to make these errors eventually
+    // though.
+    auto scriptVarForwardRefIsError =
+        isa<TopLevelCodeDecl>(DC) ||
+        Context.isLanguageModeAtLeast(LanguageMode::future);
+
+    VarDecl *localDeclAfterUse = nullptr;
     AllDeclRefs = findNonMembers(
         Lookup.innerResults(), UDRE->getRefKind(),
         /*breakOnMember=*/true, ResultValues, [&](ValueDecl *D) {
-          return isValidForwardReference(D, DC, localDeclAfterUse);
+          return isValidForwardReference(D, DC, Loc, scriptVarForwardRefIsError,
+                                         localDeclAfterUse);
         });
+
+    // Diagnose a use-before-decl script-mode var if we either have no other
+    // results or are warning (since we don't know whether the var will be
+    // chosen it's better to over-diagnose in that case).
+    if (localDeclAfterUse && localDeclAfterUse->isTopLevelGlobal() &&
+        (ResultValues.empty() || !scriptVarForwardRefIsError)) {
+      Context.Diags.diagnose(Loc, diag::use_global_before_declaration, Name)
+          .warnUntilLanguageModeIf(!scriptVarForwardRefIsError,
+                                   LanguageMode::future);
+      Context.Diags.diagnose(localDeclAfterUse, diag::decl_declared_here,
+                             localDeclAfterUse);
+      if (scriptVarForwardRefIsError)
+        return errorResult();
+
+      // If we warned on the use, carry on and pretend we didn't see a
+      // use-before-decl.
+      localDeclAfterUse = nullptr;
+    }
 
     // If local declaration after use is found, check outer results for
     // better matching candidates.
@@ -610,7 +681,8 @@ static Expr *resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *DC,
         AllDeclRefs = findNonMembers(
             Lookup.innerResults(), UDRE->getRefKind(),
             /*breakOnMember=*/true, ResultValues, [&](ValueDecl *D) {
-              return isValidForwardReference(D, DC, localDeclAfterUse);
+              return isValidForwardReference(
+                  D, DC, Loc, scriptVarForwardRefIsError, localDeclAfterUse);
             });
       }
     }

--- a/test/Constraints/ranking.swift
+++ b/test/Constraints/ranking.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types %s -verify -swift-version 5 | %FileCheck %s
+// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types %s -verify -swift-version 5 -g | %FileCheck %s
 
 protocol P {
   var p: P { get set }
@@ -29,6 +29,20 @@ func genericOverload<T>(_: T) {}
 func genericOverload<T>(_: T?) {}
 func genericOptional<T>(_: T?) {}
 func genericNoOptional<T>(_: T) {}
+
+// CHECK-LABEL: sil [ossa] @main
+
+// We prefer the function when the overloaded var is a use-after-decl.
+func overloadedWithScriptVar1(_ x: Int) {}
+overloadedWithScriptVar1(0)
+// CHECK: function_ref @$s7ranking24overloadedWithScriptVar1yySiF
+let overloadedWithScriptVar1 = { (x: Int) in }
+
+func overloadedWithScriptVar2(_ x: Int) {}
+let overloadedWithScriptVar2 = { (x: Int) in }
+overloadedWithScriptVar2(0)
+// CHECK: [[CLOSURE_ADDR:%[0-9]+]] = global_addr @$s7ranking24overloadedWithScriptVar2yySicvp
+// CHECK: load [copy] [[CLOSURE_ADDR]] {{.*}} loc {{.*}}:[[@LINE-2]]:1
 
 // CHECK-LABEL: sil hidden [ossa] @$s7ranking22propertyVersusFunctionyyAA1P_p_xtAaCRzlF
 func propertyVersusFunction<T : P>(_ p: P, _ t: T) {

--- a/test/Macros/macro_script_var_forward_ref.swift
+++ b/test/Macros/macro_script_var_forward_ref.swift
@@ -1,0 +1,56 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %t/MacroDefinition.swift -g -no-toolchain-stdlib-rpath
+
+// RUN: %target-swift-frontend -typecheck -verify -load-plugin-library %t/%target-library-name(MacroDefinition) %t/main.swift
+// RUN: not --crash %target-swift-frontend -typecheck -verify -load-plugin-library %t/%target-library-name(MacroDefinition) -DCRASH %t/main.swift
+
+//--- MacroDefinition.swift
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+public struct UseBeforeDeclRef: ExpressionMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> ExprSyntax {
+    "print(x)"
+  }
+}
+
+public struct UseBeforeDecl: DeclarationMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    [
+      """
+      print(y)
+      let y = 0
+      """
+    ]
+  }
+}
+
+//--- main.swift
+@freestanding(expression)
+public macro UseBeforeDeclRef() = #externalMacro(module: "MacroDefinition", type: "UseBeforeDeclRef")
+
+#UseBeforeDeclRef // expected-note {{in expansion of macro 'UseBeforeDeclRef' here}}
+// expected-expansion@-1:1{{
+//   expected-error@1 {{use of global variable 'x' before its declaration}}
+// }}
+let x = 0 // expected-note {{'x' declared here}}
+#UseBeforeDeclRef
+
+@freestanding(declaration)
+public macro UseBeforeDecl() = #externalMacro(module: "MacroDefinition", type: "UseBeforeDecl")
+
+// FIXME: This currently crashes the compiler, once fixed insert the right
+// diagnostic expectation.
+#if CRASH
+#UseBeforeDecl()
+#endif

--- a/test/NameLookup/name_lookup2.swift
+++ b/test/NameLookup/name_lookup2.swift
@@ -209,11 +209,12 @@ class ForwardReference {
 }
 
 func questionablyValidForwardReference() { print(qvfrVar, terminator: ""); }; var qvfrVar: Int = 0
+// expected-warning@-1 {{use of global variable 'qvfrVar' before its declaration; this will be an error in a future Swift language mode}}
+// expected-note@-2 {{'qvfrVar' declared here}}
 
-// FIXME: This should warn too.
 print(forwardReferenceVar, terminator: ""); var forwardReferenceVar: Int = 0
-
-
+// expected-error@-1:7 {{use of global variable 'forwardReferenceVar' before its declaration}}
+// expected-note@-2:49 {{'forwardReferenceVar' declared here}}
 
 // <rdar://problem/23248290> Name lookup: "Cannot convert type 'Int' to expected argument type 'Int'" while trying to initialize ivar of generic type in class scope
 // https://gist.github.com/erynofwales/61768899502b7ac83c6e

--- a/test/NameLookup/script_var_forward_ref_import_shadowing.swift
+++ b/test/NameLookup/script_var_forward_ref_import_shadowing.swift
@@ -1,0 +1,15 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-emit-module-interface(%t/A.swiftinterface) -module-name A %t/a.swift
+// RUN: %target-swift-frontend -typecheck -verify %t/main.swift -I %t
+
+//--- a.swift
+public let foo = 0
+
+//--- main.swift
+import A
+
+// Make sure we still diagnose this even if there's an imported result available.
+_ = foo // expected-error {{use of global variable 'foo' before its declaration}}
+let foo = 0 // expected-note {{'foo' declared here}}

--- a/test/Parse/using.swift
+++ b/test/Parse/using.swift
@@ -14,13 +14,13 @@ using @Test // expected-error {{default isolation can only be set to '@MainActor
 using test // expected-error {{default isolation can only be set to '@MainActor' or 'nonisolated'}}
 
 do {
-  using // expected-warning {{expression of type 'Int' is unused}}
+  using // expected-error {{use of global variable 'using' before its declaration}}
   @MainActor
 // expected-error@+1 {{expected declaration}}
 }
 
 do {
-  using // expected-warning {{expression of type 'Int' is unused}}
+  using // expected-error {{use of global variable 'using' before its declaration}}
   nonisolated // expected-error {{cannot find 'nonisolated' in scope}}
 }
 
@@ -40,7 +40,7 @@ do {
 }
 
 let
-  using = 42
+  using = 42 // expected-note 2{{'using' declared here}}
 
 let (x: Int, using: String) = (x: 42, using: "")
 

--- a/test/Sema/struct_property_let_destructuring.swift
+++ b/test/Sema/struct_property_let_destructuring.swift
@@ -4,6 +4,8 @@
 // Destructuring initializations for `let` properties in structs isn't
 // implemented correctly in SILGen, so diagnose it as unsupported for now.
 
+let foo = Foo(/*value: 1*/)
+
 struct Foo {
     var value: Int = 42
 
@@ -23,13 +25,5 @@ struct Foo {
 
 }
 
-
-let foo = Foo(/*value: 1*/)
-
-
 foo.tellMe()
-
-
-
-
 print("Hello")

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -1342,12 +1342,14 @@ struct SelfRecursiveLookup<T> { // expected-note {{'T' declared as parameter to 
   init(_: () -> KeyPath<Self, T>) {}
   subscript<U>(dynamicMember kp: KeyPath<T, U>) -> SelfRecursiveLookup<U> {}
 }
-let selfRecurse1 = SelfRecursiveLookup { selfRecurse1.e }
+let selfRecurse1 = SelfRecursiveLookup { selfRecurse1.e } // expected-note {{'selfRecurse1' declared here}}
 // expected-error@-1 {{could not find member 'e'; exceeded the maximum number of nested dynamic member lookups}}
+// expected-warning@-2 {{use of global variable 'selfRecurse1' before its declaration; this will be an error in a future Swift language mode}}
 
-let selfRecurse2 = SelfRecursiveLookup { selfRecurse2[a: 0] }
+ let selfRecurse2 = SelfRecursiveLookup { selfRecurse2[a: 0] } // expected-note {{'selfRecurse2' declared here}}
 // expected-error@-1 {{generic parameter 'T' could not be inferred}}
 // expected-note@-2 {{explicitly specify the generic arguments to fix this issue}}
+// expected-warning@-3 {{use of global variable 'selfRecurse2' before its declaration; this will be an error in a future Swift language mode}}
 
 let selfRecurse3 = SelfRecursiveLookup { \.e }
 // expected-error@-1 {{could not find member 'e'; exceeded the maximum number of nested dynamic member lookups}}
@@ -1360,8 +1362,11 @@ extension SelfRecursiveLookup where T == SelfRecursiveLookup<SelfRecursiveLookup
   subscript(terminator terminator: Int) -> T { fatalError() }
 }
 
-let selfRecurse5 = SelfRecursiveLookup { selfRecurse5.terminator }
-let selfRecurse6 = SelfRecursiveLookup { selfRecurse6[terminator: 0] }
+let selfRecurse5 = SelfRecursiveLookup { selfRecurse5.terminator } // expected-note {{'selfRecurse5' declared here}}
+// expected-warning@-1 {{use of global variable 'selfRecurse5' before its declaration; this will be an error in a future Swift language mode}}
+
+let selfRecurse6 = SelfRecursiveLookup { selfRecurse6[terminator: 0] } // expected-note {{'selfRecurse6' declared here}}
+// expected-warning@-1 {{use of global variable 'selfRecurse6' before its declaration; this will be an error in a future Swift language mode}}
 
 let selfRecurse7 = SelfRecursiveLookup { \.terminator }
 let selfRecurse8 = SelfRecursiveLookup { \.[terminator: 0] }

--- a/test/attr/attr_extern.swift
+++ b/test/attr/attr_extern.swift
@@ -91,6 +91,11 @@ func funcScopeC() {
 @_extern(c, "c_value")
 var nonFunc: Int = 0 // expected-error{{'@_extern' variable cannot have an initializer}}
 
+// Forward references of extern vars is fine
+_ = forwardRef
+@_extern(c, "c_value2")
+var forwardRef: Int
+
 @_extern(c, "with_body")
 func withInvalidBody() {} // expected-error {{unexpected body of function declaration}}
 

--- a/test/decl/overload.swift
+++ b/test/decl/overload.swift
@@ -5,10 +5,8 @@ var_redecl1 = 0
 var var_redecl1: UInt // expected-error {{invalid redeclaration of 'var_redecl1'}}
 
 var var_redecl2: Int // expected-note {{previously declared here}}
-// expected-note@-1 {{found this candidate}}
-var_redecl2 = 0 // expected-error {{ambiguous use of 'var_redecl2'}}
+var_redecl2 = 0
 var var_redecl2: Int // expected-error {{invalid redeclaration of 'var_redecl2'}}
-// expected-note@-1 {{found this candidate}}
 
 var var_redecl3: (Int) -> () { get {} } // expected-note {{previously declared here}}
 var var_redecl3: () -> () { get {} } // expected-error {{invalid redeclaration of 'var_redecl3'}}

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -1235,6 +1235,27 @@ class r24314506 {  // expected-error {{class 'r24314506' has no initializers}}
   var myDict: [String: AnyObject]  // expected-note {{stored property 'myDict' without initial value prevents synthesized initializers}} {{34-34= = [:]}}
 }
 
+struct Circular {
+  var self1 = self1
+  // expected-note@-1 {{through reference here}}
+  // expected-error@-2 {{circular reference}}
+
+  var self2 : Int = self2 // expected-error {{cannot use instance member 'self2' within property initializer; property initializers run before 'self' is available}}
+  var (self3) : Int = self3 // expected-error {{cannot use instance member 'self3' within property initializer; property initializers run before 'self' is available}}
+  var (self4) : Int = self4 // expected-error {{cannot use instance member 'self4' within property initializer; property initializers run before 'self' is available}}
+
+  var self5 = self5 + self5
+  // expected-note@-1 {{through reference here}}
+  // expected-error@-2 {{circular reference}}
+
+  var self6 = !self6
+  // expected-note@-1 {{through reference here}}
+  // expected-error@-2 {{circular reference}}
+
+  var (self7a, self7b) = (self7b, self7a)
+  // expected-note@-1 {{through reference here}}
+  // expected-error@-2 {{circular reference}}
+}
 
 // https://github.com/apple/swift/issues/46478
 // Generic type is not inferenced from its initial value for properties with

--- a/test/decl/var/script_mode_forward_ref.swift
+++ b/test/decl/var/script_mode_forward_ref.swift
@@ -1,0 +1,154 @@
+// RUN: %target-typecheck-verify-swift -verify-additional-prefix swift6-
+// RUN: %target-typecheck-verify-swift -language-mode 7 -verify-additional-prefix swift7-
+
+// REQUIRES: swift7
+
+_ = forwardRef1 // expected-error {{use of global variable 'forwardRef1' before its declaration}}
+_ = forwardRef2 // expected-error {{use of global variable 'forwardRef2' before its declaration}}
+_ = forwardRef3 // expected-error {{use of global variable 'forwardRef3' before its declaration}}
+_ = forwardRef4 // expected-error {{use of global variable 'forwardRef4' before its declaration}}
+_ = forwardRef5 // expected-error {{use of global variable 'forwardRef5' before its declaration}}
+
+// MARK: Closures
+
+let _ = {
+  _ = forwardRef1
+  // expected-swift6-warning@-1 {{use of global variable 'forwardRef1' before its declaration; this will be an error in a future Swift language mode}}
+  // expected-swift7-error@-2 {{use of global variable 'forwardRef1' before its declaration}}
+  _ = forwardRef2
+  // expected-swift6-warning@-1 {{use of global variable 'forwardRef2' before its declaration; this will be an error in a future Swift language mode}}
+  // expected-swift7-error@-2 {{use of global variable 'forwardRef2' before its declaration}}
+  _ = forwardRef3
+  // expected-swift6-warning@-1 {{use of global variable 'forwardRef3' before its declaration; this will be an error in a future Swift language mode}}
+  // expected-swift7-error@-2 {{use of global variable 'forwardRef3' before its declaration}}
+}
+_ = {
+  _ = forwardRef4
+  // expected-swift6-warning@-1 {{use of global variable 'forwardRef4' before its declaration; this will be an error in a future Swift language mode}}
+  // expected-swift7-error@-2 {{use of global variable 'forwardRef4' before its declaration}}
+  _ = forwardRef5
+  // expected-swift6-warning@-1 {{use of global variable 'forwardRef5' before its declaration; this will be an error in a future Swift language mode}}
+  // expected-swift7-error@-2 {{use of global variable 'forwardRef5' before its declaration}}
+}
+
+// MARK: Functions
+
+func forwardFn() {
+  _ = forwardRef1
+  // expected-swift6-warning@-1 {{use of global variable 'forwardRef1' before its declaration; this will be an error in a future Swift language mode}}
+  // expected-swift7-error@-2 {{use of global variable 'forwardRef1' before its declaration}}
+  _ = forwardRef2
+  // expected-swift6-warning@-1 {{use of global variable 'forwardRef2' before its declaration; this will be an error in a future Swift language mode}}
+  // expected-swift7-error@-2 {{use of global variable 'forwardRef2' before its declaration}}
+  _ = forwardRef3
+  // expected-swift6-warning@-1 {{use of global variable 'forwardRef3' before its declaration; this will be an error in a future Swift language mode}}
+  // expected-swift7-error@-2 {{use of global variable 'forwardRef3' before its declaration}}
+  _ = forwardRef4
+  // expected-swift6-warning@-1 {{use of global variable 'forwardRef4' before its declaration; this will be an error in a future Swift language mode}}
+  // expected-swift7-error@-2 {{use of global variable 'forwardRef4' before its declaration}}
+  _ = forwardRef5
+  // expected-swift6-warning@-1 {{use of global variable 'forwardRef5' before its declaration; this will be an error in a future Swift language mode}}
+  // expected-swift7-error@-2 {{use of global variable 'forwardRef5' before its declaration}}
+}
+
+struct InAType {
+  func forwardMethod() {
+    _ = forwardRef1
+    // expected-swift6-warning@-1 {{use of global variable 'forwardRef1' before its declaration; this will be an error in a future Swift language mode}}
+    // expected-swift7-error@-2 {{use of global variable 'forwardRef1' before its declaration}}
+    _ = forwardRef2
+    // expected-swift6-warning@-1 {{use of global variable 'forwardRef2' before its declaration; this will be an error in a future Swift language mode}}
+    // expected-swift7-error@-2 {{use of global variable 'forwardRef2' before its declaration}}
+    _ = forwardRef3
+    // expected-swift6-warning@-1 {{use of global variable 'forwardRef3' before its declaration; this will be an error in a future Swift language mode}}
+    // expected-swift7-error@-2 {{use of global variable 'forwardRef3' before its declaration}}
+    _ = forwardRef4
+    // expected-swift6-warning@-1 {{use of global variable 'forwardRef4' before its declaration; this will be an error in a future Swift language mode}}
+    // expected-swift7-error@-2 {{use of global variable 'forwardRef4' before its declaration}}
+    _ = forwardRef5
+    // expected-swift6-warning@-1 {{use of global variable 'forwardRef5' before its declaration; this will be an error in a future Swift language mode}}
+    // expected-swift7-error@-2 {{use of global variable 'forwardRef5' before its declaration}}
+  }
+}
+
+// MARK: Weird intialization
+
+_ = delayedInitForwardRef1 // expected-error {{use of global variable 'delayedInitForwardRef1' before its declaration}}
+let delayedInitForwardRef1: Int // expected-note {{'delayedInitForwardRef1' declared here}}
+_ = delayedInitForwardRef1
+delayedInitForwardRef1 = 1
+
+_ = delayedInitForwardRef2 // expected-error {{use of global variable 'delayedInitForwardRef2' before its declaration}}
+var delayedInitForwardRef2: Int // expected-note {{'delayedInitForwardRef2' declared here}}
+_ = delayedInitForwardRef2
+delayedInitForwardRef2 = 1
+
+initBeforeDecl1 = 1 // expected-error {{use of global variable 'initBeforeDecl1' before its declaration}}
+print(initBeforeDecl1) // expected-error {{use of global variable 'initBeforeDecl1' before its declaration}}
+let initBeforeDecl1: Int // expected-note 2{{'initBeforeDecl1' declared here}}
+print(initBeforeDecl1)
+
+multiInitLet = 1 // expected-error {{use of global variable 'multiInitLet' before its declaration}}
+multiInitLet = 2 // expected-error {{use of global variable 'multiInitLet' before its declaration}}
+let multiInitLet: Int // expected-note 2{{'multiInitLet' declared here}}
+multiInitLet = 3
+
+// MARK: Self references
+
+var self1 = self1 // expected-note {{'self1' declared here}}
+// expected-error@-1 {{use of global variable 'self1' before its declaration}}
+
+var self2 : Int = self2 // expected-note {{'self2' declared here}}
+// expected-error@-1 {{use of global variable 'self2' before its declaration}}
+var (self3) : Int = self3 // expected-note {{'self3' declared here}}
+// expected-error@-1 {{use of global variable 'self3' before its declaration}}
+var (self4) : Int = self4 // expected-note {{'self4' declared here}}
+// expected-error@-1 {{use of global variable 'self4' before its declaration}}
+
+var self5 = self5 + self5 // expected-note 2{{'self5' declared here}}
+// expected-error@-1 2{{use of global variable 'self5' before its declaration}}
+
+var self6 = !self6 // expected-note {{'self6' declared here}}
+// expected-error@-1 {{use of global variable 'self6' before its declaration}}
+
+var (self7a, self7b) = (self7b, self7a) // expected-note {{'self7a' declared here}} expected-note {{'self7b' declared here}}
+// expected-error@-1 {{use of global variable 'self7a' before its declaration}}
+// expected-error@-2 {{use of global variable 'self7b' before its declaration}}
+
+// For now we allow these with a warning.
+var selfClosure1 : Int = { selfClosure1 }() // expected-note {{'selfClosure1' declared here}}
+// expected-swift6-warning@-1 {{use of global variable 'selfClosure1' before its declaration; this will be an error in a future Swift language mode}}
+// expected-swift7-error@-2 {{use of global variable 'selfClosure1' before its declaration}}
+var (selfClosure2) : Int = { selfClosure2 }() // expected-note {{'selfClosure2' declared here}}
+// expected-swift6-warning@-1 {{use of global variable 'selfClosure2' before its declaration; this will be an error in a future Swift language mode}}
+// expected-swift7-error@-2 {{use of global variable 'selfClosure2' before its declaration}}
+
+// MARK: Computed vars
+
+// Forward references of computed vars in script mode is fine.
+_ = forwardRefComputedVar1
+var forwardRefComputedVar1: Int { 0 }
+
+_ = forwardRefComputedVar2
+var forwardRefComputedVar2: Int { get { 0 } set {} }
+
+var forwardRefComputedVar3: Int { forwardRefComputedVar3 }
+// expected-warning@-1 {{attempting to access 'forwardRefComputedVar3' within its own getter}}
+
+// MARK: Misc
+
+// Fine.
+let refWithinSinglePBD1 = 0, refWithinSinglePBD2 = refWithinSinglePBD1
+
+// Not fine.
+let multiPBDForwardRef1 = multiPBDForwardRef2 ; let multiPBDForwardRef2 = multiPBDForwardRef1
+// expected-error@-1:27 {{use of global variable 'multiPBDForwardRef2' before its declaration}}
+// expected-note@-2:53 {{'multiPBDForwardRef2' declared here}}
+
+// MARK: The declarations
+
+let forwardRef1 = 0 // expected-note 4{{'forwardRef1' declared here}}
+var forwardRef2 = 0 // expected-note 4{{'forwardRef2' declared here}}
+var forwardRef3 = 0 { didSet {} } // expected-note 4{{'forwardRef3' declared here}}
+let forwardRef4: Int // expected-note 4{{'forwardRef4' declared here}}
+var forwardRef5: Int // expected-note 4{{'forwardRef5' declared here}}

--- a/test/decl/var/script_mode_multi_file_ref.swift
+++ b/test/decl/var/script_mode_multi_file_ref.swift
@@ -1,0 +1,25 @@
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -emit-ir %t/main.swift %t/other.swift > /dev/null
+
+// FIXME: This is unsound, we either ought to consistently treat the variables
+// as local or global.
+
+//--- main.swift
+
+fn()
+
+let x1 = 0
+var x2 = 0
+var x3 = 0 { didSet {} }
+let x4: Int
+var x5: Int
+
+//--- other.swift
+
+func fn() {
+  _ = x1
+  _ = x2
+  _ = x3
+  _ = x4
+  _ = x5
+}

--- a/test/decl/var/variables.swift
+++ b/test/decl/var/variables.swift
@@ -14,30 +14,10 @@ var bfx : Int, bfy : Int
 
 _ = 10
 
-var self1 = self1
-// expected-note@-1 {{through reference here}}
-// expected-error@-2 {{circular reference}}
-
-var self2 : Int = self2
-var (self3) : Int = self3
-var (self4) : Int = self4
-
-var self5 = self5 + self5
-// expected-note@-1 {{through reference here}}
-// expected-error@-2 {{circular reference}}
-
-var self6 = !self6
-// expected-note@-1 {{through reference here}}
-// expected-error@-2 {{circular reference}}
-
-var (self7a, self7b) = (self7b, self7a)
-// expected-note@-1 {{through reference here}}
-// expected-error@-2 {{circular reference}}
-
-var self8 = 0
+var shadowedByLocal = 0
 func testShadowing() {
-  var self8 = self8
-  // expected-warning@-1 {{initialization of variable 'self8' was never used; consider replacing with assignment to '_' or removing it}}
+  var shadowedByLocal = shadowedByLocal
+  // expected-warning@-1 {{initialization of variable 'shadowedByLocal' was never used; consider replacing with assignment to '_' or removing it}}
 }
 
 var (paren) = 0
@@ -92,12 +72,6 @@ weak let V = SomeClass() // ok since SE-0481
 // expected-warning@-1 {{instance will be immediately deallocated because variable 'V' is 'weak'}}
 // expected-note@-2 {{'V' declared here}}
 // expected-note@-3 {{a strong reference is required to prevent the instance from being deallocated}}
-
-let a = b ; let b = a
-// expected-error@-1:1 {{circular reference}}
-// expected-note@-2:5 {{through reference here}}
-// expected-note@-3:13 {{through reference here}}
-// expected-note@-4:17 {{through reference here}}
 
 // <rdar://problem/17501765> Swift should warn about immutable default initialized values
 let uselessValue : String?

--- a/test/diagnostics/Localization/en_debug_diagnostic_name.swift
+++ b/test/diagnostics/Localization/en_debug_diagnostic_name.swift
@@ -3,7 +3,7 @@
 _ = "HI!
 // CHECK_NAMES: error: unterminated string literal [lex_unterminated_string]{{$}}
 
-var self1 = self1
+struct Circular { let x = x }
 // CHECK_NAMES: error: circular reference [circular_reference]{{$}}
 // CHECK_NAMES: note: through reference here [circular_reference_through]{{$}}
 

--- a/test/diagnostics/Localization/en_localization.swift
+++ b/test/diagnostics/Localization/en_localization.swift
@@ -2,7 +2,8 @@
 
 _ = "HI!
 // expected-error@-1{{unterminated string literal}}
-var self1 = self1
+
+struct Circular { let x = x }
 // expected-note@-1 {{through reference here}}
 // expected-error@-2 {{circular reference}}
 

--- a/test/diagnostics/Localization/fr_debug_diagnostic_name.swift
+++ b/test/diagnostics/Localization/fr_debug_diagnostic_name.swift
@@ -8,7 +8,7 @@ _ = "HI!
 
 // FIXME: This used to produce a localized diagnostic.
 
-var self1 = self1
+struct Circular { let x = x }
 // CHECK_NAMES: error: circular reference [circular_reference]{{$}}
 // CHECK_NAMES: note: through reference here [circular_reference_through]{{$}}
 

--- a/test/diagnostics/Localization/fr_localization.swift
+++ b/test/diagnostics/Localization/fr_localization.swift
@@ -8,8 +8,9 @@ _ = "HI!
 
 // FIXME: This used to produce a localized diagnostic.
 
-var self1 = self1 // expected-note {{through reference here}}
-// expected-error@-1 {{circular reference}}
+struct Circular { let x = x }
+// expected-note@-1 {{through reference here}}
+// expected-error@-2 {{circular reference}}
 
 struct Broken {
   var b : Bool = True // expected-error{{impossible de trouver 'True' portée}}

--- a/test/diagnostics/Localization/no_localization_files_and_wrong_path.swift
+++ b/test/diagnostics/Localization/no_localization_files_and_wrong_path.swift
@@ -5,7 +5,8 @@
 
 _ = "HI!
 // expected-error@-1{{unterminated string literal}}
-var self1 = self1
+
+struct Circular { let x = x }
 // expected-note@-1 {{through reference here}}
 // expected-error@-2 {{circular reference}}
 

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -119,13 +119,15 @@ func f0(_ a: Any) -> Int { return 1 }
 assert(f0(1) == 1)
 
 // TODO(diagnostics): Bad diagnostic - should be `circular reference`
-var selfRef = { selfRef() }
+var selfRef = { selfRef() } // expected-note {{'selfRef' declared here}}
 // expected-error@-1 {{unable to infer closure type without a type annotation}}
+// expected-warning@-2 {{use of global variable 'selfRef' before its declaration; this will be an error in a future Swift language mode}}
 
 // TODO: should be an error `circular reference` but it's diagnosed via overlapped requests
-var nestedSelfRef = {
+var nestedSelfRef = { // expected-note {{'nestedSelfRef' declared here}}
   var recursive = { nestedSelfRef() }
   // expected-warning@-1 {{variable 'recursive' was never mutated; consider changing to 'let' constant}}
+  // expected-warning@-2 {{use of global variable 'nestedSelfRef' before its declaration; this will be an error in a future Swift language mode}}
   recursive()
 }
 

--- a/test/expr/unary/if_expr_global_self_ref.swift
+++ b/test/expr/unary/if_expr_global_self_ref.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift
 
 let x = if .random() { x } else { 0 }
-// expected-error@-1 {{cannot reference invalid declaration 'x'}}
+// expected-error@-1 {{use of global variable 'x' before its declaration}}
 // expected-note@-2 {{'x' declared here}}

--- a/test/expr/unary/switch_expr_global_self_ref.swift
+++ b/test/expr/unary/switch_expr_global_self_ref.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift
 
 let x = switch Bool.random() { case true: x case false: 0 }
-// expected-error@-1 {{cannot reference invalid declaration 'x'}}
+// expected-error@-1 {{use of global variable 'x' before its declaration}}
 // expected-note@-2 {{'x' declared here}}

--- a/validation-test/IDE/crashers_fixed/TypePrinter-printWithParensIfNotSimple-44e8aa.swift
+++ b/validation-test/IDE/crashers_fixed/TypePrinter-printWithParensIfNotSimple-44e8aa.swift
@@ -1,5 +1,5 @@
 // {"kind":"complete","original":"8af9696a","signature":"(anonymous namespace)::TypePrinter::printWithParensIfNotSimple(swift::Type)","signatureAssert":"Assertion failed: (isa<To>(Val) && \"cast<Ty>() argument of incompatible type!\"), function cast","signatureNext":"TypePrinter::visitOptionalType"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
 // REQUIRES: OS=macosx
 import Foundation
 var a: some NSMutableArray = a == #^^# = <#expression#>

--- a/validation-test/Sema/type_checker_perf/fast/issue-48706.swift
+++ b/validation-test/Sema/type_checker_perf/fast/issue-48706.swift
@@ -30,6 +30,19 @@ class AnyRelationship<Base> {
     }
 }
 
+var issue = IssueModel(uid: "1", title: "ABC", assignees: [], followers: [])
+let assignees = [
+    IssueAssignee(issueUid: "1", assigneeUid: "Assigned to Issue 1"),
+    IssueAssignee(issueUid: "2", assigneeUid: "Assigned to Issue 2"),
+    IssueAssignee(issueUid: "1", assigneeUid: "Also assigned to issue 1!!!!")
+]
+
+let followers = [
+    IssueFollower(issueUid: "1", followerUid: "Following Issue 1"),
+    IssueFollower(issueUid: "2", followerUid: "Following Issue 2"),
+    IssueFollower(issueUid: "1", followerUid: "Also following issue 1!!!!")
+]
+
 final class OneToMany<One, Many, SharedKey: Equatable>: AnyRelationship<One> {
     let oneKeyPath: WritableKeyPath<One, [Many]>
     let manyKeyPath: KeyPath<Many, SharedKey>
@@ -54,19 +67,6 @@ final class OneToMany<One, Many, SharedKey: Equatable>: AnyRelationship<One> {
         }
     }
 }
-
-var issue = IssueModel(uid: "1", title: "ABC", assignees: [], followers: [])
-let assignees = [
-    IssueAssignee(issueUid: "1", assigneeUid: "Assigned to Issue 1"),
-    IssueAssignee(issueUid: "2", assigneeUid: "Assigned to Issue 2"),
-    IssueAssignee(issueUid: "1", assigneeUid: "Also assigned to issue 1!!!!")
-]
-
-let followers = [
-    IssueFollower(issueUid: "1", followerUid: "Following Issue 1"),
-    IssueFollower(issueUid: "2", followerUid: "Following Issue 2"),
-    IssueFollower(issueUid: "1", followerUid: "Also following issue 1!!!!")
-]
 
 for join in IssueModel.joins {
     join.query(withModel: &issue)

--- a/validation-test/compiler_crashers_fixed/CoercibleOptionalCheckedCastFailure-diagnoseForcedCastExpr-e030be.swift
+++ b/validation-test/compiler_crashers_fixed/CoercibleOptionalCheckedCastFailure-diagnoseForcedCastExpr-e030be.swift
@@ -1,3 +1,3 @@
 // {"kind":"typecheck","original":"8f4e40cf","signature":"swift::constraints::CoercibleOptionalCheckedCastFailure::diagnoseForcedCastExpr() const","signatureNext":"CoercibleOptionalCheckedCastFailure::diagnoseAsError"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 let a: Int??.Type = a as! Int.Type?

--- a/validation-test/compiler_crashers_fixed/ConstraintSystem-matchTypes-7c8101.swift
+++ b/validation-test/compiler_crashers_fixed/ConstraintSystem-matchTypes-7c8101.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","signature":"swift::constraints::ConstraintSystem::matchTypes(swift::Type, swift::Type, swift::constraints::ConstraintKind, swift::optionset::OptionSet<swift::constraints::ConstraintSystem::TypeMatchFlags, unsigned int>, swift::constraints::ConstraintLocatorBuilder)","signatureNext":"ConstraintSystem::addConstraintImpl"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 weak var a : b? a
 class c
   class b

--- a/validation-test/compiler_crashers_fixed/NamingPatternRequest-evaluate-029cff.swift
+++ b/validation-test/compiler_crashers_fixed/NamingPatternRequest-evaluate-029cff.swift
@@ -1,3 +1,3 @@
 // {"kind":"typecheck","signature":"swift::NamingPatternRequest::evaluate(swift::Evaluator&, swift::VarDecl*) const","signatureAssert":"Assertion failed: (Context.SourceMgr.hasIDEInspectionTargetBuffer() || Context.LangOpts.IsForSourceKit || Context.TypeCheckerOpts.EnableLazyTypecheck || inSecondaryScriptFile() && \"Querying VarDecl's type before type-checking parent stmt\"), function evaluate","signatureNext":"NamingPatternRequest::OutputType"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 a guard let b let a = b

--- a/validation-test/compiler_crashers_fixed/SILGenBuilder-createEnum-845e70.swift
+++ b/validation-test/compiler_crashers_fixed/SILGenBuilder-createEnum-845e70.swift
@@ -1,3 +1,3 @@
 // {"kind":"emit-silgen","original":"7b4a72a9","signature":"swift::Lowering::SILGenBuilder::createEnum(swift::SILLocation, swift::Lowering::ManagedValue, swift::EnumElementDecl*, swift::SILType)","signatureAssert":"Assertion failed: (v->getType().isObject()), function operator()","signatureNext":"Lowering::SILGenFunction::getOptionalSomeValue"}
-// RUN: not --crash %target-swift-frontend -emit-silgen %s
+// RUN: not %target-swift-frontend -emit-silgen %s
 var a: Any = ["": [a]] as [String: [AnyObject?]]

--- a/validation-test/compiler_crashers_fixed/matchCallArguments-7460ca.swift
+++ b/validation-test/compiler_crashers_fixed/matchCallArguments-7460ca.swift
@@ -1,3 +1,3 @@
 // {"kind":"typecheck","original":"c230493b","signature":"matchCallArguments(swift::constraints::ConstraintSystem&, swift::FunctionType*, swift::ArgumentList*, llvm::ArrayRef<swift::AnyFunctionType::Param>, llvm::ArrayRef<swift::AnyFunctionType::Param>, swift::constraints::ConstraintKind, swift::constraints::ConstraintLocatorBuilder, std::__1::optional<swift::constraints::TrailingClosureMatching>, llvm::SmallVectorImpl<std::__1::pair<swift::TypeVariableType*, swift::ExistentialArchetypeType*>>&)","signatureAssert":"Assertion failed: (param), function matchCallArguments","signatureNext":"ConstraintSystem::simplifyApplicableFnConstraint"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 let a: (String) -> Void = a($b: 0)


### PR DESCRIPTION
Emit an error for a forward reference to a global script-mode variable that is likely to be unsound. This handles cases where the variable is stored, and the reference is made at the top level before the declaration. Such uses would otherwise have likely read uninitialized memory. 

The only way such a reference could have been used in a sound way is by also initializing it before declaration, e.g:

```swift
x = 1
print(x)
let x: Int
```

But source compatibility testing has shown this to be incredibly rare, testing across both the source compat suite and internal Swift projects at Apple has only turned up a single case so far.

Uses within closures and functions are unfortunately more common so cannot be outright banned, but we will emit a warning on them.

Note that this checking doesn't help with cross-file cases, ultimately we still need to properly fix script-mode variables such that they are consistently treated as either local or global variables. Such a change will be quite source breaking though, this patch at least allows us to diagnose the majority of cases in the mean time.

### Why not diagnose in SIL?

SILGen already emits `mark_uninitialized` and `mark_function_escape` instructions for script-mode variables which allows use-before-init to be diagnosed by DefiniteInitialization, however this only works when the use actually follows the declaration. In principe we could adjust the SILGen here to emit these mark instructions at the start of `main`, which would let us more precisely diagnose _only_ the unsound cases. However the fact that we allow these forward references is also generally problematic in Sema, e.g:

```swift
print(a)
guard let b = 3 as Int? else {}
let a = b
```

This currently crashes the compiler since the forward reference to `a` kicks lazy type-checking, which type-checks the statement condition. This then results in us attempting to type-check the condition multiple times. Such code would already be invalid if in a local context such as a function. In principe we could defensively guard against these cases, but I would rather just eliminate them entirely.

Forum post: https://forums.swift.org/t/reject-likely-unsound-script-variable-forward-references/85996

Resolves #86438