### PR TITLE
PrintAsClang: Avoid crashing when anyAppleOS availability cannot be remapped

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -1839,9 +1839,16 @@ public:
 
       auto platKind = AvAttr.getPlatform();
       if (platKind == PlatformKind::anyAppleOS) {
-        if (auto domainAndRange =
-                AvAttr.getIntroducedDomainAndRange(D->getASTContext()))
-          platKind = domainAndRange->getDomain().getPlatformKind();
+        auto domainAndRange =
+            AvAttr.getIntroducedDomainAndRange(D->getASTContext());
+        if (!domainAndRange)
+          continue;
+
+        platKind = domainAndRange->getDomain().getPlatformKind();
+
+        // Skip the attribute if it cannot be remapped.
+        if (platKind == PlatformKind::anyAppleOS)
+          continue;
       }
       const char *plat;
       switch (platKind) {

--- a/test/Interop/SwiftToCxx/core/availability-any-apple-os.swift
+++ b/test/Interop/SwiftToCxx/core/availability-any-apple-os.swift
@@ -1,0 +1,14 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name Core -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/core.h
+// RUN: %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-os < %t/core.h
+
+// CHECK: SWIFT_INLINE_THUNK void anyAppleOS26Func() noexcept SWIFT_SYMBOL("s:4Core16anyAppleOS26FuncyyF")
+// CHECK-macosx-SAME: SWIFT_AVAILABILITY(macos,introduced=26)
+// CHECK-linux-gnu-NOT: SWIFT_AVAILABILITY
+@available(anyAppleOS 26, *)
+public func anyAppleOS26Func() { }
+
+// CHECK: SWIFT_INLINE_THUNK void macOS26Func() noexcept SWIFT_SYMBOL("s:4Core11macOS26FuncyyF")
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,introduced=26)
+@available(macOS 26, *)
+public func macOS26Func() { }

--- a/test/PrintAsObjC/availability_any_apple_os_objc.swift
+++ b/test/PrintAsObjC/availability_any_apple_os_objc.swift
@@ -10,7 +10,7 @@ import Foundation
 // CHECK-SAME: SWIFT_AVAILABILITY(macos,introduced=26)
 // CHECK: @end
 
-// CHECK-LABEL: SWIFT_CLASS("{{.*}}availability13PropertyClass{{.*}}")
+// CHECK-LABEL: SWIFT_CLASS("{{.*}}PropertyClass{{.*}}")
 // CHECK: @property{{.*}}propertyWithAvailability
 // CHECK-SAME: SWIFT_AVAILABILITY(macos,introduced=26)
 // CHECK: @end


### PR DESCRIPTION
Follow up to https://github.com/swiftlang/swift/pull/86941.
