### PR TITLE
[cxx-interop] Fix "Failed to reconstruct type" assertion for `NS_OPTIONS` types

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3873,6 +3873,29 @@ void ClangImporter::lookupTypeDecl(
     }
   }
 
+  // In C++ language mode, CF_OPTIONS/NS_OPTIONS have a different expansion. If
+  // the tag lookup didn't find anything, try an ordinary name lookup for the
+  // typedef and resolve it to the anonymous enum.
+  if (!foundViaClang && kind == ClangTypeKind::Tag &&
+      !Impl.DisableSourceImport &&
+      Impl.SwiftContext.LangOpts.EnableCXXInterop) {
+    clang::LookupResult lookupResult(sema, clangName, clang::SourceLocation(),
+                                     clang::Sema::LookupOrdinaryName);
+    if (sema.LookupName(lookupResult, /*Scope=*/sema.TUScope)) {
+      for (auto clangDecl : lookupResult) {
+        if (auto typedefDecl = dyn_cast<clang::TypedefNameDecl>(clangDecl)) {
+          auto qualType = Impl.getClangASTContext().getTypedefType(typedefDecl);
+          if (auto optionSetEnum = findOptionSetEnum(qualType, Impl)) {
+            if (auto typeDecl = optionSetEnum.getType()->getAnyNominal()) {
+              foundViaClang = true;
+              receiver(typeDecl);
+            }
+          }
+        }
+      }
+    }
+  }
+
   // If Clang couldn't find the type, query the DWARFImporterDelegate.
   if (!foundViaClang)
     Impl.lookupTypeDeclDWARF(rawName, kind, receiver);

--- a/test/Interop/Cxx/objc-correctness/ns-options-mangling.swift
+++ b/test/Interop/Cxx/objc-correctness/ns-options-mangling.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -I %S/Inputs -c -cxx-interoperability-mode=swift-5.9 %s -S -o - | %FileCheck %s
+// RUN: %target-swift-frontend -I %S/Inputs -c -cxx-interoperability-mode=swift-5.9 -g %s -S -o - | %FileCheck %s
 // RUN: %target-swift-frontend -I %S/Inputs -c %s -S -o - | %FileCheck %s
 
 // REQUIRES: objc_interop
@@ -9,3 +10,5 @@
 import NSOptionsMangling
 protocol Fooable { }
 extension UIControl.State: Fooable {}
+
+func foo(_ s: UIControl.State) {}


### PR DESCRIPTION
This fixes the following assertion failure when building with debug info:
```
Abort: function getMangledName at IRGenDebugInfo.cpp:1098
Failed to reconstruct type for $sSo20NSDataWritingOptionsVmD
```

This assertion started triggering after d4869193, which enabled stricter coherency checks for types imported from C++.

`NS_OPTIONS` types are special in C++, because the `NS_OPTIONS`/`CF_OPTIONS` macro has a different expansion in C++ language mode.

rdar://172418942

<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
