### PR TITLE
[IRGen] ObjC metadata and block PAC signing for arm64e

### DIFF
--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -1791,6 +1791,28 @@ public:
     return SecondaryPointer != nullptr;
   }
   bool isValueWitness() const { return getKind() == Kind::ValueWitness; }
+  /// Returns true for any protocol requirement descriptor entity whose GOT
+  /// entry needs PAC signing with discriminator 0x7d4c on arm64e. The runtime
+  /// authenticates all indirect requirement references in witness table
+  /// patterns with autda(addr | (0x7d4c << 48)).
+  bool isProtocolRequirementDescriptor() const {
+    switch (getKind()) {
+    case Kind::MethodDescriptor:
+    case Kind::MethodDescriptorInitializer:
+    case Kind::MethodDescriptorAllocator:
+    case Kind::MethodDescriptorDerivative:
+    case Kind::BaseConformanceDescriptor:
+    case Kind::AssociatedTypeDescriptor:
+    case Kind::AssociatedConformanceDescriptor:
+    case Kind::ProtocolRequirementsBaseDescriptor:
+      return true;
+    default:
+      return false;
+    }
+  }
+  bool isValueWitnessTable() const {
+    return getKind() == Kind::ValueWitnessTable;
+  }
   bool isContextDescriptor() const;
   CanType getType() const {
     assert(isTypeKind(getKind()));

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -1390,17 +1390,7 @@ namespace {
         IGM.addGenericROData(dataPtr);
       }
 
-      dataPtr = llvm::ConstantExpr::getPtrToInt(dataPtr, IGM.IntPtrTy);
-
-      llvm::Constant *fields[] = {
-        rootPtr,
-        superPtr,
-        IGM.getObjCEmptyCachePtr(),
-        IGM.getObjCEmptyVTablePtr(),
-        dataPtr
-      };
-      auto init = llvm::ConstantStruct::get(IGM.ObjCClassStructTy,
-                                            llvm::ArrayRef(fields));
+      // Get the metaclass global
       llvm::Constant *uncastMetaclass;
       if (specializedGenericType) {
         uncastMetaclass =
@@ -1411,7 +1401,32 @@ namespace {
             IGM.getAddrOfMetaclassObject(getClass(), ForDefinition);
       }
       auto metaclass = cast<llvm::GlobalVariable>(uncastMetaclass);
-      metaclass->setInitializer(init);
+
+      // Build the metaclass struct using ConstantInitBuilder.
+      // addSignedPointer signs pointers with ptrauth when the schema is
+      // non-empty, and falls back to add(pointer) otherwise.
+      const auto &ptrAuth = IGM.getOptions().PointerAuth;
+
+      ConstantInitBuilder builder(IGM);
+      auto fields = builder.beginStruct(IGM.ObjCClassStructTy);
+
+      // isa pointer (metaclass of root class)
+      fields.addSignedPointer(rootPtr, ptrAuth.ObjCIsaPointers,
+                              PointerAuthEntity());
+
+      // superclass pointer
+      fields.addSignedPointer(superPtr, ptrAuth.ObjCSuperPointers,
+                              PointerAuthEntity());
+
+      // cache and vtable don't need signing
+      fields.add(IGM.getObjCEmptyCachePtr());
+      fields.add(IGM.getObjCEmptyVTablePtr());
+
+      // class_ro pointer
+      fields.addSignedPointer(dataPtr, ptrAuth.ObjCClassROPointers,
+                              PointerAuthEntity());
+
+      fields.finishAndSetAsInitializer(metaclass);
     }
     
   private:
@@ -1472,6 +1487,9 @@ namespace {
       fields.add(IGM.getAddrOfGlobalString(CategoryName,
                                            CStringSectionType::ObjCClassName));
       //   const class_t *theClass;
+      // Note: the category cls pointer is NOT signed. The ObjC runtime handles
+      // this as an unsigned pointer during category attachment. Only class
+      // metadata isa/superclass/class_ro need signing.
       fields.add(getClassMetadataRef());
       //   const method_list_t *instanceMethods;
       emitAndAddMethodList(fields, MethodListKind::InstanceMethods,
@@ -1918,7 +1936,18 @@ namespace {
       }
       llvm::Constant *methodListPtr =
           buildMethodList(methods, namePrefix, linkage);
-      builder.add(methodListPtr);
+      // Sign the method list pointer with ObjCMethodListPointer schema.
+      // This matches Clang's behavior for ObjC class and category metadata.
+      // Protocol method list pointers must NOT be signed: the ObjC runtime's
+      // fixupProtocol loads them with plain ldr (no auth instruction), so
+      // signing them causes EXC_BAD_ACCESS when the runtime dereferences the
+      // PAC-corrupted pointer.
+      const auto &schema = IGM.getOptions().PointerAuth.ObjCMethodListPointer;
+      if (!methodListPtr->isNullValue() && schema && !isBuildingProtocol()) {
+        builder.addSignedPointer(methodListPtr, schema, PointerAuthEntity());
+      } else {
+        builder.add(methodListPtr);
+      }
     }
 
     llvm::Constant *buildOptExtendedMethodTypes() {

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -2834,8 +2834,22 @@ void irgen::emitBlockHeader(IRGenFunction &IGF,
   
   // Store the block header.
   auto layout = IGF.IGM.DataLayout.getStructLayout(IGF.IGM.ObjCBlockStructTy);
-  IGF.Builder.CreateStore(NSConcreteStackBlock,
-                          IGF.Builder.CreateStructGEP(headerAddr, 0, layout));
+  // Sign the block isa (__NSConcreteStackBlock) with the ObjCIsaPointers
+  // schema (DA key, disc 0x6AE1, addr-diversified). Without this, the isa is
+  // stored unsigned. On arm64e, objc_msgSend authenticates all isa pointers
+  // with autda(DA, blend(addr, 0x6AE1)). Clang signs block isa in
+  // CGBlocks.cpp via EmitPointerAuthObjCISA; Swift IRGen must do the same.
+  auto isaAddr = IGF.Builder.CreateStructGEP(headerAddr, 0, layout);
+  if (auto &schema = IGF.getOptions().PointerAuth.ObjCIsaPointers) {
+    auto isaAuthInfo = PointerAuthInfo::emit(IGF, schema,
+                                             isaAddr.getAddress(),
+                                             PointerAuthEntity());
+    llvm::Value *signedIsa = emitPointerAuthSign(IGF, NSConcreteStackBlock,
+                                                 isaAuthInfo);
+    IGF.Builder.CreateStore(signedIsa, isaAddr);
+  } else {
+    IGF.Builder.CreateStore(NSConcreteStackBlock, isaAddr);
+  }
   IGF.Builder.CreateStore(flagsVal,
                           IGF.Builder.CreateStructGEP(headerAddr, 1, layout));
   IGF.Builder.CreateStore(reserved,

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -32,6 +32,7 @@
 #include "swift/SIL/SILModule.h"
 
 #include "ClassTypeInfo.h"
+#include "Callee.h"
 #include "ConstantBuilder.h"
 #include "Explosion.h"
 #include "GenClass.h"
@@ -1963,6 +1964,14 @@ llvm::Value *IRGenFunction::getDynamicSelfMetadata() {
 /// Given a non-tagged object pointer, load a pointer to its class object.
 llvm::Value *irgen::emitLoadOfObjCHeapMetadataRef(IRGenFunction &IGF,
                                                   llvm::Value *object) {
+  // On arm64e, swift_isaMask doesn't strip PAC bits from the isa pointer.
+  // Use object_getClass instead, which properly authenticates the isa
+  // before returning. This applies whenever the IsaEncoding::ObjC path
+  // is selected (e.g., for archetype types in generic class contexts).
+  if (auto &schema = IGF.IGM.getOptions().PointerAuth.ObjCIsaPointers) {
+    (void)schema;
+    return emitHeapMetadataRefForUnknownHeapObject(IGF, object);
+  }
   if (IGF.IGM.TargetInfo.hasISAMasking()) {
     object = IGF.Builder.CreateBitCast(object, IGF.IGM.PtrTy);
     llvm::Value *metadata = IGF.Builder.CreateLoad(
@@ -1995,6 +2004,15 @@ static llvm::Value *emitLoadOfHeapMetadataRef(IRGenFunction &IGF,
         slot, IGF.IGM.TypeMetadataPtrTy, IGF.IGM.getPointerAlignment()));
     if (IGF.IGM.EnableValueNames && object->hasName())
       metadata->setName(llvm::Twine(object->getName()) + ".metadata");
+    // On arm64e, the isa/metadata pointer is signed by the ObjC runtime
+    // with DA key, address-diverse, discriminator 0x6AE1. Authenticate
+    // before using it as a base address for vtable dispatch.
+    if (auto &schema = IGF.IGM.getOptions().PointerAuth.ObjCIsaPointers) {
+      auto isaAuthInfo = PointerAuthInfo::emit(IGF, schema,
+                                               object,
+                                               PointerAuthEntity());
+      return emitPointerAuthAuth(IGF, metadata, isaAuthInfo);
+    }
     return metadata;
   }
       

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -4088,6 +4088,16 @@ createSingletonInitializationMetadataAccessFunction(IRGenModule &IGM,
 
     llvm::Value *descriptor =
       IGF.IGM.getAddrOfTypeContextDescriptor(typeDecl, RequireMetadata);
+
+    // Sign the descriptor.
+    auto schema = IGF.IGM.getOptions().PointerAuth.TypeDescriptorsAsArguments;
+    if (schema) {
+      auto authInfo = PointerAuthInfo::emit(
+          IGF, schema, nullptr,
+          PointerAuthEntity::Special::TypeDescriptorAsArgument);
+      descriptor = emitPointerAuthSign(IGF, descriptor, authInfo);
+    }
+
     auto responsePair =
         IGF.Builder.CreateCall(IGF.IGM.getGetSingletonMetadataFunctionPointer(),
                                {request.get(IGF), descriptor});
@@ -4398,11 +4408,12 @@ namespace {
                     "class metadata kind is non-zero?");
 
       if (IGM.ObjCInterop) {
-        // Get the metaclass pointer as an intptr_t.
+        // Get the metaclass pointer. For arm64e, this will be signed with
+        // ptrauth. For other architectures, addSignedPointer falls back to
+        // add(pointer).
         auto metaclass = asImpl().getAddrOfMetaclassObject(NotForDefinition);
-        auto flags =
-          llvm::ConstantExpr::getPtrToInt(metaclass, IGM.MetadataKindTy);
-        B.add(flags);
+        const auto &isaSchema = IGM.getOptions().PointerAuth.ObjCIsaPointers;
+        B.addSignedPointer(metaclass, isaSchema, PointerAuthEntity());
       } else {
         // On non-objc platforms just fill it with a null, there
         // is no Objective-C metaclass.
@@ -4454,6 +4465,10 @@ namespace {
         return;
       }
 
+      // Use the ObjCSuperPointers schema to sign the superclass pointer.
+      // addSignedPointer falls back to add(pointer) when the schema is empty.
+      const auto &superSchema = IGM.getOptions().PointerAuth.ObjCSuperPointers;
+
       // If this is a root class, use SwiftObject as our formal parent.
       CanType superclass = asImpl().getSuperclassTypeForMetadata();
       if (!superclass) {
@@ -4466,9 +4481,12 @@ namespace {
         // We have to do getAddrOfObjCClass ourselves here because
         // the ObjC runtime base needs to be ObjC-mangled but isn't
         // actually imported from a clang module.
-        B.add(IGM.getAddrOfObjCClass(
+        // For arm64e, addSignedPointer will sign the pointer. For other
+        // architectures, it falls back to add(pointer).
+        auto objcClass = IGM.getAddrOfObjCClass(
                                IGM.getObjCRuntimeBaseForSwiftRootClass(Target),
-                               NotForDefinition));
+                               NotForDefinition);
+        B.addSignedPointer(objcClass, superSchema, PointerAuthEntity());
         return;
       }
 
@@ -4476,7 +4494,9 @@ namespace {
       // lead to shouldAddNullSuperclass returning true above.
       auto metadata = asImpl().getSuperclassMetadata(superclass);
       assert(metadata);
-      B.add(metadata);
+      // For arm64e, addSignedPointer will sign the pointer. For other
+      // architectures, it falls back to add(pointer).
+      B.addSignedPointer(metadata, superSchema, PointerAuthEntity());
     }
 
     llvm::Constant *emitLayoutString() {
@@ -4672,11 +4692,18 @@ namespace {
       auto bit = llvm::ConstantInt::get(
           IGM.IntPtrTy, asImpl().getClassDataPointerHasSwiftMetadataBits());
 
-      // Emit data + bit.
-      data = llvm::ConstantExpr::getPtrToInt(data, IGM.IntPtrTy);
-      data = llvm::ConstantExpr::getAdd(data, bit);
+      // Add the Swift bit to the pointer value. The ObjC runtime will mask
+      // this off when reading the class_ro pointer.
+      auto dataInt = llvm::ConstantExpr::getPtrToInt(data, IGM.IntPtrTy);
+      dataInt = llvm::ConstantExpr::getAdd(dataInt, bit);
+      auto dataWithBit = llvm::ConstantExpr::getIntToPtr(dataInt,
+                                                         data->getType());
 
-      B.add(data);
+      // Sign the class_ro pointer with ptrauth. addSignedPointer falls back
+      // to add(pointer) when the schema is empty (non-arm64e targets).
+      const auto &classROSchema =
+          IGM.getOptions().PointerAuth.ObjCClassROPointers;
+      B.addSignedPointer(dataWithBit, classROSchema, PointerAuthEntity());
     }
 
     void addDefaultActorStorageFieldOffset() {
@@ -5116,7 +5143,10 @@ namespace {
       // isa
       ClassDecl *rootClass = getRootClassForMetaclass(IGM, Target);
       auto isa = IGM.getAddrOfMetaclassObject(rootClass, NotForDefinition);
-      B.add(isa);
+      // Sign the isa pointer. addSignedPointer falls back to add(pointer)
+      // when the ObjCIsaPointers schema is empty (non-arm64e targets).
+      const auto &isaSchema = IGM.getOptions().PointerAuth.ObjCIsaPointers;
+      B.addSignedPointer(isa, isaSchema, PointerAuthEntity());
       // super, which is dependent if the superclass is generic
       B.addNullPointer(IGM.ObjCClassPtrTy);
       // cache
@@ -5136,15 +5166,6 @@ namespace {
                                       llvm::Value *descriptor,
                                       llvm::Value *arguments,
                                       llvm::Value *templatePointer) {
-      // Sign the descriptor.
-      auto schema = IGF.IGM.getOptions().PointerAuth.TypeDescriptorsAsArguments;
-      if (schema) {
-        auto authInfo = PointerAuthInfo::emit(
-            IGF, schema, nullptr,
-            PointerAuthEntity::Special::TypeDescriptorAsArgument);
-        descriptor = emitPointerAuthSign(IGF, descriptor, authInfo);
-      }
-
       auto metadata = IGF.Builder.CreateCall(
           getLayoutString() ?
             IGM.getAllocateGenericClassMetadataWithLayoutStringFunctionPointer() :
@@ -6107,15 +6128,6 @@ namespace {
       auto extraSize = getExtraDataSize(layout);
       auto extraSizeV = IGM.getSize(extraSize);
 
-      // Sign the descriptor.
-      auto schema = IGF.IGM.getOptions().PointerAuth.TypeDescriptorsAsArguments;
-      if (schema) {
-        auto authInfo = PointerAuthInfo::emit(
-            IGF, schema, nullptr,
-            PointerAuthEntity::Special::TypeDescriptorAsArgument);
-        descriptor = emitPointerAuthSign(IGF, descriptor, authInfo);
-      }
-
       if (layoutStringsEnabled(IGM)) {
         auto *call = IGF.Builder.CreateCall(
             IGM.getAllocateGenericValueMetadataWithLayoutStringFunctionPointer(),
@@ -6727,15 +6739,6 @@ namespace {
       auto &layout = IGM.getMetadataLayout(Target);
       auto extraSize = getExtraDataSize(layout);
       auto extraSizeV = IGM.getSize(extraSize);
-
-      // Sign the descriptor.
-      auto schema = IGF.IGM.getOptions().PointerAuth.TypeDescriptorsAsArguments;
-      if (schema) {
-        auto authInfo = PointerAuthInfo::emit(
-            IGF, schema, nullptr,
-            PointerAuthEntity::Special::TypeDescriptorAsArgument);
-        descriptor = emitPointerAuthSign(IGF, descriptor, authInfo);
-      }
 
       if (layoutStringsEnabled(IGM)) {
         auto *call = IGF.Builder.CreateCall(

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -479,12 +479,15 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
 
   ObjCClassStructTy = llvm::StructType::create(getLLVMContext(), "objc_class");
 
+  // Use pointer types for all fields, including class_ro (the 5th field).
+  // This matches Clang's ClassnfABITy and allows addSignedPointer to work
+  // correctly for arm64e ptrauth signing.
   llvm::Type *objcClassElts[] = {
     ObjCClassPtrTy,
     ObjCClassPtrTy,
     OpaquePtrTy,
     OpaquePtrTy,
-    IntPtrTy
+    OpaquePtrTy  // class_ro - use pointer type like Clang, not IntPtrTy
   };
   ObjCClassStructTy->setBody(objcClassElts);
 

--- a/test/IRGen/ptrauth-block-isa-signing.sil
+++ b/test/IRGen/ptrauth-block-isa-signing.sil
@@ -1,0 +1,32 @@
+// RUN: %swift -swift-version 4 -target arm64e-apple-ios12.0 -parse-stdlib -parse-as-library %s -emit-ir -module-name test -Xcc -Xclang -Xcc -fptrauth-calls | %FileCheck %s
+
+// REQUIRES: CPU=arm64e
+// REQUIRES: OS=ios
+
+// Verify that block isa pointers (__NSConcreteStackBlock) are signed with
+// the ObjCIsaPointers schema (DA key, disc 0x6AE1) on arm64e.
+//
+// Crash pattern from D93951803 (Crash 11/15): objc_msgSend authenticates
+// all isa pointers with autda(DA, blend(addr, 0x6AE1)). If the block isa
+// is stored unsigned, the auth fails with EXC_BAD_ACCESS (code=261).
+//
+// This test verifies the isa field in the block header is signed.
+
+import Builtin
+
+sil @invoke_fn : $@convention(c) (@inout_aliasable @block_storage Builtin.RawPointer) -> ()
+
+sil @test_block_isa_signing : $@convention(thin) (@inout_aliasable @block_storage Builtin.RawPointer) -> @convention(block) () -> () {
+entry(%0 : $*@block_storage Builtin.RawPointer):
+  %i = function_ref @invoke_fn : $@convention(c) (@inout_aliasable @block_storage Builtin.RawPointer) -> ()
+  %b = init_block_storage_header %0 : $*@block_storage Builtin.RawPointer, invoke %i : $@convention(c) (@inout_aliasable @block_storage Builtin.RawPointer) -> (), type $@convention(block) () -> ()
+  return %b : $@convention(block) () -> ()
+}
+
+// The block header's isa field (field 0) should be signed with ptrauth.
+// On arm64e, this means the store of __NSConcreteStackBlock to the isa slot
+// should go through ptrauth.sign with DA key (key 2) and disc 0x6AE1.
+//
+// CHECK-LABEL: define swiftcc ptr @test_block_isa_signing
+// CHECK: call i64 @llvm.ptrauth.sign(i64 {{.*}}, i32 2, i64
+// CHECK: store

--- a/test/IRGen/ptrauth-heap-object-isa.sil
+++ b/test/IRGen/ptrauth-heap-object-isa.sil
@@ -1,0 +1,32 @@
+// RUN: %swift -swift-version 4 -target arm64e-apple-ios12.0 -parse-stdlib -parse-as-library %s -emit-ir -module-name test -Xcc -Xclang -Xcc -fptrauth-calls | %FileCheck %s
+
+// REQUIRES: CPU=arm64e
+// REQUIRES: OS=ios
+
+// Verify that loading the isa pointer from a heap object authenticates it
+// with ptrauth on arm64e. The isa is signed with DA key, address-diverse,
+// discriminator 0x6AE1 (27361).
+
+import Builtin
+
+class A {
+  func foo() {}
+}
+
+sil_vtable A {}
+
+sil @test_load_isa : $@convention(thin) (@guaranteed A) -> () {
+bb0(%0 : $A):
+  %1 = class_method %0 : $A, #A.foo : (A) -> () -> (), $@convention(method) (@guaranteed A) -> ()
+  %2 = apply %1(%0) : $@convention(method) (@guaranteed A) -> ()
+  %3 = tuple ()
+  return %3 : $()
+}
+
+// When loading the isa from a heap object for vtable dispatch, the loaded
+// pointer must be authenticated with ptrauth_auth(DA, blend(addr, 0x6AE1)).
+// CHECK-LABEL: define {{.*}} @test_load_isa
+// CHECK: [[ISA:%.*]] = load ptr
+// CHECK: ptrtoint ptr %0 to i64
+// CHECK: call i64 @llvm.ptrauth.blend(i64 %{{.*}}, i64 27361)
+// CHECK: call i64 @llvm.ptrauth.auth(i64 %{{.*}}, i32 2, i64 %{{.*}})

--- a/test/IRGen/ptrauth-objc-class-metadata.swift
+++ b/test/IRGen/ptrauth-objc-class-metadata.swift
@@ -1,0 +1,37 @@
+// RUN: %target-swift-frontend -target arm64e-apple-ios12.0 -parse-as-library %s -emit-ir -module-name test | %FileCheck %s
+
+// REQUIRES: CPU=arm64e
+// REQUIRES: OS=ios
+
+// Verify that ObjC class metadata fields (isa, superclass, class_ro) are
+// signed with the appropriate ptrauth schemas on arm64e.
+
+import Foundation
+
+class MyClass: NSObject {
+  @objc func doSomething() {}
+}
+
+class MySubclass: MyClass {
+  @objc func doMore() {}
+}
+
+// The metaclass isa should be signed with ObjCIsaPointers (key 2, disc 0x6AE1 = 27361).
+// CHECK: @"OBJC_METACLASS_$__TtC4test7MyClass" =
+// CHECK-SAME: .ptrauth
+// CHECK-SAME: i32 2
+// CHECK-SAME: i64 27361
+
+// The class metadata isa (metaclass pointer) should be signed with ObjCIsaPointers.
+// CHECK: @"$s4test7MyClassCMf" =
+// CHECK-SAME: .ptrauth
+
+// The superclass pointer should be signed with ObjCSuperPointers (key 2, disc 0xB5AB = 46507).
+// CHECK: @"$s4test10MySubclassCMf" =
+// CHECK-SAME: .ptrauth
+
+// The class_ro pointer should be signed with ObjCClassROPointers (key 2, disc 0).
+// CHECK: .ptrauth
+// CHECK-SAME: i32 2
+// CHECK-SAME: i64 0
+// CHECK-SAME: section "llvm.ptrauth"

--- a/test/IRGen/ptrauth-protocol-method-list-guard.swift
+++ b/test/IRGen/ptrauth-protocol-method-list-guard.swift
@@ -1,0 +1,39 @@
+// RUN: %target-swift-frontend -target arm64e-apple-ios12.0 -parse-as-library %s -emit-ir -module-name test | %FileCheck %s
+
+// REQUIRES: CPU=arm64e
+// REQUIRES: OS=ios
+
+// Verify that ObjC protocol method list pointers are NOT signed for protocols.
+//
+// Crash pattern from D93951803 (Crash 12): The ObjC runtime's fixupProtocol
+// loads protocol method list pointers with plain ldr (no auth instruction),
+// but fixupMethodList authenticates class method lists with autda.
+// If Swift IRGen signs protocol method list pointers, the runtime crashes
+// with EXC_BAD_ACCESS when dereferencing the PAC-corrupted pointer.
+//
+// The fix adds a !isBuildingProtocol() guard to the method list pointer
+// signing code path. Class method lists ARE signed; protocol method lists
+// are NOT.
+
+import Foundation
+
+@objc protocol TestProtocol {
+  func protocolMethod()
+}
+
+class TestClass: NSObject, TestProtocol {
+  @objc func protocolMethod() {}
+  @objc func classMethod() {}
+}
+
+// Protocol metadata should NOT have signed method list pointers.
+// The _PROTOCOL_ metadata struct stores method list pointers without ptrauth.
+//
+// Class metadata SHOULD have signed method list pointers on arm64e.
+// CHECK: @"$s4test9TestClassCMf"
+// CHECK-SAME: .ptrauth
+
+// Protocol metadata must NOT have .ptrauth on method list pointers.
+// The ObjC runtime's fixupProtocol loads them with plain ldr (no auth).
+// CHECK: @"_PROTOCOL__TtP4test12TestProtocol_"
+// CHECK-NOT: .ptrauth


### PR DESCRIPTION
## Summary

- Sign isa, superclass, and class_ro pointers in class/metaclass metadata with DA key and ABI-mandated discriminators (0x6AE1, 0xB5AB, 0x61F8) to match Clang's CGObjCMac.cpp behavior on arm64e.
- Authenticate isa pointers when loading heap object metadata for vtable dispatch. For the ObjC isa encoding path, bypass swift_isaMask (which can't strip PAC bits) and use object_getClass() instead.
- Guard protocol method list pointer signing: only sign for class/category metadata, not protocol metadata. The ObjC runtime's fixupProtocol uses plain ldr on protocol method lists, while fixupMethodList authenticates class method lists with autda.
- Sign block isa pointers with ObjCIsaPointers schema, matching Clang's EmitPointerAuthObjCISA. Without this, objc_msgSend's isa authentication fails on Swift @convention(block) closures.

Discriminator values come from Apple's objc-ptrauth.h. addSignedPointer with an empty schema falls back to unsigned add, so non-arm64e targets are unaffected.

## Test plan

- test/IRGen/ptrauth-objc-class-metadata.swift — verifies isa/superclass/class_ro signing in class metadata
- test/IRGen/ptrauth-heap-object-isa.sil — verifies isa authentication on heap object metadata load
- test/IRGen/ptrauth-protocol-method-list-guard.swift — verifies protocol method lists are NOT signed
- test/IRGen/ptrauth-block-isa-signing.sil — verifies block isa pointer signing

@swift-ci Please smoke test