### PR TITLE
[Incremental build check] Disable timestamp check for Embedded Swift wasm

### DIFF
--- a/utils/check-incremental
+++ b/utils/check-incremental
@@ -73,6 +73,8 @@ def main():
     next_arg_is_output = False
     compare_time = True
     output_file = None
+    embedded = False
+    wasm = False
 
     for arg in sys.argv:
         if next_arg_is_output:
@@ -84,8 +86,15 @@ def main():
             compare_time = False
         elif arg == '-emit-empty-object-file':
             compare_time = False
+        elif arg == 'Embedded':
+            embedded = True
+        elif arg.startswith('wasm'):
+            wasm = True
         elif arg == '-o':
             next_arg_is_output = True
+
+    if embedded and wasm:
+        compare_time = False
 
     new_args = sys.argv[1:]
 


### PR DESCRIPTION
- **Explanation**: The combination of Embedded Swift and WebAssembly is preventing the object file write from being suppressed despite the module hash matching. Don't check the timestamp for this combination so we can keep finding other (later) issues while we figure out what's going on.
- **Scope**: Disables a timestamp check on a consistency-checking script. No other changes.
- **Issues**: rdar://174062039
- **Risk**: Practically zero. It's a checking script.
- **Testing**: Checked that this does disable the check for Embedded Swift on wasm.
