### PR TITLE
[cxx-interop] Fix compiler crashes due to unreachable FRT base definition

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -282,6 +282,9 @@ ERROR(foreign_reference_types_retain_release_not_a_function_decl, none,
 ERROR(foreign_reference_types_retain_release_not_an_instance_function, none,
       "specified %select{retain|release}0 function '%1' is a static function; expected an instance function",
       (bool, StringRef))
+ERROR(foreign_reference_type_unreachable, none,
+      "foreign reference type '%0' has unreachable definition",
+      (StringRef))
 
 GROUPED_WARNING(unannotated_cxx_func_returning_frt, ForeignReferenceType, none,
         "cannot infer ownership of foreign reference value returned by %0",

--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -614,6 +614,7 @@ struct CustomRefCountingOperationResult {
     immortal,
     notFound,
     tooManyFound,
+    unreachable,
     foundOperation
   };
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3009,6 +3009,16 @@ namespace {
         CustomRefCountingOperationResult retainOperation,
         CustomRefCountingOperationResult releaseOperation) {
 
+      if (retainOperation.kind ==
+              CustomRefCountingOperationResult::unreachable ||
+          releaseOperation.kind ==
+              CustomRefCountingOperationResult::unreachable) {
+        Impl.diagnose(HeaderLoc(decl->getLocation()),
+                      diag::foreign_reference_type_unreachable,
+                      classDecl->getNameStr());
+        return;
+      }
+
       enum class RetainReleaseOperationKind {
         notAfunction,
         notAnInstanceFunction,

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -3602,12 +3602,18 @@ SwiftDeclSynthesizer::addRefCountOperations(
     cloneReferenceAttributes(baseClangDecl, clangDecl, clangCtx);
     return std::make_pair(retainResult, releaseResult);
   }
-  if (!retainResult.operation || !releaseResult.operation)
+
+  auto getUnderlyingOp = [this](ValueDecl *op) -> const clang::FunctionDecl * {
+    if (!op)
+      return nullptr;
+    if (auto *original = this->ImporterImpl.getOriginalForClonedMember(op))
+      op = original;
+    return dyn_cast_or_null<clang::FunctionDecl>(op->getClangDecl());
+  };
+  auto *retainClangFn = getUnderlyingOp(retainResult.operation);
+  auto *releaseClangFn = getUnderlyingOp(releaseResult.operation);
+  if (!retainClangFn || !releaseClangFn)
     return std::make_pair(retainResult, releaseResult);
-  auto retainClangFn =
-      cast<clang::FunctionDecl>(retainResult.operation->getClangDecl());
-  auto releaseClangFn =
-      cast<clang::FunctionDecl>(releaseResult.operation->getClangDecl());
 
   // Synthesize forwarding function.
   auto &clangSema = ImporterImpl.getClangSema();

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -3618,8 +3618,23 @@ SwiftDeclSynthesizer::addRefCountOperations(
   if (!retainClangFn || !releaseClangFn)
     return std::make_pair(retainResult, releaseResult);
 
-  // Synthesize forwarding function.
   auto &clangSema = ImporterImpl.getClangSema();
+  {
+    clang::Sema::SFINAETrap trap(clangSema);
+    // The derived FRT and its FRT base must both have reachable definitions so
+    // that we can synthesize expressions that implicitly cast from one to the
+    // other (which requires knowing their layout).
+    if (!clangSema.hasReachableDefinition(
+            const_cast<clang::CXXRecordDecl *>(clangDecl)) ||
+        !clangSema.hasReachableDefinition(
+            const_cast<clang::CXXRecordDecl *>(baseClangDecl))) {
+      retainResult.kind = releaseResult.kind =
+          CustomRefCountingOperationResult::unreachable;
+      return std::make_pair(retainResult, releaseResult);
+    }
+  }
+
+  // Synthesize forwarding function.
 
   clang::QualType methodType = clangCtx.getFunctionType(
       clangCtx.VoidTy, {}, clang::FunctionProtoType::ExtProtoInfo{});

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -3233,9 +3233,8 @@ SwiftDeclSynthesizer::synthesizeStaticFactoryForCXXForeignRef(
         /*IsStdInitListInitialization=*/false,
         /*RequiresZeroInit=*/false, clang::CXXConstructionKind::Complete,
         clang::SourceRange());
-    assert(!synthCtorExprResult.isInvalid() &&
-           "Unable to synthesize constructor expression for c++ foreign "
-           "reference type");
+    if (synthCtorExprResult.isInvalid())
+      continue;
     clang::Expr *synthCtorExpr = synthCtorExprResult.get();
 
     clang::ExprResult synthNewExprResult = clangSema.BuildCXXNew(
@@ -3245,9 +3244,8 @@ SwiftDeclSynthesizer::synthesizeStaticFactoryForCXXForeignRef(
         cxxRecordDeclLoc, synthCtorExpr);
     // NOTE: ^ some valid location is needed here because BuildCXXNew uses that
     //       to determine the CXXNewInitializationStyle
-    assert(
-        !synthNewExprResult.isInvalid() &&
-        "Unable to synthesize `new` expression for c++ foreign reference type");
+    if (synthNewExprResult.isInvalid())
+      continue;
     auto *synthNewExpr = cast<clang::CXXNewExpr>(synthNewExprResult.get());
 
     clang::ReturnStmt *synthRetStmt =

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -3064,6 +3064,11 @@ SwiftDeclSynthesizer::synthesizeStaticFactoryForCXXForeignRef(
   clang::ASTContext &clangCtx = cxxRecordDecl->getASTContext();
   clang::Sema &clangSema = ImporterImpl.getClangSema();
 
+  if (clang::Sema::SFINAETrap trap(clangSema);
+      !clangSema.hasReachableDefinition(
+          const_cast<clang::CXXRecordDecl *>(cxxRecordDecl)))
+    return {};
+
   clang::QualType cxxRecordTy = clangCtx.getRecordType(cxxRecordDecl);
   clang::SourceLocation cxxRecordDeclLoc = cxxRecordDecl->getLocation();
 

--- a/test/Interop/Cxx/foreign-reference/frt-with-unreachable-definition.swift
+++ b/test/Interop/Cxx/foreign-reference/frt-with-unreachable-definition.swift
@@ -1,0 +1,167 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+//
+// Make sure we get diagnostics when FRT reachability is an issue:
+//
+// RUN: %target-swift-frontend -typecheck -verify %t%{fs-sep}verify.swift \
+// RUN:   -I %t%{fs-sep}Inputs -cxx-interoperability-mode=default \
+// RUN:   -disable-availability-checking \
+// RUN:   -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}FRTImpl.h \
+// RUN:   -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}OpsImpl.h \
+// RUN:   -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}CxxModule.h
+//
+// Make sure the program compiles when FRT reachability isn't an issue:
+//
+// RUN: %target-swift-frontend -typecheck %t/compile.swift \
+// RUN:   -I %t/Inputs -cxx-interoperability-mode=default \
+// RUN:   -disable-availability-checking
+
+//--- Inputs/module.modulemap
+module CxxModule {
+    textual header "Annotations.h"
+
+    // Full definitions of FRTBase and FRTDerived live here, but because this
+    // submodule is explicit, those definitions are not reachable to Swift when
+    // it has `import CxxModule`.
+    explicit module Definition {
+        header "FRTImpl.h"
+        export *
+    }
+
+    // Free-function retain/release for FRTOps live here.
+    explicit module OpsImpl {
+        header "OpsImpl.h"
+        export *
+    }
+
+    // What Swift "sees"
+    header "CxxModule.h"
+    export *
+}
+
+//--- Inputs/Annotations.h
+#pragma once
+
+#define SWIFT_SHARED_REFERENCE(_retain, _release)                              \
+  __attribute__((swift_attr("import_reference")))                              \
+  __attribute__((swift_attr("retain:" #_retain)))                              \
+  __attribute__((swift_attr("release:" #_release)))
+
+#define SWIFT_RETURNED_AS_UNRETAINED_BY_DEFAULT                                \
+  __attribute__((swift_attr("returned_as_unretained_by_default")))
+
+//--- Inputs/FRTImpl.h
+#pragma once
+#include <cstddef> // for size_t
+#include "Annotations.h"
+
+class FRTBasic {
+  mutable int m_count = 0;
+  FRTBasic(const FRTBasic &) = delete;
+  FRTBasic &operator=(const FRTBasic &) = delete;
+public:
+  FRTBasic() = default;
+  virtual ~FRTBasic() = default;
+  void ref() const;
+  void deref() const;
+  void *operator new(size_t size);
+  void operator delete(void *ptr);
+} SWIFT_SHARED_REFERENCE(.ref, .deref)
+  SWIFT_RETURNED_AS_UNRETAINED_BY_DEFAULT;
+
+template <typename T>
+class FRTBase {
+  mutable int m_count = 0;
+  FRTBase(const FRTBase &) = delete;
+  FRTBase &operator=(const FRTBase &) = delete;
+public:
+  FRTBase() = default;
+  virtual ~FRTBase() = default;
+  void ref() const { ++m_count; }
+  void deref() const {
+    if (--m_count < 0) __builtin_trap();
+    if (m_count == 0) delete static_cast<T *>(const_cast<FRTBase *>(this));
+  }
+  void *operator new(size_t size) { static FRTBase f{}; return &f; }
+  void operator delete(void *ptr) {}
+} SWIFT_SHARED_REFERENCE(.ref, .deref)
+  SWIFT_RETURNED_AS_UNRETAINED_BY_DEFAULT;
+
+// expected-error@+1 {{has unreachable definition}}
+class FRTDerived : public FRTBase<FRTDerived> {
+  FRTDerived(const FRTDerived &) = delete;
+  FRTDerived &operator=(const FRTDerived &) = delete;
+public:
+  FRTDerived() = default;
+  void *operator new(size_t size) { static FRTDerived f{}; return &f; }
+  void operator delete(void *ptr) {}
+};
+
+class FRTAnnotated : public FRTBase<FRTAnnotated> {
+  FRTAnnotated(const FRTAnnotated &) = delete;
+  FRTAnnotated &operator=(const FRTAnnotated &) = delete;
+public:
+  FRTAnnotated() = default;
+  void *operator new(size_t size) { static FRTAnnotated f{}; return &f; }
+  void operator delete(void *ptr) {}
+} SWIFT_SHARED_REFERENCE(.ref, .deref)
+  SWIFT_RETURNED_AS_UNRETAINED_BY_DEFAULT;
+
+//--- Inputs/OpsImpl.h
+#pragma once
+
+class FRTOps;
+
+void retainDirect(FRTOps *);
+void releaseDirect(FRTOps *);
+
+//--- Inputs/CxxModule.h
+#pragma once
+#include <cstddef>
+#include "Annotations.h"
+
+class FRTBasic;
+FRTBasic *makeFRTBasic();
+
+class FRTDerived;
+FRTDerived *makeFRTDerived();
+
+class FRTAnnotated;
+FRTAnnotated *makeFRTAnnotated();
+
+// FRTOps is fully defined here and thus reachable, but its retain/release
+// functions are only declared in the OpsImpl submodule and thus unreachable.
+// expected-error@+2 {{cannot find retain function 'retainDirect' for reference type 'FRTOps'}}
+// expected-error@+1 {{cannot find release function 'releaseDirect' for reference type 'FRTOps'}}
+class FRTOps {
+public:
+  FRTOps() = default;
+  void *operator new(size_t size);
+  void operator delete(void *ptr);
+} SWIFT_SHARED_REFERENCE(retainDirect, releaseDirect)
+  SWIFT_RETURNED_AS_UNRETAINED_BY_DEFAULT;
+
+FRTOps *makeFRTOps();
+
+//--- verify.swift
+import CxxModule
+
+let _ = makeFRTBasic()
+let _ = makeFRTDerived()
+let _ = makeFRTOps()
+let _ = makeFRTAnnotated()
+
+//--- compile.swift
+import CxxModule
+
+// This works because we support FRTs of forward-declared classes, as long as
+// they aren't FRTs as a result of inheritance.
+func makeBasic() -> FRTBasic {
+  return makeFRTBasic()
+}
+
+// This still works because even though FRTAnnotated inherits from an FRT base,
+// it has been re-annotated.
+func makeAnnotated() -> FRTAnnotated {
+  return makeFRTAnnotated()
+}


### PR DESCRIPTION
- **Explanation**: This patch set fixes assertion failures that arise from scenarios when those FRTs are both derived and have an unreachable definition.
- **Scope**: These fixes only affect the handling of foreign reference types
- **Issues**: rdar://172291423
- **Original PRs**: N/A
- **Risk**: Low
- **Testing**: Reproduced problem in test case, encountered three different compiler crashes (from roughly that same test case), fixed them all.
- **Reviewers**: (pending)