### PR TITLE
[6.3][Macros] Set binary I/O mode in MockPlugin in Windows 

### DIFF
--- a/tools/libMockPlugin/MockPlugin.cpp
+++ b/tools/libMockPlugin/MockPlugin.cpp
@@ -16,6 +16,10 @@
 #include "llvm/Support/JSON.h"
 
 #include <stdio.h>
+#if defined(_WIN32)
+#include <fcntl.h>
+#include <io.h>
+#endif
 
 namespace {
 struct TestItem {
@@ -191,6 +195,11 @@ TestItem *TestRunner::findMatchItem(const llvm::json::Value &req) {
 }
 
 int TestRunner::run() {
+#if defined(_WIN32)
+  // Set I/O to binary mode. Avoid CRLF translation, and Ctrl+Z (0x1A) as EOF.
+  _setmode(_fileno(stdin), _O_BINARY);
+  _setmode(_fileno(stdout), _O_BINARY);
+#endif
   size_t ioSize;
   while (true) {
     // Read request header.


### PR DESCRIPTION
Cherry-pick #88409 into `release/6.3`

**Explanation**: In Windows, stdin/stdout is "text" mode by default, where `0x1A` is considered EOF. `libMockPlugin` didn't set them to "binary" mode, so when a binary macro plugin message happens to contains it, the plugin exits silently and and the test fails. Set stdin/stdout "binary" mode instead.
**Scope**: Macro plugin testing
**Risk**: Low. `libMockPlugin` is a macro plugin testing tool and it only affects test cases.
**Issue**: rdar://174235365
**Testing**: Passes current test cases, and a known issue-reproducing case.
**Reviewer**: @hamishknight @compnerd 
