### PR TITLE
PrintAsClang: Print `anyappleos` in compatibility headers

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -1838,18 +1838,6 @@ public:
       }
 
       auto platKind = AvAttr.getPlatform();
-      if (platKind == PlatformKind::anyAppleOS) {
-        auto domainAndRange =
-            AvAttr.getIntroducedDomainAndRange(D->getASTContext());
-        if (!domainAndRange)
-          continue;
-
-        platKind = domainAndRange->getDomain().getPlatformKind();
-
-        // Skip the attribute if it cannot be remapped.
-        if (platKind == PlatformKind::anyAppleOS)
-          continue;
-      }
       const char *plat;
       switch (platKind) {
       case PlatformKind::macOS:
@@ -1896,7 +1884,7 @@ public:
         llvm::report_fatal_error("unsupported platform kind");
         break;
       case PlatformKind::anyAppleOS:
-        llvm_unreachable("must have been resolved before");
+        plat = "anyappleos";
         break;
       case PlatformKind::FreeBSD:
         plat = "freebsd";

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -1893,7 +1893,7 @@ public:
         break;
       case PlatformKind::Swift:
         // FIXME: [runtime availability] Figure out how to support this.
-        ASSERT(0);
+        llvm::report_fatal_error("unsupported platform kind");
         break;
       case PlatformKind::anyAppleOS:
         llvm_unreachable("must have been resolved before");

--- a/test/Interop/SwiftToCxx/core/availability-any-apple-os.swift
+++ b/test/Interop/SwiftToCxx/core/availability-any-apple-os.swift
@@ -1,10 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -module-name Core -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/core.h
-// RUN: %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-os < %t/core.h
+// RUN: %FileCheck %s < %t/core.h
 
 // CHECK: SWIFT_INLINE_THUNK void anyAppleOS26Func() noexcept SWIFT_SYMBOL("s:4Core16anyAppleOS26FuncyyF")
-// CHECK-macosx-SAME: SWIFT_AVAILABILITY(macos,introduced=26)
-// CHECK-linux-gnu-NOT: SWIFT_AVAILABILITY
+// CHECK-SAME: SWIFT_AVAILABILITY(anyappleos,introduced=26)
 @available(anyAppleOS 26, *)
 public func anyAppleOS26Func() { }
 

--- a/test/PrintAsObjC/availability_any_apple_os_objc.swift
+++ b/test/PrintAsObjC/availability_any_apple_os_objc.swift
@@ -7,19 +7,19 @@
 import Foundation
 
 // CHECK-LABEL: SWIFT_CLASS("{{.*}}AvailableOnAnyAppleOS26{{.*}}")
-// CHECK-SAME: SWIFT_AVAILABILITY(macos,introduced=26)
+// CHECK-SAME: SWIFT_AVAILABILITY(anyappleos,introduced=26)
 // CHECK: @end
 
 // CHECK-LABEL: SWIFT_CLASS("{{.*}}PropertyClass{{.*}}")
 // CHECK: @property{{.*}}propertyWithAvailability
-// CHECK-SAME: SWIFT_AVAILABILITY(macos,introduced=26)
+// CHECK-SAME: SWIFT_AVAILABILITY(anyappleos,introduced=26)
 // CHECK: @end
 
 // CHECK-LABEL: SWIFT_CLASS("{{.*}}SomeClass{{.*}}")
 // CHECK: - (void)methodWithAnyAppleOSAvailability
-// CHECK-SAME: SWIFT_AVAILABILITY(macos,introduced=26)
+// CHECK-SAME: SWIFT_AVAILABILITY(anyappleos,introduced=26)
 // CHECK: - (void)methodWithMinorVersion
-// CHECK-SAME: SWIFT_AVAILABILITY(macos,introduced=26.5)
+// CHECK-SAME: SWIFT_AVAILABILITY(anyappleos,introduced=26.5)
 // CHECK: @end
 
 @objc


### PR DESCRIPTION
Clang now supports `anyAppleOS` availability so we can stop remapping it to the target OS for generated compatibility headers.

Resolves rdar://173339752.