### PR TITLE
Fix module names on OpenBSD for amd64/x86_64.

### DIFF
--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -473,15 +473,20 @@ llvm::Triple swift::getTargetSpecificModuleTriple(const llvm::Triple &triple) {
 
 llvm::Triple swift::getUnversionedTriple(const llvm::Triple &triple) {
   StringRef unversionedOSName = triple.getOSName().take_until(llvm::isDigit);
+  StringRef arch = triple.getArchName();
+  if (triple.isOSOpenBSD()) {
+    arch = swift::getMajorArchitectureName(triple);
+  }
+
   if (triple.getEnvironment()) {
     StringRef environment =
         llvm::Triple::getEnvironmentTypeName(triple.getEnvironment());
 
-    return llvm::Triple(triple.getArchName(), triple.getVendorName(),
+    return llvm::Triple(arch, triple.getVendorName(),
                         unversionedOSName, environment);
   }
 
-  return llvm::Triple(triple.getArchName(), triple.getVendorName(),
+  return llvm::Triple(arch, triple.getVendorName(),
                       unversionedOSName);
 }
 


### PR DESCRIPTION
In #88224 we moved to unversioned triples. However in using the existing getUnversionedTriple implementation, we lost the call to getMajorArchitectureName and just used getArchName on the triple.

On OpenBSD, the spelling is amd64. We make a number of transpositions to use the LLVM spelling x86_64 in a number of places, but the target triple by default uses amd64. This means that instead of having a mismatch between versioned and unversioned triple, we have a mismatch between architecture spellings.

Here, we call getMajorArchitectureName on OpenBSD to use the LLVM architecture spellings in getUnversionedTriple for the platform. This is only a problem for amd64/x86_64; there is no problem on aarch64, which is why this wasn't spotted earlier.