### PR TITLE
[IRGenDebugInfo][CodeView] Name inner type member in bound generic sized containers

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1693,8 +1693,12 @@ private:
       InnerTypeCache[UID] = llvm::TrackingMDNodeRef(UniqueType);
     }
 
+    // CodeView drops empty unnamed members, so we need to give the inner struct
+    // member a name so it survives.
+    StringRef MemberName = Opts.isDebugInfoCodeView() ? MangledName : "";
     llvm::Metadata *Elements[] = {DBuilder.createMemberType(
-        Scope, "", File, 0, SizeInBits, AlignInBits, 0, Flags, UniqueType)};
+        Scope, MemberName, File, 0, SizeInBits, AlignInBits, 0, Flags,
+        UniqueType)};
     // FIXME: It's a limitation of LLVM that a forward declaration cannot have a
     // specificationOf, so this attritbute is put on the sized container type
     // instead. This is confusing consumers, and LLDB has to go out of its way

--- a/test/DebugInfo/BoundGenericStruct.swift
+++ b/test/DebugInfo/BoundGenericStruct.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend %s -O -emit-ir -g -o - | %FileCheck %s
 // RUN: %target-swift-frontend %s -emit-ir -gdwarf-types -o - | %FileCheck %s --check-prefix=DWARF
+// RUN: %target-swift-frontend %s -O -emit-ir -g -debug-info-format=codeview -o - | %FileCheck %s --check-prefix=CV
 public struct S<T> {
   let t : T
 }
@@ -42,8 +43,13 @@ public let inner = S2<Double>.Inner(t:4.2)
 // DWARF-DAG: ![[PARAMS4]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Double"{{.*}} size: 64, {{.*}}runtimeLang: DW_LANG_Swift,{{.*}} identifier: "$sSdD")
 
 // DWARF-DAG: ![[SPECIFICATION:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Inner", {{.*}}elements: ![[ELEMENTS1:[0-9]+]], runtimeLang: DW_LANG_Swift, identifier: "$s18BoundGenericStruct2S2V5InnerVyx_GD")
-// DWARF-DAG: !DICompositeType(tag: DW_TAG_structure_type, {{.*}}line: 26, size: 64, {{.*}}specification: ![[SPECIFICATION]]
+// DWARF-DAG: !DICompositeType(tag: DW_TAG_structure_type, {{.*}}line: 27, size: 64, {{.*}}specification: ![[SPECIFICATION]]
 
 // DWARF-DAG: ![[ELEMENTS1]] = !{![[ELEMENTS2:[0-9]+]]}
 
 // DWARF-DAG: ![[ELEMENTS2]] = !DIDerivedType(tag: DW_TAG_member, name: "t"
+
+// In CodeView, the sized container's member is named with the mangled name
+// so that it survives CodeView emission (unnamed members are dropped).
+// CV: !DIDerivedType(tag: DW_TAG_member, name: "$s18BoundGenericStruct1SVySiGD", {{.*}}baseType: ![[INNER:[0-9]+]]
+// CV: ![[INNER]] = !DICompositeType(tag: DW_TAG_structure_type, name: "$s18BoundGenericStruct1SVySiGD", {{.*}}DIFlagFwdDecl


### PR DESCRIPTION
As a workaround for issues with uniquing, bound generics are emitted as a nested structure:
- A sized outer structure with no name or identifier
- A sizeless inner structure with the mangled name as the name and no identifier.

The actual mechanism of connection for the inner and outer structures is that the outer structure has a single unnamed member whose type is the inner structure.

However, LLVM CodeView emission treats unnamed members as anonymous structs and tries to inline their members into the parent. But since the inner struct has no members, the effect is that it gets dropped.

This change names the inner struct with the mangled type name. This will have the effect of preserving the inner struct in CodeView output, and allow us to use a variation of the DWARF logic at
https://github.com/swiftlang/llvm-project/blob/cd1235e59b87c84144802ab85592ee75a615f231/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp#L166 to recognize and handle this pattern.

More details and discussion at https://github.com/swiftlang/swift/issues/87093
