### PR TITLE
[CSRanking] Don't treat functions that are generic only over typed throws as generic

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4553,6 +4553,11 @@ unsigned getNumApplications(bool hasAppliedSelf,
 /// Determine whether the debug output is enabled for the given target.
 bool debugConstraintSolverForTarget(ASTContext &C,
                                     SyntacticElementTarget target);
+
+/// Determine whether the given declaration is only generic because it
+/// adopted typed throws.
+bool isGenericOnlyOverThrownType(AbstractFunctionDecl *func);
+
 } // end namespace constraints
 
 /// If the expression has the effect of a forced downcast, find the

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -579,8 +579,13 @@ bool CompareDeclSpecializationRequest::evaluate(
   // A non-generic declaration is more specialized than a generic declaration.
   if (auto func1 = dyn_cast<AbstractFunctionDecl>(decl1)) {
     auto func2 = cast<AbstractFunctionDecl>(decl2);
-    if (func1->hasGenericParamList() != func2->hasGenericParamList())
-      return completeResult(func2->hasGenericParamList());
+    bool func1IsGeneric =
+        func1->hasGenericParamList() && !isGenericOnlyOverThrownType(func1);
+    bool func2IsGeneric =
+        func2->hasGenericParamList() && !isGenericOnlyOverThrownType(func2);
+
+    if (func1IsGeneric != func2IsGeneric)
+      return completeResult(func2IsGeneric);
   }
 
   if (auto subscript1 = dyn_cast<SubscriptDecl>(decl1)) {

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1235,18 +1235,8 @@ tryOptimizeGenericDisjunction(ConstraintSystem &cs, Constraint *disjunction,
     // If a function has been converted to typed throws, let's ignore it
     // when it's generic only over a thrown type now just like we would
     // regular `throws` version.
-    if (auto thrownType = AFD->getThrownInterfaceType()) {
-      auto genericParams = AFD->getGenericParams();
-      // If there is only one generic parameter, check if it appears
-      // inside of thrown type i.e. `throws(E)` or `throws(MyError<E>)`.
-      if (thrownType->hasTypeParameter() && genericParams->size() == 1) {
-        auto paramTy =
-            genericParams->getParams().front()->getDeclaredInterfaceType();
-        if (thrownType.findIf(
-                [&paramTy](Type type) { return type->isEqual(paramTy); }))
-          return false;
-      }
-    }
+    if (isGenericOnlyOverThrownType(AFD))
+      return false;
 
     auto funcType = AFD->getInterfaceType();
     auto hasAnyOrOptional = funcType.findIf([](Type type) -> bool {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5349,3 +5349,23 @@ bool constraints::isResultBuilderMethodReference(ASTContext &ctx,
     return UDE->getName().compare(DeclNameRef(methodId)) == 0;
   });
 }
+
+bool constraints::isGenericOnlyOverThrownType(AbstractFunctionDecl *func) {
+  // If a function has been converted to typed throws, let's ignore it
+  // when it's generic only over a thrown type now just like we would
+  // regular `throws` version.
+  auto thrownType = func->getThrownInterfaceType();
+  if (!thrownType || !thrownType->hasTypeParameter())
+    return false;
+
+  // If there is only one generic parameter, check if it appears
+  // inside of thrown type i.e. `throws(E)` or `throws(MyError<E>)`.
+
+  auto genericParams = func->getGenericParams();
+  if (genericParams->size() != 1)
+    return false;
+
+  auto paramTy = genericParams->getParams().front()->getDeclaredInterfaceType();
+  return thrownType.findIf(
+      [&paramTy](Type type) { return type->isEqual(paramTy); });
+}

--- a/test/Concurrency/typed_throws.swift
+++ b/test/Concurrency/typed_throws.swift
@@ -21,3 +21,20 @@ func testAsyncFor<S: AsyncSequence>(seq: S) async throws(MyError)
   for try await _ in seq {
   }
 }
+
+do {
+  struct Test {
+    func compute(_: () async throws -> Void) async rethrows {} // expected-note {{found this candidate}}
+    func compute<E>(_: () throws(E) -> Void) throws(E) {} // expected-note {{found this candidate}}
+  }
+
+  func test(_: @Sendable (Test) async throws -> Void) {}
+
+  func unrelated() async {}
+
+  // The solutions are incomparable because rethrows version cannot be called through typed throws one.
+  test {
+    await unrelated()
+    $0.compute {} // expected-error {{ambiguous use of 'compute'}}
+  }
+}


### PR DESCRIPTION
Adopting typed throws on previously non-generic function (the
one that doesn't have any direct generic parameters) affects
ranking because declaration is now considered to be generic
and so is less specialized than an overload that still hasn't
adopted typed throws and isn't otherwise generic. This is
problematic for situations when overloads differ in `async`.

<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
