### PR TITLE
Reparenting: improve interface feature guarding

### DIFF
--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -646,8 +646,11 @@ static bool usesFeatureReparenting(Decl *decl) {
     return false;
   };
 
-  // Check the where-clause of the generic context.
-  if (auto *gc = decl->getAsGenericContext()) {
+  // Search the decl or extension for mentions of a reparentable protocol.
+  if (isa<ValueDecl>(decl)) {
+    if (usesTypeMatching(decl, reparentableProto))
+      return true;
+  } else if (auto *gc = decl->getAsGenericContext()) {
     bool foundInWhereClause = usesTypeMatching(
         WhereClauseOwner(const_cast<GenericContext *>(gc)), reparentableProto);
 
@@ -655,6 +658,7 @@ static bool usesFeatureReparenting(Decl *decl) {
       return true;
   }
 
+  // Check the inheritance clause for mentions of a reparentable protocol.
   InheritedTypes inherited(decl);
   for (auto const &entry : inherited.getEntries()) {
     if (entry.isReparented())
@@ -664,6 +668,7 @@ static bool usesFeatureReparenting(Decl *decl) {
       return true;
   }
 
+  // Check if this decl itself is a reparentable protocol (of extension of).
   if (auto ext = dyn_cast<ExtensionDecl>(decl)) {
     decl = ext->getExtendedNominal();
   }

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -639,6 +639,9 @@ static bool usesFeatureTildeSendable(Decl *decl) {
 
 static bool usesFeatureReparenting(Decl *decl) {
   auto reparentableProto = [](Type ty) {
+    if (!ty)
+      return false;
+
     if (auto protoTy = ty->getAs<ProtocolType>()) {
       if (protoTy->getDecl()->getAttrs().hasAttribute<ReparentableAttr>())
         return true;
@@ -664,8 +667,9 @@ static bool usesFeatureReparenting(Decl *decl) {
     if (entry.isReparented())
       return true;
 
-    if (entry.getType().findIf(reparentableProto))
-      return true;
+    if (Type ty = entry.getType())
+      if (ty.findIf(reparentableProto))
+        return true;
   }
 
   // Check if this decl itself is a reparentable protocol (of extension of).

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -21,9 +21,47 @@
 #include "swift/AST/Pattern.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "clang/AST/DeclObjC.h"
+#include "swift/AST/TypeCheckRequests.h"
+
 #include "swift/Basic/Assertions.h"
 
 using namespace swift;
+
+/// Calls \p callback for each type in each requirement provided by
+/// \p source.
+///
+/// @returns true after short-circuiting if the callback returned true for
+///          any of the types
+static bool
+forAllRequirementTypes(WhereClauseOwner &&source,
+                       llvm::function_ref<bool(Type, TypeRepr *)> callback) {
+  return std::move(source).visitRequirements(
+      TypeResolutionStage::Interface,
+      [&](const Requirement &req, RequirementRepr *reqRepr) {
+        switch (req.getKind()) {
+        case RequirementKind::SameShape:
+        case RequirementKind::Conformance:
+        case RequirementKind::SameType:
+        case RequirementKind::Superclass:
+          if (callback(req.getFirstType(),
+                       RequirementRepr::getFirstTypeRepr(reqRepr)))
+            return true;
+
+          if (callback(req.getSecondType(),
+                       RequirementRepr::getSecondTypeRepr(reqRepr)))
+            return true;
+
+          break;
+
+        case RequirementKind::Layout:
+          if (callback(req.getFirstType(),
+                       RequirementRepr::getFirstTypeRepr(reqRepr)))
+            return true;
+          break;
+        }
+        return false;
+      });
+}
 
 /// Does the interface of this declaration use a type for which the
 /// given predicate returns true?
@@ -36,6 +74,14 @@ static bool usesTypeMatching(const Decl *decl,
   }
 
   return false;
+}
+
+// Does the where-clause use a type for which the given predicate returns true?
+static bool usesTypeMatching(WhereClauseOwner &&source,
+                             llvm::function_ref<bool(Type)> fn) {
+  return forAllRequirementTypes(
+      std::move(source),
+      [&](Type ty, TypeRepr *_unused_) { return ty.findIf(fn); });
 }
 
 // ----------------------------------------------------------------------------
@@ -592,14 +638,38 @@ static bool usesFeatureTildeSendable(Decl *decl) {
 }
 
 static bool usesFeatureReparenting(Decl *decl) {
-  if (auto proto = dyn_cast<ProtocolDecl>(decl)) {
-    if (proto->getAttrs().hasAttribute<ReparentableAttr>())
+  auto reparentableProto = [](Type ty) {
+    if (auto protoTy = ty->getAs<ProtocolType>()) {
+      if (protoTy->getDecl()->getAttrs().hasAttribute<ReparentableAttr>())
+        return true;
+    }
+    return false;
+  };
+
+  // Check the where-clause of the generic context.
+  if (auto *gc = decl->getAsGenericContext()) {
+    bool foundInWhereClause = usesTypeMatching(
+        WhereClauseOwner(const_cast<GenericContext *>(gc)), reparentableProto);
+
+    if (foundInWhereClause)
       return true;
   }
 
   InheritedTypes inherited(decl);
   for (auto const &entry : inherited.getEntries()) {
     if (entry.isReparented())
+      return true;
+
+    if (entry.getType().findIf(reparentableProto))
+      return true;
+  }
+
+  if (auto ext = dyn_cast<ExtensionDecl>(decl)) {
+    decl = ext->getExtendedNominal();
+  }
+
+  if (auto proto = dyn_cast<ProtocolDecl>(decl)) {
+    if (proto->getAttrs().hasAttribute<ReparentableAttr>())
       return true;
   }
 

--- a/test/ModuleInterface/reparenting.swift
+++ b/test/ModuleInterface/reparenting.swift
@@ -2,28 +2,89 @@
 
 // RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -module-name Library -enable-experimental-feature Reparenting
 // RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -module-name Library
-// RUN: %FileCheck %s --check-prefixes=CHECK < %t/Library.swiftinterface
+// RUN: %FileCheck %s --check-prefixes=CHECK --implicit-check-not '$Reparenting' < %t/Library.swiftinterface
 
 // REQUIRES: swift_feature_Reparenting
 
-// CHECK-LABEL: @reparentable public protocol Circle {
-
+// CHECK: #if compiler(>=5.3) && $Reparenting
+// CHECK-NEXT: @reparentable public protocol Circle {
 @reparentable
 public protocol Circle {
   associatedtype Color
   func fill() -> Color
 }
 
-// CHECK-LABEL: public protocol Ball : Library::Circle {
+// CHECK: #if compiler(>=5.3) && $Reparenting
+// CHECK-NEXT: extension Library::Circle where Self.Color == Swift::String {
+extension Circle where Color == String {
+  public func fill() -> Color { "blue" }
+}
+
+// CHECK: #if compiler(>=5.3) && $Reparenting
+// CHECK-NEXT: public protocol Ball : Library::Circle {
 // CHECK:         associatedtype Color = Swift::Int
 public protocol Ball: Circle {
   associatedtype Color = Int
   func roll()
 }
 
-// CHECK-LABEL: extension Library::Ball : @reparented Library::Circle where Self.Color == Swift::Int {
+// CHECK: #if compiler(>=5.3) && $Reparenting
+// CHECK-NEXT: extension Library::Ball : @reparented Library::Circle where Self.Color == Swift::Int {
 // CHECK:         public func fill() -> Self.Color
 // CHECK-NOT:     typealias
 extension Ball: @reparented Circle where Color == Int {
   public func fill() -> Color { return 0xFFFD74 }
+}
+
+public struct Oval {}
+
+extension Oval: Sendable {}
+
+// CHECK: #if compiler(>=5.3) && $Reparenting
+// CHECK-NEXT: extension Library::Oval : Library::Circle {
+extension Oval: Circle {
+  public typealias Color = Int
+  public func fill() -> Color { 0 }
+}
+
+// No need to become viral and guard mentions of protocols downstream of a reparentable one.
+// The expected failure condition is that they'll be missing from the interface according to old compilers.
+public struct Sun: Ball {
+  public typealias Color = Int
+  public func fill() -> Color { 0 }
+  public func roll() {}
+}
+
+public struct Moon {}
+
+extension Moon: Ball {
+  public typealias Color = Int
+  public func fill() -> Color { 0 }
+  public func roll() {}
+}
+
+// CHECK: #if compiler(>=5.3) && $Reparenting
+// CHECK-NEXT: public func guarded<T>(_: T.Type) where T : Library::Circle
+public func guarded<T>(_: T.Type) where T: Circle {}
+
+// CHECK: #if compiler(>=5.3) && $Reparenting
+// CHECK-NEXT: public func guarded2<T>(_: T.Type) where T : Library::Circle
+public func guarded2<T: Circle>(_: T.Type) {}
+
+public func notGuarded<T: Ball>(_: T.Type) {}
+
+
+public protocol Unrelated {}
+
+// CHECK: #if compiler(>=5.3) && $Reparenting
+// CHECK-NEXT: extension Library::Unrelated where Self : Library::Circle {
+extension Unrelated where Self: Circle {
+  public func star() {}
+}
+
+public protocol Lake {
+// CHECK:   #if compiler(>=5.3) && $Reparenting
+// CHECK-NEXT: associatedtype Shape : Library::Circle
+  associatedtype Shape: Circle
+  associatedtype Depth: Comparable
 }


### PR DESCRIPTION
This should avoid a condfail when using an older compiler on the newer stdlib that contains the `@reparentable` BorrowingSequence.

The only known condfail scenario is inheriting from
a protocol P that inherits from a reparentable one R.

We already guard P if it mentions R in its inheritance clause.
So older compilers will simply report that "P" is missing in the
interface, which is a better error message than virally guarding
everything mentioning P. It's an ABI break anyway to do that
without introducing a `@reparented` extension, which needs a guard.

In theory, older compilers shouldn't have too much go wrong if they
were to ignore `@reparentable`, though the RequirementMachine and
witness tables will look different.

rdar://174263176
rdar://174396487
