### PR TITLE
ModuleInterface: Handle more synthesized conformance availability corner cases

### DIFF
--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -458,11 +458,14 @@ class InheritedProtocolCollector {
       for (auto nextAttr : D->getSemanticAvailableAttrs()) {
         // FIXME: This is just approximating the effects of nested availability
         // attributes for the same platform; formally they'd need to be merged.
-        bool alreadyHasMoreSpecificAttrForThisPlatform = llvm::any_of(
+        bool alreadyHasActiveAttrForDomain = llvm::any_of(
             *cache, [nextAttr](SemanticAvailableAttr existingAttr) {
+              if (nextAttr.getParsedAttr()->getKind() !=
+                  existingAttr.getParsedAttr()->getKind())
+                return false;
               return existingAttr.getDomain().contains(nextAttr.getDomain());
             });
-        if (alreadyHasMoreSpecificAttrForThisPlatform)
+        if (alreadyHasActiveAttrForDomain)
           continue;
         pendingAttrs.push_back(nextAttr);
       }

--- a/test/ModuleInterface/synthesized-conformances.swift
+++ b/test/ModuleInterface/synthesized-conformances.swift
@@ -70,6 +70,19 @@ public struct HasNestedTypesAndAvailability {
   }
 }
 
+// CHECK-LABEL: @available(visionOS, unavailable)
+// CHECK-NEXT: public struct UnavailableOnVisionOS {
+@available(visionOS, unavailable)
+public struct UnavailableOnVisionOS {
+  // CHECK-LABEL: @available(iOS 18, *)
+  // CHECK-NEXT: public enum HasRawValueAndRefinediOSAvailability : Swift::Int {
+  @available(iOS 18, *)
+  public enum HasRawValueAndRefinediOSAvailability: Int {
+    // CHECK-NEXT: case a
+    case a
+  }
+}
+
 @objc public enum ObjCEnum: Int32 {
   case a, b = 5, c
 }
@@ -150,6 +163,15 @@ extension NoRawValueWithExplicitHashable : Hashable {
 // CHECK-NEXT: @available(*, deprecated, message: "Use something else")
 // CHECK-NEXT: extension synthesized::HasNestedTypesAndAvailability.synthesized::HasRawValueUniversallyDeprecated : Swift::RawRepresentable {}
 
+// CHECK: @available(iOS 18, *)
+// CHECK-NEXT: @available(visionOS, unavailable)
+// CHECK-NEXT: extension synthesized::UnavailableOnVisionOS.synthesized::HasRawValueAndRefinediOSAvailability : Swift::Equatable {}
+// CHECK: @available(iOS 18, *)
+// CHECK-NEXT: @available(visionOS, unavailable)
+// CHECK-NEXT: extension synthesized::UnavailableOnVisionOS.synthesized::HasRawValueAndRefinediOSAvailability : Swift::Hashable {}
+// CHECK: @available(iOS 18, *)
+// CHECK-NEXT: @available(visionOS, unavailable)
+// CHECK-NEXT: extension synthesized::UnavailableOnVisionOS.synthesized::HasRawValueAndRefinediOSAvailability : Swift::RawRepresentable {}
 
 // CHECK: extension synthesized::ObjCEnum : Swift::Equatable {}
 // CHECK: extension synthesized::ObjCEnum : Swift::Hashable {}


### PR DESCRIPTION
As a follow up to https://github.com/swiftlang/swift/pull/87832, continue adjusting the algorithm for computing synthesized conformance availability. When an outer declaration is `unavailable` in a more specific platform domain and the inner declaration is `introduced:` in a less specific domain, the inner declaration attribute does not override the outer declaration attribute. Unavailability and introduction are on separate axes of availability.

Resolves rdar://173724423.
