### PR TITLE
utils: prevent brotli tools from being built

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2454,6 +2454,7 @@ function Build-Brotli([Hashtable] $Platform) {
     -Defines @{
       BUILD_SHARED_LIBS = "NO";
       CMAKE_POSITION_INDEPENDENT_CODE = "YES";
+      BROTLI_BUILD_TOOLS = "NO";
     }
 }
 


### PR DESCRIPTION
We do not use the `brotli` command line tool, we are only interested in the library. Shave the build tools to save a bit of time. Incidentally, this improves the ability to support WASI as the tool cannot be built for a WASI environment.