### PR TITLE
[Diagnostics] Improve error message when type attributes are incorrectly applied to a type

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6167,7 +6167,7 @@ ERROR(sendable_raw_storage,none,
       "protocol", (DeclName))
 
 ERROR(typeattr_not_inheritance_clause,none,
-      "%0 only applies in inheritance clauses",
+      "attribute '%0' cannot be applied to a type",
       (const TypeAttribute *))
 ERROR(typeattr_not_extension_inheritance_clause,none,
       "%0 only applies in inheritance clauses in extensions",

--- a/test/Concurrency/concurrent_value_checking_typechecker_errors.swift
+++ b/test/Concurrency/concurrent_value_checking_typechecker_errors.swift
@@ -62,6 +62,6 @@ class C12: @unchecked C11 { } // expected-error {{'@unchecked' cannot apply to n
 
 protocol P { }
 
-protocol Q: @unchecked Sendable { } // expected-error {{'@unchecked' only applies in inheritance clauses}}
+protocol Q: @unchecked Sendable { } // expected-error {{'attribute .@unchecked. cannot be applied to a type}}
 
-typealias TypeAlias1 = @unchecked P // expected-error {{'@unchecked' only applies in inheritance clauses}}
+typealias TypeAlias1 = @unchecked P // expected-error {{'attribute .@unchecked. cannot be applied to a type}}

--- a/test/Concurrency/preconcurrency_conformances.swift
+++ b/test/Concurrency/preconcurrency_conformances.swift
@@ -15,18 +15,18 @@ do {
   struct B : @preconcurrency K {
     // expected-error@-1 {{'@preconcurrency' cannot apply to non-protocol type 'K'}}
     var x: @preconcurrency Int
-    // expected-error@-1 {{'@preconcurrency' only applies in inheritance clauses}}
+    // expected-error@-1 {{'attribute .@preconcurrency. cannot be applied to a type}}
   }
 
   typealias T = @preconcurrency Q
-  // expected-error@-1 {{'@preconcurrency' only applies in inheritance clauses}}
+  // expected-error@-1 {{'attribute .@preconcurrency. cannot be applied to a type}}
 
   func test(_: @preconcurrency K) {}
-  // expected-error@-1 {{'@preconcurrency' only applies in inheritance clauses}}
+  // expected-error@-1 {{'attribute .@preconcurrency. cannot be applied to a type}}
 }
 
 protocol InvalidUseOfPreconcurrencyAttr : @preconcurrency Q {
-  // expected-error@-1 {{'@preconcurrency' only applies in inheritance clauses}}
+  // expected-error@-1 {{'attribute .@preconcurrency. cannot be applied to a type}}
 }
 
 struct TestPreconcurrencyAttr {}


### PR DESCRIPTION
Resolves #88338.

**Description:**
Previously, when `@preconcurrency` (or other similar attributes like `@unchecked`, `@unsafe`, or `@nonisolated`) was incorrectly parsed as a type attribute outside of an inheritance clause, the compiler emitted the error:
`@preconcurrency only applies in inheritance clauses`

This message was misleading because the attribute can validly be applied to many different declarations (such as types, functions, and imports) as a declaration attribute. To provide a more accurate and less confusing error message, this PR updates the diagnostic `typeattr_not_inheritance_clause` to instead state: 
`attribute '@preconcurrency' cannot be applied to a type`

**Changes Made:**
- Modified the error message for `typeattr_not_inheritance_clause` in `include/swift/AST/DiagnosticsSema.def`.
- Updated compiler test expectations in `test/Concurrency/preconcurrency_conformances.swift` and `test/Concurrency/concurrent_value_checking_typechecker_errors.swift` to match the new diagnostic string.
