### PR TITLE
[cxx-interop] Suppress ASSERT failure in FRT diagnostics

### DIFF
--- a/lib/ClangImporter/ClangAnalysis.cpp
+++ b/lib/ClangImporter/ClangAnalysis.cpp
@@ -213,7 +213,9 @@ bool importer::diagnoseForeignReferenceType(
   // this time with ClangImporter::Implemention in order to emit diagnostics.
   // This slow path does redundant work but only for invalid decls.
   auto infoAgain = checkForeignReferenceType(decl, &Impl);
-  ASSERT(!infoAgain.isValid() && "FRT check validity should be deterministic");
+  // FIXME: this appears to be non-deterministic in some configurations
+  // ASSERT(!infoAgain.isValid() && "FRT check validity should be deterministic");
+  (void)infoAgain;
   return false;
 }
 


### PR DESCRIPTION
- **Explanation**: This assertion is a sanity check but apparently fails in some scenarios that I have yet to investigate. Suppressing this assertion is harmless; nothing depends on the result of this call.
- **Scope**: Removes an assertion that is not strictly necessary.
- **Issues**: rdar://171995960
- **Original PRs**: N/A
- **Risk**: Low
- **Testing**: None; this is just removing an assertion.
- **Reviewers**: @jrflat 
