### PR TITLE
Add a sanity check for self while optimizing fixed storage bounds checks

### DIFF
--- a/lib/SILOptimizer/LoopTransforms/BoundsCheckOpts.cpp
+++ b/lib/SILOptimizer/LoopTransforms/BoundsCheckOpts.cpp
@@ -1214,6 +1214,23 @@ bool BoundsCheckOpts::removeRedundantArrayChecksInBlock(SILBasicBlock &BB) {
   return Changed;
 }
 
+static bool canOptimize(FixedStorageSemanticsCall call) {
+  if (!call.hasSelf()) {
+    return false;
+  }
+  auto selfValue = call.getSelf();
+  if (!selfValue->getType().isAddress()) {
+    return true;
+  }
+  auto rootAddr = lookThroughAddressAndValueProjections(selfValue);
+  auto *funcArg = dyn_cast<SILFunctionArgument>(rootAddr);
+  if (!funcArg || funcArg->getArgumentConvention() !=
+                      SILArgumentConvention::Indirect_In_Guaranteed) {
+    return false;
+  }
+  return true;
+}
+
 bool BoundsCheckOpts::hoistFixedStorageBoundsChecksInBlock(SILBasicBlock &block) {
   bool changed = false;
 
@@ -1231,6 +1248,10 @@ bool BoundsCheckOpts::hoistFixedStorageBoundsChecksInBlock(SILBasicBlock &block)
         fixedStorageCall.getKind() !=
             FixedStorageSemanticsCallKind::CheckIndex ||
         fixedStorageCall->getNumArguments() < 2) {
+      continue;
+    }
+
+    if (!canOptimize(fixedStorageCall)) {
       continue;
     }
 
@@ -1700,13 +1721,11 @@ bool BoundsCheckOpts::hoistFixedStorageBoundsChecksInLoop(
             FixedStorageSemanticsCallKind::CheckIndex) {
       continue;
     }
-
-    if (!fixedStorageSemantics->hasSelfArgument()) {
+    if (!canOptimize(fixedStorageSemantics)) {
       continue;
     }
 
-    auto selfValue = fixedStorageSemantics->getSelfArgument();
-
+    auto selfValue = fixedStorageSemantics.getSelf();
     if (!DT->dominates(selfValue->getParentBlock(), preheader)) {
       LLVM_DEBUG(llvm::dbgs()
                  << "  " << *selfValue << " does not dominate preheader\n");
@@ -1798,7 +1817,7 @@ bool BoundsCheckOpts::removeRedundantFixedStorageBoundsChecksInLoop(
       continue;
     }
 
-    if (!fixedStorageSemantics->hasSelfArgument()) {
+    if (!canOptimize(fixedStorageSemantics)) {
       continue;
     }
 

--- a/test/SILOptimizer/fixed_storage_bounds_check_hoisting.sil
+++ b/test/SILOptimizer/fixed_storage_bounds_check_hoisting.sil
@@ -229,3 +229,115 @@ bb3:
   %ret = struct $Bool (%true_val : $Builtin.Int1)
   return %ret : $Bool
 }
+
+sil [_semantics "fixed_storage.check_index"] @checkIndex_addr : $@convention(method) (Int, @in_guaranteed Span<Int>) -> ()
+
+sil @replace_span : $@convention(thin) (@inout Span<Int>) -> ()
+
+// CHECK-LABEL: sil @test_checkindex_address_self_across_inout :
+// CHECK: function_ref @checkIndex_addr
+// CHECK: apply {{%[0-9]+}}({{%[0-9]+}}, %0)
+// CHECK: function_ref @replace_span
+// CHECK: apply
+// CHECK: apply {{%[0-9]+}}({{%[0-9]+}}, %0)
+// CHECK-LABEL: } // end sil function 'test_checkindex_address_self_across_inout'
+sil @test_checkindex_address_self_across_inout : $@convention(thin) (@inout Span<Int>) -> () {
+bb0(%0 : $*Span<Int>):
+  %idx1_raw = integer_literal $Builtin.Int64, 0
+  %idx1 = struct $Int (%idx1_raw : $Builtin.Int64)
+  %check_fn = function_ref @checkIndex_addr : $@convention(method) (Int, @in_guaranteed Span<Int>) -> ()
+  %c1 = apply %check_fn(%idx1, %0) : $@convention(method) (Int, @in_guaranteed Span<Int>) -> ()
+
+  %replace_fn = function_ref @replace_span : $@convention(thin) (@inout Span<Int>) -> ()
+  %r = apply %replace_fn(%0) : $@convention(thin) (@inout Span<Int>) -> ()
+
+  %idx2_raw = integer_literal $Builtin.Int64, 5
+  %idx2 = struct $Int (%idx2_raw : $Builtin.Int64)
+  %c2 = apply %check_fn(%idx2, %0) : $@convention(method) (Int, @in_guaranteed Span<Int>) -> ()
+
+  %t = tuple ()
+  return %t : $()
+}
+
+sil [_semantics "fixed_storage.get_count"] @getCount_addr : $@convention(method) (@in_guaranteed Span<Int>) -> Int
+
+// CHECK-LABEL: sil @test_checkindex_address_self_loop_hoist :
+// CHECK: bb2({{%[0-9]+}} : $Builtin.Int64):
+// CHECK:   function_ref @checkIndex_addr
+// CHECK:   apply
+// CHECK:   function_ref @replace_span
+// CHECK:   apply
+// CHECK-LABEL: } // end sil function 'test_checkindex_address_self_loop_hoist'
+sil @test_checkindex_address_self_loop_hoist : $@convention(thin) (@inout Span<Int>) -> () {
+bb0(%0 : $*Span<Int>):
+  %zero = integer_literal $Builtin.Int64, 0
+  %get_count_fn = function_ref @getCount_addr : $@convention(method) (@in_guaranteed Span<Int>) -> Int
+  %count_struct = apply %get_count_fn(%0) : $@convention(method) (@in_guaranteed Span<Int>) -> Int
+  %count = struct_extract %count_struct, #Int._value
+  %is_zero = builtin "cmp_eq_Int64"(%zero : $Builtin.Int64, %count : $Builtin.Int64) : $Builtin.Int1
+  cond_br %is_zero, bb3, bb1
+
+bb1:
+  br bb2(%zero : $Builtin.Int64)
+
+bb2(%i : $Builtin.Int64):
+  %idx = struct $Int (%i : $Builtin.Int64)
+  %check_fn = function_ref @checkIndex_addr : $@convention(method) (Int, @in_guaranteed Span<Int>) -> ()
+  %c1 = apply %check_fn(%idx, %0) : $@convention(method) (Int, @in_guaranteed Span<Int>) -> ()
+
+  %replace_fn = function_ref @replace_span : $@convention(thin) (@inout Span<Int>) -> ()
+  %r = apply %replace_fn(%0) : $@convention(thin) (@inout Span<Int>) -> ()
+
+  %one = integer_literal $Builtin.Int64, 1
+  %no_trap = integer_literal $Builtin.Int1, 0
+  %inc = builtin "sadd_with_overflow_Int64"(%i : $Builtin.Int64, %one : $Builtin.Int64, %no_trap : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %next = tuple_extract %inc : $(Builtin.Int64, Builtin.Int1), 0
+  %done = builtin "cmp_eq_Int64"(%next : $Builtin.Int64, %count : $Builtin.Int64) : $Builtin.Int1
+  cond_br %done, bb3, bb2(%next : $Builtin.Int64)
+
+bb3:
+  %t = tuple ()
+  return %t : $()
+}
+
+// CHECK-LABEL: sil @test_checkindex_address_self_loop_redundant :
+// CHECK: bb2({{%[0-9]+}} : $Builtin.Int64):
+// CHECK:   function_ref @checkIndex_addr
+// CHECK:   apply {{%[0-9]+}}({{%[0-9]+}}, %0)
+// CHECK:   function_ref @replace_span
+// CHECK:   apply
+// CHECK:   apply {{%[0-9]+}}({{%[0-9]+}}, %0)
+// CHECK-LABEL: } // end sil function 'test_checkindex_address_self_loop_redundant'
+sil @test_checkindex_address_self_loop_redundant : $@convention(thin) (@inout Span<Int>) -> () {
+bb0(%0 : $*Span<Int>):
+  %zero = integer_literal $Builtin.Int64, 0
+  %get_count_fn = function_ref @getCount_addr : $@convention(method) (@in_guaranteed Span<Int>) -> Int
+  %count_struct = apply %get_count_fn(%0) : $@convention(method) (@in_guaranteed Span<Int>) -> Int
+  %count = struct_extract %count_struct, #Int._value
+  %is_zero = builtin "cmp_eq_Int64"(%zero : $Builtin.Int64, %count : $Builtin.Int64) : $Builtin.Int1
+  cond_br %is_zero, bb3, bb1
+
+bb1:
+  br bb2(%zero : $Builtin.Int64)
+
+bb2(%i : $Builtin.Int64):
+  %idx = struct $Int (%i : $Builtin.Int64)
+  %check_fn = function_ref @checkIndex_addr : $@convention(method) (Int, @in_guaranteed Span<Int>) -> ()
+  %c1 = apply %check_fn(%idx, %0) : $@convention(method) (Int, @in_guaranteed Span<Int>) -> ()
+
+  %replace_fn = function_ref @replace_span : $@convention(thin) (@inout Span<Int>) -> ()
+  %r = apply %replace_fn(%0) : $@convention(thin) (@inout Span<Int>) -> ()
+
+  %c2 = apply %check_fn(%idx, %0) : $@convention(method) (Int, @in_guaranteed Span<Int>) -> ()
+
+  %one = integer_literal $Builtin.Int64, 1
+  %no_trap = integer_literal $Builtin.Int1, 0
+  %inc = builtin "sadd_with_overflow_Int64"(%i : $Builtin.Int64, %one : $Builtin.Int64, %no_trap : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %next = tuple_extract %inc : $(Builtin.Int64, Builtin.Int1), 0
+  %done = builtin "cmp_eq_Int64"(%next : $Builtin.Int64, %count : $Builtin.Int64) : $Builtin.Int1
+  cond_br %done, bb3, bb2(%next : $Builtin.Int64)
+
+bb3:
+  %t = tuple ()
+  return %t : $()
+}

--- a/test/SILOptimizer/inlinearray_bounds_check_tests.swift
+++ b/test/SILOptimizer/inlinearray_bounds_check_tests.swift
@@ -312,9 +312,10 @@ public func local_inlinearray_repeating_init_sum_iterate_to_count_trap_spl() -> 
   return sum
 }
 
+// TODO: To support hoisting bounds checks of mutable InlineArray, we should prove it's not rewritten within the loop.
 // CHECK-SIL-LABEL: sil @$s30inlinearray_bounds_check_tests0A11_inc_by_oneyys11InlineArrayVyxSiGz_SitSiRVzlF :
 // CHECK-SIL: bb3({{.*}}):
-// CHECK-SIL-NOT: cond_fail {{.*}}, "Index out of bounds"
+// TODO-CHECK-SIL-NOT: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: cond_br
 public func inlinearray_inc_by_one<let N: Int>(_ v: inout InlineArray<N, Int>, _ n: Int) {
   for i in v.indices {


### PR DESCRIPTION
 Add a sanity check to ensure we don't have self with address type while optimizing bounds checks for fixed storage types.
    
When the self operand of a fixed_storage.check_index call is an address type (e.g. @inout InlineArray<Int>), the value at that address can be mutated between bounds checks. Add a bailout to prevent illegal optimization in such cases.