### PR TITLE
stdlib: Avoid pointless overhead in `withUnsafeTemporaryAllocation()`

### DIFF
--- a/stdlib/public/core/TemporaryAllocation.swift
+++ b/stdlib/public/core/TemporaryAllocation.swift
@@ -58,7 +58,6 @@ internal func _byteCountForTemporaryAllocation<T: ~Copyable>(
 ///   `byteCount` bytes of memory.
 @_alwaysEmitIntoClient @_transparent
 internal func _isStackAllocationSafe(byteCount: Int, alignment: Int) -> Bool {
-#if compiler(>=5.5) && $BuiltinStackAlloc
   // PRECONDITIONS: Non-positive alignments are nonsensical, as are
   // non-power-of-two alignments.
   if _isComputed(alignment) {
@@ -86,21 +85,10 @@ internal func _isStackAllocationSafe(byteCount: Int, alignment: Int) -> Bool {
     return true
   }
 
-#if !$Embedded
-  // Finally, take a slow path through the standard library to see if the
-  // current environment can accept a larger stack allocation.
-  guard #available(macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4, *) //SwiftStdlib 5.6
-  else {
-    return false
-  }
-  return swift_stdlib_isStackAllocationSafe(byteCount, alignment)
-#else
+  // NOTE: If swift_stdlib_isStackAllocationSafe() is ever updated to return
+  // something other than false, call it here instead of returning false
+  // unconditionally.
   return false
-#endif
-
-#else
-  fatalError("unsupported compiler")
-#endif
 }
 
 /// Provides scoped access to a raw buffer pointer with the specified type,
@@ -140,7 +128,6 @@ internal func _withUnsafeTemporaryAllocation<
   // notice and complain.)
   let result: R
   
-#if compiler(>=5.5) && $BuiltinStackAlloc
   let stackAddress = Builtin.stackAlloc(
     capacity._builtinWordValue,
     MemoryLayout<T>.stride._builtinWordValue,
@@ -153,9 +140,6 @@ internal func _withUnsafeTemporaryAllocation<
   result = body(stackAddress)
   Builtin.stackDealloc(stackAddress)
   return result
-#else
-  fatalError("unsupported compiler")
-#endif
 }
 
 @_alwaysEmitIntoClient @_transparent

--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -376,6 +376,10 @@ __swift_bool swift_stdlib_isStackAllocationSafe(__swift_size_t byteCount,
   // been measured for its performance characteristics. In particular, if the
   // platform-specific functions we need to use end up calling malloc(), it's
   // pointless to use them.
+  //
+  // NOTE: If this is ever updated to do an actual computation, the standard
+  // library function must also be updated to start calling into this runtime
+  // hook again.
   return false;
 
 #if 0

--- a/test/IRGen/temporary_allocation/codegen_very_large_allocation.swift
+++ b/test/IRGen/temporary_allocation/codegen_very_large_allocation.swift
@@ -1,40 +1,20 @@
-// RUN: %target-swift-frontend -target %target-swift-5.5-abi-triple -primary-file %s -O -emit-ir | %FileCheck %s --check-prefixes=CHECK-LARGE-ALLOC,CHECK-LARGE-ALLOC-%target-vendor -DWORD=i%target-ptrsize
-// RUN: %target-swift-frontend -target %target-swift-5.5-abi-triple -primary-file %s -O -emit-ir | %FileCheck %s --check-prefix=CHECK-LARGE-STACK-ALLOC -DWORD=i%target-ptrsize
-// RUN: %target-swift-frontend -target %target-swift-5.5-abi-triple -primary-file %s -O -emit-ir | %FileCheck %s --check-prefix=CHECK-LARGE-HEAP-ALLOC -DWORD=i%target-ptrsize
+// RUN: %target-swift-frontend -target %target-swift-5.5-abi-triple -primary-file %s -O -emit-ir > %t.ir
+// RUN: %FileCheck %s -DWORD=i%target-ptrsize < %t.ir
+// RUN: %FileCheck %s --check-prefix=CHECK-NEGATIVE -DWORD=i%target-ptrsize < %t.ir
 
-// This test for conditionally checking the version with ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF
-// xrOS is always succeeds the availability check so there is no need to call
-// this function.
-// UNSUPPORTED: OS=xros
-
-// On iOS _stdlib_isOSVersionAtLeast() is @_transparent, which affects codegen.
-// UNSUPPORTED: OS=ios
-
-// When macCatalyst support is enabled, isOSVersionAtLeast transforms into
-// isOSVersionAtLeastOrVariantVersionAtLeast
-// UNSUPPORTED: maccatalyst_support
 
 @_silgen_name("blackHole")
 func blackHole(_ value: UnsafeMutableRawPointer?) -> Void
 
 // MARK: Very large allocation
 
-// A large allocation size should produce an OS version check, call to
-// swift_stdlib_isStackAllocationSafe(), and then a branch based on the result
-// to either stack-allocate or heap-allocate.
 withUnsafeTemporaryAllocation(byteCount: 0x0FFF_FFFF, alignment: 1) { buffer in
   blackHole(buffer.baseAddress)
 }
-// CHECK-LARGE-HEAP-ALLOC: [[HEAP_PTR_RAW:%[0-9]+]] = {{(tail )?}}call noalias ptr @swift_slowAlloc([[WORD]] 268435455, [[WORD]] -1)
-// CHECK-LARGE-HEAP-ALLOC-NEXT: [[HEAP_PTR:%[0-9]+]] = ptrtoint ptr [[HEAP_PTR_RAW]] to [[WORD]]
-// CHECK-LARGE-HEAP-ALLOC-NEXT: {{(tail )?}}call swiftcc void @blackHole([[WORD]] [[HEAP_PTR]])
-// CHECK-LARGE-HEAP-ALLOC-NEXT: {{(tail )?}}call void @swift_slowDealloc(ptr [[HEAP_PTR_RAW]], [[WORD]] -1, [[WORD]] -1)
+// CHECK: [[HEAP_PTR_RAW:%[0-9]+]] = {{(tail )?}}call noalias ptr @swift_slowAlloc([[WORD]] 268435455, [[WORD]] -1)
+// CHECK-NEXT: [[HEAP_PTR:%[0-9]+]] = ptrtoint ptr [[HEAP_PTR_RAW]] to [[WORD]]
+// CHECK-NEXT: {{(tail )?}}call swiftcc void @blackHole([[WORD]] [[HEAP_PTR]])
+// CHECK-NEXT: {{(tail )?}}call void @swift_slowDealloc(ptr [[HEAP_PTR_RAW]], [[WORD]] -1, [[WORD]] -1)
 
-// CHECK-LARGE-STACK-ALLOC: [[STACK_PTR_RAW:%temp_alloc[0-9]*]] = alloca [268435455 x i8], align 1
-// CHECK-LARGE-STACK-ALLOC: [[STACK_PTR:%[0-9]+]] = ptrtoint ptr [[STACK_PTR_RAW]] to [[WORD]]
-// CHECK-LARGE-STACK-ALLOC-NEXT: call swiftcc void @blackHole([[WORD]] [[STACK_PTR]])
-
-// CHECK-LARGE-ALLOC-DAG: [[IS_SAFE:%[0-9]+]] = {{(tail )?}}call {{(zeroext )?}}i1 @swift_stdlib_isStackAllocationSafe([[WORD]] 268435455, [[WORD]] 1)
-// CHECK-LARGE-ALLOC-DAG: br i1 [[IS_SAFE]], label %{{[0-9]+}}, label %{{[0-9]+}}
-// CHECK-LARGE-ALLOC-apple-DAG: [[IS_OS_OK:%[0-9]+]] = {{(tail )?}}call swiftcc i1 @"$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF"
-// CHECK-LARGE-ALLOC-apple-DAG: br i1 [[IS_OS_OK]], label %{{[0-9]+}}, label %{{[0-9]+}}
+// CHECK-NEGATIVE-NOT: swift_stdlib_isStackAllocationSafe
+// CHECK-NEGATIVE-NOT: ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF


### PR DESCRIPTION
The runtime function `swift_stdlib_isStackAllocationSafe()` never returns a value other than false, so calling it and checking availability in order to determine whether it is safe to do so are unnecessary overhead for the current implementation. This overhead is especially noticable on macOS currently because standard library availability checks are not elided by the optimizer when inlined into clients due to the standard library being built zippered for macCatalyst.

If `swift_stdlib_isStackAllocationSafe()` ever becomes non-trivial, we can reintroduce the check.

Resolves rdar://174020289.
