### PR TITLE
[6.3][cxx-interop] Tighten isSpecialAppKitFunctionKeyProperty

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8774,7 +8774,12 @@ bool importer::isSpecialAppKitFunctionKeyProperty(
   auto rawName = ident->getName();
 
   return rawName.starts_with("NS") &&
-         (rawName.ends_with("FunctionKey") || rawName.ends_with("Character"));
+         (rawName.ends_with("FunctionKey") || rawName.ends_with("Character")) &&
+         llvm::any_of(decl->specific_attrs<clang::SwiftNameAttr>(),
+                      [](const auto *attr) {
+                        return attr->getName().starts_with(
+                            "NSEvent.SpecialKey");
+                      });
 }
 
 bool importer::hasSameUnderlyingType(const clang::Type *a,

--- a/test/Interop/Cxx/objc-correctness/appkit-uikit.swift
+++ b/test/Interop/Cxx/objc-correctness/appkit-uikit.swift
@@ -15,6 +15,10 @@ var _ = NSEvent.SpecialKey.enter.rawValue
 var _ = NSUpArrowFunctionKey
 var _ = NSEnterCharacter
 
+#if swift(>=4.2)
+var _ = NSTextAttachment.character
+#endif
+
 #elseif canImport(UIKit)
 import UIKit
 


### PR DESCRIPTION
- **Explanation**:
Previously, any declaration whose raw name started with `NS` and ended with `FunctionKey` or `Character` was considered a special AppKit function key property. This change requires the declaration to have a `__attribute__((swift_name(...)))` that starts with `NSEvent.SpecialKey.`. This prevents matching decls that are not special keys, like `NSAttachmentCharacter`.

- **Scope**:
This only affects Swift/C++ interop consumers of AppKit headers. Specifically, any code accessing `NSTextAttachment.character` (or similarly named `NS*Character`/`NS*FunctionKey` non-special-key constants) that broke after the original (too-broad) heuristic was introduced. The fix restores their availability.

- **Issues**:
rdar://171083643

- **Original PRs**:
https://github.com/swiftlang/swift/pull/88291

- **Risk**:
Low, it only fixes a regression.

- **Testing**:
  - Local Swift testing passed, no regression.
  - Swift CI smoke tests passed on main (see the original PR).
  - Dump the public SDK using `utils/swift-api-dump.py` before and after the change, there is only one difference on macOS, which is expected:
    ```
    diff --color -r macOS-before/AppKit/NSTextAttachment.swift macOS-after/AppKit/NSTextAttachment.swift
    1,2c1,4
    < @available(macOS 10.0, *)
    < var NSAttachmentCharacter: Int { get }
    ---
    > extension NSTextAttachment {
    >   @available(macOS 10.0, *)
    >   class var character: Int { get }
    > }
    ```

- **Reviewers**:
@egorzhdan @hnrklssn @DougGregor
