### PR TITLE
Use setOnlyIfDifferent for emit-pcm and emit-pch

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2252,7 +2252,7 @@ bool ClangImporter::emitBridgingPCH(
   FrontendOpts.ProgramAction = clang::frontend::GeneratePCH;
 
   auto action = wrapActionForIndexingIfEnabled(
-      FrontendOpts, std::make_unique<clang::GeneratePCHAction>());
+      FrontendOpts, std::make_unique<clang::GeneratePCHAction>(/*SetOnlyIfDifferent=*/true));
   emitInstance->ExecuteAction(*action);
 
   if (emitInstance->getDiagnostics().hasErrorOccurred() &&
@@ -2316,7 +2316,7 @@ bool ClangImporter::emitPrecompiledModule(
 
   auto action = wrapActionForIndexingIfEnabled(
       FrontendOpts,
-      std::make_unique<clang::GenerateModuleFromModuleMapAction>());
+      std::make_unique<clang::GenerateModuleFromModuleMapAction>(/*SetOnlyIfDifferent=*/true));
   emitInstance->ExecuteAction(*action);
 
   if (emitInstance->getDiagnostics().hasErrorOccurred() &&

--- a/test/Frontend/emit-pcm-pch-setonlyifdifferent.swift
+++ b/test/Frontend/emit-pcm-pch-setonlyifdifferent.swift
@@ -1,0 +1,26 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-emit-pcm -module-name Header -o %t/Header.pcm %t/module.modulemap
+// RUN: %{python} %S/../Inputs/getmtime.py %t/Header.pcm > %t/Header.pcm.stat.before
+// RUN: %target-swift-emit-pcm -module-name Header -o %t/Header.pcm %t/module.modulemap
+// RUN: %{python} %S/../Inputs/getmtime.py %t/Header.pcm > %t/Header.pcm.stat.after
+// RUN: diff %t/Header.pcm.stat.before %t/Header.pcm.stat.after
+
+// RUN: %target-swift-frontend -emit-pch %t/Header.h -o %t/Header.h.pch
+// RUN: %{python} %S/../Inputs/getmtime.py %t/Header.h.pch > %t/Header.h.pch.stat.before
+// RUN: %target-swift-frontend -emit-pch %t/Header.h -o %t/Header.h.pch
+// RUN: %{python} %S/../Inputs/getmtime.py %t/Header.h.pch > %t/Header.h.pch.stat.after
+// RUN: diff %t/Header.h.pch.stat.before %t/Header.h.pch.stat.after
+
+//--- test.swift
+import Header
+func testFunc() {}
+
+//--- module.modulemap
+module Header {
+  header "Header.h"
+}
+
+//--- Header.h
+void header(void);


### PR DESCRIPTION
This is to extend https://github.com/swiftlang/swift/pull/87922 to emit-pcm actions.

This fixes the issue of system modules getting rebuilt repeatedly on Windows.

Issue: https://github.com/swiftlang/swift/issues/88449
