### PR TITLE
[6.3][cxx-interop] Import macro-declared `CF_OPTIONS` enums correctly

### DIFF
--- a/test/Interop/Cxx/enum/Inputs/c-enums-withOptions-omit.h
+++ b/test/Interop/Cxx/enum/Inputs/c-enums-withOptions-omit.h
@@ -52,6 +52,14 @@ typedef CF_OPTIONS(NSUInteger, UITableViewScrollPosition) {
   UITableViewScrollPosition1,
   UITableViewScrollPosition2
 };
+
+#define TEST(X) MacroPrefix##X
+
+typedef CF_OPTIONS(NSUInteger, TEST(Enum)) {
+  MacroPrefixEnumFoo = (1 << 0),
+  MacroPrefixEnumBar = (1 << 1),
+};
+
 @interface NSIndexPath
 @end
 

--- a/test/Interop/Cxx/enum/c-enums-withOptions-omit.swift
+++ b/test/Interop/Cxx/enum/c-enums-withOptions-omit.swift
@@ -8,6 +8,9 @@ import CenumsWithOptionsOmit
 // CHECK-NEXT: func enumerateObjects(options
 // CHECK-NEXT: @available(swift, obsoleted: 3, renamed: "enumerateObjects(options:)")
 
+// CHECK-NOT: typealias MacroPrefixEnum
+// CHECK: struct MacroPrefixEnum : OptionSet
+
 // CHECK: class TestsForEnhancedOmitNeedlessWords {
 
 // Tests for withOptions -> 'with options'


### PR DESCRIPTION
- **Explanation**:

  In C++ language mode, `CF_OPTIONS`/`NS_OPTIONS` macros expand differently than in C. This commit adds extra logic in `ImportEnumInfo.h` to handle that difference, ensuring types like `typedef CF_OPTIONS(NSUInteger, MyEnum)` are imported correctly when C++ interop is enabled.

- **Scope**:

  Only Swift code using C++ interop that imports `CF_OPTIONS`/`NS_OPTIONS` types whose names are themselves macro-generated. Pure C interop is unaffected.
This change enables us to correctly handle `CF_OPTIONS`/`NS_OPTIONS` wrapped in function-like macros, which unblocks developers relying on such wrappers.

- **Issues**:
  rdar://173637096

- **Original PRs**:

  https://github.com/swiftlang/swift/pull/86892

- **Risk**:

  Low. The walking loop terminates as soon as it finds a match or runs out of macro levels, and the new test case covers the previously-broken scenario.

- **Testing**:
  - Swift CI smoke tests passed on main (see the original PR).
  - Local Swift testing passed.

- **Reviewers**:

  @Xazax-hun @j-hui @hamishknight
