### PR TITLE
Embedded: fix OOM in `swift-frontend` with recursive generics

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8861,6 +8861,13 @@ GROUPED_WARNING(dynamic_cast_involving_protocol_in_embedded_swift,
                 "cannot perform a dynamic cast to a type involving %kind0 in Embedded Swift",
                 (const Decl *))
 
+GROUPED_ERROR(self_referential_superclass_in_embedded_swift,
+              EmbeddedRestrictions, none,
+              "class %0 cannot inherit from %1 in Embedded Swift because "
+              "a generic argument of the superclass refers to the subclass itself, "
+              "creating a circular metadata dependency",
+              (Type, Type))
+
 //===----------------------------------------------------------------------===//
 // MARK: @abi Attribute
 //===----------------------------------------------------------------------===//

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -476,6 +476,29 @@ static void checkInheritanceClause(
       }
 
       if (canHaveSuperclass) {
+        // Check for self-referential generic superclass in Embedded Swift.
+        // A class like `class Tree: ManagedBuffer<Int, Tree>` creates a
+        // circular metadata dependency that cannot be resolved statically.
+        if (auto *classDecl = dyn_cast<ClassDecl>(decl)) {
+          if (auto behavior = shouldDiagnoseEmbeddedLimitations(
+                  classDecl, inherited.getSourceRange().Start,
+                  /*wasAlwaysEmbeddedError=*/true)) {
+            if (auto superBGT = inheritedTy->getAs<BoundGenericClassType>()) {
+              for (auto arg : superBGT->getGenericArgs()) {
+                if (auto *nominal = arg->getAnyNominal()) {
+                  if (nominal == classDecl) {
+                    diags.diagnose(
+                        inherited.getSourceRange().Start,
+                        diag::self_referential_superclass_in_embedded_swift,
+                        classDecl->getDeclaredInterfaceType(), inheritedTy)
+                      .limitBehavior(*behavior);
+                  }
+                }
+              }
+            }
+          }
+        }
+
         // Record the superclass.
         superclassTy = inheritedTy;
         superclassRange = inherited.getSourceRange();

--- a/test/embedded/self-referential-managed-buffer.swift
+++ b/test/embedded/self-referential-managed-buffer.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -typecheck %s -enable-experimental-feature Embedded -verify
 // REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_Embedded
 
 // Self-referential generic superclass should be diagnosed in Embedded Swift
 // because it creates a circular metadata dependency.

--- a/test/embedded/self-referential-managed-buffer.swift
+++ b/test/embedded/self-referential-managed-buffer.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend -typecheck %s -enable-experimental-feature Embedded -verify
+// REQUIRES: swift_in_compiler
+
+// Self-referential generic superclass should be diagnosed in Embedded Swift
+// because it creates a circular metadata dependency.
+
+final class Tree: ManagedBuffer<Int, Tree> { // expected-error {{class 'Tree' cannot inherit from 'ManagedBuffer<Int, Tree>' in Embedded Swift because a generic argument of the superclass refers to the subclass itself, creating a circular metadata dependency}}
+    var children: AnySequence<Tree> { AnySequence([]) }
+}


### PR DESCRIPTION
**Explanation**: Provides an error diagnostic that notifies the user that recursive generics are not supported in Embedded Swift. This prevents current OOM behavior in `swift-frontend`.
**Scope**: limited to a rarely used pattern in Embedded Swift
**Risk**: low due to limited scope.
**Testing**: added new lit test
**Issue**: rdar://174011486
