### PR TITLE
SILGen: Emit `@_addressableSelf` accessor bases properly.

### DIFF
--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -4252,13 +4252,24 @@ LValue SILGenLValue::visitMemberRefExpr(MemberRefExpr *e,
   CanType substFormalRValueType = getSubstFormalRValueType(e);
   CanType baseTy = getBaseFormalType(e->getBase());
   AbstractionPattern orig = AbstractionPattern::getInvalid();
+
+  AccessorDecl *calleeAccessor = strategy.hasAccessor()
+    ? var->getAccessor(strategy.getAccessor())
+    : nullptr;
+  ParamDecl *calleeAccessorSelfParam = calleeAccessor
+    ? calleeAccessor->getImplicitSelfDecl()
+    : nullptr;
+  
   bool addressable = false;
-  // If the access produces a dependent value, and the base is addressable-for-
-  // dependencies, then request an addressable base.
-  if (!substFormalRValueType->isEscapable()
-      && SGF.getTypeProperties(baseTy).isAddressableForDependencies()) {
-    addressable = true;
-    orig = AbstractionPattern::getOpaque();
+  // If the access produces a dependent value, and the base is addressable,
+  // then request an addressable base.
+  if (!substFormalRValueType->isEscapable()) {
+    addressable = SGF.getTypeProperties(baseTy).isAddressableForDependencies()
+      || (calleeAccessorSelfParam && calleeAccessorSelfParam->isAddressable());
+      
+    if (addressable) {
+      orig = AbstractionPattern::getOpaque();
+    }
   }
   
   LValue lv = visitRec(e->getBase(),

--- a/test/SILOptimizer/lifetime_dependence/addressable_accessor_self.swift
+++ b/test/SILOptimizer/lifetime_dependence/addressable_accessor_self.swift
@@ -1,0 +1,46 @@
+// RUN: %target-swift-emit-sil -enable-experimental-feature Lifetimes -enable-experimental-feature AddressableParameters -verify %s
+//
+// REQUIRES: swift_feature_AddressableParameters
+// REQUIRES: swift_feature_Lifetimes
+
+struct Optionable<Wrapped: ~Copyable>: ~Copyable {
+  public var span: Span<Wrapped> {
+    @_addressableSelf
+    @_lifetime(borrow self)
+    get {
+		fatalError()
+    }
+  }
+
+  @_addressableSelf
+  @_lifetime(borrow self)
+  public func getSpan() -> Span<Wrapped> {    
+	fatalError()
+  }
+
+  public mutating func set(_: consuming Wrapped) { }
+}
+
+extension Optionable: Copyable where Wrapped: Copyable {}
+
+func testProperty_mutate(_ o: inout Optionable<[Int]>, _ value: [Int]) -> Int {
+  let span = o.span // expected-note{{}}
+  o.set(value) // expected-error{{overlapping access}}
+  return span.count
+}
+func testMethod_mutate(_ o: inout Optionable<[Int]>, _ value: [Int]) -> Int {
+  let span = o.getSpan() // expected-note{{}}
+  o.set(value) // expected-error{{overlapping access}}
+  return span.count
+}
+
+func testProperty_reassign(_ o: inout Optionable<[Int]>, _ value: Optionable<[Int]>) -> Int {
+  let span = o.span // expected-error{{escapes}} expected-note{{}}
+  o = value
+  return span.count // expected-note{{}}
+}
+func testMethod_reassign(_ o: inout Optionable<[Int]>, _ value: Optionable<[Int]>) -> Int {
+  let span = o.getSpan() // expected-error{{escapes}} expected-note{{}}
+  o = value
+  return span.count // expected-note{{}}
+}


### PR DESCRIPTION
Fix the check here to account for ad-hoc addressable parameters in addition to addressable-for-dependencies types.

Fixes rdar://173472004
