### PR TITLE
[Concurrency] Fix missing trailing space in 'final' fix-it for non-final Sendable class

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -7448,10 +7448,10 @@ bool swift::checkSendableConformance(
   if (classDecl && classDecl->getParentSourceFile()) {
     bool isInherited = isa<InheritedProtocolConformance>(conformance);
 
-    // An non-final class cannot conform to `Sendable`.
+    // A non-final class cannot conform to `Sendable`.
     if (!classDecl->isSemanticallyFinal()) {
       classDecl->diagnose(diag::concurrent_value_nonfinal_class,classDecl->getName())
-          .fixItInsert(classDecl->getStartLoc(), "final")
+          .fixItInsert(classDecl->getStartLoc(), "final ")
           .limitBehaviorUntilLanguageMode(behavior, LanguageMode::v6);
 
       if (behavior == DiagnosticBehavior::Unspecified)

--- a/test/Concurrency/sendable_conformance_checking.swift
+++ b/test/Concurrency/sendable_conformance_checking.swift
@@ -156,7 +156,7 @@ actor A10: AsyncThrowingProtocolWithNotSendable {
 }
 
 // rdar://86653457 - Crash due to missing Sendable conformances.
-// expected-warning @+1 {{non-final class 'Klass' cannot conform to the 'Sendable' protocol; this is an error in the Swift 6 language mode}}
+// expected-warning @+1 {{non-final class 'Klass' cannot conform to the 'Sendable' protocol; this is an error in the Swift 6 language mode}} {{1-1=final }}
 class Klass<Output: Sendable>: Sendable {}
 // expected-complete-warning @+1 {{type 'S' does not conform to the 'Sendable' protocol}}
 final class SubKlass: Klass<[S]> {}
@@ -182,7 +182,7 @@ extension MultiConformance: @unchecked Sendable {} // expected-warning {{redunda
 
 @available(SwiftStdlib 5.1, *)
 actor MyActor {
-  // expected-warning@+1 {{non-final class 'Nested' cannot conform to the 'Sendable' protocol; this is an error in the Swift 6 language mode}}
+  // expected-warning@+1 {{non-final class 'Nested' cannot conform to the 'Sendable' protocol; this is an error in the Swift 6 language mode}} {{3-3=final }}
   class Nested: Sendable {}
 }
 


### PR DESCRIPTION
The `fixItInsert` for adding `final` to a non-final class conforming to `Sendable` (introduced in #83053) was missing a trailing space, causing the applied fix-it to produce `finalclass Foo` instead of `final class Foo`.

**Before (broken):**
```swift
class MyClass: Sendable {} // warning: non-final class 'MyClass' cannot conform to 'Sendable'
// Applying the fix-it produces:
finalclass MyClass: Sendable {} // compilation error
```

**After (fixed):**
```swift
class MyClass: Sendable {} // warning: non-final class 'MyClass' cannot conform to 'Sendable'
// Applying the fix-it produces:
final class MyClass: Sendable {} // correct
```

**Changes:**
- `lib/Sema/TypeCheckConcurrency.cpp`: Change `fixItInsert(classDecl->getStartLoc(), "final")` to `"final "` (add trailing space). Also fix the comment grammar: "An non-final" → "A non-final".
- `test/Concurrency/sendable_conformance_checking.swift`: Add fix-it content verification (`{{1-1=final }}` and `{{3-3=final }}`) to the two existing `concurrent_value_nonfinal_class` test cases that previously only checked the diagnostic message.
