### PR TITLE
Fix escape analysis for pointer_to_address 

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeUtils.swift
@@ -275,6 +275,15 @@ struct EscapeUtilityTypes {
       return Self(projectionPath: self.projectionPath, followStores: self.followStores,
                   addressIsStored: self.addressIsStored, knownType: knownType)
     }
+
+    func forPointerToAddress(_ pta: PointerToAddressInst) -> Self {
+      // When `originatingAddress` is nil, the pointer_to_address may reinterpret the type, the accumulated projection path is no longer meaningful.
+      // Use anyValueFields to be conservative.
+      if pta.originatingAddress == nil {
+        return self.with(projectionPath: SmallProjectionPath(.anyValueFields)).with(knownType: nil)
+      }
+      return self.with(knownType: nil)
+    }
     
     func merge(with other: EscapePath) -> EscapePath {
       let mergedPath = self.projectionPath.merge(with: other.projectionPath)
@@ -403,7 +412,7 @@ fileprivate struct EscapeWalker<V: EscapeVisitor> : ValueDefUseWalker,
       // 2. something can escape in a destructor when the context is destroyed
       return walkDownUses(ofValue: pai, path: path.with(knownType: nil))
     case let pta as PointerToAddressInst:
-      return walkDownUses(ofAddress: pta, path: path.with(knownType: nil))
+      return walkDownUses(ofAddress: pta, path: path.forPointerToAddress(pta))
     case let cv as ConvertFunctionInst:
       return walkDownUses(ofValue: cv, path: path.with(knownType: nil))
     case let bi as BuiltinInst:
@@ -844,8 +853,8 @@ fileprivate struct EscapeWalker<V: EscapeVisitor> : ValueDefUseWalker,
       } else {
         return isEscaping
       }
-    case is PointerToAddressInst:
-      return walkUp(value: (def as! SingleValueInstruction).operands[0].value, path: path.with(knownType: nil))
+    case let pta as PointerToAddressInst:
+      return walkUp(value: pta.operands[0].value, path: path.forPointerToAddress(pta))
     case let rta as RefTailAddrInst:
       return walkUp(value: rta.instance, path: path.push(.tailElements, index: 0).with(knownType: nil))
     case let rea as RefElementAddrInst:

--- a/test/SILOptimizer/dead_alloc_elim_ossa.sil
+++ b/test/SILOptimizer/dead_alloc_elim_ossa.sil
@@ -579,3 +579,28 @@ bb0:
   return %5
 }
 
+struct UInt64 {
+  var _value: Builtin.Int64
+}
+
+// CHECK-LABEL: sil @dont_remove_store_read_via_address_to_pointer :
+// CHECK:         [[S:%[0-9]+]] = alloc_stack
+// CHECK:         tuple_element_addr [[S]]{{.*}}, 0
+// CHECK:         store
+// CHECK:         tuple_element_addr [[S]]{{.*}}, 1
+// CHECK:         store
+// CHECK:       } // end sil function 'dont_remove_store_read_via_address_to_pointer'
+sil @dont_remove_store_read_via_address_to_pointer : $@convention(thin) (UInt64, UInt64) -> Builtin.Int64 {
+bb0(%0 : $UInt64, %1 : $UInt64):
+  %2 = alloc_stack $(UInt64, UInt64)
+  %3 = tuple_element_addr %2 : $*(UInt64, UInt64), 0
+  store %0 to %3 : $*UInt64
+  %5 = tuple_element_addr %2 : $*(UInt64, UInt64), 1
+  store %1 to %5 : $*UInt64
+  %7 = address_to_pointer [stack_protection] %2 : $*(UInt64, UInt64) to $Builtin.RawPointer
+  %8 = pointer_to_address %7 : $Builtin.RawPointer to $*UInt64
+  %9 = struct_element_addr %8 : $*UInt64, #UInt64._value
+  %10 = load %9 : $*Builtin.Int64
+  dealloc_stack %2 : $*(UInt64, UInt64)
+  return %10 : $Builtin.Int64
+}


### PR DESCRIPTION
When a `pointer_to_address` reinterprets the type (i.e. the address type differs from the originating `address_to_pointer`), the accumulated projection path is no longer meaningful. Use `anyValueFields` to be conservative in both the walk-down and walk-up directions.

Without this fix, escape analysis could incorrectly conclude that a store to an `alloc_stack` does not escape when it is read back through a type-reinterpreting `pointer_to_address`, causing DeadStoreElimination to illegally remove the store.

rdar://171841812

