### PR TITLE
[cxx-interop] Honor default arguments of constructors

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2803,7 +2803,6 @@ static ParamDecl *getParameterInfo(ClangImporter::Implementation *impl,
   // (https://github.com/apple/swift/issues/70124)
   // TODO: support params with template parameters
   if (param->hasDefaultArg() && !isInOut &&
-      !isa<clang::CXXConstructorDecl>(param->getDeclContext()) &&
       impl->isDefaultArgSafeToImport(param) &&
       !param->isTemplated()) {
     SwiftDeclSynthesizer synthesizer(*impl);

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -2768,10 +2768,6 @@ SwiftDeclSynthesizer::makeDefaultArgument(const clang::ParmVarDecl *param,
   ASTContext &ctx = ImporterImpl.SwiftContext;
   auto clangFunc =
       cast<clang::FunctionDecl>(param->getParentFunctionOrMethod());
-  if (isa<clang::CXXConstructorDecl>(clangFunc))
-    // TODO: support default arguments of constructors
-    // (https://github.com/apple/swift/issues/70124)
-    return nullptr;
 
   std::string s;
   llvm::raw_string_ostream os(s);

--- a/test/Interop/Cxx/function/Inputs/default-arguments.h
+++ b/test/Interop/Cxx/function/Inputs/default-arguments.h
@@ -102,8 +102,6 @@ public:
   static bool isArgZeroRef(ArgTy &a = customTy) { return a.value == 0; }
 };
 
-// TODO: support default arguments of constructors
-// (https://github.com/apple/swift/issues/70124)
 struct HasCtorWithDefaultArg {
   int value;
 

--- a/test/Interop/Cxx/function/default-arguments-module-interface.swift
+++ b/test/Interop/Cxx/function/default-arguments-module-interface.swift
@@ -48,8 +48,7 @@
 // CHECK: }
 
 // CHECK: struct HasCtorWithDefaultArg {
-// TODO: support default arguments of constructors (https://github.com/apple/swift/issues/70124)
-// TODO:   init(_ a: Int32, _ b: Int32 = cxxDefaultArg, _ c: Int32 = cxxDefaultArg)
+// CHECK:   init(_ a: Int32, _ b: Int32 = cxxDefaultArg, _ c: Int32 = cxxDefaultArg)
 // CHECK: }
 
 // CHECK: struct TemplatedHasMethodWithDefaultArg<CFloat> {

--- a/test/Interop/Cxx/function/default-arguments-typechecker.swift
+++ b/test/Interop/Cxx/function/default-arguments-typechecker.swift
@@ -53,9 +53,8 @@ let _ = HasStaticMethodWithDefaultArg.isNonZeroPrivateCounter(1)
 let _ = HasStaticMethodWithDefaultArg.isArgZeroRef() // expected-error {{missing argument for parameter #1 in call}}
 
 let _ = HasCtorWithDefaultArg(1, 2, 3)
-// TODO: support default arguments of constructors (https://github.com/apple/swift/issues/70124)
-//let _ = HasCtorWithDefaultArg(1, 2)
-//let _ = HasCtorWithDefaultArg(1)
+let _ = HasCtorWithDefaultArg(1, 2)
+let _ = HasCtorWithDefaultArg(1)
 
 let _ = TemplatedHasMethodWithDefaultArgFloat().isZero()
 let _ = TemplatedHasMethodWithDefaultArgFloat().isNonZero()

--- a/test/Interop/Cxx/function/default-arguments.swift
+++ b/test/Interop/Cxx/function/default-arguments.swift
@@ -83,17 +83,15 @@ DefaultArgTestSuite.test("method with integer parameter") {
   expectTrue(z1)
 }
 
-// TODO: support default args of constructors
-// (https://github.com/apple/swift/issues/70124)
 DefaultArgTestSuite.test("constructor with integer parameter") {
   let a = HasCtorWithDefaultArg(1, 2, 3)
   expectEqual(a.value, 6)
 
-//  let b = HasCtorWithDefaultArg(1, 2)
-//  expectEqual(b.value, 126)
+  let b = HasCtorWithDefaultArg(1, 2)
+  expectEqual(b.value, 126)
 
-//  let c = HasCtorWithDefaultArg(1)
-//  expectEqual(c.value, 580)
+  let c = HasCtorWithDefaultArg(1)
+  expectEqual(c.value, 580)
 }
 
 DefaultArgTestSuite.test("method in a templated class") {


### PR DESCRIPTION
Previously Swift imported default argument expressions in C++ methods and global functions, but not constructors.

rdar://118987713 / resolves https://github.com/apple/swift/issues/70124

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
