### PR TITLE
[Concurrency] Prevent isolated conf escaping to Sendable existential

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8986,6 +8986,11 @@ GROUPED_ERROR(isolated_conformance_with_sendable_simple,IsolatedConformances,
       "%2 conformance of %0 to %1 cannot satisfy "
       "conformance requirement for a 'Sendable' type parameter ",
       (Type, DeclName, ActorIsolation))
+GROUPED_ERROR(isolated_conformance_in_sendable_existential,IsolatedConformances,
+      none,
+      "%2 conformance of %0 to %1 cannot be used to satisfy a "
+      "'Sendable' existential type",
+      (Type, DeclName, ActorIsolation))
 GROUPED_ERROR(isolated_conformance_wrong_domain,IsolatedConformances,none,
       "%0 conformance of %1 to %2 cannot be used in %3 context",
       (ActorIsolation, Type, DeclName, ActorIsolation))

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -500,6 +500,9 @@ enum class FixKind : uint8_t {
 
   /// Ignore that a conformance is isolated but is not allowed to be.
   IgnoreIsolatedConformance,
+
+  /// Ignore that an isolated conformance is used in a Sendable existential.
+  IgnoreIsolatedConformanceInSendableExistential,
 };
 
 class ConstraintFix {
@@ -3988,6 +3991,38 @@ public:
 
   static bool classof(const ConstraintFix *fix) {
     return fix->getKind() == FixKind::IgnoreIsolatedConformance;
+  }
+};
+
+class IgnoreIsolatedConformanceInSendableExistential : public ConstraintFix {
+  ProtocolConformance *conformance;
+
+  IgnoreIsolatedConformanceInSendableExistential(
+      ConstraintSystem &cs, ConstraintLocator *locator,
+      ProtocolConformance *conformance)
+      : ConstraintFix(cs,
+                      FixKind::IgnoreIsolatedConformanceInSendableExistential,
+                      locator),
+        conformance(conformance) {}
+
+public:
+  std::string getName() const override {
+    return "ignore isolated conformance in Sendable existential";
+  }
+
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
+
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
+    return diagnose(*commonFixes.front().first);
+  }
+
+  static IgnoreIsolatedConformanceInSendableExistential *
+  create(ConstraintSystem &cs, ConstraintLocator *locator,
+         ProtocolConformance *conformance);
+
+  static bool classof(const ConstraintFix *fix) {
+    return fix->getKind() ==
+           FixKind::IgnoreIsolatedConformanceInSendableExistential;
   }
 };
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -9798,3 +9798,11 @@ bool DisallowedIsolatedConformance::diagnoseAsError() {
 
   return true;
 }
+
+bool DisallowedIsolatedConformanceInSendableExistential::diagnoseAsError() {
+  emitDiagnostic(diag::isolated_conformance_in_sendable_existential,
+                 conformance->getType(),
+                 conformance->getProtocol()->getName(),
+                 conformance->getIsolation());
+  return true;
+}

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -3409,6 +3409,21 @@ public:
   bool diagnoseAsError() override;
 };
 
+/// Diagnose when an isolated conformance is stored into a Sendable existential
+/// type, e.g., `any P & Sendable`.
+class DisallowedIsolatedConformanceInSendableExistential final
+    : public FailureDiagnostic {
+  ProtocolConformance *conformance;
+
+public:
+  DisallowedIsolatedConformanceInSendableExistential(
+      const Solution &solution, ProtocolConformance *conformance,
+      ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator), conformance(conformance) {}
+
+  bool diagnoseAsError() override;
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2885,3 +2885,18 @@ bool IgnoreIsolatedConformance::diagnose(const Solution &solution,
   DisallowedIsolatedConformance failure(solution, conformance, getLocator());
   return failure.diagnose(asNote);
 }
+
+IgnoreIsolatedConformanceInSendableExistential *
+IgnoreIsolatedConformanceInSendableExistential::create(
+    ConstraintSystem &cs, ConstraintLocator *locator,
+    ProtocolConformance *conformance) {
+  return new (cs.getAllocator())
+      IgnoreIsolatedConformanceInSendableExistential(cs, locator, conformance);
+}
+
+bool IgnoreIsolatedConformanceInSendableExistential::diagnose(
+    const Solution &solution, bool asNote) const {
+  DisallowedIsolatedConformanceInSendableExistential failure(
+      solution, conformance, getLocator());
+  return failure.diagnose(asNote);
+}

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4095,6 +4095,19 @@ ConstraintSystem::matchDeepEqualityTypes(Type type1, Type type2,
   return matchDeepTypeArguments(*this, subflags, args1, args2, locator);
 }
 
+static ProtocolConformanceRef findFirstConcreteIsolatedConformance(
+  ProtocolConformanceRef conformance) {
+  ProtocolConformanceRef isolatedConformance;
+  conformance.forEachIsolatedConformance([&](ProtocolConformanceRef conf) {
+    if (!conf.isConcrete())
+      return false;
+
+    isolatedConformance = conf;
+    return true;
+  });
+  return isolatedConformance;
+}
+
 ConstraintSystem::TypeMatchResult
 ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
                                         ConstraintKind kind,
@@ -4243,10 +4256,45 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
       return result;
   }
 
+  auto &C = getASTContext();
+  auto *sendableProto = C.getProtocol(KnownProtocolKind::Sendable);
+  bool existentialIsSendable = sendableProto && llvm::any_of(
+      layout.getProtocols(), [sendableProto](ProtocolDecl *proto) {
+        return proto == sendableProto || proto->inheritsFrom(sendableProto);
+      });
+
   for (auto *protoDecl : layout.getProtocols()) {
     switch (simplifyConformsToConstraint(type1, protoDecl, kind, locator,
                                          subflags)) {
-      case SolutionKind::Solved:
+      case SolutionKind::Solved: {
+        // Check if an isolated conformance is escaping into a Sendable existential.
+        // This would allow it to be used from another isolation context, so we need to prevent that.
+        if (existentialIsSendable) {
+          // Existential (any P) to e.g. any (P & Sendable) is already checked structurally
+          if (type1->isExistentialType())
+            break;
+
+          // Marker protocols can't have isolated conformances
+          if (protoDecl->isMarkerProtocol())
+            break;
+
+          if (auto conformance = lookupConformance(type1, protoDecl)) {
+            if (ProtocolConformanceRef isolatedConformance =
+                findFirstConcreteIsolatedConformance(conformance)) {
+              if (!shouldAttemptFixes())
+                return getTypeMatchFailure(locator);
+
+              auto fix =
+                  IgnoreIsolatedConformanceInSendableExistential::create(
+                      *this, getConstraintLocator(locator),
+                      isolatedConformance.getConcrete());
+              if (recordFix(fix))
+                return getTypeMatchFailure(locator);
+            }
+          }
+        }
+        break;
+      }
       case SolutionKind::Unsolved:
         break;
 
@@ -15843,6 +15891,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::TooManyDynamicMemberLookups:
   case FixKind::IgnoreNonMetatypeDynamicType:
   case FixKind::IgnoreIsolatedConformance:
+  case FixKind::IgnoreIsolatedConformanceInSendableExistential:
     llvm_unreachable("handled elsewhere");
   }
 

--- a/test/Concurrency/isolated_conformance_sendable_existential.swift
+++ b/test/Concurrency/isolated_conformance_sendable_existential.swift
@@ -1,0 +1,106 @@
+// RUN: %target-swift-frontend -swift-version 6 -emit-sil -verify %s -enable-upcoming-feature IsolatedConformances
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+@globalActor
+actor AnotherActor: GlobalActor {
+  static let shared = AnotherActor()
+}
+
+protocol P {
+  nonisolated(nonsending) func foo(_ ns: NS) async
+}
+
+protocol Q {
+  func bar()
+}
+
+protocol SendableThing: Sendable {
+  func baz()
+}
+
+class NS {
+  var k: Int = 0
+}
+
+@MainActor
+class C: @MainActor P {
+  @MainActor
+  func foo(_ ns: NS) async {
+  }
+}
+
+@MainActor
+class CQ: @MainActor P, @MainActor Q {
+  @MainActor
+  func foo(_ ns: NS) async {
+  }
+  @MainActor
+  func bar() {
+  }
+}
+
+@MainActor
+class CSendable: @MainActor P, Sendable {
+  @MainActor
+  func foo(_ ns: NS) async {
+  }
+}
+
+@MainActor
+final class CSendableThing: @MainActor P, SendableThing { // expected-error{{conformance of 'CSendableThing' to protocol 'SendableThing' crosses into main actor-isolated code and can cause data races}}
+  // expected-note@-1{{isolate this conformance to the main actor with '@MainActor'}}
+  // expected-note@-2{{turn data races into runtime errors with '@preconcurrency'}}
+  @MainActor
+  func foo(_ ns: NS) async {
+  }
+  func baz() { // expected-note{{main actor-isolated instance method 'baz()' cannot satisfy nonisolated requirement}}
+  // expected-note@-1{{mark instance method 'baz()' 'nonisolated'}}
+  }
+}
+
+@AnotherActor
+func test<T: P & Sendable>(_ x: T) async { // expected-note{{'test' declared here}}
+  await x.foo(NS())
+}
+
+// ==== Isolated conformance escapes via Sendable existential
+
+@MainActor
+func callIt() async {
+  await test(C()) // expected-error{{main actor-isolated conformance of 'C' to 'P' cannot satisfy conformance requirement for a 'Sendable' type parameter}}
+
+  let s: any P & Sendable = C() // expected-error{{main actor-isolated conformance of 'C' to 'P' cannot be used to satisfy a 'Sendable' existential type}}
+  await test(s)
+}
+
+// === Multiple protocols: any P & Q & Sendable
+
+@MainActor
+func callMultiProto() async {
+  let s: any P & Q & Sendable = CQ() // expected-error{{main actor-isolated conformance of 'CQ' to 'P' cannot be used to satisfy a 'Sendable' existential type}}
+  _ = s
+}
+
+@MainActor
+func callMultiProto(pq: any (P & Q)) async {
+  let s: any P & Q & Sendable = pq // expected-error{{type 'any P & Q' does not conform to the 'Sendable' protocol}}
+  _ = s
+}
+
+// === Class that is itself Sendable with isolated conformance
+
+@MainActor
+func callSendableClass() async {
+  let s: any P & Sendable = CSendable() // expected-error{{main actor-isolated conformance of 'CSendable' to 'P' cannot be used to satisfy a 'Sendable' existential type}}
+  _ = s
+}
+
+// ==== Inherited Sendable in LHS protocol
+
+@MainActor
+func callSendableThing() async {
+  let s: any P & SendableThing = CSendableThing() // expected-error{{main actor-isolated conformance of 'CSendableThing' to 'P' cannot be used to satisfy a 'Sendable' existential type}}
+  _ = s
+}

--- a/test/Concurrency/isolated_conformance_sendable_existential.swift
+++ b/test/Concurrency/isolated_conformance_sendable_existential.swift
@@ -2,6 +2,7 @@
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
+// REQUIRES: swift_feature_IsolatedConformances
 
 @globalActor
 actor AnotherActor: GlobalActor {


### PR DESCRIPTION
This closes a hole in isolated conformance safety where we'd allow a isolated conformance to to escape into a Sedable type by doing:

```
// oh no!
let s: any P & Sendable = C() // C: @MainActor P
```
Meanwhile the same would already be properly rejected if this were to happen while passing as method parameter.

We handle this in the constraint system when matching existential types, by detecting a sendable type is involved LHS and if an isolated conformance is found, we must prevent this match.

resolves rdar://169275327
resolves #86895

Please have a look @xedin, I tried to replicate how we do this in similar cases in the solver but not very familiar with the "fix" patterns here, hope I got it right.
