### PR TITLE
[Concurrency] Don't attempt to infer `nonisolated(nonsending)` on non…

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6216,17 +6216,29 @@ computeDefaultInferredActorIsolation(ValueDecl *value) {
     // decl.
     auto isolation = getOverriddenIsolationFor(value);
 
-    // If this is an override of an async completion handler, mark
-    // it `@concurrent` instead of inferring `nonisolated(nonsending)`
-    // to preserve pre-SE-0461 behavior.
-    if (isolation.isCallerIsolationInheriting() &&
-        overriddenValue->hasClangNode()) {
-      if (auto *AFD = dyn_cast<AbstractFunctionDecl>(overriddenValue)) {
-        if (AFD->getForeignAsyncConvention()) {
-          return {{ActorIsolation::forNonisolated(/*unsafe=*/false),
-                   IsolationSource(overriddenValue, IsolationSource::Override)},
-                  overriddenValue,
-                  isolation};
+    // Overriden declaration is `nonisolated(nonsending)`.
+    if (isolation.isCallerIsolationInheriting()) {
+      // Override is non-async when the overriden member was async. Let's
+      // produce `nonisolated` here which is equivalent.
+      if (!value->isAsync()) {
+        return {{ActorIsolation::forNonisolated(/*unsafe=*/false),
+                 IsolationSource(overriddenValue, IsolationSource::Override)},
+                overriddenValue,
+                isolation};
+      }
+
+      // If this is an override of an async completion handler, mark
+      // it `@concurrent` instead of inferring `nonisolated(nonsending)`
+      // to preserve pre-SE-0461 behavior.
+      if (overriddenValue->hasClangNode()) {
+        if (auto *AFD = dyn_cast<AbstractFunctionDecl>(overriddenValue)) {
+          if (AFD->getForeignAsyncConvention()) {
+            return {
+                {ActorIsolation::forNonisolated(/*unsafe=*/false),
+                 IsolationSource(overriddenValue, IsolationSource::Override)},
+                overriddenValue,
+                isolation};
+          }
         }
       }
     }

--- a/test/Concurrency/attr_execution/property_overrides.swift
+++ b/test/Concurrency/attr_execution/property_overrides.swift
@@ -1,0 +1,42 @@
+// RUN: %target-swift-emit-silgen %s -target %target-swift-5.1-abi-triple -language-mode 6 -enable-upcoming-feature NonisolatedNonsendingByDefault | %FileCheck %s
+
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
+
+class Base {
+  // CHECK: Base.prop.getter
+  // CHECK: Isolation: caller_isolation_inheriting
+  // CHECK-LABEL: sil hidden [ossa] @$s18property_overrides4BaseC4propSivg : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed Base) -> (Int, @error any Error)
+  var prop: Int { get async throws { 0 } }
+}
+
+class OverrideWithSync: Base {
+  // CHECK: OverrideWithSync.prop.getter
+  // CHECK: Isolation: nonisolated
+  // CHECK-LABEL: sil hidden [ossa] @$s18property_overrides16OverrideWithSyncC4propSivg : $@convention(method) (@guaranteed OverrideWithSync) -> Int
+  override var prop: Int { 42 }
+}
+
+// CHECK: // vtable thunk for Base.prop.getter dispatching to OverrideWithSync.prop.getter
+// CHECK: sil private [thunk] [ossa] @$s18property_overrides16OverrideWithSyncC4propSivgAA4BaseCADSivgTV : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed OverrideWithSync) -> (Int, @error any Error) {
+// CHECK: bb0([[ACTOR:%.*]] : @guaranteed $Builtin.ImplicitActor, [[SELF:%.*]] : @guaranteed $OverrideWithSync):
+// CHECK:   [[PROP_OVERRIDE:%.*]] = function_ref @$s18property_overrides16OverrideWithSyncC4propSivg : $@convention(method) (@guaranteed OverrideWithSync) -> Int
+// CHECK:   [[RESULT:%.*]] = apply [[PROP_OVERRIDE]]([[SELF]]) : $@convention(method) (@guaranteed OverrideWithSync) -> Int
+// CHECK:   hop_to_executor [[ACTOR]]
+// CHECK:   return [[RESULT]]
+// CHECK: } // end sil function '$s18property_overrides16OverrideWithSyncC4propSivgAA4BaseCADSivgTV'
+
+class OverridenWithAsync: Base {
+  // CHECK: OverridenWithAsync.prop.getter
+  // CHECK: Isolation: caller_isolation_inheriting
+  // CHECK-LABEL: sil hidden [ossa] @$s18property_overrides18OverridenWithAsyncC4propSivg : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed OverridenWithAsync) -> Int
+  override var prop: Int { get async { 42 } }
+}
+
+// CHECK: // vtable thunk for Base.prop.getter dispatching to OverridenWithAsync.prop.getter
+// CHECK: sil private [thunk] [ossa] @$s18property_overrides18OverridenWithAsyncC4propSivgAA4BaseCADSivgTV : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed OverridenWithAsync) -> (Int, @error any Error) {
+// CHECK: bb0([[ACTOR:%.*]] : @guaranteed $Builtin.ImplicitActor, [[SELF:%.*]] : @guaranteed $OverridenWithAsync):
+// CHECK:   [[PROP_OVERRIDE:%.*]] = function_ref @$s18property_overrides18OverridenWithAsyncC4propSivg : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed OverridenWithAsync) -> Int
+// CHECK:   [[RESULT:%.*]] = apply [[PROP_OVERRIDE]]([[ACTOR]], [[SELF]]) : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed OverridenWithAsync) -> Int
+// CHECK:   hop_to_executor [[ACTOR]]
+// CHECK:   return [[RESULT]]
+// CHECK: } // end sil function '$s18property_overrides18OverridenWithAsyncC4propSivgAA4BaseCADSivgTV'


### PR DESCRIPTION
…-async overrides

Handle a situation where an async `nonisolated(nonsending)` property gets overriden by non-async one and use `nonisolated` isolation for that. Methods don't allow this sort of override.

Resolves: rdar://157226022

<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
