### PR TITLE
Remove -enable-experimental-feature BorrowMutateAccessors from the standard library

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -347,7 +347,6 @@ list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "AllowUnsa
 list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "SuppressedAssociatedTypesWithDefaults")
 list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "Reparenting")
 list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "Lifetimes")
-list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "BorrowAndMutateAccessors")
 list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "BorrowInout")
 list(APPEND swift_stdlib_compile_flags "-strict-memory-safety")
 


### PR DESCRIPTION
Certain older compilers that recognize BorrowMutateAccessors feature, but do not have BorrowMutateAccessors enabled in production run into cond_fail errors when compiling the swiftinterface file of the standard library generated by the newer compiler.

`BorrowAndMutateAccessors` have been enabled by default on main, remove explicitly enabling them in the standard library. This ensures there are no cond_fail errors when compiling the stdlib's swiftinterface with older compilers.

Resolves rdar://174264561

