### PR TITLE
[DebugInfo] [SILGen] Consider a SILLocation created from an implicit conversion of an explicit node as explicit

### DIFF
--- a/lib/SIL/IR/SILLocation.cpp
+++ b/lib/SIL/IR/SILLocation.cpp
@@ -32,8 +32,16 @@ SILLocation::SILLocation(Stmt *S) : SILLocation(ASTNodeTy(S), RegularKind) {
 }
 
 SILLocation::SILLocation(Expr *E) : SILLocation(ASTNodeTy(E), RegularKind) {
-  if (E->isImplicit())
-    kindAndFlags.fields.implicit = true;
+  if (E->isImplicit()) {
+    if (auto *ICE = dyn_cast<ImplicitConversionExpr>(E)) {
+      if (ICE->getSyntacticSubExpr()->isImplicit()) {
+        // If this is just an implicit conversion of an explicit node, don't mark the location as implicit.
+        kindAndFlags.fields.implicit = true;
+      }
+    } else {
+      kindAndFlags.fields.implicit = true;
+    }
+  }
 }
 SILLocation::SILLocation(Decl *D) : SILLocation(ASTNodeTy(D), RegularKind) {
   if (D && D->isImplicit())

--- a/test/DebugInfo/if-bool-var.swift
+++ b/test/DebugInfo/if-bool-var.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend %s -emit-ir -g -o - | %FileCheck %s
+func doSomething() {}
+
+// CHECK-LABEL: @"$s4main5hello5paramySb_tF"
+func hello(param: Bool) {
+    var mutable = param
+    // CHECK: br i1 %{{[0-9]+}}, label %{{[0-9]+}}, label %{{[0-9]+}}, !dbg ![[IF_STMT:[0-9]+]]
+    if mutable {
+    // CHECK: ![[IF_STMT]] = !DILocation(line: [[@LINE-1]], column: 8,
+        doSomething()
+        mutable = false
+    }
+}
+


### PR DESCRIPTION
In a program like this:
```swift
func hello(param: Bool) {
    var mutable = param
    if mutable { // <— LLDB skips over this line
        print("true")
    }
}

hello(param: true)
```
The `if mutable` condition was skipped over by LLDB. The condition is an implicit conversion, and implicit nodes get skipped over. The explicit node in this case doesn't generate any instruction.
This was fixed by treating implicit conversions of explicit nodes as explicit, so the debugger can still stop at the condition.

rdar://149788015