### PR TITLE
[Sema] Add fix-its for value passed where closure expected

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -7601,6 +7601,9 @@ bool ArgumentMismatchFailure::diagnoseAsError() {
   if (diagnoseKeyPathAsFunctionResultMismatch())
     return true;
 
+  if (diagnoseValuePassedAsClosure())
+    return true;
+
   auto argType = getFromType();
 
   // Unresolved key path argument requires a tailored diagnostic
@@ -7985,6 +7988,35 @@ bool ArgumentMismatchFailure::diagnoseKeyPathAsFunctionResultMismatch() const {
   emitDiagnostic(diag::expr_keypath_value_covert_to_contextual_type,
                  kpValueType, paramFnType->getResult());
   return true;
+}
+
+bool ArgumentMismatchFailure::diagnoseValuePassedAsClosure() const {
+  // The inverse case (closure passed to non-closure param) belongs to
+  // diagnoseClosureMismatch().
+  if (isExpr<ClosureExpr>(getAnchor()))
+    return false;
+
+  // Only concrete (non-generic) function types. getAs<FunctionType>() fails
+  // for GenericFunctionType intentionally — the fix-it text would be
+  // type-unsafe for generic parameters.
+  auto paramFnType = getToType()->getAs<FunctionType>();
+  if (!paramFnType)
+    return false;
+
+  auto argType = getFromType();
+
+  // '() -> T' where arg type == T: wrap the argument expression in '{ <expr> }'.
+  // This is the simpler case — the user has the value and just needs to defer
+  // its evaluation.
+  if (paramFnType->getNumParams() == 0 &&
+      paramFnType->getResult()->isEqual(argType)) {
+    emitDiagnostic(diag::cannot_convert_argument_value, argType, getToType())
+        .fixItInsert(getSourceRange().Start, "{ ")
+        .fixItInsertAfter(getSourceRange().End, " }");
+    return true;
+  }
+
+  return false;
 }
 
 void ExpandArrayIntoVarargsFailure::tryDropArrayBracketsFixIt(

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -8016,6 +8016,18 @@ bool ArgumentMismatchFailure::diagnoseValuePassedAsClosure() const {
     return true;
   }
 
+  // '(T) -> Void' where arg type == T: replace the argument with '{ _ in }'.
+  // Only the single-argument case is handled; multi-argument closures would
+  // require a different fix-it string and are excluded from scope.
+  if (paramFnType->getNumParams() == 1 && paramFnType->getResult()->isVoid()) {
+    auto closureParamType = paramFnType->getParams().front().getPlainType();
+    if (argType->isEqual(closureParamType)) {
+      emitDiagnostic(diag::cannot_convert_argument_value, argType, getToType())
+          .fixItReplace(getSourceRange(), "{ _ in }");
+      return true;
+    }
+  }
+
   return false;
 }
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2264,6 +2264,12 @@ public:
   /// result value.
   bool diagnoseKeyPathAsFunctionResultMismatch() const;
 
+  /// Tailored fix-it for when a value is passed where a closure is expected
+  /// and the types align precisely: '() -> T' when arg type is T (wraps arg in
+  /// '{ <expr> }'), or '(T) -> Void' when arg type is T (replaces with
+  /// '{ _ in }').
+  bool diagnoseValuePassedAsClosure() const;
+
   /// Situations like this:
   ///
   /// func foo(_: Int, _: String) {}

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -1430,3 +1430,16 @@ do {
       .reduce([:], { x, y in x.merging(y, uniquingKeysWith: +) })
       .mapValues { Set($0) }
 }
+
+// Fix-it: value of type T passed where () -> T closure is expected.
+// The fix-it wraps the argument in '{ <expr> }', preserving the expression.
+do {
+  struct AStruct {}
+  func iExpectAReturningClosure(_ aClosure: () -> AStruct) {}
+
+  iExpectAReturningClosure(AStruct()) // expected-error {{cannot convert value of type 'AStruct' to expected argument type '() -> AStruct'}}
+
+  // Guard: type mismatch — arg type does not match closure result type, no fix-it.
+  struct BStruct {}
+  iExpectAReturningClosure(BStruct()) // expected-error {{cannot convert value of type 'BStruct' to expected argument type '() -> AStruct'}}
+}

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -1443,3 +1443,21 @@ do {
   struct BStruct {}
   iExpectAReturningClosure(BStruct()) // expected-error {{cannot convert value of type 'BStruct' to expected argument type '() -> AStruct'}}
 }
+
+// Fix-it: value of type T passed where (T) -> Void closure is expected.
+// The fix-it replaces the argument with '{ _ in }'; only single-argument Void
+// closures are handled.
+do {
+  struct AStruct {}
+  func iExpectAClosure(_ aClosure: (AStruct) -> Void) {}
+
+  iExpectAClosure(AStruct()) // expected-error {{cannot convert value of type 'AStruct' to expected argument type '(AStruct) -> Void'}}
+
+  // Guard: multi-argument closure — no fix-it.
+  func expectsTwoArgs(_ f: (AStruct, AStruct) -> Void) {}
+  expectsTwoArgs(AStruct()) // expected-error {{cannot convert value of type 'AStruct' to expected argument type '(AStruct, AStruct) -> Void'}}
+
+  // Guard: non-Void return — no fix-it (falls through both branches).
+  func expectsTransform(_ f: (AStruct) -> AStruct) {}
+  expectsTransform(AStruct()) // expected-error {{cannot convert value of type 'AStruct' to expected argument type '(AStruct) -> AStruct'}}
+}


### PR DESCRIPTION
## Summary

When a user passes a plain value where a closure is expected and the types align exactly, the compiler errors correctly but offers no fix-it. This PR adds two tailored fix-its in `ArgumentMismatchFailure::diagnoseValuePassedAsClosure()`:

- **`() -> T` where `T` is passed**: wraps the argument in `{ <expr> }`, preserving the expression (the user has the value and just needs to defer its evaluation)
- **`(T) -> Void` where `T` is passed**: replaces the argument with `{ _ in }` (single-argument Void closures only)

Both checks are guarded on concrete `FunctionType` (not `GenericFunctionType`) and run on the error path only — no impact on successful compilation.

```swift
struct AStruct {}
func iExpectAReturningClosure(_ aClosure: () -> AStruct) {}
func iExpectAClosure(_ aClosure: (AStruct) -> Void) {}

iExpectAReturningClosure(AStruct())
// error: cannot convert value of type 'AStruct' to expected argument type '() -> AStruct'
// fix-it: replace 'AStruct()' with '{ AStruct() }'

iExpectAClosure(AStruct())
// error: cannot convert value of type 'AStruct' to expected argument type '(AStruct) -> Void'
// fix-it: replace 'AStruct()' with '{ _ in }'
```

## Test plan

- [ ] `llvm-lit test/Constraints/closures.swift -v` — two new `do` blocks covering positive cases and guard cases for each fix-it
- [ ] Full `llvm-lit test/Constraints/` to confirm no regressions
- [ ] Fix-it column annotations in test to be filled in after first build