### PR TITLE
ClangImporter: Fix null dereference in finalizeLookupTable for decls …

### DIFF
--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -2139,8 +2139,9 @@ void importer::finalizeLookupTable(
             nameImporter.getClangContext().getSourceManager(), diagLoc);
 
         DiagnosticEngine &swiftDiags = nameImporter.getContext().Diags;
-        if (decl->getOwningModule()->IsSystem)
-          continue;
+        if (const auto *owningModule = decl->getOwningModule())
+          if (owningModule->IsSystem)
+            continue;
         swiftDiags.diagnose(swiftSourceLoc, diag::unresolvable_clang_decl,
                             decl->getNameAsString(), swiftName->getName());
         StringRef moduleName =

--- a/test/ClangImporter/pcm-emit-system-module-suppress-warning.swift
+++ b/test/ClangImporter/pcm-emit-system-module-suppress-warning.swift
@@ -2,6 +2,12 @@
 
 // RUN: %empty-directory(%t)
 
+// Verify that generating a bridging PCH with an unresolvable swift_name
+// does not crash when getOwningModule() returns null (rdar://173729736).
+// RUN: %target-swift-frontend -emit-pch \
+// RUN:   -o %t/bridging.pch \
+// RUN:   %S/Inputs/custom-modules/SystemModuleWithWarnings.h
+
 // RUN: %target-swift-emit-pcm -module-name SystemModuleWithWarnings \
 // RUN:   -Xcc -Xclang -Xcc -emit-module \
 // RUN:   -Xcc -Xclang -Xcc -fsystem-module \


### PR DESCRIPTION
…without an owning module

getOwningModule() can return nullptr for declarations encountered during bridging PCH generation. Guard the IsSystem check to avoid crashing.

rdar://173729736

<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
