### PR TITLE
[Concurrency] regression test for async deinit in generic actor

### DIFF
--- a/test/SILGen/deinit_isolation_generic.swift
+++ b/test/SILGen/deinit_isolation_generic.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -target %target-future-triple -parse-as-library -emit-silgen %s
+
+// Also check if there's any weird accidental interactions with modes which affect default isolation:
+// RUN: %target-swift-frontend -target %target-future-triple -parse-as-library -emit-silgen %s -enable-upcoming-feature NonisolatedNonsendingByDefault
+// RUN: %target-swift-frontend -target %target-future-triple -parse-as-library -emit-silgen %s -enable-upcoming-feature NonisolatedNonsendingByDefault -default-isolation=MainActor
+
+// REQUIRES: concurrency
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
+
+// Isolated deinit was wrongly passed generic substitution map in SIL, which would then crash.
+
+@MainActor
+final class GenericMainActorClass<T> {
+  isolated deinit {}
+}
+
+actor GenericActor<T> {
+  isolated deinit {}
+}


### PR DESCRIPTION
This actually was fixed already in
https://github.com/swiftlang/swift/commit/e09363644d7 just adding more modes coverage for it in normal test/ rather than just a validation test, and with a global actor as well.

Refs rdar://173740679
Refs rdar://171398563
Refs https://github.com/swiftlang/swift/issues/88197