### PR TITLE
utils: Unify Debug Format handling in build.ps1

### DIFF
--- a/docs/WindowsProfilingCompiler.md
+++ b/docs/WindowsProfilingCompiler.md
@@ -100,6 +100,6 @@ This section describes Windows profiling tools that can be used with the Swift c
 
 To build the Swift compiler with PDB format debug symbols that are used by profile analysis tools like WPA or Visual Studio, follow the https://github.com/compnerd/swift-build/blob/main/docs/WindowsQuickStart.md instructions, using the following `build.cmd` command line (or a variant on it based on your exact needs):
 
-`S:\SourceCache\swift\utils\build.cmd -Windows -DebugInfo -SkipPackaging -WindowsSDKArchitectures x64 -CDebugFormat codeview -SwiftDebugFormat codeview`
+`S:\SourceCache\swift\utils\build.cmd -Windows -DebugInfo -SkipPackaging -WindowsSDKArchitectures x64 -DebugFormat codeview`
 
 If you need to build a package that you can install on a separate Windows host, either remove `-SkipPackaging` in the above command, or if you've already run the above build, substitute `-SkipBuild` in place of `-SkipPackaging`.

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -62,13 +62,9 @@ Include debug information in the builds. Useful for debugging the toolchain
 itself.
 Note: This significantly increases build time and disk usage.
 
-.PARAMETER CDebugFormat
-The debug information format for C/C++ code. Valid values: dwarf, codeview.
-Default: dwarf
-
-.PARAMETER SwiftDebugFormat
-The debug information format for Swift code. Valid values: dwarf, codeview.
-Default: dwarf
+.PARAMETER DebugFormat
+The debug information format for. Valid values: dwarf, codeview.
+Default: codeview
 
 .PARAMETER Android
 Build Android SDKs. Requires Android NDK to be available.
@@ -179,9 +175,7 @@ param
   # Debug Information
   [switch] $DebugInfo,
   [ValidateSet("codeview", "dwarf")]
-  [string] $CDebugFormat = "dwarf",
-  [ValidateSet("codeview", "dwarf")]
-  [string] $SwiftDebugFormat = "dwarf",
+  [string] $DebugFormat = "codeview",
 
   # Android SDK Options
   [switch] $Android = $false,
@@ -1524,7 +1518,7 @@ function Build-CMakeProject {
           Add-KeyValueIfNew $Defines CMAKE_ASM_COMPILE_OPTIONS_MSVC_RUNTIME_LIBRARY_MultiThreadedDLL "/MD"
 
           if ($DebugInfo) {
-            $ASMDebugFlags = if ($CDebugFormat -eq "dwarf") {
+            $ASMDebugFlags = if ($DebugFormat -eq "dwarf") {
               if ($UseGNUDriver) { @("-gdwarf") } else { @("-clang:-gdwarf") }
             } else {
               if ($UseGNUDriver) { @("-gcodeview") } else { @("-clang:-gcodeview") }
@@ -1575,7 +1569,7 @@ function Build-CMakeProject {
 
           if ($DebugInfo) {
             if ($UsePinnedCompilers.Contains("C") -or $UseBuiltCompilers.Contains("C")) {
-              if ($CDebugFormat -eq "dwarf") {
+              if ($DebugFormat -eq "dwarf") {
                 $CFLAGS += if ($UseGNUDriver) {
                   @("-gdwarf")
                 } else {
@@ -1615,7 +1609,7 @@ function Build-CMakeProject {
 
           if ($DebugInfo) {
             if ($UsePinnedCompilers.Contains("CXX") -or $UseBuiltCompilers.Contains("CXX")) {
-              if ($CDebugFormat -eq "dwarf") {
+              if ($DebugFormat -eq "dwarf") {
                 $CXXFLAGS += if ($UseGNUDriver) {
                   @("-gdwarf")
                 } else {
@@ -1653,7 +1647,7 @@ function Build-CMakeProject {
           }
 
           $SwiftFlags += if ($DebugInfo) {
-            if ($SwiftDebugFormat -eq "dwarf") {
+            if ($DebugFormat -eq "dwarf") {
               @("-g", "-debug-info-format=dwarf", "-use-ld=lld-link", "-Xlinker", "/DEBUG:DWARF")
             } else {
               @("-g", "-debug-info-format=codeview", "-Xlinker", "/DEBUG")
@@ -1700,7 +1694,7 @@ function Build-CMakeProject {
             # `lld-link.exe` argument, not `link.exe`, so this can only be enabled when we use
             # `lld-link.exe` for linking.
             # TODO: Investigate supporting fission with PE/COFF, this should avoid this warning.
-            if ($SwiftDebugFormat -eq "dwarf" -and -not ($UseMSVCCompilers.Contains("C") -or $UseMSVCCompilers.Contains("CXX"))) {
+            if ($DebugFormat -eq "dwarf" -and -not ($UseMSVCCompilers.Contains("C") -or $UseMSVCCompilers.Contains("CXX"))) {
               Add-LinkerFlagsDefine $Defines @("/IGNORE:longsections")
             }
           }
@@ -1976,7 +1970,7 @@ function Build-SPMProject {
       "-c", $Configuration
     )
     if ($DebugInfo) {
-      if ($Platform.OS -eq [OS]::Windows -and $SwiftDebugFormat -eq "codeview") {
+      if ($Platform.OS -eq [OS]::Windows -and $DebugFormat -eq "codeview") {
         $Arguments += @("-debug-info-format", "codeview")
       } else {
         $Arguments += @("-debug-info-format", "dwarf")


### PR DESCRIPTION
Previously, it was possible to specify different debug formats for C/C++ and Swift code. In practice, binaries with both C/C++ and Swift code would end up only having one format over the other, depending on the exact project configuration. Since there is little value in having separate debug information format, this changes the build configuration to only have one debug format for both C/C++ and Swift code.

This also changes the default debug format to codeview. This is because some of the toolchain binaries now exceed 4 GiB of dwarf debug information, resulting in a build failure.