### PR TITLE
Make StrictAccessControl an experimental feature

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -320,7 +320,6 @@ MIGRATABLE_UPCOMING_FEATURE(MemberImportVisibility, 444, LanguageMode::future)
 MIGRATABLE_UPCOMING_FEATURE(InferIsolatedConformances, 470, LanguageMode::future)
 MIGRATABLE_UPCOMING_FEATURE(NonisolatedNonsendingByDefault, 461, LanguageMode::future)
 UPCOMING_FEATURE(ImmutableWeakCaptures, 481, LanguageMode::future)
-UPCOMING_FEATURE(StrictAccessControl, 0, LanguageMode::future)
 
 //===----------------------------------------------------------------------===//
 // MARK: - Optional features
@@ -623,6 +622,9 @@ EXPERIMENTAL_FEATURE(BorrowInout, true)
 
 /// Allow access to the BorrowingSequence protocols/types outside the stdlib.
 EXPERIMENTAL_FEATURE(BorrowingSequence, true)
+
+/// Turns some source breaking access control warnings into errors.
+EXPERIMENTAL_FEATURE(StrictAccessControl, true)
 
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE

--- a/test/Sema/strict_access_control.swift
+++ b/test/Sema/strict_access_control.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/Other.swiftmodule %S/Inputs/strict_access_control_other.swift -module-name Other -swift-version 5
-// RUN: %target-typecheck-verify-swift -enable-upcoming-feature StrictAccessControl -swift-version 5 -enable-library-evolution -I %t -verify-ignore-unrelated
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature StrictAccessControl -swift-version 5 -enable-library-evolution -I %t -verify-ignore-unrelated
 
 // REQUIRES: swift_feature_StrictAccessControl
 

--- a/test/attr/attr_inlinable_strict.swift
+++ b/test/attr/attr_inlinable_strict.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-library-evolution -enable-upcoming-feature StrictAccessControl
+// RUN: %target-typecheck-verify-swift -enable-library-evolution -enable-experimental-feature StrictAccessControl
 
 // REQUIRES: swift_feature_StrictAccessControl
 

--- a/test/decl/protocol/conforms/access_corner_case_strict.swift
+++ b/test/decl/protocol/conforms/access_corner_case_strict.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -package-name myPkg -enable-upcoming-feature StrictAccessControl
+// RUN: %target-typecheck-verify-swift -package-name myPkg -enable-experimental-feature StrictAccessControl
 
 // REQUIRES: swift_feature_StrictAccessControl
 


### PR DESCRIPTION
It was originally introduced as an upcoming feature, but there isn't any precedent for using upcoming features as a way to opt-in to type checking fixes without an associated Swift Evolution proposal. Rather than using a "feature" to control this behavior, it would probably be better to offer a way to use `-Werror` to upgrade these warnings to errors.
