### PR TITLE
Sema: Improve MemberImportVisibility diagnostics for conformances

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -174,6 +174,16 @@ GROUPED_ERROR(member_from_missing_imports_2_or_more,MemberImportVisibility,none,
       "%kind0 is not available due to missing imports of defining modules "
       "%2%select{ and|, }1 %3%select{|, and others}1",
       (const ValueDecl *, bool, const ModuleDecl *, const ModuleDecl *))
+GROUPED_ERROR(witness_from_missing_import,MemberImportVisibility,none,
+      "%kind0 used to satisfy a requirement of protocol %1 is not available "
+      "due to missing import of defining module %2",
+      (const ValueDecl *, const ProtocolDecl *, const ModuleDecl *))
+GROUPED_ERROR(witness_from_missing_imports_2_or_more,MemberImportVisibility,none,
+      "%kind0 used to satisfy a requirement of protocol %1 is not available "
+      "due to missing import of defining modules "
+      "%3%select{ and|, }2 %4%select{|, and others}2",
+      (const ValueDecl *, const ProtocolDecl *, bool, const ModuleDecl *,
+       const ModuleDecl *))
 NOTE(candidate_add_import,none,
      "add import of module %0", (const ModuleDecl *))
 
@@ -181,6 +191,9 @@ GROUPED_WARNING(add_required_import_for_member,MemberImportVisibility,none,
      "import of module %0 is required", (const ModuleDecl *))
 NOTE(decl_from_module_used_here,none,
      "%kind0 from %1 used here", (const ValueDecl *, const ModuleDecl *))
+NOTE(witness_from_module_used_here,none,
+     "%kind0 from %1 used to satisfy a requirement of protocol %2",
+     (const ValueDecl *, const ModuleDecl *, const ProtocolDecl *))
 
 ERROR(cannot_pass_rvalue_mutating_subelement,none,
       "cannot use mutating member on immutable value: %0",

--- a/include/swift/AST/RequirementMatch.h
+++ b/include/swift/AST/RequirementMatch.h
@@ -245,6 +245,9 @@ enum class CheckKind : unsigned {
   /// The witness is a deprecated default implementation provided by the
   /// protocol.
   DefaultWitnessDeprecated,
+
+  /// The witness is defined in a module that hasn't been imported.
+  RequiresMissingImport,
 };
 
 /// Describes the suitability of the chosen witness for

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -55,6 +55,40 @@ enum class RestrictedImportKind {
 /// Import that limits the access level of imported entities.
 using ImportAccessLevel = std::optional<AttributedImport<ImportedModule>>;
 
+/// Carries information about a single use of a member declaration that may
+/// require a missing import to be diagnosed. An instance is created at each
+/// use site and later processed by \c diagnoseMissingImports().
+///
+/// When the member is a conformance witness, \c getProtocol() returns the
+/// protocol whose requirement the witness satisfies, enabling a more
+/// descriptive diagnostic.
+class MissingImportForMemberDiag {
+  SourceLoc loc;
+  const ProtocolDecl *protocol;
+  DiagnosticBehavior behaviorLimit;
+
+public:
+  /// Create a diagnostic for a use of \p decl at \p loc.
+  ///
+  /// \param loc         The source location of the use.
+  /// \param behaviorLimit  An optional limit on the diagnostic's severity.
+  /// \param protocol    If non-null, the protocol whose requirement the used
+  ///                    member satisfies as a witness.
+  MissingImportForMemberDiag(SourceLoc loc, DiagnosticBehavior behaviorLimit,
+                             const ProtocolDecl *protocol)
+      : loc(loc), protocol(protocol), behaviorLimit(behaviorLimit) {}
+
+  /// The source location of the member use.
+  SourceLoc getLoc() const { return loc; }
+
+  /// An optional upper bound on how severe the emitted diagnostic may be.
+  DiagnosticBehavior getBehaviorLimit() const { return behaviorLimit; }
+
+  /// If this use is a conformance witness, the protocol whose requirement
+  /// the witness satisfies; otherwise, \c nullptr.
+  const ProtocolDecl *getProtocol() const { return protocol; }
+};
+
 /// A file containing Swift source code.
 ///
 /// This is a .swift or .sil file (or a virtual file, such as the contents of
@@ -137,8 +171,9 @@ private:
 
   /// Associates a list of source locations to the member declarations that must
   /// be diagnosed as being out of scope due to a missing import.
-  using DelayedMissingImportForMemberDiags = llvm::SmallDenseMap<
-      const ValueDecl *, std::vector<std::pair<SourceLoc, DiagnosticBehavior>>>;
+  using DelayedMissingImportForMemberDiags =
+      llvm::SmallDenseMap<const ValueDecl *,
+                          std::vector<MissingImportForMemberDiag>>;
   DelayedMissingImportForMemberDiags MissingImportForMemberDiagnostics;
 
   /// A unique identifier representing this file; used to mark private decls
@@ -522,10 +557,9 @@ public:
 
   /// Add a source location for which a delayed missing import for member
   /// diagnostic should be emited.
-  void addDelayedMissingImportForMemberDiagnostic(const ValueDecl *decl,
-                                                  SourceLoc loc,
-                                                  DiagnosticBehavior limit) {
-    MissingImportForMemberDiagnostics[decl].push_back({loc, limit});
+  void addDelayedMissingImportForMemberDiagnostic(
+      const ValueDecl *decl, const MissingImportForMemberDiag diag) {
+    MissingImportForMemberDiagnostics[decl].push_back(diag);
   }
 
   DelayedMissingImportForMemberDiags

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -936,21 +936,38 @@ public:
 
 static void diagnoseMissingImportsForMember(
     const ValueDecl *decl, SmallVectorImpl<ModuleDecl *> &modulesToImport,
-    SourceFile *sf, SourceLoc loc, DiagnosticBehavior limit) {
+    SourceFile *sf, const MissingImportForMemberDiag &missingImportDiag) {
   auto &ctx = sf->getASTContext();
-  auto count = modulesToImport.size();
-  ASSERT(count > 0);
+  auto moduleCount = modulesToImport.size();
+  auto loc = missingImportDiag.getLoc();
+  ASSERT(moduleCount > 0);
 
-  if (count > 1) {
-    ctx.Diags
-        .diagnose(loc, diag::member_from_missing_imports_2_or_more, decl,
-                  bool(count > 2), modulesToImport[0], modulesToImport[1])
-        .limitBehavior(limit);
+  if (auto *protocol = missingImportDiag.getProtocol()) {
+    if (moduleCount > 1) {
+      ctx.Diags
+          .diagnose(loc, diag::witness_from_missing_imports_2_or_more, decl,
+                    protocol, bool(moduleCount > 2), modulesToImport[0],
+                    modulesToImport[1])
+          .limitBehavior(missingImportDiag.getBehaviorLimit());
+    } else {
+      ctx.Diags
+          .diagnose(loc, diag::witness_from_missing_import, decl, protocol,
+                    modulesToImport.front())
+          .limitBehavior(missingImportDiag.getBehaviorLimit());
+    }
   } else {
-    ctx.Diags
-        .diagnose(loc, diag::member_from_missing_import, decl,
-                  modulesToImport.front())
-        .limitBehavior(limit);
+    if (moduleCount > 1) {
+      ctx.Diags
+          .diagnose(loc, diag::member_from_missing_imports_2_or_more, decl,
+                    bool(moduleCount > 2), modulesToImport[0],
+                    modulesToImport[1])
+          .limitBehavior(missingImportDiag.getBehaviorLimit());
+    } else {
+      ctx.Diags
+          .diagnose(loc, diag::member_from_missing_import, decl,
+                    modulesToImport.front())
+          .limitBehavior(missingImportDiag.getBehaviorLimit());
+    }
   }
 }
 
@@ -996,7 +1013,7 @@ static void emitMissingImportNoteAndFixIt(
 
 static void
 diagnoseAndFixMissingImportForMember(const ValueDecl *decl, SourceFile *sf,
-                                     SourceLoc loc, DiagnosticBehavior limit,
+                                     const MissingImportForMemberDiag &diag,
                                      MissingImportFixItCache &fixItCache) {
 
   auto modulesAndFixits =
@@ -1007,7 +1024,7 @@ diagnoseAndFixMissingImportForMember(const ValueDecl *decl, SourceFile *sf,
   if (modulesToImport.empty())
     return;
 
-  diagnoseMissingImportsForMember(decl, modulesToImport, sf, loc, limit);
+  diagnoseMissingImportsForMember(decl, modulesToImport, sf, diag);
 
   auto &ctx = sf->getASTContext();
   SourceLoc bestLoc = ctx.Diags.getBestAddImportFixItLoc(sf);
@@ -1019,10 +1036,8 @@ diagnoseAndFixMissingImportForMember(const ValueDecl *decl, SourceFile *sf,
   }
 }
 
-bool swift::maybeDiagnoseMissingImportForMember(const ValueDecl *decl,
-                                                const DeclContext *dc,
-                                                SourceLoc loc,
-                                                DiagnosticBehavior limit) {
+bool swift::shouldDiagnoseMissingImportForMember(const ValueDecl *decl,
+                                                 const DeclContext *dc) {
   // Only diagnose references in source files.
   auto sf = dc->getParentSourceFile();
   if (!sf)
@@ -1041,8 +1056,9 @@ bool swift::maybeDiagnoseMissingImportForMember(const ValueDecl *decl,
   if (dc->isDeclImported(decl))
     return false;
 
-  auto definingModule = decl->getModuleContextForNameLookup();
   if (ctx.LangOpts.EnableCXXInterop) {
+    auto definingModule = decl->getModuleContextForNameLookup();
+
     // With Cxx interop enabled, there are some declarations that always belong
     // to the Clang header import module which should always be implicitly
     // visible. However, that module is not implicitly imported in source files
@@ -1051,24 +1067,56 @@ bool swift::maybeDiagnoseMissingImportForMember(const ValueDecl *decl,
       return false;
   }
 
-  // In lazy typechecking mode just emit the diagnostic immediately without a
-  // fix-it since there won't be an opportunity to emit delayed diagnostics.
   if (ctx.TypeCheckerOpts.EnableLazyTypecheck) {
     // Lazy type-checking and migration for MemberImportVisibility are
     // completely incompatible, so just skip the diagnostic entirely.
     if (ctx.LangOpts.isMigratingToFeature(Feature::MemberImportVisibility))
       return false;
+  }
 
+  return true;
+}
+
+static bool
+emitOrDelayMissingImportForMemberDiag(const ValueDecl *decl,
+                                      const DeclContext *dc,
+                                      MissingImportForMemberDiag diag) {
+  if (!shouldDiagnoseMissingImportForMember(decl, dc))
+    return false;
+
+  auto &ctx = dc->getASTContext();
+  auto sf = dc->getParentSourceFile();
+
+  // In lazy typechecking mode just emit the diagnostic immediately without a
+  // fix-it since there won't be an opportunity to emit delayed diagnostics.
+  if (ctx.TypeCheckerOpts.EnableLazyTypecheck) {
+    auto definingModule = decl->getModuleContextForNameLookup();
     auto modulesToImport = missingImportsForDefiningModule(definingModule, *sf);
     if (modulesToImport.empty())
       return false;
 
-    diagnoseMissingImportsForMember(decl, modulesToImport, sf, loc, limit);
+    diagnoseMissingImportsForMember(decl, modulesToImport, sf, diag);
     return true;
   }
 
-  sf->addDelayedMissingImportForMemberDiagnostic(decl, loc, limit);
+  sf->addDelayedMissingImportForMemberDiagnostic(decl, diag);
   return false;
+}
+
+bool swift::maybeDiagnoseMissingImportForMember(const ValueDecl *decl,
+                                                const DeclContext *dc,
+                                                SourceLoc loc,
+                                                DiagnosticBehavior limit) {
+  return emitOrDelayMissingImportForMemberDiag(
+      decl, dc, MissingImportForMemberDiag(loc, limit, /*protocol=*/nullptr));
+}
+
+bool swift::maybeDiagnoseMissingImportForConformanceWitness(
+    const ValueDecl *decl, const ProtocolDecl *protocol, const DeclContext *dc,
+    SourceLoc loc, DiagnosticBehavior limit) {
+  ASSERT(protocol);
+  return emitOrDelayMissingImportForMemberDiag(
+      decl, dc, MissingImportForMemberDiag(loc, limit, protocol));
 }
 
 void migrateToMemberImportVisibility(SourceFile &sf) {
@@ -1087,8 +1135,8 @@ void migrateToMemberImportVisibility(SourceFile &sf) {
   llvm::SmallVector<ModuleDecl *, 8> modulesToImport;
   llvm::SmallDenseMap<ModuleDecl *, std::vector<const ValueDecl *>>
       declsByModuleToImport;
-  for (auto declAndLocs : delayedDiags) {
-    auto decl = declAndLocs.first;
+  for (const auto &declAndDiags : delayedDiags) {
+    auto decl = declAndDiags.first;
     auto definingModules = missingImportsForDefiningModule(
         decl->getModuleContextForNameLookup(), sf);
 
@@ -1122,13 +1170,19 @@ void migrateToMemberImportVisibility(SourceFile &sf) {
       continue;
 
     for (auto decl : decls->second) {
-      auto locs = delayedDiags.find(decl);
-      if (locs == delayedDiags.end())
+      const auto &declAndDiags = delayedDiags.find(decl);
+      if (declAndDiags == delayedDiags.end())
         continue;
 
-      for (auto locAndLimit : locs->second) {
-        auto loc = locAndLimit.first;
-        ctx.Diags.diagnose(loc, diag::decl_from_module_used_here, decl, mod);
+      for (const auto &diag : declAndDiags->second) {
+        if (auto *protocol = diag.getProtocol()) {
+          ctx.Diags.diagnose(diag.getLoc(),
+                             diag::witness_from_module_used_here, decl, mod,
+                             protocol);
+        } else {
+          ctx.Diags.diagnose(diag.getLoc(), diag::decl_from_module_used_here,
+                             decl, mod);
+        }
       }
     }
   }
@@ -1145,10 +1199,9 @@ void swift::diagnoseMissingImports(SourceFile &sf) {
   auto delayedDiags = sf.takeDelayedMissingImportForMemberDiagnostics();
   auto fixItCache = MissingImportFixItCache(sf);
 
-  for (auto declAndLocs : delayedDiags) {
-    for (auto locAndLimit : declAndLocs.second) {
-      auto [loc, limit] = locAndLimit;
-      diagnoseAndFixMissingImportForMember(declAndLocs.first, &sf, loc, limit,
+  for (const auto &declAndDiags : delayedDiags) {
+    for (const auto &diag : declAndDiags.second) {
+      diagnoseAndFixMissingImportForMember(declAndDiags.first, &sf, diag,
                                            fixItCache);
     }
   }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1506,13 +1506,16 @@ WitnessChecker::WitnessChecker(ASTContext &ctx, ProtocolDecl *proto,
     : Context(ctx), Proto(proto), Adoptee(adoptee), DC(dc) {}
 
 static void
-lookupValueWitnessesViaImplementsAttr(
-    DeclContext *DC, ValueDecl *req, SmallVector<ValueDecl *, 4> &witnesses) {
+lookupValueWitnessesViaImplementsAttr(DeclContext *DC, ValueDecl *req,
+                                      SmallVector<ValueDecl *, 4> &witnesses,
+                                      bool ignoreMissingImports) {
 
   auto name = req->createNameRef();
   auto *nominal = DC->getSelfNominalTypeDecl();
 
   NLOptions subOptions = (NL_ProtocolMembers | NL_IncludeAttributeImplements);
+  if (ignoreMissingImports)
+    subOptions |= NL_IgnoreMissingImports;
 
   nominal->synthesizeSemanticMembersIfNeeded(name.getFullName());
 
@@ -1557,7 +1560,8 @@ static bool contextMayExpandOperator(
 }
 
 SmallVector<ValueDecl *, 4>
-swift::lookupValueWitnesses(DeclContext *DC, ValueDecl *req, bool *ignoringNames) {
+swift::lookupValueWitnesses(DeclContext *DC, ValueDecl *req,
+                            bool *ignoringNames, bool ignoreMissingImports) {
   assert(!isa<AssociatedTypeDecl>(req) && "Not for lookup for type witnesses*");
   assert(req->isProtocolRequirement() || isa<AccessorDecl>(req));
 
@@ -1565,7 +1569,8 @@ swift::lookupValueWitnesses(DeclContext *DC, ValueDecl *req, bool *ignoringNames
 
   // Do an initial check to see if there are any @_implements remappings
   // for this requirement.
-  lookupValueWitnessesViaImplementsAttr(DC, req, witnesses);
+  lookupValueWitnessesViaImplementsAttr(DC, req, witnesses,
+                                        ignoreMissingImports);
 
   auto reqName = req->createNameRef();
   auto reqBaseName = reqName.withoutArgumentLabels(DC->getASTContext());
@@ -1601,8 +1606,10 @@ swift::lookupValueWitnesses(DeclContext *DC, ValueDecl *req, bool *ignoringNames
     // extensions, including those that match only by base name. Take care not
     // to restate them in the resulting list, or else an otherwise valid
     // conformance will become ambiguous.
-    const NLOptions options =
-        doUnqualifiedLookup ? NLOptions(0) : NL_ProtocolMembers;
+    NLOptions options = doUnqualifiedLookup ? NLOptions(0) : NL_ProtocolMembers;
+
+    if (ignoreMissingImports)
+      options |= NL_IgnoreMissingImports;
 
     SmallVector<ValueDecl *, 4> lookupResults;
     bool addedAny = false;
@@ -1662,9 +1669,15 @@ bool WitnessChecker::findBestWitness(
                                bool &doNotDiagnoseMatches) {
   enum Attempt {
     Regular,
+    IgnoreMissingImports,
     OperatorsFromOverlay,
     Done
   };
+
+  const bool ignoreMissingImportsDuringRegularLookup =
+      DC->getAsDecl()->isImplicit() ||
+      !Context.LangOpts.hasFeature(Feature::MemberImportVisibility,
+                                   /*allowMigration=*/true);
 
   bool anyFromUnconstrainedExtension;
   numViable = 0;
@@ -1673,7 +1686,16 @@ bool WitnessChecker::findBestWitness(
     SmallVector<ValueDecl *, 4> witnesses;
     switch (attempt) {
     case Regular:
-      witnesses = lookupValueWitnesses(DC, requirement, ignoringNames);
+      witnesses = lookupValueWitnesses(DC, requirement, ignoringNames,
+                                       ignoreMissingImportsDuringRegularLookup);
+      break;
+    case IgnoreMissingImports:
+      if (ignoreMissingImportsDuringRegularLookup)
+        continue;
+
+      // Try again, this time ignoring missing imports to find more candidates.
+      witnesses = lookupValueWitnesses(DC, requirement, ignoringNames,
+                                       /*ignoreMissingImports=*/true);
       break;
     case OperatorsFromOverlay: {
       // If we have a Clang declaration, the matching operator might be in the
@@ -2024,6 +2046,10 @@ RequirementCheck WitnessChecker::checkWitness(ValueDecl *requirement,
       return RequirementCheck(CheckKind::DefaultWitnessDeprecated);
     }
   }
+
+  // Check whether the witness has been imported appropriately.
+  if (shouldDiagnoseMissingImportForMember(match.Witness, DC))
+    return CheckKind::RequiresMissingImport;
 
   return CheckKind::Success;
 }
@@ -4722,6 +4748,21 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
                            requirement);
           });
         break;
+
+      case CheckKind::RequiresMissingImport: {
+        // In migrate mode the conformance is still valid (it's just a warning
+        // to add the import), so don't mark it as an error.
+        bool isError = !Context.LangOpts.isMigratingToFeature(
+            Feature::MemberImportVisibility);
+        getASTContext().addDelayedConformanceDiag(
+            Conformance, isError,
+            [witness](NormalProtocolConformance *conformance) {
+              maybeDiagnoseMissingImportForConformanceWitness(
+                  witness, conformance->getProtocol(),
+                  conformance->getDeclContext(), conformance->getLoc());
+            });
+        break;
+      }
     }
 
     if (auto *classDecl = DC->getSelfClassDecl()) {

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -49,9 +49,9 @@ class RequirementEnvironment;
 /// witnesses with the correct full name, the results will reflect
 /// lookup for just the base name and the pointee will be set to
 /// \c true.
-SmallVector<ValueDecl *, 4> lookupValueWitnesses(DeclContext *DC,
-                                                 ValueDecl *req,
-                                                 bool *ignoringNames);
+SmallVector<ValueDecl *, 4>
+lookupValueWitnesses(DeclContext *DC, ValueDecl *req, bool *ignoringNames,
+                     bool ignoreMissingImports = false);
 
 class RequirementCheck;
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1544,6 +1544,11 @@ void recordRequiredImportAccessLevelForDecl(const ValueDecl *decl,
 /// Report imports that are marked public but are not used in API.
 void diagnoseUnnecessaryPublicImports(SourceFile &SF);
 
+/// Returns true if a diagnostic ought to be emitted for any explicit reference
+/// to decl made from within the given DeclContext.
+bool shouldDiagnoseMissingImportForMember(const ValueDecl *decl,
+                                          const DeclContext *dc);
+
 /// Emit or delay a diagnostic that suggests adding a missing import that is
 /// necessary to bring \p decl into scope in the containing source file. If
 /// delayed, the diagnostic will instead be emitted after type checking the
@@ -1552,6 +1557,16 @@ void diagnoseUnnecessaryPublicImports(SourceFile &SF);
 bool maybeDiagnoseMissingImportForMember(
     const ValueDecl *decl, const DeclContext *dc, SourceLoc loc,
     DiagnosticBehavior limit = DiagnosticBehavior::Unspecified);
+
+/// Emit or delay a diagnostic that suggests adding a missing import that is
+/// necessary to bring \p decl into scope in the containing source file so that
+/// a conformance to \p protocol is valid. If delayed, the diagnostic will
+/// instead be emitted after type checking the entire file and will include an
+/// appropriate fix-it. Returns true if a diagnostic was emitted (and not
+/// delayed).
+bool maybeDiagnoseMissingImportForConformanceWitness(
+    const ValueDecl *decl, const ProtocolDecl *protocol, const DeclContext *dc,
+    SourceLoc loc, DiagnosticBehavior limit = DiagnosticBehavior::Unspecified);
 
 /// Emit delayed diagnostics regarding imports that should be added to the
 /// source file.

--- a/test/NameLookup/Inputs/MemberImportVisibility/members_A.swift
+++ b/test/NameLookup/Inputs/MemberImportVisibility/members_A.swift
@@ -81,6 +81,16 @@ extension ProtocolInA {
   public func defaultedRequirementInA() { }
 }
 
+public protocol ProtocolWithAssociatedTypesInA {
+  associatedtype WitnessedInA
+  associatedtype WitnessedInB
+  associatedtype WitnessedInC
+}
+
+public struct StructWithWitnessesForProtocolWithAssociatedTypesInA {
+  public struct WitnessedInA { }
+}
+
 public struct EquatableInA: Equatable {
   public static func ==(_: Self, _: Self) -> Bool {
     false

--- a/test/NameLookup/Inputs/MemberImportVisibility/members_B.swift
+++ b/test/NameLookup/Inputs/MemberImportVisibility/members_B.swift
@@ -61,6 +61,10 @@ extension ProtocolInA {
   public func defaultedRequirementInB() { }
 }
 
+extension StructWithWitnessesForProtocolWithAssociatedTypesInA {
+  public struct WitnessedInB { }
+}
+
 public struct EquatableInB: Equatable {
   public static func ==(_: EquatableInB, _: EquatableInB) -> Bool {
     false

--- a/test/NameLookup/Inputs/MemberImportVisibility/members_C.swift
+++ b/test/NameLookup/Inputs/MemberImportVisibility/members_C.swift
@@ -53,6 +53,10 @@ extension ProtocolInA {
   public func defaultedRequirementInC() { }
 }
 
+extension StructWithWitnessesForProtocolWithAssociatedTypesInA {
+  public struct WitnessedInC { }
+}
+
 public struct EquatableInC: Equatable {
   public static func ==(_: EquatableInC, _: EquatableInC) -> Bool {
     false

--- a/test/NameLookup/member_import_visibility.swift
+++ b/test/NameLookup/member_import_visibility.swift
@@ -9,7 +9,7 @@
 // REQUIRES: swift_feature_MemberImportVisibility
 
 import members_C
-// expected-member-visibility-note 27{{add import of module 'members_B'}}{{1-1=internal import members_B\n}}
+// expected-member-visibility-note 28{{add import of module 'members_B'}}{{1-1=internal import members_B\n}}
 
 
 func testExtensionMembers(x: X, y: Y<Z>) {
@@ -137,8 +137,16 @@ class DerivedFromClassInC: DerivedClassInC {
   override func methodInC() {}
 }
 
-// FIXME: Visibility of defaultedRequirementInB() should be diagnosed (rdar://154237873)
-struct ConformsToProtocolInA: ProtocolInA {} // expected-member-visibility-error{{type 'ConformsToProtocolInA' does not conform to protocol 'ProtocolInA'}} expected-member-visibility-note {{add stubs for conformance}}{{44-44=\n    func defaultedRequirementInB() {\n        <#code#>\n    \}\n}}
+struct ConformsToProtocolInA: ProtocolInA {}
+// expected-member-visibility-error@-1{{type 'ConformsToProtocolInA' does not conform to protocol 'ProtocolInA'}}
+// expected-member-visibility-error@-2{{instance method 'defaultedRequirementInB()' used to satisfy a requirement of protocol 'ProtocolInA' is not available due to missing import of defining module 'members_B'}}
+
+// FIXME: The missing import for WitnessedInB should be diagnosed (rdar://154237873)
+extension StructWithWitnessesForProtocolWithAssociatedTypesInA: ProtocolWithAssociatedTypesInA {}
+// expected-warning@-1{{extension declares a conformance of imported type 'StructWithWitnessesForProtocolWithAssociatedTypesInA' to imported protocol 'ProtocolWithAssociatedTypesInA'; this will not behave correctly if the owners of 'members_A' introduce this conformance in the future}}
+// expected-note@-2{{add '@retroactive' to silence this warning}}
+// expected-member-visibility-error@-3{{type 'StructWithWitnessesForProtocolWithAssociatedTypesInA' does not conform to protocol 'ProtocolWithAssociatedTypesInA'}}
+// expected-member-visibility-note@-4{{add stubs for conformance}}{{97-97=\n    public typealias WitnessedInB = <#type#>\n}}
 
 func testInheritedMethods(
   a: BaseClassInA,

--- a/test/NameLookup/member_import_visibility_migrate.swift
+++ b/test/NameLookup/member_import_visibility_migrate.swift
@@ -106,6 +106,47 @@ extension Int {
 
 extension Int.TypealiasInInternalUsesOnly { } // expected-note {{type alias 'TypealiasInInternalUsesOnly' from 'InternalUsesOnly' used here}}
 
+protocol InternalProtocolWithImportedWitnesses {
+  var memberInInternalUsesOnly: Int { get }
+  var memberInInternalUsesOnlyDefaultedImport: Int { get }
+  var memberInMixedUses: Int { get }
+  var memberInInternalUsesOnlyReexported: Int { get }
+  var memberInInternalUsesOnlySPIOnly: Int { get }
+  var memberInInternalUsesOnlyDefaultedImportSPIOnly: Int { get }
+  var memberInInternalUsesOnlyTransitivelyImported: Int { get }
+}
+
+extension Int: InternalProtocolWithImportedWitnesses { }
+// expected-note@-1 {{property 'memberInInternalUsesOnlyReexported' from 'InternalUsesOnlyReexported' used to satisfy a requirement of protocol 'InternalProtocolWithImportedWitnesses'}}
+// expected-note@-2 {{property 'memberInInternalUsesOnlyDefaultedImport' from 'InternalUsesOnlyDefaultedImport' used to satisfy a requirement of protocol 'InternalProtocolWithImportedWitnesses'}}
+// expected-note@-3 {{property 'memberInMixedUses' from 'MixedUses' used to satisfy a requirement of protocol 'InternalProtocolWithImportedWitnesses'}}
+// expected-note@-4 {{property 'memberInInternalUsesOnlyDefaultedImportSPIOnly' from 'InternalUsesOnlyDefaultedImportSPIOnly' used to satisfy a requirement of protocol 'InternalProtocolWithImportedWitnesses'}}
+// expected-note@-5 {{property 'memberInInternalUsesOnly' from 'InternalUsesOnly' used to satisfy a requirement of protocol 'InternalProtocolWithImportedWitnesses'}}
+// expected-note@-6 {{property 'memberInInternalUsesOnlyTransitivelyImported' from 'InternalUsesOnlyTransitivelyImported' used to satisfy a requirement of protocol 'InternalProtocolWithImportedWitnesses'}}
+// expected-note@-7 {{property 'memberInInternalUsesOnlySPIOnly' from 'InternalUsesOnlySPIOnly' used to satisfy a requirement of protocol 'InternalProtocolWithImportedWitnesses'}}
+
+package protocol PackageProtocolWithImportedWitnesses {
+  var memberInPackageUsesOnly: Int { get }
+  var memberInMixedUses: Int { get }
+}
+
+extension Int: PackageProtocolWithImportedWitnesses { }
+// expected-note@-1 {{property 'memberInPackageUsesOnly' from 'PackageUsesOnly' used to satisfy a requirement of protocol 'PackageProtocolWithImportedWitnesses'}}
+// expected-note@-2 {{property 'memberInMixedUses' from 'MixedUses' used to satisfy a requirement of protocol 'PackageProtocolWithImportedWitnesses'}}
+
+public protocol PublicProtocolWithImportedWitnesses {
+  var memberInPublicUsesOnly: Int { get }
+  var memberInPublicUsesOnlyDefaultedImport: Int { get }
+  var memberInMixedUses: Int { get }
+  var memberInPublicUsesOnlySPIOnly: Int { get }
+}
+
+extension Int: PublicProtocolWithImportedWitnesses { }
+// expected-note@-1 {{property 'memberInPublicUsesOnlySPIOnly' from 'PublicUsesOnlySPIOnly' used to satisfy a requirement of protocol 'PublicProtocolWithImportedWitnesses'}}
+// expected-note@-2 {{property 'memberInPublicUsesOnly' from 'PublicUsesOnly' used to satisfy a requirement of protocol 'PublicProtocolWithImportedWitnesses'}}
+// expected-note@-3 {{property 'memberInMixedUses' from 'MixedUses' used to satisfy a requirement of protocol 'PublicProtocolWithImportedWitnesses'}}
+// expected-note@-4 {{property 'memberInPublicUsesOnlyDefaultedImport' from 'PublicUsesOnlyDefaultedImport' used to satisfy a requirement of protocol 'PublicProtocolWithImportedWitnesses'}}
+
 //--- imports.swift
 
 internal import InternalUsesOnly


### PR DESCRIPTION
- **Explanation**: The compiler previously emitted unhelpful diagnostics when a protocol conformance witness became unavailable after enabling `MemberImportVisibility`. Now, conformance checking will perform a fallback lookup to find witnesses that would match requirements if `MemberImportVisibility` were disabled and suggests a fix-it to import the necessary module to make the witness visible. This change is also a prerequisite to fixing https://github.com/swiftlang/swift/issues/87227, which is a high priority for the Swift 6.4 release.
- **Scope**: Affects compilation of modules containing conformance declarations built with `MemberImportVisibility` enabled.
- **Issues**: rdar://154237873
- **Risk**: Medium. These changes are somewhat extensive, but they are not designed to cause more or less code to be accepted by the compiler. They should only to improve diagnostics for already rejected code in modules built with the `MemberImportVisibility` upcoming feature enabled. 
- **Testing**: New test cases.
