### PR TITLE
Sema: Allow default implementations of conformance requirements regardless of visibility

### DIFF
--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -1019,10 +1019,8 @@ diagnoseAndFixMissingImportForMember(const ValueDecl *decl, SourceFile *sf,
   }
 }
 
-bool swift::maybeDiagnoseMissingImportForMember(const ValueDecl *decl,
-                                                const DeclContext *dc,
-                                                SourceLoc loc,
-                                                DiagnosticBehavior limit) {
+bool swift::shouldDiagnoseMissingImportForMember(const ValueDecl *decl,
+                                                 const DeclContext *dc) {
   // Only diagnose references in source files.
   auto sf = dc->getParentSourceFile();
   if (!sf)
@@ -1030,7 +1028,7 @@ bool swift::maybeDiagnoseMissingImportForMember(const ValueDecl *decl,
 
   auto &ctx = dc->getASTContext();
   if (!ctx.LangOpts.hasFeature(Feature::MemberImportVisibility,
-                          /*allowMigration=*/true))
+                               /*allowMigration=*/true))
     return false;
 
   // Only diagnose members.
@@ -1051,13 +1049,30 @@ bool swift::maybeDiagnoseMissingImportForMember(const ValueDecl *decl,
       return false;
   }
 
-  // In lazy typechecking mode just emit the diagnostic immediately without a
-  // fix-it since there won't be an opportunity to emit delayed diagnostics.
   if (ctx.TypeCheckerOpts.EnableLazyTypecheck) {
     // Lazy type-checking and migration for MemberImportVisibility are
     // completely incompatible, so just skip the diagnostic entirely.
     if (ctx.LangOpts.isMigratingToFeature(Feature::MemberImportVisibility))
       return false;
+  }
+
+  return true;
+}
+
+bool swift::maybeDiagnoseMissingImportForMember(const ValueDecl *decl,
+                                                const DeclContext *dc,
+                                                SourceLoc loc,
+                                                DiagnosticBehavior limit) {
+  if (!shouldDiagnoseMissingImportForMember(decl, dc))
+    return false;
+
+  auto &ctx = dc->getASTContext();
+  auto sf = dc->getParentSourceFile();
+
+  // In lazy typechecking mode just emit the diagnostic immediately without a
+  // fix-it since there won't be an opportunity to emit delayed diagnostics.
+  if (ctx.TypeCheckerOpts.EnableLazyTypecheck) {
+    auto definingModule = decl->getModuleContextForNameLookup();
 
     auto modulesToImport = missingImportsForDefiningModule(definingModule, *sf);
     if (modulesToImport.empty())

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1560,6 +1560,65 @@ static bool contextMayExpandOperator(
   return potentialExpansions.shouldExpandForName(operatorName);
 }
 
+enum class DefaultImplementationKind {
+  /// The witness is not a member of a protocol extension.
+  None,
+  /// The witness is a member of an unconstrained extension on the protocol that
+  /// defined the requirement and is located in the same module as that
+  /// protocol.
+  Inherited,
+  /// The witness is a member of a protocol extension located in a different
+  /// module than the protocol.
+  Retroactive,
+  /// The exact witness is not identified at compile time but is assumed to
+  /// exist at runtime. This kind of witness may be used for conformances in
+  /// .swiftinterface files under the assumption that a concrete witness was
+  /// known when building the module from source but cannot be found when
+  /// building the module from its interface. Supporting this case is necessary
+  /// because there are conformance checking holes that allow witnesses to
+  /// satisfy requirements even though the witness will not be visible to
+  /// clients of the .swiftinterface.
+  Opaque,
+};
+
+/// Returns the kind of default implementation that \p witness is for \p
+/// requirement. A witness is a "default implementation" when it is defined in a
+/// protocol extension, as opposed to being explicitly defined in the conforming
+/// type. Default implementations can come from protocol extensions in any
+/// module, not necessarily the module that defines the protocol or the
+/// conformance.
+static DefaultImplementationKind
+getDefaultImplementationKind(ValueDecl *witness, ValueDecl *requirement) {
+  // Check whether the requirement is self-witnessing and therefore "opaque".
+  if (witness == requirement)
+    return DefaultImplementationKind::Opaque;
+
+  // Check if the witness is a member of a protocol extension. If it isn't, then
+  // it's not a default implementation.
+  auto *extension = dyn_cast_or_null<ExtensionDecl>(witness->getDeclContext());
+  if (!extension)
+    return DefaultImplementationKind::None;
+
+  auto *witnessProto =
+      dyn_cast_or_null<ProtocolDecl>(extension->getSelfNominalTypeDecl());
+  if (!witnessProto)
+    return DefaultImplementationKind::None;
+
+  if (extension->isConstrainedExtension())
+    return DefaultImplementationKind::Retroactive;
+
+  // The witness is a default implementation. Check whether it is inherited.
+  auto *requirementProto = cast<ProtocolDecl>(requirement->getDeclContext());
+  if (witnessProto == requirementProto) {
+    auto witnessModule = witness->getModuleContextForNameLookup();
+    if (witnessModule->isSameModuleLookingThroughOverlays(
+            requirementProto->getModuleContextForNameLookup()))
+      return DefaultImplementationKind::Inherited;
+  }
+
+  return DefaultImplementationKind::Retroactive;
+}
+
 SmallVector<ValueDecl *, 4>
 swift::lookupValueWitnesses(DeclContext *DC, ValueDecl *req, bool *ignoringNames) {
   assert(!isa<AssociatedTypeDecl>(req) && "Not for lookup for type witnesses*");
@@ -1606,29 +1665,51 @@ swift::lookupValueWitnesses(DeclContext *DC, ValueDecl *req, bool *ignoringNames
     // to restate them in the resulting list, or else an otherwise valid
     // conformance will become ambiguous.
     const NLOptions options =
-        doUnqualifiedLookup ? NLOptions(0) : NL_ProtocolMembers;
+        (doUnqualifiedLookup ? NLOptions(0) : NL_ProtocolMembers) |
+        NL_IgnoreMissingImports;
+
+    auto getWitness = [req, DC](ValueDecl *witness) -> ValueDecl * {
+      // Protocol members can't be witnesses.
+      if (isa<ProtocolDecl>(witness->getDeclContext()))
+        return nullptr;
+
+      // Filter out results that would require an import to be visible.
+      if (shouldDiagnoseMissingImportForMember(witness, DC)) {
+        auto defaultImplKind = getDefaultImplementationKind(witness, req);
+        switch (defaultImplKind) {
+        case DefaultImplementationKind::None:
+        case DefaultImplementationKind::Retroactive:
+          return nullptr;
+        case DefaultImplementationKind::Opaque:
+        case DefaultImplementationKind::Inherited:
+          // Default implementations that are inherited don't have to be
+          // imported in order to witness a requirement.
+          break;
+        }
+      }
+
+      // Distributed thunk requirements are witnessed by distributed thunks.
+      auto func = dyn_cast<AbstractFunctionDecl>(req);
+      if (func && func->isDistributedThunk()) {
+        if (auto candidate = dyn_cast<AbstractFunctionDecl>(witness)) {
+          if (auto thunk = candidate->getDistributedThunk())
+            return thunk;
+        }
+      }
+
+      return witness;
+    };
 
     SmallVector<ValueDecl *, 4> lookupResults;
     bool addedAny = false;
     DC->lookupQualified(nominal, reqName, nominal->getLoc(),
                         options, lookupResults);
     for (auto *decl : lookupResults) {
-      // a distributed thunk is the witness
-      if (!isa<ProtocolDecl>(decl->getDeclContext())) {
-        auto func = dyn_cast<AbstractFunctionDecl>(req);
-        if (func && func->isDistributedThunk()) {
-          if (auto candidate = dyn_cast<AbstractFunctionDecl>(decl)) {
-            if (auto thunk = candidate->getDistributedThunk()) {
-              witnesses.push_back(thunk);
-              addedAny = true;
-            }
-          }
-        } else {
-          witnesses.push_back(decl);
-          addedAny = true;
-        }
+      if (auto witness = getWitness(decl)) {
+        witnesses.push_back(witness);
+        addedAny = true;
       }
-    };
+    }
 
     // If we didn't find anything with the appropriate name, look
     // again using only the base name.
@@ -1637,9 +1718,8 @@ swift::lookupValueWitnesses(DeclContext *DC, ValueDecl *req, bool *ignoringNames
       DC->lookupQualified(nominal, reqBaseName, nominal->getLoc(),
                           options, lookupResults);
       for (auto *decl : lookupResults) {
-        if (!isa<ProtocolDecl>(decl->getDeclContext())) {
-          witnesses.push_back(decl);
-        }
+        if (auto witness = getWitness(decl))
+          witnesses.push_back(witness);
       }
 
       *ignoringNames = true;
@@ -2018,11 +2098,10 @@ RequirementCheck WitnessChecker::checkWitness(ValueDecl *requirement,
 
   // Warn about deprecated default implementations if the requirement is
   // not deprecated, and the conformance is not deprecated.
-  bool isDefaultWitness = false;
-  if (auto *nominal = match.Witness->getDeclContext()->getSelfNominalTypeDecl())
-    isDefaultWitness = isa<ProtocolDecl>(nominal);
-  if (isDefaultWitness && match.Witness->isDeprecated() &&
-      !requirement->isDeprecated()) {
+  auto defaultImplKind =
+      getDefaultImplementationKind(match.Witness, requirement);
+  if (defaultImplKind != DefaultImplementationKind::None &&
+      match.Witness->isDeprecated() && !requirement->isDeprecated()) {
     auto conformanceContext = AvailabilityContext::forDeclSignature(DC->getInnermostDeclarationDeclContext());
     if (!conformanceContext.isDeprecated()) {
       return RequirementCheck(CheckKind::DefaultWitnessDeprecated);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1518,6 +1518,11 @@ void recordRequiredImportAccessLevelForDecl(const ValueDecl *decl,
 /// Report imports that are marked public but are not used in API.
 void diagnoseUnnecessaryPublicImports(SourceFile &SF);
 
+/// Returns true if a diagnostic ought to be emitted for any explicit reference
+/// to decl made from within the given DeclContext.
+bool shouldDiagnoseMissingImportForMember(const ValueDecl *decl,
+                                          const DeclContext *dc);
+
 /// Emit or delay a diagnostic that suggests adding a missing import that is
 /// necessary to bring \p decl into scope in the containing source file. If
 /// delayed, the diagnostic will instead be emitted after type checking the

--- a/test/NameLookup/Inputs/MemberImportVisibility/members_A.swift
+++ b/test/NameLookup/Inputs/MemberImportVisibility/members_A.swift
@@ -71,8 +71,10 @@ open class BaseClassInA {
   open func overriddenInBMethod() {}
 }
 
+public protocol EmptyProtocolInA { }
+
 public protocol ProtocolInA1 {
-  func defaultedRequirementInA()
+  func defaultedRequirementInA() // has an inherited default
 }
 
 extension ProtocolInA1 {
@@ -80,9 +82,9 @@ extension ProtocolInA1 {
 }
 
 public protocol ProtocolInA2 {
-  func defaultedRequirementInA()
-  func defaultedRequirementInB()
-  func defaultedRequirementInC()
+  func defaultedRequirementInA() // has an inherited default
+  func defaultedRequirementInB() // has a retroactive default (in B)
+  func defaultedRequirementInC() // has a retroactive default (in C)
 }
 
 extension ProtocolInA2 {
@@ -90,7 +92,17 @@ extension ProtocolInA2 {
 }
 
 public protocol ProtocolInA3 {
-  func defaultedRequirementInBAndC()
+  func defaultedRequirementInBAndC() // has retroactive defaults (in both B and C)
+}
+
+public protocol BaseProtocolInA4 {
+  func defaultedRequirementInRefinementInA() // has a retroactive default (in an extension on a refined protocol)
+}
+
+public protocol ProtocolInA4: BaseProtocolInA4 { }
+
+extension ProtocolInA4 {
+  public func defaultedRequirementInRefinementInA() { }
 }
 
 public protocol ProtocolWithAssociatedTypesInA {

--- a/test/NameLookup/Inputs/MemberImportVisibility/members_B.swift
+++ b/test/NameLookup/Inputs/MemberImportVisibility/members_B.swift
@@ -74,7 +74,7 @@ extension StructInA2 {
 }
 
 public protocol ProtocolInB1 {
-  func defaultedRequirementInB()
+  func defaultedRequirementInB() // has an inherited default
 }
 
 extension ProtocolInB1 {
@@ -82,8 +82,17 @@ extension ProtocolInB1 {
 }
 
 public protocol ProtocolInB2 {
-  func defaultedRequirementInC()
+  func defaultedRequirementInC() // has a retroactive default (in C)
 }
+
+public protocol ProtocolInB3 {
+  func defaultedRequirementInB() // has a retroactive default (in a constrained extension)
+}
+
+extension ProtocolInB3 where Self: EmptyProtocolInA {
+  public func defaultedRequirementInB() { }
+}
+
 
 public struct EquatableInB: Equatable {
   public static func ==(_: EquatableInB, _: EquatableInB) -> Bool {

--- a/test/NameLookup/Inputs/MemberImportVisibility/members_C.swift
+++ b/test/NameLookup/Inputs/MemberImportVisibility/members_C.swift
@@ -69,6 +69,8 @@ extension ProtocolInC2 {
   public func defaultedRequirementInC() { }
 }
 
+public protocol ProtocolInC3: ProtocolInB3 { }
+
 public struct EquatableInC: Equatable {
   public static func ==(_: EquatableInC, _: EquatableInC) -> Bool {
     false

--- a/test/NameLookup/member_import_visibility.swift
+++ b/test/NameLookup/member_import_visibility.swift
@@ -145,13 +145,13 @@ struct ConformsToProtocolInA2: ProtocolInA2 {}
 // expected-member-visibility-note@-2{{add stubs for conformance}}
 
 struct ConformsToProtocolInA3: ProtocolInA3 {}
-
-// FIXME: Should diagnose import needed for defaultedRequirementInB().
+struct ConformsToProtocolInA4: ProtocolInA4 {}
 struct ConformsToProtocolInC1: ProtocolInC1 {}
-// expected-member-visibility-error@-1{{type 'ConformsToProtocolInC1' does not conform to protocol 'ProtocolInB1'}}
-// expected-member-visibility-note@-2{{add stubs for conformance}}
-
 struct ConformsToProtocolInC2: ProtocolInC2 {}
+
+struct ConformsToProtocolInC3: ProtocolInC3, EmptyProtocolInA {}
+// expected-member-visibility-error@-1{{type 'ConformsToProtocolInC3' does not conform to protocol 'ProtocolInB3'}}
+// expected-member-visibility-note@-2{{add stubs for conformance}}
 
 // FIXME: The missing import for WitnessedInB should be diagnosed (rdar://154237873)
 extension StructInA1: ProtocolWithAssociatedTypesInA {}

--- a/test/NameLookup/member_import_visibility_multifile.swift
+++ b/test/NameLookup/member_import_visibility_multifile.swift
@@ -25,10 +25,7 @@ func testQualifiedMembers() {
   takesEnumInC(EnumInC.caseInC) // expected-error{{cannot find 'EnumInC' in scope; did you mean 'EnumInB'?}}
 }
 
-// FIXME: Should diagnose import needed for defaultedRequirementInC().
 struct ConformsToRefinesProtocolInA1: RefinesProtocolInA1 {}
-// expected-member-visibility-error@-1 {{type 'ConformsToRefinesProtocolInA1' does not conform to protocol 'ProtocolInA1'}}
-// expected-member-visibility-note@-2 {{add stubs for conformance}}
 
 // FIXME: Should diagnose import needed for defaultedRequirementInA()/defaultedRequirementInC().
 struct ConformsToRefinesProtocolInA2: RefinesProtocolInA2 {}
@@ -36,6 +33,11 @@ struct ConformsToRefinesProtocolInA2: RefinesProtocolInA2 {}
 // expected-member-visibility-note@-2 {{add stubs for conformance}}
 
 struct ConformsToRefinesProtocolInA3: RefinesProtocolInA3 {}
+
+struct ConformsToRefinesProtocolInA4: RefinesProtocolInA4 {}
+// expected-member-visibility-error@-1 {{type 'ConformsToRefinesProtocolInA4' does not conform to protocol 'BaseProtocolInA4'}}
+// expected-member-visibility-note@-2 {{add stubs for conformance}}
+
 struct ConformsToRefinesProtocolInC1: RefinesProtocolInC1 {}
 
 // FIXME: Should diagnose import needed for defaultedRequirementInC().
@@ -43,15 +45,20 @@ struct ConformsToRefinesProtocolInC2: RefinesProtocolInC2 {}
 // expected-member-visibility-error@-1 {{type 'ConformsToRefinesProtocolInC2' does not conform to protocol 'ProtocolInB2'}}
 // expected-member-visibility-note@-2 {{add stubs for conformance}}
 
+struct ConformsToRefinesProtocolInC3: RefinesProtocolInC3, RefinesEmptyProtocolInA {}
+
 //--- A.swift
 
 @_implementationOnly import members_A
 
 func takesEnumInA(_ e: EnumInA) {}
 
+protocol RefinesEmptyProtocolInA: EmptyProtocolInA {}
+
 protocol RefinesProtocolInA1: ProtocolInA1 {}
 protocol RefinesProtocolInA2: ProtocolInA2 {}
 protocol RefinesProtocolInA3: ProtocolInA3 {}
+protocol RefinesProtocolInA4: ProtocolInA4 {}
 
 //--- B.swift
 
@@ -67,3 +74,4 @@ func takesEnumInC(_ e: EnumInC) {}
 
 protocol RefinesProtocolInC1: ProtocolInC1 {}
 protocol RefinesProtocolInC2: ProtocolInC2 {}
+protocol RefinesProtocolInC3: ProtocolInC3 {}


### PR DESCRIPTION
Implements the amendment to SE-0444 reviewed in https://forums.swift.org/t/se-0444-amendment-exempt-default-implementations-of-protocol-requirements-from-member-import-visibility-rules/86683/.

When checking conformances, if the witness to a protocol requirement is the default witness for that requirement, ignore `MemberImportVisibility` restrictions. A default witness is the witness that will be used at runtime for a conformance to a resilient protocol when the conformance does not provide its own witness. Default witnesses must belong to an unconstrained extension of the protocol and be declared in the same module as that protocol. This exception is necessary because otherwise evolving a protocol by adding a new requirement with a default witness is potentially source breaking, even though it would not be ABI breaking.

Resolves https://github.com/swiftlang/swift/issues/87227 and rdar://170348842.