### PR TITLE
[stdlib] Guard new builtins around feature

### DIFF
--- a/Runtimes/Core/Core/CMakeLists.txt
+++ b/Runtimes/Core/Core/CMakeLists.txt
@@ -318,6 +318,7 @@ target_compile_options(swiftCore PRIVATE
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature AddressableParameters>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature AddressableTypes>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature BorrowAndMutateAccessors>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature BorrowInout>"
   $<$<COMPILE_LANGUAGE:Swift>:-parse-stdlib>
   $<$<COMPILE_LANGUAGE:Swift>:-nostdimport>
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -group-info-path -Xfrontend ${CMAKE_CURRENT_SOURCE_DIR}/GroupInfo.json>"

--- a/include/swift/AST/KnownStdlibTypes.def
+++ b/include/swift/AST/KnownStdlibTypes.def
@@ -105,4 +105,7 @@ KNOWN_STDLIB_TYPE_DECL(_InlineArray, NominalTypeDecl, 2)
 
 KNOWN_STDLIB_TYPE_DECL(MutableSpan, NominalTypeDecl, 1)
 
+KNOWN_STDLIB_TYPE_DECL(Borrow, NominalTypeDecl, 1)
+KNOWN_STDLIB_TYPE_DECL(Inout, NominalTypeDecl, 1)
+
 #undef KNOWN_STDLIB_TYPE_DECL

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -607,7 +607,17 @@ static bool usesFeatureReparenting(Decl *decl) {
 }
 
 UNINTERESTING_FEATURE(StrictAccessControl)
-UNINTERESTING_FEATURE(BorrowInout)
+
+static bool usesFeatureBorrowInout(Decl *decl) {
+  auto &ctx = decl->getASTContext();
+
+  if (auto ext = dyn_cast<ExtensionDecl>(decl)) {
+    decl = ext->getExtendedNominal();
+  }
+
+  return decl == ctx.getBorrowDecl() || decl == ctx.getInoutDecl();
+}
+
 UNINTERESTING_FEATURE(BorrowingSequence)
 
 // ----------------------------------------------------------------------------

--- a/stdlib/public/core/Borrow.swift
+++ b/stdlib/public/core/Borrow.swift
@@ -45,7 +45,11 @@ public struct Borrow<Value: ~Copyable>: Copyable, ~Escapable {
     unsafeAddress pointer: UnsafePointer<Value>,
     borrowing owner: borrowing Owner
   ) {
+#if $BorrowInout
     builtin = unsafe Builtin.makeBorrow(pointer.pointee)
+#else
+    fatalError()
+#endif
   }
 }
 
@@ -58,7 +62,11 @@ extension Borrow where Value: ~Copyable {
   @_transparent
   public var value: Value {
     borrow {
+#if $BorrowInout
       Builtin.dereferenceBorrow(builtin)
+#else
+      fatalError()
+#endif
     }
   }
 }

--- a/stdlib/public/core/Borrow.swift
+++ b/stdlib/public/core/Borrow.swift
@@ -45,11 +45,7 @@ public struct Borrow<Value: ~Copyable>: Copyable, ~Escapable {
     unsafeAddress pointer: UnsafePointer<Value>,
     borrowing owner: borrowing Owner
   ) {
-#if $BorrowInout
     builtin = unsafe Builtin.makeBorrow(pointer.pointee)
-#else
-    fatalError()
-#endif
   }
 }
 
@@ -62,11 +58,7 @@ extension Borrow where Value: ~Copyable {
   @_transparent
   public var value: Value {
     borrow {
-#if $BorrowInout
       Builtin.dereferenceBorrow(builtin)
-#else
-      fatalError()
-#endif
     }
   }
 }

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -348,6 +348,7 @@ list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "Suppresse
 list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "Reparenting")
 list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "Lifetimes")
 list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "BorrowAndMutateAccessors")
+list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "BorrowInout")
 list(APPEND swift_stdlib_compile_flags "-strict-memory-safety")
 
 if("${SWIFT_NATIVE_SWIFT_TOOLS_PATH}" STREQUAL "")


### PR DESCRIPTION
These new builtins are not available on older compilers trying to type check newer stdlib interfaces. Guard them with the feature flag.

Resolves: rdar://173801670