### PR TITLE
SILGen: fix mismatch in expectations of substitution map

### DIFF
--- a/lib/SILGen/SILGenAvailability.cpp
+++ b/lib/SILGen/SILGenAvailability.cpp
@@ -185,7 +185,12 @@ static void emitBackDeployForwardApplyAndReturnOrThrow(
   SILFunctionConventions fnConv(silFnType, SGF.SGM.M);
 
   SILValue functionRef = SGF.emitGlobalFunctionRef(loc, function);
-  auto subs = SGF.F.getForwardingSubstitutionMap();
+
+  // Only if the callee is generic, provide a forwarding substitution map.
+  SubstitutionMap subs;
+  if (fnType->getInvocationGenericSignature())
+    subs = SGF.F.getForwardingSubstitutionMap();
+
   SmallVector<SILValue, 4> directResults;
 
   // If the function is a coroutine, we need to use 'begin_apply'.

--- a/test/SILGen/backdeployed.swift
+++ b/test/SILGen/backdeployed.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-emit-silgen %s
+
+// Exercises a SILGen code path that would trigger an assertion.
+
+public struct Anchor<Value> {}
+
+extension Anchor where Value == String {
+  @backDeployed(before: macOS 26.0)
+  public static func fixedGenericParam() -> Value {
+      return "hello"
+  }
+
+  @backDeployed(before: macOS 26.0)
+  public static func generic<T>(_ t: T) -> T {
+      return t
+  }
+}


### PR DESCRIPTION
The backdeployment thunk is calling into a method within a constrained extension, but it's constrained the generic parameter to a fixed type.

So, there is no invocation generic signature, thus no substitution map is expected by the assertion added in https://github.com/swiftlang/swift/pull/88160

resolves rdar://174437884
