### PR TITLE
AST,Sema: add protocol metatype extensions

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -1535,6 +1535,9 @@ void BridgedExtensionDecl_setParsedMembers(BridgedExtensionDecl decl,
                                            BridgedArrayRef members,
                                            BridgedFingerprint fingerprint);
 
+SWIFT_NAME("BridgedExtensionDecl.setIsMetatypeExtension(self:)")
+void BridgedExtensionDecl_setIsMetatypeExtension(BridgedExtensionDecl decl);
+
 SWIFT_NAME(
     "BridgedEnumDecl.createParsed(_:declContext:enumKeywordLoc:name:nameLoc:"
     "genericParamList:inheritedTypes:genericWhereClause:braceRange:)")

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -879,7 +879,7 @@ protected:
     Specifier : NumUsingSpecifierBits
   );
 
-  SWIFT_INLINE_BITFIELD(ExtensionDecl, Decl, 4+1,
+  SWIFT_INLINE_BITFIELD(ExtensionDecl, Decl, 4+1+1,
     /// An encoding of the default and maximum access level for this extension.
     /// The value 4 corresponds to AccessLevel::Public
     ///
@@ -889,7 +889,11 @@ protected:
     DefaultAndMaxAccessLevel : 4,
 
     /// Whether there is are lazily-loaded conformances for this extension.
-    HasLazyConformances : 1
+    HasLazyConformances : 1,
+
+    /// Whether this is a `metatype extension` whose members live on the
+    /// protocol metatype and are not inherited by conforming types.
+    IsMetatypeExtension : 1
   );
 
   SWIFT_INLINE_BITFIELD(MissingMemberDecl, Decl, 1+2,
@@ -2132,6 +2136,13 @@ public:
   SourceRange getBraces() const { return Braces; }
   void setBraces(SourceRange braces) { Braces = braces; }
 
+  bool isMetatypeExtension() const {
+    return Bits.ExtensionDecl.IsMetatypeExtension;
+  }
+  void setIsMetatypeExtension(bool value = true) {
+    Bits.ExtensionDecl.IsMetatypeExtension = value;
+  }
+
   bool hasBeenBound() const { return ExtendedNominal.getInt(); }
 
   void setExtendedNominal(NominalTypeDecl *n) {
@@ -2168,6 +2179,7 @@ public:
   /// Repr would not be available if the extension was been loaded
   /// from a serialized module.
   TypeRepr *getExtendedTypeRepr() const { return ExtendedTypeRepr; }
+  void setExtendedTypeRepr(TypeRepr *repr) { ExtendedTypeRepr = repr; }
                               
   /// Retrieve the set of protocols that this type inherits (i.e,
   /// explicitly conforms to).

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2154,6 +2154,13 @@ WARNING(extern_c_maybe_invalid_name, none,
 ERROR(extern_variable_initializer, none,
       "'@_extern' variable cannot have an initializer", ())
 
+ERROR(metatype_extension_requires_flag, none,
+      "protocol metatype extensions require '-enable-experimental-feature ProtocolMetatypeExtensions'", ())
+ERROR(metatype_extension_non_protocol, none,
+      "metatype extension can only extend a protocol, not %0", (Type))
+ERROR(metatype_extension_instance_member, none,
+      "instance members are not allowed in metatype extensions", ())
+
 // @_staticExclusiveOnly
 ERROR(attr_static_exclusive_only_disabled,none,
       "attribute requires '-enable-experimental feature StaticExclusiveOnly'", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2158,8 +2158,6 @@ ERROR(metatype_extension_requires_flag, none,
       "protocol metatype extensions require '-enable-experimental-feature ProtocolMetatypeExtensions'", ())
 ERROR(metatype_extension_non_protocol, none,
       "metatype extension can only extend a protocol, not %0", (Type))
-ERROR(metatype_extension_instance_member, none,
-      "instance members are not allowed in metatype extensions", ())
 
 // @_staticExclusiveOnly
 ERROR(attr_static_exclusive_only_disabled,none,

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -627,6 +627,10 @@ EXPERIMENTAL_FEATURE(BorrowingSequence, true)
 /// Turns some source breaking access control warnings into errors.
 EXPERIMENTAL_FEATURE(StrictAccessControl, true)
 
+/// Enables `metatype extension` declarations — extensions whose members live
+/// on the protocol metatype itself and are not inherited by conforming types.
+EXPERIMENTAL_FEATURE(ProtocolMetatypeExtensions, false)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -3346,9 +3346,15 @@ public:
         return;
 
       // If this function is generic or is within a generic context, it should
-      // have an interface type.
-      if (AFD->isGenericContext() !=
-          AFD->getInterfaceType()->is<GenericFunctionType>()) {
+      // have an interface type.  Metatype extension members are an exception:
+      // they live in a protocol extension but have no generic signature.
+      bool isInMetatypeExt = false;
+      if (auto *ext = dyn_cast<ExtensionDecl>(AFD->getDeclContext()))
+        isInMetatypeExt = ext->isMetatypeExtension();
+
+      if (!isInMetatypeExt &&
+          AFD->isGenericContext() !=
+              AFD->getInterfaceType()->is<GenericFunctionType>()) {
         Out << "Functions in generic context must have an interface type\n";
         AFD->dump(Out);
         abort();
@@ -3356,8 +3362,9 @@ public:
 
       // If the function has a generic interface type, it should also have a
       // generic signature.
-      if (AFD->isGenericContext() !=
-          (!AFD->getGenericSignature().isNull())) {
+      if (!isInMetatypeExt &&
+          AFD->isGenericContext() !=
+              (!AFD->getGenericSignature().isNull())) {
         Out << "Functions in generic context must have a generic signature\n";
         AFD->dump(Out);
         abort();

--- a/lib/AST/Bridging/DeclBridging.cpp
+++ b/lib/AST/Bridging/DeclBridging.cpp
@@ -342,6 +342,10 @@ void BridgedExtensionDecl_setParsedMembers(BridgedExtensionDecl cDecl,
   setParsedMembers(cDecl.unbridged(), cMembers, cFingerprint);
 }
 
+void BridgedExtensionDecl_setIsMetatypeExtension(BridgedExtensionDecl cDecl) {
+  cDecl.unbridged()->setIsMetatypeExtension();
+}
+
 static ArrayRef<InheritedEntry>
 convertToInheritedEntries(ASTContext &ctx, BridgedArrayRef cInheritedTypes) {
   return ctx.AllocateTransform<InheritedEntry>(

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2053,6 +2053,7 @@ ExtensionDecl::ExtensionDecl(SourceLoc extensionLoc,
 {
   Bits.ExtensionDecl.DefaultAndMaxAccessLevel = 0;
   Bits.ExtensionDecl.HasLazyConformances = false;
+  Bits.ExtensionDecl.IsMetatypeExtension = false;
   setTrailingWhereClause(trailingWhereClause);
 }
 
@@ -9431,6 +9432,18 @@ Type DeclContext::getSelfInterfaceType() const {
       return builtinTupleDecl->getTupleSelfType(dyn_cast<ExtensionDecl>(this));
 
     if (isa<ProtocolDecl>(nominalDecl)) {
+      // For metatype extensions, Self is the concrete existential type
+      // rather than the generic parameter.
+      for (auto *dc = this; dc; dc = dc->getParent()) {
+        if (auto *ext = dyn_cast<ExtensionDecl>(dc)) {
+          if (ext->isMetatypeExtension())
+            return ExistentialType::get(nominalDecl->getDeclaredInterfaceType());
+          break;
+        }
+        if (isa<NominalTypeDecl>(dc))
+          break;
+      }
+
       auto *genericParams = nominalDecl->getGenericParams();
       return genericParams->getParams().front()
           ->getDeclaredInterfaceType();

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9432,12 +9432,16 @@ Type DeclContext::getSelfInterfaceType() const {
       return builtinTupleDecl->getTupleSelfType(dyn_cast<ExtensionDecl>(this));
 
     if (isa<ProtocolDecl>(nominalDecl)) {
-      // For metatype extensions, Self is the concrete existential type
-      // rather than the generic parameter.
+      // For metatype extensions, Self is the metatype of the existential
+      // type.  Members are instance members of the metatype, so their self
+      // parameter has type (any P).Type.
       for (auto *dc = this; dc; dc = dc->getParent()) {
         if (auto *ext = dyn_cast<ExtensionDecl>(dc)) {
-          if (ext->isMetatypeExtension())
-            return ExistentialType::get(nominalDecl->getDeclaredInterfaceType());
+          if (ext->isMetatypeExtension()) {
+            auto existentialTy =
+                ExistentialType::get(nominalDecl->getDeclaredInterfaceType());
+            return MetatypeType::get(existentialTy);
+          }
           break;
         }
         if (isa<NominalTypeDecl>(dc))

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -698,6 +698,7 @@ static bool usesFeatureBorrowInout(Decl *decl) {
 }
 
 UNINTERESTING_FEATURE(BorrowingSequence)
+UNINTERESTING_FEATURE(ProtocolMetatypeExtensions)
 
 // ----------------------------------------------------------------------------
 // MARK: - FeatureSet

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2795,6 +2795,13 @@ QualifiedLookupRequest::evaluate(Evaluator &eval, const DeclContext *DC,
       if ((options & NL_OnlyMacros) && !isa<MacroDecl>(decl))
         continue;
 
+      // Metatype extension members are only visible when looking up directly
+      // on the protocol, not when reached via a conforming type.
+      if (auto *ext = dyn_cast<ExtensionDecl>(decl->getDeclContext())) {
+        if (ext->isMetatypeExtension() && !llvm::is_contained(typeDecls, current))
+          continue;
+      }
+
       if (isAcceptableLookupResult(DC, options, decl, onlyCompleteObjectInits,
                                    requireImport))
         decls.push_back(decl);

--- a/lib/ASTGen/Sources/ASTGen/Decls.swift
+++ b/lib/ASTGen/Sources/ASTGen/Decls.swift
@@ -310,11 +310,18 @@ extension ASTGenVisitor {
 extension ASTGenVisitor {
   func generate(extensionDecl node: ExtensionDeclSyntax) -> BridgedExtensionDecl {
     let attrs = self.generateDeclAttributes(node, allowStatic: false)
+    // Detect `extension P.Protocol { }` — a protocol metatype extension.
+    // Strip the `.Protocol` so the extension binds to the protocol `P`.
+    let protoMeta = node.extendedType.as(MetatypeTypeSyntax.self)
+        .flatMap { $0.metatypeSpecifier.keywordKind == .Protocol ? $0 : nil }
+    let extendedType = protoMeta.map { self.generate(type: $0.baseType) }
+                    ?? self.generate(type: node.extendedType)
+
     let decl = BridgedExtensionDecl.createParsed(
       self.ctx,
       declContext: self.declContext,
       extensionKeywordLoc: self.generateSourceLoc(node.extensionKeyword),
-      extendedType: self.generate(type: node.extendedType),
+      extendedType: extendedType,
       inheritedTypes: self.generate(inheritedTypeList: node.inheritanceClause?.inheritedTypes),
       genericWhereClause: self.generate(genericWhereClause: node.genericWhereClause),
       braceRange: self.generateSourceRange(
@@ -323,6 +330,10 @@ extension ASTGenVisitor {
       )
     )
     decl.asDecl.attachParsedAttrs(attrs.attributes)
+
+    if protoMeta != nil {
+      decl.setIsMetatypeExtension()
+    }
 
     let members = self.withDeclContext(decl.asDeclContext) {
       self.generate(memberBlockItemList: node.memberBlock.members)

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -7412,6 +7412,14 @@ Parser::parseDeclExtension(ParseDeclOptions Flags, DeclAttributes &Attributes) {
                                              CurDeclContext,
                                              trailingWhereClause);
   ext->attachParsedAttrs(Attributes);
+
+  // Detect `extension P.Protocol { }` — a protocol metatype extension.
+  // Strip the `.Protocol` suffix so the extension binds to the protocol `P`.
+  if (auto *PTR = dyn_cast_or_null<ProtocolTypeRepr>(extendedType.getPtrOrNull())) {
+    ext->setIsMetatypeExtension();
+    ext->setExtendedTypeRepr(PTR->getBase());
+  }
+
   if (trailingWhereHadCodeCompletion && CodeCompletionCallbacks)
     CodeCompletionCallbacks->setParsedDecl(ext);
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1037,9 +1037,14 @@ namespace {
 
       // Unbound instance method references always build a thunk, even if
       // we apply the arguments (eg, SomeClass.method(self)(a)), to avoid
-      // representational issues.
-      if (!baseIsInstance && member->isInstanceMember())
+      // representational issues.  Metatype extension instance members are
+      // bound directly since the metatype value is the instance.
+      if (!baseIsInstance && member->isInstanceMember()) {
+        if (auto *ext = dyn_cast<ExtensionDecl>(member->getDeclContext()))
+          if (ext->isMetatypeExtension())
+            return false;
         return true;
+      }
 
       // Bound member references that are '@objc optional' or found via dynamic
       // lookup are always represented via DynamicMemberRefExpr instead of a
@@ -1851,8 +1856,12 @@ namespace {
         return forceUnwrapIfExpected(ref, memberLocator);
       }
 
+      const bool isMetatypeExtMember =
+          isa<ExtensionDecl>(member->getDeclContext()) &&
+          cast<ExtensionDecl>(member->getDeclContext())->isMetatypeExtension();
       const bool isUnboundInstanceMember =
-          (!baseIsInstance && member->isInstanceMember());
+          (!baseIsInstance && member->isInstanceMember() &&
+           !isMetatypeExtMember);
       const bool needsCurryThunk =
           shouldBuildCurryThunk(choice, baseIsInstance);
 
@@ -1916,7 +1925,11 @@ namespace {
       }
 
       auto isDynamic = choice.getKind() == OverloadChoiceKind::DeclViaDynamic;
-      if (baseIsInstance) {
+      if (isMetatypeExtMember) {
+        // For metatype extension members, the metatype value IS the instance.
+        // The base is already the right type; just coerce to an rvalue.
+        base = cs.coerceToRValue(base);
+      } else if (baseIsInstance) {
         // Convert the base to the appropriate container type, turning it
         // into an lvalue if required.
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10606,6 +10606,13 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
       }
     };
 
+    // Metatype extension members are only accessible on the protocol
+    // metatype itself, not on conforming types.
+    if (auto *ext = dyn_cast<ExtensionDecl>(decl->getDeclContext())) {
+      if (ext->isMetatypeExtension() && !instanceTy->isExistentialType())
+        return;
+    }
+
     // See if we have an instance method, instance member or static method,
     // and check if it can be accessed on our base type.
 
@@ -10692,6 +10699,11 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
                     ->hasTypeParameter()) {
 
       /* We're OK */
+    } else if (instanceTy->isExistentialType() &&
+               isa<ExtensionDecl>(decl->getDeclContext()) &&
+               cast<ExtensionDecl>(decl->getDeclContext())->isMetatypeExtension()) {
+      // Metatype extension members are directly accessible on the
+      // protocol metatype without requiring Self to be bound.
     } else if (hasStaticMembers && baseObjTy->is<MetatypeType>() &&
                instanceTy->isExistentialType()) {
       // Static member lookup on protocol metatype in generic context

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -182,12 +182,17 @@ bool constraints::doesMemberRefApplyCurriedSelf(Type baseTy,
          "Expected a member reference");
 
   // For a reference to an instance method on a metatype, we want to keep the
-  // curried self.
+  // curried self.  Metatype extension instance members are an exception: the
+  // metatype value IS self, so the curried self is applied.
   if (decl->isInstanceMember()) {
     assert(baseTy);
     if (isa<AbstractFunctionDecl>(decl) &&
-        baseTy->getRValueType()->is<AnyMetatypeType>())
+        baseTy->getRValueType()->is<AnyMetatypeType>()) {
+      if (auto *ext = dyn_cast<ExtensionDecl>(decl->getDeclContext()))
+        if (ext->isMetatypeExtension())
+          return true;
       return false;
+    }
   }
 
   // Otherwise the reference applies self.
@@ -10618,6 +10623,16 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
 
     if (decl->isInstanceMember()) {
       if (baseObjTy->is<AnyMetatypeType>()) {
+        // Metatype extension instance members are instance members of the
+        // metatype type itself.  They are accessed directly on the protocol
+        // metatype value (e.g. P.value), not on an instance of the protocol.
+        if (auto *ext = dyn_cast<ExtensionDecl>(decl->getDeclContext())) {
+          if (ext->isMetatypeExtension()) {
+            result.addViable(candidate);
+            return;
+          }
+        }
+
         // `AnyObject` has special semantics, so let's just let it be.
         // Otherwise adjust base type and reference kind to make it
         // look as if lookup was done on the instance, that helps

--- a/lib/Sema/OpenedExistentials.cpp
+++ b/lib/Sema/OpenedExistentials.cpp
@@ -531,6 +531,12 @@ swift::isMemberAvailableOnExistential(Type baseTy, const ValueDecl *member) {
     return ExistentialMemberAccessLimitation::None;
   }
 
+  // Metatype extension members are non-generic and don't reference Self.
+  if (auto *ext = dyn_cast<ExtensionDecl>(dc)) {
+    if (ext->isMetatypeExtension())
+      return ExistentialMemberAccessLimitation::None;
+  }
+
   auto &ctx = member->getASTContext();
   auto existentialSig = ctx.getOpenedExistentialSignature(baseTy);
 

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -3880,6 +3880,26 @@ public:
       return;
     }
 
+    // Validate metatype extension constraints.
+    if (ED->isMetatypeExtension()) {
+      if (!ED->getASTContext().LangOpts.hasFeature(Feature::ProtocolMetatypeExtensions)) {
+        ED->diagnose(diag::metatype_extension_requires_flag);
+        ED->setInvalid();
+        return;
+      }
+      if (!isa<ProtocolDecl>(nominal)) {
+        ED->diagnose(diag::metatype_extension_non_protocol, extType);
+        ED->setInvalid();
+        return;
+      }
+      for (auto *member : ED->getMembers()) {
+        if (auto *VD = dyn_cast<ValueDecl>(member)) {
+          if (VD->isInstanceMember())
+            VD->diagnose(diag::metatype_extension_instance_member);
+        }
+      }
+    }
+
     if (!extType->hasError()) {
       // The first condition catches syntactic forms like
       //     protocol A & B { ... } // may be protocols or typealiases

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -3892,12 +3892,6 @@ public:
         ED->setInvalid();
         return;
       }
-      for (auto *member : ED->getMembers()) {
-        if (auto *VD = dyn_cast<ValueDecl>(member)) {
-          if (VD->isInstanceMember())
-            VD->diagnose(diag::metatype_extension_instance_member);
-        }
-      }
     }
 
     if (!extType->hasError()) {

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -967,6 +967,11 @@ GenericSignatureRequest::evaluate(Evaluator &evaluator,
     // Self or its associated types will infer default requirements in
     // ordinary extensions of that protocol, so the signature can differ there.
     if (auto *proto = dyn_cast<ProtocolDecl>(extendedNominal)) {
+      // Metatype extensions have no generic signature.  Their members are
+      // statically dispatched and cannot reference Self.
+      if (ext->isMetatypeExtension())
+        return nullptr;
+
       if (extraReqs.empty() && !ext->getTrailingWhereClause() &&
           proto->getInverseRequirements().empty()) {
         return extendedNominal->getGenericSignatureOfContext();

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -669,6 +669,13 @@ void TypeChecker::performTypoCorrection(DeclContext *DC, DeclRefKind refKind,
     if (!isPlausibleTypo(refKind, corrections.WrittenName, decl))
       return;
 
+    // Metatype extension members are not visible on conforming types.
+    if (auto *ext = dyn_cast<ExtensionDecl>(decl->getDeclContext())) {
+      if (ext->isMetatypeExtension() && baseTypeOrNull &&
+          !baseTypeOrNull->isExistentialType())
+        return;
+    }
+
     const auto candidateName = decl->getName();
 
     // Don't waste time computing edit distances that are more than

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -2014,6 +2014,11 @@ ConstraintSystem::getTypeOfMemberReferencePre(
                                   preparedOverload);
         }
       }
+    } else if (auto *ext = dyn_cast<ExtensionDecl>(outerDC);
+               ext && ext->isMetatypeExtension()) {
+      // Metatype extension members do not require existential opening.
+      // The member belongs to the protocol metatype itself, not a
+      // conforming type.
     } else {
       // Open the existential.
       auto openedArchetype =
@@ -2029,7 +2034,8 @@ ConstraintSystem::getTypeOfMemberReferencePre(
   assert(openedParams.size() == 1);
 
   bool isDynamicLookup = (choice.getKind() == OverloadChoiceKind::DeclViaDynamic);
-  bool skipProtocolSelfConstraint = isDynamicLookup || isRequirementOrWitness(locator);
+  bool skipProtocolSelfConstraint =
+      isDynamicLookup || isRequirementOrWitness(locator);
 
   Type selfObjTy = openedParams.front().getPlainType()->getMetatypeInstanceType();
   if (outerDC->getSelfProtocolDecl()) {

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5408,13 +5408,15 @@ public:
     DeclID extendedNominalID;
     DeclContextID contextID;
     bool isImplicit;
+    bool isMetatypeExtension;
     GenericSignatureID genericSigID;
     unsigned numConformances, numInherited;
     ArrayRef<uint64_t> data;
 
     decls_block::ExtensionLayout::readRecord(scratch, extendedTypeID,
                                              extendedNominalID, contextID,
-                                             isImplicit, genericSigID,
+                                             isImplicit, isMetatypeExtension,
+                                             genericSigID,
                                              numConformances, numInherited,
                                              data);
 
@@ -5440,6 +5442,7 @@ public:
 
     auto extension = ExtensionDecl::create(ctx, SourceLoc(), nullptr, { },
                                            DC, nullptr);
+    extension->setIsMetatypeExtension(isMetatypeExtension);
     declOrOffset = extension;
 
     // Generic parameter lists are written from outermost to innermost.
@@ -5485,7 +5488,7 @@ public:
     }
 
 #ifndef NDEBUG
-    if (outerParams) {
+    if (outerParams && !extension->isMetatypeExtension()) {
       unsigned paramCount = 0;
       for (auto *paramList = outerParams;
            paramList != nullptr;

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 991; // add LIBRARY_LEVEL to options_block
+const uint16_t SWIFTMODULE_VERSION_MINOR = 992; // metatype extension flag
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1989,6 +1989,7 @@ namespace decls_block {
     DeclIDField, // extended nominal
     DeclContextIDField, // context decl
     BCFixed<1>,  // implicit flag
+    BCFixed<1>,  // isMetatypeExtension flag
     GenericSignatureIDField,  // generic environment
     BCVBR<4>,    // # of protocol conformances
     BCVBR<4>,    // number of inherited types

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4402,6 +4402,7 @@ public:
                                 S.addDeclRef(extendedNominal),
                                 contextID.getOpaqueValue(),
                                 extension->isImplicit(),
+                                extension->isMetatypeExtension(),
                                 S.addGenericSignatureRef(
                                            extension->getGenericSignature()),
                                 numConformances,

--- a/test/SILGen/metatype-extension.swift
+++ b/test/SILGen/metatype-extension.swift
@@ -1,0 +1,59 @@
+// REQUIRES: swift_feature_ProtocolMetatypeExtensions
+// RUN: %target-swift-emit-silgen -enable-experimental-feature ProtocolMetatypeExtensions %s -module-name metatype_extension | %FileCheck %s
+
+protocol P {}
+
+extension P.Protocol {
+  static var value: Int { 42 }
+  static func greet() -> String { "hello" }
+}
+
+// Members are non-generic: no type parameters, no witness tables.
+
+// CHECK-LABEL: sil hidden [ossa] @$s18metatype_extension1PPAAE5valueSivgZ : $@convention(method) (@thin (any P).Type) -> Int
+// CHECK-NOT:     witness_method
+// CHECK-NOT:     witness_table
+// CHECK:       } // end sil function '$s18metatype_extension1PPAAE5valueSivgZ'
+
+// CHECK-LABEL: sil hidden [ossa] @$s18metatype_extension1PPAAE5greetSSyFZ : $@convention(method) (@thin (any P).Type) -> @owned String
+// CHECK-NOT:     witness_method
+// CHECK-NOT:     witness_table
+// CHECK:       } // end sil function '$s18metatype_extension1PPAAE5greetSSyFZ'
+
+// Direct access on the protocol metatype.
+
+// CHECK-LABEL: sil hidden [ossa] @$s18metatype_extension18testMetatypeDirectyyF
+// CHECK:         [[META:%[0-9]+]] = metatype $@thin (any P).Type
+// CHECK:         [[FN:%[0-9]+]] = function_ref @$s18metatype_extension1PPAAE5valueSivgZ : $@convention(method) (@thin (any P).Type) -> Int
+// CHECK:         apply [[FN]]([[META]])
+// CHECK:       } // end sil function '$s18metatype_extension18testMetatypeDirectyyF'
+func testMetatypeDirect() {
+  let _ = P.value
+}
+
+// Store the protocol metatype and dispatch through the stored value.
+
+// CHECK-LABEL: sil hidden [ossa] @$s18metatype_extension18testMetatypeStoredyyF
+// CHECK:         [[META:%[0-9]+]] = metatype $@thin (any P).Type
+// CHECK:         [[FN:%[0-9]+]] = function_ref @$s18metatype_extension1PPAAE5greetSSyFZ : $@convention(method) (@thin (any P).Type) -> @owned String
+// CHECK:         apply [[FN]]([[META]])
+// CHECK:       } // end sil function '$s18metatype_extension18testMetatypeStoredyyF'
+func testMetatypeStored() {
+  let _ = P.self.greet()
+}
+
+// Protocol refinement: members do not propagate.
+
+protocol Q: P {}
+
+extension Q.Protocol {
+  static var qValue: Int { 99 }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s18metatype_extension22testRefinementMetatypeyyF
+// CHECK:         function_ref @$s18metatype_extension1QPAAE6qValueSivgZ
+// CHECK-NOT:     function_ref {{.*}}PPAAE5value
+// CHECK:       } // end sil function '$s18metatype_extension22testRefinementMetatypeyyF'
+func testRefinementMetatype() {
+  let _ = Q.qValue
+}

--- a/test/SILGen/metatype-extension.swift
+++ b/test/SILGen/metatype-extension.swift
@@ -4,27 +4,27 @@
 protocol P {}
 
 extension P.Protocol {
-  static var value: Int { 42 }
-  static func greet() -> String { "hello" }
+  var value: Int { 42 }
+  func greet() -> String { "hello" }
 }
 
 // Members are non-generic: no type parameters, no witness tables.
 
-// CHECK-LABEL: sil hidden [ossa] @$s18metatype_extension1PPAAE5valueSivgZ : $@convention(method) (@thin (any P).Type) -> Int
+// CHECK-LABEL: sil hidden [ossa] @$s18metatype_extension1PPAAE5valueSivg : $@convention(method) (@thin (any P).Type) -> Int
 // CHECK-NOT:     witness_method
 // CHECK-NOT:     witness_table
-// CHECK:       } // end sil function '$s18metatype_extension1PPAAE5valueSivgZ'
+// CHECK:       } // end sil function '$s18metatype_extension1PPAAE5valueSivg'
 
-// CHECK-LABEL: sil hidden [ossa] @$s18metatype_extension1PPAAE5greetSSyFZ : $@convention(method) (@thin (any P).Type) -> @owned String
+// CHECK-LABEL: sil hidden [ossa] @$s18metatype_extension1PPAAE5greetSSyF : $@convention(method) (@thin (any P).Type) -> @owned String
 // CHECK-NOT:     witness_method
 // CHECK-NOT:     witness_table
-// CHECK:       } // end sil function '$s18metatype_extension1PPAAE5greetSSyFZ'
+// CHECK:       } // end sil function '$s18metatype_extension1PPAAE5greetSSyF'
 
 // Direct access on the protocol metatype.
 
 // CHECK-LABEL: sil hidden [ossa] @$s18metatype_extension18testMetatypeDirectyyF
 // CHECK:         [[META:%[0-9]+]] = metatype $@thin (any P).Type
-// CHECK:         [[FN:%[0-9]+]] = function_ref @$s18metatype_extension1PPAAE5valueSivgZ : $@convention(method) (@thin (any P).Type) -> Int
+// CHECK:         [[FN:%[0-9]+]] = function_ref @$s18metatype_extension1PPAAE5valueSivg : $@convention(method) (@thin (any P).Type) -> Int
 // CHECK:         apply [[FN]]([[META]])
 // CHECK:       } // end sil function '$s18metatype_extension18testMetatypeDirectyyF'
 func testMetatypeDirect() {
@@ -35,7 +35,7 @@ func testMetatypeDirect() {
 
 // CHECK-LABEL: sil hidden [ossa] @$s18metatype_extension18testMetatypeStoredyyF
 // CHECK:         [[META:%[0-9]+]] = metatype $@thin (any P).Type
-// CHECK:         [[FN:%[0-9]+]] = function_ref @$s18metatype_extension1PPAAE5greetSSyFZ : $@convention(method) (@thin (any P).Type) -> @owned String
+// CHECK:         [[FN:%[0-9]+]] = function_ref @$s18metatype_extension1PPAAE5greetSSyF : $@convention(method) (@thin (any P).Type) -> @owned String
 // CHECK:         apply [[FN]]([[META]])
 // CHECK:       } // end sil function '$s18metatype_extension18testMetatypeStoredyyF'
 func testMetatypeStored() {
@@ -47,11 +47,11 @@ func testMetatypeStored() {
 protocol Q: P {}
 
 extension Q.Protocol {
-  static var qValue: Int { 99 }
+  var qValue: Int { 99 }
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s18metatype_extension22testRefinementMetatypeyyF
-// CHECK:         function_ref @$s18metatype_extension1QPAAE6qValueSivgZ
+// CHECK:         function_ref @$s18metatype_extension1QPAAE6qValueSivg
 // CHECK-NOT:     function_ref {{.*}}PPAAE5value
 // CHECK:       } // end sil function '$s18metatype_extension22testRefinementMetatypeyyF'
 func testRefinementMetatype() {

--- a/test/Sema/metatype-extension-disabled.swift
+++ b/test/Sema/metatype-extension-disabled.swift
@@ -1,0 +1,5 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P {}
+
+extension P.Protocol {} // expected-error {{protocol metatype extensions require '-enable-experimental-feature ProtocolMetatypeExtensions'}}

--- a/test/Sema/metatype-extension.swift
+++ b/test/Sema/metatype-extension.swift
@@ -1,0 +1,36 @@
+// REQUIRES: swift_feature_ProtocolMetatypeExtensions
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature ProtocolMetatypeExtensions
+
+protocol P {}
+
+extension P.Protocol {
+  static var value: Int { 42 }
+  static func greet() -> String { "hello" }
+}
+
+// --- Protocol metatype extension members are accessible on the protocol.
+let _: Int = P.value
+let _: String = P.greet()
+
+// --- Protocol metatype extension members are NOT accessible on conforming types.
+struct ConcreteP: P {}
+let _ = ConcreteP.value // expected-error {{type 'ConcreteP' has no member 'value'}}
+let _ = ConcreteP.greet() // expected-error {{type 'ConcreteP' has no member 'greet'}}
+
+// --- Protocol metatype extension members do NOT propagate through refinement.
+protocol Q: P {}
+let _ = Q.value // expected-error {{type 'any Q' has no member 'value'}}
+let _ = Q.greet() // expected-error {{type 'any Q' has no member 'greet'}}
+
+// --- Instance members are not allowed.
+extension P.Protocol {
+  var x: Int { 0 } // expected-error {{instance members are not allowed in metatype extensions}}
+  func f() {} // expected-error {{instance members are not allowed in metatype extensions}}
+}
+
+// --- Metatype extension on non-protocol types.
+struct S {}
+extension S.Protocol {} // expected-error {{metatype extension can only extend a protocol, not 'S'}}
+
+class C {}
+extension C.Protocol {} // expected-error {{metatype extension can only extend a protocol, not 'C'}}

--- a/test/Sema/metatype-extension.swift
+++ b/test/Sema/metatype-extension.swift
@@ -4,13 +4,18 @@
 protocol P {}
 
 extension P.Protocol {
-  static var value: Int { 42 }
-  static func greet() -> String { "hello" }
+  var value: Int { 42 }
+  func greet() -> String { "hello" }
 }
 
 // --- Protocol metatype extension members are accessible on the protocol.
 let _: Int = P.value
 let _: String = P.greet()
+
+// --- Protocol metatype extension members are accessible on a stored metatype.
+let p = P.self
+let _: Int = p.value
+let _: String = p.greet()
 
 // --- Protocol metatype extension members are NOT accessible on conforming types.
 struct ConcreteP: P {}
@@ -21,12 +26,6 @@ let _ = ConcreteP.greet() // expected-error {{type 'ConcreteP' has no member 'gr
 protocol Q: P {}
 let _ = Q.value // expected-error {{type 'any Q' has no member 'value'}}
 let _ = Q.greet() // expected-error {{type 'any Q' has no member 'greet'}}
-
-// --- Instance members are not allowed.
-extension P.Protocol {
-  var x: Int { 0 } // expected-error {{instance members are not allowed in metatype extensions}}
-  func f() {} // expected-error {{instance members are not allowed in metatype extensions}}
-}
 
 // --- Metatype extension on non-protocol types.
 struct S {}

--- a/test/Serialization/Inputs/metatype-extension-lib.swift
+++ b/test/Serialization/Inputs/metatype-extension-lib.swift
@@ -1,0 +1,5 @@
+public protocol P {}
+
+extension P.Protocol {
+  public static var value: Int { 42 }
+}

--- a/test/Serialization/Inputs/metatype-extension-lib.swift
+++ b/test/Serialization/Inputs/metatype-extension-lib.swift
@@ -1,5 +1,5 @@
 public protocol P {}
 
 extension P.Protocol {
-  public static var value: Int { 42 }
+  public var value: Int { 42 }
 }

--- a/test/Serialization/metatype-extension.swift
+++ b/test/Serialization/metatype-extension.swift
@@ -1,0 +1,13 @@
+// REQUIRES: swift_feature_ProtocolMetatypeExtensions
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module-path %t/MetatypeExtLib.swiftmodule -module-name MetatypeExtLib -enable-experimental-feature ProtocolMetatypeExtensions %S/Inputs/metatype-extension-lib.swift
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature ProtocolMetatypeExtensions -I %t
+
+import MetatypeExtLib
+
+// Members from the metatype extension should be accessible on the protocol metatype.
+let _: Int = P.value
+
+// Members from the metatype extension should NOT be accessible on conforming types.
+struct S: P {}
+let _ = S.value // expected-error {{type 'S' has no member 'value'}}


### PR DESCRIPTION
This adds an implementation to support protocol metatype extensions. The primary motivation for this feature is to allow metadata attached to protocol types for supporting COM interop in Swift. But it is built as a general purpose feature that might enable protocol metatype extensions.