### PR TITLE
build.ps1: change the minimum Android API to 23

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -76,7 +76,7 @@ Default: "r28c"
 
 .PARAMETER AndroidAPILevel
 The API Level to target when building the Android SDKs. Must be between 21 and 36.
-Default: 24
+Default: 23
 
 .PARAMETER AndroidSDKVersions
 An array of SDKs to build for the Android OS.
@@ -182,7 +182,7 @@ param
   [ValidatePattern("^r(?:[1-9]|[1-9][0-9])(?:[a-z])?$")]
   [string] $AndroidNDKVersion = "r28c",
   [ValidateRange(21, 36)]
-  [int] $AndroidAPILevel = 24,
+  [int] $AndroidAPILevel = 23,
   [string[]] $AndroidSDKArchitectures = @("aarch64", "armv7", "i686", "x86_64"),
   [ValidateSet("dynamic", "static")]
   [string[]] $AndroidSDKLinkModes = @("dynamic", "static"),


### PR DESCRIPTION
- **Explanation**: Push the minimum API down to 23, [as discussed in the Android workgroup for months](https://forums.swift.org/t/android-api-minimum-for-the-swift-sdk-for-android/82874) now.
- **Scope**: Only affects the trunk Android SDK in the Windows toolchain
- **Issues**: none
- **Risk**: very low, few are likely using these Android SDKs on Windows
- **Testing**: we moved the minimum to API 24 last month without problem, and my local testing with API 23 on linux hasn't shown any issues
- **Reviewers**: @compnerd