### PR TITLE
SuppAssocTypesWithDefaults: extra tests + migration guide

### DIFF
--- a/include/swift/AST/DiagnosticGroups.def
+++ b/include/swift/AST/DiagnosticGroups.def
@@ -93,6 +93,7 @@ GROUP(UnknownWarningGroup,none,"unknown-warning-group")
 GROUP(UntypedThrows,DefaultIgnoreWarnings,"untyped-throws")
 GROUP(UseAnyAppleOSAvailability,DefaultIgnoreWarnings,"use-any-apple-os-availability")
 GROUP(WeakMutability,none,"weak-mutability")
+GROUP(OldSuppressedAssociatedTypes,none,"old-suppressed-associatedtypes")
 
 GROUP_LINK(PerformanceHints,ExistentialType)
 GROUP_LINK(PerformanceHints,ReturnTypeImplicitCopy)

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8337,8 +8337,8 @@ ERROR(inverse_generic_but_also_conforms, none,
 ERROR(inverse_associatedtype_restriction, none,
       "cannot suppress '%0' requirement of an associated type",
       (StringRef))
-WARNING(legacy_suppressed_assoc_types, none,
-      "experimental feature 'SuppressedAssociatedTypes' is deprecated; see SE-0503 for the official version", ())
+GROUPED_WARNING(legacy_suppressed_assoc_types, OldSuppressedAssociatedTypes, none,
+      "experimental feature 'SuppressedAssociatedTypes' is deprecated; see SE-503 for the official version", ())
 ERROR(inverse_on_class, none,
       "%select{classes|actors}1 cannot be '~%0'",
       (StringRef, bool))

--- a/test/Generics/inverse_assoc_types.swift
+++ b/test/Generics/inverse_assoc_types.swift
@@ -182,3 +182,15 @@ func push<Val>(_ s: Stack<Val>, _ v: Val)
 protocol Stackable<Element>: Pushable {}
 
 extension Stackable where Element: ~Copyable {} // expected-error {{'Self.Element' required to be 'Copyable' but is marked with '~Copyable'}}
+
+protocol Recur<Assoc>: ~Copyable {
+    associatedtype Assoc: Recur, ~Copyable where Assoc.Assoc: ~Copyable
+}
+
+func doCopy<T>(_ t: T) {}
+
+func foo<T: Recur>(_ base: T,
+                   _ lvl1: T.Assoc,
+                   _ lvl2: T.Assoc.Assoc,  // expected-error {{parameter of noncopyable type 'T.Assoc.Assoc' must specify ownership}} // expected-note 3{{add}}
+                   _ lvl3: T.Assoc.Assoc.Assoc // expected-error {{parameter of noncopyable type 'T.Assoc.Assoc.Assoc' must specify ownership}} // expected-note 3{{add}}
+                   ) {}

--- a/test/Generics/inverse_assoc_types.swift
+++ b/test/Generics/inverse_assoc_types.swift
@@ -176,8 +176,13 @@ protocol Pushable<Element> {
 
 struct Stack<Scope: Pushable> {}
 
-func push<Val>(_ s: Stack<Val>, _ v: Val)
-  where Val.Element: ~Copyable {} // expected-error {{'Val.Element' required to be 'Copyable' but is marked with '~Copyable'}}
+func push<Scope>(_ s: Stack<Scope>)
+  where Scope.Element: ~Copyable {} // expected-error {{'Scope.Element' required to be 'Copyable' but is marked with '~Copyable'}}
+
+struct StackOfNC<Scope: Pushable> where Scope.Element: ~Copyable {}
+
+func pushOfNC<Scope, Val>(_ s: StackOfNC<Scope>, _ v: consuming Val)
+  where Val: ~Copyable, Val == Scope.Element {}
 
 protocol Stackable<Element>: Pushable {}
 

--- a/test/Generics/inverse_assoc_types.swift
+++ b/test/Generics/inverse_assoc_types.swift
@@ -199,3 +199,8 @@ func foo<T: Recur>(_ base: T,
                    _ lvl2: T.Assoc.Assoc,  // expected-error {{parameter of noncopyable type 'T.Assoc.Assoc' must specify ownership}} // expected-note 3{{add}}
                    _ lvl3: T.Assoc.Assoc.Assoc // expected-error {{parameter of noncopyable type 'T.Assoc.Assoc.Assoc' must specify ownership}} // expected-note 3{{add}}
                    ) {}
+
+protocol Dog {
+    associatedtype A
+}
+protocol Hotdog: Dog where Self.A: ~Copyable {} // expected-error {{'Self.A' required to be 'Copyable' but is marked with '~Copyable'}}

--- a/test/Generics/inverse_assoc_types_recur.swift
+++ b/test/Generics/inverse_assoc_types_recur.swift
@@ -1,0 +1,35 @@
+// RUN: %target-typecheck-verify-swift  -enable-experimental-feature SuppressedAssociatedTypesWithDefaults
+
+// REQUIRES: swift_feature_SuppressedAssociatedTypesWithDefaults
+
+protocol Recur1<Assoc>: ~Copyable {
+    associatedtype Assoc: Recur1, ~Copyable where Assoc.Assoc: ~Copyable
+                                               // ^~~~~~~~~~~~~~~~~~~~~~
+                                               // The important difference.
+}
+
+struct TestRecur1: Recur1, ~Copyable {
+  typealias Assoc = TestRecur1
+}
+
+struct TestRecur1_Expanded: Recur1, ~Copyable {
+  struct Assoc: Recur1, ~Copyable {
+    struct Assoc: Recur1, ~Copyable {
+      struct Assoc: Recur1, ~Copyable {
+        struct Assoc: Recur1, ~Copyable {
+          typealias Assoc = TestRecur1_Expanded
+        }
+      }
+    }
+  }
+}
+
+protocol Recur2<Assoc>: ~Copyable {
+    associatedtype Assoc: Recur2, ~Copyable
+}
+
+struct TestRecur2: Recur2, ~Copyable {  // expected-error {{'TestRecur2' does not conform to protocol 'Recur2'}}
+                                        // expected-error@-1 {{type 'TestRecur2.Assoc' (aka 'TestRecur2') does not conform to protocol 'Copyable'}}
+
+  typealias Assoc = TestRecur2
+}

--- a/userdocs/diagnostics/diagnostic-groups.md
+++ b/userdocs/diagnostics/diagnostic-groups.md
@@ -42,6 +42,7 @@ Or upgrade all warnings except deprecated declaration to errors:
 - <doc:clang-declaration-import>
 - <doc:isolated-conformances>
 - <doc:error-in-future-swift-version>
+- <doc:old-suppressed-associatedtypes>
 - <doc:module-version-missing>
 - <doc:oslog>
 - <doc:result-builder-methods>
@@ -75,6 +76,7 @@ Or upgrade all warnings except deprecated declaration to errors:
 - <doc:clang-declaration-import>
 - <doc:isolated-conformances>
 - <doc:error-in-future-swift-version>
+- <doc:old-suppressed-associatedtypes>
 - <doc:missing-module-on-known-paths>
 - <doc:module-version-missing>
 - <doc:module-not-testable>

--- a/userdocs/diagnostics/old-suppressed-associatedtypes.md
+++ b/userdocs/diagnostics/old-suppressed-associatedtypes.md
@@ -1,0 +1,100 @@
+# Migrating away from experimental suppressed associated types (OldSuppressedAssociatedTypes)
+
+[SE-503](https://github.com/swiftlang/swift-evolution/blob/main/proposals/503-suppressed-associated-types.md) 
+officially introduced the ability to define protocols with associated types that are `~Copyable` and/or
+`~Escapable` (i.e., "suppressed"), which relaxes the requirement on types conforming to that protocol.
+During the evolution process, a prototype version of this feature existed under the experimental feature
+named `SuppressedAssociatedTypes`. **That experimental feature is now deprecated** and is source-incompatible with the accepted
+version detailed in SE-503. 
+
+This document provides high-level guidance for users of this experimental feature to help them
+update their code to be compatible with [SE-503](https://github.com/swiftlang/swift-evolution/blob/main/proposals/503-suppressed-associated-types.md).
+Please see the evolution proposal for complete details of the accepted functionality.
+
+## Source Changes
+
+>The difference between the prototype experimental feature and SE-503 is with its treatment of primary associated types that are suppressed.
+>
+>Thus, if your suppressions were only on associated types that are **not** primary i.e., not mentioned within the angle
+brackets of the protocol in which they're defined, then there are no source changes required.
+
+Primary associated types are those that are mentioned within angle brackets of a protocol:
+
+```swift
+protocol Mailbox<Items> {
+  //            ^~~~~~~ declares that `Items` is a primary associated type
+  
+  associatedtype Items: ~Copyable
+  associatedtype Generator: ~Copyable
+  
+  // ...
+}
+```
+
+Relative to the prototype, [SE-503](https://github.com/swiftlang/swift-evolution/blob/main/proposals/503-suppressed-associated-types.md) 
+infers default requirements for primary associated types in places they were not already. The defaults are expanded
+within extensions of the protocol:
+
+```swift
+extension Mailbox {} // OLD
+extension Mailbox where Items: ~Copyable {} // NEW
+```
+
+The defaults are also expanded in generic contexts where a conformance requirement involving that protocol is written. 
+So, to preserve existing behavior, you'll need add explicit suppressions on the associated types induced by those
+conformance requirements within those contexts:
+
+```swift
+func foo<T>(..) where T: Mailbox {} // OLD
+func foo<T>(..) where T: Mailbox, T.Items: ~Copyable {} // NEW
+
+struct PostOffice<M: Mailbox> {} // OLD
+struct PostOffice<M: Mailbox> where M.Items: ~Copyable {} // NEW
+```
+
+
+## ABI Changes
+
+>This section is only of interest to who distribute pre-built shared libraries and declared a public
+>protocol that has a suppressed primary associated type.
+
+The implementation of SE-503 changes the mangling scheme for generic signatures as a result of the inferred defaults. 
+Suppose you have this protocol:
+
+```swift
+protocol Drink<Flavor> {
+  associatedtype Flavor: ~Copyable
+}
+```
+and these two functions that are completely explicit about whether `T.Flavor` is Copyable or not:
+
+```swift
+func foo<T: Drink>(_ t: T) where T.Flavor: Copyable {}
+func bar<T: Drink>(_ t: T) where T.Flavor: ~Copyable {}
+```
+
+In the prototype version of the feature, `bar`'s requirement `T.Flavor: ~Copyable` was redundant, whereas 
+`foo`'s requirement `T.Flavor: Copyable` was _not_ redundant, so it would be included in the mangled symbol of `foo`:
+
+```
+$s1X3fooyyxAA5DrinkRzs8Copyable6FlavorRpzlF ---> X.foo<A where A: X.Drink, A.Flavor: Swift.Copyable>(A) -> ()
+$s1X3baryyxAA5DrinkRzlF ---> X.bar<A where A: X.Drink>(A) -> ()
+```
+
+With SE-503, this _almost_ flips around. It's now `foo` whose requirement is redundant, and `bar`'s mangled symbol now
+mentions the requirement `T.Flavor: ~Copyable`:
+
+```
+$s1X3fooyyxAA5DrinkRzlF ---> X.foo<A where A: X.Drink>(A) -> ()
+$s1X3baryyxAA5DrinkRz6FlavorRj_zlF ---> X.bar<A where A: X.Drink, A.Flavor: ~Swift.Copyable>(A) -> ()
+```
+
+It's possible to preserve the old symbol for `bar` by using `@abi` to produce its symbol as if `T.Flavor: Copyable`:
+
+```swift
+// $s1X3baryyxAA5DrinkRzlF ---> X.bar<A where A: X.Drink>(A) -> ()
+@abi(func bar<T: Drink>(_ t: T) where T.Flavor: Copyable)
+func bar<T: Drink>(_ t: T) where T.Flavor: ~Copyable {}
+```
+
+But, only [brittle internal compiler features](https://github.com/swiftlang/swift/blob/main/docs/StandardLibraryProgrammersManual.md#_silgen_name) can be used preserve `foo`'s old mangled symbol `$s1X3fooyyxAA5DrinkRzs8Copyable6FlavorRpzlF`.

--- a/userdocs/diagnostics/old-suppressed-associatedtypes.md
+++ b/userdocs/diagnostics/old-suppressed-associatedtypes.md
@@ -1,6 +1,6 @@
 # Migrating away from experimental suppressed associated types (OldSuppressedAssociatedTypes)
 
-[SE-503](https://github.com/swiftlang/swift-evolution/blob/main/proposals/503-suppressed-associated-types.md) 
+[SE-503](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0503-suppressed-associated-types.md) 
 officially introduced the ability to define protocols with associated types that are `~Copyable` and/or
 `~Escapable` (i.e., "suppressed"), which relaxes the requirement on types conforming to that protocol.
 During the evolution process, a prototype version of this feature existed under the experimental feature
@@ -8,7 +8,7 @@ named `SuppressedAssociatedTypes`. **That experimental feature is now deprecated
 version detailed in SE-503. 
 
 This document provides high-level guidance for users of this experimental feature to help them
-update their code to be compatible with [SE-503](https://github.com/swiftlang/swift-evolution/blob/main/proposals/503-suppressed-associated-types.md).
+update their code to be compatible with [SE-503](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0503-suppressed-associated-types.md).
 Please see the evolution proposal for complete details of the accepted functionality.
 
 ## Source Changes
@@ -31,7 +31,7 @@ protocol Mailbox<Items> {
 }
 ```
 
-Relative to the prototype, [SE-503](https://github.com/swiftlang/swift-evolution/blob/main/proposals/503-suppressed-associated-types.md) 
+Relative to the prototype, [SE-503](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0503-suppressed-associated-types.md) 
 infers default requirements for primary associated types in places they were not already. The defaults are expanded
 within extensions of the protocol:
 


### PR DESCRIPTION
Non-functional change aimed at polishing support for SuppressedAssociatedTypesWithDefaults ahead of enabling it by default.

rdar://174185197