### PR TITLE
[SILGen] Emit thunk for sync function called as async via override

### DIFF
--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -5250,6 +5250,12 @@ TypeConverter::checkFunctionForABIDifferences(SILModule &M,
       (fnTy1->isAsync() || fnTy2->isAsync()))
     return ABIDifference::NeedsThunk;
 
+  // A synchronous function requires a thunk to be treated as an asynchronous
+  // function. An async function cannot be called synchronously just by adding a
+  // thunk and hopefully doesn't get here.
+  if (!fnTy1->isAsync() && fnTy2->isAsync())
+    return ABIDifference::NeedsThunk;
+
   for (unsigned i = 0, e = fnTy1->getParameters().size(); i < e; ++i) {
     auto param1 = fnTy1->getParameters()[i], param2 = fnTy2->getParameters()[i];
     

--- a/test/SILGen/async_vtable_thunk.swift
+++ b/test/SILGen/async_vtable_thunk.swift
@@ -4,20 +4,36 @@
 class BaseClass<T> {
   func wait() async -> T {}
   func waitOrDie() async throws -> T {}
+  // TODO: When overriding an async method with a sync method is possible, this case should also be tested.
+  // See https://forums.swift.org/t/override-functions-behaves-differently-in-async-and-throws/83998/14
+  // func retry() async {}
+  var isReady: Bool { get async {} }
+  subscript(waitingOn i: Int) -> T { get async {} }
 }
 
 class Derived : BaseClass<Int> {
   override func wait() async -> Int {}
   override func waitOrDie() async -> Int {}
+  // override func retry() {}
+  override var isReady: Bool { get {} }
+  override subscript(waitingOn i: Int) -> Int { get {} }
 }
 
 // CHECK-LABEL: sil private [thunk] [ossa] @$s18async_vtable_thunk7DerivedC4waitSiyYaFAA9BaseClassCADxyYaFTV : $@convention(method) @async (@guaranteed Derived) -> @out Int {
 
+// CHECK-LABEL: sil private [thunk] [ossa] @$s18async_vtable_thunk7DerivedC7isReadySbvgAA9BaseClassCADSbvgTV : $@convention(method) @async (@guaranteed Derived) -> Bool {
+
+// CHECK-LABEL: sil private [thunk] [ossa] @$s18async_vtable_thunk7DerivedC9waitingOnS2i_tcigAA9BaseClassCADxSi_tcigTV : $@convention(method) @async (Int, @guaranteed Derived) -> @out Int {
+
 // CHECK-LABEL: sil_vtable Derived {
 // CHECK:  #BaseClass.wait: <T> (BaseClass<T>) -> () async -> T : @$s18async_vtable_thunk7DerivedC4waitSiyYaFAA9BaseClassCADxyYaFTV [override]
 // CHECK-NEXT:  #BaseClass.waitOrDie: <T> (BaseClass<T>) -> () async throws -> T : @$s18async_vtable_thunk7DerivedC9waitOrDieSiyYaFAA9BaseClassCADxyYaKFTV [override]
+// CHECK-NEXT:  #BaseClass.isReady!getter: <T> (BaseClass<T>) -> () async -> Bool : @$s18async_vtable_thunk7DerivedC7isReadySbvgAA9BaseClassCADSbvgTV [override]
+// CHECK-NEXT:  #BaseClass.subscript!getter: <T> (BaseClass<T>) -> (Int) async -> T : @$s18async_vtable_thunk7DerivedC9waitingOnS2i_tcigAA9BaseClassCADxSi_tcigTV [override]
 // CHECK-NEXT:  #BaseClass.init!allocator: <T> (BaseClass<T>.Type) -> () -> BaseClass<T> : @$s18async_vtable_thunk7DerivedCACycfC [override]
 // CHECK-NEXT:  #Derived.waitOrDie: (Derived) -> () async -> Int : @$s18async_vtable_thunk7DerivedC9waitOrDieSiyYaF
+// CHECK-NEXT:  #Derived.isReady!getter: (Derived) -> () -> Bool : @$s18async_vtable_thunk7DerivedC7isReadySbvg
+// CHECK-NEXT:  #Derived.subscript!getter: (Derived) -> (Int) -> Int : @$s18async_vtable_thunk7DerivedC9waitingOnS2i_tcig
 // CHECK-NEXT:  #Derived.deinit!deallocator: @$s18async_vtable_thunk7DerivedCfD
 // CHECK-NEXT: }
 


### PR DESCRIPTION
This change fixes rdar://164087561, #85332 by adding a check to `TypeConverter::checkFunctionForABIDifferences` for sync function called as async to be marked as needing a thunk, since they do not have the same calling convention. Witnesses don't exhibit this issue, since (I believe) we always emit a thunk for witnesses, and that thunk will have the effect of the conformance.

```swift
class Super {
	var bar: Int {
		get async {
			return 1
		}
	}
}

class Sub: Super {
	override var bar: Int {
		return 2
	}
}


func useSuper(_ o: Super) async {
	print(await o.bar)
}

await useSuper(Super())
await useSuper(Sub())
```

```
swiftc async_override.swift -o async_bin && ./async_bin
hello from super bar
1
fish: Job 1, './async_bin' terminated by signal SIGBUS (Misaligned address error)
```

We were generating a vtable that tried to use `Sub`s sync implementation of `bar`:

```
sil_vtable Super {
  #Super.bar!getter: (Super) -> () async -> Int : @$s14async_override5SuperC3barSivg	// Super.bar.getter
  #Super.init!allocator: (Super.Type) -> () -> Super : @$s14async_override5SuperCACycfC	// Super.__allocating_init()
  #Super.deinit!deallocator: @$s14async_override5SuperCfD	// Super.__deallocating_deinit
}

sil_vtable Sub {
  #Super.bar!getter: (Super) -> () async -> Int : @$s14async_override3SubC3barSivg [override]	// Sub.bar.getter
  #Super.init!allocator: (Super.Type) -> () -> Super : @$s14async_override3SubCACycfC [override]	// Sub.__allocating_init()
  #Sub.bar!getter: (Sub) -> () -> Int : @$s14async_override3SubC3barSivg	// Sub.bar.getter
  #Sub.deinit!deallocator: @$s14async_override3SubCfD	// Sub.__deallocating_deinit
}
```

Code like this used to fail SIL verification if enabled or crash at runtime if not, and now generates a thunk and works correctly:

```
sil_vtable Super {
  #Super.bar!getter: (Super) -> () async -> Int : @$s14async_override5SuperC3barSivg    // Super.bar.getter
  #Super.init!allocator: (Super.Type) -> () -> Super : @$s14async_override5SuperCACycfC    // Super.__allocating_init()
  #Super.deinit!deallocator: @$s14async_override5SuperCfD    // Super.__deallocating_deinit
}

sil_vtable Sub {
  #Super.bar!getter: (Super) -> () async -> Int : @$s14async_override3SubC3barSivgAA5SuperCADSivgTV [override]    // vtable thunk for Super.bar.getter dispatching to
Sub.bar.getter
  #Super.init!allocator: (Super.Type) -> () -> Super : @$s14async_override3SubCACycfC [override]    // Sub.__allocating_init()
  #Sub.bar!getter: (Sub) -> () -> Int : @$s14async_override3SubC3barSivg    // Sub.bar.getter
  #Sub.deinit!deallocator: @$s14async_override3SubCfD    // Sub.__deallocating_deinit
}
```

Overriding an asynchronous function with a sync function isn't supported today, but we should test for that thunk once it is.

- [x] Need to also investigate if bad things happen here for typed throws, but I'll address that in a separate PR.