### PR TITLE
[Concurrency] Silence super verbose counters printing test

### DIFF
--- a/test/Concurrency/Runtime/actor_counters.swift
+++ b/test/Concurrency/Runtime/actor_counters.swift
@@ -10,6 +10,8 @@
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
 
+let printCounters = false
+
 @available(SwiftStdlib 5.1, *)
 actor Counter {
   private var value = 0
@@ -50,7 +52,9 @@ func worker(identity: Int, counters: [Counter], numIterations: Int) async {
     let counterIndex = Int.random(in: 0 ..< counters.count)
     let counter = counters[counterIndex]
     let nextValue = await counter.next()
-    print("Worker \(identity) calling counter \(counterIndex) produced \(nextValue)")
+    if printCounters {
+      print("Worker \(identity) calling counter \(counterIndex) produced \(nextValue)")
+    }
   }
 }
 

--- a/test/Sanitizers/tsan/actor_counters.swift
+++ b/test/Sanitizers/tsan/actor_counters.swift
@@ -10,6 +10,8 @@
 
 // REQUIRES: rdar83246843
 
+let printCounters = false
+
 @available(SwiftStdlib 5.1, *)
 actor Counter {
   private var value = 0
@@ -45,7 +47,9 @@ func worker(identity: Int, counters: [Counter], numIterations: Int) async {
     let counterIndex = Int.random(in: 0 ..< counters.count)
     let counter = counters[counterIndex]
     let nextValue = await counter.next()
-    print("Worker \(identity) calling counter \(counterIndex) produced \(nextValue)")
+    if printCounters {
+      print("Worker \(identity) calling counter \(counterIndex) produced \(nextValue)")
+    }
   }
 }
 


### PR DESCRIPTION
There's no real reason for this test to spam the command line every single time. Let's disable the printing.

The TSAN one has been disabled since ages, but applying the same thing for now.
