### PR TITLE
[SIL] Harden SendNonSendable against missing SILFunction actor isolation

### DIFF
--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -74,6 +74,13 @@ static llvm::cl::opt<bool> ForceTypedErrors(
 //                              MARK: Utilities
 //===----------------------------------------------------------------------===//
 
+/// SIL may omit actor isolation (e.g. parsed SIL without `[isolation ...]`, or
+/// functions that never had \c setActorIsolation). Never dereference an empty
+/// optional from \c SILFunction::getActorIsolation().
+static ActorIsolation getActorIsolationForDiagnostics(SILFunction *fn) {
+  return fn->getActorIsolation().value_or(ActorIsolation::forUnspecified());
+}
+
 static SILValue stripFunctionConversions(SILValue val) {
   while (true) {
     if (auto ti = dyn_cast<ThinToThickFunctionInst>(val)) {
@@ -1162,8 +1169,8 @@ bool UseAfterSendDiagnosticInferrer::initForIsolatedPartialApply(
   auto *diagnosticOp = diagnosticPair->first;
 
   ApplyIsolationCrossing crossing(
-      *op->getFunction()->getActorIsolation(),
-      *diagnosticOp->getFunction()->getActorIsolation());
+      getActorIsolationForDiagnostics(op->getFunction()),
+      getActorIsolationForDiagnostics(diagnosticOp->getFunction()));
 
   auto &state = sendingOpToStateMap.get(sendingOp);
   if (auto rootValueAndName = inferNameAndRootHelper(sendingOp->get())) {
@@ -2078,8 +2085,8 @@ bool SentNeverSendableDiagnosticEmitter::initForIsolatedPartialApply(
   auto *diagnosticOp = diagnosticPair->first;
 
   ApplyIsolationCrossing crossing(
-      *op->getFunction()->getActorIsolation(),
-      *diagnosticOp->getFunction()->getActorIsolation());
+      getActorIsolationForDiagnostics(op->getFunction()),
+      getActorIsolationForDiagnostics(diagnosticOp->getFunction()));
 
   // We do not need to worry about failing to infer a name here since we are
   // going to be returning some form of a SILFunctionArgument which is always

--- a/test/Concurrency/sendnonsendable_sil_without_fn_isolation_attr.sil
+++ b/test/Concurrency/sendnonsendable_sil_without_fn_isolation_attr.sil
@@ -1,0 +1,74 @@
+// RUN: %target-sil-opt -send-non-sendable -strict-concurrency=complete -swift-version 5 %s -verify -verify-additional-prefix complete-
+// RUN: %target-sil-opt -send-non-sendable -swift-version 6 %s -verify -verify-additional-prefix tns-
+
+// REQUIRES: asserts
+// REQUIRES: concurrency
+
+// Parsed SIL omits `SILFunction::actorIsolation` unless `[isolation "..."]` is
+// present (see ParseSIL.cpp). `SILFunction::getActorIsolation()` is then
+// `std::nullopt`. SendNonSendable must treat that as unspecified isolation when
+// building `ApplyIsolationCrossing` for diagnostics (e.g.
+// `initForIsolatedPartialApply`), not dereference the optional (undefined
+// behavior).
+//
+// The `-verify` lines mirror test/sil-opt/swift-version.sil: isolation crossing
+// on `apply` is diagnosed even when callee/caller SIL functions carry no stored
+// isolation attribute.
+//
+// Source-level coverage for isolated partial-apply / closure diagnostics lives
+// in transfernonsendable_isolationcrossing_partialapply.swift (normal SILGen
+// always sets `SILFunction` isolation; this `.sil` file is the nullopt case).
+
+sil_stage raw
+
+import Swift
+import Builtin
+import _Concurrency
+
+class NonSendableKlass {}
+
+sil @transfer_to_main : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+
+// No `[isolation ...]` — SILFunction::getActorIsolation() is nullopt.
+
+sil [ossa] @fn_without_stored_isolation : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %1 = function_ref @transfer_to_main : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %1(%0) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+  // expected-complete-warning @-1 {{}}
+  // expected-complete-note @-2 {{}}
+  // expected-tns-error @-3 {{}}
+  // expected-tns-note @-4 {{}}
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// Second entry point: another function body without `[isolation ...]` so the
+// pass runs region analysis again with nullopt function isolation.
+
+sil [ossa] @second_fn_without_stored_isolation : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %1 = function_ref @transfer_to_main : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %1(%0) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+  // expected-complete-warning @-1 {{}}
+  // expected-complete-note @-2 {{}}
+  // expected-tns-error @-3 {{}}
+  // expected-tns-note @-4 {{}}
+  %r = tuple ()
+  return %r : $()
+}
+
+// Explicit `[isolation "..."]` sets `SILFunction::actorIsolation` (contrast with
+// the functions above). Diagnostics should still be emitted and must not crash.
+
+sil [isolation "nonisolated"] [ossa] @fn_with_explicit_sil_isolation_attr : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %1 = function_ref @transfer_to_main : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %1(%0) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+  // expected-complete-warning @-1 {{}}
+  // expected-complete-note @-2 {{}}
+  // expected-tns-error @-3 {{}}
+  // expected-tns-note @-4 {{}}
+  %t = tuple ()
+  return %t : $()
+}


### PR DESCRIPTION
## Summary

We are seeing a crash in `SendNonSendable` while emitting diagnostics for isolated `partial_apply` / closure patterns: `initForIsolatedPartialApply` built an `ApplyIsolationCrossing` by dereferencing `SILFunction::getActorIsolation()` even when that optional was empty. This change treats missing isolation as unspecified for diagnostics and adds regression coverage in SIL.

## Problem (stack trace)

While running the mandatory **`SendNonSendable`** SIL pass, the compiler crashed inside isolation diagnostic printing, for example:

1. `ExecuteSILPipelineRequest` → `SendNonSendable`
2. `SentNeverSendableDiagnosticEmitter::emit()` → `initForIsolatedPartialApply`
3. `SILIsolationInfo::printActorIsolationForDiagnostics` / `ActorIsolation::printForDiagnostics`

Example frames from a failing build (Swift 6.2.x, effective Swift 5.10), shortened:

While running pass ... "SendNonSendable" on SILFunction "...visit(commentNode:)"

```
swift::SILIsolationInfo::printActorIsolationForDiagnostics(swift::SILFunction*, swift::ActorIsolation, ...) 
(anonymous namespace)::SentNeverSendableDiagnosticEmitter::initForIsolatedPartialApply(...) 
(anonymous namespace)::SendNonSendableImpl::emitVerbatimErrors()
```

The same optional was also dereferenced in `UseAfterSendDiagnosticInferrer::initForIsolatedPartialApply`.

## Root cause

`SILFunction::getActorIsolation()` returns `std::optional<ActorIsolation>`. It is only set when something has called `setActorIsolation` (e.g. SILGen for normal Swift). For **parsed SIL**, isolation is stored only if the function declares **`[isolation "..."]`**; otherwise the optional stays **empty** (`ParseSIL.cpp`).

Dereferencing that empty optional in `SendNonSendable.cpp` when constructing:

```cpp
ApplyIsolationCrossing crossing(
    *op->getFunction()->getActorIsolation(),
    *diagnosticOp->getFunction()->getActorIsolation());
```

is undefined behavior. That can surface as a crash while formatting isolation for diagnostics (e.g. under printActorIsolationForDiagnostics), including repeated or corrupted stack frames.

## Solution

Add a small helper that returns fn->getActorIsolation().value_or(ActorIsolation::forUnspecified()).
Use it for both operands when building ApplyIsolationCrossing in:
UseAfterSendDiagnosticInferrer::initForIsolatedPartialApply
SentNeverSendableDiagnosticEmitter::initForIsolatedPartialApply
Missing SIL function isolation is then treated like unspecified isolation for diagnostic text, which matches ActorIsolation::printForDiagnostics for that kind.

## Testing

test/Concurrency/sendnonsendable_sil_without_fn_isolation_attr.sil: sil-opt -send-non-sendable with -verify (Swift 5 / 6 prefixes aligned with test/sil-opt/swift-version.sil), including:
* functions without [isolation ...] (nullopt case),
* a control function with sil [isolation "nonisolated"] (optional present).
* End-to-end Swift coverage for isolated partial-apply diagnostics remains in existing tests (e.g. transfernonsendable_isolationcrossing_partialapply.swift); the new .sil file documents the parsed-SIL / nullopt case in a comment.

Scope note: This is a compiler fix in lib/SILOptimizer/Mandatory/SendNonSendable.cpp; it is not a Swift Evolution or standard library API change.