### PR TITLE
Enable find_package(SwiftTestingMacros) in XCTest CMake build

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2334,6 +2334,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     -Ddispatch_DIR=$(build_directory ${host} libdispatch)/cmake/modules
                     -DFoundation_DIR=$(build_directory ${host} foundation)/cmake/modules
                     -DSwiftTesting_DIR=$(build_directory ${host} swifttesting)/cmake/modules
+                    -DSwiftTestingMacros_DIR=$(build_directory ${host} swifttestingmacros)/cmake/modules
                     -DLLVM_DIR=$(build_directory ${host} llvm)/lib/cmake/llvm
 
                     -DXCTEST_PATH_TO_LIBDISPATCH_SOURCE:PATH=${LIBDISPATCH_SOURCE_DIR}

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3312,6 +3312,7 @@ function Build-XCTest([Hashtable] $Platform) {
       ENABLE_TESTING = "NO";
       XCTest_INSTALL_NESTED_SUBDIR = "YES";
       SwiftTesting_DIR = (Get-ProjectCMakeModules $Platform Testing);
+      SwiftTestingMacros_DIR = (Get-ProjectCMakeModules $Platform BootstrapTestingMacros);
     }
 }
 


### PR DESCRIPTION
Enables building XCTest's lit tests that require `import Testing`, which is new for testing the interop feature.