### PR TITLE
[Embedded] Only include detailed exclusivity failure message in debug builds

### DIFF
--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -822,19 +822,24 @@ func _embeddedReportExclusivityViolation(
   newAction: Access.Action, newPC: UnsafeRawPointer?,
   pointer: UnsafeRawPointer
 ) {
-  print("Simultaneous access to 0x", terminator: "")
-  printAsHex(Int(bitPattern: pointer), terminator: "")
-  print(", but modification requires exclusive access")
+  if _isDebugAssertConfiguration() {
+    print("Simultaneous access to 0x", terminator: "")
+    printAsHex(Int(bitPattern: pointer), terminator: "")
+    print(", but modification requires exclusive access")
 
-  print("Previous access (a ", terminator: "")
-  oldAction.printName()
-  print(") started at 0x", terminator: "")
-  printAsHex(Int(bitPattern: oldPC))
+    print("Previous access (a ", terminator: "")
+    oldAction.printName()
+    print(") started at 0x", terminator: "")
+    printAsHex(Int(bitPattern: oldPC))
 
-  print("Current access (a ", terminator: "")
-  newAction.printName()
-  print(") started at 0x", terminator: "")
-  printAsHex(Int(bitPattern: newPC))
+    print("Current access (a ", terminator: "")
+    newAction.printName()
+    print(") started at 0x", terminator: "")
+    printAsHex(Int(bitPattern: newPC))
+  }
+  Builtin.condfail_message(
+    true._value, StaticString("dynamic exclusivity violation").unsafeRawPointer)
+  Builtin.int_trap()
 }
 
 // CXX Exception Personality

--- a/stdlib/public/core/Exclusivity.swift
+++ b/stdlib/public/core/Exclusivity.swift
@@ -271,21 +271,34 @@ internal func _swift_exclusivityAccessGetParent(
 
 @inline(never)
 fileprivate func invalidFlags(_ flags: UInt) -> Never {
+  #if !$Embedded
   reportExclusivityError("Internal exclusivity error",
-                         "unable to construct action from flags \(flags)")
+    "unable to construct action from flags \(flags)")
+  #else
+  fatalError("Internal exclusivity error: unable to construct action from flags")
+  #endif
 }
 
 @inline(never)
 fileprivate func accessNotFound(_ access: AccessPointer) -> Never {
+  #if !$Embedded
   unsafe reportExclusivityError("Internal exclusivity error",
                                 "didn't find exclusive access buffer \(access)")
+  #else
+  fatalError("Internal exclusivity error: didn't find exclusive access buffer")
+  #endif
 }
 
 @inline(never)
 fileprivate func nullAccessBuffer() -> Never {
+  #if !$Embedded
   reportExclusivityError("Internal exclusivity error", "NULL access buffer")
+  #else
+  fatalError("Internal exclusivity error: NULL access buffer")
+  #endif
 }
 
+@_unavailableInEmbedded
 fileprivate func reportExclusivityError(
   _ prefix: StaticString, _ message: String
 ) -> Never {

--- a/test/embedded/exclusivity_runtime.swift
+++ b/test/embedded/exclusivity_runtime.swift
@@ -1,9 +1,29 @@
 // RUN: %empty-directory(%t)
+
+// Single-threaded exclusivity checking implementation.
+
+// Build without optimization.
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -emit-ir -o %t/yesopt.ll -enforce-exclusivity=checked -enable-experimental-feature EmbeddedDynamicExclusivity
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o -enforce-exclusivity=checked -enable-experimental-feature EmbeddedDynamicExclusivity
 
-// Single-threaded exclusivity checking implementation
-// RUN: %target-clang %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip -lswiftExclusivitySingleThreaded
-// RUN: %target-run %t/a.out 2>&1| %FileCheck %s
+// Ensure that the detailed printing strings are there in the resulting binary.
+// RUN: %FileCheck -check-prefix YESOPT %s < %t/yesopt.ll
+
+// Run without optimization.
+// RUN: %target-clang %t/a.o %target-embedded-posix-shim -o %t/noopt.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip -lswiftExclusivitySingleThreaded
+// RUN: %target-run not --crash %t/noopt.out
+
+// Build with optimization.
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -emit-ir -o %t/noopt.ll -enforce-exclusivity=checked -enable-experimental-feature EmbeddedDynamicExclusivity -O
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o -enforce-exclusivity=checked -enable-experimental-feature EmbeddedDynamicExclusivity -O
+
+// Ensure that the detailed printing strings are not there in the resulting
+// binary.
+// RUN: %FileCheck -check-prefix NOOPT %s < %t/noopt.ll
+
+// Run with optimization.
+// RUN: %target-clang %t/a.o %target-embedded-posix-shim -o %t/opt.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip -lswiftExclusivitySingleThreaded
+// RUN: %target-run not --crash %t/opt.out
 
 // REQUIRES: executable_test
 // REQUIRES: swift_in_compiler
@@ -25,6 +45,7 @@ struct NC: ~Copyable {
 class C1 {
   var nc = NC()
 
+  @inline(never)
   func foo() {
     nc.add(nc)
   }
@@ -33,6 +54,7 @@ class C1 {
 struct S {
   var i: Int = 1
 
+  @inline(never)
   mutating func add(_ c: C2) {
     let other = c.getS()
     i += other.i
@@ -48,6 +70,7 @@ final class C2 {
   @inline(never)
   func getS() -> S { s }
 
+  @inline(never)
   func foo() {
     s.add(self)
   }
@@ -56,9 +79,20 @@ final class C2 {
 @main
 struct Main {
   static func main() {
+    // FIXME: These are actually disabled, because we don't flush standard
+    // output before crashing.
     // CHECK: Simultaneous access to 0x{{.*}}, but modification requires exclusive access
     // CHECK: Previous access (a modify) started at 0x{{.*}}
     // CHECK: Current access (a read) started at 0x{{.*}}
     C1().foo()
   }
 }
+
+// YESOPT: [[SIMULT_ACCESS_STR:@.*]] = private unnamed_addr constant [26 x i8] c"Simultaneous access to 0x\00"
+// YESOPT: define{{.*}}void @"$es35_embeddedReportExclusivityViolation9oldAction0E2PC03newF00hG07pointerys6AccessV0F0O_SVSgAjKSVtF"
+// YESOPT-NOT: unreachable
+// YESOPT: [[SIMULT_ACCESS_STR]]
+
+// NOOOPT-NO: Simultaneous access to 0x
+// NOOPT: define{{.*}}void @"$es35_embeddedReportExclusivityViolation9oldAction0E2PC03newF00hG07pointerys6AccessV0F0O_SVSgAjKSVtFTf4ddddd_n"
+// NOOPT: unreachable

--- a/test/embedded/exclusivity_runtime.swift
+++ b/test/embedded/exclusivity_runtime.swift
@@ -31,6 +31,8 @@
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: swift_feature_EmbeddedDynamicExclusivity
 
+// UNSUPPORTED: OS=wasip1
+
 struct NC: ~Copyable {
   var i: Int = 1
 

--- a/test/embedded/exclusivity_runtime.swift
+++ b/test/embedded/exclusivity_runtime.swift
@@ -96,5 +96,8 @@ struct Main {
 // YESOPT: [[SIMULT_ACCESS_STR]]
 
 // NOOOPT-NO: Simultaneous access to 0x
-// NOOPT: define{{.*}}void @"$es35_embeddedReportExclusivityViolation9oldAction0E2PC03newF00hG07pointerys6AccessV0F0O_SVSgAjKSVtFTf4ddddd_n"
+// NOOPT: define{{.*}}void @swift_beginAccess
+// NOOPT: tail call swiftcc void [[TRAPFN:@.*]]()
+// NOOPT: define{{.*}}void [[TRAPFN]]()
+// NOOPT: call void @llvm.trap()
 // NOOPT: unreachable

--- a/test/embedded/exclusivity_runtime_multi.swift
+++ b/test/embedded/exclusivity_runtime_multi.swift
@@ -3,7 +3,7 @@
 
 // Multi-threaded exclusivity checking implementation (that uses C11 thread_local).
 // RUN: %target-clang %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip -lswiftExclusivityC11ThreadLocal
-// RUN: %target-run %t/a.out 2>&1| %FileCheck %s
+// RUN: %target-run not --crash %t/a.out
 
 // REQUIRES: executable_test
 // REQUIRES: swift_in_compiler
@@ -58,6 +58,7 @@ final class C2 {
 @main
 struct Main {
   static func main() {
+    // Note: not actually checked because it doesn't get flushed.
     // CHECK: Simultaneous access to 0x{{.*}}, but modification requires exclusive access
     // CHECK: Previous access (a modify) started at 0x{{.*}}
     // CHECK: Current access (a read) started at 0x{{.*}}


### PR DESCRIPTION
In release builds that enable dynamic exclusivity checking, we are including all of the printing code for producing the nice "simultaneous access" failure message. That increases code size too much, so only include this in debug builds. For release builds, we just trap here.

Fixes rdar://173338152.