### PR TITLE
[APIGen] Pass previous-module-installname-map file to APIGen

### DIFF
--- a/include/swift/IRGen/TBDGen.h
+++ b/include/swift/IRGen/TBDGen.h
@@ -113,7 +113,8 @@ std::vector<std::string> getPublicSymbols(TBDGenDescriptor desc);
 void writeTBDFile(ModuleDecl *M, llvm::raw_ostream &os,
                   const TBDGenOptions &opts);
 
-void writeAPIJSONFile(ModuleDecl *M, llvm::raw_ostream &os, bool PrettyPrint);
+void writeAPIJSONFile(ModuleDecl *M, llvm::raw_ostream &os,
+                      const TBDGenOptions &opts, bool PrettyPrint);
 
 } // end namespace swift
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -739,12 +739,13 @@ static bool writeTBDIfNeeded(CompilerInstance &Instance) {
 }
 
 static bool writeAPIDescriptor(ModuleDecl *M, StringRef OutputPath,
-                               llvm::vfs::OutputBackend &Backend) {
-  return withOutputPath(M->getDiags(), Backend, OutputPath,
-                        [&](raw_ostream &OS) -> bool {
-                          writeAPIJSONFile(M, OS, /*PrettyPrinted=*/false);
-                          return false;
-                        });
+                               llvm::vfs::OutputBackend &Backend,
+                               const TBDGenOptions &TBDOpts) {
+  return withOutputPath(
+      M->getDiags(), Backend, OutputPath, [&](raw_ostream &OS) -> bool {
+        writeAPIJSONFile(M, OS, TBDOpts, /*PrettyPrinted=*/false);
+        return false;
+      });
 }
 
 static bool writeAPIDescriptorIfNeeded(CompilerInstance &Instance) {
@@ -762,8 +763,10 @@ static bool writeAPIDescriptorIfNeeded(CompilerInstance &Instance) {
   const std::string &APIDescriptorPath =
       Invocation.getAPIDescriptorPathForWholeModule();
 
+  const auto &TBDOpts = Invocation.getTBDGenOptions();
+
   return writeAPIDescriptor(Instance.getMainModule(), APIDescriptorPath,
-                            Instance.getOutputBackend());
+                            Instance.getOutputBackend(), TBDOpts);
 }
 
 static bool performCompileStepsPostSILGen(

--- a/lib/IRGen/TBDGen.cpp
+++ b/lib/IRGen/TBDGen.cpp
@@ -953,10 +953,9 @@ apigen::API APIGenRequest::evaluate(Evaluator &evaluator,
 }
 
 void swift::writeAPIJSONFile(ModuleDecl *M, llvm::raw_ostream &os,
-                             bool PrettyPrint) {
-  TBDGenOptions opts;
+                             const TBDGenOptions &TBDOpts, bool PrettyPrint) {
   auto &evaluator = M->getASTContext().evaluator;
-  auto desc = TBDGenDescriptor::forModule(M, opts);
+  auto desc = TBDGenDescriptor::forModule(M, TBDOpts);
   auto api = evaluateOrFatal(evaluator, APIGenRequest{desc});
   api.writeAPIJSONFile(os, PrettyPrint);
 }

--- a/test/APIJSON/originally-defined-in.swift
+++ b/test/APIJSON/originally-defined-in.swift
@@ -1,0 +1,143 @@
+// REQUIRES: objc_interop, OS=macosx
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/ModuleCache)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) %t/MyModuleCore.swift -parse-as-library  -emit-module -emit-module-path %t/MyModuleCore.swiftmodule -enable-library-evolution -module-name MyModuleCore -swift-version 5 -emit-api-descriptor-path %t/api.json -target arm64-apple-macos26 -library-level api -previous-module-installname-map-file %t/previous-module-installname-map.json
+// RUN: %validate-json %t/api.json | %FileCheck %s
+
+//--- MyModuleCore.swift
+@_originallyDefinedIn(module: "MyModule", macOS 15)
+@available(macOS 13, *)
+public class MyClass {}
+
+//--- previous-module-installname-map.json
+[
+  {
+    "module": "MyModule",
+    "install_name": "/System/Library/Frameworks/MyModule.framework/MyModule",
+    "platforms": ["macOS"]
+  }
+]
+
+//--- Checks
+// CHECK:      {
+// CHECK-NEXT:   "target": "arm64-apple-macos26",
+// CHECK-NEXT:   "globals": [
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "name": "$ld$previous$/System/Library/Frameworks/MyModule.framework/MyModule$$1$1.0$15.0$_$s8MyModule0A5ClassCMa$",
+// CHECK-NEXT:       "access": "public",
+// CHECK-NEXT:       "file": "TMP_DIR/MyModuleCore.swift",
+// CHECK-NEXT:       "linkage": "exported",
+// CHECK-NEXT:       "introduced": "13"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "name": "$ld$previous$/System/Library/Frameworks/MyModule.framework/MyModule$$1$1.0$15.0$_$s8MyModule0A5ClassCMm$",
+// CHECK-NEXT:       "access": "public",
+// CHECK-NEXT:       "file": "TMP_DIR/MyModuleCore.swift",
+// CHECK-NEXT:       "linkage": "exported",
+// CHECK-NEXT:       "introduced": "13"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "name": "$ld$previous$/System/Library/Frameworks/MyModule.framework/MyModule$$1$1.0$15.0$_$s8MyModule0A5ClassCMn$",
+// CHECK-NEXT:       "access": "public",
+// CHECK-NEXT:       "file": "TMP_DIR/MyModuleCore.swift",
+// CHECK-NEXT:       "linkage": "exported",
+// CHECK-NEXT:       "introduced": "13"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "name": "$ld$previous$/System/Library/Frameworks/MyModule.framework/MyModule$$1$1.0$15.0$_$s8MyModule0A5ClassCMo$",
+// CHECK-NEXT:       "access": "public",
+// CHECK-NEXT:       "file": "TMP_DIR/MyModuleCore.swift",
+// CHECK-NEXT:       "linkage": "exported",
+// CHECK-NEXT:       "introduced": "13"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "name": "$ld$previous$/System/Library/Frameworks/MyModule.framework/MyModule$$1$1.0$15.0$_$s8MyModule0A5ClassCMu$",
+// CHECK-NEXT:       "access": "public",
+// CHECK-NEXT:       "file": "TMP_DIR/MyModuleCore.swift",
+// CHECK-NEXT:       "linkage": "exported",
+// CHECK-NEXT:       "introduced": "13"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "name": "$ld$previous$/System/Library/Frameworks/MyModule.framework/MyModule$$1$1.0$15.0$_$s8MyModule0A5ClassCN$",
+// CHECK-NEXT:       "access": "public",
+// CHECK-NEXT:       "file": "TMP_DIR/MyModuleCore.swift",
+// CHECK-NEXT:       "linkage": "exported",
+// CHECK-NEXT:       "introduced": "13"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "name": "$ld$previous$/System/Library/Frameworks/MyModule.framework/MyModule$$1$1.0$15.0$_$s8MyModule0A5ClassCfD$",
+// CHECK-NEXT:       "access": "public",
+// CHECK-NEXT:       "file": "TMP_DIR/MyModuleCore.swift",
+// CHECK-NEXT:       "linkage": "exported",
+// CHECK-NEXT:       "introduced": "13"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "name": "$ld$previous$/System/Library/Frameworks/MyModule.framework/MyModule$$1$1.0$15.0$_$s8MyModule0A5ClassCfd$",
+// CHECK-NEXT:       "access": "public",
+// CHECK-NEXT:       "file": "TMP_DIR/MyModuleCore.swift",
+// CHECK-NEXT:       "linkage": "exported",
+// CHECK-NEXT:       "introduced": "13"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "name": "_$s8MyModule0A5ClassCMa",
+// CHECK-NEXT:       "access": "public",
+// CHECK-NEXT:       "file": "TMP_DIR/MyModuleCore.swift",
+// CHECK-NEXT:       "linkage": "exported",
+// CHECK-NEXT:       "introduced": "13"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "name": "_$s8MyModule0A5ClassCMm",
+// CHECK-NEXT:       "access": "public",
+// CHECK-NEXT:       "file": "TMP_DIR/MyModuleCore.swift",
+// CHECK-NEXT:       "linkage": "exported",
+// CHECK-NEXT:       "introduced": "13"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "name": "_$s8MyModule0A5ClassCMn",
+// CHECK-NEXT:       "access": "public",
+// CHECK-NEXT:       "file": "TMP_DIR/MyModuleCore.swift",
+// CHECK-NEXT:       "linkage": "exported",
+// CHECK-NEXT:       "introduced": "13"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "name": "_$s8MyModule0A5ClassCMo",
+// CHECK-NEXT:       "access": "public",
+// CHECK-NEXT:       "file": "TMP_DIR/MyModuleCore.swift",
+// CHECK-NEXT:       "linkage": "exported",
+// CHECK-NEXT:       "introduced": "13"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "name": "_$s8MyModule0A5ClassCMu",
+// CHECK-NEXT:       "access": "public",
+// CHECK-NEXT:       "file": "TMP_DIR/MyModuleCore.swift",
+// CHECK-NEXT:       "linkage": "exported",
+// CHECK-NEXT:       "introduced": "13"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "name": "_$s8MyModule0A5ClassCN",
+// CHECK-NEXT:       "access": "public",
+// CHECK-NEXT:       "file": "TMP_DIR/MyModuleCore.swift",
+// CHECK-NEXT:       "linkage": "exported",
+// CHECK-NEXT:       "introduced": "13"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "name": "_$s8MyModule0A5ClassCfD",
+// CHECK-NEXT:       "access": "public",
+// CHECK-NEXT:       "file": "TMP_DIR/MyModuleCore.swift",
+// CHECK-NEXT:       "linkage": "exported",
+// CHECK-NEXT:       "introduced": "13"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "name": "_$s8MyModule0A5ClassCfd",
+// CHECK-NEXT:       "access": "public",
+// CHECK-NEXT:       "file": "TMP_DIR/MyModuleCore.swift",
+// CHECK-NEXT:       "linkage": "exported",
+// CHECK-NEXT:       "introduced": "13"
+// CHECK-NEXT:     }
+// CHECK-NEXT:   ],
+// CHECK-NEXT:   "interfaces": [],
+// CHECK-NEXT:   "categories": [],
+// CHECK-NEXT:   "version": "1.0"
+// CHECK-NEXT: }


### PR DESCRIPTION
For `@_originallyDefinedIn` declarations, we should be consistent with TBDGen to emit `$ld$previous` symbols instead of a huge number of `$ld$hide` symbols, when a previous-module-installname-map file is given from TBDGen options.
`APIGenRequest` was constructing a new and empty set of `TBDGenOptions` so the map file was missing when generating API descriptor. Pass the actual options from the invocation.