### PR TITLE
[gardening] Modernize build_swift module to use f-strings (NFC)

### DIFF
--- a/utils/build_swift/build_swift/argparse/actions.py
+++ b/utils/build_swift/build_swift/argparse/actions.py
@@ -283,7 +283,7 @@ class _ToggleAction(Action):
             values = self.off_value
         else:
             raise argparse.ArgumentTypeError(
-                '{} is not a boolean value'.format(values))
+                f'{values} is not a boolean value')
 
         for dest in self.dests:
             setattr(namespace, dest, values)
@@ -340,4 +340,4 @@ class UnsupportedAction(Action):
             parser.error(self.message)
 
         arg = option_string or str(values)
-        parser.error('unsupported argument: {}'.format(arg))
+        parser.error(f'unsupported argument: {arg}')

--- a/utils/build_swift/build_swift/argparse/types.py
+++ b/utils/build_swift/build_swift/argparse/types.py
@@ -39,9 +39,9 @@ def _repr(cls, args):
 
     _args = []
     for key, value in args.items():
-        _args.append('{}={}'.format(key, repr(value)))
+        _args.append(f'{key}={value!r}')
 
-    return '{}({})'.format(type(cls).__name__, ', '.join(_args))
+    return f'{type(cls).__name__}({", ".join(_args)})'
 
 
 class BoolType(object):
@@ -65,7 +65,7 @@ class BoolType(object):
         elif value in self._false_values:
             return False
         else:
-            raise ArgumentTypeError('{} is not a boolean value'.format(value))
+            raise ArgumentTypeError(f'{value} is not a boolean value')
 
     def __repr__(self):
         return _repr(self, {
@@ -89,10 +89,10 @@ class PathType(object):
         path = os.path.abspath(path)
 
         if self._assert_exists and not os.path.exists(path):
-            raise ArgumentTypeError('{} does not exist'.format(path))
+            raise ArgumentTypeError(f'{path} does not exist')
 
         if self._assert_executable and not PathType._is_executable(path):
-            raise ArgumentTypeError('{} is not an executable'.format(path))
+            raise ArgumentTypeError(f'{path} is not an executable')
 
         return path
 

--- a/utils/build_swift/build_swift/class_utils.py
+++ b/utils/build_swift/build_swift/class_utils.py
@@ -26,9 +26,9 @@ def generate_repr(*attrs):
         args = []
         for attr in attrs:
             value = getattr(self, attr)
-            args.append('{}={}'.format(attr, repr(value)))
+            args.append(f'{attr}={value!r}')
 
-        return '{}({})'.format(type(self).__name__, ', '.join(args))
+        return f'{type(self).__name__}({", ".join(args)})'
 
     def decorator(cls):
         setattr(cls, '__repr__', _repr)

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -721,8 +721,7 @@ def create_argument_parser():
            default=None,
            help='The targets to compile or cross-compile the Swift standard '
                 'library for. %(default)s by default.'
-                ' Comma separated list: {}'.format(
-                    ' '.join(StdlibDeploymentTarget.get_target_names())))
+                f' Comma separated list: {" ".join(StdlibDeploymentTarget.get_target_names())}')
 
     option('--build-stdlib-deployment-targets', store,
            type=argparse.ShellSplitType(),
@@ -1508,8 +1507,7 @@ def create_argument_parser():
            default=android.adb.commands.DEVICE_TEMP_DIR,
            help='Path on an Android device to which built Swift stdlib '
                 'products will be deployed. If running host tests, specify '
-                'the "{}" directory.'.format(
-                    android.adb.commands.DEVICE_TEMP_DIR))
+                f'the "{android.adb.commands.DEVICE_TEMP_DIR}" directory.')
 
     option('--android-arch', store,
            choices=['armv7', 'aarch64', 'x86_64'],

--- a/utils/build_swift/build_swift/migration.py
+++ b/utils/build_swift/build_swift/migration.py
@@ -40,7 +40,7 @@ class UnknownSDKError(Exception):
         self.sdk = sdk
 
         super(UnknownSDKError, self).__init__(
-            'Unknown SDK: {}'.format(self.sdk))
+            f'Unknown SDK: {self.sdk}')
 
 
 def migrate_swift_sdks(args):
@@ -71,7 +71,7 @@ def migrate_swift_sdks(args):
         targets = _flatten(map(_swift_sdk_to_stdlib_targets, sdk_list))
         target_names = [target.name for target in targets]
 
-        return '--stdlib-deployment-targets={}'.format(' '.join(target_names))
+        return f'--stdlib-deployment-targets={" ".join(target_names)}'
 
     return list(map(_migrate_swift_sdks_arg, args))
 

--- a/utils/build_swift/build_swift/presets.py
+++ b/utils/build_swift/build_swift/presets.py
@@ -121,7 +121,7 @@ class DuplicatePresetError(PresetError):
 
     def __init__(self, preset_name):
         super(DuplicatePresetError, self).__init__(
-            '{} already exists'.format(preset_name))
+            f'{preset_name} already exists')
 
         self.preset_name = preset_name
 
@@ -132,7 +132,7 @@ class DuplicateOptionError(PresetError):
 
     def __init__(self, preset_name, option):
         super(DuplicateOptionError, self).__init__(
-            '{} already exists in preset {}'.format(option, preset_name))
+            f'{option} already exists in preset {preset_name}')
 
         self.preset_name = preset_name
         self.option = option
@@ -145,7 +145,7 @@ class InterpolationError(PresetError):
 
     def __init__(self, preset_name, option, rawval, reference):
         super(InterpolationError, self).__init__(
-            'no value found for {} in "{}"'.format(reference, rawval))
+            f'no value found for {reference} in "{rawval}"')
 
         self.preset_name = preset_name
         self.option = option
@@ -159,7 +159,7 @@ class PresetNotFoundError(PresetError):
 
     def __init__(self, preset_name):
         super(PresetNotFoundError, self).__init__(
-            '{} not found'.format(preset_name))
+            f'{preset_name} not found')
 
         self.preset_name = preset_name
 
@@ -170,7 +170,7 @@ class UnparsedFilesError(PresetError):
 
     def __init__(self, unparsed_files):
         super(UnparsedFilesError, self).__init__(
-            'unable to parse files: {}'.format(unparsed_files))
+            f'unable to parse files: {unparsed_files}')
 
         self.unparsed_files = unparsed_files
 
@@ -199,9 +199,9 @@ class Preset(object):
         args = []
         for (name, value) in self.options:
             if value is None:
-                args.append('--{}'.format(name))
+                args.append(f'--{name}')
             else:
-                args.append('--{}={}'.format(name, value))
+                args.append(f'--{name}={value}')
 
         return args
 

--- a/utils/build_swift/build_swift/shell.py
+++ b/utils/build_swift/build_swift/shell.py
@@ -124,7 +124,7 @@ def _echo_command(command, stream, prefix=ECHO_PREFIX):
 
     stream = _get_stream_file(stream)
 
-    stream.write('{}{}\n'.format(prefix, quote(command)))
+    stream.write(f'{prefix}{quote(command)}\n')
     stream.flush()
 
 
@@ -144,8 +144,7 @@ def _normalize_args(args):
         if isinstance(arg, AbstractWrapper):
             return list(map(_convert_pathlib_path, arg.command))
 
-        raise ValueError('Invalid argument type: {}'.format(
-            type(arg).__name__))
+        raise ValueError(f'Invalid argument type: {type(arg).__name__}')
 
     if isinstance(args, AbstractWrapper):
         return normalize_arg(args)
@@ -209,7 +208,7 @@ def quote(command):
     if isinstance(command, collections.abc.Iterable):
         return ' '.join([_quote(arg) for arg in _normalize_args(command)])
 
-    raise ValueError('Invalid command type: {}'.format(type(command).__name__))
+    raise ValueError(f'Invalid command type: {type(command).__name__}')
 
 
 def rerun_as_root():
@@ -494,15 +493,13 @@ class ExecutableWrapper(AbstractWrapper):
 
     def __init__(self):
         if self.EXECUTABLE is None:
-            raise AttributeError('{}.EXECUTABLE cannot be None'.format(
-                type(self).__name__))
+            raise AttributeError(f'{type(self).__name__}.EXECUTABLE cannot be None')
 
         self.EXECUTABLE = _convert_pathlib_path(self.EXECUTABLE)
 
         if not isinstance(self.EXECUTABLE, (str,)):
             raise AttributeError(
-                '{}.EXECUTABLE must be an executable name or path'.format(
-                    type(self).__name__))
+                f'{type(self).__name__}.EXECUTABLE must be an executable name or path')
 
         super(ExecutableWrapper, self).__init__()
 

--- a/utils/build_swift/build_swift/versions.py
+++ b/utils/build_swift/build_swift/versions.py
@@ -71,8 +71,7 @@ def _get_component_type(component):
         elif component.islower():
             return _ComponentType.ALPHA_LOWER
         else:
-            raise ValueError('Unknown component type for {!r}'.format(
-                component))
+            raise ValueError(f'Unknown component type for {component!r}')
 
     return _ComponentType.OTHER
 
@@ -157,7 +156,7 @@ class InvalidVersionError(Exception):
         self.version = version
 
         if msg is None:
-            msg = 'Invalid version: {}'.format(self.version)
+            msg = f'Invalid version: {self.version}'
 
         super(InvalidVersionError, self).__init__(msg)
 
@@ -199,4 +198,4 @@ class Version(object):
         return self._str
 
     def __repr__(self):
-        return '{}({!r})'.format(type(self).__name__, self._str)
+        return f'{type(self).__name__}({self._str!r})'


### PR DESCRIPTION
  Replace all `str.format()` calls with f-strings across the `build_swift`
  module (8 files, 28 occurrences). f-strings have been the preferred string
  formatting style since Python 3.6, and the Swift build system already
  requires Python 3.

  This is NFC — all replacements produce identical output. No logic,
  control flow, or behavior is modified. All existing `build_swift` unit
  tests continue to pass.