### PR TITLE
[cxx-interop] Re-apply support for subscripts of non-copyable types

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6294,9 +6294,9 @@ makeBaseClassMemberAccessors(DeclContext *declContext,
 
   // Use 'address' or 'mutableAddress' accessors for non-copyable
   // types, unless the base accessor returns it by value.
-  bool useAddress = contextTy->isNoncopyable() &&
-                    (baseClassVar->getReadImpl() == ReadImplKind::Stored ||
-                     baseClassVar->getAccessor(AccessorKind::Address));
+  bool useAddress = baseClassVar->getAccessor(AccessorKind::Address) ||
+                    (contextTy->isNoncopyable() &&
+                     baseClassVar->getReadImpl() == ReadImplKind::Stored);
 
   ParameterList *bodyParams = nullptr;
   if (auto subscript = dyn_cast<SubscriptDecl>(baseClassVar)) {
@@ -6444,12 +6444,6 @@ static ValueDecl *cloneBaseMemberDecl(ValueDecl *decl, DeclContext *newContext,
   }
 
   if (auto subscript = dyn_cast<SubscriptDecl>(decl)) {
-    auto contextTy =
-        newContext->mapTypeIntoEnvironment(subscript->getElementInterfaceType());
-    // Subscripts that return non-copyable types are not yet supported.
-    // See: https://github.com/apple/swift/issues/70047.
-    if (contextTy->isNoncopyable())
-      return nullptr;
     auto out = SubscriptDecl::create(
         subscript->getASTContext(), subscript->getName(), subscript->getStaticLoc(),
         subscript->getStaticSpelling(), subscript->getSubscriptLoc(),
@@ -8186,6 +8180,13 @@ bool importer::hasNonEscapableAttr(const clang::RecordDecl *decl) {
 
 bool importer::hasEscapableAttr(const clang::RecordDecl *decl) {
   return hasSwiftAttribute(decl, "Escapable");
+}
+
+CxxValueSemanticsKind
+importer::getCxxValueSemanticsKind(const clang::Type *type,
+                                   ClangImporter::Implementation &Impl) {
+  return evaluateOrDefault(Impl.SwiftContext.evaluator,
+                           CxxValueSemantics({type, &Impl}), {});
 }
 
 /// Recursively checks that there are no pointers in any fields or base classes.

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2184,13 +2184,6 @@ namespace {
           .isReference();
     }
 
-    bool recordIsCopyable(const clang::RecordDecl *decl) {
-      auto semanticsKind = evaluateOrDefault(
-          Impl.SwiftContext.evaluator,
-          CxxValueSemantics({decl->getTypeForDecl(), &Impl}), {});
-      return semanticsKind == CxxValueSemanticsKind::Copyable;
-    }
-
     void markReturnsUnsafeNonescapable(AbstractFunctionDecl *fd) {
       fd->addAttribute(new (Impl.SwiftContext) UnsafeAttr(/*Implicit=*/true));
 
@@ -2489,7 +2482,8 @@ namespace {
             loc, ArrayRef<InheritedEntry>(), nullptr, dc);
       Impl.ImportedDecls[{decl->getCanonicalDecl(), getVersion()}] = result;
 
-      if (!recordIsCopyable(decl)) {
+      if (getCxxValueSemanticsKind(decl->getTypeForDecl(), Impl) !=
+          CxxValueSemanticsKind::Copyable) {
         if (decl->isInStdNamespace() && decl->getName() == "promise") {
           // Do not import std::promise.
           return nullptr;
@@ -3361,9 +3355,8 @@ namespace {
 
       // It is important that we bail on an unimportable record *before* we import
       // any of its members or cache the decl.
-      auto valueSemanticsKind = evaluateOrDefault(
-          Impl.SwiftContext.evaluator,
-          CxxValueSemantics({decl->getTypeForDecl(), &Impl}), {});
+      auto valueSemanticsKind =
+          getCxxValueSemanticsKind(decl->getTypeForDecl(), Impl);
       if (valueSemanticsKind == CxxValueSemanticsKind::Unknown) {
 
         HeaderLoc loc(decl->getLocation());
@@ -3611,9 +3604,8 @@ namespace {
       // when it comes to getter/setter generation.
       if (auto parent = dyn_cast<clang::CXXRecordDecl>(
               decl->getAnonField()->getParent())) {
-        auto semanticsKind = evaluateOrDefault(
-            Impl.SwiftContext.evaluator,
-            CxxValueSemantics({parent->getTypeForDecl(), &Impl}), {});
+        auto semanticsKind =
+            getCxxValueSemanticsKind(parent->getTypeForDecl(), Impl);
         if (semanticsKind == CxxValueSemanticsKind::Unknown)
           return nullptr;
       }

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -34,6 +34,7 @@
 #include "swift/Basic/SourceLoc.h"
 #include "swift/Basic/StringExtras.h"
 #include "swift/ClangImporter/ClangImporter.h"
+#include "swift/ClangImporter/ClangImporterRequests.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Decl.h"
@@ -2209,6 +2210,9 @@ bool hasIteratorAPIAttr(const clang::Decl *decl);
 bool hasNonEscapableAttr(const clang::RecordDecl *decl);
 bool hasNonCopyableAttr(const clang::RecordDecl *decl);
 bool hasEscapableAttr(const clang::RecordDecl *decl);
+CxxValueSemanticsKind
+getCxxValueSemanticsKind(const clang::Type *type,
+                         ClangImporter::Implementation &Impl);
 
 bool isViewType(const clang::CXXRecordDecl *decl);
 

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -1841,8 +1841,14 @@ synthesizeUnwrappingAddressSetterBody(AbstractFunctionDecl *afd,
   ASTContext &ctx = setterDecl->getASTContext();
 
   auto selfArg = createSelfArg(setterDecl);
+  SmallVector<Expr *> arguments;
+  arguments.reserve(setterDecl->getParameters()->size());
+  for (size_t idx = 0, end = setterDecl->getParameters()->size(); idx < end;
+       ++idx)
+    arguments.push_back(createParamRefExpr(setterDecl, idx));
+
   auto *setterImplCallExpr =
-      createAccessorImplCallExpr(setterImpl, selfArg, {});
+      createAccessorImplCallExpr(setterImpl, selfArg, arguments);
 
   auto *returnStmt = ReturnStmt::createImplicit(ctx, setterImplCallExpr);
 
@@ -1861,7 +1867,6 @@ SubscriptDecl *SwiftDeclSynthesizer::makeSubscript(FuncDecl *getter,
   FuncDecl *getterImpl = getter ? getter : setter;
   FuncDecl *setterImpl = setter;
 
-  // FIXME: support unsafeAddress accessors.
   // Get the return type wrapped in `Unsafe(Mutable)Pointer<T>`.
   const auto rawElementTy = getterImpl->getResultInterfaceType();
   // Unwrap `T`. Use rawElementTy for return by value.
@@ -1899,17 +1904,34 @@ SubscriptDecl *SwiftDeclSynthesizer::makeSubscript(FuncDecl *getter,
   }
   subscript->copyFormalAccessFrom(getterImpl);
 
-  AccessorDecl *getterDecl =
-      AccessorDecl::create(ctx, getterImpl->getLoc(), getterImpl->getLoc(),
-                           AccessorKind::Get, subscript,
-                           /*async*/ false, SourceLoc(),
-                           /*throws*/ false, SourceLoc(),
-                           /*ThrownType=*/TypeLoc(), bodyParams, elementTy, dc);
+  bool elementIsNoncopyable = false;
+  if (auto *nominal = elementTy->getAnyNominal()) {
+    if (auto *clangDecl =
+            dyn_cast_or_null<clang::RecordDecl>(nominal->getClangDecl()))
+      elementIsNoncopyable =
+          getCxxValueSemanticsKind(clangDecl->getTypeForDecl(), ImporterImpl) ==
+          CxxValueSemanticsKind::MoveOnly;
+  }
+
+  bool useAddress =
+      rawElementTy->getAnyPointerElementType() && elementIsNoncopyable;
+
+  AccessorDecl *getterDecl = AccessorDecl::create(
+      ctx, getterImpl->getLoc(), getterImpl->getLoc(),
+      useAddress ? AccessorKind::Address : AccessorKind::Get, subscript,
+      /*async*/ false, SourceLoc(),
+      /*throws*/ false, SourceLoc(),
+      /*ThrownType=*/TypeLoc(), bodyParams,
+      useAddress ? elementTy->wrapInPointer(PTK_UnsafePointer) : elementTy, dc);
   getterDecl->copyFormalAccessFrom(subscript);
-  getterDecl->setImplicit();
+  if (!useAddress)
+    getterDecl->setImplicit();
   getterDecl->setIsDynamic(false);
   getterDecl->setIsTransparent(true);
-  getterDecl->setBodySynthesizer(synthesizeUnwrappingGetterBody, getterImpl);
+  getterDecl->setBodySynthesizer(useAddress
+                                     ? synthesizeUnwrappingAddressGetterBody
+                                     : synthesizeUnwrappingGetterBody,
+                                 getterImpl);
 
   if (getterImpl->isMutating()) {
     getterDecl->setSelfAccessKind(SelfAccessKind::Mutating);
@@ -1925,22 +1947,31 @@ SubscriptDecl *SwiftDeclSynthesizer::makeSubscript(FuncDecl *getter,
     paramVarDecl->setInterfaceType(elementTy);
 
     SmallVector<ParamDecl *> setterParams;
-    setterParams.push_back(paramVarDecl);
+    if (!useAddress)
+      setterParams.push_back(paramVarDecl);
     setterParams.append(bodyParams->begin(), bodyParams->end());
 
     auto setterParamList = ParameterList::create(ctx, setterParams);
 
     setterDecl = AccessorDecl::create(
-        ctx, setterImpl->getLoc(), setterImpl->getLoc(), AccessorKind::Set,
+        ctx, setterImpl->getLoc(), setterImpl->getLoc(),
+        useAddress ? AccessorKind::MutableAddress : AccessorKind::Set,
         subscript,
         /*async*/ false, SourceLoc(),
         /*throws*/ false, SourceLoc(), /*ThrownType=*/TypeLoc(),
-        setterParamList, TupleType::getEmpty(ctx), dc);
+        setterParamList,
+        useAddress ? elementTy->wrapInPointer(PTK_UnsafeMutablePointer)
+                   : TupleType::getEmpty(ctx),
+        dc);
     setterDecl->copyFormalAccessFrom(subscript);
-    setterDecl->setImplicit();
+    if (!useAddress)
+      setterDecl->setImplicit();
     setterDecl->setIsDynamic(false);
     setterDecl->setIsTransparent(true);
-    setterDecl->setBodySynthesizer(synthesizeUnwrappingSetterBody, setterImpl);
+    setterDecl->setBodySynthesizer(useAddress
+                                       ? synthesizeUnwrappingAddressSetterBody
+                                       : synthesizeUnwrappingSetterBody,
+                                   setterImpl);
 
     if (setterImpl->isMutating()) {
       setterDecl->setSelfAccessKind(SelfAccessKind::Mutating);
@@ -2418,13 +2449,10 @@ clang::CXXMethodDecl *SwiftDeclSynthesizer::synthesizeCXXForwardingMethod(
     clang::Expr *argExpr = new (clangCtx) clang::DeclRefExpr(
         clangCtx, param, false, type.getNonReferenceType(),
         clang::ExprValueKind::VK_LValue, clang::SourceLocation());
-    bool isMoveOnly = false;
-    if (!type->isReferenceType())
-      if (evaluateOrDefault(
-              ImporterImpl.SwiftContext.evaluator,
-              CxxValueSemantics({type.getTypePtr(), &ImporterImpl}),
-              {}) == CxxValueSemanticsKind::MoveOnly)
-        isMoveOnly = true;
+    bool isMoveOnly =
+        !type->isReferenceType() &&
+        getCxxValueSemanticsKind(type.getTypePtr(), ImporterImpl) ==
+            CxxValueSemanticsKind::MoveOnly;
     if (type->isRValueReferenceType() || isMoveOnly) {
       argExpr = clangSema
                     .BuildCXXNamedCast(
@@ -3485,9 +3513,8 @@ FuncDecl *SwiftDeclSynthesizer::findExplicitDestroy(
   // If this type isn't imported as noncopyable, we can't respect the request
   // for a destroy operation.
   ASTContext &ctx = ImporterImpl.SwiftContext;
-  auto valueSemanticsKind = evaluateOrDefault(
-      ctx.evaluator, 
-      CxxValueSemantics({clangType->getTypeForDecl(), &ImporterImpl}), {});
+  auto valueSemanticsKind =
+      getCxxValueSemanticsKind(clangType->getTypeForDecl(), ImporterImpl);
 
   if (valueSemanticsKind == CxxValueSemanticsKind::Unknown)
     return nullptr;

--- a/test/Interop/Cxx/class/noncopyable-irgen.swift
+++ b/test/Interop/Cxx/class/noncopyable-irgen.swift
@@ -4,6 +4,7 @@
 // RUN: %target-swift-frontend -cxx-interoperability-mode=default -emit-ir -I %swift_src_root/lib/ClangImporter/SwiftBridging -I %t%{fs-sep}Inputs %t%{fs-sep}test.swift -Xcc -fignore-exceptions -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}noncopyable.h -verify-additional-prefix TEST2- -D TEST2
 // RUN: %target-swift-frontend -cxx-interoperability-mode=default -emit-ir -I %swift_src_root/lib/ClangImporter/SwiftBridging -I %t%{fs-sep}Inputs %t%{fs-sep}test.swift -Xcc -fignore-exceptions -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}noncopyable.h -verify-additional-prefix TEST3- -D TEST3
 // RUN: %target-swift-frontend -cxx-interoperability-mode=default -emit-ir -I %swift_src_root/lib/ClangImporter/SwiftBridging -I %t%{fs-sep}Inputs %t%{fs-sep}test.swift -Xcc -fignore-exceptions -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}noncopyable.h -verify-additional-prefix TEST4- -D TEST4 -Xcc -DTEST4 -Xcc -std=c++20
+// RUN: %target-swift-frontend -cxx-interoperability-mode=default -emit-ir -I %swift_src_root/lib/ClangImporter/SwiftBridging -I %t%{fs-sep}Inputs %t%{fs-sep}test.swift -Xcc -fignore-exceptions -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}noncopyable.h -verify-additional-prefix TEST5- -D TEST5
 
 //--- Inputs/module.modulemap
 module Test {
@@ -17,8 +18,15 @@ module Test {
 
 struct NonCopyable {
     NonCopyable() = default;
-    NonCopyable(const NonCopyable& other) = delete; // expected-note {{'NonCopyable' has been explicitly marked deleted here}}
+    NonCopyable(int x) : number(x) {}
+    NonCopyable(const NonCopyable& other) = delete; 
+    // expected-TEST1-note@-1 {{'NonCopyable' has been explicitly marked deleted here}}
+    // expected-TEST2-note@-2 {{'NonCopyable' has been explicitly marked deleted here}}
+    // expected-TEST3-note@-3 {{'NonCopyable' has been explicitly marked deleted here}}
+    // expected-TEST4-note@-4 {{'NonCopyable' has been explicitly marked deleted here}}
     NonCopyable(NonCopyable&& other) = default;
+
+    int number = 0;
 };
 
 template <typename T>
@@ -79,6 +87,11 @@ template <typename T> struct Requires {
 using RequiresOwnsNonCopyable = Requires<OwnsT<NonCopyable>>;
 #endif
 
+struct HasSubscript {
+    NonCopyable &operator[](int idx) { return nc; }
+    NonCopyable nc;
+};
+
 //--- test.swift
 import Test
 import CxxStdlib
@@ -115,4 +128,13 @@ func requires() {
     takeCopyable(s)
 }
 
+#elseif TEST5
+func useSubscript() {
+    var obj = HasSubscript(nc: NonCopyable(5))
+    let _ = obj[42] // expected-TEST5-error {{'obj.subscript' is borrowed and cannot be consumed}}
+    // expected-TEST5-note@-1 {{consumed here}}
+    
+    func borrow(_ x: borrowing NonCopyable) -> Int32 { return x.number; }
+    let _ = borrow(obj[42])
+}
 #endif

--- a/test/Interop/Cxx/class/noncopyable-typechecker.swift
+++ b/test/Interop/Cxx/class/noncopyable-typechecker.swift
@@ -16,8 +16,11 @@ module Test {
 
 struct NonCopyable {
     NonCopyable() = default;
+    NonCopyable(int x) : number(x) {}
     NonCopyable(const NonCopyable& other) = delete; // expected-note {{'NonCopyable' has been explicitly marked deleted here}}
     NonCopyable(NonCopyable&& other) = default;
+
+    int number = 0;
 };
 
 template <typename T>
@@ -202,6 +205,11 @@ struct FieldDependsOnMe { // used to trigger a request cycle
   OneField<NoFields<FieldDependsOnMe, NonCopyable>> field;
 };
 
+struct HasConstSubscript {
+    const NonCopyable &operator[](int idx) { return nc; }
+    NonCopyable nc;
+};
+
 //--- test.swift
 import Test
 import CxxStdlib
@@ -292,4 +300,10 @@ func couldCreateCycleOfCxxValueSemanticsRequests() {
 
   let d3 = FieldDependsOnMe()
   takeCopyable(d3) // expected-error {{global function 'takeCopyable' requires that 'FieldDependsOnMe' conform to 'Copyable'}}
+}
+
+func useConstSubscript() {
+  var obj = HasConstSubscript(nc: NonCopyable(5))
+  _ = obj[42]
+  obj[42] = NonCopyable(7) // expected-error {{cannot assign through subscript: subscript is get-only}}
 }

--- a/test/Interop/Cxx/class/noncopyable.swift
+++ b/test/Interop/Cxx/class/noncopyable.swift
@@ -1,0 +1,74 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-build-swift %t%{fs-sep}test.swift -I %t%{fs-sep}Inputs -o %t%{fs-sep}out -cxx-interoperability-mode=default
+// RUN: %target-codesign %t%{fs-sep}out
+// RUN: %target-run %t%{fs-sep}out
+//
+// REQUIRES: executable_test
+
+//--- Inputs/module.modulemap
+module Test {
+    header "noncopyable.h"
+    requires cplusplus
+}
+
+//--- Inputs/noncopyable.h
+#include <string>
+
+struct NonCopyable {
+    NonCopyable() = default;
+    NonCopyable(int x) : number(x) {}
+    NonCopyable(const NonCopyable& other) = delete; 
+    NonCopyable(NonCopyable&& other) = default;
+
+    int number = 0;
+};
+
+template<typename T>
+struct HasSubscript {
+    T &operator[](int idx) { return element; }
+    T element;
+};
+
+using HasSubscriptInt = HasSubscript<int>;
+using HasSubscriptNonCopyable = HasSubscript<NonCopyable>;
+
+struct InheritsFromHasSubscript : public HasSubscript<NonCopyable> {};
+
+//--- test.swift
+import StdlibUnittest
+import Test
+
+var NonCopyableTestSuite = TestSuite("NonCopyable")
+
+func borrow(_ x: borrowing NonCopyable) -> Int32 { return x.number; }
+
+NonCopyableTestSuite.test("Use subscript") {
+    var o1 = HasSubscriptInt(element: 7)
+    expectEqual(o1[42], 7)
+
+    var o2 = HasSubscriptNonCopyable(element: NonCopyable(5))
+    expectEqual(borrow(o2[42]), 5)
+
+    var inherited = InheritsFromHasSubscript()
+    expectEqual(borrow(inherited[42]), 0)
+}
+
+NonCopyableTestSuite.test("Mutate subscript") {
+    var o1 = HasSubscriptInt(element: 7)
+    expectEqual(o1[42], 7)
+    o1[42] = 8
+    expectEqual(o1[42], 8)
+
+    var o2 = HasSubscriptNonCopyable(element: NonCopyable(5))
+    expectEqual(borrow(o2[42]), 5)
+    o2[42] = NonCopyable(16)
+    expectEqual(borrow(o2[42]), 16)
+
+    var inherited = InheritsFromHasSubscript()
+    expectEqual(borrow(inherited[42]), 0)
+    inherited[42] = NonCopyable(3)
+    expectEqual(borrow(inherited[42]), 3)
+}
+
+runAllTests()

--- a/test/Interop/Cxx/stdlib/use-std-vector.swift
+++ b/test/Interop/Cxx/stdlib/use-std-vector.swift
@@ -211,4 +211,26 @@ StdVectorTestSuite.test("VectorOfImmortalRefPtr").require(.stdlib_5_8).code {
     expectEqual(v[0]?.value, 123)
 }
 
+StdVectorTestSuite.test("Subscript of VectorOfNonCopyable") {
+    var v = makeVectorOfNonCopyable()
+    expectEqual(v.size(), 3)
+    expectFalse(v.empty())
+
+    func getNumber(_ x: borrowing NonCopyable) -> Int32 {
+        return x.number
+    }
+
+    expectEqual(getNumber(v[0]), 1)
+    expectEqual(getNumber(v[1]), 2)
+    expectEqual(getNumber(v[2]), 3)
+
+    v[0] = NonCopyable(3)
+    v[1] = NonCopyable(4)
+
+    expectEqual(getNumber(v[0]), 3)
+    expectEqual(getNumber(v[1]), 4)
+    expectEqual(getNumber(v[2]), 3)
+}
+
+
 runAllTests()


### PR DESCRIPTION
Support for reading from and modifying subscripts of non-copyable types was initially added in https://github.com/swiftlang/swift/pull/86125. However, this triggered some deserialisation issues (rdar://168941879). The original change called `isNoncopyable()` during `makeSubscript()`, which I believe could trigger a conformance lookup before the conformance tables are fully initialised, causing the deserialisation issue.

rdar://174230224
