### PR TITLE
[CMake] Don't remove sourcekit-inproc from _SWIFT_DEFAULT_COMPONENTS in SwiftComponents.cmake

### DIFF
--- a/cmake/modules/SwiftComponents.cmake
+++ b/cmake/modules/SwiftComponents.cmake
@@ -83,10 +83,8 @@ list(REMOVE_ITEM _SWIFT_DEFAULT_COMPONENTS "clang-resource-dir-symlink")
 list(REMOVE_ITEM _SWIFT_DEFAULT_COMPONENTS "clang-builtin-headers-in-clang-resource-dir")
 # This conflicts with LLVM itself when doing unified builds.
 list(REMOVE_ITEM _SWIFT_DEFAULT_COMPONENTS "llvm-toolchain-dev-tools")
-# The sourcekit install variants are currently mutually exclusive.
-if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
-  list(REMOVE_ITEM _SWIFT_DEFAULT_COMPONENTS "sourcekit-inproc")
-else()
+# XPC is only available on Darwin platforms.
+if(NOT CMAKE_SYSTEM_NAME MATCHES "Darwin")
   list(REMOVE_ITEM _SWIFT_DEFAULT_COMPONENTS "sourcekit-xpc-service")
 endif()
 list(REMOVE_ITEM _SWIFT_DEFAULT_COMPONENTS "stdlib-experimental")


### PR DESCRIPTION
SourceKit always needs sourcekit-inproc. With this change we always get a `lib/sourcekitdInProc.framework` directory in the swift build directory (e.g., `build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64`). This can then be used in SourceKit-LSP to run SourceKitD in-process on macOS for debugging. For more context see https://github.com/swiftlang/sourcekit-lsp/pull/2580.
