### PR TITLE
[PrintAsClang] initialize variable to silence warning

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -1838,7 +1838,7 @@ public:
       }
 
       auto platKind = AvAttr.getPlatform();
-      const char *plat;
+      const char *plat = nullptr;
       switch (platKind) {
       case PlatformKind::macOS:
         plat = "macos";


### PR DESCRIPTION
Remove the following compiler warning

```
[246/579][ 42%][80.290s] Building CXX object lib/PrintAsClang/CMakeFiles/swiftPrintAsClang.dir/DeclAndTypePrinter.cpp.o
/swift-project/swift/lib/PrintAsClang/DeclAndTypePrinter.cpp:1827:12: warning: variable 'plat' is used uninitialized whenever switch case is taken [-Wsometimes-uninitialized]
 1827 |       case PlatformKind::Swift:
      |            ^~~~~~~~~~~~~~~~~~~
/swift-project/swift/lib/PrintAsClang/DeclAndTypePrinter.cpp:1849:38: note: uninitialized use occurs here
 1849 |       os << "SWIFT_AVAILABILITY(" << plat;
      |                                      ^~~~
/swift-project/swift/lib/PrintAsClang/DeclAndTypePrinter.cpp:1828:12: warning: variable 'plat' is used uninitialized whenever switch case is taken [-Wsometimes-uninitialized]
 1828 |       case PlatformKind::anyAppleOS:
      |            ^~~~~~~~~~~~~~~~~~~~~~~~
/swift-project/swift/lib/PrintAsClang/DeclAndTypePrinter.cpp:1849:38: note: uninitialized use occurs here
 1849 |       os << "SWIFT_AVAILABILITY(" << plat;
      |                                      ^~~~
/swift-project/swift/lib/PrintAsClang/DeclAndTypePrinter.cpp:1786:23: note: initialize the variable 'plat' to silence this warning
 1786 |       const char *plat;
      |                       ^
      |                        = nullptr
2 warnings generated.
```