### PR TITLE
Diagnose static key path members on protocol metatypes

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -728,6 +728,9 @@ ERROR(expr_keypath_application_root_type_mismatch, none,
       (Type, Type))
 ERROR(expr_swift_keypath_anyobject_root,none,
       "the root type of a Swift key path cannot be 'AnyObject'", ())
+ERROR(expr_keypath_protocol_metatype_static_member,none,
+      "key path cannot refer to static member %0 of protocol type %1",
+      (DeclNameRef, Type))
 ERROR(expr_keypath_multiparam_func_conversion, none,
       "cannot convert key path into a multi-argument function type %0", (Type))
 ERROR(cannot_convert_type_to_keypath_subscript_index,none,

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -2032,6 +2032,8 @@ class AllowInvalidRefInKeyPath final : public ConstraintFix {
   enum RefKind {
     // Allow invalid references to static members i.e. on instance of a type.
     StaticMember,
+    // Allow a reference to a static member through a protocol metatype root.
+    ProtocolMetatypeStaticMember,
     // Allow a reference to a static member as a key path component if it is
     // declared in a module with built with Swift 6.0 compiler version or older.
     UnsupportedStaticMember,
@@ -2067,6 +2069,9 @@ public:
     case RefKind::StaticMember:
       return "allow reference to a static member on invalid base in key path "
              "context";
+    case RefKind::ProtocolMetatypeStaticMember:
+      return "allow reference to a static member on a protocol metatype in "
+             "key path context";
     case RefKind::UnsupportedStaticMember:
       return "allow unsupported static member reference";
     case RefKind::MutatingGetter:

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3588,7 +3588,7 @@ static ManagedValue emitKeyPathRValueBase(SILGenFunction &subSGF,
 
   // If base is a metatype, it cannot be opened as an existential or upcasted
   // from a class.
-  if (baseType->is<MetatypeType>())
+  if (baseType->is<AnyMetatypeType>())
     return paramSubstValue;
   
   // Pop open an existential container base.
@@ -4896,7 +4896,7 @@ KeyPathPatternComponent SILGenModule::emitKeyPathComponentForDecl(
       if (!var->getDeclContext()->isTypeContext()) {
         componentTy = var->getInterfaceType()->getCanonicalType();
       } else if (var->getDeclContext()->getSelfProtocolDecl() &&
-                 baseTy->isExistentialType()) {
+                 baseTy->isAnyExistentialType()) {
         componentTy = var->getValueInterfaceType()->getCanonicalType();
         ASSERT(!componentTy->hasTypeParameter());
       } else {

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6571,6 +6571,16 @@ bool InvalidStaticMemberRefInKeyPath::diagnoseAsError() {
   return true;
 }
 
+bool InvalidProtocolMetatypeStaticMemberRefInKeyPath::diagnoseAsError() {
+  auto baseType = BaseType;
+  if (auto *metatype = baseType->getAs<AnyMetatypeType>())
+    baseType = metatype->getInstanceType();
+
+  emitDiagnostic(diag::expr_keypath_protocol_metatype_static_member,
+                 DeclNameRef(getMember()->getName()), baseType);
+  return true;
+}
+
 bool UnsupportedStaticMemberRefInKeyPath::diagnoseAsError() {
   auto *member = getMember();
   auto *module = member->getDeclContext()->getParentModule();

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1812,6 +1812,20 @@ public:
   bool diagnoseAsError() override;
 };
 
+class InvalidProtocolMetatypeStaticMemberRefInKeyPath final
+    : public InvalidMemberRefInKeyPath {
+  Type BaseType;
+
+public:
+  InvalidProtocolMetatypeStaticMemberRefInKeyPath(
+      const Solution &solution, Type baseType, ValueDecl *member,
+      ConstraintLocator *locator)
+      : InvalidMemberRefInKeyPath(solution, member, locator),
+        BaseType(resolveType(baseType)->getRValueType()) {}
+
+  bool diagnoseAsError() override;
+};
+
 /// Diagnose an attempt to reference a static member from an unsupported module.
 ///
 /// Only modules built either from source with 6.1+ compiler or

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1289,6 +1289,12 @@ bool AllowInvalidRefInKeyPath::diagnose(const Solution &solution,
     return failure.diagnose(asNote);
   }
 
+  case RefKind::ProtocolMetatypeStaticMember: {
+    InvalidProtocolMetatypeStaticMemberRefInKeyPath failure(
+        solution, BaseType, Member, getLocator());
+    return failure.diagnose(asNote);
+  }
+
   case RefKind::UnsupportedStaticMember: {
     UnsupportedStaticMemberRefInKeyPath failure(solution, BaseType, Member,
                                                 getLocator());
@@ -1367,9 +1373,17 @@ AllowInvalidRefInKeyPath::forRef(ConstraintSystem &cs, Type baseType,
       }
     }
 
-    if (!baseType->getRValueType()->is<AnyMetatypeType>())
+    auto baseRValueType = baseType->getRValueType();
+    if (auto *metatype = baseRValueType->getAs<AnyMetatypeType>()) {
+      if (metatype->getInstanceType()->isExistentialType()) {
+        return AllowInvalidRefInKeyPath::create(
+            cs, baseType, RefKind::ProtocolMetatypeStaticMember, member,
+            locator);
+      }
+    } else {
       return AllowInvalidRefInKeyPath::create(
           cs, baseType, RefKind::StaticMember, member, locator);
+    }
   }
 
   // Referencing enum cases in key path is not currently allowed.

--- a/test/Constraints/keypath_protocol_metatype.swift
+++ b/test/Constraints/keypath_protocol_metatype.swift
@@ -1,0 +1,19 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P {
+  static var foo: Int { get }
+}
+
+let _: KeyPath<P.Type, P.Type> = \.self
+
+func ordinaryLookup(_ type: P.Type) -> Int {
+  type.foo
+}
+
+let kp: KeyPath<P.Type, Int> = \.foo
+// expected-error@-1 {{key path cannot refer to static member 'foo' of protocol type 'P'}}
+
+func takesKeyPath(_ kp: KeyPath<P.Type, Int>) {}
+
+takesKeyPath(\.foo)
+// expected-error@-1 {{key path cannot refer to static member 'foo' of protocol type 'P'}}

--- a/test/SILGen/keypath_protocol_metatype.swift
+++ b/test/SILGen/keypath_protocol_metatype.swift
@@ -1,0 +1,15 @@
+// RUN: not %target-swift-emit-silgen %s 2>&1 | %FileCheck %s
+
+protocol P {
+  static var foo: Int { get }
+}
+
+struct S {
+  init(_ kp: KeyPath<P.Type, Int>) {}
+}
+
+func test() {
+  S(\.foo)
+}
+
+// CHECK: error: key path cannot refer to static member 'foo' of protocol type 'P'

--- a/validation-test/compiler_crashers_fixed/Transform-transform-c18626.swift
+++ b/validation-test/compiler_crashers_fixed/Transform-transform-c18626.swift
@@ -1,10 +1,10 @@
 // {"kind":"emit-silgen","original":"6e2be603","signature":"(anonymous namespace)::Transform::transform(swift::Lowering::ManagedValue, swift::Lowering::AbstractionPattern, swift::CanType, swift::Lowering::AbstractionPattern, swift::CanType, swift::SILType, swift::Lowering::SGFContext)","signatureNext":"Lowering::SILGenFunction::emitTransformedValue"}
-// RUN: not --crash %target-swift-frontend -emit-silgen %s
+// RUN: %target-swift-frontend -emit-silgen -verify %s
 protocol a {
   static var b: UInt32 {
     get
   }
 }
 func c(d: [a.Type]) {
-  d.map(\.b)
+  d.map(\.b) // expected-error {{key path cannot refer to static member 'b' of protocol type 'a'}}
 }


### PR DESCRIPTION
 - **Explanation**:
    Fix a compiler crash when a key path rooted at a protocol metatype references a static property such as `\.foo`. These references could bypass the normal metatype checks, reach SILGen, and leave the compiler in an invalid state
  instead of producing a targeted diagnostic.

  - **Scope**:
    This is a narrow compiler correctness and diagnostics fix. It affects invalid key-path expressions rooted at protocol metatypes and should not change the behavior of valid code. The intended user-visible effect is that malformed code
  now emits a clear error instead of crashing the compiler.

  - **Issues**:
    Fixes #87765.

  - **Original PRs**:
    N/A. This is the originating change.

  - **Risk**:
    Low. The change is localized to key-path member lookup, constraint fixing, diagnostics, and SILGen handling for metatype roots. The main risk is changing behavior in nearby protocol/existential metatype key-path paths, but the
  affected path is already invalid and should diagnose rather than proceed.

  - **Testing**:
    The change was validated with a reduced reproducer for a protocol metatype key path referencing a static property.


  - **Reviewers**:
    TBD
