### PR TITLE
Serialization: Only skip serializing implementation-only decls in Strict mode

### DIFF
--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -285,7 +285,8 @@ SerializationOptions CompilerInvocation::computeSerializationOptions(
       getLangOptions().SkipNonExportableDecls;
 
   serializationOpts.SkipImplementationOnlyDecls =
-      getLangOptions().hasFeature(Feature::CheckImplementationOnly);
+      getLangOptions().hasFeature(Feature::CheckImplementationOnlyStrict) &&
+      !::getenv("SWIFT_DISABLE_IMPLICIT_CHECK_IMPLEMENTATION_ONLY");
 
   serializationOpts.ExplicitModuleBuild = FrontendOpts.DisableImplicitModules;
 


### PR DESCRIPTION
Enable `SkipImplementationOnlyDecls` only in `CheckImplementationOnlyStrict` mode. It was meant to be aligned with that mode in the first place and has been causing issues at indexing on partially serialized AST trees.

rdar://173168470