### PR TITLE
[Concurrency] Harden async_taskgroup_dontLeakTasks test

### DIFF
--- a/test/Concurrency/Runtime/async_taskgroup_dontLeakTasks.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_dontLeakTasks.swift
@@ -9,6 +9,7 @@
 
 // UNSUPPORTED: back_deployment_runtime
 
+// Use this class to detect if the values are retained longer than necessary
 final class Something {
   let int: Int
   init(int: Int) {
@@ -27,6 +28,8 @@ func test_taskGroup_next() async {
 
     var sum = 0
     for await value in group {
+      // Uncomment to simulate a leak and verify the `leaks` detection actually works:
+      // _ = Unmanaged.passRetained(value)
       sum += value.int
     }
 

--- a/test/Concurrency/Runtime/async_taskgroup_dontLeakTasks.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_dontLeakTasks.swift
@@ -1,25 +1,18 @@
-// RUN: %target-run-simple-swift( -target %target-swift-5.1-abi-triple -parse-as-library) | %FileCheck %s
-// RUN: %target-run-simple-swift( -target %target-swift-5.1-abi-triple -parse-as-library -swift-version 5 -strict-concurrency=complete -enable-upcoming-feature NonisolatedNonsendingByDefault)  | %FileCheck %s
+// RUN: %target-run-simple-leaks-swift( -target %target-swift-5.1-abi-triple -parse-as-library)
+// RUN: %target-run-simple-leaks-swift( -target %target-swift-5.1-abi-triple -parse-as-library -swift-version 5 -strict-concurrency=complete -enable-upcoming-feature NonisolatedNonsendingByDefault)
 // REQUIRES: swift_feature_NonisolatedNonsendingByDefault
-// TODO: move to target-run-simple-leaks-swift once CI is using at least Xcode 14.3
-
-// Task group addTask is not supported in freestanding mode
-// UNSUPPORTED: freestanding
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
-
 // REQUIRES: concurrency_runtime
+// REQUIRES: OS=macosx
+
 // UNSUPPORTED: back_deployment_runtime
 
 final class Something {
   let int: Int
   init(int: Int) {
     self.int = int
-  }
-
-  deinit {
-    print("deinit, Something, int: \(self.int)")
   }
 }
 
@@ -36,13 +29,6 @@ func test_taskGroup_next() async {
     for await value in group {
       sum += value.int
     }
-
-
-    // CHECK-DAG: deinit, Something, int: 0
-    // CHECK-DAG: deinit, Something, int: 1
-    // CHECK-DAG: deinit, Something, int: 2
-    // CHECK-DAG: deinit, Something, int: 3
-    // CHECK-DAG: deinit, Something, int: 4
 
     return sum
   }

--- a/test/Concurrency/Runtime/async_taskgroup_dontLeakTasks.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_dontLeakTasks.swift
@@ -1,34 +1,76 @@
-// RUN: %target-run-simple-leaks-swift( -target %target-swift-5.1-abi-triple -parse-as-library)
-// RUN: %target-run-simple-leaks-swift( -target %target-swift-5.1-abi-triple -parse-as-library -swift-version 5 -strict-concurrency=complete -enable-upcoming-feature NonisolatedNonsendingByDefault)
-// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
+// RUN: %target-run-simple-swift( -target %target-swift-5.1-abi-triple -parse-as-library) | %FileCheck %s
+
+// Task group addTask is not supported in freestanding mode
+// UNSUPPORTED: freestanding
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 // REQUIRES: concurrency_runtime
-// REQUIRES: OS=macosx
-
 // UNSUPPORTED: back_deployment_runtime
+
+import _Concurrency
+
+actor SimpleCountDownLatch {
+  let from: Int
+  var count: Int
+
+  var continuations: [CheckedContinuation<Void, Never>] = []
+
+  init(from: Int) {
+    self.from = from
+    self.count = from
+  }
+
+  func hit() {
+    defer { count -= 1 }
+    if count == 0 {
+      fatalError("Counted down more times than expected! (From: \(from))")
+    } else if count == 1 {
+      for continuation in continuations {
+        continuation.resume()
+      }
+      continuations = []
+    }
+  }
+
+  func wait() async {
+    guard self.count > 0 else {
+      return // we're done
+    }
+
+    return await withCheckedContinuation { cc in
+      self.continuations.append(cc)
+    }
+  }
+}
 
 // Use this class to detect if the values are retained longer than necessary
 final class Something {
   let int: Int
-  init(int: Int) {
+  let latch: SimpleCountDownLatch
+
+  init(int: Int, latch: SimpleCountDownLatch) {
     self.int = int
+    self.latch = latch
+  }
+
+  deinit {
+    Task { [latch] in await latch.hit() }
   }
 }
 
-func test_taskGroup_next() async {
+func test_taskGroup_next(latch: SimpleCountDownLatch) async {
   let tasks = 5
   _ = await withTaskGroup(of: Something.self, returning: Int.self) { group in
     for n in 0..<tasks {
       group.addTask {
-        Something(int: n)
+        Something(int: n, latch: latch)
       }
     }
 
     var sum = 0
     for await value in group {
-      // Uncomment to simulate a leak and verify the `leaks` detection actually works:
+      // Uncomment to simulate a leak and verify the detection actually works:
       // _ = Unmanaged.passRetained(value)
       sum += value.int
     }
@@ -37,8 +79,43 @@ func test_taskGroup_next() async {
   }
 }
 
+// Wait until all instances have been released
+@available(SwiftStdlib 6.0, *)
+func waitForReleaseOrTimeout(latch: SimpleCountDownLatch) async {
+  await withTaskGroup(of: Bool.self) { group in
+    group.addTask {
+      await latch.wait()
+      return false // completed: not a timeout
+    }
+    group.addTask {
+      // 10s is far longer than the ms-scale deinit timing, so this never
+      // trips for a non-leak even on slow CI; woken early via cancelAll()
+      try? await Task.sleep(for: .seconds(10))
+      return true // timed out
+    }
+
+    let timedOut = await group.next()! // take first completed task
+    group.cancelAll() // wakeup the sleeping task
+
+    if timedOut {
+      print("LEAKED: not all Something instances were released")
+      fatalError("Leak detected: latch did not reach zero within deadline")
+    }
+  }
+}
+
+@available(SwiftStdlib 6.0, *)
 @main struct Main {
   static func main() async {
-    await test_taskGroup_next()
+    let tasks = 5
+    let latch = SimpleCountDownLatch(from: tasks)
+
+    // Taskgroup that returns some instances:
+    await test_taskGroup_next(latch: latch)
+
+    // Wait for the instances deinit to actually run:
+    await waitForReleaseOrTimeout(latch: latch)
+
+    print("done") // CHECK: done
   }
 }

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2844,15 +2844,33 @@ if not getattr(config, 'target_run_simple_swift', None):
            escape_for_substitute_captures(config.target_codesign),
            escape_for_substitute_captures(config.target_run))
     )
+    # This `leaks` runner is a bit more complicated than you might expect.
+    # This is because `leaks --atExit` works by injecting libLeaksAtExit.dylib
+    # into the child process via DYLD_INSERT_LIBRARIES. On macOS with SIP enabled,
+    # it strips all DYLD_* variables from SIP-protected binaries (/usr/bin/*, /usr/lib/*).
+    #
+    # This means that:
+    # 1) We can't use %target_run (which wraps the binary in /usr/bin/env
+    #    DYLD_LIBRARY_PATH=...) because `leaks`'s DYLD_INSERT_LIBRARIES would
+    #    be stripped from /usr/bin/env
+    # 2) The test binary links against /usr/lib/swift/*.dylib with absolute
+    #    paths, so it loads the system runtime instead of the just-built one
+    #
+    # So we would not be testing against the built-runtime, but against whatever
+    # the host's runtime libraries are.
+    #
+    # Instead, we use `install_name_tool` to rewrite /usr/lib/swift/* references
+    # to @rpath/*, so the binary's rpaths resolve to the just-built libraries.
     config.target_run_simple_leaks_swift_parameterized = SubstituteCaptures(
         r"%%empty-directory(%%t) && "
         r"%s %s %%s \1 -o %%t/a.out -module-name main  && "
+        r"otool -L %%t/a.out | "
+        r"""sed -n 's|^[[:space:]]*\(/usr/lib/swift/\(lib[^ ]*\)\).*|install_name_tool -change "\\1" "@rpath/\\2" %%t/a.out|p' | sh && """
         r"%s %%t/a.out && "
-        r"%s leaks --atExit -- %%t/a.out"
+        r"leaks --atExit -- %%t/a.out"
         % (escape_for_substitute_captures(config.target_build_swift),
            escape_for_substitute_captures(mcp_opt),
-           escape_for_substitute_captures(config.target_codesign),
-           escape_for_substitute_captures(config.target_run))
+           escape_for_substitute_captures(config.target_codesign))
     )
     config.target_fail_simple_swift_parameterized = SubstituteCaptures(
         r"%%empty-directory(%%t) && "
@@ -2909,9 +2927,11 @@ if not getattr(config, 'target_run_simple_swift', None):
     config.target_run_simple_leaks_swift = (
         '%%empty-directory(%%t) && '
         '%s %s %%s -o %%t/a.out -module-name main  && '
+        'otool -L %%t/a.out | '
+        """sed -n 's|^[[:space:]]*\\(/usr/lib/swift/\\(lib[^ ]*\\)\\).*|install_name_tool -change "\\1" "@rpath/\\2" %%t/a.out|p' | sh && """
         '%s %%t/a.out && '
-        '%s leaks --atExit -- %%t/a.out'
-        % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
+        'leaks --atExit -- %%t/a.out'
+        % (config.target_build_swift, mcp_opt, config.target_codesign))
     config.target_run_stdlib_swift = (
         '%%empty-directory(%%t) && '
         '%s %s %%s -o %%t/a.out -module-name main '

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2844,34 +2844,6 @@ if not getattr(config, 'target_run_simple_swift', None):
            escape_for_substitute_captures(config.target_codesign),
            escape_for_substitute_captures(config.target_run))
     )
-    # This `leaks` runner is a bit more complicated than you might expect.
-    # This is because `leaks --atExit` works by injecting libLeaksAtExit.dylib
-    # into the child process via DYLD_INSERT_LIBRARIES. On macOS with SIP enabled,
-    # it strips all DYLD_* variables from SIP-protected binaries (/usr/bin/*, /usr/lib/*).
-    #
-    # This means that:
-    # 1) We can't use %target_run (which wraps the binary in /usr/bin/env
-    #    DYLD_LIBRARY_PATH=...) because `leaks`'s DYLD_INSERT_LIBRARIES would
-    #    be stripped from /usr/bin/env
-    # 2) The test binary links against /usr/lib/swift/*.dylib with absolute
-    #    paths, so it loads the system runtime instead of the just-built one
-    #
-    # So we would not be testing against the built-runtime, but against whatever
-    # the host's runtime libraries are.
-    #
-    # Instead, we use `install_name_tool` to rewrite /usr/lib/swift/* references
-    # to @rpath/*, so the binary's rpaths resolve to the just-built libraries.
-    config.target_run_simple_leaks_swift_parameterized = SubstituteCaptures(
-        r"%%empty-directory(%%t) && "
-        r"%s %s %%s \1 -o %%t/a.out -module-name main  && "
-        r"otool -L %%t/a.out | "
-        r"""sed -n 's|^[[:space:]]*\(/usr/lib/swift/\(lib[^ ]*\)\).*|install_name_tool -change "\\1" "@rpath/\\2" %%t/a.out|p' | sh && """
-        r"%s %%t/a.out && "
-        r"leaks --atExit -- %%t/a.out"
-        % (escape_for_substitute_captures(config.target_build_swift),
-           escape_for_substitute_captures(mcp_opt),
-           escape_for_substitute_captures(config.target_codesign))
-    )
     config.target_fail_simple_swift_parameterized = SubstituteCaptures(
         r"%%empty-directory(%%t) && "
         r"%s %s %%s \1 -o %%t/a.out -module-name main  && "
@@ -2924,14 +2896,6 @@ if not getattr(config, 'target_run_simple_swift', None):
         '%s %%t/a.out && '
         '%s %%t/a.out'
         % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
-    config.target_run_simple_leaks_swift = (
-        '%%empty-directory(%%t) && '
-        '%s %s %%s -o %%t/a.out -module-name main  && '
-        'otool -L %%t/a.out | '
-        """sed -n 's|^[[:space:]]*\\(/usr/lib/swift/\\(lib[^ ]*\\)\\).*|install_name_tool -change "\\1" "@rpath/\\2" %%t/a.out|p' | sh && """
-        '%s %%t/a.out && '
-        'leaks --atExit -- %%t/a.out'
-        % (config.target_build_swift, mcp_opt, config.target_codesign))
     config.target_run_stdlib_swift = (
         '%%empty-directory(%%t) && '
         '%s %s %%s -o %%t/a.out -module-name main '
@@ -3069,9 +3033,6 @@ config.substitutions.append(('%target-swift-frontend', config.target_swift_front
 config.substitutions.append((r'%target-run-simple-swiftgyb\(([^)]+)\)',
                             config.target_run_simple_swiftgyb_parameterized))
 config.substitutions.append(('%target-run-simple-swiftgyb', config.target_run_simple_swiftgyb))
-config.substitutions.append((r'%target-run-simple-leaks-swift\(([^)]+)\)',
-                            config.target_run_simple_leaks_swift_parameterized))
-config.substitutions.append(('%target-run-simple-leaks-swift', config.target_run_simple_leaks_swift))
 config.substitutions.append((r'%target-run-simple-swift\(([^)]+)\)',
                             config.target_run_simple_swift_parameterized))
 config.substitutions.append((r'%target-fail-simple-swift\(([^)]+)\)',

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2844,6 +2844,16 @@ if not getattr(config, 'target_run_simple_swift', None):
            escape_for_substitute_captures(config.target_codesign),
            escape_for_substitute_captures(config.target_run))
     )
+    config.target_run_simple_leaks_swift_parameterized = SubstituteCaptures(
+        r"%%empty-directory(%%t) && "
+        r"%s %s %%s \1 -o %%t/a.out -module-name main  && "
+        r"%s %%t/a.out && "
+        r"%s leaks --atExit -- %%t/a.out"
+        % (escape_for_substitute_captures(config.target_build_swift),
+           escape_for_substitute_captures(mcp_opt),
+           escape_for_substitute_captures(config.target_codesign),
+           escape_for_substitute_captures(config.target_run))
+    )
     config.target_fail_simple_swift_parameterized = SubstituteCaptures(
         r"%%empty-directory(%%t) && "
         r"%s %s %%s \1 -o %%t/a.out -module-name main  && "
@@ -2895,6 +2905,12 @@ if not getattr(config, 'target_run_simple_swift', None):
         '%s %s %%s -o %%t/a.out -module-name main  && '
         '%s %%t/a.out && '
         '%s %%t/a.out'
+        % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
+    config.target_run_simple_leaks_swift = (
+        '%%empty-directory(%%t) && '
+        '%s %s %%s -o %%t/a.out -module-name main  && '
+        '%s %%t/a.out && '
+        '%s leaks --atExit -- %%t/a.out'
         % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
     config.target_run_stdlib_swift = (
         '%%empty-directory(%%t) && '
@@ -3033,6 +3049,9 @@ config.substitutions.append(('%target-swift-frontend', config.target_swift_front
 config.substitutions.append((r'%target-run-simple-swiftgyb\(([^)]+)\)',
                             config.target_run_simple_swiftgyb_parameterized))
 config.substitutions.append(('%target-run-simple-swiftgyb', config.target_run_simple_swiftgyb))
+config.substitutions.append((r'%target-run-simple-leaks-swift\(([^)]+)\)',
+                            config.target_run_simple_leaks_swift_parameterized))
+config.substitutions.append(('%target-run-simple-leaks-swift', config.target_run_simple_leaks_swift))
 config.substitutions.append((r'%target-run-simple-swift\(([^)]+)\)',
                             config.target_run_simple_swift_parameterized))
 config.substitutions.append((r'%target-fail-simple-swift\(([^)]+)\)',


### PR DESCRIPTION
We had to make this into println again but a bit more resilient with a latch to do the waiting...

Resolves rdar://174207235


---

> NOTE: we cannot use `leaks` on CI, so this below idea sadly had to be dropped.

This is more reliable than the deinit printing which often is flaky when CI is slow etc.

Outputs are rather nice as well:
```
# | Process 8318: 453 nodes malloced for 55 KB
# | Process 8318: 0 leaks for 0 total leaked bytes.
```

And if we actually have a leak:

```
# | Process 82548: 5 leaks for 160 total leaked bytes.
# |
# | STACK OF 5 INSTANCES OF 'ROOT LEAK: <Something>':
# | 10  libsystem_pthread.dylib               0x18b01ec10 start_wqthread + 8
# | 9   libsystem_pthread.dylib               0x18b01fe84 _pthread_wqthread + 232
# | 8   libdispatch.dylib                     0x18ae7b120 _dispatch_worker_thread2 + 184
# | 7   libdispatch.dylib                     0x18ae7a980 _dispatch_root_queue_drain + 360
# | 6   libswift_Concurrency.dylib            0x100dbd578 swift_job_runImpl(swift::Job*, swift::SerialExecutorRef) + 188  Actor.cpp:2229
# | 5   libswift_Concurrency.dylib            0x100dbbfd0 swift::runJobInEstablishedExecutorContext(swift::Job*, swift::SerialExecutorRef, swift::TaskExecutorRef) + 228  Actor.cpp:238
# | 4   a.out                                 0x100d114e8 closure #1 in closure #1 in test_taskGroup_next() + 72
# | 3   a.out                                 0x100d10be0 Something.__allocating_init(int:) + 44
# | 2   libswiftCore.dylib                    0x102968bc4 swift_allocObject + 64  HeapObject.cpp:275
# | 1   libswiftCore.dylib                    0x102968744 swift_slowAlloc + 48  Heap.cpp:94
# | 0   libsystem_malloc.dylib                0x18ae50178 _malloc_zone_malloc_instrumented_or_legacy + 152
# | ====
# |     5 (160 bytes) << TOTAL >>
# |       1 (32 bytes) ROOT LEAK: <Something 0x827028060> [32]
# |       1 (32 bytes) ROOT LEAK: <Something 0x827028080> [32]
# |       1 (32 bytes) ROOT LEAK: <Something 0x8270280a0> [32]
# |       1 (32 bytes) ROOT LEAK: <Something 0x8270280c0> [32]
# |       1 (32 bytes) ROOT LEAK: <Something 0x8270280e0> [32]
```

etc