### PR TITLE
[cxx-interop] Fix missing dtor call for methods taking rvalue ref

### DIFF
--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1474,7 +1474,8 @@ public:
       return ParameterConvention::Indirect_In_Guaranteed;
     case ValueOwnership::Owned:
       if (kind == ConventionsKind::CFunction ||
-          kind == ConventionsKind::CFunctionType)
+          kind == ConventionsKind::CFunctionType ||
+          kind == ConventionsKind::CXXMethod)
         return getIndirectParameter(index, type, substTL);
       return ParameterConvention::Indirect_In;
     }

--- a/test/Interop/Cxx/reference/Inputs/print-special-members.h
+++ b/test/Interop/Cxx/reference/Inputs/print-special-members.h
@@ -19,3 +19,11 @@ struct Copyable {
 
 inline void byRValueRef(MoveOnly&& x) {}
 inline void byRValueRef(Copyable&& x) {}
+
+template <typename T>
+struct UniversalRef {
+  inline void byRValueRef(T &&x) {}
+};
+
+using UniversalMoveOnly = UniversalRef<MoveOnly>;
+using UniversalCopyable = UniversalRef<Copyable>;

--- a/test/Interop/Cxx/reference/rvalue-reference.swift
+++ b/test/Interop/Cxx/reference/rvalue-reference.swift
@@ -34,6 +34,20 @@ func moveOnly2() {
 // CHECK-DASH-ONONE-NEXT: MoveOnly 2 destroyed
 }
 
+func moveOnly3() {
+    var u = UniversalMoveOnly.init()
+    let x = MoveOnly()
+// CHECK-DASH-ONONE: MoveOnly 0 created
+// CHECK-DASH-O: MoveOnly 0 created
+    u.byRValueRef(consuming: x)
+// CHECK-DASH-ONONE-NEXT: MoveOnly 1 move-created
+// CHECK-DASH-O-NEXT: MoveOnly 1 move-created
+// CHECK-DASH-ONONE-NEXT: MoveOnly 0 destroyed
+// CHECK-DASH-O-NEXT: MoveOnly 0 destroyed
+// CHECK-DASH-ONONE-NEXT: MoveOnly 1 destroyed
+// CHECK-DASH-O-NEXT: MoveOnly 1 destroyed
+}
+
 func copyable1() {
     let x = Copyable()
 // CHECK-DASH-ONONE-NEXT: Copyable 0 created
@@ -60,11 +74,27 @@ func copyable2() {
 // CHECK-DASH-O-NEXT: Copyable 0 destroyed
 }
 
+func copyable3() {
+    var u = UniversalCopyable.init()
+    let x = Copyable()
+// CHECK-DASH-ONONE-NEXT: Copyable 0 created
+// CHECK-DASH-O-NEXT: Copyable 0 created
+    u.byRValueRef(consuming: x)
+// CHECK-DASH-ONONE-NEXT: Copyable 1 copy-created
+// CHECK-DASH-O-NEXT: Copyable 1 copy-created
+// CHECK-DASH-ONONE-NEXT: Copyable 1 destroyed
+// CHECK-DASH-O-NEXT: Copyable 1 destroyed
+// CHECK-DASH-ONONE-NEXT: Copyable 0 destroyed
+// CHECK-DASH-O-NEXT: Copyable 0 destroyed
+}
+
 func main() {
     moveOnly1()
     moveOnly2()
+    moveOnly3()
     copyable1()
     copyable2()
+    copyable3()
 }
 
 main()


### PR DESCRIPTION
In C++, moved-from objects' dtors need to be invoked. Swift had some special logic in place to make sure this happens when an C++ object is consumed by a C++ function in Swift code. Unfortunately, this logic only applied to free functions but not to methods.

rdar://171011011