### PR TITLE
[CSSimplify] Handle situations when generic argument mismatch happens…

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6880,7 +6880,13 @@ bool ConstraintSystem::repairFailures(
           auto *overloadTy =
               simplifyType(overload->boundType)->castTo<FunctionType>();
           auto *argList = getArgumentList(argLoc);
-          ASSERT(argList);
+          // If the argument was synthesized by the solver, let's fail. This can
+          // happen when a parameter type is optional and (currently) inference
+          // would try both optional and non-optional bindings for the new
+          // argument which cases a mismatch in one of the conversion cases.
+          if (!argList || argList->size() <= argIdx)
+            return false;
+
           conversionsOrFixes.push_back(AllowArgumentMismatch::create(
               *this, getType(argList->getExpr(argIdx)),
               overloadTy->getParams()[paramIdx].getPlainType(), argLoc));

--- a/validation-test/IDE/crashers_fixed/TypeDecl-getName-e52359.swift
+++ b/validation-test/IDE/crashers_fixed/TypeDecl-getName-e52359.swift
@@ -1,5 +1,5 @@
 // {"kind":"complete","original":"108dc1e5","signature":"swift::TypeDecl::getName() const","signatureAssert":"Assertion failed: (Index < Length && \"Invalid index!\"), function operator[]"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
 extension {
 a {
   typealias b = ()?

--- a/validation-test/compiler_crashers_fixed/ConstraintSystem-repairFailures-df69d2.swift
+++ b/validation-test/compiler_crashers_fixed/ConstraintSystem-repairFailures-df69d2.swift
@@ -1,3 +1,3 @@
 // {"kind":"typecheck","signature":"swift::constraints::ConstraintSystem::repairFailures(swift::Type, swift::Type, swift::constraints::ConstraintKind, swift::optionset::OptionSet<swift::constraints::ConstraintSystem::TypeMatchFlags, unsigned int>, llvm::SmallVectorImpl<swift::constraints::RestrictionOrFix>&, swift::constraints::ConstraintLocatorBuilder)","signatureAssert":"Assertion failed: (Index < Length && \"Invalid index!\"), function operator[]","signatureNext":"ConstraintSystem::matchTypes"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 func a< b , c : Sequence, d >( b, c) where b== c.Element a( ( 0 , [ (0 0), (


### PR DESCRIPTION
… in a synthesized argument

<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!-- Please fill out the following form: --> 
- **Explanation**:
  
   If the argument was synthesized by the solver, let's fail. This can happen when a parameter type is optional and (currently) inference would try both optional and non-optional bindings for the new argument which cases a mismatch in one of the conversion cases.

- **Scope**:

   Invalid calls where some of the arguments are missing and parameters are generic in some way that would make solver attempt multiple different bindings i.e. optional type.  

- **Issues**:
  
  Resolves: https://github.com/swiftlang/swift/issues/88456
  Resolves: rdar://174723056

- **Risk**:

   Very low. Replaces an assertion with a  graceful failure. 

- **Testing**:
 
  Resolved a few existing crashers and added a new test-case into the validation suite.

- **Reviewers**:
  
  @hamishknight 

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
