### PR TITLE
Disable `test/IRGen/task_local_function_value_metadata.swift`

### DIFF
--- a/test/IRGen/task_local_function_value_metadata.swift
+++ b/test/IRGen/task_local_function_value_metadata.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend -primary-file %s -emit-ir -O -swift-version 5 -plugin-path %swift-plugin-dir -module-name main | %FileCheck %s
 
 // REQUIRES: concurrency
+// REQUIRES: rdar174207398
 
 @TaskLocal var taskLocal: (() -> Void)?
 


### PR DESCRIPTION
Disable `test/IRGen/task_local_function_value_metadata.swift` while we investigate failures on arm64.