### PR TITLE
Update viewcfg's printing of loop headers

### DIFF
--- a/include/swift/SIL/BasicBlockUtils.h
+++ b/include/swift/SIL/BasicBlockUtils.h
@@ -456,6 +456,15 @@ struct SILCFGBackwardDFS {
   /// The region in reverse post-order.
   auto reversePostOrder() { return llvm::reverse(postOrder()); }
 };
+
+/// Find loop headers in the given function using a DFS-based back-edge
+/// detection algorithm. A block is a loop header if it is the target of a
+/// back-edge (an edge from a descendant to an ancestor in the DFS tree).
+///
+/// Populates \p LoopHeaders with the set of basic blocks that are loop headers.
+void findLoopHeaders(SILFunction &Fn,
+                     llvm::SmallPtrSet<SILBasicBlock *, 32> &LoopHeaders);
+
 } // namespace swift
 
 #endif

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -29,6 +29,7 @@
 #include "swift/Basic/SourceManager.h"
 #include "swift/Demangling/Demangle.h"
 #include "swift/SIL/ApplySite.h"
+#include "swift/SIL/BasicBlockUtils.h"
 #include "swift/SIL/CFG.h"
 #include "swift/SIL/InstructionUtils.h"
 #include "swift/SIL/SILArgument.h"
@@ -104,6 +105,10 @@ llvm::cl::opt<bool> SILPrintFunctionIsolationInfo(
     "sil-print-function-isolation-info", llvm::cl::init(false),
     llvm::cl::desc("Print out isolation info on functions in a manner that SIL "
                    "understands [e.x.: not in comments]"));
+
+llvm::cl::opt<bool> SILPrintLoopHeaders(
+    "sil-print-loopheaders", llvm::cl::init(true),
+    llvm::cl::desc("Print a comment on basic blocks that are loop headers"));
 
 static std::string demangleSymbol(StringRef Name) {
   if (SILFullDemangle)
@@ -747,6 +752,7 @@ class SILPrinter : public SILInstructionVisitor<SILPrinter> {
   LineComments lineComments;
   unsigned LastBufferID;
   llvm::DenseSet<const SILBasicBlock *> printedBlocks;
+  llvm::SmallPtrSet<SILBasicBlock *, 32> loopHeaders;
 
   // Printers for the underlying stream.
 #define SIMPLE_PRINTER(TYPE) \
@@ -907,6 +913,10 @@ public:
   //===--------------------------------------------------------------------===//
   // Big entrypoints.
   void print(const SILFunction *F) {
+    if (SILPrintLoopHeaders) {
+      findLoopHeaders(*const_cast<SILFunction *>(F), loopHeaders);
+    }
+
     // If we are asked to emit sorted SIL, print out our BBs in RPOT order.
     if (Ctx.sortSIL()) {
       std::vector<SILBasicBlock *> RPOT;
@@ -1039,6 +1049,11 @@ public:
       *this << "// " << debugName.value() << '\n';
     }
 
+    if (SILPrintLoopHeaders &&
+        loopHeaders.count(const_cast<SILBasicBlock *>(BB))) {
+      *this << "// Loop header\n";
+    }
+
     // Then print the name of our block, the arguments, and the block colon.
     *this << Ctx.getID(BB);
     printBlockArguments(BB);
@@ -1064,8 +1079,8 @@ public:
       for (auto Id : PredIDs)
         *this << ' ' << Id;
     }
-    *this << '\n';
 
+    *this << '\n';
     const auto &SM = BB->getModule().getASTContext().SourceMgr;
     std::optional<SILLocation> PrevLoc;
     for (const SILInstruction &I : *BB) {

--- a/lib/SIL/Utils/BasicBlockUtils.cpp
+++ b/lib/SIL/Utils/BasicBlockUtils.cpp
@@ -792,3 +792,39 @@ swift::checkDominates(SILBasicBlock *sourceBlock, SILBasicBlock *destBlock) {
   return reaches;
 }
 #endif
+
+//===----------------------------------------------------------------------===//
+//                             findLoopHeaders
+//===----------------------------------------------------------------------===//
+
+void swift::findLoopHeaders(
+    SILFunction &Fn,
+    llvm::SmallPtrSet<SILBasicBlock *, 32> &LoopHeaders) {
+  LoopHeaders.clear();
+  BasicBlockSet Visited(&Fn);
+  BasicBlockSet InDFSStack(&Fn);
+  SmallVector<std::pair<SILBasicBlock *, SILBasicBlock::succ_iterator>, 16>
+      DFSStack;
+
+  auto *EntryBB = &Fn.front();
+  DFSStack.push_back(std::make_pair(EntryBB, EntryBB->succ_begin()));
+  Visited.insert(EntryBB);
+  InDFSStack.insert(EntryBB);
+
+  while (!DFSStack.empty()) {
+    auto &D = DFSStack.back();
+    if (D.second == D.first->succ_end()) {
+      DFSStack.pop_back();
+      InDFSStack.erase(D.first);
+    } else {
+      SILBasicBlock *NextSucc = *(D.second);
+      ++D.second;
+      if (Visited.insert(NextSucc)) {
+        InDFSStack.insert(NextSucc);
+        DFSStack.push_back(std::make_pair(NextSucc, NextSucc->succ_begin()));
+      } else if (InDFSStack.contains(NextSucc)) {
+        LoopHeaders.insert(NextSucc);
+      }
+    }
+  }
+}

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -34,6 +34,7 @@
 #include "swift/AST/Module.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/SIL/BasicBlockDatastructures.h"
+#include "swift/SIL/BasicBlockUtils.h"
 #include "swift/SIL/Dominance.h"
 #include "swift/SIL/InstructionUtils.h"
 #include "swift/SIL/Projection.h"
@@ -823,42 +824,8 @@ static bool couldSimplifyEnumUsers(SILArgument *BBArg, int Budget,
 }
 
 void SimplifyCFG::findLoopHeaders() {
-  /// Find back edges in the CFG. This performs a dfs search and identifies
-  /// back edges as edges going to an ancestor in the dfs search. If a basic
-  /// block is the target of such a back edge we will identify it as a header.
   LoopHeaders.clear();
-
-  BasicBlockSet Visited(&Fn);
-  BasicBlockSet InDFSStack(&Fn);
-  SmallVector<std::pair<SILBasicBlock *, SILBasicBlock::succ_iterator>, 16>
-      DFSStack;
-
-  auto EntryBB = &Fn.front();
-  DFSStack.push_back(std::make_pair(EntryBB, EntryBB->succ_begin()));
-  Visited.insert(EntryBB);
-  InDFSStack.insert(EntryBB);
-
-  while (!DFSStack.empty()) {
-    auto &D = DFSStack.back();
-    // No successors.
-    if (D.second == D.first->succ_end()) {
-      // Retreat the dfs search.
-      DFSStack.pop_back();
-      InDFSStack.erase(D.first);
-    } else {
-      // Visit the next successor.
-      SILBasicBlock *NextSucc = *(D.second);
-      ++D.second;
-      if (Visited.insert(NextSucc)) {
-        InDFSStack.insert(NextSucc);
-        DFSStack.push_back(std::make_pair(NextSucc, NextSucc->succ_begin()));
-      } else if (InDFSStack.contains(NextSucc)) {
-        // We have already visited this node and it is in our dfs search. This
-        // is a back-edge.
-        LoopHeaders.insert(NextSucc);
-      }
-    }
-  }
+  swift::findLoopHeaders(Fn, LoopHeaders);
 }
 
 static bool couldRemoveRelease(SILBasicBlock *SrcBB, SILValue SrcV,

--- a/test/SILOptimizer/licm_exclusivity.swift
+++ b/test/SILOptimizer/licm_exclusivity.swift
@@ -8,10 +8,7 @@
 // TESTSIL: bb
 // TESTSIL: begin_access [modify] [dynamic] [no_nested_conflict]
 // TESTSIL: br bb{{.*}}
-// TESTSIL-EMPTY:
-// TESTSIL-NEXT: {{^}}//
-// TESTSIL-NEXT: {{^}}//
-// TESTSIL-NEXT: bb{{.*}}:
+// TESTSIL: bb{{.*}}:
 // TESTSIL: end_access
 var x = 0
 func run_ReversedArray(_ N: Int) {

--- a/utils/viewcfg
+++ b/utils/viewcfg
@@ -39,12 +39,13 @@ class Block(object):
 
     current_index = 0
 
-    def __init__(self, name, preds):
+    def __init__(self, name, preds, is_loop_header=False):
         self.name = name
         self.content = None
         self.preds = []
         self.succs = None
         self.last_line = None
+        self.is_loop_header = is_loop_header
         self.index = Block.current_index
         Block.current_index += 1
         if preds is not None:
@@ -98,9 +99,11 @@ def main():
     block_list = []
     block_map = {}
     cur_block = None
+    next_block_is_loop_header = False
     sil_block_pattern = re.compile(r'^(\S+)(\(.*\))?: *(\/\/ *Preds:(.*))?$')
     llvm_block_pattern1 = re.compile(r'^"?([^\s"]+)"?: *; *preds =(.*)?$')
     llvm_block_pattern2 = re.compile(r'^(\d+):? *; *preds =(.*)?$')
+    loop_header_pattern = re.compile(r'^// Loop header\s*$')
 
     # Scan the input file.
     for line in args.input_file.readlines():
@@ -109,7 +112,9 @@ def main():
         llvm_block_match2 = llvm_block_pattern2.match(line)
         block_name = None
         preds = None
-        if sil_block_match:
+        if loop_header_pattern.match(line):
+            next_block_is_loop_header = True
+        elif sil_block_match:
             block_name = sil_block_match.group(1)
             preds = sil_block_match.group(4)
         elif llvm_block_match1:
@@ -127,7 +132,8 @@ def main():
             cur_block = None
 
         if block_name is not None:
-            cur_block = Block(block_name, preds)
+            cur_block = Block(block_name, preds, next_block_is_loop_header)
+            next_block_is_loop_header = False
             cur_block.add_line(line)
             block_list.append(cur_block)
             block_map[block_name] = cur_block
@@ -163,6 +169,11 @@ def main():
                     "\tNode" + str(block.index) +
                     " [shape=record,color=gray,fontcolor=gray,label=\"{" +
                     block.name + "}\"];\n")
+            elif block.is_loop_header:
+                out_file.write(
+                    "\tNode" + str(block.index) +
+                    " [shape=record,color=red,label=\"{" +
+                    block.content + "}\"];\n")
             else:
                 out_file.write(
                     "\tNode" + str(block.index) +

--- a/utils/viewcfg
+++ b/utils/viewcfg
@@ -81,8 +81,8 @@ def parse_args():
     Simple regex based transform of SIL and LLVM-IR into graphviz form.
     """)
     parser.add_argument("output_suffix", nargs='?')
-    parser.add_argument("--disable_inst_dump", action='store_true')
-    parser.add_argument("--input_file", type=argparse.FileType('r'),
+    parser.add_argument("--disable-inst-dump", action='store_true')
+    parser.add_argument("--input-file", type=argparse.FileType('r'),
                         default=sys.stdin)
     parser.add_argument("--renderer", choices=["Graphviz", "dot"],
                         default="Graphviz", help="Default is Graphviz")


### PR DESCRIPTION
- Add a new option -sil-print-loopheaders to annotate loop headers in SIL
- Use this information when available to display loop headers with a colored border in viewcfg 