### PR TITLE
[cxx-interop] [test] Re-enable protected special members test

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -803,7 +803,8 @@ public func expectCrash(withMessage message: String = "", executing: () -> Void)
 }
 
 func _defaultTestSuiteFailedCallback() {
-  abort()
+  exit(1)
+  // abort()
 }
 
 var _testSuiteFailedCallback: () -> Void = _defaultTestSuiteFailedCallback

--- a/test/Interop/Cxx/class/inheritance/Inputs/protected-special-member.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/protected-special-member.h
@@ -38,20 +38,27 @@ struct ProtectedDtorBaseAndField : ProtectedDtor {
 struct ProtectedCopy {
   int fromBase = 111;
   ProtectedCopy() = default;
+
 protected:
   // NOTE: the copy has an incremented fromBase, so we can check at runtime that
   // the correct custom copy operation took place
   ProtectedCopy(const ProtectedCopy &c) : fromBase{c.fromBase + 1} {}
 };
 
-struct InheritsProtectedCopy : ProtectedCopy {
+struct InheritsProtectedCopy : public ProtectedCopy {
   int getFromBase(void) const { return fromBase; }
   void setFromBase(int x) { fromBase = x; }
+
+  // This is used to fake out the Swift optimizer to ensure that copies aren't elided.
+  void fakeMutation() {}
 };
 
 struct PrivatelyInheritsProtectedCopy : private ProtectedCopy {
   int getFromBase(void) const { return fromBase; }
   void setFromBase(int x) { fromBase = x; }
+
+  // This is used to fake out the Swift optimizer to ensure that copies aren't elided.
+  void fakeMutation() {}
 };
 
 struct PrivatelyInheritsPrivatelyInheritsProtectedCopy : private PrivatelyInheritsProtectedCopy {};
@@ -82,6 +89,9 @@ struct FieldVecOfInheritsProtectedCopy {
     v[2].setFromBase(z);
   }
   int get(unsigned idx) const { return v[idx].getFromBase(); }
+
+  // This is used to fake out the Swift optimizer to ensure that copies aren't elided.
+  void fakeMutation() {}
 };
 
 // suppressed-note@+1 {{record 'ProtectedMove' is not automatically available}}
@@ -95,6 +105,9 @@ protected:
 struct InheritsProtectedMove : ProtectedMove {
   int getFromBase(void) const { return fromBase; }
   void setFromBase(int x) { fromBase = x; }
+
+  // This is used to fake out the Swift optimizer to ensure that copies aren't elided.
+  void fakeMutation() {}
 };
 
 using VecOfProtectedMove = std::vector<ProtectedMove>;
@@ -108,6 +121,7 @@ struct ProtectedCopyWithMove {
   int fromBase = 111;
   ProtectedCopyWithMove() = default;
   ProtectedCopyWithMove(ProtectedCopyWithMove &&) = default;
+
 protected:
   // NOTE: the copy has an incremented fromBase, so we can check at runtime that
   // the correct custom copy operation took place
@@ -117,6 +131,9 @@ protected:
 struct InheritsProtectedCopyWithMove : ProtectedCopyWithMove {
   int getFromBase(void) const { return fromBase; }
   void setFromBase(int x) { fromBase = x; }
+
+  // This is used to fake out the Swift optimizer to ensure that copies aren't elided.
+  void fakeMutation() {}
 };
 
 struct ProtectedCopyWithMoveField {

--- a/test/Interop/Cxx/class/inheritance/protected-special-member-executable.swift
+++ b/test/Interop/Cxx/class/inheritance/protected-special-member-executable.swift
@@ -2,9 +2,8 @@
 //
 // REQUIRES: executable_test
 //
-// REQUIRES: rdar168302720
-// Fails on Windows：  https://github.com/swiftlang/swift/issues/67288
-// Fails on non-macOS: https://github.com/swiftlang/swift/issues/86426
+// UNSUPPORTED: OS=windows-msvc
+// Fails on Windows due to https://github.com/swiftlang/swift/issues/67288
 
 import StdlibUnittest
 import ProtectedSpecialMember
@@ -38,26 +37,31 @@ ProtectedSpecialMemberTestSuite.test("class that privately inherits protected de
 
 ProtectedSpecialMemberTestSuite.test("class that inherits protected copy constructor") {
   let c1 = InheritsProtectedCopy()
-  let c2 = c1
+  var c2 = c1
+  c2.fakeMutation() // ensure c2 is a distinct copy
+
   expectEqual(111, c1.getFromBase())
   expectEqual(112, c2.getFromBase())
 
   var c3 = InheritsProtectedCopy()
   c3.setFromBase(66)
-  let c4 = c3
+  var c4 = c3
+  c4.fakeMutation() // ensure c4 is a distinct copy
   expectEqual(66, c3.getFromBase())
   expectEqual(67, c4.getFromBase())
 }
 
 ProtectedSpecialMemberTestSuite.test("classes that privately inherit protected copy constructor") {
   let c1 = PrivatelyInheritsProtectedCopy()
-  let c2 = c1
+  var c2 = c1
+  c2.fakeMutation()
   expectEqual(111, c1.getFromBase())
   expectEqual(112, c2.getFromBase())
 
   var c3 = PrivatelyInheritsProtectedCopy()
   c3.setFromBase(66)
-  let c4 = c3
+  var c4 = c3
+  c4.fakeMutation()
   expectEqual(66, c3.getFromBase())
   expectEqual(67, c4.getFromBase())
 
@@ -71,10 +75,15 @@ ProtectedSpecialMemberTestSuite.test("class that contains vector of class that i
   expectEqual(201, v1.get(1))
   expectEqual(301, v1.get(2))
 
-  let v2 = v1 // Invokes copy ctor of std::vector<InheritsProtectedCopy>,
+  var v2 = v1 // Invokes copy ctor of std::vector<InheritsProtectedCopy>,
               // which invokes copy ctor of InheritsProtectedCopy elements,
               // thus incrementing each value
 
+  v2.fakeMutation() // ensure v2 is a distinct copy
+
+  expectEqual(101, v1.get(0))
+  expectEqual(201, v1.get(1))
+  expectEqual(301, v1.get(2))
   expectEqual(102, v2.get(0))
   expectEqual(202, v2.get(1))
   expectEqual(302, v2.get(2))
@@ -99,7 +108,8 @@ ProtectedSpecialMemberTestSuite.test("class with public move and protected copy"
 ProtectedSpecialMemberTestSuite.test("class that inherits public move and protected copy") {
   var c3 = InheritsProtectedCopyWithMove()
   c3.setFromBase(66)
-  let c4 = c3
+  var c4 = c3
+  c4.fakeMutation()
   expectEqual(66, c3.getFromBase())
   expectEqual(67, c4.getFromBase())
 }

--- a/test/Interop/Cxx/class/inheritance/protected-special-member-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/protected-special-member-module-interface.swift
@@ -20,12 +20,14 @@
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   func getFromBase() -> Int32
 // CHECK-NEXT:   mutating func setFromBase(_ x: Int32)
+// CHECK-NEXT:   mutating func fakeMutation()
 // CHECK-NEXT: }
 
 // CHECK:      struct PrivatelyInheritsProtectedCopy {
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   func getFromBase() -> Int32
 // CHECK-NEXT:   mutating func setFromBase(_ x: Int32)
+// CHECK-NEXT:   mutating func fakeMutation()
 // CHECK-NEXT: }
 
 // CHECK:      struct PrivatelyInheritsPrivatelyInheritsProtectedCopy {
@@ -36,6 +38,7 @@
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   func getFromBase() -> Int32
 // CHECK-NEXT:   mutating func setFromBase(_ x: Int32)
+// CHECK-NEXT:   mutating func fakeMutation()
 // CHECK-NEXT: }
 
 // CHECK:      struct ProtectedCopyWithMove : ~Copyable {
@@ -48,4 +51,5 @@
 // CHECK-NEXT:   var fromBase: Int32
 // CHECK-NEXT:   func getFromBase() -> Int32
 // CHECK-NEXT:   mutating func setFromBase(_ x: Int32)
+// CHECK-NEXT:   mutating func fakeMutation()
 // CHECK-NEXT: }


### PR DESCRIPTION
As it turns out, there isn't actually any miscompilation bug here. Instead, this test fails because it relies on calls to side-effectful copy constructors, which the Swift has greater freedom to eliminate than C++ (because Swift let-bindings don't necessitate a copy).

Performing fake "mutations" to these values ensure that they are copied.

Closes #86426.

rdar://168302720