### PR TITLE
[APIGen] Record SPI-available symbols as public

### DIFF
--- a/lib/IRGen/TBDGen.cpp
+++ b/lib/IRGen/TBDGen.cpp
@@ -718,7 +718,7 @@ class APIGenRecorder final : public APIRecorder {
         return true;
     }
 
-    return decl->isSPI() || getAvailability(decl).spiAvailable;
+    return decl->isSPI();
   }
 
 public:

--- a/test/APIJSON/library-level.swift
+++ b/test/APIJSON/library-level.swift
@@ -97,7 +97,8 @@ public func spiAvailableFunc() {}
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule0A6Class2C18spiAvailableMethodyyFTj",
-// CHECK-NEXT:       "access": "private",
+// API-NEXT:         "access": "public",
+// NON-API-NEXT:     "access": "private",
 // CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/library-level.swift",
 // CHECK-NEXT:       "linkage": "exported",
 // CHECK-NEXT:       "introduced": "10.10",
@@ -105,7 +106,8 @@ public func spiAvailableFunc() {}
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule0A6Class2C18spiAvailableMethodyyFTq",
-// CHECK-NEXT:       "access": "private",
+// API-NEXT:         "access": "public",
+// NON-API-NEXT:     "access": "private",
 // CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/library-level.swift",
 // CHECK-NEXT:       "linkage": "exported",
 // CHECK-NEXT:       "introduced": "10.10",
@@ -187,7 +189,8 @@ public func spiAvailableFunc() {}
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule16spiAvailableFuncyyF",
-// CHECK-NEXT:       "access": "private",
+// API-NEXT:         "access": "public",
+// NON-API-NEXT:     "access": "private",
 // CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/library-level.swift",
 // CHECK-NEXT:       "linkage": "exported",
 // CHECK-NEXT:       "introduced": "10.10",
@@ -230,7 +233,8 @@ public func spiAvailableFunc() {}
 // CHECK-NEXT:         },
 // CHECK-NEXT:         {
 // CHECK-NEXT:           "name": "spiAvailableMethod",
-// CHECK-NEXT:           "access": "private",
+// API-NEXT:             "access": "public",
+// NON-API-NEXT:         "access": "private",
 // CHECK-NEXT:           "file": "SOURCE_DIR/test/APIJSON/library-level.swift",
 // CHECK-NEXT:           "introduced": "10.10",
 // CHECK-NEXT:           "SPIAvailable": true

--- a/test/APIJSON/spi.swift
+++ b/test/APIJSON/spi.swift
@@ -96,7 +96,7 @@ public class SPIClass {
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule0A6Class2C18spiAvailableMethodyyFTj",
-// CHECK-NEXT:       "access": "private",
+// CHECK-NEXT:       "access": "public",
 // CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
 // CHECK-NEXT:       "linkage": "exported",
 // CHECK-NEXT:       "introduced": "10.10",
@@ -104,7 +104,7 @@ public class SPIClass {
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule0A6Class2C18spiAvailableMethodyyFTq",
-// CHECK-NEXT:       "access": "private",
+// CHECK-NEXT:       "access": "public",
 // CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
 // CHECK-NEXT:       "linkage": "exported",
 // CHECK-NEXT:       "introduced": "10.10",
@@ -178,7 +178,7 @@ public class SPIClass {
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule16spiAvailableFuncyyF",
-// CHECK-NEXT:       "access": "private",
+// CHECK-NEXT:       "access": "public",
 // CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
 // CHECK-NEXT:       "linkage": "exported",
 // CHECK-NEXT:       "introduced": "10.10",
@@ -186,7 +186,7 @@ public class SPIClass {
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule8SPIClassC18noAvailabilityAttryyFTj",
-// CHECK-NEXT:       "access": "private",
+// CHECK-NEXT:       "access": "public",
 // CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
 // CHECK-NEXT:       "linkage": "exported",
 // CHECK-NEXT:       "introduced": "11",
@@ -194,7 +194,7 @@ public class SPIClass {
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule8SPIClassC18noAvailabilityAttryyFTq",
-// CHECK-NEXT:       "access": "private",
+// CHECK-NEXT:       "access": "public",
 // CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
 // CHECK-NEXT:       "linkage": "exported",
 // CHECK-NEXT:       "introduced": "11",
@@ -202,7 +202,7 @@ public class SPIClass {
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule8SPIClassCMa",
-// CHECK-NEXT:       "access": "private",
+// CHECK-NEXT:       "access": "public",
 // CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
 // CHECK-NEXT:       "linkage": "exported",
 // CHECK-NEXT:       "introduced": "11",
@@ -210,7 +210,7 @@ public class SPIClass {
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule8SPIClassCMm",
-// CHECK-NEXT:       "access": "private",
+// CHECK-NEXT:       "access": "public",
 // CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
 // CHECK-NEXT:       "linkage": "exported",
 // CHECK-NEXT:       "introduced": "11",
@@ -218,7 +218,7 @@ public class SPIClass {
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule8SPIClassCMn",
-// CHECK-NEXT:       "access": "private",
+// CHECK-NEXT:       "access": "public",
 // CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
 // CHECK-NEXT:       "linkage": "exported",
 // CHECK-NEXT:       "introduced": "11",
@@ -226,7 +226,7 @@ public class SPIClass {
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule8SPIClassCMo",
-// CHECK-NEXT:       "access": "private",
+// CHECK-NEXT:       "access": "public",
 // CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
 // CHECK-NEXT:       "linkage": "exported",
 // CHECK-NEXT:       "introduced": "11",
@@ -234,7 +234,7 @@ public class SPIClass {
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule8SPIClassCMu",
-// CHECK-NEXT:       "access": "private",
+// CHECK-NEXT:       "access": "public",
 // CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
 // CHECK-NEXT:       "linkage": "exported",
 // CHECK-NEXT:       "introduced": "11",
@@ -242,7 +242,7 @@ public class SPIClass {
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule8SPIClassCN",
-// CHECK-NEXT:       "access": "private",
+// CHECK-NEXT:       "access": "public",
 // CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
 // CHECK-NEXT:       "linkage": "exported",
 // CHECK-NEXT:       "introduced": "11",
@@ -250,7 +250,7 @@ public class SPIClass {
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule8SPIClassCfD",
-// CHECK-NEXT:       "access": "private",
+// CHECK-NEXT:       "access": "public",
 // CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
 // CHECK-NEXT:       "linkage": "exported",
 // CHECK-NEXT:       "introduced": "11",
@@ -258,7 +258,7 @@ public class SPIClass {
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule8SPIClassCfd",
-// CHECK-NEXT:       "access": "private",
+// CHECK-NEXT:       "access": "public",
 // CHECK-NEXT:       "file": "SOURCE_DIR/test/APIJSON/spi.swift",
 // CHECK-NEXT:       "linkage": "exported",
 // CHECK-NEXT:       "introduced": "11",
@@ -300,7 +300,7 @@ public class SPIClass {
 // CHECK-NEXT:         },
 // CHECK-NEXT:         {
 // CHECK-NEXT:           "name": "spiAvailableMethod",
-// CHECK-NEXT:           "access": "private",
+// CHECK-NEXT:           "access": "public",
 // CHECK-NEXT:           "file": "SOURCE_DIR/test/APIJSON/spi.swift",
 // CHECK-NEXT:           "introduced": "10.10",
 // CHECK-NEXT:           "SPIAvailable": true


### PR DESCRIPTION
Swift emits references to SPI-available symbols in some cases, so we can't really mark these as private.

rdar://172320860

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
