### PR TITLE
[6.3 🍒][AutoDiff] Allow force-inlining of implicitly generated VJP/JVP

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -1030,6 +1030,10 @@ static SILFunction *createEmptyVJP(ADContext &context,
       original->isRuntimeAccessible());
   vjp->setDebugScope(new (module) SILDebugScope(original->getLocation(), vjp));
 
+  if (original->getInlineStrategy() == AlwaysInline ||
+      original->getInlineStrategy() == HeuristicAlwaysInline)
+    vjp->setInlineStrategy(HeuristicAlwaysInline);
+
   LLVM_DEBUG(llvm::dbgs() << "VJP type: " << vjp->getLoweredFunctionType()
                           << "\n");
   return vjp;
@@ -1073,6 +1077,10 @@ static SILFunction *createEmptyJVP(ADContext &context,
       original->isDistributed(),
       original->isRuntimeAccessible());
   jvp->setDebugScope(new (module) SILDebugScope(original->getLocation(), jvp));
+
+  if (original->getInlineStrategy() == AlwaysInline ||
+      original->getInlineStrategy() == HeuristicAlwaysInline)
+    jvp->setInlineStrategy(HeuristicAlwaysInline);
 
   LLVM_DEBUG(llvm::dbgs() << "JVP type: " << jvp->getLoweredFunctionType()
                           << "\n");


### PR DESCRIPTION
Note: this is already cherry-picked to release/6.3.1. Cherry-picking to release/6.3 as requested in https://github.com/swiftlang/swift/pull/87959#issuecomment-4179018996

- **Explanation**:
This change allows force-inlining of implicitly generated VJP/JVP. This functionality is needed for tests relying on certain inlining behavior which are otherwise fragile and prone to changes in inlining due to changes in other passes.

- **Scope**:
This affects only implicitly generated AutoDiff VJP/JVP functions and only in cases when a user explicitly requests for force-inline. This is a prerequisite for #87961 optimization patch allowing to unbreak tests relying on certain inlining behavior. This patch which should not break existing code.

- **Original PRs**:
https://github.com/swiftlang/swift/pull/87859

- **Risk**:
Low. The change is AutoDiff-specific and does not affect code not using AutoDiff functionality.

- **Testing**:
This patch by itself does not contain tests since: (a) the functionality is tested by AutoDiff/SILOptimizer/licm_context.swift passing after applying #87961; (b) the patch is trivial enough.

  Standard Swift CI tests have passed on `main`.

- **Reviewers**:
Approved by @asl 