### PR TITLE
Repro test case

### DIFF
--- a/test/Serialization/implementation-only-testable-explicit-modules.swift
+++ b/test/Serialization/implementation-only-testable-explicit-modules.swift
@@ -1,0 +1,36 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module %t/HiddenDep.swift \
+// RUN:   -o %t/HiddenDep.swiftmodule -module-name HiddenDep \
+// RUN:   -swift-version 5 -enable-library-evolution \
+// RUN:   -disable-implicit-swift-modules -parse-stdlib
+
+// RUN: %target-swift-frontend -emit-module %t/TestedLib.swift \
+// RUN:   -o %t/TestedLib.swiftmodule -module-name TestedLib \
+// RUN:   -swift-version 5 -enable-library-evolution \
+// RUN:   -disable-implicit-swift-modules -parse-stdlib \
+// RUN:   -swift-module-file=HiddenDep=%t/HiddenDep.swiftmodule \
+// RUN:   -enable-testing
+
+// RUN: rm %t/HiddenDep.swiftmodule
+
+// RUN: %target-swift-frontend -typecheck %t/Client.swift \
+// RUN:   -swift-version 5 -disable-implicit-swift-modules -parse-stdlib \
+// RUN:   -swift-module-file=TestedLib=%t/TestedLib.swiftmodule 
+
+//--- HiddenDep.swift
+
+public struct HiddenType {}
+
+//--- TestedLib.swift
+
+@_implementationOnly import HiddenDep
+
+internal func internalFunc() {}
+
+//--- Client.swift
+
+@testable import TestedLib
+
+internalFunc()


### PR DESCRIPTION
<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->


This test fails because we try to load the missing _implementationOnly module:

```
<unknown>:0: error: failed to open explicit Swift module: /Users/nuriamari/Git/swift-project/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/test-macosx-arm64/Serialization/Output/implementation-only-testable-explicit-modules.swift.tmp/HiddenDep.swiftmodule
```