### PR TITLE
[6.3] [SILOptimizer] Fix ConstantCapturePropagation ODR violation with generic closures

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ConstantCapturePropagation.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ConstantCapturePropagation.swift
@@ -155,9 +155,16 @@ private func specializeClosure(specializedName: String,
                   callee.convention.results.contains { $0.type.hasTypeParameter } ||
                   callee.convention.errorResult?.type.hasTypeParameter ?? false
 
+  let representation = partialApply.callee.type.functionTypeRepresentation
+  // We are removing arguments from the original function. If the removed argument is the
+  // "self" argument, the specialized function cannot be a "method" anymore. It's in general
+  // safe to make it a "thin" function (even if "self" was not removed).
+  let newRepr = representation == .method ? .thin : representation
+
   let specializedClosure = context.createSpecializedFunctionDeclaration(from: callee,
                                                                         withName: specializedName,
                                                                         withParams: newParams,
+                                                                        withRepresentation: newRepr,
                                                                         preserveGenericSignature: isGeneric)
 
   context.buildSpecializedFunction(specializedFunction: specializedClosure) { (specializedClosure, specContext) in
@@ -214,7 +221,7 @@ private func rewritePartialApply(_ partialApply: PartialApplyInst, withSpecializ
   let builder = Builder(before: partialApply, context)
   let fri = builder.createFunctionRef(specialized)
   let newClosure: Value
-  if arguments.isEmpty {
+  if arguments.isEmpty, fri.type.functionTypeRepresentation == .thin {
     newClosure = builder.createThinToThickFunction(thinFunction: fri, resultType: partialApply.type)
     context.erase(instructions: partialApply.uses.users(ofType: DeallocStackInst.self))
   } else {

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ConstantCapturePropagation.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ConstantCapturePropagation.swift
@@ -168,9 +168,17 @@ private func specializeClosure(specializedName: String,
                                                                         preserveGenericSignature: isGeneric)
 
   context.buildSpecializedFunction(specializedFunction: specializedClosure) { (specializedClosure, specContext) in
-    cloneAndSpecializeFunction(from: callee, toEmpty: specializedClosure,
-                               substitutions: partialApply.substitutionMap,
-                               specContext)
+    if isGeneric {
+      // When the specialized closure is still generic, clone without type substitutions.
+      // The mangled name only encodes constant values, not type substitutions, so the body
+      // must stay generic to avoid ODR violations when different concrete types produce the
+      // same symbol but with different type-substituted bodies.
+      cloneFunction(from: callee, toEmpty: specializedClosure, specContext)
+    } else {
+      cloneAndSpecializeFunction(from: callee, toEmpty: specializedClosure,
+                                 substitutions: partialApply.substitutionMap,
+                                 specContext)
+    }
 
     let entryBlock = specializedClosure.entryBlock
     for constArgOp in constantArguments {
@@ -221,7 +229,7 @@ private func rewritePartialApply(_ partialApply: PartialApplyInst, withSpecializ
   let builder = Builder(before: partialApply, context)
   let fri = builder.createFunctionRef(specialized)
   let newClosure: Value
-  if arguments.isEmpty, fri.type.functionTypeRepresentation == .thin {
+  if arguments.isEmpty, specialized.genericSignature.isEmpty, fri.type.functionTypeRepresentation == .thin {
     newClosure = builder.createThinToThickFunction(thinFunction: fri, resultType: partialApply.type)
     context.erase(instructions: partialApply.uses.users(ofType: DeallocStackInst.self))
   } else {

--- a/test/SILOptimizer/capture_propagation.sil
+++ b/test/SILOptimizer/capture_propagation.sil
@@ -938,3 +938,62 @@ bb0(%0 : $*T):
   return %r : $()
 }
 
+sil @useClosure : $@convention(thin) (@noescape @callee_guaranteed () -> Builtin.Int32) -> ()
+
+// CHECK-LABEL: sil [ossa] @testClosureWithNonThinConvention :
+// CHECK:         [[C:%.*]] = function_ref @$s18cClosureWithStruct4main1SVs5Int32VSbTf3pSSi3Si0_n : $@convention(c) () -> Builtin.Int32
+// CHECK:         = partial_apply [callee_guaranteed] [[C]]() : $@convention(c) () -> Builtin.Int32
+// CHECK:       } // end sil function 'testClosureWithNonThinConvention'
+sil [ossa] @testClosureWithNonThinConvention : $@convention(thin) () -> () {
+bb0:
+  %0 = integer_literal $Builtin.Int32, 3
+  %1 = struct $Int32 (%0)
+  %2 = integer_literal $Builtin.Int1, 0
+  %3 = struct $Bool (%2)
+  %4 = struct $S (%1, %3)
+  %5 = function_ref @cClosureWithStruct : $@convention(c) (S) -> Builtin.Int32
+  %6 = partial_apply [callee_guaranteed] %5(%4) : $@convention(c) (S) -> Builtin.Int32
+  %7 = convert_escape_to_noescape %6 to $@noescape @callee_guaranteed () -> Builtin.Int32
+  %8 = function_ref @useClosure : $@convention(thin) (@noescape @callee_guaranteed () -> Builtin.Int32) -> ()
+  %9 = apply %8(%7) : $@convention(thin) (@noescape @callee_guaranteed () -> Builtin.Int32) -> ()
+  destroy_value %7
+  destroy_value %6
+  %12 = tuple ()
+  return %12 : $()
+}
+
+sil [ossa] @cClosureWithStruct : $@convention(c) (S) -> Builtin.Int32 {
+bb0(%1 : $S):
+  %2 = struct_extract %1, #S.i
+  %3 = struct_extract %2, #Int32._value
+  return %3
+}
+
+// CHECK-LABEL: sil [ossa] @testClosureWithMethodConvention :
+// CHECK:         [[C:%.*]] = function_ref @$s23methodClosureWithStruct4main1SVs5Int32VSbTf3pSSi3Si0_n : $@convention(thin) () -> Builtin.Int32
+// CHECK:         = thin_to_thick_function [[C]] : $@convention(thin) () -> Builtin.Int32 to $@callee_guaranteed () -> Builtin.Int32
+// CHECK:       } // end sil function 'testClosureWithMethodConvention'
+sil [ossa] @testClosureWithMethodConvention : $@convention(thin) () -> () {
+bb0:
+  %0 = integer_literal $Builtin.Int32, 3
+  %1 = struct $Int32 (%0)
+  %2 = integer_literal $Builtin.Int1, 0
+  %3 = struct $Bool (%2)
+  %4 = struct $S (%1, %3)
+  %5 = function_ref @methodClosureWithStruct : $@convention(method) (S) -> Builtin.Int32
+  %6 = partial_apply [callee_guaranteed] %5(%4) : $@convention(method) (S) -> Builtin.Int32
+  %7 = convert_escape_to_noescape %6 to $@noescape @callee_guaranteed () -> Builtin.Int32
+  %8 = function_ref @useClosure : $@convention(thin) (@noescape @callee_guaranteed () -> Builtin.Int32) -> ()
+  %9 = apply %8(%7) : $@convention(thin) (@noescape @callee_guaranteed () -> Builtin.Int32) -> ()
+  destroy_value %7
+  destroy_value %6
+  %12 = tuple ()
+  return %12 : $()
+}
+
+sil [ossa] @methodClosureWithStruct : $@convention(method) (S) -> Builtin.Int32 {
+bb0(%1 : $S):
+  %2 = struct_extract %1, #S.i
+  %3 = struct_extract %2, #Int32._value
+  return %3
+}

--- a/test/SILOptimizer/constant_capture_propagation_odr.sil
+++ b/test/SILOptimizer/constant_capture_propagation_odr.sil
@@ -1,0 +1,66 @@
+// RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all %s -constant-capture-propagation | %FileCheck %s
+
+// Regression test for an ODR violation in ConstantCapturePropagation.
+sil_stage raw
+
+import Builtin
+import Swift
+
+// A minimal generic closure that writes to an Optional<T> indirect result.
+sil shared [heuristic_always_inline] [ossa] @generic_closure : $@convention(thin) <T where T : FixedWidthInteger> (UnsafeBufferPointer<UInt8>, Int) -> @out Optional<T> {
+bb0(%0 : $*Optional<T>, %1 : $UnsafeBufferPointer<UInt8>, %2 : $Int):
+  inject_enum_addr %0 : $*Optional<T>, #Optional.none!enumelt
+  %3 = tuple ()
+  return %3 : $()
+}
+
+// The specialized closure must preserve its generic signature. Verify that the
+// body uses $*Optional<T> (generic) rather than $*Optional<UInt8> (concrete).
+//
+// CHECK-LABEL: sil shared {{.*}}@$s15generic_closureSiTf3nnpSi10_n
+// CHECK:         bb0({{.*}} : $*Optional<T>, {{.*}} : $UnsafeBufferPointer<UInt8>):
+// CHECK:           inject_enum_addr {{.*}} : $*Optional<T>, #Optional.none!enumelt
+// CHECK:       } // end sil function '$s15generic_closureSiTf3nnpSi10_n'
+
+// caller_uint8: partial_apply generic_closure<UInt8> with constant radix=10.
+// The specialized closure should keep generic types in the body, not $*UInt8.
+//
+// CHECK-LABEL: sil [ossa] @caller_uint8
+// CHECK:         function_ref @$s15generic_closureSiTf3nnpSi10_n
+// CHECK:         partial_apply [callee_guaranteed] {{%[0-9]+}}<UInt8>()
+// CHECK:       } // end sil function 'caller_uint8'
+sil [ossa] @caller_uint8 : $@convention(thin) (UnsafeBufferPointer<UInt8>) -> @out Optional<UInt8> {
+bb0(%0 : $*Optional<UInt8>, %1 : $UnsafeBufferPointer<UInt8>):
+  %2 = integer_literal $Builtin.Int64, 10
+  %3 = struct $Int (%2 : $Builtin.Int64)
+  %4 = function_ref @generic_closure : $@convention(thin) <T where T : FixedWidthInteger> (UnsafeBufferPointer<UInt8>, Int) -> @out Optional<T>
+  %5 = partial_apply [callee_guaranteed] %4<UInt8>(%3) : $@convention(thin) <T where T : FixedWidthInteger> (UnsafeBufferPointer<UInt8>, Int) -> @out Optional<T>
+  %6 = begin_borrow %5 : $@callee_guaranteed (UnsafeBufferPointer<UInt8>) -> @out Optional<UInt8>
+  %7 = apply %6(%0, %1) : $@callee_guaranteed (UnsafeBufferPointer<UInt8>) -> @out Optional<UInt8>
+  end_borrow %6 : $@callee_guaranteed (UnsafeBufferPointer<UInt8>) -> @out Optional<UInt8>
+  destroy_value %5 : $@callee_guaranteed (UnsafeBufferPointer<UInt8>) -> @out Optional<UInt8>
+  %10 = tuple ()
+  return %10 : $()
+}
+
+// caller_int: partial_apply generic_closure<Int> with constant radix=10.
+// Must reuse the same specialized closure. If the body was baked with UInt8,
+// the verifier would catch the type mismatch here.
+//
+// CHECK-LABEL: sil [ossa] @caller_int
+// CHECK:         function_ref @$s15generic_closureSiTf3nnpSi10_n
+// CHECK:         partial_apply [callee_guaranteed] {{%[0-9]+}}<Int>()
+// CHECK:       } // end sil function 'caller_int'
+sil [ossa] @caller_int : $@convention(thin) (UnsafeBufferPointer<UInt8>) -> @out Optional<Int> {
+bb0(%0 : $*Optional<Int>, %1 : $UnsafeBufferPointer<UInt8>):
+  %2 = integer_literal $Builtin.Int64, 10
+  %3 = struct $Int (%2 : $Builtin.Int64)
+  %4 = function_ref @generic_closure : $@convention(thin) <T where T : FixedWidthInteger> (UnsafeBufferPointer<UInt8>, Int) -> @out Optional<T>
+  %5 = partial_apply [callee_guaranteed] %4<Int>(%3) : $@convention(thin) <T where T : FixedWidthInteger> (UnsafeBufferPointer<UInt8>, Int) -> @out Optional<T>
+  %6 = begin_borrow %5 : $@callee_guaranteed (UnsafeBufferPointer<UInt8>) -> @out Optional<Int>
+  %7 = apply %6(%0, %1) : $@callee_guaranteed (UnsafeBufferPointer<UInt8>) -> @out Optional<Int>
+  end_borrow %6 : $@callee_guaranteed (UnsafeBufferPointer<UInt8>) -> @out Optional<Int>
+  destroy_value %5 : $@callee_guaranteed (UnsafeBufferPointer<UInt8>) -> @out Optional<Int>
+  %10 = tuple ()
+  return %10 : $()
+}

--- a/test/SILOptimizer/constant_capture_propagation_odr.sil
+++ b/test/SILOptimizer/constant_capture_propagation_odr.sil
@@ -1,4 +1,5 @@
 // RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all %s -constant-capture-propagation | %FileCheck %s
+// REQUIRES: PTRSIZE=64
 
 // Regression test for an ODR violation in ConstantCapturePropagation.
 sil_stage raw

--- a/test/SILOptimizer/constant_capture_propagation_odr.swift
+++ b/test/SILOptimizer/constant_capture_propagation_odr.swift
@@ -1,0 +1,30 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -Osize -Xllvm -sil-disable-pass=GenericSpecializer -module-name=test %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+// REQUIRES: executable_test
+
+// Regression test for an ODR violation in ConstantCapturePropagation.
+@inline(never)
+func parseU8(_ s: String) -> UInt8? {
+    return UInt8(s, radix: 10)
+}
+
+@inline(never)
+func parseInt(_ s: String) -> Int? {
+    return Int(s, radix: 10)
+}
+
+@inline(never)
+func parseInt32(_ s: String) -> Int32? {
+    return Int32(s, radix: 10)
+}
+
+// CHECK: UInt8: Optional(42)
+print("UInt8: \(parseU8("42") as Any)")
+
+// CHECK: Int: Optional(42)
+print("Int: \(parseInt("42") as Any)")
+
+// CHECK: Int32: Optional(42)
+print("Int32: \(parseInt32("42") as Any)")


### PR DESCRIPTION
- **Explanation**: We discovered a miscompile in SILOptimizer (detailed in https://github.com/swiftlang/swift/issues/87917). It creates an ODR violation by improperly sharing the same symbol for generic closures with different concrete type substitutions, leading to a miscompile where the wrong function body is executed at runtime, ultimately producing garbage data or crashes. It caused our app to enter a SIGTRAP on 26.3, when it worked fine before.

- **Scope**: This change fixes a bug in SILVerifier and Optimizer

- **Issues**:
https://github.com/swiftlang/swift/issues/87917
rdar://172777411

- **Original PRs**:
    - https://github.com/swiftlang/swift/pull/87977
    - https://github.com/swiftlang/swift/pull/87916
    - https://github.com/swiftlang/swift/pull/88076

- **Risk**: Low, it is a rather simple fix in the optimization pass.

- **Testing**: New tests added

- **Reviewers**: @eeckstein @drodriguez 

cc @hborla @airspeedswift 