### PR TITLE
ClangImporter: honour `--sysroot` for C library searches

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -737,19 +737,22 @@ void importer::getNormalInvocationArguments(
       invocationArgStrs.push_back("-isystem");
       invocationArgStrs.push_back(std::string(path.str()));
     } else {
-      // On Darwin, Clang uses -isysroot to specify the include
-      // system root. On other targets, it seems to use --sysroot.
+      // Darwin uses -isysroot; other targets use --sysroot=. The distinction
+      // matters because the Clang driver sets D.SysRoot only from --sysroot=,
+      // not -isysroot. Toolchain helpers such as AddClangSystemIncludeArgs and
+      // AddClangCXXStdlibIncludeArgs read D.SysRoot to build include paths, so
+      // omitting --sysroot= on non-Darwin produces broken paths. The driver
+      // automatically forwards --sysroot= to CC1 as -isysroot.
       if (triple.isOSDarwin()) {
         invocationArgStrs.push_back("-isysroot");
         invocationArgStrs.push_back(searchPathOpts.getSDKPath().str());
       } else {
-        if (auto sysroot = searchPathOpts.getSysRoot()) {
-          invocationArgStrs.push_back("--sysroot");
-          invocationArgStrs.push_back(sysroot->str());
-        } else {
-          invocationArgStrs.push_back("--sysroot");
-          invocationArgStrs.push_back(searchPathOpts.getSDKPath().str());
-        }
+        std::string sysroot;
+        if (auto s = searchPathOpts.getSysRoot())
+          sysroot = s->str();
+        else
+          sysroot = searchPathOpts.getSDKPath().str();
+        invocationArgStrs.emplace_back("--sysroot=" + sysroot);
       }
     }
   }

--- a/lib/ClangImporter/ClangIncludePaths.cpp
+++ b/lib/ClangImporter/ClangIncludePaths.cpp
@@ -192,13 +192,21 @@ ClangImporter::createClangArgs(const ClangImporterOptions &ClangImporterOpts,
   }
   llvm::opt::InputArgList clangDriverArgs =
       parseClangDriverArgs(clangDriver, clangArgs);
-  // If an SDK path was explicitly passed to Swift, make sure to pass it to
-  // Clang driver as well. It affects the resulting include paths.
+  // If a sysroot was explicitly passed to Swift, make sure to pass it to the
+  // Clang driver as well. It affects the resulting include paths. Fall back to
+  // the SDK path when no explicit sysroot is present.
   auto sdkPath = SearchPathOpts.getSDKPath();
   if (!sdkPath.empty())
     clangDriver.SysRoot = sdkPath.str();
   if (auto sysroot = SearchPathOpts.getSysRoot())
     clangDriver.SysRoot = sysroot->str();
+  // An explicit --sysroot= or -isysroot in ExtraArgs takes precedence over
+  // the SDK/sysroot set above; --sysroot= is checked first as the canonical
+  // driver-level form.
+  if (const auto *A = clangDriverArgs.getLastArg(
+          clang::driver::options::OPT__sysroot_EQ,
+          clang::driver::options::OPT_isysroot))
+    clangDriver.SysRoot = A->getValue();
   return clangDriverArgs;
 }
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2243,6 +2243,15 @@ static bool ParseClangImporterArgs(ClangImporterOptions &Opts, ArgList &Args,
   if (const Arg *A = Args.getLastArg(OPT_index_store_path))
     Opts.IndexStorePath = A->getValue();
 
+  // Forward -sysroot as --sysroot= so the Clang driver sets D.SysRoot, which
+  // toolchain helpers (AddClangSystemIncludeArgs, etc.) use to locate system
+  // headers. Skipped in -direct-clang-cc1-module-build mode where ExtraArgs
+  // are parsed directly as CC1 args and --sysroot= is driver-only.
+  if (!Args.hasArg(OPT_direct_clang_cc1_module_build)) {
+    if (const Arg *A = Args.getLastArg(OPT_sysroot))
+      Opts.ExtraArgs.push_back("--sysroot=" + std::string(A->getValue()));
+  }
+
   for (const Arg *A : Args.filtered(OPT_Xcc)) {
     StringRef clangArg = A->getValue();
     if (clangArg.consume_front("-working-directory")) {

--- a/test/ClangImporter/sysroot-clang-args.swift
+++ b/test/ClangImporter/sysroot-clang-args.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/mysdk %t/mysysroot
+
+// -sdk alone is forwarded as --sysroot=<sdk>.
+// RUN: %swift -target x86_64-unknown-linux-gnu -sdk %t/mysdk -parse-stdlib -typecheck %s -dump-clang-diagnostics 2>&1 | %FileCheck -check-prefix CHECK-SDK %s
+
+// -sysroot alone is forwarded as --sysroot=<sysroot>.
+// RUN: %swift -target x86_64-unknown-linux-gnu -sysroot %t/mysysroot -parse-stdlib -typecheck %s -dump-clang-diagnostics 2>&1 | %FileCheck -check-prefix CHECK-SYSROOT %s
+
+// when both -sdk and -sysroot are given, -sysroot takes precedence.
+// RUN: %swift -target x86_64-unknown-linux-gnu -sdk %t/mysdk -sysroot %t/mysysroot -parse-stdlib -typecheck %s -dump-clang-diagnostics 2>&1 | %FileCheck -check-prefix CHECK-BOTH %s
+
+// CHECK-SDK: clang importer driver args:
+// CHECK-SDK: '--sysroot={{.*}}{{/|\\}}mysdk'
+
+// CHECK-SYSROOT: clang importer driver args:
+// CHECK-SYSROOT: '--sysroot={{.*}}{{/|\\}}mysysroot'
+
+// CHECK-BOTH: clang importer driver args:
+// CHECK-BOTH: '--sysroot={{.*}}{{/|\\}}mysysroot'
+// CHECK-BOTH-NOT: '--sysroot={{.*}}{{/|\\}}mysdk'


### PR DESCRIPTION
When looking for the C library, honour `--sysroot` spellings as the first search path.

- **Explanation**: Improve the `--sysroot` handling for the ClangImporter to forward the parameter with `-Xfrontend` and `-Xcc`
- **Scope**: This improves the `-sysroot` handling meaningfully for users and is limited to non-Apple platforms.
- **Issues**:
- **Original PRs**:
- **Risk**: Relatively low risk, it is just changing the default behaviour and the user can still override that
- **Testing**: Used to build the WASI SDK on Windows
- **Reviewers**: @etcwilde @artemcm 