### PR TITLE
[Sema] Narrow Swift availability fix-its

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -744,8 +744,7 @@ static bool fixAvailabilityByNarrowingNearbyVersionCheck(
     SourceRange ReferenceRange, const DeclContext *ReferenceDC,
     AvailabilityDomain Domain, const AvailabilityRange &RequiredAvailability,
     ASTContext &Context, InFlightDiagnostic &Err) {
-  // FIXME: [availability] Support fixing availability for non-platform domains
-  if (!Domain.isPlatform())
+  if (!Domain.isVersioned())
     return false;
 
   const AvailabilityScope *scope = nullptr;
@@ -768,17 +767,20 @@ static bool fixAvailabilityByNarrowingNearbyVersionCheck(
     auto Platform = targetPlatform(Context.LangOpts);
     if (RunningVers.getMajor() != RequiredVers.getMajor())
       return false;
-    if ((Platform == PlatformKind::macOS ||
+    if (Domain.isPlatform() &&
+        (Platform == PlatformKind::macOS ||
          Platform == PlatformKind::macOSApplicationExtension) &&
         RunningVers.getMajor() == 10 &&
         !(RunningVers.getMinor().has_value() &&
           RequiredVers.getMinor().has_value() &&
           RunningVers.getMinor().value() ==
-          RequiredVers.getMinor().value()))
+              RequiredVers.getMinor().value()))
       return false;
 
     auto FixRange = scope->getAvailabilityConditionVersionSourceRange(
-        AvailabilityDomain::forPlatform(Platform), RunningVers);
+        Domain.isPlatform() ? AvailabilityDomain::forPlatform(Platform)
+                            : Domain,
+        RunningVers);
     if (!FixRange.isValid())
       return false;
     // Have found a nontrivial availability scope-introducer to narrow.

--- a/test/attr/attr_availability_swift_language_mode.swift
+++ b/test/attr/attr_availability_swift_language_mode.swift
@@ -58,15 +58,15 @@ func testMemberAvailability() {
   TestStruct().doAnotherThing() // expected-error {{'doAnotherThing()' is unavailable}}
 }
 
-@available(swift 5.1)
+@available(swift 50.1)
 extension TestStruct {
-  func doTheSlightlyNewerThing() {} // expected-note {{'doTheSlightlyNewerThing()' was introduced in Swift 5.1}}
+  func doTheSlightlyNewerThing() {} // expected-note {{'doTheSlightlyNewerThing()' was introduced in Swift 50.1}}
 }
 
-@available(swift 5.0)
+@available(swift 50.0)
 extension TestStruct {
   func useDoTheSlightlyNewerThing() {
-    doTheSlightlyNewerThing() // expected-error {{'doTheSlightlyNewerThing()' is unavailable}} {{-3:18-21=5.1}}
+    doTheSlightlyNewerThing() // expected-error {{'doTheSlightlyNewerThing()' is unavailable}} {{-3:18-22=50.1}}
   }
 }
 

--- a/test/attr/attr_availability_swift_language_mode.swift
+++ b/test/attr/attr_availability_swift_language_mode.swift
@@ -58,6 +58,18 @@ func testMemberAvailability() {
   TestStruct().doAnotherThing() // expected-error {{'doAnotherThing()' is unavailable}}
 }
 
+@available(swift 5.1)
+extension TestStruct {
+  func doTheSlightlyNewerThing() {} // expected-note {{'doTheSlightlyNewerThing()' was introduced in Swift 5.1}}
+}
+
+@available(swift 5.0)
+extension TestStruct {
+  func useDoTheSlightlyNewerThing() {
+    doTheSlightlyNewerThing() // expected-error {{'doTheSlightlyNewerThing()' is unavailable}} {{-3:18-21=5.1}}
+  }
+}
+
 @available(swift 400)
 @available(macOS 10.11, *)
 extension TestStruct {}


### PR DESCRIPTION
This teaches availability narrowing fix-its to work for Swift language availability in addition to platform availability.

`fixAvailabilityByNarrowingNearbyVersionCheck` currently bails out for non-platform domains, even though the surrounding source-range lookup is already generic for versioned domains. This change switches that path to allow any versioned availability domain, while keeping the existing macOS 10.x special case limited to platform availability.

The test adds a Swift-language availability case where an enclosing `@available(swift 5.0)` declaration references a member introduced in Swift 5.1, and verifies that the fix-it narrows `5.0` to `5.1`.

No GitHub issue is linked for this change; it follows the FIXME in `lib/Sema/TypeCheckAvailability.cpp`.