### PR TITLE
[Concurrency] Fix IRGen test for task-local metadata on ARM64

### DIFF
--- a/test/IRGen/task_local_function_value_metadata.swift
+++ b/test/IRGen/task_local_function_value_metadata.swift
@@ -1,13 +1,12 @@
 // RUN: %target-swift-frontend -primary-file %s -emit-ir -O -swift-version 5 -plugin-path %swift-plugin-dir -module-name main | %FileCheck %s
 
 // REQUIRES: concurrency
-// REQUIRES: rdar174207398
 
 @TaskLocal var taskLocal: (() -> Void)?
 
 // Verify that taskLocalValuePush uses the formal AST type metadata (Optional<() -> ()>, mangled as "yycSg"):
 // CHECK-LABEL: define hidden swiftcc void @"$s4main4testyyF"()
-// CHECK: %{{[0-9]+}} = tail call ptr @__swift_instantiateConcreteTypeFromMangledName(ptr nonnull @"$syycSgMD")
+// CHECK: %{{[0-9]+}} = {{(tail )?}}call ptr @__swift_instantiateConcreteTypeFromMangledName(ptr nonnull @"$syycSgMD")
 // CHECK: %{{[0-9]+}} = call swiftcc {} @swift_task_localValuePush(ptr %{{[0-9]+}}, ptr nonnull %{{[0-9]+}}, ptr %{{[0-9]+}})
 func test() {
   $taskLocal.withValue({}) {


### PR DESCRIPTION
The CHECK pattern expected `tail call` but LLVM only emits `tail call` on x86.

resolves rdar://174207398