### PR TITLE
Optimizer: fix deinit barrier detection for instructions which access memory via a pointer

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Analysis/CalleeAnalysis.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Analysis/CalleeAnalysis.swift
@@ -143,7 +143,7 @@ extension Instruction {
     if let aai = self as? AbortApplyInst {
       return aai.isBarrier(analysis)
     }
-    return mayAccessPointer || mayLoadWeakOrUnowned || maySynchronize
+    return mayAccessPointerOrGlobal || mayLoadWeakOrUnowned || maySynchronize
   }
 }
 

--- a/SwiftCompilerSources/Sources/Optimizer/Analysis/CalleeAnalysis.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Analysis/CalleeAnalysis.swift
@@ -143,7 +143,7 @@ extension Instruction {
     if let aai = self as? AbortApplyInst {
       return aai.isBarrier(analysis)
     }
-    return mayAccessPointerOrGlobal || mayLoadWeakOrUnowned || maySynchronize
+    return isDeinitBarrier
   }
 }
 

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeSideEffects.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeSideEffects.swift
@@ -283,8 +283,7 @@ private struct CollectedEffects {
     // If we didn't already, check whether the instruction could be a deinit
     // barrier.  If it's an apply of some sort, that was already done in
     // handleApply.
-    if !checkedIfDeinitBarrier,
-       inst.mayBeDeinitBarrierNotConsideringSideEffects {
+    if !checkedIfDeinitBarrier, inst.isDeinitBarrier {
       globalEffects.isDeinitBarrier = true
     }
   }

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -179,8 +179,13 @@ public class Instruction : CustomStringConvertible, Hashable {
     return bridged.maySynchronize()
   }
 
-  public final var mayBeDeinitBarrierNotConsideringSideEffects: Bool {
-    return bridged.mayBeDeinitBarrierNotConsideringSideEffects()
+  public final var isDeinitBarrier: Bool {
+    switch self {
+    case is FullApplySite, is EndApplyInst, is AbortApplyInst:
+      return true
+    default:
+      return mayAccessPointerOrGlobal || mayLoadWeakOrUnowned || maySynchronize
+    }
   }
 
   public final var isEndOfScopeMarker: Bool {

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -144,8 +144,26 @@ public class Instruction : CustomStringConvertible, Hashable {
     return bridged.mayHaveSideEffects()
   }
 
-  public final var mayAccessPointer: Bool {
-    return bridged.mayAccessPointer()
+  public final var mayAccessPointerOrGlobal: Bool {
+    guard mayReadOrWriteMemory else {
+      return false
+    }
+    switch self {
+    case is BuiltinInst:
+      // Consider all builtins that read/write memory to access pointers.
+      return true
+    case let endBorrow as EndBorrowInst:
+      switch endBorrow.borrow {
+      case let loadBorrow as LoadBorrowInst:
+        return FindPointerOrGlobalWalker.mayAccessPointerOrGlobal(loadBorrow.address)
+      default:
+        return false
+      }
+    default:
+      return operands.contains { op in
+        FindPointerOrGlobalWalker.mayAccessPointerOrGlobal(op.value)
+      }
+    }
   }
 
   /// True if arbitrary functions may be called by this instruction.
@@ -203,6 +221,30 @@ public class Instruction : CustomStringConvertible, Hashable {
 
   public var bridged: BridgedInstruction {
     BridgedInstruction(SwiftObject(self))
+  }
+}
+
+/// Returns `abortWalk` if the address stems from a raw pointer or a global variable.
+/// We cannot simply use `AccessPath` for this because `AccessPath` looks through
+/// `address_to_pointer` - `pointer_to_address` pairs.
+private struct FindPointerOrGlobalWalker : AddressUseDefWalker {
+
+  static func mayAccessPointerOrGlobal(_ value: Value) -> Bool {
+    guard value.type.isAddress else {
+      return false
+    }
+    var walker = FindPointerOrGlobalWalker()
+    return walker.walkUp(address: value, path: UnusedWalkingPath()) == .abortWalk
+  }
+
+  func rootDef(address: Value, path: UnusedWalkingPath) -> WalkResult {
+    let accessBase = AccessBase(baseAddress: address)
+    switch accessBase {
+    case .box, .stack, .class, .tail, .argument, .yield, .storeBorrow, .index:
+      return .continueWalk
+    case .global, .pointer, .unidentified:
+      return .abortWalk
+    }
   }
 }
 

--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -257,13 +257,6 @@ bool mayLoadWeakOrUnowned(SILInstruction* instruction);
 /// point like a memory barrier, lock or syscall.
 bool maySynchronize(SILInstruction* instruction);
 
-/// Conservatively, whether this instruction could be a barrier to hoisting
-/// destroys.
-///
-/// Does not consider function so effects, so every apply is treated as a
-/// barrier.
-bool mayBeDeinitBarrierNotConsideringSideEffects(SILInstruction *instruction);
-
 } // end namespace swift
 
 //===----------------------------------------------------------------------===//

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -740,7 +740,6 @@ struct BridgedInstruction {
   bool mayAccessPointer() const;
   bool mayLoadWeakOrUnowned() const;
   bool maySynchronize() const;
-  bool mayBeDeinitBarrierNotConsideringSideEffects() const;
   BRIDGED_INLINE bool shouldBeForwarding() const;
   BRIDGED_INLINE bool isIdenticalTo(BridgedInstruction inst) const;
 

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -481,18 +481,6 @@ bool swift::maySynchronize(SILInstruction *instruction) {
   return isa<HopToExecutorInst>(instruction);
 }
 
-bool swift::mayBeDeinitBarrierNotConsideringSideEffects(SILInstruction *instruction) {
-  if (FullApplySite::isa(instruction) || isa<EndApplyInst>(instruction) ||
-      isa<AbortApplyInst>(instruction)) {
-    return true;
-  }
-  bool retval = mayAccessPointer(instruction)
-             || mayLoadWeakOrUnowned(instruction)
-             || maySynchronize(instruction);
-  assert(!retval || !isa<BranchInst>(instruction) && "br as deinit barrier!?");
-  return retval;
-}
-
 //===----------------------------------------------------------------------===//
 //                         MARK: AccessRepresentation
 //===----------------------------------------------------------------------===//

--- a/lib/SIL/Utils/SILBridging.cpp
+++ b/lib/SIL/Utils/SILBridging.cpp
@@ -599,10 +599,6 @@ bool BridgedInstruction::maySynchronize() const {
   return ::maySynchronize(unbridged());
 }
 
-bool BridgedInstruction::mayBeDeinitBarrierNotConsideringSideEffects() const {
-  return ::mayBeDeinitBarrierNotConsideringSideEffects(unbridged());
-}
-
 //===----------------------------------------------------------------------===//
 //                               BridgedBuilder
 //===----------------------------------------------------------------------===//

--- a/lib/SILOptimizer/Analysis/BasicCalleeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/BasicCalleeAnalysis.cpp
@@ -76,7 +76,7 @@ getMemoryBehavior(FullApplySite as, bool observeRetains) {
 bool swift::isDeinitBarrier(SILInstruction *const instruction,
                             BasicCalleeAnalysis *bca) {
   if (!instructionIsDeinitBarrierFunction || !bca) {
-    return mayBeDeinitBarrierNotConsideringSideEffects(instruction);
+    return true;
   }
   BridgedInstruction inst = {
       cast<SILNode>(const_cast<SILInstruction *>(instruction))};

--- a/lib/SILOptimizer/SemanticARC/CopyValueOpts.cpp
+++ b/lib/SILOptimizer/SemanticARC/CopyValueOpts.cpp
@@ -28,6 +28,7 @@
 #include "swift/SIL/OwnershipUtils.h"
 #include "swift/SIL/Projection.h"
 #include "swift/SIL/Test.h"
+#include "swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h"
 
 using namespace swift;
 using namespace swift::semanticarc;
@@ -414,8 +415,9 @@ static bool tryJoinIfDestroyConsumingUseInSameBlock(
   // consuming use of the copy and the destroy.  If any of those instructions
   // is a deinit barrier, it would be illegal to shorten the original lexical
   // value's lifetime to end at that consuming use.  Bail if any are.
-  if (llvm::any_of(visitedInsts, [](auto *inst) {
-        return mayBeDeinitBarrierNotConsideringSideEffects(inst);
+  auto *bca = ctx.ctx.pm->getAnalysis<BasicCalleeAnalysis>();
+  if (llvm::any_of(visitedInsts, [bca](auto *inst) {
+        return isDeinitBarrier(inst, bca);
       }))
     return false;
 

--- a/test/SILOptimizer/deinit_barrier.sil
+++ b/test/SILOptimizer/deinit_barrier.sil
@@ -140,6 +140,42 @@ entry:
   return %retval : $()
 }
 
+class C {}
+
+// CHECK-LABEL: begin running test 1 of {{[0-9]+}} on test_load_from_pointer: is_deinit_barrier
+// CHECK:  load
+// CHECK:  true
+// CHECK-LABEL: end running test 1 of {{[0-9]+}} on test_load_from_pointer: is_deinit_barrier
+sil [ossa] @test_load_from_pointer : $@convention(thin) (@guaranteed C) -> Int32 {
+bb0(%0 : @guaranteed $C):
+  %1 = ref_tail_addr %0, $Int32
+  %2 = address_to_pointer %1 to $Builtin.RawPointer
+  %3 = pointer_to_address %2 to $*Int32
+  specify_test "is_deinit_barrier @instruction"
+  %4 = load [trivial] %3
+  return %4
+}
+
+// CHECK-LABEL: begin running test 1 of {{[0-9]+}} on test_load_borrow_from_pointer: is_deinit_barrier
+// CHECK:  load_borrow
+// CHECK:  true
+// CHECK-LABEL: end running test 1 of {{[0-9]+}} on test_load_borrow_from_pointer: is_deinit_barrier
+// CHECK-LABEL: begin running test 2 of {{[0-9]+}} on test_load_borrow_from_pointer: is_deinit_barrier
+// CHECK:  end_borrow
+// CHECK:  true
+// CHECK-LABEL: end running test 2 of {{[0-9]+}} on test_load_borrow_from_pointer: is_deinit_barrier
+sil [ossa] @test_load_borrow_from_pointer : $@convention(thin) (@in_guaranteed C) -> () {
+bb0(%0 : $*C):
+  %1 = address_to_pointer %0 to $Builtin.RawPointer
+  %2 = pointer_to_address %1 to $*C
+  specify_test "is_deinit_barrier @instruction"
+  %3 = load_borrow %2
+  specify_test "is_deinit_barrier @instruction"
+  end_borrow %3
+  %r = tuple ()
+  return %r
+}
+
 // CHECK-LABEL: begin running test {{.*}} on rdar120656227: is_deinit_barrier
 // CHECK:       builtin "int_memmove_RawPointer_RawPointer_Int64"
 // CHECK:       true

--- a/test/SILOptimizer/hoist_destroy_addr.sil
+++ b/test/SILOptimizer/hoist_destroy_addr.sil
@@ -1365,7 +1365,7 @@ entry(%c_addr : $*X):
 
 // CHECK-LABEL: sil [ossa] @no_hoist_into_load_borrow_scope : {{.*}} {
 // CHECK:         end_borrow
-// CHECK-NEXT:    destroy_addr
+// CHECK:         destroy_addr
 // CHECK-LABEL: } // end sil function 'no_hoist_into_load_borrow_scope'
 sil [ossa] @no_hoist_into_load_borrow_scope : $@convention(thin) (@in X) -> () {
 entry(%c_addr_in : $*X):

--- a/test/SILOptimizer/side_effects.sil
+++ b/test/SILOptimizer/side_effects.sil
@@ -1065,7 +1065,7 @@ bb3(%12 : $List):
 
 // CHECK-LABEL: sil [ossa] @testStructPhiCommon
 // CHECK-NEXT:  [%0: write s0.v**]
-// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  [global: deinit_barrier]
 // CHECK-NEXT:  {{^[^[]}}
 sil [ossa] @testStructPhiCommon : $@convention(thin) (@inout Ptr) -> () {
 bb0(%0 : $*Ptr):

--- a/test/SILOptimizer/sil_combine_ossa.sil
+++ b/test/SILOptimizer/sil_combine_ossa.sil
@@ -5589,6 +5589,24 @@ bb0(%0 : @owned $B, %1 : @guaranteed $D):
   return %5
 }
 
+// CHECK-LABEL: sil [ossa] @dont_hoist_destroy_over_deinit_barrier2 :
+// CHECK:         store %1 to [trivial]
+// CHECK-NEXT:    destroy_value %0
+// CHECK:       } // end sil function 'dont_hoist_destroy_over_deinit_barrier2'
+sil [ossa] @dont_hoist_destroy_over_deinit_barrier2 : $@convention(thin) (@owned Klass, UInt8) -> () {
+bb0(%0 : @owned $Klass, %1 : $UInt8):
+  %2 = begin_borrow %0
+  %3 = ref_tail_addr %2, $UInt8
+  %4 = address_to_pointer %3 to $Builtin.RawPointer
+  end_borrow %2
+  %6 = pointer_to_address %4 to [strict] $*UInt8
+  store %1 to [trivial] %6
+  %8 = end_cow_mutation %0
+  destroy_value %8
+  %10 = tuple ()
+  return %10
+}
+
 // Just check that this doesn't produce illegal SIL
 sil [ossa] @inject_enum_addr_in_different_block : $@convention(thin) (@inout Substring) -> @owned Optional<Character> {
 bb0(%0 : $*Substring):


### PR DESCRIPTION
The original implementation of `mayAccessPointer` did look through `address_to_pointer` - `pointer_to_address` pairs and therefore not detect such pointers.

Fixes a miscompile
rdar://174268466
