### PR TITLE
[rbi] Emit a specific error on the capture when emitting a use-after-send that involves capturing into a closure literal.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -1104,6 +1104,18 @@ NOTE(regionbasedisolation_typed_tns_passed_to_sending_closure_helper_have_value_
 NOTE(regionbasedisolation_typed_tns_passed_to_sending_closure_helper_have_boxed_value_task_isolated, none,
      "closure captures reference to mutable %kind0 which remains modifiable by code in the current task",
      (const ValueDecl *))
+GROUPED_ERROR(regionbasedisolation_sent_closure_captures_mutable_var, SendingRisksDataRace, none,
+     "closure passed as an argument to a 'sending' parameter captures reference to mutable %kind0 which is accessed later by code in the current task",
+     (const ValueDecl *))
+GROUPED_ERROR(regionbasedisolation_sent_closure_captures_value, SendingRisksDataRace, none,
+     "closure passed as an argument to a 'sending' parameter captures %0 which is accessed later by code in the current task",
+     (DeclName))
+GROUPED_ERROR(regionbasedisolation_sent_autoclosure_captures_mutable_var, SendingRisksDataRace, none,
+     "mutable %kind0 cannot be captured by 'sending' @autoclosure parameter because %0 is accessed later in the current task",
+     (const ValueDecl *))
+GROUPED_ERROR(regionbasedisolation_sent_autoclosure_captures_value, SendingRisksDataRace, none,
+     "%0 cannot be captured by 'sending' @autoclosure parameter because %0 is accessed later in the current task",
+     (DeclName))
 NOTE(regionbasedisolation_typed_tns_passed_to_sending_closure_helper_have_value_region, none,
      "closure captures %1 which is accessible to %0 code",
      (StringRef, DeclName))

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -1009,6 +1009,97 @@ public:
     emitRequireInstDiagnostics();
   }
 
+  /// Emit an error when a closure capturing a mutable variable (box) is sent
+  /// as a 'sending' argument and the variable is used afterwards.
+  void emitSendingClosureCapturesMutableVar(SILLocation errorLoc,
+                                            Type closureType,
+                                            Operand *actualUse,
+                                            SILArgument *fArg,
+                                            bool isAutoclosure) {
+    if (isAutoclosure) {
+      diagnoseError(
+          actualUse->getUser()->getLoc(),
+          diag::regionbasedisolation_sent_autoclosure_captures_mutable_var,
+          fArg->getDecl())
+          .limitBehaviorIf(getBehaviorLimit());
+    } else {
+      diagnoseError(
+          actualUse->getUser()->getLoc(),
+          diag::regionbasedisolation_sent_closure_captures_mutable_var,
+          fArg->getDecl())
+          .limitBehaviorIf(getBehaviorLimit());
+    }
+    emitRequireInstDiagnostics();
+  }
+
+  /// Emit an error when a closure capturing a non-Sendable value is sent as a
+  /// 'sending' argument and the value is used afterwards.
+  void emitSendingClosureCapturesValue(SILLocation errorLoc, Type closureType,
+                                       Operand *actualUse, SILArgument *fArg,
+                                       bool isAutoclosure) {
+    if (isAutoclosure) {
+      diagnoseError(
+          actualUse->getUser()->getLoc(),
+          diag::regionbasedisolation_sent_autoclosure_captures_value,
+          fArg->getDecl()->getName())
+          .limitBehaviorIf(getBehaviorLimit());
+    } else {
+      diagnoseError(actualUse->getUser()->getLoc(),
+                    diag::regionbasedisolation_sent_closure_captures_value,
+                    fArg->getDecl()->getName())
+          .limitBehaviorIf(getBehaviorLimit());
+    }
+    emitRequireInstDiagnostics();
+  }
+
+  /// Emit an error when a closure capturing multiple non-Sendable values is
+  /// sent as a 'sending' argument and the values are used afterwards.
+  void emitSendingClosureCapturesMultipleValues(
+      SILLocation errorLoc, Type closureType,
+      ArrayRef<std::pair<Operand *, SILArgument *>> capturedValues,
+      bool isAutoclosure) {
+    // Emit the rest of the capturedValues.
+    for (auto pair : capturedValues) {
+      auto &use = pair.first;
+      auto *arg = cast<SILFunctionArgument>(pair.second);
+
+      if (auto boxTy = arg->getType().getAs<SILBoxType>();
+          boxTy && boxTy->getNumFields() == 1 && boxTy->isFieldMutable(0) &&
+          SILIsolationInfo::boxTypeContainsOnlySendableFields(
+              boxTy, arg->getFunction())) {
+        if (isAutoclosure) {
+          diagnoseError(
+              use->getUser()->getLoc(),
+              diag::regionbasedisolation_sent_autoclosure_captures_mutable_var,
+              arg->getDecl())
+              .limitBehaviorIf(getBehaviorLimit());
+        } else {
+          diagnoseError(
+              use->getUser()->getLoc(),
+              diag::regionbasedisolation_sent_closure_captures_mutable_var,
+              arg->getDecl())
+              .limitBehaviorIf(getBehaviorLimit());
+        }
+        continue;
+      }
+
+      if (isAutoclosure) {
+        diagnoseError(
+            use->getUser()->getLoc(),
+            diag::regionbasedisolation_sent_autoclosure_captures_value,
+            arg->getDecl()->getName())
+            .limitBehaviorIf(getBehaviorLimit());
+      } else {
+        diagnoseError(use->getUser()->getLoc(),
+                      diag::regionbasedisolation_sent_closure_captures_value,
+                      arg->getDecl()->getName())
+            .limitBehaviorIf(getBehaviorLimit());
+      }
+    }
+
+    emitRequireInstDiagnostics();
+  }
+
   void emitNamedIsolationCrossingDueToCapture(
       SILLocation loc, Identifier name,
       SILIsolationInfo namedValuesIsolationInfo,
@@ -1145,6 +1236,7 @@ public:
 
 private:
   bool initForIsolatedPartialApply(Operand *op, AbstractClosureExpr *ace);
+  bool initForSendingPartialApply(FullApplySite fas, Operand *callsiteOp);
 
   void initForApply(Operand *op, ApplyExpr *expr);
   void initForAutoclosure(Operand *op, AutoClosureExpr *expr);
@@ -1175,6 +1267,48 @@ bool UseAfterSendDiagnosticInferrer::initForIsolatedPartialApply(
 
   diagnosticEmitter.emitTypedIsolationCrossingDueToCapture(
       diagnosticOp->getUser()->getLoc(), baseInferredType, crossing);
+  return true;
+}
+
+bool UseAfterSendDiagnosticInferrer::initForSendingPartialApply(
+    FullApplySite fas, Operand *callsiteOp) {
+  // See if the sending operand is a partial_apply (closure literal or
+  // autoclosure expr).
+  auto *sendingPAI =
+      dyn_cast<PartialApplyInst>(stripFunctionConversions(callsiteOp->get()));
+  if (!sendingPAI || (!sendingPAI->getLoc().getAsASTNode<ClosureExpr>() &&
+                      !sendingPAI->getLoc().getAsASTNode<AutoClosureExpr>()))
+    return false;
+
+  bool isAutoclosure =
+      sendingPAI->getLoc().getAsASTNode<AutoClosureExpr>() != nullptr;
+
+  // Loop over captured parameters looking for non-sendable captured values.
+  SmallVector<Operand *, 8> nonSendableOps;
+  for (auto &sendingPAIOp : sendingPAI->getArgumentOperands()) {
+    auto trackableValue = valueMap.getTrackableValue(sendingPAIOp.get());
+    if (trackableValue.value.isSendable())
+      continue;
+    nonSendableOps.push_back(&sendingPAIOp);
+  }
+
+  // If we did not find any non-sendable captured values, bail.
+  if (nonSendableOps.empty())
+    return false;
+
+  // Find the closure use for each of our captures.
+  SmallVector<std::pair<Operand *, SILArgument *>, 4> capturedValues;
+  for (auto *captured : nonSendableOps) {
+    if (auto capturedValue = findClosureUse(captured))
+      capturedValues.push_back(*capturedValue);
+  }
+
+  if (capturedValues.empty())
+    return false;
+
+  // Then emit the closure capture diagnostic.
+  diagnosticEmitter.emitSendingClosureCapturesMultipleValues(
+      baseLoc, baseInferredType, capturedValues, isAutoclosure);
   return true;
 }
 
@@ -1331,6 +1465,12 @@ void UseAfterSendDiagnosticInferrer::infer() {
            "We should never send an indirect out parameter");
     if (fas.getArgumentParameterInfo(*sendingOp)
             .hasOption(SILParameterInfo::Sending)) {
+
+      // Before we try anything else, see if we are passing a closure literal
+      // that captures non-Sendable values. If so, emit a diagnostic that
+      // identifies the specific captured values.
+      if (initForSendingPartialApply(fas, sendingOp))
+        return;
 
       // First try to do the named diagnostic if we can find a name.
       if (auto rootValueAndName = inferNameAndRootHelper(sendingOp->get())) {

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -1895,10 +1895,7 @@ func mutableLocalCaptureDataRace() async {
   _ = x
 
   Task.detached { x = 1 }
-  // expected-ni-warning @-1 {{sending value of non-Sendable type '() async -> ()' risks causing data races}}
-  // expected-ni-note @-2 {{Passing value of non-Sendable type '() async -> ()' as a 'sending' argument to static method 'detached(name:priority:operation:)' risks causing races in between local and caller code}}
-  // expected-ni-ns-warning @-3 {{sending value of non-Sendable type '@concurrent () async -> ()' risks causing data races}}
-  // expected-ni-ns-note @-4 {{Passing value of non-Sendable type '@concurrent () async -> ()' as a 'sending' argument to static method 'detached(name:priority:operation:)' risks causing races in between local and caller code}}
+  // expected-warning @-1 {{closure passed as an argument to a 'sending' parameter captures reference to mutable var 'x' which is accessed later by code in the current task}}
 
   x = 2 // expected-note {{access can happen concurrently}}
 }
@@ -1907,11 +1904,7 @@ func mutableLocalCaptureDataRace2() async {
   var x = 0
   x = 0
 
-  Task.detached { x = 1 }
-  // expected-ni-warning @-1 {{sending value of non-Sendable type '() async -> ()' risks causing data races}}
-  // expected-ni-note @-2 {{Passing value of non-Sendable type '() async -> ()' as a 'sending' argument to static method 'detached(name:priority:operation:)' risks causing races in between local and caller code}}
-  // expected-ni-ns-warning @-3 {{sending value of non-Sendable type '@concurrent () async -> ()' risks causing data races}}
-  // expected-ni-ns-note @-4 {{Passing value of non-Sendable type '@concurrent () async -> ()' as a 'sending' argument to static method 'detached(name:priority:operation:)' risks causing races in between local and caller code}}
+  Task.detached { x = 1 } // expected-warning {{closure passed as an argument to a 'sending' parameter captures reference to mutable var 'x' which is accessed later by code in the current task}}
 
   print(x) // expected-note {{access can happen concurrently}}
 }
@@ -2043,22 +2036,16 @@ func avoidThinkingClosureParameterIsSending() {
 enum RequireSrcWhenStoringEvenWhenSendable {
   func test<T: Sendable>(t: T) {
     var result: T = t
-    Task { // expected-ni-warning {{sending value of non-Sendable type '() async -> ()' risks causing data races}}
-      // expected-ni-note @-1 {{Passing value of non-Sendable type '() async -> ()' as a 'sending' argument to initializer 'init(name:priority:operation:)' risks causing races in between local and caller code}}
-      // expected-ni-ns-warning @-2 {{sending value of non-Sendable type '@concurrent () async -> ()' risks causing data races}}
-      // expected-ni-ns-note @-3 {{Passing value of non-Sendable type '@concurrent () async -> ()' as a 'sending' argument to initializer 'init(name:priority:operation:)' risks causing races in between local and caller code}}
-      result = t
+    Task {
+      result = t // expected-warning {{closure passed as an argument to a 'sending' parameter captures reference to mutable var 'result' which is accessed later by code in the current task}}
     }
     useValue(result) // expected-note {{access can happen concurrently}}
   }
 
   func test2() {
     var result: Any = 0
-    Task { // expected-ni-warning {{sending value of non-Sendable type '() async -> ()' risks causing data races}}
-      // expected-ni-note @-1 {{Passing value of non-Sendable type '() async -> ()' as a 'sending' argument to initializer 'init(name:priority:operation:)' risks causing races in between local and caller code}}
-      // expected-ni-ns-warning @-2 {{sending value of non-Sendable type '@concurrent () async -> ()' risks causing data races}}
-      // expected-ni-ns-note @-3 {{Passing value of non-Sendable type '@concurrent () async -> ()' as a 'sending' argument to initializer 'init(name:priority:operation:)' risks causing races in between local and caller code}}
-      result = 0
+    Task {
+      result = 0 // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'result' which is accessed later by code in the current task}}
     }
     useValue(result) // expected-note {{access can happen concurrently}}
   }
@@ -2069,11 +2056,8 @@ enum RequireSrcWhenStoringEvenWhenSendable {
 
   func test3<T: Initializable & SendableMetatype>(type: T.Type) {
     var result = type.init()
-    Task { // expected-ni-warning {{sending value of non-Sendable type '() async -> ()' risks causing data races}}
-      // expected-ni-note @-1 {{Passing value of non-Sendable type '() async -> ()' as a 'sending' argument to initializer 'init(name:priority:operation:)' risks causing races in between local and caller code}}
-      // expected-ni-ns-warning @-2 {{sending value of non-Sendable type '@concurrent () async -> ()' risks causing data races}}
-      // expected-ni-ns-note @-3 {{Passing value of non-Sendable type '@concurrent () async -> ()' as a 'sending' argument to initializer 'init(name:priority:operation:)' risks causing races in between local and caller code}}
-      result = type.init()
+    Task {
+      result = type.init() // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'result' which is accessed later by code in the current task}}
     }
     useValue(result) // expected-note {{access can happen concurrently}}
   }

--- a/test/Concurrency/transfernonsendable_closure_captures.swift
+++ b/test/Concurrency/transfernonsendable_closure_captures.swift
@@ -1386,3 +1386,162 @@ func testCaptureWithClosureSpecialization() {
     static func takesNS(_: KlassNonsendable) async {}
   }
 }
+
+////////////////////////////////
+// MARK: Use After Send Tests //
+////////////////////////////////
+//
+// These exist in other places (e.x.: transfernonsendable.swift), but I would
+// like to put some here as well that are more exhaustive.
+
+func useAfterFreeClosureTests() {
+  func acceptsSendingClosure(_ x: sending () -> ()) {}
+  func acceptsEscapingSendingClosure(_ x: sending @escaping () -> ()) {}
+  func acceptsAutoclosureSendingClosure(_ x: sending @autoclosure () -> ()) {}
+  func acceptsAutoclosureEscapingSendingClosure(_ x: sending @autoclosure @escaping () -> ()) {}
+
+  func simpleTestMutableCopyableNonsendable() {
+    var x = KlassNonsendable()
+    x = KlassNonsendable()
+    acceptsSendingClosure {
+      _ = x // expected-error {{closure passed as an argument to a 'sending' parameter captures 'x' which is accessed later by code in the current task}}
+    }
+    useValue(x) // expected-note {{access can happen concurrently}}
+  }
+
+  // In this case, we do not error since we are not escaping x meaning that we
+  // stack promote it. Since we stack promote it, we know that the memory cannot
+  // escape, so the value is ok to be written to since we are not escaping a
+  // non-Sendable box.
+  func simpleTestMutableCopyableSendable() {
+    var x = KlassSendable()
+    x = KlassSendable()
+    acceptsSendingClosure {
+      useValue(x)
+      x = KlassSendable()
+    }
+    useValue(x)
+    x = KlassSendable()
+    _ = x
+  }
+
+  func simpleTestMutableNoncopyableNonsendable() {
+    var x = NoncopyableStructNonsendable()
+    x = NoncopyableStructNonsendable()
+    acceptsSendingClosure {
+      _ = x // expected-error {{closure passed as an argument to a 'sending' parameter captures 'x' which is accessed later by code in the current task}}
+      x = NoncopyableStructNonsendable()
+    }
+    useValue(x) // expected-note {{access can happen concurrently}}
+  }
+
+  // In this case, we do not error since we are not escaping x meaning that we
+  // stack promote it. Since we stack promote it, we know that the memory cannot
+  // escape, so the value is ok to be written to since we are not escaping a
+  // non-Sendable box.
+  func simpleTestMutableNoncopyableSendable() {
+    var x = NoncopyableStructSendable()
+    x = NoncopyableStructSendable()
+    acceptsSendingClosure {
+      _ = x
+      x = NoncopyableStructSendable()
+    }
+    x = NoncopyableStructSendable()
+  }
+
+  func simpleTestEscapingClosureMutableCopyableNonsendable() {
+    var x = KlassNonsendable()
+    x = KlassNonsendable()
+    acceptsEscapingSendingClosure {
+      _ = x // expected-error {{closure passed as an argument to a 'sending' parameter captures 'x' which is accessed later by code in the current task}}
+    }
+    useValue(x) // expected-note {{access can happen concurrently}}
+  }
+
+  func simpleTestEscapingClosureMutableCopyableSendable() {
+    var x = KlassSendable()
+    x = KlassSendable()
+    acceptsEscapingSendingClosure {
+      x = KlassSendable() // expected-error {{closure passed as an argument to a 'sending' parameter captures reference to mutable var 'x' which is accessed later by code in the current task}}
+    }
+    x = KlassSendable() // expected-note {{access can happen concurrently}}
+    _ = x
+  }
+
+  func simpleTestEscapingClosureMutableNoncopyableNonsendable() {
+    var x = NoncopyableStructNonsendable()
+    x = NoncopyableStructNonsendable()
+    acceptsEscapingSendingClosure {
+      x = NoncopyableStructNonsendable() // expected-error {{closure passed as an argument to a 'sending' parameter captures 'x' which is accessed later by code in the current task}}
+    }
+    useValue(x) // expected-note {{access can happen concurrently}}
+  }
+
+  func simpleTestEscapingClosureMutableNoncopyableSendable() {
+    var x = NoncopyableStructSendable() // expected-warning {{variable 'x' was written to, but never read}}
+    x = NoncopyableStructSendable()
+    acceptsEscapingSendingClosure {
+      x = NoncopyableStructSendable() // expected-error {{closure passed as an argument to a 'sending' parameter captures reference to mutable var 'x' which is accessed later by code in the current task}}
+    }
+    x = NoncopyableStructSendable() // expected-note {{access can happen concurrently}}
+  }
+
+  func simpleTestAutoclosureMutableCopyableNonsendable() {
+    var x = KlassNonsendable()
+    x = KlassNonsendable()
+    acceptsAutoclosureSendingClosure(useValue(x)) // expected-error {{'x' cannot be captured by 'sending' @autoclosure parameter because 'x' is accessed later in the current task}}
+    useValue(x) // expected-note {{access can happen concurrently}}
+  }
+
+  func simpleTestAutoclosureMutableCopyableSendable() {
+    var x = KlassSendable()
+    x = KlassSendable()
+    acceptsAutoclosureSendingClosure(useValue(x))
+    useValue(x)
+    x = KlassSendable()
+    _ = x
+  }
+
+  func simpleTestAutoclosureMutableNoncopyableNonsendable() {
+    var x = NoncopyableStructNonsendable()
+    x = NoncopyableStructNonsendable()
+    acceptsAutoclosureSendingClosure(useValue(x)) // expected-error {{'x' cannot be captured by 'sending' @autoclosure parameter because 'x' is accessed later in the current task}}
+    useValue(x) // expected-note {{access can happen concurrently}}
+  }
+
+  func simpleTestAutoclosureMutableNoncopyableSendable() {
+    var x = NoncopyableStructSendable()
+    x = NoncopyableStructSendable()
+    acceptsAutoclosureSendingClosure(useValue(x))
+    x = NoncopyableStructSendable()
+  }
+
+  func simpleTestEscapingAutoclosureMutableCopyableNonsendable() {
+    var x = KlassNonsendable()
+    x = KlassNonsendable()
+    acceptsAutoclosureEscapingSendingClosure(useValue(x)) // expected-error {{'x' cannot be captured by 'sending' @autoclosure parameter because 'x' is accessed later in the current task}}
+    useValue(x) // expected-note {{access can happen concurrently}}
+  }
+
+  func simpleTestEscapingAutoclosureMutableCopyableSendable() {
+    var x = KlassSendable()
+    x = KlassSendable()
+    acceptsAutoclosureEscapingSendingClosure(useValue(x)) // expected-error {{mutable var 'x' cannot be captured by 'sending' @autoclosure parameter because 'x' is accessed later in the current task}}
+    x = KlassSendable() // expected-note {{access can happen concurrently}}
+    _ = x
+  }
+
+  func simpleTestEscapingAutoclosureMutableNoncopyableNonsendable() {
+    var x = NoncopyableStructNonsendable()
+    x = NoncopyableStructNonsendable()
+    acceptsAutoclosureEscapingSendingClosure(useValue(x)) // expected-error {{'x' cannot be captured by 'sending' @autoclosure parameter because 'x' is accessed later in the current task}}
+    useValue(x) // expected-note {{access can happen concurrently}}
+  }
+
+  func simpleTestEscapingAutoclosureMutableNoncopyableSendable() {
+    var x = NoncopyableStructSendable()
+    x = NoncopyableStructSendable()
+    acceptsAutoclosureEscapingSendingClosure(useValue(x)) // expected-error {{mutable var 'x' cannot be captured by 'sending' @autoclosure parameter because 'x' is accessed later in the current task}}
+    x = NoncopyableStructSendable() // expected-note {{access can happen concurrently}}
+  }
+}

--- a/test/Concurrency/transfernonsendable_nonisolatedunsafe.swift
+++ b/test/Concurrency/transfernonsendable_nonisolatedunsafe.swift
@@ -845,8 +845,7 @@ func closureTests() async {
 
   func testLetOneNSVariableError() async {
     let x = NonSendableKlass()
-    sendingClosure { _ = x } // expected-warning {{sending value of non-Sendable type '() -> ()' risks causing data races}}
-    // expected-note @-1 {{Passing value of non-Sendable type '() -> ()' as a 'sending' argument to local function 'sendingClosure' risks causing races in between local and caller code}}
+    sendingClosure { _ = x } // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'x' which is accessed later by code in the current task}}
     sendingClosure { _ = x } // expected-note {{access can happen concurrently}}
   }
 
@@ -859,9 +858,8 @@ func closureTests() async {
   func testLetOneNSVariableSVariableError() async {
     let x = NonSendableKlass()
     let y = CustomActorInstance()
-    sendingClosure { // expected-warning {{sending value of non-Sendable type '() -> ()' risks causing data races}}
-      // expected-note @-1 {{Passing value of non-Sendable type '() -> ()' as a 'sending' argument to local function 'sendingClosure' risks causing races in between local and caller code}}
-      _ = x
+    sendingClosure {
+      _ = x // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'x' which is accessed later by code in the current task}}
       _ = y
     }
     sendingClosure { // expected-note {{access can happen concurrently}}
@@ -886,10 +884,9 @@ func closureTests() async {
   func testLetTwoNSVariableError() async {
     let x = NonSendableKlass()
     let y = NonSendableKlass()
-    sendingClosure { // expected-warning {{sending value of non-Sendable type '() -> ()' risks causing data races}}
-      // expected-note @-1 {{Passing value of non-Sendable type '() -> ()' as a 'sending' argument to local function 'sendingClosure' risks causing races in between local and caller code}}
-      _ = x
-      _ = y
+    sendingClosure {
+      _ = x // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'x' which is accessed later by code in the current task}}
+      _ = y // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'y' which is accessed later by code in the current task}}
     }
     sendingClosure { // expected-note {{access can happen concurrently}}
       _ = x
@@ -900,10 +897,9 @@ func closureTests() async {
   func testLetTwoNSVariableError2() async {
     nonisolated(unsafe) let x = NonSendableKlass()
     let y = NonSendableKlass()
-    sendingClosure { // expected-warning {{sending value of non-Sendable type '() -> ()' risks causing data races}}
-      // expected-note @-1 {{Passing value of non-Sendable type '() -> ()' as a 'sending' argument to local function 'sendingClosure' risks causing races in between local and caller code}}
-      _ = x
-      _ = y
+    sendingClosure {
+      _ = x // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'x' which is accessed later by code in the current task}}
+      _ = y // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'y' which is accessed later by code in the current task}}
     }
     sendingClosure { // expected-note {{access can happen concurrently}}
       _ = x
@@ -928,8 +924,7 @@ func closureTests() async {
     var x = NonSendableKlass()
     x = NonSendableKlass()
 
-    sendingClosure { _ = x } // expected-warning {{sending value of non-Sendable type '() -> ()' risks causing data races}}
-    // expected-note @-1 {{Passing value of non-Sendable type '() -> ()' as a 'sending' argument to local function 'sendingClosure' risks causing races in between local and caller code}}
+    sendingClosure { _ = x } // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'x' which is accessed later by code in the current task}}
     sendingClosure { _ = x } // expected-note {{access can happen concurrently}}
   }
 
@@ -946,9 +941,8 @@ func closureTests() async {
     x = NonSendableKlass()
     var y = CustomActorInstance()
     y = CustomActorInstance()
-    sendingClosure { // expected-warning {{sending value of non-Sendable type '() -> ()' risks causing data races}}
-      // expected-note @-1 {{Passing value of non-Sendable type '() -> ()' as a 'sending' argument to local function 'sendingClosure' risks causing races in between local and caller code}}
-      _ = x
+    sendingClosure {
+      _ = x // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'x' which is accessed later by code in the current task}}
       _ = y
     }
     sendingClosure { // expected-note {{access can happen concurrently}}
@@ -977,10 +971,9 @@ func closureTests() async {
     x = NonSendableKlass()
     var y = NonSendableKlass()
     y = NonSendableKlass()
-    sendingClosure { // expected-warning {{sending value of non-Sendable type '() -> ()' risks causing data races}}
-      // expected-note @-1 {{Passing value of non-Sendable type '() -> ()' as a 'sending' argument to local function 'sendingClosure' risks causing races in between local and caller code}}
-      _ = x
-      _ = y
+    sendingClosure {
+      _ = x // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'x' which is accessed later by code in the current task}}
+      _ = y // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'y' which is accessed later by code in the current task}}
     }
     sendingClosure { // expected-note {{access can happen concurrently}}
       _ = x
@@ -993,10 +986,9 @@ func closureTests() async {
     x = NonSendableKlass()
     var y = NonSendableKlass()
     y = NonSendableKlass()
-    sendingClosure { // expected-warning {{sending value of non-Sendable type '() -> ()' risks causing data races}}
-      // expected-note @-1 {{Passing value of non-Sendable type '() -> ()' as a 'sending' argument to local function 'sendingClosure' risks causing races in between local and caller code}}
-      _ = x
-      _ = y
+    sendingClosure {
+      _ = x // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'x' which is accessed later by code in the current task}}
+      _ = y // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'y' which is accessed later by code in the current task}}
     }
     sendingClosure { // expected-note {{access can happen concurrently}}
       _ = x
@@ -1021,12 +1013,7 @@ func closureTests() async {
 
   func testWithTaskDetached() async {
     let x1 = NonSendableKlass()
-    Task.detached { _ = x1 }
-    // expected-ni-warning @-1 {{sending value of non-Sendable type '() async -> ()' risks causing data races}}
-    // expected-ni-note @-2 {{Passing value of non-Sendable type '() async -> ()' as a 'sending' argument to static method 'detached(name:priority:operation:)' risks causing races in between local and caller code}}
-    // expected-ni-ns-warning @-3 {{sending value of non-Sendable type '@concurrent () async -> ()' risks causing data races}}
-    // expected-ni-ns-note @-4 {{Passing value of non-Sendable type '@concurrent () async -> ()' as a 'sending' argument to static method 'detached(name:priority:operation:)' risks causing races in between local and caller code}}
-
+    Task.detached { _ = x1 } // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'x1' which is accessed later by code in the current task}}
     Task.detached { _ = x1 } // expected-note {{access can happen concurrently}}
 
     nonisolated(unsafe) let x2 = NonSendableKlass()
@@ -1040,13 +1027,15 @@ func closureTests() async {
 
     nonisolated(unsafe) let x4a = NonSendableKlass()
     let x4b = NonSendableKlass()
-    Task.detached { _ = x4a; _ = x4b }
-    // expected-ni-warning @-1 {{sending value of non-Sendable type '() async -> ()' risks causing data races}}
-    // expected-ni-note @-2 {{Passing value of non-Sendable type '() async -> ()' as a 'sending' argument to static method 'detached(name:priority:operation:)' risks causing races in between local and caller code}}
-    // expected-ni-ns-warning @-3 {{sending value of non-Sendable type '@concurrent () async -> ()' risks causing data races}}
-    // expected-ni-ns-note @-4 {{Passing value of non-Sendable type '@concurrent () async -> ()' as a 'sending' argument to static method 'detached(name:priority:operation:)' risks causing races in between local and caller code}}
+    Task.detached {
+      _ = x4a; // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'x4a' which is accessed later by code in the current task}}
+      _ = x4b // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'x4b' which is accessed later by code in the current task}}
+    }
 
-    Task.detached { _ = x4a; _ = x4b } // expected-note {{access can happen concurrently}}
+    Task.detached { // expected-note {{access can happen concurrently}}
+      _ = x4a
+      _ = x4b
+    }
   }
 
   // The reason why this works is that we do not infer nonisolated(unsafe)


### PR DESCRIPTION
I also ensured that if we are capturing a non-Sendable box containing a Sendable thing, we emit the mutable form of this message.

rdar://150329055

-----

<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!-- Please fill out the following form: --> 
- **Explanation**: When a closure literal is passed as a `sending` parameter and captures values that are used after the send, the compiler previously emitted a generic "sending value of non-Sendable type" error on the closure itself. This change emits more specific diagnostics on the actual capture site inside the closure, identifying the captured variable by name and distinguishing between mutable var captures (where the box escapes) and non-Sendable value captures.
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: Region-Based Isolation (RBI) diagnostics in SILOptimizer's SendNonSendable pass and DiagnosticsSIL.def. Affects concurrency checking for closures passed as `sending` arguments. It does not impact where the diagnostics are emitted... just what diagnostic is emitted.
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Issues**: rdar://150329055
  <!--
  References to issues the changes resolve, if any.
  -->
- **Risk**: Low. This only changes diagnostic output (error/warning messages and their locations), not codegen or type-checking semantics. The new diagnostics are strictly more informative than the old ones.
  <!--
  The (specific) risk to the release for taking the changes.
  -->
- **Testing**: Tests were added to the test suite.
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->
- **Reviewers**: @xedin 
  <!--
  The code owners that GitHub-approved the original changes in the mainline
  branch pull requests. If an original change has not been GitHub-approved by
  a respective code owner, provide a reason. Technical review can be delegated
  by a code owner or otherwise requested as deemed appropriate or useful.
  -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
