### PR TITLE
Replace an O(n) search for a destructor with a lookup

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2846,9 +2846,8 @@ ExportedLevel VarDecl::isLayoutExposedToClients() const {
 
     // In embedded, we need to ensure the class has a deinit marked
     // '@export(interface)'.
-    for (auto member : parent->getMembers()) {
-      if (isa<DestructorDecl>(member) &&
-          member->isNeverEmittedIntoClient()) {
+    if (auto dtor = cast<ClassDecl>(parent)->getDestructor()) {
+      if (dtor->isNeverEmittedIntoClient()) {
         return ExportedLevel::None;
       }
     }


### PR DESCRIPTION
- **Explanation**: Replaces an unnecessary O(n) loop through class members to find the `deinit` with a direct query.
- **Scope**: Limited to the "is layout exposed to clients" check in Embedded Swift.
- **Risk**: Very low.
- **Testing**: CI
