### PR TITLE
[Sema] Support additional args in @dynamicMemberLookup subscripts 2.0

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -7731,15 +7731,6 @@ public:
   /// implies.
   ObjCSubscriptKind getObjCSubscriptKind() const;
 
-  /// Returns whether the decl can be used to satisfy an `@dynamicMemberLookup`
-  /// requirement.
-  ///
-  /// If `useDC` is provided (where the decl is being used), validates that
-  /// access control is being used consistently and that `decl` is appropriately
-  /// accessible, returning `false` if inaccessible.
-  bool isValidDynamicMemberLookupSubscript(
-      std::optional<const DeclContext *> useDC) const;
-
   /// If the decl can be used to satisfy an `@dynamicMemberLookup` requirement,
   /// returns whether it satisfies the requirement using a key-path- or string-
   /// based type.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -63,11 +63,6 @@ namespace clang {
 class PointerAuthQualifier;
 } // end namespace clang
 
-namespace {
-class AttributeChecker;
-class DeclChecker;
-} // end anonymous namespace
-
 namespace swift {
   enum class AccessSemantics : unsigned char;
   class AccessorDecl;
@@ -548,24 +543,9 @@ protected:
     defaultArgumentKind : NumDefaultArgumentKindBits
   );
 
-  SWIFT_INLINE_BITFIELD(SubscriptDecl, VarDecl, 2+2,
-    StaticSpelling : 2,
-
-    /// Whether this decl has been evaluated as eligible to satisfy an
-    /// `@dynamicMemberLookup` requirement, and if eligible, the type of dynamic
-    /// member parameter it would use to satisfy the requirement.
-    ///
-    /// * 0b00 - not yet evaluated
-    /// * 0b01 - evaluated; not eligible
-    /// * 0b10 - evaluated; eligible, taking a `{{Reference}Writable}KeyPath`
-    ///          value
-    /// * 0b11 - evaluated; eligible, taking an `ExpressibleByStringLiteral`
-    ///          value
-    ///
-    /// i.e., 0 or `DynamicMemberLookupSubscriptEligibility` values + 1
-    DynamicMemberLookupEligibility : 2
+  SWIFT_INLINE_BITFIELD(SubscriptDecl, VarDecl, 2,
+    StaticSpelling : 2
   );
-  
   SWIFT_INLINE_BITFIELD(AbstractFunctionDecl, ValueDecl, 3+2+2+2+8+1+1+1+1+1+1,
     /// \see AbstractFunctionDecl::BodyKind
     BodyKind : 3,
@@ -7617,35 +7597,6 @@ enum class ObjCSubscriptKind {
   Keyed
 };
 
-/// Describes how a `SubscriptDecl` could be eligible to fulfill a
-/// `@dynamicMemberLookup` requirement.
-///
-/// `@dynamicMemberLookup` requires that a subscript:
-///
-///   1. Take an initial argument with an explicit `dynamicMember` argument
-///      label,
-///   2. Whose parameter type is non-variadic and is either
-///      * A `{{Reference}Writable}KeyPath`, or
-///      * A concrete type conforming to `ExpressibleByStringLiteral`,
-///   3. And whose following arguments (if any) are all either variadic or have
-///      a default value
-///
-/// Subscripts which don't meet these requirements strictly are not eligible.
-enum class DynamicMemberLookupSubscriptEligibility : uint8_t {
-  /// The `SubscriptDecl` cannot fulfill a `@dynamicMemberLookup` requirement.
-  ///
-  /// This can be due to a name mismatch, type mismatch, missing default
-  /// arguments, or otherwise.
-  None,
-
-  /// The `SubscriptDecl` can fulfill a `@dynamicMemberLookup` requirement with
-  /// a `{{Reference}Writable}KeyPath` dynamic member parameter.
-  KeyPath,
-
-  /// The `SubscriptDecl` can fulfill a `@dynamicMemberLookup` requirement with
-  /// an `ExpressibleByStringLiteral`-conforming dynamic member parameter.
-  String,
-};
 
 /// Declares a subscripting operator for a type.
 ///
@@ -7676,36 +7627,25 @@ enum class DynamicMemberLookupSubscriptEligibility : uint8_t {
 /// signatures (indices and element type) are distinct.
 ///
 class SubscriptDecl : public GenericContext, public AbstractStorageDecl {
-  friend AttributeChecker;
-  friend DeclChecker;
+public:
+  /// Describes the kinds of supported types for `dynamicMember` parameters to a
+  /// subscript which can fulfill a `@dynamicMemberLookup` requirement.
+  enum class DynamicMemberLookupKind : uint8_t {
+    /// A `{{Reference}Writable}KeyPath`.
+    KeyPath,
+
+    /// A concrete type conforming to `ExpressibleByStringLiteral`.
+    String,
+  };
+
+private:
+  friend class DynamicMemberLookupSubscriptRequest;
   friend class ResultTypeRequest;
 
   SourceLoc StaticLoc;
   SourceLoc ArrowLoc;
   ParameterList *Indices;
   TypeLoc ElementTy;
-
-  // Evaluates and stores the decl's eligibility to fulfill
-  // `@dynamicMemberLookup` requirements. Given `Diags`, emits diagnostics for
-  // requirement mismatches; should only be passed in by `AttributeChecker` and
-  // `DeclChecker` within a type-checking context.
-  //
-  // Implemented in the type checker because checking the validity of a
-  // string-based dynamic member parameter requires checking conformance to
-  // `ExpressibleByStringLiteral`.
-  DynamicMemberLookupSubscriptEligibility
-  evaluateDynamicMemberLookupEligibility(
-      AccessScope *requiredAccessScope = nullptr,
-      DiagnosticEngine *Diags = nullptr);
-
-  // Maps `Bits.SubscriptDecl.DynamicMemberLookupEligibility` as stored to a
-  // `DynamicMemberLookupSubscriptEligibility`; `None` if `@dynamicMemberLookup`
-  // requirements have not been checked yet.
-  DynamicMemberLookupSubscriptEligibility
-  getStoredDynamicMemberLookupEligibility() const;
-
-  void setDynamicMemberLookupEligibility(
-      DynamicMemberLookupSubscriptEligibility eligibility);
 
   void setElementInterfaceType(Type type);
 
@@ -7791,15 +7731,34 @@ public:
   /// implies.
   ObjCSubscriptKind getObjCSubscriptKind() const;
 
-  /// Determines, caches, and returns whether the decl can be used to satisfy an
-  /// `@dynamicMemberLookup` requirement (and if so, how).
-  DynamicMemberLookupSubscriptEligibility
-  getDynamicMemberLookupSubscriptEligibility();
+  /// Returns whether the decl can be used to satisfy an `@dynamicMemberLookup`
+  /// requirement.
+  ///
+  /// If `useDC` is provided (where the decl is being used), validates that
+  /// access control is being used consistently and that `decl` is appropriately
+  /// accessible, returning `false` if inaccessible.
+  bool isValidDynamicMemberLookupSubscript(
+      std::optional<const DeclContext *> useDC) const;
+
+  /// If the decl can be used to satisfy an `@dynamicMemberLookup` requirement,
+  /// returns whether it satisfies the requirement using a key-path- or string-
+  /// based type.
+  ///
+  /// If `useDC` is provided (where the decl is being used), validates that
+  /// access control is being used consistently and that `decl` is appropriately
+  /// accessible, returning `std::nullopt` if inaccessible.
+  std::optional<DynamicMemberLookupKind>
+  getDynamicMemberLookupKind(std::optional<const DeclContext *> useDC) const;
 
   /// If the decl can be used to satisfy an `@dynamicMemberLookup` requirement
   /// using a `{{Reference}Writable}KeyPath` dynamic member parameter, returns
   /// the type of that parameter; `nullptr` otherwise.
-  BoundGenericType *getDynamicMemberLookupKeyPathType();
+  ///
+  /// If `useDC` is provided (where the decl is being used), validates that
+  /// access control is being used consistently and that `decl` is appropriately
+  /// accessible, returning `nullptr` if inaccessible.
+  BoundGenericType *getDynamicMemberLookupKeyPathType(
+      std::optional<const DeclContext *> useDC) const;
 
   SubscriptDecl *getOverriddenDecl() const {
     return cast_or_null<SubscriptDecl>(

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -63,6 +63,10 @@ namespace clang {
 class PointerAuthQualifier;
 } // end namespace clang
 
+namespace {
+class AttributeChecker;
+} // end anonymous namespace
+
 namespace swift {
   enum class AccessSemantics : unsigned char;
   class AccessorDecl;
@@ -543,9 +547,24 @@ protected:
     defaultArgumentKind : NumDefaultArgumentKindBits
   );
 
-  SWIFT_INLINE_BITFIELD(SubscriptDecl, VarDecl, 2,
-    StaticSpelling : 2
+  SWIFT_INLINE_BITFIELD(SubscriptDecl, VarDecl, 2+2,
+    StaticSpelling : 2,
+
+    /// Whether this decl has been evaluated as eligible to satisfy an
+    /// `@dynamicMemberLookup` requirement, and if eligible, the type of dynamic
+    /// member parameter it would use to satisfy the requirement.
+    ///
+    /// * 0b00 - not yet evaluated
+    /// * 0b01 - evaluated; not eligible
+    /// * 0b10 - evaluated; eligible, taking a `{{Reference}Writable}KeyPath`
+    ///          value
+    /// * 0b11 - evaluated; eligible, taking an `ExpressibleByStringLiteral`
+    ///          value
+    ///
+    /// i.e., 0 or `DynamicMemberLookupSubscriptEligibility` values + 1
+    DynamicMemberLookupEligibility : 2
   );
+  
   SWIFT_INLINE_BITFIELD(AbstractFunctionDecl, ValueDecl, 3+2+2+2+8+1+1+1+1+1+1,
     /// \see AbstractFunctionDecl::BodyKind
     BodyKind : 3,
@@ -7597,6 +7616,33 @@ enum class ObjCSubscriptKind {
   Keyed
 };
 
+/// Describes how a `SubscriptDecl` could be eligible to fulfill a
+/// `@dynamicMemberLookup` requirement.
+///
+/// `@dynamicMemberLookup` requires that a subscript:
+///
+///   1. Take a single argument with an explicit `dynamicMember` argument label,
+///   2. Whose parameter type is non-variadic and is either
+///      * A `{{Reference}Writable}KeyPath`, or
+///      * A concrete type conforming to `ExpressibleByStringLiteral`,
+///
+/// Subscripts which don't meet these requirements strictly are not eligible.
+enum class DynamicMemberLookupSubscriptEligibility : uint8_t {
+  /// The `SubscriptDecl` cannot fulfill a `@dynamicMemberLookup` requirement.
+  ///
+  /// This can be due to a name mismatch, type mismatch, missing default
+  /// arguments, or otherwise.
+  None,
+
+  /// The `SubscriptDecl` can fulfill a `@dynamicMemberLookup` requirement with
+  /// a `{{Reference}Writable}KeyPath` dynamic member parameter.
+  KeyPath,
+
+  /// The `SubscriptDecl` can fulfill a `@dynamicMemberLookup` requirement with
+  /// an `ExpressibleByStringLiteral`-conforming dynamic member parameter.
+  String,
+};
+
 /// Declares a subscripting operator for a type.
 ///
 /// A subscript declaration is defined as a get/set pair that produces a
@@ -7626,12 +7672,35 @@ enum class ObjCSubscriptKind {
 /// signatures (indices and element type) are distinct.
 ///
 class SubscriptDecl : public GenericContext, public AbstractStorageDecl {
+  friend AttributeChecker;
   friend class ResultTypeRequest;
 
   SourceLoc StaticLoc;
   SourceLoc ArrowLoc;
   ParameterList *Indices;
   TypeLoc ElementTy;
+
+  // Evaluates and stores the decl's eligibility to fulfill
+  // `@dynamicMemberLookup` requirements. Given `Diags`, emits diagnostics for
+  // requirement mismatches; should only be passed in by `AttributeChecker` and
+  // `DeclChecker` within a type-checking context.
+  //
+  // Implemented in the type checker because checking the validity of a
+  // string-based dynamic member parameter requires checking conformance to
+  // `ExpressibleByStringLiteral`.
+  DynamicMemberLookupSubscriptEligibility
+  evaluateDynamicMemberLookupEligibility(
+      AccessScope *requiredAccessScope = nullptr,
+      DiagnosticEngine *Diags = nullptr);
+
+  // Maps `Bits.SubscriptDecl.DynamicMemberLookupEligibility` as stored to a
+  // `DynamicMemberLookupSubscriptEligibility`; `None` if `@dynamicMemberLookup`
+  // requirements have not been checked yet.
+  DynamicMemberLookupSubscriptEligibility
+  getStoredDynamicMemberLookupEligibility() const;
+
+  void setDynamicMemberLookupEligibility(
+      DynamicMemberLookupSubscriptEligibility eligibility);
 
   void setElementInterfaceType(Type type);
 
@@ -7650,6 +7719,11 @@ class SubscriptDecl : public GenericContext, public AbstractStorageDecl {
     Bits.SubscriptDecl.StaticSpelling = static_cast<unsigned>(StaticSpelling);
     setIndices(Indices);
   }
+
+  /// Returns the given type as a `BoundGenericType` if it is a
+  /// `{{Reference}Writable}KeyPath` type which could be used to fulfill
+  /// `@dynamicMemberLookup` requirements; `nullptr` otherwise.
+  static BoundGenericType *getDynamicMemberParamTypeAsKeyPathType(Type paramTy);
 
 public:
   /// Factory function only for use by deserialization.
@@ -7711,6 +7785,16 @@ public:
   /// Determine the kind of Objective-C subscripting this declaration
   /// implies.
   ObjCSubscriptKind getObjCSubscriptKind() const;
+
+  /// Determines, caches, and returns whether the decl can be used to satisfy an
+  /// `@dynamicMemberLookup` requirement (and if so, how).
+  DynamicMemberLookupSubscriptEligibility
+  getDynamicMemberLookupSubscriptEligibility();
+
+  /// If the decl can be used to satisfy an `@dynamicMemberLookup` requirement
+  /// using a `{{Reference}Writable}KeyPath` dynamic member parameter, returns
+  /// the type of that parameter; `nullptr` otherwise.
+  BoundGenericType *getDynamicMemberLookupKeyPathType();
 
   SubscriptDecl *getOverriddenDecl() const {
     return cast_or_null<SubscriptDecl>(

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -7734,12 +7734,7 @@ public:
   /// If the decl can be used to satisfy an `@dynamicMemberLookup` requirement,
   /// returns whether it satisfies the requirement using a key-path- or string-
   /// based type.
-  ///
-  /// If `useDC` is provided (where the decl is being used), validates that
-  /// access control is being used consistently and that `decl` is appropriately
-  /// accessible, returning `std::nullopt` if inaccessible.
-  std::optional<DynamicMemberLookupKind>
-  getDynamicMemberLookupKind(std::optional<const DeclContext *> useDC) const;
+  std::optional<DynamicMemberLookupKind> getDynamicMemberLookupKind() const;
 
   /// If the decl can be used to satisfy an `@dynamicMemberLookup` requirement
   /// using a `{{Reference}Writable}KeyPath` dynamic member parameter, returns
@@ -7748,8 +7743,7 @@ public:
   /// If `useDC` is provided (where the decl is being used), validates that
   /// access control is being used consistently and that `decl` is appropriately
   /// accessible, returning `nullptr` if inaccessible.
-  BoundGenericType *getDynamicMemberLookupKeyPathType(
-      std::optional<const DeclContext *> useDC) const;
+  BoundGenericType *getDynamicMemberLookupKeyPathType() const;
 
   SubscriptDecl *getOverriddenDecl() const {
     return cast_or_null<SubscriptDecl>(

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -65,6 +65,7 @@ class PointerAuthQualifier;
 
 namespace {
 class AttributeChecker;
+class DeclChecker;
 } // end anonymous namespace
 
 namespace swift {
@@ -7621,10 +7622,13 @@ enum class ObjCSubscriptKind {
 ///
 /// `@dynamicMemberLookup` requires that a subscript:
 ///
-///   1. Take a single argument with an explicit `dynamicMember` argument label,
+///   1. Take an initial argument with an explicit `dynamicMember` argument
+///      label,
 ///   2. Whose parameter type is non-variadic and is either
 ///      * A `{{Reference}Writable}KeyPath`, or
 ///      * A concrete type conforming to `ExpressibleByStringLiteral`,
+///   3. And whose following arguments (if any) are all either variadic or have
+///      a default value
 ///
 /// Subscripts which don't meet these requirements strictly are not eligible.
 enum class DynamicMemberLookupSubscriptEligibility : uint8_t {
@@ -7673,6 +7677,7 @@ enum class DynamicMemberLookupSubscriptEligibility : uint8_t {
 ///
 class SubscriptDecl : public GenericContext, public AbstractStorageDecl {
   friend AttributeChecker;
+  friend DeclChecker;
   friend class ResultTypeRequest;
 
   SourceLoc StaticLoc;

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1737,9 +1737,14 @@ ERROR(invalid_dynamic_member_lookup_type,none,
       "'@dynamicMemberLookup' requires %0 to have a "
       "'subscript(dynamicMember:)' method that accepts either "
       "'ExpressibleByStringLiteral' or a key path", (Type))
-NOTE(invalid_dynamic_member_subscript, none,
-     "add an explicit argument label to this subscript to satisfy "
-     "the '@dynamicMemberLookup' requirement", ())
+NOTE(invalid_dynamic_member_subscript_missing_label, none,
+     "add an explicit argument label to this subscript to satisfy the "
+     "'@dynamicMemberLookup' requirement", ())
+NOTE(invalid_dynamic_member_subscript_out_of_order, none,
+     "'dynamicMember' argument must appear first in the argument list", ())
+NOTE(invalid_dynamic_member_subscript_missing_default, none,
+     "add a default value to this argument to satisfy the "
+     "'@dynamicMemberLookup' requirement", ())
 ERROR(dynamic_member_lookup_candidate_inaccessible,none,
       "'@dynamicMemberLookup' requires %0 to be as accessible as its "
       "enclosing type",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1737,15 +1737,25 @@ ERROR(invalid_dynamic_member_lookup_type,none,
       "'@dynamicMemberLookup' requires %0 to have a "
       "'subscript(dynamicMember:)' method that accepts either "
       "'ExpressibleByStringLiteral' or a key path", (Type))
-NOTE(invalid_dynamic_member_subscript_missing_label, none,
-     "add an explicit argument label to this subscript to satisfy the "
-     "'@dynamicMemberLookup' requirement", ())
-NOTE(invalid_dynamic_member_subscript_out_of_order, none,
-     "'dynamicMember' argument must appear first in the argument list", ())
-NOTE(invalid_dynamic_member_subscript_missing_default, none,
-     "add a default value to this argument to satisfy the "
-     "'@dynamicMemberLookup' requirement", ())
-ERROR(dynamic_member_lookup_candidate_inaccessible,none,
+ERROR(invalid_dynamic_member_subscript_missing_param_label, none,
+      "'@dynamicMemberLookup' requires %0 to have an explicit parameter label",
+      (ParamDecl *))
+ERROR(invalid_dynamic_member_subscript_invalid_arg_label, none,
+      "'@dynamicMemberLookup' requires %0 to have an explicit 'dynamicMember' "
+      "argument label",
+      (ParamDecl *))
+ERROR(invalid_dynamic_member_subscript_invalid_order, none,
+      "'@dynamicMemberLookup' requires %0 to appear first in the parameter "
+      "list",
+      (ParamDecl *))
+ERROR(invalid_dynamic_member_subscript_invalid_type, none,
+      "'@dynamicMemberLookup' requires %0 to be either "
+      "'ExpressibleByStringLiteral' or a key path",
+      (ParamDecl *))
+ERROR(invalid_dynamic_member_subscript_missing_default, none,
+      "'@dynamicMemberLookup' requires %0 to have a default value",
+      (ParamDecl *))
+ERROR(dynamic_member_lookup_candidate_inaccessible, none,
       "'@dynamicMemberLookup' requires %0 to be as accessible as its "
       "enclosing type",
       (ValueDecl *))

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -33,6 +33,7 @@
 #include "swift/AST/SourceFile.h"
 #include "swift/AST/Type.h"
 #include "swift/AST/TypeResolutionStage.h"
+#include "swift/Basic/Assertions.h"
 #include "swift/Basic/Statistic.h"
 #include "swift/Basic/TaggedUnion.h"
 #include "swift/Basic/TypeID.h"
@@ -5630,6 +5631,187 @@ public:
   std::optional<BraceStmt *> getCachedResult() const;
   void cacheResult(BraceStmt *stmt) const;
 };
+
+/// Describes how a `SubscriptDecl` is (or is not) be eligible to fulfill a
+/// `@dynamicMemberLookup` requirement.
+///
+/// `@dynamicMemberLookup` requires that a subscript:
+///
+///   1. Take an initial argument with an explicit `dynamicMember` argument
+///      label,
+///   2. Whose parameter type is non-variadic and is either
+///      * A `{{Reference}Writable}KeyPath`, or
+///      * A concrete type conforming to `ExpressibleByStringLiteral`,
+///   3. And whose following arguments (if any) are all either variadic or have
+///      a default value
+///
+/// Subscripts which don't meet these requirements strictly are not eligible.
+class DynamicMemberLookupSubscriptEligibility {
+public:
+  /// The kind of `dynamicMember` parameter the subscript takes (or could take,
+  /// if eligible for a fix-it for a missing `dynamicMember` label).
+  using DynamicMemberKind = SubscriptDecl::DynamicMemberLookupKind;
+
+  /// Reasons why a parameter disqualifies the subscript from meeting a
+  /// `@dynamicMemberLookup` requirement.
+  enum class InvalidParameterFlag {
+    /// The subscript has no `dynamicMember` parameter (so likely isn't eligible
+    /// for `@dynamicMemberLookup` subscript checking at all), but _could_ be
+    /// made valid if the parameter had a `"dynamicMember"` argument label
+    /// (e.g., `subscript(member: String)`).
+    ///
+    /// A fix-it can be provided to insert an argument label.
+    DynamicMemberMissingArgumentLabel = 1 << 0,
+
+    /// The parameter has a `dynamicMember` parameter label but no explicit
+    /// argument label (e.g., `subscript(dynamicMember: String)`). Since the
+    /// subscript must have `dynamicMember` as its argument label, we treat this
+    /// _as if_ the parameter label is missing.
+    ///
+    /// A fix-it can be provided to insert a parameter label.
+    DynamicMemberMissingParameterLabel = 1 << 1,
+
+    /// The parameter has a `"dynamicMember"` parameter label but a different
+    /// argument label (e.g., `subscript(_ dynamicMember: String)`).
+    ///
+    /// While it's possible that such a subscript isn't intended to implement a
+    /// `@dynamicMemberLookup` requirement, it's much more likely to be a
+    /// mistake than not and is worth diagnosing.
+    DynamicMemberInvalidArgumentLabel = 1 << 2,
+
+    /// The `dynamicMember` parameter does not appear first in the argument
+    /// list (e.g., `subscript(foo: Int = 42, dynamicMember member: String)`).
+    DynamicMemberInvalidOrder = 1 << 3,
+
+    /// The `dynamicMember` parameter has a type that does not meet the
+    /// requirements of being either key-path- or string-based.
+    DynamicMemberInvalidType = 1 << 4,
+
+    /// The parameter is a non-`dynamicMember` parameter which does not have a
+    /// default value.
+    ParameterMissingDefaultValue = 1 << 5,
+  };
+
+  using InvalidParameterFlags = OptionSet<InvalidParameterFlag>;
+
+private:
+  /// The declaration this eligibility describes.
+  const SubscriptDecl *Decl;
+
+  /// The subscript index of the `dynamicMember` parameter, if present.
+  std::optional<unsigned> DynamicMemberIdx;
+
+  /// The type of the `dynamicMember` parameter; separately-optional from
+  /// `DynamicMemberIdx` to represent an invalid parameter type.
+  std::optional<DynamicMemberKind> Kind;
+
+  /// Flags describing the validity of each of the subscript parameters.
+  SmallVector<InvalidParameterFlags> ParamFlags;
+
+public:
+  DynamicMemberLookupSubscriptEligibility(
+      const SubscriptDecl *decl, std::optional<unsigned> dynamicMemberIdx,
+      std::optional<DynamicMemberKind> kind,
+      SmallVector<InvalidParameterFlags> paramFlags)
+      : Decl(decl), DynamicMemberIdx(dynamicMemberIdx), Kind(kind),
+        ParamFlags(paramFlags) {
+    ASSERT(decl->getIndices()->size() == paramFlags.size());
+  }
+
+  bool isValid() const {
+    return DynamicMemberIdx == 0 && Kind &&
+           std::all_of(ParamFlags.begin(), ParamFlags.end(),
+                       [&](const InvalidParameterFlags &f) { return !f; });
+  }
+
+  bool isEligibleForArgumentLabelFixIt() const {
+    // We can offer a fix-it to insert a `dynamicMember` argument label iff the
+    // subscript is only missing the label itself.
+    return !DynamicMemberIdx && Kind &&
+           ParamFlags[0].containsOnly(
+               InvalidParameterFlag::DynamicMemberMissingArgumentLabel) &&
+           std::all_of(ParamFlags.begin() + 1, ParamFlags.end(),
+                       [&](const InvalidParameterFlags &f) { return !f; });
+  }
+
+  const SubscriptDecl *getDecl() const { return Decl; }
+
+  /// Returns the kind of the `dynamicMember` parameter if the decl is eligible
+  /// for dynamic member lookup; `std::nullopt` otherwise.
+  std::optional<DynamicMemberKind> getDynamicMemberKind() const {
+    return isValid() ? Kind : std::nullopt;
+  }
+
+  /// If invalid, produces diagnostics describing the ineligibility.
+  ///
+  /// Uses the `SubscriptDecl`'s AST context for diagnostics unless an explicit
+  /// diagnostic engine is given.
+  ///
+  /// Returns whether an error diagnostic was produced.
+  bool diagnose(DiagnosticEngine *diags = nullptr);
+
+  friend llvm::hash_code
+  hash_value(const DynamicMemberLookupSubscriptEligibility &e) {
+    auto hash = llvm::hash_combine(llvm::hash_value(e.DynamicMemberIdx),
+                                   llvm::hash_value(e.Kind));
+    for (auto flags : e.ParamFlags) {
+      hash = llvm::hash_combine(hash, flags.toRaw());
+    }
+
+    return hash;
+  }
+
+  friend bool operator==(const DynamicMemberLookupSubscriptEligibility &lhs,
+                         const DynamicMemberLookupSubscriptEligibility &rhs) {
+    return lhs.DynamicMemberIdx == rhs.DynamicMemberIdx &&
+           lhs.Kind == rhs.Kind &&
+           // `OptionSet` intentionally does not offer `==` in favor of
+           // requiring `containsOnly`.
+           llvm::equal(lhs.ParamFlags, rhs.ParamFlags,
+                       [&](const InvalidParameterFlags &lhs,
+                           const InvalidParameterFlags &rhs) {
+                         return lhs.containsOnly(rhs);
+                       });
+  }
+
+  friend bool operator!=(const DynamicMemberLookupSubscriptEligibility &lhs,
+                         const DynamicMemberLookupSubscriptEligibility &rhs) {
+    return !(lhs == rhs);
+  }
+};
+
+class DynamicMemberLookupSubscriptRequest
+    : public SimpleRequest<
+          DynamicMemberLookupSubscriptRequest,
+          std::pair<DynamicMemberLookupSubscriptEligibility, bool>(
+              const SubscriptDecl *, const DeclContext *),
+          RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+  // This type alias is provided primarily for use from
+  // `TypeCheckerTypeIDZone.def`, where the comma inside `std::pair<>`
+  // interferes with macro parsing.
+  using Result = std::pair<DynamicMemberLookupSubscriptEligibility,
+                           bool /* isAccessible */>;
+
+private:
+  friend SimpleRequest;
+
+  /// Given a `SubscriptDecl` and its use (`useDC`), returns whether the decl is
+  /// a viable candidate for `@dynamicMemberLookup` accessible from that point
+  /// of use.
+  Result evaluate(Evaluator &evaluator, const SubscriptDecl *decl,
+                  const DeclContext *useDC) const;
+
+public:
+  SourceLoc getNearestLoc() const {
+    return std::get<0>(getStorage())->getLoc();
+  }
+
+  bool isCached() const { return true; }
+};
+
 
 #define SWIFT_TYPEID_ZONE TypeChecker
 #define SWIFT_TYPEID_HEADER "swift/AST/TypeCheckerTypeIDZone.def"

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -5695,9 +5695,6 @@ public:
   using InvalidParameterFlags = OptionSet<InvalidParameterFlag>;
 
 private:
-  /// The declaration this eligibility describes.
-  const SubscriptDecl *Decl;
-
   /// The subscript index of the `dynamicMember` parameter, if present.
   std::optional<unsigned> DynamicMemberIdx;
 
@@ -5710,13 +5707,11 @@ private:
 
 public:
   DynamicMemberLookupSubscriptEligibility(
-      const SubscriptDecl *decl, std::optional<unsigned> dynamicMemberIdx,
+      std::optional<unsigned> dynamicMemberIdx,
       std::optional<DynamicMemberKind> kind,
       SmallVector<InvalidParameterFlags> paramFlags)
-      : Decl(decl), DynamicMemberIdx(dynamicMemberIdx), Kind(kind),
-        ParamFlags(paramFlags) {
-    ASSERT(decl->getIndices()->size() == paramFlags.size());
-  }
+      : DynamicMemberIdx(dynamicMemberIdx), Kind(kind),
+        ParamFlags(paramFlags) {}
 
   bool isValid() const {
     return DynamicMemberIdx == 0 && Kind &&
@@ -5734,8 +5729,6 @@ public:
                        [&](const InvalidParameterFlags &f) { return !f; });
   }
 
-  const SubscriptDecl *getDecl() const { return Decl; }
-
   /// Returns the kind of the `dynamicMember` parameter if the decl is eligible
   /// for dynamic member lookup; `std::nullopt` otherwise.
   std::optional<DynamicMemberKind> getDynamicMemberKind() const {
@@ -5744,10 +5737,8 @@ public:
 
   /// If invalid, produces diagnostics describing the ineligibility.
   ///
-  /// Uses the diagnostic engine belonging to the `SubscriptDecl`'s AST context.
-  ///
   /// Returns whether an error diagnostic was produced.
-  bool diagnose();
+  bool diagnose(SubscriptDecl *decl) const;
 
   friend llvm::hash_code
   hash_value(const DynamicMemberLookupSubscriptEligibility &e) {

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -5654,7 +5654,7 @@ public:
 
   /// Reasons why a parameter disqualifies the subscript from meeting a
   /// `@dynamicMemberLookup` requirement.
-  enum class InvalidParameterFlag {
+  enum class InvalidParameterFlag: uint8_t {
     /// The subscript has no `dynamicMember` parameter (so likely isn't eligible
     /// for `@dynamicMemberLookup` subscript checking at all), but _could_ be
     /// made valid if the parameter had a `"dynamicMember"` argument label

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -5744,11 +5744,10 @@ public:
 
   /// If invalid, produces diagnostics describing the ineligibility.
   ///
-  /// Uses the `SubscriptDecl`'s AST context for diagnostics unless an explicit
-  /// diagnostic engine is given.
+  /// Uses the diagnostic engine belonging to the `SubscriptDecl`'s AST context.
   ///
   /// Returns whether an error diagnostic was produced.
-  bool diagnose(DiagnosticEngine *diags = nullptr);
+  bool diagnose();
 
   friend llvm::hash_code
   hash_value(const DynamicMemberLookupSubscriptEligibility &e) {

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -5782,26 +5782,18 @@ public:
 class DynamicMemberLookupSubscriptRequest
     : public SimpleRequest<
           DynamicMemberLookupSubscriptRequest,
-          std::pair<DynamicMemberLookupSubscriptEligibility, bool>(
-              const SubscriptDecl *, const DeclContext *),
+          DynamicMemberLookupSubscriptEligibility(const SubscriptDecl *),
           RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
 
-  // This type alias is provided primarily for use from
-  // `TypeCheckerTypeIDZone.def`, where the comma inside `std::pair<>`
-  // interferes with macro parsing.
-  using Result = std::pair<DynamicMemberLookupSubscriptEligibility,
-                           bool /* isAccessible */>;
-
 private:
   friend SimpleRequest;
 
-  /// Given a `SubscriptDecl` and its use (`useDC`), returns whether the decl is
-  /// a viable candidate for `@dynamicMemberLookup` accessible from that point
-  /// of use.
-  Result evaluate(Evaluator &evaluator, const SubscriptDecl *decl,
-                  const DeclContext *useDC) const;
+  /// Given a `SubscriptDecl`, returns whether the decl is a viable candidate
+  /// for `@dynamicMemberLookup`.
+  DynamicMemberLookupSubscriptEligibility
+  evaluate(Evaluator &evaluator, const SubscriptDecl *decl) const;
 
 public:
   SourceLoc getNearestLoc() const {

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -675,8 +675,7 @@ SWIFT_REQUEST(TypeChecker, EmitPerformanceHints,
               Cached, NoLocationInfo)
 
 SWIFT_REQUEST(TypeChecker, DynamicMemberLookupSubscriptRequest,
-              std::optional<DynamicMemberLookupSubscriptRequest::Result>
-              (const SubscriptDecl *, const DeclContext *),
+              DynamicMemberLookupSubscriptEligibility(const SubscriptDecl *),
               Cached, NoLocationInfo)
 
 SWIFT_REQUEST(TypeChecker, DesugarForEachStmtRequest,

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -674,6 +674,11 @@ SWIFT_REQUEST(TypeChecker, EmitPerformanceHints,
               evaluator::SideEffect(SourceFile *),
               Cached, NoLocationInfo)
 
+SWIFT_REQUEST(TypeChecker, DynamicMemberLookupSubscriptRequest,
+              std::optional<DynamicMemberLookupSubscriptRequest::Result>
+              (const SubscriptDecl *, const DeclContext *),
+              Cached, NoLocationInfo)
+
 SWIFT_REQUEST(TypeChecker, DesugarForEachStmtRequest,
               BraceStmt *(ForEachStmt *),
               SeparatelyCached, NoLocationInfo)

--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -339,13 +339,6 @@ namespace swift {
   llvm::TinyPtrVector<ValueDecl *>
   findWitnessedObjCRequirements(const ValueDecl *witness,
                                 bool anySingleRequirement);
-
-  /// Returns true if the given subscript method is an valid implementation of
-  /// the `subscript(dynamicMember: {Writable}KeyPath<...>)` requirement for
-  /// @dynamicMemberLookup.
-  /// The method is given to be defined as `subscript(dynamicMember:)` which
-  /// takes a single non-variadic parameter of `{Writable}KeyPath<T, U>` type.
-  bool isValidKeyPathDynamicMemberLookup(SubscriptDecl *decl);
 }
 
 #endif

--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -339,13 +339,13 @@ namespace swift {
   llvm::TinyPtrVector<ValueDecl *>
   findWitnessedObjCRequirements(const ValueDecl *witness,
                                 bool anySingleRequirement);
-  /// Returns true if the given subscript method is a valid implementation of
+
+  /// Returns true if the given subscript method is an valid implementation of
   /// the `subscript(dynamicMember: {Writable}KeyPath<...>)` requirement for
   /// @dynamicMemberLookup.
   /// The method is given to be defined as `subscript(dynamicMember:)` which
   /// takes a single non-variadic parameter of `{Writable}KeyPath<T, U>` type.
-  bool isValidKeyPathDynamicMemberLookup(SubscriptDecl *decl,
-                                         bool ignoreLabel = false);
+  bool isValidKeyPathDynamicMemberLookup(SubscriptDecl *decl);
 }
 
 #endif

--- a/include/swift/Sema/OverloadChoice.h
+++ b/include/swift/Sema/OverloadChoice.h
@@ -221,7 +221,7 @@ public:
   }
 
   /// Retrieve an overload choice for a declaration that was found via
-  /// dynamic member lookup. The `ValueDecl` is a `subscript(dynamicMember:)`
+  /// dynamic member lookup. The `ValueDecl` is a `subscript(dynamicMember:...)`
   /// method.
   static OverloadChoice getDynamicMemberLookup(Type base, ValueDecl *value,
                                                Identifier name,

--- a/include/swift/Sema/Solution.h
+++ b/include/swift/Sema/Solution.h
@@ -120,6 +120,8 @@ struct MatchCallArgumentResult {
       Bindings.push_back({i});
     return {TrailingClosureMatching::Forward, Bindings, std::nullopt};
   }
+
+  void dump(llvm::raw_ostream &out);
 };
 
 /// Provides information about the application of a function argument to a

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10206,23 +10206,18 @@ SourceRange SubscriptDecl::getSignatureSourceRange() const {
 }
 
 std::optional<SubscriptDecl::DynamicMemberLookupKind>
-SubscriptDecl::getDynamicMemberLookupKind(
-    std::optional<const DeclContext *> useDC) const {
+SubscriptDecl::getDynamicMemberLookupKind() const {
   auto &ctx = getASTContext();
   auto eligibility = evaluateOrFatal(
       ctx.evaluator,
       DynamicMemberLookupSubscriptRequest{this});
 
-  if (useDC && !isAccessibleFrom(*useDC))
-    return std::nullopt;
-
   // `getDynamicMemberKind()` checks `isValid()`
   return eligibility.getDynamicMemberKind();
 }
 
-BoundGenericType *SubscriptDecl::getDynamicMemberLookupKeyPathType(
-    std::optional<const DeclContext *> useDC) const {
-  if (getDynamicMemberLookupKind(useDC) != DynamicMemberLookupKind::KeyPath) {
+BoundGenericType *SubscriptDecl::getDynamicMemberLookupKeyPathType() const {
+  if (getDynamicMemberLookupKind() != DynamicMemberLookupKind::KeyPath) {
     return nullptr;
   }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10225,7 +10225,7 @@ BoundGenericType *SubscriptDecl::getDynamicMemberLookupKeyPathType(
   }
 
   auto *indices = getIndices();
-  assert(indices->size() > 0 && "subscript must have at least one arg");
+  ASSERT(indices->size() > 0 && "subscript must have at least one arg");
   return getDynamicMemberParamTypeAsKeyPathType(
       indices->get(0)->getInterfaceType());
 }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10209,13 +10209,15 @@ std::optional<SubscriptDecl::DynamicMemberLookupKind>
 SubscriptDecl::getDynamicMemberLookupKind(
     std::optional<const DeclContext *> useDC) const {
   auto &ctx = getASTContext();
-  auto [eligibility, isAccessible] = evaluateOrFatal(
+  auto eligibility = evaluateOrFatal(
       ctx.evaluator,
-      DynamicMemberLookupSubscriptRequest{this, useDC ? *useDC : nullptr});
+      DynamicMemberLookupSubscriptRequest{this});
+
+  if (useDC && !isAccessibleFrom(*useDC))
+    return std::nullopt;
 
   // `getDynamicMemberKind()` checks `isValid()`
-  return (isAccessible || !useDC) ? eligibility.getDynamicMemberKind()
-                                  : std::nullopt;
+  return eligibility.getDynamicMemberKind();
 }
 
 BoundGenericType *SubscriptDecl::getDynamicMemberLookupKeyPathType(

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10205,11 +10205,6 @@ SourceRange SubscriptDecl::getSignatureSourceRange() const {
   return getSubscriptLoc();
 }
 
-bool SubscriptDecl::isValidDynamicMemberLookupSubscript(
-    std::optional<const DeclContext *> useDC) const {
-  return (bool)getDynamicMemberLookupKind(useDC);
-}
-
 std::optional<SubscriptDecl::DynamicMemberLookupKind>
 SubscriptDecl::getDynamicMemberLookupKind(
     std::optional<const DeclContext *> useDC) const {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10072,20 +10072,6 @@ ObjCSubscriptKind SubscriptDecl::getObjCSubscriptKind() const {
   return ObjCSubscriptKind::Keyed;
 }
 
-DynamicMemberLookupSubscriptEligibility
-SubscriptDecl::getStoredDynamicMemberLookupEligibility() const {
-  return Bits.SubscriptDecl.DynamicMemberLookupEligibility
-             ? static_cast<DynamicMemberLookupSubscriptEligibility>(
-                   Bits.SubscriptDecl.DynamicMemberLookupEligibility - 1)
-             : DynamicMemberLookupSubscriptEligibility::None;
-}
-
-void SubscriptDecl::setDynamicMemberLookupEligibility(
-    DynamicMemberLookupSubscriptEligibility eligibility) {
-  Bits.SubscriptDecl.DynamicMemberLookupEligibility =
-      static_cast<uint8_t>(eligibility) + 1;
-}
-
 void SubscriptDecl::setElementInterfaceType(Type type) {
   getASTContext().evaluator.cacheOutput(ResultTypeRequest{this},
                                         std::move(type));
@@ -10219,22 +10205,34 @@ SourceRange SubscriptDecl::getSignatureSourceRange() const {
   return getSubscriptLoc();
 }
 
-DynamicMemberLookupSubscriptEligibility
-SubscriptDecl::getDynamicMemberLookupSubscriptEligibility() {
-  evaluateDynamicMemberLookupEligibility();
-  return getStoredDynamicMemberLookupEligibility();
+bool SubscriptDecl::isValidDynamicMemberLookupSubscript(
+    std::optional<const DeclContext *> useDC) const {
+  return (bool)getDynamicMemberLookupKind(useDC);
 }
 
-BoundGenericType *SubscriptDecl::getDynamicMemberLookupKeyPathType() {
-  if (getDynamicMemberLookupSubscriptEligibility() !=
-      DynamicMemberLookupSubscriptEligibility::KeyPath) {
+std::optional<SubscriptDecl::DynamicMemberLookupKind>
+SubscriptDecl::getDynamicMemberLookupKind(
+    std::optional<const DeclContext *> useDC) const {
+  auto &ctx = getASTContext();
+  auto [eligibility, isAccessible] = evaluateOrFatal(
+      ctx.evaluator,
+      DynamicMemberLookupSubscriptRequest{this, useDC ? *useDC : nullptr});
+
+  // `getDynamicMemberKind()` checks `isValid()`
+  return (isAccessible || !useDC) ? eligibility.getDynamicMemberKind()
+                                  : std::nullopt;
+}
+
+BoundGenericType *SubscriptDecl::getDynamicMemberLookupKeyPathType(
+    std::optional<const DeclContext *> useDC) const {
+  if (getDynamicMemberLookupKind(useDC) != DynamicMemberLookupKind::KeyPath) {
     return nullptr;
   }
 
   auto *indices = getIndices();
   assert(indices->size() > 0 && "subscript must have at least one arg");
   return getDynamicMemberParamTypeAsKeyPathType(
-    indices->get(0)->getInterfaceType());
+      indices->get(0)->getInterfaceType());
 }
 
 DeclName AbstractFunctionDecl::getEffectiveFullName() const {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10072,9 +10072,53 @@ ObjCSubscriptKind SubscriptDecl::getObjCSubscriptKind() const {
   return ObjCSubscriptKind::Keyed;
 }
 
+DynamicMemberLookupSubscriptEligibility
+SubscriptDecl::getStoredDynamicMemberLookupEligibility() const {
+  return Bits.SubscriptDecl.DynamicMemberLookupEligibility
+             ? static_cast<DynamicMemberLookupSubscriptEligibility>(
+                   Bits.SubscriptDecl.DynamicMemberLookupEligibility - 1)
+             : DynamicMemberLookupSubscriptEligibility::None;
+}
+
+void SubscriptDecl::setDynamicMemberLookupEligibility(
+    DynamicMemberLookupSubscriptEligibility eligibility) {
+  Bits.SubscriptDecl.DynamicMemberLookupEligibility =
+      static_cast<uint8_t>(eligibility) + 1;
+}
+
 void SubscriptDecl::setElementInterfaceType(Type type) {
   getASTContext().evaluator.cacheOutput(ResultTypeRequest{this},
                                         std::move(type));
+}
+
+BoundGenericType *
+SubscriptDecl::getDynamicMemberParamTypeAsKeyPathType(Type paramTy) {
+  // Allow composing a key path type with a `Sendable` protocol as a way to
+  // express sendability requirements.
+  if (auto *existential = paramTy->getAs<ExistentialType>()) {
+    auto layout = existential->getExistentialLayout();
+
+    auto protocols = layout.getProtocols();
+    if (!llvm::all_of(protocols, [](ProtocolDecl *proto) {
+          return proto->isSpecificProtocol(KnownProtocolKind::Sendable) ||
+                 proto->getInvertibleProtocolKind();
+        })) {
+      return nullptr;
+    }
+
+    paramTy = layout.getSuperclass();
+    if (!paramTy) {
+      return nullptr;
+    }
+  }
+
+  if (!paramTy->isKeyPath() &&
+      !paramTy->isWritableKeyPath() &&
+      !paramTy->isReferenceWritableKeyPath()) {
+    return nullptr;
+  }
+
+  return paramTy->getAs<BoundGenericType>();
 }
 
 SubscriptDecl *
@@ -10173,6 +10217,24 @@ SourceRange SubscriptDecl::getSignatureSourceRange() const {
     }
   }
   return getSubscriptLoc();
+}
+
+DynamicMemberLookupSubscriptEligibility
+SubscriptDecl::getDynamicMemberLookupSubscriptEligibility() {
+  evaluateDynamicMemberLookupEligibility();
+  return getStoredDynamicMemberLookupEligibility();
+}
+
+BoundGenericType *SubscriptDecl::getDynamicMemberLookupKeyPathType() {
+  if (getDynamicMemberLookupSubscriptEligibility() !=
+      DynamicMemberLookupSubscriptEligibility::KeyPath) {
+    return nullptr;
+  }
+
+  auto *indices = getIndices();
+  assert(indices->size() > 0 && "subscript must have at least one arg");
+  return getDynamicMemberParamTypeAsKeyPathType(
+    indices->get(0)->getInterfaceType());
 }
 
 DeclName AbstractFunctionDecl::getEffectiveFullName() const {

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -476,7 +476,7 @@ ASTWalker::PreWalkResult<Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
       if (baseType) {
         baseType = baseType->getWithoutSpecifierType();
         if (baseType->hasDynamicMemberLookupAttribute() &&
-            SD->getDynamicMemberLookupKind(SD->getDeclContext()) ==
+            SD->getDynamicMemberLookupKind() ==
                 SubscriptDecl::DynamicMemberLookupKind::KeyPath) {
           isKeyPathDynamicMemberLookup = true;
         }

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -476,8 +476,8 @@ ASTWalker::PreWalkResult<Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
       if (baseType) {
         baseType = baseType->getWithoutSpecifierType();
         if (baseType->hasDynamicMemberLookupAttribute() &&
-            (SD->getDynamicMemberLookupSubscriptEligibility() !=
-             DynamicMemberLookupSubscriptEligibility::None)) {
+            SD->getDynamicMemberLookupKind(SD->getDeclContext()) ==
+                SubscriptDecl::DynamicMemberLookupKind::KeyPath) {
           isKeyPathDynamicMemberLookup = true;
         }
       }

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -476,7 +476,8 @@ ASTWalker::PreWalkResult<Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
       if (baseType) {
         baseType = baseType->getWithoutSpecifierType();
         if (baseType->hasDynamicMemberLookupAttribute() &&
-            isValidKeyPathDynamicMemberLookup(SD)) {
+            (SD->getDynamicMemberLookupSubscriptEligibility() !=
+             DynamicMemberLookupSubscriptEligibility::None)) {
           isKeyPathDynamicMemberLookup = true;
         }
       }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3684,10 +3684,6 @@ namespace {
       auto param = params[0];
       auto paramTy = simplifyType(param.getParameterType());
 
-      SmallVector<AnyFunctionType::Param, 1> args;
-      AnyFunctionType::Param arg(paramTy, ctx.Id_dynamicMember);
-      args.push_back(arg);
-
       Expr *argExpr;
       if (overload.choice.isKeyPathDynamicMemberLookup()) {
         argExpr = buildKeyPathDynamicMemberArgExpr(paramTy, componentLoc,
@@ -3699,7 +3695,7 @@ namespace {
                                                   paramTy);
       }
 
-      return ArgumentList::forImplicitSingle(ctx, arg.getLabel(), argExpr);
+      return ArgumentList::forImplicitSingle(ctx, ctx.Id_dynamicMember, argExpr);
     }
 
     /// Form a type checked expression for the argument of a

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3705,7 +3705,6 @@ namespace {
       // Build and type check the string literal index value to the specific
       // string type expected by the subscript.
       auto *nameExpr = new (ctx) StringLiteralExpr(name, loc, /*implicit*/true);
-      nameExpr->setType(literalTy);
       cs.setType(nameExpr, literalTy);
       return handleStringLiteralExpr(nameExpr);
     }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2611,7 +2611,7 @@ namespace {
           LocatorPathElt::KeyPathDynamicMember(keyPathTy->getAnyNominal()));
       auto overload = solution.getOverloadChoice(componentLoc);
 
-      // Looks like there is a chain of implicit `subscript(dynamicMember:)`
+      // Looks like there is a chain of implicit `subscript(dynamicMember:...)`
       // calls necessary to resolve a member reference.
       switch (overload.choice.getKind()) {
       case OverloadChoiceKind::DynamicMemberLookup:
@@ -3647,6 +3647,55 @@ namespace {
       llvm_unreachable("Unhandled OverloadChoiceKind in switch.");
     }
 
+    /// Builds an argument list for making a call to the given
+    /// `@dynamicMemberLookup` subscript by inserting any necessary default
+    /// arguments.
+    ArgumentList *buildArgumentListForDynamicMemberLookupSubscript(
+        const SelectedOverload &overload, SourceLoc componentLoc,
+        ConstraintLocator *locator) {
+      assert(overload.choice.isAnyDynamicMemberLookup() &&
+             "Overload must be for dynamic member lookup");
+      auto *SD = cast<SubscriptDecl>(overload.choice.getDecl());
+      auto memberLoc = cs.getCalleeLocator(locator);
+      auto subscript = resolveConcreteDeclRef(SD, memberLoc);
+
+      // We specifically don't want the full type here to avoid losing parameter
+      // pack references.
+      auto fnType = overload.adjustedOpenedType->castTo<FunctionType>();
+
+      auto params = fnType->getParams();
+      SmallVector<Expr *, 4> args;
+      for (auto paramIdx : indices(params)) {
+        auto param = params[paramIdx];
+        auto paramTy =
+            simplifyType(param.getParameterType(/*forCanonical=*/true, &ctx));
+
+        Expr *argExpr;
+        if (paramIdx == 0) {
+          if (overload.choice.isKeyPathDynamicMemberLookup()) {
+            argExpr = buildKeyPathDynamicMemberArgExpr(paramTy, componentLoc,
+                                                       memberLoc);
+          } else {
+            auto fieldName =
+                overload.choice.getName().getBaseIdentifier().str();
+            argExpr = buildDynamicMemberLookupArgExpr(fieldName, componentLoc,
+                                                      paramTy);
+          }
+        } else {
+          argExpr = new (ctx) DefaultArgumentExpr(subscript, paramIdx,
+                                                  componentLoc, paramTy, dc);
+        }
+
+        if (!argExpr) {
+          return nullptr;
+        }
+
+        args.emplace_back(cs.cacheType(argExpr));
+      }
+
+      return ArgumentList::forImplicitCallTo(SD->getIndices(), args, ctx);
+    }
+
     /// Form a type checked expression for the argument of a
     /// @dynamicMemberLookup subscript index parameter.
     Expr *buildDynamicMemberLookupArgExpr(StringRef name, SourceLoc loc,
@@ -3654,6 +3703,7 @@ namespace {
       // Build and type check the string literal index value to the specific
       // string type expected by the subscript.
       auto *nameExpr = new (ctx) StringLiteralExpr(name, loc, /*implicit*/true);
+      nameExpr->setType(literalTy);
       cs.setType(nameExpr, literalTy);
       return handleStringLiteralExpr(nameExpr);
     }
@@ -3663,49 +3713,25 @@ namespace {
                                       const SelectedOverload &overload,
                                       ConstraintLocator *memberLocator) {
       // Application of a DynamicMemberLookup result turns
-      // a member access of `x.foo` into x[dynamicMember: "foo"], or
-      // x[dynamicMember: KeyPath<T, U>]
+      // a member access of `x.foo` into `x[dynamicMember: "foo", ...]`, or
+      // `x[dynamicMember: KeyPath<T, U>, ...]`
+      auto componentLoc =
+          overload.choice.getKind() == OverloadChoiceKind::DynamicMemberLookup
+              ? nameLoc
+              : dotLoc;
+      auto *argList = buildArgumentListForDynamicMemberLookupSubscript(
+          overload, componentLoc, memberLocator);
 
-      // Figure out the expected type of the lookup parameter. We know the
-      // openedFullType will be "xType -> indexType -> resultType".  Dig out
-      // its index type.
-      auto paramTy = getTypeOfDynamicMemberIndex(overload);
-
-      Expr *argExpr = nullptr;
-      if (overload.choice.getKind() ==
-          OverloadChoiceKind::DynamicMemberLookup) {
-        // Build and type check the string literal index value to the specific
-        // string type expected by the subscript.
-        auto fieldName = overload.choice.getName().getBaseIdentifier().str();
-        argExpr = buildDynamicMemberLookupArgExpr(fieldName, nameLoc, paramTy);
-      } else {
-        argExpr =
-            buildKeyPathDynamicMemberArgExpr(paramTy, dotLoc, memberLocator);
-      }
-
-      if (!argExpr)
+      if (!argList) {
         return nullptr;
+      }
 
       solution.recordSingleArgMatchingChoice(cs.getConstraintLocator(expr));
 
-      // Build an argument list.
-      auto *argList =
-          ArgumentList::forImplicitSingle(ctx, ctx.Id_dynamicMember, argExpr);
       // Build and return a subscript that uses this string as the index.
       return buildSubscript(base, argList, cs.getConstraintLocator(expr),
                             memberLocator, /*isImplicit*/ true,
                             AccessSemantics::Ordinary, overload);
-    }
-
-    Type getTypeOfDynamicMemberIndex(const SelectedOverload &overload) {
-      assert(overload.choice.isAnyDynamicMemberLookup());
-
-      auto declTy = solution.simplifyType(overload.adjustedOpenedFullType);
-      auto subscriptTy = declTy->castTo<FunctionType>()->getResult();
-      auto refFnType = subscriptTy->castTo<FunctionType>();
-      assert(refFnType->getParams().size() == 1 &&
-             "subscript always has one arg");
-      return refFnType->getParams()[0].getPlainType();
     }
 
   public:
@@ -5385,23 +5411,14 @@ namespace {
       // Compute substitutions to refer to the member.
       auto ref = resolveConcreteDeclRef(subscript, memberLoc);
 
-      // If this is a @dynamicMemberLookup reference to resolve a property
-      // through the subscript(dynamicMember:) member, restore the
+      // If this is a `@dynamicMemberLookup` reference to resolve a property
+      // through the `subscript(dynamicMember:...)` member, restore the
       // openedType and origComponent to its full reference as if the user
       // wrote out the subscript manually.
       if (overload.choice.isAnyDynamicMemberLookup()) {
-        auto indexType = getTypeOfDynamicMemberIndex(overload);
-        Expr *argExpr = nullptr;
-        if (overload.choice.isKeyPathDynamicMemberLookup()) {
-          argExpr = buildKeyPathDynamicMemberArgExpr(indexType, componentLoc,
-                                                     memberLoc);
-        } else {
-          auto fieldName = overload.choice.getName().getBaseIdentifier().str();
-          argExpr = buildDynamicMemberLookupArgExpr(fieldName, componentLoc,
-                                                    indexType);
-        }
-        args = ArgumentList::forImplicitSingle(ctx, ctx.Id_dynamicMember,
-                                               argExpr);
+        args = buildArgumentListForDynamicMemberLookupSubscript(
+            overload, componentLoc, locator);
+
         // Record the implicit subscript expr's parameter bindings and matching
         // direction as `coerceCallArguments` requires them.
         solution.recordSingleArgMatchingChoice(locator);

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2284,14 +2284,20 @@ namespace {
     /// \param args The argument list of the subscript.
     /// \param locator The locator used to refer to the subscript.
     /// \param isImplicit Whether this is an implicit subscript.
+    /// \param isDynamicMemberLookup Whether this is an implicit
+    /// subscript inserted as a result of dynamic member access. This
+    /// changes how we fish out the call argument match for the call.
     Expr *buildSubscript(Expr *base, ArgumentList *args,
                          ConstraintLocatorBuilder locator,
                          ConstraintLocatorBuilder memberLocator,
-                         bool isImplicit, AccessSemantics semantics,
+                         bool isImplicit, bool isDynamicMemberLookup,
+                         AccessSemantics semantics,
                          const SelectedOverload &selected) {
       // Build the new subscript.
       auto newSubscript = buildSubscriptHelper(base, args, selected,
-                                               locator, isImplicit, semantics);
+                                               locator, isImplicit,
+                                               isDynamicMemberLookup,
+                                               semantics);
       return forceUnwrapIfExpected(newSubscript, memberLocator,
                                    IUOReferenceKind::ReturnValue);
     }
@@ -2299,7 +2305,8 @@ namespace {
     Expr *buildSubscriptHelper(Expr *base, ArgumentList *args,
                                const SelectedOverload &selected,
                                ConstraintLocatorBuilder locator,
-                               bool isImplicit, AccessSemantics semantics) {
+                               bool isImplicit, bool isDynamicMemberLookup,
+                               AccessSemantics semantics) {
       auto choice = selected.choice;
 
       // Apply a key path if we have one.
@@ -2436,9 +2443,17 @@ namespace {
 
       auto appliedWrappers =
           solution.getAppliedPropertyWrappers(memberLoc->getAnchor());
+
+      auto tempLoc = ConstraintLocatorBuilder(memberLoc);
+      auto callArgLoc =
+          (isDynamicMemberLookup
+           ? tempLoc.withPathElement(
+                ConstraintLocator::ImplicitDynamicMemberSubscript)
+           : locator);
+
       args = coerceCallArguments(
           args, fullSubscriptTy, subscriptRef, nullptr,
-          locator.withPathElement(ConstraintLocator::ApplyArgument),
+          callArgLoc.withPathElement(ConstraintLocator::ApplyArgument),
           appliedWrappers);
       if (!args)
         return nullptr;
@@ -3653,47 +3668,38 @@ namespace {
     ArgumentList *buildArgumentListForDynamicMemberLookupSubscript(
         const SelectedOverload &overload, SourceLoc componentLoc,
         ConstraintLocator *locator) {
-      assert(overload.choice.isAnyDynamicMemberLookup() &&
+      ASSERT(overload.choice.isAnyDynamicMemberLookup() &&
              "Overload must be for dynamic member lookup");
-      auto *SD = cast<SubscriptDecl>(overload.choice.getDecl());
+      ASSERT(isa<SubscriptDecl>(overload.choice.getDecl()));
+
       auto memberLoc = cs.getCalleeLocator(locator);
-      auto subscript = resolveConcreteDeclRef(SD, memberLoc);
 
       // We specifically don't want the full type here to avoid losing parameter
       // pack references.
       auto fnType = overload.adjustedOpenedType->castTo<FunctionType>();
 
       auto params = fnType->getParams();
-      SmallVector<Expr *, 4> args;
-      for (auto paramIdx : indices(params)) {
-        auto param = params[paramIdx];
-        auto paramTy =
-            simplifyType(param.getParameterType(/*forCanonical=*/true, &ctx));
+      ASSERT(params.size() >= 1);
 
-        Expr *argExpr;
-        if (paramIdx == 0) {
-          if (overload.choice.isKeyPathDynamicMemberLookup()) {
-            argExpr = buildKeyPathDynamicMemberArgExpr(paramTy, componentLoc,
-                                                       memberLoc);
-          } else {
-            auto fieldName =
-                overload.choice.getName().getBaseIdentifier().str();
-            argExpr = buildDynamicMemberLookupArgExpr(fieldName, componentLoc,
-                                                      paramTy);
-          }
-        } else {
-          argExpr = new (ctx) DefaultArgumentExpr(subscript, paramIdx,
-                                                  componentLoc, paramTy, dc);
-        }
+      auto param = params[0];
+      auto paramTy = simplifyType(param.getParameterType());
 
-        if (!argExpr) {
-          return nullptr;
-        }
+      SmallVector<AnyFunctionType::Param, 1> args;
+      AnyFunctionType::Param arg(paramTy, ctx.Id_dynamicMember);
+      args.push_back(arg);
 
-        args.emplace_back(cs.cacheType(argExpr));
+      Expr *argExpr;
+      if (overload.choice.isKeyPathDynamicMemberLookup()) {
+        argExpr = buildKeyPathDynamicMemberArgExpr(paramTy, componentLoc,
+                                                   memberLoc);
+      } else {
+        auto fieldName =
+            overload.choice.getName().getBaseIdentifier().str();
+        argExpr = buildDynamicMemberLookupArgExpr(fieldName, componentLoc,
+                                                  paramTy);
       }
 
-      return ArgumentList::forImplicitCallTo(SD->getIndices(), args, ctx);
+      return ArgumentList::forImplicitSingle(ctx, arg.getLabel(), argExpr);
     }
 
     /// Form a type checked expression for the argument of a
@@ -3726,11 +3732,11 @@ namespace {
         return nullptr;
       }
 
-      solution.recordSingleArgMatchingChoice(cs.getConstraintLocator(expr));
-
       // Build and return a subscript that uses this string as the index.
       return buildSubscript(base, argList, cs.getConstraintLocator(expr),
-                            memberLocator, /*isImplicit*/ true,
+                            memberLocator,
+                            /*isImplicit*/ true,
+                            /*isDynamicMemberLookup*/true,
                             AccessSemantics::Ordinary, overload);
     }
 
@@ -3852,7 +3858,8 @@ namespace {
 
       return buildSubscript(expr->getBase(), expr->getArgs(),
                             cs.getConstraintLocator(expr), memberLocator,
-                            expr->isImplicit(), expr->getAccessSemantics(),
+                            expr->isImplicit(), /*isDynamicMemberLookup*/false,
+                            expr->getAccessSemantics(),
                             overload);
     }
 
@@ -3957,7 +3964,8 @@ namespace {
           cs.getConstraintLocator(expr, ConstraintLocator::SubscriptMember);
       return buildSubscript(expr->getBase(), expr->getArgs(),
                             cs.getConstraintLocator(expr), memberLocator,
-                            expr->isImplicit(), AccessSemantics::Ordinary,
+                            expr->isImplicit(), /*isDynamicMemberLookup=*/false,
+                            AccessSemantics::Ordinary,
                             solution.getOverloadChoice(memberLocator));
     }
 
@@ -5418,10 +5426,6 @@ namespace {
       if (overload.choice.isAnyDynamicMemberLookup()) {
         args = buildArgumentListForDynamicMemberLookupSubscript(
             overload, componentLoc, locator);
-
-        // Record the implicit subscript expr's parameter bindings and matching
-        // direction as `coerceCallArguments` requires them.
-        solution.recordSingleArgMatchingChoice(locator);
       }
 
       auto subscriptType =

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2537,36 +2537,39 @@ AssignmentFailure::getMemberRef(ConstraintLocator *locator) const {
   if (!member)
     return std::nullopt;
 
-  if (!member->choice.isDecl())
+  // If the member is a subscript, it might be a dynamic member lookup access,
+  // in which case we need to peer through the keypath parameter to get the
+  // underlying member.
+  auto *SD = member->choice.isDecl()
+                 ? dyn_cast<SubscriptDecl>(member->choice.getDecl())
+                 : nullptr;
+  auto eligibility = SD ? SD->getDynamicMemberLookupSubscriptEligibility()
+                        : DynamicMemberLookupSubscriptEligibility::None;
+  switch (eligibility) {
+  case DynamicMemberLookupSubscriptEligibility::None:
+    // Not a decl, subscript, or dynamic member lookup subscript; stick with the
+    // existing overload choice.
     return member->choice;
 
-  auto *decl = member->choice.getDecl();
-  if (isa<SubscriptDecl>(decl) &&
-      isValidDynamicMemberLookupSubscript(cast<SubscriptDecl>(decl))) {
-    auto *subscript = cast<SubscriptDecl>(decl);
-    // If this is a keypath dynamic member lookup, we have to
-    // adjust the locator to find member referred by it.
-    if (isValidKeyPathDynamicMemberLookup(subscript)) {
-      // Type has a following format:
-      // `(Self) -> (dynamicMember: {Writable}KeyPath<T, U>) -> U`
-      auto *fullType = member->adjustedOpenedFullType->castTo<FunctionType>();
-      auto *fnType = fullType->getResult()->castTo<FunctionType>();
-
-      auto paramTy = fnType->getParams()[0].getPlainType();
-      auto keyPath = paramTy->getAnyNominal();
-      auto memberLoc = getConstraintLocator(
-          locator, LocatorPathElt::KeyPathDynamicMember(keyPath));
-
-      auto memberRef = getOverloadChoiceIfAvailable(memberLoc);
-      return memberRef ? std::optional<OverloadChoice>(memberRef->choice)
-                       : std::nullopt;
-    }
-
-    // If this is a string based dynamic lookup, there is no member declaration.
+  case DynamicMemberLookupSubscriptEligibility::String:
+    // There is no member declaration for string-based dynamic member lookup
+    // subscripts.
     return std::nullopt;
-  }
 
-  return member->choice;
+  case DynamicMemberLookupSubscriptEligibility::KeyPath: {
+    auto keyPathType = SD->getDynamicMemberLookupKeyPathType();
+    assert(keyPathType && "KeyPath-based dynamic member lookup subscripts must "
+                          "have a valid dynamic member type");
+
+    auto memberLoc = getConstraintLocator(
+        locator,
+        LocatorPathElt::KeyPathDynamicMember(keyPathType->getAnyNominal()));
+
+    auto memberRef = getOverloadChoiceIfAvailable(memberLoc);
+    return memberRef ? std::optional<OverloadChoice>(memberRef->choice)
+                     : std::nullopt;
+  }
+  }
 }
 
 Diag<StringRef> AssignmentFailure::findDeclDiagnostic(ASTContext &ctx,

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2543,22 +2543,26 @@ AssignmentFailure::getMemberRef(ConstraintLocator *locator) const {
   auto *SD = member->choice.isDecl()
                  ? dyn_cast<SubscriptDecl>(member->choice.getDecl())
                  : nullptr;
-  auto eligibility = SD ? SD->getDynamicMemberLookupSubscriptEligibility()
-                        : DynamicMemberLookupSubscriptEligibility::None;
-  switch (eligibility) {
-  case DynamicMemberLookupSubscriptEligibility::None:
+
+  auto kind = SD ? SD->getDynamicMemberLookupKind(getDC()) : std::nullopt;
+  if (!kind) {
     // Not a decl, subscript, or dynamic member lookup subscript; stick with the
     // existing overload choice.
     return member->choice;
+  }
 
-  case DynamicMemberLookupSubscriptEligibility::String:
+  switch (*kind) {
+  case SubscriptDecl::DynamicMemberLookupKind::String:
     // There is no member declaration for string-based dynamic member lookup
     // subscripts.
     return std::nullopt;
 
-  case DynamicMemberLookupSubscriptEligibility::KeyPath: {
-    auto keyPathType = SD->getDynamicMemberLookupKeyPathType();
-    assert(keyPathType && "KeyPath-based dynamic member lookup subscripts must "
+  case SubscriptDecl::DynamicMemberLookupKind::KeyPath: {
+    // Access control has already been checked above when fetching `kind`; no
+    // need to repeat here.
+    auto keyPathType =
+        SD->getDynamicMemberLookupKeyPathType(/*useDC=*/std::nullopt);
+    ASSERT(keyPathType && "KeyPath-based dynamic member lookup subscripts must "
                           "have a valid dynamic member type");
 
     auto memberLoc = getConstraintLocator(

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2544,7 +2544,7 @@ AssignmentFailure::getMemberRef(ConstraintLocator *locator) const {
                  ? dyn_cast<SubscriptDecl>(member->choice.getDecl())
                  : nullptr;
 
-  auto kind = SD ? SD->getDynamicMemberLookupKind(getDC()) : std::nullopt;
+  auto kind = SD ? SD->getDynamicMemberLookupKind() : std::nullopt;
   if (!kind) {
     // Not a decl, subscript, or dynamic member lookup subscript; stick with the
     // existing overload choice.
@@ -2560,8 +2560,7 @@ AssignmentFailure::getMemberRef(ConstraintLocator *locator) const {
   case SubscriptDecl::DynamicMemberLookupKind::KeyPath: {
     // Access control has already been checked above when fetching `kind`; no
     // need to repeat here.
-    auto keyPathType =
-        SD->getDynamicMemberLookupKeyPathType(/*useDC=*/std::nullopt);
+    auto keyPathType = SD->getDynamicMemberLookupKeyPathType();
     ASSERT(keyPathType && "KeyPath-based dynamic member lookup subscripts must "
                           "have a valid dynamic member type");
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1008,7 +1008,7 @@ void MatchCallArgumentResult::dump(llvm::raw_ostream &out) {
   }
 
   auto printBindings = [&](const SmallVector<ParamBinding, 4> &parameterBindings) {
-    for (unsigned i = 0, e = parameterBindings.size(); i < e; ++i) {
+    for (unsigned i : indices(parameterBindings)) {
       const auto &bindings = parameterBindings[i];
       out << " [" << i << ": ";
       bool first = true;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10892,7 +10892,7 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
     // (in that case label is expected to match).
     if (auto *SD = dyn_cast<SubscriptDecl>(cand)) {
       if (memberLocator && instanceTy->hasDynamicMemberLookupAttribute()) {
-        if (SD->getDynamicMemberLookupKind(instanceTy->getAnyNominal()) ==
+        if (SD->getDynamicMemberLookupKind() ==
             SubscriptDecl::DynamicMemberLookupKind::KeyPath) {
           auto *args = getArgumentList(memberLocator);
           auto isDirectCallToSubscript =
@@ -11032,7 +11032,7 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
       auto name = memberName.getBaseIdentifier();
       for (const auto &candidate : subscripts.ViableCandidates) {
         auto *SD = cast<SubscriptDecl>(candidate.getDecl());
-        auto kind = SD->getDynamicMemberLookupKind(DC);
+        auto kind = SD->getDynamicMemberLookupKind();
         if (!kind) {
           continue;
         }
@@ -11046,7 +11046,7 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
       for (auto index : indices(subscripts.UnviableCandidates)) {
         auto *SD =
             cast<SubscriptDecl>(subscripts.UnviableCandidates[index].getDecl());
-        auto kind = SD->getDynamicMemberLookupKind(DC);
+        auto kind = SD->getDynamicMemberLookupKind();
         if (!kind) {
           continue;
         }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1019,6 +1019,9 @@ void MatchCallArgumentResult::dump(llvm::raw_ostream &out) {
         out << arg;
         first = false;
       }
+      if (first) {
+        out << "<not present>";
+      }
       out << "]";
     }
   };

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10847,20 +10847,23 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
     }
 
     // While looking for subscript choices it's possible to find
-    // `subscript(dynamicMember: {Writable}KeyPath)` on types
-    // marked as `@dynamicMemberLookup`, let's mark this candidate
-    // as representing "dynamic lookup" unless it's a direct call
-    // to such subscript (in that case label is expected to match).
-    if (auto *subscript = dyn_cast<SubscriptDecl>(cand)) {
-      if (memberLocator && instanceTy->hasDynamicMemberLookupAttribute() &&
-          isValidKeyPathDynamicMemberLookup(subscript)) {
-        auto *args = getArgumentList(memberLocator);
-
-        if (!(args && args->isUnary() &&
-              args->getLabel(0) == getASTContext().Id_dynamicMember)) {
-          return OverloadChoice::getDynamicMemberLookup(
-              baseTy, subscript, ctx.getIdentifier("subscript"),
-              /*isKeyPathBased=*/true);
+    // `subscript(dynamicMember: {Reference{Writable}}KeyPath)` on types marked
+    // as `@dynamicMemberLookup`; let's mark this candidate as representing
+    // "dynamic lookup" unless it's a direct call to such subscript (in that
+    // case label is expected to match).
+    if (auto *SD = dyn_cast<SubscriptDecl>(cand)) {
+      if (memberLocator && instanceTy->hasDynamicMemberLookupAttribute()) {
+        if (SD->getDynamicMemberLookupSubscriptEligibility() ==
+            DynamicMemberLookupSubscriptEligibility::KeyPath) {
+          auto *args = getArgumentList(memberLocator);
+          auto isDirectCallToSubscript =
+              args && args->isUnary() &&
+              args->getLabel(0) == getASTContext().Id_dynamicMember;
+          if (!isDirectCallToSubscript) {
+            return OverloadChoice::getDynamicMemberLookup(
+                baseTy, SD, ctx.getIdentifier("subscript"),
+                /*isKeyPathBased=*/true);
+          }
         }
       }
     }
@@ -10981,32 +10984,50 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
          allFromConditionalConformances(*this, instanceTy, candidates)) &&
         !isSelfRecursiveKeyPathDynamicMemberLookup(*this, baseTy,
                                                    memberLocator)) {
-      auto &ctx = getASTContext();
 
-      // Recursively look up `subscript(dynamicMember:)` methods in this type.
-      DeclNameRef subscriptName(
-          { ctx, DeclBaseName::createSubscript(), { ctx.Id_dynamicMember } });
       auto subscripts = performMemberLookup(
-          constraintKind, subscriptName, baseTy, functionRefInfo, memberLocator,
-          includeInaccessibleMembers);
+          constraintKind, DeclNameRef::createSubscript(), baseTy,
+          functionRefInfo, memberLocator, includeInaccessibleMembers);
 
       // Reflect the candidates found as `DynamicMemberLookup` results.
       auto name = memberName.getBaseIdentifier();
       for (const auto &candidate : subscripts.ViableCandidates) {
         auto *SD = cast<SubscriptDecl>(candidate.getDecl());
-        bool isKeyPathBased = isValidKeyPathDynamicMemberLookup(SD);
+        bool isKeyPathBased;
+        switch (SD->getDynamicMemberLookupSubscriptEligibility()) {
+        case DynamicMemberLookupSubscriptEligibility::None:
+          continue;
+        case DynamicMemberLookupSubscriptEligibility::KeyPath:
+          isKeyPathBased = true;
+          break;
+        case DynamicMemberLookupSubscriptEligibility::String:
+          isKeyPathBased = false;
+          break;
+        }
 
-        if (isValidStringDynamicMemberLookup(SD) || isKeyPathBased)
-          result.addViable(OverloadChoice::getDynamicMemberLookup(
-              baseTy, SD, name, isKeyPathBased));
+        result.addViable(OverloadChoice::getDynamicMemberLookup(
+            baseTy, SD, name, isKeyPathBased));
       }
 
       for (auto index : indices(subscripts.UnviableCandidates)) {
         auto *SD =
             cast<SubscriptDecl>(subscripts.UnviableCandidates[index].getDecl());
-        auto choice = OverloadChoice::getDynamicMemberLookup(
-            baseTy, SD, name, isValidKeyPathDynamicMemberLookup(SD));
-        result.addUnviable(choice, subscripts.UnviableReasons[index]);
+
+        bool isKeyPathBased;
+        switch (SD->getDynamicMemberLookupSubscriptEligibility()) {
+        case DynamicMemberLookupSubscriptEligibility::None:
+          continue;
+        case DynamicMemberLookupSubscriptEligibility::KeyPath:
+          isKeyPathBased = true;
+          break;
+        case DynamicMemberLookupSubscriptEligibility::String:
+          isKeyPathBased = false;
+          break;
+        }
+
+        result.addUnviable(OverloadChoice::getDynamicMemberLookup(
+                               baseTy, SD, name, isKeyPathBased),
+                           subscripts.UnviableReasons[index]);
       }
     }
   }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10853,8 +10853,8 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
     // (in that case label is expected to match).
     if (auto *SD = dyn_cast<SubscriptDecl>(cand)) {
       if (memberLocator && instanceTy->hasDynamicMemberLookupAttribute()) {
-        if (SD->getDynamicMemberLookupSubscriptEligibility() ==
-            DynamicMemberLookupSubscriptEligibility::KeyPath) {
+        if (SD->getDynamicMemberLookupKind(instanceTy->getAnyNominal()) ==
+            SubscriptDecl::DynamicMemberLookupKind::KeyPath) {
           auto *args = getArgumentList(memberLocator);
           auto isDirectCallToSubscript =
               args && args->isUnary() &&
@@ -10993,41 +10993,31 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
       auto name = memberName.getBaseIdentifier();
       for (const auto &candidate : subscripts.ViableCandidates) {
         auto *SD = cast<SubscriptDecl>(candidate.getDecl());
-        bool isKeyPathBased;
-        switch (SD->getDynamicMemberLookupSubscriptEligibility()) {
-        case DynamicMemberLookupSubscriptEligibility::None:
+        auto kind = SD->getDynamicMemberLookupKind(DC);
+        if (!kind) {
           continue;
-        case DynamicMemberLookupSubscriptEligibility::KeyPath:
-          isKeyPathBased = true;
-          break;
-        case DynamicMemberLookupSubscriptEligibility::String:
-          isKeyPathBased = false;
-          break;
         }
 
         result.addViable(OverloadChoice::getDynamicMemberLookup(
-            baseTy, SD, name, isKeyPathBased));
+            baseTy, SD, name,
+            /*isKeyPathBased=*/kind ==
+                SubscriptDecl::DynamicMemberLookupKind::KeyPath));
       }
 
       for (auto index : indices(subscripts.UnviableCandidates)) {
         auto *SD =
             cast<SubscriptDecl>(subscripts.UnviableCandidates[index].getDecl());
-
-        bool isKeyPathBased;
-        switch (SD->getDynamicMemberLookupSubscriptEligibility()) {
-        case DynamicMemberLookupSubscriptEligibility::None:
+        auto kind = SD->getDynamicMemberLookupKind(DC);
+        if (!kind) {
           continue;
-        case DynamicMemberLookupSubscriptEligibility::KeyPath:
-          isKeyPathBased = true;
-          break;
-        case DynamicMemberLookupSubscriptEligibility::String:
-          isKeyPathBased = false;
-          break;
         }
 
-        result.addUnviable(OverloadChoice::getDynamicMemberLookup(
-                               baseTy, SD, name, isKeyPathBased),
-                           subscripts.UnviableReasons[index]);
+        result.addUnviable(
+            OverloadChoice::getDynamicMemberLookup(
+                baseTy, SD, name,
+                /*isKeyPathBased=*/kind ==
+                    SubscriptDecl::DynamicMemberLookupKind::KeyPath),
+            subscripts.UnviableReasons[index]);
       }
     }
   }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10847,10 +10847,10 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
     }
 
     // While looking for subscript choices it's possible to find
-    // `subscript(dynamicMember: {Reference{Writable}}KeyPath)` on types marked
-    // as `@dynamicMemberLookup`; let's mark this candidate as representing
-    // "dynamic lookup" unless it's a direct call to such subscript (in that
-    // case label is expected to match).
+    // `subscript(dynamicMember: {Reference{Writable}}KeyPath, ...)` on types
+    // marked as `@dynamicMemberLookup`; let's mark this candidate as
+    // representing "dynamic lookup" unless it's a direct call to such subscript
+    // (in that case label is expected to match).
     if (auto *SD = dyn_cast<SubscriptDecl>(cand)) {
       if (memberLocator && instanceTy->hasDynamicMemberLookupAttribute()) {
         if (SD->getDynamicMemberLookupSubscriptEligibility() ==
@@ -10973,7 +10973,7 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
   // or if all of the candidates come from conditional conformances (which
   // might not be applicable), and we are looking for members in a type with
   // the @dynamicMemberLookup attribute, then we resolve a reference to a
-  // `subscript(dynamicMember:)` method and pass the member name as a string
+  // `subscript(dynamicMember:...)` method and pass the member name as a string
   // parameter.
   if (constraintKind == ConstraintKind::ValueMember &&
       memberName.isSimpleName() && !memberName.isSpecial() &&

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10996,8 +10996,7 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
         auto *SD = cast<SubscriptDecl>(candidate.getDecl());
         bool isKeyPathBased = isValidKeyPathDynamicMemberLookup(SD);
 
-        if (isValidStringDynamicMemberLookup(SD, DC->getParentModule()) ||
-            isKeyPathBased)
+        if (isValidStringDynamicMemberLookup(SD) || isKeyPathBased)
           result.addViable(OverloadChoice::getDynamicMemberLookup(
               baseTy, SD, name, isKeyPathBased));
       }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -997,6 +997,42 @@ static bool requiresBothTrailingClosureDirections(
   return false;
 }
 
+void MatchCallArgumentResult::dump(llvm::raw_ostream &out) {
+  switch (trailingClosureMatching) {
+  case TrailingClosureMatching::Forward:
+    out << "[forward]";
+    break;
+  case TrailingClosureMatching::Backward:
+    out << "[backward]";
+    break;
+  }
+
+  auto printBindings = [&](const SmallVector<ParamBinding, 4> &parameterBindings) {
+    for (unsigned i = 0, e = parameterBindings.size(); i < e; ++i) {
+      const auto &bindings = parameterBindings[i];
+      out << " [" << i << ": ";
+      bool first = true;
+      for (auto arg : bindings) {
+        if (!first) {
+          out << ", ";
+        }
+        out << arg;
+        first = false;
+      }
+      out << "]";
+    }
+  };
+
+  printBindings(parameterBindings);
+
+  if (backwardParameterBindings.has_value()) {
+    out << " backward: ";
+    printBindings(*backwardParameterBindings);
+  }
+
+  out << "\n";
+}
+
 std::optional<MatchCallArgumentResult> constraints::matchCallArguments(
     SmallVectorImpl<AnyFunctionType::Param> &args,
     ArrayRef<AnyFunctionType::Param> params, const ParameterListInfo &paramInfo,

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4071,8 +4071,8 @@ ConstraintSystem::getArgumentInfoLocator(ConstraintLocator *locator) {
   if (auto *UME = getAsExpr<UnresolvedMemberExpr>(anchor))
     return getConstraintLocator(UME);
 
-  // All implicit x[dynamicMember:] subscript calls can share the same argument
-  // list.
+  // All implicit `x[dynamicMember:...]` subscript calls can share the same
+  // argument list.
   if (locator->findLast<LocatorPathElt::ImplicitDynamicMemberSubscript>()) {
     return getConstraintLocator(
         ASTNode(), LocatorPathElt::ImplicitDynamicMemberSubscript());

--- a/lib/Sema/IDETypeCheckingRequests.cpp
+++ b/lib/Sema/IDETypeCheckingRequests.cpp
@@ -258,7 +258,7 @@ TypeRelationCheckRequest::evaluate(Evaluator &evaluator,
 TypePair
 RootAndResultTypeOfKeypathDynamicMemberRequest::evaluate(Evaluator &evaluator,
                                               SubscriptDecl *subscript) const {
-  auto keyPathType = getKeyPathTypeForDynamicMemberLookup(subscript);
+  auto keyPathType = subscript->getDynamicMemberLookupKeyPathType();
   if (!keyPathType)
     return TypePair();
 

--- a/lib/Sema/IDETypeCheckingRequests.cpp
+++ b/lib/Sema/IDETypeCheckingRequests.cpp
@@ -255,10 +255,10 @@ TypeRelationCheckRequest::evaluate(Evaluator &evaluator,
                                              *CKind, Owner.DC);
 }
 
-TypePair
-RootAndResultTypeOfKeypathDynamicMemberRequest::evaluate(Evaluator &evaluator,
-                                              SubscriptDecl *subscript) const {
-  auto keyPathType = subscript->getDynamicMemberLookupKeyPathType();
+TypePair RootAndResultTypeOfKeypathDynamicMemberRequest::evaluate(
+    Evaluator &evaluator, SubscriptDecl *subscript) const {
+  auto keyPathType =
+      subscript->getDynamicMemberLookupKeyPathType(/*useDC=*/std::nullopt);
   if (!keyPathType)
     return TypePair();
 

--- a/lib/Sema/IDETypeCheckingRequests.cpp
+++ b/lib/Sema/IDETypeCheckingRequests.cpp
@@ -257,8 +257,7 @@ TypeRelationCheckRequest::evaluate(Evaluator &evaluator,
 
 TypePair RootAndResultTypeOfKeypathDynamicMemberRequest::evaluate(
     Evaluator &evaluator, SubscriptDecl *subscript) const {
-  auto keyPathType =
-      subscript->getDynamicMemberLookupKeyPathType(/*useDC=*/std::nullopt);
+  auto keyPathType = subscript->getDynamicMemberLookupKeyPathType();
   if (!keyPathType)
     return TypePair();
 

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -1126,7 +1126,7 @@ static void lookupVisibleDynamicMemberLookupDecls(
 
   for (ValueDecl *VD : subscripts) {
     auto *subscript = dyn_cast<SubscriptDecl>(VD);
-    if (!subscript || subscript->getDynamicMemberLookupKind(dc) !=
+    if (!subscript || subscript->getDynamicMemberLookupKind() !=
                           SubscriptDecl::DynamicMemberLookupKind::KeyPath) {
       continue;
     }

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -40,7 +40,6 @@
 #include "clang/Basic/Module.h"
 #include "clang/Lex/Preprocessor.h"
 #include "llvm/ADT/SetVector.h"
-#include <algorithm>
 #include <set>
 
 using namespace swift;
@@ -1121,20 +1120,20 @@ static void lookupVisibleDynamicMemberLookupDecls(
   if (!baseType->hasDynamicMemberLookupAttribute())
     return;
 
-  // Fetch all subscripts which satisfy the `@dynamicMemberLookup` attribute.
   SmallVector<ValueDecl *, 4> subscripts;
   dc->lookupQualified(baseType, DeclNameRef::createSubscript(), loc,
                       NL_QualifiedDefault | NL_ProtocolMembers, subscripts);
-  (void)std::remove_if(subscripts.begin(), subscripts.end(), [](ValueDecl *VD) {
-    auto *SD = dyn_cast<SubscriptDecl>(VD);
-    return !SD || SD->getDynamicMemberLookupSubscriptEligibility() ==
-                      DynamicMemberLookupSubscriptEligibility::None;
-  });
 
   for (ValueDecl *VD : subscripts) {
-    auto *subscript = cast<SubscriptDecl>(VD);
-    auto rootType = evaluateOrDefault(subscript->getASTContext().evaluator,
-      RootTypeOfKeypathDynamicMemberRequest{subscript}, Type());
+    auto *subscript = dyn_cast<SubscriptDecl>(VD);
+    if (!subscript || subscript->getDynamicMemberLookupKind(dc) !=
+                          SubscriptDecl::DynamicMemberLookupKind::KeyPath) {
+      continue;
+    }
+
+    auto rootType = evaluateOrDefault(
+        subscript->getASTContext().evaluator,
+        RootTypeOfKeypathDynamicMemberRequest{subscript}, Type());
     if (rootType.isNull())
       continue;
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2152,8 +2152,9 @@ void AttributeChecker::visitDynamicMemberLookupAttr(
   // group. (2) produces warnings in the current language mode, which will be
   // upgraded to errors in the next language mode (hence the separate diagnostic
   // stages).
-  SmallVector<DynamicMemberLookupSubscriptEligibility> validButInacessible;
-  SmallVector<DynamicMemberLookupSubscriptEligibility> invalid;
+  SubscriptDecl *validButInacessible = nullptr;
+  SmallVector<std::pair<SubscriptDecl *, DynamicMemberLookupSubscriptEligibility>>
+      invalid;
 
   auto requiredAccessScope = decl->getFormalAccessScope();
   auto accessDC = requiredAccessScope.getDeclContext();
@@ -2170,14 +2171,14 @@ void AttributeChecker::visitDynamicMemberLookupAttr(
         return;
       }
 
-      validButInacessible.emplace_back(eligibility);
+      validButInacessible = SD;
       continue;
     }
 
-    invalid.emplace_back(eligibility);
+    invalid.emplace_back(SD, eligibility);
   }
 
-  if (!validButInacessible.empty()) {
+  if (validButInacessible != nullptr) {
     const auto languageModeForError = LanguageMode::future;
     bool shouldError = ctx.isLanguageModeAtLeast(languageModeForError);
 
@@ -2187,12 +2188,10 @@ void AttributeChecker::visitDynamicMemberLookupAttr(
     shouldError |= decl->getModuleContext()->isResilient() &&
                    !decl->getDeclContext()->isInSwiftinterface();
 
-    auto firstInaccessible =
-        const_cast<SubscriptDecl *>(validButInacessible[0].getDecl());
-    auto diag = diagnose(firstInaccessible->getLoc(),
+    auto diag = diagnose(validButInacessible->getLoc(),
                          diag::dynamic_member_lookup_candidate_inaccessible,
-                         firstInaccessible);
-    fixItAccess(diag, firstInaccessible,
+                         validButInacessible);
+    fixItAccess(diag, validButInacessible,
                 requiredAccessScope.requiredAccessForDiagnostics(),
                 /*isForSetter=*/false, /*useDefaultAccess=*/false,
                 /*updateAttr=*/false);
@@ -2205,8 +2204,8 @@ void AttributeChecker::visitDynamicMemberLookupAttr(
   }
 
   if (!invalid.empty()) {
-    for (auto &candidate : invalid) {
-      candidate.diagnose();
+    for (const auto &pair : invalid) {
+      pair.second.diagnose(pair.first);
     }
 
     attr->setInvalid();

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2194,29 +2194,6 @@ SubscriptDecl::evaluateDynamicMemberLookupEligibility(
   return eligibility;
 }
 
-/// Returns true if the given subscript method is an valid implementation of
-/// the `subscript(dynamicMember:)` requirement for @dynamicMemberLookup.
-/// The method is given to be defined as `subscript(dynamicMember:)`.
-bool swift::isValidDynamicMemberLookupSubscript(SubscriptDecl *decl) {
-  return decl->getDynamicMemberLookupSubscriptEligibility() !=
-         DynamicMemberLookupSubscriptEligibility::None;
-}
-
-bool swift::isValidStringDynamicMemberLookup(SubscriptDecl *decl) {
-  return decl->getDynamicMemberLookupSubscriptEligibility() ==
-         DynamicMemberLookupSubscriptEligibility::String;
-}
-
-BoundGenericType *
-swift::getKeyPathTypeForDynamicMemberLookup(SubscriptDecl *decl) {
-  return decl->getDynamicMemberLookupKeyPathType();
-}
-
-bool swift::isValidKeyPathDynamicMemberLookup(SubscriptDecl *decl) {
-  return decl->getDynamicMemberLookupSubscriptEligibility() ==
-         DynamicMemberLookupSubscriptEligibility::KeyPath;
-}
-
 /// The @dynamicMemberLookup attribute is only allowed on types that have at
 /// least one subscript member declared like this:
 ///

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2107,142 +2107,6 @@ visitDynamicCallableAttr(DynamicCallableAttr *attr) {
   }
 }
 
-DynamicMemberLookupSubscriptEligibility
-SubscriptDecl::evaluateDynamicMemberLookupEligibility(
-    AccessScope *requiredAccessScope, DiagnosticEngine *Diags) {
-  if (Bits.SubscriptDecl.DynamicMemberLookupEligibility) {
-    return getStoredDynamicMemberLookupEligibility();
-  }
-
-  auto eligibility = DynamicMemberLookupSubscriptEligibility::None;
-  [&] {
-    // If we have an explicit diagnostic engine, we'll output to it on error; if
-    // we don't then all queued diagnostics will get discarded.
-    DiagnosticQueue queue{Diags ? *Diags : getDiags(),
-                          /*emitOnDestruction=*/(bool)Diags};
-
-    queue.getDiags().diagnose(this, diag::invalid_dynamic_member_lookup_type,
-                              getDeclContext()->getDeclaredInterfaceType());
-
-    if (isInvalid()) {
-      return;
-    }
-
-    auto *indices = getIndices();
-    if (indices->size() == 0) {
-      return;
-    }
-
-    auto isInvalid = false;
-    auto &ctx = getASTContext();
-    auto diagnosedOutOfOrder = false;
-    auto firstIndex = indices->get(0);
-    if (firstIndex->getArgumentName() != ctx.Id_dynamicMember) {
-      if (!Diags) {
-        // If we're not here to produce diagnostics during type-checking,
-        // there's no need to keep going.
-        return;
-      }
-
-      isInvalid = true;
-
-      // We can separately diagnose whether the `dynamicMember` parameter is out
-      // of order vs. whether we're missing a `dynamicMember` label altogether.
-      if (indices->size() > 1) {
-        for (auto idx : range(1, indices->size())) {
-          auto index = indices->get(idx);
-          if (index->getArgumentName() == ctx.Id_dynamicMember) {
-            queue.getDiags()
-                .diagnose(this,
-                          diag::invalid_dynamic_member_subscript_out_of_order)
-                .highlight(index->getSourceRange());
-            diagnosedOutOfOrder = true;
-            break;
-          }
-        }
-      }
-
-      // If there is no argument label at all, we can offer a fix-it to insert
-      // it. Note that we intentionally don't want to emit a diagnostic if there
-      // _is_ a label, since it's clearly just not a dynamic member lookup
-      // subscript.
-      if (!diagnosedOutOfOrder && firstIndex->getParameterNameLoc().isValid() &&
-          firstIndex->getArgumentNameLoc().isInvalid()) {
-        queue.getDiags()
-            .diagnose(this,
-                      diag::invalid_dynamic_member_subscript_missing_label)
-            .highlight(firstIndex->getSourceRange())
-            .fixItInsert(firstIndex->getParameterNameLoc(), "dynamicMember ");
-      }
-    }
-
-    for (auto index : *indices) {
-      if (!index->hasInterfaceType() ||
-          (index == firstIndex && index->isVariadic())) {
-        isInvalid = true;
-      }
-
-      if (index != firstIndex &&
-          (!diagnosedOutOfOrder ||
-           index->getArgumentName() != ctx.Id_dynamicMember) &&
-          (!index->isDefaultArgument() && !index->isVariadic() &&
-           !isa<PackExpansionType>(
-               index->getInterfaceType()->getCanonicalType()))) {
-        queue.getDiags()
-            .diagnose(this,
-                      diag::invalid_dynamic_member_subscript_missing_default)
-            .highlight(index->getSourceRange())
-            .fixItInsertAfter(index->getEndLoc(), " = <#Default#>");
-        isInvalid = true;
-      }
-    }
-
-    if (isInvalid) {
-      // There's no point in checking the `dynamicMember` argument type since
-      // we've already output diagnostics.
-      return;
-    }
-
-    if (TypeChecker::conformsToKnownProtocol(
-            firstIndex->getTypeInContext(),
-            KnownProtocolKind::ExpressibleByStringLiteral)) {
-      queue.clear();
-      eligibility = DynamicMemberLookupSubscriptEligibility::String;
-    } else if (getDynamicMemberParamTypeAsKeyPathType(
-                   firstIndex->getInterfaceType())) {
-      queue.clear();
-      eligibility = DynamicMemberLookupSubscriptEligibility::KeyPath;
-    }
-
-    // This subscript is valid, but it also needs to be sufficiently accessible
-    // to be considered.
-    if (requiredAccessScope &&
-        !isAccessibleFrom(requiredAccessScope->getDeclContext())) {
-      eligibility = DynamicMemberLookupSubscriptEligibility::None;
-
-      const auto languageModeForError = LanguageMode::future;
-      bool shouldError = getASTContext().isLanguageModeAtLeast(languageModeForError);
-
-      // Diagnose as an error in resilient modules regardless of language
-      // version since this will break the swiftinterface. Don't diagnose
-      // cases in existing swiftinterface files, though.
-      shouldError |= getModuleContext()->isResilient() &&
-                     !getDeclContext()->isInSwiftinterface();
-
-      auto diag = queue.getDiags().diagnose(
-          this, diag::dynamic_member_lookup_candidate_inaccessible, this);
-      fixItAccess(diag, this,
-                  requiredAccessScope->requiredAccessForDiagnostics(),
-                  /*isForSetter=*/false, /*useDefaultAccess=*/false,
-                  /*updateAttr=*/false);
-      diag.warnUntilLanguageModeIf(!shouldError, languageModeForError);
-    }
-  }();
-
-  setDynamicMemberLookupEligibility(eligibility);
-  return eligibility;
-}
-
 /// The @dynamicMemberLookup attribute is only allowed on types that have at
 /// least one subscript member declared like this:
 ///
@@ -2260,29 +2124,109 @@ void AttributeChecker::visitDynamicMemberLookupAttr(
   // This attribute is only allowed on nominal types.
   auto decl = cast<NominalTypeDecl>(D);
   auto type = decl->getDeclaredType();
+  auto &ctx = decl->getASTContext();
+
+  // Because dynamic member subscripts can take any number of parameters, we
+  // can't look them up by specific name: we'll find all subscript members on
+  // the type and filter for ones attempting to fulfill the
+  // `@dynamicMemberLookup` requirement.
   auto candidates =
       TypeChecker::lookupMember(decl, type, DeclNameRef::createSubscript());
 
-  if (candidates.empty()) {
-    diagnose(attr->getLocation(), diag::invalid_dynamic_member_lookup_type,
-             type);
-  } else {
-    auto requiredAccessScope = decl->getFormalAccessScope(/*useDC=*/nullptr);
-    // If we find at least one valid candidate, we won't produce any
-    // diagnostics.
-    DiagnosticQueue queue{Ctx.Diags, /*emitOnDestruction=*/true};
-    for (auto candidate : candidates) {
-      auto *SD = cast<SubscriptDecl>(candidate.getValueDecl());
-      if (SD->evaluateDynamicMemberLookupEligibility(&requiredAccessScope,
-                                                     &queue.getDiags()) !=
-          DynamicMemberLookupSubscriptEligibility::None) {
-        queue.clear();
+  // For validity and diagnostics, there are 4 kinds of subscripts we care
+  // about:
+  //
+  //   1. Subscripts which are both valid for fulfilling the requirement, and
+  //      are accessible from outside the type
+  //   2. Subscripts which are valid for fulfilling the requirement but which
+  //      are inaccessible from outside the type
+  //   3. Subscripts which have a `dynamicMember` argument/parameter label for
+  //      at least one parameter (so are considered for validation) but which
+  //      are invalid
+  //   4. Subscripts which _would_ be valid if a `dynamicMember` argument label
+  //      were inserted for their first argument (we can offer a fix-it)
+  //
+  // If we have any of (1), the attribute requirements will be considered
+  // fulfilled and we won't diagnose; if not, then we'll go through (2), (3),
+  // and (4) in order and produce diagnostics/fix-its for the first non-empty
+  // group. (2) produces warnings in the current language mode, which will be
+  // upgraded to errors in the next language mode (hence the separate diagnostic
+  // stages).
+  SmallVector<DynamicMemberLookupSubscriptEligibility> validButInacessible,
+      invalid, potentiallyValid;
+
+  auto requiredAccessScope = decl->getFormalAccessScope();
+  auto accessDC = requiredAccessScope.getDeclContext();
+  for (auto &candidate : candidates) {
+    auto *SD = dyn_cast<SubscriptDecl>(candidate.getValueDecl());
+    if (!SD) {
+      continue;
+    }
+
+    auto result = evaluateOrFatal(
+        ctx.evaluator, DynamicMemberLookupSubscriptRequest{SD, accessDC});
+    auto [eligibility, isAccessible] = result;
+    if (eligibility.isValid()) {
+      if (isAccessible) {
         return;
       }
+
+      validButInacessible.emplace_back(eligibility);
+    } else if (eligibility.isEligibleForArgumentLabelFixIt()) {
+      potentiallyValid.emplace_back(eligibility);
+    } else {
+      invalid.emplace_back(eligibility);
     }
   }
 
+  if (!validButInacessible.empty()) {
+    const auto languageModeForError = LanguageMode::future;
+    bool shouldError = ctx.isLanguageModeAtLeast(languageModeForError);
+
+    // Diagnose as an error in resilient modules regardless of language version
+    // since this will break the swiftinterface. Don't diagnose cases in
+    // existing swiftinterface files, though.
+    shouldError |= decl->getModuleContext()->isResilient() &&
+                   !decl->getDeclContext()->isInSwiftinterface();
+
+    auto firstInaccessible =
+        const_cast<SubscriptDecl *>(validButInacessible[0].getDecl());
+    auto diag = diagnose(firstInaccessible->getLoc(),
+                         diag::dynamic_member_lookup_candidate_inaccessible,
+                         firstInaccessible);
+    fixItAccess(diag, firstInaccessible,
+                requiredAccessScope.requiredAccessForDiagnostics(),
+                /*isForSetter=*/false, /*useDefaultAccess=*/false,
+                /*updateAttr=*/false);
+    diag.warnUntilLanguageModeIf(!shouldError, languageModeForError);
+
+    if (shouldError) {
+      attr->setInvalid();
+      return;
+    }
+  }
+
+  if (!invalid.empty()) {
+    for (auto &candidate : invalid) {
+      candidate.diagnose();
+    }
+
+    attr->setInvalid();
+    return;
+  }
+
+  if (!potentiallyValid.empty()) {
+    for (auto &candidate : potentiallyValid) {
+      candidate.diagnose();
+    }
+
+    attr->setInvalid();
+    return;
+  }
+
+  // There were no candidates at all.
   attr->setInvalid();
+  diagnose(attr->getStartLoc(), diag::invalid_dynamic_member_lookup_type, type);
 }
 
 /// Get the innermost enclosing declaration for a declaration.

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2163,11 +2163,10 @@ void AttributeChecker::visitDynamicMemberLookupAttr(
       continue;
     }
 
-    auto result = evaluateOrFatal(
-        ctx.evaluator, DynamicMemberLookupSubscriptRequest{SD, accessDC});
-    auto [eligibility, isAccessible] = result;
+    auto eligibility = evaluateOrFatal(
+        ctx.evaluator, DynamicMemberLookupSubscriptRequest{SD});
     if (eligibility.isValid()) {
-      if (isAccessible) {
+      if (SD->isAccessibleFrom(accessDC)) {
         return;
       }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -49,6 +49,7 @@
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/Basic/SourceLoc.h"
 #include "swift/Parse/Lexer.h"
 #include "swift/Parse/ParseDeclName.h"
 #include "swift/Sema/IDETypeChecking.h"
@@ -2105,99 +2106,115 @@ visitDynamicCallableAttr(DynamicCallableAttr *attr) {
   }
 }
 
-static bool hasSingleNonVariadicParam(SubscriptDecl *decl,
-                                      Identifier expectedLabel,
-                                      bool ignoreLabel = false) {
-  auto *indices = decl->getIndices();
-  if (decl->isInvalid() || indices->size() != 1)
-    return false;
-
-  auto *index = indices->get(0);
-  if (index->isVariadic() || !index->hasInterfaceType())
-    return false;
-
-  if (ignoreLabel) {
-    return true;
+DynamicMemberLookupSubscriptEligibility
+SubscriptDecl::evaluateDynamicMemberLookupEligibility(
+    AccessScope *requiredAccessScope, DiagnosticEngine *Diags) {
+  if (Bits.SubscriptDecl.DynamicMemberLookupEligibility) {
+    return getStoredDynamicMemberLookupEligibility();
   }
 
-  return index->getArgumentName() == expectedLabel;
+  auto eligibility = DynamicMemberLookupSubscriptEligibility::None;
+  [&] {
+    // If we have an explicit diagnostic engine, we'll output to it on error; if
+    // we don't then all queued diagnostics will get discarded.
+    DiagnosticQueue queue{Diags ? *Diags : getDiags(),
+                          /*emitOnDestruction=*/(bool)Diags};
+
+    queue.getDiags().diagnose(this, diag::invalid_dynamic_member_lookup_type,
+                              getDeclContext()->getDeclaredInterfaceType());
+
+    if (isInvalid()) {
+      return;
+    }
+
+    auto *indices = getIndices();
+    if (indices->size() == 0) {
+      return;
+    }
+
+    auto index = indices->get(0);
+    if (index->getArgumentName() != getASTContext().Id_dynamicMember) {
+      // If there is no argument label at all, we can offer a fix-it to insert
+      // it. Note that we intentionally don't want to emit a diagnostic if there
+      // _is_ a label, since it's clearly just not a dynamic member lookup
+      // subscript.
+      if (Diags && index->getParameterNameLoc().isValid() &&
+          index->getArgumentNameLoc().isInvalid()) {
+        queue.getDiags()
+            .diagnose(this,
+                      diag::invalid_dynamic_member_subscript_missing_label)
+            .highlight(index->getSourceRange())
+            .fixItInsert(index->getParameterNameLoc(), "dynamicMember ");
+      }
+
+      return;
+    }
+
+    if (!index->hasInterfaceType() || index->isVariadic()) {
+      return;
+    }
+
+    if (TypeChecker::conformsToKnownProtocol(
+            index->getTypeInContext(),
+            KnownProtocolKind::ExpressibleByStringLiteral)) {
+      queue.clear();
+      eligibility = DynamicMemberLookupSubscriptEligibility::String;
+    } else if (getDynamicMemberParamTypeAsKeyPathType(
+                   index->getInterfaceType())) {
+      queue.clear();
+      eligibility = DynamicMemberLookupSubscriptEligibility::KeyPath;
+    }
+
+    // This subscript is valid, but it also needs to be sufficiently accessible
+    // to be considered.
+    if (requiredAccessScope &&
+        !isAccessibleFrom(requiredAccessScope->getDeclContext())) {
+      eligibility = DynamicMemberLookupSubscriptEligibility::None;
+
+      const auto languageModeForError = LanguageMode::future;
+      bool shouldError = getASTContext().isLanguageModeAtLeast(languageModeForError);
+
+      // Diagnose as an error in resilient modules regardless of language
+      // version since this will break the swiftinterface. Don't diagnose
+      // cases in existing swiftinterface files, though.
+      shouldError |= getModuleContext()->isResilient() &&
+                     !getDeclContext()->isInSwiftinterface();
+
+      auto diag = queue.getDiags().diagnose(
+          this, diag::dynamic_member_lookup_candidate_inaccessible, this);
+      fixItAccess(diag, this,
+                  requiredAccessScope->requiredAccessForDiagnostics(),
+                  /*isForSetter=*/false, /*useDefaultAccess=*/false,
+                  /*updateAttr=*/false);
+      diag.warnUntilLanguageModeIf(!shouldError, languageModeForError);
+    }
+  }();
+
+  setDynamicMemberLookupEligibility(eligibility);
+  return eligibility;
 }
 
 /// Returns true if the given subscript method is an valid implementation of
 /// the `subscript(dynamicMember:)` requirement for @dynamicMemberLookup.
 /// The method is given to be defined as `subscript(dynamicMember:)`.
-bool swift::isValidDynamicMemberLookupSubscript(SubscriptDecl *decl,
-                                                bool ignoreLabel) {
-  // It could be
-  // - `subscript(dynamicMember: {Writable}KeyPath<...>)`; or
-  // - `subscript(dynamicMember: String*)`
-  return isValidKeyPathDynamicMemberLookup(decl, ignoreLabel) ||
-         isValidStringDynamicMemberLookup(decl, ignoreLabel);
+bool swift::isValidDynamicMemberLookupSubscript(SubscriptDecl *decl) {
+  return decl->getDynamicMemberLookupSubscriptEligibility() !=
+         DynamicMemberLookupSubscriptEligibility::None;
 }
 
-bool swift::isValidStringDynamicMemberLookup(SubscriptDecl *decl,
-                                             bool ignoreLabel) {
-  auto &ctx = decl->getASTContext();
-  // There are two requirements:
-  // - The subscript method has exactly one, non-variadic parameter.
-  // - The parameter type conforms to `ExpressibleByStringLiteral`.
-  if (!hasSingleNonVariadicParam(decl, ctx.Id_dynamicMember,
-                                 ignoreLabel))
-    return false;
-
-  const auto *param = decl->getIndices()->get(0);
-  auto paramType = param->getTypeInContext();
-
-  // If this is `subscript(dynamicMember: String*)`
-  return TypeChecker::conformsToKnownProtocol(
-      paramType, KnownProtocolKind::ExpressibleByStringLiteral);
+bool swift::isValidStringDynamicMemberLookup(SubscriptDecl *decl) {
+  return decl->getDynamicMemberLookupSubscriptEligibility() ==
+         DynamicMemberLookupSubscriptEligibility::String;
 }
 
 BoundGenericType *
-swift::getKeyPathTypeForDynamicMemberLookup(SubscriptDecl *decl,
-                                            bool ignoreLabel) {
-  auto &ctx = decl->getASTContext();
-  if (!hasSingleNonVariadicParam(decl, ctx.Id_dynamicMember,
-                                 ignoreLabel))
-    return nullptr;
-
-  auto paramTy = decl->getIndices()->get(0)->getInterfaceType();
-
-  // Allow to compose key path type with a `Sendable` protocol as
-  // a way to express sendability requirement.
-  if (auto *existential = paramTy->getAs<ExistentialType>()) {
-    auto layout = existential->getExistentialLayout();
-
-    auto protocols = layout.getProtocols();
-    if (!llvm::all_of(protocols,
-                      [&](ProtocolDecl *proto) {
-                        if (proto->isSpecificProtocol(KnownProtocolKind::Sendable))
-                          return true;
-
-                        if (proto->getInvertibleProtocolKind())
-                          return true;
-
-                        return false;
-                      })) {
-      return nullptr;
-    }
-
-    paramTy = layout.getSuperclass();
-    if (!paramTy)
-      return nullptr;
-  }
-
-  if (!paramTy->isKeyPath() &&
-      !paramTy->isWritableKeyPath() &&
-      !paramTy->isReferenceWritableKeyPath()) {
-    return nullptr;
-  }
-  return paramTy->getAs<BoundGenericType>();
+swift::getKeyPathTypeForDynamicMemberLookup(SubscriptDecl *decl) {
+  return decl->getDynamicMemberLookupKeyPathType();
 }
 
-bool swift::isValidKeyPathDynamicMemberLookup(SubscriptDecl *decl,
-                                              bool ignoreLabel) {
-  return bool(getKeyPathTypeForDynamicMemberLookup(decl, ignoreLabel));
+bool swift::isValidKeyPathDynamicMemberLookup(SubscriptDecl *decl) {
+  return decl->getDynamicMemberLookupSubscriptEligibility() ==
+         DynamicMemberLookupSubscriptEligibility::KeyPath;
 }
 
 /// The @dynamicMemberLookup attribute is only allowed on types that have at
@@ -2208,112 +2225,34 @@ bool swift::isValidKeyPathDynamicMemberLookup(SubscriptDecl *decl,
 ///
 /// ... but doesn't care about the mutating'ness of the getter/setter.
 /// We just manually check the requirements here.
-void AttributeChecker::
-visitDynamicMemberLookupAttr(DynamicMemberLookupAttr *attr) {
+void AttributeChecker::visitDynamicMemberLookupAttr(
+    DynamicMemberLookupAttr *attr) {
   // This attribute is only allowed on nominal types.
   auto decl = cast<NominalTypeDecl>(D);
   auto type = decl->getDeclaredType();
-  auto &ctx = decl->getASTContext();
-
-  auto emitInvalidTypeDiagnostic = [&](const SourceLoc loc) {
-    diagnose(loc, diag::invalid_dynamic_member_lookup_type, type);
-    attr->setInvalid();
-  };
-
-  // Look up `subscript(dynamicMember:)` candidates.
-  DeclNameRef subscriptName(
-      { ctx, DeclBaseName::createSubscript(), { ctx.Id_dynamicMember } });
-  auto candidates = TypeChecker::lookupMember(decl, type, subscriptName);
-
-  if (!candidates.empty()) {
-    // If no candidates are valid, then reject one.
-    auto oneCandidate = candidates.front().getValueDecl();
-    candidates.filter([&](LookupResultEntry entry, bool isOuter) -> bool {
-      auto cand = cast<SubscriptDecl>(entry.getValueDecl());
-      return isValidDynamicMemberLookupSubscript(cand);
-    });
-
-    if (candidates.empty()) {
-      emitInvalidTypeDiagnostic(oneCandidate->getLoc());
-      return;
-    }
-
-    // Diagnose if there are no candidates that are sufficiently accessible.
-    auto requiredAccessScope = decl->getFormalAccessScope(/*useDC=*/nullptr);
-    auto accessDC = requiredAccessScope.getDeclContext();
-    auto inaccessibleCandidate = candidates.front().getValueDecl();
-    candidates.filter([&](LookupResultEntry entry, bool isOuter) -> bool {
-      return entry.getValueDecl()->isAccessibleFrom(accessDC);
-    });
-
-    if (candidates.empty()) {
-      const auto languageModeForError = LanguageMode::future;
-      bool shouldError = ctx.isLanguageModeAtLeast(languageModeForError);
-
-      // Diagnose as an error in resilient modules regardless of language
-      // version since this will break the swiftinterface. Don't diagnose
-      // cases in existing swiftinterface files, though.
-      shouldError |= decl->getModuleContext()->isResilient() &&
-                     !decl->getDeclContext()->isInSwiftinterface();
-
-      auto diag = diagnose(inaccessibleCandidate->getLoc(),
-                            diag::dynamic_member_lookup_candidate_inaccessible,
-                            inaccessibleCandidate);
-      fixItAccess(diag, inaccessibleCandidate,
-                  requiredAccessScope.requiredAccessForDiagnostics(),
-                  /*isForSetter=*/false, /*useDefaultAccess=*/false,
-                  /*updateAttr=*/false);
-      diag.warnUntilLanguageModeIf(!shouldError, languageModeForError);
-
-      if (shouldError) {
-        attr->setInvalid();
-        return;
-      }
-    }
-
-    return;
-  }
-
-  // If we couldn't find any candidates, it's likely because:
-  //
-  // 1. We don't have a subscript with `dynamicMember` label.
-  // 2. We have a subscript with `dynamicMember` label, but no argument label.
-  //
-  // Let's do another lookup using just the base name.
-  auto newCandidates =
+  auto candidates =
       TypeChecker::lookupMember(decl, type, DeclNameRef::createSubscript());
 
-  // Validate the candidates while ignoring the label.
-  newCandidates.filter([&](const LookupResultEntry entry, bool isOuter) {
-    auto cand = cast<SubscriptDecl>(entry.getValueDecl());
-    return isValidDynamicMemberLookupSubscript(cand, /*ignoreLabel*/ true);
-  });
-
-  // If there were no potentially valid candidates, then throw an error.
-  if (newCandidates.empty()) {
-    emitInvalidTypeDiagnostic(attr->getLocation());
-    return;
-  }
-
-  // For each candidate, emit a diagnostic. If we don't have an explicit
-  // argument label, then emit a fix-it to suggest the user to add one.
-  for (auto cand : newCandidates) {
-    auto SD = cast<SubscriptDecl>(cand.getValueDecl());
-    auto index = SD->getIndices()->get(0);
-    diagnose(SD, diag::invalid_dynamic_member_lookup_type, type);
-
-    // If we have something like `subscript(foo:)` then we want to insert
-    // `dynamicMember` before `foo`.
-    if (index->getParameterNameLoc().isValid() &&
-        index->getArgumentNameLoc().isInvalid()) {
-      diagnose(SD, diag::invalid_dynamic_member_subscript)
-          .highlight(index->getSourceRange())
-          .fixItInsert(index->getParameterNameLoc(), "dynamicMember ");
+  if (candidates.empty()) {
+    diagnose(attr->getLocation(), diag::invalid_dynamic_member_lookup_type,
+             type);
+  } else {
+    auto requiredAccessScope = decl->getFormalAccessScope(/*useDC=*/nullptr);
+    // If we find at least one valid candidate, we won't produce any
+    // diagnostics.
+    DiagnosticQueue queue{Ctx.Diags, /*emitOnDestruction=*/true};
+    for (auto candidate : candidates) {
+      auto *SD = cast<SubscriptDecl>(candidate.getValueDecl());
+      if (SD->evaluateDynamicMemberLookupEligibility(&requiredAccessScope,
+                                                     &queue.getDiags()) !=
+          DynamicMemberLookupSubscriptEligibility::None) {
+        queue.clear();
+        return;
+      }
     }
   }
 
   attr->setInvalid();
-  return;
 }
 
 /// Get the innermost enclosing declaration for a declaration.

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2152,8 +2152,8 @@ void AttributeChecker::visitDynamicMemberLookupAttr(
   // group. (2) produces warnings in the current language mode, which will be
   // upgraded to errors in the next language mode (hence the separate diagnostic
   // stages).
-  SmallVector<DynamicMemberLookupSubscriptEligibility> validButInacessible,
-      invalid, potentiallyValid;
+  SmallVector<DynamicMemberLookupSubscriptEligibility> validButInacessible;
+  SmallVector<DynamicMemberLookupSubscriptEligibility> invalid;
 
   auto requiredAccessScope = decl->getFormalAccessScope();
   auto accessDC = requiredAccessScope.getDeclContext();
@@ -2171,11 +2171,10 @@ void AttributeChecker::visitDynamicMemberLookupAttr(
       }
 
       validButInacessible.emplace_back(eligibility);
-    } else if (eligibility.isEligibleForArgumentLabelFixIt()) {
-      potentiallyValid.emplace_back(eligibility);
-    } else {
-      invalid.emplace_back(eligibility);
+      continue;
     }
+
+    invalid.emplace_back(eligibility);
   }
 
   if (!validButInacessible.empty()) {
@@ -2207,15 +2206,6 @@ void AttributeChecker::visitDynamicMemberLookupAttr(
 
   if (!invalid.empty()) {
     for (auto &candidate : invalid) {
-      candidate.diagnose();
-    }
-
-    attr->setInvalid();
-    return;
-  }
-
-  if (!potentiallyValid.empty()) {
-    for (auto &candidate : potentiallyValid) {
       candidate.diagnose();
     }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -31,6 +31,7 @@
 #include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DeclExportabilityVisitor.h"
+#include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/DiagnosticsParse.h"
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/Effects.h"
@@ -2132,35 +2133,83 @@ SubscriptDecl::evaluateDynamicMemberLookupEligibility(
       return;
     }
 
-    auto index = indices->get(0);
-    if (index->getArgumentName() != getASTContext().Id_dynamicMember) {
+    auto isInvalid = false;
+    auto &ctx = getASTContext();
+    auto diagnosedOutOfOrder = false;
+    auto firstIndex = indices->get(0);
+    if (firstIndex->getArgumentName() != ctx.Id_dynamicMember) {
+      if (!Diags) {
+        // If we're not here to produce diagnostics during type-checking,
+        // there's no need to keep going.
+        return;
+      }
+
+      isInvalid = true;
+
+      // We can separately diagnose whether the `dynamicMember` parameter is out
+      // of order vs. whether we're missing a `dynamicMember` label altogether.
+      if (indices->size() > 1) {
+        for (auto idx : range(1, indices->size())) {
+          auto index = indices->get(idx);
+          if (index->getArgumentName() == ctx.Id_dynamicMember) {
+            queue.getDiags()
+                .diagnose(this,
+                          diag::invalid_dynamic_member_subscript_out_of_order)
+                .highlight(index->getSourceRange());
+            diagnosedOutOfOrder = true;
+            break;
+          }
+        }
+      }
+
       // If there is no argument label at all, we can offer a fix-it to insert
       // it. Note that we intentionally don't want to emit a diagnostic if there
       // _is_ a label, since it's clearly just not a dynamic member lookup
       // subscript.
-      if (Diags && index->getParameterNameLoc().isValid() &&
-          index->getArgumentNameLoc().isInvalid()) {
+      if (!diagnosedOutOfOrder && firstIndex->getParameterNameLoc().isValid() &&
+          firstIndex->getArgumentNameLoc().isInvalid()) {
         queue.getDiags()
             .diagnose(this,
                       diag::invalid_dynamic_member_subscript_missing_label)
-            .highlight(index->getSourceRange())
-            .fixItInsert(index->getParameterNameLoc(), "dynamicMember ");
+            .highlight(firstIndex->getSourceRange())
+            .fixItInsert(firstIndex->getParameterNameLoc(), "dynamicMember ");
       }
-
-      return;
     }
 
-    if (!index->hasInterfaceType() || index->isVariadic()) {
+    for (auto index : *indices) {
+      if (!index->hasInterfaceType() ||
+          (index == firstIndex && index->isVariadic())) {
+        isInvalid = true;
+      }
+
+      if (index != firstIndex &&
+          (!diagnosedOutOfOrder ||
+           index->getArgumentName() != ctx.Id_dynamicMember) &&
+          (!index->isDefaultArgument() && !index->isVariadic() &&
+           !isa<PackExpansionType>(
+               index->getInterfaceType()->getCanonicalType()))) {
+        queue.getDiags()
+            .diagnose(this,
+                      diag::invalid_dynamic_member_subscript_missing_default)
+            .highlight(index->getSourceRange())
+            .fixItInsertAfter(index->getEndLoc(), " = <#Default#>");
+        isInvalid = true;
+      }
+    }
+
+    if (isInvalid) {
+      // There's no point in checking the `dynamicMember` argument type since
+      // we've already output diagnostics.
       return;
     }
 
     if (TypeChecker::conformsToKnownProtocol(
-            index->getTypeInContext(),
+            firstIndex->getTypeInContext(),
             KnownProtocolKind::ExpressibleByStringLiteral)) {
       queue.clear();
       eligibility = DynamicMemberLookupSubscriptEligibility::String;
     } else if (getDynamicMemberParamTypeAsKeyPathType(
-                   index->getInterfaceType())) {
+                   firstIndex->getInterfaceType())) {
       queue.clear();
       eligibility = DynamicMemberLookupSubscriptEligibility::KeyPath;
     }
@@ -2197,8 +2246,12 @@ SubscriptDecl::evaluateDynamicMemberLookupEligibility(
 /// The @dynamicMemberLookup attribute is only allowed on types that have at
 /// least one subscript member declared like this:
 ///
-/// subscript<KeywordType: ExpressibleByStringLiteral, LookupValue>
-///   (dynamicMember name: KeywordType) -> LookupValue { get }
+/// subscript(dynamicMember name: T, ...) -> U
+///   (where T is a concrete type conforming to `ExpressibleByStringLiteral`)
+///
+///   or
+///
+/// subscript(dynamicMember name: {{Reference}Writable}KeyPath<T, U>, ...) -> V
 ///
 /// ... but doesn't care about the mutating'ness of the getter/setter.
 /// We just manually check the requirements here.

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2152,7 +2152,7 @@ void AttributeChecker::visitDynamicMemberLookupAttr(
   // group. (2) produces warnings in the current language mode, which will be
   // upgraded to errors in the next language mode (hence the separate diagnostic
   // stages).
-  SubscriptDecl *validButInacessible = nullptr;
+  SubscriptDecl *validButInaccessible = nullptr;
   SmallVector<std::pair<SubscriptDecl *, DynamicMemberLookupSubscriptEligibility>>
       invalid;
 
@@ -2171,14 +2171,16 @@ void AttributeChecker::visitDynamicMemberLookupAttr(
         return;
       }
 
-      validButInacessible = SD;
+      validButInaccessible = SD;
       continue;
     }
 
     invalid.emplace_back(SD, eligibility);
   }
 
-  if (validButInacessible != nullptr) {
+  bool diagnosed = false;
+
+  if (validButInaccessible != nullptr) {
     const auto languageModeForError = LanguageMode::future;
     bool shouldError = ctx.isLanguageModeAtLeast(languageModeForError);
 
@@ -2188,33 +2190,30 @@ void AttributeChecker::visitDynamicMemberLookupAttr(
     shouldError |= decl->getModuleContext()->isResilient() &&
                    !decl->getDeclContext()->isInSwiftinterface();
 
-    auto diag = diagnose(validButInacessible->getLoc(),
+    auto diag = diagnose(validButInaccessible->getLoc(),
                          diag::dynamic_member_lookup_candidate_inaccessible,
-                         validButInacessible);
-    fixItAccess(diag, validButInacessible,
+                         validButInaccessible);
+    fixItAccess(diag, validButInaccessible,
                 requiredAccessScope.requiredAccessForDiagnostics(),
                 /*isForSetter=*/false, /*useDefaultAccess=*/false,
                 /*updateAttr=*/false);
     diag.warnUntilLanguageModeIf(!shouldError, languageModeForError);
 
-    if (shouldError) {
+    if (shouldError)
       attr->setInvalid();
-      return;
-    }
+
+    return;
   }
 
   if (!invalid.empty()) {
     for (const auto &pair : invalid) {
-      pair.second.diagnose(pair.first);
+      diagnosed |= pair.second.diagnose(pair.first);
     }
-
-    attr->setInvalid();
-    return;
   }
 
-  // There were no candidates at all.
   attr->setInvalid();
-  diagnose(attr->getStartLoc(), diag::invalid_dynamic_member_lookup_type, type);
+  if (!diagnosed)
+    diagnose(attr->getStartLoc(), diag::invalid_dynamic_member_lookup_type, type);
 }
 
 /// Get the innermost enclosing declaration for a declaration.

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3419,3 +3419,129 @@ SourceLoc PrettyPrintDeclRequest::evaluate(Evaluator &eval, const Decl *decl) co
 
   return memBufferStartLoc.getAdvancedLoc(targetDeclOffsetInBuffer);
 }
+
+bool DynamicMemberLookupSubscriptEligibility::diagnose(
+    DiagnosticEngine *diags) {
+  return false;
+}
+
+DynamicMemberLookupSubscriptRequest::Result
+DynamicMemberLookupSubscriptRequest::evaluate(Evaluator &evaluator,
+                                              const SubscriptDecl *SD,
+                                              const DeclContext *useDC) const {
+  using DynamicMemberKind =
+      DynamicMemberLookupSubscriptEligibility::DynamicMemberKind;
+  using InvalidParameterFlag =
+      DynamicMemberLookupSubscriptEligibility::InvalidParameterFlag;
+  using InvalidParameterFlags =
+      DynamicMemberLookupSubscriptEligibility::InvalidParameterFlags;
+
+  auto &ctx = SD->getASTContext();
+  auto *indices = SD->getIndices();
+
+  // We want to check for the presence of a `dynamicMember` label to determine
+  // intent so we can offer fix-its for invalid types; this is inherently
+  // ambiguous, but we'll go by the following rules:
+  //
+  //  1. The first parameter with an explicit `dynamicMember` argument label (or
+  //     parameter label, with no argument label) will be considered "the"
+  //     `dynamicMember` parameter, regardless of other labels (e.g.,
+  //     `subscript(dynamicMember member: String)` or
+  //     `subscript(dynamicMember: String)`)
+  //  2. If (1) does not exist, the first parameter with an explicit
+  //     `dynamicMember` parameter label (with any argument label) will be
+  //     considered an attempt at writing (1), and worth diagnosing with a
+  //     fix-it (e.g., `subscript(_ dynamicMember: String)`)
+  //  3. If no `dynamicMember` parameter exists at all, we'll treat the first
+  //     subscript parameter as a candidate for a `dynamicMember` argument label
+  //     fix-it if it would otherwise be valid (e.g.,
+  //     `subscript(member: String)`)
+  auto seenDynamicMemberLabel = false;
+  std::optional<unsigned> dynamicMemberIdx = std::nullopt;
+  for (auto idx : range(0, indices->size())) {
+    auto *param = indices->get(idx);
+
+    auto argLabel = param->getArgumentName();
+    auto paramLabel = param->getParameterName();
+    if (argLabel == ctx.Id_dynamicMember ||
+        (param->getArgumentNameLoc().isInvalid() &&
+         paramLabel == ctx.Id_dynamicMember)) {
+      seenDynamicMemberLabel = true;
+      dynamicMemberIdx = idx;
+      break;
+    }
+
+    if (paramLabel == ctx.Id_dynamicMember) {
+      seenDynamicMemberLabel = true;
+    }
+  }
+
+  auto seenDynamicMemberParamLabel = false;
+  std::optional<DynamicMemberKind> kind = std::nullopt;
+  SmallVector<InvalidParameterFlags> paramFlags;
+  for (auto idx : range(0, indices->size())) {
+    auto *param = indices->get(idx);
+    InvalidParameterFlags flags;
+
+    auto isDynamicMemberParam = false;
+    if (idx == dynamicMemberIdx) {
+      isDynamicMemberParam = true;
+
+      // We only diagnose "the" `dynamicMember` parameter. Technically,
+      // multiple parameters can have the `dynamicMember` argument label (if
+      // they have different parameter labels), but only one of them can be
+      // first in the parameter list.
+      if (idx != 0) {
+        flags |= InvalidParameterFlag::DynamicMemberInvalidOrder;
+      }
+
+      if (param->getArgumentNameLoc().isInvalid()) {
+        flags |= InvalidParameterFlag::DynamicMemberMissingParameterLabel;
+      }
+    } else if (param->getParameterName() == ctx.Id_dynamicMember) {
+      // We'll only consider the first parameter with an explicit
+      // `dynamicMember` parameter label to be eligible for checking. (Repeated
+      // parameter labels are invalid for methods anyway.)
+      isDynamicMemberParam = !dynamicMemberIdx && !seenDynamicMemberParamLabel;
+      seenDynamicMemberParamLabel = true;
+      if (isDynamicMemberParam) {
+        flags |= InvalidParameterFlag::DynamicMemberInvalidArgumentLabel;
+      }
+    } else if (!seenDynamicMemberLabel && idx == 0) {
+      // We don't have any `dynamicMember` parameters at all, so we can check
+      // this one for potential validity.
+      isDynamicMemberParam = true;
+    }
+
+    if (isDynamicMemberParam) {
+      if (SubscriptDecl::getDynamicMemberParamTypeAsKeyPathType(
+              param->getInterfaceType())) {
+        kind = DynamicMemberKind::KeyPath;
+      } else if (TypeChecker::conformsToKnownProtocol(
+                     param->getTypeInContext(),
+                     KnownProtocolKind::ExpressibleByStringLiteral)) {
+        kind = DynamicMemberKind::String;
+      }
+
+      if (kind && !seenDynamicMemberLabel) {
+        // We can offer a fix-it if the rest of the subscript is valid.
+        flags |= InvalidParameterFlag::DynamicMemberMissingArgumentLabel;
+      } else if (!kind && seenDynamicMemberLabel) {
+        // We only want to flags this on a "real" `dynamicMember` parameter,
+        // since a subscript like `subscript(foo: Foo)` just isn't applicable
+        // for `@dynamicMemberLookup` checking at all.
+        flags |= InvalidParameterFlag::DynamicMemberInvalidType;
+      }
+    } else if (!param->isDefaultArgument() && !param->isVariadic() &&
+               !param->getInterfaceType()->is<PackExpansionType>()) {
+      flags |= InvalidParameterFlag::ParameterMissingDefaultValue;
+    }
+
+    paramFlags.push_back(flags);
+  }
+
+  auto eligibility = DynamicMemberLookupSubscriptEligibility(
+      SD, dynamicMemberIdx, kind, paramFlags);
+  auto isAccessible = SD->isAccessibleFrom(useDC);
+  return std::pair(eligibility, isAccessible);
+}

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3501,10 +3501,9 @@ bool DynamicMemberLookupSubscriptEligibility::diagnose() {
   return diagnosed;
 }
 
-DynamicMemberLookupSubscriptRequest::Result
+DynamicMemberLookupSubscriptEligibility
 DynamicMemberLookupSubscriptRequest::evaluate(Evaluator &evaluator,
-                                              const SubscriptDecl *SD,
-                                              const DeclContext *useDC) const {
+                                              const SubscriptDecl *SD) const {
   using DynamicMemberKind =
       DynamicMemberLookupSubscriptEligibility::DynamicMemberKind;
   using InvalidParameterFlag =
@@ -3618,8 +3617,6 @@ DynamicMemberLookupSubscriptRequest::evaluate(Evaluator &evaluator,
     paramFlags.push_back(flags);
   }
 
-  auto eligibility = DynamicMemberLookupSubscriptEligibility(
+  return DynamicMemberLookupSubscriptEligibility(
       SD, dynamicMemberIdx, kind, paramFlags);
-  auto isAccessible = SD->isAccessibleFrom(useDC);
-  return std::pair(eligibility, isAccessible);
 }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3422,9 +3422,9 @@ SourceLoc PrettyPrintDeclRequest::evaluate(Evaluator &eval, const Decl *decl) co
 
 bool DynamicMemberLookupSubscriptEligibility::diagnose() {
   auto &diags = Decl->getASTContext().Diags;
-  auto *indices = Decl->getIndices();
+  auto *params = Decl->getParameterList();
   if (isEligibleForArgumentLabelFixIt()) {
-    auto *param = const_cast<ParamDecl *>(indices->get(0));
+    auto *param = const_cast<ParamDecl *>(params->get(0));
     diags
         .diagnose(param,
                   diag::invalid_dynamic_member_subscript_invalid_arg_label,
@@ -3435,13 +3435,13 @@ bool DynamicMemberLookupSubscriptEligibility::diagnose() {
   }
 
   auto diagnosed = false;
-  for (auto idx : range(0, indices->size())) {
+  for (auto idx : indices(*params)) {
     auto flags = ParamFlags[idx];
     if (!flags) {
       continue;
     }
 
-    auto *param = const_cast<ParamDecl *>(indices->get(idx));
+    auto *param = const_cast<ParamDecl *>(params->get(idx));
     if (flags & InvalidParameterFlag::DynamicMemberMissingParameterLabel) {
       // Technically, a `ParamDecl` can't have an argument label without a
       // parameter label, but we treat `dynamicMember:` as if it were an
@@ -3512,7 +3512,7 @@ DynamicMemberLookupSubscriptRequest::evaluate(Evaluator &evaluator,
       DynamicMemberLookupSubscriptEligibility::InvalidParameterFlags;
 
   auto &ctx = SD->getASTContext();
-  auto *indices = SD->getIndices();
+  auto *params = SD->getParameterList();
   bool isSourceFile = SD->getParentSourceFile() != nullptr;
 
   // We want to check for the presence of a `dynamicMember` label to determine
@@ -3534,8 +3534,8 @@ DynamicMemberLookupSubscriptRequest::evaluate(Evaluator &evaluator,
   //     `subscript(member: String)`)
   auto seenDynamicMemberLabel = false;
   std::optional<unsigned> dynamicMemberIdx = std::nullopt;
-  for (auto idx : range(0, indices->size())) {
-    auto *param = indices->get(idx);
+  for (auto idx : indices(*params)) {
+    auto *param = params->get(idx);
 
     auto argLabel = param->getArgumentName();
     auto paramLabel = param->getParameterName();
@@ -3556,8 +3556,8 @@ DynamicMemberLookupSubscriptRequest::evaluate(Evaluator &evaluator,
   auto seenDynamicMemberParamLabel = false;
   std::optional<DynamicMemberKind> kind = std::nullopt;
   SmallVector<InvalidParameterFlags> paramFlags;
-  for (auto idx : range(0, indices->size())) {
-    auto *param = indices->get(idx);
+  for (auto idx : indices(*params)) {
+    auto *param = params->get(idx);
     InvalidParameterFlags flags;
 
     auto isDynamicMemberParam = false;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3461,11 +3461,7 @@ bool DynamicMemberLookupSubscriptEligibility::diagnose() {
           param);
       if (param->getArgumentName().is("_")) {
         diag.highlight(param->getSourceRange())
-            .fixItReplace(
-                SourceRange(
-                    param->getArgumentNameLoc(),
-                    param->getArgumentNameLoc().getAdvancedLocOrInvalid(1)),
-                "dynamicMember");
+            .fixItReplace(param->getArgumentNameLoc(), "dynamicMember");
       }
       diagnosed = true;
     }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3438,6 +3438,7 @@ DynamicMemberLookupSubscriptRequest::evaluate(Evaluator &evaluator,
 
   auto &ctx = SD->getASTContext();
   auto *indices = SD->getIndices();
+  bool isSourceFile = SD->getParentSourceFile() != nullptr;
 
   // We want to check for the presence of a `dynamicMember` label to determine
   // intent so we can offer fix-its for invalid types; this is inherently
@@ -3464,7 +3465,8 @@ DynamicMemberLookupSubscriptRequest::evaluate(Evaluator &evaluator,
     auto argLabel = param->getArgumentName();
     auto paramLabel = param->getParameterName();
     if (argLabel == ctx.Id_dynamicMember ||
-        (param->getArgumentNameLoc().isInvalid() &&
+        (isSourceFile &&
+         param->getArgumentNameLoc().isInvalid() &&
          paramLabel == ctx.Id_dynamicMember)) {
       seenDynamicMemberLabel = true;
       dynamicMemberIdx = idx;
@@ -3495,7 +3497,7 @@ DynamicMemberLookupSubscriptRequest::evaluate(Evaluator &evaluator,
         flags |= InvalidParameterFlag::DynamicMemberInvalidOrder;
       }
 
-      if (param->getArgumentNameLoc().isInvalid()) {
+      if (isSourceFile && param->getArgumentNameLoc().isInvalid()) {
         flags |= InvalidParameterFlag::DynamicMemberMissingParameterLabel;
       }
     } else if (param->getParameterName() == ctx.Id_dynamicMember) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3420,9 +3420,85 @@ SourceLoc PrettyPrintDeclRequest::evaluate(Evaluator &eval, const Decl *decl) co
   return memBufferStartLoc.getAdvancedLoc(targetDeclOffsetInBuffer);
 }
 
-bool DynamicMemberLookupSubscriptEligibility::diagnose(
-    DiagnosticEngine *diags) {
-  return false;
+bool DynamicMemberLookupSubscriptEligibility::diagnose() {
+  auto &diags = Decl->getASTContext().Diags;
+  auto *indices = Decl->getIndices();
+  if (isEligibleForArgumentLabelFixIt()) {
+    auto *param = const_cast<ParamDecl *>(indices->get(0));
+    diags
+        .diagnose(param,
+                  diag::invalid_dynamic_member_subscript_invalid_arg_label,
+                  param)
+        .highlight(param->getSourceRange())
+        .fixItInsert(param->getParameterNameLoc(), "dynamicMember ");
+    return true;
+  }
+
+  auto diagnosed = false;
+  for (auto idx : range(0, indices->size())) {
+    auto flags = ParamFlags[idx];
+    if (!flags) {
+      continue;
+    }
+
+    auto *param = const_cast<ParamDecl *>(indices->get(idx));
+    if (flags & InvalidParameterFlag::DynamicMemberMissingParameterLabel) {
+      // Technically, a `ParamDecl` can't have an argument label without a
+      // parameter label, but we treat `dynamicMember:` as if it were an
+      // argument label and offer to insert a new "parameter" label.
+      diags
+          .diagnose(param,
+                    diag::invalid_dynamic_member_subscript_missing_param_label,
+                    param)
+          .highlight(param->getSourceRange())
+          .fixItInsertAfter(param->getParameterNameLoc(), " <#label#>");
+      diagnosed = true;
+    }
+
+    if (flags & InvalidParameterFlag::DynamicMemberInvalidArgumentLabel) {
+      auto diag = diags.diagnose(
+          param, diag::invalid_dynamic_member_subscript_invalid_arg_label,
+          param);
+      if (param->getArgumentName().is("_")) {
+        diag.highlight(param->getSourceRange())
+            .fixItReplace(
+                SourceRange(
+                    param->getArgumentNameLoc(),
+                    param->getArgumentNameLoc().getAdvancedLocOrInvalid(1)),
+                "dynamicMember");
+      }
+      diagnosed = true;
+    }
+
+    if (flags & InvalidParameterFlag::DynamicMemberInvalidOrder) {
+      diags.diagnose(
+          param, diag::invalid_dynamic_member_subscript_invalid_order, param);
+      diagnosed = true;
+    }
+
+    if (flags & InvalidParameterFlag::DynamicMemberInvalidType) {
+      diags.diagnose(param, diag::invalid_dynamic_member_subscript_invalid_type,
+                     param);
+      diagnosed = true;
+    }
+
+    if (flags & InvalidParameterFlag::ParameterMissingDefaultValue) {
+      diags
+          .diagnose(param,
+                    diag::invalid_dynamic_member_subscript_missing_default,
+                    param)
+          .highlight(param->getSourceRange())
+          .fixItInsertAfter(param->getEndLoc(), " = <#Default#>");
+      diagnosed = true;
+    }
+
+    // At least one flag has been set (or else we would have continued early);
+    // light-weight sanity check that we'll be reporting we've diagnosed at
+    // least once.
+    ASSERT(diagnosed);
+  }
+
+  return diagnosed;
 }
 
 DynamicMemberLookupSubscriptRequest::Result

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3420,9 +3420,9 @@ SourceLoc PrettyPrintDeclRequest::evaluate(Evaluator &eval, const Decl *decl) co
   return memBufferStartLoc.getAdvancedLoc(targetDeclOffsetInBuffer);
 }
 
-bool DynamicMemberLookupSubscriptEligibility::diagnose() {
-  auto &diags = Decl->getASTContext().Diags;
-  auto *params = Decl->getParameterList();
+bool DynamicMemberLookupSubscriptEligibility::diagnose(SubscriptDecl *decl) const {
+  auto &diags = decl->getASTContext().Diags;
+  auto *params = decl->getParameterList();
   if (isEligibleForArgumentLabelFixIt()) {
     auto *param = const_cast<ParamDecl *>(params->get(0));
     diags
@@ -3434,7 +3434,7 @@ bool DynamicMemberLookupSubscriptEligibility::diagnose() {
     return true;
   }
 
-  auto diagnosed = false;
+  bool diagnosed = false;
   for (auto idx : indices(*params)) {
     auto flags = ParamFlags[idx];
     if (!flags) {
@@ -3614,5 +3614,5 @@ DynamicMemberLookupSubscriptRequest::evaluate(Evaluator &evaluator,
   }
 
   return DynamicMemberLookupSubscriptEligibility(
-      SD, dynamicMemberIdx, kind, paramFlags);
+      dynamicMemberIdx, kind, paramFlags);
 }

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -2018,9 +2018,9 @@ static bool checkSingleOverride(ValueDecl *override, ValueDecl *base) {
           (bool) parentSubscript->getDynamicMemberLookupKind(std::nullopt)) {
         auto overrideSubscript = cast<SubscriptDecl>(overrideASD);
 
-        auto [eligibility, _] = evaluateOrFatal(
+        auto eligibility = evaluateOrFatal(
             overrideSubscript->getASTContext().evaluator,
-            DynamicMemberLookupSubscriptRequest{overrideSubscript, nullptr});
+            DynamicMemberLookupSubscriptRequest{overrideSubscript});
         if (eligibility.diagnose()) {
           return true;
         }

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -2004,6 +2004,28 @@ static bool checkSingleOverride(ValueDecl *override, ValueDecl *base) {
                      "throwing");
       return true;
     }
+
+    // Make sure that if we're overriding a `@dynamicMemberLookup` subscript, it
+    // remains as valid as its parent. `@dynamicMemberLookup`-annotated types
+    // normally go through `AttributeChecker` for validation, but if
+    // `@dynamicMemberLookup` is inherited, there isn't an explicit attr to
+    // validate. Most potential mismatches have been caught at this point, but
+    // we do still need to check that, e.g., the overridden decl hasn't dropped
+    // a default value for one of its parameters.
+    if (auto parentSubscript = dyn_cast<SubscriptDecl>(baseASD)) {
+      auto owningTy = override->getDeclContext()->getDeclaredInterfaceType();
+      if (owningTy->hasDynamicMemberLookupAttribute() &&
+          parentSubscript->isValidDynamicMemberLookupSubscript(std::nullopt)) {
+        auto overrideSubscript = cast<SubscriptDecl>(overrideASD);
+
+        auto [eligibility, _] = evaluateOrFatal(
+            overrideSubscript->getASTContext().evaluator,
+            DynamicMemberLookupSubscriptRequest{overrideSubscript, nullptr});
+        if (eligibility.diagnose()) {
+          return true;
+        }
+      }
+    }
   }
 
   // Various properties are only checked for the storage declarations

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -2021,7 +2021,7 @@ static bool checkSingleOverride(ValueDecl *override, ValueDecl *base) {
         auto eligibility = evaluateOrFatal(
             overrideSubscript->getASTContext().evaluator,
             DynamicMemberLookupSubscriptRequest{overrideSubscript});
-        if (eligibility.diagnose()) {
+        if (eligibility.diagnose(overrideSubscript)) {
           return true;
         }
       }

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -2015,7 +2015,7 @@ static bool checkSingleOverride(ValueDecl *override, ValueDecl *base) {
     if (auto parentSubscript = dyn_cast<SubscriptDecl>(baseASD)) {
       auto owningTy = override->getDeclContext()->getDeclaredInterfaceType();
       if (owningTy->hasDynamicMemberLookupAttribute() &&
-          (bool) parentSubscript->getDynamicMemberLookupKind(std::nullopt)) {
+          (bool) parentSubscript->getDynamicMemberLookupKind()) {
         auto overrideSubscript = cast<SubscriptDecl>(overrideASD);
 
         auto eligibility = evaluateOrFatal(

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -2015,7 +2015,7 @@ static bool checkSingleOverride(ValueDecl *override, ValueDecl *base) {
     if (auto parentSubscript = dyn_cast<SubscriptDecl>(baseASD)) {
       auto owningTy = override->getDeclContext()->getDeclaredInterfaceType();
       if (owningTy->hasDynamicMemberLookupAttribute() &&
-          parentSubscript->isValidDynamicMemberLookupSubscript(std::nullopt)) {
+          (bool) parentSubscript->getDynamicMemberLookupKind(std::nullopt)) {
         auto overrideSubscript = cast<SubscriptDecl>(overrideASD);
 
         auto [eligibility, _] = evaluateOrFatal(

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2952,10 +2952,11 @@ public:
     checkExplicitAvailability(SD);
 
     if (!checkOverrides(SD)) {
-      // If a subscript has an override attribute but does not override
-      // anything, complain.
       if (auto *OA = SD->getAttrs().getAttribute<OverrideAttr>()) {
-        if (!SD->getOverriddenDecl()) {
+        auto *overriddenDecl = SD->getOverriddenDecl();
+        if (!overriddenDecl) {
+          // If a subscript has an override attribute but does not override
+          // anything, complain.
           auto DC = SD->getDeclContext();
           auto isClassContext = DC->getSelfClassDecl() != nullptr;
           auto isStructOrEnumContext = DC->getSelfEnumDecl() != nullptr ||
@@ -2969,6 +2970,28 @@ public:
                 .highlight(OA->getLocation());
           }
           OA->setInvalid();
+        } else if (auto outerTy = DC->getDeclaredInterfaceType()) {
+          // This is an overridden subscript; if the outer type has
+          // `@dynamicMemberLookup` but isn't directly annotated with it (e.g.,
+          // it's inherited), its members won't go through
+          // `@dynamicMemberLookup` checking via `AttributeChecker`. We need to
+          // ensure that if the overridden decl was a valid dynamic member
+          // lookup subscript, this override remains valid.
+          if (outerTy->hasDynamicMemberLookupAttribute()) {
+            auto D = outerTy->getAnyNominal();
+            if (!D->getAttrs().hasAttribute<DynamicMemberLookupAttr>()) {
+              if (overriddenDecl
+                      ->getDynamicMemberLookupSubscriptEligibility() !=
+                  DynamicMemberLookupSubscriptEligibility::None) {
+                auto accessScope = D->getFormalAccessScope();
+                if (SD->evaluateDynamicMemberLookupEligibility(
+                        &accessScope, &SD->getDiags()) ==
+                    DynamicMemberLookupSubscriptEligibility::None) {
+                  SD->setInvalid();
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2980,13 +2980,10 @@ public:
           if (outerTy->hasDynamicMemberLookupAttribute()) {
             auto D = outerTy->getAnyNominal();
             if (!D->getAttrs().hasAttribute<DynamicMemberLookupAttr>()) {
-              if (overriddenDecl
-                      ->getDynamicMemberLookupSubscriptEligibility() !=
-                  DynamicMemberLookupSubscriptEligibility::None) {
-                auto accessScope = D->getFormalAccessScope();
-                if (SD->evaluateDynamicMemberLookupEligibility(
-                        &accessScope, &SD->getDiags()) ==
-                    DynamicMemberLookupSubscriptEligibility::None) {
+              if (overriddenDecl->isValidDynamicMemberLookupSubscript(
+                      /*useDC=*/std::nullopt)) {
+                if (!SD->isValidDynamicMemberLookupSubscript(
+                        /*useDC=*/std::nullopt)) {
                   SD->setInvalid();
                 }
               }

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2952,11 +2952,10 @@ public:
     checkExplicitAvailability(SD);
 
     if (!checkOverrides(SD)) {
+      // If a subscript has an override attribute but does not override
+      // anything, complain.
       if (auto *OA = SD->getAttrs().getAttribute<OverrideAttr>()) {
-        auto *overriddenDecl = SD->getOverriddenDecl();
-        if (!overriddenDecl) {
-          // If a subscript has an override attribute but does not override
-          // anything, complain.
+        if (!SD->getOverriddenDecl()) {
           auto DC = SD->getDeclContext();
           auto isClassContext = DC->getSelfClassDecl() != nullptr;
           auto isStructOrEnumContext = DC->getSelfEnumDecl() != nullptr ||
@@ -2970,25 +2969,6 @@ public:
                 .highlight(OA->getLocation());
           }
           OA->setInvalid();
-        } else if (auto outerTy = DC->getDeclaredInterfaceType()) {
-          // This is an overridden subscript; if the outer type has
-          // `@dynamicMemberLookup` but isn't directly annotated with it (e.g.,
-          // it's inherited), its members won't go through
-          // `@dynamicMemberLookup` checking via `AttributeChecker`. We need to
-          // ensure that if the overridden decl was a valid dynamic member
-          // lookup subscript, this override remains valid.
-          if (outerTy->hasDynamicMemberLookupAttribute()) {
-            auto D = outerTy->getAnyNominal();
-            if (!D->getAttrs().hasAttribute<DynamicMemberLookupAttr>()) {
-              if (overriddenDecl->isValidDynamicMemberLookupSubscript(
-                      /*useDC=*/std::nullopt)) {
-                if (!SD->isValidDynamicMemberLookupSubscript(
-                        /*useDC=*/std::nullopt)) {
-                  SD->setInvalid();
-                }
-              }
-            }
-          }
         }
       }
     }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1317,16 +1317,14 @@ bool isValidDynamicCallableMethod(FuncDecl *decl,
 /// Returns true if the given subscript method is an valid implementation of
 /// the `subscript(dynamicMember:)` requirement for @dynamicMemberLookup.
 /// The method is given to be defined as `subscript(dynamicMember:)`.
-bool isValidDynamicMemberLookupSubscript(SubscriptDecl *decl,
-                                         bool ignoreLabel = false);
+bool isValidDynamicMemberLookupSubscript(SubscriptDecl *decl);
 
 /// Returns true if the given subscript method is an valid implementation of
 /// the `subscript(dynamicMember:)` requirement for @dynamicMemberLookup.
 /// The method is given to be defined as `subscript(dynamicMember:)` which
 /// takes a single non-variadic parameter that conforms to
 /// `ExpressibleByStringLiteral` protocol.
-bool isValidStringDynamicMemberLookup(SubscriptDecl *decl,
-                                      bool ignoreLabel = false);
+bool isValidStringDynamicMemberLookup(SubscriptDecl *decl);
 
 /// Returns the KeyPath parameter type for a valid implementation of
 /// the `subscript(dynamicMember: {Writable}KeyPath<...>)` requirement for
@@ -1337,8 +1335,7 @@ bool isValidStringDynamicMemberLookup(SubscriptDecl *decl,
 /// Returns null if the given subscript is not a valid dynamic member lookup
 /// implementation.
 BoundGenericType *
-getKeyPathTypeForDynamicMemberLookup(SubscriptDecl *decl,
-                                     bool ignoreLabel = false);
+getKeyPathTypeForDynamicMemberLookup(SubscriptDecl *decl);
 
 /// Compute the wrapped value type for the given property that has attached
 /// property wrappers, when the backing storage is known to have the given type.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1314,29 +1314,6 @@ diag::RequirementKind getProtocolRequirementKind(ValueDecl *Requirement);
 bool isValidDynamicCallableMethod(FuncDecl *decl,
                                   bool hasKeywordArguments);
 
-/// Returns true if the given subscript method is an valid implementation of
-/// the `subscript(dynamicMember:)` requirement for @dynamicMemberLookup.
-/// The method is given to be defined as `subscript(dynamicMember:)`.
-bool isValidDynamicMemberLookupSubscript(SubscriptDecl *decl);
-
-/// Returns true if the given subscript method is an valid implementation of
-/// the `subscript(dynamicMember:)` requirement for @dynamicMemberLookup.
-/// The method is given to be defined as `subscript(dynamicMember:)` which
-/// takes a single non-variadic parameter that conforms to
-/// `ExpressibleByStringLiteral` protocol.
-bool isValidStringDynamicMemberLookup(SubscriptDecl *decl);
-
-/// Returns the KeyPath parameter type for a valid implementation of
-/// the `subscript(dynamicMember: {Writable}KeyPath<...>)` requirement for
-/// @dynamicMemberLookup.
-/// The method is given to be defined as `subscript(dynamicMember:)` which
-/// takes a single non-variadic parameter of `{Writable}KeyPath<T, U>` type.
-///
-/// Returns null if the given subscript is not a valid dynamic member lookup
-/// implementation.
-BoundGenericType *
-getKeyPathTypeForDynamicMemberLookup(SubscriptDecl *decl);
-
 /// Compute the wrapped value type for the given property that has attached
 /// property wrappers, when the backing storage is known to have the given type.
 ///

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -2345,17 +2345,17 @@ void ConstraintSystem::bindOverloadType(const SelectedOverload &overload,
     }
   };
   auto addDynamicMemberSubscriptConstraints = [&](Type argTy, Type resultTy) {
-    // DynamicMemberLookup results are always a (dynamicMember: T1) -> T2
+    // DynamicMemberLookup results are always a `(dynamicMember: T1, ...) -> T2`
     // subscript.
     auto *fnTy = openedType->castTo<FunctionType>();
-    assert(fnTy->getParams().size() == 1 &&
-           "subscript always has one argument");
+    assert(fnTy->getParams().size() > 0 &&
+           "subscript always has at least one argument");
 
     auto *callLoc = getConstraintLocator(
         locator, LocatorPathElt::ImplicitDynamicMemberSubscript());
 
-    // Associate an argument list for the implicit x[dynamicMember:] subscript
-    // if we haven't already.
+    // Associate an argument list for the implicit `x[dynamicMember:...]`
+    // subscript if we haven't already.
     auto *argLoc = getArgumentInfoLocator(callLoc);
     if (ArgumentLists.find(argLoc) == ArgumentLists.end()) {
       auto *argList = ArgumentList::createImplicit(
@@ -2420,9 +2420,9 @@ void ConstraintSystem::bindOverloadType(const SelectedOverload &overload,
     if (!stringLiteral)
       return;
 
-    // Form constraints for a x[dynamicMember:] subscript with a string literal
-    // argument, where the overload type is bound to the result to model the
-    // fact that this a property access in the source.
+    // Form constraints for a `x[dynamicMember:...]` subscript with a string
+    // literal argument, where the overload type is bound to the result to model
+    // the fact that this a property access in the source.
     auto argTy = createTypeVariable(locator, /*options*/ 0);
     addConstraint(ConstraintKind::LiteralConformsTo, argTy,
                   stringLiteral->getDeclaredInterfaceType(), locator);
@@ -2431,8 +2431,8 @@ void ConstraintSystem::bindOverloadType(const SelectedOverload &overload,
   }
   case OverloadChoiceKind::KeyPathDynamicMemberLookup: {
     auto *fnType = openedType->castTo<FunctionType>();
-    assert(fnType->getParams().size() == 1 &&
-           "subscript always has one argument");
+    assert(fnType->getParams().size() > 0 &&
+           "subscript always has at least one argument");
     // Parameter type is KeyPath<T, U> where `T` is a root type
     // and U is a leaf type (aka member type).
     auto paramTy = fnType->getParams()[0].getPlainType();
@@ -2586,7 +2586,7 @@ void ConstraintSystem::bindOverloadType(const SelectedOverload &overload,
       // type into "leaf" directly.
       addConstraint(ConstraintKind::Equal, memberTy, leafTy, keyPathLoc);
 
-      // Form constraints for a x[dynamicMember:] subscript with a key path
+      // Form constraints for a `x[dynamicMember:...]` subscript with a key path
       // argument, where the overload type is bound to the result to model the
       // fact that this a property access in the source.
       addDynamicMemberSubscriptConstraints(/*argTy*/ paramTy, boundType);

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -136,6 +136,127 @@ func testIUOResult(x: IUOResult) {
 }
 
 //===----------------------------------------------------------------------===//
+// Taking multiple arguments
+//===----------------------------------------------------------------------===//
+
+// Parameters after the initial `dynamicMember:` are valid as long as they
+// have default arguments or are variadic. These can be concrete or generic.
+
+protocol MultiArgDefaultValue {
+  static var defaultValue: Self { get }
+}
+
+@dynamicMemberLookup
+struct ValidMultiArg1 {
+  subscript<T, U, V: MultiArgDefaultValue, each W>(
+    dynamicMember member: KeyPath<T, U>,
+    magic: StaticString = #function,
+    generic: V = .defaultValue,
+    variadic: KeyPath<V, V>...,
+    parameterPack pack: repeat each W
+  ) -> KeyPath<T, U> {
+    get { member }
+    set {}
+  }
+}
+
+@dynamicMemberLookup
+struct ValidMultiArg2 {
+  subscript<T, U, V: MultiArgDefaultValue, each W>(
+    dynamicMember member: WritableKeyPath<T, U>,
+    magic: StaticString = #function,
+    generic: V = .defaultValue,
+    variadic: KeyPath<V, V>...,
+    parameterPack pack: repeat each W
+  ) -> WritableKeyPath<T, U> {
+    get { member }
+    set {}
+  }
+}
+
+@dynamicMemberLookup
+struct ValidMultiArg3 {
+  subscript<T, U, V: MultiArgDefaultValue, each W>(
+    dynamicMember member: ReferenceWritableKeyPath<T, U>,
+    magic: StaticString = #function,
+    generic: V = .defaultValue,
+    variadic: KeyPath<V, V>...,
+    parameterPack pack: repeat each W
+  ) -> WritableKeyPath<T, U> {
+    get { member }
+    set {}
+  }
+}
+
+@dynamicMemberLookup
+struct ValidMultiArg4 {
+  subscript<V: MultiArgDefaultValue, each W>(
+    dynamicMember member: String,
+    magic: StaticString = #function,
+    generic: V = .defaultValue,
+    variadic: KeyPath<V, V>...,
+    parameterPack pack: repeat each W
+  ) -> String {
+    get { member }
+    set {}
+  }
+}
+
+// Simultaneous overloads don't introduce ambiguity
+
+@dynamicMemberLookup
+struct ValidMultiArg5 {
+  subscript(dynamicMember member: StaticString) -> Int {
+    get { return 42 }
+    set {}
+  }
+
+  subscript<T, U, V: MultiArgDefaultValue, each W>(
+    dynamicMember member: KeyPath<T, U>,
+    magic: StaticString = #function,
+    generic: V = .defaultValue,
+    variadic: KeyPath<V, V>...,
+    parameterPack pack: repeat each W
+  ) -> KeyPath<T, U> {
+    get { member }
+    set {}
+  }
+
+  subscript<T, U, V: MultiArgDefaultValue, each W>(
+    dynamicMember member: WritableKeyPath<T, U>,
+    magic: StaticString = #function,
+    generic: V = .defaultValue,
+    variadic: KeyPath<V, V>...,
+    parameterPack pack: repeat each W
+  ) -> WritableKeyPath<T, U> {
+    get { member }
+    set {}
+  }
+
+  subscript<T, U, V: MultiArgDefaultValue, each W>(
+    dynamicMember member: ReferenceWritableKeyPath<T, U>,
+    magic: StaticString = #function,
+    generic: V = .defaultValue,
+    variadic: KeyPath<V, V>...,
+    parameterPack pack: repeat each W
+  ) -> WritableKeyPath<T, U> {
+    get { member }
+    set {}
+  }
+
+  subscript<V: MultiArgDefaultValue, each W>(
+    dynamicMember member: String,
+    magic: StaticString = #function,
+    generic: V = .defaultValue,
+    variadic: KeyPath<V, V>...,
+    parameterPack pack: repeat each W
+  ) -> String {
+    get { member }
+    set {}
+  }
+}
+
+//===----------------------------------------------------------------------===//
 // Error cases
 //===----------------------------------------------------------------------===//
 
@@ -157,6 +278,25 @@ struct Invalid2 {
   }
 }
 
+// Given multiple arguments, all values after `dynamicMember:` must have a
+// default value.
+@dynamicMemberLookup
+struct InvalidMultiArg1 {
+  // expected-error@+1{{'@dynamicMemberLookup' requires 'InvalidMultiArg1' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
+  subscript(dynamicMember member: String, magic: StaticString) -> String { // expected-note{{add a default value to this argument to satisfy the '@dynamicMemberLookup' requirement}} {{62-62= = <#Default#>}}
+    member
+  }
+}
+
+// `dynamicMember:` must still be the first argument among multiple.
+@dynamicMemberLookup
+struct InvalidMultiArg2 {
+  // expected-error@+1{{'@dynamicMemberLookup' requires 'InvalidMultiArg2' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
+  subscript(magic: StaticString = #function, dynamicMember member: String) -> String { // expected-note{{'dynamicMember' argument must appear first in the argument list}}
+    member
+  }
+}
+
 // References to overloads are resolved just like normal subscript lookup:
 // they are either contextually disambiguated or are invalid.
 @dynamicMemberLookup
@@ -173,6 +313,81 @@ func testAmbiguity(a: Ambiguity) {
   let _: Int = a.flexibility
   let _: Float = a.dynamism
   _ = a.dynamism // expected-error {{ambiguous use of 'subscript(dynamicMember:)'}}
+}
+
+// References to overloads are also resolved just like normal subscript and
+// function lookup in the presence of overloads with default arguments: they are
+// either contextually disambiguated or are invalid, with a preference for
+// overloads with fewer arguments.
+@dynamicMemberLookup
+struct MultiArgAmbiguity {
+  subscript(dynamicMember member: String) -> String {
+    member
+  }
+
+  subscript(dynamicMember member: String, magic: StaticString = #function, variadic: Any...) -> Int {
+    42
+  }
+
+  subscript<V: MultiArgDefaultValue>(dynamicMember member: String, generic: V = .defaultValue, variadic: Any...) -> V {
+    generic
+  }
+
+  subscript(dynamicMember member: String, magic: StaticString = #function) -> Float {
+    42.0
+  }
+
+  subscript(dynamicMember member: String, magic: StaticString = #function) -> Double {
+    42.0
+  }
+
+  subscript<T, U>(dynamicMember member: KeyPath<T, U>, magic: StaticString = #function, variadic: Any...) -> KeyPath<T, U> {
+    member
+  }
+
+  subscript<T, U>(dynamicMember member: WritableKeyPath<T, U>, magic: StaticString = #function, variadic: Any...) -> WritableKeyPath<T, U> {
+    member
+  }
+
+  subscript<T, U>(dynamicMember member: ReferenceWritableKeyPath<T, U>, magic: StaticString = #function, variadic: Any...) -> ReferenceWritableKeyPath<T, U> {
+    member
+  }
+
+  subscript(dynamicMember member: String, magic: StaticString = #function, variadic: Any...) -> String {
+    member
+  }
+}
+
+extension Int: MultiArgDefaultValue {
+  static var defaultValue: Int { 0 }
+}
+
+func testMultiArgAmbiguity(a: MultiArgAmbiguity) {
+  // `subscript(dynamicMember: String) -> String` is preferred over other
+  // overloads as it has fewer parameters; even though the other subscripts can
+  // be ambiguous.
+  let _ = a.foo
+
+  // This is also true when selecting between specific overloads by return type:
+  // `subscript(dynamicMember:) -> String` is preferred over
+  // `subscript<V>(dynamicMember:magic:variadic:) -> String`.
+  let _: String = a.foo
+
+  // Normal disambiguation rules also apply to multi-arg subscripts:
+  // `subscript(dynamicMember:magic:variadic:) -> Int` is preferred over
+  // `subscript<V>(dynamicMember:generic:varadic:) -> V` because it's more
+  // specific.
+  let _: Int = a.foo
+
+  // Other normal ambiguity rules still apply too.
+  let _: Float = a.foo
+  let _: Double = a.foo
+  let _: any BinaryFloatingPoint = a.foo // expected-error{{ambiguous use of 'subscript(dynamicMember:_:)'}}
+
+  class Cls { var foo: Int = 42 }
+  let _: KeyPath<Cls, _> = a.foo
+  let _: WritableKeyPath<Cls, _> = a.foo
+  let _: ReferenceWritableKeyPath<Cls, _> = a.foo
 }
 
 // expected-error @+1 {{'@dynamicMemberLookup' attribute cannot be applied to this declaration}}
@@ -393,7 +608,22 @@ class BaseClass {
   subscript(dynamicMember member: String) -> Int {
     return 42
   }
+
+  subscript(dynamicMember member: String, magic: StaticString = #function) -> String {
+    return member
+  }
+
+  // These overloads are disfavored at callsites compared to the above and
+  // shouldn't introduce ambiguity.
+  subscript<each W>(dynamicMember member: String, magic: StaticString = #function, pack: repeat each W) -> Int {
+    return 42
+  }
+
+  subscript<each W>(dynamicMember member: String, magic: StaticString = #function, pack: repeat each W) -> String {
+    return member
+  }
 }
+
 class DerivedClass : BaseClass {}
 
 func testDerivedClass(x: BaseClass, y: DerivedClass) -> Int {
@@ -414,6 +644,31 @@ func testOverrideSubscript(a: BaseClass, b: DerivedClassWithSetter) {
   a.balboza = 12 // expected-error {{cannot assign through dynamic lookup property: 'a' is a 'let' constant}}
 }
 
+// Overriding with a different default value is valid.
+class DerivedClassWithOverriddenDefault : BaseClass {
+  override subscript(dynamicMember member: String, magic: StaticString = #fileID) -> String {
+    return member
+  }
+}
+
+func testOverrideSubscript(a: BaseClass, b: DerivedClassWithOverriddenDefault) {
+  let _: String = a.magic
+  let _: String = b.magic
+}
+
+// Overriding with a different default value is valid.
+class DerivedClassWithMissingDefault : BaseClass {
+  // expected-error@+1{{'@dynamicMemberLookup' requires 'DerivedClassWithMissingDefault' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
+  override subscript(dynamicMember member: String, magic: StaticString) -> String { // expected-note{{add a default value to this argument to satisfy the '@dynamicMemberLookup' requirement}} {{71-71= = <#Default#>}}
+    return member
+  }
+}
+
+func testOverrideSubscript(a: BaseClass, b: DerivedClassWithMissingDefault) {
+  let _: String = a.magic
+  let _: String = b.magic
+}
+
 //===----------------------------------------------------------------------===//
 // Generics
 //===----------------------------------------------------------------------===//
@@ -421,6 +676,13 @@ func testOverrideSubscript(a: BaseClass, b: DerivedClassWithSetter) {
 @dynamicMemberLookup
 struct SettableGeneric1<T> {
   subscript(dynamicMember member: StaticString) -> T? {
+    get {}
+    nonmutating set {}
+  }
+
+  // This overload is disfavored at callsites compared to the above and
+  // shouldn't introduce ambiguity.
+  subscript<each W>(dynamicMember member: StaticString, variadic: T..., parameterPack pack: repeat each W) -> T? {
     get {}
     nonmutating set {}
   }
@@ -439,6 +701,13 @@ func testConcreteGenericType(a: SettableGeneric1<Int>) -> Int? {
 @dynamicMemberLookup
 struct SettableGeneric2<T> {
   subscript<U: ExpressibleByStringLiteral>(dynamicMember member: U) -> T {
+    get {}
+    nonmutating set {}
+  }
+
+  // This overload is disfavored at callsites compared to the above and
+  // shouldn't introduce ambiguity.
+  subscript<U: ExpressibleByStringLiteral, each W>(dynamicMember member: U, variadic: U..., parameterPack pack: repeat each W) -> T {
     get {}
     nonmutating set {}
   }
@@ -488,8 +757,17 @@ func testGenerics<S, T, P: GenericProtocol>(
 @dynamicMemberLookup
 class KP {
   subscript(dynamicMember member: String) -> Int { return 7 }
+
+  // This overload is disfavored at callsites compared to the above and
+  // shouldn't introduce ambiguity.
+  //
+  // We're using `String` here instead of `StaticString` since a `KeyPath`
+  // reference below requires arguments to be `Hashable` and `StaticString`
+  // isn't.
+  subscript(dynamicMember member: String, magic: String = #function) -> Int { return 42 }
 }
 _ = \KP.[dynamicMember: "hi"]
+_ = \KP.[dynamicMember: "hi", #fileID]
 _ = \KP.testLookup
 
 /* KeyPath based dynamic lookup */
@@ -518,6 +796,17 @@ struct Lens<T> {
   }
 
   subscript<U>(dynamicMember member: WritableKeyPath<T, U>) -> Lens<U> {
+    get { return Lens<U>(obj[keyPath: member]) }
+    set { obj[keyPath: member] = newValue.obj }
+  }
+
+  // These overloads are disfavored at callsites compared to the above and
+  // shouldn't introduce ambiguity.
+  subscript<U, each W>(dynamicMember member: KeyPath<T, U>, magic: StaticString = #function, pack: repeat each W) -> Lens<U> {
+    get { return Lens<U>(obj[keyPath: member]) }
+  }
+
+  subscript<U>(dynamicMember member: WritableKeyPath<T, U>, magic: StaticString = #function) -> Lens<U> {
     get { return Lens<U>(obj[keyPath: member]) }
     set { obj[keyPath: member] = newValue.obj }
   }
@@ -630,6 +919,12 @@ class AMetatype<T> {
   subscript<U>(dynamicMember member: KeyPath<T.Type, U>) -> U {
     get { return value[keyPath: member] }
   }
+
+  // This overload is disfavored at callsites compared to the above and
+  // shouldn't introduce ambiguity.
+  subscript<U, each W>(dynamicMember member: KeyPath<T.Type, U>, magic: StaticString = #function, pack: repeat each W) -> U {
+    get { return value[keyPath: member] }
+  }
 }
 
 // Let's make sure that keypath dynamic member lookup
@@ -659,6 +954,12 @@ extension KeyPathLookup {
   subscript(dynamicMember member: KeyPath<T, Int>) -> Int! {
     get { return value[keyPath: member] }
   }
+
+  // This overload is disfavored at callsites compared to the above and
+  // shouldn't introduce ambiguity.
+  subscript<each W>(dynamicMember member: KeyPath<T, Int>, magic: StaticString = #function, pack: repeat each W) -> Int! {
+    get { return value[keyPath: member] }
+  }
 }
 
 class C<T> : KeyPathLookup {
@@ -684,6 +985,12 @@ class D<T> {
   }
 
   subscript<U: Numeric>(dynamicMember member: KeyPath<T, U>) -> (U) -> U {
+    get { return { offset in self.value[keyPath: member] + offset } }
+  }
+
+  // This overload is disfavored at callsites compared to the above and
+  // shouldn't introduce ambiguity.
+  subscript<U: Numeric, each W>(dynamicMember member: KeyPath<T, U>, magic: StaticString = #function, pack: repeat each W) -> (U) -> U {
     get { return { offset in self.value[keyPath: member] + offset } }
   }
 }
@@ -715,6 +1022,26 @@ struct SubscriptLens<T> {
   }
 
   subscript<U>(dynamicMember member: WritableKeyPath<T, U>) -> U {
+    get { return value[keyPath: member] }
+    set { value[keyPath: member] = newValue }
+  }
+
+  // These overloads are disfavored at callsites compared to the above and
+  // shouldn't introduce ambiguity.
+  subscript<each W>(foo: String, magic: StaticString = #function, pack: repeat each W) -> Int {
+    get { return 42 }
+  }
+
+  subscript(offset: Int, magic: StaticString = #function) -> Int {
+    get { return counter }
+    set { counter = counter + newValue }
+  }
+
+  subscript<U>(dynamicMember member: KeyPath<T, U>, magic: StaticString = #function) -> U! {
+    get { return value[keyPath: member] }
+  }
+
+  subscript<U>(dynamicMember member: WritableKeyPath<T, U>, magic: StaticString = #function) -> U {
     get { return value[keyPath: member] }
     set { value[keyPath: member] = newValue }
   }
@@ -789,6 +1116,13 @@ struct SingleChoiceLens<T> {
     get { return obj[keyPath: member] }
     set { obj[keyPath: member] = newValue }
   }
+
+  // This overload is disfavored at callsites compared to the above and
+  // shouldn't introduce ambiguity.
+  subscript<U, each W>(dynamicMember member: WritableKeyPath<T, U>, magic: StaticString = #function, pack: repeat each W) -> U {
+    get { return obj[keyPath: member] }
+    set { obj[keyPath: member] = newValue }
+  }
 }
 
 // Make sure that disjunction filtering optimization doesn't
@@ -837,6 +1171,10 @@ func invalid_refs_through_dynamic_lookup() {
     _ = lens.baz("hello")
   }
 }
+
+//===----------------------------------------------------------------------===//
+// Specific Issues
+//===----------------------------------------------------------------------===//
 
 // https://github.com/apple/swift/issues/52997
 

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -457,6 +457,7 @@ public struct Accessible5 {
   }
 }
 
+// expected-non-resilient-error @+1 {{'@dynamicMemberLookup' requires 'Inaccessible1' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
 @dynamicMemberLookup
 public struct Inaccessible1 {
   // expected-non-resilient-warning @+2 {{'@dynamicMemberLookup' requires 'subscript(dynamicMember:)' to be as accessible as its enclosing type; this will be an error in a future Swift language mode}}{{3-3=public }}
@@ -466,6 +467,7 @@ public struct Inaccessible1 {
   }
 }
 
+// expected-non-resilient-error @+1 {{'@dynamicMemberLookup' requires 'Inaccessible2' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
 @dynamicMemberLookup
 public struct Inaccessible2 {
   // expected-non-resilient-warning @+2 {{'@dynamicMemberLookup' requires 'subscript(dynamicMember:)' to be as accessible as its enclosing type; this will be an error in a future Swift language mode}}{{21-29=public}}
@@ -475,6 +477,7 @@ public struct Inaccessible2 {
   }
 }
 
+// expected-non-resilient-error @+1 {{'@dynamicMemberLookup' requires 'Inaccessible3' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
 @dynamicMemberLookup
 internal struct Inaccessible3 {
   // expected-non-resilient-warning @+2 {{'@dynamicMemberLookup' requires 'subscript(dynamicMember:)' to be as accessible as its enclosing type; this will be an error in a future Swift language mode}}{{3-10=internal}}
@@ -484,6 +487,7 @@ internal struct Inaccessible3 {
   }
 }
 
+// expected-non-resilient-error @+1 {{'@dynamicMemberLookup' requires 'Inaccessible4' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
 @dynamicMemberLookup
 private struct Inaccessible4 {
   // expected-non-resilient-warning @+2 {{'@dynamicMemberLookup' requires 'subscript(dynamicMember:)' to be as accessible as its enclosing type; this will be an error in a future Swift language mode}}{{3-10=fileprivate}}
@@ -493,6 +497,7 @@ private struct Inaccessible4 {
   }
 }
 
+// expected-non-resilient-error @+1 {{'@dynamicMemberLookup' requires 'Inaccessible5' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
 @dynamicMemberLookup
 public struct Inaccessible5 {
   internal struct Nested { }

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -4,6 +4,12 @@
 
 var global = 42
 
+// expected-error@+1 {{'@dynamicMemberLookup' requires 'S' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
+@dynamicMemberLookup
+struct S {
+  subscript(bogus: Int) -> Void { () }
+}
+
 @dynamicMemberLookup
 struct Gettable {
   subscript(dynamicMember member: StaticString) -> Int {
@@ -457,7 +463,6 @@ public struct Accessible5 {
   }
 }
 
-// expected-non-resilient-error @+1 {{'@dynamicMemberLookup' requires 'Inaccessible1' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
 @dynamicMemberLookup
 public struct Inaccessible1 {
   // expected-non-resilient-warning @+2 {{'@dynamicMemberLookup' requires 'subscript(dynamicMember:)' to be as accessible as its enclosing type; this will be an error in a future Swift language mode}}{{3-3=public }}
@@ -467,7 +472,6 @@ public struct Inaccessible1 {
   }
 }
 
-// expected-non-resilient-error @+1 {{'@dynamicMemberLookup' requires 'Inaccessible2' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
 @dynamicMemberLookup
 public struct Inaccessible2 {
   // expected-non-resilient-warning @+2 {{'@dynamicMemberLookup' requires 'subscript(dynamicMember:)' to be as accessible as its enclosing type; this will be an error in a future Swift language mode}}{{21-29=public}}
@@ -477,7 +481,6 @@ public struct Inaccessible2 {
   }
 }
 
-// expected-non-resilient-error @+1 {{'@dynamicMemberLookup' requires 'Inaccessible3' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
 @dynamicMemberLookup
 internal struct Inaccessible3 {
   // expected-non-resilient-warning @+2 {{'@dynamicMemberLookup' requires 'subscript(dynamicMember:)' to be as accessible as its enclosing type; this will be an error in a future Swift language mode}}{{3-10=internal}}
@@ -487,7 +490,6 @@ internal struct Inaccessible3 {
   }
 }
 
-// expected-non-resilient-error @+1 {{'@dynamicMemberLookup' requires 'Inaccessible4' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
 @dynamicMemberLookup
 private struct Inaccessible4 {
   // expected-non-resilient-warning @+2 {{'@dynamicMemberLookup' requires 'subscript(dynamicMember:)' to be as accessible as its enclosing type; this will be an error in a future Swift language mode}}{{3-10=fileprivate}}
@@ -497,7 +499,6 @@ private struct Inaccessible4 {
   }
 }
 
-// expected-non-resilient-error @+1 {{'@dynamicMemberLookup' requires 'Inaccessible5' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
 @dynamicMemberLookup
 public struct Inaccessible5 {
   internal struct Nested { }
@@ -1363,3 +1364,12 @@ let selfRecurse6 = SelfRecursiveLookup { selfRecurse6[terminator: 0] }
 
 let selfRecurse7 = SelfRecursiveLookup { \.terminator }
 let selfRecurse8 = SelfRecursiveLookup { \.[terminator: 0] }
+
+// Make sure we only warn in this case.
+@dynamicMemberLookup
+struct InaccessibleAndInvalidCandidate {
+  private subscript(dynamicMember x: String) -> Void { () }
+  // expected-non-resilient-warning@-1 {{'@dynamicMemberLookup' requires 'subscript(dynamicMember:)' to be as accessible as its enclosing type; this will be an error in a future Swift language mode}}
+  // expected-resilient-error@-2 {{'@dynamicMemberLookup' requires 'subscript(dynamicMember:)' to be as accessible as its enclosing type}}
+  subscript(dynamicMember x: Int) -> Void { () }
+}

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -263,7 +263,7 @@ struct ValidMultiArg5 {
 // Subscript index must be ExpressibleByStringLiteral.
 @dynamicMemberLookup
 struct Invalid1 {
-  // expected-error @+1 {{'@dynamicMemberLookup' requires 'Invalid1' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
+  // expected-error @+1 {{'@dynamicMemberLookup' requires 'member' to be either 'ExpressibleByStringLiteral' or a key path}}
   subscript(dynamicMember member: Int) -> Int {
     return 42
   }
@@ -272,7 +272,7 @@ struct Invalid1 {
 // Subscript may not be variadic.
 @dynamicMemberLookup
 struct Invalid2 {
-  // expected-error @+1 {{'@dynamicMemberLookup' requires 'Invalid2' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
+  // expected-error @+1 {{'@dynamicMemberLookup' requires 'member' to be either 'ExpressibleByStringLiteral' or a key path}}
   subscript(dynamicMember member: String...) -> Int {
     return 42
   }
@@ -282,8 +282,8 @@ struct Invalid2 {
 // default value.
 @dynamicMemberLookup
 struct InvalidMultiArg1 {
-  // expected-error@+1{{'@dynamicMemberLookup' requires 'InvalidMultiArg1' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
-  subscript(dynamicMember member: String, magic: StaticString) -> String { // expected-note{{add a default value to this argument to satisfy the '@dynamicMemberLookup' requirement}} {{62-62= = <#Default#>}}
+  // expected-error @+1 {{'@dynamicMemberLookup' requires 'magic' to have a default value}} {{62-62= = <#Default#>}}
+  subscript(dynamicMember member: String, magic: StaticString) -> String {
     member
   }
 }
@@ -291,8 +291,8 @@ struct InvalidMultiArg1 {
 // `dynamicMember:` must still be the first argument among multiple.
 @dynamicMemberLookup
 struct InvalidMultiArg2 {
-  // expected-error@+1{{'@dynamicMemberLookup' requires 'InvalidMultiArg2' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
-  subscript(magic: StaticString = #function, dynamicMember member: String) -> String { // expected-note{{'dynamicMember' argument must appear first in the argument list}}
+  // expected-error @+1 {{'@dynamicMemberLookup' requires 'member' to appear first in the parameter list}}
+  subscript(magic: StaticString = #function, dynamicMember member: String) -> String {
     member
   }
 }
@@ -661,10 +661,10 @@ func testOverrideSubscript(a: BaseClass, b: DerivedClassWithOverriddenDefault) {
   let _: String = b.magic
 }
 
-// Overriding with a different default value is valid.
+// Overriding without a default value is invalid.
 class DerivedClassWithMissingDefault : BaseClass {
-  // expected-error@+1{{'@dynamicMemberLookup' requires 'DerivedClassWithMissingDefault' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
-  override subscript(dynamicMember member: String, magic: StaticString) -> String { // expected-note{{add a default value to this argument to satisfy the '@dynamicMemberLookup' requirement}} {{71-71= = <#Default#>}}
+  // expected-error @+1 {{'@dynamicMemberLookup' requires 'magic' to have a default value}} {{71-71= = <#Default#>}}
+  override subscript(dynamicMember member: String, magic: StaticString) -> String {
     return member
   }
 }
@@ -1224,20 +1224,21 @@ do {
 
 @dynamicMemberLookup
 struct S1_52957 {
-  subscript(dynamicMember: String) -> String { // expected-error {{'@dynamicMemberLookup' requires 'S1_52957' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
-  // expected-note@-1 {{add an explicit argument label to this subscript to satisfy the '@dynamicMemberLookup' requirement}}{{13-13=dynamicMember }}
+  // expected-error @+1 {{'@dynamicMemberLookup' requires 'dynamicMember' to have an explicit parameter label}}{{26-26= <#label#>}}
+  subscript(dynamicMember: String) -> String {
     fatalError()
   }
 }
 
 @dynamicMemberLookup
 struct S2_52957 {
-  subscript(foo bar: String) -> String { // expected-error {{'@dynamicMemberLookup' requires 'S2_52957' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
+  // expected-error @+1 {{'@dynamicMemberLookup' requires 'bar' to have an explicit 'dynamicMember' argument label}}
+  subscript(foo bar: String) -> String {
     fatalError()
   }
 
-  subscript(foo: String) -> String { // expected-error {{'@dynamicMemberLookup' requires 'S2_52957' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
-  // expected-note@-1 {{add an explicit argument label to this subscript to satisfy the '@dynamicMemberLookup' requirement}} {{13-13=dynamicMember }}
+  // expected-error @+1 {{'@dynamicMemberLookup' requires 'foo' to have an explicit 'dynamicMember' argument label}} {{13-13=dynamicMember }}
+  subscript(foo: String) -> String {
     fatalError()
   }
 }

--- a/test/attr/attr_dynamic_member_lookup_default_args.swift
+++ b/test/attr/attr_dynamic_member_lookup_default_args.swift
@@ -14,6 +14,7 @@ struct Magic: Hashable {
   let line: Int
   let column: Int
   let dsohandle: UnsafeRawPointer
+  let extra: Int
 
   init(
     fileID: String = #fileID,
@@ -22,7 +23,8 @@ struct Magic: Hashable {
     function: String = #function,
     line: Int = #line,
     column: Int = #column,
-    dsohandle: UnsafeRawPointer = #dsohandle
+    dsohandle: UnsafeRawPointer = #dsohandle,
+    extra: Int = 42
   ) {
     self.fileID = fileID
     self.file = file
@@ -31,6 +33,7 @@ struct Magic: Hashable {
     self.line = line
     self.column = column
     self.dsohandle = dsohandle
+    self.extra = extra
   }
 
   subscript(
@@ -41,7 +44,8 @@ struct Magic: Hashable {
     function: String = #function,
     line: Int = #line,
     column: Int = #column,
-    dsohandle: UnsafeRawPointer = #dsohandle
+    dsohandle: UnsafeRawPointer = #dsohandle,
+    extra: Int = 42
   ) -> Magic {
     return Magic(
       fileID: fileID,
@@ -50,7 +54,8 @@ struct Magic: Hashable {
       function: function,
       line: line,
       column: column,
-      dsohandle: dsohandle
+      dsohandle: dsohandle,
+      extra: extra
     )
   }
 
@@ -62,23 +67,24 @@ struct Magic: Hashable {
       function: function,
       line: line + lineOffset,
       column: column + columnOffset,
-      dsohandle: dsohandle
+      dsohandle: dsohandle,
+      extra: extra
     )
   }
 }
 
 /* ! ENSURE FORMATTERS ARE DISABLED TO PRESERVE WHITESPACE ! */
-let m1 = Magic() // 71:15
-let m2 = m1.member // 72:13
+let m1 = Magic() // 77:15
+let m2 = m1.member // 78:13
 assert(m1.offset(lineBy: +1, columnBy: -2) == m2)
 
 let m3 = m1
-  .member // 76:4
+  .member // 82:4
 assert(m1.offset(lineBy: +5, columnBy: -11) == m3)
 
 let m4 = m1
   .
-  member // 81:3
+  member // 87:3
 assert(m1.offset(lineBy: +10, columnBy: -12) == m4)
 
 //===----------------------------------------------------------------------===//

--- a/test/attr/attr_dynamic_member_lookup_default_args.swift
+++ b/test/attr/attr_dynamic_member_lookup_default_args.swift
@@ -1,0 +1,157 @@
+// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking)
+// REQUIRES: executable_test
+
+//===----------------------------------------------------------------------===//
+// Magic Literals
+//===----------------------------------------------------------------------===//
+
+@dynamicMemberLookup
+struct Magic: Hashable {
+  let fileID: String
+  let file: String
+  let filePath: String
+  let function: String
+  let line: Int
+  let column: Int
+  let dsohandle: UnsafeRawPointer
+
+  init(
+    fileID: String = #fileID,
+    file: String = #file,
+    filePath: String = #filePath,
+    function: String = #function,
+    line: Int = #line,
+    column: Int = #column,
+    dsohandle: UnsafeRawPointer = #dsohandle
+  ) {
+    self.fileID = fileID
+    self.file = file
+    self.filePath = filePath
+    self.function = function
+    self.line = line
+    self.column = column
+    self.dsohandle = dsohandle
+  }
+
+  subscript(
+    dynamicMember member: String,
+    fileID: String = #fileID,
+    file: String = #file,
+    filePath: String = #filePath,
+    function: String = #function,
+    line: Int = #line,
+    column: Int = #column,
+    dsohandle: UnsafeRawPointer = #dsohandle
+  ) -> Magic {
+    return Magic(
+      fileID: fileID,
+      file: file,
+      filePath: filePath,
+      function: function,
+      line: line,
+      column: column,
+      dsohandle: dsohandle
+    )
+  }
+
+  func offset(lineBy lineOffset: Int, columnBy columnOffset: Int) -> Magic {
+    Magic(
+      fileID: fileID,
+      file: file,
+      filePath: filePath,
+      function: function,
+      line: line + lineOffset,
+      column: column + columnOffset,
+      dsohandle: dsohandle
+    )
+  }
+}
+
+/* ! ENSURE FORMATTERS ARE DISABLED TO PRESERVE WHITESPACE ! */
+let m1 = Magic() // 71:15
+let m2 = m1.member // 72:13
+assert(m1.offset(lineBy: +1, columnBy: -2) == m2)
+
+let m3 = m1
+  .member // 76:4
+assert(m1.offset(lineBy: +5, columnBy: -11) == m3)
+
+let m4 = m1
+  .
+  member // 81:3
+assert(m1.offset(lineBy: +10, columnBy: -12) == m4)
+
+//===----------------------------------------------------------------------===//
+// Inheritance
+//===----------------------------------------------------------------------===//
+
+@dynamicMemberLookup
+class Parent {
+  subscript(
+    dynamicMember member: String,
+    kept: String = #fileID,
+    overridden: String = #fileID
+  ) -> String {
+    [member, kept, overridden].joined(separator: ":")
+  }
+}
+
+@dynamicMemberLookup
+class Child: Parent {
+  override subscript(
+    dynamicMember member: String,
+    kept: String = #fileID,
+    overridden: String = #filePath
+  ) -> String {
+    [member, kept, overridden].joined(separator: ":")
+  }
+}
+
+assert(Parent().member == ["member", #fileID, #fileID].joined(separator: ":"))
+assert(Child().member == ["member", #fileID, #filePath].joined(separator: ":"))
+
+//===----------------------------------------------------------------------===//
+// Parameter Packs
+//===----------------------------------------------------------------------===//
+
+@dynamicMemberLookup
+struct Pack {
+  subscript<each T>(dynamicMember member: String, pack: repeat each T) -> (repeat each T) {
+    (repeat each pack)
+  }
+
+  subscript<each T, each U>(
+    dynamicMember member: String, pack1 pack1: repeat each T, pack2 pack2: repeat each U
+  ) -> Int {
+    var count = 0
+    for _ in repeat each pack1 {
+      count += 1
+    }
+
+    for _ in repeat each pack2 {
+      count += 1
+    }
+
+    return count
+  }
+}
+
+let p = Pack()
+assert(p.member == ())
+assert(p.member == 0)
+
+//===----------------------------------------------------------------------===//
+// Isolation
+//===----------------------------------------------------------------------===//
+
+@dynamicMemberLookup
+struct Isolated {
+  subscript(dynamicMember member: String, isolation: isolated (any Actor)? = #isolation) -> (any Actor)? {
+    isolation
+  }
+}
+
+Task<Void, Never>.immediate { @MainActor in
+  let `actor` = await Isolated().actor
+  assert(`actor` === MainActor.shared)
+}

--- a/test/attr/attr_dynamic_member_lookup_default_args.swift
+++ b/test/attr/attr_dynamic_member_lookup_default_args.swift
@@ -146,6 +146,15 @@ let p = Pack()
 assert(p.member == ())
 assert(p.member == 0)
 
+@dynamicMemberLookup
+struct Pack2 {
+  subscript<each T>(dynamicMember str: String, xs: repeat each T, k k: Int = 123) -> Int {
+    return k
+  }
+}
+
+assert(Pack2().foo == 123)
+
 //===----------------------------------------------------------------------===//
 // Isolation
 //===----------------------------------------------------------------------===//
@@ -161,3 +170,16 @@ Task<Void, Never>.immediate { @MainActor in
   let `actor` = await Isolated().actor
   assert(`actor` === MainActor.shared)
 }
+
+//===----------------------------------------------------------------------===//
+// Classic varargs
+//===----------------------------------------------------------------------===//
+
+@dynamicMemberLookup
+struct Vararg {
+  subscript(dynamicMember str: String, xs: Int...) -> Int {
+    return xs.count
+  }
+}
+
+assert(Vararg().foo == 0)

--- a/test/attr/attr_dynamic_member_lookup_module.swift
+++ b/test/attr/attr_dynamic_member_lookup_module.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -emit-module %t/attr_dynamic_member_lookup_other.swift -emit-module-path %t/attr_dynamic_member_lookup_other.swiftmodule
+// RUN: %target-swift-frontend -typecheck %t/client.swift -I %t
+
+//--- client.swift
+
+import attr_dynamic_member_lookup_other
+
+func f(m: MySubscript) -> Int {
+  return m.x
+}
+
+//--- attr_dynamic_member_lookup_other.swift
+
+public struct S {
+  public var x: Int
+}
+
+@dynamicMemberLookup
+public struct MySubscript {
+  public subscript(dynamicMember keyPath: KeyPath<S, Int>) -> Int {
+     return 0
+  }
+}

--- a/test/attr/attr_dynamic_member_lookup_swift7.swift
+++ b/test/attr/attr_dynamic_member_lookup_swift7.swift
@@ -71,3 +71,10 @@ private struct Inaccessible4 {
     return 42
   }
 }
+
+@dynamicMemberLookup
+struct InaccessibleAndInvalidCandidate {
+  private subscript(dynamicMember x: String) -> Void { () }
+  // expected-error@-1 {{'@dynamicMemberLookup' requires 'subscript(dynamicMember:)' to be as accessible as its enclosing type}}
+  subscript(dynamicMember x: Int) -> Void { () }
+}

--- a/validation-test/compiler_crashers_fixed/ArgumentList-getSourceRange-9ae72b.swift
+++ b/validation-test/compiler_crashers_fixed/ArgumentList-getSourceRange-9ae72b.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"307d2ff3","signature":"swift::ArgumentList::getSourceRange() const","signatureNext":"diagnoseArgumentLabelError"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 @dynamicMemberLookup protocol a {
   subscript(dynamicMember b: String)  Self
   struct c: a {


### PR DESCRIPTION
I'm finishing up https://github.com/swiftlang/swift/pull/81148.

From Itai's original PR description:

Adds support for satisfying `@dynamicMemberLookup` requirements using subscripts which have arguments following `dynamicMember:` so long as they are either variadic or have default arguments. This allows transforming member references into `x[dynamicMember:...]` calls which can pass in arguments such as `#function`, `#fileID`, `#line`, etc.

* Pitch: https://forums.swift.org/t/dynamicmemberlookup-subscript-with-additional-defaulted-arguments/78471
* Proposal: https://github.com/swiftlang/swift-evolution/pull/2814

Main changes:

1. Allows `SubscriptDecl`s to satisfy `@dynamicMemberLookup` requirements as long as `dynamicMember:` remains the first explicitly-labeled argument, and all following arguments are either `isDefaultArgument()` or `isVariadic()`
2. Caches the result of checking for eligibility in `SubscriptDecl.Bits`; this was being checked multiple times per decl and it seems prudent to just store the info since we have the bits
3. Updates `ExprRewriter` to produce `ArgumentList`s for these subscripts by filling in `DefaultArgumentExpr`s as needed
4. Adds unit tests

The PR has been split into individual commits for (ideally) ease of review.