### PR TITLE
[cxx-interop] Stop instantiating return types before importing them

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4607,32 +4607,6 @@ namespace {
     }
 
     Decl *VisitCXXMethodDecl(const clang::CXXMethodDecl *decl) {
-      // If the return type is a templated class, instantiate it. This must
-      // happen before we import the name of the method, as the name is affected
-      // by safety/unsafety of the return type. The safety detection logic
-      // (`IsSafeUseOfCxxDecl`) relies on the class being instantiated.
-      //
-      // This behavior is currently gated on ImportCxxMembersLazily to provide
-      // an easy off-ramp in case of qualification issues.
-      if (auto *returnedTmpl =
-              dyn_cast_or_null<clang::ClassTemplateSpecializationDecl>(
-                  desugarIfElaborated(decl->getReturnType())->getAsTagDecl());
-          Impl.SwiftContext.LangOpts.hasFeature(
-              Feature::ImportCxxMembersLazily) &&
-          returnedTmpl && !returnedTmpl->getDefinition()) {
-        Impl.getClangSema().InstantiateClassTemplateSpecialization(
-            decl->getLocation(),
-            const_cast<clang::ClassTemplateSpecializationDecl *>(returnedTmpl),
-            clang::TemplateSpecializationKind::TSK_ImplicitInstantiation,
-            /*Complain*/ false, /*PrimaryStrictPackMatch*/ false);
-        // N.B. InstantiateClassTemplateSpecialization() returns true if it
-        //      encountered an error while instantiating the returned template.
-        //      Even if it does, we don't bail out here, and defer error
-        //      handling to later. This is because that handler may involve
-        //      things like import a method and mark it as unavailable, rather
-        //      than simply not import it at all.
-      }
-
       // The static `operator ()` introduced in C++ 23 is still callable as an
       // instance operator in C++, and we want to preserve the ability to call
       // it as an instance method in Swift as well for source compatibility.
@@ -4646,6 +4620,55 @@ namespace {
           return result;
       }
       auto method = VisitFunctionDecl(decl);
+
+      // For regular methods (not operators, constructors, etc.), if the return
+      // type is an uninstantiated templated class, instantiate it now and
+      // update the imported name if it changed. The safety detection logic
+      // (IsSafeUseOfCxxDecl) relies on the returned class being instantiated,
+      // and may affect the imported name (e.g., adding a "__*Unsafe" prefix).
+      // We defer this instantiation to after importing the method so that we
+      // don't eagerly instantiate templates for methods we may not even end up
+      // importing. The "__*Unsafe" lookup fallback in ClangDirectLookupRequest
+      // will also find methods whose imported name changes due to safety after
+      // instantiation.
+      //
+      // This post-import behavior is gated on ImportCxxMembersLazily, because
+      // without that feature, IsSafeUseOfCxxDecl relies on ClangImporter
+      // (over-)eagerly instantiating typedef members.
+      if (method && Impl.SwiftContext.LangOpts.hasFeature(
+                        Feature::ImportCxxMembersLazily)) {
+        if (!isa<clang::CXXConstructorDecl, clang::CXXDestructorDecl,
+                 clang::CXXConversionDecl>(decl) &&
+            decl->getOverloadedOperator() ==
+                clang::OverloadedOperatorKind::OO_None) {
+
+          using ClassTmplSpec = clang::ClassTemplateSpecializationDecl;
+
+          auto retTy = desugarIfElaborated(decl->getReturnType());
+          auto *retTemplate =
+              dyn_cast_or_null<ClassTmplSpec>(retTy->getAsTagDecl());
+
+          if (retTemplate && !retTemplate->hasDefinition()) {
+            // N.B. InstantiateClassTemplateSpecialization() returns true if it
+            // encountered an error while instantiating the returned template.
+            (void)Impl.getClangSema().InstantiateClassTemplateSpecialization(
+                decl->getLocation(), const_cast<ClassTmplSpec *>(retTemplate),
+                clang::TemplateSpecializationKind::TSK_ImplicitInstantiation,
+                /*Complain*/ false, /*PrimaryStrictPackMatch*/ false);
+          }
+          // Re-import the name now that the return type template is (or was
+          // already) instantiated; safety may have changed, affecting the
+          // base name. Clear the cached name first so importFullName
+          // recomputes it.
+          Impl.getNameImporter().clearCachedName(decl, Impl.CurrentVersion);
+          if (auto updatedName =
+                  Impl.importFullName(decl, Impl.CurrentVersion)) {
+            auto *valueDecl = cast<ValueDecl>(method);
+            if (valueDecl->getName() != updatedName.getDeclName())
+              valueDecl->setName(updatedName.getDeclName());
+          }
+        }
+      }
 
       // Do not expose constructors of abstract C++ classes.
       if (auto recordDecl =

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -438,6 +438,13 @@ public:
                           clang::DeclarationName preferredName =
                             clang::DeclarationName());
 
+  /// Clear the cached imported name for a particular Clang decl so that the
+  /// next call to importName will recompute it.
+  void clearCachedName(const clang::NamedDecl *decl,
+                       ImportNameVersion version) {
+    importNameCache.erase({decl, version});
+  }
+
   /// Attempts to import the name of \p decl with each possible
   /// ImportNameVersion. \p action will be called with each unique name.
   ///

--- a/test/Interop/Cxx/class/invalid-members/function-members-with-invalid-types.swift
+++ b/test/Interop/Cxx/class/invalid-members/function-members-with-invalid-types.swift
@@ -9,11 +9,17 @@
 // RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default \
 // RUN:   -enable-experimental-feature ImportCxxMembersLazily \
 // RUN:   -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}function.h \
-// RUN:   %t%{fs-sep}ok.swift
+// RUN:   -typo-correction-limit 0 \
+// RUN:   %t%{fs-sep}ok.swift -verify-additional-prefix ok-swift-
 // RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default \
 // RUN:   -enable-experimental-feature ImportCxxMembersLazily \
 // RUN:   -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}function.h \
+// RUN:   -typo-correction-limit 0 \
 // RUN:   %t%{fs-sep}err.swift -verify-additional-prefix swift-
+//
+// Note that we need -typo-correction-limit 0 because otherwise the compiler
+// will try to import other members anyway to suggest "did you mean" diagnostics
+// that unintentionally trigger even more instantiations and thus errors.
 //
 // Check module interface of function.h
 // RUN: %target-swift-ide-test -print-module -source-filename=x \
@@ -41,6 +47,10 @@ struct Bro {
 };
 
 struct Ken {};
+
+struct __attribute__((swift_attr("import_reference")))
+       __attribute__((swift_attr("retain:immortal")))
+       __attribute__((swift_attr("release:immortal"))) FRT {};
 
 // None of GoodStruct's members should prevent it from being imported sans error
 struct GoodStruct {
@@ -77,6 +87,12 @@ struct GoodStruct {
 
   Bro<Ken> begin() const;
   Bro<Ken> end() const;
+
+  // Return type templates are instantiated only if the function member is
+  // actually imported, e.g., not if the function member is deleted.
+  Bro<Ken> operator~() const = delete;
+  Bro<Ken> deleted() const = delete;
+  Bro<Ken> frtArgByValue(FRT) const; // expected-ok-swift-note {{uses foreign reference type 'FRT' as a value}}
 };
 // CHECK:      struct GoodStruct {
 // CHECK-NEXT:   init()
@@ -189,12 +205,19 @@ func ok() {
   let _: UnsafePointer<UsingGoodStruct>
   let _: UnsafePointer<UsesGoodStruct>
 
-  let gs = GoodStruct() // expected-warning {{never used}}
+  let gs = GoodStruct()
   // TODO: calling overloadsDiffNumArgs(_:_) should work since we should never
   //       need to import the (invalid) single-argument overload. The following
   //       call is commented out so that ok.swift compiles without C++ errors,
   //       but should be added back when this behavior is fixed.
   // gs.overloadsDiffNumArgs(42, 24)
+
+  // NOTE: these function members have invalid return types but aren't imported,
+  // so attempting to use them should ONLY trigger missing member diagnostics
+  // and no template instantiation errors.
+  let _ = ~gs  // expected-error {{cannot be applied}}
+  gs.deleted() // expected-error {{has no member}}
+  gs.frtArgByValue() // expected-error {{has no member}}
 
   let _ = DerivedGoodStruct()
   let _ = UsingGoodStruct()


### PR DESCRIPTION
tl;dr (for consideration to merge into `main`):

- **Explanation**: This patch gets rid of the over-eager return type instantiation by moving it to *after* the function is imported.
- **Scope**: Only affects behavior when `ImportCxxMembersLazily` feature is enabled (which it isn't by default)
- **Issues**: rdar://174028575
- **Original PRs**: N/A
- **Risk**: Low
- **Testing**: Added test scenario to ensure that things still work
- **Reviewers**: @Xazax-hun + perhaps others

The extended cut:

In f305ffc69f2fbfc80eaa984c170d3f735f4b5cc4 I added a change that eagerly instantiates return type templates before importing them, which technically makes ClangImporter *more* eager. I made this change, in conjunction with 3a213c0085bda80a0b0178311b6cb3252a7ac6c1, in an attempt to make sure that the `__Unsafe` name mangling does not rely on the unintentional side effect of importing typedefs eagerly (which I made lazy in c57863df0cfc092936fa266ebfedcc41d6418b7d). The fact that this is more eager is not sound, but I hadn't thought of any better ways around this at the time.

This patch gets rid of the over-eager return type instantiation by moving it to *after* the function is imported. If and only if the method is actually imported, Swift will instantiate the return type, re-import the name, and overwrite the name of the imported decl, in case the instantiation or some other side effect during import causes it to gain the `__Unsafe` name mangling. Admittedly, this is an ugly hack, but an inevitable consequence of how we do name importing.

I've added a test scenario to ensure that deleted functions do not have their return types instantiated, but other test to pay attention to is test/Interop/Cxx/templates/using-return-type.swift, which checks that the `__Unsafe` mangling logic is robust. This test does not change.

rdar://174028575
