### PR TITLE
Remove -enable-experimental-feature BorrowAndMutateAccessors from the core runtime library

### DIFF
--- a/Runtimes/Core/Core/CMakeLists.txt
+++ b/Runtimes/Core/Core/CMakeLists.txt
@@ -317,7 +317,6 @@ target_compile_options(swiftCore PRIVATE
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -enable-experimental-concise-pound-file>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature AddressableParameters>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature AddressableTypes>"
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature BorrowAndMutateAccessors>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature BorrowInout>"
   $<$<COMPILE_LANGUAGE:Swift>:-parse-stdlib>
   $<$<COMPILE_LANGUAGE:Swift>:-nostdimport>


### PR DESCRIPTION
This is a follow up to PR #88346 which removed this flag from the standard library. This is to avoid a condfail when building the standard library swift interfaces with compilers that don't support BorrowAndMutateAccessors in production compilers. Since it's enabled by default in main, this should behave the same but avoid printing the flag in the interfaces.