### PR TITLE
stdlib: Remove a spurious `unsafe`

### DIFF
--- a/stdlib/public/core/StringStorage.swift
+++ b/stdlib/public/core/StringStorage.swift
@@ -529,7 +529,7 @@ extension __StringStorage {
     @inline(__always) get {
       _internalInvariant(hasBreadcrumbs)
       return Int(Builtin.atomicload_acquire_Word(
-        unsafe UnsafeMutableRawPointer(_realCapacityEnd)._rawValue))
+        UnsafeMutableRawPointer(_realCapacityEnd)._rawValue))
     }
   }
   


### PR DESCRIPTION
Resolves this warning:

```
warning: no unsafe operations occur within 'unsafe' expression
```
