### PR TITLE
Revert "ASCII fast paths for unicode scalar distance (#79886)"

### DIFF
--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -176,10 +176,6 @@ extension String.UnicodeScalarView: BidirectionalCollection {
     let start = _guts.validateInclusiveScalarIndex(start)
     let end = _guts.validateInclusiveScalarIndex(end)
 
-    if _guts.isASCII {
-      return end._encodedOffset - start._encodedOffset
-    }
-    
     var i = start
     var count = 0
     if i < end {
@@ -199,12 +195,6 @@ extension String.UnicodeScalarView: BidirectionalCollection {
   @_alwaysEmitIntoClient
   public func index(_ i: Index, offsetBy distance: Int) -> Index {
     var i = _guts.validateInclusiveScalarIndex(i)
-    
-    if _guts.isASCII {
-      return _guts.validateInclusiveScalarIndex(
-        i.encoded(offsetBy: distance)._scalarAligned._knownUTF8
-      )
-    }
 
     if distance >= 0 {
       for _ in stride(from: 0, to: distance, by: 1) {
@@ -232,17 +222,8 @@ extension String.UnicodeScalarView: BidirectionalCollection {
     let start = _guts.ensureMatchingEncoding(i)
 
     var i = _guts.validateInclusiveScalarIndex(i)
-    
+
     if distance >= 0 {
-      if _guts.isASCII {
-        let targetOffset = i._encodedOffset + distance
-        guard limit < start || targetOffset <= limit._encodedOffset else {
-          return nil
-        }
-        return _guts.validateInclusiveScalarIndex(
-          i.encoded(offsetBy: distance)._scalarAligned._knownUTF8
-        )
-      }
       for _ in stride(from: 0, to: distance, by: 1) {
         guard limit < start || i < limit else { return nil }
         _precondition(i._encodedOffset < _guts.count, "String index is out of bounds")
@@ -250,15 +231,6 @@ extension String.UnicodeScalarView: BidirectionalCollection {
       }
       guard limit < start || i <= limit else { return nil }
     } else {
-      if _guts.isASCII {
-        let targetOffset = i._encodedOffset + distance
-        guard limit > start || targetOffset >= limit._encodedOffset else {
-          return nil
-        }
-        return _guts.validateInclusiveScalarIndex(
-          i.encoded(offsetBy: distance)._scalarAligned._knownUTF8
-        )
-      }
       for _ in stride(from: 0, to: distance, by: -1) {
         guard limit > start || i > limit else { return nil }
         _precondition(i._encodedOffset > 0, "String index is out of bounds")


### PR DESCRIPTION
This reverts commit b3fbc4cf75b9563e281cb46950117eceba6f6c79.

Need to make it work on arm64_32 before relanding it
