### PR TITLE
[Swiftify][Embedded] don't print empty availability

### DIFF
--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -17,6 +17,7 @@
 #include "ImporterImpl.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTPrinter.h"
+#include "swift/AST/Attr.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticsClangImporter.h"
 #include "swift/AST/DiagnosticsSema.h"
@@ -116,9 +117,24 @@ public:
   void printAvailability() {
     if (!hasMacroParameter("spanAvailability"))
       return;
+
+    ValueDecl *D = getKnownSingleDecl(SwiftContext, "Span");
+    const SemanticAvailableAttributes availabilityAttrs =
+        D->getSemanticAvailableAttrs(/*includingInactive=*/true);
+    if (availabilityAttrs.empty())
+      return; // don't print availability when targeting embedded
+
     printSeparator();
     out << "spanAvailability: ";
-    printAvailabilityOfType("Span");
+    out << "\"";
+    llvm::SaveAndRestore<bool> hasAvailbilitySeparatorRestore(firstParam, true);
+    for (auto attr : availabilityAttrs) {
+      auto introducedOpt = attr.getIntroduced();
+      if (!introducedOpt.has_value()) continue;
+      printSeparator();
+      out << prettyPlatformString(attr.getPlatform()) << " " << introducedOpt.value();
+    }
+    out << "\"";
   }
 private:
   bool hasMacroParameter(StringRef ParamName) const {
@@ -126,19 +142,6 @@ private:
       if (Param->getArgumentName().str() == ParamName)
         return true;
     return false;
-  }
-
-  void printAvailabilityOfType(StringRef Name) {
-    ValueDecl *D = getKnownSingleDecl(SwiftContext, Name);
-    out << "\"";
-    llvm::SaveAndRestore<bool> hasAvailbilitySeparatorRestore(firstParam, true);
-    for (auto attr : D->getSemanticAvailableAttrs(/*includingInactive=*/true)) {
-      auto introducedOpt = attr.getIntroduced();
-      if (!introducedOpt.has_value()) continue;
-      printSeparator();
-      out << prettyPlatformString(attr.getPlatform()) << " " << introducedOpt.value();
-    }
-    out << "\"";
   }
 
 protected:

--- a/test/embedded/safe-interop-wrapper.swift
+++ b/test/embedded/safe-interop-wrapper.swift
@@ -1,0 +1,48 @@
+// REQUIRES: swift_feature_Lifetimes
+// REQUIRES: swift_feature_Embedded
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %t -enable-experimental-feature Lifetimes -strict-memory-safety %t/test.swift -enable-experimental-feature Embedded \
+// RUN:   -verify -verify-additional-file %t%{fs-sep}test.h -Rmacro-expansions -suppress-notes
+
+//--- test.h
+#pragma once
+
+#define __counted_by(x) __attribute__((__counted_by__(x)))
+#define __noescape __attribute__((noescape))
+
+// expected-expansion@+13:58{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_lifetime(p: copy p) @_disfavoredOverload public func simple(_ p: inout MutableSpan<Int32>) {|}}
+//   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
+//   expected-remark@4{{macro content: |    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {|}}
+//   expected-remark@5{{macro content: |        unsafe $0|}}
+//   expected-remark@6{{macro content: |    }|}}
+//   expected-remark@7{{macro content: |    defer {|}}
+//   expected-remark@8{{macro content: |        _fixLifetime(p)|}}
+//   expected-remark@9{{macro content: |    }|}}
+//   expected-remark@10{{macro content: |    return unsafe simple(len, _pPtr.baseAddress!)|}}
+//   expected-remark@11{{macro content: |}|}}
+// }}
+void simple(int len, int * __counted_by(len) __noescape p);
+
+//--- module.modulemap
+module Test {
+  header "test.h"
+}
+
+//--- test.swift
+// GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Test -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature Lifetimes -enable-experimental-feature Embedded > %t/Test-interface.swift && %swift-function-caller-generator Test %t/Test-interface.swift
+// GENERATED-HASH: 2b8bfdc1396a0dd0376855c2b2e2103e5b25c5430ddc4232d58e53ae5f4baff9
+import Test
+
+func call_simple(_ len: Int32, _ p: UnsafeMutablePointer<Int32>!) {
+  return unsafe simple(len, p)
+}
+
+@_lifetime(p: copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_simple(_ p: inout MutableSpan<Int32>) {
+  return simple(&p)
+}


### PR DESCRIPTION
Since 60d5ce8f195198196e0eed8a6ef6b4632417f1bf stdlib availability is substituted with an empty availability when targeting Embedded Swift, since availability is irrelevant when statically linked. This resulted in the _SwiftifyImport macro expansion emitting an `@available(, *)` annotation, which is syntactically invalid. Avoid this by simply not including an availability parameter.

The regression test is added to the `test/embedded` directory rather than the usual `test/Interop/C/swiftify-import` because the local lit config replaces the macOS 13 target with macOS 14 when targeting macOS, which is required for Embedded Swift standard library.

rdar://174341000

- **Explanation**:
Fixes regression when using safe interop in Embedded Swift targeting an Apple OS.
- **Scope**:
This should only affect Embedded Swift. Cases that would erroneously cause a compilation error now compile successfully.
- **Issues**:
rdar://174341000
- **Original PRs**:
me, I'm the original PR
- **Risk**:
Low risk, should only affect cases that would previously fail to compile
- **Testing**:
Tested using regression test.
- **Reviewers**:
whomstever'd this PR approveth