### PR TITLE
[Sema] Add scope-based analogues of -warn-long-expression-type-checking

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7671,6 +7671,12 @@ WARNING(debug_long_closure_body, none,
 WARNING(debug_long_expression, none,
         "expression took %0ms to type-check (limit: %1ms)",
         (unsigned, unsigned))
+WARNING(debug_long_expression_scopes, none,
+        "expression took %0 scope(s) to type-check (limit: %1)",
+        (unsigned, unsigned))
+WARNING(debug_long_expression_trail, none,
+        "expression took %0 trail step(s) to type-check (limit: %1)",
+        (unsigned, unsigned))
 
 //------------------------------------------------------------------------------
 // MARK: Pattern match diagnostics

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -931,6 +931,20 @@ namespace swift {
     /// Intended for debugging purposes only.
     unsigned WarnLongExpressionTypeChecking = 0;
 
+    /// If non-zero, warn when type-checking an expression uses more than
+    /// this many solver scopes.
+    ///
+    /// Intended for debugging purposes only. Unlike WarnLongExpressionTypeChecking,
+    /// this threshold is deterministic across machines.
+    unsigned WarnLongExpressionTypeCheckingScopes = 0;
+
+    /// If non-zero, warn when type-checking an expression uses more than
+    /// this many solver trail steps.
+    ///
+    /// Intended for debugging purposes only. Unlike WarnLongExpressionTypeChecking,
+    /// this threshold is deterministic across machines.
+    unsigned WarnLongExpressionTypeCheckingTrail = 0;
+
     /// If non-zero, abort the expression type checker if it takes more
     /// than this many seconds.
     unsigned ExpressionTimeoutThreshold = 0;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -911,6 +911,18 @@ def warn_long_expression_type_checking : Separate<["-"], "warn-long-expression-t
 def warn_long_expression_type_checking_EQ : Joined<["-"], "warn-long-expression-type-checking=">,
   Alias<warn_long_expression_type_checking>;
 
+def warn_long_expression_type_checking_scopes : Separate<["-"], "warn-long-expression-type-checking-scopes">,
+  MetaVarName<"<n>">,
+  HelpText<"Warns when type-checking an expression uses more than <n> solver scopes">;
+def warn_long_expression_type_checking_scopes_EQ : Joined<["-"], "warn-long-expression-type-checking-scopes=">,
+  Alias<warn_long_expression_type_checking_scopes>;
+
+def warn_long_expression_type_checking_trail : Separate<["-"], "warn-long-expression-type-checking-trail">,
+  MetaVarName<"<n>">,
+  HelpText<"Warns when type-checking an expression uses more than <n> solver trail steps">;
+def warn_long_expression_type_checking_trail_EQ : Joined<["-"], "warn-long-expression-type-checking-trail=">,
+  Alias<warn_long_expression_type_checking_trail>;
+
 def Rmodule_interface_rebuild : Flag<["-"], "Rmodule-interface-rebuild">,
   HelpText<"Emits a remark if an imported module needs to be re-compiled from its module interface">;
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4073,6 +4073,12 @@ public:
     return CurrentRange;
   }
 
+  /// Return the number of solver scopes created so far.
+  unsigned getNumSolverScopes() const { return NumSolverScopes; }
+
+  /// Return the number of solver trail steps taken so far.
+  unsigned getNumTrailSteps() const { return NumTrailSteps; }
+
   /// Determine if we've already explored too many paths in an
   /// attempt to solve this expression.
   std::pair<bool, SourceRange> isAlreadyTooComplex = {false, SourceRange()};

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -227,24 +227,37 @@ public:
 };
 
 
-class ExpressionTimer {
+class ComplexityTracker {
   ConstraintSystem &CS;
   llvm::TimeRecord StartTime;
 
   /// The number of seconds from creation until
-  /// this timer is considered expired.
+  /// this tracker is considered expired.
   unsigned ThresholdInSecs;
+
+  /// Threshold (in milliseconds) for emitting a wall-clock-based warning.
+  /// 0 disables the warning.
+  unsigned WarnTimeLimitInMillis;
+
+  /// Threshold for emitting a solver-scope-based warning.
+  /// 0 disables the warning.
+  unsigned WarnScopeLimit;
+
+  /// Threshold for emitting a solver-trail-step-based warning.
+  /// 0 disables the warning.
+  unsigned WarnTrailLimit;
 
   bool PrintWarning;
 
 public:
   const static unsigned NoLimit = (unsigned) -1;
 
-  ExpressionTimer(ConstraintSystem &CS, unsigned thresholdInSecs);
+  ComplexityTracker(ConstraintSystem &CS, unsigned thresholdInSecs,
+                    unsigned warnTimeLimitInMillis, unsigned warnScopeLimit,
+                    unsigned warnTrailLimit);
 
-  ~ExpressionTimer();
+  ~ComplexityTracker();
 
-  unsigned getWarnLimit() const;
   llvm::TimeRecord startedAt() const { return StartTime; }
 
   /// Return the elapsed process time (including fractional seconds)
@@ -782,7 +795,7 @@ public:
   DeclContext *DC;
   ConstraintSystemOptions Options;
   DiagnosticTransaction *diagnosticTransaction;
-  std::optional<ExpressionTimer> Timer;
+  std::optional<ComplexityTracker> Timer;
 
   friend class Solution;
   friend class ConstraintFix;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2028,6 +2028,10 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
                              Opts.WarnLongFunctionBodies);
   setUnsignedIntegerArgument(OPT_warn_long_expression_type_checking,
                              Opts.WarnLongExpressionTypeChecking);
+  setUnsignedIntegerArgument(OPT_warn_long_expression_type_checking_scopes,
+                             Opts.WarnLongExpressionTypeCheckingScopes);
+  setUnsignedIntegerArgument(OPT_warn_long_expression_type_checking_trail,
+                             Opts.WarnLongExpressionTypeCheckingTrail);
   setUnsignedIntegerArgument(OPT_solver_expression_time_threshold_EQ,
                              Opts.ExpressionTimeoutThreshold);
   setUnsignedIntegerArgument(OPT_dynamic_member_lookup_depth_limit_EQ,

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -627,7 +627,6 @@ ConstraintSystem::SolverState::SolverState(
 ConstraintSystem::SolverState::~SolverState() {
   assert((CS.solverState == this) &&
          "Expected constraint system to have this solver state!");
-  CS.NumTrailSteps += NumTrailSteps;
   CS.solverState = nullptr;
 
   // If constraint system ended up being in an invalid state
@@ -764,7 +763,9 @@ void ConstraintSystem::SolverState::endScope(unsigned scopeNumber,
   ASSERT(depth > 0);
   --depth;
 
-  NumTrailSteps += (endTrailSteps - startTrailSteps);
+  unsigned steps = endTrailSteps - startTrailSteps;
+  NumTrailSteps += steps;
+  CS.NumTrailSteps += steps;
 
   unsigned countSolverScopes = NumSolverScopes - scopeNumber;
   if (countSolverScopes == 1)

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -627,6 +627,7 @@ ConstraintSystem::SolverState::SolverState(
 ConstraintSystem::SolverState::~SolverState() {
   assert((CS.solverState == this) &&
          "Expected constraint system to have this solver state!");
+  CS.NumTrailSteps += NumTrailSteps;
   CS.solverState = nullptr;
 
   // If constraint system ended up being in an invalid state

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -884,8 +884,13 @@ public:
     if (HadFailure)
       restoreBestScore();
 
-    if (OuterTimeRemaining)
-      CS.Timer.emplace(CS, *OuterTimeRemaining);
+    if (OuterTimeRemaining) {
+      const auto &opts = CS.getASTContext().TypeCheckerOpts;
+      CS.Timer.emplace(CS, *OuterTimeRemaining,
+                       opts.WarnLongExpressionTypeChecking,
+                       opts.WarnLongExpressionTypeCheckingScopes,
+                       opts.WarnLongExpressionTypeCheckingTrail);
+    }
   }
 
   StepResult resume(bool prevFailed) override;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -112,17 +112,20 @@ bool ConstraintSystem::isTooComplex(size_t solutionMemory) {
   return false;
 }
 
-ExpressionTimer::ExpressionTimer(ConstraintSystem &CS, unsigned thresholdInSecs)
+ComplexityTracker::ComplexityTracker(ConstraintSystem &CS,
+                                     unsigned thresholdInSecs,
+                                     unsigned warnTimeLimitInMillis,
+                                     unsigned warnScopeLimit,
+                                     unsigned warnTrailLimit)
     : CS(CS),
       StartTime(llvm::TimeRecord::getCurrentTime()),
       ThresholdInSecs(thresholdInSecs),
+      WarnTimeLimitInMillis(warnTimeLimitInMillis),
+      WarnScopeLimit(warnScopeLimit),
+      WarnTrailLimit(warnTrailLimit),
       PrintWarning(true) {}
 
-unsigned ExpressionTimer::getWarnLimit() const {
-  return CS.getASTContext().TypeCheckerOpts.WarnLongExpressionTypeChecking;
-}
-
-ExpressionTimer::~ExpressionTimer() {
+ComplexityTracker::~ComplexityTracker() {
   auto elapsed = getElapsedProcessTimeInFractionalSeconds();
   unsigned elapsedMS = static_cast<unsigned>(elapsed * 1000);
   auto &ctx = CS.getASTContext();
@@ -141,34 +144,32 @@ ExpressionTimer::~ExpressionTimer() {
     return;
 
   // Time-based warning (non-deterministic).
-  const auto WarnLimit = getWarnLimit();
-  if (WarnLimit > 0 && elapsedMS >= WarnLimit && range.Start.isValid()) {
+  if (WarnTimeLimitInMillis > 0 && elapsedMS >= WarnTimeLimitInMillis &&
+      range.Start.isValid()) {
     ctx.Diags
         .diagnose(range.Start, diag::debug_long_expression, elapsedMS,
-                  WarnLimit)
+                  WarnTimeLimitInMillis)
         .highlight(range);
   }
 
   // Scope-based warning (deterministic).
-  const auto scopeLimit = ctx.TypeCheckerOpts.WarnLongExpressionTypeCheckingScopes;
-  if (scopeLimit > 0) {
+  if (WarnScopeLimit > 0) {
     unsigned numScopes = CS.getNumSolverScopes();
-    if (numScopes > scopeLimit && range.Start.isValid()) {
+    if (numScopes > WarnScopeLimit && range.Start.isValid()) {
       ctx.Diags
           .diagnose(range.Start, diag::debug_long_expression_scopes,
-                    numScopes, scopeLimit)
+                    numScopes, WarnScopeLimit)
           .highlight(range);
     }
   }
 
   // Trail-based warning (deterministic).
-  const auto trailLimit = ctx.TypeCheckerOpts.WarnLongExpressionTypeCheckingTrail;
-  if (trailLimit > 0) {
+  if (WarnTrailLimit > 0) {
     unsigned numSteps = CS.getNumTrailSteps();
-    if (numSteps > trailLimit && range.Start.isValid()) {
+    if (numSteps > WarnTrailLimit && range.Start.isValid()) {
       ctx.Diags
           .diagnose(range.Start, diag::debug_long_expression_trail,
-                    numSteps, trailLimit)
+                    numSteps, WarnTrailLimit)
           .highlight(range);
     }
   }
@@ -208,8 +209,8 @@ void ConstraintSystem::startExpressionTimer() {
   unsigned timeout = opts.ExpressionTimeoutThreshold;
 
   // If either the timeout is set, we're asked to emit warnings, or we're
-  // asked to debug expression type-checking times, start the timer.
-  // Otherwise, don't start the timer, it's needless overhead.
+  // asked to debug expression type-checking times, start the tracker.
+  // Otherwise, don't start the tracker, it's needless overhead.
   if (timeout == 0) {
     if (opts.WarnLongExpressionTypeChecking == 0 &&
         opts.WarnLongExpressionTypeCheckingScopes == 0 &&
@@ -217,10 +218,12 @@ void ConstraintSystem::startExpressionTimer() {
         !opts.DebugTimeExpressions)
       return;
 
-    timeout = ExpressionTimer::NoLimit;
+    timeout = ComplexityTracker::NoLimit;
   }
 
-  Timer.emplace(*this, timeout);
+  Timer.emplace(*this, timeout, opts.WarnLongExpressionTypeChecking,
+                opts.WarnLongExpressionTypeCheckingScopes,
+                opts.WarnLongExpressionTypeCheckingTrail);
 }
 
 void ConstraintSystem::incrementScopeCounter() {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -140,16 +140,37 @@ ExpressionTimer::~ExpressionTimer() {
   if (!PrintWarning)
     return;
 
+  // Time-based warning (non-deterministic).
   const auto WarnLimit = getWarnLimit();
-
-  if (WarnLimit == 0 || elapsedMS < WarnLimit)
-    return;
-
-  if (range.Start.isValid()) {
+  if (WarnLimit > 0 && elapsedMS >= WarnLimit && range.Start.isValid()) {
     ctx.Diags
         .diagnose(range.Start, diag::debug_long_expression, elapsedMS,
                   WarnLimit)
         .highlight(range);
+  }
+
+  // Scope-based warning (deterministic).
+  const auto scopeLimit = ctx.TypeCheckerOpts.WarnLongExpressionTypeCheckingScopes;
+  if (scopeLimit > 0) {
+    unsigned numScopes = CS.getNumSolverScopes();
+    if (numScopes > scopeLimit && range.Start.isValid()) {
+      ctx.Diags
+          .diagnose(range.Start, diag::debug_long_expression_scopes,
+                    numScopes, scopeLimit)
+          .highlight(range);
+    }
+  }
+
+  // Trail-based warning (deterministic).
+  const auto trailLimit = ctx.TypeCheckerOpts.WarnLongExpressionTypeCheckingTrail;
+  if (trailLimit > 0) {
+    unsigned numSteps = CS.getNumTrailSteps();
+    if (numSteps > trailLimit && range.Start.isValid()) {
+      ctx.Diags
+          .diagnose(range.Start, diag::debug_long_expression_trail,
+                    numSteps, trailLimit)
+          .highlight(range);
+    }
   }
 }
 
@@ -191,6 +212,8 @@ void ConstraintSystem::startExpressionTimer() {
   // Otherwise, don't start the timer, it's needless overhead.
   if (timeout == 0) {
     if (opts.WarnLongExpressionTypeChecking == 0 &&
+        opts.WarnLongExpressionTypeCheckingScopes == 0 &&
+        opts.WarnLongExpressionTypeCheckingTrail == 0 &&
         !opts.DebugTimeExpressions)
       return;
 

--- a/test/Sema/warn_long_expression_type_checking_scopes.swift
+++ b/test/Sema/warn_long_expression_type_checking_scopes.swift
@@ -1,0 +1,11 @@
+// Regression test: -warn-long-expression-type-checking-scopes must emit a
+// warning when an expression uses more solver scopes than the threshold.
+// Using threshold=1 guarantees the warning fires on any non-trivial expression,
+// making the test deterministic across machines and build configurations.
+//
+// RUN: %target-swiftc_driver -Xfrontend -warn-long-expression-type-checking-scopes=1 %s 2>&1 | %FileCheck %s
+// CHECK: expression took {{[0-9]+}} scope(s) to type-check (limit: 1)
+
+func example() {
+    let _: Int = [1, 2, 3].map { $0 * 2 }.reduce(0, +)
+}

--- a/test/Sema/warn_long_expression_type_checking_trail.swift
+++ b/test/Sema/warn_long_expression_type_checking_trail.swift
@@ -1,0 +1,11 @@
+// Regression test: -warn-long-expression-type-checking-trail must emit a
+// warning when an expression uses more solver trail steps than the threshold.
+// Using threshold=1 guarantees the warning fires on any non-trivial expression,
+// making the test deterministic across machines and build configurations.
+//
+// RUN: %target-swiftc_driver -Xfrontend -warn-long-expression-type-checking-trail=1 %s 2>&1 | %FileCheck %s
+// CHECK: expression took {{[0-9]+}} trail step(s) to type-check (limit: 1)
+
+func example() {
+    let _: Int = [1, 2, 3].map { $0 * 2 }.reduce(0, +)
+}


### PR DESCRIPTION
- **Explanation**:
  Adds two scope-based analogues to `-warn-long-expression-type-checking`:
  - `-warn-long-expression-type-checking-scopes <N>` — warns when an expression uses more than N solver scopes
  - `-warn-long-expression-type-checking-trail <N>` — warns when an expression uses more than N solver trail steps

  Scope count measures type variable binding attempts and disjunction options explored. Trail steps measure constraint system changes recorded. Both are deterministic proxies for solver complexity, unlike the existing wall-clock-based warning, which varies across machines and CI environments.

  Also fixes a latent bug where `ConstraintSystem::NumTrailSteps` was never incremented (only `SolverState::NumTrailSteps` was), so `getNumTrailSteps()` always returned 0.

- **Scope**:
  Additive. Two new opt-in frontend flags; default behavior is unchanged. The trail-step counter fix changes a value that was previously always 0; no in-tree consumers depend on the old behavior.

- **Issues**:
  Follows up on #88102.

- **Risk**:
  Low. New flags are off by default. The trail-step counter fix only affects observability (the value was effectively dead before this PR).

- **Testing**:
  Two new lit tests in `test/Sema/` using `threshold=1`, which guarantees the warning fires on any non-trivial expression regardless of machine or build configuration.
