### PR TITLE
[cxx-interop] Fix lookup for friend methods within namespaces

### DIFF
--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -1987,9 +1987,23 @@ void importer::addEntryToLookupTable(SwiftLookupTable &table,
           clang::ObjCProtocolDecl, clang::ObjCCategoryDecl>(named)) {
     clang::DeclContext *dc = cast<clang::DeclContext>(named);
     for (auto member : dc->decls()) {
-      if (auto friendDecl = dyn_cast<clang::FriendDecl>(member))
-        if (auto underlyingDecl = friendDecl->getFriendDecl())
+      if (auto friendDecl = dyn_cast<clang::FriendDecl>(member)) {
+        if (auto underlyingDecl = friendDecl->getFriendDecl()) {
+          // Skip non-member friend function declarations that were introduced
+          // solely by the friend declaration and don't have an inline body.
+          // In C++, these are only visible through argument-dependent lookup,
+          // and should not be imported as members of the enclosing namespace
+          // in Swift. However, friend functions with inline definitions must
+          // still be imported, since they are the only declaration of the
+          // function and Swift does not have ADL.
+          if (auto *funcDecl = dyn_cast<clang::FunctionDecl>(underlyingDecl))
+            if (funcDecl->getFriendObjectKind() ==
+                    clang::Decl::FriendObjectKind::FOK_Undeclared &&
+                !funcDecl->doesThisDeclarationHaveABody())
+              continue;
           member = underlyingDecl;
+        }
+      }
 
       if (auto namedMember = dyn_cast<clang::NamedDecl>(member))
         addEntryToLookupTable(table, namedMember, nameImporter);

--- a/test/Interop/Cxx/class/Inputs/friend-function.h
+++ b/test/Interop/Cxx/class/Inputs/friend-function.h
@@ -1,0 +1,16 @@
+namespace NS {
+struct MyString;
+}
+
+NS::MyString makeMyString();
+
+namespace NS {
+struct MyString {
+public:
+  int val;
+
+private:
+  MyString();
+  friend NS::MyString makeMyString();
+};
+} // namespace NS

--- a/test/Interop/Cxx/class/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/Inputs/module.modulemap
@@ -178,3 +178,9 @@ module SuppressibleProtocols {
   requires cplusplus
   export *
 }
+
+module FriendFunction {
+  header "friend-function.h"
+  requires cplusplus
+  export *
+}

--- a/test/Interop/Cxx/class/friend-function-typechecker.swift
+++ b/test/Interop/Cxx/class/friend-function-typechecker.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swiftxx-frontend -typecheck -verify -I %S/Inputs %s
+
+// expected-no-diagnostics
+
+// Ensure that a friend function declared inside a nested type does not get
+// incorrectly imported as a member of the enclosing namespace.
+
+import FriendFunction
+
+extension NS {
+  func foo(_ code: (NS.MyString) -> ()) {
+    let _ = makeMyString()
+  }
+}
+
+func bar() {
+  let _ = makeMyString()
+}


### PR DESCRIPTION
This fixes a crash that was happening for calls to C++ methods declared within types that are nested in a namespace.

ClangImporter was adding those methods do the wrong lookup table.

rdar://147000056 / resolves https://github.com/swiftlang/swift/issues/83085

<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
