### PR TITLE
[cxx-interop] Import getSomething() lazily if not it isn't a property getter/setter

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -921,13 +921,22 @@ static bool areRecordFieldsComplete(const clang::CXXRecordDecl *decl) {
   return true;
 }
 
+static bool hasComputedPropertyAttr(const clang::Decl *decl) {
+  return decl->hasAttrs() && llvm::any_of(decl->getAttrs(), [](auto *attr) {
+           if (auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr))
+             return swiftAttr->getAttribute() == "import_computed_property";
+           return false;
+         });
+}
+
 /// Whether to import a member decl when importing its parent record.
 ///
 /// In theory this should just be isa<clang::FieldDecl>(decl), but currently
 /// various parts of ClangImporter still relies on eagerly importing non-field
 /// members (e.g., for deriving protocol conformances, etc.). This helper
 /// function encapsulates those edge cases.
-static bool shouldEagerlyImportClangRecordMember(const clang::NamedDecl *decl) {
+static bool shouldEagerlyImportClangRecordMember(const clang::NamedDecl *decl,
+                                                 const LangOptions &LangOpts) {
   // Look through using decls to determine whether to import decl
   while (auto *usd = dyn_cast<clang::UsingShadowDecl>(decl)) {
     // VisitUsingShadowDecl() only imports types and non-constructor methods,
@@ -967,9 +976,12 @@ static bool shouldEagerlyImportClangRecordMember(const clang::NamedDecl *decl) {
           return true;
 
         // Name lookup doesn't know about these renamed methods, import eagerly
-        if (CXXMethodBridging(md).classify() !=
-            CXXMethodBridging::Kind::unknown)
-          return true;
+        if (LangOpts.CxxInteropGettersSettersAsProperties ||
+            hasComputedPropertyAttr(fn)) {
+          if (CXXMethodBridging(md).classify() !=
+              CXXMethodBridging::Kind::unknown)
+            return true;
+        }
       }
 
       // All other functions can be imported lazily
@@ -981,7 +993,6 @@ static bool shouldEagerlyImportClangRecordMember(const clang::NamedDecl *decl) {
 
   return true;
 }
-
 
 namespace {
   /// Search the member tables for this class and its superclasses and try to
@@ -2597,7 +2608,8 @@ namespace {
 
         if (Impl.SwiftContext.LangOpts.hasFeature(
                 Feature::ImportCxxMembersLazily) &&
-            !shouldEagerlyImportClangRecordMember(nd))
+            !shouldEagerlyImportClangRecordMember(nd,
+                                                  Impl.SwiftContext.LangOpts))
           continue;
 
         Decl *member = Impl.importDecl(nd, getActiveSwiftVersion());
@@ -4592,14 +4604,6 @@ namespace {
 
       recordObjCOverride(result);
       Impl.swiftify(result);
-    }
-
-    static bool hasComputedPropertyAttr(const clang::Decl *decl) {
-      return decl->hasAttrs() && llvm::any_of(decl->getAttrs(), [](auto *attr) {
-               if (auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr))
-                 return swiftAttr->getAttribute() == "import_computed_property";
-               return false;
-             });
     }
 
     Decl *VisitCXXMethodDecl(const clang::CXXMethodDecl *decl) {

--- a/test/Interop/Cxx/class/invalid-members/function-members-with-invalid-types.swift
+++ b/test/Interop/Cxx/class/invalid-members/function-members-with-invalid-types.swift
@@ -61,6 +61,9 @@ struct GoodStruct {
   // expected-swift-note@+1 {{unavailable (cannot import)}}
   void badArg(Bro<Ken>) const;
 
+  // expected-swift-note@+1 * {{explicitly marked unavailable here}}
+  Bro<Ken> getBad() const;
+
   // expected-swift-note@+2 {{unavailable (cannot import)}}
   // expected-swift-note@+1 {{unavailable (cannot import)}}
   static Bro<Ken> badStatic(Bro<Ken>);
@@ -85,6 +88,8 @@ struct GoodStruct {
 //
 // NOTE-MISSING: func badArg(_: Never)
 //
+// CHECK-NEXT:   func getBad() -> Never
+//
 // NOTE-MISSING: func badStatic(_: Never) -> Never
 //
 // CHECK-NEXT:   func overloadsSameNumArgs(_: Int32)
@@ -102,6 +107,7 @@ struct DerivedGoodStruct : GoodStruct {};
 // CHECK:      struct DerivedGoodStruct {
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   func badReturn() -> Never
+// CHECK-NEXT:   func getBad() -> Never
 // CHECK-NEXT:   func overloadsSameNumArgs(_: Int32)
 // CHECK-NEXT:   func overloadsDiffNumArgs(_: Int32, _: Int32)
 // CHECK-NEXT:   func __beginUnsafe() -> Never
@@ -111,12 +117,14 @@ struct DerivedGoodStruct : GoodStruct {};
 struct UsingGoodStruct : GoodStruct {
   using GoodStruct::badReturn;
   using GoodStruct::badArg;
+  using GoodStruct::getBad;
   using GoodStruct::badStatic;
 };
 
 // CHECK:      struct UsingGoodStruct {
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   func badReturn() -> Never
+// CHECK-NEXT:   func getBad() -> Never
 // CHECK-NEXT:   func overloadsSameNumArgs(_: Int32)
 // CHECK-NEXT:   func overloadsDiffNumArgs(_: Int32, _: Int32)
 // CHECK-NEXT:   func __beginUnsafe() -> Never
@@ -166,17 +174,20 @@ void err(void) {
   // its following uses:
   auto inc = gs.badReturn();
   gs.badArg(inc);
-  GoodStruct::badStatic(inc);
+  auto inc2 = gs.getBad();
+  GoodStruct::badStatic(inc2);
 
   DerivedGoodStruct dgs;
   auto dinc = dgs.badReturn();
   dgs.badArg(dinc);
-  DerivedGoodStruct::badStatic(dinc);
+  auto dinc2 = dgs.getBad();
+  DerivedGoodStruct::badStatic(dinc2);
 
   UsingGoodStruct ugs;
   auto uinc = ugs.badReturn();
   ugs.badArg(uinc);
-  UsingGoodStruct::badStatic(uinc);
+  auto uinc2 = ugs.getBad();
+  UsingGoodStruct::badStatic(uinc2);
 }
 
 //--- ok.swift
@@ -214,7 +225,11 @@ func err() {
                             // expected-swift-warning@-1 {{an enum with no cases}}
                             // expected-swift-note@-2 {{add an explicit type annotation}}
   gs.badArg(inc)            // expected-swift-error {{has no member}}
-  GoodStruct.badStatic(inc) // expected-swift-error {{has no member}}
+
+  let inc2 = gs.getBad()     // expected-swift-error {{is unavailable}}
+                             // expected-swift-warning@-1 {{an enum with no cases}}
+                             // expected-swift-note@-2 {{add an explicit type annotation}}
+  GoodStruct.badStatic(inc2) // expected-swift-error {{has no member}}
 
   let _ = GoodStruct(inc) // expected-swift-error {{call that takes no arguments}}
 
@@ -234,9 +249,13 @@ func err() {
                               // expected-swift-note@-2 {{add an explicit type annotation}}
   dgs.badArg(dinc)            // expected-swift-error {{has no member}}
 
+  let _ = dgs.getBad()  // expected-swift-error {{is unavailable}}
+
   let ugs = UsingGoodStruct()
   let uinc = ugs.badReturn() // expected-swift-error {{is unavailable}}
                              // expected-swift-warning@-1 {{an enum with no cases}}
                              // expected-swift-note@-2 {{add an explicit type annotation}}
   ugs.badArg(uinc)           // expected-swift-error {{has no member}}
+
+  let _ = ugs.getBad()  // expected-swift-error {{is unavailable}}
 }


### PR DESCRIPTION
- **Explanation**: We were eagerly importing methods like `Smth getSomething()` and `setSomething(Smth)` to avoid tripping up the logic that imports those as property getters and setters, but that logic doesn't kick in unless the relevant compiler flag/decl annotation is present. This patch makes those methods lazily imported when the flag and annotation are both absent.
- **Scope**: Only affects behavior when `ImportCxxMembersLazily` feature is enabled (which it isn't by default)
- **Issues**: rdar://174587372
- **Original PRs**: N/A
- **Risk**: Low
- **Testing**: Updated test
- **Reviewers**: pending
