### PR TITLE
[TEST-ONLY] Fix tsan tests with new swift-driver

### DIFF
--- a/validation-test/SILOptimizer/rdar133779160.swift
+++ b/validation-test/SILOptimizer/rdar133779160.swift
@@ -1,7 +1,10 @@
 // RUN: %target-build-swift %s -sanitize=thread
 
 // REQUIRES: tsan_runtime
-// UNSUPPORTED: OS=ios && CPU=arm64e
+// UNSUPPORTED: OS=ios
+// UNSUPPORTED: OS=tvos
+// UNSUPPORTED: OS=watchos
+// UNSUPPORTED: OS=xros
 
 class C {}
 func passC(_ b: consuming C) {


### PR DESCRIPTION
After switching to new swift-driver, it is using clang to do the linking and clang doesn't support linking tsan on non-simulator apple platforms other than macOS.

rdar://173364504

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
