### PR TITLE
[cxx-interop] Prevent emitting conflicting decls for properties

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -1129,12 +1129,18 @@ private:
   }
 
   /// Returns true if the given function overload is safe to emit in the current
-  /// C++ lexical scope.
-  bool canPrintOverloadOfFunction(const AbstractFunctionDecl *funcDecl) const {
+  /// C++ lexical scope. If \p cxxNameOverride is non-empty, it is used as the
+  /// C++ function name instead of the default name derived from the
+  /// declaration.
+  bool
+  canPrintOverloadOfFunction(const AbstractFunctionDecl *funcDecl,
+                             StringRef cxxNameOverride = StringRef()) const {
     assert(outputLang == OutputLanguageMode::Cxx);
     auto &overloads =
         owningPrinter.getCxxDeclEmissionScope().emittedFunctionOverloads;
-    auto cxxName = cxx_translation::getNameForCxx(funcDecl);
+    auto cxxName = cxxNameOverride.empty()
+                       ? cxx_translation::getNameForCxx(funcDecl)
+                       : cxxNameOverride;
     auto paramTypes = getCxxParamTypes(funcDecl);
     auto [overloadIt, inserted] = overloads.try_emplace(
         cxxName,
@@ -1195,8 +1201,24 @@ private:
         if (!dispatchInfo)
           return;
       }
-      // FIXME: handle getters/setters ambiguities here too.
-      if (!isa<AccessorDecl>(AFD)) {
+      // Check for naming conflicts between accessors and explicit methods
+      // using the unified emittedFunctionOverloads map.
+      if (auto *accessor = dyn_cast<AccessorDecl>(AFD)) {
+        // Subscript accessors emit as operator[] and cannot conflict with
+        // named methods, so skip the overload check for them.
+        if (!SD) {
+          std::string remappedName = remapPropertyName(accessor, resultTy);
+          if (!canPrintOverloadOfFunction(AFD, remappedName)) {
+            auto comment = ("  // skip emitting accessor method for \'" +
+                            accessor->getStorage()->getBaseIdentifier().str() +
+                            "\'. \'" + remappedName + "\' already declared.\n")
+                               .str();
+            os << comment;
+            owningPrinter.outOfLineDefinitionsOS << comment;
+            return;
+          }
+        }
+      } else {
         if (!canPrintOverloadOfFunction(AFD))
           return;
       }

--- a/lib/PrintAsClang/DeclAndTypePrinter.h
+++ b/lib/PrintAsClang/DeclAndTypePrinter.h
@@ -58,7 +58,6 @@ struct CxxDeclEmissionScope {
   /// lexical scope.
   llvm::StringMap<llvm::SmallVector<EmittedFunctionOverload, 2>>
       emittedFunctionOverloads;
-  llvm::StringMap<const AccessorDecl *> emittedAccessorMethodNames;
 };
 
 /// Responsible for printing a Swift Decl or Type in Objective-C, to be

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -1651,27 +1651,6 @@ void DeclAndTypeClangFunctionPrinter::printCxxThunkBody(
   }
 }
 
-static bool checkDuplicatedMethodName(StringRef funcName,
-                                      const AccessorDecl *AD,
-                                      DeclAndTypePrinter &declAndTypePrinter,
-                                      raw_ostream &os) {
-  auto *&decl = declAndTypePrinter.getCxxDeclEmissionScope()
-                    .emittedAccessorMethodNames[funcName];
-
-  if (!decl) {
-    // This is the first time an accessor with this name has been emitted.
-    decl = AD;
-  } else if (decl != AD) {
-    // An accessor for another property had the same name.
-    os << "  // skip emitting accessor method for \'"
-       << AD->getStorage()->getBaseIdentifier().str() << "\'. \'" << funcName
-       << "\' already declared.\n";
-    return false;
-  }
-
-  return true;
-}
-
 void DeclAndTypeClangFunctionPrinter::printCxxMethod(
     DeclAndTypePrinter &declAndTypePrinter,
     const NominalTypeDecl *typeDeclContext, const AbstractFunctionDecl *FD,
@@ -1726,7 +1705,7 @@ static bool canRemapBoolPropertyNameDirectly(StringRef name) {
   return startsWithAndLonger("is") || startsWithAndLonger("has");
 }
 
-static std::string remapPropertyName(const AccessorDecl *accessor,
+std::string swift::remapPropertyName(const AccessorDecl *accessor,
                                      Type resultTy) {
   // For a getter or setter, go through the variable or subscript decl.
   StringRef propertyName =
@@ -1754,10 +1733,6 @@ void DeclAndTypeClangFunctionPrinter::printCxxPropertyAccessorMethod(
     std::optional<IRABIDetailsProvider::MethodDispatchInfo> dispatchInfo) {
   assert(accessor->isSetter() || accessor->getParameters()->size() == 0);
   std::string accessorName = remapPropertyName(accessor, resultTy);
-
-  if (!checkDuplicatedMethodName(accessorName, accessor, declAndTypePrinter,
-                                 os))
-    return;
 
   os << "  ";
 

--- a/lib/PrintAsClang/PrintClangFunction.h
+++ b/lib/PrintAsClang/PrintClangFunction.h
@@ -41,6 +41,10 @@ class PrimitiveTypeMapping;
 class SwiftToClangInteropContext;
 class DeclAndTypePrinter;
 
+/// Returns the C++ method name for a property accessor (e.g. "getList" for
+/// a getter of `var list`, or "isEmpty" for a Bool property named `isEmpty`).
+std::string remapPropertyName(const AccessorDecl *accessor, Type resultTy);
+
 struct ClangRepresentation {
   enum Kind { representable, objcxxonly, unsupported };
 

--- a/test/Interop/SwiftToCxx/properties/name-collision.swift
+++ b/test/Interop/SwiftToCxx/properties/name-collision.swift
@@ -12,6 +12,39 @@ public class C1 {
   public var Feat: Int { 123 }
 }
 
+public class C2 {
+    public var item: Int { 42 }
+
+    public func getItem() -> Int {
+        return item + 1
+    }
+}
+
+public class C3 {
+    public func getValue() -> Int {
+        return 0
+    }
+
+    public var value: Int { 42 }
+}
+
+public class C4 {
+    public var item: Int { 42 }
+
+    public func getItem() -> String {
+        return "hello"
+    }
+}
+
+public struct S0 {
+    public var x: Int
+    public var count: Int { x }
+
+    public func getCount(_ offset: Int) -> Int {
+        return count + offset
+    }
+}
+
 // CHECK: class SWIFT_SYMBOL("s:4main2C0C") C0 :
 // CHECK-NOT: getDescription()
 // CHECK: static SWIFT_INLINE_THUNK swift::String getDescription()
@@ -26,8 +59,27 @@ public class C1 {
 // CHECK-NOT: getFeat()
 // CHECK:};
 
-// CHECK: namespace main SWIFT_PRIVATE_ATTR SWIFT_SYMBOL_MODULE("main") {
-// CHECK-NOT: getDescription()
+// CHECK: class SWIFT_SYMBOL("s:4main2C2C") C2 :
+// CHECK:   SWIFT_INLINE_THUNK swift::Int getItem()
+// CHECK-NOT: getItem()
+// CHECK:};
+
+// CHECK: class SWIFT_SYMBOL("s:4main2C3C") C3 :
+// CHECK:   SWIFT_INLINE_THUNK swift::Int getValue()
+// CHECK-NOT: getValue()
+// CHECK:};
+
+// CHECK: class SWIFT_SYMBOL("s:4main2C4C") C4 :
+// CHECK:   SWIFT_INLINE_THUNK swift::Int getItem()
+// CHECK-NOT: getItem()
+// CHECK:};
+
+// CHECK: class SWIFT_SYMBOL("s:4main2S0V") S0 final {
+// CHECK:   SWIFT_INLINE_THUNK swift::Int getCount() const
+// CHECK:   SWIFT_INLINE_THUNK swift::Int getCount(swift::Int offset) const
+// CHECK:};
+
+// Out-of-line definitions section.
 // CHECK: SWIFT_INLINE_THUNK swift::String C0::getDescription() {
 // CHECK: skip emitting accessor method for 'description'. 'getDescription' already declared.
 // CHECK-NOT: getDescription()


### PR DESCRIPTION
Instead of having a property-specific mechanism to detect duplicates, let's use the generic facilities we have to detect problems with method overloading. This both fixes an issue where we generated reverse interop headers that would not compile when a user written method has the sanem name as the getter we generate on the C++ side. But it also makes the detection more flexible allowing for overloading when the parameter types differ.

rdar://164465903