### PR TITLE
[TypeChecker] Update `computeOverriddenDecls` to account for concurre…

### DIFF
--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -32,6 +32,8 @@
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/UnsafeUse.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/Basic/LanguageMode.h"
+#include "llvm/ADT/SmallVector.h"
 using namespace swift;
 
 static void adjustFunctionTypeForOverride(Type &type) {
@@ -2480,24 +2482,31 @@ computeOverriddenDecls(ValueDecl *decl, bool ignoreMissingImports) {
     return noResults;
   }
 
-  auto matches = matcher.match(OverrideCheckingAttempt::PerfectMatch);
-  if (matches.empty()) {
-    return noResults;
+  // Mismatches on @Sendable and global-actor attributes are treated as
+  // warnings depending on the language mode and declaration attributes.
+  // `checkOverrides` would produce mismatching override results and so
+  // should this method.
+  for (auto attempt : {OverrideCheckingAttempt::PerfectMatch,
+                       OverrideCheckingAttempt::MismatchedConcurrency}) {
+    auto matches = matcher.match(attempt);
+    if (matches.empty())
+      continue;
+
+    // If we have more than one potential match from a class, diagnose the
+    // ambiguity and fail.
+    if (matches.size() > 1 && decl->getDeclContext()->getSelfClassDecl()) {
+      diagnoseGeneralOverrideFailure(decl, matches, attempt);
+      invalidateOverrideAttribute(decl);
+      return noResults;
+    }
+
+    // Check the matches. If any are ill-formed, invalidate the override
+    // attribute
+    // so we don't try again.
+    return matcher.checkPotentialOverrides(matches, attempt);
   }
 
-  // If we have more than one potential match from a class, diagnose the
-  // ambiguity and fail.
-  if (matches.size() > 1 && decl->getDeclContext()->getSelfClassDecl()) {
-    diagnoseGeneralOverrideFailure(decl, matches,
-                                   OverrideCheckingAttempt::PerfectMatch);
-    invalidateOverrideAttribute(decl);
-    return noResults;
-  }
-
-  // Check the matches. If any are ill-formed, invalidate the override attribute
-  // so we don't try again.
-  return matcher.checkPotentialOverrides(matches,
-                                         OverrideCheckingAttempt::PerfectMatch);
+  return noResults;
 }
 
 llvm::TinyPtrVector<ValueDecl *>

--- a/test/Concurrency/rdar163249014.swift
+++ b/test/Concurrency/rdar163249014.swift
@@ -1,0 +1,52 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-clang %t/Impl.m -c -o %t/Test.o
+// RUN: %target-build-swift %t/main.swift %t/doc.swift -import-objc-header %t/Test.h %t/Test.o -language-mode 5 -strict-concurrency=complete -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+// REQUIRES: concurrency
+
+// UNSUPPORTED: remote_run || device_run
+
+//--- Test.h
+#import "Foundation/Foundation.h"
+
+#define SWIFT_SENDABLE __attribute__((__swift_attr__("@Sendable")))
+
+@interface Document : NSObject
+- (void) relinquishToReader:(void (SWIFT_SENDABLE ^)(void (SWIFT_SENDABLE ^reacquirer)())) reader;
+@end
+
+//--- Impl.m
+#import "Test.h"
+@implementation Document
+  - (void) relinquishToReader:(void (^ SWIFT_SENDABLE)(void (^reacquirer)())) reader {
+  }
+@end
+
+//--- doc.swift
+class Doc: Document {
+  // No Sendable annotations
+  override func relinquish(toReader: @escaping ((() -> Void)?) -> Void) {
+  }
+
+  func test1() {
+    print("test1")
+  }
+
+  func test2() {
+    print("test2")
+  }
+}
+
+//--- main.swift
+func test(doc: Doc) {
+  doc.test1()
+}
+
+test(doc: Doc())
+// CHECK: test1


### PR DESCRIPTION
…ncy related mismatches

Depending on the combination of language mode and declaration attributes some of the non-perfect override matches are accepted with a warning. This happens, for example, when there are mismatches on `@Sendable` or global-actor isolation attributes.

`computeOverriddenDecls` should behave the same way as `checkOverrides` when it comes to concurrency, otherwise if declaration comes from a different file in the same module it's impossible to miss the override which leads to mismatches at the use site (because class vtables are going to be computed differently).

Resolves: rdar://173366668

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
