### PR TITLE
[FineGrainedDeps] Use source path instead of swiftdeps path for sourceFileProvide key

### DIFF
--- a/lib/AST/FrontendSourceFileDepGraphFactory.cpp
+++ b/lib/AST/FrontendSourceFileDepGraphFactory.cpp
@@ -259,9 +259,10 @@ FrontendSourceFileDepGraphFactory::FrontendSourceFileDepGraphFactory(
     const SourceFile *SF, llvm::vfs::OutputBackend &backend,
     StringRef outputPath, const DependencyTracker &depTracker,
     const bool alsoEmitDotFile)
-    : AbstractSourceFileDepGraphFactory(
-          SF->getASTContext().hadError(), outputPath, SF->getInterfaceHash(),
-          alsoEmitDotFile, SF->getASTContext().Diags, backend),
+    : AbstractSourceFileDepGraphFactory(SF->getASTContext().hadError(),
+                                        SF->getFilename(),
+                                        SF->getInterfaceHash(), alsoEmitDotFile,
+                                        SF->getASTContext().Diags, backend),
       SF(SF), depTracker(depTracker) {}
 
 //==============================================================================

--- a/test/CAS/swiftdeps_prefix_map.swift
+++ b/test/CAS/swiftdeps_prefix_map.swift
@@ -1,0 +1,71 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module -module-name B -o %t/B.swiftmodule -swift-version 5 \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   %t/B.swift
+
+// RUN: %target-swift-frontend-plain -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache %t/foo.swift %t/bar.swift \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   -scanner-prefix-map-paths %t /^tmp -I %t \
+// RUN:   -o %t/deps.json -I %t -cache-compile-job -cas-path %t/cas -swift-version 5
+
+// RUN: %{python} %S/../../utils/swift-build-modules.py --cas %t/cas %swift_frontend_plain %t/deps.json -o %t/Test.cmd
+
+// RUN: %target-swift-frontend-plain \
+// RUN:   -c -cache-compile-job -cas-path %t/cas -module-name Test \
+// RUN:   -disable-implicit-swift-modules -o %t/foo.o \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   -emit-reference-dependencies-path %t/foo.swiftdeps -emit-dependencies \
+// RUN:   -primary-file /^tmp/foo.swift /^tmp/bar.swift @%t/Test.cmd
+
+// RUN: %target-swift-frontend-plain \
+// RUN:   -c -cache-compile-job -cas-path %t/cas -module-name Test \
+// RUN:   -disable-implicit-swift-modules -o %t/bar.o \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   -emit-reference-dependencies-path %t/bar.swiftdeps -emit-dependencies \
+// RUN:   /^tmp/foo.swift -primary-file /^tmp/bar.swift @%t/Test.cmd
+
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/foo.swiftdeps | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-FOO
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/bar.swiftdeps | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-BAR
+
+// CHECK-DAG: externalDepend interface '' '{{/|\\}}^tmp{{/|\\}}A.h'
+// CHECK-DAG: externalDepend interface '' '{{/|\\}}^tmp{{/|\\}}A.swiftinterface'
+
+// CHECK-FOO-DAG: sourceFileProvide implementation '' '/^tmp{{/|\\}}foo.swift'
+// CHECK-FOO-DAG: sourceFileProvide interface '' '/^tmp{{/|\\}}foo.swift'
+
+// CHECK-BAR-DAG: sourceFileProvide implementation '' '/^tmp{{/|\\}}bar.swift'
+// CHECK-BAR-DAG: sourceFileProvide interface '' '/^tmp{{/|\\}}bar.swift'
+// CHECK-BAR-DAG: topLevel interface '' foo
+
+//--- module.modulemap
+module A {
+  header "A.h"
+  export *
+}
+
+//--- A.h
+void a(void);
+
+//--- A.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name A -O -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib -user-module-version 1.0
+
+@_exported import A
+public struct A {}
+
+//--- B.swift
+public func b() {}
+
+//--- foo.swift
+import A
+func foo() {}
+
+//--- bar.swift
+import B
+
+func bar() {
+  b()
+  foo()
+}


### PR DESCRIPTION
The swiftdeps output path is marked CacheInvariant and should not appear in output content. Use the source file path (SF->getFilename()) instead of the output path when constructing sourceFileProvide dependency nodes.

<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
