### PR TITLE
AST: Skip useless availability diags in fragile funcs with opaque result types

### DIFF
--- a/lib/AST/AvailabilityScopeBuilder.cpp
+++ b/lib/AST/AvailabilityScopeBuilder.cpp
@@ -1096,15 +1096,28 @@ private:
           if (isUnavailability.value())
             continue;
 
-          DiagnosticEngine &diags = Context.Diags;
-          if (currentScope->getReason() != AvailabilityScope::Reason::Root) {
-            diags.diagnose(query->getLoc(),
-                           diag::availability_query_useless_enclosing_scope,
-                           domain.getNameForAttributePrinting());
-            diags.diagnose(
-                currentScope->getIntroductionLoc(),
-                diag::availability_query_useless_enclosing_scope_here);
+          if (currentScope->getReason() == AvailabilityScope::Reason::Root)
+            continue;
+
+          // Skip diagnosing useless availability in fragile functions with
+          // opaque result types since removing an availability check could
+          // change the ABI of the function and result in a miscompilation.
+          auto *dc = getCurrentDeclContext();
+          if (dc->getResilienceExpansion() == ResilienceExpansion::Minimal) {
+            if (auto decl = dc->getInnermostDeclarationDeclContext()) {
+              if (auto afd = dyn_cast<AbstractFunctionDecl>(decl)) {
+                if (afd->getOpaqueResultTypeDecl())
+                  continue;
+              }
+            }
           }
+
+          DiagnosticEngine &diags = Context.Diags;
+          diags.diagnose(query->getLoc(),
+                         diag::availability_query_useless_enclosing_scope,
+                         domain.getNameForAttributePrinting());
+          diags.diagnose(currentScope->getIntroductionLoc(),
+                         diag::availability_query_useless_enclosing_scope_here);
         }
 
         continue;

--- a/test/Availability/availability_versions.swift
+++ b/test/Availability/availability_versions.swift
@@ -1351,6 +1351,29 @@ func functionWithSpecifiedAvailabilityAndUselessCheck() { // expected-note 2{{en
   }
 }
 
+@available(OSX, introduced: 51)
+@inlinable
+public func fragileFunctionWithSpecifiedAvailabilityAndUselessCheck() { // expected-note {{enclosing scope here}}
+  if #available(OSX 51, *) { } // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
+}
+
+public protocol Mystery { }
+public struct Secret: Mystery {
+  public init() { }
+}
+public struct SuperSecret: Mystery {
+  public init() { }
+}
+
+@available(OSX, introduced: 51)
+@inlinable
+public func fragileFunctionWithSpecifiedAvailabilityUselessCheckAndOpaqueResult() -> some Mystery {
+  if #available(OSX 51, *) {
+    return Secret()
+  }
+  return SuperSecret()
+}
+
 // #available(...) outside if statement guards
 
 func injectToOptional<T>(_ v: T) -> T? {


### PR DESCRIPTION
Removing an availability check in these functions could change the ABI of the function and result in a miscompilation.

Resolves rdar://127829648.
