### PR TITLE
[docs]  WebAssembly: adjust compile command

### DIFF
--- a/docs/WebAssembly.md
+++ b/docs/WebAssembly.md
@@ -92,7 +92,6 @@ swift sdk install ../swift-sdk-generator/Bundles/swift-DEVELOPMENT-SNAPSHOT_wasm
 
 ## Building Swift SDK for WebAssembly without building the compiler
 
-Building the Swift compiler is a time-consuming process. If you only want to build the Swift standard library
 Building the Swift compiler is a time-consuming process. If you have a pre-built Swift compiler that's sufficiently recent and you only want to build the Swift standard library
 with this pre-built Swift compiler, you can use the following command:
 

--- a/docs/WebAssembly.md
+++ b/docs/WebAssembly.md
@@ -93,7 +93,8 @@ swift sdk install ../swift-sdk-generator/Bundles/swift-DEVELOPMENT-SNAPSHOT_wasm
 ## Building Swift SDK for WebAssembly without building the compiler
 
 Building the Swift compiler is a time-consuming process. If you only want to build the Swift standard library
-with pre-built Swift compiler, you can use the following command:
+Building the Swift compiler is a time-consuming process. If you have a pre-built Swift compiler that's sufficiently recent and you only want to build the Swift standard library
+with this pre-built Swift compiler, you can use the following command:
 
 ```console
 $ SWIFT_TOOLS_PATH=path/to/swift-development-snapshot/usr/bin

--- a/docs/WebAssembly.md
+++ b/docs/WebAssembly.md
@@ -97,11 +97,13 @@ with pre-built Swift compiler, you can use the following command:
 
 ```console
 $ SWIFT_TOOLS_PATH=path/to/swift-development-snapshot/usr/bin
+$ export PATH=$SWIFT_TOOLS_PATH:$PATH
 $ ./utils/build-script \
     --skip-build-llvm \
     --skip-build-swift \
     --skip-build-cmark \
     --build-wasm-stdlib \
+    --skip-test-wasm-stdlib \
     --native-swift-tools-path="$SWIFT_TOOLS_PATH" \
     --native-clang-tools-path="$SWIFT_TOOLS_PATH" \
     --native-llvm-tools-path="$SWIFT_TOOLS_PATH"


### PR DESCRIPTION
Adjust compile command for building WebAssembly without building the toolchain beforehand.