### PR TITLE
SILGen: drop substitution map in partial applies

### DIFF
--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -4169,6 +4169,7 @@ static CanAnyFunctionType getPropertyWrappedFieldInitAccessorInterfaceType(
     CanType selfType = wrappedProperty->getDeclContext()
                            ->getSelfInterfaceType()
                            ->getCanonicalType();
+    selfType = sig.getReducedType(selfType);
     // Create the self param
     params.emplace_back(
         selfType, Identifier(),

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -61,6 +61,27 @@ SILDebugLocation SILGenBuilder::getSILDebugLocation(SILLocation Loc,
 }
 
 //===----------------------------------------------------------------------===//
+//                             SILValue APIs
+//===----------------------------------------------------------------------===//
+
+PartialApplyInst *SILGenBuilder::createPartialApply(
+    SILLocation Loc, SILValue Fn, SubstitutionMap Subs, ArrayRef<SILValue> Args,
+    ParameterConvention CalleeConvention,
+    SILFunctionTypeIsolation ResultIsolation,
+    PartialApplyInst::OnStackKind OnStack, StackAllocationIsNested_t IsNested,
+    const GenericSpecializationInformation *SpecializationInfo) {
+
+  // We completely drop the generic signature if all generic parameters were
+  // concrete. Similar to emitRawApply.
+  if (Subs && Subs.getGenericSignature()->areAllParamsConcrete())
+    Subs = SubstitutionMap();
+
+  return SILBuilder::createPartialApply(Loc, Fn, Subs, Args, CalleeConvention,
+                                        ResultIsolation, OnStack, IsNested,
+                                        SpecializationInfo);
+}
+
+//===----------------------------------------------------------------------===//
 //                             Managed Value APIs
 //===----------------------------------------------------------------------===//
 

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -87,7 +87,16 @@ public:
                            CanType formalConcreteType, ManagedValue concrete,
                            ArrayRef<ProtocolConformanceRef> conformances);
 
-  using SILBuilder::createPartialApply;
+  PartialApplyInst *createPartialApply(
+      SILLocation Loc, SILValue Fn, SubstitutionMap Subs,
+      ArrayRef<SILValue> Args, ParameterConvention CalleeConvention,
+      SILFunctionTypeIsolation ResultIsolation =
+          SILFunctionTypeIsolation::forUnknown(),
+      PartialApplyInst::OnStackKind OnStack =
+          PartialApplyInst::OnStackKind::NotOnStack,
+      StackAllocationIsNested_t IsNested = StackAllocationIsNested,
+      const GenericSpecializationInformation *SpecializationInfo = nullptr);
+
   ManagedValue createPartialApply(SILLocation loc, SILValue fn,
                                   SubstitutionMap subs,
                                   ArrayRef<ManagedValue> args,

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -1987,13 +1987,6 @@ void SILGenFunction::emitAssignOrInit(SILLocation loc, ManagedValue selfValue,
                              getLoweredType(MetatypeType::get(expectedSelfTy)));
   }
 
-  if (auto invocationSig = initTy->getInvocationGenericSignature()) {
-    if (invocationSig->areAllParamsConcrete())
-      substitutions = SubstitutionMap();
-  } else {
-    substitutions = SubstitutionMap();
-  }
-
   PartialApplyInst *initPAI =
       B.createPartialApply(loc, initFRef, substitutions, selfMetatype,
                            ParameterConvention::Direct_Guaranteed,

--- a/test/SILGen/property_wrapper_constrained_extension.swift
+++ b/test/SILGen/property_wrapper_constrained_extension.swift
@@ -1,0 +1,66 @@
+// RUN: %target-swift-emit-silgen -module-name X %s | %FileCheck %s
+
+// Exercises a SILGen code path that would trigger an assertion when emitting
+// a property wrapper initializer inside a class nested in a constrained
+// extension, where the generic parameter is fully substituted (rdar://174669500)
+
+struct Projection<T> {
+  var value: T
+}
+
+@propertyWrapper
+struct Published<Value> {
+    var wrappedValue: Value
+    init(wrappedValue: Value) { self.wrappedValue = wrappedValue }
+
+    var projectedValue: Projection<Value> {
+        Projection(value: wrappedValue)
+    }
+
+    init(projectedValue: Projection<Value>) {
+      self.wrappedValue = projectedValue.value
+    }
+}
+
+struct Container<T: Hashable> {
+    var entries: [T: Int] = [:]
+}
+
+extension Container where T == String {
+    class Inner {
+    // CHECK-LABEL: sil hidden [ossa] @$s1X9ContainerVAASSRszrlE5InnerCAEySS_Gycfc
+    // CHECK: // function_ref property wrapped field init accessor of Container<>.Inner.data
+    // CHECK: [[INIT:%[0-9]+]] = function_ref @$s1X9ContainerVAASSRszrlE5InnerC4dataACySSGvpfF : $@convention(thin) (@owned Container<String>, @thick Container<String>.Inner.Type) -> @out Published<Container<String>>
+    // CHECK: [[INIT_PA:%[0-9]+]] = partial_apply [callee_guaranteed] [[INIT]]
+    // CHECK: // function_ref Container<>.Inner.data.setter
+    // CHECK: [[SET:%[0-9]+]] = function_ref @$s1X9ContainerVAASSRszrlE5InnerC4dataACySSGvs : $@convention(method) (@owned Container<String>, @guaranteed Container<String>.Inner) -> ()
+    // CHECK: [[SET_PA:%[0-9]+]] = partial_apply [callee_guaranteed] [on_stack] [[SET]]
+    // CHECK: assign_or_init #Container.Inner.data, {{.*}} init [[INIT_PA]], set [[SET_PA]]
+        init() {
+            data = Container<String>()
+        }
+
+        @Published var data: Container<String>
+
+        // For extra coverage only; not part of original issue.
+        func asProjected() -> Projection<Container<String>> {
+          return $data
+        }
+    }
+}
+
+// This is the generic version of the above.
+extension Container {
+    class Inner2 {
+        init(asGeneric t: T.Type) {
+            data2 = Container<T>()
+        }
+
+        @Published var data2: Container<T>
+
+        // For extra coverage only; not part of original issue.
+        func asProjected2() -> Projection<Container<T>> {
+          return $data2
+        }
+    }
+}


### PR DESCRIPTION
- Explanation: Fix an assertion failure from a recently upgraded assert [2]
- Scope: We do this kind of dropping of the substitution map for nearly every apply emitted in SILGen already (see `emitRawApply`) [1]. The partial applies also need this to avoid asserting when constructing SIL. This was most commonly violated in a seemingly harmless way by providing a substitution map that is fully concrete; the invocation signature would then expected to be empty in that case. 
It also fixes a small issue in TypeLowering for property wrapped field init accessors, where the type for Self within a constrained extension had a type parameter that was fixed to a concrete type and would trigger a different assertion failure.

- Issue: rdar://174669500
- Risk: Low-ish; we already would be asserting in asserts builds for years now. Ever since the assertion was upgraded, a few more corner cases that were missed should now be plugged by having it happen upon creation of the partial apply.
- Testing: regression tests added, along with local testing.
- Reviewers: TBD

[1] https://github.com/swiftlang/swift/pull/74266
[2] https://github.com/swiftlang/swift/pull/88160
