### PR TITLE
[stdlib] form a Span from an Optional

### DIFF
--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -4291,13 +4291,24 @@ LValue SILGenLValue::visitMemberRefExpr(MemberRefExpr *e,
   CanType substFormalRValueType = getSubstFormalRValueType(e);
   CanType baseTy = getBaseFormalType(e->getBase());
   AbstractionPattern orig = AbstractionPattern::getInvalid();
+
+  AccessorDecl *calleeAccessor = strategy.hasAccessor()
+    ? var->getAccessor(strategy.getAccessor())
+    : nullptr;
+  ParamDecl *calleeAccessorSelfParam = calleeAccessor
+    ? calleeAccessor->getImplicitSelfDecl()
+    : nullptr;
+  
   bool addressable = false;
-  // If the access produces a dependent value, and the base is addressable-for-
-  // dependencies, then request an addressable base.
-  if (!substFormalRValueType->isEscapable()
-      && SGF.getTypeProperties(baseTy).isAddressableForDependencies()) {
-    addressable = true;
-    orig = AbstractionPattern::getOpaque();
+  // If the access produces a dependent value, and the base is addressable,
+  // then request an addressable base.
+  if (!substFormalRValueType->isEscapable()) {
+    addressable = SGF.getTypeProperties(baseTy).isAddressableForDependencies()
+      || (calleeAccessorSelfParam && calleeAccessorSelfParam->isAddressable());
+      
+    if (addressable) {
+      orig = AbstractionPattern::getOpaque();
+    }
   }
   
   LValue lv = visitRec(e->getBase(),

--- a/stdlib/public/core/BorrowingSequence.swift
+++ b/stdlib/public/core/BorrowingSequence.swift
@@ -213,7 +213,7 @@ public struct BorrowingIteratorAdapter<Iterator: IteratorProtocol>: BorrowingIte
   @lifetime(&self)
   public mutating func nextSpan(maximumCount: Int) -> Span<Iterator.Element> {
     curValue = iterator.next()
-    return curValue._span()
+    return curValue.span
   }
 }
 

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -427,6 +427,20 @@ extension Optional where Wrapped: ~Copyable & Escapable {
     return unsafe _overrideLifetime(s, borrowing: self)
   }
 
+  public var span: Span<Wrapped> {
+    @_alwaysEmitIntoClient
+    @_addressableSelf
+    @lifetime(borrow self)
+    borrowing get {
+      if self == nil {
+        return Span()
+      }
+      let a = Builtin.unprotectedAddressOfBorrow(self)
+      let s = unsafe Span<Wrapped>(_unsafeStart: .init(a), count: 1)
+      return unsafe _overrideLifetime(s, borrowing: self)
+    }
+  }
+
   public var mutableSpan: MutableSpan<Wrapped> {
     @_alwaysEmitIntoClient
     @lifetime(&self)

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -426,6 +426,19 @@ extension Optional where Wrapped: ~Copyable & Escapable {
     let s = unsafe Span<Wrapped>(_unsafeStart: .init(a), count: 1)
     return unsafe _overrideLifetime(s, borrowing: self)
   }
+
+  public var mutableSpan: MutableSpan<Wrapped> {
+    @_alwaysEmitIntoClient
+    @lifetime(&self)
+    mutating get {
+      if self == nil {
+        return MutableSpan()
+      }
+      let a = Builtin.unprotectedAddressOfBorrow(self)
+      let s = unsafe MutableSpan<Wrapped>(_unsafeStart: .init(a), count: 1)
+      return unsafe _overrideLifetime(s, borrowing: self)
+    }
+  }
 }
 
 extension Optional where Wrapped: ~Copyable & ~Escapable {

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -415,24 +415,17 @@ extension Optional where Wrapped: ~Copyable & ~Escapable {
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension Optional where Wrapped: ~Copyable & Escapable {
+  @available(*, deprecated, renamed: "span")
   @_alwaysEmitIntoClient
   @_addressableSelf
   @lifetime(borrow self)
-  public func _span() -> Span<Wrapped> {
-    if self == nil {
-      return Span()
-    }
-    let a = Builtin.unprotectedAddressOfBorrow(self)
-    let s = unsafe Span<Wrapped>(_unsafeStart: .init(a), count: 1)
-    return unsafe _overrideLifetime(s, borrowing: self)
-  }
+  public func _span() -> Span<Wrapped> { span }
 
   public var span: Span<Wrapped> {
     @_alwaysEmitIntoClient
     @_addressableSelf
     @lifetime(borrow self)
     borrowing get {
-      // FIXME: rdar://173472004. The `_span()` function below works as expected.
       if self == nil {
         return Span()
       }

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -432,6 +432,7 @@ extension Optional where Wrapped: ~Copyable & Escapable {
     @_addressableSelf
     @lifetime(borrow self)
     borrowing get {
+      // FIXME: rdar://173472004. The `_span()` function below works as expected.
       if self == nil {
         return Span()
       }

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -427,6 +427,20 @@ extension Optional where Wrapped: ~Copyable & Escapable {
     return unsafe _overrideLifetime(s, borrowing: self)
   }
 
+  public var span: Span<Wrapped> {
+    @export(implementation)
+    @_addressableSelf
+    @_lifetime(borrow self)
+    borrowing get {
+      let count = (self == nil) ? 0 : 1
+      let address = Builtin.unprotectedAddressOfBorrow(self)
+      let span = unsafe Span<Wrapped>(
+        _unchecked: UnsafePointer(address), count: count
+      )
+      return unsafe _overrideLifetime(span, borrowing: self)
+    }
+  }
+
   public var mutableSpan: MutableSpan<Wrapped> {
     @export(implementation)
     @_lifetime(&self)

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -426,6 +426,19 @@ extension Optional where Wrapped: ~Copyable & Escapable {
     let s = unsafe Span<Wrapped>(_unsafeStart: .init(a), count: 1)
     return unsafe _overrideLifetime(s, borrowing: self)
   }
+
+  public var mutableSpan: MutableSpan<Wrapped> {
+    @export(implementation)
+    @_lifetime(&self)
+    mutating get {
+      let count = (self == nil) ? 0 : 1
+      let address = Builtin.unprotectedAddressOfBorrow(self)
+      let span = unsafe MutableSpan<Wrapped>(
+        _unchecked: UnsafeMutablePointer(address), count: count
+      )
+      return unsafe _overrideLifetime(span, mutating: &self)
+    }
+  }
 }
 
 extension Optional where Wrapped: ~Copyable & ~Escapable {

--- a/test/SILOptimizer/lifetime_dependence/addressable_accessor_self.swift
+++ b/test/SILOptimizer/lifetime_dependence/addressable_accessor_self.swift
@@ -1,0 +1,46 @@
+// RUN: %target-swift-emit-sil -enable-experimental-feature Lifetimes -enable-experimental-feature AddressableParameters -verify %s
+//
+// REQUIRES: swift_feature_AddressableParameters
+// REQUIRES: swift_feature_Lifetimes
+
+struct Optionable<Wrapped: ~Copyable>: ~Copyable {
+  public var span: Span<Wrapped> {
+    @_addressableSelf
+    @_lifetime(borrow self)
+    get {
+		fatalError()
+    }
+  }
+
+  @_addressableSelf
+  @_lifetime(borrow self)
+  public func getSpan() -> Span<Wrapped> {    
+	fatalError()
+  }
+
+  public mutating func set(_: consuming Wrapped) { }
+}
+
+extension Optionable: Copyable where Wrapped: Copyable {}
+
+func testProperty_mutate(_ o: inout Optionable<[Int]>, _ value: [Int]) -> Int {
+  let span = o.span // expected-note{{}}
+  o.set(value) // expected-error{{overlapping access}}
+  return span.count
+}
+func testMethod_mutate(_ o: inout Optionable<[Int]>, _ value: [Int]) -> Int {
+  let span = o.getSpan() // expected-note{{}}
+  o.set(value) // expected-error{{overlapping access}}
+  return span.count
+}
+
+func testProperty_reassign(_ o: inout Optionable<[Int]>, _ value: Optionable<[Int]>) -> Int {
+  let span = o.span // expected-error{{escapes}} expected-note{{}}
+  o = value
+  return span.count // expected-note{{}}
+}
+func testMethod_reassign(_ o: inout Optionable<[Int]>, _ value: Optionable<[Int]>) -> Int {
+  let span = o.getSpan() // expected-error{{escapes}} expected-note{{}}
+  o = value
+  return span.count // expected-note{{}}
+}

--- a/test/stdlib/Optional.swift
+++ b/test/stdlib/Optional.swift
@@ -428,32 +428,36 @@ OptionalTests.test("unsafelyUnwrapped nil")
 }
 
 OptionalTests.test("Span from Optional.none")
-.xfail(.always("rdar://173472004"))
 .require(.stdlib_6_2).code {
   var o = Optional<[Int]>.none
-  let span = o.span
-  o = [1, 2, 3] // Should not compile, exclusivity violation
-  expectEqual(span.count, 0)
+  do {
+    let span = o.span
+    // o = [1, 2, 3] // Does not compile, exclusivity violation
+    expectEqual(span.count, 0)
 
-  // make it fail at test time if exclusivity was violated
-  expectNil(o, "fail due to exclusivity violation")
+    // make it fail at test time if exclusivity was violated
+    expectNil(o, "fail due to exclusivity violation")
+  }
+  o = nil
 }
 
 OptionalTests.test("Span from Optional.some")
-.xfail(.always("rdar://173472004"))
 .require(.stdlib_6_2).code {
   let a: [Int] = [1, 2, 3]
   var o: Optional = a
-  let span = o.span
-  o = nil // Should not compile, exclusivity violation
-  expectEqual(span.count, 1)
-  expectEqual(span[0], o, "accessed mysterious memory location")
+  do {
+    let span = o.span
+    // o = nil // Does not compile, exclusivity violation
+    expectEqual(span.count, 1)
+    expectEqual(span[0], o, "accessed mysterious memory location")
 
-  expectNotNil(o, "fail due to exclusivity violation")
+    expectNotNil(o, "fail due to exclusivity violation")
 
-  let b = [4, 5, 6]
-  o = b // Should not compile, exclusivity violation
-  expectNotEqual(span[0], b, "accessed mysterious memory location")
+    let b = [4, 5, 6]
+    // o = b // Does not compile, exclusivity violation
+    expectNotEqual(span[0], b, "accessed mysterious memory location")
+  }
+  o = nil
 }
 
 OptionalTests.test("_span() from Optional.none")

--- a/test/stdlib/Optional.swift
+++ b/test/stdlib/Optional.swift
@@ -23,7 +23,7 @@ OptionalTests.test("nil comparison") {
   expectFalse(x != nil)
 
   switch x {
-  case .some(let y): expectUnreachable()
+  case .some(_): expectUnreachable()
   case .none: break
   }
 
@@ -31,10 +31,10 @@ OptionalTests.test("nil comparison") {
   expectTrue(x != nil)
 
   do {
-    var y1: Int? = .none
+    let y1: Int? = .none
     expectTrue(y1 == nil)
 
-    var y2: Int? = .none
+    let y2: Int? = .none
     expectTrue(y2 == nil)
   }
 
@@ -91,7 +91,7 @@ OptionalTests.test("CustomReflectable") {
     var output = ""
     dump(value, to: &output)
     expectEqual("- nil\n", output)
-    expectEqual(.optional, Mirror(reflecting: value).displayStyle)
+    expectEqual(.optional, Mirror(reflecting: value as Any).displayStyle)
   }
   do {
     let value: OpaqueValue<Int>? = OpaqueValue(1010)
@@ -103,7 +103,7 @@ OptionalTests.test("CustomReflectable") {
       "    - value: 1010\n" +
       "    - identity: 0\n"
     expectEqual(expected, output)
-    expectEqual(.optional, Mirror(reflecting: value).displayStyle)
+    expectEqual(.optional, Mirror(reflecting: value as Any).displayStyle)
   }
   // Test with a reference type.
   do {
@@ -111,7 +111,7 @@ OptionalTests.test("CustomReflectable") {
     var output = ""
     dump(value, to: &output)
     expectEqual("- nil\n", output)
-    expectEqual(.optional, Mirror(reflecting: value).displayStyle)
+    expectEqual(.optional, Mirror(reflecting: value as Any).displayStyle)
   }
   do {
     let value: LifetimeTracked? = LifetimeTracked(1010)
@@ -124,7 +124,7 @@ OptionalTests.test("CustomReflectable") {
       "    - identity: 0\n" +
       "    - serialNumber: 1\n"
     expectEqual(expected, output)
-    expectEqual(.optional, Mirror(reflecting: value).displayStyle)
+    expectEqual(.optional, Mirror(reflecting: value as Any).displayStyle)
   }
 }
 
@@ -308,7 +308,7 @@ OptionalTests.test("Casting Optional") {
 
   // https://github.com/apple/swift/issues/43076
   // Weakened optionals don't zero
-  var t = LifetimeTracked(0)
+  let t = LifetimeTracked(0)
   _ = anyToAny(Optional(t), CustomDebugStringConvertible.self)
   expectTrue(anyToAnyIs(Optional(t), CustomDebugStringConvertible.self))
 

--- a/test/stdlib/Optional.swift
+++ b/test/stdlib/Optional.swift
@@ -460,33 +460,6 @@ OptionalTests.test("Span from Optional.some")
   o = nil
 }
 
-OptionalTests.test("_span() from Optional.none")
-.require(.stdlib_6_2).code {
-  var o = Optional<[Int]>.none
-  let span = o._span()
-  // o = [1, 2, 3] // Does not compile, exclusivity violation
-  expectEqual(span.count, 0)
-
-  // make it fail at test time if exclusivity was violated
-  expectNil(o, "fail due to exclusivity violation")
-}
-
-OptionalTests.test("_span() from Optional.some")
-.require(.stdlib_6_2).code {
-  let a: [Int] = [1, 2, 3]
-  var o: Optional = a
-  let span = o._span()
-  // o = nil // Does not compile, exclusivity violation
-  expectEqual(span.count, 1)
-  expectEqual(span[0], o, "accessed mysterious memory location")
-
-  expectNotNil(o, "fail due to exclusivity violation")
-
-  let b = [4, 5, 6]
-  // o = b // Does not compile, exclusivity violation
-  expectNotEqual(span[0], b, "accessed mysterious memory location")
-}
-
 OptionalTests.test("MutableSpan from Optional.none")
 .require(.stdlib_6_2).code {
   var o = Optional<[Int]>.none

--- a/test/stdlib/Optional.swift
+++ b/test/stdlib/Optional.swift
@@ -342,17 +342,19 @@ OptionalTests.test("Casting Optional") {
   expectTrue(anyToAnyIsOptional(Optional<(String, String)>.none, Bool.self))
 }
 
-#if !os(WASI)
-// Trap tests aren't available on WASI.
-OptionalTests.test("Casting Optional Traps") {
+OptionalTests.test("Casting Optional Traps")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.code {
   let nx: C? = nil
   expectCrash { _blackHole(anyToAny(nx, Int.self)) }
 }
-OptionalTests.test("Casting Optional Any Traps") {
+
+OptionalTests.test("Casting Optional Any Traps")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.code {
   let nx: X? = X()
   expectCrash { _blackHole(anyToAny(nx as Any, Optional<Int>.self)) }
 }
-#endif
 
 class TestNoString {}
 class TestString : CustomStringConvertible, CustomDebugStringConvertible {
@@ -414,18 +416,45 @@ OptionalTests.test("unsafelyUnwrapped") {
   expectEqual(3, nonEmpty.unsafelyUnwrapped)
 }
 
-#if !os(WASI)
-// Trap tests aren't available on WASI.
 OptionalTests.test("unsafelyUnwrapped nil")
-  .xfail(.custom(
-    { !_isDebugAssertConfiguration() },
-    reason: "assertions are disabled in Release and Unchecked mode"))
-  .code {
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.xfail(.custom(
+  { !_isDebugAssertConfiguration() },
+  reason: "assertions are disabled in Release and Unchecked mode"))
+.code {
   let empty: Int? = nil
   expectCrashLater()
   _blackHole(empty.unsafelyUnwrapped)
 }
-#endif
+
+OptionalTests.test("Span from Optional.none")
+.xfail(.always("rdar://173472004"))
+.require(.stdlib_6_2).code {
+  var o = Optional<[Int]>.none
+  let span = o.span
+  o = [1, 2, 3] // Should not compile, exclusivity violation
+  expectEqual(span.count, 0)
+
+  // make it fail at test time if exclusivity was violated
+  expectNil(o, "fail due to exclusivity violation")
+}
+
+OptionalTests.test("Span from Optional.some")
+.xfail(.always("rdar://173472004"))
+.require(.stdlib_6_2).code {
+  let a: [Int] = [1, 2, 3]
+  var o: Optional = a
+  let span = o.span
+  o = nil // Should not compile, exclusivity violation
+  expectEqual(span.count, 1)
+  expectEqual(span[0], o, "accessed mysterious memory location")
+
+  expectNotNil(o, "fail due to exclusivity violation")
+
+  let b = [4, 5, 6]
+  o = b // Should not compile, exclusivity violation
+  expectNotEqual(span[0], b, "accessed mysterious memory location")
+}
 
 OptionalTests.test("_span() from Optional.none")
 .require(.stdlib_6_2).code {
@@ -452,4 +481,29 @@ OptionalTests.test("_span() from Optional.some")
   let b = [4, 5, 6]
   // o = b // Does not compile, exclusivity violation
   expectNotEqual(span[0], b, "accessed mysterious memory location")
+}
+
+OptionalTests.test("MutableSpan from Optional.none")
+.require(.stdlib_6_2).code {
+  var o = Optional<[Int]>.none
+  let span = o.mutableSpan
+  // o = [1, 2, 3] // Does not compile, exclusivity violation
+  expectEqual(span.count, 0)
+}
+
+OptionalTests.test("MutableSpan from Optional.some")
+.require(.stdlib_6_2).code {
+  var a: [Int] = [1, 2, 3]
+  var o: Optional = a
+  var span = o.mutableSpan
+  // o = nil // Does not compile, exclusivity violation
+  expectEqual(span.count, 1)
+  expectEqual(span[0], a, "accessed mysterious memory location")
+
+  a = [4, 5, 6]
+  span[0] = a
+  _ = consume span
+  // exclusive access through `span` ends here
+
+  expectEqual(o, a)
 }


### PR DESCRIPTION
Get a `Span` from an `Optional` binding, or a `MutableSpan` from a mutable `Optional` binding.

```swift
extension Optional {
  public var span: Span<Wrapped> { @_lifetime(borrow self) get }
  public var mutableSpan: MutableSpan<Wrapped> { @_lifetime(&self) mutating get }
}
```
The resulting `Span` or `MutableSpan` instance will be empty when `self` is `nil`, or when non-nil will refer to the contents of `self` with a count of 1.


Addresses rdar://169123810

**Note:** <s>`@_addressableSelf` on the getter doesn't behave correctly. As a consequence, while the intended API `Optional.span` is here, the implementation doesn't diagnose exclusivity violations correctly. The alternate API `func _span() -> Span<Wrapped>` works as intended, though with not quite the desired shape.</s> @jckarter fixed `@_addressableSelf` for this use case in https://github.com/swiftlang/swift/pull/88289.