### PR TITLE
[Runtime] Add _swift_getSubclasses SPI to enumerate subclasses of a class.

### DIFF
--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -1021,6 +1021,21 @@ SWIFT_RUNTIME_STDLIB_SPI
 bool _swift_class_isSubclass(const Metadata *subclass,
                              const Metadata *superclass);
 
+/// Returns a NULL-terminated array of class metadata pointers for all known
+/// subclasses of a class. All classes involved must be non-generic: concrete
+/// subclasses of a generic will not be returned. Returns an empty array if
+/// superclass is generic. The caller must free the returned array with
+/// swift_slowDealloc or UnsafeMutablePointer.deallocate.
+///
+/// Any metadata returned will be fully instantiated before being returned.
+/// Availability is not checked, and the runtime will attempt to instantiate and
+/// return subclasses that are marked as requiring a newer OS than what it's
+/// running on.
+SWIFT_CC(swift)
+SWIFT_RUNTIME_STDLIB_SPI
+const Metadata *_Nonnull const *_Nonnull _swift_copyNongenericSubclasses(
+    const Metadata *_Nonnull superclass);
+
 #if !NDEBUG
 /// Verify that the given metadata pointer correctly roundtrips its
 /// mangled name through the demangler.

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1100,6 +1100,9 @@ const Metadata *_Nonnull const *_Nonnull swift::_swift_copyNongenericSubclasses(
     const Metadata *superclass) {
   auto *targetDesc = superclass->getTypeContextDescriptor();
 
+  fprintf(stderr, "[copySubclasses] enter, superclass=%p targetDesc=%p\n",
+          superclass, targetDesc);
+
   // Collect matching descriptors first, then instantiate metadata.
   llvm::SmallVector<const TypeContextDescriptor *, 16> matchingDescs;
 
@@ -1110,50 +1113,81 @@ const Metadata *_Nonnull const *_Nonnull swift::_swift_copyNongenericSubclasses(
     auto &T = TypeMetadataRecords.get();
 
     // Scan all type metadata record sections.
-    auto scanSections = [&](auto &sections) {
+    size_t sectionIndex = 0;
+    size_t recordIndex = 0;
+    auto scanSections = [&](auto &sections, const char *label) {
+      sectionIndex = 0;
       for (auto &section : sections.snapshot()) {
+        recordIndex = 0;
         for (const auto &record : section) {
           auto *context = record.getContextDescriptor();
+          fprintf(stderr, "[copySubclasses] %s section %zu record %zu "
+                  "context=%p\n", label, sectionIndex, recordIndex, context);
           auto *classDesc = dyn_cast_or_null<ClassDescriptor>(context);
-          if (!classDesc)
+          if (!classDesc) {
+            fprintf(stderr, "[copySubclasses]   not a class, skipping\n");
+            recordIndex++;
             continue;
+          }
+
+          fprintf(stderr, "[copySubclasses]   classDesc=%p isGeneric=%d\n",
+                  classDesc, classDesc->isGeneric());
 
           // Skip generic classes. We can't meaningfully return them.
-          if (classDesc->isGeneric())
+          if (classDesc->isGeneric()) {
+            recordIndex++;
             continue;
+          }
 
           // Skip the target class itself.
-          if (equalContexts(classDesc, targetDesc))
+          if (equalContexts(classDesc, targetDesc)) {
+            fprintf(stderr, "[copySubclasses]   is target class, skipping\n");
+            recordIndex++;
             continue;
+          }
 
           // If it's a subclass, add it.
-          if (_isSubclassDescriptor(classDesc, targetDesc))
+          fprintf(stderr, "[copySubclasses]   checking _isSubclassDescriptor\n");
+          if (_isSubclassDescriptor(classDesc, targetDesc)) {
+            fprintf(stderr, "[copySubclasses]   match! adding descriptor\n");
             matchingDescs.push_back(cast<TypeContextDescriptor>(classDesc));
+          }
+          recordIndex++;
         }
+        sectionIndex++;
       }
     };
 
-    scanSections(T.SectionsToScan);
+    scanSections(T.SectionsToScan, "SectionsToScan");
 #if DYLD_GET_SWIFT_PRESPECIALIZED_DATA_DEFINED
-    scanSections(T.SharedCacheSectionsToScan);
+    scanSections(T.SharedCacheSectionsToScan, "SharedCache");
 #endif
   }
 
+  fprintf(stderr, "[copySubclasses] scan done, %zu matches\n",
+          matchingDescs.size());
+
   // Allocate the result array (matching classes + NULL terminator).
+  size_t allocSize = matchingDescs.size_in_bytes() + sizeof(const Metadata *);
+  fprintf(stderr, "[copySubclasses] allocating %zu bytes\n", allocSize);
   auto **result = static_cast<const Metadata **>(
-      swift_slowAlloc(matchingDescs.size_in_bytes() + sizeof(const Metadata *),
-                      alignof(const Metadata *) - 1));
+      swift_slowAlloc(allocSize, alignof(const Metadata *) - 1));
+  fprintf(stderr, "[copySubclasses] result buffer=%p\n", result);
 
   // Instantiate metadata for each matching class.
   size_t i = 0;
-  for (auto *desc : matchingDescs) {
+  for (size_t descIdx = 0; descIdx < matchingDescs.size(); descIdx++) {
+    auto *desc = matchingDescs[descIdx];
+    fprintf(stderr, "[copySubclasses] instantiating %zu/%zu desc=%p\n",
+            descIdx, matchingDescs.size(), desc);
     auto accessFn = desc->getAccessFunction();
     if (!accessFn) {
-      // Shouldn't happen, but just in case, we'll skip this entry.
+      fprintf(stderr, "[copySubclasses]   no access function, skipping\n");
       continue;
     }
+    fprintf(stderr, "[copySubclasses]   calling accessFn=%p\n", accessFn);
     auto response = accessFn(MetadataRequest(MetadataState::Complete));
-    // We should never get NULL, but just in case we do, we'll skip this entry.
+    fprintf(stderr, "[copySubclasses]   response.Value=%p\n", response.Value);
     if (response.Value)
       result[i++] = response.Value;
   }
@@ -1161,6 +1195,7 @@ const Metadata *_Nonnull const *_Nonnull swift::_swift_copyNongenericSubclasses(
   // Terminating nullptr.
   result[i] = nullptr;
 
+  fprintf(stderr, "[copySubclasses] done, returning %zu results\n", i);
   return result;
 }
 

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1053,6 +1053,117 @@ _findContextDescriptor(Demangle::NodePointer node,
   return foundContext;
 }
 
+/// Given a class descriptor, locate the descriptor of its superclass using the
+/// SuperclassType mangled name.
+///
+/// Returns nullptr if the class has no superclass, if the superclass
+/// descriptor cannot be found, or if the superclass is generic.
+///
+/// Note: _swift_copyNongenericSubclasses depends on this returning nullptr when
+/// the superclass is generic.
+static const ClassDescriptor *
+_findSuperclassDescriptor(const ClassDescriptor *classDesc) {
+  auto superclassNameBase = classDesc->SuperclassType.get();
+  if (!superclassNameBase)
+    return nullptr;
+
+  DemanglerForRuntimeTypeResolution<> demangler;
+  auto name = Demangle::makeSymbolicMangledNameStringRef(superclassNameBase);
+  auto node = demangler.demangleTypeRef(name);
+  if (!node)
+    return nullptr;
+
+  // Unwrap a Type node if necessary.
+  if (node->getKind() == Demangle::Node::Kind::Type)
+    node = node->getChild(0);
+
+  return dyn_cast_or_null<ClassDescriptor>(
+      _findContextDescriptor(node, demangler));
+}
+
+/// Check whether a class descriptor is a (non-strict) subclass of the given
+/// target descriptor, walking the superclass chain at the descriptor level.
+static bool _isSubclassDescriptor(const ClassDescriptor *classDesc,
+                                  const ContextDescriptor *targetDesc) {
+  const ClassDescriptor *current = classDesc;
+  while (current) {
+    if (equalContexts(current, targetDesc))
+      return true;
+
+    current = _findSuperclassDescriptor(current);
+  }
+  return false;
+}
+
+SWIFT_CC(swift)
+const Metadata *_Nonnull const *_Nonnull swift::_swift_copyNongenericSubclasses(
+    const Metadata *superclass) {
+  auto *targetDesc = superclass->getTypeContextDescriptor();
+
+  // Collect matching descriptors first, then instantiate metadata.
+  llvm::SmallVector<const TypeContextDescriptor *, 16> matchingDescs;
+
+  // Don't attempt to find subclasses of generic classes. We don't implement
+  // checking of the specialization, so a concrete subclass of Foo<Int> would
+  // show up as a subclass of Foo<String>.
+  if (!targetDesc->isGeneric()) {
+    auto &T = TypeMetadataRecords.get();
+
+    // Scan all type metadata record sections.
+    auto scanSections = [&](auto &sections) {
+      for (auto &section : sections.snapshot()) {
+        for (const auto &record : section) {
+          auto *context = record.getContextDescriptor();
+          auto *classDesc = dyn_cast_or_null<ClassDescriptor>(context);
+          if (!classDesc)
+            continue;
+
+          // Skip generic classes. We can't meaningfully return them.
+          if (classDesc->isGeneric())
+            continue;
+
+          // Skip the target class itself.
+          if (equalContexts(classDesc, targetDesc))
+            continue;
+
+          // If it's a subclass, add it.
+          if (_isSubclassDescriptor(classDesc, targetDesc))
+            matchingDescs.push_back(cast<TypeContextDescriptor>(classDesc));
+        }
+      }
+    };
+
+    scanSections(T.SectionsToScan);
+#if DYLD_GET_SWIFT_PRESPECIALIZED_DATA_DEFINED
+    scanSections(T.SharedCacheSectionsToScan);
+#endif
+  }
+
+  // Allocate the result array (matching classes + NULL terminator).
+  auto **result = static_cast<const Metadata **>(
+      swift_slowAlloc(matchingDescs.size_in_bytes() + sizeof(const Metadata *),
+                      alignof(const Metadata *) - 1));
+
+  // Instantiate metadata for each matching class.
+  size_t i = 0;
+  for (auto *desc : matchingDescs) {
+    auto accessFn = desc->getAccessFunction();
+    if (!accessFn) {
+      // Shouldn't happen, but just in case, we'll skip this entry.
+      continue;
+    }
+    auto response = accessFn(MetadataRequest(MetadataState::Complete));
+    // We should never get NULL, but just in case we do, we'll skip this entry.
+    if (response.Value)
+      result[i++] = response.Value;
+  }
+
+  // Terminating nullptr.
+  result[i] = nullptr;
+
+  return result;
+}
+
 /// Function to check whether we're currently running on the given global
 /// actor.
 bool (* __ptrauth_swift_is_global_actor_function SWIFT_CC(swift)

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1098,13 +1098,28 @@ static bool _isSubclassDescriptor(const ClassDescriptor *classDesc,
 SWIFT_CC(swift)
 const Metadata *_Nonnull const *_Nonnull swift::_swift_copyNongenericSubclasses(
     const Metadata *superclass) {
+  // Stack canary to detect corruption during scan.
+  volatile uint64_t canary1 = 0xDEADBEEFCAFEBABEULL;
+
   auto *targetDesc = superclass->getTypeContextDescriptor();
 
-  fprintf(stderr, "[copySubclasses] enter, superclass=%p targetDesc=%p\n",
-          superclass, targetDesc);
+  fprintf(stderr, "[copySubclasses] enter, superclass=%p targetDesc=%p "
+          "canary@%p\n", superclass, targetDesc, &canary1);
 
   // Collect matching descriptors first, then instantiate metadata.
   llvm::SmallVector<const TypeContextDescriptor *, 16> matchingDescs;
+
+  volatile uint64_t canary2 = 0x1234567890ABCDEFULL;
+
+  #define CHECK_CANARIES(where) do { \
+    if (canary1 != 0xDEADBEEFCAFEBABEULL || \
+        canary2 != 0x1234567890ABCDEFULL) { \
+      fprintf(stderr, "[copySubclasses] CANARY CORRUPTED at %s! " \
+              "canary1=%llx canary2=%llx\n", where, \
+              (unsigned long long)canary1, (unsigned long long)canary2); \
+      abort(); \
+    } \
+  } while (0)
 
   // Don't attempt to find subclasses of generic classes. We don't implement
   // checking of the specialization, so a concrete subclass of Foo<Int> would
@@ -1121,17 +1136,11 @@ const Metadata *_Nonnull const *_Nonnull swift::_swift_copyNongenericSubclasses(
         recordIndex = 0;
         for (const auto &record : section) {
           auto *context = record.getContextDescriptor();
-          fprintf(stderr, "[copySubclasses] %s section %zu record %zu "
-                  "context=%p\n", label, sectionIndex, recordIndex, context);
           auto *classDesc = dyn_cast_or_null<ClassDescriptor>(context);
           if (!classDesc) {
-            fprintf(stderr, "[copySubclasses]   not a class, skipping\n");
             recordIndex++;
             continue;
           }
-
-          fprintf(stderr, "[copySubclasses]   classDesc=%p isGeneric=%d\n",
-                  classDesc, classDesc->isGeneric());
 
           // Skip generic classes. We can't meaningfully return them.
           if (classDesc->isGeneric()) {
@@ -1139,19 +1148,23 @@ const Metadata *_Nonnull const *_Nonnull swift::_swift_copyNongenericSubclasses(
             continue;
           }
 
+          CHECK_CANARIES("before equalContexts");
+
           // Skip the target class itself.
           if (equalContexts(classDesc, targetDesc)) {
-            fprintf(stderr, "[copySubclasses]   is target class, skipping\n");
+            CHECK_CANARIES("after equalContexts (matched)");
             recordIndex++;
             continue;
           }
 
+          CHECK_CANARIES("after equalContexts");
+
           // If it's a subclass, add it.
-          fprintf(stderr, "[copySubclasses]   checking _isSubclassDescriptor\n");
           if (_isSubclassDescriptor(classDesc, targetDesc)) {
-            fprintf(stderr, "[copySubclasses]   match! adding descriptor\n");
+            CHECK_CANARIES("after _isSubclassDescriptor (matched)");
             matchingDescs.push_back(cast<TypeContextDescriptor>(classDesc));
           }
+          CHECK_CANARIES("after _isSubclassDescriptor");
           recordIndex++;
         }
         sectionIndex++;
@@ -1164,39 +1177,35 @@ const Metadata *_Nonnull const *_Nonnull swift::_swift_copyNongenericSubclasses(
 #endif
   }
 
-  fprintf(stderr, "[copySubclasses] scan done, %zu matches\n",
-          matchingDescs.size());
+  CHECK_CANARIES("after scan");
 
   // Allocate the result array (matching classes + NULL terminator).
   size_t allocSize = matchingDescs.size_in_bytes() + sizeof(const Metadata *);
-  fprintf(stderr, "[copySubclasses] allocating %zu bytes\n", allocSize);
   auto **result = static_cast<const Metadata **>(
       swift_slowAlloc(allocSize, alignof(const Metadata *) - 1));
-  fprintf(stderr, "[copySubclasses] result buffer=%p\n", result);
 
   // Instantiate metadata for each matching class.
   size_t i = 0;
   for (size_t descIdx = 0; descIdx < matchingDescs.size(); descIdx++) {
     auto *desc = matchingDescs[descIdx];
-    fprintf(stderr, "[copySubclasses] instantiating %zu/%zu desc=%p\n",
-            descIdx, matchingDescs.size(), desc);
     auto accessFn = desc->getAccessFunction();
-    if (!accessFn) {
-      fprintf(stderr, "[copySubclasses]   no access function, skipping\n");
+    if (!accessFn)
       continue;
-    }
-    fprintf(stderr, "[copySubclasses]   calling accessFn=%p\n", accessFn);
     auto response = accessFn(MetadataRequest(MetadataState::Complete));
-    fprintf(stderr, "[copySubclasses]   response.Value=%p\n", response.Value);
     if (response.Value)
       result[i++] = response.Value;
+    CHECK_CANARIES("after accessFn");
   }
 
   // Terminating nullptr.
   result[i] = nullptr;
 
-  fprintf(stderr, "[copySubclasses] done, returning %zu results\n", i);
+  CHECK_CANARIES("before return");
+  fprintf(stderr, "[copySubclasses] done, returning %zu results, "
+          "canaries OK\n", i);
   return result;
+
+  #undef CHECK_CANARIES
 }
 
 /// Function to check whether we're currently running on the given global

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1098,6 +1098,9 @@ static bool _isSubclassDescriptor(const ClassDescriptor *classDesc,
 SWIFT_CC(swift)
 const Metadata *_Nonnull const *_Nonnull swift::_swift_copyNongenericSubclasses(
     const Metadata *superclass) {
+  // Force unbuffered stderr so output survives a crash.
+  setvbuf(stderr, nullptr, _IONBF, 0);
+
   // Stack canary to detect corruption during scan.
   volatile uint64_t canary1 = 0xDEADBEEFCAFEBABEULL;
 

--- a/test/Runtime/enumerate_subclasses.swift
+++ b/test/Runtime/enumerate_subclasses.swift
@@ -1,0 +1,83 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+import Swift
+import StdlibUnittest
+
+let CopySubclassesTests = TestSuite("CopySubclasses")
+
+// Set up a class hierarchy for testing.
+class Base {}
+class Sub1: Base {}
+class Sub2: Base {}
+class GrandChild: Sub1 {}
+class Unrelated {}
+
+class GenericBase<T> {}
+class NongenericSub: GenericBase<Int> {}
+
+class NongenericBase {}
+class GenericSub<T>: NongenericBase {}
+
+class NongenericWithGenericIntermediate: GenericSub<Int> {}
+
+func objectIdentifierSet(_ types: [Any.Type]) -> Set<ObjectIdentifier> {
+  Set(types.map{ ObjectIdentifier($0) })
+}
+
+@_silgen_name("_swift_copyNongenericSubclasses")
+func _swift_copyNongenericSubclasses(
+  _ superclass: UnsafeRawPointer
+) -> UnsafePointer<UnsafeRawPointer?>
+
+func copySubclasses(of type: AnyClass) -> Set<ObjectIdentifier> {
+  let metadataPtr = unsafeBitCast(type, to: UnsafeRawPointer.self)
+  let result = _swift_copyNongenericSubclasses(metadataPtr)
+  var classes: [AnyClass] = []
+  var i = 0
+  while let ptr = result[i] {
+    classes.append(unsafeBitCast(ptr, to: AnyClass.self))
+    i += 1
+  }
+  result.deallocate()
+  return objectIdentifierSet(classes)
+}
+
+CopySubclassesTests.test("direct subclasses") {
+  let subclasses = copySubclasses(of: Base.self)
+  expectEqual(subclasses, objectIdentifierSet([
+      Sub1.self, Sub2.self, GrandChild.self
+  ]))
+}
+
+CopySubclassesTests.test("transitive subclasses") {
+  let subclasses = copySubclasses(of: Sub1.self)
+  expectEqual(subclasses, objectIdentifierSet([
+      GrandChild.self
+  ]))
+}
+
+CopySubclassesTests.test("leaf class has no subclasses") {
+  let subclasses = copySubclasses(of: GrandChild.self)
+  expectEqual(subclasses, [])
+}
+
+CopySubclassesTests.test("unrelated class has no subclasses") {
+  let subclasses = copySubclasses(of: Unrelated.self)
+  expectEqual(subclasses, [])
+}
+
+CopySubclassesTests.test("generic superclass provides no subclasses") {
+  let subclasses = copySubclasses(of: GenericBase<Int>.self)
+  expectEqual(subclasses, [])
+}
+
+CopySubclassesTests.test("generic subclasses") {
+  // A generic subclass of a non-generic class should not be returned. A
+  // concrete subclass of a generic subclass of a non-generic class should also
+  // not be returned.
+  let subclasses = copySubclasses(of: NongenericBase.self)
+  expectEqual(subclasses, [])
+}
+
+runAllTests()

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -1282,3 +1282,6 @@ Added: _$ss15EmptyCollectionVyxGSHsWP
 
 // Wrapper for SWIFT_CONCURRENCY_TRACING_SUBSYSTEM environment variable
 Added: _concurrencyTracingSubsystem
+
+// SPI for finding subclasses of a class.
+Added: __swift_copyNongenericSubclasses

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -1277,3 +1277,6 @@ Added: _$ss15EmptyCollectionVyxGSHsWP
 
 // Wrapper for SWIFT_CONCURRENCY_TRACING_SUBSYSTEM environment variable
 Added: _concurrencyTracingSubsystem
+
+// SPI for finding subclasses of a class.
+Added: __swift_copyNongenericSubclasses


### PR DESCRIPTION
Scan all descriptors and resolve class descriptors' superclass names to locate subclasses of the given class.

Skip generic classes when doing this scan, as we can't instantiate their metadata to return. Return nothing when requesting subclasses of a generic class, as it's difficult to determine if a subclass is of that or of a different specialization. We do allow generics in the class hierarchy between non-generics, as we can treat them the same as other classes for this purpose.

rdar://172942099