### PR TITLE
[6.3][cherrypick] Use unversioned triples on OpenBSD.

### DIFF
--- a/cmake/modules/SwiftConfigureSDK.cmake
+++ b/cmake/modules/SwiftConfigureSDK.cmake
@@ -451,6 +451,7 @@ macro(configure_sdk_unix name architectures)
         message(STATUS "OpenBSD Version: ${openbsd_system_version}")
 
         set(SWIFT_SDK_OPENBSD_ARCH_${arch}_TRIPLE "${arch}-unknown-openbsd${openbsd_system_version}")
+        set(SWIFT_SDK_OPENBSD_ARCH_${arch}_MODULE "${arch}-unknown-openbsd")
 
         add_link_options("LINKER:-z,origin")
 

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -457,13 +457,8 @@ llvm::Triple swift::getTargetSpecificModuleTriple(const llvm::Triple &triple) {
                         triple.getOSName(), environment);
   }
 
-  if (triple.isOSFreeBSD()) {
+  if (triple.isOSFreeBSD() || triple.isOSOpenBSD()) {
     return swift::getUnversionedTriple(triple);
-  }
-
-  if (triple.isOSOpenBSD()) {
-    StringRef arch = swift::getMajorArchitectureName(triple);
-    return llvm::Triple(arch, triple.getVendorName(), triple.getOSName());
   }
 
   // Other platforms get no normalization.


### PR DESCRIPTION
- **Explanation**:

OpenBSD uses unversioned triples when generating module names.

- **Scope**:

Minor, since this targets OpenBSD only. Any existing install base for OpenBSD is likely minimal.

- **Issues**:

Of relevance to the OpenBSD port in https://github.com/swiftlang/swift/issues/78437

- **Original PRs**:

#88224  

- **Risk**:

Minor, affects OpenBSD only.

- **Testing**:

Local testing, passes CI.

- **Reviewers**:

@DougGregor 
@jakepetroules 