### PR TITLE
FreeBSD: Continue after test failures

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1413,6 +1413,8 @@ test-installable-package
 skip-test-lldb
 skip-test-swiftdocc
 
+continue-on-test-failure
+
 [preset: freebsd_package,no_test]
 mixin-preset=
   mixin_freebsd_package_products


### PR DESCRIPTION
Trying to maintain visibility on how all of the projects are doing by running as many of the test suites as we are able to build.
Adopting the continue-on-test-failure so that we have visible test failures for each project that can be filed as bug reports.
The flag was added recently in https://github.com/swiftlang/swift/pull/88364.

- Explanation:

Adopt the new continue-on-test-failure flag in build-script when building for FreeBSD to see all of the test failures in all of the projects instead of stopping at the first one.

- Scope:

This only impacts the FreeBSD test preset. It has no impact on currently supported platforms.

- Issues:

None

- Original PRs:

This is the main branch. This is the original PR.

- Risk:

None, this only impacts FreeBSD.

- Testing:

Local. The tests are already failing on FreeBSD. Trying to get through the full build to file bug reports.

- Reviewers:

This is the initial PR. It will be reviewed by the reviewers who review it.