### PR TITLE
LifetimeDependence: Do not check witness method lifetimes in associated type inference

### DIFF
--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -2530,8 +2530,13 @@ AssociatedTypeInference::getPotentialTypeWitnessesByMatchingTypes(ValueDecl *req
       [&](const LifetimeDependentInterface &witnessInterface,
           const LifetimeDependentInterface &reqInterface)
       -> std::optional<RequirementMatch> {
-    if (!witnessInterface.canConvertTo(reqInterface))
-      return RequirementMatch(witness, MatchKind::LifetimeConflict);
+    // Mismatched lifetime dependencies should not be necessary to rule out a
+    // candidate associated type, except in contrived cases.
+    //
+    // Matching lifetimes accurately requires a constraint system (see
+    // ConstraintSystem::matchFunctionLifetimes). This is performed during value
+    // witness matching, when it is necessary (see both overloads of
+    // swift::matchWitness in TypeCheckProtocol.cpp)
     return std::nullopt;
   };
 

--- a/test/decl/protocol/conforms/lifetime.swift
+++ b/test/decl/protocol/conforms/lifetime.swift
@@ -315,6 +315,20 @@ struct S157801454 : P157801454 { // expected-error{{type 'S157801454' does not c
   }
 }
 
+// MARK: rdar://173716835, Associated type inference with lifetimes
+protocol IterProtocol<Element> {
+  associatedtype Element
+  mutating func next() -> Self.Element?
+}
+
+struct Iter<T: ~Escapable>: ~Escapable {
+  @_lifetime(copy self)
+  mutating func next() -> T? { fatalError() }
+}
+extension Iter: Escapable where T: Escapable {}
+extension Iter: IterProtocol where T: Escapable {} // OK: Dependencies are ignored when the target is Escapable
+
+
 // MARK: Simultaneous conformance to conflicting protocols
 protocol CopyF: ~Escapable {
   @_lifetime(copy self)


### PR DESCRIPTION
rdar://173716835
Lifetimes only need to be checked in value witness matching, not type witness matching.
<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
