### PR TITLE
stdlib: Adopt `#if os(anyAppleOS)`

### DIFF
--- a/stdlib/private/StdlibUnittest/OpaqueIdentityFunctions.swift
+++ b/stdlib/private/StdlibUnittest/OpaqueIdentityFunctions.swift
@@ -77,7 +77,7 @@ public func getFloat32(_ x: Float32) -> Float32 { return _opaqueIdentity(x) }
 @inline(never)
 public func getFloat64(_ x: Float64) -> Float64 { return _opaqueIdentity(x) }
 
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !os(anyAppleOS))) && (arch(i386) || arch(x86_64))
 @inline(never)
 public func getFloat80(_ x: Float80) -> Float80 { return _opaqueIdentity(x) }
 #endif

--- a/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
+++ b/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
@@ -28,7 +28,7 @@ let RequestDone = "d"
 let RequestPointerSize = "p"
 
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
+#if os(anyAppleOS)
 internal import MachO
 internal import Darwin
 internal import var Darwin.errno

--- a/stdlib/public/Concurrency/CFExecutor.swift
+++ b/stdlib/public/Concurrency/CFExecutor.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if !$Embedded && (os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(visionOS))
+#if !$Embedded && os(anyAppleOS)
 
 import Swift
 

--- a/stdlib/public/Concurrency/Deque/Compatibility.swift
+++ b/stdlib/public/Concurrency/Deque/Compatibility.swift
@@ -33,7 +33,7 @@ extension Array {
     // The bug is caused by a bogus precondition inside a non-inlinable stdlib
     // method, so to determine if we're affected, we need to check the currently
     // running OS version.
-    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    #if os(anyAppleOS)
     guard #available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *) else {
       // The OS is too old to be affected by this bug.
       return false

--- a/stdlib/public/Concurrency/MainActor.swift
+++ b/stdlib/public/Concurrency/MainActor.swift
@@ -163,7 +163,7 @@ extension MainActor {
   }
 }
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
+#if os(anyAppleOS)
 @_extern(c, "pthread_main_np")
 @usableFromInline
 internal func pthread_main_np() -> CInt

--- a/stdlib/public/Concurrency/PlatformExecutorDarwin.swift
+++ b/stdlib/public/Concurrency/PlatformExecutorDarwin.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if !$Embedded && !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY && (os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(visionOS))
+#if !$Embedded && !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY && os(anyAppleOS)
 
 import Swift
 
@@ -34,4 +34,4 @@ public struct PlatformExecutorFactory: ExecutorFactory {
   }
 }
 
-#endif // os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
+#endif // os(anyAppleOS)

--- a/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
+++ b/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
@@ -26,7 +26,7 @@ def Availability(bits):
 }%
 
 % if bits == 80:
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !os(anyAppleOS))) && (arch(i386) || arch(x86_64))
 % end
 % if bits == 16:
 #if !os(macOS) && !(os(iOS) && targetEnvironment(macCatalyst))

--- a/stdlib/public/Differentiation/TgmathDerivatives.swift.gyb
+++ b/stdlib/public/Differentiation/TgmathDerivatives.swift.gyb
@@ -14,7 +14,7 @@
 
 import Swift
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
+#if os(anyAppleOS)
   #if canImport(tgmath_h)
     import tgmath_h
   #else
@@ -149,7 +149,7 @@ func _${derivative_kind}Trunc${generic_signature} (
 %  linear_map_kind = 'differential' if derivative_kind == 'jvp' else 'pullback'
 %  for T in ['Float', 'Double', 'Float80']:
 %    if T == 'Float80':
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !os(anyAppleOS))) && (arch(i386) || arch(x86_64))
 %    end
 @inlinable
 @derivative(of: exp)
@@ -290,7 +290,7 @@ func _${derivative_kind}Erfc(_ x: ${T}) -> (value: ${T}, ${linear_map_kind}: (${
 // Binary functions
 %for T in ['Float', 'Double', 'Float80']:
 %  if T == 'Float80':
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !os(anyAppleOS))) && (arch(i386) || arch(x86_64))
 %  end
 @inlinable
 @derivative(of: pow)

--- a/stdlib/public/Distributed/LocalTestingDistributedActorSystem.swift
+++ b/stdlib/public/Distributed/LocalTestingDistributedActorSystem.swift
@@ -238,7 +238,7 @@ public struct LocalTestingDistributedActorSystemError: DistributedActorSystemErr
 @available(SwiftStdlib 5.7, *)
 @safe
 fileprivate class _Lock {
-  #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS) || os(visionOS)
+  #if os(anyAppleOS)
   private let underlying: UnsafeMutablePointer<os_unfair_lock>
   #elseif os(Windows)
   private let underlying: UnsafeMutablePointer<SRWLOCK>
@@ -251,7 +251,7 @@ fileprivate class _Lock {
   #endif
 
   init() {
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS) || os(visionOS)
+    #if os(anyAppleOS)
     unsafe self.underlying = UnsafeMutablePointer.allocate(capacity: 1)
     unsafe self.underlying.initialize(to: os_unfair_lock())
     #elseif os(Windows)
@@ -268,7 +268,7 @@ fileprivate class _Lock {
   }
 
   deinit {
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS) || os(visionOS)
+    #if os(anyAppleOS)
     // `os_unfair_lock`s do not need to be explicitly destroyed
     #elseif os(Windows)
     // `SRWLOCK`s do not need to be explicitly destroyed
@@ -289,7 +289,7 @@ fileprivate class _Lock {
 
   @discardableResult
   func withLock<T>(_ body: () -> T) -> T {
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS) || os(visionOS)
+    #if os(anyAppleOS)
     unsafe os_unfair_lock_lock(self.underlying)
     #elseif os(Windows)
     unsafe AcquireSRWLockExclusive(self.underlying)
@@ -302,7 +302,7 @@ fileprivate class _Lock {
     #endif
 
     defer {
-      #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS) || os(visionOS)
+      #if os(anyAppleOS)
       unsafe os_unfair_lock_unlock(self.underlying)    
       #elseif os(Windows)
       unsafe ReleaseSRWLockExclusive(self.underlying)

--- a/stdlib/public/RuntimeModule/Backtrace.swift
+++ b/stdlib/public/RuntimeModule/Backtrace.swift
@@ -16,7 +16,7 @@
 
 import Swift
 
-// #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+// #if os(anyAppleOS)
 // internal import Darwin
 // #elseif os(Windows)
 // internal import ucrt
@@ -372,7 +372,7 @@ public struct Backtrace: CustomStringConvertible, Sendable {
     case Linux
     case Windows
 
-    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    #if os(anyAppleOS)
     static public let `default` = SymbolicationPlatform.Darwin
     #elseif os(Linux)
     static public let `default` = SymbolicationPlatform.Linux

--- a/stdlib/public/RuntimeModule/BacktraceFormatter.swift
+++ b/stdlib/public/RuntimeModule/BacktraceFormatter.swift
@@ -17,7 +17,7 @@
 
 import Swift
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(anyAppleOS)
 internal import Darwin
 internal import BacktracingImpl.OS.Darwin
 #elseif os(Windows)

--- a/stdlib/public/RuntimeModule/Compression.swift
+++ b/stdlib/public/RuntimeModule/Compression.swift
@@ -27,7 +27,7 @@
 
 import Swift
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(anyAppleOS)
 internal import Darwin
 #elseif os(Windows)
 internal import ucrt
@@ -64,7 +64,7 @@ protocol CompressedStream {
 
 // .. Compression library bindings .............................................
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(anyAppleOS)
 private var lzmaHandle = dlopen("liblzma.dylib", RTLD_LAZY)
 private var zlibHandle = dlopen("libz.dylib", RTLD_LAZY)
 private var zstdHandle = dlopen("libzstd.dylib", RTLD_LAZY)

--- a/stdlib/public/RuntimeModule/Context.swift
+++ b/stdlib/public/RuntimeModule/Context.swift
@@ -19,7 +19,7 @@
 
 import Swift
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(anyAppleOS)
 internal import Darwin
 #elseif os(Windows)
 internal import WinSDK
@@ -29,7 +29,7 @@ internal import Glibc
 internal import Musl
 #endif
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(anyAppleOS)
 internal import BacktracingImpl.OS.Darwin
 #elseif os(Windows)
 internal import BacktracingImpl.OS.Windows
@@ -436,7 +436,7 @@ extension arm_gprs {
     return (framePointer & 0xf) == 0
   }
 
-  #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+  #if os(anyAppleOS)
   internal static var coreSymbolicationArchitecture: CSArchitecture {
     return kCSArchitectureX86_64
   }
@@ -619,7 +619,7 @@ extension arm_gprs {
     return (framePointer & 0xf) == 8
   }
 
-  #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+  #if os(anyAppleOS)
   internal static var coreSymbolicationArchitecture: CSArchitecture {
     return kCSArchitectureI386
   }
@@ -830,7 +830,7 @@ extension arm_gprs {
     return (framePointer & 1) == 0
   }
 
-  #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+  #if os(anyAppleOS)
   public static func stripPtrAuth(address: Address) -> Address {
     // Is there a better way to do this?  It'd be easy if we just wanted to
     // strip for the *host*, but we might conceivably want this under other
@@ -980,7 +980,7 @@ extension arm_gprs {
     return (framePointer & 1) == 0
   }
 
-  #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+  #if os(anyAppleOS)
   internal static var coreSymbolicationArchitecture: CSArchitecture {
     return kCSArchitectureArmV7K
   }
@@ -1025,7 +1025,7 @@ extension arm_gprs {
 
 // .. Darwin specifics .........................................................
 
-#if (os(macOS) || os(iOS) || os(watchOS) || os(tvOS))
+#if os(anyAppleOS)
 private func thread_get_state<T>(_ thread: thread_t,
                                  _ flavor: CInt,
                                  _ result: inout T) -> kern_return_t {

--- a/stdlib/public/RuntimeModule/CoreSymbolication.swift
+++ b/stdlib/public/RuntimeModule/CoreSymbolication.swift
@@ -15,7 +15,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(anyAppleOS)
 
 import Swift
 

--- a/stdlib/public/RuntimeModule/Elf.swift
+++ b/stdlib/public/RuntimeModule/Elf.swift
@@ -19,7 +19,7 @@
 
 import Swift
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(anyAppleOS)
 internal import Darwin
 #elseif os(Windows)
 internal import WinSDK

--- a/stdlib/public/RuntimeModule/FramePointerUnwinder.swift
+++ b/stdlib/public/RuntimeModule/FramePointerUnwinder.swift
@@ -129,7 +129,7 @@ public struct FramePointerUnwinder<C: Context, M: MemoryReader>: Sequence, Itera
   @_specialize(exported: true, kind: full, where C == HostContext, M == MemserverMemoryReader)
   #endif
   private func isAsyncFrame(_ storedFp: Address) -> Bool {
-    #if (os(macOS) || os(iOS) || os(watchOS)) && (arch(arm64) || arch(arm64_32) || arch(x86_64))
+    #if os(anyAppleOS) && (arch(arm64) || arch(arm64_32) || arch(x86_64))
     // On Darwin, we borrow a bit of the frame pointer to indicate async
     // stack frames
     return (storedFp & (1 << 60)) != 0

--- a/stdlib/public/RuntimeModule/ImageMap+Darwin.swift
+++ b/stdlib/public/RuntimeModule/ImageMap+Darwin.swift
@@ -14,7 +14,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(anyAppleOS)
 
 import Swift
 
@@ -129,4 +129,4 @@ extension ImageMap {
 
 }
 
-#endif // os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#endif // os(anyAppleOS)

--- a/stdlib/public/RuntimeModule/ImageMap.swift
+++ b/stdlib/public/RuntimeModule/ImageMap.swift
@@ -17,7 +17,7 @@
 
 import Swift
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(anyAppleOS)
 internal import Darwin
 internal import BacktracingImpl.OS.Darwin
 #endif
@@ -147,7 +147,7 @@ public struct ImageMap: Collection, Sendable, Hashable {
 
   /// Capture the image map for the current process.
   public static func capture() -> ImageMap {
-    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    #if os(anyAppleOS)
     return capture(for: mach_task_self())
     #elseif os(Windows)
     return capture(for: UInt(bitPattern: GetCurrentProcess()))

--- a/stdlib/public/RuntimeModule/ImageSource.swift
+++ b/stdlib/public/RuntimeModule/ImageSource.swift
@@ -16,7 +16,7 @@
 
 import Swift
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(anyAppleOS)
 internal import Darwin
 #elseif os(Windows)
 internal import ucrt

--- a/stdlib/public/RuntimeModule/Mangling.swift
+++ b/stdlib/public/RuntimeModule/Mangling.swift
@@ -16,7 +16,7 @@
 
 import Swift
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(anyAppleOS)
 internal import Darwin
 #elseif os(Windows)
 internal import ucrt

--- a/stdlib/public/RuntimeModule/MemoryReader.swift
+++ b/stdlib/public/RuntimeModule/MemoryReader.swift
@@ -17,7 +17,7 @@
 
 import Swift
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(anyAppleOS)
 internal import Darwin
 #elseif os(Windows)
 internal import ucrt

--- a/stdlib/public/RuntimeModule/PDB/MultiStreamFile.swift
+++ b/stdlib/public/RuntimeModule/PDB/MultiStreamFile.swift
@@ -17,7 +17,7 @@
 
 import Swift
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(anyAppleOS)
 internal import Darwin
 #elseif os(Windows)
 internal import WinSDK

--- a/stdlib/public/RuntimeModule/PDB/PDBFile.swift
+++ b/stdlib/public/RuntimeModule/PDB/PDBFile.swift
@@ -17,7 +17,7 @@
 
 import Swift
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(anyAppleOS)
 internal import Darwin
 #elseif os(Windows)
 internal import WinSDK

--- a/stdlib/public/RuntimeModule/PDBCache.swift
+++ b/stdlib/public/RuntimeModule/PDBCache.swift
@@ -17,7 +17,7 @@
 
 import Swift
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(anyAppleOS)
 internal import Darwin
 #elseif os(Windows)
 internal import WinSDK

--- a/stdlib/public/RuntimeModule/PeCoff.swift
+++ b/stdlib/public/RuntimeModule/PeCoff.swift
@@ -17,7 +17,7 @@
 
 import Swift
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(anyAppleOS)
 internal import Darwin
 #elseif os(Windows)
 internal import WinSDK

--- a/stdlib/public/RuntimeModule/SymbolicatedBacktrace.swift
+++ b/stdlib/public/RuntimeModule/SymbolicatedBacktrace.swift
@@ -17,11 +17,11 @@
 
 import Swift
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(anyAppleOS)
 internal import BacktracingImpl.OS.Darwin
 #endif
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(anyAppleOS)
 internal import Darwin
 #elseif os(Windows)
 internal import ucrt
@@ -202,7 +202,7 @@ public struct SymbolicatedBacktrace: CustomStringConvertible {
     /// For instance, the `start` function from `dyld` on macOS is a system
     /// function, and we don't need to display it under normal circumstances.
     public var isSystemFunction: Bool {
-      #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+      #if os(anyAppleOS)
       if rawName == "start", imageName == "dyld" {
         return true
       }
@@ -318,7 +318,7 @@ public struct SymbolicatedBacktrace: CustomStringConvertible {
     self.frames = frames
   }
 
-  #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+  #if os(anyAppleOS)
   private enum macOSSymbolicationError: Error {
     case invalidUUID
   }
@@ -497,7 +497,7 @@ public struct SymbolicatedBacktrace: CustomStringConvertible {
 
     switch symbolicationPlatform {
     case .Darwin:
-      #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+      #if os(anyAppleOS)
       withSymbolicator(images: theImages,
                       useSymbolCache: options.contains(.useSymbolCache)) {
         symbolicator in

--- a/stdlib/public/RuntimeModule/Utils.swift
+++ b/stdlib/public/RuntimeModule/Utils.swift
@@ -16,7 +16,7 @@
 
 import Swift
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(anyAppleOS)
 internal import Darwin
 #elseif os(Windows)
 internal import WinSDK

--- a/stdlib/public/core/Availability.swift
+++ b/stdlib/public/core/Availability.swift
@@ -75,7 +75,7 @@ public func _stdlib_isOSVersionAtLeast_AEIC(
   _ minor: Builtin.Word,
   _ patch: Builtin.Word
 ) -> Builtin.Int1 {
-#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(visionOS) || os(Android)) && SWIFT_RUNTIME_OS_VERSIONING
+#if (os(anyAppleOS) || os(Android)) && SWIFT_RUNTIME_OS_VERSIONING
   if Int(major) == 9999 {
     return true._value
   }

--- a/stdlib/public/core/BuiltinMath.swift
+++ b/stdlib/public/core/BuiltinMath.swift
@@ -113,7 +113,7 @@ public func _rint(_ x: Double) -> Double {
 
 // Float80 Intrinsics (80 bits)
 
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !os(anyAppleOS))) && (arch(i386) || arch(x86_64))
 @_transparent
 public func _cos(_ x: Float80) -> Float80 {
   return Float80(Builtin.int_cos_FPIEEE80(x._value))

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -77,7 +77,7 @@ public typealias CFloat = Float
 public typealias CDouble = Double
 
 /// The C 'long double' type.
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
+#if os(anyAppleOS)
 // On Darwin, long double is Float80 on x86, and Double otherwise.
 #if arch(x86_64) || arch(i386)
 public typealias CLongDouble = Float80
@@ -296,7 +296,7 @@ extension UInt {
 }
 
 /// A wrapper around a C `va_list` pointer.
-#if arch(arm64) && !(os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(visionOS) ||  os(Windows))
+#if arch(arm64) && !(os(anyAppleOS) || os(Windows))
 @frozen
 @unsafe
 public struct CVaListPointer {

--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -1522,7 +1522,7 @@ public protocol BinaryFloatingPoint: FloatingPoint, ExpressibleByFloatLiteral {
   /// - Parameter value: A floating-point value to be converted.
   init(_ value: Double)
 
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !os(anyAppleOS))) && (arch(i386) || arch(x86_64))
   /// Creates a new instance from the given value, rounded to the closest
   /// possible representation.
   ///
@@ -1933,7 +1933,7 @@ extension BinaryFloatingPoint {
         significandBitPattern:
           UInt64(truncatingIfNeeded: value.significandBitPattern))
       self = Self(value_)
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !os(anyAppleOS))) && (arch(i386) || arch(x86_64))
     case (15, 63):
       let value_ = value as? Float80 ?? Float80(
         sign: value.sign,

--- a/stdlib/public/core/FloatingPointParsing.swift.gyb
+++ b/stdlib/public/core/FloatingPointParsing.swift.gyb
@@ -48,7 +48,7 @@ internal func _isspace_clocale(_ u: UTF16.CodeUnit) -> Bool {
 %   Self = floatName(bits)
 
 % if bits == 80:
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !os(anyAppleOS))) && (arch(i386) || arch(x86_64))
 % elif bits == 16:
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 % end

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -68,7 +68,7 @@ else:
 }%
 
 % if bits == 80:
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !os(anyAppleOS))) && (arch(i386) || arch(x86_64))
 % elif bits == 16:
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 % end
@@ -927,7 +927,7 @@ extension ${Self}: _ExpressibleByBuiltinIntegerLiteral, ExpressibleByIntegerLite
 }
 
 % if bits != 80:
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !os(anyAppleOS))) && (arch(i386) || arch(x86_64))
 % end
 
 % builtinFloatLiteralBits = 80
@@ -1134,7 +1134,7 @@ extension ${Self} {
 %   That = src_type.stdlib_name
 
 %   if srcBits == 80:
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !os(anyAppleOS))) && (arch(i386) || arch(x86_64))
 %   elif srcBits == 16:
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 %   end

--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -128,7 +128,7 @@ public struct ${Self}
 %     (lower, upper) = getFtoIBounds(floatBits=FloatBits, intBits=int(bits), signed=signed)
 
 %     if FloatType == 'Float80':
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !os(anyAppleOS))) && (arch(i386) || arch(x86_64))
 %     elif FloatType == 'Float16':
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 %     end

--- a/stdlib/public/core/Mirrors.swift
+++ b/stdlib/public/core/Mirrors.swift
@@ -252,7 +252,7 @@ extension Int: _CustomPlaygroundQuickLookable {
   }
 }
 
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !os(anyAppleOS))) && (arch(i386) || arch(x86_64))
 extension Float80: CustomReflectable {
   /// A mirror that reflects the Float80 instance.
   public var customMirror: Mirror {

--- a/stdlib/public/core/Policy.swift
+++ b/stdlib/public/core/Policy.swift
@@ -168,7 +168,7 @@ public typealias StringLiteralType = String
 //===----------------------------------------------------------------------===//
 // Default types for unconstrained number literals
 //===----------------------------------------------------------------------===//
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !os(anyAppleOS))) && (arch(i386) || arch(x86_64))
 public typealias _MaxBuiltinFloatType = Builtin.FPIEEE80
 #else
 public typealias _MaxBuiltinFloatType = Builtin.FPIEEE64

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -103,7 +103,7 @@ internal let _countGPRegisters = 16
 @usableFromInline
 internal let _registerSaveWords = _countGPRegisters
 
-#elseif arch(arm64) && !(os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(visionOS) || os(Windows))
+#elseif arch(arm64) && !(os(anyAppleOS) || os(Windows))
 // ARM Procedure Call Standard for aarch64. (IHI0055B)
 // The va_list type may refer to any parameter in a parameter list may be in one
 // of three memory locations depending on its type and position in the argument
@@ -420,7 +420,7 @@ extension Double: _CVarArgPassedAsDouble, _CVarArgAligned {
   }
 }
 
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !os(anyAppleOS))) && (arch(i386) || arch(x86_64))
 extension Float80: CVarArg, _CVarArgAligned {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.
@@ -439,7 +439,7 @@ extension Float80: CVarArg, _CVarArgAligned {
 }
 #endif
 
-#if (arch(x86_64) && !os(Windows)) || arch(s390x) || (arch(arm64) && !(os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(visionOS) || os(Windows)))
+#if (arch(x86_64) && !os(Windows)) || arch(s390x) || (arch(arm64) && !(os(anyAppleOS) || os(Windows)))
 
 /// An object that can manage the lifetime of storage backing a
 /// `CVaListPointer`.

--- a/stdlib/public/libexec/swift-backtrace/Utils.swift
+++ b/stdlib/public/libexec/swift-backtrace/Utils.swift
@@ -99,7 +99,7 @@ internal func recursiveRemoveContents(_ dir: String) throws {
   while let dp = readdir(dirp) {
     let name: String =
       withUnsafePointer(to: &dp.pointee.d_name) {
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(anyAppleOS)
         let len = Int(dp.pointee.d_namlen)
 #else
         let len = Int(strlen($0))

--- a/stdlib/public/libexec/swift-backtrace/main.swift
+++ b/stdlib/public/libexec/swift-backtrace/main.swift
@@ -744,7 +744,7 @@ Generate a backtrace for the parent process.
         backtraceFormatter.writeCrashLog(now: now.iso8601)
     }
 
-    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    #if os(anyAppleOS)
     // On Darwin, if Developer Mode is turned off, or we can't tell if it's
     // on or not, disable interactivity
     var developerMode: Int32 = 0
@@ -810,7 +810,7 @@ Generate a backtrace for the parent process.
     }
   }
 
-  #if os(Linux) || os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+  #if os(Linux) || os(anyAppleOS)
   static func setRawMode() -> termios {
     var oldAttrs = termios()
     tcgetattr(0, &oldAttrs)

--- a/test/Concurrency/Runtime/RuntimeDemangle.swift
+++ b/test/Concurrency/Runtime/RuntimeDemangle.swift
@@ -23,7 +23,7 @@ if #available(SwiftStdlib 6.4, *) {
     expectEqual(try? demangle("Swift is super cool!"), nil)
 
     // Test that correct symbols are demangled. (Test all documented prefixes)
-    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) // legacy mangling is not supported on Linux
+    #if os(anyAppleOS) // legacy mangling is not supported on Linux
     expectEqual(try? demangle("_TSb"), "Swift.Bool")
     expectEqual(try? demangle("_T0Si"), "Swift.Int")
     #endif
@@ -82,7 +82,7 @@ if #available(SwiftStdlib 6.4, *) {
     }
 
     // Test that correct symbols are demangled. (Test all documented prefixes)
-    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) // legacy mangling is not supported on Linux
+    #if os(anyAppleOS) // legacy mangling is not supported on Linux
     test { outputSpan in
       do {
         try demangle("_TSb".utf8Span, into: &outputSpan)
@@ -94,7 +94,7 @@ if #available(SwiftStdlib 6.4, *) {
     }
     #endif
 
-    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) // legacy mangling is not supported on Linux
+    #if os(anyAppleOS) // legacy mangling is not supported on Linux
     test { outputSpan in
       do {
         try demangle("_T0Si".utf8Span, into: &outputSpan)

--- a/test/Concurrency/Runtime/async.swift
+++ b/test/Concurrency/Runtime/async.swift
@@ -61,7 +61,7 @@ if #available(SwiftStdlib 5.1, *) {
   asyncTests.test("GlobalDispatchQueue") {
     DispatchQueue.global(qos: .utility).async {
       async {
-#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS))
+#if os(anyAppleOS)
         // Non-Darwin platforms currently lack qos_class_self().
         assert(Task.currentPriority == .utility)
 #endif

--- a/test/TypeRoundTrip/Inputs/testcases/objc_classes.swift
+++ b/test/TypeRoundTrip/Inputs/testcases/objc_classes.swift
@@ -1,5 +1,5 @@
 // We need Objective-C support for this test
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(anyAppleOS)
 
 import Foundation
 import RoundTrip

--- a/test/TypeRoundTrip/Inputs/testcases/structural_types.swift
+++ b/test/TypeRoundTrip/Inputs/testcases/structural_types.swift
@@ -24,7 +24,7 @@ public func test() {
   roundTripType(Array<@convention(c) () -> ()>.self)
 
   // @convention(block) requires Objective-C support
-  #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+  #if os(anyAppleOS)
   roundTripType(Array<(@escaping @convention(block) () -> (), @convention(block) () -> ()) -> ()>.self)
   #endif
 
@@ -45,7 +45,7 @@ public func test() {
   roundTripType(Array<@convention(c) () -> ()>.Type.self)
 
   // @convention(block) requires Objective-C support
-  #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+  #if os(anyAppleOS)
   roundTripType(Array<(@escaping @convention(block) () -> (), @convention(block) () -> ()) -> ()>.Type.self)
   #endif
 


### PR DESCRIPTION
Replace error prone and verbose compilation conditionals like

```swift
#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
```

with

```swift
#if os(anyAppleOS)
```

Resolves https://github.com/swiftlang/swift/issues/51610.
