### PR TITLE
[diagnostics] Increasing impact for extra trailing closures

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -13605,8 +13605,19 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyApplicableFnConstraint(
     // Let's make this fix as high impact so if there is a function or member
     // overload with e.g. argument-to-parameter type mismatches it would take
     // a higher priority.
-    return recordFix(fix, /*impact=*/3) ? SolutionKind::Error
-                                         : SolutionKind::Solved;
+
+    // If there are arguments that increases probability this should be a function,
+    // so let's skew the impact higher to compensate
+    auto numExtraArguments =
+       getArgumentList(
+          getConstraintLocator(outerLocator
+                               .withPathElement(ConstraintLocator::ApplyArgument)))->size();
+
+    auto baseImpact = 3;
+    return recordFix(fix,
+                     /*impact=*/ (5 * numExtraArguments) + baseImpact)
+        ? SolutionKind::Error
+        : SolutionKind::Solved;
   }
 
   return result;


### PR DESCRIPTION
Increased impact of trailing arguments on some failed function calls reduces the chances of the fix being selected, which suggest removing them. If the program contains trailing closures, likely this was intentional and if there are other solutions may be better fits.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
