### PR TITLE
build-script: prefer Python from Xcode when building under macOS

### DIFF
--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -627,6 +627,11 @@ def create_argument_parser():
            help='Pass additional CMake options to the Swift build. '
                 'Can be passed multiple times to add multiple options.',
            default=[])
+    option('--extra-lldb-cmake-options', append,
+           type=argparse.ShellSplitType(),
+           help='Pass additional CMake options to the LLDB build. '
+                'Can be passed multiple times to add multiple options.',
+           default=[])
 
     option('--dsymutil-jobs', store_int,
            default=defaults.DSYMUTIL_JOBS,

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -209,6 +209,7 @@ EXPECTED_DEFAULTS = {
     'enable_ubsan': False,
     'export_compile_commands': False,
     'extra_cmake_options': [],
+    'extra_lldb_cmake_options': [],
     'extra_llvm_cmake_options': [],
     'extra_swift_args': [],
     'extra_swift_cmake_options': [],
@@ -840,6 +841,7 @@ EXPECTED_OPTIONS = [
     StrOption('--swift-darwin-supported-archs'),
     SetTrueOption('--swift-freestanding-is-darwin'),
     AppendOption('--extra-swift-cmake-options'),
+    AppendOption('--extra-lldb-cmake-options'),
 
     StrOption('--stdlib-docs-hosting-base-path'),
 

--- a/utils/swift_build_support/swift_build_support/products/lldb.py
+++ b/utils/swift_build_support/swift_build_support/products/lldb.py
@@ -15,9 +15,19 @@ from . import libcxx
 from . import llvm
 from . import product
 from . import swift
+from .. import toolchain as toolchaintypes
 
 
 class LLDB(product.Product):
+
+    def __init__(self, args, toolchain, source_dir, build_dir):
+        product.Product.__init__(self, args, toolchain, source_dir,
+                                 build_dir)
+        if isinstance(self.toolchain, toolchaintypes.Darwin):
+            self.cmake_options.extend([('Python3_EXECUTABLE', self.toolchain.python3)])
+
+        self.cmake_options.extend_raw(self.args.extra_lldb_cmake_options)
+
     @classmethod
     def is_build_script_impl_product(cls):
         """is_build_script_impl_product -> bool

--- a/utils/swift_build_support/swift_build_support/toolchain.py
+++ b/utils/swift_build_support/swift_build_support/toolchain.py
@@ -74,7 +74,7 @@ _register("llvm_ranlib", "llvm-ranlib")
 _register("sccache", "sccache")
 _register("swiftc", "swiftc")
 _register("swift_build", "swift-build")
-
+_register("python3", "python3")
 
 class Darwin(Toolchain):
     def __init__(self, sdk, toolchain):

--- a/utils/swift_build_support/tests/products/test_lldb.py
+++ b/utils/swift_build_support/tests/products/test_lldb.py
@@ -1,0 +1,109 @@
+# tests/products/test_swift.py ----------------------------------*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+# ----------------------------------------------------------------------------
+
+import argparse
+import os
+import platform
+import shutil
+import sys
+import tempfile
+import unittest
+from io import StringIO
+
+from swift_build_support import shell
+from swift_build_support.products import LLDB
+from swift_build_support.toolchain import host_toolchain
+from swift_build_support.workspace import Workspace
+
+
+class LLDBTestCase(unittest.TestCase):
+
+    def setUp(self):
+        # Setup workspace
+        tmpdir1 = os.path.realpath(tempfile.mkdtemp())
+        tmpdir2 = os.path.realpath(tempfile.mkdtemp())
+        os.makedirs(os.path.join(tmpdir1, 'swift'))
+
+        self.workspace = Workspace(source_root=tmpdir1,
+                                   build_root=tmpdir2)
+
+        # Setup toolchain
+        self.toolchain = host_toolchain()
+        self.toolchain.cc = '/path/to/cc'
+        self.toolchain.cxx = '/path/to/cxx'
+        self.toolchain.python3 = '/path/to/python3'
+
+        # Setup args
+        self.args = argparse.Namespace(
+            extra_lldb_cmake_options='',
+        )
+
+        # Setup shell
+        shell.dry_run = True
+        self._orig_stdout = sys.stdout
+        self._orig_stderr = sys.stderr
+        self.stdout = StringIO()
+        self.stderr = StringIO()
+        sys.stdout = self.stdout
+        sys.stderr = self.stderr
+
+    def tearDown(self):
+        shutil.rmtree(self.workspace.build_root)
+        shutil.rmtree(self.workspace.source_root)
+        sys.stdout = self._orig_stdout
+        sys.stderr = self._orig_stderr
+        shell.dry_run = False
+        self.workspace = None
+        self.toolchain = None
+        self.args = None
+
+    @classmethod
+    def isDarwin(cls):
+        return platform.system() == 'Darwin'
+
+    def test_default_options(self):
+        lldb = LLDB(
+            args=self.args,
+            toolchain=self.toolchain,
+            source_dir='/path/to/src',
+            build_dir='/path/to/build')
+
+        if LLDBTestCase.isDarwin(): 
+            expected = [
+              '-DPython3_EXECUTABLE=/path/to/python3',
+            ]
+        else:
+            expected = []
+
+        self.assertEqual(set(lldb.cmake_options), set(expected))
+
+    def test_extra_lldb_cmake_options(self):
+        self.args.extra_lldb_cmake_options = [
+            "--trace-expand", "-DPython3_EXECUTABLE=/different/path/to/python3"
+        ]
+
+        lldb = LLDB(
+            args=self.args,
+            toolchain=self.toolchain,
+            source_dir='/path/to/src',
+            build_dir='/path/to/build')
+
+        expected = [ 
+            "--trace-expand", "-DPython3_EXECUTABLE=/different/path/to/python3"
+        ]
+        if LLDBTestCase.isDarwin(): 
+            expected.append(
+                '-DPython3_EXECUTABLE=/path/to/python3',
+            )
+
+        self.assertEqual(set(lldb.cmake_options), set(expected))
+        # Ensure we are indeed overriding the path to the Python interpreter
+        self.assertEqual("-DPython3_EXECUTABLE=/different/path/to/python3", lldb.cmake_options._options[-1])


### PR DESCRIPTION
**Explanation**:
When building under macOS, LLDB should link against the Python shipped as part of Xcode, so we are sure that e.g. we find the expected fat Python dylibs that are needed to build the LLDB.framework fat.

To allow users to point to a different Python, add a `--extra-lldb-cmake-options` flag as well, that can be used to set a different value for the `Python3_EXECUTABLE` CMake variable.

**Scope**:
build-script invocations that build lldb under macOS

**Issues**:
rdar://173807747

**Original PRs**:
N/A (in a sense this is the original PR)

**Risk**:
Low

* this only affects builds of LLDB
* existing builds at desk will keep using the Python previously configured, and will keep working the same
* `--extra-lldb-cmake-options` is implemented using the same strategy as `--extra-swift-cmake-options` (#81364), which has no regression
* in the worst case, this change has no effect (i.e. `Python3_EXECUTABLE` variable is not set), causing builds to behave as they do currently without causing additional failures.

**Testing**:
* added unit tests to prove the new logic works as expected
* run builds at desk for macOS and ensured `Python3_EXECUTABLE` is set correctly in the underlying CMakeCache.txt for LLDB, and that LLDB.framework links the expected Python

**Reviewers**:
N/A -- this is PR for `main`, so reviewers will be listed as part as part of normal review process