### PR TITLE
[IRGen] Emit direct retain/release code in IRGen.

### DIFF
--- a/include/swift/AST/FeatureAvailability.def
+++ b/include/swift/AST/FeatureAvailability.def
@@ -87,6 +87,7 @@ FEATURE(CustomGlobalExecutors,                          FUTURE)
 FEATURE(Differentiation,                                FUTURE)
 FEATURE(ClearSensitive,                                 FUTURE)
 FEATURE(UpdatePureObjCClassMetadata,                    FUTURE)
+FEATURE(PreservemostRetainRelease,                      (6, 4))
 // TODO: CoroutineAccessors: Change to correct version number.
 FEATURE(CoroutineAccessors,                             FUTURE)
 #undef FEATURE

--- a/lib/IRGen/CMakeLists.txt
+++ b/lib/IRGen/CMakeLists.txt
@@ -23,6 +23,7 @@ add_swift_host_library(swiftIRGen STATIC
   GenConcurrency.cpp
   GenDistributed.cpp
   GenDecl.cpp
+  GenDirectRuntime.cpp
   GenDiffFunc.cpp
   GenDiffWitness.cpp
   GenEnum.cpp

--- a/lib/IRGen/GenDirectRuntime.cpp
+++ b/lib/IRGen/GenDirectRuntime.cpp
@@ -1,0 +1,219 @@
+//===--- GenDirectRuntime.cpp - Direct runtime inline asm emission --------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file implements emission of direct runtime functions as module-level
+//  inline assembly. The assembly is read from an installed .s template file and
+//  parameterized via .set directives. The functions use .weak_definition so the
+//  linker coalesces duplicates. This allows non-Swift projects linking Swift
+//  static libraries to work without needing Swift's library search paths.
+//
+//===----------------------------------------------------------------------===//
+
+#include "IRGenModule.h"
+#include "swift/ABI/System.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Module.h"
+#include "llvm/MC/MCSubtargetInfo.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/TargetParser/Triple.h"
+
+using namespace swift;
+using namespace irgen;
+
+/// Create an IR function that saves preserve_most registers, masks the object
+/// pointer, calls the given target function, and returns. This allows LLVM to
+/// handle pointer authentication and frame layout automatically, rather than
+/// hand-coding PAC instructions in inline assembly.
+static llvm::Function *createCallFrameHelper(
+    IRGenModule &IGM, StringRef name, StringRef targetName,
+    bool returnObject, uint64_t pointerMask) {
+  auto &Module = IGM.Module;
+  auto &Ctx = Module.getContext();
+  auto *ptrTy = llvm::PointerType::getUnqual(Ctx);
+  auto *voidTy = llvm::Type::getVoidTy(Ctx);
+  auto *i64Ty = llvm::Type::getInt64Ty(Ctx);
+
+  // Helper function signature: ptr(ptr) for retain, void(ptr) for release.
+  auto *retTy = returnObject ? static_cast<llvm::Type *>(ptrTy) : voidTy;
+  auto *fnTy = llvm::FunctionType::get(retTy, {ptrTy}, false);
+
+  auto *fn = llvm::Function::Create(
+      fnTy, llvm::GlobalValue::WeakODRLinkage, name, &Module);
+  fn->setVisibility(llvm::GlobalValue::HiddenVisibility);
+  fn->setCallingConv(llvm::CallingConv::PreserveMost);
+  fn->setAttributes(IGM.constructInitialAttributes());
+
+  auto *entry = llvm::BasicBlock::Create(Ctx, "", fn);
+  llvm::IRBuilder<> builder(entry);
+
+  auto *obj = fn->getArg(0);
+
+  // Mask the object pointer to clear non-pointer bits (e.g., ObjC/tagged bits
+  // from bridge objects).
+  auto *objInt = builder.CreatePtrToInt(obj, i64Ty);
+  auto *maskedInt = builder.CreateAnd(
+      objInt, llvm::ConstantInt::get(i64Ty, pointerMask));
+  auto *cleanPtr = builder.CreateIntToPtr(maskedInt, ptrTy);
+
+  // Declare and call the target function (C calling convention).
+  auto *targetRetTy =
+      returnObject ? static_cast<llvm::Type *>(ptrTy) : voidTy;
+  auto *targetTy = llvm::FunctionType::get(targetRetTy, {ptrTy}, false);
+  auto targetCallee = Module.getOrInsertFunction(targetName, targetTy);
+  builder.CreateCall(targetCallee, {cleanPtr});
+
+  // For retain: return the original (unmasked) pointer.
+  // For release: return void.
+  if (returnObject)
+    builder.CreateRet(obj);
+  else
+    builder.CreateRetVoid();
+
+  return fn;
+}
+
+/// Emit direct retain/release functions as ARM64 inline assembly.
+static void emitDirectRetainReleaseARM64(IRGenModule &IGM) {
+  auto &Module = IGM.Module;
+  auto &Ctx = Module.getContext();
+
+  // Check whether any direct retain/release functions are referenced.
+  bool needRetain =
+      Module.getNamedValue("swift_retainDirect") != nullptr ||
+      Module.getNamedValue("swift_bridgeObjectRetainDirect") != nullptr;
+  bool needRelease =
+      Module.getNamedValue("swift_releaseDirect") != nullptr ||
+      Module.getNamedValue("swift_bridgeObjectReleaseDirect") != nullptr;
+
+  if (!needRetain && !needRelease)
+    return;
+
+  // Determine target configuration.
+  auto *STI = IGM.TargetMachine->getMCSubtargetInfo();
+  bool useCAS = STI->checkFeatures("+lse");
+  bool objcInterop = IGM.ObjCInterop;
+
+  // If the deployment target guarantees the preservemost entrypoints exist,
+  // skip the fallback. Exclude macOS from this in order to support tools that
+  // build with a new deployment target but are run on older OS versions.
+  bool targetHasPreservemostRetainRelease =
+      !IGM.Triple.isMacOSX() &&
+      IGM.getAvailabilityRange().isContainedIn(
+          IGM.Context.getPreservemostRetainReleaseAvailability());
+
+  // ABI constants.
+  // The strong refcount field is at bit offset 33 within the refcount word:
+  // PureSwiftDealloc (1) + UnownedRefCount (31) + IsDeiniting (1) = 33.
+  const uint64_t strongRCOne = 1ULL << 33;
+  const uint64_t bridgeObjectPointerBits =
+      ~(uint64_t)SWIFT_ABI_ARM64_SWIFT_SPARE_BITS_MASK;
+
+  // Set up __retainRelease_slowpath_mask. This mask indicates when we must call
+  // into the runtime slowpath. If the object's refcount field has any bits set
+  // that are in the mask, then we must take the slow path. The variable is
+  // placed in a special section so the runtime can locate and override it. It
+  // is derived from the address of _swift_retainRelease_slowpath_mask_v1. The
+  // addend is set such that it has the correct value for older runtimes that
+  // don't have that symbol.
+  auto *slowpathMaskExtern = Module.getOrInsertGlobal(
+      "_swift_retainRelease_slowpath_mask_v1",
+      llvm::Type::getInt64Ty(Ctx));
+  if (auto *GV = llvm::dyn_cast<llvm::GlobalVariable>(slowpathMaskExtern)) {
+    GV->setLinkage(llvm::GlobalValue::ExternalWeakLinkage);
+  }
+
+  const char *maskName = "__retainRelease_slowpath_mask";
+  auto *maskTy = llvm::Type::getInt64Ty(Ctx);
+  auto *maskGV = new llvm::GlobalVariable(
+      Module, maskTy, /*isConstant=*/false,
+      llvm::GlobalValue::WeakODRLinkage,
+      /*Initializer=*/llvm::ConstantExpr::getAdd(
+          llvm::ConstantExpr::getPtrToInt(slowpathMaskExtern, maskTy),
+          llvm::ConstantInt::get(maskTy, 0x8000000000000000ULL)),
+      maskName);
+  maskGV->setAlignment(llvm::Align(8));
+  maskGV->setSection("__DATA,__swift5_rr_mask");
+  maskGV->setVisibility(llvm::GlobalValue::HiddenVisibility);
+  IGM.addUsedGlobal(maskGV);
+
+  // Create IR helper functions for the slowpath call frames. These are
+  // LLVM IR functions with preserve_most CC and the standard function
+  // attributes, so LLVM handles pointer authentication and register
+  // save/restore automatically.
+  if (!targetHasPreservemostRetainRelease) {
+    if (needRetain)
+      createCallFrameHelper(IGM, "swift_retain_callframe", "swift_retain",
+                            /*returnObject=*/true, bridgeObjectPointerBits);
+    if (needRelease)
+      createCallFrameHelper(IGM, "swift_release_callframe", "swift_release",
+                            /*returnObject=*/false, bridgeObjectPointerBits);
+  }
+  if (objcInterop) {
+    if (needRetain)
+      createCallFrameHelper(IGM, "swift_objc_retain_callframe", "objc_retain",
+                            /*returnObject=*/true, bridgeObjectPointerBits);
+    if (needRelease)
+      createCallFrameHelper(IGM, "swift_objc_release_callframe",
+                            "objc_release",
+                            /*returnObject=*/false, bridgeObjectPointerBits);
+  }
+
+  // --- Read the assembly template ---
+  auto &resourcePath = IGM.Context.SearchPathOpts.RuntimeResourcePath;
+  llvm::SmallString<128> asmPath(resourcePath);
+  llvm::sys::path::append(asmPath, "DirectRuntimeRetainRelease-arm64.s");
+
+  auto fs =
+      IGM.getSwiftModule()->getASTContext().SourceMgr.getFileSystem();
+  auto fileOrErr = fs->getBufferForFile(asmPath);
+  if (!fileOrErr) {
+    IGM.error(SourceLoc(),
+              "cannot read direct retain/release assembly template at '" +
+                  asmPath + "'");
+    return;
+  }
+
+  // --- Build the assembly preamble ---
+  std::string asmStr;
+  llvm::raw_string_ostream OS(asmStr);
+
+  // Emit a .set directive to define an assembler constant.
+  auto setConst = [&](const char *name, uint64_t value) {
+    OS << ".set " << name << ", " << value << "\n";
+  };
+
+  // Set parameters that the assembly template reads via .if conditionals.
+  setConst("USE_CAS", useCAS);
+  setConst("OBJC_INTEROP", objcInterop);
+  setConst("TARGET_HAS_PRESERVEMOST", targetHasPreservemostRetainRelease);
+  setConst("NEED_RETAIN", needRetain);
+  setConst("NEED_RELEASE", needRelease);
+  setConst("STRONG_RC_ONE", strongRCOne);
+  setConst("BRIDGEOBJECT_POINTER_BITS", bridgeObjectPointerBits);
+
+  // Append the assembly template.
+  OS << fileOrErr.get()->getBuffer();
+
+  OS.flush();
+  Module.appendModuleInlineAsm(asmStr);
+}
+
+void IRGenModule::emitDirectRuntimeAsm() {
+  if (!TargetInfo.HasSwiftSwiftDirectRuntimeLibrary ||
+      !getOptions().EnableSwiftDirectRetainRelease)
+    return;
+
+  if (Triple.getArch() == llvm::Triple::aarch64 && Triple.isOSDarwin())
+    emitDirectRetainReleaseARM64(*this);
+}

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1718,11 +1718,6 @@ void IRGenModule::addLinkLibraries() {
     registerLinkLibrary(
         LinkLibrary{"objc", LibraryKind::Library, /*static=*/false});
 
-  if (TargetInfo.HasSwiftSwiftDirectRuntimeLibrary &&
-      getOptions().EnableSwiftDirectRetainRelease)
-    registerLinkLibrary(LinkLibrary{"swiftSwiftDirectRuntime",
-                                    LibraryKind::Library, /*static=*/true});
-
   // If C++ interop is enabled, add -lc++ on Darwin and -lstdc++ on linux.
   // Also link with C++ bridging utility module (Cxx) and C++ stdlib overlay
   // (std) if available.
@@ -2106,6 +2101,7 @@ bool IRGenModule::finalize() {
     addUsedGlobal(ModuleHash);
   }
   emitLazyPrivateDefinitions();
+  emitDirectRuntimeAsm();
 
   // Finalize Swift debug info before running Clang codegen, because it may
   // delete the llvm module.

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -2076,6 +2076,7 @@ private:
                                         llvm::Type *overrideDeclType = nullptr);
 
   void emitLazyPrivateDefinitions();
+  void emitDirectRuntimeAsm();
   void addRuntimeResolvableType(GenericTypeDecl *nominal);
 
   /// Add all conformances of the given \c IterableDeclContext

--- a/stdlib/public/SwiftDirectRuntime/CMakeLists.txt
+++ b/stdlib/public/SwiftDirectRuntime/CMakeLists.txt
@@ -20,3 +20,34 @@ add_swift_target_library(swiftSwiftDirectRuntime
 
   INSTALL_IN_COMPONENT compiler
   INSTALL_WITH_SHARED)
+
+# The inline assembly template is read by the compiler at compile time and
+# emitted as module-level inline assembly. Copy it to the resource directory
+# (lib/swift/ and lib/swift_static/) so the compiler can find it.
+set(inline_asm_src "${CMAKE_CURRENT_SOURCE_DIR}/DirectRuntimeRetainRelease-arm64.s")
+set(inline_asm_filename "DirectRuntimeRetainRelease-arm64.s")
+
+set(inline_asm_dest "${SWIFTLIB_DIR}/${inline_asm_filename}")
+set(inline_asm_static_dest "${SWIFTSTATICLIB_DIR}/${inline_asm_filename}")
+
+add_custom_command(
+  OUTPUT "${inline_asm_dest}" "${inline_asm_static_dest}"
+  DEPENDS "${inline_asm_src}"
+  COMMAND "${CMAKE_COMMAND}" -E copy "${inline_asm_src}" "${inline_asm_dest}"
+  COMMAND "${CMAKE_COMMAND}" -E copy "${inline_asm_src}" "${inline_asm_static_dest}")
+
+add_custom_target(copy-direct-retain-release-inline-asm ALL
+  DEPENDS "${inline_asm_dest}" "${inline_asm_static_dest}"
+  SOURCES "${inline_asm_src}")
+
+swift_install_in_component(
+  FILES "${inline_asm_src}"
+  DESTINATION "lib/swift/"
+  COMPONENT compiler)
+
+if(SWIFT_BUILD_STATIC_STDLIB)
+  swift_install_in_component(
+    FILES "${inline_asm_src}"
+    DESTINATION "lib/swift_static/"
+    COMPONENT compiler)
+endif()

--- a/stdlib/public/SwiftDirectRuntime/DirectRuntimeRetainRelease-arm64.s
+++ b/stdlib/public/SwiftDirectRuntime/DirectRuntimeRetainRelease-arm64.s
@@ -1,0 +1,323 @@
+; DirectRuntimeRetainRelease-arm64.s - ARM64 asm for direct retain/release
+;
+; This file is read by the Swift compiler at compile time and emitted as
+; module-level inline assembly into each .o file. The functions use
+; .weak_definition so the linker coalesces duplicates.
+;
+; The compiler prepends .set directives to parameterize this assembly:
+;
+;   USE_CAS                      - 1 if the target has LSE atomics
+;   OBJC_INTEROP                 - 1 if ObjC interop is enabled
+;   TARGET_HAS_PRESERVEMOST      - 1 if the deployment target guarantees
+;                                  the preservemost retain/release entrypoints
+;   NEED_RETAIN                  - 1 if any retain functions are referenced
+;   NEED_RELEASE                 - 1 if any release functions are referenced
+;   STRONG_RC_ONE                - value of one strong refcount in the
+;                                  refcount field
+;   BRIDGEOBJECT_POINTER_BITS    - mask to extract the pointer from a
+;                                  BridgeObject value
+
+.subsections_via_symbols
+
+; preservemost retain/release entrypoints in the runtime. When the deployment
+; target doesn't guarantee they exist, use weak references.
+.if TARGET_HAS_PRESERVEMOST == 0
+  .weak_reference _swift_retain_preservemost
+  .weak_reference _swift_release_preservemost
+.endif
+
+.text
+.align 2
+
+; Enable target-specific instructions. Module-level inline asm doesn't inherit
+; target features from the LLVM module.
+.if USE_CAS
+  .arch_extension lse
+.endif
+
+
+; NOTE: we're using the preserve_most calling convention, so x9-15 are off
+; limits, in addition to the usual x19 and up. Any calls to functions that use
+; the standard calling convention need to save/restore x9-x15.
+
+
+; =============================================================================
+; Release
+; =============================================================================
+
+; Emit the release functions if they're used. This is wrapped in .ifndef to
+; prevent duplicate labels when LTO concatenates module asm from multiple
+; translation units.
+.if NEED_RELEASE
+
+.ifndef _swift_releaseDirect
+
+.weak_definition _swift_bridgeObjectReleaseDirect
+.private_extern _swift_bridgeObjectReleaseDirect
+.weak_definition _swift_releaseDirect
+.private_extern _swift_releaseDirect
+
+.if OBJC_INTEROP
+
+_swift_bridgeObjectReleaseDirect:
+  ; If it's a tagged pointer, then we don't do anything.
+  tbz  x0, #63, LbridgeObjectReleaseNotTagged
+  ret
+LbridgeObjectReleaseNotTagged:
+  ; If the ObjC bit is set, call objc_release. Otherwise, mask out the
+  ; non-pointer bits and fall through to swift_releaseDirect.
+  tbnz  x0, #62, LbridgeObjectReleaseDirectObjC
+  and   x0, x0, BRIDGEOBJECT_POINTER_BITS
+
+.else ; !OBJC_INTEROP
+
+_swift_bridgeObjectReleaseDirect:
+  ; Mask out the non-pointer bits and fall through to swift_releaseDirect.
+  and   x0, x0, BRIDGEOBJECT_POINTER_BITS
+
+.endif ; OBJC_INTEROP
+
+; Ensure that the fallthrough into swift_releaseDirect works.
+.alt_entry _swift_releaseDirect
+_swift_releaseDirect:
+
+  ; RR of NULL or values with high bit set is a no-op.
+  cmp   x0, #0
+  b.le  Lrelease_ret
+
+  ; We'll operate on the address of the refcount field, which is 8 bytes into
+  ; the object.
+  add   x1, x0, #8
+
+  ; Load the current value in the refcount field when using CAS.
+.if USE_CAS
+  ldr x16, [x1]
+.endif
+
+  ; The compare-and-swap goes back to here when it needs to retry.
+Lrelease_retry:
+
+  ; Get the slow path mask and see if the refcount field has any of those bits
+  ; set.
+  adrp  x17, ___retainRelease_slowpath_mask@PAGE
+  ldr   x17, [x17, ___retainRelease_slowpath_mask@PAGEOFF]
+
+  ; Load-exclusive of the current value in the refcount field when using LLSC.
+  ; stxr does not update x16 like cas does, so this load must be inside the
+  ; loop. ldxr/stxr are not guaranteed to make forward progress if there are
+  ; memory accesses between them, so we need to do this after getting the mask
+  ; above.
+.if USE_CAS == 0
+  ldxr x16, [x1]
+.endif
+
+  tst   x16, x17
+
+  ; Also check if we're releasing with a refcount of 0. That will initiate
+  ; dealloc and requires calling the slow path. We don't try to decrement and
+  ; then call dealloc in that case. We'll just immediately go to the slow path
+  ; and let it take care of the entire operation.
+  mov   x17, #STRONG_RC_ONE
+  ccmp  x16, x17, #0x8, eq
+
+  ; If the refcount value matches the slow path mask, or the strong refcount
+  ; is zero, then go to the slow path.
+  b.lt  Lslowpath_release
+
+  ; We're good to proceed with the fast path. Compute the new value of the
+  ; refcount field.
+  sub   x17, x16, x17
+
+.if USE_CAS
+  ; Save a copy of the old value so we can determine if the CAS succeeded.
+  mov   x2, x16
+
+  ; Compare and swap the new value into the refcount field. Perform the
+  ; operation with release memory ordering so that dealloc on another thread
+  ; will see all stores performed on this thread prior to calling release.
+  casl  x16, x17, [x1]
+
+  ; The previous value of the refcount field is now in x16. We succeeded if
+  ; that value is the same as the old value we had before. If we failed, retry.
+  cmp   x2, x16
+  b.ne  Lrelease_retry
+.else ; !USE_CAS
+  ; Try to store the updated value.
+  stlxr  w16, x17, [x1]
+
+  ; On failure, retry.
+  cbnz  w16, Lrelease_retry
+.endif ; USE_CAS
+
+  ; On success, return.
+Lrelease_ret:
+  ret
+
+Lslowpath_release:
+.if USE_CAS == 0
+  clrex
+.endif
+.if TARGET_HAS_PRESERVEMOST
+  ; The deployment target guarantees this symbol exists.
+  b _swift_release_preservemost
+.else
+  ; If the weak preservemost symbol is NULL, call our helper. Otherwise call
+  ; the runtime directly.
+  adrp x17, _swift_release_preservemost@GOTPAGE
+  ldr  x17, [x17, _swift_release_preservemost@GOTPAGEOFF]
+  cbz x17, Lcall_swift_release
+  b _swift_release_preservemost
+  ; Branch to the IR helper function which saves/restores preserve_most
+  ; registers and calls the runtime.
+Lcall_swift_release:
+  b _swift_release_callframe
+.endif ; TARGET_HAS_PRESERVEMOST
+
+  ; ObjC release path.
+.if OBJC_INTEROP
+LbridgeObjectReleaseDirectObjC:
+  b _swift_objc_release_callframe
+.endif ; OBJC_INTEROP
+
+.endif ; .ifndef _swift_releaseDirect
+
+.endif ; NEED_RELEASE
+
+
+; =============================================================================
+; Retain
+; =============================================================================
+
+; Emit retain functions if they're used. Like with release, we wrap it in a
+; .ifndef to avoid multiple definitions.
+.if NEED_RETAIN
+
+.ifndef _swift_retainDirect
+
+.weak_definition _swift_bridgeObjectRetainDirect
+.private_extern _swift_bridgeObjectRetainDirect
+.weak_definition _swift_retainDirect
+.private_extern _swift_retainDirect
+
+.if OBJC_INTEROP
+
+_swift_bridgeObjectRetainDirect:
+  ; If it's a tagged pointer, then we don't do anything.
+  tbz  x0, #63, LbridgeObjectRetainNotTagged
+  ret
+LbridgeObjectRetainNotTagged:
+  ; If the ObjC bit is set, call objc_retain. Otherwise, fall through to
+  ; swift_retainDirect, which will tolerate and preserve any nonpointer bits
+  ; set in x0.
+  tbnz  x0, #62, Lswift_bridgeObjectRetainDirectObjC
+
+.alt_entry _swift_retainDirect
+
+.else ; !OBJC_INTEROP
+
+  ; When there's no ObjC interop, then swift_retainDirect works for
+  ; bridgeObjects too.
+  .set _swift_bridgeObjectRetainDirect, _swift_retainDirect
+
+.endif ; OBJC_INTEROP
+
+_swift_retainDirect:
+
+  ; RR of NULL or values with high bit set is a no-op.
+  cmp   x0, #0
+  b.le  Lretain_ret
+
+  ; Mask off spare bits that may have come in from bridgeObjectRetain. Keep the
+  ; original value in x0 since we have to return it.
+  and   x1, x0, BRIDGEOBJECT_POINTER_BITS
+
+  ; We'll operate on the address of the refcount field, which is 8 bytes into
+  ; the object.
+  add   x1, x1, #8
+
+  ; Load the current value of the refcount field when using CAS.
+.if USE_CAS
+  ldr   x16, [x1]
+.endif
+
+Lretain_retry:
+
+  ; Get the slow path mask and see if the refcount field has any of those bits
+  ; set.
+  adrp  x17, ___retainRelease_slowpath_mask@PAGE
+  ldr   x17, [x17, ___retainRelease_slowpath_mask@PAGEOFF]
+
+  ; Load-exclusive of the current value in the refcount field when using LLSC.
+  ; stxr does not update x16 like cas does, so this load must be inside the
+  ; loop. ldxr/stxr are not guaranteed to make forward progress if there are
+  ; memory accesses between them, so we need to do this after getting the mask
+  ; above.
+.if USE_CAS == 0
+  ldxr x16, [x1]
+.endif
+
+  ; Compute a refcount field with the strong refcount incremented.
+  mov   x3, #STRONG_RC_ONE
+  add   x3, x16, x3
+
+  ; Test the incremented value against the slowpath mask. This checks for both
+  ; the side table case and the overflow case, as the overflow sets the high
+  ; bit.
+  tst   x3, x17
+  b.ne  Lslowpath_retain
+
+.if USE_CAS
+  ; Save the old value so we can check if the CAS succeeded.
+  mov   x2, x16
+
+  ; Compare and swap the new value into the refcount field. Retain can use
+  ; relaxed memory ordering.
+  cas   x16, x3, [x1]
+
+  ; The previous value of the refcount field is now in x16. We succeeded if
+  ; that value is the same as the old value we had before. If we failed, retry.
+  cmp   x2, x16
+  b.ne  Lretain_retry
+.else ; !USE_CAS
+  ; Try to store the updated value.
+  stxr  w16, x3, [x1]
+
+  ; On failure, retry.
+  cbnz  w16, Lretain_retry
+.endif ; USE_CAS
+
+  ; If the store succeeds, return. Retain returns the object pointer being
+  ; retained, which is still in x0 at this point. bridgeObjectRetain returns
+  ; the unmasked pointer, which we've preserved in x0.
+Lretain_ret:
+  ret
+
+Lslowpath_retain:
+.if USE_CAS == 0
+  clrex
+.endif
+.if TARGET_HAS_PRESERVEMOST
+  ; The deployment target guarantees this symbol exists.
+  b _swift_retain_preservemost
+.else
+  ; If the weak preservemost symbol is NULL, call our helper. Otherwise call
+  ; the runtime directly.
+  adrp x17, _swift_retain_preservemost@GOTPAGE
+  ldr  x17, [x17, _swift_retain_preservemost@GOTPAGEOFF]
+  cbz x17, Lcall_swift_retain
+  b _swift_retain_preservemost
+  ; Branch to the IR helper function which saves/restores preserve_most
+  ; registers and calls the runtime.
+Lcall_swift_retain:
+  b _swift_retain_callframe
+.endif ; TARGET_HAS_PRESERVEMOST
+
+  ; ObjC retain path.
+.if OBJC_INTEROP
+Lswift_bridgeObjectRetainDirectObjC:
+  b _swift_objc_retain_callframe
+.endif ; OBJC_INTEROP
+
+.endif ; .ifndef _swift_retainDirect
+
+.endif ; NEED_RETAIN


### PR DESCRIPTION
The DirectRuntime static library poses difficulties at link time, as the build system may not know where to find the library. This is especially problematic when linking a Swift static library into an otherwise non-Swift target, as the linker will likely not be informed of the location of Swift support libraries.

Avoid this issue by emitting the direct runtime code (currently just retain/release) directly into the module rather than linking it from a separate library. Add GenDirectRuntime.cpp for managing this. When the module is finalized, we emit the direct functions as needed.

The functions are emitted as a mixture of module-level inline assembly and LLVM functions. The inline assembly is necessary to get the desired codegen for the fast paths. The slow path preservemost helpers are done with LLVM IR since their codegen is reasonable and they're less performance sensitive anyway.

Since we know the target for this specific module, we can take advantage of that and elide the preservemost weak symbol check when the target is known to always have that symbol.

rdar://174350641