### PR TITLE
AST: Restrict targets `anyAppleOS` availability is active on

### DIFF
--- a/lib/AST/PlatformKindUtils.cpp
+++ b/lib/AST/PlatformKindUtils.cpp
@@ -166,7 +166,8 @@ static bool isPlatformActiveForTarget(PlatformKind Platform,
       return Target.isDriverKit();
     case PlatformKind::Swift:
     case PlatformKind::anyAppleOS:
-      return Target.isOSDarwin();
+      return Target.isMacOSX() || Target.isiOS() || Target.isWatchOS() ||
+             Target.isTvOS() || Target.isXROS();
     case PlatformKind::OpenBSD:
       return Target.isOSOpenBSD();
     case PlatformKind::FreeBSD:


### PR DESCRIPTION
`anyAppleOS` should only be active on macOS, iOS, watchOS, tvOS, and visionOS. `isOSDarwin()` covers additional targets for which the availability domain does not apply.

Resolves rdar://173718271.
