### PR TITLE
[Parse] Fix-it: strip quotes when a string literal is used where a pattern is expected

### DIFF
--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -1180,6 +1180,17 @@ ParserResult<Pattern> Parser::parsePattern() {
     consumeToken();
     return makeParserErrorResult(new (Context) AnyPattern(Loc));
   }
+  if (Tok.is(tok::string_literal) && !Tok.isMultilineString() &&
+      Tok.getCustomDelimiterLen() == 0) {
+    StringRef content = Tok.getText().drop_front().drop_back();
+    if (Lexer::isIdentifier(content)) {
+      diagnose(Tok, diag::expected_pattern)
+          .fixItReplace(Tok.getLoc(), content);
+      SourceLoc Loc = Tok.getLoc();
+      consumeToken();
+      return makeParserErrorResult(new (Context) AnyPattern(Loc));
+    }
+  }
   diagnose(Tok, diag::expected_pattern);
   return nullptr;
 }

--- a/test/Parse/matching_patterns.swift
+++ b/test/Parse/matching_patterns.swift
@@ -414,3 +414,16 @@ func testNonBinding6(y: [Int], z: Int) -> Int {
     0
   }
 }
+
+// Fix-it: suggest removing quotes when a string literal is typed where a
+// pattern is expected and the contents form a valid identifier.
+var "status": Int = 0 // expected-error {{expected pattern}} {{5-13=status}}
+let "foo" = 1 // expected-error {{expected pattern}} {{5-10=foo}}
+
+// No fix-it when the contents are not a valid identifier.
+var "has space": Int = 0 // expected-error {{expected pattern}}
+var "1digit": Int = 0 // expected-error {{expected pattern}}
+var "": Int = 0 // expected-error {{expected pattern}}
+
+// No fix-it for raw string literals.
+var #"status"#: Int = 0 // expected-error {{expected pattern}}


### PR DESCRIPTION
## What

Add a fix-it when a string literal is typed where a pattern (variable name) is expected.

Today, `var "status": Int` produces a bare `error: expected pattern` with no guidance. After this change, the parser offers to replace `"status"` with `status` via a fix-it, as long as the string contents form a valid Swift identifier.

```
var "status": Int = 0
    ^~~~~~~~
    status
```

## Why

Quoted identifiers are a plausible mistake for users coming from languages where that syntax is legal (Python dict keys, SQL column aliases, etc.) or for copy-paste from non-code sources. The intent is unambiguous, and the parser is already the right place to help: it provides a parallel fix-it for reserved keywords used as identifiers (`var class: Int` gets a backticks fix-it).

## Where

`Parser::parsePattern()` in `lib/Parse/ParsePattern.cpp`. A new recovery branch sits next to the existing keyword-as-identifier branch and reuses `diag::expected_pattern` with a `fixItReplace`.

## Guards

The fix-it is offered only when:
- the token is `tok::string_literal`,
- it is not a multiline string (`"""..."""`),
- it has no custom delimiter (`#"..."#`),
- and the quoted content passes `Lexer::isIdentifier`.

`Lexer::isIdentifier` rules out string interpolation (the `\(` gets rejected), whitespace, empty strings, and anything starting with a digit, so no incorrect suggestions are produced.

## Tests

Added to `test/Parse/matching_patterns.swift`:
- Positive: `var "status": Int = 0` and `let "foo" = 1` verify the fix-it replacement range.
- Negative: `"has space"`, `"1digit"`, empty string, and `#"status"#` verify that no fix-it is offered.
