### PR TITLE
[android][test] Disable stdlib C++ Interop test that is failing again, this time because of `anyappleos`

### DIFF
--- a/test/Interop/SwiftToCxx/stdlib/stdlib-in-cxx-no-diagnostics-generated-header.cpp
+++ b/test/Interop/SwiftToCxx/stdlib/stdlib-in-cxx-no-diagnostics-generated-header.cpp
@@ -7,6 +7,9 @@
 
 // RUN: %target-interop-build-clangxx -std=gnu++20 -fsyntax-only -c %t/test-stdlib.cpp -I %t -Wall -Werror -Werror=ignored-attributes -Wno-error=unused-command-line-argument
 
+// Failing because of new `anyAppleOS` unrecognized by NDK clang, see #86085
+// XFAIL: OS=linux-android, OS=linux-androideabi
+
 //--- print-string.swift
 
 public func printString(_ s: String) {


### PR DESCRIPTION
Maybe this will get into a future NDK clang...