### PR TITLE
Aggressive CMO can force the serialization of the bodies of `@export(interface)` functions

### DIFF
--- a/docs/SIL/FunctionAttributes.md
+++ b/docs/SIL/FunctionAttributes.md
@@ -125,6 +125,19 @@ sil-function-attribute ::= '[weak_imported]'
 
 Cross-module references to this function should always use weak linking.
 
+### Export of of the function body
+
+```
+sil-function-attribute ::= '[export_interface]'
+sil-function-attribute ::= '[export_implementation]'
+```
+
+SIL representation of the `@export(interface)` and `@export(implementation)`
+attributes, respectively. The former implies that the function body is never
+serialized to be made available to clients of the module. The latter implies
+that the function body is always serialized, and clients must emit a (shared)
+copy of it if they need to use the function.
+
 ### Stack protection
 
 ```

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -76,6 +76,7 @@ namespace swift {
   class ASTPrinter;
   class ASTWalker;
   enum class BuiltinMacroKind: uint8_t;
+  enum class CodeGenerationModel: uint8_t;
   class ConstructorDecl;
   class DestructorDecl;
   class DiagnosticEngine;
@@ -778,7 +779,7 @@ protected:
     HasLazyUnderlyingSubstitutions : 1
   );
 
-  SWIFT_INLINE_BITFIELD(ModuleDecl, TypeDecl, 1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+8+1+2,
+  SWIFT_INLINE_BITFIELD(ModuleDecl, TypeDecl, 1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+2+8+1+2,
     /// If the module is compiled as static library.
     StaticLibrary : 1,
 
@@ -849,8 +850,8 @@ protected:
     /// Whether this module has enabled strict memory safety checking.
     StrictMemorySafety : 1,
 
-    /// Whether this module uses deferred code generation in Embedded Swift.
-    DeferredCodeGen : 1,
+    /// The code generation model used by this module.
+    CodeGenModel : 2,
 
     /// Whether this module was compile with "aggressive" CMO i.e
     /// the flag: -cross-module-optimization.
@@ -1126,6 +1127,21 @@ public:
   /// This can be spelled with @export(interface) or the historical
   /// @_neverEmitIntoClient.
   bool isNeverEmittedIntoClient() const;
+
+  /// Compute the code generation model that was explicitly requested for
+  /// this declaration.
+  ///
+  /// This function queries attributes relevant to the code generation
+  /// model (@export, @inlinable, etc.) but does not apply defaults based
+  /// on Embedded Swift or feature flags.
+  std::optional<CodeGenerationModel>
+  getExplicitCodeGenerationModel() const;
+
+  /// Compute the code generation model for the declaration, combining the
+  /// explicitly-specified information from attributes with defaults
+  /// based on Embedded Swift or feature flags.
+  CodeGenerationModel
+  getEffectiveCodeGenerationModel() const;
 
   using AuxiliaryDeclCallback = llvm::function_ref<void(Decl *)>;
 

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -53,6 +53,7 @@ namespace swift {
   enum class ArtificialMainKind : uint8_t;
   class ASTContext;
   class ASTWalker;
+  enum class CodeGenerationModel: uint8_t;
   class CustomAvailabilityDomain;
   class Decl;
   class DeclAttribute;
@@ -851,13 +852,13 @@ public:
     Bits.ModuleDecl.StrictMemorySafety = value;
   }
 
-  /// Whether this module uses deferred code generation.
-  bool deferredCodeGen() const {
-    return Bits.ModuleDecl.DeferredCodeGen;
+  /// The code generation model used by this module.
+  CodeGenerationModel codeGenerationModel() const {
+    return static_cast<CodeGenerationModel>(Bits.ModuleDecl.CodeGenModel);
   }
 
-  void setDeferredCodeGen(bool value = true) {
-    Bits.ModuleDecl.DeferredCodeGen = value;
+  void setCodeGenerationModel(CodeGenerationModel value) {
+    Bits.ModuleDecl.CodeGenModel = static_cast<unsigned>(value);
   }
 
   bool isObjCNameLookupCachePopulated() const {

--- a/include/swift/Basic/CodeGenerationModel.h
+++ b/include/swift/Basic/CodeGenerationModel.h
@@ -1,0 +1,54 @@
+//===--- CodeGenerationModel.h - Code generation model ----------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file provides a description of the code generation model.
+//
+//===----------------------------------------------------------------------===//
+#ifndef SWIFT_BASIC_CODEGENERATIONMODEL_H
+#define SWIFT_BASIC_CODEGENERATIONMODEL_H
+
+#include <cstdint>
+
+namespace swift {
+
+/// Describes where the code associated with a declaration is generated,
+/// whether into the resulting object file (hiding the implementation),
+/// Swift module for clients (exposing the implementation), or both.
+///
+/// The code generation model can be affected by a number of factors. For a
+/// specific declaration, `@export` attribute introduced in SE-0497
+/// explicitly chooses between "interface" and "implementation", while the
+/// inlinability attributes choose "inlinable".
+///
+/// Globally, Embedded Swift defaults to "inlinable" but can be set to
+/// "implementation" with the experimental feature DeferredCodeGen.
+/// Non-embedded Swift uses "interface" and doesn't currently allow
+/// customization.
+enum class CodeGenerationModel: uint8_t {
+  /// Only the interface of the declaration is made available, and clients can
+  /// call through that interface. This is the equivalent to
+  /// `@export(interface)` on a specific declaration.
+  Interface,
+  /// Both the interface and the implementation are made available to clients,
+  /// who can choose whether to inline the implementation or call the
+  /// implementation. This is equivalent to @inlinable.
+  Inlinable,
+  /// The implementation of the declaration is made available for the client to
+  /// inline when it is used. There is no implementation in the corresponding
+  /// module. This is the equivalent of `@export(implementation)` on a
+  /// specific declaration.
+  Implementation,
+};
+  
+}
+
+#endif 

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -34,6 +34,7 @@
 namespace swift {
 
 class ASTContext;
+enum class CodeGenerationModel: uint8_t;
 class SILInstruction;
 class SILModule;
 class SILFunctionBuilder;
@@ -403,6 +404,11 @@ private:
   /// Whether cross-module references to this function should always use weak
   /// linking.
   unsigned IsAlwaysWeakImported : 1;
+
+  /// The code generation model used for this particular function. This is
+  /// zero in the case where it's using the default model, or 1 + the
+  /// CodeGenerationModel otherwise.
+  unsigned CodeGenModel : 2;
 
   /// Whether the implementation can be dynamically replaced.
   unsigned IsDynamicReplaceable : 1;
@@ -982,6 +988,11 @@ public:
 
   bool isWeakImported(ModuleDecl *module) const;
 
+  /// Determine the explicit code generation model
+  std::optional<CodeGenerationModel> codeGenerationModel() const;
+
+  void setCodeGenerationModel(std::optional<CodeGenerationModel> value);
+
   /// Returns whether this function implementation can be dynamically replaced.
   IsDynamicallyReplaceable_t isDynamicallyReplaceable() const {
     return IsDynamicallyReplaceable_t(IsDynamicReplaceable);
@@ -1446,15 +1457,11 @@ public:
     return false;
   }
 
-  /// Returns true if this function belongs to a declaration that
-  /// has `@_alwaysEmitIntoClient` attribute.
-  bool markedAsAlwaysEmitIntoClient() const {
-    if (!hasLocation())
-      return false;
+  /// Whether this declaration is always emitted into the client.
+  bool isAlwaysEmitIntoClient() const;
 
-    auto *V = getLocation().getAsASTNode<ValueDecl>();
-    return V && V->isAlwaysEmittedIntoClient();
-  }
+  /// Whether this declaration is never emitted into the client.
+  bool isNeverEmitIntoClient() const;
 
   /// Return whether this function has attribute @used on it
   bool markedAsUsed() const { return MarkedAsUsed; }

--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -29,6 +29,7 @@
 namespace swift {
 
 class ModuleFile;
+enum class CodeGenerationModel: uint8_t;
 struct ExplicitSwiftModuleMap;
 struct ExplicitClangModuleMap;
 enum class ResilienceStrategy : unsigned;
@@ -152,7 +153,7 @@ class ExtendedValidationInfo {
     unsigned AllowNonResilientAccess: 1;
     unsigned SerializePackageEnabled: 1;
     unsigned StrictMemorySafety: 1;
-    unsigned DeferredCodeGen: 1;
+    unsigned CodeGenModel: 2;
     unsigned AggressiveCMOEnabled : 1;
     unsigned LibraryLevel : 2;
   } Bits;
@@ -265,11 +266,11 @@ public:
     Bits.StrictMemorySafety = val;
   }
 
-  bool deferredCodeGen() const {
-    return Bits.DeferredCodeGen;
+  CodeGenerationModel codeGenerationModel() const {
+    return static_cast<CodeGenerationModel>(Bits.CodeGenModel);
   }
-  void setDeferredCodeGen(bool val = true) {
-    Bits.DeferredCodeGen = val;
+  void setCodeGenerationModel(CodeGenerationModel val) {
+    Bits.CodeGenModel = static_cast<unsigned>(val);
   }
 
   bool isAggressiveCMOEnabled() const {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -56,6 +56,7 @@
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/TypeLoc.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/Basic/CodeGenerationModel.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/Range.h"
 #include "swift/Basic/Statistic.h"
@@ -2296,31 +2297,83 @@ bool Decl::isObjCImplementation() const {
 }
 
 bool Decl::isAlwaysEmittedIntoClient() const {
-  // @export(implementation)
-  if (auto exportAttr = getAttrs().getAttribute<ExportAttr>()) {
-    if (exportAttr->exportKind == ExportKind::Implementation)
-      return true;
-  }
-
-  // @_alwaysEmitIntoClient
-  if (getAttrs().hasAttribute<AlwaysEmitIntoClientAttr>())
-    return true;
+  if (auto codeGenModel = getExplicitCodeGenerationModel())
+    return *codeGenModel == CodeGenerationModel::Implementation;
 
   return false;
 }
 
 bool Decl::isNeverEmittedIntoClient() const {
-  // @export(interface)
-  if (auto exportAttr = getAttrs().getAttribute<ExportAttr>()) {
-    if (exportAttr->exportKind == ExportKind::Interface)
-      return true;
-  }
-
-  // @_neverEmitIntoClient
-  if (getAttrs().hasAttribute<NeverEmitIntoClientAttr>())
-    return true;
+  if (auto codeGenModel = getExplicitCodeGenerationModel())
+    return *codeGenModel == CodeGenerationModel::Interface;
 
   return false;
+}
+
+std::optional<CodeGenerationModel>
+Decl::getExplicitCodeGenerationModel() const {
+  bool sawInlinable = false;
+  for (auto attr : getAttrs()) {
+    // @export
+    if (auto exportAttr = dyn_cast<ExportAttr>(attr)) {
+      switch (exportAttr->exportKind) {
+        case ExportKind::Interface:
+          return CodeGenerationModel::Interface;
+
+        case ExportKind::Implementation:
+          return CodeGenerationModel::Implementation;
+      }
+    }
+
+    // @_alwaysEmitIntoClient - historical spelling for @export(implementation)
+    if (isa<AlwaysEmitIntoClientAttr>(attr))
+      return CodeGenerationModel::Implementation;
+
+    // @_neverEmitIntoClient - historical spelling for @export(interface)
+    if (isa<NeverEmitIntoClientAttr>(attr))
+      return CodeGenerationModel::Interface;
+
+    // @inlinable
+    if (isa<InlinableAttr>(attr)) {
+      sawInlinable = true;
+      continue;
+    }
+
+    // @inline(always) implies @inlinable on "public"
+    // (open, public, package) declarations.
+    if (auto inlineAttr = dyn_cast<InlineAttr>(attr)) {
+      if (inlineAttr->getKind() == InlineKind::Always) {
+        if (auto valueDecl = dyn_cast<ValueDecl>(this)) {
+          AccessScope access =
+                valueDecl->getFormalAccessScope(
+                    nullptr, /*treatUsableFromInlineAsPublic*/false,
+                    /*ignoreImportAccessLevel*/false);
+          if (access.isPublicOrPackage()) {
+            sawInlinable = true;
+          }
+        }
+      }
+      continue;
+    }
+  }
+
+  // If we saw an inlinable attribute but no other explicit attribute,
+  // treat as inlinable.
+  if (sawInlinable)
+    return CodeGenerationModel::Inlinable;
+
+  return std::nullopt;
+}
+
+CodeGenerationModel
+Decl::getEffectiveCodeGenerationModel() const {
+  // If there is an explicit attribute that specifies the model for this
+  // declaration, use it.
+  if (auto explicitModel = getExplicitCodeGenerationModel())
+    return *explicitModel;
+
+  // Otherwise, apply the model-level defaults.
+  return getModuleContext()->codeGenerationModel();
 }
 
 PatternBindingDecl::PatternBindingDecl(SourceLoc StaticLoc,
@@ -5051,21 +5104,8 @@ SourceLoc Decl::getAttributeInsertionLoc(bool forModifier) const {
 }
 
 bool ValueDecl::hasAttributeWithInlinableSemantics() const {
-  if (getAttrs().hasAttribute<InlinableAttr>())
-    return true;
-
-  // @inline(always) implies @inlinable on "public" (open, public, package)
-  // declarations.
-  AccessScope access =
-        getFormalAccessScope(nullptr, /*treatUsableFromInlineAsPublic*/false,
-                             /*ignoreImportAccessLevel*/false);
-  if (!access.isPublicOrPackage())
-    return false;
-
-  if (auto *inlineAttr = getAttrs().getAttribute<InlineAttr>()) {
-    if (inlineAttr && inlineAttr->getKind() == InlineKind::Always)
-      return true;
-  }
+  if (auto codeGenModel = getExplicitCodeGenerationModel())
+    return *codeGenModel == CodeGenerationModel::Inlinable;
 
   return false;
 }

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -46,6 +46,7 @@
 #include "swift/AST/Type.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/Basic/CodeGenerationModel.h"
 #include "swift/Basic/Compiler.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/SourceManager.h"
@@ -781,7 +782,8 @@ ModuleDecl::ModuleDecl(Identifier name, ASTContext &ctx,
   Bits.ModuleDecl.AllowNonResilientAccess = 0;
   Bits.ModuleDecl.SerializePackageEnabled = 0;
   Bits.ModuleDecl.StrictMemorySafety = 0;
-  Bits.ModuleDecl.DeferredCodeGen = 0;
+  Bits.ModuleDecl.CodeGenModel =
+      static_cast<unsigned>(CodeGenerationModel::Interface);
   Bits.ModuleDecl.AggressiveCMOEnabled = 0;
 
   // Populate the module's files.

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1561,9 +1561,11 @@ ModuleDecl *CompilerInstance::getMainModule() const {
       MainModule->setCodeGenerationModel(CodeGenerationModel::Interface);
     }
     if (Invocation.getSILOptions().CMOMode ==
-        CrossModuleOptimizationMode::Aggressive)
+          CrossModuleOptimizationMode::Aggressive ||
+        Invocation.getSILOptions().CMOMode ==
+          CrossModuleOptimizationMode::Everything) {
       MainModule->setAggressiveCMOEnabled(true);
-
+    }
     configureAvailabilityDomains(getASTContext(),
                                  Invocation.getFrontendOptions(), MainModule);
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -27,6 +27,7 @@
 #include "swift/AST/PluginLoader.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/Basic/CodeGenerationModel.h"
 #include "swift/Basic/FileTypes.h"
 #include "swift/Basic/Platform.h"
 #include "swift/Basic/SourceManager.h"
@@ -1550,9 +1551,15 @@ ModuleDecl *CompilerInstance::getMainModule() const {
       MainModule->setSerializePackageEnabled();
     if (Invocation.getLangOptions().hasFeature(Feature::StrictMemorySafety))
       MainModule->setStrictMemorySafety(true);
-    if (Invocation.getLangOptions().hasFeature(Feature::Embedded) &&
-        Invocation.getLangOptions().hasFeature(Feature::DeferredCodeGen))
-      MainModule->setDeferredCodeGen(true);
+    if (Invocation.getLangOptions().hasFeature(Feature::Embedded)) {
+      bool isImplementation =
+          Invocation.getLangOptions().hasFeature(Feature::DeferredCodeGen);
+      MainModule->setCodeGenerationModel(
+          isImplementation ? CodeGenerationModel::Implementation
+                           : CodeGenerationModel::Inlinable);
+    } else {
+      MainModule->setCodeGenerationModel(CodeGenerationModel::Interface);
+    }
     if (Invocation.getSILOptions().CMOMode ==
         CrossModuleOptimizationMode::Aggressive)
       MainModule->setAggressiveCMOEnabled(true);

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2616,7 +2616,7 @@ void IRGenSILFunction::emitSILFunction() {
     IGM.IRGen.addDynamicReplacement(CurSILFn);
 
   if (CurSILFn->getLinkage() == SILLinkage::Shared) {
-    if (CurSILFn->markedAsAlwaysEmitIntoClient() &&
+    if (CurSILFn->isAlwaysEmitIntoClient() &&
         CurSILFn->hasOpaqueResultTypeWithAvailabilityConditions()) {
       auto *V = CurSILFn->getLocation().castToASTNode<ValueDecl>();
       auto *opaqueResult = V->getOpaqueResultTypeDecl();

--- a/lib/SIL/IR/Linker.cpp
+++ b/lib/SIL/IR/Linker.cpp
@@ -142,7 +142,7 @@ void SILLinkerVisitor::maybeAddFunctionToWorklist(
       Worklist.push_back(F);
     }
 
-    if (F->markedAsAlwaysEmitIntoClient()) {
+    if (F->isAlwaysEmitIntoClient()) {
       // For @_alwaysEmitIntoClient functions, we need to lookup its
       // differentiability witness and, if present, ask SILLoader to obtain its
       // definition. Otherwise, a linker error would occur due to undefined
@@ -175,7 +175,7 @@ void SILLinkerVisitor::maybeAddFunctionToWorklist(
   // So try deserializing HiddenExternal functions too.
   if (linkage == SILLinkage::HiddenExternal) {
     deserializeAndPushToWorklist(F);
-    if (!F->markedAsAlwaysEmitIntoClient())
+    if (!F->isAlwaysEmitIntoClient())
       return;
     // For @_alwaysEmitIntoClient functions, we need to lookup its
     // differentiability witness and, if present, ask SILLoader to obtain its

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -19,6 +19,7 @@
 #include "swift/AST/PropertyWrappers.h"
 #include "swift/AST/SourceFile.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/Basic/CodeGenerationModel.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/SIL/SILLinkage.h"
@@ -1211,14 +1212,18 @@ bool SILDeclRef::declHasNonUniqueDefinition(const ValueDecl *decl) {
   if (!decl->getASTContext().LangOpts.hasFeature(Feature::Embedded))
     return false;
 
-  // If the declaration is marked as never being emitted into the client, it
-  // has a unique definition.
-  if (decl->isNeverEmittedIntoClient())
-    return false;
+  // Explicit attributes to control whether the implementation can be
+  // duplicated.
+  if (auto explicitModel = decl->getExplicitCodeGenerationModel()) {
+    switch (*explicitModel) {
+    case CodeGenerationModel::Inlinable:
+    case CodeGenerationModel::Implementation:
+      return true;
 
-  /// Always-emit-into-client means that we have a non-unique definition.
-  if (decl->isAlwaysEmittedIntoClient())
-    return true;
+    case CodeGenerationModel::Interface:
+      return false;
+    }
+  }
 
   // If the declaration is marked in a manner that indicates that other
   // systems will expect it to have a symbol, then it has a unique definition.
@@ -1247,7 +1252,7 @@ bool SILDeclRef::declHasNonUniqueDefinition(const ValueDecl *decl) {
 
   /// With deferred code generation, declarations are emitted as late as
   /// possible, so they must have non-unique definitions.
-  if (module->deferredCodeGen())
+  if (module->codeGenerationModel() == CodeGenerationModel::Implementation)
     return true;
 
   // If the declaration is not from the main module, treat its definition as

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/Module.h"
 #include "swift/AST/Stmt.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/Basic/CodeGenerationModel.h"
 #include "swift/Basic/OptimizationMode.h"
 #include "swift/Basic/Statistic.h"
 #include "swift/SIL/CFG.h"
@@ -269,6 +270,7 @@ void SILFunction::init(
   this->HasCReferences = false;
   this->MarkedAsUsed = false;
   this->IsAlwaysWeakImported = false;
+  this->CodeGenModel = 0; // none case
   this->IsDynamicReplaceable = isDynamic;
   this->ExactSelfClass = isExactSelfClass;
   this->IsDistributed = isDistributed;
@@ -359,6 +361,7 @@ void SILFunction::createSnapshot(int id) {
   newSnapshot->HasCReferences = HasCReferences;
   newSnapshot->MarkedAsUsed = MarkedAsUsed;
   newSnapshot->IsAlwaysWeakImported = IsAlwaysWeakImported;
+  newSnapshot->CodeGenModel = CodeGenModel;
   newSnapshot->HasOwnership = HasOwnership;
   newSnapshot->IsWithoutActuallyEscapingThunk = IsWithoutActuallyEscapingThunk;
   newSnapshot->OptMode = OptMode;
@@ -493,6 +496,28 @@ void SILFunction::numberValues(llvm::DenseMap<const SILNode*, unsigned> &
 
 ASTContext &SILFunction::getASTContext() const {
   return getModule().getASTContext();
+}
+
+std::optional<CodeGenerationModel> SILFunction::codeGenerationModel() const {
+  if (CodeGenModel == 0)
+    return std::nullopt;
+
+  return static_cast<CodeGenerationModel>(CodeGenModel - 1);
+}
+
+void SILFunction::setCodeGenerationModel(std::optional<CodeGenerationModel> value) {
+  if (value)
+    CodeGenModel = static_cast<unsigned>(*value) + 1;
+  else
+    CodeGenModel = 0;
+}
+
+bool SILFunction::isAlwaysEmitIntoClient() const {
+  return codeGenerationModel() == CodeGenerationModel::Implementation;
+}
+
+bool SILFunction::isNeverEmitIntoClient() const {
+  return codeGenerationModel() == CodeGenerationModel::Interface;
 }
 
 OptimizationMode SILFunction::getEffectiveOptimizationMode() const {
@@ -1102,7 +1127,7 @@ SILFunction::isPossiblyUsedExternally() const {
   // Declaration marked as `@_alwaysEmitIntoClient` that
   // returns opaque result type with availability conditions
   // has to be kept alive to emit opaque type metadata descriptor.
-  if (markedAsAlwaysEmitIntoClient() &&
+  if (isAlwaysEmitIntoClient() &&
       hasOpaqueResultTypeWithAvailabilityConditions())
     return true;
 
@@ -1139,7 +1164,7 @@ bool SILFunction::shouldBePreservedForDebugger() const {
     return false;
 
   // Don't preserve anything markes as always emit into client.
-  if (markedAsAlwaysEmitIntoClient())
+  if (isAlwaysEmitIntoClient())
     return false;
 
   // Needed by lldb to print global variables which are propagated by the

--- a/lib/SIL/IR/SILFunctionBuilder.cpp
+++ b/lib/SIL/IR/SILFunctionBuilder.cpp
@@ -21,6 +21,7 @@
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/SemanticAttrs.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/Basic/CodeGenerationModel.h"
 #include "clang/AST/Mangle.h"
 
 using namespace swift;
@@ -391,6 +392,16 @@ SILFunction *SILFunctionBuilder::getOrCreateFunction(
       F->setAvailabilityForLinkage(*availability);
 
     F->setIsAlwaysWeakImported(decl->isAlwaysWeakImported());
+    if (auto cgModel = decl->getExplicitCodeGenerationModel()) {
+      switch (*cgModel) {
+      case CodeGenerationModel::Interface:
+      case CodeGenerationModel::Implementation:
+        F->setCodeGenerationModel(*cgModel);
+        break;
+      case CodeGenerationModel::Inlinable:
+        break;
+      }
+    }
 
     if (auto *accessor = dyn_cast<AccessorDecl>(decl)) {
       auto *storage = accessor->getStorage();

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -25,6 +25,7 @@
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/Basic/CodeGenerationModel.h"
 #include "swift/Basic/QuotedString.h"
 #include "swift/Basic/STLExtras.h"
 #include "swift/Basic/SourceManager.h"
@@ -3809,6 +3810,21 @@ void SILFunction::print(SILPrintContext &PrintCtx) const {
   }
   if (isAlwaysWeakImported())
     OS << "[weak_imported] ";
+  if (auto cgModel = codeGenerationModel()) {
+    switch (*cgModel) {
+    case CodeGenerationModel::Interface:
+      OS << "[export_interface] ";
+      break;
+
+    case CodeGenerationModel::Implementation:
+      OS << "[export_implementation] ";
+      break;
+
+    case CodeGenerationModel::Inlinable:
+      break;
+    }
+  }
+
   auto availability = getAvailabilityForLinkage();
   if (!availability.isAlwaysAvailable()) {
     OS << "[available " << availability.getVersionString() << "] ";

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -26,6 +26,7 @@
 #include "swift/AST/SourceFile.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/Basic/CodeGenerationModel.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Demangling/Demangle.h"
 #include "swift/Parse/Lexer.h"
@@ -690,7 +691,9 @@ static bool parseDeclSILOptional(
     OptimizationMode *optimizationMode, PerformanceConstraints *perfConstraints,
     bool *isPerformanceConstraint, bool *markedAsUsed, StringRef *asmName,
     StringRef *section,
-    bool *isLet, bool *isWeakImported, bool *needStackProtection,
+    bool *isLet, bool *isWeakImported,
+    std::optional<CodeGenerationModel> *codeGenerationModel,
+    bool *needStackProtection,
     bool *isSpecialized, AvailabilityRange *availability,
     bool *isWithoutActuallyEscapingThunk,
     SmallVectorImpl<std::string> *Semantics,
@@ -764,6 +767,10 @@ static bool parseDeclSILOptional(
                       M.getASTContext().LangOpts.Target.str());
       else
         *isWeakImported = true;
+    } else if (codeGenerationModel && SP.P.Tok.getText() == "export_interface") {
+      *codeGenerationModel = CodeGenerationModel::Interface;
+    } else if (codeGenerationModel && SP.P.Tok.getText() == "export_implementation") {
+      *codeGenerationModel = CodeGenerationModel::Implementation;
     } else if (availability && SP.P.Tok.getText() == "available") {
       SP.P.consumeToken(tok::identifier);
 
@@ -7431,6 +7438,7 @@ bool SILParserState::parseDeclSIL(Parser &P) {
   IsThunk_t isThunk = IsNotThunk;
   SILFunction::Purpose specialPurpose = SILFunction::Purpose::None;
   bool isWeakImported = false;
+  std::optional<CodeGenerationModel> codeGenerationModel;
   bool needStackProtection = false;
   AvailabilityRange availability = AvailabilityRange::alwaysAvailable();
   bool isWithoutActuallyEscapingThunk = false;
@@ -7459,7 +7467,7 @@ bool SILParserState::parseDeclSIL(Parser &P) {
           &objCReplacementFor, &specialPurpose, &inlineStrategy,
           &optimizationMode, &perfConstr, &isPerformanceConstraint,
           &markedAsUsed, &asmName, &section, nullptr, &isWeakImported,
-          &needStackProtection, nullptr, &availability,
+          &codeGenerationModel, &needStackProtection, nullptr, &availability,
           &isWithoutActuallyEscapingThunk, &Semantics, &SpecAttrs, &ClangDecl,
           &MRK, &actorIsolation, FunctionState, M) ||
       P.parseToken(tok::at_sign, diag::expected_sil_function_name) ||
@@ -7507,6 +7515,7 @@ bool SILParserState::parseDeclSIL(Parser &P) {
       FunctionState.F->setObjCReplacement(objCReplacementFor);
     FunctionState.F->setSpecialPurpose(specialPurpose);
     FunctionState.F->setIsAlwaysWeakImported(isWeakImported);
+    FunctionState.F->setCodeGenerationModel(codeGenerationModel);
     FunctionState.F->setAvailabilityForLinkage(availability);
     FunctionState.F->setWithoutActuallyEscapingThunk(
       isWithoutActuallyEscapingThunk);
@@ -7728,7 +7737,7 @@ bool SILParserState::parseSILGlobal(Parser &P) {
                            nullptr, nullptr, nullptr, &isMarkedAsUsed, &asmName,
                            &section, &isLet, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-                           State, M) ||
+                           nullptr, State, M) ||
       P.parseToken(tok::at_sign, diag::expected_sil_value_name) ||
       P.parseIdentifier(GlobalName, NameLoc, /*diagnoseDollarPrefix=*/false,
                         diag::expected_sil_value_name) ||
@@ -7785,7 +7794,8 @@ bool SILParserState::parseSILProperty(Parser &P) {
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-                           nullptr, nullptr, nullptr, nullptr, nullptr, SP, M))
+                           nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+                           SP, M))
     return true;
   
   ValueDecl *VD;
@@ -7876,7 +7886,7 @@ bool SILParserState::parseSILVTable(Parser &P) {
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-                           nullptr, nullptr, nullptr, nullptr, nullptr,
+                           nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            VTableState, M))
     return true;
 
@@ -8023,7 +8033,7 @@ bool SILParserState::parseSILMoveOnlyDeinit(Parser &parser) {
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-                           nullptr, nullptr, nullptr, nullptr, nullptr,
+                           nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            moveOnlyDeinitTableState, M))
     return true;
 
@@ -8547,7 +8557,7 @@ bool SILParserState::parseSILWitnessTable(Parser &P) {
           nullptr, &isSerialized, nullptr, nullptr, nullptr, nullptr, nullptr,
           nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
           nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-          nullptr, nullptr, nullptr, nullptr, nullptr, &isSpecialized,
+          nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, &isSpecialized,
           nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
           WitnessState, M))
     return true;

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1475,7 +1475,7 @@ void SILGenModule::emitDifferentiabilityWitness(
     // we can serialize it (the original function itself might be HiddenExternal
     // in this case if we only have declaration without definition).
     auto linkage =
-        originalFunction->markedAsAlwaysEmitIntoClient()
+        originalFunction->isAlwaysEmitIntoClient()
             ? SILLinkage::PublicNonABI
             : stripExternalFromLinkage(originalFunction->getLinkage());
     diffWitness = SILDifferentiabilityWitness::createDefinition(

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -6612,7 +6612,7 @@ SILFunction *SILGenModule::getOrCreateCustomDerivativeThunk(
   // linkage of derivative thunks so we can serialize them (the original
   // function itself might be HiddenExternal in this case if we only have
   // declaration without definition).
-  auto linkage = originalFn->markedAsAlwaysEmitIntoClient()
+  auto linkage = originalFn->isAlwaysEmitIntoClient()
                      ? SILLinkage::PublicNonABI
                      : stripExternalFromLinkage(originalFn->getLinkage());
 

--- a/lib/SILOptimizer/Differentiation/Common.cpp
+++ b/lib/SILOptimizer/Differentiation/Common.cpp
@@ -553,8 +553,8 @@ SILDifferentiabilityWitness *getOrCreateMinimalASTDifferentiabilityWitness(
       // Witness for @_alwaysEmitIntoClient original function must be emitted,
       // otherwise a linker error would occur due to undefined reference to the
       // witness symbol.
-      original->markedAsAlwaysEmitIntoClient() ? SILLinkage::PublicNonABI
-                                               : SILLinkage::PublicExternal,
+      original->isAlwaysEmitIntoClient() ? SILLinkage::PublicNonABI
+                                         : SILLinkage::PublicExternal,
       original, kind, minimalConfig->parameterIndices,
       minimalConfig->resultIndices, minimalConfig->derivativeGenericSignature);
 }

--- a/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
+++ b/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
@@ -513,6 +513,13 @@ bool CrossModuleOptimization::canSerializeFunction(
   // it to true at the end of this function.
   canSerializeFlags[function] = false;
 
+  // We can't serialize a function that explicitly opted out of being
+  // serialized.
+  if (auto decl = function->getDeclRef().getDecl()) {
+    if (decl->isNeverEmittedIntoClient())
+      return false;
+  }
+
   if (everything) {
     canSerializeFlags[function] = true;
     return true;

--- a/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
+++ b/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
@@ -515,10 +515,8 @@ bool CrossModuleOptimization::canSerializeFunction(
 
   // We can't serialize a function that explicitly opted out of being
   // serialized.
-  if (auto decl = function->getDeclRef().getDecl()) {
-    if (decl->isNeverEmittedIntoClient())
-      return false;
-  }
+  if (function->isNeverEmitIntoClient())
+    return false;
 
   if (everything) {
     canSerializeFlags[function] = true;

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -1148,7 +1148,7 @@ bool DifferentiationTransformer::canonicalizeDifferentiabilityWitness(
   // HiddenExternal if we only have declaration without definition), we want
   // derivatives to be serialized and do not patch `serializeFunctions`.
   if (orig->getLinkage() == SILLinkage::HiddenExternal &&
-      !orig->markedAsAlwaysEmitIntoClient())
+      !orig->isAlwaysEmitIntoClient())
     serializeFunctions = IsNotSerialized;
 
   // If the JVP doesn't exist, need to synthesize it.

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -25,6 +25,7 @@
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/Basic/CodeGenerationModel.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/PrettyStackTrace.h"
 #include "swift/SIL/SILArgument.h"
@@ -802,6 +803,7 @@ llvm::Expected<SILFunction *> SILDeserializer::readSILFunctionChecked(
       isWithoutActuallyEscapingThunk, specialPurpose, inlineStrategy,
       optimizationMode, perfConstr, subclassScope, hasCReferences,
       markedAsUsed, effect, numAttrs, hasQualifiedOwnership, isWeakImported,
+      codeGenerationModel,
       LIST_VER_TUPLE_PIECES(available), isDynamic, isExactSelfClass,
       isDistributed, isRuntimeAccessible, forceEnableLexicalLifetimes,
       onlyReferencedByDebugInfo;
@@ -811,6 +813,7 @@ llvm::Expected<SILFunction *> SILDeserializer::readSILFunctionChecked(
       isWithoutActuallyEscapingThunk, specialPurpose, inlineStrategy,
       optimizationMode, perfConstr, subclassScope, hasCReferences, markedAsUsed,
       effect, numAttrs, hasQualifiedOwnership, isWeakImported,
+      codeGenerationModel,
       LIST_VER_TUPLE_PIECES(available), isDynamic, isExactSelfClass,
       isDistributed, isRuntimeAccessible, forceEnableLexicalLifetimes,
       onlyReferencedByDebugInfo, funcTyID, replacedFunctionID,
@@ -981,6 +984,11 @@ llvm::Expected<SILFunction *> SILDeserializer::readSILFunctionChecked(
     fn->setOptimizationMode(OptimizationMode(optimizationMode));
     fn->setPerfConstraints((PerformanceConstraints)perfConstr);
     fn->setIsAlwaysWeakImported(isWeakImported);
+    if (codeGenerationModel) {
+      fn->setCodeGenerationModel(static_cast<CodeGenerationModel>(codeGenerationModel - 1));
+    } else {
+      fn->setCodeGenerationModel(std::nullopt);
+    }
     fn->setClassSubclassScope(SubclassScope(subclassScope));
     fn->setHasCReferences(bool(hasCReferences));
     fn->setMarkedAsUsed(bool(markedAsUsed));
@@ -4120,6 +4128,7 @@ bool SILDeserializer::hasSILFunction(StringRef Name,
       isWithoutActuallyEscapingThunk, isGlobal, inlineStrategy,
       optimizationMode, perfConstr, subclassScope, hasCReferences, markedAsUsed,
       effect, numSpecAttrs, hasQualifiedOwnership, isWeakImported,
+      codeGenerationModel,
       LIST_VER_TUPLE_PIECES(available), isDynamic, isExactSelfClass,
       isDistributed, isRuntimeAccessible, forceEnableLexicalLifetimes,
       onlyReferencedByDebugInfo;
@@ -4129,6 +4138,7 @@ bool SILDeserializer::hasSILFunction(StringRef Name,
       isWithoutActuallyEscapingThunk, isGlobal, inlineStrategy,
       optimizationMode, perfConstr, subclassScope, hasCReferences, markedAsUsed,
       effect, numSpecAttrs, hasQualifiedOwnership, isWeakImported,
+      codeGenerationModel,
       LIST_VER_TUPLE_PIECES(available), isDynamic, isExactSelfClass,
       isDistributed, isRuntimeAccessible, forceEnableLexicalLifetimes,
       onlyReferencedByDebugInfo, funcTyID, replacedFunctionID,

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -714,8 +714,10 @@ public:
   /// \c true if this module was built with strict memory safety.
   bool strictMemorySafety() const { return Core->strictMemorySafety(); }
 
-  /// \c true if this module uses deferred code generation.
-  bool deferredCodeGen() const { return Core->deferredCodeGen(); }
+  /// The code generation model used by this module.
+  CodeGenerationModel codeGenerationModel() const {
+    return Core->codeGenerationModel();
+  }
 
 
   /// \c true if this module was built with aggressive CMO

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -228,8 +228,11 @@ static bool readOptionsBlock(llvm::BitstreamCursor &cursor,
     case options_block::STRICT_MEMORY_SAFETY:
       extendedInfo.setStrictMemorySafety(true);
       break;
-    case options_block::DEFERRED_CODE_GEN:
-      extendedInfo.setDeferredCodeGen(true);
+    case options_block::CODE_GENERATION_MODEL:
+      unsigned codeGenModel;
+      options_block::CodeGenerationModelLayout::readRecord(scratch, codeGenModel);
+      extendedInfo.setCodeGenerationModel(
+          static_cast<CodeGenerationModel>(codeGenModel));
       break;
     case options_block::OSLOG_STRING_SECTION_NAME:
       extendedInfo.setOSLogStringSectionName(blobData);
@@ -1609,7 +1612,8 @@ ModuleFileSharedCore::ModuleFileSharedCore(
       Bits.AllowNonResilientAccess = extInfo.allowNonResilientAccess();
       Bits.SerializePackageEnabled = extInfo.serializePackageEnabled();
       Bits.StrictMemorySafety = extInfo.strictMemorySafety();
-      Bits.DeferredCodeGen = extInfo.deferredCodeGen();
+      Bits.CodeGenModel =
+          static_cast<unsigned>(extInfo.codeGenerationModel());
       Bits.AggressiveCMOEnabled = extInfo.isAggressiveCMOEnabled();
       Bits.LibraryLevel = unsigned(extInfo.getLibraryLevel());
       MiscVersion = info.miscVersion;

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -419,16 +419,14 @@ private:
     /// Whether this module enabled strict memory safety.
     unsigned StrictMemorySafety : 1;
 
-    /// Whether this module used deferred code generation.
-    unsigned DeferredCodeGen : 1;
+    /// The code generation model used by this module.
+    unsigned CodeGenModel : 2;
 
     /// Whether this module used deferred code generation.
     unsigned AggressiveCMOEnabled : 1;
 
     /// Discriminator for library level (LibraryLevel enum).
     unsigned LibraryLevel : 2;
-
-    // Explicitly pad out to the next word boundary if neccessary.
   } Bits = {};
   static_assert(sizeof(ModuleBits) <= 8, "The bit set should be small");
 
@@ -701,7 +699,9 @@ public:
 
   bool strictMemorySafety() const { return Bits.StrictMemorySafety; }
 
-  bool deferredCodeGen() const { return Bits.DeferredCodeGen; }
+  CodeGenerationModel codeGenerationModel() const {
+    return static_cast<CodeGenerationModel>(Bits.CodeGenModel);
+  }
 
   bool isAggressiveCMOEnabled() const { return Bits.AggressiveCMOEnabled; }
 

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 992; // generalized isolation storage in SILFunctionTypeLayout
+const uint16_t SWIFTMODULE_VERSION_MINOR = 993; // code generation model
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1009,7 +1009,7 @@ namespace options_block {
     PUBLIC_MODULE_NAME,
     SWIFT_INTERFACE_COMPILER_VERSION,
     STRICT_MEMORY_SAFETY,
-    DEFERRED_CODE_GEN,
+    CODE_GENERATION_MODEL,
     OSLOG_STRING_SECTION_NAME,
     AGGRESSIVE_CMO,
     LIBRARY_LEVEL,
@@ -1113,8 +1113,9 @@ namespace options_block {
     STRICT_MEMORY_SAFETY
   >;
 
-  using DeferredCodeGenLayout = BCRecordLayout<
-    DEFERRED_CODE_GEN
+  using CodeGenerationModelLayout = BCRecordLayout<
+    CODE_GENERATION_MODEL,
+    BCFixed<2>
   >;
 
   using AggressiveCMOEnabledLayout = BCRecordLayout<

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 993; // code generation model
+const uint16_t SWIFTMODULE_VERSION_MINOR = 994; // SIL code generation model
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -412,6 +412,7 @@ namespace sil_block {
                      BCVBR<8>,    // number of trailing records
                      BCFixed<1>,  // has qualified ownership
                      BCFixed<1>,  // force weak linking
+                     BCFixed<2>,  // code generation model
                      BC_AVAIL_TUPLE, // availability for weak linking
                      BCFixed<1>,  // is dynamically replacable
                      BCFixed<1>,  // exact self class

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -888,7 +888,7 @@ void Serializer::writeBlockInfoBlock() {
   BLOCK_RECORD(options_block, ALLOW_NON_RESILIENT_ACCESS);
   BLOCK_RECORD(options_block, SERIALIZE_PACKAGE_ENABLED);
   BLOCK_RECORD(options_block, STRICT_MEMORY_SAFETY);
-  BLOCK_RECORD(options_block, DEFERRED_CODE_GEN);
+  BLOCK_RECORD(options_block, CODE_GENERATION_MODEL);
   BLOCK_RECORD(options_block, AGGRESSIVE_CMO);
   BLOCK_RECORD(options_block, CXX_STDLIB_KIND);
   BLOCK_RECORD(options_block, PUBLIC_MODULE_NAME);
@@ -1211,9 +1211,9 @@ void Serializer::writeHeader() {
         StrictMemorySafety.emit(ScratchRecord);
       }
 
-      if (M->deferredCodeGen()) {
-        options_block::DeferredCodeGenLayout DeferredCodeGen(Out);
-        DeferredCodeGen.emit(ScratchRecord);
+      {
+        options_block::CodeGenerationModelLayout codeGenModel(Out);
+        codeGenModel.emit(ScratchRecord, static_cast<unsigned>(M->codeGenerationModel()));
       }
 
       if (M->hasCxxInteroperability()) {

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -621,7 +621,9 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
       (unsigned)F.getOptimizationMode(), (unsigned)F.getPerfConstraints(),
       (unsigned)F.getClassSubclassScope(), (unsigned)F.hasCReferences(),
       (unsigned)F.markedAsUsed(), (unsigned)F.getEffectsKind(),
-      (unsigned)numTrailingRecords, (unsigned)F.hasOwnership(), F.isAlwaysWeakImported(),
+      (unsigned)numTrailingRecords, (unsigned)F.hasOwnership(),
+      F.isAlwaysWeakImported(),
+      F.codeGenerationModel() ? (static_cast<unsigned>(*F.codeGenerationModel()) + 1) : 0,
       LIST_VER_TUPLE_PIECES(available), (unsigned)F.isDynamicallyReplaceable(),
       (unsigned)F.isExactSelfClass(), (unsigned)F.isDistributed(),
       (unsigned)F.isRuntimeAccessible(),
@@ -3769,11 +3771,9 @@ bool SILSerializer::shouldEmitFunctionBody(const SILFunction *F,
   if (F->isAvailableExternally())
     return false;
 
-  if (F->getDeclRef().hasDecl()) {
-    if (auto decl = F->getDeclRef().getDecl())
-      if (decl->isNeverEmittedIntoClient())
-        return false;
-  }
+  // Don't serialize the body if the client can never see it.
+  if (F->isNeverEmitIntoClient())
+    return false;
 
   // If we are asked to serialize everything, go ahead and do it.
   if (Options.SerializeAllSIL)

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -993,8 +993,7 @@ LoadedFile *SerializedModuleLoaderBase::loadAST(
       M.setIsConcurrencyChecked();
     if (loadedModuleFile->strictMemorySafety())
       M.setStrictMemorySafety();
-    if (loadedModuleFile->deferredCodeGen())
-      M.setDeferredCodeGen();
+    M.setCodeGenerationModel(loadedModuleFile->codeGenerationModel());
     if (loadedModuleFile->isAggressiveCMOEnabled())
       M.setAggressiveCMOEnabled();
     M.setStoredLibraryLevel(loadedModuleFile->getLibraryLevel());

--- a/test/AutoDiff/SILGen/nil_coalescing.swift
+++ b/test/AutoDiff/SILGen/nil_coalescing.swift
@@ -3,7 +3,7 @@
 
 import _Differentiation
 
-// CHECK: sil non_abi @test_nil_coalescing
+// CHECK: sil non_abi [export_implementation] @test_nil_coalescing
 // CHECK: bb0(%{{.*}} : $*T, %[[ARG_OPT:.*]] : $*Optional<T>, %[[ARG_PB:.*]] :
 // CHECK:    $@noescape @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <T>):
 // CHECK: %[[ALLOC_OPT:.*]] = alloc_stack [lexical] $Optional<T>

--- a/test/CAS/embedded-Xcc.swift
+++ b/test/CAS/embedded-Xcc.swift
@@ -20,10 +20,10 @@
 
 // RUN: %llvm-bcanalyzer --dump %t/Test.swiftmodule | %FileCheck %s
 
-// CHECK: <XCC abbrevid=7/> blob data = '-cc1'
-// CHECK: <XCC abbrevid=7/> blob data = '-D'
-// CHECK: <XCC abbrevid=7/> blob data = 'TEST=1'
-// CHECK-NOT: <XCC abbrevid=7/> blob data = '--target=
+// CHECK: <XCC abbrevid=[[XCC:[0-9]+]]/> blob data = '-cc1'
+// CHECK: <XCC abbrevid=[[XCC]]/> blob data = '-D'
+// CHECK: <XCC abbrevid=[[XCC]]/> blob data = 'TEST=1'
+// CHECK-NOT: <XCC abbrevid=6/> blob data = '--target=
 
 //--- main.swift
 public func test() {}

--- a/test/CAS/macro_plugin_external.swift
+++ b/test/CAS/macro_plugin_external.swift
@@ -74,7 +74,7 @@
 /// Encoded PLUGIN_SEARCH_OPTION is remapped.
 // RUN: %llvm-bcanalyzer -dump %t/Macro.swiftmodule | %FileCheck %s --check-prefix=MOD -DLIB=%target-library-name(MacroDefinition)
 
-// MOD: <PLUGIN_SEARCH_OPTION abbrevid=8 op0=4/> blob data = '/^test{{/|\\}}plugins{{/|\\}}[[LIB]]#/^bin{{/|\\}}swift-plugin-server{{(.exe)?}}#MacroDefinition'
+// MOD: <PLUGIN_SEARCH_OPTION abbrevid={{[0-9-]+}} op0=4/> blob data = '/^test{{/|\\}}plugins{{/|\\}}[[LIB]]#/^bin{{/|\\}}swift-plugin-server{{(.exe)?}}#MacroDefinition'
 
 /// Cache hit has no macro-loading remarks because no macro is actually loaded and the path might not be correct due to different mapping.
 // RUN: %target-swift-frontend-plain \

--- a/test/Concurrency/deinit_isolation_backdeploy.swift
+++ b/test/Concurrency/deinit_isolation_backdeploy.swift
@@ -12,4 +12,4 @@ class C {
 }
 
 // Make sure this function is available
-// CHECK: sil hidden_external [serialized] [available 12.0.0] @swift_task_deinitOnExecutorMainActorBackDeploy : $@convention(thin) (@owned AnyObject, @convention(thin) (@owned AnyObject) -> (), Builtin.Executor, Builtin.Word) -> ()
+// CHECK: sil hidden_external [serialized] [export_implementation] [available 12.0.0] @swift_task_deinitOnExecutorMainActorBackDeploy : $@convention(thin) (@owned AnyObject, @convention(thin) (@owned AnyObject) -> (), Builtin.Executor, Builtin.Word) -> ()

--- a/test/ModuleInterface/init_accessors.swift
+++ b/test/ModuleInterface/init_accessors.swift
@@ -107,7 +107,7 @@ func testTransparent() {
   _ = Transparent(x: 42)
 }
 
-// CHECK-LABEL: sil shared @$s1A11TransparentV1xACSi_tcfC : $@convention(method) (Int, @thin Transparent.Type) -> Transparent
+// CHECK-LABEL: sil shared [export_implementation] @$s1A11TransparentV1xACSi_tcfC : $@convention(method) (Int, @thin Transparent.Type) -> Transparent
 
 // CHECK-LABEL: sil hidden @$s6Client13testInlinableyyF : $@convention(thin) () -> ()
 // CHECK: [[X:%.*]] = struct $Int (%1 : $Builtin.Int{{[0-9]+}})
@@ -120,4 +120,4 @@ func testInlinable() {
 
 // CHECK-LABEL: sil @$s1A9InlinableV1xACSi_tcfC : $@convention(method) (Int, @thin Inlinable.Type) -> Inlinable
 
-// CHECK-LABEL: sil shared @$s1A11TransparentV1xSivi : $@convention(thin) (Int, @thin Transparent.Type) -> @out Int
+// CHECK-LABEL: sil shared [export_implementation] @$s1A11TransparentV1xSivi : $@convention(thin) (Int, @thin Transparent.Type) -> @out Int

--- a/test/Profiler/profiler_serialization.swift
+++ b/test/Profiler/profiler_serialization.swift
@@ -7,7 +7,7 @@
 
 import Foo
 
-// CHECK-LABEL: sil shared @$s3Foo19functionToSerializeSiyF
+// CHECK-LABEL: sil shared [export_implementation] @$s3Foo19functionToSerializeSiyF
 // CHECK:       increment_profiler_counter 0, "$s3Foo19functionToSerializeSiyF", num_counters 2, hash 0
 // CHECK:       increment_profiler_counter 1, "$s3Foo19functionToSerializeSiyF", num_counters 2, hash 0
 

--- a/test/SIL/availability_query_maccatalyst_zippered_inlined.swift
+++ b/test/SIL/availability_query_maccatalyst_zippered_inlined.swift
@@ -28,7 +28,7 @@ import Library
 
 test()
 
-// CHECK-LABEL: sil shared @$s7Library4testyyF
+// CHECK-LABEL: sil shared [export_implementation] @$s7Library4testyyF
 // CHECK: [[MACOS_MAJOR:%.*]] = integer_literal $Builtin.Word, 14
 // CHECK: [[MACOS_MINOR:%.*]] = integer_literal $Builtin.Word, 0
 // CHECK: [[MACOS_PATCH:%.*]] = integer_literal $Builtin.Word, 0

--- a/test/SILGen/always_emit_into_client_attribute.swift
+++ b/test/SILGen/always_emit_into_client_attribute.swift
@@ -1,24 +1,24 @@
 // RUN: %target-swift-emit-silgen -primary-file %s %S/Inputs/always_emit_into_client_other_file.swift -package-name Package | %FileCheck %s
 
-// CHECK-LABEL: sil non_abi [serialized] [ossa] @$s33always_emit_into_client_attribute0A22EmitIntoClientFunctionyyF : $@convention(thin) () -> ()
+// CHECK-LABEL: sil non_abi [serialized] [export_implementation] [ossa] @$s33always_emit_into_client_attribute0A22EmitIntoClientFunctionyyF : $@convention(thin) () -> ()
 @_alwaysEmitIntoClient public func alwaysEmitIntoClientFunction() {
   alwaysEmitIntoClientOtherFunction()
 }
 
-// CHECK: sil hidden_external [serialized] @$s33always_emit_into_client_attribute0A27EmitIntoClientOtherFunctionyyF : $@convention(thin) () -> ()
+// CHECK: sil hidden_external [serialized] [export_implementation] @$s33always_emit_into_client_attribute0A27EmitIntoClientOtherFunctionyyF : $@convention(thin) () -> ()
 
-// CHECK-LABEL: sil non_abi [serialized] [ossa] @$s33always_emit_into_client_attribute26implicitlyUsableFromInlineyyF : $@convention(thin) () -> ()
+// CHECK-LABEL: sil non_abi [serialized] [export_implementation] [ossa] @$s33always_emit_into_client_attribute26implicitlyUsableFromInlineyyF : $@convention(thin) () -> ()
 @_alwaysEmitIntoClient func implicitlyUsableFromInline() {
   alwaysEmitIntoClientOtherFunction()
 }
 
-// CHECK-LABEL: sil non_abi [serialized] [ossa] @$s33always_emit_into_client_attribute35packageAlwaysEmitIntoClientFunctionyyF : $@convention(thin) () -> ()
+// CHECK-LABEL: sil non_abi [serialized] [export_implementation] [ossa] @$s33always_emit_into_client_attribute35packageAlwaysEmitIntoClientFunctionyyF : $@convention(thin) () -> ()
 @_alwaysEmitIntoClient package func packageAlwaysEmitIntoClientFunction() {
   alwaysEmitIntoClientOtherFunction()
 }
 
 // FIXME: @_alwaysEmitIntoClient should not be allowed on private decls
-// CHECK-LABEL: sil non_abi [serialized] [ossa] @$s33always_emit_into_client_attribute35privateAlwaysEmitIntoClientFunction33_5D0713A780245A446371C699E6F23C4FLLyyF : $@convention(thin) () -> ()
+// CHECK-LABEL: sil non_abi [serialized] [export_implementation] [ossa] @$s33always_emit_into_client_attribute35privateAlwaysEmitIntoClientFunction33_5D0713A780245A446371C699E6F23C4FLLyyF : $@convention(thin) () -> ()
 @_alwaysEmitIntoClient private func privateAlwaysEmitIntoClientFunction() {
   alwaysEmitIntoClientOtherFunction()
 }
@@ -43,18 +43,18 @@ public struct S {
 
 public final class C {
   // C.__allocating_init()
-  // CHECK-LABEL: sil non_abi [serialized] [exact_self_class] [ossa] @$s33always_emit_into_client_attribute1CCACycfC : $@convention(method) (@thick C.Type) -> @owned C
+  // CHECK-LABEL: sil non_abi [serialized] [exact_self_class] [export_implementation] [ossa] @$s33always_emit_into_client_attribute1CCACycfC : $@convention(method) (@thick C.Type) -> @owned C
 
   // C.init()
-  // CHECK-LABEL: sil non_abi [serialized] [ossa] @$s33always_emit_into_client_attribute1CCACycfc : $@convention(method) (@owned C) -> @owned C
+  // CHECK-LABEL: sil non_abi [serialized] [export_implementation] [ossa] @$s33always_emit_into_client_attribute1CCACycfc : $@convention(method) (@owned C) -> @owned C
   @_alwaysEmitIntoClient
   public init() {}
 
   // C.deinit
-  // CHECK-LABEL: sil non_abi [serialized] [ossa] @$s33always_emit_into_client_attribute1CCfd : $@convention(method) (@guaranteed C) -> @owned Builtin.NativeObject
+  // CHECK-LABEL: sil non_abi [serialized] [export_implementation] [ossa] @$s33always_emit_into_client_attribute1CCfd : $@convention(method) (@guaranteed C) -> @owned Builtin.NativeObject
 
   // C.__deallocating_deinit
-  // CHECK-LABEL: sil non_abi [serialized] [ossa] @$s33always_emit_into_client_attribute1CCfD : $@convention(method) (@owned C) -> ()
+  // CHECK-LABEL: sil non_abi [serialized] [export_implementation] [ossa] @$s33always_emit_into_client_attribute1CCfD : $@convention(method) (@owned C) -> ()
   @_alwaysEmitIntoClient
   deinit {}
 }

--- a/test/SILGen/back_deployed_attr.swift
+++ b/test/SILGen/back_deployed_attr.swift
@@ -60,7 +60,7 @@ func inlinableCaller(_ s: inout S<Z>) {
   s.x = Z()
 }
 
-// CHECK-LABEL: sil non_abi [serialized] [ossa] @$s11back_deploy10aeicCalleryyAA1SVyAA1ZVGzF
+// CHECK-LABEL: sil non_abi [serialized] [export_implementation] [ossa] @$s11back_deploy10aeicCalleryyAA1SVyAA1ZVGzF
 @_alwaysEmitIntoClient
 func aeicCaller(_ s: inout S<Z>) {
   // CHECK: function_ref @$s11back_deploy8someFuncyyFTwb : $@convention(thin) () -> ()

--- a/test/Serialization/plugin_search_option_prefixing.swift
+++ b/test/Serialization/plugin_search_option_prefixing.swift
@@ -17,9 +17,9 @@
 // RUN:   -debug-prefix-map %swift-plugin-dir=/plugindir
 // RUN: %llvm-bcanalyzer -dump %t/Test.swiftmodule | %FileCheck %s
 
-// CHECK: <PLUGIN_SEARCH_OPTION abbrevid=9 op0=1/> blob data = '/externalsearchpath#/externalserverpath'
-// CHECK: <PLUGIN_SEARCH_OPTION abbrevid=9 op0=0/> blob data = '/plugindir'
-// CHECK: <PLUGIN_SEARCH_OPTION abbrevid=9 op0=2/> blob data = '/externalsearchpath/{{(lib)?}}MacroOne
+// CHECK: <PLUGIN_SEARCH_OPTION abbrevid=[[ID:[0-9]+]] op0=1/> blob data = '/externalsearchpath#/externalserverpath'
+// CHECK: <PLUGIN_SEARCH_OPTION abbrevid=[[ID]] op0=0/> blob data = '/plugindir'
+// CHECK: <PLUGIN_SEARCH_OPTION abbrevid=[[ID]] op0=2/> blob data = '/externalsearchpath/{{(lib)?}}MacroOne
 
 //--- macro-1.swift
 import SwiftSyntax

--- a/test/embedded/concurrency-deleted-method.swift
+++ b/test/embedded/concurrency-deleted-method.swift
@@ -38,7 +38,7 @@ actor MyActor {
 }
 
 // CHECK-IR:      @swift_deletedAsyncMethodErrorTu =
-// CHECK-IR:      @"$e4main7MyActorCN" = hidden constant <{ ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr }> <{
+// CHECK-IR:      @"$e4main7MyActorCN" = constant <{ ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr }> <{
 // CHECK-IR-SAME:   ptr null,
 // CHECK-IR-SAME:   ptr @"$e4main7MyActorCfD{{(.ptrauth[.0-9]*)?}}",
 // CHECK-IR-SAME:   ptr null,

--- a/test/embedded/linkage/export_interface.swift
+++ b/test/embedded/linkage/export_interface.swift
@@ -46,7 +46,7 @@ public func unnecessary() -> Int { 5 }
 
 // LIBRARY-IR: define linkonce_odr hidden swiftcc { ptr, ptr } @"$es27_allocateUninitializedArrayySayxG_BptBwlFSi_Tg5"
 
-// LIBRARY-SIL: sil @$e7Library5helloSaySiGyF
+// LIBRARY-SIL: sil [export_interface] @$e7Library5helloSaySiGyF
 // LIBRARY-SIL: sil @$e7Library8getArraySaySiGyF : $@convention(thin) () -> @owned Array<Int> {
 
 //--- Application.swift
@@ -61,7 +61,7 @@ public func testMe() {
 // Note: "hello" is emitted only into the object file, so there is no definition
 // here.
 
-// APPLICATION-SIL: sil @$e7Library5helloSaySiGyF : $@convention(thin) () -> @owned Array<Int>{{$}}
+// APPLICATION-SIL: sil [export_interface] @$e7Library5helloSaySiGyF : $@convention(thin) () -> @owned Array<Int>{{$}}
 // APPLICATION-IR: declare swiftcc ptr @"$e7Library5helloSaySiGyF"()
 
 // Note: "getArray" is not prohibited from being emitted into the client, so


### PR DESCRIPTION
* **Explanation**: Aggressive Cross-Module Optimization (and the variant of it used in Embedded Swift) mark additional functions as serialized. However, it does not respect `@export(interface)` as introduced by [SE-0497](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0497-definition-visibility.md), causing those function definitions to be serialized if they're needed by other serialized functions. Make CMO honor `@export(interface)`.
* **Scope**: This change centralizes the logic for determining the code generation model to use for a function, which can be `@export(interface)`, `@export(implementation)`, `@inlineable`, or the default, and extends the SIL function definition to include these options as well. This ensures that (1) we have more consistent computation of this information, and (2) it is always available to CMO, even after deserialization. 
* **Issues**: rdar://174749515
* **Risk**: Low-to-moderate risk, because it does centralize all "always emit into client" checks in the compiler. It's plausible that there is an edge case that will change behavior in a manner that causes a build breakage.
* **Testing**: Tests updated to ensure that the attributes propagate to SIL and the right definitions are serialized (or not).