### PR TITLE
Add a test for region isolation with parameter packs

### DIFF
--- a/test/Concurrency/transfernonsendable_parameter_packs.swift
+++ b/test/Concurrency/transfernonsendable_parameter_packs.swift
@@ -1,0 +1,98 @@
+// RUN: %target-swift-frontend -swift-version 5 -strict-concurrency=complete -target %target-swift-5.9-abi-triple -parse-as-library -emit-sil -o /dev/null -verify -verify-additional-prefix swift5- %s
+// RUN: %target-swift-frontend -swift-version 6 -target %target-swift-5.9-abi-triple -parse-as-library -emit-sil -o /dev/null -verify -verify-additional-prefix swift6- %s
+
+// REQUIRES: concurrency
+
+// https://github.com/apple/swift/issues/74688
+// Parameter packs should not interfere with region-based isolation.
+
+actor PackActor<each T> {
+  var messages : [(repeat each T)] = []
+
+  func message(_ num : repeat each T) {
+    messages.append((repeat each num))
+  }
+}
+
+func test_parameter_pack_actor_isolation_sendable() async {
+  let a = PackActor<Int>()
+  let value = 10
+
+  await a.message(value)
+}
+
+class NS {
+  var n = 0
+}
+
+func test_parameter_pack_actor_isolation_nonsendable() async {
+  let a = PackActor<NS>()
+  let value = NS()
+
+  await a.message(value)
+}
+
+func test_parameter_pack_actor_multi_sendable() async {
+  let a = PackActor<Int, String, Double>()
+
+  await a.message(1, "hello", 3.14)
+}
+
+func test_parameter_pack_actor_multi_nonsendable() async {
+  let a = PackActor<NS, NS>()
+  let p = NS()
+  let q = NS()
+
+  await a.message(p, q)
+}
+
+func test_parameter_pack_actor_mixed() async {
+  let a = PackActor<Int, NS, String>()
+  let ns = NS()
+
+  await a.message(1, ns, "hello")
+}
+
+func test_parameter_pack_actor_nonsendable_not_disconnected() async {
+  let a = PackActor<NS>()
+  let value = NS()
+
+  // TODO: https://github.com/swiftlang/swift/issues/88417
+  // The transfer non sendable pass should be updated to be able to find the name of packs.
+  await a.message(value) // expected-swift5-warning {{sending value of non-Sendable type 'NS' risks causing data races}}
+  // expected-swift6-error @-1 {{sending value of non-Sendable type 'NS' risks causing data races}}
+  // expected-note @-2 {{sending value of non-Sendable type 'NS' to actor-isolated instance method 'message' risks causing data races between actor-isolated and local nonisolated uses}}
+
+  print(value) // expected-note {{access can happen concurrently}}
+}
+
+func test_parameter_pack_actor_sendable_not_disconnected() async {
+  let a = PackActor<Int>()
+  let value = 10
+
+  await a.message(value)
+
+  print(value)
+}
+
+nonisolated(nonsending) func test_parameter_pack_actor_nonsending_nonsendable_not_disconnected() async {
+  let a = PackActor<NS>()
+  let value = NS()
+
+  // TODO: https://github.com/swiftlang/swift/issues/88417
+  // The transfer non sendable pass should avoid saying "local caller isolation inheriting-isolated".
+  await a.message(value) // expected-swift5-warning {{sending value of non-Sendable type 'NS' risks causing data races}}
+  // expected-swift6-error @-1 {{sending value of non-Sendable type 'NS' risks causing data races}}
+  // expected-note @-2 {{sending value of non-Sendable type 'NS' to actor-isolated instance method 'message' risks causing data races between actor-isolated and local caller isolation inheriting-isolated uses}}
+
+  print(value) // expected-note {{access can happen concurrently}}
+}
+
+nonisolated(nonsending) func test_parameter_pack_actor_nonsending_sendable_not_disconnected() async {
+  let a = PackActor<Int>()
+  let value = 10
+
+  await a.message(value)
+
+  print(value)
+}


### PR DESCRIPTION
Could fix the diagnostic in this PR but it seemed a little involved, need to teach `findRootValueForNonTupleTempAllocation` how to work with pack SIL.

Resolves rdar://131726749

<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
