### PR TITLE
Consistently classify "-" as a Swift input file

### DIFF
--- a/include/swift/Frontend/InputFile.h
+++ b/include/swift/Frontend/InputFile.h
@@ -57,8 +57,7 @@ public:
   InputFile(StringRef name, bool isPrimary,
             llvm::MemoryBuffer *buffer = nullptr)
       : InputFile(name, isPrimary, buffer,
-                  file_types::lookupTypeForExtension(
-                      llvm::sys::path::extension(name))) {}
+                  file_types::lookupTypeFromFilename(name)) {}
 
   /// Constructs an input file from the provided data.
   InputFile(StringRef name, bool isPrimary, llvm::MemoryBuffer *buffer,

--- a/lib/Basic/FileTypes.cpp
+++ b/lib/Basic/FileTypes.cpp
@@ -60,6 +60,10 @@ ID file_types::lookupTypeForExtension(StringRef Ext) {
 // Compute the file type from filename. This handles the lookup for extensions
 // with multiple dots, like `.private.swiftinterface` correctly.
 ID file_types::lookupTypeFromFilename(StringRef Filename) {
+  // stdin is treated as a Swift input
+  if (Filename == "-")
+    return TY_Swift;
+
   StringRef MaybeExt = Filename;
   // Search from leftmost `.`, return the first match or till all dots are
   // consumed.

--- a/test/Frontend/parse_stdin.swift
+++ b/test/Frontend/parse_stdin.swift
@@ -1,0 +1,1 @@
+// RUN: echo "" | %target-swift-frontend -parse -


### PR DESCRIPTION
Fixes rdar://171657301, a crash with `swiftc -parse -`