### PR TITLE
Guard `getUTF16Count()` one-crumb optimization on 32-bit

### DIFF
--- a/stdlib/public/core/StringStorage.swift
+++ b/stdlib/public/core/StringStorage.swift
@@ -916,9 +916,16 @@ extension _StringGuts {
   
   @_effects(releasenone)
   internal func getUTF16Count() -> Int {
+#if _pointerBitWidth(_64)
     // Read the one-crumb value in a single atomic load to avoid a TOCTOU race
     // with loadUnmanagedBreadcrumbs(), which can CAS the slot to zero or
     // replace it with a real breadcrumbs pointer concurrently.
+    //
+    // On 32-bit platforms, Int(Int32.max) == Int.max, so any positive value
+    // (including a breadcrumbs pointer) would pass the range check below,
+    // causing a pointer address to be returned as a UTF-16 count. The
+    // one-crumb optimization is already disabled on 32-bit (hasOneCrumb
+    // returns false), so skip this fast path entirely.
     if hasNativeStorage {
       let val = _object.withNativeStorage { storage -> Int in
         guard storage.hasBreadcrumbs else { return -1 }
@@ -928,6 +935,7 @@ extension _StringGuts {
         return val
       }
     }
+#endif
 
     let result: Int
     if _useBreadcrumbs(forEncodedOffset: endIndex._encodedOffset) {


### PR DESCRIPTION
<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!-- Please fill out the following form: --> 
- **Explanation**: On 32-bit platforms, `Int(Int32.max) == Int.max`, so the range check in `getUTF16Count()` that distinguishes a one-crumb UTF-16 count from a real breadcrumbs pointer always passes, returning the pointer address as the UTF-16 count. Guard the one-crumb fast path with `#if _pointerBitWidth(_64)` since the optimization is already disabled on 32-bit via `hasOneCrumb`.
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: Bug fix for 32-bit platforms only. On 64-bit platforms, the code is unchanged. On 32-bit, `getUTF16Count()` now skips the one-crumb fast path and falls through to the existing path, which is the intended behavior.
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Issues**: Resolves rdar://174180121
  <!--
  References to issues the changes resolve, if any.
  -->
- **Original PRs**: None
  <!--
  Links to mainline branch pull requests in which the changes originated.
  -->
- **Risk**: Low, prevents a code path from running on 32-bit where the optimization is not supported
  <!--
  The (specific) risk to the release for taking the changes.
  -->
- **Testing**: CI testing
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->
- **Reviewers**: To be reviewed
  <!--
  The code owners that GitHub-approved the original changes in the mainline
  branch pull requests. If an original change has not been GitHub-approved by
  a respective code owner, provide a reason. Technical review can be delegated
  by a code owner or otherwise requested as deemed appropriate or useful.
  -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
