### PR TITLE
[android] Re-enable stdlib C++ Interop test that is passing again

### DIFF
--- a/test/Interop/SwiftToCxx/stdlib/stdlib-in-cxx-no-diagnostics-generated-header.cpp
+++ b/test/Interop/SwiftToCxx/stdlib/stdlib-in-cxx-no-diagnostics-generated-header.cpp
@@ -7,9 +7,6 @@
 
 // RUN: %target-interop-build-clangxx -std=gnu++20 -fsyntax-only -c %t/test-stdlib.cpp -I %t -Wall -Werror -Werror=ignored-attributes -Wno-error=unused-command-line-argument
 
-// #84574 and #82055 have turned up an availability edge case on Android, disable till fixed.
-// XFAIL: OS=linux-android, OS=linux-androideabi
-
 //--- print-string.swift
 
 public func printString(_ s: String) {


### PR DESCRIPTION
This is [passing on CI](https://ci.swift.org/job/oss-swift-package-swift-sdk-for-android/361/console) again, maybe because of #87435?

Let's see if we can re-enable it, perhaps @Xazax-hun knows the reason why it works now. @justice-adams-apple, any chance you updated the NDK to 28 but kept it labeled as 27 still? 😉