### PR TITLE
[ClangImporter] Handle DeclContexts that may not originate from Clang modules

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -5472,8 +5472,10 @@ namespace {
                                 ObjCSelector selector, bool forceClassMethod,
                                 std::optional<AccessorInfo> accessorInfo) {
       assert(dc->isTypeContext() && "Method in non-type context?");
-      assert(isa<ClangModuleUnit>(dc->getModuleScopeContext()) &&
-             "Clang method in Swift context?");
+      // If the DeclContext is not from a Clang module, this is a Swift-originated
+      // method being re-imported via a -Swift.h header. Skip it.
+      if (!isa<ClangModuleUnit>(dc->getModuleScopeContext()))
+        return nullptr;
 
       // FIXME: We should support returning "Self.Type" for a root class
       // instance method mirrored as a class method, but it currently causes
@@ -6004,7 +6006,9 @@ namespace {
                             bool hasKnownSwiftName = true) {
       if (!importer::hasNativeSwiftDecl(decl))
         return false;
-      auto wrapperUnit = cast<ClangModuleUnit>(dc->getModuleScopeContext());
+      auto wrapperUnit = dyn_cast<ClangModuleUnit>(dc->getModuleScopeContext());
+      if (!wrapperUnit)
+        return false;
       swiftDecl = resolveSwiftDecl<T>(decl, name, hasKnownSwiftName,
                                       wrapperUnit);
       return true;

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -88,8 +88,12 @@ class SubscriptDecl;
 class ValueDecl;
 
 /// Check whether the given declaration context is from a system module.
+/// Uses dyn_cast because the DeclContext may originate from a Swift module
+/// re-imported via a -Swift.h bridging header, not a Clang module.
 inline bool isInSystemModule(const DeclContext *D) {
-  return cast<ClangModuleUnit>(D->getModuleScopeContext())->isSystemModule();
+  if (auto *clangUnit = dyn_cast<ClangModuleUnit>(D->getModuleScopeContext()))
+    return clangUnit->isSystemModule();
+  return false;
 }
 
 /// Describes the kind of conversion to apply to a constant value.


### PR DESCRIPTION
## Summary

- Change cast<ClangModuleUnit> to dyn_cast<ClangModuleUnit> in three ClangImporter locations where the DeclContext may originate from a Swift module re-imported via a -Swift.h bridging header.
- The hard cast asserts when processing Swift-originated methods that come back through the Clang importer during bridging header processing. This occurs more frequently under arm64e due to additional ObjC metadata processing, but the fix is not arm64e-specific.
- The fix follows standard LLVM/Swift patterns for handling polymorphic DeclContexts. dyn_cast returns null and the existing fallback paths handle it.

## Test plan

- Existing ClangImporter tests continue to pass.
- Verified against projects that use -Swift.h bridging headers with ObjC interop.

@swift-ci Please smoke test