### PR TITLE
[Diagnostics] Coalesce large homogeneous tuples in diagnostics

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -651,6 +651,10 @@ public:
   /// compilers that might parse the result.
   bool PrintCompatibilityFeatureChecks = false;
 
+  /// Whether to print homogeneous unlabeled tuples in compact form
+  /// (e.g. `(3 of Int)` instead of `(Int, Int, Int)`).
+  bool PrintHomogeneousTuplesCompactly = false;
+
   /// Whether to always desugar array types from `[base_type]` to `Array<base_type>`
   bool AlwaysDesugarArraySliceTypes = false;
 
@@ -720,6 +724,7 @@ public:
   static PrintOptions forDiagnosticArguments() {
     PrintOptions result;
     result.PrintExplicitPackTypes = false;
+    result.PrintHomogeneousTuplesCompactly = true;
     return result;
   }
 
@@ -749,6 +754,7 @@ public:
     result.ShouldQualifyNestedDeclarations =
         QualifyNestedDeclarations::TypesOnly;
     result.PrintDocumentationComments = false;
+    result.PrintHomogeneousTuplesCompactly = true;
     result.PrintCurrentMembersOnly = true;
     if (printFullConvention)
       result.PrintFunctionRepresentationAttrs =

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -652,7 +652,8 @@ public:
   bool PrintCompatibilityFeatureChecks = false;
 
   /// Whether to print homogeneous unlabeled tuples in compact form
-  /// (e.g. `(3 of Int)` instead of `(Int, Int, Int)`).
+  /// (e.g. `(Int /* ... repeated 5 times ... */)` instead of 
+  /// `(Int, Int, Int, Int, Int)`).
   bool PrintHomogeneousTuplesCompactly = false;
 
   /// Whether to always desugar array types from `[base_type]` to `Array<base_type>`

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -6862,9 +6862,8 @@ public:
       });
 
       if (IsHomogeneous) {
-        Printer << Fields.size() << " of ";
         visit(FirstEltType);
-        Printer << ")";
+        Printer << " /* ... repeated " << Fields.size() << " times ... */)";
         return;
       }
     }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -6852,6 +6852,23 @@ public:
     Printer << "(";
 
     auto Fields = T->getElements();
+
+    // Compact printing for homogeneous unlabeled tuples with 5+ elements.
+    if (Options.PrintHomogeneousTuplesCompactly && Fields.size() > 4) {
+      Type FirstEltType = Fields[0].getType();
+      bool IsHomogeneous = llvm::all_of(Fields, [&](const TupleTypeElt &elt) {
+        return !elt.hasName() && 
+               elt.getType().getPointer() == FirstEltType.getPointer();
+      });
+
+      if (IsHomogeneous) {
+        Printer << Fields.size() << " of ";
+        visit(FirstEltType);
+        Printer << ")";
+        return;
+      }
+    }
+
     for (unsigned i = 0, e = Fields.size(); i != e; ++i) {
       if (i)
         Printer << ", ";

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -6858,7 +6858,7 @@ public:
       Type FirstEltType = Fields[0].getType();
       bool IsHomogeneous = llvm::all_of(Fields, [&](const TupleTypeElt &elt) {
         return !elt.hasName() && 
-               elt.getType().getPointer() == FirstEltType.getPointer();
+               elt.getType()->isEqual(FirstEltType);
       });
 
       if (IsHomogeneous) {

--- a/test/Sema/homogeneous_tuple_diagnostic.swift
+++ b/test/Sema/homogeneous_tuple_diagnostic.swift
@@ -1,0 +1,17 @@
+// RUN: %target-typecheck-verify-swift
+
+// Homogeneous tuples with 5+ elements should print in compact form.
+func largeTuple(_: (Int, Int, Int, Int, Int)) {}
+largeTuple("hello") // expected-error {{cannot convert value of type 'String' to expected argument type '(5 of Int)'}}
+
+// Homogeneous tuples with 4 or fewer elements should print normally.
+func smallTuple(_: (Int, Int, Int, Int)) {}
+smallTuple("hello") // expected-error {{cannot convert value of type 'String' to expected argument type '(Int, Int, Int, Int)'}}
+
+// Labeled tuples should not be coalesced.
+func labeledTuple(_: (a: Int, b: Int, c: Int, d: Int, e: Int)) {}
+labeledTuple("hello") // expected-error {{cannot convert value of type 'String' to expected argument type '(a: Int, b: Int, c: Int, d: Int, e: Int)'}}
+
+// Heterogeneous tuples should not be coalesced.
+func heterogeneousTuple(_: (Int, Int, Int, Int, Bool)) {}
+heterogeneousTuple("hello") // expected-error {{cannot convert value of type 'String' to expected argument type '(Int, Int, Int, Int, Bool)'}}

--- a/test/Sema/homogeneous_tuple_diagnostic.swift
+++ b/test/Sema/homogeneous_tuple_diagnostic.swift
@@ -2,7 +2,7 @@
 
 // Homogeneous tuples with 5+ elements should print in compact form.
 func largeTuple(_: (Int, Int, Int, Int, Int)) {}
-largeTuple("hello") // expected-error {{cannot convert value of type 'String' to expected argument type '(5 of Int)'}}
+largeTuple("hello") // expected-error {{cannot convert value of type 'String' to expected argument type '(Int /* ... repeated 5 times ... */)'}}
 
 // Homogeneous tuples with 4 or fewer elements should print normally.
 func smallTuple(_: (Int, Int, Int, Int)) {}


### PR DESCRIPTION
Homogeneous unlabeled tuples with many elements produce unwieldy type names in diagnostics. This is especially common when writing Swift/C interop code. This PR prints them in a compact `(N of T)` format, mirroring the style used in `TypePrinter.visitInlineArrayType()` and [SE-0483](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0483-inline-array-sugar.md) (`InlineArray` Type Sugar).

Current:

```swift
func process(
    _ buffer: (Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32)
) { }

process("oops")
// Cannot convert value of type 'String' to expected argument type 
// '(Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32)'
```

Proposed:

```swift
func process(
    _ buffer: (Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32)
) { }

process("oops")
// Cannot convert value of type 'String' to expected argument type '(8 of Int32)'
```

## Design

This PR adds `PrintOptions.PrintHomogeneousTuplesCompactly`, enables it only in diagnostic print paths (`forDiagnosticArguments()` and `printForDiagnostics()`), and coalesces homogeneous tuples with 5+ elements to a more compact form in `TypePrinter.visitTupleType()`.

The threshold for compacting is 5 elements, since tuples of 4 or fewer elements are short enough to read in the expanded form. Type equality uses `getPointer()` for pointer comparison to avoid coalescing differently-sugared types (e.g. a tuple that mixes `Int` with a typealias for `Int` shouldn't be coalesced).

## Testing

This PR adds a new test file at `Sema/homogeneous_tuple_diagnostic.swift` to verify that homogeneous unlabeled tuples with 5+ elements are coalesced (and 4 or fewer are not), and that labeled or heterogeneous tuples are not coalesced.

No existing tests required updates.

## Release Nomination

- **Explanation**:
  Adds compact diagnostic printing for large homogeneous unlabeled 
  tuples (5+ elements), e.g. `(Int32 /* ... repeated 8 times ... */)` 
  instead of expanding all elements. Controlled by a new `PrintOptions` 
  flag enabled only in diagnostic print paths.

- **Scope**:
  Diagnostic output only. No changes to type checking, code generation, 
  or ABI. Cannot break existing code. Only affects how tuple types are 
  displayed in error messages.

- **Issues**:
  None.

- **Original PRs**:
  None.

- **Risk**:
  Very low. The change is guarded behind a new `PrintOptions` flag that 
  is only set in `forDiagnosticArguments()` and `printForDiagnostics()`.
  No existing tests required updates.

- **Testing**:
  New test file at `test/Sema/homogeneous_tuple_diagnostic.swift` 
  covering compact printing for 5+ element homogeneous tuples, 
  non-coalescing for small/labeled/heterogeneous tuples. Full test 
  suite run locally with zero new failures.

- **Reviewers**:
  @xedin approved April 8, 2026