### PR TITLE
Optimizer: fix optimization of unconditional `cond_fail`s

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyCondFail.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyCondFail.swift
@@ -15,23 +15,23 @@ import SIL
 extension CondFailInst : OnoneSimplifiable, SILCombineSimplifiable {
   func simplify(_ context: SimplifyContext) {
 
+    if let literal = condition as? IntegerLiteralInst, let value = literal.value {
+      if value == 0 {
+        // Eliminates
+        // ```
+        //   %0 = integer_literal 0
+        //   cond_fail %0, "message"
+        // ```
+        context.erase(instruction: self)
+      }
+      // Even if `shouldRemoveCondFail` is true, we don't want to remove unconditioal fails,
+      // i.e. `cond_fail` with a non-zero condition, because this would prevent removing dead
+      // code after such a `cond_fail` in a later optimization.
+      return
+    }
+
     if context.options.shouldRemoveCondFail(withMessage: message, inFunction: parentFunction.name) {
       context.erase(instruction: self)
-      return
     }
-
-    // Eliminates
-    // ```
-    //   %0 = integer_literal 0
-    //   cond_fail %0, "message"
-    // ```
-    guard let literal = condition as? IntegerLiteralInst,
-          let value = literal.value,
-          value == 0
-    else {
-      return
-    }
-
-    context.erase(instruction: self)
   }
 }

--- a/lib/SILOptimizer/Utils/CastOptimizer.cpp
+++ b/lib/SILOptimizer/Utils/CastOptimizer.cpp
@@ -1343,6 +1343,23 @@ CastOptimizer::optimizeCheckedCastBranchInst(CheckedCastBranchInst *Inst) {
   return nullptr;
 }
 
+static bool isPrecededByUnconditionalFail(SILInstruction *inst) {
+  // It's fine to just check the previous instruction (and not all preceding
+  // instructions in the block), because - even if another SILCombine optimization
+  // inserts an instruction between the `cond_fail` and the cast - it will not
+  // end in an infinite optimization loop. In worst case two cond_fail instructions
+  // will be generated.
+  if (SILInstruction *pred = inst->getPreviousInstruction()) {
+    if (auto *cf = dyn_cast<CondFailInst>(pred)) {
+      if (auto *literal = dyn_cast<IntegerLiteralInst>(cf->getOperand())) {
+        if (!literal->getValue().isZero())
+          return true;
+      }
+    }
+  }
+  return false;
+}
+
 ValueBase *CastOptimizer::optimizeUnconditionalCheckedCastInst(
     UnconditionalCheckedCastInst *Inst) {
   SILDynamicCastInst dynamicCast(Inst);
@@ -1353,6 +1370,10 @@ ValueBase *CastOptimizer::optimizeUnconditionalCheckedCastInst(
       dynamicCast.classifyFeasibility(false /*allowWholeModule*/);
 
   if (Feasibility == DynamicCastFeasibility::WillFail) {
+    // Check if the cast was already optimized.
+    if (isPrecededByUnconditionalFail(Inst))
+      return nullptr;
+
     // Remove the cast and insert a trap, followed by an
     // unreachable instruction.
     SILBuilderWithScope Builder(Inst, builderContext);
@@ -1543,6 +1564,10 @@ SILInstruction *CastOptimizer::optimizeUnconditionalCheckedCastAddrInst(
   }
 
   if (Feasibility == DynamicCastFeasibility::WillFail) {
+    // Check if the cast was already optimized.
+    if (isPrecededByUnconditionalFail(Inst))
+      return nullptr;
+
     // Remove the cast and insert a trap, followed by an
     // unreachable instruction.
     SILBuilderWithScope Builder(Inst, builderContext);

--- a/test/SILOptimizer/sil_combine_uncheck_ossa.sil
+++ b/test/SILOptimizer/sil_combine_uncheck_ossa.sil
@@ -15,6 +15,10 @@ class D : C {
 class E {
 }
 
+struct S {
+  var x: Int
+}
+
 // CHECK-LABEL: sil [ossa] @test_cond_fail
 // CHECK: bb0
 // CHECK-NEXT: tuple ()
@@ -22,6 +26,18 @@ class E {
 sil [ossa] @test_cond_fail : $@convention(thin) (Builtin.Int1) -> () {
 bb0(%0 : $Builtin.Int1):
   cond_fail %0 : $Builtin.Int1
+  %2 = tuple ()
+  return %2 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @dont_remove_unconditional_cond_fail :
+// CHECK:         %0 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:    cond_fail %0
+// CHECK:       } // end sil function 'dont_remove_unconditional_cond_fail'
+sil [ossa] @dont_remove_unconditional_cond_fail : $@convention(thin) () -> () {
+bb0:
+  %0 = integer_literal $Builtin.Int1, -1
+  cond_fail %0
   %2 = tuple ()
   return %2 : $()
 }
@@ -48,5 +64,45 @@ bb0(%0 : @owned $C):
   %3 = unconditional_checked_cast %0a : $C to C
   destroy_value %0 : $C
   return %3 : $C
+}
+
+// CHECK-LABEL: sil [ossa] @no_infinite_optimization_loop_with_failing_cast :
+// CHECK:         %2 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:    cond_fail %2
+// CHECK-NEXT:    unconditional_checked_cast_addr
+// CHECK:       } // end sil function 'no_infinite_optimization_loop_with_failing_cast'
+sil [ossa] @no_infinite_optimization_loop_with_failing_cast : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $S
+  %1 = alloc_stack $()
+  %2 = integer_literal $Builtin.Int1, -1
+  cond_fail %2, "failed cast"
+  unconditional_checked_cast_addr () in %1 to S in %0
+  dealloc_stack %1
+  dealloc_stack %0
+  %7 = tuple ()
+  return %7
+}
+
+// CHECK-LABEL: sil [ossa] @no_infinite_optimization_loop_with_failing_cast2 :
+// CHECK:         %2 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:    cond_fail %2
+// CHECK-NEXT:    debug_step
+// CHECK-NEXT:    %5 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:    cond_fail %5
+// CHECK-NEXT:    unconditional_checked_cast_addr
+// CHECK:       } // end sil function 'no_infinite_optimization_loop_with_failing_cast2'
+sil [ossa] @no_infinite_optimization_loop_with_failing_cast2 : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $S
+  %1 = alloc_stack $()
+  %2 = integer_literal $Builtin.Int1, -1
+  cond_fail %2, "failed cast"
+  debug_step
+  unconditional_checked_cast_addr () in %1 to S in %0
+  dealloc_stack %1
+  dealloc_stack %0
+  %7 = tuple ()
+  return %7
 }
 

--- a/test/SILOptimizer/simplify_cond_fail.sil
+++ b/test/SILOptimizer/simplify_cond_fail.sil
@@ -1,4 +1,5 @@
-// RUN: %target-sil-opt -enable-sil-verify-all %s -onone-simplification -simplify-instruction=cond_fail | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -onone-simplification -simplify-instruction=cond_fail | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-ASSERT
+// RUN: %target-sil-opt -enable-sil-verify-all %s -onone-simplification -simplify-instruction=cond_fail -remove-runtime-asserts | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-NOASSERT
 
 // REQUIRES: swift_in_compiler
 
@@ -32,9 +33,10 @@ bb0(%0 : @owned $String):
   unreachable
 }
 
-// CHECK-LABEL: sil @unknown
-// CHECK:         cond_fail
-// CHECK:       } // end sil function 'unknown'
+// CHECK-LABEL:        sil @unknown
+// CHECK-ASSERT:         cond_fail
+// CHECK-NOASSERT-NOT:   cond_fail
+// CHECK:              } // end sil function 'unknown'
 sil @unknown : $@convention(thin) (Builtin.Int1) -> () {
 bb0(%0 : $Builtin.Int1):
   cond_fail %0 : $Builtin.Int1, "unknown"


### PR DESCRIPTION
When the option `-remove-runtime-asserts` is used all `cond_fail` instructions are removed. However, the cast optimizer inserts such unconditional fails for failing casts. This ended up in an infinite optimization loop in SILCombine. The fix is
1. don't remove unconditional `cond_fail`s, even if with the `-remove-runtime-asserts` option. This also has the benefit that it enables later optimizations to remove all the dead code after such an unconditional `cond_fail`.
2. Don't optimize a failing cast if it is already preceded by an unconditional `cond_fail`

This bug was introduced by https://github.com/swiftlang/swift/pull/88258

Fixes a compiler hang
rdar://174185165
