### PR TITLE
ObjectOutliner: don't outline objects in external functions because this would "duplicate" singletons

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ObjectOutliner.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ObjectOutliner.swift
@@ -60,6 +60,11 @@ let objectOutliner = FunctionPass(name: "object-outliner") {
     return
   }
 
+  if function.linkage.isExternal {
+    // Don't outline objects in external functions because this would "duplicate" singletons.
+    return
+  }
+
   var allocRefs = Stack<AllocRefInstBase>(context)
   defer { allocRefs.deinitialize() }
 

--- a/test/SILOptimizer/object-outliner-and-cmo.swift
+++ b/test/SILOptimizer/object-outliner-and-cmo.swift
@@ -1,0 +1,53 @@
+// RUN: %empty-directory(%t) 
+// RUN: split-file %s %t
+
+// RUN: %target-build-swift -O -wmo -parse-as-library -cross-module-optimization -emit-module -emit-module-path=%t/Singleton.swiftmodule -module-name=Singleton %t/singleton.swift -c -o %t/singleton.o
+// RUN: %target-build-swift -O -wmo -parse-as-library -cross-module-optimization -I %t -emit-module -emit-module-path=%t/Shared.swiftmodule -module-name=Shared %t/shared.swift -c -o %t/shared.o
+// RUN: %target-build-swift -O -wmo -module-name=Main -I %t %t/main.swift -c -o %t/main.o
+// RUN: %target-swiftc_driver %t/main.o %t/shared.o %t/singleton.o -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+
+// Don't outline static let objects in external functions.
+// This would duplicate singleton objects.
+
+//--- singleton.swift
+
+public final class Singleton: Sendable {
+  public static let shared = Singleton()
+
+  nonisolated(unsafe) private var i: Int = 0
+
+  @inline(__always)
+  private init() {}
+
+  public func foo() -> Int {
+    i += 1
+    return i
+  }
+}
+
+//--- shared.swift
+
+import Singleton
+
+@inline(never)
+public func notInlined() -> Int {
+  Singleton.shared.foo()
+}
+
+public func inlined() -> Int {
+  Singleton.shared.foo()
+}
+
+//--- main.swift
+
+import Shared
+
+// CHECK:      1
+print(Shared.inlined())
+// CHECK-NEXT: 2
+print(Shared.notInlined())
+

--- a/test/SILOptimizer/objectoutliner.sil
+++ b/test/SILOptimizer/objectoutliner.sil
@@ -22,6 +22,7 @@ sil_global [let] @g1 : $Int32 = {
 }
 
 sil_global [let] @gobj : $Obj
+sil_global [let] @gobj2 : $Obj
 sil_global @gobj_var : $Obj
 
 // CHECK-LABEL: sil_global private [let] @outline_global_simpleTv_ : $Obj = {
@@ -508,6 +509,24 @@ sil [global_init_once_fn] @init_gobj : $@convention(c) (Builtin.RawPointer) -> (
 bb0(%0 : $Builtin.RawPointer):
   alloc_global @gobj
   %2 = global_addr @gobj : $*Obj
+  %3 = integer_literal $Builtin.Int64, 27
+  %4 = struct $Int64 (%3 : $Builtin.Int64)
+  %5 = alloc_ref $Obj
+  %8 = end_init_let_ref %5 : $Obj
+  %9 = ref_element_addr %8 : $Obj, #Obj.value
+  store %4 to %9 : $*Int64
+  store %8 to %2 : $*Obj
+  %12 = tuple ()
+  return %12 : $()
+}
+
+// CHECK-LABEL: sil public_external [global_init_once_fn] @dont_outline_in_external_func :
+// CHECK-NOT:     global_value
+// CHECK:       } // end sil function 'dont_outline_in_external_func'
+sil public_external [global_init_once_fn] @dont_outline_in_external_func : $@convention(c) (Builtin.RawPointer) -> () {
+bb0(%0 : $Builtin.RawPointer):
+  alloc_global @gobj2
+  %2 = global_addr @gobj2 : $*Obj
   %3 = integer_literal $Builtin.Int64, 27
   %4 = struct $Int64 (%3 : $Builtin.Int64)
   %5 = alloc_ref $Obj


### PR DESCRIPTION
Fixes a miscompile
rdar://172766879
