### PR TITLE
[Sema] Resolve self to concrete type for witness parameter sendability checking

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -34,6 +34,7 @@
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/AccessScope.h"
 #include "swift/AST/ClangModuleLoader.h"
+#include "swift/AST/ConcreteDeclRef.h"
 #include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DistributedDecl.h"
@@ -3651,8 +3652,15 @@ ConformanceChecker::checkActorIsolation(ValueDecl *requirement,
 
       // If this requirement is a function, check that its parameters are Sendable as well
       if (isa<AbstractFunctionDecl>(requirement)) {
+        // Create substitutions based on the conformance that are in the
+        // requirements generic environment, so that protocol generic parameters
+        // and associated types within the conformance can both resolve.
+        auto reqGenEnv = requirement->getInnermostDeclContext()
+                             ->getGenericEnvironmentOfContext();
+        auto reqSubs = Conformance->getType()->getMemberSubstitutionMap(
+            requirement, reqGenEnv);
         diagnoseNonSendableTypesInReference(
-            /*base=*/nullptr, getDeclRefInContext(requirement),
+            /*base=*/nullptr, ConcreteDeclRef(requirement, reqSubs),
             requirement->getInnermostDeclContext(), requirement->getLoc(),
             SendableCheckReason::Conformance, getActorIsolation(witness),
             FunctionCheckKind::Params, loc);

--- a/test/Concurrency/sendable_associated_type_in_witness.swift
+++ b/test/Concurrency/sendable_associated_type_in_witness.swift
@@ -1,0 +1,124 @@
+// RUN: %target-typecheck-verify-swift -swift-version 6
+
+class NS {} // expected-note 9 {{class 'NS' does not conform to the 'Sendable' protocol}}
+
+protocol AssocParam {
+  associatedtype Value
+  func process(_ value: Value) async
+}
+
+actor ActorNonSendableAssocParam: AssocParam {
+  typealias Value = NS
+  func process(_ value: NS) async {}
+  // expected-error@-1 {{non-Sendable parameter type 'ActorNonSendableAssocParam.Value' (aka 'NS') cannot be sent from caller of protocol requirement 'process' into actor-isolated implementation}}
+}
+
+actor ActorSendableAssocParam: AssocParam {
+  typealias Value = Int
+  func process(_ value: Int) async {}
+}
+
+@MainActor
+struct MainActorStructNonSendableAssocParam: AssocParam {
+  typealias Value = NS
+  func process(_ value: NS) async {}
+  // expected-error@-1 {{non-Sendable parameter type 'MainActorStructNonSendableAssocParam.Value' (aka 'NS') cannot be sent from caller of protocol requirement 'process' into main actor-isolated implementation}}
+}
+
+protocol SendableConstrainedAssocParam {
+  associatedtype Value: Sendable
+  func process(_ value: Value) async
+}
+
+actor ActorSendableConstrainedAssocParam: SendableConstrainedAssocParam {
+  typealias Value = Int
+  func process(_ value: Int) async {}
+}
+
+actor ActorNonSendableConstrainedAssocParam: SendableConstrainedAssocParam { // expected-error {{type 'ActorNonSendableConstrainedAssocParam.Value' (aka 'NS') does not conform to the 'Sendable' protocol}}
+  typealias Value = NS
+  func process(_ value: NS) async {}
+  // expected-error@-1 {{non-Sendable parameter type 'ActorNonSendableConstrainedAssocParam.Value' (aka 'NS') cannot be sent from caller of protocol requirement 'process' into actor-isolated implementation}}
+}
+
+protocol SelfParam {
+  func accept(_ other: Self) async
+}
+
+actor ActorSelfParam: SelfParam {
+  func accept(_ other: ActorSelfParam) async {}
+}
+
+protocol ArrayAssocParam {
+  associatedtype Element
+  func processAll(_ elements: [Element]) async
+}
+
+actor ActorNonSendableArrayAssocParam: ArrayAssocParam {
+  typealias Element = NS
+  func processAll(_ elements: [NS]) async {}
+  // expected-error@-1 {{non-Sendable parameter type '[ActorNonSendableArrayAssocParam.Element]' (aka 'Array<NS>') cannot be sent from caller of protocol requirement 'processAll' into actor-isolated implementation}}
+}
+
+protocol MixedAssocParams {
+  associatedtype Key
+  associatedtype Payload
+  func store(_ key: Key, _ payload: Payload) async
+}
+
+@MainActor
+struct MainActorStructMixedAssocParams: MixedAssocParams {
+  typealias Key = String
+  typealias Payload = NS
+  func store(_ key: String, _ payload: NS) async {}
+  // expected-error@-1 {{non-Sendable parameter type 'MainActorStructMixedAssocParams.Payload' (aka 'NS') cannot be sent from caller of protocol requirement 'store' into main actor-isolated implementation}}
+}
+
+protocol GenericAndAssocParam {
+  associatedtype Config
+  func apply<T>(_ config: Config, to value: T) async
+  // expected-note@-1 {{consider making generic parameter 'T' conform to the 'Sendable' protocol}}
+}
+
+actor ActorGenericAndAssocParam: GenericAndAssocParam {
+  typealias Config = Int
+  func apply<T>(_ config: Int, to value: T) async {}
+  // expected-error@-1 {{non-Sendable parameter type 'T' cannot be sent from caller of protocol requirement 'apply(_:to:)' into actor-isolated implementation}}
+}
+
+struct StructWithIsolatedMethod: AssocParam {
+  typealias Value = NS
+  @MainActor func process(_ value: NS) async {}
+  // expected-error@-1 {{non-Sendable parameter type 'StructWithIsolatedMethod.Value' (aka 'NS') cannot be sent from caller of protocol requirement 'process' into main actor-isolated implementation}}
+}
+
+protocol Entity {
+  associatedtype ID
+  var id: ID { get }
+}
+
+protocol Query {
+  associatedtype E: Entity
+  func fetch(for identifiers: [E.ID]) async
+}
+
+struct NSEntity: Entity {
+  let id: NS
+}
+
+actor ActorQueryNonSendableNestedAssoc: Query {
+  typealias E = NSEntity
+  func fetch(for identifiers: [NS]) async {}
+  // expected-error@-1 {{non-Sendable parameter type '[NS]' cannot be sent from caller of protocol requirement 'fetch(for:)' into actor-isolated implementation}}
+}
+
+protocol AssocReturn {
+  associatedtype Result
+  func produce() async -> Result
+}
+
+actor ActorNonSendableAssocReturn: AssocReturn {
+  typealias Result = NS
+  func produce() async -> NS { NS() }
+  // expected-error@-1 {{non-Sendable type 'NS' cannot be returned from actor-isolated implementation to caller of protocol requirement 'produce()'}}
+}


### PR DESCRIPTION
This PR builds a substitution map based on the conformance in the environment of the requirement, so that sendable associated types in the witness can be accepted in positions that need to be sendable.

Notably, the diagnostics aren't consistently presented regarding associated types in the parameter and return position, which might be an issue.

This allows us to accept code like this:

```swift
protocol P {
    associatedtype T
    var t: Self.T { get }
    func foo(_ t: Self.T) async
}

@MainActor
struct S: P {
    var t = 42
    func foo(_ t: T) async { }
}
```

Prior to this PR, we would have rejected this code because `T` is not `Sendable` in `P`.

Resolves rdar://125546061

<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!-- Please fill out the following form: --> 
- **Explanation**:
Creates a substitution map based on the conformance in the environment of the requirement to use for sendability checking of the parameters of a witness for a requirement, so that associated types can be resolved, while still ensuring the parameters are not more narrow than the requirement.
- **Scope**:
This change should only widen the amount of permissible conformances we accept. It should not break existing code, unless there could be something on the Self of the protocol that isn't present on the conformance?
- **Issues**:
 rdar://125546061
- **Risk**:
This could have a fallout in the way conformances are checked for sendability, and potentially break existing conformances by rejecting them (for some issue with the new substitution map). It could also theoretically permit invalid conformances, although associated types should always be fixed so it should be fine to check sendability with them instead of with the requirements.
- **Testing**:
Checked the example in the radar, ran the test suite, and added tests for cases with associated types.
