### PR TITLE
Runtimes: correct WASI overlay image

### DIFF
--- a/Runtimes/Overlay/WASI/clang/CMakeLists.txt
+++ b/Runtimes/Overlay/WASI/clang/CMakeLists.txt
@@ -27,6 +27,8 @@ target_compile_options(SwiftWASILibc INTERFACE
 install(TARGETS SwiftWASILibc
   EXPORT SwiftOverlayTargets)
 install(FILES
-  SwiftWASILibc.apinotes
   wasi-libc.modulemap
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/swift/${SwiftOverlay_PLATFORM_SUBDIR}/${SwiftOverlay_ARCH_SUBDIR})
+install(FILES
+  SwiftWASILibc.apinotes
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/swift/apinotes)


### PR DESCRIPTION
Install the API notes to the proper location. This is required to allow the API Notes to be loaded by the frontend.

- **Explanation**: Correct the installation of the WASI modulemap
- **Scope**: Just changes where the file is installed by CMake
- **Issues**:
- **Original PRs**:
- **Risk**: No risk, the runtimes build for WASI is not used yet
- **Testing**: Used to build the WASI SDK on Windows
- **Reviewers**: @etcwilde 