### PR TITLE
[DependencyScan] Give each scanning worker its own SourceManager

### DIFF
--- a/include/swift/DependencyScan/ModuleDependencyScanner.h
+++ b/include/swift/DependencyScan/ModuleDependencyScanner.h
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/AST/ASTContext.h"
+#include "swift/Basic/SourceManager.h"
 #include "swift/AST/Identifier.h"
 #include "swift/AST/ModuleDependencies.h"
 #include "swift/Frontend/ModuleInterfaceLoader.h"
@@ -197,6 +198,8 @@ private:
 
   // Worker-specific instance of CompilerInvocation
   std::unique_ptr<CompilerInvocation> workerCompilerInvocation;
+  // Worker-specific SourceManager
+  SourceManager workerSourceMgr;
   // Worker-specific diagnostic engine
   std::unique_ptr<DiagnosticEngine> workerDiagnosticEngine;
   // Worker-specific instance of ASTContext

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -213,6 +213,7 @@ ModuleDependencyScanningWorker::ModuleDependencyScanningWorker(
     llvm::PrefixMapper *Mapper)
     : workerCompilerInvocation(
           std::make_unique<CompilerInvocation>(ScanCompilerInvocation)),
+      workerSourceMgr(ScanASTContext.SourceMgr.getFileSystem()),
       clangScanningTool(
           *globalScanningService.ClangScanningService,
           getClangScanningFS(globalScanningService, CAS, ScanASTContext)),
@@ -226,7 +227,7 @@ ModuleDependencyScanningWorker::ModuleDependencyScanningWorker(
 
   // Instantiate a worker-specific diagnostic engine and copy over
   // the scanner's diagnostic consumers (expected to be thread-safe).
-  workerDiagnosticEngine = std::make_unique<DiagnosticEngine>(ScanASTContext.SourceMgr);
+  workerDiagnosticEngine = std::make_unique<DiagnosticEngine>(workerSourceMgr);
   for (auto &scannerDiagConsumer : DiagnosticReporter.Diagnostics.getConsumers())
     workerDiagnosticEngine->addConsumer(*scannerDiagConsumer);
 
@@ -239,7 +240,7 @@ ModuleDependencyScanningWorker::ModuleDependencyScanningWorker(
                       workerCompilerInvocation->getSymbolGraphOptions(),
                       workerCompilerInvocation->getCASOptions(),
                       workerCompilerInvocation->getSerializationOptions(),
-                      ScanASTContext.SourceMgr, *workerDiagnosticEngine));
+                      workerSourceMgr, *workerDiagnosticEngine));
 
   scanningASTDelegate = std::make_unique<InterfaceSubContextDelegateImpl>(
       workerASTContext->SourceMgr, workerDiagnosticEngine.get(),


### PR DESCRIPTION
- **Explanation**: All `ModuleDependencyScanningWorker`s previously shared the parent scanner's `SourceManager`. `SourceManager` contains mutable caches that are not thread-safe, so concurrent worker access allowed for a data race that could corrupt the heap and crash in unrelated code (observed as an abort in `json::Value::destroy()` during `parseDarwinSDKInfo` on a worker thread).
Give each worker a private `SourceManager` initialized from the same (thread-safe, refcounted) VFS.

- **Scope**: Affects all multi-threaded (default) dependency scanning actions.

- **Issues**: Speculatively resolves rdar://174752231

- **Risk**: The change is low risk. It adds a per-scanner-worker `SourceManager`, replacing the previously shared
   `ScanASTContext.SourceMgr`. The scanner's diagnostic infrastructure already assumes `SourceLoc`s don't escape their originating `SourceManager`: `DepScanInMemoryDiagnosticCollector` already eagerly materializes locations into strings. The shared VFS is thread-safe by design. Workers already own their own `CompilerInvocation`, `DiagnosticEngine`, and `ASTContext`, the shared `SourceManager` was the outlier.

- **Testing**: The change is structural, validated by the existing test suite.

- **Reviewers**: TBD