### PR TITLE
[CSOptimizer] Score candidate matches that require easure lower for o…

### DIFF
--- a/lib/Sema/CSOptimizer.cpp
+++ b/lib/Sema/CSOptimizer.cpp
@@ -1032,8 +1032,11 @@ scoreCandidateMatch(ConstraintSystem &cs,
 
   // Conversion from a concrete type to its existential value.
   if (paramType->isExistentialType()) {
-    if (isSubtypeOfExistentialType(candidateType, paramType))
-      return 100;
+    if (isSubtypeOfExistentialType(candidateType, paramType)) {
+      // Operators always prefer exact and subtype matches. Erasure should
+      // shouldn't be scored higher than a match on a generic parameter.
+      return choice->isOperator() ? 90 : 100;
+    }
   }
 
   // Candidate could be converted to a superclass.
@@ -1066,8 +1069,11 @@ scoreCandidateMatch(ConstraintSystem &cs,
       // metatypes.
       if (candidateType->is<ExistentialMetatypeType>() ||
           !instanceType->isExistentialType()) {
-        if (isSubtypeOfExistentialType(instanceType, EMT->getInstanceType()))
-          return 100;
+        if (isSubtypeOfExistentialType(instanceType, EMT->getInstanceType())) {
+          // See other use of \c isSubtypeOfExistentialType as to why the score
+          // is lower.
+          return choice->isOperator() ? 90 : 100;
+        }
       }
     }
   }

--- a/test/Constraints/operator_generics_vs_erasure.swift
+++ b/test/Constraints/operator_generics_vs_erasure.swift
@@ -1,0 +1,33 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+func identity<T>(_ t: T) -> T { return t }
+
+extension Error where Self: Equatable {
+  // CHECK-LABEL: sil hidden [ossa] @$ss5ErrorP28operator_generics_vs_erasureSQRzrlE6equalsySbsAA_pF
+  // CHECK: // function_ref static Error.== infix(_:_:)
+  // CHECK: {{.*}} = function_ref @$ss5ErrorP28operator_generics_vs_erasureE2eeoiySbx_sAA_ptFZ
+  // CHECK: } // end sil function '$ss5ErrorP28operator_generics_vs_erasureSQRzrlE6equalsySbsAA_pF'
+  func equals(_ other: any Error) -> Bool {
+    other == self
+  }
+
+  // CHECK-LABEL: sil private [ossa] @$ss5ErrorP28operator_generics_vs_erasureSQRzrlE14equalsWithCastySbsAA_pFSbxXEfU_
+  // CHECK: {{.*}} = witness_method $Self, #Equatable."==" : <Self where Self : Equatable, Self : ~Copyable, Self : ~Escapable> (Self.Type) -> (borrowing Self, borrowing Self) -> Bool
+  // CHECK: } // end sil function '$ss5ErrorP28operator_generics_vs_erasureSQRzrlE14equalsWithCastySbsAA_pFSbxXEfU_'
+  func equalsWithCast(_ other: any Error) -> Bool {
+    (other as? Self).map { $0 == self } ?? false
+  }
+
+  // CHECK-LABEL: sil private [ossa] @$ss5ErrorP28operator_generics_vs_erasureSQRzrlE18equalsWithIdentityySbsAA_pFSbxXEfU_
+  // CHECK: {{.*}} = witness_method $Self, #Equatable."==" : <Self where Self : Equatable, Self : ~Copyable, Self : ~Escapable> (Self.Type) -> (borrowing Self, borrowing Self) -> Bool
+  // CHECK: } // end sil function '$ss5ErrorP28operator_generics_vs_erasureSQRzrlE18equalsWithIdentityySbsAA_pFSbxXEfU_'
+  func equalsWithIdentity(_ other: any Error) -> Bool {
+    (other as? Self).map { $0 == identity(self) } ?? false
+  }
+}
+
+extension Error {
+  static func == (lhs: Self, rhs: any Error) -> Bool {
+    false
+  }
+}


### PR DESCRIPTION
…perators

This change restores pre-6.3 operator overload selection behavior.

The same is done for cases when candidate matches all of the requirements placed on the generic parameter and optional injections because operators historically favored exact/subtype matches in concrete overloads above all else.

Resolves: https://github.com/swiftlang/swift/issues/88193
Resolves: rdar://173728495

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
