### PR TITLE
[Windows] [ARM64] Fix cross compiled arm64 package

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2436,7 +2436,7 @@ function Patch-mimalloc() {
     [hashtable]$Platform
   )
 
-  $BuildSuffix = if ($BuildPlatform -eq $KnownPlatforms["WindowsX64"]) { "" } else { "-arm64" }
+  $BuildSuffix = if ($Platform -eq $KnownPlatforms["WindowsX64"]) { "" } else { "-arm64" }
 
   $Tools = @(
     "swift.exe",


### PR DESCRIPTION
- **Explanation**:
The NoAsserts toolchains are not working for installer packages created on the CI. Our best guess is the platform is incorrectly being taken from the machine the build is running on, instead of the intended target of the toolchain.

This causes the wrong version of minject to be run, which injects the wrong redirect stub for the platform when cross compiling to arm64 tools, built on an Intel machine.

- **Scope**:
This changes how the minject patch function works to try and match the toolchain being built rather than the machine the build is being run on. As such it does have a risk of breaking the Windows build.

- **Issues**:
rdar://173864813

- **Original PRs**:
n/a

- **Risk**:
This risks breaking the Windows packaging build. It should not affect Darwin or Linux builds in any way as those use different scripts.

- **Testing**:
Built locally on a Parallels VM.

- **Reviewers**:
@compnerd @charles-zablit
