### PR TITLE
[Observation] Dirty bits should only apply to the properties that are accessed in the scope of the apply methods

### DIFF
--- a/stdlib/public/Observation/Sources/Observation/ObservationTracking.swift
+++ b/stdlib/public/Observation/Sources/Observation/ObservationTracking.swift
@@ -452,9 +452,32 @@ public func withObservationTracking<Result: ~Copyable, Failure: Error>(
   ObservationTracking._installTracking(options: options, tracking, willSet: willSet, didSet: didSet, deinit: `deinit`)
   switch accessListResult.dirty {
   case .willSet(let keyPath):
-    willSet?(ObservationTracking(accessListResult.accessList, changed: keyPath))
+    if let entries = accessListResult.accessList?.entries {
+      var foundDirty = false
+      for (_, entry) in entries {
+        if entry.properties.contains(keyPath) {
+          foundDirty = true
+          break
+        }
+      }
+      if foundDirty {
+        willSet?(ObservationTracking(accessListResult.accessList, changed: keyPath))
+      }
+    }
+    
   case .didSet(let keyPath):
-    didSet?(ObservationTracking(accessListResult.accessList, changed: keyPath))
+    if let entries = accessListResult.accessList?.entries {
+      var foundDirty = false
+      for (_, entry) in entries {
+        if entry.properties.contains(keyPath) {
+          foundDirty = true
+          break
+        }
+      }
+      if foundDirty {
+        didSet?(ObservationTracking(accessListResult.accessList, changed: keyPath))
+      }
+    }
   case .deinit:
     `deinit`?()
   default:


### PR DESCRIPTION
The previous dirty bit fixes did not restrict that to just the properties accessed within the scope of `Observations` it instead applied to all properties. This is incorrect since that would result in events that are not associated with those accessed properties. This restricts that access to only the key paths that are actually accessed.