### PR TITLE
Runtime: correct Differentiation build on WASI

### DIFF
--- a/Runtimes/Supplemental/Differentiation/CMakeLists.txt
+++ b/Runtimes/Supplemental/Differentiation/CMakeLists.txt
@@ -18,6 +18,14 @@ project(SwiftDifferentiation
   LANGUAGES Swift C
   VERSION ${SWIFT_RUNTIME_VERSION})
 
+# FIXME(compnerd) add a compatibility shim for WASI on older CMake releases.
+if(CMAKE_VERSION VERSION_LESS 3.31)
+  if(CMAKE_SYSTEM_NAME STREQUAL "Generic" AND CMAKE_SYSTEM_PROCESSOR MATCHES "wasm32")
+    set(CMAKE_SYSTEM_NAME WASI)
+    set(WASI 1)
+  endif()
+endif()
+
 if(NOT PROJECT_IS_TOP_LEVEL)
   message(SEND_ERROR "Swift Differentiation must build as a standalone project")
 endif()
@@ -120,6 +128,7 @@ target_link_libraries(swift_Differentiation PRIVATE
   swiftCore
   $<$<PLATFORM_ID:Android>:swiftAndroid>
   $<$<PLATFORM_ID:Windows>:swiftCRT>
+  $<$<PLATFORM_ID:WASI>:swiftWASILibc>
   $<$<BOOL:${SwiftSwiftDirectRuntime_FOUND}>:swiftSwiftDirectRuntime>)
 
 


### PR DESCRIPTION
This adds a compatibility shim for WASI and a workaround to allow building the Differentiation module for WASI with the older CMake releases.