### PR TITLE
[SILOptimizer]: fix an erroneous hop_to_executor removal

### DIFF
--- a/lib/SILOptimizer/Mandatory/OptimizeHopToExecutor.cpp
+++ b/lib/SILOptimizer/Mandatory/OptimizeHopToExecutor.cpp
@@ -396,14 +396,15 @@ bool OptimizeHopToExecutor::needsExecutor(SILInstruction *inst) {
     return true;
   }
 
-  // Treat returns from a caller isolation inheriting function as requiring the
-  // liveness of hop to executors before it.
+  // Treat function exits from a caller isolation inheriting function as
+  // requiring the liveness of hop to executors before it.
   //
   // DISCUSSION: We do this since callers of callee functions with isolation
   // inheriting isolation are not required to have a hop after the return from
   // the callee function... so we have no guarantee that there isn't code in the
   // caller that needs this hop to executor to run on the correct actor.
-  if (isa<ReturnInst>(inst)) {
+  if (auto *term = dyn_cast<TermInst>(inst);
+      term && term->isFunctionExiting()) {
     if (auto isolation = inst->getFunction()->getActorIsolation();
         isolation && isolation->isCallerIsolationInheriting()) {
       return true;

--- a/test/Concurrency/Runtime/nonisolated_nonsending_hop_to_executor_throws.swift
+++ b/test/Concurrency/Runtime/nonisolated_nonsending_hop_to_executor_throws.swift
@@ -1,0 +1,151 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+// RUN: %target-run-simple-swift(-enable-upcoming-feature NonisolatedNonsendingByDefault) | %FileCheck %s
+
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+// REQUIRES: executable_test
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
+
+// UNSUPPORTED: freestanding
+
+// Regression tests for: https://github.com/swiftlang/swift/issues/88259
+//
+// Verifies that nonisolated(nonsending) functions that throw correctly
+// hop back to the caller's executor before exiting.
+
+protocol ErrorFactory: Error {
+  static func make() -> Self
+}
+
+struct SomeError: ErrorFactory {
+  static func make() -> SomeError { SomeError() }
+}
+
+@concurrent func asyncThrows_throw() async throws {
+  throw SomeError()
+}
+
+@concurrent func asyncTypedThrows_throw() async throws(SomeError) {
+  throw SomeError()
+}
+
+@concurrent func asyncTypedThrowsGeneric_throw<E: ErrorFactory>(_: E.Type = E.self) async throws(E) {
+  throw E.make()
+}
+
+@concurrent func asyncThrows_nothrow() async throws {}
+
+@concurrent func asyncTypedThrows_nothrow() async throws(SomeError) {}
+
+@concurrent func asyncTypedThrowsGeneric_nothrow<E: Error>(_: E.Type = E.self) async throws(E) {}
+
+// MARK: - forwarding wrappers
+
+func callThrows_throw() async throws {
+  try await asyncThrows_throw()
+}
+
+func callTypedThrows_throw() async throws(SomeError) {
+  try await asyncTypedThrows_throw()
+}
+
+func callGenericTypedThrows_throw<E: ErrorFactory>(_ e: E.Type = E.self) async throws(E) {
+  try await asyncTypedThrowsGeneric_throw(e)
+}
+
+func callThrows_nothrow() async throws {
+  try await asyncThrows_nothrow()
+}
+
+func callTypedThrows_nothrow() async throws(SomeError) {
+  try await asyncTypedThrows_nothrow()
+}
+
+func callGenericTypedThrows_nothrow<E: Error>(_ e: E.Type = E.self) async throws(E) {
+  try await asyncTypedThrowsGeneric_nothrow(e)
+}
+
+// MARK: - Tests
+
+@MainActor
+func test_callThrows_throw() async {
+  // CHECK: callThrows_throw: caught on main
+  do {
+    try await callThrows_throw()
+    fatalError("should have thrown")
+  } catch {
+    MainActor.preconditionIsolated("should be on main")
+    print("callThrows_throw: caught on main")
+  }
+}
+
+@MainActor
+func test_callTypedThrows_throw() async {
+  // CHECK: callTypedThrows_throw: caught on main
+  do {
+    try await callTypedThrows_throw()
+    fatalError("should have thrown")
+  } catch {
+    MainActor.preconditionIsolated("should be on main")
+    print("callTypedThrows_throw: caught on main")
+  }
+}
+
+@MainActor
+func test_callGenericTypedThrows_throw() async {
+  // CHECK: callGenericTypedThrows_throw: caught on main
+  do {
+    try await callGenericTypedThrows_throw(SomeError.self)
+    fatalError("should have thrown")
+  } catch {
+    MainActor.preconditionIsolated("should be on main")
+    print("callGenericTypedThrows_throw: caught on main")
+  }
+}
+
+@MainActor
+func test_callThrows_nothrow() async {
+  // CHECK: callThrows_nothrow: return on main
+  do {
+    try await callThrows_nothrow()
+    MainActor.preconditionIsolated("should be on main")
+    print("callThrows_nothrow: return on main")
+  } catch {
+    fatalError("should not throw")
+  }
+}
+
+@MainActor
+func test_callTypedThrows_nothrow() async {
+  // CHECK: callTypedThrows_nothrow: return on main
+  do {
+    try await callTypedThrows_nothrow()
+    MainActor.preconditionIsolated("should be on main")
+    print("callTypedThrows_nothrow: return on main")
+  } catch {
+    fatalError("should not throw")
+  }
+}
+
+@MainActor
+func test_callGenericTypedThrows_nothrow() async {
+  // CHECK: callGenericTypedThrows_nothrow: return on main
+  do {
+    try await callGenericTypedThrows_nothrow(SomeError.self)
+    MainActor.preconditionIsolated("should be on main")
+    print("callGenericTypedThrows_nothrow: return on main")
+  } catch {
+    fatalError("should not throw")
+  }
+}
+
+@MainActor func run() async {
+  await test_callThrows_throw()
+  await test_callTypedThrows_throw()
+  await test_callGenericTypedThrows_throw()
+  await test_callThrows_nothrow()
+  await test_callTypedThrows_nothrow()
+  await test_callGenericTypedThrows_nothrow()
+}
+
+await run()

--- a/test/Concurrency/nonisolated_nonsending_optimize_hoptoexecutor.swift
+++ b/test/Concurrency/nonisolated_nonsending_optimize_hoptoexecutor.swift
@@ -28,3 +28,55 @@ public func caller() async {
   await test2()
   await test3()
 }
+
+// Regression test for: https://github.com/swiftlang/swift/issues/88259
+
+@inline(never)
+nonisolated func asyncThrows() async throws {}
+
+// CHECK-LABEL: sil hidden @$s4test0A7GH88259yyYaKF : $@convention(thin) @caller_isolated @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor) -> @error any Error
+// CHECK: try_apply {{.*}} normal [[NORMALBB:bb[0-9]+]], error [[ERRORBB:bb[0-9]+]]
+// CHECK: [[NORMALBB]]
+// CHECK: hop_to_executor
+// CHECK: return
+// CHECK: [[ERRORBB]]
+// CHECK: hop_to_executor
+// CHECK: throw
+// CHECK: } // end sil function '$s4test0A7GH88259yyYaKF'
+nonisolated(nonsending) func testGH88259() async throws {
+  try await asyncThrows()
+}
+
+struct SomeError: Error {}
+
+@inline(never)
+nonisolated func asyncThrowsTyped() async throws(SomeError) {}
+
+// CHECK-LABEL: sil hidden @$s4test0A12GH88259TypedyyYaAA9SomeErrorVYKF : $@convention(thin) @caller_isolated @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor) -> @error SomeError
+// CHECK: try_apply {{.*}} normal [[NORMALBB:bb[0-9]+]], error [[ERRORBB:bb[0-9]+]]
+// CHECK: [[NORMALBB]]
+// CHECK: hop_to_executor
+// CHECK: return
+// CHECK: [[ERRORBB]]
+// CHECK: hop_to_executor
+// CHECK: throw
+// CHECK: } // end sil function '$s4test0A12GH88259TypedyyYaAA9SomeErrorVYKF'
+nonisolated(nonsending) func testGH88259Typed() async throws(SomeError) {
+  try await asyncThrowsTyped()
+}
+
+@inline(never)
+nonisolated func asyncThrowsGeneric<E: Error>(_ error: E.Type = E.self) async throws(E) {}
+
+// CHECK-LABEL: sil hidden @$s4test0A14GH88259GenericyyxYaxYKs5ErrorRzlF : $@convention(thin) @caller_isolated @async <E where E : Error> (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @in_guaranteed E) -> @error_indirect E
+// CHECK: try_apply {{.*}} normal [[NORMALBB:bb[0-9]+]], error [[ERRORBB:bb[0-9]+]]
+// CHECK: [[NORMALBB]]
+// CHECK: hop_to_executor
+// CHECK: return
+// CHECK: [[ERRORBB]]
+// CHECK: hop_to_executor
+// CHECK: throw_addr
+// CHECK: } // end sil function '$s4test0A14GH88259GenericyyxYaxYKs5ErrorRzlF'
+nonisolated(nonsending) func testGH88259Generic<E: Error>(_ error: E) async throws(E) {
+  try await asyncThrowsGeneric(E.self)
+}

--- a/test/SILOptimizer/optimize_hop_to_executor.sil
+++ b/test/SILOptimizer/optimize_hop_to_executor.sil
@@ -15,6 +15,7 @@ actor MyActor {
 sil [ossa] @requiredToRunOnActor : $@convention(method) (@guaranteed MyActor) -> ()
 sil [ossa] @anotherAsyncFunction : $@convention(thin) @async () -> ()
 sil [ossa] @nonisolatedNonsendingAsyncFunction : $@convention(thin) @caller_isolated @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor) -> ()
+sil [ossa] @asyncThrowingFunction : $@convention(thin) @async () -> @error any Error
 sil [ossa] @syncFunction : $@convention(thin) () -> ()
 
 // CHECK-LABEL: sil [ossa] @simpleRedundantActor : $@convention(method) @async (@guaranteed MyActor) -> () {
@@ -454,4 +455,29 @@ bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor, %2 : @guaranteed $MyAc
   hop_to_executor %0
   %9999 = tuple ()
   return %9999 : $()
+}
+
+// https://github.com/swiftlang/swift/issues/88259
+
+// CHECK-LABEL: sil [isolation "caller_isolation_inheriting"] [ossa] @callerIsolationInheritingPreservesHopBeforeThrow : $@convention(thin) @caller_isolated @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor) -> @error any Error {
+// CHECK: bb1
+// CHECK:   hop_to_executor
+// CHECK:   return
+// CHECK: bb2
+// CHECK:   hop_to_executor
+// CHECK:   throw
+// CHECK: } // end sil function 'callerIsolationInheritingPreservesHopBeforeThrow'
+sil [isolation "caller_isolation_inheriting"] [ossa] @callerIsolationInheritingPreservesHopBeforeThrow : $@convention(thin) @caller_isolated @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor) -> @error any Error {
+bb0(%0 : @guaranteed $Builtin.ImplicitActor):
+  %f = function_ref @asyncThrowingFunction : $@convention(thin) @async () -> @error any Error
+  try_apply %f() : $@convention(thin) @async () -> @error any Error, normal bb1, error bb2
+
+bb1(%result : $()):
+  hop_to_executor %0 : $Builtin.ImplicitActor
+  %ret = tuple ()
+  return %ret: $()
+
+bb2(%error : @owned $any Error):
+  hop_to_executor %0 : $Builtin.ImplicitActor
+  throw %error : $any Error
 }


### PR DESCRIPTION
Previously dead hop to executor removal would conservatively treat returns from nonisolated(nonsending) functions as preventing removal of earlier hop_to_executor instructions. The same logic was not applied to other forms of function exiting instructions, such as throws, which could lead to missing a hop back before returning to the caller. Fix this by applying the same logic to all function exiting instructions.

Resolves: https://github.com/swiftlang/swift/issues/88259

---

- **Explanation**: Fixes a bug in OptimizeHopToExecutor that resulted in `nonisolated(nonsending)` functions failing to preserve their original isolation in some circumstances when returning to their caller by throwing an error.
- **Scope**: The change treats function-exiting instructions uniformly with respect to their preventing the deletion of earlier-occurring executor hops in functions that inherit and maintain their caller's isolation. Previously only `ReturnInst` had this behavior, hence the issue when throwing.
- **Issues**: https://github.com/swiftlang/swift/issues/88259
- **Risk**: Low risk, since it just fixes a regression.
- **Testing**: Added new test cases to verify the SIL output contains the expected instructions, and runtime tests to validate that the expected executor assumptions hold.
- **Reviewers**: @xedin
