### PR TITLE
Allow alloc_pack_metadata to be marked as [non_nested]

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Builder.swift
+++ b/SwiftCompilerSources/Sources/SIL/Builder.swift
@@ -253,13 +253,14 @@ public struct Builder {
     return notifyNew(allocPack.getAs(AllocPackInst.self))
   }
 
-  public func createAllocPackMetadata() -> AllocPackMetadataInst {
-    let allocPackMetadata = bridged.createAllocPackMetadata()
+  public func createAllocPackMetadata(nested: Bool = true) -> AllocPackMetadataInst {
+    let allocPackMetadata = bridged.createAllocPackMetadata(nested)
     return notifyNew(allocPackMetadata.getAs(AllocPackMetadataInst.self))
   }
 
-  public func createAllocPackMetadata(_ packType: Type) -> AllocPackMetadataInst {
-    let allocPackMetadata = bridged.createAllocPackMetadata(packType.bridged)
+  public func createAllocPackMetadata(_ packType: Type,
+                                      nested: Bool = true) -> AllocPackMetadataInst {
+    let allocPackMetadata = bridged.createAllocPackMetadata(packType.bridged, nested)
     return notifyNew(allocPackMetadata.getAs(AllocPackMetadataInst.self))
   }
 

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -1280,8 +1280,8 @@ struct BridgedBuilder{
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction
   createAllocStack(BridgedType type, bool hasDynamicLifetime, bool isLexical, bool isFromVarDecl, bool wasMoved) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createAllocPack(BridgedType type) const;
-  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createAllocPackMetadata() const;
-  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createAllocPackMetadata(BridgedType type) const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createAllocPackMetadata(bool isNested) const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createAllocPackMetadata(BridgedType type, bool isNested) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createAllocVector(BridgedValue capacity,
                                                                           BridgedType type) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createDeallocStack(BridgedValue operand) const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -2505,12 +2505,15 @@ BridgedInstruction BridgedBuilder::createAllocPack(BridgedType type) const {
   return {unbridged().createAllocPack(regularLoc(), type.unbridged())};
 }
 
-BridgedInstruction BridgedBuilder::createAllocPackMetadata() const {
-  return {unbridged().createAllocPackMetadata(regularLoc())};
+BridgedInstruction BridgedBuilder::createAllocPackMetadata(bool nested) const {
+  return {unbridged().createAllocPackMetadata(regularLoc(), std::nullopt,
+      swift::StackAllocationIsNested_t(nested))};
 }
 
-BridgedInstruction BridgedBuilder::createAllocPackMetadata(BridgedType type) const {
-  return {unbridged().createAllocPackMetadata(regularLoc(), type.unbridged())};
+BridgedInstruction BridgedBuilder::createAllocPackMetadata(BridgedType type,
+                                                           bool nested) const {
+  return {unbridged().createAllocPackMetadata(regularLoc(), type.unbridged(),
+      swift::StackAllocationIsNested_t(nested))};
 }
 
 BridgedInstruction BridgedBuilder::createDeallocStack(BridgedValue operand) const {

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -448,12 +448,15 @@ public:
   }
   AllocPackMetadataInst *
   createAllocPackMetadata(SILLocation loc,
-                          std::optional<SILType> elementType = std::nullopt) {
+                          std::optional<SILType> elementType = std::nullopt,
+                          StackAllocationIsNested_t isNested =
+                            StackAllocationIsNested) {
     return insert(new (getModule()) AllocPackMetadataInst(
         getSILDebugLocation(loc),
         elementType.value_or(
             SILType::getEmptyTupleType(getModule().getASTContext())
-                .getAddressType())));
+                .getAddressType()),
+        isNested));
   }
 
   AllocRefInst *createAllocRef(SILLocation Loc, SILType ObjectType,

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1087,7 +1087,9 @@ void SILCloner<ImplClass>::visitAllocPackMetadataInst(
     AllocPackMetadataInst *Inst) {
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   recordClonedInstruction(Inst, getBuilder().createAllocPackMetadata(
-                                    getOpLocation(Inst->getLoc())));
+                                    getOpLocation(Inst->getLoc()),
+                                    getOpType(Inst->getType()),
+                                    Inst->isStackAllocationNested()));
 }
 
 template<typename ImplClass>

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -2319,11 +2319,25 @@ class AllocPackMetadataInst final
           AllocationInst> {
   friend SILBuilder;
 
-  AllocPackMetadataInst(SILDebugLocation loc, SILType elementType)
+  USE_SHARED_UINT8;
+
+  AllocPackMetadataInst(SILDebugLocation loc, SILType elementType,
+                        StackAllocationIsNested_t isNested)
       : NullaryInstructionWithTypeDependentOperandsBase(
-            loc, {}, elementType.getAddressType()) {}
+            loc, {}, elementType.getAddressType()) {
+    sharedUInt8().AllocPackMetadataInst.isNested = bool(isNested);
+  }
 
 public:
+  StackAllocationIsNested_t isStackAllocationNested() const {
+    return StackAllocationIsNested_t(
+             sharedUInt8().AllocPackMetadataInst.isNested);
+  }
+
+  void setStackAllocationIsNested(StackAllocationIsNested_t isNested) {
+    sharedUInt8().AllocPackMetadataInst.isNested = bool(isNested);
+  }
+
   /// The instruction which may trigger on-stack pack metadata when IRGen
   /// lowering.
   SILInstruction *getIntroducer() { return getNextInstruction(); }
@@ -9854,6 +9868,7 @@ public:
   AllocPackMetadataInst *getAllocation() {
     return cast<AllocPackMetadataInst>(getOperand().getDefiningInstruction());
   }
+
   /// The instruction which may trigger on-stack pack metadata when IRGen
   /// lowering.
   SILInstruction *getIntroducer() { return getAllocation()->getIntroducer(); }

--- a/include/swift/SIL/SILNode.h
+++ b/include/swift/SIL/SILNode.h
@@ -246,6 +246,9 @@ protected:
       isBare : 1,   // Only used in AllocRefInst
       numTailTypes: NumAllocRefTailTypesBits);
 
+    SHARED_FIELD(AllocPackMetadataInst, uint8_t
+      isNested : 1);
+
     SHARED_FIELD(PartialApplyInst, uint8_t
                  isNested : 1);
 

--- a/lib/IRGen/GenOpaque.cpp
+++ b/lib/IRGen/GenOpaque.cpp
@@ -553,16 +553,86 @@ irgen::emitInitializeBufferWithCopyOfBufferCall(IRGenFunction &IGF,
   return call;
 }
 
+static llvm::Value *emitArraySizeInBytes(IRGenFunction &IGF,
+                                         Size eltSize,
+                                         llvm::Value *arrayLength) {
+  if (eltSize == Size(1)) {
+    return arrayLength;
+  } else {
+    return IGF.Builder.CreateMul(arrayLength, IGF.IGM.getSize(eltSize));
+  }
+}
+
+static llvm::Value *emitArraySizeInBytes(IRGenFunction &IGF,
+                                         llvm::Type *eltTy,
+                                         llvm::Value *arrayLength) {
+  auto eltSize = Size(IGF.IGM.DataLayout.getTypeAllocSize(eltTy));
+  return emitArraySizeInBytes(IGF, eltSize, arrayLength);
+}
+
+static Size getMaxVoluntaryStackAlloc(IRGenModule &IGM) {
+  return 16 * IGM.getPointerSize();
+}
+
+static bool isInEntryBlock(IRGenFunction &IGF) {
+  return IGF.Builder.GetInsertBlock() == &*IGF.CurFn->begin();
+}
+
+static bool isAcceptableStackAllocSize(IRGenFunction &IGF,
+                                       const llvm::APInt &size) {
+  return (isInEntryBlock(IGF) ||
+          size.ule(getMaxVoluntaryStackAlloc(IGF.IGM).getValue()));
+}
+
+static bool isAcceptableArrayStackAllocSize(IRGenFunction &IGF,
+                                            Size eltSize,
+                                            const llvm::APInt &arraySize) {
+  if (isInEntryBlock(IGF)) return true;
+
+  return (arraySize * eltSize.getValue()).ule(
+            getMaxVoluntaryStackAlloc(IGF.IGM).getValue());
+}
+
+StackAddress
+IRGenFunction::emitArrayStackAllocation(llvm::Type *eltTy,
+                                        llvm::Value *arrayLength,
+                                        Alignment align,
+                                        StackAllocationIsNested_t isNested,
+                                        const llvm::Twine &name) {
+  Size eltSize = Size(IGM.DataLayout.getTypeAllocSize(eltTy));
+
+  // Allocate constant-sized allocations directly in the LLVM frame.
+  // We limit this unless we're emitting in the entry block.
+  if (auto constantLength = dyn_cast<llvm::ConstantInt>(arrayLength)) {
+    if (isAcceptableArrayStackAllocSize(*this, eltSize,
+                                        constantLength->getValue())) {
+      return emitStaticArrayAlloca(eltTy, eltSize, constantLength, align, name);
+    }
+  }
+
+  // If this code is properly-nested, use a dynamic allocation path.
+  if (isNested) {
+    return emitDynamicAlloca(eltTy, arrayLength, align, AllowsTaskAlloc,
+                             /*mallocTypeId=*/nullptr, name);
+  }
+
+  // Otherwise, use the non-nested dynamic allocation method (generally
+  // malloc).
+  auto byteCount = emitArraySizeInBytes(*this, eltSize, arrayLength);
+  auto allocation = emitNonNestedStackAllocation(byteCount, align, name);
+  auto castedAddress =
+    Builder.CreateElementBitCast(allocation.getAddress(), eltTy);
+  return allocation.withAddress(castedAddress);
+}
+
 StackAddress
 IRGenFunction::emitStackAllocation(llvm::Value *size, Alignment align,
                                    StackAllocationIsNested_t isNested,
                                    const llvm::Twine &name) {
   // Allocate constant-sized allocations directly in the LLVM frame.
-  // We limit this to 16 words unless we're emitting in the entry block.
+  // We limit this unless we're emitting in the entry block.
   if (auto constantSize = dyn_cast<llvm::ConstantInt>(size)) {
-    bool isInEntryBlock = (Builder.GetInsertBlock() == &*CurFn->begin());
-    if (isInEntryBlock ||
-        constantSize->getValue().ule(16 * IGM.getPointerSize().getValue())) {
+    if (isAcceptableStackAllocSize(*this, constantSize->getValue())) {
       return emitStaticByteArrayAlloca(constantSize, align, name);
     }
   }
@@ -613,12 +683,21 @@ StackAddress
 IRGenFunction::emitStaticByteArrayAlloca(llvm::ConstantInt *size,
                                          Alignment align,
                                          const llvm::Twine &name) {
-  auto addr = createAlloca(IGM.Int8Ty, size, align, name);
+  return emitStaticArrayAlloca(IGM.Int8Ty, Size(1), size, align, name);
+}
+
+StackAddress
+IRGenFunction::emitStaticArrayAlloca(llvm::Type *eltTy, Size eltSize,
+                                     llvm::ConstantInt *arrayLength,
+                                     Alignment align,
+                                     const llvm::Twine &name) {
+  auto addr = createAlloca(eltTy, arrayLength, align, name);
 
   // The lifetime intrinsics require an i64 on all targets.
-  auto sizeForLifetime = size;
-  if (size->getType() != IGM.Int64Ty) {
-    sizeForLifetime = llvm::ConstantInt::get(IGM.Int64Ty, size->getZExtValue());
+  auto sizeForLifetime = arrayLength;
+  if (eltSize != Size(1) || arrayLength->getType() != IGM.Int64Ty) {
+    sizeForLifetime = llvm::ConstantInt::get(IGM.Int64Ty,
+                        eltSize.getValue() * arrayLength->getZExtValue());
   }
 
   Builder.CreateLifetimeStart(addr, sizeForLifetime);
@@ -699,13 +778,7 @@ StackAddress IRGenFunction::emitDynamicAlloca(llvm::Type *eltTy,
                                               const llvm::Twine &name) {
   // Async functions call task alloc.
   if (allowTaskAlloc && isAsync()) {
-    llvm::Value *byteCount;
-    auto eltSize = IGM.DataLayout.getTypeAllocSize(eltTy);
-    if (eltSize == 1) {
-      byteCount = arraySize;
-    } else {
-      byteCount = Builder.CreateMul(arraySize, IGM.getSize(Size(eltSize)));
-    }
+    llvm::Value *byteCount = emitArraySizeInBytes(*this, eltTy, arraySize);
     // The task allocator wants size increments in the multiple of
     // MaximumAlignment.
     byteCount = alignUpToMaximumAlignment(IGM.SizeTy, byteCount);
@@ -719,13 +792,7 @@ StackAddress IRGenFunction::emitDynamicAlloca(llvm::Type *eltTy,
     // NOTE: llvm does not support dynamic allocas in coroutines.
 
     // Compute the number of bytes to allocate.
-    llvm::Value *byteCount;
-    auto eltSize = IGM.DataLayout.getTypeAllocSize(eltTy);
-    if (eltSize == 1) {
-      byteCount = arraySize;
-    } else {
-      byteCount = Builder.CreateMul(arraySize, IGM.getSize(Size(eltSize)));
-    }
+    llvm::Value *byteCount = emitArraySizeInBytes(*this, eltTy, arraySize);
 
     auto alignment = llvm::ConstantInt::get(IGM.Int32Ty, align.getValue());
 
@@ -753,7 +820,7 @@ StackAddress IRGenFunction::emitDynamicAlloca(llvm::Type *eltTy,
 
   // Save the stack pointer if we are not in the entry block (we could be
   // executed more than once).
-  bool isInEntryBlock = (Builder.GetInsertBlock() == &*CurFn->begin());
+  bool isInEntryBlock = ::isInEntryBlock(*this);
   if (!isInEntryBlock) {
     stackRestorePoint = Builder.CreateIntrinsicCall(
         llvm::Intrinsic::stacksave,

--- a/lib/IRGen/GenPack.cpp
+++ b/lib/IRGen/GenPack.cpp
@@ -467,8 +467,9 @@ irgen::emitTypeMetadataPack(IRGenFunction &IGF, CanPackType packType,
 
   assert(packType->containsPackExpansionType());
   auto pack =
-      IGF.emitDynamicAlloca(IGF.IGM.TypeMetadataPtrTy, shape,
-                            IGF.IGM.getPointerAlignment(), AllowsTaskAlloc);
+      IGF.emitArrayStackAllocation(IGF.IGM.TypeMetadataPtrTy, shape,
+                                   IGF.IGM.getPointerAlignment(),
+                                   IGF.packMetadataIsNested);
 
   auto visitFn =
     [&](CanType eltTy, unsigned staticIndex,
@@ -607,8 +608,9 @@ irgen::emitWitnessTablePack(IRGenFunction &IGF, CanPackType packType,
 
   assert(packType->containsPackExpansionType());
   auto pack =
-      IGF.emitDynamicAlloca(IGF.IGM.WitnessTablePtrTy, shape,
-                            IGF.IGM.getPointerAlignment(), AllowsTaskAlloc);
+      IGF.emitArrayStackAllocation(IGF.IGM.WitnessTablePtrTy, shape,
+                                   IGF.IGM.getPointerAlignment(),
+                                   IGF.packMetadataIsNested);
 
   auto index = 0;
   auto visitFn = [&](CanType eltTy, unsigned staticIndex,
@@ -704,6 +706,10 @@ void IRGenFunction::eraseStackPackWitnessTableAlloc(StackAddress addr,
 }
 
 void IRGenFunction::withLocalStackPackAllocs(llvm::function_ref<void()> fn) {
+  // These scopes should always be properly nested.
+  llvm::SaveAndRestore<StackAllocationIsNested_t>
+    savedState(packMetadataIsNested, StackAllocationIsNested);
+
   auto oldSize = OutstandingStackPackAllocs.size();
   fn();
   SmallVector<StackPackAlloc, 2> allocs;
@@ -1414,8 +1420,9 @@ irgen::emitInducedTupleTypeMetadataPack(
   auto *shape = emitTupleTypeMetadataLength(IGF, tupleMetadata);
 
   auto pack =
-      IGF.emitDynamicAlloca(IGF.IGM.TypeMetadataPtrTy, shape,
-                            IGF.IGM.getPointerAlignment(), AllowsTaskAlloc);
+      IGF.emitArrayStackAllocation(IGF.IGM.TypeMetadataPtrTy, shape,
+                                   IGF.IGM.getPointerAlignment(),
+                                   IGF.packMetadataIsNested);
   auto elementForIndex =
     [&](llvm::Value *index) -> llvm::Value * {
       return irgen::emitTupleTypeMetadataElementType(IGF, tupleMetadata, index);

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -258,6 +258,11 @@ private:
   llvm::Value *AsyncCoroutineCurrentResume = nullptr;
   llvm::Value *AsyncCoroutineCurrentContinuationContext = nullptr;
 
+public:
+  /// Whether pack metadata allocations in the current scope are known to be
+  /// nested.
+  StackAllocationIsNested_t packMetadataIsNested = StackAllocationIsNested;
+
 protected:
   // Whether pack metadata stack promotion is disabled for this function in
   // particular.
@@ -317,6 +322,13 @@ public:
                                      StackAllocationIsNested,
                                    const llvm::Twine &name = "");
 
+  StackAddress emitArrayStackAllocation(llvm::Type *elementType,
+                                        llvm::Value *arraySize,
+                                        Alignment align,
+                                        StackAllocationIsNested_t isNested =
+                                          StackAllocationIsNested,
+                                        const llvm::Twine &name = "");
+
   /// Deallocate memory that was allocated with emitStackAllocation.
   ///
   /// Calling this is equivalent to calling whichever the appropriate
@@ -348,6 +360,11 @@ public:
   /// The memory should be deallocated with emitDeallocateStaticAlloca.
   StackAddress emitStaticAlloca(llvm::Type *ty, Size size, Alignment align,
                                 const llvm::Twine &name = "");
+  StackAddress emitStaticArrayAlloca(llvm::Type *ty,
+                                     Size eltSize,
+                                     llvm::ConstantInt *arraySize,
+                                     Alignment align,
+                                     const llvm::Twine &name = "");
   StackAddress emitStaticByteArrayAlloca(llvm::ConstantInt *size,
                                          Alignment align,
                                          const llvm::Twine &name = "");

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -6693,7 +6693,13 @@ void IRGenSILFunction::visitAllocPackInst(swift::AllocPackInst *i) {
   setLoweredStackAddress(i, addr);
 }
 
-void IRGenSILFunction::visitAllocPackMetadataInst(AllocPackMetadataInst *i) {}
+void IRGenSILFunction::visitAllocPackMetadataInst(AllocPackMetadataInst *i) {
+  // alloc_pack_metadata is meant to control pack metadata just for the
+  // next instruction. As long as we enter these scopes prior to
+  // every such instruction, we can just treat this as global state
+  // on the IGF.
+  packMetadataIsNested = i->isStackAllocationNested();
+}
 
 static void
 buildTailArrays(IRGenSILFunction &IGF,

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -1369,6 +1369,8 @@ StackAllocationIsNested_t SILInstruction::isStackAllocationNested() const {
     return PAI->isStackAllocationNested();
   } else if (auto ARI = dyn_cast<AllocRefInstBase>(this)) {
     return ARI->isStackAllocationNested();
+  } else if (auto API = dyn_cast<AllocPackMetadataInst>(this)) {
+    return API->isStackAllocationNested();
   } else {
     // TODO: implement for all remaining allocations
     return StackAllocationIsNested;
@@ -1383,6 +1385,8 @@ void SILInstruction::setStackAllocationIsNested(
     PAI->setStackAllocationIsNested(nested);
   } else if (auto ARI = dyn_cast<AllocRefInstBase>(this)) {
     ARI->setStackAllocationIsNested(nested);
+  } else if (auto API = dyn_cast<AllocPackMetadataInst>(this)) {
+    API->setStackAllocationIsNested(nested);
   } else if (!nested) {
     verificationFailure("setStackAllocationIsNested unimplemented for instruction",
                         this, [](SILPrintContext &ctx) {});

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1685,6 +1685,7 @@ public:
     *this << API->getType().getObjectType();
   }
   void visitAllocPackMetadataInst(AllocPackMetadataInst *APMI) {
+    printNonNested(APMI);
     *this << APMI->getType().getObjectType();
   }
 

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -5003,11 +5003,24 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
     break;
   }
   case SILInstructionKind::AllocPackMetadataInst: {
+    auto isNested = StackAllocationIsNested;
+    StringRef attributeName;
+    SourceLoc attributeLoc;
+    while (parseSILOptional(attributeName, attributeLoc, *this)) {
+      if (attributeName == "non_nested")
+        isNested = StackAllocationIsNotNested;
+      else {
+        P.diagnose(attributeLoc, diag::sil_invalid_attribute_for_instruction,
+                   attributeName, "alloc_pack_metadata");
+        return true;
+      }
+    }
+
     SILType Ty;
     if (parseSILType(Ty))
       return true;
 
-    ResultVal = B.createAllocPackMetadata(InstLoc, Ty);
+    ResultVal = B.createAllocPackMetadata(InstLoc, Ty, isNested);
     break;
   }
   case SILInstructionKind::AllocStackInst: {

--- a/test/SILOptimizer/stack-nesting-lowered.sil
+++ b/test/SILOptimizer/stack-nesting-lowered.sil
@@ -1,0 +1,40 @@
+// RUN: %target-sil-opt -sil-disable-input-verify -test-runner %s -o /dev/null 2>&1 | %FileCheck %s
+
+import Builtin
+import Swift
+
+sil_stage lowered
+
+struct VGStruct<each T> {}
+
+sil private @priority_helper : $@convention(thin) (UInt8, UInt8) -> () {
+bb0(%0 : $UInt8, %1 : $UInt8):
+  unreachable
+}
+
+// alloc_pack_metadata must be markable as non-nested
+// CHECK-LABEL: sil [ossa] @test_mark_alloc_pack_metadata_non_nested :
+// CHECK:         builtin "taskAddPriorityEscalationHandler"
+// CHECK-NEXT:    [[ALLOC:%.*]] = alloc_pack_metadata [non_nested] $()
+// CHECK-NEXT:    metatype $@thick VGStruct<Int, Int>.Type
+// CHECK-NEXT:    builtin "taskRemovePriorityEscalationHandler"
+// CHECK-NEXT:    dealloc_pack_metadata [[ALLOC]]
+// CHECK-LABEL: // end sil function 'test_mark_alloc_pack_metadata_non_nested'
+sil [ossa] @test_mark_alloc_pack_metadata_non_nested : $@convention(thin) @async () -> () {
+bb0:
+  specify_test "stack_nesting_fixup"
+
+  %fn = function_ref @priority_helper : $@convention(thin) (UInt8, UInt8) -> ()
+  %thick_fn = thin_to_thick_function %fn to $@noescape @callee_guaranteed (UInt8, UInt8) -> ()
+  %handler = builtin "taskAddPriorityEscalationHandler"(%thick_fn) : $UnsafeRawPointer
+
+  %a = alloc_pack_metadata $()
+  %metatype = metatype $@thick VGStruct<Int, Int>.Type
+
+  %out = builtin "taskRemovePriorityEscalationHandler"(%handler) : $()
+
+  dealloc_pack_metadata %a
+
+  %ret = tuple ()
+  return %ret : $()
+}


### PR DESCRIPTION
This is inserted by SIL passes and so may not always be properly nested with respect to non-unreorderable allocations such as async lets.

PR is missing IRGen testing, but that seems to be somewhat tricky because the instructions are normally automatically inserted.