### PR TITLE
[Sema] Fix -debug-time-expression-type-checking producing no output

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -186,11 +186,12 @@ void ConstraintSystem::startExpressionTimer() {
   const auto &opts = getASTContext().TypeCheckerOpts;
   unsigned timeout = opts.ExpressionTimeoutThreshold;
 
-  // If either the timeout is set, or we're asked to emit warnings,
-  // start the timer. Otherwise, don't start the timer, it's needless
-  // overhead.
+  // If either the timeout is set, we're asked to emit warnings, or we're
+  // asked to debug expression type-checking times, start the timer.
+  // Otherwise, don't start the timer, it's needless overhead.
   if (timeout == 0) {
-    if (opts.WarnLongExpressionTypeChecking == 0)
+    if (opts.WarnLongExpressionTypeChecking == 0 &&
+        !opts.DebugTimeExpressions)
       return;
 
     timeout = ExpressionTimer::NoLimit;

--- a/test/Sema/debug_time_expression_type_checking.swift
+++ b/test/Sema/debug_time_expression_type_checking.swift
@@ -1,0 +1,11 @@
+// Regression test: -debug-time-expression-type-checking must emit per-expression
+// timing lines to stderr. Prior to the fix, startExpressionTimer() would return
+// early when ExpressionTimeoutThreshold == 0, suppressing all output.
+//
+// RUN: %target-swiftc_driver -Xfrontend -debug-time-expression-type-checking %s 2>&1 | %FileCheck %s
+// CHECK: ms	{{.*}}debug_time_expression_type_checking.swift:
+
+func example() {
+    let x = [1, 2, 3].map { $0 * 2 }
+    let _ = x.reduce(0, +)
+}


### PR DESCRIPTION
Fixes #88101.

## Summary

`-debug-time-expression-type-checking` silently produced no output in Swift 6.x (exits 0, nothing on stderr). `-debug-time-function-bodies` was unaffected.

**Root cause:** `ConstraintSystem::startExpressionTimer()` had an early-exit guard checking `ExpressionTimeoutThreshold == 0 && WarnLongExpressionTypeChecking == 0` but not `DebugTimeExpressions`. When only the debug flag is passed, the timer was never created and its destructor never ran.

**Fix:** Extend the early-exit condition to also require `!opts.DebugTimeExpressions`.

## Changes

- `lib/Sema/ConstraintSystem.cpp` — one-line fix in `startExpressionTimer()`, comment updated
- `test/Sema/debug_time_expression_type_checking.swift` — new regression test verifying the flag emits timing output

## Testing

New lit test covers the regression:

```
// RUN: %target-swiftc_driver -Xfrontend -debug-time-expression-type-checking %s 2>&1 | %FileCheck %s
// CHECK: {{[0-9]+\.[0-9]+ms}}
```

Reproduced locally on Swift 6.2.1 (swiftlang-6.2.1.4.8, arm64-apple-macosx).
