### PR TITLE
[AST] Use `.value()` in `SpecializedProtocolConformance::getConditionalRequirements`

### DIFF
--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -1077,7 +1077,7 @@ public:
 
   /// Get any requirements that must be satisfied for this conformance to apply.
   ArrayRef<Requirement> getConditionalRequirements() const {
-    return *getConditionalRequirementsIfAvailable();
+    return getConditionalRequirementsIfAvailable().value();
   }
 
   /// Get the protocol being conformed to.

--- a/validation-test/IDE/crashers/Requirement-checkRequirement-16e11d.swift
+++ b/validation-test/IDE/crashers/Requirement-checkRequirement-16e11d.swift
@@ -1,0 +1,8 @@
+// {"kind":"complete","original":"f14f150c","signature":"swift::Requirement::checkRequirement(llvm::SmallVectorImpl<swift::Requirement>&, bool, llvm::SmallVectorImpl<swift::ProtocolConformanceRef>*) const","signatureNext":"desugarRequirement"}
+// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+protocol a
+#^^#{
+associatedtype b where b == Self }
+protocol c: a struct d<e extension d: a where b == {
+#^f^# }
+extension d: c where e: c, e.b == d


### PR DESCRIPTION
- Explanation: Make sure we're guaranteed to trap if conditional requirements haven't been computed yet rather than returning garbage.
- Scope: Conformance checking
- Issue: N/A
- Risk: Low, previously we would have returned garbage instead of crashing
- Testing: Added test to test suite
