### PR TITLE
Fix Builtin.Borrow<T> OSSA representation

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OwnershipLiveness.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OwnershipLiveness.swift
@@ -477,8 +477,6 @@ extension OwnershipUseVisitor {
       return dependentUse(of: operand, dependentValue: mdi)
     case let bfi as BorrowedFromInst where !bfi.borrowedPhi.isReborrow:
       return dependentUse(of: operand, dependentValue: bfi)
-    case let mbi as MakeBorrowInst:
-      return dependentUse(of: operand, dependentValue: mbi)
     default:
       return borrowingUse(of: operand,
                           by: BorrowingInstruction(operand.instruction)!)

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -260,7 +260,6 @@ public:
     PartialApplyStack,
     MarkDependenceNonEscaping,
     BeginAsyncLet,
-    MakeBorrow,
   };
 
 private:
@@ -295,8 +294,6 @@ public:
       return Kind::PartialApplyStack;
     case SILInstructionKind::MarkDependenceInst:
       return Kind::MarkDependenceNonEscaping;
-    case SILInstructionKind::MakeBorrowInst:
-      return Kind::MakeBorrow;
     case SILInstructionKind::BuiltinInst: {
       auto bi = cast<BuiltinInst>(i);
       if (bi->getBuiltinKind() == BuiltinValueKind::StartAsyncLetWithLocalBuffer) {
@@ -418,7 +415,6 @@ struct BorrowingOperand {
     case BorrowingOperandKind::PartialApplyStack:
     case BorrowingOperandKind::MarkDependenceNonEscaping:
     case BorrowingOperandKind::BeginAsyncLet:
-    case BorrowingOperandKind::MakeBorrow:
       return false;
     case BorrowingOperandKind::Branch:
       return true;

--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -435,10 +435,26 @@ OperandOwnershipClassifier::visitBeginBorrowInst(BeginBorrowInst *borrow) {
   return OperandOwnership::Borrow;
 }
 
-// A make_borrow is nested in the referent's scope.
+// A make_borrow is nested in the referent's scope. It creates a value with no
+// ownership, which cannot be tracked by OSSA utilities. Normally, we
+// conservatively declare such untracked uses as PointerEscape. But, if we
+// treated make_borrow as an escape, then liveness would bailout causing
+// diagnostic errors, particularly in the move-checker. That would render
+// Builtin.makeBorrow useless, So instead, we optimistically treat make_borrow
+// like an InstantaneousUse. This assumes, without verification, that all uses
+// are already guarded by a mark_dependence.
+//
+// TODO: Correctness currently relies on cooperation by the programmer to
+// correctly use Builtin.makeBorrow with no compiler checking. Instead, we
+// should treat the result of make_borrow like a non-Escapable value. It's
+// operand ownership should be `Borrow`, it should produce an `Owned`
+// non-Escapable value, OSSA liveness should find all dependent uses (just like
+// mark_dependence), and LifetimeDependenceDiagnostics should verify that all
+// dependent uses are within the original borrow scope. To do this, it will need
+// to look through stores into the field of a wrapper type (Borrow<T>).
 OperandOwnership
 OperandOwnershipClassifier::visitMakeBorrowInst(MakeBorrowInst *borrow) {
-  return OperandOwnership::Borrow;
+  return OperandOwnership::InstantaneousUse;
 }
 
 OperandOwnership

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -626,9 +626,6 @@ void BorrowingOperandKind::print(llvm::raw_ostream &os) const {
   case Kind::BeginAsyncLet:
     os << "BeginAsyncLet";
     return;
-  case Kind::MakeBorrow:
-    os << "MakeBorrow";
-    return;
   }
   llvm_unreachable("Covered switch isn't covered?!");
 }
@@ -661,7 +658,6 @@ bool BorrowingOperand::hasEmptyRequiredEndingUses() const {
   case BorrowingOperandKind::StoreBorrow:
   case BorrowingOperandKind::BeginApply:
   case BorrowingOperandKind::BeginAsyncLet:
-  case BorrowingOperandKind::MakeBorrow:
   case BorrowingOperandKind::PartialApplyStack:
   case BorrowingOperandKind::MarkDependenceNonEscaping: {
     return op->getUser()->hasUsesOfAnyResult();
@@ -770,10 +766,6 @@ bool BorrowingOperand::visitScopeEndingUses(
     }
     return true;
   }
-  case BorrowingOperandKind::MakeBorrow: {
-    // TODO: Conservatively bail out for now.
-    return true;
-  }
   // These are instantaneous borrow scopes so there aren't any special end
   // scope instructions.
   case BorrowingOperandKind::Apply:
@@ -827,7 +819,6 @@ SILValue BorrowingOperand::getBorrowIntroducingUserResult() const {
     return SILValue();
 
   case BorrowingOperandKind::BeginBorrow:
-  case BorrowingOperandKind::MakeBorrow:
     return cast<SingleValueInstruction>(op->getUser());
 
   case BorrowingOperandKind::BorrowedFrom: {
@@ -888,7 +879,6 @@ SILValue BorrowingOperand::getDependentUserResult() const {
     return SILValue();
   }
   case BorrowingOperandKind::Invalid:
-  case BorrowingOperandKind::MakeBorrow:
   case BorrowingOperandKind::BeginBorrow:
   case BorrowingOperandKind::StoreBorrow:
   case BorrowingOperandKind::BeginApply:


### PR DESCRIPTION
Builtin.Borrow<T> does not introduce a new borrow scope at the level of
SILValue. A SILValue that introduces a borrow scope is expected to be tracked by
OSSA--it cannot produce a trivial value. That borrow scope is expected to have a
scope-ending operation on all paths.

It's not clear how OSSA utilities and passes will handle the previous
implementation which doesn't honor those invariants. Fixing this is needed to
rely on Builtin.Borrow<T> more extensively.

Instead, treat the make_borrow instruction like an instantenous use. It produces
a Builtin.Borrow<T> value with ownership None. That value is completely ignored
by OSSA and does not contribute to liveness of the incoming value.

This is at least a coherent representation, but still incredibly dangerous. The
validity of SIL depends on the programmer using Builtin.makeBorrow
correctly. Add a TODO for implementing verification.

Fixes rdar://173800290 (Fix Builtin.Borrow<T> OSSA representation)
