### PR TITLE
[IncrementalScan][Caching] Validate Swift Binary Module Deps

### DIFF
--- a/include/swift/DependencyScan/ScanDependencies.h
+++ b/include/swift/DependencyScan/ScanDependencies.h
@@ -23,6 +23,7 @@
 namespace llvm {
 class StringSaver;
 namespace cas {
+class ActionCache;
 class ObjectStore;
 } // namespace cas
 namespace vfs {
@@ -81,6 +82,7 @@ namespace incremental {
 void validateInterModuleDependenciesCache(
     const ModuleDependencyID &rootModuleID, ModuleDependenciesCache &cache,
     std::shared_ptr<llvm::cas::ObjectStore> cas,
+    std::shared_ptr<llvm::cas::ActionCache> actionCache,
     const llvm::sys::TimePoint<> &cacheTimeStamp, llvm::vfs::FileSystem &fs,
     DiagnosticEngine &diags, bool emitRemarks = false);
 
@@ -91,6 +93,7 @@ void validateInterModuleDependenciesCache(
 void outOfDateModuleScan(const ModuleDependencyID &sourceModuleID,
                          const ModuleDependenciesCache &cache,
                          std::shared_ptr<llvm::cas::ObjectStore> cas,
+                         std::shared_ptr<llvm::cas::ActionCache> actionCache,
                          const llvm::sys::TimePoint<> &cacheTimeStamp,
                          llvm::vfs::FileSystem &fs, DiagnosticEngine &diags,
                          bool emitRemarks, ModuleDependencyIDSet &visited,
@@ -101,6 +104,7 @@ void outOfDateModuleScan(const ModuleDependencyID &sourceModuleID,
 bool verifyModuleDependencyUpToDate(
     const ModuleDependencyID &moduleID, const ModuleDependenciesCache &cache,
     std::shared_ptr<llvm::cas::ObjectStore> cas,
+    std::shared_ptr<llvm::cas::ActionCache> actionCache,
     const llvm::sys::TimePoint<> &cacheTimeStamp, llvm::vfs::FileSystem &fs,
     DiagnosticEngine &diags, bool emitRemarks);
 } // end namespace incremental

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -1417,8 +1417,9 @@ performModuleScanImpl(
                              ModuleDependencyKind::SwiftSource};
       incremental::validateInterModuleDependenciesCache(
           mainModuleID, cache, instance->getSharedCASInstance(),
-          serializedCacheTimeStamp, *instance->getSourceMgr().getFileSystem(),
-          ctx.Diags, opts.EmitDependencyScannerCacheRemarks);
+          instance->getSharedCacheInstance(), serializedCacheTimeStamp,
+          *instance->getSourceMgr().getFileSystem(), ctx.Diags,
+          opts.EmitDependencyScannerCacheRemarks);
     }
   }
 
@@ -1617,12 +1618,13 @@ llvm::ErrorOr<swiftscan_import_set_t> swift::dependencies::performModulePrescan(
 void swift::dependencies::incremental::validateInterModuleDependenciesCache(
     const ModuleDependencyID &rootModuleID, ModuleDependenciesCache &cache,
     std::shared_ptr<llvm::cas::ObjectStore> cas,
+    std::shared_ptr<llvm::cas::ActionCache> actionCache,
     const llvm::sys::TimePoint<> &cacheTimeStamp, llvm::vfs::FileSystem &fs,
     DiagnosticEngine &diags, bool emitRemarks) {
   ModuleDependencyIDSet visited;
   ModuleDependencyIDSet modulesRequiringRescan;
-  outOfDateModuleScan(rootModuleID, cache, cas, cacheTimeStamp, fs, diags,
-                      emitRemarks, visited, modulesRequiringRescan);
+  outOfDateModuleScan(rootModuleID, cache, cas, actionCache, cacheTimeStamp, fs,
+                      diags, emitRemarks, visited, modulesRequiringRescan);
   for (const auto &outOfDateModID : modulesRequiringRescan)
     cache.removeDependency(outOfDateModID);
   // Regardless of invalidation, always re-scan main module.
@@ -1632,6 +1634,7 @@ void swift::dependencies::incremental::validateInterModuleDependenciesCache(
 void swift::dependencies::incremental::outOfDateModuleScan(
     const ModuleDependencyID &moduleID, const ModuleDependenciesCache &cache,
     std::shared_ptr<llvm::cas::ObjectStore> cas,
+    std::shared_ptr<llvm::cas::ActionCache> actionCache,
     const llvm::sys::TimePoint<> &cacheTimeStamp, llvm::vfs::FileSystem &fs,
     DiagnosticEngine &diags, bool emitRemarks, ModuleDependencyIDSet &visited,
     ModuleDependencyIDSet &modulesRequiringRescan) {
@@ -1640,8 +1643,8 @@ void swift::dependencies::incremental::outOfDateModuleScan(
   for (const auto &depID : cache.getAllDependencies(moduleID)) {
     // If we have not already visited this module, recurse.
     if (visited.find(depID) == visited.end())
-      outOfDateModuleScan(depID, cache, cas, cacheTimeStamp, fs, diags,
-                          emitRemarks, visited, modulesRequiringRescan);
+      outOfDateModuleScan(depID, cache, cas, actionCache, cacheTimeStamp, fs,
+                          diags, emitRemarks, visited, modulesRequiringRescan);
 
     // Even if we're not revisiting a dependency, we must check if it's
     // already known to be out of date.
@@ -1654,8 +1657,9 @@ void swift::dependencies::incremental::outOfDateModuleScan(
       diags.diagnose(SourceLoc(), diag::remark_scanner_invalidate_upstream,
                      moduleID.ModuleName);
     modulesRequiringRescan.insert(moduleID);
-  } else if (!verifyModuleDependencyUpToDate(
-                 moduleID, cache, cas, cacheTimeStamp, fs, diags, emitRemarks))
+  } else if (!verifyModuleDependencyUpToDate(moduleID, cache, cas, actionCache,
+                                             cacheTimeStamp, fs, diags,
+                                             emitRemarks))
     modulesRequiringRescan.insert(moduleID);
 
   visited.insert(moduleID);
@@ -1664,6 +1668,7 @@ void swift::dependencies::incremental::outOfDateModuleScan(
 bool swift::dependencies::incremental::verifyModuleDependencyUpToDate(
     const ModuleDependencyID &moduleID, const ModuleDependenciesCache &cache,
     std::shared_ptr<llvm::cas::ObjectStore> cas,
+    std::shared_ptr<llvm::cas::ActionCache> actionCache,
     const llvm::sys::TimePoint<> &cacheTimeStamp, llvm::vfs::FileSystem &fs,
     DiagnosticEngine &diags, bool emitRemarks) {
   const auto &moduleInfo = cache.findKnownDependency(moduleID);
@@ -1683,27 +1688,45 @@ bool swift::dependencies::incremental::verifyModuleDependencyUpToDate(
     return true;
   };
 
-  auto verifyCASID = [cas, &diags, emitRemarks](StringRef moduleName,
-                                                     const std::string &casID) {
+  auto emitMissingCASInputRemark = [&](StringRef casID) {
+    if (emitRemarks)
+      diags.diagnose(SourceLoc(), diag::remark_scanner_invalidate_missing_cas,
+                     moduleID.ModuleName, casID);
+  };
+
+  auto emitCASErrorRemark = [&](llvm::Error err) {
+    if (emitRemarks)
+      diags.diagnose(SourceLoc(), diag::remark_scanner_invalidate_cas_error,
+                     moduleID.ModuleName, toString(std::move(err)));
+    else
+      consumeError(std::move(err));
+  };
+
+  auto verifyAndGetCASID =
+      [&](const std::string &casID) -> std::optional<llvm::cas::CASID> {
     if (!cas) {
       // If the wrong cache is passed.
       if (emitRemarks)
         diags.diagnose(SourceLoc(),
                        diag::remark_scanner_invalidate_configuration,
-                       moduleName);
-      return false;
+                       moduleID.ModuleName);
+      return std::nullopt;
     }
     auto ID = cas->parseID(casID);
     if (!ID) {
-      if (emitRemarks)
-        diags.diagnose(SourceLoc(), diag::remark_scanner_invalidate_cas_error,
-                       moduleName, toString(ID.takeError()));
-      return false;
+      emitCASErrorRemark(ID.takeError());
+      return std::nullopt;
     }
+    return *ID;
+  };
+
+  auto verifyCASID = [&](const std::string &casID) {
+    auto ID = verifyAndGetCASID(casID);
+    if (!ID)
+      return false;
+
     if (!cas->getReference(*ID)) {
-      if (emitRemarks)
-        diags.diagnose(SourceLoc(), diag::remark_scanner_invalidate_missing_cas,
-                       moduleName, casID);
+      emitMissingCASInputRemark(casID);
       return false;
     }
     return true;
@@ -1711,11 +1734,28 @@ bool swift::dependencies::incremental::verifyModuleDependencyUpToDate(
 
   // Check CAS inputs exist
   if (const auto casID = moduleInfo.getClangIncludeTree())
-    if (!verifyCASID(moduleID.ModuleName, *casID))
+    if (!verifyCASID(*casID))
       return false;
   if (const auto casID = moduleInfo.getCASFSRootID())
-    if (!verifyCASID(moduleID.ModuleName, *casID))
+    if (!verifyCASID(*casID))
       return false;
+
+  // For swift binary module, the cache key and output is setup during scanning
+  // time. Need re-scan if the cache key and the cache result is not in CAS.
+  if (moduleInfo.isSwiftBinaryModule() && !moduleInfo.getModuleCacheKey().empty()) {
+    if (auto casID = verifyAndGetCASID(moduleInfo.getModuleCacheKey())) {
+      auto result = actionCache->get(*casID);
+      if (!result) {
+        emitCASErrorRemark(result.takeError());
+        return false;
+      }
+      if (!*result || !cas->getReference(**result)) {
+        emitMissingCASInputRemark(moduleInfo.getModuleCacheKey());
+        return false;
+      }
+    } else
+      return false;
+  }
 
   // Check interface file for Swift textual modules
   if (const auto &textualModuleDetails = moduleInfo.getAsSwiftInterfaceModule())

--- a/test/CAS/incremental_scan_binary.swift
+++ b/test/CAS/incremental_scan_binary.swift
@@ -1,0 +1,47 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module -module-name A -o %t/A.swiftmodule -swift-version 5 \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   %t/A.swift
+
+// RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-interface -module-cache-path %t/module-cache \
+// RUN:   %t/Test.swift -o %t/deps.json -I %t -cache-compile-job -cas-path %t/cas  \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   -Rdependency-scan-cache -load-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache \
+// RUN:   -serialize-dependency-scan-cache -validate-prior-dependency-scan-cache 2>&1 | %FileCheck %s --check-prefix=REUSE --check-prefix=FAILED-LOAD
+
+// RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-interface -module-cache-path %t/module-cache \
+// RUN:   %t/Test.swift -o %t/deps.json -I %t -cache-compile-job -cas-path %t/cas  \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   -Rdependency-scan-cache -load-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache \
+// RUN:   -serialize-dependency-scan-cache -validate-prior-dependency-scan-cache 2>&1 | %FileCheck %s --check-prefix=REUSE
+
+/// Test invalidation after removing CAS.
+// RUN: rm -rf %t/cas
+// RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-interface -module-cache-path %t/module-cache \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   %t/Test.swift -o %t/deps.json -I %t -cache-compile-job -cas-path %t/cas  \
+// RUN:   -Rdependency-scan-cache -load-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache \
+// RUN:   -serialize-dependency-scan-cache -validate-prior-dependency-scan-cache 2>&1 | %FileCheck %s --check-prefix=REUSE --check-prefix=INVALIDATE
+
+/// Test a swiftmodule in CAS but not in action cache.
+// RUN: rm -rf %t/cas
+// RUN: llvm-cas -cas %t/cas -make-blob -data %t/A.swiftmodule
+// RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-interface -module-cache-path %t/module-cache \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   %t/Test.swift -o %t/deps.json -I %t -cache-compile-job -cas-path %t/cas  \
+// RUN:   -Rdependency-scan-cache -load-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache \
+// RUN:   -serialize-dependency-scan-cache -validate-prior-dependency-scan-cache 2>&1 | %FileCheck %s --check-prefix=REUSE --check-prefix=INVALIDATE
+
+// REUSE: Incremental module scan: Re-using serialized module scanning dependency cache from:
+// FAILED-LOD: Incremental module scan: Failed to load module scanning dependency cache from
+// INVALIDATE: Incremental module scan: Dependency info for module 'A' invalidated due to missing CAS input
+// INVALIDATE: Incremental module scan: Dependency info for module 'deps' invalidated due to an out-of-date dependency.
+// REUSE: Incremental module scan: Serializing module scanning dependency cache to
+
+//--- A.swift
+public func a() {}
+
+//--- Test.swift
+import A


### PR DESCRIPTION
For swift binary module deps, it's cache key and output are setup during dependency scanning time. When loading the module dependency from the incremental cache, need to validate the CAS key and output for swift binary module both exist in the CAS, otherwise, it needs to be invalidated so a rescan will re-ingest the binary modules into the CAS.

rdar://173647646

<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
