### PR TITLE
Avoid inlining when substitution map has dynamic self

### DIFF
--- a/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
+++ b/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
@@ -15,6 +15,7 @@
 #include "swift/SILOptimizer/Analysis/IsSelfRecursiveAnalysis.h"
 #include "swift/SILOptimizer/Utils/PerformanceInlinerUtils.h"
 #include "swift/AST/Module.h"
+#include "swift/AST/SubstitutionMap.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/SILOptimizer/Utils/InstOptUtils.h"
 #include "llvm/Support/CommandLine.h"
@@ -839,6 +840,12 @@ SILFunction *swift::getEligibleFunction(FullApplySite AI,
     if (CalleeSelf != SILValue(CallerSelf)) {
       return nullptr;
     }
+  }
+
+  if (AI.hasSubstitutions()) {
+    auto Subs = AI.getSubstitutionMap();
+    if (Subs.getRecursiveProperties().hasDynamicSelf())
+      return nullptr;
   }
 
   // Detect self-recursive calls.

--- a/test/IRGen/Inputs/inline_dynamic_self_module.swift
+++ b/test/IRGen/Inputs/inline_dynamic_self_module.swift
@@ -1,0 +1,10 @@
+@inlinable @inline(__always)
+public func withWrapper<R>(_ body: @escaping (Int) -> R) -> R {
+    _withInner { x in body(x) }
+}
+
+@usableFromInline
+@inline(never)
+internal func _withInner<R>(_ body: (Int) -> R) -> R {
+    body(42)
+}

--- a/test/IRGen/inline_dynamic_self.swift
+++ b/test/IRGen/inline_dynamic_self.swift
@@ -1,0 +1,12 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -O -emit-module-path=%t/inline_dynamic_self_module.swiftmodule -module-name=inline_dynamic_self_module %S/Inputs/inline_dynamic_self_module.swift
+// RUN: %target-swift-frontend -I %t -O -emit-ir %s
+
+import inline_dynamic_self_module
+
+class C {
+    required init() {}
+    static func make() -> Self? {
+        withWrapper { _ in self.init() }
+    }
+}

--- a/test/SILOptimizer/specialize_dynamic_self.swift
+++ b/test/SILOptimizer/specialize_dynamic_self.swift
@@ -12,7 +12,7 @@ extension P {
 class C<T> : P {
   // CHECK-LABEL: sil shared [noinline] @$s23specialize_dynamic_self1CC11returnsSelfACyxGXDyFSi_Tg5 : $@convention(method) (@guaranteed C<Int>) -> @owned C<Int>
   // CHECK: [[RESULT:%.*]] = alloc_stack {{.*}}$C<Int>
-  // CHECK: [[FN:%.*]] = function_ref @$s23specialize_dynamic_self1PPAAE7method1yyF : $@convention(method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
+  // CHECK: [[FN:%.*]] = function_ref @$s23specialize_dynamic_self1PPAAE7method2yyF : $@convention(method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
   // CHECK: apply [[FN]]<@dynamic_self C<Int>>([[RESULT]]) : $@convention(method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
   // CHECK: return %0 : $C<Int>
   @inline(never)


### PR DESCRIPTION
This is a workaround to avoid missing lowering of dynamic_self in IRGen

Fixes rdar://174428100

