### PR TITLE
[Reapply][Concurrency] Reject isolated conformances escaping through async callees

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8995,6 +8995,10 @@ GROUPED_WARNING(isolated_conformance_will_become_nonisolated,IsolatedConformance
 GROUPED_ERROR(isolated_conformance_to_sendable_metatype,IsolatedConformances,none,
     "cannot form %0 conformance of %1 to SendableMetatype-inheriting %kind2",
     (ActorIsolation, Type, const ValueDecl *))
+GROUPED_ERROR(isolated_conformance_may_cross_isolation,IsolatedConformances,none,
+    "conformance of %select{underlying type of 'some %1'|%0}0 to protocol "
+    "'%1' may be isolated and cannot be passed to %2 context",
+    (Identifier, StringRef, ActorIsolation))
 
 //===----------------------------------------------------------------------===//
 // MARK: @_inheritActorContext

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "TypeCheckConcurrency.h"
+#include "../AST/AbstractConformance.h"
 #include "MiscDiagnostics.h"
 #include "NonisolatedNonsendingByDefaultMigration.h"
 #include "TypeCheckDistributed.h"
@@ -4100,6 +4101,24 @@ namespace {
       if (!unsatisfiedIsolation)
         return false;
 
+      // Check for isolated conformances escaping through the callee's
+      // generic substitutions across the isolation boundary.
+      {
+        std::optional<std::pair<ConcreteDeclRef, SourceLoc>> calleeDeclRef;
+        if (auto *selfApply = dyn_cast<SelfApplyExpr>(apply->getFn()->getValueProvidingExpr())) {
+          calleeDeclRef = findReference(selfApply->getFn()->getValueProvidingExpr());
+        } else {
+          calleeDeclRef = findReference(apply->getFn());
+        }
+
+        if (calleeDeclRef) {
+          checkIsolatedConformancesForIsolationCrossing(
+              calleeDeclRef->first, apply->getLoc(),
+              *unsatisfiedIsolation, getDeclContext(),
+              RefineConformances{*this});
+        }
+      }
+
       // Record whether the callee isolation or the context isolation
       // is preconcurrency, which is used later to downgrade errors to
       // warnings in minimal checking.
@@ -4539,11 +4558,11 @@ namespace {
       if (!declRef)
         return false;
 
+      auto *const decl = declRef.getDecl();
+
       // Make sure isolated conformances are formed in the right context.
       checkIsolatedConformancesInContext(declRef, loc, getDeclContext(),
                                          RefineConformances{*this});
-
-      auto *const decl = declRef.getDecl();
 
       // If this declaration is a callee from the enclosing application,
       // it's already been checked via the call.
@@ -8924,7 +8943,10 @@ namespace {
     llvm::TinyPtrVector<ProtocolConformance *> badIsolatedConformances;
     DeclContext *fromDC;
     HandleConformanceIsolationFn handleBad;
-    mutable std::optional<ActorIsolation> fromIsolation;
+
+    // Isolation can either be set explicitly,
+    // or will be lazy loaded from the 'fromDC' context otherwise.
+    mutable std::optional<ActorIsolation> isolation;
 
   public:
     MismatchedIsolatedConformances(const DeclContext *fromDC,
@@ -8932,11 +8954,20 @@ namespace {
       : fromDC(const_cast<DeclContext *>(fromDC)),
         handleBad(handleBad) { }
 
-    ActorIsolation getContextIsolation() const {
-      if (!fromIsolation)
-        fromIsolation = getActorIsolationOfContext(fromDC);
+    MismatchedIsolatedConformances(ActorIsolation targetIsolation,
+                                   const DeclContext *fromDC,
+                                   HandleConformanceIsolationFn handleBad)
+      : fromDC(const_cast<DeclContext *>(fromDC)),
+        handleBad(handleBad),
+        isolation(targetIsolation) { }
 
-      return *fromIsolation;
+    /// Lazy compute the isolation of the context 'fromDC',
+    /// unless the isolation was set explicitly already.
+    ActorIsolation getIsolation() const {
+      if (!isolation)
+        isolation = getActorIsolationOfContext(fromDC);
+
+      return *isolation;
     }
 
     ArrayRef<ProtocolConformance *> getBadIsolatedConformances() const {
@@ -8957,7 +8988,12 @@ namespace {
 
       auto conformanceIsolation = concrete->getIsolation();
       if (!conformanceIsolation.isGlobalActor() ||
-          conformanceIsolation == getContextIsolation())
+          conformanceIsolation == getIsolation())
+        return true;
+
+      // In a nonisolated(nonsending) context the conformance is valid because
+      // effectively always is on the caller's isolation.
+      if (getIsolation().isCallerIsolationInheriting())
         return true;
 
       badIsolatedConformances.push_back(concrete);
@@ -8986,7 +9022,7 @@ namespace {
           .diagnose(
               loc, diag::isolated_conformance_wrong_domain,
               firstConformance->getIsolation(), firstConformance->getType(),
-              firstConformance->getProtocol()->getName(), getContextIsolation())
+              firstConformance->getProtocol()->getName(), getIsolation())
           .warnUntilLanguageMode(LanguageMode::v6);
       return true;
     }
@@ -9030,4 +9066,94 @@ bool swift::checkIsolatedConformancesInContext(
   MismatchedIsolatedConformances mismatched(dc, handleBad);
   forEachConformance(type, mismatched);
   return mismatched.diagnose(loc);
+}
+
+bool swift::checkIsolatedConformancesForIsolationCrossing(
+    ConcreteDeclRef declRef, SourceLoc loc,
+    ActorIsolation targetIsolation, const DeclContext *dc,
+    HandleConformanceIsolationFn handleBad) {
+  MismatchedIsolatedConformances mismatched(targetIsolation, dc, handleBad);
+  forEachConformance(declRef, mismatched);
+  bool diagnosed = mismatched.diagnose(loc);
+
+  // Return early, we already found a problem
+  if (diagnosed)
+    return diagnosed;
+
+  auto &ctx = dc->getASTContext();
+  auto *sendableMetatypeProto =
+      ctx.getProtocol(KnownProtocolKind::SendableMetatype);
+
+  // Also check for abstract conformances, since if we can't prove they are nonisolated,
+  // we must conservatively reject them.
+  if (auto subs = declRef.getSubstitutions()) {
+    // For protocol member calls, the Self conformance is used for witness
+    // dispatch and doesn't escape to another context, so we skip it.
+    Type selfInterfaceType;
+    if (auto *calleeProto =
+            declRef.getDecl()->getDeclContext()->getSelfProtocolDecl()) {
+      selfInterfaceType = calleeProto->getSelfInterfaceType();
+    }
+
+    for (auto conf : subs.getConformances()) {
+      // We're only checking abstract conformances here; concrete ones
+      // were checked above already.
+      if (!conf.isAbstract())
+        continue;
+
+      auto *abstract = conf.getAbstract();
+      auto *proto = abstract->getProtocol();
+      Type conformingType = abstract->getType();
+
+      // Skip Self conformances; these should be diagnosed already in other ways
+      if (selfInterfaceType) {
+        if (auto *archetype = conformingType->getAs<ArchetypeType>()) {
+          if (archetype->getInterfaceType()->isEqual(selfInterfaceType))
+            continue;
+        }
+      }
+
+      // Marker protocols have no requirements and can never be isolated.
+      if (proto->isMarkerProtocol())
+        continue;
+
+      // Protocols inheriting from SendableMetatype cannot have isolated
+      // conformances.
+      if (sendableMetatypeProto &&
+          proto->inheritsFrom(sendableMetatypeProto))
+        continue;
+
+      // If the conforming type is Sendable, its conformances cannot be
+      // isolated — isolated conformances require non-Sendable types.
+      if (auto *archetype = conformingType->getAs<ArchetypeType>()) {
+        if (auto *sendableProto =
+                ctx.getProtocol(KnownProtocolKind::Sendable)) {
+          bool isSendable =
+              llvm::any_of(archetype->getConformsTo(), [&](ProtocolDecl *p) {
+                return p == sendableProto || p->inheritsFrom(sendableProto);
+              });
+
+          if (isSendable)
+            continue;
+        }
+      }
+
+      // Get the name of the generic type parameter for the diagnostic.
+      // For opaque types ('some Protocol'), we leave the name empty so
+      // the diagnostic uses "underlying type of 'some Proto'" instead.
+      Identifier genericParamName;
+      if (auto *archetype = conformingType->getAs<ArchetypeType>()) {
+        if (!archetype->getAs<OpaqueTypeArchetypeType>())
+          genericParamName = archetype->getName();
+      }
+
+      ctx.Diags
+          .diagnose(loc, diag::isolated_conformance_may_cross_isolation,
+                    genericParamName, proto->getName().str(), targetIsolation)
+          .warnUntilLanguageMode(LanguageMode::v6);
+      diagnosed = true;
+    }
+  }
+
+  return diagnosed;
 }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -9126,15 +9126,8 @@ bool swift::checkIsolatedConformancesForIsolationCrossing(
       // If the conforming type is Sendable, its conformances cannot be
       // isolated — isolated conformances require non-Sendable types.
       if (auto *archetype = conformingType->getAs<ArchetypeType>()) {
-        if (auto *sendableProto =
-                ctx.getProtocol(KnownProtocolKind::Sendable)) {
-          bool isSendable =
-              llvm::any_of(archetype->getConformsTo(), [&](ProtocolDecl *p) {
-                return p == sendableProto || p->inheritsFrom(sendableProto);
-              });
-
-          if (isSendable)
-            continue;
+        if (archetype->isSendableType()) {
+          continue;
         }
       }
 

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -792,6 +792,18 @@ bool checkIsolatedConformancesInContext(
     Type type, SourceLoc loc, const DeclContext *dc,
     HandleConformanceIsolationFn handleBad = doNotDiagnoseConformanceIsolation);
 
+/// Check for isolated conformances escaping through a call that crosses
+/// an isolation boundary. The conformances in the 'declRef' are checked against
+/// the given target isolation of the call rather than the isolation of its
+/// DeclContext.
+///
+/// Also checks for abstract (generic) conformances that may be isolated,
+/// skipping Self conformances for protocol members (used only for dispatch).
+bool checkIsolatedConformancesForIsolationCrossing(
+    ConcreteDeclRef declRef, SourceLoc loc,
+    ActorIsolation targetIsolation, const DeclContext *dc,
+    HandleConformanceIsolationFn handleBad = doNotDiagnoseConformanceIsolation);
+
 /// For a protocol conformance that does not have a "raw" isolation, infer its isolation.
 ///
 /// - hasKnownIsolatedWitness: indicates when it is known that there is an actor-isolated witness, meaning

--- a/test/Concurrency/isolated_conformance_generic_escape.swift
+++ b/test/Concurrency/isolated_conformance_generic_escape.swift
@@ -1,0 +1,173 @@
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple -swift-version 6
+
+// REQUIRES: concurrency
+
+// This verifies additional enforcement of Rule (1) from the
+// isolated conformances proposal: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0470-isolated-conformances.md
+// We must not allow escaping an isolated conformance through generic parameters
+// into a context that is isolated differently, because we may then end up calling e.g.
+// a synchronous requirement from the wrong isolated context and violate actor isolation.
+// rdar://173120506
+
+import _Concurrency
+
+protocol MyProtocol {
+  func doSomething()
+
+  @MainActor
+  func doSomethingOnMainActor()
+}
+
+@MainActor
+class MyClass: @MainActor MyProtocol {
+  func doSomething() {
+    MainActor.shared.assertIsolated()
+  }
+
+  @MainActor
+  func doSomethingOnMainActor() {
+    MainActor.shared.assertIsolated()
+  }
+}
+
+// ==== -----------------------------------------------------------------------
+// MARK: @concurrent callees — disallowed
+
+@concurrent
+func callDoSomethingConcurrent(_ p: some MyProtocol) async {
+  p.doSomething() // bad, would call actor synchronously from other context
+}
+
+// ==== -----------------------------------------------------------------------
+// MARK: nonisolated(nonsending) callees — inherits caller's executor
+
+nonisolated(nonsending) func callDoSomethingNonisolatedNonsending(_ p: some MyProtocol) async {
+  p.doSomething() // ok, inherits caller's isolation
+}
+
+// ==== -----------------------------------------------------------------------
+// MARK: nonisolated(nonsending) that forwards to @concurrent — error in body
+
+// When the conformance is concrete (not generic), the error is caught at the
+// forwarding call site inside the nonisolated(nonsending) function body.
+nonisolated(nonsending) func nonsendingForwardToConcurrent(_ p: MyClass) async {
+  // expected-error@+1{{main actor-isolated conformance of 'MyClass' to 'MyProtocol' cannot be used in nonisolated context}}
+  await callDoSomethingConcurrent(p)
+}
+
+// When the conformance is abstract (generic), we reject it because the concrete
+// conformance may be isolated.
+nonisolated(nonsending) func nonsendingForwardToConcurrentGeneric(_ p: some MyProtocol) async {
+  // expected-error@+1{{conformance of underlying type of 'some MyProtocol' to protocol 'MyProtocol' may be isolated and cannot be passed to nonisolated context}}
+  await callDoSomethingConcurrent(p)
+}
+
+struct Container<T: MyProtocol> {
+  nonisolated(nonsending) func nonsendingForwardToConcurrentGeneric(_ p: T) async {
+    // expected-error@+1{{conformance of 'T' to protocol 'MyProtocol' may be isolated and cannot be passed to nonisolated context}}
+    await callDoSomethingConcurrent(p)
+  }
+}
+
+// Sendable protocols cannot have isolated conformances, so forwarding is safe.
+protocol SendableProtocol: Sendable {
+  func doSomething()
+}
+
+@concurrent
+func callSendableProtocol(_ p: some SendableProtocol) async {
+  p.doSomething()
+}
+
+@concurrent
+func callSendableProtocolComp(_ p: some (MyProtocol & Sendable)) async {
+  p.doSomething()
+}
+
+nonisolated(nonsending) func nonsendingForwardSendableGeneric(_ p: some SendableProtocol) async {
+  await callSendableProtocol(p) // ok, Sendable protocols can't have isolated conformances
+}
+
+nonisolated(nonsending) func nonsendingForwardSendableGenericComp<P: MyProtocol>(_ p: P) async { // expected-note{{consider making generic parameter 'P' conform to the 'Sendable' protocol}}
+  // expected-error@+2{{conformance of 'P' to protocol 'MyProtocol' may be isolated and cannot be passed to nonisolated context}}
+  // expected-error@+1{{type 'P' does not conform to the 'Sendable' protocol}}
+  await callSendableProtocolComp(p)
+}
+
+final class Caller {
+  @concurrent func call(first p: some MyProtocol, second fine: String) async { p.doSomething() }
+}
+nonisolated(nonsending) func nonsendingForwardSendableGeneric(caller: Caller, _ p: some MyProtocol) async {
+  // expected-error@+1{{conformance of underlying type of 'some MyProtocol' to protocol 'MyProtocol' may be isolated and cannot be passed to nonisolated context}}
+  await caller.call(first: p, second: "this is fine")
+}
+
+// Callee with explicit generic parameter — the name appears in the diagnostic.
+@concurrent
+func callDoSomethingConcurrentExplicit<ItsMe: MyProtocol>(_ p: ItsMe) async {
+  p.doSomething()
+}
+
+nonisolated(nonsending) func nonsendingForwardExplicitGeneric<TheProblemIsNotHere: MyProtocol>(_ p: TheProblemIsNotHere) async {
+  // expected-error@+1{{conformance of 'TheProblemIsNotHere' to protocol 'MyProtocol' may be isolated and cannot be passed to nonisolated context}}
+  await callDoSomethingConcurrentExplicit(p)
+}
+
+@concurrent func nonsendingForwardSendableGeneric(_ p: some MyProtocol) async {
+  await p.doSomethingOnMainActor() // ok: requirement is @MainActor, hop is explicit
+}
+
+// @MainActor forwarding generic to @concurrent — same issue, rejected.
+@MainActor
+func mainActorForwardToConcurrentGeneric(_ p: some MyProtocol) async {
+  // expected-error@+1{{conformance of underlying type of 'some MyProtocol' to protocol 'MyProtocol' may be isolated and cannot be passed to nonisolated context}}
+  await callDoSomethingConcurrent(p)
+}
+
+// ==== -----------------------------------------------------------------------
+// MARK: Different global actor callee - disallowed
+
+@globalActor actor OtherActor {
+  static let shared = OtherActor()
+}
+
+@OtherActor
+func callDoSomethingFromOtherActor(_ p: some MyProtocol) async {
+  p.doSomething()
+}
+
+@MainActor
+func test1() async {
+  // Different global actor callee — not allowed, same as hopping to global executor, we don't allow ANY other isolation
+  // expected-error@+1{{main actor-isolated conformance of 'MyClass' to 'MyProtocol' cannot be used in global actor 'OtherActor'-isolated context}}
+  await callDoSomethingFromOtherActor(MyClass())
+}
+
+// ==== -----------------------------------------------------------------------
+// MARK: @MainActor callee — same isolation domain, ok
+
+@MainActor
+func callDoSomethingFromMainActor(_ p: some MyProtocol) async {
+  p.doSomething()
+}
+
+// ==== -----------------------------------------------------------------------
+// MARK: Tests
+
+@MainActor
+func test() async {
+  // @concurrent async - don't allow changing execution context, would allow synchronous call on actor
+  // expected-error@+1{{main actor-isolated conformance of 'MyClass' to 'MyProtocol' cannot be used in nonisolated context}}
+  await callDoSomethingConcurrent(MyClass())
+
+  // nonisolated(nonsending) — inherits caller's isolation, this is allowed
+  await callDoSomethingNonisolatedNonsending(MyClass())
+
+  // nonisolated(nonsending) that forwards to @concurrent — the error is
+  // caught at the forwarding call site inside the func, not here
+  await nonsendingForwardToConcurrent(MyClass())
+  await nonsendingForwardToConcurrentGeneric(MyClass())
+
+  // @MainActor callee — same caller isolation, this is allowed
+  await callDoSomethingFromMainActor(MyClass())
+}

--- a/test/Concurrency/isolated_conformance_generic_escape.swift
+++ b/test/Concurrency/isolated_conformance_generic_escape.swift
@@ -102,6 +102,20 @@ nonisolated(nonsending) func nonsendingForwardSendableGeneric(caller: Caller, _ 
   await caller.call(first: p, second: "this is fine")
 }
 
+// Sendable superclass — a generic parameter constrained to a Sendable
+// superclass is itself Sendable, so its conformances cannot be isolated.
+class SendableBase: @unchecked Sendable {}
+class SendableMiddle: SendableBase, @unchecked Sendable {}
+
+@concurrent
+func callSendableSuperclass<T: SendableMiddle & MyProtocol>(_ p: T) async {
+  p.doSomething()
+}
+
+nonisolated(nonsending) func nonsendingForwardSendableSuperclass<T: SendableMiddle & MyProtocol>(_ p: T) async {
+  await callSendableSuperclass(p) // ok, Sendable superclass means no isolated conformances
+}
+
 // Callee with explicit generic parameter — the name appears in the diagnostic.
 @concurrent
 func callDoSomethingConcurrentExplicit<ItsMe: MyProtocol>(_ p: ItsMe) async {


### PR DESCRIPTION
Reverts the revert https://github.com/swiftlang/swift/pull/88145

So, reapplies https://github.com/swiftlang/swift/pull/88030 after we are certain we can land the change.

> This fixes holes in "rule 1" checking of [SE-470](https://swiftlang.github.io/swift-> evolution/#?proposal=SE-470) which was supposed to
> protect escaping isolated conformances to other execution contexts:
> 
> An isolated conformance can only be used within its isolation domain.
> When using an async method with a generic parameter we allowed an
> isolated conformance to escape to it; and then allowed, wrongly, to call
> synchronous protocol requirements on it. This horribly violates actor
> isolation since the actual type is actor isolated yet we SYNCHRONOUSLY
> called a method on it, resulting in actor isolation violations.
> 
> This is even worse in accessible concurrency because isolated
> conformances are inferred and you don't even know you're using them,
> yet the compiler happily allows you to call synchronous methods on
> actors from wrong isolations due to this problem.
> 
> The solution is to more carefully check async methods for crossing
isolation boundaries.
> 
> Synchronous methods are safe because the're always strictly on the same
> context AND if they wanted to escape the passed parameter to another
> context, Sendable checking (rule 2) would prevent this from happening.

Risk: Low, we qualified that change with @xedin and it seems it causes no regressions

rdar://173120506