### PR TITLE
[Sema] Add fix-it to remove 'throws' for protocol witness throws conflict

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3277,9 +3277,19 @@ diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
                    req->isObjC());
     break;
 
-  case MatchKind::ThrowsConflict:
-    diags.diagnose(match.Witness, diag::protocol_witness_throws_conflict);
+  case MatchKind::ThrowsConflict: {
+    auto witness = match.Witness;
+    auto diag = diags.diagnose(witness, diag::protocol_witness_throws_conflict);
+    if (auto FD = dyn_cast<AbstractFunctionDecl>(witness))
+      if (auto thrownTypeRepr = FD->getThrownTypeRepr()) {
+        auto &SM = module->getASTContext().SourceMgr;
+        SourceLoc rParenLoc = Lexer::getLocForEndOfToken(SM, thrownTypeRepr->getEndLoc());
+        diag.fixItRemove(SourceRange(FD->getThrowsLoc(), rParenLoc));
+      } else {
+        diag.fixItRemove(FD->getThrowsLoc());
+      }
     break;
+  }
 
   case MatchKind::OptionalityConflict: {
     auto &adjustments = match.OptionalAdjustments;

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -34,6 +34,7 @@
 #include "swift/AST/ASTContextGlobalCache.h"
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/ASTPrinter.h"
+#include "swift/AST/ASTWalker.h"
 #include "swift/AST/AccessScope.h"
 #include "swift/AST/ClangModuleLoader.h"
 #include "swift/AST/ConcreteDeclRef.h"
@@ -43,6 +44,7 @@
 #include "swift/AST/DistributedDecl.h"
 #include "swift/AST/Effects.h"
 #include "swift/AST/ExistentialLayout.h"
+#include "swift/AST/Expr.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/NameLookup.h"
@@ -53,6 +55,7 @@
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/RequirementMatch.h"
+#include "swift/AST/Stmt.h"
 #include "swift/AST/Type.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/TypeDeclFinder.h"
@@ -3233,6 +3236,56 @@ static SourceLoc getIUOConflictLoc(ValueDecl *witness,
   return SourceLoc();
 }
 
+/// Check whether the witness body contains any throwing operations ('try'
+/// expressions or 'throw' statements) that removing the 'throws' clause from
+/// its signature would break. Effects inside nested closures and local
+/// functions do not propagate to the enclosing signature, so they are
+/// skipped. Returns true conservatively when the body is unavailable.
+static bool witnessBodyHasThrowingOperation(AbstractFunctionDecl *witness) {
+  auto *body = witness->getBody(/*canSynthesize=*/false);
+  if (!body)
+    return true;
+
+  class Walker : public ASTWalker {
+  public:
+    bool FoundThrowingOperation = false;
+
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::Expansion;
+    }
+
+    PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
+      if (isa<AbstractClosureExpr>(E))
+        return Action::SkipNode(E);
+
+      // 'try?' and 'try!' do not require the enclosing function to throw.
+      if (isa<TryExpr>(E)) {
+        FoundThrowingOperation = true;
+        return Action::Stop();
+      }
+
+      return Action::Continue(E);
+    }
+
+    PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
+      if (isa<ThrowStmt>(S)) {
+        FoundThrowingOperation = true;
+        return Action::Stop();
+      }
+
+      return Action::Continue(S);
+    }
+
+    PreWalkAction walkToDeclPre(Decl *D) override {
+      return Action::SkipNodeIf(isa<AbstractFunctionDecl>(D) ||
+                                isa<NominalTypeDecl>(D));
+    }
+  } walker;
+
+  body->walk(walker);
+  return walker.FoundThrowingOperation;
+}
+
 /// Diagnose a requirement match, describing what went wrong (or not).
 static void
 diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
@@ -3359,9 +3412,23 @@ diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
                    req->isObjC());
     break;
 
-  case MatchKind::ThrowsConflict:
-    diags.diagnose(match.Witness, diag::protocol_witness_throws_conflict);
+  case MatchKind::ThrowsConflict: {
+    auto witness = match.Witness;
+    auto diag = diags.diagnose(witness, diag::protocol_witness_throws_conflict);
+    auto FD = dyn_cast<AbstractFunctionDecl>(witness);
+    // Only suggest removing 'throws' when the body has no throwing
+    // operations; otherwise the fix-it would break the body.
+    if (FD && !witnessBodyHasThrowingOperation(FD)) {
+      if (auto thrownTypeRepr = FD->getThrownTypeRepr()) {
+        auto &SM = module->getASTContext().SourceMgr;
+        SourceLoc rParenLoc = Lexer::getLocForEndOfToken(SM, thrownTypeRepr->getEndLoc());
+        diag.fixItRemove(SourceRange(FD->getThrowsLoc(), rParenLoc));
+      } else {
+        diag.fixItRemove(FD->getThrowsLoc());
+      }
+    }
     break;
+  }
 
   case MatchKind::OptionalityConflict: {
     auto &adjustments = match.OptionalAdjustments;

--- a/test/decl/func/rethrows.swift
+++ b/test/decl/func/rethrows.swift
@@ -24,10 +24,10 @@ protocol P {
 
 struct T0 : P { // expected-error {{type 'T0' does not conform to protocol 'P'}} expected-note {{add stubs for conformance}}
   func tf() throws {}
-  func nf() throws {} // expected-note {{candidate throws, but protocol does not allow it}}
+  func nf() throws {} // expected-note {{candidate throws, but protocol does not allow it}}{{13-20=}}
 
   func thf(_ f: () throws -> ()) throws {}
-  func nhf(_ f: () throws -> ()) throws {} // expected-note {{candidate throws, but protocol does not allow it}}
+  func nhf(_ f: () throws -> ()) throws {} // expected-note {{candidate throws, but protocol does not allow it}}{{34-41=}}
   func rhf(_ f: () throws -> ()) throws {} // expected-note {{candidate is not 'rethrows', but protocol requires it}}
 }
 
@@ -45,7 +45,7 @@ struct T2 : P { // expected-error {{type 'T2' does not conform to protocol 'P'}}
   func nf() {}
 
   func thf(_ f: () throws -> ()) rethrows {}
-  func nhf(_ f: () throws -> ()) rethrows {} // expected-note {{candidate throws, but protocol does not allow it}}
+  func nhf(_ f: () throws -> ()) rethrows {} // expected-note {{candidate throws, but protocol does not allow it}}{{34-43=}}
   func rhf(_ f: () throws -> ()) rethrows {}
 }
 

--- a/test/decl/protocol/conforms/effects.swift
+++ b/test/decl/protocol/conforms/effects.swift
@@ -8,7 +8,7 @@ protocol P {
 
 struct S {
     func perform<E: Error>(_ body: () throws(E) -> Void) throws(E) -> Void {
-    // expected-note@-1 {{candidate throws, but protocol does not allow it}}
+    // expected-note@-1 {{candidate throws, but protocol does not allow it}}{{58-68=}}
         try body()
     }
 }

--- a/test/decl/protocol/conforms/effects.swift
+++ b/test/decl/protocol/conforms/effects.swift
@@ -8,7 +8,7 @@ protocol P {
 
 struct S {
     func perform<E: Error>(_ body: () throws(E) -> Void) throws(E) -> Void {
-    // expected-note@-1 {{candidate throws, but protocol does not allow it}}
+    // expected-note@-1 {{candidate throws, but protocol does not allow it}}{{none}}
         try body()
     }
 }

--- a/test/decl/protocol/conforms/typed_throws.swift
+++ b/test/decl/protocol/conforms/typed_throws.swift
@@ -29,7 +29,7 @@ protocol VeryThrowing {
 struct ConformingToVeryThrowing: VeryThrowing {
   func f() throws(MyError) { } // okay to make type more specific
   func g() { } // okay to be non-throwing
-  func h() throws(MyError) { } // expected-note{{candidate throws, but protocol does not allow it}}
+  func h() throws(MyError) { } // expected-note{{candidate throws, but protocol does not allow it}}{{12-28=}} 
                                // FIXME: Diagnostic above should be better
   func i() throws(SubError) { } // okay to have a subtype
 

--- a/test/decl/protocol/effectful_properties.swift
+++ b/test/decl/protocol/effectful_properties.swift
@@ -52,13 +52,13 @@ class CN_AT : AT   { typealias V = Int; var someProp : Int { _read {yield 0} } }
 // Remaining conformances test the limit check for kinds of effects allowed
 
 // expected-note@+3 {{add stubs for conformance}}
-// expected-note@+2 3 {{candidate throws, but protocol does not allow it}}
+// expected-note@+2 3 {{candidate throws, but protocol does not allow it}} {{65-72=}}
 // expected-error@+1 {{type 'CT_N' does not conform to protocol 'None'}}
 class CT_N : None { typealias V = Int; var someProp : Int { get throws {0} } }
 class CT_T : T    { typealias V = Int; var someProp : Int { get throws {0} } }
 
 // expected-note@+3 {{add stubs for conformance}}
-// expected-note@+2 {{candidate throws, but protocol does not allow it}}
+// expected-note@+2 {{candidate throws, but protocol does not allow it}} {{65-72=}}
 // expected-error@+1{{type 'CT_A' does not conform to protocol 'A'}}
 class CT_A : A    { typealias V = Int; var someProp : Int { get throws {0} } }
 class CT_AT : AT   { typealias V = Int; var someProp : Int { get throws {0} } }
@@ -83,21 +83,21 @@ enum CA_AT : AT   { typealias V = Int; var someProp : Int { get async {0} } }
 // expected-note@+2 {{add stubs for conformance}}
 // expected-error@+1 {{type 'CAT_N' does not conform to protocol 'None'}}
 class CAT_N : None { typealias V = Int;
-  // expected-note@+2 {{candidate throws, but protocol does not allow it}}
+  // expected-note@+2 {{candidate throws, but protocol does not allow it}} {{34-41=}}
   // expected-note@+1 2 {{candidate is 'async', but protocol requirement is not}}
   var someProp : Int { get async throws {0} }
 }
 // expected-note@+2 {{add stubs for conformance}}
 // expected-error@+1 {{type 'CAT_T' does not conform to protocol 'T'}}
 enum CAT_T : T    { typealias V = Int;
-  // expected-note@+2 {{candidate throws, but protocol does not allow it}}
+  // expected-note@+2 {{candidate throws, but protocol does not allow it}} {{34-41=}}
   // expected-note@+1 2 {{candidate is 'async', but protocol requirement is not}}
   var someProp : Int { get async throws {0} }
 }
 // expected-note@+2 {{add stubs for conformance}}
 // expected-error@+1 {{type 'CAT_A' does not conform to protocol 'A'}}
 class CAT_A : A    { typealias V = Int;
-  // expected-note@+1 {{candidate throws, but protocol does not allow it}}
+  // expected-note@+1 {{candidate throws, but protocol does not allow it}} {{34-41=}}
   var someProp : Int { get async throws {0} }
 }
 class CAT_AT : AT   { typealias V = Int;
@@ -172,7 +172,7 @@ struct SN_N : NoneSub
 class SA_N : NoneSub // expected-error{{type 'SA_N' does not conform to protocol 'NoneSub'}} expected-note {{add stubs for conformance}}
   { subscript(_ i : Int) -> Bool { get async { true } }} // expected-note{{candidate is 'async', but protocol requirement is not}}
 class ST_N : NoneSub // expected-error{{type 'ST_N' does not conform to protocol 'NoneSub'}} expected-note {{add stubs for conformance}}
-  { subscript(_ i : Int) -> Bool { get throws { true } }} // expected-note{{candidate throws, but protocol does not allow it}}
+  { subscript(_ i : Int) -> Bool { get throws { true } }} // expected-note{{candidate throws, but protocol does not allow it}} {{40-47=}}
 class SAT_N : NoneSub // expected-error{{type 'SAT_N' does not conform to protocol 'NoneSub'}} expected-note {{add stubs for conformance}}
   { subscript(_ i : Int) -> Bool { get async throws { true } }} // expected-note{{candidate is 'async', but protocol requirement is not}}
 
@@ -181,9 +181,9 @@ class SN_A : AsyncSub
 struct SA_A : AsyncSub
   { subscript(_ i : Int) -> Bool { get async { true } }}
 enum ST_A : AsyncSub // expected-error{{type 'ST_A' does not conform to protocol 'AsyncSub'}} expected-note {{add stubs for conformance}}
-  { subscript(_ i : Int) -> Bool { get throws { true } }} // expected-note{{candidate throws, but protocol does not allow it}}
+  { subscript(_ i : Int) -> Bool { get throws { true } }} // expected-note{{candidate throws, but protocol does not allow it}} {{40-47=}}
 class SAT_A : AsyncSub // expected-error{{type 'SAT_A' does not conform to protocol 'AsyncSub'}} expected-note {{add stubs for conformance}}
-  { subscript(_ i : Int) -> Bool { get async throws { true } }} // expected-note{{candidate throws, but protocol does not allow it}}
+  { subscript(_ i : Int) -> Bool { get async throws { true } }} // expected-note{{candidate throws, but protocol does not allow it}} {{46-53=}}
 
 class SN_T : ThrowsSub
   { subscript(_ i : Int) -> Bool { get { true } }}


### PR DESCRIPTION
## Summary

When a protocol witness has a `throws` clause that the protocol requirement does not allow, the compiler emits a note ("candidate throws, but protocol does not allow it") but previously offered no fix-it.

This PR adds a fix-it to remove the `throws` clause from the witness:
- For plain `throws` / `rethrows`, removes the keyword
- For typed throws like `throws(MyError)`, removes the entire clause including the error type

## Motivation

```swift
protocol P {
    func f()
}

struct S: P {
    func f() throws {} // note: candidate throws, but protocol does not allow it
    //       ~~~~~~ fix-it: remove 'throws'
}
```

This helps users quickly resolve conformance failures, especially for typed throws where the fix may not be immediately obvious.

## Changes

- `lib/Sema/TypeCheckProtocol.cpp`: In the `ThrowsConflict` case of `diagnoseMatch`, capture the `InFlightDiagnostic` and attach a `fixItRemove` targeting the throws clause. Uses `getThrownTypeRepr()` to determine if the full `throws(ErrorType)` range needs to be removed.
- Updated tests in `test/decl/func/rethrows.swift`, `test/decl/protocol/conforms/effects.swift`, `test/decl/protocol/conforms/typed_throws.swift`, and `test/decl/protocol/effectful_properties.swift` to verify the expected fix-its.

## Note

For property witnesses (e.g., `var prop: Int { get throws { ... } }`), the witness is reported as a `VarDecl` rather than an `AccessorDecl`, so the `dyn_cast<AbstractFunctionDecl>` does not succeed and no fix-it is emitted. This could be addressed in a follow-up.
