### PR TITLE
Fix IRGen/typed_allocation.swift - REQUIRES: embedded_stdlib

### DIFF
--- a/test/IRGen/typed_allocation.swift
+++ b/test/IRGen/typed_allocation.swift
@@ -2,6 +2,7 @@
 
 // REQUIRES: OS=macosx
 // REQUIRES: swift_in_compiler
+// REQUIRES: embedded_stdlib
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: swift_feature_TypedAllocation
 


### PR DESCRIPTION
Tests that require swift_feature_Embedded and use the stdlib also require
embedded_stdlib. This must be listed as an explicit requirement for tests
outside of the test/embedded subdirectory.

Without the fix, this test always fails locally for me with breaks the development process.