### PR TITLE
build-script: dump current checkout

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -691,8 +691,6 @@ def main_normal():
         print_note('Using toolchain {}'.format(xcrun_toolchain))
         args.darwin_xcrun_toolchain = xcrun_toolchain
 
-    dump_current_checkout()
-
     toolchain = host_toolchain(xcrun_toolchain=args.darwin_xcrun_toolchain)
     os.environ['TOOLCHAINS'] = args.darwin_xcrun_toolchain
 
@@ -784,6 +782,7 @@ def main_normal():
 # -----------------------------------------------------------------------------
 
 def main():
+    dump_current_checkout()
     if not SWIFT_SOURCE_ROOT:
         fatal_error(
             "could not infer source root directory " +

--- a/utils/build-script
+++ b/utils/build-script
@@ -655,7 +655,7 @@ def main_preset():
 def dump_current_checkout():
     base_path = os.path.dirname(os.path.abspath(__file__))
     file_path = os.path.join(base_path, "update-checkout")
-    print(20 * "=", "begin current checkout:")
+    print(20 * "=", "begin current checkout:", flush=True)
     subprocess.run(
      [file_path, "--dump-hashes"],
      cwd=base_path

--- a/utils/build-script
+++ b/utils/build-script
@@ -21,6 +21,7 @@ import platform
 import re
 import sys
 import time
+import subprocess
 
 from build_swift.build_swift import argparse
 from build_swift.build_swift import defaults
@@ -651,6 +652,16 @@ def main_preset():
     shell.call_without_sleeping(build_script_args)
     return 0
 
+def dump_current_checkout():
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    print(20 * "=", "begin current checkout:")
+    subprocess.run(
+     ["./update-checkout", "--dump-hashes"],
+     cwd=current_dir
+    ) 
+    print(os.linesep, 20 * "=", "end current checkout:")
+
+
 
 # -----------------------------------------------------------------------------
 # Main (normal)
@@ -668,7 +679,6 @@ def main_normal():
                                       args.build_script_impl_args)
         except ValueError as e:
             exit_rejecting_arguments(e, parser)
-
         if '--check-args-only' in args.build_script_impl_args:
             return 0
 
@@ -681,6 +691,8 @@ def main_normal():
 
         print_note('Using toolchain {}'.format(xcrun_toolchain))
         args.darwin_xcrun_toolchain = xcrun_toolchain
+
+    dump_current_checkout()
 
     toolchain = host_toolchain(xcrun_toolchain=args.darwin_xcrun_toolchain)
     os.environ['TOOLCHAINS'] = args.darwin_xcrun_toolchain

--- a/utils/build-script
+++ b/utils/build-script
@@ -661,8 +661,6 @@ def dump_current_checkout():
     ) 
     print(os.linesep, 20 * "=", "end current checkout:")
 
-
-
 # -----------------------------------------------------------------------------
 # Main (normal)
 

--- a/utils/build-script
+++ b/utils/build-script
@@ -678,6 +678,7 @@ def main_normal():
                                       args.build_script_impl_args)
         except ValueError as e:
             exit_rejecting_arguments(e, parser)
+
         if '--check-args-only' in args.build_script_impl_args:
             return 0
 

--- a/utils/build-script
+++ b/utils/build-script
@@ -658,8 +658,8 @@ def dump_current_checkout():
     print(20 * "=", "begin current checkout:")
     subprocess.run(
      [file_path, "--dump-hashes"],
-     cwd=base_path 
-    ) 
+     cwd=base_path
+    )
     print(os.linesep + 20 * "=", "end current checkout:")
 
 # -----------------------------------------------------------------------------

--- a/utils/build-script
+++ b/utils/build-script
@@ -655,12 +655,12 @@ def main_preset():
 def dump_current_checkout():
     base_path = os.path.dirname(os.path.abspath(__file__))
     file_path = os.path.join(base_path, "update-checkout")
-    print(20 * "=", "begin current checkout:", flush=True)
+    print(20 * "=", "begin current checkout", flush=True)
     subprocess.run(
      [file_path, "--dump-hashes"],
      cwd=base_path
     )
-    print(os.linesep + 20 * "=", "end current checkout:")
+    print(os.linesep + 20 * "=", "end current checkout")
 
 # -----------------------------------------------------------------------------
 # Main (normal)

--- a/utils/build-script
+++ b/utils/build-script
@@ -653,13 +653,14 @@ def main_preset():
     return 0
 
 def dump_current_checkout():
-    current_dir = os.path.dirname(os.path.abspath(__file__))
+    base_path = os.path.dirname(os.path.abspath(__file__))
+    file_path = os.path.join(base_path, "update-checkout")
     print(20 * "=", "begin current checkout:")
     subprocess.run(
-     ["./update-checkout", "--dump-hashes"],
-     cwd=current_dir
+     [file_path, "--dump-hashes"],
+     cwd=base_path 
     ) 
-    print(os.linesep, 20 * "=", "end current checkout:")
+    print(os.linesep + 20 * "=", "end current checkout:")
 
 # -----------------------------------------------------------------------------
 # Main (normal)


### PR DESCRIPTION
Dump current checkout at build script start.
This is beneficial for reproducibility!
Always enabled, it is inside all logs of CI and local runs.
Developers are able to copy paste the config and reproduce checkout with:
`./swift/utils/update-checkout --scheme repro --config <path_to_config>`
