### PR TITLE
[DependencyScan][Caching] Do not mix CAS instance

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -1093,6 +1093,13 @@ public:
   /// Allocate string inside ScanningService.
   StringRef save(StringRef str);
 
+  /// Get clang scanning service.
+  const clang::tooling::dependencies::DependencyScanningService &
+  getClangScanningService() const {
+    assert(ClangScanningService);
+    return *ClangScanningService;
+  }
+
 private:
   /// Enforce clients not being allowed to query this cache directly, it must be
   /// wrapped in an instance of `ModuleDependenciesCache`.

--- a/include/swift/DependencyScan/ModuleDependencyScanner.h
+++ b/include/swift/DependencyScan/ModuleDependencyScanner.h
@@ -315,8 +315,6 @@ private:
                           const SILOptions &SILOptions,
                           ASTContext &ScanASTContext,
                           DependencyTracker &DependencyTracker,
-                          std::shared_ptr<llvm::cas::ObjectStore> CAS,
-                          std::shared_ptr<llvm::cas::ActionCache> ActionCache,
                           DiagnosticEngine &Diagnostics, bool ParallelScan,
                           bool EmitScanRemarks);
   llvm::Error initializeWorkerClangScanningTool();

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -655,7 +655,7 @@ swift::dependencies::registerBackDeployLibraries(
 
 bool SwiftDependencyScanningService::setupCachingDependencyScanningService(
     CompilerInstance &Instance) {
-  if (!Instance.getInvocation().getCASOptions().EnableCaching)
+  if (!Instance.getInvocation().requiresCAS())
     return false;
 
   if (CASConfig) {

--- a/lib/DependencyScan/DependencyScanningTool.cpp
+++ b/lib/DependencyScan/DependencyScanningTool.cpp
@@ -390,6 +390,12 @@ llvm::ErrorOr<ScanQueryContext> DependencyScanningTool::createScanQueryContext(
     if (std::error_code EC = Invocation.getError())
       return EC;
 
+    // Setup the CAS instance from scanning service if applicable.
+    if (Invocation->requiresCAS())
+      Instance->setSharedCASInstances(
+          ScanningService->getClangScanningService().getCAS(),
+          ScanningService->getClangScanningService().getActionCache());
+
     // Setup the instance
     std::string InstanceSetupError;
     if (Instance->setup(*Invocation, InstanceSetupError))

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -218,6 +218,12 @@ ModuleDependencyScanningWorker::ModuleDependencyScanningWorker(
           getClangScanningFS(globalScanningService, CAS, ScanASTContext)),
       CAS(CAS), ActionCache(ActionCache),
       diagnosticReporter(DiagnosticReporter) {
+  assert(globalScanningService.ClangScanningService->getCAS() == CAS &&
+         "Need to be the same CAS instance");
+  assert(globalScanningService.ClangScanningService->getActionCache() ==
+             ActionCache &&
+         "Need to be the same ActionCache instance");
+
   // Instantiate a worker-specific diagnostic engine and copy over
   // the scanner's diagnostic consumers (expected to be thread-safe).
   workerDiagnosticEngine = std::make_unique<DiagnosticEngine>(ScanASTContext.SourceMgr);
@@ -534,7 +540,6 @@ ModuleDependencyScanner::create(SwiftDependencyScanningService &service,
       std::unique_ptr<ModuleDependencyScanner>(new ModuleDependencyScanner(
           service, cache, instance->getInvocation(), instance->getSILOptions(),
           instance->getASTContext(), *instance->getDependencyTracker(),
-          instance->getSharedCASInstance(), instance->getSharedCacheInstance(),
           instance->getDiags(),
           instance->getInvocation().getFrontendOptions().ParallelDependencyScan,
           instance->getInvocation()
@@ -560,24 +565,22 @@ ModuleDependencyScanner::ModuleDependencyScanner(
     ModuleDependenciesCache &Cache,
     const CompilerInvocation &ScanCompilerInvocation,
     const SILOptions &SILOptions, ASTContext &ScanASTContext,
-    swift::DependencyTracker &DependencyTracker,
-    std::shared_ptr<llvm::cas::ObjectStore> CAS,
-    std::shared_ptr<llvm::cas::ActionCache> ActionCache,
-    DiagnosticEngine &Diagnostics, bool ParallelScan,
-    bool EmitScanRemarks)
+    swift::DependencyTracker &DependencyTracker, DiagnosticEngine &Diagnostics,
+    bool ParallelScan, bool EmitScanRemarks)
     : ScanCompilerInvocation(ScanCompilerInvocation),
       ScanASTContext(ScanASTContext),
       ScanDiagnosticReporter(Diagnostics, EmitScanRemarks),
       ModuleOutputPath(ScanCompilerInvocation.getFrontendOptions()
-                       .ExplicitModulesOutputPath),
+                           .ExplicitModulesOutputPath),
       SDKModuleOutputPath(ScanCompilerInvocation.getFrontendOptions()
-                          .ExplicitSDKModulesOutputPath),
+                              .ExplicitSDKModulesOutputPath),
       DependencyCache(Cache),
       NumThreads(ParallelScan
                      ? llvm::hardware_concurrency().compute_thread_count()
                      : 1),
-      ScanningThreadPool(llvm::hardware_concurrency(NumThreads)), CAS(CAS),
-      ActionCache(ActionCache) {
+      ScanningThreadPool(llvm::hardware_concurrency(NumThreads)),
+      CAS(ScanningService.ClangScanningService->getCAS()),
+      ActionCache(ScanningService.ClangScanningService->getActionCache()) {
   // Setup prefix mapping.
   auto &ScannerPrefixMapper =
       ScanCompilerInvocation.getSearchPathOptions().ScannerPrefixMapper;

--- a/test/CAS/swift-scan-test-multithread.swift
+++ b/test/CAS/swift-scan-test-multithread.swift
@@ -1,0 +1,39 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+/// Test parallel dependency scanning from libSwiftScan APIs.
+ // RUN: %swift-scan-test -action scan_dependency -cas-path %t/cas -threads 5 -- \
+// RUN:   %target-swift-frontend -scan-dependencies -target arm64-apple-macos26 -module-name Test -module-cache-path %t/clang-module-cache -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   %t/main.swift -o %t/deps.json -sdk %sdk -swift-version 5 -cache-compile-job -cas-path %t/cas -I %t/include > %t/deps.json
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json A | %FileCheck %s --check-prefix=INTERFACE_A
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:B | %FileCheck %s --check-prefix=PCM_B
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test | %FileCheck %s --check-prefix=TEST
+
+// INTERFACE_A: -frontend
+// INTERFACE_A: -compile-module-from-interface
+
+// PCM_B: -frontend
+// PCM_B: -emit-pcm
+
+// TEST: -direct-clang-cc1-module-build
+
+//--- include/module.modulemap
+module B {
+  header "B.h"
+  export *
+}
+
+//--- include/B.h
+void notused(void);
+
+//--- include/A.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name A -O -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib -user-module-version 1.0
+import B
+
+public struct A {}
+
+//--- main.swift
+import A


### PR DESCRIPTION
Make sure the CAS instances are not mixed during dependency scanning, especially when used from libSwiftScan C APIs.

For clang scanning service and file system, it should always be created from the global CAS instance.

For CAS instance inside the swift instance when performing dependency scanning, it reuse the CAS instance from global as well if that is already initialized.

rdar://173703843

<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
