### PR TITLE
Runtimes: correct Synchronization build for WASI

### DIFF
--- a/Runtimes/Supplemental/Synchronization/CMakeLists.txt
+++ b/Runtimes/Supplemental/Synchronization/CMakeLists.txt
@@ -23,6 +23,14 @@ project(SwiftSynchronization
 # with a pure Swift project.
 enable_language(C)
 
+# FIXME(compnerd) this is a compatibility shim for CMake <3.31.
+if(CMAKE_VERSION VERSION_LESS 3.31)
+  if(CMAKE_SYSTEM_NAME STREQUAL "Generic" AND CMAKE_SYSTEM_PROCESSOR MATCHES "wasm32")
+    set(CMAKE_SYSTEM_NAME WASI)
+    set(WASI 1)
+  endif()
+endif()
+
 if(NOT PROJECT_IS_TOP_LEVEL)
   message(SEND_ERROR "Swift Synchronization must build as a standalone project")
 endif()


### PR DESCRIPTION
This adds a compatibility shim and workaround for building the Synchronization module for WASI with the new runtimes build with an older CMake version.