### PR TITLE
[android][test] Fix and reenable android-and-std-module.swift with `stat` from #88236

### DIFF
--- a/test/Interop/Cxx/stdlib/android-and-std-module.swift
+++ b/test/Interop/Cxx/stdlib/android-and-std-module.swift
@@ -4,15 +4,15 @@
 // RUN: %target-swift-frontend %s -c -cxx-interoperability-mode=default -Xcc -std=c++20 -Xcc -fmodules-cache-path=%t
 
 // Ensure that the pre-compiled modules are emitted.
-// RUN: ls %t/Android*.pcm
-// RUN: ls %t/std*.pcm
+// RUN: stat %t/*/SwiftAndroid-*.pcm
+// RUN: stat %t/*/std-*.pcm
 
 // RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend %s -c -cxx-interoperability-mode=default -Xcc -std=c++17 -Xcc -fmodules-cache-path=%t -DADD_CXXSTDLIB
 // RUN: %target-swift-frontend %s -c -cxx-interoperability-mode=default -Xcc -std=c++20 -Xcc -fmodules-cache-path=%t -DADD_CXXSTDLIB
 
-// REQUIRES: OS=linux-android-stat
+// REQUIRES: OS=linux-android || OS=linux-androideabi
 
 import Android
 import Bionic


### PR DESCRIPTION
This started failing after the removal of `find` because the clang modules are in temporary cache directories and the module is named `SwiftAndroid`. I enabled this test for armv7 also, after making sure it worked.

My understanding is that the release form is not needed for test fixes like this that only update the tests themselves, since they represent no risk to the toolchain.