### PR TITLE
Fix infinite recursion in the presence of phi cycles in PartialApplyInst::visitOnStackLifetimeEnds

### DIFF
--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -2022,15 +2022,14 @@ PartialApplyInst::visitOnStackLifetimeEnds(
   SSAPrunedLiveness liveness(function, &discoveredBlocks);
   liveness.initializeDef(this);
 
-  StackList<SILValue> values(function);
-  values.push_back(this);
+  ValueWorklist values(function);
+  values.push(this);
 
-  while (!values.empty()) {
-    auto value = values.pop_back_val();
+  while (auto value = values.pop()) {
     for (auto *use : value->getUses()) {
       if (!use->isConsuming()) {
         if (auto *cvi = dyn_cast<CopyValueInst>(use->getUser())) {
-          values.push_back(cvi);
+          values.pushIfNotVisited(cvi);
         }
         continue;
       }
@@ -2068,7 +2067,7 @@ PartialApplyInst::visitOnStackLifetimeEnds(
                                  "forwarded to a destroy_value");
       }
       forward.visitForwardedValues([&values](auto value) {
-        values.push_back(value);
+        values.pushIfNotVisited(value);
         return true;
       });
     }

--- a/test/SIL/Instruction/partial_apply_on_stack_lifetime_ends.sil
+++ b/test/SIL/Instruction/partial_apply_on_stack_lifetime_ends.sil
@@ -4,6 +4,8 @@
 // RUN:     -o /dev/null \
 // RUN: 2>&1 | %FileCheck %s
 
+import Builtin
+
 sil_stage canonical
 
 class C {}
@@ -37,4 +39,32 @@ entry(%c: @owned $C):
   destroy_value %c
   %retval = tuple ()
   return %retval
+}
+
+sil @useClosure : $@convention(thin) (@noescape @callee_guaranteed () -> ()) -> Builtin.Int1
+
+// Ensure SIL verification does not hang.
+// CHECK-LABEL: begin running test {{.*}} on phi_cycle_partial_apply
+// CHECK-LABEL: end running test {{.*}} on phi_cycle_partial_apply
+sil [ossa] @phi_cycle_partial_apply : $@convention(thin) (@owned C) -> () {
+entry(%c : @owned $C):
+  specify_test "partial_apply_print_on_stack_lifetime_ends %pa"
+
+  %callee = function_ref @borrowC : $@convention(thin) (@guaranteed C) -> ()
+  %pa = partial_apply [callee_guaranteed] [on_stack] %callee(%c) : $@convention(thin) (@guaranteed C) -> ()
+  %use_fn = function_ref @useClosure : $@convention(thin) (@noescape @callee_guaranteed () -> ()) -> Builtin.Int1
+  br loop(%pa : $@noescape @callee_guaranteed () -> ())
+
+loop(%phi : @owned $@noescape @callee_guaranteed () -> ()):
+  %cond = apply %use_fn(%phi) : $@convention(thin) (@noescape @callee_guaranteed () -> ()) -> Builtin.Int1
+  cond_br %cond, loop_back, exit
+
+loop_back:
+  br loop(%phi : $@noescape @callee_guaranteed () -> ())
+
+exit:
+  destroy_value %phi : $@noescape @callee_guaranteed () -> ()
+  destroy_value %c : $C
+  %retval = tuple ()
+  return %retval : $()
 }


### PR DESCRIPTION
Use a visited set to avoid infinite recursion when there are phi cycles in the SSA.
    
Fixes rdar://173953876