### PR TITLE
AST: Filter out un-imported overrides when MemberImportVisibility is enabled

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2497,35 +2497,20 @@ static bool isAcceptableLookupResult(const DeclContext *dc, NLOptions options,
       return false;
   }
 
+  // Apply MemberImportVisibility restrictions.
   if (requireImport) {
-    // Check that there is some import in the originating context that makes
-    // this decl visible.
-    if (!(options & NL_IgnoreMissingImports)) {
-      if (!dc->isDeclImported(decl))
-        return false;
-    }
+    // If the options indicate that visibility should be enforced in this
+    // lookup, check if the decl is imported.
+    bool checkDeclImport = !(options & NL_IgnoreMissingImports);
 
-    // Unlike in Swift, Obj-C allows method overrides to be declared in
-    // extensions (categories), even outside of the module that defines the
-    // type that is being extended. When MemberImportVisibility is enabled,
-    // if these overrides are not filtered out they can hijack name
-    // lookup and cause the compiler to insist that the module that defines
-    // the extension be imported, contrary to developer expectations.
-    //
-    // Filter results belonging to these extensions out, even when ignoring
-    // missing imports, if we're in a context that requires imports to access
-    // member declarations.
-    if (decl->getOverriddenDecl()) {
-      if (auto *extension = dyn_cast<ExtensionDecl>(decl->getDeclContext())) {
-        if (auto *nominal = extension->getExtendedNominal()) {
-          auto extensionMod = extension->getModuleContext();
-          auto nominalMod = nominal->getModuleContext();
-          if (!extensionMod->isSameModuleLookingThroughOverlays(nominalMod) &&
-              !dc->isDeclImported(extension))
-            return false;
-        }
-      }
-    }
+    // Even when missing imports are being ignored, we still need to filter out
+    // overrides that haven't been imported. Otherwise, removeOverriddenDecls()
+    // could select a canonical declaration that hasn't been imported.
+    if (!checkDeclImport)
+      checkDeclImport |= (decl->getOverriddenDecl() != nullptr);
+
+    if (checkDeclImport && !dc->isDeclImported(decl))
+      return false;
   }
 
   // Check that it has the appropriate ABI role.

--- a/test/NameLookup/Inputs/MemberImportVisibility/Categories_A.h
+++ b/test/NameLookup/Inputs/MemberImportVisibility/Categories_A.h
@@ -1,15 +1,26 @@
 @import Foundation;
 
-@interface Base
+@interface Base : NSObject
 - (void)overriddenInOverlayForA __attribute__((deprecated("Categories_A.h")));
 - (void)overriddenInOverlayForB __attribute__((deprecated("Categories_A.h")));
 - (void)overriddenInOverlayForC __attribute__((deprecated("Categories_A.h")));
 - (void)overriddenInSubclassInOverlayForC __attribute__((deprecated("Categories_A.h")));
+- (void)witnessesObjCConformanceRequirementInA __attribute__((deprecated("Categories_A.h")));
+- (void)witnessesObjCConformanceRequirementInB __attribute__((deprecated("Categories_A.h")));
+- (void)witnessesObjCConformanceRequirementInC __attribute__((deprecated("Categories_A.h")));
 @end
 
 @interface X : Base
+@property (readonly, nonnull) NSObject *overriddenInCategoryWithMethodReturningOptional;
 @end
 
 @interface X (A)
 - (void)fromA;
+@end
+
+@protocol ObjCProtoInA
+- (void)witnessesObjCConformanceRequirementInA __attribute__((deprecated("ObjCProtoInA")));
+@end
+
+@interface Base () <ObjCProtoInA>
 @end

--- a/test/NameLookup/Inputs/MemberImportVisibility/Categories_B.h
+++ b/test/NameLookup/Inputs/MemberImportVisibility/Categories_B.h
@@ -3,3 +3,10 @@
 @interface X (B)
 - (void)fromB;
 @end
+
+@protocol ObjCProtoInB
+- (void)witnessesObjCConformanceRequirementInB __attribute__((deprecated("ObjCProtoInB")));
+@end
+
+@interface Base () <ObjCProtoInB>
+@end

--- a/test/NameLookup/Inputs/MemberImportVisibility/Categories_C.h
+++ b/test/NameLookup/Inputs/MemberImportVisibility/Categories_C.h
@@ -7,3 +7,14 @@
 @interface SubclassFromC : X
 - (instancetype)init;
 @end
+
+@protocol ObjCProtoInC
+- (void)witnessesObjCConformanceRequirementInC __attribute__((deprecated("ObjCProtoInC")));
+@end
+
+@interface Base () <ObjCProtoInC>
+@end
+
+@interface NSObject (Categories_C)
+- (nullable id)overriddenInCategoryWithMethodReturningOptional;
+@end

--- a/test/NameLookup/Inputs/MemberImportVisibility/members_A.swift
+++ b/test/NameLookup/Inputs/MemberImportVisibility/members_A.swift
@@ -68,6 +68,7 @@ public enum EnumInA {
 open class BaseClassInA {
   open func methodInA() {}
   open func overriddenMethod() {}
+  open func overriddenInBMethod() {}
 }
 
 public protocol ProtocolInA {

--- a/test/NameLookup/Inputs/MemberImportVisibility/members_B.swift
+++ b/test/NameLookup/Inputs/MemberImportVisibility/members_B.swift
@@ -54,6 +54,7 @@ package enum EnumInB_package {
 open class DerivedClassInB: BaseClassInA {
   open func methodInB() {}
   open override func overriddenMethod() {}
+  open override func overriddenInBMethod() {}
 }
 
 extension ProtocolInA {

--- a/test/NameLookup/member_import_visibility.swift
+++ b/test/NameLookup/member_import_visibility.swift
@@ -9,7 +9,7 @@
 // REQUIRES: swift_feature_MemberImportVisibility
 
 import members_C
-// expected-member-visibility-note 28{{add import of module 'members_B'}}{{1-1=internal import members_B\n}}
+// expected-member-visibility-note 30{{add import of module 'members_B'}}{{1-1=internal import members_B\n}}
 
 
 func testExtensionMembers(x: X, y: Y<Z>) {
@@ -158,6 +158,10 @@ func testInheritedMethods(
   a.overriddenMethod()
   b.overriddenMethod() // expected-member-visibility-error{{instance method 'overriddenMethod()' is not available due to missing import of defining module 'members_B'}}
   c.overriddenMethod()
+
+  a.overriddenInBMethod()
+  b.overriddenInBMethod() // expected-member-visibility-error{{instance method 'overriddenInBMethod()' is not available due to missing import of defining module 'members_B'}}
+  c.overriddenInBMethod() // expected-member-visibility-error{{instance method 'overriddenInBMethod()' is not available due to missing import of defining module 'members_B'}}
 }
 
 func testLeadingDotSyntax() {

--- a/test/NameLookup/member_import_visibility.swift
+++ b/test/NameLookup/member_import_visibility.swift
@@ -9,7 +9,7 @@
 // REQUIRES: swift_feature_MemberImportVisibility
 
 import members_C
-// expected-member-visibility-note 30{{add import of module 'members_B'}}{{1-1=internal import members_B\n}}
+// expected-member-visibility-note 27{{add import of module 'members_B'}}{{1-1=internal import members_B\n}}
 
 
 func testExtensionMembers(x: X, y: Y<Z>) {
@@ -156,12 +156,12 @@ func testInheritedMethods(
   c.methodInC()
 
   a.overriddenMethod()
-  b.overriddenMethod() // expected-member-visibility-error{{instance method 'overriddenMethod()' is not available due to missing import of defining module 'members_B'}}
+  b.overriddenMethod()
   c.overriddenMethod()
 
   a.overriddenInBMethod()
-  b.overriddenInBMethod() // expected-member-visibility-error{{instance method 'overriddenInBMethod()' is not available due to missing import of defining module 'members_B'}}
-  c.overriddenInBMethod() // expected-member-visibility-error{{instance method 'overriddenInBMethod()' is not available due to missing import of defining module 'members_B'}}
+  b.overriddenInBMethod()
+  c.overriddenInBMethod()
 }
 
 func testLeadingDotSyntax() {

--- a/test/NameLookup/member_import_visibility_objc.swift
+++ b/test/NameLookup/member_import_visibility_objc.swift
@@ -13,7 +13,7 @@
 import Categories_B
 import Categories_E
 
-// expected-member-visibility-note@-1 3 {{add import of module 'Categories_C'}}{{1-1=internal import Categories_C\n}}
+// expected-member-visibility-note@-1 2 {{add import of module 'Categories_C'}}{{1-1=internal import Categories_C\n}}
 // expected-member-visibility-note@-2 {{add import of module 'Categories_D'}}{{1-1=internal import Categories_D\n}}
 func test(x: X) {
   x.fromA()
@@ -43,8 +43,8 @@ func test(x: X) {
 
   let subclassFromC = makeSubclassFromC()
   subclassFromC.overriddenInSubclassInOverlayForC()
-  // expected-warning@-1 {{'overriddenInSubclassInOverlayForC()' is deprecated: Categories_C.swift}}
-  // expected-member-visibility-error@-2 {{instance method 'overriddenInSubclassInOverlayForC()' is not available due to missing import of defining module 'Categories_C'}}
+  // expected-no-member-visibility-warning@-1 {{'overriddenInSubclassInOverlayForC()' is deprecated: Categories_C.swift}}
+  // expected-member-visibility-warning@-2 {{'overriddenInSubclassInOverlayForC()' is deprecated: Categories_A.h}}
 }
 
 func testAnyObject(a: AnyObject) {

--- a/test/NameLookup/member_import_visibility_objc.swift
+++ b/test/NameLookup/member_import_visibility_objc.swift
@@ -19,17 +19,27 @@ func test(x: X) {
   x.fromA()
   x.fromOverlayForA()
   x.overriddenInOverlayForA() // expected-warning {{'overriddenInOverlayForA()' is deprecated: Categories_A.swift}}
+  x.witnessesObjCConformanceRequirementInA()
+  // expected-warning@-1 {{'witnessesObjCConformanceRequirementInA()' is deprecated: Categories_A.h}}
   x.fromB()
   x.fromOverlayForB()
   x.overriddenInOverlayForB() // expected-warning {{'overriddenInOverlayForB()' is deprecated: Categories_B.swift}}
+  x.witnessesObjCConformanceRequirementInB()
+  // expected-warning@-1 {{'witnessesObjCConformanceRequirementInB()' is deprecated: Categories_A.h}}
   x.fromC() // expected-member-visibility-error {{instance method 'fromC()' is not available due to missing import of defining module 'Categories_C'}}
   x.fromOverlayForC() // expected-member-visibility-error {{instance method 'fromOverlayForC()' is not available due to missing import of defining module 'Categories_C'}}
   x.overriddenInOverlayForC()
   // expected-no-member-visibility-warning@-1 {{'overriddenInOverlayForC()' is deprecated: Categories_C.swift}}
   // expected-member-visibility-warning@-2 {{'overriddenInOverlayForC()' is deprecated: Categories_A.h}}
+  x.witnessesObjCConformanceRequirementInC()
+  // expected-no-member-visibility-warning@-1 {{'witnessesObjCConformanceRequirementInC()' is deprecated: Categories_A.h}}
+  // expected-member-visibility-warning@-2 {{'witnessesObjCConformanceRequirementInC()' is deprecated: Categories_A.h}}
   x.fromSubmoduleOfD() // expected-member-visibility-error {{instance method 'fromSubmoduleOfD()' is not available due to missing import of defining module 'Categories_D'}}
   x.fromBridgingHeader()
   x.overridesCategoryMethodOnNSObject()
+  // rdar://172424054
+  let _: NSObject = x.overriddenInCategoryWithMethodReturningOptional
+  // expected-error@-1 {{cannot convert value of type '() -> Any?' to specified type 'NSObject'}}
 
   let subclassFromC = makeSubclassFromC()
   subclassFromC.overriddenInSubclassInOverlayForC()

--- a/test/NameLookup/member_import_visibility_objc_overrides.swift
+++ b/test/NameLookup/member_import_visibility_objc_overrides.swift
@@ -27,25 +27,22 @@
 //--- file1.swift
 
 import Root
-// expected-member-visibility-note 3 {{add import of module 'Branch'}}
-// expected-member-visibility-note@-1 2 {{add import of module 'Leaf'}}
-// expected-member-visibility-note@-2 2 {{add import of module 'Fruit'}}
 
 func testImportRoot_overridden1() {
   makeRootObject().overridden1()
   // expected-warning@-1 {{'overridden1()' is deprecated: Root.h}}
 
   makeBranchObject().overridden1()
-  // expected-warning@-1 {{'overridden1()' is deprecated: Branch.h}}
-  // expected-member-visibility-error@-2 {{instance method 'overridden1()' is not available due to missing import of defining module 'Branch'}}
+  // expected-no-member-visibility-warning@-1 {{'overridden1()' is deprecated: Branch.h}}
+  // expected-member-visibility-warning@-2 {{'overridden1()' is deprecated: Root.h}}
 
   makeLeafObject().overridden1()
-  // expected-warning@-1 {{'overridden1()' is deprecated: Leaf.h}}
-  // expected-member-visibility-error@-2 {{instance method 'overridden1()' is not available due to missing import of defining module 'Leaf'}}
+  // expected-no-member-visibility-warning@-1 {{'overridden1()' is deprecated: Leaf.h}}
+  // expected-member-visibility-warning@-2 {{'overridden1()' is deprecated: Root.h}}
 
   makeFruitObject().overridden1()
-  // expected-warning@-1 {{'overridden1()' is deprecated: Fruit.h}}
-  // expected-member-visibility-error@-2 {{instance method 'overridden1()' is not available due to missing import of defining module 'Fruit'}}
+  // expected-no-member-visibility-warning@-1 {{'overridden1()' is deprecated: Fruit.h}}
+  // expected-member-visibility-warning@-2 {{'overridden1()' is deprecated: Root.h}}
 }
 
 func testImportRoot_overridden2() {
@@ -70,16 +67,16 @@ func testImportRoot_overridden3() {
   // expected-warning@-1 {{'overridden3()' is deprecated: Root.h}}
 
   makeBranchObject().overridden3()
-  // expected-warning@-1 {{'overridden3()' is deprecated: Branch.h}}
-  // expected-member-visibility-error@-2 {{instance method 'overridden3()' is not available due to missing import of defining module 'Branch'}}
+  // expected-no-member-visibility-warning@-1 {{'overridden3()' is deprecated: Branch.h}}
+  // expected-member-visibility-warning@-2 {{'overridden3()' is deprecated: Root.h}}
 
   makeLeafObject().overridden3()
-  // expected-warning@-1 {{'overridden3()' is deprecated: Leaf.h}}
-  // expected-member-visibility-error@-2 {{instance method 'overridden3()' is not available due to missing import of defining module 'Leaf'}}
+  // expected-no-member-visibility-warning@-1 {{'overridden3()' is deprecated: Leaf.h}}
+  // expected-member-visibility-warning@-2 {{'overridden3()' is deprecated: Root.h}}
 
   makeFruitObject().overridden3()
-  // expected-warning@-1 {{'overridden3()' is deprecated: Branch.h}}
-  // expected-member-visibility-error@-2 {{instance method 'overridden3()' is not available due to missing import of defining module 'Branch'}}
+  // expected-no-member-visibility-warning@-1 {{'overridden3()' is deprecated: Branch.h}}
+  // expected-member-visibility-warning@-2 {{'overridden3()' is deprecated: Root.h}}
 }
 
 func testImportRoot_overridden4() {
@@ -95,16 +92,14 @@ func testImportRoot_overridden4() {
   // expected-member-visibility-warning@-2 {{'overridden4()' is deprecated: Root.h}}
 
   makeFruitObject().overridden4()
-  // expected-warning@-1 {{'overridden4()' is deprecated: Fruit.h}}
-  // expected-member-visibility-error@-2 {{instance method 'overridden4()' is not available due to missing import of defining module 'Fruit'}}
+  // expected-no-member-visibility-warning@-1 {{'overridden4()' is deprecated: Fruit.h}}
+  // expected-member-visibility-warning@-2 {{'overridden4()' is deprecated: Root.h}}
 }
 
 
 //--- file2.swift
 
 import Branch
-// expected-member-visibility-note 2 {{add import of module 'Leaf'}}
-// expected-member-visibility-note@-1 2 {{add import of module 'Fruit'}}
 
 func testImportBranch_overridden1() {
   makeRootObject().overridden1()
@@ -114,12 +109,12 @@ func testImportBranch_overridden1() {
   // expected-warning@-1 {{'overridden1()' is deprecated: Branch.h}}
 
   makeLeafObject().overridden1()
-  // expected-warning@-1 {{'overridden1()' is deprecated: Leaf.h}}
-  // expected-member-visibility-error@-2 {{instance method 'overridden1()' is not available due to missing import of defining module 'Leaf'}}
+  // expected-no-member-visibility-warning@-1 {{'overridden1()' is deprecated: Leaf.h}}
+  // expected-member-visibility-warning@-2 {{'overridden1()' is deprecated: Branch.h}}
 
   makeFruitObject().overridden1()
-  // expected-warning@-1 {{'overridden1()' is deprecated: Fruit.h}}
-  // expected-member-visibility-error@-2 {{instance method 'overridden1()' is not available due to missing import of defining module 'Fruit'}}
+  // expected-no-member-visibility-warning@-1 {{'overridden1()' is deprecated: Fruit.h}}
+  // expected-member-visibility-warning@-2 {{'overridden1()' is deprecated: Branch.h}}
 }
 
 func testImportBranch_overridden2() {
@@ -147,8 +142,8 @@ func testImportBranch_overridden3() {
   // expected-warning@-1 {{'overridden3()' is deprecated: Branch.h}}
 
   makeLeafObject().overridden3()
-  // expected-warning@-1 {{'overridden3()' is deprecated: Leaf.h}}
-  // expected-member-visibility-error@-2 {{instance method 'overridden3()' is not available due to missing import of defining module 'Leaf'}}
+  // expected-no-member-visibility-warning@-1 {{'overridden3()' is deprecated: Leaf.h}}
+  // expected-member-visibility-warning@-2 {{'overridden3()' is deprecated: Branch.h}}
 
   makeFruitObject().overridden3()
   // expected-warning@-1 {{'overridden3()' is deprecated: Branch.h}}
@@ -167,15 +162,14 @@ func testImportBranch_overridden4() {
   // expected-member-visibility-warning@-2 {{'overridden4()' is deprecated: Root.h}}
 
   makeFruitObject().overridden4()
-  // expected-warning@-1 {{'overridden4()' is deprecated: Fruit.h}}
-  // expected-member-visibility-error@-2 {{instance method 'overridden4()' is not available due to missing import of defining module 'Fruit'}}
+  // expected-no-member-visibility-warning@-1 {{'overridden4()' is deprecated: Fruit.h}}
+  // expected-member-visibility-warning@-2 {{'overridden4()' is deprecated: Root.h}}
 }
 
 
 //--- file3.swift
 
 import Leaf
-// expected-member-visibility-note 2 {{add import of module 'Fruit'}}
 
 func testImportLeaf_overridden1() {
   makeRootObject().overridden1()
@@ -188,8 +182,8 @@ func testImportLeaf_overridden1() {
   // expected-warning@-1 {{'overridden1()' is deprecated: Leaf.h}}
 
   makeFruitObject().overridden1()
-  // expected-warning@-1 {{'overridden1()' is deprecated: Fruit.h}}
-  // expected-member-visibility-error@-2 {{instance method 'overridden1()' is not available due to missing import of defining module 'Fruit'}}
+  // expected-no-member-visibility-warning@-1 {{'overridden1()' is deprecated: Fruit.h}}
+  // expected-member-visibility-warning@-2 {{'overridden1()' is deprecated: Branch.h}}
 }
 
 func testImportLeaf_overridden2() {
@@ -231,15 +225,14 @@ func testImportLeaf_overridden4() {
   // expected-warning@-1 {{'overridden4()' is deprecated: Leaf.h}}
 
   makeFruitObject().overridden4()
-  // expected-warning@-1 {{'overridden4()' is deprecated: Fruit.h}}
-  // expected-member-visibility-error@-2 {{instance method 'overridden4()' is not available due to missing import of defining module 'Fruit'}}
+  // expected-no-member-visibility-warning@-1 {{'overridden4()' is deprecated: Fruit.h}}
+  // expected-member-visibility-warning@-2 {{'overridden4()' is deprecated: Leaf.h}}
 }
 
 
 //--- file4.swift
 
 import Fruit
-// expected-member-visibility-note 2 {{add import of module 'Leaf'}}
 
 func testImportFruit_overridden1() {
   makeRootObject().overridden1()
@@ -249,8 +242,8 @@ func testImportFruit_overridden1() {
   // expected-warning@-1 {{'overridden1()' is deprecated: Branch.h}}
 
   makeLeafObject().overridden1()
-  // expected-warning@-1 {{'overridden1()' is deprecated: Leaf.h}}
-  // expected-member-visibility-error@-2 {{instance method 'overridden1()' is not available due to missing import of defining module 'Leaf'}}
+  // expected-no-member-visibility-warning@-1 {{'overridden1()' is deprecated: Leaf.h}}
+  // expected-member-visibility-warning@-2 {{'overridden1()' is deprecated: Branch.h}}
 
   makeFruitObject().overridden1()
   // expected-warning@-1 {{'overridden1()' is deprecated: Fruit.h}}
@@ -281,8 +274,8 @@ func testImportFruit_overridden3() {
   // expected-warning@-1 {{'overridden3()' is deprecated: Branch.h}}
 
   makeLeafObject().overridden3()
-  // expected-warning@-1 {{'overridden3()' is deprecated: Leaf.h}}
-  // expected-member-visibility-error@-2 {{instance method 'overridden3()' is not available due to missing import of defining module 'Leaf'}}
+  // expected-no-member-visibility-warning@-1 {{'overridden3()' is deprecated: Leaf.h}}
+  // expected-member-visibility-warning@-2 {{'overridden3()' is deprecated: Branch.h}}
 
   makeFruitObject().overridden3()
   // expected-warning@-1 {{'overridden3()' is deprecated: Branch.h}}

--- a/test/NameLookup/member_import_visibility_private_submodule.swift
+++ b/test/NameLookup/member_import_visibility_private_submodule.swift
@@ -1,0 +1,62 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -typecheck %t/main.swift %t/other.swift \
+// RUN:   -F %t/Frameworks \
+// RUN:   -enable-upcoming-feature MemberImportVisibility \
+// RUN:   -verify \
+// RUN:   -verify-additional-prefix member-visibility-
+
+// RUN: %target-swift-frontend -typecheck %t/main.swift %t/other.swift \
+// RUN:   -F %t/Frameworks \
+// RUN:   -verify \
+// RUN:   -verify-additional-prefix no-member-visibility-
+
+// REQUIRES: objc_interop
+// REQUIRES: swift_feature_MemberImportVisibility
+
+//--- Frameworks/ToasterKit.framework/Headers/ToasterKit.h
+#import <Foundation/Foundation.h>
+
+@interface Toaster : NSObject
+- (void)makeToast __attribute__((deprecated("ToasterKit.h")));
+@end
+
+//--- Frameworks/ToasterKit.framework/PrivateHeaders/ToasterKit_Private.h
+#import <ToasterKit/ToasterKit.h>
+
+@protocol ToastMaker
+- (void)makeToast __attribute__((deprecated("ToasterKit_Private.h")));
+@end
+
+@interface Toaster () <ToastMaker>
+@end
+
+
+//--- Frameworks/ToasterKit.framework/Modules/module.modulemap
+framework module ToasterKit {
+  umbrella header "ToasterKit.h"
+  export *
+  module * { export * }
+}
+
+//--- Frameworks/ToasterKit.framework/Modules/module.private.modulemap
+framework module ToasterKit_Private {
+  header "ToasterKit_Private.h"
+  export *
+}
+
+//--- main.swift
+
+import ToasterKit
+
+func test(t: Toaster) {
+  t.makeToast()
+  // expected-no-member-visibility-warning@-1 {{'makeToast()' is deprecated: ToasterKit.h}}
+  // expected-member-visibility-warning@-2 {{'makeToast()' is deprecated: ToasterKit.h}}
+}
+
+//--- other.swift
+
+import ToasterKit
+import ToasterKit_Private


### PR DESCRIPTION
When performing qualified lookup with `MemberImportVisibility` enabled, always filter out all overridden methods that come from modules that have not been imported. This ensures that new overrides of a method in dependencies are not source breaking for dependents with `MemberImportVisibility` enabled. This generalizes the logic added in https://github.com/swiftlang/swift/pull/81089 that was previously limited to overrides coming from Obj-C categories.

Resolves rdar://170089840.