### PR TITLE
Embedded WASI: make `import _Concurrency` implicit

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1912,7 +1912,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   if (Opts.hasFeature(Feature::Embedded)) {
     Opts.UnavailableDeclOptimizationMode = UnavailableDeclOptimization::Complete;
     Opts.DisableImplicitStringProcessingModuleImport = true;
-    Opts.DisableImplicitConcurrencyModuleImport = !Opts.Target.isOSWASI();
+    Opts.DisableImplicitConcurrencyModuleImport |= !Opts.Target.isOSWASI();
 
     if (!swiftModulesInitialized()) {
       Diags.diagnose(SourceLoc(), diag::no_swift_sources_with_embedded);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1912,7 +1912,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   if (Opts.hasFeature(Feature::Embedded)) {
     Opts.UnavailableDeclOptimizationMode = UnavailableDeclOptimization::Complete;
     Opts.DisableImplicitStringProcessingModuleImport = true;
-    Opts.DisableImplicitConcurrencyModuleImport = true;
+    Opts.DisableImplicitConcurrencyModuleImport = !Opts.Target.isOSWASI();
 
     if (!swiftModulesInitialized()) {
       Diags.diagnose(SourceLoc(), diag::no_swift_sources_with_embedded);

--- a/test/embedded/coroutines-and-testing.swift
+++ b/test/embedded/coroutines-and-testing.swift
@@ -1,7 +1,7 @@
 // Make sure this can be compiled without any errors
 
-// RUN: %target-swift-frontend %s -emit-ir -o /dev/null -enable-experimental-feature Embedded -enable-testing
-// RUN: %target-swift-frontend %s -emit-ir -o /dev/null -enable-experimental-feature Embedded -enable-testing -no-allocations
+// RUN: %target-swift-frontend %s -emit-ir -o /dev/null -enable-experimental-feature Embedded -enable-testing -disable-implicit-concurrency-module-import
+// RUN: %target-swift-frontend %s -emit-ir -o /dev/null -enable-experimental-feature Embedded -enable-testing -no-allocations -disable-implicit-concurrency-module-import
 
 
 // REQUIRES: OS=macosx || OS=wasip1

--- a/test/embedded/dependencies-random.swift
+++ b/test/embedded/dependencies-random.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
-// RUN: %target-swift-frontend -parse-as-library -enable-experimental-feature Embedded -enable-experimental-feature Extern %t/test.swift -c -o %t/a.o
+// RUN: %target-swift-frontend -parse-as-library -enable-experimental-feature Embedded -enable-experimental-feature Extern -disable-implicit-concurrency-module-import %t/test.swift -c -o %t/a.o
 
 // RUN: %llvm-nm --undefined-only --format=just-symbols %t/a.o | sort | tee %t/actual-dependencies.txt
 

--- a/test/embedded/lazy_metadata.swift
+++ b/test/embedded/lazy_metadata.swift
@@ -1,17 +1,17 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -wmo -module-name A -emit-irgen -o %t/A1.ll %t/A.swift -enable-experimental-feature Embedded -enable-experimental-feature EmbeddedExistentials -parse-as-library
+// RUN: %target-swift-frontend -wmo -module-name A -emit-irgen -o %t/A1.ll %t/A.swift -enable-experimental-feature Embedded -enable-experimental-feature EmbeddedExistentials -parse-as-library -disable-implicit-concurrency-module-import
 // RUN: %FileCheck --check-prefix=A1 %s < %t/A1.ll
 
-// RUN: %target-swift-frontend -wmo -module-name A -num-threads 1 -emit-ir -o %t/A2.ll -o %t/B2.ll %t/A.swift %t/B.swift -enable-experimental-feature Embedded -enable-experimental-feature EmbeddedExistentials -parse-as-library
+// RUN: %target-swift-frontend -wmo -module-name A -num-threads 1 -emit-ir -o %t/A2.ll -o %t/B2.ll %t/A.swift %t/B.swift -enable-experimental-feature Embedded -enable-experimental-feature EmbeddedExistentials -parse-as-library -disable-implicit-concurrency-module-import
 // RUN: %FileCheck --check-prefix=A2 %s < %t/A2.ll
 // RUN: %FileCheck --check-prefix=B2 %s < %t/B2.ll
 
-// RUN: %target-swift-frontend  -emit-module -emit-module-path %t/A.swiftmodule -wmo -module-name A -emit-ir -o %t/A3.ll  %t/A.swift %t/B.swift -enable-experimental-feature Embedded -enable-experimental-feature EmbeddedExistentials -parse-as-library
+// RUN: %target-swift-frontend  -emit-module -emit-module-path %t/A.swiftmodule -wmo -module-name A -emit-ir -o %t/A3.ll  %t/A.swift %t/B.swift -enable-experimental-feature Embedded -enable-experimental-feature EmbeddedExistentials -parse-as-library -disable-implicit-concurrency-module-import
 // RUN: %FileCheck --check-prefix=A3 %s < %t/A3.ll
 
-// RUN: %target-swift-frontend -wmo -I %t -module-name C -emit-irgen -o %t/C4.ll  %t/C.swift -enable-experimental-feature Embedded -enable-experimental-feature EmbeddedExistentials -parse-as-library
+// RUN: %target-swift-frontend -wmo -I %t -module-name C -emit-irgen -o %t/C4.ll  %t/C.swift -enable-experimental-feature Embedded -enable-experimental-feature EmbeddedExistentials -parse-as-library -disable-implicit-concurrency-module-import
 // RUN: %FileCheck --check-prefix=C4 %s < %t/C4.ll
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/wasm/concurrency-implicit-import.swift
+++ b/test/embedded/wasm/concurrency-implicit-import.swift
@@ -1,0 +1,28 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
+// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple -lc++ -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_in_compiler
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=wasip1
+// REQUIRES: swift_feature_Embedded
+
+// Verify that _Concurrency is implicitly imported for Embedded Swift on wasip1.
+
+public func test() async -> Int {
+  let t = Task {
+    return 42
+  }
+  return await t.value
+}
+
+@main
+struct Main {
+  static func main() async {
+    let x = await test()
+    print(x == 42 ? "OK" : "FAIL")
+    // CHECK: OK
+  }
+}


### PR DESCRIPTION
**Explanation**: Existing `wasip1` triples for Embedded Swift already support concurrency, so this import should be implicit and no longer require package authors to make it explicit for Embedded Swift for WASI compatibility.
**Scope**: limited to Embedded Swift for Wasm;
**Risk**: low due to limited scope;
**Testing**: added a new lit test that verifies the change.
**Issue**: rdar://174021193

