### PR TITLE
Add bailout for memory lifetime verification of enums with switch_value terminator

### DIFF
--- a/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
+++ b/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
@@ -232,13 +232,8 @@ bool MemoryLifetimeVerifier::isTrivialEnumSuccessor(SILBasicBlock *block,
   } else if (auto *switchEnumAddr = dyn_cast<SwitchEnumAddrInst>(term)) {
     elem = switchEnumAddr->getUniqueCaseForDestination(succ);
     enumTy = switchEnumAddr->getOperand()->getType();
-  } else if (auto *switchValue = dyn_cast<SwitchValueInst>(term)) {
-    auto destCase = switchValue->getUniqueCaseForDestination(succ);
-    assert(destCase.has_value());
-    auto caseValue =
-        cast<IntegerLiteralInst>(switchValue->getCase(*destCase).first);
-    auto testValue = dyn_cast<IntegerLiteralInst>(switchValue->getOperand());
-    return testValue ? testValue->getValue() != caseValue->getValue() : true;
+  } else if (isa<SwitchValueInst>(term)) {
+    return true;
   } else {
     return false;
   }

--- a/test/SIL/memory_lifetime.sil
+++ b/test/SIL/memory_lifetime.sil
@@ -915,3 +915,65 @@ bb0(%0 : @owned $BoolAndObj, %1 : @owned $AnyObject):
   return undef : $()
 }
 
+sil [ossa] @test_switch_value_default_block : $@convention(thin) (@in_guaranteed Optional<T>, @in_guaranteed T) -> () {
+bb0(%0 : $*Optional<T>, %1 : $*T):
+  %stk = alloc_stack $Optional<T>
+  %2 = init_enum_data_addr %stk : $*Optional<T>, #Optional.some!enumelt
+  copy_addr %1 to [init] %2 : $*T
+  inject_enum_addr %stk : $*Optional<T>, #Optional.some!enumelt
+  %val = integer_literal $Builtin.Int1, 0
+  %true_val = integer_literal $Builtin.Int1, -1
+  switch_value %val : $Builtin.Int1, case %true_val: bb1, default bb2
+
+bb1:
+  destroy_addr %stk : $*Optional<T>
+  dealloc_stack %stk : $*Optional<T>
+  br bb3
+
+bb2:
+  dealloc_stack %stk : $*Optional<T>
+  br bb3
+
+bb3:
+  %r = tuple ()
+  return %r : $()
+}
+
+class Klass {}
+
+enum TripleCaseEnum {
+  case none
+  case some1(Klass)
+  case some2(Int)
+}
+
+sil [ossa] @test_switch_value_case_block : $@convention(thin) (@in_guaranteed TripleCaseEnum, @in_guaranteed Int) -> () {
+bb0(%0 : $*TripleCaseEnum, %1 : $*Int):
+  %stk = alloc_stack $TripleCaseEnum
+  %2 = init_enum_data_addr %stk : $*TripleCaseEnum, #TripleCaseEnum.some2!enumelt
+  copy_addr %1 to [init] %2 : $*Int
+  inject_enum_addr %stk : $*TripleCaseEnum, #TripleCaseEnum.some2!enumelt
+  %val = integer_literal $Builtin.Int32, 2
+  %none_val = integer_literal $Builtin.Int32, 0
+  %some1_val = integer_literal $Builtin.Int32, 1
+  %some2_val = integer_literal $Builtin.Int32, 2
+  switch_value %val, case %none_val: bb1, case %some1_val: bb2, case %some2_val: bb3
+
+bb1:
+  dealloc_stack %stk : $*TripleCaseEnum
+  br bb4
+
+bb2:
+  destroy_addr %stk : $*TripleCaseEnum
+  dealloc_stack %stk : $*TripleCaseEnum
+  br bb4
+
+bb3:
+  dealloc_stack %stk : $*TripleCaseEnum
+  br bb4
+
+bb4:
+  %r = tuple ()
+  return %r : $()
+}
+

--- a/test/SILOptimizer/sil_combine_enum_addr_ossa.sil
+++ b/test/SILOptimizer/sil_combine_enum_addr_ossa.sil
@@ -268,3 +268,31 @@ bb22:
   inject_enum_addr %3 : $*Optional<CustomStringConvertible>, #Optional.none!enumelt
   br bb2
 }
+
+// CHECK-LABEL: sil [ossa] @convert_inject_enum_addr_switch_enum_addr_default_block
+// CHECK-NOT: switch_enum_addr
+// CHECK: } // end sil function 'convert_inject_enum_addr_switch_enum_addr_default_block'
+sil [ossa] @convert_inject_enum_addr_switch_enum_addr_default_block : $@convention(thin) (@in AnyObject, @in_guaranteed CustomStringConvertible) -> () {
+bb0(%0 : $*AnyObject, %1 : $*CustomStringConvertible):
+  %3 = alloc_stack $Optional<CustomStringConvertible>
+  %4 = init_enum_data_addr %3 : $*Optional<CustomStringConvertible>, #Optional.some!enumelt
+  unconditional_checked_cast_addr AnyObject in %0 : $*AnyObject to CustomStringConvertible in %4 : $*CustomStringConvertible
+  inject_enum_addr %3 : $*Optional<CustomStringConvertible>, #Optional.some!enumelt
+  switch_enum_addr %3 : $*Optional<CustomStringConvertible>, case #Optional.some!enumelt: bb1, default bb2
+
+bb1:
+  %19 = unchecked_take_enum_data_addr %3 : $*Optional<CustomStringConvertible>, #Optional.some!enumelt
+  destroy_addr %19 : $*CustomStringConvertible
+  copy_addr %1 to [init] %19 : $*CustomStringConvertible
+  destroy_addr %19 : $*CustomStringConvertible
+  dealloc_stack %3 : $*Optional<CustomStringConvertible>
+  br bb3
+
+bb2:
+  dealloc_stack %3 : $*Optional<CustomStringConvertible>
+  br bb3
+
+bb3:
+  %r = tuple ()
+  return %r : $()
+}


### PR DESCRIPTION
SILCombine can transform a switch_enum_addr to a switch_value in certain cases. It's impossible to know whether the successors of a `switch_value` terminator are for trivial or non-trivial cases. Return true from `MemoryLifetimeVerifier::isTrivialEnumSuccessor` when we encounter switch_value terminator to avoid false positive errors.

Resolves rdar://165461597 
