### PR TITLE
Fix DeinitDevirtualizer to handle non-generic deinitializer function

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/Devirtualization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/Devirtualization.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import AST
 import SIL
 
 /// Devirtualizes all value-type deinitializers of a `destroy_value`.
@@ -151,7 +152,7 @@ extension DestroyValueInst : DevirtualizableDestroy {
 
   fileprivate func createDeinitCall(to deinitializer: Function, _ context: some MutatingContext) {
     let builder = Builder(before: self, context)
-    let subs = context.getContextSubstitutionMap(for: type)
+    let subs = deinitializer.isGeneric ? context.getContextSubstitutionMap(for: type) : SubstitutionMap()
     let deinitRef = builder.createFunctionRef(deinitializer)
     if deinitializer.argumentConventions[deinitializer.selfArgumentIndex!].isIndirect {
       let allocStack = builder.createAllocStack(type)

--- a/test/SILOptimizer/moveonly_deinit_devirtualization.swift
+++ b/test/SILOptimizer/moveonly_deinit_devirtualization.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -sil-verify-all -emit-sil -O %s | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+
+public struct Outer<T> {}
+extension Outer where T == UInt8 {
+  public struct InnerNC: ~Copyable {
+    var x: Int
+    deinit {}
+  }
+}
+
+// rdar://173803881 (~Copyable type in all-concrete constrained extension)
+// The DeinitDevirtualization should not crash.
+//
+// CHECK-LABEL: sil @$s32moveonly_deinit_devirtualization24testConstrainedExtensionyyAA5OuterVAAs5UInt8VRszlE7InnerNCVyAF_GnF : $@convention(thin) (@owned Outer<UInt8>.InnerNC) -> () {
+// CHECK-NOT: destroy
+// CHECK-LABEL: } // end sil function '$s32moveonly_deinit_devirtualization24testConstrainedExtensionyyAA5OuterVAAs5UInt8VRszlE7InnerNCVyAF_GnF'
+public func testConstrainedExtension(_ s: consuming Outer<UInt8>.InnerNC) {}


### PR DESCRIPTION
Avoid passing an invalid substitution map into createApply.

Required conditions (from the bug report):
1. `~Copyable` struct with user-defined `deinit`
2. Nested inside a constrained extension where all generic parameters are concrete
3. A `destroy_value` or `destroy_addr` of the struct's value exists in some function
4. DeinitDevirtualizer runs (release-mode optimization pipeline)

Fixes rdar://173803881 ([GH:#88213] [SILOptimizer] DeinitDevirtualizer assertion
failure with ~Copyable type in all-concrete constrained extension)

Suggested by: coenttb

Note: I spent an hour trying to generate a .sil test case and failed
in the end.
