### PR TITLE
[ClangImporter] Fix missing members of Obj-C types implementing Swift protocols.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8502,6 +8502,50 @@ void SwiftDeclConverter::importMirroredProtocolMembers(
       if (classImplementsProtocol(superInterface, clangProto, true))
         continue;
 
+    auto importClangMethod = [&](const clang::ObjCMethodDecl *objcMethod,
+                                 bool hasAsync) {
+      // For now, just remember that we saw this method.
+      methodsByName[objcMethod->getSelector()].emplace_back(objcMethod, proto,
+                                                            hasAsync);
+    };
+
+    auto importClangProperty = [&](const clang::ObjCPropertyDecl *objcProp) {
+      // We can't import a property if there's already a method with this
+      // name. (This also covers other properties with that same name.)
+      // FIXME: We should still mirror the setter as a method if it's
+      // not already there.
+      clang::Selector sel = objcProp->getGetterName();
+      if (interfaceDecl->getInstanceMethod(sel))
+        return;
+
+      bool inNearbyCategory =
+          std::any_of(interfaceDecl->known_categories_begin(),
+                      interfaceDecl->known_categories_end(),
+                      [=](const clang::ObjCCategoryDecl *category) -> bool {
+                        if (!Impl.getClangSema().isVisible(category)) {
+                          return false;
+                        }
+                        if (category != decl) {
+                          auto *categoryModule =
+                              Impl.getClangModuleForDecl(category);
+                          if (categoryModule != declModule &&
+                              categoryModule != interfaceModule) {
+                            return false;
+                          }
+                        }
+                        return category->getInstanceMethod(sel);
+                      });
+      if (inNearbyCategory)
+        return;
+
+      if (auto imported =
+              Impl.importMirroredDecl(objcProp, dc, getVersion(), proto)) {
+        members.push_back(imported);
+        // FIXME: We should mirror properties of the root class onto the
+        // metatype.
+      }
+    };
+
     auto importProtocolRequirement = [&](Decl *member) {
       // Skip compatibility stubs; there's no reason to mirror them.
       if (member->isUnavailableInCurrentSwiftVersion())
@@ -8513,49 +8557,12 @@ void SwiftDeclConverter::importMirroredProtocolMembers(
         if (!objcProp)
           return;
 
-        // We can't import a property if there's already a method with this
-        // name. (This also covers other properties with that same name.)
-        // FIXME: We should still mirror the setter as a method if it's
-        // not already there.
-        clang::Selector sel = objcProp->getGetterName();
-        if (interfaceDecl->getInstanceMethod(sel))
-          return;
-
-        bool inNearbyCategory =
-            std::any_of(interfaceDecl->known_categories_begin(),
-                        interfaceDecl->known_categories_end(),
-                        [=](const clang::ObjCCategoryDecl *category) -> bool {
-                          if (!Impl.getClangSema().isVisible(category)) {
-                            return false;
-                          }
-                          if (category != decl) {
-                            auto *categoryModule =
-                                Impl.getClangModuleForDecl(category);
-                            if (categoryModule != declModule &&
-                                categoryModule != interfaceModule) {
-                              return false;
-                            }
-                          }
-                          return category->getInstanceMethod(sel);
-                        });
-        if (inNearbyCategory)
-          return;
-
-        if (auto imported =
-                Impl.importMirroredDecl(objcProp, dc, getVersion(), proto)) {
-          members.push_back(imported);
-          // FIXME: We should mirror properties of the root class onto the
-          // metatype.
-        }
-
+        importClangProperty(objcProp);
         return;
       }
 
       auto afd = dyn_cast<AbstractFunctionDecl>(member);
-      if (!afd)
-        return;
-
-      if (isa<AccessorDecl>(afd))
+      if (!afd || isa<AccessorDecl>(afd))
         return;
 
       auto objcMethod =
@@ -8563,9 +8570,7 @@ void SwiftDeclConverter::importMirroredProtocolMembers(
       if (!objcMethod)
         return;
 
-      // For now, just remember that we saw this method.
-      methodsByName[objcMethod->getSelector()]
-        .emplace_back(objcMethod, proto, afd->hasAsync());
+      importClangMethod(objcMethod, afd->hasAsync());
     };
 
     if (name) {
@@ -8576,6 +8581,29 @@ void SwiftDeclConverter::importMirroredProtocolMembers(
         if (member->getDeclContext() == proto)
           importProtocolRequirement(member);
 
+      if (results.empty() && !name->isSpecial() && !name->empty()) {
+        // In some situations, lookupDirect may not find all members; for
+        // example, if an Objective-C @interface inherits from an @objc protocol
+        // defined in Swift but doesn't explicitly re-declare its members. To
+        // find them, look them up directly on the Clang protocol.
+        for (auto *m : clangProto->decls()) {
+          auto *named = dyn_cast<clang::NamedDecl>(m);
+          if (!named)
+            continue;
+          auto importedName = Impl.importFullName(named, getVersion());
+          if (importedName &&
+              importedName.getDeclName().getBaseName() == *name) {
+            if (auto *method = dyn_cast<clang::ObjCMethodDecl>(m)) {
+              importClangMethod(method, /*hasAsync*/ false);
+              if (importedName.getAsyncAlternateInfo().has_value()) {
+                importClangMethod(method, /*hasAsync*/ true);
+              }
+            } else if (auto *prop = dyn_cast<clang::ObjCPropertyDecl>(m)) {
+              importClangProperty(prop);
+            }
+          }
+        }
+      }
     } else {
       // Otherwise, import all mirrored members.
       for (auto *member : proto->getMembers())

--- a/test/ClangImporter/objc_protocol_swift_defined.swift
+++ b/test/ClangImporter/objc_protocol_swift_defined.swift
@@ -1,0 +1,64 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module -o %t/FooProtocol.swiftmodule -emit-objc-header-path %t/FooProtocol.h -module-name FooProtocol %t/FooProtocol.swift
+// RUN: %target-swift-frontend -typecheck -sdk %sdk -I %t %t/main.swift
+
+//--- FooProtocol.swift
+import Foundation
+
+@objc public protocol FooProtocol {
+  func instanceMethod() -> Bool
+  static func classMethod() -> Bool
+
+  func thisInstanceMethod(_ number: Int, hasArgs: String)
+  static func thisClassMethod(_ number: Int, hasArgs: String)
+
+  func someThrowingNoArgMethod() throws -> String
+  func someThrowingMethod(withAnArg: Int) throws -> String
+  func someAsyncNoArgMethod() async -> String
+  func someAsyncMethod(withAnArg: Int) async -> String
+  func someThrowingAsyncNoArgMethod() async throws -> String
+  func someThrowingAsyncMethod(withAnArg: Int) async throws -> String
+
+  var instanceProperty: Int { get set }
+  static var staticProperty: Int { get set }
+}
+
+//--- FooImpl.h
+#import <Foundation/Foundation.h>
+#import "FooProtocol.h"
+
+@interface FooImpl : NSObject <FooProtocol>
+@end
+
+//--- module.modulemap
+module FooImpl {
+  header "FooImpl.h"
+  export *
+}
+
+//--- main.swift
+import FooProtocol
+import FooImpl
+
+func testMirroring(obj: FooImpl) async throws {
+  _ = obj.instanceMethod()
+  _ = FooImpl.classMethod()
+
+  obj.thisInstanceMethod(1, hasArgs: "hello")
+  FooImpl.thisClassMethod(1, hasArgs: "hello")
+
+  _ = obj.instanceProperty
+  obj.instanceProperty = 10
+
+  _ = FooImpl.staticProperty
+  FooImpl.staticProperty = 10
+
+  _ = try obj.someThrowingNoArgMethod()
+  _ = try obj.someThrowingMethod(withAnArg: 1)
+  _ = await obj.someAsyncNoArgMethod()
+  _ = await obj.someAsyncMethod(withAnArg: 1)
+  _ = try await obj.someThrowingAsyncNoArgMethod()
+  _ = try await obj.someThrowingAsyncMethod(withAnArg: 1)
+}


### PR DESCRIPTION
If an `@objc protocol` defined in Swift is exported in a Swift generated Obj-C header, then another `@interface` declared in Objective-C imports that header and conforms to the protocol but doesn't explicitly re-declare the protocol's requirements (which is valid in Objective-C), those requirements are not currently available when that Objective-C class is imported back into Swift. This change fixes this bug.

Fixes #83614.
