### PR TITLE
[ModuleTrace] Emit real path for module paths in module trace file

### DIFF
--- a/lib/FrontendTool/LoadedModuleTrace.cpp
+++ b/lib/FrontendTool/LoadedModuleTrace.cpp
@@ -925,17 +925,26 @@ bool swift::emitLoadedModuleTraceIfNeeded(const ModuleDependencyID &mainModule,
     return llvm::find(directDeps, mod) != directDeps.end();
   };
 
+  auto realPath = [&](const std::string &path) {
+    SmallString<128> realPath;
+    if (ctxt.SourceMgr.getFileSystem()->getRealPath(path, realPath))
+      return path;
+    return realPath.str().str();
+  };
+
   std::vector<SwiftModuleTraceInfo> swiftModules;
   for (auto &mod : allLoadedModules) {
     // Record swift module dependencies and ignore other dependencies.
     auto &info = cache.findKnownDependency(mod);
     if (auto *binary = info.getAsSwiftBinaryModule())
-      swiftModules.push_back({mod.ModuleName, binary->getDefiningModulePath(),
+      swiftModules.push_back({mod.ModuleName,
+                              realPath(binary->getDefiningModulePath()),
                               isDirectImport(mod), binary->isResilient,
                               binary->isStrictMemorySafety});
     else if (auto *textual = info.getAsSwiftInterfaceModule())
       swiftModules.push_back(
-          {mod.ModuleName, textual->swiftInterfaceFile, isDirectImport(mod),
+          {mod.ModuleName, realPath(textual->swiftInterfaceFile),
+           isDirectImport(mod),
            /*isResilient=*/true, textual->isStrictMemorySafety});
   }
 

--- a/test/ScanDependencies/loaded_module_trace.swift
+++ b/test/ScanDependencies/loaded_module_trace.swift
@@ -1,7 +1,10 @@
 // REQUIRES: swift_feature_RegionBasedIsolation
+// UNSUPPORTED: OS=windows-msvc
+
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/cache)
 // RUN: split-file %s %t
+// RUN: ln -s %t/C_real.swiftinterface %t/C.swiftinterface
 
 // RUN: %target-build-swift -emit-module -module-name Module %S/../Driver/Inputs/loaded_module_trace_empty.swift \
 // RUN:   -o %t/Module.swiftmodule -module-cache-path %t/cache
@@ -30,6 +33,7 @@
 // CHECK-DAG: {"name":"SwiftOnoneSupport","path":"{{[^"]*\\[/\\]}}SwiftOnoneSupport.swiftmodule{{(\\[/\\][^"]+[.]swiftinterface)?}}","isImportedDirectly":true,"supportsLibraryEvolution":true,"strictMemorySafety":true}
 // CHECK-DAG: {"name":"Module","path":"{{[^"]*\\[/\\]}}Module.swiftmodule","isImportedDirectly":false,"supportsLibraryEvolution":false,"strictMemorySafety":false}
 // CHECK-DAG: {"name":"A","path":"{{[^"]*\\[/\\]}}A.swiftinterface","isImportedDirectly":true,"supportsLibraryEvolution":true,"strictMemorySafety":true}
+// CHECK-DAG: {"name":"C","path":"{{[^"]*\\[/\\]}}C_real.swiftinterface","isImportedDirectly":true,"supportsLibraryEvolution":true,"strictMemorySafety":false}
 // CHECK: ],
 // CHECK: "swiftmacros":[
 // CHECK-DAG: {"name":"Plugin","path":"{{[^"]*\\[/\\]}}{{libPlugin.dylib|libPlugin.so|Plugin.dll}}"}
@@ -55,7 +59,7 @@ public func funcA() { }
 // swift-module-flags: -module-name B
 public func funcB() { }
 
-//--- C.swiftinterface
+//--- C_real.swiftinterface
 // swift-interface-format-version: 1.0
 // swift-module-flags: -module-name C
 public func funcC() { }


### PR DESCRIPTION
When emitting module trace from dependency scanning results, the module binary path or module interface file in the result should be real path.

rdar://173639093

<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
