### PR TITLE
Use nomerge attribute to generate non-mergeable traps

### DIFF
--- a/lib/IRGen/IRBuilder.h
+++ b/lib/IRGen/IRBuilder.h
@@ -42,7 +42,6 @@ private:
   /// point was last cleared.  Used only for preserving block
   /// ordering.
   llvm::BasicBlock *ClearedIP;
-  unsigned NumTrapBarriers = 0;
 
 #ifndef NDEBUG
   /// Whether debug information is requested. Only used in assertions.
@@ -422,9 +421,9 @@ public:
                                    llvm::Value *value,
                                    bool expectedValue, const Twine &name = "");
 
-  /// Call the trap intrinsic. If optimizations are enabled, an inline asm
-  /// gadget is emitted before the trap. The gadget inhibits transforms which
-  /// merge trap calls together, which makes debugging crashes easier.
+  /// Call the trap intrinsic. If optimizations are enabled, the nomerge
+  /// attribute is set on the trap call to inhibit transforms which merge
+  /// trap calls together, which makes debugging crashes easier.
   llvm::CallInst *CreateNonMergeableTrap(IRGenModule &IGM, StringRef failureMsg);
 
   /// Split a first-class aggregate value into its component pieces.

--- a/lib/IRGen/IRGenFunction.cpp
+++ b/lib/IRGen/IRGenFunction.cpp
@@ -527,22 +527,6 @@ llvm::CallInst *IRBuilder::CreateNonMergeableTrap(IRGenModule &IGM,
     }
   }
 
-  if (IGM.IRGen.Opts.shouldOptimize() && !IGM.IRGen.Opts.MergeableTraps) {
-    // Emit unique side-effecting inline asm calls in order to eliminate
-    // the possibility that an LLVM optimization or code generation pass
-    // will merge these blocks back together again. We emit an empty asm
-    // string with the side-effect flag set, and with a unique integer
-    // argument for each cond_fail we see in the function.
-    llvm::IntegerType *asmArgTy = IGM.Int32Ty;
-    llvm::Type *argTys = {asmArgTy};
-    llvm::FunctionType *asmFnTy =
-        llvm::FunctionType::get(IGM.VoidTy, argTys, false /* = isVarArg */);
-    llvm::InlineAsm *inlineAsm =
-        llvm::InlineAsm::get(asmFnTy, "", "n", true /* = SideEffects */);
-    CreateAsmCall(inlineAsm,
-                  llvm::ConstantInt::get(asmArgTy, NumTrapBarriers++));
-  }
-
   // Emit the trap instruction.
   llvm::Function *trapIntrinsic = llvm::Intrinsic::getOrInsertDeclaration(
       &IGM.Module, llvm::Intrinsic::trap);
@@ -551,6 +535,10 @@ llvm::CallInst *IRBuilder::CreateNonMergeableTrap(IRGenModule &IGM,
   }
   auto Call = IRBuilderBase::CreateCall(trapIntrinsic, {});
   setCallingConvUsingCallee(Call);
+
+  if (IGM.IRGen.Opts.shouldOptimize() && !IGM.IRGen.Opts.MergeableTraps) {
+    Call->addFnAttr(llvm::Attribute::NoMerge);
+  }
 
   if (!IGM.IRGen.Opts.TrapFuncName.empty()) {
     auto A = llvm::Attribute::get(getContext(), "trap-func-name",

--- a/test/DebugInfo/doubleinlines.swift
+++ b/test/DebugInfo/doubleinlines.swift
@@ -11,14 +11,10 @@ func callCondFail(arg: Builtin.Int1, msg: Builtin.RawPointer) {
 }
 
 // CHECK: define hidden swiftcc void @"$s13DoubleInlines12callCondFail3arg3msgyBi1__BptF"{{.*}} !dbg ![[FUNC:.*]] {
-// CHECK: tail call void asm sideeffect "", "n"(i32 0) #{{[0-9]+}}, !dbg ![[SCOPEONE:.*]]
-// CHECK: tail call void @llvm.trap(), !dbg ![[LOCTRAP:.*]]
+// CHECK: tail call void @llvm.trap(){{.*}}, !dbg ![[SCOPEONE:.*]]
 
 // CHECK: ![[FUNCSCOPEOTHER:.*]] = distinct !DISubprogram(name: "condFail",{{.*}}
-// CHECK: ![[SCOPEONE]] = distinct !DILocation(line: 6, scope: ![[SCOPETWO:.*]], inlinedAt: ![[SCOPETHREE:.*]])
-// CHECK: ![[SCOPETHREE]] = !DILocation(line: 6, scope: ![[FUNCSCOPE:.*]])
-// CHECK: ![[FUNCSCOPE:[0-9]+]] = distinct !DILexicalBlock(scope: ![[FUNC]],
-// CHECK: ![[LOCTRAP]] = !DILocation(line: 6, scope: ![[SCOPETRAP:.*]], inlinedAt: ![[SCOPEONE]])
+// CHECK: ![[SCOPEONE]] = !DILocation(line: 6, scope: ![[SCOPETRAP:.*]], inlinedAt: ![[SCOPEINLINED:.*]])
 // CHECK: ![[SCOPETRAP]] = distinct !DISubprogram(name: "Swift runtime failure: unknown program error"
 
 import Builtin

--- a/test/DebugInfo/trap.swift
+++ b/test/DebugInfo/trap.swift
@@ -5,14 +5,14 @@ import Swift
 // CHECK: define{{.*}}1f
 func f(_ x : Int64) -> Int64 {
   if x < 23 {
-    // CHECK-DAG: call void @llvm.trap(), !dbg ![[LOC1:.*]]
+    // CHECK-DAG: call void @llvm.trap(){{.*}}, !dbg ![[LOC1:.*]]
     // CHECK-DAG: ![[LOC1]] = !DILocation(line: [[@LINE+1]],
     Builtin.int_trap()
   }
   if x > 42 {
     // CHECK-DAG: ![[LOC2:.*]] = !DILocation(line: [[@LINE+1]],
     Builtin.int_trap()
-    // CHECK-DAG: call void @llvm.trap(), !dbg ![[LOC2]]
+    // CHECK-DAG: call void @llvm.trap(){{.*}}, !dbg ![[LOC2]]
   }
   return x
 }

--- a/test/IRGen/bitcast_different_size.sil
+++ b/test/IRGen/bitcast_different_size.sil
@@ -10,9 +10,9 @@ import Swift
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i64 @bitcast_different_size1
 
 // OPT-LABEL: define{{.*}}@bitcast_different_size1(i32 %0)
-// OPT:   tail call void asm sideeffect "", "n"(i32 0)
-// OPT-NEXT:   tail call void @llvm.trap()
+// OPT:   tail call void @llvm.trap() [[NOMERGE:#[0-9]+]]
 // OPT-NEXT:   unreachable
+// OPT: attributes [[NOMERGE]] = {{{.*}}nomerge{{.*}}}
 
 sil @bitcast_different_size1 : $@convention(thin) (Int32) -> Int64 {
 entry(%i : $Int32):

--- a/test/IRGen/cold_split.swift
+++ b/test/IRGen/cold_split.swift
@@ -18,11 +18,15 @@
 // RUN:       | %FileCheck --check-prefix CHECK-DISABLED %s
 
 
-// CHECK-ENABLED: cold
+// CHECK-ENABLED: .cold
 
-// CHECK-DISABLED-NOT: cold
+// CHECK-DISABLED-NOT: .cold
 
 enum MyError: Error { case err }
+
+func reportError() -> Never {
+  fatalError()
+}
 
 func getRandom(_ b: Bool) throws -> Int {
     if b {
@@ -37,6 +41,6 @@ public func numberWithLogging(_ b: Bool) -> Int {
         return try getRandom(b)
     } catch {
         print("Log: random number generator failed with b=\(b)")
-        return 1337
+        reportError()
     }
 }

--- a/test/IRGen/condfail.sil
+++ b/test/IRGen/condfail.sil
@@ -17,30 +17,6 @@ import Swift
 // CHECK-powerpc64:   .cfi_startproc
 // CHECK-powerpc64le: .cfi_startproc
 // CHECK-s390x:       .cfi_startproc
-// CHECK-OPT-macosx:  InlineAsm Start
-// CHECK-OPT-macosx:  InlineAsm End
-// CHECK-OPT-linux:   ##APP
-// CHECK-OPT-linux:   ##NO_APP
-// CHECK-OPT-windows:   ##APP
-// CHECK-OPT-windows:   ##NO_APP
-// CHECK-OPT-linux-androideabi:   @APP
-// CHECK-OPT-linux-androideabi:   @NO_APP
-// CHECK-OPT-linux-android-aarch64:       //APP
-// CHECK-OPT-linux-android-aarch64:       //NO_APP
-// CHECK-OPT-linux-android-x86_64:       #APP
-// CHECK-OPT-linux-android-x86_64:       #NO_APP
-// CHECK-NOOPT-macosx-NOT: InlineAsm Start
-// CHECK-NOOPT-macosx-NOT: InlineAsm End
-// CHECK-NOOPT-linux-NOT:  ##APP
-// CHECK-NOOPT-linux-NOT:  ##NO_APP
-// CHECK-NOOPT-windows-NOT:  ##APP
-// CHECK-NOOPT-windows-NOT:  ##NO_APP
-// CHECK-OPT-linux-androideabi-NOT:   @APP
-// CHECK-OPT-linux-androideabi-NOT:   @NO_APP
-// CHECK-OPT-linux-android-aarch64-NOT:       //APP
-// CHECK-OPT-linux-android-aarch64-NOT:       //NO_APP
-// CHECK-OPT-linux-android-x86_64-NOT:       #APP
-// CHECK-OPT-linux-android-x86_64-NOT:       #NO_APP
 // CHECK-x86_64:      ud2
 // CHECK-i386:        ud2
 // CHECK-arm64:       brk
@@ -59,18 +35,6 @@ import Swift
 // CHECK-powerpc64-NOT:   .cfi_endproc
 // CHECK-powerpc64le-NOT: .cfi_endproc
 // CHECK-s390x-NOT:       .cfi_endproc
-// CHECK-OPT-macosx:  InlineAsm Start
-// CHECK-OPT-macosx:  InlineAsm End
-// CHECK-OPT-linux:   ##APP
-// CHECK-OPT-linux:   ##NO_APP
-// CHECK-OPT-windows:   ##APP
-// CHECK-OPT-windows:   ##NO_APP
-// CHECK-NOOPT-macosx-NOT: InlineAsm Start
-// CHECK-NOOPT-macosx-NOT: InlineAsm End
-// CHECK-NOOPT-linux-NOT:  ##APP
-// CHECK-NOOPT-linux-NOT:  ##NO_APP
-// CHECK-NOOPT-windows-NOT:  ##APP
-// CHECK-NOOPT-windows-NOT:  ##NO_APP
 // CHECK-x86_64:      ud2
 // CHECK-i386:        ud2
 // CHECK-arm64:       brk

--- a/test/IRGen/condfail_message.swift
+++ b/test/IRGen/condfail_message.swift
@@ -3,7 +3,7 @@
 // REQUIRES: optimized_stdlib
 
 // CHECK-LABEL: define hidden swiftcc{{.*}} i8 @"$s16condfail_message6testitys4Int8VADF"(i8 %0)
-// CHECK: call void @llvm.trap(), !dbg [[LOC:![0-9]+]]
+// CHECK: call void @llvm.trap(){{.*}}, !dbg [[LOC:![0-9]+]]
 
 func testit(_ a: Int8) -> Int8 {
   return a + 1

--- a/test/embedded/traps-fatalerror-ir.swift
+++ b/test/embedded/traps-fatalerror-ir.swift
@@ -25,8 +25,7 @@ public func test() {
 
 // CHECK-NOMESSAGE:      define {{.*}}void @"$e4main4testyyF"(){{.*}} {
 // CHECK-NOMESSAGE-NEXT: entry:
-// CHECK-NOMESSAGE-NEXT:   tail call void asm sideeffect "", "n"(i32 0)
-// CHECK-NOMESSAGE-NEXT:   tail call void @llvm.trap()
+// CHECK-NOMESSAGE-NEXT:   tail call void @llvm.trap() [[NOMERGE:#[0-9]+]]
 // CHECK-NOMESSAGE-NEXT:   unreachable
 // CHECK-NOMESSAGE-NEXT: }
 
@@ -45,7 +44,7 @@ public func testWithInterpolation(i: Int) {
 
 // CHECK-NOMESSAGE:      define {{.*}}void @"$e4main21testWithInterpolation1iySi_tF"(i64 %0){{.*}} {
 // CHECK-NOMESSAGE-NEXT: entry:
-// CHECK-NOMESSAGE-NEXT:   tail call void asm sideeffect "", "n"(i32 0)
-// CHECK-NOMESSAGE-NEXT:   tail call void @llvm.trap()
+// CHECK-NOMESSAGE-NEXT:   tail call void @llvm.trap() [[NOMERGE]]
 // CHECK-NOMESSAGE-NEXT:   unreachable
 // CHECK-NOMESSAGE-NEXT: }
+// CHECK-NOMESSAGE: attributes [[NOMERGE]] = {{{.*}}nomerge{{.*}}}

--- a/test/embedded/traps-mergeable.swift
+++ b/test/embedded/traps-mergeable.swift
@@ -15,6 +15,7 @@ public func test(i: Int, j: Int) {
 }
 
 // CHECK-NOT: call void asm sideeffect ""
+// CHECK-NOT: nomerge
 
 // CHECK: define {{.*}}@"$e4main4test1i1jySi_SitF"
 // CHECK:   tail call void @llvm.trap()

--- a/test/embedded/traps-multiple-preconditions-ir.swift
+++ b/test/embedded/traps-multiple-preconditions-ir.swift
@@ -34,18 +34,16 @@ public func test(i: Int) {
 // CHECK-MESSAGE:   unreachable
 // CHECK-MESSAGE: }
 
-// "Production builds" - We expect 4 separate trap blocks in the IR.
+// "Production builds" - We expect 4 separate trap blocks in the IR, each with
+// the nomerge attribute to prevent LLVM from merging them.
 // CHECK-NOMESSAGE: define {{.*}}void @"$e4main4test1iySi_tF"(i64 %0) {{.*}}{
-// CHECK-NOMESSAGE:   tail call void asm sideeffect "", "n"(i32 0) #3
-// CHECK-NOMESSAGE:   tail call void @llvm.trap()
+// CHECK-NOMESSAGE:   tail call void @llvm.trap() [[NOMERGE:#[0-9]+]]
 // CHECK-NOMESSAGE:   unreachable
-// CHECK-NOMESSAGE:   tail call void asm sideeffect "", "n"(i32 1) #3
-// CHECK-NOMESSAGE:   tail call void @llvm.trap()
+// CHECK-NOMESSAGE:   tail call void @llvm.trap() [[NOMERGE]]
 // CHECK-NOMESSAGE:   unreachable
-// CHECK-NOMESSAGE:   tail call void asm sideeffect "", "n"(i32 2) #3
-// CHECK-NOMESSAGE:   tail call void @llvm.trap()
+// CHECK-NOMESSAGE:   tail call void @llvm.trap() [[NOMERGE]]
 // CHECK-NOMESSAGE:   unreachable
-// CHECK-NOMESSAGE:   tail call void asm sideeffect "", "n"(i32 3) #3
-// CHECK-NOMESSAGE:   tail call void @llvm.trap()
+// CHECK-NOMESSAGE:   tail call void @llvm.trap() [[NOMERGE]]
 // CHECK-NOMESSAGE:   unreachable
 // CHECK-NOMESSAGE: }
+// CHECK-NOMESSAGE: attributes [[NOMERGE]] = {{{.*}}nomerge{{.*}}}

--- a/test/embedded/traps-string-interpolations.swift
+++ b/test/embedded/traps-string-interpolations.swift
@@ -28,8 +28,7 @@ public func test5(i: Int) {
 
 // CHECK:      define {{.*}}@"$e4main5test11iySi_tF"
 // CHECK-NEXT: entry:
-// CHECK-NEXT:   tail call void asm sideeffect ""
-// CHECK-NEXT:   tail call void @llvm.trap()
+// CHECK-NEXT:   tail call void @llvm.trap() [[NOMERGE:#[0-9]+]]
 // CHECK-NEXT:   unreachable
 // CHECK-NEXT: }
 
@@ -47,8 +46,7 @@ public func test5(i: Int) {
 // CHECK-NEXT:   ret void
 // CHECK-EMPTY:
 // CHECK-NEXT: 2:
-// CHECK-NEXT:   tail call void asm sideeffect ""
-// CHECK-NEXT:   tail call void @llvm.trap()
+// CHECK-NEXT:   tail call void @llvm.trap() [[NOMERGE]]
 // CHECK-NEXT:   unreachable
 // CHECK-NEXT: }
 
@@ -59,7 +57,7 @@ public func test5(i: Int) {
 
 // CHECK:      define {{.*}}@"$e4main5test51iySi_tF"
 // CHECK-NEXT: entry:
-// CHECK-NEXT:   tail call void asm sideeffect ""
-// CHECK-NEXT:   tail call void @llvm.trap()
+// CHECK-NEXT:   tail call void @llvm.trap() [[NOMERGE]]
 // CHECK-NEXT:   unreachable
 // CHECK-NEXT: }
+// CHECK: attributes [[NOMERGE]] = {{{.*}}nomerge{{.*}}}

--- a/test/embedded/traps-unique.swift
+++ b/test/embedded/traps-unique.swift
@@ -19,16 +19,15 @@ public func foobar(i: Int) {
 // CHECK:     i64 2, label %2
 // CHECK:   ]
 // CHECK: 1:
-// CHECK:   tail call void asm sideeffect ""
-// CHECK:   tail call void @llvm.trap()
+// CHECK:   tail call void @llvm.trap() [[NOMERGE:#[0-9]+]]
 // CHECK:   unreachable
 // CHECK: 2:
-// CHECK:   tail call void asm sideeffect ""
-// CHECK:   tail call void @llvm.trap()
+// CHECK:   tail call void @llvm.trap() [[NOMERGE]]
 // CHECK:   unreachable
 // CHECK: 3:
 // CHECK:   ret void
 // CHECK: }
+// CHECK: attributes [[NOMERGE]] = {{{.*}}nomerge{{.*}}}
 
 // We should not see a call to _asssertionFailure in IR because that means such basic block can be merged with another
 // and break the expectations that each trap point is unique.


### PR DESCRIPTION
Swift uses uniquely numbered "asm sideeffects" to prevent mergeability of traps. Use LLVM's "nomerge" attribute instead. This avoids unnecessary "asm sideeffects" for every `trap` instruction Swift generates and any unnecessary optimization barrier it maybe introducing.  