### PR TITLE
Optimizer: move the `cond_fail true` optimization out of SILCombine into its own optimization pass

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CMakeLists.txt
@@ -17,6 +17,7 @@ swift_compiler_sources(Optimizer
   ClosureSpecialization.swift
   ComputeEscapeEffects.swift
   ComputeSideEffects.swift
+  CondFailOptimization.swift
   CopyToBorrowOptimization.swift
   DeadAccessScopeElimination.swift
   DeadStoreElimination.swift

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CondFailOptimization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CondFailOptimization.swift
@@ -1,0 +1,83 @@
+//===--- CondFailOptimization.swift ----------------------------------------==//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SIL
+
+/// This optimization handles unconditional `cond_fail` instructions, i.e. `cond_fail`s with a non-zero
+/// `integer_literal` operand.
+/// It cuts off the control flow after such a `cond_fail` by inserting an `unreachable` instruction.
+/// The resulting dead code - instructions and blocks - gets removed.
+///
+/// ```
+///   %0 = integer_literal 1
+///   cond_fail %0, "message"
+///   // following instructions
+/// ```
+/// ->
+/// ```
+///   %0 = integer_literal 1
+///   cond_fail %0, "message"
+///   unreachable
+/// ```
+///
+/// This optimization cannot be done as instruction simplification, because it can leave OSSA
+/// lifetimes uncompleted. Other simplification may depend on complete lifetimes.
+/// This pass runs lifetime completion after optimizing all `cond_fail`s.
+///
+let condFailOptimization = FunctionPass(name: "cond-fail-optimization") {
+  (function: Function, context: FunctionPassContext) in
+
+  for inst in function.instructions {
+    if let cfi = inst as? CondFailInst {
+      tryRemoveUnconditional(condFail: cfi, context)
+    }
+  }
+
+  _ = context.removeDeadBlocks(in: function)
+
+  if context.needBreakInfiniteLoops {
+    breakInfiniteLoops(in: function, context)
+  }
+
+  if context.needCompleteLifetimes {
+    completeLifetimes(in: function, context)
+  }
+}
+
+private func tryRemoveUnconditional(condFail: CondFailInst, _ context: FunctionPassContext) {
+  guard let literal = condFail.condition as? IntegerLiteralInst,
+        let value = literal.value,
+        value != 0
+  else {
+    return
+  }
+
+  if InstructionList(first: condFail.next).allSatisfy({ $0.isUnreachableOrEndingLifetime }) {
+    // Don't remove instructions which would be re-inserted by lifetime completion.
+    return
+  }
+  let builder = Builder(after: condFail, context)
+  let unreachable = builder.createUnreachable()
+  _ = context.splitBlock(after: unreachable)
+}
+
+private extension Instruction {
+  var isUnreachableOrEndingLifetime: Bool {
+    switch self {
+    case is EndBorrowInst, is DestroyValueInst, is EndLifetimeInst, is DeallocStackInst, is EndAccessInst,
+         is UnreachableInst:
+      return true
+    default:
+      return false
+    }
+  }
+}

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyCondFail.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyCondFail.swift
@@ -20,54 +20,18 @@ extension CondFailInst : OnoneSimplifiable, SILCombineSimplifiable {
       return
     }
 
+    // Eliminates
+    // ```
+    //   %0 = integer_literal 0
+    //   cond_fail %0, "message"
+    // ```
     guard let literal = condition as? IntegerLiteralInst,
-          let value = literal.value
+          let value = literal.value,
+          value == 0
     else {
       return
     }
 
-    if value == 0 {
-      // Eliminates
-      // ```
-      //   %0 = integer_literal 0
-      //   cond_fail %0, "message"
-      // ```
-      context.erase(instruction: self)
-    } else {
-
-      // Inserts an unreachable after an unconditional fail:
-      // ```
-      //   %0 = integer_literal 1
-      //   cond_fail %0, "message"
-      //   // following instructions
-      // ```
-      // ->
-      // ```
-      //   %0 = integer_literal 1
-      //   cond_fail %0, "message"
-      //   unreachable
-      // deadblock:
-      //   // following instructions
-      // ```
-      if InstructionList(first: self.next).allSatisfy({ $0.isUnreachableOrEndingLifetime }) {
-        // Don't remove instructions which would be re-inserted by lifetime completion.
-        return
-      }
-      let builder = Builder(after: self, context)
-      let unreachable = builder.createUnreachable()
-      _ = context.splitBlock(after: unreachable)
-    }
-  }
-}
-
-private extension Instruction {
-  var isUnreachableOrEndingLifetime: Bool {
-    switch self {
-    case is EndBorrowInst, is DestroyValueInst, is EndLifetimeInst, is DeallocStackInst, is EndAccessInst,
-         is UnreachableInst:
-      return true
-    default:
-      return false
-    }
+    context.erase(instruction: self)
   }
 }

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
@@ -80,6 +80,7 @@ private func registerSwiftPasses() {
   registerPass(constantCapturePropagation, { constantCapturePropagation.run($0) })
   registerPass(computeEscapeEffects, { computeEscapeEffects.run($0) })
   registerPass(computeSideEffects, { computeSideEffects.run($0) })
+  registerPass(condFailOptimization, { condFailOptimization.run($0) })
   registerPass(diagnoseInfiniteRecursion, { diagnoseInfiniteRecursion.run($0) })
   registerPass(destroyHoisting, { destroyHoisting.run($0) })
   registerPass(mandatoryDestroyHoisting, { mandatoryDestroyHoisting.run($0) })

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -79,6 +79,8 @@ PASS(ComputeEscapeEffects, "compute-escape-effects",
      "Computes function escape effects")
 PASS(ComputeSideEffects, "compute-side-effects",
      "Computes function side effects")
+PASS(CondFailOptimization, "cond-fail-optimization",
+     "Optimizes cond_fail instructions")
 PASS(DiagnoseInfiniteRecursion, "diagnose-infinite-recursion",
      "Diagnose Infinitely-Recursive Code")
 PASS(InitializeStaticGlobals, "initialize-static-globals",

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -384,6 +384,7 @@ void addSimplifyCFGSILCombinePasses(SILPassPipelinePlan &P) {
   // Jump threading can expose opportunity for silcombine (enum -> is_enum_tag->
   // cond_br).
   P.addSILCombine();
+  P.addCondFailOptimization();
   // Which can expose opportunity for simplifycfg.
   P.addSimplifyCFG();
 }

--- a/lib/SILOptimizer/Utils/CastOptimizer.cpp
+++ b/lib/SILOptimizer/Utils/CastOptimizer.cpp
@@ -1356,17 +1356,9 @@ ValueBase *CastOptimizer::optimizeUnconditionalCheckedCastInst(
     // Remove the cast and insert a trap, followed by an
     // unreachable instruction.
     SILBuilderWithScope Builder(Inst, builderContext);
-    auto *Trap = Builder.createUnconditionalFail(Loc, "failed cast");
-    Inst->replaceAllUsesWithUndef();
-    eraseInstAction(Inst);
-    Builder.setInsertionPoint(std::next(SILBasicBlock::iterator(Trap)));
-    auto *UnreachableInst =
-        Builder.createUnreachable(ArtificialUnreachableLocation());
-
-    // Delete everything after the unreachable except for dealloc_stack which we
-    // move before the trap.
-    deleteInstructionsAfterUnreachable(UnreachableInst, Trap);
-
+    // The CondFailOptimization will eventually insert an `unreachable` here
+    // and remove the following dead code (including the cast instruction).
+    Builder.createUnconditionalFail(Loc, "failed cast");
     willFailAction();
     return nullptr;
   }
@@ -1554,16 +1546,9 @@ SILInstruction *CastOptimizer::optimizeUnconditionalCheckedCastAddrInst(
     // Remove the cast and insert a trap, followed by an
     // unreachable instruction.
     SILBuilderWithScope Builder(Inst, builderContext);
-    auto *TrapI = Builder.createUnconditionalFail(Loc, "failed cast");
-    eraseInstAction(Inst);
-    Builder.setInsertionPoint(std::next(TrapI->getIterator()));
-    auto *UnreachableInst =
-        Builder.createUnreachable(ArtificialUnreachableLocation());
-
-    // Delete everything after the unreachable except for dealloc_stack which we
-    // move before the trap.
-    deleteInstructionsAfterUnreachable(UnreachableInst, TrapI);
-
+    // The CondFailOptimization will eventually insert an `unreachable` here
+    // and remove the following dead code (including the cast instruction).
+    Builder.createUnconditionalFail(Loc, "failed cast");
     willFailAction();
   }
 

--- a/test/SILOptimizer/constant_propagation.sil
+++ b/test/SILOptimizer/constant_propagation.sil
@@ -1247,7 +1247,8 @@ class AnObject {}
 // CHECK:  alloc_stack $AnObject
 // CHECK: [[ONE:%[0-9]+]] = integer_literal $Builtin.Int1, -1
 // CHECK: cond_fail [[ONE]] : $Builtin.Int1, "failed cast"
-// CHECK:  unreachable
+// CHECK:  unconditional_checked_cast
+// CHECK:  } // end sil function 'replace_unconditional_check_cast_failure'
 
 sil @replace_unconditional_check_cast_failure : $@convention(thin) (Builtin.Int1, @guaranteed AnObject) -> (@out Value) {
 bb0(%2 : $*Value, %0 : $Builtin.Int1, %1 : $AnObject):

--- a/test/SILOptimizer/constant_propagation_ownership.sil
+++ b/test/SILOptimizer/constant_propagation_ownership.sil
@@ -852,7 +852,8 @@ class AnSubObject : AnObject {}
 // CHECK:  alloc_stack $AnObject
 // CHECK: [[ONE:%[0-9]+]] = integer_literal $Builtin.Int1, -1
 // CHECK: cond_fail [[ONE]] : $Builtin.Int1, "failed cast"
-// CHECK:  unreachable
+// CHECK:  unconditional_checked_cast
+// CHECK:  } // end sil function 'replace_unconditional_check_cast_failure'
 
 sil [ossa] @replace_unconditional_check_cast_failure : $@convention(thin) (Builtin.Int1, @guaranteed AnObject) -> (@out Value) {
 bb0(%2 : $*Value, %0 : $Builtin.Int1, %1 : @guaranteed $AnObject):

--- a/test/SILOptimizer/optimize_cond_fails.sil
+++ b/test/SILOptimizer/optimize_cond_fails.sil
@@ -1,0 +1,49 @@
+// RUN: %target-sil-opt %s -cond-fail-optimization | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+
+// CHECK-LABEL: sil [ossa] @remove_dead_code_after_cond_fail :
+// CHECK:         %1 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:    cond_fail %1
+// CHECK-NEXT:    destroy_value [dead_end] %0
+// CHECK-NEXT:    unreachable
+// CHECK-NEXT:  } // end sil function 'remove_dead_code_after_cond_fail'
+sil [ossa] @remove_dead_code_after_cond_fail : $@convention(thin) (@owned AnyObject) -> @owned AnyObject {
+bb0(%0 : @owned $AnyObject):
+  %1 = integer_literal $Builtin.Int1, -1
+  cond_fail %1, "message"
+  br bb1
+
+bb1:
+  return %0
+}
+
+// CHECK-LABEL: sil @cond_fail_end_scope : $@convention(thin) (@inout Builtin.Int32, Builtin.Int1) -> () {
+// CHECK:         cond_fail
+// CHECK-NEXT:    unreachable
+// CHECK-NEXT:  } // end sil function 'cond_fail_end_scope'
+sil @cond_fail_end_scope : $@convention(thin) (@inout Builtin.Int32, Builtin.Int1) -> () {
+entry(%0 : $*Builtin.Int32, %1 : $Builtin.Int1):
+  %2 = integer_literal $Builtin.Int1, -1
+  cond_fail %2, "message"
+  %4 = begin_access [read] [static] %0
+  cond_br %1, bb1, bb2
+
+bb1:
+  end_access %4
+  br bb3
+
+bb2:
+  end_access %4
+  br bb3
+
+bb3:
+  %99 = tuple ()
+  return %99
+}
+
+

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -586,31 +586,6 @@ bb0(%0 : $Builtin.Int1):
   return %2 : $()
 }
 
-// rdar://121599876 (SILCombine should delete instructions in blocks dominated by cond_fail -1)
-// CHECK-LABEL: sil @cond_fail_end_scope : $@convention(thin) (@inout Builtin.Int32, Builtin.Int1) -> () {
-// CHECK: cond_fail
-// CHECK-NEXT:   unreachable
-// CHECK-LABEL: } // end sil function 'cond_fail_end_scope'
-sil @cond_fail_end_scope : $@convention(thin) (@inout Builtin.Int32, Builtin.Int1) -> () {
-entry(%0 : $*Builtin.Int32, %1 : $Builtin.Int1):
-  %true = integer_literal $Builtin.Int1, -1
-  cond_fail %true : $Builtin.Int1
-  %access = begin_access [read] [static] %0 : $*Builtin.Int32
-  cond_br %1, left, right
-
-left:
-  end_access %access : $*Builtin.Int32
-  br end
-
-right:
-  end_access %access : $*Builtin.Int32
-  br end
-
-end:
-  %99 = tuple ()
-  return %99 : $()
-}
-
 // CHECK-LABEL: sil @release_then_retain_peephole
 // CHECK: bb0
 // CHECK-NOT: strong_release
@@ -1911,10 +1886,10 @@ bb0(%0 : $Int):
   return %8 : $()
 }
 
-//CHECK-LABEL: @remove_pointer_compare_to_zero_NE
-//CHECK-NOT: apply
-//CHECK: cond_fail
-//CHECK: unreachable
+// CHECK-LABEL: sil @remove_pointer_compare_to_zero_NE
+// CHECK:         %1 = integer_literal $Builtin.Int1, -1
+// CHECK:         cond_fail %1
+// CHECK:       } // end sil function 'remove_pointer_compare_to_zero_NE'
 sil @remove_pointer_compare_to_zero_NE : $@convention(thin) (Int) -> () {
 bb0(%0 : $Int):
   %1 = string_literal utf8 "ss"
@@ -2415,21 +2390,6 @@ sil public_external [serialized] @materializeForSetClosure : $@convention(thin) 
 bb0(%0 : $Builtin.RawPointer, %1 : $*Builtin.UnsafeValueBuffer, %2 : $*GenContainer<T>, %3 : $@thick GenContainer<T>.Type):
   unreachable
 }
-
-// CHECK-LABEL:   sil @remove_dead_code_after_cond_fail :
-// CHECK:           [[Ref:%.*]] = integer_literal $Builtin.Int1, -1
-// CHECK-NEXT:      cond_fail [[Ref]]
-// CHECK-NEXT:      unreachable
-// CHECK: } // end sil function 'remove_dead_code_after_cond_fail'
-sil @remove_dead_code_after_cond_fail : $@convention(thin) () -> (Int32) {
-bb0:
-  %0 = integer_literal $Builtin.Int32, -2
-  %1 = integer_literal $Builtin.Int1, -1
-  cond_fail %1 : $Builtin.Int1
-  %3 = struct $Int32 (%0 : $Builtin.Int32)
-  return %3 : $Int32
-}
-
 
 // CHECK-LABEL:   sil @dont_remove_code_after_cond_fail
 // CHECK:         bb0([[Cond:%.*]] : $Builtin.Int1):

--- a/test/SILOptimizer/sil_combine_ossa.sil
+++ b/test/SILOptimizer/sil_combine_ossa.sil
@@ -2243,11 +2243,10 @@ bb0(%0 : $Int):
   return %8 : $()
 }
 
-// CHECK-LABEL: @remove_pointer_compare_to_zero_NE :
-// CHECK-NOT: apply
-// CHECK: cond_fail
-// CHECK: unreachable
-// CHECK: } // end sil function 'remove_pointer_compare_to_zero_NE'
+// CHECK-LABEL: sil [ossa] @remove_pointer_compare_to_zero_NE
+// CHECK:         %1 = integer_literal $Builtin.Int1, -1
+// CHECK:         cond_fail %1
+// CHECK:       } // end sil function 'remove_pointer_compare_to_zero_NE'
 sil [ossa] @remove_pointer_compare_to_zero_NE : $@convention(thin) (Int) -> () {
 bb0(%0 : $Int):
   %1 = string_literal utf8 "ss"
@@ -2895,22 +2894,6 @@ sil public_external [serialized] @materializeForSetClosure : $@convention(thin) 
 bb0(%0 : $Builtin.RawPointer, %1 : $*Builtin.UnsafeValueBuffer, %2 : $*GenContainer<T>, %3 : $@thick GenContainer<T>.Type):
   unreachable
 }
-
-
-// CHECK-LABEL:   sil [ossa] @remove_dead_code_after_cond_fail :
-// CHECK:           [[Ref:%.*]] = integer_literal $Builtin.Int1, -1
-// CHECK-NEXT:      cond_fail [[Ref]]
-// CHECK-NEXT:      unreachable
-// CHECK: } // end sil function 'remove_dead_code_after_cond_fail'
-sil [ossa] @remove_dead_code_after_cond_fail : $@convention(thin) () -> (Int32) {
-bb0:
-  %0 = integer_literal $Builtin.Int32, -2
-  %1 = integer_literal $Builtin.Int1, -1
-  cond_fail %1 : $Builtin.Int1
-  %3 = struct $Int32 (%0 : $Builtin.Int32)
-  return %3 : $Int32
-}
-
 
 // CHECK-LABEL:   sil [ossa] @dont_remove_code_after_cond_fail
 // CHECK:         bb0([[Cond:%.*]] : $Builtin.Int1):
@@ -5679,5 +5662,77 @@ bb0(%0 : @owned $S1):
   %5 = struct $MoveOnlyStruct (%2), forwarding: @owned
   destroy_value [dead_end] %5
   unreachable
+}
+
+struct MyArray<T> {
+  var storage: MyArrayStorage
+}
+
+class MyArrayStorage {
+}
+
+struct MySliceBuffer<T> {
+  var owner: AnyObject
+  var subscriptBaseAddress: UnsafeMutablePointer<T>
+}
+
+struct MyArraySlice<T> {
+  var buffer: MySliceBuffer<T>
+}
+
+// Just check that SILCombine doesn't produce illegal SIL.
+sil [ossa] @dont_cut_off_control_flow_after_cond_fail : $@convention(thin) @async (@in_guaranteed MyArray<S1>) -> () {
+bb0(%0 : $*MyArray<S1>):
+  %2 = load_borrow %0
+  %3 = struct_extract %2, #MyArray.storage
+  %7 = copy_value %3
+  %8 = init_existential_ref %7 : $MyArrayStorage : $MyArrayStorage, $AnyObject
+  %9 = copy_value %8
+  %10 = struct $MySliceBuffer<S1> (%9, undef : $UnsafeMutablePointer<S1>)
+  end_borrow %2
+  %12 = struct $MyArraySlice<S1> (%10)
+  %13 = copy_value %12
+  %14 = destructure_struct %13
+  %15 = begin_borrow [lexical] %14
+  cond_br undef, bb2, bb1
+
+bb1:
+  end_borrow %15
+  destroy_value %14
+  br bb3
+
+bb2:
+  %20 = struct_extract %15, #MySliceBuffer.owner
+  %21 = copy_value %20
+  destroy_value %21
+  end_borrow %15
+  destroy_value %14
+  br bb3
+
+bb3:
+  %26 = begin_borrow [lexical] %12
+  cond_br undef, bb4, bb5
+
+bb4:
+  %28 = integer_literal $Builtin.Int1, -1
+  cond_fail %28, "Division results in an overflow"
+  end_borrow %26
+  destroy_value [dead_end] %12
+  destroy_value [dead_end] %8
+  unreachable
+
+bb5:
+  %34 = struct_extract %26, #MyArraySlice.buffer
+  %35 = struct_extract %34, #MySliceBuffer.subscriptBaseAddress
+  %36 = struct_extract %34, #MySliceBuffer.owner
+  %37 = mark_dependence %35 on %36
+  %38 = struct_extract %37, #UnsafeMutablePointer._rawValue
+  %39 = metatype $@thin S1.Type
+  %40 = builtin "copyArray"<S1>(%39, undef : $Builtin.RawPointer, %38, undef : $Builtin.Word) : $()
+  destroy_value %8
+  end_borrow %26
+  destroy_value %12
+  %44 = tuple ()
+  return %44
 }
 

--- a/test/SILOptimizer/sil_combine_uncheck.sil
+++ b/test/SILOptimizer/sil_combine_uncheck.sil
@@ -27,9 +27,9 @@ bb0(%0 : $Builtin.Int1):
 }
 
 // CHECK-LABEL: sil @test_unconditional_checked_cast_addr_fail
-// CHECK: bb0
-// CHECK: unreachable
-// CHECK: }
+// CHECK:         cond_fail
+// CHECK-NEXT:    unconditional_checked_cast_addr
+// CHECK:       } // end sil function 'test_unconditional_checked_cast_addr_fail'
 sil @test_unconditional_checked_cast_addr_fail : $@convention(thin) (@in E, @in D) -> @out D {
 bb0(%0 : $*D, %1 : $*E, %2 : $*D):
   unconditional_checked_cast_addr E in %1 : $*E to D in %0 : $*D

--- a/test/SILOptimizer/sil_combine_uncheck_ossa.sil
+++ b/test/SILOptimizer/sil_combine_uncheck_ossa.sil
@@ -27,9 +27,9 @@ bb0(%0 : $Builtin.Int1):
 }
 
 // CHECK-LABEL: sil [ossa] @test_unconditional_checked_cast_addr_fail
-// CHECK: bb0
-// CHECK: unreachable
-// CHECK: }
+// CHECK:         cond_fail
+// CHECK-NEXT:    unconditional_checked_cast_addr
+// CHECK:       } // end sil function 'test_unconditional_checked_cast_addr_fail'
 sil [ossa] @test_unconditional_checked_cast_addr_fail : $@convention(thin) (@in E, @in D) -> @out D {
 bb0(%0 : $*D, %1 : $*E, %2 : $*D):
   unconditional_checked_cast_addr E in %1 : $*E to D in %0 : $*D

--- a/test/SILOptimizer/simplify_cond_fail.sil
+++ b/test/SILOptimizer/simplify_cond_fail.sil
@@ -16,21 +16,6 @@ bb0:
   return %r : $()
 }
 
-// CHECK-LABEL: sil @failing
-// CHECK:         cond_fail
-// CHECK-NEXT:    unreachable
-// CHECK:       } // end sil function 'failing'
-sil @failing : $@convention(thin) () -> () {
-bb0:
-  %0 = integer_literal $Builtin.Int1, -1
-  cond_fail %0 : $Builtin.Int1, "failing"
-  br bb1
-
-bb1:
-  %r = tuple ()
-  return %r : $()
-}
-
 // CHECK-LABEL: sil [ossa] @dont_remove_lifetime_ending_instructions :
 // CHECK:         cond_fail
 // CHECK-NEXT:    end_borrow %1


### PR DESCRIPTION
This optimization handles unconditional `cond_fail` instructions, i.e. `cond_fail`s with a non-zero `integer_literal` operand. It cuts off the control flow after such a `cond_fail` by inserting an `unreachable` instruction. However, this optimization cannot be done as instruction simplification, because it can leave OSSA lifetimes uncompleted. Other simplification may depend on complete lifetimes. Similar for constant folding failing casts: we also cannot insert an `unreachable` there.

Instead, do this optimization a new function pass (which can do lifetime completion).

Fixes a SIL verification error
rdar://173728487
