### PR TITLE
StackNesting: don't mark pending allocations [non_nested]

### DIFF
--- a/lib/SIL/Verifier/FlowSensitiveVerifier.cpp
+++ b/lib/SIL/Verifier/FlowSensitiveVerifier.cpp
@@ -422,9 +422,18 @@ void swift::silverifier::verifyFlowSensitiveRules(SILFunction *F) {
         continue;
 
       if (term->isFunctionExiting()) {
-        require(state.Stack.empty(),
-                "return with stack allocs that haven't been deallocated");
-        require(state.ActiveOps.empty(), "return with operations still active");
+        if (!state.Stack.empty()) {
+          verificationFailure("return with stack allocs that haven't been deallocated",
+                              term, [&](SILPrintContext &ctx) {
+            state.printStack(ctx, "current stack");
+          });
+        }
+        if (!state.ActiveOps.empty()) {
+          verificationFailure("return with operations still active",
+                              term, [&](SILPrintContext &ctx) {
+            state.printActiveOps(ctx, "current active operation set");
+          });
+        }
         require(!state.GotAsyncContinuation,
                 "return with unawaited async continuation");
 

--- a/lib/SILOptimizer/Utils/StackNesting.cpp
+++ b/lib/SILOptimizer/Utils/StackNesting.cpp
@@ -245,15 +245,20 @@ namespace {
 enum class AllocationStatus {
   /// No deallocation has been processed for this allocation.
   Allocated,
+  /// No deallocation has been processed for this allocation, but it
+  /// was live across a non-reorderable deallocation, so the allocation
+  /// is going to end up being marked [non_nested].
+  AllocatedAndNonNested,
   /// A deallocation has been processed for this allocation, but the
   /// allocation was not at the top of the stack, so the deallocation
   /// has been deferred.
   Pending,
   /// A deallocation has been processed / emitted for this allocation.
   /// This state usually does not need to be represented explicitly because
-  /// we also remove the allocation from the stack. However, non-reorderable
-  /// deallocations mean we sometimes will have encountered or emitted
-  /// deallocations while higher allocations are still outstanding.
+  /// we normally remove the allocation from the stack whenever we emit its
+  /// deallocation. However, non-reorderable deallocations mean we sometimes
+  /// will have encountered or emitted deallocations while higher allocations
+  /// are still outstanding.
   /// (This state is not described in the correctness proof.)
   Deallocated,
   /// The allocation cannot be deallocated because there was a stack
@@ -265,12 +270,14 @@ enum class AllocationStatus {
 
 static bool isAllocatedOrUndeallocatable(AllocationStatus status) {
   return status == AllocationStatus::Allocated ||
+         status == AllocationStatus::AllocatedAndNonNested ||
          status == AllocationStatus::Undeallocatable;
 }
 
 static StringRef getNameForStatus(AllocationStatus status) {
   switch (status) {
   case AllocationStatus::Allocated: return "allocated";
+  case AllocationStatus::AllocatedAndNonNested: return "allocated-non-nested";
   case AllocationStatus::Pending: return "pending";
   case AllocationStatus::Deallocated: return "deallocated";
   case AllocationStatus::Undeallocatable: return "undeallocatable";
@@ -279,7 +286,7 @@ static StringRef getNameForStatus(AllocationStatus status) {
 }
 
 class ActiveAllocation {
-  llvm::PointerIntPair<SILInstruction*, 2, AllocationStatus> valueAndStatus;
+  llvm::PointerIntPair<SILInstruction*, 3, AllocationStatus> valueAndStatus;
 
 public:
   explicit ActiveAllocation(SILInstruction *value)
@@ -298,9 +305,16 @@ public:
     valueAndStatus.setInt(AllocationStatus::Pending);
   }
 
+  void setNonNested() {
+    assert(getStatus() == AllocationStatus::Allocated);
+    valueAndStatus.setInt(AllocationStatus::AllocatedAndNonNested);
+  }
+
   void setDeallocated(bool expectPending) {
-    assert(expectPending ? getStatus() == AllocationStatus::Pending
-                         : getStatus() == AllocationStatus::Allocated);
+    assert(expectPending
+             ? getStatus() == AllocationStatus::Pending
+             : (getStatus() == AllocationStatus::Allocated ||
+                getStatus() == AllocationStatus::AllocatedAndNonNested));
     valueAndStatus.setInt(AllocationStatus::Deallocated);
   }
 
@@ -528,6 +542,7 @@ static void emitPendingDeallocations(State &state,
 
     // Stop if we see an allocation with a different status.
     case AllocationStatus::Allocated:
+    case AllocationStatus::AllocatedAndNonNested:
     case AllocationStatus::Undeallocatable:
       return;
     }
@@ -536,7 +551,46 @@ static void emitPendingDeallocations(State &state,
 }
 
 /// We've found a deallocation for an allocation that is not the top of
-/// the stack and which cannot be reordered.
+/// the stack and which cannot be reordered. Mark this allocation as
+/// already deallocated and process every non-deallocated allocation
+/// above it on the stack: immediately emit any pending deallocations,
+/// and flag outstanding allocations as [non_nested] and requiring
+/// immediate deallocation.
+///
+/// We need to be able to mark allocations as [non_nested] if they cross
+/// the non-reorderable deallocation. That's just the unfortunate reality
+/// of non-reorderable allocations existing. Emitting pending deallocations
+/// immediately allows us to avoid marking allocations as [non_nested] when
+/// they're still properly nested w.r.t any non-reorderable deallocations(*).
+/// Requiring immediate deallocation for outstanding allocations is necessary
+/// to preserve consistency.
+///
+/// (*) This is good both because it avoids potentially moving them to the
+///     heap and because it allows us to not have to support marking
+///     certain allocations as [non_nested] at all. Allocations that are
+///     emitted by SILGen and never by SIL passes don't end up improperly
+///     nested in the first place because SILGen uses lexical scopes that
+///     are naturally nested in source.
+///
+/// The hand-wavey consistency argument here is that joint post-dominance
+/// on the allocation and the non-reorderable allocation forces two paths
+/// that share a common suffix to either agree about the state of the
+/// allocation at that point or not contain any deallocation of it.
+/// Deallocation cannot be delayed on one path in a way that "inserts" a
+/// deallocation on an overlapping path where it wouldn't occur if the
+/// latter were analyzed instead because that would require disagreement
+/// about the state of the allocation where the paths join, which can
+/// happen neither in terminating paths (because then the paths cannot
+/// agree that the allocation is deallocated at termination) nor in
+/// dead-end paths (because conservative merger will force analysis to
+/// agree that the allocation is undeallocatable).
+///
+/// An alternative approach here that would achieve some of the same goals
+/// would be to recognize allocations that we're going to mark [non_nested]
+/// and just completely avoid changing their deallocations, probably by
+/// undoing the actions of the pass at the last minute for anything in the
+/// unnestedAllocations set. If we used a less online algorithm, we could
+/// also avoid unnecessary delays when these allocations cross others.
 static void handleOutOfOrderDeallocation(State &state,
                                          ActiveAllocation &allocEntry,
                                          SILInstruction *dealloc,
@@ -579,19 +633,31 @@ static void handleOutOfOrderDeallocation(State &state,
       auto sa = i->getValue()->getStackAllocation();
       assert(sa && !isUnreorderableAllocation(*sa));
 #endif
+
+      // Add the allocation to the set that we'll mark [non_nested].
+      // We can't mark it immediately because our main iteration
+      // ignores deallocations of [non_nested] allocations, and we could
+      // get messed up if we do that "re-entrantly" during the loop.
       unnestedAllocations.insert(i->getValue());
+
+      // Change the state of the allocation so that we'll leave
+      // any future deallocations alone.
+      i->setNonNested();
+
       continue;
     }
 
-    // Ignore allocations that have already been emitted.
+    // Ignore allocations that have already been emitted or that are already
+    // [non_nested].
     case AllocationStatus::Deallocated:
+    case AllocationStatus::AllocatedAndNonNested:
       continue;
 
     // Undeallocatable allocations are a prefix, so since the paired
     // allocation is not undeallocatable and we haven't reached it yet,
     // we cannot see an undeallocatable allocation.
     case AllocationStatus::Undeallocatable:
-      llvm_unreachable("cannot see an undeallocatable allocation");
+      ABORT("cannot see an undeallocatable allocation");
 
     }
     llvm_unreachable("bad kind");
@@ -753,19 +819,21 @@ StackNesting::Changes StackNesting::fixNesting(SILFunction *F) {
         auto status = state.allocations.back().getStatus();
         assert(isAllocatedOrUndeallocatable(status));
 
-        // If the allocation has allocated status, leave the deallocation
-        // alone, pop the record of it off the stack, and pop and emit any
-        // pending allocations beneath it.
+        // If the allocation has allocated status (including non-nested),
+        // leave the deallocation alone, pop the record of it off the stack,
+        // and pop and emit any pending allocations beneath it.
         //
         // In the formal presentation, the state change is
         //   state = STATE_POP(state, alloc)
-        if (status == AllocationStatus::Allocated) {
+        if (status == AllocationStatus::Allocated ||
+            status == AllocationStatus::AllocatedAndNonNested) {
           state.allocations.pop_back();
           emitPendingDeallocations(state, /*after*/ dealloc, madeChanges);
 
         // Otherwise, it must have undeallocatable status; remove the
         // deallocation, but make no changes to the state.
         } else {
+          assert(status == AllocationStatus::Undeallocatable);
           dealloc->eraseFromParent();
           madeChanges = true;
         }
@@ -804,8 +872,16 @@ StackNesting::Changes StackNesting::fixNesting(SILFunction *F) {
         if (status == AllocationStatus::Allocated) {
           entry.setPending();
 
+        // If the allocation has allocated-and-non-nested status, leave the
+        // deallocation alone.
+        } else if (status == AllocationStatus::AllocatedAndNonNested) {
+          entry.setDeallocated(/*allow pending*/ false);
+          continue;
+
         // Otherwise, it has undeallocatable status; just remove the
         // deallocation but make no changes to the state.
+        } else {
+          assert(status == AllocationStatus::Undeallocatable);
         }
 
         // In any case, remove the deallocation.

--- a/lib/SILOptimizer/Utils/StackNesting.cpp
+++ b/lib/SILOptimizer/Utils/StackNesting.cpp
@@ -249,12 +249,13 @@ enum class AllocationStatus {
   /// allocation was not at the top of the stack, so the deallocation
   /// has been deferred.
   Pending,
-  /// A deallocation has been processed for this allocation, but the
-  /// allocation was not at the top of the stack. The deallocation could
-  /// not be deferred, so it was just deallocated out of order, and all
-  /// the active allocations above it were marked as non-nested.
+  /// A deallocation has been processed / emitted for this allocation.
+  /// This state usually does not need to be represented explicitly because
+  /// we also remove the allocation from the stack. However, non-reorderable
+  /// deallocations mean we sometimes will have encountered or emitted
+  /// deallocations while higher allocations are still outstanding.
   /// (This state is not described in the correctness proof.)
-  DeallocatedOutOfOrder,
+  Deallocated,
   /// The allocation cannot be deallocated because there was a stack
   /// mismatch on a branch into the current region (which is dead-end).
   /// Whether a deallocation has been processed for this allocation is
@@ -265,6 +266,16 @@ enum class AllocationStatus {
 static bool isAllocatedOrUndeallocatable(AllocationStatus status) {
   return status == AllocationStatus::Allocated ||
          status == AllocationStatus::Undeallocatable;
+}
+
+static StringRef getNameForStatus(AllocationStatus status) {
+  switch (status) {
+  case AllocationStatus::Allocated: return "allocated";
+  case AllocationStatus::Pending: return "pending";
+  case AllocationStatus::Deallocated: return "deallocated";
+  case AllocationStatus::Undeallocatable: return "undeallocatable";
+  }
+  llvm_unreachable("bad kind");
 }
 
 class ActiveAllocation {
@@ -287,9 +298,10 @@ public:
     valueAndStatus.setInt(AllocationStatus::Pending);
   }
 
-  void setDeallocatedOutOfOrder() {
-    assert(getStatus() == AllocationStatus::Allocated);
-    valueAndStatus.setInt(AllocationStatus::DeallocatedOutOfOrder);
+  void setDeallocated(bool expectPending) {
+    assert(expectPending ? getStatus() == AllocationStatus::Pending
+                         : getStatus() == AllocationStatus::Allocated);
+    valueAndStatus.setInt(AllocationStatus::Deallocated);
   }
 
   void setUndeallocatable() {
@@ -313,9 +325,6 @@ struct State {
   ActiveAllocation &getEntryForNonTop(SILInstruction *alloc,
                                       SILInstruction *dealloc,
                                       IndexForAllocationMap &indexForAllocation);
-
-  void collectAllocationsAbove(SILInstruction *alloc,
-                               SmallPtrSetImpl<SILInstruction*> &set) const;
 
   /// Given that these are the end states of two blocks with edges into
   /// a dead-end region R, merge them.
@@ -354,20 +363,21 @@ struct State {
   SWIFT_ATTRIBUTE_NORETURN
   void abortForUnknownAllocation(SILInstruction *alloc,
                                  SILInstruction *dealloc) {
-    llvm::errs() << "fatal error: StackNesting could not find record of "
-                    "allocation for deallocation:\n  "
-                 << *dealloc
-                 << "Allocation might not be jointly post-dominated. "
-                    "Current stack:\n";
+    auto &out = llvm::errs();
+    out << "fatal error: StackNesting could not find record of "
+           "allocation for deallocation:\n  "
+        << *dealloc
+        << "Allocation might not be jointly post-dominated. "
+           "Current stack:\n";
     for (auto i : indices(allocations)) {
+      out << "[" << i << "] ";
       auto status = allocations[i].getStatus();
-      llvm::errs() << "[" << i << "] "
-                   << (status == AllocationStatus::Allocated ? "" :
-                       status == AllocationStatus::Pending ? "(pending) " :
-                       "(undeallocatable) ")
-                   << *allocations[i].getValue();
+      if (status != AllocationStatus::Allocated) {
+        out << "(" << getNameForStatus(status) << ") ";
+      }
+      out << *allocations[i].getValue() << "\n";
     }
-    llvm::errs() << "Complete function:\n";
+    out << "Complete function:\n";
     alloc->getFunction()->dump();
     abort();
   }
@@ -472,29 +482,6 @@ State::getEntryForNonTop(SILInstruction *alloc,
   return stack[*foundIndexForAlloc];
 }
 
-void State::collectAllocationsAbove(SILInstruction *alloc,
-                         llvm::SmallPtrSetImpl<SILInstruction*> &set) const {
-  auto stack = ArrayRef(allocations);
-  assert(!stack.empty());
-  for (size_t i = stack.size() - 1; true; --i) {
-    // If we reach the target allocation, we've processed all the
-    // allocations above it, so we're done.
-    if (stack[i].getValue() == alloc) break;
-
-    // Add the allocation to the set unless it's flagged as already
-    // deallocated.
-    if (stack[i].getStatus() != AllocationStatus::DeallocatedOutOfOrder) {
-#ifndef NDEBUG
-      auto sa = stack[i].getValue()->getStackAllocation();
-      assert(sa && !isUnreorderableAllocation(*sa));
-#endif
-      set.insert(stack[i].getValue());
-    }
-
-    assert(i != 0 && "didn't find allocation in stack");
-  }
-}
-
 /// Pop and emit deallocations for any allocations on top of the
 /// active allocations stack that are pending deallocation. Also pop
 /// allocations in the deallocated-out-of-order state, but do not
@@ -533,10 +520,8 @@ static void emitPendingDeallocations(State &state,
       continue;
     }
 
-    // Pop allocations with deallocated-out-of-order status, but don't
-    // emit a deallocation for them because we left the original
-    // deallocation in place.
-    case AllocationStatus::DeallocatedOutOfOrder: {
+    // Just pop allocations that already have deallocated status.
+    case AllocationStatus::Deallocated: {
       state.allocations.pop_back();
       continue;
     }
@@ -547,6 +532,69 @@ static void emitPendingDeallocations(State &state,
       return;
     }
     llvm_unreachable("bad state");
+  }
+}
+
+/// We've found a deallocation for an allocation that is not the top of
+/// the stack and which cannot be reordered.
+static void handleOutOfOrderDeallocation(State &state,
+                                         ActiveAllocation &allocEntry,
+                                         SILInstruction *dealloc,
+                         SmallPtrSetImpl<SILInstruction*> &unnestedAllocations) {
+  // Flag that the target allocation is deallocated.
+  allocEntry.setDeallocated(/*expect pending*/ false);
+
+  // The builder we use for inserting deallocations. Initialized lazily
+  // to insert prior to the out-of-order deallocation.
+  std::optional<SILBuilderWithScope> builder;
+
+  // Iterate from the top of the stack down to the paired allocation. We
+  // can't pop anything yet because we might still see deallocations later
+  // for the allocations that are still live, but we do need to transition
+  // literally everything in the suffix.
+  auto i = state.allocations.end();
+  while (true) {
+    assert(i != state.allocations.begin() && "allocEntry not in stack!");
+    --i;
+    if (i == &allocEntry) return;
+
+    switch (i->getStatus()) {
+    // Eagerly emit pending deallocations. We need to insert these in the
+    // reverse of the order we encountered them, which is conveniently
+    // exactly the order we see them as we pop them off the stack.
+    case AllocationStatus::Pending: {
+      if (!builder) {
+        builder.emplace(/*insertion point and inherit scope from*/ dealloc);
+      }
+
+      createDealloc(*builder, dealloc->getLoc(), i->getValue());
+
+      i->setDeallocated(/*expect pending*/ true);
+      continue;
+    }
+
+    // Mark outstanding allocations [non_nested].
+    case AllocationStatus::Allocated: {
+#ifndef NDEBUG
+      auto sa = i->getValue()->getStackAllocation();
+      assert(sa && !isUnreorderableAllocation(*sa));
+#endif
+      unnestedAllocations.insert(i->getValue());
+      continue;
+    }
+
+    // Ignore allocations that have already been emitted.
+    case AllocationStatus::Deallocated:
+      continue;
+
+    // Undeallocatable allocations are a prefix, so since the paired
+    // allocation is not undeallocatable and we haven't reached it yet,
+    // we cannot see an undeallocatable allocation.
+    case AllocationStatus::Undeallocatable:
+      llvm_unreachable("cannot see an undeallocatable allocation");
+
+    }
+    llvm_unreachable("bad kind");
   }
 }
 
@@ -743,8 +791,8 @@ StackNesting::Changes StackNesting::fixNesting(SILFunction *F) {
         // here, and we don't have that information easily at hand.
         if (status == AllocationStatus::Allocated &&
             isUnreorderableAllocation(allocation)) {
-          state.collectAllocationsAbove(alloc, unnestedAllocations);
-          entry.setDeallocatedOutOfOrder();
+          handleOutOfOrderDeallocation(state, entry, dealloc,
+                                       unnestedAllocations);
           continue;
         }
 

--- a/test/SIL/store_borrow_verify_errors.sil
+++ b/test/SIL/store_borrow_verify_errors.sil
@@ -16,7 +16,10 @@ sil @use_guaranteed : $@convention(thin) (@guaranteed Klass) -> ()
 sil @get_owned : $@convention(thin) () -> @owned Klass
 
 // CHECK: Begin Error in function test_missing_end_borrow_single
-// CHECK: SIL verification failed: return with operations still active: state.ActiveOps.empty()
+// CHECK: SIL verification failed: return with operations still active
+// CHECK: current active operation set: [
+// CHECK:      %2 = store_borrow %0 to %1
+// CHECK: ]
 // CHECK: Verifying instruction:
 // CHECK:      %4 = tuple ()                                // user: %5
 // CHECK: ->   return %4 : $()                              // id: %5
@@ -31,7 +34,10 @@ bb0(%0 : @guaranteed $Klass):
 }
 
 // CHECK: Begin Error in function test_missing_end_borrow
-// CHECK: SIL verification failed: return with operations still active: state.ActiveOps.empty()
+// CHECK: SIL verification failed: return with operations still active
+// CHECK: current active operation set: [
+// CHECK:      %2 = store_borrow %0 to %1
+// CHECK: ]
 // CHECK: Verifying instruction:
 // CHECK:      %8 = tuple ()                                // user: %9
 // CHECK: ->   return %8 : $()                              // id: %9

--- a/test/SIL/verifier_reject.sil
+++ b/test/SIL/verifier_reject.sil
@@ -8,7 +8,10 @@
 
 import Builtin
 
-// CHECK: SIL verification failed: return with stack allocs that haven't been deallocated: state.Stack.empty()
+// CHECK:      SIL verification failed: return with stack allocs that haven't been deallocated
+// CHECK-NEXT: current stack: [
+// CHECK-NEXT:   alloc_stack $Builtin.Int32
+// CHECK-NEXT: ] 
 
 sil @fail1: $@convention(thin) (Builtin.Int1) -> () {
 bb0(%0 : $Builtin.Int1):

--- a/test/SILOptimizer/stack-nesting.sil
+++ b/test/SILOptimizer/stack-nesting.sil
@@ -647,3 +647,54 @@ bb0:
   %ret = tuple ()
   return %ret : $()
 }
+
+//   We must not defer deallocations after deciding that they need to be
+//   [non_nested], or else we can get inconsistencies after join points.
+// CHECK-LABEL: sil [ossa] @test_pending_async_let :
+// CHECK:         integer_literal $Builtin.Int32, 1
+// CHECK-NEXT:    [[A:%.*]] = builtin "startAsyncLetWithLocalBuffer"<Int>(
+// CHECK-NEXT:    [[B:%.*]] = alloc_stack [non_nested] $Int
+// CHECK-NEXT:    [[C:%.*]] = alloc_stack [non_nested] $Int
+// CHECK:       bb1:
+//   Note that we've deferred the deallocation of %b (by a single instruction).
+// CHECK-NEXT:    integer_literal $Builtin.Int32, 2
+// CHECK-NEXT:    dealloc_stack [[B]]
+// CHECK-NEXT:    builtin "finishAsyncLet"([[A]], {{.*}})
+// CHECK-NEXT:    br bb3
+// CHECK:       bb2:
+// CHECK-NEXT:    builtin "finishAsyncLet"([[A]], {{.*}})
+// CHECK-NEXT:    dealloc_stack [[B]]
+// CHECK-NEXT:    integer_literal $Builtin.Int32, 3
+// CHECK-NEXT:    br bb3
+// CHECK:       bb3:
+// CHECK-NEXT:    dealloc_stack [[C]]
+// CHECK-NEXT:    integer_literal $Builtin.Int32, 4
+// CHECK-LABEL: // end sil function 'test_pending_async_let'
+sil [ossa] @test_pending_async_let : $@convention(thin) @async (Builtin.Int1) -> () {
+bb0(%cond: $Builtin.Int1):
+  specify_test "stack_nesting_fixup"
+
+  integer_literal $Builtin.Int32, 1
+  %al = builtin "startAsyncLetWithLocalBuffer"<Int>(undef: $Optional<Builtin.RawPointer>, undef: $@convention(thick) @Sendable @async () -> (@out Int, @error any Error), undef: $Builtin.RawPointer) : $Builtin.RawPointer
+  %b = alloc_stack $Int
+  %c = alloc_stack $Int
+  cond_br undef, bb1, bb2
+
+bb1:
+  dealloc_stack %b
+  integer_literal $Builtin.Int32, 2
+  %out = builtin "finishAsyncLet"(%al, undef: $Builtin.RawPointer) : $()
+  br bb3
+
+bb2:
+  %out2 = builtin "finishAsyncLet"(%al, undef: $Builtin.RawPointer) : $()
+  dealloc_stack %b
+  integer_literal $Builtin.Int32, 3
+  br bb3
+
+bb3:
+  dealloc_stack %c
+  integer_literal $Builtin.Int32, 4
+  %ret = tuple ()
+  return %ret : $()
+}

--- a/test/SILOptimizer/stack-nesting.sil
+++ b/test/SILOptimizer/stack-nesting.sil
@@ -324,12 +324,12 @@ bb0(%out : $*Int):
 // CHECK:         [[PTR:%.*]] = address_to_pointer [[A]] to $Builtin.RawPointer
 // CHECK-NEXT:    [[LET:%.*]] = builtin "startAsyncLetWithLocalBuffer"<Int>({{%.*}}, {{%.*}}, [[PTR]])
 // CHECK-NEXT:    integer_literal $Builtin.Int32, 2
-// CHECK-NEXT:    [[B:%.*]] = alloc_stack [non_nested] $Int
+// CHECK-NEXT:    [[B:%.*]] = alloc_stack $Int
 // CHECK-NEXT:    [[C:%.*]] = alloc_stack [non_nested] $Int
 // CHECK-NEXT:    integer_literal $Builtin.Int32, 3
+// CHECK-NEXT:    dealloc_stack [[B]]
 // CHECK-NEXT:    builtin "finishAsyncLet"([[LET]], [[PTR]])
 // CHECK-NEXT:    dealloc_stack [[C]]
-// CHECK-NEXT:    dealloc_stack [[B]]
 // CHECK-NEXT:    dealloc_stack [[A]]
 // CHECK-NEXT:    integer_literal $Builtin.Int32, 4
 // CHECK-LABEL: // end sil function 'test_async_let_non_nested'
@@ -428,14 +428,14 @@ bb0:
 // CHECK-NEXT:    [[A:%.*]] = alloc_stack $Int
 // CHECK:         [[HANDLER:%.*]] = builtin "taskAddCancellationHandler"({{%.*}})
 // CHECK-NEXT:    integer_literal $Builtin.Int32, 2
-// CHECK-NEXT:    [[B:%.*]] = alloc_stack [non_nested] $Int
+// CHECK-NEXT:    [[B:%.*]] = alloc_stack $Int
 // CHECK-NEXT:    [[C:%.*]] = alloc_stack [non_nested] $Int
 // CHECK-NEXT:    [[D:%.*]] = alloc_stack $Int
 // CHECK-NEXT:    dealloc_stack [[D]]
 // CHECK-NEXT:    integer_literal $Builtin.Int32, 3
+// CHECK-NEXT:    dealloc_stack [[B]]
 // CHECK-NEXT:    builtin "taskRemoveCancellationHandler"([[HANDLER]])
 // CHECK-NEXT:    dealloc_stack [[C]]
-// CHECK-NEXT:    dealloc_stack [[B]]
 // CHECK-NEXT:    dealloc_stack [[A]]
 // CHECK-NEXT:    integer_literal $Builtin.Int32, 4
 // CHECK-LABEL: // end sil function 'test_cancellation_non_nested'
@@ -480,14 +480,14 @@ bb0(%0 : $UInt8, %1 : $UInt8):
 // CHECK-NEXT:    [[A:%.*]] = alloc_stack $Int
 // CHECK:         [[HANDLER:%.*]] = builtin "taskAddPriorityEscalationHandler"({{%.*}})
 // CHECK-NEXT:    integer_literal $Builtin.Int32, 2
-// CHECK-NEXT:    [[B:%.*]] = alloc_stack [non_nested] $Int
+// CHECK-NEXT:    [[B:%.*]] = alloc_stack $Int
 // CHECK-NEXT:    [[C:%.*]] = alloc_stack [non_nested] $Int
 // CHECK-NEXT:    [[D:%.*]] = alloc_stack $Int
 // CHECK-NEXT:    dealloc_stack [[D]]
 // CHECK-NEXT:    integer_literal $Builtin.Int32, 3
+// CHECK-NEXT:    dealloc_stack [[B]]
 // CHECK-NEXT:    builtin "taskRemovePriorityEscalationHandler"([[HANDLER]])
 // CHECK-NEXT:    dealloc_stack [[C]]
-// CHECK-NEXT:    dealloc_stack [[B]]
 // CHECK-NEXT:    dealloc_stack [[A]]
 // CHECK-NEXT:    integer_literal $Builtin.Int32, 4
 // CHECK-LABEL: // end sil function 'test_priority_non_nested'
@@ -608,14 +608,14 @@ bb0:
 // CHECK-NEXT:    [[A:%.*]] = alloc_stack $Int
 // CHECK:         [[BINDING:%.*]] = builtin "addTaskLocalValue"<Int>({{.*}}, [[A]])
 // CHECK-NEXT:    integer_literal $Builtin.Int32, 2
-// CHECK-NEXT:    [[B:%.*]] = alloc_stack [non_nested] $Int
+// CHECK-NEXT:    [[B:%.*]] = alloc_stack $Int
 // CHECK-NEXT:    [[C:%.*]] = alloc_stack [non_nested] $Int
 // CHECK-NEXT:    [[D:%.*]] = alloc_stack $Int
 // CHECK-NEXT:    dealloc_stack [[D]]
 // CHECK-NEXT:    integer_literal $Builtin.Int32, 3
+// CHECK-NEXT:    dealloc_stack [[B]]
 // CHECK-NEXT:    builtin "removeTaskLocalValue"([[BINDING]])
 // CHECK-NEXT:    dealloc_stack [[C]]
-// CHECK-NEXT:    dealloc_stack [[B]]
 // CHECK-NEXT:    dealloc_stack [[A]]
 // CHECK-NEXT:    integer_literal $Builtin.Int32, 4
 // CHECK-LABEL: // end sil function 'test_task_local_non_nested'


### PR DESCRIPTION
Instead, just emit them immediately when we encounter a non-reorderable deallocation. Credit for this idea goes to Michael Gottesman.

This is a nice optimization; it avoids marking a lot of allocations as [non_nested] unnecessarily. But by not marking allocations that are well-nested w.r.t the non-reorderable deallocation, it also means we never need to mark allocations that were emitted well-ordered and never fell out of order. That should actually achieve the intuition I had with the earlier work that it was okay to not support marking certain stack allocations that are never introduced directly by the SIL optimizer.