### PR TITLE
swiftScanTests: Rewrite OptTable dependency

### DIFF
--- a/unittests/DependencyScan/Features.cpp
+++ b/unittests/DependencyScan/Features.cpp
@@ -12,32 +12,17 @@
 
 #include "ScanFixture.h"
 #include "swift-c/DependencyScan/DependencyScan.h"
-#include "swift/Basic/LLVM.h"
-#include "swift/Option/Options.h"
-#include "llvm/ADT/StringRef.h"
-#include <vector>
+#include <string>
 #include <unordered_set>
 #include "gtest/gtest.h"
 
-using namespace swift;
 using namespace swift::unittest;
 
-static void
-testHasOption(llvm::opt::OptTable &table, options::ID id,
-              const std::unordered_set<std::string> &optionSet) {
-  if (table.getOption(id).hasFlag(swift::options::FrontendOption)) {
-    auto name = table.getOptionName(id);
-    if (!name.empty() && name[0] != '\0') {
-      auto nameStr = std::string(name);
-      bool setContainsOption = optionSet.find(nameStr) != optionSet.end();
-      EXPECT_EQ(setContainsOption, true) << "Missing Option: " << nameStr;
-    }
-  }
-}
-
 TEST_F(ScanTest, TestHasArgumentQuery) {
-  std::unique_ptr<llvm::opt::OptTable> table = swift::createSwiftOptTable();
   auto supported_args_set = swiftscan_compiler_supported_arguments_query();
+  ASSERT_TRUE(supported_args_set);
+  ASSERT_GT(supported_args_set->count, static_cast<size_t>(0));
+
   std::unordered_set<std::string> optionSet;
   for (size_t i = 0; i < supported_args_set->count; ++i) {
     swiftscan_string_ref_t option = supported_args_set->strings[i];
@@ -45,11 +30,18 @@ TEST_F(ScanTest, TestHasArgumentQuery) {
     optionSet.insert(std::string(data, option.length));
   }
   swiftscan_string_set_dispose(supported_args_set);
-#define OPTION(...)                                                            \
-  testHasOption(*table, swift::options::LLVM_MAKE_OPT_ID(__VA_ARGS__),         \
-                optionSet);
-#include "swift/Option/Options.inc"
-#undef OPTION
+
+  // Verify well-known frontend options are present
+  EXPECT_TRUE(optionSet.count("target")) << "Missing: target";
+  EXPECT_TRUE(optionSet.count("sdk")) << "Missing: sdk";
+  EXPECT_TRUE(optionSet.count("I")) << "Missing: I";
+  EXPECT_TRUE(optionSet.count("module-name")) << "Missing: module-name";
+  EXPECT_TRUE(optionSet.count("emit-module")) << "Missing: emit-module";
+  EXPECT_TRUE(optionSet.count("emit-object")) << "Missing: emit-object";
+  EXPECT_TRUE(optionSet.count("parse")) << "Missing: parse";
+  EXPECT_TRUE(optionSet.count("typecheck")) << "Missing: typecheck";
+  EXPECT_TRUE(optionSet.count("O")) << "Missing: O";
+  EXPECT_TRUE(optionSet.count("g")) << "Missing: g";
 }
 
 TEST_F(ScanTest, TestDoesNotHaveArgumentQuery) {


### PR DESCRIPTION
This rewrites ScanTest.TestHasArgumentQuery to remove the dependency on the internal OptTable API, checking for well-known compiler options rather than re-parsing the full list of options.

This also makes the test more resilient, as it verifies the well-known options remain stable in the public C API rather than testing internal implementation details.

This is necessary to remove the dependency on swiftOption from swiftScanTests, which is necessary to run the tests with LLVM built as a DLL on Windows. This effort is tracked in #85241.