### PR TITLE
Use unversioned triples on OpenBSD.

### DIFF
--- a/cmake/modules/SwiftConfigureSDK.cmake
+++ b/cmake/modules/SwiftConfigureSDK.cmake
@@ -451,6 +451,7 @@ macro(configure_sdk_unix name architectures)
         message(STATUS "OpenBSD Version: ${openbsd_system_version}")
 
         set(SWIFT_SDK_OPENBSD_ARCH_${arch}_TRIPLE "${arch}-unknown-openbsd${openbsd_system_version}")
+        set(SWIFT_SDK_OPENBSD_ARCH_${arch}_MODULE "${arch}-unknown-openbsd")
 
         add_link_options("LINKER:-z,origin")
 

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -463,13 +463,8 @@ llvm::Triple swift::getTargetSpecificModuleTriple(const llvm::Triple &triple) {
                         triple.getOSName(), environment);
   }
 
-  if (triple.isOSFreeBSD()) {
+  if (triple.isOSFreeBSD() || triple.isOSOpenBSD()) {
     return swift::getUnversionedTriple(triple);
-  }
-
-  if (triple.isOSOpenBSD()) {
-    StringRef arch = swift::getMajorArchitectureName(triple);
-    return llvm::Triple(arch, triple.getVendorName(), triple.getOSName());
   }
 
   // Other platforms get no normalization.


### PR DESCRIPTION
Prior to this change, we used versioned triples on this platform. However, swift-build and the planned future migrations effectively constrain the platform to abandon this module naming scheme.

Ideally, we would look for a swiftmodule named after the versioned triple, then fall back to the unversioned triple, or vice versa. However, this is not straightforward to do, and/or would induce a larger change. It transpired that it was more straightforward to just convert, despite reservations and modules generated on earlier versions requiring recompilation in the future. Because the install base for the platform is likely few, tackle the work to implement the fallback later and just get this quickly done first, especially so we can hopefully make the cut to have this incorporated in 6.3.
