### PR TITLE
[Concurrency] Must hop-back from nonsending adoption in withContinuation

### DIFF
--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -14,6 +14,7 @@
 
 #include "ArgumentSource.h"
 #include "Cleanup.h"
+#include "ExecutorBreadcrumb.h"
 #include "Conversion.h"
 #include "Initialization.h"
 #include "LValue.h"
@@ -1863,6 +1864,14 @@ static ManagedValue emitBuiltinWithUnsafeContinuation(
   if (throws) {
     SGF.B.emitBlock(errorBlock);
 
+    // After the continuation resumes with a failure, hop back to the expected executor.
+    //
+    // This is critical for CallerIsolationInheriting (nonisolated(nonsending))
+    // functions: without this hop, the function may return on whichever thread
+    // resumed the continuation, violating the contract that the function
+    // maintains the caller's isolation. (rdar://173371163)
+    ExecutorBreadcrumb(/*mustReturnToExecutor=*/true).emit(SGF, loc);
+
     Scope errorScope(SGF, loc);
 
     auto errorTy = SGF.getASTContext().getErrorExistentialType();
@@ -1873,6 +1882,9 @@ static ManagedValue emitBuiltinWithUnsafeContinuation(
   }
 
   SGF.B.emitBlock(resumeBlock);
+
+  // After the continuation resumes, hop back to the expected executor.
+  ExecutorBreadcrumb(/*mustReturnToExecutor=*/true).emit(SGF, loc);
 
   // The incoming value is the maximally-abstracted result type of the
   // continuation. Move it out of the resume buffer and reabstract it if

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -1869,7 +1869,7 @@ static ManagedValue emitBuiltinWithUnsafeContinuation(
     // This is critical for CallerIsolationInheriting (nonisolated(nonsending))
     // functions: without this hop, the function may return on whichever thread
     // resumed the continuation, violating the contract that the function
-    // maintains the caller's isolation. (rdar://173371163)
+    // maintains the caller's isolation.
     ExecutorBreadcrumb(/*mustReturnToExecutor=*/true).emit(SGF, loc);
 
     Scope errorScope(SGF, loc);

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -2406,6 +2406,13 @@ static bool mustSwitchToRun(SerialExecutorRef currentSerialExecutor,
                             TaskExecutorRef currentTaskExecutor,
                             TaskExecutorRef newTaskExecutor) {
   if (currentSerialExecutor.getIdentity() != newSerialExecutor.getIdentity()) {
+    // If the target is the generic executor and the task has a preferred
+    // task executor whose identity matches our current serial executor,
+    // we're already running where task executor preference would switch to on enqueue.
+    if (newSerialExecutor.isGeneric() && newTaskExecutor.isDefined() &&
+        currentSerialExecutor.getIdentity() == newTaskExecutor.getIdentity()) {
+      return false;
+    }
     return true; // must switch, new isolation context
   }
 

--- a/test/Concurrency/Runtime/must_not_hop_withContinuation.swift
+++ b/test/Concurrency/Runtime/must_not_hop_withContinuation.swift
@@ -28,26 +28,25 @@ if #available(SwiftStdlib 6.0, *) {
 
 // CHECK-NEXT: foo - withTaskExecutorPreference
 
-// After each continuation resumes, hop_to_executor hops back to the caller's
-// expected executor (rdar://173371163). When the caller is nonisolated inside
-// withTaskExecutorPreference, the hop goes through the task executor.
-// CHECK: foo - withTaskExecutorPreference - withCheckedContinuation
-// CHECK-NEXT: [executor][task-executor] Enqueue (2)
+// After each continuation resumes, hop_to_executor targets the generic executor.
+// Since the task has a preferred task executor whose identity matches the current
+// serial executor, mustSwitchToRun elides the hop — no enqueue needed.
+// Similarly, the hop inside withTaskExecutorPreference (after the body returns
+// but before the defer clears the preference) is also elided. The eventual hop
+// back to the generic executor (after the preference is cleared) goes through
+// libdispatch, not our custom executor, so it produces no visible enqueue here.
+
+// CHECK-NEXT: foo - withTaskExecutorPreference - withCheckedContinuation
 // CHECK-NEXT: foo - withTaskExecutorPreference - withCheckedContinuation done
 
-// CHECK: foo - withTaskExecutorPreference - withUnsafeContinuation
-// CHECK-NEXT: [executor][task-executor] Enqueue (3)
+// CHECK-NEXT: foo - withTaskExecutorPreference - withUnsafeContinuation
 // CHECK-NEXT: foo - withTaskExecutorPreference - withUnsafeContinuation done
 
-// CHECK: foo - withTaskExecutorPreference - withCheckedThrowingContinuation
-// CHECK-NEXT: [executor][task-executor] Enqueue (4)
+// CHECK-NEXT: foo - withTaskExecutorPreference - withCheckedThrowingContinuation
 // CHECK-NEXT: foo - withTaskExecutorPreference - withCheckedThrowingContinuation done
 
-// CHECK: foo - withTaskExecutorPreference - withUnsafeThrowingContinuation
-// CHECK-NEXT: [executor][task-executor] Enqueue (5)
+// CHECK-NEXT: foo - withTaskExecutorPreference - withUnsafeThrowingContinuation
 // CHECK-NEXT: foo - withTaskExecutorPreference - withUnsafeThrowingContinuation done
-
-// CHECK-NEXT: [executor][task-executor] Enqueue (6)
 
 // CHECK-NEXT: foo - withTaskExecutorPreference done
 
@@ -55,6 +54,11 @@ if #available(SwiftStdlib 6.0, *) {
 // CHECK-NEXT: ---------------------------------------
 // CHECK-NEXT: [executor][actor-executor] Enqueue (1)
 // CHECK-NEXT: actor.foo
+
+// Coming back to the origin executor,
+// which is the same actor as we just executed the continuation body on,
+// is triggering task_switch's fast path and we don't need to enqueue the again.
+// I.e. The "hop back" with hop_to_executor exists, but is optimized at runtime.
 
 // CHECK: actor.foo - withCheckedContinuation
 // CHECK-NEXT: actor.foo - withCheckedContinuation done

--- a/test/Concurrency/Runtime/must_not_hop_withContinuation.swift
+++ b/test/Concurrency/Runtime/must_not_hop_withContinuation.swift
@@ -28,21 +28,26 @@ if #available(SwiftStdlib 6.0, *) {
 
 // CHECK-NEXT: foo - withTaskExecutorPreference
 
+// After each continuation resumes, hop_to_executor hops back to the caller's
+// expected executor (rdar://173371163). When the caller is nonisolated inside
+// withTaskExecutorPreference, the hop goes through the task executor.
 // CHECK: foo - withTaskExecutorPreference - withCheckedContinuation
+// CHECK-NEXT: [executor][task-executor] Enqueue (2)
 // CHECK-NEXT: foo - withTaskExecutorPreference - withCheckedContinuation done
 
 // CHECK: foo - withTaskExecutorPreference - withUnsafeContinuation
+// CHECK-NEXT: [executor][task-executor] Enqueue (3)
 // CHECK-NEXT: foo - withTaskExecutorPreference - withUnsafeContinuation done
 
 // CHECK: foo - withTaskExecutorPreference - withCheckedThrowingContinuation
+// CHECK-NEXT: [executor][task-executor] Enqueue (4)
 // CHECK-NEXT: foo - withTaskExecutorPreference - withCheckedThrowingContinuation done
 
 // CHECK: foo - withTaskExecutorPreference - withUnsafeThrowingContinuation
+// CHECK-NEXT: [executor][task-executor] Enqueue (5)
 // CHECK-NEXT: foo - withTaskExecutorPreference - withUnsafeThrowingContinuation done
 
-// By checking that this is the second enqueue here,
-// we check that there was no stray enqueues between with... invocations:
-// CHECK-NEXT: [executor][task-executor] Enqueue (2)
+// CHECK-NEXT: [executor][task-executor] Enqueue (6)
 
 // CHECK-NEXT: foo - withTaskExecutorPreference done
 

--- a/test/Concurrency/Runtime/must_not_hop_withContinuation.swift
+++ b/test/Concurrency/Runtime/must_not_hop_withContinuation.swift
@@ -31,10 +31,6 @@ if #available(SwiftStdlib 6.0, *) {
 // After each continuation resumes, hop_to_executor targets the generic executor.
 // Since the task has a preferred task executor whose identity matches the current
 // serial executor, mustSwitchToRun elides the hop — no enqueue needed.
-// Similarly, the hop inside withTaskExecutorPreference (after the body returns
-// but before the defer clears the preference) is also elided. The eventual hop
-// back to the generic executor (after the preference is cleared) goes through
-// libdispatch, not our custom executor, so it produces no visible enqueue here.
 
 // CHECK-NEXT: foo - withTaskExecutorPreference - withCheckedContinuation
 // CHECK-NEXT: foo - withTaskExecutorPreference - withCheckedContinuation done

--- a/test/Concurrency/Runtime/task_immediate_mainactor_isolation.swift
+++ b/test/Concurrency/Runtime/task_immediate_mainactor_isolation.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking -swift-version 6 -parse-as-library) | %FileCheck %s --dump-input=always
+// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking -swift-version 6 -parse-as-library) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
@@ -8,7 +8,7 @@
 // UNSUPPORTED: back_deployment_runtime
 // UNSUPPORTED: freestanding
 
-// rdar://173181913 — Task.immediate closure must preserve @MainActor isolation
+// Task.immediate closure must preserve @MainActor isolation
 // across await suspension points. Regression: after await withCheckedContinuation,
 // the task resumes on the cooperative pool instead of @MainActor.
 

--- a/test/Concurrency/Runtime/task_immediate_mainactor_isolation.swift
+++ b/test/Concurrency/Runtime/task_immediate_mainactor_isolation.swift
@@ -4,6 +4,7 @@
 // REQUIRES: concurrency
 // REQUIRES: concurrency_runtime
 // REQUIRES: libdispatch
+// REQUIRES: foundation
 // UNSUPPORTED: back_deployment_runtime
 // UNSUPPORTED: freestanding
 

--- a/test/Concurrency/Runtime/task_immediate_mainactor_isolation.swift
+++ b/test/Concurrency/Runtime/task_immediate_mainactor_isolation.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking -swift-version 6 -parse-as-library)
+// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking -swift-version 6 -parse-as-library) | %FileCheck %s --dump-input=always
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
@@ -16,45 +16,38 @@ import Foundation
 @MainActor
 final class MyController {
   var value = 0
-
-  // Inherits @MainActor from the class — no explicit annotation
+  var doneContinuation: CheckedContinuation<Void, Never>?
 
   func applySnapshot() {
-    print("[swift] \(#fileID):\(#line) applySnapshot() — isMainThread: \(Thread.isMainThread)")
-    guard _isMainThread() else {
-      fatalError("BUG: Expected to be on main actor in applySnapshot()")
-    }
+    print("applySnapshot: isMainThread=\(_isMainThread())")
+    // CHECK: applySnapshot: isMainThread=true
 
     Task.immediate {
-      print("[swift] \(#fileID):\(#line) Task.immediate start — isMainThread: \(Thread.isMainThread)")
-      guard _isMainThread() else {
-        fatalError("BUG: Expected to be on main actor in applySnapshot/Task.immediate intro")
-      }
+      print("Task.immediate start: isMainThread=\(_isMainThread())")
+      // CHECK: Task.immediate start: isMainThread=true
 
-      print("[swift] \(#fileID):\(#line) before withCheckedContinuation — isMainThread: \(Thread.isMainThread)")
       await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-        print("[swift] \(#fileID):\(#line) inside continuation body — isMainThread: \(Thread.isMainThread)")
-        DispatchQueue.global().asyncAfter(deadline: .now() + 1) {
-          print("[swift] \(#fileID):\(#line) resuming continuation from DispatchQueue.global() — isMainThread: \(Thread.isMainThread)")
+        // Resume from a background thread to force a thread hop
+        // Avoid Task to prevent Dispatch sneakily work stealing the new task using the main thread anyway.
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.1) {
           continuation.resume()
         }
       }
 
       // After resuming from await — must be back on @MainActor (main thread)
       // In the bug, this resumes on com.apple.root.user-initiated-qos.cooperative
-      print("[swift] \(#fileID):\(#line) after withCheckedContinuation — isMainThread: \(Thread.isMainThread)")
-      guard _isMainThread() else {
-        fatalError("BUG: Task.immediate lost @MainActor isolation after await! Resumed on wrong thread.")
-      }
+      print("after withCheckedContinuation: isMainThread=\(_isMainThread())")
+      // CHECK: after withCheckedContinuation: isMainThread=true
 
-      print("[swift] \(#fileID):\(#line) Task.immediate done — isMainThread: \(Thread.isMainThread)")
       self.value = 2
+      self.doneContinuation?.resume()
     }
   }
-}
 
-// Helper to check main thread without triggering
-// "unavailable from asynchronous contexts" errors
+  func waitUntilDone() async {
+    await withCheckedContinuation { self.doneContinuation = $0 }
+  }
+}
 
 nonisolated func _isMainThread() -> Bool {
   return Thread.isMainThread
@@ -62,18 +55,12 @@ nonisolated func _isMainThread() -> Bool {
 
 @main
 struct Main {
-  static func main() async throws {
-    print("[swift] \(#fileID):\(#line) main() start — isMainThread: \(Thread.isMainThread)")
-    MainActor.preconditionIsolated()
-
+  static func main() async {
     let c = MyController()
     c.applySnapshot()
+    await c.waitUntilDone()
 
-    print("[swift] \(#fileID):\(#line) waiting for Task.immediate to complete...")
-    try await Task.sleep(for: .milliseconds(2000))
-
-    let val = c.value  // just to keep alive
-    precondition(val == 2, "Expected value to be 2, was \(val)")
-    print("OK: Task.immediate preserved @MainActor isolation across await")
+    print("value=\(c.value)")
+    // CHECK: value=2
   }
 }

--- a/test/Concurrency/Runtime/task_immediate_mainactor_isolation.swift
+++ b/test/Concurrency/Runtime/task_immediate_mainactor_isolation.swift
@@ -1,0 +1,79 @@
+// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking -swift-version 6 -parse-as-library)
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+// REQUIRES: libdispatch
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: freestanding
+
+// rdar://173181913 — Task.immediate closure must preserve @MainActor isolation
+// across await suspension points. Regression: after await withCheckedContinuation,
+// the task resumes on the cooperative pool instead of @MainActor.
+
+import Foundation
+
+@MainActor
+final class MyController {
+  var value = 0
+
+  // Inherits @MainActor from the class — no explicit annotation
+
+  func applySnapshot() {
+    print("[swift] \(#fileID):\(#line) applySnapshot() — isMainThread: \(Thread.isMainThread)")
+    guard _isMainThread() else {
+      fatalError("BUG: Expected to be on main actor in applySnapshot()")
+    }
+
+    Task.immediate {
+      print("[swift] \(#fileID):\(#line) Task.immediate start — isMainThread: \(Thread.isMainThread)")
+      guard _isMainThread() else {
+        fatalError("BUG: Expected to be on main actor in applySnapshot/Task.immediate intro")
+      }
+
+      print("[swift] \(#fileID):\(#line) before withCheckedContinuation — isMainThread: \(Thread.isMainThread)")
+      await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+        print("[swift] \(#fileID):\(#line) inside continuation body — isMainThread: \(Thread.isMainThread)")
+        DispatchQueue.global().asyncAfter(deadline: .now() + 1) {
+          print("[swift] \(#fileID):\(#line) resuming continuation from DispatchQueue.global() — isMainThread: \(Thread.isMainThread)")
+          continuation.resume()
+        }
+      }
+
+      // After resuming from await — must be back on @MainActor (main thread)
+      // In the bug, this resumes on com.apple.root.user-initiated-qos.cooperative
+      print("[swift] \(#fileID):\(#line) after withCheckedContinuation — isMainThread: \(Thread.isMainThread)")
+      guard _isMainThread() else {
+        fatalError("BUG: Task.immediate lost @MainActor isolation after await! Resumed on wrong thread.")
+      }
+
+      print("[swift] \(#fileID):\(#line) Task.immediate done — isMainThread: \(Thread.isMainThread)")
+      self.value = 2
+    }
+  }
+}
+
+// Helper to check main thread without triggering
+// "unavailable from asynchronous contexts" errors
+
+nonisolated func _isMainThread() -> Bool {
+  return Thread.isMainThread
+}
+
+@main
+struct Main {
+  static func main() async throws {
+    print("[swift] \(#fileID):\(#line) main() start — isMainThread: \(Thread.isMainThread)")
+    MainActor.preconditionIsolated()
+
+    let c = MyController()
+    c.applySnapshot()
+
+    print("[swift] \(#fileID):\(#line) waiting for Task.immediate to complete...")
+    try await Task.sleep(for: .milliseconds(2000))
+
+    let val = c.value  // just to keep alive
+    precondition(val == 2, "Expected value to be 2, was \(val)")
+    print("OK: Task.immediate preserved @MainActor isolation across await")
+  }
+}

--- a/test/SILGen/continuation_hop_to_executor.swift
+++ b/test/SILGen/continuation_hop_to_executor.swift
@@ -4,15 +4,10 @@
 import Swift
 import _Concurrency
 
-// rdar://173371163 — Verify that hop_to_executor is emitted after
+// Verify that hop_to_executor is emitted after
 // await_async_continuation in the resume (and error) blocks.
 // Without this hop, nonisolated(nonsending) functions that use continuation
 // builtins would incorrectly just continue on whichever thread resumed the continuation.
-
-// All functions must hop back to their right executor once the continuation was resumed.
-
-// The CHECK lines verify the hops survive the mandatory
-// OptimizeHopToExecutor pass (canonical SIL), not just SILGen.
 
 // === Nonisolated free function (Swift 5 default) — hops to generic executor ===
 

--- a/test/SILGen/continuation_hop_to_executor.swift
+++ b/test/SILGen/continuation_hop_to_executor.swift
@@ -1,0 +1,99 @@
+// RUN: %target-swift-frontend -Xllvm -sil-print-types -emit-silgen %s -module-name test -swift-version 5 -target %target-swift-5.1-abi-triple -parse-stdlib -sil-verify-all | %FileCheck %s
+// REQUIRES: concurrency
+
+import Swift
+import _Concurrency
+
+// rdar://173371163 — Verify that hop_to_executor is emitted after
+// await_async_continuation in the resume (and error) blocks.
+// Without this hop, nonisolated(nonsending) functions that use continuation
+// builtins would return on whichever thread resumed the continuation, violating
+// the CallerIsolationInheriting contract.
+
+// All functions must hop back to their right executor once the continuation was resumed.
+
+// === Nonisolated free function (Swift 5 default) — hops to generic executor ===
+
+// CHECK-LABEL: // nonisolatedFree()
+// CHECK-NEXT:  // Isolation: unspecified
+// CHECK-LABEL: sil [ossa] @$s4test15nonisolatedFreeSiyYaF
+// CHECK:   [[GLOBAL:%[0-9]+]] = enum $Optional<any Actor>, #Optional.none
+// CHECK:   await_async_continuation {{%[0-9]+}} : $Builtin.RawUnsafeContinuation, resume [[RESUME:bb[0-9]+]]
+// CHECK: [[RESUME]]:
+// CHECK-NEXT: hop_to_executor [[GLOBAL]] : $Optional<any Actor>
+public func nonisolatedFree() async -> Int {
+  return await Builtin.withUnsafeContinuation { c in }
+}
+
+// === nonisolated(nonsending) free function — hops to caller's implicit actor ===
+
+// CHECK-LABEL: // nonsendingFree()
+// CHECK-NEXT:  // Isolation: caller_isolation_inheriting
+// CHECK-LABEL: sil [ossa] @$s4test14nonsendingFreeSiyYaF
+// CHECK: bb0([[IMPLICIT:%[0-9]+]] : @guaranteed $Builtin.ImplicitActor):
+// CHECK:   await_async_continuation {{%[0-9]+}} : $Builtin.RawUnsafeContinuation, resume [[RESUME:bb[0-9]+]]
+// CHECK: [[RESUME]]:
+// CHECK-NEXT: hop_to_executor [[IMPLICIT]] : $Builtin.ImplicitActor
+public nonisolated(nonsending) func nonsendingFree() async -> Int {
+  return await Builtin.withUnsafeContinuation { c in }
+}
+
+// === @concurrent free function — hops to generic executor ===
+
+// CHECK-LABEL: // concurrentFree()
+// CHECK-NEXT:  // Isolation: nonisolated
+// CHECK-LABEL: sil [ossa] @$s4test14concurrentFreeSiyYaF
+// CHECK:   [[GLOBAL:%[0-9]+]] = enum $Optional<any Actor>, #Optional.none
+// CHECK:   await_async_continuation {{%[0-9]+}} : $Builtin.RawUnsafeContinuation, resume [[RESUME:bb[0-9]+]]
+// CHECK: [[RESUME]]:
+// CHECK-NEXT: hop_to_executor [[GLOBAL]] : $Optional<any Actor>
+@concurrent
+public func concurrentFree() async -> Int {
+  return await Builtin.withUnsafeContinuation { c in }
+}
+
+// === @MainActor class method — hops to MainActor ===
+
+@MainActor
+public class MainActorClass {
+  // CHECK-LABEL: // MainActorClass.mainActorMethod()
+  // CHECK-NEXT:  // Isolation: global_actor. type: MainActor
+  // CHECK-LABEL: sil [ossa] @$s4test14MainActorClassC04mainC6MethodSiyYaF
+  // CHECK:   [[MA:%[0-9]+]] = begin_borrow {{%[0-9]+}} : $MainActor
+  // CHECK:   await_async_continuation {{%[0-9]+}} : $Builtin.RawUnsafeContinuation, resume [[RESUME:bb[0-9]+]]
+  // CHECK: [[RESUME]]:
+  // CHECK-NEXT: hop_to_executor [[MA]] : $MainActor
+  public func mainActorMethod() async -> Int {
+    return await Builtin.withUnsafeContinuation { c in }
+  }
+}
+
+// === actor method — hops to actor executor ===
+
+public actor MyActor {
+  // CHECK-LABEL: // MyActor.actorMethod()
+  // CHECK-NEXT:  // Isolation: actor_instance. name: 'self'
+  // CHECK-LABEL: sil [ossa] @$s4test7MyActorC11actorMethodSiyYaF
+  // CHECK: bb0([[SELF:%[0-9]+]] : @guaranteed $MyActor):
+  // CHECK:   await_async_continuation {{%[0-9]+}} : $Builtin.RawUnsafeContinuation, resume [[RESUME:bb[0-9]+]]
+  // CHECK: [[RESUME]]:
+  // CHECK-NEXT: hop_to_executor [[SELF]] : $MyActor
+  public func actorMethod() async -> Int {
+    return await Builtin.withUnsafeContinuation { c in }
+  }
+}
+
+// === Throwing: nonisolated(nonsending) — hops in both resume and error blocks ===
+
+// CHECK-LABEL: // nonsendingThrowing()
+// CHECK-NEXT:  // Isolation: caller_isolation_inheriting
+// CHECK-LABEL: sil [ossa] @$s4test18nonsendingThrowingSiyYaKF
+// CHECK: bb0([[IMPLICIT:%[0-9]+]] : @guaranteed $Builtin.ImplicitActor):
+// CHECK:   await_async_continuation {{%[0-9]+}} : $Builtin.RawUnsafeContinuation, resume [[RESUME:bb[0-9]+]], error [[ERROR:bb[0-9]+]]
+// CHECK: [[RESUME]]:
+// CHECK-NEXT: hop_to_executor [[IMPLICIT]] : $Builtin.ImplicitActor
+// CHECK: [[ERROR]]({{%[0-9]+}} : @owned $any Error):
+// CHECK-NEXT: hop_to_executor [[IMPLICIT]] : $Builtin.ImplicitActor
+public nonisolated(nonsending) func nonsendingThrowing() async throws -> Int {
+  return try await Builtin.withUnsafeThrowingContinuation { c in }
+}

--- a/test/SILGen/continuation_hop_to_executor.swift
+++ b/test/SILGen/continuation_hop_to_executor.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -sil-print-types -emit-silgen %s -module-name test -swift-version 5 -target %target-swift-5.1-abi-triple -parse-stdlib -sil-verify-all | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-print-types -emit-sil %s -module-name test -swift-version 5 -target %target-swift-5.1-abi-triple -parse-stdlib -sil-verify-all | %FileCheck %s --check-prefix=CHECK
 // REQUIRES: concurrency
 
 import Swift
@@ -7,16 +7,17 @@ import _Concurrency
 // rdar://173371163 — Verify that hop_to_executor is emitted after
 // await_async_continuation in the resume (and error) blocks.
 // Without this hop, nonisolated(nonsending) functions that use continuation
-// builtins would return on whichever thread resumed the continuation, violating
-// the CallerIsolationInheriting contract.
+// builtins would incorrectly just continue on whichever thread resumed the continuation.
 
 // All functions must hop back to their right executor once the continuation was resumed.
+
+// The CHECK lines verify the hops survive the mandatory
+// OptimizeHopToExecutor pass (canonical SIL), not just SILGen.
 
 // === Nonisolated free function (Swift 5 default) — hops to generic executor ===
 
 // CHECK-LABEL: // nonisolatedFree()
-// CHECK-NEXT:  // Isolation: unspecified
-// CHECK-LABEL: sil [ossa] @$s4test15nonisolatedFreeSiyYaF
+// CHECK: sil @$s4test15nonisolatedFreeSiyYaF
 // CHECK:   [[GLOBAL:%[0-9]+]] = enum $Optional<any Actor>, #Optional.none
 // CHECK:   await_async_continuation {{%[0-9]+}} : $Builtin.RawUnsafeContinuation, resume [[RESUME:bb[0-9]+]]
 // CHECK: [[RESUME]]:
@@ -28,9 +29,8 @@ public func nonisolatedFree() async -> Int {
 // === nonisolated(nonsending) free function — hops to caller's implicit actor ===
 
 // CHECK-LABEL: // nonsendingFree()
-// CHECK-NEXT:  // Isolation: caller_isolation_inheriting
-// CHECK-LABEL: sil [ossa] @$s4test14nonsendingFreeSiyYaF
-// CHECK: bb0([[IMPLICIT:%[0-9]+]] : @guaranteed $Builtin.ImplicitActor):
+// CHECK: sil @$s4test14nonsendingFreeSiyYaF
+// CHECK: bb0([[IMPLICIT:%[0-9]+]] : $Builtin.ImplicitActor):
 // CHECK:   await_async_continuation {{%[0-9]+}} : $Builtin.RawUnsafeContinuation, resume [[RESUME:bb[0-9]+]]
 // CHECK: [[RESUME]]:
 // CHECK-NEXT: hop_to_executor [[IMPLICIT]] : $Builtin.ImplicitActor
@@ -41,8 +41,7 @@ public nonisolated(nonsending) func nonsendingFree() async -> Int {
 // === @concurrent free function — hops to generic executor ===
 
 // CHECK-LABEL: // concurrentFree()
-// CHECK-NEXT:  // Isolation: nonisolated
-// CHECK-LABEL: sil [ossa] @$s4test14concurrentFreeSiyYaF
+// CHECK: sil @$s4test14concurrentFreeSiyYaF
 // CHECK:   [[GLOBAL:%[0-9]+]] = enum $Optional<any Actor>, #Optional.none
 // CHECK:   await_async_continuation {{%[0-9]+}} : $Builtin.RawUnsafeContinuation, resume [[RESUME:bb[0-9]+]]
 // CHECK: [[RESUME]]:
@@ -57,9 +56,8 @@ public func concurrentFree() async -> Int {
 @MainActor
 public class MainActorClass {
   // CHECK-LABEL: // MainActorClass.mainActorMethod()
-  // CHECK-NEXT:  // Isolation: global_actor. type: MainActor
-  // CHECK-LABEL: sil [ossa] @$s4test14MainActorClassC04mainC6MethodSiyYaF
-  // CHECK:   [[MA:%[0-9]+]] = begin_borrow {{%[0-9]+}} : $MainActor
+  // CHECK: sil @$s4test14MainActorClassC04mainC6MethodSiyYaF
+  // CHECK:   [[MA:%[0-9]+]] = apply {{%[0-9]+}}({{%[0-9]+}}) : $@convention(method) (@thick MainActor.Type) -> @owned MainActor
   // CHECK:   await_async_continuation {{%[0-9]+}} : $Builtin.RawUnsafeContinuation, resume [[RESUME:bb[0-9]+]]
   // CHECK: [[RESUME]]:
   // CHECK-NEXT: hop_to_executor [[MA]] : $MainActor
@@ -72,9 +70,8 @@ public class MainActorClass {
 
 public actor MyActor {
   // CHECK-LABEL: // MyActor.actorMethod()
-  // CHECK-NEXT:  // Isolation: actor_instance. name: 'self'
-  // CHECK-LABEL: sil [ossa] @$s4test7MyActorC11actorMethodSiyYaF
-  // CHECK: bb0([[SELF:%[0-9]+]] : @guaranteed $MyActor):
+  // CHECK: sil @$s4test7MyActorC11actorMethodSiyYaF
+  // CHECK: bb0([[SELF:%[0-9]+]] : $MyActor):
   // CHECK:   await_async_continuation {{%[0-9]+}} : $Builtin.RawUnsafeContinuation, resume [[RESUME:bb[0-9]+]]
   // CHECK: [[RESUME]]:
   // CHECK-NEXT: hop_to_executor [[SELF]] : $MyActor
@@ -86,13 +83,12 @@ public actor MyActor {
 // === Throwing: nonisolated(nonsending) — hops in both resume and error blocks ===
 
 // CHECK-LABEL: // nonsendingThrowing()
-// CHECK-NEXT:  // Isolation: caller_isolation_inheriting
-// CHECK-LABEL: sil [ossa] @$s4test18nonsendingThrowingSiyYaKF
-// CHECK: bb0([[IMPLICIT:%[0-9]+]] : @guaranteed $Builtin.ImplicitActor):
+// CHECK: sil @$s4test18nonsendingThrowingSiyYaKF
+// CHECK: bb0([[IMPLICIT:%[0-9]+]] : $Builtin.ImplicitActor):
 // CHECK:   await_async_continuation {{%[0-9]+}} : $Builtin.RawUnsafeContinuation, resume [[RESUME:bb[0-9]+]], error [[ERROR:bb[0-9]+]]
 // CHECK: [[RESUME]]:
 // CHECK-NEXT: hop_to_executor [[IMPLICIT]] : $Builtin.ImplicitActor
-// CHECK: [[ERROR]]({{%[0-9]+}} : @owned $any Error):
+// CHECK: [[ERROR]]({{%[0-9]+}} : $any Error):
 // CHECK-NEXT: hop_to_executor [[IMPLICIT]] : $Builtin.ImplicitActor
 public nonisolated(nonsending) func nonsendingThrowing() async throws -> Int {
   return try await Builtin.withUnsafeThrowingContinuation { c in }

--- a/test/SILGen/hop_to_executor.swift
+++ b/test/SILGen/hop_to_executor.swift
@@ -565,7 +565,7 @@ func validateHopToExecutorLifetimeShortEnough() async {
 // ==== -----------------------------------------------------------------------
 // MARK: withCheckedContinuation (nonisolated(nonsending)) hop patterns
 //
-// rdar://173371163 — withCheckedContinuation is now nonisolated(nonsending)
+// withCheckedContinuation is now nonisolated(nonsending)
 // (CallerIsolationInheriting). At SILGen level the caller still emits a
 // hop_to_executor breadcrumb after the call. The optimizer later recognises
 // CallerIsolationInheriting calls as non-suspension-points and removes the

--- a/test/SILGen/hop_to_executor.swift
+++ b/test/SILGen/hop_to_executor.swift
@@ -561,3 +561,51 @@ func validateHopToExecutorLifetimeShortEnough() async {
   let a = MyActor()
   _ = await Klass(on: a)
 }
+
+// ==== -----------------------------------------------------------------------
+// MARK: withCheckedContinuation (nonisolated(nonsending)) hop patterns
+//
+// rdar://173371163 — withCheckedContinuation is now nonisolated(nonsending)
+// (CallerIsolationInheriting). At SILGen level the caller still emits a
+// hop_to_executor breadcrumb after the call. The optimizer later recognises
+// CallerIsolationInheriting calls as non-suspension-points and removes the
+// breadcrumb as redundant.
+
+extension MyActor {
+  // CHECK-LABEL: sil hidden [ossa] @$s4test7MyActorC23actorWithContinuationFnSiyYaF
+  // CHECK:       bb0([[SELF:%[0-9]+]] : @guaranteed $MyActor):
+  // CHECK:         hop_to_executor [[SELF]] : $MyActor
+  // CHECK:         {{%[0-9]+}} = apply
+  // CHECK:         hop_to_executor [[SELF]] : $MyActor
+  // CHECK:       } // end sil function '$s4test7MyActorC23actorWithContinuationFnSiyYaF'
+  func actorWithContinuationFn() async -> Int {
+    await withCheckedContinuation { c in
+      c.resume(returning: 42)
+    }
+  }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s4test29globalActorWithContinuationFnSiyYaF
+// CHECK:         [[B:%[0-9]+]] = begin_borrow {{%[0-9]+}} : $MyActor
+// CHECK-NEXT:    hop_to_executor [[B]] : $MyActor
+// CHECK:         {{%[0-9]+}} = apply
+// CHECK:         hop_to_executor [[B]] : $MyActor
+// CHECK:       } // end sil function '$s4test29globalActorWithContinuationFnSiyYaF'
+@GlobalActor
+func globalActorWithContinuationFn() async -> Int {
+  await withCheckedContinuation { c in
+    c.resume(returning: 42)
+  }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s4test34unspecifiedAsyncWithContinuationFnSiyYaF
+// CHECK:         [[GENERIC_EXEC:%.*]] = enum $Optional<any Actor>, #Optional.none
+// CHECK-NEXT:    hop_to_executor [[GENERIC_EXEC]] :
+// CHECK:         {{%[0-9]+}} = apply
+// CHECK:         hop_to_executor [[GENERIC_EXEC]]
+// CHECK:       } // end sil function '$s4test34unspecifiedAsyncWithContinuationFnSiyYaF'
+func unspecifiedAsyncWithContinuationFn() async -> Int {
+  await withCheckedContinuation { c in
+    c.resume(returning: 42)
+  }
+}


### PR DESCRIPTION
**Description**: The move to adopting nonisolated nonsending in continuation APIs has removed un-necessary hops INTO the continuation block, however this also removed hops "from" when the continuation is resumed to where code is supposed to run; this actually causes bugs where the continuation resume executing on whoever resumed it, rather than the expected context as dictated by isolation.

**Scope/Impact**: uses of with...Continuation that have now adopted nonisoalted(nonsending) to avoid extra hops
**Risk:** Low, corrects missing hops, the switch optimization is definitely correct as well, and a subset of fixes we wanted to do in switch optimizations
**Testing**: CI testing, verified SIL and the logic flow

**Radar:** Resolves: rdar://173371163