### PR TITLE
[android][test] Disable failing `Interop/Cxx/stdlib/android-and-std-module.swift` test since #88236

### DIFF
--- a/test/Interop/Cxx/stdlib/android-and-std-module.swift
+++ b/test/Interop/Cxx/stdlib/android-and-std-module.swift
@@ -12,7 +12,7 @@
 // RUN: %target-swift-frontend %s -c -cxx-interoperability-mode=default -Xcc -std=c++17 -Xcc -fmodules-cache-path=%t -DADD_CXXSTDLIB
 // RUN: %target-swift-frontend %s -c -cxx-interoperability-mode=default -Xcc -std=c++20 -Xcc -fmodules-cache-path=%t -DADD_CXXSTDLIB
 
-// REQUIRES: OS=linux-android
+// REQUIRES: OS=linux-android-stat
 
 import Android
 import Bionic


### PR DESCRIPTION
We'll take a look at what those changes broke and try to get it re-enabled.