### PR TITLE
[test] Limit a crasher test to macOS

### DIFF
--- a/validation-test/compiler_crashers/DiagnosticEngine-diagnose-d98e8c.swift
+++ b/validation-test/compiler_crashers/DiagnosticEngine-diagnose-d98e8c.swift
@@ -1,5 +1,6 @@
 // {"aliases":["swift::DiagnosticState::determineBehavior(swift::Diagnostic const&, swift::SourceManager&) const"],"kind":"typecheck","languageMode":6,"original":"ede44338","signature":"swift::InFlightDiagnostic swift::DiagnosticEngine::diagnose<swift::Type, swift::Type>(swift::SourceLoc, swift::Diag<swift::Type, swift::Type>, swift::detail::PassArgument<swift::Type>::type, swift::detail::PassArgument<swift::Type>::type)","signatureNext":"ContextualFailure::diagnoseAsError"}
 // RUN: not --crash %target-swift-frontend -typecheck -swift-version 6 %s
+// REQUIRES: OS=macosx
 class a {
   func
     b(c: a) -> a


### PR DESCRIPTION
This is failing on Linux AArch64 CI https://ci.swift.org/job/oss-swift-package-ubi-9-aarch64/3427/consoleText