### PR TITLE
[Concurrency] SE-0466: Refactor implementation of isolation inference

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6097,68 +6097,88 @@ computeDefaultInferredActorIsolation(ValueDecl *value) {
       if (isa<AssociatedTypeDecl>(value))
         return {};
 
+      // Opaque types cannot have custom isolation, they are tied to
+      // their parent declaration.
+      if (isa<OpaqueTypeDecl>(value))
+        return {};
+
+      // The declaration has an isolation specified by an attribute.
+      if (getIsolationFromAttributes(value))
+        return {};
+
+      if (auto *nominal = dyn_cast<NominalTypeDecl>(value)) {
+        // Actors cannot infer isolation.
+        if (nominal->isAnyActor())
+          return {};
+
+        // The declaration is a nominal type that doesn't support default
+        // isolation inference because it conforms to `SendableMetatype`
+        // inheriting protocol.
+        if (sendableConformanceRequiresNonisolated(nominal))
+          return {};
+      }
+
+      // Non-type declarations that are located inside of a type that conforms
+      // to a `SendableMetatype` inheriting protocol don't participate in
+      // default isolation inference.
+      if (!isa<TypeDecl>(value)) {
+        if (auto *nominal = value->getDeclContext()->getSelfNominalTypeDecl()) {
+          if (sendableConformanceRequiresNonisolated(nominal))
+            return {};
+        }
+      }
+
+      // Extensions suppress default isolation inference if:
+      //  - They have an explicit isolation attribute; or
+      //  - They extend a type that directly conforms to a `SendableMetatype`
+      //    inheriting protocol; or
+      //  - They extend `nonisolated` type in the same module.
+      auto suppressesIsolationInference = [&](ExtensionDecl *extension) {
+        if (getIsolationFromAttributes(extension))
+          return true;
+
+        auto *nominal = extension->getExtendedNominal();
+        if (sendableConformanceRequiresNonisolated(nominal))
+          return true;
+
+        if (getActorIsolation(nominal).isNonisolated() &&
+            extension->getModuleContext() == nominal->getModuleContext())
+          return true;
+
+        return false;
+      };
+
+      if (auto *extension = dyn_cast<ExtensionDecl>(value)) {
+        if (suppressesIsolationInference(extension))
+          return {};
+      }
+
       // Members and nested types must check the isolation of the enclosing
       // nominal type.
-      auto *dc = value->getInnermostDeclContext();
+      auto *dc = value->getDeclContext();
       while (dc) {
         if (auto *nominal = dc->getSelfNominalTypeDecl()) {
           if (nominal->isAnyActor())
             return {};
 
-          if (dc != dyn_cast<DeclContext>(value)) {
-            // If the nominal type is global-actor-isolated, there's nothing
-            // more to look for.
-            if (getActorIsolation(nominal).isMainActor())
-              break;
+          // If the nominal type is global-actor-isolated, there's nothing
+          // more to look for.
+          if (getActorIsolation(nominal).isMainActor())
+            break;
 
-            // If this is an extension of a nonisolated type, its isolation
-            // is independent of the type.
-            if (auto ext = dyn_cast<ExtensionDecl>(dc)) {
-              // Isolation of an extension synthesized by a macro expansion
-              // should match isolation of the type. Conformances/members
-              // declared in such extensions are handled as-if they are
-              // associated directly with the primary declaration of the type.
-              if (ext->isInMacroExpansionInContext())
-                return {};
+          if (auto ext = dyn_cast<ExtensionDecl>(dc)) {
+            if (suppressesIsolationInference(ext))
+              return {};
 
-              // If there were isolation attributes on the extension, respect
-              // them.
-              if (getIsolationFromAttributes(ext).has_value())
-                return {};
-
-              // Members declared in an extension are @MainActor isolated
-              // even if it's an extension of a nonisolated type. This helps
-              // to extend types from other modules, for example, to conform
-              // to new protocols declared in @MainActor isolated module without
-              // having to explicitly state `@MainActor`.
-              auto isolation =
-                  ActorIsolation::forGlobalActor(globalActor)
-                      .withPreconcurrency(
-                          !ctx.isLanguageModeAtLeast(LanguageMode::v6));
-              return {{{isolation, {}}, nullptr, {}}};
-            }
-
-            // The type is nonisolated, so its members are nonisolated.
+            // Keep looking.
+          } else {
+            // The type is nonisolated or isolated to some other global-actor
+            // which disables default isolation inference.
             return {};
           }
         }
 
         dc = dc->getParent();
-      }
-
-      // If this is or is a non-type member of a nominal type that conforms to a
-      // SendableMetatype-inheriting protocol in its primary definition, disable
-      // @MainActor inference.
-      auto nominalTypeDecl = dyn_cast<NominalTypeDecl>(value);
-      if (!nominalTypeDecl && !isa<TypeDecl>(value)) {
-        nominalTypeDecl = value->getDeclContext()->getSelfNominalTypeDecl();
-      }
-      if (nominalTypeDecl &&
-          sendableConformanceRequiresNonisolated(nominalTypeDecl)) {
-        InferredActorIsolation isolation{
-            ActorIsolation::forNonisolated(/*unsafe=*/false), /*source=*/{}};
-        return {
-            {isolation, /*overridenValue=*/nullptr, /*overridenIsolation=*/{}}};
       }
 
       if (isa<TypeDecl>(value) || isa<ExtensionDecl>(value) ||
@@ -8846,7 +8866,9 @@ ActorIsolation swift::inferConformanceIsolation(
         // implicitly nonisolated (i.e. via primary declaration conforming to
         // a `Sendable` protocol) and that gives us a hint that conformance
         // should be nonisolated as well.
-        if (nominalIsolation.isNonisolated() && !hasKnownIsolatedWitness)
+        if ((nominalIsolation.isNonisolated() ||
+             nominalIsolation.isUnspecified()) &&
+            !hasKnownIsolatedWitness)
           return nominalIsolation;
 
         return ActorIsolation::forMainActor(ctx);

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6132,7 +6132,7 @@ computeDefaultInferredActorIsolation(ValueDecl *value) {
       //  - They have an explicit isolation attribute; or
       //  - They extend a type that directly conforms to a `SendableMetatype`
       //    inheriting protocol; or
-      //  - They extend `nonisolated` type in the same module.
+      //  - The extension is synthesized by a macro expansion.
       auto suppressesIsolationInference = [&](ExtensionDecl *extension) {
         if (getIsolationFromAttributes(extension))
           return true;
@@ -6141,8 +6141,11 @@ computeDefaultInferredActorIsolation(ValueDecl *value) {
         if (sendableConformanceRequiresNonisolated(nominal))
           return true;
 
-        if (getActorIsolation(nominal).isNonisolated() &&
-            extension->getModuleContext() == nominal->getModuleContext())
+        // Isolation of an extension synthesized by a macro expansion
+        // should match isolation of the type. Conformances/members
+        // declared in such extensions are handled as-if they are
+        // associated directly with the primary declaration of the type.
+        if (extension->isInMacroExpansionInContext())
           return true;
 
         return false;

--- a/test/Concurrency/assume_mainactor_typechecker_errors.swift
+++ b/test/Concurrency/assume_mainactor_typechecker_errors.swift
@@ -86,7 +86,7 @@ func testTaskDetached() async {
 
 // @MainActor
 extension Int {
-  func memberOfInt() { } // expected-note 4{{calls to instance method 'memberOfInt()' from outside of its actor context are implicitly asynchronous}}
+  func memberOfInt() { } // expected-note 3{{calls to instance method 'memberOfInt()' from outside of its actor context are implicitly asynchronous}}
 }
 
 nonisolated func testMemberOfInt(i: Int) {
@@ -108,10 +108,8 @@ extension MyStruct: CustomStringConvertible {
 nonisolated struct MyOtherStruct { }
 
 extension MyOtherStruct {
-  func f() { // expected-note {{add '@MainActor' to make instance method 'f()' part of global actor 'MainActor'}}
-    17.memberOfInt()
-    // expected-swift5-warning@-1 {{call to main actor-isolated instance method 'memberOfInt()' in a synchronous nonisolated context}}
-    // expected-swift6-error@-2 {{call to main actor-isolated instance method 'memberOfInt()' in a synchronous nonisolated context}}
+  func f() {
+    17.memberOfInt() // ok, on main actor
   }
 }
 

--- a/test/Concurrency/assume_mainactor_typechecker_errors.swift
+++ b/test/Concurrency/assume_mainactor_typechecker_errors.swift
@@ -86,7 +86,7 @@ func testTaskDetached() async {
 
 // @MainActor
 extension Int {
-  func memberOfInt() { } // expected-note 3{{calls to instance method 'memberOfInt()' from outside of its actor context are implicitly asynchronous}}
+  func memberOfInt() { } // expected-note 4{{calls to instance method 'memberOfInt()' from outside of its actor context are implicitly asynchronous}}
 }
 
 nonisolated func testMemberOfInt(i: Int) {
@@ -108,8 +108,10 @@ extension MyStruct: CustomStringConvertible {
 nonisolated struct MyOtherStruct { }
 
 extension MyOtherStruct {
-  func f() {
-    17.memberOfInt() // okay, on main actor
+  func f() { // expected-note {{add '@MainActor' to make instance method 'f()' part of global actor 'MainActor'}}
+    17.memberOfInt()
+    // expected-swift5-warning@-1 {{call to main actor-isolated instance method 'memberOfInt()' in a synchronous nonisolated context}}
+    // expected-swift6-error@-2 {{call to main actor-isolated instance method 'memberOfInt()' in a synchronous nonisolated context}}
   }
 }
 

--- a/test/Concurrency/default_isolation_MainActor_interface_verification.swift
+++ b/test/Concurrency/default_isolation_MainActor_interface_verification.swift
@@ -36,7 +36,7 @@ nonisolated public protocol Q: Sendable {
 }
 
 // CHECK: @_Concurrency::MainActor @preconcurrency public protocol IsolatedProto<T> {
-// CHECK:   associatedtype T
+// CHECK: {{^}}  associatedtype T
 // CHECK: }
 public protocol IsolatedProto<T> {
   associatedtype T
@@ -45,10 +45,10 @@ public protocol IsolatedProto<T> {
 // CHECK: @_Concurrency::MainActor @preconcurrency public struct S : A::P {
 public struct S: P {
   // CHECK: @_Concurrency::MainActor @preconcurrency public enum E : Swift::String {
-  // CHECK:   case a
-  // CHECK:   case b
+  // CHECK: {{^}}  case a
+  // CHECK: {{^}}  case b
   // CHECK:   nonisolated public init?(rawValue: Swift::String)
-  // CHECK:   public typealias RawValue = Swift::String
+  // CHECK: {{^}}  public typealias RawValue = Swift::String
   // CHECK:   nonisolated public var rawValue: Swift::String {
   // CHECK:     get
   // CHECK:   }
@@ -71,8 +71,10 @@ public struct S: P {
   // CHECK: @_Concurrency::MainActor @preconcurrency public subscript(x: Swift::Int) -> Swift::Int {
   public subscript(x: Int) -> Int {
     // CHECK: get
+    // CHECK-NOT: @_Concurrency::MainActor get
     get { x }
     // CHECK: set
+    // CHECK-NOT: @_Concurrency::MainActor set
     set { }
   }
   // CHECK: }
@@ -86,9 +88,9 @@ public func opaqueTest() -> some P {
 
 // CHECK: public struct R : A::Q {
 public struct R: Q {
-  // CHECK: public struct Inner {
+  // CHECK: {{^}}  public struct Inner {
   public struct Inner {
-    // CHECK: public init()
+    // CHECK: {{^}}    public init()
     public init() {}
   }
   // CHECK: }
@@ -114,6 +116,29 @@ public class C {
 }
 // CHECK: }
 
+// CHECK: {{^}}extension A::C {
+public extension C {
+  // CHECK: {{^}}  public enum E : Swift::Error {
+  enum E: Error {
+    // CHECK: {{^}}    case terminated
+    case terminated
+
+    // CHECK: {{^}}    public func test()
+    public func test() {}
+  }
+
+  // CHECK: @_Concurrency::MainActor @preconcurrency public func shouldBeMainIsolated()
+  func shouldBeMainIsolated() {}
+}
+// CHECK: }
+
+// CHECK: {{^}}extension A::C.A::E : Swift::Equatable {
+extension C.E : Equatable {
+  // CHECK: {{^}}  public static func == (lhs: A::C.A::E, rhs: A::C.A::E) -> Swift::Bool 
+  public static func == (lhs: Self, rhs: Self) -> Bool { false }
+}
+// CHECK: }
+
 // CHECK: @_Concurrency::MainActor @preconcurrency open class IsolatedDeinitTest {
 open class IsolatedDeinitTest {
   // CHECK:   {{(@objc )?}} isolated deinit
@@ -124,13 +149,31 @@ open class IsolatedDeinitTest {
 // CHECK: @_Concurrency::MainActor @preconcurrency public struct TestAccessors {
 public struct TestAccessors {
   // CHECK: @_Concurrency::MainActor @preconcurrency public var test: Swift::Int {
-  // CHECK:   get
-  // CHECK:   set
+  // CHECK: {{^}}  get
+  // CHECK: {{^}}  set
   // CHECK: }
   public var test: Int {
     get { 42 }
     set { }
   }
+}
+// CHECK: }
+
+// The enum is nonisolated and so are it's members because it conforms to `Error` that inferits from `Sendable`.
+// CHECK: {{^}}public enum E : Swift::Error {
+public enum E: Error {
+  // CHECK: {{^}}  case aborted
+  case aborted
+
+  // CHECK: {{^}}  public static func == (lhs: A::E, rhs: A::E) -> Swift::Bool
+  public static func ==(lhs: E, rhs: E) -> Bool { false }
+}
+// CHECK: }
+
+// CHECK: extension Swift::Int {
+public extension Int {
+  // CHECK: @_Concurrency::MainActor @preconcurrency public func test()
+  func test() {}
 }
 // CHECK: }
 

--- a/test/Concurrency/default_mainactor_isolation_cross_module.swift
+++ b/test/Concurrency/default_mainactor_isolation_cross_module.swift
@@ -105,13 +105,13 @@ extension S: Q { // Ok (no errors about conformance isolation)
 }
 
 // @MainActor
-func globalFn() {} // expected-note {{calls to global function 'globalFn()' from outside of its actor context are implicitly asynchronous}}
-func takesMainActor(_: @MainActor () -> Void) {}
+func globalFn() {} // expected-note 2 {{calls to global function 'globalFn()' from outside of its actor context are implicitly asynchronous}}
+func takesMainActor(_: @MainActor () -> Void) {}  // expected-note {{calls to global function 'takesMainActor' from outside of its actor context are implicitly asynchronous}}
 
-// Check that a member declared in an extension of nonisolated type is considered @MainActor isolated
+// Check that a member declared in an extension of nonisolated type is considered `nonisolated` isolated when declared in the same module as `S`.
 extension S { // S is nonisolated because `P` is `Sendable`.
-  func test() {
-    globalFn() // Ok
+  func test() { // expected-note {{add '@MainActor' to make instance method 'test()' part of global actor 'MainActor'}}
+    globalFn() // expected-error {{call to main actor-isolated global function 'globalFn()' in a synchronous nonisolated context}}
   }
 }
 
@@ -121,10 +121,12 @@ protocol W {
 }
 
 extension S: W {
-  func mainActorWitness() {} // Ok (even though S is nonisolated new member is `@MainActor`)
+  func mainActorWitness() { // Ok (even though S is nonisolated new member is `@MainActor`)
+    globalFn() // Ok
+  }
 
-  func testIsolation(v: S) {
-    takesMainActor(v.mainActorWitness) // Ok
+  func testIsolation(v: S) { // expected-note {{add '@MainActor' to make instance method 'testIsolation(v:)' part of global actor 'MainActor'}}
+    takesMainActor(v.mainActorWitness) // expected-error {{call to main actor-isolated global function 'takesMainActor' in a synchronous nonisolated context}}
   }
 }
 


### PR DESCRIPTION
This change fixes the implementation of the default `MainActor` inference rules for types, extensions and their members to better align with the proposal.

Isolation inference is suppressed for a type that:
  - is an actor; or
  - has isolation other than `@MainActor` (either explicit or inferred); or
  - conforms to a `SendableMetatype` inheriting protocol;

Isolation inference is suppressed for an extension that:
  - extends an actor type; or
  - has isolation other than `@MainActor` (either explicit or inferred); or
  - extends a type that inherits from `SendableMetatype` protocol; or
  - extends `nonisolated` type declated in the same module.

When a type or its extension doesn't participate in default isolation inference that precludes their members from participation as well.

Resolves: rdar://171700249

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
