### PR TITLE
Teach canImport to reject modules that mismatch on Embedded vs. normal Swift

### DIFF
--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -197,6 +197,7 @@ protected:
                                         bool isFramework,
                                         StringRef SDKName,
                                         const llvm::Triple &target,
+                                        bool isEmbedded,
                                         StringRef packageName,
                                         llvm::vfs::FileSystem *fileSystem,
                                         PathObfuscator &recoverer);

--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -85,6 +85,10 @@ enum class Status {
   /// The module file was built with a different SDK than the one in use
   /// to build the client.
   SDKMismatch,
+
+  /// The module file was built for embedded and is being used with a
+  /// non-embedded client, or vice-versa.
+  EmbeddedMismatch,
 };
 
 /// Returns the string for the Status enum.
@@ -319,7 +323,8 @@ ValidationInfo validateSerializedAST(
     SmallVectorImpl<SearchPath> *searchPaths = nullptr,
     ExplicitSwiftModuleMap *explicitSwiftModuleMap = nullptr,
     ExplicitClangModuleMap *explicitClangModuleMa = nullptr,
-    std::optional<llvm::Triple> target = std::nullopt);
+    std::optional<llvm::Triple> target = std::nullopt,
+    std::optional<bool> isEmbedded = std::nullopt);
 
 /// Emit diagnostics explaining a failure to load a serialized AST.
 ///

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -431,6 +431,7 @@ ModuleFile::getModuleName(ASTContext &Ctx, StringRef modulePath,
       "", "", std::move(newBuf), nullptr, nullptr,
       /*isFramework=*/isFramework,
       Ctx.LangOpts.SDKName, Ctx.LangOpts.Target,
+      Ctx.LangOpts.hasFeature(Feature::Embedded),
       Ctx.SearchPathOpts.DeserializedPathRecoverer, loadedModuleFile);
   Name = loadedModuleFile->Name.str();
   return std::move(moduleBuf.get());

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -250,6 +250,7 @@ static ValidationInfo validateControlBlock(
     bool requiresRevisionMatch,
     StringRef requiredSDK,
     std::optional<llvm::Triple> target,
+    std::optional<bool> isEmbedded,
     ExtendedValidationInfo *extendedInfo,
     PathObfuscator &pathRecoverer) {
   // The control block is malformed until we've at least read a major version
@@ -285,6 +286,13 @@ static ValidationInfo validateControlBlock(
         }
         if (!readOptionsBlock(cursor, scratch, *extendedInfo, pathRecoverer)) {
           result.status = Status::Malformed;
+          return result;
+        }
+
+        // Validate extended options.
+        if (isEmbedded &&
+            extendedInfo->isEmbeddedSwiftModule() != *isEmbedded) {
+          result.status = Status::EmbeddedMismatch;
           return result;
         }
       } else {
@@ -673,6 +681,7 @@ std::string serialization::StatusToString(Status S) {
   case Status::TargetIncompatible: return "TargetIncompatible";
   case Status::TargetTooNew: return "TargetTooNew";
   case Status::SDKMismatch: return "SDKMismatch";
+  case Status::EmbeddedMismatch: return "EmbeddedMismatch";
   }
   llvm_unreachable("The switch should cover all cases");
 }
@@ -689,7 +698,8 @@ ValidationInfo serialization::validateSerializedAST(
     SmallVectorImpl<SearchPath> *searchPaths,
     ExplicitSwiftModuleMap *explicitSwiftModuleMap,
     ExplicitClangModuleMap *explicitClangModuleMap,
-    std::optional<llvm::Triple> target) {
+    std::optional<llvm::Triple> target,
+    std::optional<bool> isEmbedded) {
   ValidationInfo result;
 
   // Check 32-bit alignment.
@@ -731,7 +741,7 @@ ValidationInfo serialization::validateSerializedAST(
           cursor, scratch,
           {SWIFTMODULE_VERSION_MAJOR, SWIFTMODULE_VERSION_MINOR},
           /*requiresRevisionMatch=*/true,
-          requiredSDK, target,
+          requiredSDK, target, isEmbedded,
           extendedInfo, localObfuscator);
       if (result.status != Status::Valid)
         return result;
@@ -1284,6 +1294,7 @@ bool ModuleFileSharedCore::readModuleDocIfPresent(PathObfuscator &pathRecoverer)
           docCursor, scratch, {SWIFTDOC_VERSION_MAJOR, SWIFTDOC_VERSION_MINOR},
           /*requiresRevisionMatch*/false,
           /*requiredSDK*/StringRef(), /*target*/std::nullopt,
+          /*isEmbedded*/std::nullopt,
           /*extendedInfo*/nullptr, pathRecoverer);
       if (info.status != Status::Valid)
         return false;
@@ -1429,6 +1440,7 @@ bool ModuleFileSharedCore::readModuleSourceInfoIfPresent(PathObfuscator &pathRec
           {SWIFTSOURCEINFO_VERSION_MAJOR, SWIFTSOURCEINFO_VERSION_MINOR},
           /*requiresRevisionMatch*/false,
           /*requiredSDK*/StringRef(), /*target*/std::nullopt,
+          /*isEmbedded*/std::nullopt,
           /*extendedInfo*/nullptr, pathRecoverer);
       if (info.status != Status::Valid)
         return false;
@@ -1508,6 +1520,7 @@ ModuleFileSharedCore::ModuleFileSharedCore(
     bool isFramework,
     StringRef requiredSDK,
     std::optional<llvm::Triple> target,
+    std::optional<bool> isEmbedded,
     serialization::ValidationInfo &info, PathObfuscator &pathRecoverer)
     : ModuleInputBuffer(std::move(moduleInputBuffer)),
       ModuleDocInputBuffer(std::move(moduleDocInputBuffer)),
@@ -1558,7 +1571,7 @@ ModuleFileSharedCore::ModuleFileSharedCore(
       info = validateControlBlock(
           cursor, scratch,
           {SWIFTMODULE_VERSION_MAJOR, SWIFTMODULE_VERSION_MINOR},
-          /*requiresRevisionMatch=*/true, requiredSDK, target,
+          /*requiresRevisionMatch=*/true, requiredSDK, target, isEmbedded,
           &extInfo, pathRecoverer);
       if (info.status != Status::Valid) {
         error(info.status);

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -445,6 +445,7 @@ private:
       bool isFramework,
       StringRef requiredSDK,
       std::optional<llvm::Triple> target,
+      std::optional<bool> isEmbedded,
       serialization::ValidationInfo &info, PathObfuscator &pathRecoverer);
 
   /// Change the status of the current module.
@@ -584,13 +585,14 @@ public:
        std::unique_ptr<llvm::MemoryBuffer> moduleSourceInfoInputBuffer,
        bool isFramework,
        StringRef requiredSDK, std::optional<llvm::Triple> target,
+       std::optional<bool> isEmbedded,
        PathObfuscator &pathRecoverer,
        std::shared_ptr<const ModuleFileSharedCore> &theModule) {
     serialization::ValidationInfo info;
     auto *core = new ModuleFileSharedCore(
         std::move(moduleInputBuffer), std::move(moduleDocInputBuffer),
         std::move(moduleSourceInfoInputBuffer), isFramework,
-        requiredSDK, target, info,
+        requiredSDK, target, isEmbedded, info,
         pathRecoverer);
     if (!moduleInterfacePath.empty()) {
       ArrayRef<char> path;

--- a/lib/Serialization/ScanningLoaders.cpp
+++ b/lib/Serialization/ScanningLoaders.cpp
@@ -259,6 +259,7 @@ SwiftModuleScanner::scanInterfaceFile(Identifier moduleID,
                 getMatchingPackageOnlyImportsOfModule(
                     *adjacentBinaryModule, isFramework,
                     Ctx.LangOpts.SDKName, Ctx.LangOpts.Target,
+                    Ctx.LangOpts.hasFeature(Feature::Embedded),
                     ScannerPackageName, Ctx.SourceMgr.getFileSystem().get(),
                     Ctx.SearchPathOpts.DeserializedPathRecoverer);
 
@@ -307,6 +308,7 @@ llvm::ErrorOr<ModuleDependencyInfo> SwiftModuleScanner::scanBinaryModuleFile(
   serialization::ValidationInfo loadInfo = ModuleFileSharedCore::load(
       "", "", std::move(moduleBuf.get()), nullptr, nullptr, isFramework,
       Ctx.LangOpts.SDKName, Ctx.LangOpts.Target,
+      Ctx.LangOpts.hasFeature(Feature::Embedded),
       Ctx.SearchPathOpts.DeserializedPathRecoverer, loadedModuleFile);
 
   if (Ctx.SearchPathOpts.ScannerModuleValidation) {

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -333,6 +333,8 @@ std::optional<std::string> SerializedModuleLoaderBase::invalidModuleReason(seria
     return "target platform newer than current platform";
   case Status::SDKMismatch:
     return "SDK does not match";
+  case Status::EmbeddedMismatch:
+      return "mixes Embedded Swift and non-embedded Swift";
   case Status::Valid:
     return std::nullopt;
   }
@@ -342,7 +344,8 @@ std::optional<std::string> SerializedModuleLoaderBase::invalidModuleReason(seria
 llvm::ErrorOr<std::vector<ScannerImportStatementInfo>>
 SerializedModuleLoaderBase::getMatchingPackageOnlyImportsOfModule(
     Twine modulePath, bool isFramework,
-    StringRef SDKName, const llvm::Triple &target, StringRef packageName,
+    StringRef SDKName, const llvm::Triple &target, bool isEmbedded,
+    StringRef packageName,
     llvm::vfs::FileSystem *fileSystem, PathObfuscator &recoverer) {
   auto moduleBuf = fileSystem->getBufferForFile(modulePath);
   if (!moduleBuf)
@@ -353,7 +356,7 @@ SerializedModuleLoaderBase::getMatchingPackageOnlyImportsOfModule(
   std::shared_ptr<const ModuleFileSharedCore> loadedModuleFile;
   serialization::ValidationInfo loadInfo = ModuleFileSharedCore::load(
       "", "", std::move(moduleBuf.get()), nullptr, nullptr, isFramework,
-      SDKName, target, recoverer, loadedModuleFile);
+      SDKName, target, isEmbedded, recoverer, loadedModuleFile);
 
   if (loadedModuleFile->getModulePackageName() != packageName)
     return importedModuleNames;
@@ -952,6 +955,7 @@ LoadedFile *SerializedModuleLoaderBase::loadAST(
       std::move(moduleInputBuffer), std::move(moduleDocInputBuffer),
       std::move(moduleSourceInfoInputBuffer), isFramework,
       Ctx.LangOpts.SDKName, Ctx.LangOpts.Target,
+      Ctx.LangOpts.hasFeature(Feature::Embedded),
       Ctx.SearchPathOpts.DeserializedPathRecoverer, loadedModuleFileCore);
   SerializedASTFile *fileUnit = nullptr;
 
@@ -1069,18 +1073,6 @@ LoadedFile *SerializedModuleLoaderBase::loadAST(
   if (M.hasHermeticSealAtLink() && !Ctx.LangOpts.HermeticSealAtLink) {
     Ctx.Diags.diagnose(diagLoc.value_or(SourceLoc()),
                        diag::need_hermetic_seal_to_import_module, M.getName());
-  }
-
-  if (M.isEmbeddedSwiftModule() &&
-      !Ctx.LangOpts.hasFeature(Feature::Embedded)) {
-    Ctx.Diags.diagnose(diagLoc.value_or(SourceLoc()),
-                       diag::cannot_import_embedded_module, M.getName());
-  }
-
-  if (!M.isEmbeddedSwiftModule() &&
-      Ctx.LangOpts.hasFeature(Feature::Embedded)) {
-    Ctx.Diags.diagnose(diagLoc.value_or(SourceLoc()),
-                       diag::cannot_import_non_embedded_module, M.getName());
   }
 
   // Non-resilient modules built with C++ interoperability enabled
@@ -1227,11 +1219,20 @@ void swift::serialization::diagnoseSerializedASTLoadFailure(
     break;
   }
 
-  case serialization::Status::SDKMismatch:
+  case serialization::Status::SDKMismatch: {
     auto currentSDK = Ctx.LangOpts.SDKName;
     auto moduleSDK = loadInfo.sdkName;
     Ctx.Diags.diagnose(diagLoc, diag::serialization_sdk_mismatch,
                        ModuleName, moduleSDK, currentSDK, moduleBufferID);
+    break;
+  }
+
+  case serialization::Status::EmbeddedMismatch:
+    Ctx.Diags.diagnose(diagLoc,
+                       Ctx.LangOpts.hasFeature(Feature::Embedded)
+                         ? diag::cannot_import_non_embedded_module
+                         : diag::cannot_import_embedded_module,
+                       ModuleName);
     break;
   }
 }
@@ -1252,6 +1253,7 @@ void swift::serialization::diagnoseSerializedASTLoadFailureTransitive(
   case serialization::Status::TargetIncompatible:
   case serialization::Status::TargetTooNew:
   case serialization::Status::SDKMismatch:
+  case serialization::Status::EmbeddedMismatch:
     llvm_unreachable("status not handled by "
         "diagnoseSerializedASTLoadFailureTransitive");
 
@@ -1486,6 +1488,7 @@ std::unique_ptr<llvm::MemoryBuffer> swift::extractEmbeddedBridgingHeaderContent(
       "", "", std::move(file), nullptr, nullptr, false,
       Context.LangOpts.SDKName,
       Context.LangOpts.Target,
+      Context.LangOpts.hasFeature(Feature::Embedded),
       Context.SearchPathOpts.DeserializedPathRecoverer,
       loadedModuleFile);
 
@@ -1539,9 +1542,11 @@ bool SerializedModuleLoaderBase::canImportModule(
   }
 
   if (moduleInputBuffer) {
+    serialization::ExtendedValidationInfo extInfo;
     auto metaData = serialization::validateSerializedAST(
         moduleInputBuffer->getBuffer(),
-        Ctx.LangOpts.SDKName);
+        Ctx.LangOpts.SDKName, &extInfo, nullptr, nullptr, nullptr, nullptr,
+        std::nullopt, Ctx.LangOpts.hasFeature(Feature::Embedded));
 
     // If we only found binary module, make sure that is valid.
     if (metaData.status != serialization::Status::Valid &&

--- a/test/embedded/can-import.swift
+++ b/test/embedded/can-import.swift
@@ -1,0 +1,31 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+// RUN: mkdir -p %t/embedded
+// RUN: mkdir -p %t/desktop
+
+// Build the module as both embedded and non-embedded
+
+// RUN: %target-swift-frontend -emit-module -o %t/desktop/MyModule.swiftmodule %t/MyModule.swift -parse-as-library
+// RUN: %target-swift-frontend -emit-module -o %t/embedded/MyModule.swiftmodule %t/MyModule.swift -parse-as-library -enable-experimental-feature Embedded
+
+// Test for canImport of a non-embedded module into an embedded module
+// RUN: %target-typecheck-verify-swift -I %t/desktop -enable-experimental-feature Embedded
+
+// Test for canImport of an embedded module into a non-embedded module
+// RUNx: %target-typecheck-verify-swift -I %t/embedded
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: OS=macosx || OS=linux-gnu || OS=wasip1
+// REQUIRES: swift_feature_Embedded
+
+// BEGIN MyModule.swift
+
+public func f() { }
+
+// BEGIN Main.swift
+
+// expected-warning@+1{{canImport() evaluated to false due to invalid swiftmodule:}}
+#if canImport(MyModule)
+#error("Shouldn't be able to see the module!!")
+import MyModule
+#endif


### PR DESCRIPTION
- **Explanation**: Check for Embedded/normal Swift mismatches as part of module validation, rather than after loading. Do this check as part of canImport, so that canImport will evaluate false when there is a mismatch. This will produce a warning in this case, because it's often a mistake to have a module visible that isn't actually usable. However, don't break the build over it.
- **Scope**: Limited to the canImport module-loading logic.
- **Issues**: #86419 / rdar://167851189
- **Risk**: Low, it only changes behavior when the compile would have failed due to a mismatch.
- **Testing**: CI, new tests.
