### PR TITLE
[Concurrency] Harden the isolated_conformance_conditional_extension

### DIFF
--- a/test/IRGen/task_local_function_value_metadata.swift
+++ b/test/IRGen/task_local_function_value_metadata.swift
@@ -1,14 +1,13 @@
 // RUN: %target-swift-frontend -primary-file %s -emit-ir -O -swift-version 5 -plugin-path %swift-plugin-dir -module-name main | %FileCheck %s
 
 // REQUIRES: concurrency
-// REQUIRES: rdar174207398
 
 @TaskLocal var taskLocal: (() -> Void)?
 
 // Verify that taskLocalValuePush uses the formal AST type metadata (Optional<() -> ()>, mangled as "yycSg"):
-// CHECK-LABEL: define hidden swiftcc void @"$s4main4testyyF"()
-// CHECK: %{{[0-9]+}} = tail call ptr @__swift_instantiateConcreteTypeFromMangledName(ptr nonnull @"$syycSgMD")
-// CHECK: %{{[0-9]+}} = call swiftcc {} @swift_task_localValuePush(ptr %{{[0-9]+}}, ptr nonnull %{{[0-9]+}}, ptr %{{[0-9]+}})
+// CHECK-LABEL: define {{.*}}swiftcc void @"$s4main4testyyF"()
+// CHECK: call ptr @__swift_instantiateConcreteTypeFromMangledName{{.*}}@"$syycSg
+// CHECK: call swiftcc {} @swift_task_localValuePush(
 func test() {
   $taskLocal.withValue({}) {
     print("inside withValue")


### PR DESCRIPTION
This test running on different platforms may end up using different ways to get the metadata; x86 may use
__swift_instantiateConcreteTypeFromMangledNameV2 that looks like this:

```
%6 = tail call ptr @__swift_instantiateConcreteTypeFromMangledNameV2(ptr nonnull @"$syycSgMd", ptr nonnull @"$syycSgMR") #12
```

So we need to relax the CHECKs here a bit more


Resolves rdar://174207398 please merge with build wrangler powers @jrflat 