### PR TITLE
[6.3.1][Test] Disable macro_swiftdeps.swift test case

### DIFF
--- a/test/Macros/macro_swiftdeps.swift
+++ b/test/Macros/macro_swiftdeps.swift
@@ -1,3 +1,4 @@
+// REQUIRES: rdar174235365
 // REQUIRES: swift_swift_parser
 
 // RUN: %empty-directory(%t)


### PR DESCRIPTION

**Explanation**: `macro_swiftdeps.swift` test may fail in Windows because of the bug in `libMockPlugin` where it doesn't set `_O_BINARY` to stdio. If a binary plugin message happens to contain `0x1A`, it's considered as an EOF, and the plugin exits, causing a test failure. Disable the test.
**Scope**: Macro plugin testing
**Risk**: Low. Just disabling the test case. It's testing a feature that is well tested in `release/6.3`. And `release/6.3.1` doesn't have any changes around the feature.
**Issue**: rdar://174235365
**Testing**: Passed the current test suite
**Reviewer**: TBA