### PR TITLE
[Sema] Check references for application of functions stored in vars

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4564,13 +4564,17 @@ namespace {
       checkIsolatedConformancesInContext(declRef, loc, getDeclContext(),
                                          RefineConformances{*this});
 
-      // If this declaration is a callee from the enclosing application,
-      // it's already been checked via the call.
+      // If this declaration is a callee from the enclosing application and not
+      // a global VarDecl, it's already been checked via the call. VarDecls may
+      // be isolated and store a function type with erased isolation, so the
+      // reference must still be checked in addition to the call.
       if (auto *apply = getImmediateApply()) {
         auto immediateCallee =
             apply->getCalledValue(/*skipFunctionConversions=*/true);
-        if (decl == immediateCallee)
-          return false;
+        if (decl == immediateCallee) {
+          if (!(isa<VarDecl>(decl) && cast<VarDecl>(decl)->isGlobalStorage()))
+            return false;
+        }
       }
 
       std::optional<ReferencedActor> isolatedActor;

--- a/test/Concurrency/global_actor_function_variable_isolation.swift
+++ b/test/Concurrency/global_actor_function_variable_isolation.swift
@@ -1,0 +1,170 @@
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple -verify-additional-prefix minimal-targeted-
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple -strict-concurrency=targeted -verify-additional-prefix minimal-targeted-
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple -strict-concurrency=complete -verify-additional-prefix complete-
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple -swift-version 6 -verify-additional-prefix swift6-
+
+// REQUIRES: concurrency
+
+// https://github.com/swiftlang/swift/issues/81599
+// Top-level variables are main-actor-isolated, but their function type's isolation can be erased.
+// The reference isolation needs to be checked for applications of VarDecls.
+
+// Call this to test that the functions stored in top level variables actually have MainActor inferred.
+// MainActor isn't inferred for minimal or targeted however, so we'll need to verify that its not allowed to be called in those cases.
+@MainActor func mainActorOnly() -> Int { 0 } // expected-minimal-targeted-note 3 {{calls to global function 'mainActorOnly()' from outside of its actor context are implicitly asynchronous}}
+
+// expected-complete-note@+2 2 {{let declared here}}
+// expected-swift6-note@+1 2 {{let declared here}}
+let topLevelImplicitMainActorFnLet: () -> Void = {
+  _ = mainActorOnly() // expected-minimal-targeted-error {{call to main actor-isolated global function 'mainActorOnly()' in a synchronous nonisolated context}}
+}
+
+let sendableCaller: @Sendable () -> Void = {
+  topLevelImplicitMainActorFnLet() // expected-complete-warning {{main actor-isolated let 'topLevelImplicitMainActorFnLet' can not be referenced from a nonisolated context}}
+  // expected-swift6-error@-1 {{main actor-isolated let 'topLevelImplicitMainActorFnLet' can not be referenced from a nonisolated context}}
+
+  // Refs that weren't part of application were already being checked.
+  let _ = topLevelImplicitMainActorFnLet // expected-complete-warning {{main actor-isolated let 'topLevelImplicitMainActorFnLet' can not be referenced from a nonisolated context}}
+  // expected-swift6-error@-1 {{main actor-isolated let 'topLevelImplicitMainActorFnLet' can not be referenced from a nonisolated context}}
+}
+
+let sendableAsyncCaller: @Sendable () async -> Void = {
+  await topLevelImplicitMainActorFnLet() // expected-minimal-targeted-warning {{no 'async' operations occur within 'await' expression}}
+  // expected-complete-warning@-1 {{non-Sendable type '() -> Void' of let 'topLevelImplicitMainActorFnLet' cannot exit main actor-isolated context}}
+  // expected-complete-note@-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+  // expected-swift6-error@-3 {{non-Sendable type '() -> Void' of let 'topLevelImplicitMainActorFnLet' cannot exit main actor-isolated context}}
+  // expected-swift6-note@-4 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+}
+
+// expected-complete-note@+2 2 {{var declared here}}
+// expected-swift6-note@+1 2 {{var declared here}}
+var topLevelImplicitMainActorFnVar: () -> Void = {
+  _ = mainActorOnly() // expected-minimal-targeted-error {{call to main actor-isolated global function 'mainActorOnly()' in a synchronous nonisolated context}}
+}
+
+let sendableCallerForVar: @Sendable () -> Void = {
+  topLevelImplicitMainActorFnVar() // expected-complete-warning {{main actor-isolated var 'topLevelImplicitMainActorFnVar' can not be referenced from a nonisolated context}}
+  // expected-swift6-error@-1 {{main actor-isolated var 'topLevelImplicitMainActorFnVar' can not be referenced from a nonisolated context}}
+
+  let _ = topLevelImplicitMainActorFnVar // expected-complete-warning {{main actor-isolated var 'topLevelImplicitMainActorFnVar' can not be referenced from a nonisolated context}}
+  // expected-swift6-error@-1 {{main actor-isolated var 'topLevelImplicitMainActorFnVar' can not be referenced from a nonisolated context}}
+}
+
+@MainActor func testFromMainActor() {
+  topLevelImplicitMainActorFnLet()
+  topLevelImplicitMainActorFnVar()
+}
+
+// expected-complete-note@+2 2 {{var declared here}}
+// expected-swift6-note@+1 2 {{var declared here}}
+var topLevelImplicitMainActorOptionalFn: (() -> Void)? = {
+  _ = mainActorOnly() // expected-minimal-targeted-error {{call to main actor-isolated global function 'mainActorOnly()' in a synchronous nonisolated context}}
+}
+
+let sendableCallerForOptional: @Sendable () -> Void = {
+  topLevelImplicitMainActorOptionalFn?() // expected-complete-warning {{main actor-isolated var 'topLevelImplicitMainActorOptionalFn' can not be referenced from a nonisolated context}}
+  // expected-swift6-error@-1 {{main actor-isolated var 'topLevelImplicitMainActorOptionalFn' can not be referenced from a nonisolated context}}
+
+  let _ = topLevelImplicitMainActorOptionalFn // expected-complete-warning {{main actor-isolated var 'topLevelImplicitMainActorOptionalFn' can not be referenced from a nonisolated context}}
+  // expected-swift6-error@-1 {{main actor-isolated var 'topLevelImplicitMainActorOptionalFn' can not be referenced from a nonisolated context}}
+}
+
+struct IsolatedFnLet {
+  @MainActor static let explicitMainActorLet: () -> Void = {} // expected-minimal-targeted-note 2 {{static property declared here}}
+  // expected-complete-note@-1 2 {{static property declared here}}
+  // expected-swift6-note@-2 2 {{static property declared here}}
+}
+
+// expected-minimal-targeted-note@+3 {{add '@MainActor' to make global function 'testStaticFromNonisolated()' part of global actor 'MainActor'}} {{1-1=@MainActor }}
+// expected-complete-note@+2 {{add '@MainActor' to make global function 'testStaticFromNonisolated()' part of global actor 'MainActor'}} {{1-1=@MainActor }}
+// expected-swift6-note@+1 {{add '@MainActor' to make global function 'testStaticFromNonisolated()' part of global actor 'MainActor'}} {{1-1=@MainActor }}
+func testStaticFromNonisolated() {
+  IsolatedFnLet.explicitMainActorLet() // expected-minimal-targeted-warning {{main actor-isolated static property 'explicitMainActorLet' can not be referenced from a nonisolated context}}
+  // expected-complete-warning@-1 {{main actor-isolated static property 'explicitMainActorLet' can not be referenced from a nonisolated context}}
+  // expected-swift6-error@-2 {{main actor-isolated static property 'explicitMainActorLet' can not be referenced from a nonisolated context}}
+}
+
+@MainActor func testStaticSameActor() {
+  IsolatedFnLet.explicitMainActorLet()
+}
+
+// Exercise differing variable and function type isolation.
+
+@globalActor actor OtherGlobalActor {
+  static let shared = OtherGlobalActor()
+}
+
+struct CrossIsolatedFnLets {
+  @OtherGlobalActor static let otherActorHoldingMainActorFn: @MainActor () -> Void = {} // expected-minimal-targeted-note {{static property declared here}}
+  // expected-complete-note@-1 {{static property declared here}}
+  // expected-swift6-note@-2 {{static property declared here}}
+  @MainActor static let mainActorHoldingOtherActorFn: @OtherGlobalActor () -> Void = {} // expected-minimal-targeted-note {{static property declared here}}
+  // expected-complete-note@-1 {{static property declared here}}
+  // expected-swift6-note@-2 {{static property declared here}}
+}
+
+// From the storage's actor: storage access is fine, but the call crosses isolation.
+@OtherGlobalActor func testOtherHoldingMainSync() {
+  CrossIsolatedFnLets.otherActorHoldingMainActorFn() // expected-error {{call to main actor-isolated function in a synchronous global actor 'OtherGlobalActor'-isolated context}}
+}
+
+@MainActor func testMainHoldingOtherSync() {
+  CrossIsolatedFnLets.mainActorHoldingOtherActorFn() // expected-error {{call to global actor 'OtherGlobalActor'-isolated function in a synchronous main actor-isolated context}}
+}
+
+// From the function type's actor: call is fine, but storage access crosses isolation.
+@MainActor func testMainCallingOtherHeldSync() {
+  CrossIsolatedFnLets.otherActorHoldingMainActorFn() // expected-minimal-targeted-warning {{global actor 'OtherGlobalActor'-isolated static property 'otherActorHoldingMainActorFn' can not be referenced from the main actor}}
+  // expected-complete-warning@-1 {{global actor 'OtherGlobalActor'-isolated static property 'otherActorHoldingMainActorFn' can not be referenced from the main actor}}
+  // expected-swift6-error@-2 {{global actor 'OtherGlobalActor'-isolated static property 'otherActorHoldingMainActorFn' can not be referenced from the main actor}}
+}
+
+@OtherGlobalActor func testOtherCallingMainHeldSync() {
+  CrossIsolatedFnLets.mainActorHoldingOtherActorFn() // expected-minimal-targeted-warning {{main actor-isolated static property 'mainActorHoldingOtherActorFn' can not be referenced from global actor 'OtherGlobalActor'}}
+  // expected-complete-warning@-1 {{main actor-isolated static property 'mainActorHoldingOtherActorFn' can not be referenced from global actor 'OtherGlobalActor'}}
+  // expected-swift6-error@-2 {{main actor-isolated static property 'mainActorHoldingOtherActorFn' can not be referenced from global actor 'OtherGlobalActor'}}
+}
+
+// Async from the storage's actor: await hops to the function type's actor.
+@OtherGlobalActor func testOtherHoldingMainAsync() async {
+  await CrossIsolatedFnLets.otherActorHoldingMainActorFn()
+}
+
+@MainActor func testMainHoldingOtherAsync() async {
+  await CrossIsolatedFnLets.mainActorHoldingOtherActorFn()
+}
+
+// expected-minimal-targeted-note@+3 {{add '@MainActor' to make global function 'testReferenceWithoutCall()' part of global actor 'MainActor'}} {{1-1=@MainActor }}
+// expected-complete-note@+2 {{add '@MainActor' to make global function 'testReferenceWithoutCall()' part of global actor 'MainActor'}} {{1-1=@MainActor }}
+// expected-swift6-note@+1 {{add '@MainActor' to make global function 'testReferenceWithoutCall()' part of global actor 'MainActor'}} {{1-1=@MainActor }}
+func testReferenceWithoutCall() {
+  let _ = IsolatedFnLet.explicitMainActorLet // expected-minimal-targeted-warning {{main actor-isolated static property 'explicitMainActorLet' can not be referenced from a nonisolated context}}
+  // expected-complete-warning@-1 {{main actor-isolated static property 'explicitMainActorLet' can not be referenced from a nonisolated context}}
+  // expected-swift6-error@-2 {{main actor-isolated static property 'explicitMainActorLet' can not be referenced from a nonisolated context}}
+}
+
+func testFromNonisolatedAsync() async {
+  await topLevelImplicitMainActorFnLet() // expected-minimal-targeted-warning {{no 'async' operations occur within 'await' expression}}
+  // expected-complete-warning@-1 {{non-Sendable type '() -> Void' of let 'topLevelImplicitMainActorFnLet' cannot exit main actor-isolated context}}
+  // expected-complete-note@-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+  // expected-swift6-error@-3 {{non-Sendable type '() -> Void' of let 'topLevelImplicitMainActorFnLet' cannot exit main actor-isolated context}}
+  // expected-swift6-note@-4 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+}
+
+struct MutableFnVar {
+  @MainActor static var explicitMainActorVar: () -> Void = {} // expected-note {{static property declared here}}
+}
+
+// expected-note@+1 {{add '@MainActor' to make global function 'testMutableVar()' part of global actor 'MainActor'}} {{1-1=@MainActor }}
+func testMutableVar() {
+  MutableFnVar.explicitMainActorVar() // expected-error {{main actor-isolated static property 'explicitMainActorVar' can not be referenced from a nonisolated context}}
+}
+
+struct OptionalFnVars {
+  @MainActor static var optionalFn: (() -> Void)? = {} // expected-note {{static property declared here}}
+}
+
+// expected-note@+1 {{add '@MainActor' to make global function 'testOptionalChaining()' part of global actor 'MainActor'}} {{1-1=@MainActor }}
+func testOptionalChaining() {
+  OptionalFnVars.optionalFn?() // expected-error {{main actor-isolated static property 'optionalFn' can not be referenced from a nonisolated context}}
+}


### PR DESCRIPTION
Don't suppress reference checking due to apply when the ref is a global VarDecl. Adds a bunch of cases that I don't believe had coverage, although only a couple are affected by this change. Accepting this code was a miscompile.

It seems like this wasn't an issue in Swift 5 since we don't infer `@MainActor` for global variables in that case, so there was no mismatch.

We can now reject this code, which was a race safety hole:
```swift
// https://github.com/swiftlang/swift/issues/81599
// swiftc -language-mode 6 -sanitize=address dual_iso.swift -o dual_iso_asan && ./dual_iso_asan

import Foundation

final class Box: @unchecked Sendable {
    @MainActor static let shared = Box()
    @MainActor var items: [String] = []
}

let append: () -> Void = { // append has inferred @MainActor as a global variable, but isolation is erased from the function type
    for i in 0..<10_000 {
        Box.shared.items.append("item-\(i)")
    }
}

// and references were not being checked as part of function application (normally the ref and fn iso are the same...)
let execute: @Sendable (Int) -> Void = { _ in
    append()
}

// allowing concurrent execution of "MainActor" code, leading to a use after free
DispatchQueue.concurrentPerform(iterations: 4, execute: execute)

print("Expected: 40000, Got: \(Box.shared.items.count)")
```

```
swiftc -language-mode 6 -sanitize=address dual_iso.swift -o dual_iso_asan && ./dual_iso_asan
SUMMARY: AddressSanitizer: heap-use-after-free (libswiftSwiftOnoneSupport.dylib:arm64+0x140f8) in specialized _ArrayBuffer._consumeAndCreateNew(bufferIsUnique:minimumCapacity:growForAppend:)+0x84
fish: Job 1, './dual_iso_asan' terminated by signal SIGABRT (Abort)
```

With this change:

```
xcrun -sdk macosx build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swiftc debug-files/dual_iso.swift -o debug-files/dual_iso.swift.bin -language-mode 6
debug-files/dual_iso.swift:19:5: error: main actor-isolated let 'append' can not be referenced from a nonisolated context
 9 | }
10 |
11 | let append: () -> Void = { // append has inferred @MainActor, but isolation is erased from the function type
   |     `- note: let declared here
12 |     for i in 0..<10_000 {
13 |         Box.shared.items.append("item-\(i)")
   :
17 | // and references were not being checked as part of function application (normally the ref and fn iso are the same...)
18 | let execute: @Sendable (Int) -> Void = { _ in
19 |     append()
   |     `- error: main actor-isolated let 'append' can not be referenced from a nonisolated context
20 | }
21 |
```

<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!-- Please fill out the following form: --> 
- **Explanation**:
Fixes a miscompile which allowed an isolated function to be called concurrently. Avoid suppressing reference checking for a `DeclRef` when it is a reference to a global `VarDecl`, since variables are able to have different isolation from the function they store. Adds tests for other similar cases, which seem to already be covered.
- **Scope**:
Code that was being accepted and miscompiled in Swift 6 will now be rejected, which could "break" existing code, especially if it wasn't actually calling the main actor code concurrently / concurrently enough, so the unsafe behavior was never noticed. This should be pretty limited, since the only case I am aware of that was hitting this required script mode. Additionally, a top level global variable storing a function should be fairly rare?
- **Issues**:
rdar://151586158, #81599
- **Risk**:
Rejecting existing code with a race safety issue / miscompile. Potentially rejecting safe code somehow, although there shouldn't exist a case where a global variable is isolated to a different domain, but it's still safe to call a function stored in it.
- **Testing**:
Wrote test cases, tried example from reported issue, as well as various reproductions, like the included use after free above.


Resolves rdar://151586158, resolves #81599