### PR TITLE
Update swift-subprocess version to 0.4

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -197,7 +197,7 @@
                 "zlib": "v1.3.1",
                 "brotli": "v1.2.0",
                 "mimalloc": "v3.0.3",
-                "swift-subprocess": "0.3",
+                "swift-subprocess": "0.4",
                 "boringssl": "817ab07ebb53da35afea409ab9328f578492832d"
             }
         },
@@ -750,7 +750,7 @@
                 "zlib": "v1.3.1",
                 "brotli": "v1.2.0",
                 "mimalloc": "v3.0.3",
-                "swift-subprocess": "0.3"
+                "swift-subprocess": "0.4"
             }
         },
         "next" : {
@@ -811,7 +811,7 @@
                 "zlib": "v1.3.1",
                 "brotli": "v1.2.0",
                 "mimalloc": "v3.0.3",
-                "swift-subprocess": "0.3"
+                "swift-subprocess": "0.4"
             }
         }
     }


### PR DESCRIPTION
Pull in the latest API changes in preparation for use by the build system and package manager stack.