### PR TITLE
[build-script] Add option to continue the build on test failures

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -49,6 +49,7 @@ KNOWN_SETTINGS=(
     verbose-build                                 ""                "print the commands executed during the build"
     check-args-only                               ""                "set to check all arguments are known. Exit with status 0 if success, non zero otherwise"
     only-execute                                  "all"             "Only execute the named action (see implementation)"
+    continue-on-test-failure                      ""                "continue building and testing remaining targets even if a test target fails"
     check-incremental-compilation                 "0"               "set to 1 to compile swift libraries multiple times to check if incremental compilation works"
     enable-array-cow-checks                       "0"               "set tp 1 compile the stdlib with Array COW checks enabled (only relevant for assert builds)"
 
@@ -339,7 +340,9 @@ function call() {
     if [[ ! ${DRY_RUN} ]]; then
         { set -x; } 2>/dev/null
         "$@"
+        local exit_code=$?
         { set +x; } 2>/dev/null
+        return $exit_code
     fi
 }
 
@@ -2607,6 +2610,8 @@ tests_busted ()
     echo "*** Failed while running tests for $1 $2"
 }
 
+all_failed_targets=()
+
 for host in "${ALL_HOSTS[@]}"; do
     # Skip this pass when the only action to execute can't match.
     if ! [[ $(should_execute_host_actions_for_phase ${host} test) ]]; then
@@ -2821,14 +2826,21 @@ for host in "${ALL_HOSTS[@]}"; do
         for target in "${results_targets[@]}"; do
             if [[ "${target}" != "" ]]; then
                 echo "--- ${target} ---"
-                trap "tests_busted ${product} '(${target})'" ERR
 
                 test_target="$target"
                 if [[ ${test_target} == check-swift* ]] && [[ "${TEST_PATHS}" ]]; then
                     test_target="${test_target}-custom"
                 fi
 
-                call "${build_cmd[@]}" ${test_target}
+                if [[ "${CONTINUE_ON_TEST_FAILURE}" ]]; then
+                    call "${build_cmd[@]}" ${test_target} || {
+                        tests_busted ${product} "(${target})"
+                        all_failed_targets+=("${target}")
+                    }
+                else
+                    trap "tests_busted ${product} '(${target})'" ERR
+                    call "${build_cmd[@]}" ${test_target}
+                fi
 
                 echo "-- ${target} finished --"
             fi
@@ -2839,6 +2851,16 @@ for host in "${ALL_HOSTS[@]}"; do
     done
 done
 # END OF TEST PHASE
+
+if [[ ${#all_failed_targets[@]} -gt 0 ]]; then
+    # Save failed test targets to a text file and exit with an error.
+    # The text file is later used by build-script to print test summaries.
+    for t in "${all_failed_targets[@]}"; do
+        printf "%s\n" "${t}" \
+            >> "${BUILD_DIR}/.swift-build-failed-test-targets"
+    done
+    exit 1
+fi
 
 
 LIPO_SRC_DIRS=()

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -1193,6 +1193,11 @@ def create_argument_parser():
                 'Then re-builds the TSan runtime (compiler-rt) using this '
                 'freshly-built Clang and runs the TSan libdispatch tests.')
 
+    option('--continue-on-test-failure', toggle_true,
+           help='Continue building and testing remaining products even if '
+                'tests fail for a product. A non-zero exit code is still '
+                'returned at the end if any test failures occurred.')
+
     option('--skip-test-osx', toggle_false('test_osx'),
            help='skip testing Swift stdlibs for Mac OS X')
     option('--skip-test-linux', toggle_false('test_linux'),

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -933,4 +933,6 @@ EXPECTED_OPTIONS = [
     StrOption('--llvm-install-components'),
     ChoicesOption('--use-linker', dest='use_linker', choices=['gold', 'lld']),
     EnableOption('--enable-new-runtime-build', dest='enable_new_runtime_build'),
+
+    EnableOption('--continue-on-test-failure', dest='continue_on_test_failure'),
 ]

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -355,6 +355,7 @@ EXPECTED_DEFAULTS = {
     'clean_install_destdir': False,
     'use_linker': None,
     'enable_new_runtime_build': False,
+    'continue_on_test_failure': False,
 }
 
 

--- a/utils/swift_build_support/swift_build_support/build_script_invocation.py
+++ b/utils/swift_build_support/swift_build_support/build_script_invocation.py
@@ -198,6 +198,9 @@ class BuildScriptInvocation(object):
         if args.test_paths:
             impl_args += ["--test-paths", " ".join(args.test_paths)]
 
+        if args.continue_on_test_failure:
+            impl_args += ["--continue-on-test-failure=1"]
+
         if toolchain.ninja:
             impl_args += ["--ninja-bin=%s" % toolchain.ninja]
         if args.distcc:
@@ -757,6 +760,14 @@ class BuildScriptInvocation(object):
                                         env=self.impl_env, echo=True)
             return
 
+        # Accumulates test failures when --continue-on-test-failure is set.
+        self._test_failures = []
+        self._failed_targets_file = os.path.join(
+            self.workspace.build_root, '.swift-build-failed-test-targets')
+        # Clear any stale file from a previous run.
+        if os.path.exists(self._failed_targets_file):
+            os.remove(self._failed_targets_file)
+
         # Otherwise, we compute and execute the individual actions ourselves.
         # Compute the list of hosts to operate on.
         all_host_names = [
@@ -799,6 +810,11 @@ class BuildScriptInvocation(object):
 
         # And then perform the rest of the non-core epilogue actions.
 
+        # If any test failures were deferred, report them now and exit.
+        if self._test_failures:
+            self._print_test_failure_summary()
+            raise SystemExit(f"ERROR: {len(self._test_failures)} test action(s) failed.\n")
+
         # Extract symbols...
         for host_target in all_hosts:
             self._execute_extract_symbols_action(host_target)
@@ -834,7 +850,22 @@ class BuildScriptInvocation(object):
         # Test...
         for host_target in all_hosts:
             for product_class in pipeline:
-                self._execute_test_action(host_target, product_class)
+                try:
+                    self._execute_test_action(host_target, product_class)
+                except SystemExit as e:
+                    if os.path.exists(self._failed_targets_file):
+                        with open(self._failed_targets_file) as f:
+                            subtargets = [
+                                line.strip() for line in f if line.strip()]
+                        os.remove(self._failed_targets_file)
+                    else:
+                        subtargets = []
+                    self._test_failures.append((
+                        f"Running tests for {product_class.product_name()}",
+                        subtargets))
+                    if not self.args.continue_on_test_failure:
+                        self._print_test_failure_summary()
+                        raise
 
         # Install...
         for host_target in all_hosts:
@@ -856,6 +887,13 @@ class BuildScriptInvocation(object):
             for product_class in pipeline:
                 # Execute clean, build, test, install
                 self.execute_product_build_steps(product_class, host_target)
+
+    def _print_test_failure_summary(self):
+        print("\nERROR: The following test actions failed:")
+        for label, subtargets in self._test_failures:
+            print(f"  - {label}")
+            for subtarget in subtargets:
+                print(f"    - {subtarget}")
 
     def _execute_build_action(self, host_target, product_class):
         action_name = "{}-{}-build".format(host_target.name,
@@ -920,9 +958,16 @@ class BuildScriptInvocation(object):
         if product.should_test(host_target):
             log_message = "Running tests for %s" % product_name
             print("--- {} ---".format(log_message), flush=True)
-            with log_time_in_scope(log_message):
-                product.test(host_target)
-            print("--- Finished tests for %s ---" % product_name, flush=True)
+            try:
+                with log_time_in_scope(log_message):
+                    product.test(host_target)
+                print("--- Finished tests for %s ---" % product_name,
+                      flush=True)
+            except SystemExit as e:
+                self._test_failures.append((log_message, []))
+                if not self.args.continue_on_test_failure:
+                    self._print_test_failure_summary()
+                    raise
         # Install the product if it should be installed specifically, or
         # if it should be built and `install_all` is set to True.
         # The exception is select before_build_script_impl products


### PR DESCRIPTION
<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

Currently, when a project test suite fails, the build terminates immediately. This makes it challenging to keep an eye on the status of products downstream of the failing product.
This PR adds a new `--continue-after-test-failure` option to build-script to continue building and running tests for downstream products that depend on the failed product. The overall build still returns a failed status if any of the test suites fail, and test failures are reported as a summary at the end of the build.

An example of the test summary:
```
ERROR: The following test actions failed:
  - Running tests for cmark
  - Running tests for swift
    - check-swift-validation-macosx-arm64
ERROR: 2 test action(s) failed.
```

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
