### PR TITLE
[cxx-interop] Tighten isSpecialAppKitFunctionKeyProperty

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -9039,7 +9039,12 @@ bool importer::isSpecialAppKitFunctionKeyProperty(
   auto rawName = ident->getName();
 
   return rawName.starts_with("NS") &&
-         (rawName.ends_with("FunctionKey") || rawName.ends_with("Character"));
+         (rawName.ends_with("FunctionKey") || rawName.ends_with("Character")) &&
+         llvm::any_of(decl->specific_attrs<clang::SwiftNameAttr>(),
+                      [](const auto *attr) {
+                        return attr->getName().starts_with(
+                            "NSEvent.SpecialKey");
+                      });
 }
 
 bool importer::hasSameUnderlyingType(const clang::Type *a,

--- a/test/Interop/Cxx/objc-correctness/appkit-uikit.swift
+++ b/test/Interop/Cxx/objc-correctness/appkit-uikit.swift
@@ -15,6 +15,10 @@ var _ = NSEvent.SpecialKey.enter.rawValue
 var _ = NSUpArrowFunctionKey
 var _ = NSEnterCharacter
 
+#if swift(>=4.2)
+var _ = NSTextAttachment.character
+#endif
+
 #elseif canImport(UIKit)
 import UIKit
 


### PR DESCRIPTION
Previously, any declaration whose raw name started with `NS` and ended with `FunctionKey` or `Character` was considered a special AppKit function key property. This change requires the declaration to have a `__attribute__((swift_name(...)))` that starts with `NSEvent.SpecialKey.`. This prevents matching decls that are not special keys, like `NSAttachmentCharacter`.

Checking the decl name given that we check `NSEvent.SpecialKey` is probably redundant, but I'm too afraid to remove it :)

rdar://171083643