### PR TITLE
Wasm: fix build issues and test failures on macOS

### DIFF
--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -197,10 +197,12 @@ set(EMBEDDED_STDLIB_TARGET_TRIPLES)
 
 if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING)
   if(SWIFT_WASI_SYSROOT_PATH)
-    # Don't attempt to build any other Embedded Swift stdlib triples
-    # when building for WASI.
+    # Also include none-wasm triples, which don't require a sysroot.
+    # Skip non-Wasm targets.
     list(APPEND EMBEDDED_STDLIB_TARGET_TRIPLES
-      "wasm32    wasm32-unknown-wasip1  wasm32-unknown-wasip1"
+      "wasm32    wasm32-unknown-wasip1    wasm32-unknown-wasip1"
+      "wasm32    wasm32-unknown-none-wasm  wasm32-unknown-none-wasm"
+      "wasm64    wasm64-unknown-none-wasm  wasm64-unknown-none-wasm"
     )
   else()
     if("ARM" IN_LIST LLVM_TARGETS_TO_BUILD)

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -308,6 +308,11 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
     set(extra_c_compile_flags)
     set(extra_swift_compile_flags)
 
+    # Skip Concurrency for freestanding Wasm (no libc/libc++ available).
+    if("${triple}" MATCHES "-none-wasm$")
+      continue()
+    endif()
+
     if (SWIFT_HOST_VARIANT STREQUAL "linux")
       if(NOT "${mod}" MATCHES "-linux-gnu$")
         continue()

--- a/test/embedded/wasm/classes.swift
+++ b/test/embedded/wasm/classes.swift
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
-// RUN: %target-swift-frontend -c %t/check.swift -parse-as-library -target wasm32-unknown-none-wasm \
+// RUN: %swift-frontend -c %t/check.swift -parse-as-library -target wasm32-unknown-none-wasm \
+// RUN:   -resource-dir %test-resource-dir \
 // RUN:   -enable-experimental-feature Embedded -Xcc -fdeclspec -disable-stack-protector \
 // RUN:   -o %t/check.o
 // RUN: %clang -target wasm32-unknown-none-wasm %t/check.o %t/rt.c -nostdlib -o %t/check.wasm

--- a/test/embedded/wasm/classes.swift
+++ b/test/embedded/wasm/classes.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
-// RUN: %swift-frontend -c %t/check.swift -parse-as-library -target wasm32-unknown-none-wasm \
+// RUN: %target-swift-frontend -c %t/check.swift -parse-as-library -target wasm32-unknown-none-wasm \
 // RUN:   -enable-experimental-feature Embedded -Xcc -fdeclspec -disable-stack-protector \
 // RUN:   -o %t/check.o
 // RUN: %clang -target wasm32-unknown-none-wasm %t/check.o %t/rt.c -nostdlib -o %t/check.wasm

--- a/utils/swift_build_support/swift_build_support/products/wasisysroot.py
+++ b/utils/swift_build_support/swift_build_support/products/wasisysroot.py
@@ -181,6 +181,10 @@ class WASISysroot(product.Product):
         cmake.cmake_options.define('CMAKE_INSTALL_LIBDIR:PATH', '/lib')
         cmake.cmake_options.define('CMAKE_BUILD_TYPE:STRING', self.args.build_variant)
         cmake.cmake_options.define('CMAKE_C_COMPILER:FILEPATH', cc_path)
+        cmake.cmake_options.define('CMAKE_C_COMPILER_TARGET:STRING', target_triple)
+        # wasi-libc IS the C library, so there's nothing to link against during
+        # CMake's compiler check. Skip it.
+        cmake.cmake_options.define('CMAKE_C_COMPILER_WORKS:BOOL', 'TRUE')
         cmake.cmake_options.define('CMAKE_AR:FILEPATH', ar_path)
         cmake.cmake_options.define('CMAKE_NM:FILEPATH', nm_path)
         cmake.cmake_options.define('CMAKE_RANLIB:FILEPATH', ranlib_path)


### PR DESCRIPTION
**Explanation**: Multiple issues fixed here that prevent building Wasm Swift SDK on macOS:
1. After bumping WASI-libc to `wasi-sdk-31` tag, while building `compiler-rt`, `CMAKE_C_COMPILER_TARGET` is not set correctly, and `CMAKE_C_COMPILER_WORKS` should skip failing checks.
2. When building Swift SDKs, passing `SWIFT_WASI_SYSROOT_PATH` excludes `wasm32-unknown-none-wasm` Embedded Swift triple from building, which makes it hard to experiment with Wasm features like components that shouldn't have dependencies on `wasip1` ABI.
3. Now with `wasm32-unknown-none-wasm` triple present, `test/embedded/wasm/classes.swift` can pass, but it needs `test-resource-dir`.

**Scope**: limited to Wasm builds;
**Risk**: low due to limited scope;
**Testing**: manually tested on macOS, tested for regressions on Linux on CI;
**Issue**: rdar://173926794.
