### PR TITLE
[Concurrency] Use correct type in task-local add builtins

### DIFF
--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -1591,8 +1591,8 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &Builtin,
   case BuiltinValueKind::TaskLocalValuePush: {
     auto *key = args.claimNext();
     auto *value = args.claimNext();
-    // Grab T from the builtin.
-    auto *valueMetatype = IGF.emitTypeMetadataRef(argTypes[1].getASTType());
+    auto valueTy = substitutions.getReplacementTypes()[0]->getCanonicalType();
+    auto *valueMetatype = IGF.emitTypeMetadataRef(valueTy);
     emitBuiltinTaskLocalValuePush(IGF, key, value, valueMetatype);
 
     // The output value is not used for anything, so we don't actually set

--- a/test/Concurrency/Runtime/async_task_locals_function_value_release.swift
+++ b/test/Concurrency/Runtime/async_task_locals_function_value_release.swift
@@ -1,0 +1,24 @@
+// RUN: %target-run-simple-swift(-parse-as-library) | %FileCheck %s
+// RUN: %target-run-simple-swift(-parse-as-library -O) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+
+// REQUIRES: concurrency_runtime
+// UNSUPPORTED: back_deployment_runtime
+
+// In optimized builds specifically the task local add builtins (AddTaskLocalValue/TaskLocalValuePush)
+// would end use a the AST type directly, which would then be reabstraction thunk with ~Copyable and
+// other not representable at runtime types.
+
+@TaskLocal var taskLocal: (() -> Void)?
+
+@main
+struct Main {
+  static func main() {
+    $taskLocal.withValue({}) {
+      print("inside withValue") // CHECK: inside withValue
+    }
+    print("done") // CHECK: done
+  }
+}

--- a/test/Concurrency/Runtime/async_task_locals_function_value_release.swift
+++ b/test/Concurrency/Runtime/async_task_locals_function_value_release.swift
@@ -8,8 +8,9 @@
 // UNSUPPORTED: back_deployment_runtime
 
 // In optimized builds specifically the task local add builtins (AddTaskLocalValue/TaskLocalValuePush)
-// would end use a the AST type directly, which would then be reabstraction thunk with ~Copyable and
-// other not representable at runtime types.
+// would end up using the wrong type in this example, and attempt to demangle
+// at runtime a type including ~Copyable -- which cannot be represented at runtime
+// and therefore crash while trying to do so. 
 
 @TaskLocal var taskLocal: (() -> Void)?
 

--- a/test/IRGen/task_local_function_value_metadata.swift
+++ b/test/IRGen/task_local_function_value_metadata.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -O -swift-version 5 -plugin-path %swift-plugin-dir -module-name main | %FileCheck %s
+
+// REQUIRES: concurrency
+
+@TaskLocal var taskLocal: (() -> Void)?
+
+// Verify that taskLocalValuePush uses the formal AST type metadata (Optional<() -> ()>, mangled as "yycSg"):
+// CHECK-LABEL: define hidden swiftcc void @"$s4main4testyyF"()
+// CHECK: %{{[0-9]+}} = tail call ptr @__swift_instantiateConcreteTypeFromMangledName(ptr nonnull @"$syycSgMD")
+// CHECK: %{{[0-9]+}} = call swiftcc {} @swift_task_localValuePush(ptr %{{[0-9]+}}, ptr nonnull %{{[0-9]+}}, ptr %{{[0-9]+}})
+func test() {
+  $taskLocal.withValue({}) {
+    print("inside withValue")
+  }
+}


### PR DESCRIPTION
Specifically in optimized builds, the way the metadata is obtained for the T for the task locals builtin ended up being:

```
%6 = tail call ptr @__swift_instantiateConcreteTypeFromMangledName(ptr nonnull @"$sxRi_zRi0_zlyytIsegr_SgMD") #10
```

which the runtime demangler cannot handle, because it contains things like ~Copyable etc. (`demangling cache variable for type metadata for (@escaping @callee_guaranteed @substituted <A where A: ~Swift.Copyable, A: ~Swift.Escapable> () -> (@out A) for <()>)?`)

This can happen in code when a simple closure is used as a task local value like this:

```
@TaskLocal var taskLocal: (() -> Void)?
$taskLocal.withValue({}) {}
```

which would always crash at runtime.

The problem is that we're using the wrong type in the builtin, all builtins seem to be using the canonical AST type, which won't have these un-handleable problems.

The fix is therefore to just use the right type in the task-local add builtin.

**Risk**: Low, just fixes behavior of builtin in release mode

**Testing:** CI testing, added IR and runtime test; No other code which otherwise "happened to work" luckily already is impacted.

resolves rdar://167091108
