### PR TITLE
[DependencyScanning] Pass `-target` and `-clang-target` in PCM build commands

### DIFF
--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -2200,6 +2200,19 @@ ModuleDependencyInfo ModuleDependencyScanner::bridgeClangModuleDependency(
     swiftArgs.push_back(SDKPath.str());
   }
 
+  // Pass the -target flag so the Swift frontend uses the correct target
+  // triple for the -direct-clang-cc1-module-build action.
+  swiftArgs.push_back("-target");
+  swiftArgs.push_back(ScanASTContext.LangOpts.Target.str());
+
+  // If the scanner was invoked with -clang-target, forward it so the
+  // frontend can distinguish the Clang target from the Swift target
+  // (e.g. zippered Mac Catalyst builds).
+  if (ScanASTContext.LangOpts.ClangTarget.has_value()) {
+    swiftArgs.push_back("-clang-target");
+    swiftArgs.push_back(ScanASTContext.LangOpts.ClangTarget->str());
+  }
+
   // Add args reported by the scanner.
   auto clangArgs = invocation.getCC1CommandLine();
   llvm::for_each(clangArgs, addClangArg);

--- a/test/ScanDependencies/clang_pcm_target_triple.swift
+++ b/test/ScanDependencies/clang_pcm_target_triple.swift
@@ -1,0 +1,16 @@
+// Verify that Clang module PCM build commands from the dependency scanner
+// include the -target flag for the Swift frontend.
+
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/clang-module-cache
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import
+// RUN: %validate-json %t/deps.json | %FileCheck %s
+
+import C
+
+// Verify that Clang module C's command line includes -target.
+// CHECK: "clang": "C"
+// CHECK: "commandLine": [
+// CHECK: "-emit-pcm"
+// CHECK: "-target",
+// CHECK-NEXT: "{{[^"]+}}"


### PR DESCRIPTION
- **Explanation**: The dependency scanner was not including `-target` in the Swift frontend command line for Clang module PCM builds. This caused the frontend to default to the host triple, producing incorrect "libc not found" warnings when cross-compiling (e.g. for WebAssembly on Linux).
Also forward `-clang-target` when present so the frontend correctly distinguishes Swift and Clang targets in zippered builds.

- **Scope**: Affects all dependency scanning actions.
- **Issue**: rdar://174674714
- **Risk**: Low, the change is modifying `emit-pcm` action command-line recipes to include the same target triple as is already passed to those actions' underlying Clang invocations with `-Xcc -triple`.
- **Testing**: Added regression test to the scanner test suite.
- **Reviewers**: @owenv 
