### PR TITLE
Followup to #87483

### DIFF
--- a/stdlib/public/core/BorrowingSequence.swift
+++ b/stdlib/public/core/BorrowingSequence.swift
@@ -213,7 +213,7 @@ public struct BorrowingIteratorAdapter<Iterator: IteratorProtocol>: BorrowingIte
   @lifetime(&self)
   public mutating func nextSpan(maximumCount: Int) -> Span<Iterator.Element> {
     curValue = iterator.next()
-    return curValue._span
+    return curValue._span()
   }
 }
 

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -424,6 +424,22 @@ extension Optional where Wrapped: ~Copyable & ~Escapable {
       return x
     }
     _internalInvariantFailure("_uncheckedUnwrapped of nil optional")
+  }
+}
+
+@available(SwiftCompatibilitySpan 5.0, *)
+@_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
+extension Optional where Wrapped: ~Copyable & Escapable {
+  @_alwaysEmitIntoClient
+  @_addressableSelf
+  @lifetime(borrow self)
+  public func _span() -> Span<Wrapped> {
+    if self == nil {
+      return Span()
+    }
+    let a = Builtin.unprotectedAddressOfBorrow(self)
+    let s = unsafe Span<Wrapped>(_unsafeStart: .init(a), count: 1)
+    return unsafe _overrideLifetime(s, borrowing: self)
   }
 }
 
@@ -1016,22 +1032,3 @@ extension Optional: _ObjectiveCBridgeable {
   }
 }
 #endif
-
-extension Optional where Wrapped: ~Copyable {
-  @available(SwiftStdlib 6.3, *)
-  @_transparent
-  public var _span: Span<Wrapped> {
-    @_addressableSelf
-    @lifetime(borrow self)
-    get {
-      guard self != nil else {
-        return Span()
-      }
-
-      let ptr = Builtin.unprotectedAddressOfBorrow(self)
-      return unsafe _overrideLifetime(
-        Span(_unsafeStart: UnsafePointer(ptr), count: 1),
-        borrowing: self)
-    }
-  }
-}

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -1191,7 +1191,6 @@ Added: _$s17BorrowingIterators0A8SequencePTl
 Added: _$s7Elements17BorrowingSequencePTl
 Added: _$s7Elements25BorrowingIteratorProtocolPTl
 Added: _$sSTss17BorrowingSequenceRzrlE04makeA8Iterators0aD7AdapterVy0D0STQzGyF
-Added: _$sSqsRi_zrlE5_spans4SpanVyxGvg
 Added: _$ss11InlineArrayVyxq_Gs17BorrowingSequencesRi__rlMc
 Added: _$ss11MutableSpanVyxGs17BorrowingSequencesRi_zrlMc
 Added: _$ss14MutableRawSpanVs17BorrowingSequencesMc

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -1186,7 +1186,6 @@ Added: _$s17BorrowingIterators0A8SequencePTl
 Added: _$s7Elements17BorrowingSequencePTl
 Added: _$s7Elements25BorrowingIteratorProtocolPTl
 Added: _$sSTss17BorrowingSequenceRzrlE04makeA8Iterators0aD7AdapterVy0D0STQzGyF
-Added: _$sSqsRi_zrlE5_spans4SpanVyxGvg
 Added: _$ss11InlineArrayVyxq_Gs17BorrowingSequencesRi__rlMc
 Added: _$ss11MutableSpanVyxGs17BorrowingSequencesRi_zrlMc
 Added: _$ss14MutableRawSpanVs17BorrowingSequencesMc

--- a/test/stdlib/Optional.swift
+++ b/test/stdlib/Optional.swift
@@ -7,6 +7,7 @@ import Swift
 
 
 let OptionalTests = TestSuite("Optional")
+defer { runAllTests() }
 
 protocol TestProtocol1 {}
 
@@ -426,4 +427,29 @@ OptionalTests.test("unsafelyUnwrapped nil")
 }
 #endif
 
-runAllTests()
+OptionalTests.test("_span() from Optional.none")
+.require(.stdlib_6_2).code {
+  var o = Optional<[Int]>.none
+  let span = o._span()
+  // o = [1, 2, 3] // Does not compile, exclusivity violation
+  expectEqual(span.count, 0)
+
+  // make it fail at test time if exclusivity was violated
+  expectNil(o, "fail due to exclusivity violation")
+}
+
+OptionalTests.test("_span() from Optional.some")
+.require(.stdlib_6_2).code {
+  let a: [Int] = [1, 2, 3]
+  var o: Optional = a
+  let span = o._span()
+  // o = nil // Does not compile, exclusivity violation
+  expectEqual(span.count, 1)
+  expectEqual(span[0], o, "accessed mysterious memory location")
+
+  expectNotNil(o, "fail due to exclusivity violation")
+
+  let b = [4, 5, 6]
+  // o = b // Does not compile, exclusivity violation
+  expectNotEqual(span[0], b, "accessed mysterious memory location")
+}


### PR DESCRIPTION
https://github.com/swiftlang/swift/pull/87483 adds `BorrowingSequence`-related improvements.
One of the additions is a `_span` property to `Optional`, which does not work correctly.

This replaces the property with a function `_span()`, with test coverage.
It also makes the new function `@export(implementation)` (non-ABI)