### PR TITLE
AST: Print the override keyword when appropriate in package swiftinterfaces

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1079,7 +1079,7 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
         if (!BD->hasClangNode() &&
             !BD->getFormalAccessScope(VD->getDeclContext(),
                                       /*treatUsableFromInlineAsPublic*/ true)
-                 .isPublic()) {
+                 .isPublicOrPackage()) {
           return false;
         }
       }

--- a/test/ModuleInterface/package_interface.swift
+++ b/test/ModuleInterface/package_interface.swift
@@ -13,8 +13,8 @@
 // RUN: %target-swift-typecheck-module-from-interface(%t/Bar.package.swiftinterface) -I %t -module-name Bar
 // RUN: %target-swift-typecheck-module-from-interface(%t/Bar.private.swiftinterface) -I %t -module-name Bar
 
-// RUN: %FileCheck --check-prefixes=CHECK %s < %t/Bar.swiftinterface
-// RUN: %FileCheck --check-prefixes=CHECK,CHECK-PRIV %s < %t/Bar.private.swiftinterface
+// RUN: %FileCheck --check-prefixes=CHECK,CHECK-PUB %s < %t/Bar.swiftinterface
+// RUN: %FileCheck --check-prefixes=CHECK,CHECK-PRIV,CHECK-PRIV-ONLY %s < %t/Bar.private.swiftinterface
 // RUN: %FileCheck --check-prefixes=CHECK,CHECK-PRIV,CHECK-PKG %s < %t/Bar.package.swiftinterface
 
 
@@ -158,6 +158,8 @@ public class PubKlass {
     pubVarPrivSetInPub = 1
     pubVarPkgSetInPub = 1
   }
+
+  package func pkgMethodInPub() { }
 }
 
 // CHECK: public class PubKlass {
@@ -170,8 +172,18 @@ public class PubKlass {
 // CHECK:     get
 // CHECK:   }
 // CHECK:   public init()
+// CHECK-PKG:   package func pkgMethodInPub()
 // CHECK:   deinit
 // CHECK: }
+
+public class PubSubklass: PubKlass {
+  public override func pkgMethodInPub() { }
+}
+
+// CHECK: @_inheritsConvenienceInitializers public class PubSubklass : Bar::PubKlass {
+// CHECK-PUB:         public func pkgMethodInPub()
+// CHECK-PRIV-ONLY:   public func pkgMethodInPub()
+// CHECK-PKG:         override public func pkgMethodInPub()
 
 class IntrnKlass {
   var intrnVarInIntrn: String


### PR DESCRIPTION
If a decl written in source has `override` because it overrides a `package` decl, then the `override` keyword should be printed in the `.package.swiftinterface` since the overridden decl is visible.

Resolves rdar://158178648.
