### PR TITLE
Serialize library level into .swiftmodule binary format

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -778,7 +778,7 @@ protected:
     HasLazyUnderlyingSubstitutions : 1
   );
 
-  SWIFT_INLINE_BITFIELD(ModuleDecl, TypeDecl, 1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+8+1,
+  SWIFT_INLINE_BITFIELD(ModuleDecl, TypeDecl, 1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+8+1+2,
     /// If the module is compiled as static library.
     StaticLibrary : 1,
 
@@ -854,7 +854,10 @@ protected:
 
     /// Whether this module was compile with "aggressive" CMO i.e
     /// the flag: -cross-module-optimization.
-    AggressiveCMOEnabled : 1
+    AggressiveCMOEnabled : 1,
+
+    /// The stored library level from deserialized module data (LibraryLevel).
+    StoredLibraryLevel : 2
   );
 
   SWIFT_INLINE_BITFIELD(PrecedenceGroupDecl, Decl, 1+2,

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -715,6 +715,15 @@ public:
   /// Distribution level of the module.
   LibraryLevel getLibraryLevel() const;
 
+  /// The stored library level from deserialized module data.
+  /// Returns LibraryLevel::Other if no level was stored.
+  LibraryLevel getStoredLibraryLevel() const {
+    return LibraryLevel(Bits.ModuleDecl.StoredLibraryLevel);
+  }
+  void setStoredLibraryLevel(LibraryLevel level) {
+    Bits.ModuleDecl.StoredLibraryLevel = unsigned(level);
+  }
+
   /// Returns true if this module was or is being compiled for testing.
   bool hasIncrementalInfo() const { return Bits.ModuleDecl.HasIncrementalInfo; }
   void setHasIncrementalInfo(bool enabled = true) {

--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -16,6 +16,7 @@
 #include "swift/AST/Identifier.h"
 #include "swift/Basic/CXXStdlibKind.h"
 #include "swift/Basic/LLVM.h"
+#include "swift/Basic/LangOptions.h"
 #include "swift/Basic/SourceLoc.h"
 #include "swift/Basic/Version.h"
 #include "swift/Parse/ParseVersion.h"
@@ -153,6 +154,7 @@ class ExtendedValidationInfo {
     unsigned StrictMemorySafety: 1;
     unsigned DeferredCodeGen: 1;
     unsigned AggressiveCMOEnabled : 1;
+    unsigned LibraryLevel : 2;
   } Bits;
 
 public:
@@ -275,6 +277,13 @@ public:
   }
   void setAggressiveCMOEnabled(bool val = true) {
     Bits.AggressiveCMOEnabled = val;
+  }
+
+  LibraryLevel getLibraryLevel() const {
+    return LibraryLevel(Bits.LibraryLevel);
+  }
+  void setLibraryLevel(LibraryLevel level) {
+    Bits.LibraryLevel = unsigned(level);
   }
 
   bool hasCxxInteroperability() const { return Bits.HasCxxInteroperability; }

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -3331,8 +3331,13 @@ ModuleLibraryLevelRequest::evaluate(Evaluator &evaluator,
     return ctx.LangOpts.LibraryLevel;
 
   } else {
-    // Other Swift modules are SPI if they are from the PrivateFrameworks
-    // folder in the SDK.
+    // IPI is never returned by the path heuristic, so the stored value
+    // is the only way to detect it.
+    auto stored = module->getStoredLibraryLevel();
+    if (stored == LibraryLevel::IPI)
+      return stored;
+
+    // For API/SPI, use the path heuristic as before.
     auto modulePath = module->getModuleFilename();
     return fromPrivateFrameworks(modulePath) ?
       LibraryLevel::SPI : LibraryLevel::API;

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -722,6 +722,9 @@ public:
   /// (the flag -cross-module-optimization).
   bool isAggressiveCMOEnabled() const { return Core->isAggressiveCMOEnabled(); }
 
+  /// The library level of this module.
+  LibraryLevel getLibraryLevel() const { return Core->getLibraryLevel(); }
+
   /// Associates this module file with the AST node representing it.
   ///
   /// Checks that the file is compatible with the AST module it's being loaded

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -237,6 +237,12 @@ static bool readOptionsBlock(llvm::BitstreamCursor &cursor,
     case options_block::AGGRESSIVE_CMO:
       extendedInfo.setAggressiveCMOEnabled(true);
       break;
+    case options_block::LIBRARY_LEVEL: {
+      unsigned rawLevel;
+      options_block::LibraryLevelLayout::readRecord(scratch, rawLevel);
+      extendedInfo.setLibraryLevel(LibraryLevel(rawLevel));
+      break;
+    }
     default:
       // Unknown options record, possibly for use by a future version of the
       // module format.
@@ -1605,6 +1611,7 @@ ModuleFileSharedCore::ModuleFileSharedCore(
       Bits.StrictMemorySafety = extInfo.strictMemorySafety();
       Bits.DeferredCodeGen = extInfo.deferredCodeGen();
       Bits.AggressiveCMOEnabled = extInfo.isAggressiveCMOEnabled();
+      Bits.LibraryLevel = unsigned(extInfo.getLibraryLevel());
       MiscVersion = info.miscVersion;
       SDKVersion = info.sdkVersion;
       ModuleABIName = extInfo.getModuleABIName();

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -425,6 +425,9 @@ private:
     /// Whether this module used deferred code generation.
     unsigned AggressiveCMOEnabled : 1;
 
+    /// Discriminator for library level (LibraryLevel enum).
+    unsigned LibraryLevel : 2;
+
     // Explicitly pad out to the next word boundary if neccessary.
   } Bits = {};
   static_assert(sizeof(ModuleBits) <= 8, "The bit set should be small");
@@ -701,6 +704,10 @@ public:
   bool deferredCodeGen() const { return Bits.DeferredCodeGen; }
 
   bool isAggressiveCMOEnabled() const { return Bits.AggressiveCMOEnabled; }
+
+  LibraryLevel getLibraryLevel() const {
+    return LibraryLevel(Bits.LibraryLevel);
+  }
 
   /// How should \p dependency be loaded for a transitive import via \c this?
   ///

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 990; // vtable conformance entries
+const uint16_t SWIFTMODULE_VERSION_MINOR = 991; // add LIBRARY_LEVEL to options_block
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1004,6 +1004,7 @@ namespace options_block {
     DEFERRED_CODE_GEN,
     OSLOG_STRING_SECTION_NAME,
     AGGRESSIVE_CMO,
+    LIBRARY_LEVEL,
   };
 
   using SDKPathLayout = BCRecordLayout<
@@ -1125,6 +1126,11 @@ namespace options_block {
   using SwiftInterfaceCompilerVersionLayout = BCRecordLayout<
     SWIFT_INTERFACE_COMPILER_VERSION,
     BCBlob // version tuple
+  >;
+
+  using LibraryLevelLayout = BCRecordLayout<
+    LIBRARY_LEVEL,
+    BCFixed<2>
   >;
 }
 

--- a/lib/Serialization/ScanningLoaders.cpp
+++ b/lib/Serialization/ScanningLoaders.cpp
@@ -222,10 +222,23 @@ SwiftModuleScanner::scanInterfaceFile(Identifier moduleID,
         bool isStrictMemorySafety =
             llvm::find(ArgsRefs, "-strict-memory-safety") != ArgsRefs.end();
 
+        LibraryLevel libraryLevel = LibraryLevel::Other;
+        auto libLevelIt = llvm::find(ArgsRefs, "-library-level");
+        if (libLevelIt != ArgsRefs.end() &&
+            (libLevelIt + 1) != ArgsRefs.end()) {
+          libraryLevel = llvm::StringSwitch<LibraryLevel>(*(libLevelIt + 1))
+                             .Case("api", LibraryLevel::API)
+                             .Case("spi", LibraryLevel::SPI)
+                             .Case("ipi", LibraryLevel::IPI)
+                             .Default(LibraryLevel::Other);
+        }
+
         Result = ModuleDependencyInfo::forSwiftInterfaceModule(
             InPath, compiledCandidatesRefs, ArgsRefs, {}, {}, linkLibraries,
             isFramework, isStatic, isStrictMemorySafety, {},
             /*module-cache-key*/ "", UserModVer);
+        if (libraryLevel == LibraryLevel::IPI)
+          Result->setLibraryLevel(libraryLevel);
 
         // Walk the source file to find the import declarations.
         llvm::StringSet<> alreadyAddedModules;
@@ -282,8 +295,8 @@ SwiftModuleScanner::scanInterfaceFile(Identifier moduleID,
   if (code) {
     return code;
   }
-  // Compute library level based on the interface file path.
-  {
+  // Use path heuristic for API/SPI; IPI was already set from the flags above.
+  if (Result->getLibraryLevel() != LibraryLevel::IPI) {
     SmallString<256> modulePathBuf;
     StringRef modulePath = moduleInterfacePath.toStringRef(modulePathBuf);
     Result->setLibraryLevel(libraryLevelFromPath(
@@ -384,11 +397,17 @@ llvm::ErrorOr<ModuleDependencyInfo> SwiftModuleScanner::scanBinaryModuleFile(
                                     deps->ExecutablePath);
   }
 
-  // Compute library level based on the binary module path.
+  // Use the stored value only for IPI; path heuristic handles API/SPI as
+  // before.
   {
-    dependencies.setLibraryLevel(libraryLevelFromPath(
-        definingModulePath, Ctx.SearchPathOpts.getSDKPath(),
-        Ctx.LangOpts.Target));
+    auto storedLevel = loadedModuleFile->getLibraryLevel();
+    if (storedLevel == LibraryLevel::IPI) {
+      dependencies.setLibraryLevel(storedLevel);
+    } else {
+      dependencies.setLibraryLevel(libraryLevelFromPath(
+          definingModulePath, Ctx.SearchPathOpts.getSDKPath(),
+          Ctx.LangOpts.Target));
+    }
   }
 
   return std::move(dependencies);

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -893,6 +893,7 @@ void Serializer::writeBlockInfoBlock() {
   BLOCK_RECORD(options_block, CXX_STDLIB_KIND);
   BLOCK_RECORD(options_block, PUBLIC_MODULE_NAME);
   BLOCK_RECORD(options_block, SWIFT_INTERFACE_COMPILER_VERSION);
+  BLOCK_RECORD(options_block, LIBRARY_LEVEL);
 
   BLOCK(INPUT_BLOCK);
   BLOCK_RECORD(input_block, IMPORTED_MODULE);
@@ -1224,6 +1225,10 @@ void Serializer::writeHeader() {
         CXXStdlibKind.emit(ScratchRecord,
                            static_cast<uint8_t>(M->getCXXStdlibKind()));
       }
+
+      options_block::LibraryLevelLayout LibLevel(Out);
+      LibLevel.emit(ScratchRecord,
+                    unsigned(M->getASTContext().LangOpts.LibraryLevel));
 
       if (M->isAggressiveCMOEnabled()) {
         options_block::AggressiveCMOEnabledLayout AggressiveCMOEnabled(Out);

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -997,6 +997,7 @@ LoadedFile *SerializedModuleLoaderBase::loadAST(
       M.setDeferredCodeGen();
     if (loadedModuleFile->isAggressiveCMOEnabled())
       M.setAggressiveCMOEnabled();
+    M.setStoredLibraryLevel(loadedModuleFile->getLibraryLevel());
     if (loadedModuleFile->hasCxxInteroperability()) {
       M.setHasCxxInteroperability();
       M.setCXXStdlibKind(loadedModuleFile->getCXXStdlibKind());

--- a/test/CAS/embedded-Xcc.swift
+++ b/test/CAS/embedded-Xcc.swift
@@ -20,10 +20,10 @@
 
 // RUN: llvm-bcanalyzer --dump %t/Test.swiftmodule | %FileCheck %s
 
-// CHECK: <XCC abbrevid=6/> blob data = '-cc1'
-// CHECK: <XCC abbrevid=6/> blob data = '-D'
-// CHECK: <XCC abbrevid=6/> blob data = 'TEST=1'
-// CHECK-NOT: <XCC abbrevid=6/> blob data = '--target=
+// CHECK: <XCC abbrevid=7/> blob data = '-cc1'
+// CHECK: <XCC abbrevid=7/> blob data = '-D'
+// CHECK: <XCC abbrevid=7/> blob data = 'TEST=1'
+// CHECK-NOT: <XCC abbrevid=7/> blob data = '--target=
 
 //--- main.swift
 public func test() {}

--- a/test/CAS/macro_plugin_external.swift
+++ b/test/CAS/macro_plugin_external.swift
@@ -74,7 +74,7 @@
 /// Encoded PLUGIN_SEARCH_OPTION is remapped.
 // RUN: llvm-bcanalyzer -dump %t/Macro.swiftmodule | %FileCheck %s --check-prefix=MOD -DLIB=%target-library-name(MacroDefinition)
 
-// MOD: <PLUGIN_SEARCH_OPTION abbrevid=7 op0=4/> blob data = '/^test{{/|\\}}plugins{{/|\\}}[[LIB]]#/^bin{{/|\\}}swift-plugin-server{{(.exe)?}}#MacroDefinition'
+// MOD: <PLUGIN_SEARCH_OPTION abbrevid=8 op0=4/> blob data = '/^test{{/|\\}}plugins{{/|\\}}[[LIB]]#/^bin{{/|\\}}swift-plugin-server{{(.exe)?}}#MacroDefinition'
 
 /// Cache hit has no macro-loading remarks because no macro is actually loaded and the path might not be correct due to different mapping.
 // RUN: %target-swift-frontend-plain \

--- a/test/ScanDependencies/Inputs/Swift/IPILib.swiftinterface
+++ b/test/ScanDependencies/Inputs/Swift/IPILib.swiftinterface
@@ -1,0 +1,3 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name IPILib -library-level ipi
+public func ipiFunc() { }

--- a/test/ScanDependencies/library_level_ipi.swift
+++ b/test/ScanDependencies/library_level_ipi.swift
@@ -1,0 +1,33 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// Scanner reads -library-level ipi from .swiftinterface header flags.
+// RUN: %target-swift-frontend -scan-dependencies %t/IPIClient.swift -o %t/deps.json -I %S/Inputs/Swift
+// RUN: %validate-json %t/deps.json | %FileCheck %s --check-prefix CHECK-INTERFACE
+
+// CHECK-INTERFACE:      "swift": "IPILib"
+// CHECK-INTERFACE:      "libraryLevel": "ipi"
+
+// RUN: %target-swift-frontend -emit-module %t/IPIBinaryLib.swift -module-name IPIBinaryLib \
+// RUN:   -o %t/IPIBinaryLib.swiftmodule -library-level ipi \
+// RUN:   -enable-library-evolution -emit-module-interface-path %t/IPIBinaryLib.swiftinterface
+// Verify -library-level ipi is preserved in emitted .swiftinterface.
+// RUN: %FileCheck %s --check-prefix CHECK-FLAGS < %t/IPIBinaryLib.swiftinterface
+// CHECK-FLAGS: swift-module-flags:{{.*}}-library-level ipi
+
+// Scanner reads library level from serialized .swiftmodule.
+// RUN: rm %t/IPIBinaryLib.swiftinterface
+// RUN: %target-swift-frontend -scan-dependencies %t/IPIBinaryClient.swift -o %t/bin_deps.json -I %t
+// RUN: %validate-json %t/bin_deps.json | %FileCheck %s --check-prefix CHECK-BINARY
+
+// CHECK-BINARY:      "swiftPrebuiltExternal": "IPIBinaryLib"
+// CHECK-BINARY:      "libraryLevel": "ipi"
+
+//--- IPIClient.swift
+import IPILib
+
+//--- IPIBinaryLib.swift
+public func ipiBinaryFunc() {}
+
+//--- IPIBinaryClient.swift
+import IPIBinaryLib

--- a/test/Serialization/plugin_search_option_prefixing.swift
+++ b/test/Serialization/plugin_search_option_prefixing.swift
@@ -17,9 +17,9 @@
 // RUN:   -debug-prefix-map %swift-plugin-dir=/plugindir
 // RUN: llvm-bcanalyzer -dump %t/Test.swiftmodule | %FileCheck %s
 
-// CHECK: <PLUGIN_SEARCH_OPTION abbrevid=8 op0=1/> blob data = '/externalsearchpath#/externalserverpath'
-// CHECK: <PLUGIN_SEARCH_OPTION abbrevid=8 op0=0/> blob data = '/plugindir'
-// CHECK: <PLUGIN_SEARCH_OPTION abbrevid=8 op0=2/> blob data = '/externalsearchpath/{{(lib)?}}MacroOne
+// CHECK: <PLUGIN_SEARCH_OPTION abbrevid=9 op0=1/> blob data = '/externalsearchpath#/externalserverpath'
+// CHECK: <PLUGIN_SEARCH_OPTION abbrevid=9 op0=0/> blob data = '/plugindir'
+// CHECK: <PLUGIN_SEARCH_OPTION abbrevid=9 op0=2/> blob data = '/externalsearchpath/{{(lib)?}}MacroOne
 
 //--- macro-1.swift
 import SwiftSyntax


### PR DESCRIPTION
Add a LIBRARY_LEVEL record to the .swiftmodule options block so the declared -library-level value survives across compilations. Without this, imported modules have to always fell back to a path heuristic that could only distinguish API vs SPI and never returned IPI.

rdar://174255626

<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
