### PR TITLE
[IRGen] Fix crash on @objc private protocol with conditional runtime …

### DIFF
--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -1107,7 +1107,16 @@ public:
         },
         section);
 
-    if (IGM.IRGen.Opts.ConditionalRuntimeRecords) {
+    // @objc protocols use ObjC protocol records instead of Swift protocol
+    // descriptors. getTypeEntityReference would forward-declare a Swift
+    // protocol descriptor that is never defined, causing an LLVM verifier
+    // error. Skip conditional entries for @objc protocols since their ObjC
+    // protocol records are always kept alive.
+    bool isObjCProtocol = false;
+    if (auto proto = dyn_cast<ProtocolDecl>(NTD))
+      isObjCProtocol = proto->isObjC();
+
+    if (IGM.IRGen.Opts.ConditionalRuntimeRecords && !isObjCProtocol) {
       // Allow dead-stripping `var` (the reflection record) when the type
       // (NTD) is not referenced.
       auto ref = IGM.getTypeEntityReference(const_cast<NominalTypeDecl *>(NTD));

--- a/test/IRGen/objc_private_protocol.swift
+++ b/test/IRGen/objc_private_protocol.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend -emit-ir -disable-objc-attr-requires-foundation-module -enable-objc-interop -conditional-runtime-records %s | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+// The field descriptor's conditional liveness entry must not reference a
+// Swift protocol descriptor for @objc protocols, which use ObjC protocol
+// records and never define a Swift descriptor.
+
+// CHECK-NOT: Global is external
+// CHECK: @_PROTOCOL_
+
+@objc private protocol P {}
+@objc fileprivate protocol Q {}


### PR DESCRIPTION
FieldTypeMetadataBuilder::emit() calls getTypeEntityReference() to create a conditional liveness entry for field descriptors. For @objc protocols, this forward-declares a Swift protocol descriptor that is never defined — @objc protocols use ObjC protocol records instead.

For private/fileprivate protocols, the undefined descriptor gets InternalLinkage, which is invalid for LLVM IR declarations, causing:
```
Global is external, but doesn't have external or weak linkage!
```

Skip the conditional liveness entry for @objc protocols since their ObjC protocol records are unconditionally alive.