### PR TITLE
[6.3] [Section] Do not diagnose static-initialization failure on an already-erroneous context

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/DiagnoseUnknownConstValues.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/DiagnoseUnknownConstValues.swift
@@ -37,6 +37,14 @@ let diagnoseUnknownConstValues = ModulePass(name: "diagnose-unknown-const-values
 }
 
 private func verifyGlobals(_ context: ModulePassContext) {
+  // In case of a preceding error, `initialize-static-globals` would
+  // not have run, and we would always be emitting these diagnostics regardless
+  // of whether or not the GV actually would have failed to get statically
+  // initialized.
+  guard !context.hadError else {
+    return
+  }
+
   for gv in context.globalVariables where gv.isConst {
     if gv.staticInitValue == nil {
       context.diagnosticEngine.diagnose(.require_const_initializer_for_const,

--- a/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
@@ -764,6 +764,12 @@ private:
     // indexing purposes.
     if (!module->getOptions().EnableWMORequiredDiagnostics) return;
 
+    // Bypass this verification when a prior diagnostic error is present.
+    // In that case, required mandatory transofmation passes may not have
+    // run which would mean the diagnostics we emit here would be
+    // false-positive.
+    if (module->getASTContext().hadError()) return;
+
     PerformanceDiagnostics diagnoser(*module, getAnalysis<BasicCalleeAnalysis>());
 
     // Check that @section, @_silgen_name is only on constant globals

--- a/test/ConstValues/DiagModules.swift
+++ b/test/ConstValues/DiagModules.swift
@@ -19,4 +19,4 @@ import MyModule
 
 @const let constGlobal1: Int = foo()
 // expected-error@-1 {{'@const' value should be initialized with a compile-time value}}
-// expected-error@-2 {{global variable must be a compile-time constant}} // Remove this once we common out the diagnostics
+

--- a/test/ConstValues/DiagNotConst.swift
+++ b/test/ConstValues/DiagNotConst.swift
@@ -5,7 +5,6 @@
 
 @const let a: Bool = Bool.random()
 // expected-error@-1 {{'@const' value should be initialized with a compile-time value}}
-// expected-error@-2 {{global variable must be a compile-time constant}} // Remove this once we common out the diagnostics
 
 func foo() -> Int {
 	return 42 * Int.random(in: 0 ..< 10)
@@ -13,4 +12,3 @@ func foo() -> Int {
 
 @const let b: Int = foo()
 // expected-error@-1 {{'@const' value should be initialized with a compile-time value}}
-// expected-error@-2 {{global variable must be a compile-time constant}} // Remove this once we common out the diagnostics

--- a/test/ConstValues/SectionOnError.swift
+++ b/test/ConstValues/SectionOnError.swift
@@ -1,0 +1,3 @@
+// RUN: %target-swift-frontend -emit-ir %s -verify
+// Ensure that we do not diagnose an inability to statically-initialize globals when they contain a prior (in the compilation pipeline) error
+@section("__TEXT,__mysection") var tooBig: Int = 10000000000000000000000000000000000000 //expected-error {{integer literal '10000000000000000000000000000000000000' overflows when stored into 'Int'}}

--- a/test/IRGen/section_non_const.swift
+++ b/test/IRGen/section_non_const.swift
@@ -7,14 +7,14 @@
 
 @section("__TEXT,__mysection") var g0: Int = 1
 @section("__TEXT,__mysection") var g1: (Int, Int) = (1, 2)
-@section("__TEXT,__mysection") var g2: [Int] = [1, 2, 3] // expected-error {{global variable must be a compile-time constant to use @section attribute}}
+@section("__TEXT,__mysection") var g2: [Int] = [1, 2, 3]
 // expected-error@-1 {{'@const' value should be initialized with a compile-time value}}
-@section("__TEXT,__mysection") var g3: [Int:Int] = [:] // expected-error {{global variable must be a compile-time constant to use @section attribute}}
+@section("__TEXT,__mysection") var g3: [Int:Int] = [:]
 // expected-error@-1 {{'@const' value should be initialized with a compile-time value}}
 @section("__TEXT,__mysection") var g4: UInt = 42
-@section("__TEXT,__mysection") var g5: String = "hello" // expected-error {{global variable must be a compile-time constant to use @section attribute}}
+@section("__TEXT,__mysection") var g5: String = "hello"
 // expected-error@-1 {{'@const' value should be initialized with a compile-time value}}
-@section("__TEXT,__mysection") var g6: Any = 1 // expected-error {{global variable must be a compile-time constant to use @section attribute}}
+@section("__TEXT,__mysection") var g6: Any = 1
 // expected-error@-1 {{'@const' value should be initialized with a compile-time value}}
 @section("__TEXT,__mysection") var g7: UInt8 = 42
 @section("__TEXT,__mysection") var g8: Int = 5 * 5
@@ -28,7 +28,7 @@
 struct MyStruct1 {
     var a: [Int]
 }
-@section("__TEXT,__mysection") var g_MyStruct1: MyStruct1 = MyStruct1(a: [1, 2, 3]) // expected-error {{global variable must be a compile-time constant to use @section attribute}}
+@section("__TEXT,__mysection") var g_MyStruct1: MyStruct1 = MyStruct1(a: [1, 2, 3])
 // expected-error@-1 {{'@const' value should be initialized with a compile-time value}}
 
 struct MyStruct2 {
@@ -61,7 +61,7 @@ struct MyStruct4 {
         self.a = a
     }
 }
-@section("__TEXT,__mysection") var g_MyStruct4: MyStruct4 = MyStruct4(a: 42) // expected-error {{global variable must be a compile-time constant to use @section attribute}}
+@section("__TEXT,__mysection") var g_MyStruct4: MyStruct4 = MyStruct4(a: 42)
 // expected-error@-1 {{'@const' value should be initialized with a compile-time value}}
 
 struct MyStruct5 {
@@ -87,7 +87,7 @@ struct MyStruct6 {
         self.a = (SubStruct(x: a), SubStruct(x: a))
     }
 }
-@section("__TEXT,__mysection") var g_MyStruct6: MyStruct6 = MyStruct6(a: 42) // expected-error {{global variable must be a compile-time constant to use @section attribute}}
+@section("__TEXT,__mysection") var g_MyStruct6: MyStruct6 = MyStruct6(a: 42)
 // expected-error@-1 {{'@const' value should be initialized with a compile-time value}}
 
 @section("__TEXT,__mysection") var gp1: UnsafeMutablePointer<Int>? = nil


### PR DESCRIPTION
- **Explanation**: If we encounter an error prior to checking whether `@section` globals are initialized to constants, the compiler would emit diagnostics that are very likely to be false positives. Suppress diagnostics in these erroneous cases.
- **Scope**: Limited to the checking of new features that require constant initialization, e.g., `@section`.
- **Issues**: rdar://172195372
- **Original PRs**: https://github.com/swiftlang/swift/pull/87798
- **Risk**: Very low. Disables a cascading diagnostic.
- **Testing**: CI, and fully qualified on `main` already.
- **Reviewers**: @artemcm (original author), @eeckstein 
