### PR TITLE
[stdlib] Form a single-element Span over a value

### DIFF
--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -667,6 +667,7 @@ function(_compile_swift_files
 
   list(APPEND swift_flags "-enable-experimental-feature" "NonescapableTypes")
   list(APPEND swift_flags "-enable-experimental-feature" "Lifetimes")
+  list(APPEND swift_flags "-enable-experimental-feature" "AddressableParameters")
 
   list(APPEND swift_flags "-enable-upcoming-feature" "MemberImportVisibility")
 

--- a/stdlib/public/core/Span/MutableRawSpan.swift
+++ b/stdlib/public/core/Span/MutableRawSpan.swift
@@ -182,6 +182,26 @@ extension MutableRawSpan {
   ) {
     self = unsafe Self.init(unsafeElements: elements)
   }
+
+  /// Create a mutable span over the bytes of the value passed as a parameter.
+  ///
+  /// The `MutableRawSpan` created by this initializer will represent a
+  /// mutation of `value`.
+  ///
+  /// - Parameters:
+  ///   - value: a value to be mutated through the span
+  @export(implementation)
+  @_lifetime(&value)
+  public init<Element: ConvertibleToBytes & ConvertibleFromBytes>(
+    _ value: inout Element
+  ) {
+    let buffer = unsafe UnsafeMutableRawBufferPointer(
+      start: .init(Builtin.unprotectedAddressOfBorrow(value)),
+      count: MemoryLayout<Element>.size
+    )
+    let span = unsafe MutableRawSpan(_unsafeBytes: buffer)
+    self = unsafe _overrideLifetime(span, mutating: &value)
+  }
 }
 
 @available(SwiftCompatibilitySpan 5.0, *)

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -100,6 +100,14 @@ extension MutableSpan where Element: ~Copyable {
     let ms = unsafe MutableSpan(_unsafeElements: buffer)
     self = unsafe _overrideLifetime(ms, borrowing: start)
   }
+
+  @_alwaysEmitIntoClient
+  @lifetime(&value)
+  public init(_ value: inout Element) {
+    let address = Builtin.unprotectedAddressOfBorrow(value)
+    let span = unsafe MutableSpan(_unchecked: .init(address), count: 1)
+    self = unsafe _overrideLifetime(span, mutating: &value)
+  }
 }
 
 @available(SwiftCompatibilitySpan 5.0, *)

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -56,7 +56,7 @@ public struct MutableSpan<Element: ~Copyable>
   }
 
   @unsafe
-  @_alwaysEmitIntoClient
+  @export(implementation)
   @_lifetime(borrow start)
   @_transparent
   internal init(
@@ -113,6 +113,21 @@ extension MutableSpan where Element: ~Copyable {
     let buffer = unsafe UnsafeMutableBufferPointer(start: start, count: count)
     let ms = unsafe MutableSpan(_unsafeElements: buffer)
     self = unsafe _overrideLifetime(ms, borrowing: start)
+  }
+
+  /// Create a mutable span over the single value passed as a parameter.
+  ///
+  /// The created `MutableSpan` by this initializer will represent a
+  /// mutation of `value`.
+  ///
+  /// - Parameters:
+  ///   - value: a value to be mutated through the span
+  @export(implementation)
+  @_lifetime(&value)
+  public init(_ value: inout Element) {
+    let address = Builtin.unprotectedAddressOfBorrow(value)
+    let span = unsafe MutableSpan(_unchecked: .init(address), count: 1)
+    self = unsafe _overrideLifetime(span, mutating: &value)
   }
 }
 

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -356,6 +356,23 @@ extension RawSpan {
   public init<Element: ConvertibleToBytes>(elements span: Span<Element>) {
     unsafe self = Self.init(unsafeElements: span)
   }
+
+  /// Create a span over the bytes of the single value passed as a parameter.
+  ///
+  /// - Parameters:
+  ///   - value: a value to be borrowed by the span
+  @export(implementation)
+  @_lifetime(borrow value)
+  public init<Element: ConvertibleToBytes>(
+    _ value: borrowing @_addressable Element
+  ) {
+    let buffer = unsafe UnsafeRawBufferPointer(
+      start: .init(Builtin.unprotectedAddressOfBorrow(value)),
+      count: MemoryLayout<Element>.size
+    )
+    let span = unsafe RawSpan(_unsafeBytes: buffer)
+    self = unsafe _overrideLifetime(span, borrowing: value)
+  }
 }
 
 @available(SwiftCompatibilitySpan 5.0, *)

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -165,6 +165,14 @@ extension Span where Element: ~Copyable {
     // lifetime of 'pointer'. Make the dependence explicit.
     self = unsafe _overrideLifetime(span, borrowing: pointer)
   }
+
+  @_alwaysEmitIntoClient
+  @lifetime(borrow value)
+  public init(_ value: borrowing @_addressable Element) {
+    let address = Builtin.unprotectedAddressOfBorrow(value)
+    let span = unsafe Span(_unchecked: .init(address), count: 1)
+    self = unsafe _overrideLifetime(span, borrowing: value)
+  }
 }
 
 @available(SwiftCompatibilitySpan 5.0, *)

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -193,6 +193,18 @@ extension Span where Element: ~Copyable {
     // lifetime of 'pointer'. Make the dependence explicit.
     self = unsafe _overrideLifetime(span, borrowing: pointer)
   }
+
+  /// Create a span over the single value passed as a parameter.
+  ///
+  /// - Parameters:
+  ///   - value: a value to be borrowed by the span
+  @export(implementation)
+  @_lifetime(borrow value)
+  public init(_ value: borrowing @_addressable Element) {
+    let address = Builtin.unprotectedAddressOfBorrow(value)
+    let span = unsafe Span(_unchecked: .init(address), count: 1)
+    self = unsafe _overrideLifetime(span, borrowing: value)
+  }
 }
 
 @available(SwiftCompatibilitySpan 5.0, *)

--- a/stdlib/toolchain/CompatibilitySpan/CMakeLists.txt
+++ b/stdlib/toolchain/CompatibilitySpan/CMakeLists.txt
@@ -22,6 +22,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND DEFINED SWIFT_STDLIB_LIBRARY_BUILD_TY
 
     SWIFT_COMPILE_FLAGS
       ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
+      -enable-experimental-feature AddressableParameters
       -parse-stdlib
       -module-abi-name Swift
       -DSPAN_COMPATIBILITY_STUB

--- a/test/stdlib/Span/MutableRawSpanTests.swift
+++ b/test/stdlib/Span/MutableRawSpanTests.swift
@@ -892,6 +892,61 @@ suite.test("MutableRawSpan storeBytes repeating with ByteOrder")
   }
 }
 
+suite.test("init(_:) from value")
+.require(.minimumStdlib(.stdlib_6_5)).code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  var inline: [5 of UInt8] = [0, 1, 2, 3, 4]
+  let count = inline.count
+
+  var bytes = MutableRawSpan(&inline)
+  expectEqual(bytes.byteCount, count)
+  for o in bytes.byteOffsets {
+    bytes[o] += 1
+  }
+  _ = consume bytes
+
+  for i in inline.indices {
+    expectEqual(inline[i], UInt8(i + 1))
+  }
+}
+
+suite.test("init(_:) from value: round-trip")
+.require(.minimumStdlib(.stdlib_6_5)).code {
+  var value = UInt64.zero
+
+  var bytes = MutableRawSpan(&value)
+  expectEqual(bytes.byteCount, MemoryLayout<UInt64>.size)
+  bytes.storeBytes(of: UInt64.max, toByteOffset: 0, as: UInt64.self)
+  _ = consume bytes
+
+  expectEqual(value, .max)
+}
+
+suite.test("init(_:) from value: compare with indirect approach")
+.require(.minimumStdlib(.stdlib_6_5)).code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  var a: [5 of UInt8] = [0, 1, 2, 3, 4]
+  var b = a
+
+  var directBytes = MutableRawSpan(&a)
+  let directByteCount = directBytes.byteCount
+  directBytes.storeBytes(of: UInt16.max, toByteOffset: 2, as: UInt16.self)
+  _ = consume directBytes
+
+  var span = MutableSpan<InlineArray>(&b)
+  var spanBytes = span.mutableBytes
+  expectEqual(directByteCount, spanBytes.byteCount)
+  spanBytes.storeBytes(of: UInt16.max, toByteOffset: 2, as: UInt16.self)
+  _ = consume spanBytes
+  _ = consume span
+
+  for i in a.indices {
+    expectEqual(a[i], b[i])
+  }
+}
+
 private func send(_: borrowing some Sendable & ~Copyable & ~Escapable) {}
 
 suite.test("MutableRawSpan Sendability")

--- a/test/stdlib/Span/MutableRawSpanTests.swift
+++ b/test/stdlib/Span/MutableRawSpanTests.swift
@@ -14,6 +14,9 @@
 
 // REQUIRES: executable_test
 
+// This file triggers issue https://github.com/swiftlang/swift/issues/91660.
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
+
 import StdlibUnittest
 
 var suite = TestSuite("MutableRawSpan Tests")

--- a/test/stdlib/Span/MutableRawSpanTests.swift
+++ b/test/stdlib/Span/MutableRawSpanTests.swift
@@ -446,7 +446,7 @@ suite.test("_consumingExtracting() bounds checking")
 .crashOutputMatches("Byte offset range out of bounds", when: _isDebugAssertConfiguration())
 .code {
   var b: ContiguousArray<Int> = [1, 2, 3, 4]
-  var span = MutableRawSpan(elements: b.mutableSpan)
+  let span = MutableRawSpan(elements: b.mutableSpan)
   expectCrashLater()
   _ = span._consumingExtracting(2 ..< .max)
 }
@@ -596,7 +596,7 @@ suite.test("_consumingExtracting(first:) bound checking")
 .crashOutputMatches("Can't have a prefix of negative length", when: _isDebugAssertConfiguration())
 .code {
   var b: ContiguousArray<Int> = [1, 2, 3, 4]
-  var span = MutableRawSpan(elements: b.mutableSpan)
+  let span = MutableRawSpan(elements: b.mutableSpan)
   expectCrashLater()
   _ = span._consumingExtracting(first: -1)
 }
@@ -607,7 +607,7 @@ suite.test("_consumingExtracting(droppingLast:) bound checking")
 .crashOutputMatches("Can't drop a negative number of bytes", when: _isDebugAssertConfiguration())
 .code {
   var b: ContiguousArray<Int> = [1, 2, 3, 4]
-  var span = MutableRawSpan(elements: b.mutableSpan)
+  let span = MutableRawSpan(elements: b.mutableSpan)
   expectCrashLater()
   _ = span._consumingExtracting(droppingLast: -1)
 }
@@ -723,7 +723,7 @@ suite.test("_consumingExtracting(last:) bound checking")
 .crashOutputMatches("Can't have a suffix of negative length", when: _isDebugAssertConfiguration())
 .code {
   var b: ContiguousArray<Int> = [1, 2, 3, 4]
-  var span = MutableRawSpan(elements: b.mutableSpan)
+  let span = MutableRawSpan(elements: b.mutableSpan)
   expectCrashLater()
   _ = span._consumingExtracting(last: -1)
 }
@@ -734,7 +734,7 @@ suite.test("_consumingExtracting(droppingFirst:) bound checking")
 .crashOutputMatches("Can't drop a negative number of bytes", when: _isDebugAssertConfiguration())
 .code {
   var b: ContiguousArray<Int> = [1, 2, 3, 4]
-  var span = MutableRawSpan(elements: b.mutableSpan)
+  let span = MutableRawSpan(elements: b.mutableSpan)
   expectCrashLater()
   _ = span._consumingExtracting(droppingFirst: -1)
 }

--- a/test/stdlib/Span/MutableSpanTests.swift
+++ b/test/stdlib/Span/MutableSpanTests.swift
@@ -629,6 +629,28 @@ suite.test("MutableSpan from UnsafeMutableBufferPointer")
   expectTrue(b.elementsEqual((0..<capacity).reversed()))
 }
 
+suite.test("MutableSpan init from value")
+.require(.stdlib_6_4).code {
+  guard #available(SwiftStdlib 6.2, *) else { expectTrue(false); return }
+
+  var inline: InlineArray<5, UInt8> = [UInt8.zero, 1, 2, 3, 4]
+  let count = inline.count
+
+  var span = MutableSpan(&inline)
+  expectEqual(span.count, 1)
+  var bytes = span.mutableBytes
+  expectEqual(bytes.byteCount, count)
+  for o in bytes.byteOffsets {
+    let b = bytes.unsafeLoad(fromByteOffset: o, as: UInt8.self)
+    bytes.storeBytes(of: b&+1, toByteOffset: o, as: UInt8.self)
+  }
+  _ = consume span // access through `span` formally ends here
+
+  for i in inline.indices {
+    expectEqual(Int(inline[i]), i+1)
+  }
+}
+
 private func send(_: borrowing some Sendable & ~Copyable & ~Escapable) {}
 
 private struct NCSendable: ~Copyable, Sendable {}

--- a/test/stdlib/Span/MutableSpanTests.swift
+++ b/test/stdlib/Span/MutableSpanTests.swift
@@ -748,6 +748,28 @@ suite.test("MutableSpan from UnsafeMutableBufferPointer")
   expectTrue(b.elementsEqual((0..<capacity).reversed()))
 }
 
+suite.test("MutableSpan init from value")
+.require(.stdlib_6_5).code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  var inline: InlineArray<5, UInt8> = [UInt8.zero, 1, 2, 3, 4]
+  let count = inline.count
+
+  var span = MutableSpan(&inline)
+  expectEqual(span.count, 1)
+  var bytes = span.mutableBytes
+  expectEqual(bytes.byteCount, count)
+  for o in bytes.byteOffsets {
+    let b = bytes.unsafeLoad(fromByteOffset: o, as: UInt8.self)
+    bytes.storeBytes(of: b&+1, toByteOffset: o, as: UInt8.self)
+  }
+  _ = consume span // access through `span` formally ends here
+
+  for i in inline.indices {
+    expectEqual(Int(inline[i]), i+1)
+  }
+}
+
 private func send(_: borrowing some Sendable & ~Copyable & ~Escapable) {}
 
 private struct NCSendable: ~Copyable, Sendable {}

--- a/test/stdlib/Span/RawSpanTests.swift
+++ b/test/stdlib/Span/RawSpanTests.swift
@@ -16,7 +16,7 @@
 
 import StdlibUnittest
 
-var suite = TestSuite("Span Tests")
+var suite = TestSuite("RawSpan Tests")
 defer { runAllTests() }
 
 suite.test("Initialize with Span<Int>")
@@ -491,6 +491,40 @@ suite.test("RawSpan init(elements:)")
   let array = ContiguousArray(0..<capacity)
   let bytes = array.span.bytes
   expectEqual(bytes.byteCount, capacity * MemoryLayout<Int>.stride)
+}
+
+suite.test("init(_:) from value")
+.require(.minimumStdlib(.stdlib_6_5)).code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let inline: [5 of UInt8] = [0, 1, 2, 3, 4]
+
+  let bytes = RawSpan(inline)
+  expectEqual(bytes.byteCount, MemoryLayout<InlineArray<5, UInt8>>.size)
+  expectEqual(bytes.byteCount, inline.count)
+  for o in bytes.byteOffsets {
+    expectEqual(bytes[o], inline[o])
+  }
+}
+
+suite.test("init(_:) from value: round trip")
+.require(.minimumStdlib(.stdlib_6_5)).code {
+  let value = UInt64.random(in: .max/2 ... .max)
+
+  let bytes = RawSpan(value)
+  expectEqual(bytes.byteCount, MemoryLayout<UInt64>.size)
+  expectEqual(
+    bytes.load(fromByteOffset: 0, as: Int64.self), Int64(bitPattern: value)
+  )
+}
+
+suite.test("init(_:) from value: compare with indirect approach")
+.require(.minimumStdlib(.stdlib_6_5)).code {
+  let value = Duration.seconds(3) + .nanoseconds(14)
+
+  let direct = RawSpan(value)
+  let viaSpan = Span(value).bytes
+  expectTrue(direct.isIdentical(to: viaSpan))
 }
 
 suite.test("Typed Span")

--- a/test/stdlib/Span/RawSpanTests.swift
+++ b/test/stdlib/Span/RawSpanTests.swift
@@ -14,6 +14,9 @@
 
 // REQUIRES: executable_test
 
+// This file triggers issue https://github.com/swiftlang/swift/issues/91660.
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
+
 import StdlibUnittest
 
 var suite = TestSuite("RawSpan Tests")

--- a/test/stdlib/Span/SpanTests.swift
+++ b/test/stdlib/Span/SpanTests.swift
@@ -637,6 +637,25 @@ suite.test("initialize from raw memory")
   expectEqual(first, 0x07060504)
 }
 
+suite.test("SpanInitFromValue")
+.require(.stdlib_6_4).code {
+  guard #available(SwiftStdlib 6.2, *) else { expectTrue(false); return }
+
+  let inline: InlineArray<5, UInt8> = [UInt8.zero, 1, 2, 3, 4]
+
+  let span = Span(inline)
+  let bytes = span.bytes
+  for o in bytes.byteOffsets {
+    let b = bytes.unsafeLoad(fromByteOffset: o, as: UInt8.self)
+    let i = inline[o]
+    expectEqual(b, i)
+  }
+
+  let s = "A very long string, indeed not a smol one."
+  let strSpan = Span(s)
+  expectEqual(strSpan.count, 1)
+}
+
 private func send(_: some Sendable & ~Escapable) {}
 
 private struct NCSendable: ~Copyable, Sendable {}

--- a/test/stdlib/Span/SpanTests.swift
+++ b/test/stdlib/Span/SpanTests.swift
@@ -678,6 +678,25 @@ suite.test("initialize from raw memory")
   expectEqual(first, 0x07060504)
 }
 
+suite.test("SpanInitFromValue")
+.require(.stdlib_6_5).code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let inline: InlineArray<5, UInt8> = [UInt8.zero, 1, 2, 3, 4]
+
+  let span = Span(inline)
+  let bytes = span.bytes
+  for o in bytes.byteOffsets {
+    let b = bytes.unsafeLoad(fromByteOffset: o, as: UInt8.self)
+    let i = inline[o]
+    expectEqual(b, i)
+  }
+
+  let s = "A very long string, indeed not a smol one."
+  let strSpan = Span(s)
+  expectEqual(strSpan.count, 1)
+}
+
 private func send(_: some Sendable & ~Escapable) {}
 
 private struct NCSendable: ~Copyable, Sendable {}


### PR DESCRIPTION
Form a Span over the value in any binding, and a MutableSpan over any mutable binding.

Addresses rdar://156165923 and rdar://167869600