### PR TITLE
test: simplify test further

### DIFF
--- a/test/Interop/Cxx/stdlib/android-and-std-module.swift
+++ b/test/Interop/Cxx/stdlib/android-and-std-module.swift
@@ -4,8 +4,8 @@
 // RUN: %target-swift-frontend %s -c -cxx-interoperability-mode=default -Xcc -std=c++20 -Xcc -fmodules-cache-path=%t
 
 // Ensure that the pre-compiled modules are emitted.
-// RUN: stat %t/Android*.pcm
-// RUN: stat %t/std*.pcm
+// RUN: ls %t/Android*.pcm
+// RUN: ls %t/std*.pcm
 
 // RUN: %empty-directory(%t)
 


### PR DESCRIPTION
Rather than `stat`'ing the path, simply `ls` the path to ensure that the globbed path exists.