### PR TITLE
ClangImporter: Import `anyAppleOS` availability attributes

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2784,64 +2784,37 @@ PlatformAvailability::PlatformAvailability(const LangOptions &langOpts)
   }
 }
 
-bool PlatformAvailability::isPlatformRelevant(StringRef name) const {
-  switch (platformKind) {
-  case PlatformKind::macOS:
-    return name == "macos";
-  case PlatformKind::macOSApplicationExtension:
-    return name == "macos" || name == "macos_app_extension";
+std::optional<PlatformKind>
+PlatformAvailability::platformKindIfRelevant(StringRef platformName) const {
+  auto result =
+      llvm::StringSwitch<std::optional<PlatformKind>>(platformName)
+          .Case("anyappleos", PlatformKind::anyAppleOS)
+          .Case("ios", PlatformKind::iOS)
+          .Case("macos", PlatformKind::macOS)
+          .Case("maccatalyst", PlatformKind::macCatalyst)
+          .Case("tvos", PlatformKind::tvOS)
+          .Case("watchos", PlatformKind::watchOS)
+          .Case("xros", PlatformKind::visionOS)
+          .Case("visionos", PlatformKind::visionOS)
+          .Case("ios_app_extension", PlatformKind::iOSApplicationExtension)
+          .Case("maccatalyst_app_extension",
+                PlatformKind::macCatalystApplicationExtension)
+          .Case("macos_app_extension", PlatformKind::macOSApplicationExtension)
+          .Case("tvos_app_extension", PlatformKind::tvOSApplicationExtension)
+          .Case("watchos_app_extension",
+                PlatformKind::watchOSApplicationExtension)
+          .Case("xros_app_extension",
+                PlatformKind::visionOSApplicationExtension)
+          .Case("android", PlatformKind::Android)
+          .Default(std::nullopt);
 
-  case PlatformKind::iOS:
-    return name == "ios";
-  case PlatformKind::iOSApplicationExtension:
-    return name == "ios" || name == "ios_app_extension";
-
-  case PlatformKind::macCatalyst:
-    return name == "ios" || name == "maccatalyst";
-  case PlatformKind::macCatalystApplicationExtension:
-    return name == "ios" || name == "ios_app_extension" ||
-           name == "maccatalyst" || name == "maccatalyst_app_extension";
-
-  case PlatformKind::tvOS:
-    return name == "tvos";
-  case PlatformKind::tvOSApplicationExtension:
-    return name == "tvos" || name == "tvos_app_extension";
-
-  case PlatformKind::watchOS:
-    return name == "watchos";
-  case PlatformKind::watchOSApplicationExtension:
-    return name == "watchos" || name == "watchos_app_extension";
-
-  case PlatformKind::visionOS:
-    return name == "xros" || name == "visionos";
-  case PlatformKind::visionOSApplicationExtension:
-    return name == "xros" || name == "xros_app_extension" ||
-           name == "visionos" || name == "visionos_app_extension";
-
-  case PlatformKind::DriverKit:
-    return name == "driverkit";
-
-  case PlatformKind::Swift:
-  case PlatformKind::anyAppleOS:
-    break; // Unexpected
-
-  case PlatformKind::FreeBSD:
-    return name == "freebsd";
-
-  case PlatformKind::OpenBSD:
-    return name == "openbsd";
-
-  case PlatformKind::Windows:
-    return name == "windows";
-
-  case PlatformKind::Android:
-    return name == "android";
-
-  case PlatformKind::none:
-    return false;
+  if (result) {
+    if (platformKind == *result ||
+        inheritsAvailabilityFromPlatform(platformKind, *result))
+      return result;
   }
 
-  llvm_unreachable("Unexpected platform");
+  return std::nullopt;
 }
 
 bool PlatformAvailability::treatDeprecatedAsUnavailable(

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -9678,31 +9678,7 @@ void ClangImporter::Implementation::importAttributes(
 
       // Does this availability attribute map to the platform we are
       // currently targeting?
-      if (!platformAvailability.isPlatformRelevant(Platform))
-        continue;
-
-      auto platformK =
-          llvm::StringSwitch<std::optional<PlatformKind>>(Platform)
-              .Case("ios", PlatformKind::iOS)
-              .Case("macos", PlatformKind::macOS)
-              .Case("maccatalyst", PlatformKind::macCatalyst)
-              .Case("tvos", PlatformKind::tvOS)
-              .Case("watchos", PlatformKind::watchOS)
-              .Case("xros", PlatformKind::visionOS)
-              .Case("visionos", PlatformKind::visionOS)
-              .Case("ios_app_extension", PlatformKind::iOSApplicationExtension)
-              .Case("maccatalyst_app_extension",
-                    PlatformKind::macCatalystApplicationExtension)
-              .Case("macos_app_extension",
-                    PlatformKind::macOSApplicationExtension)
-              .Case("tvos_app_extension",
-                    PlatformKind::tvOSApplicationExtension)
-              .Case("watchos_app_extension",
-                    PlatformKind::watchOSApplicationExtension)
-              .Case("xros_app_extension",
-                    PlatformKind::visionOSApplicationExtension)
-              .Case("android", PlatformKind::Android)
-              .Default(std::nullopt);
+      auto platformK = platformAvailability.platformKindIfRelevant(Platform);
       if (!platformK)
         continue;
 

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -332,9 +332,16 @@ private:
   PlatformKind platformKind;
 
 public:
+  /// Returns a non-optional `PlatformKind` corresponding to the platform name
+  /// if the given platform should be considered for availability on imported
+  /// declarations.
+  std::optional<PlatformKind> platformKindIfRelevant(StringRef platform) const;
+
   /// Returns true when the given platform should be considered for
-  /// availabilityon imported declarations.
-  bool isPlatformRelevant(StringRef platform) const;
+  /// availability on imported declarations.
+  bool isPlatformRelevant(StringRef platform) const {
+    return platformKindIfRelevant(platform).has_value();
+  }
 
   /// Returns true when the given declaration with the given deprecation
   /// should be included in the cutoff of imported deprecated APIs marked

--- a/test/ClangImporter/availability_any_apple_os.swift
+++ b/test/ClangImporter/availability_any_apple_os.swift
@@ -1,0 +1,45 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unrelated -I %t %t/main.swift -target %target-swift-6.2-abi-triple -verify-additional-prefix %target-os-
+
+// REQUIRES: OS=macosx || OS=ios || OS=linux-gnu || OS=windows-msvc
+
+//--- module.modulemap
+
+module AnyAppleOS {
+  header "AnyAppleOS.h"
+  export *
+}
+
+//--- AnyAppleOS.h
+
+void introduced_in_26_2() __attribute__((availability(anyappleos, introduced = 26.2)));
+void deprecated_in_26_0() __attribute__((availability(anyappleos, deprecated = 26.0)));
+void obsoleted_in_26_0() __attribute__((availability(anyappleos, obsoleted = 26.0)));
+void unavailable() __attribute__((availability(anyappleos, unavailable)));
+
+//--- main.swift
+
+import AnyAppleOS
+
+func test() {
+  // expected-macosx-note@-1 {{add '@available' attribute to enclosing global function}}{{1-1=@available(macOS 26.2, *)\n}}
+  // expected-ios-note@-2 {{add '@available' attribute to enclosing global function}}{{1-1=@available(iOS 26.2, *)\n}}
+  introduced_in_26_2()
+  // expected-macosx-error@-1 {{'introduced_in_26_2()' is only available in macOS 26.2 or newer}}
+  // expected-macosx-note@-2 {{add 'if #available' version check}}{{3-23=if #available(macOS 26.2, *) {\n      introduced_in_26_2()\n  \} else {\n      // Fallback on earlier versions\n  \}}}
+  // expected-ios-error@-3 {{'introduced_in_26_2()' is only available in iOS 26.2 or newer}}
+  // expected-ios-note@-4 {{add 'if #available' version check}}{{3-23=if #available(iOS 26.2, *) {\n      introduced_in_26_2()\n  \} else {\n      // Fallback on earlier versions\n  \}}}
+
+  deprecated_in_26_0()
+  // expected-macosx-warning@-1 {{'deprecated_in_26_0()' was deprecated in any Apple OS 26.0}}
+  // expected-ios-warning@-2 {{'deprecated_in_26_0()' was deprecated in any Apple OS 26.0}}
+
+  obsoleted_in_26_0()
+  // expected-macosx-error@-1 {{'obsoleted_in_26_0()' is unavailable in macOS}}
+  // expected-ios-error@-2 {{'obsoleted_in_26_0()' is unavailable in iOS}}
+
+  unavailable()
+  // expected-macosx-error@-1 {{'unavailable()' is unavailable in macOS}}
+  // expected-ios-error@-2 {{'unavailable()' is unavailable in iOS}}
+}

--- a/test/ClangImporter/availability_print_module.swift
+++ b/test/ClangImporter/availability_print_module.swift
@@ -1,0 +1,49 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-ide-test -print-module -module-to-print Availability -I %t -source-filename=%t/main.swift > %t/Availability.txt
+// RUN: %FileCheck %s --check-prefix=CHECK < %t/Availability.txt
+
+// REQUIRES: OS=macosx
+
+//--- module.modulemap
+
+module Availability {
+  header "Availability.h"
+  export *
+}
+
+//--- Availability.h
+
+// CHECK:         @available(macOS 15.0, *)
+// CHECK-NEXT:    func IntroducedInEachAppleOS()
+void IntroducedInEachAppleOS()
+  __attribute__((availability(macosx,introduced=15.0)))
+  __attribute__((availability(ios,introduced=18.0)))
+  __attribute__((availability(watchos,introduced=11.0)))
+  __attribute__((availability(tvos,introduced=18.0)))
+  __attribute__((availability(visionos,introduced=2.0)));
+
+// CHECK:           @available(anyAppleOS 26.0, *)
+// CHECK-NEXT:      func IntroducedInAnyAppleOS()
+void IntroducedInAnyAppleOS()
+  __attribute__((availability(anyappleos,introduced=26.0)));
+
+// CHECK:           @available(macOS 15.0, *)
+// CHECK-NEXT:      func IntroducedInAnyAppleOSAndMacOS()
+void IntroducedInAnyAppleOSAndMacOS()
+  __attribute__((availability(macosx,introduced=15.0)))
+  __attribute__((availability(anyappleos,introduced=26.0)));
+
+// CHECK:           @available(anyAppleOS, introduced: 26.0, deprecated: 26.2, obsoleted: 26.4)
+// CHECK-NEXT:      func IntroducedDeprecatedAndObsoletedInAnyAppleOS()
+void IntroducedDeprecatedAndObsoletedInAnyAppleOS()
+  __attribute__((availability(anyappleos,introduced=26.0,deprecated=26.2,obsoleted=26.4)));
+
+// CHECK:           @available(anyAppleOS, unavailable)
+// CHECK-NEXT:      func UnavailableInAnyAppleOS()
+void UnavailableInAnyAppleOS()
+  __attribute__((availability(anyappleos,unavailable)));
+
+//--- main.swift
+
+import Availability


### PR DESCRIPTION
- **Explanation**: Now that Clang supports `anyAppleOS` availability, Swift should import `anyAppleOS` availability attributes attached to Clang declarations.
- **Scope**: Affects code that imports Clang modules with declarations that have `anyAppleOS` availability attributes. Clang just started supporting `anyAppleOS` in availability attributes, so there isn't any existing code that could break.
- **Issues**: rdar://173339280.
- **Risk**: Low since there isn't any existing code that could break.
- **Testing**: New compiler tests.
