### PR TITLE
[Embedded platform] Disable bridging PCH

### DIFF
--- a/stdlib/public/EmbeddedPlatform/CMakeLists.txt
+++ b/stdlib/public/EmbeddedPlatform/CMakeLists.txt
@@ -58,7 +58,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
       EmbeddedPlatformPOSIX.swift
 
       C_COMPILE_FLAGS ${extra_c_compile_flags}
-      SWIFT_COMPILE_FLAGS ${swift_stdlib_compile_flags} -Xcc -ffreestanding -enable-experimental-feature Embedded "-import-bridging-header" ${CMAKE_CURRENT_SOURCE_DIR}/swift/EmbeddedPlatform.h -enable-experimental-feature Extern -enable-experimental-feature AllowRuntimeSymbolDeclarations
+      SWIFT_COMPILE_FLAGS ${swift_stdlib_compile_flags} -Xcc -ffreestanding -enable-experimental-feature Embedded "-import-bridging-header" ${CMAKE_CURRENT_SOURCE_DIR}/swift/EmbeddedPlatform.h -enable-experimental-feature Extern -enable-experimental-feature AllowRuntimeSymbolDeclarations "-disable-bridging-pch"
       MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
       SDK "embedded"
       ARCHITECTURE "${mod}"


### PR DESCRIPTION
- **Explanation**: The bridging PCH created by the driver uses a temporary directory, which introduces nondeterminism into the results. We don't need to precompile this tiny header (the embedded platform header), so turn off the precompiled bridging header for this target. This nondeterminism is preventing us from tracking down a deeper non-determinism issue uncovered by the same CI job.
- **Scope**: Limited to the embedded Swift build of the POSIX embedded platform.
- **Issues**: rdar://172741975
- **Risk**: Very low. Disables an unnecessary build-time optimization for one small library.
- **Testing**: CI
