### PR TITLE
[6.3][test][android] Fix one IRGen test on Android CI, from #88056

### DIFF
--- a/test/IRGen/availability_android.swift
+++ b/test/IRGen/availability_android.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -target aarch64-unknown-linux-android24 -primary-file %s -emit-ir | %FileCheck %s --check-prefix=CHECK-24
-// RUN: %target-swift-frontend -target aarch64-unknown-linux-android28 -primary-file %s -emit-ir | %FileCheck %s --check-prefix=CHECK-28
+// RUN: %target-swift-frontend -target %target-triple24 -primary-file %s -emit-ir | %FileCheck %s --check-prefix=CHECK-24
+// RUN: %target-swift-frontend -target %target-triple28 -primary-file %s -emit-ir | %FileCheck %s --check-prefix=CHECK-28
 
 // CHECK-24-LABEL: define{{.*}}$s20availability_android0A5CheckyyF
 // CHECK-24: call swiftcc i1 @"$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF"(
@@ -7,7 +7,7 @@
 // CHECK-28-LABEL: define{{.*}}$s20availability_android0A5CheckyyF
 // CHECK-28-NOT: call swiftcc i1 @"$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF"(
 
-// REQUIRES: OS=linux-android || OS=linux-androideabi
+// REQUIRES: OS=linux-android
 
 public func availabilityCheck() {
   if #available(Android 28, *) {


### PR DESCRIPTION
A recent change in the Android CI build script, swiftlang/swift-docker#528, exposed that this test was only passing for other Android non-AArch64 architectures because AArch64 was built first and that SDK build wasn't removed.

Since we made that change to remove previous SDK builds for 6.3 also, this test will likely start failing on [the 6.3 Android CI](https://ci.swift.org/job/oss-swift-6.3-package-swift-sdk-for-android/) soon, so bring the fix over to 6.3.

[The 6.3 CI appear to be temporarily stopped](https://ci.swift.org/job/oss-swift-6.3-package-trigger/), so keeping this ready as a draft for when they start up again. I was told by Doug that the usual release branch form is not needed for test-only pulls like this, since this does not affect the build in any way.

