### PR TITLE
[cxx-interop] Add a test for `Set<std.string>`

### DIFF
--- a/test/Interop/Cxx/stdlib/use-std-string.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string.swift
@@ -281,6 +281,15 @@ StdStringTestSuite.test("std::string as Hashable") {
     expectNotEqual(h0, h3)
     expectNotEqual(h1, h2)
     expectNotEqual(h2, h3)
+
+    var stringSet: Set<std.string> = ["something"]
+    expectEqual(stringSet.count, 1)
+    stringSet.insert(s1)
+    expectEqual(stringSet.count, 1)
+    stringSet.insert(s2)
+    expectEqual(stringSet.count, 2)
+    stringSet.insert(s0)
+    expectEqual(stringSet.count, 3)
 }
 
 StdStringTestSuite.test("std::u16string as Hashable") {
@@ -302,6 +311,15 @@ StdStringTestSuite.test("std::u16string as Hashable") {
     expectNotEqual(h0, h3)
     expectNotEqual(h1, h2)
     expectNotEqual(h2, h3)
+
+    var stringSet: Set<std.u16string> = ["something"]
+    expectEqual(stringSet.count, 1)
+    stringSet.insert(s1)
+    expectEqual(stringSet.count, 1)
+    stringSet.insert(s2)
+    expectEqual(stringSet.count, 2)
+    stringSet.insert(s0)
+    expectEqual(stringSet.count, 3)
 }
 
 StdStringTestSuite.test("std::u32string as Hashable") {
@@ -323,6 +341,15 @@ StdStringTestSuite.test("std::u32string as Hashable") {
     expectNotEqual(h0, h3)
     expectNotEqual(h1, h2)
     expectNotEqual(h2, h3)
+
+    var stringSet: Set<std.u32string> = ["something"]
+    expectEqual(stringSet.count, 1)
+    stringSet.insert(s1)
+    expectEqual(stringSet.count, 1)
+    stringSet.insert(s2)
+    expectEqual(stringSet.count, 2)
+    stringSet.insert(s0)
+    expectEqual(stringSet.count, 3)
 }
 
 StdStringTestSuite.test("std::wstring as Hashable") {
@@ -344,6 +371,15 @@ StdStringTestSuite.test("std::wstring as Hashable") {
     expectNotEqual(h0, h3)
     expectNotEqual(h1, h2)
     expectNotEqual(h2, h3)
+
+    var stringSet: Set<std.wstring> = ["something"]
+    expectEqual(stringSet.count, 1)
+    stringSet.insert(s1)
+    expectEqual(stringSet.count, 1)
+    stringSet.insert(s2)
+    expectEqual(stringSet.count, 2)
+    stringSet.insert(s0)
+    expectEqual(stringSet.count, 3)
 }
 
 StdStringTestSuite.test("std::u16string <=> Swift.String") {


### PR DESCRIPTION
This was previously reported as a compiler crash on Linux. It is no longer crashing with a recent compiler.

rdar://165140115 / resolves https://github.com/swiftlang/swift/issues/85619

<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
