### PR TITLE
utils: trim down libxml2 to what is needed for Foundation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1544,6 +1544,28 @@ if(SWIFT_INCLUDE_TOOLS)
   add_subdirectory(lib)
 endif()
 
+# NOTE(compnerd) we cannot use `LLVM_HAVE_LIBXML2` as the basis for this check
+# as we require RelaxNG support which is not guaranteed by the LLVM check.
+option(SWIFT_ENABLE_LIBXML2 "Use libxml2 to validate the comment schema via swift-ide-test" TRUE)
+set(SWIFT_HAVE_LIBXML2 FALSE)
+if(SWIFT_ENABLE_LIBXML2)
+  find_package(LibXml2)
+  if(LibXml2_FOUND)
+    # Check if libxml2 we found is usable; for example, we may have found a
+    # 32-bit library on a 64-bit system which would result in a link-time
+    # failure.
+    cmake_push_check_state()
+    list(APPEND CMAKE_REQUIRED_INCLUDES ${LIBXML2_INCLUDE_DIRS})
+    list(APPEND CMAKE_REQUIRED_LIBRARIES ${LIBXML2_LIBRARIES})
+    list(APPEND CMAKE_REQUIRED_DEFINITIONS ${LIBXML2_DEFINITIONS})
+    check_symbol_exists(xmlRelaxNGParse libxml/relaxng.h HAVE_LIBXML2_RELAXNG)
+    cmake_pop_check_state()
+    if(HAVE_LIBXML2_RELAXNG)
+      set(SWIFT_HAVE_LIBXML2 TRUE)
+    endif()
+  endif()
+endif()
+
 ###############
 # PLEASE READ #
 ###############

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -400,12 +400,6 @@ foreach(SDK ${SWIFT_SDKS})
       set(validation_test_bin_dir
           "${CMAKE_CURRENT_BINARY_DIR}/../validation-test${VARIANT_SUFFIX}")
 
-      if(LLVM_ENABLE_LIBXML2)
-        set(SWIFT_HAVE_LIBXML2 TRUE)
-      else()
-        set(SWIFT_HAVE_LIBXML2 FALSE)
-      endif()
-
       set(VARIANT_EXTERNAL_EMBEDDED_PLATFORM FALSE)
       set(VARIANT_EXTERNAL_EMBEDDED_DEVICE)
 

--- a/tools/swift-ide-test/CMakeLists.txt
+++ b/tools/swift-ide-test/CMakeLists.txt
@@ -16,7 +16,7 @@ target_link_libraries(swift-ide-test
                         swiftCompilerModules)
 
 # If libxml2 is available, make it available for swift-ide-test.
-if(LLVM_ENABLE_LIBXML2)
+if(SWIFT_HAVE_LIBXML2)
   target_link_libraries(swift-ide-test PRIVATE LibXml2::LibXml2)
   target_compile_definitions(swift-ide-test PRIVATE SWIFT_HAVE_LIBXML=1)
 endif()

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2482,12 +2482,40 @@ function Build-XML2([Hashtable] $Platform) {
     -Defines @{
       BUILD_SHARED_LIBS = "NO";
       CMAKE_POSITION_INDEPENDENT_CODE = "YES";
+      LIBXML2_WITH_C14N = "NO";
+      LIBXML2_WITH_CATALOG = "NO";
+      LIBXML2_WITH_DEBUG = "NO";
+      LIBXML2_WITH_FTP = "NO";
+      LIBXML2_WITH_HTML = "NO";
+      LIBXML2_WITH_HTTP = "NO";
+      # NOTE(compnerd) this is technically needed for transcoding non-UTF-8 documents.
       LIBXML2_WITH_ICONV = "NO";
       LIBXML2_WITH_ICU = "NO";
+      LIBXML2_WITH_ISO8859X = "NO";
+      LIBXML2_WITH_LEGACY = "NO";
       LIBXML2_WITH_LZMA = "NO";
+      LIBXML2_WITH_MEM_DEBUG = "NO";
+      LIBXML2_WITH_MODULES = "NO";
+      LIBXML2_WITH_OUTPUT = "YES";
+      LIBXML2_WITH_PATTERN = "NO";
+      LIBXML2_WITH_PROGRAMS = "NO";
+      LIBXML2_WITH_PUSH = "YES";
       LIBXML2_WITH_PYTHON = "NO";
+      LIBXML2_WITH_READER = "NO";
+      LIBXML2_WITH_REGEXPS = "YES";
+      LIBXML2_WITH_SAX1 = "NO";
+      LIBXML2_WITH_SCHEMAS = "NO";
+      LIBXML2_WITH_SCHEMATRON = "NO";
       LIBXML2_WITH_TESTS = "NO";
+      LIBXML2_WITH_THREAD_ALLOC = "NO";
       LIBXML2_WITH_THREADS = "YES";
+      LIBXML2_WITH_TREE = "YES";
+      LIBXML2_WITH_VALID = "YES";
+      LIBXML2_WITH_WRITER = "NO";
+      LIBXML2_WITH_XINCLUDE = "NO";
+      LIBXML2_WITH_XPATH = "YES";
+      LIBXML2_WITH_XPTR = "NO";
+      LIBXML2_WITH_XPTR_LOCS = "NO";
       LIBXML2_WITH_ZLIB = "NO";
     }
 }


### PR DESCRIPTION
This trims down what we include in the libxml2 build so that we can minimise code size and build times.