### PR TITLE
Provide Swift Testing build directory when building XCTest

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2339,6 +2339,8 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DXCTEST_PATH_TO_LIBDISPATCH_SOURCE:PATH=${LIBDISPATCH_SOURCE_DIR}
                     -DXCTEST_PATH_TO_LIBDISPATCH_BUILD:PATH=$(build_directory ${host} libdispatch)
                     -DXCTEST_PATH_TO_FOUNDATION_BUILD:PATH=${FOUNDATION_BUILD_DIR}
+                    -DXCTEST_PATH_TO_SWIFT_TESTING_BUILD:PATH=$(build_directory ${host} swifttesting)
+                    -DXCTEST_PATH_TO_SWIFT_TESTING_MACROS_BUILD:PATH=$(build_directory ${host} swifttestingmacros)
                     -DCMAKE_SWIFT_COMPILER:PATH=${SWIFTC_BIN}
                     -DCMAKE_PREFIX_PATH:PATH=$(build_directory ${host} llvm)
 

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3264,6 +3264,8 @@ function Test-XCTest {
         XCTEST_PATH_TO_FOUNDATION_BUILD = $(Get-ProjectBinaryCache $BuildPlatform DynamicFoundation);
         XCTEST_PATH_TO_LIBDISPATCH_BUILD = $(Get-ProjectBinaryCache $BuildPlatform Dispatch);
         XCTEST_PATH_TO_LIBDISPATCH_SOURCE = "$SourceCache\swift-corelibs-libdispatch";
+        XCTEST_PATH_TO_SWIFT_TESTING_BUILD = $(Get-ProjectBinaryCache $BuildPlatform Testing);
+        XCTEST_PATH_TO_SWIFT_TESTING_MACROS_BUILD = $(Get-ProjectBinaryCache $BuildPlatform TestingMacros);
       }
   }
 }


### PR DESCRIPTION
Enables building XCTest's lit tests that require `import Testing`, which is new for testing the interop feature.

The Swift Testing build directory is forwarded by XCTest's CMake build to the compilation flags when building lit test binaries.

Unblocks https://github.com/swiftlang/swift-corelibs-xctest/pull/538