### PR TITLE
[SILOptimizer] Make sure that cloning also transfers the actor isolation

### DIFF
--- a/lib/SILOptimizer/Differentiation/JVPCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/JVPCloner.cpp
@@ -1712,6 +1712,9 @@ void JVPCloner::Implementation::prepareForDifferentialGeneration() {
   differential->setDebugScope(
       new (module) SILDebugScope(original->getLocation(), differential));
 
+  if (auto isolation = original->getActorIsolation())
+    differential->setActorIsolation(*isolation);
+
   return differential;
 }
 

--- a/lib/SILOptimizer/Differentiation/VJPCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/VJPCloner.cpp
@@ -1592,6 +1592,9 @@ SILFunction *VJPCloner::Implementation::createEmptyPullback() {
   pullback->setDebugScope(new (module)
                               SILDebugScope(original->getLocation(), pullback));
 
+  if (auto isolation = original->getActorIsolation())
+    pullback->setActorIsolation(*isolation);
+
   return pullback;
 }
 

--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
@@ -631,6 +631,9 @@ void ExistentialTransform::createExistentialSpecializedFunction() {
     for (auto &Attr : F->getSemanticsAttrs())
       NewF->addSemanticsAttr(Attr);
 
+    if (auto isolation = F->getActorIsolation())
+      NewF->setActorIsolation(*isolation);
+
     /// Set Unqualified ownership, if any.
     if (!F->hasOwnership()) {
       NewF->setOwnershipEliminated();

--- a/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
@@ -573,6 +573,9 @@ void FunctionSignatureTransform::createFunctionSignatureOptimizedFunction() {
       NewF->addSemanticsAttr(Attr);
   }
 
+  if (auto isolation = F->getActorIsolation())
+    NewF->setActorIsolation(*isolation);
+
   // Do the last bit of work to the newly created optimized function.
   DeadArgumentFinalizeOptimizedFunction();
   ArgumentExplosionFinalizeOptimizedFunction();

--- a/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
+++ b/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
@@ -476,6 +476,8 @@ ClosureCloner::initCloned(SILOptFunctionBuilder &functionBuilder,
       orig->getDebugScope());
   for (auto &attr : orig->getSemanticsAttrs())
     fn->addSemanticsAttr(attr);
+  if (auto isolation = orig->getActorIsolation())
+    fn->setActorIsolation(*isolation);
   return fn;
 }
 

--- a/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableAddressesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableAddressesChecker.cpp
@@ -1174,7 +1174,9 @@ SILFunction *ClosureArgumentInOutToOutCloner::initCloned(
   for (auto &Attr : orig->getSemanticsAttrs()) {
     Fn->addSemanticsAttr(Attr);
   }
-
+  if (auto isolation = orig->getActorIsolation()) {
+    Fn->setActorIsolation(*isolation);
+  }
   return Fn;
 }
 

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -1034,6 +1034,9 @@ static SILFunction *createEmptyVJP(ADContext &context,
       original->getInlineStrategy() == HeuristicAlwaysInline)
     vjp->setInlineStrategy(HeuristicAlwaysInline);
 
+  if (auto isolation = original->getActorIsolation())
+    vjp->setActorIsolation(*isolation);
+
   LLVM_DEBUG(llvm::dbgs() << "VJP type: " << vjp->getLoweredFunctionType()
                           << "\n");
   return vjp;
@@ -1081,6 +1084,9 @@ static SILFunction *createEmptyJVP(ADContext &context,
   if (original->getInlineStrategy() == AlwaysInline ||
       original->getInlineStrategy() == HeuristicAlwaysInline)
     jvp->setInlineStrategy(HeuristicAlwaysInline);
+
+  if (auto isolation = original->getActorIsolation())
+    jvp->setActorIsolation(*isolation);
 
   LLVM_DEBUG(llvm::dbgs() << "JVP type: " << jvp->getLoweredFunctionType()
                           << "\n");

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -1162,8 +1162,8 @@ bool UseAfterSendDiagnosticInferrer::initForIsolatedPartialApply(
   auto *diagnosticOp = diagnosticPair->first;
 
   ApplyIsolationCrossing crossing(
-      *op->getFunction()->getActorIsolation(),
-      *diagnosticOp->getFunction()->getActorIsolation());
+      op->getFunction()->getActorIsolation().value(),
+      diagnosticOp->getFunction()->getActorIsolation().value());
 
   auto &state = sendingOpToStateMap.get(sendingOp);
   if (auto rootValueAndName = inferNameAndRootHelper(sendingOp->get())) {
@@ -2078,8 +2078,8 @@ bool SentNeverSendableDiagnosticEmitter::initForIsolatedPartialApply(
   auto *diagnosticOp = diagnosticPair->first;
 
   ApplyIsolationCrossing crossing(
-      *op->getFunction()->getActorIsolation(),
-      *diagnosticOp->getFunction()->getActorIsolation());
+      op->getFunction()->getActorIsolation().value(),
+      diagnosticOp->getFunction()->getActorIsolation().value());
 
   // We do not need to worry about failing to infer a name here since we are
   // going to be returning some form of a SILFunctionArgument which is always

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -1586,6 +1586,9 @@ createEmptyFunction(StringRef name,
       fromFn->getClassSubclassScope(), fromFn->getInlineStrategy(),
       fromFn->getEffectsKind(), nullptr, fromFn->getDebugScope());
 
+  if (auto isolation = fromFn->getActorIsolation())
+    newF->setActorIsolation(*isolation);
+
   return newF;
 }
 

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -901,6 +901,9 @@ SILFunction *PromotedParamCloner::initCloned(SILOptFunctionBuilder &FuncBuilder,
   for (auto &Attr : Orig->getSemanticsAttrs()) {
     Fn->addSemanticsAttr(Attr);
   }
+  if (auto isolation = Orig->getActorIsolation()) {
+    Fn->setActorIsolation(*isolation);
+  }
   if (!Orig->hasOwnership()) {
     Fn->setOwnershipEliminated();
   }

--- a/lib/SILOptimizer/Utils/GenericCloner.cpp
+++ b/lib/SILOptimizer/Utils/GenericCloner.cpp
@@ -81,6 +81,9 @@ SILFunction *GenericCloner::createDeclaration(
   for (auto &Attr : Orig->getSemanticsAttrs()) {
     NewF->addSemanticsAttr(Attr);
   }
+  if (auto isolation = Orig->getActorIsolation()) {
+    NewF->setActorIsolation(*isolation);
+  }
   NewF->setOptimizationMode(Orig->getOptimizationMode());
   if (!Orig->hasOwnership()) {
     NewF->setOwnershipEliminated();

--- a/lib/SILOptimizer/Utils/OptimizerBridging.cpp
+++ b/lib/SILOptimizer/Utils/OptimizerBridging.cpp
@@ -478,6 +478,9 @@ createSpecializedFunctionDeclaration(BridgedStringRef specializedName,
   for (auto &Attr : original->getSemanticsAttrs())
     specializedApplySiteCallee->addSemanticsAttr(Attr);
 
+  if (auto isolation = original->getActorIsolation())
+    specializedApplySiteCallee->setActorIsolation(*isolation);
+
   return {specializedApplySiteCallee};
 }
 

--- a/test/AutoDiff/validation-test/closure_specialization/multi_bb_bte.swift
+++ b/test/AutoDiff/validation-test/closure_specialization/multi_bb_bte.swift
@@ -22,6 +22,7 @@ var AutoDiffClosureSpecMultiBBBTETests = TestSuite("AutoDiffClosureSpecMultiBBBT
 
 AutoDiffClosureSpecMultiBBBTETests.testWithLeakChecking("Test1") {
   // CHECK1-LABEL: {{^}}// reverse-mode derivative of mul42 #1 (_:)
+  // CHECK1-NEXT: {{^}}// Isolation: nonisolated
   // CHECK1-NEXT:  sil private @$s3outyycfU_5mul42L_yS2fSgFTJrSpSr : $@convention(thin) (Optional<Float>) -> (Float, @owned @callee_guaranteed (Float) -> Optional<Float>.TangentVector) {
   // CHECK1:         %[[#A12:]] = function_ref @$s3outyycfU_5mul42L_yS2fSgFTJpSpSr073$sSf16_DifferentiationE12_vjpMultiply3lhs3rhsSf5value_Sf_SftSfc8pullbacktj1_k5FZSf_K6SfcfU_S2fTf1nnc_n : $@convention(thin) (Float, @owned _AD__$s3outyycfU_5mul42L_yS2fSgF_bb2__Pred__src_0_wrt_0, Float, Float) -> Optional<Float>.TangentVector
   // CHECK1:         %[[#A13:]] = partial_apply [callee_guaranteed] %[[#A12]](%[[#]], %[[#]], %[[#]]) : $@convention(thin) (Float, @owned _AD__$s3outyycfU_5mul42L_yS2fSgF_bb2__Pred__src_0_wrt_0, Float, Float) -> Optional<Float>.TangentVector
@@ -47,6 +48,7 @@ AutoDiffClosureSpecMultiBBBTETests.testWithLeakChecking("Test1") {
 
 AutoDiffClosureSpecMultiBBBTETests.testWithLeakChecking("Test2") {
   // CHECK2-LABEL: {{^}}// reverse-mode derivative of cond_tuple_var #1 (_:)
+  // CHECK2-NEXT: {{^}}// Isolation: nonisolated
   // CHECK2-NEXT:  sil private @$s3outyycfU0_14cond_tuple_varL_yS2fFTJrSpSr : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
   // CHECK2:         %[[#E41:]] = function_ref @$s3outyycfU0_14cond_tuple_varL_yS2fFTJpSpSr067$sSf16_DifferentiationE7_vjpAdd3lhs3rhsSf5value_Sf_SftSfc8pullbacktl1_m5FZSf_M6SfcfU_0ef1_g4E12_i16Subtract3lhs3rhsk1_l1_mnl1_mo1_mP2U_ACTf1nnccc_n : $@convention(thin) (Float, @owned _AD__$s3outyycfU0_14cond_tuple_varL_yS2fF_bb3__Pred__src_0_wrt_0) -> Float
   // CHECK2:         %[[#E42:]] = partial_apply [callee_guaranteed] %[[#E41]](%[[#]]) : $@convention(thin) (Float, @owned _AD__$s3outyycfU0_14cond_tuple_varL_yS2fF_bb3__Pred__src_0_wrt_0) -> Float
@@ -90,6 +92,7 @@ AutoDiffClosureSpecMultiBBBTETests.testWithLeakChecking("Test3") {
     }
 
     // CHECK3-LABEL: {{^}}// reverse-mode derivative of method()
+    // CHECK3-NEXT: {{^}}// Isolation: unspecified
     // CHECK3-NEXT:  sil private @$s3outyycfU1_5ClassL_V6methodSfyFTJrSpSr : $@convention(method) (Class) -> (Float, @owned @callee_guaranteed (Float) -> Class.TangentVector) {
     // CHECK3:         %[[#C44:]] = function_ref @$s3outyycfU1_5ClassL_V6methodSfyFTJpSpSr073$sSf16_DifferentiationE12_vjpMultiply3lhs3rhsSf5value_Sf_SftSfc8pullbacktk1_l5FZSf_L6SfcfU_S2fAES2fTf1nncc_n : $@convention(thin) (Float, @owned _AD__$s3outyycfU1_5ClassL_V6methodSfyF_bb3__Pred__src_0_wrt_0, Float, Float, Float, Float) -> Class.TangentVector
     // CHECK3:         %[[#C45:]] = partial_apply [callee_guaranteed] %[[#C44]](%[[#]], %[[#]], %[[#]], %[[#]], %[[#]]) : $@convention(thin) (Float, @owned _AD__$s3outyycfU1_5ClassL_V6methodSfyF_bb3__Pred__src_0_wrt_0, Float, Float, Float, Float) -> Class.TangentVector

--- a/test/AutoDiff/validation-test/closure_specialization/multi_bb_no_bte.swift
+++ b/test/AutoDiff/validation-test/closure_specialization/multi_bb_no_bte.swift
@@ -26,6 +26,7 @@ typealias FloatArrayTan = Array<Float>.TangentVector
 
 AutoDiffClosureSpecMultiBBNoBTETests.testWithLeakChecking("Test1") {
   // CHECK1-LABEL: {{^}}// reverse-mode derivative of sumFirstThreeConcatenating1 #1 (_:_:)
+  // CHECK1-NEXT: {{^}}// Isolation: nonisolated
   // CHECK1-NEXT:  sil private @$s3outyycfU_27sumFirstThreeConcatenating1L_ySfSaySfG_ACtFTJrSSpSr : $@convention(thin) (@guaranteed Array<Float>, @guaranteed Array<Float>) -> (Float, @owned @callee_guaranteed (Float) -> (@owned Array<Float>.DifferentiableView, @owned Array<Float>.DifferentiableView)) {
   // CHECK1:         %[[#E52:]] = function_ref @$s3outyycfU_27sumFirstThreeConcatenating1L_ySfSaySfG_ACtFTJpSSpSr0138$sSa16_DifferentiationAA14DifferentiableRzlE13_vjpSubscript5indexx5value_SaA2aBRzlE0B4ViewVy13TangentVectorQz_GAIc8pullbacktSi_tFAKL_yAjiaQ7FSf_TG5ACSiAdCSi0f5Sf16_h3E7_M59Add3lhs3rhsSf5value_Sf_SftSfc8pullbacktSf_SftFZSf_SftSfcfU_AdCSiAETf1nnccccc_n : $@convention(thin) (Float, @owned @callee_guaranteed (@guaranteed Array<Float>.DifferentiableView) -> (@owned Array<Float>.DifferentiableView, @owned Array<Float>.DifferentiableView), @owned Array<Float>, Int, @owned Array<Float>, Int, @owned Array<Float>, Int) -> (@owned Array<Float>.DifferentiableView, @owned Array<Float>.DifferentiableView)
   // CHECK1:         %[[#E53:]] = partial_apply [callee_guaranteed] %[[#E52]](%[[#]], %[[#]], %[[#]], %[[#]], %[[#]], %[[#]], %[[#]]) : $@convention(thin) (Float, @owned @callee_guaranteed (@guaranteed Array<Float>.DifferentiableView) -> (@owned Array<Float>.DifferentiableView, @owned Array<Float>.DifferentiableView), @owned Array<Float>, Int, @owned Array<Float>, Int, @owned Array<Float>, Int) -> (@owned Array<Float>.DifferentiableView, @owned Array<Float>.DifferentiableView)
@@ -54,6 +55,7 @@ AutoDiffClosureSpecMultiBBNoBTETests.testWithLeakChecking("Test1") {
 
 AutoDiffClosureSpecMultiBBNoBTETests.testWithLeakChecking("Test2") {
   // CHECK2-LABEL: {{^}}// reverse-mode derivative of sumFirstThreeConcatenating2 #1 (_:_:)
+  // CHECK2-NEXT: {{^}}// Isolation: nonisolated
   // CHECK2-NEXT:  sil private @$s3outyycfU0_27sumFirstThreeConcatenating2L_ySfSaySfG_ACtFTJrSSpSr : $@convention(thin) (@guaranteed Array<Float>, @guaranteed Array<Float>) -> (Float, @owned @callee_guaranteed (Float) -> (@owned Array<Float>.DifferentiableView, @owned Array<Float>.DifferentiableView)) {
   // CHECK2:         %[[#E52:]] = function_ref @$s3outyycfU0_27sumFirstThreeConcatenating2L_ySfSaySfG_ACtFTJpSSpSr144$sSa16_DifferentiationAA14DifferentiableRzlE10_vjpAppendyyt5value_SaA2aBRzlE0B4ViewVy13TangentVectorQz_GAIzc8pullbacktSayxGz_AKtFZA2IzcfU_Sf_Tg5Si0fg1_hijk4E13_m23Subscript5indexx5value_opqrstuvwx29_GAIc8pullbacktSi_tFAKL_yAjiaQ7FSf_TG5ACSiAeCSi0f5Sf16_h3E7_M59Add3lhs3rhsSf5value_Sf_SftSfc8pullbacktSf_SftFZSf_SftSfcfU_AeCSiAFTf1ncccccc_n : $@convention(thin) (Float, Int, @owned Array<Float>, Int, @owned Array<Float>, Int, @owned Array<Float>, Int) -> (@owned Array<Float>.DifferentiableView, @owned Array<Float>.DifferentiableView)
   // CHECK2:         %[[#E53:]] = partial_apply [callee_guaranteed] %[[#E52]](%[[#]], %[[#]], %[[#]], %[[#]], %[[#]], %[[#]], %[[#]]) : $@convention(thin) (Float, Int, @owned Array<Float>, Int, @owned Array<Float>, Int, @owned Array<Float>, Int) -> (@owned Array<Float>.DifferentiableView, @owned Array<Float>.DifferentiableView)
@@ -113,6 +115,7 @@ AutoDiffClosureSpecMultiBBNoBTETests.testWithLeakChecking("Test3") {
   }
 
   // CHECK3:       {{^}}// reverse-mode derivative of multiply #1 (_:)
+  // CHECK3-NEXT: {{^}}// Isolation: nonisolated
   // CHECK3-NEXT:  sil private @$s3outyycfU1_8multiplyL_ySfAAyycfU1_20RealPropertyWrappersL_VFTJrSpSr : $@convention(thin) (RealPropertyWrappers) -> (Float, @owned @callee_guaranteed (Float) -> RealPropertyWrappers.TangentVector) {
   // CHECK3:         %[[#A22:]] = function_ref @$s3outyycfU1_8multiplyL_ySfAAyycfU1_20RealPropertyWrappersL_VFTJpSpSr073$sSf16_DifferentiationE12_vjpMultiply3lhs3rhsSf5value_Sf_SftSfc8pullbacktm1_n5FZSf_N6SfcfU_S2fTf1nnc_n015$s3outyycfU1_20cdE16L_V1xSfvgTJpSpSrTf1ncnn_n : $@convention(thin) (Float, Float, Float) -> RealPropertyWrappers.TangentVector
   // CHECK3:         %[[#A23:]] = partial_apply [callee_guaranteed] %[[#A22]](%[[#]], %[[#]]) : $@convention(thin) (Float, Float, Float) -> RealPropertyWrappers.TangentVector
@@ -160,6 +163,7 @@ AutoDiffClosureSpecMultiBBNoBTETests.testWithLeakChecking("Test4") {
   }
 
   // CHECK4-LABEL: {{^}}// reverse-mode derivative of methodWrapper #1 (_:)
+  // CHECK4-NEXT: {{^}}// Isolation: nonisolated
   // CHECK4-NEXT:  sil private @$s3outyycfU2_13methodWrapperL_ySfAAyycfU2_5ClassL_VFTJrSpSr : $@convention(thin) (Class) -> (Float, @owned @callee_guaranteed (Float) -> Class.TangentVector) {
   // CHECK4:         %[[#C39:]] = function_ref @$s3outyycfU2_13methodWrapperL_ySfAAyycfU2_5ClassL_VFTJpSpSr014$s3outyycfU2_5D21L_V6methodSfyFTJpSpSrAA05_AD__ef2_5d2L_gH24F_bb3__Pred__src_0_wrt_033_E588B908471A5F020CF23EC392ADD7D3LLOTf1nc_n : $@convention(thin) (Float, @owned _AD__$s3outyycfU2_5ClassL_V6methodSfyF_bb3__Pred__src_0_wrt_0) -> Class.TangentVector 
   // CHECK4:         %[[#C40:]] = partial_apply [callee_guaranteed] %[[#C39]](%[[#]]) : $@convention(thin) (Float, @owned _AD__$s3outyycfU2_5ClassL_V6methodSfyF_bb3__Pred__src_0_wrt_0) -> Class.TangentVector

--- a/test/AutoDiff/validation-test/closure_specialization/single_bb1.swift
+++ b/test/AutoDiff/validation-test/closure_specialization/single_bb1.swift
@@ -35,6 +35,7 @@ var AutoDiffClosureSpecSingleBBTests = TestSuite("AutoDiffClosureSpecSingleBB")
 
 AutoDiffClosureSpecSingleBBTests.testWithLeakChecking("Test1") {
   // CHECK1-LABEL: {{^}}// reverse-mode derivative of test1 #1 (_:)
+  // CHECK1-NEXT: {{^}}// Isolation: nonisolated
   // CHECK1-NEXT:  sil private @$s3outyycfU_5test1L_yS2fFTJrSpSr : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
   // CHECK1:         %[[#A10:]] = function_ref @$s3outyycfU_5test1L_yS2fFTJpSpSr62$s16_Differentiation7_vjpSinySf5value_S2fc8pullbacktSfFS2fcfU_Sf0c1_d1_e4Cosyg1_hiJ2U_Sf026$sSf16_DifferentiationE12_e16Multiply3lhs3rhsg1_i17_SftSfc8pullbackti1_q5FZSf_Q6SfcfU_S2fTf1nccc_n : $@convention(thin) (Float, Float, Float, Float, Float) -> Float
   // CHECK1:         %[[#A11:]] = partial_apply [callee_guaranteed] %[[#A10]](%[[#]], %[[#]], %[[#]], %[[#]]) : $@convention(thin) (Float, Float, Float, Float, Float) -> Float
@@ -62,6 +63,7 @@ AutoDiffClosureSpecSingleBBTests.testWithLeakChecking("Test1") {
 
 AutoDiffClosureSpecSingleBBTests.testWithLeakChecking("Test2") {
   // CHECK2-LABEL: {{^}}// reverse-mode derivative of test2 #1 (_:)
+  // CHECK2-NEXT: {{^}}// Isolation: nonisolated
   // CHECK2-NEXT:  sil private @$s3outyycfU0_5test2L_yS2fFTJrSpSr : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
   // CHECK2:         %[[#B19:]] = function_ref @$s3outyycfU0_5test2L_yS2fFTJpSpSr073$sSf16_DifferentiationE12_vjpMultiply3lhs3rhsSf5value_Sf_SftSfc8pullbacktj1_k5FZSf_K6SfcfU_S2f022$s16_Differentiation7_g4Sinyi15_S2fc8pullbacktJ8FS2fcfU_SfADSf0o1_p1_g4Cosyi1_rjS2U_SfACS2fAESf0cd1_e3E7_g11Add3lhs3rhsi1_j1_klj1_km1_kN2U_Tf1nccccccc_n : $@convention(thin) (Float, Float, Float, Float, Float, Float, Float, Float, Float) -> Float
   // CHECK2:         %[[#B20:]] = partial_apply [callee_guaranteed] %[[#B19]](%[[#]], %[[#]], %[[#]], %[[#]], %[[#]], %[[#]], %[[#]], %[[#]]) : $@convention(thin) (Float, Float, Float, Float, Float, Float, Float, Float, Float) -> Float
@@ -89,6 +91,7 @@ AutoDiffClosureSpecSingleBBTests.testWithLeakChecking("Test2") {
 
 AutoDiffClosureSpecSingleBBTests.testWithLeakChecking("Test3") {
   // CHECK3-LABEL: {{^}}// reverse-mode derivative of test3 #1 (_:_:_:)
+  // CHECK3-NEXT: {{^}}// Isolation: nonisolated
   // CHECK3-NEXT:  sil private @$s3outyycfU1_5test3L_yS2f_S2ftFTJrSSSpSr : $@convention(thin) (Float, Float, Float) -> (Float, @owned @callee_guaranteed (Float) -> (Float, Float, Float)) {
   // CHECK3:         %[[#C18:]] = function_ref @$s3outyycfU1_5test3L_yS2f_S2ftFTJpSSSpSr62$s16_Differentiation7_vjpSinySf5value_S2fc8pullbacktSfFS2fcfU_Sf0c1_d1_e4Cosyg1_hiJ2U_Sf025$sSf16_DifferentiationE7_e11Add3lhs3rhsg1_i17_SftSfc8pullbackti1_q5FZSf_Q6SfcfU_0c1_d1_e4Tanyg1_hiJ2U_Sf0lm1_n4E12_e16Subtract3lhs3rhsg1_i1_qri1_qs1_qT2U_Tf1nccccc_n : $@convention(thin) (Float, Float, Float, Float) -> (Float, Float, Float)
   // CHECK3:         %[[#C19:]] = partial_apply [callee_guaranteed] %[[#C18]](%[[#]], %[[#]], %[[#]]) : $@convention(thin) (Float, Float, Float, Float) -> (Float, Float, Float)

--- a/test/AutoDiff/validation-test/closure_specialization/single_bb2.swift
+++ b/test/AutoDiff/validation-test/closure_specialization/single_bb2.swift
@@ -31,6 +31,7 @@ AutoDiffClosureSpecSingleBBTests.testWithLeakChecking("Test4") {
   }
 
   // CHECK4-LABEL: {{^}}// reverse-mode derivative of test4 #1 (_:)
+  // CHECK4-NEXT: {{^}}// Isolation: nonisolated
   // CHECK4-NEXT:  sil private @$s3outyycfU_5test4L_yS2fFTJrSpSr : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
   // CHECK4:         %[[#D9:]] = function_ref @$s3outyycfU_5test4L_yS2fFTJpSpSr128$s3outyycfU_6doubleL_yS2fFTJpSpSr067$sSf16_DifferentiationE7_vjpAdd3lhs3rhsSf5value_Sf_SftSfc8pullbacktj1_k5FZSf_K6SfcfU_Tf1nc_n0c12U_6squareL_yefg7Sr073$si1_j4E12_l16Multiply3lhs3rhsn1_o1_pq1_rs1_tu2U_eV2_nS2fTf1ncc_n : $@convention(thin) (Float, Float, Float) -> Float
   // CHECK4:         %[[#D10:]] = partial_apply [callee_guaranteed] %[[#D9]](%[[#]], %[[#]]) : $@convention(thin) (Float, Float, Float) -> Float
@@ -58,6 +59,7 @@ AutoDiffClosureSpecSingleBBTests.testWithLeakChecking("Test4") {
 
 AutoDiffClosureSpecSingleBBTests.testWithLeakChecking("Test5") {
   // CHECK5-LABEL: {{^}}// reverse-mode derivative of test5 #1 (_:_:)
+  // CHECK5-NEXT: {{^}}// Isolation: nonisolated
   // CHECK5-NEXT:  sil private @$s3outyycfU0_5test5L_ySaySfGAC_SftFTJrSSpSr : $@convention(thin) (@guaranteed Array<Float>, Float) -> (@owned Array<Float>, @owned @callee_guaranteed (@guaranteed Array<Float>.DifferentiableView) -> (@owned Array<Float>.DifferentiableView, Float)) {
   // CHECK5:         %[[#E79:]] = function_ref @$s3outyycfU0_5test5L_ySaySfGAC_SftFTJpSSpSr073$sSf16_DifferentiationE12_vjpMultiply3lhs3rhsSf5value_Sf_SftSfc8pullbacktj1_k5FZSf_K6SfcfU_S2f0cd1_ef1_g16Subtract3lhs3rhsi1_j1_klj1_km1_kN2U_Tf1ncncn_n : $@convention(thin) (@guaranteed Array<Float>.DifferentiableView, @owned @callee_guaranteed (@guaranteed Array<Float>.DifferentiableView) -> (@owned Array<Float>.DifferentiableView, @owned Array<Float>.DifferentiableView), @owned @callee_guaranteed (@guaranteed Array<Float>.DifferentiableView) -> (@owned Array<Float>.DifferentiableView, @owned Array<Float>.DifferentiableView), Float, Float) -> (@owned Array<Float>.DifferentiableView, Float)
   // CHECK5:         %[[#E80:]] = partial_apply [callee_guaranteed] %[[#E79]](%[[#]], %[[#]], %[[#]], %[[#]]) : $@convention(thin) (@guaranteed Array<Float>.DifferentiableView, @owned @callee_guaranteed (@guaranteed Array<Float>.DifferentiableView) -> (@owned Array<Float>.DifferentiableView, @owned Array<Float>.DifferentiableView), @owned @callee_guaranteed (@guaranteed Array<Float>.DifferentiableView) -> (@owned Array<Float>.DifferentiableView, @owned Array<Float>.DifferentiableView), Float, Float) -> (@owned Array<Float>.DifferentiableView, Float)

--- a/test/Concurrency/transfernonsendable_closure_captures.swift
+++ b/test/Concurrency/transfernonsendable_closure_captures.swift
@@ -1362,3 +1362,27 @@ func testNestedClosuresMixedSendability() {
     }
   }
 }
+
+// Inner closure in this example gets specialized and it's important to make sure that it gets the right isolation
+// and the reference to `ns` doesn't get diagnosed.
+func testCaptureWithClosureSpecialization() {
+  @MainActor func test(_: @escaping @MainActor () async -> Void) async {}
+
+  @MainActor
+  class Test {
+    func compute() async {
+      var ns: KlassNonsendable? = .init()
+      // expected-warning@-1 {{variable 'ns' was never mutated; consider changing to 'let' constant}}
+
+      await test {
+        if let ns {
+          Task {
+            await Self.takesNS(ns)
+          }
+        }
+      }
+    }
+
+    static func takesNS(_: KlassNonsendable) async {}
+  }
+}

--- a/test/Concurrency/transfernonsendable_closure_captures_with_specialization.swift
+++ b/test/Concurrency/transfernonsendable_closure_captures_with_specialization.swift
@@ -1,0 +1,42 @@
+// RUN: %target-swift-frontend -emit-sil -language-mode 6 -disable-availability-checking -verify %s | %FileCheck %s
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+class KlassNonsendable {}
+
+// Inner closure in this example gets specialized and it's important to make sure that it gets the right isolation
+// and the reference to `ns` doesn't get diagnosed.
+func testCaptureWithClosureSpecialization() {
+  @MainActor func test(_: @escaping @MainActor () async -> Void) async {}
+
+  @MainActor
+  class Test {
+    func compute() async {
+      var ns: KlassNonsendable? = .init()
+      // expected-warning@-1 {{variable 'ns' was never mutated; consider changing to 'let' constant}}
+
+      await test {
+        if let ns {
+          // CHECK: // compute() in Test #1 in testCaptureWithClosureSpecialization()
+          // CHECK-NEXT: // Isolation: global_actor. type: MainActor
+          // CHECK-LABEL: sil private @$s56transfernonsendable_closure_captures_with_specialization36testCaptureWithClosureSpecializationyyF4TestL_C7computeyyYaF : $@convention(method) @async (@guaranteed Test) -> () {
+          // CHECK: [[NS:%.*]] = enum $Optional<KlassNonsendable>, #Optional.some!enumelt, {{.*}}
+          // CHECK: [[SPECIALIZED_CLOSURE:%.*]] = function_ref @$s56transfernonsendable_closure_captures_with_specialization36testCaptureWithClosureSpecializationyyF4TestL_C7computeyyYaFyyYaYbScMYccfU_Tf2in_n : $@convention(thin) @Sendable @async (@guaranteed Optional<KlassNonsendable>, @thick @dynamic_self Test.Type) -> ()
+          // CHECK-NEXT: partial_apply [callee_guaranteed] [[SPECIALIZED_CLOSURE]]([[NS]], {{.*}})
+          // CHECK: } // end sil function '$s56transfernonsendable_closure_captures_with_specialization36testCaptureWithClosureSpecializationyyF4TestL_C7computeyyYaF'
+          Task {
+            await Self.takesNS(ns)
+          }
+        }
+      }
+    }
+
+    static func takesNS(_: KlassNonsendable) async {}
+  }
+}
+
+// CHECK: // specialized closure #1 in compute() in Test #1 in testCaptureWithClosureSpecialization()
+// CHECK-NEXT: // Isolation: global_actor. type: MainActor
+// CHECK-NEXT: sil private @$s56transfernonsendable_closure_captures_with_specialization36testCaptureWithClosureSpecializationyyF4TestL_C7computeyyYaFyyYaYbScMYccfU_Tf2in_n : $@convention(thin) @Sendable @async (@guaranteed Optional<KlassNonsendable>, @thick @dynamic_self Test.Type) -> ()

--- a/test/TBD/specialization.swift
+++ b/test/TBD/specialization.swift
@@ -40,12 +40,15 @@ public func f() {
 
 // Generic specialization, from the foo call in f
 // CHECK-LABEL: // specialized Foo.foo<A>(_:)
+// CHECK-NEXT: // Isolation: unspecified
 // CHECK-NEXT: sil private [noinline] @$s14specialization3FooC3foo33_A6E3E43DB6679655BDF5A878ABC489A0LLyyxmlFSi_Ttg5Tf4d_n : $@convention(thin) () -> ()
 
 // Function signature specialization, from the bar call in Bar.init
 // CHECK-LABEL: // specialized Bar.bar()
+// CHECK-NEXT: // Isolation: unspecified
 // CHECK-NEXT: sil private [noinline] @$s14specialization3BarC3bar33_A6E3E43DB6679655BDF5A878ABC489A0LLyyFTf4d_n : $@convention(thin) () -> () {
 
 // Generic specialization, from the bar call in f
 // CHECK-LABEL: // specialized Bar.bar()
+// CHECK-NEXT: // Isolation: unspecified
 // CHECK-NEXT: sil private [noinline] @$s14specialization3BarC3bar33_A6E3E43DB6679655BDF5A878ABC489A0LLyyFSi_Tg5Tf4d_n : $@convention(thin) () -> ()


### PR DESCRIPTION
<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!-- Please fill out the following form: --> 
- **Explanation**:

    There are passes that rely on the isolation being present after
    specialization and other optimizations i.e. `SendNonSendable` which
    means the clones need to always preserve the isolation of the
    original function.

- **Scope**:
  
   This shouldn't have any impact on existing code.

- **Issues**:
  
   rdar://173640702

- **Risk**:

   Low. The impact here is limited to diagnostics only.

- **Testing**:

   Added new test-cases to the suite and modified existing test-cases. 

- **Reviewers**:
  
  @gottesmm 

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
