### PR TITLE
SIL: enable an assert in non-assert compiler builds

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -2752,7 +2752,7 @@ protected:
         SpecializationInfo(specializationInfo), NumCallArguments(args.size()),
         NumTypeDependentOperands(typeDependentOperands.size()),
         Substitutions(subs.getCanonical()) {
-    assert(!!subs == !!callee->getType().castTo<SILFunctionType>()
+    ASSERT(!!subs == !!callee->getType().castTo<SILFunctionType>()
         ->getInvocationGenericSignature());
 
     // Initialize the operands.


### PR DESCRIPTION
If this assert failure gets unnoticed (in a non-assert compiler build), it can later result in a crash in the inliner. Let's enable this assert in non-assert builds to catch such errors as early as possible.

Related to rdar://171398563
