### PR TITLE
[Sema] Improve nil-coalescing warning when LHS is implicitly promoted to a deeper optional

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5133,6 +5133,10 @@ WARNING(bitcasting_to_change_from_unsized_to_sized_int, none,
 WARNING(use_of_qq_on_non_optional_value,none,
         "left side of nil coalescing operator '?""?' has non-optional type %0, "
         "so the right side is never used", (Type))
+WARNING(use_of_qq_with_optional_lhs_promotion,none,
+        "left side of nil coalescing operator '?""?' adds an additional level "
+        "of optional to %0, making it always non-nil, so the right side is "
+        "never used", (Type))
 WARNING(nonoptional_compare_to_nil,none,
         "comparing non-optional value of type %0 to '%select{Optional.none|nil}1' always returns"
         " %select{false|true}2", (Type, bool, bool))

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1439,16 +1439,24 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
 
       Expr *subExpr = nullptr;
       if (calleeName == "??" &&
-          (subExpr = isImplicitPromotionToOptional(lhs)) &&
-          !subExpr->getType()->getOptionalObjectType()) {
-
-        Ctx.Diags
-            .diagnose(DRE->getLoc(), diag::use_of_qq_on_non_optional_value,
-                      subExpr->getType())
-            .highlight(lhs->getSourceRange())
-            .fixItRemoveChars(
-                Lexer::getLocForEndOfToken(Ctx.SourceMgr, lhs->getEndLoc()),
-                Lexer::getLocForEndOfToken(Ctx.SourceMgr, rhs->getEndLoc()));
+          (subExpr = isImplicitPromotionToOptional(lhs))) {
+        if (subExpr->getType()->getOptionalObjectType()) {
+          // The LHS is already optional and is being promoted to an additional
+          // level of optional (e.g. Int? -> Int??), making it always non-nil.
+          Ctx.Diags
+              .diagnose(DRE->getLoc(),
+                        diag::use_of_qq_with_optional_lhs_promotion,
+                        subExpr->getType())
+              .highlight(lhs->getSourceRange());
+        } else {
+          Ctx.Diags
+              .diagnose(DRE->getLoc(), diag::use_of_qq_on_non_optional_value,
+                        subExpr->getType())
+              .highlight(lhs->getSourceRange())
+              .fixItRemoveChars(
+                  Lexer::getLocForEndOfToken(Ctx.SourceMgr, lhs->getEndLoc()),
+                  Lexer::getLocForEndOfToken(Ctx.SourceMgr, rhs->getEndLoc()));
+        }
         return;
       }
       

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1439,7 +1439,8 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
 
       Expr *subExpr = nullptr;
       if (calleeName == "??" &&
-          (subExpr = isImplicitPromotionToOptional(lhs))) {
+          (subExpr = isImplicitPromotionToOptional(lhs)) &&
+          !subExpr->getType()->getOptionalObjectType()) {
 
         Ctx.Diags
             .diagnose(DRE->getLoc(), diag::use_of_qq_on_non_optional_value,

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1576,9 +1576,9 @@ func testNilCoalescingWithOptionalLHSPromotedToDoubleOptional() {
   let ten: Int = 10
   let optional: Int? = .some(1)
 
-  // Should compile without a warning: the LHS is already optional, so the
-  // "non-optional type" warning would be misleading/false.
-  let _ = (optional ?? ten).flatMap(transform)
+  // The LHS is already optional and gets promoted to an additional level of
+  // optional (Int? -> Int??), making it always non-nil.
+  let _ = (optional ?? ten).flatMap(transform) // expected-warning {{left side of nil coalescing operator '??' adds an additional level of optional to 'Int?', making it always non-nil, so the right side is never used}}
 }
 
 // https://github.com/apple/swift/issues/74617

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1570,6 +1570,17 @@ func testNilCoalescingOperatorRemoveFix() {
       ?? "").isEmpty {} // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{-1:9-+0:12=}}
 }
 
+// https://github.com/swiftlang/swift/issues/88204
+func testNilCoalescingWithOptionalLHSPromotedToDoubleOptional() {
+  let transform: (Int) -> Int? = { _ in .some(0) }
+  let ten: Int = 10
+  let optional: Int? = .some(1)
+
+  // Should compile without a warning: the LHS is already optional, so the
+  // "non-optional type" warning would be misleading/false.
+  let _ = (optional ?? ten).flatMap(transform)
+}
+
 // https://github.com/apple/swift/issues/74617
 struct Foo_74617 {
   public var bar: Float { 123 }


### PR DESCRIPTION
  - **Explanation**: When the LHS of `??` is already optional and gets implicitly promoted to a deeper optional level (e.g. `Int?` → `Int??`), the compiler was incorrectly firing `use_of_qq_on_non_optional_value` with the message "left side of nil coalescing operator '??' has non-optional type 'Int?', so the right side is never used" — which is contradictory since `Int?` is optional. This PR adds a dedicated diagnostic (`use_of_qq_with_optional_lhs_promotion`) that accurately describes the situation: the LHS adds an additional level of optional, making it always non-nil, so the RHS is never used.

  - **Scope**: Diagnostic-only change. No type-checking logic or code generation is affected. Existing code that triggered the old warning will now see a more accurate warning message. No source-breaking changes.

  - **Issues**: Resolves https://github.com/swiftlang/swift/issues/88204

  - **Risk**: Very low. The change is limited to `MiscDiagnostics.cpp` (branching on whether the sub-expression's type is itself optional) and `DiagnosticsSema.def` (one new `WARNING` entry). The original diagnostic and its fix-it are preserved for the non-optional LHS case. No existing tests were modified; one new test case was added.

  - **Testing**: A new test case covering the `Int?` → `Int??` promotion was added to `test/Constraints/diagnostics.swift` and verified via the smoke test triggered by @swift-ci.