### PR TITLE
[SymbolGraphGen] Emit "functionSignature" info for macros

### DIFF
--- a/lib/SymbolGraphGen/Symbol.cpp
+++ b/lib/SymbolGraphGen/Symbol.cpp
@@ -471,6 +471,19 @@ void Symbol::serializeFunctionSignature(llvm::json::OStream &OS) const {
                                              OS);
       }
     });
+  } else if (const auto *MD = dyn_cast_or_null<MacroDecl>(D)) {
+    OS.attributeObject("functionSignature", [&]() {
+      // Parameters
+      if (const auto *ParamList = MD->getParameterList()) {
+        serializeParameterList(ParamList);
+      }
+
+      // Returns
+      if (const auto ReturnType = MD->getCachedResultInterfaceType()) {
+        Graph->serializeDeclarationFragments("returns", ReturnType.value(),
+                                             BaseType, OS);
+      }
+    });
   }
 }
 

--- a/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/Macros.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/Macros.swift
@@ -31,6 +31,11 @@
 // following declaration/names dumps are edited to handle both situations.
 
 // CHECK-LABEL: "precise": "s:6Macros9stringifyyx_SStxclufm",
+
+// the `declarationFragments` token is part of the `functionSignature` first, so skip that
+// CHECK: "functionSignature"
+// CHECK: "declarationFragments"
+
 // CHECK:      "declarationFragments": [
 // CHECK-NEXT:     {
 // CHECK-NEXT:         "kind": "attribute",

--- a/test/SymbolGraph/Symbols/Mixins/FunctionSignature.swift
+++ b/test/SymbolGraph/Symbols/Mixins/FunctionSignature.swift
@@ -5,6 +5,7 @@
 // RUN: %FileCheck %s --input-file %t/FunctionSignature.symbols.json --check-prefix=INIT
 // RUN: %FileCheck %s --input-file %t/FunctionSignature.symbols.json --check-prefix=SUBSCRIPT
 // RUN: %FileCheck %s --input-file %t/FunctionSignature.symbols.json --check-prefix=FUNC2
+// RUN: %FileCheck %s --input-file %t/FunctionSignature.symbols.json --check-prefix=MACRO
 
 public struct MyStruct {
   public init(_ noext: Int, ext int: Int) {}
@@ -136,3 +137,36 @@ public struct MyStruct {
 // FUNC2-NEXT: "preciseIdentifier": "s:s4Voida"
     
 }
+
+@freestanding(expression)
+public macro foo(_ noext: Int, ext int: Int) -> String = #externalMacro(module: "MacroDefinition", type: "FooMacro")
+  
+// MACRO-LABEL: "precise": "s:17FunctionSignature3foo_3extSSSi_Sitcfm",
+// MACRO: "name": "noext"
+// MACRO-NOT: "internalName": "noext"
+// MACRO-NEXT: declarationFragments
+
+// MACRO: "kind": "identifier"
+// MACRO-NEXT: "spelling": "noext"
+// MACRO: "kind": "text"
+// MACRO-NEXT: "spelling": ": "
+// MACRO: "kind": "typeIdentifier"
+// MACRO-NEXT: "spelling": "Int"
+// MACRO-NEXT: "preciseIdentifier": "s:Si"
+
+// MACRO: "name": "ext"
+// MACRO-NEXT: "internalName": "int"
+// MACRO-NEXT: declarationFragments
+
+// MACRO: "kind": "identifier"
+// MACRO-NEXT: "spelling": "int"
+// MACRO: "kind": "text"
+// MACRO-NEXT: "spelling": ": "
+// MACRO: "kind": "typeIdentifier"
+// MACRO-NEXT: "spelling": "Int"
+// MACRO-NEXT: "preciseIdentifier": "s:Si"
+
+// MACRO: returns
+// MACRO: "kind": "typeIdentifier"
+// MACRO-NEXT: "spelling": "String"
+// MACRO-NEXT: "preciseIdentifier": "s:SS"


### PR DESCRIPTION
This makes the Swift symbol graph generator emit "functionSignature" information for macros, just like it does for functions, initializers, and subscripts.

Resolves rdar://173856819.

(This is very similar to https://github.com/swiftlang/swift/pull/70207 from 2023)

------

- **Explanation**: This makes the Swift symbol graph generator/extractor emit "functionSignature" information for macros, just like it does for functions/methods/operators, initializers, and subscripts.
- **Scope**: This change is isolated to the creation of supplementary "symbol graph" files that other tools can use to process the public API surface and documentation for a Swift module. For example, Swift-DocC uses this "functionSignature" information both to check that all parameters are documented (if any of them are) and to support human-readable link disambiguation using type name spellings (like `-(_,Int)` or `->String`). Currently, neither of those features work for macro symbols but both work for functions/methods/operators, initializers, and subscripts. 
- **Issues**: rdar://173856819
- **Risk**: This is a low risk change that is isolated to the creation of "symbol graph" files and that applies past good changes (from https://github.com/swiftlang/swift/pull/70207 in 2023) to a new type of symbol.
- **Testing**: New unit test verifies that macro symbols output the "functionSignature" information the same way as functions/methods/operator, initializers, and subscripts do. Manual testing verified that existing features in Swift-DocC can process this information in the output symbol graph file.