### PR TITLE
[SILGen] Forwarding arguments to `withoutActuallyEscaping` thunk shou…

### DIFF
--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -6059,6 +6059,9 @@ static void buildWithoutActuallyEscapingThunkBody(SILGenFunction &SGF,
 
   FullExpr scope(SGF.Cleanups, CleanupLocation(loc));
 
+  using ThunkGenFlag = SILGenFunction::ThunkGenFlag;
+  auto options = SILGenFunction::ThunkGenOptions();
+
   SmallVector<ManagedValue, 8> params;
   SmallVector<ManagedValue, 8> indirectResults;
   SmallVector<ManagedValue, 1> indirectErrorResults;
@@ -6088,10 +6091,11 @@ static void buildWithoutActuallyEscapingThunkBody(SILGenFunction &SGF,
   // Forward the implicit isolation parameter.
   if (implicitIsolationParam.isValid()) {
     argValues.push_back(implicitIsolationParam.getValue());
+    options |= ThunkGenFlag::CalleeHasImplicitIsolatedParam;
   }
 
    // Add the rest of the arguments.
-  forwardFunctionArguments(SGF, loc, fnType, params, argValues);
+  forwardFunctionArguments(SGF, loc, fnType, params, argValues, options);
 
   auto fun = fnType->isCalleeGuaranteed() ? fnValue.borrow(SGF, loc).getValue()
                                           : fnValue.forward(SGF);

--- a/test/Concurrency/attr_execution/attr_execution.swift
+++ b/test/Concurrency/attr_execution/attr_execution.swift
@@ -95,21 +95,27 @@ func testOpenExistential(existential: any P) async {
   await _openExistential(existential, do: open)
 }
 
-func testWithoutActuallyEscaping(_ f: () async -> ()) async {
-  // CHECK-LABEL: // closure #1 in testWithoutActuallyEscaping(_:)
+func testWithoutActuallyEscaping(_ f: () async -> (), _ f2: (Int) async -> Void) async {
+  // CHECK-LABEL: // closure #1 in testWithoutActuallyEscaping(_:_:)
   // CHECK-NEXT: // Isolation: caller_isolation_inheriting
   await withoutActuallyEscaping(f) {
     await $0()
   }
 
-  // CHECK-LABEL: // closure #2 in testWithoutActuallyEscaping(_:)
+  // CHECK-LABEL: // closure #2 in testWithoutActuallyEscaping(_:_:)
   // CHECK-NEXT: // Isolation: global_actor. type: MainActor
   await withoutActuallyEscaping(f) { @MainActor in
     await $0()
   }
 
+  // CHECK-LABEL: // closure #3 in testWithoutActuallyEscaping(_:_:)
+  // CHECK-NEXT: // Isolation: caller_isolation_inheriting
+  await withoutActuallyEscaping(f2) { body in
+    await body(42)
+  }
+
   actor Test {
-    // CHECK-LABEL: // closure #1 in testActorIsolatedCapture() in Test #1 in testWithoutActuallyEscaping(_:)
+    // CHECK-LABEL: // closure #1 in testActorIsolatedCapture() in Test #1 in testWithoutActuallyEscaping(_:_:)
     // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
     func testActorIsolatedCapture() async {
       await withoutActuallyEscaping(compute) {


### PR DESCRIPTION
…ld account for implicit isolation parameter

This was already half done by adding the parameter to the arguments but the flag to skip it while matching was missing.

Resolves: https://github.com/swiftlang/swift/issues/87537
Resolves: rdar://171274515

<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
